### PR TITLE
fix(install): default CONTINUUM_REF to canary (Carl path was 79 commits stale)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -665,19 +665,25 @@ PHASE="clone / update repo"
 # every fix to src/jtag, src/scripts/install.sh, etc landed via PR
 # but couldn't be validated by carl-install-smoke until merged. Joel:
 # "months of trying to get continuum working out-of-box for Carl."
+# Default ref is canary, NOT origin/HEAD (= main). main is intentionally
+# behind canary until release cadence promotes the branch on schedule;
+# 2026-05-03 main is 79 commits BEHIND canary, including critical install
+# fixes (mod_jtag_bin_link, WSL2 config.env mirror, .env image-tag writer,
+# resolveRoomIdentifier, stripLeakedToolMarkup, phantom-tab sanitize,
+# socket chmod 666, etc). Default Carl install used to clone main and
+# fail at line 769 with "mod_jtag_bin_link: command not found".
+# Per Joel 2026-05-03: "Everyone uses current code period."
+DEFAULT_CONTINUUM_REF="canary"
+RESOLVED_CONTINUUM_REF="${CONTINUUM_REF:-$DEFAULT_CONTINUUM_REF}"
+
 if [ -d "$INSTALL_DIR/.git" ]; then
   info "Updating existing installation..."
   cd "$INSTALL_DIR"
   git pull --ff-only 2>/dev/null || warn "Could not update — using existing version"
 else
-  if [ -n "${CONTINUUM_REF:-}" ]; then
-    info "Cloning Continuum at ref ${CONTINUUM_REF}..."
-    git clone --depth 1 --branch "$CONTINUUM_REF" "$REPO" "$INSTALL_DIR" 2>/dev/null \
-      || git clone "$REPO" "$INSTALL_DIR" && (cd "$INSTALL_DIR" && git checkout "$CONTINUUM_REF")
-  else
-    info "Cloning Continuum..."
-    git clone --depth 1 "$REPO" "$INSTALL_DIR"
-  fi
+  info "Cloning Continuum at ref $RESOLVED_CONTINUUM_REF..."
+  git clone --depth 1 --branch "$RESOLVED_CONTINUUM_REF" "$REPO" "$INSTALL_DIR" 2>/dev/null \
+    || (git clone "$REPO" "$INSTALL_DIR" && cd "$INSTALL_DIR" && git checkout "$RESOLVED_CONTINUUM_REF")
   cd "$INSTALL_DIR"
 fi
 


### PR DESCRIPTION
## Summary

Default Carl install was cloning origin/HEAD = main, which is 79 commits behind canary. install.sh:769 calls mod_jtag_bin_link from #1016 (canary only) so every default install hit command-not-found at jtag bin link.

Per Joel: Everyone uses current code period.

## Fix

Default ref to canary; explicit override via `CONTINUUM_REF=` still works.

## Context

17 install/install-path fixes shipped to canary today (#1014/#1016/#1017/#1018/#1019/#1020/#1021/#1022/#1023/#1024/#1025/#1027/#1028/#1030/#1032/#1033 etc) — none reach Carl until canary is the default.
