### PR TITLE
refactor(ipc): split mod.rs (1288 LOC) — extract protocol + diagnostics to sibling files

### DIFF
--- a/src/workers/continuum-core/src/ipc/diagnostics.rs
+++ b/src/workers/continuum-core/src/ipc/diagnostics.rs
@@ -1,0 +1,102 @@
+//! Per-command RSS tracking — surfaces which IPC commands leak memory.
+//!
+//! Split out of `ipc/mod.rs` (was 1288 LOC single-file dir, parallel-dir
+//! smell flagged in claude-tab-1's audit broadcast 2026-05-18 19:40Z).
+//! Pure observability — no behavioral wire impact. mod.rs callers use
+//! the `pub(crate)` API to record + dump.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Get current process RSS in MB using macOS task_info API.
+/// Returns actual resident memory (not peak like getrusage ru_maxrss).
+#[cfg(target_os = "macos")]
+pub(crate) fn current_rss_mb() -> u64 {
+    #[repr(C)]
+    struct MachTaskBasicInfo {
+        virtual_size: u64,
+        resident_size: u64,
+        resident_size_max: u64,
+        user_time_seconds: u32,
+        user_time_microseconds: u32,
+        system_time_seconds: u32,
+        system_time_microseconds: u32,
+        policy: i32,
+        suspend_count: i32,
+    }
+
+    extern "C" {
+        fn mach_task_self() -> u32;
+        fn task_info(
+            target_task: u32,
+            flavor: u32,
+            task_info: *mut MachTaskBasicInfo,
+            task_info_count: *mut u32,
+        ) -> i32;
+    }
+
+    const MACH_TASK_BASIC_INFO: u32 = 20;
+
+    unsafe {
+        let mut info: MachTaskBasicInfo = std::mem::zeroed();
+        let mut count =
+            (std::mem::size_of::<MachTaskBasicInfo>() / std::mem::size_of::<u32>()) as u32;
+        let kr = task_info(
+            mach_task_self(),
+            MACH_TASK_BASIC_INFO,
+            &mut info,
+            &mut count,
+        );
+        if kr == 0 {
+            info.resident_size / (1024 * 1024)
+        } else {
+            0
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn current_rss_mb() -> u64 {
+    0 // No-op on non-macOS
+}
+
+/// Periodic RSS reporter — logs every 10s so we can see growth trends.
+/// Also tracks per-command cumulative deltas to identify the leaker.
+static COMMAND_MEMORY_DELTAS: once_cell::sync::Lazy<Mutex<HashMap<String, i64>>> =
+    once_cell::sync::Lazy::new(|| Mutex::new(HashMap::new()));
+
+pub(crate) fn log_command_rss_delta(command: &str, before_mb: u64, after_mb: u64) {
+    let delta = after_mb as i64 - before_mb as i64;
+    if delta > 0 {
+        // Accumulate per-command
+        if let Ok(mut map) = COMMAND_MEMORY_DELTAS.lock() {
+            *map.entry(command.to_string()).or_insert(0) += delta;
+        }
+    }
+    // Log commands with >2MB growth per call
+    if delta > 2 {
+        eprintln!(
+            "[MEMLEAK] RSS +{}MB after '{}' ({}MB → {}MB)",
+            delta, command, before_mb, after_mb
+        );
+    }
+}
+
+/// Dump accumulated memory deltas — call periodically to see which commands leak.
+pub(crate) fn dump_memory_report() {
+    let rss = current_rss_mb();
+    if let Ok(map) = COMMAND_MEMORY_DELTAS.lock() {
+        if map.is_empty() {
+            eprintln!("[MEMLEAK] RSS={}MB, no command deltas yet", rss);
+            return;
+        }
+        let mut entries: Vec<_> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1));
+        let top: Vec<String> = entries
+            .iter()
+            .take(10)
+            .map(|(cmd, delta)| format!("{}:+{}MB", cmd, delta))
+            .collect();
+        eprintln!("[MEMLEAK] RSS={}MB | Top leakers: {}", rss, top.join(", "));
+    }
+}

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -44,13 +44,11 @@ use crate::runtime::{CommandResult, Runtime};
 use crate::system_resources::SystemResourceMonitor;
 use crate::{log_debug, log_error, log_info};
 use dashmap::DashMap;
-use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::sync::Arc;
-use ts_rs::TS;
 use uuid::Uuid;
 
 fn prepare_unix_socket_path(socket_path: &str) -> std::io::Result<()> {
@@ -100,172 +98,21 @@ impl IpcStream for TcpStream {
 }
 
 // ============================================================================
-// Request/Response Protocol
+// Request/Response Protocol + Memory Diagnostics
 // ============================================================================
+// Split out of this file 2026-05-18 — see ipc/protocol.rs (InboxMessageRequest,
+// Response) and ipc/diagnostics.rs (per-command RSS tracking). Re-exported
+// here so existing call sites resolve unchanged.
 
-/// Inbox message for IPC (mirrors InboxMessage but with string UUIDs for JSON transport)
-#[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(
-    export,
-    export_to = "../../../shared/generated/ipc/InboxMessageRequest.ts"
-)]
-pub struct InboxMessageRequest {
-    pub id: String,
-    pub room_id: String,
-    pub sender_id: String,
-    pub sender_name: String,
-    pub sender_type: String, // "human", "persona", "agent", "system"
-    pub content: String,
-    /// Timestamp in milliseconds (fits in JS number, max safe ~9 quadrillion)
-    #[ts(type = "number")]
-    pub timestamp: u64,
-    pub priority: f32,
-    #[ts(optional)]
-    pub source_modality: Option<String>, // "chat", "voice"
-    #[ts(optional)]
-    pub voice_session_id: Option<String>,
-}
+pub mod diagnostics;
+pub mod protocol;
 
