### PR TITLE
docs(vision): refresh CONTINUUM-VISION — label TS sketches, pin concept→Rust map, cross-link truth docs

### DIFF
--- a/docs/CONTINUUM-VISION.md
+++ b/docs/CONTINUUM-VISION.md
@@ -4,6 +4,28 @@
 >
 > "Describe your experience. We'll bring it to life."
 
+> **Technical companion:** [CONTINUUM-ARCHITECTURE.md](CONTINUUM-ARCHITECTURE.md) — implementation shape, engines, IPC.
+> **Substrate contract:** [CBAR-SUBSTRATE-ARCHITECTURE.md](architecture/CBAR-SUBSTRATE-ARCHITECTURE.md) — RTOS-style runtime every Rust concern inherits.
+> **Lane-shaped roadmap:** [ALPHA-GAP-ANALYSIS.md](planning/ALPHA-GAP-ANALYSIS.md) — current state of Lanes A–G.
+
+---
+
+## Doc Status @ 2026-05-16
+
+This is the **product vision** doc — what we are building and why anyone (human or persona) would care. It is intentionally not an API spec. The TypeScript interface blocks throughout the doc are **illustrative sketches**, not the shipped Rust types — they communicate shape and intent in the most-readable syntax available, and they cross-link to the canonical Rust modules where one exists.
+
+Where the canonical type lives in Rust today:
+
+| Concept in this doc                       | Canonical Rust location                                                  |
+|-------------------------------------------|--------------------------------------------------------------------------|
+| Persona genome / LoRA adapters            | `src/workers/continuum-core/src/persona/genome_paging.rs`                |
+| Grid node / inference capability          | `src/workers/continuum-core/src/inference_capability/` (GRID-INFERENCE-ROUTING) |
+| Continuum runtime / module registry       | `src/workers/continuum-core/src/runtime/`                                |
+| Resource class / target silicon           | `src/workers/continuum-core/src/cognition/adaptive_throughput.rs`        |
+| Pressure broker                           | `src/workers/continuum-core/src/paging/broker.rs`                        |
+
+The vision-side TypeScript blocks below are kept because they read cleanly. The native-truth side is and stays Rust — per the wider rule: native layer owns the data, performance-critical logic, security-sensitive operations, and the canonical type definitions; higher-level SDKs (TS, ObjC, Kotlin, Python) own ergonomic API for their language and platform integration. They do not carry their own version of the truth.
+
 ---
 
 ## The Grand Vision
@@ -46,6 +68,8 @@ Personas assemble their capabilities from:
 2. **Fine-tuned specializations** - Adapted further for specific needs
 3. **Novel traits** - Brand new capabilities trained from scratch
 4. **Inherited combinations** - Mixing traits from multiple lineages
