### PR TITLE
fix: add GPU EP to Kokoro/Orpheus/Silero ORT sessions (#964 series PR #2)

### DIFF
--- a/src/workers/continuum-core/src/live/audio/tts/kokoro.rs
+++ b/src/workers/continuum-core/src/live/audio/tts/kokoro.rs
@@ -463,7 +463,16 @@ impl TextToSpeech for KokoroTTS {
             inter_threads
         );
 
+        // GPU execution providers via the centralized helper (#985 / #964).
+        // Per architecture, CPU fallback is forbidden — TTS matmul must
+        // run on GPU. Pre-this-PR Kokoro never configured an EP at all,
+        // so ORT's implicit CPU EP took every op silently. The helper
+        // adds the right EP for the current build (CoreML on Mac,
+        // CUDA on Linux+Nvidia) and hard-fails when neither is available.
+        let providers = crate::inference::ort_providers::build_ort_gpu_execution_providers()
+            .map_err(|e| TTSError::ModelNotLoaded(format!("ORT GPU EP setup failed (Kokoro TTS): {e}")))?;
         let session = Session::builder()?
+            .with_execution_providers(providers)?
             .with_optimization_level(GraphOptimizationLevel::Level3)?
             .with_intra_threads(intra_threads)?
             .with_inter_threads(inter_threads)?

--- a/src/workers/continuum-core/src/live/audio/tts/orpheus.rs
+++ b/src/workers/continuum-core/src/live/audio/tts/orpheus.rs
@@ -193,8 +193,16 @@ impl OrpheusTts {
     /// Build SNAC decoder ONNX session
     fn build_snac_session(model_path: &Path) -> Result<Session, TTSError> {
         let threads = num_cpus::get().min(4);
+        // GPU execution providers via the centralized helper (#985 / #964).
+        // Per architecture, CPU fallback is forbidden — SNAC decoder must
+        // run on GPU. Pre-this-PR Orpheus never configured an EP at all,
+        // so ORT's implicit CPU EP took every op silently.
+        let providers = crate::inference::ort_providers::build_ort_gpu_execution_providers()
+            .map_err(|e| TTSError::ModelNotLoaded(format!("ORT GPU EP setup failed (Orpheus SNAC): {e}")))?;
         Session::builder()
             .map_err(|e| TTSError::ModelNotLoaded(format!("SNAC session builder: {e}")))?
+            .with_execution_providers(providers)
+            .map_err(|e| TTSError::ModelNotLoaded(format!("SNAC EP register: {e}")))?
             .with_optimization_level(GraphOptimizationLevel::Level3)
             .map_err(|e| TTSError::ModelNotLoaded(format!("SNAC optimization: {e}")))?
             .with_intra_threads(threads)

--- a/src/workers/continuum-core/src/live/audio/vad/silero.rs
+++ b/src/workers/continuum-core/src/live/audio/vad/silero.rs
@@ -220,9 +220,21 @@ impl VoiceActivityDetection for SileroVAD {
             )));
         }
 
+        // GPU execution providers via the centralized helper (#985 / #964).
+        // Per architecture, CPU fallback is forbidden — Silero VAD inference
+        // must run on GPU. Pre-this-PR Silero never configured an EP at all,
+        // so ORT's implicit CPU EP took every op silently. Note: Silero is
+        // small (<2MB) + per-frame; ORT's own runtime decides per-op
+        // assignment, so any genuine perf trade-off (host↔GPU transfer
+        // overhead per frame) is ORT's call to make once it sees the model
+        // graph + the GPU device profile.
+        let providers = crate::inference::ort_providers::build_ort_gpu_execution_providers()
+            .map_err(|e| VADError::ModelNotLoaded(format!("ORT GPU EP setup failed (Silero VAD): {e}")))?;
         // Load model with ONNX Runtime
         let session = Session::builder()
             .map_err(|e| VADError::ModelNotLoaded(e.to_string()))?
