### PR TITLE
Separate install-tailscale.sh — kills zombies, testable independently

### DIFF
--- a/src/scripts/install-tailscale.sh
+++ b/src/scripts/install-tailscale.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# install-tailscale.sh — Standalone Tailscale setup
+# Run independently: bash scripts/install-tailscale.sh
+# Called by install.sh but testable on its own.
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${YELLOW}Setting up Tailscale...${NC}"
+
+# 1. Install if missing
+if ! command -v tailscale &>/dev/null; then
+  echo -e "  Installing Tailscale..."
+  curl -fsSL https://tailscale.com/install.sh | sh
+fi
+
+# 2. Kill any stuck daemons (stale processes block everything)
+if pgrep -x tailscaled &>/dev/null; then
+  echo -e "  Killing existing tailscaled processes..."
+  sudo killall tailscaled 2>/dev/null || true
+  sleep 2
+fi
+
+# 3. Set up passwordless sudo (so it auto-starts on boot without prompting)
+if [ ! -f /etc/sudoers.d/tailscale ]; then
+  echo -e "  Setting up passwordless sudo for tailscale..."
+  echo "$USER ALL=(ALL) NOPASSWD: /usr/bin/tailscale, /usr/bin/tailscaled, /usr/sbin/tailscaled" | sudo tee /etc/sudoers.d/tailscale > /dev/null
+  sudo chmod 440 /etc/sudoers.d/tailscale
+fi
+
+# 4. Start daemon fresh
+echo -e "  Starting tailscaled..."
+sudo tailscaled --state=/var/lib/tailscale/tailscaled.state &
+DAEMON_PID=$!
+
+# 5. Wait for socket (not just process — socket must be ready)
+echo -e "  Waiting for daemon socket..."
+for i in $(seq 1 30); do
+  if timeout 2 tailscale status &>/dev/null; then
+    echo -e "  ${GREEN}Daemon ready (${i}s)${NC}"
+    break
+  fi
+  sleep 1
+done
+
+# 6. Check if already authenticated
+TS_IP=$(tailscale ip -4 2>/dev/null || echo "")
+if [ -n "$TS_IP" ]; then
+  echo -e "  ${GREEN}✅ Tailscale connected: ${TS_IP}${NC}"
+  echo -e "  ${GREEN}  Auto-reconnects on reboot. Done.${NC}"
+  exit 0
+fi
+
+# 7. Auth required — show URL clearly
+echo -e ""
+echo -e "  ${YELLOW}══════════════════════════════════════════════════════${NC}"
+echo -e "  ${YELLOW}  OPEN THE URL BELOW IN YOUR BROWSER${NC}"
+echo -e "  ${YELLOW}  Sign in with Google. One-time only.${NC}"
+echo -e "  ${YELLOW}══════════════════════════════════════════════════════${NC}"
+echo -e ""
+
+sudo tailscale up --ssh --accept-routes
+
+# 8. Verify
+TS_IP=$(tailscale ip -4 2>/dev/null || echo "")
+if [ -n "$TS_IP" ]; then
+  echo -e ""
+  echo -e "  ${GREEN}✅ Tailscale connected: ${TS_IP}${NC}"
+  echo -e "  ${GREEN}  This node is on the mesh. Auto-reconnects forever.${NC}"
+else
+  echo -e "  ${RED}❌ Tailscale auth failed.${NC}"
+  exit 1
+fi
+
+# 9. Enable systemd service if available
+if command -v systemctl &>/dev/null && systemctl is-system-running &>/dev/null 2>&1; then
+  sudo systemctl enable tailscaled 2>/dev/null || true
+fi

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -473,118 +473,20 @@ install_livekit
 
 echo -e "${YELLOW}[8/8] Tailscale${NC}"
 
