### PR TITLE
fix(ci): add main promotion GPU release gate

### DIFF
--- a/docs/CARL-CI-PLAN.md
+++ b/docs/CARL-CI-PLAN.md
@@ -192,16 +192,24 @@ Carl shouldn't have to read the script source to understand what broke.
 
 ## Per-platform validation
 
+`scripts/main-promotion-gate.sh` is the single entry point for canary→main
+release receipts. Canary PRs should keep using focused Rust/TS proof; promotion
+to `main` requires receipts from the machines that can actually prove each
+hardware path.
+
 | Platform | Validator | Notes |
 |---|---|---|
 | linux/amd64 | GHA runner (`ubuntu-latest`) | Always-on. Carl's dominant platform per HF data. |
-| linux/amd64 + GPU | bigmama-wsl box, eventually self-hosted runner | Real Carl path; covers vision/persona functionality |
-| darwin/arm64 | anvil mac (manual probe), eventually puppeteer-on-mac in CI | Dev's dominant platform |
-| windows + WSL2 | green-022a (manual probe), bigmama-wsl secondary | Carl's secondary platform |
+| linux/amd64 + CUDA | bigmama-wsl box, eventually self-hosted runner | Real Nvidia Carl path; run `CONTINUUM_RELEASE_PUSH_IMAGES=1 CONTINUUM_GATE_RUN_HEARTBEAT=1 scripts/main-promotion-gate.sh`. |
+| linux/amd64 + Vulkan | Linux AMD/Intel GPU host | Real Vulkan Carl path; run `CONTINUUM_RELEASE_PUSH_IMAGES=1 CONTINUUM_GATE_RUN_HEARTBEAT=1 scripts/main-promotion-gate.sh`. |
+| darwin/arm64 + Metal | anvil mac (manual probe), eventually puppeteer-on-mac in CI | Dev's dominant platform; run `scripts/main-promotion-gate.sh` for local receipt and add `CONTINUUM_RELEASE_PUSH_IMAGES=1` when publishing arm64 slices. |
+| windows + WSL2 + CUDA | green-022a (manual probe), bigmama-wsl secondary | Carl's secondary platform; WSL2 uses the same linux/amd64 CUDA receipt script. |
 | windows native (powershell) | green-022a (manual probe via install.ps1) | New platform — rely on green's dogfood |
 
-Each push to canary should have at least the linux/amd64 smoke green before
-promotion. The other tiers are progressively-tightening.
+Each push to canary should have focused local evidence. Canary→main promotion
+must collect the Mac/Metal, linux/amd64 CUDA, and linux/amd64 Vulkan receipts
+or link a typed issue explaining the missing host. Missing hardware is not a
+reason to weaken the runtime into CPU fallback.
 
 ## Success criteria
 

