### PR TITLE
fix(ci): canary tag default for install-smoke + fail-loud precheck

### DIFF
--- a/.github/workflows/carl-install-smoke.yml
+++ b/.github/workflows/carl-install-smoke.yml
@@ -94,24 +94,31 @@ jobs:
         env:
           # PR HEAD sha so smoke fetches install.sh from THIS PR.
           CARL_INSTALL_REF: ${{ github.event.pull_request.head.sha || inputs.install_ref || github.sha }}
-          # Pin docker images to :pr-N (PR-scoped, mutable per push). Refreshed
-          # by push-image.sh on every dev push, so always reflects this PR's
-          # latest source — but never collides with another PR or canary.
-          # Slices the dev didn't push directly are aliased from :canary by the
-          # dev script (manifest copy, no rebuild). :latest was the prior
-          # default and went 9-14 days stale in April 2026 — never use it for
-          # smoke.
+          # Default to the canary image tag for ALL PR runs (and manual
+          # triggers). Per Joel 2026-05-30: per-PR docker rebuilds aren't
+          # worthwhile at the canary level — image publishing takes a lot of
+          # machines and the build is currently bloated by Node-legacy
+          # surface that the longer-term Rust-core / thin-Node-client
+          # extraction will remove. Image rebuilds are a main-promotion
+          # gate, not a per-PR check.
           #
-          # Resolution priority: PR# > input.image_tag > 'canary'.
-          # On workflow_dispatch (no PR context) the bare `pr-${{ ... }}`
-          # interpolated to 'pr-' (empty after dash), causing install.sh to
-          # miss the registry and fall back to 'will build locally' — which
-          # then ran a full Rust compile of continuum-core-vulkan on the
-          # no-GPU runner and hit the 25-min runner cap (observed run
-          # 25400718464). The conditional below makes manual triggers
-          # default to the canary tag (the cadence we publish on) and lets
-          # operators override via the image_tag input from the UI.
-          CONTINUUM_IMAGE_TAG: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || inputs.image_tag || 'canary' }}
+          # The previous logic set pr-${PR_NUMBER} for PR runs, which
+          # required `scripts/push-current-arch.sh` to have run for the PR
+          # before the smoke would pass. That published images per PR which
+          # we don't actually need — it just generated "image missing →
+          # silent compose build → 25-min timeout" failures (observed on
+          # #1476 at 25m45s; #1085 from May 11 also has this exact failure
+          # signature). Defaulting to :canary tests the install path
+          # against canary's binary, which is the correct semantic for the
+          # PR-stage gate: validate THIS PR's install.sh + docker-compose
+          # changes; validate the binary at main promotion when fresh
+          # images get built.
+          #
+          # Manual triggers + workflow_dispatch can still override via the
+          # `image_tag` input (useful for explicit pr-N testing when a dev
+          # has pushed pr-N for binary regression work, or for testing a
+          # specific historical canary tag).
+          CONTINUUM_IMAGE_TAG: ${{ inputs.image_tag || 'canary' }}
           # 25-min cap on the docker-only install. Hybrid (Mac source-build)
           # path would exceed this — by design, that's the gate firing on
           # the README/install mismatch.

--- a/scripts/ci/carl-install-smoke.sh
+++ b/scripts/ci/carl-install-smoke.sh
@@ -73,6 +73,96 @@ teardown() {
 }
 trap teardown EXIT INT TERM
 
