### PR TITLE
Fix Rust memory leak + clippy cleanup (125→13)

### DIFF
--- a/src/workers/continuum-core/src/ai/adapter.rs
+++ b/src/workers/continuum-core/src/ai/adapter.rs
@@ -74,9 +74,10 @@ pub struct AdapterCapabilities {
 }
 
 /// LoRA capabilities reported by adapters
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum LoRACapabilities {
     /// No LoRA support (most cloud APIs)
+    #[default]
     None,
     /// Single adapter at a time (cloud fine-tuning APIs like Together, Fireworks)
     SingleAdapter,
@@ -87,11 +88,6 @@ pub enum LoRACapabilities {
     },
 }
 
-impl Default for LoRACapabilities {
-    fn default() -> Self {
-        LoRACapabilities::None
-    }
-}
 
 /// Information about a loaded LoRA adapter
 #[derive(Debug, Clone)]

--- a/src/workers/continuum-core/src/ai/anthropic_adapter.rs
+++ b/src/workers/continuum-core/src/ai/anthropic_adapter.rs
@@ -140,17 +140,14 @@ impl AnthropicAdapter {
                                                 "data": b64
                                             }
                                         }))
-                                    } else if let Some(url) = &image.url {
-                                        // Anthropic prefers base64, but supports URLs
-                                        Some(json!({
+                                    } else {
+                                        image.url.as_ref().map(|url| json!({
                                             "type": "image",
                                             "source": {
                                                 "type": "url",
                                                 "url": url
                                             }
                                         }))
-                                    } else {
-                                        None
                                     }
                                 }
                                 _ => None,

--- a/src/workers/continuum-core/src/ai/openai_adapter.rs
+++ b/src/workers/continuum-core/src/ai/openai_adapter.rs
@@ -438,16 +438,14 @@ impl OpenAICompatibleAdapter {
                                             "type": "image_url",
                                             "image_url": { "url": url }
                                         }))
