### PR TITLE
Fix #591: tool expanders show content (2KB preview)

### DIFF
--- a/src/system/user/server/modules/PersonaToolExecutor.ts
+++ b/src/system/user/server/modules/PersonaToolExecutor.ts
@@ -531,9 +531,11 @@ ${result.error || 'Unknown error'}
       toolResult: true,
       toolName,
       parameters,
-      // fullData intentionally omitted — was storing entire file contents, search
-      // results, etc. in chat messages. 11K tool results × full data = DB bloat.
-      // The summary is enough for working memory. Call the tool again if needed.
+      // Store truncated fullData for expand preview (2KB cap).
+      // TODO #591: lazy-load full data on expand via command instead of storing.
+      fullData: typeof result.data === 'string'
+        ? result.data.slice(0, 2048)
+        : JSON.stringify(result.data ?? '', null, 2).slice(0, 2048),
       success: result.success,
       error: result.error,
       storedAt: Date.now()


### PR DESCRIPTION
## Problem

Tool result expanders in chat show empty content. fullData was intentionally removed to prevent DB bloat.

## Fix

Store first 2KB of tool output as preview. Enough to see file contents, search results, code edits. Full lazy-load via command is tracked in #591.

## Test

- [x] npm run build:ts passes
- [ ] Deploy and verify tool expanders show content