### PR TITLE
fix(#722): SystemOrchestrator spawns + supervises continuum-core-server (closes #722)

### DIFF
--- a/src/daemons/data-daemon/server/ORMRustClient.ts
+++ b/src/daemons/data-daemon/server/ORMRustClient.ts
@@ -176,20 +176,30 @@ class IPCConnection {
 
   private scheduleReconnect(): void {
     if (this.reconnectTimer) return; // already scheduled
-    const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 30000); // 1s, 2s, 4s, ... max 30s
+    const delay = Math.min(1000 * Math.pow(2, Math.min(this.reconnectAttempts, 5)), 30000); // 1s, 2s, 4s, 8s, 16s, 30s, 30s, ...
     this.reconnectTimer = setTimeout(async () => {
       this.reconnectTimer = null;
       try {
         await this.connect();
+        if (this.reconnectAttempts > 0) {
+          console.log(`[IPC#${this.connectionIndex}] Reconnected to continuum-core after ${this.reconnectAttempts} attempts`);
+        }
         this.reconnectAttempts = 0;
-        console.log(`[IPC#${this.connectionIndex}] Reconnected to continuum-core`);
       } catch {
         this.reconnectAttempts++;
-        if (this.reconnectAttempts < 10) {
-          this.scheduleReconnect(); // try again with longer delay
-        } else {
-          console.error(`[IPC#${this.connectionIndex}] Gave up reconnecting after ${this.reconnectAttempts} attempts`);
+        // continuum#722 — never give up reconnecting. Pre-fix capped at
+        // 10 attempts (~3min total) which left widgets blank permanently
+        // when the Rust core was slow to come up. The orchestrator now
+        // respawns the core on crash (continuum#722 layer A); the IPC
+        // pool needs to be ready when it does.
+        //
+        // Surface every Nth failure so the log isn't silent during a
+        // long outage — debugger / user can tell whether reconnection
+        // is iterating (different errors) or stuck (same error).
+        if (this.reconnectAttempts === 1 || this.reconnectAttempts % 10 === 0) {
+          console.warn(`[IPC#${this.connectionIndex}] Reconnect attempt ${this.reconnectAttempts} failed — continuum-core still unreachable. Will keep trying.`);
         }
+        this.scheduleReconnect(); // try again with longer delay
       }
     }, delay);
   }

--- a/src/system/orchestration/SystemMilestones.ts
+++ b/src/system/orchestration/SystemMilestones.ts
@@ -25,11 +25,19 @@ export const SYSTEM_MILESTONES = {
   DEPLOY_PORTS_ALLOCATED: 'deploy_ports_allocated',
   DEPLOY_COMPLETE: 'deploy_complete',
   
+  // Rust Core Phase Milestones (continuum#722 — supervised lifecycle)
+  // continuum-core-server is the Rust IPC backbone. Pre-fix it was BUILT
+  // by parallel-start.sh but never LAUNCHED — users had to manually spawn
+  // it in another tab. SystemOrchestrator now owns its lifecycle (spawn,
+  // health-gate, auto-restart on crash with panic-loop detection).
+  CORE_START: 'core_start',
+  CORE_READY: 'core_ready',
+
   // Server Phase Milestones
   SERVER_START: 'server_start',
   SERVER_PROCESS_READY: 'server_process_ready',
   SERVER_WEBSOCKET_READY: 'server_websocket_ready',
-  SERVER_HTTP_READY: 'server_http_ready', 
+  SERVER_HTTP_READY: 'server_http_ready',
   SERVER_BOOTSTRAP_COMPLETE: 'server_bootstrap_complete',
   SERVER_COMMANDS_LOADED: 'server_commands_loaded',
   SERVER_READY: 'server_ready',
@@ -64,14 +72,22 @@ export const MILESTONE_DEPENDENCIES: Record<SystemMilestone, readonly SystemMile
   [SYSTEM_MILESTONES.DEPLOY_FILES_COMPLETE]: [],
   [SYSTEM_MILESTONES.DEPLOY_COMPLETE]: [],
   
+  // Rust core startup — runs in parallel with the TS server (different
+  // socket / process). SERVER_READY waits for CORE_READY so widgets that
+  // mount on first browser load find a live IPC pool — pre-fix the Rust
+  // core was never spawned, leading to the all-widgets-blank-on-refresh
+  // bug (continuum#722).
+  [SYSTEM_MILESTONES.CORE_START]: [],
+  [SYSTEM_MILESTONES.CORE_READY]: [SYSTEM_MILESTONES.CORE_START],
+
   // Essential server startup sequence
   [SYSTEM_MILESTONES.SERVER_START]: [],
   [SYSTEM_MILESTONES.SERVER_PROCESS_READY]: [SYSTEM_MILESTONES.SERVER_START],
   [SYSTEM_MILESTONES.SERVER_WEBSOCKET_READY]: [SYSTEM_MILESTONES.SERVER_START],
-  [SYSTEM_MILESTONES.SERVER_HTTP_READY]: [SYSTEM_MILESTONES.SERVER_START], 
+  [SYSTEM_MILESTONES.SERVER_HTTP_READY]: [SYSTEM_MILESTONES.SERVER_START],
   [SYSTEM_MILESTONES.SERVER_BOOTSTRAP_COMPLETE]: [SYSTEM_MILESTONES.SERVER_START],
   [SYSTEM_MILESTONES.SERVER_COMMANDS_LOADED]: [SYSTEM_MILESTONES.SERVER_START],
-  [SYSTEM_MILESTONES.SERVER_READY]: [SYSTEM_MILESTONES.SERVER_START],
+  [SYSTEM_MILESTONES.SERVER_READY]: [SYSTEM_MILESTONES.SERVER_START, SYSTEM_MILESTONES.CORE_READY],
   
   // CRITICAL: Browser launch MUST wait for server ready
   [SYSTEM_MILESTONES.BROWSER_LAUNCH_INITIATED]: [SYSTEM_MILESTONES.SERVER_READY],
@@ -191,6 +207,24 @@ export const MILESTONE_COMPLETION_CRITERIA = {
     processes: [],
     ports: ['websocket_server', 'http_server'],
     signals: ['server_ready', 'system_healthy']
+  },
+
+  // Rust core milestones (continuum#722) — see SystemOrchestrator.executeCoreReady
+  [SYSTEM_MILESTONES.CORE_START]: {
+    description: 'continuum-core-server process spawned (or skipped in docker mode)',
+    checkFunction: 'checkCoreStart',
+    files: [],
+    processes: ['continuum-core-server'],
+    ports: [],
+    signals: ['core_start']
+  },
+  [SYSTEM_MILESTONES.CORE_READY]: {
+    description: 'continuum-core-server Unix socket accepting connections',
+    checkFunction: 'checkCoreReady',
+    files: ['.continuum/sockets/continuum-core.sock'],
+    processes: ['continuum-core-server'],
+    ports: [],
+    signals: ['core_ready']
   },
   
   // Browser milestones - CRITICAL ORDERING

--- a/src/system/orchestration/SystemOrchestrator.ts
+++ b/src/system/orchestration/SystemOrchestrator.ts
@@ -10,7 +10,10 @@
 import { EventEmitter } from 'events';
 import { spawn, spawnSync, ChildProcess, exec } from 'child_process';
 import { promisify } from 'util';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
+import { stat } from 'fs/promises';
+import * as net from 'net';
+import * as path from 'path';
 import { WorkingDirConfig } from '../core/config/WorkingDirConfig';
 
 const execAsync = promisify(exec);
@@ -77,6 +80,20 @@ export class SystemOrchestrator extends EventEmitter {
   private signaler: SystemReadySignaler;
   private serverProcess: ChildProcess | null = null;
   private currentEntryPoint: string = 'unknown';
+
+  // continuum#722 — Rust core supervisor state
+  private coreProcess: ChildProcess | null = null;
+  private coreShuttingDown = false;
+  // Panic-loop detector: track restart timestamps within a rolling window.
+  // If we see >5 restarts within 60s the binary is structurally broken
+  // (e.g. missing dylib, port collision, model dir gone). Stop restarting
+  // and surface the failure rather than burning CPU on a doomed loop.
+  private coreRestartTimestamps: number[] = [];
+  private static readonly CORE_RESTART_WINDOW_MS = 60_000;
+  private static readonly CORE_RESTART_LIMIT = 5;
+  private static readonly CORE_READY_TIMEOUT_MS = 30_000;
+  private static readonly CORE_RESTART_BACKOFF_BASE_MS = 1_000;
+  private static readonly CORE_RESTART_BACKOFF_MAX_MS = 30_000;
   
   constructor() {
     super();
@@ -353,6 +370,12 @@ export class SystemOrchestrator extends EventEmitter {
         case SYSTEM_MILESTONES.DEPLOY_COMPLETE:
           return await this.executeDeployComplete();
           
+        case SYSTEM_MILESTONES.CORE_START:
+          return await this.executeCoreStart();
+
+        case SYSTEM_MILESTONES.CORE_READY:
+          return await this.executeCoreReady();
+
         case SYSTEM_MILESTONES.SERVER_START:
           return await this.executeServerStart();
           
@@ -485,6 +508,277 @@ export class SystemOrchestrator extends EventEmitter {
       this.currentEntryPoint
     );
     return true;
+  }
+
+  /**
+   * RUST CORE MILESTONES (continuum#722)
+   *
+   * continuum-core-server is the Rust IPC backbone — Unix socket at
+   * .continuum/sockets/continuum-core.sock, talked to by the data daemon
+   * (ORMRustClient), AI provider daemon, code daemon, etc. Pre-fix the
+   * binary was BUILT by parallel-start.sh:203 but never LAUNCHED — users
+   * ended up with the all-widgets-blank-on-refresh symptom because every
+   * IPC call returned "All IPC connections to continuum-core failed."
+   *
+   * The orchestrator now owns the core's lifecycle:
+   *   - executeCoreStart spawns the binary (or yields if one is already
+   *     running per pidfile / socket-existence — supports the "user
+   *     manually launched it in another tab" case)
+   *   - executeCoreReady waits for the socket to accept a TCP-equivalent
+   *     connect (for Unix sockets, just connect() succeeds when the
+   *     server is listen()ing) — gates SERVER_READY which the browser
+   *     depends on
+   *   - on('exit') handler restarts the binary with exponential backoff
+   *     up to a panic-loop cap (5 restarts / 60s rolling window)
+   *
+   * Skip the spawn entirely when JTAG_SKIP_HTTP is set — that's the
+   * Docker-mode signal (widget-server container handles HTTP, the
+   * continuum-core container handles the Rust core, orchestrator does
+   * neither).
+   */
+  private async executeCoreStart(): Promise<boolean> {
+    if (process.env.JTAG_SKIP_HTTP) {
+      console.debug('⏭️ Skipping core spawn (JTAG_SKIP_HTTP set — docker stack owns continuum-core-server)');
+      await milestoneEmitter.completeMilestone(
+        SYSTEM_MILESTONES.CORE_START,
+        this.currentEntryPoint
+      );
+      return true;
+    }
+
+    // If a continuum-core-server is already running (user pre-launched it
+    // in another tab, or a previous orchestrator left one), don't double-
+    // spawn. Detect via socket existence + a connect-test. The pgrep route
+    // in parallel-start.sh:74 also detects this; we use the socket because
+    // it's what we actually depend on.
+    const socketPath = await this.getCoreSocketPath();
+    if (await this.isCoreSocketAlive(socketPath)) {
+      console.debug(`✅ continuum-core-server already running (socket ${socketPath} alive) — skipping spawn`);
+      await milestoneEmitter.completeMilestone(
+        SYSTEM_MILESTONES.CORE_START,
+        this.currentEntryPoint
+      );
+      return true;
+    }
+
+    const corePath = await this.resolveCoreBinaryPath();
+    if (!corePath) {
+      console.error('❌ continuum-core-server binary not found — run npm start to build it (parallel-start.sh:203)');
+      console.error('   Searched: src/workers/target/release/, workers/target/release/');
+      await milestoneEmitter.failMilestone(
+        SYSTEM_MILESTONES.CORE_START,
+        this.currentEntryPoint,
+        'continuum-core-server binary not found'
+      );
+      return false;
+    }
+
+    this.spawnCoreProcess(corePath, socketPath);
+
+    await milestoneEmitter.completeMilestone(
+      SYSTEM_MILESTONES.CORE_START,
+      this.currentEntryPoint
+    );
+    return true;
+  }
+
+  private async executeCoreReady(): Promise<boolean> {
+    if (process.env.JTAG_SKIP_HTTP) {
+      console.debug('⏭️ Skipping core readiness gate (JTAG_SKIP_HTTP — docker stack health-checks separately)');
+      await milestoneEmitter.completeMilestone(
+        SYSTEM_MILESTONES.CORE_READY,
+        this.currentEntryPoint
+      );
+      return true;
+    }
+
+    const socketPath = await this.getCoreSocketPath();
+    const deadline = Date.now() + SystemOrchestrator.CORE_READY_TIMEOUT_MS;
+    const pollMs = 200;
+
+    console.debug(`⏳ Waiting for continuum-core-server to accept connections (socket ${socketPath})...`);
+
+    while (Date.now() < deadline) {
+      if (await this.isCoreSocketAlive(socketPath)) {
+        const elapsedMs = SystemOrchestrator.CORE_READY_TIMEOUT_MS - (deadline - Date.now());
+        console.debug(`✅ continuum-core-server ready (${elapsedMs}ms)`);
+        await milestoneEmitter.completeMilestone(
+          SYSTEM_MILESTONES.CORE_READY,
+          this.currentEntryPoint
+        );
+        return true;
+      }
+      // Cheap exit check — if the spawn errored synchronously, don't burn 30s.
+      if (this.coreProcess && this.coreProcess.exitCode !== null) {
+        console.error(`❌ continuum-core-server exited code=${this.coreProcess.exitCode} during startup`);
+        await milestoneEmitter.failMilestone(
+          SYSTEM_MILESTONES.CORE_READY,
+          this.currentEntryPoint,
+          `continuum-core-server exited code=${this.coreProcess.exitCode} before becoming ready`
+        );
+        return false;
+      }
+      await new Promise(r => setTimeout(r, pollMs));
+    }
+
+    console.error(`❌ continuum-core-server did not become ready within ${SystemOrchestrator.CORE_READY_TIMEOUT_MS}ms`);
+    await milestoneEmitter.failMilestone(
+      SYSTEM_MILESTONES.CORE_READY,
+      this.currentEntryPoint,
+      `continuum-core-server readiness timeout (${SystemOrchestrator.CORE_READY_TIMEOUT_MS}ms)`
+    );
+    return false;
+  }
+
+  /**
+   * Resolve the absolute path of the continuum-core-server binary.
+   * Candidates ordered by likelihood given typical CWD on `npm start`:
+   *   1. <repoRoot>/src/workers/target/release/continuum-core-server
+   *   2. <repoRoot>/workers/target/release/continuum-core-server
+   *   3. <repoRoot>/src/workers/target/debug/continuum-core-server  (dev fallback)
+   */
+  private async resolveCoreBinaryPath(): Promise<string | null> {
+    const repoRoot = await this.findRepoRoot();
+    const candidates = [
+      path.join(repoRoot, 'src/workers/target/release/continuum-core-server'),
+      path.join(repoRoot, 'workers/target/release/continuum-core-server'),
+      path.join(repoRoot, 'src/workers/target/debug/continuum-core-server'),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) return candidate;
+    }
+    return null;
+  }
+
+  /**
+   * Find repo root by walking up from CWD looking for a marker (package.json
+   * with the right name, or .git directory). Falls back to CWD if nothing found.
+   */
+  private async findRepoRoot(): Promise<string> {
+    let dir = process.cwd();
+    const root = path.parse(dir).root;
+    while (dir !== root) {
+      if (existsSync(path.join(dir, '.git'))) return dir;
+      const pkgPath = path.join(dir, 'package.json');
+      if (existsSync(pkgPath)) {
+        try {
+          const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+          if (pkg.name === 'continuum' || pkg.name === '@continuum/root') return dir;
+        } catch { /* ignore parse errors */ }
+      }
+      dir = path.dirname(dir);
+    }
+    return process.cwd();
+  }
+
+  /**
+   * Get the canonical Unix socket path for continuum-core-server.
+   * Mirror of the bindings' getContinuumCoreSocketPath() to avoid pulling
+   * in the entire bindings module here (which has its own initialization
+   * order concerns).
+   */
+  private async getCoreSocketPath(): Promise<string> {
+    const repoRoot = await this.findRepoRoot();
+    return path.join(repoRoot, '.continuum/sockets/continuum-core.sock');
+  }
+
+  /**
+   * Probe a Unix socket for liveness. Returns true if connect() succeeds
+   * AND the socket exists as a file (kernel has bound it for accept()).
+   *
+   * Why both checks: the file can exist as a stale socket file from a
+   * crashed previous process. connect() will fail in that case (ECONNREFUSED)
+   * — that's the discriminator. We treat any connect error as "not alive."
+   */
+  private async isCoreSocketAlive(socketPath: string): Promise<boolean> {
+    try {
+      const stats = await stat(socketPath);
+      if (!stats.isSocket()) return false;
+    } catch {
+      return false;
+    }
+    return new Promise<boolean>((resolve) => {
+      const sock = net.createConnection(socketPath);
+      const cleanup = () => {
+        try { sock.destroy(); } catch { /* ignore */ }
+      };
+      const timer = setTimeout(() => { cleanup(); resolve(false); }, 1000);
+      sock.once('connect', () => { clearTimeout(timer); cleanup(); resolve(true); });
+      sock.once('error', () => { clearTimeout(timer); cleanup(); resolve(false); });
+    });
+  }
+
+  /**
+   * Spawn continuum-core-server with lifecycle handlers. The on('exit')
+   * handler restarts the process unless we're shutting down OR the panic-
+   * loop detector trips.
+   */
+  private spawnCoreProcess(corePath: string, socketPath: string): void {
+    console.debug(`🦀 Spawning continuum-core-server: ${corePath} ${socketPath}`);
+
+    const childCwd = path.dirname(path.dirname(path.dirname(corePath))); // workers/target/release → workers
+    this.coreProcess = spawn(corePath, [socketPath], {
+      cwd: childCwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // Detached false: tie lifecycle to orchestrator; if orchestrator dies,
+      // node sends SIGTERM to the group on cleanup. Detached true would
+      // orphan the core to launchd reaping which we don't want here.
+      detached: false,
+      env: { ...process.env },
+    });
+
+    this.coreProcess.stdout?.on('data', (data) => {
+      // Filter to debug — core writes a LOT to stdout in dev. Aggregating
+      // it here keeps it findable while not dominating the orchestrator log.
+      console.debug(`[core] ${data.toString().trimEnd()}`);
+    });
+    this.coreProcess.stderr?.on('data', (data) => {
+      console.error(`[core:err] ${data.toString().trimEnd()}`);
+    });
+
+    this.coreProcess.on('error', (err) => {
+      console.error(`❌ continuum-core-server spawn error: ${err.message}`);
+    });
+
+    this.coreProcess.on('exit', (code, signal) => {
+      const ts = Date.now();
+      console.debug(`📋 continuum-core-server exited: code=${code} signal=${signal}`);
+      this.coreProcess = null;
+
+      if (this.coreShuttingDown) {
+        console.debug('   (orchestrator shutting down — not restarting)');
+        return;
+      }
+
+      // Panic-loop detection: prune timestamps outside the rolling window,
+      // then check the rate.
+      const cutoff = ts - SystemOrchestrator.CORE_RESTART_WINDOW_MS;
+      this.coreRestartTimestamps = this.coreRestartTimestamps.filter(t => t >= cutoff);
+      this.coreRestartTimestamps.push(ts);
+
+      if (this.coreRestartTimestamps.length > SystemOrchestrator.CORE_RESTART_LIMIT) {
+        console.error(
+          `❌ continuum-core-server panic-loop: ${this.coreRestartTimestamps.length} restarts in ` +
+          `${SystemOrchestrator.CORE_RESTART_WINDOW_MS / 1000}s — STOPPING auto-restart.`
+        );
+        console.error('   The binary is structurally broken (missing dylib, port collision, model dir gone, etc).');
+        console.error('   Inspect the core stderr above + restart orchestrator after fixing.');
+        return;
+      }
+
+      // Exponential backoff: 1s, 2s, 4s, 8s, 16s, capped at 30s.
+      const attemptIdx = this.coreRestartTimestamps.length - 1;
+      const delay = Math.min(
+        SystemOrchestrator.CORE_RESTART_BACKOFF_BASE_MS * Math.pow(2, attemptIdx),
+        SystemOrchestrator.CORE_RESTART_BACKOFF_MAX_MS
+      );
+      console.debug(`🔁 Restarting continuum-core-server in ${delay}ms (attempt ${this.coreRestartTimestamps.length})`);
+      setTimeout(() => {
+        if (!this.coreShuttingDown) {
+          this.spawnCoreProcess(corePath, socketPath);
+        }
+      }, delay);
+    });
   }
 
   /**
@@ -988,9 +1282,21 @@ export class SystemOrchestrator extends EventEmitter {
   }
 
   /**
-   * Cleanup resources
+   * Cleanup resources — sets shutdown flag FIRST so the core's
+   * on('exit') handler doesn't restart the process during teardown.
    */
   async cleanup(): Promise<void> {
+    // Set shutdown flag before killing — without this the on('exit')
+    // handler would interpret the SIGTERM as a crash and respawn (#722
+    // panic-loop self-inflicted).
+    this.coreShuttingDown = true;
+
+    if (this.coreProcess) {
+      console.debug('🛑 Cleaning up continuum-core-server process...');
+      try { this.coreProcess.kill('SIGTERM'); } catch { /* already dead */ }
+      this.coreProcess = null;
+    }
+
     if (this.serverProcess) {
       console.debug('🛑 Cleaning up server process...');
       this.serverProcess.kill('SIGTERM');


### PR DESCRIPTION
## Summary

Closes the all-widgets-blank-on-refresh bug (#722). RCA filed in [comment 4355290646](https://github.com/CambrianTech/continuum/issues/722#issuecomment-4355290646) — three compounding causes, this PR closes all three.

## What changed

**Layer A — `SystemOrchestrator` owns the Rust core lifecycle**
- New `CORE_START` + `CORE_READY` milestones (parallel to `SERVER_START`; `SERVER_READY` now depends on both)
- `executeCoreStart` spawns `continuum-core-server` (or detects a pre-launched one via socket-alive probe)
- `executeCoreReady` polls the Unix socket for accept-readiness with a 30s timeout
- `spawnCoreProcess` wires up stdout/stderr forwarding + `on('exit')` respawn

**Layer B — Never give up reconnecting** (`ORMRustClient.scheduleReconnect`)
- Removed the `< 10` cap that left widgets blank permanently after ~3min outage
- Backoff still exponential (capped exponent at 5 → max 30s delay)
- Periodic warn every 10th attempt so the log isn't silent

**Layer C — Panic-loop detector** (in `spawnCoreProcess` `on('exit')`)
- Track restart timestamps in rolling 60s window
- If >5 restarts in window → STOP + surface error (binary structurally broken; spinning forever wastes CPU)
- `cleanup()` sets `coreShuttingDown=true` BEFORE killing so the handler doesn't interpret SIGTERM as crash + respawn

## Paths covered

| Path | Status |
|---|---|
| `npm start` (dev) | **fixed** |
| `scripts/install.sh` + `CONTINUUM_AUTO_LAUNCH=1` (Carl curl install) | **fixed** (ends with `npm start`) |
| `bootstrap.sh` + `curl \| bash` one-liner | **fixed** (delegates to install.sh) |
| `docker compose up` (Carl-docker path) | unchanged (`JTAG_SKIP_HTTP` gate makes orchestrator a no-op; container stack handles it) |

## Out of scope (separate follow-ups)

- Layer D — graceful degradation UX (`Core offline — showing cached data` banner) is widget-side, orthogonal
- #56 SIGABRT shutdown — that's an upstream Rust issue. This PR ensures the orchestrator can RESTART after such a crash; fixing the SIGABRT itself is its own work.

## Validation

- [x] `tsc --noEmit` clean (zero new errors)
- [x] `bash -n scripts/install.sh` clean
- [x] Precommit passed
- [ ] Manual repro pending: kill `continuum-core-server` mid-run → orchestrator respawns + widgets recover within ~3s
- [ ] Carl-case dry-run on a fresh-ish machine (deferred per Joel's "test on Carl path with airc" pattern)

## Why it matters strategically

This is **Phase 0** of [AGENT-BACKBONE-INTEGRATION](https://github.com/CambrianTech/continuum/pull/976) — the local-fallback story (Codex / Claude Code falling back to local Continuum on rate limits) requires the Rust core to actually be running reliably. Today it's not unless the user knows the manual launch trick. This PR is the prerequisite that makes everything downstream (HTTP shims, capability mesh, training flywheel) buildable on a stable substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)