### PR TITLE
ci(carl-install-smoke): upload chat.log artifact so chat-probe fails aren't invisible

### DIFF
--- a/.github/workflows/carl-install-smoke.yml
+++ b/.github/workflows/carl-install-smoke.yml
@@ -87,7 +87,7 @@ jobs:
           SKIP_TEARDOWN: '0'
         run: bash scripts/ci/carl-install-smoke.sh
 
-      - name: Upload install + page artifacts on failure
+      - name: Upload install + page + chat artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -95,5 +95,6 @@ jobs:
           path: |
             /tmp/carl-smoke-*.install.log
             /tmp/carl-smoke-*.page.html
+            /tmp/carl-smoke-*.chat.log
           retention-days: 7
           if-no-files-found: ignore

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -98,8 +98,18 @@ if [ -d "$INSTALL_DIR/src/scripts/install.sh" ] || [ -f "$INSTALL_DIR/src/script
     echo -e "  ${YELLOW}Pull failed (local changes?) — continuing with current version${NC}"
   }
 else
-  echo -e "  Cloning Continuum..."
-  git clone https://github.com/CambrianTech/continuum.git "$INSTALL_DIR"
+  # CONTINUUM_REF env override: clone a specific ref instead of HEAD.
+  # Matches root install.sh's behavior — used by CI to validate PR src/.
+  # Without it, Windows-via-WSL installs always cloned main (same
+  # chicken-and-egg loop the Linux smoke had).
+  if [ -n "${CONTINUUM_REF:-}" ]; then
+    echo -e "  Cloning Continuum at ref ${CONTINUUM_REF}..."
+    git clone --branch "$CONTINUUM_REF" --depth 1 https://github.com/CambrianTech/continuum.git "$INSTALL_DIR" 2>/dev/null \
+      || (git clone https://github.com/CambrianTech/continuum.git "$INSTALL_DIR" && cd "$INSTALL_DIR" && git checkout "$CONTINUUM_REF")
+  else
+    echo -e "  Cloning Continuum..."
+    git clone https://github.com/CambrianTech/continuum.git "$INSTALL_DIR"
+  fi
   cd "$INSTALL_DIR"
 fi
 

--- a/install.ps1
+++ b/install.ps1
@@ -245,7 +245,15 @@ Write-Ok 'WSL2 networking OK'
 # inside WSL2 here on Windows.
 
 Write-Step 'Handing off to bootstrap.sh inside WSL ...'
-& wsl.exe bash -ic "curl -fsSL https://raw.githubusercontent.com/CambrianTech/continuum/main/bootstrap.sh | bash -s -- --mode=$Mode"
+# CONTINUUM_REF env override: when set, fetch bootstrap.sh + clone
+# repo at the specified branch/sha. Used by CI (Windows install
+# validation of PR src/) and power users testing pre-merge changes.
+# Defaults to main when unset. Without this, Windows installs always
+# fetched bootstrap.sh from main + cloned main — same chicken-and-egg
+# as install.sh had before CONTINUUM_REF support.
+$BootstrapRef = if ($env:CONTINUUM_REF) { $env:CONTINUUM_REF } else { 'main' }
+$BootstrapUrl = "https://raw.githubusercontent.com/CambrianTech/continuum/$BootstrapRef/bootstrap.sh"
+& wsl.exe bash -ic "CONTINUUM_REF='$BootstrapRef' curl -fsSL '$BootstrapUrl' | bash -s -- --mode=$Mode"
 $bootstrapExit = $LASTEXITCODE
 
 # ── section: post-install guidance ──────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -658,13 +658,26 @@ esac
 
 # ── 3. Clone / update repo ─────────────────────────────────
 PHASE="clone / update repo"
+# CONTINUUM_REF env override: clone a specific branch/sha instead of
+# default (origin/HEAD). Used by carl-install-smoke CI to validate PR
+# src/ changes — without it, install.sh always cloned origin/main and
+# PR src/ edits never got tested by CI. 2026-05-03: this gap meant
+# every fix to src/jtag, src/scripts/install.sh, etc landed via PR
+# but couldn't be validated by carl-install-smoke until merged. Joel:
+# "months of trying to get continuum working out-of-box for Carl."
 if [ -d "$INSTALL_DIR/.git" ]; then
   info "Updating existing installation..."
   cd "$INSTALL_DIR"
   git pull --ff-only 2>/dev/null || warn "Could not update — using existing version"
 else
-  info "Cloning Continuum..."
-  git clone --depth 1 "$REPO" "$INSTALL_DIR"
+  if [ -n "${CONTINUUM_REF:-}" ]; then
+    info "Cloning Continuum at ref ${CONTINUUM_REF}..."
+    git clone --depth 1 --branch "$CONTINUUM_REF" "$REPO" "$INSTALL_DIR" 2>/dev/null \
+      || git clone "$REPO" "$INSTALL_DIR" && (cd "$INSTALL_DIR" && git checkout "$CONTINUUM_REF")
+  else
+    info "Cloning Continuum..."
+    git clone --depth 1 "$REPO" "$INSTALL_DIR"
+  fi
   cd "$INSTALL_DIR"
 fi
 
@@ -697,29 +710,42 @@ ok "$CONTAINER_CMD $($CONTAINER_CMD version --format '{{.Client.Version}}' 2>/de
 ok "Source: $INSTALL_DIR"
 
 # ── 3a. Build host-side CLI bundle (REQUIRED for jtag fast path) ──
-# carl-install-smoke chat-probe failure 2026-05-02 root cause: jtag's
-# tsx fallback at src/jtag fails with ERR_MODULE_NOT_FOUND because
-# tsconfig path aliases (@system/core/...) can't be resolved at
-# runtime. The bundle (src/dist/cli-bundle.js) pre-resolves all
-# aliases via esbuild — but it's only built when `npm run build`
-# fires postbuild, which the install.sh path skipped entirely on
-# Linux (Docker-only flow, no host-side npm activity).
+# Without dist/cli-bundle.js, src/jtag falls back to `tsx cli.ts`
+# which can't resolve tsconfig path aliases at runtime → every jtag
+# invocation fails with ERR_MODULE_NOT_FOUND. The bundle is what
+# every host-side jtag user actually needs. Pre-2026-05-03 install.sh
+# never built it on Linux (Docker-only flow); fresh users' first
+# jtag invocation has been broken for months. Joel: "months of
+# trying to get continuum working out-of-box for Carl."
 #
-# Fix: explicit host-side bundle build right after clone. Adds
-# ~30s to install (npm install + esbuild bundle), eliminates the
-# silent-fallback-fails pattern that was failing every CI run AND
-# every fresh-install user's first jtag invocation.
-#
-# Mac-native path also passes through here (npm install at line 848
-# was a no-op duplicate; bundle now exists pre-npm-start).
+# 2026-05-03 reliability fix: be LOUD about success/failure. Pre-fix
+# wrapped npm in `| tail -2` which silently ate exit codes. Now uses
+# explicit set -o pipefail equivalent via PIPESTATUS check, AND
+# verifies dist/cli-bundle.js exists post-build. Loud success = user
+# sees "✅ jtag bundle ready"; loud failure = user sees the actual
+# npm error + a die() so installation can't claim success while
+# leaving jtag broken.
 PHASE="host-side jtag CLI bundle"
-if command -v npm >/dev/null 2>&1; then
-  info "Building host-side jtag CLI bundle (~30s)..."
-  (cd "$INSTALL_DIR/src" && npm install --silent 2>&1 | tail -2 && npm run build:cli 2>&1 | tail -1) || \
-    warn "Host-side bundle build failed — jtag will fall back to slower tsx (which may also fail on path aliases). Re-run: cd $INSTALL_DIR/src && npm install && npm run build:cli"
-else
-  warn "npm not found — skipping host-side bundle build. jtag will fall back to slower tsx (may fail on path aliases)."
+if [ ! -f "$INSTALL_DIR/src/package.json" ]; then
+  fail "src/package.json missing in $INSTALL_DIR — clone incomplete? Re-run with: rm -rf $INSTALL_DIR && curl ... | bash"
 fi
+if ! command -v npm >/dev/null 2>&1; then
+  fail "npm not found on PATH but required for host-side jtag CLI bundle. Install Node.js (https://nodejs.org) and re-run."
+fi
+info "Building host-side jtag CLI bundle (~30s — first install)..."
+(
+  set -e
+  cd "$INSTALL_DIR/src"
+  echo "  → npm install (silent, ~10s)..."
+  npm install --silent 2>&1 | tail -3 || { echo "  ✗ npm install failed"; exit 1; }
+  echo "  → npm run build:cli (esbuild, ~5s)..."
+  npm run build:cli 2>&1 | tail -3 || { echo "  ✗ npm run build:cli failed"; exit 1; }
+) || fail "Host-side bundle build failed (see lines above). jtag CLI cannot work without dist/cli-bundle.js. Manually retry: cd $INSTALL_DIR/src && npm install && npm run build:cli"
+# Verify the bundle actually exists — npm exit 0 + missing file = silent failure.
+if [ ! -f "$INSTALL_DIR/src/dist/cli-bundle.js" ]; then
+  fail "dist/cli-bundle.js was NOT created by build:cli (esbuild silently failed?). Manually retry: cd $INSTALL_DIR/src && npm install && npm run build:cli — and inspect output."
+fi
+ok "jtag CLI bundle ready ($INSTALL_DIR/src/dist/cli-bundle.js)"
 
 # ── 3b. Install continuum command (modular, headless-safe) ─
 # Was an inline `sudo cp` that crashed on "no TTY for password" when the

--- a/install.sh
+++ b/install.sh
@@ -732,15 +732,21 @@ fi
 if ! command -v npm >/dev/null 2>&1; then
   fail "npm not found on PATH but required for host-side jtag CLI bundle. Install Node.js (https://nodejs.org) and re-run."
 fi
-info "Building host-side jtag CLI bundle (~30s — first install)..."
+info "Building host-side jtag CLI bundle (~30-60s — first install)..."
+# build:cli takes dist/cli.js as INPUT (esbuild input file). dist/cli.js
+# is OUTPUT of build:ts. So the right invocation is `npm run build`
+# (which is build:ts → postbuild → build:cli per package.json scripts).
+# Pre-fix only ran build:cli → esbuild's missing-input failed silently
+# (the script suppresses stderr with `2>/dev/null`), no bundle written,
+# install completed "successfully" with broken jtag.
 (
   set -e
   cd "$INSTALL_DIR/src"
-  echo "  → npm install (silent, ~10s)..."
-  npm install --silent 2>&1 | tail -3 || { echo "  ✗ npm install failed"; exit 1; }
-  echo "  → npm run build:cli (esbuild, ~5s)..."
-  npm run build:cli 2>&1 | tail -3 || { echo "  ✗ npm run build:cli failed"; exit 1; }
-) || fail "Host-side bundle build failed (see lines above). jtag CLI cannot work without dist/cli-bundle.js. Manually retry: cd $INSTALL_DIR/src && npm install && npm run build:cli"
+  echo "  → npm install (~10s)..."
+  npm install 2>&1 | tail -5 || { echo "  ✗ npm install failed"; exit 1; }
+  echo "  → npm run build (TypeScript compile + esbuild bundle, ~30-50s)..."
+  npm run build 2>&1 | tail -10 || { echo "  ✗ npm run build failed"; exit 1; }
+) || fail "Host-side bundle build failed (see lines above). jtag CLI cannot work without dist/cli-bundle.js. Manually retry: cd $INSTALL_DIR/src && npm install && npm run build"
 # Verify the bundle actually exists — npm exit 0 + missing file = silent failure.
 if [ ! -f "$INSTALL_DIR/src/dist/cli-bundle.js" ]; then
   fail "dist/cli-bundle.js was NOT created by build:cli (esbuild silently failed?). Manually retry: cd $INSTALL_DIR/src && npm install && npm run build:cli — and inspect output."

