### PR TITLE
docs: plan AIRC chat substrate migration

### DIFF
--- a/docs/grid/AIRC-CONTINUUM-BRIDGE.md
+++ b/docs/grid/AIRC-CONTINUUM-BRIDGE.md
@@ -1,18 +1,21 @@
 # AIRC Continuum Bridge
 
-Status: v0 development/test harness.
+Status: v0 development/test harness; target architecture for chat substrate
+migration.
 
-AIRC is the external collaboration wire. Continuum remains the system under
-test. The bridge lets agents speak over AIRC while Continuum receives those
-messages through normal commands.
+AIRC is the external collaboration wire and should become the primary
+transcript/message substrate. Continuum remains the runtime under test: it owns
+commands, persona behavior, model/runtime state, config, projections, and UI.
+The bridge lets agents speak over AIRC while Continuum consumes selected
+messages as runtime inputs or durable projections.
 
 ## Shape
 
 ```text
 AIRC room/message
   -> airc/bridge
-  -> collaboration/chat/send
-  -> chat/export, activity/list, rooms, assertions
+  -> Continuum projection/command adapter
+  -> activity/list, rooms, assertions, persona/runtime inputs
   -> optional airc CLI response
 ```
 
@@ -35,9 +38,27 @@ Explicit development directives use `!continuum`:
 
 ## Why This Exists
 
-Agents should not need to remember direct `jtag collaboration/chat/send` and
+Agents should not need direct `jtag collaboration/chat/send` and
 `jtag collaboration/chat/export` calls during collaboration tests. They should
-talk over AIRC, and the bridge should materialize the traffic inside Continuum.
+talk over AIRC, and the bridge should materialize the traffic inside Continuum
+only where Continuum has a real concern: command execution, persona input,
+memory candidate extraction, search/history projection, or UI display.
+
+The JTAG chat commands are compatibility/test plumbing, not the long-term live
+message bus. The migration target is:
+
+- `airc msg`, `airc logs`, and structured AIRC transcript APIs own live chat,
+  scrollback, cursors, receipts, and replay.
+- `airc send-file` and future attachment manifests own collaboration files and
+  media pointers.
+- Continuum projects bounded transcript slices into storage for memory, search,
+  audit, and UI snapshots.
+- Persona video/audio streams remain WebRTC/live transport. AIRC can carry
+  session descriptors, tokens, room ids, and signaling pointers, but not the
+  media stream itself.
+- Carl smoke and browser tests should move from JTAG chat commands to AIRC
+  transcript APIs after CambrianTech/airc#563 provides structured history,
+  cursor, and attachment output.
 
 ## Boundary
 

--- a/docs/planning/ALPHA-GAP-ANALYSIS.md
+++ b/docs/planning/ALPHA-GAP-ANALYSIS.md
@@ -492,6 +492,8 @@ that prevents new verb-shaped TS cognition and forces deletion as Rust lands.
 | CambrianTech/airc#559 | public knock, approved room handoff, shared sprint queue | AIRC canary has knock and encrypted approve handoff; Continuum must consume the workflow through `.airc/` and persona/agent integration |
 | CambrianTech/airc#562 | peer-to-peer work queue/nudges | Use as the always-on flywheel: any approved peer can nudge idle agents, discover stale/unowned work, and keep the queue moving |
 | PR #1110 | repo-local `.airc/` pilot | Land to canary once docs match current AIRC commands and validation passes; this is the first Continuum-side collaboration contract |
+| #1113 | move live chat off ORM/IPC hot path | AIRC/event-log owns transcript, files, pointers, signaling metadata, and queue chatter; Continuum stores bounded projections |
+| CambrianTech/airc#563 | AIRC message/file substrate | Needed before Carl/browser chat smoke can stop using JTAG chat commands |
 
 Rules:
 
@@ -533,6 +535,10 @@ The operating model:
 - Continuum commands used by these workers must be generated/template-first.
   Manual command scaffolds break the self-development loop because agents need
   one predictable command contract.
+- JTAG chat commands are compatibility plumbing. The target is AIRC transcript
+  plus file/attachment APIs for live chat, scrollback, cursors, receipts, and
+  replay. Continuum should consume compact events/pointers and project only
+  bounded durable state.
 
 Near-term Continuum tasks:
 
@@ -747,7 +753,7 @@ Health checks:
 | #961 / PR #1047 | P0 | stale General tab canonicalization merged to canary | browser reload with stale persisted state collapses to one General tab |
 | #793 Node does not reconnect when Rust core restarts | P0 | request pipeline must drain/recreate after core restart | kill/restart core test: next command succeeds |
 | #794 AI messages not realtime | P0 | event bridge forwards AI senders immediately | browser sees AI message without refresh |
-| #962 chat history paging | P1 | ORM cursor + IntersectionObserver | scroll-up test loads older messages |
+| #962 / #1113 | P1 | AIRC transcript cursor + bounded Continuum projection + IntersectionObserver | scroll-up test loads older messages without ORM live-bus fanout |
 | #773 browser WS reconnect | P1 | reconnect/rebind without manual refresh | browser survives server restart |
 | #785 URL scheme | P1 | one consistent route rule, zero special cases | stale room URL redirects/recovers deterministically |
 | #783 stale room URLs | P1 | stale URLs show recovery path, not broken tab | route test |
@@ -767,9 +773,13 @@ TS is acceptable here because this is UI/session state. Still, data validation a
 
 Design rule:
 
-- AIRC is collaboration transport.
-- Continuum chat is product state.
-- The bridge should map messages/events without requiring agents to shell out to `jtag chat/send` manually.
+- AIRC is the collaboration transcript and message/file substrate.
+- Continuum owns runtime inputs, generated command execution, persona behavior,
+  UI state, and bounded durable projections. It should not use ORM writes and
+  broad IPC fanout as the live chat bus.
+- The bridge should map messages/events without requiring agents to shell out to
+  `jtag chat/send` manually. Long term, Carl/browser chat smoke should validate
+  through AIRC transcript APIs rather than JTAG chat commands.
 - Protocol tests must run without a browser.
 
 ## PR Roadmap To Alpha
@@ -902,6 +912,10 @@ Use AIRC for live coordination, but also create protocol tests:
   card or reports why it cannot
 - local-model persona and cloud agent both operate on the same GitHub-backed
   queue without assuming separate GitHub users
+- scrollback/history fetch reads from AIRC transcript cursors, while Continuum
+  storage only receives bounded projections
+- file attachments flow through AIRC file/manifest events and enter Continuum
+  only as pointers, cache handles, memory candidates, or UI projections
 
 ## Merge Gates
 


### PR DESCRIPTION
## Summary

- documents AIRC as the target transcript/message/file substrate for live chat coordination
- marks JTAG chat commands as compatibility/test plumbing, not the long-term message bus
- updates alpha gap analysis with Continuum #1113 and AIRC #563
- clarifies the live boundary: AIRC carries transcript, scrollback, cursors, receipts, files/manifests, pointers, tokens, and signaling metadata; WebRTC/live transports carry persona audio/video streams; Continuum stores bounded projections

## Related

- Continuum #1113
- CambrianTech/airc#563
- CambrianTech/airc#562
- CambrianTech/airc#559

## Validation

- precommit hook: TypeScript compilation passed
- precommit hook: browser ping passed
- pre-push hook: TypeScript clean
- pre-push hook: ESLint baseline improved; Rust/Docker skipped for docs-only
