### PR TITLE
fix(audio/tts): orpheus must fail-closed on no-Metal, no CPU fallback

### DIFF
--- a/src/workers/continuum-core/src/live/audio/tts/orpheus.rs
+++ b/src/workers/continuum-core/src/live/audio/tts/orpheus.rs
@@ -175,19 +175,27 @@ impl OrpheusTts {
         None
     }
 
-    /// Select the best compute device (Metal > CPU)
-    fn select_device() -> Device {
-        // Try Metal GPU first (Apple Silicon) — candle handles availability at runtime
-        match Device::new_metal(0) {
-            Ok(device) => {
-                clog_info!("Orpheus: Using Metal GPU");
-                device
-            }
-            Err(_) => {
-                clog_info!("Orpheus: Using CPU (with Accelerate BLAS)");
-                Device::Cpu
-            }
-        }
+    /// Acquire the Metal GPU device for Orpheus inference. Fail-closed:
+    /// no CPU fallback. Per CLAUDE.md off-main-thread rule + Joel's
+    /// 2026-05-16 audit (vhsm-d1f4 flagged this exact site), TTS is
+    /// GPU-only — any CPU path silently saturates the render loop and
+    /// produces the 900%-CPU pathology seen during chat.
+    ///
+    /// If Metal isn't available, surface the candle error up so the
+    /// caller can decide policy (refuse to load, surface to operator,
+    /// pick a CPU-acceptable TTS engine if one is registered). The
+    /// previous `Device::Cpu` fallback evaded the codified
+    /// no-CPU-fallback contract by being on the Candle side rather
+    /// than llamacpp/ort.
+    fn select_device() -> Result<Device, TTSError> {
+        let device = Device::new_metal(0).map_err(|e| {
+            TTSError::ModelNotLoaded(format!(
+                "Orpheus requires Metal GPU; no CPU fallback. \
+                 Device::new_metal(0) failed: {e}"
+            ))
+        })?;
+        clog_info!("Orpheus: Using Metal GPU");
+        Ok(device)
     }
 
     /// Build SNAC decoder ONNX session
@@ -546,8 +554,8 @@ impl TextToSpeech for OrpheusTts {
         let audio_end_token_id = Self::find_token_id(&tokenizer, "<|audio_end|>")?;
         clog_info!("Orpheus: audio_end token ID = {}", audio_end_token_id);
 
-        // Select compute device
-        let device = Self::select_device();
+        // Select compute device — fail-closed on no-Metal (no CPU fallback)
+        let device = Self::select_device()?;
 
         // Load GGUF model
         let gguf_path = Self::find_gguf_file(&model_dir).ok_or_else(|| {


### PR DESCRIPTION
## Summary
vhsm-d1f4 (Joel via vHSM cwd) flagged \`orpheus.rs:181-190\` in audit pass 1 (2026-05-16): explicit Metal→CPU fallback with a friendly \`"Orpheus: Using CPU (with Accelerate BLAS)"\` log. The fallback evaded \`tests/no_cpu_fallback_contract.rs\` because that test only inspects llamacpp.rs/ort_providers.rs/llamacpp_adapter.rs — Candle-side TTS slipped through.

Joel attributes the 900% CPU pathology seen during chat to this class of silent fallback: render loop is sacred per README, main thread should not be doing inference, but Orpheus CPU+Accelerate BLAS via candle ends up doing exactly that.

## What changes
- \`select_device() -> Device\` → \`select_device() -> Result<Device, TTSError>\`
- On Metal failure: returns \`TTSError::ModelNotLoaded("Orpheus requires Metal GPU; no CPU fallback. Device::new_metal(0) failed: {e}")\`
- Caller at line 550 propagates with \`?\`
- The "Using CPU" log line is gone; only the success-path Metal log remains

## What does NOT change
- Behavior on Metal-capable hosts: identical
- SNAC decoder ORT path already required GPU EP (lines 196-208); this PR brings the GGUF/candle path to the same standard

## Vision Pro test (per Joel's TS-vs-Rust criterion)
The Rust crate compiles + tests standalone with this change. Caller (any host — Swift on Vision Pro, Node on Mac, whatever) sees a typed \`TTSError\` if Metal unavailable. No JS runtime involved.

## Why this is safe
- \`cargo check + clippy clean\` (146 warnings = baseline 146, no regression)
- All Mac dev hosts have Metal; production runtime contract per README requires GPU
- Error surface is typed so callers can fall through to alternative TTS engines if registered, or fail-loud — no silent CPU drift

## VDD note (per vhsm-d1f4 audit pass 2)
This PR is defensive — it removes the SOURCE of the CPU pathology rather than tuning the hot path. tok/s measurement isn't applicable to a deletion. Whoever owns Phase A.8 next can measure aggregate tok/s with Orpheus load now correctly gated.

## Follow-ups (separate PRs)
- \`src/workers/inference-grpc/src/model.rs:275-295\` — same CUDA→Metal→CPU fallback (vhsm-d1f4 finding #2)
- Widen \`tests/no_cpu_fallback_contract.rs\` to grep whole workers tree for \`Device::Cpu\` + allow-list (finding #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)