--- a/scripts/main-promotion-gate.sh
+++ b/scripts/main-promotion-gate.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# main-promotion-gate.sh — per-host release receipt for canary -> main.
+#
+# Canary iteration should stay fast. Main promotion is where we require the
+# full Carl/Docker/GPU matrix. Each capable machine runs this same script and
+# leaves a receipt under .continuum/release-gate/receipts/.
+#
+# Usage:
+#   scripts/main-promotion-gate.sh
+#   CONTINUUM_RELEASE_PUSH_IMAGES=1 scripts/main-promotion-gate.sh
+#
+# Important env:
+#   EXPECTED_SHA                  commit being promoted; defaults to HEAD
+#   CONTINUUM_IMAGE_TAG           image tag for heartbeat/install gates
+#   CONTINUUM_RELEASE_PUSH_IMAGES 1/true to build+push this host's slices
+#   CONTINUUM_GATE_RUN_HEARTBEAT  1/true to run scripts/test-heartbeat.sh
+#   CONTINUUM_GATE_RUN_INSTALL    1/true to run scripts/ci/install-and-run-gate.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+EXPECTED_SHA="${EXPECTED_SHA:-$(git rev-parse HEAD)}"
+SHORT_SHA="${EXPECTED_SHA:0:7}"
+IMAGE_TAG="${CONTINUUM_IMAGE_TAG:-$SHORT_SHA}"
+PUSH_IMAGES="${CONTINUUM_RELEASE_PUSH_IMAGES:-0}"
+RUN_HEARTBEAT="${CONTINUUM_GATE_RUN_HEARTBEAT:-0}"
+RUN_INSTALL="${CONTINUUM_GATE_RUN_INSTALL:-0}"
+RECEIPT_DIR="${CONTINUUM_GATE_RECEIPT_DIR:-$REPO_ROOT/.continuum/release-gate/receipts}"
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+HOSTNAME_VALUE="$(hostname 2>/dev/null || echo unknown-host)"
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+STATUS="pass"
+FAILURES=()
+NOTES=()
+COMMANDS=()
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+json_array() {
+  local first=1 item
+  printf '['
+  for item in "$@"; do
+    if [ "$first" -eq 0 ]; then
+      printf ','
+    fi
+    first=0
+    printf '"%s"' "$(json_escape "$item")"
+  done
+  printf ']'
+}
+
+note() {
+  NOTES+=("$1")
+  echo "  - $1"
+}
+
+fail_gate() {
+  STATUS="fail"
+  FAILURES+=("$1")
+  echo "  ✗ $1" >&2
+}
+
+run_gate_cmd() {
+  local label="$1"
+  shift
+  COMMANDS+=("$label: $*")
+  echo "→ $label"
+  if "$@"; then
+    echo "  ✓ $label"
+  else
+    fail_gate "$label"
+  fi
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    fail_gate "missing command: $1"
+  fi
+}
+
+is_true() {
+  case "$1" in
+    1|true|TRUE|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+GPU_CLASS="none"
+HOST_ROLE="unsupported"
+REQUIRED_RECEIPTS=(
+  "darwin-arm64-metal"
+  "linux-amd64-cuda"
+  "linux-amd64-vulkan"
+)
+
+if [ "$OS" = "Darwin" ] && [ "$ARCH" = "arm64" ]; then
+  HOST_ROLE="darwin-arm64-metal"
+  GPU_CLASS="metal"
+elif [ "$OS" = "Linux" ] && [ "$ARCH" = "x86_64" ]; then
+  if grep -qi microsoft /proc/version 2>/dev/null; then
+    HOST_ROLE="wsl2-linux-amd64"
+  else
+    HOST_ROLE="linux-amd64"
+  fi
+
+  if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
+    HOST_ROLE="$HOST_ROLE-cuda"
+    GPU_CLASS="cuda"
+  elif [ -e /dev/dri ]; then
+    HOST_ROLE="$HOST_ROLE-vulkan"
+    GPU_CLASS="vulkan"
+  else
+    HOST_ROLE="$HOST_ROLE-no-gpu"
+    GPU_CLASS="none"
+  fi
+elif [ "$OS" = "Linux" ] && { [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; }; then
+  HOST_ROLE="linux-arm64-core"
+  GPU_CLASS="native-arm64"
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  main-promotion-gate"
+echo "  host:       $HOSTNAME_VALUE"
+echo "  role:       $HOST_ROLE"
+echo "  os/arch:    $OS/$ARCH"
+echo "  gpu:        $GPU_CLASS"
+echo "  sha:        $EXPECTED_SHA"
+echo "  image tag:  $IMAGE_TAG"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+require_cmd git
+require_cmd bash
+
+if [ "$EXPECTED_SHA" != "$(git rev-parse HEAD)" ]; then
+  note "EXPECTED_SHA differs from checkout HEAD; build scripts will pin to EXPECTED_SHA where supported."
+fi
+
+case "$HOST_ROLE" in
+  darwin-arm64-metal)
+    require_cmd cargo
+    require_cmd docker
+    note "Mac receipt proves native Rust/Metal support and arm64 Docker slices; CUDA/Vulkan receipts must come from Linux/WSL2 GPU hosts."
+    ;;
+  *cuda)
+    require_cmd docker
+    require_cmd nvidia-smi
+    if ! docker info 2>/dev/null | grep -qi nvidia; then
+      fail_gate "docker NVIDIA runtime not visible"
+    fi
+    ;;
+  *vulkan)
+    require_cmd docker
+    if [ ! -e /dev/dri ]; then
+      fail_gate "/dev/dri missing for Vulkan GPU receipt"
+    fi
+    if command -v vulkaninfo >/dev/null 2>&1; then
+      if vulkaninfo --summary 2>/dev/null | grep -qi llvmpipe; then
+        fail_gate "vulkaninfo reports llvmpipe; hardware Vulkan receipt required"
+      fi
+    else
+      note "vulkaninfo not installed; Docker slice test must prove Vulkan device visibility."
+    fi
+    ;;
+  linux-arm64-core)
+    require_cmd docker
+    note "Linux arm64 receipt covers core/livekit arm64 only; not a CUDA/Vulkan substitute."
+    ;;
+  *)
+    fail_gate "unsupported or no-GPU host role for main promotion: $HOST_ROLE"
+    ;;
+esac
+
+if is_true "$PUSH_IMAGES"; then
+  run_gate_cmd "push native image slices" env EXPECTED_SHA="$EXPECTED_SHA" scripts/push-current-arch.sh
+else
+  note "image push skipped; set CONTINUUM_RELEASE_PUSH_IMAGES=1 to build+push this host's native slices."
+fi
+
+if is_true "$RUN_HEARTBEAT"; then
+  run_gate_cmd "heartbeat" scripts/test-heartbeat.sh "$IMAGE_TAG"
+else
+  note "heartbeat skipped; set CONTINUUM_GATE_RUN_HEARTBEAT=1 to run stack/persona heartbeat."
+fi
+
+if is_true "$RUN_INSTALL"; then
+  run_gate_cmd "Carl install gate" env CONTINUUM_IMAGE_TAG="$IMAGE_TAG" scripts/ci/install-and-run-gate.sh
+else
+  note "Carl install gate skipped; set CONTINUUM_GATE_RUN_INSTALL=1 to run install-and-run gate."
+fi
+
+mkdir -p "$RECEIPT_DIR"
+RECEIPT="$RECEIPT_DIR/${HOST_ROLE}-${HOSTNAME_VALUE}-${SHORT_SHA}-$(date -u +%Y%m%dT%H%M%SZ).json"
+ENDED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+REQUIRED_RECEIPTS_JSON="$(json_array "${REQUIRED_RECEIPTS[@]}")"
+if [ "${#COMMANDS[@]}" -eq 0 ]; then
+  COMMANDS_JSON="[]"
+else
+  COMMANDS_JSON="$(json_array "${COMMANDS[@]}")"
+fi
+if [ "${#NOTES[@]}" -eq 0 ]; then
+  NOTES_JSON="[]"
+else
+  NOTES_JSON="$(json_array "${NOTES[@]}")"
+fi
+if [ "${#FAILURES[@]}" -eq 0 ]; then
+  FAILURES_JSON="[]"
+else
+  FAILURES_JSON="$(json_array "${FAILURES[@]}")"
+fi
+
+cat >"$RECEIPT" <<EOF
+{
+  "schema": "continuum.main-promotion-gate.v1",
+  "status": "$(json_escape "$STATUS")",
+  "host": "$(json_escape "$HOSTNAME_VALUE")",
+  "role": "$(json_escape "$HOST_ROLE")",
+  "os": "$(json_escape "$OS")",
+  "arch": "$(json_escape "$ARCH")",
+  "gpu_class": "$(json_escape "$GPU_CLASS")",
+  "expected_sha": "$(json_escape "$EXPECTED_SHA")",
+  "image_tag": "$(json_escape "$IMAGE_TAG")",
+  "started_at": "$(json_escape "$STARTED_AT")",
+  "ended_at": "$(json_escape "$ENDED_AT")",
+  "required_receipts": $REQUIRED_RECEIPTS_JSON,
+  "commands": $COMMANDS_JSON,
+  "notes": $NOTES_JSON,
+  "failures": $FAILURES_JSON
+}
+EOF
+
+echo ""
+echo "Receipt: $RECEIPT"
+
+if [ "$STATUS" = "pass" ]; then
+  echo "✓ main-promotion-gate local receipt complete"
+  exit 0
+fi
+
+echo "✗ main-promotion-gate failed; see receipt failures" >&2
+exit 2

