### PR TITLE
test(sensory): Position 2 alpha-contract WebRTC sensory smoke

### DIFF
--- a/src/tests/integration/multi-persona-response-timing.test.ts
+++ b/src/tests/integration/multi-persona-response-timing.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Multi-Persona Response Timing — chat/persona E2E regression test
+ *
+ * Codifies the bar that Mac+Windows smoke runs in #1057→#1060 surfaced:
+ * post #1062 backpressure work, the storm IS fixed (CPU stays flat) BUT
+ * fairness is broken — first-claim-wins, only ONE persona responds when
+ * N candidates are eligible. This test makes that failure mode explicit
+ * so the eventual fix has an executable green-vs-red signal.
+ *
+ * What it does
+ * ------------
+ * 1. Send ONE chat message into a room with N≥3 active personas.
+ * 2. Poll chat/export every 500ms with the probe's shortId as anchor.
+ * 3. Record when each persona's reply (replyToId === probe shortId) lands.
+ * 4. Assert:
+ *    - First persona reply within FIRST_RESPONSE_BUDGET_MS (10s per #1062)
+ *    - All eligible personas reply within ALL_RESPONSE_BUDGET_MS (30s)
+ *    - At least MIN_FAIR_RESPONSE_COUNT of N personas reply (fairness)
+ *
+ * Loud-fail buckets per #1063 / #1067 typed-bucket pattern:
+ *   probe_not_persisted             — chat/send returned ok but DB has no row
+ *   no_personas_replied             — no persona replied at all (storm-fix
+ *                                     over-corrected into total silence)
+ *   first_response_budget_exceeded  — first reply arrived after 10s
+ *   all_response_budget_exceeded    — full reply set didn't settle in 30s
+ *   fairness_violated               — only K of N replied where K < min
+ *
+ * Standing-rule alignment (#1070 / #1072):
+ * - Single attempt, no retry on failure
+ * - Loud-fail with typed bucket — operator greps result, doesn't dig
+ *   through logs
+ * - No silent fallback — the test reports what actually happened on the
+ *   user-facing surface (chat_messages → chat/export)
+ *
+ * Uses ./jtag CLI via execFile to stay decoupled from in-process JTAGClient
+ * TS surface drift; matches the chat-probe pattern operators already use.
+ *
+ * Run:
+ *   npx tsx src/tests/integration/multi-persona-response-timing.test.ts
+ */
+
+import { execFile as execFileCb } from 'child_process';
+import { promisify } from 'util';
+import * as path from 'path';
+
+const execFile = promisify(execFileCb);
+
+// =============================================================================
+// Failure bucket taxonomy
+// =============================================================================
+
+export type TimingFailureBucket =
+  | 'probe_not_persisted'
+  | 'no_personas_replied'
+  | 'first_response_budget_exceeded'
+  | 'all_response_budget_exceeded'
+  | 'fairness_violated';
+
+export interface TimingFailure {
+  bucket: TimingFailureBucket;
+  reason: string;
+  observed?: {
+    expected_personas: number;
+    replied_personas: number;
+    first_response_ms?: number;
+    full_response_ms?: number;
+    persona_response_ms: Record<string, number>;
+  };
+}
+
+export interface TimingSuccess {
+  probe_short_id: string;
+  expected_personas: number;
+  replied_personas: number;
+  first_response_ms: number;
+  full_response_ms: number;
+  persona_response_ms: Record<string, number>;
+}
+
+export type TimingResult =
+  | { ok: true; success: TimingSuccess }
+  | { ok: false; failure: TimingFailure };
+
+// =============================================================================
+// Budgets — alpha SLOs from #1062 RecipeTurnBatchPlan defaults
+// =============================================================================
+
+const FIRST_RESPONSE_BUDGET_MS = 10_000;
+const ALL_RESPONSE_BUDGET_MS = 30_000;
+const POLL_INTERVAL_MS = 500;
+const MIN_FAIR_RESPONSE_COUNT = 2;
+const TARGET_ROOM = 'general';
+const JTAG_BIN = path.resolve(__dirname, '../../../jtag');
+
+// =============================================================================
+// Smoke runner
+// =============================================================================
+
+interface JtagResult { stdout: string; stderr: string }
+
+async function jtag(command: string, params: Record<string, string | number | boolean>): Promise<unknown> {
+  const args = [command];
+  for (const [k, v] of Object.entries(params)) args.push(`--${k}=${v}`);
+  const { stdout }: JtagResult = await execFile(JTAG_BIN, args, { maxBuffer: 16 * 1024 * 1024 });
+  // ./jtag prints status lines + final JSON object. Find the trailing JSON.
+  const jsonStart = stdout.lastIndexOf('{');
+  if (jsonStart === -1) throw new Error(`./jtag ${command} produced no JSON: ${stdout.slice(0, 500)}`);
+  return JSON.parse(stdout.slice(jsonStart));
+}
+
+export async function runMultiPersonaResponseTimingSmoke(): Promise<TimingResult> {
+  // STEP 1 — count expected personas via data/list.
+  const personaList = await jtag('data/list', { collection: 'users' }) as { items?: Array<{ type?: string }> };
+  const expectedPersonas = (personaList?.items ?? []).filter((u) => u?.type === 'persona').length;
+  if (expectedPersonas < MIN_FAIR_RESPONSE_COUNT) {
+    return failBucket('no_personas_replied', `room has only ${expectedPersonas} seeded personas; need >= ${MIN_FAIR_RESPONSE_COUNT}`);
+  }
+
+  // STEP 2 — send ONE chat message.
+  const probeMarker = `multi-persona-timing-${Date.now()}`;
+  const sendResult = await jtag('collaboration/chat/send', { room: TARGET_ROOM, message: probeMarker }) as { shortId?: string };
+  const probeShortId = sendResult?.shortId;
+  if (!probeShortId) {
+    return failBucket('probe_not_persisted', 'collaboration/chat/send returned no shortId');
+  }
+
+  // STEP 3 — verify probe persisted.
+  const verify = await jtag('collaboration/chat/export', { room: TARGET_ROOM, limit: 5 }) as { markdown?: string };
+  if (!verify?.markdown?.includes(probeMarker)) {
+    return failBucket('probe_not_persisted', `probe shortId=${probeShortId} not visible in chat/export within first poll`);
+  }
+
+  // STEP 4 — poll chat_messages for replies whose replyToId === probeShortId.
+  const startWait = Date.now();
+  const personaResponseMs: Record<string, number> = {};
+  let firstResponseMs: number | undefined;
+
+  while (Date.now() - startWait < ALL_RESPONSE_BUDGET_MS) {
+    const recent = await jtag('data/list', { collection: 'chat_messages', filter: JSON.stringify({ replyToId: probeShortId }), orderBy: JSON.stringify([{ field: 'createdAt', direction: 'asc' }]), limit: 50 }) as { items?: Array<{ senderId?: string; senderName?: string; replyToId?: string }> };
+    const replies = (recent?.items ?? []).filter((m) => m?.replyToId === probeShortId);
+    const elapsedMs = Date.now() - startWait;
+
+    for (const reply of replies) {
+      const personaKey = reply.senderName || reply.senderId;
+      if (!personaKey || personaResponseMs[personaKey] !== undefined) continue;
+      personaResponseMs[personaKey] = elapsedMs;
+      if (firstResponseMs === undefined) {
+        firstResponseMs = elapsedMs;
+        if (firstResponseMs > FIRST_RESPONSE_BUDGET_MS) {
+          return failBucket(
+            'first_response_budget_exceeded',
+            `first persona reply at ${firstResponseMs}ms exceeded budget ${FIRST_RESPONSE_BUDGET_MS}ms`,
+            { expectedPersonas, repliedPersonas: Object.keys(personaResponseMs).length, firstResponseMs, fullResponseMs: elapsedMs, personaResponseMs },
+          );
+        }
+      }
+    }
+
+    if (Object.keys(personaResponseMs).length >= expectedPersonas) break;
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  const repliedPersonas = Object.keys(personaResponseMs).length;
+  const fullResponseMs = Date.now() - startWait;
+
+  if (repliedPersonas === 0) {
+    return failBucket(
+      'no_personas_replied',
+      `no persona replied to probe ${probeShortId} within ${ALL_RESPONSE_BUDGET_MS}ms — storm-fix may have over-corrected into total silence`,
+      { expectedPersonas, repliedPersonas: 0, fullResponseMs, personaResponseMs },
+    );
+  }
+
+  if (repliedPersonas < MIN_FAIR_RESPONSE_COUNT) {
+    return failBucket(
+      'fairness_violated',
+      `only ${repliedPersonas} of ${expectedPersonas} expected personas replied (need >= ${MIN_FAIR_RESPONSE_COUNT}) — first-claim-wins coordination is too sticky`,
+      { expectedPersonas, repliedPersonas, firstResponseMs, fullResponseMs, personaResponseMs },
+    );
+  }
+
+  if (firstResponseMs === undefined) {
+    return failBucket('no_personas_replied', 'unreachable: replied personas > 0 but first response never recorded');
+  }
+
+  if (fullResponseMs > ALL_RESPONSE_BUDGET_MS) {
+    return failBucket(
+      'all_response_budget_exceeded',
+      `full reply set settled at ${fullResponseMs}ms exceeded budget ${ALL_RESPONSE_BUDGET_MS}ms`,
+      { expectedPersonas, repliedPersonas, firstResponseMs, fullResponseMs, personaResponseMs },
+    );
+  }
+
+  return {
+    ok: true,
+    success: {
+      probe_short_id: probeShortId,
+      expected_personas: expectedPersonas,
+      replied_personas: repliedPersonas,
+      first_response_ms: firstResponseMs,
+      full_response_ms: fullResponseMs,
+      persona_response_ms: personaResponseMs,
+    },
+  };
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function failBucket(
+  bucket: TimingFailureBucket,
+  reason: string,
+  observed?: { expectedPersonas: number; repliedPersonas: number; firstResponseMs?: number; fullResponseMs?: number; personaResponseMs: Record<string, number> },
+): TimingResult {
+  return {
+    ok: false,
+    failure: {
+      bucket,
+      reason,
+      observed: observed
+        ? {
+            expected_personas: observed.expectedPersonas,
+            replied_personas: observed.repliedPersonas,
+            first_response_ms: observed.firstResponseMs,
+            full_response_ms: observed.fullResponseMs,
+            persona_response_ms: observed.personaResponseMs,
+          }
+        : undefined,
+    },
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// =============================================================================
+// Entry point
+// =============================================================================
+
+async function main(): Promise<void> {
+  console.log('💬  multi-persona-response-timing smoke starting…');
+  const result = await runMultiPersonaResponseTimingSmoke();
+  if (result.ok) {
+    console.log('✅ PASS', JSON.stringify(result.success, null, 2));
+    process.exit(0);
+  }
+  console.error('❌ FAIL bucket=' + result.failure.bucket);
+  console.error('   reason: ' + result.failure.reason);
+  if (result.failure.observed) {
+    console.error('   observed:');
+    console.error('     expected_personas:  ' + result.failure.observed.expected_personas);
+    console.error('     replied_personas:   ' + result.failure.observed.replied_personas);
+    if (result.failure.observed.first_response_ms !== undefined) {
+      console.error('     first_response_ms:  ' + result.failure.observed.first_response_ms);
+    }
+    if (result.failure.observed.full_response_ms !== undefined) {
+      console.error('     full_response_ms:   ' + result.failure.observed.full_response_ms);
+    }
+    console.error('     persona_response_ms:');
+    for (const [persona, ms] of Object.entries(result.failure.observed.persona_response_ms)) {
+      console.error(`       ${persona}: ${ms}ms`);
+    }
+  }
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error('❌ FAIL bucket=no_personas_replied (unhandled exception)');
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/src/tests/integration/sensory-persona-roundtrip.test.ts
+++ b/src/tests/integration/sensory-persona-roundtrip.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Sensory Persona Roundtrip — Position 2 alpha contract test
+ *
+ * Codifies the live sensory loop a STANDARD PERSONA must satisfy per #1072:
+ * resolve a multimodal model (Chat + Vision + AudioInput + AudioOutput) →
+ * spawn LiveKitAgent into a real WebRTC room → publish a question as TTS
+ * audio + a known test image as a video frame → wait for the persona's
+ * response audio AND transcription → assert transcription mentions the
+ * image content (proves vision was wired) AND audio was published (proves
+ * TTS reached the room).
+ *
+ * Failing-loud test today; passes as Position 1 (resolver with
+ * RequirementProfile::StandardPersona) and Position 3 (Qwen multimodal GPU
+ * kernels in llama.cpp/Candle) land. The bar is the test, not the impl.
+ *
+ * Loud-fail buckets — every failure path categorized so an operator can
+ * grep the result instead of digging through logs:
+ *
+ *   no_qualified_model      — resolver returned no Standard-Persona-capable model
+ *   persona_failed_to_join  — LiveKitAgent spawn errored or never joined
+ *   no_audio_published      — persona was in room but no TTS track ever appeared
+ *   no_transcription        — STT listener never produced a transcription segment
+ *   vision_blind            — transcription text doesn't mention any image content
+ *   budget_exceeded         — first response > FIRST_RESPONSE_BUDGET_MS or
+ *                             full response > ALL_RESPONSE_BUDGET_MS
+ *
+ * Per #1070 / #1072 standing rules: NO silent CPU fallback, NO degraded-mode
+ * fallback (text-only is not a passing result), NO retry-on-failure (single
+ * attempt, fail loud, surface the bucket).
+ *
+ * Run with:
+ *   npx tsx src/tests/integration/sensory-persona-roundtrip.test.ts
+ *
+ * Prerequisites (today's failing run will report which are missing):
+ *   - LiveKit server running on $LIVEKIT_URL
+ *   - continuum-core IPC socket available
+ *   - Position 1 resolver shipped (RequirementProfile::StandardPersona)
+ *   - Position 3 Qwen multimodal kernels available on this host
+ */
+
+import { RustCoreIPCClient, getContinuumCoreSocketPath } from '../../workers/continuum-core/bindings/RustCoreIPC';
+
+// =============================================================================
+// Failure bucket taxonomy — typed so operator can grep
+// =============================================================================
+
+export type SmokeFailureBucket =
+  | 'no_qualified_model'
+  | 'persona_failed_to_join'
+  | 'no_audio_published'
+  | 'no_transcription'
+  | 'vision_blind'
+  | 'budget_exceeded';
+
+export interface SmokeFailure {
+  bucket: SmokeFailureBucket;
+  reason: string;
+  dependencies?: string[];
+}
+
+export interface SmokeSuccess {
+  persona_id: string;
+  model_id: string;
+  first_response_ms: number;
+  full_response_ms: number;
+  transcription: string;
+  vision_terms_matched: string[];
+}
+
+export type SmokeResult =
+  | { ok: true; success: SmokeSuccess }
+  | { ok: false; failure: SmokeFailure };
+
+// =============================================================================
+// Budgets — per #1062 RecipeTurnBatchPlan first/all-response budgets
+// =============================================================================
+
+const FIRST_RESPONSE_BUDGET_MS = 30_000;   // first audio frame from persona
+const ALL_RESPONSE_BUDGET_MS = 60_000;     // full audio response + transcription
+const TEST_ROOM_PREFIX = 'sensory-smoke';
+
+// =============================================================================
+// Test image — a known set of visual elements the persona should describe
+// =============================================================================
+
+interface TestImage {
+  /** PNG/JPEG bytes the persona will see as a video frame */
+  bytes: Buffer;
+  /** Words a competent vision model should produce when asked 'what's in the image?' */
+  expected_terms: string[];
+}
+
+function generateTestImageWithKnownContent(): TestImage {
+  // Reuse the colored-quadrants test pattern from sensory_pipeline_test.rs
+  // (Red top-left, Green top-right, Blue bottom-left, White bottom-right).
+  // A multimodal model that sees this image should mention at least one of
+  // ['red', 'green', 'blue', 'white', 'quadrant', 'square', 'color'] in its
+  // response. If transcription mentions ZERO of these, vision is blind —
+  // the persona either didn't receive the image or processed it as text-only.
+  const width = 256;
+  const height = 256;
+  const rgba = Buffer.alloc(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      let r = 0, g = 0, b = 0;
+      if (x < width / 2 && y < height / 2) r = 255;
+      else if (x >= width / 2 && y < height / 2) g = 255;
+      else if (x < width / 2 && y >= height / 2) b = 255;
+      else { r = 255; g = 255; b = 255; }
+      rgba[i] = r;
+      rgba[i + 1] = g;
+      rgba[i + 2] = b;
+      rgba[i + 3] = 255;
+    }
+  }
+  return {
+    bytes: rgba,
+    expected_terms: ['red', 'green', 'blue', 'white', 'quadrant', 'square', 'color', 'corner'],
+  };
+}
+
+// =============================================================================
+// Smoke runner
+// =============================================================================
+
+export async function runSensoryPersonaSmoke(): Promise<SmokeResult> {
+  const ipc = new RustCoreIPCClient(getContinuumCoreSocketPath());
+  await ipc.connect();
+
+  // STEP 1 — resolve a Standard-Persona-capable model.
+  //
+  // Calls Position 1's cognition/resolve-model IPC with
+  // RequirementProfile::StandardPersona. The resolver is the one that
+  // enforces 'Chat + Vision + AudioInput + AudioOutput on GPU/UMA, no
+  // silent CPU fallback'. Until Position 1 ships, this returns
+  // no_qualified_model with the reason describing the missing API.
+  let resolved: { model_id: string; provider_id: string; target_silicon: string } | undefined;
+  try {
+    const response = await ipc.request({
+      command: 'cognition/resolve-model',
+      request: {
+        profile: 'standard_persona',
+        host: detectHostCapability(),
+      },
+    });
+    if (!response.success || !response.result) {
+      return failBucket('no_qualified_model', response.error ?? 'resolver returned no model', [
+        'depends on Position 1: cognition/resolve-model IPC + RequirementProfile::StandardPersona',
+        'depends on Position 3: a Qwen multimodal GGUF actually loadable on this host',
+      ]);
+    }
+    resolved = response.result;
+  } catch (e) {
+    return failBucket(
+      'no_qualified_model',
+      `cognition/resolve-model IPC unavailable: ${e instanceof Error ? e.message : String(e)}`,
+      ['Position 1 not merged — IPC handler not registered'],
+    );
+  }
+
+  // STEP 2 — spawn LiveKitAgent for resolved persona + join test room.
+  const roomName = `${TEST_ROOM_PREFIX}-${Date.now()}`;
+  let agentJoinedAt: number | undefined;
+  try {
+    const joinResponse = await ipc.request({
+      command: 'live/spawn-persona-agent',
+      request: {
+        room: roomName,
+        persona_id: `smoke-${Date.now()}`,
+        model_id: resolved!.model_id,
+        provider_id: resolved!.provider_id,
+      },
+    });
+    if (!joinResponse.success) {
+      return failBucket(
+        'persona_failed_to_join',
+        joinResponse.error ?? 'spawn returned non-success',
+        ['continuum-core LiveKitAgent must accept resolved-model handle'],
+      );
+    }
+    agentJoinedAt = Date.now();
+  } catch (e) {
+    return failBucket(
+      'persona_failed_to_join',
+      `live/spawn-persona-agent IPC error: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  // STEP 3 — publish a TTS question + a test image as a video frame.
+  const image = generateTestImageWithKnownContent();
+  const question = "What's in the image?";
+  await ipc.request({
+    command: 'live/publish-test-stimulus',
+    request: {
+      room: roomName,
+      audio_text: question,
+      video_rgba: image.bytes.toString('base64'),
+      width: 256,
+      height: 256,
+    },
+  });
+
+  // STEP 4 — poll for persona response: audio frames + transcription.
+  const startWait = Date.now();
+  let firstAudioMs: number | undefined;
+  let transcription: string | undefined;
+  while (Date.now() - startWait < ALL_RESPONSE_BUDGET_MS) {
+    const status = await ipc.request({
+      command: 'live/get-room-state',
+      request: { room: roomName },
+    });
+    const state = status.result as {
+      persona_audio_published: boolean;
+      transcription_segments: Array<{ text: string; participant: string }>;
+    } | undefined;
+    if (!state) break;
+    if (state.persona_audio_published && firstAudioMs === undefined) {
+      firstAudioMs = Date.now() - startWait;
+      if (firstAudioMs > FIRST_RESPONSE_BUDGET_MS) {
+        return failBucket(
+          'budget_exceeded',
+          `first audio at ${firstAudioMs}ms exceeded budget ${FIRST_RESPONSE_BUDGET_MS}ms`,
+        );
+      }
+    }
+    const personaSegments = state.transcription_segments.filter((s) => s.participant !== 'human');
+    if (personaSegments.length > 0) {
+      transcription = personaSegments.map((s) => s.text).join(' ');
+      break;
+    }
+    await sleep(500);
+  }
+
+  if (firstAudioMs === undefined) {
+    return failBucket(
+      'no_audio_published',
+      `no persona TTS track appeared within ${ALL_RESPONSE_BUDGET_MS}ms`,
+    );
+  }
+  if (!transcription) {
+    return failBucket(
+      'no_transcription',
+      `persona audio published but no STT transcription within ${ALL_RESPONSE_BUDGET_MS}ms`,
+    );
+  }
+
+  // STEP 5 — assert transcription mentions image content (proves vision worked).
+  const lower = transcription.toLowerCase();
+  const matched = image.expected_terms.filter((term) => lower.includes(term));
+  if (matched.length === 0) {
+    return failBucket(
+      'vision_blind',
+      `persona responded but transcription "${transcription}" mentioned none of ${image.expected_terms.join(', ')} — vision was not wired or model is text-only`,
+    );
+  }
+
+  return {
+    ok: true,
+    success: {
+      persona_id: `smoke-${Date.now()}`,
+      model_id: resolved!.model_id,
+      first_response_ms: firstAudioMs,
+      full_response_ms: Date.now() - startWait,
+      transcription,
+      vision_terms_matched: matched,
+    },
+  };
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function detectHostCapability(): { hw_capability_tier: string; available_memory_mb: number; primary_target_silicon: string } {
+  // Stub today — Position 1 (or a separate boot-time hardware probe module)
+  // owns the real implementation. Smoke test passes whatever it has and
+  // lets the resolver fail-loud if it can't decide.
+  return {
+    hw_capability_tier: process.env.CONTINUUM_HW_CAPABILITY_TIER ?? 'M3UmaProMax',
+    available_memory_mb: parseInt(process.env.CONTINUUM_AVAILABLE_MEMORY_MB ?? '16384', 10),
+    primary_target_silicon: process.env.CONTINUUM_PRIMARY_SILICON ?? 'UnifiedMemory',
+  };
+}
+
+function failBucket(
+  bucket: SmokeFailureBucket,
+  reason: string,
+  dependencies?: string[],
+): SmokeResult {
+  return { ok: false, failure: { bucket, reason, dependencies } };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// =============================================================================
+// Entry point
+// =============================================================================
+
+async function main(): Promise<void> {
+  console.log('🎙️  sensory-persona-roundtrip smoke starting…');
+  const result = await runSensoryPersonaSmoke();
+  if (result.ok) {
+    console.log('✅ PASS', JSON.stringify(result.success, null, 2));
+    process.exit(0);
+  }
+  console.error('❌ FAIL bucket=' + result.failure.bucket);
+  console.error('   reason: ' + result.failure.reason);
+  if (result.failure.dependencies?.length) {
+    console.error('   blockers:');
+    for (const d of result.failure.dependencies) console.error('     - ' + d);
+  }
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error('❌ FAIL bucket=persona_failed_to_join (unhandled exception)');
+    console.error(e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
Codifies the live sensory loop a STANDARD PERSONA must satisfy per #1072 sensory persona alpha contract. Failing-loud test today; flips green as Position 1 (RequirementProfile::StandardPersona resolver) and Position 3 (Qwen multimodal GPU kernels) land. The bar is the test, not the impl.

## What it proves
- Resolves a multimodal model (Chat + Vision + AudioInput + AudioOutput) via `cognition/resolve-model` IPC
- Spawns LiveKitAgent into a real WebRTC test room
- Publishes a TTS question + a known test image (RGBA quadrants: red/green/blue/white)
- Polls for persona's TTS response track + transcription
- Asserts transcription mentions image content (proves vision was wired)
- Within budget: first response < 30s, full response < 60s

## Loud-fail buckets (typed per #1063 / #1067 pattern)
- `no_qualified_model` — resolver returned no Standard-Persona-capable model
- `persona_failed_to_join` — LiveKitAgent spawn errored or never joined
- `no_audio_published` — persona was in room but no TTS track ever appeared
- `no_transcription` — STT listener never produced segments
- `vision_blind` — transcription doesn't mention any image content (text-only model)
- `budget_exceeded` — first response > 30s OR full response > 60s

Each failure path categorized so an operator can grep instead of digging through logs.

## Standing-rule alignment
- No silent CPU fallback (per #1072)
- No degraded text-only pass (per #1072)
- No retry on failure — single attempt, fail loud, surface bucket (per #1070 no-PR-sediment + #1067 no-bypass)

## Validation
- `tsc --noEmit` clean (focused + repo-wide)
- Normal precommit hook passed (TypeScript build + browser ping)
- Normal pre-push hook passed (TypeScript clean + ESLint baseline-tolerant)

## Dependencies that flip this green
- **Position 1** (sibling Codex): `cognition/resolve-model` IPC + `RequirementProfile::StandardPersona` + ResolutionError variants (TextOnlyModelRejected, SilentCpuFallbackRejected)
- **Position 3** (continuum-8e97): Qwen multimodal GGUF actually loadable on Mac M-series + RTX 5090 hosts with full vision/audio paths
- `live/spawn-persona-agent` IPC (server-side participant bridge for resolved-model handle)
- `live/publish-test-stimulus` IPC (test harness — publishes audio + RGBA image into room)
- `live/get-room-state` IPC (test harness — reports persona_audio_published + transcription_segments)

## Run
```bash
npx tsx src/tests/integration/sensory-persona-roundtrip.test.ts
```

Today's run reports which dependencies are missing via the typed `dependencies` field on the failure result.