### PR TITLE
fix(#954): wire setup-git-hooks into root postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "start": "bash src/scripts/parallel-start.sh",
     "stop": "bash src/scripts/system-stop.sh",
-    "install": "bash src/scripts/install.sh"
+    "install": "bash src/scripts/install.sh",
+    "postinstall": "bash src/scripts/setup-git-hooks.sh || echo '⚠️  setup-git-hooks failed (non-fatal — pre-commit gate skipped); run manually:  bash src/scripts/setup-git-hooks.sh'"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.76",


### PR DESCRIPTION
Fresh contributors who clone + \`npm install\` at the repo root were silently bypassing the pre-commit gate. \`src/package.json\` already had a postinstall that runs \`setup-git-hooks\`, but it only fires when running \`npm install\` from \`src/\` — a fresh contributor running \`npm install\` at the root never triggered it.

Add a \`postinstall\` to root \`package.json\` that runs the same script.

## Why this works

- \`setup-git-hooks.sh\` is idempotent (early-exits when not in a git checkout, safely skips already-installed hooks).
- Stderr/stdout NOT suppressed (unlike \`src/\`'s variant which bundles it with worker-models download). If hook setup fails, the user sees the warning + the manual command — per the never-swallow-errors rule.
- Doesn't change \`src/\`'s postinstall — both can fire (it's the same script, idempotent).

## Smoke-tested

\`\`\`
$ bash src/scripts/setup-git-hooks.sh
📁 Installed: pre-commit pre-push
⏭️  Skipped (target script missing): post-commit
\`\`\`

Closes #954.