### PR TITLE
fix(seed): use DEFAULT_USER_UNIQUE_IDS.PRIMARY_HUMAN ('owner') instead of hardcoded 'joel' — chat-probe root cause

### DIFF
--- a/src/server/seed-in-process.ts
+++ b/src/server/seed-in-process.ts
@@ -14,6 +14,7 @@ import { RoomEntity, type RoomType } from '../system/data/entities/RoomEntity';
 import { UserProfileEntity, type UserSpecialityType } from '../system/data/entities/UserProfileEntity';
 import type { UUID } from '../system/core/types/CrossPlatformUUID';
 import { PERSONA_UNIQUE_IDS, getAvailablePersonas, selectLocalModel } from '../scripts/seed/personas';
+import { DEFAULT_USER_UNIQUE_IDS } from '../system/data/domains/DefaultEntities';
 import { CONTENT_TYPE_CONFIGS } from '../shared/generated/ContentTypes';
 import { DataList } from '../commands/data/list/shared/DataListTypes';
 import { DataCreate } from '../commands/data/create/shared/DataCreateTypes';
@@ -337,11 +338,26 @@ export async function seedDatabase(): Promise<boolean> {
   console.log('🌱 Seeding database (in-process)...');
   const start = Date.now();
 
-  // Owner
-  const owner = await seeder.findOrCreateUser('joel', 'Developer', 'human');
+  // Owner — uses DEFAULT_USER_UNIQUE_IDS.PRIMARY_HUMAN ('owner') as the
+  // canonical uniqueId. SessionDaemonServer.findSeededHumanOwner() returns
+  // the FIRST type='human' user; if seed-in-process used a divergent
+  // uniqueId (e.g. hardcoded 'joel'), the find would still return SOMEONE
+  // type=human but rooms get created with the wrong owner_id, jtag CLI
+  // sessions auth as the canonical 'owner', and DataList rooms returns 0
+  // because owner_id doesn't match session-user.id.
+  // Pre-fix b69f 2026-05-02: chat-probe failed with "Room not found:
+  // general" precisely because seed wrote rooms.owner_id pointing at the
+  // 'joel' user but session-daemon picked 'owner'. Now: single source of
+  // truth via the canonical constant — matches scripts/seed-continuum.ts
+  // (line 182, 386) which has used PRIMARY_HUMAN correctly all along.
+  const owner = await seeder.findOrCreateUser(
+    DEFAULT_USER_UNIQUE_IDS.PRIMARY_HUMAN,
+    'Developer',
+    'human',
+  );
   // Emit event so SessionDaemon upgrades anonymous browser sessions to this owner
   void Events.emit('data:users:created', owner);
-  console.log(`  ✅ Owner: ${owner.displayName}`);
+  console.log(`  ✅ Owner: ${owner.displayName} (uniqueId: ${owner.uniqueId})`);
 
   // Rooms — validate recipeIds exist before creating anything
   const validRecipes = new Set(Object.keys(CONTENT_TYPE_CONFIGS));


### PR DESCRIPTION
## Root cause of carl-install-smoke chat-probe \"Room not found: general\"

`seed-in-process.ts:341` hardcoded `findOrCreateUser('joel', 'Developer', 'human')`. `SessionDaemonServer.findSeededHumanOwner()` returns the FIRST `type='human'` row. When the seed wrote rooms with `owner_id` pointing at the `'joel'` user but the session-daemon picked the canonical `'owner'` user (from `DEFAULT_USER_UNIQUE_IDS.PRIMARY_HUMAN`), `DataList rooms` returned 0 because owner_id didn't match session-user.id.

Postgres state on the running stack confirms the divergence:
- 18 users including BOTH `'owner'` (id `0653f2b3-...`) AND `'joel'` (id `ac689024-...`) — two human users from two seed paths
- All 8 rooms have `owner_id = ac689024-...` (the `'joel'` user)
- jtag CLI's `findSeededHumanOwner()` returns the `'owner'` user
- `data/list --collection=rooms` returns 0 items
- chat/send fails: `Room not found: general`

## Fix

`seed-in-process.ts` imports `DEFAULT_USER_UNIQUE_IDS` and uses `PRIMARY_HUMAN` for the human owner uniqueId — same constant `scripts/seed-continuum.ts` has been using correctly all along (line 182, 386). Single source of truth.

`scripts/seed-continuum.ts:197-200` already had a comment acknowledging this divergence: _\"find them even when the DB has uniqueId='joel' but we look for 'owner'.\"_ That was a workaround; this PR is the fix at the source.

## Diff

1 import, 1 hardcoded literal → constant + comment block explaining the failure mode (so the next debugger doesn't have to re-derive it).

## Validation path

After merge + carl-install-smoke runs the seed, the rooms get `owner_id` matching `findSeededHumanOwner()`'s returned user → `DataList rooms` returns 8 → `chat/send --room=general` resolves → chat-probe passes.

Pairs with #1013's post-write verify: that PR surfaces the divergence loudly; THIS PR removes the divergence so the verify (and chat-probe) succeed.

🤖 Drafted with Claude Opus 4.7 (1M context)