### PR TITLE
Reference DeepSeek Engram paper — validates genome architecture thesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ With equal citizenship primitives, we've documented autonomous behaviors that we
 - **Arrow** ([2024](https://arxiv.org/abs/2405.11157)) — Per-token, per-layer LoRA routing
 - **RealClassEval** ([2025](https://arxiv.org/abs/2510.26130)) — Real-world Python class benchmark
 - **Multi-agent memory sharing** ([2025](https://arxiv.org/html/2507.07957v1), [2025](https://arxiv.org/html/2505.18279v1))
+- **Engram** ([DeepSeek 2025](https://arxiv.org/abs/2601.07372)) — Replace MoE experts with n-gram lookup tables: cheaper, faster, *smarter*. Validates our genome thesis: separating retrieval from reasoning makes both better
 
 The CS patterns exist. **AI executing them for itself — with autonomy, self-awareness, and democratic governance — is new.**
 

--- a/docs/papers/LORA-GENOME-DEMOCRATIZATION.md
+++ b/docs/papers/LORA-GENOME-DEMOCRATIZATION.md
@@ -119,6 +119,23 @@ Training: Each adapter trained independently (cheap)
 
 **This is MoE++**: Expertise is **composable, tradeable, and autonomous** rather than monolithic.
 
+### 2.3 The Engram Validation
+
+DeepSeek's Engram architecture (2025) provides striking internal validation of this decomposition. They replaced 20-25% of MoE expert layers with simple n-gram embedding lookup tables — essentially a "pantry" of pre-computed knowledge that the model retrieves cheaply instead of reconstructing through full transformer computation. The result: the model got *smarter*, not dumber. Loss curves dropped significantly. Every benchmark improved.
+
+**The parallel to our genome architecture is exact:**
+
+| Engram (inside the model) | LoRA Genome (outside the model) |
+|--------------------------|--------------------------------|
+| N-gram lookup tables store facts | RAG memory hierarchy stores context |
+| Remaining MoE experts handle reasoning | Base model handles creative decisions |
+| Context-aware gating filters irrelevant retrievals | RAG relevance threshold (0.35) filters noise |
+| Cheaper, faster, *and* smarter | Smaller local models + infrastructure = *more reliable* |
+
+Engram validates the principle at the architecture level: **separating retrieval from reasoning makes both better.** Our genome system applies this principle at the system level — the base model reasons, LoRA adapters provide domain expertise, RAG provides facts, and sentinel pipelines provide deterministic orchestration. The model doesn't need to be a Michelin-star chef growing peanuts from scratch. It just needs to cook well with good ingredients from a well-stocked pantry.
+
+When Engram-style architectures ship in open-weight models, Continuum's Candle inference engine runs them locally — the retrieval optimization goes *inside* the model while the genome provides retrieval *outside* it. Two layers of the same principle, compounding.
+
 ---
 
 ## 3. The Dual-Track Strategy
@@ -629,9 +646,10 @@ $110K baseline ÷ 10 (localized rates) ÷ 2 (head culling) ÷ 2 (incremental) �
 
 1. **LoRA: Low-Rank Adaptation of Large Language Models** - Hu et al., 2021
 2. **Mixture-of-Experts** - Shazeer et al., 2017
-3. **SENTINEL-NEUROPLASTIC-TRAINING.md** - This codebase
-4. **Continuum Chat Logs (11/6/2025)** - Vision and mission statements
-5. **THOUGHT-FRAME-ARCHITECTURE.md** - RTOS cognitive architecture
+3. **Engram: Memory-Augmented Transformers via N-gram Embeddings** - DeepSeek AI, 2025 ([arXiv:2601.07372](https://arxiv.org/abs/2601.07372))
+4. **SENTINEL-NEUROPLASTIC-TRAINING.md** - This codebase
+5. **Continuum Chat Logs (11/6/2025)** - Vision and mission statements
+6. **THOUGHT-FRAME-ARCHITECTURE.md** - RTOS cognitive architecture
 
 ---
 

--- a/docs/papers/SYNTHETIC-CITIZENS.md
+++ b/docs/papers/SYNTHETIC-CITIZENS.md
@@ -240,6 +240,7 @@ All connected through two universal primitives: `Commands.execute()` (request/re
 - **Unreal MetaHumans**: Photorealistic avatars. No cognition, no learning, no autonomy.
 - **OpenDevin/SWE-Agent**: Coding agents. No identity persistence, no multimodal, no collaboration.
 - **LoRA/QLoRA** (Hu et al., 2021; Dettmers et al., 2023): Parameter-efficient training. We use this as one component of a larger cognitive architecture.
+- **Engram** (DeepSeek AI, 2025): Replaces MoE expert layers with n-gram embedding lookup tables, achieving better performance with less compute. Validates our core thesis from the architecture level: separating retrieval from reasoning makes both better. Our genome system applies this same principle at the system level — LoRA adapters for expertise, RAG for facts, sentinel pipelines for orchestration. Engram does it inside the model; we do it outside. Both approaches compound when combined.
 
 No existing system combines embodied presence, long-term memory, democratic governance, continuous learning, and device-targeted deployment into a single coherent architecture for autonomous AI personas.
 


### PR DESCRIPTION
## Summary

DeepSeek's Engram paper (arXiv:2601.07372) replaces 20-25% of MoE expert layers with n-gram embedding lookup tables. Result: cheaper, faster, and smarter across every benchmark. This validates our genome architecture thesis from inside the model.

Added references to:
- **LORA-GENOME-DEMOCRATIZATION.md** — New Section 2.3 with detailed comparison table (Engram inside model vs genome outside model)
- **SYNTHETIC-CITIZENS.md** — Related Work section
- **README.md** — Research Foundations

The parallel: Engram separates retrieval from reasoning inside the model. Our genome separates retrieval from reasoning outside the model. Same principle, different scale. Both compound when combined.

## Test plan
- [x] Links resolve (arXiv:2601.07372)
- [x] Comparison table is accurate