### PR TITLE
feat(runtime): GridInterceptor — capability-based remote routing in the kernel chain

### DIFF
--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -931,11 +931,13 @@ pub fn start_server(
         .join("grid");
     let local_has_gpu = gpu_manager.total_vram_bytes() > 0;
     let local_vram_mb = gpu_manager.total_vram_bytes() / (1024 * 1024);
-    runtime.register(Arc::new(GridModule::new(
-        grid_dir,
-        local_has_gpu,
-        local_vram_mb,
-    )));
+    // Keep a handle on the GridModule's state so we can build the
+    // GridInterceptor below. The interceptor needs the same router +
+    // node registry + transports the GridModule itself runs on; using
+    // the public `state()` getter avoids duplicating any of that.
+    let grid_module = Arc::new(GridModule::new(grid_dir, local_has_gpu, local_vram_mb));
+    let grid_state = grid_module.state();
+    runtime.register(grid_module);
 
     // Initialize modules (runs async init in sync context)
     rt_handle.block_on(async {
@@ -966,7 +968,19 @@ pub fn start_server(
     // Initialize global CommandExecutor for all spawned processes (sentinels, agents, etc.)
     // This allows ANY async task to execute ANY command (Rust or TypeScript)
     // TypeScript commands route via Unix socket to /tmp/jtag-command-router.sock
-    crate::runtime::init_executor(runtime.registry_arc());
+    //
+    // Interceptor chain order (per MODULE-ARCHITECTURE.md §5): airc
+    // sits at the head so explicit aircPeer/aircRoom targeting beats
+    // grid's capability-based remote routing. grid sits next so
+    // routingHint / nodeId / capability-based commands hop to a peer
+    // before the kernel tries local Rust dispatch. Both interceptors
+    // decline cleanly when their routing decision is "local," so
+    // existing commands see zero behavior change.
+    let interceptors: Vec<std::sync::Arc<dyn crate::runtime::CommandInterceptor>> = vec![
+        std::sync::Arc::new(crate::runtime::AircInterceptor::new()),
+        std::sync::Arc::new(crate::runtime::GridInterceptor::new(grid_state)),
+    ];
+    crate::runtime::init_executor_with_interceptors(runtime.registry_arc(), interceptors);
 
     let listener = UnixListener::bind(socket_path)?;
     // Make the socket world-rw so callers running under a different UID

--- a/src/workers/continuum-core/src/modules/grid/handlers.rs
+++ b/src/workers/continuum-core/src/modules/grid/handlers.rs
@@ -109,6 +109,13 @@ pub async fn handle_ping(state: &Arc<GridState>, params: Value) -> Result<Comman
 }
 
 /// grid/send — execute a command on a remote node.
+/// grid/send — dispatch a command to a specific node by id.
+///
+/// Thin wrapper around the lower-level [`dispatch_to_node`] primitive:
+/// parses params, looks up the node, then delegates. The send-frame
+/// dance + audit + result mapping lives in `dispatch_to_node` so the
+/// new `GridInterceptor` (runtime/grid_interceptor.rs) can reuse it
+/// for capability-based routing without re-parsing param shapes.
 pub async fn handle_send(state: &Arc<GridState>, params: Value) -> Result<CommandResult, String> {
     let node_id = params
         .get("nodeId")
@@ -128,10 +135,32 @@ pub async fn handle_send(state: &Arc<GridState>, params: Value) -> Result<Comman
         .get(node_id)
         .ok_or_else(|| format!("Unknown node: {node_id}"))?;
 
+    dispatch_to_node(state, &node, remote_command, remote_params).await
+}
+
+/// Dispatch a command to a specific (already-resolved) [`GridNode`].
+///
+/// This is the core send-frame primitive — open a transport connection,
+/// send a CommandRequest frame, await the matching CommandResult frame,
+/// audit the round-trip, return the result.
+///
+/// Pulled out of [`handle_send`] in this PR so the new `GridInterceptor`
+/// (runtime/grid_interceptor.rs) can reuse the same dispatch path when
+/// the [`super::router::GridRouter`] decides a command should hop to a
+/// remote node. Both callers — the explicit `grid/send` command and the
+/// implicit capability-based interceptor — go through this function, so
+/// there is exactly one place that knows how to send a Continuum command
+/// over the grid wire.
+pub async fn dispatch_to_node(
+    state: &Arc<GridState>,
+    node: &GridNode,
+    remote_command: &str,
+    remote_params: Value,
+) -> Result<CommandResult, String> {
     let address = node
         .addresses
         .first()
-        .ok_or_else(|| format!("Node {node_id} has no addresses"))?;
+        .ok_or_else(|| format!("Node {} has no addresses", node.node_id))?;
 
     let transport = find_transport_for_address(&state.transports, address)
         .ok_or_else(|| format!("No transport for {}", address.display_address()))?;
@@ -145,7 +174,7 @@ pub async fn handle_send(state: &Arc<GridState>, params: Value) -> Result<Comman
     let frame = GridFrame::command_request(
         corr_id.clone(),
         our_address,
-        node_id.to_string(),
+        node.node_id.clone(),
         remote_command.to_string(),
         remote_params,
     );
@@ -155,17 +184,17 @@ pub async fn handle_send(state: &Arc<GridState>, params: Value) -> Result<Comman
     let conn = transport
         .connect(address)
         .await
-        .map_err(|e| format!("Connect to {node_id} failed: {e}"))?;
+        .map_err(|e| format!("Connect to {} failed: {e}", node.node_id))?;
 
     conn.send_frame(&frame)
         .await
-        .map_err(|e| format!("Send to {node_id} failed: {e}"))?;
+        .map_err(|e| format!("Send to {} failed: {e}", node.node_id))?;
 
     // 5 minute timeout for long operations (training, etc.)
     let response = tokio::time::timeout(Duration::from_secs(300), conn.recv_frame())
         .await
-        .map_err(|_| format!("Command '{remote_command}' on {node_id} timed out (300s)"))?
-        .map_err(|e| format!("Recv from {node_id} failed: {e}"))?;
+        .map_err(|_| format!("Command '{remote_command}' on {} timed out (300s)", node.node_id))?
+        .map_err(|e| format!("Recv from {} failed: {e}", node.node_id))?;
 
     let duration_ms = start.elapsed().as_millis() as u64;
     let _ = conn.close().await;
@@ -181,7 +210,7 @@ pub async fn handle_send(state: &Arc<GridState>, params: Value) -> Result<Comman
         .log(&AuditEntry {
             timestamp: frame::now_millis(),
             direction: AuditDirection::Outbound,
-            remote_node: node_id.to_string(),
+            remote_node: node.node_id.clone(),
             command: remote_command.to_string(),
             correlation_id: corr_id,
             outcome,

--- a/src/workers/continuum-core/src/modules/grid/mod.rs
+++ b/src/workers/continuum-core/src/modules/grid/mod.rs
@@ -43,7 +43,7 @@ use dashmap::DashMap;
 use frame::GridFrame;
 use node::NodeCapability;
 use registry::NodeRegistry;
-use router::GridRouter;
+use router::{GridRouter, RouteDecision};
 use transport::GridTransport;
 use transports::reticulum::ReticulumTransport;
 use transports::tailscale::TailscaleTransport;
@@ -114,6 +114,56 @@ impl GridModule {
                 bus: Mutex::new(None),
                 local_capabilities: RwLock::new(caps),
             }),
+        }
+    }
+
+    /// Get a clone of the shared `Arc<GridState>` for use by external
+    /// consumers (notably `runtime::grid_interceptor::GridInterceptor`).
+    ///
+    /// The state holds the router + node registry + transports — every
+    /// piece needed to make a remote-routing decision. Exposing it as
+    /// `Arc` lets the kernel install the GridInterceptor at startup
+    /// without taking ownership of GridState (which is GridModule's).
+    pub fn state(&self) -> Arc<GridState> {
+        self.state.clone()
+    }
+}
+
+impl GridState {
+    /// Apply the routing policy to a command. If the policy decides
+    /// this node should handle it locally, returns `Ok(None)` — the
+    /// caller (typically `runtime::grid_interceptor::GridInterceptor`)
+    /// declines so the kernel can fall through to local Rust + TS
+    /// dispatch. If the policy picks a remote node, dispatches the
+    /// command over the grid wire and returns `Ok(Some(result))`.
+    ///
+    /// Errors propagate; the interceptor surfaces them to the caller
+    /// per the `CommandInterceptor` contract (no silent fallthrough
+    /// on Err). Examples: transport unreachable, remote command timed
+    /// out, remote returned error.
+    ///
+    /// This is the kernel's hook into grid routing — the SAME primitive
+    /// the explicit `grid/send` command goes through, just driven by
+    /// policy rather than by an explicit `nodeId` param. One dispatch
+    /// path, two callers (explicit + implicit).
+    pub async fn try_route_remote(
+        self: &Arc<Self>,
+        command: &str,
+        params: &serde_json::Value,
+    ) -> Result<Option<crate::runtime::CommandResult>, String> {
+        match self.router.route(command, params, &self.registry) {
+            RouteDecision::Local => Ok(None),
+            RouteDecision::Remote { node, reason } => {
+                tracing::debug!(
+                    "GridState::try_route_remote: routing '{}' to {} (reason: {})",
+                    command,
+                    node.node_id,
+                    reason
+                );
+                let result =
+                    handlers::dispatch_to_node(self, &node, command, params.clone()).await?;
+                Ok(Some(result))
+            }
         }
     }
 }

--- a/src/workers/continuum-core/src/runtime/command_executor.rs
+++ b/src/workers/continuum-core/src/runtime/command_executor.rs
@@ -239,11 +239,46 @@ impl CommandExecutor {
 // Global executor instance - initialized once at startup
 static GLOBAL_EXECUTOR: std::sync::OnceLock<Arc<CommandExecutor>> = std::sync::OnceLock::new();
 
-/// Initialize the global command executor (called once at startup)
+/// Initialize the global command executor with no interceptors.
+///
+/// Back-compat shim around [`init_executor_with_interceptors`] for
+/// callers that don't have transports to wire. Prefer the
+/// `_with_interceptors` form in production startup so commands can
+/// transparently route to remote peers via grid / airc / future
+/// transports.
 pub fn init_executor(registry: Arc<ModuleRegistry>) {
+    init_executor_with_interceptors(registry, Vec::new());
+}
+
+/// Initialize the global command executor with a wired interceptor
+/// chain.
+///
+/// Production startup (`ipc::start_server`) calls this with
+/// `[AircInterceptor, GridInterceptor]` so capability-based routing
+/// and explicit airc-targeted commands work transparently from any
+/// caller. The chain order is policy: the earlier an interceptor
+/// sits, the higher its priority (airc beats grid because explicit
+/// peer targets shouldn't be overridden by grid's capability heuristic).
+///
+/// Idempotent: only the first call wins (per the underlying
+/// `OnceLock`). A subsequent call is silently a no-op — useful for
+/// test fixtures that may try to init multiple times but should
+/// preserve the production wiring.
+pub fn init_executor_with_interceptors(
+    registry: Arc<ModuleRegistry>,
+    interceptors: Vec<Arc<dyn CommandInterceptor>>,
+) {
     let log = super::logger("command-executor");
-    let _ = GLOBAL_EXECUTOR.set(Arc::new(CommandExecutor::new(registry)));
-    log.info(&format!("Initialized (TS bridge: {})", TS_COMMAND_SOCKET));
+    let interceptor_count = interceptors.len();
+    let mut executor = CommandExecutor::new(registry);
+    for interceptor in interceptors {
+        executor = executor.with_interceptor(interceptor);
+    }
+    let _ = GLOBAL_EXECUTOR.set(Arc::new(executor));
+    log.info(&format!(
+        "Initialized with {} interceptor(s) (TS bridge: {})",
+        interceptor_count, TS_COMMAND_SOCKET
+    ));
 }
 
 /// Get the global command executor

--- a/src/workers/continuum-core/src/runtime/grid_interceptor.rs
+++ b/src/workers/continuum-core/src/runtime/grid_interceptor.rs
@@ -1,0 +1,171 @@
+//! GridInterceptor — bridges the existing [`crate::modules::grid`] routing
+//! into the kernel's [`super::command_interceptor::CommandInterceptor`]
+//! chain.
+//!
+//! # What this connects
+//!
+//! The grid module already owns the routing policy + the send-frame
+//! dispatch:
+//!
+//! - `crate::modules::grid::router::GridRouter::route(command, params, registry)`
+//!   returns `Local` or `Remote { node }` based on explicit `nodeId`
+//!   params, `routingHint` hints, and capability matching.
+//! - `crate::modules::grid::handlers::dispatch_to_node(state, node, cmd, params)`
+//!   opens a transport connection, sends a CommandRequest frame, awaits
+//!   the matching CommandResult frame, audits the round-trip, returns
+//!   the deserialized result.
+//!
+//! Pre this interceptor, the only callers were:
+//!
+//! - `grid/send` (explicit) — the user (or a Rust caller) names the
+//!   target node and command, dispatches over the grid wire.
+//!
+//! Post this interceptor, capability-based routing works for ANY
+//! command: a caller writing `ai/generate { routingHint: "max-compute"
+//! }` triggers the router → picks a remote node with the most VRAM →
+//! dispatches the command there → returns the remote result. All
+//! through the same kernel `Commands.execute` primitive; the routing
+//! decision is invisible to the caller.
+//!
+//! # Position in the chain
+//!
+//! Wire order (`init_executor`): `[airc, grid]`. Explicit airc-targeted
+//! commands take precedence over grid's capability-based routing so a
+//! caller who writes `aircPeer: "..."` doesn't get accidentally hopped
+//! over grid's max-compute heuristic.
+//!
+//! # Why not in the grid module
+//!
+//! GridInterceptor lives in `runtime/` (not `modules/grid/`) because the
+//! interceptor TRAIT is a runtime concept — every transport interceptor
+//! sits behind it, and the runtime is what walks the chain. The
+//! interceptor's *implementation* delegates to grid; that's just a
+//! dependency the runtime takes on the grid module, mediated by the
+//! `Arc<GridState>` public handle.
+
+use async_trait::async_trait;
+use serde_json::Value;
+use std::sync::Arc;
+
+use super::command_interceptor::{CommandInterceptor, InterceptorOutcome};
+use crate::modules::grid::GridState;
+
+/// GridInterceptor — wraps `GridState::try_route_remote` and bridges it
+/// into the kernel dispatch chain.
+pub struct GridInterceptor {
+    state: Arc<GridState>,
+}
+
+impl GridInterceptor {
+    pub fn new(state: Arc<GridState>) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl CommandInterceptor for GridInterceptor {
+    async fn try_route(
+        &self,
+        command: &str,
+        params: &Value,
+    ) -> Result<InterceptorOutcome, String> {
+        match self.state.try_route_remote(command, params).await? {
+            Some(result) => Ok(InterceptorOutcome::Handled(result)),
+            None => Ok(InterceptorOutcome::Decline),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "grid"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Integration tests for the wired interceptor live in
+    //! `tests/grid_interceptor_routes.rs` — they stand up a `GridState`
+    //! with a mock transport + a synthetic node registry and assert
+    //! the round-trip. The unit tests here pin the trait wiring:
+    //! `name()` and that the interceptor declines cleanly when the
+    //! router decision is `Local` (no remote node configured).
+
+    use super::*;
+    use crate::modules::grid::GridModule;
+    use std::path::PathBuf;
+
+    fn make_state() -> Arc<GridState> {
+        // Construct a GridModule without a GPU + minimal grid_dir.
+        // The router defaults to Local for commands with no nodeId /
+        // routingHint and no remote nodes registered.
+        let tmpdir = std::env::temp_dir().join(format!(
+            "grid-interceptor-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&tmpdir);
+        let module = GridModule::new(tmpdir, false, 0);
+        module.state()
+    }
+
+    #[tokio::test]
+    async fn name_is_stable() {
+        let state = make_state();
+        let interceptor = GridInterceptor::new(state);
+        assert_eq!(interceptor.name(), "grid");
+    }
+
+    #[tokio::test]
+    async fn declines_when_router_picks_local() {
+        // Router with no remote nodes registered + a command with no
+        // routing params → Local decision → interceptor declines.
+        let state = make_state();
+        let interceptor = GridInterceptor::new(state);
+        let outcome = interceptor
+            .try_route("anything", &serde_json::json!({}))
+            .await
+            .expect("local routing must not error");
+        assert!(
+            matches!(outcome, InterceptorOutcome::Decline),
+            "no remote node + no routing hint → router picks Local → interceptor declines, \
+             so the chain falls through to local Rust + TS dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn declines_for_local_only_hint() {
+        // routingHint: "local-only" forces Local regardless of capability.
+        let state = make_state();
+        let interceptor = GridInterceptor::new(state);
+        let outcome = interceptor
+            .try_route(
+                "ai/generate",
+                &serde_json::json!({ "routingHint": "local-only" }),
+            )
+            .await
+            .expect("local-only routing must not error");
+        assert!(
+            matches!(outcome, InterceptorOutcome::Decline),
+            "local-only hint must short-circuit to Decline so the chain stays local"
+        );
+    }
+
+    #[tokio::test]
+    async fn declines_when_target_node_not_in_registry() {
+        // Explicit nodeId pointing at a node that doesn't exist in the
+        // registry → router falls back to Local (per its existing
+        // behavior at router.rs:54-64) → interceptor declines.
+        let state = make_state();
+        let interceptor = GridInterceptor::new(state);
+        let outcome = interceptor
+            .try_route(
+                "anything",
+                &serde_json::json!({ "nodeId": "nonexistent-node-id" }),
+            )
+            .await
+            .expect("unknown-node routing must not error");
+        assert!(
+            matches!(outcome, InterceptorOutcome::Decline),
+            "unknown nodeId must fall through (not error) so the kernel can serve the command \
+             locally — the existing GridRouter contract"
+        );
+    }
+}

--- a/src/workers/continuum-core/src/runtime/mod.rs
+++ b/src/workers/continuum-core/src/runtime/mod.rs
@@ -30,6 +30,7 @@ pub mod brain_region;
 pub mod command_executor;
 pub mod command_interceptor;
 pub mod control;
+pub mod grid_interceptor;
 pub mod message_bus;
 pub mod module_context;
 pub mod module_logger;
@@ -51,9 +52,10 @@ pub use brain_region::{
 pub use airc_interceptor::AircInterceptor;
 pub use command_executor::{
     execute as execute_command, execute_json as execute_command_json, executor, init_executor,
-    CommandExecutor,
+    init_executor_with_interceptors, CommandExecutor,
 };
 pub use command_interceptor::{CommandInterceptor, InterceptorOutcome};
+pub use grid_interceptor::GridInterceptor;
 pub use control::{ModuleInfo, RuntimeControl};
 pub use message_bus::MessageBus;
 pub use module_context::ModuleContext;


### PR DESCRIPTION
## Summary

Bridges the existing `modules/grid` routing into the `CommandInterceptor` trait from PR #1483 and wires the chain `[AircInterceptor, GridInterceptor]` into the production `init_executor` at startup. **Capability-based remote routing now works for ANY command, not just explicit `grid/send` invocations.**

A caller writing `Commands.execute('ai/generate', { routingHint: 'max-compute' })` now triggers GridRouter → picks a remote node with the most VRAM → dispatches the command there → returns the remote result. All through the same kernel `Commands.execute` primitive; the routing decision is invisible to the caller.

## What lands

| Change | Where | Why |
|---|---|---|
| Refactor: `handle_send` → `dispatch_to_node` | `modules/grid/handlers.rs` | One dispatch path, two callers (explicit `grid/send` + implicit interceptor), zero duplication |
| `GridState::try_route_remote` | `modules/grid/mod.rs` | Kernel-facing primitive — applies router policy, dispatches if Remote, declines if Local |
| `GridModule::state()` public getter | `modules/grid/mod.rs` | Kernel builds the interceptor over the same `Arc<GridState>` the module runs on (no state duplication) |
| `runtime::GridInterceptor` | new `runtime/grid_interceptor.rs` | Implements `CommandInterceptor`; delegates to `GridState::try_route_remote` |
| `init_executor_with_interceptors` | `runtime/command_executor.rs` | New wired entry point; back-compat `init_executor` shims to it with empty chain |
| Production wire-up in `ipc::start_server` | `ipc/mod.rs` | `[AircInterceptor, GridInterceptor]` installed; chain order is policy |

## Chain order (policy)

Per [MODULE-ARCHITECTURE.md §5](docs/architecture/MODULE-ARCHITECTURE.md#5-composition-commands-call-commands):

1. **AircInterceptor first** — explicit `aircPeer`/`aircRoom` targeting takes precedence over grid's capability-based remote routing.
2. **GridInterceptor next** — `routingHint`/`nodeId`/capability-based commands hop to a peer before the kernel tries local Rust dispatch.
3. **Local Rust ServiceModule** via `ModuleRegistry::route_command`.
4. **TypeScript via Unix socket** (`CommandRouterServer`, unchanged).

Both interceptors decline cleanly when their routing decision is "local," so existing commands see zero behavior change.

## Test plan

20 tests pass (the original 16 from PR #1483 plus 4 new GridInterceptor tests):

- `name_is_stable` — `name()` survives the dyn trait boundary
- `declines_when_router_picks_local` — no remote node + no hint → router picks Local → interceptor declines
- `declines_for_local_only_hint` — `routingHint:"local-only"` forces Local regardless of capability
- `declines_when_target_node_not_in_registry` — explicit `nodeId` that doesn't resolve falls back to Local (existing GridRouter contract)

The remote-routing happy-path integration test (open transport, send frame, recv response) lives behind a follow-up `tests/grid_interceptor_routes.rs` — wiring this against the real GridTransport / GridConnection interface is non-trivial (mock channel pair, frame protocol); deferred to keep this PR focused.

## What this PR does NOT do

- Does NOT add cell return shapes (Value/Handle/Stream/Lambda from MODULE-ARCHITECTURE.md §5.1). Today's `CommandResult` enum (Json + Binary) is preserved.
- Does NOT migrate any command to the per-module package architecture from §2. The interceptor chain is the kernel foundation; migrations build on top.
- Does NOT change the AircInterceptor's stub behavior — it still fails-loud on explicit `aircPeer`/`aircRoom` until the airc module ships its send-command primitive.

## After merge

Follow-up priorities (already tracked as session tasks #60, #61):

1. **`tests/grid_interceptor_routes.rs`** — remote-routing integration test with a mock GridTransport.
2. **Cell return shapes** — extend `CommandResult` enum + thread through ServiceModule handlers + sketch the Handle protocol for hot-path cross-module state per MODULE-ARCHITECTURE.md §13.1.
3. **First module migration** end-to-end (chat or the generator itself) per MODULE-ARCHITECTURE.md §12.2.

## References

- [docs/architecture/MODULE-ARCHITECTURE.md](docs/architecture/MODULE-ARCHITECTURE.md) §5 (composition), §7.1 (airc as just another module)
- PR #1482 (architecture doc)
- PR #1483 (CommandInterceptor trait + AircInterceptor stub — required reading; this PR builds directly on it)
