### PR TITLE
fix(install): pre-create ~/.continuum/sockets before docker compose up

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -777,7 +777,19 @@ mod_jtag_bin_link "$INSTALL_DIR/src/jtag"
 
 # ── 4. Configuration ───────────────────────────────────────
 PHASE="configuration"
-mkdir -p "$CONTINUUM_DATA"
+# Pre-create the directories the docker mount overlays. The continuum-core
+# Dockerfile does `RUN mkdir -p /root/.continuum/sockets …` but the
+# compose `~/.continuum:/root/.continuum` mount overlays that with the
+# HOST's ~/.continuum at container start — so any subdir created at image
+# build time becomes invisible inside the container. continuum-core then
+# fails to bind its IPC socket with "IPC server error: No such file or
+# directory (os error 2)" and the healthcheck never goes green, blocking
+# the whole stack (continuum-core unhealthy → node-server's depends_on
+# fails → compose up exits 1). Caught 2026-05-30 on carl-install-smoke
+# of #1480; the canary image healthcheck regression had been silently
+# blocking install-smoke for any install touching the docker stack.
+mkdir -p "$CONTINUUM_DATA" "$CONTINUUM_DATA/sockets" \
+         "$CONTINUUM_DATA/jtag/data" "$CONTINUUM_DATA/jtag/logs"
 
 CONFIG_FILE="$CONTINUUM_DATA/config.env"
 if [ ! -f "$CONFIG_FILE" ]; then


### PR DESCRIPTION
## Summary

continuum-core's IPC server crashes at startup with `IPC server error: No such file or directory (os error 2)` because the host bind mount (`~/.continuum:/root/.continuum`) overlays the Dockerfile's image-time `mkdir -p /root/.continuum/sockets`. install.sh now pre-creates the directory tree on the host BEFORE `compose up`, so the mount delivers a populated dir to the container.

## Trace from canary install-smoke (#1480 today)

```
17:40:25 — continuum-core: All 28 modules initialized, tick loops started
17:40:25 — ❌ IPC server error: No such file or directory (os error 2)
17:40:26 — Container Error / Waiting → healthcheck never passes
17:40:26 — dependency failed to start: container continuum-core-1 is unhealthy
17:40:26 — install.sh exits at "start support services" phase (exit 1)
```

The Dockerfile creates `/root/.continuum/sockets` at build time:
```dockerfile
RUN mkdir -p /root/.continuum/sockets /root/.continuum/jtag/data /root/.continuum/jtag/logs
```

But docker-compose.yml mounts the host directory:
```yaml
volumes:
  - ~/.continuum:/root/.continuum
```

The bind mount overlays the image's dir tree. The build-time `mkdir` is shadowed by the host's `~/.continuum` (which on a fresh install/runner is just the empty `mkdir -p $CONTINUUM_DATA` install.sh already does). continuum-core then fails to bind its socket because the parent dir doesn't exist.

## Fix

install.sh's existing `mkdir -p "$CONTINUUM_DATA"` (line 780) is expanded to also create `sockets/`, `jtag/data/`, `jtag/logs/` — the same set the Dockerfile creates internally. The mount then carries them into the container.

## Why install.sh-side, not Dockerfile-side

The bind mount is the OVERLAYING layer; whatever the Dockerfile does at image build is hidden inside the container at runtime when a mount covers the same path. The canonical fix is to ensure the host directory tree exists before the mount activates.

## Was this masked by something?

Yes — install-smoke runs were hitting the slower silent-downgrade-to-build path (PR #1480 just fixed). The 25-min cargo build timeout was masking this socket-dir failure mode. Now that #1480's precheck + canary-default routing makes the run fast, the underlying bug surfaces with a clear 3-min diagnostic.

## Test plan

- [ ] CI green on this PR
- [ ] Once merged + canary-rebuilt: re-trigger install-smoke on #1476 (avatars fix) — should pass cleanly
- [ ] Then #1475 (Mac Intel tier) unblocks
