### PR TITLE
refactor(inference-grpc,PIECE-8): delete hardcoded worker-count ceilings + magic constants

### DIFF
--- a/src/workers/Cargo.lock
+++ b/src/workers/Cargo.lock
@@ -4731,13 +4731,13 @@ dependencies = [
  "half",
  "hf-hub 0.5.0",
  "log",
+ "num_cpus",
  "once_cell",
  "prost 0.14.3",
  "rand 0.8.5",
  "safetensors 0.7.0",
  "serde",
  "serde_json",
- "sys-info",
  "tokenizers 0.22.2",
  "tokio",
  "tokio-stream",
@@ -8191,16 +8191,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sys-info"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]

--- a/src/workers/inference-grpc/Cargo.toml
+++ b/src/workers/inference-grpc/Cargo.toml
@@ -35,7 +35,7 @@ once_cell.workspace = true
 rand.workspace = true
 half.workspace = true
 dirs = "5.0"
-sys-info = "0.9"
+num_cpus = "1.16"
 
 # Logging
 log = "0.4"

--- a/src/workers/inference-grpc/src/main.rs
+++ b/src/workers/inference-grpc/src/main.rs
@@ -27,37 +27,204 @@ use inference::inference_server::InferenceServer;
 use model::load_default_model;
 use worker_pool::WorkerPool;
 
-/// Get number of inference workers from config or auto-detect
-fn get_num_workers() -> usize {
-    // Load from ~/.continuum/config.env
-    let config_path = dirs::home_dir()
-        .map(|h| h.join(".continuum/config.env"))
-        .unwrap_or_else(|| PathBuf::from(".continuum/config.env"));
+/// Resolve the inference worker-pool size.
+///
+/// Source of truth, in order:
+///
+/// 1. **`INFERENCE_WORKERS` environment variable** — the channel a
+///    supervising continuum-core sets at process spawn based on its
+///    PressureBroker lease. When set, that value is the policy and
+///    inference-grpc uses it verbatim. No floor, no ceiling — supervisor
+///    knows the live hardware + memory pressure better than this binary
+///    does. Invalid integer in the env var is a configuration bug:
+///    return Err with the bad value named (no silent default).
+///
+/// 2. **No env var set** — Continuum-core wasn't the spawner (direct
+///    `cargo run`, integration test, docker exec). Fall back to the
+///    physical CPU count from `num_cpus`. CPU count is hardware-derived,
+///    not hardcoded; one worker per physical core is the most
+///    conservative "make use of the box" default. Caller sees a single
+///    info log line announcing the fallback.
+///
+/// What this fn DOES NOT do anymore (deletion targets from CBAR-PIECE-8
+/// + vhsm-d1f4 audit pass 1):
+///
+/// - **No more `~/.continuum/config.env` parsing.** Static-config-file
+///   reads violate the dynamic / broker-owned-concurrency rule. If a
+///   user wants to override, they pass `INFERENCE_WORKERS` as an env
+///   var on the process line; no file-on-disk side channel.
+/// - **No more `clamp(1, 4)` / `clamp(1, 8)` ceilings.** Hardcoded
+///   ceilings prevent the supervisor from sizing the pool for a
+///   Blackwell with 128GB RAM (capped at 4 workers, same as a 16GB
+///   MacBook Air). Removed entirely — supervisor sets the ceiling, this
+///   binary doesn't.
+/// - **No more `2GB-per-worker` magic constant.** Per-worker footprint
+///   depends on the model + quantization + context window; a fixed
+///   number is wrong for every model that isn't a 7B Q4_K_M. Calculation
+///   was wrong; deleted.
+/// - **No more `Default: 2 workers` fallback** — silent default was
+///   the exact "guess and silently degrade" anti-pattern vhsm-d1f4
+///   called out. Fallback is now `num_cpus::get_physical()` (hardware-
+///   probed, never zero) with an info log so the operator can see what
+///   was picked.
+///
+/// Returns `Result` so the supervisor can see the typed reason when
+/// INFERENCE_WORKERS is invalid; `main` propagates the error to abort
+/// startup instead of silently launching with a wrong pool size.
+fn resolve_num_workers() -> Result<usize, String> {
+    match std::env::var("INFERENCE_WORKERS") {
+        Ok(value) => {
+            let n: usize = value.parse().map_err(|e| {
+                format!(
+                    "INFERENCE_WORKERS={value:?} is not a valid usize: {e}. \
+                     The supervising continuum-core (or whoever set this) sent a bad value. \
+                     Fix the source or unset to fall back to physical CPU count."
+                )
+            })?;
+            if n == 0 {
+                return Err(
+                    "INFERENCE_WORKERS=0 — zero workers means zero concurrent inference. \
+                     Pool size must be >= 1."
+                        .into(),
+                );
+            }
+            info!("  Workers: {n} (from INFERENCE_WORKERS env, supervisor-set)");
+            Ok(n)
+        }
+        Err(_) => {
+            let n = num_cpus::get_physical().max(1);
+            info!(
+                "  Workers: {n} (INFERENCE_WORKERS not set; fell back to \
+                 num_cpus::get_physical(). Continuum-core supervisor should set \
+                 INFERENCE_WORKERS based on its PressureBroker lease — see CBAR-PIECE-8)"
+            );
+            Ok(n)
+        }
+    }
+}
 
-    if let Ok(content) = fs::read_to_string(&config_path) {
-        for line in content.lines() {
-            let line = line.trim();
-            if line.starts_with("INFERENCE_WORKERS=") {
-                if let Some(value) = line.strip_prefix("INFERENCE_WORKERS=") {
-                    if let Ok(n) = value.parse::<usize>() {
-                        return n.clamp(1, 8); // Clamp to 1-8
-                    }
-                }
+#[cfg(test)]
+mod resolve_num_workers_tests {
+    use super::resolve_num_workers;
+
+    /// Save+restore env around a test so concurrent runs don't poison
+    /// each other. INFERENCE_WORKERS is process-global so tests cannot
+    /// run in parallel against it — `cargo test --test-threads=1` is
+    /// the contract. (Documented per CLAUDE.md FEEDBACK rule on
+    /// env-mutating tests.)
+    fn with_env<F: FnOnce()>(key: &str, value: Option<&str>, f: F) {
+        let prev = std::env::var(key).ok();
+        // SAFETY: tests run serial via --test-threads=1 for env mutations.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+        f();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
             }
         }
     }
 
-    // Auto-detect: use available memory / 2GB per worker, max 4
-    // Each quantized model uses ~2GB
-    let sys_info = sys_info::mem_info();
-    if let Ok(mem) = sys_info {
-        let total_gb = mem.total as f64 / (1024.0 * 1024.0);
-        let workers = ((total_gb - 4.0) / 2.0).floor() as usize; // Reserve 4GB for system
-        return workers.clamp(1, 4); // 1-4 workers
+    /// What this catches: INFERENCE_WORKERS=8 returns 8 (no clamp, no
+    /// default). Replaces the prior clamp(1,8) ceiling — supervisor's
+    /// value must pass through verbatim.
+    #[test]
+    fn env_var_passes_through_verbatim() {
+        with_env("INFERENCE_WORKERS", Some("8"), || {
+            assert_eq!(resolve_num_workers().unwrap(), 8);
+        });
     }
 
-    // Default: 2 workers
-    2
+    /// What this catches: INFERENCE_WORKERS=64 returns 64. The prior
+    /// hardcoded clamp(1, 8) would have capped this at 8 on a Blackwell
+    /// rig with the headroom to actually run 64 concurrent workers.
+    /// Pins the no-ceiling guarantee explicitly.
+    #[test]
+    fn large_env_value_not_capped() {
+        with_env("INFERENCE_WORKERS", Some("64"), || {
+            assert_eq!(resolve_num_workers().unwrap(), 64);
+        });
+    }
+
+    /// What this catches: INFERENCE_WORKERS=0 returns Err — zero
+    /// workers means zero concurrent inference, which is a config bug
+    /// the caller surely didn't mean. Refuse rather than launch with a
+    /// dead pool.
+    #[test]
+    fn env_var_zero_returns_err() {
+        with_env("INFERENCE_WORKERS", Some("0"), || {
+            let result = resolve_num_workers();
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("0"));
+        });
+    }
+
+    /// What this catches: INFERENCE_WORKERS=not-a-number returns Err
+    /// with the bad value named. Operator sees what was set so they can
+    /// fix the source. Silent fallback to 2 (the old behavior) would
+    /// hide the bad config.
+    #[test]
+    fn env_var_invalid_returns_err_with_value_named() {
+        with_env("INFERENCE_WORKERS", Some("not-a-number"), || {
+            let result = resolve_num_workers();
+            assert!(result.is_err());
+            let msg = result.unwrap_err();
+            assert!(msg.contains("not-a-number"), "value name missing: {msg}");
+        });
+    }
+
+    /// What this catches: INFERENCE_WORKERS unset → fallback to
+    /// num_cpus::get_physical(), clamped >=1. No silent default-2;
+    /// hardware-derived. Confirms the fallback never returns 0.
+    #[test]
+    fn unset_env_falls_back_to_physical_cpus() {
+        with_env("INFERENCE_WORKERS", None, || {
+            let result = resolve_num_workers();
+            assert!(result.is_ok());
+            let n = result.unwrap();
+            assert!(n >= 1, "fallback must be >=1, got {n}");
+            // Should match num_cpus on this test host
+            assert_eq!(n, num_cpus::get_physical().max(1));
+        });
+    }
+
+    /// What this catches: empty env var (`INFERENCE_WORKERS=`) returns
+    /// Err with the empty value named. Empty != unset — empty is a
+    /// shell-script bug where someone wrote `INFERENCE_WORKERS=` with
+    /// nothing after. Refuse rather than silently fallback (the user
+    /// MEANT to set something).
+    #[test]
+    fn empty_env_var_returns_err() {
+        with_env("INFERENCE_WORKERS", Some(""), || {
+            let result = resolve_num_workers();
+            assert!(result.is_err());
+        });
+    }
+
+    /// What this catches: INFERENCE_WORKERS=1 (the minimum valid)
+    /// passes through. Edge case at the lower boundary.
+    #[test]
+    fn env_var_one_passes() {
+        with_env("INFERENCE_WORKERS", Some("1"), || {
+            assert_eq!(resolve_num_workers().unwrap(), 1);
+        });
+    }
+
+    /// What this catches: negative env value returns Err (parse fails
+    /// for usize). Defensive — shell scripts that compute the value
+    /// could underflow to a negative number; this catches.
+    #[test]
+    fn negative_env_value_returns_err() {
+        with_env("INFERENCE_WORKERS", Some("-1"), || {
+            let result = resolve_num_workers();
+            assert!(result.is_err());
+        });
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -108,9 +275,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("  Listening on: {addr}");
     info!("===========================================");
 
-    // Determine number of workers for concurrent inference
-    let num_workers = get_num_workers();
-    info!("  Workers: {num_workers} (INFERENCE_WORKERS env or auto-detected)");
+    // Determine number of workers for concurrent inference. Source: env
+    // var INFERENCE_WORKERS (supervisor-set) or num_cpus fallback. See
+    // resolve_num_workers' docstring for the deletion-of-hardcoded-ceilings
+    // rationale. Hard-fails on invalid env value instead of silent default.
+    let num_workers = resolve_num_workers()?;
 
     // Load model based on mode
     // Default: worker pool with quantized models for concurrent inference


### PR DESCRIPTION
## Summary

**CBAR-PIECE-8** (vhsm-d1f4 audit pass 1, surfaced again in #1316 ALPHA-GAP's 'Concrete deletion target' callout): `get_num_workers()` in `inference-grpc/main.rs` had three anti-patterns that violate the dynamic / broker-owned-concurrency rule. All three deleted.

## Anti-patterns deleted

| | Was | Why deleted |
|---|---|---|
| 1 | `clamp(1, 8)` ceiling on the env-var path | A Blackwell with 128GB RAM capped to 8 workers, same as a MacBook Air. Supervisor's value must pass through verbatim. |
| 2 | `clamp(1, 4)` ceiling + magic `2GB-per-worker` constant on autodetect | The 2GB number is wrong for every model that isn't a 7B Q4_K_M. Hardcoded ceiling silently capped throughput on big hardware. |
| 3 | Silent `Default: 2 workers` fallback when sys-info fails | The exact "guess and degrade" anti-pattern vhsm-d1f4 audit pass 1 + 6 explicitly called out. |

Also deleted: `~/.continuum/config.env` file reading (static-config-file violates dynamic rule); `sys-info` crate dep (only consumed by the deleted auto-detect path).

## New `resolve_num_workers()`

1. **`INFERENCE_WORKERS` env var** — the channel a supervising continuum-core sets at process spawn (broker-derived). Value passes through verbatim. No clamping. Supervisor knows the live hardware + memory pressure; this binary doesn't second-guess.

2. **Env var unset** → `num_cpus::get_physical().max(1)`. Hardware-derived, never zero, one info log so operator sees the fallback. Documents that continuum-core supervisor SHOULD set INFERENCE_WORKERS based on its PressureBroker lease — the broker integration is the next PR in this chain.

3. **`INFERENCE_WORKERS=0` or invalid** → `Err` with bad value named. `main()` propagates to abort startup. No silent default. Surfaces the config bug at the source instead of launching with a dead pool.

## Test plan

**14 passing** on `cargo test --no-default-features -- --test-threads=1`:

- env var passes through verbatim (8)
- env var=64 not capped (pins no-ceiling guarantee; would have been clamped to 8 before)
- env var=0 → Err with `0` in message
- env var=`not-a-number` → Err with value named (operator sees what was set)
- env var unset → `num_cpus::get_physical()` fallback (matches host)
- env var empty (`INFERENCE_WORKERS=`) → Err (empty ≠ unset; user meant to set something)
- env var=1 (lower boundary) → passes
- env var=-1 (negative, shell underflow case) → Err

Note: env-mutating tests must run serial (`--test-threads=1`). Pinned in the `with_env` helper docstring + the test module name makes it discoverable.

## What this enables (CBAR-SUBSTRATE alignment)

One less hardcoded ceiling between the supervisor's `PressureBroker` and the actual inference pool size. Once a future PR wires continuum-core to spawn inference-grpc with `INFERENCE_WORKERS=<broker-lease>`, the concurrency budget is dynamic + supervisor-controlled end-to-end. The deletion landed here unblocks that wiring without further refactoring of inference-grpc.

Closes one of the three deletion targets listed in #1316 ALPHA-GAP's 'Concrete deletion target' callout.

## Coordination

Two prior attempts to edit this file (per local stash history) tripped multi-tab races + got flagged by vhsm-d1f4 as keeping env-var static-config reflex. This PR keeps the env var ONLY as the supervisor-set channel; deletes the file-reading + magic-constant scaffolding. Should land cleanly because the scope is narrow + non-conflicting with concurrent docs PRs.