### PR TITLE
refactor(paths): centralize server process PATH policy

### DIFF
--- a/src/system/code/server/ExecutionSandbox.ts
+++ b/src/system/code/server/ExecutionSandbox.ts
@@ -15,6 +15,7 @@
 import { spawn, type ChildProcess } from 'child_process';
 import * as path from 'path';
 import { Logger } from '../../core/logging/Logger';
+import { sandboxPath } from '../../server/process/ProcessPathPolicy';
 import type { UUID } from '../../core/types/CrossPlatformUUID';
 
 const log = Logger.create('ExecutionSandbox', 'code');
@@ -68,14 +69,6 @@ const KILL_GRACE_PERIOD_MS = 5_000;
 /** Restricted set of allowed commands */
 const ALLOWED_COMMANDS = new Set(['node', 'npx', 'tsc', 'npm']);
 
-/** Restricted PATH — only common binary locations (includes Homebrew for macOS) */
-const RESTRICTED_PATH = [
-  '/opt/homebrew/bin',   // macOS Apple Silicon Homebrew
-  '/usr/local/bin',      // macOS Intel Homebrew / standard
-  '/usr/bin',
-  '/bin',
-].join(path.delimiter);
-
 // ────────────────────────────────────────────────────────────
 // Sandbox
 // ────────────────────────────────────────────────────────────
