### PR TITLE
substrate(d8a69c65): retype AircRealtimeEnvelope room_id String -> Uuid

### DIFF
--- a/src/workers/continuum-core/src/airc/event_transport.rs
+++ b/src/workers/continuum-core/src/airc/event_transport.rs
@@ -54,14 +54,16 @@ mod tests {
         InMemoryAircRealtimeStore,
     };
     use serde_json::json;
+    use uuid::Uuid;
 
     #[test]
     fn store_transport_round_trips_without_cli_output_parsing() {
         let transport =
             StoreAircEventTransport::new(Arc::new(InMemoryAircRealtimeStore::default()));
+        let room_id = Uuid::from_u128(0xA1);
         let envelope = AircRealtimeEnvelope::new(
             "evt-1".to_string(),
-            "general".to_string(),
+            room_id,
             "continuum".to_string(),
             100,
             AircRealtimePayload::ExistingSchema {
@@ -79,7 +81,7 @@ mod tests {
 
         let replay = transport
             .replay(AircRealtimeReplayParams {
-                room_id: "general".to_string(),
+                room_id,
                 after_event_id: None,
                 limit: Some(10),
                 include_presence: None,

--- a/src/workers/continuum-core/src/airc/realtime.rs
+++ b/src/workers/continuum-core/src/airc/realtime.rs
@@ -8,6 +8,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ts_rs::TS;
+use uuid::Uuid;
 
 /// Delivery handling requested from the AIRC substrate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
@@ -138,7 +139,8 @@ impl AircPresenceState {
     export_to = "../../../shared/generated/airc/AircPresenceEvent.ts"
 )]
 pub struct AircPresenceEvent {
-    pub room_id: String,
+    #[ts(type = "string")]
+    pub room_id: Uuid,
     pub subject_id: String,
     #[ts(optional)]
     pub display_name: Option<String>,
@@ -197,7 +199,8 @@ pub enum AircSubscriptionAction {
     export_to = "../../../shared/generated/airc/AircReplayCursor.ts"
 )]
 pub struct AircReplayCursor {
-    pub room_id: String,
+    #[ts(type = "string")]
+    pub room_id: Uuid,
     pub last_seen_event_id: String,
     #[ts(optional)]
     pub last_seen_at_ms: Option<u64>,
@@ -212,7 +215,8 @@ pub struct AircReplayCursor {
 )]
 pub struct AircSubscriptionEvent {
     pub action: AircSubscriptionAction,
-    pub room_id: String,
+    #[ts(type = "string")]
+    pub room_id: Uuid,
     pub subscriber_id: String,
     pub topic: String,
     #[ts(optional)]
@@ -285,7 +289,8 @@ pub struct AircPeerManifest {
     pub peer_id: String,
     #[ts(optional)]
     pub display_name: Option<String>,
-    pub room_ids: Vec<String>,
+    #[ts(type = "Array<string>")]
+    pub room_ids: Vec<Uuid>,
     pub capabilities: Vec<AircPeerCapability>,
     pub advertised_at_ms: u64,
     #[ts(optional)]
@@ -303,8 +308,8 @@ impl AircPeerManifest {
             .unwrap_or(false)
     }
 
-    pub fn advertises_room(&self, room_id: &str) -> bool {
-        self.room_ids.iter().any(|candidate| candidate == room_id)
+    pub fn advertises_room(&self, room_id: Uuid) -> bool {
+        self.room_ids.contains(&room_id)
     }
 }
 
@@ -361,7 +366,8 @@ impl AircRealtimePayload {
 )]
 pub struct AircRealtimeEnvelope {
     pub event_id: String,
-    pub room_id: String,
+    #[ts(type = "string")]
+    pub room_id: Uuid,
     pub source_id: String,
     #[ts(optional)]
     pub target_id: Option<String>,
@@ -375,7 +381,7 @@ pub struct AircRealtimeEnvelope {
 impl AircRealtimeEnvelope {
     pub fn new(
         event_id: String,
-        room_id: String,
+        room_id: Uuid,
         source_id: String,
         created_at_ms: u64,
         payload: AircRealtimePayload,
@@ -413,8 +419,9 @@ mod tests {
 
     #[test]
     fn typing_presence_is_ephemeral_and_expirable() {
+        let room_id = Uuid::from_u128(0xA1);
         let event = AircPresenceEvent {
-            room_id: "general".to_string(),
+            room_id,
             subject_id: "persona-1".to_string(),
             display_name: None,
             state: AircPresenceState::Typing,
@@ -426,7 +433,10 @@ mod tests {
         assert_eq!(event.delivery(), AircRealtimeDelivery::EphemeralCoalesced);
         assert!(!event.is_expired_at(3999));
         assert!(event.is_expired_at(4000));
-        assert_eq!(event.coalesce_key(), "presence:general:persona-1:typing");
+        assert_eq!(
+            event.coalesce_key(),
+            format!("presence:{room_id}:persona-1:typing")
+        );
     }
 
     #[test]
@@ -464,10 +474,13 @@ mod tests {
 
     #[test]
     fn peer_manifest_is_ephemeral_room_scoped_capability_advertisement() {
+        let general = Uuid::from_u128(0xA1);
+        let cambriantech = Uuid::from_u128(0xA2);
+        let useideem = Uuid::from_u128(0xA3);
         let manifest = AircPeerManifest {
             peer_id: "peer-continuum-1".to_string(),
             display_name: Some("Continuum GPU Host".to_string()),
-            room_ids: vec!["general".to_string(), "cambriantech".to_string()],
+            room_ids: vec![general, cambriantech],
             capabilities: vec![AircPeerCapability {
                 id: "continuum.lora.invoke".to_string(),
                 label: Some("LoRA invocation".to_string()),
@@ -478,8 +491,8 @@ mod tests {
         };
 
         assert_eq!(manifest.coalesce_key(), "peer_manifest:peer-continuum-1");
-        assert!(manifest.advertises_room("general"));
-        assert!(!manifest.advertises_room("useideem"));
+        assert!(manifest.advertises_room(general));
+        assert!(!manifest.advertises_room(useideem));
         assert!(!manifest.is_expired_at(9_999));
         assert!(manifest.is_expired_at(10_000));
 
@@ -500,7 +513,7 @@ mod tests {
 
         let mut envelope = AircRealtimeEnvelope::new(
             "receipt-1".to_string(),
-            "general".to_string(),
+            Uuid::from_u128(0xA1),
             "peer-1".to_string(),
             11,
             payload,

--- a/src/workers/continuum-core/src/airc/realtime_store.rs
+++ b/src/workers/continuum-core/src/airc/realtime_store.rs
@@ -12,6 +12,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use ts_rs::TS;
+use uuid::Uuid;
 
 pub const DEFAULT_ROOM_REPLAY_LIMIT: usize = 100;
 pub const MAX_ROOM_REPLAY_LIMIT: usize = 500;
@@ -36,7 +37,8 @@ pub struct AircRealtimePublishParams {
 pub struct AircRealtimePublishResult {
     pub ok: bool,
     pub event_id: String,
-    pub room_id: String,
+    #[ts(type = "string")]
+    pub room_id: Uuid,
     pub delivery: AircRealtimeDelivery,
     pub stored_for_replay: bool,
     #[ts(optional)]
@@ -54,7 +56,8 @@ pub struct AircRealtimePublishResult {
     export_to = "../../../shared/generated/airc/AircRealtimeReplayParams.ts"
 )]
 pub struct AircRealtimeReplayParams {
-    pub room_id: String,
+    #[ts(type = "string")]
+    pub room_id: Uuid,
     #[ts(optional)]
     pub after_event_id: Option<String>,
     #[ts(optional)]
@@ -89,7 +92,8 @@ pub struct AircCapabilityIndexEntry {
     export_to = "../../../shared/generated/airc/AircRealtimeReplayResult.ts"
 )]
 pub struct AircRealtimeReplayResult {
-    pub room_id: String,
+    #[ts(type = "string")]
+    pub room_id: Uuid,
     pub events: Vec<AircRealtimeEnvelope>,
     #[ts(optional)]
     pub cursor: Option<AircReplayCursor>,
@@ -115,7 +119,7 @@ pub struct InMemoryAircRealtimeStore {
 
 #[derive(Debug, Default)]
 struct AircRealtimeState {
-    rooms: HashMap<String, VecDeque<AircRealtimeEnvelope>>,
+    rooms: HashMap<Uuid, VecDeque<AircRealtimeEnvelope>>,
     presence: HashMap<String, AircRealtimeEnvelope>,
     peer_manifests: HashMap<String, AircRealtimeEnvelope>,
     subscriptions: HashMap<String, AircSubscriptionEvent>,
@@ -142,13 +146,13 @@ impl AircRealtimeStore for InMemoryAircRealtimeStore {
         params: AircRealtimePublishParams,
     ) -> Result<AircRealtimePublishResult, String> {
         let envelope = params.envelope;
-        validate_room_id(&envelope.room_id)?;
+        validate_room_id(envelope.room_id)?;
         envelope.validate_delivery()?;
 
         let mut state = self.inner.lock();
         state.prune_expired_presence(envelope.created_at_ms);
 
-        let room_id = envelope.room_id.clone();
+        let room_id = envelope.room_id;
         let event_id = envelope.event_id.clone();
         let delivery = envelope.delivery;
         let mut coalesced_presence_key = None;
@@ -184,9 +188,9 @@ impl AircRealtimeStore for InMemoryAircRealtimeStore {
             .get(&room_id)
             .map(VecDeque::len)
             .unwrap_or_default();
-        let active_presence_count = state.active_presence_for_room(&room_id).len();
-        let active_subscription_count = state.active_subscriptions_for_room(&room_id).len();
-        let active_peer_manifest_count = state.active_peer_manifests_for_room(&room_id).len();
+        let active_presence_count = state.active_presence_for_room(room_id).len();
+        let active_subscription_count = state.active_subscriptions_for_room(room_id).len();
+        let active_peer_manifest_count = state.active_peer_manifests_for_room(room_id).len();
 
         Ok(AircRealtimePublishResult {
             ok: true,
@@ -203,7 +207,7 @@ impl AircRealtimeStore for InMemoryAircRealtimeStore {
     }
 
     fn replay(&self, params: AircRealtimeReplayParams) -> Result<AircRealtimeReplayResult, String> {
-        validate_room_id(&params.room_id)?;
+        validate_room_id(params.room_id)?;
 
         let limit = params
             .limit
@@ -214,27 +218,27 @@ impl AircRealtimeStore for InMemoryAircRealtimeStore {
             state.prune_expired_presence(now_ms);
         }
 
-        let events = state.replay_room(&params.room_id, params.after_event_id.as_deref(), limit);
+        let events = state.replay_room(params.room_id, params.after_event_id.as_deref(), limit);
         let cursor = events.last().map(|event| AircReplayCursor {
-            room_id: params.room_id.clone(),
+            room_id: params.room_id,
             last_seen_event_id: event.event_id.clone(),
             last_seen_at_ms: Some(event.created_at_ms),
         });
         let active_presence = if params.include_presence.unwrap_or(false) {
             state
-                .active_presence_for_room(&params.room_id)
+                .active_presence_for_room(params.room_id)
                 .into_iter()
                 .collect()
         } else {
             Vec::new()
         };
         let active_subscriptions = if params.include_subscriptions.unwrap_or(false) {
-            state.active_subscriptions_for_room(&params.room_id)
+            state.active_subscriptions_for_room(params.room_id)
         } else {
             Vec::new()
         };
         let active_peer_manifests = if params.include_peer_manifests.unwrap_or(false) {
-            state.active_peer_manifests_for_room(&params.room_id)
+            state.active_peer_manifests_for_room(params.room_id)
         } else {
             Vec::new()
         };
@@ -258,7 +262,7 @@ impl AircRealtimeStore for InMemoryAircRealtimeStore {
 
 impl AircRealtimeState {
     fn push_replay(&mut self, envelope: AircRealtimeEnvelope, max_events_per_room: usize) {
-        let room = self.rooms.entry(envelope.room_id.clone()).or_default();
+        let room = self.rooms.entry(envelope.room_id).or_default();
         room.push_back(envelope);
         while room.len() > max_events_per_room {
             room.pop_front();
@@ -267,11 +271,11 @@ impl AircRealtimeState {
 
     fn replay_room(
         &self,
-        room_id: &str,
+        room_id: Uuid,
         after_event_id: Option<&str>,
         limit: usize,
     ) -> Vec<AircRealtimeEnvelope> {
-        let Some(room) = self.rooms.get(room_id) else {
+        let Some(room) = self.rooms.get(&room_id) else {
             return Vec::new();
         };
         let start = after_event_id
@@ -281,7 +285,7 @@ impl AircRealtimeState {
         room.iter().skip(start).take(limit).cloned().collect()
     }
 
-    fn active_presence_for_room(&self, room_id: &str) -> Vec<AircPresenceEvent> {
+    fn active_presence_for_room(&self, room_id: Uuid) -> Vec<AircPresenceEvent> {
         self.presence
             .values()
             .filter(|envelope| envelope.room_id == room_id)
@@ -305,7 +309,7 @@ impl AircRealtimeState {
         }
     }
 
-    fn active_subscriptions_for_room(&self, room_id: &str) -> Vec<AircSubscriptionEvent> {
+    fn active_subscriptions_for_room(&self, room_id: Uuid) -> Vec<AircSubscriptionEvent> {
         let mut subscriptions = self
             .subscriptions
             .values()
@@ -320,7 +324,7 @@ impl AircRealtimeState {
         subscriptions
     }
 
-    fn active_peer_manifests_for_room(&self, room_id: &str) -> Vec<AircPeerManifest> {
+    fn active_peer_manifests_for_room(&self, room_id: Uuid) -> Vec<AircPeerManifest> {
         let mut manifests = self
             .peer_manifests
             .values()
@@ -373,9 +377,9 @@ fn capability_index_for_manifests(manifests: &[AircPeerManifest]) -> Vec<AircCap
     entries
 }
 
-fn validate_room_id(room_id: &str) -> Result<(), String> {
-    if room_id.trim().is_empty() {
-        Err("room_id must not be empty".to_string())
+fn validate_room_id(room_id: Uuid) -> Result<(), String> {
+    if room_id.is_nil() {
+        Err("room_id must not be the nil UUID".to_string())
     } else {
         Ok(())
     }
@@ -390,10 +394,14 @@ mod tests {
     };
     use serde_json::json;
 
-    fn durable_event(id: &str, room: &str, created_at_ms: u64) -> AircRealtimeEnvelope {
+    const GENERAL: Uuid = Uuid::from_u128(0xA1);
+    const CAMBRIANTECH: Uuid = Uuid::from_u128(0xA2);
+    const OTHER: Uuid = Uuid::from_u128(0xA3);
+
+    fn durable_event(id: &str, room: Uuid, created_at_ms: u64) -> AircRealtimeEnvelope {
         AircRealtimeEnvelope::new(
             id.to_string(),
-            room.to_string(),
+            room,
             "node-a".to_string(),
             created_at_ms,
             AircRealtimePayload::ExistingSchema {
@@ -408,12 +416,12 @@ mod tests {
     fn typing_event(id: &str, started_at_ms: u64, expires_at_ms: u64) -> AircRealtimeEnvelope {
         AircRealtimeEnvelope::new(
             id.to_string(),
-            "general".to_string(),
+            GENERAL,
             "persona-1".to_string(),
             started_at_ms,
             AircRealtimePayload::Presence {
                 event: AircPresenceEvent {
-                    room_id: "general".to_string(),
+                    room_id: GENERAL,
                     subject_id: "persona-1".to_string(),
                     display_name: None,
                     state: AircPresenceState::Typing,
@@ -428,21 +436,21 @@ mod tests {
     fn peer_manifest_event(
         id: &str,
         peer_id: &str,
-        rooms: &[&str],
+        rooms: &[Uuid],
         capabilities: &[&str],
         advertised_at_ms: u64,
         expires_at_ms: Option<u64>,
     ) -> AircRealtimeEnvelope {
         AircRealtimeEnvelope::new(
             id.to_string(),
-            "general".to_string(),
+            GENERAL,
             peer_id.to_string(),
             advertised_at_ms,
             AircRealtimePayload::PeerManifest {
                 manifest: AircPeerManifest {
                     peer_id: peer_id.to_string(),
                     display_name: Some(peer_id.to_string()),
-                    room_ids: rooms.iter().map(|room| (*room).to_string()).collect(),
+                    room_ids: rooms.to_vec(),
                     capabilities: capabilities
                         .iter()
                         .map(|id| AircPeerCapability {
@@ -464,14 +472,14 @@ mod tests {
         for idx in 1..=3 {
             store
                 .publish(AircRealtimePublishParams {
-                    envelope: durable_event(&format!("evt-{idx}"), "general", idx),
+                    envelope: durable_event(&format!("evt-{idx}"), GENERAL, idx),
                 })
                 .unwrap();
         }
 
         let result = store
             .replay(AircRealtimeReplayParams {
-                room_id: "general".to_string(),
+                room_id: GENERAL,
                 after_event_id: Some("evt-1".to_string()),
                 limit: Some(10),
                 include_presence: None,
@@ -516,7 +524,7 @@ mod tests {
 
         let live = store
             .replay(AircRealtimeReplayParams {
-                room_id: "general".to_string(),
+                room_id: GENERAL,
                 after_event_id: None,
                 limit: None,
                 include_presence: Some(true),
@@ -532,7 +540,7 @@ mod tests {
 
         let expired = store
             .replay(AircRealtimeReplayParams {
-                room_id: "general".to_string(),
+                room_id: GENERAL,
                 after_event_id: None,
                 limit: None,
                 include_presence: Some(true),
@@ -553,7 +561,7 @@ mod tests {
                 envelope: peer_manifest_event(
                     "manifest-1",
                     "peer-a",
-                    &["general"],
+                    &[GENERAL],
                     &["continuum.lora.invoke"],
                     100,
                     Some(500),
@@ -565,7 +573,7 @@ mod tests {
                 envelope: peer_manifest_event(
                     "manifest-2",
                     "peer-a",
-                    &["general", "cambriantech"],
+                    &[GENERAL, CAMBRIANTECH],
                     &["continuum.lora.invoke", "continuum.chat.turn"],
                     150,
                     Some(600),
@@ -577,7 +585,7 @@ mod tests {
                 envelope: peer_manifest_event(
                     "manifest-3",
                     "peer-b",
-                    &["general"],
+                    &[GENERAL],
                     &["continuum.lora.invoke"],
                     160,
                     Some(600),
@@ -595,7 +603,7 @@ mod tests {
 
         let result = store
             .replay(AircRealtimeReplayParams {
-                room_id: "general".to_string(),
+                room_id: GENERAL,
                 after_event_id: None,
                 limit: None,
                 include_presence: None,
@@ -635,7 +643,7 @@ mod tests {
 
         let expired = store
             .replay(AircRealtimeReplayParams {
-                room_id: "general".to_string(),
+                room_id: GENERAL,
                 after_event_id: None,
                 limit: None,
                 include_presence: None,
@@ -654,7 +662,7 @@ mod tests {
         let store = InMemoryAircRealtimeStore::new(10);
         let mut receipt = AircRealtimeEnvelope::new(
             "receipt-1".to_string(),
-            "general".to_string(),
+            GENERAL,
             "peer-1".to_string(),
             10,
             AircRealtimePayload::Receipt {
@@ -675,7 +683,7 @@ mod tests {
 
         let replay = store
             .replay(AircRealtimeReplayParams {
-                room_id: "general".to_string(),
+                room_id: GENERAL,
                 after_event_id: None,
                 limit: None,
                 include_presence: None,
@@ -693,13 +701,13 @@ mod tests {
         let store = InMemoryAircRealtimeStore::new(10);
         let envelope = AircRealtimeEnvelope::new(
             "sub-1".to_string(),
-            "general".to_string(),
+            GENERAL,
             "browser-1".to_string(),
             10,
             AircRealtimePayload::Subscription {
                 event: AircSubscriptionEvent {
                     action: AircSubscriptionAction::Subscribe,
-                    room_id: "general".to_string(),
+                    room_id: GENERAL,
                     subscriber_id: "browser-1".to_string(),
                     topic: "presence".to_string(),
                     cursor: None,
@@ -718,9 +726,9 @@ mod tests {
     fn subscription_events_project_active_room_subscribers() {
         let store = InMemoryAircRealtimeStore::new(10);
         for (id, room, subscriber, topic) in [
-            ("sub-1", "general", "browser-1", "presence"),
-            ("sub-2", "general", "persona-1", "media"),
-            ("sub-3", "other", "browser-2", "presence"),
+            ("sub-1", GENERAL, "browser-1", "presence"),
+            ("sub-2", GENERAL, "persona-1", "media"),
+            ("sub-3", OTHER, "browser-2", "presence"),
         ] {
             store
                 .publish(AircRealtimePublishParams {
@@ -737,7 +745,7 @@ mod tests {
 
         let result = store
             .replay(AircRealtimeReplayParams {
-                room_id: "general".to_string(),
+                room_id: GENERAL,
                 after_event_id: None,
                 limit: None,
                 include_presence: None,
@@ -760,7 +768,7 @@ mod tests {
             .publish(AircRealtimePublishParams {
                 envelope: subscription_event(
                     "sub-1",
-                    "general",
+                    GENERAL,
                     "browser-1",
                     "presence",
                     AircSubscriptionAction::Subscribe,
@@ -771,7 +779,7 @@ mod tests {
             .publish(AircRealtimePublishParams {
                 envelope: subscription_event(
                     "unsub-1",
-                    "general",
+                    GENERAL,
                     "browser-1",
                     "presence",
                     AircSubscriptionAction::Unsubscribe,
@@ -783,7 +791,7 @@ mod tests {
 
         let result = store
             .replay(AircRealtimeReplayParams {
-                room_id: "general".to_string(),
+                room_id: GENERAL,
                 after_event_id: None,
                 limit: None,
                 include_presence: None,
@@ -806,33 +814,33 @@ mod tests {
     }
 
     #[test]
-    fn publish_rejects_empty_room_id() {
+    fn publish_rejects_nil_room_id() {
         let store = InMemoryAircRealtimeStore::new(10);
         let error = store
             .publish(AircRealtimePublishParams {
-                envelope: durable_event("evt-1", " ", 1),
+                envelope: durable_event("evt-1", Uuid::nil(), 1),
             })
             .unwrap_err();
 
-        assert_eq!(error, "room_id must not be empty");
+        assert_eq!(error, "room_id must not be the nil UUID");
     }
 
     fn subscription_event(
         id: &str,
-        room: &str,
+        room: Uuid,
         subscriber: &str,
         topic: &str,
         action: AircSubscriptionAction,
     ) -> AircRealtimeEnvelope {
         AircRealtimeEnvelope::new(
             id.to_string(),
-            room.to_string(),
+            room,
             subscriber.to_string(),
             10,
             AircRealtimePayload::Subscription {
                 event: AircSubscriptionEvent {
                     action,
-                    room_id: room.to_string(),
+                    room_id: room,
                     subscriber_id: subscriber.to_string(),
                     topic: topic.to_string(),
                     cursor: None,

--- a/src/workers/continuum-core/src/modules/airc.rs
+++ b/src/workers/continuum-core/src/modules/airc.rs
@@ -228,6 +228,9 @@ mod tests {
     };
     use parking_lot::Mutex;
     use serde_json::json;
+    use uuid::Uuid;
+
+    const TEST_ROOM_ID: Uuid = Uuid::from_u128(0xA1);
 
     struct FakeQueueClient;
 
@@ -326,12 +329,12 @@ mod tests {
         let module = AircModule::with_queue_client(Arc::new(FakeQueueClient));
         let envelope = AircRealtimeEnvelope::new(
             "typing-1".to_string(),
-            "general".to_string(),
+            TEST_ROOM_ID,
             "persona-1".to_string(),
             100,
             AircRealtimePayload::Presence {
                 event: AircPresenceEvent {
-                    room_id: "general".to_string(),
+                    room_id: TEST_ROOM_ID,
                     subject_id: "persona-1".to_string(),
                     display_name: None,
                     state: AircPresenceState::Typing,
@@ -356,7 +359,7 @@ mod tests {
             .handle_command(
                 "airc/realtime-replay",
                 json!({
-                    "roomId": "general",
+                    "roomId": TEST_ROOM_ID.to_string(),
                     "includePresence": true,
                     "nowMs": 499
                 }),
@@ -376,12 +379,12 @@ mod tests {
         let module = AircModule::with_event_transport(Arc::new(FakeQueueClient), transport.clone());
         let envelope = AircRealtimeEnvelope::new(
             "evt-through-transport".to_string(),
-            "general".to_string(),
+            TEST_ROOM_ID,
             "persona-1".to_string(),
             100,
             AircRealtimePayload::Presence {
                 event: AircPresenceEvent {
-                    room_id: "general".to_string(),
+                    room_id: TEST_ROOM_ID,
                     subject_id: "persona-1".to_string(),
                     display_name: None,
                     state: AircPresenceState::Online,


### PR DESCRIPTION
## Summary

Collapses **Q1** of [`AIRC-IPC-DEP-RATIONALE.md`](https://github.com/CambrianTech/continuum/blob/canary/docs/grid/AIRC-IPC-DEP-RATIONALE.md) (from #1449) by fixing the latent weak-typing bug: `room_id` was `String` at the continuum substrate boundary while being `Uuid` everywhere else (`turn_batch`, `turn_frame`, `rag`, `cognition`, `persona`).

After this change continuum's `room_id` passes **directly** as `airc-protocol::ChannelId`. No local map, no daemon-side name-or-uuid translation, no airc-lib dep. The "which Q1 option do we pick" design question is gone because the question itself was a symptom of the weak typing — strong-type the field and the question dissolves.

- **Closes kanban card**: `d8a69c65-3a0d-492b-ad1e-024ed431509f`
- **Follows**: #1449 (git-dep airc-ipc/airc-protocol)
- **Sibling card** (airc-side): `6e525958` — `ResolveWireRequest` — owned by dba950ce, see `airc#1011`
- **Unblocks**: `DaemonAircRealtimeStore` impl (the next continuum card)

## Why this is the right shape

> Joel: "room_id IS a UUID. Current String typing is a latent weak-typing bug."

`#[ts(type = "string")]` keeps the **TS wire form** as `string` — generated bindings under `src/shared/generated/airc/` are binary-compatible (no diff). The Rust side gets the strong typing the substrate needed; the TS side keeps reading/writing UUID-shaped strings as it already did.

## What this PR retypes

On the airc-boundary surface (the scope the card targets):

| Field / signature | Before | After |
|---|---|---|
| `AircPresenceEvent.room_id` | `String` | `Uuid` |
| `AircReplayCursor.room_id` | `String` | `Uuid` |
| `AircSubscriptionEvent.room_id` | `String` | `Uuid` |
| `AircPeerManifest.room_ids` | `Vec<String>` | `Vec<Uuid>` |
| `AircRealtimeEnvelope.room_id` | `String` | `Uuid` |
| `AircRealtimePublishResult.room_id` | `String` | `Uuid` |
| `AircRealtimeReplayParams.room_id` | `String` | `Uuid` |
| `AircRealtimeReplayResult.room_id` | `String` | `Uuid` |
| `AircRealtimeState.rooms` | `HashMap<String, _>` | `HashMap<Uuid, _>` |
| `validate_room_id` | `is_empty` check | `is_nil` check |
| `AircPeerManifest::advertises_room(&str)` | takes `&str` | takes `Uuid` (Copy) + `.contains()` |
| `AircRealtimeEnvelope::new(room_id: String)` | `String` | `Uuid` |

## What is explicitly NOT in this PR

The remaining `room_id: String` sites in the codebase are NOT substrate-boundary types and belong in separate follow-up cards:

- `memory/types.rs`, `memory/recall.rs` — memory layer typing
- `cognition/should_respond.rs`, `cognition/generate_response.rs` — cognition input shapes
- `ai/types.rs` — AI provider request schemas
- `ipc/protocol.rs` — internal IPC envelope (separate cleanup)
- `live/transport/media.rs` — LiveKit transport
- `airc/queue` types — unrelated to realtime substrate

Bundling those would balloon scope past the card's stated boundary (AircRealtimeEnvelope + siblings). Happy to file follow-up cards.

## Verification

- `cargo check -p continuum-core --features metal,accelerate` — clean
- `cargo test -p continuum-core --features metal,accelerate --lib airc::` — **48/48 pass**, including the `export_bindings_*` ts-rs tests
- `cargo clippy -p continuum-core --features metal,accelerate --lib` — no new warnings in my files (the llama crate's pre-existing `too_many_arguments` warnings are unrelated)
- Precommit hook full chain — TS compile, browser-ping, chat-roundtrip — passed

## Test plan
- [ ] CI green on canary
- [ ] No diff under `src/shared/generated/airc/` (binary-compatible wire form)
- [ ] `DaemonAircRealtimeStore` impl PR (next card) can `params.envelope.room_id` directly as `airc-protocol::ChannelId` with zero conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)