### PR TITLE
perf(cognition): make CognitionTrace optional on admit() — drop hot-path allocs

### DIFF
--- a/src/workers/continuum-core/src/modules/cognition.rs
+++ b/src/workers/continuum-core/src/modules/cognition.rs
@@ -317,8 +317,14 @@ impl ServiceModule for CognitionModule {
                     .get(&persona_uuid)
                     .ok_or_else(|| format!("No cognition for {persona_uuid}"))?;
 
+                // The TS-IPC `cognition/admit-inbox-message` caller wants
+                // the trace seam-count back in the response (it surfaces
+                // funnel telemetry to the TS observer), so this site DOES
+                // build a trace and passes Some. The in-process inline
+                // gate (`run_inline_admission_gate` below) passes None
+                // because it doesn't propagate the trace anywhere.
                 let mut trace = crate::persona::trace::CognitionTrace::new();
-                match persona.admission.admit(&inbox_msg, &mut trace) {
+                match persona.admission.admit(&inbox_msg, Some(&mut trace)) {
                     Ok(decision) => Ok(CommandResult::Json(serde_json::json!({
                         "decision": decision,
                         "engram_count": persona.admission.engram_count(),
@@ -1434,8 +1440,17 @@ pub(crate) fn run_inline_admission_gate(
         return InlineAdmissionOutcome::NoPersona;
     };
 
-    let mut admission_trace = crate::persona::trace::CognitionTrace::new();
-    match persona.admission.admit(&inbox_msg, &mut admission_trace) {
+    // Pass `None` for the trace — the inline gate doesn't propagate
+    // it anywhere (the cognition/respond IPC handler doesn't surface
+    // an admission trace seam to its caller; the recorder doesn't
+    // capture admission seams as part of the per-turn fixture). With
+    // `None`, the admission codepath skips `record_seam` entirely:
+    // no `now_ms()` syscall, no `serde_json::json!` Map allocation,
+    // no String allocations for seam name/metadata. Cuts ~7
+    // allocations per chat turn per persona. The TS-IPC
+    // `cognition/admit-inbox-message` handler still passes `Some` —
+    // it surfaces the seam count in the response.
+    match persona.admission.admit(&inbox_msg, None) {
         Ok(decision) => {
             let label = decision.label();
             // Skip Admit — common case, no allocation. Drop +

--- a/src/workers/continuum-core/src/persona/admission.rs
+++ b/src/workers/continuum-core/src/persona/admission.rs
@@ -270,13 +270,26 @@ impl AdmissionGate {
         candidate: &AdmissionCandidate,
         recipe: &R,
         ctx: &AdmissionContext<'_>,
-        trace: &mut CognitionTrace,
+        trace: Option<&mut CognitionTrace>,
     ) -> Result<AdmissionDecision, AdmissionError> {
+        // Wrap the optional trace in a reference cell so the per-step
+        // `record_seam` call sites stay uniform (one borrow API regardless
+        // of whether the caller wanted a trace). When None, all
+        // record-side work is skipped — no `now_ms()`, no `serde_json::json!`
+        // Map allocation, no String allocations for seam name/metadata.
+        // continuum#1213 follow-up: cuts ~7 allocations per chat turn per
+        // persona on the admission hot path. Trace-using callers (TS-IPC
+        // `cognition/admit-inbox-message` + the unit tests + the future
+        // recorder integration) keep their existing per-seam visibility
+        // by passing `Some(&mut trace)`; the in-process inline gate added
+        // by #1213 passes `None` because it doesn't propagate the trace
+        // anywhere.
+        let mut trace = trace;
         let started = now_ms();
 
         // Step 1: Envelope structure
         if let Err(err) = verify_envelope(&candidate.origin) {
-            record_seam(trace, recipe.id(), started, "EnvelopeVerificationFailed", None);
+            record_seam(trace.as_deref_mut(), recipe.id(), started, "EnvelopeVerificationFailed", None);
             return Err(err);
         }
 
@@ -286,7 +299,7 @@ impl AdmissionGate {
                 source_trust: candidate.trust_state,
                 threshold: ctx.config.trust_threshold,
             };
-            record_seam(trace, recipe.id(), started, "TrustBoundaryRejected", None);
+            record_seam(trace.as_deref_mut(), recipe.id(), started, "TrustBoundaryRejected", None);
             return Err(err);
         }
 
@@ -297,7 +310,7 @@ impl AdmissionGate {
                     event_id,
                     previously_seen_at_ms: prev_ms,
                 };
-                record_seam(trace, recipe.id(), started, "ReplayDetected", None);
+                record_seam(trace.as_deref_mut(), recipe.id(), started, "ReplayDetected", None);
                 return Err(err);
             }
         }
@@ -306,10 +319,15 @@ impl AdmissionGate {
         match recipe.evaluate(candidate, ctx) {
             Ok(decision) => {
                 let label = decision_label(&decision);
+                // Last use of `trace` in this branch — pass by move
+                // rather than `as_deref_mut()` (clippy
+                // `needless_option_as_deref` would fire on a final
+                // reborrow when the next line is just `Ok(...)`).
                 record_seam(trace, recipe.id(), started, "accepted", Some(label));
                 Ok(decision)
             }
             Err(err) => {
+                // Last use of `trace` in this branch — same as above.
                 record_seam(trace, recipe.id(), started, "RecipeError", None);
                 Err(err)
             }
@@ -516,14 +534,23 @@ fn wire_event_id(origin: &EngramOrigin) -> Option<String> {
     }
 }
 
-/// Append a `SEAM_ADMISSION` entry to the trace.
+/// Append a `SEAM_ADMISSION` entry to the trace, when one is supplied.
+///
+/// When `trace` is `None` (the in-process hot-path admission gate added
+/// by continuum#1213, which doesn't propagate the trace), this function
+/// is a complete no-op — no `now_ms()` syscall, no `serde_json::json!`
+/// Map allocation, no String allocations. Cuts ~7 allocations per chat
+/// turn per persona on the admission hot path.
 fn record_seam(
-    trace: &mut CognitionTrace,
+    trace: Option<&mut CognitionTrace>,
     recipe_id: &str,
     started_ms: u64,
     structural: &str,
     decision: Option<&'static str>,
 ) {
+    let Some(trace) = trace else {
+        return;
+    };
     let duration_ms = now_ms().saturating_sub(started_ms);
     let metadata = match decision {
         Some(label) => serde_json::json!({
@@ -648,7 +675,7 @@ mod tests {
             EngramOrigin::Airc(airc_ref("msg-1", "", "hash", "v1")),
         );
 
-        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace);
+        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace));
         match result {
             Err(AdmissionError::EnvelopeVerificationFailed { detail }) => {
                 assert!(detail.contains("signature"), "detail: {detail}");
@@ -680,7 +707,7 @@ mod tests {
             EngramOrigin::Airc(airc_ref("msg-x", "sig", "", "v1")),
         );
 
-        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace) {
+        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace)) {
             Err(AdmissionError::EnvelopeVerificationFailed { detail }) => {
                 assert!(detail.contains("content_hash"), "detail: {detail}");
             }
@@ -708,7 +735,7 @@ mod tests {
             EngramOrigin::Airc(airc_ref("msg-x", "sig", "hash", "")),
         );
 
-        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace) {
+        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace)) {
             Err(AdmissionError::EnvelopeVerificationFailed { detail }) => {
                 assert!(detail.contains("schema_version"), "detail: {detail}");
             }
@@ -735,7 +762,7 @@ mod tests {
             EngramOrigin::Airc(airc_ref("msg-x", "sig", "hash", "v2")),
         );
 
-        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace);
+        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace));
         match result {
             Err(AdmissionError::UnsupportedSchemaVersion { schema_version }) => {
                 assert_eq!(schema_version, "v2");
@@ -771,7 +798,7 @@ mod tests {
             },
         );
 
-        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace)
+        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace))
             .expect("self-reflection should pass structural checks");
         match result {
             AdmissionDecision::Admit { engram, .. } => {
@@ -804,7 +831,7 @@ mod tests {
         // ApprovedPeer is below IntragridMember (strict_v1's threshold).
         let cand = airc_candidate("totally legitimate content here", TrustState::ApprovedPeer, "msg-2");
 
-        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace);
+        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace));
         match result {
             Err(AdmissionError::TrustBoundaryRejected {
                 source_trust,
@@ -834,7 +861,7 @@ mod tests {
             "msg-3",
         );
 
-        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace)
+        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace))
             .expect("equal-tier source should pass threshold");
         assert!(matches!(result, AdmissionDecision::Admit { .. }));
     }
@@ -856,7 +883,7 @@ mod tests {
 
         let cand = airc_candidate("perfectly novel content here", TrustState::ApprovedPeer, "msg-replay");
 
-        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace);
+        let result = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace));
         match result {
             Err(AdmissionError::ReplayDetected {
                 event_id,
@@ -893,7 +920,7 @@ mod tests {
             },
         );
 
-        AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace)
+        AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace))
             .expect("non-airc origin should bypass replay check");
     }
 
