### PR TITLE
feat(cognition): wire admission gate onto cognition/respond hot path (#1211)

### DIFF
--- a/src/workers/continuum-core/src/modules/cognition.rs
+++ b/src/workers/continuum-core/src/modules/cognition.rs
@@ -940,6 +940,63 @@ impl ServiceModule for CognitionModule {
 
                 let input = crate::persona::cognition_io::build_respond_input(&signal, &ctx)?;
 
+                // ── Hot-path admission gate (continuum#1211) ────────
+                // Run admission BEFORE inference so the persona's
+                // engram store grows from real chat turns. Without
+                // this call the admission machinery (#1121 PR-1..5) is
+                // plumbed end-to-end but never reached on the chat
+                // path — personas accumulate zero memory.
+                //
+                // Forensic-not-destructive: a missing AdmissionState
+                // (persona never had `cognition/create-engine` called)
+                // is logged and skipped, NOT a chat-blocking error.
+                // The persona still responds; it just doesn't grow
+                // memory until the engine is created. PR-2 will
+                // surface recalled engrams to prompt_assembly so the
+                // recall side starts working too.
+                {
+                    let inbox_msg =
+                        crate::persona::cognition_io::signal_to_inbox_message(&signal, &ctx);
+                    match self.state.personas.get(&ctx.persona_id) {
+                        Some(persona) => {
+                            let mut admission_trace =
+                                crate::persona::trace::CognitionTrace::new();
+                            match persona.admission.admit(&inbox_msg, &mut admission_trace) {
+                                Ok(decision) => {
+                                    runtime::logger("cognition").info(&format!(
+                                        "cognition/respond: admission decision={} \
+                                         engrams={} (persona={})",
+                                        admission_decision_label(&decision),
+                                        persona.admission.engram_count(),
+                                        ctx.persona_id,
+                                    ));
+                                }
+                                Err(err) => {
+                                    // Admission *machinery* failure (envelope
+                                    // verification, replay-detected, etc.) —
+                                    // log and continue. The chat turn isn't
+                                    // gated on admission today; PR-2 may
+                                    // change that policy.
+                                    runtime::logger("cognition").warn(&format!(
+                                        "cognition/respond: admission error \
+                                         (continuing without memory grow): {err} \
+                                         (persona={})",
+                                        ctx.persona_id,
+                                    ));
+                                }
+                            }
+                        }
+                        None => {
+                            runtime::logger("cognition").warn(&format!(
+                                "cognition/respond: no AdmissionState for persona={} \
+                                 — skipping admission (call cognition/create-engine first \
+                                 to enable memory accumulation)",
+                                ctx.persona_id,
+                            ));
+                        }
+                    }
+                }
+
                 // Diagnostic: log what media survived the projection.
                 // Vision routing was failing 2026-04-21 and this stays
                 // as the in-flight tap to confirm media shape arriving
@@ -1364,6 +1421,19 @@ fn parse_messages(arr: &[Value]) -> Vec<text_analysis::ConversationMessage> {
             })
         })
         .collect()
+}
+
+/// Short label for an `AdmissionDecision` — used in hot-path log lines
+/// so funnel metrics can be grep'd from cognition logs without parsing
+/// the full JSON. (Used only by the cognition/respond hot-path admission
+/// integration, continuum#1211.)
+fn admission_decision_label(d: &crate::persona::engram::AdmissionDecision) -> &'static str {
+    use crate::persona::engram::AdmissionDecision;
+    match d {
+        AdmissionDecision::Admit { .. } => "admit",
+        AdmissionDecision::Drop { .. } => "drop",
+        AdmissionDecision::Quarantine { .. } => "quarantine",
+    }
 }
 
 /// Parse an InboxMessage from JSON value.

