### PR TITLE
fix(precommit): add scripts/precommit-config.sh the hook expects (#1190)

### DIFF
--- a/src/scripts/precommit-config.sh
+++ b/src/scripts/precommit-config.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# scripts/precommit-config.sh — modular precommit configuration.
+#
+# Sourced by scripts/git-precommit.sh at start. Sets the gate flags + the
+# test list. The hook falls back to safe defaults if this file is missing,
+# but having the file means defaults are now CHECKED IN AND DOCUMENTED
+# rather than implicit (continuum#1190 — config never-loaded smell).
+#
+# Edit this file (don't edit defaults inline in git-precommit.sh) when
+# changing precommit behavior. Bump CONFIG_VERSION when introducing a
+# breaking change so reviewers see the diff.
+#
+# To temporarily disable a gate locally without committing the change,
+# export the variable BEFORE the commit, e.g.:
+#   ENABLE_TYPESCRIPT_CHECK=false git commit -m "..."
+# (the hook uses `export ...` so the env var wins.)
+
+# Config schema version. Bump when adding/renaming variables so review
+# can flag breaking changes.
+export PRECOMMIT_CONFIG_VERSION="1.0.0"
+
+# ---- Gate flags --------------------------------------------------------------
+
+# Phase 1: TypeScript compilation (npm run build:ts)
+export ENABLE_TYPESCRIPT_CHECK=true
+
+# Phase 2: System restart strategy ("on_code_change" | "always" | "never").
+# "on_code_change" = restart only if code-relevant files staged.
+export RESTART_STRATEGY="on_code_change"
+
+# Phase 2: Browser test (PRECOMMIT_TESTS via vitest in tests/precommit/).
+# v1: just browser-ping.test.ts ("server didn't crash"). claude-tab-2 is
+# extending this in continuum#1186 to add chat-roundtrip + adapter unit
+# tests; once that lands, this list will grow.
+export ENABLE_BROWSER_TEST=true
+export PRECOMMIT_TESTS="tests/precommit/browser-ping.test.ts"
+
+# Phase 3: Artifact collection (test reports, screenshots). Disabled until
+# Phase 2 actually produces artifacts worth collecting.
+export ENABLE_ARTIFACTS=false
+
+# ---- Notes for future config edits ------------------------------------------
+#
+# - Branch-state guard (continuum#1187) is hard-coded ON in the hook;
+#   not a flag because turning it off defeats the purpose.
+# - Phase 0 command-generator-ownership guard is also hard-coded; same logic.
+# - Phase 1.5 strict-lint baseline ratchet is hard-coded; the baseline file
+#   src/clippy-baseline.txt + src/eslint-baseline.txt are the knobs.


### PR DESCRIPTION
## Summary

claude-tab-2 noticed during #1186 work: `git-precommit.sh` sources `scripts/precommit-config.sh` on line 29 but the file does not exist. The hook silently falls through to inline defaults — "config-driven" was actually "hardcoded" + every commit printed "Configuration file not found".

## Fix

Ship the config with the same defaults the hook was falling through to, plus:
- `PRECOMMIT_CONFIG_VERSION` schema field for future migration
- Doc comments naming load-bearing flags + how to override locally
- Notes pointing at gates that are hard-coded for security (e.g. branch-state guard from #1187)

Pure additive. No behavior change today; the hook now prints 'Loaded precommit configuration' instead of 'Configuration file not found'.

## Card

continuum#1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)