### PR TITLE
Dispatch: feature/bug/review overrides simple command gate

### DIFF
--- a/src/system/sentinel/SentinelDispatchDecider.ts
+++ b/src/system/sentinel/SentinelDispatchDecider.ts
@@ -146,7 +146,10 @@ export class SentinelDispatchDecider {
     if (signals.isQuestion && !signals.isFeature && !signals.isBugFix && !signals.isReview) {
       return this._noDispatch('Message is a question, not a task');
     }
-    if (signals.isSimpleCommand) {
+    // Simple commands are rejected UNLESS they also contain feature/bug/review signals.
+    // "read the bug report and fix it" starts with "read" (simple) but IS a bug fix task.
+    // Suggested by Fireworks AI during code review of PR #419.
+    if (signals.isSimpleCommand && !signals.isFeature && !signals.isBugFix && !signals.isReview) {
       return this._noDispatch('Message is a simple command');
     }
 


### PR DESCRIPTION
AI team code review suggestion from Fireworks AI. 'read the bug report and fix it' was blocked. Now feature/bug/review signals override isSimpleCommand.