### PR TITLE
docs: canonical-substrate pointer in CLAUDE.md + stale-section status headers in QUEUE-DRIVEN-COGNITION / UNIVERSAL-LEARNING / UNIVERSAL-SENSORY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,15 @@
 # CLAUDE - ESSENTIAL DEVELOPMENT GUIDE
 
+## 📐 Canonical Substrate Docs (read first)
+
+If you're new to the substrate, or you're picking up runtime/cognition work, read these in order before anything else in this file. They are the precedence-winning truth on substrate-shaped questions:
+
+1. **[docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md](docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md)** — the RTOS-style runtime contract every Rust module inherits. Concurrency, scheduling, memory + device pressure, telemetry, artifact handles, lifecycle. The "for free triplet" (base trait + derive macro + scaffold generator) is here, with the engram-analyzer worked example.
+2. **[docs/architecture/GENOME-FOUNDRY-SENTINEL.md](docs/architecture/GENOME-FOUNDRY-SENTINEL.md)** — the artifact-sharing economy on top of the substrate. Tiered genome cache (L1–L5), foundry-as-JIT, sentinel-AI-as-PGO, demand-aligned recall, composer + speculator, `SubstrateGovernor` (DVFS — same Rust code on MacBook Air and RTX 5090, different governor policy).
+3. **[docs/planning/ALPHA-GAP-ANALYSIS.md](docs/planning/ALPHA-GAP-ANALYSIS.md)** — the lane-shaped roadmap. Current state of Lanes A–H, owners, merge gates, active PRs.
+
+The rest of this file is project guidance — build commands, conventions, useful snippets. If it ever disagrees with the canonical substrate docs on substrate-shaped questions (concurrency, scheduling, memory, pressure, telemetry, artifact handles), defer to the canonical docs and reconcile this file in a follow-up.
+
 ## 🏭 FORGE TEMPLATE ARCHITECTURE (the next sprint)
 
 **Lesson from the qwen3-coder-30b-a3b-compacted-19b-256k v1 publish (alloy hash `aa61c4bdf463847c`):** authoring per-artifact alloy files by hand is anti-architectural. Every successful forge requires the same set of fields — `name`, `userSummary`, `description`, `tags`, `source`, `stages[]` with notes, `results.benchmarks[]` with `samplesPath` + `baseSamplesPath`, `priorMetricBaselines[]`, `limitations[]`, `methodologyPaperUrl` — and we wrote them by hand into a `.alloy.json` for the v1 publish. That's where they need to STOP being manually authored.

--- a/docs/QUEUE-DRIVEN-COGNITION.md
+++ b/docs/QUEUE-DRIVEN-COGNITION.md
@@ -3,6 +3,13 @@
 > The mind controls its own destiny. RAG, memory, and thought processes are sacred.
 > The persona decides what context it needs based on what it's servicing.
 
+> **Status @ 2026-05-16.** This document's *principle* — every queue item carries its own RAG contract, the persona composes generically, the substrate stays domain-agnostic — is still load-bearing and unchanged. Its *implementation sketch* (TypeScript-shaped `BaseQueueItem`, `PersonaUser.consolidate(contract)`, hand-coded RAG composition) has been superseded by the canonical Rust substrate. Read the principle here; read the implementation in:
+>
+> - **[CBAR-SUBSTRATE-ARCHITECTURE.md](architecture/CBAR-SUBSTRATE-ARCHITECTURE.md)** — `RuntimeFrame` / `CognitionTurnFrame` is the Rust analog of "queue item carries its own context." The `ArtifactSelector` typed subscription replaces the TS pattern of declaring sources by string.
+> - **[GENOME-FOUNDRY-SENTINEL.md](architecture/GENOME-FOUNDRY-SENTINEL.md)** — `DemandAlignedRecall` is the typed Rust API the persona reaches for; `CapabilityQuery → RankedPool` replaces the TS pattern of consolidating sources manually.
+>
+> If the queue-item-carries-its-RAG-contract sentence ever conflicts with what the canonical docs say about `RuntimeFrame` + `DemandAlignedRecall`, defer to the canonical docs.
+
 ## The Core Principle
 
 **Every queue item declares its own RAG requirements.** The persona doesn't need hardcoded knowledge of what context to gather — the work itself carries that information, and the persona consolidates across the queue item's requirements before responding.

