### PR TITLE
perf(persona): single-allocation content_hash_sha256 (#1145)

### DIFF
--- a/src/workers/continuum-core/src/persona/inbox_admission.rs
+++ b/src/workers/continuum-core/src/persona/inbox_admission.rs
@@ -59,6 +59,8 @@
 //!   needs envelope material this module's input doesn't carry; that
 //!   conversion is a separate function in a separate slice (PR-5+).
 
+use std::fmt::Write as _;
+
 use sha2::{Digest, Sha256};
 
 use super::admission::{
@@ -133,6 +135,12 @@ impl TrustMapping {
 /// Canonical content hash format used by all admission paths. Returns
 /// `"sha256:<lowercase-hex>"` so dedup keys are stable across origin
 /// kinds (chat / AIRC / tool) and machine boundaries.
+///
+/// Hot path: called once per inbox message at admission time. Hex
+/// encoding writes directly into the preallocated string buffer
+/// (single allocation total) rather than `format!()` per byte (which
+/// allocated 32 small `String`s per hash). See claude-tab-2's review
+/// nit on continuum#1143.
 pub fn content_hash_sha256(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
@@ -140,7 +148,10 @@ pub fn content_hash_sha256(content: &str) -> String {
     let mut hex = String::with_capacity(7 + digest.len() * 2);
     hex.push_str("sha256:");
     for byte in digest {
-        hex.push_str(&format!("{:02x}", byte));
+        // `write!` into a `String` cannot fail — the `Write` impl for
+        // `String` returns `Ok` unconditionally — so the unwrap is the
+        // standard idiom for this pattern.
+        write!(&mut hex, "{:02x}", byte).expect("write to String never fails");
     }
     hex
 }


### PR DESCRIPTION
## Summary

Replace `format!()` per byte with `write!()` into the pre-allocated buffer in `content_hash_sha256`. Previous code allocated 32 small `String`s per hash; now allocates exactly one `String` for the whole output. Same correctness, same canonical `"sha256:<hex>"` output.

Hot path: `content_hash_sha256` runs once per inbox message at admission time. With multi-persona load + AIRC msg flood, the per-byte allocation shows up as GC churn on the heap.

## Card

continuum#1145.

## Origin

Spotted by claude-tab-2 in their post-merge review of continuum#1143 (PR-3 of #1121). Fast follow-up rather than bundling into PR-4.

## Validation

```
$ cargo test -p continuum-core --features metal,accelerate persona::inbox_admission
test result: ok. 16 passed; 0 failed; 0 ignored
```

`npm run build:ts` clean. Hooks ran without `--no-verify`.

## Note

Force-pushed once after correcting an `--amend`-clobbered commit attempt. Branch is fresh, no prior PR opened, no other contributors. canary upstream + codex's #1144 unaffected. Lesson saved to memory; won't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)