### PR TITLE
Codify Rust-first alpha architecture

### DIFF
--- a/docs/architecture/PERSONA-AS-RUST-LIBRARY-PLAN.md
+++ b/docs/architecture/PERSONA-AS-RUST-LIBRARY-PLAN.md
@@ -23,14 +23,70 @@ Every step in the phases below earns inclusion by serving one of those three. St
 
 When a user reports a bug, the workflow becomes: capture the broken fixture → write a `#[test]` that loads it → reproduce the failure in a Rust test → fix → green. No live deploy needed for the inner loop.
 
-## Status overview (2026-04-23)
+## 2026-05-11 Architecture Posture
+
+The library plan is no longer a future refactor. It is the management plan for getting Continuum to alpha.
+
+The target is a Rust persona runtime with browser/TS as an adapter, not a TypeScript persona runtime with Rust helpers. That distinction is load-bearing:
+
+- **PersonaRuntime is the product core.** It owns turn batching, inbox consolidation, RAG/context assembly, model selection, inference, post-processing, memory events, tool execution, and resource accounting.
+- **TS is a host adapter.** It renders UI, receives browser/user events, invokes typed Rust commands, and posts results. It must not decide how a persona thinks.
+- **Every step must delete the old owner.** A Rust duplicate beside an active TS implementation is not migration; it is two sources of truth. #1068 and #1069 are the pattern: move the behavior to Rust, add Rust tests, remove the TS duplicate.
+- **Major rework is allowed when the boundary is wrong.** Do not preserve an API because downstream code is messy. Preserve user-visible behavior, not internal accidental architecture.
+- **Concurrency and pressure are first-class design inputs.** Persona code should be designed like a realtime engine: evented, bounded, backpressured, resource-aware, and measured.
+
+The next major architectural milestone is a Rust-owned persona turn pipeline:
+
+```text
+Signal/RoomEvent
+  -> Rust inbox consolidation / admission control
+  -> Rust RAG/context builder
+  -> Rust recipe or cognition executor
+  -> Rust inference/model resolver
+  -> Rust post-processing + trace/fixture capture
+  -> thin host post/broadcast adapter
+```
+
+The system is not considered healthy while this path depends on Node for batching, cognition decisions, prompt/RAG construction, or model/tool behavior.
+
+### Uniform Rust OOP Pattern
+
+Rust does not use Java/C++ base classes directly, but Continuum should preserve the same design discipline: common complexity belongs in shared base traits, default implementations, and reusable engines. Leaf modules should declare what they are, not reimplement how the runtime works.
+
+The model is CBAR-style: `QueueThread<T>` owned the queue, wake cadence, priority behavior, abort/flush semantics, and backpressure; subclasses only implemented `handleItem`. `CBAR_VideoFrame` owned lazy cached derived data; analyzers consumed it without recomputing or copying. Continuum needs the same shape for AI runtime work.
+
+In Continuum terms, a persona component, model backend, recipe step, memory source, transport, or tool should get logs, trace, fixture capture, metrics, comms, concurrency, cancellation, queueing, backpressure, and resource accounting for free by implementing the base contract. If each subclass/implementor has to wire those itself, the abstraction is wrong.
+
+Required pattern:
+
+| Layer | Rust shape | Owns |
+|---|---|---|
+| Runtime base | `PersonaRuntime`, `RuntimeEngine`, `RuntimeContext` | lifecycle, event loop, cancellation, deadlines, trace, fixture capture |
+| Capability contracts | traits such as `InferenceBackend`, `PageableBackend`, `MemoryStore`, `ToolExecutor`, `RecipeExecutor` | uniform behavior contracts and typed errors |
+| Policy engines | `PressureBroker`, `PagingPolicy`, `AdmissionController`, `TurnBatcher` | scheduling, backpressure, residency, fairness, resource budgets |
+| Data contracts | `Signal`, `PersonaContext`, `RespondInput`, `RecipeStep`, `ModelRequirement` | ts-rs exported wire types and replay fixtures |
+| Adapters | `LlamaCppAdapter`, future cloud/local/grid adapters, TS host adapter | eccentric platform/provider details only |
+| Leaf behavior | small structs implementing traits | domain-specific logic with no duplicated lifecycle/scheduling/error handling |
+
+Rules:
+
+- **Complexity lives at the base.** Backpressure, cancellation, queue draining, retry, replay capture, tracing, metrics, and typed error propagation are implemented once in the substrate.
+- **Leaf modules are boring.** If adding a backend, recipe step, tool, or memory source requires custom lifecycle code, the base trait is missing an abstraction.
+- **Uniform command semantics.** Command execution returns typed success/error. Callers own catch/retry/report behavior. Inner command implementations should not swallow errors into fake success.
+- **IDs over copies.** Runtime boundaries pass handles, IDs, offsets, buffer references, or artifact keys whenever possible; large media, KV, tensors, embeddings, and frames are not copied through Node.
+- **Speed is inherited.** New modules get concurrency, batching, backpressure, and replay automatically by implementing the base contract. Performance is not a per-feature afterthought.
+- **Pipelines are inherited.** A new subclass/implementor plugs into the runtime pipeline; it does not invent its own logging, scheduling, IPC, or test harness.
+- **Comms are inherited.** A component emits and consumes typed events through the runtime bus. AIRC/grid/host adapters bridge those events; leaf components do not know transport details.
+
+## Status overview (2026-05-11)
 
 - **Phase A (cognition substrate):** A1–A5 ✅ landed
