### PR TITLE
fix: mount model cache volume for persistent GGUF downloads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,11 @@ services:
       - voice-models:/app/models:ro
       - ~/.continuum/grid:/root/.continuum/grid:ro
       - ~/.continuum/config.env:/root/.continuum/config.env:ro
+      # Model cache: Rust core downloads GGUF models from HuggingFace on first
+      # inference. Without this mount, models download into ephemeral container
+      # storage and are lost on every restart. With it, models persist on the
+      # host at ~/.continuum/models/ and survive container rebuilds.
+      - ~/.continuum/models:/root/.continuum/models
     # GPU access for Bevy headless 3D rendering (avatar snapshots, live video).
     # Set DOCKER_GPU_RUNTIME=nvidia in .env to enable GPU passthrough.
     # Default: runc (CPU only — uses static avatar fallbacks).


### PR DESCRIPTION
Rust core downloads GGUFs into ephemeral container fs — lost on restart. Mount ~/.continuum/models into the container.