### PR TITLE
harden(utils): UTF-8-safe truncate_at_char_boundary + sweep 8 panic sites

### DIFF
--- a/src/workers/continuum-core/src/bin/diagnose_prefill.rs
+++ b/src/workers/continuum-core/src/bin/diagnose_prefill.rs
@@ -132,7 +132,7 @@ fn main() {
                 "pos={:>4} token={:>6}({:>15}) | top5=[{}] | eos={:.2} eot={:.2}",
                 pos,
                 token,
-                &current_decoded[..current_decoded.len().min(15)],
+                continuum_core::utils::str_truncate::truncate_at_char_boundary(&current_decoded, 15),
                 top_decoded.join(", "),
                 eos_logit,
                 eot_logit,
@@ -191,7 +191,7 @@ fn main() {
             0,
             prompt_len - 1,
             best_id,
-            &decoded[..decoded.len().min(15)],
+            continuum_core::utils::str_truncate::truncate_at_char_boundary(&decoded, 15),
             best_val,
             eos_logit
         );
@@ -233,7 +233,7 @@ fn main() {
             i,
             pos,
             best_id,
-            &decoded[..decoded.len().min(15)],
+            continuum_core::utils::str_truncate::truncate_at_char_boundary(&decoded, 15),
             best_val,
             eos_logit
         );

--- a/src/workers/continuum-core/src/inference/backends/mod.rs
+++ b/src/workers/continuum-core/src/inference/backends/mod.rs
@@ -356,7 +356,7 @@ pub fn generate(
                 rank + 1,
                 tid,
                 val,
-                &decoded[..decoded.len().min(20)]
+                crate::utils::str_truncate::truncate_at_char_boundary(&decoded, 20)
             );
         }
         for &eos_id in backend.eos_token_ids() {
@@ -518,7 +518,7 @@ pub fn generate(
                 "  tok[{:>3}] id={:<6} {:>20} logits=[{:.1}..{:.1}]{}",
                 i,
                 next_token,
-                format!("{:?}", &decoded[..decoded.len().min(20)]),
+                format!("{:?}", crate::utils::str_truncate::truncate_at_char_boundary(&decoded, 20)),
                 min_logit,
                 max_logit,
                 eos_info

--- a/src/workers/continuum-core/src/modules/cognition.rs
+++ b/src/workers/continuum-core/src/modules/cognition.rs
@@ -1460,7 +1460,7 @@ impl ServiceModule for CognitionModule {
                     "cognition",
                     "classify-domain {}: '{}...' → domain={}, confidence={:.2}, adapter={:?} ({:.0}μs)",
                     persona_uuid,
-                    &text[..text.len().min(40)],
+                    crate::utils::str_truncate::truncate_at_char_boundary(&text, 40),
                     result.domain,
                     result.confidence,
                     result.adapter_name,

--- a/src/workers/continuum-core/src/modules/grid/handlers.rs
+++ b/src/workers/continuum-core/src/modules/grid/handlers.rs
@@ -785,7 +785,7 @@ fn query_forge_processes() -> Vec<Value> {
                         else if cmd.contains("train") || cmd.contains("fine") { "training" }
                         else { "unknown" };
 
-                    Some(json!({ "pid": pid, "type": job_type, "detail": &cmd[..cmd.len().min(120)], "cpu": cpu, "mem": mem }))
+                    Some(json!({ "pid": pid, "type": job_type, "detail": crate::utils::str_truncate::truncate_at_char_boundary(&cmd, 120), "cpu": cpu, "mem": mem }))
                 })
                 .collect()
         }

--- a/src/workers/continuum-core/src/modules/grid/node.rs
+++ b/src/workers/continuum-core/src/modules/grid/node.rs
@@ -86,8 +86,11 @@ impl TransportAddress {
                 }
             }
             Self::Reticulum { destination_hash } => {
-                // Show first 8 chars of hash for brevity
-                let short = &destination_hash[..destination_hash.len().min(8)];
+                // Show first 8 chars of hash for brevity. UTF-8 safe even
+                // though destination_hash is in practice ASCII-hex — the
+                // safe primitive removes the latent panic by construction
+                // per [[every-error-is-an-opportunity-to-battle-harden]].
+                let short = crate::utils::str_truncate::truncate_at_char_boundary(destination_hash, 8);
                 format!("ret:{short}...")
             }
         }

