### PR TITLE
docs(architecture): per-module design pages for chat, generator, data/cursors, airc/realtime-store

### DIFF
--- a/docs/architecture/AIRC-REALTIME-STORE-MODULE.md
+++ b/docs/architecture/AIRC-REALTIME-STORE-MODULE.md
@@ -1,0 +1,142 @@
+# `airc/realtime_store` — Design
+
+> **Scope**: this doc covers the in-memory realtime store — the Rust-side substrate that handles `airc/realtime-publish` and `airc/realtime-replay` before any external airc transport attaches. The broader airc module (queue scan, daemon transport, file transport) is out of scope here.
+>
+> **Status**: store shipped pre-session; concurrency stress tests + moment-of-truth precondition doc shipped in PR #1492.
+>
+> **File**: `src/workers/continuum-core/src/airc/realtime_store.rs`
+>
+> **Canonical reference**: [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md)
+
+## Role
+
+**Events** primitive substrate. Stores AIRC realtime envelopes with:
+- bounded per-room replay queue (default 2,000 events / room)
+- coalesced ephemeral presence (typing, thinking, listening — keyed; latest wins; auto-expires)
+- coalesced peer manifests (capability index; latest per peer; auto-expires)
+- subscription state (subscribe/unsubscribe/ack tracked per subscriber+topic)
+
+This is the **moment-of-truth substrate** for headless-Rust. Multi-persona chat lands here via `airc/realtime-publish`; persona inboxes drain here via cursor polling on `airc/realtime-replay`. The store is what makes chat → persona round-trip work without Node in the loop.
+
+The store is the **in-process** transport — when external airc attaches (daemon/file/queue), it routes around or in addition to this. For moment-of-truth, in-process is enough.
+
+## Command surface
+
+| Command | Handler in | Notes |
+|---|---|---|
+| `airc/realtime-publish` | `modules/airc.rs` | Validates envelope, calls `InMemoryAircRealtimeStore::publish` |
+| `airc/realtime-replay` | `modules/airc.rs` | Cursor-paginated read of room events + active presence/subscriptions/peer manifests/capability index |
+
+The store itself is a Rust trait (`AircRealtimeStore`) with one in-memory impl (`InMemoryAircRealtimeStore`). The trait shape:
+
+```rust
+pub trait AircRealtimeStore: Send + Sync {
+    fn publish(&self, params: AircRealtimePublishParams) -> Result<AircRealtimePublishResult, String>;
+    fn replay(&self, params: AircRealtimeReplayParams) -> Result<AircRealtimeReplayResult, String>;
+}
+```
+
+Both methods are sync. They run inside the airc module's `async fn handle_command`, but the store itself doesn't `.await` anything internally — pure in-memory ops under one mutex.
+
+## Cross-module dependencies
+
+**None** for the store itself. Consumers (chat/send, persona inbox subscribers, widgets) reach the store through the airc module's command surface, not by importing it directly. Substrate principle: modules talk via commands.
+
+## State model
+
+ONE module-wide `parking_lot::Mutex<AircRealtimeState>` protects all state:
+
+```rust
+struct AircRealtimeState {
+    rooms: HashMap<Uuid, VecDeque<StoredRealtimeEnvelope>>,   // per-room replay queue
+    room_lamports: HashMap<Uuid, u64>,                         // per-room Lamport counter
+    presence: HashMap<String, AircRealtimeEnvelope>,           // coalesced by presence key
+    peer_manifests: HashMap<String, AircRealtimeEnvelope>,     // coalesced by peer key
+    subscriptions: HashMap<String, AircSubscriptionEvent>,     // coalesced by subscriber/topic
+}
+```
+
+### Why a module-wide mutex (not per-room sharding)
+
+The store IS module-wide because per-room sharding adds complexity without changing the moment-of-truth correctness story. For 5–10 personas, mutex contention is sub-microsecond on uncontended in-memory ops — negligible. For 50+ personas it becomes a real bottleneck.
+
+**Future refinement (flagged in PR #1492, NOT scheduled)**: shard state by room_id:
+
+```rust
+struct AircRealtimeState {
+    rooms: DashMap<Uuid, Arc<parking_lot::Mutex<RoomState>>>,
+}
+```
+
+This would unblock multi-room throughput while keeping the same correctness contract. Not needed for moment-of-truth; the module-wide lock is the simplest substrate that meets the requirements.
+
+### Replay queue bound
+
+`DEFAULT_EVENTS_PER_ROOM = 2_000`. When a room's queue reaches the bound, oldest events get popped from the front. **Known limitation** (out of scope here): a replayer with a stale cursor whose Lamport is older than the queue's oldest entry silently misses events 6..99 if the queue starts at 100. Future PR can add a "did_truncate" hint or a "your-cursor-is-stale-please-resync" signal.
+
+### Coalesced presence + peer manifest pruning
+
+`prune_expired_presence(now_ms)` runs on every publish AND on every replay that passes a `now_ms` parameter. Presence events with `expires_at_ms < now_ms` get removed; same for peer manifests. Pruning under the same module-wide mutex keeps consistency.
+
+## Events emitted
+
+The store IS the event log — consumers replay from it rather than subscribing to publish-time emissions. The flow:
+
+1. Publisher calls `airc/realtime-publish` → store appends to room queue + updates Lamport
+2. Subscriber calls `airc/realtime-replay` with `after_cursor` → store returns events strictly after the cursor + new cursor for the next round
+
+This is the **cursor polling pattern** — the canonical way persona inboxes and widget subscribers drain the event stream.
+
+## Concurrency contract
+
+**Module-wide correctness** — all state mutations atomic under the parking_lot Mutex; per-room Lamport monotonicity holds; replay sees consistent snapshots; cursor polling never duplicates or loses events.
+
+### Pinned invariants (multi-thread tests in `airc::realtime_store::tests`)
+
+1. **`concurrent_publishes_to_same_room_lose_no_events_and_keep_lamports_contiguous`** — 64 concurrent publishers to GENERAL; final replay returns all 64; every Lamport in 1..=64 appears exactly once (no gaps, no duplicates from a race)
+2. **`concurrent_publishes_to_different_rooms_keep_independent_lamport_sequences`** — 60 publishers across 3 rooms; each room's final Lamport == 20; cross-room interleaving doesn't break per-room contiguity
+3. **`replay_during_concurrent_publish_observes_consistent_snapshot`** — 32 publishers + 8 replayers racing; each replayer's observed events are a consistent subset (no torn reads — no duplicates within one replay, no out-of-range timestamps); final replay returns all 32
+4. **`cursor_polling_during_concurrent_publish_never_loses_or_duplicates_events`** — 40 staggered publishers + 1 cursor-polling consumer; no duplicate event_ids in the observed set; every published event eventually observed
+
+All multi-thread with `worker_threads = 4`. PR #1492 codified these as moment-of-truth preconditions.
+
+### Lamport monotonicity guarantee
+
+Per-room Lamport is incremented under the module-wide mutex during each `push_replay`. Two concurrent publishes to the same room serialize through the mutex; one increments first, the other sees the next value. No race possible.
+
+### Cursor protocol contract
+
+The `AircReplayCursor` returned by `publish` (and at the tail of `replay`) is `{ room_id, lamport, event_id, observed_at_ms }`. A subsequent `replay` with `after_cursor = Some(c)` returns events where `c.strictly_before(event.cursor)` — strictly increasing Lamport order. No event served twice for the same cursor; no event skipped.
+
+## Migration notes
+
+**No TS predecessor.** Designed fresh in Rust as the in-process airc substrate. The wire shape (envelope / payload / delivery / replay cursor) is canonical from the start; the in-memory store implements the trait that future external transports also implement.
+
+## Kinks found
+
+**Concurrency invariants proven, throughput constraint flagged.**
+
+1. **Module-wide mutex serializes multi-room throughput.** All 4 concurrency tests pass with the current design (correctness holds), but the design serializes cross-room work unnecessarily. Future per-room sharding (DashMap<Uuid, Mutex<RoomState>>) is the natural evolution when persona count grows past ~10. Flagged in PR #1492 commit message + this doc; NOT blocking for moment-of-truth.
+
+2. **Stale cursor + replay queue bound** (known limitation, out of scope). A subscriber whose cursor lamport is older than the queue's oldest entry silently misses the pruned events. Future PR can add a `was_truncated: bool` hint to the replay result, or a sentinel error like "cursor stale, oldest available is N — resync from current snapshot." Not a concurrency bug; a substrate-contract gap.
+
+3. **Other transports unproven.** PR #1492 pins ONLY the in-memory transport. Daemon-attached / file-store / queue-client transports get their own concurrency audit when they become hot paths.
+
+### What this gives the moment-of-truth test
+
+| Risk | Pinned by test |
+|---|---|
+| Multi-persona chat publishes lose events | ✅ `concurrent_publishes_to_same_room_lose_no_events_...` |
+| Per-room Lamport breaks under cross-room interleaving | ✅ `..._different_rooms_keep_independent_lamport_sequences` |
+| Replay during publish sees torn/partial state | ✅ `replay_during_concurrent_publish_observes_consistent_snapshot` |
+| Cursor polling gives the same event twice or skips one | ✅ `cursor_polling_during_concurrent_publish_never_loses_or_duplicates_events` |
+
+The four together guarantee: **chat → airc → persona inbox round-trip works correctly under multi-persona load.** That's the moment-of-truth precondition.
+
+## References
+
+- PR #1492 — Concurrency stress tests (4 tests pinning moment-of-truth invariants)
+- `src/workers/continuum-core/src/airc/realtime.rs` — Envelope + cursor + presence + manifest type defs
+- `src/workers/continuum-core/src/modules/airc.rs` — `airc/realtime-publish` + `airc/realtime-replay` command handlers
+- [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md §4](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md) — concurrency doctrine
+- Memory: `headless-rust-must-work-soon`, `three-primitives-commands-events-persona`

--- a/docs/architecture/CHAT-MODULE.md
+++ b/docs/architecture/CHAT-MODULE.md
@@ -1,0 +1,125 @@
+# `chat` module — Design
+
+> **Status**: chat/poll + chat/send shipped in PR #1489 (Rust); chat/analyze + chat/export still on TS pending follow-up migrations.
+>
+> **File**: `src/workers/continuum-core/src/modules/chat/` (mod.rs + types.rs)
+>
+> **Canonical reference**: [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md)
+
+## Role
+
+**Persona's primary I/O surface.** Per the three-primitive framing ([COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md §1](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md)), chat serves **Persona** by providing **Commands** (chat/send, chat/poll) and indirectly **Events** (via airc realtime broadcasts on send).
+
+Personas subscribe to airc room events to see incoming messages, then call `chat/send` to respond. Widgets connect to the same surface (subscribe + execute) — chat is the canonical example of a module that bridges human and AI consumers through identical primitives.
+
+## Command surface
+
+| Command | Params type | Result type | Status | Notes |
+|---|---|---|---|---|
+| `chat/poll` | `ChatPollParams` | `ChatPollResult` | ✅ Rust (PR #1489) | Read messages by room / anchor / limit |
+| `chat/send` | `ChatSendParams` | `ChatSendResult` | ✅ Rust (PR #1489) | Write message + broadcast (data-first dual-write) |
+| `chat/analyze` | TBD | TBD | ❌ TS stub | Pending migration with HandleRef + event streaming (field manual §5.3) |
+| `chat/export` | TBD | TBD | ❌ TS stub | Pending migration |
+
+Both `chat/*` (canonical) and `collaboration/chat/*` (legacy) prefixes route to this module — consumers migrate at their own pace.
+
+## Cross-module dependencies
+
+- **`data/query`** — chat/poll reads from `chat_messages` collection
+- **`data/create`** — chat/send writes to `chat_messages` (the persistence primary)
+- **`airc/realtime-publish`** — chat/send broadcasts to airc (the delivery secondary)
+
+All cross-module calls go through `executor.execute_json(...)`. Chat depends on data + airc through the command surface only — no Rust-type imports across module boundaries.
+
+## State model
+
+**Stateless.** The `ChatModule` struct carries only an optional executor override behind an `RwLock<Option<Arc<CommandExecutor>>>` for test injection. No per-resource locks; no in-memory caches; no shared mutable state across calls.
+
+```rust
+pub struct ChatModule {
+    executor_override: RwLock<Option<Arc<CommandExecutor>>>,
+}
+```
+
+If future migrations make chat stateful (e.g., a chat/analyze HandleRef map), the per-resource lock pattern from [field manual §4.1](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md) applies. Today's surface doesn't need it.
+
+## Events emitted
+
+**Indirect via airc.** chat/send constructs an `AircRealtimeEnvelope` with `payload.kind = "existing_schema"` + `schema = "chat_transcript"` and publishes via `airc/realtime-publish`. Subscribers on the room (other personas, widgets, peers on the grid) see the message through airc's replay store.
+
+The envelope's `inline` payload carries `{ messageId, text, senderId, replyToId }` — enough for subscribers to render the message without needing a separate data/query lookup.
+
+**Future events** (when chat/analyze migrates per field manual §5.3):
+- `chat:analyze:finding` — per-finding emission during a run
+- `chat:analyze:complete` — run terminal event
+- `chat:analyze:cancelled` — caller-initiated abort
+
+## Concurrency contract
+
+**Safe by construction.** The handler is `&self`, mints a fresh `Uuid` per send, and holds no shared mutable state. Multiple personas calling `chat/send` concurrently produce distinct messages with distinct ids; no per-call interference.
+
+### Pinned invariants (multi-thread tests in `chat::tests`)
+
+1. **`send_under_concurrent_load_stores_all_messages_with_distinct_ids`** — 50 concurrent sends; every message stored, every id distinct, stored set ≡ returned set (no losses, no phantoms)
+2. **`send_preserves_per_call_ordering_under_concurrent_load`** — 25 concurrent sends; per-call `data/create` MUST precede per-call `airc/realtime-publish` across the interleaved global log
+3. **`send_isolates_mixed_outcomes_under_concurrent_load`** — 30 concurrent sends with half airc-failing; each call's `warning` references THIS call's `message_id`, no cross-contamination
+4. **`poll_isolates_results_under_concurrent_load`** — 30 concurrent polls each targeting a different room; every task receives ITS OWN room's result
+
+Every test runs `flavor = "multi_thread", worker_threads = 4` so tasks preempt across OS threads. Single-threaded tokio would silently serialize and pass even if the handler had a data race.
+
+### Dual-write partial-failure semantics (chat/send)
+
+| Primary (data) | Secondary (airc) | Handler returns |
+|---|---|---|
+| ok | ok | `Ok(ChatSendResult { message_id, event_id: Some(...), warning: None })` |
+| ok | fail | `Ok(ChatSendResult { message_id, event_id: None, warning: Some("airc/realtime-publish failed: ...") })` — degraded success |
+| fail | — | `Err("chat/send: data/create failed: ...")` — secondary NEVER called |
+
+**Data-first ordering** is the invariant that prevents bad-divergence (peers seeing a message the node didn't store). Pinned by `send_calls_data_before_airc`.
+
+**airc-only failure is NOT command-level failure.** The message IS in the local store; consumers see it via chat/poll; a future retry/sync mechanism heals the broadcast. The `warning` field is the substrate's canonical shape for degraded success.
+
+## Migration notes
+
+**Rethink-not-port applied** per [field manual §5](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md):
+
+| TS shape (`ChatSendServerCommand`) | Rust rethink | Why |
+|---|---|---|
+| Took `room: string` and resolved name → uuid inside the handler | Takes already-resolved `room_id: Uuid` | Name resolution belongs to caller/CLI (or future `channel/resolve` command) — kernel handler stays compositional |
+| Sender priority chain (explicit → owner → fallback) inside handler | Takes already-resolved `sender_id: Uuid` | Same — identity resolution belongs upstream |
+| Returned `{ ok, eventId, roomId, error? }` with `eventId` always present | Returns `{ messageId, eventId?, warning? }` with `eventId` ONLY when broadcast succeeded | Degraded success has its own shape; caller distinguishes "stored + broadcast" from "stored only" |
+| Synchronous full media externalization (base64 → blob storage) inside handler | Media externalization **deferred** | First migration scopes to the dual-write substrate stress; media is its own kink-finder |
+| Vision pre-warming fire-and-forget | **Deferred** | Same scoping; will return when vision module migrates |
+
+The command-name surface is preserved (`collaboration/chat/send` + `chat/send` both work) so TS consumers see no break.
+
+### Deferred for follow-up PRs
+
+- chat/analyze — migrate with HandleRef + `chat:analyze:*` events per field manual §5.3
+- chat/export — straightforward read+format; low priority
+- Sender resolution priority chain — when user module migrates
+- Room name resolution — when channel module gets a `channel/resolve` command
+- Media externalization — separate scope; needs MediaBlobService rethink
+- Vision pre-warming — when vision module migrates
+- Reply-to threading metadata richer than `replyToId` — when thread tracking design lands
+- **Idempotency**: a retried `chat/send` currently produces two stored messages. Matches today's TS behavior. Future PR can add `client_dedup_id` + TTL'd dedup map; the substrate is ready for it but the design is its own scope.
+
+## Kinks found
+
+None at correctness level — the dual-write design + multi-thread tests caught the design space before it caused bugs. Substrate gaps flagged for potential future refinement:
+
+1. **Hand-rolled airc envelope JSON.** chat hand-codes the `json!({...})` for `airc/realtime-publish`. If a second module needs to publish to airc from Rust, an `airc::realtime_publish_envelope(...)` builder would distill the wire shape. Flagged in PR #1489 commit message — waiting for second consumer before distilling.
+
+2. **No typed cross-module command call.** chat uses `executor.execute_json(...)` with raw JSON in/out and parses responses via `.get("success")`. A typed `executor.execute_typed::<P, R>(...)` would catch wire-shape drift at compile time. Same shape as the `handle_id_or_legacy` refinement (PR #1491) solved for handle resolution. Flag for if/when a second consumer appears.
+
+3. **No transaction primitive across modules.** chat hand-codes the data-first / airc-best-effort ordering inline. A substrate-level `dual_write!(primary => ..., best_effort => ...)` macro could centralize the partial-failure pattern if a second consumer appears.
+
+The pattern across all three: **wait for the second consumer before distilling into substrate.** Single consumer = interesting; second consumer = pattern. Same rule that produced `expect_owned_by` + `handle_id_or_legacy` from the data-query consumer (PR #1491).
+
+## References
+
+- PR #1489 — ChatModule (chat/poll + chat/send + concurrency tests)
+- PR #1486 — `CommandRequest<P>` / `CommandResponse<T>` envelopes used here
+- PR #1485 — Cell shapes (HandleRef ready for chat/analyze migration)
+- [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md) §3 (Module Design Template), §4 (Concurrency doctrine), §5 (Migration playbook)
+- Memory: `three-primitives-commands-events-persona`, `chat-extracts-to-airc`

--- a/docs/architecture/DATA-CURSORS-MODULE.md
+++ b/docs/architecture/DATA-CURSORS-MODULE.md
@@ -1,0 +1,164 @@
+# `data/query` cursors — Design
+
+> **Scope**: this doc covers the cursor surface only — `data/query-open` / `data/query-next` / `data/query-close`. The data module has other concerns (CRUD, vector search, migration, batch ops) which are out of scope here; each will get its own design page as it migrates.
+>
+> **Status**: HandleRef migration + per-cursor mutex fix shipped in PR #1490.
+>
+> **File**: `src/workers/continuum-core/src/modules/data.rs` (single-file module; cursor surface is one of several concerns)
+>
+> **Canonical reference**: [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md)
+
+## Role
+
+**Commands** primitive, serving **persona / widget consumers that need bounded pagination over arbitrary collections**. The cursor surface is the **first real consumer of HandleRef** — the mint-handle-then-poll pattern Joel called out for inference / training / hosting / ORM. Validating it on the data layer proved the substrate's promise before any other module reached for it.
+
+## Command surface
+
+| Command | Params type | Result type | Role |
+|---|---|---|---|
+| `data/query-open` | `QueryOpenParams` | (returns `{success, data: {queryId, ...}, handle}`) | Mint a cursor — returns BOTH the typed HandleRef AND the legacy queryId string for the same underlying UUID |
+| `data/query-next` | `CommandRequest<QueryNextParams>` (handle OR queryId) | (returns `{success, data: {items, pageNumber, ...}}`) | Advance the cursor; resolve cursor id from envelope handle (preferred) or legacy field (back-compat) |
+| `data/query-close` | `CommandRequest<QueryCloseParams>` (handle OR queryId) | (returns `{success, queryId}`) | Release cursor state |
+
+### Dual-shape resolution
+
+Per [field manual §2.5](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md), every additive migration of a stringly-typed id to a typed HandleRef uses one resolver:
+
+```rust
+let cursor_id = req.handle_id_or_legacy(
+    DATA_MODULE_OWNER,        // "data"
+    QUERY_CURSOR_TYPE_TAG,    // "data::QueryCursor"
+    "queryId",
+    &req.params.query_id,
+    "data/query-next",
+)?;
+```
+
+- **Envelope `handle`** present → validated via `HandleRef::expect_owned_by`, returns inner UUID as string
+- **Legacy `queryId`** string present → returned as-is
+- **Neither** → typed error naming BOTH supported shapes
+- **Both** → envelope wins (so consumers mid-migration don't diverge from new consumers)
+
+## Cross-module dependencies
+
+- **`orm::adapter::StorageAdapter`** (internal to the data module's substrate) — actual SQLite/Postgres execution
+- **`orm::query::{StorageQuery, SortSpec, FieldFilter}`** — typed query AST
+
+No cross-module command calls — the cursor surface is data-internal.
+
+## State model
+
+Per-cursor state under per-cursor lock:
+
+```rust
+pub struct DataModule {
+    // ... other fields for CRUD, vector, migration ...
+    paginated_queries: DashMap<String, Arc<tokio::sync::Mutex<PaginatedQueryState>>>,
+}
+
+struct PaginatedQueryState {
+    db_path: String,
+    collection: String,
+    filter: Option<HashMap<String, FieldFilter>>,
+    sort: Option<Vec<SortSpec>>,
+    page_size: usize,
+    total_count: u64,
+    current_page: usize,
+    cursor_id: Option<String>,
+    has_more: bool,
+    created_at: Instant,
+}
+```
+
+DashMap key is the UUID string (canonical form). The HandleRef carries the same UUID; `to_string()` at the lookup boundary bridges the two representations.
+
+**Lifetime**: producer-owned. Cursors live until `data/query-close` removes them or (future) a TTL eviction sweep fires. No global handle registry — each cursor's lifetime belongs to this module's state map.
+
+## Events emitted
+
+**None.** The cursor surface is request/response only.
+
+## Concurrency contract
+
+### The bug that drove the design
+
+Original implementation (pre-PR #1490):
+
+```rust
+let snapshot = self.paginated_queries.get(&cursor_id).map(|s| (s.current_page, ...));
+// ^ DashMap shard lock released HERE
+// ... async adapter.query() runs with NO lock ...
+self.paginated_queries.get_mut(&cursor_id).map(|mut s| s.current_page += 1);
+```
+
+Under N concurrent `query-next` calls on the SAME cursor (canonical multi-persona scenario, or one persona retrying), every call read `current_page=0`, queried the same first page, wrote `current_page=1`. 8 concurrent callers got `pageNumber=1` back; cursor advanced by 1.
+
+Caught by `same_cursor_concurrent_next_does_not_corrupt_state` (PR #1490) — the test panicked with *"page 1 served 8 times — the cursor advanced through it MORE than once, indicating a lost serialization"*.
+
+### The fix: per-cursor `tokio::sync::Mutex`
+
+```rust
+let state_lock = self.paginated_queries.get(&cursor_id)
+    .map(|entry| entry.value().clone())   // cheap Arc clone out of shard lock
+    .ok_or("handle not found ...")?;
+let mut state = state_lock.lock().await;  // serialize SAME-cursor concurrent calls
+// ... read state, run adapter query, update state — all under the lock ...
+```
+
+- **Different cursors stay fully parallel** — DashMap's per-shard locking; each cursor has its own Mutex
+- **Same cursor serializes** — each non-tail page served at most once; cursor advances atomically
+
+### Pinned invariants
+
+1. **`cursors_are_isolated_under_concurrent_open_and_next`** — 20 personas open distinct cursors concurrently; every cursor mints a distinct UUID; each cursor's first page returns its own pageSize items
+2. **`same_cursor_concurrent_next_does_not_corrupt_state`** — 8 concurrent next-calls on the SAME cursor; each non-tail page served EXACTLY once (regression net for the read-then-async-write race)
+3. **`query_open_returns_handle_alongside_legacy_query_id`** — additive migration: legacy queryId AND typed handle in same response
+4. **`query_next_rejects_handle_with_wrong_owner`** — cross-module handle confusion fails loud
+5. **`query_next_rejects_handle_with_wrong_type_tag`** — within-module cross-resource confusion fails loud
+6. **`query_next_with_unknown_handle_returns_handle_not_found`** — stale handle typed error with cause hints
+7. **`full_round_trip_open_next_close_via_handles_only`** — end-to-end through the new canonical shape, 12 rows / 3 pages
+
+All multi-thread tests use `flavor = "multi_thread", worker_threads = 4`.
+
+### `query-close` race
+
+`DashMap.remove()` is atomic. If a concurrent `query-next` holds the `Arc<Mutex>` mid-flight when `query-close` fires, the Arc keeps the Mutex alive; the next's mutation succeeds against an orphaned state map (never read again). From the caller's view: close said success; in-flight next returns its now-meaningless page; cursor unreachable for subsequent calls. Benign — callers shouldn't race close with next.
+
+## Migration notes
+
+**Migrated in PR #1490** from a hand-rolled string-id pattern to typed HandleRef. The migration was **additive** — the legacy `queryId` field stays in responses and inputs so existing TS consumers see no break. A follow-up drops `queryId` once every consumer threads the handle.
+
+### Rethink-vs-port outcomes
+
+| TS shape | Rust rethink | Why |
+|---|---|---|
+| `queryId: string` returned at top level | `queryId` nested in `data.{...}` PLUS top-level `handle: HandleRef` | Additive — legacy callers still parse `response.data.queryId`; new callers thread the typed handle |
+| `{queryId: "..."}` flat in next/close inputs | `CommandRequest` envelope with `handle: HandleRef` OR legacy `queryId` field | Same — dual-shape during migration window |
+| Generic "Query X not found" error | "handle not found — cursor X is unknown ... may have been closed via data/query-close, evicted by future TTL ..." | Callers self-diagnose without grepping source |
+| No owner/type validation | `HandleRef::expect_owned_by` validates owner first (routing) then type_tag (within-module discriminator); both errors name offender + expected | Cross-module handle confusion impossible to detect with bare strings; typed HandleRef makes it impossible to miss |
+| Empty params crashed with "missing field" | Both `handle` and `queryId` optional; resolver fails loud naming BOTH supported shapes | Empty case is now reachable; user-friendly diagnostic instead of serde panic |
+
+## Kinks found
+
+**Two real bugs, both caught by the multi-thread concurrency tests before merge:**
+
+1. **Read-then-async-then-write race** (the page-1-served-8-times bug). Fix: per-cursor `tokio::sync::Mutex`. Doctrine: every ServiceModule holding per-resource mutable state across `.await` MUST use per-resource locks (field manual §4.1).
+
+2. **Bare-string handles silenced cross-module routing bugs.** A handle minted by module X reaching module Y's handler would silently miss in Y's state map. Fix: typed `HandleRef::expect_owned_by` validates owner+type_tag, fails loud with diagnostic naming offender+expected. Substrate refinement landed in PR #1491.
+
+**Substrate refinements distilled from this consumer** (PR #1491):
+
+- `HandleRef::expect_owned_by(owner, type_tag) → Result<Uuid, String>` — canonical validation
+- `CommandRequest::handle_id_or_legacy(...)` — dual-shape resolver for any migration
+
+Both replaced ~35 lines of inline boilerplate per future migration with one method call each. The data cursor migration was the proving ground — refinements that came out of it benefit every future consumer.
+
+## References
+
+- PR #1490 — HandleRef migration + per-cursor mutex fix + concurrency tests
+- PR #1491 — `expect_owned_by` + `handle_id_or_legacy` distilled from the cursor consumer
+- PR #1485 — Cell shapes (HandleRef definition)
+- PR #1486 — `CommandRequest<P>` / `CommandResponse<T>` envelopes
+- [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md §2.3, §2.4, §2.5](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md) — HandleRef, expect_owned_by, handle_id_or_legacy
+- [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md §4.1](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md) — per-resource locks
+- [ORM-PHASE-2-DESIGN.md](ORM-PHASE-2-DESIGN.md) — broader ORM context the cursor surface lives in

--- a/docs/architecture/GENERATOR-MODULE.md
+++ b/docs/architecture/GENERATOR-MODULE.md
@@ -1,0 +1,127 @@
+# `generator` module — Design
+
+> **Status**: v1 shipped in PR #1487 (recursive bootstrap); v2 enriched scaffold in PR #1494 (matches Module Design Template).
+>
+> **File**: `src/workers/continuum-core/src/modules/generator/` (mod.rs + types.rs + templates.rs)
+>
+> **Canonical reference**: [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md)
+
+## Role
+
+**Commands** primitive, serving **architects + AI personas scaffolding new functionality**. Per Joel 2026-05-30:
+
+> *"We developed a generator so we could manufacture these patterns for new commands modules etc, which itself was a command. Meta."*
+
+The generator IS a module; the things it creates are modules; every operation it performs is a command. The system describes itself in its own terms — the recursive bootstrap.
+
+After PR #1494 (v2), authoring a new ServiceModule means running ONE command:
+
+```bash
+./jtag generate/module --name "chat_analyze" --commands "..." --stateful
+```
+
+…then filling in handler bodies. All envelope wiring, typed Params/Result skeletons, concurrency test scaffold, DESIGN.md skeleton, per-resource lock pattern, and ts-rs annotations are emitted automatically.
+
+## Command surface
+
+| Command | Params type | Result type | Status |
+|---|---|---|---|
+| `generate/module` | `GenerateModuleParams` | `GenerateModuleResult` | ✅ Rust (PR #1487 + #1494) |
+| `generate/command` (planned) | — | — | ❌ Not yet — add a new command to an existing module |
+| `generate/refresh` (planned) | — | — | ❌ Not yet — re-scan modules tree + refresh manifests/barrels |
+
+### `generate/module` spec
+
+Params:
+- `name: String` — lowercase ASCII identifier (validated; becomes Rust struct name + directory name)
+- `description: String` — embedded in mod.rs docstring + README + DESIGN.md
+- `commands: Vec<String>` — each becomes a dispatch arm + typed handler method + Params/Result type
+- `events_subscribed: Vec<String>` — wired into `ModuleConfig::event_subscriptions`
+- `events_published: Vec<String>` — documented in mod.rs docstring + DESIGN.md (no runtime wiring)
+- `priority: PrioritySpec` — one of `Realtime` / `High` / `Normal` / `Background`
+- `force: bool` — overwrite existing directory
+- `stateful: bool` — opt in to per-resource lock scaffold (DashMap + tokio Mutex + helper + concurrency test)
+
+Output (4 files per generation):
+- `mod.rs` — ServiceModule impl with typed envelope dispatch + handler methods + concurrency test
+- `types.rs` — `<Cmd>Params` / `<Cmd>Result` pair per declared command with `#[derive(TS)]`
+- `DESIGN.md` — per-module design skeleton with required 8 sections
+- `README.md` — author-facing summary + wire-up reminder
+
+## Cross-module dependencies
+
+**None.** Pure filesystem operations + template rendering. The generator is self-contained — it doesn't call any other module.
+
+## State model
+
+**Per-name locks** for the generation operation:
+
+```rust
+pub struct GeneratorModule {
+    workspace_root: Option<PathBuf>,
+    name_locks: DashMap<String, Arc<std::sync::Mutex<()>>>,
+}
+```
+
+`std::sync::Mutex` (not `tokio::sync`) because the protected critical section is purely synchronous filesystem I/O — no `.await` inside the lock. Blocking the tokio worker for the brief mkdir + 4 file writes is correct and avoids cascading the API into async.
+
+Lock entries are never evicted — module names are bounded (no unbounded production stream of unique names) and each entry is ~50 bytes. If memory ever matters, a TTL scan can be added without changing the protocol.
+
+## Events emitted
+
+**None.** Filesystem operations are the side effect.
+
+## Concurrency contract
+
+**Per-name lock** serializes concurrent same-name `generate/module` calls; different names stay fully parallel via DashMap's per-shard locking.
+
+### Pinned invariants (multi-thread tests)
+
+1. **`same_name_concurrent_generation_without_force_yields_one_winner`** — 8 racers, same name, no force; exactly ONE wins, 7 fail loud with "already exists" + escape hatch hint
+2. **`same_name_concurrent_generation_with_force_produces_consistent_final_state`** — 8 racers, same name, force=true; both files (mod.rs + README.md) carry the SAME `MARKER-XX` proving they came from ONE generation round (no torn state)
+3. **`different_names_concurrent_generation_runs_fully_parallel`** — 12 racers with distinct names, all succeed, each module's files distinct, lock map has 12 entries
+
+All run `flavor = "multi_thread", worker_threads = 4`.
+
+### Without the per-name lock (the bug it prevents)
+
+Two parallel callers with the same name and different params would:
+- Both call `target_dir.exists()` and see false
+- Both call `create_dir_all` (idempotent — both succeed)
+- Both write all 4 files in interleaved order
+- Last write wins per file → on-disk state has mod.rs from caller A + README.md from caller B (silent torn state)
+
+The friendly "already exists" error never fires; the corruption is silent.
+
+## Migration notes
+
+**No TS predecessor.** Designed fresh in Rust per the substrate doctrine. The generator's wire shape is the rethink — there was nothing to port.
+
+### v1 → v2 (PR #1487 → PR #1494)
+
+v1 produced 2 files (mod.rs + README.md) with raw-`Err` dispatch arms. Authors had to hand-author types.rs, the typed envelope wiring, the test module, the concurrency stress-test scaffold, and the DESIGN.md.
+
+v2 produces 4 files matching [the Module Design Template](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md). Author fills in ONE line per command (the Err body) + adds typed fields to Params/Result + writes the DESIGN.md prose. That's it.
+
+The v2 enrichment was driven by the substrate work in PRs #1485 (cell shapes) + #1486 (envelopes) + #1490–#1492 (concurrency doctrine). The generator now encodes those patterns automatically.
+
+## Kinks found
+
+1. **Same-name race silenced the friendly error.** Initial v1 impl had a race window between `exists()` check and `create_dir_all`. Two concurrent callers with the same name both passed the check, both created, both wrote — the "already exists" friendly error never fired. **Fix**: per-name `std::sync::Mutex` held across the entire exists/mkdir/write sequence (PR #1487 + concurrency test that caught it pre-merge).
+
+2. **Same-name race with force=true could torn-write.** Even with force, two concurrent racers' files could interleave (mod.rs from A, README from B). **Fix**: same per-name lock; force-mode writes serialize to ONE complete generation round per caller, with the second caller's writes overwriting the first cleanly. Pinned by the MARKER test.
+
+3. **v1's bare-`Err` dispatch carried no envelope wiring.** Every author writing a real handler had to convert raw `Err("not yet implemented")` arms into proper `CommandRequest::from_value` + typed handler + `CommandResponse::ok(...).into_command_result()`. **Fix in v2**: emit the envelope wiring + typed handler stubs directly — author only replaces the inner Err body.
+
+### Substrate refinements not needed yet
+
+The generator's surface is narrow (one command, four files emitted). It hasn't surfaced kinks that require new substrate primitives. If `generate/command` adds the "modify an existing module" pattern, AST-level parsing may surface design decisions (which Rust parser? `syn`? handwritten?) — flagged for then.
+
+## References
+
+- PR #1487 — v1 GeneratorModule (recursive bootstrap base + per-name lock fix)
+- PR #1494 — v2 enriched scaffold (matches Module Design Template)
+- PR #1493 — Field manual (the template v2 emits)
+- [MODULE-ARCHITECTURE.md §10](MODULE-ARCHITECTURE.md) — recursive bootstrap doctrine
+- [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md §3 + §6](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md) — Module Design Template + Generator usage
+- Memory: `three-primitives-commands-events-persona`, `rethink-dont-port-commands-to-rust`


### PR DESCRIPTION
## Summary

Step 3 of the doc set Joel approved on 2026-05-30 ("Yeah let's do it. In order"):

1. ✅ Field manual codifying substrate ([PR #1493](https://github.com/CambrianTech/continuum/pull/1493))
2. ✅ Generator v2 emitting modules per the template ([PR #1494](https://github.com/CambrianTech/continuum/pull/1494))
3. **This PR**: per-module design pages for everything we've built
4. (Next) MODULE-CATALOG.md update marking which modules are alive in Rust

Each doc follows the canonical 8-section template from the field manual (Role / Command surface / Cross-module deps / State model / Events emitted / Concurrency contract / Migration notes / Kinks found).

## What this PR adds

| Doc | Lines | Subject status |
|---|---|---|
| `CHAT-MODULE.md` | 125 | chat/poll + chat/send Rust ([#1489](https://github.com/CambrianTech/continuum/pull/1489)); analyze/export still TS |
| `GENERATOR-MODULE.md` | 127 | v1 + v2 ([#1487](https://github.com/CambrianTech/continuum/pull/1487) + [#1494](https://github.com/CambrianTech/continuum/pull/1494)) — recursive bootstrap |
| `DATA-CURSORS-MODULE.md` | 164 | data/query-{open,next,close} migrated to HandleRef ([#1490](https://github.com/CambrianTech/continuum/pull/1490)) |
| `AIRC-REALTIME-STORE-MODULE.md` | 142 | In-memory store + 4 moment-of-truth concurrency tests ([#1492](https://github.com/CambrianTech/continuum/pull/1492)) |
| **Total** | **558** | |

## Why under `docs/architecture/` (not next to mod.rs)

Field manual §3 prescribes "DESIGN.md next to mod.rs" for canonical directory modules. For this PR:
- `chat/` and `generator/` directories only exist on unmerged PR branches (#1489 / #1487) — putting docs there would couple this PR to that chain
- `data` and `airc/realtime_store` are single-file modules — no natural "next to mod.rs" location

Resolution: all four go under `docs/architecture/` following existing convention (PERSONA-COGNITION-CONTRACT.md, ORM-PHASE-2-DESIGN.md style). When the open PR chain merges, future PRs CAN move `chat/DESIGN.md` + `generator/DESIGN.md` into their respective directories if preferred — content stays the same; only the file path changes. Single-file module docs stay under `docs/architecture/` indefinitely.

## What each doc captures

### CHAT-MODULE.md
- chat/send dual-write semantics + warning-field degraded-success pattern
- All 11 concurrency tests pinning multi-persona invariants
- TS→Rust rethink table (resolved UUIDs only, no name resolution in kernel)
- Three flagged substrate kinks waiting for second consumers (envelope builder, typed cross-module call, dual-write macro)

### GENERATOR-MODULE.md
- Recursive bootstrap doctrine + v1→v2 evolution
- The two same-name race bugs the per-name lock caught
- Why `std::sync::Mutex` over `tokio::sync::Mutex` (sync filesystem critical section)

### DATA-CURSORS-MODULE.md
- The read-then-async-then-write race story ("page 1 served 8 times" bug)
- Dual-shape (handle OR queryId) resolver + additive migration story
- All seven HandleRef migration tests pinning invariants
- Substrate refinements distilled to PR #1491 (`expect_owned_by`, `handle_id_or_legacy`)

### AIRC-REALTIME-STORE-MODULE.md
- Module-wide mutex + correctness-vs-throughput rationale
- Four moment-of-truth concurrency tests
- Flagged per-room sharding refinement (when persona count grows)
- Known stale-cursor + replay-bound limitation (out of scope but flagged)

## What this PR explicitly does NOT do

- **Does NOT touch any code** — pure documentation
- **Does NOT move chat/generator DESIGN.md into module directories** — see above
- **Does NOT cover the full data module** — only the cursor surface. CRUD / vector / migration / batch each get their own design page as they migrate
- **Does NOT cover the broader airc module** — only the in-memory realtime store. queue-scan / daemon transport / file transport get their own audit when they become hot
- **Does NOT ship MODULE-CATALOG.md update** — step 4, separate PR

## Test plan

- [ ] Docs render on GitHub; section anchors resolve
- [ ] Cross-references (PRs, field manual, other architecture docs) all resolve
- [ ] Internal links between the four docs work
- [ ] Each doc's 8 required sections per field manual §3 are present

## Stacks on

`canary` directly — pure documentation PR.

## References

- [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md](https://github.com/CambrianTech/continuum/blob/canary/docs/architecture/COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md) (PR #1493) — canonical 8-section template
- PRs #1487, #1489, #1490, #1492, #1494 — modules being documented