--- a/scripts/main-promotion-gate.sh
+++ b/scripts/main-promotion-gate.sh
@@ -7,6 +7,7 @@
 #
 # Usage:
 #   scripts/main-promotion-gate.sh
+#   scripts/main-promotion-gate.sh --check-receipts
 #   CONTINUUM_RELEASE_PUSH_IMAGES=1 scripts/main-promotion-gate.sh
 #
 # Important env:
@@ -22,6 +23,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
+MODE="${1:-run}"
 EXPECTED_SHA="${EXPECTED_SHA:-$(git rev-parse HEAD)}"
 SHORT_SHA="${EXPECTED_SHA:0:7}"
 IMAGE_TAG="${CONTINUUM_IMAGE_TAG:-$SHORT_SHA}"
@@ -91,6 +93,63 @@ is_true() {
   esac
 }
 
+receipt_value() {
+  local file="$1"
+  local key="$2"
+  sed -n "s/.*\"$key\": \"\\([^\"]*\\)\".*/\\1/p" "$file" | head -1
+}
+
+check_receipts() {
+  local missing=()
+  local role receipt_status
+  local matched
+
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  main-promotion-gate receipt check"
+  echo "  sha:      $EXPECTED_SHA"
+  echo "  receipts: $RECEIPT_DIR"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+  if [ ! -d "$RECEIPT_DIR" ]; then
+    echo "✗ receipt directory missing: $RECEIPT_DIR" >&2
+    exit 2
+  fi
+
+  for role in "${REQUIRED_RECEIPTS[@]}"; do
+    matched=0
+    while IFS= read -r receipt; do
+      [ -f "$receipt" ] || continue
+      if [ "$(receipt_value "$receipt" role)" = "$role" ] \
+        && [ "$(receipt_value "$receipt" expected_sha)" = "$EXPECTED_SHA" ]; then
+        matched=1
+        receipt_status="$(receipt_value "$receipt" status)"
+        if [ "$receipt_status" = "pass" ]; then
+          echo "  ✓ $role: $receipt"
+        else
+          echo "  ✗ $role receipt failed: $receipt" >&2
+          missing+=("$role failed")
+        fi
+        break
+      fi
+    done < <(find "$RECEIPT_DIR" -type f -name '*.json' 2>/dev/null | sort)
+
+    if [ "$matched" -eq 0 ]; then
+      echo "  ✗ missing receipt: $role" >&2
+      missing+=("$role missing")
+    fi
+  done
+
+  if [ "${#missing[@]}" -eq 0 ]; then
+    echo "✓ all required main-promotion receipts present for $EXPECTED_SHA"
+    exit 0
+  fi
+
+  echo "" >&2
+  echo "Missing or failed required receipts:" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  exit 2
+}
+
 GPU_CLASS="none"
 HOST_ROLE="unsupported"
 REQUIRED_RECEIPTS=(
@@ -99,14 +158,22 @@ REQUIRED_RECEIPTS=(
   "linux-amd64-vulkan"
 )
 
+case "$MODE" in
+  run) ;;
+  --check-receipts|check-receipts) check_receipts ;;
+  *)
+    echo "Usage: $0 [--check-receipts]" >&2
+    exit 1
+    ;;
+esac
+
 if [ "$OS" = "Darwin" ] && [ "$ARCH" = "arm64" ]; then
   HOST_ROLE="darwin-arm64-metal"
   GPU_CLASS="metal"
 elif [ "$OS" = "Linux" ] && [ "$ARCH" = "x86_64" ]; then