+
+> *Illustrative sketch.* Canonical genome / LoRA paging types live in `src/workers/continuum-core/src/persona/genome_paging.rs`.
 
 ```typescript
 // A persona's genome - assembled from the community pool + custom training
@@ -211,6 +235,8 @@ The Grid is the distributed foundation. A P2P mesh network where:
 - **Compute distribution**: Heavy tasks can be shared across nodes
 - **Natural redundancy**: No single point of failure
 
+> *Illustrative sketch.* Canonical Grid node / inference-capability types live in `src/workers/continuum-core/src/inference_capability/` (announcer + probe + registry under GRID-INFERENCE-ROUTING, PR-1 in flight on `feat/grid-inference-routing-pr2-announcer`).
+
 ```typescript
 // A Grid node - the basic building block
 interface GridNode {
@@ -241,6 +267,8 @@ Continuum runs ON the Grid. It's where life happens:
 - **Rooms contain activity**: Chat, code, canvas, video, games - all room types
 - **Genomics enables growth**: LoRA layers, training, inheritance
 - **Community enables sharing**: Adapters, skills, knowledge, collaboration
+
+> *Illustrative sketch.* No single `Continuum` struct ships in code — the system IS the assembly of `runtime::ModuleRegistry` + `paging::PressureBroker` + `persona::genome_paging::*` + room state + community-facing surfaces. This sketch shows the conceptual shape, not a Rust type.
 
 ```typescript
 // Continuum - the living system
@@ -276,6 +304,8 @@ Products are deployments FROM Continuum TO the world:
 - **Games**: Interactive experiences with AI characters
 - **Widgets**: Embeddable components for any site
 - **APIs**: AI services exposed to other systems
+
+> *Illustrative sketch — aspirational deploy API.* The deploy surface is not yet shipped as a single command; today, deployment is the engagement model and not on the alpha critical path. Shown here to communicate the product loop, not as a current API.
 
 ```typescript
 // Deploy a room as a product
@@ -504,6 +534,8 @@ FASTLY_API_KEY=...
 
 ### Multi-Target Deploy
 
+> *Illustrative sketch — aspirational deploy API.* See note above on the deploy section.
+
 ```typescript
 // Deploy to multiple targets with one command
 await continuum.deploy({
@@ -602,6 +634,14 @@ Continuum runs in Docker. Deploy anywhere:
 
 ## See Also
 
-- [POSITRON-ARCHITECTURE.md](POSITRON-ARCHITECTURE.md) - The UI framework
-- [ENTERPRISE-IVR-PRODUCT.md](ENTERPRISE-IVR-PRODUCT.md) - First product (voice AI)
-- [CONTINUUM-BUSINESS-MODEL.md](CONTINUUM-BUSINESS-MODEL.md) - How to make money
+**Technical truth docs (read these alongside this vision):**
+
+- [CONTINUUM-ARCHITECTURE.md](CONTINUUM-ARCHITECTURE.md) — implementation shape, engines, IPC.
+- [CBAR-SUBSTRATE-ARCHITECTURE.md](architecture/CBAR-SUBSTRATE-ARCHITECTURE.md) — runtime/RTOS substrate contract. Owns concurrency, scheduling, memory pressure, device pressure, telemetry, artifact handles, lifecycle.
+- [ALPHA-GAP-ANALYSIS.md](planning/ALPHA-GAP-ANALYSIS.md) — lane-shaped roadmap, current state of Lanes A–G, owners, merge gates.
+
+**Supporting:**
+
+- [POSITRON-ARCHITECTURE.md](POSITRON-ARCHITECTURE.md) — the UI framework.
+- [ENTERPRISE-IVR-PRODUCT.md](ENTERPRISE-IVR-PRODUCT.md) — first product (voice AI).
+- [CONTINUUM-BUSINESS-MODEL.md](CONTINUUM-BUSINESS-MODEL.md) — how to make money.


### PR DESCRIPTION
## What

Three surgical refinements to \`docs/CONTINUUM-VISION.md\`. Doc-only PR, no code touched. The vision voice and the product/persona story are unchanged.

## Why

CONTINUUM-VISION is the product vision doc — what we are building and why anyone (human or persona) would care. It is intentionally not an API spec. But six TypeScript interface blocks throughout the doc were reading like API references, and at least two (the genome assembly at the top, the Grid node interface) describe concepts that now have canonical Rust locations the doc never linked to. Per the architecture refresh bar, the goal is to keep the readable vision and pin the TS blocks correctly as illustrative sketches with cross-links to the native-truth Rust modules.

## Changes

### 1. Doc Status @ 2026-05-16

Names the doc as the product vision, intentionally not an API spec. Adds a concept → Rust-location map for the most-referenced shapes:

| Concept                                | Canonical Rust                                                            |
|----------------------------------------|---------------------------------------------------------------------------|
| Persona genome / LoRA adapters         | \`continuum-core/src/persona/genome_paging.rs\`                             |
| Grid node / inference capability       | \`continuum-core/src/inference_capability/\` (GRID-INFERENCE-ROUTING)       |
| Continuum runtime / module registry    | \`continuum-core/src/runtime/\`                                             |
| Resource class / target silicon        | \`continuum-core/src/cognition/adaptive_throughput.rs\`                     |
| Pressure broker                        | \`continuum-core/src/paging/broker.rs\`                                     |

Header cross-links to CONTINUUM-ARCHITECTURE, CBAR-SUBSTRATE-ARCHITECTURE, ALPHA-GAP-ANALYSIS. Restates the native-truth / thin-SDK rule: native layer owns the data + canonical types; higher-level SDKs are wrappers, not replacements.

### 2. Per-block illustrative-sketch labels

Each of the six TypeScript blocks gets a one-line italicized lead-in naming what it is (illustrative sketch / aspirational deploy API) and cross-linking to the canonical Rust location where one exists:

- Genome assembly (line 50): → \`genome_paging.rs\`
- GridNode interface (line 214): → \`inference_capability/\` + GRID-INFERENCE-ROUTING
- Continuum interface (line 245): no single struct ships; the system IS the assembly of runtime + broker + persona modules
- Product deploy (line 280): aspirational deploy API, not on alpha critical path
- Multi-target deploy (line 507): aspirational deploy API
- RoomType union (line 424): small enum, fine as sketch

The TS blocks themselves are kept intact — they read cleanly as vision-side sketches and the product story relies on them.

### 3. See Also reorganized

Leads with the three technical truth docs (CONTINUUM-ARCHITECTURE, CBAR-SUBSTRATE-ARCHITECTURE, ALPHA-GAP-ANALYSIS), then product/business docs.

## Validation

- Local precommit passed (TypeScript compile clean; no Rust/TS files staged).
- Cross-links resolved against actual file paths under \`docs/\`, \`docs/architecture/\`, \`docs/planning/\`.

## Companion PRs in flight on canary track

- **#1316** — ALPHA-GAP refresh.
- **#1317** — CONTINUUM-ARCHITECTURE refresh.
- **\`joel/docs-cbar-substrate-refine\`** (staged) — CBAR-SUBSTRATE refinement, awaiting Joel's call on precommit-hook collision.
- **airc#642** — manager-role + lane substrate design proposal.