### PR TITLE
fix: upsert user_states — personas crash silently on restart

### DIFF
--- a/src/system/user/server/PersonaUser.ts
+++ b/src/system/user/server/PersonaUser.ts
@@ -2069,12 +2069,30 @@ export class PersonaUser extends AIUser {
     const userState = this.getDefaultState(storedEntity.id);
     userState.preferences = getDefaultPreferencesForType('persona');
 
-    const storedState = await ORM.store<UserStateEntity>(
-      COLLECTIONS.USER_STATES,
-      userState,
-      false,
-      'default'
-    );
+    // Upsert: create if new, update if exists (persona restarts reuse state).
+    // ORM has no upsert — store fails on "already exists" if the persona ran
+    // before and ~/.continuum persists state across Docker restarts.
+    let storedState: UserStateEntity;
+    try {
+      storedState = await ORM.store<UserStateEntity>(
+        COLLECTIONS.USER_STATES,
+        userState,
+        false,
+        'default'
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('already exists')) {
+        storedState = await ORM.update<UserStateEntity>(
+          COLLECTIONS.USER_STATES,
+          userState.id,
+          userState,
+          'default'
+        );
+      } else {
+        throw err;
+      }
+    }
 
     // STEP 3: Room membership now handled by RoomMembershipDaemon via events
     // User creation → data:users:created event → RoomMembershipDaemon auto-joins user

--- a/src/system/user/shared/AgentUser.ts
+++ b/src/system/user/shared/AgentUser.ts
@@ -85,12 +85,19 @@ export class AgentUser extends AIUser {
     const userState = this.getDefaultState(storedEntity.id);
     userState.preferences = getDefaultPreferencesForType('agent');
 
-    const storedState = await ORM.store<UserStateEntity>(
-      COLLECTIONS.USER_STATES,
-      userState,
-      false,
-      'default'
-    );
+    let storedState: UserStateEntity;
+    try {
+      storedState = await ORM.store<UserStateEntity>(
+        COLLECTIONS.USER_STATES, userState, false, 'default'
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('already exists')) {
+        storedState = await ORM.update<UserStateEntity>(
+          COLLECTIONS.USER_STATES, userState.id, userState, 'default'
+        );
+      } else { throw err; }
+    }
 
     // STEP 3: Create AgentUser instance with SQLite storage (persistent)
     // Use SQLite on server, Memory in browser (though agents are typically server-only)

--- a/src/system/user/shared/HumanUser.ts
+++ b/src/system/user/shared/HumanUser.ts
@@ -101,12 +101,19 @@ export class HumanUser extends BaseUser {
     const userState = this.getDefaultState(storedEntity.id);
     userState.preferences = getDefaultPreferencesForType('human');
 
-    const storedState = await ORM.store<UserStateEntity>(
-      COLLECTIONS.USER_STATES,
-      userState,
-      false,
-      'default'
-    );
+    let storedState: UserStateEntity;
+    try {
+      storedState = await ORM.store<UserStateEntity>(
+        COLLECTIONS.USER_STATES, userState, false, 'default'
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('already exists')) {
+        storedState = await ORM.update<UserStateEntity>(
+          COLLECTIONS.USER_STATES, userState.id, userState, 'default'
+        );
+      } else { throw err; }
+    }
 
     // STEP 3: Room membership now handled by RoomMembershipDaemon via events
     // User creation → data:users:created event → RoomMembershipDaemon auto-joins user


### PR DESCRIPTION
store() throws on existing state from previous run, kills persona init before the autonomous loop starts. AIs never respond. Fix: store → upsert pattern.