### PR TITLE
feat(inference): inference-llm PR-5 — Runtime registration

### DIFF
--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -917,6 +917,25 @@ pub fn start_server(
     // of duplicating the RAM formula. See issue #887.
     runtime.register(Arc::new(InferenceModule::new()));
 
+    // Phase 5: InferenceLlmModule (MODULE-CATALOG §II `inference-llm`)
+    // — the substrate's local-LLM generation surface. Subscribes to
+    // inference/llm/request commands, returns InferenceComplete +
+    // FirstTokenEmitted bundles. Stub-backed in PR-2; adapter-routed
+    // in PR-4 (#1395) when constructed via with_adapter. PR-5 (this
+    // registration) wires the module into the runtime so it's
+    // callable from the cognition path — no Runtime adapter wiring
+    // yet (caller construction option lands when persona-cognition
+    // composes via with_bus_and_adapter).
+    //
+    // Shipped via the .new() constructor (bus-less, stub-backed)
+    // so this PR doesn't bind us to a specific LlamaCppAdapter
+    // initialization story; downstream PRs swap construction when
+    // the LlamaCppAdapter init lifecycle is integrated with the
+    // Runtime startup phase.
+    runtime.register(Arc::new(
+        crate::inference::llm_module_service::InferenceLlmModule::new(),
+    ));
+
     // Shared state for per-persona cognition (unified: engine + inbox + rate limiter + sleep + adapters + genome)
     let rag_engine = Arc::new(RagEngine::new());
     let cognition_state =

--- a/src/workers/continuum-core/src/runtime/runtime.rs
+++ b/src/workers/continuum-core/src/runtime/runtime.rs
@@ -41,6 +41,7 @@ pub const EXPECTED_MODULES: &[&str] = &[
     "avatar",            // Avatar snapshots: Bevy 3D renders → PNG
     "dataset",           // Dataset import/management for Academy training
     "persona_allocator", // Hardware-aware persona allocation decisions
+    "inference-llm",     // Phase 5: local LLM generation (MODULE-CATALOG §II)
 ];
 
 pub struct Runtime {


### PR DESCRIPTION
## Summary

PR-5 of **inference-llm**. Wires `InferenceLlmModule` into the Runtime so it's callable from the cognition path via `inference/llm/request` commands.

**Pure Rust, zero TS, 20-line diff.**

## What lands

- Add `"inference-llm"` to `EXPECTED_MODULES` in `runtime/runtime.rs`
- `runtime.register(Arc::new(InferenceLlmModule::new()))` in `ipc/mod.rs` alongside the existing `InferenceModule` registration

## Design choices

- **Constructed via `.new()`** (bus-less, stub-backed) rather than `.with_bus_and_adapter()`. Reason: `with_bus_and_adapter` requires an `AIProviderAdapter` Arc, which would couple PR-5's runtime registration to a specific `LlamaCppAdapter` init lifecycle. The substrate's `LlamaCppAdapter` is owned by `AIProviderModule`'s adapter registry with its own initialization phase; threading the adapter Arc here would either duplicate the registration or create an init-ordering dependency this slice shouldn't introduce.
- **The stub-backed registration is still useful**: it exposes the `inference/llm/request` command surface to the cognition path so downstream PRs (turn-execute chaining `drain-turn-frame` → `response_prompt` → `inference/llm/request`) can wire against the real command name. Bus + adapter integration is a follow-up PR that updates the construction call here.

## Test plan

- [x] `cargo build --features metal,accelerate --lib` clean
- [x] EXPECTED_MODULES enforcement validates at boot — if the registration is missing the runtime fails with "missing inference-llm" error
- [x] Pre-push gate clean
- [x] No new test fixtures needed — the module's existing 44/44 tests cover the trait-impl correctness; this PR just plumbs construction into runtime startup

## Stack

- #1387 — inference-llm PR-1: typed event surface
- #1391 — inference-llm PR-2: ServiceModule impl (stub-backed)
- #1392 — inference-llm PR-3a: bus keys + publishing helpers
- #1393 — inference-llm PR-3b: auto-publish wiring
- #1395 — inference-llm PR-4: adapter integration (translation + new constructors)
- **This PR — inference-llm PR-5**: Runtime registration
- **FOLLOW-UP** — adapter Arc wiring when `LlamaCppAdapter` init phase is integrated with Runtime startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)