### PR TITLE
refine(runtime): HandleRef::expect_owned_by + CommandRequest::handle_id_or_legacy — distill kinks from #1490

### DIFF
--- a/src/workers/continuum-core/src/inference/llm_module_service.rs
+++ b/src/workers/continuum-core/src/inference/llm_module_service.rs
@@ -528,7 +528,7 @@ mod tests {
                 assert_eq!(response.complete.tokens_generated, 3);
                 assert_eq!(response.first_token.request_id, req.request_id);
             }
-            CommandResult::Binary { .. } => panic!("expected Json response"),
+            other => panic!("expected CommandResult::Json, got {other:?}"),
         }
     }
 

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -367,6 +367,15 @@ fn handle_client<S: IpcStream>(stream: S, state: Arc<ServerState>) -> std::io::R
                         json_header: Response::success(metadata),
                         binary_data: data,
                     },
+                    // Cell shapes from MODULE-ARCHITECTURE.md §5.1.
+                    // Handle: serialize the HandleRef as JSON over the
+                    // wire; the TS-side caller holds it and passes back
+                    // on subsequent calls (long-running session pattern
+                    // — inference, training, hosting, ORM).
+                    Some(Ok(other)) => match other.to_json_value() {
+                        Ok(value) => HandleResult::Json(Response::success(value)),
+                        Err(e) => HandleResult::Json(Response::error(e)),
+                    },
                     Some(Err(e)) => HandleResult::Json(Response::error(e)),
                     None => HandleResult::Json(Response::error(format!(
                         "Unknown command: '{}'. No module registered for this command prefix.",

--- a/src/workers/continuum-core/src/modules/cognition.rs
+++ b/src/workers/continuum-core/src/modules/cognition.rs
@@ -1795,10 +1795,13 @@ async fn execute_rust_module_json(
         format!("{command}: no Rust module route registered; refusing TypeScript fallback")
     })?;
 
-    match module.handle_command(&routed_command, params).await? {
-        CommandResult::Json(value) => Ok(value),
-        CommandResult::Binary { metadata, .. } => Ok(metadata),
-    }
+    // Project the cell shape into a plain JSON Value. Handle returns
+    // its HandleRef as JSON (the caller can hold it and pass back);
+    // Stream/Lambda return their not-yet-wired protocol error.
+    module
+        .handle_command(&routed_command, params)
+        .await?
+        .to_json_value()
 }
 
 #[cfg(test)]
@@ -2003,7 +2006,7 @@ mod turn_execute_tests {
                     "empty drain produces null inferenceResponse; got {v}"
                 );
             }
-            CommandResult::Binary { .. } => panic!("expected Json"),
+            other => panic!("expected CommandResult::Json, got {other:?}"),
         }
     }
 

--- a/src/workers/continuum-core/src/modules/data.rs
+++ b/src/workers/continuum-core/src/modules/data.rs
@@ -16,13 +16,16 @@ use crate::orm::{
     sqlite::SqliteAdapter,
     types::{BatchOperation, DataRecord, RecordMetadata, UUID},
 };
-use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
+use crate::runtime::{
+    CommandRequest, CommandResponse, CommandResult, HandleRef, ModuleConfig, ModuleContext,
+    ModulePriority, ServiceModule,
+};
 use crate::{log_error, log_info};
 use async_trait::async_trait;
 use chrono;
 use dashmap::DashMap;
 use rayon::prelude::*;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::any::Any;
 use std::collections::HashMap;
@@ -473,13 +476,18 @@ impl ServiceModule for DataModule {
                 self.handle_query_open(deserialize_params!(command, params)?)
                     .await
             }
+            // query-next/close take the cursor via `CommandRequest` so
+            // the typed envelope's `handle` field is reachable. The
+            // body deserializes into `QueryNextParams`/`QueryCloseParams`
+            // which preserve the legacy flat `queryId` shape; the
+            // handler picks whichever shape the caller used.
             "data/query-next" => {
-                self.handle_query_next(deserialize_params!(command, params)?)
-                    .await
+                let req = CommandRequest::<QueryNextParams>::from_value(params)?;
+                self.handle_query_next(req).await
             }
             "data/query-close" => {
-                self.handle_query_close(deserialize_params!(command, params)?)
-                    .await
+                let req = CommandRequest::<QueryCloseParams>::from_value(params)?;
+                self.handle_query_close(req).await
             }
 
             "adapter/capabilities" => self.handle_capabilities(params).await,
@@ -720,18 +728,69 @@ struct QueryOpenParams {
     count_exact: bool,
 }
 
-/// Get next page params
-#[derive(Debug, Deserialize)]
+/// Get next page params.
+///
+/// The cursor id reaches this handler one of two ways:
+/// - Legacy flat `queryId` string field on the params body (what TS
+///   consumers send today and will keep sending through the migration
+///   window).
+/// - Kernel-level `handle: HandleRef` on the [`CommandRequest`]
+///   envelope (the canonical post-PR #1486 shape — minted by
+///   `data/query-open` via `CommandResponse::with_handle`).
+///
+/// `resolve_query_cursor_id` walks the envelope first, falls back to
+/// the legacy field, and fails loud when neither is present so a
+/// caller who simply forgot the cursor sees a typed error instead of
+/// silently no-op'ing.
+#[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct QueryNextParams {
-    query_id: String,
+    #[serde(default)]
+    query_id: Option<String>,
 }
 
-/// Close query params
-#[derive(Debug, Deserialize)]
+/// Close query params. Same dual-shape contract as
+/// [`QueryNextParams`] — see its docs for the legacy/envelope handoff.
+#[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct QueryCloseParams {
+    #[serde(default)]
+    query_id: Option<String>,
+}
+
+/// The canonical type tag for cursor handles minted by `data/query-open`.
+/// Lives here so cross-module callers can match on it without depending
+/// on string magic.
+const QUERY_CURSOR_TYPE_TAG: &str = "data::QueryCursor";
+
+/// The canonical owner string for handles this module mints. Matches
+/// the module's `name` in `ModuleConfig`. Centralized so a future rename
+/// of the module name is a single edit.
+const DATA_MODULE_OWNER: &str = "data";
+
+/// Response payload shape for `data/query-open`. Lives in a typed struct
+/// so the typed envelope can flatten it cleanly — the legacy wire shape
+/// nests every field under a `data:` key, so we preserve that here.
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct QueryOpenResponseShape {
+    /// Nested for back-compat with the pre-envelope wire shape that
+    /// TS consumers currently parse as `response.data.queryId`. New
+    /// consumers should read the kernel-level `handle` instead.
+    data: QueryOpenInner,
+}
+
+/// Inner payload — the historical fields the cursor returns at open
+/// time. `query_id` stays for back-compat (it's the same UUID stringly
+/// rendered as the `handle.id`); new consumers thread the handle.
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct QueryOpenInner {
     query_id: String,
+    collection: String,
+    total_count: u64,
+    page_size: usize,
+    has_more: bool,
 }
 
 // ============================================================================
