### PR TITLE
fix: three install blockers found on fresh M5 MacBook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,7 +199,7 @@ services:
     restart: unless-stopped
     profiles: ["grid"]
     environment:
-      - TS_AUTHKEY=${TS_AUTHKEY:?Set TS_AUTHKEY in .env or ~/.continuum/config.env}
+      - TS_AUTHKEY=${TS_AUTHKEY:-}
       - TS_STATE_DIR=/var/lib/tailscale
       - TS_SERVE_CONFIG=/config/tailscale-serve.json
       - TS_USERSPACE=false

--- a/install.sh
+++ b/install.sh
@@ -156,7 +156,7 @@ docker compose $COMPOSE_ARGS up -d
 # ── 8. Wait for health ─────────────────────────────────────
 info "Waiting for services..."
 for i in {1..30}; do
-  if curl -sf http://localhost:9000 &>/dev/null || curl -sf https://localhost:9000 -k &>/dev/null; then
+  if curl -sf http://localhost:9003 &>/dev/null || curl -sf https://localhost:9003 -k &>/dev/null; then
     break
   fi
   [ $i -eq 30 ] && warn "Services still starting — check: docker compose logs"
@@ -165,9 +165,9 @@ done
 
 # ── 9. Determine URL + open browser ────────────────────────
 if [ -n "$TS_HOSTNAME" ] && [ -f "$CONTINUUM_DATA/$TS_HOSTNAME.crt" ]; then
-  URL="https://$TS_HOSTNAME:9000"
+  URL="https://$TS_HOSTNAME:9003"
 else
-  URL="http://localhost:9000"
+  URL="http://localhost:9003"
 fi
 
 case "$OS" in
@@ -198,6 +198,6 @@ if [[ "$HAS_GPU" == "true" ]]; then
   echo "  GPU:     ${GPU_NAME:-detected}"
 fi
 if [ -n "$TS_HOSTNAME" ]; then
-  echo "  Mesh:    https://$TS_HOSTNAME:9000"
+  echo "  Mesh:    https://$TS_HOSTNAME:9003"
 fi
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/setup.sh
+++ b/setup.sh
@@ -38,6 +38,9 @@ echo "✅ Docker found"
 
 # ── Ensure ~/.continuum exists ────────────────────
 mkdir -p "$HOME/.continuum/grid"
+# config.env MUST exist as a file before docker compose — bind mounts create
+# directories for missing paths, which then fails with "not a directory".
+touch "$HOME/.continuum/config.env"
 
 # ── Check if Docker is running ────────────────────
 if ! docker info &>/dev/null; then
@@ -100,10 +103,11 @@ docker logout ghcr.io 2>/dev/null || true
 
 echo ""
 echo "📦 Pulling pre-built images..."
-if docker compose pull 2>&1 | tee /tmp/continuum-pull.log | grep -q "Pulled"; then
+if docker compose pull 2>&1; then
   echo "✅ Images pulled from registry"
 else
   # Pull failed (arch mismatch, network, etc.) — build locally
+  echo ""
   echo "⚠️  Pre-built images not available for this platform. Building locally..."
   echo "   (This takes 15-20 minutes the first time. Subsequent starts are instant.)"
   echo ""


### PR DESCRIPTION
## Summary
- setup.sh: `touch config.env` before docker compose (prevents bind mount creating directory)
- setup.sh: remove `tee|grep` pipe that hangs on Windows Git Bash, use exit code instead
- docker-compose.yml: `TS_AUTHKEY` uses `${:-}` not `${:?}` so non-grid users aren't blocked
- install.sh: fix port 9000→9003 (widget-server serves on 9003)

## Test plan
- [x] Tested on fresh M5 MacBook via Tailscale SSH — confirmed TS_AUTHKEY error, fix resolves it
- [ ] Full end-to-end: clone → setup.sh → browser opens → chat works

🤖 Generated with [Claude Code](https://claude.com/claude-code)