### PR TITLE
feat(vdd): add typed harness registry

### DIFF
--- a/src/workers/continuum-core/src/bin/cargo-continuum-vdd.rs
+++ b/src/workers/continuum-core/src/bin/cargo-continuum-vdd.rs
@@ -1,20 +1,43 @@
 use continuum_core::vdd::{
-    ArtifactWriter, ChatRoundtripConfig, ChatRoundtripHarness, HarnessStatus, LiveChatProbe,
+    ArtifactWriter, ChatRoundtripConfig, ChatRoundtripHarness, HARNESS_SPECS, HarnessId,
+    HarnessStatus, LiveChatProbe,
 };
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Command {
+    List,
+    Run(HarnessId),
+}
 
 #[tokio::main]
 async fn main() {
-    let mut args = std::env::args().skip(1);
-    let harness = match args.next() {
-        Some(name) => name,
-        None => {
+    let command = match parse_command(std::env::args().skip(1)) {
+        Ok(command) => command,
+        Err(error) => {
+            eprintln!("{error}");
+            eprintln!("usage: cargo continuum-vdd list");
             eprintln!("usage: cargo continuum-vdd <chat-roundtrip-live>");
             std::process::exit(2);
         }
     };
 
-    let result = match harness.as_str() {
-        "chat-roundtrip-live" => {
+    if command == Command::List {
+        match serde_json::to_string_pretty(HARNESS_SPECS) {
+            Ok(body) => {
+                println!("{body}");
+                return;
+            }
+            Err(error) => {
+                eprintln!("continuum-vdd failed to serialize harness registry: {error}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let result = match command {
+        Command::List => unreachable!("list command returned before harness execution"),
+        Command::Run(HarnessId::ChatRoundtripLive) => {
             let runner =
                 ChatRoundtripHarness::new(LiveChatProbe, ArtifactWriter::continuum_default());
             let config = match ChatRoundtripConfig::from_env() {
@@ -26,10 +49,6 @@ async fn main() {
             };
             runner.run(config).await
         }
-        other => {
-            eprintln!("unknown continuum-vdd harness: {other}");
-            std::process::exit(2);
-        }
     };
 
     let bundle = match result {
@@ -40,14 +59,90 @@ async fn main() {
         }
     };
 
-    let record_body = std::fs::read_to_string(&bundle.record_jsonl)
-        .expect("record just written by continuum-vdd must be readable");
+    let record_body = match std::fs::read_to_string(&bundle.record_jsonl) {
+        Ok(body) => body,
+        Err(error) => {
+            eprintln!(
+                "continuum-vdd failed to read record {}: {error}",
+                bundle.record_jsonl.display()
+            );
+            std::process::exit(1);
+        }
+    };
     let record: continuum_core::vdd::StandardVddRecord =
-        serde_json::from_str(record_body.trim()).expect("record just written must parse");
+        match serde_json::from_str(record_body.trim()) {
+            Ok(record) => record,
+            Err(error) => {
+                eprintln!(
+                    "continuum-vdd wrote an invalid record {}: {error}",
+                    bundle.record_jsonl.display()
+                );
+                std::process::exit(1);
+            }
+        };
     println!("{}", bundle.dir.display());
     match record.status {
         HarnessStatus::Pass => {}
         HarnessStatus::PrerequisiteMissing => std::process::exit(3),
         HarnessStatus::Fail => std::process::exit(1),
+    }
+}
+
+fn parse_command(args: impl IntoIterator<Item = String>) -> Result<Command, String> {
+    let mut args = args.into_iter();
+    let Some(first) = args.next() else {
+        return Err("missing continuum-vdd command".to_string());
+    };
+    if let Some(extra) = args.next() {
+        return Err(format!("unexpected extra continuum-vdd argument: {extra}"));
+    }
+    match first.as_str() {
+        "list" => Ok(Command::List),
+        harness => HarnessId::from_str(harness)
+            .map(Command::Run)
+            .map_err(|error| error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(values: &[&str]) -> Result<Command, String> {
+        parse_command(values.iter().map(|value| (*value).to_string()))
+    }
+
+    #[test]
+    fn list_is_a_first_class_command() {
+        assert_eq!(parse(&["list"]), Ok(Command::List));
+    }
+
+    #[test]
+    fn direct_harness_invocation_remains_supported() {
+        assert_eq!(
+            parse(&["chat-roundtrip-live"]),
+            Ok(Command::Run(HarnessId::ChatRoundtripLive))
+        );
+    }
+
+    #[test]
+    fn missing_command_fails_loud() {
+        assert_eq!(parse(&[]), Err("missing continuum-vdd command".to_string()));
+    }
+
+    #[test]
+    fn unknown_harness_fails_loud() {
+        assert_eq!(
+            parse(&["helper-chat"]),
+            Err("unknown continuum-vdd harness: helper-chat".to_string())
+        );
+    }
+
+    #[test]
+    fn extra_arguments_fail_loud() {
+        assert_eq!(
+            parse(&["chat-roundtrip-live", "extra"]),
+            Err("unexpected extra continuum-vdd argument: extra".to_string())
+        );
     }
 }

--- a/src/workers/continuum-core/src/vdd/mod.rs
+++ b/src/workers/continuum-core/src/vdd/mod.rs
@@ -6,6 +6,7 @@
 pub mod artifacts;
 pub mod chat_roundtrip;
 pub mod record;
+pub mod registry;
 
 pub use artifacts::{ArtifactBundle, ArtifactWriter};
 pub use chat_roundtrip::{
@@ -13,3 +14,4 @@ pub use chat_roundtrip::{
     LiveChatProbe,
 };
 pub use record::{HarnessStatus, StandardVddRecord, VddError};
+pub use registry::{HARNESS_SPECS, HarnessCadence, HarnessId, HarnessSpec, harness_spec};

--- a/src/workers/continuum-core/src/vdd/registry.rs
+++ b/src/workers/continuum-core/src/vdd/registry.rs
@@ -1,0 +1,105 @@
+use serde::Serialize;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HarnessId {
+    ChatRoundtripLive,
+}
+
+impl HarnessId {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ChatRoundtripLive => "chat-roundtrip-live",
+        }
+    }
+}
+
+impl fmt::Display for HarnessId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for HarnessId {
+    type Err = UnknownHarness;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "chat-roundtrip-live" => Ok(Self::ChatRoundtripLive),
+            other => Err(UnknownHarness {
+                requested: other.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("unknown continuum-vdd harness: {requested}")]
+pub struct UnknownHarness {
+    pub requested: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct HarnessSpec {
+    pub id: HarnessId,
+    pub scenario: &'static str,
+    pub cadence: HarnessCadence,
+    pub requires_live_substrate: bool,
+    pub command: &'static str,
+    pub description: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HarnessCadence {
+    PerPr,
+}
+
+pub const CHAT_ROUNDTRIP_LIVE_SPEC: HarnessSpec = HarnessSpec {
+    id: HarnessId::ChatRoundtripLive,
+    scenario: "chat-roundtrip-live-harness",
+    cadence: HarnessCadence::PerPr,
+    requires_live_substrate: true,
+    command: "cargo continuum-vdd chat-roundtrip-live",
+    description: "Verifies the live chat substrate can admit a probe and observe persona replies without counting missing prerequisites as success.",
+};
+
+pub const HARNESS_SPECS: &[HarnessSpec] = &[CHAT_ROUNDTRIP_LIVE_SPEC];
+
+pub fn harness_spec(id: HarnessId) -> HarnessSpec {
+    match id {
+        HarnessId::ChatRoundtripLive => CHAT_ROUNDTRIP_LIVE_SPEC,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_harness_id() {
+        assert_eq!(
+            "chat-roundtrip-live".parse::<HarnessId>(),
+            Ok(HarnessId::ChatRoundtripLive)
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_harness_ids() {
+        let err = "chat".parse::<HarnessId>().unwrap_err();
+
+        assert_eq!(err.requested, "chat");
+    }
+
+    #[test]
+    fn registry_has_stable_command_and_scenario() {
+        let spec = harness_spec(HarnessId::ChatRoundtripLive);
+
+        assert_eq!(HARNESS_SPECS, &[spec]);
+        assert_eq!(spec.command, "cargo continuum-vdd chat-roundtrip-live");
+        assert_eq!(spec.scenario, "chat-roundtrip-live-harness");
+        assert!(spec.requires_live_substrate);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a typed Rust VDD harness registry with stable harness ids/specs.
- Adds `cargo continuum-vdd list` as a machine-readable JSON manifest surface.
- Keeps direct `cargo continuum-vdd chat-roundtrip-live` invocation working and makes missing/unknown/extra CLI args fail loudly.

## Proof
- `cargo test --manifest-path src/workers/continuum-core/Cargo.toml --lib --features metal,accelerate vdd::` — 6 passed.
- `cargo test --manifest-path src/workers/continuum-core/Cargo.toml --bin cargo-continuum-vdd --features metal,accelerate` — 5 passed.
- `cargo check --manifest-path src/workers/continuum-core/Cargo.toml --bin cargo-continuum-vdd --features metal,accelerate` — passed.
- `cargo run --manifest-path src/workers/continuum-core/Cargo.toml --bin cargo-continuum-vdd --features metal,accelerate -- list` — emitted JSON manifest.
- `cargo run --manifest-path src/workers/continuum-core/Cargo.toml --bin cargo-continuum-vdd --features metal,accelerate -- helper-chat` — exited 2 with unknown-harness error.
- Precommit hook — passed; browser tests skipped because `jtag ping` and continuum-core IPC socket were not reachable.
- Prepush hook — TS, ESLint, Rust compile, and Rust tests passed. Native Docker slice built but failed boot readiness for `continuum-core:e4045e464`, so image push was skipped and CI verify-architectures may block merge until that boot issue is resolved.

## Notes
- Strict `cargo clippy -- -D warnings` is currently blocked before this change by existing local path dependency warnings in `llama/src/mtmd.rs` (`too_many_arguments`). The precommit baseline clippy gate passed.