### PR TITLE
feat(persona): load turn frame replay fixtures

### DIFF
--- a/src/workers/continuum-core/src/persona/recorder.rs
+++ b/src/workers/continuum-core/src/persona/recorder.rs
@@ -56,10 +56,13 @@
 use crate::cognition::tool_executor::types::MediaItemLite;
 use crate::persona::response::{PersonaResponse, RespondInput};
 use crate::persona::trace::CognitionTrace;
-use crate::persona::PersonaTurnFrameReplayRecord;
+use crate::persona::{
+    PersonaTurnFrame, PersonaTurnFrameReplayRecord, PERSONA_TURN_FRAME_REPLAY_SCHEMA_VERSION,
+};
 use crate::runtime;
 use serde::Serialize;
 use serde_json::json;
+use std::fmt;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
@@ -233,6 +236,140 @@ pub fn record_turn_frame_replay(record: &PersonaTurnFrameReplayRecord) {
     };
     let fname = turn_frame_filename_for(record);
     persist_json_payload(&dir, &fname, record);
+}
+
+#[derive(Debug)]
+pub enum TurnFrameReplayLoadError {
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    UnsupportedSchema {
+        path: PathBuf,
+        expected: u32,
+        actual: u32,
+    },
+    InvalidRecord {
+        path: PathBuf,
+        reason: String,
+    },
+}
+
+impl fmt::Display for TurnFrameReplayLoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Read { path, source } => {
+                write!(
+                    f,
+                    "turn-frame fixture read failed for {}: {source}",
+                    path.display()
+                )
+            }
+            Self::Parse { path, source } => {
+                write!(
+                    f,
+                    "turn-frame fixture parse failed for {}: {source}",
+                    path.display()
+                )
+            }
+            Self::UnsupportedSchema {
+                path,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "turn-frame fixture {} has schemaVersion {actual}, expected {expected}",
+                path.display()
+            ),
+            Self::InvalidRecord { path, reason } => {
+                write!(
+                    f,
+                    "turn-frame fixture {} is invalid: {reason}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for TurnFrameReplayLoadError {}
+
+/// Load and validate a Rust-owned turn-frame replay fixture.
+///
+/// Validation recomputes the derived consolidated inbox and RAG seed from the
+/// raw inbox frame. A fixture whose derived fields do not match its raw frame is
+/// rejected instead of being treated as replayable evidence.
+pub fn load_turn_frame_replay_fixture(
+    path: impl AsRef<Path>,
+) -> Result<PersonaTurnFrameReplayRecord, TurnFrameReplayLoadError> {
+    let path = path.as_ref();
+    let bytes = std::fs::read(path).map_err(|source| TurnFrameReplayLoadError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let record: PersonaTurnFrameReplayRecord =
+        serde_json::from_slice(&bytes).map_err(|source| TurnFrameReplayLoadError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    validate_turn_frame_replay_record(path, &record)?;
+    Ok(record)
+}
+
+pub fn validate_turn_frame_replay_record(
+    path: impl AsRef<Path>,
+    record: &PersonaTurnFrameReplayRecord,
+) -> Result<(), TurnFrameReplayLoadError> {
+    let path = path.as_ref();
+    if record.schema_version != PERSONA_TURN_FRAME_REPLAY_SCHEMA_VERSION {
+        return Err(TurnFrameReplayLoadError::UnsupportedSchema {
+            path: path.to_path_buf(),
+            expected: PERSONA_TURN_FRAME_REPLAY_SCHEMA_VERSION,
+            actual: record.schema_version,
+        });
+    }
+    if record.persona_id != record.inbox_frame.persona_id {
+        return invalid_record(path, "personaId does not match inboxFrame.personaId");
+    }
+    if record.room_id != record.inbox_frame.room_id {
+        return invalid_record(path, "roomId does not match inboxFrame.roomId");
+    }
+
+    let turn_frame = PersonaTurnFrame::from_inbox_frame(record.inbox_frame.clone());
+    let expected_consolidated =
+        turn_frame
+            .consolidated_inbox()
+            .ok_or_else(|| TurnFrameReplayLoadError::InvalidRecord {
+                path: path.to_path_buf(),
+                reason: "inboxFrame is empty".to_string(),
+            })?;
+    if record.consolidated_inbox != expected_consolidated {
+        return invalid_record(path, "consolidatedInbox does not match inboxFrame");
+    }
+
+    let expected_rag_seed =
+        turn_frame
+            .rag_seed()
+            .ok_or_else(|| TurnFrameReplayLoadError::InvalidRecord {
+                path: path.to_path_buf(),
+                reason: "ragSeed cannot be derived from inboxFrame".to_string(),
+            })?;
+    if record.rag_seed != expected_rag_seed {
+        return invalid_record(path, "ragSeed does not match inboxFrame");
+    }
+
+    Ok(())
+}
+
+fn invalid_record<T>(path: &Path, reason: &str) -> Result<T, TurnFrameReplayLoadError> {
+    Err(TurnFrameReplayLoadError::InvalidRecord {
+        path: path.to_path_buf(),
+        reason: reason.to_string(),
+    })
 }
 
 fn persist_turn_payload(input: &RespondInput, payload: serde_json::Value) {
@@ -725,5 +862,83 @@ mod tests {
 
         let dir = tmp.path().join(TURN_FRAME_FIXTURE_DIR);
         assert!(!dir.exists());
+    }
+
+    /// What this catches: replay tooling can load the exact fixture emitted by
+    /// the Rust recorder and gets the typed replay record back only after the
+    /// duplicate derived fields validate against the raw inbox frame.
+    #[test]
+    fn load_turn_frame_replay_fixture_accepts_recorder_output() {
+        let _lock = env_lock();
+        let tmp = tempdir().expect("temp home");
+        let _restore = EnvRestore::install(tmp.path(), None);
+        let record = fake_turn_frame_replay_record();
+        let expected_query = record.rag_seed.query_text.clone();
+
+        record_turn_frame_replay(&record);
+
+        let dir = tmp.path().join(TURN_FRAME_FIXTURE_DIR);
+        let entry = std::fs::read_dir(&dir)
+            .expect("turn-frame fixture dir exists")
+            .next()
+            .expect("fixture exists")
+            .expect("fixture entry")
+            .path();
+        let loaded = load_turn_frame_replay_fixture(&entry).expect("fixture loads");
+
+        assert_eq!(
+            loaded.schema_version,
+            PERSONA_TURN_FRAME_REPLAY_SCHEMA_VERSION
+        );
+        assert_eq!(loaded.rag_seed.query_text, expected_query);
+        assert_eq!(loaded.consolidated_inbox.source_count, 2);
+    }
+
+    /// What this catches: schemaVersion is a real compatibility gate. Replay
+    /// tools must reject unknown fixture schemas instead of trying to guess.
+    #[test]
+    fn load_turn_frame_replay_fixture_rejects_unknown_schema() {
+        let tmp = tempdir().expect("temp home");
+        let record = fake_turn_frame_replay_record();
+        let mut json = serde_json::to_value(&record).expect("record to json");
+        json["schemaVersion"] = serde_json::json!(999);
+        let path = tmp.path().join("bad-schema.json");
+        std::fs::write(&path, serde_json::to_vec_pretty(&json).expect("json bytes"))
+            .expect("write fixture");
+
+        let error = load_turn_frame_replay_fixture(&path).expect_err("schema rejected");
+
+        match error {
+            TurnFrameReplayLoadError::UnsupportedSchema {
+                expected, actual, ..
+            } => {
+                assert_eq!(expected, PERSONA_TURN_FRAME_REPLAY_SCHEMA_VERSION);
+                assert_eq!(actual, 999);
+            }
+            other => panic!("expected UnsupportedSchema, got {other:?}"),
+        }
+    }
+
+    /// What this catches: the loader does not trust duplicated derived fields.
+    /// If someone edits the stored transcript without changing the raw frame,
+    /// replay rejects the fixture as non-evidence.
+    #[test]
+    fn load_turn_frame_replay_fixture_rejects_tampered_consolidation() {
+        let tmp = tempdir().expect("temp home");
+        let record = fake_turn_frame_replay_record();
+        let mut json = serde_json::to_value(&record).expect("record to json");
+        json["consolidatedInbox"]["transcript"] = serde_json::json!("tampered");
+        let path = tmp.path().join("tampered.json");
+        std::fs::write(&path, serde_json::to_vec_pretty(&json).expect("json bytes"))
+            .expect("write fixture");
+
+        let error = load_turn_frame_replay_fixture(&path).expect_err("tamper rejected");
+
+        match error {
+            TurnFrameReplayLoadError::InvalidRecord { reason, .. } => {
+                assert!(reason.contains("consolidatedInbox"));
+            }
+            other => panic!("expected InvalidRecord, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a Rust typed loader for persona-turn-frame replay fixtures
- validate schemaVersion before replay use
- recompute consolidated inbox and RAG seed from the raw inbox frame so tampered fixtures are rejected
- keep scope to Rust recorder/replay tooling foundation; no TS, model, retrieval, or scheduler changes

## Tests
- cargo test --manifest-path src/workers/continuum-core/Cargo.toml --features metal,accelerate persona::recorder --lib
- cargo test --manifest-path src/workers/continuum-core/Cargo.toml --features metal,accelerate turn_frame_recording_tests --lib
- cargo test --manifest-path src/workers/continuum-core/Cargo.toml --features metal,accelerate persona::turn_frame --lib
- cargo test --manifest-path src/workers/continuum-core/Cargo.toml --features metal,accelerate persona::inbox --lib
- precommit hook: TS passed, clippy baseline held; browser tests skipped because local jtag/core IPC prerequisites were not running
- pre-push hook: TS, ESLint baseline, Rust compile, Rust tests passed; native-arch Docker push failed and needs follow-up if CI verify-architectures blocks merge