### PR TITLE
docs(architecture): AGENT-BACKBONE-INTEGRATION — Continuum as local-first backbone for Claude Code / Codex / openclaws / Hermes

### DIFF
--- a/.github/workflows/carl-install-smoke.yml
+++ b/.github/workflows/carl-install-smoke.yml
@@ -1,0 +1,99 @@
+# Carl-install smoke — runs the EXACT install command Carl runs, then
+# verifies the page Carl opens after install actually serves usable HTML.
+#
+# Closes the gap that let #950 merge with the Mac install path doing a
+# hidden 5-15min Rust source build despite the README claiming "Docker-
+# first: no compilation needed." Existing CI gates (verify-architectures,
+# verify-after-rebuild, validate, install-and-run-gate) all passed because
+# they validate image presence + revision label + service health on a
+# CI-only docker compose. They never exercised `curl install.sh | bash`.
+#
+# Status: ADVISORY for the first week of operation (per docs/CARL-CI-PLAN.md
+# rollout section). Once we have <2% false-fail rate over 1 week, flip to
+# REQUIRED via the PrimaryBranches ruleset PUT. Until then, this workflow
+# runs but doesn't block merge — letting us tune the smoke without locking
+# the merge button on flakes.
+
+name: Carl Install Smoke
+
+on:
+  pull_request:
+    branches: [canary, main]
+    paths:
+      # Run when anything that affects Carl's install path changes.
+      # No need to re-run on TS-only widget changes that don't touch
+      # install/docker; those are covered by other gates.
+      - 'install.sh'
+      - 'install.ps1'
+      - 'setup.sh'
+      - 'bootstrap.sh'
+      - 'src/scripts/install*.sh'
+      - 'src/scripts/lib/install-common.sh'
+      - 'docker/**'
+      - 'docker-compose*.yml'
+      - 'src/.dockerignore'
+      - 'src/workers/.dockerignore'
+      - 'scripts/ci/carl-install-smoke.sh'
+      - '.github/workflows/carl-install-smoke.yml'
+  push:
+    branches: [canary, main]
+  # Manual trigger so anyone can validate Carl's path against any branch
+  # without opening a throwaway PR.
+  workflow_dispatch:
+    inputs:
+      install_ref:
+        description: 'Git ref to fetch install.sh from (sha / branch / tag)'
+        required: false
+        default: ''
+
+jobs:
+  carl-install-smoke-amd64:
+    name: carl-install-smoke (linux/amd64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # PR HEAD, not the synthetic merge commit. Otherwise github.sha
+          # is the merge commit and the install.sh we'd fetch from raw.
+          # githubusercontent.com wouldn't be the one in this PR. Same
+          # rationale as docker-images.yml's ref pattern.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Smoke uses the local script directly; no need for full history.
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io (so install.sh can pull pre-built images)
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Run carl-install smoke
+        env:
+          # Pass the PR HEAD sha so the smoke fetches the install.sh from
+          # THIS PR (not main). Falls back to manual workflow_dispatch input
+          # when not in a PR context.
+          CARL_INSTALL_REF: ${{ github.event.pull_request.head.sha || inputs.install_ref || github.sha }}
+          # 25-min cap on the docker-only install. Hybrid (Mac source-build)
+          # path would exceed this — by design, that's the gate firing on
+          # the README/install mismatch.
+          CARL_INSTALL_TIMEOUT_SEC: '1500'
+          # Generous health wait — model-init can take 3-5min on cold pull.
+          CARL_HEALTH_TIMEOUT_SEC: '300'
+          # CI shouldn't leave docker compose stacks running.
+          SKIP_TEARDOWN: '0'
+        run: bash scripts/ci/carl-install-smoke.sh
+
+      - name: Upload install + page artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: carl-install-debug-${{ github.event.pull_request.head.sha || github.sha }}
+          path: |
+            /tmp/carl-smoke-*.install.log
+            /tmp/carl-smoke-*.page.html
+          retention-days: 7
+          if-no-files-found: ignore

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -127,13 +127,13 @@ echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━
 echo ""
 case "$MODE" in
   browser)
-    echo -e "  UI:        ${GREEN}http://localhost:9000${NC}"
+    echo -e "  UI:        ${GREEN}http://localhost:9003${NC}"
     ;;
   cli)
     echo -e "  CLI:       ${GREEN}./jtag${NC}"
     ;;
   headless)
-    echo -e "  Server:    ${GREEN}http://localhost:9000${NC} (API only)"
+    echo -e "  Server:    ${GREEN}http://localhost:9003${NC} (API only)"
     ;;
 esac
 echo -e "  Stop:      ${GREEN}cd $INSTALL_DIR/src && npm stop${NC}"

--- a/docs/CARL-CI-PLAN.md
+++ b/docs/CARL-CI-PLAN.md
@@ -92,21 +92,29 @@ is where we discover regressions, that's its job.
 
 ### B. Mac-mode install rationalization
 
-Two options to fix the README mismatch — pick whichever is cleaner per
-in-implementation discovery:
+**Update 2026-04-25 (anvil, after reading install.sh:118-123):** B.1 is
+not a choice we have. Apple's hypervisor blocks GPU passthrough to
+containers (confirmed by Docker Feb 2026, comment in install.sh). Mac
+NEEDS to run continuum-core natively for Metal acceleration. The 5-15min
+Rust build is architectural, not a bug. Going with B.2.
 
-**Option B.1 (preferred):** install.sh on Mac defaults to docker-only,
-matching the README. The Rust source build + npm-start path moves behind a
-`CONTINUUM_DEV=1` flag. Carl's path: docker pull + compose up. Dev's path:
-explicit opt-in.
+**B.2 (current plan):** README updated to admit the hybrid split:
+- Linux: docker-first, no compilation (matches the existing README claim)
+- Mac: docker for support services + native continuum-core for Metal
+  (~10min first build, incremental after; happens automatically as part
+  of `curl install.sh | bash` — no separate command, no env flag)
 
-**Option B.2:** README explicitly describes the hybrid (docker for users,
-source-build for live-mode/voice/avatar features), and install.sh prints a
-big "this will take 15-30 minutes for full feature set, use
-CONTINUUM_MODE=carl for the 3-min docker-only install" banner.
+Implementation:
+- README's headline install section gets a small per-platform table or
+  inline note explaining the wall-clock difference.
+- install.sh prints an upfront banner on Mac estimating build time
+  (so Carl knows to expect ~10min, not ~3min).
+- `--quiet` mode keeps existing behavior; just clearer messaging.
 
-B.1 is cleaner because the README is what Carl read; the install should
-match it. B.2 is honest but admits we shipped an inconsistency.
+(Considered B.3: ship TWO install commands — install-mac.sh vs install.sh.
+Rejected: more docs surface, more drift risk, fragments the support story.
+One entry point with honest messaging beats two entry points with shorter
+average time.)
 
 ### C. Browser smoke test (puppeteer)
 

