### PR TITLE
feat(paging): EmbeddingCache → PagedResourcePool (Phase 2 — fixes 0/64 hit rate)

### DIFF
--- a/docs/architecture/RESOURCE-ARCHITECTURE.md
+++ b/docs/architecture/RESOURCE-ARCHITECTURE.md
@@ -268,7 +268,7 @@ This architecture is what the work tonight is building toward. Inventory:
 | `RustEmbeddingClient` | Existing | Will adopt EmbeddingPool migration; fixes 0/64 hits |
 | `GpuMemoryManager` | Existing | Provides GPU pressure signal to broker |
 | `ResourcePressureWatcher` | Existing | Provides RAM/CPU pressure signal to broker |
-| **PressureBroker** | **Phase 7 — not started** | Cross-resource orchestrator |
+| **PressureBroker** | **Phase 7a — scaffolding shipping (this PR)** | Cross-resource orchestrator |
 | `LiveCallTracker` etc. | Existing | Exclusive stateful lifecycle (correctly outside paging architecture) |
 
 ---
@@ -301,6 +301,12 @@ Wire `forcedState` from broker into `PersonaState`. Less-active reduces RAG sour
 
 ### Phase 7 — PressureBroker
 Cross-pool eviction orchestration + priority arbitration + dormancy decisions. Heuristic first, ML/LLM later via the levers the pool exposes.
+
+**7a (this PR) — scaffolding.** `PressureSource` trait + `PressureBroker` struct + tier-based relief + tick loop in Rust (`src/workers/continuum-core/src/paging/broker.rs`). Blanket impl wires every `PagedResourcePool<K, V>` straight in — register an `Arc<PagedResourcePool<...>>` and the broker reads pressure + fires eviction per the tier ladder (Normal/Warning observe; High evicts worst pool; Critical evicts all over-budget pools). 8 unit tests cover trait, tier mapping, registration dedup, and a real-pool-via-blanket-impl integration test. Heuristic only; the ML/LLM layer (7b/7c) plugs in by overriding `PoolConfig::eviction_priority` per pool, not by replacing the broker.
+
+**7b — ML-policy.** Activity prediction (which keys are about to be needed) feeds `evict_some` selection. Same broker shape; just smarter `eviction_priority` callbacks. Decoupled from 7a delivery.
+
+**7c — LLM-mediated.** For novel pressure situations the heuristics don't cover (recipe-aware reshaping, multi-machine grid pressure, quality-vs-speed trade-offs the user cares about), the broker exposes its `BrokerSnapshot` to a control LLM and accepts back per-pool eviction directives + dormancy state changes. Same broker shape.
 
 ### Phase 8 — MoE forge + MoEExpertPool
 When MoE-forged Qwen3.5-A8B-MoE lands: `<ExpertId, ExpertWeights>` pool. Router pins active experts per token. Enables 32B-MoE intelligence on 16 GB MacBook Air.

--- a/src/workers/continuum-core/src/modules/embedding.rs
+++ b/src/workers/continuum-core/src/modules/embedding.rs
@@ -28,7 +28,9 @@ use tracing::{info, warn};
 
 use crate::gpu::make_entry;
 use crate::gpu::memory_manager::{GpuAllocationGuard, GpuMemoryManager, GpuPriority, GpuSubsystem};
+use crate::paging::{size_weighted_lru, PagedResourcePool, PoolConfig};
 use crate::utils::params::Params;
+use sha2::{Digest, Sha256};
 
 /// Global model cache - models loaded on demand
 static MODEL_CACHE: OnceCell<Arc<Mutex<HashMap<String, TextEmbedding>>>> = OnceCell::new();
@@ -61,91 +63,58 @@ fn get_model_cache() -> &'static Arc<Mutex<HashMap<String, TextEmbedding>>> {
     MODEL_CACHE.get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
 }
 
