### PR TITLE
fix(docker): retain slice logs after boot crash

### DIFF
--- a/scripts/test-slices.sh
+++ b/scripts/test-slices.sh
@@ -74,7 +74,8 @@ if ! docker info &>/dev/null; then
 fi
 
 # Variant-specific docker run flags.
-RUN_FLAGS=(--rm -d --name "continuum-slice-$VARIANT-$$")
+CONTAINER_NAME="continuum-slice-$VARIANT-$$"
+RUN_FLAGS=(-d --name "$CONTAINER_NAME")
 case "$VARIANT" in
   cuda)
     # Requires NVIDIA Container Toolkit on the host. If absent, cuda slice
@@ -108,7 +109,9 @@ fail() {
 
 cleanup() {
   if [[ -n "${CID:-}" ]]; then
-    docker kill "$CID" >/dev/null 2>&1 || true
+    docker rm -f "$CID" >/dev/null 2>&1 || true
+  elif docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
   fi
 }
 trap cleanup EXIT
@@ -134,7 +137,10 @@ BOOT_OK=false
 CID="$(docker run "${RUN_FLAGS[@]}" "$IMAGE_TAG" 2>/dev/null || true)"
 if [[ -z "$CID" ]]; then
   fail "boot" "docker run exited immediately"
-  echo "  docker logs: $(docker logs "continuum-slice-$VARIANT-$$" 2>&1 | tail -10)" >&2
+  if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    echo "  docker logs:" >&2
+    docker logs "$CONTAINER_NAME" 2>&1 | tail -20 | sed 's/^/    /' >&2
+  fi
   exit 2
 fi
 


### PR DESCRIPTION
## Summary
- Keeps Docker slice-test containers long enough to read logs when boot fails.
- Cleans retained containers explicitly in the existing trap.
- Preserves current slice semantics, but makes `no-panic` inspect the real logs after a boot failure instead of silently passing because `--rm` deleted evidence.

## Proof
- `bash -n scripts/test-slices.sh` — passed.
- Reproduced against known-failing `ghcr.io/cambriantech/continuum-core:e4045e464`: `scripts/test-slices.sh core ghcr.io/cambriantech/continuum-core:e4045e464` now reports both `boot` and `no-panic` failures and prints the actual `GpuMemoryManager` no-GPU panic log.
- Precommit hook — passed; browser tests skipped because `jtag ping` and continuum-core IPC socket were not reachable.
- Prepush hook — TS and ESLint passed; Rust and Docker phases skipped because this is shell-script-only.