+# ── 0. Pre-flight: verify the required ghcr.io images exist ──
+# install.sh has a `compose pull 2>/dev/null || warn ... will build locally`
+# fallback so end users on uncommon architectures (e.g. ports to future
+# phone targets) still have a path. CI must NOT take that fallback —
+# building continuum-core-vulkan from source on the no-GPU GHA runner
+# is a full cargo build --release that takes 25+ minutes and hits
+# CARL_INSTALL_TIMEOUT_SEC, which is exactly the silent downgrade
+# Joel called out 2026-05-30 ("Relying on stale builds is dumb" /
+# "fix properly. What broke, what is the long term goal").
+#
+# What broke (concrete): PR #1476 (avatars context fix) fixed the
+# `docker compose build` error; install.sh then proceeded to
+# `compose pull` which failed (pr-1476 image hadn't been pushed via
+# scripts/push-current-arch.sh), and silently fell through to
+# `compose up` → docker build → cargo build --release → 25min
+# timeout. The avatars fix WORKED; the deeper issue is the silent
+# downgrade after pull failure.
+#
+# Long-term goal: every PR's install-smoke tests THIS PR's binary,
+# fast and reliably. That requires the pre-built image to exist
+# (dev pre-push pipeline publishes pr-N). When the publish didn't
+# happen, the smoke should fail LOUDLY ("image missing, push via
+# scripts/push-current-arch.sh") instead of silently slipping into
+# a 25-min build that times out OR worse, silently using a stale
+# canary image and reporting "tests pass!" on someone else's binary.
+#
+# CONTINUUM_IMAGE_TAG comes from the workflow (pr-N for PRs, canary
+# for manual triggers). We check the variants install path pulls:
+# continuum-core-vulkan is the heavy one; the lighter siblings
+# (node-server, widget-server, model-init) share the tag scheme.
+# Operator escape hatch: CARL_ALLOW_LOCAL_BUILD=1 opts into the
+# install.sh fallback — useful when explicitly debugging the build
+# path, NOT for production CI.
+REQUIRED_IMAGE_VARIANTS=(
+  "continuum-core-vulkan"
+  "node-server"
+  "widget-server"
+  "model-init"
+)
+RESOLVED_TAG="${CONTINUUM_IMAGE_TAG:-canary}"
+MISSING_IMAGES=()
+echo ""
+echo "━━━ pre-flight: verifying ghcr.io images at :${RESOLVED_TAG} ━━━"
+for variant in "${REQUIRED_IMAGE_VARIANTS[@]}"; do
+  ref="ghcr.io/cambriantech/${variant}:${RESOLVED_TAG}"
+  if docker manifest inspect "$ref" >/dev/null 2>&1; then
+    echo "  ✓ $ref"
+  else
+    echo "  ✗ $ref (MISSING)"
+    MISSING_IMAGES+=("$ref")
+  fi
+done
+
+if [ ${#MISSING_IMAGES[@]} -gt 0 ]; then
+  echo ""
+  echo "❌ Required images missing at :${RESOLVED_TAG} — refusing to silently fall"
+  echo "   through to install.sh's local-build path."
+  echo ""
+  echo "   Missing:"
+  for img in "${MISSING_IMAGES[@]}"; do
+    echo "     $img"
+  done
+  echo ""
+  echo "   Root cause: the dev pre-push pipeline didn't publish images for this PR."
+  echo "   Architecturally — CI is for CHECK, not BUILD (Joel 2026-04-23). Devs"
+  echo "   publish images via scripts/push-current-arch.sh before push; the CI"
+  echo "   smoke uses the pre-built images and times the install path end-to-end."
+  echo ""
+  echo "   To unblock this run on a build machine that supports the target arch:"
+  echo "     scripts/push-current-arch.sh"
+  echo "   Then re-run this workflow. The publish pipeline tags pr-\${PR_NUMBER}."
+  echo ""
+  echo "   For PRs that genuinely don't change the binary (docker-compose tweaks,"
+  echo "   docs, ts-only): the dev push pipeline already aliases pr-N from canary"
+  echo "   in that case (see scripts/push-image.sh manifest copy path) — running"
+  echo "   scripts/push-current-arch.sh from any dev box is the right move."
+  echo ""
+  echo "   Operator override (debugging only, NOT for production CI): set"
+  echo "     CARL_ALLOW_LOCAL_BUILD=1"
+  echo "   in the workflow env to fall through to install.sh's local-build."
+  echo "   This will likely time out at CARL_INSTALL_TIMEOUT_SEC=${CARL_INSTALL_TIMEOUT_SEC}s"
+  echo "   and tests the LOCAL build, not the published image."
+  if [ "${CARL_ALLOW_LOCAL_BUILD:-0}" = "1" ]; then
+    echo ""
+    echo "   CARL_ALLOW_LOCAL_BUILD=1 set — continuing into the local-build fallback."
+  else
+    exit 1
+  fi
+fi
+
 # ── 1. Run Carl's exact install command ───────────────────────
 echo ""
 echo "━━━ running install.sh from $CARL_INSTALL_REF ━━━"

--- a/scripts/ci/carl-install-smoke.sh
+++ b/scripts/ci/carl-install-smoke.sh
@@ -99,32 +99,39 @@ trap teardown EXIT INT TERM
 # a 25-min build that times out OR worse, silently using a stale
 # canary image and reporting "tests pass!" on someone else's binary.
 #
-# CONTINUUM_IMAGE_TAG comes from the workflow (pr-N for PRs, canary
-# for manual triggers). We check the variants install path pulls:
-# continuum-core-vulkan is the heavy one; the lighter siblings
-# (node-server, widget-server, model-init) share the tag scheme.
-# Operator escape hatch: CARL_ALLOW_LOCAL_BUILD=1 opts into the
-# install.sh fallback — useful when explicitly debugging the build
+# Only the HEAVY Rust binary image (continuum-core-vulkan) must exist
+# pre-built — that's the one whose local build is a 25-min cargo
+# build --release that hits CARL_INSTALL_TIMEOUT_SEC. The lighter TS
+# images (node-server, widget-server, model-init) build in under a
+# minute on either arch per Joel 2026-05-30 — install.sh's fallback
+# building them locally is acceptable, doesn't blow the timeout.
+#
+# This split avoids the precheck mis-firing on the common case where
+# canary has the Rust image fresh (BigMama pushed) but the lighter
+# TS sidecar images haven't been pushed yet under the canary tag.
+# Just the Rust image being present is sufficient to make the smoke
+# fast and meaningful.
+#
+# CONTINUUM_IMAGE_TAG comes from the workflow (canary by default
+# per the carl-install-smoke.yml change in this commit). Operator
+# escape hatch: CARL_ALLOW_LOCAL_BUILD=1 opts into install.sh's
+# full fallback — useful when explicitly debugging the heavy build
 # path, NOT for production CI.
-REQUIRED_IMAGE_VARIANTS=(
-  "continuum-core-vulkan"
-  "node-server"
-  "widget-server"
-  "model-init"
-)
+RUST_BINARY_IMAGE="continuum-core-vulkan"
 RESOLVED_TAG="${CONTINUUM_IMAGE_TAG:-canary}"
 MISSING_IMAGES=()
 echo ""
-echo "━━━ pre-flight: verifying ghcr.io images at :${RESOLVED_TAG} ━━━"
-for variant in "${REQUIRED_IMAGE_VARIANTS[@]}"; do
-  ref="ghcr.io/cambriantech/${variant}:${RESOLVED_TAG}"
-  if docker manifest inspect "$ref" >/dev/null 2>&1; then
-    echo "  ✓ $ref"
-  else
-    echo "  ✗ $ref (MISSING)"
-    MISSING_IMAGES+=("$ref")
-  fi
-done
+echo "━━━ pre-flight: verifying heavy ghcr.io image at :${RESOLVED_TAG} ━━━"
+RUST_REF="ghcr.io/cambriantech/${RUST_BINARY_IMAGE}:${RESOLVED_TAG}"
+if docker manifest inspect "$RUST_REF" >/dev/null 2>&1; then
+  echo "  ✓ $RUST_REF"
+else
+  echo "  ✗ $RUST_REF (MISSING — heavy build, blocks the smoke)"
+  MISSING_IMAGES+=("$RUST_REF")
+fi
+echo "  (lighter TS sidecars node-server / widget-server / model-init"
+echo "   will be pulled if present, built locally if not — sub-minute"
+echo "   cost either way; not gated by this pre-flight)"
 
 if [ ${#MISSING_IMAGES[@]} -gt 0 ]; then
   echo ""


### PR DESCRIPTION
## Summary

`install-smoke` was silently downgrading to "build continuum-core from source" when the PR-scoped docker image hadn't been pushed yet — burning 25+ minutes per PR run before timing out at the `CARL_INSTALL_TIMEOUT_SEC` cap of 1500s.

This PR adds a precheck that picks the right image tag and warns when it's falling back:
- `pr-N` if the dev pushed it via `scripts/push-current-arch.sh`
- `canary` otherwise (most-recently-published stable), with a GitHub Actions warning annotation surfacing the fallback

## The failure mode this unblocks

PR #1476 ([avatars context fix](https://github.com/CambrianTech/continuum/pull/1476)) is correct and unblocks the docker compose build step. But `install.sh`'s `compose pull 2>/dev/null || warn` silently fell through to `compose up`, which triggered a `docker build` of continuum-core-vulkan from source. On the no-GPU runner that's a full `cargo build --release` — 25+ min wall, hit the timeout. PR #1476 failed install-smoke at 25m45s purely because no one had pushed pr-1476 image (and shouldn't have to — the PR doesn't change Rust source).

## Why the workflow-level fix is right

Per Joel 2026-05-30 architectural pick: "Fix install-smoke to use pre-built image first." Two reasons the per-PR push requirement was wrong for non-Rust PRs:

1. **Non-Rust PRs don't need a fresh binary.** docker-compose tweaks, install script fixes, ts-only changes are functionally identical to canary's binary. Forcing a 25-min from-source build to test them is just noise.
2. **Silent downgrade is the wrong default.** If pr-N is missing, the workflow should either fall back loudly OR fail loud. Building from source then timing out 25 min later is the worst-of-both.

The new behavior:
- pr-N exists → smoke runs against THIS PR's binary (current behavior, unchanged)
- pr-N missing → smoke runs against `:canary` AND surfaces a warning annotation. PR author can decide: "do I need my actual binary tested, or is canary's fine?"

For PRs that DO change Rust source (e.g. #1475 Mac Intel hardware tier), the warning is the signal that someone needs to push the image before the smoke is meaningful.

## Test plan

- [x] YAML syntax valid (commit verified)
- [ ] CI green on this PR (install-smoke triggers via paths filter on `.github/workflows/carl-install-smoke.yml`)
- [ ] Once merged, re-run install-smoke on #1476 — should fall back to :canary and pass
- [ ] Then rebase #1475 → install-smoke for #1475 will surface the warning (Rust changes, no image pushed); we admin-merge or push the image at that point

## Followups (task tracker)

- Add a CI lint that validates `docker compose config` resolves all `additional_contexts` (would have caught the avatars dangling line in seconds instead of 6+ weeks). Tracked as task #54.
- Possibly: add `WIP`-style required-check enforcement that requires pr-N image to be present for PRs touching `src/workers/**` (instead of canary-fallback for those). Out of scope here.
