### PR TITLE
Fix chat/send sender identity: personas show as themselves (#412)

### DIFF
--- a/docs/planning/ALPHA-GAP-ANALYSIS.md
+++ b/docs/planning/ALPHA-GAP-ANALYSIS.md
@@ -79,7 +79,7 @@ This document is the **single source of truth** for remaining work before open-s
 | [#379](https://github.com/CambrianTech/continuum/issues/379) | **Sentinel test coverage: 55 → 100+** | TODO | 12 step types need thorough coverage. Approve and WebResearch likely untested. |
 | [#334](https://github.com/CambrianTech/continuum/issues/334) | **Technical debt deep clean** | TODO | ESLint config, disabled systems, error handling audit, 14 failing Rust tests. |
 | [#360](https://github.com/CambrianTech/continuum/issues/360) | **ORM date/pagination/indexes** | INVESTIGATED | Dates work correctly (TIMESTAMPTZ/RFC3339). Composite indexes working for high-traffic tables. Cursor pagination unimplemented (OFFSET fine for alpha). |
-| [#412](https://github.com/CambrianTech/continuum/issues/412) | **chat/send sender identity** | TODO | CLI sends show as human owner. Persona tool calls should show as persona. |
+| [#412](https://github.com/CambrianTech/continuum/issues/412) | **chat/send sender identity** | DONE (PR #422) | Persona tool calls now show as persona. Uses params.userId (auto-injected). |
 
 **Previously completed:**
 - 1D: Magic number consolidation (PersonaTimingConfig.ts) — DONE
@@ -137,7 +137,7 @@ This document is the **single source of truth** for remaining work before open-s
 | [#343](https://github.com/CambrianTech/continuum/issues/343) | **Native multimodal** | TODO | Skip STT/TTS for models that handle audio/images directly. |
 | [#342](https://github.com/CambrianTech/continuum/issues/342) | **Vision feedback** | TODO | Personas see screenshots, live visual context. |
 | [#341](https://github.com/CambrianTech/continuum/issues/341) | **API cost budgeting** | PARTIAL (PR #405) | Cost tracking fixed (used wrong provider). `ai/cost` command works. Budget limits still TODO. |
-| [#413](https://github.com/CambrianTech/continuum/issues/413) | **Sentinel logs: list available streams** | TODO | Personas hit "stream not found" with no hint of valid streams. Found by AI team. |
+| [#413](https://github.com/CambrianTech/continuum/issues/413) | **Sentinel logs: list available streams** | DONE (PR #421) | Error messages now list available streams. Found by AI team. |
 | [#417](https://github.com/CambrianTech/continuum/issues/417) | **Evaluate Qwen3.5-35B-A3B** | TODO | Opus reasoning distilled, 3B active MoE. Could replace Llama-3.2-3B as local model. |
 
 **Done when**: Local model reliably calls tools. Parser handles all model families. Per-task routing picks best model. Cost tracked.
@@ -153,8 +153,8 @@ This document is the **single source of truth** for remaining work before open-s
 | [#326](https://github.com/CambrianTech/continuum/issues/326) | **E2E dev orchestration** | TODO | Sentinel templates → auto-trigger → PR workflow → chat bridge. |
 | [#370](https://github.com/CambrianTech/continuum/issues/370) | **Coding pipeline never proven** | PARTIAL (PR #407) | sentinel/coding-agent works e2e. Persona→chat→code trigger needs proof. |
 | [#411](https://github.com/CambrianTech/continuum/issues/411) | **Self-improving system** | TODO | Personas autonomously propose → code → test → PR. The endgame. |
-| [#415](https://github.com/CambrianTech/continuum/issues/415) | **Dispatch classifier too trigger-happy** | TODO | Chat messages dispatched as bug fix tasks. Burned $0.50 on a conversation. |
-| [#416](https://github.com/CambrianTech/continuum/issues/416) | **sentinel/resume rejects BudgetExhausted** | TODO | Status set to Failed not BudgetExhausted — can't resume after budget extension. |
+| [#415](https://github.com/CambrianTech/continuum/issues/415) | **Dispatch classifier too trigger-happy** | DONE (PR #419) | Tightened patterns + technical context gate. |
+| [#416](https://github.com/CambrianTech/continuum/issues/416) | **sentinel/resume rejects BudgetExhausted** | DONE (PR #420) | Budget exhaustion now sets correct resumable status. |
 
 **Previously completed:**
 - 3 sentinel dev templates (build-feature, fix-bug, code-review) — DONE

--- a/src/commands/collaboration/chat/send/server/ChatSendServerCommand.ts
+++ b/src/commands/collaboration/chat/send/server/ChatSendServerCommand.ts
@@ -42,12 +42,14 @@ export class ChatSendServerCommand extends ChatSendCommand {
       throw new Error(`Room not found: ${params.room || 'general'}`);
     }
 
-    // 2. Get sender — explicit senderId takes priority, otherwise resolve human owner.
-    // params.userId reflects the session identity (could be @cli, agent, system).
-    // For chat/send without explicit sender, the human owner is the correct attribution
-    // since this is a single-owner system and CLI/agent are the human's tools.
-    const sender = params.senderId
-      ? await this.findUserById(params.senderId, params)
+    // 2. Get sender — resolve identity from whoever initiated the command.
+    // Priority: explicit senderId > params.userId (auto-injected by infrastructure) > human owner fallback.
+    // When a persona calls chat/send via tool executor, params.userId is the persona's UUID.
+    // When the CLI calls chat/send, params.userId is the human owner or @cli.
+    // Only fall back to human owner when no identity is available at all.
+    const senderId = params.senderId || params.userId;
+    const sender = senderId
+      ? await this.findUserById(senderId as UUID, params)
       : await this.findHumanOwnerOrFallback(params);
 
     // 3. Create message entity


### PR DESCRIPTION
## Summary

Persona tool calls to chat/send showed as the human owner because sender resolution skipped params.userId and went straight to findHumanOwnerOrFallback.

Fix: use params.userId (auto-injected by AgentToolExecutor with persona UUID) before falling back. Priority: explicit senderId > params.userId > human owner.

- Browser/CLI: params.userId = human UUID → shows as human (correct)
- Persona tool call: params.userId = persona UUID → shows as persona (now correct)
- No identity: falls back to human owner (correct for single-owner system)

Also updates gap analysis: #412, #413, #415, #416 all marked DONE.

## Test plan

- [x] TypeScript compilation clean
- [ ] Deploy and verify persona chat messages show persona name, not Joel

🤖 Generated with [Claude Code](https://claude.com/claude-code)