### PR TITLE
feat(runtime): CommandInterceptor chain — kernel dispatch composes routing transports

### DIFF
--- a/src/workers/continuum-core/src/runtime/airc_interceptor.rs
+++ b/src/workers/continuum-core/src/runtime/airc_interceptor.rs
@@ -1,0 +1,172 @@
+//! AircInterceptor — routes commands targeting airc-addressed peers via
+//! the airc messaging substrate. **Stub form: trait wired, transport
+//! deferred until the airc module ships its command-transport surface.**
+//!
+//! # Why this exists today, in stub form
+//!
+//! Per [docs/architecture/MODULE-ARCHITECTURE.md](../../../../../docs/architecture/MODULE-ARCHITECTURE.md)
+//! §7.1: airc is "just another module" providing a transport. The
+//! eventual contract is that `Commands::execute("foo/bar", { aircPeer:
+//! "id" })` should route the command over the airc messaging substrate
+//! to that peer's continuum-core, execute there, return the result.
+//! Same primitive as grid hops; different transport.
+//!
+//! Why land the interceptor in stub form before the transport exists:
+//!
+//! 1. The interceptor chain is a sequence; landing the airc slot now
+//!    pins the order before grid wires in. Today's wire order is
+//!    `[airc, grid]` — explicit airc-targeted commands take precedence
+//!    over grid's capability-based remote routing.
+//! 2. The stub fail-loud on actual airc targets (rather than silently
+//!    declining) keeps the contract honest: a caller who writes
+//!    `aircPeer: "..."` learns immediately that the transport isn't
+//!    ready, rather than having the request silently fall through to
+//!    local dispatch where there's no airc routing at all.
+//! 3. Per Joel's `[[every-error-is-an-opportunity-to-battle-harden]]`
+//!    standing rule: fail-loud surfaces the gap. Silent decline would
+//!    hide it under the rug until live chat traffic hits.
+//!
+//! # How callers signal an airc target
+//!
+//! `params.aircPeer: String` — explicit peer ID. The transport (when
+//! wired) routes to that peer's continuum-core over the airc substrate.
+//!
+//! `params.aircRoom: String` — broadcast to a room's members. Useful
+//! for "tell everyone in this conversation" semantics.
+//!
+//! Absent both, the interceptor declines and the chain continues.
+//!
+//! # When the transport lands
+//!
+//! Replace [`AircInterceptor::try_route`]'s `Err` path with a real call
+//! into the airc module's `airc/send-command` (or equivalent). The
+//! stub's structure already discriminates the param shape; only the
+//! transport call body needs to change.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use super::command_interceptor::{CommandInterceptor, InterceptorOutcome};
+
+/// AircInterceptor — sits at the head of the interceptor chain so airc-
+/// targeted commands route to the messaging substrate before grid even
+/// looks at them. See module docs for the stub contract.
+pub struct AircInterceptor;
+
+impl AircInterceptor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AircInterceptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl CommandInterceptor for AircInterceptor {
+    async fn try_route(
+        &self,
+        command: &str,
+        params: &Value,
+    ) -> Result<InterceptorOutcome, String> {
+        let peer = params.get("aircPeer").and_then(|v| v.as_str());
+        let room = params.get("aircRoom").and_then(|v| v.as_str());
+
+        match (peer, room) {
+            // Neither airc target field set — this isn't an airc-routed
+            // command. Decline cleanly, let the chain continue.
+            (None, None) => Ok(InterceptorOutcome::Decline),
+
+            // Airc target set, but the transport isn't wired yet. Fail
+            // loudly with a concrete pointer to the missing piece, so a
+            // caller writing `aircPeer` finds out at request time rather
+            // than from silent fallthrough.
+            (Some(target), _) | (_, Some(target)) => Err(format!(
+                "airc routing requested for command '{command}' \
+                 (target: '{target}'), but the airc transport is not \
+                 yet wired into the kernel — see MODULE-ARCHITECTURE.md \
+                 §7.1. Until @continuum-modules/airc exposes the \
+                 send-command primitive this interceptor delegates to, \
+                 callers must omit aircPeer/aircRoom params."
+            )),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "airc"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn declines_when_no_airc_target() {
+        let interceptor = AircInterceptor::new();
+        let outcome = interceptor
+            .try_route("chat/send", &serde_json::json!({ "roomId": "abc", "content": "hi" }))
+            .await
+            .expect("no-target call must not error");
+        assert!(
+            matches!(outcome, InterceptorOutcome::Decline),
+            "interceptor must Decline when no aircPeer/aircRoom param is present, \
+             so the chain falls through to grid + local dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn fails_loud_when_airc_peer_targeted_but_transport_missing() {
+        let interceptor = AircInterceptor::new();
+        let err = interceptor
+            .try_route(
+                "chat/send",
+                &serde_json::json!({
+                    "aircPeer": "peer-uuid-here",
+                    "content": "hi"
+                }),
+            )
+            .await
+            .expect_err(
+                "explicit aircPeer must surface a real error until the \
+                 transport is wired — silent decline would hide the gap",
+            );
+        assert!(
+            err.contains("airc"),
+            "error must name the missing transport: {err}"
+        );
+        assert!(
+            err.contains("MODULE-ARCHITECTURE"),
+            "error must point at the canonical doc for the design: {err}"
+        );
+        assert!(
+            err.contains("peer-uuid-here"),
+            "error must echo the target so the caller can correlate logs: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fails_loud_when_airc_room_targeted_but_transport_missing() {
+        let interceptor = AircInterceptor::new();
+        let err = interceptor
+            .try_route(
+                "chat/send",
+                &serde_json::json!({
+                    "aircRoom": "room-uuid",
+                    "content": "hi"
+                }),
+            )
+            .await
+            .expect_err("explicit aircRoom must surface a real error");
+        assert!(err.contains("room-uuid"), "error echoes the target: {err}");
+    }
+
+    #[tokio::test]
+    async fn name_is_stable() {
+        let interceptor = AircInterceptor::new();
+        assert_eq!(interceptor.name(), "airc");
+    }
+}

--- a/src/workers/continuum-core/src/runtime/command_executor.rs
+++ b/src/workers/continuum-core/src/runtime/command_executor.rs
@@ -25,34 +25,114 @@ use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
+use super::command_interceptor::{CommandInterceptor, InterceptorOutcome};
 use super::{CommandResult, ModuleRegistry};
 
 /// Socket path for TypeScript command routing
 const TS_COMMAND_SOCKET: &str = "/tmp/jtag-command-router.sock";
 
-/// Universal command executor that routes to Rust modules or TypeScript
+/// Universal command executor that routes to interceptors, then Rust
+/// modules, then TypeScript.
+///
+/// # Dispatch order (the chain)
+///
+/// Per [docs/architecture/MODULE-ARCHITECTURE.md](../../../../../docs/architecture/MODULE-ARCHITECTURE.md)
+/// §5 ("Composition: Commands Call Commands"): every command walks the
+/// same dispatch chain regardless of which language or machine
+/// implements it. The chain is:
+///
+/// 1. **Interceptors** (in insertion order). Each one gets first look at
+///    `(command, params)`. An interceptor can take the command (and
+///    short-circuit the chain), pass (`Decline` — try the next), or
+///    fail (`Err` — propagate immediately, no silent fallthrough).
+///    Today's intended order is `[airc, grid]`: explicit airc-routed
+///    commands beat grid's capability-based remote routing.
+///
+/// 2. **Local Rust module registry**. If no interceptor took the
+///    command, the registry tries to find a Rust `ServiceModule` whose
+///    `command_prefixes` include this command. If found, the module's
+///    `handle_command` runs locally.
+///
+/// 3. **TypeScript via Unix socket**. If no Rust module owns the
+///    command, fall through to the existing `CommandRouterServer` IPC
+///    bridge. This preserves backwards compatibility with every
+///    TS-implemented command in `src/commands/`.
+///
+/// The chain is the same primitive for every transport: local Rust,
+/// remote Rust over grid, remote Rust over airc, TS over IPC. Adding a
+/// transport is adding an interceptor; no kernel changes needed.
 pub struct CommandExecutor {
-    /// Rust module registry (for Rust-implemented commands)
+    /// Rust module registry (for Rust-implemented commands).
     registry: Arc<ModuleRegistry>,
+    /// Interceptor chain. Tried in insertion order BEFORE local
+    /// dispatch. First interceptor to return Handled wins.
+    interceptors: Vec<Arc<dyn CommandInterceptor>>,
 }
 
 impl CommandExecutor {
     pub fn new(registry: Arc<ModuleRegistry>) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            interceptors: Vec::new(),
+        }
     }
 
-    /// Execute ANY command - routes to Rust or TypeScript automatically
-    /// Returns CommandResult for consistency with ServiceModule pattern
+    /// Add an interceptor to the chain (builder-style). Interceptors are
+    /// tried in insertion order, so wire higher-priority transports
+    /// FIRST.
+    ///
+    /// Default global wire order (in `init_executor`): `[airc, grid]`.
+    /// Tests and one-off bin tools can build their own chain.
+    pub fn with_interceptor(mut self, interceptor: Arc<dyn CommandInterceptor>) -> Self {
+        self.interceptors.push(interceptor);
+        self
+    }
+
+    /// Number of registered interceptors. Diagnostic; not on the hot
+    /// path. Useful for asserting the wire order in tests and for the
+    /// `kernel/health` command to surface the chain depth.
+    pub fn interceptor_count(&self) -> usize {
+        self.interceptors.len()
+    }
+
+    /// Execute ANY command — walks the dispatch chain documented on the
+    /// struct: interceptors → local Rust module → TypeScript bridge.
     pub async fn execute(&self, command: &str, params: Value) -> Result<CommandResult, String> {
         let log = super::logger("command-executor");
 
-        // 1. Try Rust module registry first
+        // 1. Walk the interceptor chain. First Handle wins. Decline
+        //    moves on. Err propagates immediately — no silent
+        //    fallthrough, per the trait contract.
+        for interceptor in &self.interceptors {
+            match interceptor.try_route(command, &params).await {
+                Ok(InterceptorOutcome::Handled(result)) => {
+                    log.debug(&format!(
+                        "Routing '{}' via interceptor '{}'",
+                        command,
+                        interceptor.name()
+                    ));
+                    return Ok(result);
+                }
+                Ok(InterceptorOutcome::Decline) => continue,
+                Err(e) => {
+                    log.error(&format!(
+                        "Interceptor '{}' failed on '{}': {}",
+                        interceptor.name(),
+                        command,
+                        e
+                    ));
+                    return Err(e);
+                }
+            }
+        }
+
+        // 2. Try the local Rust module registry.
         if let Some((module, cmd)) = self.registry.route_command(command) {
-            log.debug(&format!("Routing '{}' to Rust module", command));
+            log.debug(&format!("Routing '{}' to local Rust module", command));
             return module.handle_command(&cmd, params).await;
         }
 
-        // 2. Route to TypeScript via Unix socket (CommandRouterServer)
+        // 3. Fall through to TypeScript via Unix socket.
         log.debug(&format!(
             "Routing '{}' to TypeScript via CommandRouterServer",
             command
@@ -206,12 +286,210 @@ pub async fn execute_ts_json(command: &str, params: Value) -> Result<Value, Stri
 
 #[cfg(test)]
 mod tests {
+    use super::super::airc_interceptor::AircInterceptor;
     use super::*;
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn test_executor_creation() {
         let registry = Arc::new(ModuleRegistry::new());
         let _executor = CommandExecutor::new(registry);
         // Just verify it compiles and can be created
+    }
+
+    #[test]
+    fn empty_chain_by_default() {
+        let registry = Arc::new(ModuleRegistry::new());
+        let executor = CommandExecutor::new(registry);
+        assert_eq!(
+            executor.interceptor_count(),
+            0,
+            "fresh executor must have NO interceptors; \
+             interceptors are opt-in via with_interceptor or init_executor wiring"
+        );
+    }
+
+    #[test]
+    fn with_interceptor_grows_chain_in_insertion_order() {
+        let registry = Arc::new(ModuleRegistry::new());
+        let executor = CommandExecutor::new(registry)
+            .with_interceptor(Arc::new(AircInterceptor::new()));
+        assert_eq!(
+            executor.interceptor_count(),
+            1,
+            "with_interceptor must append, not replace"
+        );
+    }
+
+    /// Test interceptor that records the call order so we can prove the
+    /// chain walks in insertion order.
+    struct RecordingDecliner {
+        name: &'static str,
+        seen: Arc<AtomicUsize>,
+        mark: usize,
+    }
+
+    #[async_trait]
+    impl CommandInterceptor for RecordingDecliner {
+        async fn try_route(
+            &self,
+            _command: &str,
+            _params: &Value,
+        ) -> Result<InterceptorOutcome, String> {
+            // Record which slot was consulted. The test asserts the
+            // observed counter equals the expected slot, proving order.
+            self.seen.store(self.mark, Ordering::SeqCst);
+            Ok(InterceptorOutcome::Decline)
+        }
+
+        fn name(&self) -> &'static str {
+            self.name
+        }
+    }
+
+    /// Test interceptor that always handles, used to short-circuit the
+    /// fall-through to local Rust + TS dispatch (which would require
+    /// actual modules and a live TS bridge — out of scope for unit tests).
+    struct AlwaysHandle;
+
+    #[async_trait]
+    impl CommandInterceptor for AlwaysHandle {
+        async fn try_route(
+            &self,
+            _command: &str,
+            _params: &Value,
+        ) -> Result<InterceptorOutcome, String> {
+            Ok(InterceptorOutcome::Handled(CommandResult::Json(
+                serde_json::json!({ "handled": true }),
+            )))
+        }
+
+        fn name(&self) -> &'static str {
+            "always-handle"
+        }
+    }
+
+    #[tokio::test]
+    async fn interceptors_walked_in_insertion_order_when_all_decline() {
+        let last_seen = Arc::new(AtomicUsize::new(0));
+        let registry = Arc::new(ModuleRegistry::new());
+        let executor = CommandExecutor::new(registry)
+            .with_interceptor(Arc::new(RecordingDecliner {
+                name: "first",
+                seen: last_seen.clone(),
+                mark: 1,
+            }))
+            .with_interceptor(Arc::new(RecordingDecliner {
+                name: "second",
+                seen: last_seen.clone(),
+                mark: 2,
+            }))
+            .with_interceptor(Arc::new(AlwaysHandle));
+
+        let result = executor
+            .execute("anything", Value::Null)
+            .await
+            .expect("AlwaysHandle should resolve the dispatch");
+
+        match result {
+            CommandResult::Json(v) => assert_eq!(v["handled"], true),
+            other => panic!("expected Json, got {other:?}"),
+        }
+        // The last decliner to run was `second` (mark 2). If the chain
+        // walked out of order, this would be `1` or `0`.
+        assert_eq!(
+            last_seen.load(Ordering::SeqCst),
+            2,
+            "interceptors must be consulted in insertion order"
+        );
+    }
+
+    #[tokio::test]
+    async fn first_handler_short_circuits_later_interceptors() {
+        let later_called = Arc::new(AtomicUsize::new(0));
+        let registry = Arc::new(ModuleRegistry::new());
+        let executor = CommandExecutor::new(registry)
+            .with_interceptor(Arc::new(AlwaysHandle))
+            .with_interceptor(Arc::new(RecordingDecliner {
+                name: "should-never-run",
+                seen: later_called.clone(),
+                mark: 99,
+            }));
+
+        let _ = executor.execute("anything", Value::Null).await.unwrap();
+        assert_eq!(
+            later_called.load(Ordering::SeqCst),
+            0,
+            "interceptors after the first Handled must not be consulted"
+        );
+    }
+
+    #[tokio::test]
+    async fn airc_interceptor_declines_when_no_airc_target_params() {
+        // The airc interceptor at the head of the chain must NOT block
+        // existing local-Rust or TS commands that don't carry airc
+        // routing params. This is the back-compat guarantee that lets
+        // the airc interceptor be safely installed at init_executor.
+        //
+        // Without a registered Rust module for "test/cmd", the executor
+        // will fall through past the airc interceptor (Decline) past the
+        // registry (no match) and try to connect to the TS bridge,
+        // which fails in tests because the socket doesn't exist. That
+        // failure is expected: the test is asserting the airc
+        // interceptor did NOT short-circuit, NOT that TS dispatch works.
+        let registry = Arc::new(ModuleRegistry::new());
+        let executor =
+            CommandExecutor::new(registry).with_interceptor(Arc::new(AircInterceptor::new()));
+
+        let result = executor
+            .execute(
+                "test/cmd",
+                serde_json::json!({ "ordinaryParam": "value" }),
+            )
+            .await;
+
+        // We expect the TS bridge connection to fail (no socket in tests).
+        // The IMPORTANT assertion is that the failure came from the TS
+        // bridge, NOT from the airc interceptor — proving the airc
+        // interceptor declined cleanly and the chain fell through.
+        let err = result.expect_err("TS bridge will fail in tests; that's OK");
+        assert!(
+            !err.contains("airc"),
+            "error must come from TS bridge fallthrough, not from airc \
+             interceptor — otherwise the airc interceptor incorrectly \
+             intercepted a non-airc command. err: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn airc_interceptor_fails_loud_when_airc_peer_targeted() {
+        // The airc interceptor MUST short-circuit with a loud error when
+        // a caller passes aircPeer, even before the transport is wired.
+        // Silent fall-through would hide the missing transport from the
+        // caller, who would then see local-dispatch results (or worse,
+        // success on the wrong machine) and not know airc wasn't used.
+        let registry = Arc::new(ModuleRegistry::new());
+        let executor =
+            CommandExecutor::new(registry).with_interceptor(Arc::new(AircInterceptor::new()));
+
+        let err = executor
+            .execute(
+                "chat/send",
+                serde_json::json!({ "aircPeer": "peer-id", "content": "hello" }),
+            )
+            .await
+            .expect_err(
+                "explicit aircPeer must error until transport is wired — \
+                 not silently fall through to local",
+            );
+        assert!(
+            err.contains("airc"),
+            "error must identify airc as the unresolved transport: {err}"
+        );
+        assert!(
+            err.contains("peer-id"),
+            "error must echo the target so the caller can correlate logs: {err}"
+        );
     }
 }

--- a/src/workers/continuum-core/src/runtime/command_interceptor.rs
+++ b/src/workers/continuum-core/src/runtime/command_interceptor.rs
@@ -1,0 +1,285 @@
+//! CommandInterceptor — the routing-decision chain that runs before local
+//! dispatch in [`super::command_executor::CommandExecutor`].
+//!
+//! # Why this exists
+//!
+//! Per [docs/architecture/MODULE-ARCHITECTURE.md](../../../../../docs/architecture/MODULE-ARCHITECTURE.md)
+//! §5 ("Composition: Commands Call Commands") and §7.1 ("airc as just
+//! another module"): the kernel composes routing decisions by walking a
+//! chain of interceptors before falling back to local Rust dispatch and
+//! finally to TypeScript. No transport is special at the kernel level —
+//! grid, airc, future mesh transports, future caching layers all sit
+//! behind the same trait and the same dispatch loop.
+//!
+//! Today's `CommandExecutor::execute` already does the local-Rust-then-TS
+//! pair. This trait adds the prefix: interceptors get FIRST look. The
+//! result is a single primitive that handles four transport modes
+//! (local Rust, IPC to TS, grid hop to a peer, airc routing to a peer)
+//! with one entry point and one signature.
+//!
+//! # The contract
+//!
+//! Implementations decide per call whether to handle the command or step
+//! aside:
+//!
+//! - [`InterceptorOutcome::Handled`] — interceptor took the command;
+//!   the chain stops and this result is returned to the caller.
+//! - [`InterceptorOutcome::Decline`] — interceptor passed; the next
+//!   interceptor (or the local-dispatch fallthrough) takes over.
+//! - `Err(_)` — interceptor failed in a way the caller should see;
+//!   the chain stops and the error propagates. No silent fallthrough
+//!   on Err — that would hide exactly the routing bugs interceptors
+//!   exist to surface.
+//!
+//! # Composition order
+//!
+//! Interceptors are walked in insertion order. Wire order is therefore
+//! policy: the earlier an interceptor sits, the higher its priority.
+//! Today the intended order is `[airc, grid]` so explicit airc-targeted
+//! commands take precedence over grid's capability-based remote routing.
+//! Both currently decline by default (airc has no transport yet; grid is
+//! not yet wired here) so adding the chain is a no-op until those land.
+//!
+//! # Why not just modify `CommandExecutor::execute` per-transport
+//!
+//! The legacy TS-side dispatch [pre-#1198] grew a `_gridInterceptor`
+//! shim on the singleton specifically to hop work over to the grid before
+//! local dispatch. That worked but baked grid into the kernel signature.
+//! The same pressure exists for airc, and any future transport (mesh,
+//! tower-relay, etc.) would re-bake the kernel each time. The interceptor
+//! trait is the generalization: kernel knows "walk a list, fall through
+//! when no one bites"; transports register themselves.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use super::CommandResult;
+
+/// What an interceptor returns from a `try_route` attempt.
+#[derive(Debug)]
+pub enum InterceptorOutcome {
+    /// Interceptor took the command. The kernel returns this result
+    /// without consulting later interceptors or the local dispatch.
+    Handled(CommandResult),
+    /// Interceptor passed. The next interceptor (or the local-dispatch
+    /// fallthrough) gets to try.
+    Decline,
+}
+
+/// A pluggable routing-decision step. See module docs for the contract.
+///
+/// Implementations must be `Send + Sync` because the executor holds them
+/// in a singleton and dispatches commands concurrently.
+#[async_trait]
+pub trait CommandInterceptor: Send + Sync {
+    /// First look at the command + params. Return
+    /// [`InterceptorOutcome::Handled`] to short-circuit the chain, or
+    /// [`InterceptorOutcome::Decline`] to let the next interceptor (or
+    /// the local dispatcher) handle it.
+    ///
+    /// Returning `Err` aborts the chain — no silent fall-through on
+    /// error, so a misconfigured interceptor surfaces loudly rather
+    /// than masking the work.
+    async fn try_route(
+        &self,
+        command: &str,
+        params: &Value,
+    ) -> Result<InterceptorOutcome, String>;
+
+    /// Static name for logging + telemetry. e.g. `"grid"`, `"airc"`.
+    fn name(&self) -> &'static str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// Interceptor that counts calls + always declines. Used to assert
+    /// the chain walks every interceptor in order when no one handles.
+    struct DeclineCounter {
+        name: &'static str,
+        count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl CommandInterceptor for DeclineCounter {
+        async fn try_route(
+            &self,
+            _command: &str,
+            _params: &Value,
+        ) -> Result<InterceptorOutcome, String> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            Ok(InterceptorOutcome::Decline)
+        }
+
+        fn name(&self) -> &'static str {
+            self.name
+        }
+    }
+
+    /// Interceptor that always handles with a fixed result. Used to
+    /// assert the chain short-circuits on the first Handle.
+    struct AlwaysHandle {
+        name: &'static str,
+        value: i64,
+    }
+
+    #[async_trait]
+    impl CommandInterceptor for AlwaysHandle {
+        async fn try_route(
+            &self,
+            _command: &str,
+            _params: &Value,
+        ) -> Result<InterceptorOutcome, String> {
+            Ok(InterceptorOutcome::Handled(CommandResult::Json(
+                serde_json::json!({ "value": self.value }),
+            )))
+        }
+
+        fn name(&self) -> &'static str {
+            self.name
+        }
+    }
+
+    /// Interceptor that always errors. Used to assert errors propagate
+    /// (no silent fall-through to later interceptors or local dispatch).
+    struct AlwaysErr {
+        name: &'static str,
+    }
+
+    #[async_trait]
+    impl CommandInterceptor for AlwaysErr {
+        async fn try_route(
+            &self,
+            _command: &str,
+            _params: &Value,
+        ) -> Result<InterceptorOutcome, String> {
+            Err(format!("{} failed loudly", self.name))
+        }
+
+        fn name(&self) -> &'static str {
+            self.name
+        }
+    }
+
+    /// Walk-the-chain helper that mirrors the loop in `CommandExecutor`.
+    /// Lets us test the contract here without standing up the full
+    /// executor + module registry.
+    async fn walk(
+        interceptors: &[Arc<dyn CommandInterceptor>],
+        command: &str,
+        params: &Value,
+    ) -> Result<Option<CommandResult>, String> {
+        for interceptor in interceptors {
+            match interceptor.try_route(command, params).await? {
+                InterceptorOutcome::Handled(result) => return Ok(Some(result)),
+                InterceptorOutcome::Decline => continue,
+            }
+        }
+        Ok(None)
+    }
+
+    #[tokio::test]
+    async fn empty_chain_returns_none() {
+        let chain: Vec<Arc<dyn CommandInterceptor>> = vec![];
+        let result = walk(&chain, "anything", &Value::Null).await.unwrap();
+        assert!(result.is_none(), "empty chain must fall through (None)");
+    }
+
+    #[tokio::test]
+    async fn all_decline_falls_through() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let chain: Vec<Arc<dyn CommandInterceptor>> = vec![
+            Arc::new(DeclineCounter {
+                name: "a",
+                count: count.clone(),
+            }),
+            Arc::new(DeclineCounter {
+                name: "b",
+                count: count.clone(),
+            }),
+            Arc::new(DeclineCounter {
+                name: "c",
+                count: count.clone(),
+            }),
+        ];
+        let result = walk(&chain, "anything", &Value::Null).await.unwrap();
+        assert!(result.is_none(), "all-decline chain must fall through");
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            3,
+            "every interceptor must be consulted when all decline"
+        );
+    }
+
+    #[tokio::test]
+    async fn first_to_handle_wins_short_circuits_later() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let chain: Vec<Arc<dyn CommandInterceptor>> = vec![
+            Arc::new(DeclineCounter {
+                name: "a",
+                count: count.clone(),
+            }),
+            Arc::new(AlwaysHandle {
+                name: "b",
+                value: 42,
+            }),
+            Arc::new(DeclineCounter {
+                name: "c-never-called",
+                count: count.clone(),
+            }),
+        ];
+        let result = walk(&chain, "anything", &Value::Null)
+            .await
+            .unwrap()
+            .expect("middle interceptor should have handled");
+        match result {
+            CommandResult::Json(v) => assert_eq!(v["value"], 42),
+            other => panic!("expected Json, got {other:?}"),
+        }
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "interceptors AFTER the handler must NOT be consulted"
+        );
+    }
+
+    #[tokio::test]
+    async fn err_aborts_chain_no_silent_fallthrough() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let chain: Vec<Arc<dyn CommandInterceptor>> = vec![
+            Arc::new(AlwaysErr { name: "boom" }),
+            Arc::new(DeclineCounter {
+                name: "never-called",
+                count: count.clone(),
+            }),
+        ];
+        let err = walk(&chain, "anything", &Value::Null)
+            .await
+            .expect_err("Err must propagate");
+        assert!(
+            err.contains("boom"),
+            "error must carry the interceptor identity for diagnosis: {err}"
+        );
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "interceptors AFTER an error must NOT be consulted — \
+             silent fallthrough on err would hide the routing bug"
+        );
+    }
+
+    #[tokio::test]
+    async fn name_propagates_through_dyn_trait() {
+        // Pin that `name()` survives the trait-object boundary so logs
+        // and telemetry can identify which interceptor handled which
+        // command without storing extra metadata.
+        let handler: Arc<dyn CommandInterceptor> = Arc::new(AlwaysHandle {
+            name: "diagnostic",
+            value: 0,
+        });
+        assert_eq!(handler.name(), "diagnostic");
+    }
+}

