### PR TITLE
Fix #599: live mode STT restored — ORT path, async deadlock, diagnostic logging

### DIFF
--- a/src/workers/continuum-core/src/live/audio/vad/production.rs
+++ b/src/workers/continuum-core/src/live/audio/vad/production.rs
@@ -202,8 +202,11 @@ impl ProductionVAD {
 
     /// Initialize both VAD stages (SYNC - model loading is sync)
     pub fn initialize(&mut self) -> Result<(), VADError> {
+        clog_info!("🎤 VAD: Initializing WebRTC stage...");
         self.webrtc.initialize()?;
+        clog_info!("🎤 VAD: WebRTC OK. Initializing Silero stage...");
         self.silero.initialize()?;
+        clog_info!("🎤 VAD: Both stages initialized successfully");
         self.initialized = true;
         Ok(())
     }

--- a/src/workers/continuum-core/src/live/transport/livekit_agent.rs
+++ b/src/workers/continuum-core/src/live/transport/livekit_agent.rs
@@ -1148,7 +1148,9 @@ async fn spawn_stt_listener(
                             let room_ref = room_for_events.clone();
                             let cid = call_id_owned.clone();
                             let tbuf = transcription_buffer.clone();
+                            let sname = speaker_name.clone();
                             tokio::spawn(async move {
+                                clog_info!("🎤 STT: Starting listen_and_transcribe for '{}'", sname);
                                 listen_and_transcribe(
                                     audio_track,
                                     speaker_id,
@@ -1159,6 +1161,7 @@ async fn spawn_stt_listener(
                                     tbuf,
                                 )
                                 .await;
+                                clog_warn!("🎤 STT: listen_and_transcribe exited for '{}'", sname);
                             });
                         }
                         RemoteTrack::Video(video_track) => {
@@ -1223,11 +1226,28 @@ async fn listen_and_transcribe(
     );
 
     // Initialize ProductionVAD — two-stage (WebRTC fast filter → Silero confirmation)
-    let mut vad = ProductionVAD::new();
-    if let Err(e) = vad.initialize() {
-        clog_error!("🎤 STT: Failed to init VAD for '{}': {}", speaker_name, e);
-        return;
-    }
+    // CRITICAL: ORT (ONNX Runtime) can deadlock if Session::builder() is called from
+    // a tokio async context on Apple Silicon. Use spawn_blocking to init on a real thread.
+    clog_info!("🎤 STT: Creating and initializing ProductionVAD for '{}' (spawn_blocking for ORT)...", speaker_name);
+    let vad_result = tokio::task::spawn_blocking(|| {
+        let mut vad = ProductionVAD::new();
+        match vad.initialize() {
+            Ok(()) => Ok(vad),
+            Err(e) => Err(e),
+        }
+    }).await;
+
+    let mut vad = match vad_result {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
+            clog_error!("🎤 STT: Failed to init VAD for '{}': {}", speaker_name, e);
+            return;
+        }
+        Err(e) => {
+            clog_error!("🎤 STT: VAD init task panicked for '{}': {}", speaker_name, e);
+            return;
+        }
+    };
 
     clog_info!("🎤 STT: VAD initialized, listening to '{}'", speaker_name);
 

--- a/src/workers/start-workers.sh
+++ b/src/workers/start-workers.sh
@@ -187,6 +187,14 @@ declare -a WORKER_NAMES=()
 # Get default memory limit from config
 DEFAULT_MEM_LIMIT=$(jq -r '.memoryLimits.default // "4G"' "$CONFIG_FILE")
 
+# Set ORT_DYLIB_PATH for ONNX Runtime (needed by Silero VAD in live mode)
+# The ort crate with load-dynamic feature needs to find libonnxruntime.dylib
+if [ -f "/opt/homebrew/lib/libonnxruntime.dylib" ]; then
+  export ORT_DYLIB_PATH="/opt/homebrew/lib/libonnxruntime.dylib"
+elif [ -f "/usr/local/lib/libonnxruntime.so" ]; then
+  export ORT_DYLIB_PATH="/usr/local/lib/libonnxruntime.so"
+fi
+
 while read -r worker; do
   name=$(echo "$worker" | jq -r '.name')
   binary=$(echo "$worker" | jq -r '.binary')


### PR DESCRIPTION
## Problem

Live mode subtitles completely broken. No speech-to-text from human mic.

## Root Causes (3 layers)

1. **ORT_DYLIB_PATH not set** — ONNX Runtime installed via Homebrew but Rust binary couldn't find it. Set in start-workers.sh.
2. **ORT deadlocked in async context** — `ort::Session::builder()` uses internal std::sync::Mutex that deadlocks when called from tokio async task. Fixed with `spawn_blocking`.
3. **Whisper killed by orphan watchdog** — 60s timeout assumed stable session count = orphaned. Live calls have 15 stable sessions. Timeout → 600s (PR #600).

## Evidence

Before: `VAD init task panicked with message "Mutex poisoned"`
After: Subtitles appear when speaking in live mode.

## Test

- [x] cargo build --release passes
- [x] Subtitles appear in live mode (verified by user)