### PR TITLE
docs: define CBAR-like Rust substrate

### DIFF
--- a/docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md
+++ b/docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md
@@ -1,195 +1,374 @@
-# CBAR Substrate Architecture — The Pattern Continuum Will Adopt
+# CBAR Substrate Architecture
 
-**Status**: Architecture reference. The CBAR pattern from [react-home-ar](https://github.com/CambrianTech/react-home-ar) is the cleanest streaming-compute architecture in the Cambrian ecosystem. It should be the reference pattern for all streaming pipelines in continuum, and the basis for future responsiveness improvements.
+**Status**: architecture reference for Continuum's Rust runtime.
 
-**Rust implementation**: [open-eyes-core](https://github.com/CambrianTech/open-eyes) (`crates/open-eyes-core/src/frame.rs`)
+**Authoritative precedent**:
+`/Users/joelteply/Development/cambrian/cb-mobile-sdk/cpp/cbar`
 
----
+CBAR matters because of its engineering philosophy, not because Continuum
+should copy every class literally. It is a small-code, high-throughput,
+RTOS-style runtime where each concern gets threading, cadence, shared frame
+artifacts, logging, lifecycle, and performance behavior almost for free.
+Continuum needs that same shape for persona cognition, inference, memory,
+WebRTC, Bevy/rendering, ORM/data, and grid work.
 
-## The Pattern
+## Core Philosophy
 
-Three components, zero coupling:
+CBAR's lesson is:
 
-### 1. Frame (the shared data bus)
+- Put the hard machinery in the substrate.
+- Keep each concern small.
+- Give modules a narrow contract.
+- Pass handles and shared frames, not copied memory.
+- Let independent work run independently.
+- Wake work from dependency readiness, state change, cadence, or explicit
+  events.
+- Drop or defer stale work instead of draining obsolete queues.
+- Use GPU/SIMD/BLAS where available inside the artifact/module, not in wrappers.
+- Make low-end hardware viable by reducing cadence and precision under
+  pressure, not by turning the architecture into synchronous FIFO.
 
-A single immutable object that wraps a raw input (camera frame, audio chunk, inference request) with **lazy-computed derived outputs**. Each output is a `OnceLock<T>` that computes on first access and caches forever.
+That is the target for Continuum. Rust owns the substrate. TypeScript and other
+wrappers ask for work and display results.
+
+## What CBAR Actually Does
+
+The important C++ pieces:
+
+- `CBAR_VideoFrame`: one frame object with raw input plus cached derived
+  artifacts. It lazily imports/derives RGB, HSV, upright images, edges,
+  optical-flow scale images, enhanced images, and metadata.
+- `CBAR_VideoThread`: a bounded `QueueThread<CBAR_VideoFramePtr>` base that
+  gives subclasses queueing, thread lifecycle, timing/FPS, flush, abort, join,
+  and a tiny `handleFrame` override.
+- `CBP_AnalyzerThread`: a concern class that declares whether it needs color,
+  realtime, or video-only frames and implements only the relevant analysis.
+- `CBP_Analyzer`: the fanout coordinator. Realtime analyzers run immediately;
+  delayed analyzers run on cadence. Analyzer threads can be appended or removed
+  without rewriting the engine.
+- `CBP_RenderingEngine`: the opaque runtime owner. Public methods stay small;
+  implementation state, frame state, scene state, locks, caches, rendering, and
+  analyzer lifecycle stay behind `Impl`.
+- `RawFrame.textureID`: proof of the handle-first mindset. The frame can carry
+  a GPU/texture identity instead of forcing every boundary to copy pixels.
+
+The result is a performant system where adding a new concern is usually short:
+derive from the base, declare needs/cadence, implement `handleFrame`, and let
+the substrate do queueing, lifecycle, logging, and scheduling.
+
+## Continuum Translation
+
+Continuum should implement the same pattern in Rust:
 
 ```rust
-pub struct Frame {
-    raw: image::RgbImage,
-    timestamp: f64,
-    
-    // Lazy outputs — compute on first access, cache forever
-    greyscale: OnceLock<GrayImage>,
-    edges: OnceLock<EdgeMap>,
-    features: OnceLock<Vec<FeaturePoint>>,
-    normals: OnceLock<NormalMap>,
-    semantic: OnceLock<SemanticMap>,
-    optical_flow: OnceLock<FlowField>,
-}
-
-impl Frame {
-    pub fn greyscale(&self) -> &GrayImage {
-        self.greyscale.get_or_init(|| image::imageops::grayscale(&self.raw))
-    }
-    
-    pub fn features(&self) -> &Vec<FeaturePoint> {
-        self.features.get_or_init(|| {
-            let grey = self.greyscale(); // chains — computes greyscale if not yet cached
-            extract_features(grey)
-        })
-    }
+pub trait RuntimeModule: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn lane(&self) -> ResourceClass;
+    fn target(&self) -> TargetSilicon;
+    fn subscriptions(&self) -> &[ArtifactSelector];
+    fn cadence(&self) -> CadencePolicy;
+    fn handle(&self, frame: Arc<RuntimeFrame>, ctx: ModuleContext) -> ModuleResult;
 }
 ```
 
-**Key properties:**
-- **Any concern can read any other concern's output** — the Frame IS the pub/sub bus
-- **Compute cost is proportional to what's actually requested** — if nobody needs edges, edge detection never runs
-- **Thread-safe via OnceLock** — share via `Arc<Frame>` across processing threads/tasks
-- **Dependencies chain automatically** — `features()` calls `greyscale()` internally; greyscale computes once regardless of how many nodes need it
-- **Resolution-agnostic** — each output can be at any resolution. A quarter-res flow field and a full-res edge map coexist on the same Frame. Consumers interpolate to what they need.
-- **GPGPU-transparent** — the compute function inside each lazy getter can dispatch to wgpu/Metal/CUDA. The Frame doesn't care. Swapping CPU↔GPU is a per-getter decision invisible to consuming nodes.
+`subscriptions` and dependency wakeups are deliberate Continuum upgrades beyond
+CBAR, not a direct port. CBAR analyzers declare routing flags such as
+`needsColorFrames`, `needsRealTime`, and `videoOnly`; then they pull artifacts
+opportunistically from `CBAR_VideoFrame`. Continuum needs a richer contract
+because N personas, RAG builders, model planners, memory jobs, and bridge
+observers may all be waiting on different artifacts from the same turn. The
+runtime must know those dependencies so it can wake only the useful work,
+coalesce duplicates, and report deferrals.
 
-### 2. ProcessNode (the subscriber)
+The substrate provides:
 
-An independent processing unit that receives Frames and pulls what it needs. Zero knowledge of other nodes.
+- bounded per-lane queues
+- dependency wakeups
+- realtime versus delayed lanes
+- newest-state coalescing
+- resource admission
+- GPU/model residency leases
+- per-module logs and metrics
+- flush/abort/shutdown
+- trace events
+- silence/deferred reasons
+- automatic TDD/VDD evidence capture hooks
+- fail-hard command errors
+- ts-rs exported contracts
 
-```rust
-pub trait ProcessNode: Send + Sync {
-    fn name(&self) -> &str;
-    fn enabled(&self) -> bool { true }
-    fn update(&mut self, frame: &Frame) -> Vec<PipelineEvent>;
-}
+The module author provides:
+
+- what artifacts it needs
+- what resource lane it uses
+- how often it should run
+- the small piece of actual work
+
+That is the "for free" architecture.
+
+## Extension Bar
+
+A new concern should normally be a few hundred lines, not a new subsystem. If a
+persona recipe, model adapter, RAG source, media observer, render observer,
+memory consolidator, or grid bridge needs to implement its own transport,
+backpressure, retry loop, logging, queue, metrics, throttle, or lifecycle, the
+substrate is missing a base capability.
+
+The acceptance test for the runtime pattern is:
+
+- New modules are small and focused.
+- Communication is inherited from the runtime bus.
+- Backpressure is inherited from the lane and pressure broker.
+- Timing and performance metrics are automatic.
+- Failure and deferred-state reporting are automatic.
+- Resource leases and handles are standard.
+- Cross-module consistency is enforced by common traits and generated types.
+- No module grows into a monolith to compensate for missing substrate behavior.
+
+This is the practical reason for the CBAR model. The architecture should make
+the correct high-performance path the shortest path for every new class/module.
+
+## Timing, Logging, And VDD For Free
+
+Timing and logging are substrate behavior, not instrumentation added after a
+bug. Every runtime concern should inherit the same observability contract that
+CBAR gave threads through names, FPS timing, queue ownership, and lifecycle.
+
+Every module/job must automatically emit:
+
+- module name, job id, turn/frame key, resource class, target silicon, and
+  dependency keys
+- queued-at, admitted-at, started-at, first-output-at, completed-at, and
+  dropped/deferred-at timestamps
+- queue depth, queue wait, execution time, first-output latency, and total
+  latency
+- coalesced count, stale-drop count, retry count, deferred reason, and silence
+  reason
+- CPU/RSS deltas where available
+- GPU backend, GPU layer count, residency estimate, VRAM/unified-memory deltas,
+  and unsupported layers for inference work
+- structured success/error state suitable for command callers and replay tests
+
+TDD proves the contract. VDD proves the behavior. The runtime should make both
+cheap: each module gets trace spans, logs, counters, timing samples, and replay
+hooks by implementing the common trait. A PR that adds a new runtime concern
+without this evidence path is adding an unobservable subsystem, even if the
+feature appears to work.
+
+### Standard VDD Record
+
+All agents and platforms should report the same record shape. Do not invent a
+new timing table per machine.
+
+```text
+scenario:
+platform:
+hardware:
+backend:
+git_sha:
+command:
+model:
+gpu_layers:
+unsupported_layers:
+cold_start_ms:
+first_token_ms:
+first_response_ms:
+all_responses_ms:
+responses_expected:
+responses_observed:
+silence_reasons:
+tok_per_sec:
+cpu_pct_avg:
+cpu_pct_peak:
+rss_mb:
+gpu_util_pct_avg:
+gpu_memory_mb:
+queue_wait_ms:
+execution_ms:
+coalesced_count:
+deferred_count:
+stale_drop_count:
+error_count:
+degraded_reason:
+log_refs:
+next_bottleneck:
 ```
 
-**Key properties:**
-- **Nodes subscribe to inputs by calling lazy getters** — no explicit subscription registration. A node that needs features calls `frame.features()`. A node that needs normals calls `frame.normals()`. The dependency graph is implicit in the code.
-- **Disabled nodes cost zero** — `enabled()` returns false, node is skipped entirely
-- **Each node is a thread/task** — in the C++17 version, each node is a pthread with its own event loop. In Rust, each node is a tokio task or rayon work item. The Frame is the shared data bus passed between them.
-- **Adding a node cannot break existing nodes** — zero coupling. New node, new file, register it with the pipeline, done.
+The runtime should be able to emit this as JSONL from the same trace data used
+by tests. Humans can paste the text form into PR comments, but the canonical
+machine-readable output should come from the Rust substrate.
 
-### 3. Pipeline (the orchestrator)
+### One-Line Instrumentation API
 
-Manages the node list and feeds Frames through. Thin — just a loop.
-
-```rust
-pub struct Pipeline {
-    nodes: Vec<Box<dyn ProcessNode>>,
-}
-
-impl Pipeline {
-    pub fn process_frame(&mut self, raw: RgbImage, ...) -> Vec<PipelineEvent> {
-        let frame = Frame::new(raw, ...);
-        let mut events = Vec::new();
-        for node in &mut self.nodes {
-            if node.enabled() {
-                events.extend(node.update(&frame));
-            }
-        }
-        events
-    }
-}
-```
-
----
-
-## The Two-Tier Compute Model
-
-Not all outputs run at the same frequency. The architecture has two tiers:
-
-**Tier 1: Synchronous (every frame, GPU, low-res)**
-- Optical flow at quarter resolution
-- This is the HEARTBEAT — if flow says nothing's moving, everything else sleeps
-- Runs on GPU textures/framebuffers that already exist at the right size
-- One synchronous process, full frame rate
-
-**Tier 2: Lazy/Event-driven (on demand, CPU or GPU, any resolution)**
-- Feature extraction (triggered by motion detection)
-- Surface normals (CNN, runs every Nth frame or on scene change)
-- Semantic segmentation (forged model, runs on demand)
-- Edge detection (for plane estimation, runs rarely)
-- Entity detection (YOLO variant, triggered by motion)
-
-The tier 1 heartbeat drives tier 2 activation. If the flow field shows no motion, tier 2 nodes never wake up. If flow shows motion in region R, only nodes that care about region R activate. **Compute cost is proportional to what's actually happening in the scene.**
-
----
-
-## Three Levels of Recycling
-
-1. **Per-frame (Frame's OnceLock)** — within one frame, computed outputs are cached. Multiple nodes requesting greyscale get the same cached result.
-
-2. **Cross-frame (Scene cache)** — the static scene model (planes, normals, semantic labels) is computed once and recycled across thousands of frames. Only dynamic elements (entities, motion) update per-frame.
-
-3. **Cross-camera (Fusion engine)** — the shared world model is maintained across all cameras. Calibration is one-time (with self-regulating updates). Per-camera processing is independent; only the fusion layer merges outputs.
-
----
-
-## Self-Regulating Calibration
-
-Stationary cameras don't need per-frame pose estimation. The calibration is:
-1. **One-time**: cross-camera feature matching → relative pose solve
-2. **Self-regulating**: optical flow detects global drift (camera bumped) → recalibration triggers automatically
-3. **The heartbeat IS the drift detector** — the same optical flow that detects scene motion also detects camera motion. If ALL features shift uniformly, the camera moved, not the scene.
-
-No ARKit. No accelerometer. No external tracking. Just features and flow.
-
----
-
-## Platform Adapters (not branches)
-
-If the device provides capabilities natively (ARKit pose, ARCore depth, LiDAR point clouds), wrap them as adapters:
+The substrate should expose tiny helpers so module authors do not hand-roll
+timers. The target ergonomics should feel like C/C++ one-line macros while
+still producing structured Rust data:
 
 ```rust
-trait PoseProvider: Send + Sync {
-    fn current_pose(&self) -> Option<Transform>;
-}
-
-struct ARKitPoseAdapter { /* wraps ARKit */ }
-struct FeatureTrackingPoseAdapter { /* pure CV fallback */ }
+let _span = vdd_scope!(ctx, "persona.generate", ResourceClass::LocalGeneration);
+vdd_mark!(ctx, "first_token");
+vdd_counter!(ctx, "tokens", generated_tokens);
+vdd_residency!(ctx, backend = "metal", gpu_layers = n_gpu_layers, vram_mb = vram_mb);
+vdd_defer!(ctx, "gpu_pressure", retry_after_ms = 250);
+vdd_fail!(ctx, "unsupported_qwen_layer", layer = layer_name);
 ```
 
-Both implement `PoseProvider`. The pipeline doesn't care which one provides the data. Same "adapters not branches" principle as continuum's model family adapters.
+Those calls should feed the same `Standard VDD Record` fields automatically.
+The common helpers must be available to persona, inference, memory, media,
+render, ORM/data, grid, and Docker-adapter code. Iterative optimization should
+be a tight loop:
 
----
+1. run one standard command
+2. compare CPU, GPU, memory, power, queue time, first token, tok/s, and
+   response count against the prior run
+3. make the bottleneck visible
+4. repeat until CPU drops, GPU residency rises, memory/power stay bounded, and
+   throughput increases
 
-## Where This Applies in Continuum
+If a performance PR requires custom scripts to discover basic timings, the
+substrate is not doing its job.
 
-The CBAR pattern generalizes beyond cameras. Every streaming-compute pipeline in continuum could use this architecture:
+## Runtime Frame
 
-| Domain | Raw Input | Lazy Outputs | Heartbeat |
-|---|---|---|---|
-| **Camera/Security** | RGB frame | greyscale, edges, features, normals, semantic, flow | optical flow |
-| **Audio/Voice** | PCM chunk | spectrogram, VAD, transcription, speaker embedding | VAD energy |
-| **AI Inference** | token sequence | attention weights, hidden states, logits, tool calls | token generation |
-| **Persona Cognition** | inbox message | RAG context, tool relevance, priority score, response draft | inbox poll |
-| **Live Call** | WebRTC frame | transcription, facial expression, gesture, speaking state | audio energy |
+`CBAR_VideoFrame` becomes a broader `RuntimeFrame` / `CognitionTurnFrame`.
+The frame owns stable keys and lazy artifacts for one unit of work:
 
-Each row is a Pipeline with domain-specific ProcessNodes pulling from a domain-specific Frame. The pattern is the same; only the types change.
+- chat trigger
+- canonical room snapshot
+- conversation history window
+- RAG source bundle
+- model/capability selection
+- media frame handles
+- embedding handles
+- prompt fragments
+- KV cache leases
+- LoRA leases
+- response envelopes
+- trace/metrics
 
-**When continuum's responsiveness improves**: the CBAR substrate is the target architecture. Replace the current imperative persona-cognition cycle with a lazy-evaluated Frame-based pipeline, and the per-cycle compute cost drops to only what the current conversation actually requires — same way CBAR drops camera processing to only what motion requires.
+Multiple personas handling one room event share one frame. They do not each
+rebuild RAG, model selection, prompt context, embeddings, or media decoding.
 
----
+## Resource Classes And Targets
 
-## The open-eyes Implementation
+The runtime already has a useful two-axis shape:
 
-[open-eyes-core](https://github.com/CambrianTech/open-eyes) is the first Rust implementation of this pattern:
+- `ResourceClass` describes what kind of work is being scheduled:
+  `Cpu`, `Data`, `Gpu`, `Embedding`, `LocalGeneration`, `CloudProvider`, `Io`,
+  `Media`, `Render`, `Memory`, and `Background`.
+- `TargetSilicon` describes where the work wants to run: `Cpu`, `Gpu`,
+  `UnifiedMemory`, `Network`, `Disk`, `Cloud`, or `Background`.
 
-- `frame.rs` — Frame + ProcessNode trait + Pipeline (the full pattern)
-- `geometry/` — 3D math (projection, triangulation, RANSAC plane fitting)
-- `features/` — two-tier feature architecture (flow heartbeat + lazy ORB)
-- `fusion/` — N-camera fusion engine with self-regulating calibration
+Those shipped names are the source of truth for implementation. Docs may use
+"lane" informally, but code should converge on `ResourceClass` plus
+`TargetSilicon` rather than inventing a second enum.
 
-19 tests validate the core math and the lazy-evaluation semantics.
+Background lanes never silently consume the visible chat generation lane.
+If a lane is saturated, work is deferred with a reason, coalesced, or dropped if
+stale.
 
-The same `open-eyes-core` crate will serve both security cameras AND mixed-reality devices (VR/AR headsets are just more camera sources feeding the same fusion engine). The on-device part is lightweight and fast; the grid part (AI, splats, persona reasoning) is heavy and distributed.
+## Handles, Leases, And No Bulk Copies
 
----
+Pipes carry control messages and handles:
 
-## References
+- media frame ids
+- texture ids
+- buffer leases
+- embedding ids
+- model residency leases
+- KV page ids
+- LoRA page ids
+- room/entity handles
+- artifact hashes and offsets
 
-- `react-home-ar/src/core/internal/pipeline/CBARPipeline.ts` — the original TypeScript pipeline
-- `react-home-ar/src/core/internal/CBARFrame.ts` — the original lazy-evaluated Frame
-- `react-home-ar/src/core/internal/pipeline/CBARProcessNode.ts` — the original subscriber interface
-- `open-eyes/crates/open-eyes-core/src/frame.rs` — the Rust port (this is the reference implementation going forward)
-- `docs/CONVERSATIONAL-CADENCE-ARCHITECTURE.md` — Alex's LoD primitive (same Gaussian attention-weighted summarization applied to conversation instead of vision)
-- `docs/personas/AUTONOMOUS-PERSONA-ARCHITECTURE.md` — the persona cognition cycle that could adopt this pattern
+Large payloads stay resident in the owner pool. Copy only at the final edge
+where there is no better representation.
+
+## RTOS Rules
+
+Continuum runtime work must follow these rules:
+
+1. The hot path cannot block on background work.
+2. Realtime work runs first; slow work runs on cadence or explicit dependency
+   readiness.
+3. Work declares dependencies and wakes when they are ready.
+4. CPU workers stay busy with independent work.
+5. GPU/model work is admitted by Rust from current pressure and residency
+   evidence.
+6. Low-end devices degrade by cadence, precision, context length, subscriber
+   count, or modality, with visible reasons.
+7. No module owns an ad hoc queue/throttle/retry/cache when the substrate can
+   provide the shared version.
+8. No silent fallback to CPU, random providers, placeholder models, stale room
+   ids, or swallowed command errors.
+9. Extension code should be short because the base substrate is doing the hard
+   work.
+
+## Domain Mapping
+
+| CBAR Concept | Continuum Equivalent |
+|---|---|
+| `CBAR_VideoFrame` | `RuntimeFrame` / `CognitionTurnFrame` |
+| lazy derived image | lazy RAG/model/media/embedding/prompt artifact |
+| `textureID` | GPU/media/model/embedding/KV/LoRA handle |
+| `CBAR_VideoThread` | `ResourceClass` worker lane |
+| `CBP_AnalyzerThread` | recipe, RAG source, memory job, bridge, renderer |
+| realtime analyzer | visible chat, media heartbeat, transport health |
+| delayed analyzer | memory consolidation, semantic compression, slow learning |
+| `CBP_RenderingEngine::Impl` | opaque Rust runtime state |
+| Swift/Kotlin/ObjC wrappers | TS UI, command adapters, Docker process shell |
+
+## Substrate Gap Analysis
+
+The Rust substrate is not greenfield. Several core primitives are already
+shipped and should be extended rather than replaced:
+
+- `ResourceClass` and `TargetSilicon` in
+  `workers/continuum-core/src/cognition/adaptive_throughput.rs`.
+- `ThroughputLease` and `ThroughputLeaseRevocationPolicy` in
+  `workers/continuum-core/src/cognition/throughput_lease.rs`.
+- `PressureBroker` and `PressureSource` in
+  `workers/continuum-core/src/paging/broker.rs`.
+- `ServiceModule`, `ModuleRegistry`, `MessageBus`, `SharedCompute`, metrics,
+  and logging under `workers/continuum-core/src/runtime/`.
+- `ChannelQueue` and related persona queue consolidation primitives under the
+  persona runtime.
+
+The genuinely missing pieces are:
+
+1. Define `RuntimeFrame` / `CognitionTurnFrame` on top of the existing
+   `ResourceClass` + `TargetSilicon` + `ThroughputLease` + `PressureBroker`
+   primitives.
+2. Add formal artifact subscription, cadence, and dependency declarations to
+   the module/job contracts. This can extend `ServiceModule` and existing
+   planner jobs; it does not require discarding the runtime registry.
+3. Move chat turn fanout onto `CognitionTurnFrame` so all personas share one
+   room/RAG/model/prompt artifact set.
+4. Attach VDD metrics to existing lanes/classes: queue depth, queue time,
+   execution time, coalesced count, deferred count, GPU residency, CPU/GPU
+   utilization, and first-response/all-response latency.
+5. Add a Qwen GPU residency gate for local generation: selected Qwen model,
+   backend, GPU layer count, unsupported layers, residency estimate, and
+   platform backend evidence must be available before the turn runs. The
+   required happy paths are Mac -> Metal, NVIDIA -> CUDA, and AMD/Intel ->
+   Vulkan. CPU graph splits or unsupported Qwen layers are blockers unless the
+   turn is explicitly degraded with a visible reason.
+6. Migrate one expensive consumer at a time: persona chat, then embeddings,
+   then memory consolidation, then media/WebRTC, then render/avatar output.
+
+## Test Contract
+
+CBAR-like runtime work is not accepted by browser smoke alone.
+
+Required tests:
+
+- Unit TDD for dependency wakeups, lane admission, cadence, and coalescing.
+- Resource VDD for bounded queues, memory leases, and no monotonic growth.
+- Performance VDD for first response, all responses, tok/s, and queue time.
+- Residency VDD proving Metal/CUDA/Vulkan/local GPU path when required.
+- Qwen VDD proving Qwen 3.5 text/code and Qwen2-VL vision use the expected
+  local GPU backend, report layer residency, and fail loud on unsupported
+  layers instead of silently running CPU-shaped inference.
+- Accuracy VDD for replayed persona/RAG/tool output.
+
+The alpha gate is not "it boots." The gate is that the runtime behaves like an
+engine: predictable, concurrent, observable, fast, and small to extend.

--- a/docs/planning/ALPHA-GAP-ANALYSIS.md
+++ b/docs/planning/ALPHA-GAP-ANALYSIS.md
@@ -45,6 +45,66 @@ The non-negotiable gates:
 11. **Replay before live claims**: persona, RAG, tool, inference, and memory changes must include a Rust fixture/replay/unit test before "works live" is accepted.
 12. **One source of truth per runtime fact**: model definitions, provider availability, context budgets, hardware capability, config values, room identity, and command semantics must each have one canonical owner.
 
+### CBAR-Like Runtime Substrate Contract
+
+Continuum's Rust runtime must adopt the CBAR performance philosophy from
+`/Users/joelteply/Development/cambrian/cb-mobile-sdk/cpp/cbar`: small concern
+modules inherit the hard machinery from a shared substrate. The goal is not a
+literal class-for-class port; the goal is the same RTOS-style behavior:
+concurrent lanes, bounded queues, lazy shared artifacts, realtime-first
+cadence, resource admission, and handles instead of copied memory.
+
+The reusable substrate must provide:
+
+- `RuntimeFrame` / `CognitionTurnFrame`: one turn/frame object with stable keys
+  and lazy artifacts for room snapshot, RAG, model selection, prompt fragments,
+  media handles, embeddings, KV leases, LoRA leases, response envelopes, and
+  trace metrics.
+- `RuntimeModule`: a narrow Rust trait for concerns. Modules declare
+  subscriptions, lane, cadence, dependencies, and budget; they do not invent
+  their own scheduler.
+- `ResourceClass` plus `TargetSilicon`: the shipped two-axis scheduler shape.
+  `ResourceClass` describes what kind of work is being scheduled, while
+  `TargetSilicon` describes where it wants to run. Docs may say "lane"
+  informally, but implementation should reuse these shipped enums rather than
+  invent `ResourceLane`.
+- `ArtifactHandle` / leases: module boundaries pass ids, hashes, offsets,
+  texture ids, buffer leases, model residency leases, KV page ids, and LoRA
+  page ids. Bulk payloads stay resident in the owning pool.
+- dependency wakeups: work runs when required artifacts become ready, not
+  because a global FIFO happened to drain.
+- cadence and pressure gates: realtime work runs first; delayed work runs by
+  cadence, state delta, or explicit trigger; pressure reduces cadence,
+  precision, context, subscriber count, or modality with visible reasons.
+- built-in logs, metrics, flush, abort, shutdown, queue depth, queue time,
+  execution time, coalesced count, deferred count, and resource residency.
+- one standard VDD record emitted by the Rust substrate for every platform, so
+  Mac, Windows/RTX, Docker, and future grid nodes report comparable timing,
+  throughput, CPU/GPU, residency, silence, and bottleneck fields.
+- one-line instrumentation helpers for runtime code: scopes, marks, counters,
+  residency, deferrals, and failures should feed the standard VDD record
+  automatically. A module author should not write a custom timing harness to
+  answer whether CPU fell, GPU utilization rose, memory/power stayed bounded,
+  or throughput improved.
+
+This substrate is the base-class/OOP-equivalent discipline for Rust. Extension
+code should be short: implement the small trait, declare dependencies, and let
+the runtime provide concurrency, telemetry, pressure, wakeups, and lifecycle.
+New modules should normally be measured in a few hundred lines, not thousands.
+If a new runtime concern needs its own bespoke communications, queue,
+backpressure, retry, metrics, lifecycle, or failure-reporting system, the PR is
+exposing missing substrate work and should fix the shared substrate instead of
+growing a monolith.
+
+The first implementation PRs should not add more bespoke queues, fallback
+paths, or TS orchestration. They should converge existing Rust pieces into this
+substrate: `ServiceModule`, `MessageBus`, `SharedCompute`, `ChannelQueue`,
+`PressureBroker`, `PagedResourcePool`, model registry, and
+`llamacpp_scheduler`.
+The missing work is specifically `RuntimeFrame` / `CognitionTurnFrame` and
+formal artifact subscription/cadence/dependency declarations on top of the
+shipped substrate primitives, not a restart from zero.
+
 ### Sensory Persona Product Contract
 
 Continuum's differentiator is not "chat with several text bots." The alpha product is a local sensory persona grid: users can call personas into a WebRTC room, speak to them, see them, and receive useful multimodal responses from agents that can perceive images/video/audio and drive avatar or other control outputs.
@@ -54,6 +114,15 @@ Implementation consequences:
 - **Every standard persona declares sensory requirements.** The default requirement set includes text, vision, audio input, voice/audio output, avatar/control output, and WebRTC presence. A persona that cannot satisfy those requirements is marked `Degraded` with the missing capability, not silently treated as alpha-complete.
 - **STT/TTS are adapters, not the center.** They exist to support compatibility models and weaker hosts. The standard local model path targets multimodal models directly where possible.
 - **Qwen 3.5/3.6 are optimization targets.** The registry and runtime resolve model requirements by capability, context, memory budget, and GPU support. They do not scatter hardcoded model names or accept random provider/model drift.
+- **Qwen GPU support is an alpha contract.** Qwen 3.5 text/code and Qwen2-VL
+  vision must run through Continuum's llama.cpp/local runtime with all viable
+  layers on the required platform backend: Mac -> Metal, NVIDIA -> CUDA, and
+  AMD/Intel -> Vulkan. Unsupported Qwen layers, mmproj/audio/vision gaps, CPU
+  graph splits, or missing upstream kernels are implementation blockers to fix
+  or vendor/upstream, not reasons to route around the local runtime. The model
+  resolver must expose selected model, backend, GPU layer count, expected
+  residency, unsupported layers, and any degraded reason before a persona turn
+  starts.
 - **Open-source runtime gaps are ours to fix.** If llama.cpp, Candle training code, GGUF conversion, kernels, multimodal projectors, audio layers, or paging support are missing what Qwen needs, the work item is to fork/vendor/upstream the fix with benchmarks. "Upstream cannot" is not a final answer for open-source dependencies.
 - **No CPU crutches in the happy path.** CPU fallback is explicit degraded mode for unsupported hardware, tests, or emergency operation. It is not a performance plan for a 3090/5090/M-series target.
 - **Live media is a gate.** Video chat, avatar output, and WebRTC bridge health are alpha gates. A PR that breaks sensory persona presence must fail validation before canary promotion.


### PR DESCRIPTION
## Summary
- Rewrites the CBAR substrate reference around the actual C++ precedent at /Users/joelteply/Development/cambrian/cb-mobile-sdk/cpp/cbar.
- Defines the Rust runtime substrate contract: RuntimeFrame/CognitionTurnFrame, RuntimeModule, ResourceLane, ArtifactHandle/leases, dependency wakeups, cadence/pressure gates, and no bespoke queues/fallbacks.
- Adds the same substrate contract to the alpha gap plan so future PRs are judged by inherited performance/comms/backpressure behavior and small module size, not monolith growth.

## Validation class
- Contract TDD: n/a - docs-only architecture contract.
- Failure TDD: n/a - docs-only architecture contract.
- Performance/Resource/Residency VDD: n/a - defines future VDD gates, no runtime code changed.
- Browser/UX evidence: precommit browser ping passed.
- Platform coverage: local Mac docs/precommit hooks.

## Validation
- npx markdownlint-cli2 docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md docs/planning/ALPHA-GAP-ANALYSIS.md
- git diff --check -- docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md docs/planning/ALPHA-GAP-ANALYSIS.md
- precommit hook: TypeScript compilation passed; browser-ping precommit test passed
- pre-push hook: TypeScript clean; ESLint baseline-tolerant passed; Rust/Docker skipped because docs-only

## Known gaps
- Generated ts-rs/schema files were already dirty locally and are intentionally not part of this PR.
- AIRC review requested from peer agents; record ACK/BLOCKER comments as they come in.