### PR TITLE
Add daily cloud cost budget for per-task routing (#341)

### DIFF
--- a/src/system/user/server/modules/PersonaResponseGenerator.ts
+++ b/src/system/user/server/modules/PersonaResponseGenerator.ts
@@ -22,7 +22,7 @@ import { CognitionLogger } from './cognition/CognitionLogger';
 import { truncate, getMessageText, messagePreview } from '../../../../shared/utils/StringUtils';
 import { calculateCost as calculateModelCost } from '../../../../daemons/ai-provider-daemon/shared/PricingConfig';
 import { AIDecisionLogger } from '../../../ai/server/AIDecisionLogger';
-import { routeForTask, getAvailableCloudProviders } from './TaskAwareProviderRouter';
+import { routeForTask, getAvailableCloudProviders, recordUpgradeCost } from './TaskAwareProviderRouter';
 import { CoordinationDecisionLogger, type LogDecisionParams } from '../../../coordination/server/CoordinationDecisionLogger';
 import { Events } from '../../../core/shared/Events';
 import { EVENT_SCOPES } from '../../../events/shared/EventSystemConstants';
@@ -577,6 +577,11 @@ export class PersonaResponseGenerator {
           inputTokenEstimate,
           outputTokenEstimate
         );
+
+        // Track cloud upgrade costs for daily budget enforcement
+        if (routing.upgraded && cost > 0) {
+          recordUpgradeCost(cost);
+        }
 
         CognitionLogger.logResponseGeneration(
           this.personaId,

--- a/src/system/user/server/modules/TaskAwareProviderRouter.ts
+++ b/src/system/user/server/modules/TaskAwareProviderRouter.ts
@@ -27,6 +27,59 @@ import { AIProvidersStatus } from '../../../../commands/ai/providers/status/shar
 
 const log = Logger.create('TaskAwareProviderRouter', 'persona');
 
+// ─── Daily Cost Budget ──────────────────────────────────────────────
+// Prevents runaway cloud spend from per-task routing upgrades.
+// Default: $5/day total across all personas. Configurable via config.env.
+
+const DAILY_BUDGET_USD = parseFloat(process.env.CONTINUUM_DAILY_BUDGET_USD || '5.0');
+
+interface DailyCostTracker {
+  date: string;        // YYYY-MM-DD
+  totalCostUsd: number;
+  upgradeCount: number;
+}
+
+let _dailyCost: DailyCostTracker = { date: '', totalCostUsd: 0, upgradeCount: 0 };
+
+function getTodayStr(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+/** Record a cloud upgrade cost estimate. Called after inference completes. */
+export function recordUpgradeCost(costUsd: number): void {
+  const today = getTodayStr();
+  if (_dailyCost.date !== today) {
+    _dailyCost = { date: today, totalCostUsd: 0, upgradeCount: 0 };
+  }
+  _dailyCost.totalCostUsd += costUsd;
+  _dailyCost.upgradeCount++;
+}
+
+/** Check if daily budget allows another cloud upgrade. */
+function isDailyBudgetExhausted(): boolean {
+  const today = getTodayStr();
+  if (_dailyCost.date !== today) {
+    _dailyCost = { date: today, totalCostUsd: 0, upgradeCount: 0 };
+    return false;
+  }
+  return _dailyCost.totalCostUsd >= DAILY_BUDGET_USD;
+}
+
+/** Get current daily spend stats. */
+export function getDailySpend(): { date: string; spent: number; budget: number; remaining: number; upgradeCount: number } {
+  const today = getTodayStr();
+  if (_dailyCost.date !== today) {
+    return { date: today, spent: 0, budget: DAILY_BUDGET_USD, remaining: DAILY_BUDGET_USD, upgradeCount: 0 };
+  }
+  return {
+    date: today,
+    spent: Math.round(_dailyCost.totalCostUsd * 10000) / 10000,
+    budget: DAILY_BUDGET_USD,
+    remaining: Math.round((DAILY_BUDGET_USD - _dailyCost.totalCostUsd) * 10000) / 10000,
+    upgradeCount: _dailyCost.upgradeCount,
+  };
+}
+
 /** Domains where local models are completely inadequate */
 const CLOUD_REQUIRED_DOMAINS = new Set([
   'code', 'debug', 'analysis', 'tool_use',
@@ -143,6 +196,18 @@ export function routeForTask(
       provider: defaultProvider,
       upgraded: false,
       reason: `Domain '${taskDomain ?? 'unknown'}' works with local model`,
+    };
+  }
+
+  // Check daily budget before upgrading to cloud
+  if (isDailyBudgetExhausted()) {
+    const spend = getDailySpend();
+    log.warn(`Daily budget exhausted ($${spend.spent}/$${spend.budget}) — staying local for ${taskDomain ?? 'unknown'} task`);
+    return {
+      model: defaultModel,
+      provider: defaultProvider,
+      upgraded: false,
+      reason: `Daily cloud budget exhausted ($${spend.spent}/$${spend.budget}) — using local`,
     };
   }
 


### PR DESCRIPTION
Default $5/day cap on cloud upgrades. Configurable via CONTINUUM_DAILY_BUDGET_USD. Tracks spend, stops upgrading when exhausted, system keeps working on local. No hard stops.