### PR TITLE
feat(paging): unified PagedResourcePool primitive in Rust — foundation for KV/LoRA/MoE/memory paging

### DIFF
--- a/docs/architecture/RESOURCE-ARCHITECTURE.md
+++ b/docs/architecture/RESOURCE-ARCHITECTURE.md
@@ -163,6 +163,31 @@ Same hierarchy serves every paged AI entity:
 
 This is what "cold storage → inference" looks like in our system: a continuous gradient from "available somewhere on the internet" to "in the GPU registers right now," with the broker arbitrating placement based on real activity. No layer is special-cased. The same paging primitive serves the full chain because each tier is just another `PagedResourcePool` with its own loader (cold-fetch / mmap / dequantize / etc.) and its own demotion target. **Working smarter, not harder, all the way from the network down to the silicon.**
 
+#### Compositional paging: handle more than you should fit
+
+The hierarchy above treats each entity (an MoE expert, a LoRA adapter, a model layer) as the unit of paging. The next-deeper insight: **an entity is itself an assembly of typed sub-entities**, and if the system knows the assembly recipe, it can page parts in/out *during* an inference run — not just at load time.
+
+An MoE expert isn't a monolithic blob; it's W₁, W₂, W₃ projection matrices + a layer norm + a router-projection vector. A LoRA adapter is the rank-decomposed factors (B × A) plus a scale. A transformer layer is attention + feed-forward + norms. All of these are *compositions* of typed parts.
+
+Once we name the parts as their own pool entries, **inference can pull them just-in-time** from whatever tier currently holds them:
+
+```
+Expert-42 activates for this token
+  → router declares need for [W₁, W₂, W₃] of expert 42
+  → W₁ is L1 (VRAM full precision)        — used directly
+  → W₂ is L2 (RAM quantized)              — dequantize, stream to GPU, use
+  → W₃ is L3 (mmap'd disk)                — page in, stream to GPU, use
+  → After this token, all three demoted back to wherever the broker chooses,
+    based on predicted next use (broker may keep W₁/W₂ hot if router pattern
+    suggests this expert will fire again soon)
+```
+
+This unlocks **handling more than physically fits**. A 70B-parameter MoE model whose total weights exceed VRAM becomes runnable on a 16 GB machine if the architecture tolerates streaming sub-entity loads per token. The trade-off is latency (cold-tier hits cost real time), but the freedom is enormous: the system can attempt workloads that "shouldn't fit," and the broker decides per-request whether the latency is acceptable for that activity (research recipe? yes, take the hit. Voice chat? skip the cold expert, use a hotter approximation).
+
+Existing inference engines already do crude versions: llama.cpp's `--n-gpu-layers 32` (offload N layers), Hugging Face Accelerate's disk-offload, vllm's PagedAttention. **What we add: principled, uniform, broker-managed across every entity type, with the assembly recipe declared as part of the entity's metadata.** Same primitive serves it because each sub-entity is just another `PagedResourcePool` entry; the assembler is a thin orchestration layer that consults the recipe and pulls parts from wherever they live.
+
+When this lands fully, the answer to "can my MacBook Air run a 70B MoE?" becomes "yes, slower than VRAM-resident, but yes — and the broker decides per-request whether the slowdown is acceptable for what you're doing." Hardware ceiling becomes negotiable rather than fixed. That's the working-smarter-not-harder pattern at its limit: the system literally exceeds its own apparent capacity because it knows how to stream the constituent parts.
+
 ### 4. Intelligent (eventually ML/LLM-driven) priority
 
 The pool exposes the levers; the brain plugs in via the PressureBroker (Phase 7).

--- a/docs/architecture/RESOURCE-ARCHITECTURE.md
+++ b/docs/architecture/RESOURCE-ARCHITECTURE.md
@@ -308,6 +308,8 @@ When MoE-forged Qwen3.5-A8B-MoE lands: `<ExpertId, ExpertWeights>` pool. Router 
 ### Phase 9 — Recipe-declared resource needs
 Recipes formally declare their resource holds: "chat needs KV ≤16k, identity, recent history, 5 contextual tools." "Codereview needs KV ≤64k, identity, history, code-search, code-edit, code-read." Broker grants on activation, releases on deactivation. Replaces ad-hoc isApplicable + budget percentages with declarative resource manifests.
 
