### PR TITLE
fix(install): skip 3.9GB model download in agent lanes + CI (#1172)

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -141,7 +141,7 @@
     "clean:dist": "rm -rf dist/ 2>/dev/null || true",
     "clean:logs": "find .continuum/jtag/logs -name '*.log' -type f -delete 2>/dev/null || true; find .continuum/personas -name '*.log' -type f -delete 2>/dev/null || true; rm -f /tmp/jtag-*-timing.jsonl 2>/dev/null || true; echo '✅ Cleaned all log files (system + persona + timing logs)'",
     "prepare": "npx tsx scripts/ensure-config.ts 2>/dev/null || true",
-    "postinstall": "(bash scripts/setup-git-hooks.sh > /dev/null 2>&1 || true) && (npm run worker:models || echo '⚠️ Voice model download failed (non-fatal — system starts without STT/TTS)')",
+    "postinstall": "(bash scripts/setup-git-hooks.sh > /dev/null 2>&1 || true) && bash scripts/maybe-download-models.sh",
     "prebuild": "npx tsx scripts/ensure-config.ts && npx tsx generator/validate-command-spec-coverage.ts && npx tsx generator/generate-rust-bindings.ts && npx tsx generator/generate-structure.ts && npx tsx generator/generate-command-schemas.ts && npx tsx generator/generate-command-constants.ts && npx tsx scripts/compile-sass.ts",
     "build:ts": "npx tsx generator/generate-version.ts && npx tsx generator/generate-config.ts && npx tsx generator/generate-entity-schemas.ts && npx tsx scripts/build-with-loud-failure.ts",
     "build:cli": "npx esbuild dist/cli.js --bundle --platform=node --target=node18 --outfile=dist/cli-bundle.js --external:sqlite3 --external:better-sqlite3 --external:@anthropic-ai/sdk --external:@grpc/grpc-js --external:@grpc/proto-loader --external:playwright-core --external:playwright --minify 2>/dev/null && echo '✅ CLI bundle created'",

--- a/src/scripts/maybe-download-models.sh
+++ b/src/scripts/maybe-download-models.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Postinstall wrapper: skip the heavyweight model download in agent
+# worktrees / explicit-skip contexts. The actual voice/avatar bytes are
+# only needed by the running stack; per-worktree npm install in an agent
+# lane wastes 30s+ + several GB of disk per lane.
+#
+# Skip conditions (any one is sufficient):
+#   1. CONTINUUM_SKIP_MODEL_DOWNLOAD=1 in the env
+#   2. pwd is under an airc lane worktree (~/.airc-worktrees/...)
+#   3. CI=true or GITHUB_ACTIONS=true (CI runners don't need the bytes;
+#      tests that need them download on demand)
+#
+# Otherwise, delegate to the existing download-voice-models.sh.
+#
+# See continuum#1172 for the issue + rationale.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+skip_reason=""
+
+if [ "${CONTINUUM_SKIP_MODEL_DOWNLOAD:-0}" = "1" ]; then
+  skip_reason="CONTINUUM_SKIP_MODEL_DOWNLOAD=1"
+fi
+
+if [ -z "$skip_reason" ] && [[ "$PWD" == *".airc-worktrees"* ]]; then
+  skip_reason="airc lane worktree detected (PWD=$PWD)"
+fi
+
+if [ -z "$skip_reason" ] && { [ "${CI:-}" = "true" ] || [ "${GITHUB_ACTIONS:-}" = "true" ]; }; then
+  skip_reason="CI environment detected"
+fi
+
+if [ -n "$skip_reason" ]; then
+  echo "⏭️  Skipping voice/avatar model download (~3.9GB) — $skip_reason"
+  echo "    To force download: unset CONTINUUM_SKIP_MODEL_DOWNLOAD and run:"
+  echo "    npm run worker:models"
+  exit 0
+fi
+
+# Delegate to the real download script. Honor its non-fatal contract
+# (the original postinstall wrapped this in `|| echo …` so the install
+# itself never failed on missing models).
+if ! "$SCRIPT_DIR/download-voice-models.sh"; then
+  echo "⚠️  Voice model download failed (non-fatal — system starts without STT/TTS)"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Per codex-main report at AIRC 15:54:52Z 2026-05-14: every npm install in a fresh agent lane pulled ~3.9GB of voice/avatar models even though the lane is purely for code changes. Wasted 30s+ install time + GB of disk per worktree. Today I had to clean ~100GB across the lanes I'd spawned.

## Issue

continuum#1172 / Card continuum#1173.

## Fix

Tiny wrapper `scripts/maybe-download-models.sh` that the postinstall calls instead of `npm run worker:models` directly. Skip conditions (any one is sufficient):

1. `CONTINUUM_SKIP_MODEL_DOWNLOAD=1` in env (explicit override)
2. `PWD` contains `.airc-worktrees` (auto-detect agent lane)
3. `CI=true` OR `GITHUB_ACTIONS=true` (CI runners don't need bytes; tests download on demand)

Otherwise delegates to the original `download-voice-models.sh`, preserving its non-fatal contract (failed download just warns, install continues).

## Proof

```
$ cd /Users/joelteply/.airc-worktrees/...-1173-claude-tab-1/src
$ npm install --prefer-offline --no-audit --no-fund 2>&1 | tail -5
✅ Config up to date: /Users/joelteply/.continuum/config.env
added 726 packages in 7s
```

7s vs the ~50s+download we were getting before. Manual wrapper invocation tested with all 3 skip conditions — each prints the right reason.

To force a download in a lane: `unset CONTINUUM_SKIP_MODEL_DOWNLOAD && cd /path/outside/.airc-worktrees && npm run worker:models`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)