### PR TITLE
perf(cognition): lift max_concurrency:1 cap — event fanout is the invariant, not the gate

### DIFF
--- a/src/workers/continuum-core/src/modules/cognition.rs
+++ b/src/workers/continuum-core/src/modules/cognition.rs
@@ -140,10 +140,15 @@ impl ServiceModule for CognitionModule {
             command_prefixes: &["cognition/", "inbox/"],
             event_subscriptions: &[],
             needs_dedicated_thread: false,
-            // Persona response can invoke RAG, embeddings, and generation.
-            // Keep a single cognition response in flight until the pressure
-            // broker can perform explicit multi-persona batching.
-            max_concurrency: 1,
+            // Persona response is event-fanout work: every active persona
+            // builds prompt/context/should-respond in parallel (cheap), then
+            // hits ai_provider (which serializes inference). Capping cognition
+            // itself was a belt-and-suspenders waiting for a real broker —
+            // codex's persona inbox fanout primitive (today) + the upcoming
+            // PressureBroker singleton (#1299) make event fanout the
+            // intended invariant. Inference is still gated downstream by
+            // ai_provider::max_concurrency. No hardcoded fixed cap here.
+            max_concurrency: usize::MAX,
             tick_interval: None,
         }
     }
@@ -386,9 +391,7 @@ impl ServiceModule for CognitionModule {
                             "chat" => crate::persona::EngramOriginKind::Chat,
                             "airc" => crate::persona::EngramOriginKind::Airc,
                             "tool" => crate::persona::EngramOriginKind::Tool,
-                            "self_reflection" => {
-                                crate::persona::EngramOriginKind::SelfReflection
-                            }
+                            "self_reflection" => crate::persona::EngramOriginKind::SelfReflection,
                             other => {
                                 return Err(format!(
                                     "unknown origin kind '{other}'; expected one of: \
@@ -1087,10 +1090,9 @@ impl ServiceModule for CognitionModule {
                         temperature: p.f32_opt("temperature"),
                     };
 
-                let response = crate::cognition::generate_recipe::generate_recipe_with_ai(
-                    orchestrator_params,
-                )
-                .await?;
+                let response =
+                    crate::cognition::generate_recipe::generate_recipe_with_ai(orchestrator_params)
+                        .await?;
 
                 Ok(CommandResult::Json(
                     serde_json::to_value(&response).map_err(|e| format!("Serialize error: {e}"))?,
@@ -1645,7 +1647,9 @@ mod inline_admission_tests {
             kind: SignalKind::ChatMessage,
             text: "hello world".to_string(),
             media: vec![],
-            originator: SignalOriginator::User { user_id: Uuid::new_v4() },
+            originator: SignalOriginator::User {
+                user_id: Uuid::new_v4(),
+            },
             timestamp_ms: 1_715_625_600_000,
             message_id: Some(Uuid::new_v4()),
         };


### PR DESCRIPTION
## Summary
Per Joel's architecture reset broadcast 2026-05-16 ("scheduler only meters expensive inference lanes from actual resources. No hardcoded fixed concurrency"), lift the \`max_concurrency: 1\` cap on \`CognitionModule\`. The cap was explicitly an interim until the PressureBroker (#1299, claude-tab-1) landed; codex's persona inbox fanout primitive (shipped today) proves the invariant: **event fanout is not the capacity gate, expensive inference is.**

## What changes
- \`max_concurrency: 1\` → \`usize::MAX\` in \`CognitionModule::config()\`
- Comment rewritten to point at the real gating sites:
  - Downstream: \`ai_provider::max_concurrency\` (GPU/llama threadpool saturation gate)
  - Future: \`PressureBroker\` (resource-aware gating, #1299)

## What does NOT change
- \`ai_provider::max_concurrency\` stays at 1 — the actual inference bottleneck stays serialized
- \`embedding::max_concurrency\` stays at 1 — fastembed/ONNX threadpool saturation gate
- Runtime behavior: multiple personas can prompt-build / context-build / should-respond in parallel (cheap work). Inference itself is still serialized at \`ai_provider\`, so DMR/llama.cpp slot isn't oversaturated.

## Why this is safe
- The cap was redundant — the actual inference bottleneck (\`ai_provider\`) has its own gate
- 254 \`cognition::*\` tests pass with the cap removed
- The chat-roundtrip precommit gate exercises live persona reply through this path

## Unblocks
- Codex's persona inbox fanout invariant (every persona builds context in parallel; inference layer gates the expensive part)
- claude-tab-1's #1299 broker singleton (broker absorbs gating responsibility cleanly when it lands)

## Test plan
- [x] cargo test --lib --features metal,accelerate cognition -- --test-threads=1 → 254 passed
- [x] precommit: TS compile + browser-ping + chat-roundtrip PASSED
- [ ] Reviewer: confirm the safety argument (downstream ai_provider still gates inference; cognition itself doesn't need its own cap)

## Mapping to Joel's reset
> "every room event is delivered to every active persona inbox; each persona builds its own memory/context view and decides whether to speak; scheduler only meters expensive inference lanes from actual resources"

Codex shipped: persona inbox fanout primitive (event delivery to every persona inbox).
claude-tab-1 in flight: PressureBroker singleton (resource-aware gating, #1299).
This PR: removes the hardcoded cap that was blocking the fanout from being parallel. The chain is event fanout (codex) → per-persona context build (parallel, this PR enables it) → should-respond → ai_provider (gated) → broker (resource-aware, #1299).

🤖 Generated with [Claude Code](https://claude.com/claude-code)