### PR TITLE
feat(cognition): surface recalled engrams into prompt_assembly (#1211 PR-2)

### DIFF
--- a/src/workers/continuum-core/src/modules/cognition.rs
+++ b/src/workers/continuum-core/src/modules/cognition.rs
@@ -938,9 +938,9 @@ impl ServiceModule for CognitionModule {
                 let signal: crate::persona::cognition_io::Signal = p.json("signal")?;
                 let ctx: crate::persona::cognition_io::PersonaContext = p.json("personaContext")?;
 
-                let input = crate::persona::cognition_io::build_respond_input(&signal, &ctx)?;
+                let mut input = crate::persona::cognition_io::build_respond_input(&signal, &ctx)?;
 
-                // ── Hot-path admission gate (continuum#1211) ────────
+                // ── Hot-path admission gate (continuum#1211 PR-1) ──
                 // Run admission BEFORE inference so the persona's
                 // engram store grows from real chat turns. Without
                 // this call the admission machinery (#1121 PR-1..5) is
@@ -951,10 +951,39 @@ impl ServiceModule for CognitionModule {
                 // (persona never had `cognition/create-engine` called)
                 // is logged and skipped, NOT a chat-blocking error.
                 // The persona still responds; it just doesn't grow
-                // memory until the engine is created. PR-2 will
-                // surface recalled engrams to prompt_assembly so the
-                // recall side starts working too.
+                // memory until the engine is created.
                 run_inline_admission_gate(&self.state, &signal, &ctx);
+
+                // ── Hot-path recall surface (continuum#1211 PR-2) ──
+                // After admission gate, populate input.recalled_engrams
+                // with the persona's most-recently-admitted memory so
+                // prompt_assembly can render a `[Recent Memory]` block
+                // in the system prompt. Closes the engram loop:
+                // admit (PR-1) → store → recall (PR-2) → context →
+                // model sees its own memory.
+                //
+                // Cap = 5 most-recent engrams. The number is a budget
+                // policy: enough to ground the persona in continuity
+                // ("yes the user mentioned teal earlier") without
+                // dominating the prompt. Future tunable via per-persona
+                // AdmissionConfig; v1 is a hardcoded sensible default.
+                //
+                // Empty when persona has no AdmissionState (same
+                // forensic-skip path as the gate above) OR no admitted
+                // engrams yet (cold-start). Both are normal early-life
+                // states; a no-recall persona is unchanged from
+                // pre-PR-2 behavior. Prompt_assembly skips rendering
+                // when the list is empty (no `[Recent Memory]` header
+                // appears).
+                const RECALL_LIMIT: usize = 5;
+                if let Some(persona) = self.state.personas.get(&ctx.persona_id) {
+                    input.recalled_engrams = persona
+                        .admission
+                        .recall_recent(RECALL_LIMIT)
+                        .into_iter()
+                        .map(|e| e.content)
+                        .collect();
+                }
 
                 // Diagnostic: log what media survived the projection.
                 // Vision routing was failing 2026-04-21 and this stays

--- a/src/workers/continuum-core/src/persona/cognition_io.rs
+++ b/src/workers/continuum-core/src/persona/cognition_io.rs
@@ -263,6 +263,14 @@ pub fn build_respond_input(
         // declared them at construction; the projection doesn't
         // second-guess.
         capabilities: ctx.capabilities.iter().copied().collect(),
+        // Recalled engrams default empty here. The IPC layer
+        // (`cognition/respond` handler in modules/cognition.rs)
+        // populates this AFTER the inline admission gate runs and
+        // BEFORE calling respond(). Keeping the default empty means
+        // any RespondInput constructed outside the IPC path (tests,
+        // direct callers) gets a no-op memory render — same shape
+        // as the system pre-#1211 PR-2.
+        recalled_engrams: Vec::new(),
     })
 }
 

--- a/src/workers/continuum-core/src/persona/prompt_assembly.rs
+++ b/src/workers/continuum-core/src/persona/prompt_assembly.rs
@@ -43,6 +43,16 @@ pub struct PromptAssemblyInput {
     /// and `SingleUserTurnFlattenedHistory` ignore this field.
     #[serde(default)]
     pub other_persona_names: Vec<String>,
+    /// Recalled engrams (per-persona admitted memory) — content
+    /// strings only, ordered most-recent first, already trimmed by
+    /// the caller. Rendered as a `[Recent Memory]` block right after
+    /// the matched-angle injection so the persona sees its own
+    /// memory adjacent to the analyzer's per-turn perspective. Empty
+    /// = no memory recall on this turn (normal early-life state, or
+    /// admission gate skipped because no AdmissionState).
+    /// Continuum#1211 PR-2.
+    #[serde(default)]
+    pub recalled_engrams: Vec<String>,
 }
 
 /// A message in conversation history.
@@ -112,6 +122,33 @@ pub fn assemble(input: &PromptAssemblyInput) -> AssembledPrompt {
              to your expertise. Focus your contribution here:\n{}",
             input.matched_angle
         );
+    }
+
+    // Inject recalled engrams as a memory block — continuum#1211 PR-2.
+    // The persona's admission gate (#1213) collected these from prior
+    // chat turns; rendering them here is what closes the engram loop
+    // (admit → store → recall → context). Caller (cognition/respond
+    // IPC handler) is responsible for trimming to a sensible count
+    // before calling assemble — prompt_assembly stays a pure
+    // formatter, doesn't make policy decisions about budget.
+    //
+    // Empty list = no rendering, no header. A persona that hasn't
+    // accumulated memory yet (or the inline gate skipped because no
+    // AdmissionState exists) sees the prompt unchanged from before
+    // PR-2 — backwards-compatible.
+    if !input.recalled_engrams.is_empty() {
+        system_prompt.push_str(
+            "\n\n[Recent Memory]\n\
+             Things you have remembered from prior conversations in this room. \
+             Use this context as background; not every memory needs to be cited:\n",
+        );
+        for engram in &input.recalled_engrams {
+            // `- ` bullet prefix keeps each engram visually separable
+            // even when the content runs multiple lines. writeln!
+            // appends the newline without the trailing-newline-in-
+            // format-string clippy lint.
+            let _ = writeln!(system_prompt, "- {engram}");
+        }
     }
 
     // Inject social awareness signals
