### PR TITLE
Make postinstall non-fatal — unblocks tower npm install

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -138,7 +138,7 @@
     "clean:dist": "rm -rf dist/ 2>/dev/null || true",
     "clean:logs": "find .continuum/jtag/logs -name '*.log' -type f -delete 2>/dev/null || true; find .continuum/personas -name '*.log' -type f -delete 2>/dev/null || true; rm -f /tmp/jtag-*-timing.jsonl 2>/dev/null || true; echo '✅ Cleaned all log files (system + persona + timing logs)'",
     "prepare": "npx tsx scripts/ensure-config.ts 2>/dev/null || true",
-    "postinstall": "npm run worker:models",
+    "postinstall": "npm run worker:models || echo '⚠️ Voice model download failed (non-fatal — system starts without STT/TTS)'",
     "prebuild": "npx tsx scripts/ensure-config.ts && npx tsx generator/generate-rust-bindings.ts && npx tsx generator/generate-structure.ts && npx tsx generator/generate-command-schemas.ts && npx tsx generator/generate-command-constants.ts && npx tsx scripts/compile-sass.ts",
     "build:ts": "npx tsx generator/generate-version.ts && npx tsx generator/generate-config.ts && npx tsx scripts/build-with-loud-failure.ts",
     "build:cli": "npx esbuild dist/cli.js --bundle --platform=node --target=node18 --outfile=dist/cli-bundle.js --external:sqlite3 --external:better-sqlite3 --external:@anthropic-ai/sdk --external:@grpc/grpc-js --external:@grpc/proto-loader --minify 2>/dev/null && echo '✅ CLI bundle created (6.6MB)'",


### PR DESCRIPTION
Voice model download failure killed npm install on WSL2 tower. Now non-fatal with warning.