### PR TITLE
Remove legacy references

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,6 @@ continuum adapt --assistant claude  # Creates continuum.claude
 continuum adapt --assistant gpt     # Creates continuum.gpt
 ```
 
-You can also use the legacy command name (though this is deprecated):
-
-```bash
-ai-config init
-```
 
 > Note: The CLI is currently in development mode with placeholder functionality.
 

--- a/packages/cli/bin/ai-config.js
+++ b/packages/cli/bin/ai-config.js
@@ -1,29 +1,21 @@
 #!/usr/bin/env node
-// Simply redirect to the Continuum CLI
+// Continuum CLI (Original filename kept for backward compatibility)
 
-import { exec } from 'child_process';
+import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
-// Display deprecation warning
-console.log("⚠️  'ai-config' is deprecated. Please use 'continuum' instead.");
-console.log("Learn more: https://github.com/CambrianTech/continuum");
-console.log('');
-
-// Get the directory of this file
+// Get the directory of this file and real implementation
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
-// Full path to continuum.js
 const continuumPath = join(__dirname, 'continuum.js');
 
 // Forward all arguments to continuum.js
-const args = process.argv.slice(2).join(' ');
-const command = `node "${continuumPath}" ${args}`;
+const childProcess = spawn('node', [continuumPath, ...process.argv.slice(2)], {
+  stdio: 'inherit'
+});
 
-// Execute continuum.js
-exec(command, { stdio: 'inherit' }, (error, stdout, stderr) => {
-  if (stdout) process.stdout.write(stdout);
-  if (stderr) process.stderr.write(stderr);
-  if (error) process.exit(error.code || 1);
+// Handle process exit
+childProcess.on('exit', (code) => {
+  process.exit(code || 0);
 });


### PR DESCRIPTION
## Summary

This PR removes unnecessary legacy references:

- Remove 'ai-config' references from README as we don't need legacy support
- Simplify ai-config.js implementation without warning messages
- Improve README clarity

## Test plan
1. Verify README no longer mentions legacy command
2. Test that both 'continuum' and 'ai-config' commands work identically
3. Confirm clean output with no warnings

This makes the documentation more straightforward for this new project.

🤖 Generated with [Claude Code](https://claude.ai/code)