### PR TITLE
perf(persona,#1218): build_messages_single_user_turn allocations 3+N -> 1 (write! into pre-sized buffer)

### DIFF
--- a/src/workers/continuum-core/src/persona/prompt_assembly.rs
+++ b/src/workers/continuum-core/src/persona/prompt_assembly.rs
@@ -238,33 +238,51 @@ fn build_messages_single_user_turn(
     current: &HistoryMessage,
     persona_name: &str,
 ) -> Vec<PromptMessage> {
-    let mut transcript = String::new();
+    // Pre-size the transcript buffer (#1218a — alloc discipline). Each
+    // history line is roughly len(name) + len(content) + 4 bytes;
+    // overhead covers the "Recent conversation:\n" header + the closing
+    // cue. write! into the buffer instead of `push_str(&format!(...))`
+    // so the format intermediate doesn't allocate a throw-away String.
+    let header_overhead: usize = 96;
+    let history_capacity: usize = history
+        .iter()
+        .map(|m| m.name.as_ref().map_or(0, |n| n.len() + 2) + m.content.len() + 1)
+        .sum();
+    let current_capacity = current.name.as_ref().map_or(20, |n| n.len() + 22)
+        + current.content.len();
+    let closing_cue_capacity = persona_name.len() + 128;
+    let mut transcript = String::with_capacity(
+        header_overhead + history_capacity + current_capacity + closing_cue_capacity,
+    );
+
     if !history.is_empty() {
         transcript.push_str("Recent conversation:\n");
         for msg in history {
-            let line = if let Some(ref name) = msg.name {
-                format!("{}: {}\n", name, msg.content)
+            if let Some(ref name) = msg.name {
+                let _ = writeln!(transcript, "{}: {}", name, msg.content);
             } else {
-                format!("{}\n", msg.content)
-            };
-            transcript.push_str(&line);
+                let _ = writeln!(transcript, "{}", msg.content);
+            }
         }
         transcript.push('\n');
     }
     if let Some(ref name) = current.name {
-        transcript.push_str(&format!("New message from {name}:\n{}\n", current.content));
+        let _ = writeln!(transcript, "New message from {name}:");
     } else {
-        transcript.push_str(&format!("New message:\n{}\n", current.content));
+        transcript.push_str("New message:\n");
     }
+    transcript.push_str(&current.content);
+    transcript.push('\n');
     // Closing cue. Same intent as the analyzer's "Respond with ONLY ..."
     // — without this the render model has no clear signal that it should
     // produce content for THIS turn (vs. summarizing a passive log).
     // Lives inside the same user turn so chat-template structure stays
     // single-system + single-user → assistant.
-    transcript.push_str(&format!(
+    let _ = write!(
+        transcript,
         "\nRespond now as {persona_name}. Reply directly to the new message above — \
          no name prefix, no quoting, just your contribution.\n"
-    ));
+    );
     vec![PromptMessage {
         role: "user".to_string(),
         content: transcript,


### PR DESCRIPTION
## Summary

Refs #1218 (hot-path format!() audit). Same allocation-discipline pattern as #1209 just merged but in build_messages_single_user_turn.

## Sites converted

`build_messages_single_user_turn` was the third hot-path String builder in the cognition+persona path that did `push_str(&format!())` in a loop. Now writes directly into a pre-sized buffer:

- **History loop**: `format!() + let line + push_str(&line)` → `writeln!(transcript, ...)` (per-line throw-away String eliminated)
- **Current message**: `push_str(&format!())` → `writeln!(...)` + raw push_str of content
- **Closing cue**: `push_str(&format!())` → `write!(...)`
- **Buffer**: `String::new()` → `String::with_capacity(estimated)` covering header + per-line overhead + closing cue

## Allocations per call

- **Before**: 1 (transcript) + N (per-history format!) + 1 (current format!) + 1 (closing format!) = 3+N per call
- **After**: 1 (transcript with capacity, ideally fits) per call
- N=5 history → **8 → 1 allocation per call**

## Tests

- All 8 persona::prompt_assembly tests pass byte-identical (test_social_signals + test_voice_mode + test_basic_assembly + test_time_gap_markers + proper_chatml_*)
- Clippy stays at baseline 162

## Pattern consolidation note (per sibling's 18:36 coordination)

This is the **third** application of `String::with_capacity(estimate) + write!(...)` to a hot-path builder this session (after #1209 build_prompt + assemble). The pattern is now well-proven and the remaining audit sites in #1218 are pure mechanical application — anyone can pick them up.

Considered extracting into a `PromptBuilder` helper but the 3 use cases have different estimate strategies (history-bounded, signal-conditional, transcript-style) — premature abstraction risk outweighs the LOC savings. Direct application to the remaining sites is the cleaner move.

Refs umbrella #1201 / #1203, refs #1218.