### PR TITLE
Auto-adjust cost histogram bucket intervals (#436)

### DIFF
--- a/src/commands/ai/cost/server/AICostServerCommand.ts
+++ b/src/commands/ai/cost/server/AICostServerCommand.ts
@@ -126,7 +126,8 @@ export class AICostServerCommand extends AICostCommand {
       const costByProvider = params.includeBreakdown ? this.aggregateByProvider(finalGens, totalCost) : undefined;
       const costByModel = params.includeBreakdown ? this.aggregateByModel(finalGens, totalCost) : undefined;
       const topModels = params.includeTopModels ? this.getTopModels(finalGens, totalCost, params.includeTopModels) : undefined;
-      const timeSeries = params.includeTimeSeries ? this.generateTimeSeries(finalGens, startTime, endTime, params.interval || '1h') : undefined;
+      const interval = params.interval || this.autoInterval(endTime - startTime);
+      const timeSeries = params.includeTimeSeries ? this.generateTimeSeries(finalGens, startTime, endTime, interval) : undefined;
       const latency = params.includeLatency ? this.calculateLatencyMetrics(finalGens) : undefined;
 
       if (params.format === 'text') {
@@ -281,6 +282,20 @@ export class AICostServerCommand extends AICostCommand {
     }
 
     return points;
+  }
+
+  /**
+   * Auto-select bucket interval based on time range span.
+   * Targets 12-24 buckets for visual clarity at any zoom level.
+   */
+  private autoInterval(spanMs: number): string {
+    const hours = spanMs / 3_600_000;
+    if (hours <= 1) return '5m';
+    if (hours <= 6) return '15m';
+    if (hours <= 24) return '1h';
+    if (hours <= 72) return '3h';
+    if (hours <= 168) return '6h'; // 7 days
+    return '1d';
   }
 
   private parseIntervalToMs(interval: string): number {

--- a/src/widgets/continuum-metrics/ContinuumMetricsWidget.ts
+++ b/src/widgets/continuum-metrics/ContinuumMetricsWidget.ts
@@ -379,18 +379,10 @@ export class ContinuumMetricsWidget extends ReactiveWidget {
 
   private async _fetchAIData(): Promise<void> {
     try {
-      // Adaptive interval: finer granularity for shorter time ranges
-      const intervalMap: Record<string, string> = {
-        '1h': '5m',
-        '6h': '30m',
-        '24h': '1h',
-        '7d': '6h',
-      };
-
+      // Server auto-selects bucket interval based on time range span
       const result = await AICost.execute({
         startTime: this._timeRange,
         includeTimeSeries: true,
-        interval: intervalMap[this._timeRange] ?? '1h',
         includeBreakdown: false,
       });
 

--- a/src/widgets/metrics-detail/MetricsDetailWidget.ts
+++ b/src/widgets/metrics-detail/MetricsDetailWidget.ts
@@ -667,14 +667,10 @@ export class MetricsDetailWidget extends ReactiveWidget {
 
   private async _fetchAIData(): Promise<void> {
     try {
-      const intervalMap: Record<string, string> = {
-        '1h': '5m', '6h': '30m', '24h': '1h', '7d': '6h', '30d': '1d'
-      };
-
+      // Server auto-selects bucket interval based on time range span
       const result = await AICost.execute({
         startTime: this._timeRange,
         includeTimeSeries: true,
-        interval: intervalMap[this._timeRange] ?? '1h',
         includeBreakdown: true,
         includeTopModels: 10,
         includeLatency: true,


### PR DESCRIPTION
## Summary
- Server-side `autoInterval()` picks optimal bucket width based on time range: 1h→5m, 6h→15m, 24h→1h, 72h→3h, 7d→6h, 30d→1d
- Targets 12-24 buckets for visual clarity at any zoom level
- Removed duplicated interval maps from ContinuumMetricsWidget and MetricsDetailWidget — single source of truth in AICostServerCommand
- Callers can still override with explicit `interval` param

Closes #436.

## Test plan
- [x] TypeScript compilation passes
- [ ] Visual verification: cost dashboard shows appropriate bucket granularity at each time range