### PR TITLE
feat(gpu): add ROCm / DirectML / OpenVINO ORT EP cfg branches

### DIFF
--- a/src/workers/continuum-core/Cargo.toml
+++ b/src/workers/continuum-core/Cargo.toml
@@ -197,6 +197,21 @@ cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda", "llama
 # to MoltenVK on the host, which translates to Metal. Also valid on Linux
 # Nvidia/AMD hosts with libvulkan available.
 vulkan = ["llama/vulkan"]
+# ORT execution providers for the broader Carl-OOTB matrix (#964 series
+# follow-up). Each adds a cfg branch in inference/ort_providers.rs so
+# fastembed / Piper-TTS / Moonshine-STT / Kokoro / Orpheus / Silero VAD
+# pick up the right GPU EP per platform — no silent CPU fallback per
+# the architectural rule. Linux runs continuum-core in containers with
+# the matching GPU passthrough; native dev hosts pick whichever feature
+# matches their hardware.
+#
+#   rocm     → AMD GPU (Linux). ort/rocm needs ROCm runtime libs at link.
+#   directml → Windows native + DirectX 12 (Nvidia / AMD / Intel).
+#   openvino → Intel CPU/GPU/VPU (Linux + Windows). Different from CPU
+#              fallback: OpenVINO is Intel's GPU/NPU acceleration path.
+rocm = ["ort/rocm"]
+directml = ["ort/directml"]
+openvino = ["ort/openvino"]
 # MLX — Apple Silicon native inference path (phases A–E of continuum#897).
 # Only compiles on macOS/aarch64; the adapter module is guarded by this feature
 # AND by cfg(target_os = "macos") so non-Mac targets simply don't see the code.

--- a/src/workers/continuum-core/src/inference/ort_providers.rs
+++ b/src/workers/continuum-core/src/inference/ort_providers.rs
@@ -87,20 +87,49 @@ pub fn build_ort_gpu_execution_providers() -> Result<Vec<ExecutionProviderDispat
         providers.push(CUDAExecutionProvider::default().build());
     }
 
+    // ROCm — Linux + AMD GPU. Builds when --features rocm + ROCm runtime
+    // libs are installed. Carl on Linux+AMD picks this path.
+    #[cfg(all(feature = "rocm", target_os = "linux"))]
+    {
+        use ort::execution_providers::ROCmExecutionProvider;
+        providers.push(ROCmExecutionProvider::default().build());
+    }
+
+    // DirectML — Windows native. Works with any DX12-compatible GPU
+    // (Nvidia / AMD / Intel). Carl on Windows-native picks this path.
+    #[cfg(all(feature = "directml", target_os = "windows"))]
+    {
+        use ort::execution_providers::DirectMLExecutionProvider;
+        providers.push(DirectMLExecutionProvider::default().build());
+    }
+
+    // OpenVINO — Intel CPU/GPU/VPU. Linux + Windows. NOT a CPU fallback
+    // (OpenVINO targets Intel's accelerators specifically). Carl on
+    // Intel-Arc Linux or Windows picks this path.
+    #[cfg(feature = "openvino")]
+    {
+        use ort::execution_providers::OpenVINOExecutionProvider;
+        providers.push(OpenVINOExecutionProvider::default().build());
+    }
+
     if providers.is_empty() {
         return Err(format!(
             "No GPU Execution Provider configured for ORT on this build. \
              Per architecture, CPU fallback is forbidden — ORT consumers \
              (embedding, TTS, STT, vision) must run on GPU. \
              Build with the appropriate cargo feature: \
-             '--features metal' (Mac, Apple Silicon GPU via CoreML EP) or \
-             '--features cuda' (Linux+Nvidia, WSL+Nvidia, Windows+Nvidia). \
-             Detected: target_os={}, features=(metal={}, cuda={}). \
-             If your hardware needs ROCm / Vulkan / DirectML coverage, that \
-             EP needs wiring in inference/ort_providers.rs (currently a gap).",
+             '--features metal' (Mac, Apple Silicon GPU via CoreML EP), \
+             '--features cuda' (Linux+Nvidia, WSL+Nvidia, Windows+Nvidia), \
+             '--features rocm' (Linux+AMD), \
+             '--features directml' (Windows-native, any DX12 GPU), \
+             '--features openvino' (Linux+Intel / Windows+Intel). \
+             Detected: target_os={}, features=(metal={}, cuda={}, rocm={}, directml={}, openvino={}).",
             std::env::consts::OS,
             cfg!(feature = "metal"),
             cfg!(feature = "cuda"),
+            cfg!(feature = "rocm"),
+            cfg!(feature = "directml"),
+            cfg!(feature = "openvino"),
         ));
     }
 


### PR DESCRIPTION
Joel: "OOTB on all architectures from Docker." Extends #985 ORT EP coverage from Mac/CUDA-only to ROCm (Linux+AMD), DirectML (Windows-native DX12), OpenVINO (Intel). cfg-gated; only fires when explicitly built with the matching feature.

🤖 Generated with Claude Code