### PR TITLE
Fix persona response storm backpressure

### DIFF
--- a/src/system/user/server/modules/PersonaInbox.ts
+++ b/src/system/user/server/modules/PersonaInbox.ts
@@ -16,6 +16,7 @@
 
 import { EventEmitter } from 'events';
 import type { UUID } from '../../../core/types/CrossPlatformUUID';
+import type { TimerHandle } from '../../../core/types/CrossPlatformTypes';
 import type { QueueItem, InboxMessage, InboxTask } from './QueueItemTypes';
 import { isInboxMessage, isInboxTask, toChannelEnqueueRequest } from './QueueItemTypes';
 import { getChatCoordinator } from '../../../coordination/server/ChatCoordinationStream';
@@ -51,6 +52,7 @@ export const DEFAULT_INBOX_CONFIG: InboxConfig = {
  */
 const AGING_RATE_MS = PersonaTimingConfig.inbox.agingRateMs;
 const MAX_AGING_BOOST = PersonaTimingConfig.inbox.maxAgingBoost;
+const CHAT_ACTIVITY_DEBOUNCE_MS = PersonaTimingConfig.inbox.chatActivityDebounceMs;
 
 /**
  * Compute effective priority with RTOS-style aging
@@ -112,6 +114,7 @@ export class PersonaInbox {
   private readonly personaId: UUID;
   private readonly personaName: string;
   private readonly signal: EventEmitter;
+  private readonly pendingRoomSignals = new Map<UUID, TimerHandle>();
 
   // Rust-backed channel routing: enqueue routes through Rust IPC
   private rustBridge: RustCognitionBridge | null = null;
@@ -192,8 +195,11 @@ export class PersonaInbox {
           this.log(`❌ channelEnqueue FAILED: ${error}`);
         });
 
-      // Signal TS service loop IMMEDIATELY — don't wait for IPC response
-      this.signal.emit('work-available');
+      // Wake the TS service loop after a short room-activity quiet window.
+      // The Rust queue already consolidates same-room chat items; this delay
+      // gives a burst time to become one conversation chunk instead of one
+      // inference wakeup per message. Directed/voice/task work stays immediate.
+      this.signalForItem(item);
 
       return true; // Item sent to Rust channel (fire-and-forget)
     }
@@ -225,10 +231,37 @@ export class PersonaInbox {
       this.log(`📬 Enqueued task: ${item.taskType} → priority=${item.priority.toFixed(2)} (queue=${this.queue.length})`);
     }
 
-    // CRITICAL: Signal waiting serviceInbox (instant wakeup, no polling)
-    this.signal.emit('work-available');
+    this.signalForItem(item);
 
     return true;
+  }
+
+  private signalForItem(item: QueueItem): void {
+    if (!isInboxMessage(item)) {
+      this.signalWorkAvailable();
+      return;
+    }
+
+    if (item.sourceModality === 'voice' || item.mentions === true) {
+      this.signalWorkAvailable();
+      return;
+    }
+
+    const existing = this.pendingRoomSignals.get(item.roomId);
+    if (existing) {
+      clearTimeout(existing);
+    }
+
+    const timer = setTimeout(() => {
+      this.pendingRoomSignals.delete(item.roomId);
+      this.signalWorkAvailable();
+    }, CHAT_ACTIVITY_DEBOUNCE_MS);
+
+    this.pendingRoomSignals.set(item.roomId, timer);
+  }
+
+  private signalWorkAvailable(): void {
+    this.signal.emit('work-available');
   }
 
   /**
@@ -400,6 +433,10 @@ export class PersonaInbox {
   clear(): void {
     const cleared = this.queue.length;
     this.queue = [];
+    for (const timer of this.pendingRoomSignals.values()) {
+      clearTimeout(timer);
+    }
+    this.pendingRoomSignals.clear();
     this.log(`🗑️  Cleared ${cleared} items`);
   }
 

--- a/src/system/user/server/modules/PersonaTimingConfig.ts
+++ b/src/system/user/server/modules/PersonaTimingConfig.ts
@@ -47,6 +47,7 @@ export const PersonaTimingConfig = {
     maxSize: 1000,                 // Default max inbox size
     popTimeoutMs: 5000,            // Default pop timeout
     waitForWorkTimeoutMs: 30_000,  // Default waitForWork timeout
+    chatActivityDebounceMs: 500,   // Same-room chat quiet window before inference wakeup
   },
 
   /** AI generation */

--- a/src/system/user/server/tests/validation/PersonaInboxDebounce.test.ts
+++ b/src/system/user/server/tests/validation/PersonaInboxDebounce.test.ts
@@ -1,0 +1,81 @@
+/**
+ * PersonaInbox room-activity wakeup behavior.
+ *
+ * Regular room chat should wake cognition after a short quiet window so the
+ * Rust channel queue can consolidate a burst into one conversation item.
+ * Directed work still wakes immediately.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { UUID } from '../../../../core/types/CrossPlatformUUID';
+import { PersonaInbox } from '../../modules/PersonaInbox';
+import type { InboxMessage } from '../../modules/QueueItemTypes';
+
+function message(overrides: Partial<InboxMessage> = {}): InboxMessage {
+  return {
+    id: 'message-1' as UUID,
+    type: 'message',
+    roomId: 'room-1' as UUID,
+    content: 'hello',
+    senderId: 'human-1' as UUID,
+    senderName: 'Developer',
+    senderType: 'human',
+    priority: 0.6,
+    timestamp: Date.now(),
+    domain: 'chat' as InboxMessage['domain'],
+    sourceModality: 'text',
+    ...overrides,
+  };
+}
+
+function inboxWithRustBridge(): PersonaInbox {
+  const inbox = new PersonaInbox('persona-1' as UUID, 'Test Persona', {
+    enableLogging: false,
+  });
+
+  inbox.setRustBridge({
+    channelEnqueue: vi.fn().mockResolvedValue({
+      routed_to: 'chat',
+      status: { total_size: 1 },
+    }),
+  } as any);
+
+  return inbox;
+}
+
+describe('PersonaInbox room activity debounce', () => {
+  it('debounces normal chat wakeups so bursts can consolidate', async () => {
+    vi.useFakeTimers();
+    try {
+      const inbox = inboxWithRustBridge();
+      const wait = inbox.waitForWork(1000);
+      let resolved = false;
+      wait.then(() => {
+        resolved = true;
+      });
+
+      await inbox.enqueue(message());
+      await vi.advanceTimersByTimeAsync(499);
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(wait).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('wakes immediately for directed mentions', async () => {
+    vi.useFakeTimers();
+    try {
+      const inbox = inboxWithRustBridge();
+      const wait = inbox.waitForWork(1000);
+
+      await inbox.enqueue(message({ mentions: true }));
+
+      await expect(wait).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/workers/continuum-core/src/modules/ai_provider.rs
+++ b/src/workers/continuum-core/src/modules/ai_provider.rs
@@ -569,7 +569,11 @@ impl ServiceModule for AIProviderModule {
             command_prefixes: &["ai/"],
             event_subscriptions: &[],
             needs_dedicated_thread: false,
-            max_concurrency: 10, // Allow parallel inference requests
+            // Local inference adapters fan out into GPU/ORT/llama threadpools.
+            // Letting every persona call ai/generate concurrently saturates the
+            // machine and lowers throughput. Queue at the runtime boundary; the
+            // backend scheduler can batch/serialize work deliberately.
+            max_concurrency: 1,
             // DMR watchdog cadence — see DMR_TICK_INTERVAL. The runtime's
             // `start_tick_loops` spawns one tokio task that calls `tick()`
             // on this interval; on every fire we probe DMR and reconcile

--- a/src/workers/continuum-core/src/modules/cognition.rs
+++ b/src/workers/continuum-core/src/modules/cognition.rs
@@ -136,7 +136,10 @@ impl ServiceModule for CognitionModule {
             command_prefixes: &["cognition/", "inbox/"],
             event_subscriptions: &[],
             needs_dedicated_thread: false,
-            max_concurrency: 0,
+            // Persona response can invoke RAG, embeddings, and generation.
+            // Keep a single cognition response in flight until the pressure
+            // broker can perform explicit multi-persona batching.
+            max_concurrency: 1,
             tick_interval: None,
         }
     }
@@ -828,8 +831,7 @@ impl ServiceModule for CognitionModule {
                 let response = crate::persona::response::respond(input).await?;
 
                 Ok(CommandResult::Json(
-                    serde_json::to_value(&response)
-                        .map_err(|e| format!("Serialize error: {e}"))?,
+                    serde_json::to_value(&response).map_err(|e| format!("Serialize error: {e}"))?,
                 ))
             }
 

--- a/src/workers/continuum-core/src/modules/embedding.rs
+++ b/src/workers/continuum-core/src/modules/embedding.rs
@@ -1003,7 +1003,10 @@ impl ServiceModule for EmbeddingModule {
             command_prefixes: &["embedding/"],
             event_subscriptions: &[],
             needs_dedicated_thread: false,
-            max_concurrency: 0,
+            // fastembed/ONNX uses its own native threadpool per invocation.
+            // Runtime-level serialization prevents multiple batches from
+            // multiplying CPU threadpools during persona bursts.
+            max_concurrency: 1,
             tick_interval: None,
         }
     }

--- a/src/workers/continuum-core/src/persona/evaluator.rs
+++ b/src/workers/continuum-core/src/persona/evaluator.rs
@@ -298,7 +298,9 @@ pub struct GateDetails {
 ///
 /// Hard gates (system protection only):
 /// 1. Sleep mode — persona's OWN voluntary decision (respects autonomy)
-/// 2. Self-message — infinite loop prevention (inside fast_path)
+/// 2. Non-human echo storm — undirected AI/agent chatter is suppressed once
+///    the room is already AI-heavy
+/// 3. Self-message — infinite loop prevention (inside fast_path)
 ///
 /// Removed: response cap. Was a cloud-provider "resource exhaustion" concept
 /// that blocked local personas (which have zero cost) after 50 responses per
@@ -409,6 +411,43 @@ pub fn full_evaluate(
                 social_signals: Some(social_signals),
             };
         }
+    }
+
+    // =========================================================================
+    // HARD GATE 2: Non-human echo storm.
+    //
+    // A bridged agent broadcast or another persona's generic reply must not
+    // summon every persona repeatedly. Human messages and direct mentions still
+    // flow through normally; only undirected AI/agent/system chatter is damped
+    // once the recent room window is already AI-heavy.
+    // =========================================================================
+    let sender_is_non_human = matches!(
+        request.sender_type,
+        SenderType::Persona | SenderType::Agent | SenderType::System
+    );
+    if sender_is_non_human && !is_mentioned && echo_result.ai_message_count >= 2 {
+        return FullEvaluateResult {
+            should_respond: false,
+            confidence: 1.0,
+            reason: format!(
+                "Undirected non-human chatter suppressed after {} recent AI messages",
+                echo_result.ai_message_count
+            ),
+            gate: "non_human_echo_storm".into(),
+            decision_time_ms: start.elapsed().as_secs_f64() * 1000.0,
+            gate_details: Some(GateDetails {
+                response_count: Some(response_count),
+                max_responses: Some(rate_limiter.max_responses_per_session),
+                rate_limit_wait_seconds: rate_limiter
+                    .rate_limit_wait_seconds(request.room_id, now_ms),
+                sleep_mode: None,
+                is_mentioned: Some(is_mentioned),
+                has_directed_mention: Some(has_directed_mention),
+                topic_similarity: None,
+                echo_chamber_ai_count: Some(echo_result.ai_message_count as u32),
+            }),
+            social_signals: Some(social_signals),
+        };
     }
 
     // =========================================================================
@@ -555,6 +594,7 @@ pub fn check_response_adequacy(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::persona::message_cache::{CachedMessage, SenderCategory};
     use crate::rag::RagEngine;
     use std::sync::Arc;
     use tokio::sync::watch;
@@ -817,6 +857,82 @@ mod tests {
         );
         // Human sender + recent message = high priority → should respond
         assert!(result.should_respond);
+    }
+
+    #[test]
+    fn test_non_human_echo_storm_blocks_undirected_agent_chatter() {
+        let (engine, persona_id) = test_engine("TestBot");
+        let mut request = test_request(persona_id, "TestBot");
+        request.sender_type = SenderType::Agent;
+        request.sender_is_human = false;
+        request.sender_name = "airc-bridge".into();
+        request.content = "[airc:mac-claude] please respond if you see this".into();
+
+        let now = now_ms();
+        let mut cache = RecentMessageCache::new();
+        for i in 0..2 {
+            cache.push(
+                request.room_id,
+                CachedMessage {
+                    id: Uuid::new_v4(),
+                    sender_id: Uuid::new_v4(),
+                    sender_type: SenderCategory::AI,
+                    sender_name: format!("Persona{i}"),
+                    content_text: "Hello! How can I assist you today?".into(),
+                    timestamp_ms: now - 1_000,
+                },
+            );
+        }
+
+        let result = full_evaluate(
+            &request,
+            &RateLimiterState::default(),
+            &SleepState::default(),
+            &engine,
+            &cache,
+            now,
+        );
+
+        assert!(!result.should_respond);
+        assert_eq!(result.gate, "non_human_echo_storm");
+    }
+
+    #[test]
+    fn test_non_human_echo_storm_allows_direct_mentions() {
+        let (engine, persona_id) = test_engine("TestBot");
+        let mut request = test_request(persona_id, "TestBot");
+        request.sender_type = SenderType::Agent;
+        request.sender_is_human = false;
+        request.sender_name = "airc-bridge".into();
+        request.content = "@TestBot please respond if you see this".into();
+
+        let now = now_ms();
+        let mut cache = RecentMessageCache::new();
+        for i in 0..5 {
+            cache.push(
+                request.room_id,
+                CachedMessage {
+                    id: Uuid::new_v4(),
+                    sender_id: Uuid::new_v4(),
+                    sender_type: SenderCategory::AI,
+                    sender_name: format!("Persona{i}"),
+                    content_text: "Hello! How can I assist you today?".into(),
+                    timestamp_ms: now - 1_000,
+                },
+            );
+        }
+
+        let result = full_evaluate(
+            &request,
+            &RateLimiterState::default(),
+            &SleepState::default(),
+            &engine,
+            &cache,
+            now,
+        );
+
+        assert_ne!(result.gate, "non_human_echo_storm");
+        assert!(result.social_signals.unwrap().is_mentioned);
     }
 
     #[test]

--- a/src/workers/continuum-core/src/runtime/runtime.rs
+++ b/src/workers/continuum-core/src/runtime/runtime.rs
@@ -11,7 +11,9 @@ use super::module_context::ModuleContext;
 use super::registry::ModuleRegistry;
 use super::service_module::{CommandResult, ServiceModule};
 use super::shared_compute::SharedCompute;
+use dashmap::DashMap;
 use std::sync::Arc;
+use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
@@ -47,6 +49,7 @@ pub struct Runtime {
     registry: Arc<ModuleRegistry>,
     bus: Arc<MessageBus>,
     compute: Arc<SharedCompute>,
+    concurrency_limits: Arc<DashMap<&'static str, Arc<Semaphore>>>,
 }
 
 impl Default for Runtime {
@@ -61,6 +64,7 @@ impl Runtime {
             registry: Arc::new(ModuleRegistry::new()),
             bus: Arc::new(MessageBus::new()),
             compute: Arc::new(SharedCompute::new()),
+            concurrency_limits: Arc::new(DashMap::new()),
         }
     }
 
@@ -76,6 +80,13 @@ impl Runtime {
         // Wire event subscriptions into the message bus
         for pattern in config.event_subscriptions {
             self.bus.subscribe(pattern, config.name, false);
+        }
+
+        if config.max_concurrency > 0 {
+            self.concurrency_limits.insert(
+                config.name,
+                Arc::new(Semaphore::new(config.max_concurrency)),
+            );
         }
 
         self.registry.register(module);
@@ -173,12 +184,28 @@ impl Runtime {
         let metrics = self.registry.get_metrics(module_name);
         let queued_at = std::time::Instant::now();
 
+        let permit = match self.concurrency_limits.get(module_name) {
+            Some(limit) => match limit.clone().acquire_owned().await {
+                Ok(permit) => Some(permit),
+                Err(_) => {
+                    return Some(Err(format!(
+                        "Runtime concurrency limiter for module '{module_name}' is closed"
+                    )));
+                }
+            },
+            None => None,
+        };
+
+        let tracker = metrics
+            .as_ref()
+            .map(|metrics| metrics.start_command(command, queued_at));
+
         // Execute command
         let result = module.handle_command(&full_cmd, params).await;
+        drop(permit);
 
         // Record timing (automatic for ALL commands)
-        if let Some(metrics) = metrics {
-            let tracker = metrics.start_command(command, queued_at);
+        if let (Some(metrics), Some(tracker)) = (metrics, tracker) {
             let timing = tracker.finish(result.is_ok());
             metrics.record(timing);
         }
@@ -204,12 +231,29 @@ impl Runtime {
         // Get metrics tracker for this module (created at registration)
         let metrics = self.registry.get_metrics(module_name);
         let queued_at = std::time::Instant::now();
+        let limit = self
+            .concurrency_limits
+            .get(module_name)
+            .map(|entry| entry.clone());
 
         // Use sync channel to bridge async -> sync safely
         let (tx, rx) = std::sync::mpsc::sync_channel(1);
 
         rt_handle.spawn(async move {
+            let permit = match limit {
+                Some(limit) => match limit.acquire_owned().await {
+                    Ok(permit) => Some(permit),
+                    Err(_) => {
+                        let _ = tx.send(Err(format!(
+                            "Runtime concurrency limiter for module '{module_name}' is closed"
+                        )));
+                        return;
+                    }
+                },
+                None => None,
+            };
             let result = module.handle_command(&full_cmd, params).await;
+            drop(permit);
             let _ = tx.send(result);
         });
 


### PR DESCRIPTION
## Summary
- enforce Runtime ModuleConfig.max_concurrency with per-module semaphores
- serialize cognition, ai_provider, and embedding modules to prevent native threadpool fanout during persona bursts
- debounce normal same-room PersonaInbox chat wakeups so Rust channel consolidation gets a conversation chunk instead of one wakeup per message
- hard-gate undirected non-human echo storms while preserving human messages and direct mentions

## Validation
- npm stop cleared the runaway local Continuum process before patch validation
- npx vitest run system/user/server/tests/validation/PersonaInboxDebounce.test.ts --reporter=verbose
- ./node_modules/.bin/tsc --noEmit --project . --pretty false
- cargo check --manifest-path src/workers/Cargo.toml -p continuum-core --features metal,accelerate from a clean worktree with vendor/llama.cpp initialized

## Notes
- Pre-existing Rust warnings remain; no new Rust hard errors.
- The first temp worktree lacked initialized vendor/llama.cpp, so initial cargo/pre-push attempts failed on missing CMakeLists.txt. Clean worktree validation passed after submodule init.