@@ -913,7 +940,7 @@ mod tests {
 
         let cand = airc_candidate("short", TrustState::ApprovedPeer, "msg-short");
 
-        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace).unwrap() {
+        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace)).unwrap() {
             AdmissionDecision::Drop {
                 reason: AdmissionDropReason::NotMemorable { explanation },
             } => {
@@ -943,7 +970,7 @@ mod tests {
         let padded = "                ACK                ";
         let cand = airc_candidate(padded, TrustState::ApprovedPeer, "msg-noise");
 
-        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace).unwrap() {
+        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace)).unwrap() {
             AdmissionDecision::Drop {
                 reason: AdmissionDropReason::NotMemorable { explanation },
             } => {
@@ -976,7 +1003,7 @@ mod tests {
         let cand = airc_candidate("twenty-nine character content", TrustState::ApprovedPeer, "msg-d");
         assert_eq!(cand.content_hash, "sha256:fake-29");
 
-        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace).unwrap() {
+        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace)).unwrap() {
             AdmissionDecision::Drop {
                 reason: AdmissionDropReason::Duplicate { existing_engram_id },
             } => {
@@ -1004,7 +1031,7 @@ mod tests {
             "msg-admit-1",
         );
 
-        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace).unwrap() {
+        match AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace)).unwrap() {
             AdmissionDecision::Admit { engram, why } => {
                 assert_eq!(engram.kind, EngramKind::Episodic);
                 assert_eq!(engram.trust_state_at_admission, TrustState::IntragridMember);
@@ -1037,7 +1064,7 @@ mod tests {
                 TrustState::ApprovedPeer,
                 EngramOrigin::Airc(airc_ref("e1", "", "h", "v1")),
             );
-            let _ = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace);
+            let _ = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace));
         }
         assert_eq!(trace.seam_count(), 1);
 
