### PR TITLE
Fix: DeepSeek max_tokens 8192 limit

### DIFF
--- a/src/commands/genome/dataset-synthesize/server/GenomeDatasetSynthesizeServerCommand.ts
+++ b/src/commands/genome/dataset-synthesize/server/GenomeDatasetSynthesizeServerCommand.ts
@@ -54,7 +54,7 @@ export class GenomeDatasetSynthesizeServerCommand extends CommandBase<GenomeData
       ],
       ...(model && { model }),
       ...(provider && { provider: provider as AIGenerateParams['provider'] }),
-      maxTokens: 16384,  // Large enough for <think> reasoning + JSON output
+      maxTokens: 8192,  // DeepSeek max is 8192. For models with <think>, reduce examplesPerTopic to fit.
       temperature: 0.8,
     };
 


### PR DESCRIPTION
16384 exceeded DeepSeek's limit. Reverted.