### PR TITLE
feat(governor): watch policy directory reloads

### DIFF
--- a/src/workers/Cargo.lock
+++ b/src/workers/Cargo.lock
@@ -2167,6 +2167,7 @@ dependencies = [
  "metal 0.32.0",
  "msedge-tts",
  "ndarray",
+ "notify",
  "num_cpus",
  "objc",
  "once_cell",
@@ -3458,6 +3459,15 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4763,6 +4773,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5021,6 +5051,26 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
 
 [[package]]
 name = "ktx2"
@@ -5544,6 +5594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -5777,6 +5828,33 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "ntapi"

--- a/src/workers/continuum-core/Cargo.toml
+++ b/src/workers/continuum-core/Cargo.toml
@@ -146,6 +146,7 @@ wgpu = "27"
 wgpu-hal = "27"
 
 arc-swap = "1.7"           # Wait-free policy publish for SubstrateGovernor (Lane H)
+notify = "8"               # Policy directory watch + hot reload for SubstrateGovernor
 crossbeam-channel = "0.5"  # Frame delivery from Bevy render thread to LiveKit
 image = "0.25"             # RGBA → PNG encoding for avatar snapshots
 

--- a/src/workers/continuum-core/src/governor/mod.rs
+++ b/src/workers/continuum-core/src/governor/mod.rs
@@ -11,24 +11,28 @@ pub mod cascade;
 pub mod local;
 pub mod policy_file;
 pub mod policy_selector;
+pub mod policy_watcher;
 pub mod types;
 
 pub use cascade::{
-    apply_action, evaluate_next_step, CascadeAction, CascadeThresholds, CASCADE_STEP_MAX,
-    CASCADE_STEP_MIN,
+    CASCADE_STEP_MAX, CASCADE_STEP_MIN, CascadeAction, CascadeThresholds, apply_action,
+    evaluate_next_step,
 };
 pub use local::LocalSubstrateGovernor;
 pub use policy_file::{
-    into_governor_policy, load_policy_file, parse_policy_text, PolicyFile, PolicyFileError,
+    PolicyFile, PolicyFileError, into_governor_policy, load_policy_file, parse_policy_text,
 };
 pub use policy_selector::{
-    hardware_fingerprint, policy_matches_hardware, select_policy, PolicySelectionError,
+    PolicySelectionError, hardware_fingerprint, policy_matches_hardware, select_policy,
+};
+pub use policy_watcher::{
+    PolicyDirectoryError, PolicyDirectoryWatcher, load_policy_directory, reload_policy_candidates,
+    watch_policy_directory,
 };
 pub use types::{
-    classify_hardware, CadenceMultipliers, ConcurrencyCaps, ConsolidationSchedule,
-    FederationCadence, GovernorPolicy, GovernorSnapshot, HardwareClass, PowerSource,
-    PressureSignal, RecallScoreWeights, SpeculationLevel, TargetSilicon, ThermalClass,
-    ThermalSeverity, TierSizes,
+    CadenceMultipliers, ConcurrencyCaps, ConsolidationSchedule, FederationCadence, GovernorPolicy,
+    GovernorSnapshot, HardwareClass, PowerSource, PressureSignal, RecallScoreWeights,
+    SpeculationLevel, TargetSilicon, ThermalClass, ThermalSeverity, TierSizes, classify_hardware,
 };
 
 /// The trait every Substrate Governor implementation must satisfy.

--- a/src/workers/continuum-core/src/governor/policy_watcher.rs
+++ b/src/workers/continuum-core/src/governor/policy_watcher.rs
@@ -1,0 +1,448 @@
+//! Policy directory discovery and hot reload for `LocalSubstrateGovernor`.
+//!
+//! This module is deliberately small: it loads TOML policy files through
+//! `policy_file`, swaps the fully parsed candidate set into the governor,
+//! and keeps a `notify` watcher alive so operator edits can trigger the
+//! same reload path. Broken directories or malformed files return typed
+//! errors. The watcher callback records and logs failures instead of
+//! replacing a good candidate set with junk.
+
+use crate::governor::{LocalSubstrateGovernor, PolicyFile, PolicyFileError, load_policy_file};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, thiserror::Error)]
+pub enum PolicyDirectoryError {
+    #[error("policy directory I/O failed at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("policy file failed to load at {path}: {source}")]
+    Policy {
+        path: PathBuf,
+        #[source]
+        source: PolicyFileError,
+    },
+    #[error("policy directory {path} has no .toml policy files")]
+    Empty { path: PathBuf },
+    #[error("policy watcher failed for {path}: {source}")]
+    Watch {
+        path: PathBuf,
+        #[source]
+        source: notify::Error,
+    },
+}
+
+pub struct PolicyDirectoryWatcher {
+    _watcher: RecommendedWatcher,
+    policy_dir: PathBuf,
+    governor: Arc<LocalSubstrateGovernor>,
+    last_error: Arc<Mutex<Option<String>>>,
+}
+
+impl PolicyDirectoryWatcher {
+    pub fn policy_dir(&self) -> &Path {
+        &self.policy_dir
+    }
+
+    pub fn candidate_count(&self) -> usize {
+        self.governor.candidate_count()
+    }
+
+    pub fn last_error(&self) -> Option<String> {
+        self.last_error
+            .lock()
+            .expect("PolicyDirectoryWatcher last_error mutex poisoned")
+            .clone()
+    }
+
+    pub fn reload_now(&self) -> Result<usize, PolicyDirectoryError> {
+        reload_policy_candidates(&self.governor, &self.policy_dir)
+    }
+
+    pub fn clear_last_error(&self) {
+        let mut guard = self
+            .last_error
+            .lock()
+            .expect("PolicyDirectoryWatcher last_error mutex poisoned");
+        *guard = None;
+    }
+}
+
+pub fn watch_policy_directory(
+    policy_dir: impl AsRef<Path>,
+    governor: Arc<LocalSubstrateGovernor>,
+) -> Result<PolicyDirectoryWatcher, PolicyDirectoryError> {
+    let policy_dir = policy_dir.as_ref().to_path_buf();
+    reload_policy_candidates(&governor, &policy_dir)?;
+
+    let last_error = Arc::new(Mutex::new(None));
+    let callback_dir = policy_dir.clone();
+    let callback_governor = Arc::clone(&governor);
+    let callback_last_error = Arc::clone(&last_error);
+
+    let mut watcher = notify::recommended_watcher(move |event: notify::Result<Event>| {
+        let result = match event {
+            Ok(event) if is_reload_event(&event) => {
+                reload_policy_candidates(&callback_governor, &callback_dir).map(|_| ())
+            }
+            Ok(_) => Ok(()),
+            Err(source) => Err(PolicyDirectoryError::Watch {
+                path: callback_dir.clone(),
+                source,
+            }),
+        };
+
+        if let Err(error) = result {
+            let message = error.to_string();
+            tracing::error!(target: "continuum_core::governor::policy_watcher", %message);
+            let mut guard = callback_last_error
+                .lock()
+                .expect("PolicyDirectoryWatcher last_error mutex poisoned");
+            *guard = Some(message);
+        }
+    })
+    .map_err(|source| PolicyDirectoryError::Watch {
+        path: policy_dir.clone(),
+        source,
+    })?;
+
+    watcher
+        .watch(&policy_dir, RecursiveMode::NonRecursive)
+        .map_err(|source| PolicyDirectoryError::Watch {
+            path: policy_dir.clone(),
+            source,
+        })?;
+
+    Ok(PolicyDirectoryWatcher {
+        _watcher: watcher,
+        policy_dir,
+        governor,
+        last_error,
+    })
+}
+
+pub fn reload_policy_candidates(
+    governor: &LocalSubstrateGovernor,
+    policy_dir: &Path,
+) -> Result<usize, PolicyDirectoryError> {
+    let policies = load_policy_directory(policy_dir)?;
+    let count = policies.len();
+    governor.set_candidates(policies);
+    Ok(count)
+}
+
+pub fn load_policy_directory(policy_dir: &Path) -> Result<Vec<PolicyFile>, PolicyDirectoryError> {
+    let mut paths = Vec::new();
+    let entries = std::fs::read_dir(policy_dir).map_err(|source| PolicyDirectoryError::Io {
+        path: policy_dir.to_path_buf(),
+        source,
+    })?;
+
+    for entry in entries {
+        let entry = entry.map_err(|source| PolicyDirectoryError::Io {
+            path: policy_dir.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("toml") {
+            paths.push(path);
+        }
+    }
+
+    paths.sort();
+    if paths.is_empty() {
+        return Err(PolicyDirectoryError::Empty {
+            path: policy_dir.to_path_buf(),
+        });
+    }
+
+    paths
+        .into_iter()
+        .map(|path| {
+            load_policy_file(&path).map_err(|source| PolicyDirectoryError::Policy { path, source })
+        })
+        .collect()
+}
+
+fn is_reload_event(event: &Event) -> bool {
+    let touches_policy = event.paths.is_empty()
+        || event
+            .paths
+            .iter()
+            .any(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"));
+
+    touches_policy
+        && matches!(
+            event.kind,
+            EventKind::Any | EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::governor::types::{
+        CadenceMultipliers, ConcurrencyCaps, ConsolidationSchedule, FederationCadence,
+        GovernorPolicy, HardwareClass, PowerSource, RecallScoreWeights, SpeculationLevel,
+        TargetSilicon, ThermalClass, TierSizes,
+    };
+    use notify::event::{AccessKind, CreateKind};
+
+    const AIR_POLICY: &str = r#"
+policy_version = 3
+applies_to    = "apple-m,thinandlight,uma,vram_mb=0..0,ram_mb=14000..18000"
+
+[tier_sizes]
+l1_lora_layers       = 2
+l1_kv_tokens         = 2048
+l2_lora_layers       = 4
+l3_lora_layers       = 12
+l3_engrams           = 1024
+
+[cadence_multipliers]
+realtime             = 1.0
+delayed              = 1.5
+background           = 2.0
+
+[concurrency_caps]
+personas_concurrent  = 2
+inference_lanes      = 1
+foundry_lanes        = 0
+sentinel_lanes       = 1
+
+[speculation]
+level                = "conservative"
+
+[consolidation]
+schedule             = "idle-plugged-in"
+
+[federation]
+pull_cadence_seconds = 600
+
+[recall_weights]
+semantic             = 0.4
+outcome_history      = 0.3
+recency              = 0.1
+tier_proximity       = 0.1
+provenance_trust     = 0.1
+"#;
+
+    const NVIDIA_POLICY: &str = r#"
+policy_version = 1
+applies_to     = "nvidia,workstation,vram_mb=30000..36000,ram_mb=60000..80000"
+
+[tier_sizes]
+l1_lora_layers        = 8
+l1_kv_tokens          = 16384
+l2_lora_layers        = 16
+l3_lora_layers        = 40
+l3_engrams            = 10240
+
+[cadence_multipliers]
+realtime              = 1.0
+delayed               = 1.0
+background            = 1.5
+
+[concurrency_caps]
+personas_concurrent   = 8
+inference_lanes       = 4
+foundry_lanes         = 1
+sentinel_lanes        = 2
+
+[speculation]
+level                 = "aggressive"
+
+[consolidation]
+schedule              = "idle"
+
+[federation]
+pull_cadence_seconds  = 60
+
+[recall_weights]
+semantic              = 0.4
+outcome_history       = 0.3
+recency               = 0.1
+tier_proximity        = 0.1
+provenance_trust      = 0.1
+"#;
+
+    #[test]
+    fn load_policy_directory_loads_sorted_toml_only() {
+        let dir = tempfile::tempdir().expect("tempdir should be creatable");
+        write(dir.path().join("b-nvidia.toml"), NVIDIA_POLICY);
+        write(dir.path().join("a-air.toml"), AIR_POLICY);
+        write(dir.path().join("notes.txt"), "ignored");
+
+        let policies = load_policy_directory(dir.path()).expect("policies should load");
+
+        assert_eq!(policies.len(), 2);
+        assert_eq!(policies[0].policy_version, 3);
+        assert_eq!(policies[1].policy_version, 1);
+    }
+
+    #[test]
+    fn load_policy_directory_empty_dir_fails_loud() {
+        let dir = tempfile::tempdir().expect("tempdir should be creatable");
+
+        let result = load_policy_directory(dir.path());
+
+        assert!(matches!(result, Err(PolicyDirectoryError::Empty { .. })));
+    }
+
+    #[test]
+    fn load_policy_directory_invalid_policy_identifies_path() {
+        let dir = tempfile::tempdir().expect("tempdir should be creatable");
+        let bad_path = dir.path().join("bad.toml");
+        write(&bad_path, "not valid [[[");
+
+        let result = load_policy_directory(dir.path());
+
+        match result {
+            Err(PolicyDirectoryError::Policy { path, source }) => {
+                assert_eq!(path, bad_path);
+                assert!(matches!(source, PolicyFileError::Toml(_)));
+            }
+            other => panic!("expected policy parse error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reload_policy_candidates_replaces_candidate_pool_atomically() {
+        let dir = tempfile::tempdir().expect("tempdir should be creatable");
+        write(dir.path().join("air.toml"), AIR_POLICY);
+        write(dir.path().join("nvidia.toml"), NVIDIA_POLICY);
+        let governor = LocalSubstrateGovernor::new(initial_policy());
+
+        let count =
+            reload_policy_candidates(&governor, dir.path()).expect("valid policies should reload");
+
+        assert_eq!(count, 2);
+        assert_eq!(governor.candidate_count(), 2);
+    }
+
+    #[test]
+    fn reload_policy_candidates_keeps_existing_pool_on_error() {
+        let valid_dir = tempfile::tempdir().expect("tempdir should be creatable");
+        write(valid_dir.path().join("air.toml"), AIR_POLICY);
+        let bad_dir = tempfile::tempdir().expect("tempdir should be creatable");
+        write(bad_dir.path().join("bad.toml"), "not valid [[[");
+        let governor = LocalSubstrateGovernor::new(initial_policy());
+        reload_policy_candidates(&governor, valid_dir.path())
+            .expect("valid policies should reload first");
+
+        let result = reload_policy_candidates(&governor, bad_dir.path());
+
+        assert!(matches!(result, Err(PolicyDirectoryError::Policy { .. })));
+        assert_eq!(governor.candidate_count(), 1);
+    }
+
+    #[test]
+    fn watch_policy_directory_initial_loads_candidates() {
+        let dir = tempfile::tempdir().expect("tempdir should be creatable");
+        write(dir.path().join("air.toml"), AIR_POLICY);
+        let governor = Arc::new(LocalSubstrateGovernor::new(initial_policy()));
+
+        let watcher = watch_policy_directory(dir.path(), Arc::clone(&governor))
+            .expect("valid directory should start watcher");
+
+        assert_eq!(watcher.policy_dir(), dir.path());
+        assert_eq!(watcher.candidate_count(), 1);
+        assert_eq!(watcher.last_error(), None);
+    }
+
+    #[test]
+    fn watcher_reload_now_uses_same_strict_loader() {
+        let dir = tempfile::tempdir().expect("tempdir should be creatable");
+        write(dir.path().join("air.toml"), AIR_POLICY);
+        let governor = Arc::new(LocalSubstrateGovernor::new(initial_policy()));
+        let watcher = watch_policy_directory(dir.path(), Arc::clone(&governor))
+            .expect("valid directory should start watcher");
+        write(dir.path().join("nvidia.toml"), NVIDIA_POLICY);
+
+        let count = watcher
+            .reload_now()
+            .expect("manual reload should load both");
+
+        assert_eq!(count, 2);
+        assert_eq!(governor.candidate_count(), 2);
+    }
+
+    #[test]
+    fn is_reload_event_requires_policy_file_and_write_kind() {
+        let toml_create = Event {
+            kind: EventKind::Create(CreateKind::File),
+            paths: vec![PathBuf::from("policy.toml")],
+            attrs: Default::default(),
+        };
+        let txt_create = Event {
+            kind: EventKind::Create(CreateKind::File),
+            paths: vec![PathBuf::from("notes.txt")],
+            attrs: Default::default(),
+        };
+        let toml_access = Event {
+            kind: EventKind::Access(AccessKind::Any),
+            paths: vec![PathBuf::from("policy.toml")],
+            attrs: Default::default(),
+        };
+
+        assert!(is_reload_event(&toml_create));
+        assert!(!is_reload_event(&txt_create));
+        assert!(!is_reload_event(&toml_access));
+    }
+
+    fn write(path: impl AsRef<Path>, text: &str) {
+        std::fs::write(path, text).expect("test file should be writable");
+    }
+
+    fn initial_policy() -> GovernorPolicy {
+        GovernorPolicy {
+            policy_version: 1,
+            hardware_class: HardwareClass {
+                silicon: TargetSilicon::AppleM,
+                silicon_model: "M2".to_string(),
+                vram_mb: 0,
+                system_ram_mb: 16_384,
+                thermal_class: ThermalClass::ThinAndLight,
+                power_source: PowerSource::Battery,
+                battery_pct: Some(80),
+                thermal_headroom_pct: Some(60),
+            },
+            tier_sizes: TierSizes {
+                l1_lora_layers: 2,
+                l1_kv_tokens: 2048,
+                l2_lora_layers: 4,
+                l3_lora_layers: 12,
+                l3_engrams: 1024,
+            },
+            cadence_multipliers: CadenceMultipliers {
+                realtime: 1.0,
+                delayed: 1.5,
+                background: 2.0,
+            },
+            concurrency_caps: ConcurrencyCaps {
+                personas_concurrent: 2,
+                inference_lanes: 1,
+                foundry_lanes: 0,
+                sentinel_lanes: 1,
+            },
+            speculation_aggressiveness: SpeculationLevel::Conservative,
+            consolidation_schedule: ConsolidationSchedule::IdlePluggedIn,
+            federation_pull_cadence: FederationCadence {
+                pull_cadence_seconds: 600,
+            },
+            recall_score_weights: RecallScoreWeights {
+                semantic: 0.4,
+                outcome_history: 0.3,
+                recency: 0.1,
+                tier_proximity: 0.1,
+                provenance_trust: 0.1,
+            },
+            cascade_step: 0,
+            committed_at_ms: 1,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Rust `policy_watcher` module for deterministic TOML policy directory loading
- expose `watch_policy_directory` / `reload_policy_candidates` for `LocalSubstrateGovernor` hot reload
- fail loud on missing, empty, malformed, and watcher errors; callback records last error instead of replacing valid candidates with bad state

## Proof
- `cargo test --manifest-path src/workers/continuum-core/Cargo.toml --lib --features metal,accelerate governor::policy_watcher::` -> 8 passed
- `cargo test --manifest-path src/workers/continuum-core/Cargo.toml --lib --features metal,accelerate governor::` -> 146 passed
- precommit -> TS passed; targeted Rust clippy at baseline; browser gate skipped because local jtag/core IPC prerequisites were down
- prepush -> TS, ESLint, Rust compile, Rust tests passed; native Docker image step did not run because hook-generated tracked-file churn made the docker script refuse mixed source state before I cleaned the temp worktree