### PR TITLE
fix: proportional memory guard (80% system RAM) + setup.sh auto-config

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -46,17 +46,117 @@ if ! docker info &>/dev/null; then
 fi
 echo "✅ Docker is running"
 
-# ── Check Docker resources ────────────────────────
-# Rancher Desktop and Docker Desktop have configurable VM memory.
-# 8GB minimum needed for all containers.
+# ── Auto-configure Docker VM resources ────────────
+# Docker Desktop and Rancher Desktop run a VM with fixed RAM/CPU.
+# Default allocations (2-6GB) are too small for continuum.
+# Auto-detect system resources and configure the VM to use half.
 DOCKER_MEM=$(docker info --format '{{.MemTotal}}' 2>/dev/null || echo "0")
 DOCKER_MEM_GB=$((DOCKER_MEM / 1073741824))
-if [ "$DOCKER_MEM_GB" -lt 8 ] && [ "$DOCKER_MEM_GB" -gt 0 ]; then
+MIN_MEM_GB=8
+
+if [ "$DOCKER_MEM_GB" -lt "$MIN_MEM_GB" ] && [ "$DOCKER_MEM_GB" -gt 0 ]; then
   echo ""
-  echo "⚠️  Docker has ${DOCKER_MEM_GB}GB RAM. Continuum needs at least 8GB."
-  echo "   Increase in Docker Desktop → Settings → Resources → Memory"
-  echo "   Or Rancher Desktop → Preferences → Virtual Machine → Memory"
+  echo "⚠️  Docker VM has ${DOCKER_MEM_GB}GB RAM (minimum ${MIN_MEM_GB}GB needed)."
   echo ""
