### PR TITLE
feat(commands): RustBackedCommand base + first refactor (#1198)

### DIFF
--- a/src/commands/cognition/admit-inbox-message/server/CognitionAdmitInboxMessageServerCommand.ts
+++ b/src/commands/cognition/admit-inbox-message/server/CognitionAdmitInboxMessageServerCommand.ts
@@ -11,9 +11,15 @@
  * "if not UI/UX it is rust" rule: this TS file exists ONLY so the
  * recipe pipeline + ./jtag CLI can route through `Commands.execute`.
  * It is a thin bridge. No business logic. No reimplementation.
+ *
+ * **Refactored to RustBackedCommand (#1198):** the standard validate +
+ * call mixin + wrap-result envelope is now in the base class. Only the
+ * variable bits — required-param list, mixin call, result mapping —
+ * remain here. See `RustBackedCommand.ts` for the migration pattern.
  */
 
-import { CommandBase, type ICommandDaemon } from '@daemons/command-daemon/shared/CommandBase';
+import type { ICommandDaemon } from '@daemons/command-daemon/shared/CommandBase';
+import { RustBackedCommand } from '@daemons/command-daemon/shared/RustBackedCommand';
 import type { JTAGContext } from '@system/core/types/JTAGTypes';
 import { ValidationError } from '@system/core/types/ErrorTypes';
 import type {
@@ -21,44 +27,62 @@ import type {
   CognitionAdmitInboxMessageResult,
 } from '../shared/CognitionAdmitInboxMessageTypes';
 import { createCognitionAdmitInboxMessageResultFromParams } from '../shared/CognitionAdmitInboxMessageTypes';
-import { RustCoreIPCClient } from '../../../../workers/continuum-core/bindings/RustCoreIPC';
+import type { RustCoreIPCClient } from '../../../../workers/continuum-core/bindings/RustCoreIPC';
 import type { InboxMessageRequest } from '../../../../shared/generated';
 
-export class CognitionAdmitInboxMessageServerCommand extends CommandBase<
+/** Snake-case shape returned by the Rust mixin — matches the IPC payload. */
+type AdmitInboxMessageRustResponse = {
+  decision: unknown;
+  engram_count: number;
+  trace_seam_count: number;
+};
+
+export class CognitionAdmitInboxMessageServerCommand extends RustBackedCommand<
   CognitionAdmitInboxMessageParams,
-  CognitionAdmitInboxMessageResult
+  CognitionAdmitInboxMessageResult,
+  AdmitInboxMessageRustResponse
 > {
+  protected override readonly requiredParams = ['personaId', 'message'] as const;
+
   constructor(context: JTAGContext, subpath: string, commander: ICommandDaemon) {
     super('cognition/admit-inbox-message', context, subpath, commander);
   }
 
-  async execute(
-    params: CognitionAdmitInboxMessageParams,
-  ): Promise<CognitionAdmitInboxMessageResult> {
-    if (!params.personaId || params.personaId.trim() === '') {
-      throw new ValidationError(
-        'personaId',
-        `Missing required parameter 'personaId'. Provide the UUID of the persona whose admission gate should run. See the cognition/admit-inbox-message README for usage.`,
-      );
-    }
-    if (!params.message || typeof params.message !== 'object') {
+  /**
+   * Subclass override: `message` must be a non-null object, not just
+   * truthy. The base class default checks for non-empty strings; this
+   * shape constraint is command-specific.
+   */
+  protected override validateParams(params: CognitionAdmitInboxMessageParams): void {
+    super.validateParams(params);
+    if (typeof params.message !== 'object' || params.message === null) {
       throw new ValidationError(
         'message',
-        `Missing required parameter 'message'. Provide an InboxMessageRequest object — the candidate inbox message to admit. See shared/generated/ipc/InboxMessageRequest.ts for shape.`,
+        `Required parameter 'message' must be an InboxMessageRequest object — ` +
+          `see shared/generated/ipc/InboxMessageRequest.ts for shape.`,
       );
     }
+  }
 
-    const client = await RustCoreIPCClient.getInstanceAsync();
-    const { decision, engram_count, trace_seam_count } = await client.cognitionAdmitInboxMessage(
+  protected override async callRust(
+    params: CognitionAdmitInboxMessageParams,
+    client: RustCoreIPCClient,
+  ): Promise<AdmitInboxMessageRustResponse> {
+    return client.cognitionAdmitInboxMessage(
       params.personaId,
       params.message as unknown as InboxMessageRequest,
     );
+  }
 
+  protected override toResult(
+    raw: AdmitInboxMessageRustResponse,
+    params: CognitionAdmitInboxMessageParams,
+  ): CognitionAdmitInboxMessageResult {
     return createCognitionAdmitInboxMessageResultFromParams(params, {
       success: true,
-      decision: decision as unknown as Record<string, unknown>,
-      engramCount: engram_count,
-      traceSeamCount: trace_seam_count,
+      decision: raw.decision as Record<string, unknown>,
+      engramCount: raw.engram_count,
+      traceSeamCount: raw.trace_seam_count,
     });
   }
 }

--- a/src/daemons/command-daemon/shared/RustBackedCommand.ts
+++ b/src/daemons/command-daemon/shared/RustBackedCommand.ts
@@ -1,0 +1,126 @@
+/**
+ * RustBackedCommand — base class for the standard "validate → call mixin →
+ * wrap result" envelope shared by every TS command that exists ONLY to
+ * route into a Rust IPC handler (#1198).
+ *
+ * # Why this exists
+ *
+ * Per Joel's "TS moves DOWN into rust… if not UI/UX it is rust" rule
+ * (2026-05-14), every Rust-backed TS command in `src/commands/*` does
+ * the same five things in the same order:
+ *
+ *   1. Validate the required params (throw `ValidationError` with a
+ *      consistent message + missing-field name)
+ *   2. Resolve the Rust IPC client singleton
+ *   3. Call the typed mixin method on the client
+ *   4. Translate the snake_case Rust response into the camelCase
+ *      `Result` shape via `createXResultFromParams`
+ *   5. Return the wrapped result
+ *
+ * Steps 1, 2, and 5 are pure boilerplate. Steps 3 and 4 are the only
+ * variable bits per command. The pre-#1198 status quo was every command
+ * re-writing the boilerplate inline, ~30 LOC of envelope around ~5 LOC
+ * of actual call. That's uncompressed redundancy → drift target (the
+ * specific drift the compression principle in CLAUDE.md exists to
+ * prevent).
+ *
+ * # How to use
+ *
+ * Subclass declares: `requiredParams` (which fields must be non-empty),
+ * `callRust(params, client)` (the variable mixin call), and
+ * `toResult(raw, params)` (the variable result wrapping). Base class
+ * owns: validation loop, client resolution, error consistency.
+ *
+ * See `commands/cognition/admit-inbox-message/server/CognitionAdmitInboxMessageServerCommand.ts`
+ * for the canonical example refactored under #1198.
+ *
+ * # Why TRest is generic (not `unknown`)
+ *
+ * Each subclass knows the exact mixin response shape (it's a typed
+ * ts-rs export). Threading it through `TRest` lets `toResult` be
+ * type-safe instead of carrying an `unknown` cast. Subclasses that
+ * don't care can use `unknown` explicitly.
+ *
+ * # Custom validation
+ *
+ * Subclasses that need richer per-field validation than non-empty
+ * (e.g., shape constraints like `typeof params.message === 'object'`)
+ * override `validateParams(params)` and call `super.validateParams(params)`
+ * BEFORE adding their custom checks. This preserves the consistent
+ * required-field behavior.
+ */
+
+import { CommandBase, type ICommandDaemon } from './CommandBase';
+import type {
+  CommandParams,
+  CommandResult,
+  JTAGContext,
+} from '../../../system/core/types/JTAGTypes';
+import { ValidationError } from '../../../system/core/types/ErrorTypes';
+import { RustCoreIPCClient } from '../../../workers/continuum-core/bindings/RustCoreIPC';
+
+export abstract class RustBackedCommand<
+  TParams extends CommandParams,
+  TResult extends CommandResult,
+  TRest = unknown,
+> extends CommandBase<TParams, TResult> {
+  /**
+   * Names of params this command requires to be present + non-empty.
+   * The base class throws `ValidationError` with a consistent message
+   * that names the offending field and points at the command's README.
+   */
+  protected abstract readonly requiredParams: ReadonlyArray<keyof TParams>;
+
+  constructor(
+    name: string,
+    context: JTAGContext,
+    subpath: string,
+    commander: ICommandDaemon,
+  ) {
+    super(name, context, subpath, commander);
+  }
+
+  /**
+   * Subclass implements the actual mixin invocation. The base class
+   * has already validated `requiredParams` and resolved `client`.
+   */
+  protected abstract callRust(
+    params: TParams,
+    client: RustCoreIPCClient,
+  ): Promise<TRest>;
+
+  /**
+   * Subclass translates the raw Rust response (snake_case) into the
+   * camelCase `Result` type, typically via the per-command
+   * `createXResultFromParams(...)` factory.
+   */
+  protected abstract toResult(raw: TRest, params: TParams): TResult;
+
+  /**
+   * Common required-param check. Subclasses with richer needs override
+   * and call `super.validateParams(params)` first.
+   */
+  protected validateParams(params: TParams): void {
+    for (const key of this.requiredParams) {
+      const value = (params as Record<string, unknown>)[key as string];
+      const missing =
+        value === undefined ||
+        value === null ||
+        (typeof value === 'string' && value.trim() === '');
+      if (missing) {
+        throw new ValidationError(
+          String(key),
+          `Missing required parameter '${String(key)}'. ` +
+            `See the ${this.name} README for usage.`,
+        );
+      }
+    }
+  }
+
+  override async execute(params: TParams): Promise<TResult> {
+    this.validateParams(params);
+    const client = await RustCoreIPCClient.getInstanceAsync();
+    const raw = await this.callRust(params, client);
+    return this.toResult(raw, params);
+  }
+}


### PR DESCRIPTION
Closes #1198 for the pattern + first migration. Per Joel's "TS moves DOWN into rust… if not UI/UX it is rust" rule (2026-05-14).

## Smell

Every TS command in `src/commands/*` that exists only to route into a Rust IPC handler does the same five things in the same order:

1. Validate required params (throw `ValidationError` with consistent message + missing-field name)
2. Resolve the Rust IPC client singleton
3. Call the typed mixin method
4. Translate snake_case Rust response → camelCase Result via `createXResultFromParams`
5. Return the wrapped result

Steps 1, 2, and 5 are pure boilerplate (~30 LOC per command). Steps 3 and 4 are the only variable bits. Pre-#1198 status quo: every command re-wrote the boilerplate inline — exactly the uncompressed redundancy the compression principle exists to prevent.

## What this PR adds

### `RustBackedCommand<TParams, TResult, TRest>` base class

`daemons/command-daemon/shared/RustBackedCommand.ts`:
- Subclass declares `requiredParams` (which fields must be non-empty).
- Subclass implements `callRust(params, client)` (variable mixin call) and `toResult(raw, params)` (variable result wrapping).
- Base class owns: validation loop, client resolution, error consistency, the `execute()` orchestration.
- `validateParams()` is overridable — subclasses needing richer shape constraints (e.g., typeof-object checks) call `super.validateParams(params)` then add their own.
- `TRest` generic threads the raw mixin response shape to `toResult` for type safety (no `unknown` cast at the seam).

### Canonical example refactor

`commands/cognition/admit-inbox-message/server/CognitionAdmitInboxMessageServerCommand.ts`. The original 64-line file becomes 85 lines, but most of the new lines are typed declarations (`requiredParams`, `AdmitInboxMessageRustResponse` type alias) that replace inline boilerplate. Every other command can adopt the same shape and lose ~30 LOC of envelope.

The refactored command preserves the existing custom message-shape validation (`typeof params.message !== 'object'` check) via the `validateParams` override pattern.

## Scope

This is **PR-1**: pattern + one example. Other ~50 Rust-backed commands adopt incrementally — don't churn-rewrite all in one PR. As each command picks up the base class it sheds ~30 LOC of envelope and inherits future improvements (consistent error format, future adapters between mixin and result, etc.) for free.

## Verification

- `npm run build:ts` clean.
- The refactored command is structurally simpler and the variable bits are explicitly named.