### PR TITLE
Fix Copilot review: modelFamily passthrough, tailscaled, cleanup

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -28,6 +28,12 @@ Write-Host ""
 Write-Host "  Mode: $Mode" -ForegroundColor Green
 Write-Host ""
 
+# Clean up RunOnce continuation script if this is a post-restart run
+$continuationPath = "$env:USERPROFILE\.continuum-bootstrap-continue.ps1"
+if (Test-Path $continuationPath) {
+    Remove-Item $continuationPath -Force
+}
+
 # ============================================================================
 # Step 1: Check if WSL2 + Ubuntu are ready
 # ============================================================================

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -497,7 +497,14 @@ install_tailscale() {
   # Linux/WSL: ensure daemon is running
   if [ "$PLATFORM" = "linux" ] || [ "$PLATFORM" = "wsl" ]; then
     if ! pgrep -x tailscaled &>/dev/null; then
-      sudo tailscaled --state=/var/lib/tailscale/tailscaled.state &>/dev/null &
+      # Prefer system service manager; fall back to direct spawn only if needed
+      if command -v systemctl &>/dev/null; then
+        sudo systemctl start tailscaled 2>/dev/null || true
+      elif command -v service &>/dev/null; then
+        sudo service tailscaled start 2>/dev/null || true
+      else
+        sudo tailscaled --state=/var/lib/tailscale/tailscaled.state &>/dev/null &
+      fi
       sleep 1
     fi
 

--- a/src/system/user/server/modules/PersonaAgentLoop.ts
+++ b/src/system/user/server/modules/PersonaAgentLoop.ts
@@ -245,7 +245,7 @@ export async function runAgentLoop(
 
       if (!regeneratedResponse.text && !regeneratedResponse.toolCalls?.length) {
         ctx.log(`⚠️  ${ctx.personaName}: [AGENT-LOOP] Empty response from ${ctx.provider} after ${toolIterations} tool iteration(s), using cleaned previous text`);
-        const fallback = await ctx.toolExecutor.parseResponse(aiResponse.text);
+        const fallback = await ctx.toolExecutor.parseResponse(aiResponse.text, ctx.modelFamily);
         aiResponse.text = fallback.cleanedText;
         break;
       }
@@ -270,7 +270,7 @@ export async function runAgentLoop(
     } catch (regenerateError) {
       const errorMsg = regenerateError instanceof Error ? regenerateError.message : String(regenerateError);
       ctx.log(`❌ ${ctx.personaName}: [AGENT-LOOP] Regeneration failed: ${errorMsg}`);
-      aiResponse.text = (await ctx.toolExecutor.parseResponse(aiResponse.text)).cleanedText;
+      aiResponse.text = (await ctx.toolExecutor.parseResponse(aiResponse.text, ctx.modelFamily)).cleanedText;
       break;
     }
   }
@@ -281,7 +281,7 @@ export async function runAgentLoop(
 
   // Always strip any remaining tool call text from the final response
   if (toolIterations > 0 && aiResponse.text) {
-    const finalCleaned = await ctx.toolExecutor.parseResponse(aiResponse.text);
+    const finalCleaned = await ctx.toolExecutor.parseResponse(aiResponse.text, ctx.modelFamily);
     if (finalCleaned.toolCalls.length > 0) {
       ctx.log(`🧹 ${ctx.personaName}: [AGENT-LOOP] Stripped ${finalCleaned.toolCalls.length} residual tool call(s) from final response`);
       aiResponse.text = finalCleaned.cleanedText;


### PR DESCRIPTION
## Summary
- Pass `ctx.modelFamily` to all 4 `parseResponse()` calls in agent loop (was missing on 3)
- Tailscaled: use systemctl/service before raw daemon spawn
- bootstrap.ps1: clean up RunOnce continuation script

Addresses Copilot review comments from #348.