### PR TITLE
fix(verify): drop continuum-core from DEFAULT_IMAGES (#1038 follow-up)

### DIFF
--- a/scripts/verify-image-revisions.sh
+++ b/scripts/verify-image-revisions.sh
@@ -52,7 +52,7 @@ if [[ -z "${TAG:-}" ]]; then
 fi
 
 REGISTRY_HOST="ghcr.io"
-DEFAULT_IMAGES="ghcr.io/cambriantech/continuum-core:ghcr.io/cambriantech/continuum-core-vulkan:ghcr.io/cambriantech/continuum-core-cuda:ghcr.io/cambriantech/continuum-livekit-bridge:ghcr.io/cambriantech/continuum-node:ghcr.io/cambriantech/continuum-model-init:ghcr.io/cambriantech/continuum-widgets"
+DEFAULT_IMAGES="ghcr.io/cambriantech/continuum-core-vulkan:ghcr.io/cambriantech/continuum-core-cuda:ghcr.io/cambriantech/continuum-livekit-bridge:ghcr.io/cambriantech/continuum-node:ghcr.io/cambriantech/continuum-model-init:ghcr.io/cambriantech/continuum-widgets"
 IMAGES="${IMAGES:-$DEFAULT_IMAGES}"
 
 STALE_ARM64_OUT="${STALE_ARM64_OUT:-/dev/null}"


### PR DESCRIPTION
## Summary

PR #1038 dropped the `continuum-core` build target (architectural rule: lack of GPU integration is forbidden), but `scripts/verify-image-revisions.sh:55` still listed `ghcr.io/cambriantech/continuum-core` in `DEFAULT_IMAGES`. As a result, every `verify-after-rebuild` gate keeps reporting STALE on continuum-core (with the frozen `2efa5dedc792` label from before #1038 merged), unconditionally blocking #1035 and any future canary→main promotion.

This trims the dropped variant from the verify list. Remaining checked images: `continuum-core-vulkan`, `continuum-core-cuda`, `continuum-livekit-bridge`, `continuum-node`, `continuum-model-init`, `continuum-widgets`.

## Test plan

- [ ] `verify-after-rebuild` on this PR no longer reports continuum-core STALE
- [ ] After merge, `verify-after-rebuild` on #1035 unblocks (only legitimate stale entries remain — vulkan amd64 + arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)