### PR TITLE
feat(paging): PressureBroker scaffolding (Phase 7a)

### DIFF
--- a/docs/architecture/RESOURCE-ARCHITECTURE.md
+++ b/docs/architecture/RESOURCE-ARCHITECTURE.md
@@ -268,7 +268,7 @@ This architecture is what the work tonight is building toward. Inventory:
 | `RustEmbeddingClient` | Existing | Will adopt EmbeddingPool migration; fixes 0/64 hits |
 | `GpuMemoryManager` | Existing | Provides GPU pressure signal to broker |
 | `ResourcePressureWatcher` | Existing | Provides RAM/CPU pressure signal to broker |
-| **PressureBroker** | **Phase 7 — not started** | Cross-resource orchestrator |
+| **PressureBroker** | **Phase 7a — scaffolding shipping (this PR)** | Cross-resource orchestrator |
 | `LiveCallTracker` etc. | Existing | Exclusive stateful lifecycle (correctly outside paging architecture) |
 
 ---
@@ -301,6 +301,12 @@ Wire `forcedState` from broker into `PersonaState`. Less-active reduces RAG sour
 
 ### Phase 7 — PressureBroker
 Cross-pool eviction orchestration + priority arbitration + dormancy decisions. Heuristic first, ML/LLM later via the levers the pool exposes.
+
+**7a (this PR) — scaffolding.** `PressureSource` trait + `PressureBroker` struct + tier-based relief + tick loop in Rust (`src/workers/continuum-core/src/paging/broker.rs`). Blanket impl wires every `PagedResourcePool<K, V>` straight in — register an `Arc<PagedResourcePool<...>>` and the broker reads pressure + fires eviction per the tier ladder (Normal/Warning observe; High evicts worst pool; Critical evicts all over-budget pools). 8 unit tests cover trait, tier mapping, registration dedup, and a real-pool-via-blanket-impl integration test. Heuristic only; the ML/LLM layer (7b/7c) plugs in by overriding `PoolConfig::eviction_priority` per pool, not by replacing the broker.
+
+**7b — ML-policy.** Activity prediction (which keys are about to be needed) feeds `evict_some` selection. Same broker shape; just smarter `eviction_priority` callbacks. Decoupled from 7a delivery.
+
+**7c — LLM-mediated.** For novel pressure situations the heuristics don't cover (recipe-aware reshaping, multi-machine grid pressure, quality-vs-speed trade-offs the user cares about), the broker exposes its `BrokerSnapshot` to a control LLM and accepts back per-pool eviction directives + dormancy state changes. Same broker shape.
 
 ### Phase 8 — MoE forge + MoEExpertPool
 When MoE-forged Qwen3.5-A8B-MoE lands: `<ExpertId, ExpertWeights>` pool. Router pins active experts per token. Enables 32B-MoE intelligence on 16 GB MacBook Air.

