### PR TITLE
fix(#980-bug4): supervisor visibility + IPC reconnect counter + Linux pgrep + hook worktree path

### DIFF
--- a/src/scripts/git-precommit.sh
+++ b/src/scripts/git-precommit.sh
@@ -109,7 +109,15 @@ if [ -n "$TS_FILES" ]; then
     # Update baseline after a real cleanup pass:
     #   cd src && npx eslint './**/*.ts' --max-warnings 0 --quiet 2>&1 \
     #     | grep -cE "error\s+" > eslint-baseline.txt
-    BASELINE_FILE="$(git rev-parse --show-toplevel)/src/eslint-baseline.txt"
+    # Use a script-relative path instead of `git rev-parse --show-toplevel`.
+    # When invoked from a git worktree's `src/` cwd (which the hook does at
+    # line 5 + 52), `--show-toplevel` returned the cwd `/repo/src` rather
+    # than the worktree root `/repo`, producing an incorrect double-`src`
+    # path `/repo/src/src/eslint-baseline.txt`. The hook ALWAYS lives at
+    # `<src>/scripts/git-precommit.sh`, so the baseline is one dir up from
+    # the script's parent dir — deterministic, no git resolution needed.
+    HOOK_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    BASELINE_FILE="$(dirname "$HOOK_SCRIPT_DIR")/eslint-baseline.txt"
 
     # Tier 1: staged-files-only fast lint.
     STAGED_LINT_LOG="$(mktemp)"

--- a/src/system/orchestration/SystemOrchestrator.ts
+++ b/src/system/orchestration/SystemOrchestrator.ts
@@ -632,7 +632,10 @@ export class SystemOrchestrator extends EventEmitter {
       return;
     }
     this.adoptedCorePid = pid;
-    console.debug(`   adopted PID ${pid}; watcher polling every ${SystemOrchestrator.ADOPTED_CORE_POLL_MS}ms`);
+    // Promoted debug → info: this is the supervisor's adoption signal +
+    // critical to seeing in logs when later debugging "why didn't respawn fire?"
+    // (#980 Bug 4 + the silent-success-is-failure rule applied to supervisor).
+    console.info(`   adopted continuum-core-server PID ${pid}; watcher polling every ${SystemOrchestrator.ADOPTED_CORE_POLL_MS}ms`);
 
     this.adoptedCoreWatcher = setInterval(() => {
       if (this.coreShuttingDown) {
@@ -666,17 +669,47 @@ export class SystemOrchestrator extends EventEmitter {
    * Returns 0 if not found.
    */
   private async findCoreProcessPid(): Promise<number> {
+    // Use pgrep -f (full command-line match) instead of -x (exact comm
+    // match). On Linux `pgrep -x` checks /proc/PID/comm which is
+    // truncated to 15 chars (TASK_COMM_LEN); the binary name
+    // `continuum-core-server` is 22 chars → -x silently fails to match
+    // on Linux even when the process is running. macOS pgrep doesn't
+    // have this limit, but using -f works on both. Without this the
+    // adopted-core PID watcher silently never installs on Linux →
+    // supervisor blind to inherited-core death (#980 Bug 4 family).
     return new Promise<number>((resolve) => {
-      const child = spawn('pgrep', ['-x', 'continuum-core-server'], {
+      const child = spawn('pgrep', ['-f', 'continuum-core-server'], {
         stdio: ['ignore', 'pipe', 'pipe'],
       });
       let stdout = '';
       child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
       child.on('error', () => resolve(0));
       child.on('close', () => {
-        const firstLine = stdout.trim().split('\n')[0] ?? '';
-        const pid = Number.parseInt(firstLine, 10);
-        resolve(Number.isFinite(pid) && pid > 0 ? pid : 0);
+        // pgrep -f also matches the orchestrator's own pgrep invocation
+        // (briefly) + any tail/grep on the log. Filter to PIDs where the
+        // process name is exactly continuum-core-server using a second pass.
+        const candidates = stdout.trim().split('\n')
+          .map(line => Number.parseInt(line, 10))
+          .filter(n => Number.isFinite(n) && n > 0);
+        if (candidates.length === 0) { resolve(0); return; }
+        // Cross-check via ps to find the candidate whose argv[0] basename is the binary.
+        // Best-effort — if ps fails, fall back to first candidate.
+        const ps = spawn('ps', ['-o', 'pid=,comm=', ...candidates.flatMap(p => ['-p', String(p)])], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let psOut = '';
+        ps.stdout.on('data', (c: Buffer) => { psOut += c.toString('utf8'); });
+        ps.on('error', () => resolve(candidates[0] ?? 0));
+        ps.on('close', () => {
+          for (const line of psOut.trim().split('\n')) {
+            const m = line.trim().match(/^(\d+)\s+(.+)$/);
+            if (m && (m[2].endsWith('continuum-core-server') || m[2].includes('continuum-core'))) {
+              resolve(Number.parseInt(m[1], 10));
+              return;
+            }
+          }
+          resolve(candidates[0] ?? 0);
+        });
       });
     });
   }
@@ -851,11 +884,15 @@ export class SystemOrchestrator extends EventEmitter {
 
     this.coreProcess.on('exit', (code, signal) => {
       const ts = Date.now();
-      console.debug(`📋 continuum-core-server exited: code=${code} signal=${signal}`);
+      // Promoted from debug → info so the supervisor's lifecycle is
+      // visible in default logs. Carl's #980 Bug 4 reported "no respawn"
+      // partly because the respawn-related debug logs weren't visible —
+      // can't diagnose what didn't happen if the logs hide what did.
+      console.info(`📋 continuum-core-server exited: code=${code} signal=${signal}`);
       this.coreProcess = null;
 
       if (this.coreShuttingDown) {
-        console.debug('   (orchestrator shutting down — not restarting)');
+        console.info('   (orchestrator shutting down — not restarting)');
         return;
       }
 
@@ -881,9 +918,10 @@ export class SystemOrchestrator extends EventEmitter {
         SystemOrchestrator.CORE_RESTART_BACKOFF_BASE_MS * Math.pow(2, attemptIdx),
         SystemOrchestrator.CORE_RESTART_BACKOFF_MAX_MS
       );
-      console.debug(`🔁 Restarting continuum-core-server in ${delay}ms (attempt ${this.coreRestartTimestamps.length})`);
+      console.info(`🔁 Restarting continuum-core-server in ${delay}ms (attempt ${this.coreRestartTimestamps.length})`);
       setTimeout(() => {
         if (!this.coreShuttingDown) {
+          console.info(`🔁 Spawning continuum-core-server now (restart attempt ${this.coreRestartTimestamps.length})`);
           this.spawnCoreProcess(corePath, socketPath);
         }
       }, delay);

--- a/src/workers/continuum-core/bindings/modules/base.ts
+++ b/src/workers/continuum-core/bindings/modules/base.ts
@@ -216,10 +216,19 @@ export class RustCoreIPCClientBase extends EventEmitter {
 				this._connected = false;
 				this._rejectAllPending(err instanceof Error ? err : new Error(String(err)));
 				this.emit('connection-error', err);
-				// Only reject the initial connect() promise — reconnects are handled internally
-				if (!this._wasConnected) {
-					reject(err);
-				}
+				// Always reject THIS connect() promise on socket error.
+				// Promise.reject is a no-op if already settled, so this is
+				// safe for both initial connects + post-reconnect calls.
+				//
+				// Pre-fix this only rejected when !_wasConnected, which left
+				// reconnect attempts hanging forever — `await this.connect()`
+				// in _scheduleReconnect's try/catch never resolved or
+				// rejected when the backend was dead, so the catch block
+				// (which increments _reconnectAttempts + reschedules) never
+				// fired. Counter stuck at 1 + no further reconnect attempts.
+				// Carl's #980 Bug 4 sub-bug: "[IPC] Reconnecting to
+				// continuum-core in 1000ms (attempt 1)" repeated forever.
+				reject(err);
 			});
 
 			this._socket.on('close', () => {


### PR DESCRIPTION
## What

Carl's M1 #980 Bug 4 reported the supervisor's auto-respawn never fired after killing continuum-core, and IPC's "Reconnecting (attempt 1)" log repeated forever without the counter incrementing. Three sub-fixes plus a hook bug discovered while shipping this PR.

## Fix 1 — IPC reconnect counter never increments

`base.ts` ConnectionPool's socket error handler only called `reject(err)` when `!_wasConnected`. But `_scheduleReconnect`'s `await this.connect()` IS exactly the kind of post-`_wasConnected` call that needed `reject()` to wake up. Result: socket connect attempt → backend dead → handler skips reject → await hangs forever → catch-block-that-increments never fires → counter stuck at 1.

**Fix:** always `reject()` on socket error (Promise.reject is a no-op if already settled). **Also unblocks the F4 carl-killer family** — IPC pool can now finish + retry instead of wedging on a hung promise.

## Fix 2 — Supervisor lifecycle visibility

Promoted `console.debug` → `console.info` on the on('exit') handler, panic-loop-detect path, restart timer, and `adoptInheritedCore` PID adoption. Carl couldn't tell if supervisor was RUNNING but silent or DEAD.

## Fix 3 — Linux pgrep -x silently misses the binary

`pgrep -x continuum-core-server` checks `/proc/PID/comm` truncated to 15 chars on Linux. Binary name is 22 chars → silent miss on Linux/WSL → adopted-core PID watcher silently never installs → supervisor blind to inherited-core death. Use `pgrep -f` + ps cross-check.

## Fix 4 — git-precommit.sh worktree-path bug (bonus)

`BASELINE_FILE="$(git rev-parse --show-toplevel)/src/eslint-baseline.txt"` returned an incorrect double-`src` path (`/repo/src/src/eslint-baseline.txt`) because the hook does `cd src` before this line. Fix: deterministic script-relative path.

## Note on push

Pushed with `--no-verify` (one-time exception authorized by Joel). The push environment had two adjacent issues separate from this PR: (a) prepush Phase 4 docker-push step blocking, (b) original repo's `.git/config` `bare = true`. Code IS verified clean: `npm run build:ts` ✓, `cargo check --features metal,accelerate` ✓.

Follow-up cleanup in next commit: lint the two TS files I touched so they pass the strict per-file gate going forward (won't need --no-verify again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)