### PR TITLE
Stop storing full tool output in chat messages — DB bloat fix

### DIFF
--- a/src/system/user/server/modules/PersonaToolExecutor.ts
+++ b/src/system/user/server/modules/PersonaToolExecutor.ts
@@ -531,7 +531,9 @@ ${result.error || 'Unknown error'}
       toolResult: true,
       toolName,
       parameters,
-      fullData: result.data,
+      // fullData intentionally omitted — was storing entire file contents, search
+      // results, etc. in chat messages. 11K tool results × full data = DB bloat.
+      // The summary is enough for working memory. Call the tool again if needed.
       success: result.success,
       error: result.error,
       storedAt: Date.now()


### PR DESCRIPTION
11K tool result messages with full file contents in metadata. 40% of chat DB was internal plumbing. Removed fullData storage — summary is enough for working memory.