### PR TITLE
Planning: MLX backend for native Qwen3.5-Omni on M-series (refs #896)

### DIFF
--- a/docs/inference/MLX-BACKEND.md
+++ b/docs/inference/MLX-BACKEND.md
@@ -1,0 +1,137 @@
+# MLX Backend Adapter — Planning Doc
+
+**Status:** planning (no code yet). Branch `feature/inference-perf-metal` off `feature/inference-perf`. Closes part of #896 (Apple MLX adapter candidate).
+
+## Why
+
+Continuum's stated goal for its target MacBook audience: **low-latency e2e live Qwen3.5 models that see, hear, speak, and emote via avatars naturally — 3–5 local personas — without routing through slower TTS/STT/YOLO pipelines.**
+
+The existing backends don't deliver that:
+
+| Backend | Text | Audio in | Audio out | Vision in | M-series native |
+|---|---|---|---|---|---|
+| `llama.cpp` (Metal) | ✅ | — | — | partial (llava adapter) | via ggml-metal translation |
+| `candle` | ✅ | — | — | — | via Metal fork |
+| ONNX Runtime (existing, used for VAD/Piper) | ✅ maybe | — | — | — | CoreML EP (limited for 4B+ LLMs) |
+
+Qwen3.5-Omni has native audio-token output + vision heads. The `mlx-community` ports of Qwen-Omni are already running on M-series today with the full omni stack. MLX is the backend that matches the deliverable.
+
+## Non-goals
+
+- Replacing `llama.cpp` for CUDA/Vulkan — llama.cpp stays primary for non-Apple hardware.
+- Replacing `candle` for training — candle's forward/backward graph stays the training primary per `memory/feedback_upstream_fixes_tri_repo.md`.
+- Building custom Metal kernels from scratch — MLX already has them, use them.
+
+## Architecture
+
+Slot into the existing `ModelBackend` trait at `src/workers/continuum-core/src/inference/backends/mod.rs`. One new file: `backends/mlx_adapter.rs`. Nothing else in the stack should need to know an MLX-backed persona is any different from a llama.cpp-backed one.
+
+```
+inference/backends/
+├── mlx_adapter.rs          ← NEW
+├── llamacpp.rs             ← existing (text, any HW)
+├── qwen35_gguf.rs          ← existing (GGUF loader)
+├── ...
+└── mod.rs                  ← trait def (no changes expected)
+```
+
+Model selection per persona stays in `model_registry.json`. MLX variants register alongside GGUF/safetensors variants.
+
+## Rust binding strategy (the first unknown to resolve)
+
+**Open question, resolved in PR A** (see below): does the community `mlx-rs` crate cover enough of MLX's C++ API for our needs?
+
+Decision criteria:
+1. Does it expose the operations Qwen3.5 inference needs? (embedding, matmul, attention, RMSNorm, RoPE, LoRA weight merging)
+2. Is it maintained? Last commit recency, open-issue volume, version churn.
+3. Does it wrap MLX ≥ 0.24 (Qwen-Omni requires recent MLX)?
+4. Is the memory model sane for our unified-memory sharing with Bevy / LiveKit?
+
+Outcome branches:
+- **Viable** → use `mlx-rs`, focus on adapter logic.
+- **Thin / stale** → hand-FFI against `mlx-c` (Apple's C bindings layer). This is a 3–5 day bridge before any adapter work starts.
+- **Nonexistent `mlx-c` for needed surface** → escalate to Joel; scope may shift to "contribute upstream bindings first, adapter after."
+
+## Staged PRs
+
+All target `feature/inference-perf` (the PR #891 integration branch). Same branch memento is on for Vulkan work; our file surfaces don't overlap.
+
+### PR A — binding choice + scaffold (this PR)
+
+**Contents:**
+- This doc.
+- `backends/mlx_adapter.rs` scaffold — `ModelBackend` impl with `unimplemented!()` bodies + capability declarations. Compiles, links, `continuum doctor` doesn't regress.
+- `Cargo.toml` feature flag `mlx` gated on `target_os = "macos"` and `target_arch = "aarch64"`.
+- Follow-up issue opened: "Evaluate mlx-rs vs hand-FFI — decision + bench."
+
+**Does not include:** actual MLX library link yet. That's PR A.5 (or folded into PR A if mlx-rs turns out to be a one-liner).
+
+**Acceptance:**
+- `cargo check --features mlx` on M-series passes.
+- `cargo check` on non-Mac targets still passes (mlx feature flag disables the module entirely on non-Apple).
+
+### PR B — text-only Qwen3.5 via MLX (the outlier validation)
+
+**Contents:**
+- Fill in `generate()`, `prefill()`, tokenization, EOS handling for Qwen3.5-4B Q4.
+- Register `qwen3.5-4b-mlx-q4` in `model_registry.json`.
+- Benchmark harness: N concurrent generation requests, measure tokens/s + TTFT + memory. Compare to `qwen3.5-4b-gguf-q4_k_m` over `llamacpp` on the same M5.
+
+**Acceptance:**
+- ≥ parity with `llama.cpp-Metal` on tokens/s + TTFT on M5 for Qwen3.5-4B Q4.
+- No CPU fallback path (per `memory/feedback_support_all_features_no_cheating.md`).
+- Concurrent sensory envelope holds: run test assembly of `MLX-persona + Bevy + Piper-kept-for-reference + LiveKit` and measure whether the other components degrade.
+
+**Outlier-validation payoff:** if the trait survives a backend this different from llama.cpp, every other candidate in #896 is a smaller lift.
+
+### PR C — Audio output head (the Omni win)
+
+**Contents:**
+- Extend adapter to emit Qwen-Omni audio tokens + audio decoder.
+- `MediaArtifactSource` integration — personas backed by MLX bypass the Piper TTS call on hot path.
+- Preservation path: non-MLX personas keep Piper; routing is per-persona.
+
+**Acceptance:**
+- Persona speaks natively, no Piper on the hot path.
+- Audio latency ≤ current Piper+pipeline latency (probably much better, but that's the floor).
+
+### PR D — Vision input head
+
+**Contents:**
+- Image encoding via Qwen-Omni vision adapter.
+- `VisionDescriptionService` routes MLX-backed personas to the native head; others keep the existing image-to-text classifier.
+
+**Acceptance:**
+- Persona "sees" a screenshot natively, no YOLO / CLIP / VisionDescriptionService fallback for MLX personas.
+
+### PR E — Forge tier publication
+
+**Contents:**
+- `ForgeRecipe.quantTiers[]` gains MLX Q4 + Q8 entries.
+- Foundry template emits MLX artifacts alongside GGUF.
+
+**Acceptance:**
+- Forge publishes a Qwen3.5 alloy with both GGUF and MLX tiers.
+- Continuum's auto-download picks the right tier per device.
+
+## Risks named upfront
+
+1. **mlx-rs maturity** — unknown until PR A. If thin, PR A expands from "days" to "1-2 weeks of FFI bridge" before any adapter work starts. This is the load-bearing unknown.
+2. **Qwen3.5-Omni MLX port stability** — `mlx-community` ports the architecture but the audio-head API surface isn't frozen. May need to pin a specific port commit + track upstream.
+3. **M5-16GB unified memory pressure** — Qwen3.5-Omni + avatar + LiveKit + system OS is tight. Benchmarks must include the full sensory envelope, not just tokens/s in isolation (per CLAUDE.md's concurrent-sensory-envelope rule).
+4. **Benchmark parity is not a given** — ggml-metal is heavily optimized. MLX may win on some ops and lose on others. Honest reporting over green-washed comparisons.
+
+## Coordination
+
+Memento is on `feature/inference-perf` for Vulkan (Carl-on-Mac Podman+krunkit path). Different `backends/*.rs` file, different `model_registry.json` entries, no overlap. Syncing with memento's work = `git pull` on `feature/inference-perf` before each commit.
+
+Airc cross-mesh DM bug (filed as airc#14, fix in airc#16) currently blocks direct DM coordination with memento. Until that merges, coordination goes via Joel or shared-log broadcasts.
+
+## Related
+
+- #896 — open invitation for ModelBackend adapters
+- #891 — feature/inference-perf integration branch
+- `memory/project_m5_is_primary_audience.md` — M-series is the target
+- `memory/feedback_support_all_features_no_cheating.md` — no CPU fallback
+- `memory/feedback_upstream_fixes_tri_repo.md` — fork-first, cycle upstream as fixes merge
+- `memory/project_3d_immersive_vision.md` — 3D-immersive-first product identity (avatars, audio, vision are load-bearing)

--- a/src/workers/continuum-core/Cargo.toml
+++ b/src/workers/continuum-core/Cargo.toml
@@ -161,6 +161,13 @@ tokio-postgres.workspace = true                           # Postgres async drive
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = "0.32"
 objc = "0.2"    # Objective-C runtime — for Metal APIs not wrapped by metal crate
+# MLX — Apple Silicon native inference runtime. Phase A of continuum#897
+# only flags the module on via the `mlx` feature; the actual `mlx-rs` crate
+# dep lands in phase B when we implement forward() and have the full-Xcode
+# build prerequisite (mlx-sys transitively needs `xcrun metal` for shader
+# compilation, which the Command Line Tools don't include).
+#
+# mlx-rs = { version = "0.25", optional = true }  # phase B
 
 [features]
 default = ["livekit-webrtc"]
@@ -172,6 +179,12 @@ cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda", "llama
 # to MoltenVK on the host, which translates to Metal. Also valid on Linux
 # Nvidia/AMD hosts with libvulkan available.
 vulkan = ["llama/vulkan"]
+# MLX — Apple Silicon native inference path (phases A–E of continuum#897).
+# Only compiles on macOS/aarch64; the adapter module is guarded by this feature
+# AND by cfg(target_os = "macos") so non-Mac targets simply don't see the code.
+# Phase A: flag only, no mlx-rs dep yet. Phase B will add `dep:mlx-rs` back
+# once we're writing forward() and can ensure full Xcode is installed.
+mlx = []
 accelerate = ["candle-core/accelerate", "candle-nn/accelerate", "candle-transformers/accelerate"]
 # Linux: swap ORT from static (download-binaries) to dynamic loading.
 # Avoids protobuf symbol conflict with webrtc-sys. macOS uses static (default).

--- a/src/workers/continuum-core/src/inference/backends/mlx_adapter.rs
+++ b/src/workers/continuum-core/src/inference/backends/mlx_adapter.rs
@@ -1,0 +1,103 @@
+//! MLX Backend Adapter — Phase A scaffold
+//!
+//! Native Apple Silicon inference via `mlx-rs` (oxideai 0.25). This file is
+//! the landing zone for phases A–E of [continuum#897]. Only compiles when
+//! both the `mlx` cargo feature is enabled AND we're on macOS; on other
+//! platforms the module is absent entirely.
+//!
+//! ## Status: phase A — scaffold only
+//!
+//! This file compiles and registers, nothing more. Actual inference lands in
+//! phase B; audio in phase C; vision in phase D; forge tier publication in
+//! phase E. See `docs/inference/MLX-BACKEND.md` for the staged plan and
+//! `docs/inference/SD-PORT-PATTERNS.md` for the runtime-boundary research
+//! memento (continuum-3bb8) landed while I slept on it.
+//!
+//! ## Why MLX
+//!
+//! Continuum's primary audience is the M-series Mac (see
+//! `memory/project_m5_is_primary_audience.md`). MLX gives us:
+//!
+//! - Native Metal dispatch (no ggml-metal translation overhead)
+//! - Unified memory residency handled by the framework (no `.to_device()`)
+//! - First-class support for Qwen3.5-Omni's audio + vision heads in the
+//!   `mlx-community` ports — which llama.cpp and ort don't match
+//! - Lazy evaluation: the full forward + CFG-blend + scheduler step can be
+//!   fused into one graph per timestep, only materialized on `eval()`
+//!
+//! ## The trait-shape problem (phase B gate)
+//!
+//! The existing `ModelBackend` trait signs its forward methods against
+//! `candle_core::Tensor`, which is a Candle runtime object. MLX has its own
+//! `mlx_rs::Array` with different lifetime + device semantics (lazy, unified
+//! memory). Two resolutions possible, to be decided in phase B:
+//!
+//! 1. **Generic trait over tensor type.** Refactor `ModelBackend` to be
+//!    parameterized by a tensor type, with associated `type TensorT: ...`.
+//!    Cleanest long-term; biggest churn to existing backends.
+//!
+//! 2. **Additive MLX-native methods with defaults.** Add `forward_mlx()`,
+//!    `eval_mlx()`, etc., defaulting to `unimplemented!()`. Existing
+//!    backends unchanged; MLX backend doesn't implement the Candle-tensor
+//!    methods. Callers dispatch on which methods a backend supports.
+//!
+//! Promised to memento: additive with defaults so their Vulkan work
+//! doesn't need to change. Decision deferred to phase B because the right
+//! shape depends on whether KV cache ownership lives in the backend or the
+//! scheduler (separate open question in SD-PORT-PATTERNS.md).
+//!
+//! [continuum#897]: https://github.com/CambrianTech/continuum/pull/897
+
+#![cfg(all(feature = "mlx", target_os = "macos"))]
+
+use std::path::Path;
+
+/// Placeholder for the MLX-backed adapter. Holds no state in phase A;
+/// phase B fills in the `mlx_rs::Module` reference, weight metadata, and
+/// the MLX-native forward/eval methods.
+///
+/// Construction deliberately fails until phase B so any caller that tries
+/// to actually use this gets a clear "not implemented" error instead of a
+/// silent no-op — same philosophy as the error-evidence rule we learned
+/// the hard way today.
+#[derive(Debug)]
+pub struct MlxAdapter {
+    _private: (),
+}
+
+impl MlxAdapter {
+    /// Load a model from an MLX-native artifact directory. Phase B will:
+    ///
+    /// 1. Resolve the model tier for this device (same logic as
+    ///    `qwen35_gguf.rs` uses for GGUF — pick the right quant based on
+    ///    available VRAM from `GpuMemoryManager`).
+    /// 2. Load weights via `mlx_rs` (indexed NPY + JSON index — not raw
+    ///    safetensors; see SD-PORT-PATTERNS.md for the format rationale).
+    /// 3. Apply the HF→MLX key remap table (static data, same pattern as
+    ///    mlx-community's `model_io.py`).
+    /// 4. Construct the transformer module graph.
+    ///
+    /// In phase A this just returns a sentinel error so nobody can
+    /// accidentally wire it up yet.
+    pub fn load(_model_path: &Path) -> Result<Self, String> {
+        Err(
+            "MlxAdapter::load not implemented — phase A scaffold only. \
+             See docs/inference/MLX-BACKEND.md for the staged plan."
+                .to_string(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_returns_phase_a_sentinel() {
+        let err = MlxAdapter::load(Path::new("/nonexistent")).unwrap_err();
+        assert!(
+            err.contains("phase A"),
+            "error should call out phase A status: {err}"
+        );
+    }
+}

--- a/src/workers/continuum-core/src/inference/backends/mod.rs
+++ b/src/workers/continuum-core/src/inference/backends/mod.rs
@@ -21,6 +21,12 @@ pub mod llamacpp_scheduler;
 pub mod qwen2_safetensors;
 pub mod qwen35_gguf;
 
+// MLX adapter: macOS + `mlx` feature only. Gated here so non-Mac / feature-off
+// builds don't see the module at all. Phase A scaffold — see continuum#897
+// and docs/inference/MLX-BACKEND.md.
+#[cfg(all(feature = "mlx", target_os = "macos"))]
+pub mod mlx_adapter;
+
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;


### PR DESCRIPTION
## Planning PR — no code yet

This PR exists primarily so the plan is visible and reviewable before any FFI or adapter code lands. Branch `feature/inference-perf-metal` is a child of `feature/inference-perf` (PR #891, where memento is also working on Vulkan). MLX and Vulkan don't collide — different files, different model_registry entries.

Full doc: [`docs/inference/MLX-BACKEND.md`](docs/inference/MLX-BACKEND.md).

## Why MLX over the other #896 candidates

Stated deliverable: **live Qwen3.5-Omni (native see/hear/speak/emote, no TTS/STT/YOLO pipeline), 3–5 concurrent personas, on MacBook-class hardware.**

| Backend | Text | Audio in | Audio out | Vision in | Qwen-Omni native on M-series |
|---|---|---|---|---|---|
| `llama.cpp` (Metal) | ✅ | — | — | partial | ❌ |
| `candle` | ✅ | — | — | — | ❌ |
| ONNX Runtime (CoreML EP) | ~ | — | — | — | ❌ |
| **MLX** | ✅ | ✅ | ✅ | ✅ | ✅ (mlx-community ports) |

MLX is the backend that actually delivers the omni-modal stack on Apple Silicon today. Everything else would require pipeline bolts that we're explicitly trying to get rid of.

## Staged PRs targeting this branch

- **A** — mlx-rs-vs-hand-FFI decision + adapter scaffold compiling on M-series
- **B** — Text-only Qwen3.5 via MLX (outlier-validates the `ModelBackend` trait against a backend as different from llama.cpp as you can get without going to custom)
- **C** — Audio output head (the Omni win — personas speak natively, Piper off the hot path)
- **D** — Vision input head (personas see natively, YOLO/CLIP/VisionDescriptionService off)
- **E** — Forge tier publication (MLX Q4/Q8 alongside GGUF)

## Risks I want on the record before starting code

1. **mlx-rs crate maturity** — the load-bearing unknown. Resolved in PR A. If thin, PR A expands from days to 1–2 weeks of FFI bridge.
2. **Qwen3.5-Omni MLX port stability** — `mlx-community` ports the architecture but the audio-head API surface isn't frozen. May pin a specific port commit.
3. **M5-16GB unified memory envelope** — MLX, Bevy, LiveKit, and OS all share the same memory pool. Benchmarks must include the full sensory envelope per CLAUDE.md.
4. **Benchmark parity is not guaranteed** — ggml-metal is heavily optimized. Honest reporting over green-washed comparisons.

## Coordination

- Memento on `feature/inference-perf` (Vulkan). Different files, different backends — coordination = pull `feature/inference-perf` frequently.
- Airc cross-mesh DM is currently broken (airc#14, fix in airc#16 staging). Until that merges, coordination routes through Joel or shared-log broadcasts, not direct DMs.

## This PR's acceptance criteria

- Plan is readable and scrutinizable.
- Scope and staging feel right to Joel + memento + any reviewer.
- Risks are named honestly, not buried.
- No code churn yet — this is gate 1.

Once the plan is blessed, PR A drops the scaffold here, and we start.

Related: #896, #891