--- a/src/workers/continuum-core/src/paging/broker.rs
+++ b/src/workers/continuum-core/src/paging/broker.rs
@@ -1,0 +1,498 @@
+//! PressureBroker — cross-pool eviction orchestration.
+//!
+//! Phase 7 of the resource architecture (RESOURCE-ARCHITECTURE.md).
+//!
+//! The PagedResourcePool primitive is the per-resource brain. The broker
+//! is the cross-resource brain: one orchestrator that reads pressure
+//! from every registered pool, decides which to relieve, and pulls the
+//! eviction lever. Same broker is the future home of recipe-aware
+//! priority arbitration, ML-policy-driven tiering decisions, and
+//! eventually LLM-mediated control for novel pressure situations.
+//!
+//! This commit lands the trait + broker scaffolding + tick loop. Pools
+//! register themselves as `PressureSource` implementors; the broker
+//! aggregates pressure on a periodic tick; when global pressure crosses
+//! threshold, eviction fires on the highest-pressure pool first.
+//!
+//! What's NOT in this commit (intentionally — separate phases):
+//!   - ML/LLM policy hook (the broker exposes the lever; the brain
+//!     plugs in later via PressureSource priority overrides)
+//!   - Recipe activation/deactivation hooks (Phase 9)
+//!   - Cross-machine pressure (grid-level paging is its own layer)
+//!
+//! See: docs/architecture/RESOURCE-ARCHITECTURE.md (Phase 7)
+
+use std::hash::Hash;
+use std::sync::Arc;
+use std::time::Duration;
+use parking_lot::RwLock;
+use crate::paging::pool::{PagedResourcePool, PoolStats};
+
+/// Anything the broker can read pressure from + evict to relieve it.
+///
+/// Implemented by every paged resource pool in the system. The trait is
+/// deliberately minimal — name for diagnostics, pressure for decisions,
+/// `evict_some` for action. Eviction strategy lives inside the pool;
+/// the broker just asks for some relief.
+pub trait PressureSource: Send + Sync {
+    /// Stable identifier used in logs and broker diagnostics.
+    fn name(&self) -> &str;
+
+    /// Current pressure 0.0..1.0 (or higher if over-budget). Snapshot
+    /// only — no side effects. Cheap; called every tick from the broker.
+    fn pressure(&self) -> f64;
+
+    /// Drop unpinned entries until pressure returns to a healthy level.
+    /// Returns the byte count freed (or 0 if nothing was evictable —
+    /// fully pinned pool).
+    fn evict_some(&self) -> u64;
+
+    /// Snapshot stats for monitoring / IPC export. Same shape as
+    /// `PagedResourcePool::stats()` so the broker can present a
+    /// uniform view across pools of any value type.
+    fn stats_snapshot(&self) -> PoolStats;
+}
+
+/// Blanket impl — every `PagedResourcePool<K, V>` automatically satisfies
+/// `PressureSource`. Consumers wrap their pool in `Arc<...>` and pass it
+/// straight to `broker.register()`; no per-pool adapter struct needed.
+///
+/// This is the architectural point of the trait: the broker speaks a tiny
+/// interface, every pool plugs in for free, and future ML/LLM policy
+/// hooks can specialize behavior per pool by overriding the `evict_some`
+/// strategy via `PoolConfig::eviction_priority` instead of by writing a
+/// custom `PressureSource`.
+impl<K, V> PressureSource for PagedResourcePool<K, V>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    fn name(&self) -> &str {
+        self.config_name()
+    }
+    fn pressure(&self) -> f64 {
+        self.stats_blocking().pressure
+    }
+    fn evict_some(&self) -> u64 {
+        self.evict_under_pressure()
+    }
+    fn stats_snapshot(&self) -> PoolStats {
+        self.stats_blocking()
+    }
+}
+
+/// Pressure tier — drives the broker's response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PressureTier {
+    /// All pools comfortably under their budgets.
+    Normal,
+    /// Some pool approaching its limit. Broker relieves the worst pool.
+    Warning,
+    /// Multiple pools at or over budget. Broker fires parallel eviction.
+    High,
+    /// System in real trouble — aggressive eviction across all pools.
+    Critical,
+}
+
+impl PressureTier {
+    /// Map a pressure ratio (0.0..) to a tier. Same thresholds as
+    /// GpuPressureWatcher uses — keeps the system's mental model
+    /// consistent across resource types.
+    pub fn for_pressure(p: f64) -> Self {
+        if p >= 0.95 {
+            PressureTier::Critical
+        } else if p >= 0.80 {
+            PressureTier::High
+        } else if p >= 0.60 {
+            PressureTier::Warning
+        } else {
+            PressureTier::Normal
+        }
+    }
+}
+
+/// Broker configuration. All fields required (no Option<>) per Joel's
+/// required-not-optional discipline.
+#[derive(Debug, Clone)]
+pub struct BrokerConfig {
+    /// Tick period — how often the broker checks pressure and acts.
+    /// Default 5 seconds; faster ticks waste CPU on quiet pools, slower
+    /// ticks let pressure spike before relief fires.
+    pub tick_interval: Duration,
+    /// Pressure threshold above which the broker fires eviction.
+    /// Below this, the broker watches but doesn't act.
+    pub act_above: f64,
+}
+
+impl Default for BrokerConfig {
+    fn default() -> Self {
+        Self {
+            tick_interval: Duration::from_secs(5),
+            act_above: 0.80, // High tier
+        }
+    }
+}
+
+/// Per-pool snapshot exposed to monitoring / IPC.
+#[derive(Debug, Clone)]
+pub struct PoolView {
+    pub name: String,
+    pub pressure: f64,
+    pub tier: PressureTier,
+    pub stats: PoolStats,
+}
+
+/// Full broker state snapshot — for the future PressureBroker IPC command
+/// + monitoring widget.
+#[derive(Debug, Clone)]
+pub struct BrokerSnapshot {
+    pub global_pressure: f64,
+    pub global_tier: PressureTier,
+    pub pools: Vec<PoolView>,
+    pub evictions_fired: u64,
+    pub bytes_freed_total: u64,
+}
+
+/// Result of a relief action.
+#[derive(Debug, Clone)]
+pub struct ReliefReport {
+    pub triggered: bool,
+    pub global_pressure_before: f64,
+    pub bytes_freed: u64,
+    pub pools_acted: Vec<String>,
+}
+
+/// Cross-pool pressure orchestrator. Singleton in practice; one per
+/// process is sufficient (cross-machine pressure lives at the grid
+/// layer, not here).
+pub struct PressureBroker {
+    pools: RwLock<Vec<Arc<dyn PressureSource>>>,
+    config: BrokerConfig,
+    evictions_fired: parking_lot::Mutex<u64>,
+    bytes_freed: parking_lot::Mutex<u64>,
+}
+
+impl PressureBroker {
+    pub fn new(config: BrokerConfig) -> Self {
+        Self {
+            pools: RwLock::new(Vec::new()),
+            config,
+            evictions_fired: parking_lot::Mutex::new(0),
+            bytes_freed: parking_lot::Mutex::new(0),
+        }
+    }
+
+    /// Register a pool as a pressure source. The broker holds a weak-ish
+    /// reference (Arc) so pools that outlive the broker stay valid; the
+    /// broker iterates the registered set each tick.
+    pub fn register(&self, pool: Arc<dyn PressureSource>) {
+        let mut pools = self.pools.write();
+        let name = pool.name().to_string();
+        // Dedup by name — registering twice replaces (avoids duplicate eviction calls).
+        pools.retain(|p| p.name() != name);
+        pools.push(pool);
+    }
+
+    /// Drop a pool from the broker's awareness (e.g., on shutdown of
+    /// a subsystem that owned the pool).
+    pub fn unregister(&self, name: &str) {
+        let mut pools = self.pools.write();
+        pools.retain(|p| p.name() != name);
+    }
+
+    /// Read pressure across all pools — global = max(per-pool). Cheap;
+    /// the broker calls this every tick.
+    pub fn global_pressure(&self) -> f64 {
+        let pools = self.pools.read();
+        pools.iter().map(|p| p.pressure()).fold(0.0_f64, f64::max)
+    }
+
+    /// Run one relief pass. Returns a report describing what (if anything)
+    /// was done. This is the broker's atomic action — eviction strategy
+    /// per tier:
+    ///
+    ///   Normal/Warning  → no action (broker observes)
+    ///   High            → evict from highest-pressure pool
+    ///   Critical        → evict from all over-budget pools in parallel
+    ///                     (sequential here since pool.evict_some returns
+    ///                     immediately; parallel only matters if eviction
+    ///                     is async, which it isn't in our design)
+    pub fn relieve(&self) -> ReliefReport {
+        let global = self.global_pressure();
+        let tier = PressureTier::for_pressure(global);
+        if (tier == PressureTier::Normal || tier == PressureTier::Warning)
+            && global < self.config.act_above
+        {
+            return ReliefReport {
+                triggered: false,
+                global_pressure_before: global,
+                bytes_freed: 0,
+                pools_acted: Vec::new(),
+            };
+        }
+        let pools = self.pools.read();
+        // Build (pressure, ref) list, sorted descending by pressure.
+        let mut pressured: Vec<(f64, Arc<dyn PressureSource>)> = pools
+            .iter()
+            .map(|p| (p.pressure(), p.clone()))
+            .filter(|(p, _)| *p >= self.config.act_above)
+            .collect();
+        pressured.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        let act_on: &[(f64, Arc<dyn PressureSource>)] = match tier {
+            PressureTier::High => pressured.first().map(std::slice::from_ref).unwrap_or(&[]),
+            PressureTier::Critical => &pressured[..],
+            _ => &[],
+        };
+        let mut bytes_freed = 0u64;
+        let mut pools_acted: Vec<String> = Vec::new();
+        for (_, pool) in act_on {
+            let freed = pool.evict_some();
+            if freed > 0 {
+                bytes_freed += freed;
+                pools_acted.push(pool.name().to_string());
+            }
+        }
+        if bytes_freed > 0 {
+            *self.evictions_fired.lock() += 1;
+            *self.bytes_freed.lock() += bytes_freed;
+        }
+        ReliefReport {
+            triggered: !pools_acted.is_empty(),
+            global_pressure_before: global,
+            bytes_freed,
+            pools_acted,
+        }
+    }
+
+    /// Full state snapshot — for monitoring widgets, IPC stats commands,
+    /// and the future ML-policy layer to consume as input.
+    pub fn snapshot(&self) -> BrokerSnapshot {
+        let pools = self.pools.read();
+        let mut views: Vec<PoolView> = pools
+            .iter()
+            .map(|p| {
+                let pressure = p.pressure();
+                PoolView {
+                    name: p.name().to_string(),
+                    pressure,
+                    tier: PressureTier::for_pressure(pressure),
+                    stats: p.stats_snapshot(),
+                }
+            })
+            .collect();
+        views.sort_by(|a, b| b.pressure.partial_cmp(&a.pressure).unwrap_or(std::cmp::Ordering::Equal));
+        let global_pressure = views.iter().map(|v| v.pressure).fold(0.0_f64, f64::max);
+        BrokerSnapshot {
+            global_pressure,
+            global_tier: PressureTier::for_pressure(global_pressure),
+            pools: views,
+            evictions_fired: *self.evictions_fired.lock(),
+            bytes_freed_total: *self.bytes_freed.lock(),
+        }
+    }
+
+    /// Spawn a tokio task that calls `relieve()` on `tick_interval`.
+    /// Returns the JoinHandle so the caller can abort on shutdown.
+    /// Idempotent at the call site — caller decides if/when to spawn.
+    pub fn spawn_tick(self: Arc<Self>) -> tokio::task::JoinHandle<()> {
+        let interval = self.config.tick_interval;
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            // Skip the immediate first tick — let pools warm up before
+            // we start measuring + acting.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                let _report = self.relieve();
+                // Future: emit IPC event or log when triggered=true.
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Mock pool for broker testing — exposes a settable pressure value
+    /// and counts evict_some invocations.
+    struct MockPool {
+        name: String,
+        pressure_val: AtomicU64, // f64 bits
+        evict_count: AtomicU64,
+        bytes_per_evict: u64,
+    }
+
+    impl MockPool {
+        fn new(name: &str, pressure: f64, bytes_per_evict: u64) -> Arc<Self> {
+            Arc::new(Self {
+                name: name.to_string(),
+                pressure_val: AtomicU64::new(pressure.to_bits()),
+                evict_count: AtomicU64::new(0),
+                bytes_per_evict,
+            })
+        }
+        fn set_pressure(&self, p: f64) {
+            self.pressure_val.store(p.to_bits(), Ordering::Release);
+        }
+        fn evict_count(&self) -> u64 {
+            self.evict_count.load(Ordering::Acquire)
+        }
+    }
+
+    impl PressureSource for MockPool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn pressure(&self) -> f64 {
+            f64::from_bits(self.pressure_val.load(Ordering::Acquire))
+        }
+        fn evict_some(&self) -> u64 {
+            self.evict_count.fetch_add(1, Ordering::AcqRel);
+            // Simulate eviction reducing pressure.
+            let cur = self.pressure();
+            self.set_pressure((cur - 0.3).max(0.0));
+            self.bytes_per_evict
+        }
+        fn stats_snapshot(&self) -> PoolStats {
+            PoolStats {
+                name: self.name.clone(),
+                entry_count: 0,
+                pinned_count: 0,
+                total_bytes: 0,
+                max_bytes: 0,
+                pressure: self.pressure(),
+                hit_count: 0,
+                miss_count: 0,
+                eviction_count: 0,
+                inflight_count: 0,
+            }
+        }
+    }
+
+    #[test]
+    fn tier_thresholds_match_gpu_pressure_watcher() {
+        assert_eq!(PressureTier::for_pressure(0.0), PressureTier::Normal);
+        assert_eq!(PressureTier::for_pressure(0.59), PressureTier::Normal);
+        assert_eq!(PressureTier::for_pressure(0.60), PressureTier::Warning);
+        assert_eq!(PressureTier::for_pressure(0.79), PressureTier::Warning);
+        assert_eq!(PressureTier::for_pressure(0.80), PressureTier::High);
+        assert_eq!(PressureTier::for_pressure(0.94), PressureTier::High);
+        assert_eq!(PressureTier::for_pressure(0.95), PressureTier::Critical);
+        assert_eq!(PressureTier::for_pressure(1.50), PressureTier::Critical);
+    }
+
+    #[test]
+    fn no_action_when_all_pools_normal() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        broker.register(MockPool::new("kv", 0.3, 1024));
+        broker.register(MockPool::new("lora", 0.5, 1024));
+        let report = broker.relieve();
+        assert!(!report.triggered);
+        assert_eq!(report.bytes_freed, 0);
+    }
+
+    #[test]
+    fn high_pressure_evicts_only_worst_pool() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        let kv = MockPool::new("kv", 0.85, 100);
+        let lora = MockPool::new("lora", 0.70, 100);
+        broker.register(kv.clone());
+        broker.register(lora.clone());
+        let report = broker.relieve();
+        assert!(report.triggered);
+        // Only KV should have been evicted (highest pressure, above 0.80 threshold).
+        // LoRA at 0.70 is below act_above, so even if "highest" it shouldn't fire.
+        assert_eq!(kv.evict_count(), 1);
+        assert_eq!(lora.evict_count(), 0);
+        assert_eq!(report.pools_acted, vec!["kv".to_string()]);
+        assert_eq!(report.bytes_freed, 100);
+    }
+
+    #[test]
+    fn critical_pressure_evicts_all_over_budget_pools() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        let kv = MockPool::new("kv", 0.97, 100);
+        let lora = MockPool::new("lora", 0.96, 100);
+        let model = MockPool::new("model", 0.50, 100); // not over budget
+        broker.register(kv.clone());
+        broker.register(lora.clone());
+        broker.register(model.clone());
+        let report = broker.relieve();
+        assert!(report.triggered);
+        assert_eq!(kv.evict_count(), 1, "KV should be evicted (critical)");
+        assert_eq!(lora.evict_count(), 1, "LoRA should be evicted (critical)");
+        assert_eq!(model.evict_count(), 0, "Model under budget, not evicted");
+        assert_eq!(report.bytes_freed, 200);
+    }
+
+    #[test]
+    fn registration_dedups_by_name() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        broker.register(MockPool::new("kv", 0.85, 100));
+        broker.register(MockPool::new("kv", 0.85, 100)); // same name — replaces
+        let report = broker.relieve();
+        // If dedup works, evict_some fires once. If not, twice (200 bytes).
+        assert_eq!(report.bytes_freed, 100);
+    }
+
+    #[test]
+    fn unregister_removes_pool() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        broker.register(MockPool::new("kv", 0.85, 100));
+        broker.unregister("kv");
+        let report = broker.relieve();
+        assert!(!report.triggered);
+        let snap = broker.snapshot();
+        assert_eq!(snap.pools.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn real_paged_resource_pool_plugs_into_broker_via_blanket_impl() {
+        use crate::paging::pool::{lru_priority, PagedResourcePool, PoolConfig};
+
+        // Build a real pool and fill it past the act_above threshold.
+        let pool: Arc<PagedResourcePool<String, Vec<u8>>> =
+            Arc::new(PagedResourcePool::new(PoolConfig {
+                name: "real-embeddings".to_string(),
+                max_bytes: 1000,
+                sizer: Arc::new(|v: &Vec<u8>| v.len() as u64),
+                eviction_priority: lru_priority(),
+            }));
+
+        // Insert 900 bytes (90% pressure → above 0.80 act threshold).
+        for i in 0..9 {
+            pool.load_or_share(format!("k{i}"), |_| async move { Ok(vec![0u8; 100]) })
+                .await
+                .unwrap();
+        }
+        assert!(pool.pressure() >= 0.80, "expected pressure ≥0.80, got {}", pool.pressure());
+        assert_eq!(pool.name(), "real-embeddings");
+
+        // Register via blanket impl — no adapter struct needed.
+        let broker = PressureBroker::new(BrokerConfig::default());
+        broker.register(pool.clone());
+
+        let report = broker.relieve();
+        assert!(report.triggered, "broker should fire on real pool over budget");
+        assert!(report.bytes_freed > 0, "blanket evict_some should free bytes");
+        assert_eq!(report.pools_acted, vec!["real-embeddings".to_string()]);
+        // Pressure should drop after eviction.
+        assert!(pool.pressure() < 0.80, "post-eviction pressure should be <0.80, got {}", pool.pressure());
+    }
+
+    #[test]
+    fn snapshot_orders_pools_by_pressure_descending() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        broker.register(MockPool::new("low", 0.2, 1));
+        broker.register(MockPool::new("high", 0.9, 1));
+        broker.register(MockPool::new("mid", 0.5, 1));
+        let snap = broker.snapshot();
+        assert_eq!(snap.pools[0].name, "high");
+        assert_eq!(snap.pools[1].name, "mid");
+        assert_eq!(snap.pools[2].name, "low");
+        assert!((snap.global_pressure - 0.9).abs() < 0.001);
+        assert_eq!(snap.global_tier, PressureTier::High);
+    }
+}

