### PR TITLE
Fix: chat messages exempt from event coalescing

### DIFF
--- a/src/workers/continuum-core/src/runtime/message_bus.rs
+++ b/src/workers/continuum-core/src/runtime/message_bus.rs
@@ -199,7 +199,9 @@ impl MessageBus {
             || event_name.starts_with("academy:")
             || event_name.starts_with("chat:")
             || event_name.starts_with("presence:")
-            || event_name.starts_with("tool:");
+            || event_name.starts_with("tool:")
+            || event_name.contains("chat_messages")  // data:chat_messages:created must not be coalesced
+            || event_name.contains("chat_rooms");     // room events are real-time too
 
         if !is_realtime {
             // Coalesce: extract prefix (first two segments) and rate-limit


### PR DESCRIPTION
Event coalescing was dropping chat message events. data:chat_messages:created now passthrough.