### PR TITLE
feat(model): admit Qwen2.5-Omni sensory input

### DIFF
--- a/src/workers/continuum-core/config/models.toml
+++ b/src/workers/continuum-core/config/models.toml
@@ -306,6 +306,37 @@ gguf_hint = "huggingface.co/bartowski/Qwen2-VL-7B-Instruct-GGUF"
 gguf_local_path = "~/models/qwen2-vl-7b/Qwen2-VL-7B-Instruct-Q4_K_M.gguf"
 mmproj_local_path = "~/models/qwen2-vl-7b/mmproj-Qwen2-VL-7B-Instruct-f16.gguf"
 
+# ─── Sensory-input Qwen2.5-Omni-7B (in-process llama.cpp + mtmd) ─────────
+# Full-tier local sensory-input candidate validated on RTX 5090 sm_120
+# (2026-05-11, upstream llama.cpp 1ec7ba0):
+#   - text bench: pp512 ~13,659 t/s, tg128 ~220 t/s
+#   - vision smoke: image description passed, text generation ~212 t/s
+#   - audio smoke: JFK WAV transcription passed, text generation ~216 t/s
+#
+# Capability boundary is explicit: this row declares AudioInput, not
+# AudioOutput. The GGUF path does not yet prove native speech output, so voice
+# output remains a typed downstream adapter / forge task.
+#
+# Known VDD gap: upstream llama.cpp reports CUDA POOL_1D unsupported in the
+# CLIP/mmproj graph on Blackwell sm_120, so that operator falls back to CPU.
+# Decode remains CUDA/full-offload. Keep this row marked as a full-tier
+# candidate with a tracked upstream kernel gap until POOL_1D is implemented.
+[[model]]
+id = "qwen2.5-omni-7b-instruct"
+name = "Qwen2.5-Omni-7B-Instruct (in-process)"
+provider = "llamacpp-local"
+arch = "qwen2"
+context_window = 32768
+max_output_tokens = 4096
+tokens_per_second = 220.0
+capabilities = ["text-generation", "chat", "vision", "audio-input", "streaming"]
+cost_input_per_1k = 0.0
+cost_output_per_1k = 0.0
+multi_party_strategy = "proper_chat_ml_single_party"
+gguf_hint = "huggingface.co/ggml-org/Qwen2.5-Omni-7B-GGUF"
+gguf_local_path = "~/models/qwen2.5-omni-7b/Qwen2.5-Omni-7B-Q4_K_M.gguf"
+mmproj_local_path = "~/models/qwen2.5-omni-7b/mmproj-Qwen2.5-Omni-7B-f16.gguf"
+
 # ─── Local in-process: Qwen2-Audio-7B-Instruct (audio-input native) ───
 #
 # DISABLED 2026-04-22 — registering this model spawns a SECOND

