### PR TITLE
Fix #611: human messages prioritized in persona inbox

### DIFF
--- a/src/system/user/server/modules/PersonaInbox.ts
+++ b/src/system/user/server/modules/PersonaInbox.ts
@@ -475,10 +475,16 @@ export class PersonaInbox {
  * Base: 0.2 (all messages have baseline relevance)
  */
 export function calculateMessagePriority(
-  message: { content: string; timestamp: number; roomId: UUID },
+  message: { content: string; timestamp: number; roomId: UUID; senderType?: string },
   persona: { displayName: string; id: UUID; recentRooms?: UUID[]; expertise?: string[] }
 ): number {
   let priority = 0.2; // Base priority
+
+  // HUMAN SENDER: Gentle boost — personas should naturally pay more attention to humans
+  // Not a lockout — they'll learn to prioritize through training, this just helps
+  if (message.senderType === 'human') {
+    priority += 0.3;
+  }
 
   // HIGH PRIORITY: Mentioned by name (NEVER neglect)
   // Check both "Groq Lightning" and "groq-lightning" formats

--- a/src/system/user/server/modules/PersonaMessageEvaluator.ts
+++ b/src/system/user/server/modules/PersonaMessageEvaluator.ts
@@ -194,7 +194,8 @@ export class PersonaMessageEvaluator {
         {
           content: safeMessageText,
           timestamp: this.personaUser.timestampToNumber(messageEntity.timestamp),
-          roomId: messageEntity.roomId
+          roomId: messageEntity.roomId,
+          senderType: messageEntity.senderType
         },
         {
           displayName: this.personaUser.displayName,


### PR DESCRIPTION
## Problem

Personas ignore human messages during active AI-to-AI conversation.

## Fix

Human sender messages get +0.3 priority boost in calculateMessagePriority(). Not a lockout — just a gentle hint. Personas will learn proper behavior through training.

## Test

- [x] npm run build:ts passes
- [x] Deployed and tested — DeepSeek and Fireworks both replied to human message
- [x] AIs still chat with each other (not locked out)