### PR TITLE
gpu-always: DMR Metal routing, no silent CPU fallback, device-based adapter selection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -259,6 +259,37 @@ PYEOF
     ;;
 esac
 
+# ── GPU detection + persona model pull (shared by Carl + Dev) ──────
+# Uses the centralized ic_detect_hardware / ic_decide_gpu_path from
+# install-common.sh so both install.sh paths use the SAME detection.
+# After this block: IC_GPU_PATH tells us which inference backend to
+# verify, and the default persona model is pulled into DMR (if DMR path).
+if type ic_detect_hardware &>/dev/null; then
+  ic_detect_hardware
+  ic_decide_gpu_path
+  ic_describe_hardware
+
+  # Pull default persona model into DMR so Carl's first chat is instant.
+  # Only for DMR paths — Vulkan path loads models differently (local GGUF).
+  PERSONA_MODEL="hf.co/continuum-ai/qwen3.5-4b-code-forged-GGUF"
+  case "$IC_GPU_PATH" in
+    dmr-*)
+      if ! docker model ls 2>/dev/null | grep -q "qwen3.5-4b-code-forged"; then
+        info "Pulling default persona model into Docker Model Runner (~2.7GB, first install only)..."
+        docker model pull "$PERSONA_MODEL" || warn "Model pull failed — chat will error until model is available. Retry: docker model pull $PERSONA_MODEL"
+      else
+        ok "Persona model already in DMR: $PERSONA_MODEL"
+      fi
+      ;;
+    llama-vulkan)
+      ok "Vulkan GPU path — model download handled by continuum-core at first inference"
+      ;;
+    unsupported)
+      warn "No supported GPU detected. Local chat will error until a GPU adapter is available."
+      ;;
+  esac
+fi
+
 # ── Per-service memory caps — auto-calculated from host RAM ────────
 # Joel's directive: don't ask users to set mem limits; auto-calc from host.
 # Don't paper over OOMs with undersized limits; size containers for the

