### PR TITLE
feat(chat,#1100): renderMessageElement on URLCard + ToolOutput adapters

### DIFF
--- a/src/widgets/chat/adapters/ToolOutputAdapter.ts
+++ b/src/widgets/chat/adapters/ToolOutputAdapter.ts
@@ -431,6 +431,37 @@ export class ToolOutputAdapter extends AbstractMessageAdapter<ToolOutputContentD
     `;
   }
 
+  /**
+   * DOM-returning render path (issue #1100). Same shape as
+   * `TextMessageAdapter.renderMessageElement` — builds the wrapper via
+   * DOM APIs and adopts the rich content as a `DocumentFragment` so the
+   * live message-content slot never sees `innerHTML`. Reactive children
+   * inside the message bubble survive sibling updates.
+   *
+   * Sanitization: tool data is already passed through `escapeHtml` at
+   * `renderContent` interpolation sites (see lines 404-432) — the
+   * detached-template parse keeps that contract; this PR doesn't change
+   * the escape path.
+   */
+  override renderMessageElement(message: ChatMessageEntity, currentUserId: string): HTMLElement | null {
+    try {
+      const data = this.parseContent(message);
+      if (!data) return null;
+      this.contentData = data;
+
+      const wrapper = this.createAdapterWrapper();
+      const contentHtml = this.renderContent(data, currentUserId);
+
+      const template = globalThis.document.createElement('template');
+      template.innerHTML = contentHtml;
+      wrapper.appendChild(template.content.cloneNode(true));
+      return wrapper;
+    } catch (error) {
+      console.error('ToolOutputAdapter.renderMessageElement failed:', error);
+      return null;
+    }
+  }
+
   async handleContentLoading(_element: HTMLElement): Promise<void> {
     // Tool outputs are synchronous text — no async loading needed
   }

--- a/src/widgets/chat/adapters/URLCardAdapter.ts
+++ b/src/widgets/chat/adapters/URLCardAdapter.ts
@@ -137,6 +137,40 @@ export class URLCardAdapter extends AbstractMessageAdapter<URLCardData> {
   }
 
   /**
+   * DOM-returning render path (issue #1100). Same shape as
+   * `TextMessageAdapter.renderMessageElement` — builds the wrapper via
+   * DOM APIs, parses the rich content on a detached `<template>`, and
+   * adopts as a `DocumentFragment` so the live message-content slot
+   * never sees an `innerHTML` assignment. Reactive children inside the
+   * message bubble survive sibling updates.
+   *
+   * Sanitization model is unchanged from the string path. The string
+   * `renderContent` still has interpolation hot spots (originalText,
+   * title, description, siteName) — those are the URL-metadata-XSS
+   * surface and need a separate hardening PR. This PR closes the
+   * `innerHTML` Lit-reactivity hole; the metadata-string XSS hardening
+   * is tracked as a follow-up to #1100.
+   */
+  override renderMessageElement(message: ChatMessageEntity, currentUserId: string): HTMLElement | null {
+    try {
+      const data = this.parseContent(message);
+      if (!data) return null;
+      this.contentData = data;
+
+      const wrapper = this.createAdapterWrapper();
+      const contentHtml = this.renderContent(data, currentUserId);
+
+      const template = globalThis.document.createElement('template');
+      template.innerHTML = contentHtml;
+      wrapper.appendChild(template.content.cloneNode(true));
+      return wrapper;
+    } catch (error) {
+      console.error('URLCardAdapter.renderMessageElement failed:', error);
+      return null;
+    }
+  }
+
+  /**
    * Handle URL metadata fetching and card population
    */
   async handleContentLoading(element: HTMLElement): Promise<void> {

--- a/src/widgets/chat/chat-widget/ChatWidget.ts
+++ b/src/widgets/chat/chat-widget/ChatWidget.ts
@@ -454,22 +454,13 @@ export class ChatWidget extends EntityScrollerWidget<ChatMessageEntity> {
       const contentDiv = globalThis.document.createElement('div');
       contentDiv.className = 'message-content';
 
-      // Adapter content: prefer the DOM-returning path (#1100). Adapters
-      // that have migrated return a fully-built HTMLElement we append
-      // directly. Adapters not yet migrated still return an HTML string
-      // we innerHTML — that path stays until every adapter is migrated.
-      const adapterElement = adapter?.renderMessageElement?.(message, this._myUserId) ?? null;
-      if (adapterElement) {
-        contentDiv.appendChild(adapterElement);
-      } else if (adapter) {
-        contentDiv.innerHTML = adapter.renderMessage(message, this._myUserId);
-      } else {
-        // No adapter — render fallback via textContent to avoid any
-        // HTML interpretation of arbitrary message text.
-        const fallback = globalThis.document.createElement('p');
-        fallback.textContent = message.content?.text || '(no content)';
-        contentDiv.appendChild(fallback);
-      }
+      // Adapter content: ALWAYS the DOM-returning path (#1100). All four
+      // current adapters (Text, Image, URLCard, ToolOutput) implement
+      // `renderMessageElement` so the live message-content slot never
+      // sees `innerHTML` — Lit-bound children inside the message body
+      // survive sibling updates, and user text lives in `.textContent`
+      // not in a concatenated HTML string.
+      this.renderAdapterContentInto(contentDiv, adapter, message);
 
       bubble.appendChild(header);
       bubble.appendChild(contentDiv);
@@ -485,6 +476,38 @@ export class ChatWidget extends EntityScrollerWidget<ChatMessageEntity> {
 
       return messageElement;
     };
+  }
+
+  /**
+   * Adapter render seam (#1100). Calls the adapter's DOM-returning path
+   * and appends the result. Defense-in-depth: if a future adapter
+   * forgets to override OR its override returns null on a render
+   * failure, fall back to textContent on the raw message text rather
+   * than re-introducing the innerHTML hole. Logged loudly so the gap
+   * surfaces.
+   *
+   * Extracted from `getRenderFunction()` to keep that arrow function's
+   * cyclomatic complexity at the project's max of 15 — it touches a lot
+   * of conditional setup already.
+   */
+  private renderAdapterContentInto(
+    contentDiv: HTMLElement,
+    adapter: ReturnType<AdapterRegistry['selectAdapter']>,
+    message: ChatMessageEntity
+  ): void {
+    const adapterElement = adapter?.renderMessageElement?.(message, this._myUserId) ?? null;
+    if (adapterElement) {
+      contentDiv.appendChild(adapterElement);
+      return;
+    }
+    if (adapter) {
+      console.warn(
+        `[chat-widget] adapter ${adapter.constructor?.name ?? '<anonymous>'} returned null from renderMessageElement; falling back to textContent. Adapter must implement renderMessageElement (#1100).`
+      );
+    }
+    const fallback = globalThis.document.createElement('p');
+    fallback.textContent = message.content?.text ?? '(no content)';
+    contentDiv.appendChild(fallback);
   }
 
   // Required by EntityScrollerWidget - load function using data/list command


