### PR TITLE
feat: Mac Intel hardware tier + cognition perf pass

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -235,6 +235,23 @@ For 16GB MBA: chat-only OOTB works (smaller model). For 32GB+: full multimodal e
       CONTINUUM_TIER="primary"
       info "Hardware tier: primary (${PHYS_GB}GB) — full multimodal + Qwen 4B code-forged"
     fi
+
+    # Mac Intel override — RAM-based tier alone misclassifies Mac Intel +
+    # discrete AMD or integrated Intel UHD as full/primary, but the
+    # llama.cpp Metal-AMD shader path produces incoherent tokens on this
+    # hardware (continuum 2026-05-30 evidence on MacBookPro15,1 / Radeon
+    # Pro 560X: 0.8 tok/s + multilingual garbage + hundreds of nil
+    # tensor buffer errors). Force the small CPU-runnable model tier
+    # regardless of RAM until our CambrianTech/llama.cpp fork patches
+    # the Metal-AMD kernels OR grid-share routes to an Apple-Silicon /
+    # NVIDIA peer. Mirrors the Rust HwCapabilityTier::MacIntelMetalDiscrete
+    # branch and the `mac_intel_discrete` tier in src/shared/models.json.
+    CPU_BRAND=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "")
+    if [[ "$CPU_BRAND" == *"Intel"* ]]; then
+      info "Mac Intel detected ($CPU_BRAND) — overriding to mac_intel_discrete tier (Metal-AMD shaders unreliable; smallest forged model + CPU-only floor)"
+      CONTINUUM_TIER="mac_intel_discrete"
+      NATIVE_RESERVE_MIB=$((5 * 1024))
+    fi
     export CONTINUUM_TIER
     MACOS_RESERVE_MIB=$((6 * 1024))
     HEADROOM_MIB=$((NATIVE_RESERVE_MIB + MACOS_RESERVE_MIB))
@@ -417,6 +434,15 @@ EOF
       # 24-31GB: 2B general (~1.4GB GGUF). Bigger context window viable.
       PERSONA_MODEL="hf.co/continuum-ai/qwen3.5-2b-general-forged"
       info "Persona model tier: mid → qwen3.5-2b-general-forged (~1.4GB)"
+      ;;
+    mac_intel_discrete)
+      # Mac Intel + discrete AMD / integrated Intel UHD. llama.cpp Metal
+      # shaders broken on this path; smallest forged model + CPU-only.
+      # Matches `tiers.mac_intel_discrete.default_chat` in
+      # src/shared/models.json. When CambrianTech/llama.cpp lands the
+      # Metal-AMD shader patch, this branch can promote to mid or full.
+      PERSONA_MODEL="hf.co/continuum-ai/qwen3.5-0.8b-general-forged"
+      info "Persona model tier: mac_intel_discrete → qwen3.5-0.8b-general-forged (~500MB, CPU-only)"
       ;;
     *)
       # 32GB+: original code-forged 4B (~2.7GB GGUF). Multimodal headroom.

