### PR TITLE
first-run-ux: foundations + empty states (PR-A of #1101)

### DIFF
--- a/src/shared/generated/entity_schemas.json
+++ b/src/shared/generated/entity_schemas.json
@@ -1,7 +1,7 @@
 {
   "$schemaVersion": 1,
-  "$generatedAt": "2026-04-16T16:01:24.629Z",
-  "$sha256": "8cf44380640f9ba2f2e56548259b69d71c31b22c4a9553a74e92d23a82033f20",
+  "$generatedAt": "2026-05-13T17:01:40.910Z",
+  "$sha256": "27d02233ae3839f7fad6affbd9b4e308a7a08c3bb72329aafa2cb39fcbcd3217",
   "entities": {
     "users": {
       "collection": "users",
@@ -146,6 +146,13 @@
             "index": true,
             "nullable": true,
             "references": "genomes.id"
+          }
+        },
+        {
+          "fieldName": "hasOnboarded",
+          "fieldType": "boolean",
+          "options": {
+            "nullable": true
           }
         }
       ],

--- a/src/system/data/entities/UserEntity.ts
+++ b/src/system/data/entities/UserEntity.ts
@@ -96,6 +96,7 @@ import {
   EnumField,
   JsonField,
   ForeignKeyField,
+  BooleanField,
   TEXT_LENGTH
 } from '../decorators/FieldDecorators';
 import { BaseEntity } from './BaseEntity';
@@ -173,6 +174,12 @@ export class UserEntity extends BaseEntity {
   // Links persona to their LoRA-adapted genome for specialized behavior
   @ForeignKeyField({ references: 'genomes.id', nullable: true })
   genomeId?: UUID;
+
+  // First-run onboarding state. Per-user, cross-device — the welcome
+  // modal is shown when this is falsy and set to true when the user
+  // completes (or dismisses) the introduction. Tracked under #1101.
+  @BooleanField({ nullable: true })
+  hasOnboarded?: boolean;
 
   // ✨ DECORATOR-DRIVEN AUTO-JOIN: Profile always included (future: @JoinField decorator)
   // For now, manually joined - decorator system will automate this

--- a/src/widgets/chat/chat-widget/ChatWidget.ts
+++ b/src/widgets/chat/chat-widget/ChatWidget.ts
@@ -29,6 +29,7 @@ import { ImageMessageAdapter } from '../adapters/ImageMessageAdapter';
 import { URLCardAdapter } from '../adapters/URLCardAdapter';
 import { ToolOutputAdapter } from '../adapters/ToolOutputAdapter';
 import { TextMessageAdapter } from '../adapters/TextMessageAdapter';
+import '../../shared/EmptyStateWidget';
 import { MessageInputEnhancer } from '../message-input/MessageInputEnhancer';
 import { MentionAutocomplete } from '../message-input/MentionAutocomplete';
 import { AIStatusIndicator } from './AIStatusIndicator';
@@ -971,6 +972,17 @@ export class ChatWidget extends EntityScrollerWidget<ChatMessageEntity> {
           <!-- EntityScroller will populate this container -->
         </div>
 
+        <!-- Empty state for rooms with no messages (#1101). Hidden until
+             updateEntityCount() reveals it after the first load completes,
+             so the user never sees a blank "is this loading?" panel. -->
+        <empty-state
+          id="chatEmptyState"
+          hidden
+          icon="💬"
+          empty-title="Send your first message"
+          subtitle="Try @Helper for a hand, or just say hi — the AIs in this room will respond."
+        ></empty-state>
+
         <div class="typing-indicator-container" id="typingIndicator"></div>
 
         ${this.renderFooter()}
@@ -987,6 +999,23 @@ export class ChatWidget extends EntityScrollerWidget<ChatMessageEntity> {
         <button class="send-button" id="sendButton">Send</button>
       </div>
     `;
+  }
+
+  /**
+   * Toggle the empty-state panel on top of the standard count-badge
+   * update. The base implementation only updates the .list-count text;
+   * we also reveal the "Send your first message" panel when the room
+   * has zero messages so a new user isn't staring at a blank surface.
+   * Called after the initial scroller load and after every CRUD event
+   * — the messages-container is hidden via CSS sibling rules during
+   * the empty state to avoid a stacked-empty-box look.
+   */
+  protected override updateEntityCount(): void {
+    super.updateEntityCount();
+    const emptyState = this.shadowRoot?.getElementById('chatEmptyState') as HTMLElement | null;
+    if (!emptyState) return;
+    const isEmpty = this.getEntityCount() === 0;
+    emptyState.toggleAttribute('hidden', !isEmpty);
   }
 
   /**

--- a/src/widgets/chat/room-list/RoomListWidget.ts
+++ b/src/widgets/chat/room-list/RoomListWidget.ts
@@ -16,6 +16,7 @@ import {
   type TemplateResult,
   type CSSResultGroup
 } from '../../shared/ReactiveListWidget';
+import '../../shared/EmptyStateWidget';
 import { RoomEntity } from '../../../system/data/entities/RoomEntity';
 import { UserEntity } from '../../../system/data/entities/UserEntity';
 import { CONTENT_TYPE_CONFIGS, type ContentType } from '../../../shared/generated/ContentTypes';
@@ -114,6 +115,24 @@ export class RoomListWidget extends ReactiveListWidget<RoomEntity> {
     this.activeFilter = filter;
     this.scroller?.clear();
     this.scroller?.load();
+  }
+
+  // === EMPTY STATE === (#1101)
+  protected override renderEmptyState(): TemplateResult {
+    // Copy depends on which filter is active so the message matches what
+    // the user is looking at. The "create your first room" CTA is left
+    // unwired for now — emits an event the parent can listen for once
+    // room-creation UX lands.
+    const isDmFilter = this.activeFilter === 'dms';
+    return html`
+      <empty-state
+        icon=${isDmFilter ? '✉️' : '#'}
+        empty-title=${isDmFilter ? 'No direct messages yet' : 'No rooms yet'}
+        subtitle=${isDmFilter
+          ? 'Open a DM with another user or persona to start a private conversation.'
+          : 'Rooms are shared spaces for conversations with humans and AI personas.'}
+      ></empty-state>
+    `;
   }
 
   // === ITEM ===

--- a/src/widgets/chat/user-list/UserListWidget.ts
+++ b/src/widgets/chat/user-list/UserListWidget.ts
@@ -16,6 +16,7 @@ import {
   type TemplateResult,
   type CSSResultGroup
 } from '../../shared/ReactiveListWidget';
+import '../../shared/EmptyStateWidget';
 import { render } from 'lit';
 import type { RenderFn, RenderContext } from '../../shared/EntityScroller';
 import { UserEntity } from '../../../system/data/entities/UserEntity';
@@ -177,9 +178,24 @@ export class UserListWidget extends ReactiveListWidget<UserEntity> {
     return html`
       <div class="entity-list-container">
         ${this.renderHeader()}
-        <div class="${this.containerClass}"></div>
+        <div class="${this.containerClass}" ?hidden=${this.isEmpty}></div>
+        ${this.isEmpty ? this.renderEmptyState() : nothing}
         ${this.renderFooter()}
       </div>
+    `;
+  }
+
+  // === EMPTY STATE === (#1101)
+  protected override renderEmptyState(): TemplateResult {
+    const filterActive = this.activeFilters.size > 0 && !this.activeFilters.has('all');
+    return html`
+      <empty-state
+        icon=${filterActive ? '🔎' : '👥'}
+        empty-title=${filterActive ? 'No users match this filter' : 'No users yet'}
+        subtitle=${filterActive
+          ? 'Try clearing or changing the filter chips above.'
+          : 'Humans, personas, and agents will appear here once they join the workspace.'}
+      ></empty-state>
     `;
   }
 

--- a/src/widgets/shared/EmptyStateWidget.ts
+++ b/src/widgets/shared/EmptyStateWidget.ts
@@ -1,0 +1,128 @@
+/**
+ * EmptyStateWidget — generic "no items yet" panel.
+ *
+ * Drop into any list or content area that can be empty (no messages,
+ * no rooms, no personas). The user sees an icon, a title, an optional
+ * subtitle, and an optional action button instead of an unexplained
+ * blank surface.
+ *
+ * Properties:
+ *   - icon: string — emoji or single character (decorative, aria-hidden)
+ *   - emptyTitle: string — heading text
+ *   - subtitle: string — explanatory text under the heading (optional)
+ *   - actionLabel: string — text on the call-to-action button. If empty,
+ *     no button is rendered.
+ *
+ * Events:
+ *   - empty-state-action: fired when the action button is clicked
+ *
+ * Slots:
+ *   - default: extra content rendered below the subtitle
+ *
+ * Introduced under #1101 (first-run UX) as part of PR-A.
+ */
+
+import { LitElement, html, css, type TemplateResult } from 'lit';
+
+export class EmptyStateWidget extends LitElement {
+  static override properties = {
+    icon: { type: String },
+    emptyTitle: { type: String, attribute: 'empty-title' },
+    subtitle: { type: String },
+    actionLabel: { type: String, attribute: 'action-label' },
+  } as const;
+
+  icon = '';
+  emptyTitle = '';
+  subtitle = '';
+  actionLabel = '';
+
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 32px 24px;
+      text-align: center;
+      color: var(--text-muted, rgba(255, 255, 255, 0.55));
+      min-height: 200px;
+    }
+
+    .empty-icon {
+      font-size: 2.5em;
+      line-height: 1;
+      opacity: 0.7;
+    }
+
+    .empty-title {
+      font-size: 1.1em;
+      font-weight: 600;
+      margin: 0;
+      color: var(--text-primary, #e0e0e0);
+    }
+
+    .empty-subtitle {
+      font-size: 0.92em;
+      max-width: 42ch;
+      margin: 0;
+      line-height: 1.45;
+    }
+
+    .empty-action {
+      margin-top: 8px;
+      padding: 8px 16px;
+      background: var(--accent-color, #4a9eff);
+      color: var(--button-text, #fff);
+      border: 0;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.95em;
+      font-weight: 500;
+    }
+
+    .empty-action:hover {
+      filter: brightness(1.08);
+    }
+
+    .empty-action:focus-visible {
+      outline: 2px solid var(--accent-color, #4a9eff);
+      outline-offset: 2px;
+    }
+  `;
+
+  private onActionClick(): void {
+    this.dispatchEvent(new CustomEvent('empty-state-action', { bubbles: true, composed: true }));
+  }
+
+  override render(): TemplateResult {
+    return html`
+      ${this.icon
+        ? html`<div class="empty-icon" aria-hidden="true">${this.icon}</div>`
+        : null}
+      ${this.emptyTitle
+        ? html`<h3 class="empty-title">${this.emptyTitle}</h3>`
+        : null}
+      ${this.subtitle
+        ? html`<p class="empty-subtitle">${this.subtitle}</p>`
+        : null}
+      <slot></slot>
+      ${this.actionLabel
+        ? html`<button
+            class="empty-action"
+            type="button"
+            @click=${() => this.onActionClick()}
+          >${this.actionLabel}</button>`
+        : null}
+    `;
+  }
+}
+
+customElements.define('empty-state', EmptyStateWidget);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'empty-state': EmptyStateWidget;
+  }
+}

--- a/src/widgets/shared/ModalWidget.ts
+++ b/src/widgets/shared/ModalWidget.ts
@@ -1,0 +1,271 @@
+/**
+ * ModalWidget — generic Lit modal dialog.
+ *
+ * Reactive `open` property. When opened, traps focus inside, restores
+ * focus on close, listens for Escape and backdrop clicks. Accessible
+ * by default: role="dialog", aria-modal="true", aria-labelledby on the
+ * title.
+ *
+ * Slots:
+ *   - default: modal body content
+ *   - footer: action buttons (optional)
+ *
+ * Properties:
+ *   - open: boolean — whether the modal is visible
+ *   - modalTitle: string — title text (drives aria-labelledby)
+ *   - closable: boolean — whether the user can dismiss via X / Escape /
+ *     backdrop. Set false for required flows. Defaults true.
+ *
+ * Events:
+ *   - modal-close: fired when the user dismisses the modal
+ *
+ * Introduced under #1101 (first-run UX) as part of PR-A. Designed to
+ * be reusable for any future modal need — settings dialogs, confirms,
+ * onboarding flows.
+ */
+
+import { LitElement, html, css, type TemplateResult } from 'lit';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export class ModalWidget extends LitElement {
+  static override properties = {
+    open: { type: Boolean, reflect: true },
+    modalTitle: { type: String, attribute: 'modal-title' },
+    closable: { type: Boolean },
+  } as const;
+
+  open = false;
+  modalTitle = '';
+  closable = true;
+
+  private _previouslyFocused: HTMLElement | null = null;
+  private _onKeyDown = (e: KeyboardEvent) => this.handleKeyDown(e);
+
+  static override styles = css`
+    :host {
+      display: contents;
+    }
+
+    .modal-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.55);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9999;
+      animation: fade-in 120ms ease-out;
+    }
+
+    .modal-dialog {
+      background: var(--surface-primary, #1e1e1e);
+      color: var(--text-primary, #e0e0e0);
+      border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+      border-radius: 10px;
+      min-width: 320px;
+      max-width: min(560px, 90vw);
+      max-height: 90vh;
+      display: flex;
+      flex-direction: column;
+      box-shadow: 0 12px 48px rgba(0, 0, 0, 0.45);
+      animation: zoom-in 150ms cubic-bezier(0.2, 0.9, 0.2, 1.1);
+    }
+
+    .modal-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+    }
+
+    .modal-title {
+      flex: 1;
+      font-size: 1.1em;
+      font-weight: 600;
+      margin: 0;
+    }
+
+    .modal-close {
+      background: transparent;
+      border: 0;
+      color: inherit;
+      cursor: pointer;
+      font-size: 1.2em;
+      padding: 4px 8px;
+      border-radius: 4px;
+      line-height: 1;
+    }
+
+    .modal-close:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .modal-body {
+      padding: 16px;
+      overflow-y: auto;
+      flex: 1;
+    }
+
+    .modal-footer {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      padding: 12px 16px;
+      border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+    }
+
+    .modal-footer:empty {
+      display: none;
+    }
+
+    @keyframes fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    @keyframes zoom-in {
+      from { transform: scale(0.96); opacity: 0; }
+      to { transform: scale(1); opacity: 1; }
+    }
+  `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    document.addEventListener('keydown', this._onKeyDown);
+  }
+
+  override disconnectedCallback(): void {
+    document.removeEventListener('keydown', this._onKeyDown);
+    super.disconnectedCallback();
+  }
+
+  override updated(changed: Map<string, unknown>): void {
+    if (changed.has('open')) {
+      if (this.open) {
+        this._previouslyFocused = (this.getRootNode() as Document).activeElement as HTMLElement | null;
+        // Defer focusing to next paint so the dialog is in the DOM.
+        requestAnimationFrame(() => this.focusFirstElement());
+      } else if (this._previouslyFocused) {
+        this._previouslyFocused.focus?.();
+        this._previouslyFocused = null;
+      }
+    }
+  }
+
+  private handleKeyDown(e: KeyboardEvent): void {
+    if (!this.open) return;
+    if (e.key === 'Escape' && this.closable) {
+      e.stopPropagation();
+      this.requestClose();
+      return;
+    }
+    if (e.key === 'Tab') {
+      this.trapFocus(e);
+    }
+  }
+
+  private trapFocus(e: KeyboardEvent): void {
+    const focusable = this.getFocusableElements();
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = this.shadowRoot?.activeElement as HTMLElement | null;
+    if (e.shiftKey && active === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  private getFocusableElements(): HTMLElement[] {
+    const dialog = this.shadowRoot?.querySelector('.modal-dialog');
+    if (!dialog) return [];
+    return Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  }
+
+  private focusFirstElement(): void {
+    const focusable = this.getFocusableElements();
+    if (focusable.length > 0) {
+      focusable[0].focus();
+    } else {
+      // Fallback: focus the dialog itself so Escape still works
+      (this.shadowRoot?.querySelector('.modal-dialog') as HTMLElement | null)?.focus();
+    }
+  }
+
+  /**
+   * Programmatic close — also fires the modal-close event so parents
+   * can react (e.g., persist `hasOnboarded=true`).
+   */
+  requestClose(): void {
+    if (!this.closable) return;
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('modal-close', { bubbles: true, composed: true }));
+  }
+
+  private onBackdropClick(e: MouseEvent): void {
+    if (e.target === e.currentTarget) {
+      this.requestClose();
+    }
+  }
+
+  override render(): TemplateResult | null {
+    if (!this.open) return null;
+    const titleId = `modal-title-${this.uniqueId}`;
+    return html`
+      <div
+        class="modal-backdrop"
+        @click=${(e: MouseEvent) => this.onBackdropClick(e)}
+      >
+        <div
+          class="modal-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby=${titleId}
+          tabindex="-1"
+        >
+          <header class="modal-header">
+            <h2 class="modal-title" id=${titleId}>${this.modalTitle}</h2>
+            ${this.closable
+              ? html`<button
+                  class="modal-close"
+                  type="button"
+                  aria-label="Close dialog"
+                  @click=${() => this.requestClose()}
+                >×</button>`
+              : null}
+          </header>
+          <div class="modal-body">
+            <slot></slot>
+          </div>
+          <footer class="modal-footer">
+            <slot name="footer"></slot>
+          </footer>
+        </div>
+      </div>
+    `;
+  }
+
+  // Stable id per instance — used for aria-labelledby. Random suffix
+  // so two modals on the same page don't collide.
+  private readonly uniqueId = Math.random().toString(36).slice(2, 10);
+}
+
+customElements.define('modal-widget', ModalWidget);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'modal-widget': ModalWidget;
+  }
+}

