### PR TITLE
refine(runtime): HandleRef::expect_owned_by + CommandRequest::handle_id_or_legacy (re-opens #1491)

### DIFF
--- a/src/workers/continuum-core/src/modules/data.rs
+++ b/src/workers/continuum-core/src/modules/data.rs
@@ -1858,64 +1858,14 @@ impl DataModule {
             .into_command_result()
     }
 
-    /// Pull the cursor id out of the request envelope — preferring the
-    /// kernel-level `handle`, falling back to the legacy `queryId`
-    /// field, failing loud when neither is present or the handle is
-    /// mis-owned/mis-typed. Single resolver shared by query-next and
-    /// query-close so the dual-shape contract has ONE place to drift.
-    fn resolve_query_cursor_id(
-        handle: &Option<HandleRef>,
-        legacy_query_id: &Option<String>,
-        command: &str,
-    ) -> Result<String, String> {
-        if let Some(h) = handle {
-            // Kernel typed contract: a handle minted by a different
-            // module reaching this module's handler is ALWAYS a bug.
-            // The grid interceptor is supposed to have routed the call
-            // back to the actual owner before we ever see it; arriving
-            // here with the wrong owner means either the routing
-            // misfired or a caller hand-crafted a bogus handle. Either
-            // way, fail loud with the offending values named.
-            if h.owner != DATA_MODULE_OWNER {
-                return Err(format!(
-                    "{command}: handle owner mismatch — got owner={:?}, this module owns only {:?}. \
-                     Handles must be minted by the same module that consumes them, OR the grid \
-                     interceptor must route the command back to the owner before dispatch.",
-                    h.owner, DATA_MODULE_OWNER
-                ));
-            }
-            // Within the data module, multiple handle shapes are
-            // possible in principle (e.g., a future `data::Migration`
-            // handle). The type tag is the within-module discriminator;
-            // a wrong tag here means the caller threaded a handle
-            // belonging to a DIFFERENT resource through the cursor
-            // surface. Same fail-loud reasoning.
-            if h.type_tag != QUERY_CURSOR_TYPE_TAG {
-                return Err(format!(
-                    "{command}: handle type mismatch — got type_tag={:?}, expected {:?}. \
-                     This handler operates only on query-cursor handles; threading a different \
-                     handle shape here is a programming error.",
-                    h.type_tag, QUERY_CURSOR_TYPE_TAG
-                ));
-            }
-            return Ok(h.id.to_string());
-        }
-
-        if let Some(id) = legacy_query_id {
-            // Belt-and-braces: legacy callers send a UUID-shaped string;
-            // a non-UUID string is almost certainly a bug, but the
-            // existing wire contract doesn't guarantee validation —
-            // accept it as-is to preserve back-compat. If the string
-            // fails the DashMap lookup later, the "not found" path
-            // surfaces it.
-            return Ok(id.clone());
-        }
-
-        Err(format!(
-            "{command}: neither `handle` (envelope field) nor `queryId` (legacy params field) \
-             was provided. Pass the handle minted by `data/query-open` via either shape."
-        ))
-    }
+    // The dual-shape (envelope handle OR legacy `queryId` string)
+    // resolver previously lived here as a 35-line inline helper.
+    // That logic moved into the substrate at
+    // [`CommandRequest::handle_id_or_legacy`] (with owner/type
+    // validation via [`HandleRef::expect_owned_by`]) so every future
+    // migration of a stringly-typed id to a typed handle reaches
+    // for the same primitive. `handle_query_next` / `handle_query_close`
+    // call it directly with this module's owner + type tag constants.
 
     /// Get next page from paginated query.
     ///
@@ -1932,8 +1882,13 @@ impl DataModule {
         use std::time::Instant;
         let start = Instant::now();
 
-        let cursor_id =
-            Self::resolve_query_cursor_id(&req.handle, &req.params.query_id, "data/query-next")?;
+        let cursor_id = req.handle_id_or_legacy(
+            DATA_MODULE_OWNER,
+            QUERY_CURSOR_TYPE_TAG,
+            "queryId",
+            &req.params.query_id,
+            "data/query-next",
+        )?;
 
         // ── Acquire the per-cursor mutex ─────────────────────────────
         //
@@ -2079,8 +2034,13 @@ impl DataModule {
         &self,
         req: CommandRequest<QueryCloseParams>,
     ) -> Result<CommandResult, String> {
-        let cursor_id =
-            Self::resolve_query_cursor_id(&req.handle, &req.params.query_id, "data/query-close")?;
+        let cursor_id = req.handle_id_or_legacy(
+            DATA_MODULE_OWNER,
+            QUERY_CURSOR_TYPE_TAG,
+            "queryId",
+            &req.params.query_id,
+            "data/query-close",
+        )?;
         let removed = self.paginated_queries.remove(&cursor_id).is_some();
 
         log_info!(

--- a/src/workers/continuum-core/src/runtime/cell_shapes.rs
+++ b/src/workers/continuum-core/src/runtime/cell_shapes.rs
@@ -176,6 +176,67 @@ impl HandleRef {
     pub fn mint(owner: impl Into<String>, type_tag: impl Into<String>) -> Self {
         Self::with_id(owner, Uuid::new_v4(), type_tag)
     }
+
+    /// Validate this handle's `owner` and `type_tag` match the values
+    /// the consumer expects, returning the inner `Uuid` for the
+    /// consumer's own state-map lookup.
+    ///
+    /// This is the canonical handle-validation entry point — every
+    /// handler that consumes a `HandleRef` should call it before
+    /// looking the id up in its state map, so:
+    ///
+    /// - A handle minted by a different module reaching the wrong
+    ///   handler surfaces a typed "owner mismatch" error rather than
+    ///   silently miss-looking-up in the wrong state map. The grid
+    ///   interceptor is supposed to route by `owner` before dispatch
+    ///   ever fires; an owner-mismatch reaching this far means the
+    ///   routing misfired or a caller hand-crafted a bogus handle.
+    ///
+    /// - A handle for the wrong resource (right module, wrong type —
+    ///   e.g. a `data::Migration` handle threaded through a cursor
+    ///   handler) surfaces a typed "type mismatch" error rather than
+    ///   miss-looking-up across handle shapes.
+    ///
+    /// Errors are formatted consistently across every module that
+    /// uses handles, naming BOTH the offending value AND the expected
+    /// value so the caller self-corrects without grepping source.
+    /// Consumers typically prepend their command name via `map_err`:
+    ///
+    /// ```ignore
+    /// let cursor_id = handle.expect_owned_by("data", "data::QueryCursor")
+    ///     .map_err(|e| format!("data/query-next: {e}"))?;
+    /// ```
+    ///
+    /// For dual-shape resolvers that accept EITHER a typed handle
+    /// (envelope) OR a legacy string field (back-compat during
+    /// migration), prefer
+    /// [`crate::runtime::CommandRequest::handle_id_or_legacy`] which
+    /// composes this method with the legacy fallback path and the
+    /// command-name prefix in a single call.
+    pub fn expect_owned_by(
+        &self,
+        expected_owner: &str,
+        expected_type_tag: &str,
+    ) -> Result<Uuid, String> {
+        if self.owner != expected_owner {
+            return Err(format!(
+                "handle owner mismatch — got owner={:?}, expected {:?}. \
+                 Handles must be minted by the same module that consumes them, \
+                 OR the grid interceptor must route the command back to the owner \
+                 before local dispatch.",
+                self.owner, expected_owner
+            ));
+        }
+        if self.type_tag != expected_type_tag {
+            return Err(format!(
+                "handle type mismatch — got type_tag={:?}, expected {:?}. \
+                 This handler operates only on handles of the expected type; \
+                 threading a different handle shape here is a programming error.",
+                self.type_tag, expected_type_tag
+            ));
+        }
+        Ok(self.id)
+    }
 }
 
 fn now_ms() -> u64 {
@@ -329,5 +390,89 @@ mod tests {
         assert_eq!(l, back);
         assert_eq!(back.command, "ai/generate");
         assert_eq!(back.bound_params["model"], "qwen");
+    }
+
+    // ── HandleRef::expect_owned_by ───────────────────────────────────
+    //
+    // The canonical validation entry point distilled from the data
+    // module's first real HandleRef consumer (PR #1490). Every future
+    // handler that consumes a HandleRef should reach for this method
+    // rather than reimplementing the owner/type checks inline.
+
+    #[test]
+    fn expect_owned_by_returns_uuid_when_owner_and_type_match() {
+        let id = Uuid::new_v4();
+        let h = HandleRef::with_id("data", id, "data::QueryCursor");
+        let resolved = h
+            .expect_owned_by("data", "data::QueryCursor")
+            .expect("matched handle must validate");
+        assert_eq!(
+            resolved, id,
+            "expect_owned_by must return the inner UUID, not a string-rendered copy"
+        );
+    }
+
+    #[test]
+    fn expect_owned_by_rejects_wrong_owner_with_both_values_named() {
+        let h = HandleRef::mint("chat", "chat::MessageHandle");
+        let err = h
+            .expect_owned_by("data", "data::QueryCursor")
+            .expect_err("wrong owner must Err");
+        assert!(
+            err.contains("owner mismatch"),
+            "error must name the failure mode: {err}"
+        );
+        assert!(
+            err.contains("\"chat\"") && err.contains("\"data\""),
+            "error must name BOTH offender AND expected so caller self-corrects: {err}"
+        );
+    }
+
+    #[test]
+    fn expect_owned_by_rejects_wrong_type_tag_with_both_values_named() {
+        let h = HandleRef::mint("data", "data::Migration");
+        let err = h
+            .expect_owned_by("data", "data::QueryCursor")
+            .expect_err("wrong type must Err");
+        assert!(
+            err.contains("type mismatch"),
+            "error must name the failure mode: {err}"
+        );
+        assert!(
+            err.contains("data::Migration") && err.contains("data::QueryCursor"),
+            "error must name BOTH offender AND expected: {err}"
+        );
+    }
+
+    #[test]
+    fn expect_owned_by_checks_owner_first_then_type() {
+        // Pin the order: owner mismatch should surface even when the
+        // type tag is ALSO wrong. The owner-first check matters
+        // because owner determines routing — type is a secondary
+        // within-module discriminator.
+        let h = HandleRef::mint("chat", "chat::MessageHandle");
+        let err = h
+            .expect_owned_by("data", "data::QueryCursor")
+            .expect_err("both fields wrong must Err on the routing one first");
+        assert!(
+            err.contains("owner mismatch") && !err.contains("type mismatch"),
+            "owner mismatch must take precedence over type mismatch: {err}"
+        );
+    }
+
+    #[test]
+    fn expect_owned_by_error_includes_routing_hint() {
+        // The owner-mismatch error explicitly points consumers at the
+        // grid interceptor's responsibility to route by owner — that's
+        // the hint that turns "weird error" into "ah, the interceptor
+        // is misconfigured" or "ah, this caller built a bogus handle".
+        let h = HandleRef::mint("chat", "data::QueryCursor");
+        let err = h
+            .expect_owned_by("data", "data::QueryCursor")
+            .expect_err("wrong owner must Err");
+        assert!(
+            err.contains("grid interceptor") || err.contains("route"),
+            "owner-mismatch error must hint at routing semantics: {err}"
+        );
     }
 }

--- a/src/workers/continuum-core/src/runtime/command_envelope.rs
+++ b/src/workers/continuum-core/src/runtime/command_envelope.rs
@@ -189,6 +189,81 @@ impl<P> CommandRequest<P> {
         self.user_id = Some(user_id);
         self
     }
+
+    /// Resolve a resource id during migration from string-typed ids to
+    /// typed [`HandleRef`]s, returning the id as a string.
+    ///
+    /// Walks two possible shapes in priority order:
+    ///
+    /// 1. **Envelope `handle`** (the new canonical shape). When
+    ///    present, validates against the expected `owner` and
+    ///    `type_tag` via [`HandleRef::expect_owned_by`]; a failure
+    ///    here surfaces with the `command` name prepended so the
+    ///    consumer's error names the offending surface, the failure
+    ///    mode, and the expected values in one breath.
+    ///
+    /// 2. **Legacy string field** (the back-compat shape). Returned
+    ///    as-is. The historical wire contract pre-dates UUID typing,
+    ///    so legacy callers may send anything — if the string fails
+    ///    the consumer's downstream lookup, the consumer's own
+    ///    "not found" error names it.
+    ///
+    /// 3. **Neither present** — typed error naming BOTH supported
+    ///    shapes so the caller knows what to add.
+    ///
+    /// This is the single primitive shared by every additive
+    /// migration of a stringly-typed id to a typed handle. See
+    /// `data.rs`'s `handle_query_next` / `handle_query_close` for the
+    /// canonical consumer; other migrations should reach for this
+    /// rather than reimplementing the resolver.
+    ///
+    /// # Why does it return `String`?
+    ///
+    /// Two callers consume the same id today:
+    /// - the envelope path produces a `Uuid` (typed)
+    /// - the legacy path produces a string (predates UUID typing)
+    ///
+    /// To present a unified resolved-id type to the consumer, we
+    /// collapse to `String` — the historical wire format that every
+    /// consumer's existing state map is already keyed on. Future
+    /// modules whose state maps are keyed on `Uuid` can `Uuid::parse_str`
+    /// the result; the parse failure mode for legacy strings is fine
+    /// because handle-only consumers (post-migration) won't have a
+    /// legacy field to fall back to anyway.
+    ///
+    /// # Usage
+    ///
+    /// ```ignore
+    /// let cursor_id = req.handle_id_or_legacy(
+    ///     "data",                   // expected owner
+    ///     "data::QueryCursor",      // expected type_tag
+    ///     "queryId",                // legacy field name (for error)
+    ///     &req.params.query_id,     // legacy field value (Option<String>)
+    ///     "data/query-next",        // command name (for error prefix)
+    /// )?;
+    /// ```
+    pub fn handle_id_or_legacy(
+        &self,
+        expected_owner: &str,
+        expected_type_tag: &str,
+        legacy_field_name: &str,
+        legacy_field: &Option<String>,
+        command: &str,
+    ) -> Result<String, String> {
+        if let Some(h) = &self.handle {
+            return h
+                .expect_owned_by(expected_owner, expected_type_tag)
+                .map(|uuid| uuid.to_string())
+                .map_err(|e| format!("{command}: {e}"));
+        }
+        if let Some(id) = legacy_field {
+            return Ok(id.clone());
+        }
+        Err(format!(
+            "{command}: neither `handle` (envelope field) nor `{legacy_field_name}` \
+             (legacy params field) was provided. Pass the resource id via either shape."
+        ))
+    }
 }
 
 /// Typed envelope around an outbound command's result.
@@ -494,5 +569,174 @@ mod tests {
         assert_eq!(req.session_id, Some(session_id));
         assert_eq!(req.user_id, Some(user_id));
         assert_eq!(req.handle.unwrap().id, handle_id);
+    }
+
+    // ── CommandRequest::handle_id_or_legacy ─────────────────────────
+    //
+    // The single primitive shared by every additive migration of a
+    // stringly-typed id to a typed handle. Distilled from data
+    // module's first real consumer (PR #1490) so future migrations
+    // don't reimplement the resolver. Each kink the data migration
+    // discovered is pinned by a test here so the substrate
+    // guarantees them centrally.
+
+    #[derive(Debug, Clone, Default, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct CursorParams {
+        #[serde(default)]
+        query_id: Option<String>,
+    }
+
+    fn cursor_handle(id: Uuid) -> HandleRef {
+        HandleRef::with_id("data", id, "data::QueryCursor")
+    }
+
+    #[test]
+    fn handle_id_or_legacy_prefers_envelope_handle_when_both_present() {
+        // When the envelope carries a handle AND a legacy field is
+        // also present, the typed handle wins. Otherwise consumers
+        // mid-migration would diverge from new consumers about which
+        // id the resolver sees.
+        let h_id = Uuid::new_v4();
+        let req = CommandRequest::new(CursorParams {
+            query_id: Some(Uuid::new_v4().to_string()), // legacy populated
+        })
+        .with_handle(cursor_handle(h_id));
+
+        let resolved = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-next",
+            )
+            .expect("envelope handle must win");
+        assert_eq!(
+            resolved,
+            h_id.to_string(),
+            "envelope handle MUST win when both shapes are present"
+        );
+    }
+
+    #[test]
+    fn handle_id_or_legacy_falls_back_to_legacy_string_when_no_handle() {
+        let legacy = "11111111-2222-3333-4444-555555555555".to_string();
+        let req = CommandRequest::new(CursorParams {
+            query_id: Some(legacy.clone()),
+        });
+
+        let resolved = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-next",
+            )
+            .expect("legacy fallback must succeed");
+        assert_eq!(resolved, legacy, "legacy string returned as-is");
+    }
+
+    #[test]
+    fn handle_id_or_legacy_errors_loud_when_neither_shape_provided() {
+        let req = CommandRequest::new(CursorParams::default());
+        let err = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-next",
+            )
+            .expect_err("empty request must Err");
+        assert!(
+            err.contains("data/query-next"),
+            "error must name the failing command surface: {err}"
+        );
+        assert!(
+            err.contains("`handle`") && err.contains("`queryId`"),
+            "error must name BOTH supported shapes so caller knows what to add: {err}"
+        );
+    }
+
+    #[test]
+    fn handle_id_or_legacy_prepends_command_name_to_handle_validation_errors() {
+        // Critical for diagnostics: when a wrong-owner handle reaches
+        // this resolver, the error must name BOTH the failing command
+        // (so the caller knows which surface) AND the
+        // HandleRef-level mismatch (so the caller knows what to fix).
+        let req = CommandRequest::new(CursorParams::default()).with_handle(HandleRef::mint(
+            "chat",
+            "chat::MessageHandle",
+        ));
+
+        let err = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-next",
+            )
+            .expect_err("wrong-owner handle must Err");
+        assert!(
+            err.starts_with("data/query-next:"),
+            "command name must prefix the error: {err}"
+        );
+        assert!(
+            err.contains("owner mismatch"),
+            "HandleRef's failure mode must propagate: {err}"
+        );
+        assert!(
+            err.contains("\"chat\"") && err.contains("\"data\""),
+            "both offender and expected named: {err}"
+        );
+    }
+
+    #[test]
+    fn handle_id_or_legacy_propagates_type_mismatch_with_command_name() {
+        let req = CommandRequest::new(CursorParams::default())
+            .with_handle(HandleRef::mint("data", "data::Migration"));
+
+        let err = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-close",
+            )
+            .expect_err("wrong-type handle must Err");
+        assert!(err.starts_with("data/query-close:"), "command prefix: {err}");
+        assert!(err.contains("type mismatch"), "type mismatch propagates: {err}");
+        assert!(
+            err.contains("data::Migration") && err.contains("data::QueryCursor"),
+            "both offender and expected named: {err}"
+        );
+    }
+
+    #[test]
+    fn handle_id_or_legacy_uses_canonical_uuid_string_for_handle_path() {
+        // The envelope path must produce the UUID's canonical string
+        // form (not some other rendering), so downstream consumers
+        // can use the resolved string as a stable cache key with
+        // legacy-path values from the same migration window.
+        let id = Uuid::new_v4();
+        let req = CommandRequest::new(CursorParams::default()).with_handle(cursor_handle(id));
+        let resolved = req
+            .handle_id_or_legacy(
+                "data",
+                "data::QueryCursor",
+                "queryId",
+                &req.params.query_id,
+                "data/query-next",
+            )
+            .unwrap();
+        assert_eq!(
+            resolved,
+            id.to_string(),
+            "canonical UUID string is the bridge format between handle and legacy paths"
+        );
     }
 }


### PR DESCRIPTION
Re-opens [#1491](https://github.com/CambrianTech/continuum/pull/1491) which auto-closed when its base (`feat/data-query-handle-migration`) was deleted with #1490's auto-close.

## What lands

Same content as #1491: two substrate primitives distilled from the data-cursor migration's inline boilerplate:

- `HandleRef::expect_owned_by(owner, type_tag) → Result<Uuid, String>` — canonical handle-validation entry point
- `CommandRequest::handle_id_or_legacy(...)` — dual-shape resolver for any migration from string-typed ids to typed handles

11 new substrate tests + the data-cursor consumer refactored to use them (-84 lines from data.rs).

## Stacks on

[#1497](https://github.com/CambrianTech/continuum/pull/1497) (the new home of #1490's content). Will need to retarget to `canary` once #1497 merges.

## Original PR

Full description on [#1491](https://github.com/CambrianTech/continuum/pull/1491). Closed with #1490.