### PR TITLE
fix: catch ORT runtime panic — prevents Rust core death

### DIFF
--- a/docker/widget-server.Dockerfile
+++ b/docker/widget-server.Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 
 # Root deps first (cached layer)
 COPY package.json package-lock.json tsconfig*.json ./
-RUN npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts
+RUN npm ci --ignore-scripts
 
 # Full source (widgets reach into shared/, daemons/, commands/, scripts/)
 COPY . .
@@ -28,7 +28,7 @@ COPY . .
 RUN npm run build:ts
 
 # Widget-ui deps + Vite bundle (must build inside Docker to pick up source changes)
-RUN cd examples/widget-ui && npm install 2>/dev/null || true
+RUN cd examples/widget-ui && npm install
 RUN cd examples/widget-ui && npx vite build
 
 EXPOSE 9003

--- a/docker/widget-server.Dockerfile
+++ b/docker/widget-server.Dockerfile
@@ -22,16 +22,10 @@ RUN npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts
 # Full source (widgets reach into shared/, daemons/, commands/, scripts/)
 COPY . .
 
-# Generate shared/config.ts (required by TypeScript build — generated from config.env + package.json)
-RUN npx tsx scripts/generate-config.ts 2>/dev/null || \
-    node -e "const fs=require('fs'); fs.writeFileSync('shared/config.ts', \
-    'export const HTTP_PORT = 9000;\nexport const WS_PORT = 9001;\nexport const ACTIVE_EXAMPLE = \"widget-ui\";\nexport const VERSION = \"1.0.0\";\nexport const config = { HTTP_PORT: 9000, WS_PORT: 9001 };\n')" || \
-    echo "Config generation skipped"
-
-# Build TypeScript
-RUN npx tsc --project tsconfig.json --noEmit false --outDir dist 2>/dev/null || \
-    npm run build:ts 2>/dev/null || \
-    echo "TS build skipped — tsx will handle at runtime"
+# Build TypeScript — no fallbacks, no silent failures.
+# npm run build:ts generates shared/config.ts then compiles.
+# If it fails, the Docker build fails. We don't ship broken images.
+RUN npm run build:ts
 
 # Widget-ui deps + Vite bundle (must build inside Docker to pick up source changes)
 RUN cd examples/widget-ui && npm install 2>/dev/null || true

--- a/docker/widget-server.Dockerfile
+++ b/docker/widget-server.Dockerfile
@@ -22,6 +22,12 @@ RUN npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts
 # Full source (widgets reach into shared/, daemons/, commands/, scripts/)
 COPY . .
 
+# Generate shared/config.ts (required by TypeScript build — generated from config.env + package.json)
+RUN npx tsx scripts/generate-config.ts 2>/dev/null || \
+    node -e "const fs=require('fs'); fs.writeFileSync('shared/config.ts', \
+    'export const HTTP_PORT = 9000;\nexport const WS_PORT = 9001;\nexport const ACTIVE_EXAMPLE = \"widget-ui\";\nexport const VERSION = \"1.0.0\";\nexport const config = { HTTP_PORT: 9000, WS_PORT: 9001 };\n')" || \
+    echo "Config generation skipped"
+
 # Build TypeScript
 RUN npx tsc --project tsconfig.json --noEmit false --outDir dist 2>/dev/null || \
     npm run build:ts 2>/dev/null || \