--- a/src/workers/continuum-core/src/persona/cognition.rs
+++ b/src/workers/continuum-core/src/persona/cognition.rs
@@ -150,7 +150,7 @@ impl PersonaCognitionEngine {
 
         debug!(
             "Priority calc for {} in {:.2}ms: {:.2} (mention={:.2}, sender={:.2}, recency={:.2})",
-            &content[..content.len().min(30)],
+            crate::utils::str_truncate::truncate_at_char_boundary(content, 30),
             start.elapsed().as_secs_f64() * 1000.0,
             final_score,
             mention_score,

--- a/src/workers/continuum-core/src/utils/mod.rs
+++ b/src/workers/continuum-core/src/utils/mod.rs
@@ -5,3 +5,4 @@
 
 pub mod audio;
 pub mod params;
+pub mod str_truncate;

--- a/src/workers/continuum-core/src/utils/str_truncate.rs
+++ b/src/workers/continuum-core/src/utils/str_truncate.rs
@@ -1,0 +1,146 @@
+//! UTF-8-safe string truncation helpers.
+//!
+//! `&str` indexing in Rust slices by BYTE offsets — `s[..N]` panics with
+//! "byte index N is not a char boundary" when N lands inside a multi-byte
+//! UTF-8 sequence. The idiom `&s[..s.len().min(N)]` is therefore unsafe
+//! for any text that might contain non-ASCII characters (emoji, accented
+//! letters, CJK, etc.) — and chat content / decoded LLM tokens routinely
+//! contain those.
+//!
+//! Concretely: this codebase had 8 sites doing `&s[..s.len().min(N)]` for
+//! diagnostic / debug logging across persona cognition, inference backends,
+//! and grid handlers. Each one was a latent panic that fired when a chat
+//! message or decoded token happened to have a multi-byte char near the
+//! truncation boundary. Production today tends to miss these because
+//! tracing's compile-time level filter strips most `debug!` invocations,
+//! but as soon as someone runs RUST_LOG=debug on real chat traffic the
+//! crash surface opens.
+//!
+//! This module centralizes the safe-truncate primitive so every consumer
+//! gets the same behavior and the lesson lands once rather than 8 times.
+//! Per Joel 2026-05-30 "every error is an opportunity to battle harden" —
+//! the fix isn't just the call sites, it's making the safe primitive the
+//! easy thing to reach for.
+
+/// Return the longest prefix of `s` whose byte length is at most
+/// `max_bytes`, rounding DOWN to the nearest char boundary. Never
+/// panics on UTF-8 multi-byte sequences.
+///
+/// `&s[..s.len().min(N)]` is the panic-prone idiom this replaces:
+/// when byte index N lands inside a multi-byte UTF-8 sequence the
+/// slice panics with "byte index N is not a char boundary." Real-world
+/// trigger: a chat message with an emoji at byte 28-31 hits a 30-byte
+/// truncation and crashes the persona cognition path.
+///
+/// Cost: O(min(4, max_bytes - actual_boundary)) — at most 3 backtracks
+/// because UTF-8 chars are bounded to 4 bytes. Effectively free for the
+/// log-truncate use case.
+///
+/// # Examples
+///
+/// ```ignore
+/// # use continuum_core::utils::str_truncate::truncate_at_char_boundary;
+/// assert_eq!(truncate_at_char_boundary("hello", 3), "hel");
+/// assert_eq!(truncate_at_char_boundary("hello", 100), "hello");
+/// assert_eq!(truncate_at_char_boundary("\u{1F44B} hi", 2), ""); // 👋 is 4 bytes
+/// assert_eq!(truncate_at_char_boundary("\u{1F44B} hi", 4), "\u{1F44B}");
+/// assert_eq!(truncate_at_char_boundary("héllo", 2), "h");      // é = 0xc3 0xa9
+/// ```
+pub fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    // UTF-8 char length is bounded to 4 bytes, so this loop runs at
+    // most 3 iterations before landing on a char boundary or 0.
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_truncates_to_exact_byte_count() {
+        assert_eq!(truncate_at_char_boundary("hello world", 5), "hello");
+        assert_eq!(truncate_at_char_boundary("hello world", 11), "hello world");
+        assert_eq!(truncate_at_char_boundary("hello", 100), "hello");
+    }
+
+    #[test]
+    fn max_bytes_zero_returns_empty() {
+        assert_eq!(truncate_at_char_boundary("anything", 0), "");
+        assert_eq!(truncate_at_char_boundary("", 0), "");
+    }
+
+    #[test]
+    fn empty_input_always_returns_empty() {
+        assert_eq!(truncate_at_char_boundary("", 5), "");
+        assert_eq!(truncate_at_char_boundary("", 100), "");
+    }
+
+    #[test]
+    fn multibyte_codepoint_backed_off_to_previous_boundary() {
+        // 👋 (U+1F44B WAVING HAND SIGN) is 4 bytes in UTF-8: F0 9F 91 8B.
+        // Truncating at byte 2 of "👋 hi" lands inside the emoji and must
+        // back off to byte 0 (returning "") rather than panicking.
+        let s = "\u{1F44B} hi";
+        assert_eq!(s.len(), 7); // 4 bytes emoji + 1 space + 2 ascii
+        assert_eq!(truncate_at_char_boundary(s, 0), "");
+        assert_eq!(truncate_at_char_boundary(s, 2), "");
+        assert_eq!(truncate_at_char_boundary(s, 3), "");
+        assert_eq!(truncate_at_char_boundary(s, 4), "\u{1F44B}");
+        assert_eq!(truncate_at_char_boundary(s, 5), "\u{1F44B} ");
+        assert_eq!(truncate_at_char_boundary(s, 7), "\u{1F44B} hi");
+    }
+
+    #[test]
+    fn two_byte_codepoint_handled() {
+        // é (U+00E9 LATIN SMALL LETTER E WITH ACUTE) is 2 bytes: C3 A9.
+        // "héllo" = h(1) + é(2) + l(1) + l(1) + o(1) = 6 bytes.
+        let s = "héllo";
+        assert_eq!(s.len(), 6);
+        assert_eq!(truncate_at_char_boundary(s, 1), "h");
+        assert_eq!(truncate_at_char_boundary(s, 2), "h"); // mid-é → back to 1
+        assert_eq!(truncate_at_char_boundary(s, 3), "hé");
+        assert_eq!(truncate_at_char_boundary(s, 4), "hél");
+    }
+
+    #[test]
+    fn matches_pre_fix_idiom_for_ascii_only_inputs() {
+        // The fix preserves the exact behavior of `&s[..s.len().min(N)]`
+        // for ASCII-only inputs (no panics either way). This pins the
+        // back-compat so future readers can confirm the swap is safe.
+        let ascii = "the quick brown fox jumps over";
+        for n in [0_usize, 1, 5, 10, 30, 31, 100].iter().copied() {
+            let safe = truncate_at_char_boundary(ascii, n);
+            let unsafe_idiom = &ascii[..ascii.len().min(n)];
+            assert_eq!(
+                safe, unsafe_idiom,
+                "ASCII truncation diverged at n={n}: safe={safe:?} unsafe={unsafe_idiom:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn never_panics_on_arbitrary_unicode_boundaries() {
+        // Brute-force: for every possible byte boundary 0..s.len(),
+        // truncate_at_char_boundary must NOT panic. Pins the
+        // contract that this primitive is total over all (s, n).
+        let samples = [
+            "\u{1F44B} hello \u{1F30D}",       // emoji + ascii + emoji
+            "café résumé naïve",                 // accented latin
+            "日本語のテスト",                      // CJK
+            "mixed 한국어 with English and emoji 🚀",
+        ];
+        for s in samples.iter() {
+            for n in 0..=s.len() + 5 {
+                // Just call it — no panic = pass.
+                let _ = truncate_at_char_boundary(s, n);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Centralized UTF-8-safe string truncation primitive + swept 8 latent panic sites that did `&s[..s.len().min(N)]` (which panics when N lands inside a multi-byte UTF-8 sequence — emoji, accents, CJK).

Per Joel 2026-05-30 "every error is an opportunity to battle harden": the fix isn't just the immediate cognition.rs panic, it's making the panic-free primitive the easy thing to reach for.

## The 8 sites

| File | Line | Context |
|---|---|---|
| `src/persona/cognition.rs` | 153 | debug! log of chat content (30 bytes) |
| `src/inference/backends/mod.rs` | 359 | eprintln of decoded LLM token (20) |
| `src/inference/backends/mod.rs` | 521 | trace of decoded token in step log (20) |
| `src/modules/cognition.rs` | 1463 | log of classify-domain input text (40) |
| `src/modules/grid/handlers.rs` | 788 | grid status job detail JSON (120) — *serialized over wire* |
| `src/modules/grid/node.rs` | 90 | Reticulum hash display (8) |
| `src/bin/diagnose_prefill.rs` | 135, 194, 236 | prefill diagnostic decoded tokens (15) |

The grid handler one is the worst — it serializes into a JSON status response. If a process command line has a non-ASCII char near byte 120, the status endpoint crashes the daemon. The persona cognition one fires on chat messages with emoji at byte 28-31 (extremely common).

Production has been masked by tracing's compile-time level filter (debug! strip-out) but RUST_LOG=debug on real chat traffic hits it. The eprintln / serialization paths are unmasked.

## The fix

`continuum_core::utils::str_truncate::truncate_at_char_boundary(s, max_bytes)` backs off to the nearest char boundary ≤ max_bytes. Loop bounded to 3 iterations (UTF-8 chars are ≤4 bytes), so cost is effectively free for the log-truncate case.

```rust
pub fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
    if s.len() <= max_bytes { return s; }
    let mut end = max_bytes;
    while end > 0 && !s.is_char_boundary(end) { end -= 1; }
    &s[..end]
}
```

## Tests (7 added, 7/7 pass)

- `ascii_truncates_to_exact_byte_count` — back-compat for the ASCII fast path
- `max_bytes_zero_returns_empty` + `empty_input_always_returns_empty` — edges
- `multibyte_codepoint_backed_off_to_previous_boundary` — 👋 (4 bytes) case
- `two_byte_codepoint_handled` — é (2 bytes) case
- `matches_pre_fix_idiom_for_ascii_only_inputs` — pins back-compat across multiple N values
- `never_panics_on_arbitrary_unicode_boundaries` — brute force over emoji + Korean + Japanese + accented latin

## Test plan

- [x] `cargo test --lib utils::str_truncate` — 7/7
- [x] All 8 call sites compile + still build
- [ ] CI green

## Followups

- Add a clippy lint or compile-time check that catches `&str[..N]` byte-slice patterns going forward. Tracked separately.
