### PR TITLE
fix(#980-bug7): default ai/generate to 'local', never silent cloud fallback

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -220,6 +220,36 @@ async function main() {
     // This allows `./jtag help screenshot` instead of `./jtag help commandName=screenshot`
     const positional = params._positional;
     if (Array.isArray(positional) && positional.length > 0) {
+      // #980 Bug 10: if the first positional arg is a JSON object literal,
+      // unpack it into named params. Pre-fix `./jtag collab/chat/send
+      // '{"message":"hello"}'` left the JSON blob in _positional and the
+      // command's validator failed with "Message must have either text
+      // content or media" — confusing, looked like a malformed message
+      // when it was actually a CLI param-shape mismatch. Now the user
+      // can pass a JSON blob OR --key=value flags interchangeably; both
+      // work, the validator sees the same params object either way.
+      const firstPositional = positional[0];
+      if (typeof firstPositional === 'string' && (firstPositional.startsWith('{') || firstPositional.startsWith('['))) {
+        try {
+          const parsed: unknown = JSON.parse(firstPositional);
+          if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+            // Merge each top-level key into params. Explicit --flags win
+            // over JSON-blob keys (so users can override one field while
+            // keeping the rest of a JSON template).
+            for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+              if (params[k] === undefined) {
+                params[k] = v as ParsedValue;
+              }
+            }
+            positional.shift();  // consume the JSON blob
+            params._positional = positional;
+          }
+        } catch {
+          // Not valid JSON — fall through to existing positional handling.
+          // The command's own param validator will surface a clear error.
+        }
+      }
+
       // Map of commands to their primary parameter name
       const singleParamCommands: Record<string, string> = {
         'help': 'commandName',

--- a/src/commands/ai/generate/server/AIGenerateServerCommand.ts
+++ b/src/commands/ai/generate/server/AIGenerateServerCommand.ts
@@ -126,7 +126,19 @@ export class AIGenerateServerCommand extends AIGenerateCommand {
           model: params.model || LOCAL_MODELS.DEFAULT,
           temperature: params.temperature ?? 0.7,
           maxTokens: params.maxTokens ?? 150,
-          provider: params.provider || 'candle',
+          // Default to 'local' (DMR via Rust IPC), NEVER a cloud provider.
+          // Continuum's architectural point is local models; cloud providers
+          // are opt-in via explicit --provider, not silent fallback. Pre-fix
+          // the default was 'candle' which is misleading (Candle is a
+          // training framework, not inference) and Rust's routing for an
+          // unknown provider could pick a registered cloud adapter (Carl's
+          // #980 Bug 7: silent DeepSeek 401 with no key configured). 'local'
+          // explicitly routes to Rust→DMR; if DMR isn't running, Rust
+          // hard-fails with an actionable error instead of silently falling
+          // through to a cloud provider that requires a key the user never
+          // set. Joel: "deepseek can't be a fallback" / "whole point is
+          // local models, make them work."
+          provider: params.provider || 'local',
           personaContext: {
             uniqueId: targetPersonaId,
             displayName: ragContext.identity?.name || personaDisplayName,

--- a/src/commands/ai/generate/shared/AIGenerateTypes.ts
+++ b/src/commands/ai/generate/shared/AIGenerateTypes.ts
@@ -97,7 +97,11 @@ export function paramsToRequest(params: AIGenerateParams): TextGenerationRequest
     model: params.model,
     temperature: params.temperature,
     maxTokens: params.maxTokens,
-    provider: params.provider,
+    // Default to 'local' (DMR via Rust IPC). Same rationale as the RAG-mode
+    // path in AIGenerateServerCommand.ts: continuum's architectural point
+    // is local models; cloud is opt-in via explicit provider, never silent
+    // fallback (#980 Bug 7).
+    provider: params.provider || 'local',
     context: params.context,
   };
 }

--- a/src/commands/collaboration/chat/send/server/ChatSendServerCommand.ts
+++ b/src/commands/collaboration/chat/send/server/ChatSendServerCommand.ts
@@ -181,9 +181,34 @@ export class ChatSendServerCommand extends ChatSendCommand {
     // 7. Generate short ID (last 6 chars of UUID - from BaseEntity.id)
     const shortId = storedEntity.id.slice(-6);
 
+    // 8. No-listener warning (#980 Bug 8): if zero persona-users exist in
+    // the system, the message is stored successfully but no AI will ever
+    // respond to it. Carl's #980 caught this: chat-send returned success,
+    // user typed "hello" + got nothing back, no signal anywhere that the
+    // message had no listener. Cascade from seed-failure (Bug 3): no
+    // personas seeded → agent/list returns []. Surface a clear "stored
+    // but no listener" warning so the user knows to investigate.
+    //
+    // Cheap query: count how many persona-type users exist (limit 1 — we
+    // only need to distinguish 0 vs ≥1). Non-blocking on the result
+    // payload — message is still stored either way; this just adds a
+    // warning string when listeners are absent.
+    const personaCheck = await DataList.execute<UserEntity>({
+      dbHandle: 'default',
+      collection: UserEntity.collection,
+      filter: { type: 'persona' },
+      limit: 1,
+      context: params.context,
+      sessionId: params.sessionId,
+    });
+    const hasListener = personaCheck.success && (personaCheck.items?.length ?? 0) > 0;
+    const successMessage = hasListener
+      ? `Message sent to ${resolved.displayName} (#${shortId})`
+      : `Message sent to ${resolved.displayName} (#${shortId}) ⚠️ No AI personas in system — message stored but won't get a reply. Check: ./jtag data/list --collection=users --filter='{"type":"persona"}'  (likely cascade from a failed seed; re-run: npm run data:seed)`;
+
     return transformPayload(params, {
       success: true,
-      message: `Message sent to ${resolved.displayName} (#${shortId})`,
+      message: successMessage,
       messageEntity: storedEntity,
       shortId: shortId,
       roomId: resolved.id


### PR DESCRIPTION
Joel: "deepseek can't be a fallback isn't it api key based?" / "whole point is local models make them work." Default ai/generate to 'local' (Rust→DMR), never silent fallback to cloud. Both RAG-mode + direct-mode paths fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)