--- a/src/workers/continuum-core/src/modules/cognition.rs
+++ b/src/workers/continuum-core/src/modules/cognition.rs
@@ -954,48 +954,7 @@ impl ServiceModule for CognitionModule {
                 // memory until the engine is created. PR-2 will
                 // surface recalled engrams to prompt_assembly so the
                 // recall side starts working too.
-                {
-                    let inbox_msg =
-                        crate::persona::cognition_io::signal_to_inbox_message(&signal, &ctx);
-                    match self.state.personas.get(&ctx.persona_id) {
-                        Some(persona) => {
-                            let mut admission_trace =
-                                crate::persona::trace::CognitionTrace::new();
-                            match persona.admission.admit(&inbox_msg, &mut admission_trace) {
-                                Ok(decision) => {
-                                    runtime::logger("cognition").info(&format!(
-                                        "cognition/respond: admission decision={} \
-                                         engrams={} (persona={})",
-                                        admission_decision_label(&decision),
-                                        persona.admission.engram_count(),
-                                        ctx.persona_id,
-                                    ));
-                                }
-                                Err(err) => {
-                                    // Admission *machinery* failure (envelope
-                                    // verification, replay-detected, etc.) —
-                                    // log and continue. The chat turn isn't
-                                    // gated on admission today; PR-2 may
-                                    // change that policy.
-                                    runtime::logger("cognition").warn(&format!(
-                                        "cognition/respond: admission error \
-                                         (continuing without memory grow): {err} \
-                                         (persona={})",
-                                        ctx.persona_id,
-                                    ));
-                                }
-                            }
-                        }
-                        None => {
-                            runtime::logger("cognition").warn(&format!(
-                                "cognition/respond: no AdmissionState for persona={} \
-                                 — skipping admission (call cognition/create-engine first \
-                                 to enable memory accumulation)",
-                                ctx.persona_id,
-                            ));
-                        }
-                    }
-                }
+                run_inline_admission_gate(&self.state, &signal, &ctx);
 
                 // Diagnostic: log what media survived the projection.
                 // Vision routing was failing 2026-04-21 and this stays
@@ -1423,16 +1382,195 @@ fn parse_messages(arr: &[Value]) -> Vec<text_analysis::ConversationMessage> {
         .collect()
 }
 
-/// Short label for an `AdmissionDecision` — used in hot-path log lines
-/// so funnel metrics can be grep'd from cognition logs without parsing
-/// the full JSON. (Used only by the cognition/respond hot-path admission
-/// integration, continuum#1211.)
-fn admission_decision_label(d: &crate::persona::engram::AdmissionDecision) -> &'static str {
-    use crate::persona::engram::AdmissionDecision;
-    match d {
-        AdmissionDecision::Admit { .. } => "admit",
-        AdmissionDecision::Drop { .. } => "drop",
-        AdmissionDecision::Quarantine { .. } => "quarantine",
+/// Outcome of the inline admission gate. Made testable by extracting
+/// from the `cognition/respond` IPC handler — claude-tab-2 review nit
+/// #3 on PR #1213 (the forensic-skip path was untested as inline code).
+///
+/// Logged for the same funnel-metric grep-ability as the underlying
+/// `AdmissionDecision::label()` (#1213 nit #2 — label moved to live
+/// next to the type in `persona/engram.rs`).
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum InlineAdmissionOutcome {
+    /// Admission ran and produced a decision. Variant carried so
+    /// callers (today: hot-path log) can branch on `admit` vs
+    /// `drop`/`quarantine` without re-walking the full enum.
+    Decided(&'static str),
+    /// Admission machinery itself errored (envelope verify, replay,
+    /// etc.). Carried so the warn log reads the typed cause.
+    MachineryError(String),
+    /// Persona had no `AdmissionState` — `cognition/create-engine`
+    /// was never called for this persona. Forensic-not-destructive:
+    /// log + continue, don't block the chat turn.
+    NoPersona,
+}
+
+/// Run the admission gate inline as a pre-step to `respond()`. Side
+/// effects: AdmissionState's engram store grows on Admit; a warn log
+/// fires on MachineryError or NoPersona. Returns the typed outcome
+/// for caller-side telemetry / unit tests (claude-tab-2 review nit
+/// #3 on PR #1213).
+///
+/// **Hot-path log discipline (claude-tab-2 review nit #1):** the
+/// steady-state `Admit` decision does NOT log — every chat turn for
+/// every persona would otherwise pay a `format!` allocation that
+/// nobody reads. The engram store growth itself is observable via
+/// `cognition/recall-engrams` (#1121 PR-5) for funnel telemetry.
+/// Drop and Quarantine decisions DO log at info because they're the
+/// unhappy paths a debugger needs to find. Errors and missing-state
+/// log at warn.
+pub(crate) fn run_inline_admission_gate(
+    state: &CognitionState,
+    signal: &crate::persona::cognition_io::Signal,
+    ctx: &crate::persona::cognition_io::PersonaContext,
+) -> InlineAdmissionOutcome {
+    let inbox_msg = crate::persona::cognition_io::signal_to_inbox_message(signal, ctx);
+    let Some(persona) = state.personas.get(&ctx.persona_id) else {
+        runtime::logger("cognition").warn(&format!(
+            "cognition/respond: no AdmissionState for persona={} \
+             — skipping admission (call cognition/create-engine first \
+             to enable memory accumulation)",
+            ctx.persona_id,
+        ));
+        return InlineAdmissionOutcome::NoPersona;
+    };
+
+    let mut admission_trace = crate::persona::trace::CognitionTrace::new();
+    match persona.admission.admit(&inbox_msg, &mut admission_trace) {
+        Ok(decision) => {
+            let label = decision.label();
+            // Skip Admit — common case, no allocation. Drop +
+            // Quarantine are the noteworthy outcomes a debugger wants
+            // to grep for; log those at info. Engram count piggy-
+            // backs the unhappy-path log so funnel monitoring can
+            // join "% drops" against "engram store size" without a
+            // separate query.
+            if label != "admit" {
+                runtime::logger("cognition").info(&format!(
+                    "cognition/respond: admission decision={label} \
+                     engrams={} (persona={})",
+                    persona.admission.engram_count(),
+                    ctx.persona_id,
+                ));
+            }
+            InlineAdmissionOutcome::Decided(label)
+        }
+        Err(err) => {
+            let err_string = err.to_string();
+            runtime::logger("cognition").warn(&format!(
+                "cognition/respond: admission error \
+                 (continuing without memory grow): {err_string} \
+                 (persona={})",
+                ctx.persona_id,
+            ));
+            InlineAdmissionOutcome::MachineryError(err_string)
+        }
+    }
+}
+
+// ─── Tests for the inline admission gate (claude-tab-2 review nit
+// #3 on PR #1213) ────────────────────────────────────────────────────
+//
+// The inline admission gate inside the `cognition/respond` IPC
+// handler used to live as inline code, untestable without a full
+// IPC fixture. Extracting `run_inline_admission_gate` made it a
+// callable function; these tests exercise the forensic-skip branch
+// (no AdmissionState for the persona) so a future refactor can't
+// silently change the behavior to an error-and-block (which would
+// make every chat turn for an uncreated persona fail).
+//
+// Tests use a real `CognitionState` constructed with an empty
+// `RagEngine` — same shape `persona::evaluator::tests` uses. No
+// mocks; the substrate is small enough to construct as-is.
+#[cfg(test)]
+mod inline_admission_tests {
+    use super::*;
+    use crate::cognition::RecentMessage;
+    use crate::persona::cognition_io::{Signal, SignalKind, SignalOriginator};
+    use std::sync::Arc;
+
+    /// Build a minimal Signal + PersonaContext pair for the test.
+    /// Both are wire-shape types; the test mirrors what `cognition/respond`
+    /// receives over IPC at the inline-gate site.
+    fn fixture(persona_id: Uuid) -> (Signal, crate::persona::cognition_io::PersonaContext) {
+        let signal = Signal {
+            kind: SignalKind::ChatMessage,
+            text: "hello world".to_string(),
+            media: vec![],
+            originator: SignalOriginator::User { user_id: Uuid::new_v4() },
+            timestamp_ms: 1_715_625_600_000,
+            message_id: Some(Uuid::new_v4()),
+        };
+        let ctx = crate::persona::cognition_io::PersonaContext {
+            persona_id,
+            display_name: "Test Persona".to_string(),
+            specialty: "general".to_string(),
+            model: "test-model".to_string(),
+            capabilities: vec![],
+            system_prompt: String::new(),
+            recent_history: Vec::<RecentMessage>::new(),
+            known_specialties: vec![],
+            other_persona_names: vec![],
+            room_id: Some(Uuid::new_v4()),
+            is_voice: false,
+        };
+        (signal, ctx)
+    }
+
+    /// What this catches: the forensic-not-destructive missing-
+    /// AdmissionState branch returns `NoPersona` and continues
+    /// (no panic, no error propagated). If a future edit changes
+    /// the `let Some(persona) = ...` to a `?` or an `expect()`,
+    /// this test fails and surfaces the regression at unit-test
+    /// time rather than during a live chat-roundtrip smoke.
+    #[test]
+    fn missing_admission_state_returns_no_persona_no_panic() {
+        let rag_engine = Arc::new(crate::rag::RagEngine::new());
+        let state = CognitionState::new(rag_engine);
+        // Note: state.personas is empty — no `cognition/create-engine`
+        // was ever called for this persona, modeling the bootstrap
+        // edge case where a chat turn lands before the engine is up.
+        let persona_id = Uuid::new_v4();
+        let (signal, ctx) = fixture(persona_id);
+
+        let outcome = run_inline_admission_gate(&state, &signal, &ctx);
+        assert_eq!(outcome, InlineAdmissionOutcome::NoPersona);
+        // Verify the state DashMap stays empty — the gate is a
+        // pure no-op when there's no AdmissionState to mutate.
+        assert_eq!(state.personas.len(), 0);
+    }
+
+    /// What this catches: when the persona DOES have AdmissionState,
+    /// the gate runs admission and returns `Decided(...)`. The label
+    /// is one of the documented variants — guards against
+    /// `AdmissionDecision::label` ever returning a fresh slug that
+    /// would silently break log-grep dashboards.
+    #[test]
+    fn admission_with_persona_returns_decided_variant() {
+        let rag_engine = Arc::new(crate::rag::RagEngine::new());
+        let state = CognitionState::new(rag_engine.clone());
+        let persona_id = Uuid::new_v4();
+        // Materialize the persona state — same path
+        // `cognition/create-engine` takes during bootstrap.
+        state.personas.insert(
+            persona_id,
+            crate::persona::PersonaCognition::new(
+                persona_id,
+                "Test Persona".to_string(),
+                rag_engine,
+            ),
+        );
+
+        let (signal, ctx) = fixture(persona_id);
+        let outcome = run_inline_admission_gate(&state, &signal, &ctx);
+        match outcome {
+            InlineAdmissionOutcome::Decided(label) => {
+                assert!(
+                    matches!(label, "admit" | "drop" | "quarantine"),
+                    "label must be one of the documented slugs, got: {label}",
+                );
+            }
+            other => panic!("expected Decided, got {other:?}"),
+        }
     }
 }
 

--- a/src/workers/continuum-core/src/persona/cognition_io.rs
+++ b/src/workers/continuum-core/src/persona/cognition_io.rs
@@ -37,6 +37,7 @@ use crate::cognition::RecentMessage;
 use crate::model_registry::Capability;
 use crate::persona::response::RespondInput;
 use crate::persona::turn_context::TurnContext;
+use crate::persona::types::{InboxMessage, Modality, SenderType};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 use uuid::Uuid;
@@ -265,6 +266,72 @@ pub fn build_respond_input(
     })
 }
 
+// ─── Signal → InboxMessage projection ────────────────────────────────
+//
+// The admission gate (`AdmissionState::admit`) consumes `InboxMessage`,
+// not `Signal`. To run admission inline on the chat hot path
+// (continuum#1211 — wire admission into `respond()`), the cognition/respond
+// IPC handler needs to project the inbound `Signal + PersonaContext`
+// into an `InboxMessage` BEFORE calling `respond()`.
+//
+// One canonical projection. Lives next to `build_respond_input` so the
+// two projections evolve together.
+//
+// **Sender mapping** is the only non-trivial part: `SignalOriginator` is
+// open-vocab (User | Persona | Tool | GameEngine | System) and
+// `SenderType` is closed (Human | Persona | Agent | System). The mapping:
+//
+//   User      → Human       (with user_id as sender_id)
+//   Persona   → Persona     (with persona_id as sender_id)
+//   Tool      → Agent       (Uuid::nil sender_id; `Tool` carries no id)
+//   GameEngine→ System      (Uuid::nil sender_id)
+//   System    → System      (Uuid::nil sender_id)
+//
+// **Modality**: derived from `ctx.is_voice` (true → Voice, false → Chat).
+// **Priority**: 0.5 default — the host doesn't carry per-message priority
+// in `Signal` today; admission's own scoring re-evaluates anyway.
+// **voice_session_id**: None (Signal doesn't carry one in v1).
+
+/// Project `(Signal, PersonaContext) → InboxMessage` so the admission
+/// gate can score the inbound event. The projection is total — every
+/// `SignalOriginator` variant maps to a `SenderType` (with `Uuid::nil()`
+/// for variants that don't carry an id).
+pub fn signal_to_inbox_message(signal: &Signal, ctx: &PersonaContext) -> InboxMessage {
+    let (sender_id, sender_name, sender_type) = match &signal.originator {
+        SignalOriginator::User { user_id } => {
+            (*user_id, String::new(), SenderType::Human)
+        }
+        SignalOriginator::Persona { persona_id } => {
+            // Best-effort name — the originator's display name isn't on
+            // Signal. Empty string is acceptable; admission scoring uses
+            // sender_type, not the name.
+            (*persona_id, String::new(), SenderType::Persona)
+        }
+        SignalOriginator::Tool { tool_name } => {
+            (Uuid::nil(), tool_name.clone(), SenderType::Agent)
+        }
+        SignalOriginator::GameEngine => {
+            (Uuid::nil(), "game-engine".to_string(), SenderType::System)
+        }
+        SignalOriginator::System => {
+            (Uuid::nil(), "system".to_string(), SenderType::System)
+        }
+    };
+
+    InboxMessage {
+        id: signal.message_id.unwrap_or_else(Uuid::new_v4),
+        room_id: ctx.room_id.unwrap_or(Uuid::nil()),
+        sender_id,
+        sender_name,
+        sender_type,
+        content: signal.text.clone(),
+        timestamp: signal.timestamp_ms,
+        priority: 0.5,
+        source_modality: Some(if ctx.is_voice { Modality::Voice } else { Modality::Chat }),
+        voice_session_id: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     //! Pure tests for the value objects and the projection. No I/O,
@@ -438,5 +505,100 @@ mod tests {
             vec!["code".to_string(), "general".to_string()],
         );
         assert!(input.turn_context.recent_history.is_empty());
+    }
+
+    // ─── signal_to_inbox_message ────────────────────────────────────
+
+    /// What this catches: a User-originated chat Signal projects to
+    /// SenderType::Human with the user_id preserved. Admission scoring
+    /// keys off sender_type for trust-mapping; if Human messages got
+    /// labeled as Agent, the trust threshold would silently downgrade.
+    #[test]
+    fn signal_to_inbox_user_origin_maps_to_human() {
+        let mut signal = chat_signal("hi");
+        let user_id = Uuid::new_v4();
+        signal.originator = SignalOriginator::User { user_id };
+        signal.timestamp_ms = 12345;
+        let mut ctx = empty_ctx();
+        ctx.room_id = Some(Uuid::new_v4());
+
+        let msg = signal_to_inbox_message(&signal, &ctx);
+        assert_eq!(msg.sender_id, user_id);
+        assert!(matches!(msg.sender_type, SenderType::Human));
+        assert_eq!(msg.content, "hi");
+        assert_eq!(msg.timestamp, 12345);
+        assert_eq!(msg.room_id, ctx.room_id.unwrap());
+    }
+
+    /// What this catches: Persona-originated signals correctly become
+    /// SenderType::Persona with the persona_id preserved. Without this,
+    /// AI-to-AI messages would route through the Human trust mapping
+    /// and admission's loop-prevention heuristics would silently misfire.
+    #[test]
+    fn signal_to_inbox_persona_origin_maps_to_persona() {
+        let mut signal = chat_signal("from another persona");
+        let persona_id = Uuid::new_v4();
+        signal.originator = SignalOriginator::Persona { persona_id };
+
+        let msg = signal_to_inbox_message(&signal, &empty_ctx());
+        assert_eq!(msg.sender_id, persona_id);
+        assert!(matches!(msg.sender_type, SenderType::Persona));
+    }
+
+    /// What this catches: Tool/GameEngine/System originators map
+    /// without panicking and use Uuid::nil() as a stable sender_id
+    /// (since these variants carry no id). The match is exhaustive —
+    /// adding a new SignalOriginator variant later WILL be caught at
+    /// compile time, not at runtime.
+    #[test]
+    fn signal_to_inbox_handles_all_originator_variants() {
+        let cases = [
+            (SignalOriginator::Tool { tool_name: "search".to_string() }, SenderType::Agent),
+            (SignalOriginator::GameEngine, SenderType::System),
+            (SignalOriginator::System, SenderType::System),
+        ];
+        for (origin, expected) in cases {
+            let mut signal = chat_signal("noop");
+            signal.originator = origin;
+            let msg = signal_to_inbox_message(&signal, &empty_ctx());
+            assert_eq!(msg.sender_id, Uuid::nil(), "non-id originators use nil");
+            assert!(
+                std::mem::discriminant(&msg.sender_type) == std::mem::discriminant(&expected),
+                "expected SenderType variant didn't match",
+            );
+        }
+    }
+
+    /// What this catches: voice context flows from PersonaContext
+    /// through to InboxMessage::source_modality. Admission policy may
+    /// score voice messages differently in future; preserving the
+    /// modality bit ensures it can.
+    #[test]
+    fn signal_to_inbox_modality_follows_is_voice() {
+        let mut ctx = empty_ctx();
+        ctx.is_voice = true;
+        let msg = signal_to_inbox_message(&chat_signal("hello"), &ctx);
+        assert!(matches!(msg.source_modality, Some(Modality::Voice)));
+
+        ctx.is_voice = false;
+        let msg = signal_to_inbox_message(&chat_signal("hello"), &ctx);
+        assert!(matches!(msg.source_modality, Some(Modality::Chat)));
+    }
+
+    /// What this catches: when Signal carries a message_id, the
+    /// projection preserves it (admission dedup keys off content_hash
+    /// but consumers may want to correlate the engram to the original
+    /// chat message). When absent, the projection generates a fresh
+    /// Uuid — never panics, never returns nil.
+    #[test]
+    fn signal_to_inbox_preserves_or_generates_id() {
+        let known_id = Uuid::new_v4();
+        let mut signal = chat_signal("known id");
+        signal.message_id = Some(known_id);
+        assert_eq!(signal_to_inbox_message(&signal, &empty_ctx()).id, known_id);
+
+        signal.message_id = None;
+        let generated = signal_to_inbox_message(&signal, &empty_ctx()).id;
+        assert_ne!(generated, Uuid::nil(), "fresh id, not nil");
     }
 }

--- a/src/workers/continuum-core/src/persona/engram.rs
+++ b/src/workers/continuum-core/src/persona/engram.rs
@@ -335,6 +335,24 @@ pub enum AdmissionDecision {
     },
 }
 
