### PR TITLE
Fix: detect Anthropic credit exhaustion (singular 'credit', 400 status)

### DIFF
--- a/src/daemons/ai-provider-daemon/shared/adapters/BaseOpenAICompatibleAdapter.ts
+++ b/src/daemons/ai-provider-daemon/shared/adapters/BaseOpenAICompatibleAdapter.ts
@@ -718,9 +718,10 @@ export abstract class BaseOpenAICompatibleAdapter extends BaseAIProviderAdapter 
           if (statusCode === 402 || statusCode === 429 ||
               errorLower.includes('insufficient_quota') ||
               errorLower.includes('quota') ||
-              errorLower.includes('credits') ||
+              errorLower.includes('credit') ||
               errorLower.includes('billing') ||
-              errorLower.includes('spending limit')) {
+              errorLower.includes('spending limit') ||
+              errorLower.includes('balance is too low')) {
 
             // Determine specific status
             const isRateLimited = statusCode === 429 && !errorLower.includes('quota') && !errorLower.includes('credits');


### PR DESCRIPTION
Anthropic returns 400 with 'credit balance is too low' — the detector only matched 'credits' (plural) and status 402. Now matches 'credit' and 'balance is too low'.