### PR TITLE
install: kill 3 sudo traps that broke npm start + curl|bash on Mac

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -185,22 +185,25 @@ PYEOF
   3. Re-run this install script
 "
     fi
-    # CLI-plugins directory — Model Runner installs its backend plugins here.
-    # One-time sudo mkdir; ensure_sudo_warmed gives us a single-prompt warmup
-    # that all remaining install steps reuse.
-    if [ ! -d /usr/local/cli-plugins ]; then
-      info "Creating /usr/local/cli-plugins for Docker Model Runner (one-time sudo)…"
-      ensure_sudo_warmed
-      sudo mkdir -p /usr/local/cli-plugins
-    fi
-    # Install the vllm-metal backend if not present. This downloads and
-    # registers the host-native vllm binary that Docker Desktop orchestrates.
-    # `docker model status` output lists each registered backend in a BACKEND
-    # column with a STATUS column next to it. `list-runners` was the wrong
-    # subcommand name (caught during M5 validation 2026-04-16).
+    # Verify the vllm runner is registered. On Docker DESKTOP (Mac), the
+    # runners are bundled — Docker Desktop installs them automatically when
+    # Model Runner is enabled. There's no /usr/local/cli-plugins step
+    # (that's the Docker ENGINE / Linux path; `docker model install-runner
+    # --help` says "Docker Engine only"). The earlier mkdir + install-runner
+    # block was misapplied Linux logic on Mac, and forced a sudo prompt
+    # for a directory Docker Desktop never reads from. Caught when CONTINUUM_
+    # DEPS_ONLY=1 from parallel-start.sh tripped the prompt non-interactively
+    # on every `npm start` (2026-04-16).
+    #
+    # If vllm shows "Not Installed", the user needs to enable it in Docker
+    # Desktop → Settings → Beta features → Model Runner → install backends.
+    # No CLI command can do this on Desktop, so we point at the GUI.
     if ! docker model status 2>/dev/null | awk '/^vllm[[:space:]]+Running/{found=1} END{exit !found}'; then
-      info "Installing vllm-metal runner (native Metal LLM inference on host)…"
-      docker model install-runner --backend vllm
+      warn "vllm-metal backend not registered with Docker Model Runner.
+  Open Docker Desktop → Settings → Features in development → Model Runner
+  → ensure 'Enable Docker Model Runner' is on → install the vllm backend.
+  Continuum will fall back to llama.cpp until vllm is enabled (~5x slower
+  on M-series for some models)."
     fi
     # Enable Model Runner's host-side TCP endpoint on port 12434. Without this,
     # continuum-core (running natively on the Mac host) can't reach the OpenAI-

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -428,25 +428,39 @@ install_postgres() {
     echo -e "  ${GREEN}✅ PostgreSQL installed${NC}"
   fi
 
-  # Set trust auth for local connections (no password needed for development).
-  # Sudo cache already warmed above (or already root); these calls are silent.
-  ensure_sudo_warmed
-  local pg_hba=$(sudo -u postgres psql -t -c "SHOW hba_file" 2>/dev/null | tr -d ' ')
-  if [ -n "$pg_hba" ] && [ -f "$pg_hba" ]; then
-    if grep -q "scram-sha-256" "$pg_hba" 2>/dev/null; then
-      sudo sed -i 's/scram-sha-256/trust/g' "$pg_hba"
-      sudo service postgresql restart 2>/dev/null || sudo pg_ctlcluster 16 main restart 2>/dev/null || true
-    fi
-  fi
-
-  # Create user and database if they don't exist
-  local pg_user="${USER:-postgres}"
-  if ! sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='$pg_user'" 2>/dev/null | grep -q 1; then
-    sudo -u postgres createuser -s "$pg_user" 2>/dev/null || true
-  fi
-  if ! psql -lqt 2>/dev/null | cut -d \| -f 1 | grep -qw continuum; then
-    createdb continuum 2>/dev/null || sudo -u postgres createdb continuum 2>/dev/null || true
-  fi
+  # Trust-auth + createuser logic is Linux-only. On macOS, Homebrew postgres
+  # accepts local connections without auth by default and runs as the
+  # invoking user — `createdb continuum` works directly with no sudo. The
+  # earlier unconditional `ensure_sudo_warmed` here was the failure mode
+  # that broke `npm start` when stdin wasn't a TTY (parallel-start.sh
+  # invokes this with CONTINUUM_DEPS_ONLY=1 every restart).
+  case "$PLATFORM" in
+    macos)
+      # Homebrew postgres: peer auth, user is whoever started brew services.
+      # Just ensure the continuum database exists.
+      if ! psql -lqt 2>/dev/null | cut -d \| -f 1 | grep -qw continuum; then
+        createdb continuum 2>/dev/null || true
+      fi
+      ;;
+    linux|wsl)
+      # apt-installed postgres needs trust-auth + role setup, all sudo.
+      ensure_sudo_warmed
+      local pg_hba=$(sudo -u postgres psql -t -c "SHOW hba_file" 2>/dev/null | tr -d ' ')
+      if [ -n "$pg_hba" ] && [ -f "$pg_hba" ]; then
+        if grep -q "scram-sha-256" "$pg_hba" 2>/dev/null; then
+          sudo sed -i 's/scram-sha-256/trust/g' "$pg_hba"
+          sudo service postgresql restart 2>/dev/null || sudo pg_ctlcluster 16 main restart 2>/dev/null || true
+        fi
+      fi
+      local pg_user="${USER:-postgres}"
+      if ! sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='$pg_user'" 2>/dev/null | grep -q 1; then
+        sudo -u postgres createuser -s "$pg_user" 2>/dev/null || true
+      fi
+      if ! psql -lqt 2>/dev/null | cut -d \| -f 1 | grep -qw continuum; then
+        createdb continuum 2>/dev/null || sudo -u postgres createdb continuum 2>/dev/null || true
+      fi
+      ;;
+  esac
   echo -e "  ${GREEN}✅ Database 'continuum' ready${NC}"
 }
 

