### PR TITLE
Remove auto-forward browser→server — caused infinite loop + 8GB crash

### DIFF
--- a/src/daemons/command-daemon/shared/CommandDaemon.ts
+++ b/src/daemons/command-daemon/shared/CommandDaemon.ts
@@ -7,7 +7,6 @@
 
 import { DaemonBase } from './DaemonBase';
 import type { JTAGContext, JTAGMessage, CommandParams, CommandResult } from '../../../system/core/types/JTAGTypes';
-import { JTAG_ENVIRONMENTS } from '../../../system/core/types/JTAGTypes';
 import type { JTAGRouter } from '../../../system/core/router/shared/JTAGRouter';
 import { CommandBase, type CommandEntry, type ICommandDaemon } from './CommandBase';
 import type { CommandResponse } from './CommandResponseTypes';
@@ -166,15 +165,6 @@ export abstract class CommandDaemon extends DaemonBase {
       return await command.execute(fullParams);
     }
 
-    // Browser: auto-forward unknown commands to server via remoteExecute.
-    // Server-only commands (e.g., filesystem access, training) work seamlessly
-    // without needing boilerplate browser forwarding files.
-    if (this.context.environment === JTAG_ENVIRONMENTS.BROWSER) {
-      const proxy = new RemoteForwardingCommand(commandName, this.context, commandName, this as unknown as ICommandDaemon);
-      const fullParams = { ...params, context: this.context, sessionId } as CommandParams;
-      return await proxy.forward(fullParams);
-    }
-
     throw new Error(`Command '${commandName}' not available in ${this.context.environment} context`);
   }
 
@@ -238,20 +228,3 @@ export abstract class CommandDaemon extends DaemonBase {
   }
 }
 
-/**
- * Lightweight concrete command for auto-forwarding browser → server.
- * Used by CommandDaemon.execute() when a command has no browser implementation.
- */
-class RemoteForwardingCommand extends CommandBase {
-  constructor(name: string, context: JTAGContext, subpath: string, commander: ICommandDaemon) {
-    super(name, context, subpath, commander);
-  }
-
-  async execute(_params: CommandParams): Promise<CommandResult> {
-    throw new Error('RemoteForwardingCommand.execute should not be called directly');
-  }
-
-  async forward(params: CommandParams): Promise<CommandResult> {
-    return await this.remoteExecute(params, this.subpath);
-  }
-}


### PR DESCRIPTION
## Summary
- Removed the auto-forward in `CommandDaemon.execute()` that forwarded unknown browser commands to server via `remoteExecute`
- One missing browser command registration caused infinite recursion, blowing Opera to 8GB and freezing the UI
- Commands must have explicit browser registrations — no magic forwarding

## Root cause
The auto-forward was a gravity-ON switch: it worked silently until it didn't, then everything crashed. Any unregistered browser command would loop.