--- a/src/workers/continuum-core/src/cognition/model_resolver.rs
+++ b/src/workers/continuum-core/src/cognition/model_resolver.rs
@@ -507,6 +507,18 @@ mod tests {
                 ],
             ),
             make_model(
+                "qwen2.5-omni-7b-instruct",
+                "llamacpp-local",
+                Arch::Qwen2,
+                32_768,
+                &[
+                    Capability::TextGeneration,
+                    Capability::Chat,
+                    Capability::Vision,
+                    Capability::AudioInput,
+                ],
+            ),
+            make_model(
                 "qwen2-0.5b-gating",
                 "llamacpp-local",
                 Arch::Qwen2,
@@ -529,6 +541,19 @@ mod tests {
     fn req_vision_local(host: HostCapability) -> ModelRequirement {
         ModelRequirement {
             required_capabilities: [Capability::Chat, Capability::Vision]
+                .iter()
+                .copied()
+                .collect(),
+            arch_preference: vec![],
+            context_window_min: 0,
+            provider_policy: LocalOrCloudPolicy::LocalOnly,
+            host,
+        }
+    }
+
+    fn req_sensory_input_local(host: HostCapability) -> ModelRequirement {
+        ModelRequirement {
+            required_capabilities: [Capability::Chat, Capability::Vision, Capability::AudioInput]
                 .iter()
                 .copied()
                 .collect(),
@@ -566,6 +591,49 @@ mod tests {
         assert_eq!(resolved.provider_id, "llamacpp-local");
         assert_eq!(resolved.target_silicon, TargetSilicon::Gpu);
         assert_eq!(resolved.hw_capability_tier, HwCapabilityTier::Sm120);
+    }
+
+    #[test]
+    fn sensory_input_request_resolves_to_qwen25_omni_on_rtx() {
+        let r = registry();
+        let resolved = resolve_model(
+            &req_sensory_input_local(host_rtx5090()),
+            r.iter(),
+            providers().iter(),
+        )
+        .unwrap();
+        assert_eq!(resolved.model_id, "qwen2.5-omni-7b-instruct");
+        assert_eq!(resolved.provider_id, "llamacpp-local");
+        assert_eq!(resolved.target_silicon, TargetSilicon::Gpu);
+        assert_eq!(resolved.hw_capability_tier, HwCapabilityTier::Sm120);
+    }
+
+    #[test]
+    fn local_full_sensory_rejects_cloud_audio_output_no_fallback() {
+        let r = registry();
+        let req = ModelRequirement {
+            required_capabilities: [
+                Capability::Chat,
+                Capability::Vision,
+                Capability::AudioInput,
+                Capability::AudioOutput,
+            ]
+            .iter()
+            .copied()
+            .collect(),
+            arch_preference: vec![],
+            context_window_min: 0,
+            provider_policy: LocalOrCloudPolicy::LocalOnly,
+            host: host_rtx5090(),
+        };
+        let err = resolve_model(&req, r.iter(), providers().iter()).unwrap_err();
+        let ResolutionError::NoModelMatchesRequirement { unmet_filters, .. } = err;
+        assert!(
+            unmet_filters
+                .iter()
+                .any(|filter| filter.contains("provider_policy=LocalOnly")),
+            "local full-sensory must not fall back to cloud audio-output, got {unmet_filters:?}"
+        );
     }
 
     #[test]

--- a/src/workers/continuum-core/src/model_registry/loader.rs
+++ b/src/workers/continuum-core/src/model_registry/loader.rs
@@ -412,6 +412,22 @@ auth = "none"
             .expect("forged Qwen3.5-4B must be in the registry");
         assert_eq!(forged.arch, crate::model_registry::Arch::Qwen35);
         assert_eq!(forged.context_window, 262144);
+
+        let omni = reg
+            .model("qwen2.5-omni-7b-instruct")
+            .expect("Qwen2.5-Omni-7B sensory-input model must be in the registry");
+        assert_eq!(omni.provider, "llamacpp-local");
+        assert_eq!(omni.arch, crate::model_registry::Arch::Qwen2);
+        assert!(omni.has(crate::model_registry::Capability::Vision));
+        assert!(omni.has(crate::model_registry::Capability::AudioInput));
+        assert!(
+            !omni.has(crate::model_registry::Capability::AudioOutput),
+            "GGUF admission must not claim native audio output until it is validated"
+        );
+        assert!(
+            omni.mmproj_local_path.is_some(),
+            "local sensory-input admission requires an mmproj path"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Qwen2.5-Omni-7B as the local llama.cpp sensory-input model candidate with vision + audio-input capabilities
- keep the capability boundary explicit: no native audio-output claim until validated
- add resolver coverage proving local sensory input resolves to Omni on RTX/SM120 and local full-sensory does not fall back to cloud audio-output
- add real models.toml validation for the Omni registry row and mmproj path

## Validation
- cargo test -p continuum-core --features metal,accelerate cognition::model_resolver --lib
- cargo test -p continuum-core --features metal,accelerate model_registry::loader::tests::real_config_files_parse_and_validate --lib
- precommit hook: TypeScript build, Rust clippy baseline, browser ping
- prepush hook: TypeScript clean, ESLint baseline, Rust compile, Rust tests

## VDD Notes
- RTX 5090 Qwen2.5-Omni-7B bench from continuum-8e97: text pp512 ~13,659 t/s, tg128 ~220 t/s; vision smoke ~212 t/s text-gen; audio smoke ~216 t/s text-gen
- Known upstream gap remains loud: CUDA POOL_1D unsupported in CLIP/mmproj graph on Blackwell, so this is admitted as sensory-input candidate with tracked kernel work, not as a fully solved GPU path