### PR TITLE
refactor(shared): delete ModelContextWindows lookup tables — adapter authority

### DIFF
--- a/src/system/shared/ModelContextWindows.ts
+++ b/src/system/shared/ModelContextWindows.ts
@@ -1,364 +1,166 @@
 /**
- * Model Context Windows - Centralized Configuration (SINGLE SOURCE OF TRUTH)
+ * Model Context / Speed Helpers — Shim over the adapter authority
  *
- * This file is the ONLY place model context window sizes should be defined.
- * When adding new models, update THIS FILE ONLY.
+ * @deprecated The functions in this file are a transitional shim. The adapter
+ * is the authority on its own models — it declares ModelInfo (context window,
+ * tokens/sec, capabilities) via the `ai/model-info` IPC and registers them in
+ * `ModelRegistry`. Callers should read those fields directly through PRG-injected
+ * `ModelInfo` rather than calling these helpers. When all 18 call sites migrate,
+ * this file goes away entirely.
  *
- * Used by:
- * - ChatRAGBuilder (message count budgeting)
- * - RAGBudgetServerCommand (token budget calculation)
- * - PersonaUser (model capability checks)
+ * What changed in this revision:
  *
- * Dynamic discovery:
- * ModelRegistry (populated async from provider APIs in initializeDeferred)
- * is checked FIRST. Static maps below are the fallback when the registry
- * hasn't discovered a model yet or the provider API is unavailable.
+ *   - Deleted the `MODEL_CONTEXT_WINDOWS` / `MODEL_INFERENCE_SPEEDS` static
+ *     lookup tables (~150 lines of hardcoded model knowledge that drifted
+ *     against reality every time a forge run shipped a new artifact).
+ *   - All functions now delegate to `ModelRegistry` — populated at boot from
+ *     each provider's `ai/model-info` IPC. When the registry doesn't know
+ *     a model, callers get a sane default + a one-shot warn-log (visibility
+ *     into "the adapter for this model isn't reporting its own ModelInfo").
  *
- * Provider-scoped lookups:
- * All functions accept an optional `provider` parameter. When provided,
- * ModelRegistry returns only that provider's entry — preventing collisions
- * where the same modelId exists on multiple providers with different context
- * windows (e.g., meta-llama/Llama-3.1-8B-Instruct: 131K on Together, 1400 on Candle).
+ * Why this matters: the static tables encoded "what we believed about a model
+ * in early 2026." Forged Qwen3.5-4B-code shipped with a 262144-token context;
+ * the table didn't have an entry → caller saw 8192 default → RAG truncated
+ * pointlessly. Adapter authority + warn-log makes that class of bug visible
+ * AND fixable in one place (the adapter's ModelInfo).
+ *
+ * Removed in this PR (smell that needs to die):
+ *
+ *   - `MODEL_CONTEXT_WINDOWS` and `MODEL_INFERENCE_SPEEDS` literal maps —
+ *     ~70 entries, all guesses; ModelRegistry has the live truth.
+ *   - The < 500 TPS heuristic in `isSlowLocalModel` — replaced by a real
+ *     check on whether the registry classifies the model as local.
+ *   - Per-function string-table normalization (suffix-strip, prefix-match) —
+ *     ModelRegistry already does this, and once was enough.
  */
 
 import { ModelRegistry } from './ModelRegistry';
 
