### PR TITLE
fix(install,#980-bug1): auto-install cmake on Mac (vendored llama.cpp prereq)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -287,6 +287,23 @@ PYEOF
       docker desktop enable model-runner --tcp=12434 --cors=all 2>&1 | tail -3 || \
         warn "Could not enable Model Runner TCP — continuum-core will fall back to Candle (slower). Enable manually: docker desktop enable model-runner --tcp=12434 --cors=all"
     fi
+    # cmake — required by the vendored llama.cpp build (Phase 2a of `npm
+    # start`). Carl's M1 install pass (#980 Bug 1) hit
+    #   thread 'main' panicked at cmake-0.1.57/src/lib.rs:1132:5:
+    #   failed to execute command: No such file or directory (os error 2)
+    #   is `cmake` not installed?
+    # because install.sh said "✅ Continuum Tower installed!" without
+    # checking cmake, then npm start died inside the cargo build of the
+    # llama crate. Auto-install via brew matches the node pattern below
+    # so fresh-Mac users have a working build path out of the box.
+    if ! command -v cmake &>/dev/null; then
+      if command -v brew &>/dev/null; then
+        info "cmake not found — installing via Homebrew (needed by vendored llama.cpp build)…"
+        brew install cmake
+      else
+        fail "cmake required for vendored llama.cpp build. Install Homebrew + run 'brew install cmake', or use 'xcode-select --install' to get the macOS CLI tools that include cmake."
+      fi
+    fi
     # Rust toolchain — continuum-core-server is built natively on Mac (not
     # containerized) so it can link Metal for Candle embeddings, Bevy, vision,
     # and audio MPS paths. Build happens during `npm start` at end of install.


### PR DESCRIPTION
## What

Add cmake to the Mac (Darwin) prereq block in install.sh. Auto-install via Homebrew when brew is available; fall back to a clear error message naming both \`brew install cmake\` and \`xcode-select --install\` (the macOS CLI tools alternative).

## Why

M1 Carl-validator pass (issue #980, **Bug 1** — Carl-blocker) hit:

```
install.sh said "✅ Continuum Tower installed!"
→ npm start → Phase 2a Rust build dies in workers/llama
→ cmake-0.1.57/src/lib.rs:1132:5: failed to execute command
→ "is \`cmake\` not installed?"
```

install.sh checked for git, docker, cargo, node — but NOT cmake — even though cmake is a hard requirement of the vendored llama.cpp build that runs as part of \`npm start\`. Carl saw the success banner, then the build crashed with no clear hint that cmake was the missing piece.

## Pattern

Matches the existing node auto-install at line 303: check, info+install if brew available, fail with clear message if not.

## Linux

Unchanged. continuum-core builds inside the Linux Docker image, so the Linux host doesn't need cmake at the host level — the container has its own toolchain.

## Test

Dry-run on this M5 (cmake already installed → check passes immediately, no behaviour change).

## Series context

This is the first concrete fix from #980's catalogued 10 bugs. Joel: \"continue getting our carl case up to speed.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)