### PR TITLE
feat(vdd): Lane C PR-3 — vdd/report IPC + reader (machine-readable VDD from artifacts)

### DIFF
--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -936,6 +936,15 @@ pub fn start_server(
         crate::inference::llm_module_service::InferenceLlmModule::new(),
     ));
 
+    // Lane C PR-3: VddModule — `vdd/report` reads structured
+    // VDD records from `~/.continuum/vdd/<sha>/<scenario>/record.jsonl`
+    // (written by the harness via `ArtifactWriter`) and emits a
+    // machine-readable report. Replaces "tail the log and grep
+    // for first-token-ms" with a single command return. PR-body
+    // VDD claims become `./jtag vdd/report --git_sha=<sha>`,
+    // not pasted terminal text.
+    runtime.register(Arc::new(crate::modules::vdd::VddModule::new()));
+
     // Shared state for per-persona cognition (unified: engine + inbox + rate limiter + sleep + adapters + genome)
     let rag_engine = Arc::new(RagEngine::new());
     let cognition_state = Arc::new(

--- a/src/workers/continuum-core/src/modules/mod.rs
+++ b/src/workers/continuum-core/src/modules/mod.rs
@@ -43,4 +43,5 @@ pub mod search;
 pub mod sentinel;
 pub mod system_resources;
 pub mod tool_parsing;
+pub mod vdd;
 pub mod vision;

--- a/src/workers/continuum-core/src/modules/vdd.rs
+++ b/src/workers/continuum-core/src/modules/vdd.rs
@@ -1,0 +1,497 @@
+//! `vdd/report` IPC module — Lane C PR-3 of the doc's
+//! [Lane C VDD telemetry substrate] sequence.
+//!
+//! Consumes the pure read-side primitive from
+//! `crate::vdd::reader` and emits a structured JSON report so
+//! callers (CI dashboards, the chat-roundtrip post-mortem
+//! command, sentinel attribution) stop scraping random console
+//! text. Every claim "VDD: tokens/sec improved from X → Y" in a
+//! PR body should be a query against this command, not a paste
+//! from a terminal.
+//!
+//! Commands:
+//! - `vdd/report` — read records from `~/.continuum/vdd/...`,
+//!   apply optional git_sha / scenario filters, return list of
+//!   matching records + a small aggregate summary.
+//!
+//! Failure modes (per Joel's never-swallow rule):
+//! - Corrupt `record.jsonl` → typed Err, surface the parse error
+//!   with the file path so the caller can `cat` the bad artifact.
+//! - Missing artifact root → empty result (NOT error); fresh dev
+//!   machine has nothing to report and that's a valid state.
+//!
+//! NOT in this slice:
+//! - Cross-PR regression detection (compare two git_shas + flag
+//!   tokens/sec regressions). That's a separate report mode that
+//!   builds on this primitive — adds a `mode: "regression"` param.
+//! - Subscribing to live `RuntimeMetric` events from inference
+//!   paths (Lane C PR-1/PR-2 prereqs). This command reads what
+//!   the harness has already written; the live-emit path lands
+//!   when those PRs are bound.
+
+use crate::logging::TimingGuard;
+use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
+use crate::utils::params::Params;
+use crate::vdd::reader::{latest_per_scenario, read_records, VddReadOptions, VddRecordEntry};
+use crate::vdd::record::HarnessStatus;
+use async_trait::async_trait;
+use serde::Serialize;
+use serde_json::Value;
+use std::any::Any;
+use std::path::{Path, PathBuf};
+
+pub struct VddModule {
+    /// Artifact root. In production this points at
+    /// `~/.continuum/vdd`; in tests, the harness wires a temp
+    /// dir so test data doesn't leak into the dev's real
+    /// artifact store.
+    artifact_root: PathBuf,
+}
+
+impl VddModule {
+    pub fn new() -> Self {
+        Self {
+            artifact_root: default_artifact_root(),
+        }
+    }
+
+    /// Constructor for tests + non-default deployments. Allows
+    /// pointing the module at any artifact root.
+    pub fn with_root(root: impl Into<PathBuf>) -> Self {
+        Self {
+            artifact_root: root.into(),
+        }
+    }
+}
+
+impl Default for VddModule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Resolve `~/.continuum/vdd` as the canonical artifact root.
+/// Matches `vdd::ArtifactWriter::continuum_default()` — that's the
+/// writer's path; this is the reader's path; they must agree.
+fn default_artifact_root() -> PathBuf {
+    dirs::home_dir()
+        .expect("home directory must exist for VDD artifact reads")
+        .join(".continuum")
+        .join("vdd")
+}
+
+#[async_trait]
+impl ServiceModule for VddModule {
+    fn config(&self) -> ModuleConfig {
+        ModuleConfig {
+            name: "vdd",
+            priority: ModulePriority::Background,
+            command_prefixes: &["vdd/"],
+            event_subscriptions: &[],
+            needs_dedicated_thread: false,
+            // Pure-read + bounded fs scan; no need to cap fan-out.
+            max_concurrency: 0,
+            tick_interval: None,
+        }
+    }
+
+    async fn initialize(&self, _ctx: &ModuleContext) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn handle_command(&self, command: &str, params: Value) -> Result<CommandResult, String> {
+        match command {
+            "vdd/report" => {
+                let _timer = TimingGuard::new("module", "vdd_report");
+                let p = Params::new(&params);
+
+                let opts = VddReadOptions {
+                    git_sha: p.str_opt("git_sha").map(String::from),
+                    scenario: p.str_opt("scenario").map(String::from),
+                };
+                let latest_only = p.bool_or("latest_only", false);
+
+                let entries =
+                    read_records(&self.artifact_root, &opts).map_err(|e| e.to_string())?;
+
+                let report = if latest_only {
+                    let collapsed = latest_per_scenario(entries);
+                    build_report(collapsed.into_values().collect(), &self.artifact_root, &opts)
+                } else {
+                    build_report(entries, &self.artifact_root, &opts)
+                };
+
+                Ok(CommandResult::Json(
+                    serde_json::to_value(&report)
+                        .map_err(|e| format!("Serialize VDD report: {e}"))?,
+                ))
+            }
+
+            other => Err(format!("Unknown vdd command: {other}")),
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// On-the-wire shape returned by `vdd/report`. Stable, camelCase
+/// for the TS / CI-dashboard side that consumes it.
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VddReport {
+    /// Absolute path the records were read from. Surfaces "where
+    /// the harness is writing" to humans + LLM consumers — the
+    /// "where did this come from" answer is one field away.
+    pub artifact_root: String,
+    /// The filters applied. Empty fields are reported back as
+    /// null so the consumer's expectation matches what was asked.
+    pub filters: VddReportFilters,
+    /// Headline counts. Cheap to compute, surface in a banner /
+    /// PR-body snippet without iterating the full record list.
+    pub summary: VddReportSummary,
+    /// The matching records, sorted deterministically by
+    /// (git_sha, scenario). The detail layer for any consumer
+    /// that wants to drill in on a specific row.
+    pub records: Vec<VddReportEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VddReportFilters {
+    pub git_sha: Option<String>,
+    pub scenario: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VddReportSummary {
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub prerequisite_missing: usize,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VddReportEntry {
+    pub git_sha: String,
+    pub scenario: String,
+    pub platform: String,
+    pub hardware: String,
+    pub backend: String,
+    pub status: HarnessStatus,
+    pub first_token_ms: Option<u64>,
+    pub tok_per_sec: Option<f64>,
+    pub responses_observed: u32,
+    pub responses_expected: u32,
+    pub degraded_reason: Option<String>,
+    pub silence_reasons: Vec<String>,
+    /// Path to the on-disk `record.jsonl` for this entry. Lets
+    /// the consumer fetch the FULL StandardVddRecord (not just
+    /// the headline fields surfaced here) on demand without the
+    /// report itself carrying every byte of every record.
+    pub source: String,
+}
+
+fn build_report(
+    entries: Vec<VddRecordEntry>,
+    artifact_root: &Path,
+    opts: &VddReadOptions,
+) -> VddReport {
+    let mut summary = VddReportSummary {
+        total: entries.len(),
+        passed: 0,
+        failed: 0,
+        prerequisite_missing: 0,
+    };
+    let mut records: Vec<VddReportEntry> = Vec::with_capacity(entries.len());
+    for e in entries {
+        match e.record.status {
+            HarnessStatus::Pass => summary.passed += 1,
+            HarnessStatus::Fail => summary.failed += 1,
+            HarnessStatus::PrerequisiteMissing => summary.prerequisite_missing += 1,
+        }
+        records.push(VddReportEntry {
+            git_sha: e.record.git_sha,
+            scenario: e.record.scenario,
+            platform: e.record.platform,
+            hardware: e.record.hardware,
+            backend: e.record.backend,
+            status: e.record.status,
+            first_token_ms: e.record.first_token_ms,
+            tok_per_sec: e.record.tok_per_sec,
+            responses_observed: e.record.responses_observed,
+            responses_expected: e.record.responses_expected,
+            degraded_reason: e.record.degraded_reason,
+            silence_reasons: e.record.silence_reasons,
+            source: e.source.to_string_lossy().into_owned(),
+        });
+    }
+    records.sort_by(|a, b| {
+        (a.git_sha.as_str(), a.scenario.as_str()).cmp(&(b.git_sha.as_str(), b.scenario.as_str()))
+    });
+    VddReport {
+        artifact_root: artifact_root.to_string_lossy().into_owned(),
+        filters: VddReportFilters {
+            git_sha: opts.git_sha.clone(),
+            scenario: opts.scenario.clone(),
+        },
+        summary,
+        records,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pin the IPC contract end-to-end: command name + param
+    //! parsing + filter passthrough + summary aggregation + JSON
+    //! wire shape. Each test seeds a temp artifact root via the
+    //! real `ArtifactWriter` so writer/reader/report drift fails
+    //! at unit-test time.
+    use super::*;
+    use crate::vdd::artifacts::{ArtifactWriter, ReproducibilityManifest};
+    use crate::vdd::record::{HarnessStatus, StandardVddRecord};
+
+    fn sample_record(git_sha: &str, scenario: &str, status: HarnessStatus) -> StandardVddRecord {
+        StandardVddRecord {
+            scenario: scenario.to_string(),
+            platform: "darwin".to_string(),
+            hardware: "m1-air-8gb".to_string(),
+            backend: "metal".to_string(),
+            git_sha: git_sha.to_string(),
+            command: "npm start".to_string(),
+            model: Some("qwen2-vl-7b-instruct".to_string()),
+            gpu_layers: Some(32),
+            unsupported_layers: Vec::new(),
+            cold_start_ms: Some(8_000),
+            first_token_ms: Some(450),
+            first_response_ms: Some(1_200),
+            all_responses_ms: Some(3_400),
+            responses_expected: 4,
+            responses_observed: if status == HarnessStatus::Pass { 4 } else { 1 },
+            silence_reasons: if status == HarnessStatus::Fail {
+                vec!["model_load_timeout".to_string()]
+            } else {
+                Vec::new()
+            },
+            tok_per_sec: Some(28.6),
+            cpu_pct_avg: Some(55.0),
+            cpu_pct_peak: Some(98.0),
+            rss_mb: Some(3_120),
+            gpu_util_pct_avg: Some(72.0),
+            gpu_memory_mb: Some(4_800),
+            queue_wait_ms: Some(12),
+            execution_ms: Some(820),
+            coalesced_count: 1,
+            deferred_count: 0,
+            stale_drop_count: 0,
+            error_count: 0,
+            degraded_reason: None,
+            log_refs: Vec::new(),
+            next_bottleneck: None,
+            policy_version: Some("v1".to_string()),
+            cascade_step: Some(2),
+            status,
+        }
+    }
+
+    fn write(tmp_root: &Path, sha: &str, scen: &str, status: HarnessStatus) {
+        let writer = ArtifactWriter::new(tmp_root);
+        let r = sample_record(sha, scen, status);
+        let m = ReproducibilityManifest::from_record(&r, &[]);
+        writer.write(&r, &m).unwrap();
+    }
+
+    /// What this catches: config exposes the canonical `vdd/`
+    /// prefix + module name. If either drifts, the registry routes
+    /// the command elsewhere.
+    #[test]
+    fn config_reports_name_and_prefix() {
+        let m = VddModule::new();
+        let cfg = m.config();
+        assert_eq!(cfg.name, "vdd");
+        assert_eq!(cfg.command_prefixes, &["vdd/"]);
+    }
+
+    /// What this catches: with no artifact root + no records, the
+    /// command returns an empty report (not an error). Fresh dev
+    /// machine == valid state.
+    #[tokio::test]
+    async fn report_with_missing_root_returns_empty_report() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nonexistent = tmp.path().join("never-created");
+        let module = VddModule::with_root(&nonexistent);
+
+        let result = module
+            .handle_command("vdd/report", serde_json::json!({}))
+            .await
+            .expect("empty root returns Ok");
+
+        match result {
+            CommandResult::Json(v) => {
+                let report: VddReport = serde_json::from_value(v).unwrap();
+                assert_eq!(report.summary.total, 0);
+                assert_eq!(report.summary.passed, 0);
+                assert!(report.records.is_empty());
+            }
+            _ => panic!("expected Json"),
+        }
+    }
+
+    /// What this catches: end-to-end command path bundles the
+    /// reader's output into the wire report. Aggregates the
+    /// summary correctly across pass/fail/prerequisite_missing.
+    #[tokio::test]
+    async fn report_aggregates_summary_across_record_statuses() {
+        let tmp = tempfile::tempdir().unwrap();
+        // 2 pass on different shas.
+        write(tmp.path(), "sha-a", "chat-roundtrip-live-harness", HarnessStatus::Pass);
+        write(tmp.path(), "sha-b", "chat-roundtrip-live-harness", HarnessStatus::Pass);
+        // 1 fail.
+        write(tmp.path(), "sha-c", "chat-roundtrip-live-harness", HarnessStatus::Fail);
+        // 1 prerequisite_missing.
+        write(
+            tmp.path(),
+            "sha-d",
+            "chat-roundtrip-live-harness",
+            HarnessStatus::PrerequisiteMissing,
+        );
+
+        let module = VddModule::with_root(tmp.path());
+        let result = module
+            .handle_command("vdd/report", serde_json::json!({}))
+            .await
+            .unwrap();
+        let v = match result {
+            CommandResult::Json(v) => v,
+            _ => panic!("expected Json"),
+        };
+        let report: VddReport = serde_json::from_value(v).unwrap();
+        assert_eq!(report.summary.total, 4);
+        assert_eq!(report.summary.passed, 2);
+        assert_eq!(report.summary.failed, 1);
+        assert_eq!(report.summary.prerequisite_missing, 1);
+        assert_eq!(report.records.len(), 4);
+    }
+
+    /// What this catches: the `git_sha` filter narrows the result
+    /// to one commit's records + reports back the filter on the
+    /// wire so the consumer knows what query produced the report.
+    #[tokio::test]
+    async fn report_git_sha_filter_narrows_results_and_echoes_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        for sha in ["sha-a", "sha-b", "sha-c"] {
+            write(tmp.path(), sha, "chat-roundtrip-live-harness", HarnessStatus::Pass);
+        }
+
+        let module = VddModule::with_root(tmp.path());
+        let result = module
+            .handle_command("vdd/report", serde_json::json!({"git_sha": "sha-b"}))
+            .await
+            .unwrap();
+        let v = match result {
+            CommandResult::Json(v) => v,
+            _ => panic!("expected Json"),
+        };
+        let report: VddReport = serde_json::from_value(v).unwrap();
+        assert_eq!(report.summary.total, 1);
+        assert_eq!(report.records[0].git_sha, "sha-b");
+        // Filter is echoed back so consumers can verify what they queried.
+        assert_eq!(report.filters.git_sha.as_deref(), Some("sha-b"));
+        assert_eq!(report.filters.scenario, None);
+    }
+
+    /// What this catches: `latest_only=true` collapses duplicate
+    /// (git_sha, scenario) entries to one row. Used by PR-body
+    /// snippets that want "the most recent result per scenario."
+    #[tokio::test]
+    async fn report_latest_only_collapses_duplicate_scenario_per_sha() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Two writes to same (sha, scenario): writer overwrites
+        // in place, so reader sees the latest.
+        write(tmp.path(), "sha-x", "chat-roundtrip", HarnessStatus::Pass);
+        write(tmp.path(), "sha-x", "chat-roundtrip", HarnessStatus::Fail);
+        // Different scenario on the same sha — should NOT collapse.
+        write(tmp.path(), "sha-x", "vision-smoke", HarnessStatus::Pass);
+
+        let module = VddModule::with_root(tmp.path());
+        let result = module
+            .handle_command("vdd/report", serde_json::json!({"latest_only": true}))
+            .await
+            .unwrap();
+        let v = match result {
+            CommandResult::Json(v) => v,
+            _ => panic!("expected Json"),
+        };
+        let report: VddReport = serde_json::from_value(v).unwrap();
+        assert_eq!(report.summary.total, 2);
+        // (sha-x, chat-roundtrip) entry reports the latest = Fail.
+        let chat = report
+            .records
+            .iter()
+            .find(|r| r.scenario == "chat-roundtrip")
+            .expect("chat-roundtrip row present");
+        assert_eq!(chat.status, HarnessStatus::Fail);
+    }
+
+    /// What this catches: unknown vdd command returns a typed Err
+    /// per Joel's never-swallow rule. The error mentions the
+    /// unknown command so callers debug from the message.
+    #[tokio::test]
+    async fn unknown_command_returns_loud_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let module = VddModule::with_root(tmp.path());
+        let result = module
+            .handle_command("vdd/bogus", serde_json::json!({}))
+            .await;
+        match result {
+            Err(msg) => {
+                assert!(msg.contains("Unknown vdd command"));
+                assert!(msg.contains("vdd/bogus"));
+            }
+            Ok(_) => panic!("unknown command must Err"),
+        }
+    }
+
+    /// What this catches: wire-shape stability for the
+    /// VddReportEntry — surfaces the headline VDD fields (tokens/sec,
+    /// first_token_ms, status) AND the source path so consumers can
+    /// fetch the full record on demand. PR-body snippets read these
+    /// directly.
+    #[tokio::test]
+    async fn report_entry_carries_headline_fields_and_source_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            tmp.path(),
+            "sha-w",
+            "chat-roundtrip-live-harness",
+            HarnessStatus::Pass,
+        );
+
+        let module = VddModule::with_root(tmp.path());
+        let result = module
+            .handle_command("vdd/report", serde_json::json!({}))
+            .await
+            .unwrap();
+        let v = match result {
+            CommandResult::Json(v) => v,
+            _ => panic!("expected Json"),
+        };
+        let report: VddReport = serde_json::from_value(v).unwrap();
+        let entry = &report.records[0];
+        assert_eq!(entry.git_sha, "sha-w");
+        assert_eq!(entry.first_token_ms, Some(450));
+        assert_eq!(entry.tok_per_sec, Some(28.6));
+        assert_eq!(entry.status, HarnessStatus::Pass);
+        assert!(
+            entry.source.ends_with("record.jsonl"),
+            "source path points at the on-disk record file"
+        );
+        assert!(
+            report.artifact_root.contains(tmp.path().file_name().unwrap().to_str().unwrap()),
+            "artifact_root surfaces the resolved root path"
+        );
+    }
+}

--- a/src/workers/continuum-core/src/runtime/runtime.rs
+++ b/src/workers/continuum-core/src/runtime/runtime.rs
@@ -42,6 +42,7 @@ pub const EXPECTED_MODULES: &[&str] = &[
     "dataset",           // Dataset import/management for Academy training
     "persona_allocator", // Hardware-aware persona allocation decisions
     "inference-llm",     // Phase 5: local LLM generation (MODULE-CATALOG §II)
+    "vdd",               // Lane C PR-3: VDD report from structured artifacts
 ];
 
 pub struct Runtime {

--- a/src/workers/continuum-core/src/vdd/mod.rs
+++ b/src/workers/continuum-core/src/vdd/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod artifacts;
 pub mod chat_roundtrip;
+pub mod reader;
 pub mod record;
 pub mod registry;
 
@@ -13,5 +14,6 @@ pub use chat_roundtrip::{
     ChatRoundtripConfig, ChatRoundtripHarness, ChatRoundtripObservation, ChatRoundtripProbe,
     LiveChatProbe,
 };
+pub use reader::{latest_per_scenario, read_records, VddReadOptions, VddRecordEntry};
 pub use record::{HarnessStatus, StandardVddRecord, VddError};
 pub use registry::{HARNESS_SPECS, HarnessCadence, HarnessId, HarnessSpec, harness_spec};

--- a/src/workers/continuum-core/src/vdd/reader.rs
+++ b/src/workers/continuum-core/src/vdd/reader.rs
@@ -1,0 +1,434 @@
+//! VDD record reader — walks `~/.continuum/vdd/<git_sha>/<scenario>/`
+//! artifact directories and parses the `record.jsonl` files into
+//! [`StandardVddRecord`] values.
+//!
+//! This is the read side of the artifact-writer (`artifacts.rs`) that the
+//! `chat-roundtrip` harness writes through. The write side ships records
+//! to disk; this side aggregates them back for inspection / reporting.
+//!
+//! Why a separate reader: the harness emits one record per run, but a
+//! "VDD report" is a cross-run aggregation ("here is the latest pass on
+//! Mac, the latest fail on Windows, the regressions since last release"
+//! etc). The reader is the data-access primitive every reporting consumer
+//! shares — the `vdd/report` IPC command is one of them; the precommit
+//! ratchet + the CI dashboards are the next ones.
+
+use crate::vdd::record::{StandardVddRecord, VddError};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+/// Options for filtering records when reading. Empty filters mean
+/// "include everything"; non-empty filters narrow the result set.
+///
+/// Designed so callers can build "show me only Mac chat-roundtrip
+/// records on this commit" queries without re-scanning the whole tree
+/// twice. The reader applies filters at parse time, not after.
+#[derive(Debug, Clone, Default)]
+pub struct VddReadOptions {
+    /// If set, only include records under this git_sha subdirectory.
+    pub git_sha: Option<String>,
+    /// If set, only include records whose `scenario` matches.
+    pub scenario: Option<String>,
+}
+
+/// One entry returned by [`read_records`]: the parsed record + the file
+/// it came from. The file path is included so callers (e.g. the report
+/// IPC command) can surface "from artifacts at <path>" to humans and
+/// LLM-driven CI dashboards alike.
+#[derive(Debug, Clone)]
+pub struct VddRecordEntry {
+    pub record: StandardVddRecord,
+    pub source: PathBuf,
+}
+
+/// Walk the artifact tree under `root` and return every record whose
+/// `record.jsonl` parses cleanly + matches `opts`. Returns entries
+/// sorted by (git_sha, scenario) for deterministic output.
+///
+/// Layout matches what `ArtifactWriter::write` produces:
+///   `<root>/<git_sha>/<scenario>/record.jsonl`
+///
+/// Failure modes:
+/// - `root` does not exist → returns empty Vec (NOT an error — a fresh
+///   install has nothing to report, that's a valid state).
+/// - A `record.jsonl` exists but won't parse → propagates the
+///   `VddError::Json` from serde so the caller surfaces "this artifact
+///   file is corrupt, here's the path" rather than silently dropping
+///   it. Per Joel's never-swallow rule: bad data is loud.
+pub fn read_records(
+    root: impl AsRef<Path>,
+    opts: &VddReadOptions,
+) -> Result<Vec<VddRecordEntry>, VddError> {
+    let root = root.as_ref();
+    // A missing root is not an error — it just means no harness has
+    // written yet. Common on fresh dev machines.
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries: Vec<VddRecordEntry> = Vec::new();
+    for git_sha_dir in read_subdirs(root)? {
+        let git_sha = file_name_string(&git_sha_dir);
+        if let Some(ref want_sha) = opts.git_sha {
+            if &git_sha != want_sha {
+                continue;
+            }
+        }
+        for scenario_dir in read_subdirs(&git_sha_dir)? {
+            let scenario = file_name_string(&scenario_dir);
+            if let Some(ref want_scen) = opts.scenario {
+                if &scenario != want_scen {
+                    continue;
+                }
+            }
+            let record_path = scenario_dir.join("record.jsonl");
+            if !record_path.exists() {
+                // Scenario directory without a record file: skip silently.
+                // The writer always writes record.jsonl, so this is either
+                // a partially-cleaned-up dir or a foreign artifact — not
+                // ours to interpret.
+                continue;
+            }
+            for record in parse_record_jsonl(&record_path)? {
+                entries.push(VddRecordEntry {
+                    record,
+                    source: record_path.clone(),
+                });
+            }
+        }
+    }
+    // Deterministic sort: git_sha then scenario then status. Callers that
+    // need cross-platform comparable output rely on this ordering
+    // (so does the regression-detection logic in CI dashboards).
+    entries.sort_by(|a, b| {
+        (a.record.git_sha.as_str(), a.record.scenario.as_str())
+            .cmp(&(b.record.git_sha.as_str(), b.record.scenario.as_str()))
+    });
+    Ok(entries)
+}
+
+/// Bucket records by `(git_sha, scenario)`. Each bucket carries the
+/// latest record (by file mtime via natural disk order, since the
+/// writer overwrites in place). Useful for reports that want "one
+/// row per scenario on this commit" instead of every historical run.
+pub fn latest_per_scenario(
+    entries: Vec<VddRecordEntry>,
+) -> BTreeMap<(String, String), VddRecordEntry> {
+    let mut by_key: BTreeMap<(String, String), VddRecordEntry> = BTreeMap::new();
+    for entry in entries {
+        let key = (entry.record.git_sha.clone(), entry.record.scenario.clone());
+        by_key.insert(key, entry);
+    }
+    by_key
+}
+
+fn read_subdirs(root: &Path) -> Result<Vec<PathBuf>, VddError> {
+    let read = fs::read_dir(root).map_err(|source| VddError::Io {
+        path: root.to_path_buf(),
+        source,
+    })?;
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    for entry in read {
+        let entry = entry.map_err(|source| VddError::Io {
+            path: root.to_path_buf(),
+            source,
+        })?;
+        let p = entry.path();
+        if p.is_dir() {
+            dirs.push(p);
+        }
+    }
+    dirs.sort();
+    Ok(dirs)
+}
+
+fn file_name_string(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(String::from)
+        // Path components are valid UTF-8 by construction on our writers;
+        // fall back to lossy if somehow not, so the reader doesn't crash
+        // on a foreign-encoded directory name dropped into the artifact
+        // root.
+        .unwrap_or_else(|| path.to_string_lossy().to_string())
+}
+
+fn parse_record_jsonl(path: &Path) -> Result<Vec<StandardVddRecord>, VddError> {
+    let file = fs::File::open(path).map_err(|source| VddError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let reader = BufReader::new(file);
+    let mut records: Vec<StandardVddRecord> = Vec::new();
+    for line in reader.lines() {
+        let line = line.map_err(|source| VddError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let record: StandardVddRecord = serde_json::from_str(trimmed)?;
+        records.push(record);
+    }
+    Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pin the reader contract end-to-end against real on-disk
+    //! artifacts (written by `ArtifactWriter`, the canonical writer).
+    //! Using the real writer in tests catches schema-drift between
+    //! writer and reader at unit-test time, not at "I shipped a VDD
+    //! report and CI dashboards stopped parsing" time.
+    use super::*;
+    use crate::vdd::artifacts::{ArtifactWriter, ReproducibilityManifest};
+    use crate::vdd::record::{HarnessStatus, StandardVddRecord};
+
+    fn sample_record(git_sha: &str, scenario: &str) -> StandardVddRecord {
+        StandardVddRecord {
+            scenario: scenario.to_string(),
+            platform: "darwin".to_string(),
+            hardware: "m1-air-8gb".to_string(),
+            backend: "metal".to_string(),
+            git_sha: git_sha.to_string(),
+            command: "npm start".to_string(),
+            model: Some("qwen2-vl-7b-instruct".to_string()),
+            gpu_layers: Some(32),
+            unsupported_layers: Vec::new(),
+            cold_start_ms: Some(8_000),
+            first_token_ms: Some(450),
+            first_response_ms: Some(1_200),
+            all_responses_ms: Some(3_400),
+            responses_expected: 4,
+            responses_observed: 4,
+            silence_reasons: Vec::new(),
+            tok_per_sec: Some(28.6),
+            cpu_pct_avg: Some(55.0),
+            cpu_pct_peak: Some(98.0),
+            rss_mb: Some(3_120),
+            gpu_util_pct_avg: Some(72.0),
+            gpu_memory_mb: Some(4_800),
+            queue_wait_ms: Some(12),
+            execution_ms: Some(820),
+            coalesced_count: 1,
+            deferred_count: 0,
+            stale_drop_count: 0,
+            error_count: 0,
+            degraded_reason: None,
+            log_refs: vec!["~/.continuum/sessions/.../logs/server.log".to_string()],
+            next_bottleneck: None,
+            policy_version: Some("v1".to_string()),
+            cascade_step: Some(2),
+            status: HarnessStatus::Pass,
+        }
+    }
+
+    /// What this catches: missing artifact root is a normal "fresh
+    /// install, no harness has run yet" state, not an error. Per
+    /// the spec, the reader returns an empty Vec.
+    #[test]
+    fn missing_root_returns_empty_vec_not_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nonexistent = tmp.path().join("never-created");
+
+        let entries = read_records(&nonexistent, &VddReadOptions::default())
+            .expect("missing root is not an error");
+        assert!(entries.is_empty());
+    }
+
+    /// What this catches: an empty artifact root (exists but no
+    /// git_sha subdirs) returns an empty Vec. Same "no data yet"
+    /// shape as missing root, different filesystem state.
+    #[test]
+    fn empty_root_returns_empty_vec() {
+        let tmp = tempfile::tempdir().unwrap();
+        let entries = read_records(tmp.path(), &VddReadOptions::default())
+            .expect("empty root reads cleanly");
+        assert!(entries.is_empty());
+    }
+
+    /// What this catches: a single record round-trips through
+    /// writer → disk → reader. End-to-end format pin against the
+    /// real `ArtifactWriter`.
+    #[test]
+    fn single_record_round_trips_through_writer_reader() {
+        let tmp = tempfile::tempdir().unwrap();
+        let writer = ArtifactWriter::new(tmp.path());
+        let original = sample_record("abc1234", "chat-roundtrip-live-harness");
+        let manifest = ReproducibilityManifest::from_record(&original, &[]);
+        writer.write(&original, &manifest).expect("write succeeds");
+
+        let entries = read_records(tmp.path(), &VddReadOptions::default())
+            .expect("read succeeds");
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry.record.git_sha, "abc1234");
+        assert_eq!(entry.record.scenario, "chat-roundtrip-live-harness");
+        assert_eq!(entry.record.tok_per_sec, Some(28.6));
+        assert_eq!(entry.record.status, HarnessStatus::Pass);
+        // source path points at the actual record.jsonl on disk.
+        assert!(entry.source.ends_with("record.jsonl"));
+    }
+
+    /// What this catches: multiple records under different git_shas
+    /// + scenarios are all discovered + sorted deterministically.
+    #[test]
+    fn multiple_records_discovered_and_sorted_deterministically() {
+        let tmp = tempfile::tempdir().unwrap();
+        let writer = ArtifactWriter::new(tmp.path());
+        // Intentionally write in non-sorted order to verify sort.
+        for (sha, scen) in [
+            ("z9", "chat-roundtrip-live-harness"),
+            ("a1", "vision-smoke"),
+            ("a1", "chat-roundtrip-live-harness"),
+            ("m5", "chat-roundtrip-live-harness"),
+        ] {
+            let r = sample_record(sha, scen);
+            let m = ReproducibilityManifest::from_record(&r, &[]);
+            writer.write(&r, &m).unwrap();
+        }
+
+        let entries = read_records(tmp.path(), &VddReadOptions::default())
+            .expect("read succeeds");
+        let pairs: Vec<(&str, &str)> = entries
+            .iter()
+            .map(|e| (e.record.git_sha.as_str(), e.record.scenario.as_str()))
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![
+                ("a1", "chat-roundtrip-live-harness"),
+                ("a1", "vision-smoke"),
+                ("m5", "chat-roundtrip-live-harness"),
+                ("z9", "chat-roundtrip-live-harness"),
+            ],
+            "entries must sort by (git_sha, scenario) for deterministic reports"
+        );
+    }
+
+    /// What this catches: `git_sha` filter narrows the result set
+    /// to just that commit's records. Used by reports that ask
+    /// "what's the VDD state on HEAD?" without rescanning history.
+    #[test]
+    fn git_sha_filter_narrows_results() {
+        let tmp = tempfile::tempdir().unwrap();
+        let writer = ArtifactWriter::new(tmp.path());
+        for sha in ["sha-a", "sha-b", "sha-c"] {
+            let r = sample_record(sha, "chat-roundtrip-live-harness");
+            let m = ReproducibilityManifest::from_record(&r, &[]);
+            writer.write(&r, &m).unwrap();
+        }
+
+        let opts = VddReadOptions {
+            git_sha: Some("sha-b".to_string()),
+            scenario: None,
+        };
+        let entries = read_records(tmp.path(), &opts).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].record.git_sha, "sha-b");
+    }
+
+    /// What this catches: `scenario` filter works independently of
+    /// git_sha. Reports that ask "show me every commit's
+    /// vision-smoke status" use this.
+    #[test]
+    fn scenario_filter_narrows_results_across_shas() {
+        let tmp = tempfile::tempdir().unwrap();
+        let writer = ArtifactWriter::new(tmp.path());
+        for sha in ["sha-a", "sha-b"] {
+            for scen in ["chat-roundtrip-live-harness", "vision-smoke"] {
+                let r = sample_record(sha, scen);
+                let m = ReproducibilityManifest::from_record(&r, &[]);
+                writer.write(&r, &m).unwrap();
+            }
+        }
+
+        let opts = VddReadOptions {
+            git_sha: None,
+            scenario: Some("vision-smoke".to_string()),
+        };
+        let entries = read_records(tmp.path(), &opts).unwrap();
+        assert_eq!(entries.len(), 2);
+        for e in &entries {
+            assert_eq!(e.record.scenario, "vision-smoke");
+        }
+    }
+
+    /// What this catches: `latest_per_scenario` collapses duplicate
+    /// (git_sha, scenario) pairs to a single entry. Used by report
+    /// queries that want one row per scenario per commit.
+    #[test]
+    fn latest_per_scenario_collapses_duplicates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let writer = ArtifactWriter::new(tmp.path());
+
+        // First write: PASS.
+        let mut r = sample_record("sha-x", "chat-roundtrip-live-harness");
+        r.status = HarnessStatus::Pass;
+        let m = ReproducibilityManifest::from_record(&r, &[]);
+        writer.write(&r, &m).unwrap();
+
+        // Second write to the same (git_sha, scenario): FAIL.
+        // Writer overwrites in place; reader sees the latest.
+        let mut r2 = sample_record("sha-x", "chat-roundtrip-live-harness");
+        r2.status = HarnessStatus::Fail;
+        r2.silence_reasons = vec!["model_load_timeout".to_string()];
+        let m2 = ReproducibilityManifest::from_record(&r2, &[]);
+        writer.write(&r2, &m2).unwrap();
+
+        let entries = read_records(tmp.path(), &VddReadOptions::default()).unwrap();
+        let latest = latest_per_scenario(entries);
+        assert_eq!(latest.len(), 1);
+        let entry = latest
+            .get(&("sha-x".to_string(), "chat-roundtrip-live-harness".to_string()))
+            .expect("scenario present");
+        assert_eq!(entry.record.status, HarnessStatus::Fail);
+        assert_eq!(entry.record.silence_reasons, vec!["model_load_timeout"]);
+    }
+
+    /// What this catches: a corrupt `record.jsonl` produces a typed
+    /// VddError::Json with the parse failure, NOT silent omission.
+    /// Per Joel's never-swallow rule: bad data is loud.
+    #[test]
+    fn corrupt_record_returns_typed_json_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sha-x").join("scen-x");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("record.jsonl"), "{not valid json").unwrap();
+
+        let result = read_records(tmp.path(), &VddReadOptions::default());
+        match result {
+            Err(VddError::Json(_)) => { /* expected */ }
+            Ok(v) => panic!("corrupt jsonl must error, got {} entries", v.len()),
+            Err(e) => panic!("expected Json error, got: {e}"),
+        }
+    }
+
+    /// What this catches: scenario directory without a record.jsonl
+    /// is skipped silently (NOT an error). This is the partially-
+    /// cleaned-up-dir case; the writer's invariant is "directory
+    /// only exists if it has record.jsonl," but external cleanup
+    /// scripts can leave the directory behind.
+    #[test]
+    fn scenario_dir_without_record_jsonl_is_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let writer = ArtifactWriter::new(tmp.path());
+
+        // Valid record.
+        let r = sample_record("sha-real", "chat-roundtrip-live-harness");
+        let m = ReproducibilityManifest::from_record(&r, &[]);
+        writer.write(&r, &m).unwrap();
+
+        // Empty scenario dir (no record.jsonl).
+        let empty_dir = tmp.path().join("sha-empty").join("partial-cleanup");
+        fs::create_dir_all(&empty_dir).unwrap();
+
+        let entries = read_records(tmp.path(), &VddReadOptions::default()).unwrap();
+        assert_eq!(entries.len(), 1, "only the real record is returned");
+        assert_eq!(entries[0].record.git_sha, "sha-real");
+    }
+}


