### PR TITLE
Fix: timeout=0 fell through || operator — Academy 600s death

### DIFF
--- a/src/commands/sentinel/run/server/SentinelRunServerCommand.ts
+++ b/src/commands/sentinel/run/server/SentinelRunServerCommand.ts
@@ -87,9 +87,10 @@ export class SentinelRunServerCommand extends CommandBase<SentinelRunParams, Sen
     const workingDir = runParams.workingDir || process.cwd();
     const asyncMode = runParams.async !== false;
 
+    // Use ?? not || — timeout=0 means "no timeout", but || treats 0 as falsy
     const timeoutSecs = runParams.timeout
-      || definition.timeoutSecs
-      || definition.timeout_secs;
+      ?? definition.timeoutSecs
+      ?? definition.timeout_secs;
 
     const pipeline: Pipeline = {
       name: definition.name || 'unnamed',


### PR DESCRIPTION
The || operator treats 0 as falsy. timeout=0 became undefined, Rust defaulted to 600s. Every Academy session died at 10 minutes. Fix: use ?? instead of ||.