### PR TITLE
Fix #585: reject LLM placeholder paths in coding-agent workspace

### DIFF
--- a/src/commands/sentinel/coding-agent/server/SentinelCodingAgentServerCommand.ts
+++ b/src/commands/sentinel/coding-agent/server/SentinelCodingAgentServerCommand.ts
@@ -68,6 +68,17 @@ export class SentinelCodingAgentServerCommand extends CommandBase<SentinelCoding
       });
     }
 
+    // ── Sanitize paths — LLMs sometimes output placeholder paths from docs ──
+    const PLACEHOLDER_PATHS = ['/path/to/project', '/path/to/', '/tmp/project', 'path/to/project'];
+    if (p.cwd && PLACEHOLDER_PATHS.some(ph => p.cwd!.includes(ph))) {
+      console.warn(`⚠️ coding-agent: Rejecting placeholder cwd "${p.cwd}" — using process.cwd() instead`);
+      p.cwd = undefined;
+    }
+    if (p.repoPath && PLACEHOLDER_PATHS.some(ph => p.repoPath!.includes(ph))) {
+      console.warn(`⚠️ coding-agent: Rejecting placeholder repoPath "${p.repoPath}" — clearing`);
+      p.repoPath = undefined;
+    }
+
     // ── Bootstrap workspace ──────────────────────────────────────────
     let workspaceCwd: string;
     let workspaceBranch: string | undefined;


### PR DESCRIPTION
## Problem

Fireworks AI hitting: `Workspace bootstrap failed: Invalid workspace root: '/path/to/project'`

LLMs read tool documentation containing example paths like `/path/to/project` and use them literally in tool calls.

## Fix

Sanitize cwd and repoPath before workspace bootstrap. Known placeholder patterns are rejected with a warning, falling back to `process.cwd()`.

## Test

- [x] npm run build:ts passes