### PR TITLE
feat(airc): publish continuum realtime over daemon IPC

### DIFF
--- a/docs/grid/AIRC-IPC-DEP-RATIONALE.md
+++ b/docs/grid/AIRC-IPC-DEP-RATIONALE.md
@@ -1,6 +1,6 @@
 # Continuum → airc-ipc: direct IPC dep (no subprocess, no JSON transcode)
 
-**Status:** dep landed; consumer impl pending follow-up PRs.
+**Status:** direct IPC dep landed; daemon-backed publish/replay bridge in progress.
 **Pairs with:** [`AIRC-CONTINUUM-BRIDGE.md`](AIRC-CONTINUUM-BRIDGE.md) — long-term architecture.
 **Roadmap:** kanban card `156770cf-95f9-4945-88da-5dcce795ceb7`.
 
@@ -16,27 +16,27 @@ The grid-event hot path moves typed envelopes (chat:posted, presence:peer-manife
 
 The IPC ABI version (`airc_ipc::IPC_PROTOCOL_VERSION`) pinning is what makes shape 2 safe across redeploys: Continuum and the daemon negotiate the same version or refuse to connect.
 
-## What this PR lands
+## What the dependency PR landed
 
 Workspace-level git deps in `src/workers/Cargo.toml`:
 
 ```toml
-airc-core    = { git = "https://github.com/CambrianTech/airc", rev = "ef6eced…" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "ef6eced…" }
-airc-ipc      = { git = "https://github.com/CambrianTech/airc", rev = "ef6eced…" }
+airc-core     = { git = "https://github.com/CambrianTech/airc", rev = "428f928…" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "428f928…" }
+airc-ipc      = { git = "https://github.com/CambrianTech/airc", rev = "428f928…" }
 ```
 
-`continuum-core/Cargo.toml` picks up `airc-ipc.workspace = true` + `airc-protocol.workspace = true`. (`airc-core` is pulled transitively; not redeclared.)
+`continuum-core/Cargo.toml` picks up `airc-ipc.workspace = true`, `airc-protocol.workspace = true`, and `airc-core.workspace = true`.
 
-**Zero new code, zero behavior change.** The existing `InMemoryAircRealtimeStore` stays the default. The dep addition is purely the architectural commitment — every follow-up PR consumes types from `airc_ipc::` / `airc_protocol::` directly instead of subprocess + parse.
+The first dependency-only PR had zero behavior change. The current bridge PR consumes the typed ABI directly: `AircModule::new()` publishes through the daemon-backed event transport for the current project `.airc` scope, while the in-memory store remains an explicit test fixture path.
 
 ## Why no consumer impl in this PR
 
-Two design questions block writing the `DaemonAircRealtimeStore` cleanly today:
+Two design questions blocked writing the daemon-backed transport cleanly; both are resolved:
 
 ### Q1 — room-id boundary
 
-Continuum's `AircRealtimeEnvelope` carries `room_id: String`. airc's `PublishRequest` carries `channel: Uuid` + `wire: PathBuf`. The deterministic mapping (`airc room <name>` derives both from the name) lives in `airc-lib::room::Room::from_name` + `airc-lib::subscriptions::derive_room_id`.
+Continuum's `AircRealtimeEnvelope` carries `room_id: Uuid`. airc's `PublishRequest` carries `channel: Uuid` + `wire: PathBuf`.
 
 Three options:
 
@@ -46,7 +46,7 @@ Three options:
 | B | Continuum keeps string room-ids; daemon translates at the IPC boundary | Requires adding a translation hop to airc-ipc's `PublishRequest` shape (accept name string OR uuid) |
 | C | Continuum maintains its own room-id↔channel-uuid map, populated at room-join time | Cleanest dep boundary; one-time setup cost per room |
 
-Recommend C.
+Decision: C, now implemented at the type boundary. Continuum carries the channel UUID it received from room/join context; it does not ask the daemon to translate room names on every publish.
 
 ### Q2 — wire path
 
@@ -59,11 +59,11 @@ Two options:
 | α | Add a `wire-by-channel-uuid` lookup to `airc-ipc` (daemon resolves) | Tiny airc PR; clean shape on continuum side |
 | β | Continuum tracks wire paths per room (subscribe step) | More state on continuum side; requires `airc subscribe` round-trip per room-join |
 
-Recommend α — `airc-ipc` exposing the lookup is consistent with its role as "the typed ABI for talking to the daemon."
+Decision: α. airc exposes `ResolveWireRequest { channel: Uuid }` over `airc-ipc`; Continuum resolves the daemon-owned wire path immediately before publish and fails loud when the channel is not joined.
 
 ## Follow-up PRs
 
-1. **continuum**: `DaemonAircRealtimeStore` impl (this PR's deps + Q1=C decision). Replaces `InMemoryAircRealtimeStore` as default. Feature-gated fallback to in-memory for unit-test paths.
-2. **airc**: `airc-ipc::ResolveWireRequest` + corresponding daemon handler (Q2=α decision).
-3. **continuum**: airc-side inbound stream — long-lived `Request::Attach` poller that drains `Response::Event` frames + dispatches as local `Events.subscribe` callbacks. The reverse direction.
-4. **continuum**: L1-6 Phase B — peer-pubkey lookup via L1-4's `presence:peer-manifest` (needs card `290f64b7-5837-42ff-9844-570088fbb01a` resolved first — `signing_pubkey_hex` field on `AircPeerManifest`).
+1. **continuum**: daemon-backed `AircEventTransport` publish/replay bridge. Replaces `InMemoryAircRealtimeStore` as the default runtime path; in-memory remains explicit for tests.
+2. **continuum**: airc-side inbound stream — long-lived `Request::Attach` poller that drains `Response::Event` frames + dispatches as local `Events.subscribe` callbacks. The reverse direction.
+3. **continuum**: L1-6 Phase B — peer-pubkey lookup via L1-4's `presence:peer-manifest` and `signing_pubkey_hex`.
+4. **continuum/airc**: cursor contract upgrade. `airc-ipc::InboxRequest` is lamport-cursor-native; Continuum's public replay API is still event-id-cursor-shaped. The bridge handles current bounded replay, but the cross-system contract should move to `(lamport, event_id)` cursors before high-rate Continuum event streams depend on it.

--- a/src/workers/Cargo.lock
+++ b/src/workers/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=ef6eced1667a0a98d8b40c32bba6f60c2d249b2c#ef6eced1667a0a98d8b40c32bba6f60c2d249b2c"
+source = "git+https://github.com/CambrianTech/airc?rev=428f9281e029072c0b7c39eca1781c94136fe697#428f9281e029072c0b7c39eca1781c94136fe697"
 dependencies = [
  "serde",
  "serde_json",
@@ -67,7 +67,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=ef6eced1667a0a98d8b40c32bba6f60c2d249b2c#ef6eced1667a0a98d8b40c32bba6f60c2d249b2c"
+source = "git+https://github.com/CambrianTech/airc?rev=428f9281e029072c0b7c39eca1781c94136fe697#428f9281e029072c0b7c39eca1781c94136fe697"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=ef6eced1667a0a98d8b40c32bba6f60c2d249b2c#ef6eced1667a0a98d8b40c32bba6f60c2d249b2c"
+source = "git+https://github.com/CambrianTech/airc?rev=428f9281e029072c0b7c39eca1781c94136fe697#428f9281e029072c0b7c39eca1781c94136fe697"
 dependencies = [
  "airc-core",
  "ciborium",
@@ -2201,6 +2201,7 @@ dependencies = [
 name = "continuum-core"
 version = "0.1.0"
 dependencies = [
+ "airc-core",
  "airc-ipc",
  "airc-protocol",
  "arc-swap",

--- a/src/workers/Cargo.toml
+++ b/src/workers/Cargo.toml
@@ -23,9 +23,9 @@ members = [
 # when adopting an airc change; both crates resolve from the same
 # checkout so the IPC ABI version (IPC_PROTOCOL_VERSION) stays
 # consistent across the dependency graph.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "ef6eced1667a0a98d8b40c32bba6f60c2d249b2c" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "ef6eced1667a0a98d8b40c32bba6f60c2d249b2c" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "ef6eced1667a0a98d8b40c32bba6f60c2d249b2c" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "428f9281e029072c0b7c39eca1781c94136fe697" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "428f9281e029072c0b7c39eca1781c94136fe697" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "428f9281e029072c0b7c39eca1781c94136fe697" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/src/workers/continuum-core/Cargo.toml
+++ b/src/workers/continuum-core/Cargo.toml
@@ -47,6 +47,7 @@ ed25519-dalek = { version = "2", features = ["rand_core", "serde"] }  # L1-6 con
 # (Unix domain socket / Windows named pipe). Pulls airc-protocol +
 # airc-core transitively. SHA pinned at the workspace level.
 airc-ipc.workspace = true
+airc-core.workspace = true
 airc-protocol.workspace = true
 
 async-trait.workspace = true

--- a/src/workers/continuum-core/src/airc/daemon_endpoint.rs
+++ b/src/workers/continuum-core/src/airc/daemon_endpoint.rs
@@ -1,0 +1,50 @@
+//! Local AIRC daemon endpoint derivation.
+
+use std::path::{Path, PathBuf};
+
+/// Default daemon IPC endpoint for an AIRC home.
+///
+/// The path is versioned by `airc_ipc::IPC_PROTOCOL_VERSION` so a client
+/// cannot accidentally talk to a daemon speaking an older ABI.
+pub fn default_socket_path_in(home: &Path) -> PathBuf {
+    #[cfg(unix)]
+    {
+        use sha2::{Digest, Sha256};
+
+        let canonical = home.canonicalize().unwrap_or_else(|_| home.to_path_buf());
+        let mut hasher = Sha256::new();
+        hasher.update(airc_ipc::IPC_PROTOCOL_VERSION.to_be_bytes());
+        hasher.update(canonical.to_string_lossy().as_bytes());
+        let digest = hasher.finalize();
+        let hex = digest
+            .iter()
+            .take(12)
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+
+        std::env::temp_dir().join(format!(
+            "airc-ipc-v{}-{hex}.sock",
+            airc_ipc::IPC_PROTOCOL_VERSION
+        ))
+    }
+
+    #[cfg(not(unix))]
+    {
+        home.join(format!("daemon-v{}.sock", airc_ipc::IPC_PROTOCOL_VERSION))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn socket_path_is_protocol_versioned() {
+        let path = default_socket_path_in(Path::new("/tmp/continuum-airc-home"));
+        let rendered = path.to_string_lossy();
+        assert!(
+            rendered.contains(&format!("v{}", airc_ipc::IPC_PROTOCOL_VERSION)),
+            "socket path must carry IPC protocol version: {rendered}"
+        );
+    }
+}

--- a/src/workers/continuum-core/src/airc/daemon_transport.rs
+++ b/src/workers/continuum-core/src/airc/daemon_transport.rs
@@ -1,0 +1,350 @@
+//! Daemon-backed realtime transport for Continuum AIRC envelopes.
+//!
+//! Continuum publishes structured events through the running AIRC daemon
+//! using typed IPC requests. No shell command, no stdout parsing, no JSON
+//! command adapter in the hot path.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use airc_core::{Body, Headers, MentionTarget, RoomId};
+use airc_ipc::{
+    DaemonClient, InboxRequest, PublishRequest, PublishResponse, ResolveWireRequest,
+    ResolveWireResponse,
+};
+use airc_protocol::{FrameKind, HEADER_FORGE_BODY_HINT};
+use async_trait::async_trait;
+
+use crate::airc::event_transport::AircEventTransport;
+use crate::airc::realtime::AircRealtimeDelivery;
+use crate::airc::realtime_store::{
+    AircRealtimePublishParams, AircRealtimePublishResult, AircRealtimeReplayParams,
+    AircRealtimeReplayResult, AircRealtimeStore, InMemoryAircRealtimeStore, MAX_ROOM_REPLAY_LIMIT,
+};
+
+const CONTINUUM_BODY_HINT: &str = "continuum.airc.realtime.envelope.v1";
+const HEADER_CONTINUUM_EVENT_ID: &str = "continuum.event_id";
+const HEADER_CONTINUUM_SOURCE_ID: &str = "continuum.source_id";
+const HEADER_CONTINUUM_DELIVERY: &str = "continuum.delivery";
+const HEADER_CONTINUUM_TRACE_ID: &str = "continuum.trace_id";
+
+#[async_trait]
+pub trait AircDaemonClient: Send + Sync {
+    async fn resolve_wire(
+        &self,
+        request: ResolveWireRequest,
+    ) -> Result<ResolveWireResponse, String>;
+
+    async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, String>;
+
+    async fn inbox(&self, request: InboxRequest) -> Result<airc_ipc::InboxResponse, String>;
+}
+
+#[async_trait]
+impl AircDaemonClient for DaemonClient {
+    async fn resolve_wire(
+        &self,
+        request: ResolveWireRequest,
+    ) -> Result<ResolveWireResponse, String> {
+        DaemonClient::resolve_wire(self, request)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, String> {
+        DaemonClient::publish(self, request)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    async fn inbox(&self, request: InboxRequest) -> Result<airc_ipc::InboxResponse, String> {
+        DaemonClient::inbox(self, request)
+            .await
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[derive(Clone)]
+pub struct DaemonAircEventTransport {
+    client: Arc<dyn AircDaemonClient>,
+}
+
+impl DaemonAircEventTransport {
+    pub fn new(socket_path: PathBuf) -> Self {
+        Self::with_client(Arc::new(DaemonClient::new(socket_path)))
+    }
+
+    pub fn with_client(client: Arc<dyn AircDaemonClient>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl AircEventTransport for DaemonAircEventTransport {
+    async fn publish(
+        &self,
+        params: AircRealtimePublishParams,
+    ) -> Result<AircRealtimePublishResult, String> {
+        let envelope = params.envelope;
+        envelope.validate_delivery()?;
+
+        let wire = self.resolve_wire(envelope.room_id).await?;
+        let publish = self
+            .client
+            .publish(PublishRequest {
+                wire,
+                channel: envelope.room_id,
+                kind: frame_kind_for_delivery(envelope.delivery),
+                target: MentionTarget::All,
+                body: Body::Json(serde_json::to_value(&envelope).map_err(|error| {
+                    format!("failed to encode continuum airc envelope: {error}")
+                })?),
+                headers: headers_for_envelope(&envelope),
+            })
+            .await?;
+
+        Ok(AircRealtimePublishResult {
+            ok: true,
+            event_id: publish.event_id.to_string(),
+            room_id: publish.channel_id.as_uuid(),
+            delivery: envelope.delivery,
+            stored_for_replay: matches!(
+                envelope.delivery,
+                AircRealtimeDelivery::Durable | AircRealtimeDelivery::Control
+            ),
+            coalesced_presence_key: None,
+            replay_depth: 0,
+            active_presence_count: 0,
+            active_subscription_count: 0,
+            active_peer_manifest_count: 0,
+        })
+    }
+
+    async fn replay(
+        &self,
+        params: AircRealtimeReplayParams,
+    ) -> Result<AircRealtimeReplayResult, String> {
+        let response = self
+            .client
+            .inbox(InboxRequest {
+                since: None,
+                channel: Some(RoomId::from_uuid(params.room_id)),
+                limit: Some(params.limit.unwrap_or(MAX_ROOM_REPLAY_LIMIT)),
+            })
+            .await?;
+
+        let projection = InMemoryAircRealtimeStore::new(MAX_ROOM_REPLAY_LIMIT);
+        for event in response.events {
+            let Some(body) = event.body else {
+                continue;
+            };
+            if event
+                .headers
+                .get(HEADER_FORGE_BODY_HINT)
+                .map(String::as_str)
+                != Some(CONTINUUM_BODY_HINT)
+            {
+                continue;
+            }
+            let Body::Json(value) = body else {
+                continue;
+            };
+            let envelope = serde_json::from_value(value)
+                .map_err(|error| format!("failed to decode continuum airc envelope: {error}"))?;
+            projection.publish(AircRealtimePublishParams { envelope })?;
+        }
+
+        projection.replay(params)
+    }
+}
+
+impl DaemonAircEventTransport {
+    async fn resolve_wire(&self, room_id: uuid::Uuid) -> Result<PathBuf, String> {
+        let response = self
+            .client
+            .resolve_wire(ResolveWireRequest { channel: room_id })
+            .await?;
+        response.wire.ok_or_else(|| {
+            format!(
+                "airc channel {room_id} is not joined in the daemon scope; run airc join before publishing"
+            )
+        })
+    }
+}
+
+fn frame_kind_for_delivery(delivery: AircRealtimeDelivery) -> FrameKind {
+    match delivery {
+        AircRealtimeDelivery::Durable => FrameKind::Message,
+        AircRealtimeDelivery::EphemeralCoalesced => FrameKind::Event,
+        AircRealtimeDelivery::Control | AircRealtimeDelivery::ReceiptOnly => FrameKind::Control,
+    }
+}
+
+fn headers_for_envelope(envelope: &crate::airc::realtime::AircRealtimeEnvelope) -> Headers {
+    let mut headers = Headers::new();
+    headers.insert(
+        HEADER_FORGE_BODY_HINT.to_string(),
+        CONTINUUM_BODY_HINT.to_string(),
+    );
+    headers.insert(
+        HEADER_CONTINUUM_EVENT_ID.to_string(),
+        envelope.event_id.clone(),
+    );
+    headers.insert(
+        HEADER_CONTINUUM_SOURCE_ID.to_string(),
+        envelope.source_id.clone(),
+    );
+    headers.insert(
+        HEADER_CONTINUUM_DELIVERY.to_string(),
+        format!("{:?}", envelope.delivery),
+    );
+    if let Some(trace_id) = &envelope.trace_id {
+        headers.insert(HEADER_CONTINUUM_TRACE_ID.to_string(), trace_id.clone());
+    }
+    headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::airc::realtime::{
+        AircRealtimeEnvelope, AircRealtimePayload, AircRealtimePayloadRef, AircRealtimeSchema,
+    };
+    use airc_core::{ClientId, EventId, PeerId, TranscriptEvent, TranscriptKind};
+    use parking_lot::Mutex;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    #[derive(Default)]
+    struct FakeDaemonClient {
+        wire: Mutex<Option<PathBuf>>,
+        publishes: Mutex<Vec<PublishRequest>>,
+        inbox_events: Mutex<Vec<TranscriptEvent>>,
+    }
+
+    #[async_trait]
+    impl AircDaemonClient for FakeDaemonClient {
+        async fn resolve_wire(
+            &self,
+            _request: ResolveWireRequest,
+        ) -> Result<ResolveWireResponse, String> {
+            Ok(ResolveWireResponse {
+                wire: self.wire.lock().clone(),
+            })
+        }
+
+        async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, String> {
+            self.publishes.lock().push(request);
+            Ok(PublishResponse {
+                event_id: EventId::from_u128(0xfeed),
+                lamport: 7,
+                occurred_at_ms: 1000,
+                channel_id: RoomId::from_u128(0xA1),
+            })
+        }
+
+        async fn inbox(&self, _request: InboxRequest) -> Result<airc_ipc::InboxResponse, String> {
+            Ok(airc_ipc::InboxResponse {
+                events: self.inbox_events.lock().clone(),
+                newest: None,
+            })
+        }
+    }
+
+    fn envelope(event_id: &str) -> AircRealtimeEnvelope {
+        AircRealtimeEnvelope::new(
+            event_id.to_string(),
+            Uuid::from_u128(0xA1),
+            "continuum".to_string(),
+            100,
+            AircRealtimePayload::ExistingSchema {
+                payload: AircRealtimePayloadRef::inline(
+                    AircRealtimeSchema::EventBridgePayload,
+                    json!({"event": "persona.ready"}),
+                ),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn publish_resolves_wire_then_sends_structured_body() {
+        let fake = Arc::new(FakeDaemonClient::default());
+        *fake.wire.lock() = Some(PathBuf::from("/tmp/airc-wire"));
+        let transport = DaemonAircEventTransport::with_client(fake.clone());
+
+        let result = transport
+            .publish(AircRealtimePublishParams {
+                envelope: envelope("evt-1"),
+            })
+            .await
+            .unwrap();
+
+        assert!(result.ok);
+        let publishes = fake.publishes.lock();
+        assert_eq!(publishes.len(), 1);
+        assert_eq!(publishes[0].wire, PathBuf::from("/tmp/airc-wire"));
+        assert_eq!(publishes[0].kind, FrameKind::Message);
+        assert_eq!(
+            publishes[0]
+                .headers
+                .get(HEADER_FORGE_BODY_HINT)
+                .map(String::as_str),
+            Some(CONTINUUM_BODY_HINT)
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_fails_loud_when_room_is_not_joined() {
+        let fake = Arc::new(FakeDaemonClient::default());
+        let transport = DaemonAircEventTransport::with_client(fake);
+
+        let error = transport
+            .publish(AircRealtimePublishParams {
+                envelope: envelope("evt-1"),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(error.contains("not joined"));
+    }
+
+    #[tokio::test]
+    async fn replay_decodes_only_continuum_body_hint_events() {
+        let fake = Arc::new(FakeDaemonClient::default());
+        let env = envelope("evt-1");
+        let event = TranscriptEvent {
+            event_id: EventId::from_u128(1),
+            room_id: RoomId::from_uuid(env.room_id),
+            peer_id: PeerId::from_u128(2),
+            client_id: ClientId::from_u128(3),
+            kind: TranscriptKind::Message,
+            occurred_at_ms: 100,
+            lamport: 1,
+            target: MentionTarget::All,
+            headers: headers_for_envelope(&env),
+            body: Some(Body::Json(serde_json::to_value(&env).unwrap())),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        };
+        fake.inbox_events.lock().push(event);
+        let transport = DaemonAircEventTransport::with_client(fake);
+
+        let replay = transport
+            .replay(AircRealtimeReplayParams {
+                room_id: env.room_id,
+                after_event_id: None,
+                limit: Some(10),
+                include_presence: None,
+                include_subscriptions: None,
+                include_peer_manifests: None,
+                include_capability_index: None,
+                now_ms: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(replay.events.len(), 1);
+        assert_eq!(replay.events[0].event_id, "evt-1");
+    }
+}

--- a/src/workers/continuum-core/src/airc/event_transport.rs
+++ b/src/workers/continuum-core/src/airc/event_transport.rs
@@ -8,18 +8,24 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
+
 use crate::airc::realtime_store::{
     AircRealtimePublishParams, AircRealtimePublishResult, AircRealtimeReplayParams,
     AircRealtimeReplayResult, AircRealtimeStore,
 };
 
+#[async_trait]
 pub trait AircEventTransport: Send + Sync {
-    fn publish(
+    async fn publish(
         &self,
         params: AircRealtimePublishParams,
     ) -> Result<AircRealtimePublishResult, String>;
 
-    fn replay(&self, params: AircRealtimeReplayParams) -> Result<AircRealtimeReplayResult, String>;
+    async fn replay(
+        &self,
+        params: AircRealtimeReplayParams,
+    ) -> Result<AircRealtimeReplayResult, String>;
 }
 
 #[derive(Clone)]
@@ -33,15 +39,19 @@ impl StoreAircEventTransport {
     }
 }
 
+#[async_trait]
 impl AircEventTransport for StoreAircEventTransport {
-    fn publish(
+    async fn publish(
         &self,
         params: AircRealtimePublishParams,
     ) -> Result<AircRealtimePublishResult, String> {
         self.store.publish(params)
     }
 
-    fn replay(&self, params: AircRealtimeReplayParams) -> Result<AircRealtimeReplayResult, String> {
+    async fn replay(
+        &self,
+        params: AircRealtimeReplayParams,
+    ) -> Result<AircRealtimeReplayResult, String> {
         self.store.replay(params)
     }
 }
@@ -56,8 +66,8 @@ mod tests {
     use serde_json::json;
     use uuid::Uuid;
 
-    #[test]
-    fn store_transport_round_trips_without_cli_output_parsing() {
+    #[tokio::test]
+    async fn store_transport_round_trips_without_cli_output_parsing() {
         let transport =
             StoreAircEventTransport::new(Arc::new(InMemoryAircRealtimeStore::default()));
         let room_id = Uuid::from_u128(0xA1);
@@ -76,6 +86,7 @@ mod tests {
 
         let publish = transport
             .publish(AircRealtimePublishParams { envelope })
+            .await
             .unwrap();
         assert!(publish.stored_for_replay);
 
@@ -90,6 +101,7 @@ mod tests {
                 include_capability_index: None,
                 now_ms: None,
             })
+            .await
             .unwrap();
 
         assert_eq!(replay.events.len(), 1);

--- a/src/workers/continuum-core/src/airc/mod.rs
+++ b/src/workers/continuum-core/src/airc/mod.rs
@@ -5,6 +5,8 @@
 //! ServiceModule wrappers stay thin and future AIRC commands reuse one path.
 
 pub mod client;
+pub mod daemon_endpoint;
+pub mod daemon_transport;
 pub mod event_transport;
 pub mod process;
 pub mod realtime;
@@ -12,6 +14,8 @@ pub mod realtime_store;
 pub mod types;
 
 pub use client::{AircQueueClient, CliAircQueueClient};
+pub use daemon_endpoint::default_socket_path_in;
+pub use daemon_transport::{AircDaemonClient, DaemonAircEventTransport};
 pub use event_transport::{AircEventTransport, StoreAircEventTransport};
 pub use process::{AircCommandRunner, AircInvocation, TokioAircCommandRunner};
 pub use realtime::{

--- a/src/workers/continuum-core/src/modules/airc.rs
+++ b/src/workers/continuum-core/src/modules/airc.rs
@@ -3,7 +3,8 @@
 use crate::airc::{
     AircEventTransport, AircQueueClient, AircQueueListRequest, AircQueueScanParams,
     AircRealtimePublishParams, AircRealtimeReplayParams, AircRealtimeStore, CliAircQueueClient,
-    InMemoryAircRealtimeStore, StoreAircEventTransport, TokioAircCommandRunner,
+    DaemonAircEventTransport, InMemoryAircRealtimeStore, StoreAircEventTransport,
+    TokioAircCommandRunner, default_socket_path_in,
 };
 use crate::runtime::{
     CommandResult, CommandSchema, ModuleConfig, ModuleContext, ModulePriority, ParamSchema,
@@ -21,10 +22,18 @@ pub struct AircModule {
 
 impl AircModule {
     pub fn new() -> Self {
+        let airc_home = std::env::current_dir()
+            .map(|dir| dir.join(".airc"))
+            .unwrap_or_else(|_| std::path::PathBuf::from(".airc"));
+        Self::with_daemon_home(airc_home)
+    }
+
+    pub fn with_daemon_home(airc_home: impl Into<std::path::PathBuf>) -> Self {
+        let airc_home = airc_home.into();
         Self {
             queue_client: Arc::new(CliAircQueueClient::new(TokioAircCommandRunner)),
-            event_transport: Arc::new(StoreAircEventTransport::new(Arc::new(
-                InMemoryAircRealtimeStore::default(),
+            event_transport: Arc::new(DaemonAircEventTransport::new(default_socket_path_in(
+                &airc_home,
             ))),
         }
     }
@@ -95,13 +104,13 @@ impl ServiceModule for AircModule {
             "airc/realtime-publish" => {
                 let params: AircRealtimePublishParams = serde_json::from_value(params)
                     .map_err(|e| format!("invalid airc/realtime-publish params: {e}"))?;
-                let result = self.event_transport.publish(params)?;
+                let result = self.event_transport.publish(params).await?;
                 CommandResult::json(&result)
             }
             "airc/realtime-replay" => {
                 let params: AircRealtimeReplayParams = serde_json::from_value(params)
                     .map_err(|e| format!("invalid airc/realtime-replay params: {e}"))?;
-                let result = self.event_transport.replay(params)?;
+                let result = self.event_transport.replay(params).await?;
                 CommandResult::json(&result)
             }
             _ => Err(format!("Unknown airc command: {command}")),
@@ -265,8 +274,9 @@ mod tests {
         }
     }
 
+    #[async_trait]
     impl AircEventTransport for FakeEventTransport {
-        fn publish(
+        async fn publish(
             &self,
             params: AircRealtimePublishParams,
         ) -> Result<AircRealtimePublishResult, String> {
@@ -285,7 +295,7 @@ mod tests {
             })
         }
 
-        fn replay(
+        async fn replay(
             &self,
             params: AircRealtimeReplayParams,
         ) -> Result<AircRealtimeReplayResult, String> {


### PR DESCRIPTION
## Summary
- update airc git deps to the IPC rev with ResolveWire + publish support
- add daemon endpoint derivation and a daemon-backed AIRC event transport
- route AircModule::new realtime publish/replay through typed airc-ipc instead of the in-memory default
- keep the in-memory realtime store as an explicit test fixture path
- update the IPC rationale doc with the resolved room/wire decisions and remaining cursor follow-up

## Verification
- rustfmt --edition 2024 --check --config skip_children=true src/workers/continuum-core/src/airc/event_transport.rs src/workers/continuum-core/src/airc/daemon_endpoint.rs src/workers/continuum-core/src/airc/daemon_transport.rs src/workers/continuum-core/src/airc/mod.rs src/workers/continuum-core/src/modules/airc.rs
- cargo test --manifest-path src/workers/Cargo.toml -p continuum-core --lib airc --features metal,accelerate
- cargo clippy --manifest-path src/workers/Cargo.toml -p continuum-core --lib --features metal,accelerate
- git commit precommit: TypeScript passed; chat roundtrip passed; browser ping skipped by existing 60s timeout policy

References: docs/grid/AIRC-IPC-DEP-RATIONALE.md; Continuum card df0018ae-1bf9-40db-b861-56bc1ea8423d