### PR TITLE
fix(vision): bounded wait for in-flight VDS description on first message (#970 stage 1)

### DIFF
--- a/src/system/user/server/modules/PersonaResponseGenerator.ts
+++ b/src/system/user/server/modules/PersonaResponseGenerator.ts
@@ -373,16 +373,33 @@ export class PersonaResponseGenerator {
           if (!base64) {
             return null; // Nothing to send to the model
           }
-          // Pull cached description (populated by prewarmVisionDescriptions
-          // at chat-send time). Cache hit takes ~0ms; miss returns
-          // undefined — text-only personas downstream get a "no
-          // description available" marker instead of fabricating.
+          // Pull description from VDS — populated by prewarmVisionDescriptions
+          // at chat-send time. Two states are valid waits:
+          //   'cached'   → ~0ms instant lookup (pre-warm finished).
+          //   'inflight' → bounded wait. Pre-warm started but hasn't
+          //                resolved yet; we'd rather wait up to 8s than
+          //                hand the persona an empty description and
+          //                let it hallucinate "I don't see any image."
+          //                VDS already deduplicates inflight requests, so
+          //                this await piggybacks on the existing call —
+          //                no extra inference cost.
+          // Status `none` / `error` → don't trigger a blocking describe
+          // here; the chat-send path is responsible for prewarming. Stage
+          // 2 (Rust-side) is responsible for emitting an [Attached image:
+          // unavailable] marker when description ends up undefined, so a
+          // text-only persona at least KNOWS an image was attached
+          // instead of fabricating absence. Tracked in #970.
           let description: string | undefined;
           if (m.type === 'image') {
             try {
               const visionSvc = VisionDescriptionService.getInstance();
-              if (visionSvc.descriptionStatus(base64) === 'cached') {
-                const desc = await visionSvc.describeBase64(base64, m.mimeType ?? 'image/png', { maxLength: 200 });
+              const status = visionSvc.descriptionStatus(base64);
+              if (status === 'cached' || status === 'inflight') {
+                const VDS_WAIT_MS = 8000;
+                const desc = await Promise.race([
+                  visionSvc.describeBase64(base64, m.mimeType ?? 'image/png', { maxLength: 200 }),
+                  new Promise<null>((resolve) => setTimeout(() => resolve(null), VDS_WAIT_MS)),
+                ]);
                 description = desc?.description;
               }
             } catch {


### PR DESCRIPTION
## Summary

- Text-only personas no longer hallucinate "absence of images" on the first message after a fresh start. PersonaResponseGenerator now waits up to 8s for an in-flight VDS description, instead of skipping the wait entirely when the cache is cold.
- VDS already deduplicates in-flight requests, so the wait piggybacks on the pre-warm started at chat-send time — no extra inference cost on the happy path.
- Stage 1 of #970 (TS-side). Stage 2 (Rust-side marker for the description=None case) still tracked in #970.

## Background — empirical hit (Anvil, PR #950 / 2026-04-25)

> CodeReview AI #e50f39 HALLUCINATED "absence of images or attachments" when image IS attached. VDS [Attached image: <desc>] marker missing on user-role msg (your separate bug). non-vision personas can't see + no fail-loud marker either.

## Root cause (TS-side)

`PersonaResponseGenerator.ts:380-391` only attached the VDS description when `descriptionStatus(base64) === 'cached'`. On the first message with a fresh image, pre-warm started at chat-send time is still `'inflight'` when the persona reaches this code — so `description` stays `undefined`, the Rust IPC signal carries `{ ..., description: undefined }`, and the text-only persona's user-role message has no image marker.

## Fix

Wait when status is `'cached'` OR `'inflight'`:

```typescript
if (m.type === 'image') {
  try {
    const visionSvc = VisionDescriptionService.getInstance();
    const status = visionSvc.descriptionStatus(base64);
    if (status === 'cached' || status === 'inflight') {
      const VDS_WAIT_MS = 8000;
      const desc = await Promise.race([
        visionSvc.describeBase64(base64, m.mimeType ?? 'image/png', { maxLength: 200 }),
        new Promise<null>((resolve) => setTimeout(() => resolve(null), VDS_WAIT_MS)),
      ]);
      description = desc?.description;
    }
  } catch { /* ... */ }
}
```

8s ceiling protects against a stuck pre-warm. LLaVA on CPU at 60-70s would still time out and leave `description` undefined — that's where Stage 2 (Rust marker injection) takes over.

## Test plan

- [x] `npm run build:ts` — clean.
- [ ] Empirical: send an image to a text-only persona on the first message after a fresh start. Persona MUST receive a valid description in its user-role context.
- [ ] Cache-hit path unchanged: subsequent messages with the same image still take ~0ms (VDS cache returns immediately).

## Refs

- #970 (parent issue, both stages)
- Stage 2 (Rust marker injection when description=None) is the next chunk.