### PR TITLE
feat(forge): forge/run IPC stub (Phase 4 of #1164)

### DIFF
--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -11,6 +11,7 @@ use crate::modules::cognition::{CognitionModule, CognitionState};
 use crate::modules::data::DataModule;
 use crate::modules::dataset::DatasetModule;
 use crate::modules::embedding::EmbeddingModule;
+use crate::modules::forge::ForgeModule;
 use crate::modules::gpu::GpuModule;
 use crate::modules::grid::GridModule;
 use crate::modules::health::HealthModule;
@@ -838,6 +839,11 @@ pub fn start_server(
 
     // Phase 1: GpuModule (GPU stats + pressure IPC)
     runtime.register(Arc::new(GpuModule::new(gpu_manager.clone())));
+
+    // ForgeModule (continuum#1164 Phase 4 stub — forge/run IPC).
+    // v1 returns a stub ForgeArtifact from a recipe; Phase 5+ wires the
+    // real foundry executor.
+    runtime.register(Arc::new(ForgeModule::new()));
 
     // Phase 1: PersonaAllocatorModule (hardware-aware persona allocation)
     runtime.register(Arc::new(PersonaAllocatorModule::new(gpu_manager.clone())));

--- a/src/workers/continuum-core/src/modules/forge.rs
+++ b/src/workers/continuum-core/src/modules/forge.rs
@@ -1,0 +1,289 @@
+//! ForgeModule — IPC commands for the foundry pipeline.
+//!
+//! Phase 4 of continuum#1164 (design at FORGE-RECIPE-AS-ENTITY.md).
+//! v1 is a stub: `forge/run` accepts a `ForgeRecipe` payload and
+//! returns a synthetic `ForgeArtifact` populated with placeholder
+//! execution outputs. Real stage execution (prune / train / lora /
+//! quant / eval) lands in Phase 5+ when the foundry executor is
+//! ported into Rust.
+//!
+//! Commands:
+//! - `forge/run`: Take a ForgeRecipe + hardware node label, return a
+//!   stub ForgeArtifact with `recipe_id` lineage + `forged_at_ms`
+//!   timestamp + an `alloy_hash` derived from the recipe's content
+//!   hash. Caller persists the artifact via `data/upsert` against
+//!   the `forge_artifacts` collection (Phase 3 #1180 wired the entity
+//!   registration).
+//!
+//! Stub semantics for Phase 4:
+//! - No models are loaded.
+//! - No stages execute.
+//! - No HuggingFace publishing.
+//! - The artifact's `results` / `receipt` / `integrity` fields stay
+//!   `None`. `hardware_verified` is empty.
+//! - `alloy_hash` is `"sha256:stub-<recipe_id_short>"` so the
+//!   placeholder is identifiable but doesn't collide with real hashes.
+//!
+//! This proves the IPC reachability + recipe→artifact transformation
+//! shape end-to-end without claiming to forge anything. Phase 5
+//! replaces the stub with the real executor.
+
+use crate::forge::{ForgeArtifact, ForgeRecipe};
+use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::Value;
+use std::any::Any;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+pub struct ForgeModule;
+
+impl ForgeModule {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ForgeModule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ForgeRunParams {
+    recipe: ForgeRecipe,
+    /// Hardware node label (e.g., "m5-pro@local", "rtx-5090@bigmama").
+    /// Stub records this in the artifact's hardware_verified for trace
+    /// purposes; Phase 5+ will actually dispatch to the named node.
+    #[serde(default)]
+    hardware_node: Option<String>,
+}
+
+#[async_trait]
+impl ServiceModule for ForgeModule {
+    fn config(&self) -> ModuleConfig {
+        ModuleConfig {
+            name: "forge",
+            priority: ModulePriority::Normal,
+            command_prefixes: &["forge/"],
+            event_subscriptions: &[],
+            needs_dedicated_thread: false,
+            max_concurrency: 0,
+            tick_interval: None,
+        }
+    }
+
+    async fn initialize(&self, _ctx: &ModuleContext) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn handle_command(&self, command: &str, params: Value) -> Result<CommandResult, String> {
+        match command {
+            "forge/run" => {
+                let parsed: ForgeRunParams = serde_json::from_value(params)
+                    .map_err(|e| format!("forge/run: invalid params: {e}"))?;
+
+                let artifact = synthesize_stub_artifact(&parsed.recipe, parsed.hardware_node.as_deref())?;
+                let json = serde_json::to_value(&artifact)
+                    .map_err(|e| format!("forge/run: serialize artifact: {e}"))?;
+                Ok(CommandResult::Json(json))
+            }
+            other => Err(format!("Unknown forge command: {other}")),
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Synthesize a stub `ForgeArtifact` from a recipe. Phase 4 placeholder
+/// — real foundry execution lands in Phase 5+. Caller persists the
+/// returned artifact via `data/upsert` against `forge_artifacts`.
+fn synthesize_stub_artifact(recipe: &ForgeRecipe, hardware_node: Option<&str>) -> Result<ForgeArtifact, String> {
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("system time before epoch: {e}"))?
+        .as_millis() as u64;
+
+    // Derive an identifiable stub hash from the recipe id (first 16 hex
+    // chars). Real Phase 5 hash will be sha256 of the populated alloy
+    // content. Stub format prefix avoids collision with real hashes.
+    let stub_hash = format!("sha256:stub-{}", recipe.id.simple().to_string().chars().take(16).collect::<String>());
+
+    Ok(ForgeArtifact {
+        id: Uuid::new_v4(),
+        recipe_id: recipe.id,
+        recipe_version: recipe.version.clone(),
+        recipe_name: recipe.name.clone(),
+        description: recipe.description.clone(),
+        user_summary: recipe.user_summary.clone(),
+        author: recipe.author.clone(),
+        tags: recipe.tags.clone(),
+        license: recipe.license.clone(),
+        methodology_paper_url: recipe.methodology_paper_url.clone(),
+        limitations: recipe.limitations.clone(),
+        prior_metric_baselines: recipe.prior_metric_baselines.clone(),
+        source: recipe.source.clone(),
+        calibration_corpus: recipe.calibration_corpus.clone(),
+        quant_tiers: recipe.quant_tiers.clone(),
+        evaluation_benchmarks: recipe.evaluation_benchmarks.clone(),
+        hardware: recipe.hardware.clone(),
+        forged_at_ms: now_ms,
+        // Phase 5+ populates the rest; v1 stub leaves them empty/None.
+        duration_minutes: None,
+        forged_params_b: None,
+        active_params_b: None,
+        hardware_verified: hardware_node
+            .map(|node| {
+                vec![crate::forge::HardwareProfile {
+                    device: node.to_string(),
+                    format: "stub".to_string(),
+                    size_gb: None,
+                    tokens_per_sec: None,
+                    memory_usage_gb: None,
+                    verified: false,
+                }]
+            })
+            .unwrap_or_default(),
+        alloy_hash: Some(stub_hash),
+        results: None,
+        receipt: None,
+        integrity: None,
+    })
+}
+
+//=============================================================================
+// TESTS
+//=============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::forge::{AlloyHardware, AlloySource, CorpusRef};
+
+    fn synthetic_recipe() -> ForgeRecipe {
+        ForgeRecipe {
+            id: Uuid::new_v4(),
+            name: "test-recipe".to_string(),
+            version: "0.1.0".to_string(),
+            description: "test".to_string(),
+            user_summary: "test summary".to_string(),
+            author: "test".to_string(),
+            tags: vec!["test".to_string()],
+            license: "apache-2.0".to_string(),
+            methodology_paper_url: None,
+            limitations: vec![],
+            prior_metric_baselines: vec![],
+            source: AlloySource {
+                base_model: "test-model".to_string(),
+                architecture: "test-arch".to_string(),
+                revision: None,
+                is_moe: false,
+                total_experts: None,
+            },
+            stages: vec![],
+            cycles: 1,
+            calibration_corpus: CorpusRef {
+                name: "test-corpus".to_string(),
+                content_hash: "sha256:test".to_string(),
+                size_bytes: 0,
+                source_url: None,
+            },
+            quant_tiers: vec![],
+            evaluation_benchmarks: vec![],
+            hardware: AlloyHardware {
+                min_vram_gb: None,
+                recommended_vram_gb: None,
+                estimated_duration_minutes: None,
+                supports_cpu: false,
+                tested_on: vec![],
+            },
+            parent_recipe_id: None,
+            authored_at_ms: 0,
+            updated_at_ms: 0,
+        }
+    }
+
+    /// What this catches: stub artifact carries the recipe's lineage
+    /// (recipe_id + recipe_version + recipe_name) frozen at synthesis
+    /// time. If a Phase 5+ refactor accidentally drops the lineage,
+    /// the artifact would lose its provenance anchor.
+    #[test]
+    fn stub_artifact_carries_recipe_lineage() {
+        let recipe = synthetic_recipe();
+        let recipe_id = recipe.id;
+        let artifact = synthesize_stub_artifact(&recipe, None).expect("synth");
+        assert_eq!(artifact.recipe_id, recipe_id);
+        assert_eq!(artifact.recipe_version, "0.1.0");
+        assert_eq!(artifact.recipe_name, "test-recipe");
+    }
+
+    /// What this catches: stub artifact has its OWN id, not the recipe's.
+    /// Multiple artifacts can come from one recipe (re-runs on different
+    /// hardware) and each must be distinguishable.
+    #[test]
+    fn stub_artifact_has_distinct_id_from_recipe() {
+        let recipe = synthetic_recipe();
+        let artifact = synthesize_stub_artifact(&recipe, None).expect("synth");
+        assert_ne!(
+            artifact.id, recipe.id,
+            "artifact id MUST differ from recipe id (1:N relationship)"
+        );
+    }
+
+    /// What this catches: alloy_hash uses the canonical "sha256:..."
+    /// prefix matching admission's content_hash convention. Stub
+    /// includes "stub-" suffix so it's distinguishable from real hashes
+    /// in the wild.
+    #[test]
+    fn stub_alloy_hash_is_canonical_with_stub_marker() {
+        let recipe = synthetic_recipe();
+        let artifact = synthesize_stub_artifact(&recipe, None).expect("synth");
+        let hash = artifact.alloy_hash.expect("stub hash present");
+        assert!(hash.starts_with("sha256:stub-"), "got: {hash}");
+    }
+
+    /// What this catches: hardware_node parameter (when set) lands in
+    /// hardware_verified as a stub HardwareProfile. Phase 5+ will
+    /// actually dispatch + populate real measurements; for now the
+    /// caller sees their requested node echoed back.
+    #[test]
+    fn stub_artifact_records_requested_hardware_node() {
+        let recipe = synthetic_recipe();
+        let artifact = synthesize_stub_artifact(&recipe, Some("m5-pro@local")).expect("synth");
+        assert_eq!(artifact.hardware_verified.len(), 1);
+        assert_eq!(artifact.hardware_verified[0].device, "m5-pro@local");
+        assert_eq!(artifact.hardware_verified[0].format, "stub");
+        assert!(!artifact.hardware_verified[0].verified, "stub is not verified");
+    }
+
+    /// What this catches: with no hardware_node, hardware_verified
+    /// stays empty (vs an entry with empty device label). Caller can
+    /// distinguish "no hw requested" from "hw requested but no metrics".
+    #[test]
+    fn stub_artifact_without_hardware_node_is_empty_verified() {
+        let recipe = synthetic_recipe();
+        let artifact = synthesize_stub_artifact(&recipe, None).expect("synth");
+        assert!(artifact.hardware_verified.is_empty());
+    }
+
+    /// What this catches: Phase 4 fields that Phase 5+ will populate
+    /// (results, receipt, integrity, duration, params_b) all start as
+    /// None on the stub. A Phase 5 refactor that accidentally fills
+    /// them with placeholder data would silently claim measurements
+    /// that didn't happen.
+    #[test]
+    fn stub_artifact_phase5_fields_are_none() {
+        let recipe = synthetic_recipe();
+        let artifact = synthesize_stub_artifact(&recipe, Some("m5-pro@local")).expect("synth");
+        assert!(artifact.results.is_none());
+        assert!(artifact.receipt.is_none());
+        assert!(artifact.integrity.is_none());
+        assert!(artifact.duration_minutes.is_none());
+        assert!(artifact.forged_params_b.is_none());
+        assert!(artifact.active_params_b.is_none());
+    }
+}

--- a/src/workers/continuum-core/src/modules/mod.rs
+++ b/src/workers/continuum-core/src/modules/mod.rs
@@ -20,6 +20,7 @@ pub mod data;
 pub mod dataset;
 pub mod embedding;
 pub mod entity_schemas;
+pub mod forge;
 pub mod gpu;
 pub mod grid;
 pub mod health;


### PR DESCRIPTION
## Summary

Phase 4 of continuum#1164. ForgeModule + `forge/run` IPC handler. v1 stub: takes a ForgeRecipe + optional hardware_node, returns a synthesized ForgeArtifact with the recipe lineage frozen + a `sha256:stub-<id>` alloy_hash marker. No models loaded, no stages executed, no HF publishing — Phase 5+ wires the real foundry executor.

## What ships

- `modules/forge.rs` — ForgeModule ServiceModule + `synthesize_stub_artifact` helper
- `modules/mod.rs` — `pub mod forge`
- `ipc/mod.rs` — register ForgeModule in the runtime

## Tests

6 passing: recipe lineage frozen, distinct artifact id, canonical sha256:stub- hash, hardware_node echo, empty hw_verified when no hw_node, Phase 5+ fields all None on the stub.

## Stub semantics

Explicitly does NOT claim to forge anything. Proves IPC reachability + recipe→artifact transformation shape end-to-end. Phase 5 replaces the stub with the real Rust foundry executor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)