### PR TITLE
feat(contracts): verify signed replay events against peer manifests

### DIFF
--- a/docs/grid/AIRC-IPC-DEP-RATIONALE.md
+++ b/docs/grid/AIRC-IPC-DEP-RATIONALE.md
@@ -65,6 +65,6 @@ Decision: α. airc exposes `ResolveWireRequest { channel: Uuid }` over `airc-ipc
 
 ## Follow-up PRs
 
-1. **continuum**: L1-6 Phase B — peer-pubkey lookup via L1-4's `presence:peer-manifest` and `signing_pubkey_hex`.
+1. **continuum**: L1-6 Phase B landed — replayed contract events verify the signed envelope and bind the signer pubkey to L1-4's `presence:peer-manifest.signing_pubkey_hex`.
 2. **continuum/airc**: cursor contract upgrade. `airc-ipc::InboxRequest` is lamport-cursor-native; Continuum's public replay API now accepts `afterCursor` and returns a cursor shaped as `(lamport, event_id)` so high-rate Continuum event streams resume from the substrate position instead of fetching a bounded page and filtering by event id.
 3. **continuum**: runtime e2e proof. Start a daemon for a temp project `.airc`, publish a Continuum realtime envelope through `AircModule::new()`, observe the attach stream republish it into `MessageBus`, and prove no CLI/stdout path participates.

--- a/src/workers/continuum-core/src/contracts/envelope.rs
+++ b/src/workers/continuum-core/src/contracts/envelope.rs
@@ -218,7 +218,6 @@ mod tests {
 
     #[test]
     fn sign_then_verify_roundtrips() {
-          
         let sk = ContractSigningKey::generate();
 
         let envelope = SignedContractEvent::sign(
@@ -237,16 +236,12 @@ mod tests {
     fn relabeling_attack_fails() {
         // Sign a payload as `contract:bid`, then relabel the envelope
         // to `contract:proposed` and try to verify — must fail.
-          
+
         let sk = ContractSigningKey::generate();
 
-        let envelope = SignedContractEvent::sign(
-            EVENT_CONTRACT_BID,
-            sample_bid(),
-            &sk,
-            1_779_800_000_000,
-        )
-        .unwrap();
+        let envelope =
+            SignedContractEvent::sign(EVENT_CONTRACT_BID, sample_bid(), &sk, 1_779_800_000_000)
+                .unwrap();
 
         let mut tampered = envelope.clone();
         tampered.event_name = EVENT_CONTRACT_PROPOSED.into();
@@ -257,7 +252,6 @@ mod tests {
 
     #[test]
     fn payload_mutation_fails_verify() {
-          
         let sk = ContractSigningKey::generate();
 
         let envelope = SignedContractEvent::sign(
@@ -277,7 +271,6 @@ mod tests {
 
     #[test]
     fn signature_mutation_fails_verify() {
-          
         let sk = ContractSigningKey::generate();
 
         let envelope = SignedContractEvent::sign(
@@ -300,7 +293,6 @@ mod tests {
 
     #[test]
     fn pubkey_swap_fails_verify() {
-          
         let sk_a = ContractSigningKey::generate();
         let sk_b = ContractSigningKey::generate();
 
@@ -321,7 +313,6 @@ mod tests {
 
     #[test]
     fn envelope_round_trips_through_json() {
-          
         let sk = ContractSigningKey::generate();
 
         let envelope = SignedContractEvent::sign(

--- a/src/workers/continuum-core/src/contracts/event_classes.rs
+++ b/src/workers/continuum-core/src/contracts/event_classes.rs
@@ -91,7 +91,10 @@ pub const CONTRACT_SCHEMA_VERSION: &str = "v1";
 /// a synthetic "ping contract" alloy with no proof suite.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "../../../shared/generated/contracts/ContractProposedPayload.ts")]
+#[ts(
+    export,
+    export_to = "../../../shared/generated/contracts/ContractProposedPayload.ts"
+)]
 pub struct ContractProposedPayload {
     pub contract_id: String,
     pub proposer_id: String,
@@ -113,7 +116,10 @@ pub struct ContractProposedPayload {
 /// `contract:bid` — an executor's offer to take on a proposed contract.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "../../../shared/generated/contracts/ContractBidPayload.ts")]
+#[ts(
+    export,
+    export_to = "../../../shared/generated/contracts/ContractBidPayload.ts"
+)]
 pub struct ContractBidPayload {
     pub contract_id: String,
     pub bidder_id: String,
@@ -129,7 +135,10 @@ pub struct ContractBidPayload {
 /// `contract:accepted` — proposer's signed selection of one bidder.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "../../../shared/generated/contracts/ContractAcceptedPayload.ts")]
+#[ts(
+    export,
+    export_to = "../../../shared/generated/contracts/ContractAcceptedPayload.ts"
+)]
 pub struct ContractAcceptedPayload {
     pub contract_id: String,
     pub proposer_id: String,
@@ -145,7 +154,10 @@ pub struct ContractAcceptedPayload {
 /// router daemon to mark a routing slot as in-use.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "../../../shared/generated/contracts/ContractExecutingPayload.ts")]
+#[ts(
+    export,
+    export_to = "../../../shared/generated/contracts/ContractExecutingPayload.ts"
+)]
 pub struct ContractExecutingPayload {
     pub contract_id: String,
     pub executor_id: String,
@@ -158,7 +170,10 @@ pub struct ContractExecutingPayload {
 /// detect bait-and-switch).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "../../../shared/generated/contracts/ContractDeliveredPayload.ts")]
+#[ts(
+    export,
+    export_to = "../../../shared/generated/contracts/ContractDeliveredPayload.ts"
+)]
 pub struct ContractDeliveredPayload {
     pub contract_id: String,
     pub executor_id: String,
@@ -179,7 +194,10 @@ pub struct ContractDeliveredPayload {
 /// against the delivered artifact.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "../../../shared/generated/contracts/ContractVerifiedPayload.ts")]
+#[ts(
+    export,
+    export_to = "../../../shared/generated/contracts/ContractVerifiedPayload.ts"
+)]
 pub struct ContractVerifiedPayload {
     pub contract_id: String,
     pub verifier_id: String,
@@ -198,7 +216,10 @@ pub struct ContractVerifiedPayload {
 /// with `amount: 0`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "../../../shared/generated/contracts/ContractPaidPayload.ts")]
+#[ts(
+    export,
+    export_to = "../../../shared/generated/contracts/ContractPaidPayload.ts"
+)]
 pub struct ContractPaidPayload {
     pub contract_id: String,
     pub payer_id: String,
@@ -216,7 +237,10 @@ pub struct ContractPaidPayload {
 /// disputed contract for auditor review.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "../../../shared/generated/contracts/ContractDisputedPayload.ts")]
+#[ts(
+    export,
+    export_to = "../../../shared/generated/contracts/ContractDisputedPayload.ts"
+)]
 pub struct ContractDisputedPayload {
     pub contract_id: String,
     pub disputer_id: String,
@@ -254,9 +278,8 @@ pub fn declare_contract_event_classes() -> Result<usize, String> {
             on_unknown_schema: None, // defaults to Fail
             description: Some(format!("L1-6 contract event chain — {name}")),
         };
-        declare_event_class(name, &cfg).map_err(|e| {
-            format!("L1-6: failed to declare event class '{name}': {e}")
-        })?;
+        declare_event_class(name, &cfg)
+            .map_err(|e| format!("L1-6: failed to declare event class '{name}': {e}"))?;
         declared += 1;
     }
     Ok(declared)
@@ -292,9 +315,8 @@ mod tests {
         assert_eq!(count, 8);
 
         for name in ALL_CONTRACT_EVENT_NAMES {
-            let cfg = lookup_event_class(name).unwrap_or_else(|| {
-                panic!("class '{name}' was declared but lookup returned None")
-            });
+            let cfg = lookup_event_class(name)
+                .unwrap_or_else(|| panic!("class '{name}' was declared but lookup returned None"));
             assert!(cfg.broadcast, "{name} must be broadcast");
             assert_eq!(cfg.schema_version, CONTRACT_SCHEMA_VERSION);
         }

--- a/src/workers/continuum-core/src/contracts/mod.rs
+++ b/src/workers/continuum-core/src/contracts/mod.rs
@@ -15,29 +15,29 @@
 //!      `signature_hex`. Signature pins `(event_name, payload)`
 //!      together so relabeling attacks fail verification.
 //!
-//! Phase A (this PR): primitives + types + declarations + unit tests.
-//! Phase B (next): pubkey lookup against L1-4's `presence:peer-manifest`,
+//! Phase A: primitives + types + declarations + unit tests.
+//! Phase B: pubkey lookup against L1-4's `presence:peer-manifest`,
 //! verify-on-replay handler over L1-2's `AircEventTransport`.
 
 pub mod envelope;
 pub mod event_classes;
 pub mod signing;
+pub mod verification;
 
 #[cfg(test)]
 mod chain_tests;
 
 pub use envelope::SignedContractEvent;
 pub use event_classes::{
-    declare_contract_event_classes,
-    ContractAcceptedPayload, ContractBidPayload, ContractDeliveredPayload,
-    ContractDisputedPayload, ContractExecutingPayload, ContractPaidPayload,
-    ContractProposedPayload, ContractVerifiedPayload,
-    ALL_CONTRACT_EVENT_NAMES, CONTRACT_SCHEMA_VERSION,
-    EVENT_CONTRACT_ACCEPTED, EVENT_CONTRACT_BID, EVENT_CONTRACT_DELIVERED,
-    EVENT_CONTRACT_DISPUTED, EVENT_CONTRACT_EXECUTING, EVENT_CONTRACT_PAID,
-    EVENT_CONTRACT_PROPOSED, EVENT_CONTRACT_VERIFIED,
+    declare_contract_event_classes, ContractAcceptedPayload, ContractBidPayload,
+    ContractDeliveredPayload, ContractDisputedPayload, ContractExecutingPayload,
+    ContractPaidPayload, ContractProposedPayload, ContractVerifiedPayload,
+    ALL_CONTRACT_EVENT_NAMES, CONTRACT_SCHEMA_VERSION, EVENT_CONTRACT_ACCEPTED, EVENT_CONTRACT_BID,
+    EVENT_CONTRACT_DELIVERED, EVENT_CONTRACT_DISPUTED, EVENT_CONTRACT_EXECUTING,
+    EVENT_CONTRACT_PAID, EVENT_CONTRACT_PROPOSED, EVENT_CONTRACT_VERIFIED,
 };
 pub use signing::{
-    canonical_hash, ContractSigningKey, ContractVerifyingKey, SigningError,
-    CANONICAL_HASH_LEN, PUBLIC_KEY_LEN, SIGNATURE_LEN,
+    canonical_hash, ContractSigningKey, ContractVerifyingKey, SigningError, CANONICAL_HASH_LEN,
+    PUBLIC_KEY_LEN, SIGNATURE_LEN,
 };
+pub use verification::{verify_contract_replay, ContractVerificationError, VerifiedContractEvent};

--- a/src/workers/continuum-core/src/contracts/signing.rs
+++ b/src/workers/continuum-core/src/contracts/signing.rs
@@ -143,8 +143,7 @@ impl std::fmt::Debug for ContractVerifyingKey {
         write!(
             f,
             "ContractVerifyingKey({:02x}{:02x}{:02x}{:02x}..{:02x}{:02x}{:02x}{:02x})",
-            bytes[0], bytes[1], bytes[2], bytes[3],
-            bytes[28], bytes[29], bytes[30], bytes[31],
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[28], bytes[29], bytes[30], bytes[31],
         )
     }
 }
@@ -189,11 +188,11 @@ impl ContractVerifyingKey {
         let mut arr = [0u8; SIGNATURE_LEN];
         arr.copy_from_slice(signature_bytes);
         let sig = Signature::from_bytes(&arr);
-        self.inner.verify(canonical_bytes, &sig).map_err(|_| {
-            SigningError::VerificationFailed {
+        self.inner
+            .verify(canonical_bytes, &sig)
+            .map_err(|_| SigningError::VerificationFailed {
                 bytes_signed: canonical_bytes.len(),
-            }
-        })
+            })
     }
 }
 
@@ -212,8 +211,8 @@ impl ContractVerifyingKey {
 /// Returns the 32-byte SHA-256 of the canonical bytes.
 pub fn canonical_hash<T: Serialize>(payload: &T) -> Result<[u8; CANONICAL_HASH_LEN], SigningError> {
     // 1. Serialize to JSON value (handles any T: Serialize).
-    let value =
-        serde_json::to_value(payload).map_err(|e| SigningError::PayloadSerialization(e.to_string()))?;
+    let value = serde_json::to_value(payload)
+        .map_err(|e| SigningError::PayloadSerialization(e.to_string()))?;
     // 2. Reserialize through BTreeMap-backed Value to get key-sorted output.
     //    serde_json's Value uses BTreeMap when the `preserve_order`
     //    feature is OFF (default). So `to_vec(&value)` yields keys in
@@ -251,7 +250,6 @@ mod tests {
 
     #[test]
     fn keygen_then_sign_then_verify_roundtrips() {
-          
         let sk = ContractSigningKey::generate();
         let vk = sk.verifying_key();
 
@@ -263,7 +261,6 @@ mod tests {
 
     #[test]
     fn pubkey_round_trips_through_bytes() {
-          
         let sk = ContractSigningKey::generate();
         let vk = sk.verifying_key();
 
@@ -279,7 +276,6 @@ mod tests {
 
     #[test]
     fn bad_signature_bytes_fail_loud() {
-          
         let sk = ContractSigningKey::generate();
         let vk = sk.verifying_key();
 
@@ -294,7 +290,6 @@ mod tests {
 
     #[test]
     fn wrong_payload_fails_loud() {
-          
         let sk = ContractSigningKey::generate();
         let vk = sk.verifying_key();
 
@@ -315,7 +310,6 @@ mod tests {
 
     #[test]
     fn cross_key_verify_fails_loud() {
-          
         let sk_a = ContractSigningKey::generate();
         let sk_b = ContractSigningKey::generate();
 
@@ -329,13 +323,15 @@ mod tests {
 
     #[test]
     fn signature_is_deterministic() {
-          
         let sk = ContractSigningKey::generate();
 
         let hash = canonical_hash(&dummy()).unwrap();
         let sig1 = sk.sign(&hash);
         let sig2 = sk.sign(&hash);
-        assert_eq!(sig1, sig2, "ed25519 must be deterministic for replay-equivalence");
+        assert_eq!(
+            sig1, sig2,
+            "ed25519 must be deterministic for replay-equivalence"
+        );
     }
 
     #[test]
@@ -360,16 +356,27 @@ mod tests {
 
     #[test]
     fn signature_length_validation() {
-          
         let vk = ContractSigningKey::generate().verifying_key();
         let err = vk.verify(b"anything", &[0u8; 63]).unwrap_err();
-        assert!(matches!(err, SigningError::SignatureLength { expected: 64, got: 63 }));
+        assert!(matches!(
+            err,
+            SigningError::SignatureLength {
+                expected: 64,
+                got: 63
+            }
+        ));
     }
 
     #[test]
     fn pubkey_length_validation() {
         let err = ContractVerifyingKey::from_bytes(&[0u8; 31]).unwrap_err();
-        assert!(matches!(err, SigningError::PublicKeyLength { expected: 32, got: 31 }));
+        assert!(matches!(
+            err,
+            SigningError::PublicKeyLength {
+                expected: 32,
+                got: 31
+            }
+        ));
     }
 
     // NOTE: Point-validation (rejecting 32 bytes that decompress off-curve)

--- a/src/workers/continuum-core/src/contracts/verification.rs
+++ b/src/workers/continuum-core/src/contracts/verification.rs
@@ -1,0 +1,473 @@
+//! Contract replay verification against AIRC peer manifests.
+//!
+//! L1-6 Phase A verifies that an ed25519 key signed a contract event.
+//! This module closes Phase B: the verified key must also be the key
+//! advertised by the peer manifest for the participant that claims to
+//! have signed the event.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::airc::{
+    AircPeerManifest, AircRealtimeEnvelope, AircRealtimePayload, AircRealtimeReplayResult,
+    AircRealtimeSchema,
+};
+use crate::contracts::{
+    ContractAcceptedPayload, ContractBidPayload, ContractDeliveredPayload, ContractDisputedPayload,
+    ContractExecutingPayload, ContractPaidPayload, ContractProposedPayload,
+    ContractVerifiedPayload, SignedContractEvent, EVENT_CONTRACT_ACCEPTED, EVENT_CONTRACT_BID,
+    EVENT_CONTRACT_DELIVERED, EVENT_CONTRACT_DISPUTED, EVENT_CONTRACT_EXECUTING,
+    EVENT_CONTRACT_PAID, EVENT_CONTRACT_PROPOSED, EVENT_CONTRACT_VERIFIED,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedContractEvent {
+    pub replay_event_id: String,
+    pub room_id: uuid::Uuid,
+    pub contract_id: String,
+    pub event_name: String,
+    pub signer_peer_id: String,
+    pub signer_pubkey_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContractVerificationError {
+    MalformedContractEvent {
+        event_id: String,
+        event_name: String,
+        reason: String,
+    },
+    SignatureRejected {
+        event_id: String,
+        event_name: String,
+        reason: String,
+    },
+    MissingPeerManifest {
+        event_id: String,
+        event_name: String,
+        signer_peer_id: String,
+    },
+    ManifestPubkeyMismatch {
+        event_id: String,
+        event_name: String,
+        signer_peer_id: String,
+        manifest_pubkey_hex: String,
+        event_pubkey_hex: String,
+    },
+    SourcePeerMismatch {
+        event_id: String,
+        event_name: String,
+        source_id: String,
+        signer_peer_id: String,
+    },
+}
+
+impl std::fmt::Display for ContractVerificationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MalformedContractEvent {
+                event_id,
+                event_name,
+                reason,
+            } => write!(
+                f,
+                "contract event {event_id} ({event_name}) is malformed: {reason}",
+            ),
+            Self::SignatureRejected {
+                event_id,
+                event_name,
+                reason,
+            } => write!(
+                f,
+                "contract event {event_id} ({event_name}) signature rejected: {reason}",
+            ),
+            Self::MissingPeerManifest {
+                event_id,
+                event_name,
+                signer_peer_id,
+            } => write!(
+                f,
+                "contract event {event_id} ({event_name}) signer {signer_peer_id} has no active peer manifest",
+            ),
+            Self::ManifestPubkeyMismatch {
+                event_id,
+                event_name,
+                signer_peer_id,
+                ..
+            } => write!(
+                f,
+                "contract event {event_id} ({event_name}) signer {signer_peer_id} pubkey does not match peer manifest",
+            ),
+            Self::SourcePeerMismatch {
+                event_id,
+                event_name,
+                source_id,
+                signer_peer_id,
+            } => write!(
+                f,
+                "contract event {event_id} ({event_name}) source_id {source_id} does not match signer {signer_peer_id}",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ContractVerificationError {}
+
+pub fn verify_contract_replay(
+    replay: &AircRealtimeReplayResult,
+) -> Result<Vec<VerifiedContractEvent>, ContractVerificationError> {
+    let manifests = PeerManifestIndex::new(&replay.active_peer_manifests);
+    let mut verified = Vec::new();
+    for event in &replay.events {
+        if let Some(contract) = parse_contract_event(event)? {
+            verify_manifest_binding(&manifests, event, &contract)?;
+            verified.push(contract);
+        }
+    }
+    Ok(verified)
+}
+
+struct PeerManifestIndex<'a> {
+    by_peer_id: HashMap<&'a str, &'a AircPeerManifest>,
+}
+
+impl<'a> PeerManifestIndex<'a> {
+    fn new(manifests: &'a [AircPeerManifest]) -> Self {
+        Self {
+            by_peer_id: manifests
+                .iter()
+                .map(|manifest| (manifest.peer_id.as_str(), manifest))
+                .collect(),
+        }
+    }
+
+    fn get(&self, peer_id: &str) -> Option<&AircPeerManifest> {
+        self.by_peer_id.get(peer_id).copied()
+    }
+}
+
+fn parse_contract_event(
+    event: &AircRealtimeEnvelope,
+) -> Result<Option<VerifiedContractEvent>, ContractVerificationError> {
+    let Some(value) = inline_event_bridge_payload(event) else {
+        return Ok(None);
+    };
+    let Some(event_name) = value.get("eventName").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+
+    let verified = match event_name {
+        EVENT_CONTRACT_PROPOSED => {
+            parse_and_verify::<ContractProposedPayload>(event, event_name, value, |payload| {
+                (&payload.contract_id, &payload.proposer_id)
+            })?
+        }
+        EVENT_CONTRACT_BID => {
+            parse_and_verify::<ContractBidPayload>(event, event_name, value, |payload| {
+                (&payload.contract_id, &payload.bidder_id)
+            })?
+        }
+        EVENT_CONTRACT_ACCEPTED => {
+            parse_and_verify::<ContractAcceptedPayload>(event, event_name, value, |payload| {
+                (&payload.contract_id, &payload.proposer_id)
+            })?
+        }
+        EVENT_CONTRACT_EXECUTING => {
+            parse_and_verify::<ContractExecutingPayload>(event, event_name, value, |payload| {
+                (&payload.contract_id, &payload.executor_id)
+            })?
+        }
+        EVENT_CONTRACT_DELIVERED => {
+            parse_and_verify::<ContractDeliveredPayload>(event, event_name, value, |payload| {
+                (&payload.contract_id, &payload.executor_id)
+            })?
+        }
+        EVENT_CONTRACT_VERIFIED => {
+            parse_and_verify::<ContractVerifiedPayload>(event, event_name, value, |payload| {
+                (&payload.contract_id, &payload.verifier_id)
+            })?
+        }
+        EVENT_CONTRACT_PAID => {
+            parse_and_verify::<ContractPaidPayload>(event, event_name, value, |payload| {
+                (&payload.contract_id, &payload.payer_id)
+            })?
+        }
+        EVENT_CONTRACT_DISPUTED => {
+            parse_and_verify::<ContractDisputedPayload>(event, event_name, value, |payload| {
+                (&payload.contract_id, &payload.disputer_id)
+            })?
+        }
+        _ => return Ok(None),
+    };
+
+    Ok(Some(verified))
+}
+
+fn inline_event_bridge_payload(event: &AircRealtimeEnvelope) -> Option<&Value> {
+    match &event.payload {
+        AircRealtimePayload::ExistingSchema { payload }
+            if payload.schema == AircRealtimeSchema::EventBridgePayload =>
+        {
+            payload.inline.as_ref()
+        }
+        _ => None,
+    }
+}
+
+fn parse_and_verify<P>(
+    event: &AircRealtimeEnvelope,
+    event_name: &str,
+    value: &Value,
+    signer_fields: impl for<'a> FnOnce(&'a P) -> (&'a String, &'a String),
+) -> Result<VerifiedContractEvent, ContractVerificationError>
+where
+    P: Serialize + for<'de> Deserialize<'de>,
+{
+    let signed =
+        serde_json::from_value::<SignedContractEvent<P>>(value.clone()).map_err(|error| {
+            ContractVerificationError::MalformedContractEvent {
+                event_id: event.event_id.clone(),
+                event_name: event_name.to_string(),
+                reason: error.to_string(),
+            }
+        })?;
+    signed
+        .verify()
+        .map_err(|error| ContractVerificationError::SignatureRejected {
+            event_id: event.event_id.clone(),
+            event_name: event_name.to_string(),
+            reason: error.to_string(),
+        })?;
+    let (contract_id, signer_peer_id) = signer_fields(&signed.payload);
+    Ok(VerifiedContractEvent {
+        replay_event_id: event.event_id.clone(),
+        room_id: event.room_id,
+        contract_id: contract_id.clone(),
+        event_name: signed.event_name,
+        signer_peer_id: signer_peer_id.clone(),
+        signer_pubkey_hex: signed.signer_pubkey_hex,
+    })
+}
+
+fn verify_manifest_binding(
+    manifests: &PeerManifestIndex<'_>,
+    envelope: &AircRealtimeEnvelope,
+    contract: &VerifiedContractEvent,
+) -> Result<(), ContractVerificationError> {
+    let manifest = manifests.get(&contract.signer_peer_id).ok_or_else(|| {
+        ContractVerificationError::MissingPeerManifest {
+            event_id: envelope.event_id.clone(),
+            event_name: contract.event_name.clone(),
+            signer_peer_id: contract.signer_peer_id.clone(),
+        }
+    })?;
+
+    if !manifest
+        .signing_pubkey_hex
+        .eq_ignore_ascii_case(&contract.signer_pubkey_hex)
+    {
+        return Err(ContractVerificationError::ManifestPubkeyMismatch {
+            event_id: envelope.event_id.clone(),
+            event_name: contract.event_name.clone(),
+            signer_peer_id: contract.signer_peer_id.clone(),
+            manifest_pubkey_hex: manifest.signing_pubkey_hex.clone(),
+            event_pubkey_hex: contract.signer_pubkey_hex.clone(),
+        });
+    }
+
+    if envelope.source_id != contract.signer_peer_id {
+        return Err(ContractVerificationError::SourcePeerMismatch {
+            event_id: envelope.event_id.clone(),
+            event_name: contract.event_name.clone(),
+            source_id: envelope.source_id.clone(),
+            signer_peer_id: contract.signer_peer_id.clone(),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::airc::{
+        AircPeerCapability, AircRealtimeDelivery, AircRealtimePayloadRef, AircReplayCursor,
+    };
+    use crate::contracts::{ContractSigningKey, EVENT_CONTRACT_PROPOSED};
+
+    fn room() -> uuid::Uuid {
+        uuid::Uuid::from_u128(0xA1)
+    }
+
+    fn proposed_payload(peer_id: &str) -> ContractProposedPayload {
+        ContractProposedPayload {
+            contract_id: "contract-1".to_string(),
+            proposer_id: peer_id.to_string(),
+            alloy_hash: "sha256:contract".to_string(),
+            bid_currency: "".to_string(),
+            max_bid: 0,
+            expiry_unix_ms: 1_779_800_000_000,
+            required_capability: "continuum.lora.invoke".to_string(),
+        }
+    }
+
+    fn manifest(peer_id: &str, key: &ContractSigningKey) -> AircPeerManifest {
+        let pubkey_hex =
+            SignedContractEvent::sign(EVENT_CONTRACT_PROPOSED, proposed_payload(peer_id), key, 1)
+                .unwrap()
+                .signer_pubkey_hex;
+        AircPeerManifest {
+            peer_id: peer_id.to_string(),
+            display_name: None,
+            room_ids: vec![room()],
+            capabilities: vec![AircPeerCapability {
+                id: "continuum.lora.invoke".to_string(),
+                label: None,
+                version: None,
+            }],
+            signing_pubkey_hex: pubkey_hex,
+            advertised_at_ms: 1,
+            expires_at_ms: None,
+        }
+    }
+
+    fn signed_contract_event(peer_id: &str, key: &ContractSigningKey) -> AircRealtimeEnvelope {
+        let signed =
+            SignedContractEvent::sign(EVENT_CONTRACT_PROPOSED, proposed_payload(peer_id), key, 2)
+                .unwrap();
+        AircRealtimeEnvelope {
+            event_id: "event-1".to_string(),
+            room_id: room(),
+            source_id: peer_id.to_string(),
+            target_id: None,
+            created_at_ms: 2,
+            delivery: AircRealtimeDelivery::Durable,
+            payload: AircRealtimePayload::ExistingSchema {
+                payload: AircRealtimePayloadRef::inline(
+                    AircRealtimeSchema::EventBridgePayload,
+                    serde_json::to_value(signed).unwrap(),
+                ),
+            },
+            trace_id: None,
+        }
+    }
+
+    fn replay(
+        events: Vec<AircRealtimeEnvelope>,
+        active_peer_manifests: Vec<AircPeerManifest>,
+    ) -> AircRealtimeReplayResult {
+        AircRealtimeReplayResult {
+            room_id: room(),
+            events,
+            cursor: Some(AircReplayCursor {
+                room_id: room(),
+                lamport: 1,
+                event_id: "event-1".to_string(),
+                observed_at_ms: Some(2),
+            }),
+            active_presence: Vec::new(),
+            active_subscriptions: Vec::new(),
+            active_peer_manifests,
+            capability_index: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn verifies_contract_event_against_peer_manifest_pubkey() {
+        let key = ContractSigningKey::generate();
+        let peer_id = "peer-a";
+        let result = verify_contract_replay(&replay(
+            vec![signed_contract_event(peer_id, &key)],
+            vec![manifest(peer_id, &key)],
+        ))
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].contract_id, "contract-1");
+        assert_eq!(result[0].event_name, EVENT_CONTRACT_PROPOSED);
+        assert_eq!(result[0].signer_peer_id, peer_id);
+    }
+
+    #[test]
+    fn rejects_contract_event_without_peer_manifest() {
+        let key = ContractSigningKey::generate();
+        let error = verify_contract_replay(&replay(
+            vec![signed_contract_event("peer-a", &key)],
+            Vec::new(),
+        ))
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ContractVerificationError::MissingPeerManifest { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_contract_event_when_manifest_pubkey_differs() {
+        let signer = ContractSigningKey::generate();
+        let other = ContractSigningKey::generate();
+        let error = verify_contract_replay(&replay(
+            vec![signed_contract_event("peer-a", &signer)],
+            vec![manifest("peer-a", &other)],
+        ))
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ContractVerificationError::ManifestPubkeyMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_contract_event_when_source_id_is_not_signer() {
+        let key = ContractSigningKey::generate();
+        let mut event = signed_contract_event("peer-a", &key);
+        event.source_id = "peer-b".to_string();
+        let error = verify_contract_replay(&replay(vec![event], vec![manifest("peer-a", &key)]))
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ContractVerificationError::SourcePeerMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn ignores_non_contract_event_bridge_payloads() {
+        let event = AircRealtimeEnvelope::new(
+            "event-2".to_string(),
+            room(),
+            "peer-a".to_string(),
+            2,
+            AircRealtimePayload::ExistingSchema {
+                payload: AircRealtimePayloadRef::inline(
+                    AircRealtimeSchema::EventBridgePayload,
+                    serde_json::json!({"eventName": "chat:posted", "payload": {}}),
+                ),
+            },
+        );
+
+        let result = verify_contract_replay(&replay(vec![event], Vec::new())).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn rejects_tampered_contract_event_signature() {
+        let key = ContractSigningKey::generate();
+        let mut event = signed_contract_event("peer-a", &key);
+        if let AircRealtimePayload::ExistingSchema { payload } = &mut event.payload {
+            payload.inline.as_mut().unwrap()["payload"]["maxBid"] = serde_json::json!(10);
+        }
+
+        let error = verify_contract_replay(&replay(vec![event], vec![manifest("peer-a", &key)]))
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ContractVerificationError::SignatureRejected { .. }
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- completes L1-6 Phase B by adding `contracts::verification`
- verifies replayed signed contract events cryptographically, then binds the signer pubkey to the active `presence:peer-manifest.signing_pubkey_hex`
- rejects missing manifests, pubkey mismatches, source/signer mismatches, and tampered signatures with typed errors
- updates `docs/grid/AIRC-IPC-DEP-RATIONALE.md` to mark the Phase B gap as landed

## Roadmap
- Card: `e25898e6-8690-46dc-9693-c67d65b60f6e`
- Docs: `docs/grid/AIRC-IPC-DEP-RATIONALE.md`, `docs/grid/GRID-MIGRATION-ROADMAP.md`

## Verification
- `rustfmt --edition 2021 --check src/workers/continuum-core/src/contracts/verification.rs src/workers/continuum-core/src/contracts/mod.rs src/workers/continuum-core/src/contracts/envelope.rs src/workers/continuum-core/src/contracts/event_classes.rs src/workers/continuum-core/src/contracts/signing.rs`
- `cargo test --manifest-path src/workers/Cargo.toml -p continuum-core --lib contracts --features metal,accelerate`
- `cargo test --manifest-path src/workers/Cargo.toml -p continuum-core --lib contracts::verification --features metal,accelerate`
- `cargo test --manifest-path src/workers/Cargo.toml -p continuum-core --lib airc --features metal,accelerate`
- precommit passed: TS, modified-file Rust clippy baseline, chat roundtrip; browser ping used existing timeout-skip path
- prepush passed: TS, ESLint baseline ratchet, Rust compile, Rust tests

## Note
Full-library clippy with `-D warnings` is still blocked by the existing `llama/src/mtmd.rs` `too_many_arguments` baseline, unrelated to this PR.
