### PR TITLE
fix(chat,#1159): URLCardAdapter HTML-escape every interpolation + safe-href guard

### DIFF
--- a/src/tests/unit/url-card-adapter-xss.spec.ts
+++ b/src/tests/unit/url-card-adapter-xss.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * URLCardAdapter XSS hardening tests (#1159).
+ *
+ * Asserts that every interpolation site in `renderContent` escapes
+ * attacker-controlled input AND that `href="${url}"` neutralizes
+ * `javascript:` / `data:` / `vbscript:` schemes. These are the gaps
+ * left open by PR-1 (which only closed the `innerHTML` Lit-reactivity
+ * hole) and called out in the PR-1 doc comment as "the URL-metadata
+ * XSS surface" requiring a follow-up PR.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { URLCardAdapter } from '../../widgets/chat/adapters/URLCardAdapter';
+
+type RenderableData = {
+  url: string;
+  title?: string;
+  description?: string;
+  siteName?: string;
+  favicon?: string;
+  imageUrl?: string;
+  domain: string;
+  isSecure: boolean;
+  originalText: string;
+};
+
+function renderWith(overrides: Partial<RenderableData>): string {
+  const adapter = new URLCardAdapter();
+  const data: RenderableData = {
+    url: 'https://example.com/x',
+    title: 'Title',
+    description: 'Description',
+    siteName: 'example.com',
+    favicon: 'https://example.com/favicon.ico',
+    domain: 'example.com',
+    isSecure: true,
+    originalText: 'check this https://example.com/x',
+    ...overrides,
+  };
+  // renderContent is the string-builder path; renderMessageElement
+  // runs the same string through `template.innerHTML` materialization,
+  // so the string-level escape is the load-bearing surface.
+  return adapter.renderContent(data as never, 'user-id');
+}
+
+describe('URLCardAdapter XSS — per-field HTML escape', () => {
+  it('escapes <script> in the additional-text slot (originalText)', () => {
+    const html = renderWith({
+      url: 'https://example.com/x',
+      originalText: '<script>alert(1)</script> https://example.com/x',
+    });
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('escapes <script> in the title field', () => {
+    const html = renderWith({ title: '<script>alert("title")</script>' });
+    expect(html).not.toContain('<script>alert("title")</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('escapes <script> in the description field', () => {
+    const html = renderWith({ description: '<img src=x onerror=alert(1)>' });
+    expect(html).not.toContain('<img src=x onerror=alert(1)>');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('escapes <script> in the siteName field', () => {
+    const html = renderWith({ siteName: '"><script>alert("siteName")</script>' });
+    expect(html).not.toContain('"><script>alert("siteName")</script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&quot;&gt;&lt;script&gt;');
+  });
+
+  it('escapes the favicon URL (belt-and-suspenders)', () => {
+    const html = renderWith({
+      favicon: 'https://google.com/favicons?domain=evil"onerror=alert(1)',
+    });
+    expect(html).not.toContain('"onerror=alert(1)');
+    expect(html).toContain('&quot;onerror=alert(1)');
+  });
+
+  it('escapes the domain field (used in 3 places)', () => {
+    const html = renderWith({ domain: '"><script>alert("domain")</script>' });
+    expect(html).not.toContain('"><script>alert("domain")</script>');
+    expect(html).toContain('&quot;&gt;&lt;script&gt;');
+  });
+});
+
+describe('URLCardAdapter XSS — attribute-context escape', () => {
+  it('escapes double-quote breakout in the URL attribute (data-url + title=)', () => {
+    const html = renderWith({
+      url: 'https://example.com/x"><script>alert(1)</script>',
+    });
+    expect(html).not.toContain('"><script>');
+    expect(html).toMatch(/data-url="https:\/\/example\.com\/x&quot;&gt;&lt;script&gt;/);
+    expect(html).toMatch(/title="https:\/\/example\.com\/x&quot;&gt;&lt;script&gt;/);
+  });
+
+  it('escapes & properly so &amp; is not double-encoded', () => {
+    const html = renderWith({ title: 'A & B' });
+    expect(html).toContain('A &amp; B');
+    expect(html).not.toContain('&amp;amp;');
+  });
+});
+
+describe('URLCardAdapter XSS — href scheme neutralization', () => {
+  it('neutralizes javascript: URL in the href slot', () => {
+    const html = renderWith({ url: 'javascript:alert(1)' });
+    expect(html).toMatch(/href="#"/);
+    expect(html).not.toMatch(/href="javascript:/i);
+  });
+
+  it('neutralizes case-mixed JavaScript: URL in the href slot', () => {
+    const html = renderWith({ url: 'JaVaScRiPt:alert(1)' });
+    expect(html).toMatch(/href="#"/);
+    expect(html).not.toMatch(/href="JaVaScRiPt:/);
+  });
+
+  it('neutralizes data: URL in the href slot', () => {
+    const html = renderWith({ url: 'data:text/html,<script>alert(1)</script>' });
+    expect(html).toMatch(/href="#"/);
+    expect(html).not.toMatch(/href="data:/);
+  });
+
+  it('neutralizes vbscript: URL in the href slot', () => {
+    const html = renderWith({ url: 'vbscript:msgbox(1)' });
+    expect(html).toMatch(/href="#"/);
+    expect(html).not.toMatch(/href="vbscript:/);
+  });
+});
+
+describe('URLCardAdapter XSS — href whitelist preservation', () => {
+  it('preserves http://, https://, mailto:, tel:, ftp: in the href slot', () => {
+    for (const safeUrl of [
+      'http://example.com/x',
+      'https://example.com/x',
+      'mailto:hi@example.com',
+      'tel:+15555550123',
+      'ftp://ftp.example.com/file',
+    ]) {
+      const html = renderWith({ url: safeUrl });
+      expect(html).toContain(`href="${safeUrl}"`);
+    }
+  });
+
+  it('preserves protocol-relative URLs in the href slot', () => {
+    const html = renderWith({ url: '//cdn.example.com/asset' });
+    expect(html).toContain('href="//cdn.example.com/asset"');
+  });
+
+  it('preserves same-document fragment URLs in the href slot', () => {
+    const html = renderWith({ url: '#section-1' });
+    expect(html).toContain('href="#section-1"');
+  });
+
+  it('treats empty/whitespace URL as #', () => {
+    const empty = renderWith({ url: '' });
+    expect(empty).toMatch(/href="#"/);
+    const ws = renderWith({ url: '   ' });
+    expect(ws).toMatch(/href="#"/);
+  });
+});

--- a/src/tsconfig.eslint.json
+++ b/src/tsconfig.eslint.json
@@ -18,6 +18,7 @@
     "generator/generate-command-schemas.ts",
     "widgets/**/*.ts",
     "tests/workers/**/*.ts",
+    "tests/unit/url-card-adapter-xss.spec.ts",
     "test-path-aliases.ts",
     "test-path-aliases-runtime.ts"
   ],

--- a/src/widgets/chat/adapters/URLCardAdapter.ts
+++ b/src/widgets/chat/adapters/URLCardAdapter.ts
@@ -72,7 +72,26 @@ export class URLCardAdapter extends AbstractMessageAdapter<URLCardData> {
   }
 
   /**
-   * Render rich URL card with metadata
+   * Render rich URL card with metadata.
+   *
+   * **XSS hardening (#1159 — closes the metadata-XSS surface PR-1
+   * deferred):** every interpolation is now passed through `escapeHtml`
+   * before landing in the HTML template. Three classes of input feed
+   * the template:
+   *   1. Raw user text (`originalText`, `additionalText`) — directly
+   *      from chat content, fully attacker-controlled.
+   *   2. Parsed URL fields (`url`, `domain`, `siteName` initial value)
+   *      — parsed via `new URL()` so the hostname is structurally
+   *      safe, but `url` itself is the raw input string and may
+   *      contain quotes, angle brackets, or a `javascript:` scheme.
+   *   3. Async metadata (`title`, `description`, `siteName` post-fetch
+   *      via `updateCardWithMetadata`) — fetched from a remote URL,
+   *      attacker-controlled in the worst case.
+   *
+   * The `href="${url}"` slot additionally goes through `safeHref` to
+   * neutralize `javascript:` / `data:` / `vbscript:` URLs (these
+   * become `#` so a click does nothing instead of executing script in
+   * the page's origin).
    */
   renderContent(data: URLCardData, currentUserId: string): string {
     const { url, title, description, siteName, favicon, domain, isSecure, originalText } = data;
@@ -81,11 +100,20 @@ export class URLCardAdapter extends AbstractMessageAdapter<URLCardData> {
     // Extract any text that isn't the URL
     const additionalText = originalText.replace(url, '').trim();
 
+    const safeAdditionalText = this.escapeHtml(additionalText);
+    const safeUrlAttr = this.escapeHtml(url);
+    const safeFavicon = this.escapeHtml(favicon ?? '');
+    const safeDomain = this.escapeHtml(domain);
+    const safeSiteName = this.escapeHtml(siteName ?? domain);
+    const safeTitle = this.escapeHtml(title ?? '');
+    const safeDescription = this.escapeHtml(description ?? '');
+    const safeHrefValue = this.escapeHtml(this.safeHref(url));
+
     return `
       <div class="url-card-content">
-        ${additionalText ? `<div class="url-message-text">${additionalText}</div>` : ''}
+        ${additionalText ? `<div class="url-message-text">${safeAdditionalText}</div>` : ''}
 
-        <div class="url-card" data-card-id="${cardId}" data-url="${url}" data-action="url-card-click">
+        <div class="url-card" data-card-id="${cardId}" data-url="${safeUrlAttr}" data-action="url-card-click">
           <div class="url-card-loading" style="display: block;">
             <div class="loading-spinner"></div>
             <span class="loading-text">Loading preview...</span>
@@ -93,11 +121,11 @@ export class URLCardAdapter extends AbstractMessageAdapter<URLCardData> {
 
           <div class="url-card-content-area" style="display: none;">
             <div class="url-card-header">
-              <img src="${favicon}" alt="${domain} favicon" class="site-favicon" loading="lazy" />
+              <img src="${safeFavicon}" alt="${safeDomain} favicon" class="site-favicon" loading="lazy" />
               <div class="site-info">
-                <span class="site-name">${siteName}</span>
+                <span class="site-name">${safeSiteName}</span>
                 <span class="url-domain ${isSecure ? 'secure' : 'insecure'}">
-                  ${isSecure ? '🔒' : '🔓'} ${domain}
+                  ${isSecure ? '🔒' : '🔓'} ${safeDomain}
                 </span>
               </div>
               <div class="card-actions">
@@ -107,10 +135,10 @@ export class URLCardAdapter extends AbstractMessageAdapter<URLCardData> {
             </div>
 
             <div class="url-card-body">
-              <h3 class="url-title">${title}</h3>
-              <p class="url-description">${description}</p>
+              <h3 class="url-title">${safeTitle}</h3>
+              <p class="url-description">${safeDescription}</p>
               <div class="url-metadata">
-                <span class="url-full" title="${url}">${url}</span>
+                <span class="url-full" title="${safeUrlAttr}">${safeUrlAttr}</span>
               </div>
             </div>
 
@@ -123,17 +151,64 @@ export class URLCardAdapter extends AbstractMessageAdapter<URLCardData> {
             <div class="error-content">
               <span class="error-icon">🔗</span>
               <span class="error-text">Preview unavailable</span>
-              <button class="retry-preview" data-action="url-retry-preview" data-url="${url}">Retry</button>
+              <button class="retry-preview" data-action="url-retry-preview" data-url="${safeUrlAttr}">Retry</button>
             </div>
             <div class="fallback-link">
-              <a href="${url}" target="_blank" rel="noopener noreferrer" class="external-link-fallback">
-                ${url}
+              <a href="${safeHrefValue}" target="_blank" rel="noopener noreferrer" class="external-link-fallback">
+                ${safeUrlAttr}
               </a>
             </div>
           </div>
         </div>
       </div>
     `;
+  }
+
+  /**
+   * HTML-escape the 5 dangerous characters. Same shape as
+   * TextMessageAdapter.escapeHtml — the canonical pattern in this
+   * codebase. Safe in both text-content and double-quoted-attribute
+   * contexts because it escapes both `"` and `'`.
+   */
+  private escapeHtml(unsafe: string): string {
+    return unsafe
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  /**
+   * Neutralize dangerous URL schemes so `<a href="${safeHref(url)}">`
+   * cannot execute script. Whitelist approach: keep http/https/mailto/
+   * tel/ftp/sftp + protocol-relative + same-document fragments;
+   * otherwise return `#` (renders as a no-op click).
+   *
+   * Why a whitelist not a blacklist: a blacklist of `javascript:` /
+   * `data:` / `vbscript:` misses `\tjavascript:` (control-character
+   * smuggling), `JaVaScRiPt:` case mixing, `&NewLine;javascript:`
+   * (HTML-entity smuggling once the attribute is decoded), and any
+   * future scheme that turns out to be code-executing. Whitelist of
+   * known-safe schemes is the only audit-once approach.
+   */
+  private safeHref(url: string): string {
+    if (typeof url !== 'string' || url.length === 0) return '#';
+    const trimmed = url.trim();
+    if (trimmed.length === 0) return '#';
+    // Same-document fragment + protocol-relative URLs — both safe.
+    if (trimmed.startsWith('#') || trimmed.startsWith('//')) return trimmed;
+    // Schemed URL — only allow the audit-once safe set. Match scheme
+    // case-insensitively because the URL spec is case-insensitive.
+    const schemeMatch = trimmed.match(/^([a-z][a-z0-9+.\-]*):/i);
+    if (!schemeMatch) {
+      // No scheme — relative URL. Safe (cannot escape the document
+      // origin without a scheme).
+      return trimmed;
+    }
+    const scheme = schemeMatch[1].toLowerCase();
+    const safeSchemes = new Set(['http', 'https', 'mailto', 'tel', 'ftp', 'sftp']);
+    return safeSchemes.has(scheme) ? trimmed : '#';
   }
 
   /**


### PR DESCRIPTION
Closes #1159 (PR-3 of #1100). Closes the URL-metadata-XSS surface PR-1 explicitly deferred (its doc comment named this slice).

## Vulnerability

URLCardAdapter.renderContent built card HTML by string-interpolating 9 attacker-controlled fields without escaping (originalText, url, title, description, siteName, favicon, domain×3). Two attack classes were live: HTML injection via any field, AND scheme injection via `<a href="${url}">` accepting `javascript:` / `data:` / `vbscript:` URLs.

## Fix

1. **escapeHtml(s)** — same canonical 5-char escape used in TextMessageAdapter. Safe in both text and double-quoted attribute contexts.
2. **safeHref(url)** — whitelist neutralizer. Returns `#` for any scheme outside the audit-once safe set (http, https, mailto, tel, ftp, sftp). Whitelist not blacklist because blacklists miss `\tjavascript:`, case-mixing, HTML-entity smuggling.
3. **Apply at every interpolation** in renderContent.

## Tests

16 tests in tests/unit/url-card-adapter-xss.spec.ts, all pass. Four describe blocks (per-field escape, attribute-context escape, href scheme neutralization, href whitelist preservation) so each stays under the 80-line/function limit. Each test asserts BOTH "raw injection MUST NOT appear" and "escaped form MUST appear".

File is `.spec.ts` not `.test.ts` to bypass tsconfig.eslint.json exclude — file is type-aware lint-clean. ESLint baseline unchanged at 5461 (no drift). TypeScript build clean. Honors the airc-8a5e "no baseline bumps or parse-error debt for new test code" direction.

## Path

PR-1 (#1154) closed innerHTML hole, deferred metadata XSS. PR-3 (this) closes the deferred metadata XSS. URLCardAdapter is now safe against the full audit set called out in the original Joel review nit.

Refs #1100.