### PR TITLE
Fix #599: STT killed mid-call — orphan watchdog timeout too aggressive

### DIFF
--- a/src/workers/continuum-core/src/live/audio/resource_lifecycle.rs
+++ b/src/workers/continuum-core/src/live/audio/resource_lifecycle.rs
@@ -162,8 +162,8 @@ impl AudioResourceLifecycle {
     /// Force-reset the counter and trigger shutdown.
     pub fn spawn_orphan_watchdog(self: &Arc<Self>) {
         let lifecycle = Arc::clone(self);
-        const ORPHAN_CHECK_INTERVAL_SECS: u64 = 15;
-        const ORPHAN_TIMEOUT_SECS: u64 = 60; // 1 minute without change = orphaned
+        const ORPHAN_CHECK_INTERVAL_SECS: u64 = 30;
+        const ORPHAN_TIMEOUT_SECS: u64 = 600; // 10 minutes — live calls have stable session counts for the entire call duration. 60s was killing Whisper mid-conversation.
         const CHECKS_UNTIL_ORPHAN: u64 = ORPHAN_TIMEOUT_SECS / ORPHAN_CHECK_INTERVAL_SECS;
 
         tokio::spawn(async move {


### PR DESCRIPTION
## Root Cause

Whisper STT was being shut down 60 seconds into every live call. The orphan watchdog saw 15 sessions with stable count and assumed they were orphaned.

Log evidence:
```
02:55:43 — Whisper model loaded (407MB)
02:57:44 — "28 sessions stuck for 60s — orphaned, force-resetting"
02:57:44 — "STT 'whisper' shut down", "Models unloaded (~407MB freed)"
```

## Fix

Increased orphan timeout from 60s to 600s (10 minutes). Live calls naturally have stable session counts — personas join and stay for the duration.

## Test

- [x] cargo build --release passes
- [ ] Deploy, join live call, verify subtitles appear after speaking