### PR TITLE
feat(model-registry): boot runtime from Rust catalog

### DIFF
--- a/src/workers/continuum-core/src/model_registry/catalog.rs
+++ b/src/workers/continuum-core/src/model_registry/catalog.rs
@@ -1,0 +1,561 @@
+//! Curated Rust model catalog.
+//!
+//! Runtime model truth lives here, not in TypeScript maps or editable TOML.
+//! Discovery may propose candidates elsewhere; admission only chooses from
+//! this vetted catalog.
+
+use super::loader::{Registry, RegistryError};
+use super::types::{
+    Arch, AuthKind, Capability, Model, MultiPartyChatStrategy, Provider, ProviderKind,
+};
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+const QWEN35_CHAT_TEMPLATE: &str = "{% for message in messages %}{{ '<|im_start|>' + message['role'] + '\\n' + message['content'] + '<|im_end|>\\n' }}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\\n' }}{% endif %}";
+
+pub fn registry() -> Result<Registry, RegistryError> {
+    Registry::from_catalog(models(), providers())
+}
+
+pub fn models() -> Vec<Model> {
+    vec![
+        model(ModelSpec {
+            id: "claude-sonnet-4-5-20250929",
+            name: "Claude Sonnet 4.5",
+            provider: "anthropic",
+            arch: Arch::Claude,
+            context_window: 200_000,
+            max_output_tokens: 8192,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Vision,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.003,
+            cost_output_per_1k: 0.015,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "claude-opus-4-20250514",
+            name: "Claude Opus 4",
+            provider: "anthropic",
+            arch: Arch::Claude,
+            context_window: 200_000,
+            max_output_tokens: 4096,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Vision,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.015,
+            cost_output_per_1k: 0.075,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "claude-3-5-haiku-20250107",
+            name: "Claude 3.5 Haiku",
+            provider: "anthropic",
+            arch: Arch::Claude,
+            context_window: 200_000,
+            max_output_tokens: 4096,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Vision,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.00025,
+            cost_output_per_1k: 0.00125,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "gpt-4-turbo-preview",
+            name: "GPT-4 Turbo",
+            provider: "openai",
+            arch: Arch::Gpt,
+            context_window: 128_000,
+            max_output_tokens: 4096,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Vision,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.01,
+            cost_output_per_1k: 0.03,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "gpt-4o",
+            name: "GPT-4o",
+            provider: "openai",
+            arch: Arch::Gpt,
+            context_window: 128_000,
+            max_output_tokens: 4096,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Vision,
+                Capability::AudioInput,
+                Capability::AudioOutput,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.005,
+            cost_output_per_1k: 0.015,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "deepseek-chat",
+            name: "DeepSeek Chat",
+            provider: "deepseek",
+            arch: Arch::Deepseek,
+            context_window: 128_000,
+            max_output_tokens: 8192,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.00014,
+            cost_output_per_1k: 0.00028,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "deepseek-reasoner",
+            name: "DeepSeek Reasoner",
+            provider: "deepseek",
+            arch: Arch::Deepseek,
+            context_window: 128_000,
+            max_output_tokens: 8192,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.00055,
+            cost_output_per_1k: 0.00219,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+            name: "Llama 3.1 70B (Together)",
+            provider: "together",
+            arch: Arch::Llama,
+            context_window: 131_072,
+            max_output_tokens: 4096,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.00088,
+            cost_output_per_1k: 0.00088,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "llama-3.1-8b-instant",
+            name: "Llama 3.1 8B Instant (Groq)",
+            provider: "groq",
+            arch: Arch::Llama,
+            context_window: 131_072,
+            max_output_tokens: 8192,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.00005,
+            cost_output_per_1k: 0.00008,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "accounts/fireworks/models/llama-v3p3-70b-instruct",
+            name: "Llama 3.3 70B (Fireworks)",
+            provider: "fireworks",
+            arch: Arch::Llama,
+            context_window: 128_000,
+            max_output_tokens: 8192,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.0009,
+            cost_output_per_1k: 0.0009,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "grok-3",
+            name: "Grok 3",
+            provider: "xai",
+            arch: Arch::Grok,
+            context_window: 131_072,
+            max_output_tokens: 8192,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.003,
+            cost_output_per_1k: 0.015,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "gemini-2.0-flash",
+            name: "Gemini 2.0 Flash",
+            provider: "google",
+            arch: Arch::Gemini,
+            context_window: 1_000_000,
+            max_output_tokens: 8192,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Vision,
+                Capability::AudioInput,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.000075,
+            cost_output_per_1k: 0.0003,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "docker.io/ai/qwen2.5:7B-Q4_K_M",
+            name: "Qwen2.5 7B Q4_K_M (DMR)",
+            provider: "docker-model-runner",
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 4096,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            gguf_hint: Some("docker.io/ai/qwen2.5:7B-Q4_K_M"),
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "huggingface.co/mlx-community/qwen2.5-7b-instruct-4bit:latest",
+            name: "Qwen2.5 7B MLX 4-bit (DMR)",
+            provider: "docker-model-runner",
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 4096,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::Streaming,
+            ],
+            gguf_hint: Some("huggingface.co/mlx-community/qwen2.5-7b-instruct-4bit"),
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "huggingface.co/continuum-ai/qwen3.5-4b-code-forged-gguf:latest",
+            name: "Qwen3.5 4B Code-Forged (DMR)",
+            provider: "docker-model-runner",
+            arch: Arch::Qwen35,
+            context_window: 262_144,
+            max_output_tokens: 32_768,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            gguf_hint: Some("huggingface.co/continuum-ai/qwen3.5-4b-code-forged-gguf"),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "continuum-ai/qwen3.5-4b-code-forged-GGUF",
+            name: "Qwen3.5 4B Code-Forged (in-process)",
+            provider: "llamacpp-local",
+            arch: Arch::Qwen35,
+            context_window: 262_144,
+            max_output_tokens: 32_768,
+            tokens_per_second: 33.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            gguf_hint: Some("huggingface.co/continuum-ai/qwen3.5-4b-code-forged-gguf"),
+            chat_template: Some(QWEN35_CHAT_TEMPLATE),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            stop_sequences: &["<|im_end|>", "<|endoftext|>"],
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "qwen2-vl-7b-instruct",
+            name: "Qwen2-VL-7B-Instruct (in-process)",
+            provider: "llamacpp-local",
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 4096,
+            tokens_per_second: 16.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::Vision,
+                Capability::Streaming,
+            ],
+            gguf_hint: Some("huggingface.co/bartowski/Qwen2-VL-7B-Instruct-GGUF"),
+            gguf_local_path: Some("~/models/qwen2-vl-7b/Qwen2-VL-7B-Instruct-Q4_K_M.gguf"),
+            mmproj_local_path: Some("~/models/qwen2-vl-7b/mmproj-Qwen2-VL-7B-Instruct-f16.gguf"),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "qwen2.5-omni-7b-instruct",
+            name: "Qwen2.5-Omni-7B-Instruct (in-process)",
+            provider: "llamacpp-local",
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 4096,
+            tokens_per_second: 220.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::Vision,
+                Capability::AudioInput,
+                Capability::Streaming,
+            ],
+            gguf_hint: Some("huggingface.co/ggml-org/Qwen2.5-Omni-7B-GGUF"),
+            gguf_local_path: Some("~/models/qwen2.5-omni-7b/Qwen2.5-Omni-7B-Q4_K_M.gguf"),
+            mmproj_local_path: Some("~/models/qwen2.5-omni-7b/mmproj-Qwen2.5-Omni-7B-f16.gguf"),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            ..ModelSpec::default()
+        }),
+    ]
+}
+
+pub fn providers() -> Vec<Provider> {
+    vec![
+        provider(ProviderSpec {
+            id: "anthropic",
+            name: "Anthropic",
+            base_url: "https://api.anthropic.com",
+            api_key_env: Some("ANTHROPIC_API_KEY"),
+            default_model: Some("claude-sonnet-4-5-20250929"),
+            auth: AuthKind::ApiKey,
+            kind: ProviderKind::Cloud,
+            model_prefixes: &["claude"],
+        }),
+        provider(ProviderSpec {
+            id: "openai",
+            name: "OpenAI",
+            base_url: "https://api.openai.com",
+            api_key_env: Some("OPENAI_API_KEY"),
+            default_model: Some("gpt-4-turbo-preview"),
+            auth: AuthKind::Bearer,
+            kind: ProviderKind::Cloud,
+            model_prefixes: &["gpt", "o1", "o3"],
+        }),
+        provider(ProviderSpec {
+            id: "deepseek",
+            name: "DeepSeek",
+            base_url: "https://api.deepseek.com",
+            api_key_env: Some("DEEPSEEK_API_KEY"),
+            default_model: Some("deepseek-chat"),
+            auth: AuthKind::Bearer,
+            kind: ProviderKind::Cloud,
+            model_prefixes: &["deepseek"],
+        }),
+        provider(ProviderSpec {
+            id: "together",
+            name: "Together AI",
+            base_url: "https://api.together.xyz",
+            api_key_env: Some("TOGETHER_API_KEY"),
+            default_model: Some("meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo"),
+            auth: AuthKind::Bearer,
+            kind: ProviderKind::Cloud,
+            model_prefixes: &["togethercomputer/", "meta-llama/"],
+        }),
+        provider(ProviderSpec {
+            id: "groq",
+            name: "Groq",
+            base_url: "https://api.groq.com/openai",
+            api_key_env: Some("GROQ_API_KEY"),
+            default_model: Some("llama-3.1-8b-instant"),
+            auth: AuthKind::Bearer,
+            kind: ProviderKind::Cloud,
+            model_prefixes: &["llama-3", "mixtral", "gemma2"],
+        }),
+        provider(ProviderSpec {
+            id: "fireworks",
+            name: "Fireworks AI",
+            base_url: "https://api.fireworks.ai/inference",
+            api_key_env: Some("FIREWORKS_API_KEY"),
+            default_model: Some("accounts/fireworks/models/llama-v3p3-70b-instruct"),
+            auth: AuthKind::Bearer,
+            kind: ProviderKind::Cloud,
+            model_prefixes: &["accounts/fireworks/"],
+        }),
+        provider(ProviderSpec {
+            id: "xai",
+            name: "xAI",
+            base_url: "https://api.x.ai",
+            api_key_env: Some("XAI_API_KEY"),
+            default_model: Some("grok-3"),
+            auth: AuthKind::Bearer,
+            kind: ProviderKind::Cloud,
+            model_prefixes: &["grok"],
+        }),
+        provider(ProviderSpec {
+            id: "google",
+            name: "Google",
+            base_url: "https://generativelanguage.googleapis.com/v1beta/openai",
+            api_key_env: Some("GOOGLE_API_KEY"),
+            default_model: Some("gemini-2.0-flash"),
+            auth: AuthKind::Bearer,
+            kind: ProviderKind::Cloud,
+            model_prefixes: &["gemini"],
+        }),
+        provider(ProviderSpec {
+            id: "docker-model-runner",
+            name: "Docker Model Runner (local Metal/CUDA)",
+            base_url: "http://127.0.0.1:12434/engines/llama.cpp",
+            api_key_env: None,
+            default_model: Some("huggingface.co/continuum-ai/qwen3.5-4b-code-forged-gguf:latest"),
+            auth: AuthKind::None,
+            kind: ProviderKind::Local,
+            model_prefixes: &[],
+        }),
+        provider(ProviderSpec {
+            id: "llamacpp-local",
+            name: "Llama.cpp (in-process Metal/CUDA)",
+            base_url: "in-process",
+            api_key_env: None,
+            default_model: Some("continuum-ai/qwen3.5-4b-code-forged-GGUF"),
+            auth: AuthKind::None,
+            kind: ProviderKind::Local,
+            model_prefixes: &[],
+        }),
+    ]
+}
+
+#[derive(Clone)]
+struct ModelSpec {
+    id: &'static str,
+    name: &'static str,
+    provider: &'static str,
+    arch: Arch,
+    context_window: u32,
+    max_output_tokens: u32,
+    tokens_per_second: f32,
+    capabilities: &'static [Capability],
+    cost_input_per_1k: f32,
+    cost_output_per_1k: f32,
+    gguf_hint: Option<&'static str>,
+    gguf_local_path: Option<&'static str>,
+    mmproj_local_path: Option<&'static str>,
+    chat_template: Option<&'static str>,
+    multi_party_strategy: MultiPartyChatStrategy,
+    stop_sequences: &'static [&'static str],
+}
+
+impl Default for ModelSpec {
+    fn default() -> Self {
+        Self {
+            id: "",
+            name: "",
+            provider: "",
+            arch: Arch::Unknown,
+            context_window: 0,
+            max_output_tokens: 0,
+            tokens_per_second: 0.0,
+            capabilities: &[],
+            cost_input_per_1k: 0.0,
+            cost_output_per_1k: 0.0,
+            gguf_hint: None,
+            gguf_local_path: None,
+            mmproj_local_path: None,
+            chat_template: None,
+            multi_party_strategy: MultiPartyChatStrategy::NamePrefixedUserTurns,
+            stop_sequences: &[],
+        }
+    }
+}
+
+fn model(spec: ModelSpec) -> Model {
+    Model {
+        id: spec.id.to_string(),
+        name: Some(spec.name.to_string()),
+        provider: spec.provider.to_string(),
+        arch: spec.arch,
+        context_window: spec.context_window,
+        max_output_tokens: spec.max_output_tokens,
+        tokens_per_second: spec.tokens_per_second,
+        capabilities: caps(spec.capabilities),
+        cost_input_per_1k: spec.cost_input_per_1k,
+        cost_output_per_1k: spec.cost_output_per_1k,
+        gguf_hint: spec.gguf_hint.map(str::to_string),
+        gguf_local_path: spec.gguf_local_path.map(PathBuf::from),
+        mmproj_local_path: spec.mmproj_local_path.map(PathBuf::from),
+        chat_template: spec.chat_template.map(str::to_string),
+        multi_party_strategy: spec.multi_party_strategy,
+        stop_sequences: spec.stop_sequences.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+struct ProviderSpec {
+    id: &'static str,
+    name: &'static str,
+    base_url: &'static str,
+    api_key_env: Option<&'static str>,
+    default_model: Option<&'static str>,
+    auth: AuthKind,
+    kind: ProviderKind,
+    model_prefixes: &'static [&'static str],
+}
+
+fn provider(spec: ProviderSpec) -> Provider {
+    Provider {
+        id: spec.id.to_string(),
+        name: Some(spec.name.to_string()),
+        base_url: spec.base_url.to_string(),
+        api_key_env: spec.api_key_env.map(str::to_string),
+        default_model: spec.default_model.map(str::to_string),
+        auth: spec.auth,
+        model_prefixes: spec
+            .model_prefixes
+            .iter()
+            .map(|prefix| prefix.to_string())
+            .collect(),
+        kind: spec.kind,
+    }
+}
+
+fn caps(capabilities: &[Capability]) -> BTreeSet<Capability> {
+    capabilities.iter().copied().collect()
+}

--- a/src/workers/continuum-core/src/model_registry/loader.rs
+++ b/src/workers/continuum-core/src/model_registry/loader.rs
@@ -27,6 +27,36 @@ pub struct Registry {
 }
 
 impl Registry {
+    pub fn from_catalog(
+        raw_models: Vec<Model>,
+        raw_providers: Vec<Provider>,
+    ) -> Result<Self, RegistryError> {
+        let mut providers: HashMap<String, Provider> = HashMap::with_capacity(raw_providers.len());
+        for p in raw_providers {
+            if providers.contains_key(&p.id) {
+                return Err(RegistryError::DuplicateProvider { id: p.id });
+            }
+            providers.insert(p.id.clone(), p);
+        }
+
+        let mut models: HashMap<String, Model> = HashMap::with_capacity(raw_models.len());
+        for mut m in raw_models {
+            if models.contains_key(&m.id) {
+                return Err(RegistryError::DuplicateModel { id: m.id });
+            }
+            if !providers.contains_key(&m.provider) {
+                return Err(RegistryError::UnknownProvider {
+                    model_id: m.id,
+                    provider_id: m.provider,
+                });
+            }
+            resolve_model_artifacts(&mut m);
+            models.insert(m.id.clone(), m);
+        }
+
+        Ok(Self { models, providers })
+    }
+
     pub fn model(&self, id: &str) -> Option<&Model> {
         self.models.get(id)
     }
@@ -138,31 +168,7 @@ pub fn load_registry(
 ) -> Result<Registry, RegistryError> {
     let raw_models = load_models(models_path)?;
     let raw_providers = load_providers(providers_path)?;
-
-    let mut providers: HashMap<String, Provider> = HashMap::with_capacity(raw_providers.len());
-    for p in raw_providers {
-        if providers.contains_key(&p.id) {
-            return Err(RegistryError::DuplicateProvider { id: p.id });
-        }
-        providers.insert(p.id.clone(), p);
-    }
-
-    let mut models: HashMap<String, Model> = HashMap::with_capacity(raw_models.len());
-    for mut m in raw_models {
-        if models.contains_key(&m.id) {
-            return Err(RegistryError::DuplicateModel { id: m.id });
-        }
-        if !providers.contains_key(&m.provider) {
-            return Err(RegistryError::UnknownProvider {
-                model_id: m.id,
-                provider_id: m.provider,
-            });
-        }
-        resolve_model_artifacts(&mut m);
-        models.insert(m.id.clone(), m);
-    }
-
-    Ok(Registry { models, providers })
+    Registry::from_catalog(raw_models, raw_providers)
 }
 
 #[cfg(test)]
@@ -428,6 +434,11 @@ auth = "none"
         assert!(
             omni.mmproj_local_path.is_some(),
             "local sensory-input admission requires an mmproj path"
+        );
+
+        assert!(
+            reg.model("qwen2-vl-7b-instruct").is_some(),
+            "Rust catalog must own the vetted local vision model"
         );
     }
 

--- a/src/workers/continuum-core/src/model_registry/mod.rs
+++ b/src/workers/continuum-core/src/model_registry/mod.rs
@@ -1,25 +1,19 @@
 //! Model registry — single source of truth for model + provider metadata.
 //!
-//! Replaces the dozens of hardcoded `ModelInfo` entries, per-model
-//! HashMap literals, and `match arch { "qwen35" => ... }` branches
-//! scattered across `ai/` and `inference/`. Adding a new model is a
-//! TOML row. Code consumes *capabilities*, not identity.
+//! Replaces scattered `ModelInfo` entries, per-model HashMap literals,
+//! TypeScript registries, and `match arch { "qwen35" => ... }` branches.
+//! Runtime code consumes capabilities and requirements, not provider strings.
 //!
-//! Joel's rule (2026-04-20): "code should NEVER (other than ONE place)
-//! be allowed to know the model. config gives it."
-//!
-//! This module IS the ONE place.
+//! This module is the one place allowed to know curated model facts.
 //!
 //! Invariants:
-//! - Nothing outside this module knows any specific model ID or arch
-//!   string. Callers ask for a `Model` by id (opaque string from config)
-//!   and check capabilities.
+//! - Nothing outside this module should own specific model facts.
 //! - Enum variants (`Arch`, `Capability`, `AuthKind`) are the closed
 //!   vocabulary. Adding a model with a new arch means adding an `Arch::`
-//!   variant AND a TOML row — but the TOML rows for existing arches
-//!   remain unaffected.
+//!   variant and one catalog row.
 
 pub mod artifacts;
+pub mod catalog;
 pub mod loader;
 pub mod singleton;
 pub mod types;
@@ -28,6 +22,7 @@ pub use artifacts::{
     find_first_local_gguf, resolve_gguf_for_model, resolve_gguf_for_model_id,
     resolve_local_model_dir_for_model_id,
 };
-pub use loader::{load_models, load_providers, load_registry, Registry, RegistryError};
+pub use catalog::{models as catalog_models, providers as catalog_providers};
+pub use loader::{Registry, RegistryError, load_models, load_providers, load_registry};
 pub use singleton::{global, init_global, try_global};
 pub use types::{Arch, AuthKind, Capability, Model, Provider};

--- a/src/workers/continuum-core/src/model_registry/singleton.rs
+++ b/src/workers/continuum-core/src/model_registry/singleton.rs
@@ -4,7 +4,7 @@
 //! from `main.rs` / `backend_init()`). Adapters and inference code ask
 //! `global()` for the live registry and look up models / providers by id.
 //!
-//! **Why a singleton.** Registry is immutable after load (TOML is read
+//! **Why a singleton.** Registry is immutable after boot (catalog is built
 //! once, no runtime writes), so `&'static Registry` is the natural fit.
 //! Threading it through every adapter constructor would be boilerplate
 //! without benefit — there's only ever one. The singleton is filled
@@ -12,26 +12,15 @@
 //! by design so tests can re-seed with their own fixture paths).
 //!
 //! **Why not lazy_static / build-time.** We want explicit control of
-//! WHEN load happens (after logging is up, before any adapter touches it)
-//! and WHERE load reads from (env override for deployment, crate-dir
-//! default for dev/test). A deferred `init_global` keeps that control.
+//! WHEN load happens (after logging is up, before any adapter touches it).
+//! A deferred `init_global` keeps that control.
 
-use super::loader::{load_registry, Registry, RegistryError};
-use std::path::{Path, PathBuf};
+use super::catalog;
+use super::loader::{Registry, RegistryError, load_registry};
+use std::path::Path;
 use std::sync::OnceLock;
 
 static GLOBAL: OnceLock<Registry> = OnceLock::new();
-
-/// Default models/providers TOML paths — `{CARGO_MANIFEST_DIR}/config/*.toml`.
-/// These are the checked-in source-of-truth files. Deployment environments
-/// can override via `CONTINUUM_MODEL_REGISTRY_DIR` env var pointing at an
-/// alternate directory that contains `models.toml` + `providers.toml`.
-fn default_paths() -> (PathBuf, PathBuf) {
-    let base: PathBuf = std::env::var("CONTINUUM_MODEL_REGISTRY_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config"));
-    (base.join("models.toml"), base.join("providers.toml"))
-}
 
 /// Initialize the process-wide registry. Idempotent: subsequent calls
 /// are ignored (the first one wins). Returns the registry reference so
