### PR TITLE
docs(grid): clarify AIRC pipeline and transport contracts

### DIFF
--- a/docs/grid/AIRC-CONTINUUM-BRIDGE.md
+++ b/docs/grid/AIRC-CONTINUUM-BRIDGE.md
@@ -4,19 +4,27 @@ Status: v0 development/test harness; target architecture for chat substrate
 migration.
 
 AIRC is the external collaboration wire and should become the primary
-transcript/message substrate. Continuum remains the runtime under test: it owns
-commands, persona behavior, model/runtime state, config, projections, and UI.
-The bridge lets agents speak over AIRC while Continuum consumes selected
-messages as runtime inputs or durable projections.
+handshake, initiation, and pipeline-control substrate. Continuum remains the
+runtime under test: it owns commands, persona behavior, model/runtime state,
+config, projections, and UI. The bridge lets agents speak over AIRC while
+Continuum consumes selected messages as runtime inputs or durable projections.
+
+Continuum messages are normal grid messages: commands, events, receipts,
+presence, "is thinking" signals, activity updates, artifact pointers, and
+session descriptors. AIRC coordinates who is speaking to whom, which room or
+node is involved, and which side channel should carry the high-rate or
+specialized traffic. The transport that actually moves bytes can vary per
+message or workflow.
 
 ## Shape
 
 ```text
-AIRC room/message
+AIRC handshake / room message / command envelope
   -> airc/bridge
   -> Continuum projection/command adapter
-  -> activity/list, rooms, assertions, persona/runtime inputs
-  -> optional airc CLI response
+  -> command/event/receipt/presence/activity message
+  -> optional side-channel transport (local IPC, tailnet, WebRTC/UDP, LAN)
+  -> optional airc CLI response or signed receipt
 ```
 
 Normal AIRC messages are mirrored into Continuum chat as:
@@ -47,8 +55,8 @@ memory candidate extraction, search/history projection, or UI display.
 The JTAG chat commands are compatibility/test plumbing, not the long-term live
 message bus. The migration target is:
 
-- `airc msg`, `airc logs`, and structured AIRC transcript APIs own live chat,
-  scrollback, cursors, receipts, and replay.
+- `airc msg`, `airc logs`, and structured AIRC transcript APIs own handshake,
+  initiation, room transcript, scrollback, cursors, receipts, and replay.
 - `airc send-file` and future attachment manifests own collaboration files and
   media pointers.
 - Continuum projects bounded transcript slices into storage for memory, search,
@@ -56,9 +64,30 @@ message bus. The migration target is:
 - Persona video/audio streams remain WebRTC/live transport. AIRC can carry
   session descriptors, tokens, room ids, and signaling pointers, but not the
   media stream itself.
+- UDP/WebRTC/tailnet/LAN/local IPC are side-channel transports. They are
+  selected by envelope policy and capability, not baked into the domain model.
 - Carl smoke and browser tests should move from JTAG chat commands to AIRC
   transcript APIs after CambrianTech/airc#563 provides structured history,
   cursor, and attachment output.
+
+## Layer Split
+
+The bridge keeps four concerns separate:
+
+1. **AIRC pipeline control** — identity, handshake, room membership, delivery
+   intent, command/event envelope, replay cursor, receipt pointer.
+2. **Continuum runtime messages** — typed commands, events, receipts, presence,
+   room activity, persona inputs, artifact handles, and projections.
+3. **Transport side channels** — local IPC, tailnet/Tailscale, WebRTC/UDP,
+   direct LAN, GitHub bridge, Reticulum/off-grid links, or future QUIC/UDP.
+4. **Forge-alloy-style work contracts** — invocable blueprints and proof
+   records for what work was requested, who authorized it, where it ran, and
+   what artifacts or security decisions were produced.
+
+AIRC starts and coordinates the pipeline. Continuum emits and consumes typed
+messages. The transport adapter moves each class of message over the right
+channel. Forge-alloy-style contracts make the work invocable, verifiable, and
+later billable without making the transport the source of truth.
 
 ## Boundary
 

--- a/docs/grid/GRID-ARCHITECTURE.md
+++ b/docs/grid/GRID-ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # The Grid: Architecture & Vision
 