@@ -1051,7 +1078,7 @@ mod tests {
                 TrustState::ApprovedPeer,
                 "e2",
             );
-            let _ = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace);
+            let _ = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace));
         }
         assert_eq!(trace.seam_count(), 2);
 
@@ -1061,7 +1088,7 @@ mod tests {
             let events = InMemoryEvents::default();
             let ctx = permissive_ctx(&cfg, &content, &events);
             let cand = airc_candidate("short", TrustState::ApprovedPeer, "e3");
-            let _ = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace);
+            let _ = AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace));
         }
         assert_eq!(trace.seam_count(), 3);
 
@@ -1089,7 +1116,7 @@ mod tests {
             "msg-trace-1",
         );
 
-        AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, &mut trace).unwrap();
+        AdmissionGate::admit(&cand, &HeuristicIsMemorable::default_v1(), &ctx, Some(&mut trace)).unwrap();
         let seam = &trace.seams[0];
         assert_eq!(seam.metadata["recipe"], serde_json::json!("heuristic.v1"));
         assert_eq!(seam.metadata["structural"], serde_json::json!("accepted"));
@@ -1133,7 +1160,7 @@ mod tests {
             "msg-fail",
         );
 
-        let result = AdmissionGate::admit(&cand, &FailingRecipe, &ctx, &mut trace);
+        let result = AdmissionGate::admit(&cand, &FailingRecipe, &ctx, Some(&mut trace));
         match result {
             Err(AdmissionError::RecipeFailure { recipe_id, detail }) => {
                 assert_eq!(recipe_id, "test.failing");
@@ -1179,7 +1206,7 @@ mod tests {
             "msg-quar",
         );
 
-        match AdmissionGate::admit(&cand, &QuarantineRecipe, &ctx, &mut trace).unwrap() {
+        match AdmissionGate::admit(&cand, &QuarantineRecipe, &ctx, Some(&mut trace)).unwrap() {
             AdmissionDecision::Quarantine {
                 engram, expiry_ms, ..
             } => {

--- a/src/workers/continuum-core/src/persona/admission_state.rs
+++ b/src/workers/continuum-core/src/persona/admission_state.rs
@@ -131,7 +131,7 @@ impl AdmissionState {
     pub fn admit(
         &self,
         message: &InboxMessage,
-        trace: &mut CognitionTrace,
+        trace: Option<&mut CognitionTrace>,
     ) -> Result<AdmissionDecision, AdmissionError> {
         let decision = self.runner.admit(
             message,
@@ -383,7 +383,7 @@ mod tests {
         let content = "this is a non-trivial design observation worth storing";
         let msg = synthetic_human_message(content);
 
-        let first = state.admit(&msg, &mut trace).unwrap();
+        let first = state.admit(&msg, Some(&mut trace)).unwrap();
         assert!(matches!(first, AdmissionDecision::Admit { .. }));
         assert_eq!(state.engram_count(), 1);
         assert!(state.is_content_seen(&content_hash_sha256(content)));
@@ -391,7 +391,7 @@ mod tests {
         // Second admit of identical content (different message id, same content)
         // should drop as Duplicate.
         let msg2 = synthetic_human_message(content);
-        let second = state.admit(&msg2, &mut trace).unwrap();
+        let second = state.admit(&msg2, Some(&mut trace)).unwrap();
         match second {
             AdmissionDecision::Drop {
                 reason: AdmissionDropReason::Duplicate { .. },
@@ -413,7 +413,7 @@ mod tests {
         // Short content → drops with NotMemorable.
         let msg = synthetic_human_message("short");
 
-        let decision = state.admit(&msg, &mut trace).unwrap();
+        let decision = state.admit(&msg, Some(&mut trace)).unwrap();
         match decision {
             AdmissionDecision::Drop {
                 reason: AdmissionDropReason::NotMemorable { .. },
@@ -437,7 +437,7 @@ mod tests {
             "third design observation worth recording",
         ];
         for content in messages {
-            let _ = state.admit(&synthetic_human_message(content), &mut trace);
+            let _ = state.admit(&synthetic_human_message(content), Some(&mut trace));
         }
         assert_eq!(state.engram_count(), 3);
         assert_eq!(
@@ -464,9 +464,9 @@ mod tests {
         let msg1 = synthetic_human_message("a long enough observation worth recording");
         let msg2 = synthetic_human_message("short");
         let msg3 = synthetic_human_message("a long enough observation worth recording");
-        let _ = state.admit(&msg1, &mut trace);
-        let _ = state.admit(&msg2, &mut trace);
-        let _ = state.admit(&msg3, &mut trace);
+        let _ = state.admit(&msg1, Some(&mut trace));
+        let _ = state.admit(&msg2, Some(&mut trace));
+        let _ = state.admit(&msg3, Some(&mut trace));
         assert_eq!(trace.seam_count(), 3, "one seam per admit() call");
     }
 
@@ -620,7 +620,7 @@ mod tests {
         let mut trace = CognitionTrace::new();
         let mut ids = Vec::new();
         for c in contents {
-            match state.admit(&synthetic_human_message(c), &mut trace).unwrap() {
+            match state.admit(&synthetic_human_message(c), Some(&mut trace)).unwrap() {
                 AdmissionDecision::Admit { engram, .. } => ids.push(engram.id),
                 other => panic!("expected Admit for content {c:?}, got {other:?}"),
             }

--- a/src/workers/continuum-core/src/persona/inbox_admission.rs
+++ b/src/workers/continuum-core/src/persona/inbox_admission.rs
@@ -254,7 +254,7 @@ impl<R: IsMemorable> InboxAdmissionRunner<R> {
         msg: &InboxMessage,
         seen_content: &'a dyn SeenContentLookup,
         seen_events: &'a dyn SeenEventLookup,
-        trace: &mut CognitionTrace,
+        trace: Option<&mut CognitionTrace>,
     ) -> Result<AdmissionDecision, AdmissionError> {
         let candidate = inbox_message_to_candidate(msg, &self.trust_mapping);
         let ctx = AdmissionContext::new(&self.config, seen_content, seen_events);
@@ -482,7 +482,7 @@ mod tests {
         );
 
         let decision = runner
-            .admit(&msg, &content, &events, &mut trace)
+            .admit(&msg, &content, &events, Some(&mut trace))
             .expect("well-formed message should admit cleanly");
         match decision {
             AdmissionDecision::Admit { engram, .. } => {
@@ -511,7 +511,7 @@ mod tests {
         let mut trace = CognitionTrace::new();
         let msg = synthetic_message("short", SenderType::Human);
 
-        match runner.admit(&msg, &content, &events, &mut trace).unwrap() {
+        match runner.admit(&msg, &content, &events, Some(&mut trace)).unwrap() {
             AdmissionDecision::Drop { reason: AdmissionDropReason::NotMemorable { .. } } => {}
             other => panic!("expected Drop NotMemorable, got {other:?}"),
         }
@@ -532,7 +532,7 @@ mod tests {
         let mut trace = CognitionTrace::new();
 
         let msg = synthetic_message(content_text, SenderType::Human);
-        match runner.admit(&msg, &content, &events, &mut trace).unwrap() {
+        match runner.admit(&msg, &content, &events, Some(&mut trace)).unwrap() {
             AdmissionDecision::Drop { reason: AdmissionDropReason::Duplicate { existing_engram_id } } => {
                 assert_eq!(existing_engram_id, existing);
             }
@@ -555,7 +555,7 @@ mod tests {
         );
 
         let decision = runner
-            .admit(&msg, &content, &events, &mut trace)
+            .admit(&msg, &content, &events, Some(&mut trace))
             .expect("system messages reach SelfTrust which clears any threshold");
         assert!(matches!(decision, AdmissionDecision::Admit { .. }));
     }
@@ -575,7 +575,7 @@ mod tests {
             SenderType::Persona,
         );
 
-        match runner.admit(&msg, &content, &events, &mut trace) {
+        match runner.admit(&msg, &content, &events, Some(&mut trace)) {
             Err(AdmissionError::TrustBoundaryRejected { source_trust, threshold }) => {
                 assert_eq!(source_trust, TrustState::Authenticated);
                 assert_eq!(threshold, TrustState::IntragridMember);
@@ -630,7 +630,7 @@ mod tests {
         // via the custom recipe — proves the custom recipe is the one being
         // consulted.
         let msg = synthetic_message("short", SenderType::Human);
-        let decision = runner.admit(&msg, &content, &events, &mut trace).unwrap();
+        let decision = runner.admit(&msg, &content, &events, Some(&mut trace)).unwrap();
         assert!(matches!(decision, AdmissionDecision::Admit { .. }));
     }
 
@@ -655,7 +655,7 @@ mod tests {
                 ),
                 &content,
                 &events,
-                &mut trace,
+                Some(&mut trace),
             );
         }
         assert_eq!(trace.seam_count(), 1);
@@ -668,7 +668,7 @@ mod tests {
                 &synthetic_message("short", SenderType::Human),
                 &content,
                 &events,
-                &mut trace,
+                Some(&mut trace),
             );
         }
         assert_eq!(trace.seam_count(), 2);

--- a/src/workers/continuum-core/tests/persona_respond_replay.rs
+++ b/src/workers/continuum-core/tests/persona_respond_replay.rs
@@ -20,6 +20,7 @@
 use continuum_core::ai::AIProviderAdapter;
 use continuum_core::cognition::{PersonaSlot, RecentMessage};
 use continuum_core::persona::response::{respond, PersonaResponse, RespondInput};
+use continuum_core::persona::turn_context::TurnContext;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::sync::Once;
@@ -166,11 +167,17 @@ fn build_input(fix: &Fixture, known_specialties: Vec<String>) -> RespondInput {
             specialty: fix.rust_request.specialty.clone(),
             display_name: fix.rust_request.persona_name.clone(),
         },
-        room_id: fix.rust_request.room_id,
+        // Per-turn shared context (continuum#1206). Replay reconstructs
+        // the room-level fields from the captured fixture, then bundles
+        // them into Arc<TurnContext> so the constructed RespondInput
+        // matches the live IPC path's shape.
+        turn_context: TurnContext::arc(
+            fix.rust_request.room_id,
+            recent_history,
+            known_specialties,
+        ),
         message_id: fix.rust_request.message_id,
         message_text: fix.rust_request.message_text.clone(),
-        recent_history,
-        known_specialties,
         other_persona_names: Vec::new(),
         system_prompt: fix.rust_request.system_prompt.clone(),
         model: fix.rust_request.model.clone(),
@@ -273,15 +280,18 @@ async fn clean_minimal_input_produces_spoke() {
             specialty: "general".to_string(),
             display_name: "Helper AI".to_string(),
         },
-        room_id: Uuid::new_v4(),
+        // Per-turn shared context (continuum#1206).
+        turn_context: TurnContext::arc(
+            Uuid::new_v4(),
+            vec![RecentMessage {
+                id: Uuid::new_v4(),
+                sender_name: "Developer".to_string(),
+                text: "Hi everyone, what's a good way to learn Rust?".to_string(),
+            }],
+            vec!["general".to_string()],
+        ),
         message_id: Uuid::new_v4(),
         message_text: "Hi everyone, what's a good way to learn Rust?".to_string(),
-        recent_history: vec![RecentMessage {
-            id: Uuid::new_v4(),
-            sender_name: "Developer".to_string(),
-            text: "Hi everyone, what's a good way to learn Rust?".to_string(),
-        }],
-        known_specialties: vec!["general".to_string()],
         other_persona_names: Vec::new(),
         system_prompt: "You are Helper AI. Respond naturally and concisely.".to_string(),
         model: "continuum-ai/qwen3.5-4b-code-forged-GGUF".to_string(),
@@ -454,16 +464,19 @@ async fn synthesized_prod_shape_input_produces_coherent_response() {
             specialty: "general".to_string(),
             display_name: "Helper AI".to_string(),
         },
-        room_id: Uuid::new_v4(),
+        // Per-turn shared context (continuum#1206).
+        turn_context: TurnContext::arc(
+            Uuid::new_v4(),
+            recent_history,
+            vec![
+                "general".to_string(),
+                "code".to_string(),
+                "learning".to_string(),
+                "local".to_string(),
+            ],
+        ),
         message_id: Uuid::new_v4(),
         message_text,
-        recent_history,
-        known_specialties: vec![
-            "general".to_string(),
-            "code".to_string(),
-            "learning".to_string(),
-            "local".to_string(),
-        ],
         other_persona_names: Vec::new(),
         system_prompt,
         model: "continuum-ai/qwen3.5-4b-code-forged-GGUF".to_string(),
@@ -586,7 +599,16 @@ async fn long_code_generation_request_completes_without_clipping() {
             specialty: fix.rust_request.specialty.clone(),
             display_name: fix.rust_request.persona_name.clone(),
         },
-        room_id: fix.rust_request.room_id,
+        // Per-turn shared context (continuum#1206).
+        turn_context: TurnContext::arc(
+            fix.rust_request.room_id,
+            vec![],
+            vec![
+                fix.rust_request.specialty.clone(),
+                "general".to_string(),
+                "code".to_string(),
+            ],
+        ),
         message_id: Uuid::new_v4(),
         message_text: "Write a complete recursive descent parser in Rust for a small expression \
              language (numbers, +, -, *, /, parentheses). Include the AST types, the \
@@ -594,12 +616,6 @@ async fn long_code_generation_request_completes_without_clipping() {
              explaining grammar precedence and associativity decisions. Output the full \
              code, not a sketch."
             .to_string(),
-        recent_history: vec![],
-        known_specialties: vec![
-            fix.rust_request.specialty.clone(),
-            "general".to_string(),
-            "code".to_string(),
-        ],
         other_persona_names: Vec::new(),
         system_prompt: fix.rust_request.system_prompt.clone(),
         model: fix.rust_request.model.clone(),

--- a/src/workers/continuum-core/tests/vision_integration.rs
+++ b/src/workers/continuum-core/tests/vision_integration.rs
@@ -32,6 +32,7 @@
 
 use continuum_core::cognition::tool_executor::types::MediaItemLite;
 use continuum_core::persona::response::{respond, PersonaResponse, RespondInput};
+use continuum_core::persona::turn_context::TurnContext;
 use uuid::Uuid;
 
 /// Minimal valid JPEG — 8x8 red square, ~160 bytes encoded.
@@ -83,11 +84,17 @@ fn build_vision_request(model_id: &str) -> RespondInput {
             specialty: "vision".to_string(),
             display_name: "VisionTestPersona".to_string(),
         },
-        room_id: Uuid::nil(),
+        // Per-turn shared context (continuum#1206). Room-level fields
+        // moved off RespondInput into Arc<TurnContext>; constructing
+        // here mirrors the projection done by `build_respond_input`
+        // for the live IPC path.
+        turn_context: TurnContext::arc(
+            Uuid::nil(),
+            Vec::new(),
+            vec!["vision".to_string()],
+        ),
         message_id: Uuid::nil(),
         message_text: "What do you see in this image?".to_string(),
-        recent_history: Vec::new(),
-        known_specialties: vec!["vision".to_string()],
         other_persona_names: Vec::new(),
         system_prompt: "You are a vision-capable assistant. Describe what you see in any image attached to the user's message. Keep the response under 40 words.".to_string(),
         model: model_id.to_string(),


### PR DESCRIPTION
Joel directive 18:30 — \"iterate for performance, lower latency + CPU drain for same/more features.\"

## Before

`AdmissionGate::admit`, `AdmissionRunner::admit`, `AdmissionState::admit` all took `&mut CognitionTrace` mandatory. The in-process hot-path admission gate added by #1213 constructs a fresh `CognitionTrace::new()` every chat turn, feeds it through `admit()` (which appends a `SEAM_ADMISSION` entry via `record_seam`), and drops it on the floor. The trace's recording work is pure waste on that path:

- `now_ms()` syscall for the duration
- `serde_json::json!({...})` Map allocation (HashMap + 3-4 String key/value pairs)
- `trace.record(...)` Vec push + `name.to_string()` allocation

Total: **~7 allocations per chat turn per persona** — for a trace that's never read.

## After

`admit()` at all three layers takes `Option<&mut CognitionTrace>`. `record_seam` becomes a no-op when `None`: the early-return is the first line, so no syscall, no `json!` Map, no Vec push.

- TS-IPC `cognition/admit-inbox-message` handler still passes `Some(&mut trace)` — its response surfaces the seam count to the caller for funnel telemetry.
- In-process inline gate (`run_inline_admission_gate` in `modules/cognition.rs`) passes `None` — it doesn't propagate the trace anywhere.
- Test sites (16 callers across `admission.rs`, `admission_state.rs`, `inbox_admission.rs`) pass `Some(&mut trace)` — existing behavior.

Internal use of `trace.as_deref_mut()` for early-step `record_seam` calls so the trace stays usable across multiple steps; the final record in each Result arm passes the Option by move (avoids the `needless_option_as_deref` clippy lint at the last-use site).

## Composes with the cognition perf cluster

- #1215 (claude-tab-2): `Shared<BoxFuture>` single-flight in shared_analysis
- #1219 + #1220 (claude-tab-2): `build_prompt` 40→1 allocs, prompt assembly 5+N→1, single-user-turn 3+N→1
- #1216 (mine): `Arc<TurnContext>` hoist eliminates N-clone per-turn duplication
- #1213 (mine): admission gate now runs on every chat turn — adds work — this PR cuts that added work to its essentials

Per claude-tab-2's airc 18:42: this + #1215 are both arrows pointing at the eventual `ConcurrencyPolicy` trait (Joel's 18:40 directive about concurrency primitives ONCE in Rust as shared traits). When that trait lands (claude-tab-2 takes first slice via `candle_adapter.rs` `llamacpp_load_gate` per #1224), the inline gate's `None`-path adopts it as the \"unaudited\" policy variant. **PR-shaped to compose into that future refactor, not preempt it.**

## Test plan

- [x] `cargo test --lib --features metal,accelerate -- persona::admission persona::admission_state persona::inbox_admission inline_admission` — 55 passed, 0 failed
- [x] `cargo clippy --lib --features metal,accelerate` — no NEW warnings introduced
- [x] Pre-push hook ran without `--no-verify`

The vision_integration test E0560 errors visible in `cargo check --tests` are pre-existing on canary from #1216's RespondInput hoist — separate issue, not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)