### PR TITLE
feat(rag): tool-relevance filtering on native path — cuts ~17k → ~3k tokens per request

### DIFF
--- a/src/system/rag/sources/ToolDefinitionsSource.ts
+++ b/src/system/rag/sources/ToolDefinitionsSource.ts
@@ -110,10 +110,35 @@ export class ToolDefinitionsSource implements RAGSource {
 
     let prioritizedTools = toolDefinitions.filter(t => !META_TOOLS.has(t.name));
 
-    // Three-tier prioritization with budget awareness
+    // Contextual group filtering — same pattern the XML path already uses.
+    // Without this, the native path was sending all ~349 → MAX_NATIVE_TOOLS=64
+    // tools per request (~17k tokens). The XML path drops to 5-12 contextually
+    // relevant tools by analyzing the trigger message; mirror that here so
+    // native providers (Anthropic, OpenAI, Groq, etc.) get the same win.
+    //
+    // Recipe tools always survive the filter via the unshift below — recipes
+    // declare what they need explicitly, that's the strongest signal.
+    const groupRegistry = ToolGroupRegistry.sharedInstance();
+    const triggerText = context.options.currentMessage?.content || '';
+    const selectedGroups = groupRegistry.selectGroups(triggerText, 5);
     const recipeToolNames = this.getRecipeToolNames(context);
     const hasRecipeTools = recipeToolNames.size > 0;
-    const MAX_NATIVE_TOOLS = hasRecipeTools ? 32 : 64;
+
+    const contextual = groupRegistry.filterToolsByGroups(prioritizedTools, selectedGroups);
+    if (hasRecipeTools) {
+      const recipeTools = prioritizedTools.filter(t => recipeToolNames.has(t.name));
+      const contextualNames = new Set(contextual.map(t => t.name));
+      for (const rt of recipeTools) {
+        if (!contextualNames.has(rt.name)) {
+          contextual.unshift(rt);
+        }
+      }
+    }
+    prioritizedTools = contextual;
+
+    // Cap is now a safety net, not the primary lever — contextual filter
+    // typically returns 5-12 tools well under these caps.
+    const MAX_NATIVE_TOOLS = hasRecipeTools ? 32 : 16;
 
     if (prioritizedTools.length > MAX_NATIVE_TOOLS) {
       prioritizedTools = this.prioritizeTools(prioritizedTools, recipeToolNames, hasRecipeTools, MAX_NATIVE_TOOLS);
@@ -134,10 +159,7 @@ export class ToolDefinitionsSource implements RAGSource {
 
     // Native providers still need behavioral instruction IN the system prompt.
     // JSON tool specs alone don't tell the model to prefer action over prose.
-    // Include contextual guidance based on what the user is asking about.
-    const groupRegistry = ToolGroupRegistry.sharedInstance();
-    const triggerText = context.options.currentMessage?.content || '';
-    const selectedGroups = groupRegistry.selectGroups(triggerText, 3);
+    // Reuse the contextual groups already selected above (line ~115) for hints.
     const groupHints = selectedGroups
       .filter(g => !g.alwaysInclude)
       .map(g => `For ${g.label.toLowerCase()}: use ${g.toolPatterns.slice(0, 2).join(', ')}`)


### PR DESCRIPTION
The XML tool path (`loadXmlTools`) already filters tools by contextual relevance via `groupRegistry.filterToolsByGroups` — drops from ~349 catalog → 5-12 contextual tools per request. The native tool path (`loadNativeTools`, used by Anthropic / OpenAI / Groq / etc.) didn't. It kept all 64 tools (`MAX_NATIVE_TOOLS=64`) and shipped ~17k tokens of tool definitions every chat turn.

## Change

Mirror the XML pattern on native:

1. `selectGroups(triggerText, 5)` picks up to 5 contextually-relevant groups from the message.
2. `filterToolsByGroups` drops tools not in those groups.
3. Recipe tools survive via `unshift` regardless of group filter (recipes know what they need).
4. `MAX_NATIVE_TOOLS` lowered from 64 → 16 (safety cap; contextual filter usually returns 5-12 well under it). With recipe tools: 32.
5. Behavioral-nudge group hints reuse the `selectedGroups` already computed — no duplicate `selectGroups` call.

## Token impact

| | Before | After |
|---|---|---|
| Native tools per request | ~64 | ~5-12 |
| Token cost | ~16-17k | ~2-3k |

## Why it compounds

With Phase 1 + 1.5 already in main, the persona's INVARIANT prompt prefix is byte-stable. This PR makes that prefix **much smaller** — DMR / llama-server / vllm prefix-KV-cache reuse fires on a tighter region, AND each cache miss costs less to recompute.

## Verification

- `tsc` clean.
- One file changed: `system/rag/sources/ToolDefinitionsSource.ts`, +28 −6.
- Cross-test: cargo & runtime both unaffected (TS-only change).
- Runtime acceptance: a chat turn's prompt should drop ~14k tokens after this lands. With memento's MLX install (parallel) the combined output-decode + prompt-eval gets a real boost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)