@@ -466,6 +503,7 @@ mod tests {
             social_signals: None,
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
+            recalled_engrams: vec![],
         };
 
         let result = assemble(&input);
@@ -474,6 +512,87 @@ mod tests {
         assert!(result.system_message.contains("Rust error handling"));
         assert!(result.messages.len() >= 2); // history + current (identity reminder removed 2026-04-20)
         assert!(result.estimated_tokens > 0);
+    }
+
+    /// What this catches (continuum#1211 PR-2): when recalled_engrams
+    /// is non-empty, the assembled system_message includes the
+    /// `[Recent Memory]` block AND each engram bullet.
+    /// Regression: a future formatter change that drops the bullet
+    /// prefix or the header would break the persona's ability to
+    /// distinguish memory from current context.
+    #[test]
+    fn recalled_engrams_render_as_memory_block() {
+        let input = PromptAssemblyInput {
+            persona_name: "Helper AI".to_string(),
+            system_prompt: "You are Helper AI.".to_string(),
+            matched_angle: String::new(),
+            history: vec![],
+            current_message: HistoryMessage {
+                role: "user".to_string(),
+                name: Some("Joel".to_string()),
+                content: "what color did I say I liked?".to_string(),
+                timestamp_ms: Some(1000),
+            },
+            is_voice: false,
+            social_signals: None,
+            multi_party_strategy: MultiPartyChatStrategy::default(),
+            other_persona_names: vec![],
+            recalled_engrams: vec![
+                "Joel's favorite color is teal.".to_string(),
+                "Joel works in San Francisco.".to_string(),
+            ],
+        };
+
+        let result = assemble(&input);
+        assert!(
+            result.system_message.contains("[Recent Memory]"),
+            "expected Recent Memory header in: {}",
+            result.system_message
+        );
+        assert!(
+            result.system_message.contains("- Joel's favorite color is teal."),
+            "expected bullet-prefixed engram in: {}",
+            result.system_message
+        );
+        assert!(
+            result.system_message.contains("- Joel works in San Francisco."),
+            "expected second bullet in: {}",
+            result.system_message
+        );
+    }
+
+    /// What this catches (continuum#1211 PR-2): empty recalled_engrams
+    /// produces NO `[Recent Memory]` block and NO header. Backwards-
+    /// compat with all pre-PR-2 callers + cold-start personas (no
+    /// engrams yet). Regression: a formatter that always emits the
+    /// header would clutter every prompt for every persona that hasn't
+    /// accumulated memory yet.
+    #[test]
+    fn empty_recalled_engrams_emits_no_memory_block() {
+        let input = PromptAssemblyInput {
+            persona_name: "Helper AI".to_string(),
+            system_prompt: "You are Helper AI.".to_string(),
+            matched_angle: String::new(),
+            history: vec![],
+            current_message: HistoryMessage {
+                role: "user".to_string(),
+                name: None,
+                content: "hi".to_string(),
+                timestamp_ms: None,
+            },
+            is_voice: false,
+            social_signals: None,
+            multi_party_strategy: MultiPartyChatStrategy::default(),
+            other_persona_names: vec![],
+            recalled_engrams: vec![],
+        };
+
+        let result = assemble(&input);
+        assert!(
+            !result.system_message.contains("[Recent Memory]"),
+            "should NOT render Recent Memory header for empty engrams: {}",
+            result.system_message
+        );
     }
 
     #[test]
@@ -493,6 +612,7 @@ mod tests {
             social_signals: None,
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
+            recalled_engrams: vec![],
         };
 
         let result = assemble(&input);
@@ -516,6 +636,7 @@ mod tests {
             social_signals: None,
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
+            recalled_engrams: vec![],
         };
 
         let result = assemble(&input);