-/// Global embedding result cache - avoids recomputing same text embeddings
-/// Key: (model_name, text_hash) -> embedding vector
-/// TTL: Entries older than 5 minutes are evicted on access
-static EMBEDDING_CACHE: OnceCell<Arc<Mutex<EmbeddingResultCache>>> = OnceCell::new();
-
-struct CachedEmbedding {
-    embedding: Vec<f32>,
-    created_at: Instant,
+/// Embedding pool key: (model, content_hash). The model is part of the key
+/// because different models map the same text to different vectors. Content
+/// hash is SHA-256 of the input text — collision-free in practice and fixed
+/// at 32 bytes (no per-key allocation for the text itself).
+#[derive(Clone, Hash, Eq, PartialEq, Debug)]
+pub struct EmbeddingKey {
+    pub model: String,
+    pub content_hash: [u8; 32],
 }
 
-struct EmbeddingResultCache {
-    entries: HashMap<(String, u64), CachedEmbedding>,
-    ttl: std::time::Duration,
-    max_entries: usize,
-    hits: u64,
-    misses: u64,
-}
-
-impl EmbeddingResultCache {
-    fn new() -> Self {
+impl EmbeddingKey {
+    fn new(model: &str, text: &str) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(text.as_bytes());
+        let digest = hasher.finalize();
+        let mut content_hash = [0u8; 32];
+        content_hash.copy_from_slice(&digest);
         Self {
-            entries: HashMap::new(),
-            ttl: std::time::Duration::from_secs(300), // 5 minutes
-            max_entries: 10_000,
-            hits: 0,
-            misses: 0,
+            model: model.to_string(),
+            content_hash,
         }
-    }
-
-    fn get(&mut self, model: &str, text_hash: u64) -> Option<Vec<f32>> {
-        let key = (model.to_string(), text_hash);
-        if let Some(entry) = self.entries.get(&key) {
-            if entry.created_at.elapsed() < self.ttl {
-                self.hits += 1;
-                return Some(entry.embedding.clone());
-            }
-            // Expired - remove it
-            self.entries.remove(&key);
-        }
-        self.misses += 1;
-        None
-    }
-
-    fn insert(&mut self, model: &str, text_hash: u64, embedding: Vec<f32>) {
-        // Sweep expired entries before inserting (amortized cleanup)
-        let ttl = self.ttl;
-        self.entries.retain(|_, v| v.created_at.elapsed() < ttl);
-
-        // Evict oldest if still at capacity after sweep
-        if self.entries.len() >= self.max_entries {
-            if let Some(oldest_key) = self
-                .entries
-                .iter()
-                .min_by_key(|(_, v)| v.created_at)
-                .map(|(k, _)| k.clone())
-            {
-                self.entries.remove(&oldest_key);
-            }
-        }
-
-        self.entries.insert(
-            (model.to_string(), text_hash),
-            CachedEmbedding {
-                embedding,
-                created_at: Instant::now(),
-            },
-        );
-    }
-
-    fn stats(&self) -> (u64, u64, usize) {
-        (self.hits, self.misses, self.entries.len())
     }
 }
 
-fn get_embedding_cache() -> &'static Arc<Mutex<EmbeddingResultCache>> {
-    EMBEDDING_CACHE.get_or_init(|| Arc::new(Mutex::new(EmbeddingResultCache::new())))
-}
+/// Default budget for the embedding pool. Tuned for the average codebase
+/// indexer + RAG workload: 384-dim FP32 ≈ 1.5 KB per vector → 256 MB holds
+/// ~170k entries, comfortably more than the previous 10k count cap.
+/// Eventually overridden by recipe-declared budgets (Phase 9) and pressure
+/// broker (Phase 7b).
+const EMBEDDING_POOL_BUDGET_BYTES: u64 = 256 * 1024 * 1024;
 
-/// Fast hash for text (djb2 algorithm)
-fn hash_text(text: &str) -> u64 {
-    let mut hash: u64 = 5381;
-    for byte in text.bytes() {
-        hash = hash.wrapping_mul(33).wrapping_add(byte as u64);
-    }
-    hash
+/// Global embedding pool — single source of truth for cached embeddings.
+/// Replaces the old per-IPC `EMBEDDING_CACHE` that internal Rust callers
+/// (DataModule, memory providers) were silently bypassing — those now
+/// route through `generate_embedding{,s_batch}` and inherit cache hits
+/// for free.
+static EMBEDDING_POOL: OnceCell<Arc<PagedResourcePool<EmbeddingKey, Vec<f32>>>> = OnceCell::new();
+
+fn get_embedding_pool() -> &'static Arc<PagedResourcePool<EmbeddingKey, Vec<f32>>> {
+    EMBEDDING_POOL.get_or_init(|| {
+        Arc::new(PagedResourcePool::new(PoolConfig {
+            name: "embedding-cache".to_string(),
+            max_bytes: EMBEDDING_POOL_BUDGET_BYTES,
+            // Sizer: 4 bytes per f32 dimension. Accurate to within an
+            // allocator-rounding constant; pool budgeting is byte-driven.
+            sizer: Arc::new(|emb: &Vec<f32>| (emb.len() * std::mem::size_of::<f32>()) as u64),
+            // Size-weighted LRU: among similarly-aged entries, evict the
+            // largest first (frees more memory per drop). Right policy for
+            // mixed-dimension models in one pool.
+            eviction_priority: size_weighted_lru(),
+        }))
+    })
 }
 
 /// Get cache directory for fastembed models
@@ -301,28 +270,39 @@ fn get_or_load_model(model_name: &str) -> Result<(), String> {
 /// Public function for cross-module embedding generation
 /// Used by DataModule for backfillVectors
 pub fn generate_embedding(text: &str, model_name: &str) -> Result<Vec<f32>, String> {
-    // Load model if needed
-    get_or_load_model(model_name)?;
+    // Pool check first — the cache lookup that internal callers used to
+    // bypass. This is the 0/64-hit-rate fix: now every internal embedder
+    // (DataModule.backfill_vectors, ModuleBackedEmbeddingProvider, etc.)
+    // hits the same cache the IPC handler does.
+    let pool = get_embedding_pool();
+    let key = EmbeddingKey::new(model_name, text);
+    if let Some(cached) = pool.get(&key) {
+        return Ok(cached);
+    }
 
-    // Get model from cache
+    // Miss → load model + embed + cache.
+    get_or_load_model(model_name)?;
     let cache = get_model_cache();
     let mut models = cache.lock().map_err(|e| format!("Lock error: {e}"))?;
     let embedding_model = models
         .get_mut(model_name)
         .ok_or_else(|| format!("Model not loaded: {model_name}"))?;
-
-    // Generate embedding for single text
     let embeddings = embedding_model
         .embed(vec![text], None)
         .map_err(|e| format!("Embedding generation failed: {e}"))?;
-
-    embeddings
+    let embedding = embeddings
         .into_iter()
         .next()
-        .ok_or_else(|| "No embedding returned".to_string())
+        .ok_or_else(|| "No embedding returned".to_string())?;
+
+    pool.insert(key, embedding.clone());
+    Ok(embedding)
 }
 
-/// Batch embedding generation for efficiency
+/// Batch embedding generation. Pool-aware: per-text cache lookup, single
+/// `model.embed()` call for the uncached subset, then per-text insert.
+/// One model invocation per batch (vs N for per-text single-flight) keeps
+/// the GPU/ONNX path efficient.
 pub fn generate_embeddings_batch(
     texts: &[&str],
     model_name: &str,
@@ -331,20 +311,45 @@ pub fn generate_embeddings_batch(
         return Ok(vec![]);
     }
 
-    // Load model if needed
-    get_or_load_model(model_name)?;
+    let pool = get_embedding_pool();
 
-    // Get model from cache
-    let cache = get_model_cache();
-    let mut models = cache.lock().map_err(|e| format!("Lock error: {e}"))?;
-    let embedding_model = models
-        .get_mut(model_name)
-        .ok_or_else(|| format!("Model not loaded: {model_name}"))?;
+    // Pre-fill from cache; collect misses for batched generation.
+    let mut results: Vec<Option<Vec<f32>>> = Vec::with_capacity(texts.len());
+    let mut keys: Vec<EmbeddingKey> = Vec::with_capacity(texts.len());
+    let mut misses: Vec<(usize, &str)> = Vec::new();
+    for (i, text) in texts.iter().enumerate() {
+        let key = EmbeddingKey::new(model_name, text);
+        if let Some(cached) = pool.get(&key) {
+            results.push(Some(cached));
+        } else {
+            results.push(None);
+            misses.push((i, *text));
+        }
+        keys.push(key);
+    }
 
-    // Generate embeddings
-    embedding_model
-        .embed(texts, None)
-        .map_err(|e| format!("Embedding generation failed: {e}"))
+    // Generate only the misses — one batched model.embed() call.
+    if !misses.is_empty() {
+        get_or_load_model(model_name)?;
+        let cache = get_model_cache();
+        let mut models = cache.lock().map_err(|e| format!("Lock error: {e}"))?;
+        let embedding_model = models
+            .get_mut(model_name)
+            .ok_or_else(|| format!("Model not loaded: {model_name}"))?;
+        let miss_texts: Vec<&str> = misses.iter().map(|(_, t)| *t).collect();
+        let new_embeddings = embedding_model
+            .embed(miss_texts, None)
+            .map_err(|e| format!("Embedding generation failed: {e}"))?;
+        for ((idx, _), emb) in misses.into_iter().zip(new_embeddings.into_iter()) {
+            pool.insert(keys[idx].clone(), emb.clone());
+            results[idx] = Some(emb);
+        }
+    }
+
+    Ok(results
+        .into_iter()
+        .map(|opt| opt.expect("every slot was either cached or generated"))
+        .collect())
 }
 
 // ─── Similarity Functions ───────────────────────────────────────────────────
@@ -659,56 +664,14 @@ impl EmbeddingModule {
         let start = Instant::now();
         let batch_size = texts.len();
 
-        // Check embedding cache for each text
-        let embed_cache = get_embedding_cache();
-        let mut embeddings: Vec<Vec<f32>> = Vec::with_capacity(batch_size);
-        let mut texts_to_generate: Vec<(usize, String)> = Vec::new(); // (index, text)
-
-        {
-            let mut cache = embed_cache
-                .lock()
-                .map_err(|e| format!("Cache lock error: {e}"))?;
-            for (i, text) in texts.iter().enumerate() {
-                let text_hash = hash_text(text);
-                if let Some(cached) = cache.get(model_name, text_hash) {
-                    embeddings.push(cached);
-                } else {
-                    embeddings.push(vec![]); // Placeholder
-                    texts_to_generate.push((i, text.clone()));
-                }
-            }
-        }
-
-        let cache_hits = batch_size - texts_to_generate.len();
-
-        // Generate embeddings only for texts not in cache
-        if !texts_to_generate.is_empty() {
-            // Load model if needed
-            get_or_load_model(model_name)?;
-
-            // Get model from cache
-            let model_cache = get_model_cache();
-            let mut models = model_cache.lock().map_err(|e| format!("Lock error: {e}"))?;
-            let embedding_model = models
-                .get_mut(model_name)
-                .ok_or_else(|| format!("Model not loaded: {model_name}"))?;
-
-            // Generate embeddings for uncached texts
-            let text_refs: Vec<&str> = texts_to_generate.iter().map(|(_, t)| t.as_str()).collect();
-            let new_embeddings = embedding_model
-                .embed(text_refs, None)
-                .map_err(|e| format!("Embedding generation failed: {e}"))?;
-
-            // Store in cache and update result vector
-            let mut cache = embed_cache
-                .lock()
-                .map_err(|e| format!("Cache lock error: {e}"))?;
-            for ((idx, text), emb) in texts_to_generate.iter().zip(new_embeddings.into_iter()) {
-                let text_hash = hash_text(text);
-                cache.insert(model_name, text_hash, emb.clone());
-                embeddings[*idx] = emb;
-            }
-        }
+        // Pool-backed generation — cache check + batched miss-fill happens
+        // inside `generate_embeddings_batch`. Same path internal callers
+        // take, so cache hits accrue across IPC + Rust consumers uniformly.
+        let pool_hits_before = get_embedding_pool().stats_blocking().hit_count;
+        let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+        let embeddings = generate_embeddings_batch(&text_refs, model_name)?;
+        let cache_hits =
+            (get_embedding_pool().stats_blocking().hit_count - pool_hits_before) as usize;
 
         let duration_ms = start.elapsed().as_millis() as u64;
         let dimensions = embeddings.first().map(|e| e.len()).unwrap_or(0);
@@ -932,40 +895,35 @@ impl EmbeddingModule {
         })))
     }
 
