### PR TITLE
refactor(cognition): drop TS slot coord from generateResponse (Rust admits now)

### DIFF
--- a/src/system/ai/server/AIDecisionService.ts
+++ b/src/system/ai/server/AIDecisionService.ts
@@ -16,7 +16,6 @@ import type { ChatMessageEntity } from '../../data/entities/ChatMessageEntity';
 import type { RAGContext } from '../../rag/shared/RAGTypes';
 import { AIDecisionLogger } from './AIDecisionLogger';
 import { InferenceCoordinator } from '../../coordination/server/InferenceCoordinator';
-import { LOCAL_MODELS } from '../../shared/Constants';
 import { RustCoreIPCClient } from '../../../workers/continuum-core/bindings/RustCoreIPC';
 import type {
   AIDecisionContext as RustAIDecisionContext,
@@ -219,10 +218,13 @@ export class AIDecisionService {
   }
 
   /**
-   * Generate AI response text
+   * Generate AI response text.
    *
-   * COORDINATION: Requests inference slot before calling AI to prevent flooding
-   * the serial gRPC server with simultaneous requests from all personas.
+   * Rust owns admission for this path via `ResourceAdmissionGate` (added
+   * in commit a89c8ab47 `admit generate-response through Rust resource
+   * gate`). Per directive: hosts should not coordinate slots outside
+   * Rust. This shim is the IPC seam plus error logging only — no
+   * TS-side rate limiting.
    */
   static async generateResponse(
     context: AIDecisionContext,
@@ -231,40 +233,18 @@ export class AIDecisionService {
       temperature?: number;
       maxTokens?: number;
       timeoutMs?: number;
-      isMentioned?: boolean;  // @mentioned personas bypass slot limits
-      messageId?: string;     // For slot tracking
     } = {}
   ): Promise<AIGenerationResult> {
-    const model = options.model ?? LOCAL_MODELS.DEFAULT;
-    const provider = 'local';
-
-    // Request inference slot to prevent thundering herd
-    const messageId = options.messageId ?? context.triggerMessage?.id ?? 'generate-' + Date.now();
-    const slotGranted = await InferenceCoordinator.requestSlot(
-      context.personaId,
-      messageId,
-      provider,
-      { isMentioned: options.isMentioned }
-    );
-
-    if (!slotGranted) {
-      // Slot denied - throw error to let caller handle
-      throw new Error('Inference slot denied (coordinator rate limiting)');
-    }
-
     try {
       const client = await RustCoreIPCClient.getInstanceAsync();
       const request: GenerateResponseRequest = {
         context: context as unknown as RustAIDecisionContext,
-        model,
+        model: options.model,
         temperature: options.temperature,
         maxTokens: options.maxTokens,
         timeoutMs: options.timeoutMs
       };
       const result = await client.cognitionGenerateResponse(request);
-
-      // Release slot after successful generation
-      InferenceCoordinator.releaseSlot(context.personaId, provider);
 
       return {
         text: result.text,
@@ -275,9 +255,6 @@ export class AIDecisionService {
       };
 
     } catch (error) {
-      // Release slot on error
-      InferenceCoordinator.releaseSlot(context.personaId, provider);
-
       const errorMessage = error instanceof Error ? error.message : String(error);
       AIDecisionLogger.logError(context.personaName, 'Response generation', errorMessage);
       throw error;


### PR DESCRIPTION
## Summary

Follow-up to **#1402**. Joel's commit **a89c8ab47** (admit generate-response through Rust resource gate) added `ResourceAdmissionGate` inside `cognition/generate_response.rs::evaluate_response`. The TS-side `InferenceCoordinator.requestSlot`/`releaseSlot` calls in `AIDecisionService.generateResponse` were now redundant — double-coordinating the same path.

Per directive: **hosts should not coordinate slots outside Rust**. This PR removes them.

## What changes

- `AIDecisionService.generateResponse`:
  - Drop `InferenceCoordinator.requestSlot` / `releaseSlot` (both success + error paths)
  - Drop `messageId` / `isMentioned` options (slot-coord-specific — unused without slot coord)
  - Drop messageId derivation + slot-denied fallback throw
  - Drop `LOCAL_MODELS.DEFAULT` fallback (Rust `evaluate_response` carries its own `DEFAULT_GENERATE_MODEL` constant; passing `undefined` lets Rust apply its default — single source of truth)
- Drop `LOCAL_MODELS` import (no longer referenced)
- `InferenceCoordinator` import **kept** (still used by `evaluateGating` + `checkRedundancy` — those still slot-coord because Rust admission hasn't been extended to those paths yet)

## After this PR

`generateResponse` is a **25-LOC try/catch around a single IPC call** — the thinnest possible shim. The slot leak risk codex flagged on #1402 becomes structurally impossible (no slots → no leaks).

## Diff

**+7 / -30** in 1 file.

## Verification

- [x] `npm run build:ts` — clean
- [x] ESLint baseline held at 5435 (no new errors)
- [x] `scripts/ratchet/persona-ts-ratchet.sh check` — passes (Lane F ratchet now watches `src/system/ai/server` after #1406; deletion is consistent with baseline, no refresh needed)
- [x] Grep verified: zero TS callers of `AIDecisionService.generateResponse` pass `isMentioned` or `messageId`
- [ ] CI green

## Refs

- #1402 — PR-3 of the generate_response oxidizer stack (MERGED)
- a89c8ab47 — Joel's commit adding Rust `ResourceAdmissionGate`
- #1385 — completed oxidizer sub-card (closed)
- #1406 — Lane F ratchet expansion to `src/system/ai/server` (MERGED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)