-> **"The same two primitives that work across browser and server today work across Continuums via airc — no new protocol needed. Reticulum slots in as an alternative wire when off-grid scenarios demand it."**
+> **"The same two primitives that work across browser and server today work across Continuums via airc — no new protocol needed. AIRC coordinates the pipeline; transport side channels carry the right traffic; forge-alloy-style contracts make work invocable and verifiable."**
 
 ---
 
@@ -16,7 +16,18 @@ The Grid is a decentralized mesh of Continuum instances sharing compute, intelli
 
 ### What this looks like in practice TODAY
 
-The grid → grid comms substrate is **[airc](https://github.com/CambrianTech/airc)** — gh-rooted IRC over Tailscale. AI peers and engineers coordinate cross-machine via airc right now (zero-arg `airc connect` → auto-join `#general` on the user's gh account). The continuum-airc bridge layer (one airc citizen per persona) is the explicit work item once cognition fixes from #75 land. See [docs/grid/README.md](README.md) for the substrate architecture and the four-layer stack (wire, registry, UX, protocol) that any layer can be swapped without touching the others.
+The grid → grid comms substrate is **[airc](https://github.com/CambrianTech/airc)** — gh-rooted IRC over Tailscale today, evolving toward a Rust-owned handshake and pipeline-control layer. AI peers and engineers coordinate cross-machine via airc right now (zero-arg `airc connect` → auto-join `#general` on the user's gh account). The continuum-airc bridge layer (one airc citizen per persona) is the explicit work item once cognition fixes from #75 land. See [docs/grid/README.md](README.md) for the substrate architecture and the four-layer stack (wire, registry, UX, protocol) that any layer can be swapped without touching the others.
+
+The important abstraction is not "which socket moved the bytes." The grid is a
+distributed mesh of room/server-like nodes. AIRC initiates relationships,
+routes intent, records message flow, and coordinates command/event pipelines.
+Continuum messages are the domain payloads: commands, events, receipts,
+presence, room activity, artifact pointers, and security decisions. Transport
+side channels such as tailnet/Tailscale, WebRTC/UDP, local IPC, direct LAN,
+Reticulum, GitHub bridge, or future QUIC/UDP are adapters selected by policy
+and capability. Forge-alloy-style contracts describe the work and proof:
+who requested it, who authorized it, where it ran, what was produced, and how
+to verify it.
 
 **Document map:**
 
@@ -37,6 +48,43 @@ The grid → grid comms substrate is **[airc](https://github.com/CambrianTech/ai
 ---
 
 ## 2. Design Principles
+
+### 2.0 Contract-First Transport
+
+The grid is contract-first, transport-second. AIRC is the handshake and
+pipeline-control layer. It carries identity, room/channel membership,
+initiation, command/event envelopes, replay cursors, and receipt pointers.
+It does not have to carry every byte.
+
+Continuum emits and consumes typed grid messages:
+
+- commands
+- events
+- receipts
+- presence and "is thinking" signals
+- room/activity updates
+- artifact handles and proof-bundle pointers
+- security and quarantine decisions
+
+Transport side channels carry the traffic class they are good at:
+
+- local IPC for same-host control
+- tailnet/Tailscale for intragrid node control
+- WebRTC/UDP for live media or low-latency side channels
+- direct LAN for trusted local peers
+- GitHub bridge for durable coordination/bootstrap
+- Reticulum/off-grid links when infrastructure is unavailable
+- future QUIC/UDP for direct high-performance interlinks
+
+Forge-alloy-style contracts sit above transport. They are the invocable
+blueprints and proof records for distributed work: what was requested, what
+authority allowed it, what node executed it, what artifact or decision resulted,
+and what receipt proves it. Later, the same contract/receipt layer can support
+invoicing or settlement without changing how rooms and commands think.
+
+This keeps domain code future-proof. Rooms, recipes, personas, foundry, and
+Sentinel-AI interact through typed messages and contracts. Transport adapters
+change underneath without rewriting the domain model.
 
 ### 2.1 Accessibility First
 


### PR DESCRIPTION
## Summary
- document AIRC as handshake/initiation/pipeline control rather than raw transport for every byte
- define Continuum messages as typed commands/events/receipts/presence/activity updates
- separate transport side channels: local IPC, tailnet, WebRTC/UDP, LAN, GitHub bridge, Reticulum, future QUIC/UDP
- connect forge-alloy-style contracts to invocable/verifiable distributed work and future settlement hooks

## Validation
- precommit: TypeScript build + browser ping
- pre-push: TypeScript + ESLint ratchet

Refs #1267