### PR TITLE
Entity cache: rooms, users, grid never blank when offline (#710)

### DIFF
--- a/src/widgets/chat/room-list/RoomListWidget.ts
+++ b/src/widgets/chat/room-list/RoomListWidget.ts
@@ -34,6 +34,9 @@ type RoomFilter = 'all' | 'rooms' | 'dms';
 export class RoomListWidget extends ReactiveListWidget<RoomEntity> {
   readonly collection = RoomEntity.collection;
 
+  // Cache rooms so sidebar isn't blank when Rust core is offline
+  protected override get entityCacheKey(): string { return 'room-list'; }
+
   // Always fetch rooms from server — localStorage cache goes stale after reseed
   // and 'auto' backend returns cached data without ever hitting the server.
   protected override get loadBackend(): 'server' { return 'server'; }

--- a/src/widgets/chat/user-list/UserListWidget.ts
+++ b/src/widgets/chat/user-list/UserListWidget.ts
@@ -34,6 +34,8 @@ const verbose = () => typeof window !== 'undefined' && window.JTAG_VERBOSE === t
 export class UserListWidget extends ReactiveListWidget<UserEntity> {
   readonly collection = UserEntity.collection;
 
+  protected override get entityCacheKey(): string { return 'user-list'; }
+
   // === REACTIVE STATE ===
   @reactive() private _selectedUserId: string | null = null;
 

--- a/src/widgets/grid/GridStatusSection.ts
+++ b/src/widgets/grid/GridStatusSection.ts
@@ -53,6 +53,29 @@ export class GridStatusSection extends ReactiveWidget {
 
   constructor() {
     super({ widgetName: 'GridStatusSection' });
+    // Restore cached node data so grid section isn't blank when core is offline
+    this.restoreNodeCache();
+  }
+
+  private restoreNodeCache(): void {
+    try {
+      const raw = localStorage.getItem('wc:grid-status-nodes');
+      if (!raw) return;
+      const entries = JSON.parse(raw) as Array<[string, NodeSnapshot]>;
+      this._nodes = new Map(entries);
+    } catch { /* corrupt */ }
+  }
+
+  private saveNodeCache(): void {
+    if (this._nodes.size === 0) return;
+    try {
+      localStorage.setItem('wc:grid-status-nodes', JSON.stringify([...this._nodes.entries()]));
+    } catch { /* full */ }
+  }
+
+  protected override updated(changedProperties: Map<string, unknown>): void {
+    super.updated(changedProperties);
+    if (this._nodes.size > 0) this.saveNodeCache();
   }
 
   protected override onFirstRender(): void {

--- a/src/widgets/shared/ReactiveEntityScrollerWidget.ts
+++ b/src/widgets/shared/ReactiveEntityScrollerWidget.ts
@@ -34,6 +34,31 @@ export abstract class ReactiveEntityScrollerWidget<T extends BaseEntity> extends
   private _pendingUpdate = false;
   @reactive() private _entityCount: number = 0;
 
+  /** Override to enable entity caching. Return a unique key per widget instance. */
+  protected get entityCacheKey(): string | null { return null; }
+
+  /** Cache entities to localStorage after successful load */
+  protected cacheEntities(entities: T[]): void {
+    const key = this.entityCacheKey;
+    if (!key || entities.length === 0) return;
+    try {
+      // Cache essential fields only — not the full entity to save space
+      const slim = entities.map(e => ({ ...e }));
+      localStorage.setItem(`ec:${key}`, JSON.stringify(slim));
+    } catch { /* localStorage full */ }
+  }
+
+  /** Restore cached entities — returns empty array if no cache */
+  protected restoreCachedEntities(): T[] {
+    const key = this.entityCacheKey;
+    if (!key) return [];
+    try {
+      const raw = localStorage.getItem(`ec:${key}`);
+      if (!raw) return [];
+      return JSON.parse(raw) as T[];
+    } catch { return []; }
+  }
+
   /**
    * Batched requestUpdate() - prevents cascading re-renders from rapid CRUD events.
    * Multiple calls within the same microtask are coalesced into a single update.
@@ -133,12 +158,28 @@ export abstract class ReactiveEntityScrollerWidget<T extends BaseEntity> extends
       this.getScrollerPreset()
     );
 
-    // Load initial data
+    // Restore cached entities FIRST so the widget isn't blank while loading
+    const cached = this.restoreCachedEntities();
+    if (cached.length > 0) {
+      for (const entity of cached) {
+        this.scroller.addWithAutoScroll(entity);
+      }
+      this._entityCount = cached.length;
+      this.requestUpdate();
+    }
+
+    // Load fresh data from server
     await this.scroller.load();
     this._scrollerInitialized = true;
 
+    // Cache successful load for next time
+    const loaded = this.scroller.entities();
+    if (loaded.length > 0) {
+      this.cacheEntities([...loaded]);
+    }
+
     // Update reactive entity count — triggers header re-render
-    this._entityCount = this.scroller.entities().length;
+    this._entityCount = loaded.length;
     this.requestUpdate();
   }
 


### PR DESCRIPTION
Rooms showed 0 and grid showed disconnected on refresh when Rust core offline. Now all list widgets cache their data and restore immediately on mount.