### PR TITLE
Fix: seed reliability — retry IPC failures, verify Rust worker ready

### DIFF
--- a/src/scripts/seed-continuum.ts
+++ b/src/scripts/seed-continuum.ts
@@ -243,8 +243,24 @@ async function waitForJTAGReady(maxWaitSeconds: number = 180): Promise<boolean> 
       if (response.success &&
           response.server?.health?.systemReady &&
           response.server?.health?.commandsRegistered > 0) {
-        console.log(`✅ JTAG ready with ${response.server.health.commandsRegistered} commands registered`);
-        return true;
+        // Also verify Rust IPC is connected — seed depends on data/create which goes through Rust ORM
+        try {
+          const { stdout: dbCheck } = await execAsync('./jtag data/list --collection=users --limit=1', { timeout: 10000 });
+          if (dbCheck.includes('"success":true') || dbCheck.includes('"success": true')) {
+            console.log(`✅ JTAG ready with ${response.server.health.commandsRegistered} commands + Rust IPC confirmed`);
+            return true;
+          }
+          // Rust IPC not ready yet — data command failed but TS server is up
+          if (attempts % 5 === 0) {
+            console.log(`   TS server ready but Rust IPC not yet connected...`);
+          }
+        } catch {
+          // data/list failed — Rust worker not up yet, keep waiting
+          if (attempts % 5 === 0) {
+            console.log(`   TS server ready but Rust worker not responding...`);
+          }
+        }
+        // Don't return true yet — wait for Rust
       }
 
       if (attempts % 5 === 0 && attempts > 0) {

--- a/src/scripts/seed/helpers.ts
+++ b/src/scripts/seed/helpers.ts
@@ -298,48 +298,66 @@ export async function createUserViaCommand(
   const providerArg = provider ? ` --provider=${provider}` : '';
   const cmd = `./jtag user/create --type=${type} --displayName="${displayName}"${uniqueIdArg}${providerArg}`;
 
-  try {
-    const { stdout } = await execAsync(cmd);
-    const response: UserCreateResult = JSON.parse(stdout);
+  // Retry up to 3 times with backoff — Rust IPC may not be ready on first attempt
+  const MAX_RETRIES = 3;
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const { stdout } = await execAsync(cmd, { timeout: 15000 });
+      const response: UserCreateResult = JSON.parse(stdout);
 
-    if (response.success && response.user) {
-      console.log(`✅ Created user (${type}): ${displayName} (uniqueId: ${response.user.uniqueId}, ID: ${response.user.id.slice(0, 8)}...)`);
-      return response.user;
-    } else {
+      if (response.success && response.user) {
+        console.log(`✅ Created user (${type}): ${displayName} (uniqueId: ${response.user.uniqueId}, ID: ${response.user.id.slice(0, 8)}...)`);
+        return response.user;
+      } else if (response.error?.includes('IPC') || response.error?.includes('timeout')) {
+        // Rust IPC not ready — retry
+        if (attempt < MAX_RETRIES) {
+          console.log(`   ⏳ Rust IPC not ready, retrying in ${attempt * 3}s (attempt ${attempt}/${MAX_RETRIES})...`);
+          await new Promise(r => setTimeout(r, attempt * 3000));
+          continue;
+        }
+      }
       console.error(`❌ Failed to create user ${displayName}: ${response.error || 'Unknown error'}`);
       return null;
-    }
-  } catch (error: unknown) {
-    const err = toExecError(error);
-    if (err.stdout) {
-      try {
-        const response: UserCreateResult = JSON.parse(err.stdout);
-        if (response.success && response.user) {
-          console.log(`✅ Created user (${type}): ${displayName} (uniqueId: ${response.user.uniqueId}, ID: ${response.user.id.slice(0, 8)}...)`);
-          return response.user;
+    } catch (error: unknown) {
+      const err = toExecError(error);
+      if (err.stdout) {
+        try {
+          const response: UserCreateResult = JSON.parse(err.stdout);
+          if (response.success && response.user) {
+            console.log(`✅ Created user (${type}): ${displayName} (uniqueId: ${response.user.uniqueId}, ID: ${response.user.id.slice(0, 8)}...)`);
+            return response.user;
+          }
+        } catch {
+          // Fall through
         }
-      } catch {
-        // Fall through
       }
-    }
 
-    // "Record already exists" means the user is there — load it instead of failing
-    if (err.stdout && err.stdout.includes('already exists')) {
-      console.log(`✅ User ${displayName} already exists — loading`);
-      if (uniqueId) {
-        return await loadUserByUniqueId(uniqueId);
+      // "Record already exists" means the user is there — load it instead of failing
+      if (err.stdout && err.stdout.includes('already exists')) {
+        console.log(`✅ User ${displayName} already exists — loading`);
+        if (uniqueId) {
+          return await loadUserByUniqueId(uniqueId);
+        }
+        if (type === 'human') {
+          return await loadFirstUserByType('human');
+        }
       }
-      // Try loading by type if no uniqueId match (human user may have different uniqueId)
-      if (type === 'human') {
-        return await loadFirstUserByType('human');
-      }
-    }
 
-    console.error(`❌ Failed to create user ${displayName}: ${err.message}`);
-    if (err.stdout) console.error(`   Output: ${err.stdout.substring(0, 500)}`);
-    if (err.stderr) console.error(`   Stderr: ${err.stderr.substring(0, 500)}`);
-    return null;
+      // IPC/timeout errors — retry if attempts remain
+      const isTransient = err.message?.includes('IPC') || err.message?.includes('timeout') || err.message?.includes('TIMEOUT');
+      if (isTransient && attempt < MAX_RETRIES) {
+        console.log(`   ⏳ Transient error, retrying in ${attempt * 3}s (attempt ${attempt}/${MAX_RETRIES})...`);
+        await new Promise(r => setTimeout(r, attempt * 3000));
+        continue;
+      }
+
+      console.error(`❌ Failed to create user ${displayName}: ${err.message}`);
+      if (err.stdout) console.error(`   Output: ${err.stdout.substring(0, 500)}`);
+      if (err.stderr) console.error(`   Stderr: ${err.stderr.substring(0, 500)}`);
+      return null;
+    }
   }
+  return null; // All retries exhausted
 }
 
 /**


### PR DESCRIPTION
## Problem

Seeding fails on fresh installs: `All IPC connections to continuum-core failed`. The Rust worker isn't ready when seeding starts.

## Fix

1. `waitForJTAGReady()` now verifies Rust IPC via `data/list` — won't proceed until Rust worker responds
2. `createUserViaCommand()` retries 3x with backoff on IPC/timeout errors

## Test

- [x] npm run build:ts passes
- [x] `npm run data:seed` succeeds — all 16 personas created
- [x] AIs responding in chat (4+ personas verified)