-                                    } else if let Some(b64) = &image.base64 {
-                                        Some(json!({
+                                    } else {
+                                        image.base64.as_ref().map(|b64| json!({
                                             "type": "image_url",
                                             "image_url": {
                                                 "url": format!("data:{};base64,{}",
                                                     image.mime_type.as_deref().unwrap_or("image/png"), b64)
                                             }
                                         }))
-                                    } else {
-                                        None
                                     }
                                 }
                                 _ => None,
@@ -847,7 +845,7 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
 
     fn supported_model_prefixes(&self) -> Vec<&'static str> {
         // Return prefixes based on provider
-        match self.config.provider_id.as_ref() {
+        match self.config.provider_id {
             "openai" => vec!["gpt", "o1", "o3"],
             "deepseek" => vec!["deepseek"],
             "groq" => vec!["llama-3", "mixtral", "gemma2"], // Groq's hosted models

--- a/src/workers/continuum-core/src/ai/types.rs
+++ b/src/workers/continuum-core/src/ai/types.rs
@@ -115,8 +115,8 @@ pub struct VideoInput {
 ///
 /// Field names match the Anthropic API wire format (snake_case):
 /// - `input_schema` NOT `inputSchema`
-/// This must NOT use rename_all = "camelCase" because the wire format
-/// from TypeScript AND the Anthropic API both use snake_case for this struct.
+///   This must NOT use rename_all = "camelCase" because the wire format
+///   from TypeScript AND the Anthropic API both use snake_case for this struct.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "../../../shared/generated/ai/NativeToolSpec.ts")]
 pub struct NativeToolSpec {

--- a/src/workers/continuum-core/src/ffi/mod.rs
+++ b/src/workers/continuum-core/src/ffi/mod.rs
@@ -282,10 +282,6 @@ pub unsafe extern "C" fn continuum_voice_on_utterance(
     0
 }
 
-/// Check if TTS should be routed to a session
-///
-/// @param ptr VoiceOrchestrator pointer
-/// @param session_id UUID string
 // ============================================================================
 // PersonaInbox FFI
 // ============================================================================

--- a/src/workers/continuum-core/src/gpu/eviction_registry.rs
+++ b/src/workers/continuum-core/src/gpu/eviction_registry.rs
@@ -99,6 +99,12 @@ pub struct EvictionRegistry {
     entries: Mutex<HashMap<String, EvictableEntry>>,
 }
 
+impl Default for EvictionRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EvictionRegistry {
     pub fn new() -> Self {
         Self {
@@ -171,6 +177,11 @@ impl EvictionRegistry {
     /// Number of registered entries.
     pub fn len(&self) -> usize {
         self.entries.lock().map(|m| m.len()).unwrap_or(0)
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 

--- a/src/workers/continuum-core/src/inference/backends/llama_safetensors.rs
+++ b/src/workers/continuum-core/src/inference/backends/llama_safetensors.rs
@@ -55,6 +55,7 @@ impl LlamaSafetensorsBackend {
     ///
     /// This is the construction path from `model::load_model_by_id()`.
     /// Context length is read from `config.max_position_embeddings`.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         model: Llama,
         cache: Cache,

--- a/src/workers/continuum-core/src/inference/candle_adapter.rs
+++ b/src/workers/continuum-core/src/inference/candle_adapter.rs
@@ -178,9 +178,11 @@ impl CandleAdapter {
             }
         }
 
-        let mut active = self.active_adapters.write();
-        if !active.contains(&adapter_id.to_string()) {
-            active.push(adapter_id.to_string());
+        {
+            let mut active = self.active_adapters.write();
+            if !active.contains(&adapter_id.to_string()) {
+                active.push(adapter_id.to_string());
+            }
         }
 
         {

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -810,7 +810,7 @@ pub fn start_server(
     // Verify all expected modules are registered (fails server if any missing)
     if let Err(e) = runtime.verify_registration() {
         log_error!("ipc", "server", "{}", e);
-        return Err(std::io::Error::new(std::io::ErrorKind::Other, e));
+        return Err(std::io::Error::other(e));
     }
 
     log_info!(

--- a/src/workers/continuum-core/src/live/audio/vad/production.rs
+++ b/src/workers/continuum-core/src/live/audio/vad/production.rs
@@ -230,7 +230,7 @@ impl ProductionVAD {
 
             if !quick_result.is_speech {
                 // Debug: log WebRTC rejections periodically
-                if self.frame_count % 100 == 0 {
+                if self.frame_count.is_multiple_of(100) {
                     clog_debug!("VAD frame #{}: WebRTC=silence, max_amp={}, speech_frames={}, silence_frames={}",
                         self.frame_count, max_amp, self.buffer.speech_frames, self.buffer.silence_frames);
                 }
@@ -241,7 +241,7 @@ impl ProductionVAD {
                 let accurate_result = self.silero.detect(audio)?;
                 let confirmed = accurate_result.confidence > self.config.silero_threshold;
                 // Periodic Silero decision log (every 100th speech frame, not every frame)
-                if self.frame_count % 100 == 0 {
+                if self.frame_count.is_multiple_of(100) {
                     clog_debug!("VAD frame #{}: WebRTC=SPEECH, Silero={:.3} (threshold={:.1}), confirmed={}, max_amp={}",
                         self.frame_count, accurate_result.confidence, self.config.silero_threshold,
                         confirmed, max_amp);

--- a/src/workers/continuum-core/src/live/audio/vad/webrtc.rs
+++ b/src/workers/continuum-core/src/live/audio/vad/webrtc.rs
@@ -113,7 +113,7 @@ impl VoiceActivityDetection for WebRtcVAD {
         // If input isn't a multiple, chunk it and use majority voting
         const CHUNK_SIZE: usize = 240;
 
-        let is_speech = if samples.len() % CHUNK_SIZE == 0 {
+        let is_speech = if samples.len().is_multiple_of(CHUNK_SIZE) {
             // Perfect size - process directly
             let mut detector = self.detector.lock();
             detector.predict_16khz(samples).map_err(|e| {

--- a/src/workers/continuum-core/src/live/avatar/backends/bevy_3d.rs
+++ b/src/workers/continuum-core/src/live/avatar/backends/bevy_3d.rs
@@ -102,13 +102,14 @@ impl AvatarRenderer for BevyChannelRenderer {
 
 /// Backend factory for the Bevy 3D renderer.
 /// Handles VRM and glTF models via the BevyAvatarSystem GPU pipeline.
+#[derive(Default)]
 pub struct Bevy3DBackend {
     initialized: bool,
 }
 
 impl Bevy3DBackend {
     pub fn new() -> Self {
-        Self { initialized: false }
+        Self::default()
     }
 }
 

--- a/src/workers/continuum-core/src/live/avatar/backends/live2d.rs
+++ b/src/workers/continuum-core/src/live/avatar/backends/live2d.rs
@@ -205,13 +205,14 @@ impl AvatarRenderer for Live2DRenderer {
 
 /// Backend factory for Live2D sprite-sheet rendering.
 /// Handles .moc3 (future: real Cubism SDK) and sprite-sheet formats.
+#[derive(Default)]
 pub struct Live2DBackend {
     initialized: bool,
 }
 
 impl Live2DBackend {
     pub fn new() -> Self {
-        Self { initialized: false }
+        Self::default()
     }
 }
 
@@ -254,7 +255,7 @@ impl RenderBackend for Live2DBackend {
         // Load the atlas image
         // For now, we support raw RGBA files (width/height encoded in filename or manifest).
         // A real implementation would use image crate to decode PNG/WebP.
-        let atlas_data = std::fs::read(&atlas_path).map_err(|e| AvatarError::IoError(e))?;
+        let atlas_data = std::fs::read(&atlas_path).map_err(AvatarError::IoError)?;
 
         // Infer atlas dimensions from file size assuming square-ish atlas
         // with EXPRESSION_COLS × VISEME_ROWS cells.

--- a/src/workers/continuum-core/src/live/avatar/backends/procedural.rs
+++ b/src/workers/continuum-core/src/live/avatar/backends/procedural.rs
@@ -124,13 +124,14 @@ fn hsl_to_rgb(h: f32, s: f32, l: f32) -> (u8, u8, u8) {
 
 /// Backend factory for the procedural renderer.
 /// Always available, supports all formats as a fallback (renders identity-colored circle).
+#[derive(Default)]
 pub struct ProceduralBackend {
     initialized: bool,
 }
 
 impl ProceduralBackend {
     pub fn new() -> Self {
-        Self { initialized: false }
+        Self::default()
     }
 }
 

--- a/src/workers/continuum-core/src/live/avatar/frame_publisher.rs
+++ b/src/workers/continuum-core/src/live/avatar/frame_publisher.rs
@@ -108,7 +108,7 @@ impl FramePublisher for CpuI420Publisher {
 
                 self.frame_count += 1;
                 // Periodic health log: every 450 frames (~30s at ~15fps effective readback)
-                if self.frame_count == 1 || self.frame_count % 450 == 0 {
+                if self.frame_count == 1 || self.frame_count.is_multiple_of(450) {
                     let elapsed = self.started_at.elapsed().as_secs_f64();
                     let fps = if elapsed > 0.0 {
                         self.frame_count as f64 / elapsed
@@ -235,8 +235,8 @@ pub(crate) fn rgba_to_i420_into(rgba: &[u8], buffer: &mut I420Buffer, width: u32
     }
 
     // U and V planes: one chroma value per 2x2 block (subsampled)
-    let cw = (w + 1) / 2;
-    let ch = (h + 1) / 2;
+    let cw = w.div_ceil(2);
+    let ch = h.div_ceil(2);
     for cy in 0..ch {
         for cx in 0..cw {
             let px = cx * 2;

--- a/src/workers/continuum-core/src/live/avatar/publishers/gpu_bridge.rs
+++ b/src/workers/continuum-core/src/live/avatar/publishers/gpu_bridge.rs
@@ -18,10 +18,10 @@
 //!   Tokio thread: take_frame() → surface[(N-1)%2] → CVPixelBufferCreateWithIOSurface → publish
 //!
 //! Per-frame cost: CVPixelBufferCreateWithIOSurface (~40 bytes metadata wrapper)
-//!   + Retain/Release pair (~2 atomic ops). Orders of magnitude cheaper than
-//!   1.2MB heap alloc + 460KB kernel alloc.
+//! plus Retain/Release pair (~2 atomic ops). Orders of magnitude cheaper than
+//! 1.2MB heap alloc + 460KB kernel alloc.
 
-#![cfg(target_os = "macos")]
+// cfg(target_os = "macos") is applied at the mod declaration in publishers/mod.rs
 
 use crossbeam_channel::{Receiver, TryRecvError};
 use livekit::webrtc::video_frame::{native::NativeBuffer, VideoFrame, VideoRotation};
@@ -154,14 +154,13 @@ impl IoSurfacePair {
         let mut uv_stride = 0usize;
 
         for i in 0..2 {
-            let (pb, ios) = create_iosurface_backed_nv12(width, height).map_err(|e| {
+            let (pb, ios) = create_iosurface_backed_nv12(width, height).inspect_err(|_| {
                 // Clean up already-allocated buffers on failure
                 for master in masters.iter().take(i) {
                     unsafe {
                         CVPixelBufferRelease(*master);
                     }
                 }
-                e
             })?;
 
             masters[i] = pb;
@@ -300,20 +299,20 @@ fn create_iosurface_backed_nv12(
             std::ptr::null(),
             std::ptr::null(),
             0,
-            &kCFTypeDictionaryKeyCallBacks as *const _ as *const std::ffi::c_void,
-            &kCFTypeDictionaryValueCallBacks as *const _ as *const std::ffi::c_void,
+            &kCFTypeDictionaryKeyCallBacks as *const _,
+            &kCFTypeDictionaryValueCallBacks as *const _,
         );
 
         // Attributes dict: { kCVPixelBufferIOSurfacePropertiesKey: {} }
-        let keys = [kCVPixelBufferIOSurfacePropertiesKey as *const std::ffi::c_void];
-        let values = [empty_dict as *const std::ffi::c_void];
+        let keys = [kCVPixelBufferIOSurfacePropertiesKey];
+        let values = [empty_dict];
         let attrs = CFDictionaryCreate(
             std::ptr::null(),
             keys.as_ptr(),
             values.as_ptr(),
             1,
-            &kCFTypeDictionaryKeyCallBacks as *const _ as *const std::ffi::c_void,
-            &kCFTypeDictionaryValueCallBacks as *const _ as *const std::ffi::c_void,
+            &kCFTypeDictionaryKeyCallBacks as *const _,
+            &kCFTypeDictionaryValueCallBacks as *const _,
         );
         CFRelease(empty_dict);
 
@@ -608,7 +607,7 @@ impl FramePublisher for GpuBridgePublisher {
         self.frame_count += 1;
 
         // Periodic health log: every 450 frames (~30s at ~15fps effective readback)
-        if self.frame_count == 1 || self.frame_count % 450 == 0 {
+        if self.frame_count == 1 || self.frame_count.is_multiple_of(450) {
             let elapsed = self.started_at.elapsed().as_secs_f64();
             let fps = if elapsed > 0.0 {
                 self.frame_count as f64 / elapsed

--- a/src/workers/continuum-core/src/live/avatar/publishers/native_buffer.rs
+++ b/src/workers/continuum-core/src/live/avatar/publishers/native_buffer.rs
@@ -22,7 +22,7 @@
 //!   6. When VideoFrame drops, C++ releases the CVPixelBuffer (refcount → 1)
 //!   7. We CVPixelBufferRelease our retain (refcount → 0, freed)
 
-#![cfg(target_os = "macos")]
+// cfg(target_os = "macos") is applied at the mod declaration in publishers/mod.rs
 
 use crossbeam_channel::{Receiver, TryRecvError};
 use livekit::webrtc::video_frame::{native::NativeBuffer, VideoFrame, VideoRotation};
@@ -220,7 +220,7 @@ impl FramePublisher for NativeBufferPublisher {
         };
         if result != K_CV_RETURN_SUCCESS || cv_pb.is_null() {
             self.alloc_failures += 1;
-            if self.alloc_failures == 1 || self.alloc_failures % 100 == 0 {
+            if self.alloc_failures == 1 || self.alloc_failures.is_multiple_of(100) {
                 clog_warn!(
                     "📹 NativeBufferPublisher: CVPixelBufferCreate NV12 failed (CVReturn={}, failures={})",
                     result, self.alloc_failures
@@ -301,7 +301,7 @@ impl FramePublisher for NativeBufferPublisher {
         self.frame_count += 1;
 
         // Periodic health log: every 450 frames (~30s at ~15fps effective readback)
-        if self.frame_count == 1 || self.frame_count % 450 == 0 {
+        if self.frame_count == 1 || self.frame_count.is_multiple_of(450) {
             let elapsed = self.started_at.elapsed().as_secs_f64();
             let fps = if elapsed > 0.0 {
                 self.frame_count as f64 / elapsed
@@ -361,8 +361,8 @@ pub(crate) unsafe fn rgba_to_nv12(
     }
 
     // UV plane: interleaved Cb/Cr, subsampled 2×2
-    let ch = (height + 1) / 2;
-    let cw = (width + 1) / 2;
+    let ch = height.div_ceil(2);
+    let cw = width.div_ceil(2);
     for cy in 0..ch {
         let uv_row = uv_base.add(cy * uv_stride);
         let py = cy * 2;

--- a/src/workers/continuum-core/src/live/transport/livekit_agent.rs
+++ b/src/workers/continuum-core/src/live/transport/livekit_agent.rs
@@ -134,7 +134,7 @@ pub type TranscriptionBuffer = Arc<Mutex<VecDeque<TranscriptionEntry>>>;
 const MAX_TRANSCRIPTION_BUFFER: usize = 100;
 
 /// Audio samples per 10ms at 16kHz — LiveKit processes in 10ms chunks
-const SAMPLES_PER_10MS: u32 = (AUDIO_SAMPLE_RATE / 100) as u32;
+const SAMPLES_PER_10MS: u32 = AUDIO_SAMPLE_RATE / 100;
 
 /// STT listener identity prefix (for descriptive LiveKit room identities only).
 /// Role classification uses ParticipantMetadata, NOT these prefixes.
@@ -757,7 +757,7 @@ async fn publish_data_channel_transcription(
 
     room.local_participant()
         .publish_data(DataPacket {
-            payload: bytes.into(),
+            payload: bytes,
             topic: Some("transcription".to_string()),
             reliable: true,
             ..Default::default()
@@ -1300,7 +1300,7 @@ async fn listen_and_transcribe(
         frame_count += 1;
 
         // Log first frame + every 3000th frame
-        if frame_count == 1 || frame_count % 3000 == 0 {
+        if frame_count == 1 || frame_count.is_multiple_of(3000) {
             let max_amp = samples.iter().map(|s| s.unsigned_abs()).max().unwrap_or(0);
             clog_info!(
                 "🎤 STT: Frame #{} from '{}' — {} samples, max_amp={}, sr={}",
@@ -1465,6 +1465,12 @@ pub struct LiveKitAgentManager {
     transcription_buffer: TranscriptionBuffer,
 }
 
+impl Default for LiveKitAgentManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LiveKitAgentManager {
     /// Create manager, resolving LiveKit URL from secrets (config.env) with dev fallback.
     pub fn new() -> Self {
@@ -1555,6 +1561,7 @@ impl LiveKitAgentManager {
         // then all call connect(), creating 3 agents and 3 video loops
         // that burn 3 Bevy render slots for the same identity.
         let creation_lock = {
+            #[allow(clippy::type_complexity)]
             static CREATION_LOCKS: std::sync::Mutex<
                 Option<std::collections::HashMap<(String, String), Arc<tokio::sync::Mutex<()>>>>,
             > = std::sync::Mutex::new(None);
@@ -1870,7 +1877,7 @@ async fn run_ambient_audio_loop(
     // Wait for other participants (human, STT listener) to join the room
     tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
-    let gen = TestAudioGenerator::new(AUDIO_SAMPLE_RATE as u32);
+    let gen = TestAudioGenerator::new(AUDIO_SAMPLE_RATE);
     let chunk_duration_ms: u64 = 100; // 100ms chunks
     let chunk_samples = (AUDIO_SAMPLE_RATE as usize * chunk_duration_ms as usize) / 1000;
 
@@ -1909,7 +1916,7 @@ async fn run_ambient_audio_loop(
         for frame_chunk in samples.chunks(frame_size) {
             let frame = AudioFrame {
                 data: Cow::Borrowed(frame_chunk),
-                sample_rate: AUDIO_SAMPLE_RATE as u32,
+                sample_rate: AUDIO_SAMPLE_RATE,
                 num_channels: 1,
                 samples_per_channel: frame_chunk.len() as u32,
             };

--- a/src/workers/continuum-core/src/live/video/bevy_renderer.rs
+++ b/src/workers/continuum-core/src/live/video/bevy_renderer.rs
@@ -257,7 +257,7 @@ impl BevyAvatarSystem {
 
         // Clone notifiers for Bevy thread — it fires these on readback completion
         let notifiers_for_bevy: Vec<std::sync::Arc<tokio::sync::Notify>> =
-            frame_notifiers.iter().map(|n| n.clone()).collect();
+            frame_notifiers.to_vec();
 
         std::thread::Builder::new()
             .name("bevy-avatar-renderer".into())
@@ -1119,10 +1119,10 @@ fn spawn_readback_entity_opt(
 
                 // Log first readback per slot + pixel diversity diagnostic
                 static FIRST_READBACK: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(0);
-                static FRAME_COUNTER: [std::sync::atomic::AtomicU32; 16] = {
-                    const INIT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-                    [INIT; 16]
-                };
+                #[allow(clippy::declare_interior_mutable_const)]
+                const ATOMIC_ZERO: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+                #[allow(clippy::borrow_interior_mutable_const)]
+                static FRAME_COUNTER: [std::sync::atomic::AtomicU32; 16] = [ATOMIC_ZERO; 16];
                 let mask = 1u16 << slot_id;
                 let prev = FIRST_READBACK.fetch_or(mask, std::sync::atomic::Ordering::Relaxed);
                 if prev & mask == 0 {
@@ -1184,12 +1184,12 @@ fn spawn_readback_entity_opt(
                             }
                         }
                         Err(crossbeam_channel::TrySendError::Full(_)) => {
-                            static DROP_COUNTS: [std::sync::atomic::AtomicU32; 16] = {
-                                const INIT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-                                [INIT; 16]
-                            };
+                            #[allow(clippy::declare_interior_mutable_const)]
+                            const DROP_ZERO: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+                            #[allow(clippy::borrow_interior_mutable_const)]
+                            static DROP_COUNTS: [std::sync::atomic::AtomicU32; 16] = [DROP_ZERO; 16];
                             let count = DROP_COUNTS[slot_id as usize].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                            if count % 150 == 0 {
+                            if count.is_multiple_of(150) {
                                 clog_warn!("🎨 Slot {}: {} frames dropped (channel full)", slot_id, count + 1);
                             }
                         }
@@ -1585,6 +1585,7 @@ fn manage_render_cadence(
 ///
 /// Only readbacks slots whose camera is active this frame (per render cadence).
 /// Uses `ReadbackMarker` to distinguish readback entities from cameras/scenes.
+#[allow(clippy::type_complexity)]
 fn ensure_continuous_readback(
     query: Query<(Entity, &AvatarSlotId), (With<ReadbackMarker>, Without<Readback>)>,
     registry: Res<SlotRegistry>,
@@ -1619,6 +1620,7 @@ fn ensure_continuous_readback(
 }
 
 /// Process commands from the main application.
+#[allow(clippy::too_many_arguments)]
 fn process_commands(
     command_channel: Res<CommandChannel>,
     time: Res<Time>,
@@ -1893,7 +1895,7 @@ fn process_commands(
                 let state = emotion_state
                     .slots
                     .entry(slot)
-                    .or_insert_with(SlotEmotionState::default);
+                    .or_default();
                 state.target = emotion;
                 state.target_weight = weight.clamp(0.0, 1.0);
                 state.transition_rate = rate;
@@ -2438,6 +2440,7 @@ fn discover_morph_targets(
 /// Like a game engine animation system: one clip drives all speech-related
 /// attributes from a single timeline. Clips can be interrupted by new speech
 /// or StopSpeech commands.
+#[allow(clippy::too_many_arguments)]
 fn animate_speaking(
     time: Res<Time>,
     speaking_query: Query<&AvatarSlotId, With<Speaking>>,
@@ -2479,7 +2482,7 @@ fn animate_speaking(
         use std::sync::atomic::{AtomicU32, Ordering};
         static FRAME_COUNTER: AtomicU32 = AtomicU32::new(0);
         let frame = FRAME_COUNTER.fetch_add(1, Ordering::Relaxed);
-        if frame % 300 == 0 {
+        if frame.is_multiple_of(300) {
             let started = speech_clips.clips_started;
             let stopped = speech_clips.clips_auto_stopped;
             let interrupted = speech_clips.clips_interrupted;
@@ -3378,7 +3381,7 @@ fn fix_tpose_arms(
 
     for (bone_entity, rotation) in adjustments {
         if let Ok(mut transform) = transforms.get_mut(bone_entity) {
-            transform.rotation = transform.rotation * rotation;
+            transform.rotation *= rotation;
         }
     }
 }

--- a/src/workers/continuum-core/src/live/video/capture.rs
+++ b/src/workers/continuum-core/src/live/video/capture.rs
@@ -277,7 +277,7 @@ async fn capture_video_stream(
         match result {
             Ok((Some(snapshot), hash)) => {
                 let jpeg_kb = snapshot.jpeg.len() / 1024;
-                if frame_count <= 3 || frame_count % 60 == 0 {
+                if frame_count <= 3 || frame_count.is_multiple_of(60) {
                     clog_info!(
                         "👁 Captured frame #{} from '{}': {}x{}, {}KB JPEG",
                         frame_count,
@@ -319,7 +319,7 @@ fn compose_grid(participants: &[ParticipantSnapshot]) -> Option<ParticipantSnaps
     // Determine grid layout (try to keep aspect ratio reasonable)
     let count = participants.len();
     let cols = (count as f64).sqrt().ceil() as u32;
-    let rows = ((count as u32) + cols - 1) / cols;
+    let rows = (count as u32).div_ceil(cols);
 
     // Target cell size — scale each participant's frame to fit
     let cell_w: u32 = 320;

--- a/src/workers/continuum-core/src/live/video/metal_gpu_convert.rs
+++ b/src/workers/continuum-core/src/live/video/metal_gpu_convert.rs
@@ -20,7 +20,7 @@
 //!
 //! The entire pixel pipeline stays on GPU. CPU only orchestrates (dispatch + signal).
 
-#![cfg(target_os = "macos")]
+// cfg(target_os = "macos") is applied at the mod declaration in video/mod.rs
 
 use bevy::asset::AssetId;
 use bevy::prelude::*;
@@ -211,7 +211,7 @@ impl MetalGpuConverter {
 
         // Periodic logging
         let count = self.frame_count.fetch_add(1, Ordering::Relaxed) + 1;
-        if count == 1 || count % 450 == 0 {
+        if count == 1 || count.is_multiple_of(450) {
             let elapsed = self.created_at.elapsed().as_secs_f64();
             let fps = if elapsed > 0.0 {
                 count as f64 / elapsed
@@ -351,14 +351,12 @@ fn extract_gpu_bridge_data(
     extracted_dims.dims.clear();
 
     for (slot, state) in &registry.slots {
-        if state.active && state.model_loaded {
-            if gpu_bridge::has_bridge(*slot) {
-                extracted_slots
-                    .slots
-                    .push((*slot, state.render_target_id()));
-                if let Some(&dims) = slot_dims.dims.get(slot) {
-                    extracted_dims.dims.insert(*slot, dims);
-                }
+        if state.active && state.model_loaded && gpu_bridge::has_bridge(*slot) {
+            extracted_slots
+                .slots
+                .push((*slot, state.render_target_id()));
+            if let Some(&dims) = slot_dims.dims.get(slot) {
+                extracted_dims.dims.insert(*slot, dims);
             }
         }
     }

--- a/src/workers/continuum-core/src/memory/corpus.rs
+++ b/src/workers/continuum-core/src/memory/corpus.rs
@@ -228,47 +228,78 @@ impl MemoryCorpus {
             .max_by(|a, b| a.timestamp.cmp(&b.timestamp))
     }
 
-    // ─── Copy-on-Write Append ─────────────────────────────────────────────
+    // ─── In-Place Append ───────────────────────────────────────────────────
 
-    /// Create a new corpus with an additional memory appended.
-    /// Copy-on-write: clones all data, pushes new memory, returns new corpus.
-    /// O(n) but appends are rare (~1/min/persona). Readers on old Arc unaffected.
-    pub fn with_appended_memory(&self, corpus_memory: CorpusMemory) -> Self {
-        let mut memories = self.memories.clone();
-        let mut memory_embeddings = self.memory_embeddings.clone();
-
+    /// Append a memory in-place. O(1) amortized — no cloning.
+    /// Caller must hold a write lock (via RwLock in PersonaMemoryManager).
+    pub fn append_memory_mut(&mut self, corpus_memory: CorpusMemory) {
         if let Some(emb) = corpus_memory.embedding {
-            memory_embeddings.insert(corpus_memory.record.id.clone(), emb);
+            self.memory_embeddings.insert(corpus_memory.record.id.clone(), emb);
         }
-        memories.push(corpus_memory.record);
-
-        Self {
-            memories,
-            memory_embeddings,
-            timeline_events: self.timeline_events.clone(),
-            event_embeddings: self.event_embeddings.clone(),
-            loaded_at: self.loaded_at,
-        }
+        self.memories.push(corpus_memory.record);
     }
 
-    /// Create a new corpus with an additional timeline event appended.
-    /// Copy-on-write: clones all data, pushes new event, returns new corpus.
-    pub fn with_appended_event(&self, corpus_event: CorpusTimelineEvent) -> Self {
-        let mut timeline_events = self.timeline_events.clone();
-        let mut event_embeddings = self.event_embeddings.clone();
-
+    /// Append a timeline event in-place. O(1) amortized — no cloning.
+    /// Caller must hold a write lock (via RwLock in PersonaMemoryManager).
+    pub fn append_event_mut(&mut self, corpus_event: CorpusTimelineEvent) {
         if let Some(emb) = corpus_event.embedding {
-            event_embeddings.insert(corpus_event.event.id.clone(), emb);
+            self.event_embeddings.insert(corpus_event.event.id.clone(), emb);
         }
-        timeline_events.push(corpus_event.event);
+        self.timeline_events.push(corpus_event.event);
+    }
 
-        Self {
-            memories: self.memories.clone(),
-            memory_embeddings: self.memory_embeddings.clone(),
-            timeline_events,
-            event_embeddings,
-            loaded_at: self.loaded_at,
+    /// Trim memories to a max count, keeping highest-importance entries.
+    /// Returns number of entries evicted.
+    pub fn trim_memories(&mut self, max_count: usize) -> usize {
+        if self.memories.len() <= max_count {
+            return 0;
         }
+        // Sort by importance DESC, keep top N
+        self.memories.sort_by(|a, b| {
+            b.importance
+                .partial_cmp(&a.importance)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let evicted = self.memories.len() - max_count;
+        // Collect IDs of memories being removed so we can clean up embeddings
+        let removed_ids: Vec<String> = self.memories[max_count..]
+            .iter()
+            .map(|m| m.id.clone())
+            .collect();
+        self.memories.truncate(max_count);
+        for id in &removed_ids {
+            self.memory_embeddings.remove(id);
+        }
+        evicted
+    }
+
+    /// Trim timeline events to a max count, keeping most recent.
+    /// Returns number of entries evicted.
+    pub fn trim_events(&mut self, max_count: usize) -> usize {
+        if self.timeline_events.len() <= max_count {
+            return 0;
+        }
+        // Sort by timestamp DESC, keep most recent N
+        self.timeline_events.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        let evicted = self.timeline_events.len() - max_count;
+        let removed_ids: Vec<String> = self.timeline_events[max_count..]
+            .iter()
+            .map(|e| e.id.clone())
+            .collect();
+        self.timeline_events.truncate(max_count);
+        for id in &removed_ids {
+            self.event_embeddings.remove(id);
+        }
+        evicted
+    }
+
+    /// Total approximate memory usage in bytes.
+    pub fn approx_size_bytes(&self) -> usize {
+        let memory_size = self.memories.len() * std::mem::size_of::<MemoryRecord>();
+        let event_size = self.timeline_events.len() * std::mem::size_of::<TimelineEvent>();
+        // Each embedding is 384 f32s = 1536 bytes + HashMap overhead
+        let embedding_size = (self.memory_embeddings.len() + self.event_embeddings.len()) * (384 * 4 + 64);
+        memory_size + event_size + embedding_size
     }
 
     // ─── Timeline Queries (continued) ────────────────────────────────────

--- a/src/workers/continuum-core/src/memory/embedding.rs
+++ b/src/workers/continuum-core/src/memory/embedding.rs
@@ -97,7 +97,7 @@ impl EmbeddingProvider for FastEmbedProvider {
             .lock()
             .map_err(|e| EmbeddingError(format!("Model lock poisoned: {e}")))?;
         model
-            .embed(texts.to_vec(), None)
+            .embed(texts, None)
             .map_err(|e| EmbeddingError(format!("Batch embed failed: {e}")))
     }
 }
@@ -138,7 +138,7 @@ impl EmbeddingProvider for ModuleBackedEmbeddingProvider {
 
     fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
         crate::modules::embedding::generate_embedding(text, &self.model_name)
-            .map_err(|e| EmbeddingError(e))
+            .map_err(EmbeddingError)
     }
 
     fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
@@ -147,7 +147,7 @@ impl EmbeddingProvider for ModuleBackedEmbeddingProvider {
         }
         let refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
         crate::modules::embedding::generate_embeddings_batch(&refs, &self.model_name)
-            .map_err(|e| EmbeddingError(e))
+            .map_err(EmbeddingError)
     }
 }
 

--- a/src/workers/continuum-core/src/memory/mod.rs
+++ b/src/workers/continuum-core/src/memory/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! Architecture:
 //! ```text
-//! PersonaMemoryManager (DashMap<persona_id, Arc<MemoryCorpus>>)
+//! PersonaMemoryManager (DashMap<persona_id, Arc<RwLock<MemoryCorpus>>>)
 //!   ├── embedding_provider: Arc<dyn EmbeddingProvider>  (shared, loaded once)
 //!   ├── recall_engine: MultiLayerRecall                 (6 pluggable layers)
 //!   └── per-persona cached MemoryCorpus                 (loaded from TS ORM via IPC)
@@ -38,7 +38,7 @@ pub use recall::{MultiLayerRecall, RecallLayer, RecallQuery, ScoredMemory};
 pub use types::*;
 
 use dashmap::DashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 // ─── Error ────────────────────────────────────────────────────────────────────
@@ -57,6 +57,13 @@ impl std::error::Error for MemoryError {}
 
 // ─── PersonaMemoryManager ─────────────────────────────────────────────────────
 
+/// Max memories per persona corpus before trimming (keep highest importance).
+const MAX_MEMORIES_PER_CORPUS: usize = 2000;
+/// Max timeline events per persona corpus before trimming (keep most recent).
+const MAX_EVENTS_PER_CORPUS: usize = 2000;
+/// Stale corpus TTL — evict if not accessed in 30 minutes.
+const CORPUS_STALE_TTL: Duration = Duration::from_secs(30 * 60);
+
 /// Top-level manager for all persona memory operations.
 ///
 /// - Holds per-persona MemoryCorpus in a DashMap (zero cross-persona contention)
@@ -65,9 +72,11 @@ impl std::error::Error for MemoryError {}
 /// - Consciousness context cached per-persona with 30s TTL
 ///
 /// Thread safety: All 14 personas operate on independent DashMap entries.
-/// Within a persona, recall layers operate on shared &MemoryCorpus (read-only).
+/// RwLock per corpus: multiple concurrent readers, exclusive writer.
+/// In-place mutation on append — zero full-corpus cloning.
 pub struct PersonaMemoryManager {
-    corpora: DashMap<String, Arc<MemoryCorpus>>,
+    corpora: DashMap<String, Arc<RwLock<MemoryCorpus>>>,
+    corpus_access_times: DashMap<String, Instant>,
     embedding: Arc<dyn EmbeddingProvider>,
     recall_engine: MultiLayerRecall,
     consciousness_cache: MemoryCache<ConsciousnessContextResponse>,
@@ -77,6 +86,7 @@ impl PersonaMemoryManager {
     pub fn new(embedding: Arc<dyn EmbeddingProvider>) -> Self {
         Self {
             corpora: DashMap::new(),
+            corpus_access_times: DashMap::new(),
             embedding,
             recall_engine: MultiLayerRecall::new(),
             consciousness_cache: MemoryCache::new(Duration::from_secs(30)),
@@ -108,7 +118,9 @@ impl PersonaMemoryManager {
 
         let corpus = MemoryCorpus::from_corpus_data(corpus_memories, corpus_events);
         self.corpora
-            .insert(persona_id.to_string(), Arc::new(corpus));
+            .insert(persona_id.to_string(), Arc::new(RwLock::new(corpus)));
+        self.corpus_access_times
+            .insert(persona_id.to_string(), Instant::now());
 
         // Invalidate consciousness cache (new data affects context)
         self.consciousness_cache.invalidate(persona_id);
@@ -124,8 +136,10 @@ impl PersonaMemoryManager {
         }
     }
 
-    /// Get a persona's cached corpus.
-    fn get_corpus(&self, persona_id: &str) -> Result<Arc<MemoryCorpus>, MemoryError> {
+    /// Get a persona's cached corpus (Arc<RwLock>). Caller acquires read/write lock as needed.
+    fn get_corpus(&self, persona_id: &str) -> Result<Arc<RwLock<MemoryCorpus>>, MemoryError> {
+        self.corpus_access_times
+            .insert(persona_id.to_string(), Instant::now());
         self.corpora
             .get(persona_id)
             .map(|c| c.value().clone())
@@ -145,7 +159,10 @@ impl PersonaMemoryManager {
         persona_id: &str,
         req: &MultiLayerRecallRequest,
     ) -> Result<MemoryRecallResponse, MemoryError> {
-        let corpus = self.get_corpus(persona_id)?;
+        let corpus_lock = self.get_corpus(persona_id)?;
+        let corpus = corpus_lock.read().map_err(|e| {
+            MemoryError(format!("Failed to acquire read lock for {persona_id}: {e}"))
+        })?;
 
         // Pre-compute query embedding if text provided
         let query_embedding = req
@@ -183,7 +200,10 @@ impl PersonaMemoryManager {
             return Ok(cached);
         }
 
-        let corpus = self.get_corpus(persona_id)?;
+        let corpus_lock = self.get_corpus(persona_id)?;
+        let corpus = corpus_lock.read().map_err(|e| {
+            MemoryError(format!("Failed to acquire read lock for {persona_id}: {e}"))
+        })?;
         let response = build_consciousness_context(&corpus, req);
 
         // Cache the result
@@ -192,41 +212,96 @@ impl PersonaMemoryManager {
         Ok(response)
     }
 
-    // ─── Incremental Append (Cache Coherence) ───────────────────────────────
+    // ─── Incremental Append (In-Place Mutation) ─────────────────────────────
 
     /// Append a single memory to the persona's cached corpus.
-    /// Copy-on-write: clones corpus, appends memory, swaps Arc in DashMap.
-    /// Readers holding old Arc are unaffected (snapshot isolation).
-    /// O(n) per append, but appends are rare (~1/min/persona).
+    /// In-place mutation via write lock — O(1) amortized, zero cloning.
     pub fn append_memory(&self, persona_id: &str, memory: CorpusMemory) -> Result<(), MemoryError> {
-        let old_corpus = self.get_corpus(persona_id)?;
-        let new_corpus = old_corpus.with_appended_memory(memory);
-        self.corpora
-            .insert(persona_id.to_string(), Arc::new(new_corpus));
+        let corpus_lock = self.get_corpus(persona_id)?;
+        let mut corpus = corpus_lock.write().map_err(|e| {
+            MemoryError(format!("Failed to acquire write lock for {persona_id}: {e}"))
+        })?;
+        corpus.append_memory_mut(memory);
+        // Trim if over capacity
+        if corpus.memories.len() > MAX_MEMORIES_PER_CORPUS {
+            let evicted = corpus.trim_memories(MAX_MEMORIES_PER_CORPUS);
+            if evicted > 0 {
+                eprintln!(
+                    "🧠 MemoryManager: Trimmed {evicted} low-importance memories for {persona_id} (cap: {MAX_MEMORIES_PER_CORPUS})"
+                );
+            }
+        }
+        drop(corpus); // Release write lock before invalidating cache
         self.consciousness_cache.invalidate(persona_id);
         Ok(())
     }
 
     /// Append a single timeline event to the persona's cached corpus.
-    /// Copy-on-write: clones corpus, appends event, swaps Arc in DashMap.
+    /// In-place mutation via write lock — O(1) amortized, zero cloning.
     pub fn append_event(
         &self,
         persona_id: &str,
         event: CorpusTimelineEvent,
     ) -> Result<(), MemoryError> {
-        let old_corpus = self.get_corpus(persona_id)?;
-        let new_corpus = old_corpus.with_appended_event(event);
-        self.corpora
-            .insert(persona_id.to_string(), Arc::new(new_corpus));
+        let corpus_lock = self.get_corpus(persona_id)?;
+        let mut corpus = corpus_lock.write().map_err(|e| {
+            MemoryError(format!("Failed to acquire write lock for {persona_id}: {e}"))
+        })?;
+        corpus.append_event_mut(event);
+        // Trim if over capacity
+        if corpus.timeline_events.len() > MAX_EVENTS_PER_CORPUS {
+            let evicted = corpus.trim_events(MAX_EVENTS_PER_CORPUS);
+            if evicted > 0 {
+                eprintln!(
+                    "🧠 MemoryManager: Trimmed {evicted} old timeline events for {persona_id} (cap: {MAX_EVENTS_PER_CORPUS})"
+                );
+            }
+        }
+        drop(corpus); // Release write lock before invalidating cache
         self.consciousness_cache.invalidate(persona_id);
         Ok(())
     }
 
     // ─── Maintenance ──────────────────────────────────────────────────────────
 
-    /// Evict expired cache entries (call periodically).
+    /// Evict expired cache entries and stale corpora (call periodically).
     pub fn evict_caches(&self) {
         self.consciousness_cache.evict_expired();
+
+        // Evict stale corpora not accessed within TTL
+        let now = Instant::now();
+        let stale_personas: Vec<String> = self
+            .corpus_access_times
+            .iter()
+            .filter(|entry| now.duration_since(*entry.value()) > CORPUS_STALE_TTL)
+            .map(|entry| entry.key().clone())
+            .collect();
+
+        for persona_id in &stale_personas {
+            self.corpora.remove(persona_id);
+            self.corpus_access_times.remove(persona_id);
+            eprintln!("🧠 MemoryManager: Evicted stale corpus for {persona_id}");
+        }
+    }
+
+    /// Get memory usage stats for debugging.
+    pub fn memory_stats(&self) -> Vec<(String, usize, usize, usize)> {
+        self.corpora
+            .iter()
+            .map(|entry| {
+                let persona_id = entry.key().clone();
+                if let Ok(corpus) = entry.value().read() {
+                    (
+                        persona_id,
+                        corpus.memories.len(),
+                        corpus.timeline_events.len(),
+                        corpus.approx_size_bytes(),
+                    )
+                } else {
+                    (persona_id, 0, 0, 0)
+                }
+            })
+            .collect()
     }
 }
 

--- a/src/workers/continuum-core/src/modules/agent.rs
+++ b/src/workers/continuum-core/src/modules/agent.rs
@@ -1207,7 +1207,7 @@ impl ServiceModule for AgentModule {
                     .to_string();
 
                 // Generate handle
-                let handle = format!("agent-{}", Uuid::new_v4().to_string()[..8].to_string());
+                let handle = format!("agent-{}", &Uuid::new_v4().to_string()[..8]);
 
                 // Spawn agent in background
                 self.spawn_agent(

--- a/src/workers/continuum-core/src/modules/avatar.rs
+++ b/src/workers/continuum-core/src/modules/avatar.rs
@@ -17,6 +17,12 @@ use std::any::Any;
 
 pub struct AvatarModule;
 
+impl Default for AvatarModule {
+    fn default() -> Self {
+        Self
+    }
+}
+
 impl AvatarModule {
     pub fn new() -> Self {
         Self

--- a/src/workers/continuum-core/src/modules/code.rs
+++ b/src/workers/continuum-core/src/modules/code.rs
@@ -144,7 +144,7 @@ impl ServiceModule for CodeModule {
 
                 let result = engine
                     .read(file_path, start_line, end_line)
-                    .map_err(|e| format!("{}", e))?;
+                    .map_err(|e| e.to_string())?;
                 Ok(CommandResult::Json(
                     serde_json::to_value(&result).unwrap_or_default(),
                 ))
@@ -165,7 +165,7 @@ impl ServiceModule for CodeModule {
 
                 let result = engine
                     .write(file_path, content, description)
-                    .map_err(|e| format!("{}", e))?;
+                    .map_err(|e| e.to_string())?;
                 log_info!(
                     "module",
                     "code",
@@ -194,7 +194,7 @@ impl ServiceModule for CodeModule {
 
                 let result = engine
                     .edit(file_path, &edit, description)
-                    .map_err(|e| format!("{}", e))?;
+                    .map_err(|e| e.to_string())?;
                 log_info!("module", "code", "Edit {} by {}", file_path, persona_id);
                 Ok(CommandResult::Json(
                     serde_json::to_value(&result).unwrap_or_default(),
@@ -215,7 +215,7 @@ impl ServiceModule for CodeModule {
 
                 let result = engine
                     .delete(file_path, description)
-                    .map_err(|e| format!("{}", e))?;
+                    .map_err(|e| e.to_string())?;
                 log_info!("module", "code", "Delete {} by {}", file_path, persona_id);
                 Ok(CommandResult::Json(
                     serde_json::to_value(&result).unwrap_or_default(),
@@ -236,7 +236,7 @@ impl ServiceModule for CodeModule {
 
                 let result = engine
                     .preview_diff(file_path, &edit)
-                    .map_err(|e| format!("{}", e))?;
+                    .map_err(|e| e.to_string())?;
                 Ok(CommandResult::Json(
                     serde_json::to_value(&result).unwrap_or_default(),
                 ))
@@ -257,7 +257,7 @@ impl ServiceModule for CodeModule {
                 if let Some(id_str) = change_id {
                     let change_uuid =
                         Uuid::parse_str(id_str).map_err(|e| format!("Invalid change_id: {}", e))?;
-                    let result = engine.undo(&change_uuid).map_err(|e| format!("{}", e))?;
+                    let result = engine.undo(&change_uuid).map_err(|e| e.to_string())?;
                     log_info!("module", "code", "Undo {} by {}", id_str, persona_id);
                     Ok(CommandResult::Json(serde_json::json!({
                         "success": true,
@@ -266,7 +266,7 @@ impl ServiceModule for CodeModule {
                     })))
                 } else {
                     let n = count.unwrap_or(1);
-                    let result = engine.undo_last(n).map_err(|e| format!("{}", e))?;
+                    let result = engine.undo_last(n).map_err(|e| e.to_string())?;
                     log_info!(
                         "module",
                         "code",
@@ -500,7 +500,7 @@ impl ServiceModule for CodeModule {
 
                     let exec_id = shell
                         .execute(cmd, timeout_ms, &self.state.rt_handle)
-                        .map_err(|e| format!("{}", e))?;
+                        .map_err(|e| e.to_string())?;
                     let state = shell
                         .get_execution_state(&exec_id)
                         .ok_or_else(|| "Execution vanished".to_string())?;
@@ -594,7 +594,7 @@ impl ServiceModule for CodeModule {
                     .get(persona_id)
                     .ok_or_else(|| format!("No shell session for {}", persona_id))?;
 
-                let result = shell.poll(execution_id).map_err(|e| format!("{}", e))?;
+                let result = shell.poll(execution_id).map_err(|e| e.to_string())?;
                 Ok(CommandResult::Json(
                     serde_json::to_value(&result).unwrap_or_default(),
                 ))
@@ -611,7 +611,7 @@ impl ServiceModule for CodeModule {
                     .get(persona_id)
                     .ok_or_else(|| format!("No shell session for {}", persona_id))?;
 
-                shell.kill(execution_id).map_err(|e| format!("{}", e))?;
+                shell.kill(execution_id).map_err(|e| e.to_string())?;
                 Ok(CommandResult::Json(serde_json::json!({ "killed": true })))
             }
 
@@ -626,7 +626,7 @@ impl ServiceModule for CodeModule {
                     .get_mut(persona_id)
                     .ok_or_else(|| format!("No shell session for {}", persona_id))?;
 
-                let new_cwd = shell.cd(path).map_err(|e| format!("{}", e))?;
+                let new_cwd = shell.cd(path).map_err(|e| e.to_string())?;
                 Ok(CommandResult::Json(
                     serde_json::json!({ "changed": true, "cwd": new_cwd }),
                 ))
@@ -661,7 +661,7 @@ impl ServiceModule for CodeModule {
                         .ok_or_else(|| format!("No shell session for {}", persona_id))?;
                     shell
                         .get_watch_handles(execution_id)
-                        .map_err(|e| format!("{}", e))?
+                        .map_err(|e| e.to_string())?
                 };
 
                 let exec_id = execution_id.to_string();
@@ -669,7 +669,7 @@ impl ServiceModule for CodeModule {
                     .state
                     .rt_handle
                     .block_on(async { code::watch_execution(&exec_id, exec_state, notify).await })
-                    .map_err(|e| format!("{}", e))?;
+                    .map_err(|e| e.to_string())?;
 
                 Ok(CommandResult::Json(
                     serde_json::to_value(&result).unwrap_or_default(),
@@ -690,7 +690,7 @@ impl ServiceModule for CodeModule {
 
                 let count = shell
                     .set_sentinel(execution_id, &rules)
-                    .map_err(|e| format!("{}", e))?;
+                    .map_err(|e| e.to_string())?;
                 Ok(CommandResult::Json(
                     serde_json::json!({ "rules_applied": count }),
                 ))

--- a/src/workers/continuum-core/src/modules/data.rs
+++ b/src/workers/continuum-core/src/modules/data.rs
@@ -682,13 +682,13 @@ impl DataModule {
         };
 
         // Log when column projection is active (visibility into optimization)
-        if query.select.is_some() {
+        if let Some(ref select) = query.select {
             log_info!(
                 "data",
                 "query",
                 "Column projection active for {}: SELECT {} (instead of *)",
                 params.collection,
-                query.select.as_ref().unwrap().join(", ")
+                select.join(", ")
             );
         }
 
@@ -1570,7 +1570,7 @@ impl DataModule {
                     "items": [],
                     "pageNumber": current_page,
                     "hasMore": false,
-                    "totalCount": total_count as u64
+                    "totalCount": total_count
                 }
             })));
         }

--- a/src/workers/continuum-core/src/modules/dataset.rs
+++ b/src/workers/continuum-core/src/modules/dataset.rs
@@ -45,12 +45,17 @@ pub struct DatasetModule {
     datasets_root: PathBuf,
 }
 
-impl DatasetModule {
-    pub fn new() -> Self {
-        // Default datasets root — overridable per-request via params
+impl Default for DatasetModule {
+    fn default() -> Self {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
         let datasets_root = PathBuf::from(home).join(".continuum").join("datasets");
         Self { datasets_root }
+    }
+}
+
+impl DatasetModule {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Resolve the datasets root directory, preferring param override.

--- a/src/workers/continuum-core/src/modules/embedding.rs
+++ b/src/workers/continuum-core/src/modules/embedding.rs
@@ -314,7 +314,7 @@ pub fn generate_embeddings_batch(
 
     // Generate embeddings
     embedding_model
-        .embed(texts.to_vec(), None)
+        .embed(texts, None)
         .map_err(|e| format!("Embedding generation failed: {e}"))
 }
 
@@ -474,8 +474,8 @@ pub fn detect_clusters(
             component.push(node);
 
             // Add neighbors above threshold
-            for neighbor in 0..n {
-                if !visited[neighbor] && get_sim(node, neighbor) >= min_similarity {
+            for (neighbor, &is_visited) in visited.iter().enumerate() {
+                if !is_visited && get_sim(node, neighbor) >= min_similarity {
                     queue.push(neighbor);
                 }
             }

--- a/src/workers/continuum-core/src/modules/health.rs
+++ b/src/workers/continuum-core/src/modules/health.rs
@@ -14,11 +14,17 @@ pub struct HealthModule {
     started_at: Instant,
 }
 
-impl HealthModule {
-    pub fn new() -> Self {
+impl Default for HealthModule {
+    fn default() -> Self {
         Self {
             started_at: Instant::now(),
         }
+    }
+}
+
+impl HealthModule {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/src/workers/continuum-core/src/modules/mcp.rs
+++ b/src/workers/continuum-core/src/modules/mcp.rs
@@ -67,6 +67,12 @@ pub struct MCPModule {
     categories: HashMap<&'static str, ToolCategory>,
 }
 
+impl Default for MCPModule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MCPModule {
     pub fn new() -> Self {
         // Compute schemas path relative to the binary location
@@ -477,7 +483,7 @@ impl MCPModule {
 
             // Exact segment match
             let segments: Vec<&str> = name_lower
-                .split(|c| c == '/' || c == '-' || c == '_')
+                .split(['/', '-', '_'])
                 .collect();
             if segments.contains(&query_lower.as_str()) {
                 score += 8;

--- a/src/workers/continuum-core/src/modules/models.rs
+++ b/src/workers/continuum-core/src/modules/models.rs
@@ -16,6 +16,12 @@ use std::any::Any;
 
 pub struct ModelsModule;
 
+impl Default for ModelsModule {
+    fn default() -> Self {
+        Self
+    }
+}
+
 impl ModelsModule {
     pub fn new() -> Self {
         Self

--- a/src/workers/continuum-core/src/modules/runtime_control.rs
+++ b/src/workers/continuum-core/src/modules/runtime_control.rs
@@ -23,11 +23,17 @@ pub struct RuntimeModule {
     registry: OnceCell<Arc<ModuleRegistry>>,
 }
 
-impl RuntimeModule {
-    pub fn new() -> Self {
+impl Default for RuntimeModule {
+    fn default() -> Self {
         Self {
             registry: OnceCell::new(),
         }
+    }
+}
+
+impl RuntimeModule {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/src/workers/continuum-core/src/modules/search.rs
+++ b/src/workers/continuum-core/src/modules/search.rs
@@ -604,9 +604,10 @@ impl SearchModule {
         let input: VectorSearchInput = serde_json::from_value(params)
             .map_err(|e| format!("Invalid vector search params: {e}"))?;
 
-        let mut algo = CosineAlgorithm::default();
-        algo.normalize = input.normalize;
-        algo.threshold = input.threshold;
+        let algo = CosineAlgorithm {
+            normalize: input.normalize,
+            threshold: input.threshold,
+        };
 
         let output = algo.vector_search(&input);
 

--- a/src/workers/continuum-core/src/modules/sentinel/steps/loop_step.rs
+++ b/src/workers/continuum-core/src/modules/sentinel/steps/loop_step.rs
@@ -16,6 +16,7 @@ use crate::modules::sentinel::types::{
 };
 
 /// Execute a loop step with flexible termination
+#[allow(clippy::too_many_arguments)]
 pub async fn execute(
     count: Option<usize>,
     while_condition: Option<&str>,

--- a/src/workers/continuum-core/src/modules/sentinel/steps/shell.rs
+++ b/src/workers/continuum-core/src/modules/sentinel/steps/shell.rs
@@ -13,6 +13,7 @@ use crate::modules::sentinel::types::{ExecutionContext, PipelineContext, StepRes
 /// Environment variables in `env` are interpolated and set on the child process.
 /// This is the safe way to pass arbitrary data (code, JSON, etc.) to shell commands
 /// without shell quoting issues — the data goes through env vars, not the command string.
+#[allow(clippy::too_many_arguments)]
 pub async fn execute(
     cmd: &str,
     args: &[String],

--- a/src/workers/continuum-core/src/modules/tool_parsing.rs
+++ b/src/workers/continuum-core/src/modules/tool_parsing.rs
@@ -20,11 +20,17 @@ pub struct ToolParsingModule {
     codec: Arc<ToolNameCodec>,
 }
 
-impl ToolParsingModule {
-    pub fn new() -> Self {
+impl Default for ToolParsingModule {
+    fn default() -> Self {
         Self {
             codec: Arc::new(ToolNameCodec::new()),
         }
+    }
+}
+
+impl ToolParsingModule {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/src/workers/continuum-core/src/modules/vision.rs
+++ b/src/workers/continuum-core/src/modules/vision.rs
@@ -79,8 +79,8 @@ pub struct VisionModule {
     bus: RwLock<Option<Arc<MessageBus>>>,
 }
 
-impl VisionModule {
-    pub fn new() -> Self {
+impl Default for VisionModule {
+    fn default() -> Self {
         Self {
             cache: RwLock::new(HashMap::with_capacity(256)),
             hits: RwLock::new(0),
@@ -88,6 +88,12 @@ impl VisionModule {
             evictions: RwLock::new(0),
             bus: RwLock::new(None),
         }
+    }
+}
+
+impl VisionModule {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     fn now_ms() -> u64 {

--- a/src/workers/continuum-core/src/orm/vector.rs
+++ b/src/workers/continuum-core/src/orm/vector.rs
@@ -54,41 +54,31 @@ impl Default for EmbeddingModel {
 }
 
 /// Similarity metric for vector search
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, TS, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, TS, PartialEq)]
 #[ts(
     export,
     export_to = "../../../shared/generated/orm/SimilarityMetric.ts"
 )]
 #[serde(rename_all = "lowercase")]
 pub enum SimilarityMetric {
+    #[default]
     Cosine,
     Euclidean,
     DotProduct,
 }
 
-impl Default for SimilarityMetric {
-    fn default() -> Self {
-        SimilarityMetric::Cosine
-    }
-}
-
 /// Hybrid search mode
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, TS, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, TS, PartialEq)]
 #[ts(
     export,
     export_to = "../../../shared/generated/orm/HybridSearchMode.ts"
 )]
 #[serde(rename_all = "lowercase")]
 pub enum HybridSearchMode {
+    #[default]
     Semantic,
     Keyword,
     Hybrid,
-}
-
-impl Default for HybridSearchMode {
-    fn default() -> Self {
-        HybridSearchMode::Semantic
-    }
 }
 
 /// Vector search query options
@@ -473,7 +463,7 @@ pub mod similarity {
         match metric {
             super::SimilarityMetric::Cosine => (1.0 + distance) / 2.0, // cosine is already -1 to 1
             super::SimilarityMetric::Euclidean => 1.0 / (1.0 + distance), // larger distance = lower score
-            super::SimilarityMetric::DotProduct => distance.max(0.0).min(1.0), // clamp to 0-1
+            super::SimilarityMetric::DotProduct => distance.clamp(0.0, 1.0), // clamp to 0-1
         }
     }
 }

--- a/src/workers/continuum-core/src/persona/domain_classifier.rs
+++ b/src/workers/continuum-core/src/persona/domain_classifier.rs
@@ -325,15 +325,12 @@ impl DomainClassifier {
                         matches += 2; // Multi-word matches are worth more
                     }
                 } else {
-                    // Single-word keywords: check word boundaries
+                    // Single-word keywords: check word boundaries or substring for compound words
                     if text_words
                         .iter()
                         .any(|w| w.trim_matches(|c: char| !c.is_alphanumeric()) == keyword.as_str())
+                        || text_lower.contains(keyword.as_str())
                     {
-                        matches += 1;
-                    }
-                    // Also check substring for compound words (e.g. "typescript" in "typescript-expertise")
-                    else if text_lower.contains(keyword.as_str()) {
                         matches += 1;
                     }
                 }
@@ -412,6 +409,12 @@ impl DomainClassifier {
             .iter()
             .map(|(domain, vocab)| (domain.clone(), vocab.adapter_name.is_some()))
             .collect()
+    }
+}
+
+impl Default for DomainClassifier {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/workers/continuum-core/src/persona/evaluator.rs
+++ b/src/workers/continuum-core/src/persona/evaluator.rs
@@ -28,21 +28,16 @@ use uuid::Uuid;
 // =============================================================================
 
 /// Voluntary sleep modes — persona controls own attention.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, TS)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, TS)]
 #[serde(rename_all = "snake_case")]
 #[ts(export, export_to = "../../../shared/generated/persona/SleepMode.ts")]
 pub enum SleepMode {
+    #[default]
     Active,
     MentionedOnly,
     HumanOnly,
     Sleeping,
     UntilTopic,
-}
-
-impl Default for SleepMode {
-    fn default() -> Self {
-        SleepMode::Active
-    }
 }
 
 /// Per-persona sleep state with optional auto-wake.

--- a/src/workers/continuum-core/src/persona/self_task_generator.rs
+++ b/src/workers/continuum-core/src/persona/self_task_generator.rs
@@ -214,11 +214,11 @@ impl SelfTaskGenerator {
             let updated_at = data
                 .get("updatedAt")
                 .and_then(|v| v.as_str())
-                .and_then(|s| parse_iso_to_epoch_ms(s))
+                .and_then(parse_iso_to_epoch_ms)
                 .or_else(|| {
                     data.get("createdAt")
                         .and_then(|v| v.as_str())
-                        .and_then(|s| parse_iso_to_epoch_ms(s))
+                        .and_then(parse_iso_to_epoch_ms)
                 })
                 .unwrap_or(now_ms);
 
@@ -386,7 +386,7 @@ fn chrono_now_iso() -> String {
         .unwrap_or_default();
     let secs = duration.as_secs();
     // Approximate: good enough for task timestamps
-    format!("1970-01-01T00:00:00.000Z") // Placeholder — overwritten by DB on insert
+    "1970-01-01T00:00:00.000Z".to_string() // Placeholder — overwritten by DB on insert
         .replace("1970-01-01T00:00:00.000Z", &format_epoch_secs(secs))
 }
 
@@ -437,7 +437,7 @@ fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
 }
 
 fn is_leap_year(year: u64) -> bool {
-    (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
 }
 
 fn parse_iso_to_epoch_ms(iso: &str) -> Option<u64> {
@@ -479,8 +479,8 @@ fn parse_iso_to_epoch_ms(iso: &str) -> Option<u64> {
         [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     };
 
-    for m in 0..(month.saturating_sub(1) as usize).min(11) {
-        days += month_days[m];
+    for &md in month_days.iter().take((month.saturating_sub(1) as usize).min(11)) {
+        days += md;
     }
     days += day.saturating_sub(1);
 

--- a/src/workers/continuum-core/src/persona/text_analysis/loop_detection.rs
+++ b/src/workers/continuum-core/src/persona/text_analysis/loop_detection.rs
@@ -28,11 +28,17 @@ const RESPONSE_LOOP_WINDOW_MS: u128 = 600_000; // 10 minutes
 const RESPONSE_LOOP_THRESHOLD: usize = 3; // Block after 3 similar responses
 const RESPONSE_HASH_LENGTH: usize = 200; // First 200 chars for comparison
 
-impl LoopDetector {
-    pub fn new() -> Self {
+impl Default for LoopDetector {
+    fn default() -> Self {
         Self {
             states: DashMap::new(),
         }
+    }
+}
+
+impl LoopDetector {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Check if a response is a loop (repeating similar content).
@@ -76,7 +82,6 @@ impl LoopDetector {
 /// Matches TypeScript hashResponse() exactly.
 fn hash_response(text: &str) -> String {
     text.to_lowercase()
-        .trim()
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")

--- a/src/workers/continuum-core/src/runtime/command_executor.rs
+++ b/src/workers/continuum-core/src/runtime/command_executor.rs
@@ -110,7 +110,7 @@ impl CommandExecutor {
             "command": command,
             "params": params,
         });
-        let request_line = format!("{}\n", request.to_string());
+        let request_line = format!("{}\n", request);
 
         log.debug(&format!("Sending: {}", command));
         writer

--- a/src/workers/continuum-core/src/runtime/message_bus.rs
+++ b/src/workers/continuum-core/src/runtime/message_bus.rs
@@ -57,6 +57,12 @@ pub struct MessageBus {
     recent_events: Mutex<Vec<TimestampedEvent>>,
 }
 
+impl Default for MessageBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MessageBus {
     pub fn new() -> Self {
         let (sender, _) = broadcast::channel(1024);

--- a/src/workers/continuum-core/src/runtime/mod.rs
+++ b/src/workers/continuum-core/src/runtime/mod.rs
@@ -31,6 +31,7 @@ pub mod module_context;
 pub mod module_logger;
 pub mod module_metrics;
 pub mod registry;
+#[allow(clippy::module_inception)]
 pub mod runtime;
 pub mod service_module;
 pub mod shared_compute;

--- a/src/workers/continuum-core/src/runtime/module_metrics.rs
+++ b/src/workers/continuum-core/src/runtime/module_metrics.rs
@@ -109,7 +109,7 @@ impl ModuleMetrics {
         let mut timings = self
             .command_timings
             .entry(timing.command.clone())
-            .or_insert_with(VecDeque::new);
+            .or_default();
 
         timings.push_back(timing);
         while timings.len() > TIMING_WINDOW_SIZE {

--- a/src/workers/continuum-core/src/runtime/registry.rs
+++ b/src/workers/continuum-core/src/runtime/registry.rs
@@ -33,6 +33,12 @@ pub struct ModuleRegistry {
     type_routes: DashMap<TypeId, &'static str>,
 }
 
+impl Default for ModuleRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ModuleRegistry {
     pub fn new() -> Self {
         Self {

--- a/src/workers/continuum-core/src/runtime/runtime.rs
+++ b/src/workers/continuum-core/src/runtime/runtime.rs
@@ -47,6 +47,12 @@ pub struct Runtime {
     compute: Arc<SharedCompute>,
 }
 
+impl Default for Runtime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Runtime {
     pub fn new() -> Self {
         Self {

--- a/src/workers/continuum-core/src/runtime/shared_compute.rs
+++ b/src/workers/continuum-core/src/runtime/shared_compute.rs
@@ -47,6 +47,12 @@ pub struct SharedCompute {
     cache: DashMap<String, DashMap<String, LazyValue>>,
 }
 
+impl Default for SharedCompute {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SharedCompute {
     pub fn new() -> Self {
         Self {
@@ -71,7 +77,7 @@ impl SharedCompute {
         let scope_map = self
             .cache
             .entry(scope.to_string())
-            .or_insert_with(DashMap::new);
+            .or_default();
 
         let lazy = scope_map
             .entry(key.to_string())

--- a/src/workers/continuum-core/src/system_resources/monitor.rs
+++ b/src/workers/continuum-core/src/system_resources/monitor.rs
@@ -131,6 +131,12 @@ struct MonitorInner {
     processes_baselined: bool,
 }
 
+impl Default for SystemResourceMonitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SystemResourceMonitor {
     /// Create a new monitor. Performs initial CPU + memory refresh.
     pub fn new() -> Self {

--- a/src/workers/continuum-core/src/tool_parsing/codec.rs
+++ b/src/workers/continuum-core/src/tool_parsing/codec.rs
@@ -18,6 +18,12 @@ pub struct ToolNameCodec {
     reverse_map: RwLock<HashMap<String, String>>,
 }
 
+impl Default for ToolNameCodec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ToolNameCodec {
     pub fn new() -> Self {
         Self {

--- a/src/workers/continuum-core/src/utils/audio.rs
+++ b/src/workers/continuum-core/src/utils/audio.rs
@@ -12,7 +12,7 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 ///
 /// Returns empty vec if byte count is not even (i16 requires 2 bytes)
 pub fn bytes_to_i16(data: &[u8]) -> Vec<i16> {
-    if data.len() % 2 != 0 {
+    if !data.len().is_multiple_of(2) {
         return Vec::new();
     }
     data.chunks_exact(2)


### PR DESCRIPTION
## Summary
- **Memory leak fix**: MemoryCorpus `with_appended_memory/event()` was doing full deep clone of ALL collections (memories, embeddings, timeline_events, event_embeddings) on every single append. With 14 personas accumulating data, this caused 38GB+ RAM usage. Fixed by switching from copy-on-write `Arc<MemoryCorpus>` to in-place mutation via `Arc<RwLock<MemoryCorpus>>`.
- **Corpus size caps**: 2000 memories + 2000 events per persona, with importance-based and recency-based trimming.
- **Stale corpus eviction**: 30min TTL on idle corpora — `evict_caches()` now cleans both consciousness cache AND stale corpora.
- **Clippy cleanup**: 125 warnings → 13 (remaining 13 are unfixable `objc` crate macro warnings). Fixed across 54 files.

## Test plan
- [x] All 49 memory module tests pass
- [x] Full lib test suite: 1223 pass (14 pre-existing failures in ORM/DB tests unrelated to this change)
- [x] Release build clean
- [x] `cargo clippy --lib` shows only 13 unfixable objc macro warnings
- [ ] Deploy and verify RAM stays bounded under load with 14 active personas