### PR TITLE
fix: temp model fallback to Qwen2.5-Coder-3B (qwen35 candle TODO)

### DIFF
--- a/src/workers/continuum-core/src/inference/quantized.rs
+++ b/src/workers/continuum-core/src/inference/quantized.rs
@@ -150,20 +150,23 @@ pub fn load_default_quantized(
 
     log.info(&format!("System RAM: {}GB — selecting best model", total_ram_gb));
 
-    // Model selection: our forged Qwen3.5 models
+    // Model selection: Qwen2.5-Coder-3B-Instruct (known working with candle).
+    // TODO(#163): Switch to continuum-ai/qwen3.5-4b-code-forged-GGUF once the
+    // Rust candle engine supports the qwen35 hybrid architecture (DeltaNet +
+    // full attention). The 3.5 GGUF exists on HF but candle can't load it yet.
     let (repo, filename, tokenizer_repo) = if total_ram_gb >= 32 {
-        log.info("Selected: qwen3.5-4b-code-forged Q8_0 (high quality, 32GB+ device)");
+        log.info("Selected: Qwen2.5-Coder-3B-Instruct Q8_0 (high quality, 32GB+ device)");
         (
-            "continuum-ai/qwen3.5-4b-code-forged-GGUF",
-            "qwen3.5-4b-code-forged-Q8_0.gguf",
-            "Qwen/Qwen3-4B",
+            "Qwen/Qwen2.5-Coder-3B-Instruct-GGUF",
+            "qwen2.5-coder-3b-instruct-q8_0.gguf",
+            "Qwen/Qwen2.5-Coder-3B-Instruct",
         )
     } else {
-        log.info("Selected: qwen3.5-4b-code-forged Q4_K_M (compact, universal)");
+        log.info("Selected: Qwen2.5-Coder-3B-Instruct Q4_K_M (compact, universal)");
         (
-            "continuum-ai/qwen3.5-4b-code-forged-GGUF",
-            "qwen3.5-4b-code-forged-Q4_K_M.gguf",
-            "Qwen/Qwen3-4B",
+            "Qwen/Qwen2.5-Coder-3B-Instruct-GGUF",
+            "qwen2.5-coder-3b-instruct-q4_k_m.gguf",
+            "Qwen/Qwen2.5-Coder-3B-Instruct",
         )
     };
 


### PR DESCRIPTION
Qwen3.5 GGUF can't load in candle (hybrid arch). Swap to Qwen2.5-Coder-3B so AIs work. #163 tracks the real fix.