-install_tailscale() {
-  # Fast path: already connected → done (works on all platforms)
-  local ts_ip=$(tailscale ip -4 2>/dev/null || echo "")
-  if [ -n "$ts_ip" ]; then
-    echo -e "  ${GREEN}✅ Tailscale connected (${ts_ip})${NC}"
-    return
-  fi
-
-  case "$PLATFORM" in
-    macos)
-      if [ -d "/Applications/Tailscale.app" ]; then
-        open -a Tailscale 2>/dev/null || true
-        echo -e "  ${GREEN}✅ Tailscale installed — sign in via the menu bar icon${NC}"
-      else
-        echo -e "  Installing Tailscale..."
-        brew install --cask tailscale
-        open -a Tailscale 2>/dev/null || true
-        echo -e "  ${GREEN}✅ Tailscale installed — sign in via the menu bar icon${NC}"
-      fi
-      return
-      ;;
-    linux|wsl)
-      if ! command -v tailscale &>/dev/null; then
-        echo -e "  Installing Tailscale..."
-        curl -fsSL https://tailscale.com/install.sh | sh
-      fi
-      ;;
-  esac
-
-  # Linux/WSL: set up passwordless sudo for tailscale so it auto-starts on boot
-  # without prompting. This is critical for grid resilience — nodes must reconnect
-  # to the mesh automatically after reboots.
-  if [ "$PLATFORM" = "linux" ] || [ "$PLATFORM" = "wsl" ]; then
-    if [ ! -f /etc/sudoers.d/tailscale ]; then
-      echo -e "  Setting up passwordless sudo for tailscale (grid auto-reconnect)..."
-      echo "$USER ALL=(ALL) NOPASSWD: /usr/bin/tailscale, /usr/bin/tailscaled, /usr/sbin/tailscaled" | sudo tee /etc/sudoers.d/tailscale > /dev/null
-      sudo chmod 440 /etc/sudoers.d/tailscale
-      echo -e "  ${GREEN}✅ Passwordless sudo for tailscale configured${NC}"
-    fi
-
-    # Enable systemd service if available (survives reboots on native Linux)
-    if command -v systemctl &>/dev/null && systemctl is-system-running &>/dev/null 2>&1; then
-      sudo systemctl enable tailscaled 2>/dev/null || true
-    fi
-
-    if ! pgrep -x tailscaled &>/dev/null; then
-      echo -e "  ${YELLOW}Starting tailscaled daemon...${NC}"
-      # WSL2 doesn't have systemd — always try direct spawn first
-      if [ "$PLATFORM" = "wsl" ]; then
-        sudo tailscaled --state=/var/lib/tailscale/tailscaled.state &
-      elif command -v systemctl &>/dev/null && systemctl is-system-running &>/dev/null; then
-        sudo systemctl start tailscaled 2>/dev/null
-      elif command -v service &>/dev/null; then
-        sudo service tailscaled start 2>/dev/null
-      else
-        sudo tailscaled --state=/var/lib/tailscale/tailscaled.state &
-      fi
-
-      # Wait for daemon with timeout
-      local waited=0
-      while ! pgrep -x tailscaled &>/dev/null && [ $waited -lt 15 ]; do
-        sleep 1
-        waited=$((waited + 1))
-      done
-
-      if ! pgrep -x tailscaled &>/dev/null; then
-        echo -e "  ${RED}❌ tailscaled failed to start after ${waited}s${NC}"
-        echo -e "  ${YELLOW}Try manually: sudo tailscaled &${NC}"
-        return
-      fi
-      echo -e "  ${GREEN}✅ tailscaled running (took ${waited}s)${NC}"
-    fi
-
-    # Wait for daemon socket to actually be ready (not just process existing)
-    echo -e "  Waiting for tailscaled socket..."
-    local socket_wait=0
-    while ! tailscale status 2>/dev/null | grep -q '.' && [ $socket_wait -lt 30 ]; do
-      sleep 1
-      socket_wait=$((socket_wait + 1))
-    done
-
-    # Check if already authenticated
-    local ts_ip=$(tailscale ip -4 2>/dev/null || echo "")
-    if [ -n "$ts_ip" ]; then
-      echo -e "  ${GREEN}✅ Tailscale already connected (${ts_ip})${NC}"
-      return
-    fi
-
-    # Need auth — tailscale up prints a login URL that must be opened in a browser.
-    echo -e ""
-    echo -e "  ${YELLOW}═══════════════════════════════════════════════════════════${NC}"
-    echo -e "  ${YELLOW}  TAILSCALE LOGIN REQUIRED${NC}"
-    echo -e "  ${YELLOW}  A URL will appear below. Open it in your browser.${NC}"
-    echo -e "  ${YELLOW}  ONE-TIME — after this, Tailscale auto-reconnects forever.${NC}"
-    echo -e "  ${YELLOW}═══════════════════════════════════════════════════════════${NC}"
-    echo -e ""
-
-    # Print the URL and wait. DO NOT eat stdout or stderr.
-    sudo tailscale up --ssh --accept-routes
-    echo -e ""
-
-    local ts_ip=$(tailscale ip -4 2>/dev/null || echo "pending")
-    if [ "$ts_ip" != "pending" ] && [ -n "$ts_ip" ]; then
-      echo -e "  ${GREEN}✅ Tailscale connected! IP: ${ts_ip}${NC}"
-      echo -e "  ${GREEN}  This node is now part of the mesh. It will auto-reconnect on reboot.${NC}"
+# Tailscale is its own script — testable independently: bash scripts/install-tailscale.sh
+case "$PLATFORM" in
+  macos)
+    if [ -d "/Applications/Tailscale.app" ]; then
+      echo -e "  ${GREEN}✅ Tailscale installed — sign in via menu bar${NC}"
     else
-      echo -e "  ${RED}❌ Tailscale auth may have failed. Run manually: sudo tailscale up --ssh${NC}"
+      brew install --cask tailscale 2>/dev/null
+      echo -e "  ${GREEN}✅ Tailscale installed — sign in via menu bar${NC}"
     fi
-  fi
-}
-
-install_tailscale
+    ;;
+  linux|wsl)
+    bash "$SCRIPT_DIR/install-tailscale.sh"
+    ;;
+esac
 
 # DEPS_ONLY mode: all infrastructure installed, skip config/summary/auto-launch
 if [ "$SKIP_BUILD" = "1" ]; then


### PR DESCRIPTION
110 lines of inline Tailscale mess → standalone script. Kills stuck daemons, waits for socket, shows URL. Run: bash scripts/install-tailscale.sh