### PR TITLE
Fix sentinel resume: budget exhaustion now resumable (#416)

### DIFF
--- a/src/workers/continuum-core/src/modules/sentinel/executor.rs
+++ b/src/workers/continuum-core/src/modules/sentinel/executor.rs
@@ -167,9 +167,20 @@ pub async fn execute_pipeline(
                 // Update budget consumed
                 budget_consumed.elapsed_secs = start_time.elapsed().as_secs();
 
-                // Write durable checkpoint after each step
+                // Write durable checkpoint after each step.
+                // Distinguish budget exhaustion from general failure — BudgetExhausted
+                // is resumable after sentinel/extend-budget, Failed is not.
                 let cp_status = if failed {
-                    PipelineStatus::Failed
+                    let is_budget = error_msg.as_ref().map_or(false, |e| {
+                        e.contains("max_budget_usd")
+                            || e.contains("budget")
+                            || e.contains("Budget exhausted")
+                    });
+                    if is_budget {
+                        PipelineStatus::BudgetExhausted
+                    } else {
+                        PipelineStatus::Failed
+                    }
                 } else {
                     PipelineStatus::Running
                 };


### PR DESCRIPTION
## Summary

When CodingAgent hits `error_max_budget_usd`, the pipeline status was set to `Failed` (not resumable). Now detects budget-related errors and sets `BudgetExhausted` instead — which IS resumable after `sentinel/extend-budget`.

The flywheel can't turn if the system keeps killing its own work. Budget exhaustion is a pause, not a death.

## Test plan

- [x] Rust compilation clean (`cargo check`)
- [x] Error message matching: "max_budget_usd", "budget", "Budget exhausted" all trigger BudgetExhausted status
- [ ] Deploy and verify: sentinel hits budget → extend-budget → resume works

🤖 Generated with [Claude Code](https://claude.com/claude-code)