### PR TITLE
ratchet(ts-cognition): add TS persona-cognition deletion ratchet (Lane F)

### DIFF
--- a/.github/workflows/ts-persona-cognition-ratchet.yml
+++ b/.github/workflows/ts-persona-cognition-ratchet.yml
@@ -1,0 +1,40 @@
+# Lane F (PR #1084) — TS Persona Cognition Deletion Ratchet.
+#
+# Enforces the Rust-first alpha contract (PR #1070,
+# docs/planning/ALPHA-GAP-ANALYSIS.md "Rust core owns behavior"):
+# every PR touching the persona surface must keep the TS line count
+# flat or shrink it. New cognition logic belongs in Rust, not in TS.
+#
+# Fast: shell + python only, no node_modules, no cargo. Runs in <10s.
+# Doesn't block on TS compile or Rust build — independent gate.
+
+name: ts-persona-cognition-ratchet
+
+on:
+  pull_request:
+    branches: [canary, main]
+    paths:
+      - 'src/system/user/server/**/*.ts'
+      - 'scripts/ratchets/ts-persona-cognition-baseline.json'
+      - 'scripts/ratchets/check-ts-persona-cognition.sh'
+      - '.github/workflows/ts-persona-cognition-ratchet.yml'
+  push:
+    branches: [canary, main]
+
+jobs:
+  ratchet:
+    name: ts-persona-cognition-ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Run ratchet check
+        run: bash scripts/ratchets/check-ts-persona-cognition.sh
+
+      - name: Print verbose surface table on failure
+        if: failure()
+        run: bash scripts/ratchets/check-ts-persona-cognition.sh --verbose || true