--- a/src/shared/ModelRegistry.ts
+++ b/src/shared/ModelRegistry.ts
@@ -17,7 +17,19 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 export type ModelKind = 'chat-llm' | 'vision-llm' | 'embedding' | 'stt' | 'tts' | 'tts-trainable' | 'vad' | 'chat-llm-fast';
-export type Tier = 'mba' | 'mid' | 'full';
+
+/**
+ * Host-tier label that drives default-model selection. Most tiers are
+ * RAM-bucketed (mba/mid/full); `mac_intel_discrete` is a hardware-shaped
+ * override for Mac Intel hosts with a discrete AMD or integrated Intel
+ * UHD Metal device — even with 32GB RAM, llama.cpp's Metal-AMD shader
+ * path produces incoherent tokens (continuum 2026-05-30 evidence on
+ * MacBookPro15,1 / Radeon Pro 560X), so the tier policy must override
+ * the RAM-based bucket and pick the smallest forged model that CPU
+ * inference can comfortably run. Matches the Rust `HwCapabilityTier`
+ * variant `MacIntelMetalDiscrete` — keep the two in sync.
+ */
+export type Tier = 'mba' | 'mid' | 'full' | 'mac_intel_discrete';
 
 /**
  * Canonical symbolic refs that personas store in DB. Code reads these
@@ -42,6 +54,7 @@ export const TIERS = {
   MBA: 'mba' as const,
   MID: 'mid' as const,
   FULL: 'full' as const,
+  MAC_INTEL_DISCRETE: 'mac_intel_discrete' as const,
 };
 
 export interface ModelSpec {
@@ -109,11 +122,39 @@ function load(): RegistryFile {
  * Pick host tier from total RAM in GB. Same logic as install.sh's
  * tier-detection block — kept consistent so install-time and runtime
  * resolve to the same default model.
+ *
+ * Pure-RAM fallback. Prefer [`tierFromHost`] when a hardware-capability
+ * hint is available — RAM alone misclassifies Mac Intel + discrete GPU
+ * (32GB Mac Intel reads as "full" but its 4GB AMD VRAM can't run a 4B
+ * model, and the Metal-AMD shader path is broken — continuum 2026-05-30
+ * evidence).
  */
 export function tierFromRamGB(ramGB: number): Tier {
   if (ramGB >= 32) return 'full';
   if (ramGB >= 24) return 'mid';
   return 'mba';
+}
+
+/**
+ * Pick host tier from RAM + hardware-capability tier (matches the Rust
+ * `HwCapabilityTier` variants from `cognition::model_resolver`). The
+ * hardware tier overrides RAM when it names a class whose physical-VRAM
+ * or shader-path budget diverges from the RAM-based expectation.
+ *
+ * Current overrides:
+ * - `mac_intel_metal_discrete` → `mac_intel_discrete`. Mac Intel with
+ *   discrete AMD or integrated Intel UHD. llama.cpp Metal shaders
+ *   unreliable on this path; the tier maps to a small CPU-runnable
+ *   model regardless of system RAM.
+ *
+ * Other hardware tiers (M-series, NVIDIA, VulkanAmd) fall through to
+ * RAM-based selection — they have unified or reliable discrete VRAM
+ * and the RAM heuristic remains accurate. Pass `hwTier === undefined`
+ * to get pure-RAM behavior (equivalent to [`tierFromRamGB`]).
+ */
+export function tierFromHost(ramGB: number, hwTier?: string): Tier {
+  if (hwTier === 'mac_intel_metal_discrete') return 'mac_intel_discrete';
+  return tierFromRamGB(ramGB);
 }
 
 /**

--- a/src/shared/generated/cognition/HwCapabilityTier.ts
+++ b/src/shared/generated/cognition/HwCapabilityTier.ts
@@ -22,4 +22,4 @@
  * caller's hardware probe must produce it AND every match-on-tier site
  * gets a compile error reminding the author to handle it.
  */
-export type HwCapabilityTier = "cpu_only" | "m1_uma8_gb" | "m1_uma16_gb" | "m2_uma_pro_max" | "m3_uma_pro_max" | "sm70" | "sm75" | "sm80" | "sm86" | "sm89" | "sm90" | "sm100" | "sm120" | "vulkan_amd" | "cloud";
+export type HwCapabilityTier = "cpu_only" | "m1_uma8_gb" | "m1_uma16_gb" | "m2_uma_pro_max" | "m3_uma_pro_max" | "mac_intel_metal_discrete" | "sm70" | "sm75" | "sm80" | "sm86" | "sm89" | "sm90" | "sm100" | "sm120" | "vulkan_amd" | "cloud";