--- a/src/workers/continuum-core/src/paging/mod.rs
+++ b/src/workers/continuum-core/src/paging/mod.rs
@@ -15,8 +15,13 @@
 //!
 //! See: docs/architecture/UNIFIED-PAGING.md
 
+pub mod broker;
 pub mod pool;
 
+pub use broker::{
+    BrokerConfig, BrokerSnapshot, PoolView, PressureBroker, PressureSource, PressureTier,
+    ReliefReport,
+};
 pub use pool::{
     lru_priority, size_weighted_lru, EvictionPriority, PagedResourcePool, PinHandle, PoolConfig,
     PoolEntry, PoolEntryView, PoolStats, Sizer,

--- a/src/workers/continuum-core/src/paging/pool.rs
+++ b/src/workers/continuum-core/src/paging/pool.rs
@@ -232,6 +232,12 @@ where
         }
     }
 
+    /// Stable name from PoolConfig — used by PressureBroker for diagnostics
+    /// and by IPC stats exports.
+    pub fn config_name(&self) -> &str {
+        &self.inner.config.name
+    }
+
     /// L1 hit — returns the value if cached, None on miss. Concurrent
     /// readers run in parallel under RwLock::read; per-entry atomics
     /// update last_access_at + access_count without serializing.
@@ -336,6 +342,85 @@ where
             return true;
         }
         false
