### PR TITLE
feat(vdd): add chat roundtrip harness

### DIFF
--- a/src/workers/continuum-core/Cargo.toml
+++ b/src/workers/continuum-core/Cargo.toml
@@ -23,6 +23,10 @@ path = "src/bin/vrm_convert_textures.rs"
 name = "vrm-inspect"
 path = "src/bin/vrm_inspect.rs"
 
+[[bin]]
+name = "cargo-continuum-vdd"
+path = "src/bin/cargo-continuum-vdd.rs"
+
 [dependencies]
 tokio.workspace = true
 serde.workspace = true

--- a/src/workers/continuum-core/src/bin/cargo-continuum-vdd.rs
+++ b/src/workers/continuum-core/src/bin/cargo-continuum-vdd.rs
@@ -1,0 +1,53 @@
+use continuum_core::vdd::{
+    ArtifactWriter, ChatRoundtripConfig, ChatRoundtripHarness, HarnessStatus, LiveChatProbe,
+};
+
+#[tokio::main]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let harness = match args.next() {
+        Some(name) => name,
+        None => {
+            eprintln!("usage: cargo continuum-vdd <chat-roundtrip-live>");
+            std::process::exit(2);
+        }
+    };
+
+    let result = match harness.as_str() {
+        "chat-roundtrip-live" => {
+            let runner =
+                ChatRoundtripHarness::new(LiveChatProbe, ArtifactWriter::continuum_default());
+            let config = match ChatRoundtripConfig::from_env() {
+                Ok(config) => config,
+                Err(error) => {
+                    eprintln!("invalid chat-roundtrip-live config: {error}");
+                    std::process::exit(2);
+                }
+            };
+            runner.run(config).await
+        }
+        other => {
+            eprintln!("unknown continuum-vdd harness: {other}");
+            std::process::exit(2);
+        }
+    };
+
+    let bundle = match result {
+        Ok(bundle) => bundle,
+        Err(error) => {
+            eprintln!("continuum-vdd failed to write artifacts: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    let record_body = std::fs::read_to_string(&bundle.record_jsonl)
+        .expect("record just written by continuum-vdd must be readable");
+    let record: continuum_core::vdd::StandardVddRecord =
+        serde_json::from_str(record_body.trim()).expect("record just written must parse");
+    println!("{}", bundle.dir.display());
+    match record.status {
+        HarnessStatus::Pass => {}
+        HarnessStatus::PrerequisiteMissing => std::process::exit(3),
+        HarnessStatus::Fail => std::process::exit(1),
+    }
+}

--- a/src/workers/continuum-core/src/lib.rs
+++ b/src/workers/continuum-core/src/lib.rs
@@ -50,6 +50,7 @@ pub mod secrets;
 pub mod system_resources;
 pub mod tool_parsing;
 pub mod utils;
+pub mod vdd;
 
 pub use audio_constants::*;
 

--- a/src/workers/continuum-core/src/vdd/artifacts.rs
+++ b/src/workers/continuum-core/src/vdd/artifacts.rs
@@ -1,0 +1,140 @@
+use crate::vdd::record::{StandardVddRecord, VddError};
+use serde::Serialize;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactBundle {
+    pub dir: PathBuf,
+    pub record_jsonl: PathBuf,
+    pub manifest_toml: PathBuf,
+    pub summary_md: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct ArtifactWriter {
+    root: PathBuf,
+}
+
+impl ArtifactWriter {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn continuum_default() -> Self {
+        let home = dirs::home_dir().expect("home directory must exist for VDD artifacts");
+        Self::new(home.join(".continuum").join("vdd"))
+    }
+
+    pub fn write(
+        &self,
+        record: &StandardVddRecord,
+        manifest: &ReproducibilityManifest,
+    ) -> Result<ArtifactBundle, VddError> {
+        let dir = self.root.join(&record.git_sha).join(&record.scenario);
+        fs::create_dir_all(&dir).map_err(|source| VddError::Io {
+            path: dir.clone(),
+            source,
+        })?;
+
+        let record_jsonl = dir.join("record.jsonl");
+        let manifest_toml = dir.join("manifest.toml");
+        let summary_md = dir.join("summary.md");
+
+        write_file(
+            &record_jsonl,
+            format!("{}\n", serde_json::to_string(record)?),
+        )?;
+        write_file(&manifest_toml, toml::to_string_pretty(manifest)?)?;
+        write_file(&summary_md, render_summary(record))?;
+
+        Ok(ArtifactBundle {
+            dir,
+            record_jsonl,
+            manifest_toml,
+            summary_md,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReproducibilityManifest {
+    pub git_sha: String,
+    pub scenario: String,
+    pub command: String,
+    pub hardware: String,
+    pub backend: String,
+    pub policy_version: Option<String>,
+    pub cascade_step: Option<u8>,
+    pub env: Vec<ManifestEnvVar>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ManifestEnvVar {
+    pub name: String,
+    pub value: String,
+}
+
+impl ReproducibilityManifest {
+    pub fn from_record(record: &StandardVddRecord, env_names: &[&str]) -> Self {
+        let env = env_names
+            .iter()
+            .filter_map(|name| {
+                std::env::var(name).ok().map(|value| ManifestEnvVar {
+                    name: (*name).to_string(),
+                    value,
+                })
+            })
+            .collect();
+        Self {
+            git_sha: record.git_sha.clone(),
+            scenario: record.scenario.clone(),
+            command: record.command.clone(),
+            hardware: record.hardware.clone(),
+            backend: record.backend.clone(),
+            policy_version: record.policy_version.clone(),
+            cascade_step: record.cascade_step,
+            env,
+        }
+    }
+}
+
+fn write_file(path: &Path, body: impl AsRef<[u8]>) -> Result<(), VddError> {
+    let mut file = fs::File::create(path).map_err(|source| VddError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    file.write_all(body.as_ref())
+        .map_err(|source| VddError::Io {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+fn render_summary(record: &StandardVddRecord) -> String {
+    format!(
+        "# VDD: {}\n\n| Field | Value |\n|---|---|\n| status | {:?} |\n| git_sha | {} |\n| hardware | {} |\n| backend | {} |\n| first_response_ms | {} |\n| all_responses_ms | {} |\n| responses | {}/{} |\n| degraded_reason | {} |\n| silence_reasons | {} |\n",
+        record.scenario,
+        record.status,
+        record.git_sha,
+        record.hardware,
+        record.backend,
+        opt_u64(record.first_response_ms),
+        opt_u64(record.all_responses_ms),
+        record.responses_observed,
+        record.responses_expected,
+        record.degraded_reason.as_deref().unwrap_or("none"),
+        if record.silence_reasons.is_empty() {
+            "none".to_string()
+        } else {
+            record.silence_reasons.join(", ")
+        }
+    )
+}
+
+fn opt_u64(value: Option<u64>) -> String {
+    value
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "null".to_string())
+}

--- a/src/workers/continuum-core/src/vdd/chat_roundtrip.rs
+++ b/src/workers/continuum-core/src/vdd/chat_roundtrip.rs
@@ -1,0 +1,269 @@
+use crate::vdd::artifacts::{ArtifactBundle, ArtifactWriter, ReproducibilityManifest};
+use crate::vdd::record::{HarnessStatus, StandardVddRecord, VddError};
+use async_trait::async_trait;
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChatRoundtripConfigError {
+    #[error("CONTINUUM_CHAT_ROUNDTRIP_EXPECTED must be an unsigned integer: {0}")]
+    InvalidExpectedResponses(std::num::ParseIntError),
+    #[error("CONTINUUM_CHAT_ROUNDTRIP_EXPECTED must be valid unicode")]
+    NonUnicodeExpectedResponses,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChatRoundtripConfig {
+    pub expected_responses: u32,
+    pub git_sha: String,
+    pub command: String,
+    pub socket_path: Option<PathBuf>,
+    pub timeout: Duration,
+}
+
+impl ChatRoundtripConfig {
+    pub fn from_env() -> Result<Self, ChatRoundtripConfigError> {
+        let expected_responses = match std::env::var("CONTINUUM_CHAT_ROUNDTRIP_EXPECTED") {
+            Ok(raw) => raw
+                .parse::<u32>()
+                .map_err(ChatRoundtripConfigError::InvalidExpectedResponses)?,
+            Err(std::env::VarError::NotPresent) => 1,
+            Err(std::env::VarError::NotUnicode(_)) => {
+                return Err(ChatRoundtripConfigError::NonUnicodeExpectedResponses);
+            }
+        };
+        let git_sha = std::env::var("CONTINUUM_GIT_SHA").unwrap_or_else(|_| "unknown".to_string());
+        let command = "cargo continuum-vdd chat-roundtrip-live".to_string();
+        let socket_path = std::env::var_os("CONTINUUM_CHAT_ROUNDTRIP_SOCKET").map(PathBuf::from);
+        Ok(Self {
+            expected_responses,
+            git_sha,
+            command,
+            socket_path,
+            timeout: Duration::from_secs(30),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatRoundtripObservation {
+    pub first_response_ms: u64,
+    pub all_responses_ms: u64,
+    pub responses_observed: u32,
+    pub silence_reasons: Vec<String>,
+    pub log_refs: Vec<String>,
+}
+
+#[async_trait]
+pub trait ChatRoundtripProbe {
+    async fn observe(
+        &self,
+        config: &ChatRoundtripConfig,
+    ) -> Result<ChatRoundtripObservation, ChatRoundtripProbeError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChatRoundtripProbeError {
+    #[error("missing live chat substrate prerequisite: {0}")]
+    PrerequisiteMissing(String),
+    #[error("chat roundtrip failed: {0}")]
+    Failed(String),
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LiveChatProbe;
+
+#[async_trait]
+impl ChatRoundtripProbe for LiveChatProbe {
+    async fn observe(
+        &self,
+        config: &ChatRoundtripConfig,
+    ) -> Result<ChatRoundtripObservation, ChatRoundtripProbeError> {
+        let socket_path = config.socket_path.as_ref().ok_or_else(|| {
+            ChatRoundtripProbeError::PrerequisiteMissing(
+                "CONTINUUM_CHAT_ROUNDTRIP_SOCKET is not set".to_string(),
+            )
+        })?;
+        if !socket_path.exists() {
+            return Err(ChatRoundtripProbeError::PrerequisiteMissing(format!(
+                "chat roundtrip socket does not exist: {}",
+                socket_path.display()
+            )));
+        }
+        Err(ChatRoundtripProbeError::PrerequisiteMissing(
+            "live chat socket protocol adapter is not wired yet; refusing fake success".to_string(),
+        ))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ChatRoundtripHarness<P> {
+    probe: P,
+    artifacts: ArtifactWriter,
+}
+
+impl<P> ChatRoundtripHarness<P> {
+    pub fn new(probe: P, artifacts: ArtifactWriter) -> Self {
+        Self { probe, artifacts }
+    }
+}
+
+impl<P> ChatRoundtripHarness<P>
+where
+    P: ChatRoundtripProbe + Sync,
+{
+    pub async fn run(&self, config: ChatRoundtripConfig) -> Result<ArtifactBundle, VddError> {
+        let record = self.measure(config).await;
+        let manifest = ReproducibilityManifest::from_record(
+            &record,
+            &[
+                "CONTINUUM_CHAT_ROUNDTRIP_SOCKET",
+                "CONTINUUM_CHAT_ROUNDTRIP_EXPECTED",
+                "CONTINUUM_HARNESS_HARDWARE_CLASS",
+                "CONTINUUM_HARNESS_BACKEND",
+            ],
+        );
+        self.artifacts.write(&record, &manifest)
+    }
+
+    pub async fn measure(&self, config: ChatRoundtripConfig) -> StandardVddRecord {
+        let mut record = StandardVddRecord::chat_roundtrip(
+            config.git_sha.clone(),
+            config.command.clone(),
+            config.expected_responses,
+        );
+        match self.probe.observe(&config).await {
+            Ok(observation) => {
+                record.first_response_ms = Some(observation.first_response_ms);
+                record.all_responses_ms = Some(observation.all_responses_ms);
+                record.responses_observed = observation.responses_observed;
+                record.silence_reasons = observation.silence_reasons;
+                record.log_refs = observation.log_refs;
+                record.status = if record.responses_observed >= record.responses_expected
+                    && record.silence_reasons.is_empty()
+                {
+                    HarnessStatus::Pass
+                } else {
+                    record.error_count = 1;
+                    record.next_bottleneck =
+                        Some("persona cognition did not emit the expected replies".to_string());
+                    HarnessStatus::Fail
+                };
+            }
+            Err(ChatRoundtripProbeError::PrerequisiteMissing(reason)) => {
+                record.status = HarnessStatus::PrerequisiteMissing;
+                record.degraded_reason = Some(reason);
+                record.next_bottleneck =
+                    Some("wire the real chat roundtrip substrate probe".into());
+            }
+            Err(ChatRoundtripProbeError::Failed(reason)) => {
+                record.status = HarnessStatus::Fail;
+                record.error_count = 1;
+                record.degraded_reason = Some(reason);
+            }
+        }
+        record
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vdd::record::HarnessStatus;
+    use tempfile::tempdir;
+
+    struct StaticProbe(Result<ChatRoundtripObservation, ChatRoundtripProbeError>);
+
+    #[async_trait]
+    impl ChatRoundtripProbe for StaticProbe {
+        async fn observe(
+            &self,
+            _config: &ChatRoundtripConfig,
+        ) -> Result<ChatRoundtripObservation, ChatRoundtripProbeError> {
+            match &self.0 {
+                Ok(observation) => Ok(observation.clone()),
+                Err(ChatRoundtripProbeError::PrerequisiteMissing(reason)) => {
+                    Err(ChatRoundtripProbeError::PrerequisiteMissing(reason.clone()))
+                }
+                Err(ChatRoundtripProbeError::Failed(reason)) => {
+                    Err(ChatRoundtripProbeError::Failed(reason.clone()))
+                }
+            }
+        }
+    }
+
+    fn config() -> ChatRoundtripConfig {
+        ChatRoundtripConfig {
+            expected_responses: 2,
+            git_sha: "test-sha".to_string(),
+            command: "cargo continuum-vdd chat-roundtrip-live".to_string(),
+            socket_path: None,
+            timeout: Duration::from_millis(10),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_live_substrate_is_not_a_pass() {
+        let harness = ChatRoundtripHarness::new(
+            StaticProbe(Err(ChatRoundtripProbeError::PrerequisiteMissing(
+                "socket missing".to_string(),
+            ))),
+            ArtifactWriter::new(tempdir().unwrap().path()),
+        );
+
+        let record = harness.measure(config()).await;
+
+        assert_eq!(record.status, HarnessStatus::PrerequisiteMissing);
+        assert_eq!(record.responses_observed, 0);
+        assert_eq!(record.degraded_reason.as_deref(), Some("socket missing"));
+    }
+
+    #[tokio::test]
+    async fn insufficient_responses_fail_with_silence_reason() {
+        let harness = ChatRoundtripHarness::new(
+            StaticProbe(Ok(ChatRoundtripObservation {
+                first_response_ms: 42,
+                all_responses_ms: 77,
+                responses_observed: 1,
+                silence_reasons: vec!["helper-ai-only".to_string()],
+                log_refs: vec!["airc://log/1".to_string()],
+            })),
+            ArtifactWriter::new(tempdir().unwrap().path()),
+        );
+
+        let record = harness.measure(config()).await;
+
+        assert_eq!(record.status, HarnessStatus::Fail);
+        assert_eq!(record.error_count, 1);
+        assert_eq!(record.responses_observed, 1);
+        assert_eq!(record.silence_reasons, ["helper-ai-only"]);
+    }
+
+    #[tokio::test]
+    async fn successful_roundtrip_writes_jsonl_manifest_and_summary() {
+        let dir = tempdir().unwrap();
+        let harness = ChatRoundtripHarness::new(
+            StaticProbe(Ok(ChatRoundtripObservation {
+                first_response_ms: 40,
+                all_responses_ms: 120,
+                responses_observed: 2,
+                silence_reasons: Vec::new(),
+                log_refs: Vec::new(),
+            })),
+            ArtifactWriter::new(dir.path()),
+        );
+
+        let bundle = harness.run(config()).await.unwrap();
+
+        let jsonl = std::fs::read_to_string(&bundle.record_jsonl).unwrap();
+        let record: StandardVddRecord = serde_json::from_str(jsonl.trim()).unwrap();
+        assert_eq!(record.status, HarnessStatus::Pass);
+        assert_eq!(record.first_response_ms, Some(40));
+        assert!(bundle.manifest_toml.exists());
+        assert!(
+            std::fs::read_to_string(&bundle.summary_md)
+                .unwrap()
+                .contains("chat-roundtrip-live-harness")
+        );
+    }
+}

--- a/src/workers/continuum-core/src/vdd/mod.rs
+++ b/src/workers/continuum-core/src/vdd/mod.rs
@@ -1,0 +1,15 @@
+//! VDD harness support.
+//!
+//! Harnesses emit machine-readable records plus replay artifacts. A missing
+//! live prerequisite is a typed result, not a passing fallback.
+
+pub mod artifacts;
+pub mod chat_roundtrip;
+pub mod record;
+
+pub use artifacts::{ArtifactBundle, ArtifactWriter};
+pub use chat_roundtrip::{
+    ChatRoundtripConfig, ChatRoundtripHarness, ChatRoundtripObservation, ChatRoundtripProbe,
+    LiveChatProbe,
+};
+pub use record::{HarnessStatus, StandardVddRecord, VddError};

--- a/src/workers/continuum-core/src/vdd/record.rs
+++ b/src/workers/continuum-core/src/vdd/record.rs
@@ -1,0 +1,110 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HarnessStatus {
+    Pass,
+    Fail,
+    PrerequisiteMissing,
+}
+
+#[derive(Debug, Error)]
+pub enum VddError {
+    #[error("io error at {path:?}: {source}")]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("json serialization failed: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("toml serialization failed: {0}")]
+    Toml(#[from] toml::ser::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StandardVddRecord {
+    pub scenario: String,
+    pub platform: String,
+    pub hardware: String,
+    pub backend: String,
+    pub git_sha: String,
+    pub command: String,
+    pub model: Option<String>,
+    pub gpu_layers: Option<u32>,
+    pub unsupported_layers: Vec<String>,
+    pub cold_start_ms: Option<u64>,
+    pub first_token_ms: Option<u64>,
+    pub first_response_ms: Option<u64>,
+    pub all_responses_ms: Option<u64>,
+    pub responses_expected: u32,
+    pub responses_observed: u32,
+    pub silence_reasons: Vec<String>,
+    pub tok_per_sec: Option<f64>,
+    pub cpu_pct_avg: Option<f64>,
+    pub cpu_pct_peak: Option<f64>,
+    pub rss_mb: Option<u64>,
+    pub gpu_util_pct_avg: Option<f64>,
+    pub gpu_memory_mb: Option<u64>,
+    pub queue_wait_ms: Option<u64>,
+    pub execution_ms: Option<u64>,
+    pub coalesced_count: u32,
+    pub deferred_count: u32,
+    pub stale_drop_count: u32,
+    pub error_count: u32,
+    pub degraded_reason: Option<String>,
+    pub log_refs: Vec<String>,
+    pub next_bottleneck: Option<String>,
+    pub policy_version: Option<String>,
+    pub cascade_step: Option<u8>,
+    pub status: HarnessStatus,
+}
+
+impl StandardVddRecord {
+    pub fn chat_roundtrip(
+        git_sha: impl Into<String>,
+        command: impl Into<String>,
+        expected: u32,
+    ) -> Self {
+        Self {
+            scenario: "chat-roundtrip-live-harness".to_string(),
+            platform: std::env::consts::OS.to_string(),
+            hardware: std::env::var("CONTINUUM_HARNESS_HARDWARE_CLASS")
+                .unwrap_or_else(|_| "unknown".to_string()),
+            backend: std::env::var("CONTINUUM_HARNESS_BACKEND")
+                .unwrap_or_else(|_| "unknown".to_string()),
+            git_sha: git_sha.into(),
+            command: command.into(),
+            model: None,
+            gpu_layers: None,
+            unsupported_layers: Vec::new(),
+            cold_start_ms: None,
+            first_token_ms: None,
+            first_response_ms: None,
+            all_responses_ms: None,
+            responses_expected: expected,
+            responses_observed: 0,
+            silence_reasons: Vec::new(),
+            tok_per_sec: None,
+            cpu_pct_avg: None,
+            cpu_pct_peak: None,
+            rss_mb: None,
+            gpu_util_pct_avg: None,
+            gpu_memory_mb: None,
+            queue_wait_ms: None,
+            execution_ms: None,
+            coalesced_count: 0,
+            deferred_count: 0,
+            stale_drop_count: 0,
+            error_count: 0,
+            degraded_reason: None,
+            log_refs: Vec::new(),
+            next_bottleneck: None,
+            policy_version: None,
+            cascade_step: None,
+            status: HarnessStatus::Fail,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Rust VDD record/artifact primitives under continuum-core/src/vdd
- add chat-roundtrip-live harness with explicit pass/fail/prerequisite-missing statuses
- add cargo-continuum-vdd subcommand so cargo continuum-vdd chat-roundtrip-live emits JSONL, TOML, and markdown artifacts

## Proof
- cargo test --manifest-path src/workers/continuum-core/Cargo.toml --lib --features metal,accelerate vdd::chat_roundtrip::
- cargo check --manifest-path src/workers/continuum-core/Cargo.toml --bin cargo-continuum-vdd --features metal,accelerate
- CONTINUUM_GIT_SHA=$(git rev-parse --short HEAD) cargo run --manifest-path src/workers/continuum-core/Cargo.toml --bin cargo-continuum-vdd --features metal,accelerate -- chat-roundtrip-live
  - expected exit 3 when CONTINUUM_CHAT_ROUNDTRIP_SOCKET is unset
  - wrote ~/.continuum/vdd/<sha>/chat-roundtrip-live-harness/{record.jsonl,manifest.toml,summary.md}

## Pre-push
- TypeScript: passed
- ESLint baseline: passed
- Rust compile: passed
- Rust tests: passed
- Native Docker push: attempted by hook, failed with BuildKit transport EOF / graceful_stop after long compile; hook continued. CI verify-architectures may block until scripts/push-current-arch.sh succeeds.