### PR TITLE
interact: waitForMs for dynamic UI after tab switches

### DIFF
--- a/src/commands/interface/interact/browser/InterfaceInteractBrowserCommand.ts
+++ b/src/commands/interface/interact/browser/InterfaceInteractBrowserCommand.ts
@@ -25,16 +25,28 @@ export class InterfaceInteractBrowserCommand extends CommandBase<InterfaceIntera
       return this.fail(params, false, `Missing required parameter: ${!action ? 'action' : 'selector'}`);
     }
 
-    // Find element (inside try/catch for invalid CSS selectors)
-    let element: Element | null;
+    // Find element with retry — handles dynamic UI where elements appear after tab switches
+    const maxWaitMs = params.waitForMs ?? 0; // 0 = no waiting (immediate)
+    let element: Element | null = null;
+    const startTime = Date.now();
+
     try {
       element = this.querySelector(selector);
+
+      // If not found and waitForMs specified, poll until element appears or timeout
+      if (!element && maxWaitMs > 0) {
+        while (!element && (Date.now() - startTime) < maxWaitMs) {
+          await new Promise(resolve => setTimeout(resolve, 100));
+          element = this.querySelector(selector);
+        }
+      }
     } catch (err) {
       return this.fail(params, false, `Invalid selector: ${err instanceof Error ? err.message : String(err)}`);
     }
 
     if (!element) {
-      return this.fail(params, false, `No element found for selector: ${selector}`);
+      const waitMsg = maxWaitMs > 0 ? ` (waited ${Date.now() - startTime}ms)` : '';
+      return this.fail(params, false, `No element found for selector: ${selector}${waitMsg}. Try waitForMs parameter if element appears after a tab switch.`);
     }
 
     const elementTag = element.tagName.toLowerCase();

--- a/src/commands/interface/interact/shared/InterfaceInteractTypes.ts
+++ b/src/commands/interface/interact/shared/InterfaceInteractTypes.ts
@@ -27,6 +27,9 @@ export interface InterfaceInteractParams extends CommandParams {
   amount?: number;
   // Wait time after interaction for UI to settle (default: 100)
   waitAfterMs?: number;
+  // Max time to wait for element to appear in DOM (default: 0 = immediate, no waiting).
+  // Use after tab switches when elements mount asynchronously.
+  waitForMs?: number;
 }
 
 /**

--- a/src/system/user/server/modules/PersonaToolDefinitions.ts
+++ b/src/system/user/server/modules/PersonaToolDefinitions.ts
@@ -304,6 +304,7 @@ const PARAM_DESCRIPTION_OVERRIDES: Record<string, Record<string, string>> = {
     direction: 'Scroll direction: up, down, left, right',
     amount: 'Scroll amount in pixels (default: 300)',
     waitAfterMs: 'Wait time after interaction for UI to settle (default: 100)',
+    waitForMs: 'Max time to wait for element to appear (default: 0). Use after tab switches — elements mount asynchronously.',
   },
   'interface/navigate': {
     url: 'URL to navigate to',


### PR DESCRIPTION
Elements mount asynchronously after tab switches. waitForMs polls for the element to appear. Enables seamless tab→interact workflows.