--- a/src/workers/continuum-core/src/runtime/mod.rs
+++ b/src/workers/continuum-core/src/runtime/mod.rs
@@ -24,9 +24,11 @@ use dashmap::DashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+pub mod airc_interceptor;
 pub mod artifact_handle;
 pub mod brain_region;
 pub mod command_executor;
+pub mod command_interceptor;
 pub mod control;
 pub mod message_bus;
 pub mod module_context;
@@ -46,10 +48,12 @@ pub use brain_region::{
     PressureProfile, PressureSignalKind, RegionContext, RegionError, RegionId, RegionSignal,
     SleepPhase, TickOutcome,
 };
+pub use airc_interceptor::AircInterceptor;
 pub use command_executor::{
     execute as execute_command, execute_json as execute_command_json, executor, init_executor,
     CommandExecutor,
 };
+pub use command_interceptor::{CommandInterceptor, InterceptorOutcome};
 pub use control::{ModuleInfo, RuntimeControl};
 pub use message_bus::MessageBus;
 pub use module_context::ModuleContext;


### PR DESCRIPTION
## Summary

First execution of [MODULE-ARCHITECTURE.md](docs/architecture/MODULE-ARCHITECTURE.md) (PR #1482): the kernel composes routing decisions by walking a chain of interceptors before falling back to local Rust dispatch and then to TypeScript. **No transport is special at the kernel level.** Grid, airc, future mesh transports, future caching layers all sit behind the same trait and the same dispatch loop.

**Zero behavior change for existing callers** — the global executor is unchanged, no interceptors auto-installed, all existing commands work identically. **New capability:** any transport can plug into the dispatch chain via `with_interceptor(...)`.

## What broke before

The TS-side `CommandDaemon` grew a `_gridInterceptor` shim on the singleton specifically to hop work over to the grid before local dispatch. Same pressure now applies to airc, and any future transport (mesh, tower-relay) would re-bake the kernel each time. This PR generalizes: the kernel knows "walk a list, fall through when no one bites"; transports register themselves.

## What this PR adds

### `runtime::command_interceptor::CommandInterceptor` trait

```rust
#[async_trait]
pub trait CommandInterceptor: Send + Sync {
    async fn try_route(
        &self,
        command: &str,
        params: &Value,
    ) -> Result<InterceptorOutcome, String>;

    fn name(&self) -> &'static str;
}

pub enum InterceptorOutcome {
    Handled(CommandResult),  // Stop chain. Use this result.
    Decline,                 // Pass. Next interceptor (or local) tries.
}
```

`Err` aborts the chain immediately — no silent fallthrough on error. Per `[[every-error-is-an-opportunity-to-battle-harden]]`: silent fallthrough would hide exactly the routing bugs interceptors exist to surface.

### `runtime::airc_interceptor::AircInterceptor` stub

- **Declines cleanly** when no `aircPeer`/`aircRoom` param is present (back-compat guarantee for existing callers)
- **Fails loud** with a concrete pointer to MODULE-ARCHITECTURE.md §7.1 when a caller actually requests airc routing
- The fail-loud is the design: a caller writing `aircPeer` today learns immediately that the transport isn't ready, rather than getting silent local dispatch that masquerades as airc success
- Replace the `Err` body with a call into `@continuum-modules/airc`'s send-command primitive when the airc module ships

### Extended `CommandExecutor`

```rust
let executor = CommandExecutor::new(registry)
    .with_interceptor(Arc::new(AircInterceptor::new()))
    .with_interceptor(Arc::new(GridInterceptor::new(...)));  // when wired
```

Dispatch order, single primitive:
1. **Interceptors** (insertion order; first `Handled` wins; `Err` aborts)
2. **Local Rust ServiceModule** via `ModuleRegistry::route_command`
3. **TypeScript** via Unix socket (`CommandRouterServer`, unchanged)

Adding a transport = adding an interceptor. The trait is the seam.

## Test plan

**16 tests pin the contract:**

| Test | Verifies |
|---|---|
| `empty_chain_returns_none` | Empty chain falls through to local dispatch unchanged |
| `all_decline_falls_through` | Walks every interceptor in insertion order |
| `first_to_handle_wins_short_circuits_later` | Later interceptors not consulted (assertion on call count, not just result) |
| `err_aborts_chain_no_silent_fallthrough` | Error propagates with interceptor name; later interceptors NOT consulted |
| `name_propagates_through_dyn_trait` | `name()` survives the trait-object boundary for logs |
| `airc::declines_when_no_airc_target` | Back-compat: existing callers see zero behavior change |
| `airc::fails_loud_when_airc_peer_targeted` | Caller writing `aircPeer` today learns immediately |
| `airc::fails_loud_when_airc_room_targeted` | Same for `aircRoom` |
| `executor::empty_chain_by_default` | Fresh executor has zero interceptors |
| `executor::with_interceptor_grows_chain_in_insertion_order` | `with_interceptor` appends, doesn't replace |
| `executor::interceptors_walked_in_insertion_order_when_all_decline` | Order is observable |
| `executor::first_handler_short_circuits_later_interceptors` | Stop happens, not just "result returned" |
| `executor::airc_interceptor_declines_when_no_airc_target_params` | Composes with executor without false intercepts |
| `executor::airc_interceptor_fails_loud_when_airc_peer_targeted` | Error reaches caller through executor + interceptor + chain |

- [x] `cargo check --lib --no-default-features --features metal,accelerate` — clean
- [x] `cargo test --lib runtime::command_interceptor runtime::airc_interceptor runtime::command_executor` — 16/16

## What this PR explicitly does NOT do

- Does NOT modify `init_executor` — the global chain stays empty so this is purely additive. A follow-up PR can auto-install airc + grid interceptors once grid is wired.
- Does NOT implement the GridInterceptor — that's a follow-up that bridges the existing `modules/grid/router.rs::GridRouter` into the new trait. The interceptor design supports it; the wiring is its own piece.
- Does NOT add cell return shapes (Value/Handle/Stream/Lambda from MODULE-ARCHITECTURE §5.1). Today's `CommandResult` enum (Json + Binary) is preserved. Cells are a follow-up.
- Does NOT migrate any existing command. The interceptor chain is the foundation; migrations build on top.

## After merge

Follow-up PRs in priority order:

1. **GridInterceptor** — bridges `modules/grid/router.rs::GridRouter` into the new trait. Wires `Arc<GridRouter>` + `Arc<NodeRegistry>` + `Arc<dyn GridTransport>` into the interceptor; auto-installs in `init_executor`.
2. **airc module + transport** — `@continuum-modules/airc` ships with `airc/send-command`; AircInterceptor's `Err` body becomes a real call into it.
3. **Cell return shapes** — extend `CommandResult` enum with `Handle`, `Stream`, `Lambda` per MODULE-ARCHITECTURE §5.1.
4. **First module migration** — chat or generator module migrated under the full module-architecture pattern.

## References

- [MODULE-ARCHITECTURE.md](docs/architecture/MODULE-ARCHITECTURE.md) §5 (Composition), §7.1 (airc as just another module)
- [UNIVERSAL-PRIMITIVES.md](docs/UNIVERSAL-PRIMITIVES.md) (the two-primitive kernel this extends)
- [SHAREABLE-COMMAND-MODULES.md](docs/infrastructure/SHAREABLE-COMMAND-MODULES.md) (per-command npm packaging — superseded at module level by MODULE-ARCHITECTURE)
- [PR #1482](https://github.com/CambrianTech/continuum/pull/1482) (the architecture doc this PR executes)
