### PR TITLE
Strip <think> tags from synth parser — unblocks Academy (#456)

### DIFF
--- a/src/commands/development/verify-web/shared/DevelopmentVerifyWebTypes.ts
+++ b/src/commands/development/verify-web/shared/DevelopmentVerifyWebTypes.ts
@@ -87,13 +87,12 @@ export const createDevelopmentVerifyWebResult = (
   context: JTAGContext,
   sessionId: UUID,
   data: {
-    success: boolean;
     // True if page loaded with zero errors
-    success?: boolean;
+    success: boolean;
     // Runtime JavaScript errors captured from page
-    errors?: array;
+    errors?: string[];
     // All console.log/warn/error messages
-    consoleOutput?: array;
+    consoleOutput?: string[];
     // Path to captured screenshot
     screenshotPath?: string;
     // Base64-encoded screenshot for AI vision
@@ -105,14 +104,13 @@ export const createDevelopmentVerifyWebResult = (
     error?: JTAGError;
   }
 ): DevelopmentVerifyWebResult => createPayload(context, sessionId, {
-  success: data.success ?? false,
-  errors: data.errors ?? {} as array,
-  consoleOutput: data.consoleOutput ?? {} as array,
+  success: data.success,
+  errors: data.errors ?? [],
+  consoleOutput: data.consoleOutput ?? [],
   screenshotPath: data.screenshotPath ?? '',
   screenshotBase64: data.screenshotBase64 ?? '',
   pageTitle: data.pageTitle ?? '',
   loadTimeMs: data.loadTimeMs ?? 0,
-  ...data
 });
 
 /**

--- a/src/commands/genome/dataset-synthesize/server/GenomeDatasetSynthesizeServerCommand.ts
+++ b/src/commands/genome/dataset-synthesize/server/GenomeDatasetSynthesizeServerCommand.ts
@@ -234,6 +234,10 @@ export class GenomeDatasetSynthesizeServerCommand extends CommandBase<GenomeData
     try {
       let cleaned = text.trim();
 
+      // Strip <think>...</think> reasoning blocks (DeepSeek, Qwen3.5, etc.)
+      // These models emit chain-of-thought before the actual JSON output.
+      cleaned = cleaned.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+
       // Strip markdown code fences (```json ... ```)
       const fenceMatch = cleaned.match(/```(?:json)?\s*\n?([\s\S]*?)```/);
       if (fenceMatch) {


### PR DESCRIPTION
DeepSeek reasoning tags blocked JSON parsing. Training data parser now strips <think> before extracting JSON array. Academy sessions should complete now.