### PR TITLE
perf(persona): zero-alloc mention detection + promote str_case to utils

### DIFF
--- a/src/workers/continuum-core/src/persona/cognition.rs
+++ b/src/workers/continuum-core/src/persona/cognition.rs
@@ -199,8 +199,8 @@ impl PersonaCognitionEngine {
     /// compare byte-for-byte (cannot false-match ASCII bytes — see
     /// [`u8::eq_ignore_ascii_case`]).
     fn is_mentioned(&self, content: &str) -> bool {
-        contains_ascii_case_insensitive(content, &self.mention_marker)
-            || contains_ascii_case_insensitive(content, &self.name_lower)
+        crate::utils::str_case::contains_ascii_case_insensitive(content, &self.mention_marker)
+            || crate::utils::str_case::contains_ascii_case_insensitive(content, &self.name_lower)
     }
 
     /// Fast-path decision: should we even consider responding?
@@ -328,36 +328,6 @@ impl PersonaCognitionEngine {
     }
 }
 
-/// Case-insensitive ASCII substring search. Returns `true` when
-/// `haystack` contains `needle`, comparing alphabetic ASCII bytes
-/// case-insensitively (via [`u8::eq_ignore_ascii_case`]) and all other
-/// bytes literally.
-///
-/// Used by [`PersonaCognitionEngine::is_mentioned`] to avoid the
-/// `haystack.to_lowercase()` allocation that would otherwise fire once
-/// per message per persona per tick. Names + mention markers in
-/// continuum are ASCII, so the ASCII fast path is sufficient — non-ASCII
-/// content bytes can't accidentally match an ASCII needle byte because
-/// `eq_ignore_ascii_case` only folds bytes in `0x41..=0x5A` /
-/// `0x61..=0x7A` and compares others byte-for-byte.
-///
-/// Complexity: O((haystack_len - needle_len + 1) * needle_len) — naive
-/// scan, same as `str::contains` minus the allocation. Persona names
-/// are ~5-20 chars and chat content is typically ~100-500 chars, so
-/// the constant factor is small; the saved allocation is the actual
-/// win at scale.
-fn contains_ascii_case_insensitive(haystack: &str, needle: &str) -> bool {
-    if needle.is_empty() {
-        return true;
-    }
-    let h = haystack.as_bytes();
-    let n = needle.as_bytes();
-    if n.len() > h.len() {
-        return false;
-    }
-    h.windows(n.len()).any(|w| w.eq_ignore_ascii_case(n))
-}
-
 //=============================================================================
 // TESTS
 //=============================================================================
@@ -456,49 +426,10 @@ mod tests {
         assert_eq!(decision2.reason, "Already evaluated");
     }
 
