### PR TITLE
docs(architecture): refine CBAR-SUBSTRATE — pin trait to shipped types, add engram-analyzer worked example, codex derive-macro gate

### DIFF
--- a/docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md
+++ b/docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md
@@ -58,74 +58,228 @@ the substrate do queueing, lifecycle, logging, and scheduling.
 
 ## Continuum Translation
 
-Continuum should implement the same pattern in Rust:
+Continuum already has the first half of this pattern in
+`src/workers/continuum-core/src/runtime/`. The shipped substrate is:
 
 ```rust
-pub trait RuntimeModule: Send + Sync {
-    fn name(&self) -> &'static str;
-    fn lane(&self) -> ResourceClass;
-    fn target(&self) -> TargetSilicon;
-    fn subscriptions(&self) -> &[ArtifactSelector];
-    fn cadence(&self) -> CadencePolicy;
-    fn handle(&self, frame: Arc<RuntimeFrame>, ctx: ModuleContext) -> ModuleResult;
+// src/workers/continuum-core/src/runtime/service_module.rs
+pub trait ServiceModule: Send + Sync + Any {
+    fn config(&self) -> ModuleConfig;
+    async fn initialize(&self, ctx: &ModuleContext) -> Result<(), String>;
+    async fn handle_command(&self, command: &str, params: Value) -> Result<CommandResult, String>;
+    async fn handle_event(&self, event_name: &str, payload: Value) -> Result<(), String>;
+    async fn tick(&self) -> Result<(), String>;
+}
+
+pub struct ModuleConfig {
+    pub name: &'static str,
+    pub priority: ModulePriority,
+    pub command_prefixes: &'static [&'static str],
+    pub event_subscriptions: &'static [&'static str],   // string globs today
+    pub needs_dedicated_thread: bool,
+    pub max_concurrency: usize,
+    pub tick_interval: Option<Duration>,
 }
 ```
 
