### PR TITLE
fix(ui): kill phantom 'General' tab on startup — remove hardcoded /chat/general default

### DIFF
--- a/src/widgets/main/MainWidget.ts
+++ b/src/widgets/main/MainWidget.ts
@@ -21,7 +21,6 @@ import { Events } from '../../system/core/shared/Events';
 import { jtagGlobal } from '../../system/core/types/GlobalAugmentations';
 import { UI_EVENTS } from '../../system/core/shared/EventConstants';
 import type { UUID } from '../../system/core/types/CrossPlatformUUID';
-import { ROOM_UNIQUE_IDS } from '../../system/data/constants/RoomConstants';
 import { getWidgetForType, buildContentPath, parseContentPath, getRightPanelConfig, initializeRecipeLayouts } from './shared/ContentTypeRegistry';
 import { PositronContentStateAdapter } from '../shared/services/state/PositronContentStateAdapter';
 import { PositronWidgetState } from '../shared/services/state/PositronWidgetState';
@@ -41,7 +40,9 @@ export class MainWidget extends ReactiveWidget {
   ] as CSSResultGroup;
 
   // Reactive state
-  @reactive() private currentPath = `/chat/${ROOM_UNIQUE_IDS.GENERAL}`;
+  // Joel 2026-05-03: was defaulted to `/chat/general` — same phantom-tab
+  // antipattern. setupUrlRouting() sets currentPath from the actual URL.
+  @reactive() private currentPath = '';
 
   // Non-reactive state (internal tracking)
   private contentManager!: ContentInfoManager;
@@ -175,18 +176,28 @@ export class MainWidget extends ReactiveWidget {
     });
 
     // Initialize from current URL
-    let initialPath = window.location.pathname;
+    const initialPath = window.location.pathname;
+    this.currentPath = initialPath;
 
-    // Default route: / or /chat without room → /chat/general
-    const defaultPath = `/chat/${ROOM_UNIQUE_IDS.GENERAL}`;
-    if (!initialPath || initialPath === '/' || initialPath === '/chat' || initialPath === '/chat/') {
-      initialPath = defaultPath;
-      window.history.replaceState({ path: initialPath }, '', initialPath);
-      this.log(`Redirected to default route: ${initialPath}`);
+    // Joel 2026-05-03: NO default tab on root. The previous redirect from
+    // `/` → `/chat/general` was the source of the phantom "General" tab
+    // that appeared with a stale UUID + "Loading members..." forever
+    // (same antipattern family as the long-fixed stringToUUID('General')
+    // ghost — see system/data/domains/DefaultEntities.ts header). Empty
+    // root means empty content area; persisted tabs (if any) restore
+    // via initializeContentTabs() above and the user picks from the
+    // sidebar / opens what they want.
+    const isRootPath = !initialPath || initialPath === '/' || initialPath === '/chat' || initialPath === '/chat/';
+    if (isRootPath) {
+      this.log('Root path — no default tab; persisted tabs (if any) restore from contentState');
+      return;
     }
 
-    this.currentPath = initialPath;
     const { type, entityId } = parseContentPath(initialPath);
+    if (!type) {
+      this.log(`Unrecognized initial route '${initialPath}' — no tab opened`);
+      return;
+    }
     this.log(`Initial route: ${type}/${entityId || 'default'}`);
 
     // Wait for JTAG client to be connected before resolving routes.
@@ -405,6 +416,10 @@ export class MainWidget extends ReactiveWidget {
 
   async navigateToPath(newPath: string): Promise<void> {
     const { type, entityId } = parseContentPath(newPath);
+    if (!type) {
+      this.log(`Unrecognized navigation path '${newPath}' — ignoring`);
+      return;
+    }
 
     if (type === 'chat' && entityId) {
       await this.ensureRoomExists(entityId);

--- a/src/widgets/main/shared/ContentTypeRegistry.ts
+++ b/src/widgets/main/shared/ContentTypeRegistry.ts
@@ -85,7 +85,7 @@ export function getContentTypeConfig(contentType: string): ContentTypeConfig | u
  * /live/general → { type: 'live', entityId: 'general' }
  * /factory      → { type: 'factory' }
  */
-export function parseContentPath(path: string): { type: string; entityId?: string } {
+export function parseContentPath(path: string): { type?: string; entityId?: string } {
     const normalized = path.startsWith('/') ? path : `/${path}`;
 
     // Match by view — sort longest first to prevent /grid matching before /grid-overview
@@ -111,7 +111,10 @@ export function parseContentPath(path: string): { type: string; entityId?: strin
         }
     }
 
-    return { type: 'chat', entityId: undefined };
+    // Joel 2026-05-03: was `return { type: 'chat', ... }` — silent default
+    // that opened a phantom General tab on every unknown path. No match =
+    // no tab. Callers must handle undefined type explicitly.
+    return { type: undefined, entityId: undefined };
 }
 
 /**


### PR DESCRIPTION
## Summary

User-facing symptom (Joel 2026-05-03): every fresh page load opened a phantom "General" tab with a stale UUID + "Loading members..." forever. Clicking General in the sidebar then opened a SECOND, real chat tab next to the broken one.

Same antipattern family as the long-fixed `stringToUUID('General')` ghost (see `src/system/data/domains/DefaultEntities.ts` header) — relocated to the URL-default + URL-fallback layers.

## Roots removed

1. **MainWidget.setupUrlRouting()** explicitly redirected `/`, `/chat`, `/chat/` → `/chat/${ROOM_UNIQUE_IDS.GENERAL}`. Every visit to root hard-replaced the URL and triggered `openContentFromUrl`, which on races between `RoutingService.resolve()` retries + persisted-tab restore wound up creating an entity-less or stale-UUID tab that ChatWidget rendered as title=General + body=raw UUID + "Loading members..." forever.
2. **parseContentPath()** fallback for unknown paths returned `{ type: 'chat', entityId: undefined }` — second silent default that funneled any unrecognized URL into a broken chat tab.
3. **MainWidget.currentPath** default initializer was `\`/chat/${ROOM_UNIQUE_IDS.GENERAL}\`` — third silent default contributing to the drift.

## After fix

- Root path opens NO default tab. Persisted tabs (if any) restore via `initializeContentTabs()`; user picks from sidebar.
- `parseContentPath` returns `{ type: undefined, entityId: undefined }` on no match. Caller is now required to handle that explicitly.
- `setupUrlRouting` + `navigateToPath` both early-return when type is undefined.
- `currentPath` default initializer changed to `''`.
- Unused `ROOM_UNIQUE_IDS` import removed from MainWidget.

## Verification

- TypeScript clean (`npm run build:ts`).
- Validated live: rebuilt browser bundle docker-cp'd into running widget-server container; confirmed served bundle contains the new guards (`grep 'no default tab'` returns 1, `grep 'Root path'` returns 1).
- Browser hard-reload required to pick up new bundle.

Joel quote: > stringToUUID is WRONG! REMOVE THAT LAUNCH OF A DEFAULT TAB. ITS MORE OF THIS IDIOTIC stringToUUID('GENERAL') THIS IS WRONG> search for 'general' as its uniqueID when matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)