+- **Phase A.4/A.5 follow-through:** #1068 moved turn recording fully Rust-side; #1069 moved response cleanup Rust-side and removed the TS duplicate.
 - **Phase B (recipes):** Rust Recipe-trait approach RIPPED (was wrong shape — recipes are DATA). Replaced with: JSON recipe entities + Rust-native pipeline executor (per `RECIPE-EXECUTION-RUNTIME.md`). Executor not yet built. Old hardcoded Recipe trait + ChatRecipe deleted in commit `983d30102`.
-- **Phase C (paging):** All steps unstarted. Today proved C5 (MtmdContext pool) is the latency killer — see findings below.
+- **Phase C (paging):** Substrate pieces exist, but the actual resource manager is incomplete. MtmdContext pooling, KV policy, LoRA/model residency, and pressure gates are alpha-critical.
 - **Phase D (FFI / embeddable):** All steps unstarted.
-- **Phase E (trace + replay):** Replay test infrastructure repaired in commit `66c4d3799`. Trace emission still pending.
-- **Phase F (output quality):** NEW phase added 2026-04-23 — model output bugs surfaced during testing (echo loops, "SpeakerName: X" garbage, tool_use markup leak). Widget chip rendering shipped in commit `980bcbce6`. Prompt assembly bugs remain.
+- **Phase E (trace + replay):** Recorder exists and is now Rust-owned. Per-seam trace emission and replay tooling still need to become mandatory gates.
+- **Phase F (output quality):** Tool/thinking markup cleanup is Rust-owned as of #1069. Echo loops, generic greetings, and prompt/RAG quality remain active blockers.
 
 ## What today taught us (load-bearing findings 2026-04-23)
 

--- a/docs/architecture/PERSONA-COGNITION-RUST-MIGRATION.md
+++ b/docs/architecture/PERSONA-COGNITION-RUST-MIGRATION.md
@@ -2,7 +2,7 @@
 
 > **Every cognition PR ships net-negative TypeScript lines under `src/system/user/server/`. No exceptions.** This is the enforceable gate that prevents the persona-cognition footprint from continuing to sprawl in Node while we wait for "the right time" to migrate. The right time is every PR.
 
-Status: design — 2026-04-19. Authored after Joel observed that even the shared-cognition work I'd planned (modify `PersonaResponseGenerator.ts` to call into Rust) would preserve the TS cognition layer with a Rust dependency grafted on — defeating the principles we'd just spent the morning establishing (Rust = logic, TS = schema-only thin shim, CBAR-style native truth + thin SDKs). The right answer: build it in Rust, shrink or delete the TS counterpart, gate every PR on TS line-count drop.
+Status: active migration policy — updated 2026-05-11. Authored after Joel observed that even the shared-cognition work I'd planned (modify `PersonaResponseGenerator.ts` to call into Rust) would preserve the TS cognition layer with a Rust dependency grafted on — defeating the principles we'd just spent the morning establishing (Rust = logic, TS = schema-only thin shim, CBAR-style native truth + thin SDKs). The right answer: build it in Rust, shrink or delete the TS counterpart, gate every PR on TS line-count drop.
 
 ---
 
@@ -33,6 +33,30 @@ Every one of these is a verb-shaped module — algorithm, scoring, orchestration
 Historically: every new cognitive capability got its first draft in TS because TS iteration is fast (no cargo build). The drafts never migrated. Each Claude session, each pair-programming sprint, each "let's try X" experiment left another `.ts` file behind. Nobody removed them. The footprint grew monotonically.
 
 The pattern that has to break: **TS is no longer the iteration language for cognition.** Even fast-iteration cognitive prototypes go in Rust. cargo's incremental build is fast enough; the type system catches more bugs than TS does; the resulting code is faster, more concurrent, and ready for the wrappable-from-anywhere architecture (Unity, AR/VR, native iOS/Android — all CBAR's lineage).