+            .with_execution_providers(providers)
+            .map_err(|e| VADError::ModelNotLoaded(format!("Silero EP register: {e}")))?
             .with_optimization_level(GraphOptimizationLevel::Level3)
             .map_err(|e| VADError::ModelNotLoaded(e.to_string()))?
             .with_intra_threads(num_cpus::get().min(4))

--- a/src/workers/continuum-core/src/live/audio/vad/silero_raw.rs
+++ b/src/workers/continuum-core/src/live/audio/vad/silero_raw.rs
@@ -157,9 +157,17 @@ impl VoiceActivityDetection for SileroRawVAD {
             )));
         }
 
+        // GPU execution providers via the centralized helper (#985 / #964).
+        // Per architecture, CPU fallback is forbidden — Silero VAD inference
+        // must run on GPU. Pre-this-PR Silero never configured an EP at all,
+        // so ORT's implicit CPU EP took every op silently.
+        let providers = crate::inference::ort_providers::build_ort_gpu_execution_providers()
+            .map_err(|e| VADError::ModelNotLoaded(format!("ORT GPU EP setup failed (Silero VAD raw): {e}")))?;
         // Load ONNX model
         let session = Session::builder()
             .map_err(|e| VADError::ModelNotLoaded(e.to_string()))?
+            .with_execution_providers(providers)
+            .map_err(|e| VADError::ModelNotLoaded(format!("Silero raw EP register: {e}")))?
             .with_optimization_level(GraphOptimizationLevel::Level3)
             .map_err(|e| VADError::ModelNotLoaded(e.to_string()))?
             .with_intra_threads(num_cpus::get().min(4))


### PR DESCRIPTION
## What

Continues the GPU-fallback-removal series started in #985. PR #1 (#985) fixed the 3 sites with broken \`feature = \"coreml\"\` cfg gates (embedding, piper, moonshine). This PR (#2) covers the 4 sites that configured **NO Execution Provider at all** — they relied on ORT's implicit CPU EP, which is the same silent-fallback shape per Joel's architectural rule (2026-05-01: *\"lack of GPU integration is forbidden, GPU acceleration in all cases\"*).

## Sites updated (all use the centralized helper from #985)

| File | Component |
|---|---|
| \`live/audio/tts/kokoro.rs\` | Kokoro TTS |
| \`live/audio/tts/orpheus.rs\` | Orpheus SNAC decoder |
| \`live/audio/vad/silero.rs\` | Silero VAD |
| \`live/audio/vad/silero_raw.rs\` | Silero VAD (raw ORT) |

Each call site is identical in shape: insert one \`build_ort_gpu_execution_providers()\` call between \`Session::builder()\` and \`with_optimization_level()\`. No other behaviour change.

## Note on Silero VAD perf

Silero is small (<2 MB) and per-frame; on its own a CPU EP would arguably be faster than CoreML/CUDA due to host↔GPU transfer overhead. But ORT's runtime decides per-op assignment once it sees the model graph + the GPU device profile, so any genuine perf trade-off is ORT's call. Per the architectural rule, we provide the GPU EP — ORT optimises from there.

## Test

- \`cargo check -p continuum-core --features metal\`: PASSES (verified locally on M5; new EP-attachment compiles + integrates with the existing helper from #985)

## Note on PR cycle

Branch named \`mac-pr/...\` to disambiguate from another AI working in the same workspace; this PR was rescued via SHA-to-ref push after a parallel-git race contaminated three earlier branch names. Setting up git worktrees per-AI as a permanent fix.

## Out of scope (queued for PR #3 + later in series)

- \`gpu/memory_manager.rs:799 detect_cpu_fallback()\` — silent \"no GPU, use 25% RAM\" fallback. Replace with hard-fail.
- \`persona/allocator.rs:165\` — explicit \`\"cpu\"\` GPU-type branch.
- ROCm / DirectML / OpenVINO EP coverage in \`ort_providers.rs\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)