### PR TITLE
fix(git_bridge): strip inherited git-context env in run_git (kills pre-push hook race)

### DIFF
--- a/src/workers/continuum-core/src/code/git_bridge.rs
+++ b/src/workers/continuum-core/src/code/git_bridge.rs
@@ -143,6 +143,30 @@ fn run_git(workspace_root: &Path, args: &[&str]) -> Result<String, String> {
     let output = Command::new("git")
         .args(args)
         .current_dir(workspace_root)
+        // Strip git-context env vars that would otherwise pin git to
+        // the parent repo regardless of cwd. Without this, when
+        // run_git is invoked from a process that itself was launched
+        // by git (the most common case: pre-push / pre-commit hooks
+        // invoking `cargo test`), git sets GIT_DIR/GIT_PREFIX/etc and
+        // those propagate to every child. Concrete failure:
+        // git_bridge::tests' tempdir `git commit` inherited GIT_DIR
+        // pointing at the parent worktree's .git, then ran the
+        // worktree's pre-commit hook (whose paths don't exist in the
+        // tempdir context) and panicked. Caught 2026-05-02 wedging the
+        // whole git_bridge::tests cluster every time the pre-push hook
+        // ran them. Stripping these makes run_git context-clean — git
+        // discovers from current_dir(workspace_root) only, no parent
+        // contamination.
+        // GIT_CEILING_DIRECTORIES caps any residual upward discovery
+        // at workspace_root (defense in depth — env_remove handles the
+        // documented vars; ceiling handles anything new git might add
+        // in future versions).
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_PREFIX")
+        .env("GIT_CEILING_DIRECTORIES", workspace_root)
         .output()
         .map_err(|e| format!("Failed to run git: {}", e))?;
 


### PR DESCRIPTION
## Summary

The pre-push hook's Phase 3 (Rust tests) was reliably failing 9-of-9 `code::git_bridge::tests::*` whenever invoked, even though the same tests passed in isolation. Root cause is **git env inheritance**, not parallelism.

## Root cause

`git push` sets `GIT_DIR`, `GIT_PREFIX`, etc. on the pre-push hook's environment. Those env vars propagate through every child — including `cargo test`, including the test binary, including each test's tempdir `git init`/`git commit`. So a test's `git commit` in its tempdir inherits `GIT_DIR=/Users/.../continuum/.git`, runs the parent worktree's `pre-commit` hook (which can't find its target script in the tempdir context), and panics.

Three different surface symptoms, all from the same upstream cause:
- "could not lock config file `<bare>/.git/config`: File exists"
- "Unable to create '`<bare>/.git/worktrees/<x>/index.lock`'"
- "`<bare>/.git/hooks/pre-commit`: `<tmp>/src/scripts/git-precommit.sh`: No such file or directory"

## Fix

In `run_git`:
- `env_remove` for `GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_INDEX_FILE`, `GIT_PREFIX`
- Set `GIT_CEILING_DIRECTORIES=workspace_root` as defense-in-depth against future env vars

`run_git` is now context-clean: git discovers from `current_dir(workspace_root)` only, no parent contamination. Production callers get a small safety improvement (continuum-core's git_bridge invoked from any process won't accidentally inherit the caller's git context); test callers get reliable isolation.

## Tests

Reproduces the previously-failing case by simulating the hook environment:

| Command | Before | After |
|---|---|---|
| `cargo test --lib code::git_bridge` | passed | passed |
| `GIT_DIR=<continuum>/.git cargo test --lib code::git_bridge` | **9 failures** | **9 passed** |
| `cargo test --lib` (full suite, normal env) | passed | passed |
| `cargo test --lib` (full suite, via pre-push) | **9 failures** | **passed (this push)** |

## Why this PR matters beyond itself

The pre-push hook's Phase 3 false-positive was blocking ANY PR whose change is non-Rust (PowerShell-only, docs-only, TS-only) from passing through. Two such PRs were blocked tonight — b69f's #1005 (Carl-OOTB Windows fix #1) and my unpushed install.ps1 networking-probe (Carl-OOTB Windows fix #2). With this fix, the hook stops false-positive blocking on the inherited-env race.

## Test plan

- [x] CI green (clean-install matrix unaffected; this is Rust-only fix in continuum-core)
- [x] Local pre-push passed (this push went through cleanly)
- [ ] Reviewers can repro: `GIT_DIR=$(git rev-parse --git-dir) cargo test --lib --features metal,accelerate code::git_bridge` — should pass on this branch, fail on canary

🤖 Generated with [Claude Code](https://claude.com/claude-code)