-// NOTE: InboxMessageRequest is used for ts-rs TypeScript generation.
-// The to_inbox_message() method was removed when migrating to CognitionModule.
-// See modules/cognition.rs for the parsing logic.
+pub use protocol::InboxMessageRequest;
+use diagnostics::{current_rss_mb, dump_memory_report, log_command_rss_delta};
+use protocol::Response;
 
-// All commands route through ServiceModule implementations in src/modules/.
-
-// ============================================================================
-// Memory Diagnostics — track RSS per IPC command to find leaks
-// ============================================================================
-
-/// Get current process RSS in MB using macOS task_info API.
-/// Returns actual resident memory (not peak like getrusage ru_maxrss).
-#[cfg(target_os = "macos")]
-fn current_rss_mb() -> u64 {
-    #[repr(C)]
-    struct MachTaskBasicInfo {
-        virtual_size: u64,
-        resident_size: u64,
-        resident_size_max: u64,
-        user_time_seconds: u32,
-        user_time_microseconds: u32,
-        system_time_seconds: u32,
-        system_time_microseconds: u32,
-        policy: i32,
-        suspend_count: i32,
-    }
-
-    extern "C" {
-        fn mach_task_self() -> u32;
-        fn task_info(
-            target_task: u32,
-            flavor: u32,
-            task_info: *mut MachTaskBasicInfo,
-            task_info_count: *mut u32,
-        ) -> i32;
-    }
-
-    const MACH_TASK_BASIC_INFO: u32 = 20;
-
-    unsafe {
-        let mut info: MachTaskBasicInfo = std::mem::zeroed();
-        let mut count =
-            (std::mem::size_of::<MachTaskBasicInfo>() / std::mem::size_of::<u32>()) as u32;
-        let kr = task_info(
-            mach_task_self(),
-            MACH_TASK_BASIC_INFO,
-            &mut info,
-            &mut count,
-        );
-        if kr == 0 {
-            info.resident_size / (1024 * 1024)
-        } else {
-            0
-        }
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-fn current_rss_mb() -> u64 {
-    0 // No-op on non-macOS
-}
-
-use std::collections::HashMap;
-/// Periodic RSS reporter — logs every 10s so we can see growth trends.
-/// Also tracks per-command cumulative deltas to identify the leaker.
-use std::sync::Mutex;
-static COMMAND_MEMORY_DELTAS: once_cell::sync::Lazy<Mutex<HashMap<String, i64>>> =
-    once_cell::sync::Lazy::new(|| Mutex::new(HashMap::new()));
-
-fn log_command_rss_delta(command: &str, before_mb: u64, after_mb: u64) {
-    let delta = after_mb as i64 - before_mb as i64;
-    if delta > 0 {
-        // Accumulate per-command
-        if let Ok(mut map) = COMMAND_MEMORY_DELTAS.lock() {
-            *map.entry(command.to_string()).or_insert(0) += delta;
-        }
-    }
-    // Log commands with >2MB growth per call
-    if delta > 2 {
-        eprintln!(
-            "[MEMLEAK] RSS +{}MB after '{}' ({}MB → {}MB)",
-            delta, command, before_mb, after_mb
-        );
-    }
-}
-
-/// Dump accumulated memory deltas — call periodically to see which commands leak.
-fn dump_memory_report() {
-    let rss = current_rss_mb();
-    if let Ok(map) = COMMAND_MEMORY_DELTAS.lock() {
-        if map.is_empty() {
-            eprintln!("[MEMLEAK] RSS={}MB, no command deltas yet", rss);
-            return;
-        }
-        let mut entries: Vec<_> = map.iter().collect();
-        entries.sort_by(|a, b| b.1.cmp(a.1));
-        let top: Vec<String> = entries
-            .iter()
-            .take(10)
-            .map(|(cmd, delta)| format!("{}:+{}MB", cmd, delta))
-            .collect();
-        eprintln!("[MEMLEAK] RSS={}MB | Top leakers: {}", rss, top.join(", "));
-    }
-}
 // See modules/health.rs, cognition.rs, channel.rs, voice.rs, code.rs, memory.rs,
 // models.rs, data.rs, logger.rs, search.rs, embedding.rs, rag.rs for command handlers.
-
-#[derive(Debug, Serialize, Deserialize)]
-struct Response {
-    success: bool,
-    result: Option<serde_json::Value>,
-    error: Option<String>,
-    #[serde(rename = "requestId")]
-    request_id: Option<u64>,
-}
-
-impl Response {
-    fn success(result: serde_json::Value) -> Self {
-        Self {
-            success: true,
-            result: Some(result),
-            error: None,
-            request_id: None,
-        }
-    }
-
-    fn error(msg: String) -> Self {
-        Self {
-            success: false,
-            result: None,
-            error: Some(msg),
-            request_id: None,
-        }
-    }
-
-    fn with_request_id(mut self, request_id: Option<u64>) -> Self {
-        self.request_id = request_id;
-        self
-    }
-}
 
 // ============================================================================
 // IPC Server State

--- a/src/workers/continuum-core/src/ipc/protocol.rs
+++ b/src/workers/continuum-core/src/ipc/protocol.rs
@@ -1,0 +1,76 @@
+//! IPC protocol types — request/response surface shared by every command.
+//!
+//! Split out of `ipc/mod.rs` (was 1288 LOC single-file dir, parallel-dir
+//! smell flagged in claude-tab-1's audit broadcast 2026-05-18 19:40Z).
+//! Per Joel's zero-users no-migration-ceremony directive, no separate
+//! re-export ceremony — `ipc/mod.rs` `pub use`s these types so existing
+//! call sites resolve unchanged.
+
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+/// Inbox message for IPC (mirrors InboxMessage but with string UUIDs for
+/// JSON transport).
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(
+    export,
+    export_to = "../../../shared/generated/ipc/InboxMessageRequest.ts"
+)]
+pub struct InboxMessageRequest {
+    pub id: String,
+    pub room_id: String,
+    pub sender_id: String,
+    pub sender_name: String,
+    pub sender_type: String, // "human", "persona", "agent", "system"
+    pub content: String,
+    /// Timestamp in milliseconds (fits in JS number, max safe ~9 quadrillion)
+    #[ts(type = "number")]
+    pub timestamp: u64,
+    pub priority: f32,
+    #[ts(optional)]
+    pub source_modality: Option<String>, // "chat", "voice"
+    #[ts(optional)]
+    pub voice_session_id: Option<String>,
+}
+
+// NOTE: InboxMessageRequest is used for ts-rs TypeScript generation.
+// The to_inbox_message() method was removed when migrating to CognitionModule.
+// See modules/cognition.rs for the parsing logic.
+
+// All commands route through ServiceModule implementations in src/modules/.
+
+/// Wire response for every command. `request_id` round-trips to let
+/// the TS client correlate concurrent requests.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Response {
+    pub(crate) success: bool,
+    pub(crate) result: Option<serde_json::Value>,
+    pub(crate) error: Option<String>,
+    #[serde(rename = "requestId")]
+    pub(crate) request_id: Option<u64>,
+}
+
+impl Response {
+    pub(crate) fn success(result: serde_json::Value) -> Self {
+        Self {
+            success: true,
+            result: Some(result),
+            error: None,
+            request_id: None,
+        }
+    }
+
+    pub(crate) fn error(msg: String) -> Self {
+        Self {
+            success: false,
+            result: None,
+            error: Some(msg),
+            request_id: None,
+        }
+    }
+
+    pub(crate) fn with_request_id(mut self, request_id: Option<u64>) -> Self {
+        self.request_id = request_id;
+        self
+    }
+}


