### PR TITLE
fix(concurrency,#1232): RAII Drop-guard so panicking work futures don't poison in_flight map

### DIFF
--- a/src/workers/continuum-core/src/concurrency/mod.rs
+++ b/src/workers/continuum-core/src/concurrency/mod.rs
@@ -94,6 +94,57 @@ where
     }
 }
 
+/// RAII guard for the analyzer's in-flight entry (#1232).
+///
+/// Owns cleanup of `in_flight[key]` regardless of whether the work
+/// future returns normally OR unwinds via panic. Without this guard,
+/// a panic inside the work future skips the post-await cleanup and
+/// the in_flight entry stays in the map forever — every subsequent
+/// call for the same key sees the poisoned shared future + tries to
+/// await it again, hanging or replaying the panic.
+///
+/// Only the **analyzer** holds the guard. Awaiters hold `None` because
+/// the analyzer owns the lifecycle; if the analyzer's work panics,
+/// awaiters of the same Shared get a cancellation, the analyzer's
+/// guard cleans up the entry, and the next caller for the same key
+/// starts a fresh inference instead of finding the broken entry.
+struct InFlightGuard<'a, K, V, E>
+where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    E: Clone + Send + Sync + 'static,
+{
+    in_flight: &'a Mutex<HashMap<K, SharedResult<V, E>>>,
+    in_flight_count: &'a AtomicUsize,
+    /// Wrapped in Option so Drop can take() it. Always Some until
+    /// drop fires; a None here would mean the guard already cleaned
+    /// up (used as a no-double-cleanup guard if we add `complete()`
+    /// later).
+    key: Option<K>,
+}
+
+impl<K, V, E> Drop for InFlightGuard<'_, K, V, E>
+where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    E: Clone + Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        if let Some(key) = self.key.take() {
+            // parking_lot::Mutex::lock is poison-free (vs std::sync) so
+            // a previously-panicking future cannot poison this lock.
+            // The cleanup runs in BOTH the normal-return path (drop
+            // at scope end) and the panic-unwind path (drop during
+            // unwind). Atomic decrement matches the analyzer's
+            // earlier increment exactly once.
+            let mut in_flight = self.in_flight.lock();
+            if in_flight.remove(&key).is_some() {
+                self.in_flight_count.fetch_sub(1, Ordering::AcqRel);
+            }
+        }
+    }
+}
+
 #[async_trait]
 impl<K, V, E> ConcurrencyPolicy<K, V, E> for TokioConcurrencyPolicy<K, V, E>
 where