+
+## The two-pronged fix
+
+## 2026-05-11 Hardening: No Compromise Rust-First Rule
+
+This migration is now the default engineering standard, not a preference.
+
+Agents should not ask whether cognition belongs in Rust. It does. The only design question is which Rust boundary owns it and which tests prove it.
+
+Rules:
+
+1. **No new TS cognition behavior.** New behavior under persona cognition, prompt/RAG decisions, tool parsing/execution, model selection, memory consolidation, turn batching, or inference scheduling must be Rust-first.
+2. **No duplicate owners.** If Rust takes over a behavior, remove or shrink the TS implementation in the same PR. #1068 and #1069 are the current pattern.
+3. **No "temporary" fallbacks that hide failure.** Rust can return typed `Unavailable`, `Degraded`, or `Backpressured` states. TS may display them. TS must not silently pick another model/provider/path.
+4. **No swallowed command failures.** Commands are dynamically generated and executed by callers that own error handling. Inner execution loops should return errors, not catch-and-convert them into false success.
+5. **Tests are architectural evidence.** A Rust unit/replay test should prove the boundary. A live chat smoke test proves integration only after the Rust test exists.
+6. **Major rework is acceptable.** When the boundary is wrong, preserve the user contract and rewrite the internal contract. Small compatibility patches that keep the wrong owner are technical debt.
+
+Current canary examples:
+
+- **#1068** moved persona turn fixture recording into Rust and removed the duplicate TS writer.
+- **#1069** moved leaked tool/thinking markup cleanup into Rust and removed the duplicate TS sanitizer.
+
+Those are small examples of the rule. The same pattern must now be applied to the large remaining owners: inbox consolidation, ChatRAGBuilder, tool execution, prompt turn assembly, memory consolidation, and model/provider selection.
 
 ## The two-pronged fix
 

--- a/docs/planning/ALPHA-GAP-ANALYSIS.md
+++ b/docs/planning/ALPHA-GAP-ANALYSIS.md
@@ -2,14 +2,29 @@
 
 <!-- markdownlint-disable MD013 MD060 -->
 
-**Updated**: 2026-05-07
+**Updated**: 2026-05-11
 **Branch policy**: every change lands as `PR -> canary -> validation -> PR -> main`
 **Status**: active planning document, shared by humans and agents
 **Operating rule**: Rust owns runtime logic. TypeScript is UI, schema, generated types, and thin command/transport glue.
+**Architectural mandate**: Rust-first, GPU-first, replay-tested. No patchwork substitutes for the target architecture.
 
 This document is the alpha source of truth. Work should not proceed as disconnected chat threads or private agent branches. Each implementation PR must name the issue it advances, land in `canary`, publish validation evidence, and only then be considered for promotion to `main`.
 
 The previous 2026-05-01 alpha snapshot was useful but had become a historical log. This revision turns it into an execution plan for the current goal: **stable, GPU-first, Rust-centric Continuum with modular Docker and fast tests that do not depend on the Node/UI stack for core correctness.**
+
+## 2026-05-11 Management Reset: Rust First, No Patchwork
+
+Continuum is past the point where local fixes to Node/TS symptoms can be treated as product progress. The product is a native, highly concurrent, resource-aware AI runtime that happens to have a browser UI. The implementation posture is therefore:
+
+1. **Architecture beats remedies.** If the bug is caused by cognition, inference, resource pressure, model routing, memory, tool execution, or persona scheduling living in the wrong layer, the fix is to move the responsibility to the right Rust abstraction. Do not add another TS guardrail around a Rust/runtime concern.
+2. **Rust is the design language for runtime behavior.** New behavior under persona cognition, model selection, local inference, paging, LoRA/model residency, memory consolidation, tool parsing/execution, command execution semantics, and recovery state machines starts in Rust.
+3. **TypeScript is not the prototype layer for cognition.** TS iteration speed is not a justification. A fast prototype that stays in Node becomes permanent debt. The correct loop is Rust unit test -> Rust replay/VDD test -> canary integration -> live smoke.
+4. **No silent fallbacks.** CPU fallback, cloud fallback, empty API-key availability, generic model fallback, placeholder UUIDs, and swallowed command errors are alpha blockers unless explicitly surfaced as degraded state with a user-visible remedy.
+5. **No feature-disabling fixes.** A fix that makes tests pass by disabling local models, personas, chat, inference, telemetry, or replay is a regression unless the PR is explicitly a kill-switch PR and documents the lost capability.
+6. **No PR sediment.** PRs are not storage. A PR either merges to canary after evidence, gets rebased and completed, or is closed with the durable work moved into an issue/design doc. Long-lived PRs are technical debt.
+7. **Perfect means structurally correct, not endlessly delayed.** The expected cadence is small architectural PRs that move ownership to Rust and delete the wrong layer. "Perfect" does not mean one huge rewrite branch; it means every merged increment points at the final architecture and reduces future work.
+
+This reset supersedes "move fast and break things" thinking. Agents have enough implementation bandwidth to spend the extra hours on the correct abstraction up front. That is cheaper than debugging another patchwork system for weeks.
 
 ## Alpha Definition
 
