### PR TITLE
a11y phase 2: listbox/option semantics + keyboard nav + message-row labels (#1099)

### DIFF
--- a/src/widgets/chat/chat-widget/ChatWidget.ts
+++ b/src/widgets/chat/chat-widget/ChatWidget.ts
@@ -434,6 +434,17 @@ export class ChatWidget extends EntityScrollerWidget<ChatMessageEntity> {
       messageElement.className = `message-row ${isCurrentUser ? 'right' : 'left'}${postingClass}`;
       // CRITICAL: Add entity ID to DOM for testing/debugging (test expects 'message-id')
       messageElement.setAttribute('message-id', message.id);
+      // A11Y (#1099 phase 2). Each message row gets a screen-reader
+      // label and role=article so the chat transcript can be navigated
+      // message-by-message instead of word-by-word. The transcript
+      // container already carries role=log + aria-live=polite from
+      // phase 1, so new messages auto-announce.
+      messageElement.setAttribute('role', 'article');
+      const ts = new Date(message.timestamp).toLocaleString();
+      messageElement.setAttribute(
+        'aria-label',
+        `${senderName} at ${ts}${message.status === 'sending' ? ', sending' : ''}`
+      );
 
       // Build message structure with DOM APIs (no innerHTML for static structure)
       const bubble = globalThis.document.createElement('div');

--- a/src/widgets/chat/room-list/RoomListWidget.ts
+++ b/src/widgets/chat/room-list/RoomListWidget.ts
@@ -182,13 +182,32 @@ export class RoomListWidget extends ReactiveListWidget<RoomEntity> {
     return html`
       <div class="entity-list-container">
         ${this.renderHeader()}
-        <div class="${this.containerClass}"></div>
+        <div
+          class="${this.containerClass}"
+          role="listbox"
+          aria-label="Rooms and direct messages"
+        ></div>
         ${showNewDM && hasDMs ? html`
           <div class="new-dm-btn" @click=${this.startNewDM}>+ Start a conversation</div>
         ` : ''}
         ${this.renderFooter()}
       </div>
     `;
+  }
+
+  // === A11Y === (#1099 phase 2)
+  protected override getItemLabel(room: RoomEntity): string {
+    if (this.isDM(room)) {
+      const info = this.getDMDisplayInfo(room);
+      const memberCount = room.members?.length ?? 0;
+      const isGroup = memberCount > 2;
+      return isGroup
+        ? `Group DM: ${info.name}, ${memberCount} members`
+        : `Direct message with ${info.name}`;
+    }
+    const name = room.displayName ?? room.name ?? 'Room';
+    const topic = room.topic ?? '';
+    return topic ? `Room ${name} — ${topic}` : `Room ${name}`;
   }
 
   // === FILTERING ===

--- a/src/widgets/chat/user-list/UserListWidget.ts
+++ b/src/widgets/chat/user-list/UserListWidget.ts
@@ -177,10 +177,22 @@ export class UserListWidget extends ReactiveListWidget<UserEntity> {
     return html`
       <div class="entity-list-container">
         ${this.renderHeader()}
-        <div class="${this.containerClass}"></div>
+        <div
+          class="${this.containerClass}"
+          role="listbox"
+          aria-label="Users and personas"
+        ></div>
         ${this.renderFooter()}
       </div>
     `;
+  }
+
+  // === A11Y === (#1099 phase 2)
+  protected override getItemLabel(user: UserEntity): string {
+    const name = user.displayName ?? 'Unknown user';
+    const typeLabel = user.type === 'persona' ? 'persona' : user.type === 'agent' ? 'agent' : 'user';
+    const status = user.status ?? 'offline';
+    return `${name}, ${typeLabel}, ${status}`;
   }
 
   // === ITEM RENDERING ===

--- a/src/widgets/shared/ReactiveListWidget.ts
+++ b/src/widgets/shared/ReactiveListWidget.ts
@@ -114,7 +114,11 @@ export abstract class ReactiveListWidget<T extends BaseEntity> extends ReactiveE
     return html`
       <div class="list-widget">
         ${this.renderHeader()}
-        <div class="${this.containerClass}">
+        <div
+          class="${this.containerClass}"
+          role="listbox"
+          aria-label=${this.listTitle}
+        >
           <!-- EntityScroller populates items here -->
         </div>
         ${this.renderFooter()}
@@ -130,13 +134,89 @@ export abstract class ReactiveListWidget<T extends BaseEntity> extends ReactiveE
       const div = document.createElement('div');
       div.className = 'list-item';
       div.dataset.id = item.id;
+      // ARIA listbox semantics (#1099 phase 2). The container has
+      // role="listbox" (set in subclass render overrides); each item
+      // is role="option". tabindex=0 makes items keyboard-focusable —
+      // proper roving tabindex (only the active item gets tabindex=0)
+      // is a phase-3 follow-up.
+      div.setAttribute('role', 'option');
+      div.tabIndex = 0;
+      const label = this.getItemLabel(item);
+      if (label) div.setAttribute('aria-label', label);
+      div.setAttribute('aria-selected', String(this.isSelected(item)));
       render(this.renderItem(item), div);
       div.addEventListener('click', (e) => {
         e.stopPropagation();
         this.onItemClick(item);
       });
+      // Enter or Space activates the item — same effect as a mouse click.
+      // The click handler above already handles selection updates.
+      div.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          e.stopPropagation();
+          this.onItemClick(item);
+        }
+      });
       return div;
     };
+  }
+
+  /**
+   * Accessible name for a list item. Default uses `displayName` or `name`
+   * fields if present on the entity, otherwise empty (which omits the
+   * aria-label and lets the screen reader fall back to the rendered
+   * text content). Subclasses override to provide a richer label —
+   * for example "<room name>, <member count> members".
+   */
+  protected getItemLabel(item: T): string {
+    const e = item as unknown as { displayName?: string; name?: string };
+    return e.displayName ?? e.name ?? '';
+  }
+
+  /**
+   * Keyboard navigation handler attached to the listbox container in
+   * `firstUpdated()`. ArrowDown/Up move focus to the next/previous
+   * `.list-item`, Home/End jump to first/last, Enter/Space activate.
+   * Handler is scoped to the container so it doesn't interfere with
+   * keyboard handling on sibling widgets (e.g., the chat composer).
+   */
+  private onListKeydown = (e: KeyboardEvent): void => {
+    const items = Array.from(
+      this.shadowRoot?.querySelectorAll<HTMLElement>(`.${this.containerClass} > .list-item`) ?? []
+    );
+    if (items.length === 0) return;
+
+    const active = this.shadowRoot?.activeElement as HTMLElement | null;
+    const currentIdx = active ? items.indexOf(active) : -1;
+
+    let nextIdx: number | null = null;
+    switch (e.key) {
+      case 'ArrowDown':
+        nextIdx = currentIdx < 0 ? 0 : Math.min(currentIdx + 1, items.length - 1);
+        break;
+      case 'ArrowUp':
+        nextIdx = currentIdx < 0 ? items.length - 1 : Math.max(currentIdx - 1, 0);
+        break;
+      case 'Home':
+        nextIdx = 0;
+        break;
+      case 'End':
+        nextIdx = items.length - 1;
+        break;
+      default:
+        return;
+    }
+    if (nextIdx !== null) {
+      e.preventDefault();
+      items[nextIdx].focus();
+    }
+  };
+
+  protected override firstUpdated(): void {
+    super.firstUpdated();
+    const container = this.shadowRoot?.querySelector(`.${this.containerClass}`);
+    container?.addEventListener('keydown', this.onListKeydown as EventListener);
   }
 
   protected getLoadFunction(): LoadFn<T> {


### PR DESCRIPTION
## Summary

- Phase 2 of #1099, layered on the phase 1 work in #1103. Behavior-preserving — additive ARIA + keyboard handlers.
- Room and user sidebars become real ARIA listboxes: `role=listbox` on the container, `role=option` + `aria-label` on each item, arrow-key navigation, Enter/Space to activate.
- Chat message rows get `role=article` + an `aria-label` (sender + timestamp), so screen readers can jump message-by-message through the transcript that phase 1 already exposed as a live `role=log`.

## What changed

### `ReactiveListWidget` — base class
- Default `render()` adds `role=\"listbox\"` and `aria-label` (from `listTitle`) on the container. Subclasses that override `render()` add the same locally.
- `getRenderFunction` sets `role=\"option\"`, `tabindex=0`, `aria-label` (via new virtual `getItemLabel()`), and `aria-selected` on each `.list-item` wrapper.
- Enter / Space on a focused item activates it (mirrors click).
- New `onListKeydown` handler attached in `firstUpdated()`: ArrowDown / ArrowUp move focus between sibling items; Home / End jump to first/last. Scoped to the container so it doesn't interfere with the chat composer or other widgets.

### `RoomListWidget`
- `role=\"listbox\"` + `aria-label=\"Rooms and direct messages\"` in the render override.
- Overrides `getItemLabel()`:
  - Rooms → `Room {name} — {topic}` (topic omitted when empty)
  - DMs → `Direct message with {name}`
  - Group DMs → `Group DM: {name}, {count} members`

### `UserListWidget`
- `role=\"listbox\"` + `aria-label=\"Users and personas\"` in the render override.
- Overrides `getItemLabel()`: `{name}, {persona|agent|user}, {status}` so the screen reader announces both kind (persona/agent/human) and presence (online/away/offline).

### `ChatWidget.getRenderFunction`
- `role=\"article\"` + `aria-label` on each `.message-row` containing sender name, timestamp, and (for in-flight) " sending".
- Pairs with phase 1's `role=log` + `aria-live=polite` on the transcript container — new messages auto-announce, individual rows are nameable.

## Out of scope (phase 3 follow-ups, not blockers for this PR)

- **Dynamic `aria-selected` updates** when the active room/user changes after initial render. Currently set once at item-creation time. The visual `.active` class still updates correctly via Lit. Real fix needs a Lit `updated()` hook that walks DOM after every render.
- **Roving tabindex** — every item is `tabindex=0`, so Tab cycles through all items. The proper pattern is "active item is tabindex=0, others are -1." Arrow keys already handle within-list navigation; this is a refinement.
- **Color-contrast audit** across the six themes (base / classic / cyberpunk / light / monochrome / retro-mac).
- `<div onclick>` → `<button>` migration for click-only divs (semantic HTML).
- axe-core lint gate in CI.

## Test plan

- [x] `npm run build:ts` → green (verified locally)
- [ ] Tab into the room list: focus lands on the first room. Arrow Down moves to the next, Arrow Up to the previous, Home/End jump to first/last. Enter activates (switches to that room).
- [ ] Same flow on the user list.
- [ ] Screen reader (VoiceOver / NVDA) navigation:
  - Room list reads as "listbox, Rooms and direct messages, N items"
  - Each item reads as the room/DM label
  - User list reads as "listbox, Users and personas, N items"
  - Each user reads as "{name}, {kind}, {status}"
- [ ] Chat transcript: rotor / message-by-message navigation. Each message announced as `{sender} at {time}`. Phase 1's auto-announce of new messages still works.
- [ ] Visual: no regressions in any theme. The `.list-item` wrapper styling is unaffected (only attributes added).

⚠️ **Not visually or screen-reader validated** by me locally. TS compile is the only check.

## Relationship to other open PRs

- **Layered on #1103** (a11y phase 1) — but doesn't depend on it directly. Both target main; merge order doesn't matter because they touch disjoint attributes (phase 1: chat region/log/status; phase 2: list listbox/option + message-row labels).
- Doesn't conflict with #1106 (adapter migration) or #1107/#1108 (first-run UX).