-`subscriptions` and dependency wakeups are deliberate Continuum upgrades beyond
-CBAR, not a direct port. CBAR analyzers declare routing flags such as
-`needsColorFrames`, `needsRealTime`, and `videoOnly`; then they pull artifacts
-opportunistically from `CBAR_VideoFrame`. Continuum needs a richer contract
-because N personas, RAG builders, model planners, memory jobs, and bridge
-observers may all be waiting on different artifacts from the same turn. The
-runtime must know those dependencies so it can wake only the useful work,
-coalesce duplicates, and report deferrals.
+`ServiceModule` already gives Continuum: registry-mediated discovery
+(`ModuleContext::registry`), event bus pub/sub (`ModuleContext::bus`), the
+shared lazy-compute cache that fills the role `CBAR_VideoFrame`'s lazy getters
+played (`ModuleContext::compute` over `SharedCompute`), a tokio runtime
+handle, a periodic tick, and command routing. `ResourceClass` and
+`TargetSilicon` are shipped under `cognition/adaptive_throughput.rs`.
+`PressureBroker` and `ThroughputLease` are shipped under `paging/broker.rs`
+and `cognition/throughput_lease.rs`. Bootstrap PR-1/2/3 (#1307 / #1308 /
+#1310) put the broker on the runtime; PR #1313 added the lease broker.
 
-The substrate provides:
+What's missing is the *richer* contract — the one CBAR analyzers had through
+`CBAR_VideoFrame` artifact pulls plus `needsColorFrames`/`needsRealTime`/
+`videoOnly` routing flags. Continuum needs that contract because N personas,
+RAG builders, model planners, memory jobs, and bridge observers may all be
+waiting on different artifacts from the same turn:
 
-- bounded per-lane queues
-- dependency wakeups
-- realtime versus delayed lanes
-- newest-state coalescing
-- resource admission
-- GPU/model residency leases
-- per-module logs and metrics
-- flush/abort/shutdown
-- trace events
-- silence/deferred reasons
-- automatic TDD/VDD evidence capture hooks
-- fail-hard command errors
-- ts-rs exported contracts
+```rust
+// PROPOSED — extends ServiceModule, does not replace it. Each new type below
+// is a Lane D deliverable; see "Substrate Gap Analysis" for assignment.
+pub trait RuntimeModule: ServiceModule {
+    /// Typed artifact subscriptions, replacing the string-glob
+    /// `event_subscriptions` field. The runtime uses this to wake only the
+    /// useful work and to coalesce duplicates across personas.
+    fn subscriptions(&self) -> &[ArtifactSelector];
 
-The module author provides:
+    /// Typed cadence policy, generalizing the present
+    /// `tick_interval: Option<Duration>` + `ModulePriority` pair. Encodes
+    /// realtime / delayed / on-dependency-ready / on-pressure-change.
+    fn cadence(&self) -> CadencePolicy;
 
-- what artifacts it needs
-- what resource lane it uses
-- how often it should run
-- the small piece of actual work
+    /// Frame-shaped handler. Receives the immutable per-turn frame and the
+    /// existing `ModuleContext`. Returns a typed result that includes
+    /// `Deferred(reason)`, `Coalesced(into)`, and `Failed(typed_error)` so
+    /// silence is never a success.
+    async fn handle_frame(
+        &self,
+        frame: Arc<RuntimeFrame>,
+        ctx: &ModuleContext,
+    ) -> ModuleResult;
+}
+```
 
-That is the "for free" architecture.
+The richer contract is the smallest superset of `ServiceModule` that lets the
+substrate wake work from dependency readiness instead of pub/sub strings and
+treat the persona turn as a single shared frame instead of N independent
+event handlers. `ArtifactSelector`, `CadencePolicy`, `RuntimeFrame`, and
+`ModuleResult` are the four proposed-new types this lane lands.
+
+The substrate provides — today and after Lane D — the following. The "after"
+column is the target; the "today" column is what is already in canary:
+
+| Today, on `ServiceModule`                            | After Lane D, on `RuntimeModule`                                       |
+|------------------------------------------------------|-------------------------------------------------------------------------|
+| String-glob event subscriptions                      | Typed `ArtifactSelector`                                                |
+| `tick_interval` + `ModulePriority`                   | `CadencePolicy` (realtime / delayed / on-ready / on-pressure)           |
+| Command + event routing                              | Frame-shaped handler over `RuntimeFrame`                                |
+| `ResourceClass` + `TargetSilicon` declared per module| unchanged                                                               |
+| `PressureBroker` admission                           | unchanged                                                               |
+| `SharedCompute` lazy artifacts                       | promoted into `RuntimeFrame`'s lazy fields                              |
+| Per-module logs/metrics via `module_logger`          | unchanged, now also keyed by frame id                                   |
+| Flush/abort/shutdown via `ModuleRegistry`            | unchanged                                                               |
+| ts-rs exported contracts                             | unchanged                                                               |
+
+The module author provides — at either layer — only:
+
+- what artifacts it needs (subscriptions)
+- what resource lane it uses (`ResourceClass` + `TargetSilicon`)
+- how often it should run (cadence)
+- the small piece of actual work (`handle_frame` body)
+
+That is the "for free" architecture. The next section makes it concrete.
+
+## The "For Free" Triplet
+
+Inheritance from a trait is not enough on its own. The CBAR pattern only feels
+"free" because three things ship together:
+
+1. **A base trait** that every module implements. (Today `ServiceModule`;
+   tomorrow `RuntimeModule`.) Provides the contract.
+2. **A derive macro** that wires the base contract's required behavior —
+   timing spans, structured logging, metric emission, pressure-response,
+   lease renewal — onto the module type at compile time. The author writes
+   `#[derive(RuntimeModule)] struct EngramAnalyzer { ... }` once; the macro
+   emits the boilerplate that would otherwise be ten files of glue.
+3. **A scaffold generator** (`just scaffold-module <name>`) that drops a new
+   module file pre-populated with the base trait impl, default `ModuleConfig`,
+   a doc comment template, and the matching test file. The author edits four
+   lines (name, subscriptions, cadence, handler body) and has a working
+   module.
+
+Today Continuum has piece (1) only. Pieces (2) and (3) are the rest of the
+"for free" triplet — without them, every new module re-declares its own
+concurrency, retry, logging, and pressure-response, which is the friction
+Lane D and this section exist to remove.
+
+### Worked Example: A New Engram Analyzer
+
+A reader should be able to trace exactly what the developer wrote, what they
+got for free, and what tests they inherited. This is the test of the doc.
+
+The developer types one command:
+
+```bash
+just scaffold-module engram-analyzer --lane Background \
+    --target Cpu \
+    --subscribes "memory.consolidation.window"
+```
+
+The generator emits `src/workers/continuum-core/src/modules/engram_analyzer.rs`:
+
+```rust
+//! Engram analyzer — consolidates recent memory writes into compressed
+//! engram artifacts on each consolidation window.
+
+use continuum_runtime::{
+    ArtifactSelector, CadencePolicy, ModuleContext, ModuleResult,
+    ResourceClass, RuntimeFrame, RuntimeModule, TargetSilicon,
+};
+
+#[derive(RuntimeModule)]
+#[runtime(
+    name = "engram-analyzer",
+    lane = ResourceClass::Background,
+    target = TargetSilicon::Cpu,
+    cadence = CadencePolicy::OnReady,
+)]
+pub struct EngramAnalyzer {
+    // ... module-owned state, e.g. a handle to the engram store
+}
+
+impl EngramAnalyzer {
+    pub fn new() -> Self { Self {} }
+}
+
+#[runtime::handler]
+impl RuntimeModule for EngramAnalyzer {
+    fn subscriptions(&self) -> &[ArtifactSelector] {
+        &[ArtifactSelector::MemoryConsolidationWindow]
+    }
+
+    async fn handle_frame(
+        &self,
+        frame: Arc<RuntimeFrame>,
+        ctx: &ModuleContext,
+    ) -> ModuleResult {
+        let window = frame.memory_consolidation_window().await?;
+        let engram = self.compress(window).await?;
+        ctx.engram_store().write(engram).await?;
+        ModuleResult::ok()
+    }
+}
+```
+
+That is the entire file. Everything else is inherited:
+
+| Concern                                  | Source                                                        |
+|------------------------------------------|---------------------------------------------------------------|
+| Module name, lane, target, cadence       | `#[runtime(...)]` macro attribute → `ModuleConfig`            |
+| Registration with `ModuleRegistry`       | macro-generated `inventory::submit!` at module load           |
+| Tokio worker / dedicated thread choice   | derived from `ResourceClass::Background` → tokio default pool |
+| Memory pressure response                 | `PressureBroker` admits / defers `handle_frame`; if VRAM/RSS pressure rises, the macro-generated wrapper returns `Deferred(MemoryPressure)` before `handle_frame` is called |
+| CPU pressure / device pressure response  | `ThroughputLease` renewal on lane `Background`; degrades cadence under pressure with a visible reason |
+| Concurrency cap                          | from `ResourceClass`; `Background` is non-realtime so cap is shared with peer background work, not invented per-module |
+| Queue / dedupe / coalesce                | `ArtifactSelector::MemoryConsolidationWindow` → shared frame; if 3 windows arrive in 100ms, the runtime coalesces and `handle_frame` runs once with the newest |
+| Span / timing / structured log           | macro wraps `handle_frame` in `vdd_scope!`; first-token / queue-wait / execution-ms / RSS-delta land in the Standard VDD Record automatically |
+| Failure path                             | `?` on any inner call → typed `ModuleResult::Failed(reason)`; the runtime emits the failure to the trace bus, never silently |
+| `Deferred(reason)` and silence reporting | macro-emitted; `Deferred` is a first-class return, not an absence |
+| Replay test fixture                      | scaffold drops `engram_analyzer_test.rs` with one replay fixture covering happy path + one `Deferred` case |
+| ts-rs exported contract for UI/command   | `#[derive(RuntimeModule)]` registers the module name with the generated TS catalog; admin UI sees it without code edits |
+| Flush / abort / shutdown                 | `ModuleRegistry` lifecycle; analyzer is dropped cleanly when broker enters shutdown |
+
+Joel's framing was: *"need a new engram analyzer? works in its own thread
+with zero effort, responds to memory and cpu pressures, runs when it is
+needed."* The example above is the literal materialization of that sentence.
+The developer wrote four config attributes and a handler body. They got
+concurrency, scheduling, memory/CPU pressure response, observability,
+coalescing, typed failure, replay fixture, and TS exposure for free.
+
+If a new module ever has to hand-roll any of the inherited concerns, the
+substrate is missing a base capability and the fix is in the substrate, not
+the module.
 
 ## Extension Bar
 
-A new concern should normally be a few hundred lines, not a new subsystem. If a
-persona recipe, model adapter, RAG source, media observer, render observer,
-memory consolidator, or grid bridge needs to implement its own transport,
-backpressure, retry loop, logging, queue, metrics, throttle, or lifecycle, the
-substrate is missing a base capability.
+The acceptance test for the runtime pattern is unified in §"Acceptance
+Criteria for Substrate-Done" below. The shorter version, restated for the
+person about to write a new module:
 
-The acceptance test for the runtime pattern is:
-
-- New modules are small and focused.
-- Communication is inherited from the runtime bus.
-- Backpressure is inherited from the lane and pressure broker.
-- Timing and performance metrics are automatic.
-- Failure and deferred-state reporting are automatic.
-- Resource leases and handles are standard.
-- Cross-module consistency is enforced by common traits and generated types.
-- No module grows into a monolith to compensate for missing substrate behavior.
-
-This is the practical reason for the CBAR model. The architecture should make
-the correct high-performance path the shortest path for every new class/module.
+- New modules are small (a few hundred lines at most). If a persona recipe,
+  model adapter, RAG source, media observer, render observer, memory
+  consolidator, or grid bridge needs to implement its own transport,
+  backpressure, retry loop, logging, queue, metrics, throttle, or lifecycle,
+  the substrate is missing a base capability — file the substrate gap, do
+  not work around it in the module.
+- The correct high-performance path is the *shortest* path. Anti-pattern: a
+  PR that grows a module to compensate for missing substrate behavior. The
+  reviewer's job in that case is to ask which substrate gap is being papered
+  over, then route the work there.
 
 ## Timing, Logging, And VDD For Free
 
@@ -327,48 +481,127 @@ shipped and should be extended rather than replaced:
 - `ThroughputLease` and `ThroughputLeaseRevocationPolicy` in
   `workers/continuum-core/src/cognition/throughput_lease.rs`.
 - `PressureBroker` and `PressureSource` in
-  `workers/continuum-core/src/paging/broker.rs`.
-- `ServiceModule`, `ModuleRegistry`, `MessageBus`, `SharedCompute`, metrics,
-  and logging under `workers/continuum-core/src/runtime/`.
+  `workers/continuum-core/src/paging/broker.rs` (bootstrap landed via
+  PR #1307 / #1308 / #1310; runtime lease broker via PR #1313).
+- `ServiceModule`, `ModuleConfig`, `ModuleRegistry`, `MessageBus`,
+  `SharedCompute`, `ModuleContext`, metrics, and structured logging under
+  `workers/continuum-core/src/runtime/`.
 - `ChannelQueue` and related persona queue consolidation primitives under the
   persona runtime.
 
-The genuinely missing pieces are:
+The genuinely missing pieces, each cross-linked to its lane in
+[ALPHA-GAP-ANALYSIS](../planning/ALPHA-GAP-ANALYSIS.md):
 
-1. Define `RuntimeFrame` / `CognitionTurnFrame` on top of the existing
-   `ResourceClass` + `TargetSilicon` + `ThroughputLease` + `PressureBroker`
-   primitives.
-2. Add formal artifact subscription, cadence, and dependency declarations to
-   the module/job contracts. This can extend `ServiceModule` and existing
-   planner jobs; it does not require discarding the runtime registry.
-3. Move chat turn fanout onto `CognitionTurnFrame` so all personas share one
-   room/RAG/model/prompt artifact set.
-4. Attach VDD metrics to existing lanes/classes: queue depth, queue time,
-   execution time, coalesced count, deferred count, GPU residency, CPU/GPU
-   utilization, and first-response/all-response latency.
-5. Add a Qwen GPU residency gate for local generation: selected Qwen model,
-   backend, GPU layer count, unsupported layers, residency estimate, and
-   platform backend evidence must be available before the turn runs. The
-   required happy paths are Mac -> Metal, NVIDIA -> CUDA, and AMD/Intel ->
-   Vulkan. CPU graph splits or unsupported Qwen layers are blockers unless the
-   turn is explicitly degraded with a visible reason.
-6. Migrate one expensive consumer at a time: persona chat, then embeddings,
-   then memory consolidation, then media/WebRTC, then render/avatar output.
+| # | Missing piece                                                                                                                                                                                                                                                                                                                                                                                            | Owning lane                                            |
+|---|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+| 1 | `RuntimeFrame` / `CognitionTurnFrame` on top of the existing `ResourceClass` + `TargetSilicon` + `ThroughputLease` + `PressureBroker` primitives. Owns stable keys and lazy artifacts for one unit of work (chat trigger, room snapshot, RAG bundle, model selection, media handles, KV/LoRA leases, response envelopes, trace).                                                                          | Lane D                                                 |
+| 2 | Typed artifact subscription, cadence, and dependency declarations on the module contract (`ArtifactSelector`, `CadencePolicy`). Extends `ServiceModule` to the proposed `RuntimeModule` trait shown above; does not discard the runtime registry.                                                                                                                                                        | Lane D                                                 |
+| 3 | The "for free" triplet — `RuntimeModule` base trait, `#[derive(RuntimeModule)]` macro, and `just scaffold-module` generator — so a new concern is four lines plus a handler body (worked example in the previous section). Without (3), even after (1) and (2) land each module still hand-rolls the boilerplate, which is the same friction Lane D was created to remove.                               | Lane D (companion to #2; lands in the same PR series)  |
+| 4 | Move chat turn fanout onto `CognitionTurnFrame` so all personas share one room/RAG/model/prompt artifact set instead of rebuilding it per persona per event. This is the consumer-side migration that proves (1)–(3) actually pay off.                                                                                                                                                                  | Lane D                                                 |
+| 5 | Attach VDD metrics to existing lanes/classes: queue depth, queue time, execution time, coalesced count, deferred count, GPU residency, CPU/GPU utilization, and first-response/all-response latency, fed into the Standard VDD Record schema in this doc. The triplet's derive macro should be what emits these — the module author should not call `vdd_*!` macros by hand for the inherited fields. | Lane C (substrate); Lane D (frame integration)         |
+| 6 | Qwen GPU residency gate for local generation: selected Qwen model, backend, GPU layer count, unsupported layers, residency estimate, and platform backend evidence must be available before the turn runs. Required happy paths: Mac → Metal, NVIDIA → CUDA, AMD/Intel → Vulkan. CPU graph splits or unsupported Qwen layers are blockers unless the turn is explicitly degraded with a visible reason. | Lane A (registry & admission); Lane E (admission gate) |
+| 7 | Sequential consumer migration: persona chat → embeddings → memory consolidation → media/WebRTC → render/avatar output. Each consumer move is its own PR and must show VDD evidence that the post-move path is at least as fast as the pre-move path and emits the Standard VDD Record.                                                                                                                  | Lane D (sequencing); Lanes B/C/E (per-consumer support)|
+| 8 | Pre-broker concurrency-hack deletion. Each module today that picks a worker count from `~/.continuum/config.env` or from system memory at startup (current concrete example: `src/workers/inference-grpc/src/main.rs::get_num_workers()`) is a violation of the "we do not hard code" rule and must be deleted in favor of `PressureBroker` leases.                                                       | Lane E                                                 |
 
-## Test Contract
+## Acceptance Criteria For Substrate-Done
 
-CBAR-like runtime work is not accepted by browser smoke alone.
+CBAR-like runtime work is not accepted by browser smoke alone. The substrate
+is "done" when all of the following are true on canary, with PR-attached
+evidence:
 
-Required tests:
+**Author ergonomics (what the engram-analyzer example proves):**
 
-- Unit TDD for dependency wakeups, lane admission, cadence, and coalescing.
-- Resource VDD for bounded queues, memory leases, and no monotonic growth.
-- Performance VDD for first response, all responses, tok/s, and queue time.
-- Residency VDD proving Metal/CUDA/Vulkan/local GPU path when required.
-- Qwen VDD proving Qwen 3.5 text/code and Qwen2-VL vision use the expected
-  local GPU backend, report layer residency, and fail loud on unsupported
-  layers instead of silently running CPU-shaped inference.
-- Accuracy VDD for replayed persona/RAG/tool output.
+- New modules are small (target: a few hundred lines, including tests).
+- The `#[derive(RuntimeModule)]` macro emits the required boilerplate;
+  authors do not hand-roll timing spans, structured logs, metric emission,
+  lease renewal, or pressure-response.
+- The `just scaffold-module` generator produces a working module from one
+  command line; the author edits four config attributes and a handler body.
+- No new module owns an ad hoc queue, throttle, retry loop, cache, log
+  format, or lifecycle when the substrate can provide the shared version.
 
-The alpha gate is not "it boots." The gate is that the runtime behaves like an
-engine: predictable, concurrent, observable, fast, and small to extend.
+**Derive-macro acceptance gate (per codex review on #cambriantech):**
+
+The `#[derive(RuntimeModule)]` macro is the load-bearing piece of the "for
+free" triplet. If it ships sloppy, every module that uses it inherits the
+sloppiness invisibly. Therefore the derive macro must clear five specific
+gates before it lands:
+
+1. **Thin.** Generated code per `#[derive(RuntimeModule)]` is bounded —
+   target is "what a careful human would write by hand, not a framework's
+   worth of indirection." A reviewer should be able to read the generated
+   output of a small module in one screen.
+2. **Contract-preserving.** The macro emits exactly the `RuntimeModule` /
+   `ServiceModule` trait the hand-written version would. No extra behavior
+   smuggled in. No silent type coercions. If the hand-written version
+   would not compile, the macro-generated version does not compile either
+   — the contract is the same.
+3. **Inspectable.** `cargo expand --package <crate> --module <m>` must
+   produce readable output. A reviewer can audit any module's actual
+   runtime behavior in 30 seconds. The macro emits hygenic code, not
+   identifier soup.
+4. **Tested.** The macro itself has tests (golden-file or trybuild) that
+   prove every supported attribute permutation expands to known-good
+   code. Tests include the failure modes — e.g. a module declaring two
+   `lane`s, or an `ArtifactSelector` that doesn't exist, must fail to
+   compile with a useful error.
+5. **No hidden behavior.** The macro must NOT hide resource leases,
+   scheduling decisions, or fallback behavior. If a module gets a lease
+   from `PressureBroker`, it is visible in the macro output. If a module
+   has a cadence policy, it is visible. If a module degrades under
+   pressure, the degradation path is visible. The macro saves typing,
+   not auditability.
+
+The shape of these gates is: anything the macro generates, a reviewer can
+see and reason about; nothing the macro generates is doing "magic" that
+makes the module's behavior unpredictable.
+
+**Runtime behavior (what the substrate must actually do):**
+
+- Realtime work runs first; delayed work runs on cadence or explicit
+  dependency readiness.
+- Work declares dependencies (`ArtifactSelector`) and the runtime wakes only
+  the useful work.
+- N personas handling one room event share one `CognitionTurnFrame`; they do
+  not each rebuild RAG, model selection, prompt context, embeddings, or
+  media decoding.
+- `PressureBroker` admits / defers / drops requests with a typed reason; no
+  silent fallback to CPU, random providers, placeholder models, stale room
+  ids, or swallowed command errors.
+- Background lanes never silently consume the visible chat-generation lane.
+- Low-end devices degrade by cadence, precision, context length, subscriber
+  count, or modality, with visible reasons.
+
+**Required tests, per module and per substrate change:**
+
+- Unit TDD: dependency wakeups, lane admission, cadence, coalescing,
+  `Deferred` / `Failed` return paths.
+- Resource VDD: bounded queues, memory leases, no monotonic growth across
+  hundreds of frames.
+- Performance VDD: first response, all responses, tok/s, queue time, all
+  emitted as Standard VDD Record fields.
+- Residency VDD: Metal / CUDA / Vulkan local GPU path proven when required.
+- Qwen VDD: Qwen 3.5 text/code and Qwen2-VL vision use the expected local
+  GPU backend, report layer residency, and fail loud on unsupported layers
+  instead of silently running CPU-shaped inference.
+- Accuracy VDD: replayed persona / RAG / tool output is reproducible from
+  trace records.
+- No-CPU-fallback contract: enforced across the whole workers tree, not the
+  three currently-whitelisted paths in `no_cpu_fallback_contract.rs`.
+
+The alpha gate is not "it boots." The gate is that the runtime behaves like
+an engine: predictable, concurrent, observable, fast, and small to extend.
+
+## See Also
+
+- [ALPHA-GAP-ANALYSIS.md](../planning/ALPHA-GAP-ANALYSIS.md) — the planning
+  document. The Substrate Gap Analysis table above is the authoritative
+  mapping between the eight numbered missing pieces here and the lane
+  structure (A–G) there. If the two ever disagree on the substrate contract
+  (concurrency, scheduling, memory, pressure, telemetry, artifact handles),
+  this document wins per the precedence rule in ALPHA-GAP.
+- `src/workers/continuum-core/src/runtime/` — shipped substrate primitives
+  this document refines and extends.
+- `src/workers/continuum-core/src/paging/broker.rs` — `PressureBroker`
+  shipping point. The example in §"For Free Triplet" shows how a new module
+  inherits pressure-response from the broker without owning a private hook.

--- a/docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md
+++ b/docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md
@@ -594,10 +594,17 @@ an engine: predictable, concurrent, observable, fast, and small to extend.
 
 ## See Also
 
+- [GENOME-FOUNDRY-SENTINEL.md](GENOME-FOUNDRY-SENTINEL.md) — the
+  artifact-sharing economy layered on top of this substrate contract.
+  This document specifies what every cell inherits; that document
+  specifies what every cell *recalls*, *composes*, and *evolves*
+  through. The two are paired: the substrate is the floor, the genome
+  economy is what runs on it. Lane H in ALPHA-GAP converges on the
+  genome doc; Lanes C/D/E converge here.
 - [ALPHA-GAP-ANALYSIS.md](../planning/ALPHA-GAP-ANALYSIS.md) — the planning
   document. The Substrate Gap Analysis table above is the authoritative
   mapping between the eight numbered missing pieces here and the lane
-  structure (A–G) there. If the two ever disagree on the substrate contract
+  structure (A–H) there. If the two ever disagree on the substrate contract
   (concurrency, scheduling, memory, pressure, telemetry, artifact handles),
   this document wins per the precedence rule in ALPHA-GAP.
 - `src/workers/continuum-core/src/runtime/` — shipped substrate primitives


### PR DESCRIPTION
## What

Four structural refinements to \`docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md\`. Doc-only PR, no code touched.

Previously parked on \`joel/docs-cbar-substrate-refine\` waiting on the precommit-gate fix (now landed via #1319) and on incorporating codex's derive-macro review from #cambriantech.

## Why

This document is the substrate contract — what every Rust concern in continuum-core inherits. The earlier draft was already directionally right (RTOS / CBAR pattern) but had three load-bearing weaknesses that this refresh fixes:

1. The \`RuntimeModule\` trait sketch named types (\`ArtifactSelector\`, \`CadencePolicy\`, \`RuntimeFrame\`, \`ModuleResult\`) as if they shipped — they don't. A reader couldn't tell what was real and what was proposed.
2. The "for free" framing was stated without showing how a new module actually inherits concurrency / memory pressure / device pressure / telemetry. The engram-analyzer worked example, asked for explicitly by Joel ("need a new engram analyzer? works in its own thread with zero effort..."), now demonstrates this concretely.
3. No acceptance gate on the derive-macro layer. Codex correctly flagged on #cambriantech that the derive macro is the load-bearing piece — if it ships sloppy, every module that uses it inherits the sloppiness invisibly.

## Changes

### 1. Continuum Translation — anchor the trait sketch in shipped types

The section now first shows the actually-shipped \`ServiceModule\` + \`ModuleConfig\` from \`src/workers/continuum-core/src/runtime/service_module.rs\` with the real field set, then shows the proposed \`RuntimeModule: ServiceModule\` extension trait that adds typed \`ArtifactSelector\` / \`CadencePolicy\` / \`RuntimeFrame\` / \`ModuleResult\`. Each new type is labelled as a Lane D deliverable. A side-by-side table makes the today-vs-after-Lane-D delta explicit.

### 2. New section "The 'For Free' Triplet" + engram-analyzer worked example

Names the three things that have to ship together: base trait, \`#[derive(RuntimeModule)]\` macro, \`just scaffold-module\` generator. The engram-analyzer worked example shows the literal Rust source the developer writes (four config attributes + a handler body) and a per-concern inheritance table tracing what they get for free: registration, tokio/dedicated-thread choice, memory + CPU + device pressure response, concurrency cap, coalescing, spans / timing / VDD emission, typed failure path, replay test fixture, ts-rs exposure, lifecycle.

### 3. Substrate Gap Analysis cross-linked to ALPHA-GAP lanes

The previous "six numbered missing pieces" list now sits in a table that assigns each piece to its lane (A–G) and adds two pieces the earlier list omitted: piece 3 (the for-free triplet companion to the typed contract), and piece 8 (deletion of pre-broker concurrency hacks with the concrete \`inference-grpc/main.rs::get_num_workers()\` example calling out the \`INFERENCE_WORKERS=\` config.env read + system-memory heuristic as a Lane E deletion target).

### 4. Derive-macro acceptance gate (codex review)

Five gates the \`#[derive(RuntimeModule)]\` macro must clear before landing:

1. **Thin** — generated code is what a careful human would write; a reviewer can read a small module's expansion in one screen.
2. **Contract-preserving** — emits exactly the trait the hand-written version would; no smuggled behavior.
3. **Inspectable** — \`cargo expand\` output is auditable in 30 seconds, not identifier soup.
4. **Tested** — golden-file or trybuild tests over every supported attribute permutation, including failure modes with useful errors.
5. **No hidden behavior** — resource leases, scheduling decisions, and fallback/degradation paths remain visible in the macro output. The macro saves typing, not auditability.

### Also

- Replaces the two-section "Extension Bar" + "Test Contract" pair with a single "Acceptance Criteria For Substrate-Done" section organized by what the substrate proves.
- "See Also" footer names ALPHA-GAP as the planning document and reasserts the precedence rule (CBAR-SUBSTRATE wins on substrate contract).

## Validation

- Local precommit passed cleanly on the rebased branch (the precommit-gate fix from #1319 correctly skipped browser tests when core was down).
- Cross-links resolved.

## Companion PRs (canary doc track)

- **#1316** — ALPHA-GAP refresh (open)
- **#1317** — CONTINUUM-ARCHITECTURE refresh + codex persona-cognition asks (open, follow-up commit just pushed)
- **#1320** — CONTINUUM-VISION refresh (open)
- **airc#642** — manager-role + lane substrate design proposal (open)

This PR closes the parked block on CBAR-SUBSTRATE. The four-doc set (this one + #1316 + #1317 + #1320) now cross-reference each other consistently, with this doc named as the precedence-winner on substrate-shape questions.