### PR TITLE
Fix cost tracking: use actual routed provider for cost calculation (#341)

### DIFF
--- a/src/system/user/server/modules/PersonaResponseGenerator.ts
+++ b/src/system/user/server/modules/PersonaResponseGenerator.ts
@@ -567,9 +567,13 @@ export class PersonaResponseGenerator {
         // Fire-and-forget: Log AI response generation to cognition database (non-blocking telemetry)
         const inputTokenEstimate = messages.reduce((sum, m) => sum + Math.ceil(getMessageText(m.content).length / 4), 0);  // ~4 chars/token
         const outputTokenEstimate = Math.ceil(aiResponse.text.length / 4);
+        // Use the ACTUAL provider/model (after task routing), not the persona's default.
+        // Without this, candle→deepseek upgrades show $0 cost.
+        const actualProvider = request.provider ?? this.modelConfig.provider;
+        const actualModel = request.model ?? this.modelConfig.model;
         const cost = calculateModelCost(
-          this.modelConfig.provider,
-          this.modelConfig.model,
+          actualProvider,
+          actualModel,
           inputTokenEstimate,
           outputTokenEstimate
         );


### PR DESCRIPTION
## Summary

- `calculateModelCost()` used `this.modelConfig.provider` (persona's default, e.g., candle=$0) instead of the actual routed provider (e.g., deepseek after task routing upgrade)
- All cloud-upgraded generations showed $0 cost in `ai/cost` reports
- Fix: use `request.provider` (post-routing) for cost calculation

Partial fix for #341 — cost tracking now accurate. Budget limits and hard caps still TODO.

## Test plan

- [x] TypeScript compilation clean
- [x] `ai/cost` command returns data (667 generations in 1h)
- [ ] Verify non-zero costs appear after routing upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)