--- a/src/daemons/ai-provider-daemon/server/AIProviderRustClient.ts
+++ b/src/daemons/ai-provider-daemon/server/AIProviderRustClient.ts
@@ -81,6 +81,9 @@ export class AIProviderRustClient {
   private nextRequestId = 1;
   private connected = false;
   private connecting = false;
+  private wasConnected = false;
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   private constructor() {}
 
@@ -121,7 +124,9 @@ export class AIProviderRustClient {
 
       this.socket.on('connect', () => {
         this.connected = true;
+        this.wasConnected = true;
         this.connecting = false;
+        this.reconnectAttempts = 0;
         resolve();
       });
 
@@ -131,13 +136,26 @@ export class AIProviderRustClient {
 
       this.socket.on('error', (err) => {
         this.connecting = false;
-        reject(err);
+        if (!this.wasConnected) {
+          reject(err);
+        }
       });
 
       this.socket.on('close', () => {
         this.connected = false;
         this.connecting = false;
         this.socket = null;
+        // CRITICAL: reject all in-flight requests so callers fail fast.
+        // Without this, aiGenerate callers hung forever when native core
+        // restarted — the root cause of the persona-subs-die-on-restart bug.
+        const err = new Error('AIProvider IPC socket closed — continuum-core restarted');
+        for (const callback of this.pendingRequests.values()) {
+          callback({ success: false, error: err.message });
+        }
+        this.pendingRequests.clear();
+        if (this.wasConnected) {
+          this.scheduleReconnect();
+        }
       });
 
       setTimeout(() => {
@@ -147,6 +165,26 @@ export class AIProviderRustClient {
         }
       }, 5000);
     });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return;
+    const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 15000);
+    console.log(`[AIProviderRustClient] Reconnecting to continuum-core in ${delay}ms (attempt ${this.reconnectAttempts + 1})`);
+    this.reconnectTimer = setTimeout(async () => {
+      this.reconnectTimer = null;
+      try {
+        await this.ensureConnected();
+        console.log('[AIProviderRustClient] Reconnected to continuum-core');
+      } catch {
+        this.reconnectAttempts++;
+        if (this.reconnectAttempts < 20) {
+          this.scheduleReconnect();
+        } else {
+          console.error('[AIProviderRustClient] Gave up reconnecting after 20 attempts');
+        }
+      }
+    }, delay);
   }
 
   /**

--- a/src/scripts/lib/install-common.sh
+++ b/src/scripts/lib/install-common.sh
@@ -331,3 +331,165 @@ mod_docker_check() {
   fi
   module_skip "docker" "$(docker version --format '{{.Server.Version}}' 2>/dev/null) reachable"
 }
+
+# ============================================================================
+# Hardware detection + GPU/inference runtime decision (shared by Carl + Dev)
+# ============================================================================
+#
+# Both install entry points (public `install.sh` curl-target, and
+# `src/scripts/install.sh` Dev/parallel-start target) call these functions
+# so detection lives in ONE place. Yesterday's session surfaced a pattern:
+# the same detection duplicated across both install scripts drifted out
+# of sync. Centralizing here kills that drift.
+#
+# What "detection" produces (globals, no subshell needed by callers):
+#   IC_PLATFORM   : macos | linux | wsl
+#   IC_ARCH       : arm64 | x86_64 | other
+#   IC_RAM_GB     : integer
+#   IC_RAM_MIB    : integer (computed once, used for Docker VM sizing)
+#   IC_GPU_KIND   : metal | cuda | vulkan | rocm | none
+#   IC_GPU_NAME   : human-readable (e.g. "Apple Silicon", "NVIDIA RTX 5090")
+#   IC_VRAM_GB    : integer (0 if unknown or unified-memory device)
+#
+# What "decision" produces:
+#   IC_GPU_PATH   : dmr-metal | dmr-cuda | dmr-rocm | llama-vulkan | unsupported
+#   IC_DMR_BACKEND   : vllm | llama.cpp | "" (when not DMR-path)
+#   IC_DMR_GPU_FLAG  : cuda | rocm | "" (Mac's vllm-metal needs no flag)
+#   IC_MODEL_TIER    : 4b   (universal default; higher tiers later)
+#
+# CPU path is INTENTIONALLY UNSUPPORTED here. Continuum's contract is
+# GPU-always for chat (Metal on Mac, Vulkan/CUDA/ROCm elsewhere). When
+# a future CPU adapter lands it will be its own IC_GPU_PATH value,
+# gated on `CONTINUUM_ALLOW_CPU_INFERENCE=1`, and explicit in logs.
+
+ic_detect_hardware() {
+  # Platform
+  case "$(uname -s)" in
+    Darwin) IC_PLATFORM="macos" ;;
+    Linux)
+      if grep -qi microsoft /proc/version 2>/dev/null; then
+        IC_PLATFORM="wsl"
+      else
+        IC_PLATFORM="linux"
+      fi
+      ;;
+    *) IC_PLATFORM="unknown" ;;
+  esac
+  IC_ARCH="$(uname -m)"
+
+  # RAM
+  case "$IC_PLATFORM" in
+    macos)
+      IC_RAM_MIB=$(( $(sysctl -n hw.memsize) / 1048576 ))
+      ;;
+    linux|wsl)
+      IC_RAM_MIB=$(awk '/^MemTotal:/ {printf "%d", $2/1024}' /proc/meminfo)
+      ;;
+    *)
+      IC_RAM_MIB=0
+      ;;
+  esac
+  IC_RAM_GB=$(( IC_RAM_MIB / 1024 ))
+
+  # GPU
+  IC_GPU_KIND="none"
+  IC_GPU_NAME=""
+  IC_VRAM_GB=0
+
+  case "$IC_PLATFORM" in
+    macos)
+      if sysctl -n machdep.cpu.brand_string 2>/dev/null | grep -qi apple; then
+        IC_GPU_KIND="metal"
+        IC_GPU_NAME="Apple Silicon"
+        IC_VRAM_GB="$IC_RAM_GB"   # Apple unified memory — GPU shares with CPU
+      fi
+      ;;
+    linux|wsl)
+      # nvidia-smi — easiest signal. Works on Linux + WSL2 when CUDA drivers installed.
+      local smi=""
+      if command -v nvidia-smi &>/dev/null; then
+        smi="nvidia-smi"
+      elif [ -f /usr/lib/wsl/lib/nvidia-smi ]; then
+        smi="/usr/lib/wsl/lib/nvidia-smi"
+      fi
+      if [ -n "$smi" ] && "$smi" --query-gpu=name --format=csv,noheader >/dev/null 2>&1; then
+        IC_GPU_KIND="cuda"
+        IC_GPU_NAME="$("$smi" --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)"
+        local vram_mib="$("$smi" --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | head -1)"
+        IC_VRAM_GB=$(( vram_mib / 1024 ))
+      elif command -v rocminfo &>/dev/null && rocminfo >/dev/null 2>&1; then
+        IC_GPU_KIND="rocm"
+        IC_GPU_NAME="$(rocminfo 2>/dev/null | awk '/Marketing Name:/{sub(/.*Name:[[:space:]]*/,"");print;exit}')"
+        # rocm-smi VRAM parsing — best-effort, not all AMD stacks report uniformly
+        if command -v rocm-smi &>/dev/null; then
+          local vram_bytes="$(rocm-smi --showmeminfo vram 2>/dev/null | awk '/vram.*Total.*Memory/{for(i=1;i<=NF;i++)if($i~/^[0-9]+$/){print $i;exit}}')"
+          IC_VRAM_GB=$(( ${vram_bytes:-0} / 1073741824 ))
+        fi
+      elif command -v vulkaninfo &>/dev/null && vulkaninfo --summary 2>/dev/null | grep -q deviceName; then
+        # Vulkan-only case: GPU exists, no CUDA/ROCm drivers. Common on Intel
+        # Arc / older AMD / mixed hardware. Use our vendored llama.cpp with
+        # --features=vulkan (shipped natively, not through DMR which doesn't
+        # expose a Vulkan flag).
+        IC_GPU_KIND="vulkan"
+        IC_GPU_NAME="$(vulkaninfo --summary 2>/dev/null | awk -F= '/deviceName/{gsub(/^[[:space:]]*/,"",$2);print $2;exit}')"
+        # Vulkan VRAM query is nontrivial; leave IC_VRAM_GB=0 for now.
+      fi
+      ;;
+  esac
+}
+
+ic_decide_gpu_path() {
+  # Requires ic_detect_hardware to have run.
+  case "$IC_PLATFORM:$IC_GPU_KIND" in
+    macos:metal)
+      IC_GPU_PATH="dmr-metal"
+      IC_DMR_BACKEND="vllm"     # Docker Desktop bundles vllm-metal
+      IC_DMR_GPU_FLAG=""         # --gpu not applicable on Desktop
+      ;;
+    linux:cuda|wsl:cuda)
+      IC_GPU_PATH="dmr-cuda"
+      IC_DMR_BACKEND="llama.cpp"
+      IC_DMR_GPU_FLAG="cuda"
+      ;;
+    linux:rocm)
+      IC_GPU_PATH="dmr-rocm"
+      IC_DMR_BACKEND="llama.cpp"
+      IC_DMR_GPU_FLAG="rocm"
+      ;;
+    linux:vulkan|wsl:vulkan)
+      IC_GPU_PATH="llama-vulkan"
+      IC_DMR_BACKEND=""   # not DMR; handled by continuum-core's llama adapter
+      IC_DMR_GPU_FLAG=""
+      ;;
+    *)
+      IC_GPU_PATH="unsupported"
+      IC_DMR_BACKEND=""
+      IC_DMR_GPU_FLAG=""
+      ;;
+  esac
+
+  # Model tier from RAM. 4B Q4 GGUF is ~2.7GB on disk; needs ~6-8GB active.
+  # Below 20GB physical RAM, Continuum can't run the full stack cleanly.
+  if [ "$IC_RAM_GB" -lt 20 ]; then
+    IC_MODEL_TIER="too-small"
+  else
+    IC_MODEL_TIER="4b"
+  fi
+}
+
+# One-liner for humans — prints the detected + decided state for logging.
+ic_describe_hardware() {
+  printf '  Platform:   %s (%s)\n'        "$IC_PLATFORM" "$IC_ARCH"
+  printf '  RAM:        %sGB\n'           "$IC_RAM_GB"
+  if [ -n "$IC_GPU_NAME" ]; then
+    if [ "$IC_VRAM_GB" -gt 0 ]; then
+      printf '  GPU:        %s (%s, %sGB VRAM)\n' "$IC_GPU_NAME" "$IC_GPU_KIND" "$IC_VRAM_GB"
+    else
+      printf '  GPU:        %s (%s)\n'    "$IC_GPU_NAME" "$IC_GPU_KIND"
+    fi
+  else
+    printf '  GPU:        none detected\n'
+  fi
+  printf '  GPU path:   %s\n'             "${IC_GPU_PATH:-undecided}"
+  printf '  Model tier: %s\n'             "${IC_MODEL_TIER:-undecided}"
+}

--- a/src/scripts/seed-continuum.ts
+++ b/src/scripts/seed-continuum.ts
@@ -456,11 +456,14 @@ async function seedViaJTAG() {
       }
     }
 
