### PR TITLE
fix(paths): remove personal machine assumptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ src/commands/**/*.d.ts
 
 # Runtime directories (session data, logs, temp files)
 .continuum/
+/src/.airc/
 .continuum-comm/
 .continuum-system/
 .continuum-safe-backup/

--- a/bin/continuum
+++ b/bin/continuum
@@ -26,6 +26,7 @@
 set -euo pipefail
 
 CONTINUUM_HOME="${CONTINUUM_HOME:-$HOME/.continuum}"
+CONTINUUM_SSH_USER="${CONTINUUM_SSH_USER:-$(whoami)}"
 COMPOSE_DIR=""
 
 # ── Colors ──────────────────────────────────────────────────
@@ -529,7 +530,7 @@ cmd_provision() {
   mkdir -p "$CONTINUUM_HOME"
   echo -e "  Pulling config from $from..."
   scp -o ConnectTimeout=5 -o StrictHostKeyChecking=no \
-    "joel@$from:~/.continuum/config.env" "$CONTINUUM_HOME/config.env" 2>/dev/null || {
+    "$CONTINUUM_SSH_USER@$from:~/.continuum/config.env" "$CONTINUUM_HOME/config.env" 2>/dev/null || {
     echo -e "${RED}❌ Failed to pull config${RESET}"
     exit 1
   }
@@ -548,14 +549,14 @@ cmd_transfer() {
   [ -z "$ip" ] && ip="$target"
 
   echo -e "  Step 1: Config..."
-  ssh -o StrictHostKeyChecking=no "${CONTINUUM_SSH_USER:-$(whoami)}@$ip" "mkdir -p ~/.continuum" 2>/dev/null
-  scp -o StrictHostKeyChecking=no "$CONTINUUM_HOME/config.env" "joel@$ip:~/.continuum/config.env" 2>/dev/null || {
+  ssh -o StrictHostKeyChecking=no "$CONTINUUM_SSH_USER@$ip" "mkdir -p ~/.continuum" 2>/dev/null
+  scp -o StrictHostKeyChecking=no "$CONTINUUM_HOME/config.env" "$CONTINUUM_SSH_USER@$ip:~/.continuum/config.env" 2>/dev/null || {
     echo -e "${RED}❌ Failed to copy config${RESET}"; exit 1
   }
   echo -e "  ${GREEN}✓${RESET} Config transferred"
 
   echo -e "  Step 2: Repo..."
-  ssh -o StrictHostKeyChecking=no "${CONTINUUM_SSH_USER:-$(whoami)}@$ip" "
+  ssh -o StrictHostKeyChecking=no "$CONTINUUM_SSH_USER@$ip" "
     if [ -d ~/continuum ]; then
       cd ~/continuum && git pull origin main
     else

--- a/docs/infrastructure/PATH-OWNERSHIP.md
+++ b/docs/infrastructure/PATH-OWNERSHIP.md
@@ -1,0 +1,42 @@
+# Path Ownership
+
+Continuum has multiple state roots because some data belongs to the repo, some to the current checkout, and some to the local user or machine. Code must make that ownership explicit. A path that depends on one developer's username, home directory, package manager, host layout, or SSH account is a bug.
+
+## Owned Roots
+
+| Root | Owner | Purpose | Commit Policy |
+| --- | --- | --- | --- |
+| `.airc/` | Repository | Project collaboration policy, onboarding, and queue documentation | Tracked only when the file is intentional project documentation |
+| `src/.airc/` | Local AIRC runtime | Scoped AIRC state created by commands, lanes, monitors, and tool integrations | Ignored; never commit runtime state or secrets |
+| `src/.continuum/` | Local Continuum runtime | App, test, generated, socket, session, and scratch state for this checkout | Ignored unless a generated artifact is deliberately promoted through the generator pipeline |
+| `$HOME/.continuum/` | Local user | User config, secrets, model caches, machine-local logs, large artifacts, and long-lived local state | Never commit; paths must be configurable and must not assume a username |
+| `$AIRC_HOME`, `~/.airc-*`, `.airc-worktrees/` | Local AIRC install/runtime | AIRC install, mesh state, and isolated worktrees | Never commit from Continuum |
+
+## Rules
+
+- Do not hardcode `/Users/joelteply`, `/home/joel`, `joel@`, Homebrew paths, or machine-specific mount points in executable code.
+- Use `SystemPaths` or a small domain-specific path helper for Continuum-owned state. Add a helper before adding another one-off `path.join(process.cwd(), '.continuum', ...)`.
+- Use `os.homedir()`, `process.env.HOME`, `PathBuf`, or an explicit environment/config value for user-owned state.
+- Use command lookup through `PATH` for tools such as `espeak-ng`; allow an override such as `ESPEAK_NG_BIN` when local installs need it.
+- Remote SSH commands must use `CONTINUUM_SSH_USER`, then safe local defaults such as `USER` or `LOGNAME`. They must not assume a developer account name.
+- Scripts that need large local artifacts should accept a path override and default under `$HOME/.continuum`, not a personal home path.
+- Generated TypeScript/Rust boundary files belong in the established generated output tree and should come from `ts-rs` or the generator, not handwritten parallel types.
+- Tests should write under ignored checkout-local temp/state roots or OS temp directories. Fixture emails and display names are fine; machine paths and real usernames are not.
+
+## Current Overrides
+
+| Variable | Meaning |
+| --- | --- |
+| `CONTINUUM_HOME` | Preferred future override for user-level Continuum state |
+| `CONTINUUM_ROOT` | Preferred future override for checkout-level Continuum state |
+| `CONTINUUM_SSH_USER` | SSH account for grid and remote model commands |
+| `CONTINUUM_COMPACTION_MODEL` | Local model path for compaction profiling |
+| `ESPEAK_NG_BIN` | `espeak-ng` executable path when it is not on `PATH` |
+
+## Review Checklist
+
+- New code has no personal absolute path, host-specific path, or hardcoded SSH user.
+- The root of every new path is visibly repo-owned, checkout-local, user-local, or OS temp.
+- The path can work on macOS, Linux, and Windows/WSL unless the feature is explicitly platform-gated.
+- Runtime output is ignored by Git.
+- If the same path construction appears twice, move it into `SystemPaths` or the relevant Rust path module before merging.

--- a/docs/infrastructure/README.md
+++ b/docs/infrastructure/README.md
@@ -110,6 +110,7 @@
 | [CONTINUUM-STATE-ARCHITECTURE](CONTINUUM-STATE-ARCHITECTURE.md) | Global system state management: initialization, lifecycle, shutdown |
 | [SYSTEM-CONFIG-ARCHITECTURE](SYSTEM-CONFIG-ARCHITECTURE.md) | Configuration system: sources, merging, validation, hot-reload |
 | [SYSTEM-DAEMON-ARCHITECTURE](SYSTEM-DAEMON-ARCHITECTURE.md) | System daemon design: the orchestrator that manages all other daemons |
+| [PATH-OWNERSHIP](PATH-OWNERSHIP.md) | Ownership contract for `.airc`, `.continuum`, user-local state, and machine-specific path bans |
 | [SYSTEM-PATHS-MIGRATION](SYSTEM-PATHS-MIGRATION.md) | Migration of hardcoded paths to centralized path constants |
 | [ARCHITECTURE_INCONSISTENCIES](ARCHITECTURE_INCONSISTENCIES.md) | Catalog of architectural inconsistencies found during audit |
 | [RUST-TS-INFERENCE-ARCHITECTURE](RUST-TS-INFERENCE-ARCHITECTURE.md) | Architecture for Rust-TypeScript inference boundary: type generation, IPC typing |

--- a/src/commands/grid/deploy/server/GridDeployServerCommand.ts
+++ b/src/commands/grid/deploy/server/GridDeployServerCommand.ts
@@ -4,7 +4,7 @@
  * Pull latest code and rebuild on grid nodes via SSH over Tailscale.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { CommandBase, type ICommandDaemon } from '@daemons/command-daemon/shared/CommandBase';
 import type { JTAGContext } from '@system/core/types/JTAGTypes';
 import type { GridDeployParams, GridDeployResult } from '../shared/GridDeployTypes';
@@ -19,6 +19,8 @@ interface NodeDeployResult {
   buildSuccess?: boolean;
   error?: string;
 }
+
+const shellQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`;
 
 export class GridDeployServerCommand extends CommandBase<GridDeployParams, GridDeployResult> {
 
@@ -75,9 +77,15 @@ export class GridDeployServerCommand extends CommandBase<GridDeployParams, GridD
     skipBuild?: boolean,
     restart?: boolean,
   ): Promise<NodeDeployResult> {
+    const sshUser = process.env.CONTINUUM_SSH_USER ?? process.env.USER ?? process.env.LOGNAME;
+    if (!sshUser) {
+      return { nodeId: ip, status: 'failed', error: 'CONTINUUM_SSH_USER or USER must be set' };
+    }
+
     const ssh = (cmd: string) =>
-      execSync(
-        `ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no joel@${ip} "${cmd.replace(/"/g, '\\"')}"`,
+      execFileSync(
+        'ssh',
+        ['-o', 'ConnectTimeout=10', '-o', 'StrictHostKeyChecking=no', `${sshUser}@${ip}`, cmd],
         { encoding: 'utf-8', timeout: 180_000 },
       ).trim();
 
@@ -89,18 +97,18 @@ export class GridDeployServerCommand extends CommandBase<GridDeployParams, GridD
       }
 
       // Git pull
-      let gitCmd = `cd ${repoDir} && git fetch origin`;
-      if (branch) gitCmd += ` && git checkout ${branch}`;
+      let gitCmd = `cd ${shellQuote(repoDir)} && git fetch origin`;
+      if (branch) gitCmd += ` && git checkout ${shellQuote(branch)}`;
       gitCmd += ' && git pull';
       ssh(gitCmd);
 
-      const currentBranch = ssh(`cd ${repoDir} && git branch --show-current`);
+      const currentBranch = ssh(`cd ${shellQuote(repoDir)} && git branch --show-current`);
 
       // Build
       let buildSuccess = true;
       if (!skipBuild) {
         try {
-          ssh(`cd ${repoDir}/src && npm run build:ts 2>&1 | tail -1`);
+          ssh(`cd ${shellQuote(`${repoDir}/src`)} && npm run build:ts 2>&1 | tail -1`);
         } catch {
           buildSuccess = false;
         }
@@ -109,7 +117,7 @@ export class GridDeployServerCommand extends CommandBase<GridDeployParams, GridD
       // Restart
       if (restart) {
         try {
-          ssh(`cd ${repoDir}/src && npm stop 2>/dev/null; nohup npm start > /dev/null 2>&1 &`);
+          ssh(`cd ${shellQuote(`${repoDir}/src`)} && npm stop 2>/dev/null; nohup npm start > /dev/null 2>&1 &`);
         } catch { /* backgrounded process — timeout expected */ }
       }
 

--- a/src/commands/model/download/server/ModelDownloadServerCommand.ts
+++ b/src/commands/model/download/server/ModelDownloadServerCommand.ts
@@ -5,12 +5,14 @@
  * for large models that need GPU VRAM. Uses huggingface_hub snapshot_download.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { CommandBase, type ICommandDaemon } from '@daemons/command-daemon/shared/CommandBase';
 import type { JTAGContext } from '@system/core/types/JTAGTypes';
 import { ValidationError } from '@system/core/types/ErrorTypes';
 import type { ModelDownloadParams, ModelDownloadResult } from '../shared/ModelDownloadTypes';
 import { createModelDownloadResultFromParams } from '../shared/ModelDownloadTypes';
+
+const pythonLiteral = (value: string | undefined): string => value === undefined ? 'None' : JSON.stringify(value);
 
 export class ModelDownloadServerCommand extends CommandBase<ModelDownloadParams, ModelDownloadResult> {
 
@@ -29,14 +31,18 @@ export class ModelDownloadServerCommand extends CommandBase<ModelDownloadParams,
 
     console.log(`📥 MODEL DOWNLOAD: ${modelId}${node ? ` → ${node}` : ' (local)'}`);
 
-    const revisionArg = revision ? `, revision="${revision}"` : '';
-    const pythonCmd = `python3 -c "
+    const revisionLiteral = pythonLiteral(revision);
+    const pythonScript = `
 from huggingface_hub import snapshot_download
 import json, os
-path = snapshot_download('${modelId}'${revisionArg})
+kwargs = {}
+revision = ${revisionLiteral}
+if revision is not None:
+    kwargs["revision"] = revision
+path = snapshot_download(${JSON.stringify(modelId)}, **kwargs)
 size = sum(os.path.getsize(os.path.join(dp, f)) for dp, _, fns in os.walk(path) for f in fns)
 print(json.dumps({'path': path, 'sizeGb': round(size / 1e9, 2)}))
-"`;
+`;
 
     try {
       let output: string;
@@ -44,14 +50,28 @@ print(json.dumps({'path': path, 'sizeGb': round(size / 1e9, 2)}))
       if (node) {
         // Download on remote node via SSH
         console.log(`   Downloading on remote node ${node}...`);
-        output = execSync(
-          `ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no joel@${node} "${pythonCmd.replace(/"/g, '\\"')}"`,
+        const sshUser = process.env.CONTINUUM_SSH_USER ?? process.env.USER ?? process.env.LOGNAME;
+        if (!sshUser) {
+          throw new Error('CONTINUUM_SSH_USER or USER must be set for remote model download');
+        }
+        output = execFileSync(
+          'ssh',
+          [
+            '-o',
+            'ConnectTimeout=10',
+            '-o',
+            'StrictHostKeyChecking=no',
+            `${sshUser}@${node}`,
+            'python3',
+            '-c',
+            pythonScript,
+          ],
           { encoding: 'utf-8', timeout: 3600_000 }, // 1 hour timeout for large models
         ).trim();
       } else {
         // Download locally
         console.log('   Downloading locally...');
-        output = execSync(pythonCmd, {
+        output = execFileSync('python3', ['-c', pythonScript], {
           encoding: 'utf-8',
           timeout: 3600_000,
         }).trim();

--- a/src/commands/model/introspect/server/ModelIntrospectServerCommand.ts
+++ b/src/commands/model/introspect/server/ModelIntrospectServerCommand.ts
@@ -12,12 +12,14 @@ import type { JTAGContext } from '@system/core/types/JTAGTypes';
 import { ValidationError } from '@system/core/types/ErrorTypes';
 import type { ModelIntrospectParams, ModelIntrospectResult } from '../shared/ModelIntrospectTypes';
 import { createModelIntrospectResultFromParams } from '../shared/ModelIntrospectTypes';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 
 /** Grid nodes discovered at runtime — no hardcoded IPs */
 const SENTINEL_NODES: Array<{ name: string; ip: string }> = [];
+
+const shellQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`;
 
 export class ModelIntrospectServerCommand extends CommandBase<ModelIntrospectParams, ModelIntrospectResult> {
 
@@ -78,9 +80,10 @@ export class ModelIntrospectServerCommand extends CommandBase<ModelIntrospectPar
       if (!fs.existsSync(script)) continue;
 
       try {
-        const output = execSync(
-          `cd ${sentinelPath} && python3 scripts/stages/introspect.py "${model}"`,
-          { timeout: 15000, encoding: 'utf-8' }
+        const output = execFileSync(
+          'python3',
+          ['scripts/stages/introspect.py', model],
+          { cwd: sentinelPath, timeout: 15000, encoding: 'utf-8' }
         );
         return JSON.parse(output.trim());
       } catch {
@@ -92,9 +95,22 @@ export class ModelIntrospectServerCommand extends CommandBase<ModelIntrospectPar
 
   private tryRemoteIntrospect(model: string, ip: string): any {
     const home = process.env.HOME ?? '';
+    const sshUser = process.env.CONTINUUM_SSH_USER ?? process.env.USER ?? process.env.LOGNAME;
+    if (!sshUser) return null;
+
     try {
-      const output = execSync(
-        `ssh -i ${home}/.ssh/id_ed25519 -o ConnectTimeout=3 -o StrictHostKeyChecking=no joel@${ip} "cd ~/sentinel-ai && python3 scripts/stages/introspect.py '${model}'" 2>/dev/null`,
+      const output = execFileSync(
+        'ssh',
+        [
+          '-i',
+          path.join(home, '.ssh', 'id_ed25519'),
+          '-o',
+          'ConnectTimeout=3',
+          '-o',
+          'StrictHostKeyChecking=no',
+          `${sshUser}@${ip}`,
+          `cd ~/sentinel-ai && python3 scripts/stages/introspect.py ${shellQuote(model)}`,
+        ],
         { timeout: 15000, encoding: 'utf-8' }
       );
       return JSON.parse(output.trim());

--- a/src/scripts/compaction/runtime_profile.py
+++ b/src/scripts/compaction/runtime_profile.py
@@ -6,7 +6,10 @@ import sys
 from collections import defaultdict
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-MODEL = "/home/joel/.continuum/models/qwen3.5-35b-a3b-opus"
+MODEL = os.environ.get(
+    "CONTINUUM_COMPACTION_MODEL",
+    os.path.expanduser("~/.continuum/models/qwen3.5-35b-a3b-opus"),
+)
 
 PROMPTS = [
     "Write a TypeScript function that implements a rate limiter using the token bucket algorithm.",

--- a/src/scripts/compaction/runtime_profile_v2.py
+++ b/src/scripts/compaction/runtime_profile_v2.py
@@ -2,10 +2,14 @@
 import torch
 import json
 import time
+import os
 from collections import defaultdict
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-MODEL = "/home/joel/.continuum/models/qwen3.5-35b-a3b-opus"
+MODEL = os.environ.get(
+    "CONTINUUM_COMPACTION_MODEL",
+    os.path.expanduser("~/.continuum/models/qwen3.5-35b-a3b-opus"),
+)
 
 PROMPTS = [
     "Write a TypeScript function that implements a rate limiter.",

--- a/src/workers/continuum-core/src/live/audio/tts/kokoro.rs
+++ b/src/workers/continuum-core/src/live/audio/tts/kokoro.rs
@@ -15,8 +15,8 @@ use crate::live::audio::reloadable::ReloadableModel;
 use crate::{clog_info, clog_warn};
 use async_trait::async_trait;
 use ndarray;
-use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
+use ort::session::builder::GraphOptimizationLevel;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -241,7 +241,9 @@ impl KokoroTTS {
 
     /// Call espeak-ng to phonemize text (same as Piper, but returns raw IPA string)
     fn phonemize(text: &str) -> Result<String, TTSError> {
-        let output = Command::new("/opt/homebrew/bin/espeak-ng")
+        let espeak_ng_bin =
+            std::env::var("ESPEAK_NG_BIN").unwrap_or_else(|_| "espeak-ng".to_string());
+        let output = Command::new(espeak_ng_bin)
             .args(["-v", "en-us", "-q", "--ipa=3"])
             .arg(text)
             .output()
@@ -470,7 +472,9 @@ impl TextToSpeech for KokoroTTS {
         // adds the right EP for the current build (CoreML on Mac,
         // CUDA on Linux+Nvidia) and hard-fails when neither is available.
         let providers = crate::inference::ort_providers::build_ort_gpu_execution_providers()
-            .map_err(|e| TTSError::ModelNotLoaded(format!("ORT GPU EP setup failed (Kokoro TTS): {e}")))?;
+            .map_err(|e| {
+                TTSError::ModelNotLoaded(format!("ORT GPU EP setup failed (Kokoro TTS): {e}"))
+            })?;
         let session = Session::builder()?
             .with_execution_providers(providers)?
             .with_optimization_level(GraphOptimizationLevel::Level3)?

--- a/src/workers/continuum-core/src/live/audio/tts/phonemizer.rs
+++ b/src/workers/continuum-core/src/live/audio/tts/phonemizer.rs
@@ -5,6 +5,10 @@ use crate::{clog_error, clog_warn};
 use std::collections::HashMap;
 use std::process::Command;
 
+fn espeak_ng_bin() -> String {
+    std::env::var("ESPEAK_NG_BIN").unwrap_or_else(|_| "espeak-ng".to_string())
+}
+
 pub struct Phonemizer {
     phoneme_to_id: HashMap<String, i64>,
 }
@@ -39,7 +43,7 @@ impl Phonemizer {
 
     /// Call espeak-ng to phonemize text
     fn call_espeak(&self, text: &str) -> Result<String, String> {
-        let output = Command::new("/opt/homebrew/bin/espeak-ng")
+        let output = Command::new(espeak_ng_bin())
             .args(["-v", "en-us", "-q", "--ipa=3"])
             .arg(text)
             .output()


### PR DESCRIPTION
## Summary
- remove hardcoded joel SSH users from grid deploy, model download, model introspect, and bin/continuum paths
- replace shell-string command execution with execFileSync argument vectors where user/model input was interpolated
- make compaction model and espeak-ng paths configurable, and ignore src/.airc runtime state
- document .airc/.continuum//Users/joelteply path ownership rules in docs/infrastructure/PATH-OWNERSHIP.md

## Validation
- npm run build:ts
- cargo test --package continuum-core live::audio::tts --features metal,accelerate
- precommit hook: TypeScript build, ESLint baseline, Rust clippy baseline, browser ping
- git diff --check
- hardcoding scan for /Users/joelteply, /home/joel, joel@, /opt/homebrew/bin/espeak-ng (only fixture emails remain)

Refs #1212