### PR TITLE
Fix task routing: case mismatch prevented cloud provider upgrade (#371)

### DIFF
--- a/src/system/user/server/modules/TaskAwareProviderRouter.ts
+++ b/src/system/user/server/modules/TaskAwareProviderRouter.ts
@@ -79,7 +79,7 @@ export async function getAvailableCloudProviders(): Promise<Set<string>> {
     const configured = new Set<string>();
     for (const p of result.providers) {
       if (p.isConfigured && p.category === 'cloud') {
-        configured.add(p.provider);
+        configured.add(p.provider.toLowerCase());
       }
     }
     _cachedProviders = configured;


### PR DESCRIPTION
## Summary

- `getAvailableCloudProviders()` stored provider names as PascalCase ("DeepSeek", "Anthropic") from the status API
- `CLOUD_PROVIDER_FALLBACK` uses lowercase ("deepseek", "anthropic")
- `Set.has()` is case-sensitive → no match → routing never upgraded local personas to cloud
- Fix: `.toLowerCase()` when populating the set

This was the second bug preventing task-aware routing from working (first was hasTools=false in PR #401).

## Test plan

- [x] TypeScript compilation clean
- [ ] Deploy and verify `🔄 Task routing` log appears for local personas

🤖 Generated with [Claude Code](https://claude.com/claude-code)