-    /// Handle embedding/cache/stats - get cache hit/miss statistics
+    /// Handle embedding/cache/stats - get cache hit/miss + pressure
+    /// statistics from the embedding pool. Now byte-driven (pressure +
+    /// max_bytes) rather than count-capped — see EMBEDDING_POOL_BUDGET_BYTES.
     fn handle_cache_stats(&self) -> Result<CommandResult, String> {
-        let embed_cache = get_embedding_cache();
-        let cache = embed_cache
-            .lock()
-            .map_err(|e| format!("Cache lock error: {e}"))?;
-        let (hits, misses, size) = cache.stats();
-        let hit_rate = if hits + misses > 0 {
-            (hits as f64) / ((hits + misses) as f64) * 100.0
+        let stats = get_embedding_pool().stats_blocking();
+        let total = stats.hit_count + stats.miss_count;
+        let hit_rate = if total > 0 {
+            (stats.hit_count as f64) / (total as f64) * 100.0
         } else {
             0.0
         };
 
         Ok(CommandResult::Json(json!({
-            "hits": hits,
-            "misses": misses,
-            "size": size,
-            "maxSize": 10_000,
+            "hits": stats.hit_count,
+            "misses": stats.miss_count,
+            "size": stats.entry_count,
+            "pinned": stats.pinned_count,
+            "totalBytes": stats.total_bytes,
+            "maxBytes": stats.max_bytes,
+            "pressure": stats.pressure,
+            "evictions": stats.eviction_count,
             "hitRatePercent": format!("{:.1}", hit_rate),
-            "ttlSeconds": 300
         })))
     }
 
-    /// Handle embedding/cache/clear - clear the embedding cache
+    /// Handle embedding/cache/clear - drain the embedding pool. Resets
+    /// hit/miss/eviction counters too (admin-level reset).
     fn handle_cache_clear(&self) -> Result<CommandResult, String> {
-        let embed_cache = get_embedding_cache();
-        let mut cache = embed_cache
-            .lock()
-            .map_err(|e| format!("Cache lock error: {e}"))?;
-        let cleared = cache.entries.len();
-        cache.entries.clear();
-        cache.hits = 0;
-        cache.misses = 0;
-
+        let cleared = get_embedding_pool().clear();
         info!("Cleared {} cached embeddings", cleared);
 
         Ok(CommandResult::Json(json!({
@@ -1075,5 +1033,111 @@ impl ServiceModule for EmbeddingModule {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pool integration tests. Don't load real ONNX models — pre-populate
+    //! the pool with synthetic embeddings and verify the lookup path
+    //! short-circuits before fastembed is called. The "0/64 hit rate"
+    //! regression test sits here.
+    //!
+    //! NOTE: `EMBEDDING_POOL` is a process-global; cargo test runs tests
+    //! in parallel by default and would race on the shared hit/miss
+    //! counters. `TEST_LOCK` serializes the cases that read counters; the
+    //! pure-key-shape test (`embedding_key_is_model_namespaced`) doesn't
+    //! need the lock.
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    fn fake_embedding(seed: u8) -> Vec<f32> {
+        (0..384).map(|i| (i as f32 + seed as f32) * 0.001).collect()
+    }
+
+    /// The bug we're fixing: internal callers used to bypass the cache
+    /// entirely. After migration, `generate_embeddings_batch` consults
+    /// the pool first and returns cached entries without touching the
+    /// model — proven here by pre-loading the pool with a known vector
+    /// for a model that doesn't exist (so a real model.embed() would
+    /// error out).
+    #[test]
+    fn generate_embeddings_batch_hits_pool_before_loading_model() {
+        let _g = TEST_LOCK.lock().unwrap();
+        let pool = get_embedding_pool();
+        pool.clear();
+        let key = EmbeddingKey::new("nonexistent-model-name", "the cached text");
+        let expected = fake_embedding(7);
+        pool.insert(key, expected.clone());
+
+        let got = generate_embeddings_batch(&["the cached text"], "nonexistent-model-name")
+            .expect("cache hit should succeed without loading the (nonexistent) model");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0], expected);
+
+        // Hit accounted for in pool stats.
+        let stats = pool.stats_blocking();
+        assert!(stats.hit_count >= 1, "expected ≥1 hit, got {}", stats.hit_count);
+    }
+
+    #[test]
+    fn single_embedding_hits_pool_before_loading_model() {
+        let _g = TEST_LOCK.lock().unwrap();
+        let pool = get_embedding_pool();
+        pool.clear();
+        let key = EmbeddingKey::new("nonexistent-model-name", "single text");
+        let expected = fake_embedding(11);
+        pool.insert(key, expected.clone());
+
+        let got = generate_embedding("single text", "nonexistent-model-name")
+            .expect("cache hit should bypass model load");
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn embedding_key_is_model_namespaced() {
+        // Same text + different model = different cache slots. Critical
+        // because different models map identical text to different vectors.
+        let k1 = EmbeddingKey::new("modelA", "hello");
+        let k2 = EmbeddingKey::new("modelB", "hello");
+        assert_ne!(k1, k2, "same-text + different-model must not collide");
+
+        let k3 = EmbeddingKey::new("modelA", "hello");
+        assert_eq!(k1, k3, "deterministic: same model + text → same key");
+    }
+
+    #[test]
+    fn pool_clear_resets_stats_and_drops_entries() {
+        let _g = TEST_LOCK.lock().unwrap();
+        let pool = get_embedding_pool();
+        let key = EmbeddingKey::new("test", "to be cleared");
+        pool.insert(key.clone(), fake_embedding(3));
+        let _ = pool.get(&key); // force a hit
+        let dropped = pool.clear();
+        assert!(dropped >= 1, "expected ≥1 entry dropped, got {}", dropped);
+        let stats = pool.stats_blocking();
+        assert_eq!(stats.hit_count, 0, "clear resets hits");
+        assert_eq!(stats.miss_count, 0, "clear resets misses");
+        assert_eq!(stats.entry_count, 0, "all entries dropped");
+    }
+
+    #[test]
+    fn batch_with_partial_hits_records_correct_hit_count() {
+        let _g = TEST_LOCK.lock().unwrap();
+        let pool = get_embedding_pool();
+        pool.clear();
+        // Pre-populate two of three entries.
+        let model = "nonexistent-batch-test-model";
+        pool.insert(EmbeddingKey::new(model, "cached_a"), fake_embedding(1));
+        pool.insert(EmbeddingKey::new(model, "cached_b"), fake_embedding(2));
+        // Calling batch with only the cached texts should fully short-circuit.
+        let got = generate_embeddings_batch(&["cached_a", "cached_b"], model)
+            .expect("all-hit batch should succeed without model load");
+        assert_eq!(got.len(), 2);
+        let stats = pool.stats_blocking();
+        assert_eq!(stats.hit_count, 2);
+        assert_eq!(stats.miss_count, 0);
     }
 }

--- a/src/workers/continuum-core/src/paging/broker.rs
+++ b/src/workers/continuum-core/src/paging/broker.rs
@@ -1,0 +1,498 @@
+//! PressureBroker — cross-pool eviction orchestration.
+//!
+//! Phase 7 of the resource architecture (RESOURCE-ARCHITECTURE.md).
+//!
+//! The PagedResourcePool primitive is the per-resource brain. The broker
+//! is the cross-resource brain: one orchestrator that reads pressure
+//! from every registered pool, decides which to relieve, and pulls the
+//! eviction lever. Same broker is the future home of recipe-aware
+//! priority arbitration, ML-policy-driven tiering decisions, and
+//! eventually LLM-mediated control for novel pressure situations.
+//!
+//! This commit lands the trait + broker scaffolding + tick loop. Pools
+//! register themselves as `PressureSource` implementors; the broker
+//! aggregates pressure on a periodic tick; when global pressure crosses
+//! threshold, eviction fires on the highest-pressure pool first.
+//!
+//! What's NOT in this commit (intentionally — separate phases):
+//!   - ML/LLM policy hook (the broker exposes the lever; the brain
+//!     plugs in later via PressureSource priority overrides)
+//!   - Recipe activation/deactivation hooks (Phase 9)
+//!   - Cross-machine pressure (grid-level paging is its own layer)
+//!
+//! See: docs/architecture/RESOURCE-ARCHITECTURE.md (Phase 7)
+
+use std::hash::Hash;
+use std::sync::Arc;
+use std::time::Duration;
+use parking_lot::RwLock;
+use crate::paging::pool::{PagedResourcePool, PoolStats};
+
+/// Anything the broker can read pressure from + evict to relieve it.
+///
+/// Implemented by every paged resource pool in the system. The trait is
+/// deliberately minimal — name for diagnostics, pressure for decisions,
+/// `evict_some` for action. Eviction strategy lives inside the pool;
+/// the broker just asks for some relief.
+pub trait PressureSource: Send + Sync {
+    /// Stable identifier used in logs and broker diagnostics.
+    fn name(&self) -> &str;
+
+    /// Current pressure 0.0..1.0 (or higher if over-budget). Snapshot
+    /// only — no side effects. Cheap; called every tick from the broker.
+    fn pressure(&self) -> f64;
+
+    /// Drop unpinned entries until pressure returns to a healthy level.
+    /// Returns the byte count freed (or 0 if nothing was evictable —
+    /// fully pinned pool).
+    fn evict_some(&self) -> u64;
+
+    /// Snapshot stats for monitoring / IPC export. Same shape as
+    /// `PagedResourcePool::stats()` so the broker can present a
+    /// uniform view across pools of any value type.
+    fn stats_snapshot(&self) -> PoolStats;
+}
+
+/// Blanket impl — every `PagedResourcePool<K, V>` automatically satisfies
+/// `PressureSource`. Consumers wrap their pool in `Arc<...>` and pass it
+/// straight to `broker.register()`; no per-pool adapter struct needed.
+///
+/// This is the architectural point of the trait: the broker speaks a tiny
+/// interface, every pool plugs in for free, and future ML/LLM policy
+/// hooks can specialize behavior per pool by overriding the `evict_some`
+/// strategy via `PoolConfig::eviction_priority` instead of by writing a
+/// custom `PressureSource`.
+impl<K, V> PressureSource for PagedResourcePool<K, V>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    fn name(&self) -> &str {
+        self.config_name()
+    }
+    fn pressure(&self) -> f64 {
+        self.stats_blocking().pressure
+    }
+    fn evict_some(&self) -> u64 {
+        self.evict_under_pressure()
+    }
+    fn stats_snapshot(&self) -> PoolStats {
+        self.stats_blocking()
+    }
+}
+
+/// Pressure tier — drives the broker's response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PressureTier {
+    /// All pools comfortably under their budgets.
+    Normal,
+    /// Some pool approaching its limit. Broker relieves the worst pool.
+    Warning,
+    /// Multiple pools at or over budget. Broker fires parallel eviction.
+    High,
+    /// System in real trouble — aggressive eviction across all pools.
+    Critical,
+}
+
+impl PressureTier {
+    /// Map a pressure ratio (0.0..) to a tier. Same thresholds as
+    /// GpuPressureWatcher uses — keeps the system's mental model
+    /// consistent across resource types.
+    pub fn for_pressure(p: f64) -> Self {
+        if p >= 0.95 {
+            PressureTier::Critical
+        } else if p >= 0.80 {
+            PressureTier::High
+        } else if p >= 0.60 {
+            PressureTier::Warning
+        } else {
+            PressureTier::Normal
+        }
+    }
+}
+
+/// Broker configuration. All fields required (no Option<>) per Joel's
+/// required-not-optional discipline.
+#[derive(Debug, Clone)]
+pub struct BrokerConfig {
+    /// Tick period — how often the broker checks pressure and acts.
+    /// Default 5 seconds; faster ticks waste CPU on quiet pools, slower
+    /// ticks let pressure spike before relief fires.
+    pub tick_interval: Duration,
+    /// Pressure threshold above which the broker fires eviction.
+    /// Below this, the broker watches but doesn't act.
+    pub act_above: f64,
+}
+
+impl Default for BrokerConfig {
+    fn default() -> Self {
+        Self {
+            tick_interval: Duration::from_secs(5),
+            act_above: 0.80, // High tier
+        }
+    }
+}
+
+/// Per-pool snapshot exposed to monitoring / IPC.
+#[derive(Debug, Clone)]
+pub struct PoolView {
+    pub name: String,
+    pub pressure: f64,
+    pub tier: PressureTier,
+    pub stats: PoolStats,
+}
+
+/// Full broker state snapshot — for the future PressureBroker IPC command
+/// + monitoring widget.
+#[derive(Debug, Clone)]
+pub struct BrokerSnapshot {
+    pub global_pressure: f64,
+    pub global_tier: PressureTier,
+    pub pools: Vec<PoolView>,
+    pub evictions_fired: u64,
+    pub bytes_freed_total: u64,
+}
+
+/// Result of a relief action.
+#[derive(Debug, Clone)]
+pub struct ReliefReport {
+    pub triggered: bool,
+    pub global_pressure_before: f64,
+    pub bytes_freed: u64,
+    pub pools_acted: Vec<String>,
+}
+
+/// Cross-pool pressure orchestrator. Singleton in practice; one per
+/// process is sufficient (cross-machine pressure lives at the grid
+/// layer, not here).
+pub struct PressureBroker {
+    pools: RwLock<Vec<Arc<dyn PressureSource>>>,
+    config: BrokerConfig,
+    evictions_fired: parking_lot::Mutex<u64>,
+    bytes_freed: parking_lot::Mutex<u64>,
+}
+
+impl PressureBroker {
+    pub fn new(config: BrokerConfig) -> Self {
+        Self {
+            pools: RwLock::new(Vec::new()),
+            config,
+            evictions_fired: parking_lot::Mutex::new(0),
+            bytes_freed: parking_lot::Mutex::new(0),
+        }
+    }
+
+    /// Register a pool as a pressure source. The broker holds a weak-ish
+    /// reference (Arc) so pools that outlive the broker stay valid; the
+    /// broker iterates the registered set each tick.
+    pub fn register(&self, pool: Arc<dyn PressureSource>) {
+        let mut pools = self.pools.write();
+        let name = pool.name().to_string();
+        // Dedup by name — registering twice replaces (avoids duplicate eviction calls).
+        pools.retain(|p| p.name() != name);
+        pools.push(pool);
+    }
+
+    /// Drop a pool from the broker's awareness (e.g., on shutdown of
+    /// a subsystem that owned the pool).
+    pub fn unregister(&self, name: &str) {
+        let mut pools = self.pools.write();
+        pools.retain(|p| p.name() != name);
+    }
+
+    /// Read pressure across all pools — global = max(per-pool). Cheap;
+    /// the broker calls this every tick.
+    pub fn global_pressure(&self) -> f64 {
+        let pools = self.pools.read();
+        pools.iter().map(|p| p.pressure()).fold(0.0_f64, f64::max)
+    }
+
+    /// Run one relief pass. Returns a report describing what (if anything)
+    /// was done. This is the broker's atomic action — eviction strategy
+    /// per tier:
+    ///
+    ///   Normal/Warning  → no action (broker observes)
+    ///   High            → evict from highest-pressure pool
+    ///   Critical        → evict from all over-budget pools in parallel
+    ///                     (sequential here since pool.evict_some returns
+    ///                     immediately; parallel only matters if eviction
+    ///                     is async, which it isn't in our design)
+    pub fn relieve(&self) -> ReliefReport {
+        let global = self.global_pressure();
+        let tier = PressureTier::for_pressure(global);
+        if (tier == PressureTier::Normal || tier == PressureTier::Warning)
+            && global < self.config.act_above
+        {
+            return ReliefReport {
+                triggered: false,
+                global_pressure_before: global,
+                bytes_freed: 0,
+                pools_acted: Vec::new(),
+            };
+        }
+        let pools = self.pools.read();
+        // Build (pressure, ref) list, sorted descending by pressure.
+        let mut pressured: Vec<(f64, Arc<dyn PressureSource>)> = pools
+            .iter()
+            .map(|p| (p.pressure(), p.clone()))
+            .filter(|(p, _)| *p >= self.config.act_above)
+            .collect();
+        pressured.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        let act_on: &[(f64, Arc<dyn PressureSource>)] = match tier {
+            PressureTier::High => pressured.first().map(std::slice::from_ref).unwrap_or(&[]),
+            PressureTier::Critical => &pressured[..],
+            _ => &[],
+        };
+        let mut bytes_freed = 0u64;
+        let mut pools_acted: Vec<String> = Vec::new();
+        for (_, pool) in act_on {
+            let freed = pool.evict_some();
+            if freed > 0 {
+                bytes_freed += freed;
+                pools_acted.push(pool.name().to_string());
+            }
+        }
+        if bytes_freed > 0 {
+            *self.evictions_fired.lock() += 1;
+            *self.bytes_freed.lock() += bytes_freed;
+        }
+        ReliefReport {
+            triggered: !pools_acted.is_empty(),
+            global_pressure_before: global,
+            bytes_freed,
+            pools_acted,
+        }
+    }
+
+    /// Full state snapshot — for monitoring widgets, IPC stats commands,
+    /// and the future ML-policy layer to consume as input.
+    pub fn snapshot(&self) -> BrokerSnapshot {
+        let pools = self.pools.read();
+        let mut views: Vec<PoolView> = pools
+            .iter()
+            .map(|p| {
+                let pressure = p.pressure();
+                PoolView {
+                    name: p.name().to_string(),
+                    pressure,
+                    tier: PressureTier::for_pressure(pressure),
+                    stats: p.stats_snapshot(),
+                }
+            })
+            .collect();
+        views.sort_by(|a, b| b.pressure.partial_cmp(&a.pressure).unwrap_or(std::cmp::Ordering::Equal));
+        let global_pressure = views.iter().map(|v| v.pressure).fold(0.0_f64, f64::max);
+        BrokerSnapshot {
+            global_pressure,
+            global_tier: PressureTier::for_pressure(global_pressure),
+            pools: views,
+            evictions_fired: *self.evictions_fired.lock(),
+            bytes_freed_total: *self.bytes_freed.lock(),
+        }
+    }
+
+    /// Spawn a tokio task that calls `relieve()` on `tick_interval`.
+    /// Returns the JoinHandle so the caller can abort on shutdown.
+    /// Idempotent at the call site — caller decides if/when to spawn.
+    pub fn spawn_tick(self: Arc<Self>) -> tokio::task::JoinHandle<()> {
+        let interval = self.config.tick_interval;
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            // Skip the immediate first tick — let pools warm up before
+            // we start measuring + acting.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                let _report = self.relieve();
+                // Future: emit IPC event or log when triggered=true.
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Mock pool for broker testing — exposes a settable pressure value
+    /// and counts evict_some invocations.
+    struct MockPool {
+        name: String,
+        pressure_val: AtomicU64, // f64 bits
+        evict_count: AtomicU64,
+        bytes_per_evict: u64,
+    }
+
+    impl MockPool {
+        fn new(name: &str, pressure: f64, bytes_per_evict: u64) -> Arc<Self> {
+            Arc::new(Self {
+                name: name.to_string(),
+                pressure_val: AtomicU64::new(pressure.to_bits()),
+                evict_count: AtomicU64::new(0),
+                bytes_per_evict,
+            })
+        }
+        fn set_pressure(&self, p: f64) {
+            self.pressure_val.store(p.to_bits(), Ordering::Release);
+        }
+        fn evict_count(&self) -> u64 {
+            self.evict_count.load(Ordering::Acquire)
+        }
+    }
+
+    impl PressureSource for MockPool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn pressure(&self) -> f64 {
+            f64::from_bits(self.pressure_val.load(Ordering::Acquire))
+        }
+        fn evict_some(&self) -> u64 {
+            self.evict_count.fetch_add(1, Ordering::AcqRel);
+            // Simulate eviction reducing pressure.
+            let cur = self.pressure();
+            self.set_pressure((cur - 0.3).max(0.0));
+            self.bytes_per_evict
+        }
+        fn stats_snapshot(&self) -> PoolStats {
+            PoolStats {
+                name: self.name.clone(),
+                entry_count: 0,
+                pinned_count: 0,
+                total_bytes: 0,
+                max_bytes: 0,
+                pressure: self.pressure(),
+                hit_count: 0,
+                miss_count: 0,
+                eviction_count: 0,
+                inflight_count: 0,
+            }
+        }
+    }
+
+    #[test]
+    fn tier_thresholds_match_gpu_pressure_watcher() {
+        assert_eq!(PressureTier::for_pressure(0.0), PressureTier::Normal);
+        assert_eq!(PressureTier::for_pressure(0.59), PressureTier::Normal);
+        assert_eq!(PressureTier::for_pressure(0.60), PressureTier::Warning);
+        assert_eq!(PressureTier::for_pressure(0.79), PressureTier::Warning);
+        assert_eq!(PressureTier::for_pressure(0.80), PressureTier::High);
+        assert_eq!(PressureTier::for_pressure(0.94), PressureTier::High);
+        assert_eq!(PressureTier::for_pressure(0.95), PressureTier::Critical);
+        assert_eq!(PressureTier::for_pressure(1.50), PressureTier::Critical);
+    }
+
+    #[test]
+    fn no_action_when_all_pools_normal() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        broker.register(MockPool::new("kv", 0.3, 1024));
+        broker.register(MockPool::new("lora", 0.5, 1024));
+        let report = broker.relieve();
+        assert!(!report.triggered);
+        assert_eq!(report.bytes_freed, 0);
+    }
+
+    #[test]
+    fn high_pressure_evicts_only_worst_pool() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        let kv = MockPool::new("kv", 0.85, 100);
+        let lora = MockPool::new("lora", 0.70, 100);
+        broker.register(kv.clone());
+        broker.register(lora.clone());
+        let report = broker.relieve();
+        assert!(report.triggered);
+        // Only KV should have been evicted (highest pressure, above 0.80 threshold).
+        // LoRA at 0.70 is below act_above, so even if "highest" it shouldn't fire.
+        assert_eq!(kv.evict_count(), 1);
+        assert_eq!(lora.evict_count(), 0);
+        assert_eq!(report.pools_acted, vec!["kv".to_string()]);
+        assert_eq!(report.bytes_freed, 100);
+    }
+
+    #[test]
+    fn critical_pressure_evicts_all_over_budget_pools() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        let kv = MockPool::new("kv", 0.97, 100);
+        let lora = MockPool::new("lora", 0.96, 100);
+        let model = MockPool::new("model", 0.50, 100); // not over budget
+        broker.register(kv.clone());
+        broker.register(lora.clone());
+        broker.register(model.clone());
+        let report = broker.relieve();
+        assert!(report.triggered);
+        assert_eq!(kv.evict_count(), 1, "KV should be evicted (critical)");
+        assert_eq!(lora.evict_count(), 1, "LoRA should be evicted (critical)");
+        assert_eq!(model.evict_count(), 0, "Model under budget, not evicted");
+        assert_eq!(report.bytes_freed, 200);
+    }
+
+    #[test]
+    fn registration_dedups_by_name() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        broker.register(MockPool::new("kv", 0.85, 100));
+        broker.register(MockPool::new("kv", 0.85, 100)); // same name — replaces
+        let report = broker.relieve();
+        // If dedup works, evict_some fires once. If not, twice (200 bytes).
+        assert_eq!(report.bytes_freed, 100);
+    }
+
+    #[test]
+    fn unregister_removes_pool() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        broker.register(MockPool::new("kv", 0.85, 100));
+        broker.unregister("kv");
+        let report = broker.relieve();
+        assert!(!report.triggered);
+        let snap = broker.snapshot();
+        assert_eq!(snap.pools.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn real_paged_resource_pool_plugs_into_broker_via_blanket_impl() {
+        use crate::paging::pool::{lru_priority, PagedResourcePool, PoolConfig};
+
+        // Build a real pool and fill it past the act_above threshold.
+        let pool: Arc<PagedResourcePool<String, Vec<u8>>> =
+            Arc::new(PagedResourcePool::new(PoolConfig {
+                name: "real-embeddings".to_string(),
+                max_bytes: 1000,
+                sizer: Arc::new(|v: &Vec<u8>| v.len() as u64),
+                eviction_priority: lru_priority(),
+            }));
+
+        // Insert 900 bytes (90% pressure → above 0.80 act threshold).
+        for i in 0..9 {
+            pool.load_or_share(format!("k{i}"), |_| async move { Ok(vec![0u8; 100]) })
+                .await
+                .unwrap();
+        }
+        assert!(pool.pressure() >= 0.80, "expected pressure ≥0.80, got {}", pool.pressure());
+        assert_eq!(pool.name(), "real-embeddings");
+
+        // Register via blanket impl — no adapter struct needed.
+        let broker = PressureBroker::new(BrokerConfig::default());
+        broker.register(pool.clone());
+
+        let report = broker.relieve();
+        assert!(report.triggered, "broker should fire on real pool over budget");
+        assert!(report.bytes_freed > 0, "blanket evict_some should free bytes");
+        assert_eq!(report.pools_acted, vec!["real-embeddings".to_string()]);
+        // Pressure should drop after eviction.
+        assert!(pool.pressure() < 0.80, "post-eviction pressure should be <0.80, got {}", pool.pressure());
+    }
+
+    #[test]
+    fn snapshot_orders_pools_by_pressure_descending() {
+        let broker = PressureBroker::new(BrokerConfig::default());
+        broker.register(MockPool::new("low", 0.2, 1));
+        broker.register(MockPool::new("high", 0.9, 1));
+        broker.register(MockPool::new("mid", 0.5, 1));
+        let snap = broker.snapshot();
+        assert_eq!(snap.pools[0].name, "high");
+        assert_eq!(snap.pools[1].name, "mid");
+        assert_eq!(snap.pools[2].name, "low");
+        assert!((snap.global_pressure - 0.9).abs() < 0.001);
+        assert_eq!(snap.global_tier, PressureTier::High);
+    }
+}