@@ -43,16 +32,21 @@ fn default_paths() -> (PathBuf, PathBuf) {
 /// # Ok::<(), continuum_core::model_registry::RegistryError>(())
 /// ```
 pub fn init_global() -> Result<&'static Registry, RegistryError> {
-    let (models, providers) = default_paths();
-    init_global_from(&models, &providers)
+    init_global_with(catalog::registry)
 }
 
-/// Initialize from explicit paths. Used by tests + any deployment that
-/// keeps its config outside `CARGO_MANIFEST_DIR`. Idempotent same as
-/// `init_global`.
+/// Legacy TOML initializer for parser tests and the short-lived migration
+/// window. Runtime boot must call [`init_global`], which uses the Rust
+/// catalog directly.
 pub fn init_global_from(
     models: &Path,
     providers: &Path,
+) -> Result<&'static Registry, RegistryError> {
+    init_global_with(|| load_registry(models, providers))
+}
+
+fn init_global_with(
+    build_registry: impl FnOnce() -> Result<Registry, RegistryError>,
 ) -> Result<&'static Registry, RegistryError> {
     // If GLOBAL is already set, the first-loaded one wins. We don't
     // re-load on subsequent calls — that would break the "load once"
@@ -60,7 +54,7 @@ pub fn init_global_from(
     if let Some(existing) = GLOBAL.get() {
         return Ok(existing);
     }
-    let reg = load_registry(models, providers)?;
+    let reg = build_registry()?;
     // Race: two threads may hit here simultaneously. OnceLock::set
     // returns Err on the loser thread; we discard its registry and
     // return the winner's.
@@ -98,13 +92,13 @@ mod tests {
     use crate::model_registry::Capability;
 
     #[test]
-    fn init_once_picks_up_seeded_config() {
+    fn init_once_picks_up_rust_catalog() {
         // Idempotent init — test isolation is tricky for OnceLock statics;
         // if another test already called init_global, this call reuses
         // that registry. That's still a valid state under our "first
         // caller wins" contract, so the assertion just has to hold
         // regardless of order.
-        let reg = init_global().expect("seeded config must load");
+        let reg = init_global().expect("Rust catalog must load");
         assert!(reg.models().count() > 0);
         assert!(reg.providers().count() > 0);
         // Canonical anchor: Claude Sonnet 4.5 must exist and have Vision.

--- a/src/workers/continuum-core/src/model_registry/types.rs
+++ b/src/workers/continuum-core/src/model_registry/types.rs
@@ -178,7 +178,7 @@ pub enum MultiPartyChatStrategy {
     ProperChatMlSingleParty,
 }
 
-/// A single model's metadata. Loaded from TOML; never constructed in code.
+/// A single model's metadata. Constructed by the Rust model catalog.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Model {
     /// Canonical id — matches the provider's API request body.

--- a/src/workers/continuum-core/src/modules/models.rs
+++ b/src/workers/continuum-core/src/modules/models.rs
@@ -7,7 +7,7 @@
 
 use crate::log_info;
 use crate::logging::TimingGuard;
-use crate::models::{discover_all, ProviderConfig};
+use crate::models::{ProviderConfig, discover_all};
 use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
 use crate::utils::params::Params;
 use async_trait::async_trait;
@@ -74,36 +74,22 @@ impl ServiceModule for ModelsModule {
                 })))
             }
 
