### PR TITLE
test: unblock cargo --tests build (SamplingConfig + format string drift)

### DIFF
--- a/src/workers/continuum-core/tests/llamacpp_metal_throughput.rs
+++ b/src/workers/continuum-core/tests/llamacpp_metal_throughput.rs
@@ -23,6 +23,7 @@
 //! path, takes 10-30s, and isn't part of the regular CI test loop.
 
 use continuum_core::inference::backends::llamacpp::{LlamaCppBackend, LlamaCppConfig};
+use continuum_core::inference::backends::SamplingConfig;
 use std::env;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -105,10 +106,12 @@ fn qwen35_4b_metal_throughput_via_bundled_llamacpp() {
     );
 
     // Warm-up call so the first-call compile/cache cost doesn't pollute measurement.
+    // SamplingConfig::chat() = temp 0.6 + repeat_penalty 1.1 + top-k 40 + top-p 0.95,
+    // matching what live chat traffic uses (the throughput we want to measure).
     eprintln!("[smoke] warm-up generation (10 tokens)...");
     let warm_start = Instant::now();
     let warm_result = backend
-        .generate("Reply OK.", 10, 0.7, &[], &[])
+        .generate("Reply OK.", 10, SamplingConfig::chat(), &[], &[])
         .expect("warm-up generate failed");
     eprintln!(
         "[smoke] warm-up: {} tokens in {}ms ({:.1} tok/s) — text={:?}",
@@ -125,7 +128,7 @@ fn qwen35_4b_metal_throughput_via_bundled_llamacpp() {
         .generate(
             "Count from 1 to 50, separated by commas.",
             100,
-            0.7,
+            SamplingConfig::chat(),
             &[],
             &[],
         )

--- a/src/workers/continuum-core/tests/persona_prompt_token_diagnostic.rs
+++ b/src/workers/continuum-core/tests/persona_prompt_token_diagnostic.rs
@@ -48,11 +48,12 @@ fn load_tokenizer_only() -> Model {
     // n_gpu_layers = 0 keeps weights on CPU only and avoids Metal pipeline
     // compilation. Tokenizer lives on the model object regardless of
     // device, so we get full tokenization without paying GPU init cost.
-    let path = PathBuf::from(model_path());
+    let path = model_path();
     assert!(
         path.exists(),
-        "Model GGUF not present at {model_path()}. \
-         Pull continuum-ai/qwen3.5-4b-code-forged-gguf via DMR before running this test."
+        "Model GGUF not present at {}. \
+         Pull continuum-ai/qwen3.5-4b-code-forged-gguf via DMR before running this test.",
+        path.display()
     );
     Model::load(
         &path,

--- a/src/workers/continuum-core/tests/qwen35_live_pipeline_diff.rs
+++ b/src/workers/continuum-core/tests/qwen35_live_pipeline_diff.rs
@@ -14,6 +14,7 @@
 //!   cargo test --release --test qwen35_live_pipeline_diff -- --ignored --nocapture
 
 use continuum_core::inference::backends::llamacpp::{LlamaCppBackend, LlamaCppConfig};
+use continuum_core::inference::backends::SamplingConfig;
 use std::path::PathBuf;
 
 mod common;
@@ -38,8 +39,16 @@ fn qwen35_live_pipeline_produces_correct_answer() {
 
     // temperature=0.0 → triggers Sampler::greedy() in start_request, fully
     // deterministic. Same path the chat persona uses for inference.
+    // Pure greedy (no repeat_penalty) so output matches the bare-decode test.
+    let sampling = SamplingConfig {
+        temperature: 0.0,
+        repeat_penalty: 1.0,
+        top_k: 0,
+        top_p: 1.0,
+        grammar: None,
+    };
     let (text, n_tokens) = backend
-        .generate(PROMPT, N_GENERATE, 0.0, &[], &[])
+        .generate(PROMPT, N_GENERATE, sampling, &[], &[])
         .expect("generate");
 
     eprintln!("[live-pipeline] tokens={n_tokens} text={text:?}");


### PR DESCRIPTION
## Summary

Three pre-existing canary breakages blocked the broader \`cargo --tests\` build path. These were flagged as out-of-scope in PR #1082's "Known gaps"; cleared here so the integration test build stays compilable going forward (and so regressions in any test file can land in CI signal instead of being masked behind \"build broken\" silence).

- \`llamacpp_metal_throughput.rs\` / \`qwen35_live_pipeline_diff.rs\`: backend \`.generate(...)\` signature took \`temperature: f64\` until the \`SamplingConfig\` refactor; tests still passed \`0.0\` / \`0.7\`. Updated to \`SamplingConfig\` literal (qwen35: explicit greedy, no repeat_penalty so output matches the bare-decode reference) and \`SamplingConfig::chat()\` (throughput: matches what live chat traffic uses).
- \`persona_prompt_token_diagnostic.rs\`: format string \`\"Model GGUF not present at {model_path()}\"\` uses Rust 2024 captured-identifier syntax which doesn't allow function calls — emits \"expected \`}\`, found \`(\`\" at compile time. Bound to a local + use positional \`{}\` with \`path.display()\`.

## Validation class

- Contract TDD: n/a — test-only diff, no production behavior changes.
- Failure TDD: n/a — same as above.
- Performance/Resource/Residency VDD: n/a.
- Browser/UX evidence: precommit browser ping passed.
- Platform coverage: Mac M5 Pro Metal, \`cargo build --features metal,accelerate --tests\` clean.

## Validation

- \`cargo build --features metal,accelerate --tests\` — clean, no errors (was 3 distinct errors before).
- \`cargo test --lib --features metal,accelerate\` — unchanged (pre-push gate).
- Precommit hook: TypeScript clean; browser-ping precommit test passed.

## Scope discipline

This is a test-fixture-only cleanup — three files, all under \`tests/\`. No production source touched. Cleared from PR #1082's Known-Gaps list.