@@ -547,6 +668,7 @@ mod tests {
             }),
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
+            recalled_engrams: vec![],
         };
 
         let result = assemble(&input);
@@ -588,6 +710,7 @@ mod tests {
             social_signals: None,
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
+            recalled_engrams: vec![],
         };
 
         let result = assemble(&input);
@@ -630,6 +753,7 @@ mod tests {
             social_signals: None,
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
+            recalled_engrams: vec![],
         };
 
         let result = assemble(&input);

--- a/src/workers/continuum-core/src/persona/recorder.rs
+++ b/src/workers/continuum-core/src/persona/recorder.rs
@@ -361,6 +361,7 @@ mod tests {
             is_voice: false,
             message_media: vec![],
             capabilities: HashSet::new(),
+            recalled_engrams: vec![],
         }
     }
 

--- a/src/workers/continuum-core/src/persona/response.rs
+++ b/src/workers/continuum-core/src/persona/response.rs
@@ -105,6 +105,26 @@ pub struct RespondInput {
     /// declaration travels with the request — registry-key drift can't
     /// silently disable vision.
     pub capabilities: std::collections::HashSet<crate::model_registry::Capability>,
+    /// Recalled engrams (per-persona admitted memory) injected as
+    /// system-prompt context (continuum#1211 PR-2). The IPC layer
+    /// pulls these from `AdmissionState::recall_recent` after the
+    /// inline admission gate runs, then passes them through so
+    /// `prompt_assembly` can render them as a `[Recent Memory]`
+    /// section. Empty when the persona has no admission state OR no
+    /// admitted engrams yet — both are normal early-life states and
+    /// neither blocks the response cycle.
+    ///
+    /// Per-persona (each persona's admission store is independent)
+    /// so this lives on `RespondInput`, not the per-turn-shared
+    /// `TurnContext` (#1206) — different personas in the same room
+    /// recall different memory.
+    ///
+    /// `String` (the engram's content text) rather than `Engram`
+    /// because prompt_assembly only needs the text. Keeping the full
+    /// `Engram` type out of this layer means a future structural
+    /// change to engrams (kind enum, embeddings, recall_keys reshape)
+    /// doesn't ripple into the prompt path.
+    pub recalled_engrams: Vec<String>,
 }
 
 /// What `respond()` returns.
@@ -395,6 +415,13 @@ async fn run_render(
         social_signals: None,
         multi_party_strategy,
         other_persona_names: input.other_persona_names.clone(),
+        // Recalled engrams populated by the IPC layer post-admission
+        // (continuum#1211 PR-2). respond() is just a pass-through —
+        // caller decides how many engrams to recall (sensible default
+        // is 5-10, see modules/cognition.rs cognition/respond
+        // handler). Empty when admission was skipped or persona has
+        // no memory yet.
+        recalled_engrams: input.recalled_engrams.clone(),
     };
 
     let assembled = assemble(&prompt_input);


### PR DESCRIPTION
Closes the engram loop end-to-end. PR-1 (#1213) wired admission inline on the cognition/respond hot path so personas grow engrams from chat turns. **PR-2 plumbs the RECALL side** — model now SEES its own memory.

## What

After admission gate runs in cognition/respond IPC handler, pull the persona's most-recent engrams via AdmissionState::recall_recent(5) and populate input.recalled_engrams. respond_inner passes through to PromptAssemblyInput, which renders a [Recent Memory] block in the system prompt right after the matched-angle injection.

## End-to-end loop now wired

- inbox → admission gate (PR-1) → engram store grows
- recall surface (this PR) → prompt context → model sees its own memory

A persona that says "my favorite color is teal" in turn N now has that fact available as [Recent Memory] context in turn N+1, and can answer "what color did I say I liked?" correctly.

## Design choices

- **Vec<String> not Vec<Engram>**: prompt_assembly only needs the content text; full Engram type stays in the admission/recall layer so future structural changes (kind enum, embeddings, recall_keys reshape) don't ripple into the prompt path
- **Per-persona on RespondInput, not TurnContext (#1206)**: each persona's admission store is independent — different personas in the same room recall different memory
- **Cap of 5 engrams**: enough to ground in continuity without dominating the prompt. Future tunable via per-persona AdmissionConfig
- **Empty list = no rendering, no header**: backwards-compat with cold-start personas + pre-PR-2 callers
- **prompt_assembly stays a pure formatter**: no policy decisions about budget; caller (IPC handler) trims

## Test plan

- [x] cargo test --lib --features metal,accelerate persona:: — 451 passed, 2 new (recalled_engrams_render_as_memory_block + empty_recalled_engrams_emits_no_memory_block)
- [x] cargo clippy clean (no new warnings; writeln! avoids the trailing-newline format string lint)
- [x] Pre-push hook ran without --no-verify
- [ ] **Live smoke**: send memorable chat in general room → next turn from same persona surfaces the memory in their reply (deferred to a separate validation card; substrate is in place)

Refs #1211. Refs #1121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)