--- a/docs/UNIVERSAL-LEARNING-ARCHITECTURE.md
+++ b/docs/UNIVERSAL-LEARNING-ARCHITECTURE.md
@@ -3,6 +3,13 @@
 > The generic RAG pipeline doesn't just enable cognition — it enables universal learning.
 > Training, memory, and optimization all emerge from the same domain-agnostic composition.
 
+> **Status @ 2026-05-16.** The *insight* this document encodes — that the (context, response) pair from queue-driven cognition is universal training signal, and that training + memory + action all consume the same generic output — is still load-bearing and unchanged. The *implementation* (TS-shaped `TrainingDataAccumulator`, Hippocampus class, genome-as-skill-marketplace) has been superseded by the canonical Rust substrate:
+>
+> - **[GENOME-FOUNDRY-SENTINEL.md](architecture/GENOME-FOUNDRY-SENTINEL.md)** — Sentinel-AI is the profile-guided optimizer that consumes cognition traces and produces refined LoRA layers + MoE experts + engrams. The "three outputs" of this document (training pair / memory / action) are reified there as: traces → sentinel refinement passes; engrams → longterm.db via consolidation; action → back to the queue substrate. The foundry handles the SOTA-import side; sentinel handles the lived-experience side; both feed the same genome pool with provenance.
+> - **[CBAR-SUBSTRATE-ARCHITECTURE.md](architecture/CBAR-SUBSTRATE-ARCHITECTURE.md)** — the trace bus that carries the (context, response) tuple as a typed event, and the substrate's "evidence travels verbatim" rule that makes the learning signal auditable.
+>
+> The genome-as-skill-marketplace concept in this doc is reframed in GENOME-FOUNDRY-SENTINEL as **sharing protocol with provenance + eventual consistency**. Trust is learned, not declared. If the marketplace prose ever conflicts with the sharing-protocol prose, defer to GENOME-FOUNDRY-SENTINEL.
+
 ## The Insight
 
 Queue-driven cognition (see [QUEUE-DRIVEN-COGNITION.md](QUEUE-DRIVEN-COGNITION.md)) makes RAG composition generic: every queue item declares its own context requirements, the persona composes them without domain-specific logic, and the response flows back.

--- a/docs/UNIVERSAL-SENSORY-ARCHITECTURE.md
+++ b/docs/UNIVERSAL-SENSORY-ARCHITECTURE.md
@@ -5,6 +5,13 @@
 > equal access to every sense. Like accessibility aids for the visually impaired:
 > the infrastructure provides what the model lacks.
 
+> **Status @ 2026-05-16.** The *principle* this document encodes — every model gets every modality through universal sensory adapters, no model is structurally blind/deaf/mute — is still load-bearing and unchanged. The *implementation* (TS-shaped sensory adapter classes, modality routing in PersonaUser) has been superseded by the canonical Rust substrate:
+>
+> - **[CBAR-SUBSTRATE-ARCHITECTURE.md](architecture/CBAR-SUBSTRATE-ARCHITECTURE.md)** — sensory adapters are `RuntimeModule`s (after Lane D, `RuntimeModule: ServiceModule`). They subscribe to `ArtifactSelector`s for the modalities they translate to/from, declare a `CadencePolicy`, and emit translated artifacts onto the `RuntimeFrame`. The substrate's typed subscriptions replace the TS pattern of registering adapters by string.
+> - **[GENOME-FOUNDRY-SENTINEL.md](architecture/GENOME-FOUNDRY-SENTINEL.md)** — vision encoders, STT models, TTS voices, embedders are all `ImportedArtifact`s the foundry adapts from SOTA. The sensory adapter does not own its model weights; it composes against the genome pool via `DemandAlignedRecall`. A blind 0.8B text model recalls a vision encoder for the modality it needs, not a different *adapter implementation*.
+>
+> The "modality routing in PersonaUser" pattern is reframed as: the persona's current `CompositionPlan` includes whatever sensory `ImportedArtifact`s its `CapabilityQuery` ranked high for the current `TaskKind`. If a section here implies the persona owns a static set of sensory adapters, defer to the canonical docs — composition is dynamic, demand-aligned, and substrate-owned.
+
 ## The Principle
 
 No model is truly blind, deaf, or mute in Continuum. The system provides universal


