### PR TITLE
perf(concurrency,#1235): refcount-per-key cleanup so analyzer cancellation can't drop entry mid-flight

### DIFF
--- a/src/workers/continuum-core/src/concurrency/mod.rs
+++ b/src/workers/continuum-core/src/concurrency/mod.rs
@@ -15,6 +15,25 @@ use tokio::sync::Semaphore;
 
 type SharedResult<V, E> = Shared<BoxFuture<'static, Result<V, E>>>;
 
+/// Per-key in-flight entry: the shared future + a refcount of how many
+/// callers (analyzer + awaiters) currently hold a `RefCountGuard` for
+/// this key. The entry is removed when the refcount drops to zero
+/// (#1235 — replaces the previous "only-analyzer-cleans-up" model so
+/// analyzer cancellation can no longer remove the entry while awaiters
+/// still hold the Shared, which previously let a brand-new caller race
+/// in and start duplicate work for the same key).
+struct KeyEntry<V, E>
+where
+    V: Clone + Send + Sync + 'static,
+    E: Clone + Send + Sync + 'static,
+{
+    shared: SharedResult<V, E>,
+    /// Number of `single_flight` calls currently holding a guard for
+    /// this key. Bumped under the in_flight mutex on every entry path
+    /// (analyzer + awaiter), decremented on every guard drop.
+    refcount: Arc<AtomicUsize>,
+}
+
 #[async_trait]
 pub trait ConcurrencyPolicy<K, V, E>: Send + Sync
 where
@@ -40,7 +59,7 @@ where
     V: Clone + Send + Sync + 'static,
     E: Clone + Send + Sync + 'static,
 {
-    in_flight: Mutex<HashMap<K, SharedResult<V, E>>>,
+    in_flight: Mutex<HashMap<K, KeyEntry<V, E>>>,
     in_flight_count: AtomicUsize,
     limiter: Option<Arc<Semaphore>>,
 }
@@ -94,53 +113,97 @@ where
     }
 }
 
-/// RAII guard for the analyzer's in-flight entry (#1232).
+/// RAII refcount guard for an in-flight entry (#1232 + #1235).
 ///
-/// Owns cleanup of `in_flight[key]` regardless of whether the work
-/// future returns normally OR unwinds via panic. Without this guard,
-/// a panic inside the work future skips the post-await cleanup and
-/// the in_flight entry stays in the map forever — every subsequent
-/// call for the same key sees the poisoned shared future + tries to
-/// await it again, hanging or replaying the panic.
+/// **Every** caller — the analyzer (first caller for this key) AND each
+/// awaiter — holds a `RefCountGuard` for the duration of its
+/// `single_flight` call. The entry's `Arc<AtomicUsize>` is bumped under
+/// the in_flight mutex when the guard is constructed, and decremented
+/// when the guard drops. The map entry is removed only when the
+/// refcount hits zero (under the lock, double-checked to handle a new
+/// caller racing in between fetch_sub and the lock acquisition).
 ///
-/// Only the **analyzer** holds the guard. Awaiters hold `None` because
-/// the analyzer owns the lifecycle; if the analyzer's work panics,
-/// awaiters of the same Shared get a cancellation, the analyzer's
-/// guard cleans up the entry, and the next caller for the same key
-/// starts a fresh inference instead of finding the broken entry.
-struct InFlightGuard<'a, K, V, E>
+/// # Why every caller holds one (not just the analyzer)
+///
+/// Pre-#1235 only the analyzer held a Drop guard. That correctly fixed
+/// the panic-cleanup case (#1232) but left a window during analyzer
+/// cancellation:
+///
+/// ```text
+///   T0: analyzer.single_flight("k") → creates entry, holds guard
+///   T1: awaiter1.single_flight("k") → clones Shared, no guard
+///   T2: analyzer task is dropped (cancellation)
+///   T3: analyzer's guard.drop fires → removes entry from in_flight
+///   T4: NEW caller.single_flight("k") → finds no entry → starts a
+///       FRESH `work` future for "k" — duplicate work, contract
+///       violated. awaiter1 still completes the original Shared, but
+///       there are now two concurrent inferences for the same key.
+/// ```
+///
+/// With per-caller refcounts, the entry stays alive as long as ANY
+/// caller (analyzer or awaiter) is still holding the Shared. Only when
+/// the last holder drops does cleanup fire — at which point any future
+/// caller correctly starts fresh (no one is waiting for the old
+/// result).
+///
+/// # Panic behavior preserved
+///
+/// If the work future panics, the panic unwinds through `shared.await`
+/// in every caller (Shared re-raises to clones). All guards drop during
+/// unwind, refcount → 0, entry removed. Same end state as #1232.
+struct RefCountGuard<'a, K, V, E>
 where
     K: Eq + Hash + Clone + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
     E: Clone + Send + Sync + 'static,
 {
-    in_flight: &'a Mutex<HashMap<K, SharedResult<V, E>>>,
+    in_flight: &'a Mutex<HashMap<K, KeyEntry<V, E>>>,
     in_flight_count: &'a AtomicUsize,
+    /// Same Arc the entry holds — pre-bumped under the in_flight lock
+    /// when this guard was constructed.
+    refcount: Arc<AtomicUsize>,
     /// Wrapped in Option so Drop can take() it. Always Some until
-    /// drop fires; a None here would mean the guard already cleaned
-    /// up (used as a no-double-cleanup guard if we add `complete()`
-    /// later).
+    /// drop fires.
     key: Option<K>,
 }
 
