### PR TITLE
fix: WS initial connect retries silently during Docker startup race

### DIFF
--- a/docker/widget-server.Dockerfile
+++ b/docker/widget-server.Dockerfile
@@ -33,7 +33,9 @@ RUN cd examples/widget-ui && npx vite build
 
 EXPOSE 9003
 
-HEALTHCHECK --interval=5s --timeout=3s --retries=3 \
+# Healthcheck — just verify the HTTP server responds. 30s interval, not 5s.
+# The real health signal is the WebSocket connection, which the browser monitors.
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
     CMD curl -sf http://localhost:9003/ || exit 1
 
 WORKDIR /app/examples/widget-ui

--- a/src/system/transports/websocket-transport/shared/WebSocketTransportClient.ts
+++ b/src/system/transports/websocket-transport/shared/WebSocketTransportClient.ts
@@ -422,33 +422,50 @@ export abstract class WebSocketTransportClient extends TransportBase {
     }
 
     return new Promise((resolve, reject) => {
-      try {
-        this.socket = this.createWebSocket(url);
-        const clientId = this.generateClientId('ws_client');
-        
-        // Set up consistent event handling
-        this.setupWebSocketEvents(this.socket, clientId);
-        
-        // Add Promise resolution/rejection to the consistent event handlers
-        const handleOpen = (event: JTAGWebSocketOpenEvent): void => {
-          verbose() && console.log(`✅ ${this.name}: Handler compliance enforced by TypeScript`);
-          this.socket!.removeEventListener('error', handleError);
-          resolve();
-        };
-        
-        const handleError = (event: JTAGWebSocketErrorEvent): void => {
-          const errorMsg = event.error?.message || event.message || 'Connection failed';
-          this.socket!.removeEventListener('open', handleOpen);
-          reject(new Error(`WebSocket connection error: ${errorMsg}`));
-        };
-        
-        // Add temporary listeners for Promise resolution
-        this.socket.addEventListener('open', handleOpen);
-        this.socket.addEventListener('error', handleError);
-        
-      } catch (error) {
-        reject(error);
-      }
+      const maxInitialRetries = 30; // Try for up to ~60s (2s intervals)
+      let attempt = 0;
+
+      const tryConnect = () => {
+        try {
+          this.socket = this.createWebSocket(url);
+          const clientId = this.generateClientId('ws_client');
+
+          // Set up consistent event handling
+          this.setupWebSocketEvents(this.socket, clientId);
+
+          // Add Promise resolution/rejection to the consistent event handlers
+          const handleOpen = (_event: JTAGWebSocketOpenEvent): void => {
+            this.socket!.removeEventListener('error', handleError);
+            resolve();
+          };
+
+          const handleError = (_event: JTAGWebSocketErrorEvent): void => {
+            this.socket!.removeEventListener('open', handleOpen);
+            attempt++;
+            if (attempt < maxInitialRetries) {
+              // Retry silently — server may still be starting up (Docker race).
+              // No error log, no reject, no page reload. Just wait and try again.
+              setTimeout(tryConnect, 2000);
+            } else {
+              reject(new Error(`WebSocket connection failed after ${attempt} attempts`));
+            }
+          };
+
+          // Add temporary listeners for Promise resolution
+          this.socket.addEventListener('open', handleOpen);
+          this.socket.addEventListener('error', handleError);
+
+        } catch (error) {
+          attempt++;
+          if (attempt < maxInitialRetries) {
+            setTimeout(tryConnect, 2000);
+          } else {
+            reject(error);
+          }
+        }
+      };
+
+      tryConnect();
     });
   }
 


### PR DESCRIPTION
## Summary
Comprehensive install fix branch — combines all fixes from the Docker e2e test on fresh M5 MacBook:

- **WS initial connect**: `connect()` now retries 30 times at 2s intervals (60s window) instead of rejecting on first failure. No error logs, no page reload loop. Fixes the white screen on first Docker boot.
- **WS reconnect**: `close` handler delegates to `attemptReconnect()` for persistent 10s polling (PR #865 fix included)
- **Healthcheck**: widget-server Dockerfile healthcheck interval 5s→30s (stops GET / spam)
- **Memory guard**: 80% system RAM instead of hardcoded 4GB (PR #866 fix included)
- **setup.sh**: config.env touch, auto-RAM config, grep pipe fix
- **docker-compose.yml**: TS_AUTHKEY fix
- **Persona seeder**: always seed Helper AI on 0 GPU/keys
- **chmod**: all scripts executable
- **install.sh**: port 9000→9003

## Test plan
- [x] Clean wipe e2e on fresh M5: rm -rf, clone, setup.sh → all containers healthy, 3 personas seeded
- [x] Widget-server serves on :9003, WS proxy connects after node-server ready
- [x] Browser loads without manual refresh (initial connect retry handles startup race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)