### PR TITLE
fix: stabilize llama.cpp JSON grammar sampling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/workers/vendor/llama.cpp"]
 	path = src/workers/vendor/llama.cpp
-	url = https://github.com/ggerganov/llama.cpp
+	url = https://github.com/CambrianTech/llama.cpp
 [submodule "src/workers/vendor/whisper.cpp"]
 	path = src/workers/vendor/whisper.cpp
 	url = https://github.com/ggerganov/whisper.cpp

--- a/src/workers/continuum-core/src/inference/backends/llamacpp.rs
+++ b/src/workers/continuum-core/src/inference/backends/llamacpp.rs
@@ -46,15 +46,23 @@ pub struct LlamaCppConfig {
     /// Batch size for prefill / per-decode token cap. Larger = faster
     /// prefill but more Metal compute buffer.
     pub n_batch: u32,
+    /// Physical backend ubatch. On llama.cpp this controls the largest graph
+    /// reserved for prompt processing. Keeping it configurable lets Rust avoid
+    /// known-bad fused Metal graph shapes without changing model/provider.
+    pub n_ubatch: u32,
     /// GPU layers to offload (-1 = all)
     pub n_gpu_layers: i32,
     /// Maximum concurrent sequences in the shared context. Each persona
     /// inflight occupies one seq_id (0..n_seq_max). Scaled by RAM in the
     /// caller (CandleAdapter) and matched by the TS InferenceCoordinator.
     pub n_seq_max: u32,
-    /// Flash attention. `Auto` lets llama.cpp pick per-backend (Metal: ON
-    /// for supported head dims). Default Auto is the right call.
+    /// Flash attention. `Auto` lets llama.cpp pick per-backend.
     pub flash_attn: FlashAttn,
+    /// Fused Gated Delta Net graph toggles. Defaults match upstream; callers
+    /// can disable for model/backend combinations whose fused Metal kernels
+    /// throw across FFI while preserving GPU residency.
+    pub fused_gdn_ar: bool,
+    pub fused_gdn_ch: bool,
     /// KV cache K element type. F16 = lossless. Q8_0 halves K memory.
     pub type_k: KvCacheType,
     /// KV cache V element type. V is more sensitive than K — keep F16
@@ -79,10 +87,13 @@ impl Default for LlamaCppConfig {
             // window (rare on M5+/RTX class).
             context_length: None,
             n_batch: 512,
+            n_ubatch: 512,
             n_gpu_layers: -1,
             // 3 = M5 Pro tier (48GB+). CandleAdapter overrides per-RAM.
             n_seq_max: 3,
             flash_attn: FlashAttn::Auto,
+            fused_gdn_ar: true,
+            fused_gdn_ch: true,
             // F16/F16 measured fastest for single-token decode on M5 Pro.
             // K=Q8_0 was slower (44 vs 47.5 tok/s) due to per-token dequant
             // overhead. Q8_0 only pays off when KV memory pressure is the
@@ -336,8 +347,11 @@ impl LlamaCppBackend {
             .new_context(llama::ContextParams {
                 n_ctx: per_seq,
                 n_batch: self.config.n_batch,
+                n_ubatch: self.config.n_ubatch,
                 n_seq_max: 1,
                 flash_attn: self.config.flash_attn,
+                fused_gdn_ar: self.config.fused_gdn_ar,
+                fused_gdn_ch: self.config.fused_gdn_ch,
                 type_k: self.config.type_k,
                 type_v: self.config.type_v,
             })
@@ -428,7 +442,6 @@ impl LlamaCppBackend {
         // honors -1 as that position.
         loop {
             let token = sampler.sample(&ctx, -1);
-            sampler.accept(token);
             if self.model.is_eog_token(token) {
                 break;
             }
@@ -535,8 +548,11 @@ impl LlamaCppBackend {
                 SchedulerConfig {
                     n_ctx: total_n_ctx,
                     n_batch: self.config.n_batch,
+                    n_ubatch: self.config.n_ubatch,
                     n_seq_max: self.config.n_seq_max,
                     flash_attn: self.config.flash_attn,
+                    fused_gdn_ar: self.config.fused_gdn_ar,
+                    fused_gdn_ch: self.config.fused_gdn_ch,
                     type_k: self.config.type_k,
                     type_v: self.config.type_v,
                 },

--- a/src/workers/continuum-core/src/inference/backends/llamacpp_scheduler.rs
+++ b/src/workers/continuum-core/src/inference/backends/llamacpp_scheduler.rs
@@ -92,11 +92,14 @@ pub struct GenerationRequest {
 pub struct SchedulerConfig {
     pub n_ctx: u32,
     pub n_batch: u32,
+    pub n_ubatch: u32,
     pub n_seq_max: u32,
     /// Flash attention. Default `Auto` lets llama.cpp pick per-backend; on
     /// Metal with supported head dims (qwen3.5-4b's 256 qualifies) it turns
     /// on. Helps prefill more than single-token decode but cheap to enable.
     pub flash_attn: FlashAttn,
+    pub fused_gdn_ar: bool,
+    pub fused_gdn_ch: bool,
     /// KV cache K element type. `F16` lossless / `Q8_0` halves K memory.
     pub type_k: KvCacheType,
     /// KV cache V element type. `F16` lossless / `Q8_0` halves V memory.
@@ -193,8 +196,11 @@ fn driver_loop(
     let mut ctx = match model.new_context(ContextParams {
         n_ctx: config.n_ctx,
         n_batch: config.n_batch,
+        n_ubatch: config.n_ubatch,
         n_seq_max: config.n_seq_max,
         flash_attn: config.flash_attn,
+        fused_gdn_ar: config.fused_gdn_ar,
+        fused_gdn_ch: config.fused_gdn_ch,
         type_k: config.type_k,
         type_v: config.type_v,
     }) {
@@ -205,8 +211,8 @@ fn driver_loop(
         }
     };
     log.info(&format!(
-        "Scheduler context ready (n_ctx={}, n_batch={}, n_seq_max={})",
-        config.n_ctx, config.n_batch, config.n_seq_max
+        "Scheduler context ready (n_ctx={}, n_batch={}, n_ubatch={}, n_seq_max={})",
+        config.n_ctx, config.n_batch, config.n_ubatch, config.n_seq_max
     ));
 
     let n_batch = config.n_batch as usize;
@@ -242,7 +248,6 @@ fn driver_loop(
     let mut post_sample_total = std::time::Duration::ZERO;
     let mut tokens_sampled_window: u64 = 0;
     const PERF_LOG_INTERVAL_TOKENS: u64 = 50;
-
     loop {
         // ── Phase 1: Accept new requests into free slots ──
         // If nothing is active, block on the first request (avoid spinning).
@@ -437,7 +442,6 @@ fn driver_loop(
                 let token = seq.sampler.sample(&ctx, logit_idx);
                 let sample_call_elapsed = sample_call_start.elapsed();
                 sample_call_iter_total += sample_call_elapsed;
-                seq.sampler.accept(token);
 
                 // If this role was PrefillFinal (first decode for the seq),
                 // llama.cpp has now committed the seq's KV cache. Ask the

--- a/src/workers/continuum-core/src/inference/backends/mod.rs
+++ b/src/workers/continuum-core/src/inference/backends/mod.rs
@@ -209,18 +209,33 @@ impl SamplingConfig {
     }
 }
 
-/// Built-in JSON grammar (GBNF) — produces any valid JSON value. Used
-/// when callers request `response_format: JsonObject`. Lifted from the
-/// llama.cpp grammars/json.gbnf reference grammar; trimmed to the
-/// expressions actually needed for chat persona analyze responses.
+/// Built-in JSON grammar (GBNF) — produces a valid JSON object. Used when
+/// callers request `response_format: JsonObject`. Keep this aligned with the
+/// vendored llama.cpp `grammars/json.gbnf`.
 pub const JSON_GRAMMAR: &str = r#"
 root   ::= object
 value  ::= object | array | string | number | ("true" | "false" | "null") ws
-object ::= "{" ws ( string ":" ws value ("," ws string ":" ws value)* )? "}" ws
-array  ::= "[" ws ( value ("," ws value)* )? "]" ws
-string ::= "\"" ( [^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) )* "\"" ws
-number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= ([ \t\n] ws)?
+
+object ::=
+  "{" ws (
+            string ":" ws value
+    ("," ws string ":" ws value)*
+  )? "}" ws
+
+array  ::=
+  "[" ws (
+            value
+    ("," ws value)*
+  )? "]" ws
+
+string ::=
+  "\"" (
+    [^"\\\x7F\x00-\x1F] |
+    "\\" (["\\bfnrt] | "u" [0-9a-fA-F]{4})
+  )* "\"" ws
+
+number ::= ("-"? ([0-9] | [1-9] [0-9]{0,15})) ("." [0-9]+)? ([eE] [-+]? [0-9] [1-9]{0,15})? ws
+ws ::= | " " | "\n" [ \t]{0,20}
 "#;
 
 /// Generate text from a prompt using ANY ModelBackend.
@@ -610,12 +625,14 @@ pub fn read_gguf_metadata(path: &Path) -> Result<GgufMetadata, String> {
         .get("general.architecture")
         .and_then(|v| v.to_string().ok())
         .cloned()
-        .ok_or_else(|| format!(
-            "GGUF {} is missing required metadata key 'general.architecture' — cannot \
+        .ok_or_else(|| {
+            format!(
+                "GGUF {} is missing required metadata key 'general.architecture' — cannot \
              determine backend. Silent fallback to 'llama' has been removed; fix the \
              GGUF file or re-export it with proper metadata.",
-            path.display()
-        ))?;
+                path.display()
+            )
+        })?;
 
     // Try architecture-specific key first, then llama fallback for the context_length
     // key only (some older tools wrote 'llama.context_length' regardless of actual
@@ -626,12 +643,14 @@ pub fn read_gguf_metadata(path: &Path) -> Result<GgufMetadata, String> {
         .or_else(|| content.metadata.get("llama.context_length"))
         .and_then(|v| v.to_u32().ok())
         .map(|v| v as usize)
-        .ok_or_else(|| format!(
-            "GGUF {} (architecture={architecture}) is missing context_length metadata \
+        .ok_or_else(|| {
+            format!(
+                "GGUF {} (architecture={architecture}) is missing context_length metadata \
              (tried '{architecture}.context_length' and 'llama.context_length'). Silent \
              fallback to 4096 has been removed; fix the GGUF file.",
-            path.display()
-        ))?;
+                path.display()
+            )
+        })?;
 
     let model_name = content
         .metadata
@@ -670,11 +689,13 @@ pub fn load_gguf_backend(
         .get("general.architecture")
         .and_then(|v| v.to_string().ok())
         .cloned()
-        .ok_or_else(|| format!(
-            "GGUF {} is missing required 'general.architecture' metadata — cannot \
+        .ok_or_else(|| {
+            format!(
+                "GGUF {} is missing required 'general.architecture' metadata — cannot \
              determine backend. Fix the GGUF file or re-export it with proper metadata.",
-            model_path.display()
-        ))?;
+                model_path.display()
+            )
+        })?;
 
     log.info(&format!("GGUF architecture: {architecture}"));
 

--- a/src/workers/continuum-core/src/inference/llamacpp_adapter.rs
+++ b/src/workers/continuum-core/src/inference/llamacpp_adapter.rs
@@ -35,12 +35,14 @@
 use crate::ai::adapter::{AIProviderAdapter, AdapterCapabilities, ApiStyle, InferenceDevice};
 use crate::ai::registry_bridge::models_for_provider_via_registry;
 use crate::ai::types::{
-    FinishReason, HealthState, HealthStatus, MessageContent, ModelInfo, TextGenerationRequest,
-    TextGenerationResponse, UsageMetrics,
+    FinishReason, HealthState, HealthStatus, MessageContent, ModelInfo, ResponseFormat,
+    TextGenerationRequest, TextGenerationResponse, UsageMetrics,
 };
 use crate::inference::backends::llamacpp::{LlamaCppBackend, LlamaCppConfig};
+use crate::inference::backends::{SamplingConfig, JSON_GRAMMAR};
 use crate::runtime;
 use async_trait::async_trait;
+use llama::FlashAttn;
 use parking_lot::RwLock;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -69,6 +71,26 @@ fn model_info_with_runtime(
     info.max_output_tokens = n_ctx;
     info.tokens_per_second = last_tok_per_s as f32;
     info
+}
+
+fn sampling_config_from_request(request: &TextGenerationRequest) -> SamplingConfig {
+    let mut sampling = SamplingConfig::chat();
+    if let Some(t) = request.temperature {
+        sampling.temperature = t as f64;
+    }
+    if let Some(k) = request.top_k {
+        sampling.top_k = k as usize;
+    }
+    if let Some(p) = request.top_p {
+        sampling.top_p = p as f64;
+    }
+    if let Some(rp) = request.repeat_penalty {
+        sampling.repeat_penalty = rp;
+    }
+    if matches!(request.response_format, Some(ResponseFormat::JsonObject)) {
+        sampling.grammar = Some(JSON_GRAMMAR.to_string());
+    }
+    sampling
 }
 
 /// Decode an `ImageInput` to raw bytes the multimodal projector can
@@ -361,6 +383,16 @@ impl LlamaCppAdapter {
             // this via with_context_length() to bound the KV cache (24GB
             // at 262K → 500MB at 16K).
             context_length: self.context_length_override,
+            // qwen3.5's recurrent/Gated-Delta-Net Metal graph aborts inside
+            // llama.cpp on the default aggressive graph shape. Keep this path
+            // GPU-only but choose a conservative graph explicitly: single seq,
+            // no FlashAttention auto-upgrade, smaller ubatch. That preserves
+            // Rust-owned local inference while avoiding the known abort path.
+            n_seq_max: 1,
+            n_ubatch: 128,
+            flash_attn: FlashAttn::Disabled,
+            fused_gdn_ar: false,
+            fused_gdn_ch: false,
             type_k: active_kv.k,
             type_v: active_kv.v,
             ..Default::default()
@@ -630,32 +662,7 @@ impl AIProviderAdapter for LlamaCppAdapter {
             .max_tokens
             .map(|n| n as usize)
             .unwrap_or_else(|| backend.n_ctx_train() as usize);
-        // Build the full SamplingConfig from the request. Caller's fields
-        // override our defaults; if caller asked for JsonObject response
-        // format, attach the JSON grammar so output is structurally valid.
-        // Same value-object pattern Joel called for ('pass the struct').
-        use crate::inference::backends::{SamplingConfig, JSON_GRAMMAR};
-        let mut sampling = SamplingConfig::chat();
-        if let Some(t) = request.temperature {
-            sampling.temperature = t as f64;
-        }
-        if let Some(k) = request.top_k {
-            sampling.top_k = k as usize;
-        }
-        if let Some(p) = request.top_p {
-            sampling.top_p = p as f64;
-        }
-        if let Some(rp) = request.repeat_penalty {
-            sampling.repeat_penalty = rp;
-        }
-        // GRAMMAR ENFORCEMENT DISABLED. Wiring response_format=JsonObject
-        // to llama.cpp grammar via llama_sampler_init_grammar crashed the
-        // scheduler ('scheduler closed without Done event'); the grammar
-        // string or pointer-handling needs more diagnosis. Falling back to
-        // prompt-only JSON guidance — cognition's existing parser tolerates
-        // model deviations. Re-enable once grammar is verified safe.
-        let _ = request.response_format; // suppress unused warning
-        let _ = JSON_GRAMMAR;
+        let sampling = sampling_config_from_request(&request);
         // Stop sequences = caller-supplied + model's registry-declared
         // text-form stops. Some GGUFs (the forged qwen3.5 included) carry
         // the wrong tokenizer.ggml.eos_token_id, so is_eog_token never
@@ -867,9 +874,38 @@ impl AIProviderAdapter for LlamaCppAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ai::{ChatMessage, MessageContent};
     use crate::model_registry::types::{Arch, MultiPartyChatStrategy};
     use crate::model_registry::Model;
     use std::collections::BTreeSet;
+
+    fn text_request(response_format: Option<ResponseFormat>) -> TextGenerationRequest {
+        TextGenerationRequest {
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: MessageContent::Text("Return JSON.".to_string()),
+                name: None,
+            }],
+            system_prompt: None,
+            model: None,
+            provider: None,
+            temperature: None,
+            max_tokens: None,
+            top_p: None,
+            top_k: None,
+            repeat_penalty: None,
+            stop_sequences: None,
+            tools: None,
+            tool_choice: None,
+            response_format,
+            active_adapters: None,
+            request_id: None,
+            user_id: None,
+            room_id: None,
+            purpose: None,
+            persona_id: None,
+        }
+    }
 
     fn synthetic_llamacpp_local_model(id: &str, gguf_path: Option<PathBuf>) -> Model {
         Model {
@@ -916,6 +952,19 @@ mod tests {
     }
 
     #[test]
+    fn json_object_response_format_enables_json_grammar() {
+        let sampling =
+            sampling_config_from_request(&text_request(Some(ResponseFormat::JsonObject)));
+        assert_eq!(sampling.grammar.as_deref(), Some(JSON_GRAMMAR));
+    }
+
+    #[test]
+    fn text_response_format_leaves_grammar_unconstrained() {
+        let sampling = sampling_config_from_request(&text_request(Some(ResponseFormat::Text)));
+        assert!(sampling.grammar.is_none());
+    }
+
+    #[test]
     fn try_new_from_errors_when_llamacpp_rows_exist_but_none_have_gguf_path() {
         // Registry has llamacpp-local rows but artifact resolver couldn't
         // find the GGUF on disk for any of them — `gguf_local_path` is
@@ -946,10 +995,7 @@ mod tests {
         let resolved_path = PathBuf::from("/tmp/synthetic-test-only.gguf");
         let models = vec![
             synthetic_llamacpp_local_model("qwen3.5-4b-code-forged-GGUF", None),
-            synthetic_llamacpp_local_model(
-                "qwen2-vl-7b-instruct",
-                Some(resolved_path.clone()),
-            ),
+            synthetic_llamacpp_local_model("qwen2-vl-7b-instruct", Some(resolved_path.clone())),
         ];
         match LlamaCppAdapter::try_new_from(models.iter()) {
             Ok(adapter) => {

--- a/src/workers/continuum-core/tests/common/mod.rs
+++ b/src/workers/continuum-core/tests/common/mod.rs
@@ -203,9 +203,7 @@ pub fn server_is_running() -> bool {
 pub fn dmr_model_gguf(model_name: &str) -> Option<std::path::PathBuf> {
     let env_override_var = format!(
         "TEST_MODEL_PATH_{}",
-        model_name
-            .to_uppercase()
-            .replace(['/', '.', '-', ':'], "_")
+        model_name.to_uppercase().replace(['/', '.', '-', ':'], "_")
     );
     if let Ok(p) = std::env::var(&env_override_var) {
         let pb = std::path::PathBuf::from(p);
@@ -283,6 +281,13 @@ fn lookup_dmr_bundle(model_name: &str) -> Option<std::path::PathBuf> {
 /// install hint.
 #[allow(dead_code)]
 pub fn qwen35_4b_code_gguf() -> Option<std::path::PathBuf> {
+    if let Ok(path) = std::env::var("QWEN35_4B_GGUF") {
+        let path = std::path::PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
     for name in [
         "huggingface.co/continuum-ai/qwen3.5-4b-code-forged-gguf",
         "hf.co/continuum-ai/qwen3.5-4b-code-forged-gguf",

--- a/src/workers/continuum-core/tests/llamacpp_metal_throughput.rs
+++ b/src/workers/continuum-core/tests/llamacpp_metal_throughput.rs
@@ -24,6 +24,7 @@
 
 use continuum_core::inference::backends::llamacpp::{LlamaCppBackend, LlamaCppConfig};
 use continuum_core::inference::backends::SamplingConfig;
+use llama::FlashAttn;
 use std::env;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -95,6 +96,12 @@ fn qwen35_4b_metal_throughput_via_bundled_llamacpp() {
     let config = LlamaCppConfig {
         model_path,
         n_gpu_layers: -1, // Offload all layers to GPU (Metal on Mac)
+        context_length: Some(32768),
+        n_seq_max: 1,
+        n_ubatch: 128,
+        flash_attn: FlashAttn::Disabled,
+        fused_gdn_ar: false,
+        fused_gdn_ch: false,
         ..Default::default()
     };
     let backend = LlamaCppBackend::load(config).expect("failed to load llama.cpp backend");
@@ -292,7 +299,6 @@ fn qwen35_4b_spec_dec_throughput() {
 
     // Seed: sample target's first token (off the prompt's last-token logits).
     let mut last_token = target_sampler.sample(&target_ctx, prompt_len - 1);
-    target_sampler.accept(last_token);
     output_tokens.push(last_token);
 
     // Prime draft with the same first token so both contexts agree on pos.
@@ -316,7 +322,6 @@ fn qwen35_4b_spec_dec_throughput() {
             // draft's last decode had logits at its last position; sample from there
             let draft_last_logit_idx = if k == 0 { 0 } else { 0 }; // always position 0 of last batch
             let next = draft_sampler.sample(&draft_ctx, draft_last_logit_idx);
-            draft_sampler.accept(next);
             drafts.push(next);
             // feed next into draft so it can produce draft[k+1]
             let mut batch = Batch::allocated(1, 1);
@@ -349,7 +354,6 @@ fn qwen35_4b_spec_dec_throughput() {
         for i in 0..k_drafted {
             let tgt_pred = target_sampler.sample(&target_ctx, i as i32);
             if tgt_pred == drafts[i] {
-                target_sampler.accept(tgt_pred);
                 accepted += 1;
             } else {
                 correction = Some(tgt_pred);
@@ -388,7 +392,6 @@ fn qwen35_4b_spec_dec_throughput() {
                 // [p0, p1). Passing p1 = -1 means "to the end". So we cut everything
                 // from pos+accepted inclusive — BOTH contexts had drafts[accepted] or
                 // later cached there and none of that is valid anymore.
-                target_sampler.accept(c);
                 output_tokens.push(c);
                 last_token = c;
                 let cut_pos = pos + accepted as i32;
@@ -410,7 +413,6 @@ fn qwen35_4b_spec_dec_throughput() {
                 // Target's logits_ith(K-1) gives the prediction for position pos+K
                 // (what comes after drafts[K-1]). Bonus token lands at position pos+k_drafted.
                 let bonus = target_sampler.sample(&target_ctx, (k_drafted - 1) as i32);
-                target_sampler.accept(bonus);
                 output_tokens.push(bonus);
                 last_token = bonus;
                 let bonus_pos = pos + k_drafted as i32;

--- a/src/workers/continuum-core/tests/qwen35_chat_pipeline_full.rs
+++ b/src/workers/continuum-core/tests/qwen35_chat_pipeline_full.rs
@@ -13,8 +13,8 @@
 //!   cargo test --release --test qwen35_chat_pipeline_full -- --ignored --nocapture
 
 use continuum_core::inference::backends::llamacpp::{LlamaCppBackend, LlamaCppConfig};
-use continuum_core::inference::backends::SamplingConfig;
-use llama::{render_chat, ChatMsg};
+use continuum_core::inference::backends::{SamplingConfig, JSON_GRAMMAR};
+use llama::{render_chat, ChatMsg, FlashAttn};
 use std::path::PathBuf;
 
 mod common;
@@ -33,6 +33,12 @@ fn qwen35_persona_style_chat_produces_coherent_short_reply() {
     let backend = LlamaCppBackend::load(LlamaCppConfig {
         model_path: PathBuf::from(model_path()),
         n_gpu_layers: -1,
+        context_length: Some(32_768),
+        n_seq_max: 1,
+        n_ubatch: 128,
+        flash_attn: FlashAttn::Disabled,
+        fused_gdn_ar: false,
+        fused_gdn_ch: false,
         ..Default::default()
     })
     .expect("load");
@@ -98,5 +104,50 @@ fn qwen35_persona_style_chat_produces_coherent_short_reply() {
     assert!(
         text.contains("84") || text.contains("eighty-four") || text.contains("eighty four"),
         "answer (84) not in output: {text:?}"
+    );
+}
+
+#[test]
+#[ignore = "requires local GGUF; cargo test --release --test qwen35_chat_pipeline_full -- --ignored --nocapture"]
+fn qwen35_scheduler_json_grammar_returns_object() {
+    let backend = LlamaCppBackend::load(LlamaCppConfig {
+        model_path: PathBuf::from(model_path()),
+        n_gpu_layers: -1,
+        context_length: Some(32_768),
+        n_seq_max: 1,
+        n_ubatch: 128,
+        flash_attn: FlashAttn::Disabled,
+        fused_gdn_ar: false,
+        fused_gdn_ch: false,
+        ..Default::default()
+    })
+    .expect("load");
+
+    let messages = vec![
+        ChatMsg {
+            role: "system".to_string(),
+            content: "Return only a compact JSON object with key ok and boolean value true."
+                .to_string(),
+        },
+        ChatMsg {
+            role: "user".to_string(),
+            content: "Report whether the cognition pipeline is live.".to_string(),
+        },
+    ];
+    let prompt = render_chat(Some(CHATML), &messages, true).expect("render_chat");
+    let sampling = SamplingConfig {
+        grammar: Some(JSON_GRAMMAR.to_string()),
+        ..SamplingConfig::chat()
+    };
+
+    let (text, n_tokens) = backend
+        .generate(&prompt, 128, sampling, &["<|im_end|>", "<|endoftext|>"], &[])
+        .expect("generate");
+
+    eprintln!("[json-grammar] tokens={n_tokens} text={text:?}");
+    assert!(n_tokens > 0, "no tokens generated");
+    assert!(
+        serde_json::from_str::<serde_json::Value>(text.trim()).is_ok(),
+        "grammar-constrained output should parse as JSON object: {text:?}"
     );
 }

--- a/src/workers/continuum-core/tests/qwen35_cpu_vs_gpu_diff.rs
+++ b/src/workers/continuum-core/tests/qwen35_cpu_vs_gpu_diff.rs
@@ -59,7 +59,6 @@ fn run(n_gpu_layers: i32, label: &str) -> Vec<i32> {
     let mut text = String::new();
     for _ in 0..N_GENERATE {
         let tok = sampler.sample(&ctx, -1);
-        sampler.accept(tok);
         if model.is_eog_token(tok) {
             break;
         }

--- a/src/workers/llama/src/bin/bench.rs
+++ b/src/workers/llama/src/bin/bench.rs
@@ -20,16 +20,26 @@ fn main() {
     let load_start = Instant::now();
     let model = Model::load(
         PathBuf::from(model_path),
-        ModelParams { n_gpu_layers: -1, use_mmap: true },
-    ).expect("load");
-    println!("Loaded in {:.2}s (vocab={})", load_start.elapsed().as_secs_f64(), model.n_vocab());
+        ModelParams {
+            n_gpu_layers: -1,
+            use_mmap: true,
+        },
+    )
+    .expect("load");
+    println!(
+        "Loaded in {:.2}s (vocab={})",
+        load_start.elapsed().as_secs_f64(),
+        model.n_vocab()
+    );
 
-    let mut ctx = model.new_context(ContextParams {
-        n_ctx: 4096,
-        n_batch: 512,
-        n_seq_max: 1,
-        ..Default::default()
-    }).expect("context");
+    let mut ctx = model
+        .new_context(ContextParams {
+            n_ctx: 4096,
+            n_batch: 512,
+            n_seq_max: 1,
+            ..Default::default()
+        })
+        .expect("context");
 
     let prompt_tokens = model.tokenize(prompt, true, false).expect("tokenize");
     let prompt_len = prompt_tokens.len();
@@ -45,8 +55,12 @@ fn main() {
     ctx.decode(&batch).expect("prefill decode");
     let prefill_elapsed = prefill_start.elapsed();
     let prefill_tok_s = prompt_len as f64 / prefill_elapsed.as_secs_f64();
-    println!("Prefill: {} tokens in {:.3}s = {:.1} tok/s",
-        prompt_len, prefill_elapsed.as_secs_f64(), prefill_tok_s);
+    println!(
+        "Prefill: {} tokens in {:.3}s = {:.1} tok/s",
+        prompt_len,
+        prefill_elapsed.as_secs_f64(),
+        prefill_tok_s
+    );
 
     // Generate N tokens
     let mut sampler = Sampler::greedy();
@@ -57,8 +71,9 @@ fn main() {
 
     for _ in 0..n_tokens {
         let token = sampler.sample(&ctx, -1);
-        sampler.accept(token);
-        if model.is_eog_token(token) { break; }
+        if model.is_eog_token(token) {
+            break;
+        }
         output.push_str(&model.token_to_piece(token));
 
         batch.clear();
@@ -71,8 +86,15 @@ fn main() {
 
     let gen_elapsed = gen_start.elapsed();
     let gen_tok_s = n_decoded as f64 / gen_elapsed.as_secs_f64();
-    println!("Generation: {} tokens in {:.3}s = {:.1} tok/s",
-        n_decoded, gen_elapsed.as_secs_f64(), gen_tok_s);
+    println!(
+        "Generation: {} tokens in {:.3}s = {:.1} tok/s",
+        n_decoded,
+        gen_elapsed.as_secs_f64(),
+        gen_tok_s
+    );
     println!("\n--- Output ---\n{}\n--- End ---", output);
-    println!("\nSummary:  prefill={:.1} tok/s  generation={:.1} tok/s", prefill_tok_s, gen_tok_s);
+    println!(
+        "\nSummary:  prefill={:.1} tok/s  generation={:.1} tok/s",
+        prefill_tok_s, gen_tok_s
+    );
 }

--- a/src/workers/llama/src/safe.rs
+++ b/src/workers/llama/src/safe.rs
@@ -150,7 +150,9 @@ unsafe fn assert_gpu_backend_registered_when_expected() {
         let name = if name_ptr.is_null() {
             "<unnamed>".to_string()
         } else {
-            std::ffi::CStr::from_ptr(name_ptr).to_string_lossy().into_owned()
+            std::ffi::CStr::from_ptr(name_ptr)
+                .to_string_lossy()
+                .into_owned()
         };
         // Anything that isn't CPU counts as a GPU/accelerator device for
         // this purpose. ggml_backend_dev_type_GGML_BACKEND_DEVICE_TYPE_CPU
@@ -221,7 +223,9 @@ pub fn render_chat(
     // default. Useful for GGUFs that don't embed a template in metadata
     // (continuum-ai/qwen3.5-4b-code-forged is one such model — see
     // forge recipe TODO to add tokenizer.chat_template at next bake).
-    let tmpl_c = template.map(|t| CString::new(t).map_err(|e| format!("template has nul byte: {e}"))).transpose()?;
+    let tmpl_c = template
+        .map(|t| CString::new(t).map_err(|e| format!("template has nul byte: {e}")))
+        .transpose()?;
     let owned: Vec<(CString, CString)> = messages
         .iter()
         .map(|m| {
@@ -232,10 +236,16 @@ pub fn render_chat(
         .collect::<Result<_, _>>()?;
     let chat: Vec<sys::llama_chat_message> = owned
         .iter()
-        .map(|(r, c)| sys::llama_chat_message { role: r.as_ptr(), content: c.as_ptr() })
+        .map(|(r, c)| sys::llama_chat_message {
+            role: r.as_ptr(),
+            content: c.as_ptr(),
+        })
         .collect();
 
-    let tmpl_ptr = tmpl_c.as_ref().map(|c| c.as_ptr()).unwrap_or(std::ptr::null());
+    let tmpl_ptr = tmpl_c
+        .as_ref()
+        .map(|c| c.as_ptr())
+        .unwrap_or(std::ptr::null());
     let render = |buf: &mut Vec<i8>| -> i32 {
         unsafe {
             sys::llama_chat_apply_template(
@@ -288,7 +298,10 @@ pub struct ModelParams {
 
 impl Default for ModelParams {
     fn default() -> Self {
-        Self { n_gpu_layers: -1, use_mmap: true }
+        Self {
+            n_gpu_layers: -1,
+            use_mmap: true,
+        }
     }
 }
 
@@ -306,9 +319,8 @@ impl Model {
         ffi_params.use_mmap = params.use_mmap;
 
         let raw = unsafe { sys::llama_model_load_from_file(c_path.as_ptr(), ffi_params) };
-        let ptr = NonNull::new(raw).ok_or_else(|| {
-            format!("failed to load model from {}", path.display())
-        })?;
+        let ptr = NonNull::new(raw)
+            .ok_or_else(|| format!("failed to load model from {}", path.display()))?;
 
         Ok(Self { ptr })
     }
@@ -331,7 +343,11 @@ impl Model {
     /// rather than redefining the model's natural capability.
     pub fn n_ctx_train(&self) -> u32 {
         let n = unsafe { sys::llama_model_n_ctx_train(self.ptr.as_ptr()) };
-        if n > 0 { n as u32 } else { 0 }
+        if n > 0 {
+            n as u32
+        } else {
+            0
+        }
     }
 
     /// Create an inference context.
@@ -339,12 +355,15 @@ impl Model {
         let mut ffi = unsafe { sys::llama_context_default_params() };
         ffi.n_ctx = params.n_ctx;
         ffi.n_batch = params.n_batch;
+        ffi.n_ubatch = params.n_ubatch;
         ffi.n_seq_max = params.n_seq_max;
         ffi.flash_attn_type = match params.flash_attn {
             FlashAttn::Auto => sys::llama_flash_attn_type_LLAMA_FLASH_ATTN_TYPE_AUTO,
             FlashAttn::Enabled => sys::llama_flash_attn_type_LLAMA_FLASH_ATTN_TYPE_ENABLED,
             FlashAttn::Disabled => sys::llama_flash_attn_type_LLAMA_FLASH_ATTN_TYPE_DISABLED,
         };
+        ffi.fused_gdn_ar = params.fused_gdn_ar;
+        ffi.fused_gdn_ch = params.fused_gdn_ch;
         ffi.type_k = match params.type_k {
             KvCacheType::F16 => sys::ggml_type_GGML_TYPE_F16,
             KvCacheType::Q8_0 => sys::ggml_type_GGML_TYPE_Q8_0,
@@ -356,7 +375,10 @@ impl Model {
 
         let raw = unsafe { sys::llama_new_context_with_model(self.ptr.as_ptr(), ffi) };
         let ctx = NonNull::new(raw).ok_or_else(|| "failed to create context".to_string())?;
-        Ok(Context { ptr: ctx, _model: PhantomData })
+        Ok(Context {
+            ptr: ctx,
+            _model: PhantomData,
+        })
     }
 
     /// Load a LoRA adapter bound to this model. Used for genome paging.
@@ -372,9 +394,8 @@ impl Model {
         let c_path = CString::new(path.to_string_lossy().as_bytes())
             .map_err(|e| format!("invalid path: {e}"))?;
         let raw = unsafe { sys::llama_adapter_lora_init(self.ptr.as_ptr(), c_path.as_ptr()) };
-        let ptr = NonNull::new(raw).ok_or_else(|| {
-            format!("failed to load LoRA from {}", path.display())
-        })?;
+        let ptr = NonNull::new(raw)
+            .ok_or_else(|| format!("failed to load LoRA from {}", path.display()))?;
         Ok(LoraAdapter { ptr })
     }
 
@@ -424,7 +445,10 @@ impl Model {
         if p.is_null() {
             None
         } else {
-            unsafe { std::ffi::CStr::from_ptr(p) }.to_str().ok().map(String::from)
+            unsafe { std::ffi::CStr::from_ptr(p) }
+                .to_str()
+                .ok()
+                .map(String::from)
         }
     }
 
@@ -442,7 +466,9 @@ impl Model {
                 false,
             )
         };
-        if n < 0 { return String::new(); }
+        if n < 0 {
+            return String::new();
+        }
         buf.truncate(n as usize);
         String::from_utf8_lossy(&buf).into_owned()
     }
@@ -467,7 +493,9 @@ impl Model {
 
 impl Drop for Model {
     fn drop(&mut self) {
-        unsafe { sys::llama_model_free(self.ptr.as_ptr()); }
+        unsafe {
+            sys::llama_model_free(self.ptr.as_ptr());
+        }
     }
 }
 
@@ -486,7 +514,9 @@ unsafe impl Sync for LoraAdapter {}
 
 impl Drop for LoraAdapter {
     fn drop(&mut self) {
-        unsafe { sys::llama_adapter_lora_free(self.ptr.as_ptr()); }
+        unsafe {
+            sys::llama_adapter_lora_free(self.ptr.as_ptr());
+        }
     }
 }
 
@@ -521,6 +551,11 @@ pub enum KvCacheType {
 pub struct ContextParams {
     pub n_ctx: u32,
     pub n_batch: u32,
+    /// Physical Metal/CUDA graph size for prompt processing. Keep separate
+    /// from n_batch so the scheduler can accept larger logical prompt chunks
+    /// while reserving smaller backend graphs on model families with fragile
+    /// fused kernels.
+    pub n_ubatch: u32,
     /// Maximum parallel sequences. Default llama.cpp sets this > 1 which
     /// DIVIDES n_ctx among sequences — a 4096 n_ctx with default n_seq_max
     /// yields only ~512-1024 usable positions per sequence, making RAG
@@ -529,6 +564,12 @@ pub struct ContextParams {
     pub n_seq_max: u32,
     /// Flash attention setting. Default `Auto` — runtime picks per-backend.
     pub flash_attn: FlashAttn,
+    /// Fused Gated Delta Net autoregressive graph. Some new Metal stacks can
+    /// compile the kernels but throw foreign exceptions during graph setup;
+    /// callers can disable the fused graph while keeping the model on GPU.
+    pub fused_gdn_ar: bool,
+    /// Fused Gated Delta Net chunked graph. Same contract as fused_gdn_ar.
+    pub fused_gdn_ch: bool,
     /// KV cache element type for K. Default `F16` (lossless).
     pub type_k: KvCacheType,
     /// KV cache element type for V. Default `F16` (lossless).
@@ -540,8 +581,11 @@ impl Default for ContextParams {
         Self {
             n_ctx: 4096,
             n_batch: 512,
+            n_ubatch: 512,
             n_seq_max: 1,
             flash_attn: FlashAttn::Auto,
+            fused_gdn_ar: true,
+            fused_gdn_ch: true,
             type_k: KvCacheType::F16,
             type_v: KvCacheType::F16,
         }
@@ -606,9 +650,9 @@ impl<'m> Context<'m> {
     ///
     /// Use `-1` for the last token that had logits requested.
     pub fn logits_ith(&self, i: i32) -> &[f32] {
-        let n_vocab = unsafe {
-            sys::llama_vocab_n_tokens(sys::llama_model_get_vocab(self.model_ptr()))
-        } as usize;
+        let n_vocab =
+            unsafe { sys::llama_vocab_n_tokens(sys::llama_model_get_vocab(self.model_ptr())) }
+                as usize;
         unsafe {
             let ptr = sys::llama_get_logits_ith(self.ptr.as_ptr(), i);
             if ptr.is_null() {
@@ -622,9 +666,9 @@ impl<'m> Context<'m> {
     /// Mutable logits for the i-th position — for repetition penalty / logit bias
     /// applied before sampling without routing through a sampler.
     pub fn logits_ith_mut(&mut self, i: i32) -> &mut [f32] {
-        let n_vocab = unsafe {
-            sys::llama_vocab_n_tokens(sys::llama_model_get_vocab(self.model_ptr()))
-        } as usize;
+        let n_vocab =
+            unsafe { sys::llama_vocab_n_tokens(sys::llama_model_get_vocab(self.model_ptr())) }
+                as usize;
         unsafe {
             let ptr = sys::llama_get_logits_ith(self.ptr.as_ptr(), i);
             if ptr.is_null() {
@@ -646,12 +690,24 @@ impl<'m> Context<'m> {
         let rc = unsafe {
             sys::llama_set_adapters_lora(
                 self.ptr.as_ptr(),
-                if ptrs.is_empty() { std::ptr::null_mut() } else { ptrs.as_mut_ptr() },
+                if ptrs.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    ptrs.as_mut_ptr()
+                },
                 ptrs.len(),
-                if scales.is_empty() { std::ptr::null_mut() } else { scales.as_mut_ptr() },
+                if scales.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    scales.as_mut_ptr()
+                },
             )
         };
-        if rc == 0 { Ok(()) } else { Err(format!("llama_set_adapters_lora returned {rc}")) }
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(format!("llama_set_adapters_lora returned {rc}"))
+        }
     }
 
     /// Clear all LoRA adapters.
@@ -661,7 +717,9 @@ impl<'m> Context<'m> {
 
     /// Number of threads used for single-token generation.
     pub fn set_n_threads(&mut self, n_threads: i32, n_threads_batch: i32) {
-        unsafe { sys::llama_set_n_threads(self.ptr.as_ptr(), n_threads, n_threads_batch); }
+        unsafe {
+            sys::llama_set_n_threads(self.ptr.as_ptr(), n_threads, n_threads_batch);
+        }
     }
 
     fn model_ptr(&self) -> *const sys::llama_model {
@@ -701,7 +759,9 @@ impl<'m> Context<'m> {
 
 impl<'m> Drop for Context<'m> {
     fn drop(&mut self) {
-        unsafe { sys::llama_free(self.ptr.as_ptr()); }
+        unsafe {
+            sys::llama_free(self.ptr.as_ptr());
+        }
     }
 }
 
@@ -741,10 +801,11 @@ impl Batch {
         backend_init();
         // SAFETY: tokens' backing storage is kept alive via storage field;
         // llama_batch_get_one points at the slice, does not take ownership.
-        let inner = unsafe {
-            sys::llama_batch_get_one(tokens.as_mut_ptr(), tokens.len() as i32)
-        };
-        Self { inner, storage: BatchStorage::OneSequence(tokens) }
+        let inner = unsafe { sys::llama_batch_get_one(tokens.as_mut_ptr(), tokens.len() as i32) };
+        Self {
+            inner,
+            storage: BatchStorage::OneSequence(tokens),
+        }
     }
 
     /// Preallocated batch capable of holding up to `n_tokens` with up to
@@ -754,7 +815,10 @@ impl Batch {
         let inner = unsafe { sys::llama_batch_init(n_tokens, 0, n_seq_max) };
         let mut b = Self {
             inner,
-            storage: BatchStorage::Allocated { n_seq_max, capacity: n_tokens },
+            storage: BatchStorage::Allocated {
+                n_seq_max,
+                capacity: n_tokens,
+            },
         };
         // init leaves n_tokens uninitialized; clear forces it to 0.
         b.clear();
@@ -766,7 +830,10 @@ impl Batch {
     /// `seq_ids.len() > n_seq_max`.
     pub fn push(&mut self, token: i32, pos: i32, seq_ids: &[i32], want_logits: bool) {
         let (n_seq_max, capacity) = match self.storage {
-            BatchStorage::Allocated { n_seq_max, capacity } => (n_seq_max, capacity),
+            BatchStorage::Allocated {
+                n_seq_max,
+                capacity,
+            } => (n_seq_max, capacity),
             BatchStorage::OneSequence(_) => panic!("push() on single-sequence batch"),
         };
         assert!(
@@ -774,12 +841,14 @@ impl Batch {
             "Batch::push overflow: n_tokens={} already at capacity={}. \
              Chunk your prefill into capacity-sized decode calls \
              (prompts longer than the batch size must be decoded in pieces).",
-            self.inner.n_tokens, capacity
+            self.inner.n_tokens,
+            capacity
         );
         assert!(
             seq_ids.len() as i32 <= n_seq_max,
             "seq_ids.len()={} exceeds n_seq_max={}",
-            seq_ids.len(), n_seq_max
+            seq_ids.len(),
+            n_seq_max
         );
         let idx = self.inner.n_tokens as usize;
         // SAFETY: we write INTO llama-allocated arrays (token/pos/n_seq_id/
@@ -812,7 +881,9 @@ impl Batch {
 impl Drop for Batch {
     fn drop(&mut self) {
         if matches!(self.storage, BatchStorage::Allocated { .. }) {
-            unsafe { sys::llama_batch_free(self.inner); }
+            unsafe {
+                sys::llama_batch_free(self.inner);
+            }
         }
         // OneSequence: Vec drop handles token memory; batch struct itself is
         // stack-allocated, no free needed.
@@ -834,7 +905,9 @@ impl Sampler {
     pub fn greedy() -> Self {
         let raw = unsafe { sys::llama_sampler_init_greedy() };
         // SAFETY: init_greedy is infallible in upstream llama.cpp.
-        Self { ptr: NonNull::new(raw).expect("llama_sampler_init_greedy returned null") }
+        Self {
+            ptr: NonNull::new(raw).expect("llama_sampler_init_greedy returned null"),
+        }
     }
 
     /// Start building a sampler chain. Samplers apply in insertion order;
@@ -848,27 +921,35 @@ impl Sampler {
         }
     }
 
-    /// Sample the next token from logits at `idx` in the context. Updates the
-    /// sampler's internal state (e.g., penalties).
+    /// Sample and accept the next token from logits at `idx` in the context.
+    /// llama.cpp's `llama_sampler_sample` applies the sampler chain and then
+    /// calls `llama_sampler_accept` before returning; callers must not accept
+    /// the returned token again.
     pub fn sample(&mut self, ctx: &Context<'_>, idx: i32) -> i32 {
         unsafe { sys::llama_sampler_sample(self.ptr.as_ptr(), ctx.ptr.as_ptr(), idx) }
     }
 
-    /// Notify the sampler a token was accepted (for stateful samplers like
-    /// penalties / mirostat). Usually called after sample() by the caller.
+    /// Notify the sampler that an externally-selected token was accepted.
+    /// Do not call this after `sample()`; `sample()` already accepts.
     pub fn accept(&mut self, token: i32) {
-        unsafe { sys::llama_sampler_accept(self.ptr.as_ptr(), token); }
+        unsafe {
+            sys::llama_sampler_accept(self.ptr.as_ptr(), token);
+        }
     }
 
     /// Reset sampler state (e.g., clear penalty history).
     pub fn reset(&mut self) {
-        unsafe { sys::llama_sampler_reset(self.ptr.as_ptr()); }
+        unsafe {
+            sys::llama_sampler_reset(self.ptr.as_ptr());
+        }
     }
 }
 
 impl Drop for Sampler {
     fn drop(&mut self) {
-        unsafe { sys::llama_sampler_free(self.ptr.as_ptr()); }
+        unsafe {
+            sys::llama_sampler_free(self.ptr.as_ptr());
+        }
     }
 }
 
@@ -880,7 +961,9 @@ pub struct SamplerChainBuilder {
 impl SamplerChainBuilder {
     fn add(self, smpl: *mut sys::llama_sampler) -> Self {
         // SAFETY: chain takes ownership of smpl per llama.h docs.
-        unsafe { sys::llama_sampler_chain_add(self.chain.as_ptr(), smpl); }
+        unsafe {
+            sys::llama_sampler_chain_add(self.chain.as_ptr(), smpl);
+        }
         self
     }
 
@@ -906,16 +989,8 @@ impl SamplerChainBuilder {
 
     /// Repetition/frequency/presence penalties, llama.cpp style.
     /// `last_n` = number of recent tokens to consider (0 disables, -1 = n_ctx).
-    pub fn penalties(
-        self,
-        last_n: i32,
-        repeat: f32,
-        freq: f32,
-        presence: f32,
-    ) -> Self {
-        let s = unsafe {
-            sys::llama_sampler_init_penalties(last_n, repeat, freq, presence)
-        };
+    pub fn penalties(self, last_n: i32, repeat: f32, freq: f32, presence: f32) -> Self {
+        let s = unsafe { sys::llama_sampler_init_penalties(last_n, repeat, freq, presence) };
         self.add(s)
     }
 

--- a/src/workers/llama/tests/concurrent_streams_test.rs
+++ b/src/workers/llama/tests/concurrent_streams_test.rs
@@ -26,8 +26,8 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Instant;
 use std::thread;
+use std::time::Instant;
 
 use llama::{Batch, ContextParams, Model, ModelParams, Sampler};
 
@@ -38,7 +38,9 @@ fn test_model() -> Option<PathBuf> {
             .join("models--continuum-ai--qwen3.5-4b-code-forged-GGUF/snapshots")
             .join("6cfe43981913730b1abc4ad520510a24b3f05922")
             .join("qwen3.5-4b-code-forged-Q4_K_M.gguf");
-        if p.exists() { return Some(p); }
+        if p.exists() {
+            return Some(p);
+        }
     }
     None
 }
@@ -71,8 +73,9 @@ fn generate_once(model: &Model, prompt: &str, max_tokens: usize) -> (usize, u128
     let start = Instant::now();
     for _ in 0..max_tokens {
         let token = sampler.sample(&ctx, -1);
-        sampler.accept(token);
-        if model.is_eog_token(token) { break; }
+        if model.is_eog_token(token) {
+            break;
+        }
         batch.clear();
         batch.push(token, n_cur, &[0], true);
         ctx.decode(&batch).expect("gen");
@@ -84,11 +87,7 @@ fn generate_once(model: &Model, prompt: &str, max_tokens: usize) -> (usize, u128
 
 /// Helper: load model once, run N parallel generate calls on the same
 /// Arc<Model>. Returns (per-thread token counts, wall-clock ms).
-fn run_concurrent(
-    n_streams: usize,
-    prompt: &str,
-    max_tokens: usize,
-) -> Option<(Vec<usize>, u128)> {
+fn run_concurrent(n_streams: usize, prompt: &str, max_tokens: usize) -> Option<(Vec<usize>, u128)> {
     let path = test_model()?;
     let model = Arc::new(Model::load(&path, ModelParams::default()).ok()?);
 
@@ -120,7 +119,10 @@ fn run_concurrent(
 fn no_corruption_two_streams() {
     let path = match test_model() {
         Some(p) => p,
-        None => { eprintln!("no model — skipping"); return; }
+        None => {
+            eprintln!("no model — skipping");
+            return;
+        }
     };
     let model = Arc::new(Model::load(&path, ModelParams::default()).expect("load"));
 
@@ -144,7 +146,10 @@ fn no_corruption_two_streams() {
 fn no_corruption_four_streams() {
     let model = match test_model().and_then(|p| Model::load(&p, ModelParams::default()).ok()) {
         Some(m) => Arc::new(m),
-        None => { eprintln!("no model — skipping"); return; }
+        None => {
+            eprintln!("no model — skipping");
+            return;
+        }
     };
 
     let prompts = [
@@ -154,10 +159,13 @@ fn no_corruption_four_streams() {
         "fn gcd(a: u32, b: u32) -> u32 {\n",
     ];
 
-    let handles: Vec<_> = prompts.iter().map(|&p| {
-        let m = Arc::clone(&model);
-        thread::spawn(move || generate_once(&m, p, 8))
-    }).collect();
+    let handles: Vec<_> = prompts
+        .iter()
+        .map(|&p| {
+            let m = Arc::clone(&model);
+            thread::spawn(move || generate_once(&m, p, 8))
+        })
+        .collect();
 
     for (i, h) in handles.into_iter().enumerate() {
         let (n, _) = h.join().unwrap();
@@ -175,7 +183,10 @@ fn no_corruption_four_streams() {
 fn solo_throughput_baseline() {
     let path = match test_model() {
         Some(p) => p,
-        None => { eprintln!("no model — skipping"); return; }
+        None => {
+            eprintln!("no model — skipping");
+            return;
+        }
     };
     let model = Model::load(&path, ModelParams::default()).expect("load");
     let _ = generate_once(&model, "warm", 4); // warmup
@@ -205,7 +216,10 @@ fn concurrent_streams_match_solo_throughput() {
     // Solo baseline
     let path = match test_model() {
         Some(p) => p,
-        None => { eprintln!("no model — skipping"); return; }
+        None => {
+            eprintln!("no model — skipping");
+            return;
+        }
     };
     let model = Model::load(&path, ModelParams::default()).expect("load");
     let _ = generate_once(&model, "warm", 4);
@@ -216,7 +230,10 @@ fn concurrent_streams_match_solo_throughput() {
     // 4-stream concurrent run, same prompt + max_tokens
     let (tok_counts, wall_ms) = match run_concurrent(4, "fn add(a: u32, b: u32) -> u32 {\n", 32) {
         Some(x) => x,
-        None => { eprintln!("concurrent run failed — skipping"); return; }
+        None => {
+            eprintln!("concurrent run failed — skipping");
+            return;
+        }
     };
 
     let total_tokens: usize = tok_counts.iter().sum();
@@ -227,8 +244,10 @@ fn concurrent_streams_match_solo_throughput() {
     eprintln!("SOLO:        {:.1} tok/s", solo_tok_s);
     eprintln!("CONCURRENT:  {} streams produced {} tok in {} ms = {:.1} tok/s aggregate, {:.1} tok/s per stream",
         tok_counts.len(), total_tokens, wall_ms, aggregate_tok_s, per_stream_tok_s);
-    eprintln!("EFFICIENCY:  {:.2}x solo per stream  (1.0 = perfect batching, 0.25 = serialized 4-way)",
-        efficiency);
+    eprintln!(
+        "EFFICIENCY:  {:.2}x solo per stream  (1.0 = perfect batching, 0.25 = serialized 4-way)",
+        efficiency
+    );
 
     // Per-call-context on 4 streams should land near 0.25x (serialized).
     // Floor is 0.15x — catches deadlocks/starvation without flagging
@@ -244,16 +263,21 @@ fn concurrent_does_not_panic_or_segv() {
     // races, double-frees in shared Model, batch buffer aliasing.
     let model = match test_model().and_then(|p| Model::load(&p, ModelParams::default()).ok()) {
         Some(m) => Arc::new(m),
-        None => { eprintln!("no model — skipping"); return; }
+        None => {
+            eprintln!("no model — skipping");
+            return;
+        }
     };
 
-    let handles: Vec<_> = (0..8).map(|i| {
-        let m = Arc::clone(&model);
-        thread::spawn(move || {
-            let p = format!("fn f_{}() {{\n", i);
-            generate_once(&m, &p, 4)
+    let handles: Vec<_> = (0..8)
+        .map(|i| {
+            let m = Arc::clone(&model);
+            thread::spawn(move || {
+                let p = format!("fn f_{}() {{\n", i);
+                generate_once(&m, &p, 4)
+            })
         })
-    }).collect();
+        .collect();
 
     let mut survived = 0;
     for h in handles {

--- a/src/workers/llama/tests/context_test.rs
+++ b/src/workers/llama/tests/context_test.rs
@@ -1,14 +1,16 @@
 //! Isolated tests for Context — each test exercises one thing.
 //! Run: cargo test --release -p llama --features metal --test context_test
 
-use std::path::PathBuf;
 use llama::{Batch, ContextParams, Model, ModelParams, Sampler};
+use std::path::PathBuf;
 
 /// Find a test model. Mirrors model_test.rs — keep in sync.
 fn test_model() -> Option<PathBuf> {
     for candidate in ["/tmp/qwen25_3b.gguf", "/tmp/test_model.gguf"] {
         let p = PathBuf::from(candidate);
-        if p.exists() { return Some(p); }
+        if p.exists() {
+            return Some(p);
+        }
     }
     if let Ok(home) = std::env::var("HOME") {
         let p = PathBuf::from(home)
@@ -16,7 +18,9 @@ fn test_model() -> Option<PathBuf> {
             .join("models--continuum-ai--qwen3.5-4b-code-forged-GGUF/snapshots")
             .join("6cfe43981913730b1abc4ad520510a24b3f05922")
             .join("qwen3.5-4b-code-forged-Q4_K_M.gguf");
-        if p.exists() { return Some(p); }
+        if p.exists() {
+            return Some(p);
+        }
     }
     None
 }
@@ -76,7 +80,10 @@ fn batch_for_tokens_push_panics() {
 fn decode_prefill_succeeds() {
     let (model, cp) = match load() {
         Some(v) => v,
-        None => { eprintln!("no test model — skipping"); return; }
+        None => {
+            eprintln!("no test model — skipping");
+            return;
+        }
     };
     let mut ctx = model.new_context(cp).expect("context");
     let tokens = model.tokenize("Hello", true, false).expect("tokenize");
@@ -84,25 +91,33 @@ fn decode_prefill_succeeds() {
     ctx.decode(&batch).expect("decode should succeed");
     // Logits for last token should be non-empty
     let logits = ctx.logits_ith(-1);
-    assert_eq!(logits.len(), model.n_vocab() as usize,
-        "logits length must match vocab size");
+    assert_eq!(
+        logits.len(),
+        model.n_vocab() as usize,
+        "logits length must match vocab size"
+    );
 }
 
 #[test]
 fn decode_one_token_after_prefill() {
     let (model, cp) = match load() {
         Some(v) => v,
-        None => { eprintln!("no test model — skipping"); return; }
+        None => {
+            eprintln!("no test model — skipping");
+            return;
+        }
     };
     let mut ctx = model.new_context(cp).expect("context");
-    let tokens = model.tokenize("The capital of France is", true, false).expect("tokenize");
+    let tokens = model
+        .tokenize("The capital of France is", true, false)
+        .expect("tokenize");
     ctx.decode(&Batch::for_tokens(tokens)).expect("prefill");
 
     // Sample next token greedily, then feed it back as a 1-token batch
     let mut sampler = Sampler::greedy();
     let next = sampler.sample(&ctx, -1);
-    sampler.accept(next);
-    ctx.decode(&Batch::for_tokens(vec![next])).expect("one-token decode");
+    ctx.decode(&Batch::for_tokens(vec![next]))
+        .expect("one-token decode");
 
     let logits = ctx.logits_ith(-1);
     assert_eq!(logits.len(), model.n_vocab() as usize);
@@ -112,21 +127,29 @@ fn decode_one_token_after_prefill() {
 fn logits_have_finite_values() {
     let (model, cp) = match load() {
         Some(v) => v,
-        None => { eprintln!("no test model — skipping"); return; }
+        None => {
+            eprintln!("no test model — skipping");
+            return;
+        }
     };
     let mut ctx = model.new_context(cp).expect("context");
     let tokens = model.tokenize("test", true, false).expect("tokenize");
     ctx.decode(&Batch::for_tokens(tokens)).expect("decode");
     let logits = ctx.logits_ith(-1);
-    assert!(logits.iter().any(|&x| x.is_finite()),
-        "at least some logits must be finite");
+    assert!(
+        logits.iter().any(|&x| x.is_finite()),
+        "at least some logits must be finite"
+    );
     // argmax produces a sane token id
-    let (argmax, _) = logits.iter()
+    let (argmax, _) = logits
+        .iter()
         .enumerate()
         .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
         .unwrap();
-    assert!((argmax as i32) < model.n_vocab(),
-        "argmax must be a valid token id");
+    assert!(
+        (argmax as i32) < model.n_vocab(),
+        "argmax must be a valid token id"
+    );
 }
 
 // ─── Sampling ───────────────────────────────────────────────────────────
@@ -135,7 +158,10 @@ fn logits_have_finite_values() {
 fn sample_greedy_returns_argmax() {
     let (model, cp) = match load() {
         Some(v) => v,
-        None => { eprintln!("no test model — skipping"); return; }
+        None => {
+            eprintln!("no test model — skipping");
+            return;
+        }
     };
     let mut ctx = model.new_context(cp).expect("context");
     let tokens = model.tokenize("hello", true, false).expect("tokenize");
@@ -153,7 +179,10 @@ fn sample_greedy_returns_argmax() {
 fn sample_temperature_chain_builds_and_samples() {
     let (model, cp) = match load() {
         Some(v) => v,
-        None => { eprintln!("no test model — skipping"); return; }
+        None => {
+            eprintln!("no test model — skipping");
+            return;
+        }
     };
     let mut ctx = model.new_context(cp).expect("context");
     let tokens = model.tokenize("hello", true, false).expect("tokenize");
@@ -173,7 +202,10 @@ fn sample_temperature_chain_builds_and_samples() {
 fn sample_temperature_with_penalties() {
     let (model, cp) = match load() {
         Some(v) => v,
-        None => { eprintln!("no test model — skipping"); return; }
+        None => {
+            eprintln!("no test model — skipping");
+            return;
+        }
     };
     let mut ctx = model.new_context(cp).expect("context");
     let tokens = model.tokenize("hello", true, false).expect("tokenize");
@@ -185,7 +217,6 @@ fn sample_temperature_with_penalties() {
         .dist(42)
         .build();
     let tok = sampler.sample(&ctx, -1);
-    sampler.accept(tok);
     assert!(tok >= 0 && tok < model.n_vocab());
 }
 
@@ -195,7 +226,10 @@ fn sample_temperature_with_penalties() {
 fn lora_clear_on_fresh_context_is_noop() {
     let (model, cp) = match load() {
         Some(v) => v,
-        None => { eprintln!("no test model — skipping"); return; }
+        None => {
+            eprintln!("no test model — skipping");
+            return;
+        }
     };
     let mut ctx = model.new_context(cp).expect("context");
     // Clearing with no adapters loaded must not error.
@@ -206,7 +240,10 @@ fn lora_clear_on_fresh_context_is_noop() {
 fn lora_set_empty_slice_is_noop() {
     let (model, cp) = match load() {
         Some(v) => v,
-        None => { eprintln!("no test model — skipping"); return; }
+        None => {
+            eprintln!("no test model — skipping");
+            return;
+        }
     };
     let mut ctx = model.new_context(cp).expect("context");
     ctx.set_loras(&[]).expect("empty set must be ok");
@@ -216,7 +253,10 @@ fn lora_set_empty_slice_is_noop() {
 fn lora_load_fails_on_missing_file() {
     let (model, _) = match load() {
         Some(v) => v,
-        None => { eprintln!("no test model — skipping"); return; }
+        None => {
+            eprintln!("no test model — skipping");
+            return;
+        }
     };
     let result = model.load_lora("/nonexistent/adapter.gguf");
     assert!(result.is_err(), "load_lora must fail on missing file");
@@ -228,7 +268,10 @@ fn lora_load_fails_on_missing_file() {
 fn lora_hot_swap_round_trips_with_empty_sets() {
     let (model, cp) = match load() {
         Some(v) => v,
-        None => { eprintln!("no test model — skipping"); return; }
+        None => {
+            eprintln!("no test model — skipping");
+            return;
+        }
     };
     let mut ctx = model.new_context(cp).expect("context");
     // Simulate paging cycle: active set changes over time.
@@ -249,7 +292,9 @@ fn context_is_send() {
     // a worker thread, this test will need to be updated. Keeping it here
     // as a breadcrumb.
     // assert_send::<llama::Context<'_>>();
-    fn _noop() { assert_send::<()>(); }
+    fn _noop() {
+        assert_send::<()>();
+    }
     _noop();
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate llama.cpp sampler accepts after `llama_sampler_sample()`, which already accepts internally
- re-enable OpenAI-style JSON response format as real llama.cpp grammar sampling
- wire the Qwen3.5 Metal graph controls through the Rust wrapper and point the submodule at CambrianTech/llama.cpp commit e6ae163ca
- add ignored Qwen smoke coverage for JSON grammar and persona-style chat

## Verification
- cargo test --manifest-path src/workers/llama/Cargo.toml --features metal --lib
- cargo test --manifest-path src/workers/continuum-core/Cargo.toml --features metal,accelerate inference::llamacpp_adapter::tests --lib
- QWEN35_4B_GGUF=... cargo test --manifest-path src/workers/continuum-core/Cargo.toml --features metal,accelerate --test qwen35_chat_pipeline_full --release -- --ignored --nocapture
- npm exec tsc -- --noEmit --pretty false
- npm run worker:build
- npx tsx tests/precommit/chat-roundtrip.test.ts

## Notes
Pre-push TypeScript, ESLint ratchet, Rust compile, and Rust tests passed. Native Docker slice push was skipped by the hook because this local main worktree has unrelated modified tracked files; CI may still require the image verifier to be satisfied before merge.