### PR DESCRIPTION
## Closes ALPHA-GAP-ANALYSIS Lane C PR-3

Line 199: *\"the vdd-report-command step (Lane C PR sequence step 3) is not yet bound. As a result, 'VDD' is still mostly read from logs rather than from a single command's structured output.\"*

Line 1128: *\"Bind Lane C vdd-report-command. Still open. Structured RuntimeMetric events already emit from inference paths, but VDD is still read from logs because the report command was not bound. Small; unblocks every PR's 'VDD: tokens/sec improved from X → Y' claim.\"*

## What this ships (one PR, per Joel's \"stop the 4-PR ceremony\" calibration)

- **\`src/vdd/reader.rs\`** (new): pure read primitive walking \`~/.continuum/vdd/<sha>/<scenario>/record.jsonl\` artifacts
- **\`src/modules/vdd.rs\`** (new): \`VddModule\` + \`vdd/report\` IPC command consuming the reader
- **\`src/modules/mod.rs\`**: registers the new module file
- **\`src/runtime/runtime.rs\`**: adds \`\"vdd\"\` to \`EXPECTED_MODULES\`
- **\`src/ipc/mod.rs\`**: registers \`VddModule\` with the Runtime
- **\`src/vdd/mod.rs\`**: barrel exports

## \`vdd/report\` wire shape

Params (optional):
- \`git_sha\`: narrow to one commit's records
- \`scenario\`: narrow to one scenario across commits
- \`latest_only\`: collapse to one row per (git_sha, scenario)

Returns camelCase JSON:
\`\`\`
{
  artifactRoot, filters, summary: { total, passed, failed, prerequisiteMissing },
  records: [{ gitSha, scenario, status, firstTokenMs, tokPerSec, ..., source }]
}
\`\`\`

## Tests (+16, all green)

\`vdd::reader\` (9 tests): missing root → empty Vec (fresh-install valid state), single-record round-trip against real \`ArtifactWriter\`, multi-record deterministic sort, git_sha + scenario filters, latest_per_scenario collapse, corrupt-jsonl → typed Err (never-swallow rule), partially-cleaned scenario-dir skipped.

\`modules::vdd::tests\` (7 tests): config name + prefix, empty report path, status aggregation (pass/fail/prereq_missing), git_sha filter + filter-echo, latest_only collapse, unknown command → loud Err, wire-shape stability for VddReportEntry.

## Validation

\`\`\`
cd src/workers/continuum-core
cargo test --features metal,accelerate --lib modules::vdd vdd::reader
\`\`\`

Local: 16/16 pass. **Precommit chat-roundtrip passed** (Lane A #1424 fix landed before this PR opened — first commit on this branch sees the working substrate).

## What this doesn't ship

- Cross-PR regression detection (\`mode: \"regression\"\`); separate PR builds on this primitive
- Live RuntimeMetric subscription path (Lane C PR-1/PR-2 prereqs); this command reads what the harness has already written
- No TS-side log-scraping scripts found via grep — nothing to delete

PR-body VDD claims become \`./jtag vdd/report --git_sha=<sha>\` instead of pasted terminal text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)