--- a/src/shared/models.json
+++ b/src/shared/models.json
@@ -135,7 +135,8 @@
   "tiers": {
     "mba":  { "min_ram_gb": 16, "default_chat": "qwen3.5-0.8b-general", "description": "MacBook Air / 16-23GB RAM. Chat-only OOTB, minimal footprint." },
     "mid":  { "min_ram_gb": 24, "default_chat": "qwen3.5-2b-general",   "description": "Mid-tier 24-31GB. Larger context window viable." },
-    "full": { "min_ram_gb": 32, "default_chat": "qwen3.5-4b-code-forged", "description": "32GB+. Full multimodal experience including vision." }
+    "full": { "min_ram_gb": 32, "default_chat": "qwen3.5-4b-code-forged", "description": "32GB+. Full multimodal experience including vision." },
+    "mac_intel_discrete": { "default_chat": "qwen3.5-0.8b-general", "description": "Mac Intel with discrete AMD or integrated Intel UHD Metal device (e.g. MacBookPro15,1 / Radeon Pro 560X). llama.cpp Metal shaders unreliable on this path; CPU-only with smallest forged model until our CambrianTech/llama.cpp fork patches AMD-Metal kernels OR grid-share routes to an Apple-Silicon or NVIDIA peer." }
   },
 
   "symbolic_refs": {
@@ -159,7 +160,8 @@
     "by_tier": {
       "mba":  ["qwen3.5-0.8b-general"],
       "mid":  ["qwen3.5-2b-general"],
-      "full": ["qwen3.5-4b-code-forged", "qwen2-vl-7b"]
+      "full": ["qwen3.5-4b-code-forged", "qwen2-vl-7b"],
+      "mac_intel_discrete": ["qwen3.5-0.8b-general"]
     }
   },
 

--- a/src/shared/models.json
+++ b/src/shared/models.json
@@ -36,7 +36,7 @@
       "hf_repo": "continuum-ai/qwen3.5-4b-code-forged-GGUF",
       "format": "gguf",
       "architecture": "qwen3",
-      "files": ["qwen3.5-4b-code-forged-q4_k_m.gguf"],
+      "files": ["qwen3.5-4b-code-forged-Q4_K_M.gguf"],
       "size_gb": 2.7,
       "min_ram_gb": 32,
       "chat_template": "qwen2",

--- a/src/workers/continuum-core/src/cognition/host_capability_probe.rs
+++ b/src/workers/continuum-core/src/cognition/host_capability_probe.rs
@@ -158,7 +158,11 @@ fn metal_tier(
             apple_silicon_tier(cpu_brand, total_mem_mb),
             TargetSilicon::UnifiedMemory,
         ))
