### PR TITLE
orm(phase2-step4): seed QW#1 cache at ensure_schema time — zero runtime data-shape inference

### DIFF
--- a/src/workers/continuum-core/src/orm/postgres.rs
+++ b/src/workers/continuum-core/src/orm/postgres.rs
@@ -1355,6 +1355,29 @@ impl StorageAdapter for PostgresAdapter {
             }
         }
 
+        // Phase 2 Step 4: seed the ensured_columns_cache (m5's QW#1) with
+        // the DECLARED column set from the schema. Subsequent writes skip
+        // the ensure_table_exists_cached probe entirely — zero runtime
+        // data-shape inference on the hot write path. Previously the cache
+        // was populated lazily on first write and grew column-by-column;
+        // now it starts authoritative.
+        //
+        // Bare-table name matches what ensure_table_exists_cached uses as
+        // the cache key (the unqualified collection → snake_case conversion).
+        let bare_table = naming::to_table_name(&schema.collection);
+        let mut cols = HashSet::new();
+        cols.insert("id".to_string());
+        cols.insert("created_at".to_string());
+        cols.insert("updated_at".to_string());
+        cols.insert("version".to_string());
+        for field in &schema.fields {
+            cols.insert(naming::to_snake_case(&field.name));
+        }
+        {
+            let mut cache = self.ensured_columns_cache.write().await;
+            cache.insert(bare_table, cols);
+        }
+
         StorageResult::ok(true)
     }
 

--- a/src/workers/continuum-core/src/orm/postgres.rs
+++ b/src/workers/continuum-core/src/orm/postgres.rs
@@ -1362,20 +1362,26 @@ impl StorageAdapter for PostgresAdapter {
         // was populated lazily on first write and grew column-by-column;
         // now it starts authoritative.
         //
+        // Merge semantics (per m5-test review of PR #904): extend, don't
+        // replace. If ensure_table_exists_cached populated the entry first
+        // (theoretical ordering window — ensure_schema typically runs before
+        // any write, but nothing enforces that), we union our declared set
+        // into what's already known rather than dropping it. Matches the
+        // `or_insert_with + insert` pattern at ensure_table_exists_cached.
+        //
         // Bare-table name matches what ensure_table_exists_cached uses as
         // the cache key (the unqualified collection → snake_case conversion).
         let bare_table = naming::to_table_name(&schema.collection);
-        let mut cols = HashSet::new();
-        cols.insert("id".to_string());
-        cols.insert("created_at".to_string());
-        cols.insert("updated_at".to_string());
-        cols.insert("version".to_string());
-        for field in &schema.fields {
-            cols.insert(naming::to_snake_case(&field.name));
-        }
         {
             let mut cache = self.ensured_columns_cache.write().await;
-            cache.insert(bare_table, cols);
+            let entry = cache.entry(bare_table).or_insert_with(HashSet::new);
+            entry.insert("id".to_string());
+            entry.insert("created_at".to_string());
+            entry.insert("updated_at".to_string());
+            entry.insert("version".to_string());
+            for field in &schema.fields {
+                entry.insert(naming::to_snake_case(&field.name));
+            }
         }
 
         StorageResult::ok(true)


### PR DESCRIPTION
## Summary

Phase 2 Step 4 of the ORM refactor per docs/architecture/ORM-PHASE-2-DESIGN.md.

Builds on m5-test's QW#1 (ensured_columns_cache, 30a36d3c7). At the end of
`PostgresAdapter::ensure_schema`, pre-populate the cache with the DECLARED
column set from `CollectionSchema.fields` — which Phase 2 Step 3 already
derives from `entity_schemas.json` via `resolve()` + `to_collection_schema`.

Net effect: after a schema ensure, subsequent writes hit the cache happy
path every time. Zero runtime data-shape inference, zero
`information_schema` probes, zero ALTER existence checks on hot writes.

## Why this is small but load-bearing

The schema-ensure path is exactly where the matrix gate is most sensitive:
- Seed writes during startup (`seed-in-process.ts`)
- Persona init writes during persona-ready
- First-time deployment writes

Before Step 4, the cache was populated lazily on first write. Subsequent
writes got the fast path, but the first one still paid the probe cost.
After Step 4, the cache is authoritative from ensure_schema onward.

## What's touched

- Single file: `src/workers/continuum-core/src/orm/postgres.rs`
- Single function: `PostgresAdapter::ensure_schema`, post-index-creation
- ~15 lines inside a scoped `{}` so the write-lock drops fast
- Zero changes to `ensure_table_exists_cached`, `ensure_table_exists_pg`,
  or any other QW#1 invariant. Cache shape unchanged.

## Review asks for m5-test

- [ ] Cache key (`bare_table` from `naming::to_table_name(&schema.collection)`)
      matches the key used in `ensure_table_exists_cached`
- [ ] Pre-populated column set includes the 4 metadata cols (id,
      created_at, updated_at, version) — same set your QW#1 seeds on
      first-miss population
- [ ] No concurrency concern with a concurrent writer hitting
      ensure_table_exists_cached while ensure_schema is in-flight: both
      paths take write-lock on the same HashMap; whichever wins races the
      other's update, net result is the superset union of columns either
      sees. Safe.

## Test plan

- [x] `cargo check --lib` green
- [ ] `cargo test --lib modules::data` green (data tests don't hit postgres
      but the change is orthogonal — sqlite path unchanged)
- [ ] Manual postgres integration: `npm run build:ts` + `DATABASE_URL=
      postgres://...@localhost:5432/continuum npm start` → seed-in-process
      should write without touching `information_schema`

## Phase 2 status after this merges

- ✓ Step 1 (8b2d31758): codegen + entity_schemas.json artifact
- ✓ Step 2 (6ad84bf63): Rust loader + SHA drift check
- ✓ Step 3 (1eb3674dc): ensure_schema pivots through resolve()
- ✓ Step 4 (THIS): postgres column-cache seeded from declared schema