### PR TITLE
fix(install): cargo-features.sh detects ROCm + Vulkan + DirectML, not just CUDA

### DIFF
--- a/src/scripts/shared/cargo-features.sh
+++ b/src/scripts/shared/cargo-features.sh
@@ -6,11 +6,15 @@
 #   source scripts/shared/cargo-features.sh
 #   cargo build --release --no-default-features $CARGO_GPU_FEATURES
 #
-# Results:
-#   macOS:         --features metal
-#   Linux + CUDA:  --features cuda
-#   Linux (no GPU): (empty — CPU only)
-#   AMD ROCm:      (empty for now — future: --features rocm)
+# Results (matches Carl-OOTB matrix):
+#   macOS:                           --features metal,accelerate
+#   Linux + Nvidia (incl. WSL):      --features cuda,load-dynamic-ort
+#   Linux + AMD (ROCm runtime):      --features rocm,load-dynamic-ort
+#   Linux + AMD/Intel (Vulkan only): --features vulkan,load-dynamic-ort
+#   Windows-native (DX12):           --features directml
+#   Windows-native + Nvidia:         --features cuda,directml (both)
+#   Linux (no GPU detected):         empty → continuum-core panics at startup
+#                                    (#998 — no CPU fallback per architecture)
 
 CARGO_GPU_FEATURES=""
 
@@ -19,7 +23,12 @@ case "$(uname -s)" in
     CARGO_GPU_FEATURES="--features metal,accelerate"
     ;;
   Linux)
-    # CUDA: check for nvidia-smi in standard and WSL paths
+    # Probe order: CUDA > ROCm > Vulkan. CUDA is highest priority because
+    # ORT's CUDA EP + llama.cpp CUDA + Candle CUDA give the most paths.
+    # ROCm covers AMD with full ORT EP + Candle (when AMD is available).
+    # Vulkan is the fallback that works on AMD/Intel without proprietary
+    # runtime libs — covers llama.cpp inference but ORT EPs are absent
+    # (no ort/vulkan EP exists today).
     if command -v nvidia-smi &>/dev/null || [ -f /usr/lib/wsl/lib/nvidia-smi ]; then
       CARGO_GPU_FEATURES="--features cuda,load-dynamic-ort"
       # Ensure CUDA toolkit + nvidia-smi are in PATH
@@ -33,9 +42,25 @@ case "$(uname -s)" in
       if [ -d /usr/lib/wsl/lib ] && ! command -v nvidia-smi &>/dev/null; then
         export PATH="/usr/lib/wsl/lib:$PATH"
       fi
-    # ROCm (AMD): future support
-    # elif command -v rocminfo &>/dev/null; then
-    #   CARGO_GPU_FEATURES="--features rocm"
+    elif command -v rocminfo &>/dev/null; then
+      # AMD with ROCm runtime — full ORT ROCm EP + llama.cpp ROCm path.
+      CARGO_GPU_FEATURES="--features rocm,load-dynamic-ort"
+    elif command -v vulkaninfo &>/dev/null && vulkaninfo --summary 2>/dev/null | grep -q "deviceName"; then
+      # AMD/Intel without ROCm but with Vulkan loader — llama.cpp Vulkan
+      # path covers the LLM. ORT EPs are absent (no ort/vulkan); the
+      # ORT consumers (fastembed, TTS, STT) will still hard-fail at
+      # session create per #985's helper, surfacing the gap clearly.
+      CARGO_GPU_FEATURES="--features vulkan,load-dynamic-ort"
+    fi
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    # Windows-native (Git Bash / MSYS / Cygwin). DX12 is universally
+    # available on Win10+ → DirectML EP works on any GPU. Add CUDA on
+    # top if Nvidia is present so ORT picks CUDA first (faster) +
+    # DirectML stays as a co-listed EP for non-CUDA-supported ops.
+    CARGO_GPU_FEATURES="--features directml"
+    if command -v nvidia-smi &>/dev/null; then
+      CARGO_GPU_FEATURES="--features cuda,directml"
     fi
     ;;
 esac

--- a/src/workers/continuum-core/Cargo.toml
+++ b/src/workers/continuum-core/Cargo.toml
@@ -197,6 +197,21 @@ cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda", "llama
 # to MoltenVK on the host, which translates to Metal. Also valid on Linux
 # Nvidia/AMD hosts with libvulkan available.
 vulkan = ["llama/vulkan"]