-            // Lookup the canonical capability vocabulary for a model from
-            // models.toml. Returns kebab-case strings matching the serde
-            // rename on `model_registry::types::Capability` ("vision",
-            // "audio-input", "tool-use", "streaming", etc.).
+            // Return the canonical capability vocabulary for a Rust catalog
+            // model id.
             //
-            // Why this exists: callers (TS PRG) need to declare a model's
-            // capabilities WITH the request when invoking
-            // `cognition/respond`, so Rust never has to do a global
-            // registry lookup mid-inference (which silently returned
-            // empty caps when keys drifted, demoting image bytes to
-            // text markers — vision encoder never fired). PRG calls
-            // this once per persona at construction and caches.
-            //
-            // Hard error when the model id isn't in the registry — that
-            // means models.toml doesn't know about it and the persona's
-            // configuration is broken. No silent empty-list fallback;
-            // the contract is "if you ask, you get answers or you get
-            // an error you can debug."
+            // This is intentionally strict: callers that only know desired
+            // capabilities must use the allocator/resolver boundary, not send
+            // raw HuggingFace or provider strings to this lookup command.
             "models/capabilities" => {
                 let _timer = TimingGuard::new("module", "models_capabilities");
                 let p = Params::new(&params);
                 let model_id = p.str("model_id")?;
 
-                let registry = crate::model_registry::try_global().ok_or(
-                    "model_registry not initialized — models.toml never loaded".to_string(),
-                )?;
+                let registry = crate::model_registry::try_global()
+                    .ok_or("model registry is not initialized".to_string())?;
                 let model = registry.model(model_id).ok_or_else(|| {
                     format!(
-                        "model id '{}' not in registry — add it to models.toml",
-                        model_id
+                        "unknown Rust catalog model id '{model_id}' — call the Rust model allocator instead of naming provider artifacts"
                     )
                 })?;
 


### PR DESCRIPTION
## Summary
- add a curated Rust-owned model/provider catalog under continuum-core model_registry
- make runtime model_registry::init_global() boot from the Rust catalog instead of models.toml
- keep TOML loading only as a legacy/parser path while callers move to the Rust allocator boundary
- make models/capabilities strict against canonical Rust catalog ids and remove the old 'add it to models.toml' guidance

## Validation
- cargo test --manifest-path src/workers/continuum-core/Cargo.toml model_registry --lib --features metal,accelerate
- cargo test --manifest-path src/workers/continuum-core/Cargo.toml cognition::model_resolver --lib --features metal,accelerate
- cargo check --manifest-path src/workers/continuum-core/Cargo.toml --features metal,accelerate
- cd src/workers/continuum-core && cargo check --features metal,accelerate
- cd src/workers/continuum-core && cargo test --lib --features metal,accelerate (2999 passed, 24 ignored)
- precommit: TypeScript compilation PASSED
- precommit: browser-ping PASSED
- precommit: chat-roundtrip PASSED; live Teacher AI replied OK