+> **Transitional install-time predecessor (PR #931):** until Phase 9 lands, the per-slot KV cache cap is set globally per-machine at install time via `docker model configure --context-size N PERSONA_MODEL`, tiered by physical RAM (8GB→4096, 16GB→8192, 24GB→16384, 32GB→32768, 48GB+→65536). This is the *floor* — the conservative default that keeps `com.docker.llama-server` resident under control without recipe awareness. When Phase 9 ships, recipes override this on activation: a `codereview` recipe on a 32 GB machine can opt up to 64k for the duration of the conversation, and the broker reverts to the install-time floor when the recipe deactivates. The model-reload cost of `docker model configure` mid-session (a few seconds) is the price of dynamic budgeting; for chat-only flows that never change recipe, the install-time cap holds permanently and there's zero reload cost.
+
 ---
 
 ## Why this matters strategically

--- a/docs/architecture/RESOURCE-ARCHITECTURE.md
+++ b/docs/architecture/RESOURCE-ARCHITECTURE.md
@@ -342,6 +342,27 @@ By exposing the levers cleanly — pluggable eviction, rich stats, priority-awar
 
 ---
 
+## The maturity arc — caps are training wheels
+
+The conservative defaults in early phases (16k chat KV, install-time global cap, hardcoded `MAX_NATIVE_TOOLS`, static-tier ladders) are **protective measures, not the destination**. They exist because we don't yet trust the architecture to manage real load dynamically.
+
+As the broker, the paging primitive consumers, the pressure-aware scheduler, and the recipe-declared resource manifests each ship and prove themselves under real workloads, **the caps relax**. The arc:
+
+| Today | After the broker matures | End state |
+|---|---|---|
+| Hardcoded 16k/32k KV ceiling | Recipe-declared budgets respected | Whatever the workload genuinely needs, dynamically tiered |
+| Static `MAX_NATIVE_TOOLS=16` | Recipe-relevance filter | Whatever tools the LLM actually uses, learned per recipe |
+| Conservative `local-inference: 1` slot | Pressure-aware admission | As many concurrent inferences as the GPU can sustain at acceptable latency |
+| Embedding cache 256 MB fixed | Broker reshapes by competing demand | Cache grows when memory is free, shrinks when other pools need it |
+
+The destination isn't "no limits" — it's "limits set by ground truth, not by fear." The system measures what's happening (`gpu/stats`, pressure watchers, observed TPS, recipe activity) and sets the lever positions that fit reality. When the broker (and eventually the ML/LLM policy layer) is solid, **freedom comes back** — recipes can request what they need, conversations can be as long as they need to be, parallel personas can scale to what the hardware actually supports, because the architecture knows how to handle the consequences gracefully (demote, page out, time-share, prioritize) instead of refusing or crashing.
+
+Caps today are about not blowing up while we build the brain. Caps tomorrow are about the brain knowing exactly where the real edges are. Caps in the end-state are mostly absent — the broker handles edges by reshaping resources, not by refusing requests.
+
+This matters because it's the difference between a *constrained appliance* (hardcoded limits forever) and an *AI-native OS* (the system knows itself well enough to let workloads be expansive when capacity allows). Continuum aims for the second.
+
+---
+
 ## Provenance
 
 Architectural insights captured in this doc came out of an extended conversation between Joel and the Claude assistants during the inference-perf branch session of 2026-04-17 / -18. Key framings:

--- a/docs/architecture/RESOURCE-ARCHITECTURE.md
+++ b/docs/architecture/RESOURCE-ARCHITECTURE.md
@@ -128,6 +128,41 @@ On hit at L2/L3: optionally promote upward
 
 The primitive stays simple; tiering composes. CPU L1/L2/L3 cache works this way. OS page-out-to-disk works this way (kernel handles the actual paging). For our L3 we can `mmap` files so the kernel becomes the L4 manager automatically.
 
+#### The full hierarchy: cold storage → inference
+
+The same composition extends down to **cold storage** and up to **active inference VRAM**, giving every paged AI entity the full hierarchy:
+
+```
+L1  VRAM full precision      — active inference (hot path)
+L2  RAM quantized            — recently evicted from L1; rehydrate on hit
+L3  mmap'd disk              — kernel-managed paging (our L4 effectively free)
+L4  Cold storage / archive   — local SSD warm cache; pulled from HF/grid on miss
+                                (or remote storage / network archive)
+```
+
+For an MoE expert router asking "give me expert #42":
+
+1. **L1 hit** — VRAM full precision, used directly
+2. **L1 miss → L2 hit** — quantized RAM copy promoted to L1 (or used quantized for less-critical paths)
+3. **L2 miss → L3 hit** — mmap'd file paged in by kernel, loaded to L2/L1 by us
+4. **L3 miss → L4 hit** — fetched from cold archive (network/grid), cascades up through L3 → L2 → L1
+5. **L4 miss** — fetched from HuggingFace / model registry, populates all tiers
+
+Each transition has a cost (compress on demote, dequantize on promote, network round-trip on cold fetch). The PressureBroker decides which tier each entity lives in based on activity prediction + cost. ML-driven prediction here directly equals "less cold-tier traffic" which directly equals lower latency for the user.
+
+Same hierarchy serves every paged AI entity:
+
+| Entity | L1 (VRAM) | L2 (RAM quantized) | L3 (mmap disk) | L4 (cold) |
+|---|---|---|---|---|
+| MoE expert | Full precision weights | Quantized weights | GGUF/safetensors file | HF / grid registry |
+| LoRA adapter | Active scale weights | Quantized | On-disk adapter | HF / grid |
+| KV cache | FP16 active | INT8 demoted | INT4 spilled | (drop — too cold) |
+| Embedding | Float32Array | Int8Array | File-backed | (drop or recompute) |
+| Recalled memory | Full text in RAM | Compressed gist | Per-room corpus on disk | Long-term archive |
+| Model weights | VRAM (active inference) | RAM (warm idle) | Disk model file | HF / model registry |
+
+This is what "cold storage → inference" looks like in our system: a continuous gradient from "available somewhere on the internet" to "in the GPU registers right now," with the broker arbitrating placement based on real activity. No layer is special-cased. The same paging primitive serves the full chain because each tier is just another `PagedResourcePool` with its own loader (cold-fetch / mmap / dequantize / etc.) and its own demotion target. **Working smarter, not harder, all the way from the network down to the silicon.**
+
 ### 4. Intelligent (eventually ML/LLM-driven) priority
 
 The pool exposes the levers; the brain plugs in via the PressureBroker (Phase 7).

--- a/docs/architecture/RESOURCE-ARCHITECTURE.md
+++ b/docs/architecture/RESOURCE-ARCHITECTURE.md
@@ -1,0 +1,285 @@
+# Continuum Resource Architecture
+
+> **One coherent model for every shared resource in the system.** Time-share and prioritize what can be shared; cleanly tear down what can't. Let the system's own organic activity drive priority. Compress before evicting; demote before dropping. Degrade gracefully under pressure; never silence individuals. The same primitive serves KV cache, LoRA adapters, MoE experts, model weights, embeddings, recalled memories — and exposes the levers for intelligent (eventually ML/LLM-driven) control.
+
+Status: design — 2026-04-18. The architectural picture behind the work shipping tonight (PR #930 paging primitive, #921 inference queue, #927 cold-start prewarming) and the work yet to come (PressureBroker, KV per-recipe budgeting, LoRA pool migration, MoE forge, MLX-format forge). Authored after a session where the persona path stalled because hand-rolled paging implementations across LoRA registry, KV reservation, embedding cache, and memory recall had drifted apart — none aware of the others — and the cumulative pressure crashed the user experience.
+
+Implementation foundation: [`UNIFIED-PAGING.md`](UNIFIED-PAGING.md) — the Rust `PagedResourcePool<K, V>` primitive that this architecture builds on.
+
+---
+
+## Why this is kernel-level, and why it's different from a normal OS
+
+A traditional OS pages **generic memory** — opaque 4 KB pages, no semantic understanding of what lives in them. The kernel decides what to swap to disk based on access patterns, but it can't compress an embedding to INT8 or quantize a model weight or summarize an old memory into gist, because it doesn't know what any page *is*.
+
+Continuum's resource architecture is the **kernel layer for AI workloads** — different from a normal OS in exactly the way that matters: it pages *AI-native entities* (LoRA adapters, KV cache pages, MoE experts, model weights, embeddings, recalled memories) with full semantic awareness of what each entity is and how it can be compressed, demoted, or reconstructed. The system can:
+
+- Quantize an embedding from FP32 → INT8 because it knows what an embedding is
+- Compress old KV cache to lower precision because it knows attention is the consumer
+- Summarize an old memory into semantic gist because it knows the memory's role in cognition
+- Share an LoRA adapter's read-only weights across N personas because it knows weights are immutable
+- Page out a MoE expert because it knows the router will request it back if needed
+
+This semantic awareness is what makes "massive work on tiny systems" possible — the OS can't do it generically because it lacks the AI-native types; we can do it precisely because the same Rust trait + generic primitive serves every entity *with* its semantic adapter.
+
+The OO + adapter pattern is what makes this clean. The primitive — `PagedResourcePool<K, V>` — is the **reusable kernel concept** (the equivalent of Mach VM's `vm_object`). Concrete consumers — `KVCachePool`, `LoRAAdapterPool`, `MoEExpertPool`, `EmbeddingPool`, `MemoryRecallPool` — are **adapters**, each composing the primitive with the right key shape, value shape, sizer, eviction policy, and (eventually) tier-demotion strategy for that entity type. Same kernel concept, semantic specialization at the adapter layer.
+
+Rust makes this brilliant because generics + traits give zero-cost abstraction over the variation. No vtable overhead per page lookup. No allocator surprises. The semantic adapter is compiled away into specialized code paths per entity type — same expressiveness as Java's interfaces or C++'s templates with none of the runtime cost.
+
+This is what an AI-native OS looks like at the kernel level. It's not a userspace optimization; it's the substrate everything else runs on.
+
+### The commercial picture: small systems running big models, many at a time
+
+The strategic frame is short: **work smarter, not harder.**
+
+Mainstream AI economics scale by throwing more hardware at the problem — bigger GPUs, more nodes, more datacenters, more electricity, more $$$. Every persona, every conversation, every task buys more compute.
+
+Continuum's economics go the other way: **the same machine you already own, used efficiently, runs intelligence that the mainstream stack would charge a datacenter for.**
+
+Concretely:
+
+| Mainstream approach | Continuum approach |
+|---|---|
+| Deploy a 70B model? Buy an H100 cluster | Forge to MoE, page experts on demand, run on a MacBook Air |
+| Run 14 personas? Spin up 14 model instances on 14 GPUs | One model loaded once, 14 personas time-share via priority scheduler |
+| Long context window? Rent more VRAM | Tier KV cache (full → quantized → spilled), pay only for what's actually held |
+| Per-skill specialization? Fine-tune 14 separate models | One base, N LoRA adapters, ref-counted shared across personas using the same skill |
+| 100k embedding vectors per user? Hosted vector DB | Content-addressed pool with smart eviction on the user's own machine |
+
+Every mechanism in this architecture — paging, time-share, tiered demotion, organic prioritization, dormancy ladder, recipe-declared resource holds — is a way to **buy more intelligence with the same hardware budget**. Compounding: each layer's efficiency gain multiplies the others. The end-state is enterprise-tier AI experience on consumer-tier hardware, with $0 per turn cost to the user, no API contracts, no datacenter dependency.
+
+The technical work IS the commercial moat. The mainstream can't follow without abandoning the GPU-rental business model that funds them. Continuum can because the architecture is built on smarter resource use from kernel-level up — the way operating systems were always supposed to be designed for the resource they're managing, just specialized for AI instead of CPU/RAM.
+
+---
+
+## The thesis
+
+Every shared resource in Continuum falls into one of two categories. The architecture treats them differently — and the categorization itself is most of the design clarity.
+
+| Category | Examples | Mechanism | Lifetime |
+|---|---|---|---|
+| **Time-shareable** | Compute slots, KV cache pages, LoRA weights, model weights, embeddings, recalled memories, MoE experts | **Priority-scheduled paging pool** | Resource persists across consumers; one copy serves N |
+| **Exclusive stateful** | Microphone capture, LiveKit peer connection, Bevy avatar render entity, audio output mix, WebRTC track | **Explicit lifecycle ownership** (RAII) | Resource bound to one session; torn down when session ends, reconstructed fresh next time |
+
+Trying to force exclusive resources through paging would leak forever (pinning a mic capture is just exclusivity with extra steps). Trying to force shareable resources through teardown would waste reloading model weights every chat turn. The two categories need their own mechanisms; the architecture supports both as first-class.
+
+This doc focuses on the time-shareable category — that's where the unified paging primitive lives and where the bulk of "make personas usable on small machines" wins compound. The exclusive stateful category is well-served by existing patterns (`LiveCallTracker`-style start/stop, RAII handles, Drop semantics).
+
+---
+
+## The four mechanisms (time-shareable resources)
+
+Each mechanism is more sophisticated than the last. Most resources need only the first two; tier-demotion and ML-control are higher-order.
+
+### 1. Reference-counted pin / organic fade
+
+The base mechanism: while at least one consumer holds a `PinHandle`, the resource stays. When the last handle drops, the resource becomes a candidate for natural fade — no explicit evict() call needed.
+
+This is the **CBAR-inspired organic prioritization**: don't ask "what to evict," ask "what's still organically held." The system's current activity (active recipe, focused persona, in-flight request) creates the gradient. Resources gravitate toward active concerns and naturally fall away from inactive ones.
+
+Mapping in current code:
+- Recipe starts → pins identity + tool defs + KV prefix + voice LoRA
+- Persona engages on a turn → pins active genome adapter
+- Conversation continues → KV prefix stays pinned (live slot)
+- Recipe ends / persona goes dormant → handles drop, ref-count → 0
+
+The pool's eviction policy becomes a *fallback* for when even the actively-pinned set exceeds capacity, not the primary mechanism. RAII semantics + biological-attention semantics + CBAR semantics — same architectural shape.
+
+### 2. Time-share with priority
+
+Pin is exclusivity ("nobody else uses this until I'm done"). Time-share is fluid ("we all share, scheduled by priority").
+
+For KV pages, model weights, LoRA adapters, MoE experts: multiple consumers want them, often the SAME ones (14 personas with the same tool-defs prefix, 4 personas using the same `typescript-expertise` LoRA, all of them pulling from the same model weights). Pinning each exclusively wastes memory and serializes access. Time-sharing lets one copy serve everyone, with a scheduler arbitrating turn order.
+
+`InferenceCoordinator.requestSlot` (PR #921) is the seed: doesn't deny, queues by arrival. Adding priority weight is the next step:
+
+```
+Active speaker in video call    → priority 100
+Recently-spoke persona          → priority 50
+Listening only                  → priority 10
+```
+
+When a slot frees, queue serves highest-priority first. Everyone shares the same pool; scheduler decides order. CPU L1 cache works this way; vllm-metal's PagedAttention works this way.
+
+`pin()` becomes the special case (priority = ∞), used only for resources that genuinely can't be reconstructed mid-flight.
+
+### 3. Tiered demotion (compress, don't drop)
+
+Eviction is binary: keep or drop. The richer pattern is **demote to a smaller representation under pressure**. Same content, less memory.
+
+Examples:
+- **KV cache compression**: recent KV at FP16, older at INT8, oldest at INT4. Hit on quantized: dequantize on the fly OR re-promote to full precision when room allows.
+- **Embedding precision**: recent as `Float32Array`, older quantized to `Int8Array`. 4× memory savings, slight semantic precision loss.
+- **Memory recall (already!)**: TieredMemoryCache L1/L2/L3 IS this pattern. Recent thoughts at full fidelity, older summarized to gist. Biologically right — that's how human memory consolidates.
+- **Model weights**: full precision while actively generating, quantized when idle but next-likely-used.
+
+Architecturally this is **composition over multiple pools**, not a feature of the primitive:
+
+```
+EmbeddingL1Pool<Hash, Float32Array>   max=128MB  (recent)
+EmbeddingL2Pool<Hash, Int8Array>      max=32MB   (demoted: quantized on demotion)
+EmbeddingL3Pool<Hash, FilePath>       max=10GB   (spilled to disk)
+
+L1 eviction: don't drop, demote to L2 (call quantizer, insert there)
+L2 eviction: don't drop, demote to L3 (write to disk, insert there)
+L3 eviction: drop (or write to slower archive)
+On hit at L2/L3: optionally promote upward
+```
+
+The primitive stays simple; tiering composes. CPU L1/L2/L3 cache works this way. OS page-out-to-disk works this way (kernel handles the actual paging). For our L3 we can `mmap` files so the kernel becomes the L4 manager automatically.
+
+### 4. Intelligent (eventually ML/LLM-driven) priority
+
+The pool exposes the levers; the brain plugs in via the PressureBroker (Phase 7).
+
+Today the eviction priority callback supports heuristics: `lru_priority`, `size_weighted_lru`. The ladder of "smarter":
+
+1. **Cost-aware** — entries declare `refetch_cost_ms`; eviction priority = `recency × cost`. A 4 GB model weight costs 6 s to reload; a 384-dim embedding costs 2 ms. Cheap-to-rebuild evicts before expensive.
+2. **Recipe / activity-aware** — active recipe declares its needs; those resources are *implicitly pinned* during recipe lifetime even without explicit `pin()` calls. Domain knowledge over access patterns.
+3. **Online-learning bandit** — TinyLFU / ARC / W-TinyLFU adaptive replacement. Track "I evicted X then needed it back within 60s" events; adjust per-pool priority weights to reduce regret.
+4. **LLM-mediated broker** — when the system is in an unusual state (4 personas + research recipe + voice + indexing all under pressure), heuristics fail. Ask an LLM at *policy adjustment* tick (every minute or two): "given these stats + this activity pattern, what would you evict?" The LLM doesn't run per-eviction (too slow); it updates the cost weights / priority functions that the per-eviction heuristic uses. Apple's RTOS-with-ML approach generalized to LLM mediation.
+
+The primitive's design point is *exposing levers* (pluggable eviction, rich stats, public pin/evict, per-pool budget, function-based sizer) so this intelligence layer can plug in cleanly when ready.
+
+---
+
+## The persona dormancy ladder
+
+Pressure response should degrade gracefully — never silence individuals. The plurality principle: 6 personas at lower fidelity > 1 persona at full fidelity.
+
+```
+Active        — normal behavior, all senses, all RAG sources, full max_tokens
+Less-active   — fewer turns, lighter RAG, lower max_tokens (DEFAULT pressure response)
+Dormant       — KV prefix stays in slot, persona doesn't fire response loop (worst case while alive)
+Evicted       — slot reclaimed, persona unloaded entirely (last resort, ~6s reload cost)
+```
+
+**Critical: dormant ≠ evicted.** Dormant persona keeps KV prefix resident, voice LoRA loaded, identity warm — wakes back up instantly when pressure clears. Evicted means full reload. The broker walks down this ladder as pressure climbs; it doesn't jump to evict.
+
+Mapping in current modules:
+- `PersonaState` (autonomous loop tracks energy/mood) — same metaphor, add `forcedState: 'less-active' | 'dormant'` from broker
+- `PagedResourcePool.pin()` — broker pins active-recipe resources, unpins for dormant
+- `InferenceCoordinator` queue (PR #921) — broker adjusts per-persona priority instead of denying outright
+
+Video call example with 14 personas under pressure:
+- Active speaker: full active, KV pinned, full RAG
+- Recently-spoke: less-active, KV pinned but response probability lowered, lighter RAG
+- Listening only: dormant, KV stays warm but response loop skipped
+- Off-screen avatar: still rendered (Bevy entity persists), but inference slot evicted (avatar doesn't need full inference state when not speaking)
+
+Plurality preserved (everyone visible, no one disappears). Compute follows attention.
+
+---
+
+## The PressureBroker (Phase 7)
+
+The PagedResourcePool primitive is the per-resource brain. The PressureBroker is the cross-resource brain — one orchestrator that:
+
+1. **Reads pressure** from every registered pool (`pool.stats().pressure`)
+2. **Reads activity** from PersonaState, recipe activations, in-flight requests
+3. **Decides priorities** — what each consumer gets, what tier it lands in, what dormancy state each persona enters
+4. **Pulls levers** — calls `pool.evict(k)` surgically, sets `forcedState` on personas, reshapes per-pool budgets dynamically
+
+This is where the ML/LLM control plugs in. The broker can start as a hand-tuned heuristic (Phase 7a) and evolve to ML-policy (7b) and LLM-mediated (7c) without changing the pool API.
+
+**The broker is also the single source of "what should happen next under pressure"** — eliminates the need for each consumer to interpret pressure independently. Today every layer has its own pressure interpretation; that's the drift bug across implementations.
+
+---
+
+## Mapping to existing modules
+
+This architecture is what the work tonight is building toward. Inventory:
+
+| Module | Status | Architecture role |
+|---|---|---|
+| `PagedResourcePool<K, V>` (Rust) | **PR #930 — open** | Foundation primitive |
+| `InferenceCoordinator` queue | PR #921 — merged | Time-share with FIFO; adds priority later |
+| `PersonaState` (energy/mood) | Existing | Persona dormancy ladder consumer |
+| `TieredMemoryCache` (TS) | Existing | Tiered demotion exemplar; will reformulate as Rust pool |
+| `VisionDescriptionCache` | Existing | Content-addressed paging exemplar |
+| `GenomeRegistry` (LoRA) | Existing | Will adopt LoRAAdapterPool migration |
+| `RustEmbeddingClient` | Existing | Will adopt EmbeddingPool migration; fixes 0/64 hits |
+| `GpuMemoryManager` | Existing | Provides GPU pressure signal to broker |
+| `ResourcePressureWatcher` | Existing | Provides RAM/CPU pressure signal to broker |
+| **PressureBroker** | **Phase 7 — not started** | Cross-resource orchestrator |
+| `LiveCallTracker` etc. | Existing | Exclusive stateful lifecycle (correctly outside paging architecture) |
+
+---
+
+## The ladder of work
+
+### Phase 1 (PR #930) — Foundation
+Rust `PagedResourcePool<K, V>` with:
+- Lock-free reads via per-entry atomics
+- Single-flight via `futures::Shared`
+- Reference-counted PinHandle with Drop release
+- Pluggable eviction priority + sizer functions
+- Rich stats() snapshot for broker queries
+- 8 unit tests covering correctness invariants
+
+### Phase 2 — EmbeddingCache migration
+Wrap pool with `<ContentHash, Vec<f32>>`. Replace `RustEmbeddingClient`'s ad-hoc Map. Fixes the `0/64 hits` we observed. Sub-day work.
+
+### Phase 3 — LoRAAdapterPool migration
+Wrap pool with `<AdapterId, LoadedAdapter>`. `GenomeRegistry` becomes a thin wrapper that pins adapters per active task. Adapter unload on `Drop` frees GPU memory. Few-day work.
+
+### Phase 4 — KV cache (the big user-visible win)
+Route chat through vllm-metal (memento's PR #925 install) — vllm uses PagedAttention natively. For the GGUF/llama.cpp fallback path: thin wrapper exposes its slot reservation as `PoolStats` so broker is *aware* of it. Real benefit requires forging Qwen3.5 to MLX format so we get PagedAttention without losing forging — that's a forge-pipeline addition.
+
+### Phase 5 — Tiered demotion (compose pools)
+Add L2 quantized embedding pool. Add L3 disk-spill pool. Demotion path on L1 eviction. Promotion on L2/L3 hit. Same composition pattern usable for any shareable resource.
+
+### Phase 6 — Persona dormancy ladder
+Wire `forcedState` from broker into `PersonaState`. Less-active reduces RAG sources + max_tokens. Dormant skips response loop while keeping KV pinned. Evicted reclaims slot.
+
+### Phase 7 — PressureBroker
+Cross-pool eviction orchestration + priority arbitration + dormancy decisions. Heuristic first, ML/LLM later via the levers the pool exposes.
+
+### Phase 8 — MoE forge + MoEExpertPool
+When MoE-forged Qwen3.5-A8B-MoE lands: `<ExpertId, ExpertWeights>` pool. Router pins active experts per token. Enables 32B-MoE intelligence on 16 GB MacBook Air.
+
+### Phase 9 — Recipe-declared resource needs
+Recipes formally declare their resource holds: "chat needs KV ≤16k, identity, recent history, 5 contextual tools." "Codereview needs KV ≤64k, identity, history, code-search, code-edit, code-read." Broker grants on activation, releases on deactivation. Replaces ad-hoc isApplicable + budget percentages with declarative resource manifests.
+
+---
+
+## Why this matters strategically
+
+The architecture's promise: **total intelligence ≫ resident footprint, on every machine class.**
+
+A 16 GB MacBook Air running a forged 32B-MoE persona where:
+- Only the active MoE expert is hot in the expert pool
+- The active LoRA is shared across all personas using that skill
+- KV is paged per-token by vllm-metal
+- Memory recalls instantly from L1, deeper recall available on demand
+- Embeddings hit the cache (fixing the current 0/64 miss rate)
+- Model weights are loaded once and serve every persona
+- Bevy avatars render with one shared skeleton + per-persona texture instancing
+
+…serves a teacher-tier intelligence experience. Same hardware that today struggles with a static 4B model.
+
+The drift between hand-rolled implementations is what's preventing this today. Unifying it isn't an optimization; it's the foundation that lets every other speedup compound coherently. The primitive shipped in #930 is the foundation. The wins arrive as consumers migrate.
+
+By exposing the levers cleanly — pluggable eviction, rich stats, priority-aware request, tiered composition, broker-mediated dormancy — we leave room for the system itself (eventually ML/LLM in the broker) to manage its own resources. Apple's RTOS-with-ML pattern generalized: the *system* learns to use itself well, on every device class, without brittle hand-tuned thresholds.
+
+---
+
+## What this doc isn't
+
+- **Not a code spec.** Implementation lives in [`UNIFIED-PAGING.md`](UNIFIED-PAGING.md) and the source.
+- **Not a migration commitment for any specific timeline.** Each phase is sized to be small enough that an interrupt doesn't ruin it.
+- **Not the final word on intelligence.** The ML/LLM control pieces are sketched; the actual training / prompt design lives in future work when we have data.
+- **Not exhaustive.** The exclusive-stateful category (mic, LiveKit, Bevy entities) is named here but lives under existing lifecycle patterns; it deserves its own doc when we touch that surface meaningfully.
+
+---
+
+## Provenance
+
+Architectural insights captured in this doc came out of an extended conversation between Joel and the Claude assistants during the inference-perf branch session of 2026-04-17 / -18. Key framings:
+
+- *"paging is our general strategy in this system anyway / and with moe / all over really / so we can get away with massive work on tiny systems"* — the unified principle
+- *"like my cbar / its not an eviction system / it just prioritizes / by its own organic needs"* — organic prioritization framing
+- *"more of a time share you know? where share is prioritized"* — time-share with priority framing
+- *"some things must be torn down / hopefully i am not overcomplicating"* — the two-category clarity
+- *"intelligent control, non brittle algs, like how apple build their rtos using ml / and probably LLMS now / you just make sure to expose the levers"* — the ML/LLM control trajectory and the levers requirement
+- *"we are rust first unless inappropriate / period"* — language choice for the foundation

--- a/docs/architecture/RESOURCE-ARCHITECTURE.md
+++ b/docs/architecture/RESOURCE-ARCHITECTURE.md
@@ -188,6 +188,13 @@ Existing inference engines already do crude versions: llama.cpp's `--n-gpu-layer
 
 When this lands fully, the answer to "can my MacBook Air run a 70B MoE?" becomes "yes, slower than VRAM-resident, but yes — and the broker decides per-request whether the slowdown is acceptable for what you're doing." Hardware ceiling becomes negotiable rather than fixed. That's the working-smarter-not-harder pattern at its limit: the system literally exceeds its own apparent capacity because it knows how to stream the constituent parts.
 
+**This is the same insight as sentinel-ai forge alloy expert pruning, but inverted.** The forge identifies which experts in a model are statically removable — ship a permanently smaller model. Compositional paging is the runtime mirror: instead of removing experts permanently, page them in and out *dynamically* based on actual demand. The two compose:
+
+- Forge identifies experts that are *always cold* across observed workloads → prune them entirely (static reduction)
+- Remaining experts get compositional paging at runtime (dynamic reduction)
+
+Same architectural insight from opposite directions. The forge proves the fingerprint of what's actually used; compositional paging extends that proof from "permanently shippable smaller" to "dynamically runnable bigger than fits." The combination: ship as small as the forge proves is safe, then stream the rest on demand for the workloads that occasionally need them. Best-of-both: minimal disk footprint AND maximum model class reachable.
+
 ### 4. Intelligent (eventually ML/LLM-driven) priority
 
 The pool exposes the levers; the brain plugs in via the PressureBroker (Phase 7).

--- a/docs/architecture/UNIFIED-PAGING.md
+++ b/docs/architecture/UNIFIED-PAGING.md
@@ -1,8 +1,10 @@
-# Unified Paging Architecture
+# Unified Paging Architecture (Rust)
 
-> **One primitive. Every layer that pages uses it.** LoRA adapters, KV cache, MoE experts, model weights, embeddings, recalled memories — all instances of the same pattern. The drift between hand-rolled paging implementations IS the bug; extract the shared shape and the system gains coherence at every layer.
+> **One Rust primitive. Every layer that pages uses it. Levers exposed for intelligent (eventually ML-driven) resource control.** LoRA adapters, KV cache, MoE experts, model weights, embeddings, recalled memories — all instances of the same pattern. The drift between hand-rolled paging implementations IS the bug; extract the shared shape and the system gains coherence at every layer.
 
-Status: design — 2026-04-18. Authored after a session where the persona path stalled because llama.cpp's per-slot KV reservation (262144 tokens × N personas) blew through 32 GB of RAM, while LoRA paging (genome registry), memory recall (TieredMemoryCache), and vision-cache dedup all implemented their own version of the same primitive — none aware of each other.
+Status: design — 2026-04-18. Authored after the persona path stalled tonight because llama.cpp's per-slot KV reservation (262144 tokens × N personas) blew through 32 GB of RAM, while LoRA paging (genome registry), memory recall (TieredMemoryCache), and vision-cache dedup all implemented their own version of the same primitive — none aware of each other.
+
+The primitive lives in **Rust** (`continuum-core`), per Joel's Rust-first rule. The actual paged resources (LoRA weights, KV cache, MoE experts, model handles, embeddings) all live in Rust memory; the pool managing them belongs where they live. Performance and concurrency demand it: paging is on the hot path for every chat turn, and the parallel persona case needs lock-free reads.
 
 ---
 
@@ -17,83 +19,116 @@ The system already pages at every layer where it matters:
 - **KV cache (PagedAttention via vllm-metal)** — page in by token allocation
 - **MoE experts** — page in by router decision (when MoE forge ships)
 - **Vision description cache** — content-addressed dedup
-- **Embedding cache** — should be content-addressed dedup but isn't (0/64 hit rate observed)
+- **Embedding cache** — should be content-addressed but isn't (0/64 hit rate observed)
 - **Model weights** — DMR loads once per model, all personas share
 
-All of them implement *some* version of: load on demand, dedup in flight, reference-count to keep alive, evict under pressure. The implementations drifted. Each consumer has its own pressure interpretation, eviction policy, hit/miss counter, single-flight handling. **The drift is the bug.** When pressure rises in one pool the others don't know; when the same content arrives in two pools both cache it twice; when a consumer needs to pin a resource across pools it has to do it N different ways.
+All of them implement *some* version of: load on demand, dedup in flight, reference-count to keep alive, evict under pressure. The implementations drifted. **The drift is the bug.** When pressure rises in one pool the others don't know; identical content gets cached twice; consumers needing to pin across pools do it N different ways.
 
-The fix: one primitive — `PagedResourcePool<TKey, TValue>` — that all pageable resources adopt. Plus a `PressureBroker` that reads pressure from each pool and orchestrates eviction holistically.
+The fix: one primitive — `PagedResourcePool<K, V>` — that all pageable resources adopt. Plus a `PressureBroker` (separate module, follow-up) that reads pressure from each pool and orchestrates eviction holistically. Eventually the broker becomes ML-driven (Apple's RTOS-with-ML approach, possibly LLM-mediated for high-level decisions).
 
 ---
 
-## The primitive
+## The primitive (Rust)
 
-`src/system/core/paging/PagedResourcePool.ts` (this PR) — a generic resource pool with the operations every paging layer needs:
+`src/workers/continuum-core/src/paging/pool.rs` — generic resource pool with the operations every paging layer needs:
 
-```typescript
-class PagedResourcePool<TKey, TValue> {
-  get(key): TValue | null                       // L1 hit, no load
-  loadOrShare(key): Promise<TValue>             // single-flight load
-  pin(key): ResourceHandle | null               // ref-counted hold
-  evict(key): boolean                           // forced drop
-  stats(): PoolStats                            // pressure, hit rate, count
+```rust
+pub struct PagedResourcePool<K, V> { /* ... */ }
+
+impl<K, V> PagedResourcePool<K, V>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    pub fn new(config: PoolConfig<V>) -> Self;
+    pub fn get(&self, key: &K) -> Option<V>;        // L1 hit, no load
+    pub async fn load_or_share<F, Fut>(&self, key: K, loader: F)
+        -> Result<V, String>;                       // single-flight load
+    pub fn pin(&self, key: &K) -> Option<PinHandle<K, V>>;
+    pub fn insert(&self, key: K, value: V);         // for content-hash pools
+    pub fn evict(&self, key: &K) -> bool;
+    pub async fn stats(&self) -> PoolStats;
 }
 ```
 
-Construction is intentionally explicit (no Option<>, every choice declared):
+Construction is intentionally explicit (no `Option<>`, every choice declared per Joel's required-not-optional discipline):
 
-```typescript
-new PagedResourcePool({
-  name: 'lora-adapters',
-  maxBytes: 4 * 1024 * 1024 * 1024,           // 4 GB pool
-  sizer: (adapter) => adapter.weights.byteLength,
-  evictionPriority: sizeWeightedLruPriority(),
-  loader: async (id) => loadAdapterFromDisk(id),
+```rust
+let pool = PagedResourcePool::new(PoolConfig {
+    name: "lora-adapters".to_string(),
+    max_bytes: 4 * 1024 * 1024 * 1024,    // 4 GB
+    sizer: Arc::new(|adapter| adapter.byte_size),
+    eviction_priority: size_weighted_lru(),
 });
 ```
 
 ### Properties
 
-- **Single-flight** — concurrent `loadOrShare(k)` for the same key share ONE loader invocation. Eliminates the duplicate-work race that today causes 14 personas to each fetch the same memory recall.
-- **Reference-counted pin** — `pin(k)` returns a handle. While at least one handle is alive, eviction skips the entry. When the last handle releases, the entry becomes evictable (not immediately evicted — eviction is pressure-driven).
-- **Pressure-driven eviction** — `maybeEvict()` triggers when occupancy exceeds `maxBytes`, drops unpinned entries in `evictionPriority` order until back to 75% of capacity.
-- **Reject-promise-cleanup** — `inflight.delete(k)` runs in `.finally`, so a rejected loader doesn't poison the cache slot for future attempts.
-- **Eviction policies as functions** — `lruPriority`, `sizeWeightedLruPriority` provided; consumers supply custom policies (e.g., MoE expert pool might prioritize by recent router score; KV pool by prefix match potential).
+- **Lock-free reads on the hot path** — `get()` runs under `RwLock::read()`. Per-entry atomics (`AtomicU64` for `last_access_at`, `access_count`; `AtomicU32` for `pin_count`) update without serializing. Concurrent personas hit the cache in parallel.
+- **Single-flight via `futures::future::Shared`** — concurrent `load_or_share()` for the same key share ONE loader invocation. Eliminates the duplicate-work race that today causes 14 personas to each fetch the same memory recall.
+- **Reference-counted pin** — `pin(key)` returns a `PinHandle`. While at least one handle is alive, eviction skips the entry. Drop releases automatically.
+- **Pressure-driven eviction** — `maybe_evict()` triggers when occupancy exceeds `max_bytes`, drops unpinned entries in `eviction_priority` order until back to 75% of capacity. Between firings, occupancy can sit anywhere `≤ max_bytes`.
+- **Reject-promise cleanup** — failed loads don't poison the cache slot; the inflight slot is removed on both `Ok` and `Err`. (The exact bug we hit on `CodebaseIndexer.queryCacheLoad` earlier today.)
+- **Atomic counters** — `hits`, `misses`, `evictions` are `AtomicU64`. No mutex contention on stat updates.
+
+### Levers exposed (for the future PressureBroker / ML-driven control)
+
+The primitive's design point is *exposing levers* so an intelligent control layer can drive the system without rewriting the pools:
+
+- **`eviction_priority` is a function** — pluggable per-pool strategy. Defaults: `lru_priority`, `size_weighted_lru`. A future broker can install custom policies (e.g., MoE experts prioritized by recent router score; KV cache by prefix-match potential; LoRA adapters by recent-task fitness).
+- **`stats()` is rich** — pressure ratio, hit/miss counters, eviction counter, in-flight count, pinned vs unpinned count. Sufficient input for an ML model to predict pressure trajectory.
+- **`pin()` / `evict()` are public** — the broker can pin proactively (warm a recipe's adapters), evict surgically (drop a low-priority pool entry without waiting for natural pressure).
+- **Per-pool budget (`max_bytes`)** — the broker can dynamically reshape budgets across pools (more KV when fewer LoRAs are active; more model weights when batch sizes are high).
+- **Sizer is a function** — consumers can supply weighted sizing (e.g., GPU bytes count more than CPU bytes; quantized weights count differently than full-precision).
+
+### Test coverage (8 passing)
+
+```
+get_returns_none_on_miss_and_value_on_hit
+load_or_share_dedups_concurrent_loads          // 3 callers → 1 loader invocation
+pin_prevents_eviction_under_pressure
+maybe_evict_keeps_total_within_max_bytes
+eviction_drops_to_target_when_far_over          // single big insert → 75% target
+dropped_pin_handle_releases_ref_count
+failed_load_does_not_poison_cache               // critical correctness invariant
+stats_pressure_tracks_occupancy
+```
 
 ### What's NOT in the primitive (intentionally)
 
-- **Distributed coherency** across machines. The pool is single-node. Grid-level paging is a separate layer that uses this as a building block.
+- **Distributed coherency across machines.** The pool is single-node. Grid-level paging is a separate layer that uses this as a building block.
 - **Persistence to disk on eviction.** Pools are in-memory caches. If a consumer wants L2 disk persistence (TieredMemoryCache's L2/L3 do this), it composes two pools or uses the loader to read from disk.
-- **Async eviction.** Eviction is synchronous in `maybeEvict`. Heavy values that need async cleanup (e.g., free GPU memory) should make their `value` an object with an `unload()` method called on eviction (future hook).
+- **Async eviction.** Eviction is synchronous in `maybe_evict`. Heavy values that need async cleanup (e.g., free GPU memory) should put the cleanup in `Drop` for `V` or pre-arrange via the loader's contract.
 
 ---
 
 ## Migration plan
 
-This PR adds the primitive. Subsequent PRs migrate consumers one at a time. Each migration is small and isolated.
+This commit adds the primitive. Subsequent commits migrate consumers one at a time. Each migration is small and isolated.
 
-### Phase 1 (this PR)
-- Add `PagedResourcePool<TKey, TValue>` + `PressureBroker` interface placeholder
+### Phase 1 (this commit)
+- Add `PagedResourcePool<K, V>` in `continuum-core/src/paging/`
+- 8 unit tests covering hot paths and correctness invariants
 - Design doc (this file)
 - Zero behavior change to existing code
 
-### Phase 2 — embedding cache
-- `EmbeddingCache extends PagedResourcePool<ContentHash, Float32Array>`
-- Fixes the observed 0/64 hit rate on `CodebaseIndexer` re-runs
-- Replaces ad-hoc `Map` cache in `RustEmbeddingClient`
+### Phase 2 — embedding cache (`EmbeddingCache`)
+- Wrap `PagedResourcePool<ContentHash, Vec<f32>>`
+- Replace ad-hoc `Map` cache in `RustEmbeddingClient`
+- Fixes the observed `0/64` hit rate on `CodebaseIndexer` re-runs
 
-### Phase 3 — LoRA / genome adapters
-- `LoRAAdapterPool extends PagedResourcePool<AdapterId, LoadedAdapter>`
+### Phase 3 — LoRA / genome adapters (`LoRAAdapterPool`)
+- Wrap `PagedResourcePool<AdapterId, LoadedAdapter>`
 - `GenomeRegistry` becomes a thin wrapper that pins adapters per active task
-- Adapter unload on eviction frees GPU memory
+- Adapter unload on `Drop` for `LoadedAdapter` frees GPU memory
 
 ### Phase 4 — KV cache (the immediate user-visible win)
-- Route chat through vllm-metal (memento's #925 install) — vllm uses PagedAttention natively, which IS the unified paging at the inference layer
-- For the GGUF/llama.cpp fallback path, expose a `KVCachePool` wrapper that surfaces llama.cpp's slot reservation as pool stats so the broker can see it
-- Forge MLX-format Qwen3.5 so we get PagedAttention without losing forging benefits
+- Route chat through vllm-metal (memento's #925 install) — vllm uses PagedAttention natively, which IS unified paging at the inference layer
+- For the GGUF/llama.cpp fallback path: thin Rust wrapper exposes llama.cpp's slot reservation as `PoolStats` so the broker can see it
+- Forge MLX-format Qwen3.5 (forge-pipeline addition) so we get PagedAttention without losing forging benefits
 
-### Phase 5 — MoE experts
-- When MoE-forged Qwen3.5-A8B-MoE lands: `MoEExpertPool extends PagedResourcePool<ExpertId, ExpertWeights>`
+### Phase 5 — MoE experts (`MoEExpertPool`)
+- When MoE-forged Qwen3.5-A8B-MoE lands: `PagedResourcePool<ExpertId, ExpertWeights>`
 - Router pins active experts per token; pool evicts cold experts under pressure
 - Enables 32B-MoE intelligence on 16 GB MacBook Air
 
@@ -102,11 +137,12 @@ This PR adds the primitive. Subsequent PRs migrate consumers one at a time. Each
 - L1 cache becomes the pool itself; L2/L3 become loaders that compose
 - Stale-while-revalidate becomes a generic helper on top of the pool
 
-### Phase 7 — PressureBroker
+### Phase 7 — PressureBroker (and the ML lever-pulling)
 - Cross-pool eviction orchestration
-- Reads `stats().pressure` from each registered pool
-- When global memory pressure rises, calls `evict()` on the pools with highest priority for shedding (MoE experts before pinned LoRAs, etc.)
+- Reads `stats().pressure` from each registered pool via IPC
+- When global memory pressure rises, calls `evict()` on the pools with highest priority for shedding
 - Same broker that gates inference admission and persona slot allocation
+- **The ML/LLM control layer plugs in here**: trained model OR LLM consumes the rich stats stream, predicts pressure trajectory, decides eviction policy. Apple's RTOS-with-ML approach, but with the option of LLM-mediated high-level decisions for novel situations.
 
 ---
 
@@ -114,27 +150,28 @@ This PR adds the primitive. Subsequent PRs migrate consumers one at a time. Each
 
 Paging at every layer is what lets a small machine serve large intelligence:
 
-| Layer | Paging strategy | Effect |
+| Layer | Strategy | Effect |
 |---|---|---|
-| Model weights | Load once, share across all personas | Same model, N consumers, 1 copy in memory |
-| KV cache | PagedAttention | Dynamic per-token allocation, no per-slot reservation |
-| LoRA adapters | Genome registry, ref-counted | 14 personas using "typescript-expertise" hold ONE copy |
-| MoE experts | Router-driven activation | 32B params on disk, 8B hot per token |
-| Memory | Tiered L1/L2/L3 recall | Recent thoughts instant, deep history on demand |
-| Embeddings | Content-addressed dedup | Same text → same vector, never recomputed |
+| Model weights | Load once, share | N consumers, 1 copy |
+| KV cache | PagedAttention | Per-token allocation, no reservation |
+| LoRA adapters | Ref-counted | 14 personas using same skill, 1 copy |
+| MoE experts | Router-driven | 32B params on disk, 8B hot per token |
+| Memory | Tiered L1/L2/L3 | Recent instant, deep on demand |
+| Embeddings | Content-addressed | Same text → same vector, never recomputed |
 
-Combined: a MacBook Air with 16 GB unified memory can run a forged 32B-MoE persona where only the active expert is hot, the active LoRA is shared, the KV is paged per-token, and memory recalls instantly from L1 with deeper recall in the background. **Total intelligence ≫ resident footprint, on every machine class.** That's the architectural promise — uniformly delivered by one primitive.
+Combined: a 16 GB MacBook Air running a forged 32B-MoE persona where only the active expert is hot, the active LoRA is shared, KV is paged per-token, memory recalls instantly. **Total intelligence ≫ resident footprint, on every machine class.**
 
-The drift between hand-rolled implementations IS what's preventing this today. Unifying it isn't an optimization; it's the foundation that lets every other speedup compound coherently.
+The drift between hand-rolled implementations is what's preventing this today. Unifying it isn't an optimization; it's the foundation that lets every other speedup compound coherently. And by exposing the levers cleanly, we leave room for the system itself (eventually with ML/LLM in the broker) to manage its own resources rather than relying on brittle hand-tuned thresholds.
 
 ---
 
-## Acceptance for this PR
+## Acceptance for this commit
 
-- `src/system/core/paging/PagedResourcePool.ts` exists with the documented interface
-- `tsc` clean
+- `src/workers/continuum-core/src/paging/pool.rs` exists with the documented interface
+- `src/workers/continuum-core/src/paging/mod.rs` re-exports the public surface
+- `pub mod paging;` added to `lib.rs`
+- 8 unit tests pass; cargo check clean (61 dead-code warnings, no errors)
 - Zero behavior change to existing code (additive only — no consumer migrated yet)
 - Design doc in `docs/architecture/UNIFIED-PAGING.md`
-- Follow-up issues filed for each migration phase
 
 The primitive is the foundation. The wins arrive as consumers migrate.

--- a/docs/architecture/UNIFIED-PAGING.md
+++ b/docs/architecture/UNIFIED-PAGING.md
@@ -1,0 +1,140 @@
+# Unified Paging Architecture
+
+> **One primitive. Every layer that pages uses it.** LoRA adapters, KV cache, MoE experts, model weights, embeddings, recalled memories — all instances of the same pattern. The drift between hand-rolled paging implementations IS the bug; extract the shared shape and the system gains coherence at every layer.
+
+Status: design — 2026-04-18. Authored after a session where the persona path stalled because llama.cpp's per-slot KV reservation (262144 tokens × N personas) blew through 32 GB of RAM, while LoRA paging (genome registry), memory recall (TieredMemoryCache), and vision-cache dedup all implemented their own version of the same primitive — none aware of each other.
+
+---
+
+## The thesis
+
+The system already pages at every layer where it matters:
+
+- **LoRA / genome adapters** — page in by skill domain demand, evict LRU
+- **Persona slots** — page in by activity, page out under pressure (Phase 2/3 design)
+- **Memory recall (TieredMemoryCache)** — L1/L2/L3 stale-while-revalidate
+- **Sentinel skills** — page in by task
+- **KV cache (PagedAttention via vllm-metal)** — page in by token allocation
+- **MoE experts** — page in by router decision (when MoE forge ships)
+- **Vision description cache** — content-addressed dedup
+- **Embedding cache** — should be content-addressed dedup but isn't (0/64 hit rate observed)
+- **Model weights** — DMR loads once per model, all personas share
+
+All of them implement *some* version of: load on demand, dedup in flight, reference-count to keep alive, evict under pressure. The implementations drifted. Each consumer has its own pressure interpretation, eviction policy, hit/miss counter, single-flight handling. **The drift is the bug.** When pressure rises in one pool the others don't know; when the same content arrives in two pools both cache it twice; when a consumer needs to pin a resource across pools it has to do it N different ways.
+
+The fix: one primitive — `PagedResourcePool<TKey, TValue>` — that all pageable resources adopt. Plus a `PressureBroker` that reads pressure from each pool and orchestrates eviction holistically.
+
+---
+
+## The primitive
+
+`src/system/core/paging/PagedResourcePool.ts` (this PR) — a generic resource pool with the operations every paging layer needs:
+
+```typescript
+class PagedResourcePool<TKey, TValue> {
+  get(key): TValue | null                       // L1 hit, no load
+  loadOrShare(key): Promise<TValue>             // single-flight load
+  pin(key): ResourceHandle | null               // ref-counted hold
+  evict(key): boolean                           // forced drop
+  stats(): PoolStats                            // pressure, hit rate, count
+}
+```
+
+Construction is intentionally explicit (no Option<>, every choice declared):
+
+```typescript
+new PagedResourcePool({
+  name: 'lora-adapters',
+  maxBytes: 4 * 1024 * 1024 * 1024,           // 4 GB pool
+  sizer: (adapter) => adapter.weights.byteLength,
+  evictionPriority: sizeWeightedLruPriority(),
+  loader: async (id) => loadAdapterFromDisk(id),
+});
+```
+
+### Properties
+
+- **Single-flight** — concurrent `loadOrShare(k)` for the same key share ONE loader invocation. Eliminates the duplicate-work race that today causes 14 personas to each fetch the same memory recall.
+- **Reference-counted pin** — `pin(k)` returns a handle. While at least one handle is alive, eviction skips the entry. When the last handle releases, the entry becomes evictable (not immediately evicted — eviction is pressure-driven).
+- **Pressure-driven eviction** — `maybeEvict()` triggers when occupancy exceeds `maxBytes`, drops unpinned entries in `evictionPriority` order until back to 75% of capacity.
+- **Reject-promise-cleanup** — `inflight.delete(k)` runs in `.finally`, so a rejected loader doesn't poison the cache slot for future attempts.
+- **Eviction policies as functions** — `lruPriority`, `sizeWeightedLruPriority` provided; consumers supply custom policies (e.g., MoE expert pool might prioritize by recent router score; KV pool by prefix match potential).
+
+### What's NOT in the primitive (intentionally)
+
+- **Distributed coherency** across machines. The pool is single-node. Grid-level paging is a separate layer that uses this as a building block.
+- **Persistence to disk on eviction.** Pools are in-memory caches. If a consumer wants L2 disk persistence (TieredMemoryCache's L2/L3 do this), it composes two pools or uses the loader to read from disk.
+- **Async eviction.** Eviction is synchronous in `maybeEvict`. Heavy values that need async cleanup (e.g., free GPU memory) should make their `value` an object with an `unload()` method called on eviction (future hook).
+
+---
+
+## Migration plan
+
+This PR adds the primitive. Subsequent PRs migrate consumers one at a time. Each migration is small and isolated.
+
+### Phase 1 (this PR)
+- Add `PagedResourcePool<TKey, TValue>` + `PressureBroker` interface placeholder
+- Design doc (this file)
+- Zero behavior change to existing code
+
+### Phase 2 — embedding cache
+- `EmbeddingCache extends PagedResourcePool<ContentHash, Float32Array>`
+- Fixes the observed 0/64 hit rate on `CodebaseIndexer` re-runs
+- Replaces ad-hoc `Map` cache in `RustEmbeddingClient`
+
+### Phase 3 — LoRA / genome adapters
+- `LoRAAdapterPool extends PagedResourcePool<AdapterId, LoadedAdapter>`
+- `GenomeRegistry` becomes a thin wrapper that pins adapters per active task
+- Adapter unload on eviction frees GPU memory
+
+### Phase 4 — KV cache (the immediate user-visible win)
+- Route chat through vllm-metal (memento's #925 install) — vllm uses PagedAttention natively, which IS the unified paging at the inference layer
+- For the GGUF/llama.cpp fallback path, expose a `KVCachePool` wrapper that surfaces llama.cpp's slot reservation as pool stats so the broker can see it
+- Forge MLX-format Qwen3.5 so we get PagedAttention without losing forging benefits
+
+### Phase 5 — MoE experts
+- When MoE-forged Qwen3.5-A8B-MoE lands: `MoEExpertPool extends PagedResourcePool<ExpertId, ExpertWeights>`
+- Router pins active experts per token; pool evicts cold experts under pressure
+- Enables 32B-MoE intelligence on 16 GB MacBook Air
+
+### Phase 6 — TieredMemoryCache reformulation
+- TieredMemoryCache becomes an instance: `MemoryRecallPool` with multi-stage loader
+- L1 cache becomes the pool itself; L2/L3 become loaders that compose
+- Stale-while-revalidate becomes a generic helper on top of the pool
+
+### Phase 7 — PressureBroker
+- Cross-pool eviction orchestration
+- Reads `stats().pressure` from each registered pool
+- When global memory pressure rises, calls `evict()` on the pools with highest priority for shedding (MoE experts before pinned LoRAs, etc.)
+- Same broker that gates inference admission and persona slot allocation
+
+---
+
+## Why this matters strategically
+
+Paging at every layer is what lets a small machine serve large intelligence:
+
+| Layer | Paging strategy | Effect |
+|---|---|---|
+| Model weights | Load once, share across all personas | Same model, N consumers, 1 copy in memory |
+| KV cache | PagedAttention | Dynamic per-token allocation, no per-slot reservation |
+| LoRA adapters | Genome registry, ref-counted | 14 personas using "typescript-expertise" hold ONE copy |
+| MoE experts | Router-driven activation | 32B params on disk, 8B hot per token |
+| Memory | Tiered L1/L2/L3 recall | Recent thoughts instant, deep history on demand |
+| Embeddings | Content-addressed dedup | Same text → same vector, never recomputed |
+
+Combined: a MacBook Air with 16 GB unified memory can run a forged 32B-MoE persona where only the active expert is hot, the active LoRA is shared, the KV is paged per-token, and memory recalls instantly from L1 with deeper recall in the background. **Total intelligence ≫ resident footprint, on every machine class.** That's the architectural promise — uniformly delivered by one primitive.
+
+The drift between hand-rolled implementations IS what's preventing this today. Unifying it isn't an optimization; it's the foundation that lets every other speedup compound coherently.
+
+---
+
+## Acceptance for this PR
+
+- `src/system/core/paging/PagedResourcePool.ts` exists with the documented interface
+- `tsc` clean
+- Zero behavior change to existing code (additive only — no consumer migrated yet)
+- Design doc in `docs/architecture/UNIFIED-PAGING.md`
+- Follow-up issues filed for each migration phase
+
+The primitive is the foundation. The wins arrive as consumers migrate.

--- a/src/system/core/paging/PagedResourcePool.ts
+++ b/src/system/core/paging/PagedResourcePool.ts
@@ -1,0 +1,282 @@
+/**
+ * PagedResourcePool — the unified paging primitive for Continuum.
+ *
+ * The system already pages at multiple layers without sharing the pattern:
+ *   - LoRA / genome adapters (page in by skill domain demand)
+ *   - Persona slots (page in by activity / pressure)
+ *   - Memory recall (TieredMemoryCache: L1/L2/L3 stale-while-revalidate)
+ *   - Sentinel skills (page in by task)
+ *   - KV cache (PagedAttention does this in vllm-metal)
+ *   - MoE experts (page in by router decision)
+ *   - Vision description cache (content-addressed dedup)
+ *
+ * Each implements its own version of: load-on-demand, dedup-in-flight,
+ * reference-count to keep alive, evict-under-pressure. Drift between
+ * implementations is the bug — different consumers interpret pressure
+ * differently, evict differently, miss the cache differently.
+ *
+ * `PagedResourcePool<TKey, TValue>` extracts the common shape:
+ *
+ *   - **Single-flight load** — concurrent requests for the same key share
+ *     ONE in-flight promise. No duplicate work, no race.
+ *   - **Reference-counted pinning** — consumers pin a resource to keep it
+ *     resident. When the last reference drops, the resource becomes
+ *     evictable (not immediately evicted — eviction is pressure-driven).
+ *   - **Pressure-aware eviction** — the broker can request the pool drop
+ *     unpinned entries by some priority (LRU, size-weighted, custom).
+ *   - **Content-addressed reuse** — TKey can be a hash of content so
+ *     identical inputs return the cached value without recomputation.
+ *
+ * The same primitive serves:
+ *   `KVCachePool<PrefixHash, KVPages>` — vllm-metal handles internally;
+ *     a thin wrapper exposes its semantics through the same interface.
+ *   `LoRAAdapterPool<AdapterId, LoadedAdapter>` — genome registry adopts.
+ *   `EmbeddingCache<ContentHash, Vector>` — fixes the 0/64 hit-rate.
+ *   `ModelWeightsPool<ModelId, LoadedModel>` — DMR plus future direct loads.
+ *   `MemoryRecallPool<RoomId, RecalledMemories>` — TieredMemoryCache becomes
+ *     an instance with L1/L2/L3 loader chain.
+ *
+ * The `PressureBroker` (separate module) reads `pressure()` from each pool
+ * and orchestrates eviction across types — one brain managing the whole
+ * memory garden.
+ *
+ * See: docs/architecture/UNIFIED-PAGING.md for the full architectural
+ * picture and migration plan.
+ */
+
+/** A handle returned by `pin()`. Caller releases via `unpin()` (or `release()` on the handle).
+ * While at least one handle is active, the resource will not be evicted. */
+export interface ResourceHandle<TValue> {
+  readonly value: TValue;
+  release(): void;
+}
+
+/** Loader signature — invoked when the pool needs to materialize a missing key.
+ * Async by design: most resources (model weights, KV pages, embeddings,
+ * deep memory recall) load asynchronously. */
+export type ResourceLoader<TKey, TValue> = (key: TKey) => Promise<TValue>;
+
+/** Sizer signature — returns the byte cost (or arbitrary unit cost) of a value.
+ * Used by pressure calculations and size-weighted eviction. Pools can use
+ * a constant-1 sizer if size doesn't matter (LRU-only eviction). */
+export type ResourceSizer<TValue> = (value: TValue) => number;
+
+/** Eviction priority — lower = evict first. Pools use this to decide which
+ * unpinned entry to drop when pressure rises. Default: LRU (priority = -lastAccessTime). */
+export type EvictionPriority<TValue> = (entry: PoolEntry<TValue>) => number;
+
+/** Internal entry shape — exposed read-only via `entries()` for inspection
+ * and via `EvictionPriority` callbacks. */
+export interface PoolEntry<TValue> {
+  readonly value: TValue;
+  readonly sizeBytes: number;
+  readonly pinCount: number;
+  readonly loadedAt: number; // ms epoch
+  readonly lastAccessAt: number; // ms epoch
+  readonly accessCount: number;
+}
+
+/** Pool configuration — required so callers think about budget intentionally
+ * (per Joel: required not optional). Defaults are explicit values, not
+ * `Option<>` — sensible numbers that the pool consumer accepts on purpose. */
+export interface PagedResourcePoolConfig<TValue> {
+  /** Human-readable identifier — appears in pressure logs and metrics. */
+  readonly name: string;
+  /** Maximum total `sizer(value)` units the pool will hold before
+   * pressure forces eviction. Eviction targets dropping back to 75% of this. */
+  readonly maxBytes: number;
+  /** How big each value is. Default `() => 1` for count-based pools. */
+  readonly sizer: ResourceSizer<TValue>;
+  /** Eviction order callback. Default: LRU (oldest lastAccessAt evicted first). */
+  readonly evictionPriority: EvictionPriority<TValue>;
+  /** Loader to materialize missing keys. */
+  readonly loader: ResourceLoader<unknown, TValue>;
+}
+
+/** Statistics snapshot for monitoring + PressureBroker decisions. */
+export interface PoolStats {
+  readonly name: string;
+  readonly entryCount: number;
+  readonly pinnedCount: number;
+  readonly totalBytes: number;
+  readonly maxBytes: number;
+  readonly pressure: number; // 0..1; ratio of usage to capacity
+  readonly hitCount: number;
+  readonly missCount: number;
+  readonly evictionCount: number;
+  readonly inflightCount: number;
+}
+
+/**
+ * The unified paging primitive. Generic over key and value types so the
+ * same implementation serves KV cache pages, LoRA adapters, model weights,
+ * embeddings, recalled memories, MoE experts.
+ */
+export class PagedResourcePool<TKey, TValue> {
+  private readonly entries: Map<string, MutablePoolEntry<TValue>> = new Map();
+  private readonly inflight: Map<string, Promise<TValue>> = new Map();
+  private hits = 0;
+  private misses = 0;
+  private evictions = 0;
+
+  constructor(private readonly config: PagedResourcePoolConfig<TValue>) {}
+
+  /** Get a value by key without pinning. Returns null on miss (no load).
+   * Updates lastAccessAt and increments access counter. */
+  get(key: TKey): TValue | null {
+    const k = this.keyHash(key);
+    const entry = this.entries.get(k);
+    if (!entry) {
+      this.misses++;
+      return null;
+    }
+    entry.lastAccessAt = Date.now();
+    entry.accessCount++;
+    this.hits++;
+    return entry.value;
+  }
+
+  /** Load-or-share — if the key isn't present, invoke the loader. Concurrent
+   * calls for the same key share ONE loader invocation (single-flight). */
+  async loadOrShare(key: TKey): Promise<TValue> {
+    const k = this.keyHash(key);
+    const existing = this.entries.get(k);
+    if (existing) {
+      existing.lastAccessAt = Date.now();
+      existing.accessCount++;
+      this.hits++;
+      return existing.value;
+    }
+    this.misses++;
+    const inflight = this.inflight.get(k);
+    if (inflight) return inflight;
+    // No entry, no in-flight: start a new load. Store the promise so
+    // concurrent callers piggyback. Clean up on settle (success OR fail —
+    // .finally avoids the rejected-promise-poisons-cache bug).
+    const promise = (async () => {
+      const value = await this.config.loader(key);
+      const sizeBytes = this.config.sizer(value);
+      const now = Date.now();
+      const entry: MutablePoolEntry<TValue> = {
+        value, sizeBytes, pinCount: 0, loadedAt: now, lastAccessAt: now, accessCount: 1,
+      };
+      this.entries.set(k, entry);
+      this.maybeEvict();
+      return value;
+    })();
+    this.inflight.set(k, promise);
+    promise.finally(() => this.inflight.delete(k));
+    return promise;
+  }
+
+  /** Pin an entry to keep it resident. Returns a handle whose `release()`
+   * decrements the pin count. The entry remains evictable when pinCount=0. */
+  pin(key: TKey): ResourceHandle<TValue> | null {
+    const k = this.keyHash(key);
+    const entry = this.entries.get(k);
+    if (!entry) return null;
+    entry.pinCount++;
+    entry.lastAccessAt = Date.now();
+    let released = false;
+    return {
+      value: entry.value,
+      release: () => {
+        if (released) return;
+        released = true;
+        entry.pinCount = Math.max(0, entry.pinCount - 1);
+      },
+    };
+  }
+
+  /** Force-evict by key, regardless of pin count. Use sparingly — the
+   * normal path is `maybeEvict()` triggered by pressure. */
+  evict(key: TKey): boolean {
+    const k = this.keyHash(key);
+    if (!this.entries.delete(k)) return false;
+    this.evictions++;
+    return true;
+  }
+
+  /** Snapshot statistics for monitoring or a PressureBroker query. */
+  stats(): PoolStats {
+    let totalBytes = 0;
+    let pinnedCount = 0;
+    for (const entry of this.entries.values()) {
+      totalBytes += entry.sizeBytes;
+      if (entry.pinCount > 0) pinnedCount++;
+    }
+    return {
+      name: this.config.name,
+      entryCount: this.entries.size,
+      pinnedCount,
+      totalBytes,
+      maxBytes: this.config.maxBytes,
+      pressure: this.config.maxBytes > 0 ? totalBytes / this.config.maxBytes : 0,
+      hitCount: this.hits,
+      missCount: this.misses,
+      evictionCount: this.evictions,
+      inflightCount: this.inflight.size,
+    };
+  }
+
+  /** Reduce occupancy to 75% of maxBytes by evicting unpinned entries
+   * in eviction-priority order (lowest priority first). Pinned entries
+   * are never touched here; the consumer decides when to release. */
+  private maybeEvict(): void {
+    const targetBytes = Math.floor(this.config.maxBytes * 0.75);
+    let totalBytes = 0;
+    for (const entry of this.entries.values()) totalBytes += entry.sizeBytes;
+    if (totalBytes <= this.config.maxBytes) return;
+    // Build candidate list: only unpinned entries, sorted by eviction priority.
+    const candidates: Array<[string, MutablePoolEntry<TValue>]> = [];
+    for (const [k, entry] of this.entries) {
+      if (entry.pinCount === 0) candidates.push([k, entry]);
+    }
+    candidates.sort(([, a], [, b]) =>
+      this.config.evictionPriority(a) - this.config.evictionPriority(b)
+    );
+    for (const [k, entry] of candidates) {
+      if (totalBytes <= targetBytes) break;
+      this.entries.delete(k);
+      totalBytes -= entry.sizeBytes;
+      this.evictions++;
+    }
+  }
+
+  /** Stable string hash of the key — supports complex object keys. Default
+   * uses JSON serialization; consumers with structured keys (tuples, etc.)
+   * can pre-hash to a string and pass that as TKey. */
+  private keyHash(key: TKey): string {
+    if (typeof key === 'string') return key;
+    if (typeof key === 'number' || typeof key === 'boolean') return String(key);
+    return JSON.stringify(key);
+  }
+}
+
+/** Default LRU eviction priority — lower priority = evict first. We
+ * negate lastAccessAt so the OLDEST access becomes the LOWEST priority. */
+export function lruPriority<TValue>(): EvictionPriority<TValue> {
+  return (entry) => -entry.lastAccessAt;
+}
+
+/** Size-weighted LRU — among equally old entries, evict the largest first
+ * (frees more memory per eviction). Useful for embedding caches and
+ * model-weight pools where some entries are dramatically larger than others. */
+export function sizeWeightedLruPriority<TValue>(): EvictionPriority<TValue> {
+  return (entry) => -entry.lastAccessAt - entry.sizeBytes * 0.001;
+}
+
+/** Constant unit-1 sizer for count-based pools. */
+export function unitSizer<TValue>(): ResourceSizer<TValue> {
+  return () => 1;
+}
+
+// Internal mutable view of PoolEntry — exposed only within this module.
+interface MutablePoolEntry<TValue> {
+  value: TValue;
+  sizeBytes: number;
+  pinCount: number;
+  loadedAt: number;
+  lastAccessAt: number;
+  accessCount: number;
+}

--- a/src/system/core/paging/index.ts
+++ b/src/system/core/paging/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Unified paging primitive — the foundation that LoRA paging, KV cache
+ * paging (PagedAttention), MoE expert paging, embedding cache, and
+ * memory recall all build on.
+ *
+ * See: docs/architecture/UNIFIED-PAGING.md
+ */
+
+export {
+  PagedResourcePool,
+  lruPriority,
+  sizeWeightedLruPriority,
+  unitSizer,
+} from './PagedResourcePool';
+
+export type {
+  PagedResourcePoolConfig,
+  PoolEntry,
+  PoolStats,
+  ResourceHandle,
+  ResourceLoader,
+  ResourceSizer,
+  EvictionPriority,
+} from './PagedResourcePool';

--- a/src/workers/continuum-core/src/lib.rs
+++ b/src/workers/continuum-core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod memory;
 pub mod models;
 pub mod modules;
 pub mod orm;
+pub mod paging;
 pub mod persona;
 pub mod rag;
 pub mod runtime;

--- a/src/workers/continuum-core/src/paging/mod.rs
+++ b/src/workers/continuum-core/src/paging/mod.rs
@@ -1,0 +1,23 @@
+//! Unified paging primitive — the foundation that every paged resource
+//! in the system builds on.
+//!
+//! Same shape used by:
+//!   - LoRA adapters (genome registry adopts this)
+//!   - KV cache pages (PagedAttention via vllm-metal handles natively)
+//!   - MoE expert weights (when MoE forge ships)
+//!   - Model weights (multiple loaded models per host)
+//!   - Embedding vectors (content-addressed dedup)
+//!   - Memory recall (TieredMemoryCache reformulation)
+//!
+//! The hand-rolled implementations across these consumers diverged on
+//! pressure interpretation, eviction, single-flight handling. This is
+//! the shared shape they should all adopt.
+//!
+//! See: docs/architecture/UNIFIED-PAGING.md
+
+pub mod pool;
+
+pub use pool::{
+    lru_priority, size_weighted_lru, EvictionPriority, PagedResourcePool, PinHandle, PoolConfig,
+    PoolEntry, PoolEntryView, PoolStats, Sizer,
+};

--- a/src/workers/continuum-core/src/paging/pool.rs
+++ b/src/workers/continuum-core/src/paging/pool.rs
@@ -1,0 +1,615 @@
+//! PagedResourcePool — the unified paging primitive.
+//!
+//! Same shape used by every resource that needs paging:
+//!   - LoRA adapter weights (genome registry adopts this)
+//!   - KV cache pages (PagedAttention via vllm-metal handles natively;
+//!     thin wrapper exposes its semantics through the same interface)
+//!   - MoE expert weights (when MoE forge ships)
+//!   - Model weights (multiple loaded models per host)
+//!   - Embedding vectors (content-addressed dedup; fixes the 0/64 hit rate)
+//!   - Memory recall results (TieredMemoryCache reformulation)
+//!
+//! Each consumer hand-rolled its own implementation today. The drift between
+//! them IS the bug — different pressure interpretations, eviction policies,
+//! single-flight handling. This primitive is the shared shape.
+//!
+//! Operations:
+//!   - `get(k)` — L1 hit, returns owned value if cached, no load
+//!   - `load_or_share(k, loader)` — single-flight load + cache; concurrent
+//!     calls for the same key share ONE loader invocation
+//!   - `pin(k)` — reference-counted hold; entry not evicted while pinned
+//!   - `evict(k)` — forced drop regardless of pin count
+//!   - `stats()` — pressure, hit rate, count for the PressureBroker
+//!
+//! Properties:
+//!   - **Thread-safe** by default (parking_lot::RwLock + tokio Mutex for
+//!     the inflight map). Built for the multi-persona concurrent case.
+//!   - **Required config** — no Option<>, every choice declared explicitly
+//!     per Joel's required-not-optional discipline.
+//!   - **Reject-promise cleanup** — failed loads don't poison the cache;
+//!     the inflight slot is removed on both Ok and Err.
+//!   - **Pressure-driven eviction** — `maybe_evict` triggers when occupancy
+//!     exceeds `max_bytes`, drops unpinned entries by eviction priority
+//!     (LRU default) until back to 75% of capacity.
+//!
+//! See: docs/architecture/UNIFIED-PAGING.md
+
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::future::Future;
+use std::hash::Hash;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::Mutex;
+
+/// Stats snapshot — for monitoring + PressureBroker decisions.
+#[derive(Debug, Clone)]
+pub struct PoolStats {
+    pub name: String,
+    pub entry_count: usize,
+    pub pinned_count: usize,
+    pub total_bytes: u64,
+    pub max_bytes: u64,
+    /// 0.0..1.0 — ratio of used to capacity. >1.0 means over-budget.
+    pub pressure: f64,
+    pub hit_count: u64,
+    pub miss_count: u64,
+    pub eviction_count: u64,
+    pub inflight_count: usize,
+}
+
+/// Internal entry — exposed via `EvictionPriority` callbacks.
+///
+/// Hot fields (last_access_at, access_count, pin_count) are atomics so
+/// the pool's read-heavy `get()` path runs under RwLock::read with no
+/// serialization point. Concurrent personas hit the cache in parallel.
+pub struct PoolEntry<V> {
+    pub value: V,
+    pub size_bytes: u64,
+    pub pin_count: AtomicU32,
+    /// Unix ms.
+    pub loaded_at: u64,
+    /// Unix ms — atomic so concurrent `get()` callers can update without
+    /// blocking each other on a write lock.
+    pub last_access_at: AtomicU64,
+    /// Atomic so concurrent `get()` callers can increment without blocking.
+    pub access_count: AtomicU64,
+}
+
+/// Snapshot view for eviction-priority callbacks (atomics resolved to
+/// owned values so the callback signature is simple).
+#[derive(Debug, Clone, Copy)]
+pub struct PoolEntryView {
+    pub size_bytes: u64,
+    pub pin_count: u32,
+    pub loaded_at: u64,
+    pub last_access_at: u64,
+    pub access_count: u64,
+}
+
+/// Sizer — returns byte cost of a value. Use `|_| 1` for count-based pools.
+pub type Sizer<V> = Arc<dyn Fn(&V) -> u64 + Send + Sync>;
+
+/// Eviction priority — lower priority = evict first.
+/// Takes the snapshot view (atomics resolved) so the callback is simple.
+pub type EvictionPriority = Arc<dyn Fn(&PoolEntryView) -> i64 + Send + Sync>;
+
+/// LRU eviction priority — older `last_access_at` evicts first.
+pub fn lru_priority() -> EvictionPriority {
+    Arc::new(|entry: &PoolEntryView| -(entry.last_access_at as i64))
+}
+
+/// Size-weighted LRU — among similarly-aged entries, larger evicts first.
+/// Useful for embedding caches and model-weight pools where some entries
+/// are dramatically larger than others (free more memory per eviction).
+pub fn size_weighted_lru() -> EvictionPriority {
+    Arc::new(|entry: &PoolEntryView| {
+        -(entry.last_access_at as i64) - (entry.size_bytes / 1024) as i64
+    })
+}
+
+/// Pool configuration. All fields required (no Option<> per Joel's rule).
+pub struct PoolConfig<V> {
+    pub name: String,
+    pub max_bytes: u64,
+    pub sizer: Sizer<V>,
+    pub eviction_priority: EvictionPriority,
+}
+
+/// A pinned reference. While at least one PinHandle is alive for an entry,
+/// it cannot be evicted. Drop the handle to release; ref count decrements
+/// automatically.
+pub struct PinHandle<K, V>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    key: K,
+    pool: Arc<Inner<K, V>>,
+    released: bool,
+}
+
+impl<K, V> PinHandle<K, V>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    /// Borrow the pinned value. Available for the lifetime of the handle.
+    pub fn value(&self) -> Option<V> {
+        let entries = self.pool.entries.read();
+        entries.get(&self.key).map(|e| e.value.clone())
+    }
+
+    /// Explicitly release the pin. Idempotent. Drop also releases.
+    pub fn release(mut self) {
+        self.do_release();
+    }
+
+    fn do_release(&mut self) {
+        if self.released {
+            return;
+        }
+        self.released = true;
+        // Atomic decrement under read lock — concurrent pin/release on
+        // different keys don't serialize.
+        let entries = self.pool.entries.read();
+        if let Some(entry) = entries.get(&self.key) {
+            // Saturating sub via compare-and-swap loop.
+            let mut current = entry.pin_count.load(Ordering::Acquire);
+            loop {
+                if current == 0 {
+                    break;
+                }
+                match entry.pin_count.compare_exchange_weak(
+                    current,
+                    current - 1,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => break,
+                    Err(actual) => current = actual,
+                }
+            }
+        }
+    }
+}
+
+impl<K, V> Drop for PinHandle<K, V>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        self.do_release();
+    }
+}
+
+/// Internal shared state — held behind Arc so PinHandle and the pool
+/// share access without ownership friction.
+struct Inner<K, V>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    config: PoolConfig<V>,
+    entries: RwLock<HashMap<K, PoolEntry<V>>>,
+    /// Single-flight in-flight loaders. tokio::sync::Mutex because we
+    /// hold this across awaits.
+    inflight: Mutex<HashMap<K, futures::future::Shared<Pin<Box<dyn Future<Output = Result<V, String>> + Send>>>>>,
+    /// Atomic counters — concurrent get/load callers update without lock contention.
+    hits: AtomicU64,
+    misses: AtomicU64,
+    evictions: AtomicU64,
+}
+
+/// The unified paging primitive — generic over key and value types.
+pub struct PagedResourcePool<K, V>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    inner: Arc<Inner<K, V>>,
+}
+
+impl<K, V> PagedResourcePool<K, V>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    /// Create a new pool with the given configuration.
+    pub fn new(config: PoolConfig<V>) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                config,
+                entries: RwLock::new(HashMap::new()),
+                inflight: Mutex::new(HashMap::new()),
+                hits: AtomicU64::new(0),
+                misses: AtomicU64::new(0),
+                evictions: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    /// L1 hit — returns the value if cached, None on miss. Concurrent
+    /// readers run in parallel under RwLock::read; per-entry atomics
+    /// update last_access_at + access_count without serializing.
+    pub fn get(&self, key: &K) -> Option<V> {
+        let entries = self.inner.entries.read();
+        if let Some(entry) = entries.get(key) {
+            entry.last_access_at.store(now_ms(), Ordering::Release);
+            entry.access_count.fetch_add(1, Ordering::AcqRel);
+            self.inner.hits.fetch_add(1, Ordering::Relaxed);
+            return Some(entry.value.clone());
+        }
+        self.inner.misses.fetch_add(1, Ordering::Relaxed);
+        None
+    }
+
+    /// Load-or-share — if the key isn't present, invoke the loader.
+    /// Concurrent calls for the same key share ONE loader invocation
+    /// (single-flight). Failed loads don't poison the cache slot.
+    pub async fn load_or_share<F, Fut>(&self, key: K, loader: F) -> Result<V, String>
+    where
+        F: FnOnce(K) -> Fut + Send,
+        Fut: Future<Output = Result<V, String>> + Send + 'static,
+    {
+        // Fast path: cache hit.
+        if let Some(value) = self.get(&key) {
+            return Ok(value);
+        }
+        // Check inflight or start one.
+        let shared = {
+            let mut inflight = self.inner.inflight.lock().await;
+            if let Some(existing) = inflight.get(&key) {
+                existing.clone()
+            } else {
+                use futures::future::FutureExt;
+                let fut = loader(key.clone()).boxed();
+                let shared = fut.shared();
+                inflight.insert(key.clone(), shared.clone());
+                shared
+            }
+        };
+        // Await the shared future (other callers also waiting see the same).
+        let result = shared.await;
+        // Cleanup inflight slot regardless of success/failure.
+        {
+            let mut inflight = self.inner.inflight.lock().await;
+            inflight.remove(&key);
+        }
+        // On success, insert and maybe evict.
+        match result {
+            Ok(value) => {
+                self.insert(key, value.clone());
+                Ok(value)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Manually insert a value. Useful for content-hash pools (e.g.,
+    /// embeddings) where the key can't reconstruct the input. Caller has
+    /// already produced the value; this records it for future hits.
+    pub fn insert(&self, key: K, value: V) {
+        let size_bytes = (self.inner.config.sizer)(&value);
+        let now = now_ms();
+        {
+            let mut entries = self.inner.entries.write();
+            entries.insert(
+                key,
+                PoolEntry {
+                    value,
+                    size_bytes,
+                    pin_count: AtomicU32::new(0),
+                    loaded_at: now,
+                    last_access_at: AtomicU64::new(now),
+                    access_count: AtomicU64::new(1),
+                },
+            );
+        }
+        self.maybe_evict();
+    }
+
+    /// Pin an entry to keep it resident. Returns None on miss.
+    /// Pin/release are atomic — concurrent pins on different keys don't
+    /// serialize on each other.
+    pub fn pin(&self, key: &K) -> Option<PinHandle<K, V>> {
+        let entries = self.inner.entries.read();
+        let entry = entries.get(key)?;
+        entry.pin_count.fetch_add(1, Ordering::AcqRel);
+        entry.last_access_at.store(now_ms(), Ordering::Release);
+        Some(PinHandle {
+            key: key.clone(),
+            pool: self.inner.clone(),
+            released: false,
+        })
+    }
+
+    /// Force-evict by key, regardless of pin count. Use sparingly —
+    /// the normal path is `maybe_evict` triggered by pressure.
+    pub fn evict(&self, key: &K) -> bool {
+        let mut entries = self.inner.entries.write();
+        if entries.remove(key).is_some() {
+            self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+            return true;
+        }
+        false
+    }
+
+    /// Snapshot stats for monitoring + PressureBroker queries.
+    pub async fn stats(&self) -> PoolStats {
+        let entries = self.inner.entries.read();
+        let mut total_bytes: u64 = 0;
+        let mut pinned_count: usize = 0;
+        for entry in entries.values() {
+            total_bytes += entry.size_bytes;
+            if entry.pin_count.load(Ordering::Acquire) > 0 {
+                pinned_count += 1;
+            }
+        }
+        let max_bytes = self.inner.config.max_bytes;
+        let pressure = if max_bytes > 0 {
+            total_bytes as f64 / max_bytes as f64
+        } else {
+            0.0
+        };
+        let inflight_count = self.inner.inflight.lock().await.len();
+        PoolStats {
+            name: self.inner.config.name.clone(),
+            entry_count: entries.len(),
+            pinned_count,
+            total_bytes,
+            max_bytes,
+            pressure,
+            hit_count: self.inner.hits.load(Ordering::Relaxed),
+            miss_count: self.inner.misses.load(Ordering::Relaxed),
+            eviction_count: self.inner.evictions.load(Ordering::Relaxed),
+            inflight_count,
+        }
+    }
+
+    /// Reduce occupancy to 75% of max_bytes by evicting unpinned entries
+    /// in eviction-priority order (lowest priority first). Pinned entries
+    /// are never touched here.
+    fn maybe_evict(&self) {
+        let target_bytes = (self.inner.config.max_bytes as f64 * 0.75) as u64;
+        let mut entries = self.inner.entries.write();
+        let mut total_bytes: u64 = entries.values().map(|e| e.size_bytes).sum();
+        if total_bytes <= self.inner.config.max_bytes {
+            return;
+        }
+        // Build candidate list: only unpinned, sorted by eviction priority asc.
+        // Resolve atomics to PoolEntryView for the priority callback.
+        let mut candidates: Vec<(K, i64, u64)> = entries
+            .iter()
+            .filter(|(_, e)| e.pin_count.load(Ordering::Acquire) == 0)
+            .map(|(k, e)| {
+                let view = PoolEntryView {
+                    size_bytes: e.size_bytes,
+                    pin_count: e.pin_count.load(Ordering::Acquire),
+                    loaded_at: e.loaded_at,
+                    last_access_at: e.last_access_at.load(Ordering::Acquire),
+                    access_count: e.access_count.load(Ordering::Acquire),
+                };
+                (k.clone(), (self.inner.config.eviction_priority)(&view), e.size_bytes)
+            })
+            .collect();
+        candidates.sort_by_key(|(_, prio, _)| *prio);
+        let mut evicted: u64 = 0;
+        for (k, _, size) in candidates {
+            if total_bytes <= target_bytes {
+                break;
+            }
+            entries.remove(&k);
+            total_bytes -= size;
+            evicted += 1;
+        }
+        if evicted > 0 {
+            self.inner.evictions.fetch_add(evicted, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Current Unix ms — monotonic enough for LRU ordering.
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn count_sizer<V>() -> Sizer<V>
+    where
+        V: 'static,
+    {
+        Arc::new(|_| 1)
+    }
+
+    fn bytes_sizer() -> Sizer<Vec<u8>> {
+        Arc::new(|v: &Vec<u8>| v.len() as u64)
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_on_miss_and_value_on_hit() {
+        let pool: PagedResourcePool<String, Vec<u8>> = PagedResourcePool::new(PoolConfig {
+            name: "test".to_string(),
+            max_bytes: 1024,
+            sizer: bytes_sizer(),
+            eviction_priority: lru_priority(),
+        });
+        assert!(pool.get(&"missing".to_string()).is_none());
+        pool.insert("k1".to_string(), vec![1, 2, 3]);
+        assert_eq!(pool.get(&"k1".to_string()), Some(vec![1, 2, 3]));
+    }
+
+    #[tokio::test]
+    async fn load_or_share_dedups_concurrent_loads() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let pool: PagedResourcePool<String, u32> = PagedResourcePool::new(PoolConfig {
+            name: "test".to_string(),
+            max_bytes: 1024,
+            sizer: count_sizer(),
+            eviction_priority: lru_priority(),
+        });
+        let load_count = Arc::new(AtomicU32::new(0));
+        let lc1 = load_count.clone();
+        let lc2 = load_count.clone();
+        let lc3 = load_count.clone();
+        let key = "shared".to_string();
+        let f1 = pool.load_or_share(key.clone(), move |_| {
+            let lc = lc1.clone();
+            async move {
+                lc.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+                Ok(42_u32)
+            }
+        });
+        let f2 = pool.load_or_share(key.clone(), move |_| {
+            let lc = lc2.clone();
+            async move {
+                lc.fetch_add(1, Ordering::SeqCst);
+                Ok(99_u32)
+            }
+        });
+        let f3 = pool.load_or_share(key.clone(), move |_| {
+            let lc = lc3.clone();
+            async move {
+                lc.fetch_add(1, Ordering::SeqCst);
+                Ok(7_u32)
+            }
+        });
+        let (r1, r2, r3) = tokio::join!(f1, f2, f3);
+        assert_eq!(r1.unwrap(), 42);
+        assert_eq!(r2.unwrap(), 42);
+        assert_eq!(r3.unwrap(), 42);
+        // All three callers shared one load — counter should be 1, not 3.
+        assert_eq!(load_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn pin_prevents_eviction_under_pressure() {
+        let pool: PagedResourcePool<String, Vec<u8>> = PagedResourcePool::new(PoolConfig {
+            name: "test".to_string(),
+            max_bytes: 100,
+            sizer: bytes_sizer(),
+            eviction_priority: lru_priority(),
+        });
+        pool.insert("pinned".to_string(), vec![0; 50]);
+        let _handle = pool.pin(&"pinned".to_string()).expect("pin should succeed");
+        // Push way over budget with unpinned entries.
+        for i in 0..5 {
+            pool.insert(format!("transient_{i}"), vec![0; 80]);
+        }
+        // Pinned entry must survive.
+        assert!(pool.get(&"pinned".to_string()).is_some());
+    }
+
+    #[tokio::test]
+    async fn maybe_evict_keeps_total_within_max_bytes() {
+        let pool: PagedResourcePool<String, Vec<u8>> = PagedResourcePool::new(PoolConfig {
+            name: "test".to_string(),
+            max_bytes: 100,
+            sizer: bytes_sizer(),
+            eviction_priority: lru_priority(),
+        });
+        // Insert beyond budget. Eviction fires when total > max_bytes,
+        // drops back to 75% target. Between firings, total can sit
+        // anywhere ≤ max_bytes — that's the contract.
+        for i in 0..5 {
+            pool.insert(format!("k_{i}"), vec![0; 30]);
+        }
+        let stats = pool.stats().await;
+        assert!(
+            stats.total_bytes <= 100,
+            "expected total_bytes <= max_bytes (100) after eviction firings, got {}",
+            stats.total_bytes
+        );
+        assert!(stats.eviction_count > 0, "eviction should have fired at least once");
+    }
+
+    #[tokio::test]
+    async fn eviction_drops_to_target_when_far_over() {
+        let pool: PagedResourcePool<String, Vec<u8>> = PagedResourcePool::new(PoolConfig {
+            name: "test".to_string(),
+            max_bytes: 100,
+            sizer: bytes_sizer(),
+            eviction_priority: lru_priority(),
+        });
+        // Single insert that's WAY over budget triggers eviction down
+        // to 75% target in one pass.
+        for i in 0..3 {
+            pool.insert(format!("warm_{i}"), vec![0; 30]);
+            tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        }
+        // Now insert a big one that pushes over.
+        pool.insert("big".to_string(), vec![0; 50]);
+        let stats = pool.stats().await;
+        // After this single eviction pass, total ≤ 75 (target).
+        assert!(
+            stats.total_bytes <= 75,
+            "single big insert should trigger eviction to 75% target; got {}",
+            stats.total_bytes
+        );
+    }
+
+    #[tokio::test]
+    async fn dropped_pin_handle_releases_ref_count() {
+        let pool: PagedResourcePool<String, Vec<u8>> = PagedResourcePool::new(PoolConfig {
+            name: "test".to_string(),
+            max_bytes: 100,
+            sizer: bytes_sizer(),
+            eviction_priority: lru_priority(),
+        });
+        pool.insert("x".to_string(), vec![0; 50]);
+        {
+            let _handle = pool.pin(&"x".to_string()).unwrap();
+            let stats = pool.stats().await;
+            assert_eq!(stats.pinned_count, 1);
+        }
+        // _handle dropped here — pin count should return to 0.
+        let stats = pool.stats().await;
+        assert_eq!(stats.pinned_count, 0);
+    }
+
+    #[tokio::test]
+    async fn failed_load_does_not_poison_cache() {
+        let pool: PagedResourcePool<String, u32> = PagedResourcePool::new(PoolConfig {
+            name: "test".to_string(),
+            max_bytes: 1024,
+            sizer: count_sizer(),
+            eviction_priority: lru_priority(),
+        });
+        // First call fails.
+        let r1 = pool
+            .load_or_share("k".to_string(), |_| async {
+                Err::<u32, String>("boom".to_string())
+            })
+            .await;
+        assert!(r1.is_err());
+        // Second call should succeed (no poisoned slot from rejection).
+        let r2 = pool
+            .load_or_share("k".to_string(), |_| async { Ok(123_u32) })
+            .await;
+        assert_eq!(r2.unwrap(), 123);
+    }
+
+    #[tokio::test]
+    async fn stats_pressure_tracks_occupancy() {
+        let pool: PagedResourcePool<String, Vec<u8>> = PagedResourcePool::new(PoolConfig {
+            name: "test".to_string(),
+            max_bytes: 100,
+            sizer: bytes_sizer(),
+            eviction_priority: lru_priority(),
+        });
+        pool.insert("k".to_string(), vec![0; 25]);
+        let stats = pool.stats().await;
+        assert_eq!(stats.total_bytes, 25);
+        assert!((stats.pressure - 0.25).abs() < 0.001);
+    }
+}


### PR DESCRIPTION
**Foundation PR — Rust, additive only, zero behavior change.** The primitive every paging layer should adopt going forward.

Joel: *\"we are rust first unless inappropriate, period. / paging is our general strategy in this system anyway / keep memory and cpu LOW, parallel / expose the levers.\"* (First TS attempt was closed as #929 — muscle-memory pattern, wrong language for where the paged resources live.)

Full design: [`docs/architecture/UNIFIED-PAGING.md`](https://github.com/CambrianTech/continuum/blob/feature/paged-resource-pool-rust/docs/architecture/UNIFIED-PAGING.md)

## What's in

`src/workers/continuum-core/src/paging/pool.rs` — generic Rust resource pool with the operations every paging layer needs:

```rust
pub struct PagedResourcePool<K, V> { /* ... */ }

impl<K, V> PagedResourcePool<K, V> {
    pub fn new(config: PoolConfig<V>) -> Self;
    pub fn get(&self, key: &K) -> Option<V>;        // L1 hit, lock-free read path
    pub async fn load_or_share<F, Fut>(&self, key: K, loader: F)
        -> Result<V, String>;                       // single-flight via Shared
    pub fn pin(&self, key: &K) -> Option<PinHandle<K, V>>;  // ref-counted hold
    pub fn insert(&self, key: K, value: V);         // for content-hash pools
    pub fn evict(&self, key: &K) -> bool;
    pub async fn stats(&self) -> PoolStats;
}
```

## Performance properties

- **Lock-free reads** — `get()` runs under `RwLock::read()`; per-entry atomics (`AtomicU64`/`AtomicU32`) update `last_access_at`/`access_count`/`pin_count` without serializing
- **Atomic counters** — `hits`, `misses`, `evictions` are `AtomicU64` — no mutex contention on stat updates
- **Single-flight via `futures::Shared`** — N concurrent loaders for the same key resolve to ONE invocation (proven by `load_or_share_dedups_concurrent_loads` test)
- **Reject-promise cleanup** — failed loads don't poison the cache slot (the exact bug we hit on `CodebaseIndexer.queryCacheLoad` earlier today)
- **Required config** — `PoolConfig` has no `Option<>`; every choice declared per Joel's required-not-optional discipline

## Levers exposed (for the future PressureBroker / ML-driven control)

The primitive's design point is exposing surfaces so an intelligent control layer can drive the system without rewriting the pools:

- **`eviction_priority` is a function** — pluggable per-pool strategy (defaults: `lru_priority`, `size_weighted_lru`)
- **`stats()` returns rich snapshots** — pressure ratio, hit/miss, eviction count, in-flight, pinned vs unpinned. Sufficient input for an ML model or LLM to predict trajectory and pull levers.
- **`pin()` / `evict()` public** — broker can pin proactively (warm a recipe's adapters) or evict surgically
- **Per-pool budget (`max_bytes`)** — broker can dynamically reshape budgets across pools
- **Sizer is a function** — consumers can supply weighted sizing (GPU vs CPU vs quantized bytes count differently)

## Test coverage (8 passing)

```
✓ get_returns_none_on_miss_and_value_on_hit
✓ load_or_share_dedups_concurrent_loads (3 callers → 1 invocation)
✓ pin_prevents_eviction_under_pressure
✓ maybe_evict_keeps_total_within_max_bytes
✓ eviction_drops_to_target_when_far_over
✓ dropped_pin_handle_releases_ref_count
✓ failed_load_does_not_poison_cache (correctness invariant)
✓ stats_pressure_tracks_occupancy
```

`cargo check` clean (61 pre-existing dead-code warnings, no errors).

## Why this enables the bigger story

Paging at every layer is what lets a small machine serve large intelligence:

| Layer | Strategy | Effect |
|---|---|---|
| Model weights | Load once, share | N consumers, 1 copy |
| KV cache | PagedAttention | Per-token allocation, no reservation |
| LoRA adapters | Ref-counted | 14 personas using same skill, 1 copy |
| MoE experts | Router-driven | 32B params on disk, 8B hot per token |
| Memory | Tiered L1/L2/L3 | Recent instant, deep on demand |
| Embeddings | Content-addressed | Same text → same vector, never recomputed |

Combined: a 16 GB MacBook Air running a forged 32B-MoE persona where only the active expert is hot, the active LoRA is shared, KV is paged per-token, memory recalls instantly. **Total intelligence ≫ resident footprint, on every machine class.**

## Migration plan (post-merge)

Each consumer migrates in its own focused commit:

1. **EmbeddingCache** — wrap pool with `<ContentHash, Vec<f32>>`; fixes 0/64 hit rate
2. **LoRAAdapterPool** — wrap pool with `<AdapterId, LoadedAdapter>`; genome registry adopts
3. **KV cache** — route chat to vllm-metal (PagedAttention native); thin wrapper for llama.cpp slot reservation visibility
4. **MoEExpertPool** — when MoE forge lands
5. **TieredMemoryCache reformulation** — becomes a `MemoryRecallPool` instance
6. **PressureBroker** — cross-pool orchestration; eventually ML/LLM-mediated control plugs in here

🤖 Generated with [Claude Code](https://claude.com/claude-code)