### PR TITLE
feat(resources): add runtime lease broker

### DIFF
--- a/src/workers/continuum-core/src/inference/llamacpp_adapter.rs
+++ b/src/workers/continuum-core/src/inference/llamacpp_adapter.rs
@@ -634,7 +634,6 @@ impl AIProviderAdapter for LlamaCppAdapter {
         // override our defaults; if caller asked for JsonObject response
         // format, attach the JSON grammar so output is structurally valid.
         // Same value-object pattern Joel called for ('pass the struct').
-        use crate::ai::types::ResponseFormat;
         use crate::inference::backends::{SamplingConfig, JSON_GRAMMAR};
         let mut sampling = SamplingConfig::chat();
         if let Some(t) = request.temperature {

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -906,6 +906,12 @@ pub fn start_server(
         crate::modules::pressure_broker_module::PressureBrokerModule::new(),
     ));
 
+    // Runtime-owned lease ledger for CPU/GPU/memory/disk/network admission.
+    // Subsystems ask this broker for capacity instead of keeping private caps.
+    runtime.register(Arc::new(
+        crate::modules::resource_broker::ResourceBrokerModule::new(),
+    ));
+
     // Phase 1: InferenceModule — exposes inference/capacity so TS side
     // (InferenceCoordinator) reads a single Rust source of truth instead
     // of duplicating the RAM formula. See issue #887.

--- a/src/workers/continuum-core/src/lib.rs
+++ b/src/workers/continuum-core/src/lib.rs
@@ -41,6 +41,7 @@ pub mod paging;
 pub mod paths;
 pub mod persona;
 pub mod rag;
+pub mod resources;
 pub mod runtime;
 pub mod secrets;
 pub mod system_resources;

--- a/src/workers/continuum-core/src/modules/mod.rs
+++ b/src/workers/continuum-core/src/modules/mod.rs
@@ -37,6 +37,7 @@ pub mod plasticity;
 pub mod pressure_broker_module;
 pub mod python_adapter;
 pub mod rag;
+pub mod resource_broker;
 pub mod runtime_control;
 pub mod search;
 pub mod sentinel;

--- a/src/workers/continuum-core/src/modules/resource_broker.rs
+++ b/src/workers/continuum-core/src/modules/resource_broker.rs
@@ -1,0 +1,168 @@
+//! ResourceBrokerModule — runtime-owned admission and lease ledger.
+//!
+//! This wraps `crate::resources::ResourceBroker` as a ServiceModule so TS,
+//! commands, and Rust subsystems can share one daemon-shaped resource contract.
+
+use crate::resources::{ResourceAdmissionReport, ResourceBroker, ResourceDemand};
+use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use serde::Deserialize;
+use serde_json::Value;
+use std::any::Any;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SYSTEM_RESOURCE_BROKER_STATE: &str = "system/resource-broker-state";
+const SYSTEM_RESOURCE_ADMIT: &str = "system/resource-admit";
+const SYSTEM_RESOURCE_RELEASE: &str = "system/resource-release";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AdmitParams {
+    demands: Vec<ResourceDemand>,
+    #[serde(default)]
+    ready_artifact_keys: Vec<String>,
+    now_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReleaseParams {
+    lease_id: String,
+}
+
+pub struct ResourceBrokerModule {
+    broker: Arc<Mutex<ResourceBroker>>,
+}
+
+impl ResourceBrokerModule {
+    pub fn new() -> Self {
+        Self {
+            broker: Arc::new(Mutex::new(ResourceBroker::local_default())),
+        }
+    }
+
+    pub fn broker(&self) -> Arc<Mutex<ResourceBroker>> {
+        self.broker.clone()
+    }
+}
+
+impl Default for ResourceBrokerModule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ServiceModule for ResourceBrokerModule {
+    fn config(&self) -> ModuleConfig {
+        ModuleConfig {
+            name: "resource-broker",
+            priority: ModulePriority::High,
+            command_prefixes: &[
+                SYSTEM_RESOURCE_BROKER_STATE,
+                SYSTEM_RESOURCE_ADMIT,
+                SYSTEM_RESOURCE_RELEASE,
+            ],
+            event_subscriptions: &[],
+            needs_dedicated_thread: false,
+            max_concurrency: 0,
+            tick_interval: None,
+        }
+    }
+
+    async fn initialize(&self, _ctx: &ModuleContext) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn handle_command(&self, command: &str, params: Value) -> Result<CommandResult, String> {
+        match command {
+            SYSTEM_RESOURCE_BROKER_STATE => {
+                let now_ms = now_ms()?;
+                let broker = self.broker.lock();
+                CommandResult::json(&serde_json::json!({
+                    "laneBudgets": broker.lane_budgets(),
+                    "leases": broker.active_leases(now_ms),
+                    "reclaimable": broker.reclaimable(now_ms),
+                }))
+            }
+            SYSTEM_RESOURCE_ADMIT => {
+                let params: AdmitParams = serde_json::from_value(params)
+                    .map_err(|e| format!("resource-broker admit params invalid: {e}"))?;
+                let now_ms = params.now_ms.unwrap_or(now_ms()?);
+                let report: ResourceAdmissionReport =
+                    self.broker
+                        .lock()
+                        .admit(params.demands, params.ready_artifact_keys, now_ms);
+                CommandResult::json(&report)
+            }
+            SYSTEM_RESOURCE_RELEASE => {
+                let params: ReleaseParams = serde_json::from_value(params)
+                    .map_err(|e| format!("resource-broker release params invalid: {e}"))?;
+                let released = self
+                    .broker
+                    .lock()
+                    .release(&params.lease_id)
+                    .map_err(|e| format!("resource-broker release failed: {e:?}"))?;
+                CommandResult::json(&released)
+            }
+            other => Err(format!(
+                "resource-broker: unknown command '{other}' (handled: {SYSTEM_RESOURCE_BROKER_STATE}, {SYSTEM_RESOURCE_ADMIT}, {SYSTEM_RESOURCE_RELEASE})"
+            )),
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+fn now_ms() -> Result<u64, String> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("system clock before UNIX_EPOCH: {e}"))?;
+    u64::try_from(duration.as_millis()).map_err(|_| "system clock millis overflow u64".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn admit_command_uses_one_runtime_owned_lease_ledger() {
+        let module = ResourceBrokerModule::new();
+        let params = serde_json::json!({
+            "nowMs": 100,
+            "demands": [
+                ResourceDemand::persona_generation("helper", "event-a", 90, 10, 1_000),
+                ResourceDemand::persona_generation("planner", "event-a", 89, 10, 1_000)
+            ],
+            "readyArtifactKeys": []
+        });
+
+        let result = module
+            .handle_command(SYSTEM_RESOURCE_ADMIT, params)
+            .await
+            .expect("admit command should succeed");
+
+        let CommandResult::Json(json) = result else {
+            panic!("expected JSON result");
+        };
+        let report: ResourceAdmissionReport =
+            serde_json::from_value(json).expect("report should deserialize");
+        assert_eq!(report.admitted.len(), 2);
+        assert!(report.refused.is_empty());
+    }
+
+    #[tokio::test]
+    async fn malformed_admit_request_fails_loudly() {
+        let module = ResourceBrokerModule::new();
+        let result = module
+            .handle_command(SYSTEM_RESOURCE_ADMIT, serde_json::json!({}))
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("params invalid"));
+    }
+}

--- a/src/workers/continuum-core/src/resources/broker.rs
+++ b/src/workers/continuum-core/src/resources/broker.rs
@@ -1,0 +1,462 @@
+use crate::resources::{
+    ResourceClass, TargetSilicon, ThroughputLease, ThroughputLeaseError, ThroughputLeaseRegistry,
+    ThroughputLeaseRevocationPolicy,
+};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceBrokerConfig {
+    pub lane_budgets: Vec<ResourceLaneBudget>,
+}
+
+impl ResourceBrokerConfig {
+    pub fn local_default() -> Self {
+        let logical_cpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .expect("host must report available parallelism for resource defaults");
+        let gpu_slots = match std::env::var("CONTINUUM_GPU_CONCURRENCY") {
+            Ok(raw) => {
+                let parsed = raw.parse::<usize>().unwrap_or_else(|e| {
+                    panic!("CONTINUUM_GPU_CONCURRENCY must be a positive integer: {e}")
+                });
+                assert!(
+                    parsed > 0,
+                    "CONTINUUM_GPU_CONCURRENCY must be greater than zero"
+                );
+                parsed
+            }
+            Err(std::env::VarError::NotPresent) => logical_cpus.clamp(4, 8),
+            Err(std::env::VarError::NotUnicode(_)) => {
+                panic!("CONTINUUM_GPU_CONCURRENCY must be valid UTF-8")
+            }
+        };
+        let scaled_cost = |slots: usize| (slots as u32).saturating_mul(100);
+
+        Self {
+            lane_budgets: vec![
+                ResourceLaneBudget {
+                    resource_class: ResourceClass::Cpu,
+                    target_silicon: TargetSilicon::Cpu,
+                    max_concurrency: logical_cpus,
+                    max_cost_units: scaled_cost(logical_cpus),
+                },
+                ResourceLaneBudget {
+                    resource_class: ResourceClass::Gpu,
+                    target_silicon: TargetSilicon::Gpu,
+                    max_concurrency: gpu_slots,
+                    max_cost_units: scaled_cost(gpu_slots),
+                },
+                ResourceLaneBudget {
+                    resource_class: ResourceClass::Memory,
+                    target_silicon: TargetSilicon::UnifiedMemory,
+                    max_concurrency: logical_cpus,
+                    max_cost_units: scaled_cost(logical_cpus),
+                },
+                ResourceLaneBudget {
+                    resource_class: ResourceClass::Io,
+                    target_silicon: TargetSilicon::Disk,
+                    max_concurrency: logical_cpus,
+                    max_cost_units: scaled_cost(logical_cpus),
+                },
+                ResourceLaneBudget {
+                    resource_class: ResourceClass::CloudProvider,
+                    target_silicon: TargetSilicon::Network,
+                    max_concurrency: logical_cpus,
+                    max_cost_units: scaled_cost(logical_cpus),
+                },
+                ResourceLaneBudget {
+                    resource_class: ResourceClass::Background,
+                    target_silicon: TargetSilicon::Background,
+                    max_concurrency: logical_cpus,
+                    max_cost_units: scaled_cost(logical_cpus),
+                },
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceLaneBudget {
+    pub resource_class: ResourceClass,
+    pub target_silicon: TargetSilicon,
+    pub max_concurrency: usize,
+    pub max_cost_units: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceDemand {
+    pub demand_id: String,
+    pub holder_id: String,
+    pub artifact_key: String,
+    pub resource_class: ResourceClass,
+    pub target_silicon: TargetSilicon,
+    pub priority: u32,
+    pub cost_units: u32,
+    #[serde(default)]
+    pub dependency_keys: Vec<String>,
+    #[serde(default)]
+    pub created_at_ms: u64,
+    #[serde(default)]
+    pub stale_after_ms: u64,
+    pub ttl_ms: u64,
+    pub revocation_policy: ThroughputLeaseRevocationPolicy,
+}
+
+impl ResourceDemand {
+    pub fn persona_generation(
+        persona_id: impl Into<String>,
+        event_id: impl Into<String>,
+        priority: u32,
+        cost_units: u32,
+        ttl_ms: u64,
+    ) -> Self {
+        let persona_id = persona_id.into();
+        let event_id = event_id.into();
+        Self {
+            demand_id: format!("persona:{persona_id}:generate:{event_id}"),
+            holder_id: format!("persona:{persona_id}"),
+            artifact_key: format!("persona:{persona_id}:event:{event_id}:reply"),
+            resource_class: ResourceClass::LocalGeneration,
+            target_silicon: TargetSilicon::Gpu,
+            priority,
+            cost_units,
+            dependency_keys: Vec::new(),
+            created_at_ms: 0,
+            stale_after_ms: 0,
+            ttl_ms,
+            revocation_policy: ThroughputLeaseRevocationPolicy::Pinned,
+        }
+    }
+
+    fn is_stale(&self, now_ms: u64) -> bool {
+        self.stale_after_ms > 0 && now_ms.saturating_sub(self.created_at_ms) > self.stale_after_ms
+    }
+
+    fn lease_id(&self) -> String {
+        format!(
+            "{}:{}:{}",
+            self.holder_id, self.artifact_key, self.created_at_ms
+        )
+    }
+
+    fn into_lease(self, now_ms: u64) -> ThroughputLease {
+        ThroughputLease {
+            lease_id: self.lease_id(),
+            artifact_key: self.artifact_key,
+            resource_class: self.resource_class,
+            target_silicon: self.target_silicon,
+            holder_id: self.holder_id,
+            cost_units: self.cost_units,
+            acquired_at_ms: now_ms,
+            expires_at_ms: now_ms.saturating_add(self.ttl_ms),
+            revocation_policy: self.revocation_policy,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ResourceRefusalReason {
+    MissingDependency,
+    NoBudget,
+    ResourcePressure,
+    Stale,
+    Superseded,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceAdmissionReport {
+    pub admitted: Vec<ThroughputLease>,
+    pub refused: Vec<(ResourceDemand, ResourceRefusalReason)>,
+    pub expired: Vec<ThroughputLease>,
+}
+
+#[derive(Debug)]
+pub struct ResourceBroker {
+    budgets: BTreeMap<TargetSilicon, ResourceLaneBudget>,
+    leases: ThroughputLeaseRegistry,
+}
+
+impl ResourceBroker {
+    pub fn new(config: ResourceBrokerConfig) -> Self {
+        let budgets = config
+            .lane_budgets
+            .into_iter()
+            .map(|budget| (budget.target_silicon, budget))
+            .collect();
+        Self {
+            budgets,
+            leases: ThroughputLeaseRegistry::new(),
+        }
+    }
+
+    pub fn local_default() -> Self {
+        Self::new(ResourceBrokerConfig::local_default())
+    }
+
+    pub fn lane_budgets(&self) -> Vec<ResourceLaneBudget> {
+        self.budgets.values().copied().collect()
+    }
+
+    pub fn active_leases(&self, now_ms: u64) -> crate::resources::ThroughputLeaseSnapshot {
+        self.leases.snapshot(now_ms)
+    }
+
+    pub fn reclaimable(&self, now_ms: u64) -> Vec<ThroughputLease> {
+        self.leases.reclaimable(now_ms)
+    }
+
+    pub fn release(&mut self, lease_id: &str) -> Result<ThroughputLease, ThroughputLeaseError> {
+        self.leases.release(lease_id)
+    }
+
+    pub fn admit(
+        &mut self,
+        demands: Vec<ResourceDemand>,
+        ready_artifact_keys: Vec<String>,
+        now_ms: u64,
+    ) -> ResourceAdmissionReport {
+        let expired = self.leases.expire(now_ms);
+        let ready: BTreeSet<String> = ready_artifact_keys.into_iter().collect();
+        let mut refused = Vec::new();
+        let mut usable = Vec::new();
+
+        for demand in demands {
+            if demand.is_stale(now_ms) {
+                refused.push((demand, ResourceRefusalReason::Stale));
+            } else {
+                usable.push(demand);
+            }
+        }
+
+        let (mut candidates, superseded) = coalesce(usable);
+        refused.extend(
+            superseded
+                .into_iter()
+                .map(|demand| (demand, ResourceRefusalReason::Superseded)),
+        );
+        candidates.sort_by(compare_demands);
+
+        let mut used = self.used_capacity(now_ms);
+        let mut admitted = Vec::new();
+
+        for demand in candidates {
+            if !dependencies_ready(&demand, &ready) {
+                refused.push((demand, ResourceRefusalReason::MissingDependency));
+                continue;
+            }
+
+            let Some(budget) = self.budgets.get(&demand.target_silicon) else {
+                refused.push((demand, ResourceRefusalReason::NoBudget));
+                continue;
+            };
+
+            let lane = used.entry(demand.target_silicon).or_insert((0usize, 0u32));
+            let can_fit = lane.0 < budget.max_concurrency
+                && lane.1.saturating_add(demand.cost_units) <= budget.max_cost_units;
+
+            if !can_fit {
+                refused.push((demand, ResourceRefusalReason::ResourcePressure));
+                continue;
+            }
+
+            lane.0 += 1;
+            lane.1 = lane.1.saturating_add(demand.cost_units);
+            let lease = demand.into_lease(now_ms);
+            self.leases
+                .acquire(lease.clone(), now_ms)
+                .expect("lease id should be unique after demand coalescing");
+            admitted.push(lease);
+        }
+
+        ResourceAdmissionReport {
+            admitted,
+            refused,
+            expired,
+        }
+    }
+
+    fn used_capacity(&self, now_ms: u64) -> BTreeMap<TargetSilicon, (usize, u32)> {
+        let mut used = BTreeMap::new();
+        for lease in self.leases.snapshot(now_ms).active {
+            let lane = used.entry(lease.target_silicon).or_insert((0usize, 0u32));
+            lane.0 += 1;
+            lane.1 = lane.1.saturating_add(lease.cost_units);
+        }
+        used
+    }
+}
+
+fn dependencies_ready(demand: &ResourceDemand, ready: &BTreeSet<String>) -> bool {
+    demand.dependency_keys.iter().all(|key| ready.contains(key))
+}
+
+fn coalesce(demands: Vec<ResourceDemand>) -> (Vec<ResourceDemand>, Vec<ResourceDemand>) {
+    let mut winners: BTreeMap<(ResourceClass, String, String), ResourceDemand> = BTreeMap::new();
+    let mut dropped = Vec::new();
+
+    for demand in demands {
+        let key = (
+            demand.resource_class,
+            demand.holder_id.clone(),
+            demand.artifact_key.clone(),
+        );
+        if let Some(existing) = winners.get(&key) {
+            if compare_demands(&demand, existing).is_lt() {
+                dropped.push(existing.clone());
+                winners.insert(key, demand);
+            } else {
+                dropped.push(demand);
+            }
+        } else {
+            winners.insert(key, demand);
+        }
+    }
+
+    (winners.into_values().collect(), dropped)
+}
+
+fn compare_demands(left: &ResourceDemand, right: &ResourceDemand) -> Ordering {
+    right
+        .priority
+        .cmp(&left.priority)
+        .then_with(|| right.created_at_ms.cmp(&left.created_at_ms))
+        .then_with(|| left.demand_id.cmp(&right.demand_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn broker(gpu_slots: usize) -> ResourceBroker {
+        ResourceBroker::new(ResourceBrokerConfig {
+            lane_budgets: vec![
+                ResourceLaneBudget {
+                    resource_class: ResourceClass::LocalGeneration,
+                    target_silicon: TargetSilicon::Gpu,
+                    max_concurrency: gpu_slots,
+                    max_cost_units: 100,
+                },
+                ResourceLaneBudget {
+                    resource_class: ResourceClass::Cpu,
+                    target_silicon: TargetSilicon::Cpu,
+                    max_concurrency: 4,
+                    max_cost_units: 100,
+                },
+            ],
+        })
+    }
+
+    #[test]
+    fn independent_personas_on_same_event_are_not_coalesced() {
+        let mut broker = broker(4);
+        let event_id = "chat:general:42";
+
+        let report = broker.admit(
+            vec![
+                ResourceDemand::persona_generation("helper", event_id, 80, 10, 1_000),
+                ResourceDemand::persona_generation("planner", event_id, 79, 10, 1_000),
+                ResourceDemand::persona_generation("critic", event_id, 78, 10, 1_000),
+            ],
+            Vec::new(),
+            100,
+        );
+
+        let holders: Vec<&str> = report
+            .admitted
+            .iter()
+            .map(|lease| lease.holder_id.as_str())
+            .collect();
+        assert_eq!(
+            holders,
+            vec!["persona:helper", "persona:planner", "persona:critic"]
+        );
+        assert!(report.refused.is_empty());
+    }
+
+    #[test]
+    fn active_leases_reserve_capacity_across_batches() {
+        let mut broker = broker(2);
+        let first = broker.admit(
+            vec![ResourceDemand::persona_generation(
+                "helper", "event-a", 90, 10, 1_000,
+            )],
+            Vec::new(),
+            100,
+        );
+        assert_eq!(first.admitted.len(), 1);
+
+        let second = broker.admit(
+            vec![
+                ResourceDemand::persona_generation("planner", "event-a", 89, 10, 1_000),
+                ResourceDemand::persona_generation("critic", "event-a", 88, 10, 1_000),
+            ],
+            Vec::new(),
+            101,
+        );
+
+        assert_eq!(second.admitted.len(), 1);
+        assert_eq!(second.admitted[0].holder_id, "persona:planner");
+        assert_eq!(second.refused.len(), 1);
+        assert_eq!(second.refused[0].0.holder_id, "persona:critic");
+        assert_eq!(second.refused[0].1, ResourceRefusalReason::ResourcePressure);
+    }
+
+    #[test]
+    fn same_holder_same_artifact_coalesces_without_cross_persona_suppression() {
+        let mut broker = broker(4);
+        let mut old = ResourceDemand::persona_generation("helper", "event-a", 10, 10, 1_000);
+        old.created_at_ms = 100;
+        let mut new = old.clone();
+        new.demand_id = "newer".to_string();
+        new.priority = 20;
+        new.created_at_ms = 200;
+        let other_persona = ResourceDemand::persona_generation("planner", "event-a", 10, 10, 1_000);
+
+        let report = broker.admit(vec![old, new, other_persona], Vec::new(), 250);
+
+        let holders: Vec<&str> = report
+            .admitted
+            .iter()
+            .map(|lease| lease.holder_id.as_str())
+            .collect();
+        assert_eq!(holders, vec!["persona:helper", "persona:planner"]);
+        assert_eq!(report.refused.len(), 1);
+        assert_eq!(report.refused[0].1, ResourceRefusalReason::Superseded);
+    }
+
+    #[test]
+    fn pinned_leases_are_not_reclaimable_until_expired() {
+        let mut broker = ResourceBroker::new(ResourceBrokerConfig {
+            lane_budgets: vec![ResourceLaneBudget {
+                resource_class: ResourceClass::Memory,
+                target_silicon: TargetSilicon::UnifiedMemory,
+                max_concurrency: 2,
+                max_cost_units: 100,
+            }],
+        });
+        let report = broker.admit(
+            vec![ResourceDemand {
+                demand_id: "genome-page".to_string(),
+                holder_id: "persona:helper".to_string(),
+                artifact_key: "lora:rust-expert".to_string(),
+                resource_class: ResourceClass::Memory,
+                target_silicon: TargetSilicon::UnifiedMemory,
+                priority: 100,
+                cost_units: 1,
+                dependency_keys: Vec::new(),
+                created_at_ms: 100,
+                stale_after_ms: 0,
+                ttl_ms: 1_000,
+                revocation_policy: ThroughputLeaseRevocationPolicy::Pinned,
+            }],
+            Vec::new(),
+            100,
+        );
+
+        assert_eq!(report.admitted.len(), 1);
+        assert!(broker.reclaimable(500).is_empty());
+        assert_eq!(broker.reclaimable(1_101).len(), 1);
+    }
+}

--- a/src/workers/continuum-core/src/resources/mod.rs
+++ b/src/workers/continuum-core/src/resources/mod.rs
@@ -1,0 +1,24 @@
+//! Central resource contract for the Rust runtime.
+//!
+//! This module is the low-level admission surface every expensive subsystem
+//! should converge on: persona cognition, RAG, embeddings, local generation,
+//! genome/LoRA paging, live media, Bevy rendering, storage pruning, and grid
+//! work. Policy lives here; callers submit resource demands and receive leases
+//! or explicit refusal reasons.
+//!
+//! The older throughput primitives still live in `cognition` because that is
+//! where the first slice landed. Re-exporting them here gives new code a
+//! stable, subsystem-neutral import path while follow-up slices move call sites
+//! off `crate::cognition::*`.
+
+pub use crate::cognition::{
+    ResourceClass, TargetSilicon, ThroughputLease, ThroughputLeaseError, ThroughputLeaseRegistry,
+    ThroughputLeaseRevocationPolicy, ThroughputLeaseSnapshot,
+};
+
+pub mod broker;
+
+pub use broker::{
+    ResourceAdmissionReport, ResourceBroker, ResourceBrokerConfig, ResourceDemand,
+    ResourceLaneBudget, ResourceRefusalReason,
+};


### PR DESCRIPTION
## Summary
- add a Rust resource-broker module as the central runtime-owned lease ledger for CPU/GPU/memory/disk/network admission
- expose system/resource-broker-state, system/resource-admit, and system/resource-release IPC commands
- preserve independent persona admission by coalescing only per holder/artifact, not globally per event

## Tests
- cargo test --manifest-path src/workers/continuum-core/Cargo.toml --features metal,accelerate resources::broker --lib
- cargo test --manifest-path src/workers/continuum-core/Cargo.toml --features metal,accelerate modules::resource_broker --lib
- cargo clippy warning count: 145 (baseline 146)
- precommit: TypeScript compile + browser-ping + chat-roundtrip passed
- pre-push: TypeScript, ESLint ratchet, Rust compile, Rust tests passed

## Note
- native Docker image push was skipped by the hook because unrelated local files are dirty; CI verify-architectures may require a clean-worktree image push.