### PR TITLE
feat(cognition,#1385): generate_response PR-3 — TS shim + delete dead TS (PR-4 folded)

### DIFF
--- a/src/system/ai/server/AIDecisionService.ts
+++ b/src/system/ai/server/AIDecisionService.ts
@@ -13,8 +13,6 @@
 
 import type { UUID } from '../../core/types/CrossPlatformUUID';
 import type { ChatMessageEntity } from '../../data/entities/ChatMessageEntity';
-import { AIProviderDaemon } from '../../../daemons/ai-provider-daemon/shared/AIProviderDaemon';
-import type { TextGenerationRequest, TextGenerationResponse } from '../../../daemons/ai-provider-daemon/shared/AIProviderTypesV2';
 import type { RAGContext } from '../../rag/shared/RAGTypes';
 import { AIDecisionLogger } from './AIDecisionLogger';
 import { InferenceCoordinator } from '../../coordination/server/InferenceCoordinator';
@@ -23,6 +21,7 @@ import { RustCoreIPCClient } from '../../../workers/continuum-core/bindings/Rust
 import type {
   AIDecisionContext as RustAIDecisionContext,
   RedundancyCheckRequest,
+  GenerateResponseRequest,
 } from '../../../shared/generated';
 
 /**
@@ -236,9 +235,7 @@ export class AIDecisionService {
       messageId?: string;     // For slot tracking
     } = {}
   ): Promise<AIGenerationResult> {
-    const startTime = Date.now();
     const model = options.model ?? LOCAL_MODELS.DEFAULT;
-    const timeoutMs = options.timeoutMs ?? 180000;  // local Qwen inference can be slow under load
     const provider = 'local';
 
     // Request inference slot to prevent thundering herd
@@ -256,45 +253,25 @@ export class AIDecisionService {
     }
 
     try {
-      // Build message array from RAG context
-      const messages = this.buildResponseMessages(context);
-
-      const request: TextGenerationRequest = {
-        messages,
+      const client = await RustCoreIPCClient.getInstanceAsync();
+      const request: GenerateResponseRequest = {
+        context: context as unknown as RustAIDecisionContext,
         model,
-        temperature: options.temperature ?? 0.7,
-        maxTokens: options.maxTokens ?? 150,
-        // 'local' is the routing sentinel for the best available local
-        // Qwen/llama.cpp runtime. Engine selection stays behind the Rust
-        // registry/admission layer.
-        provider: 'local'
+        temperature: options.temperature,
+        maxTokens: options.maxTokens,
+        timeoutMs: options.timeoutMs
       };
-
-      // Wrap with timeout
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error(`AI generation timeout after ${timeoutMs}ms`)), timeoutMs);
-      });
-
-      const response: TextGenerationResponse = await Promise.race([
-        AIProviderDaemon.generateText(request),
-        timeoutPromise
-      ]);
+      const result = await client.cognitionGenerateResponse(request);
 
       // Release slot after successful generation
       InferenceCoordinator.releaseSlot(context.personaId, provider);
 
-      const responseTime = Date.now() - startTime;
-
       return {
-        text: response.text.trim(),
-        model,
-        responseTime,
-        timestamp: Date.now(),
-        tokensUsed: response.usage ? {
-          input: response.usage.inputTokens,
-          output: response.usage.outputTokens,
-          total: response.usage.totalTokens
-        } : undefined
+        text: result.text,
+        model: result.model,
+        responseTime: result.responseTimeMs,
+        timestamp: result.timestamp,
+        tokensUsed: result.tokensUsed
       };
 
     } catch (error) {
@@ -345,109 +322,4 @@ export class AIDecisionService {
     );
   }
 
-  /**
-   * Build response messages from RAG context
-   */
-  private static buildResponseMessages(context: AIDecisionContext): Array<{ role: 'system' | 'user' | 'assistant'; content: string }> {
-    const messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = [];
-
-    // System prompt with identity
-    if (context.systemPrompt ?? context.ragContext.identity?.systemPrompt) {
-      messages.push({
-        role: 'system',
-        content: context.systemPrompt ?? context.ragContext.identity!.systemPrompt
-      });
-    }
-
-    // Conversation history with timestamps
-    const conversationHistory = context.ragContext.conversationHistory ?? [];
-    let lastTimestamp: number | undefined;
-
-    for (const msg of conversationHistory) {
-      let timePrefix = '';
-      if (msg.timestamp) {
-        const date = new Date(msg.timestamp);
-        const hours = date.getHours().toString().padStart(2, '0');
-        const minutes = date.getMinutes().toString().padStart(2, '0');
-        timePrefix = `[${hours}:${minutes}] `;
-
-        // Add time gap markers
-        if (lastTimestamp) {
-          const gapMinutes = (msg.timestamp - lastTimestamp) / (1000 * 60);
-          if (gapMinutes > 60) {
-            const gapHours = Math.floor(gapMinutes / 60);
-            messages.push({
-              role: 'system',
-              content: `⏱️ ${gapHours} hour${gapHours > 1 ? 's' : ''} passed - conversation resumed`
-            });
-          }
-        }
-
-        lastTimestamp = msg.timestamp;
-      }
-
-      // Format content with timestamp and name
-      const formattedContent = msg.name
-        ? `${timePrefix}${msg.name}: ${msg.content}`
-        : `${timePrefix}${msg.content}`;
-
-      messages.push({
-        role: msg.role as 'user' | 'assistant',
-        content: formattedContent
-      });
-    }
-
-    // Identity reminder at end
-    const now = new Date();
-    const currentTime = `${now.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })} ${now.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })}`;
-
-    const members = context.ragContext.identity?.systemPrompt.match(/Current room members: ([^\n]+)/)?.[1] ?? 'unknown members';
-
-    messages.push({
-      role: 'system',
-      content: `IDENTITY REMINDER: You are ${context.personaName}. Respond naturally with JUST your message - NO name prefix, NO "A:" or "H:" labels, NO fake conversations. The room has ONLY these people: ${members}.
-
-CURRENT TIME: ${currentTime}
-
-CRITICAL TOPIC DETECTION PROTOCOL:
-
-Step 1: Check for EXPLICIT TOPIC MARKERS in the most recent message
-- "New topic:", "Different question:", "Changing subjects:", "Unrelated, but..."
-- If present: STOP. Ignore ALL previous context. This is a NEW conversation.
-
-Step 2: Extract HARD CONSTRAINTS from the most recent message
-- Look for: "NOT", "DON'T", "WITHOUT", "NEVER", "AVOID", "NO"
-- Example: "NOT triggering the app to foreground" = YOUR SOLUTION MUST NOT DO THIS
-- Example: "WITHOUT user interaction" = YOUR SOLUTION MUST BE AUTOMATIC
-- Your answer MUST respect these constraints or you're wrong.
-
-Step 3: Compare SUBJECT of most recent message to previous 2-3 messages
-- Previous: "Worker Threads" → Recent: "Webview authentication" = DIFFERENT SUBJECTS
-- Previous: "TypeScript code" → Recent: "What's 2+2?" = TEST QUESTION
-- Previous: "Worker pools" → Recent: "Should I use 5 or 10 workers?" = SAME SUBJECT
-
-Step 4: Determine response strategy
-IF EXPLICIT TOPIC MARKER or COMPLETELY DIFFERENT SUBJECT:
-- Respond ONLY to the new topic
-- Ignore old messages (they're from a previous discussion)
-- Focus 100% on the most recent message
-- Address the constraints explicitly
-
-IF SAME SUBJECT (continued conversation):
-- Use full conversation context
-- Build on previous responses
-- Still check for NEW constraints in the recent message
-- Avoid redundancy
-
-CRITICAL READING COMPREHENSION:
-- Read the ENTIRE most recent message carefully
-- Don't skim - every word matters
-- Constraints are REQUIREMENTS, not suggestions
-- If the user says "NOT X", suggesting X is a failure
-
-Time gaps > 1 hour usually indicate topic changes, but IMMEDIATE semantic shifts (consecutive messages about different subjects) are also topic changes.`
-    });
-
-    return messages;
-  }
 }