+# ORT execution providers for the broader Carl-OOTB matrix (#964 series
+# follow-up). Each adds a cfg branch in inference/ort_providers.rs so
+# fastembed / Piper-TTS / Moonshine-STT / Kokoro / Orpheus / Silero VAD
+# pick up the right GPU EP per platform — no silent CPU fallback per
+# the architectural rule. Linux runs continuum-core in containers with
+# the matching GPU passthrough; native dev hosts pick whichever feature
+# matches their hardware.
+#
+#   rocm     → AMD GPU (Linux). ort/rocm needs ROCm runtime libs at link.
+#   directml → Windows native + DirectX 12 (Nvidia / AMD / Intel).
+#   openvino → Intel CPU/GPU/VPU (Linux + Windows). Different from CPU
+#              fallback: OpenVINO is Intel's GPU/NPU acceleration path.
+rocm = ["ort/rocm"]
+directml = ["ort/directml"]
+openvino = ["ort/openvino"]
 # MLX — Apple Silicon native inference path (phases A–E of continuum#897).
 # Only compiles on macOS/aarch64; the adapter module is guarded by this feature
 # AND by cfg(target_os = "macos") so non-Mac targets simply don't see the code.

--- a/src/workers/continuum-core/src/inference/ort_providers.rs
+++ b/src/workers/continuum-core/src/inference/ort_providers.rs
@@ -87,20 +87,49 @@ pub fn build_ort_gpu_execution_providers() -> Result<Vec<ExecutionProviderDispat
         providers.push(CUDAExecutionProvider::default().build());
     }
 
+    // ROCm — Linux + AMD GPU. Builds when --features rocm + ROCm runtime
+    // libs are installed. Carl on Linux+AMD picks this path.
+    #[cfg(all(feature = "rocm", target_os = "linux"))]
+    {
+        use ort::execution_providers::ROCmExecutionProvider;
+        providers.push(ROCmExecutionProvider::default().build());
+    }
+
+    // DirectML — Windows native. Works with any DX12-compatible GPU
+    // (Nvidia / AMD / Intel). Carl on Windows-native picks this path.
+    #[cfg(all(feature = "directml", target_os = "windows"))]
+    {
+        use ort::execution_providers::DirectMLExecutionProvider;
+        providers.push(DirectMLExecutionProvider::default().build());
+    }
+
+    // OpenVINO — Intel CPU/GPU/VPU. Linux + Windows. NOT a CPU fallback
+    // (OpenVINO targets Intel's accelerators specifically). Carl on
+    // Intel-Arc Linux or Windows picks this path.
+    #[cfg(feature = "openvino")]
+    {
+        use ort::execution_providers::OpenVINOExecutionProvider;
+        providers.push(OpenVINOExecutionProvider::default().build());
+    }
+
     if providers.is_empty() {
         return Err(format!(
             "No GPU Execution Provider configured for ORT on this build. \
              Per architecture, CPU fallback is forbidden — ORT consumers \
              (embedding, TTS, STT, vision) must run on GPU. \
              Build with the appropriate cargo feature: \
-             '--features metal' (Mac, Apple Silicon GPU via CoreML EP) or \
-             '--features cuda' (Linux+Nvidia, WSL+Nvidia, Windows+Nvidia). \
-             Detected: target_os={}, features=(metal={}, cuda={}). \
-             If your hardware needs ROCm / Vulkan / DirectML coverage, that \
-             EP needs wiring in inference/ort_providers.rs (currently a gap).",
+             '--features metal' (Mac, Apple Silicon GPU via CoreML EP), \
+             '--features cuda' (Linux+Nvidia, WSL+Nvidia, Windows+Nvidia), \
+             '--features rocm' (Linux+AMD), \
+             '--features directml' (Windows-native, any DX12 GPU), \
+             '--features openvino' (Linux+Intel / Windows+Intel). \
+             Detected: target_os={}, features=(metal={}, cuda={}, rocm={}, directml={}, openvino={}).",
             std::env::consts::OS,
             cfg!(feature = "metal"),
             cfg!(feature = "cuda"),
+            cfg!(feature = "rocm"),
+            cfg!(feature = "directml"),
+            cfg!(feature = "openvino"),
         ));
     }
 


### PR DESCRIPTION
Companion to #1001 (ORT EP cfg branches). cargo-features.sh now picks the right --features per detected GPU runtime. Windows-native gets directml (CUDA too if Nvidia present). Linux+AMD picks rocm or vulkan. Tested on Mac → unchanged.

🤖 Generated with Claude Code