### PR TITLE
Fix empty content state after closing last tab

### DIFF
--- a/src/system/state/ContentService.ts
+++ b/src/system/state/ContentService.ts
@@ -235,6 +235,9 @@ class ContentServiceImpl {
         } : undefined;
         pageState.setContent(newCurrent.type, newCurrent.entityId, resolved);
         this.updateUrl(newCurrent.type, newCurrent.uniqueId || newCurrent.entityId);
+      } else if (wasCurrentItem) {
+        pageState.clear();
+        this.clearUrl();
       }
 
       // 5. Persist to server (background)
@@ -262,6 +265,12 @@ class ContentServiceImpl {
     const newPath = buildContentPath(contentType, identifier);
     if (window.location.pathname !== newPath) {
       window.history.pushState({ path: newPath }, '', newPath);
+    }
+  }
+
+  private clearUrl(): void {
+    if (window.location.pathname !== '/') {
+      window.history.pushState({ path: '/' }, '', '/');
     }
   }
 

--- a/src/system/state/PageStateService.ts
+++ b/src/system/state/PageStateService.ts
@@ -53,7 +53,7 @@ export interface PageState {
 /**
  * Callback type for page state subscribers
  */
-export type PageStateListener = (state: PageState) => void;
+export type PageStateListener = (state: PageState | null) => void;
 
 /**
  * PageStateService implementation
@@ -151,6 +151,8 @@ class PageStateServiceImpl {
    */
   clear(): void {
     this.state = null;
+    console.log('📄 PageState: cleared');
+    this.notifyListeners();
   }
 
   /**
@@ -164,8 +166,6 @@ class PageStateServiceImpl {
    * Notify all listeners of state change
    */
   private notifyListeners(): void {
-    if (!this.state) return;
-
     for (const listener of this.listeners) {
       try {
         listener(this.state);

--- a/src/tests/unit/PageStateService.test.ts
+++ b/src/tests/unit/PageStateService.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { pageState, type PageState } from '../../system/state/PageStateService';
+
+describe('PageStateService', () => {
+  afterEach(() => {
+    pageState.clear();
+  });
+
+  it('notifies subscribers with null when page state is cleared', () => {
+    const observed: Array<PageState | null> = [];
+
+    pageState.setContent('chat', 'general', {
+      id: '2789ca42-a387-43f2-815e-b0fdc60c9519',
+      uniqueId: 'general',
+      displayName: 'General'
+    });
+
+    const unsubscribe = pageState.subscribe((state) => {
+      observed.push(state);
+    });
+
+    pageState.clear();
+    unsubscribe();
+
+    expect(observed).toHaveLength(2);
+    expect(observed[0]?.contentType).toBe('chat');
+    expect(observed[0]?.entityId).toBe('general');
+    expect(observed[1]).toBeNull();
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    const observed: Array<PageState | null> = [];
+    const unsubscribe = pageState.subscribe((state) => {
+      observed.push(state);
+    });
+
+    unsubscribe();
+    pageState.setContent('settings');
+    pageState.clear();
+
+    expect(observed).toEqual([]);
+  });
+});

--- a/src/widgets/chat/room-list/RoomListWidget.ts
+++ b/src/widgets/chat/room-list/RoomListWidget.ts
@@ -261,6 +261,10 @@ export class RoomListWidget extends ReactiveListWidget<RoomEntity> {
     // Subscribe to pageState - single source of truth for current room
     this.createMountEffect(() => {
       const unsubscribe = pageState.subscribe((state) => {
+        if (!state) {
+          this.currentRoomId = null;
+          return;
+        }
         if (state.entityId) {
           const matchingRoom = this.entities.find(
             (room: RoomEntity) => room.id === state.entityId || room.uniqueId === state.entityId

--- a/src/widgets/main/MainWidget.ts
+++ b/src/widgets/main/MainWidget.ts
@@ -409,6 +409,24 @@ export class MainWidget extends ReactiveWidget {
     this.log(`Rendered ${widgetTag} for ${contentType}${entityId ? ` (${entityId})` : ''}`);
   }
 
+  private clearContentView(): void {
+    this.widgetCache.forEach((widget, tag) => {
+      if (widget.style.display !== 'none') {
+        widget.style.display = 'none';
+        if (isContentViewWidget(widget) && widget.onDeactivate) {
+          widget.onDeactivate();
+        }
+        this.log(`Deactivated ${tag}`);
+      }
+    });
+    this.currentViewType = null;
+    this.currentViewEntityId = undefined;
+    Events.emit(UI_EVENTS.RIGHT_PANEL_CONFIGURE, {
+      widget: null,
+      contentType: null
+    });
+  }
+
   private updateUrl(path: string): void {
     if (this.currentPath !== path) {
       this.currentPath = path;
@@ -665,7 +683,11 @@ export class MainWidget extends ReactiveWidget {
 
     this.createMountEffect(() => {
       const unsubscribe = pageState.subscribe((state) => {
-        if (state?.contentType) {
+        if (!state) {
+          this.clearContentView();
+          return;
+        }
+        if (state.contentType) {
           if (state.contentType !== this.currentViewType ||
               state.entityId !== this.currentViewEntityId) {
             this.switchContentView(state.contentType, state.entityId);


### PR DESCRIPTION
## Summary

Makes the zero-open-tabs state explicit instead of leaving the last rendered widget visible.

This is a state-contract fix, not a special-case General-room patch:

- `PageStateService` now notifies subscribers when page state is cleared (`PageState | null`).
- `ContentService.close()` clears page state and resets the URL to `/` when the active last tab closes.
- `MainWidget` responds to cleared page state by hiding cached content widgets and clearing right-panel config.
- `RoomListWidget` clears its active room highlight when there is no active page state.
- Added a focused unit test for the `subscribe -> clear -> null callback` contract.

## Why

Joel observed that after closing both General tabs, the center widget could still look like chat/General. That points to stale active view state after the last tab closes, separate from PR #1047's persisted duplicate tab cleanup.

The desired invariant is: content state owns whether anything is open; page state mirrors an active item only; widgets must not fabricate General when no content item is active.

## Subscriber audit

All PageState subscribers were checked after changing the listener type to `PageState | null`:

- `MainWidget`: explicitly clears the active content view on `null`.
- `RoomListWidget`: explicitly clears active room highlight on `null`.
- `ChatWidget`: already null-safe via optional chaining on `newState?.contentType` / `newState?.entityId`.
- `PositronicRAGContext`: subscribes through a debounced callback and reads state later through `pageState.getContent()`, which is already nullable.

## Validation

- `npx vitest run tests/unit/PageStateService.test.ts` passed (2 tests)
- `npm run build:ts` passed
- precommit passed:
  - TypeScript compilation
  - staged-file lint baseline check
  - `tests/precommit/browser-ping.test.ts`
- pre-push passed:
  - TypeScript compilation
  - ESLint baseline gate

Note: this package has Vitest-style tests but does not declare `vitest` in `src/package.json`; `npx` fetched Vitest for the focused local run. That dependency hygiene issue should be handled separately, not hidden in this UI-state PR.

## Manual acceptance

- Close all content tabs: tab bar shows no content tabs, center content view is empty, URL becomes `/`.
- Open `/chat/general`: exactly one canonical General tab opens, using the seeded room identity from routing.
- Reopen/close General repeatedly: no second stale General tab and no phantom chat view after last close.