--- a/src/workers/continuum-core/bindings/modules/cognition.ts
+++ b/src/workers/continuum-core/bindings/modules/cognition.ts
@@ -33,6 +33,8 @@ import type {
 	AIGatingDecision,
 	RedundancyCheckRequest,
 	RedundancyDecision,
+	GenerateResponseRequest,
+	GenerateResponseResult,
 } from '../../../../shared/generated';
 import type { PersonaResponse } from '../../../../shared/generated/cognition/PersonaResponse';
 import type { RecipeTurnBatchPlan } from '../../../../shared/generated/cognition/RecipeTurnBatchPlan';
@@ -128,6 +130,7 @@ export interface CognitionMixin {
 		temperature?: number;
 	}): Promise<AIGatingDecision>;
 	cognitionCheckRedundancy(params: RedundancyCheckRequest): Promise<RedundancyDecision>;
+	cognitionGenerateResponse(params: GenerateResponseRequest): Promise<GenerateResponseResult>;
 
 	/**
 	 * Run the per-persona admission gate over a single InboxMessage.
@@ -894,6 +897,30 @@ export function CognitionMixin<T extends new (...args: any[]) => RustCoreIPCClie
 			}
 
 			return response.result as RedundancyDecision;
+		}
+
+		/**
+		 * Rust-owned response generation. TypeScript keeps platform slot
+		 * coordination and logging; Rust owns the prompt assembly (system +
+		 * history with hour-gap markers + identity-reminder template),
+		 * provider call (existing local Qwen router), `tokio::time::timeout`
+		 * (replaces TS Promise.race), and typed result with timing + tokens.
+		 */
+		async cognitionGenerateResponse(params: GenerateResponseRequest): Promise<GenerateResponseResult> {
+			const response = await this.request({
+				command: 'cognition/generate-response',
+				context: params.context,
+				model: params.model,
+				temperature: params.temperature,
+				maxTokens: params.maxTokens,
+				timeoutMs: params.timeoutMs,
+			});
+
+			if (!response.success) {
+				throw new Error(response.error ?? 'Failed to generate response');
+			}
+
+			return response.result as GenerateResponseResult;
 		}
 
 		/**


### PR DESCRIPTION
## Summary

Stacks on **PR-2 #1390** (MERGED). `AIDecisionService.generateResponse` now delegates to `RustCoreIPCClient.cognitionGenerateResponse`; ~110 LOC of TS prompt assembly + Promise.race timeout + token decoding deleted. Mirrors codex's check_redundancy PR-3 #1383 shape (PR-4 dead-code delete folded in).

## What this ships

- **`AIDecisionService.generateResponse`** now a thin shim:
  - `InferenceCoordinator.requestSlot` (TS owns slot coordination — platform concern)
  - `client.cognitionGenerateResponse(request)` — single IPC call
  - `InferenceCoordinator.releaseSlot`
  - logError + rethrow on failure (no fail-open silent default)
- New TS binding method **`cognitionGenerateResponse(GenerateResponseRequest) -> Promise<GenerateResponseResult>`** in the cognition mixin
- `GenerateResponseRequest` + `GenerateResponseResult` re-exported from the generated barrel (already present from PR-1)

## Dead TS deleted (PR-4 folded in)

- `private static buildResponseMessages(context)` helper (~115 LOC): system-prompt injection, conversation history with `[HH:MM]` prefix, hour-gap markers, ~50-line identity-reminder template — all moved to Rust in PR-1.
- `import { AIProviderDaemon }` — no longer referenced after both `checkRedundancy` (#1383) + `generateResponse` migrations.
- `import type { TextGenerationRequest, TextGenerationResponse }` — ditto, only used by deleted helper.
- Inline timeout Promise.race code — replaced by Rust-side `tokio::time::timeout` in PR-2.

After this PR, `AIDecisionService.ts` contains only:
- `evaluateGating` (already shim to `cognition/should-respond`)
- `checkRedundancy` (already shim to `cognition/check-redundancy`)
- `generateResponse` (now shim to `cognition/generate-response`)
- `InferenceCoordinator` slot management (TS-owned platform concern)
- Logging helpers (TS-owned platform concern)

## Discipline

- No fail-open path — errors throw, caller decides (consistent with codex's check_redundancy shim pattern).
- Cast `context as unknown as RustAIDecisionContext` matches the pattern in `cognitionShouldRespond` + `cognitionCheckRedundancy`.
- Slot coordination explicitly stays TS — that's the seam codex drew with check_redundancy, preserved here.
- Token shape preserved: `result.tokensUsed` is `TokenUsage | None`; TS just passes through (Rust already mapped from provider's `UsageMetrics`, returning `None` for zero-token providers).

## Stack progress

- #1385 PR-1 (pure types + prompt builder + identity-reminder template): **#1388 MERGED**
- #1385 PR-2 (async evaluate_response + IPC handler): **#1390 MERGED**
- #1385 PR-3 (TS shim + dead-TS delete): **this PR**
- #1385 PR-4 (dead-TS delete): **folded into this PR**

Diff: **+40 / -141** (2 files).

## Refs

- #1385 sub-card
- #1388 PR-1 (MERGED)
- #1390 PR-2 (MERGED)
- #1383 codex's check_redundancy PR-3 — same shape, folded-PR-4 pattern
- #1248 umbrella

## Test plan

- [x] `npm run build:ts` — TS compilation clean
- [x] ESLint baseline held at 5435
- [x] Pre-push hook passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)