### PR TITLE
fix(#980 Bug 5): isConfigured false for empty cloud-provider keys

### DIFF
--- a/src/commands/ai/providers/status/server/AIProvidersStatusServerCommand.ts
+++ b/src/commands/ai/providers/status/server/AIProvidersStatusServerCommand.ts
@@ -129,8 +129,16 @@ export class AIProvidersStatusServerCommand extends AIProvidersStatusCommand {
 
     const providers: ProviderStatus[] = PROVIDER_CONFIG.map(config => {
       // Candle is always available — it's local inference, no API key needed
-      const isConfigured = config.category === 'local' ? true : secrets.has(config.key);
-      const rawKey = isConfigured && config.category !== 'local' ? secrets.get(config.key) : undefined;
+      //
+      // For non-local providers: SecretManager.has(key) returns true when the
+      // key NAME is present in config.env even if its VALUE is empty (the
+      // shipped fresh config has ANTHROPIC_API_KEY=, OPENAI_API_KEY=,
+      // DEEPSEEK_API_KEY= as empty placeholders). So has(key) gave false-
+      // positive isConfigured=true for every fresh install, leading users to
+      // attempt chat and hit an opaque 401. Check the actual value length
+      // instead. (#980 Bug 5.)
+      const rawKey = config.category === 'local' ? undefined : secrets.get(config.key);
+      const isConfigured = config.category === 'local' ? true : (rawKey?.length ?? 0) > 0;
 
       return {
         provider: config.provider,


### PR DESCRIPTION
## Summary

\`SecretManager.has(key)\` returns true when the key NAME is present in config.env even if its VALUE is empty. Fresh \`~/.continuum/config.env\` ships \`ANTHROPIC_API_KEY=\`, \`OPENAI_API_KEY=\`, \`DEEPSEEK_API_KEY=\` as empty placeholders → every fresh install reports \`isConfigured: true\` for all three cloud providers → Carl tries chat → opaque 401.

Check actual value length instead. Empty/missing key = not configured. Matches the user's mental model.

The existing \`local\` short-circuit (Candle) is preserved unchanged — that's a separate categorization issue tracked as #980 Bug 6.

## Why not change SecretManager.has

\`has\` legitimately means "is this key NAME present in the namespace" — there are config keys where empty-string is a valid disable signal. Changing the call-site contract preserves that for other callers.

## Test plan

- [x] TypeScript compile passes (pre-commit hook ran)
- [ ] Manually verify on fresh \`~/.continuum/config.env\` with empty cloud keys: \`isConfigured\` should be \`false\` for ANTHROPIC/OPENAI/DEEPSEEK, \`true\` for Candle (local)
- [ ] After setting \`ANTHROPIC_API_KEY=sk-ant-…\`, \`isConfigured\` for Anthropic flips to \`true\`

Closes #980 Bug 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)