### PR TITLE
test(sentinel/checkpoint): isolate via CONTINUUM_CHECKPOINT_DIR env override

### DIFF
--- a/src/workers/continuum-core/src/modules/sentinel/checkpoint.rs
+++ b/src/workers/continuum-core/src/modules/sentinel/checkpoint.rs
@@ -7,8 +7,17 @@ use std::path::PathBuf;
 
 use super::types::{PipelineCheckpoint, PipelineStatus};
 
-/// Base directory for checkpoint storage
+/// Base directory for checkpoint storage.
+///
+/// Default: `~/.continuum/sentinel/checkpoints`.
+/// Overridable via `CONTINUUM_CHECKPOINT_DIR` env var — used by tests to
+/// isolate checkpoint state from the user's real `~/.continuum` (and to
+/// survive the case where root-owned directories from a previous docker
+/// container run leave the default path unwritable for the dev user).
 fn checkpoints_dir() -> PathBuf {
+    if let Ok(override_dir) = std::env::var("CONTINUUM_CHECKPOINT_DIR") {
+        return PathBuf::from(override_dir);
+    }
     let home = dirs::home_dir().expect("Failed to resolve home directory");
     home.join(".continuum").join("sentinel").join("checkpoints")
 }
@@ -137,6 +146,35 @@ mod tests {
     use super::*;
     use crate::modules::sentinel::types::*;
     use std::collections::HashMap;
+    use std::sync::OnceLock;
+    use tempfile::TempDir;
+
+    /// Process-global tempdir for checkpoint tests, lazily initialized on
+    /// first access. All tests in this module share it — they use unique
+    /// UUID-derived handles, so file collisions don't happen. This isolates
+    /// the test runs from the user's real `~/.continuum/sentinel/checkpoints`
+    /// (which may be root-owned-and-unwritable on a dev box that previously
+    /// ran a docker container that mounted $HOME and chmod'd the dir under
+    /// root).
+    ///
+    /// Stored in a static so the TempDir is dropped (and cleaned up) only
+    /// when the test process exits — a per-test TempDir would race with
+    /// cargo's default parallel test execution since `set_var` is process-
+    /// global.
+    fn ensure_test_checkpoint_dir() {
+        static TMPDIR: OnceLock<TempDir> = OnceLock::new();
+        let dir = TMPDIR.get_or_init(|| {
+            tempfile::tempdir().expect("Failed to create test checkpoint tempdir")
+        });
+        // SAFETY: set_var is unsafe in newer Rust (process-global, racy with
+        // other threads reading env). Tests in this module only ever write
+        // the SAME path, so concurrent setters write the same value — race-
+        // free in practice.
+        std::env::set_var(
+            "CONTINUUM_CHECKPOINT_DIR",
+            dir.path(),
+        );
+    }
 
     fn make_test_checkpoint(handle: &str) -> PipelineCheckpoint {
         PipelineCheckpoint {
@@ -189,6 +227,7 @@ mod tests {
 
     #[test]
     fn test_save_load_checkpoint() {
+        ensure_test_checkpoint_dir();
         let handle = format!(
             "test-ckpt-{}",
             uuid::Uuid::new_v4().to_string()[..8].to_string()
@@ -208,6 +247,7 @@ mod tests {
 
     #[test]
     fn test_list_checkpoints() {
+        ensure_test_checkpoint_dir();
         let handle = format!(
             "test-list-{}",
             uuid::Uuid::new_v4().to_string()[..8].to_string()
@@ -223,6 +263,7 @@ mod tests {
 
     #[test]
     fn test_recover_interrupted() {
+        ensure_test_checkpoint_dir();
         let handle = format!(
             "test-recover-{}",
             uuid::Uuid::new_v4().to_string()[..8].to_string()


### PR DESCRIPTION
## Summary

- Checkpoint tests no longer write to the user's real `~/.continuum/sentinel/checkpoints/` — they redirect to a process-shared `tempfile::TempDir` via the new `CONTINUUM_CHECKPOINT_DIR` env override.
- Production code path is unchanged: when the env var is unset (always, in prod), `checkpoints_dir()` resolves to the same default `~/.continuum/sentinel/checkpoints` path as before.
- Fixes a real prepush flake: on dev machines whose `~/.continuum/sentinel/` directory is root-owned (left over from any docker compose run that bind-mounted `$HOME` and chmod'd dirs under root), `cargo test --lib` panics with "Permission denied (os error 13)" in 3 checkpoint tests and blocks the prepush gate.

## Background — empirical hit

Hit on PR #950 prepush from `bigmama-wsl` 2026-04-25:

```
modules::sentinel::checkpoint::tests::test_save_load_checkpoint
  Failed to write checkpoint tmp file: Permission denied (os error 13)
modules::sentinel::checkpoint::tests::test_list_checkpoints
  Failed to write checkpoint tmp file: Permission denied (os error 13)
modules::sentinel::checkpoint::tests::test_recover_interrupted
  Failed to write checkpoint tmp file: Permission denied (os error 13)
test result: FAILED. 1826 passed; 3 failed; 28 ignored; 0 measured; 0 filtered out
```

`ls -la ~/.continuum/sentinel/checkpoints/` showed `drwxr-xr-x 2 root root` — created by a prior root-uid docker process that wrote into the bind-mounted home. Tests had no isolation: they wrote to the production path.

## Fix structure

Two-part change in `src/workers/continuum-core/src/modules/sentinel/checkpoint.rs`:

1. **`checkpoints_dir()` env override** — checks `CONTINUUM_CHECKPOINT_DIR` first, falls through to the existing home-derived default. Production callers see no behavior change unless they explicitly set the var.

2. **Test-mode tempdir isolation** — new `ensure_test_checkpoint_dir()` helper, called at the top of each test. It lazy-initializes a process-global `tempfile::TempDir` via `OnceLock` and sets the env var to its path. Cargo runs tests in parallel within one process, and `set_var` is process-global, so a per-test TempDir would race; sharing one is fine because tests already use UUID-derived handles that structurally don't collide.

## Validation

```bash
$ source src/scripts/shared/cargo-features.sh
$ cd src/workers/continuum-core
$ cargo test --lib $CARGO_GPU_FEATURES modules::sentinel::checkpoint
test modules::sentinel::checkpoint::tests::test_save_load_checkpoint ... ok
test modules::sentinel::checkpoint::tests::test_list_checkpoints ... ok
test modules::sentinel::checkpoint::tests::test_recover_interrupted ... ok
test result: ok. 3 passed; 0 failed; 0 ignored

$ cargo test --lib $CARGO_GPU_FEATURES
test result: ok. 1829 passed; 0 failed; 28 ignored; 0 measured; 0 filtered out
```

## Why this matters beyond one machine

The checkpoint module's hard-coded `~/.continuum` dependency is a latent foot-gun for any contributor whose dev box has had a root-mounted docker run over `$HOME` — a common state given how often we run `docker compose` with bind-mounts. Env override + tempdir isolation makes the test suite portable across dev environments without per-machine sudo chown gymnastics.

## Test plan

- [x] `cargo test --lib --features cuda,load-dynamic-ort` — 1829 pass, 0 fail (was 1826/3 fail on bigmama-wsl).
- [x] Repeated runs share TempDir cleanly (parallel test execution, no panics).
- [x] Prod path (env var unset) unchanged — `checkpoints_dir()` returns `~/.continuum/sentinel/checkpoints` exactly as before.
- [ ] Re-run on a machine with root-owned `~/.continuum/sentinel/` to confirm the bug is gone there too. (Will validate post-merge on bigmama-wsl with the offending state intact.)