### PR TITLE
fix(social/post): surface Moltbook 403 setup-required errors cleanly

### DIFF
--- a/src/commands/social/post/server/SocialPostServerCommand.ts
+++ b/src/commands/social/post/server/SocialPostServerCommand.ts
@@ -10,6 +10,7 @@ import type { ICommandDaemon } from '@daemons/command-daemon/shared/CommandBase'
 import { SocialPostBaseCommand } from '../shared/SocialPostCommand';
 import type { SocialPostParams, SocialPostResult } from '../shared/SocialPostTypes';
 import { loadSocialContext } from '@system/social/server/SocialCommandHelper';
+import { SocialActionRequiredError } from '@system/social/shared/ISocialMediaProvider';
 
 export class SocialPostServerCommand extends SocialPostBaseCommand {
 
@@ -35,7 +36,26 @@ export class SocialPostServerCommand extends SocialPostBaseCommand {
       });
     }
 
-    const post = await ctx.provider.createPost({ title, content, community, url });
+    let post;
+    try {
+      post = await ctx.provider.createPost({ title, content, community, url });
+    } catch (e) {
+      // Owner-setup / verification gates are user-resolvable, not crashes.
+      // Return a clean result with the action info so the CLI/UI can surface
+      // it without dumping raw JSON.
+      if (e instanceof SocialActionRequiredError) {
+        return transformPayload(params, {
+          success: false,
+          message: e.humanMessage,
+          actionRequired: {
+            humanMessage: e.humanMessage,
+            setupUrl: e.setupUrl,
+            apiAlternative: e.apiAlternative,
+          },
+        });
+      }
+      throw e;
+    }
 
     return transformPayload(params, {
       success: true,

--- a/src/commands/social/post/shared/SocialPostTypes.ts
+++ b/src/commands/social/post/shared/SocialPostTypes.ts
@@ -63,12 +63,30 @@ export const createSocialPostParams = (
 /**
  * Social Post Command Result
  */
+/**
+ * Structured "action required" info when a platform returns a user-
+ * resolvable setup/verification gate (e.g. Moltbook's 403 that asks the
+ * owner to complete the dashboard-connect flow). Populated instead of
+ * `error` so the CLI / UI can show an actionable next step.
+ */
+export interface SocialActionRequired {
+  /** Human-readable instruction (surfaced to the user verbatim). */
+  humanMessage: string;
+  /** Web flow URL the owner should visit to resolve the gate. */
+  setupUrl?: string;
+  /** Alternative API endpoint the caller can drive programmatically. */
+  apiAlternative?: string;
+}
+
 export interface SocialPostResult extends CommandResult {
   success: boolean;
   message: string;
 
   /** Created post details */
   post?: SocialPostData;
+
+  /** Populated when the platform needs owner setup — not a runtime failure. */
+  actionRequired?: SocialActionRequired;
 
   error?: JTAGError;
 }

--- a/src/system/social/server/providers/MoltbookProvider.ts
+++ b/src/system/social/server/providers/MoltbookProvider.ts
@@ -12,7 +12,7 @@
  * - 50 comments/hr
  */
 
-import type { ISocialMediaProvider } from '../../shared/ISocialMediaProvider';
+import { SocialActionRequiredError, type ISocialMediaProvider } from '../../shared/ISocialMediaProvider';
 import type {
   SignupParams,
   SignupResult,
@@ -446,6 +446,35 @@ export class MoltbookProvider implements ISocialMediaProvider {
 
     if (!response.ok && response.status !== 404) {
       const errorText = await response.text().catch(() => 'Unknown error');
+
+      // Detect Moltbook's structured "action required" shape — they return
+      // `human_message` + `setup_url` + (optional) `api_alternative` on 403s
+      // like the post-rebrand owner-dashboard gate. Surface those fields
+      // through a typed error so callers can show the action cleanly
+      // instead of dumping raw JSON into a user's face.
+      try {
+        const parsed = JSON.parse(errorText) as Record<string, unknown>;
+        const humanMessage = typeof parsed.human_message === 'string'
+          ? parsed.human_message
+          : undefined;
+        const setupUrl = typeof parsed.setup_url === 'string' ? parsed.setup_url : undefined;
+        const apiAlternative = typeof parsed.api_alternative === 'string'
+          ? parsed.api_alternative
+          : undefined;
+        if (humanMessage && (setupUrl || apiAlternative)) {
+          throw new SocialActionRequiredError({
+            platformId: this.platformId,
+            status: response.status,
+            humanMessage,
+            setupUrl,
+            apiAlternative,
+          });
+        }
+      } catch (e) {
+        // Re-throw SocialActionRequiredError; swallow JSON parse errors.
+        if (e instanceof SocialActionRequiredError) throw e;
+      }
+
       throw new Error(`Moltbook API error (${method} ${path}): ${response.status} ${errorText}`);
     }
 

--- a/src/system/social/shared/ISocialMediaProvider.ts
+++ b/src/system/social/shared/ISocialMediaProvider.ts
@@ -28,6 +28,39 @@ import type {
   RateLimitStatus,
 } from './SocialMediaTypes';
 
+/**
+ * Raised when a platform returns a user-resolvable setup/verification gate
+ * (e.g. Moltbook's "owner must connect dashboard / X account" 403). This is
+ * NOT a runtime failure — the caller should surface `humanMessage` + the
+ * action fields to the user rather than treating it like a crash.
+ *
+ * Providers SHOULD throw this (rather than a plain Error) whenever the
+ * platform response carries a structured "action required" shape.
+ */
+export class SocialActionRequiredError extends Error {
+  readonly humanMessage: string;
+  readonly setupUrl?: string;
+  readonly apiAlternative?: string;
+  readonly platformId: string;
+  readonly status: number;
+
+  constructor(args: {
+    platformId: string;
+    status: number;
+    humanMessage: string;
+    setupUrl?: string;
+    apiAlternative?: string;
+  }) {
+    super(args.humanMessage);
+    this.name = 'SocialActionRequiredError';
+    this.platformId = args.platformId;
+    this.status = args.status;
+    this.humanMessage = args.humanMessage;
+    this.setupUrl = args.setupUrl;
+    this.apiAlternative = args.apiAlternative;
+  }
+}
+
 export interface ISocialMediaProvider {
   /** Platform identifier (e.g., 'moltbook') */
   readonly platformId: string;


### PR DESCRIPTION
## Summary

Moltbook returns a structured JSON body on the post-rebrand owner-verification 403. Previously we stringified the whole response into the error message, dumping raw JSON at the user. Now the provider parses it and surfaces \`human_message\` / \`setup_url\` / \`api_alternative\` through a typed \`SocialActionRequiredError\` + structured \`actionRequired\` field on \`SocialPostResult\`.

Closes #889.

## Before → After

**Before:**
\`\`\`
Moltbook API error (POST /posts): 403 {"statusCode":403,"message":"...","setup_url":"...","human_message":"...","api_alternative":"..."}
\`\`\`

**After:**
\`\`\`json
{
  "success": false,
  "message": "Hi! Your AI agent on Moltbook needs you to set up dashboard access...",
  "actionRequired": {
    "humanMessage": "...",
    "setupUrl": "https://www.moltbook.com/help/connect-account",
    "apiAlternative": "POST /agents/me/setup-owner-email"
  }
}
\`\`\`

## Changes

- \`system/social/shared/ISocialMediaProvider.ts\` — new \`SocialActionRequiredError\` class (exported from shared so commands can \`instanceof\`-check it)
- \`system/social/server/providers/MoltbookProvider.ts\` — parse error body, throw typed error on structured shape, fall back to existing stringified Error otherwise
- \`commands/social/post/shared/SocialPostTypes.ts\` — new \`SocialActionRequired\` interface, added \`actionRequired?\` to \`SocialPostResult\`
- \`commands/social/post/server/SocialPostServerCommand.ts\` — catch typed error, return clean result instead of rethrowing

## Test plan

- [x] \`npm run build:ts\` — clean
- [ ] Smoke: \`./jtag social/post --platform=moltbook --title=X --content=Y\` on an install without completed dashboard setup returns structured \`actionRequired\` instead of stringified-JSON error
- [ ] Negative smoke: non-403 Moltbook errors still throw with current format (no regression on the existing failure path)

## Not in this PR

- \`social/connect-owner\` command to drive \`POST /agents/me/setup-owner-email\` programmatically — tracked as part of #888
- Applying the same pattern to other providers (if/when they grow structured action-required responses) — scope: one-provider-at-a-time, no speculative abstraction