--- a/docs/CARL-CI-PLAN.md
+++ b/docs/CARL-CI-PLAN.md
@@ -1,0 +1,222 @@
+# Carl-Grade CI: closing the broken-merge gap
+
+**Status:** plan / in-progress on `fix/install-carl-mac-windows`
+**Owner:** anvil (mac), green-022a (windows), bigmama-wsl (linux/cuda)
+**Driver:** anvil
+
+## The problem we're solving
+
+#950 merged with the install path on Mac doing a hidden 5-15min Rust source
+build despite the README claiming "Docker-first: pulls pre-built images, no
+compilation needed." The CI gates that exist today (verify-architectures,
+verify-after-rebuild, validate, install-and-run-gate) caught:
+
+- Multi-arch presence at `:pr-N` ✅
+- Per-arch revision label matches HEAD SHA ✅
+- TS/Rust compile clean ✅
+- docker-compose-up + widget-server health responds ✅
+
+What they did NOT catch:
+
+- **Carl's actual install command** (`curl install.sh | bash`) was never
+  exercised by CI.
+- **README claim** (no compilation needed) vs **install.sh behavior**
+  (5-15min Rust build on Mac) was never reconciled.
+- **First chat message** the user would send was never validated to produce
+  a clean response (no `<tool_use>` XML, no vision hallucination).
+- **Browser-loaded UI** was never verified to actually render and accept
+  user input through the same path Carl would use.
+
+So #950 went green on its CI gates but Carl's install experience is
+materially different from the README's promise. That's the gap this work
+closes.
+
+## Design principles
+
+1. **Test the user's path, not a CI-only path.** The same `install.sh` that
+   Carl invokes from `curl ... | bash` runs in CI. No CI-only smoke
+   substitutes.
+
+2. **Test the user's first action, not just service health.** After install
+   succeeds, CI sends a chat message + an image, and asserts the response
+   reads like a non-broken product (no XML leak, no hallucination markers,
+   real Vision description).
+
+3. **Cross-platform from day one.** amd64-linux is mandatory; arm64-mac is
+   high-priority via self-hosted runner OR developer-pre-push gate; Windows
+   (via WSL2 or PowerShell) is third tier but not optional.
+
+4. **Conservative-by-default required-checks.** New gates added as REQUIRED
+   in the PrimaryBranches ruleset only after they demonstrate <2% false-fail
+   rate over 1 week. False positives erode trust faster than they protect.
+
+5. **Same script for CI and humans.** Per Joel 2026-04-23: "make your own
+   testing easy." Every gate is a one-line shell invocation any of us can
+   run locally in 30 seconds.
+
+## What lands in THIS PR
+
+### A. Carl-install validation in CI (the headline)
+
+A new CI job `carl-install-and-chat-smoke` that:
+
+1. On a fresh ubuntu-latest GHA runner (amd64), does:
+   ```
+   CONTINUUM_DIR=/tmp/carl-probe \
+   bash <(curl -fsSL https://raw.githubusercontent.com/CambrianTech/continuum/$GITHUB_SHA/install.sh)
+   ```
+   The actual install path Carl runs.
+
+2. Times the install (target: <15 min for the Carl-mode docker-only path).
+
+3. After install completes, hits `http://localhost:9003/health` (existing
+   health check, kept) PLUS a new `chat-smoke` script:
+   - POSTs a chat message ("hello, who are you?") via the REST API
+   - Waits up to 60s for a response
+   - Asserts response: no `<tool_use>` XML, no `<persona-name>:` prefix,
+     >100 chars, doesn't claim it cannot do something it actually can
+
+4. POSTs a chat message with an image attachment (test fixture
+   `test-data/images/image-2.jpg` — small, public CC0):
+   - Asserts Vision AI's response describes the actual image content
+   - Asserts non-vision personas EITHER skip the response OR honestly say
+     they cannot see images (no hallucinated content)
+
+5. Tears down. Captures docker logs on failure to GHA artifacts so we can
+   diagnose without re-running.
+
+**Required check:** `carl-install-and-chat-smoke` becomes required for
+canary→main promotion (after 1 week of <2% false-fail rate to confirm
+stability). For PR→canary promotion, it's required from day one — canary
+is where we discover regressions, that's its job.
+
+### B. Mac-mode install rationalization
+
+Two options to fix the README mismatch — pick whichever is cleaner per
+in-implementation discovery:
+
+**Option B.1 (preferred):** install.sh on Mac defaults to docker-only,
+matching the README. The Rust source build + npm-start path moves behind a
+`CONTINUUM_DEV=1` flag. Carl's path: docker pull + compose up. Dev's path:
+explicit opt-in.
+
+**Option B.2:** README explicitly describes the hybrid (docker for users,
+source-build for live-mode/voice/avatar features), and install.sh prints a
+big "this will take 15-30 minutes for full feature set, use
+CONTINUUM_MODE=carl for the 3-min docker-only install" banner.
+
+B.1 is cleaner because the README is what Carl read; the install should
+match it. B.2 is honest but admits we shipped an inconsistency.
+
+### C. Browser smoke test (puppeteer)
+
+Within the same CI job, after install + chat-smoke pass:
+
+1. Launch headless Chrome via puppeteer
+2. Navigate to `http://localhost:9003/`
+3. Assert page loads (no chrome-error://)
+4. Type "hello" into the chat input
+5. Assert response renders within 30s
+6. Capture screenshot for the GHA artifact (so we have visual evidence)
+
+Catches the chrome-error trap class of bug — when widget-server isn't ready
+fast enough, browser stays in a recoverable state.
+
+### D. install.sh idempotence and friendly retry
+
+When install.sh is interrupted partway (Carl Ctrl+C's, network drops),
+re-running should resume from where it left off, not retry from scratch.
+Specifically:
+
+- Skip `git clone` if repo already at $CONTINUUM_DIR with correct origin
+- Skip `docker compose pull` if all images present locally with current tags
+- Skip prereq install steps that already report installed
+- ONLY repeat the failed step + everything after it
+
+Most of this is already in install.sh's check-then-install pattern; verify
+end-to-end and document the resume behavior in the README.
+
+### E. Browser pre-open delay
+
+install.sh currently opens the browser after compose-up returns. compose-up
+returns when containers START, not when widget-server is HEALTHY. Result:
+chrome-error trap when browser hits localhost:9003 0.5 sec before the
+server is listening.
+
+Fix: install.sh polls widget-server `/health` with a 60s timeout BEFORE
+running `open http://localhost:9003/`. If health doesn't come up, print a
+human-readable timeout message + log dump command instead of opening the
+browser to an error.
+
+### F. Friendlier first-fail messaging
+
+When install.sh fails (any phase), the error output should:
+- Name the phase (`Phase 4/8: Python ML environment`)
+- Show the actual failing command + its stderr
+- Print 1-line guidance for that specific failure ("If pip install timed
+  out, retry: `python -m pip install --retries 5 ...`")
+- Capture full log to a clipboardable path (`/tmp/continuum-install-*.log`)
+
+Carl shouldn't have to read the script source to understand what broke.
+
+## What does NOT land in this PR (deferred to follow-ups)
+
+- **Self-hosted GPU runner** (bigmama's box as a GHA runner) — bigger
+  infra lift, do once Carl-install-and-chat-smoke is stable on amd64.
+- **Persona-airc bridge** (#967) — separate value stream.
+- **(d) tool_use XML parser fix** (#76) — the `chat-smoke` step in this PR
+  ASSERTS clean output, so #76 is now a hard prerequisite for the smoke
+  to pass. Decide: fix #76 first then ship this PR's smoke as required, or
+  ship the smoke as advisory until #76 lands.
+- **Recipe substrate** (#71/#73) and **Phase C paging** — independent
+  workstreams, queued.
+
+## Rollout
+
+1. **This PR adds the smoke + the Mac-mode rationalization** to canary.
+2. CI runs the new smoke as ADVISORY (not blocking) for 1 week to gather
+   false-positive rate data.
+3. After 1 week of <2% false-fail, flip to REQUIRED via the PrimaryBranches
+   ruleset (gh api PUT).
+4. Canary→main promotion is gated on the smoke passing.
+5. New install regressions become impossible to merge without explicit
+   `--no-verify` (which the team's standing rule forbids per Joel).
+
+## Per-platform validation
+
+| Platform | Validator | Notes |
+|---|---|---|
+| linux/amd64 | GHA runner (`ubuntu-latest`) | Always-on. Carl's dominant platform per HF data. |
+| linux/amd64 + GPU | bigmama-wsl box, eventually self-hosted runner | Real Carl path; covers vision/persona functionality |
+| darwin/arm64 | anvil mac (manual probe), eventually puppeteer-on-mac in CI | Dev's dominant platform |
+| windows + WSL2 | green-022a (manual probe), bigmama-wsl secondary | Carl's secondary platform |
+| windows native (powershell) | green-022a (manual probe via install.ps1) | New platform — rely on green's dogfood |
+
+Each push to canary should have at least the linux/amd64 smoke green before
+promotion. The other tiers are progressively-tightening.
+
+## Success criteria
+
+- [ ] Carl-install-and-chat-smoke runs on every PR; passes for unchanged-
+      install diffs in <15 min.
+- [ ] README's "Docker-first: no compilation needed" claim is true on all
+      platforms (Carl mode default).
+- [ ] Browser smoke catches the chrome-error trap class.
+- [ ] After 1 week, smoke is REQUIRED in the PrimaryBranches ruleset.
+- [ ] No future PR can land that breaks Carl's install without explicit
+      bypass (which the team's discipline forbids).
+
+## Coordination
+
+- **anvil:** drives the plan, implements A (Carl-install smoke), B
+  (Mac-mode), E (browser pre-open delay), F (friendlier failures).
+- **green-022a:** drives the install.ps1 / Windows-native parity with the
+  shared logic in `src/scripts/lib/install-common.sh`. Already done a lot
+  of the foundational work; this PR consolidates without re-litigating.
+- **bigmama-wsl:** Linux/CUDA Carl probe (manual, for ground truth before
+  self-hosted runner lands), reviews + maintains the Linux side of
+  install-common.sh. Eventually owns the self-hosted GPU runner.
+- **joel-mac-dm:** out of scope unless airc-side identity work surfaces a
+  conflict; airc PR #70 already shipped what we need for #967 anyway.
+- **joel:** approves the README-vs-behavior reconciliation choice (B.1 vs
+  B.2) and the timing of "advisory → required" transition for the smoke.

--- a/docs/architecture/AGENT-BACKBONE-INTEGRATION.md
+++ b/docs/architecture/AGENT-BACKBONE-INTEGRATION.md
@@ -1,0 +1,402 @@
+# Continuum as Agent Backbone — External-Agent Integration
+
+**Status:** Design (2026-04-30) — captured live during the AI-capacity squeeze that's tipping users toward local-first stacks.
+**Authors:** continuum-b741 (claude-opus on cambrian/continuum), with input from continuum-2c54 (Codex peer) and airc-src-a500 (carl-mac) over airc.
+**Audience:** Continuum + airc maintainers across the mesh. Cross-vendor (Claude Code + Codex peers).
+
+---
+
+## 1. Strategic motivation
+
+Cloud AI services (Anthropic, OpenAI) are demand-saturated. Symptoms observed in real time on 2026-04-30:
+
+- Codex auto-downgraded to a mini model after primary capacity exhausted
+- Anthropic API rate limits hitting paid users for non-trivial work
+- Joel: "We, ourselves will run out soon for the week"
+- Public AI-stock corrections reflect the same physics: spend outpaces compute build-out
+
+The opportunity is **not** "another model lab" — those are losing this race. The opportunity is **the local-first substrate that lets users keep using Claude Code or Codex exactly as today, with Continuum transparently picking up the load when cloud capacity fails or when local is preferred**.
+
+> "Continuum and airc, without disrupting workflow, allowing users to USE codex or claude code as they were, with continuum as the backbone of local models of extreme capacity, emerging as the hero here for all us humans." — Joel, 2026-04-30
+
+This integration is the win condition. The rest of this doc designs how.
+
+### 1.1 The PC-paradigm framing (Joel, 2026-04-30)
+
+> "if we SHINE, and our repo is broken, but if we do as promised, and get to a reliable backend for codex, claude, openclaw or hermes even, as a grid based compute of efficiency and reliability, WE WIN. … we only need to get it running pretty well first, then we BUILD IT OUT TO DOMINANCE. Just like the PC before it."
+
+The PC didn't beat the mainframe by being faster on day one. It beat it by:
+- Being **small, nimble, collaborative** — one user, one machine, peer-friendly software ecosystems
+- **Scaling** — every household + business adopted them
+- **Distributed across ALL the hardware** — millions of independently-owned machines, no central permission to compute
+- Iterating to dominance over a decade
+
+Continuum + airc is the same shape, applied to inference:
+- **Small / nimble**: one user can run useful local inference on a $2K Mac mini today
+- **Collaborative**: airc-mesh peers contribute spare capacity to each other; the household / co-op grid emerges
+- **Scaling**: a network of small machines outperforms a centralized data center for many real-world workloads (and CAN'T be rate-limited as a class)
+- **Distributed across ALL our hardware**: every laptop, desktop, mini-PC, gaming rig, retired Mac. No single failure point. No single owner.
+- **Self-enhancing models**: the local serving layer doubles as a training-data capture point (LocalClaudeCodeProvider's `captureTraining=true` already does this — see §3.2). Every interaction is a chance to fine-tune the local model toward the user's actual workflow. Cloud models can't do this per-user; we can.
+
+The integration target is to **get this running PRETTY WELL first**, in a state where any external agent (Claude Code, Codex, openclaws, Hermes, future open-source agents) can plug into Continuum's local serving via a single env-var change AND get correct + reasonably fast responses. From there, every additional capability (multimodal, voice, vision, the training flywheel, multi-peer routing, household-grid scaling) compounds.
+
+The cloud-AI rate-limit window NOW is the moment the PC-paradigm shift starts. We don't need to be perfect; we need to be reliable enough that users don't go back.
+
+---
+
+## 2. The architecture (3 layers)
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  LAYER 1 — External agent (the user's familiar UX)            │
+│                                                                │
+│  Claude Code CLI ──┐                                           │
+│  Codex CLI ────────┤   No code changes. Just env-var pointing. │
+│  Cursor (future) ──┘   ANTHROPIC_BASE_URL or OPENAI_BASE_URL.  │
+└────────────────────────────────┬───────────────────────────────┘
+                                 │
+                                 ▼
+┌───────────────────────────────────────────────────────────────┐
+│  LAYER 2 — Continuum local truth                              │
+│                                                                │
+│  workers/continuum-core/src/http/                             │
+│    ├─ anthropic_compat.rs   ← ALREADY EXISTS                  │
+│    └─ openai_compat.rs      ← TO ADD (small)                  │
+│                                                                │
+│  Both shims sit in front of the same Rust core:               │
+│    AIAdapter trait → CandleAdapter / LlamaCppAdapter / MLX    │
+│    FootprintRegistry tracks what's loaded + on which device   │
+│    Recipe pipeline + paging from existing PERSONA-CONTEXT-    │
+│    PAGING.md — already there, already smart about VRAM.       │
+│                                                                │
+│  TS daemon-side:                                              │
+│    src/system/sentinel/coding-agents/LocalClaudeCodeProvider  │
+│      ALREADY does the start-server + set-base-URL + spawn-    │
+│      Claude-Code dance. Generalize + harden + expose as       │
+│      first-class provider, not just a Sentinel-internal hop.  │
+└────────────────────────────────┬───────────────────────────────┘
+                                 │
+                                 ▼
+┌───────────────────────────────────────────────────────────────┐
+│  LAYER 3 — airc capability mesh (multi-machine multiplier)    │
+│                                                                │
+│  Each Continuum instance announces over airc:                 │
+│    - models loaded (qwen3.5-30b-mlx, qwen3-coder-30b-gguf,...)│
+│    - device (M3 Max / RTX 4090 / etc.)                        │
+│    - free VRAM, current load, latency p50/p95                 │
+│    - what tools/recipes are wired                             │
+│                                                                │
+│  Other peers' Layer-2 routers read this, pick best peer,      │
+│  proxy the request. Distributed local inference across a      │
+│  household / team / co-op.                                    │
+│                                                                │
+│  airc role: capability channel + routing announcements.       │
+│  Inference traffic itself goes peer-to-peer over Tailscale    │
+│  (already in airc's substrate model) or LAN.                  │
+└───────────────────────────────────────────────────────────────┘
+```
+
+**Native-truth, thin-SDK rule applied** (per Joel's CLAUDE.md global rule):
+
+| Layer | Owns | Doesn't own |
+|---|---|---|
+| Rust core (`workers/continuum-core/`) | model serving, paging, FootprintRegistry, recipe execution, the canonical AIAdapter contract | platform-specific UX |
+| TS SDK (`src/daemons/ai-provider-daemon/`, `src/commands/ai/`) | rate-limit-detect, fallback routing, capability announcements over airc | the truth (always calls into Rust core) |
+| External agent (Claude Code, Codex) | terminal UX, file-system access, the user's prompt | inference (delegates via env-var-pointed HTTP) |
+| airc | identity, peer discovery, capability gossip, comms substrate | inference itself |
+
+---
+
+## 3. What already exists (don't redesign)
+
+### 3.1 Rust HTTP serving
+- **`workers/continuum-core/src/http/anthropic_compat.rs`** — Anthropic Messages API HTTP shim. Real code, real binding to CandleAdapter via the AIAdapter trait.
+- **`workers/continuum-core/src/http/mod.rs`** — axum HTTP server module.
+- **`workers/continuum-core/src/ai/anthropic_adapter.rs`** — adapter that translates between the wire format and the internal AIAdapter contract.
+
+### 3.2 TS provider integration
+- **`src/system/sentinel/coding-agents/LocalClaudeCodeProvider.ts`** — already starts the Anthropic-compat HTTP server, sets `ANTHROPIC_BASE_URL`, launches Claude Code via Agent SDK pointed at it. Result: Claude Code talks to local Candle inference instead of Anthropic. **This is the proof-of-concept that the design works end-to-end.** The work is to lift it from a Sentinel-internal mechanism to a first-class provider that any caller can use.
+- **`src/daemons/ai-provider-daemon/adapters/anthropic/`** — TS-side adapter for outbound Anthropic API (cloud direction). Use as reference for what the local shim must accept.
+- **`src/daemons/ai-provider-daemon/adapters/openai/`** — same for OpenAI. Pair with a future `openai_compat.rs` for Codex symmetry.
+
+### 3.3 Continuum primitives this builds on
+- **`Commands.execute<T,U>('ai/...')`** — the universal request/response primitive. Already wired through ai-provider-daemon.
+- **FootprintRegistry** (`workers/continuum-core/src/footprint/`) — knows what's loaded, what fits, what to evict.
+- **Recipe pipeline** — typed Signal → cognition/respond IPC. The local-fallback path uses this; we're not bypassing it.
+- **Persona context paging** (PERSONA-CONTEXT-PAGING.md) — VRAM-aware context management. Already smart.
+
+### 3.4 airc primitives this builds on
+- gh-rooted gist substrate (post-3c E2EE-by-design)
+- Per-channel gist multiplexing (post-#287)
+- Identity blocks (`airc identity set --integrations …`)
+- Peer convergence (#321)
+
+---
+
+## 4. What's new (the integration work)
+
+### 4.1 Lane 1 (Rust): OpenAI-compatible HTTP shim
+
+**Add `workers/continuum-core/src/http/openai_compat.rs`** mirroring `anthropic_compat.rs` shape.
+
+Wire-format scope (minimal viable):
+- `POST /v1/chat/completions` — chat-completions API (Codex's primary surface)
+- `POST /v1/completions` — legacy completions (some Codex paths)
+- `GET /v1/models` — model list (for Codex's startup probe)
+- Tool-use blocks (Codex/Claude both need this; same JSON shape on the wire, different framing)
+
+Routing: same `AIAdapter` trait the Anthropic shim uses. Translation lives in the shim layer; the inference path is shared. Cuts the work to ~the wire-format mapping + tests.
+
+**Estimated:** ~600-800 lines Rust + 30+ tests. Composes with existing axum module.
+
+### 4.2 Lane 2 (TS SDK): Rate-limit-detect + auto-fallback middleware
+
+When an external agent (Claude Code, Codex) talks to its CLOUD provider directly, there's no opportunity for us to intercept. So the integration shape is:
+
+**Option A (Codex, easy):** `~/.codex/config.toml` `[shell_environment_policy.set]` (we already use this for GH_TOKEN injection in airc#368) sets `OPENAI_BASE_URL=http://localhost:NNNN/v1`. From that moment on, every Codex call goes through the local shim. The shim itself decides whether to:
+- forward to the real OpenAI API (when allowed + rate isn't hit), or
+- serve locally from Continuum.
+
+**Option B (Codex, smarter):** A `UserPromptSubmit` hook (Codex's pre-turn hook surface, openai/codex#19385) checks recent rate-limit-history sidecar file; if a recent 429 is observed, swap `OPENAI_BASE_URL` for this turn only. Per-turn switching.
+
+**Option C (Claude Code):** `ANTHROPIC_BASE_URL` env var works similarly but Claude Code's hooks surface is more limited. Wrapper-binary path is the fallback. Worth a separate effort — not blocking.
+
+Middleware logic (Rust side or TS side, TBD):
+```
+on POST /v1/messages or /v1/chat/completions:
+  if config says "always local" → serve locally
+  if cloud token absent → serve locally
+  if recent-rate-limit window active → serve locally
+  else:
+    forward to cloud
+    if 429 / 529 / capacity error → serve locally + record rate-limit event
+    if 5xx → serve locally as fallback (silently)
+    on success → return as-is
+```
+
+The "recent-rate-limit window" should be a small JSON sidecar that any peer can read — naturally publishable on airc as a capability signal.
+
+### 4.3 Lane 2 (TS SDK): airc capability publication
+
+New continuum command `Commands.execute('ai/capability/publish')` runs periodically (e.g. every 60s when models are loaded, on-change immediately):
+
+```json
+{
+  "peer": "continuum-b741",
+  "machine": "M3 Max 64GB",
+  "models": [
+    { "id": "qwen3-coder-30b-gguf-q4", "vram_mb": 19500, "loaded": true, "context_max": 32768 },
+    { "id": "qwen3.5-27b-mlx-4bit", "vram_mb": 17000, "loaded": false, "context_max": 32768 }
+  ],
+  "free_vram_mb": 8200,
+  "current_load_pct": 12,
+  "p50_latency_ms": 145,
+  "p95_latency_ms": 380,
+  "endpoints": {
+    "anthropic": "http://100.x.x.x:9101/v1/messages",
+    "openai": "http://100.x.x.x:9102/v1/chat/completions"
+  },
+  "rate_limit_status": "ok",
+  "ttl_sec": 120
+}
+```
+
+Published via `airc msg --channel ai-capability` (new dedicated channel) or as a special envelope on the project room. Peers' Layer-2 routers subscribe + maintain a peer-table.
+
+**Channel choice:** dedicated `#ai-capability` channel (one per gh-account-mesh). Avoids polluting human chat.
+
+### 4.4 Lane 2 (TS SDK): Multi-peer routing
+
+When Claude Code (via local-shim) wants to serve a request and current peer's models don't cover it (e.g. user asks for vision, this peer doesn't have a vision model loaded but a peer does):
+1. Router consults peer-table from §4.3
+2. Picks best peer by (model match × free VRAM × p50 latency × proximity preference)
+3. Proxies the request to that peer's Anthropic-compat or OpenAI-compat HTTP endpoint
+4. Returns result
+
+Failure modes: peer becomes unreachable mid-stream → fallback to next-best-peer → fallback to cloud (if available) → fallback to "we couldn't serve this" with an actionable error.
+
+### 4.5 Lane 2 + Rust: Rate-limit headers on responses
+
+Local-served responses should set headers that mimic the cloud's rate-limit-related headers (e.g. `anthropic-ratelimit-requests-remaining: 999999`) so external agents that introspect rate state see "lots of capacity" and don't artificially slow down.
+
+---
+
+## 5. Bugs + Rust enhancements blocking this (from continuum-b741's overnight sweep)
+
+These need to land before or alongside the integration work — they're the "make the substrate stable enough to bet on" gates. Status as of 2026-04-30.
+
+### 5.1 Critical (blocks all UX)
+- **#722** ALL widgets fail on refresh — Rust core IPC dies + doesn't recover. This kills the dev loop for anyone working on the integration.
+- **#974** PRs perpetually BLOCKED by overly-narrow Verify-Docker-Images trigger paths. Meta-blocker; nothing merges.
+- **#56** `continuum-core-server` shutdown SIGABRT. Clean shutdown matters when daemon-restart cycles get involved (and they will, as multi-peer routing matures).
+
+### 5.2 Rust IPC + cognition (the truth layer)
+- **#75** Persona output quality (in_progress) — tool-use markup leak, sentinel marker leak, echo loops. The local-served responses MUST be clean if external agents (which expect clean Anthropic/OpenAI wire format) are to consume them without confusion.
+- **#71** Audit existing 28 recipe JSONs + identify pipeline gaps — the recipe pipeline is the cognition surface; gaps here are gaps in what local serving can do.
+- **#73** PRG.ts becomes a thin shim → calls `cognition/respond`. Composes with the local-shim work; same Rust path serves both internal personas and external Claude Code.
+- **#39** Audit + fix qwen35 SSM kernel coverage in llama.cpp Metal. SSM gaps mean some models silently fall back to CPU; capacity announcements need to reflect actual usable performance.
+
+### 5.3 Multimodal + live-video
+- **#765** Docker Rust LiveKit agent — STT/TTS broken. Voice support is a real differentiator vs cloud — both Claude voice and OpenAI realtime are gated/expensive.
+- **#582** Native multimodal pipeline — direct audio/vision for capable models. Required for the local shim to handle vision/audio requests external agents send.
+
+### 5.4 Install + cross-platform
+- **#860** setup.sh: config.env created as DIRECTORY — Carl-blocker.
+- **#770** Fresh install E2E nuke+reinstall on Windows + macOS — install must be one-command for the integration story to land with users.
+- **#637** Tailscale must be FIRST in install pipeline — needed for the Layer-3 multi-peer routing.
+- **#908** Windows/WSL2 npm start should route through docker compose — Windows users are a primary audience here.
+
+### 5.5 Test + CI
+- **#974** (above) — un-block the merge path
+- New: integration tests for the local-shim path (Claude Code talking to local Anthropic shim, end-to-end response shape)
+- New: peer-routing tests (mock 2 peers, verify request lands on the better-fit one)
+
+---
+
+## 6. Phased delivery
+
+### Phase 0 — Stabilize (this week, in parallel with airc#381 work landing)
+- Land #381 layer A (PR #387) + layer B (#385 merged) → mesh substrate reliable
+- Land #383 (carl-mac PR #384) → daemon survives sleep → multi-peer routing actually has peers
+- Triage + close #722 (widget refresh death) — blocks dev loop
+
+### Phase 1 — Single-machine local fallback (1-2 weeks)
+- Generalize `LocalClaudeCodeProvider` from Sentinel-internal to first-class
+- Add `openai_compat.rs` Rust shim (mirrors anthropic_compat.rs)
+- Codex `OPENAI_BASE_URL` env injection via `~/.codex/config.toml` (composes with airc's existing `[shell_environment_policy.set]` pattern)
+- Rate-limit-detect middleware (Option A from §4.2)
+- Demo: Joel runs Codex on his Mac, Codex hits a rate limit, response transparently comes from local Continuum
+
+### Phase 2 — airc capability publication (1 week)
+- `Commands.execute('ai/capability/publish')` periodic emit
+- `#ai-capability` airc channel
+- Peer-table maintained from incoming capability messages
+- Demo: Joel's M3 Max publishes its loaded-models capability; vhsm's Mac sees it via `airc whois` or new `airc capabilities`
+
+### Phase 3 — Multi-peer routing (2-3 weeks)
+- TS-side router consults peer-table, picks best peer
+- Proxy logic with Tailscale-aware addressing
+- Failure-mode handling (peer unreachable mid-stream → fallback)
+- Demo: Joel's iPhone-class Mac asks Codex for a vision task; Codex calls local shim; local shim doesn't have vision but the household RTX 4090 box does (announced via airc); request transparently lands there.
+
+### Phase 4 — UX + observability (ongoing)
+- `airc capabilities` command — list peers + their models
+- Continuum status surface — show "served by: local-self / peer-X / cloud"
+- Optional cost dashboard (vs hypothetical-cloud-cost) — sells the value to non-technical household members
+
+---
+
+## 7. Where this fits Joel's CLAUDE.md rules
+
+| Rule | This design |
+|---|---|
+| Native-truth + thin-SDK-per-language | Rust core is truth. Anthropic/OpenAI HTTP shims are thin wrappers. External agents (Claude Code, Codex) become outermost SDKs that consume via standard HTTP. |
+| Two universal primitives (Commands.execute + Events) | Capability publish is `Commands.execute('ai/capability/publish')`. Peer announcements arrive as Events on the airc subscription. |
+| Off-main-thread principle | Inference already runs in Rust core (off the JS event loop). Local shim is axum (async Tokio). Routing decisions are in the daemon, not the browser. |
+| Compression principle | One AIAdapter trait → many implementations. One capability schema. One router. No duplicated truth between Rust and TS. |
+| QA is roleplay (deliver bugs not fixes) | Phase 1 demo IS the QA: a real user (Joel) hits a real rate limit and the local fallback either works or doesn't. No "tests pass but UX is broken" trap. |
+| Bugs from new users are gifts | The capacity-squeeze bringing new users to local is the gift. Every friction we surface is a bug to fix in the install / shim / routing path. |
+
+---
+
+## 8. Cross-references
+
+### Continuum architecture docs (read for deeper context)
+- `docs/architecture/PERSONA-COGNITION-RUST-MIGRATION.md` — the cognition Rust path the local-shim depends on
+- `docs/architecture/PERSONA-CONTEXT-PAGING.md` — VRAM-aware context paging (already smart, don't reinvent)
+- `docs/architecture/RECIPE-EXECUTION-RUNTIME.md` — recipe pipeline that local-shim invokes
+- `docs/architecture/RESOURCE-ARCHITECTURE.md` — FootprintRegistry + memory budgeting
+- `docs/inference/MLX-BACKEND.md` — Mac inference path
+- `CLAUDE.md` — the standing rules + project ethos
+
+### airc references
+- airc README (post-3c E2EE-by-design)
+- airc#372 — Codex pre-turn hook surface (how the rate-limit-aware swap could fire)
+- airc#368 — `[shell_environment_policy.set]` for env injection (the OPENAI_BASE_URL injection mechanism)
+- airc#381 layer A (continuum-b741 PR #387) + layer B (continuum-2c54 #385 merged) — mesh substrate reliability
+
+### External
+- Anthropic Messages API spec — wire format the anthropic_compat.rs serves
+- OpenAI Chat Completions API spec — wire format the future openai_compat.rs will serve
+- Claude Code Agent SDK — the harness LocalClaudeCodeProvider already drives
+- Codex hooks docs (openai/codex repo) — UserPromptSubmit + additionalContext
+
+---
+
+## 9. Open questions
+
+1. **License + ToS** — running a local Anthropic-compat or OpenAI-compat shim doesn't violate either provider's ToS (you're not impersonating them; you're providing your own server that speaks their wire protocol — common pattern, Ollama does this, LM Studio does this). But worth a Joel/legal pass before shipping wide.
+2. **Capability staleness** — peers' published capabilities have a TTL. What's the right poll cadence? Initial guess: 60s emit, 180s TTL. Tune based on observed churn.
+3. **Auth** — who can reach a peer's local HTTP shim? Tailscale ACLs solve the network layer, but there should be an airc-identity-rooted auth shim too (only paired-via-airc peers can call your local inference).
+4. **Cost accounting** — when a request is served by another peer, how do we account for it (electricity / wear / time)? Phase 4 problem; doesn't block Phase 1-3.
+5. **Model coherence across peers** — if peer A has qwen3-30b-gguf-q4 and peer B has qwen3-30b-gguf-q5, are responses comparable enough that auto-routing won't surprise users? Probably yes for most uses; document the surprise surface.
+
+---
+
+## 10. Out of scope (intentionally)
+
+- Training / fine-tuning across peers (the forge does that; this doc is inference-time only)
+- Distributed inference of a SINGLE request across peers (split-tensor / split-attention) — that's a different beast; we're talking request-level routing here
+- Replacing the Continuum web UI with Claude Code / Codex — those are additional surfaces, not replacements
+- Provider-marketplace UX (paying remote peers for inference) — Phase 5+
+
+---
+
+## 11. Action items for the mesh (live coordination targets)
+
+These are the concrete first claims for whoever picks them up next session, after airc#381/#383 land:
+
+| Item | Lane | Owner-fit | Notes |
+|---|---|---|---|
+| Lift `LocalClaudeCodeProvider` to first-class provider | TS SDK | continuum-b741 | Smallest scoped step; reuses existing Sentinel code |
+| `openai_compat.rs` Rust shim | Rust core | continuum-2c54 (Codex peer — natural ownership) | Mirror anthropic_compat.rs shape; serves Codex + openclaws + Hermes + any OpenAI-wire client |
+| Codex `OPENAI_BASE_URL` injection via config.toml + hook | airc + codex config | continuum-2c54 | Composes with airc#368 mechanism |
+| `ai/capability/publish` command + airc channel | TS SDK + airc | carl-mac (already deep in airc) | New `#ai-capability` channel + JSON schema |
+| Peer-routing logic | TS SDK | continuum-b741 | Builds on FootprintRegistry + capability table |
+| #722 widget refresh death triage | Rust core | open | Phase 0 prerequisite |
+| Training-flywheel hook: capture every external-agent interaction | TS SDK | open | LocalClaudeCodeProvider already has `captureTraining=true` plumbing — extend to all-providers, gated by user opt-in |
+
+### 11.1 Additional integration targets (any agent that speaks Anthropic or OpenAI wire)
+
+The shims serve a wire format, not a vendor. Once `anthropic_compat.rs` and `openai_compat.rs` are solid, every external agent below plugs in via the same env-var pattern. **No per-agent integration work**; one shim, N agents.
+
+- **Claude Code** (Anthropic SDK) — first target, partial via `LocalClaudeCodeProvider`
+- **Codex** (OpenAI SDK) — first target via `OPENAI_BASE_URL` + hooks
+- **openclaws** — Joel's open-source agent layer (memory: airc IS openclaws's grid-comms substrate, see project memory)
+- **Hermes** — NousResearch + community open-source agent
+- **Cursor** (when their plugin slot lands)
+- **Aider** (Anthropic + OpenAI both supported via base-URL)
+- **Continue.dev** (same)
+- **Anything that speaks Anthropic Messages or OpenAI Chat-Completions wire** — that's the universe.
+
+### 11.2 The training flywheel (Continuum's per-user advantage cloud cannot match)
+
+Cloud models train once on the world's data. Continuum trains continuously on YOUR data, on YOUR machine, with YOUR consent.
+
+The mechanism already exists in piece-form:
+- `LocalClaudeCodeProvider` has `captureTraining=true` → routes interactions to `persona/learning/capture-interaction`
+- `TrainingDataAccumulator` collects + curates
+- `forge-alloy/python/forge_alloy/` is the training pipeline (recipe-driven, see `docs/architecture/FORGE-ALLOY-SPEC.md`)
+- LoRA adapter paging (PERSONA-CONVERGENCE-ROADMAP.md) lets the same base model serve multiple specialized fine-tunes
+
+What needs to lock in:
+- Generalize the capture surface from `LocalClaudeCodeProvider` to ALL local-served interactions (not just Sentinel)
+- User-controlled opt-in / opt-out per workspace
+- Per-skill / per-recipe LoRA fine-tunes that improve over weeks of use
+- Eventually: peer-shareable LoRAs (with attribution) — your domain expertise compounds with the household / co-op grid
+
+This is the moat. **Cloud APIs literally cannot train on your private data per-user without crossing a line they've publicly committed not to cross.** We can — locally, opt-in, transparently — and we should.
+
+---
+
+## 12. Why we wrote this NOW
+
+Joel, 2026-04-30, after the morning's 3-issue airc fix-up and the multi-peer rate-limit cascade:
+
+> "create a new design doc for continuum. We have our bugs and rust enhancements we must also address. Let's design it NOW that its fresh in our minds, before we are rate limited away"
+
+The capacity squeeze that's tipping users toward local-first is also tipping AI peers (us) toward "we won't be able to design tomorrow." This doc is the artifact that lets the work continue when the cloud-side AI capacity that produced it is gone. Read this first; the substrate it describes is buildable from the surfaces already in `workers/continuum-core/`, `src/system/sentinel/coding-agents/`, `src/daemons/ai-provider-daemon/`, and the airc mesh. None of it is hypothetical.
+
+Continuum + airc, integrated this way, is the answer to "what do we do when the cloud is full." It's the thing humans buy local hardware FOR.
+
+— continuum-b741 / claude-opus, 2026-04-30

--- a/docs/architecture/AGENT-BACKBONE-INTEGRATION.md
+++ b/docs/architecture/AGENT-BACKBONE-INTEGRATION.md
@@ -369,7 +369,37 @@ The shims serve a wire format, not a vendor. Once `anthropic_compat.rs` and `ope
 - **Continue.dev** (same)
 - **Anything that speaks Anthropic Messages or OpenAI Chat-Completions wire** — that's the universe.
 
-### 11.2 The training flywheel (Continuum's per-user advantage cloud cannot match)
+### 11.2 Bidirectional persona ↔ external-agent over airc rooms/DMs
+
+**Added 2026-04-30 (Joel→Toby strategic context):**
+
+> "Personas to talk to outside agents like Claude code, by sharing the same rooms or dms, just a simple command addition. And vice versa. They all work together."
+
+The HTTP-shim integration in §1-§10 is one direction: external agents (Claude Code, Codex) consume Continuum's local inference. This section names the **other direction**: Continuum personas (Helper AI, Vision AI, the persona genome) sit in the SAME airc rooms as external-agent instances and converse as peers.
+
+**Architecture:** airc is the universal mesh. From airc's POV, a Claude Code tab and a Continuum persona are both just peers with identity blocks. They send messages, DM each other, share rooms. The line between "internal AI citizen" and "external agent" disappears at the substrate.
+
+**What's needed (small, composes with existing primitives):**
+
+1. **continuum command: `airc/send`** — `Commands.execute('airc/send', {channel, peer?, message})` — bridges from a persona's outbound surface to `airc msg`. Trivial wrapper around the existing airc CLI.
+2. **continuum event: `airc:message:received`** — `Events.subscribe('airc:message:received', handler)` — fed by an `airc connect` Monitor running inside Continuum's process tree. Handler routes incoming envelopes to the right persona's inbox (PERSONA-CONVERGENCE-ROADMAP `PersonaInbox`).
+3. **Persona identity in airc** — each Continuum persona registers its airc identity (`airc identity set --pronouns ... --role "continuum-persona-helper" --bio "..."`) so peers (human + external agent) see who they're talking to.
+4. **Auto-room semantics** — a persona joins a room when its scope warrants it (e.g. Vision AI joins `#cambriantech` when the project room exists). Same `airc join` rules as humans / external agents.
+5. **Cross-vendor proof:** Codex tab + Helper AI persona + Vision AI persona + Joel + Toby all in `#cambriantech`, conversing. Codex asks Vision AI to describe an image; Vision AI calls its CandleAdapter; result lands in the room; Codex picks it up. **No HTTP shim needed for this flow** — it's airc-native message routing, the same way humans and agents talk.
+
+**Why this matters:**
+- Continuum's autonomous personas get a **proven, durable comms substrate** (airc) instead of having to invent intra-process pub/sub
+- External agents get **Continuum's specialized capabilities** (vision, audio, fine-tuned LoRAs) without HTTP-API proliferation — just DM the right persona
+- Humans (Joel, Toby, household members) participate in the same conversations as both classes of agent
+- The "control room" UX (continuum widgets) renders airc rooms with avatars per peer, regardless of whether the peer is a Claude Code tab or a Continuum persona — uniform surface
+
+**Composes with §1-§10:** the HTTP-shim flow handles "Codex asks for inference, gets Anthropic-wire response back." The airc-bridge flow handles "Codex asks Helper AI a question in a chat room, Helper AI thinks + responds." Different shapes, both useful, share the substrate. Implement HTTP-shim first (Phase 1), airc-bridge second (Phase 2.5 — slot between capability-publish and multi-peer-routing).
+
+**Known minimum viable path:**
+- LocalClaudeCodeProvider already runs Claude Code as a subprocess; extend with `--airc-room <channel>` flag so the spawned Claude Code tab auto-joins that room and can converse with personas already there
+- Helper AI / Vision AI gets `airc connect` lifecycle wired into its `PersonaUser` startup (existing autonomous loop handles inbox; airc just feeds it)
+
+### 11.3 The training flywheel (Continuum's per-user advantage cloud cannot match)
 
 Cloud models train once on the world's data. Continuum trains continuously on YOUR data, on YOUR machine, with YOUR consent.
 

--- a/install.ps1
+++ b/install.ps1
@@ -214,9 +214,9 @@ if ($bootstrapExit -eq 0) {
     Write-Ok 'Continuum is up.'
     Write-Host ''
     switch ($Mode) {
-        'browser'  { Write-Host '  UI:        http://localhost:9000' }
+        'browser'  { Write-Host '  UI:        http://localhost:9003' }
         'cli'      { Write-Host '  CLI:       continuum   (from any new shell)' }
-        'headless' { Write-Host '  Server:    http://localhost:9000 (API only)' }
+        'headless' { Write-Host '  Server:    http://localhost:9003 (API only)' }
     }
     Write-Host '  Verify:    continuum doctor'
     Write-Host ''

--- a/install.sh
+++ b/install.sh
@@ -717,33 +717,69 @@ if [[ "$OS" == "Darwin" ]]; then
     warn "npm start failed — check logs at ~/.continuum/jtag/logs/system/continuum-core.log"
 fi
 
-# ── 8. Wait for health ─────────────────────────────────────
-info "Waiting for services..."
-for i in {1..30}; do
-  if curl -sf http://localhost:9003 &>/dev/null || curl -sf https://localhost:9003 -k &>/dev/null; then
+# ── 8. Wait for widget-server health ───────────────────────
+# Carl's experience hinges on this gate: if we open the browser before
+# widget-server is actually serving, Chrome lands on the failed URL,
+# replaces the location bar with chrome-error://chromewebdata/, and any
+# subsequent reload tries to navigate from chrome-error back to http: —
+# which the browser blocks as a cross-scheme navigation. Carl is then
+# stuck on an error page with no clean recovery. Empirically: 2026-04-25
+# joel hit "Unsafe attempt to load URL http://localhost:9003/ from frame
+# with URL chrome-error://chromewebdata/" exactly because of this race.
+#
+# Two changes vs the prior 'curl -sf' wait:
+#   1. Hit /health specifically (widget-server's health endpoint at
+#      JTAGEndpoints.HEALTH = '/health'). A 200 here means widget-server
+#      is actually serving HTTP, not just that the port is open.
+#   2. If we never get a 200 in HEALTH_TIMEOUT_SEC, DO NOT open the
+#      browser. Print actionable diagnostic + a manual-open command for
+#      Carl to use after he checks the logs. Opening to a not-yet-ready
+#      server is the bug; refusing to open is the correct behavior.
+info "Waiting for widget-server health (timeout ${HEALTH_TIMEOUT_SEC:=120}s)..."
+HEALTH_OK=0
+for i in $(seq 1 "$HEALTH_TIMEOUT_SEC"); do
+  # --fail returns non-zero on 4xx/5xx; --max-time keeps each probe snappy
+  # so the loop stays close to a 1s cadence even when the server hangs.
+  if curl -sf --max-time 2 http://localhost:9003/health >/dev/null 2>&1 \
+     || curl -sfk --max-time 2 https://localhost:9003/health >/dev/null 2>&1; then
+    HEALTH_OK=1
+    ok "widget-server healthy after ${i}s"
     break
   fi
-  [ $i -eq 30 ] && warn "Services still starting — check: $CONTAINER_CMD compose logs"
-  sleep 2
+  sleep 1
 done
 
-# ── 9. Determine URL + open browser ────────────────────────
+# ── 9. Determine URL + open browser (only if healthy) ──────
 if [ -n "$TS_HOSTNAME" ] && [ -f "$CONTINUUM_DATA/$TS_HOSTNAME.crt" ]; then
   URL="https://$TS_HOSTNAME:9003"
 else
   URL="http://localhost:9003"
 fi
 
-case "$OS" in
-  Darwin) open "$URL" 2>/dev/null || true ;;
-  Linux)
-    if grep -qi microsoft /proc/version 2>/dev/null; then
-      cmd.exe /c start "" "$URL" 2>/dev/null || true
-    else
-      xdg-open "$URL" 2>/dev/null || true
-    fi
-    ;;
-esac
+if [ "$HEALTH_OK" -eq 1 ]; then
+  case "$OS" in
+    Darwin) open "$URL" 2>/dev/null || true ;;
+    Linux)
+      if grep -qi microsoft /proc/version 2>/dev/null; then
+        cmd.exe /c start "" "$URL" 2>/dev/null || true
+      else
+        xdg-open "$URL" 2>/dev/null || true
+      fi
+      ;;
+  esac
+else
+  warn "widget-server not healthy after ${HEALTH_TIMEOUT_SEC}s — NOT opening browser."
+  warn "  Opening Chrome to a not-yet-ready URL traps you on a chrome-error page"
+  warn "  that cannot cleanly recover. Diagnose + retry instead:"
+  echo ""
+  echo "    Logs:   $CONTAINER_CMD compose -f $INSTALL_DIR/docker-compose.yml logs --tail=200"
+  echo "    Status: $CONTAINER_CMD compose -f $INSTALL_DIR/docker-compose.yml ps"
+  echo "    Retry:  curl -v http://localhost:9003/health"
+  echo ""
+  echo "    Once the health endpoint returns 200, open the URL manually:"
+  echo "      $URL"
+  echo ""
+fi
 
 # ── Done ────────────────────────────────────────────────────
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -21,13 +21,62 @@ REPO="https://github.com/CambrianTech/continuum.git"
 INSTALL_DIR="${CONTINUUM_DIR:-$HOME/continuum}"
 CONTINUUM_DATA="$HOME/.continuum"
 
+# ── Friendly-failure infrastructure ─────────────────────────
+# When install.sh fails partway, Carl needs to know WHICH phase died,
+# not just what bash printed. PHASE gets updated as we enter each
+# section; the ERR trap reads it + maps to phase-specific guidance.
+# Empirically (2026-04-25): existing failures dump bash's last line
+# of stderr with no context. Carl can't tell if it's a Docker thing,
+# a Tailscale thing, a model-download thing, or a Rust build thing
+# without reading install.sh source.
+PHASE="(starting up)"
+INSTALL_LOG="${INSTALL_LOG:-/tmp/continuum-install-$$.log}"
+exec > >(tee -a "$INSTALL_LOG") 2>&1
+
+phase_guidance() {
+  case "$PHASE" in
+    *"detect environment"*) echo "Verify uname -s + uname -m return expected values; check disk space (df -h /).";;
+    *"pre-clone bootstrap"*) echo "Install git + docker first; on Mac, ensure Docker Desktop is running.";;
+    *"clone"*|*"update repo"*) echo "Check network: ping github.com; verify INSTALL_DIR ($INSTALL_DIR) is writable.";;
+    *"shared modules"*) echo "Re-clone may be incomplete; rm -rf $INSTALL_DIR && re-run installer.";;
+    *"configuration"*) echo "Check $CONTINUUM_DATA exists + is writable; mkdir -p $CONTINUUM_DATA && chmod 700 $CONTINUUM_DATA.";;
+    *"TLS certs"*) echo "Tailscale + cert step is optional; export CONTINUUM_NO_TLS=1 and re-run.";;
+    *"compose files"*) echo "Verify docker-compose.yml exists in $INSTALL_DIR; the install repo may be incomplete.";;
+    *"pull"*|*"images"*) echo "Network or GHCR auth issue; docker login ghcr.io and retry.";;
+    *"start support services"*|*"bring up"*) echo "Check Docker Desktop has enough RAM (≥30GB). docker compose -f $INSTALL_DIR/docker-compose.yml logs --tail=100";;
+    *"widget-server health"*) echo "Compose came up but widget-server isn't serving. docker compose -f $INSTALL_DIR/docker-compose.yml logs widget-server --tail=100";;
+    *) echo "Capture full log + open an issue: cat $INSTALL_LOG | gh issue create -t 'install fail @ $PHASE' -b -";;
+  esac
+}
+
+on_install_fail() {
+  local rc=$?
+  # Trap fires on any non-zero exit (set -e). Avoid recursing if the
+  # ERR trap itself trips a sub-shell.
+  trap - ERR EXIT
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  ❌ Install failed during phase: $PHASE  (exit $rc)"
+  echo ""
+  echo "  Suggestion: $(phase_guidance)"
+  echo ""
+  echo "  Full log: $INSTALL_LOG"
+  echo "  Last 30 lines:"
+  tail -30 "$INSTALL_LOG" | sed 's/^/    /'
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  exit "$rc"
+}
+trap on_install_fail ERR
+
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  Continuum Installer"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Log: $INSTALL_LOG"
 echo ""
 
 # ── 1. Detect environment ───────────────────────────────────
+PHASE="detect environment"
 info "Detecting environment..."
 
 OS="$(uname -s)"
@@ -49,6 +98,7 @@ case "$OS" in
 esac
 
 # ── 2. Pre-clone bootstrap: git + minimal Docker presence check ────
+PHASE="pre-clone bootstrap"
 # We can't source the canonical module library yet (lives in the repo).
 # Just verify prerequisites so the clone can happen. Deeper checks live
 # in the canonical modules that run after the clone.
@@ -532,6 +582,7 @@ case "$OS" in
 esac
 
 # ── 3. Clone / update repo ─────────────────────────────────
+PHASE="clone / update repo"
 if [ -d "$INSTALL_DIR/.git" ]; then
   info "Updating existing installation..."
   cd "$INSTALL_DIR"
@@ -543,6 +594,7 @@ else
 fi
 
 # ── 4. Shared modules (same code that Dev runs via npm start) ────
+PHASE="shared modules"
 # docs/infrastructure/INSTALL-ARCHITECTURE.md §Module-shape: the canonical
 # module library at src/scripts/lib/install-common.sh defines
 # mod_submodules_init + mod_docker_wsl_integration + log/sudo primitives.
@@ -577,6 +629,7 @@ ok "Source: $INSTALL_DIR"
 mod_continuum_bin_link "$INSTALL_DIR/bin/continuum"
 
 # ── 4. Configuration ───────────────────────────────────────
+PHASE="configuration"
 mkdir -p "$CONTINUUM_DATA"
 
 CONFIG_FILE="$CONTINUUM_DATA/config.env"
@@ -600,6 +653,7 @@ else
 fi
 
 # ── 5. TLS certs (Tailscale) ──────────────────────────────
+PHASE="TLS certs (optional)"
 TS_HOSTNAME=""
 if command -v tailscale &>/dev/null; then
   TS_HOSTNAME=$(tailscale status --json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('Self',{}).get('DNSName','').rstrip('.'))" 2>/dev/null || echo "")
@@ -624,6 +678,7 @@ else
 fi
 
 # ── 6. Pick compose files + profile ───────────────────────
+PHASE="compose files"
 # Base file is always loaded. On GPU hosts, layer docker-compose.gpu.yml
 # so continuum-core picks up the cuda image override (otherwise compose
 # silently uses the CPU image and inference falls back to CPU). The same
@@ -654,6 +709,7 @@ elif [[ "$HAS_GPU" == "true" ]]; then
 fi
 
 # ── 7. Pull support-service images ─────────────────────────
+PHASE="pull images"
 # Image tag resolution: compose files honor ${CONTINUUM_IMAGE_TAG:-latest}.
 # Main-branch installs (Carl's default) use :latest. Reviewers validating
 # a PR before merge can pin the PR's staged image set:
@@ -669,6 +725,7 @@ info "Pulling container images (tag: ${CONTINUUM_IMAGE_TAG:-latest})..."
 $CONTAINER_CMD compose $COMPOSE_FILES $COMPOSE_ARGS pull 2>/dev/null || warn "Some images not published yet — will build locally"
 
 # ── 8. Start support services ──────────────────────────────
+PHASE="start support services"
 # Inverse of parallel-start.sh's cross-mode detection: if native Dev-mode
 # processes (continuum-core-server, tsx orchestrator) are running, docker
 # compose up will collide on ports 9001/9100/7880-82/9003/5432. Warn so
@@ -718,6 +775,7 @@ if [[ "$OS" == "Darwin" ]]; then
 fi
 
 # ── 8. Wait for widget-server health ───────────────────────
+PHASE="widget-server health"
 # Carl's experience hinges on this gate: if we open the browser before
 # widget-server is actually serving, Chrome lands on the failed URL,
 # replaces the location bar with chrome-error://chromewebdata/, and any
@@ -750,6 +808,7 @@ for i in $(seq 1 "$HEALTH_TIMEOUT_SEC"); do
 done
 
 # ── 9. Determine URL + open browser (only if healthy) ──────
+PHASE="open browser"
 if [ -n "$TS_HOSTNAME" ] && [ -f "$CONTINUUM_DATA/$TS_HOSTNAME.crt" ]; then
   URL="https://$TS_HOSTNAME:9003"
 else

--- a/scripts/ci/carl-install-smoke.sh
+++ b/scripts/ci/carl-install-smoke.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# carl-install-smoke.sh — run the EXACT install command Carl runs, then
+# assert the user-facing surface actually serves usable content.
+#
+# Why this gate: existing install-and-run-gate.sh validates the docker
+# compose stack itself (images present, services healthy on :9003). It does
+# NOT validate that `curl install.sh | bash` — Carl's actual entry point —
+# completes cleanly, or that the page Carl opens after install renders
+# something usable instead of chrome-error / empty.
+#
+# This gate closes that gap. Same one-line invocation works for CI and
+# humans (per Joel's "make your own testing easy" rule):
+#
+#   bash scripts/ci/carl-install-smoke.sh
+#
+# Optional env:
+#   CARL_INSTALL_TIMEOUT_SEC=900    full install timeout (default 15min)
+#   CARL_HEALTH_TIMEOUT_SEC=180     widget-server /health wait (default 3min)
+#   CARL_INSTALL_DIR=/tmp/carl-N    install location (default fresh tmp)
+#   CARL_INSTALL_REF=$GIT_SHA       which install.sh to fetch from main
+#   SKIP_TEARDOWN=1                 keep stack running after probe (debug)
+#
+# Exit codes:
+#   0 — install completed AND page rendered usable HTML
+#   1 — install.sh failed
+#   2 — install.sh succeeded but widget-server never returned 200 on /health
+#   3 — widget-server returned 200 but page body looks broken
+#       (empty / contains chrome-error / contains "container exited")
+
+set -uo pipefail
+
+CARL_INSTALL_TIMEOUT_SEC="${CARL_INSTALL_TIMEOUT_SEC:-900}"
+CARL_HEALTH_TIMEOUT_SEC="${CARL_HEALTH_TIMEOUT_SEC:-180}"
+CARL_INSTALL_DIR="${CARL_INSTALL_DIR:-/tmp/carl-smoke-$$}"
+CARL_INSTALL_REF="${CARL_INSTALL_REF:-${GITHUB_SHA:-main}}"
+SKIP_TEARDOWN="${SKIP_TEARDOWN:-0}"
+
+INSTALL_LOG="${CARL_INSTALL_DIR}.install.log"
+PAGE_BODY="${CARL_INSTALL_DIR}.page.html"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  carl-install-smoke"
+echo "  CARL_INSTALL_DIR=$CARL_INSTALL_DIR"
+echo "  CARL_INSTALL_REF=$CARL_INSTALL_REF"
+echo "  CARL_INSTALL_TIMEOUT_SEC=$CARL_INSTALL_TIMEOUT_SEC"
+echo "  CARL_HEALTH_TIMEOUT_SEC=$CARL_HEALTH_TIMEOUT_SEC"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+teardown() {
+  local rc=$?
+  if [ "$SKIP_TEARDOWN" != "1" ] && [ -d "$CARL_INSTALL_DIR" ]; then
+    echo ""
+    echo "━━━ tearing down $CARL_INSTALL_DIR ━━━"
+    if [ -f "$CARL_INSTALL_DIR/docker-compose.yml" ]; then
+      ( cd "$CARL_INSTALL_DIR" && docker compose down -v 2>&1 | tail -3 ) || true
+    fi
+    rm -rf "$CARL_INSTALL_DIR"
+  fi
+  exit "$rc"
+}
+trap teardown EXIT INT TERM
+
+# ── 1. Run Carl's exact install command ───────────────────────
+echo ""
+echo "━━━ running install.sh from $CARL_INSTALL_REF ━━━"
+echo "  log: $INSTALL_LOG"
+
+# Carl runs: curl -fsSL <install.sh> | bash
+# We do the same, but pin to the exact ref under test (defaults to GITHUB_SHA
+# in CI so we exercise THIS PR's install script, not main's).
+INSTALL_URL="https://raw.githubusercontent.com/CambrianTech/continuum/${CARL_INSTALL_REF}/install.sh"
+
+# Time the install. 15-min timeout for the docker-only path (Carl's expected
+# experience). Hybrid Mac path (with Rust source build) will exceed this on
+# a fresh runner — that's fine, it'll fail the gate, which is the design
+# (the README claims docker-only; install should match).
+INSTALL_START=$(date +%s)
+if ! timeout "$CARL_INSTALL_TIMEOUT_SEC" bash -c \
+     "CONTINUUM_DIR='$CARL_INSTALL_DIR' bash <(curl -fsSL '$INSTALL_URL')" \
+     >"$INSTALL_LOG" 2>&1; then
+  INSTALL_DUR=$(( $(date +%s) - INSTALL_START ))
+  echo "❌ install.sh failed or timed out after ${INSTALL_DUR}s"
+  echo ""
+  echo "  Last 50 lines of install log:"
+  tail -50 "$INSTALL_LOG" | sed 's/^/    /'
+  exit 1
+fi
+INSTALL_DUR=$(( $(date +%s) - INSTALL_START ))
+echo "✅ install.sh completed in ${INSTALL_DUR}s"
+
+# ── 2. Wait for widget-server /health ─────────────────────────
+# install.sh has its own health-wait now (piece E in this PR), but we
+# re-check here in case the user used SKIP_HEALTH=1 or ran an older
+# install.sh without the wait. Belt + suspenders.
+echo ""
+echo "━━━ waiting up to ${CARL_HEALTH_TIMEOUT_SEC}s for widget-server /health ━━━"
+HEALTH_OK=0
+for i in $(seq 1 "$CARL_HEALTH_TIMEOUT_SEC"); do
+  if curl -sf --max-time 2 http://localhost:9003/health >/dev/null 2>&1; then
+    HEALTH_OK=1
+    echo "  /health 200 after ${i}s"
+    break
+  fi
+  sleep 1
+done
+
+if [ "$HEALTH_OK" -ne 1 ]; then
+  echo "❌ widget-server never returned 200 on /health within ${CARL_HEALTH_TIMEOUT_SEC}s"
+  echo ""
+  if [ -f "$CARL_INSTALL_DIR/docker-compose.yml" ]; then
+    echo "  docker compose ps:"
+    ( cd "$CARL_INSTALL_DIR" && docker compose ps 2>&1 | sed 's/^/    /' ) || true
+    echo ""
+    echo "  Last 30 lines of widget-server logs:"
+    ( cd "$CARL_INSTALL_DIR" && docker compose logs --tail=30 widget-server 2>&1 | sed 's/^/    /' ) || true
+  fi
+  exit 2
+fi
+
+# ── 3. Validate the page Carl will open ───────────────────────
+# /health says "server is alive" but doesn't say "the page Carl opens
+# renders usable HTML." A naked health endpoint can return 200 while the
+# main page returns a stack trace or empty body. Probe the actual root.
+echo ""
+echo "━━━ probing root page Carl opens (http://localhost:9003/) ━━━"
+ROOT_CODE=$(curl -sS -o "$PAGE_BODY" -w "%{http_code}" http://localhost:9003/ 2>/dev/null || echo "000")
+ROOT_BYTES=$(wc -c < "$PAGE_BODY" 2>/dev/null || echo 0)
+echo "  HTTP status: $ROOT_CODE"
+echo "  Body bytes:  $ROOT_BYTES"
+
+if [[ ! "$ROOT_CODE" =~ ^2 ]]; then
+  echo "❌ root page returned non-2xx ($ROOT_CODE)"
+  exit 3
+fi
+
+if [ "$ROOT_BYTES" -lt 100 ]; then
+  echo "❌ root page body is suspiciously small ($ROOT_BYTES bytes); Carl would see a blank page."
+  echo "  First 500 bytes:"
+  head -c 500 "$PAGE_BODY" | sed 's/^/    /'
+  exit 3
+fi
+
+# Sanity: page should look like HTML, not a stack trace or compose error.
+if ! grep -qiE "<(html|head|body|continuum)" "$PAGE_BODY" 2>/dev/null; then
+  echo "❌ root page body doesn't look like HTML; Carl would see something broken."
+  echo "  First 500 bytes:"
+  head -c 500 "$PAGE_BODY" | sed 's/^/    /'
+  exit 3
+fi
+
+# Negative checks: any of these in the body = broken-feeling page.
+for marker in "chrome-error" "container exited" "ECONNREFUSED" "Cannot GET /" "Internal Server Error"; do
+  if grep -qF "$marker" "$PAGE_BODY"; then
+    echo "❌ root page contains failure marker: '$marker'"
+    echo "  Context:"
+    grep -F "$marker" "$PAGE_BODY" | head -3 | sed 's/^/    /'
+    exit 3
+  fi
+done
+
+echo "✅ root page looks like real HTML (${ROOT_BYTES} bytes, no failure markers)"
+
+# ── Done ──────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  ✅ carl-install-smoke PASSED"
+echo "  Install duration: ${INSTALL_DUR}s"
+echo "  Health latency:   $(( $(date +%s) - INSTALL_START - INSTALL_DUR ))s after install"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/src/scripts/parallel-start.sh
+++ b/src/scripts/parallel-start.sh
@@ -204,20 +204,47 @@ if [ ! -f "target/release/continuum-core-server" ]; then
   echo -e "  [Rust] ${YELLOW}First build detected — this takes 5-15 minutes. Showing progress...${NC}"
   CARGO_QUIET=""
 fi
+
+# Wrapper around `cargo build -p <pkg>`. On incremental builds (CARGO_QUIET
+# non-empty) we capture-then-display, which keeps the log clean. On first
+# builds (CARGO_QUIET empty) we tee so cargo's "Compiling crate vX.Y.Z"
+# lines stream live to the terminal — without this, the user saw the
+# "First build detected — Showing progress..." banner then total silence
+# for 5-15 minutes because $(cargo ...) blocks until cargo exits. We still
+# capture into $OUT for preflight_check_cargo_xcode + the failure path.
+build_pkg() {
+  local pkg="$1"; shift
+  if [ -n "$CARGO_QUIET" ]; then
+    OUT=$(cargo build --release -p "$pkg" "$@" --quiet 2>&1) \
+      || { BUILD_OUTPUT+="$OUT"; RESULT=1; }
+  else
+    local tmp
+    tmp=$(mktemp)
+    cargo build --release -p "$pkg" "$@" 2>&1 | tee "$tmp"
+    local rc=${PIPESTATUS[0]}
+    OUT=$(cat "$tmp")
+    rm -f "$tmp"
+    if [ "$rc" -ne 0 ]; then
+      BUILD_OUTPUT+="$OUT"
+      RESULT=1
+    fi
+  fi
+}
+
 for pkg in archive-worker jtag-mcp; do
-  OUT=$(cargo build --release -p $pkg $CARGO_QUIET 2>&1) || { BUILD_OUTPUT+="$OUT"; RESULT=1; }
+  build_pkg "$pkg"
 done
 # continuum-core: all GPU features (metal+accelerate on macOS, cuda on Linux)
 if [ -n "$GPU_FEAT" ]; then
-  OUT=$(cargo build --release -p continuum-core --features "$GPU_FEAT" $CARGO_QUIET 2>&1) || { BUILD_OUTPUT+="$OUT"; RESULT=1; }
+  build_pkg continuum-core --features "$GPU_FEAT"
 else
-  OUT=$(cargo build --release -p continuum-core $CARGO_QUIET 2>&1) || { BUILD_OUTPUT+="$OUT"; RESULT=1; }
+  build_pkg continuum-core
 fi
 # inference-grpc: GPU backend only (metal or cuda, no accelerate)
 if [ -n "$GPU_BACKEND" ]; then
-  OUT=$(cargo build --release -p inference-grpc --features "$GPU_BACKEND" $CARGO_QUIET 2>&1) || { BUILD_OUTPUT+="$OUT"; RESULT=1; }
+  build_pkg inference-grpc --features "$GPU_BACKEND"
 else
-  OUT=$(cargo build --release -p inference-grpc $CARGO_QUIET 2>&1) || { BUILD_OUTPUT+="$OUT"; RESULT=1; }
+  build_pkg inference-grpc
 fi
 # Filter ts-rs noise and display
 echo "$BUILD_OUTPUT" | grep -v -E "ts-rs failed to parse|failed to parse serde|= note:|skip_serializing_if|^\s*\|?\s*$|^$" | sed 's/^/  [Rust] /'


### PR DESCRIPTION
## Summary

Captures Joel's strategic framing live during the 2026-04-30 AI capacity squeeze (Codex auto-downgraded to mini, paid Anthropic users hitting rate limits, AI stocks correcting on demand-outpaces-supply).

**Architecture (3 layers):**

- **L1 — External agent** (Claude Code, Codex, openclaws, Hermes, …) pointed at local Continuum via `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL`. **No code changes to the external agent.**
- **L2 — Continuum local truth (Rust core)** — `anthropic_compat.rs` (already exists) + `openai_compat.rs` (to add) sit in front of the same `AIAdapter` trait. CandleAdapter, LlamaCppAdapter, MLX backend already implement it. `LocalClaudeCodeProvider.ts` already does the proof-of-concept end-to-end.
- **L3 — airc capability mesh** (multi-machine multiplier). Peers publish loaded models + free VRAM + endpoints over a dedicated `#ai-capability` airc channel. Layer-2 routers consult the peer table + route to the best-fit peer. Inference traffic itself goes peer-to-peer via Tailscale or LAN.

**Native-truth + thin-SDK rule applied** (per `CLAUDE.md`): Rust core is truth, TS daemon is the SDK, external agents are outermost SDKs that consume via standard HTTP. No layer reimplements another's truth.

**PC-paradigm framing:** small / nimble / collaborative / scaling / distributed across all our hardware. Ship pretty-well-first, then build to dominance. The PC didn't beat the mainframe by being faster on day one — it beat it by being everywhere, owned individually, no central permission to compute.

**Training flywheel as the moat:**
- `LocalClaudeCodeProvider` already has `captureTraining=true`
- `TrainingDataAccumulator` already routes to academy pipeline
- `forge-alloy` already builds LoRAs from captured interactions
- Cloud APIs literally cannot train per-user on private data without crossing publicly-committed lines. We can — locally, opt-in, transparently. **That's the differentiator.**

## Phased delivery

- **Phase 0** (in flight): airc#381 layer A (PR #387) + B (#385 merged), airc#383 (PR #384), continuum #722/#56/#75 stabilization
- **Phase 1** (1-2 weeks): single-machine local fallback for Codex via `OPENAI_BASE_URL` + rate-limit-detect middleware
- **Phase 2** (1 week): airc capability channel + peer announcements
- **Phase 3** (2-3 weeks): multi-peer routing across the household grid
- **Phase 4**: UX polish + training-flywheel generalization

## What's in the doc

- Full architecture with code-pointer references (real files, real Rust serving Anthropic Messages API)
- Bug + Rust-enhancement triage (#722, #56, #75, #71, #73, #39, #765, #582, #860, #770, #637, #908) with how each blocks or composes with the integration
- Cross-references to existing arch docs (PERSONA-COGNITION-RUST-MIGRATION, PERSONA-CONTEXT-PAGING, RECIPE-EXECUTION-RUNTIME, RESOURCE-ARCHITECTURE, MLX-BACKEND, FORGE-ALLOY-SPEC)
- Open questions (license/ToS, capability staleness, auth shim, cost accounting, model coherence)
- Out-of-scope clarifications (training across peers, single-request distributed inference, replacing Continuum web UI)
- **Action items for the mesh** — concrete first claims for each peer, naming who's positioned for what

## Why we wrote this NOW

The capacity squeeze tipping users toward local is also tipping AI peers (us) toward "we won't be able to design tomorrow." This doc is the artifact that lets the work continue when the cloud-side AI capacity that produced it is gone. Read this first; the substrate it describes is **buildable from surfaces already in `workers/continuum-core/`, `src/system/sentinel/coding-agents/`, `src/daemons/ai-provider-daemon/`, and the airc mesh**. None of it is hypothetical.

## Test plan

- [x] Doc renders cleanly (markdown lint TBD if CI gates require)
- [ ] Mesh review: continuum-2c54 + carl-mac read end-to-end, push back on phasing + claim assignments
- [ ] Joel sanity-checks: PC-paradigm framing + training-flywheel moat positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)