### PR TITLE
fix(cognition): max_concurrency: usize::MAX panics tokio Semaphore at registration

### DIFF
--- a/src/workers/continuum-core/src/modules/cognition.rs
+++ b/src/workers/continuum-core/src/modules/cognition.rs
@@ -152,7 +152,15 @@ impl ServiceModule for CognitionModule {
             // PressureBroker singleton (#1299) make event fanout the
             // intended invariant. Inference is still gated downstream by
             // ai_provider::max_concurrency. No hardcoded fixed cap here.
-            max_concurrency: usize::MAX,
+            //
+            // Use 0 ("no semaphore = unbounded"), NOT usize::MAX. The
+            // runtime's `register()` only creates a Semaphore when
+            // `max_concurrency > 0`; setting usize::MAX makes it call
+            // `Semaphore::new(usize::MAX)`, which exceeds tokio's
+            // MAX_PERMITS (`usize::MAX >> 3`) and panics at registration
+            // ("a semaphore may not have more than MAX_PERMITS permits").
+            // 0 expresses "no cap" without instantiating a semaphore.
+            max_concurrency: 0,
             tick_interval: None,
         }
     }
@@ -1916,6 +1924,53 @@ mod inline_admission_tests {
             }
             other => panic!("expected Decided, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod registration_safety_tests {
+    //! Regression: `runtime::Runtime::register` calls
+    //! `Semaphore::new(config.max_concurrency)` whenever
+    //! `max_concurrency > 0`. tokio's MAX_PERMITS is `usize::MAX >> 3`
+    //! (~2^61), so a `max_concurrency: usize::MAX` config panics at
+    //! registration. CognitionModule shipped with `usize::MAX` as a
+    //! mistaken way to spell "no cap" (PR #1306). The fix is to use
+    //! `0` instead, which the runtime treats as "do not create a
+    //! semaphore" (truly unbounded).
+    //!
+    //! This test pins the fix in place: any future change that
+    //! reintroduces `usize::MAX` (or any other value above
+    //! MAX_PERMITS) blows up here before it reaches production.
+    use super::*;
+    use crate::rag::RagEngine;
+    use crate::runtime::runtime::Runtime;
+    use std::sync::Arc;
+
+    #[test]
+    fn cognition_module_registers_without_semaphore_panic() {
+        // If max_concurrency is ever raised above tokio's
+        // MAX_PERMITS this `register()` call panics. The test then
+        // fails with the original "may not have more than
+        // MAX_PERMITS" message, which is the easiest possible
+        // breadcrumb back to this regression.
+        let runtime = Runtime::new();
+        let rag_engine = Arc::new(RagEngine::new());
+        let state = Arc::new(CognitionState::new(rag_engine));
+        let module = Arc::new(CognitionModule::new(state));
+        runtime.register(module);
+
+        // No assertion needed — surviving registration IS the
+        // assertion. Sanity-touch config to make the dependency
+        // explicit for future readers.
+        let cfg = CognitionModule::new(Arc::new(CognitionState::new(Arc::new(
+            RagEngine::new(),
+        ))))
+        .config();
+        assert_eq!(
+            cfg.max_concurrency, 0,
+            "max_concurrency must be 0 (= unbounded via no-semaphore branch); \
+             any positive value above tokio's MAX_PERMITS panics at registration"
+        );
     }
 }
 


### PR DESCRIPTION
## Latent bug — CognitionModule panics at Runtime registration

### Symptom

\`CognitionModule::config()\` sets \`max_concurrency: usize::MAX\` as a mistaken way to spell \"no cap\". The \`Runtime::register()\` path calls \`tokio::sync::Semaphore::new(max_concurrency)\` whenever \`max_concurrency > 0\`. tokio's MAX_PERMITS is \`usize::MAX >> 3\` (~2^61), so \`Semaphore::new(usize::MAX)\` panics immediately:

\`\`\`
thread '...' panicked at tokio-1.50.0/src/sync/batch_semaphore.rs:141:9:
a semaphore may not have more than MAX_PERMITS permits (2305843009213693951)
\`\`\`

### Why it's been latent

Existing cognition tests bypass the panic by calling \`module.handle_command\` directly without going through \`runtime.register\`. The IPC path that production uses (\`ipc/mod.rs:944\` → \`runtime.register(Arc::new(CognitionModule::new(...)))\` → \`runtime.route_command\` for cognition commands) IS affected.

Surfaced while building Lane D \`persona/turn-execute\` integration tests that go through \`runtime.route_command\`.

### Fix

\`\`\`
-            max_concurrency: usize::MAX,
+            max_concurrency: 0,
\`\`\`

The Runtime's \`register()\` only creates a Semaphore when \`max_concurrency > 0\` — \`0\` is the canonical spelling of \"unbounded, no semaphore\" used by other modules (\`inference-llm\`, the \`RecordingModule\` test fixtures, etc.). Preserves the original intent (\"no cap on cognition; downstream ai_provider enforces inference serialization\") without panicking.

### Regression test

Added \`registration_safety_tests::cognition_module_registers_without_semaphore_panic\` that calls \`Runtime::register\` with CognitionModule. If \`max_concurrency\` is ever raised above tokio's MAX_PERMITS, this test panics at the original error message — easy breadcrumb back to this regression.

### Provenance

Introduced in PR #1306 \"perf(cognition): lift max_concurrency:1 cap so event fanout is not the gate\". Author meant \"no cap\"; the right spelling for that in this codebase is \`0\`.

### Validation

\`\`\`
cd src/workers/continuum-core
cargo test --features metal,accelerate --lib modules::cognition
\`\`\`

5/5 pass (4 pre-existing + 1 new regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)