--- a/src/workers/continuum-core/src/paging/mod.rs
+++ b/src/workers/continuum-core/src/paging/mod.rs
@@ -15,8 +15,13 @@
 //!
 //! See: docs/architecture/UNIFIED-PAGING.md
 
+pub mod broker;
 pub mod pool;
 
+pub use broker::{
+    BrokerConfig, BrokerSnapshot, PoolView, PressureBroker, PressureSource, PressureTier,
+    ReliefReport,
+};
 pub use pool::{
     lru_priority, size_weighted_lru, EvictionPriority, PagedResourcePool, PinHandle, PoolConfig,
     PoolEntry, PoolEntryView, PoolStats, Sizer,

--- a/src/workers/continuum-core/src/paging/pool.rs
+++ b/src/workers/continuum-core/src/paging/pool.rs
@@ -333,6 +333,21 @@ where
         })
     }
 
+    /// Drain every entry and reset hit/miss/eviction counters.
+    /// Returns the number of entries dropped. In-flight loads are NOT
+    /// canceled — they complete normally and insert into the now-empty
+    /// pool. Pinned entries ARE dropped (clear is admin-level reset,
+    /// not pressure relief — use `evict_under_pressure` for that).
+    pub fn clear(&self) -> usize {
+        let mut entries = self.inner.entries.write();
+        let dropped = entries.len();
+        entries.clear();
+        self.inner.hits.store(0, Ordering::Relaxed);
+        self.inner.misses.store(0, Ordering::Relaxed);
+        self.inner.evictions.store(0, Ordering::Relaxed);
+        dropped
+    }
+
     /// Force-evict by key, regardless of pin count. Use sparingly —
     /// the normal path is `maybe_evict` triggered by pressure.
     pub fn evict(&self, key: &K) -> bool {

--- a/src/workers/continuum-core/src/paging/pool.rs
+++ b/src/workers/continuum-core/src/paging/pool.rs
@@ -232,6 +232,12 @@ where
         }
     }
 
