### PR TITLE
a11y phase 3a: dynamic aria-selected + roving tabindex (#1099)

### DIFF
--- a/src/widgets/chat/chat-widget/ChatWidget.ts
+++ b/src/widgets/chat/chat-widget/ChatWidget.ts
@@ -434,6 +434,17 @@ export class ChatWidget extends EntityScrollerWidget<ChatMessageEntity> {
       messageElement.className = `message-row ${isCurrentUser ? 'right' : 'left'}${postingClass}`;
       // CRITICAL: Add entity ID to DOM for testing/debugging (test expects 'message-id')
       messageElement.setAttribute('message-id', message.id);
+      // A11Y (#1099 phase 2). Each message row gets a screen-reader
+      // label and role=article so the chat transcript can be navigated
+      // message-by-message instead of word-by-word. The transcript
+      // container already carries role=log + aria-live=polite from
+      // phase 1, so new messages auto-announce.
+      messageElement.setAttribute('role', 'article');
+      const ts = new Date(message.timestamp).toLocaleString();
+      messageElement.setAttribute(
+        'aria-label',
+        `${senderName} at ${ts}${message.status === 'sending' ? ', sending' : ''}`
+      );
 
       // Build message structure with DOM APIs (no innerHTML for static structure)
       const bubble = globalThis.document.createElement('div');

--- a/src/widgets/chat/room-list/RoomListWidget.ts
+++ b/src/widgets/chat/room-list/RoomListWidget.ts
@@ -195,7 +195,11 @@ export class RoomListWidget extends ReactiveListWidget<RoomEntity> {
     `;
   }
 
-  // === A11Y === (#1099 phase 2)
+  // === A11Y === (#1099 phase 2 + 3a)
+  protected override isItemIdSelected(id: string): boolean {
+    return id === this.currentRoomId;
+  }
+
   protected override getItemLabel(room: RoomEntity): string {
     if (this.isDM(room)) {
       const info = this.getDMDisplayInfo(room);

--- a/src/widgets/chat/room-list/RoomListWidget.ts
+++ b/src/widgets/chat/room-list/RoomListWidget.ts
@@ -182,13 +182,32 @@ export class RoomListWidget extends ReactiveListWidget<RoomEntity> {
     return html`
       <div class="entity-list-container">
         ${this.renderHeader()}
-        <div class="${this.containerClass}"></div>
+        <div
+          class="${this.containerClass}"
+          role="listbox"
+          aria-label="Rooms and direct messages"
+        ></div>
         ${showNewDM && hasDMs ? html`
           <div class="new-dm-btn" @click=${this.startNewDM}>+ Start a conversation</div>
         ` : ''}
         ${this.renderFooter()}
       </div>
     `;
+  }
+
+  // === A11Y === (#1099 phase 2)
+  protected override getItemLabel(room: RoomEntity): string {
+    if (this.isDM(room)) {
+      const info = this.getDMDisplayInfo(room);
+      const memberCount = room.members?.length ?? 0;
+      const isGroup = memberCount > 2;
+      return isGroup
+        ? `Group DM: ${info.name}, ${memberCount} members`
+        : `Direct message with ${info.name}`;
+    }
+    const name = room.displayName ?? room.name ?? 'Room';
+    const topic = room.topic ?? '';
+    return topic ? `Room ${name} — ${topic}` : `Room ${name}`;
   }
 
   // === FILTERING ===

--- a/src/widgets/chat/user-list/UserListWidget.ts
+++ b/src/widgets/chat/user-list/UserListWidget.ts
@@ -187,7 +187,11 @@ export class UserListWidget extends ReactiveListWidget<UserEntity> {
     `;
   }
 
-  // === A11Y === (#1099 phase 2)
+  // === A11Y === (#1099 phase 2 + 3a)
+  protected override isItemIdSelected(id: string): boolean {
+    return id === this._selectedUserId;
+  }
+
   protected override getItemLabel(user: UserEntity): string {
     const name = user.displayName ?? 'Unknown user';
     const typeLabel = user.type === 'persona' ? 'persona' : user.type === 'agent' ? 'agent' : 'user';

--- a/src/widgets/chat/user-list/UserListWidget.ts
+++ b/src/widgets/chat/user-list/UserListWidget.ts
@@ -177,10 +177,22 @@ export class UserListWidget extends ReactiveListWidget<UserEntity> {
     return html`
       <div class="entity-list-container">
         ${this.renderHeader()}
-        <div class="${this.containerClass}"></div>
+        <div
+          class="${this.containerClass}"
+          role="listbox"
+          aria-label="Users and personas"
+        ></div>
         ${this.renderFooter()}
       </div>
     `;
+  }
+
+  // === A11Y === (#1099 phase 2)
+  protected override getItemLabel(user: UserEntity): string {
+    const name = user.displayName ?? 'Unknown user';
+    const typeLabel = user.type === 'persona' ? 'persona' : user.type === 'agent' ? 'agent' : 'user';
+    const status = user.status ?? 'offline';
+    return `${name}, ${typeLabel}, ${status}`;
   }
 
   // === ITEM RENDERING ===

--- a/src/widgets/shared/ReactiveListWidget.ts
+++ b/src/widgets/shared/ReactiveListWidget.ts
@@ -114,7 +114,11 @@ export abstract class ReactiveListWidget<T extends BaseEntity> extends ReactiveE
     return html`
       <div class="list-widget">
         ${this.renderHeader()}
-        <div class="${this.containerClass}">
+        <div
+          class="${this.containerClass}"
+          role="listbox"
+          aria-label=${this.listTitle}
+        >
           <!-- EntityScroller populates items here -->
         </div>
         ${this.renderFooter()}
@@ -130,13 +134,89 @@ export abstract class ReactiveListWidget<T extends BaseEntity> extends ReactiveE
       const div = document.createElement('div');
       div.className = 'list-item';
       div.dataset.id = item.id;
+      // ARIA listbox semantics (#1099 phase 2). The container has
+      // role="listbox" (set in subclass render overrides); each item
+      // is role="option". tabindex=0 makes items keyboard-focusable —
+      // proper roving tabindex (only the active item gets tabindex=0)
+      // is a phase-3 follow-up.
+      div.setAttribute('role', 'option');
+      div.tabIndex = 0;
+      const label = this.getItemLabel(item);
+      if (label) div.setAttribute('aria-label', label);
+      div.setAttribute('aria-selected', String(this.isSelected(item)));
       render(this.renderItem(item), div);
       div.addEventListener('click', (e) => {
         e.stopPropagation();
         this.onItemClick(item);
       });
+      // Enter or Space activates the item — same effect as a mouse click.
+      // The click handler above already handles selection updates.
+      div.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          e.stopPropagation();
+          this.onItemClick(item);
+        }
+      });
       return div;
     };
+  }
+
+  /**
+   * Accessible name for a list item. Default uses `displayName` or `name`
+   * fields if present on the entity, otherwise empty (which omits the
+   * aria-label and lets the screen reader fall back to the rendered
+   * text content). Subclasses override to provide a richer label —
+   * for example "<room name>, <member count> members".
+   */
+  protected getItemLabel(item: T): string {
+    const e = item as unknown as { displayName?: string; name?: string };
+    return e.displayName ?? e.name ?? '';
+  }
+
+  /**
+   * Keyboard navigation handler attached to the listbox container in
+   * `firstUpdated()`. ArrowDown/Up move focus to the next/previous
+   * `.list-item`, Home/End jump to first/last, Enter/Space activate.
+   * Handler is scoped to the container so it doesn't interfere with
+   * keyboard handling on sibling widgets (e.g., the chat composer).
+   */
+  private onListKeydown = (e: KeyboardEvent): void => {
+    const items = Array.from(
+      this.shadowRoot?.querySelectorAll<HTMLElement>(`.${this.containerClass} > .list-item`) ?? []
+    );
+    if (items.length === 0) return;
+
+    const active = this.shadowRoot?.activeElement as HTMLElement | null;
+    const currentIdx = active ? items.indexOf(active) : -1;
+
+    let nextIdx: number | null = null;
+    switch (e.key) {
+      case 'ArrowDown':
+        nextIdx = currentIdx < 0 ? 0 : Math.min(currentIdx + 1, items.length - 1);
+        break;
+      case 'ArrowUp':
+        nextIdx = currentIdx < 0 ? items.length - 1 : Math.max(currentIdx - 1, 0);
+        break;
+      case 'Home':
+        nextIdx = 0;
+        break;
+      case 'End':
+        nextIdx = items.length - 1;
+        break;
+      default:
+        return;
+    }
+    if (nextIdx !== null) {
+      e.preventDefault();
+      items[nextIdx].focus();
+    }
+  };
+
+  protected override firstUpdated(): void {
+    super.firstUpdated();
+    const container = this.shadowRoot?.querySelector(`.${this.containerClass}`);
+    container?.addEventListener('keydown', this.onListKeydown as EventListener);
   }
 
   protected getLoadFunction(): LoadFn<T> {

--- a/src/widgets/shared/ReactiveListWidget.ts
+++ b/src/widgets/shared/ReactiveListWidget.ts
@@ -134,16 +134,18 @@ export abstract class ReactiveListWidget<T extends BaseEntity> extends ReactiveE
       const div = document.createElement('div');
       div.className = 'list-item';
       div.dataset.id = item.id;
-      // ARIA listbox semantics (#1099 phase 2). The container has
-      // role="listbox" (set in subclass render overrides); each item
-      // is role="option". tabindex=0 makes items keyboard-focusable —
-      // proper roving tabindex (only the active item gets tabindex=0)
-      // is a phase-3 follow-up.
+      // ARIA listbox semantics (#1099 phase 2 + 3a). The container has
+      // role="listbox"; each item is role="option". Roving tabindex
+      // (only the active item gets tabindex=0, others -1) is managed
+      // here for initial render and updated dynamically by
+      // syncSelection() after every Lit update + onListKeydown after
+      // arrow-key navigation.
       div.setAttribute('role', 'option');
-      div.tabIndex = 0;
+      const isSel = this.isItemIdSelected(item.id);
+      div.tabIndex = isSel ? 0 : -1;
       const label = this.getItemLabel(item);
       if (label) div.setAttribute('aria-label', label);
-      div.setAttribute('aria-selected', String(this.isSelected(item)));
+      div.setAttribute('aria-selected', String(isSel));
       render(this.renderItem(item), div);
       div.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -178,8 +180,9 @@ export abstract class ReactiveListWidget<T extends BaseEntity> extends ReactiveE
    * Keyboard navigation handler attached to the listbox container in
    * `firstUpdated()`. ArrowDown/Up move focus to the next/previous
    * `.list-item`, Home/End jump to first/last, Enter/Space activate.
-   * Handler is scoped to the container so it doesn't interfere with
-   * keyboard handling on sibling widgets (e.g., the chat composer).
+   * Updates roving tabindex so only the focused item is in the Tab
+   * order (others get tabindex=-1) — keeps the list a single tab stop
+   * instead of one per item.
    */
   private onListKeydown = (e: KeyboardEvent): void => {
     const items = Array.from(
@@ -209,6 +212,10 @@ export abstract class ReactiveListWidget<T extends BaseEntity> extends ReactiveE
     }
     if (nextIdx !== null) {
       e.preventDefault();
+      // Roving tabindex: only the about-to-be-focused item is in the
+      // Tab order. Others step out so Tab from outside the list lands
+      // on this one item.
+      items.forEach((el, i) => { el.tabIndex = i === nextIdx ? 0 : -1; });
       items[nextIdx].focus();
     }
   };
@@ -217,6 +224,53 @@ export abstract class ReactiveListWidget<T extends BaseEntity> extends ReactiveE
     super.firstUpdated();
     const container = this.shadowRoot?.querySelector(`.${this.containerClass}`);
     container?.addEventListener('keydown', this.onListKeydown as EventListener);
+  }
+
+  /**
+   * After every Lit re-render, walk the rendered `.list-item` wrappers
+   * and update `aria-selected` + the roving `tabindex` to reflect the
+   * subclass's selection state. The visual `.active` class is already
+   * reactive via Lit (subclasses re-render their inner template); this
+   * hook keeps the ARIA attributes on the static EntityScroller-managed
+   * outer wrapper in sync without re-rendering the wrapper.
+   *
+   * If no item is currently selected (e.g., first load before any
+   * click), the first item gets tabindex=0 so the list remains a
+   * tab stop. Otherwise the selected item gets tabindex=0, others -1.
+   */
+  protected override updated(changed: Map<string, unknown>): void {
+    super.updated(changed);
+    this.syncListSelection();
+  }
+
+  private syncListSelection(): void {
+    const items = this.shadowRoot?.querySelectorAll<HTMLElement>(
+      `.${this.containerClass} > .list-item`
+    );
+    if (!items || items.length === 0) return;
+    let selectedFound = false;
+    items.forEach(item => {
+      const id = item.dataset.id;
+      if (!id) return;
+      const sel = this.isItemIdSelected(id);
+      item.setAttribute('aria-selected', String(sel));
+      item.tabIndex = sel ? 0 : -1;
+      if (sel) selectedFound = true;
+    });
+    if (!selectedFound && items[0]) {
+      items[0].tabIndex = 0;
+    }
+  }
+
+  /**
+   * Whether an item with the given id is the currently-selected one.
+   * Base implementation uses `this.selectedId`. Subclasses with their
+   * own selection state override this — RoomList uses `currentRoomId`,
+   * UserList uses `_selectedUserId`. Drives both `aria-selected` and
+   * the roving tabindex.
+   */
+  protected isItemIdSelected(id: string): boolean {
+    return id === this.selectedId;
   }
 
   protected getLoadFunction(): LoadFn<T> {


### PR DESCRIPTION
## Summary

- Phase 3a of #1099, **stacked on top of PR #1111** (a11y phase 2). Until #1111 merges, this PR's diff shows both phase 2 and phase 3a commits. Once #1111 merges, GitHub auto-rebases and this PR's diff reduces to just the phase-3a changes.
- Closes the listbox-correctness gap from phase 2: `aria-selected` and tabindex now respond to selection changes after the initial render.

## What changed

### `ReactiveListWidget` — base class
- New virtual `protected isItemIdSelected(id): boolean`. Default returns `id === this.selectedId`. Subclasses override to use their own selection state. Drives both `aria-selected` and the roving tabindex.
- New Lit `updated()` override calls `syncListSelection()` after every render. Walks `.list-item` wrappers and applies `aria-selected` + the roving `tabindex` (selected → 0, others → -1).
- `getRenderFunction` initial tabindex is now `isItemIdSelected ? 0 : -1` (phase 2 had blanket `tabindex=0`).
- Fallback in `syncListSelection`: if no item is currently selected, the first item gets `tabindex=0` so the list remains a single Tab stop.
- `onListKeydown` (the arrow-key handler from phase 2) now updates roving tabindex as focus moves — newly-focused item gets `tabindex=0`, all others `-1`. The list stays a single tab stop after the user has navigated.

### `RoomListWidget`
- Overrides `isItemIdSelected`: `id === this.currentRoomId`. The `@reactive() currentRoomId` already triggers a Lit update on change → `updated()` → `syncListSelection()` walks the DOM. New active room becomes `aria-selected="true"` with `tabindex=0`; previous active room drops to `false` / `-1`.

### `UserListWidget`
- Overrides `isItemIdSelected`: `id === this._selectedUserId`. Same reactive pattern.

## Why this matters

Phase 2 was correct at item-creation time but stale after that:
- Click a different room → visual `.active` class moves correctly (Lit re-render), but `aria-selected` stayed on the old item
- Tab into the list → every item was a tab stop (blanket `tabindex=0`)

Phase 3a fixes both. A screen reader user now hears "selected" announced on the right item when they change rooms; a keyboard user gets a single tab stop into the list, then uses arrow keys to move around (the standard listbox interaction pattern).

## Out of scope (further phase 3 follow-ups)

- Color-contrast audit across the six themes
- `<div onclick>` → `<button>` semantic migration
- axe-core lint gate in CI
- Focus restoration when a selected item is removed or filtered out

## Test plan

- [x] `npm run build:ts` → green (verified locally on top of phase 2)
- [ ] Open room list. Tab into it: focus lands on the currently-active room (or the first room if none active). Tab a second time: focus leaves the list (not stuck cycling through items).
- [ ] Arrow Down/Up moves focus between rooms. The new focus is the only tab stop (verify by Tab-leaving and Tab-returning — focus lands on the last-arrowed item).
- [ ] Click a different room: `aria-selected` moves to the new active room, `tabindex=0` moves with it. Screen reader announces "selected".
- [ ] Same flow on the user list.
- [ ] No visual regressions; the `.active` class still drives all visual styling.

⚠️ **Not visually or screen-reader validated locally** — TS compile is the only check.

## Relationship to other open PRs

- **Stacked on #1111** (a11y phase 2). Merge order: #1111 first, then this PR auto-rebases on top of main.
- Independent of #1103 (already merged), #1106, #1107, #1108.