### PR TITLE
feat(runtime): cell return shapes — Handle for long-running stateful work + reserved Stream/Lambda

### DIFF
--- a/src/workers/continuum-core/src/inference/llm_module_service.rs
+++ b/src/workers/continuum-core/src/inference/llm_module_service.rs
@@ -528,7 +528,7 @@ mod tests {
                 assert_eq!(response.complete.tokens_generated, 3);
                 assert_eq!(response.first_token.request_id, req.request_id);
             }
-            CommandResult::Binary { .. } => panic!("expected Json response"),
+            other => panic!("expected CommandResult::Json, got {other:?}"),
         }
     }
 

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -367,6 +367,15 @@ fn handle_client<S: IpcStream>(stream: S, state: Arc<ServerState>) -> std::io::R
                         json_header: Response::success(metadata),
                         binary_data: data,
                     },
+                    // Cell shapes from MODULE-ARCHITECTURE.md §5.1.
+                    // Handle: serialize the HandleRef as JSON over the
+                    // wire; the TS-side caller holds it and passes back
+                    // on subsequent calls (long-running session pattern
+                    // — inference, training, hosting, ORM).
+                    Some(Ok(other)) => match other.to_json_value() {
+                        Ok(value) => HandleResult::Json(Response::success(value)),
+                        Err(e) => HandleResult::Json(Response::error(e)),
+                    },
                     Some(Err(e)) => HandleResult::Json(Response::error(e)),
                     None => HandleResult::Json(Response::error(format!(
                         "Unknown command: '{}'. No module registered for this command prefix.",

--- a/src/workers/continuum-core/src/modules/cognition.rs
+++ b/src/workers/continuum-core/src/modules/cognition.rs
@@ -1795,10 +1795,13 @@ async fn execute_rust_module_json(
         format!("{command}: no Rust module route registered; refusing TypeScript fallback")
     })?;
 
-    match module.handle_command(&routed_command, params).await? {
-        CommandResult::Json(value) => Ok(value),
-        CommandResult::Binary { metadata, .. } => Ok(metadata),
-    }
+    // Project the cell shape into a plain JSON Value. Handle returns
+    // its HandleRef as JSON (the caller can hold it and pass back);
+    // Stream/Lambda return their not-yet-wired protocol error.
+    module
+        .handle_command(&routed_command, params)
+        .await?
+        .to_json_value()
 }
 
 #[cfg(test)]
@@ -2003,7 +2006,7 @@ mod turn_execute_tests {
                     "empty drain produces null inferenceResponse; got {v}"
                 );
             }
-            CommandResult::Binary { .. } => panic!("expected Json"),
+            other => panic!("expected CommandResult::Json, got {other:?}"),
         }
     }
 

--- a/src/workers/continuum-core/src/modules/grid/connection.rs
+++ b/src/workers/continuum-core/src/modules/grid/connection.rs
@@ -138,10 +138,10 @@ async fn execute_incoming_request(request: &GridFrame, state: &Arc<GridState>) -
             // Command matched a Rust module prefix — try Rust handler first
             let (module, full_cmd) = result;
             match module.handle_command(&full_cmd, params.clone()).await {
-                Ok(CommandResult::Json(value)) => GridFrame::success_response(request, value),
-                Ok(CommandResult::Binary { metadata, .. }) => {
-                    GridFrame::success_response(request, metadata)
-                }
+                Ok(cmd_result) => match cmd_result.to_json_value() {
+                    Ok(value) => GridFrame::success_response(request, value),
+                    Err(e) => GridFrame::error_response(request, e),
+                },
                 Err(e) if e.starts_with("Unknown") => {
                     // Rust module doesn't handle this specific command —
                     // fall through to TypeScript layer (e.g., grid/node-status,

--- a/src/workers/continuum-core/src/modules/sentinel/steps/llm.rs
+++ b/src/workers/continuum-core/src/modules/sentinel/steps/llm.rs
@@ -198,6 +198,38 @@ async fn execute_generate_mode(
                     "unexpected binary response from ai/generate",
                 ));
             }
