### PR TITLE
fix(persona): rip TS post-inference adequacy gate (Helper-only suppression)

### DIFF
--- a/src/system/user/server/modules/PersonaMessageEvaluator.ts
+++ b/src/system/user/server/modules/PersonaMessageEvaluator.ts
@@ -602,60 +602,24 @@ export class PersonaMessageEvaluator {
     // No centralized coordinator - each AI uses recipes to decide if they should contribute
     this.log(`✅ ${this.personaUser.displayName}: Autonomous decision to respond (RAG-based reasoning, conf=${gatingResult.confidence})`);
 
-    // 🔧 POST-INFERENCE VALIDATION: delegated to PersonaMessageGate
-    const postInferenceStart = Date.now();
-    const postInferenceResult = await this.messageGate.checkPostInferenceAdequacy(
-      messageEntity,
-      this.personaUser.rustCognition,
-    );
-
-    if (postInferenceResult.shouldSkip) {
-      this.log(`[GATE:POST_INFERENCE] ${this.personaUser.displayName}: BLOCK — ${postInferenceResult.reason}`);
-
-      if (this.personaUser.client) {
-        Events.emit<AIDecidedSilentEventData>(
-          DataDaemon.jtagContext!,
-          AI_DECISION_EVENTS.DECIDED_SILENT,
-          {
-            personaId: this.personaUser.id,
-            personaName: this.personaUser.displayName,
-            roomId: messageEntity.roomId,
-            messageId: messageEntity.id,
-            isHumanMessage: senderIsHuman,
-            timestamp: Date.now(),
-            reason: `Post-inference: ${postInferenceResult.reason}`,
-            confidence: 0.95,
-            gatingModel: 'post-inference'
-          },
-          { scope: EVENT_SCOPES.ROOM, scopeId: messageEntity.roomId }
-        ).catch(err => this.log(`⚠️ Event emit failed: ${err}`));
-
-        getAIAudioBridge().setCognitiveState(this.personaUser.id, 'idle').catch(() => {});
-        Events.emit(DataDaemon.jtagContext!, PRESENCE_EVENTS.TYPING_STOP, {
-          userId: this.personaUser.id, displayName: this.personaUser.displayName, roomId: messageEntity.roomId
-        }).catch(() => {});
-      }
-
-      this.personaUser.logAIDecision('SILENT', `Post-inference skip: ${postInferenceResult.reason}`, {
-        message: messageEntity.content.text,
-        sender: messageEntity.senderName,
-        roomId: messageEntity.roomId
-      });
-
-      // PHASE 5C: Log post-inference SILENT with full RAG context (already built)
-      CoordinationDecisionLogger.logDecision({
-        ...decisionContext,
-        action: 'SILENT',
-        reasoning: `Post-inference: ${postInferenceResult.reason}`,
-        responseTime: Date.now() - postInferenceStart,
-        tags: [...(decisionContext.tags ?? []), 'post-inference-block']
-      }).catch(err => this.log(`⚠️ Failed to log post-inference SILENT decision: ${err}`));
-
-      return;
-    }
-
-
-    this.log(`⏱️ ${this.personaUser.displayName}: [INNER] post-inference validation=${Date.now() - postInferenceStart}ms`);
+    // REMOVED: TS-side post-inference adequacy gate (2026-05-16, Joel's
+    // architecture reset). This gate ran `messageGate.checkPostInferenceAdequacy`
+    // AFTER inference completed and suppressed later personas when an earlier
+    // one (typically Helper AI) already posted an "adequate" response — exactly
+    // the Helper-only-path / TS-cognition-policy anti-pattern Joel banned.
+    //
+    // Per the reset: "every persona must own ... decision ... runtime only
+    // schedules compute lanes based on resources." Each persona's pre-inference
+    // should-respond is in Rust (cognition/should-respond, #1284); admission +
+    // engram recall are in Rust (#1121 series); the resource-aware gate is
+    // moving to the central resources daemon (#1299 broker stack). A TS gate
+    // that runs AFTER inference is policy duplication — and the suppression
+    // semantics specifically reproduce the "Helper-only" path Joel called out.
+    //
+    // The original logic dispatched DECIDED_SILENT, set idle audio state,
+    // emitted typing-stop, logged via CoordinationDecisionLogger. None of that
+    // is needed when the persona just naturally proceeds to post — no
+    // suppression event, no silent-decision logging, just the response.
 
     // 🔧 PHASE: Update RAG context (fire-and-forget — bookkeeping, not needed before generation)
     // The pre-built RAG context from evaluateShouldRespond already has current messages.


### PR DESCRIPTION
## Summary
Rips the TS-side post-inference adequacy gate in \`PersonaMessageEvaluator.ts\` (~50 LOC) that suppressed later personas after Helper posted an "adequate" response. Codex flagged the bug 2026-05-16; Joel ratified in architecture reset ("no Helper-only path, no TS cognition policy").

## What the gate did (now gone)
After inference completed for THIS persona, called \`messageGate.checkPostInferenceAdequacy(...)\`. If \`shouldSkip=true\` (because an earlier persona had posted a response deemed "adequate"), dispatched \`DECIDED_SILENT\`, set idle audio state, emitted typing-stop, logged via \`CoordinationDecisionLogger\`, and RETURNED before posting the persona's already-generated response.

## Why this was wrong per Joel's architecture reset
- "every persona must own ... decision" — this gate was a global policy AFTER per-persona decision was already made
- TS-side cognition policy is banned (durable logic belongs in Rust)
- Suppressing later personas after "Helper posts first" specifically reproduces the Helper-only-path symptom flagged in the reset
- Per-persona should-respond is in Rust (#1284); admission + engram recall are Rust (#1121 series); resource-aware gating is moving to PressureBroker (#1299)

## What does NOT change
- Pre-inference should-respond (Rust #1284) still runs per persona
- Admission gate (Rust #1121 PR-4) still runs per persona
- Tool/markup leak sanitization in \`PersonaResponseValidator\` unchanged
- Rate limiter / sleep mode unchanged
- The \`messageGate.checkPostInferenceAdequacy\` method itself stays for now (other callers might exist); this PR only removes the suppression call-site in \`PersonaMessageEvaluator\`

## Test plan
- [x] npm run build:ts — clean
- [x] precommit: TS + browser-ping + chat-roundtrip PASSED
- [ ] Reviewer: confirm the safety argument (gate ran AFTER inference, removing it just lets the persona post its already-generated response; pre-inference Rust gates still prevent wasted work)

## Mapping to Joel's reset
> "every persona receives each chat event into its own inbox, builds persona-scoped memory/context, then decides whether to speak"

The "decides whether to speak" is each persona's pre-inference Rust gate. The deleted block was a SECOND, global, post-inference "did someone else already say enough?" gate — exactly the centralized coordinator pattern Joel banned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)