### PR TITLE
fix: mount entire ~/.continuum R/W into continuum-core

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,15 +66,12 @@ services:
       livekit-bridge:
         condition: service_healthy
     volumes:
-      - ipc-sockets:/root/.continuum/sockets
       - voice-models:/app/models:ro
-      - ~/.continuum/grid:/root/.continuum/grid:ro
-      - ~/.continuum/config.env:/root/.continuum/config.env:ro
-      # Model cache: Rust core downloads GGUF models from HuggingFace on first
-      # inference. Without this mount, models download into ephemeral container
-      # storage and are lost on every restart. With it, models persist on the
-      # host at ~/.continuum/models/ and survive container rebuilds.
-      - ~/.continuum/models:/root/.continuum/models
+      # Mount the ENTIRE ~/.continuum directory R/W. The Rust core reads config,
+      # writes model cache, logs, grid state, sockets, sessions — all under
+      # ~/.continuum. Cherry-picking subdirs with :ro caused silent failures
+      # whenever the core needed to write to a path that wasn't mounted.
+      - ~/.continuum:/root/.continuum
     # GPU access for Bevy headless 3D rendering (avatar snapshots, live video).
     # Set DOCKER_GPU_RUNTIME=nvidia in .env to enable GPU passthrough.
     # Default: runc (CPU only — uses static avatar fallbacks).


### PR DESCRIPTION
Replace cherry-picked :ro subdirs with one R/W mount. The Rust core writes to models, logs, sockets, sessions — the whole tree. Stop failing silently when a new write path gets added.