### PR TITLE
Fix per-task routing: local personas now upgrade to cloud for tool use (#371)

### DIFF
--- a/docs/planning/ALPHA-GAP-ANALYSIS.md
+++ b/docs/planning/ALPHA-GAP-ANALYSIS.md
@@ -126,7 +126,7 @@ This document is the **single source of truth** for remaining work before open-s
 | # | Issue | Status | What |
 |---|-------|--------|------|
 | [#324](https://github.com/CambrianTech/continuum/issues/324) | **Parser-per-model-family** | TODO | 7 parsers needed: Native, Hermes, Qwen, Llama, DeepSeek, Mistral, GenericXML. |
-| [#368](https://github.com/CambrianTech/continuum/issues/368) | **PersonaToolExecutor failures** | IN PROGRESS | String(v) destroying object params, force-text too aggressive, double correction, code/search example bias. Fixes deployed, QA validated. |
+| [#368](https://github.com/CambrianTech/continuum/issues/368) | **PersonaToolExecutor failures** | DONE (PR #400) | Fixed param serialization, agent loop cap, double correction, loop detection side-effect, tool group bias. |
 | [#366](https://github.com/CambrianTech/continuum/issues/366) | **Personas can't reliably write code** | TODO | CodingAgent, tools, quality, full loop all broken. |
 | [#367](https://github.com/CambrianTech/continuum/issues/367) | **CodingAgent dispatch unreliable** | TODO | Claude Code dispatch needs error handling and retry. |
 | [#321](https://github.com/CambrianTech/continuum/issues/321) | **Local inference quality** | TODO | Compacted 14B gives poor responses. |

--- a/src/system/user/server/modules/PersonaResponseGenerator.ts
+++ b/src/system/user/server/modules/PersonaResponseGenerator.ts
@@ -349,7 +349,7 @@ export class PersonaResponseGenerator {
       const toolCap = getToolCapability(this.modelConfig.provider, this.modelConfig);
 
       // 🔧 SUB-PHASE 3.3: Generate AI response with timeout
-      this.log(`🔧 ${this.personaName}: [PHASE 3.3] Calling AIProviderDaemon.generateText (provider: ${this.modelConfig.provider}, model: ${this.modelConfig.model})...`);
+      this.log(`🔧 ${this.personaName}: [PHASE 3.3] Building inference request (default provider: ${this.modelConfig.provider}, model: ${this.modelConfig.model})...`);
 
       // Bug #5 fix: Use adjusted maxTokens from RAG context (two-dimensional budget)
       // RAG budget can only REDUCE maxTokens (protect against context overflow),
@@ -438,13 +438,19 @@ export class PersonaResponseGenerator {
         }
       }
 
-      // Native tools from RAG budget (ToolDefinitionsSource handles prioritization + budget)
+      // Tools from RAG budget (ToolDefinitionsSource handles prioritization + budget)
+      // hasTools must be true for BOTH native AND XML tools — otherwise TaskAwareProviderRouter
+      // never triggers the "tools require cloud" upgrade for local personas (who get XML tools).
       const toolMeta = fullRAGContext.metadata?.toolDefinitions;
-      const hasTools = !!(toolMeta?.nativeToolSpecs && (toolMeta.nativeToolSpecs as unknown[]).length > 0);
-      if (hasTools) {
+      const hasNativeTools = !!(toolMeta?.nativeToolSpecs && (toolMeta.nativeToolSpecs as unknown[]).length > 0);
+      const hasXmlTools = !!(toolMeta?.toolCount && (toolMeta.toolCount as number) > 0);
+      const hasTools = hasNativeTools || hasXmlTools;
+      if (hasNativeTools) {
         request.tools = toolMeta.nativeToolSpecs as NativeToolSpec[];
         request.toolChoice = (toolMeta.toolChoice as string) || 'auto';
         this.log(`🔧 ${this.personaName}: Added ${(toolMeta.nativeToolSpecs as unknown[]).length} native tools from RAG budget (toolChoice=${request.toolChoice})`);
+      } else if (hasXmlTools) {
+        this.log(`🔧 ${this.personaName}: ${toolMeta!.toolCount} XML tools in system prompt (no native specs)`);
       }
 
       // PER-TASK MODEL ROUTING (#371): If the persona uses a local model and the task


### PR DESCRIPTION
## Summary

- **Root cause**: `hasTools` only checked `nativeToolSpecs` — always false for local models (candle) which get XML tools in system prompt. `TaskAwareProviderRouter.routeForTask()` never triggered the "tools require cloud" upgrade
- **Fix**: Check `toolCount` from ToolDefinitionsSource metadata (set for both native AND XML paths). Now `hasTools = hasNativeTools || hasXmlTools`
- **Diagnostic**: Added XML tool count log, clarified pre-routing log that was showing stale provider info

This was the core bug behind #371 and #366 — local 3B models can't use tools, but the routing that was supposed to upgrade them to cloud never fired.

## Test plan

- [x] TypeScript compilation clean
- [x] Deployed, but local persona queue depth (~16 messages) prevents immediate QA
- [ ] Verify routing log `🔄 Task routing — Tools require cloud model` appears for local personas
- [ ] Verify local personas actually use cloud provider for tool-requiring tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)