+
+  # Detect system RAM and offer to fix
+  if [[ "$PLATFORM" == "mac" ]]; then
+    SYS_MEM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%d", $1/1073741824}')
+    SYS_CPUS=$(sysctl -n hw.ncpu 2>/dev/null || echo "4")
+  else
+    SYS_MEM_GB=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{printf "%d", $2/1048576}')
+    SYS_CPUS=$(nproc 2>/dev/null || echo "4")
+  fi
+  TARGET_MEM=$((SYS_MEM_GB / 2))
+  TARGET_CPUS=$((SYS_CPUS / 2))
+  [ "$TARGET_MEM" -lt "$MIN_MEM_GB" ] && TARGET_MEM="$MIN_MEM_GB"
+  [ "$TARGET_CPUS" -lt 2 ] && TARGET_CPUS=2
+
+  DOCKER_UPDATED=false
+
+  # Try Rancher Desktop (macOS)
+  RANCHER_SETTINGS="$HOME/Library/Preferences/rancher-desktop/settings.json"
+  if [ -f "$RANCHER_SETTINGS" ]; then
+    echo "   Rancher Desktop detected."
+    echo "   Your system has ${SYS_MEM_GB}GB RAM / ${SYS_CPUS} CPUs."
+    echo "   Recommended: ${TARGET_MEM}GB RAM / ${TARGET_CPUS} CPUs for Docker VM."
+    echo ""
+    read -p "   Update Rancher Desktop VM to ${TARGET_MEM}GB/${TARGET_CPUS}CPUs? [Y/n] " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+      echo "   Skipped. You can change this manually in Rancher Desktop → Preferences → Virtual Machine."
+    else
+    echo "   Updating VM: ${TARGET_MEM}GB RAM, ${TARGET_CPUS} CPUs..."
+    # Use python3 (available on macOS) to patch JSON safely
+    python3 -c "
+import json, sys
+d = json.load(open('$RANCHER_SETTINGS'))
+d['virtualMachine']['memoryInGB'] = $TARGET_MEM
+d['virtualMachine']['numberCPUs'] = $TARGET_CPUS
+json.dump(d, open('$RANCHER_SETTINGS', 'w'), indent=2)
+print('   Updated: memoryInGB=${TARGET_MEM}, numberCPUs=${TARGET_CPUS}')
+" 2>/dev/null && DOCKER_UPDATED=true
+    if [ "$DOCKER_UPDATED" = true ]; then
+      echo "   Restarting Rancher Desktop VM (this takes ~30s)..."
+      rdctl shutdown 2>/dev/null; sleep 5; rdctl start 2>/dev/null &
+      # Wait for Docker to come back
+      for i in $(seq 1 60); do
+        docker info &>/dev/null && break
+        sleep 2
+      done
+      echo "✅ Rancher Desktop VM reconfigured: ${TARGET_MEM}GB RAM, ${TARGET_CPUS} CPUs"
+    fi
+    fi # end y/n prompt
+  fi
+
+  # Try Docker Desktop (macOS)
+  if [ "$DOCKER_UPDATED" = false ]; then
+    DD_SETTINGS="$HOME/Library/Group Containers/group.com.docker/settings-store.json"
+    DD_SETTINGS_ALT="$HOME/Library/Group Containers/group.com.docker/settings.json"
+    DD_FILE=""
+    [ -f "$DD_SETTINGS" ] && DD_FILE="$DD_SETTINGS"
+    [ -f "$DD_SETTINGS_ALT" ] && DD_FILE="$DD_SETTINGS_ALT"
+
+    if [ -n "$DD_FILE" ]; then
+      echo "   Docker Desktop detected."
+      echo "   Your system has ${SYS_MEM_GB}GB RAM / ${SYS_CPUS} CPUs."
+      echo "   Recommended: ${TARGET_MEM}GB RAM / ${TARGET_CPUS} CPUs for Docker VM."
+      echo ""
+      read -p "   Update Docker Desktop VM to ${TARGET_MEM}GB/${TARGET_CPUS}CPUs? [Y/n] " -n 1 -r
+      echo ""
+      if [[ $REPLY =~ ^[Nn]$ ]]; then
+        echo "   Skipped. Change manually: Docker Desktop → Settings → Resources → Memory"
+      else
+      echo "   Updating VM: ${TARGET_MEM}GB RAM, ${TARGET_CPUS} CPUs..."
+      TARGET_MEM_MIB=$((TARGET_MEM * 1024))
+      python3 -c "
+import json
+d = json.load(open('$DD_FILE'))
+d['memoryMiB'] = $TARGET_MEM_MIB
+d['cpus'] = $TARGET_CPUS
+json.dump(d, open('$DD_FILE', 'w'), indent=2)
+print('   Updated: memoryMiB=${TARGET_MEM_MIB}, cpus=${TARGET_CPUS}')
+" 2>/dev/null && DOCKER_UPDATED=true
+      if [ "$DOCKER_UPDATED" = true ]; then
+        echo "   Restart Docker Desktop to apply. (Or: osascript -e 'quit app \"Docker\"' && open -a Docker)"
+      fi
+      fi # end y/n prompt
+    fi
+  fi
+
+  # Linux: Docker uses host resources directly, no VM config needed
+  if [ "$DOCKER_UPDATED" = false ] && [[ "$PLATFORM" == "linux" ]]; then
+    echo "   Linux detected — Docker uses host resources directly. No VM to configure."
+    DOCKER_UPDATED=true
+  fi
+
+  if [ "$DOCKER_UPDATED" = false ]; then
+    echo ""
+    echo "   Could not auto-configure. Please increase Docker VM memory to at least ${MIN_MEM_GB}GB:"
+    echo "   Docker Desktop → Settings → Resources → Memory"
+    echo "   Rancher Desktop → Preferences → Virtual Machine → Memory"
+    echo ""
+  fi
 fi
 
 # ── Install continuum CLI ─────────────────────────

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -970,20 +970,58 @@ pub fn start_server(
     log_info!("ipc", "server", "IPC server ready");
 
     // Periodic memory leak reporter — logs RSS + top leakers every 10s
-    // Also acts as OOM guard: exits gracefully at 4GB so npm start can restart
+    // Also acts as OOM guard: exits gracefully before OOM kills us ungracefully.
+    // Limit is 80% of system RAM (not a fixed 4GB) — scales from an 8GB MacBook
+    // Air to a 192GB workstation without false kills. The old 4GB limit was killing
+    // the process on 48GB machines where 5.6GB RSS is perfectly normal (whisper
+    // 1.6GB + ORT embedding runtime 1.8GB one-time alloc + working set).
     let mem_rt = state.rt_handle.clone();
     mem_rt.spawn(async {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(10));
-        const MAX_RSS_MB: u64 = 4096; // 4GB — exit before OOM kills us ungracefully
+        let system_ram_mb = {
+            #[cfg(target_os = "macos")]
+            {
+                use std::process::Command;
+                Command::new("sysctl")
+                    .args(["-n", "hw.memsize"])
+                    .output()
+                    .ok()
+                    .and_then(|o| String::from_utf8(o.stdout).ok())
+                    .and_then(|s| s.trim().parse::<u64>().ok())
+                    .map(|bytes| bytes / (1024 * 1024))
+                    .unwrap_or(8192) // fallback 8GB
+            }
+            #[cfg(target_os = "linux")]
+            {
+                std::fs::read_to_string("/proc/meminfo")
+                    .ok()
+                    .and_then(|s| {
+                        s.lines()
+                            .find(|l| l.starts_with("MemTotal:"))
+                            .and_then(|l| l.split_whitespace().nth(1))
+                            .and_then(|kb| kb.parse::<u64>().ok())
+                            .map(|kb| kb / 1024)
+                    })
+                    .unwrap_or(8192)
+            }
+            #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+            { 8192u64 }
+        };
+        // 80% of system RAM — aggressive enough to catch real leaks,
+        // generous enough not to false-kill on big machines.
+        let max_rss_mb: u64 = (system_ram_mb * 80) / 100;
+        eprintln!(
+            "[MEMGUARD] Memory guard: system={}MB, limit={}MB (80%)", system_ram_mb, max_rss_mb
+        );
         loop {
             interval.tick().await;
             dump_memory_report();
             let rss = current_rss_mb();
-            if rss > MAX_RSS_MB {
+            if rss > max_rss_mb {
                 eprintln!(
-                    "[MEMLEAK] FATAL: RSS {}MB exceeds {}MB limit — exiting gracefully to avoid OOM. \
-                     Restart with: npm start. Fix tracked in #603.",
-                    rss, MAX_RSS_MB
+                    "[MEMLEAK] FATAL: RSS {}MB exceeds {}MB limit (80% of {}MB system RAM) — \
+                     exiting gracefully to avoid OOM. Restart with: npm start. Fix tracked in #603.",
+                    rss, max_rss_mb, system_ram_mb
                 );
                 // Give time for the message to flush
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;


### PR DESCRIPTION
## Summary
Two fixes from M5 MacBook testing (bare metal npm start):

- **Memory guard**: Hardcoded 4096MB RSS limit killed continuum-core on machines with >4GB RAM (issue #603). Now detects system RAM via sysctl (Mac) / /proc/meminfo (Linux) and sets limit to 80% of system RAM. On 48GB M5 = 38GB limit. On 8GB Air = 6.4GB limit.
- **setup.sh auto-config**: Detects Docker/Rancher Desktop RAM allocation vs system RAM. If Docker has less than 8GB, prompts user (Y/n) to increase to half system RAM and restart the VM.

## Test plan
- [x] Bare metal npm start on 48GB M5 — RSS stable at 5.9GB, limit 38GB, no kill
- [x] ORT panic catch works — embeddings load and generate
- [x] jtag ping confirms: systemReady=true, 346 commands, 17 daemons
- [ ] Docker e2e: clean wipe → clone → setup.sh → chat works (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)