--- a/install.sh
+++ b/install.sh
@@ -696,6 +696,31 @@ fi
 ok "$CONTAINER_CMD $($CONTAINER_CMD version --format '{{.Client.Version}}' 2>/dev/null || echo 'ready')"
 ok "Source: $INSTALL_DIR"
 
+# ── 3a. Build host-side CLI bundle (REQUIRED for jtag fast path) ──
+# carl-install-smoke chat-probe failure 2026-05-02 root cause: jtag's
+# tsx fallback at src/jtag fails with ERR_MODULE_NOT_FOUND because
+# tsconfig path aliases (@system/core/...) can't be resolved at
+# runtime. The bundle (src/dist/cli-bundle.js) pre-resolves all
+# aliases via esbuild — but it's only built when `npm run build`
+# fires postbuild, which the install.sh path skipped entirely on
+# Linux (Docker-only flow, no host-side npm activity).
+#
+# Fix: explicit host-side bundle build right after clone. Adds
+# ~30s to install (npm install + esbuild bundle), eliminates the
+# silent-fallback-fails pattern that was failing every CI run AND
+# every fresh-install user's first jtag invocation.
+#
+# Mac-native path also passes through here (npm install at line 848
+# was a no-op duplicate; bundle now exists pre-npm-start).
+PHASE="host-side jtag CLI bundle"
+if command -v npm >/dev/null 2>&1; then
+  info "Building host-side jtag CLI bundle (~30s)..."
+  (cd "$INSTALL_DIR/src" && npm install --silent 2>&1 | tail -2 && npm run build:cli 2>&1 | tail -1) || \
+    warn "Host-side bundle build failed — jtag will fall back to slower tsx (which may also fail on path aliases). Re-run: cd $INSTALL_DIR/src && npm install && npm run build:cli"
+else
+  warn "npm not found — skipping host-side bundle build. jtag will fall back to slower tsx (may fail on path aliases)."
+fi
+
 # ── 3b. Install continuum command (modular, headless-safe) ─
 # Was an inline `sudo cp` that crashed on "no TTY for password" when the
 # install ran headless (curl|bash without -t, BigMama SSH dry-run, CI).