-    // ─── contains_ascii_case_insensitive — zero-alloc helper ────────────
-
-    #[test]
-    fn helper_matches_exact_case() {
-        assert!(contains_ascii_case_insensitive("hello world", "hello"));
-        assert!(contains_ascii_case_insensitive("hello world", "world"));
-    }
-
-    #[test]
-    fn helper_matches_case_insensitively() {
-        assert!(contains_ascii_case_insensitive("Hello World", "hello"));
-        // @ is byte 0x40 — non-alphabetic, must match literally. The
-        // haystack DOES contain '@', so case-folded substring matches.
-        assert!(contains_ascii_case_insensitive("Yo @HELPER are you", "@helper"));
-        assert!(contains_ascii_case_insensitive("Hey Helper Ai!", "helper ai"));
-        // Negative: literal '@' is required when needle has it.
-        assert!(!contains_ascii_case_insensitive("HEY HELPER", "@helper"));
-    }
-
-    #[test]
-    fn helper_rejects_when_needle_absent() {
-        assert!(!contains_ascii_case_insensitive("hello world", "goodbye"));
-        assert!(!contains_ascii_case_insensitive("short", "much longer needle"));
-    }
-
-    #[test]
-    fn helper_empty_needle_always_matches() {
-        // Mirrors std::str::contains("") semantics — every haystack
-        // (including the empty one) contains the empty substring.
-        assert!(contains_ascii_case_insensitive("anything", ""));
-        assert!(contains_ascii_case_insensitive("", ""));
-    }
-
-    #[test]
-    fn helper_non_ascii_does_not_false_match_ascii() {
-        // Non-ASCII bytes can't case-fold against ASCII bytes — confirms
-        // that emoji-heavy or unicode-rich chat content won't trigger
-        // spurious @mention hits.
-        assert!(!contains_ascii_case_insensitive("hé", "he"));
-        assert!(!contains_ascii_case_insensitive("\u{1F44B} hello", "\u{1F44B} world"));
-        // ASCII-still-matches-inside-unicode-content path stays correct.
-        assert!(contains_ascii_case_insensitive("\u{1F44B} Helper AI", "helper ai"));
-    }
+    // The contains_ascii_case_insensitive helper tests moved with the
+    // helper itself to utils::str_case (see #1478 + the str_case
+    // promotion). The engine-level mention test below remains here
+    // because it exercises the cached-state pipeline specifically.
 
     #[tokio::test]
     async fn is_mentioned_uses_cached_lowercase_via_engine() {

--- a/src/workers/continuum-core/src/persona/text_analysis/mention_detection.rs
+++ b/src/workers/continuum-core/src/persona/text_analysis/mention_detection.rs
@@ -5,7 +5,20 @@
 //!
 //! - `is_persona_mentioned`: @PersonaName, @uniqueid, or "Name," / "Name:" at start
 //! - `has_directed_mention`: any @word pattern (detects messages aimed at a specific persona)
+//!
+//! Hot path: called once per message per persona per tick from the
+//! unified evaluator pre-response gate (see
+//! [`crate::persona::evaluator::full_evaluate`]). Pre-2026-05-30 this
+//! function allocated up to 9 Strings per call (msg.to_lowercase() +
+//! name.to_lowercase() + uid.to_lowercase() + 6 format!() markers for
+//! the @prefix and trailing-comma/colon checks). Now: zero per-call
+//! allocations via [`crate::utils::str_case::contains_ascii_case_insensitive`]
+//! and [`crate::utils::str_case::starts_with_ascii_case_insensitive`],
+//! both of which fold ASCII bytes inline without allocating a
+//! lowercase copy. Persona names + uids are ASCII in continuum so the
+//! ASCII fast path is sufficient.
 
+use crate::utils::str_case::starts_with_ascii_case_insensitive;
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -20,39 +33,81 @@ static DIRECTED_MENTION_RE: LazyLock<Regex> =
 /// - @mentions anywhere: `@PersonaName` or `@uniqueid`
 /// - Direct address at start: `PersonaName,` or `PersonaName:` or `uniqueid,` or `uniqueid:`
 ///
-/// All comparisons are case-insensitive.
+/// All comparisons are ASCII case-insensitive. Persona names + uids
+/// are ASCII; the ASCII fast path avoids the unicode-aware
+/// `str::to_lowercase()` allocation per call.
+///
+/// To check "Name," at start (and similarly "Name:"), the function
+/// folds the prefix bytes against `persona_display_name` and then
+/// verifies the next byte is the literal `,` or `:`. The same logic
+/// covers the `persona_unique_id` branch.
 pub fn is_persona_mentioned(
     message_text: &str,
     persona_display_name: &str,
     persona_unique_id: &str,
 ) -> bool {
-    let msg_lower = message_text.to_lowercase();
-    let name_lower = persona_display_name.to_lowercase();
-    let uid_lower = persona_unique_id.to_lowercase();
-
-    // @mentions anywhere: "@PersonaName" or "@uniqueid"
-    if msg_lower.contains(&format!("@{name_lower}")) {
+    // @mentions anywhere: scan for "@" + name / uid in the haystack.
+    // The previous implementation pre-built `format!("@{name_lower}")`
+    // every call; here we scan two passes (one for the @-bare-name
+    // path, one for the rest-of-name), avoiding the marker String.
+    if has_at_mention_of(message_text, persona_display_name) {
         return true;
     }
-    if !uid_lower.is_empty() && msg_lower.contains(&format!("@{uid_lower}")) {
-        return true;
-    }
-
-    // Direct address at start: "PersonaName," or "PersonaName:" or "uniqueid," or "uniqueid:"
-    if msg_lower.starts_with(&format!("{name_lower},"))
-        || msg_lower.starts_with(&format!("{name_lower}:"))
+    if !persona_unique_id.is_empty()
+        && has_at_mention_of(message_text, persona_unique_id)
     {
         return true;
     }
-    if !uid_lower.is_empty()
-        && (msg_lower.starts_with(&format!("{uid_lower},"))
-            || msg_lower.starts_with(&format!("{uid_lower}:")))
+
+    // Direct address at start: "Name," / "Name:" / "uid," / "uid:".
+    // starts_with_ascii_case_insensitive covers the name part; then
+    // the next raw byte (not case-folded) must be the literal
+    // separator.
+    if starts_with_then_separator(message_text, persona_display_name) {
+        return true;
+    }
+    if !persona_unique_id.is_empty()
+        && starts_with_then_separator(message_text, persona_unique_id)
     {
         return true;
     }
 
     false
 }
+
+/// True when `haystack` contains `"@" + name` case-insensitively. Splits
+/// the check into a scan for the `@` byte then a window match — avoids
+/// allocating the `format!("@{name}")` marker.
+fn has_at_mention_of(haystack: &str, name: &str) -> bool {
+    let h = haystack.as_bytes();
+    let n = name.as_bytes();
+    if n.is_empty() {
+        return false;
+    }
+    // Need at least "@" + 1 byte of name to match.
+    if h.len() < n.len() + 1 {
+        return false;
+    }
+    // Look for '@' at any position where `name.len()` more bytes still fit.
+    for i in 0..=(h.len() - n.len() - 1) {
+        if h[i] == b'@' && h[i + 1..i + 1 + n.len()].eq_ignore_ascii_case(n) {
+            return true;
+        }
+    }
+    false
+}
+
+/// True when `haystack` starts with `name` (case-insensitive ASCII) AND
+/// the byte immediately after the name is `,` or `:`. Encodes the
+/// "direct address" idiom — `"Name, ..."` / `"Name: ..."`.
+fn starts_with_then_separator(haystack: &str, name: &str) -> bool {
+    if !starts_with_ascii_case_insensitive(haystack, name) {
+        return false;
+    }
+    let next = haystack.as_bytes().get(name.len()).copied();
+    matches!(next, Some(b',') | Some(b':'))
+}
+
 
 /// Check if a message contains ANY directed @mention (aimed at any persona).
 /// Used to prevent dog-piling: when someone @mentions a specific AI, others stay silent.

--- a/src/workers/continuum-core/src/utils/mod.rs
+++ b/src/workers/continuum-core/src/utils/mod.rs
@@ -5,4 +5,5 @@
 
 pub mod audio;
 pub mod params;
+pub mod str_case;
 pub mod str_truncate;

--- a/src/workers/continuum-core/src/utils/str_case.rs
+++ b/src/workers/continuum-core/src/utils/str_case.rs
@@ -1,0 +1,160 @@
+//! ASCII case-insensitive string helpers — zero-alloc primitives for
+//! hot paths that previously reached for `.to_lowercase().contains(...)`
+//! and `.to_lowercase().starts_with(...)` (which allocate a `String`
+//! sized to the haystack length on every call).
+//!
+//! Used by [`crate::persona::cognition::PersonaCognitionEngine::is_mentioned`]
+//! (cached mention marker check) and
+//! [`crate::persona::text_analysis::mention_detection::is_persona_mentioned`]
+//! (@mention + direct-address parsing, called once per message per
+//! persona per tick from the unified evaluator pre-response gate).
+//!
+//! Persona names in continuum are ASCII (Helper AI, Teacher AI, etc.),
+//! so the ASCII fast path is sufficient for the @mention path. Non-ASCII
+//! content bytes compare byte-for-byte and can't false-match an ASCII
+//! needle byte: [`u8::eq_ignore_ascii_case`] only folds bytes in the
+//! alphabetic ASCII range (0x41-0x5A, 0x61-0x7A) and treats all others
+//! literally. Emoji-heavy or unicode-rich chat content stays correct.
+//!
+//! Per [[rust-prioritize-hyper-efficiency]] and
+//! [[optimizing-for-low-end-compounds-on-high-end]]: every alloc you
+//! skip in the per-tick path on Mac Intel becomes M5 perceived
+//! snappiness. These helpers are the primitive that makes that easy.
+
+/// Return `true` when `haystack` contains `needle`, comparing
+/// alphabetic ASCII bytes case-insensitively and all other bytes
+/// literally. Zero-allocation. O((haystack_len - needle_len + 1) *
+/// needle_len) — naive scan, no preprocessing.
+///
+/// Replaces the panic-and-alloc-prone idiom:
+///   ```ignore
+///   haystack.to_lowercase().contains(&needle.to_lowercase())
+///   ```
+/// which allocates two Strings per call AND folds Unicode (overkill
+/// when both inputs are ASCII as they are in continuum's @mention
+/// paths).
+///
+/// Empty needle always matches (mirrors `str::contains("")`). Needle
+/// longer than haystack always fails.
+pub fn contains_ascii_case_insensitive(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    let h = haystack.as_bytes();
+    let n = needle.as_bytes();
+    if n.len() > h.len() {
+        return false;
+    }
+    h.windows(n.len()).any(|w| w.eq_ignore_ascii_case(n))
+}
+
+/// Return `true` when `haystack` begins with `prefix`, comparing
+/// alphabetic ASCII bytes case-insensitively and all other bytes
+/// literally. Zero-allocation. O(prefix_len).
+///
+/// Replaces the alloc-prone idiom:
+///   ```ignore
+///   haystack.to_lowercase().starts_with(&prefix.to_lowercase())
+///   ```
+/// which allocates two Strings per call.
+///
+/// Empty prefix always matches. Prefix longer than haystack always
+/// fails.
+pub fn starts_with_ascii_case_insensitive(haystack: &str, prefix: &str) -> bool {
+    if prefix.is_empty() {
+        return true;
+    }
+    let h = haystack.as_bytes();
+    let p = prefix.as_bytes();
+    if p.len() > h.len() {
+        return false;
+    }
+    h[..p.len()].eq_ignore_ascii_case(p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── contains_ascii_case_insensitive ────────────────────────────────
+
+    #[test]
+    fn contains_matches_exact_case() {
+        assert!(contains_ascii_case_insensitive("hello world", "hello"));
+        assert!(contains_ascii_case_insensitive("hello world", "world"));
+        assert!(contains_ascii_case_insensitive("hello world", "lo wo"));
+    }
+
+    #[test]
+    fn contains_matches_case_insensitively() {
+        assert!(contains_ascii_case_insensitive("Hello World", "hello"));
+        assert!(contains_ascii_case_insensitive("HELLO WORLD", "hello world"));
+        // Non-alpha bytes (@) must match literally — alphabetic chars after
+        // can still case-fold.
+        assert!(contains_ascii_case_insensitive("Yo @HELPER are you", "@helper"));
+    }
+
+    #[test]
+    fn contains_rejects_when_needle_absent() {
+        assert!(!contains_ascii_case_insensitive("hello world", "goodbye"));
+        assert!(!contains_ascii_case_insensitive("short", "much longer needle"));
+        // Needle has '@' but haystack doesn't.
+        assert!(!contains_ascii_case_insensitive("HEY HELPER", "@helper"));
+    }
+
+    #[test]
+    fn contains_empty_needle_always_matches() {
+        assert!(contains_ascii_case_insensitive("anything", ""));
+        assert!(contains_ascii_case_insensitive("", ""));
+    }
+
+    #[test]
+    fn contains_non_ascii_does_not_false_match_ascii() {
+        // 'é' (0xc3 0xa9) shares one byte with no ASCII letter; the second
+        // byte (0xa9) is outside alpha-fold range so compares literally
+        // and won't match 'e' (0x65).
+        assert!(!contains_ascii_case_insensitive("hé", "he"));
+        assert!(!contains_ascii_case_insensitive("\u{1F44B} hello", "\u{1F44B} world"));
+        // ASCII substring inside unicode-rich content still matches.
+        assert!(contains_ascii_case_insensitive("\u{1F44B} Helper AI", "helper ai"));
+    }
+
+    // ─── starts_with_ascii_case_insensitive ─────────────────────────────
+
+    #[test]
+    fn starts_with_matches_exact_case() {
+        assert!(starts_with_ascii_case_insensitive("hello world", "hello"));
+        assert!(starts_with_ascii_case_insensitive("hello", "hello"));
+    }
+
+    #[test]
+    fn starts_with_matches_case_insensitively() {
+        assert!(starts_with_ascii_case_insensitive("HELLO world", "hello"));
+        assert!(starts_with_ascii_case_insensitive("Teacher AI, explain", "teacher ai"));
+        assert!(starts_with_ascii_case_insensitive("Teacher AI: explain", "teacher ai"));
+    }
+
+    #[test]
+    fn starts_with_rejects_substring_not_at_start() {
+        // "world" IS in "hello world" but not at the start.
+        assert!(!starts_with_ascii_case_insensitive("hello world", "world"));
+    }
+
+    #[test]
+    fn starts_with_rejects_prefix_longer_than_haystack() {
+        assert!(!starts_with_ascii_case_insensitive("hi", "hello"));
+    }
+
+    #[test]
+    fn starts_with_empty_prefix_always_matches() {
+        assert!(starts_with_ascii_case_insensitive("anything", ""));
+        assert!(starts_with_ascii_case_insensitive("", ""));
+    }
+
+    #[test]
+    fn starts_with_non_ascii_does_not_false_match_ascii() {
+        assert!(!starts_with_ascii_case_insensitive("\u{1F44B} hi", "hello"));
+        // ASCII prefix on unicode content works as expected.
+        assert!(starts_with_ascii_case_insensitive("hello \u{1F44B}", "hello"));
+    }
+}


### PR DESCRIPTION
## Summary

`is_persona_mentioned` (called once per message per persona per tick from the unified evaluator pre-response gate) allocated up to **9 Strings per call** — `msg.to_lowercase()` + `name.to_lowercase()` + `uid.to_lowercase()` + 6 `format!()` markers. This PR drops it to **zero** per-call allocations while promoting the shared str-case helpers to `utils::str_case` (now alongside `utils::str_truncate` from #1478).

29 affected tests pass: 14 mention_detection (unchanged), 11 new utils::str_case (relocated + sibling `starts_with`), 4 cognition engine.

## Before (9 allocs per call)

```rust
let msg_lower = message_text.to_lowercase();             // 1
let name_lower = persona_display_name.to_lowercase();    // 2
let uid_lower = persona_unique_id.to_lowercase();        // 3
if msg_lower.contains(&format!("@{name_lower}")) { ... } // 4
if msg_lower.contains(&format!("@{uid_lower}")) { ... }  // 5
if msg_lower.starts_with(&format!("{name_lower},")) || msg_lower.starts_with(&format!("{name_lower}:")) { ... } // 6, 7
if msg_lower.starts_with(&format!("{uid_lower},")) || msg_lower.starts_with(&format!("{uid_lower}:")) { ... } // 8, 9
```

## After (0 allocs per call)

```rust
if has_at_mention_of(message_text, persona_display_name) { return true; }
if !persona_unique_id.is_empty() && has_at_mention_of(message_text, persona_unique_id) { return true; }
if starts_with_then_separator(message_text, persona_display_name) { return true; }
if !persona_unique_id.is_empty() && starts_with_then_separator(message_text, persona_unique_id) { return true; }
```

`has_at_mention_of` scans for the literal `@` byte then validates `name.len()` bytes of case-folded match. `starts_with_then_separator` uses `utils::str_case::starts_with_ascii_case_insensitive` for the name part then checks the next byte is `,` or `:`. Both run purely on byte slices.

## utils::str_case (new shared module)

Promoted `contains_ascii_case_insensitive` out of `persona::cognition` (where it landed in #1477) into `utils::str_case`. Added sibling `starts_with_ascii_case_insensitive`. Both:

- ASCII case-folds via `u8::eq_ignore_ascii_case` (only folds 0x41-0x5A / 0x61-0x7A)
- Non-ASCII bytes compare byte-for-byte → cannot false-match ASCII needle bytes (emoji-safe)
- Zero allocations
- 11 unit tests pin contains + starts_with semantics including non-ASCII safety

## Performance

A busy room with 5 personas + 200 messages/min routed through `full_evaluate` = ~9000 allocations/minute eliminated end-to-end. No behavioral change.

## Discipline

Per Joel 2026-05-30 "if persona cognition can work on an intel Mac it can work on anything" — the evaluator gate IS the hot path that determines Mac Intel responsiveness. Same code runs on M5; cycles saved here cash in there.

Sequence of cognition-layer wins this session:
- #1477: zero-alloc `is_mentioned` (PersonaCognitionEngine, cached state, ASCII byte scan)
- #1478: UTF-8-safe truncate (8 latent panic sites + shared primitive)
- This PR: zero-alloc `is_persona_mentioned` (free-function variant in mention_detection)

## Test plan

- [x] `cargo test --lib utils::str_case` — 11/11
- [x] `cargo test --lib persona::text_analysis::mention_detection` — 14/14 (unchanged from before refactor)
- [x] `cargo test --lib persona::cognition::tests` — 4/4
