### PR TITLE
Fix #606: stagger persona boot to prevent DB thundering herd

### DIFF
--- a/src/daemons/user-daemon/server/UserDaemonServer.ts
+++ b/src/daemons/user-daemon/server/UserDaemonServer.ts
@@ -488,7 +488,8 @@ export class UserDaemonServer extends UserDaemon {
         id: r.id  // Add id from DataRecord to entity
       } as UserEntity));
 
-      for (const persona of personas) {
+      for (let i = 0; i < personas.length; i++) {
+        const persona = personas[i];
         if (!persona || !persona.id) {
           this.log.error(`❌ UserDaemon: Invalid persona data:`, persona);
           continue;
@@ -496,6 +497,10 @@ export class UserDaemonServer extends UserDaemon {
 
         if (!this.personaClients.has(persona.id)) {
           await this.createPersonaClient(persona);
+          // Stagger persona boot — 2s between each to avoid thundering herd on DB
+          if (i < personas.length - 1) {
+            await new Promise(resolve => setTimeout(resolve, 2000));
+          }
         }
       }
 


### PR DESCRIPTION
15 personas booting simultaneously = 45+ DB queries at once = everything times out = nobody responds. 2s stagger between each persona init.