### PR TITLE
ci(#1142): auto-close AIRC queue cards on canary merges

### DIFF
--- a/.github/workflows/auto-close-queue-cards.yml
+++ b/.github/workflows/auto-close-queue-cards.yml
@@ -1,0 +1,61 @@
+name: auto-close-queue-cards
+
+# Auto-close airc-queue cards when their PR merges into canary.
+#
+# GitHub's native "Closes #N" only closes issues automatically when the PR
+# lands in the default branch. Continuum lands work in canary first, so queue
+# cards otherwise remain open until someone cleans them up manually.
+#
+# On PR merge into canary, this workflow parses the PR body for queue-card refs,
+# verifies each target has an airc-queue-card-v1 envelope, marks it merged with
+# a status-log entry, and closes it. The AIRC CLI is checked out from
+# CambrianTech/airc because Continuum intentionally does not vendor it.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [canary]
+
+concurrency:
+  group: auto-close-queue-cards
+  cancel-in-progress: false
+
+jobs:
+  close-cards:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      pull-requests: read
+      contents: read
+
+    steps:
+      - name: Checkout Continuum
+        uses: actions/checkout@v4
+
+      - name: Checkout AIRC CLI
+        uses: actions/checkout@v4
+        with:
+          repository: CambrianTech/airc
+          ref: canary
+          path: .airc-src
+
+      - name: Verify environment
+        run: |
+          set -euo pipefail
+          which gh python3 bash
+          gh --version | head -1
+          python3 --version
+          bash --version | head -1
+          test -x .airc-src/airc
+
+      - name: Run airc queue close-merged
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          .airc-src/airc queue close-merged \
+            "${{ github.event.pull_request.html_url }}" \
+            --merge-sha "${{ github.event.pull_request.merge_commit_sha }}" \
+            --actor "github-actions[continuum#1142]"


### PR DESCRIPTION
## Summary
- add Continuum's auto-close-queue-cards workflow for PRs merged into canary
- checkout CambrianTech/airc@canary inside the runner and invoke airc queue close-merged
- grant issue-write permissions so same-repo airc-queue cards can be marked merged and closed

## Proof
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/auto-close-queue-cards.yml'); puts 'yaml ok'"
- git diff --check
- /Users/joelteply/.airc-src/airc queue close-merged CambrianTech/continuum#1141 --merge-sha 79e5fa7e434ebb4c17afacdb4dee3ab81867ce19 --actor 'github-actions[continuum#1142]' --dry-run
- precommit hook: TypeScript build passed; browser tests skipped because local stack is down
- pre-push hook: TypeScript clean; ESLint 5530 errors vs baseline 6310; Rust/Docker skipped for workflow-only change

Closes #1142