### PR TITLE
Fix session identity: seed before browser connects

### DIFF
--- a/src/daemons/session-daemon/server/SessionDaemonServer.ts
+++ b/src/daemons/session-daemon/server/SessionDaemonServer.ts
@@ -428,7 +428,7 @@ export class SessionDaemonServer extends SessionDaemon {
         // CRITICAL: Validate userId exists before loading user
         // Previous failed session creation may have stored session with undefined userId
         if (!existingSession.userId) {
-          console.error(`❌ findUserByDeviceId: Found session with deviceId ${deviceId} but userId is undefined - clearing stale session`);
+          this.log.error(`findUserByDeviceId: Found session with deviceId ${deviceId} but userId is undefined - clearing stale session`);
           // Remove the broken session from memory
           const index = this.sessions.indexOf(existingSession);
           if (index > -1) {
@@ -604,17 +604,15 @@ export class SessionDaemonServer extends SessionDaemon {
     }
 
     public async createOrGetSession(params: CreateSessionParams): Promise<CreateSessionResult | GetSessionResult> {
-        console.error(`🔑 createOrGetSession ENTRY: isShared=${params.isShared}, userId=${params.userId}, category=${(params as any).category}`);
         if (params.isShared) {
           // Extract identity from enhanced connection context
           const enhancedContext = params.connectionContext as EnhancedConnectionContext | undefined;
           const clientType = enhancedContext?.clientType;
           const deviceId = enhancedContext?.identity?.deviceId;
 
-
           // For browser-ui: Single-owner system. Browser = the seeded human owner.
           // Always resolve to the owner, regardless of deviceId or existing sessions.
-          console.error(`🔑 SessionDaemon createOrGetSession: clientType=${clientType}, isShared=${params.isShared}`);
+          this.log.info(`Session create: clientType=${clientType}, isShared=${params.isShared}`);
           if (clientType === 'browser-ui') {
             const seededOwner = await this.findSeededHumanOwner();
             if (seededOwner) {
@@ -796,8 +794,8 @@ export class SessionDaemonServer extends SessionDaemon {
       // This should NEVER happen, but if it does, fail loudly rather than creating broken session
       if (!user || !user.id) {
         const errorMsg = `FATAL: User resolution failed for clientType=${clientType}. This is a bug in SessionDaemonServer.`;
-        console.error(`❌❌❌ ${errorMsg}`);
-        console.error(`Debug info: clientType=${clientType}, identity=${JSON.stringify(identity)}, params.userId=${params.userId}`);
+        this.log.error(errorMsg);
+        this.log.error(`Debug info: clientType=${clientType}, identity=${JSON.stringify(identity)}, params.userId=${params.userId}`);
         throw new Error(errorMsg);
       }
 

--- a/src/generated-command-schemas.json
+++ b/src/generated-command-schemas.json
@@ -7350,6 +7350,11 @@
           "required": false,
           "description": "isSystemTest parameter"
         },
+        "viaBrowser": {
+          "type": "boolean",
+          "required": false,
+          "description": "viaBrowser parameter"
+        },
         "media": {
           "type": "array",
           "required": false,

--- a/src/scripts/parallel-start.sh
+++ b/src/scripts/parallel-start.sh
@@ -347,7 +347,14 @@ if [ "$HEALTHY" = false ]; then
   fi
 fi
 
-# Open browser if none connected, then wait for it
+# Phase 5.5: Seed database BEFORE opening browser
+# Critical: Browser must connect AFTER seeding so findSeededHumanOwner() finds Joel.
+# Without this, browser connects → anonymous user created → wrong userId in session.
+echo -e "\n${YELLOW}Phase 5.5: Ensuring database is seeded...${NC}"
+npm run data:seed 2>&1 | sed 's/^/  [Seed] /'
+echo -e "  ${GREEN}✅ Seed complete${NC}"
+
+# Phase 6: Open browser (after seed — so Joel exists when browser connects)
 if [ "$BROWSER_CONNECTED" = false ] && [ "$HEALTHY" = true ]; then
   PLATFORM=$(preflight_detect_platform)
   URL="http://localhost:9000"
@@ -376,12 +383,6 @@ if [ "$BROWSER_CONNECTED" = false ] && [ "$HEALTHY" = true ]; then
     echo -e "  ${YELLOW}Browser didn't connect — open ${URL} manually${NC}"
   fi
 fi
-
-# Phase 5.5: Ensure database is seeded (always runs — idempotent, skips existing records)
-# This handles: fresh installs, tower deploys with no personas, config updates, model changes.
-echo -e "\n${YELLOW}Phase 5.5: Ensuring database is seeded...${NC}"
-npm run data:seed 2>&1 | sed 's/^/  [Seed] /'
-echo -e "  ${GREEN}✅ Seed complete${NC}"
 
 END_TIME=$(date +%s)
 TOTAL_ELAPSED=$((END_TIME - START_TIME))

--- a/src/widgets/chat/chat-widget/ChatWidget.ts
+++ b/src/widgets/chat/chat-widget/ChatWidget.ts
@@ -22,7 +22,7 @@ import type { SessionGetUserParams, SessionGetUserResult } from '../../../comman
 import { Commands } from '../../../system/core/shared/Commands';
 import { Events } from '../../../system/core/shared/Events';
 import { SCROLLER_PRESETS, type RenderFn, type LoadFn, type ScrollerConfig } from '../../shared/EntityScroller';
-import { DEFAULT_ROOMS, DEFAULT_USERS } from '../../../system/data/domains/DefaultEntities';
+import { DEFAULT_ROOMS } from '../../../system/data/domains/DefaultEntities';
 import { AdapterRegistry } from '../adapters/AdapterRegistry';
 import { AbstractMessageAdapter } from '../adapters/AbstractMessageAdapter';
 import { MessageEventDelegator } from '../adapters/MessageEventDelegator';


### PR DESCRIPTION
## Summary
- **Root cause fix**: Reordered `parallel-start.sh` so database seeding (Phase 5.5) runs BEFORE browser opens (Phase 6). Previously browser connected before Joel existed in DB, creating anonymous sessions.
- **Cleanup**: Replaced `console.error` debug logs in SessionDaemonServer with proper `this.log.info`/`this.log.error` routing
- **Dead code**: Removed unused `DEFAULT_USERS` import from ChatWidget

## Test plan
- [x] `npm stop && npm start` — seed runs before browser, log confirms correct order
- [x] Browser session resolves to Joel (userId `002350cc...`, displayName "Joel")
- [x] Zero anonymous sessions in metadata
- [x] Chat widget renders messages in General room
- [x] TypeScript build passes clean