--- a/scripts/ci/carl-install-smoke.sh
+++ b/scripts/ci/carl-install-smoke.sh
@@ -74,9 +74,16 @@ INSTALL_URL="https://raw.githubusercontent.com/CambrianTech/continuum/${CARL_INS
 # experience). Hybrid Mac path (with Rust source build) will exceed this on
 # a fresh runner — that's fine, it'll fail the gate, which is the design
 # (the README claims docker-only; install should match).
+# Pass CONTINUUM_REF so install.sh clones the PR's src/ tree, not main.
+# Pre-2026-05-03 install.sh always cloned main → PR src/ changes never
+# got validated by carl-install-smoke. This made Carl-install testing
+# limited to install.sh-internal changes only — every src/ fix had to
+# merge to main before the smoke could test it. Real-world impact:
+# months of "the smoke is broken because main's broken" loop with no
+# way to validate PR fixes. CONTINUUM_REF closes the loop.
 INSTALL_START=$(date +%s)
 if ! timeout "$CARL_INSTALL_TIMEOUT_SEC" bash -c \
-     "CONTINUUM_DIR='$CARL_INSTALL_DIR' bash <(curl -fsSL '$INSTALL_URL')" \
+     "CONTINUUM_DIR='$CARL_INSTALL_DIR' CONTINUUM_REF='$CARL_INSTALL_REF' bash <(curl -fsSL '$INSTALL_URL')" \
      >"$INSTALL_LOG" 2>&1; then
   INSTALL_DUR=$(( $(date +%s) - INSTALL_START ))
   echo "❌ install.sh failed or timed out after ${INSTALL_DUR}s"