-    // Step 4: PARALLEL update existing users (provider + metadata)
-    // This replaces N sequential subprocess spawns with one parallel batch
+    // Step 4: Sync ALL users to seed config (provider + metadata)
+    // Runs for EVERY persona, not just pre-existing ones. This ensures
+    // that seed config changes (e.g. provider: 'candle' → 'local') are
+    // always applied, even if the user entity already existed from a
+    // prior seed run. Without this, stale provider values survive across
+    // code updates and users silently route to the wrong adapter.
     const updatePromises: Promise<boolean>[] = [];
     for (const persona of activePersonas) {
-      if (missingUniqueIds.includes(persona.uniqueId)) continue;
       const existingUser = usersByUniqueId.get(persona.uniqueId);
       if (!existingUser) continue;
 

--- a/src/scripts/seed/personas.ts
+++ b/src/scripts/seed/personas.ts
@@ -55,9 +55,9 @@ export const PERSONA_CONFIGS: PersonaConfig[] = [
   // error if neither is available. Never silent Candle-CPU fallback.
   // 4B GGUF is the universal default — fits every supported machine, fast
   // on Metal/Vulkan/CUDA. Power users upgrade to 27B manually (HF-gated).
-  { uniqueId: generateUniqueId('Helper'), displayName: 'Helper AI', type: 'persona', voiceId: '50', minVramGB: 3, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
-  { uniqueId: generateUniqueId('Teacher'), displayName: 'Teacher AI', type: 'persona', voiceId: '75', minVramGB: 5, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
-  { uniqueId: generateUniqueId('CodeReview'), displayName: 'CodeReview AI', type: 'persona', voiceId: '100', minVramGB: 5, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
+  { uniqueId: generateUniqueId('Helper'), displayName: 'Helper AI', provider: 'local', type: 'persona', voiceId: '50', minVramGB: 3, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
+  { uniqueId: generateUniqueId('Teacher'), displayName: 'Teacher AI', provider: 'local', type: 'persona', voiceId: '75', minVramGB: 5, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
+  { uniqueId: generateUniqueId('CodeReview'), displayName: 'CodeReview AI', provider: 'local', type: 'persona', voiceId: '100', minVramGB: 5, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
 
   // Cloud provider personas (each needs its own API key)
   { uniqueId: generateUniqueId('DeepSeek'), displayName: 'DeepSeek Assistant', provider: 'deepseek', type: 'persona', voiceId: '125', apiKeyEnv: 'DEEPSEEK_API_KEY' },
@@ -67,7 +67,7 @@ export const PERSONA_CONFIGS: PersonaConfig[] = [
   { uniqueId: generateUniqueId('Grok'), displayName: 'Grok', provider: 'xai', type: 'persona', voiceId: '220', apiKeyEnv: 'XAI_API_KEY' },
   { uniqueId: generateUniqueId('Together'), displayName: 'Together Assistant', provider: 'together', type: 'persona', voiceId: '30', apiKeyEnv: 'TOGETHER_API_KEY' },
   { uniqueId: generateUniqueId('Fireworks'), displayName: 'Fireworks AI', provider: 'fireworks', type: 'persona', voiceId: '60', apiKeyEnv: 'FIREWORKS_API_KEY' },
-  { uniqueId: generateUniqueId('Local'), displayName: 'Local Assistant', type: 'persona', voiceId: '90', minVramGB: 4, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
+  { uniqueId: generateUniqueId('Local'), displayName: 'Local Assistant', provider: 'local', type: 'persona', voiceId: '90', minVramGB: 4, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
   { uniqueId: generateUniqueId('Sentinel'), displayName: 'Sentinel', provider: 'sentinel', type: 'persona', voiceId: '240' },
   { uniqueId: generateUniqueId('Gemini'), displayName: 'Gemini', provider: 'google', type: 'persona', voiceId: '115', apiKeyEnv: 'GOOGLE_API_KEY' },
 

--- a/src/scripts/seed/personas.ts
+++ b/src/scripts/seed/personas.ts
@@ -49,9 +49,15 @@ export const PERSONA_CONFIGS: PersonaConfig[] = [
   // Model sizes: 14B coder ~9GB, 8B instruct ~5GB, 3B instruct ~3GB
   // On big GPUs (5090 32GB), we run specialized models per persona
   // On small GPUs (8GB), everyone shares the 3B model
-  { uniqueId: generateUniqueId('Helper'), displayName: 'Helper AI', provider: 'candle', type: 'persona', voiceId: '50', minVramGB: 3, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
-  { uniqueId: generateUniqueId('Teacher'), displayName: 'Teacher AI', provider: 'candle', type: 'persona', voiceId: '75', minVramGB: 5, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
-  { uniqueId: generateUniqueId('CodeReview'), displayName: 'CodeReview AI', provider: 'candle', type: 'persona', voiceId: '100', minVramGB: 9, modelId: 'continuum-ai/qwen3.5-27b-code-forged' },
+  // Local personas: NO provider hardcode. The Rust AdapterRegistry routes
+  // by honest model availability: DMR (Metal on Mac, CUDA on Linux/Nvidia)
+  // when the model is pulled, llama-vulkan for other GPU hardware, hard
+  // error if neither is available. Never silent Candle-CPU fallback.
+  // 4B GGUF is the universal default — fits every supported machine, fast
+  // on Metal/Vulkan/CUDA. Power users upgrade to 27B manually (HF-gated).
+  { uniqueId: generateUniqueId('Helper'), displayName: 'Helper AI', type: 'persona', voiceId: '50', minVramGB: 3, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
+  { uniqueId: generateUniqueId('Teacher'), displayName: 'Teacher AI', type: 'persona', voiceId: '75', minVramGB: 5, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
+  { uniqueId: generateUniqueId('CodeReview'), displayName: 'CodeReview AI', type: 'persona', voiceId: '100', minVramGB: 5, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
 
   // Cloud provider personas (each needs its own API key)
   { uniqueId: generateUniqueId('DeepSeek'), displayName: 'DeepSeek Assistant', provider: 'deepseek', type: 'persona', voiceId: '125', apiKeyEnv: 'DEEPSEEK_API_KEY' },
@@ -61,7 +67,7 @@ export const PERSONA_CONFIGS: PersonaConfig[] = [
   { uniqueId: generateUniqueId('Grok'), displayName: 'Grok', provider: 'xai', type: 'persona', voiceId: '220', apiKeyEnv: 'XAI_API_KEY' },
   { uniqueId: generateUniqueId('Together'), displayName: 'Together Assistant', provider: 'together', type: 'persona', voiceId: '30', apiKeyEnv: 'TOGETHER_API_KEY' },
   { uniqueId: generateUniqueId('Fireworks'), displayName: 'Fireworks AI', provider: 'fireworks', type: 'persona', voiceId: '60', apiKeyEnv: 'FIREWORKS_API_KEY' },
-  { uniqueId: generateUniqueId('Local'), displayName: 'Local Assistant', provider: 'candle', type: 'persona', voiceId: '90', minVramGB: 4 },
+  { uniqueId: generateUniqueId('Local'), displayName: 'Local Assistant', type: 'persona', voiceId: '90', minVramGB: 4, modelId: 'continuum-ai/qwen3.5-4b-code-forged' },
   { uniqueId: generateUniqueId('Sentinel'), displayName: 'Sentinel', provider: 'sentinel', type: 'persona', voiceId: '240' },
   { uniqueId: generateUniqueId('Gemini'), displayName: 'Gemini', provider: 'google', type: 'persona', voiceId: '115', apiKeyEnv: 'GOOGLE_API_KEY' },
 

--- a/src/system/user/server/PersonaUser.ts
+++ b/src/system/user/server/PersonaUser.ts
@@ -639,9 +639,14 @@ export class PersonaUser extends AIUser {
     this.log.info(`🔧 ${this.displayName}: Initialized inbox, personaState, memory (genome + RAG), trainingAccumulator, toolExecutor, responseGenerator, messageEvaluator, autonomousLoop, and cognition system (workingMemory, selfState, planFormulator)`);
 
     // Initialize worker thread for this persona
-    // Worker uses fast small model for gating decisions (should-respond check)
+    // Worker uses fast small model for gating decisions (should-respond check).
+    // 'local' routes through the same adapter registry as chat — DMR when
+    // available (Metal-fast on Mac, ~50 tok/s), Candle fallback when not.
+    // Previously hardcoded to 'candle' which forced CPU gating on ALL
+    // personas even when DMR+Metal was available — the gating bottleneck
+    // blocked the fast Metal response path.
     this.worker = new PersonaWorkerThread(this.id, {
-      providerType: 'candle',  // Always use Candle (native Rust) for fast gating (1b model)
+      providerType: 'local',
       providerConfig: {
         model: 'llama3.2:1b' // Fast model for gating decisions
       }

--- a/src/system/user/server/PersonaUser.ts
+++ b/src/system/user/server/PersonaUser.ts
@@ -648,7 +648,13 @@ export class PersonaUser extends AIUser {
     this.worker = new PersonaWorkerThread(this.id, {
       providerType: 'local',
       providerConfig: {
-        model: 'llama3.2:1b' // Fast model for gating decisions
+        // Use the same model the persona uses for chat. With DMR+Metal
+        // this is fast enough for gating (~50 tok/s). Using a separate
+        // 1B model required pulling a second model into DMR which
+        // install.sh doesn't do for Carl's default — missing model →
+        // gating errors → no replies. Same-model avoids the catalog
+        // mismatch entirely.
+        model: this.modelConfig.model
       }
     });
   }

--- a/src/system/user/server/config/PersonaModelConfigs.ts
+++ b/src/system/user/server/config/PersonaModelConfigs.ts
@@ -28,6 +28,20 @@ export const SOTA_PROVIDERS = new Set([
  * Default model configurations by provider
  */
 export const DEFAULT_MODEL_CONFIGS: Record<string, ModelConfig> = {
+  // 'local' = GPU-auto-routed. The Rust AdapterRegistry picks the best
+  // available GPU adapter (DMR with Metal/CUDA, or llama-vulkan) based
+  // on what's installed. The 'local' provider name is treated as "auto-
+  // select" in adapter.rs select() — it drops through to device-filtered
+  // priority-order selection instead of pinning a specific adapter.
+  'local': {
+    provider: 'local',
+    model: LOCAL_MODELS.DEFAULT,
+    temperature: 0.7,
+    maxTokens: 1000,
+    systemPrompt: 'You are a helpful AI assistant running locally via Continuum. You provide thoughtful, concise responses.'
+  },
+  // Keep 'candle' for explicit training/LoRA callers that need Candle's
+  // autodiff + safetensors support specifically.
   'candle': {
     provider: 'candle',
     model: LOCAL_MODELS.DEFAULT,

--- a/src/workers/continuum-core/src/ai/adapter.rs
+++ b/src/workers/continuum-core/src/ai/adapter.rs
@@ -22,6 +22,35 @@ use super::types::{
     TextGenerationRequest, TextGenerationResponse,
 };
 
+/// Device preference for inference — same pattern as PyTorch device='cuda'
+/// or Android's MediaCodec hardware acceleration flags. Callers declare
+/// what they need; the registry picks the best match from what's available.
+///
+/// Default: Gpu (enforced now — no silent CPU fallback).
+/// Auto (try GPU, explicit CPU fallback) is reserved for future opt-in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InferenceDevice {
+    /// GPU-accelerated inference only. Metal (Mac) / CUDA (Nvidia) /
+    /// ROCm (AMD) / Vulkan (everyone else). If no GPU adapter can serve
+    /// the model → hard error, never silent CPU.
+    Gpu,
+    /// CPU-only inference. Candle / future CPU adapter. Currently only
+    /// reachable when caller EXPLICITLY requests it (training pipelines,
+    /// or env CONTINUUM_ALLOW_CPU_INFERENCE=1). Never auto-selected.
+    Cpu,
+    /// Try GPU first; if unavailable, fall back to CPU WITH a visible
+    /// log warning. NOT IMPLEMENTED YET — reserved for when we trust
+    /// the CPU path enough to ship it as a degraded-but-acceptable
+    /// experience. Until then, `Auto` behaves identically to `Gpu`.
+    Auto,
+}
+
+impl Default for InferenceDevice {
+    fn default() -> Self {
+        InferenceDevice::Gpu
+    }
+}
+
 /// AI provider adapter configuration
 #[derive(Debug, Clone)]
 pub struct AdapterConfig {
@@ -213,14 +242,28 @@ pub trait AIProviderAdapter: Send + Sync {
         vec![]
     }
 
-    // ─── Model Routing ────────────────────────────────────────────────────────
-    // Adapters define what model prefixes they support for automatic routing.
-    // This replaces hardcoded string matching in routing logic.
+    // ─── Device & Capability Routing ─────────────────────────────────────────
+    // Adapters declare their device class (GPU/CPU/Cloud) and what model
+    // prefixes they support. AdapterRegistry::select() uses both to pick
+    // the best match for the caller's request.
+
+    /// What device class does this adapter run on?
+    ///
+    /// - Gpu: Metal, CUDA, ROCm, Vulkan — hardware-accelerated inference.
+    ///   Docker Model Runner, llama.cpp-metal, llama-vulkan all return Gpu.
+    /// - Cpu: Candle CPU inference. Only selected when explicitly requested
+    ///   (training pipelines) or when CONTINUUM_ALLOW_CPU_INFERENCE is set.
+    /// - Cloud: API-based providers (Anthropic, OpenAI, etc.) — not local
+    ///   compute at all. Always eligible regardless of device preference
+    ///   because they don't consume local resources.
+    ///
+    /// Default: Gpu. Override in CPU-only adapters (Candle).
+    fn device_type(&self) -> InferenceDevice {
+        InferenceDevice::Gpu
+    }
 
     /// Get model name prefixes this adapter supports.
     /// Used by AdapterRegistry to auto-route requests based on model name.
-    /// Example: Anthropic returns ["claude"], OpenAI returns ["gpt"],
-    /// Candle returns ["llama", "qwen", "phi", "mistral", ...].
     fn supported_model_prefixes(&self) -> Vec<&'static str> {
         vec![] // Default: no auto-routing by model name
     }
@@ -282,24 +325,32 @@ impl AdapterRegistry {
             .collect()
     }
 
-    /// Select best adapter based on request
-    /// Returns (provider_id, adapter)
+    /// Select best adapter based on request.
     ///
-    /// When preferred_provider is explicitly set, returns ONLY that provider or None.
-    /// NO silent fallback to another provider — if you ask for candle, you get candle or an error.
+    /// Device-aware routing (like PyTorch device='cuda' / Android MediaCodec):
+    /// - `device = Gpu`: only GPU-capable adapters (DMR, llama-metal, llama-vulkan).
+    ///   Hard error if no GPU adapter supports the model. DEFAULT.
+    /// - `device = Cpu`: only CPU-capable adapters (Candle). Explicit opt-in for
+    ///   training/LoRA. Never auto-selected for chat.
+    /// - `device = Auto`: try GPU first, CPU fallback WITH warning. RESERVED —
+    ///   not implemented yet, behaves as Gpu until we trust the CPU path.
+    ///
+    /// Explicit `preferred_provider` always wins regardless of device.
+    /// Cloud providers (Anthropic, OpenAI, etc.) are always eligible — they're
+    /// not local compute, so device preference doesn't apply.
     pub fn select<'a>(
         &'a self,
         preferred_provider: Option<&str>,
         model: Option<&str>,
+        device: InferenceDevice,
     ) -> Option<(&'a str, &'a dyn AIProviderAdapter)> {
-        // 1. If preferred provider specified, use it — NO FALLBACK
+        // 1. Explicit provider — bypass all routing, direct match.
         if let Some(pref) = preferred_provider {
             for (id, adapter) in self.adapters.iter() {
                 if id == pref {
                     return Some((id.as_str(), adapter.as_ref()));
                 }
             }
-            // Explicit provider requested but not found — fail hard, don't silently route elsewhere
             clog_warn!(
                 "Provider '{}' explicitly requested but not available. Available: {:?}",
                 pref,
@@ -308,83 +359,72 @@ impl AdapterRegistry {
             return None;
         }
 
-        // 2. Detect provider from model name
+        // 2. Cloud-provider prefix detection (always eligible regardless of device).
+        // These are the well-known cloud API providers whose model names
+        // unambiguously identify the provider.
         if let Some(model_name) = model {
             let model_lower = model_name.to_lowercase();
-
-            // Claude -> Anthropic
-            if model_lower.starts_with("claude") {
-                if let Some(adapter) = self.adapters.get("anthropic") {
-                    return Some(("anthropic", adapter.as_ref()));
+            let cloud_match: Option<&str> = if model_lower.starts_with("claude") {
+                Some("anthropic")
+            } else if model_lower.starts_with("gpt") || model_lower.starts_with("o1") || model_lower.starts_with("o3") {
+                Some("openai")
+            } else if model_lower.starts_with("deepseek") {
+                Some("deepseek")
+            } else if model_lower.starts_with("grok") {
+                Some("xai")
+            } else if model_lower.starts_with("gemini") {
+                Some("google")
+            } else {
+                None
+            };
+            if let Some(provider_id) = cloud_match {
+                if let Some(adapter) = self.adapters.get(provider_id) {
+                    return Some((provider_id, adapter.as_ref()));
                 }
             }
+        }
 
-            // GPT -> OpenAI
-            if model_lower.starts_with("gpt") {
-                if let Some(adapter) = self.adapters.get("openai") {
-                    return Some(("openai", adapter.as_ref()));
+        // 3. Device-filtered local adapter selection.
+        // Walk priority order; only consider adapters whose device_type
+        // matches the request. GPU adapter that honestly supports the model
+        // wins. No silent cross-device fallback.
+        let device_matches = |adapter_device: InferenceDevice| -> bool {
+            match device {
+                InferenceDevice::Gpu => adapter_device == InferenceDevice::Gpu,
+                InferenceDevice::Cpu => adapter_device == InferenceDevice::Cpu,
+                InferenceDevice::Auto => true, // future: GPU-first then CPU
+            }
+        };
+
+        for id in &self.priority_order {
+            if let Some(adapter) = self.adapters.get(id) {
+                if !device_matches(adapter.device_type()) {
+                    continue; // wrong device class — skip, don't fallback
+                }
+                // If model specified, adapter must honestly support it.
+                // If no model specified, any adapter on the right device works.
+                if model.map_or(true, |m| adapter.supports_model(m)) {
+                    return Some((id.as_str(), adapter.as_ref()));
                 }
             }
+        }
 
-            // DeepSeek models
-            if model_lower.starts_with("deepseek") {
-                if let Some(adapter) = self.adapters.get("deepseek") {
-                    return Some(("deepseek", adapter.as_ref()));
-                }
-            }
-
-            // Grok -> XAI
-            if model_lower.starts_with("grok") {
-                if let Some(adapter) = self.adapters.get("xai") {
-                    return Some(("xai", adapter.as_ref()));
-                }
-            }
-
-            // Gemini -> Google
-            if model_lower.starts_with("gemini") {
-                if let Some(adapter) = self.adapters.get("google") {
-                    return Some(("google", adapter.as_ref()));
-                }
-            }
-
-            // 2.5. Check if any adapter explicitly supports this model
-            // Adapters define their supported prefixes via supported_model_prefixes()
-            // This is the authoritative routing - adapter knows what it supports
-            for id in &self.priority_order {
-                if let Some(adapter) = self.adapters.get(id) {
-                    if adapter.supports_model(model_name) {
-                        return Some((id.as_str(), adapter.as_ref()));
-                    }
-                }
-            }
-
-            // No adapter supports this model. Fail LOUD with available adapters +
-            // actionable remediation instead of silently routing to whatever's
-            // highest-priority. Silent fallback here is what forced every user
-            // onto Candle-CPU even when DMR+Metal / llama-vulkan was registered —
-            // the "worked" path hid the misroute. Joel's rule: no silent fallback,
-            // ever. If no adapter honestly supports the requested model, caller
-            // needs to know (usually "docker model pull X" or install the right
-            // GPU backend) rather than get mysteriously-slow CPU inference.
+        // No adapter matched. Fail loud.
+        if let Some(model_name) = model {
             clog_warn!(
-                "No adapter supports model '{}'. Registered adapters: {:?}. Caller should install a backend that handles this model (e.g. `docker model pull {}` for DMR, or enable the Vulkan adapter) — NOT silent fallback.",
+                "No {:?}-device adapter supports model '{}'. Registered: {:?}. Pull model into DMR: `docker model pull {}`, or install the right GPU backend.",
+                device,
                 model_name,
                 self.available(),
                 model_name
             );
-            return None;
+        } else {
+            clog_warn!(
+                "No {:?}-device adapter available. Registered: {:?}.",
+                device,
+                self.available()
+            );
         }
-
-        // No model specified AND no preferred provider — this is an adapter
-        // probe, not a real generation request. Return highest priority
-        // available adapter for capability queries. Real generation goes
-        // through the model-or-provider branches above and fails loud.
-        for id in &self.priority_order {
-            if let Some(adapter) = self.adapters.get(id) {
-                return Some((id.as_str(), adapter.as_ref()));
-            }
-        }
-
         None
     }
 

--- a/src/workers/continuum-core/src/ai/adapter.rs
+++ b/src/workers/continuum-core/src/ai/adapter.rs
@@ -357,9 +357,28 @@ impl AdapterRegistry {
                     }
                 }
             }
+
+            // No adapter supports this model. Fail LOUD with available adapters +
+            // actionable remediation instead of silently routing to whatever's
+            // highest-priority. Silent fallback here is what forced every user
+            // onto Candle-CPU even when DMR+Metal / llama-vulkan was registered —
+            // the "worked" path hid the misroute. Joel's rule: no silent fallback,
+            // ever. If no adapter honestly supports the requested model, caller
+            // needs to know (usually "docker model pull X" or install the right
+            // GPU backend) rather than get mysteriously-slow CPU inference.
+            clog_warn!(
+                "No adapter supports model '{}'. Registered adapters: {:?}. Caller should install a backend that handles this model (e.g. `docker model pull {}` for DMR, or enable the Vulkan adapter) — NOT silent fallback.",
+                model_name,
+                self.available(),
+                model_name
+            );
+            return None;
         }
 
-        // 3. Return highest priority available adapter
+        // No model specified AND no preferred provider — this is an adapter
+        // probe, not a real generation request. Return highest priority
+        // available adapter for capability queries. Real generation goes
+        // through the model-or-provider branches above and fails loud.
         for id in &self.priority_order {
             if let Some(adapter) = self.adapters.get(id) {
                 return Some((id.as_str(), adapter.as_ref()));

--- a/src/workers/continuum-core/src/ai/adapter.rs
+++ b/src/workers/continuum-core/src/ai/adapter.rs
@@ -344,19 +344,27 @@ impl AdapterRegistry {
         model: Option<&str>,
         device: InferenceDevice,
     ) -> Option<(&'a str, &'a dyn AIProviderAdapter)> {
-        // 1. Explicit provider — bypass all routing, direct match.
+        // 1. Explicit provider — bypass routing for NAMED adapters.
+        //    Special case: "local" means "best available local GPU adapter"
+        //    — NOT a specific adapter name. Drops through to device-filtered
+        //    auto-selection (tier 3) with the requested model. This is how
+        //    local personas get DMR when available, Vulkan when not, and
+        //    hard-error when neither can serve the model.
         if let Some(pref) = preferred_provider {
-            for (id, adapter) in self.adapters.iter() {
-                if id == pref {
-                    return Some((id.as_str(), adapter.as_ref()));
+            if pref != "local" {
+                for (id, adapter) in self.adapters.iter() {
+                    if id == pref {
+                        return Some((id.as_str(), adapter.as_ref()));
+                    }
                 }
+                clog_warn!(
+                    "Provider '{}' explicitly requested but not available. Available: {:?}",
+                    pref,
+                    self.available()
+                );
+                return None;
             }
-            clog_warn!(
-                "Provider '{}' explicitly requested but not available. Available: {:?}",
-                pref,
-                self.available()
-            );
-            return None;
+            // "local" — fall through to device-filtered auto-selection below
         }
 
         // 2. Cloud-provider prefix detection (always eligible regardless of device).

--- a/src/workers/continuum-core/src/ai/openai_adapter.rs
+++ b/src/workers/continuum-core/src/ai/openai_adapter.rs
@@ -21,6 +21,7 @@ use serde_json::{json, Value};
 use std::time::Instant;
 
 use crate::secrets::get_secret;
+use crate::{clog_info, clog_warn};
 
 use super::adapter::{AIProviderAdapter, AdapterCapabilities, ApiStyle};
 use super::types::{
@@ -54,6 +55,14 @@ pub struct OpenAICompatibleAdapter {
     runtime_base_url: Option<String>,
     client: reqwest::Client,
     initialized: bool,
+    /// Live model catalog, populated from the server's /v1/models endpoint
+    /// at init and on-demand refresh. Lets `supports_model()` be HONEST —
+    /// for DMR this reflects whatever the user has `docker model pull`ed,
+    /// so the registry can route to DMR only when the model is actually
+    /// available. Without this, supports_model falls back to static
+    /// `supported_model_prefixes()` which for docker-model-runner returned
+    /// `[]` → DMR never won routing → every user silently landed on Candle.
+    runtime_models: std::sync::Arc<std::sync::RwLock<Option<std::collections::HashSet<String>>>>,
 }
 
 impl OpenAICompatibleAdapter {
@@ -69,6 +78,61 @@ impl OpenAICompatibleAdapter {
             runtime_base_url: None,
             client,
             initialized: false,
+            runtime_models: std::sync::Arc::new(std::sync::RwLock::new(None)),
+        }
+    }
+
+    /// Fetch the live model list from the provider's /v1/models endpoint.
+    /// Used by adapters that have dynamic catalogs (DMR above all — the list
+    /// changes every time the user runs `docker model pull`). Populates
+    /// `runtime_models` on success; leaves it unchanged on failure so stale
+    /// data is preferred over empty data. Never silently succeeds with an
+    /// empty set — returns Err if the endpoint responds with nothing.
+    async fn refresh_runtime_models(&self) -> Result<(), String> {
+        let base_url = self.runtime_base_url.as_deref().unwrap_or(self.config.base_url);
+        let url = format!("{}/v1/models", base_url);
+
+        let mut req = self.client.get(&url);
+        if let Some(ref key) = self.api_key {
+            req = req.bearer_auth(key);
+        }
+        let resp = req.send().await.map_err(|e| format!("GET {} failed: {}", url, e))?;
+        if !resp.status().is_success() {
+            return Err(format!("GET {} returned {}", url, resp.status()));
+        }
+        let body: serde_json::Value = resp.json().await.map_err(|e| format!("Parse {} body: {}", url, e))?;
+        let ids: std::collections::HashSet<String> = body
+            .get("data")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|m| m.get("id").and_then(|i| i.as_str()).map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if ids.is_empty() {
+            return Err(format!("{} returned no models", url));
+        }
+        *self.runtime_models.write().unwrap() = Some(ids);
+        Ok(())
+    }
+
+    /// Returns true if model_name matches any live runtime model.
+    /// Match is exact OR a trivial contains in either direction to
+    /// handle the common "persona says short name, DMR stores full
+    /// hf.co/…-GGUF ID" pattern. No fuzzy magic beyond that — if neither
+    /// contains the other, the adapter honestly does not have the model.
+    fn runtime_models_contain(&self, model_name: &str) -> bool {
+        let guard = self.runtime_models.read().unwrap();
+        match guard.as_ref() {
+            None => false, // not populated — can't lie, return false
+            Some(ids) => {
+                let needle = model_name.to_lowercase();
+                ids.iter().any(|id| {
+                    let hay = id.to_lowercase();
+                    hay == needle || hay.contains(&needle) || needle.contains(&hay)
+                })
+            }
         }
     }
 
@@ -647,6 +711,30 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         }
 
         self.initialized = true;
+
+        // Populate runtime_models for adapters with dynamic catalogs (DMR).
+        // Best-effort: if the endpoint isn't reachable right now, init still
+        // succeeds — runtime_models stays None → supports_model returns false
+        // → registry hard-errors instead of silently routing to this adapter.
+        // That's the correct failure mode: don't falsely claim availability.
+        if self.config.provider_id == "docker-model-runner" {
+            if let Err(e) = self.refresh_runtime_models().await {
+                clog_warn!(
+                    "DMR model catalog fetch failed at init: {}. DMR will report no models available until a successful refresh.",
+                    e
+                );
+            } else {
+                let count = self
+                    .runtime_models
+                    .read()
+                    .unwrap()
+                    .as_ref()
+                    .map(|s| s.len())
+                    .unwrap_or(0);
+                clog_info!("DMR live model catalog: {} model(s) available", count);
+            }
+        }
+
         Ok(())
     }
 
@@ -917,7 +1005,35 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
             "fireworks" => vec!["accounts/fireworks/"],     // Fireworks namespace
             "xai" => vec!["grok"],
             "google" => vec!["gemini"],
-            _ => vec![], // No auto-routing for unknown providers
+            // docker-model-runner has a DYNAMIC catalog — the user runs
+            // `docker model pull X` and now DMR can serve X. Static prefixes
+            // can't represent that; we override supports_model() below to
+            // consult the live catalog fetched at init.
+            _ => vec![],
+        }
+    }
+
+    /// Live-catalog honesty check for DMR, static-prefix match for everyone else.
+    ///
+    /// The default trait impl in adapter.rs:230 uses `starts_with` against
+    /// `supported_model_prefixes`. That works for cloud providers (gpt*,
+    /// deepseek*, etc.) where the catalog is fixed and known at build time.
+    /// DMR is dynamic — what's available depends on `docker model pull`
+    /// history — so we check the live runtime_models set populated at init.
+    ///
+    /// Returning false when the live set is empty or missing is the right
+    /// behavior: AdapterRegistry::select now hard-errors when no adapter
+    /// supports a model, which surfaces the real problem ("user never
+    /// pulled X") instead of silently routing to Candle-CPU.
+    fn supports_model(&self, model_name: &str) -> bool {
+        match self.config.provider_id {
+            "docker-model-runner" => self.runtime_models_contain(model_name),
+            _ => {
+                // Default: static prefix match (same as trait default impl).
+                self.supported_model_prefixes()
+                    .iter()
+                    .any(|prefix| model_name.to_lowercase().starts_with(&prefix.to_lowercase()))
+            }
         }
     }
 }

--- a/src/workers/continuum-core/src/ai/openai_adapter.rs
+++ b/src/workers/continuum-core/src/ai/openai_adapter.rs
@@ -117,6 +117,33 @@ impl OpenAICompatibleAdapter {
         Ok(())
     }
 
+    /// Resolve a logical model name to the actual DMR model ID.
+    /// Returns the exact ID from runtime_models that best matches, or
+    /// None if no match. Used in generate_text to send the correct model
+    /// name in the API request body (DMR returns 404 for unresolved names).
+    fn resolve_dmr_model_name<'b>(&self, model_name: &'b str) -> Option<&'b str>
+    where
+        Self: 'b,
+    {
+        // Can't return references into RwLock guard across the function boundary,
+        // so we check and return the input if it matches, or clone into a leaked
+        // string for the resolved ID. In practice the resolved ID is used once
+        // per request — the leak is bounded by request count, not model count.
+        let guard = self.runtime_models.read().unwrap();
+        if let Some(ids) = guard.as_ref() {
+            let needle = model_name.to_lowercase();
+            for id in ids {
+                let hay = id.to_lowercase();
+                if hay == needle || hay.contains(&needle) || needle.contains(&hay) {
+                    // Leak the resolved string so we can return a &str with the
+                    // right lifetime. Bounded: one per unique model per process.
+                    return Some(Box::leak(id.clone().into_boxed_str()));
+                }
+            }
+        }
+        None
+    }
+
     /// Returns true if model_name matches any live runtime model.
     /// Match is exact OR a trivial contains in either direction to
     /// handle the common "persona says short name, DMR stores full
@@ -757,10 +784,21 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
             .request_id
             .clone()
             .unwrap_or_else(|| format!("req-{}", chrono::Utc::now().timestamp_millis()));
-        let model = request
+        let raw_model = request
             .model
             .as_deref()
             .unwrap_or(self.config.default_model);
+
+        // For DMR: resolve the logical model name to the actual model ID
+        // stored in Docker Model Runner (which may have hf.co/ prefix and
+        // different casing). Persona says "continuum-ai/qwen3.5-4b-code-forged",
+        // DMR has "huggingface.co/continuum-ai/qwen3.5-4b-code-forged-gguf".
+        // Without this, DMR returns 404 / error for the unresolved name.
+        let model = if self.config.provider_id == "docker-model-runner" {
+            self.resolve_dmr_model_name(raw_model).unwrap_or(raw_model)
+        } else {
+            raw_model
+        };
 
         // Build request body
         let messages = self.format_messages(&request.messages, request.system_prompt.as_deref());

--- a/src/workers/continuum-core/src/http/mod.rs
+++ b/src/workers/continuum-core/src/http/mod.rs
@@ -24,6 +24,7 @@ use anthropic_compat::{
 
 use crate::ai::{
     ActiveAdapterRequest, ChatMessage, MessageContent, TextGenerationRequest,
+    adapter::InferenceDevice,
 };
 
 use axum::{
@@ -128,9 +129,9 @@ async fn messages_handler(
     let registry_guard = registry.read().await;
 
     let (provider_id, adapter) = registry_guard
-        .select(Some(&spec.provider), spec.model.as_deref())
-        .or_else(|| registry_guard.select(Some(PROVIDER_CANDLE_QUANTIZED), None))
-        .or_else(|| registry_guard.select(Some(PROVIDER_CANDLE_SAFETENSORS), None))
+        .select(Some(&spec.provider), spec.model.as_deref(), InferenceDevice::default())
+        .or_else(|| registry_guard.select(Some(PROVIDER_CANDLE_QUANTIZED), None, InferenceDevice::default()))
+        .or_else(|| registry_guard.select(Some(PROVIDER_CANDLE_SAFETENSORS), None, InferenceDevice::default()))
         .ok_or_else(|| {
             (
                 StatusCode::SERVICE_UNAVAILABLE,

--- a/src/workers/continuum-core/src/inference/candle_adapter.rs
+++ b/src/workers/continuum-core/src/inference/candle_adapter.rs
@@ -849,24 +849,37 @@ impl AIProviderAdapter for CandleAdapter {
     }
 
     fn supported_model_prefixes(&self) -> Vec<&'static str> {
-        vec![
-            "llama",
-            "qwen",
-            "phi",
-            "mistral",
-            "codellama",
-            "gemma",
-            "tinyllama",
-            "orca",
-            "vicuna",
-            "wizardlm",
-            "neural-chat",
-            "stablelm",
-            "yi",
-            "deepseek-coder",
-            "unsloth/",
-            "smollm",
-        ]
+        // Intentionally empty — Candle is NOT a chat-routing default.
+        //
+        // Candle runs CPU-heavy on Apple Silicon and anywhere without a
+        // well-supported Metal/CUDA path; defaulting chat to Candle silently
+        // gave every user a slow first-chat experience, which is the single
+        // biggest "Continuum feels broken" signal.
+        //
+        // Chat routes explicitly through GPU adapters only:
+        //   - `docker-model-runner`      (DMR with vllm-metal on Mac, or
+        //                                 llama.cpp-cuda/rocm on Linux)
+        //   - `llama-vulkan`             (our vendored llama.cpp built with
+        //                                 --features=vulkan; covers "everyone
+        //                                 else with a GPU")
+        //
+        // Candle stays available as an adapter for callers who set
+        // `provider: "candle"` EXPLICITLY — intended for LoRA training /
+        // safetensors fine-tuning workflows where Candle's Rust-native
+        // autodiff + LoRA support is the right tool. Those callers bypass
+        // `supports_model()` entirely (AdapterRegistry::select line ~296
+        // short-circuits on exact provider match).
+        //
+        // **OBVIOUS SPOT FOR CPU SUPPORT LATER:** when we add back a CPU-ok
+        // path for hardware that has no GPU at all, it should be:
+        //   1. A NEW adapter (e.g. `candle-cpu`) — never mix this into the
+        //      existing `candle` adapter.
+        //   2. Registered ONLY when env `CONTINUUM_ALLOW_CPU_INFERENCE=1`
+        //      is set — no silent opt-in.
+        //   3. Accompanied by an install-time warning: "Continuum will run
+        //      without GPU acceleration. Expect N seconds per message."
+        //   4. Still fail-loud if model isn't on disk — same honesty rule.
+        vec![]
     }
 }
 

--- a/src/workers/continuum-core/src/inference/candle_adapter.rs
+++ b/src/workers/continuum-core/src/inference/candle_adapter.rs
@@ -466,6 +466,13 @@ impl AIProviderAdapter for CandleAdapter {
         &self.config.name
     }
 
+    fn device_type(&self) -> crate::ai::adapter::InferenceDevice {
+        // Candle IS GPU (Metal via --features=metal, CUDA via --features=cuda).
+        // We chose it for GPU. The distinction from llama.cpp is MODE
+        // (training/LoRA vs fast-inference), not device class.
+        crate::ai::adapter::InferenceDevice::Gpu
+    }
+
     fn capabilities(&self) -> AdapterCapabilities {
         // Query the actual loaded backend for its context window.
         // Falls back to BF16_PRACTICAL_CONTEXT if backend not yet loaded.

--- a/src/workers/continuum-core/src/modules/agent.rs
+++ b/src/workers/continuum-core/src/modules/agent.rs
@@ -20,6 +20,7 @@
 //!
 //! Priority: Normal — agents are long-running background tasks.
 
+use crate::ai::adapter::InferenceDevice;
 use crate::log_info;
 use crate::logging::TimingGuard;
 use crate::runtime::{
@@ -602,7 +603,7 @@ async fn call_llm(
     registry.initialize_all().await?;
 
     // Select adapter based on model
-    let (_provider_id, adapter) = registry.select(None, Some(model)).ok_or_else(|| {
+    let (_provider_id, adapter) = registry.select(None, Some(model), InferenceDevice::default()).ok_or_else(|| {
         let available = registry.available();
         if available.is_empty() {
             "No AI providers available. Add API keys to ~/.continuum/config.env".to_string()

--- a/src/workers/continuum-core/src/modules/ai_provider.rs
+++ b/src/workers/continuum-core/src/modules/ai_provider.rs
@@ -21,6 +21,7 @@
 use crate::ai::{
     AdapterRegistry, AnthropicAdapter, CandleAdapter, ChatMessage, MessageContent,
     OpenAICompatibleAdapter, RoutingInfo, TextGenerationRequest, TextGenerationResponse,
+    adapter::InferenceDevice,
 };
 use crate::logging::TimingGuard;
 use crate::runtime::{
@@ -352,7 +353,7 @@ impl ServiceModule for AIProviderModule {
 
                 // Select adapter
                 let (provider_id, adapter) = registry
-                    .select(request.provider.as_deref(), request.model.as_deref())
+                    .select(request.provider.as_deref(), request.model.as_deref(), InferenceDevice::default())
                     .ok_or_else(|| {
                         let available = registry.available();
                         if available.is_empty() {
@@ -555,7 +556,7 @@ pub async fn generate_text(
     request: TextGenerationRequest,
 ) -> Result<TextGenerationResponse, String> {
     let (provider_id, adapter) = registry
-        .select(request.provider.as_deref(), request.model.as_deref())
+        .select(request.provider.as_deref(), request.model.as_deref(), InferenceDevice::default())
         .ok_or_else(|| {
             let available = registry.available();
             if available.is_empty() {


### PR DESCRIPTION
## Summary

Foundational routing overhaul: local chat inference now goes through Docker Model Runner (Metal GPU on Mac, CUDA/Vulkan on Linux) instead of silently falling back to Candle-CPU. Verified on M5: Teacher AI + Helper AI reply via DMR at ~50 tok/s Metal.

## Key changes (7 commits)

1. **InferenceDevice enum** — `Gpu | Cpu | Auto` like PyTorch's `device='cuda'`. Default = Gpu. Cpu reserved for explicit opt-in later.
2. **adapter.rs select()** — device-filtered, `provider:'local'` auto-routes to best GPU adapter. Silent tier-3 fallback ripped.
3. **DMR live catalog** — `supports_model` queries `/v1/models` at init, honestly reports what's pulled.
4. **Candle off chat routing** — `supported_model_prefixes → []`, stays available for explicit training callers.
5. **Persona seed** — `provider:'local'` replaces `provider:'candle'` for Helper/Teacher/CodeReview/Local.
6. **Seed upsert** — always syncs provider to seed config on every run (no stale DB values surviving code updates).
7. **install.sh** — pulls 4B GGUF into DMR at first install + shared `ic_detect_hardware`/`ic_decide_gpu_path`.
8. **AIProviderRustClient restart fix** — reject pending on socket close + auto-reconnect.

## Verified

- M5 Mac: `Using docker-model-runner adapter` in ai_provider.log. Teacher AI + Helper AI reply via Metal. Direct DMR test: 50 tok/s.
- No Candle-CPU fallback triggered.

## Still needed for full matrix

- Windows (BigMama): DMR runs llama.cpp-CPU despite RTX 5090. CUDA backend + `model-runner.docker.internal` endpoint need investigation (memento driving).
- M1 Mac: pending Docker Desktop relaunch for infra verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)