### PR TITLE
docs(architecture): codify recipe activity graph semantics

### DIFF
--- a/docs/activities/ROOMS-AND-ACTIVITIES.md
+++ b/docs/activities/ROOMS-AND-ACTIVITIES.md
@@ -8,6 +8,11 @@
 
 A **Room** is any shared experience involving any mix of humans and AIs.
 
+In Continuum's data model, **room** and **activity** name the same core
+thing from different angles: a room is the social/place metaphor; an
+activity is the executable/workflow node. Both refer to an instantiated
+context with identity, participants, state, and events.
+
 Not just chat channels. Not just drawing canvases. **Any experience:**
 
 - A 3D landscape you walk through together
@@ -80,6 +85,29 @@ Project: "Home Renovation"
 - "Spawning a research session to look that up"
 - They navigate the tree like anyone else
 
+## Graph Invariant: Pointers, Not Nested Blobs
+
+Continuum should model room/activity hierarchy as a graph. A parent
+activity stores references to child activities; it does not embed the
+children's live room state. The same applies in reverse: a child points
+at its parent and can traverse up for context, permissions, memory, or
+breadcrumbs.
+
+This keeps the system cheap to page, cache, synchronize, and move across
+machines:
+
+- Parent activity -> child activity IDs
+- Child activity -> parent activity ID
+- Recipe -> default child recipe IDs when a template wants to suggest a
+  structure
+- Live activity state -> its own entity, never duplicated into a recipe
+  or parent payload
+
+The UI can render this as a tree of tabs, but storage stays graph-shaped.
+That lets the same room/activity node appear in different views, be
+referenced from AIRC, or be paged through Rust-owned resource controls
+without copying content around.
+
 ## UI Model: Rooms = Tabs
 
 In the interface, each room is literally a tab. This provides:
@@ -133,6 +161,11 @@ Recipes are:
 - Forkable (customize someone else's)
 - Versionable (improve over time)
 - Experimental (try new concepts)
+
+A recipe defines the reusable content/activity template. Instantiating
+that recipe creates a room/activity node. The node owns runtime state;
+the recipe owns the shape and defaults. Sub-rooms are spawned as child
+nodes linked by IDs.
 
 ## The Magic: No "Share" Buttons
 

--- a/docs/activities/recipes/RECIPES.md
+++ b/docs/activities/recipes/RECIPES.md
@@ -22,6 +22,29 @@ Every recipe follows this pattern:
 3. **Execute Actions** - Do the thing (generate text, make game move, adjust LoRA weights)
 4. **Store Artifacts** - What gets saved/shared? (responses, screenshots, training data)
 
+## Template, Not Room State
+
+A recipe is a reusable template for a collaborative experience. It can
+define widgets, capabilities, command pipelines, context strategy,
+default child activities, and AI participation rules. It is not the live
+room/activity instance.
+
+When a recipe is instantiated, Continuum creates an activity/room entity:
+
+```
+RecipeEntity
+  -> ActivityEntity / RoomEntity
+      -> child ActivityEntity IDs
+      -> artifacts, events, participants, runtime state
+```
+
+The hierarchy is a graph of entity references. Recipes may point to other
+recipes as default child templates, but live child room state belongs on
+the child activity entity. Do not copy nested child room payloads into
+the parent or into the recipe. This keeps recipes shareable and
+versionable while letting runtime rooms be paged, cached, synchronized,
+and optimized independently.
+
 ## Recipe Entity Structure
 
 ```typescript

--- a/docs/architecture/FORGE-RECIPE-AS-ENTITY.md
+++ b/docs/architecture/FORGE-RECIPE-AS-ENTITY.md
@@ -3,6 +3,7 @@
 **Issue**: continuum#1164 (this design)
 **Status**: Reviewed — open questions resolved (see §7); ready for Phase 1
 **Pairs with**: [FORGE-ALLOY-SPEC.md](./FORGE-ALLOY-SPEC.md), [FORGE-ALLOY-DOMAIN-EXTENSIBILITY.md](./FORGE-ALLOY-DOMAIN-EXTENSIBILITY.md), [grid/FORGE-ALLOY-PROOF-CONTRACTS.md](../grid/FORGE-ALLOY-PROOF-CONTRACTS.md)
+**Graph invariant**: continuum#1266 (recipes are templates; instantiated rooms/activities are graph nodes)
 
 > **Continuum-wide pattern (per claude-tab-2 review).** The
 > `ForgeRecipe` (authored input) → `ForgeArtifact` (generated output)
@@ -22,6 +23,15 @@
 > output. The forge **never consumes a hand-authored alloy**; the foundry
 > generates it. The pattern matches how every other Continuum subsystem
 > works: data lives in entities, behavior lives in pipelines.
+
+> **Recipe graph rule.** A recipe is a reusable template. It defines the
+> content/activity shape, execution stages, capabilities, and defaults.
+> It is not the live room/activity itself. Running or instantiating a
+> recipe creates an entity with its own identity and lifecycle:
+> `ForgeRecipe -> ForgeArtifact` for model foundry work, and
+> `RecipeEntity -> ActivityEntity/RoomEntity` for collaborative
+> experiences. Parent/child structure stays graph-shaped through IDs and
+> edges, not copied nested state.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that recipes are reusable templates, not live room/activity state
- define room/activity as the same instantiated graph node from social vs workflow angles
- require parent/child activities to use references/edges rather than copied nested state
- cross-link the invariant from ForgeRecipe, room/activity, and recipe architecture docs

## Validation
- precommit: TypeScript build + browser ping
- pre-push: TypeScript + ESLint ratchet

Closes #1266