### PR TITLE
Fix widget: genome/adapter-list → genome/layers

### DIFF
--- a/src/widgets/inference-sample/InferenceSampleWidget.ts
+++ b/src/widgets/inference-sample/InferenceSampleWidget.ts
@@ -404,7 +404,7 @@ export class InferenceSampleWidget extends ReactiveWidget {
 
   private async _loadAdapters(): Promise<void> {
     try {
-      const result = await this.executeCommand<any, any>('genome/adapter-list', {
+      const result = await this.executeCommand<any, any>('genome/layers', {
         includeMetrics: true,
       });
       if (result.success && result.adapters) {


### PR DESCRIPTION
Wrong command name crashed training dashboard.