### PR TITLE
fix(push-script): fetch PR HEAD sha before `git worktree add` (closes #966)

### DIFF
--- a/scripts/push-current-arch.sh
+++ b/scripts/push-current-arch.sh
@@ -207,6 +207,21 @@ if [ -e "$WORKTREE_DIR" ]; then
   git -C "$REPO_ROOT" worktree prune 2>/dev/null || true
 fi
 
+# Ensure the SHA is a local commit object before `git worktree add`.
+# In CI, actions/checkout@v4 with default settings on a pull_request event
+# fetches refs/pull/<N>/merge as a shallow clone. STARTUP_SHA_FULL
+# (resolved above from .pull_request.head.sha) names the PR HEAD commit,
+# which exists as a remote ref but NOT as a local object — so
+# `git worktree add` fails with "fatal: invalid reference: <sha>".
+# Empirical hit on PR #950 / issue #966 in rebuild-stale-arm64. Dev-
+# machine path is unaffected: cat-file -e always succeeds on local HEAD.
+if ! git -C "$REPO_ROOT" cat-file -e "$STARTUP_SHA_FULL^{commit}" 2>/dev/null; then
+  echo "→ SHA $STARTUP_SHA_FULL not present as a local object — fetching from origin"
+  git -C "$REPO_ROOT" fetch --depth 1 origin "$STARTUP_SHA_FULL" 2>/dev/null \
+    || git -C "$REPO_ROOT" fetch origin "$STARTUP_SHA_FULL" 2>/dev/null \
+    || { echo "ERROR: cannot fetch sha $STARTUP_SHA_FULL from origin (not a real commit, or network/auth issue)" >&2; exit 1; }
+fi
+
 echo "→ Creating frozen worktree at $WORKTREE_DIR (pinned at $STARTUP_SHA_FULL)"
 git -C "$REPO_ROOT" worktree add --detach "$WORKTREE_DIR" "$STARTUP_SHA_FULL" >/dev/null
 


### PR DESCRIPTION
## Summary

- `rebuild-stale-arm64` (and `-amd64` whenever it actually fires) on PR builds was hitting `fatal: invalid reference: <sha>` at `git worktree add` time, despite `STARTUP_SHA_FULL` being correctly resolved from `.pull_request.head.sha`.
- Root cause: `actions/checkout@v4` shallow-clones `refs/pull/<N>/merge`, so the PR head commit is known as a remote ref but NOT as a local object. `git worktree add --detach <DIR> <SHA>` requires the commit to be locally available.
- Fix: gate `worktree add` on `git cat-file -e`; if the sha isn't local, fetch it from origin (shallow first, full-history fallback). One small new block in `scripts/push-current-arch.sh:209-220`.

## Empirical hit

PR #950 run [24927483127](https://github.com/CambrianTech/continuum/actions/runs/24927483127):

```
→ STARTUP_SHA_FULL resolved via GITHUB_EVENT_PATH .pull_request.head.sha: d98777e3d54a62f01c86d64d54f993d75d84a8e3
→ Creating frozen worktree at /tmp/continuum-build-d98777e3d54a (pinned at d98777e3d54a62f01c86d64d54f993d75d84a8e3)
fatal: invalid reference: d98777e3d54a62f01c86d64d54f993d75d84a8e3
##[error]Process completed with exit code 128.
```

`rebuild-stale-amd64` was SKIPPED on the same run because amd64 already matched HEAD (a prior native push from `bigmama-wsl` had aligned the revision label) — so the bug was latent for amd64 and would have fired the next time CI actually had to rebuild it.

## Fix

```bash
if ! git -C "$REPO_ROOT" cat-file -e "$STARTUP_SHA_FULL^{commit}" 2>/dev/null; then
  echo "→ SHA $STARTUP_SHA_FULL not present as a local object — fetching from origin"
  git -C "$REPO_ROOT" fetch --depth 1 origin "$STARTUP_SHA_FULL" 2>/dev/null \
    || git -C "$REPO_ROOT" fetch origin "$STARTUP_SHA_FULL" 2>/dev/null \
    || { echo "ERROR: cannot fetch sha $STARTUP_SHA_FULL from origin (not a real commit, or network/auth issue)" >&2; exit 1; }
fi
```

Dev-machine path is unaffected — `cat-file -e` always succeeds on the local HEAD that `git rev-parse HEAD` would resolve to. Only fires in CI when `actions/checkout@v4`'s default fetch missed the sha.

## Test plan

- [x] `bash -n scripts/push-current-arch.sh` — clean (no syntax error from the new block).
- [ ] Empirical: next CI run that has to rebuild a stale image at PR HEAD should now succeed at `git worktree add` (validates the fetch path). Will confirm by watching `rebuild-stale-amd64` / `rebuild-stale-arm64` on the next push that triggers them.
- [ ] Local sanity (cannot easily simulate CI's shallow checkout state on a dev box without contortions; the dev path stays in the cat-file-succeeds branch, exercising no fetch).

## Closes

#966