--- a/src/workers/continuum-core/src/memory/embedding.rs
+++ b/src/workers/continuum-core/src/memory/embedding.rs
@@ -56,8 +56,23 @@ impl FastEmbedProvider {
         options.model_name = fastembed::EmbeddingModel::AllMiniLML6V2;
         options.show_download_progress = true;
 
-        let model = fastembed::TextEmbedding::try_new(options)
-            .map_err(|e| EmbeddingError(format!("Failed to load AllMiniLML6V2: {e}")))?;
+        // ORT panics (instead of returning error) when libonnxruntime can't load.
+        // catch_unwind prevents the panic from killing the process.
+        let model_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            fastembed::TextEmbedding::try_new(options)
+        }));
+        let model = match model_result {
+            Ok(Ok(m)) => m,
+            Ok(Err(e)) => return Err(EmbeddingError(format!("Failed to load AllMiniLML6V2: {e}"))),
+            Err(panic_payload) => {
+                let msg = panic_payload
+                    .downcast_ref::<String>()
+                    .map(|s| s.as_str())
+                    .or_else(|| panic_payload.downcast_ref::<&str>().copied())
+                    .unwrap_or("unknown cause");
+                return Err(EmbeddingError(format!("ORT runtime panicked: {msg}. Check ORT_DYLIB_PATH.")));
+            }
+        };
 
         Ok(Self {
             model: Mutex::new(model),

--- a/src/workers/continuum-core/src/modules/embedding.rs
+++ b/src/workers/continuum-core/src/modules/embedding.rs
@@ -214,12 +214,20 @@ fn get_or_load_model(model_name: &str) -> Result<(), String> {
 
     std::fs::create_dir_all(&cache_dir).map_err(|e| format!("Failed to create cache dir: {e}"))?;
 
-    let model = TextEmbedding::try_new(
-        InitOptions::new(model_enum)
-            .with_cache_dir(cache_dir)
-            .with_show_download_progress(true),
-    )
-    .map_err(|e| format!("Failed to load model: {e}"))?;
+    // ORT crate panics if libonnxruntime can't be loaded (instead of returning error).
+    // catch_unwind prevents the panic from poisoning our mutex and killing the process.
+    let model_result = std::panic::catch_unwind(|| {
+        TextEmbedding::try_new(
+            InitOptions::new(model_enum)
+                .with_cache_dir(cache_dir)
+                .with_show_download_progress(true),
+        )
+    });
+    let model = match model_result {
+        Ok(Ok(m)) => m,
+        Ok(Err(e)) => return Err(format!("Failed to load model: {e}")),
+        Err(_) => return Err("ORT runtime panicked — libonnxruntime not found. Set ORT_DYLIB_PATH.".to_string()),
+    };
 
     let elapsed = start.elapsed();
     info!(
@@ -596,12 +604,20 @@ impl EmbeddingModule {
         Self
     }
 
-    /// Pre-load the default model on startup
+    /// Pre-load the default model on startup.
+    /// Wrapped in catch_unwind because the ORT crate panics (instead of returning
+    /// an error) when libonnxruntime.dylib can't be loaded. The panic poisons the
+    /// model cache mutex and kills every subsequent embedding call. By catching it
+    /// here, we degrade gracefully: embeddings are disabled but the system stays alive.
     pub fn preload_default_model() {
         info!("Pre-loading default embedding model (AllMiniLML6V2)...");
-        match get_or_load_model("AllMiniLML6V2") {
-            Ok(()) => info!("Default embedding model ready"),
-            Err(e) => warn!("Failed to pre-load default model: {e}"),
+        let result = std::panic::catch_unwind(|| {
+            get_or_load_model("AllMiniLML6V2")
+        });
+        match result {
+            Ok(Ok(())) => info!("Default embedding model ready"),
+            Ok(Err(e)) => warn!("Failed to pre-load default model: {e} — embeddings disabled"),
+            Err(_) => warn!("⚠️ ORT runtime panicked during model load — embeddings disabled. Check ORT_DYLIB_PATH."),
         }
     }
 

--- a/src/workers/continuum-core/src/modules/embedding.rs
+++ b/src/workers/continuum-core/src/modules/embedding.rs
@@ -21,6 +21,7 @@ use serde_json::{json, Value};
 use std::any::Any;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tracing::{info, warn};
@@ -51,6 +52,10 @@ pub fn set_gpu_manager(mgr: Arc<GpuMemoryManager>) {
 fn gpu_manager() -> Option<&'static Arc<GpuMemoryManager>> {
     EMBEDDING_GPU_MANAGER.get()
 }
+
+/// Set once ORT panics during init — all subsequent load attempts fail fast
+/// instead of re-triggering catch_unwind and spamming logs.
+static ORT_UNAVAILABLE: AtomicBool = AtomicBool::new(false);
 
 fn get_model_cache() -> &'static Arc<Mutex<HashMap<String, TextEmbedding>>> {
     MODEL_CACHE.get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
@@ -214,8 +219,13 @@ fn get_or_load_model(model_name: &str) -> Result<(), String> {
 
     std::fs::create_dir_all(&cache_dir).map_err(|e| format!("Failed to create cache dir: {e}"))?;
 
+    // Fail fast if ORT already panicked in a previous attempt
+    if ORT_UNAVAILABLE.load(Ordering::Relaxed) {
+        return Err("ORT runtime previously panicked — embeddings unavailable until restart".to_string());
+    }
+
     // ORT crate panics if libonnxruntime can't be loaded (instead of returning error).
-    // catch_unwind prevents the panic from poisoning our mutex and killing the process.
+    // catch_unwind prevents the panic from unwinding out of this call and killing the process.
     let model_result = std::panic::catch_unwind(|| {
         TextEmbedding::try_new(
             InitOptions::new(model_enum)
@@ -226,7 +236,15 @@ fn get_or_load_model(model_name: &str) -> Result<(), String> {
     let model = match model_result {
         Ok(Ok(m)) => m,
         Ok(Err(e)) => return Err(format!("Failed to load model: {e}")),
-        Err(_) => return Err("ORT runtime panicked — libonnxruntime not found. Set ORT_DYLIB_PATH.".to_string()),
+        Err(panic_payload) => {
+            ORT_UNAVAILABLE.store(true, Ordering::Relaxed);
+            let msg = panic_payload
+                .downcast_ref::<String>()
+                .map(|s| s.as_str())
+                .or_else(|| panic_payload.downcast_ref::<&str>().copied())
+                .unwrap_or("unknown cause");
+            return Err(format!("ORT runtime panicked during model init: {msg}. Check ORT_DYLIB_PATH."));
+        }
     };
 
     let elapsed = start.elapsed();
@@ -606,9 +624,9 @@ impl EmbeddingModule {
 
     /// Pre-load the default model on startup.
     /// Wrapped in catch_unwind because the ORT crate panics (instead of returning
-    /// an error) when libonnxruntime.dylib can't be loaded. The panic poisons the
-    /// model cache mutex and kills every subsequent embedding call. By catching it
-    /// here, we degrade gracefully: embeddings are disabled but the system stays alive.
+    /// an error) when libonnxruntime can't be loaded. The panic would unwind out
+    /// of this call and kill the process. By catching it here, we set ORT_UNAVAILABLE
+    /// so subsequent calls fail fast, and the rest of the system stays alive.
     pub fn preload_default_model() {
         info!("Pre-loading default embedding model (AllMiniLML6V2)...");
         let result = std::panic::catch_unwind(|| {
@@ -616,8 +634,16 @@ impl EmbeddingModule {
         });
         match result {
             Ok(Ok(())) => info!("Default embedding model ready"),
-            Ok(Err(e)) => warn!("Failed to pre-load default model: {e} — embeddings disabled"),
-            Err(_) => warn!("⚠️ ORT runtime panicked during model load — embeddings disabled. Check ORT_DYLIB_PATH."),
+            Ok(Err(e)) => warn!("Failed to pre-load default model: {e} — embeddings unavailable"),
+            Err(panic_payload) => {
+                ORT_UNAVAILABLE.store(true, Ordering::Relaxed);
+                let msg = panic_payload
+                    .downcast_ref::<String>()
+                    .map(|s| s.as_str())
+                    .or_else(|| panic_payload.downcast_ref::<&str>().copied())
+                    .unwrap_or("unknown cause");
+                warn!("ORT runtime panicked during model load: {msg} — embeddings unavailable. Check ORT_DYLIB_PATH.");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

ORT (ONNX Runtime) panics instead of returning errors when `libonnxruntime` can't be loaded. This kills the Rust core process, which kills IPC, which kills all personas/chat/data.

**Fix:** Wrap all `TextEmbedding::try_new()` call sites in `std::panic::catch_unwind` so ORT panics become recoverable errors. Embeddings become unavailable but chat, data, and personas keep running.

### Changes

**`modules/embedding.rs`** — EmbeddingModule (IPC command handler):
- `get_or_load_model()`: `catch_unwind` around `TextEmbedding::try_new()` with panic payload extraction
- `preload_default_model()`: `catch_unwind` around startup preload with payload extraction
- `AtomicBool ORT_UNAVAILABLE` flag: set on first panic, subsequent calls fail fast (no repeated `catch_unwind` / log spam)
- Fixed comments that incorrectly described mutex poisoning as the failure mode (lock is released before `try_new`)
- Log messages say "unavailable" not "disabled" (no global disable flag exists)

**`memory/embedding.rs`** — FastEmbedProvider (trait-based adapter):
- `FastEmbedProvider::new()`: wrapped in `catch_unwind` with `AssertUnwindSafe` (previously unprotected)

**Docker (prior commits on this branch):**
- Removed all build fallbacks (`|| true`, `2>/dev/null || npm install`, `tsc || npm run build:ts || echo "skipped"`)
- widget-server Dockerfile uses `npm run build:ts` (generates config then compiles)

## Test plan

- [x] `cargo check` — compiles clean (only pre-existing warnings)
- [x] Docker CI: model-init ✅, node-server ✅, continuum-core ✅ (skipped), livekit-bridge ✅ (skipped)
- [ ] Docker CI: widget-server (building)
- [x] Local: system boots, AIs respond, embeddings work when ORT is available
- [x] Local: system stays alive when ORT is unavailable (tested — chat/data/personas unaffected)