### PR TITLE
fix(install.ps1): WSL detection — strip null bytes from UTF-16 wsl --list output

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -85,7 +85,15 @@ Install-IfMissing -Name 'Docker Desktop'     -WingetId 'Docker.DockerDesktop' `
 function Install-WSL2 {
     $wslExe = Get-Command wsl.exe -ErrorAction SilentlyContinue
     if ($wslExe) {
-        $distros = & wsl.exe --list --quiet 2>$null
+        # wsl.exe writes its --list output as UTF-16 LE; PowerShell reads
+        # as UTF-8 by default, so each character ends up interspersed with
+        # null bytes ("U`0b`0u`0n`0t`0u`0") and the regex 'Ubuntu' never
+        # matches even when Ubuntu is genuinely installed and running.
+        # Pre-fix this caused install.ps1 to false-flag WSL2 as missing
+        # and demand admin elevation on every fresh-Windows-validator run.
+        # Caught by continuum-b69f 2026-05-02 during Carl-OOTB Windows test.
+        # Strip the embedded nulls before matching.
+        $distros = (& wsl.exe --list --quiet 2>$null) -replace "`0", ""
         $hasUbuntu = $distros | Where-Object { $_ -match 'Ubuntu' }
         if ($hasUbuntu) { Write-Ok 'WSL2 + Ubuntu already installed'; return }
     }


### PR DESCRIPTION
## Carl-OOTB Windows blocker — phase 1 (prereqs)

Discovered during continuum-b69f's Carl-OOTB Windows validation 2026-05-02. Fresh-Windows validator with Ubuntu installed and running in WSL2 hits:

```
+ Git for Windows already installed
+ Docker Desktop already installed
-> Installing WSL2 + Ubuntu (will require admin elevation + a reboot on first install) ...
! Not running as admin. WSL2 install needs admin -- relaunch ...
```

But `wsl --list --verbose` shows Ubuntu running. The `Install-WSL2` detection in install.ps1 thinks WSL is missing and demands admin elevation.

## Root cause

`wsl.exe --list --quiet` writes UTF-16 LE. PowerShell reads stdout as UTF-8, so each distro name interleaves with null bytes:

```powershell
> $d = & wsl.exe --list --quiet
> $d[0]                           # appears as "U b u n t u "
> [byte[]][char[]]$d[0]           # 85,0,98,0,117,0,110,0,116,0,117,0
> $d -match 'Ubuntu'              # false — nulls block the regex
```

The detection's regex `-match 'Ubuntu'` never fires.

## Fix

One line: strip nulls before regex.

```powershell
$distros = (& wsl.exe --list --quiet 2>$null) -replace "`0", ""
```

Plus a comment block so the next reader doesn't reintroduce the bug — matches the local convention (PR #265 / #394 / #396 all carry similar 'caught by X on date Y' notes).

## Test plan

- [x] Verified the bug locally on Windows: byte-level inspection shows interleaved nulls; pre-fix regex never matches; post-fix regex matches.
- [x] Re-ran install.ps1 with the patched line — `+ WSL2 + Ubuntu already installed` now fires correctly, install proceeds past Phase 1 prereqs.
- [ ] CI verification (whatever clean-install matrix continuum has).

## Why this matters

Every Windows user running `irm install.ps1 | iex` after this PR lands gets past Phase 1 instead of hitting a wall on a working WSL install. The detection is a one-line bug masking a working environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)