### PR TITLE
fix: initial general tab broken — waitForClient too short

### DIFF
--- a/src/widgets/main/MainWidget.ts
+++ b/src/widgets/main/MainWidget.ts
@@ -192,10 +192,12 @@ export class MainWidget extends ReactiveWidget {
     // Wait for JTAG client to be connected before resolving routes.
     // On page reload, the WebSocket needs time to reconnect. Without this,
     // RoutingService.resolve() fails silently because Commands can't execute.
+    // Wait for JTAG client — must be long enough for Docker startup race.
+    // WS connect() retries for up to 60s, so this must wait at least that long.
     const waitForClient = async () => {
-      for (let i = 0; i < 50; i++) {
+      for (let i = 0; i < 300; i++) {
         if (jtagGlobal.jtag) return;
-        await new Promise(r => setTimeout(r, 100));
+        await new Promise(r => setTimeout(r, 200));
       }
     };
     setTimeout(async () => {


### PR DESCRIPTION
## Summary
The first General tab is always broken on Docker boot. User has to click rooms widget to get a working tab.

Root cause: `waitForClient()` in MainWidget only waited 5s (50×100ms) for WS connection, but the WS connect retry (PR #868) takes up to 60s during Docker startup. After 5s the tab gives up and renders with no data.

Fix: Wait 60s (300×200ms) to match the WS retry window.

## Test plan
- [ ] Docker: `docker compose up` → browser opens → general tab loads after WS connects (no manual room click needed)