+    }
+
+    /// Trigger an eviction pass without inserting anything new. Used by
+    /// the PressureBroker to free bytes when global pressure crosses a
+    /// threshold — the pool itself may not be over its own budget yet,
+    /// but the broker decides we should give some back. Returns the
+    /// total bytes freed in this pass.
+    ///
+    /// Eviction policy is the same as the insert-triggered path: drop
+    /// unpinned entries by `eviction_priority` order until occupancy
+    /// is at 75% of `max_bytes`. Pinned entries untouched.
+    pub fn evict_under_pressure(&self) -> u64 {
+        let target_bytes = (self.inner.config.max_bytes as f64 * 0.75) as u64;
+        let mut entries = self.inner.entries.write();
+        let initial_bytes: u64 = entries.values().map(|e| e.size_bytes).sum();
+        let mut total_bytes = initial_bytes;
+        let mut candidates: Vec<(K, i64, u64)> = entries
+            .iter()
+            .filter(|(_, e)| e.pin_count.load(Ordering::Acquire) == 0)
+            .map(|(k, e)| {
+                let view = PoolEntryView {
+                    size_bytes: e.size_bytes,
+                    pin_count: e.pin_count.load(Ordering::Acquire),
+                    loaded_at: e.loaded_at,
+                    last_access_at: e.last_access_at.load(Ordering::Acquire),
+                    access_count: e.access_count.load(Ordering::Acquire),
+                };
+                (k.clone(), (self.inner.config.eviction_priority)(&view), e.size_bytes)
+            })
+            .collect();
+        candidates.sort_by_key(|(_, prio, _)| *prio);
+        let mut evicted_count: u64 = 0;
+        for (k, _, size) in candidates {
+            if total_bytes <= target_bytes {
+                break;
+            }
+            entries.remove(&k);
+            total_bytes -= size;
+            evicted_count += 1;
+        }
+        if evicted_count > 0 {
+            self.inner.evictions.fetch_add(evicted_count, Ordering::Relaxed);
+        }
+        initial_bytes.saturating_sub(total_bytes)
+    }
+
+    /// Synchronous version of `stats()` — needed by `PressureSource`
+    /// implementors that can't .await (the broker's tick loop wants
+    /// non-blocking pressure reads). Excludes inflight count (which
+    /// requires async lock); leaves it as 0 since that's a transient
+    /// signal anyway, not pressure-relevant.
+    pub fn stats_blocking(&self) -> PoolStats {
+        let entries = self.inner.entries.read();
+        let mut total_bytes: u64 = 0;
+        let mut pinned_count: usize = 0;
+        for entry in entries.values() {
+            total_bytes += entry.size_bytes;
+            if entry.pin_count.load(Ordering::Acquire) > 0 {
+                pinned_count += 1;
+            }
+        }
+        let max_bytes = self.inner.config.max_bytes;
+        let pressure = if max_bytes > 0 {
+            total_bytes as f64 / max_bytes as f64
+        } else {
+            0.0
+        };
+        PoolStats {
+            name: self.inner.config.name.clone(),
+            entry_count: entries.len(),
+            pinned_count,
+            total_bytes,
+            max_bytes,
+            pressure,
+            hit_count: self.inner.hits.load(Ordering::Relaxed),
+            miss_count: self.inner.misses.load(Ordering::Relaxed),
+            eviction_count: self.inner.evictions.load(Ordering::Relaxed),
+            inflight_count: 0,
+        }
     }
 
     /// Snapshot stats for monitoring + PressureBroker queries.


