### PR TITLE
fix: defer codebase indexing 120s — stop starving chat on boot

### DIFF
--- a/src/system/core/system/server/ServiceInitializer.ts
+++ b/src/system/core/system/server/ServiceInitializer.ts
@@ -18,7 +18,10 @@ const log = Logger.create('ServiceInitializer');
  * Fire-and-forget: doesn't block server startup, logs results.
  */
 function initializeCodebaseIndexing(): void {
-  // Delay 10s to let the system fully settle before I/O-heavy indexing
+  // Delay 120s — personas must boot and respond to first chats before
+  // indexing starts. At 10s the embedding storm saturates the event loop
+  // and blocks ALL persona responses for 2+ minutes. Chat is the product;
+  // codebase search is optimization that can wait.
   setTimeout(async () => {
     try {
       const { getCodebaseIndexer } = await import('../../../rag/services/CodebaseIndexer');
@@ -40,7 +43,7 @@ function initializeCodebaseIndexing(): void {
     } catch (err) {
       log.warn(`Background codebase indexing failed: ${err}`);
     }
-  }, 10_000);
+  }, 120_000);
 }
 
 export async function initializeServices(): Promise<void> {


### PR DESCRIPTION
## Summary

Changes CodebaseIndexer startup delay from 10s to 120s. The embedding storm from indexing ~5000 source files saturates the event loop and blocks ALL persona responses for 2+ minutes after boot.

Chat is the product. Codebase search is optimization that can wait.

## Test plan

- [x] tsc clean
- [ ] Boot, verify personas respond within 30s (before indexing starts)
- [ ] Verify indexing still runs after 120s

🤖 Generated with [Claude Code](https://claude.com/claude-code)