### PR TITLE
fix(ui): canonicalize restored content tabs

### DIFF
--- a/src/system/data/entities/UserStateEntity.ts
+++ b/src/system/data/entities/UserStateEntity.ts
@@ -10,7 +10,7 @@ import type { UUID } from '../../core/types/CrossPlatformUUID';
 
 // Content types generated from recipe JSON files — DO NOT hardcode here
 // Regenerate: npx tsx generator/generate-content-types.ts
-import { type ContentType as GeneratedContentType, isContentType, CONTENT_TYPES } from '../../../shared/generated/ContentTypes';
+import { type ContentType as GeneratedContentType, isContentType, CONTENT_TYPES, CONTENT_TYPE_CONFIGS } from '../../../shared/generated/ContentTypes';
 export type ContentType = GeneratedContentType;
 export type ContentPriority = 'low' | 'normal' | 'high' | 'urgent';
 
@@ -24,6 +24,18 @@ export interface ContentItem {
   lastAccessedAt: Date;
   priority: ContentPriority;
   metadata?: Record<string, unknown>; // Type-specific metadata (scroll position, filters, etc.)
+}
+
+function isSameContentSurface(a: ContentItem['type'], b: ContentItem['type']): boolean {
+  if (a === b) return true;
+
+  const aConfig = CONTENT_TYPE_CONFIGS[a];
+  const bConfig = CONTENT_TYPE_CONFIGS[b];
+  return Boolean(
+    aConfig?.entityType &&
+    aConfig.entityType === bConfig?.entityType &&
+    (aConfig.view || a) === (bConfig.view || b)
+  );
 }
 
 /**
@@ -41,14 +53,13 @@ export function contentItemsMatch(
   a: Pick<ContentItem, 'type'> & Partial<Pick<ContentItem, 'entityId' | 'uniqueId'>>,
   b: Pick<ContentItem, 'type'> & Partial<Pick<ContentItem, 'entityId' | 'uniqueId'>>
 ): boolean {
-  // Different types = different content
-  if (a.type !== b.type) return false;
-
   // Singleton content (no entityId or uniqueId) - match by type only
   // e.g., settings, help, theme tabs that have no associated entity
   const aIssingleton = !a.entityId && !a.uniqueId;
   const bIsSingleton = !b.entityId && !b.uniqueId;
-  if (aIssingleton && bIsSingleton) return true;
+  if (aIssingleton && bIsSingleton) return a.type === b.type;
+
+  if (!isSameContentSurface(a.type, b.type)) return false;
 
   // Same entityId = same content
   if (a.entityId && b.entityId && a.entityId === b.entityId) return true;

--- a/src/system/state/ContentStateService.ts
+++ b/src/system/state/ContentStateService.ts
@@ -64,10 +64,11 @@ class ContentStateServiceImpl {
 
     // Deduplicate input — server may send duplicates from stale persisted state
     const deduped = this.deduplicateItems(openItems);
+    const resolvedCurrentItemId = this.resolveCurrentItemId(openItems, deduped, currentItemId);
 
     this.state = {
       openItems: deduped,
-      currentItemId
+      currentItemId: resolvedCurrentItemId
     };
     this.initialized = true;
     console.log(`📋 ContentState: Initialized with ${deduped.length} items${deduped.length < openItems.length ? ` (removed ${openItems.length - deduped.length} duplicates)` : ''}`);
@@ -81,15 +82,16 @@ class ContentStateServiceImpl {
   update(openItems: ContentItem[], currentItemId?: UUID): void {
     // Deduplicate input
     const deduped = this.deduplicateItems(openItems);
+    const resolvedCurrentItemId = this.resolveCurrentItemId(openItems, deduped, currentItemId);
 
     // Fast path: check if anything actually changed
-    if (this.initialized && !this.hasStateChanged(deduped, currentItemId)) {
+    if (this.initialized && !this.hasStateChanged(deduped, resolvedCurrentItemId)) {
       return;
     }
 
     this.state = {
       openItems: deduped,
-      currentItemId
+      currentItemId: resolvedCurrentItemId
     };
     this.initialized = true;
     console.log(`📋 ContentState: Updated with ${deduped.length} items`);
@@ -112,6 +114,23 @@ class ContentStateServiceImpl {
       }
     }
     return seen;
+  }
+
+  private resolveCurrentItemId(
+    originalItems: ContentItem[],
+    dedupedItems: ContentItem[],
+    currentItemId?: UUID
+  ): UUID | undefined {
+    if (!currentItemId) return dedupedItems[0]?.id;
+    if (dedupedItems.some(item => item.id === currentItemId)) return currentItemId;
+
+    const originalCurrent = originalItems.find(item => item.id === currentItemId);
+    if (originalCurrent) {
+      const canonical = dedupedItems.find(item => contentItemsMatch(item, originalCurrent));
+      if (canonical) return canonical.id;
+    }
+
+    return dedupedItems[0]?.id;
   }
 
   private hasStateChanged(openItems: ContentItem[], currentItemId?: UUID): boolean {

--- a/src/widgets/main/MainWidget.ts
+++ b/src/widgets/main/MainWidget.ts
@@ -55,35 +55,6 @@ export class MainWidget extends ReactiveWidget {
   // Widget cache - persist widgets instead of destroying them on tab switch
   private widgetCache = new Map<string, HTMLElement>();
 
-  /**
-   * Drop the legacy phantom General tab.
-   *
-   * Canary previously opened `/chat/general` by default and older state code
-   * persisted a tab whose `entityId`/`id` was the literal uniqueId "general",
-   * not the room UUID. That tab cannot hydrate members correctly and survives
-   * reloads because persisted contentState restores it before routing runs.
-   * A real General tab has `uniqueId: "general"` plus a UUID entityId; keep
-   * that if the user explicitly opened it.
-   */
-  private sanitizePersistedContentItems(openItems: ContentItem[], currentItemId?: UUID): {
-    openItems: ContentItem[];
-    currentItemId?: UUID;
-  } {
-    const sanitized = openItems.filter(item => {
-      const isLegacyGeneral =
-        item.type === 'chat' &&
-        item.title === 'General' &&
-        (item.id === 'general' || item.entityId === 'general');
-
-      return !isLegacyGeneral;
-    });
-
-    return {
-      openItems: sanitized,
-      currentItemId: sanitized.some(item => item.id === currentItemId) ? currentItemId : undefined
-    };
-  }
-
   constructor() {
     super({
       widgetName: 'MainWidget'
@@ -113,7 +84,10 @@ export class MainWidget extends ReactiveWidget {
       () => this.userState,
       {
         name: 'MainWidget',
-        onStateChange: () => offMainThread(() => this.syncUserStateToContentState(), 1000),
+        onStateChange: () => offMainThread(() => {
+          void this.syncUserStateToContentState()
+            .catch(error => console.error('❌ MainWidget: syncUserStateToContentState failed:', error));
+        }, 1000),
         onViewSwitch: (contentType, entityId) => offMainThread(() => this.switchContentView(contentType, entityId)),
         onUrlUpdate: (contentType, identifier) => {
           queueMicrotask(() => {
@@ -531,7 +505,7 @@ export class MainWidget extends ReactiveWidget {
     if (userStateLoaded) {
       const rawOpenItems = this.userState!.contentState.openItems || [];
       const rawCurrentItemId = this.userState!.contentState.currentItemId;
-      const { openItems, currentItemId } = this.sanitizePersistedContentItems(rawOpenItems, rawCurrentItemId);
+      const { openItems, currentItemId } = await this.sanitizePersistedContentItems(rawOpenItems, rawCurrentItemId);
       console.log(`✅ initializeContentTabs: Found ${rawOpenItems.length} items, using ${openItems.length}, currentItemId=${currentItemId}`);
       contentState.initialize(openItems, currentItemId);
       this.log(`Initialized global contentState with ${openItems.length} items`);
@@ -542,15 +516,86 @@ export class MainWidget extends ReactiveWidget {
     }
   }
 
-  private syncUserStateToContentState(): void {
+  private async syncUserStateToContentState(): Promise<void> {
     if (!this.userState?.contentState) return;
 
-    const { openItems, currentItemId } = this.sanitizePersistedContentItems(
+    const { openItems, currentItemId } = await this.sanitizePersistedContentItems(
       this.userState.contentState.openItems || [],
       this.userState.contentState.currentItemId
     );
     contentState.update(openItems, currentItemId);
     this.log(`Synced ${openItems.length} items from server to global contentState`);
+  }
+
+  private async sanitizePersistedContentItems(openItems: ContentItem[], currentItemId?: UUID): Promise<{
+    openItems: ContentItem[];
+    currentItemId?: UUID;
+  }> {
+    type ValidationResult =
+      | { status: 'keep'; item: ContentItem }
+      | { status: 'drop'; item: ContentItem };
+
+    const validatedItems = await Promise.all(openItems.map(async (item): Promise<ValidationResult> => {
+      const identifier = item.uniqueId || item.entityId;
+      if (!identifier || !ContentService.getCollectionForContentType(item.type)) {
+        return { status: 'keep', item };
+      }
+
+      let resolved: Awaited<ReturnType<typeof RoutingService.resolve>> | null = null;
+      try {
+        resolved = await RoutingService.resolve(item.type, identifier);
+        if (!resolved && item.entityId && item.entityId !== identifier) {
+          resolved = await RoutingService.resolve(item.type, item.entityId);
+        }
+      } catch (error) {
+        console.warn(`⚠️ MainWidget: could not validate persisted ${item.type}/${identifier}:`, error);
+        return { status: 'keep', item };
+      }
+
+      if (!resolved) {
+        console.warn(`⚠️ MainWidget: dropping stale persisted tab ${item.type}/${identifier} (${item.title})`);
+        return { status: 'drop', item };
+      }
+
+      return {
+        status: 'keep',
+        item: {
+          ...item,
+          entityId: resolved.id,
+          uniqueId: resolved.uniqueId,
+          title: resolved.displayName || item.title,
+        }
+      };
+    }));
+
+    const sanitized = validatedItems
+      .filter((result): result is Extract<ValidationResult, { status: 'keep' }> => result.status === 'keep')
+      .map(result => result.item);
+
+    const deduped: ContentItem[] = [];
+    const duplicateCurrentTargets = new Map<UUID, UUID>();
+    for (const item of sanitized) {
+      const existing = deduped.find(candidate => {
+        const candidatePath = buildContentPath(candidate.type, candidate.uniqueId || candidate.entityId);
+        const itemPath = buildContentPath(item.type, item.uniqueId || item.entityId);
+        return candidatePath === itemPath;
+      });
+      if (existing) {
+        duplicateCurrentTargets.set(item.id, existing.id);
+        continue;
+      }
+      deduped.push(item);
+    }
+
+    let resolvedCurrentItemId = currentItemId;
+    if (resolvedCurrentItemId && duplicateCurrentTargets.has(resolvedCurrentItemId)) {
+      resolvedCurrentItemId = duplicateCurrentTargets.get(resolvedCurrentItemId);
+    }
+    if (!resolvedCurrentItemId || !deduped.some(item => item.id === resolvedCurrentItemId)) {
+      resolvedCurrentItemId = deduped[0]?.id;
+    }
+
+    return { openItems: deduped, currentItemId: resolvedCurrentItemId };
   }
 
   // === HEADER CONTROLS ===


### PR DESCRIPTION
## Summary
- validate restored entity-backed content tabs against the current database before rendering
- canonicalize stale room tabs by resolving `uniqueId` through `RoutingService`, so old UUIDs like the bogus General tab recover to the real room entity
- dedupe equivalent restored surfaces across content recipes that render the same room/chat view
- remap `currentItemId` when the focused tab was a dropped stale duplicate

## Why
A reseed/schema change can leave `user_states.content_state` with a stale General tab whose old UUID no longer exists. The UI then restores a bogus tab (`Loading members...`, old messages) next to the real General room. This fixes the persisted-state recovery path instead of requiring localStorage/manual DB cleanup.

## Validation
- `npm run build:ts`
- pre-push gate: TypeScript clean, ESLint baseline-tolerant pass
- local fixture: persisted good `chat/general` + stale `academy-training/general` collapses to one canonical General tab and preserves focus