+  HOST_ROLE="linux-amd64"
   if grep -qi microsoft /proc/version 2>/dev/null; then
-    HOST_ROLE="wsl2-linux-amd64"
-  else
-    HOST_ROLE="linux-amd64"
+    note "WSL2 host detected; receipt still counts as linux/amd64 for the release matrix."
   fi
 
   if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then

--- a/scripts/main-promotion-gate.sh
+++ b/scripts/main-promotion-gate.sh
@@ -93,12 +93,6 @@ is_true() {
   esac
 }
 
-receipt_value() {
-  local file="$1"
-  local key="$2"
-  sed -n "s/.*\"$key\": \"\\([^\"]*\\)\".*/\\1/p" "$file" | head -1
-}
-
 check_receipts() {
   local missing=()
   local role receipt_status
@@ -114,15 +108,19 @@ check_receipts() {
     echo "✗ receipt directory missing: $RECEIPT_DIR" >&2
     exit 2
   fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "✗ jq is required for receipt aggregation; refusing brittle JSON parsing" >&2
+    exit 1
+  fi
 
   for role in "${REQUIRED_RECEIPTS[@]}"; do
     matched=0
-    while IFS= read -r receipt; do
+    while IFS= read -r -d '' receipt; do
       [ -f "$receipt" ] || continue
-      if [ "$(receipt_value "$receipt" role)" = "$role" ] \
-        && [ "$(receipt_value "$receipt" expected_sha)" = "$EXPECTED_SHA" ]; then
+      if jq -e --arg role "$role" --arg sha "$EXPECTED_SHA" \
+        '.role == $role and .expected_sha == $sha' "$receipt" >/dev/null 2>&1; then
         matched=1
-        receipt_status="$(receipt_value "$receipt" status)"
+        receipt_status="$(jq -r '.status // "missing"' "$receipt")"
         if [ "$receipt_status" = "pass" ]; then
           echo "  ✓ $role: $receipt"
         else
@@ -131,7 +129,7 @@ check_receipts() {
         fi
         break
       fi
-    done < <(find "$RECEIPT_DIR" -type f -name '*.json' 2>/dev/null | sort)
+    done < <(find "$RECEIPT_DIR" -type f -name '*.json' -print0 2>/dev/null | sort -z)
 
     if [ "$matched" -eq 0 ]; then
       echo "  ✗ missing receipt: $role" >&2

--- a/src/scripts/git-prepush.sh
+++ b/src/scripts/git-prepush.sh
@@ -207,9 +207,17 @@ echo "---------------------------------------------------------------"
 
 DOCKER_PUSH_START=$(date +%s)
 DOCKER_RELEVANT="$RUST_RELEVANT"
+DOCKER_PUSH_MODE="${CONTINUUM_PREPUSH_DOCKER:-manual}"
 
 if [ "$DOCKER_RELEVANT" -eq 0 ]; then
     echo "⏭️  No Rust/docker changes in this push — skipping native-arch build."
+elif [ "$DOCKER_PUSH_MODE" != "1" ] && [ "$DOCKER_PUSH_MODE" != "true" ]; then
+    echo "⏭️  Native-arch Docker publish skipped for pre-push."
+    echo "   Canary iteration is gated by local TS/Rust proof above."
+    echo "   Run explicitly for canary→main promotion:"
+    echo "     CONTINUUM_PREPUSH_DOCKER=1 scripts/git-prepush.sh"
+    echo "   Or run:"
+    echo "     scripts/push-current-arch.sh"
 elif [ ! -x "$REPO_ROOT/scripts/push-current-arch.sh" ]; then
     echo "⚠️  scripts/push-current-arch.sh not found or not executable — skipping."
     echo "   CI will still gate via verify-architectures, but this machine's native"

--- a/src/workers/start-workers.sh
+++ b/src/workers/start-workers.sh
@@ -196,13 +196,21 @@ fi
 
 # Build Rust workers — let cargo handle incremental compilation (it's smart enough)
 SCRIPT_DIR="$(dirname "$0")"
+FEATURES_SCRIPT="$PROJECT_DIR/scripts/shared/cargo-features.sh"
+
+if [ -f "$FEATURES_SCRIPT" ]; then
+  # shellcheck source=../scripts/shared/cargo-features.sh
+  source "$FEATURES_SCRIPT"
+else
+  CARGO_GPU_FEATURES=""
+fi
 
 # Skip build if --skip-build flag passed (caller already built)
 if [[ " $* " == *" --skip-build "* ]]; then
   echo -e "${GREEN}✅ Rust build skipped (--skip-build)${NC}"
 else
-  echo -e "${YELLOW}🔨 Building Rust workers (cargo incremental)...${NC}"
-  (cd "$SCRIPT_DIR" && cargo build --release --quiet)
+  echo -e "${YELLOW}🔨 Building Rust workers (cargo incremental) ${CARGO_GPU_FEATURES:-[cpu-only]}...${NC}"
+  (cd "$SCRIPT_DIR" && cargo build --release --quiet $CARGO_GPU_FEATURES)
   echo -e "${GREEN}✅ Rust build complete${NC}"
 fi
 


### PR DESCRIPTION
## Summary
- add scripts/main-promotion-gate.sh as the single canary→main per-host release receipt command
- document Mac/Metal, linux/amd64 CUDA, linux/amd64 Vulkan, and WSL2 receipt roles in docs/CARL-CI-PLAN.md
- keep native Docker publishing explicit for pre-push so canary iteration is not blocked by remote GPU host availability
- build local worker startup with the same detected Cargo GPU features used by prepush, fixing Mac Metal builds that otherwise compile without metal

## Validation
- bash -n scripts/main-promotion-gate.sh src/scripts/git-prepush.sh src/workers/start-workers.sh
- scripts/main-promotion-gate.sh
- jq . .continuum/release-gate/receipts/darwin-arm64-metal-Mac-665.lan-4d628e1-20260518T180303Z.json >/dev/null
- precommit: TypeScript compilation passed; browser tests skipped because ./jtag ping/core IPC socket were not reachable
- pre-push: TypeScript clean; ESLint baseline ratchet held; Rust compile clean with --features metal,accelerate; Rust tests passed with --features metal,accelerate; native Docker publish explicitly skipped by new canary policy

## Not tested
- linux/amd64 CUDA Carl receipt: requires BigMama/WSL2/Nvidia host
- linux/amd64 Vulkan Carl receipt: requires Linux AMD/Intel/Vulkan host
- full Carl install gate: use CONTINUUM_GATE_RUN_INSTALL=1 scripts/main-promotion-gate.sh on the target host