-impl<K, V, E> Drop for InFlightGuard<'_, K, V, E>
+impl<K, V, E> Drop for RefCountGuard<'_, K, V, E>
 where
     K: Eq + Hash + Clone + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
     E: Clone + Send + Sync + 'static,
 {
     fn drop(&mut self) {
-        if let Some(key) = self.key.take() {
-            // parking_lot::Mutex::lock is poison-free (vs std::sync) so
-            // a previously-panicking future cannot poison this lock.
-            // The cleanup runs in BOTH the normal-return path (drop
-            // at scope end) and the panic-unwind path (drop during
-            // unwind). Atomic decrement matches the analyzer's
-            // earlier increment exactly once.
-            let mut in_flight = self.in_flight.lock();
-            if in_flight.remove(&key).is_some() {
+        let Some(key) = self.key.take() else { return };
+
+        // Decrement first; this is the contract that as long as ANY
+        // refcount > 0 the entry MUST be in the map. The decrement is
+        // unconditional — every guard pre-incremented in single_flight
+        // under the lock, so every drop must match it exactly once.
+        let prev = self.refcount.fetch_sub(1, Ordering::AcqRel);
+        if prev != 1 {
+            // Other callers are still holding the entry; nothing to
+            // clean up. The entry stays in the map for them.
+            return;
+        }
+
+        // We were the last holder (refcount went 1 → 0). Acquire the
+        // lock and DOUBLE-CHECK the per-key refcount under the lock —
+        // a brand-new single_flight call may have raced in between our
+        // fetch_sub and our lock acquisition, found the entry, bumped
+        // refcount back to 1, and we'd erroneously remove the entry
+        // with that fresh caller still expecting it.
+        //
+        // parking_lot::Mutex::lock is poison-free (vs std::sync) so a
+        // previously-panicking future cannot poison this lock.
+        let mut in_flight = self.in_flight.lock();
+        if let Some(entry) = in_flight.get(&key) {
+            if entry.refcount.load(Ordering::Acquire) == 0 {
+                in_flight.remove(&key);
                 self.in_flight_count.fetch_sub(1, Ordering::AcqRel);
             }
+            // else: a new caller raced in and bumped the refcount under
+            // the lock. Leave the entry — it now belongs to them.
         }
     }
 }
@@ -153,41 +216,54 @@ where
     E: Clone + Send + Sync + 'static,
 {
     async fn single_flight(&self, key: K, work: BoxFuture<'static, Result<V, E>>) -> Result<V, E> {
-        // Two paths:
-        //   - Analyzer (first caller for this key): registers a fresh
-        //     Shared future + holds an InFlightGuard. The guard owns
-        //     cleanup via RAII — fires on normal return AND on panic
-        //     unwind (#1232).
-        //   - Awaiter (subsequent callers): clones the registered
-        //     Shared future + holds NO guard. The analyzer owns the
-        //     lifecycle.
+        // EVERY caller (analyzer + awaiters) gets a RefCountGuard so
+        // the entry's lifetime is tied to all outstanding holders, not
+        // just the first caller (#1235). The two paths differ only in
+        // whether they create a fresh entry or join an existing one;
+        // both increment the per-key refcount under the in_flight lock.
         let (shared, _guard) = {
             let mut in_flight = self.in_flight.lock();
-            if let Some(existing) = in_flight.get(&key) {
-                // Awaiter path: no guard. Analyzer's guard runs cleanup.
-                (existing.clone(), None)
-            } else {
-                let shared = work.shared();
-                in_flight.insert(key.clone(), shared.clone());
-                self.in_flight_count.fetch_add(1, Ordering::AcqRel);
-                // Analyzer path: hold the RAII guard so cleanup fires
-                // even if shared.await panics or the task is cancelled.
+            if let Some(entry) = in_flight.get(&key) {
+                // Awaiter path: bump existing refcount, clone Shared.
+                entry.refcount.fetch_add(1, Ordering::AcqRel);
                 (
-                    shared,
-                    Some(InFlightGuard {
+                    entry.shared.clone(),
+                    RefCountGuard {
                         in_flight: &self.in_flight,
                         in_flight_count: &self.in_flight_count,
+                        refcount: entry.refcount.clone(),
                         key: Some(key),
-                    }),
+                    },
+                )
+            } else {
+                // Analyzer path: create fresh entry with refcount=1.
+                let shared = work.shared();
+                let refcount = Arc::new(AtomicUsize::new(1));
+                in_flight.insert(
+                    key.clone(),
+                    KeyEntry {
+                        shared: shared.clone(),
+                        refcount: refcount.clone(),
+                    },
+                );
+                self.in_flight_count.fetch_add(1, Ordering::AcqRel);
+                (
+                    shared,
+                    RefCountGuard {
+                        in_flight: &self.in_flight,
+                        in_flight_count: &self.in_flight_count,
+                        refcount,
+                        key: Some(key),
+                    },
                 )
             }
         };
 
-        // Both arms await the SAME Shared future. If the work panics,
-        // the panic unwinds OUT of this .await — and the analyzer's
-        // _guard drops on the way out, cleaning up the in_flight entry.
-        // Awaiters get the panic re-raised by Shared (they didn't run
-        // it); their _guard is None so they don't try to clean up.
+        // Every caller awaits the SAME Shared future. The Shared keeps
+        // the underlying BoxFuture alive across analyzer cancellation
+        // (Arc internal); whichever awaiter polls drives it forward.
+        // If work panics, panic re-raises through every clone; the
+        // guards drop on the way out, refcount → 0, entry removed.
         shared.await
     }
 

--- a/src/workers/continuum-core/src/concurrency/mod.rs
+++ b/src/workers/continuum-core/src/concurrency/mod.rs
@@ -369,6 +369,232 @@ mod tests {
         assert_eq!(policy.in_flight_count(), 0, "second call should also clean up");
     }
 
+    /// What this catches: regression in the #1235 fix. The previous
+    /// "only the analyzer holds a Drop guard" model removed the
+    /// in_flight entry as soon as the analyzer cancelled, even if
+    /// awaiters were still holding the Shared. A NEW caller arriving
+    /// after the analyzer drop but before the awaiter completed would
+    /// find no entry and start duplicate work for the same key.
+    ///
+    /// With the refcount fix, the entry survives analyzer cancellation
+    /// for as long as ANY caller still holds a guard. A new caller
+    /// arriving in that window joins the existing Shared instead of
+    /// kicking off a duplicate.
+    ///
+    /// Test shape:
+    ///   1. Analyzer.single_flight("k") starts long-running work, then
+    ///      its hosting task is dropped (cancellation).
+    ///   2. While the analyzer task is dropping, an awaiter holds a
+    ///      clone of the Shared via its own single_flight call.
+    ///   3. After analyzer drop, a NEW caller arrives for "k".
+    ///   4. The new caller MUST join the same Shared (work executes
+    ///      ONCE total across all three callers), not start fresh.
+    ///
+    /// This test would FAIL on pre-#1235 code because step (1)'s drop
+    /// would have removed the in_flight entry, and step (3) would have
+    /// triggered a fresh `work` future. After #1235 the analyzer's
+    /// guard drop only decrements the refcount; the awaiter's guard
+    /// keeps the entry alive.
+    #[tokio::test]
+    async fn analyzer_cancellation_does_not_evict_entry_while_awaiters_hold_it() {
+        let policy = Arc::new(TokioConcurrencyPolicy::<String, usize, String>::new());
+        let producers = Arc::new(AtomicUsize::new(0));
+        let key = "k".to_string();
+
+        // Start the work-future producer with a release-on-signal handle
+        // so the test can hold it open until we're ready.
+        let release = Arc::new(tokio::sync::Notify::new());
+
+        // (1) Analyzer task: starts the work, awaits indefinitely until
+        // we drop its handle to simulate cancellation.
+        let analyzer_handle = {
+            let policy = Arc::clone(&policy);
+            let producers = Arc::clone(&producers);
+            let release = Arc::clone(&release);
+            let key = key.clone();
+            tokio::spawn(async move {
+                policy
+                    .single_flight(
+                        key,
+                        async move {
+                            producers.fetch_add(1, Ordering::AcqRel);
+                            // Block until released so the test can stage
+                            // cancellation + new-caller arrival.
+                            release.notified().await;
+                            Ok::<usize, String>(7)
+                        }
+                        .boxed(),
+                    )
+                    .await
+            })
+        };
+
+        // (2) Awaiter task: joins the same key. Hold this open across
+        // analyzer cancellation so the entry refcount stays >= 1.
+        let awaiter_handle = {
+            let policy = Arc::clone(&policy);
+            let release = Arc::clone(&release);
+            let key = key.clone();
+            tokio::spawn(async move {
+                // Yield so analyzer registers first.
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                let result = policy
+                    .single_flight(
+                        key,
+                        async move {
+                            // Should NEVER run: awaiter joins existing
+                            // Shared, doesn't create its own work.
+                            release.notified().await;
+                            Ok::<usize, String>(999)
+                        }
+                        .boxed(),
+                    )
+                    .await;
+                result
+            })
+        };
+
+        // Give both tasks time to register / clone the Shared.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(
+            policy.in_flight_count(),
+            1,
+            "after analyzer + awaiter, exactly one in-flight key"
+        );
+
+        // (3) Cancel the analyzer task. With the old model, this would
+        // remove the in_flight entry. With #1235 the awaiter's
+        // refcount keeps it alive.
+        analyzer_handle.abort();
+        let _ = analyzer_handle.await; // observe the cancellation
+
+        // The entry MUST still be in the map because the awaiter holds
+        // a guard. Pre-#1235 this assertion failed.
+        assert_eq!(
+            policy.in_flight_count(),
+            1,
+            "analyzer cancellation must NOT evict the entry — \
+             awaiter still holds the Shared (#1235)"
+        );
+
+        // (4) NEW caller arrives. With #1235 it joins the awaiter's
+        // Shared. Pre-#1235 it would have started fresh work.
+        let new_caller_handle = {
+            let policy = Arc::clone(&policy);
+            let key = key.clone();
+            tokio::spawn(async move {
+                policy
+                    .single_flight(
+                        key,
+                        async move {
+                            // Should NEVER run: joins existing Shared.
+                            Ok::<usize, String>(999)
+                        }
+                        .boxed(),
+                    )
+                    .await
+            })
+        };
+
+        // Give new caller time to enter single_flight + bump refcount.
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+        // Release the original work future. Awaiter + new caller both
+        // observe its result via the same Shared.
+        release.notify_waiters();
+
+        let awaiter_result = awaiter_handle.await.unwrap();
+        let new_caller_result = new_caller_handle.await.unwrap();
+
+        assert_eq!(
+            awaiter_result,
+            Ok(7),
+            "awaiter should see the original work's result"
+        );
+        assert_eq!(
+            new_caller_result,
+            Ok(7),
+            "NEW caller MUST see the SAME shared result, not a fresh \
+             work-future's value (would be 999 if duplicate work ran)"
+        );
+        assert_eq!(
+            producers.load(Ordering::Acquire),
+            1,
+            "work-future producer body must have run EXACTLY ONCE \
+             across analyzer + awaiter + new-caller (the contract \
+             #1235 enforces). Pre-#1235 this would have been 2 \
+             because the new caller started a duplicate after the \
+             analyzer's guard evicted the entry."
+        );
+        assert_eq!(
+            policy.in_flight_count(),
+            0,
+            "all callers complete → refcount → 0 → entry evicted"
+        );
+    }
+
+    /// What this catches: regression in the all-callers-cancelled path.
+    /// If every holder drops without completing, the entry should be
+    /// removed (refcount → 0) and a brand-new caller for the same key
+    /// should correctly start fresh — the prior abandoned work is
+    /// no longer of interest to anyone.
+    #[tokio::test]
+    async fn all_callers_cancelled_evicts_entry_for_fresh_start() {
+        let policy = Arc::new(TokioConcurrencyPolicy::<String, usize, String>::new());
+        let producers = Arc::new(AtomicUsize::new(0));
+        let key = "k".to_string();
+
+        // Two cancellable callers, both holding the same key.
+        let release_never = Arc::new(tokio::sync::Notify::new());
+        let make_caller = || {
+            let policy = Arc::clone(&policy);
+            let producers = Arc::clone(&producers);
+            let release = Arc::clone(&release_never);
+            let key = key.clone();
+            tokio::spawn(async move {
+                policy
+                    .single_flight(
+                        key,
+                        async move {
+                            producers.fetch_add(1, Ordering::AcqRel);
+                            release.notified().await;
+                            Ok::<usize, String>(1)
+                        }
+                        .boxed(),
+                    )
+                    .await
+            })
+        };
+
+        let a = make_caller();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        let b = make_caller();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        assert_eq!(policy.in_flight_count(), 1);
+
+        // Cancel both — entry should evict cleanly.
+        a.abort();
+        b.abort();
+        let _ = a.await;
+        let _ = b.await;
+        // Yield so the abort drops + Drop chain run.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        assert_eq!(
+            policy.in_flight_count(),
+            0,
+            "all guards dropped → entry evicted"
+        );
+
+        // Fresh caller for the same key: starts fresh work (the prior
+        // abandoned work is gone).
+        let result = policy
+            .single_flight(key, async move { Ok::<usize, String>(42) }.boxed())
+            .await;
+        assert_eq!(result, Ok(42), "fresh caller after eviction succeeds");
+        assert_eq!(policy.in_flight_count(), 0);
+    }
+
     #[tokio::test]
     async fn bounded_caps_concurrent_work() {
         let policy = Arc::new(TokioConcurrencyPolicy::<String, (), ()>::with_limit(2));


### PR DESCRIPTION
Closes #1235.

## Bug

Pre-#1235 only the analyzer (first caller for a key) held the Drop guard for the in_flight entry. That correctly fixed the panic-cleanup case (#1232) but left a window during analyzer cancellation:

\`\`\`
T0: analyzer.single_flight(\"k\") creates entry, holds guard
T1: awaiter1.single_flight(\"k\") clones the Shared, no guard
T2: analyzer task is cancelled
T3: analyzer's guard.drop fires, removes entry from in_flight
T4: NEW caller.single_flight(\"k\") finds no entry, starts FRESH work
    — duplicate inference for the same key, contract violated.
    awaiter1 still completes the original Shared.
\`\`\`

Codex flagged this on #1233 review. The result is two concurrent inference invocations for the same key — exactly what \`single_flight\` is supposed to prevent.

## Fix

Every caller (analyzer + awaiters) now holds a \`RefCountGuard\`. The HashMap value becomes \`KeyEntry { shared, refcount: Arc<AtomicUsize> }\`. Each caller bumps the refcount under the in_flight lock when constructing its guard; each guard drops decrement it. The entry is removed only when refcount hits zero — and only after a **double-check under the lock** to handle the race where a brand-new caller bumps the refcount between fetch_sub and lock acquisition.

### Race-safety walk-through

\`\`\`
T0: caller A guard drops → refcount.fetch_sub: 1 → 0
T1: caller A blocks on Mutex.lock()
T2: caller B enters single_flight, locks first, sees entry
    (still in map), refcount.fetch_add: 0 → 1, clones Shared,
    releases lock
T3: caller A acquires lock, double-checks refcount under lock,
    sees 1, does NOT remove. Caller B's expected entry stays.
\`\`\`

If no caller B arrived: A's double-check sees 0 and removes the entry. A new caller after that point sees no entry and starts fresh — correct since no one was waiting for the abandoned work.

### Panic behavior preserved

If the work future panics, the panic re-raises through every Shared clone. All guards drop during unwind, refcount → 0, entry removed. Same end state as #1232 (the existing \`single_flight_drop_guard_clears_in_flight_on_panic\` test still passes unchanged).

## Tests

Two new tests prove the fix; both would FAIL on pre-#1235 code:

- **\`analyzer_cancellation_does_not_evict_entry_while_awaiters_hold_it\`** — analyzer + awaiter both register; analyzer is aborted; new caller arrives during the cancellation window. Asserts in_flight stays at 1 across the analyzer drop, work-future producer body runs **exactly once** across all three callers, and the new caller's result equals the original (joined the same Shared, didn't start fresh).

- **\`all_callers_cancelled_evicts_entry_for_fresh_start\`** — both holders cancelled before completion; asserts refcount → 0, entry evicted, and a fresh caller for the same key starts fresh work.

## Verification

- \`cargo check --features metal,accelerate -p continuum-core\` — clean.
- \`cargo test --features metal,accelerate -p continuum-core --lib concurrency::tests\` — **6 passed, 0 failed** (4 existing + 2 new).

## Trait/contract

\`ConcurrencyPolicy\` trait surface is unchanged (\`single_flight\` + \`in_flight_count\`). All callers continue to use it without modification — only the \`TokioConcurrencyPolicy\` implementation changed. Future implementations of the trait must enforce the same single-producer-per-key contract; this PR documents the precise semantics in the \`RefCountGuard\` doc comment.

## Authorship note

#1235 was originally codex's review nit on #1233. Card was claimed by airc-8a5e-bc43 (the other claude tab) but they were occupied with the merge lane; I picked it up after re-pinging on design and getting no response (offered to take it as PR-3). Happy to fold any review notes from the original card-owner.