### PR TITLE
fix(continuum-update): handle divergent-branches by fast-forwarding to origin/main (Carl-UX #101)

### DIFF
--- a/bin/continuum
+++ b/bin/continuum
@@ -587,7 +587,21 @@ cmd_update() {
   fi
   cd "$COMPOSE_DIR"
   echo -e "${BLUE}📥 Updating...${RESET}"
-  git pull origin main
+  # Was `git pull origin main` — fails with 'divergent branches' whenever
+  # the local checkout has commits not on main (canary worktrees, agent
+  # tab branches, anything that's wandered off main). Carl-UX QA #101
+  # from codex-b741 2026-05-03: every continuum-update on Joel's canary
+  # install bailed here. Switch to a destructive-but-correct fast-forward:
+  # fetch + reset --hard to origin/main. The install dir is meant to be
+  # a managed deployment, not a place to keep local edits — anyone with
+  # commits to keep should be working in a separate worktree, which the
+  # bare-repo + worktree pattern already supports.
+  git fetch origin main || { echo -e "${RED}❌ git fetch failed${RESET}"; exit 1; }
+  if ! git diff --quiet HEAD || ! git diff --cached --quiet; then
+    echo -e "${YELLOW}⚠️  Uncommitted changes in $COMPOSE_DIR — stashing as 'continuum-update-backup-$(date +%s)'${RESET}"
+    git stash push -u -m "continuum-update-backup-$(date +%s)" || true
+  fi
+  git reset --hard origin/main || { echo -e "${RED}❌ git reset failed${RESET}"; exit 1; }
   echo -e "${BLUE}🔨 Rebuilding...${RESET}"
   docker compose build --parallel
   echo -e "${BLUE}🔄 Restarting...${RESET}"


### PR DESCRIPTION
## Summary

Carl-UX QA #101 (codex-b741, 2026-05-03 18:33Z): Joel's canary install hit `fatal: Need to specify how to reconcile divergent branches` on every `continuum update`.

Pre-fix `cmd_update` ran `git pull origin main` unconditionally — fails whenever the local install dir has any commits not on main, which happens with bare-repo + worktree setups, agent tab branches, or any user who's just touched something locally.

## Fix

The install dir is a managed deployment, not a workspace for local edits. Contract: align with origin/main.

- `git fetch origin main` (no merge conflict surface)
- Stash uncommitted/staged changes with timestamped name as safety net
- `git reset --hard origin/main` to align with remote
- Both git commands fail-fast with clear error

The stash name lets users recover with `git stash apply stash^{/continuum-update-backup-...}` if they had real work in flight.

## Verification

- `bash -n bin/continuum` syntax-clean
- Repro case: install dir on a feature branch + canary ahead of main → pre-fix bails, post-fix succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)