### PR DESCRIPTION
## What

Four-file batch. Each touched file gets a small status block at the top pointing readers at the canonical truth docs (CBAR-SUBSTRATE, GENOME-FOUNDRY-SENTINEL, ALPHA-GAP). **Body content of each doc is UNCHANGED** — only the framing is updated so a reader knows which parts are still load-bearing and which parts have been superseded by Rust substrate work.

## Why

The vision-side docs (QUEUE-DRIVEN-COGNITION, UNIVERSAL-LEARNING, UNIVERSAL-SENSORY) and the project-level CLAUDE.md were written before the canonical Rust substrate landed. Their *principles* are still load-bearing; their *implementation sketches* are now stale relative to CBAR-SUBSTRATE + GENOME-FOUNDRY-SENTINEL. Without status pointers, a reader picking these up first gets a TS-shaped mental model that the codebase has moved past.

## Changes

### \`CLAUDE.md\`

New "Canonical Substrate Docs (read first)" section at the top of the file, before the existing FORGE TEMPLATE ARCHITECTURE section. Names the three precedence-winning truth docs with one-line summaries and states the rule: this file is project guidance; canonical docs win on substrate-shaped questions.

### \`docs/QUEUE-DRIVEN-COGNITION.md\`

Status block names the principle as still load-bearing (queue item carries its own RAG contract; persona composes generically; substrate stays domain-agnostic) and the TS-shaped implementation (\`BaseQueueItem\`, \`PersonaUser.consolidate\`) as superseded by \`RuntimeFrame\` / \`CognitionTurnFrame\` (CBAR) + \`DemandAlignedRecall\` (GENOME-FOUNDRY-SENTINEL).

### \`docs/UNIVERSAL-LEARNING-ARCHITECTURE.md\`

Status block names the insight as still load-bearing (cognition trace is universal training signal; training + memory + action all consume the same generic output) and the TS-shaped implementation as superseded by sentinel-AI as profile-guided optimizer + foundry as JIT, both writing to the same genome pool with provenance. Reframes "skill marketplace" as the sharing protocol with eventual consistency.

### \`docs/UNIVERSAL-SENSORY-ARCHITECTURE.md\`

Status block names the principle as still load-bearing (every model gets every modality through universal sensory adapters; no model is structurally blind/deaf/mute) and the TS-shaped implementation as superseded: sensory adapters are \`RuntimeModule\`s with typed subscriptions; modality models are \`ImportedArtifact\`s the foundry adapts from SOTA; composition is dynamic and demand-aligned.

## Not Touched

- \`docs/UNIVERSAL-COGNITION-ARCHITECTURE.md\` — wasn't on the deprecation audit target list; will check separately.
- \`docs/UNIVERSAL-PRIMITIVES.md\` — Commands.execute / Events.subscribe are still load-bearing as-is; no status pointer needed.

## Validation

- Local precommit passed (TypeScript compile clean; no Rust/TS files staged).
- All four files render with the new status blocks at the top.
- Cross-links resolved against actual file paths.

## Companion PRs in flight

- **#1316** — ALPHA-GAP refresh + Lane H entry (latest commit \`42a05bd\`).
- **#1317** — CONTINUUM-ARCHITECTURE refresh + codex persona-cognition asks.
- **#1320** — CONTINUUM-VISION refresh.
- **#1324** — CBAR-SUBSTRATE refinement + codex derive-macro gate.
- **#1327** — GENOME-FOUNDRY-SENTINEL design doc (Lane H proposal).
- **airc#642** — manager-role + lane substrate design.
- **airc#643** — lane-kanban-protocol engineering spec.

This PR closes the doc-track loop: every supporting doc now points at the canonical truth, and the canonical truth points back at the supporting docs via See Also and Document Map.