### PR TITLE
fix(ipc): chmod 666 the Unix socket so cross-UID callers can connect (closes #1008)

### DIFF
--- a/src/workers/continuum-core/src/code/git_bridge.rs
+++ b/src/workers/continuum-core/src/code/git_bridge.rs
@@ -143,6 +143,30 @@ fn run_git(workspace_root: &Path, args: &[&str]) -> Result<String, String> {
     let output = Command::new("git")
         .args(args)
         .current_dir(workspace_root)
+        // Strip git-context env vars that would otherwise pin git to
+        // the parent repo regardless of cwd. Without this, when
+        // run_git is invoked from a process that itself was launched
+        // by git (the most common case: pre-push / pre-commit hooks
+        // invoking `cargo test`), git sets GIT_DIR/GIT_PREFIX/etc and
+        // those propagate to every child. Concrete failure:
+        // git_bridge::tests' tempdir `git commit` inherited GIT_DIR
+        // pointing at the parent worktree's .git, then ran the
+        // worktree's pre-commit hook (whose paths don't exist in the
+        // tempdir context) and panicked. Caught 2026-05-02 wedging the
+        // whole git_bridge::tests cluster every time the pre-push hook
+        // ran them. Stripping these makes run_git context-clean — git
+        // discovers from current_dir(workspace_root) only, no parent
+        // contamination.
+        // GIT_CEILING_DIRECTORIES caps any residual upward discovery
+        // at workspace_root (defense in depth — env_remove handles the
+        // documented vars; ceiling handles anything new git might add
+        // in future versions).
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_PREFIX")
+        .env("GIT_CEILING_DIRECTORIES", workspace_root)
         .output()
         .map_err(|e| format!("Failed to run git: {}", e))?;
 

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -1013,6 +1013,22 @@ pub fn start_server(
     crate::runtime::init_executor(runtime.registry_arc());
 
     let listener = UnixListener::bind(socket_path)?;
+    // Make the socket world-rw so callers running under a different UID
+    // than the server can connect. Concrete failure (#1008): on Windows
+    // WSL2 + Docker Desktop, continuum-core runs as root inside the
+    // container and binds the socket; the host-side jtag (running as
+    // the WSL user, uid 1000) gets EACCES connecting to the root-owned
+    // socket. Mac/Linux dev mode (server + caller both run as the same
+    // user) is unaffected. 0o666 is appropriate for an IPC substrate
+    // socket that lives in a path the caller can already see — same
+    // blast radius as anything reading /tmp. Failing-loud (no `?` here
+    // would suppress the error; let it propagate) is intentional per
+    // the global "evidence is for the debugger" rule. Caught live by
+    // continuum-b69f 2026-05-02 during Carl-OOTB Windows Phase 4.
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o666))?;
+    }
     let state = Arc::new(ServerState::new_with_shared_state(
         rt_handle,
         memory_manager,


### PR DESCRIPTION
## Summary

continuum-core runs as root inside its Docker Desktop / WSL2 container and binds `/tmp/continuum-core.sock` with default permissions (rwx by owner only). The host-side `jtag`, running as the Windows-WSL user (uid 1000), then gets EACCES on connect — Phase 4 chat probe blocked, full stack otherwise healthy.

Caught live by continuum-b69f 2026-05-02 during Carl-OOTB Windows test. Mac and Linux dev mode are unaffected because server + caller both run as the same user.

## Fix

After `UnixListener::bind`, explicitly `set_permissions(0o666)` on the socket path. 0o666 is appropriate for an IPC substrate socket that lives in a path the caller can already see — same blast radius as anything reading `/tmp`.

Failing-loud (propagating any chmod error via `?` rather than swallowing) is intentional per the global "evidence is for the debugger" rule.

## Stacked on

This PR includes the env_remove fix from #1009 as a parent commit (it was needed locally to push through the pre-push hook). When #1009 merges first, this PR's diff against canary will reduce to just the 16-line socket-perms change. If reviewer prefers, can rebase after #1009 merges.

## Test plan

- [x] `cargo build --lib --features metal,accelerate` clean
- [ ] CI green
- [ ] **Live**: b69f re-runs Carl-OOTB Phase 4 on Windows after this lands → jtag connects → chat probe succeeds

## Closes

- #1008 — IPC socket EACCES blocking cross-UID callers; surfaces as Phase 4 chat probe failure on Carl-OOTB Windows test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)