### PR TITLE
fix(rag): filter leaked tool instructions from chat history

### DIFF
--- a/src/system/rag/sources/ConversationHistorySource.ts
+++ b/src/system/rag/sources/ConversationHistorySource.ts
@@ -254,6 +254,7 @@ export class ConversationHistorySource implements RAGSource {
       // conversations that poison context and cause cascading failures.
       let filteredCount = 0;
       let metaSummaryCount = 0;
+      let toolInstructionLeakCount = 0;
       const cleanMessages = messages.filter((msg: MessageWithSender) => {
         const text = msg.content?.text || '';
         const poisonReason = detectConversationHistoryPoison(text);
@@ -265,6 +266,10 @@ export class ConversationHistorySource implements RAGSource {
           metaSummaryCount++;
           return false;
         }
+        if (poisonReason === 'tool-instruction-leak') {
+          toolInstructionLeakCount++;
+          return false;
+        }
         return true;
       });
       if (filteredCount > 0) {
@@ -272,6 +277,9 @@ export class ConversationHistorySource implements RAGSource {
       }
       if (metaSummaryCount > 0) {
         log.warn(`Filtered ${metaSummaryCount} meta-summary echo messages from history`);
+      }
+      if (toolInstructionLeakCount > 0) {
+        log.warn(`Filtered ${toolInstructionLeakCount} tool-instruction leak messages from history`);
       }
 
       // Sanitize bare tool call messages — replace with contextual note

--- a/src/system/rag/sources/conversationHistoryPoison.ts
+++ b/src/system/rag/sources/conversationHistoryPoison.ts
@@ -14,7 +14,20 @@ const FABRICATED_SINGLE_SPEAKER_RE = /^(?:Gemini|Groq|Together|Fireworks|Claude|
 // Persona meta-summary pattern observed during startup smoke tests.
 const META_SUMMARY_ECHO_RE = /\bI received a message from\s+[A-Z][\w -]{1,80}:\s*["“][\s\S]{10,}["”][\s\S]{0,800}\b(?:This indicates|The key pattern here|successfully acknowledged|responded to the startup smoke test)\b/i;
 
-export type ConversationHistoryPoisonReason = 'fabricated-conversation' | 'meta-summary-echo';
+const TOOL_INSTRUCTION_LEAK_MARKERS = [
+  '=== TOOL DEFINITIONS ===',
+  '=== HOW TO CALL TOOLS ===',
+  'CRITICAL RULES:',
+  '<tool_use>',
+  'RESPOND WITH TOOL CALLS, NOT DESCRIPTIONS.',
+  'Do NOT just discuss or describe what should be done',
+  'Use this EXACT XML format to call tools'
+] as const;
+
+export type ConversationHistoryPoisonReason =
+  | 'fabricated-conversation'
+  | 'meta-summary-echo'
+  | 'tool-instruction-leak';
 
 /**
  * Check if a message body is a fabricated multi-party conversation.
@@ -51,8 +64,21 @@ export function isMetaSummaryEcho(text: string): boolean {
   return META_SUMMARY_ECHO_RE.test(text);
 }
 
+export function isToolInstructionLeak(text: string): boolean {
+  if (!text || text.length < 120) return false;
+
+  const markerHits = TOOL_INSTRUCTION_LEAK_MARKERS.reduce(
+    (count, marker) => count + (text.includes(marker) ? 1 : 0),
+    0
+  );
+  if (markerHits >= 2) return true;
+
+  return text.includes('<think>') && markerHits >= 1;
+}
+
 export function detectConversationHistoryPoison(text: string): ConversationHistoryPoisonReason | null {
   if (isFabricatedConversation(text)) return 'fabricated-conversation';
   if (isMetaSummaryEcho(text)) return 'meta-summary-echo';
+  if (isToolInstructionLeak(text)) return 'tool-instruction-leak';
   return null;
 }

--- a/src/system/rag/test/unit/ConversationHistorySource.test.ts
+++ b/src/system/rag/test/unit/ConversationHistorySource.test.ts
@@ -14,6 +14,21 @@ describe('ConversationHistorySource context poison detection', () => {
     expect(detectConversationHistoryPoison('I received your startup smoke test and can respond as Helper AI.')).toBeNull();
   });
 
+  it('filters leaked model thinking and tool instruction blocks', () => {
+    const poisoned = [
+      '<think>',
+      'Thinking Process:',
+      '=== TOOL DEFINITIONS ===',
+      'Tool: code/read',
+      '=== HOW TO CALL TOOLS ===',
+      'Use this EXACT XML format to call tools:',
+      'CRITICAL RULES:',
+      'RESPOND WITH TOOL CALLS, NOT DESCRIPTIONS.'
+    ].join('\n');
+
+    expect(detectConversationHistoryPoison(poisoned)).toBe('tool-instruction-leak');
+  });
+
   it('still filters fabricated multi-speaker transcripts', () => {
     const fabricated = [
       'Teacher AI: I think we should test the room.',


### PR DESCRIPTION
## Summary
- filters leaked model-thinking/tool-instruction blocks out of ConversationHistorySource before persona RAG assembly
- adds a typed poison reason for tool-instruction leaks
- extends the existing RAG poison unit coverage

## Validation
- npx vitest run system/rag/test/unit/ConversationHistorySource.test.ts
- npm run build:ts
- normal commit hook passed: TS build, ESLint baseline, browser ping
- normal pre-push passed: TS clean, ESLint baseline, no Rust/docker changes
- restarted one local app instance from this repo only
- post-restart chat smoke: codex-post-filter-restart-smoke-1778525565 got CodeReview AI reply after ~35s
- RAG log confirmed: Filtered 3 meta-summary echo messages and 2 tool-instruction leak messages from history

## Notes
- This fixes RAG prompt poisoning, not the broader latency/memory issue.
- Remaining observed debt: cognition/respond still adds about 3.3GB RSS on a single smoke turn, and raw chat/export still exposes historical poison because export is archival rather than the RAG view.
