### PR TITLE
fix(#980-bug10): jtag CLI accepts JSON-blob as first positional arg

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -220,6 +220,36 @@ async function main() {
     // This allows `./jtag help screenshot` instead of `./jtag help commandName=screenshot`
     const positional = params._positional;
     if (Array.isArray(positional) && positional.length > 0) {
+      // #980 Bug 10: if the first positional arg is a JSON object literal,
+      // unpack it into named params. Pre-fix `./jtag collab/chat/send
+      // '{"message":"hello"}'` left the JSON blob in _positional and the
+      // command's validator failed with "Message must have either text
+      // content or media" — confusing, looked like a malformed message
+      // when it was actually a CLI param-shape mismatch. Now the user
+      // can pass a JSON blob OR --key=value flags interchangeably; both
+      // work, the validator sees the same params object either way.
+      const firstPositional = positional[0];
+      if (typeof firstPositional === 'string' && (firstPositional.startsWith('{') || firstPositional.startsWith('['))) {
+        try {
+          const parsed: unknown = JSON.parse(firstPositional);
+          if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+            // Merge each top-level key into params. Explicit --flags win
+            // over JSON-blob keys (so users can override one field while
+            // keeping the rest of a JSON template).
+            for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+              if (params[k] === undefined) {
+                params[k] = v as ParsedValue;
+              }
+            }
+            positional.shift();  // consume the JSON blob
+            params._positional = positional;
+          }
+        } catch {
+          // Not valid JSON — fall through to existing positional handling.
+          // The command's own param validator will surface a clear error.
+        }
+      }
+
       // Map of commands to their primary parameter name
       const singleParamCommands: Record<string, string> = {
         'help': 'commandName',

--- a/src/commands/collaboration/chat/send/server/ChatSendServerCommand.ts
+++ b/src/commands/collaboration/chat/send/server/ChatSendServerCommand.ts
@@ -181,9 +181,34 @@ export class ChatSendServerCommand extends ChatSendCommand {
     // 7. Generate short ID (last 6 chars of UUID - from BaseEntity.id)
     const shortId = storedEntity.id.slice(-6);
 
+    // 8. No-listener warning (#980 Bug 8): if zero persona-users exist in
+    // the system, the message is stored successfully but no AI will ever
+    // respond to it. Carl's #980 caught this: chat-send returned success,
+    // user typed "hello" + got nothing back, no signal anywhere that the
+    // message had no listener. Cascade from seed-failure (Bug 3): no
+    // personas seeded → agent/list returns []. Surface a clear "stored
+    // but no listener" warning so the user knows to investigate.
+    //
+    // Cheap query: count how many persona-type users exist (limit 1 — we
+    // only need to distinguish 0 vs ≥1). Non-blocking on the result
+    // payload — message is still stored either way; this just adds a
+    // warning string when listeners are absent.
+    const personaCheck = await DataList.execute<UserEntity>({
+      dbHandle: 'default',
+      collection: UserEntity.collection,
+      filter: { type: 'persona' },
+      limit: 1,
+      context: params.context,
+      sessionId: params.sessionId,
+    });
+    const hasListener = personaCheck.success && (personaCheck.items?.length ?? 0) > 0;
+    const successMessage = hasListener
+      ? `Message sent to ${resolved.displayName} (#${shortId})`
+      : `Message sent to ${resolved.displayName} (#${shortId}) ⚠️ No AI personas in system — message stored but won't get a reply. Check: ./jtag data/list --collection=users --filter='{"type":"persona"}'  (likely cascade from a failed seed; re-run: npm run data:seed)`;
+
     return transformPayload(params, {
       success: true,
-      message: `Message sent to ${resolved.displayName} (#${shortId})`,
+      message: successMessage,
       messageEntity: storedEntity,
       shortId: shortId,
       roomId: resolved.id


### PR DESCRIPTION
Carl's #980 Bug 10. `./jtag collab/chat/send '{"message":"hello"}'` now unpacks the JSON into named params instead of getting a misleading "message must have content" validator error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)