-/** Known local provider names for inference speed classification */
-const LOCAL_PROVIDERS = new Set(['candle', 'sentinel']);
-
 /**
- * Model context windows in tokens
- *
- * @remarks
- * Context windows determine how much conversation history can fit in a single request.
- * Larger context windows allow more messages but cost more and may be slower.
- *
- * Default: 8192 tokens (8K) if model not found
- */
-export const MODEL_CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
-  // OpenAI Models
-  'gpt-3.5-turbo': 16385,
-  'gpt-4': 8192,
-  'gpt-4-turbo': 128000,
-  'gpt-4o': 128000,
-  'gpt-4o-mini': 128000,
-  'o1': 200000,
-  'o1-mini': 128000,
-
-  // Anthropic Models (Claude) — versioned IDs used at runtime
-  'claude-sonnet-4-5-20250929': 200000,  // MODEL_IDS.ANTHROPIC.SONNET_4_5
-  'claude-opus-4-20250514': 200000,      // MODEL_IDS.ANTHROPIC.OPUS_4
-  'claude-3-5-haiku-20241022': 200000,   // MODEL_IDS.ANTHROPIC.HAIKU_3_5
-  'claude-sonnet-4': 200000,             // Alias used in UserDataSeed
-  'claude-sonnet-4-5': 200000,           // Date-stripped alias
-  // Legacy naming (kept for backward compatibility)
-  'claude-3-opus': 200000,
-  'claude-3-sonnet': 200000,
-  'claude-3-haiku': 200000,
-  'claude-3-5-sonnet': 200000,
-  'claude-3-5-haiku': 200000,
-  'claude-opus-4': 200000,
-
-  // Meta Models (Llama) — cloud API naming (dashes)
-  'llama-3.1-8b-instant': 131072,                           // Groq LPU
-  'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo': 131072,  // Together.ai
-  'accounts/fireworks/models/llama-v3p1-8b-instruct': 131072,  // Fireworks.ai (deprecated)
-  'accounts/fireworks/models/llama-v3p3-70b-instruct': 131072,  // Fireworks.ai Llama 3.3 70B
-  // Meta Models (Llama) — legacy short names
-  'llama3.2': 128000,
-  'llama3.2:3b': 128000,
-  'llama3.2:1b': 128000,
-  'llama3.1': 128000,
-  'llama3.1:70b': 128000,
-  'llama3.1:8b': 128000,
-
-  // Local Candle models — practical throughput limit (NOT theoretical model max).
-  // BF16 full-batch prefill on Metal is O(n²): 3500 tokens = 55s, unusable.
-  // The Rust backend caps context_length() to BF16_PRACTICAL_CONTEXT.
-  // These entries are safety nets for the window between boot and model discovery.
-  // Once ModelRegistry is populated (from Rust IPC), it takes priority.
-  'unsloth/Llama-3.2-3B-Instruct': 2048,
-
-  // Qwen Models — legacy short names
-  'qwen2.5': 128000,
-  'qwen2.5:7b': 128000,
-  'qwen2.5:14b': 128000,
-  'qwen2.5:32b': 128000,
-  'qwen2.5:72b': 128000,
-  'qwq': 128000,  // Qwen reasoning model
-  'qwen3-omni-flash-realtime': 128000,  // Alibaba Qwen 3 Omni
-
-  // Google Models
-  'gemini-pro': 32768,
-  'gemini-1.5-pro': 1000000,
-  'gemini-1.5-flash': 1000000,
-  'gemini-2.0-flash': 1048576,  // Gemini 2.0 Flash
-
-  // Mistral Models
-  'mistral': 32768,
-  'mistral:7b': 32768,
-  'mixtral': 32768,
-  'mistral-large': 128000,
-
-  // DeepSeek Models
-  'deepseek-coder': 128000,
-  'deepseek-coder:6.7b': 16000,
-  'deepseek-chat': 64000,
-  'deepseek-r1': 128000,
-
-  // Cohere Models
-  'command-r': 128000,
-  'command-r-plus': 128000,
-
-  // X.AI Models
-  'grok-3': 131072,
-  'grok-4': 131072,
-};
-
-/**
- * Default context window for unknown models
- * Using a conservative 8K to avoid overflow
+ * Default context window for unknown models. Conservative — if the adapter
+ * authority doesn't know the model, we stay safe rather than overflow.
  */
 export const DEFAULT_CONTEXT_WINDOW = 8192;
 
 /**
- * Model inference speeds in tokens per second (TPS)
- *
- * These estimates are for INPUT token processing (prompt evaluation).
- * Used for latency-aware budgeting to prevent timeouts on slow models.
- *
- * Categories:
- * - Cloud APIs: ~1000+ TPS (fast, network-bound)
- * - Local large models (70B+): ~20-50 TPS
- * - Local medium models (7-14B): ~50-150 TPS
- * - Local small models (1-3B): ~100-200 TPS on Apple Silicon
- *
- * Conservative estimates - actual speed varies by hardware.
- */
-export const MODEL_INFERENCE_SPEEDS: Readonly<Record<string, number>> = {
-  // Cloud APIs - fast (network-bound, not compute-bound)
-  'gpt-4': 1000,
-  'gpt-4-turbo': 1000,
-  'gpt-4o': 1000,
-  'gpt-4o-mini': 1000,
-  'claude-sonnet-4-5-20250929': 1000,
-  'claude-opus-4-20250514': 1000,
-  'claude-3-5-haiku-20241022': 1000,
-  'claude-3-opus': 1000,
-  'claude-3-sonnet': 1000,
-  'claude-3-haiku': 1000,
-  'claude-3-5-sonnet': 1000,
-  'claude-opus-4': 1000,
-  'llama-3.1-8b-instant': 1000,                            // Groq LPU
-  'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo': 1000,   // Together.ai
-  'accounts/fireworks/models/llama-v3p1-8b-instruct': 1000, // Fireworks.ai
-  'deepseek-chat': 1000,                                   // DeepSeek cloud
-  'grok-3': 1000,                                          // xAI cloud
-  'grok-4': 1000,                                          // xAI cloud
-  'gemini-2.0-flash': 1000,                                // Google cloud
-  'qwen3-omni-flash-realtime': 1000,                       // Alibaba cloud
-  'gemini-pro': 1000,
-  'gemini-1.5-pro': 1000,
-
-  // Local small models via Candle (1-3B params)
-  // ~100-200 TPS on Apple Silicon M1/M2
-  'llama3.2:1b': 200,
-  'llama3.2:3b': 100,  // Conservative for RAG-heavy prompts
-  'qwen2.5:3b': 100,
-  'qwen2:0.5b': 300,
-  'qwen2:1.5b': 150,
-
-  // HuggingFace IDs (used by Candle adapter directly)
-  // These MUST match the actual model IDs used in Rust CandleAdapter
-  'meta-llama/Llama-3.1-8B-Instruct': 40,   // Q4_K_M 8B - slower but much better quality
-  'unsloth/Llama-3.2-3B-Instruct': 60,      // Q4_K_M quantized - conservative due to NaN/Inf at long contexts
-  'Qwen/Qwen2-1.5B-Instruct': 80,
-  'Qwen/Qwen2-0.5B-Instruct': 150,
-
-  // Local medium models (7-14B params)
-  // ~50-150 TPS on Apple Silicon
-  'llama3.1:8b': 80,
-  'llama3.2': 100,  // Default for llama3.2 family
-  'qwen2.5:7b': 80,
-  'qwen2.5:14b': 50,
-  'mistral:7b': 80,
-
-  // Local large models (30B+ params)
-  // ~20-50 TPS on Apple Silicon
-  'llama3.1:70b': 25,
-  'qwen2.5:32b': 35,
-  'qwen2.5:72b': 20,
-  'mixtral': 40,
-
-  // DeepSeek models
-  'deepseek-coder:6.7b': 80,
-  'deepseek-r1': 50,
-};
-
-/**
- * Default inference speed for unknown models (conservative)
- * Assumes local medium model speed
+ * Default inference speed when the registry hasn't been told. Conservative
+ * "local medium" guess; correct values come from the adapter's ModelInfo.
  */
 export const DEFAULT_INFERENCE_SPEED = 80;
 
 /**
- * Default target latency in seconds for inference
- * Used when calculating latency-aware token budgets
+ * Default target latency in seconds for inference. Used by callers that
+ * compute latency-aware token budgets.
  */
 export const DEFAULT_TARGET_LATENCY_SECONDS = 30;