### PR DESCRIPTION
## Summary

The PagedResourcePool primitive (PR #930) is the per-resource brain. **PressureBroker is the cross-resource brain** — one orchestrator that reads pressure from every registered pool, decides which to relieve, and pulls the eviction lever. Same broker is the future home of recipe-aware priority arbitration (Phase 9), ML-policy-driven tiering (7b), and LLM-mediated control for novel pressure situations (7c).

This PR lands **Phase 7a** — the trait + broker + tier-driven relief loop in Rust. 7b/7c plug in later by overriding \`PoolConfig::eviction_priority\`, **without changing the broker API**.

## What's in this commit

- \`PressureSource\` trait — \`name\` + \`pressure\` + \`evict_some\` + \`stats_snapshot\`
- \`PressureBroker\` struct: \`register\` / \`unregister\` / \`relieve\` / \`snapshot\` / \`spawn_tick\`
- \`PressureTier\` (Normal / Warning / High / Critical at 0.6 / 0.8 / 0.95 — same thresholds as \`GpuPressureWatcher\` for system-wide consistency)
- Tier-driven relief: Normal/Warning observe; High evicts the worst pool; Critical evicts all over-budget pools
- **Blanket impl** — every \`PagedResourcePool<K, V>\` auto-satisfies \`PressureSource\`. Consumers just register \`Arc<PagedResourcePool<...>>\`. No adapter struct, no per-consumer wiring boilerplate.
- New pool methods: \`evict_under_pressure\` (broker-callable), \`stats_blocking\` (sync), \`config_name\`

## Tests (8/8 passing — \`cargo test --lib paging::broker\`)

- \`tier_thresholds_match_gpu_pressure_watcher\`
- \`no_action_when_all_pools_normal\`
- \`high_pressure_evicts_only_worst_pool\`
- \`critical_pressure_evicts_all_over_budget_pools\`
- \`registration_dedups_by_name\`
- \`unregister_removes_pool\`
- \`real_paged_resource_pool_plugs_into_broker_via_blanket_impl\` ← integration test that proves the architectural point: build a real \`PagedResourcePool<String, Vec<u8>>\`, fill it past 0.80 pressure, register via blanket impl, call \`relieve()\`, watch pressure drop. End-to-end with no shim.
- \`snapshot_orders_pools_by_pressure_descending\`

## What's NOT in this PR (intentionally — separate phases)

- ML/LLM policy hook → 7b (the broker exposes the lever; the brain plugs in via \`PoolConfig::eviction_priority\`)
- Recipe activation/deactivation hooks → Phase 9
- Cross-machine pressure → grid-level paging (its own layer)
- Migrating existing consumers (EmbeddingCache, LoRAAdapterPool, TieredMemoryCache) → Phases 2/3/6, separate PRs (memento taking 2 + 3)

## Architecture context

See \`docs/architecture/RESOURCE-ARCHITECTURE.md\` Phase 7 section — updated with the 7a/7b/7c split. Status table updated to show Phase 7a scaffolding shipping in this PR.

## Test plan

- [x] \`cargo test --features metal,accelerate --lib paging\` — all 49 paging tests pass (8 broker + 41 existing)
- [x] Integration test proves \`PagedResourcePool\` plugs in via blanket impl with no adapter
- [x] No regressions in existing \`paging::pool\` tests
- [ ] Reviewer: confirm trait shape is what the consumer migrations (Phase 2/3) want — if not, easier to fix now than after EmbeddingCache adopts it

🤖 Generated with [Claude Code](https://claude.com/claude-code)