### PR DESCRIPTION
## Summary

`ipc/` was a single-file module dir — `mod.rs` at 1288 LOC mixing wire protocol, memory diagnostics, server state, connection handler, tests, and server lifecycle in one file. Flagged in claude-tab-1's broad-code audit broadcast 2026-05-18 19:40Z (_"ipc/mod.rs 1288 LOC AND it is the ONLY file in ipc/"_).

Per Joel's zero-users no-migration-ceremony directive, ONE PR cuts the size + re-exports moved types so call sites resolve unchanged.

## What changes

- **New `ipc/protocol.rs`** — `InboxMessageRequest` (ts-rs) + internal `Response` struct
- **New `ipc/diagnostics.rs`** — per-command RSS tracking (`current_rss_mb`, `log_command_rss_delta`, `dump_memory_report`). Pure observability, no wire impact.
- **`ipc/mod.rs`** shrinks from **1288 → ~1135 LOC**; declares the two new submodules + re-exports `InboxMessageRequest` so existing `crate::ipc::InboxMessageRequest` resolves unchanged.
- Removed now-unused `serde::{Deserialize, Serialize}` + `ts_rs::TS` imports from mod.rs.

## What stays in mod.rs (deliberately)

- `ServerState` struct + all module Arc references — too tightly coupled to `start_server` to extract in one PR.
- Connection handler (binary framing + dispatch loop) — needs the module Arc references in scope.
- `start_server` lifecycle.
- Inline `#[cfg(test)]` tests for binary framing.

## Discipline

- Zero behavior change. Pure file-shape refactor.
- All visibility preserved: `pub use protocol::InboxMessageRequest` in mod.rs ensures external callers (TS bindings, generated barrel) see the type at the same path.
- `Response` stays `pub(crate)` (was private in mod.rs; module boundary requires `pub(crate)` so connection handler can use it).
- Clippy held at 157 baseline.

## Verification

- [x] `cargo check --lib --features metal,accelerate` — clean
- [x] `cargo test --lib --features metal,accelerate ipc::` — 9/9 pass
- [x] `cargo clippy --lib --features metal,accelerate` — 157 baseline
- [x] Pre-push hook green
- [ ] CI

## Refs

- claude-tab-1 broad-code-audit broadcast 2026-05-18 19:40Z
- Joel 2026-05-18 19:44Z (zero-users, full-blown Rust-driven dev, no migration ceremony)

🤖 Generated with [Claude Code](https://claude.com/claude-code)