--- a/docs/architecture/TS-PERSONA-COGNITION-RATCHET.md
+++ b/docs/architecture/TS-PERSONA-COGNITION-RATCHET.md
@@ -1,0 +1,98 @@
+# TS Persona Cognition Deletion Ratchet
+
+**Lane F** (PR #1084 alpha workstreams). Enforces the Rust-first alpha
+contract (PR #1070, `docs/planning/ALPHA-GAP-ANALYSIS.md` — "Rust core
+owns behavior"): every PR touching the persona surface must keep the
+total TypeScript line count flat or shrink it.
+
+## What's measured
+
+The ratchet counts non-test `.ts` files under `src/system/user/server/`:
+
+```
+find src/system/user/server -type f -name '*.ts' \
+  -not -name '*.test.ts' -not -name '*.spec.ts' \
+  -exec cat {} + | wc -l
+```
+
+This includes the persona orchestration layer (`PersonaUser.ts`,
+`PersonaResponseGenerator.ts`, `PersonaMessageEvaluator.ts`,
+`RustCognitionBridge.ts`, etc.) — the surface that must shrink as Rust
+runtime takes ownership of cognition.
+
+## Why a single total, not per-file
+
+Refactors that move code between files within the surface are common
+and shouldn't trip the ratchet. What matters is the SURFACE total. A
+PR can grow one file by 200 lines AS LONG AS it deletes 200+ lines
+elsewhere in the surface.
+
+## Baseline
+
+`scripts/ratchets/ts-persona-cognition-baseline.json` carries the
+high-water mark. The CI gate fails any PR whose current count exceeds
+this number.
+
+## Lowering the baseline
+
+After a PR that legitimately shrinks the surface (e.g., deletes a
+TS-side cognition path because Rust now owns that responsibility),
+the **author** updates the baseline:
+
+```bash
+bash scripts/ratchets/check-ts-persona-cognition.sh --update-baseline
+git add scripts/ratchets/ts-persona-cognition-baseline.json
+git commit -m "ratchet: lower TS persona-cognition baseline to <new>"
+```
+
+This is intentionally a manual step. The baseline only ratchets DOWN —
+mechanical write-on-merge would lose the deletion-pressure signal.
+
+## What CI does
+
+`.github/workflows/ts-persona-cognition-ratchet.yml` runs:
+
+- On PRs to `canary`/`main` that touch the surface OR the ratchet config.
+- On direct pushes to `canary`/`main`.
+- Fast: shell + python only, ~10s.
+- Independent gate (doesn't block on TS compile or Rust build).
+
+Failure output names the actionable next step:
+
+```
+━━ ❌ TS persona-cognition RATCHET FAILED ━━
+  Baseline: 27160 lines
+  Current : 27200 lines
+  Delta   : +40 (growth)
+
+  Per Rust-first alpha contract (PR #1070, docs/planning/ALPHA-GAP-ANALYSIS.md),
+  the TS persona surface must SHRINK or stay flat. New cognition logic belongs
+  in Rust:
+    workers/continuum-core/src/persona/
+    workers/continuum-core/src/cognition/
+```
+
+## Local pre-PR check
+
+Before pushing a PR that touches the surface:
+
+```bash
+bash scripts/ratchets/check-ts-persona-cognition.sh --verbose
+```
+
+Prints the per-file LOC table so you see which file changed and by how much.
+
+## Out of scope (followups)
+
+- **Forbidden-strings check**: detect `"fallback"`, direct adapter
+  instantiation, or other anti-patterns Joel has flagged. Per #1084
+  Lane F success criteria. Will land as a separate gate next to this
+  one.
+- **Verb-shape detection**: identify cognition VERBS (e.g.,
+  `shouldRespond`, `scoreRelevance`) being added in TS even when total
+  LOC drops. Heuristic, harder to define rigorously — lower priority
+  than the LOC ratchet which catches the gross case.
+- **Pre-commit hook integration**: today's gate is CI-only. Adding to
+  pre-commit would catch growth before push, faster signal. Reserve
+  for after the LOC ratchet has been live for ~1 week so we know the
+  shape isn't going to oscillate.

--- a/scripts/ratchets/check-ts-persona-cognition.sh
+++ b/scripts/ratchets/check-ts-persona-cognition.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# check-ts-persona-cognition.sh — Lane F ratchet (PR #1084).
+#
+# Enforces "TS persona cognition must shrink." Counts current LOC under
+# src/system/user/server (excluding *.test.ts / *.spec.ts), compares to
+# the baseline in scripts/ratchets/ts-persona-cognition-baseline.json,
+# fails (exit 1) if current > baseline, succeeds (exit 0) otherwise.
+#
+# Per Rust-first alpha contract (PR #1070, ALPHA-GAP-ANALYSIS.md "Rust
+# core owns behavior"): every PR touching the persona surface must
+# either keep the line count flat or shrink it. New cognition logic
+# belongs in Rust (`workers/continuum-core/src/persona/`,
+# `workers/continuum-core/src/cognition/`), not in this TS surface.
+#
+# Modes:
+#   ./check-ts-persona-cognition.sh              # check + report; exit 0/1
+#   ./check-ts-persona-cognition.sh --update-baseline   # update + commit-ready (use after legitimate shrinks)
+#   ./check-ts-persona-cognition.sh --verbose     # print per-file LOC table
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BASELINE_FILE="$SCRIPT_DIR/ts-persona-cognition-baseline.json"
+SURFACE_DIR="$REPO_ROOT/src/system/user/server"
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+UPDATE_BASELINE=0
+VERBOSE=0
+for arg in "$@"; do
+  case "$arg" in
+    --update-baseline) UPDATE_BASELINE=1 ;;
+    --verbose|-v)      VERBOSE=1 ;;
+    --help|-h)
+      echo "Usage: $0 [--update-baseline] [--verbose]"
+      echo "  Default: check current LOC against baseline; exit non-zero on growth."
+      echo "  --update-baseline: rewrite baseline to current count (use after a legitimate shrink)."
+      echo "  --verbose: print per-file LOC table."
+      exit 0
+      ;;
+    *)
+      echo -e "${RED}Unknown arg: $arg${NC}" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -d "$SURFACE_DIR" ]]; then
+  echo -e "${RED}ERROR: surface directory not found: $SURFACE_DIR${NC}" >&2
+  exit 2
+fi
+
+if [[ ! -f "$BASELINE_FILE" ]]; then
+  echo -e "${RED}ERROR: baseline file not found: $BASELINE_FILE${NC}" >&2
+  echo "  Generate one by running this script with --update-baseline (the first time)." >&2
+  exit 2
+fi
+
+# Count current TS LOC excluding tests. Use find + wc for portability;
+# bash glob ** requires shopt globstar which isn't always set in CI.
+CURRENT_TOTAL=$(find "$SURFACE_DIR" -type f -name "*.ts" \
+  -not -name "*.test.ts" -not -name "*.spec.ts" \
+  -exec cat {} + | wc -l | tr -d ' ')
+
+# Read baseline. Use python3 (always present) instead of jq (may not be).
+BASELINE=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['total_lines'])" "$BASELINE_FILE")
+
+DELTA=$((CURRENT_TOTAL - BASELINE))
+
+if [[ "$VERBOSE" -eq 1 ]]; then
+  echo -e "${YELLOW}━━ TS persona-cognition surface (per-file LOC) ━━${NC}"
+  find "$SURFACE_DIR" -type f -name "*.ts" \
+    -not -name "*.test.ts" -not -name "*.spec.ts" \
+    -exec wc -l {} + | sort -n | tail -20
+  echo ""
+fi
+
+if [[ "$UPDATE_BASELINE" -eq 1 ]]; then
+  CURRENT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  CURRENT_ISO=$(date -u +"%Y-%m-%dT%H:%MZ")
+  python3 - "$BASELINE_FILE" "$CURRENT_TOTAL" "$CURRENT_SHA" "$CURRENT_ISO" <<'PYEOF'
+import json, sys
+path, total, sha, iso = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+with open(path) as f:
+    data = json.load(f)
+data["total_lines"] = total
+data["_baseline_anchored_at_canary"] = sha
+data["_anchored_at_iso"] = iso
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+PYEOF
+  echo -e "${GREEN}✓ baseline updated to ${CURRENT_TOTAL} (was ${BASELINE}, delta ${DELTA})${NC}"
+  echo "  Commit: git add $BASELINE_FILE"
+  exit 0
+fi
+
+if [[ "$DELTA" -gt 0 ]]; then
+  echo -e "${RED}━━ ❌ TS persona-cognition RATCHET FAILED ━━${NC}" >&2
+  echo -e "${RED}  Baseline: ${BASELINE} lines${NC}" >&2
+  echo -e "${RED}  Current : ${CURRENT_TOTAL} lines${NC}" >&2
+  echo -e "${RED}  Delta   : +${DELTA} (growth)${NC}" >&2
+  echo "" >&2
+  echo "  Per Rust-first alpha contract (PR #1070, docs/planning/ALPHA-GAP-ANALYSIS.md)," >&2
+  echo "  the TS persona surface must SHRINK or stay flat. New cognition logic belongs" >&2
+  echo "  in Rust:" >&2
+  echo "    workers/continuum-core/src/persona/" >&2
+  echo "    workers/continuum-core/src/cognition/" >&2
+  echo "" >&2
+  echo "  Options:" >&2
+  echo "    1. Move the new code Rust-side." >&2
+  echo "    2. Delete equivalent TS LOC elsewhere in the surface to keep total flat or below." >&2
+  echo "    3. If this PR genuinely shrinks net (despite some additions), re-run after the" >&2
+  echo "       deletes land in this branch." >&2
+  echo "" >&2
+  echo "  Current top files (run with --verbose for full table):" >&2
+  find "$SURFACE_DIR" -type f -name "*.ts" \
+    -not -name "*.test.ts" -not -name "*.spec.ts" \
+    -exec wc -l {} + | sort -n | tail -5 >&2
+  exit 1
+fi
+
+if [[ "$DELTA" -eq 0 ]]; then
+  echo -e "${GREEN}✓ TS persona-cognition ratchet held: ${CURRENT_TOTAL} lines (baseline ${BASELINE}, no change)${NC}"
+else
+  echo -e "${GREEN}✓ TS persona-cognition ratchet shrank: ${CURRENT_TOTAL} lines (baseline ${BASELINE}, delta ${DELTA})${NC}"
+  echo "  After merge: run this script with --update-baseline to lower the baseline."
+fi
+exit 0