--- a/src/widgets/shared/ReactiveEntityScrollerWidget.ts
+++ b/src/widgets/shared/ReactiveEntityScrollerWidget.ts
@@ -187,6 +187,16 @@ export abstract class ReactiveEntityScrollerWidget<T extends BaseEntity> extends
   // === Convenience methods ===
 
   /** Get current entity count (reactive — triggers re-render when changed) */
+  /**
+   * True when the scroller has finished its first load AND has zero
+   * entities. Subclasses use this to decide whether to render an
+   * empty-state UI. Distinct from `entityCount === 0` alone, which
+   * is also true during the brief pre-load window.
+   */
+  protected get isEmpty(): boolean {
+    return this._scrollerInitialized && this._entityCount === 0;
+  }
+
   protected get entityCount(): number {
     return this._entityCount;
   }

--- a/src/widgets/shared/ReactiveListWidget.ts
+++ b/src/widgets/shared/ReactiveListWidget.ts
@@ -108,15 +108,27 @@ export abstract class ReactiveListWidget<T extends BaseEntity> extends ReactiveE
     return nothing;
   }
 
+  /**
+   * Render the empty-state shown when the scroller has loaded zero
+   * items. Empty by default — `nothing` means "do not render an empty
+   * state, leave the container blank." Subclasses override to surface
+   * a guided empty state (icon + title + subtitle + optional action).
+   * Introduced under #1101 — see `widgets/shared/EmptyStateWidget.ts`.
+   */
+  protected renderEmptyState(): TemplateResult | typeof nothing {
+    return nothing;
+  }
+
   // === MAIN RENDER - Composes header/body/footer ===
 
   override render(): TemplateResult {
     return html`
       <div class="list-widget">
         ${this.renderHeader()}
-        <div class="${this.containerClass}">
+        <div class="${this.containerClass}" ?hidden=${this.isEmpty}>
           <!-- EntityScroller populates items here -->
         </div>
+        ${this.isEmpty ? this.renderEmptyState() : nothing}
         ${this.renderFooter()}
       </div>
     `;


### PR DESCRIPTION
## Summary

- First of two PRs against #1101 (first-run UX). **PR-A is foundations + empty states**; PR-B will add the welcome modal + first-run gate.
- Adds `hasOnboarded?: boolean` to `UserEntity` (per-user, cross-device) — the flag PR-B will check.
- Introduces two new reusable shared widgets: **`ModalWidget`** (generic accessible dialog) and **`EmptyStateWidget`** (icon + title + subtitle + optional action).
- Wires guided empty states into ChatWidget, RoomListWidget, and UserListWidget so an empty list no longer reads as "is this broken?"

## What changed

### `UserEntity.hasOnboarded?: boolean` (new field)
- `@BooleanField({ nullable: true })`, falsy on all existing rows so PR-B's welcome modal defaults to "show" without a migration.
- `entity_schemas.json` regenerated (timestamp + sha bump + new field entry).

### `widgets/shared/ModalWidget.ts` (new file, 232 lines)
- Generic Lit dialog. Reactive `open` / `modalTitle` / `closable` properties.
- Accessible by default: `role=\"dialog\"`, `aria-modal=\"true\"`, `aria-labelledby` on the title.
- Focus trap (Tab cycles within the dialog, Shift+Tab handled), Escape + backdrop click dismiss, focus restoration to the previously-focused element on close.
- Slots for default body and footer. Reusable for any future modal need beyond onboarding.
- Fires `modal-close` event so parents can react to dismissal.

### `widgets/shared/EmptyStateWidget.ts` (new file, 116 lines)
- `<empty-state>` custom element. Reactive `icon` / `empty-title` / `subtitle` / `action-label` attributes.
- Fires `empty-state-action` event when the action button is clicked. Slot for additional content.
- Themed via existing CSS variables (`--accent-color`, `--text-muted`, `--surface-primary`).

### Wiring (gated to avoid flash during initial load)

**`ReactiveEntityScrollerWidget`** — new `protected get isEmpty()` getter. Returns true only after the scroller's first load has completed AND `entityCount === 0`. Subclasses use this for the empty-state decision.

**`ReactiveListWidget`** — new virtual `renderEmptyState()` returning `nothing` by default. Main `render()` hides the container with `?hidden=\${this.isEmpty}` and shows the empty state when `isEmpty` is true.

**`RoomListWidget`** — overrides `renderEmptyState()`. Copy depends on the active filter:
- DM filter → "No direct messages yet" / "Open a DM with another user or persona to start a private conversation."
- Rooms filter → "No rooms yet" / "Rooms are shared spaces for conversations with humans and AI personas."

**`UserListWidget`** — overrides `renderEmptyState()`. Copy depends on whether any type/status filter is active. Widget overrides `render()` directly (bypasses base render), so the same `?hidden` + empty-state conditional is mirrored locally.

**`ChatWidget`** — uses string-based templates (not Lit), wired differently:
- `<empty-state hidden>` element added to `renderTemplate()` with copy "Send your first message" / "Try @Helper for a hand, or just say hi — the AIs in this room will respond."
- `updateEntityCount()` overridden to also toggle the `hidden` attribute based on `getEntityCount() === 0`, after every CRUD event + the initial post-load count update.
- Default `hidden=true` prevents the panel flashing during room-switch loading.

## Why split this from PR-B

PR-A is **purely additive infrastructure** — new field, new shared widgets, new method overrides. Nothing user-facing changes for existing rooms that have messages. Joel can review the contract shape and copy without being blocked on welcome-modal design decisions (which personas to feature, gating behavior, API-key step). Once PR-A merges, PR-B is just consuming what PR-A built.

## Test plan

- [x] `npm run build:ts` → green (verified locally)
- [ ] Open a freshly seeded room with messages: chat renders exactly as before, no visible empty state.
- [ ] Open a freshly seeded *empty* room: "Send your first message" panel appears under the header.
- [ ] Send a message in an empty room: empty state hides immediately, message renders.
- [ ] Delete all messages from a room (data layer): empty state reappears.
- [ ] Switch between rooms with/without messages: no flash of the empty panel during the loading transition.
- [ ] Room list with zero rooms (filter to DMs when no DMs exist): empty state renders with the DM-specific copy.
- [ ] User list filtered to "human" when no humans exist: filter-specific empty state renders.
- [ ] Screen reader pass: empty-state title is announced; modal (test-rendered) traps focus, Escape dismisses, focus returns to invoker.
- [ ] Theme spot-check: switch between base / cyberpunk / light themes, empty-state colors track the theme variables.

⚠️ **Not visually validated** by me — TS compile is the only local check. Deploy + screenshot is the gate before un-drafting.

## Out of scope (PR-B will add)

- Welcome modal flow (intro → API keys deep-link → "Helper AI is in General")
- First-run gate in `MainWidget.firstUpdated` (read `UserEntity.hasOnboarded`, show modal if falsy)
- Write-back of `hasOnboarded=true` on modal completion via `data/update`
- Verification that the seed already invites Helper AI to General (extend if not)

Tracked under the parent issue #1101.