### PR TITLE
fix(install): symlink jtag onto PATH alongside continuum (Carl-UX bug #1)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -760,6 +760,14 @@ ok "jtag CLI bundle ready ($INSTALL_DIR/src/dist/cli-bundle.js)"
 # fallback (~/.local/bin) when sudo would prompt without a TTY.
 mod_continuum_bin_link "$INSTALL_DIR/bin/continuum"
 
+# Also place `jtag` on PATH — symlinked, not copied, so the launcher's
+# BASH_SOURCE-based dist lookup keeps working. Without this, post-install
+# `jtag <command>` (per CLAUDE.md / skill docs) returns command-not-found
+# because src/jtag never gets a PATH entry. airc-8a5e 2026-05-03 Carl-UX
+# QA caught this — chat-probe simulates `./jtag` from inside the install
+# tree but real users follow the documented `jtag` form.
+mod_jtag_bin_link "$INSTALL_DIR/src/jtag"
+
 # ── 4. Configuration ───────────────────────────────────────
 PHASE="configuration"
 mkdir -p "$CONTINUUM_DATA"

--- a/src/scripts/lib/install-common.sh
+++ b/src/scripts/lib/install-common.sh
@@ -278,6 +278,75 @@ mod_continuum_bin_link() {
   module_done "continuum-bin"
 }
 
+# ── mod_jtag_bin_link ───────────────────────────────────────
+# Place the `jtag` CLI on PATH. SYMLINK (not cp) because src/jtag is a
+# bash launcher that uses `dirname "${BASH_SOURCE[0]}"` to locate
+# dist/cli-bundle.js relative to its own directory — `cp` would put
+# the launcher at /usr/local/bin/jtag where SCRIPT_DIR resolves to
+# /usr/local/bin and the bundle lookup fails. A symlink preserves
+# BASH_SOURCE traversal back to the install dir's src/, so the
+# launcher finds dist/cli-bundle.js correctly.
+#
+# Bug origin: airc-8a5e 2026-05-03 Carl-UX QA caught that
+# CLAUDE.md / skill docs reference `./jtag` and `jtag <command>` as
+# the chat surface, but install.sh only ever symlinked `continuum` —
+# `jtag` was at $INSTALL_DIR/src/jtag with no PATH entry. Users hit
+# command-not-found and never got to the chat probe at all.
+#
+# Same tier-fallback shape as mod_continuum_bin_link: try writable
+# system path, then sudo, then user-space fallback. Idempotent re-run
+# (skip when symlink already current).
+#
+# Args:
+#   $1 — absolute path to the source jtag launcher (typically
+#        $INSTALL_DIR/src/jtag).
+mod_jtag_bin_link() {
+  local src="$1"
+  if [ -z "$src" ] || [ ! -f "$src" ]; then
+    module_fail "jtag-bin" "source binary missing at: $src"
+  fi
+
+  # Idempotency: existing symlink already points at this src.
+  if [ -L "/usr/local/bin/jtag" ] && [ "$(readlink "/usr/local/bin/jtag")" = "$src" ]; then
+    module_skip "jtag-bin" "/usr/local/bin/jtag already symlinked to $src"
+    return 0
+  fi
+  if [ -L "$HOME/.local/bin/jtag" ] && [ "$(readlink "$HOME/.local/bin/jtag")" = "$src" ]; then
+    module_skip "jtag-bin" "~/.local/bin/jtag already symlinked to $src"
+    return 0
+  fi
+
+  # Tier 1: writable system path.
+  if [ -w "/usr/local/bin" ]; then
+    module_start "jtag-bin" "Symlinking jtag CLI → /usr/local/bin/jtag"
+    ln -sf "$src" "/usr/local/bin/jtag" \
+      || module_fail "jtag-bin" "ln -s to /usr/local/bin failed"
+    module_done "jtag-bin"
+    return 0
+  fi
+
+  # Tier 2: sudo with TTY.
+  if command -v sudo &>/dev/null && [ -t 0 ]; then
+    module_start "jtag-bin" "Symlinking jtag CLI → /usr/local/bin/jtag (needs sudo)"
+    ensure_sudo_warmed
+    sudo ln -sf "$src" "/usr/local/bin/jtag" \
+      || module_fail "jtag-bin" "sudo ln -s to /usr/local/bin failed"
+    module_done "jtag-bin"
+    return 0
+  fi
+
+  # Tier 3: user-space fallback.
+  module_start "jtag-bin" "Symlinking jtag CLI → ~/.local/bin/jtag (user-space fallback, no sudo)"
+  mkdir -p "$HOME/.local/bin"
+  ln -sf "$src" "$HOME/.local/bin/jtag" \
+    || module_fail "jtag-bin" "ln -s to ~/.local/bin failed"
+  case ":$PATH:" in
+    *":$HOME/.local/bin:"*) ;;
+    *) warn "~/.local/bin is not in your PATH. Add: export PATH=\"\$HOME/.local/bin:\$PATH\"" ;;
+  esac
+  module_done "jtag-bin"
+}
+
 # ── mod_tailscale_check ─────────────────────────────────────
 # Tailscale powers cross-machine peer discovery + TLS for the grid
 # story. Optional for pure-localhost installs but the install-time


### PR DESCRIPTION
Post-install, `continuum` was on PATH but `jtag` wasn't. CLAUDE.md + skill docs reference `jtag <command>` as the chat surface. carl-install-smoke runs `./jtag` from inside the install tree, but a real Carl following the docs hits command-not-found. airc-8a5e 2026-05-03 Carl-UX QA bug #1.New `mod_jtag_bin_link` mirrors `mod_continuum_bin_link`'s tier-fallback (writable /usr/local/bin → sudo-with-TTY → user-space) but uses `ln -sf` not `cp` because `src/jtag` resolves `dist/cli-bundle.js` via `BASH_SOURCE` — copying it to /usr/local/bin/jtag would break the relative lookup. Symlink preserves BASH_SOURCE traversal back to the install dir.`continuum` stays on cp (different launcher shape — uses CONTINUUM_HOME, not BASH_SOURCE).