+    /// Stable name from PoolConfig — used by PressureBroker for diagnostics
+    /// and by IPC stats exports.
+    pub fn config_name(&self) -> &str {
+        &self.inner.config.name
+    }
+
     /// L1 hit — returns the value if cached, None on miss. Concurrent
     /// readers run in parallel under RwLock::read; per-entry atomics
     /// update last_access_at + access_count without serializing.
@@ -336,6 +342,85 @@ where
             return true;
         }
         false
+    }
+
+    /// Trigger an eviction pass without inserting anything new. Used by
+    /// the PressureBroker to free bytes when global pressure crosses a
+    /// threshold — the pool itself may not be over its own budget yet,
+    /// but the broker decides we should give some back. Returns the
+    /// total bytes freed in this pass.
+    ///
+    /// Eviction policy is the same as the insert-triggered path: drop
+    /// unpinned entries by `eviction_priority` order until occupancy
+    /// is at 75% of `max_bytes`. Pinned entries untouched.
+    pub fn evict_under_pressure(&self) -> u64 {
+        let target_bytes = (self.inner.config.max_bytes as f64 * 0.75) as u64;
+        let mut entries = self.inner.entries.write();
+        let initial_bytes: u64 = entries.values().map(|e| e.size_bytes).sum();
+        let mut total_bytes = initial_bytes;
+        let mut candidates: Vec<(K, i64, u64)> = entries
+            .iter()
+            .filter(|(_, e)| e.pin_count.load(Ordering::Acquire) == 0)
+            .map(|(k, e)| {
+                let view = PoolEntryView {
+                    size_bytes: e.size_bytes,
+                    pin_count: e.pin_count.load(Ordering::Acquire),
+                    loaded_at: e.loaded_at,
+                    last_access_at: e.last_access_at.load(Ordering::Acquire),
+                    access_count: e.access_count.load(Ordering::Acquire),
+                };
+                (k.clone(), (self.inner.config.eviction_priority)(&view), e.size_bytes)
+            })
+            .collect();
+        candidates.sort_by_key(|(_, prio, _)| *prio);
+        let mut evicted_count: u64 = 0;
+        for (k, _, size) in candidates {
+            if total_bytes <= target_bytes {
+                break;
+            }
+            entries.remove(&k);
+            total_bytes -= size;
+            evicted_count += 1;
+        }
+        if evicted_count > 0 {
+            self.inner.evictions.fetch_add(evicted_count, Ordering::Relaxed);
+        }
+        initial_bytes.saturating_sub(total_bytes)
+    }
+
+    /// Synchronous version of `stats()` — needed by `PressureSource`
+    /// implementors that can't .await (the broker's tick loop wants
+    /// non-blocking pressure reads). Excludes inflight count (which
+    /// requires async lock); leaves it as 0 since that's a transient
+    /// signal anyway, not pressure-relevant.
+    pub fn stats_blocking(&self) -> PoolStats {
+        let entries = self.inner.entries.read();
+        let mut total_bytes: u64 = 0;
+        let mut pinned_count: usize = 0;
+        for entry in entries.values() {
+            total_bytes += entry.size_bytes;
+            if entry.pin_count.load(Ordering::Acquire) > 0 {
+                pinned_count += 1;
+            }
+        }
+        let max_bytes = self.inner.config.max_bytes;
+        let pressure = if max_bytes > 0 {
+            total_bytes as f64 / max_bytes as f64
+        } else {
+            0.0
+        };
+        PoolStats {
+            name: self.inner.config.name.clone(),
+            entry_count: entries.len(),
+            pinned_count,
+            total_bytes,
+            max_bytes,
+            pressure,
+            hit_count: self.inner.hits.load(Ordering::Relaxed),
+            miss_count: self.inner.misses.load(Ordering::Relaxed),
+            eviction_count: self.inner.evictions.load(Ordering::Relaxed),
+            inflight_count: 0,
+        }
     }
 
     /// Snapshot stats for monitoring + PressureBroker queries.


