### PR TITLE
docs(architecture): MODULE-CATALOG.md — mark which modules are alive in Rust (step 4 of 4)

### DIFF
--- a/docs/architecture/MODULE-CATALOG.md
+++ b/docs/architecture/MODULE-CATALOG.md
@@ -2,11 +2,50 @@
 
 > **Premise** (Joel, 2026-05-16): *"The most effective designs are fundamentally simple. Every concern is hundreds of lines, and yet everything is performant. How do we make the others perform like CBAR in Continuum?"*
 >
-> **Companion to** [CBAR-SUBSTRATE-ARCHITECTURE.md](CBAR-SUBSTRATE-ARCHITECTURE.md) (the substrate floor), [GENOME-FOUNDRY-SENTINEL.md](GENOME-FOUNDRY-SENTINEL.md) (the artifact economy), and [PERSONA-COGNITION-CONTRACT.md](PERSONA-COGNITION-CONTRACT.md) (the cognition contract).
+> **Companion to** [CBAR-SUBSTRATE-ARCHITECTURE.md](CBAR-SUBSTRATE-ARCHITECTURE.md) (the substrate floor), [GENOME-FOUNDRY-SENTINEL.md](GENOME-FOUNDRY-SENTINEL.md) (the artifact economy), [PERSONA-COGNITION-CONTRACT.md](PERSONA-COGNITION-CONTRACT.md) (the cognition contract), and [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md) (the module-author field manual).
 >