@@ -24,6 +39,9 @@ The non-negotiable gates:
 5. **Fast tests first**: core work must be covered by `cargo test` or Rust integration tests before Docker/browser tests.
 6. **Canary is the sync point**: every fix is merged to `canary` first and tested there by available Mac/Windows/Linux agents.
 7. **No silent success**: health checks, install steps, inference readiness, bridge delivery, and UI restore paths must fail loud with actionable evidence.
+8. **Persona cognition TS line count trends downward**: any PR touching persona cognition must delete or shrink TS runtime logic under `src/system/user/server/` unless it is strictly UI/schema/adapter work.
+9. **Replay before live claims**: persona, RAG, tool, inference, and memory changes must include a Rust fixture/replay/unit test before "works live" is accepted.
+10. **One source of truth per runtime fact**: model definitions, provider availability, context budgets, hardware capability, config values, room identity, and command semantics must each have one canonical owner.
 
 ## Current Snapshot
 
@@ -45,9 +63,11 @@ The non-negotiable gates:
 
 | Issue / PR | Role | Required action |
 |---|---|---|
-| PR #1046 | AIRC bridge harness for Continuum testing | Keep reviewed; use it to reduce manual `jtag chat/send` and paste relay |
-| PR #1035 | current canary -> main promotion PR | Do not promote blindly; use this doc's gates to decide when canary is worth main |
-| PR #1047 | stale General tab recovery, merged to canary | Validate live UI state, then include in next canary -> main promotion |
+| PR #1035 | current canary -> main promotion PR | Keep rebased; promote only after canary has real chat/local-model validation plus relevant platform smoke |
+| PR #1046 | AIRC bridge harness for Continuum testing | Merge/rebase/close deliberately; use it to reduce manual `jtag chat/send` and paste relay |
+| PR #1068 | Rust persona recorder as single fixture source | Merged to canary; sets the SSoT pattern for replay/capture |
+| PR #1069 | Rust response cleanup, TS sanitizer removed | Merged to canary; sets the "move behavior Rust-side, delete TS duplicate" pattern |
+| stale canary PRs (#941, #972, #973, #1026, #912) | PR debt | Rebase and validate within one work session or close with issue notes |
 | #967 | personas as AIRC peers | Treat as the collaboration unlock: Continuum personas should participate without manual CLI glue |
 
 Rules:
@@ -56,6 +76,9 @@ Rules:
 - PR body must include: issue link, canary target, validation commands, platform coverage, and what was not tested.
 - Agents coordinate on AIRC, but the durable truth is issue + PR comments.
 - `main` promotion only happens after canary has been exercised by at least one real UI path and one non-UI/Rust path relevant to the changes.
+- Open PRs are triaged every session before new feature work. Each gets one of four states: `merge-after-green`, `needs-rebase`, `convert-to-issue`, or `close-stale`.
+- A PR older than 48 hours without a concrete blocker is presumed stale until proven otherwise.
+- If a PR is correct but incomplete, finish and merge it to canary; do not recreate the same work on a new branch.
 
 ### 1. First-Run And Install Stability
 


### PR DESCRIPTION
## Summary\n- Updates the alpha gap plan with a 2026-05-11 Rust-first management reset\n- Makes PR debt explicit: stale PRs must merge, rebase, convert to issues, or close\n- Updates the persona Rust-library plan with the CBAR-style base/subclass model: logs, trace, fixture capture, comms, concurrency, cancellation, backpressure, and resource accounting are inherited from the runtime substrate\n- Converts the persona cognition Rust migration doc from design note to active migration policy\n\n## Operating intent\nContinuum runtime behavior is Rust-first and GPU-first. TypeScript remains UI/schema/generated adapter glue. No new persona cognition behavior belongs in TS.\n\n## Validation\n- git diff --check\n- normal git commit precommit: TypeScript build passed; browser ping passed\n- normal git push pre-push: TypeScript clean; ESLint baseline-tolerant gate passed; Rust/Docker skipped because docs-only