### PR DESCRIPTION
## Summary

The 0/64 hit rate fix the architecture doc promised. Internal Rust callers (\`DataModule.backfill_vectors\`, \`ModuleBackedEmbeddingProvider\`, anywhere using \`generate_embedding{,s_batch}\`) were silently bypassing the embedding cache because it lived inside the IPC handler — \`handle_generate\` had its own ad-hoc \`HashMap<(String, u64), CachedEmbedding>\` with djb2 keys + 5-minute TTL + 10k count cap. Internal callers went around it.

This PR moves the cache **one layer down**: the pool sits behind \`generate_embedding{,s_batch}\`, so every embedder — IPC handler and Rust caller — hits the same cache uniformly. The IPC handler becomes a thin wrapper around the batched function. The architecture-doc claim is now true.

## What's in this commit

- **\`EmbeddingKey { model: String, content_hash: [u8; 32] }\`** — structured key (Joel's pass-the-struct rule), model-namespaced (different models map text → different vectors → distinct slots), SHA-256 content hash (fixed-size, collision-free vs djb2)
- **\`EMBEDDING_POOL: PagedResourcePool<EmbeddingKey, Vec<f32>>\`** replaces \`EMBEDDING_CACHE\`. 256 MB byte-driven budget (~170k entries at 384d FP32, vs the old 10k count cap), \`size_weighted_lru\` eviction. Eventually overridden by recipe-declared budgets (Phase 9) and pressure broker (Phase 7b).
- **\`generate_embedding\` / \`generate_embeddings_batch\` are pool-aware** — the actual user-visible behavior change. Batch path: per-text cache check → one \`model.embed()\` for the miss subset → per-text insert. One model invocation per batch (vs N for per-text single-flight) keeps the GPU/ONNX path efficient.
- **\`handle_generate\`** collapses to ~15 lines (was ~70) by delegating to \`generate_embeddings_batch\`
- **\`handle_cache_stats\`** now exposes \`pressure\` + \`maxBytes\` + \`evictions\` + \`pinned\` alongside hits/misses — broker-aware cache visibility for free
- **\`handle_cache_clear\`** → \`pool.clear()\` (new pool method that drains entries + resets hit/miss/eviction counters)
- **\`PagedResourcePool::clear()\`** — admin-level reset, drops pinned too. Distinct from \`evict_under_pressure\` (which respects pins). Documented inline.

## Tests (5/5 passing — \`cargo test --lib modules::embedding::tests\`)

- \`generate_embeddings_batch_hits_pool_before_loading_model\` — **the regression test for the 0/64 bug**. Pre-populates pool with vector for model \"nonexistent-model-name\"; the call returns the cached vector without trying to load that nonexistent model. If the cache path were broken, model load would fail — proves the short-circuit works.
- \`single_embedding_hits_pool_before_loading_model\` — same proof for single-text path
- \`embedding_key_is_model_namespaced\` — same text + different model = distinct cache slots (correctness invariant)
- \`pool_clear_resets_stats_and_drops_entries\` — \`pool.clear()\` drains entries AND resets counters
- \`batch_with_partial_hits_records_correct_hit_count\` — all-cached batch returns without \`model.embed()\`

Tests serialize via \`TEST_LOCK\` on the global pool — \`EMBEDDING_POOL\` is a process-global singleton (matches IPC reality) and parallel test execution would race shared hit/miss counters. The pure key-shape test doesn't need the lock.

50/50 paging tests still pass — no regressions.

## Branch base

This PR is **based on \`feature/pressure-broker\`** (PR #932), because Phase 2 needs \`stats_blocking\` (sync stats for the cache_stats handler called from sync IPC code). When #932 lands, this rebases cleanly onto main.

## Test plan

- [x] \`cargo test --features metal,accelerate --lib modules::embedding::tests\` — 5/5 pass
- [x] \`cargo test --features metal,accelerate --lib paging\` — 50/50 pass (no regression)
- [x] \`cargo build --features metal,accelerate -p continuum-core\` — clean (0 errors, only pre-existing warnings)
- [ ] Live verification (after merge): run codebase indexer, watch \`./jtag embedding/cache/stats\` — hit rate should climb past 0% as the same chunk text hits the cache from both backfill_vectors and IPC paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)