-> **Status.** Design proposal. Per-module Rust files target `src/workers/continuum-core/src/` under the indicated directories. Implementation lands per ALPHA-GAP lanes.
+> **Status.** Most entries are design proposals targeting per-module Rust files under `src/workers/continuum-core/src/`. **Some are now live in Rust** — see [§0 below](#0-currently-live-in-rust). Implementation lands per ALPHA-GAP lanes.
 
 This document is the **catalog**. Every Continuum concern — RAG, persona, memory, voice, vision, inference, sentinel, foundry, federation, live, AIRC bridge, governor, and the rest — shown as a focused `RuntimeModule`. Each entry names what the module *needs* (subscriptions), what it *provides* (emissions), its resource class + target, its cadence, a screen-or-less handler sketch, and an honest line-count estimate.
+
+## §0. Currently Live In Rust
+
+As of 2026-05-30, the following modules ship Rust implementations. Each has a per-module design doc capturing role, command surface, state model, concurrency contract, migration notes, and kinks found. New entries land here as additional modules clear the [field manual §7 acceptance criteria](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md).
+
+| Module | What ships | PR | Design doc | Concurrency proven |
+|---|---|---|---|---|
+| **`chat`** | `chat/poll` (read) + `chat/send` (dual-write with airc) | [#1489](https://github.com/CambrianTech/continuum/pull/1489) | [CHAT-MODULE.md](CHAT-MODULE.md) | ✅ 4 multi-thread stress tests |
+| **`generator`** | `generate/module` (scaffolds new ServiceModules per [§3 of field manual](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md)) | [#1487](https://github.com/CambrianTech/continuum/pull/1487) + [#1494](https://github.com/CambrianTech/continuum/pull/1494) v2 enriched scaffold | [GENERATOR-MODULE.md](GENERATOR-MODULE.md) | ✅ 3 multi-thread stress tests (caught + fixed silent torn-state race) |
+| **`data` cursors** | `data/query-{open,next,close}` with typed `HandleRef` + back-compat `queryId` | [#1490](https://github.com/CambrianTech/continuum/pull/1490) | [DATA-CURSORS-MODULE.md](DATA-CURSORS-MODULE.md) | ✅ 7 stress tests (caught + fixed read-then-async-then-write race) |
+| **`airc/realtime-store`** | In-process realtime envelope store (bounded replay, coalesced presence, capability index) — moment-of-truth substrate | shipped pre-session; tests in [#1492](https://github.com/CambrianTech/continuum/pull/1492) | [AIRC-REALTIME-STORE-MODULE.md](AIRC-REALTIME-STORE-MODULE.md) | ✅ 4 stress tests pinning moment-of-truth invariants |
+
+### Substrate primitives that landed alongside
+
+The Rust implementations above ride on substrate work codified in [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md):
+
+| Primitive | What it gives a module author | PR |
+|---|---|---|
+| `ServiceModule` trait | The one trait every module implements | landed pre-session |
+| `CommandInterceptor` chain | Local Rust / grid / airc / TS dispatch composed in one chain | [#1483](https://github.com/CambrianTech/continuum/pull/1483) + [#1484](https://github.com/CambrianTech/continuum/pull/1484) |
+| `HandleRef` + cell shapes | Typed reference to producer-owned state; the long-running-work primitive | [#1485](https://github.com/CambrianTech/continuum/pull/1485) |
+| `CommandRequest<P>` / `CommandResponse<T>` | Typed envelopes around params + result, with cross-cutting fields free | [#1486](https://github.com/CambrianTech/continuum/pull/1486) |
+| `HandleRef::expect_owned_by` + `CommandRequest::handle_id_or_legacy` | Canonical handle validation + dual-shape migration resolver — distilled from data cursor consumer | [#1491](https://github.com/CambrianTech/continuum/pull/1491) |
+| Field manual + per-module design template | The 8-section author guide + canonical directory shape | [#1493](https://github.com/CambrianTech/continuum/pull/1493) |
+| Generator v2 (eats own dogfood) | Emits modules matching the design template; new modules scaffolded, not hand-written | [#1494](https://github.com/CambrianTech/continuum/pull/1494) |
+
+### The three primitives map ([memory: three-primitives-commands-events-persona](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md))
+
+Per Joel 2026-05-30: *"Continuum is exactly three primitives — Commands, Events, Persona — in Rust. airc handles grid. Widgets are thin event-subscribers + command-callers. Everything else is supporting cast."*
+
+The currently-live modules map cleanly:
+
+- **Commands**: `chat/poll`, `chat/send`, `generate/module`, `data/query-*` — all the kernel-routable operations
+- **Events**: `airc/realtime-store` — the in-process event substrate; chat/send publishes here via `airc/realtime-publish`; persona inboxes drain here via `airc/realtime-replay`
+- **Persona**: not directly listed above — personas consume the Commands + Events. The persona's autonomous loop, inbox, and cognition stack are the next migration target (per [memory: headless-rust-must-work-soon](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md))
+
+### The remaining catalog below
+
+Everything in §I–§IX below is **design proposal**. Each entry stays in design state until it (a) gets migrated to Rust per the [field manual's acceptance criteria](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md), (b) gets a per-module design doc, and (c) has multi-thread concurrency tests. When that happens, it earns a row in §0 above.
 
 The architectural claim: when the substrate handles the rest — concurrency, scheduling, pressure response, telemetry, replay, lifecycle, reprojection, demand-aligned recall, governor-mediated sizing — **every concern reduces to a few hundred lines and is performant by inheritance.** That is what "fundamentally simple" means in production.
 


### PR DESCRIPTION
## Summary

**Final step of the 4-PR doc set** Joel approved on 2026-05-30 ("Yeah let's do it. In order"):

1. ✅ Field manual codifying substrate ([#1493](https://github.com/CambrianTech/continuum/pull/1493))
2. ✅ Generator v2 emitting modules per the template ([#1494](https://github.com/CambrianTech/continuum/pull/1494))
3. ✅ Per-module design pages for what we've built ([#1495](https://github.com/CambrianTech/continuum/pull/1495))
4. **This PR**: MODULE-CATALOG.md update marking which modules are alive in Rust

## What this PR adds

New `§0. Currently Live In Rust` section near top of the catalog. Three sub-tables:

### Sub-table 1: Live modules

| Module | What ships | PR | Design doc | Concurrency proven |
|---|---|---|---|---|
| `chat` | chat/poll + chat/send | [#1489](https://github.com/CambrianTech/continuum/pull/1489) | CHAT-MODULE.md | 4 tests |
| `generator` | generate/module + v2 scaffold | [#1487](https://github.com/CambrianTech/continuum/pull/1487) + [#1494](https://github.com/CambrianTech/continuum/pull/1494) | GENERATOR-MODULE.md | 3 tests |
| `data` cursors | data/query-* with HandleRef | [#1490](https://github.com/CambrianTech/continuum/pull/1490) | DATA-CURSORS-MODULE.md | 7 tests |
| `airc/realtime-store` | in-process realtime store | pre-session + [#1492](https://github.com/CambrianTech/continuum/pull/1492) tests | AIRC-REALTIME-STORE-MODULE.md | 4 tests |

### Sub-table 2: Substrate primitives the live modules ride on

ServiceModule trait, interceptor chain, HandleRef + cell shapes, envelopes, `expect_owned_by` + `handle_id_or_legacy`, field manual, generator v2 — each row cites its PR.

### Sub-table 3: Three-primitive map

Per Joel 2026-05-30, mapping live modules to **Commands** (chat, generator, data) / **Events** (airc/realtime-store) / **Persona** (next migration target).

## Why minimal restructure

The catalog is 1133 lines of design-proposal entries for every Continuum concern. Restructuring individual entries to mark which are live would scatter the live-vs-proposal signal across dozens of sections. Putting it in **one top-of-doc §0 section** gives readers the live-status at a glance without disturbing the rest of the catalog's design-proposal framing.

**Net diff: +41 / -2 lines.** Surgical addition.

## Doctrine §0 establishes

Modules earn a row in §0 when they clear ALL THREE of the field manual's acceptance criteria:

1. Rust implementation merged
2. Per-module design doc capturing role / surface / state / concurrency / migration / kinks
3. Multi-thread concurrency tests pinning per-resource invariants

The catalog becomes **dual-purpose**:
- **Design proposal repository** (§I–§IX, unchanged) — what we intend to build
- **Implementation status board** (§0, new) — what we've actually built + proven

Future migrations grow §0; proposal sections shrink as entries get promoted.

## Header updates

- Cross-ref added to COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md
- Status line updated: *"Most entries are design proposals … Some are now live in Rust — see §0 below"*

## What this PR does NOT do

- **Does NOT migrate any module** — pure documentation
- **Does NOT restructure §I–§IX entries** — each concern stays in design-proposal form until it migrates
- **Does NOT add new module concerns** to the catalog — §0 is the live-status index, not a new concern listing

## Test plan

- [ ] §0 renders correctly on GitHub
- [ ] All PR and design-doc links resolve
- [ ] Anchor link `#0-currently-live-in-rust` resolves from the status line
- [ ] No format breakage in the unchanged sections below

## Stacks on

`canary` directly — pure documentation PR.

## The four-PR doc set is complete

| # | Doc | PR |
|---|---|---|
| 1 | Field Manual | #1493 |
| 2 | Generator v2 (emits the template) | #1494 |
| 3 | Per-module design pages | #1495 |
| 4 | **Catalog live-status update** | **this PR** |

Module-author onboarding flow now reads end-to-end:
1. Open [MODULE-CATALOG.md §0](MODULE-CATALOG.md) — see what's live + what's proposed
2. Read the relevant per-module design doc (chat, generator, data, airc/realtime)
3. Read [COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md](COMMAND-INFRASTRUCTURE-FIELD-MANUAL.md) for the how
4. Run `./jtag generate/module ...` to scaffold the new module
5. Fill in handler bodies + DESIGN.md

That's the whole pipeline. The next module migration is faster than the last; the substrate work compounds.
