### PR TITLE
fix(test): replace missing system-startup import with SystemOrchestration (#1120)

### DIFF
--- a/src/scripts/test-with-server.ts
+++ b/src/scripts/test-with-server.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import { startSystem } from './system-startup';
+import { SystemOrchestration } from '../system/core/SystemOrchestrator';
 
 interface OutputFilter {
   shouldShowLine(line: string): boolean;
@@ -249,8 +249,15 @@ async function main(): Promise<void> {
       console.log('✅ System already running and healthy - reusing existing system');
     } else {
       console.log('🚀 No healthy system detected - starting fresh system');
-      // Start the system using shared startup logic for testing
-      await startSystem('npm-test');
+      // Start the system via SystemOrchestration's testing preset.
+      // (Earlier code imported a non-existent './system-startup' module —
+      // see continuum#1120 for context. The canonical entry for npm-test
+      // is SystemOrchestration.forTesting() in
+      // src/system/core/SystemOrchestrator.ts.)
+      const result = await SystemOrchestration.forTesting();
+      if (!result.success) {
+        throw new Error('System startup failed for npm-test mode');
+      }
     }
     
     // Run tests with verbose flag


### PR DESCRIPTION
## Symptom

From continuum#1120 (claude-tab-2 reproduction while validating PR #1085):

```
npm test -- --runTestsByPath src/tests/unit/seed-install-tier.test.ts
```

errors before any test runs because `src/scripts/test-with-server.ts` has:

```ts
import { startSystem } from './system-startup';
```

— and `./system-startup` does not exist anywhere in the tree. Module resolution fails, the test runner never starts.

## Fix

Swap the broken import for the canonical entry that already exists at `src/system/core/SystemOrchestrator.ts`:

```ts
import { SystemOrchestration } from '../system/core/SystemOrchestrator';
…
const result = await SystemOrchestration.forTesting();
if (!result.success) {
  throw new Error('System startup failed for npm-test mode');
}
```

`SystemOrchestration.forTesting()` is the exact factory the rest of the testing path uses — same options shape (`mode: 'testing'`, `persistent: true`, `captureOutput: 'logs'`, `buildIfNeeded: true`, `timeout: 60000`).

The previous call site lost its return value; restoring the loud-throw on failure means startup errors surface to the test runner instead of silently mis-behaving.

## Validation

- `npm run build:ts` passes clean (no other consumers of the dead `system-startup` module).
- Pre-push hook ran without `--no-verify`.
- Branch matches scope (per global `branch-name == work` rule); split out of `fix/precommit-config-loader` (PR #1193) where it accidentally landed first.

Closes #1120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)