+            // Cell shapes from MODULE-ARCHITECTURE.md §5.1 — ai/generate
+            // should always return Json; receiving any other shape is a
+            // contract violation we surface as a step error rather than
+            // silently dropping. The Handle shape is the natural future
+            // home for streaming inference sessions (start → handle →
+            // poll), but ai/generate (one-shot completion) stays Json.
+            Ok(CommandResult::Handle(h)) => {
+                return Err(step_err(
+                    pipeline_ctx.handle_id,
+                    "LLM step",
+                    format!(
+                        "ai/generate must return Json, got Handle (owner={}, type={}); \
+                         streaming inference belongs on a different command, not the \
+                         one-shot generate path",
+                        h.owner, h.type_tag
+                    ),
+                ));
+            }
+            Ok(CommandResult::Stream(_)) => {
+                return Err(step_err(
+                    pipeline_ctx.handle_id,
+                    "LLM step",
+                    CommandResult::stream_protocol_error(),
+                ));
+            }
+            Ok(CommandResult::Lambda(_)) => {
+                return Err(step_err(
+                    pipeline_ctx.handle_id,
+                    "LLM step",
+                    CommandResult::lambda_protocol_error(),
+                ));
+            }
             Err(e) => {
                 if is_transient_error(&e) && attempt < LLM_MAX_RETRIES {
                     last_error = e;

--- a/src/workers/continuum-core/src/runtime/cell_shapes.rs
+++ b/src/workers/continuum-core/src/runtime/cell_shapes.rs
@@ -1,0 +1,333 @@
+//! Cell return shapes per [MODULE-ARCHITECTURE.md §5.1](../../../../../docs/architecture/MODULE-ARCHITECTURE.md).
+//!
+//! A command returns one of four cell shapes. Today's `CommandResult`
+//! enum is the in-process Rust embodiment of those four shapes:
+//!
+//! | Cell shape (architecture) | `CommandResult` variant | Status |
+//! |---|---|---|
+//! | `Value<T>` (immediate typed result) | `Json(Value)` + `Binary { metadata, data }` | Mainline; back-compat |
+//! | `Handle<T>` (typed ref to state owned by producer) | `Handle(HandleRef)` | **Lands in this PR** |
+//! | `Stream<T>` (async sequence of values) | `Stream(StreamPlaceholder)` | Reserved variant; returning it errors until the wire protocol lands |
+//! | `Lambda<P, T>` (callable returned by a command) | `Lambda(LambdaPlaceholder)` | Reserved variant; returning it errors until the lambda protocol lands |
+//!
+//! The Json + Binary variants ARE the Value cell shape under the
+//! taxonomy; they're kept under their original names so the 300+
+//! existing command handlers don't need to change. New code that
+//! produces a plain typed result should still use `CommandResult::Json`
+//! (or `CommandResult::json(&value)?`). The Value name in the
+//! architecture doc is the categorical name; the implementation name
+//! stays Json for back-compat.
+//!
+//! # Why Handle is the headline shape
+//!
+//! Handle is the cell answer to MODULE-ARCHITECTURE.md §13.1 (hot-path
+//! cross-module state). A module produces a handle to its internal
+//! state; downstream commands take the handle as a param; the kernel
+//! routes those calls back to the producing module (whose handler
+//! looks up the state under the handle's `id`). No state copy, no
+//! lock contention across modules, same primitive locally as
+//! cross-machine. The producer owns; consumers compose by reference.
+//!
+//! The kernel does NOT need a global handle registry — each producing
+//! module manages the lifetime of its own handles internally (typed
+//! state map under the handle's `id`). The kernel sees a Handle the
+//! same as any other JSON payload; routing happens through the normal
+//! `Commands.execute(target/op, { handle })` path. The Handle struct
+//! is purely a data shape that travels through the existing primitive.
+//!
+//! # The canonical use cases (per Joel 2026-05-30)
+//!
+//! Handles are for **long-running stateful work** where the first call
+//! produces a handle and subsequent calls operate on it:
+//!
+//! - **inference** — `ai/inference/start { model, prompt }` returns a
+//!   handle; later `ai/inference/poll { handle }` and
+//!   `ai/inference/cancel { handle }` operate on the running session.
+//! - **training** — `training/run/start { recipe }` returns a handle;
+//!   `training/run/progress { handle }`, `training/run/cancel { handle }`
+//!   query and control the run.
+//! - **hosting** — `live/room/join { roomId }` returns a handle;
+//!   `live/audio/publish { handle, frame }` operates on the joined
+//!   session.
+//! - **ORM** — `data/transaction/begin` returns a handle;
+//!   `data/transaction/exec { handle, query }` and
+//!   `data/transaction/commit { handle }` thread the same transaction.
+//!
+//! All IDs are UUIDs. The producer mints a UUID, stores its state under
+//! that UUID, returns the handle. Subsequent calls carry the UUID; the
+//! producer's handler does an O(1) map lookup. The pattern works the
+//! same whether the producer runs in-process, in a sibling module, or
+//! on a remote peer over grid/airc.
+
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+use uuid::Uuid;
+
+/// Typed reference to state owned by a specific module.
+///
+/// # Round-trip
+///
+/// 1. Producer command (e.g., `chat/send`) creates internal state
+///    (a message buffer, a session, a render context). It allocates a
+///    handle ID, stores the state under that ID in its own state map,
+///    and returns `CommandResult::Handle(HandleRef { owner: "chat",
+///    id, type_tag: "chat::MessageHandle", created_at_ms })`.
+///
+/// 2. Caller (Rust, TS, or remote) holds the HandleRef opaquely. It
+///    serializes through any wire crossing (it's plain JSON via serde).
+///
+/// 3. Caller invokes a downstream command that takes the handle:
+///    `Commands.execute("chat/message/get", { handle })`. The kernel
+///    routes to the chat module (`chat/` prefix in the registry); the
+///    chat module reads the handle's `id` from params and looks up its
+///    state map.
+///
+/// 4. Cross-module: if a different module needs to operate on the
+///    handle's underlying state, it asks the owner via a command:
+///    `Commands.execute("chat/message/get", { handle })` — same call,
+///    routed to the owner. The kernel doesn't care which module asked.
+///
+/// # `type_tag` discipline
+///
+/// Convention: `"<module>::<TypeName>"` matching the Rust type that
+/// produced the handle. e.g., `"chat::MessageHandle"`, `"rag::Slice"`,
+/// `"persona::InboxFrame"`. Lets typed callers cast safely on receipt
+/// without round-tripping through the producer.
+///
+/// # Lifetime
+///
+/// Producer owns the lifetime. The handle is valid as long as the
+/// producer's state map holds the ID. Producers may evict handles
+/// after a TTL, on session end, on resource pressure, etc. A consumer
+/// holding a stale handle gets a typed error from the producer's
+/// command handler (`"handle not found"`); the kernel doesn't
+/// participate in lifetime management. This is intentional — the
+/// kernel stays minimal, and lifetime policy belongs to the producer.
+///
+/// # Cross-machine
+///
+/// Same primitive. A handle minted on machine A is meaningful only on
+/// machine A. If a consumer on machine B calls a command taking that
+/// handle, the kernel's grid interceptor routes the call back to A
+/// (the handle's `owner` lives there). The handle ID never leaves A's
+/// state map; the remote call carries the ID, A executes the op
+/// locally, returns the result.
+#[derive(Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq)]
+#[ts(export, export_to = "../../../shared/generated/runtime/HandleRef.ts")]
+pub struct HandleRef {
+    /// Module that owns the state behind this handle. Kernel routes
+    /// any command taking this handle through the module's registered
+    /// command prefix (e.g., `"chat"` → commands under `chat/`).
+    pub owner: String,
+
+    /// UUID the owner module uses to look up its state. Always UUID
+    /// (per Joel 2026-05-30 — no string IDs at the cell-shape level);
+    /// the producer mints via [`HandleRef::mint`] (kernel chooses) or
+    /// passes a pre-allocated UUID via [`HandleRef::with_id`] (producer
+    /// chooses). Wire format is the UUID's canonical string serialization
+    /// so ts-rs sees it as `string`.
+    #[ts(type = "string")]
+    pub id: Uuid,
+
+    /// Type tag identifying the state shape. Convention:
+    /// `"<module>::<TypeName>"`. Lets typed consumers cast safely
+    /// without asking the owner.
+    pub type_tag: String,
+
+    /// Milliseconds since unix epoch when the handle was minted.
+    /// Useful for TTL enforcement (producer's choice) and for
+    /// diagnostic ordering.
+    #[ts(type = "number")]
+    pub created_at_ms: u64,
+}
+
+impl HandleRef {
+    /// Construct a HandleRef from a pre-allocated UUID. Use this when
+    /// the producer needs to know the UUID up front — e.g., when
+    /// inserting state into its map under a specific key:
+    ///
+    /// ```ignore
+    /// let id = Uuid::new_v4();
+    /// self.sessions.insert(id, session_state);
+    /// Ok(CommandResult::Handle(HandleRef::with_id("ai/inference", id, "ai::InferenceSession")))
+    /// ```
+    pub fn with_id(
+        owner: impl Into<String>,
+        id: Uuid,
+        type_tag: impl Into<String>,
+    ) -> Self {
+        Self {
+            owner: owner.into(),
+            id,
+            type_tag: type_tag.into(),
+            created_at_ms: now_ms(),
+        }
+    }
+
+    /// Construct a HandleRef with a fresh UUID. Convenience wrapper
+    /// around [`Self::with_id`] for producers that don't need to know
+    /// the UUID before they construct the handle:
+    ///
+    /// ```ignore
+    /// let handle = HandleRef::mint("ai/inference", "ai::InferenceSession");
+    /// self.sessions.insert(handle.id, session_state);
+    /// Ok(CommandResult::Handle(handle))
+    /// ```
+    pub fn mint(owner: impl Into<String>, type_tag: impl Into<String>) -> Self {
+        Self::with_id(owner, Uuid::new_v4(), type_tag)
+    }
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Reserved: streaming result. **Returning a Stream result today is a
+/// runtime error.** The variant exists so the enum's shape is fixed
+/// before handlers begin migrating; the wire protocol (frame format,
+/// correlation IDs, backpressure, cancellation) is the open piece.
+///
+/// When the protocol lands, `correlation_id` will tie incoming stream
+/// frames to this stream so the consumer can match. The struct is
+/// `#[non_exhaustive]` so adding fields later is non-breaking for
+/// external code; internal code uses [`StreamPlaceholder::new`] to
+/// construct rather than the field-init shorthand.
+#[derive(Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq)]
+#[ts(export, export_to = "../../../shared/generated/runtime/StreamPlaceholder.ts")]
+#[non_exhaustive]
+pub struct StreamPlaceholder {
+    /// Correlation ID a future wire protocol will use to tie incoming
+    /// stream frames to this stream handle. Today: unused; reserved.
+    pub correlation_id: String,
+}
+
+impl StreamPlaceholder {
+    /// Construct a placeholder. The kernel and consumer will use
+    /// `correlation_id` once the streaming protocol is designed; until
+    /// then, callers should NOT return this variant — the executor
+    /// rejects it via [`super::CommandResult::stream_protocol_error`].
+    pub fn new(correlation_id: impl Into<String>) -> Self {
+        Self {
+            correlation_id: correlation_id.into(),
+        }
+    }
+}
+
+/// Reserved: lambda (callable returned by a command). **Returning a
+/// Lambda result today is a runtime error.** Same status as
+/// [`StreamPlaceholder`]: variant exists, in-process + wire shapes are
+/// deferred.
+///
+/// When the protocol lands, a Lambda will be a curried command — name
+/// + bound params + callsite metadata — that the caller invokes later
+/// with remaining params via the kernel. Useful for setup commands
+/// that prepare a context and return "now call THIS with the rest of
+/// your input."
+#[derive(Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq)]
+#[ts(export, export_to = "../../../shared/generated/runtime/LambdaPlaceholder.ts")]
+#[non_exhaustive]
+pub struct LambdaPlaceholder {
+    /// Name of the curried command the lambda will dispatch when
+    /// invoked. e.g., `"ai/generate"`.
+    pub command: String,
+    /// Params already bound by the producer. The caller provides the
+    /// remaining params; the kernel merges then dispatches.
+    #[ts(type = "Record<string, unknown>")]
+    pub bound_params: serde_json::Value,
+}
+
+impl LambdaPlaceholder {
+    /// Construct a placeholder. Until the lambda protocol lands,
+    /// callers should NOT return this variant — the executor rejects
+    /// it via [`super::CommandResult::lambda_protocol_error`].
+    pub fn new(command: impl Into<String>, bound_params: serde_json::Value) -> Self {
+        Self {
+            command: command.into(),
+            bound_params,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_ref_with_id_preserves_uuid() {
+        let id = Uuid::new_v4();
+        let h = HandleRef::with_id("ai/inference", id, "ai::InferenceSession");
+        assert_eq!(h.id, id, "with_id must preserve the producer-allocated UUID");
+        assert_eq!(h.owner, "ai/inference");
+        assert_eq!(h.type_tag, "ai::InferenceSession");
+        assert!(h.created_at_ms > 0, "constructor must capture a timestamp");
+    }
+
+    #[test]
+    fn handle_ref_mint_generates_fresh_uuid() {
+        let a = HandleRef::mint("ai/inference", "ai::InferenceSession");
+        let b = HandleRef::mint("ai/inference", "ai::InferenceSession");
+        assert_ne!(a.id, b.id, "mint must produce distinct UUIDs across calls");
+    }
+
+    #[test]
+    fn handle_ref_roundtrips_through_json() {
+        let h = HandleRef::mint("chat", "chat::MessageHandle");
+        let json = serde_json::to_string(&h).expect("HandleRef must serialize");
+        let back: HandleRef = serde_json::from_str(&json).expect("HandleRef must deserialize");
+        assert_eq!(h, back);
+        // Spot-check the UUID survives the round-trip.
+        assert_eq!(h.id, back.id, "UUID must round-trip byte-identical through JSON");
+    }
+
+    #[test]
+    fn handle_ref_id_serializes_as_string() {
+        // Per the ts-rs binding (`#[ts(type = "string")]`), the wire
+        // form of `id` is the UUID's canonical string. Pin that
+        // serde matches — ts-rs and serde agree on the shape so
+        // TypeScript consumers can echo handles back as strings.
+        let id = Uuid::new_v4();
+        let h = HandleRef::with_id("chat", id, "chat::MessageHandle");
+        let json: serde_json::Value =
+            serde_json::to_value(&h).expect("HandleRef must serialize");
+        let id_field = json.get("id").expect("id field present");
+        assert!(
+            id_field.is_string(),
+            "id must serialize as JSON string (ts-rs sees it as `string`), got {id_field:?}"
+        );
+        assert_eq!(id_field.as_str().unwrap(), id.to_string());
+    }
+
+    #[test]
+    fn handle_ref_owns_distinct_state() {
+        // Two handles with the same owner + type but different UUIDs
+        // represent different state — pin that they don't compare equal.
+        let a = HandleRef::mint("chat", "chat::MessageHandle");
+        let b = HandleRef::mint("chat", "chat::MessageHandle");
+        assert_ne!(a, b, "handles with different UUIDs must not be equal");
+    }
+
+    #[test]
+    fn stream_placeholder_roundtrips() {
+        let s = StreamPlaceholder::new("corr-001");
+        let json = serde_json::to_string(&s).expect("StreamPlaceholder must serialize");
+        let back: StreamPlaceholder =
+            serde_json::from_str(&json).expect("StreamPlaceholder must deserialize");
+        assert_eq!(s, back);
+        assert_eq!(back.correlation_id, "corr-001");
+    }
+
+    #[test]
+    fn lambda_placeholder_roundtrips() {
+        let l = LambdaPlaceholder::new("ai/generate", serde_json::json!({ "model": "qwen" }));
+        let json = serde_json::to_string(&l).expect("LambdaPlaceholder must serialize");
+        let back: LambdaPlaceholder =
+            serde_json::from_str(&json).expect("LambdaPlaceholder must deserialize");
+        assert_eq!(l, back);
+        assert_eq!(back.command, "ai/generate");
+        assert_eq!(back.bound_params["model"], "qwen");
+    }
+}

--- a/src/workers/continuum-core/src/runtime/command_executor.rs
+++ b/src/workers/continuum-core/src/runtime/command_executor.rs
@@ -141,12 +141,14 @@ impl CommandExecutor {
         Ok(CommandResult::Json(json))
     }
 
-    /// Convenience: execute and extract JSON directly
+    /// Convenience: execute and extract JSON directly.
+    ///
+    /// Delegates to [`CommandResult::to_json_value`] which handles all
+    /// cell shapes — Json/Binary return their payload, Handle serializes
+    /// the HandleRef, Stream/Lambda return their not-yet-wired protocol
+    /// error so the caller knows the cell shape requires direct match.
     pub async fn execute_json(&self, command: &str, params: Value) -> Result<Value, String> {
-        match self.execute(command, params).await? {
-            CommandResult::Json(v) => Ok(v),
-            CommandResult::Binary { metadata, .. } => Ok(metadata),
-        }
+        self.execute(command, params).await?.to_json_value()
     }
 
     /// Execute a command ONLY via TypeScript (bypasses Rust registry).

--- a/src/workers/continuum-core/src/runtime/mod.rs
+++ b/src/workers/continuum-core/src/runtime/mod.rs
@@ -27,6 +27,7 @@ use std::sync::OnceLock;
 pub mod airc_interceptor;
 pub mod artifact_handle;
 pub mod brain_region;
+pub mod cell_shapes;
 pub mod command_executor;
 pub mod command_interceptor;
 pub mod control;
@@ -49,6 +50,7 @@ pub use brain_region::{
     SleepPhase, TickOutcome,
 };
 pub use airc_interceptor::AircInterceptor;
+pub use cell_shapes::{HandleRef, LambdaPlaceholder, StreamPlaceholder};
 pub use command_executor::{
     execute as execute_command, execute_json as execute_command_json, executor, init_executor,
     CommandExecutor,

--- a/src/workers/continuum-core/src/runtime/service_module.rs
+++ b/src/workers/continuum-core/src/runtime/service_module.rs
@@ -102,17 +102,60 @@ pub struct ModuleConfig {
     pub tick_interval: Option<Duration>,
 }
 
-/// Result of handling a command.
-/// Supports both JSON-only and binary responses (audio, embeddings).
+/// Result of handling a command — one of the four cell return shapes
+/// per [MODULE-ARCHITECTURE.md §5.1](../../../../../docs/architecture/MODULE-ARCHITECTURE.md).
+///
+/// See [`super::cell_shapes`] for the cell taxonomy + the rationale
+/// for each variant. Short version:
+///
+/// - `Json` / `Binary` — the **Value** cell shape (immediate typed
+///   result). Kept under their original names for back-compat with
+///   the 300+ existing handlers; new code that produces a typed
+///   result still uses `Json` (or `CommandResult::json(&value)?`).
+/// - `Handle` — the **Handle** cell shape, NEW in this PR. Typed
+///   reference to state owned by the producing module. See
+///   [`super::cell_shapes::HandleRef`] for the round-trip protocol.
+///   Answers MODULE-ARCHITECTURE.md §13.1 (hot-path cross-module
+///   state via reference, not copy).
+/// - `Stream` / `Lambda` — reserved cell shapes. Returning these
+///   today is a runtime error per the contract — the variant exists
+///   so the enum shape is fixed before the wire protocols land. See
+///   [`super::cell_shapes::StreamPlaceholder`] and
+///   [`super::cell_shapes::LambdaPlaceholder`].
+///
+/// # Adding to this enum
+///
+/// `#[non_exhaustive]` lets downstream crates match without breaking
+/// when new variants land. Within continuum-core, exhaustive matches
+/// MUST cover the new variants — the compiler enforces this. Use
+/// [`CommandResult::to_json_value`] when the call site just needs the
+/// payload as JSON regardless of which cell shape arrived.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum CommandResult {
-    /// Standard JSON response
+    /// Standard JSON response. The Value cell shape under the legacy
+    /// name; preferred for new code that produces a typed result.
     Json(Value),
 
     /// Binary response: JSON metadata + raw bytes.
-    /// Wire format: [JSON header bytes][\0][raw binary bytes]
+    /// Wire format: `[JSON header bytes][\0][raw binary bytes]`.
     /// Used for audio synthesis, embedding vectors, etc.
     Binary { metadata: Value, data: Vec<u8> },
+
+    /// Typed reference to state owned by the producing module. See
+    /// [`super::cell_shapes::HandleRef`] for the round-trip protocol.
+    Handle(super::cell_shapes::HandleRef),
+
+    /// Reserved: streaming result. Returning this today is a runtime
+    /// error — see [`super::cell_shapes::StreamPlaceholder`] for the
+    /// open protocol design.
+    Stream(super::cell_shapes::StreamPlaceholder),
+
+    /// Reserved: lambda (callable returned by a command). Returning
+    /// this today is a runtime error — see
+    /// [`super::cell_shapes::LambdaPlaceholder`] for the open protocol
+    /// design.
+    Lambda(super::cell_shapes::LambdaPlaceholder),
 }
 
 impl CommandResult {
@@ -122,6 +165,78 @@ impl CommandResult {
         serde_json::to_value(value)
             .map(CommandResult::Json)
             .map_err(|e| format!("Serialization error: {e}"))
+    }
+
+    /// Create a Handle result from a producer-allocated UUID.
+    ///
+    /// Use this when the producer minted a UUID up front to insert
+    /// state into its own map under a specific key:
+    ///
+    /// ```ignore
+    /// let id = uuid::Uuid::new_v4();
+    /// self.sessions.insert(id, session_state);
+    /// Ok(CommandResult::handle("ai/inference", id, "ai::InferenceSession"))
+    /// ```
+    ///
+    /// For the simpler case where the producer doesn't need to know
+    /// the UUID before constructing the handle, use
+    /// [`super::cell_shapes::HandleRef::mint`] directly and wrap with
+    /// `CommandResult::Handle(...)`.
+    pub fn handle(
+        owner: impl Into<String>,
+        id: uuid::Uuid,
+        type_tag: impl Into<String>,
+    ) -> Self {
+        CommandResult::Handle(super::cell_shapes::HandleRef::with_id(owner, id, type_tag))
+    }
+
+    /// Project the result into a JSON `Value` for callers that don't
+    /// care about the cell shape — e.g., the TS bridge that wants to
+    /// serialize the result over a Unix socket regardless of which
+    /// cell shape the producer chose.
+    ///
+    /// `Json` returns itself. `Binary` returns its metadata (the
+    /// bytes are dropped — callers needing the raw data must match
+    /// on the variant directly). `Handle` serializes the HandleRef
+    /// as JSON so a TS caller can hold it and pass it back. `Stream`
+    /// and `Lambda` return errors per the not-yet-wired contract:
+    /// projecting them as plain JSON would lose the protocol shape
+    /// the caller needs to consume them, so we fail loud rather than
+    /// silently degrade.
+    pub fn to_json_value(&self) -> Result<Value, String> {
+        match self {
+            CommandResult::Json(v) => Ok(v.clone()),
+            CommandResult::Binary { metadata, .. } => Ok(metadata.clone()),
+            CommandResult::Handle(h) => serde_json::to_value(h)
+                .map_err(|e| format!("HandleRef serialization failed: {e}")),
+            CommandResult::Stream(_) => Err(Self::stream_protocol_error()),
+            CommandResult::Lambda(_) => Err(Self::lambda_protocol_error()),
+        }
+    }
+
+    /// Canonical error message for handlers that try to return a Stream
+    /// today. Surfaced from any callsite that needs to reject the
+    /// not-yet-wired streaming variant — same wording everywhere so
+    /// the failure mode is easy to grep.
+    pub fn stream_protocol_error() -> String {
+        "Stream cell shape is reserved but not yet wired — the streaming \
+         wire protocol (frame format, correlation IDs, backpressure, \
+         cancellation) hasn't been designed yet. Handlers MUST return \
+         Json/Binary/Handle until the protocol lands. See \
+         MODULE-ARCHITECTURE.md §5.1 + runtime::cell_shapes::StreamPlaceholder."
+            .to_string()
+    }
+
+    /// Canonical error message for handlers that try to return a Lambda
+    /// today. Same shape as [`Self::stream_protocol_error`].
+    pub fn lambda_protocol_error() -> String {
+        "Lambda cell shape is reserved but not yet wired — the lambda \
+         invocation protocol (curried-command dispatch, bound-params \
+         merge, return-shape propagation) hasn't been designed yet. \
+         Handlers MUST return Json/Binary/Handle until the protocol \
+         lands. See MODULE-ARCHITECTURE.md §5.1 + \
+         runtime::cell_shapes::LambdaPlaceholder."
+            .to_string()
     }
 }
 
@@ -465,5 +580,130 @@ mod tests {
             0,
             "no module subscribes to nothing/here — dispatcher walks zero"
         );
+    }
+
+    // ── CommandResult cell shape integration tests ─────────────────
+    //
+    // The cell shape unit tests live in
+    // `runtime::cell_shapes::tests` (HandleRef construction,
+    // serialization, distinct UUIDs, etc.). The tests below assert
+    // the integration between the cell shapes and `CommandResult` —
+    // the constructors + `to_json_value` projection that every
+    // wire-crossing site uses.
+
+    use crate::runtime::cell_shapes::{HandleRef, LambdaPlaceholder, StreamPlaceholder};
+    use serde_json::json;
+    use uuid::Uuid;
+
+    #[test]
+    fn json_to_json_value_returns_original() {
+        let v = json!({ "x": 1 });
+        let r = CommandResult::Json(v.clone());
+        assert_eq!(r.to_json_value().unwrap(), v);
+    }
+
+    #[test]
+    fn binary_to_json_value_returns_metadata_drops_bytes() {
+        // The Binary variant carries metadata + raw bytes; projecting
+        // to plain JSON drops the bytes and returns metadata. Callers
+        // who need the raw bytes match on the variant directly (e.g.,
+        // the IPC layer encodes them in the binary frame).
+        let metadata = json!({ "format": "pcm-16le", "sample_rate": 48_000 });
+        let r = CommandResult::Binary {
+            metadata: metadata.clone(),
+            data: vec![0u8, 1, 2, 3],
+        };
+        assert_eq!(r.to_json_value().unwrap(), metadata);
+    }
+
+    #[test]
+    fn handle_to_json_value_serializes_handle_ref() {
+        let id = Uuid::new_v4();
+        let r = CommandResult::handle("ai/inference", id, "ai::InferenceSession");
+        let json = r.to_json_value().expect("Handle must project to JSON");
+        assert_eq!(json["owner"], "ai/inference");
+        assert_eq!(json["type_tag"], "ai::InferenceSession");
+        assert!(json["id"].is_string(), "id must serialize as string");
+        assert_eq!(json["id"].as_str().unwrap(), id.to_string());
+        assert!(json["created_at_ms"].is_number());
+    }
+
+    #[test]
+    fn stream_to_json_value_returns_protocol_error() {
+        let r = CommandResult::Stream(StreamPlaceholder::new("corr-001"));
+        let err = r
+            .to_json_value()
+            .expect_err("Stream must NOT project as JSON — protocol not wired");
+        assert!(
+            err.contains("Stream cell shape is reserved"),
+            "error must name the cell shape so callers find the doc: {err}"
+        );
+        assert!(
+            err.contains("MODULE-ARCHITECTURE"),
+            "error must point at the canonical doc: {err}"
+        );
+    }
+
+    #[test]
+    fn lambda_to_json_value_returns_protocol_error() {
+        let r = CommandResult::Lambda(LambdaPlaceholder::new("ai/generate", json!({})));
+        let err = r
+            .to_json_value()
+            .expect_err("Lambda must NOT project as JSON — protocol not wired");
+        assert!(
+            err.contains("Lambda cell shape is reserved"),
+            "error must name the cell shape so callers find the doc: {err}"
+        );
+    }
+
+    #[test]
+    fn command_result_handle_constructor_matches_handle_ref_with_id() {
+        let id = Uuid::new_v4();
+        let r = CommandResult::handle("ai/inference", id, "ai::InferenceSession");
+        match r {
+            CommandResult::Handle(h) => {
+                assert_eq!(h.id, id);
+                assert_eq!(h.owner, "ai/inference");
+                assert_eq!(h.type_tag, "ai::InferenceSession");
+            }
+            other => panic!("expected Handle variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn command_result_protocol_errors_have_stable_wording() {
+        // The error wording is matched on by callers (the sentinel
+        // step builds its own step_err from these). Pin the prefix
+        // so future edits don't accidentally break matching code.
+        let stream_err = CommandResult::stream_protocol_error();
+        let lambda_err = CommandResult::lambda_protocol_error();
+        assert!(stream_err.starts_with("Stream cell shape is reserved"));
+        assert!(lambda_err.starts_with("Lambda cell shape is reserved"));
+        // Both should point at the architecture doc for context.
+        for err in [&stream_err, &lambda_err] {
+            assert!(
+                err.contains("MODULE-ARCHITECTURE"),
+                "error must point at the canonical doc: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn handle_ref_round_trips_through_command_result_serialization() {
+        // End-to-end pinning: a Handle returned by a Rust handler can
+        // be projected to JSON, sent over the wire, deserialized on the
+        // TS side as { owner, id, type_tag, created_at_ms }, echoed
+        // back as a param on a subsequent call, deserialized in Rust
+        // as HandleRef, and resolve to the same handle.
+        let id = Uuid::new_v4();
+        let original = HandleRef::with_id("ai/inference", id, "ai::InferenceSession");
+        // Mint a Handle result, project to JSON (wire crossing #1).
+        let r = CommandResult::Handle(original.clone());
+        let wire = r.to_json_value().unwrap();
+        // TS-side echo: serialize the JSON to a string and parse back.
+        let echoed = serde_json::to_string(&wire).unwrap();
+        let from_wire: HandleRef = serde_json::from_str(&echoed).unwrap();
+        assert_eq!(from_wire, original);
+        assert_eq!(from_wire.id, id);
     }
 }


### PR DESCRIPTION
## Summary

Lands the cell return shapes from [MODULE-ARCHITECTURE.md §5.1](docs/architecture/MODULE-ARCHITECTURE.md) as variants on `CommandResult`. **Handle is the headline shape** — the answer to §13.1 (hot-path cross-module state) and the pattern Joel called out 2026-05-30 for long-running stateful work.

> *"For long running commands like inference, hosting/inference/training/ORM. It's a handle returned by the first call, passed in for subsequent work. Always UUID for ids."*

## Canonical use cases for Handle

- **inference** — `ai/inference/start { model, prompt }` → handle; `ai/inference/poll { handle }` + `ai/inference/cancel { handle }` operate on the session
- **training** — `training/run/start { recipe }` → handle; `training/run/progress { handle }` + `training/run/cancel { handle }`
- **hosting** — `live/room/join { roomId }` → handle; `live/audio/publish { handle, frame }`
- **ORM** — `data/transaction/begin` → handle; `data/transaction/exec { handle, query }` + `data/transaction/commit { handle }`

Same primitive whether the producer is in-process, in a sibling module, or on a remote peer over grid/airc.

## What lands

- **`runtime::cell_shapes::HandleRef`** — owner + UUID id + type_tag + created_at_ms. `with_id(...)` for producer-allocated UUIDs; `mint(...)` for fresh ones.
- **`StreamPlaceholder` + `LambdaPlaceholder`** — reserved variants. Returning either is a runtime error (the wire protocols aren't designed). `#[non_exhaustive]` makes future field additions non-breaking.
- **Extended `CommandResult` enum** — `Handle(HandleRef)`, `Stream(StreamPlaceholder)`, `Lambda(LambdaPlaceholder)` added. `Json` + `Binary` ARE the Value cell shape under the legacy names — 300+ existing handlers stay unchanged.
- **`CommandResult::to_json_value`** — projects any cell shape to a plain `Value` for callers that just want the payload. Handle serializes the HandleRef; Stream/Lambda return canonical protocol errors via `stream_protocol_error` / `lambda_protocol_error`.
- **`CommandResult::handle(owner, id, type_tag)`** — direct constructor.
- **Five match sites updated** to handle the new variants (executor, cognition dispatcher, grid wire encoder, IPC encoder, sentinel LLM step). Strategy: delegate to `to_json_value` everywhere the call site just wants JSON; explicit error arms only where the cell shape signals a contract violation (LLM step).
- **Two test panic sites updated** to use `other => panic!(...)` for forward-compat.

## Test plan (23/23 pass)

- 7 cell_shapes unit tests (HandleRef constructors, serde round-trip, distinct UUIDs, ts-rs wire shape)
- 8 service_module integration tests for CommandResult cell-shape projection (Json/Binary/Handle to_json_value behavior, Stream/Lambda protocol errors with stable wording, full Handle round-trip through wire serialization)
- 3 ts-rs export verifications (HandleRef, StreamPlaceholder, LambdaPlaceholder all generate clean TS under `shared/generated/runtime/`)
- 5 pre-existing service_module tests (artifact dispatch + cadence) still pass after the enum extension

## What this PR explicitly does NOT do

- Does NOT change any existing handler's return shape. The 300+ handlers still return Json/Binary; cell shapes are opt-in for new long-running commands.
- Does NOT design the Stream or Lambda wire protocols. Variants exist with `#[non_exhaustive]` placeholders so future fields land non-breaking.
- Does NOT add a kernel-level handle registry — each producing module manages its own handle lifetimes internally per the §13.1 design.

## Follow-up: pattern lifting (Joel 2026-05-30 directive)

> *"Some things are used so much should just be part of command result and params, handle for example. Find the patterns and simplify."*

Handle is foundational enough that it deserves to be a first-class field on every command's params + result, not just a variant in an enum. The next PR introduces:

- `CommandResponse<T>` — typed wrapper that bundles `data: T` + `handle: Option<HandleRef>` + standard envelope fields. Builder-style ergonomics for handlers that produce both data AND a handle for follow-up.
- `CommandRequest<P>` — typed wrapper for params with `handle: Option<HandleRef>` + `session_id` + `user_id` as first-class fields.
- The existing `Value`-based handler signature stays for back-compat; new handlers reach for the typed shape.

Tracked as a separate PR so the cell shape foundation lands first and the pattern lifting builds on it.

## References

- [docs/architecture/MODULE-ARCHITECTURE.md](docs/architecture/MODULE-ARCHITECTURE.md) §5.1 + §13.1
- PR #1482 (architecture doc)
- PR #1483 (CommandInterceptor trait)
- PR #1484 (GridInterceptor wire-up)
