### PR TITLE
fix(gpu): inference-grpc hard-fail on no-GPU (companion to #1312)

### DIFF
--- a/src/workers/inference-grpc/src/model.rs
+++ b/src/workers/inference-grpc/src/model.rs
@@ -266,33 +266,43 @@ pub fn load_model_by_id(
     info!("📥 Loading {model_id}...");
     let start = Instant::now();
 
-    // Device selection: CUDA > Metal > CPU
-    let device = select_best_device();
+    // Device selection: CUDA > Metal, GPU-only. Hard-fail on no-GPU
+    // per CLAUDE.md GPU-required contract + supervisor audit pass 1
+    // (vhsm-d1f4 2026-05-16): "no CPU fallback" — the pre-this-fix
+    // `Device::Cpu` arm silently returned a CPU device with a friendly
+    // "no GPU acceleration" log, the same "code in fallbacks" pattern
+    // Joel flagged at 900% CPU. Same shape as the llama.cpp
+    // `n_gpu_layers: -1` GPU-only contract.
+    let device = select_best_device()?;
 
-    fn select_best_device() -> Device {
-        // Try CUDA first (RTX 5090, etc.)
+    fn select_best_device() -> Result<Device, Box<dyn std::error::Error + Send + Sync>> {
         #[cfg(feature = "cuda")]
         {
-            if let Ok(device) = Device::new_cuda(0) {
-                info!("  Using CUDA device");
-                return device;
+            match Device::new_cuda(0) {
+                Ok(device) => {
+                    info!("  Using CUDA device");
+                    return Ok(device);
+                }
+                Err(e) => info!("  CUDA not available: {e}"),
             }
-            info!("  CUDA not available");
         }
 
-        // Try Metal (macOS)
         #[cfg(feature = "metal")]
         {
-            if let Ok(device) = Device::new_metal(0) {
-                info!("  Using Metal device");
-                return device;
+            match Device::new_metal(0) {
+                Ok(device) => {
+                    info!("  Using Metal device");
+                    return Ok(device);
+                }
+                Err(e) => info!("  Metal not available: {e}"),
             }
-            info!("  Metal not available");
         }
 
-        // Fall back to CPU
-        info!("  Using CPU (no GPU acceleration)");
-        Device::Cpu
+        Err("inference-grpc: GPU required, no CPU fallback. \
+             Neither CUDA (when feature enabled) nor Metal (when feature enabled) \
+             could open a device. Build with --features cuda or --features metal on a host \
+             that actually has the corresponding GPU."
+            .into())
     }
 
     info!("  Device: {device:?}");


### PR DESCRIPTION
## Summary

Closes the inference-grpc CPU-fallback path supervisor vhsm-d1f4 flagged in audit pass 1 finding #2 (2026-05-16). Same shape + rationale as codex's #1312 for orpheus.

Pre-fix `select_best_device` tried CUDA, tried Metal, then printed "Using CPU (no GPU acceleration)" and returned `Device::Cpu`. Same "code in fallbacks" anti-pattern Joel flagged at 900% CPU.

## Change

- `select_best_device` → `Result<Device, Box<dyn Error + Send + Sync>>`
- caller propagates via `?` — no behavior change on GPU-available hosts
- Error message names what to do: rebuild with the right `--features` on a host with the matching GPU
- Same shape as the llama.cpp `n_gpu_layers: -1` GPU-only contract
- Evaded the codified `no_cpu_fallback_contract.rs` test (only inspects llamacpp / ort_providers / llamacpp_adapter, not workers/inference-grpc)

## Test plan

- [x] `cargo check --features metal` clean
- [ ] CI green
- [ ] no_cpu_fallback_contract.rs should be widened to grep workers/inference-grpc too (separate slice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)