### PR TITLE
fix(install): remove dangling avatars build context from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,20 @@ services:
       context: ./src/workers
       dockerfile: ../../docker/continuum-core-vulkan.Dockerfile
       additional_contexts:
-        avatars: ./src/models/avatars
+        # NOTE: the `avatars: ./src/models/avatars` line was here from
+        # 9b1f6ca2a "Bake CC0 avatar VRM models into continuum-core image"
+        # (April 2026), but src/models is gitignored — the directory
+        # doesn't exist in CI checkouts and the build context fails to
+        # resolve, breaking carl-install-smoke for any PR that touches
+        # install.sh (e.g. #1475). The Dockerfile already handles the
+        # empty-dir case via `RUN mkdir -p /app/avatars` (see
+        # docker/continuum-core.Dockerfile line 143 and the explanatory
+        # comment block at lines 131-142). No Dockerfile uses
+        # `--from=avatars`, so the context declaration was dangling
+        # (referenced nowhere, broke everywhere). Restore when the
+        # avatar-provisioning story lands (LFS, model-init download,
+        # or curl from a CC0 URL in CI before docker build) per the
+        # gap noted in PR891-E2E-VALIDATION.md.
         shared: ./src/shared
         shared-generated: ./src/shared/generated
       args:


### PR DESCRIPTION
## Summary

Remove dangling `avatars: ./src/models/avatars` additional_context from docker-compose.yml that has been silently breaking `carl-install-smoke` for any PR that touches install.sh.

## Root cause

April 2026 commit 9b1f6ca2a added the build context expecting CC0 avatar VRMs to be baked in. That plan rolled back — docker/continuum-core.Dockerfile lines 131-143 document the rollback (src/models is gitignored; Dockerfile uses `RUN mkdir -p /app/avatars` placeholder instead).

The compose-side `additional_contexts` declaration was left behind. No Dockerfile uses `--from=avatars` (verified by grep), so the declaration referenced nothing — but docker compose validates ALL declared additional_contexts resolve at build time. Missing local context dir fails the build with `stat .../src/models/avatars: no such file or directory`.

## Impact

PR #1475 (Mac Intel hardware tier) currently fails `carl-install-smoke` because it touches install.sh → triggers the check → docker build fails on the missing avatars context. PRs that DON'T touch install.sh (#1471, #1473, #1474) didn't run the check, so the break was invisible until now.

## Fix

Remove the dangling line. Replace with an explanatory comment so a future contributor doesn't re-add it without restoring the avatar-provisioning story (LFS, model-init download, or CC0-URL curl) per the gap in docs/infrastructure/PR891-E2E-VALIDATION.md.

## Test plan

- [ ] CI `carl-install-smoke` passes on this PR (and on follow-up rebase of #1475 once this merges)
