### PR TITLE
fix(precommit): branch-state guard against silent switches mid-hook (#1187)

### DIFF
--- a/src/scripts/git-precommit.sh
+++ b/src/scripts/git-precommit.sh
@@ -4,6 +4,66 @@ set -e  # Exit immediately on any error
 # Navigate to the correct working directory
 cd "$(dirname "$0")/.."
 
+# ==============================================================================
+# BRANCH-STATE GUARD (continuum#1187)
+# ==============================================================================
+# Capture the branch + HEAD sha BEFORE the hook does any work. The end-of-
+# script guard verifies these are unchanged before printing "Commit approved";
+# if they HAVE changed, the script aborts with exit 1 + a loud error so git
+# refuses to create the commit on the wrong ref.
+#
+# Root-cause family of #1187: backticks in commit messages can be evaluated
+# by bash if the user runs `git commit -m "fix \`git checkout\` bug"` — bash
+# executes the backtick subcommand and its side-effects (an unintended
+# `git checkout`) silently change the branch. Single-quoted HEREDOC commit
+# messages don't have this problem, but the hook can't enforce caller quoting.
+# Defense in depth: even if the bug recurs (this hook OR caller), the guard
+# catches it.
+PRECOMMIT_INITIAL_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'DETACHED')"
+PRECOMMIT_INITIAL_HEAD="$(git rev-parse HEAD 2>/dev/null || echo '')"
+PRECOMMIT_INITIAL_TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || echo '')"
+export PRECOMMIT_INITIAL_BRANCH PRECOMMIT_INITIAL_HEAD PRECOMMIT_INITIAL_TOPLEVEL
+
+# Verify the captured state still holds. Used at end of script + can be
+# called from any sub-step that wants to assert mid-run.
+verify_branch_state_unchanged() {
+    local now_branch
+    local now_head
+    local now_toplevel
+    now_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'DETACHED')"
+    now_head="$(git rev-parse HEAD 2>/dev/null || echo '')"
+    now_toplevel="$(git rev-parse --show-toplevel 2>/dev/null || echo '')"
+
+    if [ "$now_branch" != "$PRECOMMIT_INITIAL_BRANCH" ] \
+        || [ "$now_head" != "$PRECOMMIT_INITIAL_HEAD" ] \
+        || [ "$now_toplevel" != "$PRECOMMIT_INITIAL_TOPLEVEL" ]; then
+        echo ""
+        echo "🚨🚨🚨 BRANCH-STATE GUARD TRIPPED — ABORTING COMMIT 🚨🚨🚨"
+        echo "==================================================================="
+        echo "The precommit hook changed branch state mid-run. Aborting before"
+        echo "git can create a commit on the wrong ref. This protects you from"
+        echo "the silent loss-of-work failure mode tracked in continuum#1187."
+        echo ""
+        echo "  branch:    '$PRECOMMIT_INITIAL_BRANCH' -> '$now_branch'"
+        echo "  HEAD:      '$PRECOMMIT_INITIAL_HEAD' -> '$now_head'"
+        echo "  toplevel:  '$PRECOMMIT_INITIAL_TOPLEVEL' -> '$now_toplevel'"
+        echo ""
+        echo "Likely cause: backticks in your commit message that bash evaluated"
+        echo "as subcommands. Switch to single-quoted HEREDOC for commit messages:"
+        echo ""
+        echo "  git commit -m \"\$(cat <<'EOF'"
+        echo "  fix(...): your message with \`backticks\` is now safe"
+        echo "  EOF"
+        echo "  )\""
+        echo ""
+        echo "Your staged changes are still in the index. Recover with:"
+        echo "  git switch '$PRECOMMIT_INITIAL_BRANCH'"
+        echo "  git stash list   # if anything got auto-stashed"
+        echo "==================================================================="
+        exit 1
+    fi
+}
+
 require_node_deps() {
     if [ -x "node_modules/.bin/tsx" ] \
         && [ -x "node_modules/.bin/eslint" ] \
@@ -616,6 +676,12 @@ git restore src/.continuum/sessions/validation/test-output.txt 2>/dev/null || tr
 cd src
 echo "✅ Test artifacts cleaned up"
 
+# continuum#1187 — verify the hook didn't silently switch branches or
+# move HEAD via a backticks-in-commit-message side-effect or a buggy
+# sub-script. If it did, abort before printing "Commit approved" so
+# git refuses to create the commit on the wrong ref.
+verify_branch_state_unchanged
+
 # Final Summary
 echo ""
 echo "🎉 PRECOMMIT VALIDATION COMPLETE!"
@@ -624,5 +690,6 @@ echo "=================================================="
 [ "$ENABLE_SYSTEM_RESTART" = true ] && echo "✅ System restart: COMPLETED (strategy: $RESTART_STRATEGY)"
 [ "$ENABLE_BROWSER_TEST" = true ] && echo "✅ Browser tests: PASSED"
 echo "✅ Test artifacts cleaned up"
+echo "✅ Branch-state guard: ON branch '$PRECOMMIT_INITIAL_BRANCH' at $PRECOMMIT_INITIAL_HEAD"
 echo ""
 echo "🚀 Commit approved - all enabled validations passed!"


### PR DESCRIPTION
## Summary

Per claude-tab-2's CRITICAL bug report on continuum#1187: precommit hook ran, printed 'Commit approved', but the actual commit landed on a different branch than the user was on. Working tree silently moved to a stash; if the user hadn't checked stash list, work would have been lost.

## Likely root cause

Backticks inside a `git commit -m "..."` double-quoted string get evaluated by bash. A commit message like "fix the \`git checkout\` regression" causes bash to execute `git checkout` and substitute its stdout into the message. The side-effect (an actual checkout) silently moves the user's branch.

Single-quoted HEREDOC commit messages avoid this, but the hook cannot enforce caller quoting.

## Defense in depth

Capture branch + HEAD + toplevel at hook start, verify unchanged at hook end before printing 'Commit approved'. If they differ, abort with exit 1 + a loud actionable error showing before/after state + suggesting the HEREDOC pattern.

## Catches

1. Backticks-in-message side-effects (the suspected #1187 trigger)
2. Any future regression where the hook itself starts switching branches as a side-effect of a sub-script
3. Cross-worktree confusion (toplevel changed unexpectedly)

## Validation

- `bash -n` syntax check passes
- This PR's own commit ran through the new guard cleanly: '✅ Branch-state guard: ON branch fix/precommit-branch-state-guard at b40a39f24...'

🤖 Generated with [Claude Code](https://claude.com/claude-code)