### PR TITLE
Add UI interaction tool group for persona discovery

### DIFF
--- a/src/system/rag/sources/ToolGroupRegistry.ts
+++ b/src/system/rag/sources/ToolGroupRegistry.ts
@@ -189,6 +189,22 @@ To search for a pattern across files:
 </tool_use>`,
     priority: 35,
   },
+  {
+    id: 'ui-interaction',
+    label: 'UI Interaction',
+    description: 'Click, type, scroll, and navigate the UI. Take screenshots to see results.',
+    toolPatterns: ['interface/interact', 'interface/navigate', 'interface/screenshot'],
+    intentKeywords: [
+      'click', 'type', 'scroll', 'navigate', 'tab', 'button', 'input',
+      'select', 'form', 'ui', 'interface', 'design', 'layout', 'css',
+      'widget', 'sidebar', 'menu', 'theme', 'style',
+    ],
+    example: `<tool_use>
+<tool_name>interface/interact</tool_name>
+<parameters>{"action": "click", "selector": "continuum-widget >> main-widget >> .tab-button"}</parameters>
+</tool_use>`,
+    priority: 30,
+  },
 ] as const;
 
 /**


### PR DESCRIPTION
Personas discover interact/navigate/screenshot as a group when UI-related intents detected. Enables the visual design feedback loop.