+
+/** Track which models we've already warned about so we log once, not per-call. */
+const _warnedMissingModels = new Set<string>();
+function _warnMissing(kind: 'contextWindow' | 'tokensPerSecond', model: string, provider?: string) {
+  const key = `${kind}:${provider ?? '*'}:${model}`;
+  if (_warnedMissingModels.has(key)) return;
+  _warnedMissingModels.add(key);
+  // Use console; this file is shared (browser + server). Verbose only on first miss.
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[ModelContextWindows] No ${kind} for model="${model}" provider="${provider ?? '*'}" — ` +
+    `using default. Adapter should report this via ai/model-info IPC into ModelRegistry.`
+  );
+}
 
 /**
  * Get inference speed for a model in tokens per second.
  *
- * When provider is specified and the model is found in the registry:
- *   - Local providers (candle/sentinel): fall through to static speed map
- *   - Cloud providers: return 1000 TPS (network-bound)
+ * Source of truth: ModelRegistry (populated from each adapter's ModelInfo
+ * via the `ai/model-info` IPC). When unknown, returns DEFAULT_INFERENCE_SPEED
+ * and warns once so the missing entry is diagnosable.
  *
- * Bug fix: Previously, any registry hit assumed cloud (1000 TPS), even for
- * Candle models registered at 40 TPS. Now checks provider to classify correctly.
+ * @deprecated Read `ModelInfo.tokensPerSecond` from the PRG-injected struct
+ * directly. This shim exists for backward compatibility while callers migrate.
  */
 export function getInferenceSpeed(model: string, provider?: string): number {
-  const registry = ModelRegistry.sharedInstance();
-  const discovered = registry.get(model, provider);
-  if (discovered) {
-    // Check if this is a local provider — don't assume cloud speed
-    if (LOCAL_PROVIDERS.has(discovered.provider)) {
-      // Fall through to static speed map for local providers
-      // (registry has context windows, not inference speeds)
-    } else {
-      // Cloud APIs are ~1000 TPS (network-bound)
-      return 1000;
-    }
-  }
-
-  // Direct match
-  if (MODEL_INFERENCE_SPEEDS[model]) {
-    return MODEL_INFERENCE_SPEEDS[model];
-  }
-
-  // Try without version suffix
-  const baseModel = model.split(':')[0];
-  if (MODEL_INFERENCE_SPEEDS[baseModel]) {
-    return MODEL_INFERENCE_SPEEDS[baseModel];
-  }
-
-  // Strip date suffix (e.g., 'claude-sonnet-4-5-20250929' → 'claude-sonnet-4-5')
-  const dateStripped = model.replace(/-\d{8}$/, '');
-  if (dateStripped !== model && MODEL_INFERENCE_SPEEDS[dateStripped]) {
-    return MODEL_INFERENCE_SPEEDS[dateStripped];
-  }
-
-  // Try prefix matching
-  for (const [key, value] of Object.entries(MODEL_INFERENCE_SPEEDS)) {
-    if (model.startsWith(key) || key.startsWith(model)) {
-      return value;
-    }
-  }
-
+  const tps = ModelRegistry.sharedInstance().tokensPerSecond(model, provider);
+  if (tps !== undefined) return tps;
+  _warnMissing('tokensPerSecond', model, provider);
   return DEFAULT_INFERENCE_SPEED;
 }
 
 /**
- * Calculate maximum input tokens based on target latency
+ * Calculate maximum input tokens based on target latency.
+ * Derived from `getInferenceSpeed` × `targetLatencySeconds`.
  *
- * Formula: maxInputTokens = targetLatencySeconds × tokensPerSecond
- *
- * This is the LATENCY constraint - separate from the context window constraint.
- * The actual limit is MIN(contextWindow, latencyLimit).
- *
- * @param model - Model identifier
- * @param targetLatencySeconds - Target response time (default: 30s)
- * @param provider - Optional provider for scoped lookup
- * @returns Maximum input tokens to stay within latency target
+ * @deprecated Compute inline from `ModelInfo.tokensPerSecond` at the callsite.
  */
 export function getLatencyAwareTokenLimit(
   model: string,
   targetLatencySeconds: number = DEFAULT_TARGET_LATENCY_SECONDS,
   provider?: string
 ): number {
-  const tokensPerSecond = getInferenceSpeed(model, provider);
-  return Math.floor(targetLatencySeconds * tokensPerSecond);
+  return Math.floor(targetLatencySeconds * getInferenceSpeed(model, provider));
 }
 
 /**
- * Check if a model is a slow local model (needs latency-aware budgeting)
+ * Check if a model is a local model (needs latency-aware budgeting).
+ *
+ * Replaces the < 500 TPS heuristic with the honest signal: does the
+ * adapter's reported `isLocal` capability say so? When the registry doesn't
+ * know, falls back to "is the speed slow" because that's still a reasonable
+ * proxy and matches the previous behavior on unknown models.
+ *
+ * @deprecated Read `ModelInfo.isLocal` directly at the callsite.
  */
 export function isSlowLocalModel(model: string, provider?: string): boolean {
-  const speed = getInferenceSpeed(model, provider);
-  return speed < 500;  // Below 500 TPS = needs latency awareness
+  const registry = ModelRegistry.sharedInstance();
+  const meta = registry.get(model, provider);
+  if (meta?.isLocal !== undefined) return meta.isLocal;
+  // Unknown model — fall back to the speed heuristic (preserves previous behavior
+  // while we wait for adapters to finish reporting `isLocal` in their ModelInfo).
+  return getInferenceSpeed(model, provider) < 500;
 }
 
 /**
- * Get context window size for a model
+ * Get context window size for a model.
  *
- * Supports:
- * - Direct model name lookup (e.g., "gpt-4")
- * - Versioned model lookup (e.g., "llama3.2:3b" → "llama3.2")
- * - Prefix matching for similar models
- * - Provider-scoped lookup to avoid cross-provider collisions
+ * Source of truth: ModelRegistry. When the registry doesn't know, returns
+ * DEFAULT_CONTEXT_WINDOW (conservative 8192) and warns once so the missing
+ * entry is diagnosable.
  *
- * @param model - Model identifier (e.g., "gpt-4", "claude-3-sonnet")
- * @param provider - Optional provider for scoped registry lookup
- * @returns Context window size in tokens, or DEFAULT_CONTEXT_WINDOW if model not found
+ * @deprecated Read `ModelInfo.contextWindow` from the PRG-injected struct
+ * directly.
  */
 export function getContextWindow(model: string, provider?: string): number {
-  // Check ModelRegistry first (live-discovered data from provider APIs)
-  const discovered = ModelRegistry.sharedInstance().contextWindow(model, provider);
-  if (discovered !== undefined) return discovered;
-
-  // Direct match in static map
-  if (MODEL_CONTEXT_WINDOWS[model]) {
-    return MODEL_CONTEXT_WINDOWS[model];
-  }
-
-  // Try without version suffix (e.g., 'llama3.2:3b' → 'llama3.2')
-  const baseModel = model.split(':')[0];
-  if (MODEL_CONTEXT_WINDOWS[baseModel]) {
-    return MODEL_CONTEXT_WINDOWS[baseModel];
-  }
-
-  // Strip date suffix (e.g., 'claude-sonnet-4-5-20250929' → 'claude-sonnet-4-5')
-  const dateStripped = model.replace(/-\d{8}$/, '');
-  if (dateStripped !== model && MODEL_CONTEXT_WINDOWS[dateStripped]) {
-    return MODEL_CONTEXT_WINDOWS[dateStripped];
-  }
-
-  // Try prefix matching for versioned models
-  for (const [key, value] of Object.entries(MODEL_CONTEXT_WINDOWS)) {
-    if (model.startsWith(key) || key.startsWith(model)) {
-      return value;
-    }
-  }
-
+  const ctx = ModelRegistry.sharedInstance().contextWindow(model, provider);
+  if (ctx !== undefined) return ctx;
+  _warnMissing('contextWindow', model, provider);
   return DEFAULT_CONTEXT_WINDOW;
 }
 
 /**
- * Check if a model has a large context window (>32K)
- * Useful for deciding whether to include more context in RAG
+ * Check if a model has a large context window (>32K).
+ * Useful for deciding whether to include more context in RAG.
+ *
+ * @deprecated Compute inline: `modelInfo.contextWindow > 32768`.
  */
 export function isLargeContextModel(modelId: string, provider?: string): boolean {
   return getContextWindow(modelId, provider) > 32768;
 }
 
 /**
- * Get recommended output token budget for a model
- * Typically 10-25% of context window, capped at 4K for most use cases
+ * Get recommended output token budget for a model.
+ * 25% of context for small windows, capped at 4K for large.
+ *
+ * @deprecated Compute inline from `ModelInfo.contextWindow`.
  */
 export function getRecommendedMaxOutputTokens(modelId: string, provider?: string): number {
   const contextWindow = getContextWindow(modelId, provider);
-
-  // For small context windows, use 25%
-  if (contextWindow <= 8192) {
-    return Math.floor(contextWindow * 0.25);
-  }
-
-  // For large context windows, cap at 4K (most responses don't need more)
+  if (contextWindow <= 8192) return Math.floor(contextWindow * 0.25);
   return Math.min(4096, Math.floor(contextWindow * 0.1));
 }
 
 /**
- * Calculate available tokens for input given output reservation
+ * Calculate available tokens for input given output reservation.
+ *
+ * @deprecated Compute inline from `ModelInfo.contextWindow`.
  */
 export function getAvailableInputTokens(
   modelId: string,

--- a/src/system/shared/ModelRegistry.ts
+++ b/src/system/shared/ModelRegistry.ts
@@ -62,6 +62,26 @@ export interface ModelMetadata {
   readonly discoveredAt: number;
 
   /**
+   * Sustained output decode speed in tokens/second. Populated from the
+   * adapter's `ModelInfo.tokens_per_second` (delivered via the
+   * `ai/model-info` IPC). Undefined when the adapter hasn't reported.
+   *
+   * Used by latency-aware budgeting: maxInputTokens =
+   * targetLatencySeconds × tokensPerSecond. Cloud APIs report ~1000 TPS;
+   * local quantized models report what they actually measure (e.g. forged
+   * Qwen3.5-4B at ~58 TPS on M5 with the install-time KV cap).
+   */
+  readonly tokensPerSecond?: number;
+
+  /**
+   * True if the model runs on local compute (Candle, llama.cpp, MLX, etc.),
+   * false for cloud APIs (Anthropic, OpenAI, Google, etc.). Replaces the
+   * < 500 TPS heuristic in `isSlowLocalModel` with the honest signal the
+   * adapter already reports via `capabilities.is_local`.
+   */
+  readonly isLocal?: boolean;
+
+  /**
    * Fine-tuning, quantization, and adapter capability profile.
    * Populated by adapters that report detailed model capabilities.
    * Undefined for cloud APIs or adapters that haven't reported yet.
@@ -149,6 +169,18 @@ export class ModelRegistry {
   contextWindow(modelId: string, provider?: string): number | undefined {
     const metadata = this.get(modelId, provider);
     return metadata?.contextWindow;
+  }
+
+  /**
+   * Lookup tokens/second for a model — convenience accessor mirroring
+   * `contextWindow()`. Returns undefined when the adapter hasn't reported
+   * a measured speed for this model yet. Used by latency-aware budgeting.
+   *
+   * Same normalization chain as contextWindow().
+   */
+  tokensPerSecond(modelId: string, provider?: string): number | undefined {
+    const metadata = this.get(modelId, provider);
+    return metadata?.tokensPerSecond;
   }
 
   /**

--- a/src/tests/unit/semantic-cognition.test.ts
+++ b/src/tests/unit/semantic-cognition.test.ts
@@ -15,8 +15,8 @@ import {
   isLargeContextModel,
   isSlowLocalModel,
   getRecommendedMaxOutputTokens,
-  MODEL_CONTEXT_WINDOWS,
-  DEFAULT_CONTEXT_WINDOW
+  DEFAULT_CONTEXT_WINDOW,
+  DEFAULT_INFERENCE_SPEED
 } from '../../system/shared/ModelContextWindows';
 import { ModelRegistry } from '../../system/shared/ModelRegistry';
 import {
@@ -49,7 +49,11 @@ import { MemoryType as MemoryTypeHippocampus } from '../../system/user/server/mo
 import type { SentinelTrigger } from '../../system/sentinel/SentinelDefinition';
 import type { GenomePhenotypeValidateParams, PhenotypeQuestionResult } from '../../commands/genome/phenotype-validate/shared/GenomePhenotypeValidateTypes';
 import type { AcademyEventAction, InferenceDemoPayload, QualityGateFailedPayload, TopicRemediatePayload, RemediationDatasetReadyPayload } from '../../system/genome/shared/AcademyTypes';
-import { academyEvent, DEFAULT_ACADEMY_CONFIG } from '../../system/genome/shared/AcademyTypes';
+import { academyEvent, DEFAULT_ACADEMY_CONFIG, VALID_SESSION_STATUSES } from '../../system/genome/shared/AcademyTypes';
+import type { CurriculumTopic, ExamQuestion, ExamResponse } from '../../system/genome/shared/AcademyTypes';
+import { AcademySessionEntity } from '../../system/genome/entities/AcademySessionEntity';
+import { AcademyCurriculumEntity } from '../../system/genome/entities/AcademyCurriculumEntity';
+import { AcademyExaminationEntity } from '../../system/genome/entities/AcademyExaminationEntity';
 import { buildStudentPipeline } from '../../system/sentinel/pipelines/StudentPipeline';
 import { buildTeacherPipeline } from '../../system/sentinel/pipelines/TeacherPipeline';
 import type { GenomeComposeParams, ComposeLayerRef } from '../../commands/genome/compose/shared/GenomeComposeTypes';
@@ -143,52 +147,103 @@ describe('IEmbeddable', () => {
 });
 
 describe('ModelContextWindows', () => {
+  // The static MODEL_CONTEXT_WINDOWS / MODEL_INFERENCE_SPEEDS lookup tables
+  // were deleted — adapter authority now lives in ModelRegistry, populated
+  // at boot from each provider's `ai/model-info` IPC. These tests verify
+  // the new shim behavior: registry-populated → returns adapter value;
+  // unknown → returns DEFAULT.
+
   describe('getContextWindow', () => {
-    it('should return correct context window for known models', () => {
-      expect(getContextWindow('gpt-4')).toBe(8192);
-      expect(getContextWindow('gpt-4o')).toBe(128000);
-      expect(getContextWindow('claude-3-opus')).toBe(200000);
-      expect(getContextWindow('llama3.2:3b')).toBe(128000);
+    beforeEach(() => {
+      // Each test registers what it needs; the registry singleton persists
+      // across tests, so isolation is by unique modelId.
+    });
+
+    it('should return adapter-reported context window when registered', () => {
+      const registry = ModelRegistry.sharedInstance();
+      registry.register({
+        modelId: 'test-cw-gpt-4',
+        contextWindow: 8192,
+        provider: 'openai',
+        discoveredAt: Date.now(),
+      });
+      registry.register({
+        modelId: 'test-cw-gpt-4o',
+        contextWindow: 128000,
+        provider: 'openai',
+        discoveredAt: Date.now(),
+      });
+      expect(getContextWindow('test-cw-gpt-4', 'openai')).toBe(8192);
+      expect(getContextWindow('test-cw-gpt-4o', 'openai')).toBe(128000);
     });
 
     it('should return default for unknown models', () => {
-      expect(getContextWindow('unknown-model')).toBe(DEFAULT_CONTEXT_WINDOW);
+      expect(getContextWindow('genuinely-unregistered-model-xyz')).toBe(
+        DEFAULT_CONTEXT_WINDOW
+      );
     });
 
-    it('should handle versioned model names', () => {
-      // Base model lookup when version not in table
-      expect(getContextWindow('llama3.2:7b')).toBe(128000); // Should find llama3.2
-    });
-
-    it('should have reasonable values for all models', () => {
-      for (const [model, size] of Object.entries(MODEL_CONTEXT_WINDOWS)) {
-        expect(size).toBeGreaterThan(0);
-        expect(size).toBeLessThanOrEqual(1100000); // Max ~1M tokens (Gemini 2.0 Flash is 1048576)
-      }
+    it('should match by prefix when versioned suffix not registered', () => {
+      const registry = ModelRegistry.sharedInstance();
+      registry.register({
+        modelId: 'test-cw-llama-family',
+        contextWindow: 128000,
+        provider: 'candle',
+        discoveredAt: Date.now(),
+      });
+      // Registry's normalization chain handles prefix matching.
+      expect(getContextWindow('test-cw-llama-family:7b')).toBe(128000);
     });
   });
 
   describe('isLargeContextModel', () => {
-    it('should return true for large context models', () => {
-      expect(isLargeContextModel('gpt-4o')).toBe(true); // 128K
-      expect(isLargeContextModel('claude-3-opus')).toBe(true); // 200K
+    it('should return true for adapter-declared large-context models', () => {
+      const registry = ModelRegistry.sharedInstance();
+      registry.register({
+        modelId: 'test-large-128k',
+        contextWindow: 128000,
+        provider: 'openai',
+        discoveredAt: Date.now(),
+      });
+      expect(isLargeContextModel('test-large-128k', 'openai')).toBe(true);
     });
 
-    it('should return false for small context models', () => {
-      expect(isLargeContextModel('gpt-4')).toBe(false); // 8K
+    it('should return false for adapter-declared small-context models', () => {
+      const registry = ModelRegistry.sharedInstance();
+      registry.register({
+        modelId: 'test-small-8k',
+        contextWindow: 8192,
+        provider: 'openai',
+        discoveredAt: Date.now(),
+      });
+      expect(isLargeContextModel('test-small-8k', 'openai')).toBe(false);
     });
   });
 
   describe('getRecommendedMaxOutputTokens', () => {
-    it('should return reasonable output tokens for small models', () => {
-      const tokens = getRecommendedMaxOutputTokens('gpt-4');
+    it('should return 25% of context for small windows', () => {
+      const registry = ModelRegistry.sharedInstance();
+      registry.register({
+        modelId: 'test-out-small',
+        contextWindow: 8192,
+        provider: 'openai',
+        discoveredAt: Date.now(),
+      });
+      const tokens = getRecommendedMaxOutputTokens('test-out-small', 'openai');
       expect(tokens).toBeGreaterThan(0);
-      expect(tokens).toBeLessThanOrEqual(8192 * 0.25); // Max 25% of context
+      expect(tokens).toBeLessThanOrEqual(8192 * 0.25);
     });
 
-    it('should cap output tokens for large models', () => {
-      const tokens = getRecommendedMaxOutputTokens('claude-3-opus');
-      expect(tokens).toBeLessThanOrEqual(4096); // Capped at 4K
+    it('should cap output tokens at 4K for large windows', () => {
+      const registry = ModelRegistry.sharedInstance();
+      registry.register({
+        modelId: 'test-out-large',
+        contextWindow: 200000,
+        provider: 'anthropic',
+        discoveredAt: Date.now(),
+      });
+      const tokens = getRecommendedMaxOutputTokens('test-out-large', 'anthropic');
+      expect(tokens).toBeLessThanOrEqual(4096);
     });
   });
 });
@@ -335,36 +390,44 @@ describe('Provider-Scoped ModelContextWindows', () => {
     expect(getContextWindow('meta-llama/Llama-3.1-8B-Instruct', 'together')).toBe(131072);
   });
 
-  it('getContextWindow should fall back to static map when provider not in registry', () => {
-    // No registry entries — should use static map
-    expect(getContextWindow('meta-llama/Llama-3.1-8B-Instruct', 'candle')).toBe(1400);
+  it('getContextWindow should fall back to DEFAULT when registry has no entry', () => {
+    // The static lookup map was deleted — adapter authority via ModelRegistry
+    // is the only source of truth. Unregistered models return the default.
+    expect(getContextWindow('not-registered-anywhere-12345', 'candle')).toBe(
+      DEFAULT_CONTEXT_WINDOW
+    );
   });
 
-  it('getInferenceSpeed should return local TPS for local provider in registry', () => {
+  it('getInferenceSpeed returns adapter-reported tokensPerSecond when registered', () => {
     const registry = ModelRegistry.sharedInstance();
     registry.register({
-      modelId: 'meta-llama/Llama-3.1-8B-Instruct',
+      modelId: 'test-tps-local-llama-8b',
       contextWindow: 1400,
+      tokensPerSecond: 40, // adapter declares the measured local speed
+      isLocal: true,
       provider: 'candle',
-      discoveredAt: Date.now()
+      discoveredAt: Date.now(),
     });
-
-    // Bug fix verification: should return 40 TPS (static map), not 1000 TPS (cloud assumption)
-    const speed = getInferenceSpeed('meta-llama/Llama-3.1-8B-Instruct', 'candle');
-    expect(speed).toBe(40);  // From MODEL_INFERENCE_SPEEDS static map
+    expect(getInferenceSpeed('test-tps-local-llama-8b', 'candle')).toBe(40);
   });
 
-  it('getInferenceSpeed should return 1000 TPS for cloud provider in registry', () => {
+  it('getInferenceSpeed returns adapter-reported tokensPerSecond for cloud too', () => {
     const registry = ModelRegistry.sharedInstance();
     registry.register({
-      modelId: 'meta-llama/Llama-3.1-8B-Instruct',
+      modelId: 'test-tps-cloud-llama-8b',
       contextWindow: 131072,
+      tokensPerSecond: 1000, // adapter declares cloud-API speed
+      isLocal: false,
       provider: 'together',
-      discoveredAt: Date.now()
+      discoveredAt: Date.now(),
     });
+    expect(getInferenceSpeed('test-tps-cloud-llama-8b', 'together')).toBe(1000);
+  });
 
-    const speed = getInferenceSpeed('meta-llama/Llama-3.1-8B-Instruct', 'together');
-    expect(speed).toBe(1000);  // Cloud API speed
+  it('getInferenceSpeed falls back to default when unregistered', () => {
+    expect(getInferenceSpeed('genuinely-unregistered-tps-model-xyz')).toBe(
+      DEFAULT_INFERENCE_SPEED
+    );
   });
 
   it('isSlowLocalModel should be true for candle models', () => {
@@ -1060,18 +1123,12 @@ describe('AdapterPackage — Manifest & Entity', () => {
 // ============================================================================
 // Academy Dojo: Entity Validation + Pipeline Templates + Event Taxonomy
 // ============================================================================
-
-import { AcademySessionEntity } from '../../system/genome/entities/AcademySessionEntity';
-import { AcademyCurriculumEntity } from '../../system/genome/entities/AcademyCurriculumEntity';
-import { AcademyExaminationEntity } from '../../system/genome/entities/AcademyExaminationEntity';
-import {
-  academyEvent,
-  DEFAULT_ACADEMY_CONFIG,
-  VALID_SESSION_STATUSES,
-} from '../../system/genome/shared/AcademyTypes';
-import type { CurriculumTopic, ExamQuestion, ExamResponse } from '../../system/genome/shared/AcademyTypes';
-import { buildTeacherPipeline } from '../../system/sentinel/pipelines/TeacherPipeline';
-import { buildStudentPipeline } from '../../system/sentinel/pipelines/StudentPipeline';
+//
+// NOTE: All imports for this section are at the top of the file with the
+// other imports — the duplicate import block that used to live here made
+// the test file fail to even load (ESM forbids re-declaring imports).
+// Removed as a drive-by: pre-existing breakage, independent of this PR's
+// main subject (deleting ModelContextWindows lookup tables).
 
 describe('Academy Event Taxonomy', () => {
   it('should generate scoped event names', () => {


### PR DESCRIPTION
## Summary

Joel's smell-reduction directive: \"ModelContextWindows.ts — the entire file is smell. \`isSlowLocalModel\`, \`getContextWindow\`, \`getInferenceSpeed\`, \`getLatencyAwareTokenLimit\` — ALL lookup functions that guess what the adapter already knows.\"

This PR **deletes the static lookup tables** that encoded \"what we believed about a model in early 2026\" and were silently wrong every time a forge run shipped a new artifact. The visible bug: forged Qwen3.5-4B-code declares 262144-token context, the table didn't have an entry, callers saw 8192 default, RAG truncated pointlessly.

## What's deleted (~150 lines of guesses)

- \`MODEL_CONTEXT_WINDOWS\` — static map of ~30 model→ctx entries
- \`MODEL_INFERENCE_SPEEDS\` — static map of ~25 model→tps entries
- Per-function string-table normalization (date-suffix strip, prefix match) — \`ModelRegistry\` already does this, once is enough

## What replaces them

Every shim function delegates to **\`ModelRegistry\`** — the adapter-authoritative cache populated at boot from each provider's \`ai/model-info\` IPC. When the registry doesn't know a model, returns a sane DEFAULT and **warns ONCE** so the missing entry is diagnosable (visibility into \"the adapter for this model isn't reporting its own ModelInfo\" — the next-PR target).

## Registry side additions

- \`ModelMetadata.tokensPerSecond?: number\` — adapter-reported decode speed; cloud APIs ~1000 TPS, local quantized = whatever the adapter measured (forged Qwen3.5-4B at ~58 TPS on M5 with the install-time KV cap)
- \`ModelMetadata.isLocal?: boolean\` — replaces the < 500 TPS heuristic in \`isSlowLocalModel\` with the honest signal the adapter reports via \`capabilities.is_local\`
- \`ModelRegistry.tokensPerSecond(modelId, provider?)\` — convenience accessor mirroring \`contextWindow()\`

## Function signatures preserved

18 call sites + 61 invocations across the codebase keep compiling unchanged. They'll migrate to direct \`ModelInfo\` usage in a follow-up PR (memento has the PRG \`ModelInfo\` path started in #935); when all callers move, this whole file deletes.

## Drive-by

Removed the duplicate import block at the bottom of \`semantic-cognition.test.ts\` that was making the test file fail to load (ESM forbids re-declaring imports). **Pre-existing breakage independent of this PR**, fixed because the new tests sit in this file.

## Test plan

- [x] \`npx tsc --noEmit -p src/tsconfig.json\` — clean (TypeScript compiles)
- [x] Tests rewritten to drive ModelRegistry → assert shim behavior (registered → registry value, unregistered → DEFAULT)
- [ ] vitest run — blocked by separate \`@system/*\` path-alias config issue that exists on main today; tracked separately
- [ ] Post-deploy: log inspection should show \`[ModelContextWindows] No contextWindow for model=\"X\"\` warnings for any models the adapters aren't reporting yet — that list is the migration target for adapter ModelInfo completeness
- [ ] Pair with PR #935 (memento) — that PR's \`ai/model-info\` IPC populates the registry; together they make \"adapter is authority\" real end-to-end

## Coordination

- Memento on PR #935 (Candle routing cleanup + \`ai/model-info\` IPC + PRG ModelInfo struct fetch)
- This PR removes the lookup tables that were the fallback when adapter ModelInfo wasn't there
- Ordering: either order is fine; #935 makes the registry authoritative, this PR removes the tables that papered over the gaps. Together they complete the \"adapter is the authority on its own models\" architectural target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)