### PR TITLE
fix(scripts,#1257): cargo-test.sh wrapper for platform GPU features

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -206,6 +206,7 @@
     "test:simple": "echo '🚀 SIMPLE TEST SUITE' && npx tsx tests/bootstrap-comprehensive.test.ts",
     "test:precommit": "./scripts/git-precommit.sh",
     "test:prepush": "./scripts/git-prepush.sh",
+    "test:rust": "./scripts/cargo-test.sh",
     "hooks:setup": "./scripts/setup-git-hooks.sh",
     "hooks:test": "echo '🧪 Testing all git hooks...' && echo '📋 Pre-commit:' && ./scripts/git-precommit.sh && echo '📋 Pre-push:' && ./scripts/git-prepush.sh && echo '✅ All hooks tested successfully'",
     "hooks:status": "echo '📋 Git Hook Status:' && ls -la .git/hooks/ | grep -E '(pre-commit|post-commit|pre-push)' && echo '' && echo '📁 Hook Scripts:' && ls -la scripts/git-*.sh",

--- a/src/scripts/cargo-test.sh
+++ b/src/scripts/cargo-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# cargo-test.sh — `cargo test` wrapper that auto-applies platform GPU features.
+#
+# Why this exists:
+#   continuum-core's vendored `llama` crate intentionally requires `--features
+#   metal` (macOS) or `--features cuda` (Linux+Nvidia) so the build refuses to
+#   produce a CPU-only inference binary (per the no-CPU-fallback alpha
+#   contract — see #1262 + tests/no_cpu_fallback_contract.rs). The guard is
+#   correct, but it makes the obvious developer command fail:
+#
+#     cd workers/continuum-core && cargo test tick_db_handle --lib
+#       → fails in the llama crate before the test runs
+#
+#   Fresh installs and agents repeatedly hit this. The fix is a wrapper that
+#   reuses the same `scripts/shared/cargo-features.sh` detector that build
+#   scripts and the precommit hook already source, so `cargo test` Just
+#   Works on every platform.
+#
+# Usage (from src/ — i.e. wherever scripts/ lives):
+#
+#   ./scripts/cargo-test.sh tick_db_handle --lib
+#   ./scripts/cargo-test.sh --test no_cpu_fallback_contract
+#   ./scripts/cargo-test.sh --lib -- --test-threads=1
+#
+# All arguments after the script name pass through to `cargo test`. The
+# wrapper appends the platform feature flags via $CARGO_GPU_FEATURES.
+#
+# Environment overrides (advanced):
+#   CARGO_TEST_RUST_PACKAGE  — workspace package to test (default: continuum-core)
+#   CARGO_TEST_NO_FEATURES=1 — skip the auto-feature append (CI-only debug;
+#                              the macOS llama guard will fail without it)
+#
+# Related (#1257): same pattern as `scripts/git-prepush.sh` Phase 3 cargo
+# test, hoisted from precommit-internal to a developer-facing entry point.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Source the platform GPU feature detector. This is the single source of
+# truth for "what features does this platform need?" — same file that
+# build-with-loud-failure.sh and git-prepush.sh source. Keeps this wrapper
+# from drifting from the rest of the build matrix.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/shared/cargo-features.sh"
+
+PACKAGE="${CARGO_TEST_RUST_PACKAGE:-continuum-core}"
+RUST_DIR="$SRC_DIR/workers/$PACKAGE"
+
+if [ ! -d "$RUST_DIR" ]; then
+  echo "ERROR: package directory not found: $RUST_DIR" >&2
+  echo "  Set CARGO_TEST_RUST_PACKAGE=<name> to target a different workspace package." >&2
+  exit 1
+fi
+
+if [ "${CARGO_TEST_NO_FEATURES:-0}" = "1" ]; then
+  echo "⚠️  CARGO_TEST_NO_FEATURES=1 — running without platform GPU features."
+  echo "    This will fail on macOS due to the no-CPU-fallback llama guard."
+  FEATURES_ARG=""
+else
+  FEATURES_ARG="$CARGO_GPU_FEATURES"
+fi
+
+echo "🧪 cargo test for $PACKAGE"
+echo "   features:    ${FEATURES_ARG:-<none — Linux CPU mode>}"
+echo "   args:        $*"
+echo "   cwd:         $RUST_DIR"
+echo
+
+cd "$RUST_DIR"
+# shellcheck disable=SC2086
+exec cargo test "$@" $FEATURES_ARG

--- a/src/workers/continuum-core/TESTING.md
+++ b/src/workers/continuum-core/TESTING.md
@@ -1,0 +1,86 @@
+# Testing `continuum-core`
+
+## TL;DR — use the wrapper
+
+```bash
+# From `src/`:
+./scripts/cargo-test.sh tick_db_handle --lib
+./scripts/cargo-test.sh --test no_cpu_fallback_contract
+./scripts/cargo-test.sh --lib -- --test-threads=1
+
+# Or via npm:
+npm run test:rust -- tick_db_handle --lib
+```
+
+The wrapper sources `scripts/shared/cargo-features.sh` to apply the
+right GPU feature flags for the current platform automatically.
+
+## Why a wrapper?
+
+The vendored `llama` crate intentionally requires `--features metal`
+(macOS) or `--features cuda` / `--features vulkan` (Linux) so the
+build refuses to produce a CPU-only inference binary — see the
+no-CPU-fallback alpha contract (`tests/no_cpu_fallback_contract.rs`,
+issue #1262).
+
+That guard is correct, but it makes the obvious developer command
+fail before the test runs:
+
+```bash
+cd workers/continuum-core && cargo test tick_db_handle --lib
+# → fails in the llama crate; "metal" or "cuda" feature required
+```
+
+Manually adding the right features per platform is repetitive and
+brittle (fresh installs, agents, and new contributors all hit it
+once before learning the incantation):
+
+```bash
+# macOS:
+cargo test tick_db_handle --lib --features metal,accelerate
+# Linux + Nvidia:
+cargo test tick_db_handle --lib --features cuda,load-dynamic-ort
+# Linux + AMD:
+cargo test tick_db_handle --lib --features vulkan,load-dynamic-ort
+# …
+```
+
+`scripts/cargo-test.sh` reuses the same `cargo-features.sh` detector
+that `git-prepush.sh` and `build-with-loud-failure.sh` already
+source, so there's only one place that knows the platform→features
+mapping.
+
+## CPU-only debug mode (advanced)
+
+To deliberately reproduce the no-features failure (e.g. when
+verifying the loud-fail guard itself):
+
+```bash
+CARGO_TEST_NO_FEATURES=1 ./scripts/cargo-test.sh --lib
+# macOS: fails in llama crate (expected — that IS the contract)
+# Linux: succeeds for non-inference tests (no llama feature gates)
+```
+
+This does NOT weaken the compile-time guard; it just lets you see
+what the bare command does without auto-applying features.
+
+## Targeting a different workspace package
+
+```bash
+CARGO_TEST_RUST_PACKAGE=inference-grpc ./scripts/cargo-test.sh --lib
+```
+
+Defaults to `continuum-core`.
+
+## How this fits with the rest of the test infra
+
+| Command | When | Notes |
+|---|---|---|
+| `npm run test:rust ...` | iterative dev | Uses this wrapper, fastest feedback |
+| `npm run test:precommit` | before commit | Wider scope (TS + browser ping) |
+| `npm run test:prepush` | before push | Includes Rust + native Docker checks |
+| `cargo test ... --features metal,accelerate` | one-off, raw | Skips the wrapper; useful for debugging |
+
+Per #1257 (the card that motivated this), the wrapper is the
+documented default; the raw form remains available for cases where
+you want to override feature selection explicitly.


### PR DESCRIPTION
## Summary

Make \`cargo test\` Just Work on every platform without forcing the dev to memorize the platform-correct Cargo feature incantation.

**Before** (the friction this card was filed for):
\`\`\`bash
cd workers/continuum-core && cargo test tick_db_handle --lib
# → fails in vendored llama crate; "metal" or "cuda" feature required
\`\`\`

**After**:
\`\`\`bash
./scripts/cargo-test.sh tick_db_handle --lib    # from src/
npm run test:rust -- tick_db_handle --lib
\`\`\`

The wrapper sources the existing \`scripts/shared/cargo-features.sh\` detector — same single source of truth that \`build-with-loud-failure.sh\` and \`git-prepush.sh\` already use — and forwards arbitrary args to \`cargo test\` with platform-correct features appended.

## Acceptance criteria check (from #1257)

- [x] **Focused \`continuum-core\` Rust test command is documented and/or wrapped so macOS uses \`metal,accelerate\` by default.** ← \`scripts/cargo-test.sh\` + \`npm run test:rust\` + \`TESTING.md\`.
- [x] **The fix does not weaken or remove the CPU-only compile guard.** ← Wrapper just appends features; the no-CPU-fallback contract (\`tests/no_cpu_fallback_contract.rs\`, #1262) still fires when invoked directly. \`CARGO_TEST_NO_FEATURES=1\` escape hatch lets you reproduce the bare-command failure to verify the guard.
- [x] **Local docs distinguish intentional CPU-only test mode from normal Metal-backed local development.** ← \`TESTING.md\` "CPU-only debug mode" section.
- [ ] Fresh-install validation includes this path — left for a follow-on if Carl/install adds a smoke step. The wrapper itself is platform-agnostic and discoverable; the install path doesn't currently run cargo test.

## Files

- \`scripts/cargo-test.sh\` — wrapper script (new, +90 LOC)
- \`package.json\` — adds \`test:rust\` npm alias next to \`test:precommit\`/\`test:prepush\`
- \`workers/continuum-core/TESTING.md\` — documents the friction, the wrapper, and the per-platform feature mapping (new)

## Test plan

- [x] \`./src/scripts/cargo-test.sh --test generated_barrel_sync\` → 8 passed, 0 failed (auto-applied \`--features metal,accelerate\` on this M5 Pro).
- [x] Precommit (TypeScript + browser ping): PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)