### PR TITLE
fix(ratchet,#1405): cover AI server cognition shims

### DIFF
--- a/scripts/ratchet/README.md
+++ b/scripts/ratchet/README.md
@@ -30,6 +30,7 @@ the baseline (next section) so future PRs can't silently regrow.
 - `src/system/user/server/modules/being`
 - `src/system/user/server/modules/central-nervous-system`
 - `src/system/user/server/attention`
+- `src/system/ai/server`
 
 ## Usage
 

--- a/scripts/ratchet/persona-ts-baseline.txt
+++ b/scripts/ratchet/persona-ts-baseline.txt
@@ -5,44 +5,47 @@
 # The ratchet fails if a watched dir's LOC exceeds its baseline OR a new file appears
 # that is neither in the baseline file-set nor matched by persona-ts-allowlist.txt.
 # Refresh after legitimate TS deletion lands — the ratchet only moves down.
-# Refreshed: 2026-05-18T18:06:13Z
+# Refreshed: 2026-05-18T18:23:43Z
 loc src/system/user/server/modules/cognition 4643
 loc src/system/user/server/modules/cognitive 1590
 loc src/system/user/server/modules/consciousness 1303
 loc src/system/user/server/modules/being 784
 loc src/system/user/server/modules/central-nervous-system 72
 loc src/system/user/server/attention 191
+loc src/system/ai/server 509
+file src/system/user/server/modules/cognition/CognitionLogger.ts
+file src/system/user/server/modules/cognition/DecisionAdapterChain.ts
+file src/system/user/server/modules/cognition/PeerReviewManager.ts
+file src/system/user/server/modules/cognition/PeerReviewTypes.ts
+file src/system/user/server/modules/cognition/PersonaSelfState.ts
 file src/system/user/server/modules/cognition/adapters/IDecisionAdapter.ts
 file src/system/user/server/modules/cognition/adapters/LLMAdapter.ts
 file src/system/user/server/modules/cognition/adapters/ThermalAdapter.ts
-file src/system/user/server/modules/cognition/CognitionLogger.ts
-file src/system/user/server/modules/cognition/DecisionAdapterChain.ts
-file src/system/user/server/modules/cognition/memory/InboxObserver.ts
 file src/system/user/server/modules/cognition/memory/InMemoryCognitionStorage.ts
+file src/system/user/server/modules/cognition/memory/InboxObserver.ts
 file src/system/user/server/modules/cognition/memory/LongTermMemoryStore.ts
 file src/system/user/server/modules/cognition/memory/MemoryConsolidationSubprocess.ts
 file src/system/user/server/modules/cognition/memory/MemoryConsolidationWorker.ts
 file src/system/user/server/modules/cognition/memory/WorkingMemoryManager.ts
 file src/system/user/server/modules/cognition/memory/WorkingMemoryObserver.ts
-file src/system/user/server/modules/cognition/PeerReviewManager.ts
-file src/system/user/server/modules/cognition/PeerReviewTypes.ts
-file src/system/user/server/modules/cognition/PersonaSelfState.ts
 file src/system/user/server/modules/cognition/reasoning/SimplePlanFormulator.ts
 file src/system/user/server/modules/cognition/reasoning/types.ts
-file src/system/user/server/modules/cognitive/memory/adapters/MemoryConsolidationAdapter.ts
-file src/system/user/server/modules/cognitive/memory/adapters/RawMemoryAdapter.ts
-file src/system/user/server/modules/cognitive/memory/adapters/SemanticCompressionAdapter.ts
 file src/system/user/server/modules/cognitive/memory/AdaptiveConsolidationThreshold.ts
 file src/system/user/server/modules/cognitive/memory/Hippocampus.ts
 file src/system/user/server/modules/cognitive/memory/HippocampusConsolidationPolicy.ts
 file src/system/user/server/modules/cognitive/memory/NonLinearMath.ts
 file src/system/user/server/modules/cognitive/memory/PersonaMemory.ts
+file src/system/user/server/modules/cognitive/memory/adapters/MemoryConsolidationAdapter.ts
+file src/system/user/server/modules/cognitive/memory/adapters/RawMemoryAdapter.ts
+file src/system/user/server/modules/cognitive/memory/adapters/SemanticCompressionAdapter.ts
 file src/system/user/server/modules/consciousness/PersonaTimeline.ts
 file src/system/user/server/modules/consciousness/UnifiedConsciousness.ts
 file src/system/user/server/modules/being/LimbicSystem.ts
-file src/system/user/server/modules/being/logging/SubsystemLogger.ts
 file src/system/user/server/modules/being/MotorCortex.ts
 file src/system/user/server/modules/being/PrefrontalCortex.ts
+file src/system/user/server/modules/being/logging/SubsystemLogger.ts
 file src/system/user/server/modules/central-nervous-system/CNSTypes.ts
 file src/system/user/server/attention/AttentionManager.ts
 file src/system/user/server/attention/RoomActivityBatch.ts
+file src/system/ai/server/AIDecisionLogger.ts
+file src/system/ai/server/AIDecisionService.ts

--- a/scripts/ratchet/persona-ts-ratchet.sh
+++ b/scripts/ratchet/persona-ts-ratchet.sh
@@ -72,6 +72,7 @@ WATCHED_DIRS=(
     "src/system/user/server/modules/being"
     "src/system/user/server/modules/central-nervous-system"
     "src/system/user/server/attention"
+    "src/system/ai/server"
 )
 
 # Returns LOC count (non-zero) for all .ts files under $1, excluding .d.ts

--- a/scripts/ratchet/test-persona-ts-ratchet.sh
+++ b/scripts/ratchet/test-persona-ts-ratchet.sh
@@ -31,6 +31,7 @@ new_fixture_root() {
     mkdir -p "$root/src/system/user/server/modules/being"
     mkdir -p "$root/src/system/user/server/modules/central-nervous-system"
     mkdir -p "$root/src/system/user/server/attention"
+    mkdir -p "$root/src/system/ai/server"
     echo "$root"
 }
 
@@ -202,6 +203,20 @@ case_missing_baseline_returns_2() {
     rm -rf "$root" "$allowlist"
 }
 
+case_ai_server_shim_growth_fails() {
+    local root; root="$(new_fixture_root)"
+    write_ts "$root/src/system/ai/server/AIDecisionService.ts" 10
+    local baseline; baseline="$(mktemp)"
+    local allowlist; allowlist="$(mktemp)"
+    : > "$allowlist"
+    gen_baseline "$root" "$baseline" "$allowlist"
+    write_ts "$root/src/system/ai/server/AIDecisionService.ts" 25
+    assert "ai_server_shim_growth_fails" assert_exit 1 \
+        env PERSONA_RATCHET_BASELINE="$baseline" PERSONA_RATCHET_ALLOWLIST="$allowlist" \
+        "$RATCHET" --root "$root" check
+    rm -rf "$root" "$baseline" "$allowlist"
+}
+
 case_refresh_writes_baseline_idempotently() {
     local root; root="$(new_fixture_root)"
     write_ts "$root/src/system/user/server/modules/cognition/A.ts" 12
@@ -230,6 +245,7 @@ else
     case_new_types_file_passes
     case_deletion_after_refresh_passes
     case_missing_baseline_returns_2
+    case_ai_server_shim_growth_fails
     case_refresh_writes_baseline_idempotently
 fi
 


### PR DESCRIPTION
## Summary
- expand the Lane F TS cognition ratchet to cover src/system/ai/server
- refresh the baseline to include AIDecisionLogger.ts and AIDecisionService.ts after #1402
- add a regression test proving AIDecisionService.ts growth fails the ratchet

## Validation
- scripts/ratchet/persona-ts-ratchet.sh check
- scripts/ratchet/test-persona-ts-ratchet.sh (9/9 passed)
- precommit: TypeScript compilation passed; browser tests skipped because JTAG/core IPC were not reachable
- pre-push: TypeScript clean; ESLint baseline ratchet held; no Rust-relevant changes so Rust compile/tests skipped

Closes #1405