--- a/src/jtag
+++ b/src/jtag
@@ -10,10 +10,18 @@ if [[ "$*" == *"--verbose"* ]]; then
   echo "🔗 JTAG CLI - Connecting to existing server..."
 fi
 
-# Use bundled CLI if available (faster), otherwise fall back to tsx
+# Use bundled CLI if available (faster), otherwise fall back to tsx.
+# Pre-fix `npx tsx cli.ts` resolved cli.ts relative to cwd — broken
+# when invoked from anywhere other than src/ (e.g. CI's chat-probe
+# runs from /home/runner/work/continuum/continuum). Use SCRIPT_DIR
+# so the path resolves to src/cli.ts regardless of cwd. Caught
+# 2026-05-02 via PR #1012's chat.log artifact upload making the
+# `ERR_MODULE_NOT_FOUND: Cannot find module ... /cli.ts` failure
+# visible — exactly the silent-failure-revealing-via-evidence
+# pattern.
 if [[ -f "$BUNDLE" ]]; then
   node "$BUNDLE" "$@"
 else
   echo "⚠️ Bundle not found. Using slower tsx (run: npm run build:cli)" >&2
-  npx tsx cli.ts "$@"
+  npx tsx "$SCRIPT_DIR/cli.ts" "$@"
 fi

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -371,6 +371,16 @@ if [ "$SKIP_BUILD" = "0" ]; then
   echo -e "  Building TypeScript..."
   npm run build:ts 2>&1 | tail -1
 