@@ -119,7 +112,7 @@ export class ExecutionSandbox {
         child = spawn(config.command, [...config.args], {
           cwd: config.cwd,
           env: {
-            PATH: RESTRICTED_PATH,
+            PATH: sandboxPath(),
             NODE_ENV: 'sandbox',
             HOME: config.cwd,
             SANDBOX_EXECUTION: 'true',

--- a/src/system/sentinel/coding-agents/ClaudeCodeProvider.ts
+++ b/src/system/sentinel/coding-agents/ClaudeCodeProvider.ts
@@ -8,8 +8,8 @@
  * isAvailable() returns false and the system degrades gracefully.
  */
 
-import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { ensureDaemonPath } from '@system/server/process/ProcessPathPolicy';
 import type {
   CodingAgentConfig,
   CodingAgentInteraction,
@@ -70,7 +70,7 @@ export class ClaudeCodeProvider implements CodingAgentProvider {
     // CRITICAL: Must set process.env.PATH directly because the SDK uses the PARENT
     // process's PATH to locate the node binary BEFORE spawning the child process.
     // The env option only controls the child's environment, not the SDK's lookup.
-    const ensuredPath = this.ensurePath(process.env.PATH || '');
+    const ensuredPath = ensureDaemonPath(process.env.PATH || '');
     process.env.PATH = ensuredPath;
 
     // Build SDK options
@@ -321,33 +321,5 @@ export class ClaudeCodeProvider implements CodingAgentProvider {
       case 'dontAsk': return 'dontAsk';
       default: return 'default';
     }
-  }
-
-  /**
-   * Ensure PATH includes standard binary locations.
-   * When the server runs as a nohup daemon, PATH can be minimal.
-   * The SDK spawns `node` as a child process and needs to find it.
-   *
-   * CRITICAL: process.execPath resolves symlinks, so /opt/homebrew/bin/node
-   * becomes /opt/homebrew/Cellar/node/25.2.1/bin/node — a directory NOT in
-   * the standard PATH dirs. We must include the resolved directory explicitly.
-   */
-  private ensurePath(currentPath: string): string {
-    const nodeDir = path.dirname(process.execPath);
-    const requiredDirs = [
-      nodeDir,                   // Resolved node binary directory (MUST be first)
-      '/opt/homebrew/bin',       // macOS ARM homebrew
-      '/usr/local/bin',          // macOS Intel homebrew / standard
-      '/usr/bin',                // System binaries
-      `${process.env.HOME}/.local/bin`, // User-local (claude CLI)
-      `${process.env.HOME}/.nvm/current/bin`, // nvm users
-    ];
-    const pathDirs = new Set(currentPath.split(':'));
-    for (const dir of requiredDirs) {
-      if (dir && !pathDirs.has(dir)) {
-        pathDirs.add(dir);
-      }
-    }
-    return Array.from(pathDirs).join(':');
   }
 }

--- a/src/system/sentinel/coding-agents/LocalClaudeCodeProvider.ts
+++ b/src/system/sentinel/coding-agents/LocalClaudeCodeProvider.ts
@@ -20,8 +20,8 @@
  *   → TrainingDataAccumulator → academy pipeline → improved LoRA → better coding
  */
 
-import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { ensureDaemonPath } from '@system/server/process/ProcessPathPolicy';
 import type {
   CodingAgentConfig,
   CodingAgentInteraction,
@@ -133,7 +133,7 @@ export class LocalClaudeCodeProvider implements CodingAgentProvider {
     const permissionMode: PermissionMode = permissionModeMap[config.permissionMode || ''] || 'default';
 
     // ─── Ensure PATH includes standard locations ─────────────────────
-    const ensuredPath = ensurePath(process.env.PATH || '');
+    const ensuredPath = ensureDaemonPath(process.env.PATH || '');
     process.env.PATH = ensuredPath;
 
     // ─── Build SDK options ───────────────────────────────────────────
@@ -348,26 +348,4 @@ export class LocalClaudeCodeProvider implements CodingAgentProvider {
       error: errorMessage,
     };
   }
-}
-
-/**
- * Ensure PATH includes standard binary locations for daemon contexts.
- */
-function ensurePath(currentPath: string): string {
-  const nodeDir = path.dirname(process.execPath);
-  const requiredDirs = [
-    nodeDir,
-    '/opt/homebrew/bin',
-    '/usr/local/bin',
-    '/usr/bin',
-    `${process.env.HOME}/.local/bin`,
-    `${process.env.HOME}/.nvm/current/bin`,
-  ];
-  const pathDirs = new Set(currentPath.split(':'));
-  for (const dir of requiredDirs) {
-    if (dir && !pathDirs.has(dir)) {
-      pathDirs.add(dir);
-    }
-  }
-  return Array.from(pathDirs).join(':');
 }

--- a/src/system/server/process/ProcessPathPolicy.ts
+++ b/src/system/server/process/ProcessPathPolicy.ts
@@ -1,0 +1,31 @@
+import * as path from 'path';
+
+const SYSTEM_BIN_DIRS = Object.freeze([
+  '/opt/homebrew/bin',
+  '/usr/local/bin',
+  '/usr/bin',
+  '/bin',
+]);
+
+export function sandboxPath(): string {
+  return SYSTEM_BIN_DIRS.join(path.delimiter);
+}
+
+export function sandboxPathDirs(): readonly string[] {
+  return SYSTEM_BIN_DIRS;
+}
+
+export function ensureDaemonPath(currentPath: string, homeDir = process.env.HOME): string {
+  const requiredDirs = [
+    path.dirname(process.execPath),
+    ...SYSTEM_BIN_DIRS,
+    homeDir ? path.join(homeDir, '.local', 'bin') : undefined,
+    homeDir ? path.join(homeDir, '.nvm', 'current', 'bin') : undefined,
+  ].filter((dir): dir is string => Boolean(dir));
+
+  const pathDirs = new Set(currentPath.split(path.delimiter).filter(Boolean));
+  for (const dir of requiredDirs) {
+    pathDirs.add(dir);
+  }
+  return Array.from(pathDirs).join(path.delimiter);
+}

--- a/src/tests/unit/code/ExecutionSandbox.test.ts
+++ b/src/tests/unit/code/ExecutionSandbox.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ExecutionSandbox, type SandboxConfig, type SandboxResult } from '../../../system/code/server/ExecutionSandbox';
+import { sandboxPathDirs } from '../../../system/server/process/ProcessPathPolicy';
 import type { UUID } from '../../../system/core/types/CrossPlatformUUID';
 
 // Mock Logger
@@ -227,7 +228,7 @@ describe('ExecutionSandbox', () => {
 
       // PATH should only contain restricted locations
       const pathDirs = result.stdout.trim().split(':');
-      const allowedDirs = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin'];
+      const allowedDirs = sandboxPathDirs();
       for (const dir of pathDirs) {
         expect(allowedDirs).toContain(dir);
       }


### PR DESCRIPTION
## Summary
- adds a server-only ProcessPathPolicy for daemon PATH and sandbox PATH construction
- removes duplicated PATH assembly from both Claude providers
- keeps Node process policy out of core/shared/browser-facing modules
- updates sandbox tests to assert against the shared server policy instead of a copied list

## Validation
- npx vitest run tests/unit/code/ExecutionSandbox.test.ts
- npm run build:ts
- git diff --check
- precommit hook: TypeScript compile + ESLint baseline ratchet passed
- pre-push hook: TypeScript clean + ESLint baseline ratchet passed

Refs #1212.