+impl AdmissionDecision {
+    /// Short funnel label for log lines + metrics. Lives next to the
+    /// enum so adding a new variant is a compile-fail at this match
+    /// rather than a silent fall-through (per claude-tab-2 review nit
+    /// on PR #1213 — keeping the label in lockstep with new variants).
+    ///
+    /// Returns one of `"admit" | "drop" | "quarantine"` — stable
+    /// string slugs suitable for grep on log lines and Prometheus
+    /// counter labels.
+    pub fn label(&self) -> &'static str {
+        match self {
+            AdmissionDecision::Admit { .. } => "admit",
+            AdmissionDecision::Drop { .. } => "drop",
+            AdmissionDecision::Quarantine { .. } => "quarantine",
+        }
+    }
+}
+
 /// Categorized reason for dropping a candidate without admitting.
 ///
 /// Distinct from `AdmissionError` (which is for failures of the admission


### PR DESCRIPTION
## Summary

Closes the engram-substrate loop. The admission/engram thread (#1121 PR-1..5) shipped end-to-end on canary — `AdmissionGate`, `IsMemorable` recipe, `AdmissionRunner`, per-persona `AdmissionState`, IPC handlers, recall surface — but `cognition/respond` (the hot path every chat turn calls via `cognitionPersonaRespond`) never invoked admission. \`grep -n 'admission' persona/response.rs\` returned 0 hits. So the substrate was plumbed but no chat turn ever reached the gate; personas accumulated zero memory.

This PR runs admission inline on the `cognition/respond` IPC handler so admission fires on every chat turn — matching Joel's \"if not UI/UX it is rust\" rule.

## Changes

1. **`persona::cognition_io::signal_to_inbox_message(signal, ctx)`** — canonical `(Signal, PersonaContext) → InboxMessage` projection. Sender mapping is total: User → Human, Persona → Persona, Tool → Agent, GameEngine / System → System. Modality follows `ctx.is_voice`. 5 new tests covering each variant + modality + id preservation.
2. **`cognition/respond` handler** — between `build_respond_input` and `respond()`, project the signal, look up the persona's `AdmissionState` (already on `ModuleState.personas`), call `state.admission.admit(...)`. Log the decision label + new engram_count.
3. **Forensic-not-destructive**: missing `AdmissionState` is logged + skipped (chat proceeds; no memory grow until `cognition/create-engine` is called for that persona). Typed `AdmissionError` (envelope verify failure, replay-detected) is logged and continues — a transient admission failure won't break chat.
4. **`admission_decision_label(&AdmissionDecision) -> &'static str`** helper for the funnel-grep log line.

## Out of scope (PR-2 follow-up)

- Surfacing recalled engrams to `prompt_assembly` (the recall side of the loop). Today admission grows the store; the persona's prompt doesn't yet include recalled context. PR-2 plumbs `recalled: Vec<Engram>` through `RespondInput` so admitted memory becomes part of the system / context section.

## Test plan

- [x] `cargo test --lib --features metal,accelerate cognition` — 139 passed, 0 failed
- [x] `cargo check --features metal,accelerate` clean (only pre-existing warnings)
- [x] Pre-push passed without `--no-verify`
- [ ] **Live smoke (post-merge)**: send memorable chat → after 2-3 turns, `./jtag cognition/recall-engrams --personaId=<helper-uuid>` returns non-empty (deferred — PR-1 enables admission; recall surface already callable via PR #1202).

Refs #1211. Refs #1121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)