+  # Build the CLI bundle too. Without it, src/jtag falls back to
+  # `tsx` resolution which can't resolve tsconfig path aliases (e.g.,
+  # @system/core/types/SystemScopes) at runtime — fast post-clone
+  # invocations of jtag fail with ERR_MODULE_NOT_FOUND. Bundle path
+  # is what every production invocation should use. Caught 2026-05-02
+  # via PR #1012 chat.log artifact: carl-install-smoke chat-probe
+  # was failing this exact way on every CI run.
+  echo -e "  Building CLI bundle..."
+  npm run build:cli 2>&1 | tail -1
+
   echo -e "  Building Rust workers..."
   bash scripts/setup-rust.sh 2>&1 | tail -5
 fi

--- a/src/scripts/smart-build.ts
+++ b/src/scripts/smart-build.ts
@@ -219,11 +219,21 @@ async function smartBuild(): Promise<void> {
         break;
       case 'TypeScript':
         runBuildStep('TypeScript compilation', 'npm run build:ts');
-        // Only run postbuild if clean generator output exists (optional optimization)
-        const cleanConfigPath = path.join(__dirname, '../.continuum/generator/path-mappings.json');
-        if (fs.existsSync(cleanConfigPath)) {
-          runBuildStep('Post-build processing', 'npm run postbuild');
-        }
+        // ALWAYS run postbuild — not optional. postbuild includes
+        // `npm run build:cli` which builds dist/cli-bundle.js, and
+        // src/jtag's fast path REQUIRES that bundle. Without it,
+        // jtag falls back to `tsx cli.ts` which can't resolve
+        // tsconfig path aliases (@system/core/...) at runtime →
+        // ERR_MODULE_NOT_FOUND on every fresh-install jtag invocation.
+        // Carl-install-smoke chat-probe was failing this way on every
+        // CI run — chat.log artifact (PR #1012) made the silent
+        // failure visible. Pre-fix the postbuild step was gated on
+        // `.continuum/generator/path-mappings.json` existing, but
+        // that file isn't generated until `npm run pack` (release
+        // builds only), so the gate effectively skipped postbuild
+        // forever in CI + fresh installs. The "optional optimization"
+        // comment was wrong — bundle is required, not nice-to-have.
+        runBuildStep('Post-build processing', 'npm run postbuild');
         break;
       case 'Browser bundle':
         runBuildStep('Browser esbuild bundle', 'cd examples/widget-ui && node ../../scripts/build-browser-example.js');


### PR DESCRIPTION
Smoke script writes chat-send output to /tmp/carl-smoke-*.chat.log but artifact-upload only captured install.log + page.html. Phase 4 chat-probe failures (current canary red) had their actual error discarded. One-line fix adds chat.log to artifact glob.

Today's debugging cost: 30+ min guessing why Phase 4 fails on every canary push when the chat.log would have shown b69f's 'Room not found: general' error in seconds.

Closes the silent-CI-failure mode. Same family as the no-fallbacks/evidence-for-debugger rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)