-    } else if cpu_brand.to_lowercase().contains("intel") {
+    } else if cpu_brand.contains("Intel") {
+        // Intel CPU brand strings reliably capitalize "Intel"
+        // (e.g. "Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz") — match
+        // the literal substring directly instead of allocating a
+        // lowercase copy on every boot probe.
         // Mac Intel with Metal — by elimination this is one of the
         // 2018-2019 MacBookPro / iMac models with either Intel UHD
         // integrated or AMD Radeon Pro discrete (often both — system

--- a/src/workers/continuum-core/src/cognition/host_capability_probe.rs
+++ b/src/workers/continuum-core/src/cognition/host_capability_probe.rs
@@ -67,8 +67,11 @@ pub enum ProbeError {
 /// snapshot. Pure: caller owns both inputs.
 ///
 /// Mapping rules:
-/// - `platform == "metal"` → [`TargetSilicon::UnifiedMemory`]; tier from
-///   CPU brand string + total memory (Apple M-series buckets).
+/// - `platform == "metal"` → see [`metal_tier`]: Apple Silicon →
+///   [`TargetSilicon::UnifiedMemory`] with M-series bucket; Mac Intel +
+///   discrete (AMD/UHD) → [`TargetSilicon::Gpu`] with
+///   [`HwCapabilityTier::MacIntelMetalDiscrete`]; anything else surfaces
+///   [`ProbeError::UnknownGpuDevice`].
 /// - `platform == "cuda"` → [`TargetSilicon::Gpu`]; tier from device-name
 ///   pattern (RTX/A100/H100/V100/B100/T4/etc.).
 /// - `platform == "vulkan"` → [`TargetSilicon::Gpu`];
@@ -95,10 +98,7 @@ pub fn detect_host_capability(
     let (hw_capability_tier, primary_target_silicon) = match platform {
         "metal" => {
             let cpu_brand = first_cpu_brand(system_info);
-            (
-                apple_silicon_tier(&cpu_brand, total_mem_mb),
-                TargetSilicon::UnifiedMemory,
-            )
+            metal_tier(&cpu_brand, device_name, total_mem_mb, platform)?
         }
         "cuda" => (nvidia_sm_tier(device_name, platform)?, TargetSilicon::Gpu),
         "vulkan" => (HwCapabilityTier::VulkanAmd, TargetSilicon::Gpu),
@@ -128,6 +128,56 @@ fn first_cpu_brand(system_info: &System) -> String {
         .unwrap_or_default()
 }
 
+/// Classify a host whose GPU monitor reports `platform == "metal"`. Splits
+/// into two physically-distinct families:
+///
+/// 1. **Apple Silicon** (CPU brand contains `Apple M`): unified memory,
+///    Metal 3 / tensor API works, llama.cpp's Metal shaders are
+///    well-supported. Tier comes from [`apple_silicon_tier`]; silicon is
+///    [`TargetSilicon::UnifiedMemory`].
+/// 2. **Mac Intel + discrete GPU** (Intel CPU brand + non-Apple Metal
+///    device name, e.g. "AMD Radeon Pro 560X"): separate VRAM, Metal 2
+///    only, llama.cpp Metal shaders produce garbled tokens (continuum
+///    2026-05-30 evidence: 0.8 tok/s + nil tensor buffers on
+///    MacBookPro15,1). Tier is [`HwCapabilityTier::MacIntelMetalDiscrete`];
+///    silicon is [`TargetSilicon::Gpu`] (discrete VRAM, NOT unified).
+///
+/// Any other combination — Intel CPU + Apple device name, or unknown CPU
+/// brand entirely — surfaces [`ProbeError::UnknownGpuDevice`] so the
+/// operator adds the variant rather than getting silent default routing.
+/// No silent fallback to `M1Uma16Gb` (which was the bug on this host
+/// before 2026-05-30).
+fn metal_tier(
+    cpu_brand: &str,
+    device_name: &str,
+    total_mem_mb: u32,
+    platform: &str,
+) -> Result<(HwCapabilityTier, TargetSilicon), ProbeError> {
+    if cpu_brand.contains("Apple M") {
+        Ok((
+            apple_silicon_tier(cpu_brand, total_mem_mb),
+            TargetSilicon::UnifiedMemory,
+        ))
+    } else if cpu_brand.to_lowercase().contains("intel") {
+        // Mac Intel with Metal — by elimination this is one of the
+        // 2018-2019 MacBookPro / iMac models with either Intel UHD
+        // integrated or AMD Radeon Pro discrete (often both — system
+        // picks one as system_default). Either way, llama.cpp's Metal
+        // path is unreliable here until we fork-patch the shader
+        // implementation. TargetSilicon::Gpu reflects the physical
+        // reality (discrete VRAM); resolver policy should still prefer
+        // CPU lanes for this tier in practice.
+        Ok((HwCapabilityTier::MacIntelMetalDiscrete, TargetSilicon::Gpu))
+    } else {
+        Err(ProbeError::UnknownGpuDevice {
+            platform: platform.to_string(),
+            device_name: format!(
+                "{device_name} (cpu_brand={cpu_brand}, total_mem_mb={total_mem_mb})"
+            ),
+        })
+    }
+}
+
 /// Map an Apple Silicon CPU brand + total system memory to an
 /// [`HwCapabilityTier`]. The tier represents what model variants this
 /// machine can run, not just the chip generation — so memory is part of
@@ -144,6 +194,11 @@ fn first_cpu_brand(system_info: &System) -> String {
 /// The thresholds are deliberately under the marketing "16GB / 32GB"
 /// numbers because sysinfo reports physical-memory minus reserved
 /// firmware/OS regions — a "16GB" Mac reports ~15.5GiB ≈ 15800MB.
+///
+/// Precondition: caller has verified `cpu_brand` matches Apple Silicon
+/// ([`metal_tier`] enforces this). If a non-Apple brand reaches here it
+/// silently falls into `M1Uma*` — that bug bit Mac Intel hosts before
+/// 2026-05-30; the [`metal_tier`] wrapper is the guard.
 fn apple_silicon_tier(cpu_brand: &str, total_mem_mb: u32) -> HwCapabilityTier {
     if cpu_brand.contains("M3") || cpu_brand.contains("M4") || cpu_brand.contains("M5") {
         HwCapabilityTier::M3UmaProMax
@@ -298,6 +353,86 @@ mod tests {
             } => {
                 assert_eq!(platform, "cuda");
                 assert_eq!(device_name, "NVIDIA Voodoo 5 6000");
+            }
+            other => panic!("expected UnknownGpuDevice; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn metal_tier_routes_apple_silicon_to_uma_branch() {
+        // M3 Pro / 32GB → M3UmaProMax + UnifiedMemory. Confirms the
+        // wrapper still routes Apple Silicon to the existing buckets.
+        let (tier, silicon) =
+            metal_tier("Apple M3 Pro", "Apple M3 Pro", 32_000, "metal").unwrap();
+        assert_eq!(tier, HwCapabilityTier::M3UmaProMax);
+        assert_eq!(silicon, TargetSilicon::UnifiedMemory);
+    }
+
+    #[test]
+    fn metal_tier_routes_mac_intel_amd_to_new_tier_not_silent_m1() {
+        // The 2026-05-30 bug repro: Intel(R) Core(TM) i7-8850H + AMD
+        // Radeon Pro 560X + 32GB RAM was silently classified as
+        // M1Uma16Gb before this fix, which led to the resolver selecting
+        // a 4B model that produced garbled tokens at 0.8 tok/s on the
+        // discrete AMD Metal path. Post-fix it lands on
+        // MacIntelMetalDiscrete with TargetSilicon::Gpu — and the
+        // resolver / tier policy then knows to downsize.
+        let (tier, silicon) = metal_tier(
+            "Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz",
+            "AMD Radeon Pro 560X",
+            32_000,
+            "metal",
+        )
+        .unwrap();
+        assert_eq!(
+            tier,
+            HwCapabilityTier::MacIntelMetalDiscrete,
+            "Mac Intel + AMD discrete must NOT silently route to M1Uma*; \
+             that was the bug on MacBookPro15,1 before 2026-05-30"
+        );
+        assert_eq!(
+            silicon,
+            TargetSilicon::Gpu,
+            "discrete AMD has its own VRAM — NOT unified memory like Apple Silicon"
+        );
+    }
+
+    #[test]
+    fn metal_tier_routes_mac_intel_uhd_to_same_tier() {
+        // Intel UHD Graphics 630 is the integrated GPU; system_default()
+        // can pick it depending on power state. Same tier as discrete —
+        // either way this is "Mac Intel Metal" and llama.cpp's Metal
+        // path is unreliable.
+        let (tier, _silicon) = metal_tier(
+            "Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz",
+            "Intel UHD Graphics 630",
+            32_000,
+            "metal",
+        )
+        .unwrap();
+        assert_eq!(tier, HwCapabilityTier::MacIntelMetalDiscrete);
+    }
+
+    #[test]
+    fn metal_tier_loud_fails_on_unknown_cpu_brand() {
+        // Neither Apple Silicon nor Intel — e.g. some hypothetical
+        // ARM-on-macOS hackintosh, or a misreporting sysinfo. The probe
+        // surfaces UnknownGpuDevice naming all the inputs so the
+        // operator can add a tier rather than getting silent CpuOnly
+        // (or worse, silent M1Uma16Gb like the pre-fix Mac Intel bug).
+        let err = metal_tier("Some Other CPU brand", "Mystery GPU", 16_000, "metal")
+            .unwrap_err();
+        match err {
+            ProbeError::UnknownGpuDevice { platform, device_name } => {
+                assert_eq!(platform, "metal");
+                assert!(
+                    device_name.contains("Mystery GPU"),
+                    "error must name device + cpu brand: {device_name}"
+                );
+                assert!(
+                    device_name.contains("Some Other CPU brand"),
+                    "error must name device + cpu brand: {device_name}"
+                );
             }
             other => panic!("expected UnknownGpuDevice; got {other:?}"),
         }

--- a/src/workers/continuum-core/src/cognition/model_resolver/types.rs
+++ b/src/workers/continuum-core/src/cognition/model_resolver/types.rs
@@ -49,6 +49,21 @@ pub enum HwCapabilityTier {
     M2UmaProMax,
     /// Apple M3 Pro/Max/Ultra, 32GB+ unified memory.
     M3UmaProMax,
+    /// Mac Intel + discrete Metal GPU (AMD Radeon Pro on 2018-2019
+    /// MacBookPro15,*). Distinct from Apple Silicon: Metal API works but
+    /// the GPU is a discrete card with its own small VRAM budget (e.g.
+    /// 4GB on Radeon Pro 560X), no unified memory, Metal 2 only (no
+    /// Metal 3 / tensor API). llama.cpp's Metal shaders assume Apple
+    /// Silicon's unified-memory addressing and produce garbled tokens
+    /// on this path (continuum 2026-05-30 evidence: 0.8 tok/s + nil
+    /// tensor buffers on MacBookPro15,1 / Radeon Pro 560X). Standard
+    /// personas on this tier must downsize to the smallest GGUF that
+    /// fits CPU-only inference until our CambrianTech/llama.cpp fork
+    /// patches the Metal-AMD shader path. TargetSilicon for this tier
+    /// is `Gpu` (discrete VRAM, not unified) — but in PRACTICE the
+    /// resolver should be conservative and prefer CPU lanes until the
+    /// fork patch lands.
+    MacIntelMetalDiscrete,
     /// nVidia compute capability 7.0 (V100).
     Sm70,
     /// nVidia compute capability 7.5 (T4 datacenter, RTX 20xx, GTX 16xx).

--- a/src/workers/continuum-core/src/inference/llamacpp_adapter.rs
+++ b/src/workers/continuum-core/src/inference/llamacpp_adapter.rs
@@ -383,10 +383,25 @@ impl LlamaCppAdapter {
         let mmproj_path = crate::model_registry::try_global()
             .and_then(|reg| reg.model(&self.default_model))
             .and_then(|m| m.mmproj_local_path.clone());
+        // CONTINUUM_TIER is set by install.sh's hardware probe (commit
+        // 7b3b8e086) — when the install detects a Mac Intel + discrete
+        // AMD or integrated Intel UHD host, it exports
+        // CONTINUUM_TIER=mac_intel_discrete because llama.cpp's
+        // Metal-AMD shaders produce garbled tokens at 0.8 tok/s with
+        // hundreds of nil tensor buffer errors (continuum 2026-05-30
+        // evidence on MacBookPro15,1 / Radeon Pro 560X). CPU-only at
+        // 1.1 tok/s + coherent output beats broken Metal every time
+        // — n_gpu_layers=0 forces the CPU path. Follow-up: native
+        // Rust probe at adapter construction so this doesn't depend
+        // on the install-time env-var trust chain (see task tracker).
+        let n_gpu_layers: i32 = match std::env::var("CONTINUUM_TIER").as_deref() {
+            Ok("mac_intel_discrete") => 0,
+            _ => -1,
+        };
         let config = LlamaCppConfig {
             model_path: self.model_path.clone(),
             mmproj_path,
-            n_gpu_layers: -1, // All layers to GPU
+            n_gpu_layers,
             // None = honor model's n_ctx_train. Adapter caller can shrink
             // this via with_context_length() to bound the KV cache (24GB
             // at 262K → 500MB at 16K).

--- a/src/workers/continuum-core/src/persona/channel_registry.rs
+++ b/src/workers/continuum-core/src/persona/channel_registry.rs
@@ -116,21 +116,33 @@ impl ChannelRegistry {
         }
     }
 
-    /// Get full status snapshot
+    /// Get full status snapshot.
+    ///
+    /// Single-pass aggregation: builds the per-channel status Vec AND the
+    /// rollup fields (total_size / has_urgent_work / has_work) in one
+    /// walk over DOMAIN_PRIORITY_ORDER. Previously did 1 walk to build
+    /// the Vec then 3 more walks to sum/any/any over the result, plus
+    /// Vec growth from an unsized `.collect()`. service_cycle() calls
+    /// this every tick (per persona, every 3-10s); the per-tick savings
+    /// compound across the active persona fleet.
     pub fn status(&self) -> ChannelRegistryStatus {
-        let channels: Vec<_> = DOMAIN_PRIORITY_ORDER
-            .iter()
-            .filter_map(|domain| self.channels.get(domain).map(|c| c.status()))
-            .collect();
-
-        let total_size: u32 = channels.iter().map(|c| c.size).sum();
-        let has_urgent = channels.iter().any(|c| c.has_urgent);
-        let has_work = channels.iter().any(|c| c.has_work);
-
+        let mut channels = Vec::with_capacity(DOMAIN_PRIORITY_ORDER.len());
+        let mut total_size: u32 = 0;
+        let mut has_urgent_work = false;
+        let mut has_work = false;
+        for &domain in DOMAIN_PRIORITY_ORDER {
+            if let Some(channel) = self.channels.get(&domain) {
+                let s = channel.status();
+                total_size += s.size;
+                has_urgent_work |= s.has_urgent;
+                has_work |= s.has_work;
+                channels.push(s);
+            }
+        }
         ChannelRegistryStatus {
             channels,
             total_size,
-            has_urgent_work: has_urgent,
+            has_urgent_work,
             has_work,
         }
     }
@@ -165,11 +177,15 @@ impl ChannelRegistry {
 
         let stats = self.status();
 
-        // 3. Check urgent channels first (priority order)
+        // 3. Check urgent channels first (priority order). Single get_mut
+        //    per domain — the previous pattern did get() to check
+        //    has_urgent_work() then get_mut() to pop, doubling the
+        //    HashMap probes per tick. NLL handles the borrow reuse
+        //    cleanly without the double-lookup workaround.
         for &domain in DOMAIN_PRIORITY_ORDER {
-            if let Some(channel) = self.channels.get(&domain) {
+            if let Some(channel) = self.channels.get_mut(&domain) {
                 if channel.has_urgent_work() {
-                    if let Some(item) = self.channels.get_mut(&domain).and_then(|c| c.pop()) {
+                    if let Some(item) = channel.pop() {
                         debug!(
                             "Service cycle: urgent {} item from {:?} channel",
                             item.item_type(),
@@ -187,13 +203,15 @@ impl ChannelRegistry {
             }
         }
 
-        // 4. Non-urgent: check with state gating (skip Audio — already checked for urgent)
+        // 4. Non-urgent: check with state gating (skip Audio — already
+        //    checked for urgent). Same single-lookup pattern as the
+        //    urgent loop above.
         for &domain in &DOMAIN_PRIORITY_ORDER[1..] {
-            if let Some(channel) = self.channels.get(&domain) {
+            if let Some(channel) = self.channels.get_mut(&domain) {
                 if channel.has_work() {
                     let peek_priority = channel.peek_priority();
                     if state.should_engage(peek_priority) {
-                        if let Some(item) = self.channels.get_mut(&domain).and_then(|c| c.pop()) {
+                        if let Some(item) = channel.pop() {
                             debug!(
                                 "Service cycle: non-urgent {} item from {:?} channel (priority {:.2})",
                                 item.item_type(),

--- a/src/workers/continuum-core/src/persona/inbox.rs
+++ b/src/workers/continuum-core/src/persona/inbox.rs
@@ -104,7 +104,13 @@ impl PersonaInbox {
             }
         }
 
-        heap.extend(retained);
+        // At this point the heap is empty (the while loop drained it).
+        // Re-loading via heap.extend(retained) would push N items at
+        // O(log N) each = O(N log N). BinaryHeap::from(Vec<T>) does
+        // in-place heapify in O(N) (per std docs / sift-down construction).
+        // For a busy persona with hundreds of cross-room messages
+        // (anchor matches few, retained = most), the difference is real.
+        *heap = std::collections::BinaryHeap::from(retained);
         let queue_depth_after = heap.len();
         drop(heap);
 

--- a/src/workers/continuum-core/tests/llamacpp_metal_throughput.rs
+++ b/src/workers/continuum-core/tests/llamacpp_metal_throughput.rs
@@ -93,9 +93,20 @@ fn qwen35_4b_metal_throughput_via_bundled_llamacpp() {
     }
 
     let load_start = Instant::now();
+    // Override knob: $QWEN35_4B_GPU_LAYERS lets the operator force CPU-only
+    // (=0) or partial-offload (=N) to isolate which side of the Metal/CPU
+    // boundary breaks. Default -1 = all layers on GPU (the original
+    // measurement). Mac Intel + AMD-discrete debugging needs the 0 case
+    // to confirm llama.cpp emits coherent tokens when the Metal-AMD
+    // shader path is bypassed.
+    let n_gpu_layers: i32 = env::var("QWEN35_4B_GPU_LAYERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(-1);
+    eprintln!("[smoke] n_gpu_layers = {n_gpu_layers}");
     let config = LlamaCppConfig {
         model_path,
-        n_gpu_layers: -1, // Offload all layers to GPU (Metal on Mac)
+        n_gpu_layers,
         context_length: Some(32768),
         n_seq_max: 1,
         n_ubatch: 128,


### PR DESCRIPTION
## Summary

End-to-end support for Mac Intel + Metal as a first-class hardware tier (LCD floor), plus two opportunistic Rust hyper-efficiency wins discovered along the way.

Six commits, atomic per slice. Hardware-tier story is one logical unit; perf pass ties in via Joel's principle "optimizing for a low-quality computer is HOW you get a fast machine on m5."

## The Mac Intel chain

- c74754f68 fix(registry): qwen3.5-4b GGUF filename case (lowercase q4_k_m was 404ing on HF case-sensitive resolve)
- da6c89b7d feat(cognition): HwCapabilityTier::MacIntelMetalDiscrete + classifier branch. Loud-fails instead of silently routing Intel Mac + 32GB to M1Uma16Gb
- 225327030 feat(registry): mac_intel_discrete tier — TS tierFromHost, models.json tier entry, install.sh hardware probe via sysctl
- c2d9f7f0f feat(inference): LlamaCppAdapter honors CONTINUUM_TIER env; forces n_gpu_layers=0 on this tier

## The hyper-efficiency pass

- a35037fdd perf(persona): ChannelRegistry::service_cycle — single get_mut per domain; status() single-pass aggregation
- 230c5d13e perf(persona): PersonaInbox::drain_frame — BinaryHeap::from(Vec) O(N) heapify instead of O(N log N) extend

## Concrete evidence

2026-05-30 MacBookPro15,1 / Intel i7-8850H / 32GB RAM / AMD Radeon Pro 560X / qwen3.5-4b Q4_K_M:

- Metal-AMD (n_gpu_layers=-1): 0.8 tok/s + multilingual garbage + hundreds of nil tensor buffer errors
- CPU (n_gpu_layers=0): 1.1 tok/s + COHERENT English

llama.cpp itself is fine on this hardware. The Metal-AMD shader path is actively corrupting tensors — CPU is faster AND correct. With qwen3.5-0.8b on the same 6-core i7, ~5-6 tok/s expected = usable interactive chat.

## Followups (not in this PR)

- Forge publish gap: continuum-ai/qwen3.5-0.8b-general-forged HF repo has no GGUF sibling yet — install will 404 on pull until the forge runs.
- Governor classifier parallel bug: governor::types::classify_silicon still treats has_metal=true as TargetSilicon::AppleM. Same misclassification I fixed in cognition::host_capability_probe. Bigger surface; tracked separately.
- Native Rust probe at adapter construction to replace the CONTINUUM_TIER env-var trust chain.
- CambrianTech/llama.cpp Metal-AMD shader patch — the real long-term fix that unlocks this hardware's GPU.

## Test plan

- [x] cargo test --lib cognition::host_capability_probe — 10/10 (4 new classifier tests + 6 existing)
- [x] cargo test --lib cognition::model_resolver — 27/27
- [x] cargo test --lib persona::channel_registry — 9/9
- [x] cargo test --lib persona::inbox — 23/23 (covers drain_frame heap-from optimization)
- [x] Live inference test llamacpp_metal_throughput with QWEN35_4B_GPU_LAYERS=0: 1.1 tok/s coherent output
- [ ] Live ./jtag chat on Mac Intel with mac_intel_discrete tier (gated on forge publishing 0.8b GGUF)

Generated with Claude Code (https://claude.com/claude-code)