### PR DESCRIPTION
## Summary

Closes #1100 — completes the innerHTML→DOM migration for chat adapters.

Per sibling tab #1's lead-priority list, this is the no-stack-required slice — fits my Mac stack being down today, scoped tight.

## What lands

**URLCardAdapter + ToolOutputAdapter**: add `renderMessageElement` override following the same shape Text + Image adapters already use (parse → build wrapper via DOM API → adopt rich content as DocumentFragment via detached `<template>` → return wrapper). All four adapters now implement the override.

**ChatWidget**: drop the `else if (adapter) { contentDiv.innerHTML = ... }` fallback entirely. The live message-content slot never sees `innerHTML` for current adapters. If a future adapter forgets to override OR its override returns null, fall back to textContent + a loud `console.warn` so the gap surfaces.

**Refactor**: extracted the adapter-render seam into a private helper `renderAdapterContentInto` to keep `getRenderFunction()`'s arrow function at the 15-complexity max — the pre-commit ESLint ratchet caught the +1 from the new conditional, the helper drops it back to 15.

## Why

1. **XSS surface** — the live-DOM `innerHTML` re-parse step is gone. Adapter renderContent strings still need careful interpolation; the URLCardAdapter metadata-string hardening (title/description/originalText) is a separate follow-up to #1100.
2. **Lit reactivity** — `innerHTML` on a live element destroys signal-bound children. Signal-bound children inside message bodies now survive sibling updates without remount.

## Test plan

- [x] `npm run build:ts` clean
- [x] All four adapters have `renderMessageElement` (TextMessageAdapter:182, ImageMessageAdapter:121, URLCardAdapter new, ToolOutputAdapter new)
- [x] `grep "innerHTML" src/widgets/chat/chat-widget/ChatWidget.ts` shows only comments + unrelated pendingAttachments preview path (out of scope)
- [x] ESLint baseline unchanged (5464 == 5464)
- [ ] Stack-up screenshot diff: existing message types render visually identically (gated on Mac stack restart; deferred — would need npm start)

## Out of scope (separate cards/PRs)

- URLCardAdapter metadata-string XSS hardening (title, description, originalText interpolation)
- Pending-attachment preview innerHTML at ChatWidget.ts:1050,1056 (separate input-area concern)
- CI lint rule to flag new `innerHTML =` in `widgets/chat/**` (the card's nice-to-have; small follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)