### PR TITLE
Fix navigate: tab switching works (#448)

### DIFF
--- a/src/commands/interface/navigate/browser/NavigateBrowserCommand.ts
+++ b/src/commands/interface/navigate/browser/NavigateBrowserCommand.ts
@@ -34,6 +34,11 @@ export class NavigateBrowserCommand extends NavigateCommand {
    * When target='webview', navigates the co-browsing widget instead
    */
   async execute(params: NavigateParams): Promise<NavigateResult> {
+    // Tab switching: emit content:opened to switch the active content tab
+    if (params.tab) {
+      return this.switchTab(params);
+    }
+
     const isReload = !params.url;
     const isWebview = params.target === 'webview';
 
@@ -93,6 +98,28 @@ export class NavigateBrowserCommand extends NavigateCommand {
       };
 
       check();
+    });
+  }
+
+  /**
+   * Switch the active content tab by emitting content:opened event.
+   * Uses the same event system that room clicks, activity joins, etc. use.
+   */
+  private async switchTab(params: NavigateParams): Promise<NavigateResult> {
+    const tab = params.tab!;
+    console.log(`📑 BROWSER: Switching to tab '${tab}'`);
+
+    Events.emit('content:opened', {
+      contentType: tab,
+      entityId: tab,
+      title: tab.charAt(0).toUpperCase() + tab.slice(1),
+      setAsCurrent: true,
+    });
+
+    return createNavigateResult(params.context, params.sessionId, {
+      success: true,
+      url: window.location.href,
+      title: `Switched to ${tab} tab`,
     });
   }
 

--- a/src/commands/interface/navigate/shared/NavigateTypes.ts
+++ b/src/commands/interface/navigate/shared/NavigateTypes.ts
@@ -9,9 +9,10 @@ import { Commands } from '../../../../system/core/shared/Commands';
 
 export type NavigateTarget = '_blank' | '_self' | '_parent' | '_top' | 'webview' | string;
 
-/** Navigate the browser to a URL. */
+/** Navigate the browser to a URL or switch content tabs. */
 export interface NavigateParams extends CommandParams {
   readonly url?: string;  // Optional - if not provided, triggers location.reload()
+  readonly tab?: string;  // Switch to a content tab by name (e.g., 'training', 'coding', 'general')
   readonly timeout?: number;
   readonly waitForSelector?: string;
   readonly target?: NavigateTarget;  // 'webview' to navigate the co-browsing widget


### PR DESCRIPTION
Added --tab param. Emits content:opened event to switch content tabs. navigate --tab=training now shows the training view.