--- a/src/scripts/lib/install-common.sh
+++ b/src/scripts/lib/install-common.sh
@@ -78,13 +78,30 @@ ensure_sudo_warmed() {
   sudo -n true 2>/dev/null && return 0
   # Warmed earlier in this same run?
   [ "${_SUDO_WARMED:-0}" = "1" ] && return 0
-  # No terminal — we cannot prompt. Fail loud with a specific fix.
-  if [ ! -t 0 ]; then
-    die "Install needs sudo but stdin is not a terminal. Re-run in an interactive shell, or use the docker-compose path which needs no sudo."
+
+  # Caller signalled this is a non-fatal probe (e.g. parallel-start.sh
+  # re-running install.sh with CONTINUUM_DEPS_ONLY=1) — return non-zero
+  # and let the caller decide whether to skip-and-warn or fail loud.
+  if [ "${CONTINUUM_NONFAIL_SUDO:-0}" = "1" ]; then
+    return 1
+  fi
+
+  # Stdin not a TTY (curl | bash pattern, or background-launched scripts).
+  # Try /dev/tty as a fallback — many shells preserve a controlling
+  # terminal even when stdin is piped. This is what makes
+  #   curl ... install.sh | bash
+  # actually work for sudo prompts.
+  local sudo_in
+  if [ -t 0 ]; then
+    sudo_in=""           # stdin already a TTY — pass-through
+  elif [ -r /dev/tty ] && [ -w /dev/tty ]; then
+    sudo_in="< /dev/tty" # piped stdin but controlling TTY exists — recover
+  else
+    die "Install needs sudo but no TTY is available (stdin not a terminal and /dev/tty unreadable). Re-run from an interactive shell, or set CONTINUUM_NONFAIL_SUDO=1 to make sudo failures non-fatal."
   fi
 
   info "Admin access needed — prompting once now; no further password prompts this run."
-  if ! sudo -v; then
+  if ! eval "sudo -v $sudo_in"; then
     die "sudo authentication failed. Re-run after fixing your password or sudoers."
   fi
 


### PR DESCRIPTION
## Summary

Three orthogonal fixes for the **Carl** (public `curl | bash`) and **Dev** (`parallel-start.sh` deps-only re-check) install paths. Discovered when M5 × native cell of the e2e matrix tripped at `Install needs sudo but stdin is not a terminal` on first `npm start` after `docker compose down`.

### 1. `install.sh` — drop `/usr/local/cli-plugins` mkdir on Mac

`docker model install-runner --backend vllm` is "Docker Engine only" per its own `--help`. Docker Desktop on Mac bundles the runners automatically (verified: `vllm-metal` shows `Running` in `docker model status` without any cli-plugins dir). The mkdir + install-runner block was Linux logic misapplied on Mac, forcing a sudo prompt for a directory Docker Desktop never reads from.

### 2. `src/scripts/install.sh` — split `install_postgres` by platform

The trust-auth + createuser logic ran `ensure_sudo_warmed` unconditionally, then `sudo sed -i` / `sudo -u postgres` — all apt-postgres-only. On Mac with Homebrew postgres, `createdb continuum` works directly with no sudo. **This** was the actual line that died on `npm start` deps-only at step `[6/8] PostgreSQL`.

### 3. `src/scripts/lib/install-common.sh` — better `ensure_sudo_warmed`

- **`/dev/tty` fallback**: when stdin isn't a TTY (`curl | bash`) but a controlling terminal exists, route sudo prompt through `/dev/tty`. Public one-liner installer was previously broken for any sudo step.
- **`CONTINUUM_NONFAIL_SUDO=1` escape hatch**: callers (parallel-start.sh, future CI / codespaces / devcontainer integrations) opt into "warn-and-skip" semantics — `ensure_sudo_warmed` returns 1 instead of die'ing. Sets up the extensibility Joel asked for: adding a new install persona is one env var + a check, not a fork of the function.

## Verified on M5

- [x] `CONTINUUM_DEPS_ONLY=1 bash src/scripts/install.sh` → 8/8 steps green, no sudo prompt
- [x] `npm start` → orchestrator + workers up
- [x] chat send → Local Assistant + CodeReview AI both reply (30-32s via DMR/Metal)
- [x] M5 × native cell of test matrix now GREEN

## Coordination

Memento takes the WSL2/Linux mirror — same `/dev/tty` + `NONFAIL_SUDO` patterns apply universally; the apt postgres path stays as-is since it legitimately needs sudo. Bare-Windows (non-WSL2) install remains a flagged hardware gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)