### PR TITLE
fix(install): mirror config.env to Windows user home on WSL2 (Carl-Windows install blocker)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -792,6 +792,44 @@ else
   ok "Config exists: $CONFIG_FILE"
 fi
 
+# WSL2 + Docker Desktop quirk: the bind mount `~/.continuum/config.env` in
+# docker-compose.yml expands `~` on the Docker daemon side. On Windows the
+# daemon runs as the Windows user so `~` resolves to C:\Users\<WinUser>,
+# NOT the WSL user's /home/<linuxUser>. Without the file existing on the
+# Windows-side path, Docker auto-vivifies an EMPTY DIRECTORY there — and
+# then `compose up` fails with "mounting a directory onto a file" when it
+# tries to mount that dir over /root/.continuum/config.env (a file path
+# inside the container). Caught live by Carl-Windows install on
+# bigmama-1 (continuum-b69f, 2026-05-03).
+#
+# Fix: on WSL2, mirror config.env to the Windows user's home so the file
+# mount has a valid source. The OTHER bind mounts (`~/.continuum` dir)
+# survive Docker's auto-vivify because dir-on-dir mount is fine, but the
+# file mount needs the source to exist first.
+#
+# This is a no-op on Linux (no /mnt/c) and Mac (no /proc/version match).
+if grep -qi microsoft /proc/version 2>/dev/null && [ -d /mnt/c ]; then
+  WIN_USER="$(cmd.exe /c 'echo %USERNAME%' 2>/dev/null | tr -d '\r' | tr -d '\n')"
+  if [ -n "$WIN_USER" ] && [ -d "/mnt/c/Users/$WIN_USER" ]; then
+    WIN_CONTINUUM="/mnt/c/Users/$WIN_USER/.continuum"
+    mkdir -p "$WIN_CONTINUUM"
+    # If Docker auto-vivified an empty DIRECTORY where the file should
+    # be, blow it away so we can write the file. rmdir refuses
+    # non-empty dirs (so we don't clobber real user data); rm -rf only
+    # if rmdir failed AND the dir is empty.
+    if [ -d "$WIN_CONTINUUM/config.env" ]; then
+      rmdir "$WIN_CONTINUUM/config.env" 2>/dev/null \
+        || warn "Windows-side $WIN_CONTINUUM/config.env is a non-empty directory (likely user data); leaving it. May still hit the mount error — manually rm -rf and re-run if needed."
+    fi
+    if [ ! -e "$WIN_CONTINUUM/config.env" ]; then
+      cp "$CONFIG_FILE" "$WIN_CONTINUUM/config.env"
+      ok "Mirrored config.env to Windows path: $WIN_CONTINUUM/config.env"
+    fi
+  else
+    warn "WSL2 detected but Windows username/home not found; config.env may not mount on Docker Desktop."
+  fi
+fi
+
 # ── 5. TLS certs (Tailscale) ──────────────────────────────
 PHASE="TLS certs (optional)"
 TS_HOSTNAME=""


### PR DESCRIPTION
## Summary

Fixes Carl-Windows install path failure caught live on bigmama-1 today (continuum-b69f, 2026-05-03).

`docker-compose.yml` binds `~/.continuum/config.env:/root/.continuum/config.env:ro`. On WSL2 + Docker Desktop, the docker daemon runs as the **Windows** user, so `~` resolves to `C:\Users\<WinUser>` — NOT the WSL user's `/home/<linuxUser>` where install.sh creates `config.env`. Docker can't find the source file.

Worse: when source is missing, Docker auto-vivifies an empty **directory** at the expected path. The next `compose up` attempts to mount that directory over `/root/.continuum/config.env` (a file path inside the container) → mount error: *"a directory onto a file (or vice-versa)"*. install.sh aborts. widget-server never starts. Carl is stuck.

## Fix

After install.sh creates `$CONTINUUM_DATA/config.env` in the WSL home, detect WSL2 (microsoft in /proc/version + `/mnt/c` exists), look up the Windows username via `cmd.exe /c 'echo %USERNAME%'`, and mirror the file to `/mnt/c/Users/<WinUser>/.continuum/config.env`. If a prior failed install left an empty directory there, `rmdir` it (safe — refuses non-empty dirs, so real user data is preserved).

The other bind mounts in compose (e.g. `~/.continuum:/root/.continuum`) are dir-on-dir mounts — Docker's auto-vivify is fine for those because the kind matches. Only the **file** mount `config.env` needed pre-existing source.

No-op on Linux native (no `/proc/version` microsoft match, no `/mnt/c`) and Mac.

## Test plan

- [x] bash -n install.sh passes
- [ ] CI green
- [ ] On WSL2 + Docker Desktop: install.sh from this branch completes past widget-server start (was failing 43s in pre-fix)
- [ ] On Linux native: no behavior change (the new block is a noop guard-then-block)
- [ ] On Mac: no behavior change

## Follow-up (not in this PR)

Other bind-mount paths using `~` may have subtle WSL2 issues too — worth a sweep once we confirm the file mount is the only blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