@@ -1680,9 +1739,22 @@ impl DataModule {
     // Paginated Query Handlers
     // =========================================================================
 
-    /// Open a paginated query - returns handle with queryId
+    /// Open a paginated query.
     ///
-    /// Advantages over TypeScript:
+    /// Returns BOTH the legacy `queryId` string (for back-compat) AND a
+    /// kernel-typed [`HandleRef`] minted via [`CommandResponse::with_handle`]
+    /// — see PR #1485/#1486 for the cell-shape/envelope substrate. The
+    /// two share an underlying UUID; new callers thread the handle, old
+    /// callers keep reading `response.data.queryId`. A follow-up will
+    /// drop the legacy field once every consumer has migrated.
+    ///
+    /// The handle's `owner` is `"data"` and its `type_tag` is
+    /// `"data::QueryCursor"`. `data/query-next` and `data/query-close`
+    /// validate both fields when the caller threads a handle — passing
+    /// a handle minted by a different module or for a different
+    /// resource is a typed error rather than a silent misroute.
+    ///
+    /// Advantages over the TypeScript path:
     /// - No IPC overhead per page (state is Rust-side)
     /// - Cursor-based pagination using last ID (faster than OFFSET for large datasets)
     /// - DashMap for concurrent query state (lock-free reads)
@@ -1708,8 +1780,12 @@ impl DataModule {
             0
         };
 
-        // Generate unique query ID
-        let query_id = uuid::Uuid::new_v4().to_string();
+        // Mint a UUID once. The same value lives in TWO places: the
+        // DashMap key (a string for back-compat with the existing
+        // storage shape) and the HandleRef.id (a typed Uuid for the
+        // envelope). Identity is the same; only the wire shape differs.
+        let cursor_id = uuid::Uuid::new_v4();
+        let cursor_id_str = cursor_id.to_string();
 
         // has_more starts optimistic — the LIMIT N+1 probe on the first
         // query_next call is the authoritative signal. If the table is
@@ -1720,7 +1796,8 @@ impl DataModule {
             true
         };
 
-        // Create query state (query_id is the DashMap key, not stored in struct)
+        // Create query state (the string form is the DashMap key, not
+        // stored in the struct).
         let state = PaginatedQueryState {
             db_path: params.db_path.clone(),
             collection: params.collection.clone(),
@@ -1734,43 +1811,117 @@ impl DataModule {
             created_at: Instant::now(),
         };
 
-        self.paginated_queries.insert(query_id.clone(), state);
+        self.paginated_queries.insert(cursor_id_str.clone(), state);
 
         let total_ms = start.elapsed().as_millis();
         log_info!(
             "data",
             "query-open",
             "Opened query {} for {} (total={}, pageSize={}) in {}ms",
-            query_id,
+            cursor_id_str,
             params.collection,
             total_count,
             params.page_size,
             total_ms
         );
 
-        // Wrap in StorageResult-style response for TypeScript compatibility
-        Ok(CommandResult::Json(json!({
-            "success": true,
-            "data": {
-                "queryId": query_id,
-                "collection": params.collection,
-                "totalCount": total_count,
-                "pageSize": params.page_size,
-                "hasMore": has_more
-            }
-        })))
+        // Typed envelope: nested `data` preserves the legacy
+        // `response.data.queryId` wire shape; the kernel-level `handle`
+        // is the new canonical reference for the cursor.
+        let response = QueryOpenResponseShape {
+            data: QueryOpenInner {
+                query_id: cursor_id_str,
+                collection: params.collection,
+                total_count,
+                page_size: params.page_size,
+                has_more,
+            },
+        };
+
+        CommandResponse::ok(response)
+            .with_handle(DATA_MODULE_OWNER, cursor_id, QUERY_CURSOR_TYPE_TAG)
+            .into_command_result()
     }
 
-    /// Get next page from paginated query
+    /// Pull the cursor id out of the request envelope — preferring the
+    /// kernel-level `handle`, falling back to the legacy `queryId`
+    /// field, failing loud when neither is present or the handle is
+    /// mis-owned/mis-typed. Single resolver shared by query-next and
+    /// query-close so the dual-shape contract has ONE place to drift.
+    fn resolve_query_cursor_id(
+        handle: &Option<HandleRef>,
+        legacy_query_id: &Option<String>,
+        command: &str,
+    ) -> Result<String, String> {
+        if let Some(h) = handle {
+            // Kernel typed contract: a handle minted by a different
+            // module reaching this module's handler is ALWAYS a bug.
+            // The grid interceptor is supposed to have routed the call
+            // back to the actual owner before we ever see it; arriving
+            // here with the wrong owner means either the routing
+            // misfired or a caller hand-crafted a bogus handle. Either
+            // way, fail loud with the offending values named.
+            if h.owner != DATA_MODULE_OWNER {
+                return Err(format!(
+                    "{command}: handle owner mismatch — got owner={:?}, this module owns only {:?}. \
+                     Handles must be minted by the same module that consumes them, OR the grid \
+                     interceptor must route the command back to the owner before dispatch.",
+                    h.owner, DATA_MODULE_OWNER
+                ));
+            }
+            // Within the data module, multiple handle shapes are
+            // possible in principle (e.g., a future `data::Migration`
+            // handle). The type tag is the within-module discriminator;
+            // a wrong tag here means the caller threaded a handle
+            // belonging to a DIFFERENT resource through the cursor
+            // surface. Same fail-loud reasoning.
+            if h.type_tag != QUERY_CURSOR_TYPE_TAG {
+                return Err(format!(
+                    "{command}: handle type mismatch — got type_tag={:?}, expected {:?}. \
+                     This handler operates only on query-cursor handles; threading a different \
+                     handle shape here is a programming error.",
+                    h.type_tag, QUERY_CURSOR_TYPE_TAG
+                ));
+            }
+            return Ok(h.id.to_string());
+        }
+
+        if let Some(id) = legacy_query_id {
+            // Belt-and-braces: legacy callers send a UUID-shaped string;
+            // a non-UUID string is almost certainly a bug, but the
+            // existing wire contract doesn't guarantee validation —
+            // accept it as-is to preserve back-compat. If the string
+            // fails the DashMap lookup later, the "not found" path
+            // surfaces it.
+            return Ok(id.clone());
+        }
+
+        Err(format!(
+            "{command}: neither `handle` (envelope field) nor `queryId` (legacy params field) \
+             was provided. Pass the handle minted by `data/query-open` via either shape."
+        ))
+    }
+
+    /// Get next page from paginated query.
+    ///
+    /// Cursor id is resolved by [`Self::resolve_query_cursor_id`] from
+    /// either the typed envelope's `handle` (new canonical) or the
+    /// legacy `queryId` field (back-compat).
     ///
     /// Uses keyset pagination (WHERE id > cursor) instead of OFFSET for performance.
     /// For sorted queries, combines sort column(s) with id for deterministic ordering.
-    async fn handle_query_next(&self, params: QueryNextParams) -> Result<CommandResult, String> {
+    async fn handle_query_next(
+        &self,
+        req: CommandRequest<QueryNextParams>,
+    ) -> Result<CommandResult, String> {
         use std::time::Instant;
         let start = Instant::now();
 
+        let cursor_id =
+            Self::resolve_query_cursor_id(&req.handle, &req.params.query_id, "data/query-next")?;
+
         // Get query state (immutable borrow for read)
-        let state_info = self.paginated_queries.get(&params.query_id).map(|s| {
+        let state_info = self.paginated_queries.get(&cursor_id).map(|s| {
             (
                 s.db_path.clone(),
                 s.collection.clone(),
@@ -1794,7 +1945,14 @@ impl DataModule {
             current_page,
             _cursor_id,
             has_more,
-        ) = state_info.ok_or_else(|| format!("Query {} not found", params.query_id))?;
+        ) = state_info.ok_or_else(|| {
+            format!(
+                "data/query-next: handle not found — cursor {} is unknown to this module. \
+                 The handle may have been minted by a previous process instance, may have been \
+                 closed via data/query-close, or may have been evicted by a future TTL policy.",
+                cursor_id
+            )
+        })?;
 
         if !has_more {
             return Ok(CommandResult::Json(json!({
@@ -1842,7 +2000,7 @@ impl DataModule {
         let new_cursor_id = records.last().map(|r| r.id.clone());
 
         // Update query state
-        if let Some(mut state) = self.paginated_queries.get_mut(&params.query_id) {
+        if let Some(mut state) = self.paginated_queries.get_mut(&cursor_id) {
             state.current_page += 1;
             state.cursor_id = new_cursor_id;
             state.has_more = new_has_more;
@@ -1870,7 +2028,7 @@ impl DataModule {
             "query-next",
             "Page {} for query {} ({} items, hasMore={}) in {}ms",
             current_page + 1,
-            params.query_id,
+            cursor_id,
             items_count,
             new_has_more,
             total_ms
@@ -1888,21 +2046,29 @@ impl DataModule {
         })))
     }
 
-    /// Close paginated query and free resources
-    async fn handle_query_close(&self, params: QueryCloseParams) -> Result<CommandResult, String> {
-        let removed = self.paginated_queries.remove(&params.query_id).is_some();
+    /// Close paginated query and free resources. Cursor id is resolved
+    /// by [`Self::resolve_query_cursor_id`] from either the typed
+    /// envelope's `handle` (new canonical) or the legacy `queryId`
+    /// field (back-compat).
+    async fn handle_query_close(
+        &self,
+        req: CommandRequest<QueryCloseParams>,
+    ) -> Result<CommandResult, String> {
+        let cursor_id =
+            Self::resolve_query_cursor_id(&req.handle, &req.params.query_id, "data/query-close")?;
+        let removed = self.paginated_queries.remove(&cursor_id).is_some();
 
         log_info!(
             "data",
             "query-close",
             "Closed query {}: removed={}",
-            params.query_id,
+            cursor_id,
             removed
         );
 
         Ok(CommandResult::Json(json!({
             "success": removed,
-            "queryId": params.query_id
+            "queryId": cursor_id
         })))
     }
 
@@ -2802,5 +2968,362 @@ mod tests {
             (sim - 1.0).abs() < 0.001,
             "Identical 384-dim vectors should have similarity 1.0"
         );
+    }
+
+    // ====================================================================
+    // HandleRef migration tests for data/query-open/next/close
+    // ====================================================================
+    //
+    // The cursor surface migrated from a hand-rolled string queryId to
+    // typed HandleRef minted via CommandResponse::with_handle. These
+    // tests cover the migration's hard edges:
+    //   - both wire shapes (envelope handle + legacy queryId) resolve
+    //   - cross-module/cross-resource handles fail loud with named
+    //     owner/type values, not silent misroutes
+    //   - stale handles surface a typed "handle not found" error that
+    //     names the cursor + suggests likely causes
+    //   - the legacy field stays additive — old TS consumers see the
+    //     same JSON shape they parse today, plus a new top-level
+    //     `handle` field they can ignore
+
+    /// Helper: stand up a fresh DataModule + a temp SQLite + the schema
+    /// + N rows. Used by every cursor test below — keeps the cursor
+    /// tests focused on the handle behavior, not on row setup.
+    async fn setup_paginated_for_handle_tests(
+        suffix: &str,
+        rows: usize,
+    ) -> (DataModule, tempfile::TempDir, String) {
+        let module = DataModule::new();
+        let (tmp, db_path) = test_db_path(suffix);
+
+        let schema = CollectionSchema {
+            collection: "test_handle_cursor".to_string(),
+            fields: vec![crate::orm::types::SchemaField {
+                name: "name".to_string(),
+                field_type: crate::orm::types::FieldType::String,
+                indexed: false,
+                unique: false,
+                nullable: true,
+                max_length: None,
+            }],
+            indexes: vec![],
+        };
+        let adapter = module.get_adapter(&db_path).await.unwrap();
+        let _ = adapter.ensure_schema(schema).await;
+
+        for i in 0..rows {
+            let _ = module
+                .handle_command(
+                    "data/create",
+                    json!({
+                        "dbPath": &db_path,
+                        "collection": "test_handle_cursor",
+                        "data": { "name": format!("Item {i}") }
+                    }),
+                )
+                .await;
+        }
+        (module, tmp, db_path)
+    }
+
+    /// Helper: open a cursor + return the response JSON so each test
+    /// can read the new `handle` field and the legacy `data.queryId`
+    /// without re-implementing the open call.
+    async fn open_cursor(module: &DataModule, db_path: &str, page_size: usize) -> Value {
+        let result = module
+            .handle_command(
+                "data/query-open",
+                json!({
+                    "dbPath": db_path,
+                    "collection": "test_handle_cursor",
+                    "pageSize": page_size,
+                }),
+            )
+            .await
+            .expect("query-open must succeed");
+        let CommandResult::Json(v) = result else {
+            panic!("query-open must return CommandResult::Json")
+        };
+        v
+    }
+
+    #[tokio::test]
+    async fn query_open_returns_handle_alongside_legacy_query_id() {
+        let (module, _tmp, db_path) = setup_paginated_for_handle_tests("handle_open", 3).await;
+        let response = open_cursor(&module, &db_path, 10).await;
+
+        // Legacy shape: nested data.queryId still present so existing
+        // TS consumers keep parsing the same fields.
+        let legacy_id = response["data"]["queryId"]
+            .as_str()
+            .expect("legacy queryId must remain in the response shape during migration window");
+
+        // New shape: kernel-level handle minted at top level with the
+        // canonical owner + type tag from the data module's
+        // QUERY_CURSOR_TYPE_TAG / DATA_MODULE_OWNER constants.
+        let handle = &response["handle"];
+        assert!(handle.is_object(), "handle must be present: {response}");
+        assert_eq!(handle["owner"], "data");
+        assert_eq!(handle["type_tag"], "data::QueryCursor");
+        assert!(
+            handle["created_at_ms"].as_u64().is_some(),
+            "handle must carry a creation timestamp"
+        );
+
+        // Identity invariant: the two surfaces MUST address the same
+        // cursor. Otherwise a caller threading the handle and a
+        // caller threading the queryId would see different state.
+        let handle_id = handle["id"]
+            .as_str()
+            .expect("handle.id must be the canonical UUID string");
+        assert_eq!(
+            legacy_id, handle_id,
+            "legacy queryId and handle.id must be the SAME UUID — otherwise dual-shape callers diverge"
+        );
+        // Both fields are real UUIDs.
+        uuid::Uuid::parse_str(handle_id).expect("handle.id must parse as a UUID");
+    }
+
+    #[tokio::test]
+    async fn query_next_accepts_handle_in_envelope() {
+        let (module, _tmp, db_path) = setup_paginated_for_handle_tests("handle_next", 5).await;
+        let open = open_cursor(&module, &db_path, 3).await;
+        let handle = open["handle"].clone();
+
+        // New canonical shape: thread the handle via the envelope.
+        let next = module
+            .handle_command("data/query-next", json!({ "handle": handle }))
+            .await
+            .expect("query-next via handle must succeed");
+        let CommandResult::Json(v) = next else {
+            panic!("expected Json result")
+        };
+        assert_eq!(
+            v["data"]["items"].as_array().unwrap().len(),
+            3,
+            "first page must contain pageSize items"
+        );
+        assert_eq!(v["data"]["pageNumber"], 1);
+        assert_eq!(v["data"]["hasMore"], true);
+    }
+
+    #[tokio::test]
+    async fn query_next_still_accepts_legacy_query_id_field() {
+        let (module, _tmp, db_path) = setup_paginated_for_handle_tests("handle_legacy", 5).await;
+        let open = open_cursor(&module, &db_path, 3).await;
+        let legacy_id = open["data"]["queryId"].as_str().unwrap().to_string();
+
+        // Existing TS callsites send {"queryId": "..."} flat — that path
+        // must keep working through the migration window.
+        let next = module
+            .handle_command("data/query-next", json!({ "queryId": legacy_id }))
+            .await
+            .expect("query-next via legacy queryId must succeed");
+        let CommandResult::Json(v) = next else {
+            panic!("expected Json result")
+        };
+        assert_eq!(v["data"]["items"].as_array().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn query_next_rejects_handle_with_wrong_owner() {
+        // KINK: a handle minted by another module reaching this
+        // module's handler is a routing bug — fail loud with the
+        // mis-owned value named, NOT a silent lookup miss that would
+        // look like "stale handle".
+        let (module, _tmp, _db) = setup_paginated_for_handle_tests("handle_wrong_owner", 1).await;
+        let bogus_handle = json!({
+            "owner": "chat",
+            "id": uuid::Uuid::new_v4().to_string(),
+            "type_tag": "data::QueryCursor",
+            "created_at_ms": 0_u64,
+        });
+        let err = module
+            .handle_command("data/query-next", json!({ "handle": bogus_handle }))
+            .await
+            .expect_err("handle with non-data owner must surface a typed error");
+        assert!(
+            err.contains("handle owner mismatch"),
+            "error must name the failure mode: {err}"
+        );
+        assert!(
+            err.contains("\"chat\"") && err.contains("\"data\""),
+            "error must name both the offender and the expected owner: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_next_rejects_handle_with_wrong_type_tag() {
+        // KINK: even within the data module, multiple handle shapes
+        // are possible in principle (a future data::Migration handle
+        // alongside data::QueryCursor). Threading the wrong type tag
+        // here must fail loud, not silently treat it as a cursor.
+        let (module, _tmp, _db) = setup_paginated_for_handle_tests("handle_wrong_type", 1).await;
+        let wrong_type = json!({
+            "owner": "data",
+            "id": uuid::Uuid::new_v4().to_string(),
+            "type_tag": "data::Migration",
+            "created_at_ms": 0_u64,
+        });
+        let err = module
+            .handle_command("data/query-next", json!({ "handle": wrong_type }))
+            .await
+            .expect_err("wrong type_tag must surface a typed error");
+        assert!(
+            err.contains("handle type mismatch"),
+            "error must name the failure mode: {err}"
+        );
+        assert!(
+            err.contains("data::Migration") && err.contains("data::QueryCursor"),
+            "error must name both the offender and the expected type: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_next_rejects_when_neither_handle_nor_query_id_provided() {
+        // No handle, no queryId. The TS resolver previously deserialized
+        // an empty `{}` into a `QueryNextParams` with an empty string;
+        // here, BOTH fields are optional so the empty case is reachable.
+        // It must surface a typed error rather than silently 404 with
+        // an empty-string lookup.
+        let (module, _tmp, _db) = setup_paginated_for_handle_tests("handle_neither", 1).await;
+        let err = module
+            .handle_command("data/query-next", json!({}))
+            .await
+            .expect_err("empty params must surface a typed error");
+        assert!(
+            err.contains("neither `handle`")
+                && err.contains("nor `queryId`"),
+            "error must name both supported shapes: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_next_with_unknown_handle_returns_handle_not_found() {
+        // Stale-handle path: a well-formed handle whose id was never
+        // (or no longer) in the DashMap. Must surface a typed error
+        // that names the cursor + suggests likely causes (TTL eviction,
+        // already-closed, prior process instance).
+        let (module, _tmp, _db) = setup_paginated_for_handle_tests("handle_unknown", 1).await;
+        let stale_handle = json!({
+            "owner": "data",
+            "id": uuid::Uuid::new_v4().to_string(),
+            "type_tag": "data::QueryCursor",
+            "created_at_ms": 0_u64,
+        });
+        let err = module
+            .handle_command("data/query-next", json!({ "handle": stale_handle }))
+            .await
+            .expect_err("stale handle must surface a typed error");
+        assert!(
+            err.contains("handle not found"),
+            "error must name the failure mode: {err}"
+        );
+        assert!(
+            err.contains("query-close") || err.contains("evicted"),
+            "error must hint at likely causes so the caller can self-diagnose: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_close_accepts_handle_in_envelope() {
+        let (module, _tmp, db_path) = setup_paginated_for_handle_tests("handle_close", 1).await;
+        let open = open_cursor(&module, &db_path, 5).await;
+        let handle = open["handle"].clone();
+
+        let close = module
+            .handle_command("data/query-close", json!({ "handle": handle }))
+            .await
+            .expect("close via handle must succeed");
+        let CommandResult::Json(v) = close else {
+            panic!("expected Json result")
+        };
+        assert_eq!(v["success"], true);
+
+        // Subsequent next on the SAME handle must now fail loud — the
+        // close actually freed the state, not just acked.
+        let stale_handle = open["handle"].clone();
+        let err = module
+            .handle_command("data/query-next", json!({ "handle": stale_handle }))
+            .await
+            .expect_err("after-close lookup must fail loud");
+        assert!(
+            err.contains("handle not found"),
+            "close + reuse must surface stale-handle error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_close_still_accepts_legacy_query_id_field() {
+        let (module, _tmp, db_path) =
+            setup_paginated_for_handle_tests("handle_close_legacy", 1).await;
+        let open = open_cursor(&module, &db_path, 5).await;
+        let legacy_id = open["data"]["queryId"].as_str().unwrap().to_string();
+
+        let close = module
+            .handle_command("data/query-close", json!({ "queryId": legacy_id }))
+            .await
+            .expect("legacy close must succeed");
+        let CommandResult::Json(v) = close else {
+            panic!("expected Json result")
+        };
+        assert_eq!(v["success"], true);
+    }
+
+    #[tokio::test]
+    async fn full_round_trip_open_next_close_via_handles_only() {
+        // End-to-end through the new canonical shape ONLY (no legacy
+        // queryId reads). 12 rows, page size 5: page 1 → 5 items,
+        // page 2 → 5 items, page 3 → 2 items + hasMore=false. The
+        // handle stays valid across the entire cursor lifetime.
+        let (module, _tmp, db_path) = setup_paginated_for_handle_tests("round_trip", 12).await;
+        let open = open_cursor(&module, &db_path, 5).await;
+        let handle = open["handle"].clone();
+
+        // ── page 1 ───────────────────────────────────────────────────
+        let p1 = module
+            .handle_command("data/query-next", json!({ "handle": handle.clone() }))
+            .await
+            .expect("page 1 must succeed");
+        let CommandResult::Json(p1) = p1 else {
+            panic!("expected Json")
+        };
+        assert_eq!(p1["data"]["items"].as_array().unwrap().len(), 5);
+        assert_eq!(p1["data"]["pageNumber"], 1);
+        assert_eq!(p1["data"]["hasMore"], true);
+
+        // ── page 2 ───────────────────────────────────────────────────
+        let p2 = module
+            .handle_command("data/query-next", json!({ "handle": handle.clone() }))
+            .await
+            .expect("page 2 must succeed");
+        let CommandResult::Json(p2) = p2 else {
+            panic!("expected Json")
+        };
+        assert_eq!(p2["data"]["items"].as_array().unwrap().len(), 5);
+        assert_eq!(p2["data"]["pageNumber"], 2);
+        assert_eq!(p2["data"]["hasMore"], true);
+
+        // ── page 3: partial + terminal ───────────────────────────────
+        let p3 = module
+            .handle_command("data/query-next", json!({ "handle": handle.clone() }))
+            .await
+            .expect("page 3 must succeed");
+        let CommandResult::Json(p3) = p3 else {
+            panic!("expected Json")
+        };
+        assert_eq!(p3["data"]["items"].as_array().unwrap().len(), 2);
+        assert_eq!(p3["data"]["pageNumber"], 3);
+        assert_eq!(p3["data"]["hasMore"], false);
+
+        // ── close ────────────────────────────────────────────────────
+        let close = module
+            .handle_command("data/query-close", json!({ "handle": handle }))
+            .await
+            .expect("close must succeed");
+        let CommandResult::Json(close) = close else {
+            panic!("expected Json")
+        };
+        assert_eq!(close["success"], true);
     }
 }

--- a/src/workers/continuum-core/src/modules/data.rs
+++ b/src/workers/continuum-core/src/modules/data.rs
@@ -1843,64 +1843,14 @@ impl DataModule {
             .into_command_result()
     }
 
-    /// Pull the cursor id out of the request envelope — preferring the
-    /// kernel-level `handle`, falling back to the legacy `queryId`
-    /// field, failing loud when neither is present or the handle is
-    /// mis-owned/mis-typed. Single resolver shared by query-next and
-    /// query-close so the dual-shape contract has ONE place to drift.
-    fn resolve_query_cursor_id(
-        handle: &Option<HandleRef>,
-        legacy_query_id: &Option<String>,
-        command: &str,
-    ) -> Result<String, String> {
-        if let Some(h) = handle {
-            // Kernel typed contract: a handle minted by a different
-            // module reaching this module's handler is ALWAYS a bug.
-            // The grid interceptor is supposed to have routed the call
-            // back to the actual owner before we ever see it; arriving
-            // here with the wrong owner means either the routing
-            // misfired or a caller hand-crafted a bogus handle. Either
-            // way, fail loud with the offending values named.
-            if h.owner != DATA_MODULE_OWNER {
-                return Err(format!(
-                    "{command}: handle owner mismatch — got owner={:?}, this module owns only {:?}. \
-                     Handles must be minted by the same module that consumes them, OR the grid \
-                     interceptor must route the command back to the owner before dispatch.",
-                    h.owner, DATA_MODULE_OWNER
-                ));
-            }
-            // Within the data module, multiple handle shapes are
-            // possible in principle (e.g., a future `data::Migration`
-            // handle). The type tag is the within-module discriminator;
-            // a wrong tag here means the caller threaded a handle
-            // belonging to a DIFFERENT resource through the cursor
-            // surface. Same fail-loud reasoning.
-            if h.type_tag != QUERY_CURSOR_TYPE_TAG {
-                return Err(format!(
-                    "{command}: handle type mismatch — got type_tag={:?}, expected {:?}. \
-                     This handler operates only on query-cursor handles; threading a different \
-                     handle shape here is a programming error.",
-                    h.type_tag, QUERY_CURSOR_TYPE_TAG
-                ));
-            }
-            return Ok(h.id.to_string());
-        }
-
-        if let Some(id) = legacy_query_id {
-            // Belt-and-braces: legacy callers send a UUID-shaped string;
-            // a non-UUID string is almost certainly a bug, but the
-            // existing wire contract doesn't guarantee validation —
-            // accept it as-is to preserve back-compat. If the string
-            // fails the DashMap lookup later, the "not found" path
-            // surfaces it.
-            return Ok(id.clone());
-        }
-
-        Err(format!(
-            "{command}: neither `handle` (envelope field) nor `queryId` (legacy params field) \
-             was provided. Pass the handle minted by `data/query-open` via either shape."
-        ))
-    }
+    // The dual-shape (envelope handle OR legacy `queryId` string)
+    // resolver previously lived here as a 35-line inline helper.
+    // That logic moved into the substrate at
+    // [`CommandRequest::handle_id_or_legacy`] (with owner/type
+    // validation via [`HandleRef::expect_owned_by`]) so every future
+    // migration of a stringly-typed id to a typed handle reaches
+    // for the same primitive. `handle_query_next` / `handle_query_close`
+    // call it directly with this module's owner + type tag constants.
 
     /// Get next page from paginated query.
     ///
@@ -1917,8 +1867,13 @@ impl DataModule {
         use std::time::Instant;
         let start = Instant::now();
 
-        let cursor_id =
-            Self::resolve_query_cursor_id(&req.handle, &req.params.query_id, "data/query-next")?;
+        let cursor_id = req.handle_id_or_legacy(
+            DATA_MODULE_OWNER,
+            QUERY_CURSOR_TYPE_TAG,
+            "queryId",
+            &req.params.query_id,
+            "data/query-next",
+        )?;
 
         // Get query state (immutable borrow for read)
         let state_info = self.paginated_queries.get(&cursor_id).map(|s| {
@@ -2054,8 +2009,13 @@ impl DataModule {
         &self,
         req: CommandRequest<QueryCloseParams>,
     ) -> Result<CommandResult, String> {
-        let cursor_id =
-            Self::resolve_query_cursor_id(&req.handle, &req.params.query_id, "data/query-close")?;
+        let cursor_id = req.handle_id_or_legacy(
+            DATA_MODULE_OWNER,
+            QUERY_CURSOR_TYPE_TAG,
+            "queryId",
+            &req.params.query_id,
+            "data/query-close",
+        )?;
         let removed = self.paginated_queries.remove(&cursor_id).is_some();
 
         log_info!(

--- a/src/workers/continuum-core/src/modules/grid/connection.rs
+++ b/src/workers/continuum-core/src/modules/grid/connection.rs
@@ -138,10 +138,10 @@ async fn execute_incoming_request(request: &GridFrame, state: &Arc<GridState>) -
             // Command matched a Rust module prefix — try Rust handler first
             let (module, full_cmd) = result;
             match module.handle_command(&full_cmd, params.clone()).await {
-                Ok(CommandResult::Json(value)) => GridFrame::success_response(request, value),
-                Ok(CommandResult::Binary { metadata, .. }) => {
-                    GridFrame::success_response(request, metadata)
-                }
+                Ok(cmd_result) => match cmd_result.to_json_value() {
+                    Ok(value) => GridFrame::success_response(request, value),
+                    Err(e) => GridFrame::error_response(request, e),
+                },
                 Err(e) if e.starts_with("Unknown") => {
                     // Rust module doesn't handle this specific command —
                     // fall through to TypeScript layer (e.g., grid/node-status,

--- a/src/workers/continuum-core/src/modules/sentinel/steps/llm.rs
+++ b/src/workers/continuum-core/src/modules/sentinel/steps/llm.rs
@@ -198,6 +198,38 @@ async fn execute_generate_mode(
                     "unexpected binary response from ai/generate",
                 ));
             }
+            // Cell shapes from MODULE-ARCHITECTURE.md §5.1 — ai/generate
+            // should always return Json; receiving any other shape is a
+            // contract violation we surface as a step error rather than
+            // silently dropping. The Handle shape is the natural future
+            // home for streaming inference sessions (start → handle →
+            // poll), but ai/generate (one-shot completion) stays Json.
+            Ok(CommandResult::Handle(h)) => {
+                return Err(step_err(
+                    pipeline_ctx.handle_id,
+                    "LLM step",
+                    format!(
+                        "ai/generate must return Json, got Handle (owner={}, type={}); \
+                         streaming inference belongs on a different command, not the \
+                         one-shot generate path",
+                        h.owner, h.type_tag
+                    ),
+                ));
+            }
+            Ok(CommandResult::Stream(_)) => {
+                return Err(step_err(
+                    pipeline_ctx.handle_id,
+                    "LLM step",
+                    CommandResult::stream_protocol_error(),
+                ));
+            }
+            Ok(CommandResult::Lambda(_)) => {
+                return Err(step_err(
+                    pipeline_ctx.handle_id,
+                    "LLM step",
+                    CommandResult::lambda_protocol_error(),
+                ));
+            }
             Err(e) => {
                 if is_transient_error(&e) && attempt < LLM_MAX_RETRIES {
                     last_error = e;

--- a/src/workers/continuum-core/src/runtime/cell_shapes.rs
+++ b/src/workers/continuum-core/src/runtime/cell_shapes.rs
@@ -1,0 +1,333 @@
+//! Cell return shapes per [MODULE-ARCHITECTURE.md §5.1](../../../../../docs/architecture/MODULE-ARCHITECTURE.md).
+//!
+//! A command returns one of four cell shapes. Today's `CommandResult`
+//! enum is the in-process Rust embodiment of those four shapes:
+//!
+//! | Cell shape (architecture) | `CommandResult` variant | Status |
+//! |---|---|---|
+//! | `Value<T>` (immediate typed result) | `Json(Value)` + `Binary { metadata, data }` | Mainline; back-compat |
+//! | `Handle<T>` (typed ref to state owned by producer) | `Handle(HandleRef)` | **Lands in this PR** |
+//! | `Stream<T>` (async sequence of values) | `Stream(StreamPlaceholder)` | Reserved variant; returning it errors until the wire protocol lands |
+//! | `Lambda<P, T>` (callable returned by a command) | `Lambda(LambdaPlaceholder)` | Reserved variant; returning it errors until the lambda protocol lands |
+//!
+//! The Json + Binary variants ARE the Value cell shape under the
+//! taxonomy; they're kept under their original names so the 300+
+//! existing command handlers don't need to change. New code that
+//! produces a plain typed result should still use `CommandResult::Json`
+//! (or `CommandResult::json(&value)?`). The Value name in the
+//! architecture doc is the categorical name; the implementation name
+//! stays Json for back-compat.
+//!
+//! # Why Handle is the headline shape
+//!
+//! Handle is the cell answer to MODULE-ARCHITECTURE.md §13.1 (hot-path
+//! cross-module state). A module produces a handle to its internal
+//! state; downstream commands take the handle as a param; the kernel
+//! routes those calls back to the producing module (whose handler
+//! looks up the state under the handle's `id`). No state copy, no
+//! lock contention across modules, same primitive locally as
+//! cross-machine. The producer owns; consumers compose by reference.
+//!
+//! The kernel does NOT need a global handle registry — each producing
+//! module manages the lifetime of its own handles internally (typed
+//! state map under the handle's `id`). The kernel sees a Handle the
+//! same as any other JSON payload; routing happens through the normal
+//! `Commands.execute(target/op, { handle })` path. The Handle struct
+//! is purely a data shape that travels through the existing primitive.
+//!
+//! # The canonical use cases (per Joel 2026-05-30)
+//!
+//! Handles are for **long-running stateful work** where the first call
+//! produces a handle and subsequent calls operate on it:
+//!
+//! - **inference** — `ai/inference/start { model, prompt }` returns a
+//!   handle; later `ai/inference/poll { handle }` and
+//!   `ai/inference/cancel { handle }` operate on the running session.
+//! - **training** — `training/run/start { recipe }` returns a handle;
+//!   `training/run/progress { handle }`, `training/run/cancel { handle }`
+//!   query and control the run.
+//! - **hosting** — `live/room/join { roomId }` returns a handle;
+//!   `live/audio/publish { handle, frame }` operates on the joined
+//!   session.
+//! - **ORM** — `data/transaction/begin` returns a handle;
+//!   `data/transaction/exec { handle, query }` and
+//!   `data/transaction/commit { handle }` thread the same transaction.
+//!
+//! All IDs are UUIDs. The producer mints a UUID, stores its state under
+//! that UUID, returns the handle. Subsequent calls carry the UUID; the
+//! producer's handler does an O(1) map lookup. The pattern works the
+//! same whether the producer runs in-process, in a sibling module, or
+//! on a remote peer over grid/airc.
+
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+use uuid::Uuid;
+
+/// Typed reference to state owned by a specific module.
+///
+/// # Round-trip
+///
+/// 1. Producer command (e.g., `chat/send`) creates internal state
+///    (a message buffer, a session, a render context). It allocates a
+///    handle ID, stores the state under that ID in its own state map,
+///    and returns `CommandResult::Handle(HandleRef { owner: "chat",
+///    id, type_tag: "chat::MessageHandle", created_at_ms })`.
+///
+/// 2. Caller (Rust, TS, or remote) holds the HandleRef opaquely. It
+///    serializes through any wire crossing (it's plain JSON via serde).
+///
+/// 3. Caller invokes a downstream command that takes the handle:
+///    `Commands.execute("chat/message/get", { handle })`. The kernel
+///    routes to the chat module (`chat/` prefix in the registry); the
+///    chat module reads the handle's `id` from params and looks up its
+///    state map.
+///
+/// 4. Cross-module: if a different module needs to operate on the
+///    handle's underlying state, it asks the owner via a command:
+///    `Commands.execute("chat/message/get", { handle })` — same call,
+///    routed to the owner. The kernel doesn't care which module asked.
+///
+/// # `type_tag` discipline
+///
+/// Convention: `"<module>::<TypeName>"` matching the Rust type that
+/// produced the handle. e.g., `"chat::MessageHandle"`, `"rag::Slice"`,
+/// `"persona::InboxFrame"`. Lets typed callers cast safely on receipt
+/// without round-tripping through the producer.
+///
+/// # Lifetime
+///
+/// Producer owns the lifetime. The handle is valid as long as the
+/// producer's state map holds the ID. Producers may evict handles
+/// after a TTL, on session end, on resource pressure, etc. A consumer
+/// holding a stale handle gets a typed error from the producer's
+/// command handler (`"handle not found"`); the kernel doesn't
+/// participate in lifetime management. This is intentional — the
+/// kernel stays minimal, and lifetime policy belongs to the producer.
+///
+/// # Cross-machine
+///
+/// Same primitive. A handle minted on machine A is meaningful only on
+/// machine A. If a consumer on machine B calls a command taking that
+/// handle, the kernel's grid interceptor routes the call back to A
+/// (the handle's `owner` lives there). The handle ID never leaves A's
+/// state map; the remote call carries the ID, A executes the op
+/// locally, returns the result.
+#[derive(Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq)]
+#[ts(export, export_to = "../../../shared/generated/runtime/HandleRef.ts")]
+pub struct HandleRef {
+    /// Module that owns the state behind this handle. Kernel routes
+    /// any command taking this handle through the module's registered
+    /// command prefix (e.g., `"chat"` → commands under `chat/`).
+    pub owner: String,
+
+    /// UUID the owner module uses to look up its state. Always UUID
+    /// (per Joel 2026-05-30 — no string IDs at the cell-shape level);
+    /// the producer mints via [`HandleRef::mint`] (kernel chooses) or
+    /// passes a pre-allocated UUID via [`HandleRef::with_id`] (producer
+    /// chooses). Wire format is the UUID's canonical string serialization
+    /// so ts-rs sees it as `string`.
+    #[ts(type = "string")]
+    pub id: Uuid,
+
+    /// Type tag identifying the state shape. Convention:
+    /// `"<module>::<TypeName>"`. Lets typed consumers cast safely
+    /// without asking the owner.
+    pub type_tag: String,
+
+    /// Milliseconds since unix epoch when the handle was minted.
+    /// Useful for TTL enforcement (producer's choice) and for
+    /// diagnostic ordering.
+    #[ts(type = "number")]
+    pub created_at_ms: u64,
+}
+
+impl HandleRef {
+    /// Construct a HandleRef from a pre-allocated UUID. Use this when
+    /// the producer needs to know the UUID up front — e.g., when
+    /// inserting state into its map under a specific key:
+    ///
+    /// ```ignore
+    /// let id = Uuid::new_v4();
+    /// self.sessions.insert(id, session_state);
+    /// Ok(CommandResult::Handle(HandleRef::with_id("ai/inference", id, "ai::InferenceSession")))
+    /// ```
+    pub fn with_id(
+        owner: impl Into<String>,
+        id: Uuid,
+        type_tag: impl Into<String>,
+    ) -> Self {
+        Self {
+            owner: owner.into(),
+            id,
+            type_tag: type_tag.into(),
+            created_at_ms: now_ms(),
+        }
+    }
+
+    /// Construct a HandleRef with a fresh UUID. Convenience wrapper
+    /// around [`Self::with_id`] for producers that don't need to know
+    /// the UUID before they construct the handle:
+    ///
+    /// ```ignore
+    /// let handle = HandleRef::mint("ai/inference", "ai::InferenceSession");
+    /// self.sessions.insert(handle.id, session_state);
+    /// Ok(CommandResult::Handle(handle))
+    /// ```
+    pub fn mint(owner: impl Into<String>, type_tag: impl Into<String>) -> Self {
+        Self::with_id(owner, Uuid::new_v4(), type_tag)
+    }
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Reserved: streaming result. **Returning a Stream result today is a
+/// runtime error.** The variant exists so the enum's shape is fixed
+/// before handlers begin migrating; the wire protocol (frame format,
+/// correlation IDs, backpressure, cancellation) is the open piece.
+///
+/// When the protocol lands, `correlation_id` will tie incoming stream
+/// frames to this stream so the consumer can match. The struct is
+/// `#[non_exhaustive]` so adding fields later is non-breaking for
+/// external code; internal code uses [`StreamPlaceholder::new`] to
+/// construct rather than the field-init shorthand.
+#[derive(Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq)]
+#[ts(export, export_to = "../../../shared/generated/runtime/StreamPlaceholder.ts")]
+#[non_exhaustive]
+pub struct StreamPlaceholder {
+    /// Correlation ID a future wire protocol will use to tie incoming
+    /// stream frames to this stream handle. Today: unused; reserved.
+    pub correlation_id: String,
+}
+
+impl StreamPlaceholder {
+    /// Construct a placeholder. The kernel and consumer will use
+    /// `correlation_id` once the streaming protocol is designed; until
+    /// then, callers should NOT return this variant — the executor
+    /// rejects it via [`super::CommandResult::stream_protocol_error`].
+    pub fn new(correlation_id: impl Into<String>) -> Self {
+        Self {
+            correlation_id: correlation_id.into(),
+        }
+    }
+}
+
+/// Reserved: lambda (callable returned by a command). **Returning a
+/// Lambda result today is a runtime error.** Same status as
+/// [`StreamPlaceholder`]: variant exists, in-process + wire shapes are
+/// deferred.
+///
+/// When the protocol lands, a Lambda will be a curried command — name
+/// + bound params + callsite metadata — that the caller invokes later
+/// with remaining params via the kernel. Useful for setup commands
+/// that prepare a context and return "now call THIS with the rest of
+/// your input."
+#[derive(Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq)]
+#[ts(export, export_to = "../../../shared/generated/runtime/LambdaPlaceholder.ts")]
+#[non_exhaustive]
+pub struct LambdaPlaceholder {
+    /// Name of the curried command the lambda will dispatch when
+    /// invoked. e.g., `"ai/generate"`.
+    pub command: String,
+    /// Params already bound by the producer. The caller provides the
+    /// remaining params; the kernel merges then dispatches.
+    #[ts(type = "Record<string, unknown>")]
+    pub bound_params: serde_json::Value,
+}
+
+impl LambdaPlaceholder {
+    /// Construct a placeholder. Until the lambda protocol lands,
+    /// callers should NOT return this variant — the executor rejects
+    /// it via [`super::CommandResult::lambda_protocol_error`].
+    pub fn new(command: impl Into<String>, bound_params: serde_json::Value) -> Self {
+        Self {
+            command: command.into(),
+            bound_params,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_ref_with_id_preserves_uuid() {
+        let id = Uuid::new_v4();
+        let h = HandleRef::with_id("ai/inference", id, "ai::InferenceSession");
+        assert_eq!(h.id, id, "with_id must preserve the producer-allocated UUID");
+        assert_eq!(h.owner, "ai/inference");
+        assert_eq!(h.type_tag, "ai::InferenceSession");
+        assert!(h.created_at_ms > 0, "constructor must capture a timestamp");
+    }
+
+    #[test]
+    fn handle_ref_mint_generates_fresh_uuid() {
+        let a = HandleRef::mint("ai/inference", "ai::InferenceSession");
+        let b = HandleRef::mint("ai/inference", "ai::InferenceSession");
+        assert_ne!(a.id, b.id, "mint must produce distinct UUIDs across calls");
+    }
+
+    #[test]
+    fn handle_ref_roundtrips_through_json() {
+        let h = HandleRef::mint("chat", "chat::MessageHandle");
+        let json = serde_json::to_string(&h).expect("HandleRef must serialize");
+        let back: HandleRef = serde_json::from_str(&json).expect("HandleRef must deserialize");
+        assert_eq!(h, back);
+        // Spot-check the UUID survives the round-trip.
+        assert_eq!(h.id, back.id, "UUID must round-trip byte-identical through JSON");
+    }
+
+    #[test]
+    fn handle_ref_id_serializes_as_string() {
+        // Per the ts-rs binding (`#[ts(type = "string")]`), the wire
+        // form of `id` is the UUID's canonical string. Pin that
+        // serde matches — ts-rs and serde agree on the shape so
+        // TypeScript consumers can echo handles back as strings.
+        let id = Uuid::new_v4();
+        let h = HandleRef::with_id("chat", id, "chat::MessageHandle");
+        let json: serde_json::Value =
+            serde_json::to_value(&h).expect("HandleRef must serialize");
+        let id_field = json.get("id").expect("id field present");
+        assert!(
+            id_field.is_string(),
+            "id must serialize as JSON string (ts-rs sees it as `string`), got {id_field:?}"
+        );
+        assert_eq!(id_field.as_str().unwrap(), id.to_string());
+    }
+
+    #[test]
+    fn handle_ref_owns_distinct_state() {
+        // Two handles with the same owner + type but different UUIDs
+        // represent different state — pin that they don't compare equal.
+        let a = HandleRef::mint("chat", "chat::MessageHandle");
+        let b = HandleRef::mint("chat", "chat::MessageHandle");
+        assert_ne!(a, b, "handles with different UUIDs must not be equal");
+    }
+
+    #[test]
+    fn stream_placeholder_roundtrips() {
+        let s = StreamPlaceholder::new("corr-001");
+        let json = serde_json::to_string(&s).expect("StreamPlaceholder must serialize");
+        let back: StreamPlaceholder =
+            serde_json::from_str(&json).expect("StreamPlaceholder must deserialize");
+        assert_eq!(s, back);
+        assert_eq!(back.correlation_id, "corr-001");
+    }
+
+    #[test]
+    fn lambda_placeholder_roundtrips() {
+        let l = LambdaPlaceholder::new("ai/generate", serde_json::json!({ "model": "qwen" }));
+        let json = serde_json::to_string(&l).expect("LambdaPlaceholder must serialize");
+        let back: LambdaPlaceholder =
+            serde_json::from_str(&json).expect("LambdaPlaceholder must deserialize");
+        assert_eq!(l, back);
+        assert_eq!(back.command, "ai/generate");
+        assert_eq!(back.bound_params["model"], "qwen");
+    }
+}

--- a/src/workers/continuum-core/src/runtime/cell_shapes.rs
+++ b/src/workers/continuum-core/src/runtime/cell_shapes.rs
@@ -176,6 +176,67 @@ impl HandleRef {
     pub fn mint(owner: impl Into<String>, type_tag: impl Into<String>) -> Self {
         Self::with_id(owner, Uuid::new_v4(), type_tag)
     }
+
+    /// Validate this handle's `owner` and `type_tag` match the values
+    /// the consumer expects, returning the inner `Uuid` for the
+    /// consumer's own state-map lookup.
+    ///
+    /// This is the canonical handle-validation entry point — every
+    /// handler that consumes a `HandleRef` should call it before
+    /// looking the id up in its state map, so:
+    ///
+    /// - A handle minted by a different module reaching the wrong
+    ///   handler surfaces a typed "owner mismatch" error rather than
+    ///   silently miss-looking-up in the wrong state map. The grid
+    ///   interceptor is supposed to route by `owner` before dispatch
+    ///   ever fires; an owner-mismatch reaching this far means the
+    ///   routing misfired or a caller hand-crafted a bogus handle.
+    ///
+    /// - A handle for the wrong resource (right module, wrong type —
+    ///   e.g. a `data::Migration` handle threaded through a cursor
+    ///   handler) surfaces a typed "type mismatch" error rather than
+    ///   miss-looking-up across handle shapes.
+    ///
+    /// Errors are formatted consistently across every module that
+    /// uses handles, naming BOTH the offending value AND the expected
+    /// value so the caller self-corrects without grepping source.
+    /// Consumers typically prepend their command name via `map_err`:
+    ///
+    /// ```ignore
+    /// let cursor_id = handle.expect_owned_by("data", "data::QueryCursor")
+    ///     .map_err(|e| format!("data/query-next: {e}"))?;
+    /// ```
+    ///
+    /// For dual-shape resolvers that accept EITHER a typed handle
+    /// (envelope) OR a legacy string field (back-compat during
+    /// migration), prefer
+    /// [`crate::runtime::CommandRequest::handle_id_or_legacy`] which
+    /// composes this method with the legacy fallback path and the
+    /// command-name prefix in a single call.
+    pub fn expect_owned_by(
+        &self,
+        expected_owner: &str,
+        expected_type_tag: &str,
+    ) -> Result<Uuid, String> {
+        if self.owner != expected_owner {
+            return Err(format!(
+                "handle owner mismatch — got owner={:?}, expected {:?}. \
+                 Handles must be minted by the same module that consumes them, \
+                 OR the grid interceptor must route the command back to the owner \
+                 before local dispatch.",
+                self.owner, expected_owner
+            ));
+        }
+        if self.type_tag != expected_type_tag {
+            return Err(format!(
+                "handle type mismatch — got type_tag={:?}, expected {:?}. \
+                 This handler operates only on handles of the expected type; \
+                 threading a different handle shape here is a programming error.",
+                self.type_tag, expected_type_tag
+            ));
+        }
+        Ok(self.id)
+    }
 }
 
 fn now_ms() -> u64 {
@@ -329,5 +390,89 @@ mod tests {
         assert_eq!(l, back);
         assert_eq!(back.command, "ai/generate");
         assert_eq!(back.bound_params["model"], "qwen");
+    }
+
+    // ── HandleRef::expect_owned_by ───────────────────────────────────
+    //
+    // The canonical validation entry point distilled from the data
+    // module's first real HandleRef consumer (PR #1490). Every future
+    // handler that consumes a HandleRef should reach for this method
+    // rather than reimplementing the owner/type checks inline.
+
+    #[test]
+    fn expect_owned_by_returns_uuid_when_owner_and_type_match() {
+        let id = Uuid::new_v4();
+        let h = HandleRef::with_id("data", id, "data::QueryCursor");
+        let resolved = h
+            .expect_owned_by("data", "data::QueryCursor")
+            .expect("matched handle must validate");
+        assert_eq!(
+            resolved, id,
+            "expect_owned_by must return the inner UUID, not a string-rendered copy"
+        );
+    }
+
+    #[test]
+    fn expect_owned_by_rejects_wrong_owner_with_both_values_named() {
+        let h = HandleRef::mint("chat", "chat::MessageHandle");
+        let err = h
+            .expect_owned_by("data", "data::QueryCursor")
+            .expect_err("wrong owner must Err");
+        assert!(
+            err.contains("owner mismatch"),
+            "error must name the failure mode: {err}"
+        );
+        assert!(
+            err.contains("\"chat\"") && err.contains("\"data\""),
+            "error must name BOTH offender AND expected so caller self-corrects: {err}"
+        );
+    }
+
+    #[test]
+    fn expect_owned_by_rejects_wrong_type_tag_with_both_values_named() {
+        let h = HandleRef::mint("data", "data::Migration");
+        let err = h
+            .expect_owned_by("data", "data::QueryCursor")
+            .expect_err("wrong type must Err");
+        assert!(
+            err.contains("type mismatch"),
+            "error must name the failure mode: {err}"
+        );
+        assert!(
+            err.contains("data::Migration") && err.contains("data::QueryCursor"),
+            "error must name BOTH offender AND expected: {err}"
+        );
+    }
+
+    #[test]
+    fn expect_owned_by_checks_owner_first_then_type() {
+        // Pin the order: owner mismatch should surface even when the
+        // type tag is ALSO wrong. The owner-first check matters
+        // because owner determines routing — type is a secondary
+        // within-module discriminator.
+        let h = HandleRef::mint("chat", "chat::MessageHandle");
+        let err = h
+            .expect_owned_by("data", "data::QueryCursor")
+            .expect_err("both fields wrong must Err on the routing one first");
+        assert!(
+            err.contains("owner mismatch") && !err.contains("type mismatch"),
+            "owner mismatch must take precedence over type mismatch: {err}"
+        );
+    }
+
+    #[test]
+    fn expect_owned_by_error_includes_routing_hint() {
+        // The owner-mismatch error explicitly points consumers at the
+        // grid interceptor's responsibility to route by owner — that's
+        // the hint that turns "weird error" into "ah, the interceptor
+        // is misconfigured" or "ah, this caller built a bogus handle".
+        let h = HandleRef::mint("chat", "data::QueryCursor");
+        let err = h
+            .expect_owned_by("data", "data::QueryCursor")
+            .expect_err("wrong owner must Err");
+        assert!(
+            err.contains("grid interceptor") || err.contains("route"),
+            "owner-mismatch error must hint at routing semantics: {err}"
+        );
     }
 }

--- a/src/workers/continuum-core/src/runtime/command_envelope.rs
+++ b/src/workers/continuum-core/src/runtime/command_envelope.rs
@@ -1,0 +1,498 @@
+//! Command envelopes — typed wrappers around the cross-cutting params
+//! and result fields every command shares.
+//!
+//! # The pattern
+//!
+//! Per Joel 2026-05-30: *"Some things are used so much should just be
+//! part of command result and params, handle for example. Find the
+//! patterns and simplify. The better the pattern, the easier to use
+//! the command or to reduce code size."*
+//!
+//! Right. A handle for long-running work, a session ID, a user ID,
+//! a success flag, an optional error message — these are cross-cutting
+//! concerns every command touches in some combination. Today's
+//! `ServiceModule::handle_command(command, params: Value) ->
+//! Result<CommandResult, String>` shovels everything through raw JSON;
+//! handlers re-parse the cross-cutting bits themselves and rebuild the
+//! same envelope at every return point.
+//!
+//! This module gives that pattern a name:
+//!
+//! - **`CommandRequest<P>`** — typed envelope around an inbound command:
+//!   the command-specific params `P` flattened with `handle`, `sessionId`,
+//!   `userId`. Parsers + accessors live here so handlers don't re-roll
+//!   the wheel.
+//!
+//! - **`CommandResponse<T>`** — typed envelope around the outbound
+//!   result: the command-specific data `T` flattened with `success`,
+//!   `error`, optional `handle` for follow-up calls. Builder-style API
+//!   so producing both data AND a handle is one fluent expression.
+//!
+//! Existing handlers keep their `Value`-based signatures (back-compat
+//! for the 300+ surface). New handlers opt into the typed shape via
+//! `CommandRequest::<P>::from_value(params)?` at the entry +
+//! `.into_command_result()?` at the exit. Same `ServiceModule` trait,
+//! tighter internal pattern.
+//!
+//! # What this collapses
+//!
+//! Before:
+//!
+//! ```ignore
+//! async fn handle_inference_start(
+//!     &self,
+//!     params: Value,
+//! ) -> Result<CommandResult, String> {
+//!     let p: InferenceStartParams =
+//!         serde_json::from_value(params.clone()).map_err(|e| e.to_string())?;
+//!     let session_id = params
+//!         .get("sessionId")
+//!         .and_then(|v| v.as_str())
+//!         .and_then(|s| Uuid::parse_str(s).ok());
+//!     let id = Uuid::new_v4();
+//!     self.sessions.insert(id, InferenceSession::new(p));
+//!     Ok(CommandResult::Json(serde_json::json!({
+//!         "success": true,
+//!         "firstToken": first_token,
+//!         "handle": HandleRef::with_id("ai/inference", id, "ai::InferenceSession"),
+//!     })))
+//! }
+//! ```
+//!
+//! After:
+//!
+//! ```ignore
+//! async fn handle_inference_start(
+//!     &self,
+//!     params: Value,
+//! ) -> Result<CommandResult, String> {
+//!     let req = CommandRequest::<InferenceStartParams>::from_value(params)?;
+//!     let id = Uuid::new_v4();
+//!     self.sessions.insert(id, InferenceSession::new(req.params));
+//!     CommandResponse::ok(InferenceStartData { first_token })
+//!         .with_handle("ai/inference", id, "ai::InferenceSession")
+//!         .into_command_result()
+//! }
+//! ```
+//!
+//! The cross-cutting fields stop being something handlers have to know
+//! about. They become free.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use super::cell_shapes::HandleRef;
+use super::CommandResult;
+
+/// Typed envelope around an inbound command's params.
+///
+/// Wraps the command-specific `P` with the cross-cutting fields every
+/// command can carry:
+///
+/// - `handle` — a [`HandleRef`] from a previous call. Present when this
+///   command is operating on existing state owned by another command
+///   (e.g., `inference/poll` carries the handle minted by
+///   `inference/start`).
+/// - `session_id` — the calling session. Threaded by the kernel for
+///   dual logging + accountability.
+/// - `user_id` — the calling user. Threaded by the kernel for
+///   per-user scoping (e.g., per-persona work).
+///
+/// `P` is flattened into the JSON envelope at deserialize time, so
+/// the wire shape stays flat (same as today's untyped commands). The
+/// type machinery is purely a Rust-side convenience.
+///
+/// # Construction
+///
+/// Handlers parse a `CommandRequest<P>` from the raw `Value` they
+/// receive via `ServiceModule::handle_command` using
+/// [`CommandRequest::from_value`]. The parser yields a typed struct
+/// where the command-specific fields live in `params` and the
+/// cross-cutting fields live at the top.
+///
+/// Tests + one-off callsites can construct directly via the public
+/// fields.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CommandRequest<P> {
+    /// Command-specific params, deserialized from the same JSON object
+    /// as the envelope. Flatten means the wire JSON looks like
+    /// `{ ...P fields..., handle?, sessionId?, userId? }`.
+    #[serde(flatten)]
+    pub params: P,
+
+    /// Handle to existing state from a prior command call. Present
+    /// when this command operates on a long-running session (inference,
+    /// training, hosting, ORM, etc.) — the producer minted the handle;
+    /// this caller passes it back to thread the work.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub handle: Option<HandleRef>,
+
+    /// Calling session — set by the kernel from the request envelope.
+    /// Handlers reading this can correlate per-session telemetry, dual
+    /// log, etc.
+    #[serde(
+        rename = "sessionId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub session_id: Option<Uuid>,
+
+    /// Calling user — set by the kernel from the session. Handlers
+    /// reading this can scope per-user state (e.g., per-persona work).
+    #[serde(rename = "userId", skip_serializing_if = "Option::is_none", default)]
+    pub user_id: Option<Uuid>,
+}
+
+impl<P> CommandRequest<P>
+where
+    P: serde::de::DeserializeOwned,
+{
+    /// Parse a `CommandRequest<P>` from a raw `Value`. The
+    /// command-specific fields go into `params`; `handle`, `sessionId`,
+    /// `userId` are pulled from the top level of the same object.
+    ///
+    /// Error is a String describing the failure, matching the existing
+    /// `ServiceModule::handle_command` error type so handlers can `?`
+    /// the result directly.
+    pub fn from_value(value: Value) -> Result<Self, String> {
+        serde_json::from_value(value)
+            .map_err(|e| format!("CommandRequest deserialization failed: {e}"))
+    }
+}
+
+impl<P> CommandRequest<P> {
+    /// Construct a request envelope for tests or programmatic callsites
+    /// where the params are already in-hand. The cross-cutting fields
+    /// default to `None`; chain `with_handle`/`with_session`/`with_user`
+    /// to populate them.
+    pub fn new(params: P) -> Self {
+        Self {
+            params,
+            handle: None,
+            session_id: None,
+            user_id: None,
+        }
+    }
+
+    pub fn with_handle(mut self, handle: HandleRef) -> Self {
+        self.handle = Some(handle);
+        self
+    }
+
+    pub fn with_session(mut self, session_id: Uuid) -> Self {
+        self.session_id = Some(session_id);
+        self
+    }
+
+    pub fn with_user(mut self, user_id: Uuid) -> Self {
+        self.user_id = Some(user_id);
+        self
+    }
+}
+
+/// Typed envelope around an outbound command's result.
+///
+/// Wraps the command-specific `T` with the cross-cutting fields every
+/// command can produce:
+///
+/// - `success` — operation-level success flag, mirrored in the JSON
+///   envelope. Stays `true` until something fails; an error-returning
+///   handler should construct via [`CommandResponse::err`] which sets
+///   it to `false`.
+/// - `error` — operation-level error message. `None` when success.
+/// - `handle` — a [`HandleRef`] minted by this command for the caller
+///   to use in follow-up calls. The "first call returns a handle"
+///   pattern Joel called out for inference / training / hosting /
+///   ORM lives here.
+///
+/// `T` is flattened into the JSON envelope at serialize time so the
+/// wire shape stays flat. A handler producing `{ firstToken: "..." }`
+/// + a handle for follow-up materializes as
+/// `{ success: true, firstToken: "...", handle: {...} }` — same
+/// flat shape callers already know.
+///
+/// # Construction (builder)
+///
+/// `CommandResponse::ok(data)` for the happy path, then chain
+/// `.with_handle(...)` for the long-running case. `CommandResponse::err
+/// (msg)` for failure when `T: Default` (callers without a default just
+/// build the struct directly).
+///
+/// Materialize as a `CommandResult` (the ServiceModule return shape)
+/// via [`CommandResponse::into_command_result`]: serialize-flatten +
+/// wrap as `CommandResult::Json`. One method call to bridge the typed
+/// envelope into the existing kernel surface.
+#[derive(Debug, Clone, Serialize)]
+pub struct CommandResponse<T> {
+    /// Operation succeeded. Default `true`; flipped by
+    /// [`CommandResponse::err`].
+    pub success: bool,
+
+    /// Command-specific result payload, flattened into the wire JSON
+    /// alongside the envelope fields.
+    #[serde(flatten)]
+    pub data: T,
+
+    /// Handle minted by this command for the caller to use in follow-up
+    /// calls — the long-running session pattern.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handle: Option<HandleRef>,
+
+    /// Operation-level error message. Set when `success == false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl<T> CommandResponse<T> {
+    /// Construct a successful response with the given payload. Use
+    /// `.with_handle(...)` to attach a handle for follow-up.
+    pub fn ok(data: T) -> Self {
+        Self {
+            success: true,
+            data,
+            handle: None,
+            error: None,
+        }
+    }
+
+    /// Attach a handle to this response. Producer typically minted a
+    /// UUID, stored state under it, and now returns the handle for the
+    /// caller's subsequent operations.
+    pub fn with_handle(
+        mut self,
+        owner: impl Into<String>,
+        id: Uuid,
+        type_tag: impl Into<String>,
+    ) -> Self {
+        self.handle = Some(HandleRef::with_id(owner, id, type_tag));
+        self
+    }
+
+    /// Attach a pre-built [`HandleRef`]. Use when the caller already
+    /// has a handle struct (e.g., echoing a downstream module's handle).
+    pub fn with_handle_ref(mut self, handle: HandleRef) -> Self {
+        self.handle = Some(handle);
+        self
+    }
+}
+
+impl<T: Default> CommandResponse<T> {
+    /// Construct a failure response with an error message. Requires
+    /// `T: Default` so the data field has a value; callers whose `T`
+    /// doesn't default should construct directly.
+    pub fn err(message: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            data: T::default(),
+            handle: None,
+            error: Some(message.into()),
+        }
+    }
+}
+
+impl<T: Serialize> CommandResponse<T> {
+    /// Materialize this typed envelope as a `CommandResult::Json`
+    /// suitable for the `ServiceModule::handle_command` return.
+    ///
+    /// Serializes the whole envelope (with `T` flattened) to a JSON
+    /// value and wraps. The Result error is the serialization failure,
+    /// matching the canonical `ServiceModule` error string type.
+    pub fn into_command_result(self) -> Result<CommandResult, String> {
+        serde_json::to_value(&self)
+            .map(CommandResult::Json)
+            .map_err(|e| format!("CommandResponse serialization failed: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── CommandRequest<P> ────────────────────────────────────────────
+
+    #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+    struct StartParams {
+        model: String,
+        max_tokens: u32,
+    }
+
+    #[test]
+    fn request_parses_flat_params_no_envelope_fields() {
+        // Wire JSON without any envelope fields — pure command params.
+        let value = json!({ "model": "qwen", "max_tokens": 512 });
+        let req = CommandRequest::<StartParams>::from_value(value).expect("parse must succeed");
+        assert_eq!(req.params.model, "qwen");
+        assert_eq!(req.params.max_tokens, 512);
+        assert!(
+            req.handle.is_none() && req.session_id.is_none() && req.user_id.is_none(),
+            "envelope fields default to None when absent in the wire JSON"
+        );
+    }
+
+    #[test]
+    fn request_parses_envelope_fields_flat() {
+        let session_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let handle_id = Uuid::new_v4();
+        let value = json!({
+            "model": "qwen",
+            "max_tokens": 256,
+            "sessionId": session_id.to_string(),
+            "userId": user_id.to_string(),
+            "handle": {
+                "owner": "ai/inference",
+                "id": handle_id.to_string(),
+                "type_tag": "ai::InferenceSession",
+                "created_at_ms": 1_700_000_000_000_u64
+            }
+        });
+        let req = CommandRequest::<StartParams>::from_value(value).expect("parse must succeed");
+        assert_eq!(req.params.model, "qwen");
+        assert_eq!(req.session_id, Some(session_id));
+        assert_eq!(req.user_id, Some(user_id));
+        assert_eq!(req.handle.unwrap().id, handle_id);
+    }
+
+    #[test]
+    fn request_parse_error_carries_diagnostic() {
+        // Wrong types — `max_tokens` is a string. Parser must surface
+        // a String error, not panic.
+        let value = json!({ "model": "qwen", "max_tokens": "not-a-number" });
+        let err = CommandRequest::<StartParams>::from_value(value)
+            .expect_err("type mismatch must surface as Err, not panic");
+        assert!(
+            err.contains("CommandRequest deserialization failed"),
+            "error must name the envelope so the caller knows which layer failed: {err}"
+        );
+    }
+
+    #[test]
+    fn request_builder_attaches_envelope_fields() {
+        let handle = HandleRef::mint("ai/inference", "ai::InferenceSession");
+        let session_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let req = CommandRequest::new(StartParams {
+            model: "qwen".into(),
+            max_tokens: 100,
+        })
+        .with_handle(handle.clone())
+        .with_session(session_id)
+        .with_user(user_id);
+        assert_eq!(req.handle, Some(handle));
+        assert_eq!(req.session_id, Some(session_id));
+        assert_eq!(req.user_id, Some(user_id));
+    }
+
+    // ── CommandResponse<T> ───────────────────────────────────────────
+
+    #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+    struct StartData {
+        first_token: String,
+        tokens_emitted: u32,
+    }
+
+    #[test]
+    fn response_ok_serializes_flat_with_success_true() {
+        let resp = CommandResponse::ok(StartData {
+            first_token: "Hello".into(),
+            tokens_emitted: 1,
+        });
+        let json = serde_json::to_value(&resp).expect("serialize must succeed");
+        assert_eq!(json["success"], true);
+        assert_eq!(json["first_token"], "Hello");
+        assert_eq!(json["tokens_emitted"], 1);
+        assert!(
+            json.get("handle").is_none(),
+            "handle is omitted when None — clean wire shape"
+        );
+        assert!(json.get("error").is_none(), "error is omitted when None");
+    }
+
+    #[test]
+    fn response_with_handle_attaches_handle_at_top_level() {
+        let id = Uuid::new_v4();
+        let resp = CommandResponse::ok(StartData {
+            first_token: "Hi".into(),
+            tokens_emitted: 1,
+        })
+        .with_handle("ai/inference", id, "ai::InferenceSession");
+        let json = serde_json::to_value(&resp).expect("serialize must succeed");
+        assert_eq!(json["success"], true);
+        assert_eq!(json["handle"]["owner"], "ai/inference");
+        assert_eq!(json["handle"]["id"], id.to_string());
+        assert_eq!(json["handle"]["type_tag"], "ai::InferenceSession");
+        // Data fields stay flat alongside the handle.
+        assert_eq!(json["first_token"], "Hi");
+    }
+
+    #[test]
+    fn response_err_serializes_with_success_false_and_message() {
+        let resp = CommandResponse::<StartData>::err("model not found: 'qwen-99'");
+        let json = serde_json::to_value(&resp).expect("serialize must succeed");
+        assert_eq!(json["success"], false);
+        assert_eq!(json["error"], "model not found: 'qwen-99'");
+        // Default data fields still present (empty strings, 0 counts).
+        assert_eq!(json["first_token"], "");
+        assert_eq!(json["tokens_emitted"], 0);
+    }
+
+    #[test]
+    fn response_into_command_result_yields_json_variant() {
+        let resp = CommandResponse::ok(StartData {
+            first_token: "Hi".into(),
+            tokens_emitted: 1,
+        })
+        .with_handle("ai/inference", Uuid::new_v4(), "ai::InferenceSession");
+        let cr = resp.into_command_result().expect("materialize must succeed");
+        match cr {
+            CommandResult::Json(v) => {
+                assert_eq!(v["success"], true);
+                assert_eq!(v["first_token"], "Hi");
+                assert!(v["handle"].is_object());
+            }
+            other => panic!("expected CommandResult::Json, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn round_trip_through_wire_preserves_envelope_fields() {
+        // End-to-end: typed handler returns Response → serialize as
+        // CommandResult → echo as string → deserialize on a "caller"
+        // side. The caller-side gets a CommandRequest envelope back
+        // (treating the result as the next call's input) — handle,
+        // session, user all survive.
+        let session_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let handle_id = Uuid::new_v4();
+
+        // Build a response carrying a handle (the producer minted it).
+        let resp = CommandResponse::ok(StartData {
+            first_token: "Hi".into(),
+            tokens_emitted: 1,
+        })
+        .with_handle("ai/inference", handle_id, "ai::InferenceSession");
+        let wire_json = serde_json::to_value(&resp).unwrap();
+
+        // Caller takes the result, builds a new request envelope using
+        // the returned handle (+ their own session/user). The new
+        // request's params type is a "poll" shape.
+        #[derive(Debug, Clone, Deserialize, Serialize)]
+        struct PollParams {
+            max_tokens: u32,
+        }
+
+        let mut next_call = json!({ "max_tokens": 64 });
+        next_call["handle"] = wire_json["handle"].clone();
+        next_call["sessionId"] = json!(session_id.to_string());
+        next_call["userId"] = json!(user_id.to_string());
+
+        let req = CommandRequest::<PollParams>::from_value(next_call)
+            .expect("caller round-trips envelope cleanly");
+        assert_eq!(req.params.max_tokens, 64);
+        assert_eq!(req.session_id, Some(session_id));
+        assert_eq!(req.user_id, Some(user_id));
+        assert_eq!(req.handle.unwrap().id, handle_id);
+    }
+}

--- a/src/workers/continuum-core/src/runtime/command_envelope.rs
+++ b/src/workers/continuum-core/src/runtime/command_envelope.rs
@@ -189,6 +189,81 @@ impl<P> CommandRequest<P> {
         self.user_id = Some(user_id);
         self
     }
+
+    /// Resolve a resource id during migration from string-typed ids to
+    /// typed [`HandleRef`]s, returning the id as a string.
+    ///
+    /// Walks two possible shapes in priority order:
+    ///
+    /// 1. **Envelope `handle`** (the new canonical shape). When
+    ///    present, validates against the expected `owner` and
+    ///    `type_tag` via [`HandleRef::expect_owned_by`]; a failure
+    ///    here surfaces with the `command` name prepended so the
+    ///    consumer's error names the offending surface, the failure
+    ///    mode, and the expected values in one breath.
+    ///
+    /// 2. **Legacy string field** (the back-compat shape). Returned
+    ///    as-is. The historical wire contract pre-dates UUID typing,
+    ///    so legacy callers may send anything — if the string fails
+    ///    the consumer's downstream lookup, the consumer's own
+    ///    "not found" error names it.
+    ///
+    /// 3. **Neither present** — typed error naming BOTH supported
+    ///    shapes so the caller knows what to add.
+    ///
+    /// This is the single primitive shared by every additive
+    /// migration of a stringly-typed id to a typed handle. See
+    /// `data.rs`'s `handle_query_next` / `handle_query_close` for the
+    /// canonical consumer; other migrations should reach for this
+    /// rather than reimplementing the resolver.
+    ///
+    /// # Why does it return `String`?
+    ///
+    /// Two callers consume the same id today:
+    /// - the envelope path produces a `Uuid` (typed)
+    /// - the legacy path produces a string (predates UUID typing)
+    ///
+    /// To present a unified resolved-id type to the consumer, we
+    /// collapse to `String` — the historical wire format that every
+    /// consumer's existing state map is already keyed on. Future
+    /// modules whose state maps are keyed on `Uuid` can `Uuid::parse_str`
+    /// the result; the parse failure mode for legacy strings is fine
+    /// because handle-only consumers (post-migration) won't have a
+    /// legacy field to fall back to anyway.
+    ///
+    /// # Usage
+    ///
+    /// ```ignore
+    /// let cursor_id = req.handle_id_or_legacy(
+    ///     "data",                   // expected owner
+    ///     "data::QueryCursor",      // expected type_tag
+    ///     "queryId",                // legacy field name (for error)
+    ///     &req.params.query_id,     // legacy field value (Option<String>)
+    ///     "data/query-next",        // command name (for error prefix)
+    /// )?;
+    /// ```
+    pub fn handle_id_or_legacy(
+        &self,
+        expected_owner: &str,
+        expected_type_tag: &str,
+        legacy_field_name: &str,
+        legacy_field: &Option<String>,
+        command: &str,
+    ) -> Result<String, String> {
+        if let Some(h) = &self.handle {
+            return h
+                .expect_owned_by(expected_owner, expected_type_tag)
+                .map(|uuid| uuid.to_string())
+                .map_err(|e| format!("{command}: {e}"));
+        }
+        if let Some(id) = legacy_field {
+            return Ok(id.clone());
+        }
+        Err(format!(
+            "{command}: neither `handle` (envelope field) nor `{legacy_field_name}` \
+             (legacy params field) was provided. Pass the resource id via either shape."
+        ))
+    }
 }
 
 /// Typed envelope around an outbound command's result.
@@ -494,5 +569,174 @@ mod tests {
         assert_eq!(req.session_id, Some(session_id));
         assert_eq!(req.user_id, Some(user_id));
         assert_eq!(req.handle.unwrap().id, handle_id);
+    }
+
+    // ── CommandRequest::handle_id_or_legacy ─────────────────────────
+    //
+    // The single primitive shared by every additive migration of a
+    // stringly-typed id to a typed handle. Distilled from data
+    // module's first real consumer (PR #1490) so future migrations
+    // don't reimplement the resolver. Each kink the data migration
+    // discovered is pinned by a test here so the substrate
+    // guarantees them centrally.
+
+    #[derive(Debug, Clone, Default, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct CursorParams {
+        #[serde(default)]
+        query_id: Option<String>,
+    }
+
+    fn cursor_handle(id: Uuid) -> HandleRef {
+        HandleRef::with_id("data", id, "data::QueryCursor")
+    }
+
+    #[test]
+    fn handle_id_or_legacy_prefers_envelope_handle_when_both_present() {
+        // When the envelope carries a handle AND a legacy field is
+        // also present, the typed handle wins. Otherwise consumers
+        // mid-migration would diverge from new consumers about which
+        // id the resolver sees.
+        let h_id = Uuid::new_v4();
+        let req = CommandRequest::new(CursorParams {
+            query_id: Some(Uuid::new_v4().to_string()), // legacy populated
+        })
+        .with_handle(cursor_handle(h_id));
+
+        let resolved = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-next",
+            )
+            .expect("envelope handle must win");
+        assert_eq!(
+            resolved,
+            h_id.to_string(),
+            "envelope handle MUST win when both shapes are present"
+        );
+    }
+
+    #[test]
+    fn handle_id_or_legacy_falls_back_to_legacy_string_when_no_handle() {
+        let legacy = "11111111-2222-3333-4444-555555555555".to_string();
+        let req = CommandRequest::new(CursorParams {
+            query_id: Some(legacy.clone()),
+        });
+
+        let resolved = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-next",
+            )
+            .expect("legacy fallback must succeed");
+        assert_eq!(resolved, legacy, "legacy string returned as-is");
+    }
+
+    #[test]
+    fn handle_id_or_legacy_errors_loud_when_neither_shape_provided() {
+        let req = CommandRequest::new(CursorParams::default());
+        let err = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-next",
+            )
+            .expect_err("empty request must Err");
+        assert!(
+            err.contains("data/query-next"),
+            "error must name the failing command surface: {err}"
+        );
+        assert!(
+            err.contains("`handle`") && err.contains("`queryId`"),
+            "error must name BOTH supported shapes so caller knows what to add: {err}"
+        );
+    }
+
+    #[test]
+    fn handle_id_or_legacy_prepends_command_name_to_handle_validation_errors() {
+        // Critical for diagnostics: when a wrong-owner handle reaches
+        // this resolver, the error must name BOTH the failing command
+        // (so the caller knows which surface) AND the
+        // HandleRef-level mismatch (so the caller knows what to fix).
+        let req = CommandRequest::new(CursorParams::default()).with_handle(HandleRef::mint(
+            "chat",
+            "chat::MessageHandle",
+        ));
+
+        let err = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-next",
+            )
+            .expect_err("wrong-owner handle must Err");
+        assert!(
+            err.starts_with("data/query-next:"),
+            "command name must prefix the error: {err}"
+        );
+        assert!(
+            err.contains("owner mismatch"),
+            "HandleRef's failure mode must propagate: {err}"
+        );
+        assert!(
+            err.contains("\"chat\"") && err.contains("\"data\""),
+            "both offender and expected named: {err}"
+        );
+    }
+
+    #[test]
+    fn handle_id_or_legacy_propagates_type_mismatch_with_command_name() {
+        let req = CommandRequest::new(CursorParams::default())
+            .with_handle(HandleRef::mint("data", "data::Migration"));
+
+        let err = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-close",
+            )
+            .expect_err("wrong-type handle must Err");
+        assert!(err.starts_with("data/query-close:"), "command prefix: {err}");
+        assert!(err.contains("type mismatch"), "type mismatch propagates: {err}");
+        assert!(
+            err.contains("data::Migration") && err.contains("data::QueryCursor"),
+            "both offender and expected named: {err}"
+        );
+    }
+
+    #[test]
+    fn handle_id_or_legacy_uses_canonical_uuid_string_for_handle_path() {
+        // The envelope path must produce the UUID's canonical string
+        // form (not some other rendering), so downstream consumers
+        // can use the resolved string as a stable cache key with
+        // legacy-path values from the same migration window.
+        let id = Uuid::new_v4();
+        let req = CommandRequest::new(CursorParams::default()).with_handle(cursor_handle(id));
+        let resolved = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-next",
+            )
+            .unwrap();
+        assert_eq!(
+            resolved,
+            id.to_string(),
+            "canonical UUID string is the bridge format between handle and legacy paths"
+        );
     }
 }

--- a/src/workers/continuum-core/src/runtime/command_executor.rs
+++ b/src/workers/continuum-core/src/runtime/command_executor.rs
@@ -141,12 +141,14 @@ impl CommandExecutor {
         Ok(CommandResult::Json(json))
     }
 
-    /// Convenience: execute and extract JSON directly
+    /// Convenience: execute and extract JSON directly.
+    ///
+    /// Delegates to [`CommandResult::to_json_value`] which handles all
+    /// cell shapes — Json/Binary return their payload, Handle serializes
+    /// the HandleRef, Stream/Lambda return their not-yet-wired protocol
+    /// error so the caller knows the cell shape requires direct match.
     pub async fn execute_json(&self, command: &str, params: Value) -> Result<Value, String> {
-        match self.execute(command, params).await? {
-            CommandResult::Json(v) => Ok(v),
-            CommandResult::Binary { metadata, .. } => Ok(metadata),
-        }
+        self.execute(command, params).await?.to_json_value()
     }
 
     /// Execute a command ONLY via TypeScript (bypasses Rust registry).

--- a/src/workers/continuum-core/src/runtime/mod.rs
+++ b/src/workers/continuum-core/src/runtime/mod.rs
@@ -28,6 +28,7 @@ pub mod airc_interceptor;
 pub mod artifact_handle;
 pub mod brain_region;
 pub mod cell_shapes;
+pub mod command_envelope;
 pub mod command_executor;
 pub mod command_interceptor;
 pub mod control;
@@ -51,6 +52,7 @@ pub use brain_region::{
 };
 pub use airc_interceptor::AircInterceptor;
 pub use cell_shapes::{HandleRef, LambdaPlaceholder, StreamPlaceholder};
+pub use command_envelope::{CommandRequest, CommandResponse};
 pub use command_executor::{
     execute as execute_command, execute_json as execute_command_json, executor, init_executor,
     CommandExecutor,

--- a/src/workers/continuum-core/src/runtime/mod.rs
+++ b/src/workers/continuum-core/src/runtime/mod.rs
@@ -27,6 +27,7 @@ use std::sync::OnceLock;
 pub mod airc_interceptor;
 pub mod artifact_handle;
 pub mod brain_region;
+pub mod cell_shapes;
 pub mod command_executor;
 pub mod command_interceptor;
 pub mod control;
@@ -49,6 +50,7 @@ pub use brain_region::{
     SleepPhase, TickOutcome,
 };
 pub use airc_interceptor::AircInterceptor;
+pub use cell_shapes::{HandleRef, LambdaPlaceholder, StreamPlaceholder};
 pub use command_executor::{
     execute as execute_command, execute_json as execute_command_json, executor, init_executor,
     CommandExecutor,

--- a/src/workers/continuum-core/src/runtime/service_module.rs
+++ b/src/workers/continuum-core/src/runtime/service_module.rs
@@ -102,17 +102,60 @@ pub struct ModuleConfig {
     pub tick_interval: Option<Duration>,
 }
 
-/// Result of handling a command.
-/// Supports both JSON-only and binary responses (audio, embeddings).
+/// Result of handling a command — one of the four cell return shapes
+/// per [MODULE-ARCHITECTURE.md §5.1](../../../../../docs/architecture/MODULE-ARCHITECTURE.md).
+///
+/// See [`super::cell_shapes`] for the cell taxonomy + the rationale
+/// for each variant. Short version:
+///
+/// - `Json` / `Binary` — the **Value** cell shape (immediate typed
+///   result). Kept under their original names for back-compat with
+///   the 300+ existing handlers; new code that produces a typed
+///   result still uses `Json` (or `CommandResult::json(&value)?`).
+/// - `Handle` — the **Handle** cell shape, NEW in this PR. Typed
+///   reference to state owned by the producing module. See
+///   [`super::cell_shapes::HandleRef`] for the round-trip protocol.
+///   Answers MODULE-ARCHITECTURE.md §13.1 (hot-path cross-module
+///   state via reference, not copy).
+/// - `Stream` / `Lambda` — reserved cell shapes. Returning these
+///   today is a runtime error per the contract — the variant exists
+///   so the enum shape is fixed before the wire protocols land. See
+///   [`super::cell_shapes::StreamPlaceholder`] and
+///   [`super::cell_shapes::LambdaPlaceholder`].
+///
+/// # Adding to this enum
+///
+/// `#[non_exhaustive]` lets downstream crates match without breaking
+/// when new variants land. Within continuum-core, exhaustive matches
+/// MUST cover the new variants — the compiler enforces this. Use
+/// [`CommandResult::to_json_value`] when the call site just needs the
+/// payload as JSON regardless of which cell shape arrived.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum CommandResult {
-    /// Standard JSON response
+    /// Standard JSON response. The Value cell shape under the legacy
+    /// name; preferred for new code that produces a typed result.
     Json(Value),
 
     /// Binary response: JSON metadata + raw bytes.
-    /// Wire format: [JSON header bytes][\0][raw binary bytes]
+    /// Wire format: `[JSON header bytes][\0][raw binary bytes]`.
     /// Used for audio synthesis, embedding vectors, etc.
     Binary { metadata: Value, data: Vec<u8> },
+
+    /// Typed reference to state owned by the producing module. See
+    /// [`super::cell_shapes::HandleRef`] for the round-trip protocol.
+    Handle(super::cell_shapes::HandleRef),
+
+    /// Reserved: streaming result. Returning this today is a runtime
+    /// error — see [`super::cell_shapes::StreamPlaceholder`] for the
+    /// open protocol design.
+    Stream(super::cell_shapes::StreamPlaceholder),
+
+    /// Reserved: lambda (callable returned by a command). Returning
+    /// this today is a runtime error — see
+    /// [`super::cell_shapes::LambdaPlaceholder`] for the open protocol
+    /// design.
+    Lambda(super::cell_shapes::LambdaPlaceholder),
 }
 
 impl CommandResult {
@@ -122,6 +165,78 @@ impl CommandResult {
         serde_json::to_value(value)
             .map(CommandResult::Json)
             .map_err(|e| format!("Serialization error: {e}"))
+    }
+
+    /// Create a Handle result from a producer-allocated UUID.
+    ///
+    /// Use this when the producer minted a UUID up front to insert
+    /// state into its own map under a specific key:
+    ///
+    /// ```ignore
+    /// let id = uuid::Uuid::new_v4();
+    /// self.sessions.insert(id, session_state);
+    /// Ok(CommandResult::handle("ai/inference", id, "ai::InferenceSession"))
+    /// ```
+    ///
+    /// For the simpler case where the producer doesn't need to know
+    /// the UUID before constructing the handle, use
+    /// [`super::cell_shapes::HandleRef::mint`] directly and wrap with
+    /// `CommandResult::Handle(...)`.
+    pub fn handle(
+        owner: impl Into<String>,
+        id: uuid::Uuid,
+        type_tag: impl Into<String>,
+    ) -> Self {
+        CommandResult::Handle(super::cell_shapes::HandleRef::with_id(owner, id, type_tag))
+    }
+
+    /// Project the result into a JSON `Value` for callers that don't
+    /// care about the cell shape — e.g., the TS bridge that wants to
+    /// serialize the result over a Unix socket regardless of which
+    /// cell shape the producer chose.
+    ///
+    /// `Json` returns itself. `Binary` returns its metadata (the
+    /// bytes are dropped — callers needing the raw data must match
+    /// on the variant directly). `Handle` serializes the HandleRef
+    /// as JSON so a TS caller can hold it and pass it back. `Stream`
+    /// and `Lambda` return errors per the not-yet-wired contract:
+    /// projecting them as plain JSON would lose the protocol shape
+    /// the caller needs to consume them, so we fail loud rather than
+    /// silently degrade.
+    pub fn to_json_value(&self) -> Result<Value, String> {
+        match self {
+            CommandResult::Json(v) => Ok(v.clone()),
+            CommandResult::Binary { metadata, .. } => Ok(metadata.clone()),
+            CommandResult::Handle(h) => serde_json::to_value(h)
+                .map_err(|e| format!("HandleRef serialization failed: {e}")),
+            CommandResult::Stream(_) => Err(Self::stream_protocol_error()),
+            CommandResult::Lambda(_) => Err(Self::lambda_protocol_error()),
+        }
+    }
+
+    /// Canonical error message for handlers that try to return a Stream
+    /// today. Surfaced from any callsite that needs to reject the
+    /// not-yet-wired streaming variant — same wording everywhere so
+    /// the failure mode is easy to grep.
+    pub fn stream_protocol_error() -> String {
+        "Stream cell shape is reserved but not yet wired — the streaming \
+         wire protocol (frame format, correlation IDs, backpressure, \
+         cancellation) hasn't been designed yet. Handlers MUST return \
+         Json/Binary/Handle until the protocol lands. See \
+         MODULE-ARCHITECTURE.md §5.1 + runtime::cell_shapes::StreamPlaceholder."
+            .to_string()
+    }
+
+    /// Canonical error message for handlers that try to return a Lambda
+    /// today. Same shape as [`Self::stream_protocol_error`].
+    pub fn lambda_protocol_error() -> String {
+        "Lambda cell shape is reserved but not yet wired — the lambda \
+         invocation protocol (curried-command dispatch, bound-params \
+         merge, return-shape propagation) hasn't been designed yet. \
+         Handlers MUST return Json/Binary/Handle until the protocol \
+         lands. See MODULE-ARCHITECTURE.md §5.1 + \
+         runtime::cell_shapes::LambdaPlaceholder."
+            .to_string()
     }
 }
 
@@ -465,5 +580,130 @@ mod tests {
             0,
             "no module subscribes to nothing/here — dispatcher walks zero"
         );
+    }
+
+    // ── CommandResult cell shape integration tests ─────────────────
+    //
+    // The cell shape unit tests live in
+    // `runtime::cell_shapes::tests` (HandleRef construction,
+    // serialization, distinct UUIDs, etc.). The tests below assert
+    // the integration between the cell shapes and `CommandResult` —
+    // the constructors + `to_json_value` projection that every
+    // wire-crossing site uses.
+
+    use crate::runtime::cell_shapes::{HandleRef, LambdaPlaceholder, StreamPlaceholder};
+    use serde_json::json;
+    use uuid::Uuid;
+
+    #[test]
+    fn json_to_json_value_returns_original() {
+        let v = json!({ "x": 1 });
+        let r = CommandResult::Json(v.clone());
+        assert_eq!(r.to_json_value().unwrap(), v);
+    }
+
+    #[test]
+    fn binary_to_json_value_returns_metadata_drops_bytes() {
+        // The Binary variant carries metadata + raw bytes; projecting
+        // to plain JSON drops the bytes and returns metadata. Callers
+        // who need the raw bytes match on the variant directly (e.g.,
+        // the IPC layer encodes them in the binary frame).
+        let metadata = json!({ "format": "pcm-16le", "sample_rate": 48_000 });
+        let r = CommandResult::Binary {
+            metadata: metadata.clone(),
+            data: vec![0u8, 1, 2, 3],
+        };
+        assert_eq!(r.to_json_value().unwrap(), metadata);
+    }
+
+    #[test]
+    fn handle_to_json_value_serializes_handle_ref() {
+        let id = Uuid::new_v4();
+        let r = CommandResult::handle("ai/inference", id, "ai::InferenceSession");
+        let json = r.to_json_value().expect("Handle must project to JSON");
+        assert_eq!(json["owner"], "ai/inference");
+        assert_eq!(json["type_tag"], "ai::InferenceSession");
+        assert!(json["id"].is_string(), "id must serialize as string");
+        assert_eq!(json["id"].as_str().unwrap(), id.to_string());
+        assert!(json["created_at_ms"].is_number());
+    }
+
+    #[test]
+    fn stream_to_json_value_returns_protocol_error() {
+        let r = CommandResult::Stream(StreamPlaceholder::new("corr-001"));
+        let err = r
+            .to_json_value()
+            .expect_err("Stream must NOT project as JSON — protocol not wired");
+        assert!(
+            err.contains("Stream cell shape is reserved"),
+            "error must name the cell shape so callers find the doc: {err}"
+        );
+        assert!(
+            err.contains("MODULE-ARCHITECTURE"),
+            "error must point at the canonical doc: {err}"
+        );
+    }
+
+    #[test]
+    fn lambda_to_json_value_returns_protocol_error() {
+        let r = CommandResult::Lambda(LambdaPlaceholder::new("ai/generate", json!({})));
+        let err = r
+            .to_json_value()
+            .expect_err("Lambda must NOT project as JSON — protocol not wired");
+        assert!(
+            err.contains("Lambda cell shape is reserved"),
+            "error must name the cell shape so callers find the doc: {err}"
+        );
+    }
+
+    #[test]
+    fn command_result_handle_constructor_matches_handle_ref_with_id() {
+        let id = Uuid::new_v4();
+        let r = CommandResult::handle("ai/inference", id, "ai::InferenceSession");
+        match r {
+            CommandResult::Handle(h) => {
+                assert_eq!(h.id, id);
+                assert_eq!(h.owner, "ai/inference");
+                assert_eq!(h.type_tag, "ai::InferenceSession");
+            }
+            other => panic!("expected Handle variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn command_result_protocol_errors_have_stable_wording() {
+        // The error wording is matched on by callers (the sentinel
+        // step builds its own step_err from these). Pin the prefix
+        // so future edits don't accidentally break matching code.
+        let stream_err = CommandResult::stream_protocol_error();
+        let lambda_err = CommandResult::lambda_protocol_error();
+        assert!(stream_err.starts_with("Stream cell shape is reserved"));
+        assert!(lambda_err.starts_with("Lambda cell shape is reserved"));
+        // Both should point at the architecture doc for context.
+        for err in [&stream_err, &lambda_err] {
+            assert!(
+                err.contains("MODULE-ARCHITECTURE"),
+                "error must point at the canonical doc: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn handle_ref_round_trips_through_command_result_serialization() {
+        // End-to-end pinning: a Handle returned by a Rust handler can
+        // be projected to JSON, sent over the wire, deserialized on the
+        // TS side as { owner, id, type_tag, created_at_ms }, echoed
+        // back as a param on a subsequent call, deserialized in Rust
+        // as HandleRef, and resolve to the same handle.
+        let id = Uuid::new_v4();
+        let original = HandleRef::with_id("ai/inference", id, "ai::InferenceSession");
+        // Mint a Handle result, project to JSON (wire crossing #1).
+        let r = CommandResult::Handle(original.clone());
+        let wire = r.to_json_value().unwrap();
+        // TS-side echo: serialize the JSON to a string and parse back.
+        let echoed = serde_json::to_string(&wire).unwrap();
+        let from_wire: HandleRef = serde_json::from_str(&echoed).unwrap();
+        assert_eq!(from_wire, original);
+        assert_eq!(from_wire.id, id);
     }
 }


### PR DESCRIPTION
## Summary

Per Joel:
> *"You get to refine the pattern with better knowledge, therefore improving elegance and reliability"*

Distill two primitives from the kinks the first real HandleRef consumer (PR #1490) had to handle inline, so every future consumer reaches for the substrate rather than reimplementing them.

## The primitives

### `HandleRef::expect_owned_by(owner, type_tag) → Result<Uuid, String>`

The canonical handle-validation entry point. Returns the inner UUID when owner + type_tag match; otherwise emits typed errors that name BOTH offender AND expected.

Owner-mismatch is checked first (owner determines routing) and the error explicitly hints at the grid-interceptor responsibility — diagnostic turns *"weird error"* into *"the interceptor misfired"* or *"this caller built a bogus handle"*.

Replaces ~12 lines of validation boilerplate per handle-consuming handler. Standardizes the error format across every module.

### `CommandRequest::handle_id_or_legacy(...)`

The single primitive shared by every additive migration of a stringly-typed id to a typed HandleRef. Walks two shapes:

1. envelope `handle` (new canonical) — validated via `expect_owned_by`, error prefixed with the command name
2. legacy string field on the params (back-compat)
3. neither → typed error naming BOTH supported shapes so the caller knows what to add

Returns the resolved id as a `String` — the historical wire format every consumer's state map is already keyed on.

Replaces ~25 lines of bespoke resolver per migration.

## The consumer-side win (data.rs)

| Before | After |
|---|---|
| 35-line `resolve_query_cursor_id` static fn + 2 callsites that invoke it | substrate primitive called directly at each callsite |
| Hand-formatted error strings duplicated across two modules' worth of cursors | Substrate-formatted, consistent across every module |
| Type-mismatch checks reinvented per consumer | One implementation, tested centrally |

Net: **-84 lines from data.rs**. The 411-line substrate addition is all either documentation, tested primitives, or new substrate-level tests — every future handle consumer benefits from this shrink, not just data.

## Test plan (48 pass, 1 ignored — onnxruntime, unrelated)

### New (`runtime::cell_shapes::tests`, 5)
- `expect_owned_by_returns_uuid_when_owner_and_type_match` — happy path
- `expect_owned_by_rejects_wrong_owner_with_both_values_named`
- `expect_owned_by_rejects_wrong_type_tag_with_both_values_named`
- `expect_owned_by_checks_owner_first_then_type` — pins routing-first precedence
- `expect_owned_by_error_includes_routing_hint` — pins grid-interceptor diagnostic in the error

### New (`runtime::command_envelope::tests`, 6)
- `handle_id_or_legacy_prefers_envelope_handle_when_both_present` — precedence
- `handle_id_or_legacy_falls_back_to_legacy_string_when_no_handle`
- `handle_id_or_legacy_errors_loud_when_neither_shape_provided`
- `handle_id_or_legacy_prepends_command_name_to_handle_validation_errors`
- `handle_id_or_legacy_propagates_type_mismatch_with_command_name`
- `handle_id_or_legacy_uses_canonical_uuid_string_for_handle_path` — pins the bridge-format invariant: handle-path and legacy-path resolve to the SAME string

### Pre-existing (`modules::data::tests`, all 17 still pass)
The 10 HandleRef migration tests + 7 pre-existing cursor tests exercise the SAME behavior they did before through the refactored callsites. No regression — net effect is the substrate now owns what data.rs used to own inline.

## What this PR explicitly does NOT do

- **Does NOT add `CommandResponse::with_handle_minted`** (auto-generate UUID). That case is one line; the primitive doesn't justify the API surface.
- **Does NOT add a `handle_type!(QueryCursor)` macro** that derives type_tag at compile time. Worth considering, but the `const QUERY_CURSOR_TYPE_TAG = "data::QueryCursor"` pattern is already cheap and explicit.
- **Does NOT touch Stream/Lambda placeholders.** Reserved-but-unused; their kinks will surface when they get real consumers.

## Stacks on

- PR #1485 (cell shapes — HandleRef defined, extended here)
- PR #1486 (envelope pattern — CommandRequest defined, extended here)
- PR #1490 (first real HandleRef consumer — the inline boilerplate this PR distills lived there)

## Why this PR matters

Substrate primitives mature fastest when they're informed by REAL consumer pain. PR #1490 added the first real HandleRef consumer; this PR folds what was learned back into the substrate. Every future module that mints or threads handles now starts from a higher floor.

This is the pattern Joel called out: **refine with better knowledge → elegance and reliability**. Subsequent migrations of stringly-typed-id surfaces (there will be more) get the resolver for free.