--- a/scripts/ratchets/ts-persona-cognition-baseline.json
+++ b/scripts/ratchets/ts-persona-cognition-baseline.json
@@ -1,0 +1,14 @@
+{
+  "_doc": "Lane F (PR #1084) — TS Persona Cognition Deletion Ratchet. Tracks the total line count of TypeScript persona-cognition source files. Per the Rust-first alpha contract (PR #1070, ALPHA-GAP-ANALYSIS.md, memory: project_continuum_alpha_product_bar_sensory_personas.md), TS persona cognition must SHRINK as Rust runtime takes ownership. This baseline is the high-water mark: any PR that grows the total fails CI. Lower it monotonically as Rust migrations land.",
+  "_to_lower_baseline": "After a PR that legitimately shrinks the surface, run: bash scripts/ratchets/check-ts-persona-cognition.sh --update-baseline && git add scripts/ratchets/ts-persona-cognition-baseline.json && commit",
+  "_paths_glob_relative_to_repo_root": [
+    "src/system/user/server/**/*.ts"
+  ],
+  "_excludes": [
+    "*.test.ts",
+    "*.spec.ts"
+  ],
+  "_baseline_anchored_at_canary": "d2dc3a8e8",
+  "_anchored_at_iso": "2026-05-11T21:09Z",
+  "total_lines": 27160
+}


