### PR TITLE
fix(smart-build): standalone CLI bundle check + rebuild path (Carl-UX bug #2)

### DIFF
--- a/src/scripts/smart-build.ts
+++ b/src/scripts/smart-build.ts
@@ -115,6 +115,33 @@ function checkGeneratedFiles(): BuildCheck {
   return { name: 'Generated files', needed: false, reason: 'Generated files up to date' };
 }
 
+function checkCliBundle(): BuildCheck {
+  // dist/cli-bundle.js is REQUIRED by src/jtag's fast path. Without it,
+  // jtag falls back to `tsx cli.ts` which can't resolve tsconfig path
+  // aliases at runtime → ERR_MODULE_NOT_FOUND on every fresh invocation.
+  // Pre-fix smart-build only ran build:cli when the TypeScript check
+  // also fired (postbuild was bundled into the TS case at line 236),
+  // so on `npm start` after a clean dist/ wipe but no TS source change,
+  // build:cli silently never ran. airc-8a5e 2026-05-03 Carl-UX QA #2:
+  // "dist/cli-bundle.js NEVER BUILT — npm start runs smart-build but
+  // skips postbuild when TS up-to-date." This is the dedicated check.
+  const bundlePath = 'dist/cli-bundle.js';
+  const bundleTime = getFileModTime(bundlePath);
+  const cliInput = getFileModTime('cli.ts');
+  const compiledJs = getNewestFileTime('dist/**/*.js');
+
+  if (bundleTime === 0) {
+    return { name: 'CLI bundle', needed: true, reason: 'dist/cli-bundle.js does not exist (jtag fast path requires it)' };
+  }
+  if (cliInput > bundleTime) {
+    return { name: 'CLI bundle', needed: true, reason: 'cli.ts newer than dist/cli-bundle.js' };
+  }
+  if (compiledJs > bundleTime) {
+    return { name: 'CLI bundle', needed: true, reason: 'compiled JS newer than dist/cli-bundle.js (TS rebuild requires bundle rebuild)' };
+  }
+  return { name: 'CLI bundle', needed: false, reason: 'dist/cli-bundle.js up to date' };
+}
+
 function checkBrowserBundle(): BuildCheck {
   const bundlePath = 'examples/widget-ui/dist/index.js';
   const bundleTime = getFileModTime(bundlePath);
@@ -187,6 +214,7 @@ async function smartBuild(): Promise<void> {
   const checks: BuildCheck[] = [
     checkGeneratedFiles(),
     checkTypeScriptBuild(),
+    checkCliBundle(),
     checkBrowserBundle()
     // Tarball check disabled for development - only pack for releases with: npm run pack
     // checkTarball()
@@ -219,21 +247,20 @@ async function smartBuild(): Promise<void> {
         break;
       case 'TypeScript':
         runBuildStep('TypeScript compilation', 'npm run build:ts');
-        // ALWAYS run postbuild — not optional. postbuild includes
-        // `npm run build:cli` which builds dist/cli-bundle.js, and
-        // src/jtag's fast path REQUIRES that bundle. Without it,
-        // jtag falls back to `tsx cli.ts` which can't resolve
-        // tsconfig path aliases (@system/core/...) at runtime →
-        // ERR_MODULE_NOT_FOUND on every fresh-install jtag invocation.
-        // Carl-install-smoke chat-probe was failing this way on every
-        // CI run — chat.log artifact (PR #1012) made the silent
-        // failure visible. Pre-fix the postbuild step was gated on
-        // `.continuum/generator/path-mappings.json` existing, but
-        // that file isn't generated until `npm run pack` (release
-        // builds only), so the gate effectively skipped postbuild
-        // forever in CI + fresh installs. The "optional optimization"
-        // comment was wrong — bundle is required, not nice-to-have.
+        // postbuild here covers the TS-rebuild case. The CLI bundle
+        // case below is the explicit fallback when TS is up-to-date
+        // but cli-bundle.js is stale or missing (e.g. clean dist/
+        // without TS source changes, fresh install with cached TS
+        // outputs from a prior pack, etc).
         runBuildStep('Post-build processing', 'npm run postbuild');
+        break;
+      case 'CLI bundle':
+        // Standalone bundle rebuild — TS already up-to-date, just
+        // dist/cli-bundle.js missing or stale. Without this case
+        // smart-build would say "everything up to date" while jtag
+        // is silently broken (no bundle → tsx fallback → path-alias
+        // ERR_MODULE_NOT_FOUND).
+        runBuildStep('CLI bundle (esbuild)', 'npm run build:cli');
         break;
       case 'Browser bundle':
         runBuildStep('Browser esbuild bundle', 'cd examples/widget-ui && node ../../scripts/build-browser-example.js');


### PR DESCRIPTION
Pre-fix smart-build only ran `npm run build:cli` as a side effect of TypeScript-rebuild. When TS source was unchanged but `dist/cli-bundle.js` was missing/stale, smart-build said `everything up to date` while jtag was silently broken (no bundle → tsx fallback → path-alias ERR_MODULE_NOT_FOUND). airc-8a5e 2026-05-03 Carl-UX QA #2.New `checkCliBundle()` + dedicated 'CLI bundle' case in the build loop. Triggers `npm run build:cli` independently when bundle is missing OR cli.ts newer OR any compiled JS newer. Pairs with #1016 (jtag-on-PATH); together they close Carl-UX #1 + #2.