### PR TITLE
feat(ai-key): add redacted diff planning command

### DIFF
--- a/src/commands/ai/key/diff/.npmignore
+++ b/src/commands/ai/key/diff/.npmignore
@@ -1,0 +1,20 @@
+# Development files
+.eslintrc*
+tsconfig*.json
+vitest.config.ts
+
+# Build artifacts
+*.js.map
+*.d.ts.map
+
+# IDE
+.vscode/
+.idea/
+
+# Logs
+*.log
+npm-debug.log*
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/src/commands/ai/key/diff/README.md
+++ b/src/commands/ai/key/diff/README.md
@@ -1,0 +1,142 @@
+# Ai Key Diff Command
+
+Compare redacted AI key status entries and produce a value-free merge plan for trusted grid reconciliation.
+
+## Table of Contents
+
+- [Usage](#usage)
+  - [CLI Usage](#cli-usage)
+  - [Tool Usage](#tool-usage)
+- [Parameters](#parameters)
+- [Result](#result)
+- [Examples](#examples)
+- [Testing](#testing)
+  - [Unit Tests](#unit-tests)
+  - [Integration Tests](#integration-tests)
+- [Getting Help](#getting-help)
+- [Access Level](#access-level)
+- [Implementation Notes](#implementation-notes)
+
+## Usage
+
+### CLI Usage
+
+From the command line using the jtag CLI:
+
+```bash
+./jtag ai/key/diff --localEntries='[...]' --remoteEntries='[...]' --targetNode=windows-rtx
+```
+
+### Tool Usage
+
+From Persona tools or programmatic access using `Commands.execute()`:
+
+```typescript
+import { Commands } from '@system/core/shared/Commands';
+
+const result = await Commands.execute('ai/key/diff', {
+  localEntries,
+  remoteEntries,
+  targetNode: 'windows-rtx',
+});
+```
+
+## Parameters
+
+- **localEntries** (required): `array` - Local redacted ai/key/status entries.
+- **remoteEntries** (required): `array` - Remote redacted ai/key/status entries from a trusted target node.
+- **targetNode** (optional): `string` - Optional target node id or name for merge-plan labels.
+
+## Result
+
+Returns `AiKeyDiffResult` with:
+
+Returns CommandResult with:
+- **mergePlanId**: `string` - Stable id for this value-free merge plan.
+- **actions**: `array` - Merge actions containing provider/key/action/reason/fingerprint metadata only.
+- **conflictCount**: `number` - Number of conflicts requiring owner approval.
+- **actionCount**: `number` - Number of generated actions.
+
+## Examples
+
+### Compare local and remote redacted key states
+
+```bash
+./jtag ai/key/diff --localEntries='[...]' --remoteEntries='[...]' --targetNode=windows-rtx
+```
+
+**Expected result:**
+{ success: true, actionCount: 1, conflictCount: 0 }
+
+## Getting Help
+
+### Using the Help Tool
+
+Get detailed usage information for this command:
+
+**CLI:**
+```bash
+./jtag help ai/key/diff
+```
+
+**Tool:**
+```typescript
+// Use your help tool with command name 'ai/key/diff'
+```
+
+### Using the README Tool
+
+Access this README programmatically:
+
+**CLI:**
+```bash
+./jtag readme ai/key/diff
+```
+
+**Tool:**
+```typescript
+// Use your readme tool with command name 'ai/key/diff'
+```
+
+## Testing
+
+### Unit Tests
+
+Test value-free merge-plan behavior without server dependencies:
+
+```bash
+# Run unit tests (no server required)
+npx tsx commands/ai/key/diff/test/unit/AiKeyDiffCommand.test.ts
+```
+
+**What's tested:**
+- Same redacted fingerprints produce no-op actions
+- Missing remote/local keys produce explicit copy-plan actions
+- Different configured fingerprints produce conflicts
+- Missing keys on both sides are omitted
+- Merge plan ids are deterministic across input ordering
+- Results never serialize raw secret values
+
+### Integration Tests
+
+Smoke-test the shared params/result factories:
+
+```bash
+npx tsx commands/ai/key/diff/test/integration/AiKeyDiffIntegration.test.ts
+```
+
+**What's tested:**
+- Factory preservation of local/remote status arrays
+- Default empty merge-plan fields
+
+## Access Level
+
+**owner-only** - This command compares redacted key metadata for trusted grid reconciliation.
+
+## Implementation Notes
+
+- **Shared Logic**: Core business logic in `shared/AiKeyDiffPlanner.ts`
+- **Browser**: Browser-specific implementation in `browser/AiKeyDiffBrowserCommand.ts`
+- **Server**: Server-specific implementation in `server/AiKeyDiffServerCommand.ts`
+- **Unit Tests**: Isolated testing in `test/unit/AiKeyDiffCommand.test.ts`
+- **Integration Tests**: System testing in `test/integration/AiKeyDiffIntegration.test.ts`

--- a/src/commands/ai/key/diff/browser/AiKeyDiffBrowserCommand.ts
+++ b/src/commands/ai/key/diff/browser/AiKeyDiffBrowserCommand.ts
@@ -1,0 +1,21 @@
+/**
+ * Ai Key Diff Command - Browser Implementation
+ *
+ * Compare redacted AI key status entries and produce a value-free merge plan for trusted grid reconciliation.
+ */
+
+import { CommandBase, type ICommandDaemon } from '@daemons/command-daemon/shared/CommandBase';
+import type { JTAGContext } from '@system/core/types/JTAGTypes';
+import type { AiKeyDiffParams, AiKeyDiffResult } from '../shared/AiKeyDiffTypes';
+
+export class AiKeyDiffBrowserCommand extends CommandBase<AiKeyDiffParams, AiKeyDiffResult> {
+
+  constructor(context: JTAGContext, subpath: string, commander: ICommandDaemon) {
+    super('ai/key/diff', context, subpath, commander);
+  }
+
+  async execute(params: AiKeyDiffParams): Promise<AiKeyDiffResult> {
+    console.log('🌐 BROWSER: Delegating Ai Key Diff to server');
+    return await this.remoteExecute(params);
+  }
+}

--- a/src/commands/ai/key/diff/package.json
+++ b/src/commands/ai/key/diff/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@jtag-commands/ai/key/diff",
+  "version": "1.0.0",
+  "description": "Compare redacted AI key status entries and produce a value-free merge plan for trusted grid reconciliation.",
+  "main": "server/AiKeyDiffServerCommand.ts",
+  "types": "shared/AiKeyDiffTypes.ts",
+  "scripts": {
+    "test": "npm run test:unit && npm run test:integration",
+    "test:unit": "npx vitest run test/unit/*.test.ts",
+    "test:integration": "npx tsx test/integration/AiKeyDiffIntegration.test.ts",
+    "lint": "npx eslint **/*.ts",
+    "typecheck": "npx tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@jtag/core": "*"
+  },
+  "files": [
+    "shared/**/*.ts",
+    "browser/**/*.ts",
+    "server/**/*.ts",
+    "test/**/*.ts",
+    "README.md"
+  ],
+  "keywords": [
+    "jtag",
+    "command",
+    "ai/key/diff"
+  ],
+  "license": "MIT",
+  "author": "",
+  "repository": {
+    "type": "git",
+    "url": ""
+  }
+}

--- a/src/commands/ai/key/diff/server/AiKeyDiffServerCommand.ts
+++ b/src/commands/ai/key/diff/server/AiKeyDiffServerCommand.ts
@@ -1,0 +1,47 @@
+/**
+ * Ai Key Diff Command - Server Implementation
+ *
+ * Compare redacted AI key status entries and produce a value-free merge plan for trusted grid reconciliation.
+ */
+
+import { CommandBase, type ICommandDaemon } from '@daemons/command-daemon/shared/CommandBase';
+import type { JTAGContext } from '@system/core/types/JTAGTypes';
+import { ValidationError } from '@system/core/types/ErrorTypes';
+import type { AiKeyDiffParams, AiKeyDiffResult } from '../shared/AiKeyDiffTypes';
+import { createAiKeyDiffResultFromParams } from '../shared/AiKeyDiffTypes';
+import { buildAiKeyDiffActions, createAiKeyMergePlanId } from '../shared/AiKeyDiffPlanner';
+
+export class AiKeyDiffServerCommand extends CommandBase<AiKeyDiffParams, AiKeyDiffResult> {
+
+  constructor(context: JTAGContext, subpath: string, commander: ICommandDaemon) {
+    super('ai/key/diff', context, subpath, commander);
+  }
+
+  async execute(params: AiKeyDiffParams): Promise<AiKeyDiffResult> {
+    await Promise.resolve();
+
+    if (!Array.isArray(params.localEntries)) {
+      throw new ValidationError(
+        'localEntries',
+        `Missing required array parameter 'localEntries'. Use ai/key/status output for the local node.`
+      );
+    }
+
+    if (!Array.isArray(params.remoteEntries)) {
+      throw new ValidationError(
+        'remoteEntries',
+        `Missing required array parameter 'remoteEntries'. Use ai/key/status output from a trusted remote node.`
+      );
+    }
+
+    const actions = buildAiKeyDiffActions(params.localEntries, params.remoteEntries, params.targetNode);
+
+    return createAiKeyDiffResultFromParams(params, {
+      success: true,
+      mergePlanId: createAiKeyMergePlanId(actions, params.targetNode),
+      actions,
+      conflictCount: actions.filter(action => action.action === 'conflict').length,
+      actionCount: actions.length,
+    });
+  }
+}

--- a/src/commands/ai/key/diff/shared/AiKeyDiffPlanner.ts
+++ b/src/commands/ai/key/diff/shared/AiKeyDiffPlanner.ts
@@ -1,0 +1,133 @@
+import { createHash } from 'node:crypto';
+import type { AiKeyStatusEntry } from '../../status/shared/AiKeyStatusTypes';
+import type { AiKeyDiffAction, AiKeyDiffActionType } from './AiKeyDiffTypes';
+
+interface IndexedEntry {
+  entry: AiKeyStatusEntry;
+}
+
+function entryId(entry: AiKeyStatusEntry): string {
+  return `${entry.key.toUpperCase()}::${entry.provider.toLowerCase()}`;
+}
+
+function pickDisplayEntry(local: AiKeyStatusEntry | undefined, remote: AiKeyStatusEntry | undefined): AiKeyStatusEntry {
+  if (local) {
+    return local;
+  }
+
+  if (remote) {
+    return remote;
+  }
+
+  throw new Error('AiKeyDiff planner cannot build an action without a local or remote entry');
+}
+
+function indexEntries(entries: AiKeyStatusEntry[]): Map<string, IndexedEntry> {
+  const indexed = new Map<string, IndexedEntry>();
+
+  for (const entry of entries) {
+    indexed.set(entryId(entry), { entry });
+  }
+
+  return indexed;
+}
+
+function actionReason(action: AiKeyDiffActionType): string {
+  switch (action) {
+    case 'noop':
+      return 'Both nodes report the same redacted fingerprint.';
+    case 'copy-local-to-remote':
+      return 'Local node is configured and remote node is missing this key.';
+    case 'copy-remote-to-local':
+      return 'Remote node is configured and local node is missing this key.';
+    case 'conflict':
+      return 'Both nodes are configured but report different redacted fingerprints.';
+  }
+}
+
+function classifyAction(local?: AiKeyStatusEntry, remote?: AiKeyStatusEntry): AiKeyDiffActionType | undefined {
+  const localConfigured = local?.configured === true;
+  const remoteConfigured = remote?.configured === true;
+
+  if (!localConfigured && !remoteConfigured) {
+    return undefined;
+  }
+
+  if (localConfigured && remoteConfigured) {
+    return local?.fingerprint === remote?.fingerprint ? 'noop' : 'conflict';
+  }
+
+  return localConfigured ? 'copy-local-to-remote' : 'copy-remote-to-local';
+}
+
+export function buildAiKeyDiffActions(
+  localEntries: AiKeyStatusEntry[],
+  remoteEntries: AiKeyStatusEntry[],
+  targetNode?: string
+): AiKeyDiffAction[] {
+  const localById = indexEntries(localEntries);
+  const remoteById = indexEntries(remoteEntries);
+  const ids = [...new Set([...localById.keys(), ...remoteById.keys()])].sort();
+  const actions: AiKeyDiffAction[] = [];
+
+  for (const id of ids) {
+    const local = localById.get(id)?.entry;
+    const remote = remoteById.get(id)?.entry;
+    const action = classifyAction(local, remote);
+
+    if (!action) {
+      continue;
+    }
+
+    const display = pickDisplayEntry(local, remote);
+    actions.push({
+      provider: display.provider,
+      key: display.key,
+      action,
+      reason: actionReason(action),
+      localConfigured: local?.configured === true,
+      remoteConfigured: remote?.configured === true,
+      localFingerprint: local?.fingerprint,
+      remoteFingerprint: remote?.fingerprint,
+      targetNode,
+      requiresApproval: action !== 'noop',
+    });
+  }
+
+  return actions;
+}
+
+export function createAiKeyMergePlanId(actions: AiKeyDiffAction[], targetNode?: string): string {
+  const normalized = actions
+    .map(action => ({
+      action: action.action,
+      key: action.key,
+      localConfigured: action.localConfigured,
+      localFingerprint: action.localFingerprint ?? '',
+      provider: action.provider,
+      remoteConfigured: action.remoteConfigured,
+      remoteFingerprint: action.remoteFingerprint ?? '',
+      targetNode: action.targetNode ?? targetNode ?? '',
+    }))
+    .sort((left, right) => {
+      const leftId = `${left.key}:${left.provider}`;
+      const rightId = `${right.key}:${right.provider}`;
+
+      if (leftId < rightId) {
+        return -1;
+      }
+
+      if (leftId > rightId) {
+        return 1;
+      }
+
+      return 0;
+    });
+
+  const digest = createHash('sha256')
+    .update(JSON.stringify(normalized))
+    .digest('hex')
+    .slice(0, 16);
+
+  return `aikdiff_${digest}`;
+}

--- a/src/commands/ai/key/diff/shared/AiKeyDiffTypes.ts
+++ b/src/commands/ai/key/diff/shared/AiKeyDiffTypes.ts
@@ -1,0 +1,134 @@
+/**
+ * Ai Key Diff Command - Shared Types
+ *
+ * Compare redacted AI key status entries and produce a value-free merge plan for trusted grid reconciliation.
+ */
+
+import type { CommandInput, CommandParams, JTAGContext } from '@system/core/types/JTAGTypes';
+import { transformPayload } from '@system/core/types/JTAGTypes';
+import { Commands } from '@system/core/shared/Commands';
+import type { JTAGError } from '@system/core/types/ErrorTypes';
+import type { UUID } from '@system/core/types/CrossPlatformUUID';
+import {
+  type AiKeyParams,
+  type AiKeyResult,
+  createAiKeyParams,
+  createAiKeyResult
+} from '../../common/AiKeyBase';
+import type { AiKeyStatusEntry } from '../../status/shared/AiKeyStatusTypes';
+
+export type AiKeyDiffActionType =
+  | 'noop'
+  | 'copy-local-to-remote'
+  | 'copy-remote-to-local'
+  | 'conflict';
+
+export interface AiKeyDiffAction {
+  provider: string;
+  key: string;
+  action: AiKeyDiffActionType;
+  reason: string;
+  localConfigured: boolean;
+  remoteConfigured: boolean;
+  localFingerprint?: string;
+  remoteFingerprint?: string;
+  targetNode?: string;
+  requiresApproval: boolean;
+}
+
+/**
+ * Ai Key Diff Command Parameters
+ */
+export interface AiKeyDiffParams extends CommandParams, AiKeyParams {
+  // Local redacted ai/key/status entries.
+  localEntries: AiKeyStatusEntry[];
+  // Remote redacted ai/key/status entries from a trusted target node.
+  remoteEntries: AiKeyStatusEntry[];
+  // Optional target node id or name for merge-plan labels.
+  targetNode?: string;
+}
+
+/**
+ * Factory function for creating AiKeyDiffParams
+ */
+export const createAiKeyDiffParams = (
+  context: JTAGContext,
+  sessionId: UUID,
+  userId: UUID,
+  data: {
+    // Local redacted ai/key/status entries.
+    localEntries: AiKeyStatusEntry[];
+    // Remote redacted ai/key/status entries from a trusted target node.
+    remoteEntries: AiKeyStatusEntry[];
+    // Optional target node id or name for merge-plan labels.
+    targetNode?: string;
+  },
+): AiKeyDiffParams => createAiKeyParams(context, sessionId, {
+  userId,
+  ...data,
+});
+
+/**
+ * Ai Key Diff Command Result
+ */
+export interface AiKeyDiffResult extends AiKeyResult {
+  // Stable id for this value-free merge plan.
+  mergePlanId: string;
+  // Merge actions containing provider/key/action/reason/fingerprint metadata only.
+  actions: AiKeyDiffAction[];
+  // Number of conflicts requiring owner approval.
+  conflictCount: number;
+  // Number of generated actions.
+  actionCount: number;
+  error?: JTAGError;
+}
+
+/**
+ * Factory function for creating AiKeyDiffResult with defaults
+ */
+export const createAiKeyDiffResult = (
+  context: JTAGContext,
+  sessionId: UUID,
+  data: {
+    success: boolean;
+    // Stable id for this value-free merge plan.
+    mergePlanId?: string;
+    // Merge actions containing provider/key/action/reason/fingerprint metadata only.
+    actions?: AiKeyDiffAction[];
+    // Number of conflicts requiring owner approval.
+    conflictCount?: number;
+    // Number of generated actions.
+    actionCount?: number;
+    error?: JTAGError;
+  }
+): AiKeyDiffResult => createAiKeyResult(context, sessionId, {
+  mergePlanId: data.mergePlanId ?? '',
+  actions: data.actions ?? [],
+  conflictCount: data.conflictCount ?? 0,
+  actionCount: data.actionCount ?? 0,
+  ...data
+});
+
+/**
+ * Smart Ai Key Diff-specific inheritance from params
+ * Auto-inherits context and sessionId from params
+ * Must provide all required result fields
+ */
+export const createAiKeyDiffResultFromParams = (
+  params: AiKeyDiffParams,
+  differences: Omit<AiKeyDiffResult, 'context' | 'sessionId' | 'userId'>
+): AiKeyDiffResult => transformPayload(params, differences);
+
+/**
+ * Ai Key Diff — Type-safe command executor
+ *
+ * Usage:
+ *   import { AiKeyDiff } from '...shared/AiKeyDiffTypes';
+ *   const result = await AiKeyDiff.execute({ ... });
+ */
+export const AiKeyDiff = {
+  execute(params: CommandInput<AiKeyDiffParams>): Promise<AiKeyDiffResult> {
+    return Commands.execute<AiKeyDiffParams, AiKeyDiffResult>('ai/key/diff', params as Partial<AiKeyDiffParams>);
+  },
+  commandName: 'ai/key/diff' as const,
+} as const;

--- a/src/commands/ai/key/diff/test/integration/AiKeyDiffIntegration.test.ts
+++ b/src/commands/ai/key/diff/test/integration/AiKeyDiffIntegration.test.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env tsx
+
+import { generateUUID } from '@system/core/types/CrossPlatformUUID';
+import { createAiKeyDiffParams, createAiKeyDiffResult } from '../../shared/AiKeyDiffTypes';
+
+const context = { environment: 'server' as const };
+const sessionId = generateUUID();
+const params = createAiKeyDiffParams(context, sessionId, generateUUID(), {
+  localEntries: [],
+  remoteEntries: [],
+  targetNode: 'windows-rtx',
+});
+
+if (!Array.isArray(params.localEntries) || !Array.isArray(params.remoteEntries)) {
+  throw new Error('AiKeyDiff params factory did not preserve entry arrays');
+}
+
+const result = createAiKeyDiffResult(context, sessionId, {
+  success: true,
+});
+
+if (!result.success || result.mergePlanId !== '' || result.actionCount !== 0 || result.conflictCount !== 0) {
+  throw new Error('AiKeyDiff result factory did not apply defaults correctly');
+}
+
+console.log('AiKeyDiff integration smoke passed');

--- a/src/commands/ai/key/diff/test/unit/AiKeyDiffCommand.test.ts
+++ b/src/commands/ai/key/diff/test/unit/AiKeyDiffCommand.test.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env tsx
+
+import { generateUUID } from '@system/core/types/CrossPlatformUUID';
+import type { AiKeyStatusEntry } from '../../status/shared/AiKeyStatusTypes';
+import { createAiKeyDiffResult } from '../../shared/AiKeyDiffTypes';
+import { buildAiKeyDiffActions, createAiKeyMergePlanId } from '../../shared/AiKeyDiffPlanner';
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function entry(overrides: Partial<AiKeyStatusEntry>): AiKeyStatusEntry {
+  return {
+    provider: 'OpenAI',
+    key: 'OPENAI_API_KEY',
+    category: 'cloud',
+    configured: false,
+    empty: true,
+    source: 'missing',
+    description: 'GPT models',
+    ...overrides,
+  };
+}
+
+const rawSecret = 'sk-test-raw-secret-that-must-never-appear';
+
+const sameFingerprint = buildAiKeyDiffActions(
+  [entry({ configured: true, empty: false, fingerprint: 'fp_same', source: 'continuum-home' })],
+  [entry({ configured: true, empty: false, fingerprint: 'fp_same', source: 'process-env' })],
+  'windows-rtx'
+);
+
+assert(sameFingerprint.length === 1, 'same configured fingerprints produce one action');
+assert(sameFingerprint[0]?.action === 'noop', 'same configured fingerprints are no-op');
+assert(sameFingerprint[0]?.requiresApproval === false, 'no-op action does not require approval');
+
+const localOnly = buildAiKeyDiffActions(
+  [entry({ configured: true, empty: false, fingerprint: 'fp_local', source: 'continuum-home' })],
+  [entry({ configured: false, empty: true, source: 'missing' })],
+  'windows-rtx'
+);
+
+assert(localOnly.length === 1, 'local-only configured key produces one action');
+assert(localOnly[0]?.action === 'copy-local-to-remote', 'local-only key plans copy to remote');
+assert(localOnly[0]?.requiresApproval === true, 'copy action requires approval');
+assert(localOnly[0]?.localFingerprint === 'fp_local', 'copy action carries local fingerprint metadata');
+assert(!JSON.stringify(localOnly).includes(rawSecret), 'diff action serialization does not include raw secret');
+
+const conflict = buildAiKeyDiffActions(
+  [entry({ configured: true, empty: false, fingerprint: 'fp_local' })],
+  [entry({ configured: true, empty: false, fingerprint: 'fp_remote' })],
+  'windows-rtx'
+);
+
+assert(conflict.length === 1, 'different configured fingerprints produce one action');
+assert(conflict[0]?.action === 'conflict', 'different configured fingerprints produce conflict');
+assert(conflict[0]?.requiresApproval === true, 'conflict requires approval');
+
+const empty = buildAiKeyDiffActions(
+  [entry({ configured: false, empty: true })],
+  [entry({ configured: false, empty: true })],
+  'windows-rtx'
+);
+
+assert(empty.length === 0, 'missing keys on both sides are omitted from merge plan');
+
+const ordered = buildAiKeyDiffActions(
+  [
+    entry({ provider: 'OpenAI', key: 'OPENAI_API_KEY', configured: true, empty: false, fingerprint: 'fp_openai' }),
+    entry({ provider: 'Anthropic', key: 'ANTHROPIC_API_KEY', configured: true, empty: false, fingerprint: 'fp_anthropic' }),
+  ],
+  [],
+  'windows-rtx'
+);
+const reversed = buildAiKeyDiffActions(
+  [
+    entry({ provider: 'Anthropic', key: 'ANTHROPIC_API_KEY', configured: true, empty: false, fingerprint: 'fp_anthropic' }),
+    entry({ provider: 'OpenAI', key: 'OPENAI_API_KEY', configured: true, empty: false, fingerprint: 'fp_openai' }),
+  ],
+  [],
+  'windows-rtx'
+);
+
+assert(
+  createAiKeyMergePlanId(ordered, 'windows-rtx') === createAiKeyMergePlanId(reversed, 'windows-rtx'),
+  'merge plan id is deterministic across input ordering'
+);
+
+const context = { environment: 'server' as const };
+const sessionId = generateUUID();
+const result = createAiKeyDiffResult(context, sessionId, {
+  success: true,
+  mergePlanId: createAiKeyMergePlanId(conflict, 'windows-rtx'),
+  actions: conflict,
+  conflictCount: conflict.filter(action => action.action === 'conflict').length,
+  actionCount: conflict.length,
+});
+
+assert(result.success === true, 'result factory preserves success');
+assert(result.actionCount === 1, 'result factory preserves action count');
+assert(result.conflictCount === 1, 'result factory preserves conflict count');
+assert(result.actions[0]?.action === 'conflict', 'result factory preserves actions');
+
+console.log('AiKeyDiff command tests passed');

--- a/src/generator/specs/ai-key-diff.json
+++ b/src/generator/specs/ai-key-diff.json
@@ -1,0 +1,54 @@
+{
+  "name": "ai/key/diff",
+  "description": "Compare redacted AI key status entries and produce a value-free merge plan for trusted grid reconciliation.",
+  "params": [
+    {
+      "name": "localEntries",
+      "type": "array",
+      "optional": false,
+      "description": "Local redacted ai/key/status entries."
+    },
+    {
+      "name": "remoteEntries",
+      "type": "array",
+      "optional": false,
+      "description": "Remote redacted ai/key/status entries from a trusted target node."
+    },
+    {
+      "name": "targetNode",
+      "type": "string",
+      "optional": true,
+      "description": "Optional target node id or name for merge-plan labels."
+    }
+  ],
+  "results": [
+    {
+      "name": "mergePlanId",
+      "type": "string",
+      "description": "Stable id for this value-free merge plan."
+    },
+    {
+      "name": "actions",
+      "type": "array",
+      "description": "Merge actions containing provider/key/action/reason/fingerprint metadata only."
+    },
+    {
+      "name": "conflictCount",
+      "type": "number",
+      "description": "Number of conflicts requiring owner approval."
+    },
+    {
+      "name": "actionCount",
+      "type": "number",
+      "description": "Number of generated actions."
+    }
+  ],
+  "examples": [
+    {
+      "description": "Compare local and remote redacted key states",
+      "command": "./jtag ai/key/diff --localEntries='[...]' --remoteEntries='[...]' --targetNode=windows-rtx",
+      "expectedResult": "{ success: true, actionCount: 1, conflictCount: 0 }"
+    }
+  ],
+  "accessLevel": "owner-only"
+}


### PR DESCRIPTION
## Summary
- add generated ai/key/diff command from src/generator/specs/ai-key-diff.json
- compare redacted ai/key/status entries into deterministic merge-plan actions
- keep secret handling value-free: provider/key names, configured flags, source metadata, and fingerprints only
- include focused pure tests and factory smoke test

## Notes
- merge-plan IDs use stable sorted metadata and avoid locale-dependent ordering
- mutation-like copy/conflict actions require approval; same fingerprints are no-op
- generated README adjusted to match the actual smoke-test shape

## Validation
- npx tsx generator/validate-command-spec-coverage.ts
- npx tsx commands/ai/key/diff/test/unit/AiKeyDiffCommand.test.ts
- npx tsx commands/ai/key/diff/test/integration/AiKeyDiffIntegration.test.ts
- npm run test:compiler-check
- npx eslint commands/ai/key/diff/shared/AiKeyDiffPlanner.ts commands/ai/key/diff/shared/AiKeyDiffTypes.ts commands/ai/key/diff/server/AiKeyDiffServerCommand.ts commands/ai/key/diff/browser/AiKeyDiffBrowserCommand.ts
- git diff --check
- precommit hook: passed
- npm run test:prepush: passed
- git push pre-push hook: passed