@@ -102,26 +153,42 @@ where
     E: Clone + Send + Sync + 'static,
 {
     async fn single_flight(&self, key: K, work: BoxFuture<'static, Result<V, E>>) -> Result<V, E> {
-        let shared = {
+        // Two paths:
+        //   - Analyzer (first caller for this key): registers a fresh
+        //     Shared future + holds an InFlightGuard. The guard owns
+        //     cleanup via RAII — fires on normal return AND on panic
+        //     unwind (#1232).
+        //   - Awaiter (subsequent callers): clones the registered
+        //     Shared future + holds NO guard. The analyzer owns the
+        //     lifecycle.
+        let (shared, _guard) = {
             let mut in_flight = self.in_flight.lock();
             if let Some(existing) = in_flight.get(&key) {
-                existing.clone()
+                // Awaiter path: no guard. Analyzer's guard runs cleanup.
+                (existing.clone(), None)
             } else {
                 let shared = work.shared();
                 in_flight.insert(key.clone(), shared.clone());
                 self.in_flight_count.fetch_add(1, Ordering::AcqRel);
-                shared
+                // Analyzer path: hold the RAII guard so cleanup fires
+                // even if shared.await panics or the task is cancelled.
+                (
+                    shared,
+                    Some(InFlightGuard {
+                        in_flight: &self.in_flight,
+                        in_flight_count: &self.in_flight_count,
+                        key: Some(key),
+                    }),
+                )
             }
         };
 
-        let result = shared.await;
-
-        let mut in_flight = self.in_flight.lock();
-        if in_flight.remove(&key).is_some() {
-            self.in_flight_count.fetch_sub(1, Ordering::AcqRel);
-        }
-
-        result
+        // Both arms await the SAME Shared future. If the work panics,
+        // the panic unwinds OUT of this .await — and the analyzer's
+        // _guard drops on the way out, cleaning up the in_flight entry.
+        // Awaiters get the panic re-raised by Shared (they didn't run
+        // it); their _guard is None so they don't try to clean up.
+        shared.await
     }
 
     fn in_flight_count(&self) -> usize {
@@ -163,6 +230,67 @@ mod tests {
         }
         assert_eq!(producers.load(Ordering::Acquire), 1);
         assert_eq!(policy.in_flight_count(), 0);
+    }
+
+    /// What this catches: a panicking work future no longer poisons
+    /// the in_flight map (#1232). Before the Drop-guard, the panic
+    /// unwound past the post-await cleanup, leaving the entry +
+    /// counter stuck. After the guard, the entry clears on panic
+    /// unwind exactly the same way it does on normal return.
+    ///
+    /// The test:
+    ///   1. First call panics inside the work future
+    ///   2. Catch the panic via `tokio::spawn`'s JoinError-on-panic
+    ///   3. Assert in_flight_count is 0 (NOT 1) after the panic
+    ///   4. Second call succeeds — proving the key isn't poisoned
+    #[tokio::test]
+    async fn single_flight_drop_guard_clears_in_flight_on_panic() {
+        let policy = Arc::new(TokioConcurrencyPolicy::<String, usize, String>::new());
+        let key = "panic-key".to_string();
+
+        // First call: panics inside the work future. tokio::spawn
+        // catches the panic so the test process survives; we assert
+        // the policy's in-flight state recovered.
+        let policy_p = Arc::clone(&policy);
+        let key_p = key.clone();
+        let panic_handle = tokio::spawn(async move {
+            policy_p
+                .single_flight(
+                    key_p,
+                    async move {
+                        panic!("simulated work-future panic");
+                    }
+                    .boxed(),
+                )
+                .await
+        });
+        let panic_outcome = panic_handle.await;
+        assert!(
+            panic_outcome.is_err() && panic_outcome.unwrap_err().is_panic(),
+            "first call should have observed the panic"
+        );
+
+        // Drop-guard invariant: in_flight count went back to 0.
+        // Without the guard this would be 1 (entry never removed).
+        assert_eq!(
+            policy.in_flight_count(),
+            0,
+            "Drop-guard should clear in_flight entry on panic; \
+             a non-zero count means the panic poisoned the map"
+        );
+
+        // Second call for the SAME key: succeeds. Without the guard,
+        // it would either hang on the dead Shared future or replay
+        // the panic. With the guard, the key is fresh and the new
+        // work runs cleanly.
+        let result = policy
+            .single_flight(
+                key.clone(),
+                async move { Ok::<usize, String>(99) }.boxed(),
+            )
+            .await;
+        assert_eq!(result, Ok(99), "second call after panic should succeed cleanly");
+        assert_eq!(policy.in_flight_count(), 0, "second call should also clean up");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #1232. Hardens the ConcurrencyPolicy single-flight primitive sibling shipped in #1230. Direct execution of codex's review nit on that PR (2026-05-14 18:17:13); I committed to taking it in my own #1230 review.

## Bug

Pre-fix shape:

```rust
let result = shared.await;
let mut in_flight = self.in_flight.lock();
if in_flight.remove(&key).is_some() {
    self.in_flight_count.fetch_sub(1, Ordering::AcqRel);
}
result
```

If the work future panics, the panic unwinds OUT of `shared.await` before reaching cleanup. The in_flight HashMap entry stays + the atomic counter stays incremented. Every subsequent call for the same key sees the poisoned entry, awaits the dead Shared future, hangs forever.

The substrate's resilience claim ("self-heal from every failure mode") had a hole: ANY panic in run_analysis (model parser bug, OOM, downstream IPC failure that panics rather than errors) permanently breaks shared cognition for the affected message_hash on that process. Restart required.

## Fix

RAII `InFlightGuard` that owns cleanup. The analyzer arm holds the guard across the work future:

```rust
struct InFlightGuard<'a, K, V, E> { ... key: Option<K> }

impl<...> Drop for InFlightGuard<'_, K, V, E> {
    fn drop(&mut self) {
        if let Some(key) = self.key.take() {
            let mut in_flight = self.in_flight.lock();
            if in_flight.remove(&key).is_some() {
                self.in_flight_count.fetch_sub(1, Ordering::AcqRel);
            }
        }
    }
}
```

Drop fires on BOTH normal scope-end AND panic-unwind. parking_lot mutex is poison-free (vs std::sync) so a previously-panicking future cannot permanently lock out cleanup.

## Test

`single_flight_drop_guard_clears_in_flight_on_panic` — wraps a panicking work future in tokio::spawn (catches the panic), asserts:
1. `in_flight_count` returns to 0 after the panic
2. A second call for the SAME key succeeds (proves no poisoning)

Without the Drop-guard this test fails: in_flight_count stays at 1, the second call hangs forever on the dead Shared future.

3 existing tests still pass byte-identical. Clippy stays at baseline 162.

## Why this matters

Joel directive 2026-05-14 18:40: "code concurrency ONCE then incorporate it." The whole point of putting concurrency primitives in a shared trait is that EVERY caller benefits from EVERY hardening. This fix is in the trait's default impl, so every cognition / persona / future caller of ConcurrencyPolicy::single_flight gets panic-safety for free.

## Refs

- Parent: #1224 (ConcurrencyPolicy trait)
- Builds on: #1230 (sibling shipped the trait; this is the first follow-up)
- Spec: codex review on #1230 (2026-05-14 18:17:13)
- Commitment: claude-tab-2 #1230 review (2026-05-14 19:19:46)

Closes #1232.