### PR TITLE
refactor(forge): rename ForgeAlloy in TS → ForgeRecipe / ForgeArtifact (Phase 1b of #1164)

### DIFF
--- a/src/commands/model/introspect/server/ModelIntrospectServerCommand.ts
+++ b/src/commands/model/introspect/server/ModelIntrospectServerCommand.ts
@@ -2,7 +2,7 @@
  * Model Introspect Command - Server Implementation
  *
  * Introspects a model to detect its architecture, capabilities, and which
- * ForgeAlloy stages can be applied. Returns the model's current state as
+ * ForgeRecipe stages can be applied. Returns the model's current state as
  * an alloy-compatible spec. Tries local HF cache first, then SSH to grid
  * nodes, then HF API.
  */

--- a/src/widgets/factory/FactoryStatsWidget.ts
+++ b/src/widgets/factory/FactoryStatsWidget.ts
@@ -787,7 +787,7 @@ export class FactoryStatsWidget extends ReactiveWidget {
 
     return html`
       <div>
-        <div class="section-label">ForgeAlloy</div>
+        <div class="section-label">ForgeArtifact</div>
         <div class="alloy-panel">
           <div class="alloy-row">
             <span class="alloy-key">Models</span>

--- a/src/widgets/factory/stages/CompactStageElement.ts
+++ b/src/widgets/factory/stages/CompactStageElement.ts
@@ -3,7 +3,7 @@
  *
  * Utilization-aware mixed-precision compaction.
  * Controls: utilization thresholds (dead/dormant/low/medium/high), target size, quantization
- * Maps 1:1 to ForgeAlloy CompactStage schema.
+ * Maps 1:1 to ForgeRecipe CompactStage schema.
  *
  * Head precision tiers (from Rust HeadPrecision):
  *   Dead (<deadThreshold)       → Removed entirely

--- a/src/widgets/factory/stages/ContextExtendStageElement.ts
+++ b/src/widgets/factory/stages/ContextExtendStageElement.ts
@@ -2,7 +2,7 @@
  * ContextExtendStageElement — UI for the alloy 'context-extend' stage
  *
  * Controls: target length, RoPE method (YaRN, NTK, linear, dynamic-NTK), training steps
- * Maps 1:1 to ForgeAlloy ContextExtendStage schema.
+ * Maps 1:1 to ForgeRecipe ContextExtendStage schema.
  */
 
 import { html, css, reactive, type TemplateResult, type CSSResultGroup } from '../../shared/ReactiveWidget';

--- a/src/widgets/factory/stages/DeployStageElement.ts
+++ b/src/widgets/factory/stages/DeployStageElement.ts
@@ -1,7 +1,7 @@
 /**
  * DeployStageElement — Output stage: deploy to grid or endpoint
  *
- * Maps to ForgeAlloy DeployStage.
+ * Maps to ForgeRecipe DeployStage.
  * Target node, health check, warmup, auto-scale.
  */
 

--- a/src/widgets/factory/stages/EvalStageElement.ts
+++ b/src/widgets/factory/stages/EvalStageElement.ts
@@ -1,7 +1,7 @@
 /**
  * EvalStageElement — Output stage: benchmark evaluation
  *
- * Maps to ForgeAlloy EvalStage.
+ * Maps to ForgeRecipe EvalStage.
  * Select benchmarks, set passing threshold, compare to base.
  */
 

--- a/src/widgets/factory/stages/ExpertPruneStageElement.ts
+++ b/src/widgets/factory/stages/ExpertPruneStageElement.ts
@@ -3,7 +3,7 @@
  *
  * MoE expert selection: keep the best N experts, remove the rest.
  * Controls: keep count, selection strategy, profiling config
- * Maps 1:1 to ForgeAlloy ExpertPruneStage schema.
+ * Maps 1:1 to ForgeRecipe ExpertPruneStage schema.
  */
 
 import { html, css, reactive, type TemplateResult, type CSSResultGroup } from '../../shared/ReactiveWidget';

--- a/src/widgets/factory/stages/LoraStageElement.ts
+++ b/src/widgets/factory/stages/LoraStageElement.ts
@@ -2,7 +2,7 @@
  * LoraStageElement — UI for the alloy 'lora' stage
  *
  * Controls: rank, alpha, dropout, target modules, QLoRA config, dataset, epochs, merge
- * Maps 1:1 to ForgeAlloy LoraStage schema.
+ * Maps 1:1 to ForgeRecipe LoraStage schema.
  */
 
 import { html, css, reactive, type TemplateResult, type CSSResultGroup } from '../../shared/ReactiveWidget';

--- a/src/widgets/factory/stages/ModalityStageElement.ts
+++ b/src/widgets/factory/stages/ModalityStageElement.ts
@@ -3,7 +3,7 @@
  *
  * Bolt vision, audio, or multimodal encoders onto a text model.
  * Controls: modality type, encoder model, projection arch, freeze options, training
- * Maps 1:1 to ForgeAlloy ModalityStage schema.
+ * Maps 1:1 to ForgeRecipe ModalityStage schema.
  */
 
 import { html, css, reactive, type TemplateResult, type CSSResultGroup } from '../../shared/ReactiveWidget';

--- a/src/widgets/factory/stages/PruneStageElement.ts
+++ b/src/widgets/factory/stages/PruneStageElement.ts
@@ -2,7 +2,7 @@
  * PruneStageElement — UI for the alloy 'prune' stage
  *
  * Controls: strategy, level (0-90%), min heads, min KV heads, analysis steps
- * Maps 1:1 to ForgeAlloy PruneStage schema.
+ * Maps 1:1 to ForgeRecipe PruneStage schema.
  */
 
 import { html, css, reactive, type TemplateResult, type CSSResultGroup } from '../../shared/ReactiveWidget';

--- a/src/widgets/factory/stages/PublishStageElement.ts
+++ b/src/widgets/factory/stages/PublishStageElement.ts
@@ -4,7 +4,7 @@
  * Prepares forge output for review. The actual publish to HuggingFace
  * happens manually via model/publish command after reviewing results.
  * Controls: org, repo name, tags, privacy, card generation
- * Maps 1:1 to ForgeAlloy DeliverStage schema.
+ * Maps 1:1 to ForgeRecipe DeliverStage schema.
  */
 
 import { html, css, reactive, type TemplateResult, type CSSResultGroup } from '../../shared/ReactiveWidget';

--- a/src/widgets/factory/stages/QuantStageElement.ts
+++ b/src/widgets/factory/stages/QuantStageElement.ts
@@ -1,7 +1,7 @@
 /**
  * QuantStageElement — Output stage: quantization for device targets
  *
- * Maps to ForgeAlloy QuantStage.
+ * Maps to ForgeRecipe QuantStage.
  * Format (GGUF/MLX/ONNX), quant types, device targets.
  */
 

--- a/src/widgets/factory/stages/SourceConfigStageElement.ts
+++ b/src/widgets/factory/stages/SourceConfigStageElement.ts
@@ -1,7 +1,7 @@
 /**
  * SourceConfigStageElement — Front bookend: declare model capabilities
  *
- * Maps to ForgeAlloy SourceConfigStage.
+ * Maps to ForgeRecipe SourceConfigStage.
  * Context window, input modalities, target devices.
  */
 

--- a/src/widgets/factory/stages/StageElement.ts
+++ b/src/widgets/factory/stages/StageElement.ts
@@ -1,7 +1,7 @@
 /**
  * StageElement — Abstract base for alloy pipeline stage UI components
  *
- * Each ForgeAlloy stage type (prune, train, lora, quant, eval, publish, etc.)
+ * Each ForgeRecipe stage type (prune, train, lora, quant, eval, publish, etc.)
  * extends this class. The spec defines the interface, the UI implements it.
  *
  * Responsibilities:

--- a/src/widgets/factory/stages/TrainStageElement.ts
+++ b/src/widgets/factory/stages/TrainStageElement.ts
@@ -2,7 +2,7 @@
  * TrainStageElement — UI for the alloy 'train' stage
  *
  * Controls: domain, dataset, steps, learning rate, batch size, scheduler, precision, optimizations
- * Maps 1:1 to ForgeAlloy TrainStage schema.
+ * Maps 1:1 to ForgeRecipe TrainStage schema.
  */
 
 import { html, css, reactive, type TemplateResult, type CSSResultGroup } from '../../shared/ReactiveWidget';


### PR DESCRIPTION
## Summary

Phase 1b of the design at docs/architecture/FORGE-RECIPE-AS-ENTITY.md. Pure rename — no behavior change. The single-entity 'ForgeAlloy' name splits across two roles per the consensus on continuum#1165:

- **`ForgeRecipe`** — the authored input (stages, prose, methodology, hardware target). All 14 stage-element widget JSDoc references update here. Stage widgets are recipe-authoring UI; stages live on the recipe side.
- **`ForgeArtifact`** — the foundry output (measured, hardware-verified, alloy hash, publication receipt). FactoryStatsWidget's "X/Y models have an alloy" panel relabels because the panel counts published artifacts, not authored recipes.

## Validation

- `grep ForgeAlloy src/` returns 0 results
- `npm run build:ts` clean
- Hooks ran without `--no-verify`

## Scope

15 files, 15-line rename diff, +15/-15. Pure refactor — Python `forge_alloy/types.py` untouched (Phase 2 ports those types to Rust as the source of truth); TS code only references the entity names in JSDoc + UI labels, never imports them as types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)