### PR DESCRIPTION
## Lane F (PR #1084) — TS Cognition Deletion Ratchet

Enforces the Rust-first alpha contract (PR #1070, `ALPHA-GAP-ANALYSIS.md` "Rust core owns behavior") via a CI gate that fails any PR which grows the total TS line count under `src/system/user/server/`. New cognition logic belongs in Rust (`workers/continuum-core/src/{persona,cognition}/`).

## 4 files, all additive

1. **`scripts/ratchets/ts-persona-cognition-baseline.json`** — `total_lines: 27160` (anchored at canary `d2dc3a8e8`). High-water mark; ratchet only goes DOWN.
2. **`scripts/ratchets/check-ts-persona-cognition.sh`** — bash + python3 only (no node_modules / cargo). `default` checks; `--update-baseline` rewrites baseline; `--verbose` prints per-file table.
3. **`.github/workflows/ts-persona-cognition-ratchet.yml`** — runs on PRs to canary/main when surface or ratchet config touched. Fast (~10s), independent gate.
4. **`docs/architecture/TS-PERSONA-COGNITION-RATCHET.md`** — operator docs.

## Why single total, not per-file

Refactors that move code within the surface shouldn't trip the gate. A PR can grow one file by 200 lines as long as it deletes 200+ elsewhere.

## Validation

- **Default on clean canary tree**: `✓ ratchet held: 27160 lines (baseline 27160, no change)` → exit 0
- **Intentional +1 line**: `❌ RATCHET FAILED ... Delta : +1 (growth)` → exit 1, full actionable text including Rust target paths
- **After restore**: passes again, baseline preserved
- **Precommit hook**: TypeScript build PASS, browser ping PASS
- **Pre-push hook**: PASS

## Out of scope (followups, named in docs)

- Forbidden-strings check (no new `"fallback"`/anti-pattern strings) — Lane F PR-2
- Verb-shape detection (cognition VERBS in TS even when LOC drops)
- Pre-commit hook integration (after CI-only ratchet has been live ~1 week)

🤖 Generated with [Claude Code](https://claude.com/claude-code)