### PR TITLE
fix(jtag): resolve symlinks before deriving SCRIPT_DIR (Carl-Windows chat-probe blocker)

### DIFF
--- a/src/jtag
+++ b/src/jtag
@@ -2,7 +2,20 @@
 # JTAG Terminal Portal - Pure CLI client (no server startup)
 # Uses pre-bundled CLI for fast startup (~0.6s vs ~2.6s with tsx)
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve symlinks BEFORE deriving SCRIPT_DIR. install.sh's
+# mod_jtag_bin_link symlinks $HOME/.local/bin/jtag → src/jtag, so when
+# Carl runs `jtag …`, BASH_SOURCE[0] is the symlink path
+# (~/.local/bin/jtag) and dirname is ~/.local/bin — neither
+# `dist/cli-bundle.js` nor `cli.ts` lives there, so the bundle check
+# silently misses and the tsx fallback fires `npx tsx
+# ~/.local/bin/cli.ts` which dies with ERR_MODULE_NOT_FOUND.
+# `readlink -f` walks the symlink chain to the actual src/jtag, so
+# SCRIPT_DIR resolves to the real src/ directory regardless of how
+# the user invoked the script.
+# Caught 2026-05-03 by carl-install-smoke on Windows/bigmama-1
+# (continuum-b69f) after #93's earlier fix at 36e85d212 only handled
+# direct `./jtag` invocations, not the symlinked-from-PATH case.
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 BUNDLE="$SCRIPT_DIR/dist/cli-bundle.js"
 
 # Check for --verbose flag to show connection message


### PR DESCRIPTION
## Summary

Fixes the chat-probe failure on Carl-Windows install path uncovered by carl-install-smoke run on Windows/bigmama-1 today.

src/jtag derived SCRIPT_DIR from BASH_SOURCE without resolving symlinks. install.sh 's mod_jtag_bin_link symlinks ~/.local/bin/jtag → src/jtag, so when Carl runs jtag command from PATH, BASH_SOURCE[0] is the symlink path. dirname gives ~/.local/bin — not the directory holding cli-bundle.js or cli.ts.

Result: bundle check silently misses, tsx fallback fires npx tsx ~/.local/bin/cli.ts → ERR_MODULE_NOT_FOUND → chat probe fails with exit 1, the entire chat-probe phase of the install fails.

## Fix

readlink -f walks the symlink chain to the real src/jtag, so SCRIPT_DIR resolves to the actual src/ directory regardless of how the user invoked the script. Bundle check and tsx fallback now both work whether jtag was run directly (./jtag from a checkout) or via the symlinked PATH entry (jtag from anywhere).

## Why #93 (36e85d212) didn't cover this

#93 changed the tsx fallback from npx tsx cli.ts (cwd-relative) to npx tsx $SCRIPT_DIR/cli.ts (absolute via SCRIPT_DIR). That fixed the direct-./jtag case but left SCRIPT_DIR derivation symlink-unaware, so the much more common symlinked-from-PATH case still resolved to the wrong dir.

## Test plan

- [x] bash -n src/jtag passes
- [ ] CI green (TS compile + tests)
- [ ] Manual: ln -sf /path/to/repo/src/jtag /tmp/jtag-symlink, then /tmp/jtag-symlink --version (should not ERR_MODULE_NOT_FOUND)
- [ ] carl-install-smoke chat probe passes on Windows after :canary tag refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)