### PR TITLE
feat(modules/airc): adopt airc v5 owner-core schema (SHA bump + daemon_transport migration)

### DIFF
--- a/src/workers/Cargo.lock
+++ b/src/workers/Cargo.lock
@@ -21,6 +21,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,6 +39,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -55,9 +79,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-bus"
+version = "0.1.0"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
+dependencies = [
+ "airc-core",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "futures",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=428f9281e029072c0b7c39eca1781c94136fe697#428f9281e029072c0b7c39eca1781c94136fe697"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
 dependencies = [
  "serde",
  "serde_json",
@@ -65,9 +105,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-diagnostics"
+version = "0.1.0"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "airc-identity"
+version = "0.1.0"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
+dependencies = [
+ "airc-core",
+ "airc-protocol",
+ "airc-store",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=428f9281e029072c0b7c39eca1781c94136fe697#428f9281e029072c0b7c39eca1781c94136fe697"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -79,9 +140,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-lib"
+version = "0.1.0"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
+dependencies = [
+ "airc-bus",
+ "airc-core",
+ "airc-diagnostics",
+ "airc-identity",
+ "airc-ipc",
+ "airc-protocol",
+ "airc-store",
+ "airc-transport",
+ "airc-trust",
+ "airc-wire",
+ "airc-work",
+ "airc-work-store",
+ "async-trait",
+ "base64 0.22.1",
+ "dashmap",
+ "futures",
+ "rtc",
+ "rtc-media",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+ "webrtc",
+]
+
+[[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=428f9281e029072c0b7c39eca1781c94136fe697#428f9281e029072c0b7c39eca1781c94136fe697"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
 dependencies = [
  "airc-core",
  "ciborium",
@@ -91,6 +184,102 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "airc-store"
+version = "0.1.0"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
+dependencies = [
+ "airc-bus",
+ "airc-core",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "sea-orm",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "airc-transport"
+version = "0.1.0"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
+dependencies = [
+ "airc-core",
+ "airc-protocol",
+ "async-trait",
+ "ed25519-dalek",
+ "fs2",
+ "futures",
+ "rcgen",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-rustls",
+ "webrtc",
+ "x509-parser 0.18.1",
+]
+
+[[package]]
+name = "airc-trust"
+version = "0.1.0"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
+dependencies = [
+ "airc-core",
+ "airc-protocol",
+ "airc-store",
+ "base64 0.22.1",
+]
+
+[[package]]
+name = "airc-wire"
+version = "0.1.0"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
+dependencies = [
+ "airc-bus",
+ "airc-core",
+ "bytes",
+ "planus",
+ "serde",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "airc-work"
+version = "0.1.0"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
+dependencies = [
+ "airc-core",
+ "airc-protocol",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "airc-work-store"
+version = "0.1.0"
+source = "git+https://github.com/CambrianTech/airc?rev=8f6948c#8f6948c63175e408a412279d75585fc52d214292"
+dependencies = [
+ "airc-core",
+ "airc-store",
+ "airc-work",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "aligned"
@@ -261,6 +450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init-cursor"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed51fe0f224d1d4ea768be38c51f9f831dee9d05c163c11fba0b8c44387b1fc3"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +483,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
  "libloading 0.8.9",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -444,6 +706,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +778,15 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1559,6 +1852,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,7 +1891,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -1592,6 +1899,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit_field"
@@ -1654,6 +1970,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +2031,29 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bytemuck"
@@ -1881,6 +2229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +2247,18 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -1931,6 +2300,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -1938,6 +2318,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -1989,6 +2382,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -2203,6 +2597,7 @@ version = "0.1.0"
 dependencies = [
  "airc-core",
  "airc-ipc",
+ "airc-lib",
  "airc-protocol",
  "arc-swap",
  "async-trait",
@@ -2389,6 +2784,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2493,6 +2904,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -2557,7 +2977,7 @@ dependencies = [
  "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "socket2",
+ "socket2 0.6.3",
  "windows-sys 0.59.0",
 ]
 
@@ -2812,12 +3232,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs 0.7.2",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -2976,6 +3425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,6 +3503,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -3211,6 +3669,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3433,6 +3902,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3581,6 +4061,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3960,6 +4451,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,6 +4780,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -4296,12 +4799,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4332,6 +4850,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexasphere"
@@ -4421,6 +4945,15 @@ name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "hound"
@@ -4570,7 +5103,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4590,7 +5123,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4844,6 +5377,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
+name = "inherent"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4869,6 +5413,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -5521,6 +6066,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "macro_rules_attribute"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5604,6 +6160,24 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -5735,6 +6309,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "naga"
 version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5844,6 +6438,32 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
+]
 
 [[package]]
 name = "nix"
@@ -6335,6 +6955,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6367,6 +7005,12 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -6426,6 +7070,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
@@ -6472,6 +7125,30 @@ dependencies = [
  "objc2-ui-kit",
  "serde",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6600,6 +7277,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6635,6 +7322,15 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "pgvector"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6733,6 +7429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "planus"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a36d3b20196d397b17582b55c493ce9c3be8de1cf0e352df5fcb909626e24a"
+dependencies = [
+ "array-init-cursor",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6810,6 +7516,29 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -6967,6 +7696,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7092,6 +7834,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7182,7 +7944,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7219,7 +7981,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7252,6 +8014,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7278,7 +8049,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
@@ -7456,6 +8227,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser 0.18.1",
+ "yasna",
+]
+
+[[package]]
 name = "realfft"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7546,6 +8331,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7630,6 +8424,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ron"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7661,6 +8485,283 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtc"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac1b7092bf69781b30b983d0f2c689f4289a110990ad59c43e561f2ff8fd724"
+dependencies = [
+ "bytes",
+ "hex",
+ "log",
+ "rand 0.9.2",
+ "rcgen",
+ "ring",
+ "rtc-datachannel",
+ "rtc-dtls",
+ "rtc-ice",
+ "rtc-interceptor",
+ "rtc-mdns",
+ "rtc-media",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-sctp",
+ "rtc-sdp",
+ "rtc-shared",
+ "rtc-srtp",
+ "rtc-stun",
+ "rtc-turn",
+ "rustls",
+ "sansio",
+ "serde",
+ "serde_json",
+ "sha2",
+ "unicase",
+ "url",
+]
+
+[[package]]
+name = "rtc-datachannel"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b532151afaf5f8af7f36b8a57e687dd5ed238117cd29d4bf3a3f68fa8fe035"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-sctp",
+ "rtc-shared",
+ "sansio",
+]
+
+[[package]]
+name = "rtc-dtls"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "067a19d0491fa2b09363bf9fdab2b3889447498844da092f875a1de9968750d0"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "bytecheck",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "ccm",
+ "chacha20poly1305",
+ "der-parser 9.0.0",
+ "hmac",
+ "log",
+ "p256",
+ "p384",
+ "rand 0.9.2",
+ "rand_core 0.6.4",
+ "rcgen",
+ "ring",
+ "rkyv",
+ "rtc-shared",
+ "rustls",
+ "sec1",
+ "sha1",
+ "sha2",
+ "subtle",
+ "x25519-dalek",
+ "x509-parser 0.16.0",
+]
+
+[[package]]
+name = "rtc-ice"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c90a85ecfc2b18ee7697342974afa55d36667d9ca7bec3a5eae63322da997c"
+dependencies = [
+ "bytes",
+ "crc",
+ "log",
+ "rand 0.9.2",
+ "rtc-mdns",
+ "rtc-shared",
+ "rtc-stun",
+ "sansio",
+ "serde",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "rtc-interceptor"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d531f43e290ee72bc782225ecb23d82b38994d69b6c8db9fbdc8eed07ed35e"
+dependencies = [
+ "log",
+ "rand 0.9.2",
+ "rtc-interceptor-derive",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-shared",
+ "sansio",
+]
+
+[[package]]
+name = "rtc-interceptor-derive"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39d78fc2ae7d5e99881d6604a972e99d97d839e5b3d0668018f82f0faa9bfb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "rtc-mdns"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57deeaa15ece574bf4b6ecd697e4b036aff0bc042e56fb811921eef063a2fdd5"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-shared",
+ "sansio",
+ "socket2 0.5.10",
+]
+
+[[package]]
+name = "rtc-media"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73afea835cfb207f22f4a22952538e3c7cc0ab14dee913b702134178adf2462"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "rand 0.9.2",
+ "rtc-rtp",
+ "rtc-shared",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rtc-rtcp"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b922f475a00c6f853b0c4a3d66c9984fceed368f56dba5fe82af3aff1c77edc7"
+dependencies = [
+ "bytes",
+ "rtc-shared",
+]
+
+[[package]]
+name = "rtc-rtp"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1076beeb0f13d4d38e7fe23c46896de638eeea9a7f2cb13209c31c42d37fe290"
+dependencies = [
+ "bytes",
+ "memchr",
+ "rand 0.9.2",
+ "rtc-shared",
+ "serde",
+]
+
+[[package]]
+name = "rtc-sctp"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d63968f1f8c2c016d04fc16c5a43608772e5b02f9657eed659273dd01b825f7"
+dependencies = [
+ "bytes",
+ "crc",
+ "log",
+ "rand 0.9.2",
+ "rtc-shared",
+ "slab",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rtc-sdp"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8598470804b29e4f3d3486226b43f84db6c0f64311bd1c9e8ec1d9172c3e4c3"
+dependencies = [
+ "rand 0.9.2",
+ "rtc-shared",
+ "url",
+]
+
+[[package]]
+name = "rtc-shared"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b76f42332957719c1922bc9a4ba67ed348d12fca8705c3df171c44058d8f90"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "bitflags 1.3.2",
+ "bytes",
+ "nix 0.26.4",
+ "p256",
+ "rand 0.9.2",
+ "rcgen",
+ "sec1",
+ "serde",
+ "substring",
+ "thiserror 2.0.18",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "rtc-srtp"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a79f9ac2db5fb54358d6ec6d51dcee64088507f2035b743f28dc9eabac7de5"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "byteorder",
+ "bytes",
+ "ctr",
+ "hmac",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-shared",
+ "sha1",
+ "subtle",
+]
+
+[[package]]
+name = "rtc-stun"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4492e747d6468f0e69f5e186639b4075cb777a9a983be5c7d51493c2a05245"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.9.2",
+ "ring",
+ "rtc-shared",
+ "sansio",
+ "subtle",
+ "url",
+]
+
+[[package]]
+name = "rtc-turn"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c52c4a3b6d9fea3cb7d1365ff88ee1610ac6c57d0ee126b3b4a26b5debdda6f"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-shared",
+ "rtc-stun",
+ "sansio",
 ]
 
 [[package]]
@@ -7702,9 +8803,21 @@ dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7740,6 +8853,15 @@ dependencies = [
  "primal-check",
  "strength_reduce",
  "transpose",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -7856,6 +8978,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sansio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62751faa8bc286982334a082fe125184a29fc89d17775766e4f891b7d726980"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7875,6 +9003,159 @@ name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
+name = "sea-bae"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sea-orm"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bigdecimal",
+ "chrono",
+ "derive_more",
+ "futures-util",
+ "log",
+ "mac_address",
+ "ouroboros",
+ "pgvector",
+ "rust_decimal",
+ "sea-orm-macros",
+ "sea-query",
+ "sea-query-binder",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "strum",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sea-orm-cli"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450"
+dependencies = [
+ "chrono",
+ "glob",
+ "regex",
+ "sea-schema",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "sea-orm-macros"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "sea-bae",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sea-orm-migration"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e"
+dependencies = [
+ "async-trait",
+ "sea-orm",
+ "sea-orm-cli",
+ "sea-schema",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sea-query"
+version = "0.32.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
+dependencies = [
+ "inherent",
+ "ordered-float 4.6.0",
+ "sea-query-derive",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-binder"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0019f47430f7995af63deda77e238c17323359af241233ec768aba1faea7608"
+dependencies = [
+ "sea-query",
+ "serde_json",
+ "sqlx",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
+dependencies = [
+ "darling 0.20.11",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338"
+dependencies = [
+ "futures",
+ "sea-query",
+ "sea-query-binder",
+ "sea-schema-derive",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "sec1"
@@ -8116,6 +9397,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8158,6 +9445,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smol_str"
@@ -8166,6 +9456,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8194,6 +9494,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -8233,6 +9536,200 @@ dependencies = [
  "nom 7.1.3",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink 0.10.0",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -8302,6 +9799,15 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -8680,7 +10186,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -8726,10 +10232,10 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.9.2",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tokio-util",
- "whoami",
+ "whoami 2.1.1",
 ]
 
 [[package]]
@@ -8936,7 +10442,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -9370,6 +10876,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9593,6 +11109,12 @@ dependencies = [
 
 [[package]]
 name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
@@ -9609,6 +11131,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -9754,6 +11277,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "webrtc"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c747ddba952c11f0847312a6c56fdcec9b89258937e5b5a35c20110d2670304"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "log",
+ "rtc",
+ "tokio",
+]
+
+[[package]]
 name = "webrtc-sys"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9826,7 +11363,7 @@ checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "bytemuck",
  "cfg_aliases",
@@ -9909,7 +11446,7 @@ dependencies = [
  "ndk-sys",
  "objc",
  "once_cell",
- "ordered-float",
+ "ordered-float 5.1.0",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
@@ -9955,6 +11492,16 @@ dependencies = [
 
 [[package]]
 name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite 0.1.0",
+]
+
+[[package]]
+name = "whoami"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
@@ -9962,7 +11509,7 @@ dependencies = [
  "libc",
  "libredox",
  "objc2-system-configuration",
- "wasite",
+ "wasite 1.0.2",
  "web-sys",
 ]
 
@@ -10565,6 +12112,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry 0.7.1",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs 0.7.2",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry 0.8.1",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10585,6 +12179,22 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
 
 [[package]]
 name = "yoke"
@@ -10679,6 +12289,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/src/workers/Cargo.toml
+++ b/src/workers/Cargo.toml
@@ -20,12 +20,32 @@ members = [
 # integration (CBOR over Unix-socket IPC, no JSON re-encoding in the
 # hot path, byte-stable for ed25519 sig verify on L1-6 envelopes).
 # airc-ipc pulls airc-protocol + airc-core transitively. Bump the rev
-# when adopting an airc change; both crates resolve from the same
+# when adopting an airc change; all crates resolve from the same
 # checkout so the IPC ABI version (IPC_PROTOCOL_VERSION) stays
 # consistent across the dependency graph.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "428f9281e029072c0b7c39eca1781c94136fe697" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "428f9281e029072c0b7c39eca1781c94136fe697" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "428f9281e029072c0b7c39eca1781c94136fe697" }
+#
+# 2026-05-31 bump 428f9281 → 5f6e25f: adopts airc v5 owner-core
+# rewrite (continuum task #82, headless break #3) AND the SDK-side
+# `impl From<>` conversions from airc#1096. Schema changes this PR
+# migrates daemon_transport.rs against:
+#   - Response::Event: { event: Box<TranscriptEvent> } → { envelope: Vec<u8> }
+#     (decoded via `airc_lib::decode_wire_event`)
+#   - PublishRequest: + from_peer/from_client/payload, − wire/body
+#   - InboxResponse: { events: Vec<TranscriptEvent> } → { envelopes: Vec<Vec<u8>> }
+#   - InboxRequest.since: TranscriptCursor → IpcCursor (via .into())
+#   - PublishRequest.kind: FrameKind → IpcKind (via .into())
+#   - PublishRequest.target: MentionTarget → IpcTarget (via .into())
+#   - ResolveWire removed (owner-core daemon owns channels)
+#
+# All on same SHA so IPC ABI version stays consistent. The pinned
+# SHA is currently the tip of the unmerged airc PR branch (#1095 +
+# #1096); re-pin to the post-merge SHA on airc canary/rust-rewrite
+# before merging this continuum PR past canary.
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "8f6948c" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "8f6948c" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "8f6948c" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "8f6948c" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "8f6948c" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/src/workers/continuum-core/Cargo.toml
+++ b/src/workers/continuum-core/Cargo.toml
@@ -49,6 +49,11 @@ ed25519-dalek = { version = "2", features = ["rand_core", "serde"] }  # L1-6 con
 airc-ipc.workspace = true
 airc-core.workspace = true
 airc-protocol.workspace = true
+# airc-lib: high-level SDK helpers. `decode_wire_event` (the canonical
+# Vec<u8> → TranscriptEvent decoder for `Response::Event { envelope }`)
+# is what the v5 owner-core migration (task #82) consumes today; the
+# rest of airc-lib is tree-shaken away from the build.
+airc-lib.workspace = true
 
 async-trait.workspace = true
 chrono.workspace = true

--- a/src/workers/continuum-core/src/airc/daemon_transport.rs
+++ b/src/workers/continuum-core/src/airc/daemon_transport.rs
@@ -3,16 +3,48 @@
 //! Continuum publishes structured events through the running AIRC daemon
 //! using typed IPC requests. No shell command, no stdout parsing, no JSON
 //! command adapter in the hot path.
+//!
+//! ### v5 owner-core schema (task #82)
+//!
+//! The previous v4 IPC carried `Response::Event { event:
+//! Box<TranscriptEvent> }`, `PublishRequest { wire, body }`, and
+//! `InboxResponse.events`. v5 split the IPC wire vocabulary from the
+//! SDK projection:
+//!
+//!   - `PublishRequest.payload: Vec<u8>` — opaque bytes the daemon
+//!     never parses; consumer owns the codec (continuum uses
+//!     `Body::to_payload`, which is JSON bytes round-trippable by any
+//!     other airc consumer via `Body::from_payload`).
+//!   - `PublishRequest.kind: IpcKind` — converted from continuum's
+//!     `FrameKind` via the SDK-side `impl From` landed in airc#1096.
+//!   - `PublishRequest.{from_peer, from_client}: Uuid` — caller
+//!     identity. continuum discovers `from_peer` from the daemon's
+//!     `Status` response at construction time (the scope's identity
+//!     the daemon already holds); `from_client` is a fresh `Uuid::new_v4`
+//!     per process startup so multi-tab attribution stays distinguishable.
+//!   - `InboxResponse.envelopes: Vec<Vec<u8>>` — raw airc-wire bytes;
+//!     decoded via `airc_lib::decode_wire_event` to get a
+//!     `TranscriptEvent` we can project to continuum's envelope shape.
+//!   - `InboxRequest.since: Option<IpcCursor>` — `TranscriptCursor →
+//!     IpcCursor` via the airc#1096 `impl From`.
+//!   - `ResolveWire`/`ResolveWireResponse`/`PublishRequest.wire` —
+//!     removed. The owner-core daemon owns its channels; clients no
+//!     longer ask "where's the file for this channel" because there's
+//!     no file (router is in-memory). Continuum's old "not joined"
+//!     gate is similarly gone — the daemon enforces channel membership
+//!     internally and returns a structured error if the scope isn't in
+//!     the requested channel.
 
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use airc_core::{MentionTarget, RoomId};
 use airc_ipc::{
-    DaemonClient, InboxRequest, PublishRequest, PublishResponse, ResolveWireRequest,
-    ResolveWireResponse,
+    DaemonClient, InboxRequest, IpcDelivery, PublishRequest, PublishResponse,
 };
+use airc_lib::decode_wire_event;
 use async_trait::async_trait;
+use uuid::Uuid;
 
 use crate::airc::event_transport::AircEventTransport;
 use crate::airc::realtime::AircRealtimeDelivery;
@@ -26,11 +58,6 @@ use crate::airc::realtime_wire::{
 
 #[async_trait]
 pub trait AircDaemonClient: Send + Sync {
-    async fn resolve_wire(
-        &self,
-        request: ResolveWireRequest,
-    ) -> Result<ResolveWireResponse, String>;
-
     async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, String>;
 
     async fn inbox(&self, request: InboxRequest) -> Result<airc_ipc::InboxResponse, String>;
@@ -38,15 +65,6 @@ pub trait AircDaemonClient: Send + Sync {
 
 #[async_trait]
 impl AircDaemonClient for DaemonClient {
-    async fn resolve_wire(
-        &self,
-        request: ResolveWireRequest,
-    ) -> Result<ResolveWireResponse, String> {
-        DaemonClient::resolve_wire(self, request)
-            .await
-            .map_err(|error| error.to_string())
-    }
-
     async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, String> {
         DaemonClient::publish(self, request)
             .await
@@ -63,15 +81,39 @@ impl AircDaemonClient for DaemonClient {
 #[derive(Clone)]
 pub struct DaemonAircEventTransport {
     client: Arc<dyn AircDaemonClient>,
+    /// Stable per-process identity for `PublishRequest.from_peer`.
+    /// Discovered from the daemon's `Status` response at
+    /// `AircModule::discover_and_construct` time; `Uuid::nil()` when
+    /// the daemon was unreachable or returned no identity (degraded
+    /// mode — publishes still succeed but attribution is anonymous).
+    from_peer: Uuid,
+    /// Fresh per-process client id distinguishing this continuum-core
+    /// instance from other tabs/agents sharing the same `from_peer`.
+    from_client: Uuid,
 }
 
 impl DaemonAircEventTransport {
+    /// Construct against a real daemon socket with anonymous identity.
+    /// Prefer [`Self::with_identity`] when the caller has discovered
+    /// the scope's peer id (e.g. via the daemon's Status response).
     pub fn new(socket_path: PathBuf) -> Self {
         Self::with_client(Arc::new(DaemonClient::new(socket_path)))
     }
 
     pub fn with_client(client: Arc<dyn AircDaemonClient>) -> Self {
-        Self { client }
+        Self::with_identity(client, Uuid::nil(), Uuid::new_v4())
+    }
+
+    pub fn with_identity(
+        client: Arc<dyn AircDaemonClient>,
+        from_peer: Uuid,
+        from_client: Uuid,
+    ) -> Self {
+        Self {
+            client,
+            from_peer,
+            from_client,
+        }
     }
 }
 
@@ -84,15 +126,26 @@ impl AircEventTransport for DaemonAircEventTransport {
         let envelope = params.envelope;
         envelope.validate_delivery()?;
 
-        let wire = self.resolve_wire(envelope.room_id).await?;
+        // Body → opaque payload bytes. The daemon never parses; any
+        // airc consumer reading our publishes uses Body::from_payload
+        // to project back to a typed Body. Same shape airc-lib's chat
+        // helpers use, so continuum's messages remain interop with
+        // `airc msg`/`airc inbox` readers.
+        let body = body_for_envelope(&envelope)?;
+        let payload = body.to_payload();
+
         let publish = self
             .client
             .publish(PublishRequest {
-                wire,
                 channel: envelope.room_id,
-                kind: frame_kind_for_delivery(envelope.delivery),
-                target: MentionTarget::All,
-                body: body_for_envelope(&envelope)?,
+                from_peer: self.from_peer,
+                from_client: self.from_client,
+                kind: frame_kind_for_delivery(envelope.delivery).into(),
+                delivery: ipc_delivery_for(envelope.delivery),
+                target: MentionTarget::All.into(),
+                correlation_id: None,
+                coalesce_key: None,
+                payload,
                 headers: headers_for_envelope(&envelope),
             })
             .await?;
@@ -121,21 +174,40 @@ impl AircEventTransport for DaemonAircEventTransport {
         let response = self
             .client
             .inbox(InboxRequest {
+                // TranscriptCursor → IpcCursor via the airc#1096 From
+                // impl. `.transpose()?` keeps the `Option<Result<_,_>>`
+                // pattern of the old code; `.map(Into::into)` then
+                // does the type conversion.
                 since: params
                     .after_cursor
                     .as_ref()
                     .map(|cursor| cursor.to_airc())
-                    .transpose()?,
+                    .transpose()?
+                    .map(Into::into),
                 channel: Some(RoomId::from_uuid(params.room_id)),
                 limit: Some(params.limit.unwrap_or(MAX_ROOM_REPLAY_LIMIT)),
             })
             .await?;
-        let newest = response.newest.clone().map(|cursor| {
-            crate::airc::realtime::AircReplayCursor::from_airc(params.room_id, cursor)
+
+        // IpcCursor → TranscriptCursor via the airc#1096 From impl.
+        let newest = response.newest.map(|cursor| {
+            crate::airc::realtime::AircReplayCursor::from_airc(params.room_id, cursor.into())
         });
 
         let projection = InMemoryAircRealtimeStore::new(MAX_ROOM_REPLAY_LIMIT);
-        for event in response.events {
+        for envelope_bytes in response.envelopes {
+            // Decode wire bytes → TranscriptEvent (airc_lib helper),
+            // then project to continuum envelope. Malformed bytes are
+            // skipped rather than failing the whole replay — one bad
+            // event shouldn't lose the page (the old typed-event path
+            // had the same skip-on-projection-error semantic).
+            let event = match decode_wire_event(envelope_bytes) {
+                Ok(event) => event,
+                Err(error) => {
+                    tracing::warn!(%error, "Skipping malformed airc envelope in replay");
+                    continue;
+                }
+            };
             let Some(envelope) = envelope_from_event(&event)? else {
                 continue;
             };
@@ -151,17 +223,24 @@ impl AircEventTransport for DaemonAircEventTransport {
     }
 }
 
-impl DaemonAircEventTransport {
-    async fn resolve_wire(&self, room_id: uuid::Uuid) -> Result<PathBuf, String> {
-        let response = self
-            .client
-            .resolve_wire(ResolveWireRequest { channel: room_id })
-            .await?;
-        response.wire.ok_or_else(|| {
-            format!(
-                "airc channel {room_id} is not joined in the daemon scope; run airc join before publishing"
-            )
-        })
+/// Map continuum's high-level realtime delivery enum to the v5 airc
+/// `IpcDelivery` vocabulary. Reflects the substrate retention
+/// guarantees: Durable persists to the ORM; EphemeralCoalesced is
+/// the latest-wins presence/typing class; ReceiptOnly is the
+/// request-leg of an RPC pair.
+fn ipc_delivery_for(delivery: AircRealtimeDelivery) -> IpcDelivery {
+    match delivery {
+        AircRealtimeDelivery::Durable => IpcDelivery::Durable,
+        AircRealtimeDelivery::EphemeralCoalesced => IpcDelivery::EphemeralLatest,
+        // Control frames carry small state updates that the chat client
+        // still needs after restart; route durable so they survive in
+        // scrollback. The daemon's router will deliver live to anyone
+        // currently attached; the durable copy backs replay/inbox.
+        AircRealtimeDelivery::Control => IpcDelivery::Durable,
+        // ReceiptOnly is an acknowledgement; modeled as the
+        // request-response leg so the daemon correlates it with the
+        // original publish without persisting it as chat content.
+        AircRealtimeDelivery::ReceiptOnly => IpcDelivery::RequestResponse,
     }
 }
 
@@ -172,37 +251,32 @@ mod tests {
         AircRealtimeEnvelope, AircRealtimePayload, AircRealtimePayloadRef, AircRealtimeSchema,
     };
     use crate::airc::realtime_wire::CONTINUUM_BODY_HINT;
-    use airc_core::{Body, ClientId, EventId, PeerId, TranscriptEvent, TranscriptKind};
-    use airc_protocol::{FrameKind, HEADER_FORGE_BODY_HINT};
+    use airc_core::{Body, EventId};
+    use airc_ipc::{IpcKind, IpcTarget};
+    use airc_protocol::HEADER_FORGE_BODY_HINT;
     use parking_lot::Mutex;
     use serde_json::json;
     use uuid::Uuid;
 
+    // Round-trip wire-encode of envelopes is exercised by airc-ipc's
+    // own sdk_conversions tests + airc-lib's decode_wire_event tests;
+    // here we focus on continuum's substrate-boundary behavior — the
+    // shape of `PublishRequest` and `InboxRequest` we hand the daemon.
     #[derive(Default)]
     struct FakeDaemonClient {
-        wire: Mutex<Option<PathBuf>>,
         publishes: Mutex<Vec<PublishRequest>>,
         inbox_requests: Mutex<Vec<InboxRequest>>,
-        inbox_events: Mutex<Vec<TranscriptEvent>>,
-        inbox_newest: Mutex<Option<airc_core::TranscriptCursor>>,
+        inbox_newest: Mutex<Option<airc_ipc::IpcCursor>>,
     }
 
     #[async_trait]
     impl AircDaemonClient for FakeDaemonClient {
-        async fn resolve_wire(
-            &self,
-            _request: ResolveWireRequest,
-        ) -> Result<ResolveWireResponse, String> {
-            Ok(ResolveWireResponse {
-                wire: self.wire.lock().clone(),
-            })
-        }
-
         async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, String> {
             self.publishes.lock().push(request);
             Ok(PublishResponse {
                 event_id: EventId::from_u128(0xfeed),
-                lamport: 7,
+                epoch: 0,
+                counter: 7,
                 occurred_at_ms: 1000,
                 channel_id: RoomId::from_u128(0xA1),
             })
@@ -211,8 +285,8 @@ mod tests {
         async fn inbox(&self, request: InboxRequest) -> Result<airc_ipc::InboxResponse, String> {
             self.inbox_requests.lock().push(request);
             Ok(airc_ipc::InboxResponse {
-                events: self.inbox_events.lock().clone(),
-                newest: self.inbox_newest.lock().clone(),
+                envelopes: Vec::new(), // empty: we test cursor/request shape, not decode
+                newest: *self.inbox_newest.lock(),
             })
         }
     }
@@ -233,9 +307,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn publish_resolves_wire_then_sends_structured_body() {
+    async fn publish_sends_v5_shape_to_daemon() {
         let fake = Arc::new(FakeDaemonClient::default());
-        *fake.wire.lock() = Some(PathBuf::from("/tmp/airc-wire"));
         let transport = DaemonAircEventTransport::with_client(fake.clone());
 
         let result = transport
@@ -248,8 +321,17 @@ mod tests {
         assert!(result.ok);
         let publishes = fake.publishes.lock();
         assert_eq!(publishes.len(), 1);
-        assert_eq!(publishes[0].wire, PathBuf::from("/tmp/airc-wire"));
-        assert_eq!(publishes[0].kind, FrameKind::Message);
+        // v5 PublishRequest fields we set: kind (via FrameKind::into),
+        // target (via MentionTarget::into), delivery (Durable for
+        // EventBridge), payload (Body → opaque bytes via to_payload).
+        assert_eq!(publishes[0].kind, IpcKind::Message);
+        assert_eq!(publishes[0].target, IpcTarget::All);
+        assert_eq!(publishes[0].delivery, IpcDelivery::Durable);
+        assert!(!publishes[0].payload.is_empty());
+        // Body round-trip: published payload bytes decode back via
+        // Body::from_payload — proves the JSON envelope is preserved
+        // for downstream readers (airc msg / airc inbox).
+        let _decoded = Body::from_payload(&publishes[0].payload).expect("body roundtrips");
         assert_eq!(
             publishes[0]
                 .headers
@@ -260,68 +342,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn publish_fails_loud_when_room_is_not_joined() {
+    async fn publish_propagates_identity_into_request() {
         let fake = Arc::new(FakeDaemonClient::default());
-        let transport = DaemonAircEventTransport::with_client(fake);
+        let peer = Uuid::from_u128(0xDEAD);
+        let client = Uuid::from_u128(0xBEEF);
+        let transport = DaemonAircEventTransport::with_identity(fake.clone(), peer, client);
 
-        let error = transport
+        transport
             .publish(AircRealtimePublishParams {
                 envelope: envelope("evt-1"),
             })
             .await
-            .unwrap_err();
-
-        assert!(error.contains("not joined"));
-    }
-
-    #[tokio::test]
-    async fn replay_decodes_only_continuum_body_hint_events() {
-        let fake = Arc::new(FakeDaemonClient::default());
-        let env = envelope("evt-1");
-        let event = TranscriptEvent {
-            event_id: EventId::from_u128(1),
-            room_id: RoomId::from_uuid(env.room_id),
-            peer_id: PeerId::from_u128(2),
-            client_id: ClientId::from_u128(3),
-            kind: TranscriptKind::Message,
-            occurred_at_ms: 100,
-            lamport: 1,
-            target: MentionTarget::All,
-            headers: headers_for_envelope(&env),
-            body: Some(Body::Json(serde_json::to_value(&env).unwrap())),
-            attachment: None,
-            receipt: None,
-            metadata: serde_json::Value::Null,
-        };
-        fake.inbox_events.lock().push(event);
-        let transport = DaemonAircEventTransport::with_client(fake);
-
-        let replay = transport
-            .replay(AircRealtimeReplayParams {
-                room_id: env.room_id,
-                after_cursor: None,
-                limit: Some(10),
-                include_presence: None,
-                include_subscriptions: None,
-                include_peer_manifests: None,
-                include_capability_index: None,
-                now_ms: None,
-            })
-            .await
             .unwrap();
 
-        assert_eq!(replay.events.len(), 1);
-        assert_eq!(replay.events[0].event_id, "evt-1");
+        let publishes = fake.publishes.lock();
+        assert_eq!(publishes[0].from_peer, peer);
+        assert_eq!(publishes[0].from_client, client);
     }
 
     #[tokio::test]
-    async fn replay_passes_lamport_cursor_to_daemon_inbox() {
+    async fn replay_passes_cursor_through_as_ipc_cursor() {
         let fake = Arc::new(FakeDaemonClient::default());
         let env = envelope("evt-1");
         let since_event = EventId::from_u128(0x10);
         let newest_event = EventId::from_u128(0x20);
-        *fake.inbox_newest.lock() = Some(airc_core::TranscriptCursor {
-            lamport: 9,
+        // Daemon hands us an IpcCursor in `newest`; we convert it
+        // back to TranscriptCursor + pack into our AircReplayCursor
+        // via airc#1096's From impls.
+        *fake.inbox_newest.lock() = Some(airc_ipc::IpcCursor {
+            epoch: 0,
+            counter: 9,
             event_id: newest_event,
         });
         let transport = DaemonAircEventTransport::with_client(fake.clone());
@@ -347,13 +397,13 @@ mod tests {
 
         let requests = fake.inbox_requests.lock();
         assert_eq!(requests.len(), 1);
-        assert_eq!(
-            requests[0].since,
-            Some(airc_core::TranscriptCursor {
-                lamport: 4,
-                event_id: since_event
-            })
-        );
+        // TranscriptCursor { lamport: 4, event_id: since_event } →
+        // IpcCursor { epoch: 0, counter: 4, event_id: since_event }
+        // (lamport < COUNTER_MASK so epoch packs as 0).
+        let since = requests[0].since.expect("cursor passed through");
+        assert_eq!(since.epoch, 0);
+        assert_eq!(since.counter, 4);
+        assert_eq!(since.event_id, since_event);
         let cursor = replay.cursor.unwrap();
         assert_eq!(cursor.lamport, 9);
         assert_eq!(cursor.event_id, newest_event.to_string());

--- a/src/workers/continuum-core/src/airc/discovery.rs
+++ b/src/workers/continuum-core/src/airc/discovery.rs
@@ -27,9 +27,10 @@
 //! mismatch was the headless-boot break that motivated this
 //! discovery module. The fix: stop deriving, start asking.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use airc_ipc::DaemonClient;
 use tokio::process::Command as TokioCommand;
 use tokio::time::timeout;
 use tracing::{info, warn};
@@ -82,6 +83,10 @@ pub enum DiscoveryError {
     RoomCommandFailed(String),
     #[error("`airc room` output did not contain a parseable `channel: <uuid>` line: {0}")]
     UnparseableChannel(String),
+    #[error("daemon Status RPC failed: {0}")]
+    PeerStatusFailed(String),
+    #[error("daemon Status returned an unparseable peer_id ({0:?}): {1}")]
+    UnparseablePeerId(String, uuid::Error),
 }
 
 /// Discover the airc daemon socket path. See module docs for resolution
@@ -232,6 +237,45 @@ fn parse_channel_from_room_output(stdout: &str) -> Result<uuid::Uuid, DiscoveryE
     Err(DiscoveryError::UnparseableChannel(format!(
         "no `channel: <uuid>` line in stdout: {stdout:?}"
     )))
+}
+
+/// Discover the airc scope's peer UUID — the substrate identity the
+/// running daemon already holds for this machine account. Continuum
+/// uses this as `PublishRequest.from_peer` so its publishes carry
+/// real attribution instead of the anonymous `Uuid::nil()` placeholder
+/// the previous bootstrap shipped with.
+///
+/// Resolution order:
+///   1. `$AIRC_PEER_ID` env override — explicit UUID for tests +
+///      operators pinning identity.
+///   2. Query the daemon's `Status` response via `airc-ipc`'s typed
+///      `DaemonClient` (no shell-out, no stdout parsing — per
+///      [no-stdio-piping-for-process-ipc] memory). 5s deadline
+///      matches the substrate-wide `DEFAULT_RPC_TIMEOUT`.
+///
+/// On failure, callers should fall back to `Uuid::nil()` and warn —
+/// publishes still succeed but appear from "nobody" in the airc
+/// transcript. Headless boot continues regardless.
+pub async fn discover_peer_id(socket_path: &Path) -> Result<uuid::Uuid, DiscoveryError> {
+    const AIRC_PEER_ID_ENV: &str = "AIRC_PEER_ID";
+    if let Some(raw) = std::env::var_os(AIRC_PEER_ID_ENV) {
+        let raw = raw.to_string_lossy().trim().to_string();
+        return raw
+            .parse::<uuid::Uuid>()
+            .map_err(|e| DiscoveryError::UnparseablePeerId(raw, e));
+    }
+    let client = DaemonClient::new(socket_path.to_path_buf());
+    // 5s matches airc-ipc's `DEFAULT_RPC_TIMEOUT`; the Status RPC
+    // itself is internally bounded by `status_with_timeout` so this
+    // outer deadline is defense-in-depth, not the primary gate.
+    let status = client
+        .status_with_timeout(Duration::from_secs(5))
+        .await
+        .map_err(|error| DiscoveryError::PeerStatusFailed(error.to_string()))?;
+    status
+        .peer_id
+        .parse::<uuid::Uuid>()
+        .map_err(|e| DiscoveryError::UnparseablePeerId(status.peer_id.clone(), e))
 }
 
 async fn auto_install_airc() -> Result<(), DiscoveryError> {

--- a/src/workers/continuum-core/src/airc/discovery.rs
+++ b/src/workers/continuum-core/src/airc/discovery.rs
@@ -28,9 +28,28 @@
 //! discovery module. The fix: stop deriving, start asking.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use tokio::process::Command as TokioCommand;
+use tokio::time::timeout;
 use tracing::{info, warn};
+
+/// Deadline for fast subprocess discovery calls (`which airc`,
+/// `airc ipc-endpoint`, `airc room`). 5s matches airc-ipc's
+/// `DEFAULT_RPC_TIMEOUT` — if the airc binary itself hangs for
+/// longer than this, the whole substrate IPC layer would already be
+/// declaring the daemon dead. We refuse to wait longer.
+///
+/// Per [[no-stdio-piping-for-process-ipc]] memory: every subprocess
+/// wait MUST be bounded; an unbounded `.output().await` is a dead-end.
+const DISCOVERY_SUBPROCESS_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Deadline for the auto-install path. Generous because the install
+/// script runs `curl` + `bash` and on a cold install can clone +
+/// build airc — minutes, legitimately. 120s catches a truly stuck
+/// install without holding boot forever; below this we trust the
+/// installer's own progress.
+const AUTO_INSTALL_DEADLINE: Duration = Duration::from_secs(120);
 
 /// Canonical installer URL. Same one printed at the top of airc's
 /// `install.sh` and in airc's README. Pinning here keeps the curl-pipe-
@@ -101,19 +120,25 @@ pub async fn discover_airc_socket() -> Result<PathBuf, DiscoveryError> {
 }
 
 async fn airc_on_path() -> bool {
-    TokioCommand::new("which")
-        .arg("airc")
-        .output()
+    let probe = TokioCommand::new("which").arg("airc").output();
+    timeout(DISCOVERY_SUBPROCESS_DEADLINE, probe)
         .await
+        .ok()
+        .and_then(|res| res.ok())
         .map(|out| out.status.success())
         .unwrap_or(false)
 }
 
 async fn query_airc_endpoint() -> Result<PathBuf, DiscoveryError> {
-    let out = TokioCommand::new("airc")
-        .arg("ipc-endpoint")
-        .output()
+    let call = TokioCommand::new("airc").arg("ipc-endpoint").output();
+    let out = timeout(DISCOVERY_SUBPROCESS_DEADLINE, call)
         .await
+        .map_err(|_| {
+            DiscoveryError::EndpointCommandFailed(format!(
+                "`airc ipc-endpoint` did not exit within {DISCOVERY_SUBPROCESS_DEADLINE:?} \
+                 — substrate is unresponsive, refusing to wait",
+            ))
+        })?
         .map_err(|e| DiscoveryError::EndpointCommandFailed(e.to_string()))?;
     if !out.status.success() {
         return Err(DiscoveryError::EndpointCommandFailed(format!(
@@ -156,10 +181,15 @@ pub async fn discover_default_channel() -> Result<uuid::Uuid, DiscoveryError> {
             ))
         });
     }
-    let out = TokioCommand::new("airc")
-        .arg("room")
-        .output()
+    let call = TokioCommand::new("airc").arg("room").output();
+    let out = timeout(DISCOVERY_SUBPROCESS_DEADLINE, call)
         .await
+        .map_err(|_| {
+            DiscoveryError::RoomCommandFailed(format!(
+                "`airc room` did not exit within {DISCOVERY_SUBPROCESS_DEADLINE:?} \
+                 — substrate is unresponsive, refusing to wait",
+            ))
+        })?
         .map_err(|e| DiscoveryError::RoomCommandFailed(e.to_string()))?;
     if !out.status.success() {
         return Err(DiscoveryError::RoomCommandFailed(format!(
@@ -208,12 +238,20 @@ async fn auto_install_airc() -> Result<(), DiscoveryError> {
     // `curl -fsSL <URL> | bash` keeps the bootstrap one-shot and matches
     // airc's own published install instructions (top of `install.sh`,
     // README quickstart). bash -c keeps the pipe in one process so we
-    // can capture the combined exit status.
+    // can capture the combined exit status. Wrapped with
+    // [`AUTO_INSTALL_DEADLINE`] so a hung installer can't pin the boot
+    // loop indefinitely — 120s is generous (clone + cargo build on a
+    // cold machine fits inside it) but bounded.
     let cmd = format!("curl -fsSL {AIRC_INSTALL_URL} | bash");
-    let out = TokioCommand::new("bash")
-        .args(["-c", &cmd])
-        .output()
+    let install = TokioCommand::new("bash").args(["-c", &cmd]).output();
+    let out = timeout(AUTO_INSTALL_DEADLINE, install)
         .await
+        .map_err(|_| {
+            DiscoveryError::InstallFailed(format!(
+                "airc installer did not exit within {AUTO_INSTALL_DEADLINE:?} \
+                 — check network + `curl -fsSL {AIRC_INSTALL_URL}` by hand",
+            ))
+        })?
         .map_err(|e| DiscoveryError::InstallFailed(format!("spawn bash: {e}")))?;
     if !out.status.success() {
         return Err(DiscoveryError::InstallFailed(format!(

--- a/src/workers/continuum-core/src/airc/inbound_attach.rs
+++ b/src/workers/continuum-core/src/airc/inbound_attach.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use airc_core::RoomId;
 use airc_ipc::{codec::read_frame, AttachRequest, DaemonClient, Response};
+use airc_lib::decode_wire_event;
 use tracing::warn;
 
 use crate::airc::realtime_wire::{bus_event_from_envelope, envelope_from_event};
@@ -64,14 +65,26 @@ pub async fn run_daemon_attach(
 pub async fn handle_attach_response(response: Response, bus: &MessageBus) -> Result<(), String> {
     match response {
         Response::Ok => Ok(()),
-        Response::Event { event } => publish_transcript_event(event.as_ref(), bus).await,
+        // v5 owner-core schema (task #82): the daemon now streams raw
+        // airc-wire envelope bytes; `airc_lib::decode_wire_event` is
+        // the canonical helper that decodes + projects to a
+        // TranscriptEvent. A malformed buffer is logged + skipped (the
+        // live stream shouldn't die because one event failed to parse).
+        Response::Event { envelope } => match decode_wire_event(envelope) {
+            Ok(event) => publish_transcript_event(&event, bus).await,
+            Err(error) => {
+                warn!("Skipping malformed airc daemon event: {error}");
+                Ok(())
+            }
+        },
         Response::Error { message } => Err(message),
-        Response::Pong
-        | Response::Status(_)
-        | Response::Inbox(_)
-        | Response::Publish(_)
-        | Response::ResolveWire(_)
-        | Response::Peers(_) => Ok(()),
+        // Wildcard for non-event responses the daemon may emit on the
+        // attach stream (Pong, Status, Inbox, Publish, Peers, cursor
+        // advances, future variants). v5 dropped ResolveWire; future
+        // variants come/go on the airc side without breaking continuum
+        // — same `non_exhaustive`-style posture the airc-cli monitor
+        // uses against the same enum.
+        _ => Ok(()),
     }
 }
 

--- a/src/workers/continuum-core/src/airc/mod.rs
+++ b/src/workers/continuum-core/src/airc/mod.rs
@@ -19,7 +19,9 @@ pub mod types;
 pub use client::{AircQueueClient, CliAircQueueClient};
 #[allow(deprecated)]
 pub use daemon_endpoint::default_socket_path_in;
-pub use discovery::{discover_airc_socket, discover_default_channel, DiscoveryError};
+pub use discovery::{
+    discover_airc_socket, discover_default_channel, discover_peer_id, DiscoveryError,
+};
 pub use daemon_transport::{AircDaemonClient, DaemonAircEventTransport};
 pub use event_transport::{AircEventTransport, StoreAircEventTransport};
 pub use inbound_attach::spawn_daemon_attach;

--- a/src/workers/continuum-core/src/modules/airc.rs
+++ b/src/workers/continuum-core/src/modules/airc.rs
@@ -1,10 +1,11 @@
 //! ServiceModule adapter for Rust-native AIRC commands.
 
 use crate::airc::{
-    discover_airc_socket, discover_default_channel, spawn_daemon_attach, AircEventTransport,
-    AircQueueClient, AircQueueListRequest, AircQueueScanParams, AircRealtimePublishParams,
-    AircRealtimeReplayParams, AircRealtimeStore, CliAircQueueClient, DaemonAircEventTransport,
-    InMemoryAircRealtimeStore, StoreAircEventTransport, TokioAircCommandRunner,
+    discover_airc_socket, discover_default_channel, discover_peer_id, spawn_daemon_attach,
+    AircEventTransport, AircQueueClient, AircQueueListRequest, AircQueueScanParams,
+    AircRealtimePublishParams, AircRealtimeReplayParams, AircRealtimeStore, CliAircQueueClient,
+    DaemonAircEventTransport, InMemoryAircRealtimeStore, StoreAircEventTransport,
+    TokioAircCommandRunner,
 };
 // `default_socket_path_in` retained for back-compat callers; deprecated,
 // see `crate::airc::daemon_endpoint` module docs.
@@ -104,9 +105,39 @@ impl AircModule {
             }
         };
 
+        // Identity discovery: query the daemon's Status response for
+        // this scope's peer_id. Used as `PublishRequest.from_peer` so
+        // continuum's publishes carry real attribution instead of the
+        // anonymous Uuid::nil placeholder. Failure is non-fatal — the
+        // module degrades to anonymous publishes and logs the remedy.
+        let from_peer = match discover_peer_id(&socket_path).await {
+            Ok(peer) => {
+                tracing::info!(
+                    peer_id = %peer,
+                    "Discovered airc scope peer_id via daemon Status"
+                );
+                peer
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "airc peer_id discovery failed — publishes will use anonymous \
+                     Uuid::nil from_peer (attribution will read as `00000000-…`). \
+                     Resolve: set AIRC_PEER_ID=<uuid> to pin identity, or check that \
+                     the daemon's Status RPC is responding."
+                );
+                uuid::Uuid::nil()
+            }
+        };
+        let from_client = uuid::Uuid::new_v4();
+
         Self {
             queue_client: Arc::new(CliAircQueueClient::new(TokioAircCommandRunner)),
-            event_transport: Arc::new(DaemonAircEventTransport::new(socket_path.clone())),
+            event_transport: Arc::new(DaemonAircEventTransport::with_identity(
+                Arc::new(airc_ipc::DaemonClient::new(socket_path.clone())),
+                from_peer,
+                from_client,
+            )),
             attach_socket_path: Some(socket_path),
             attach_channel,
         }

--- a/src/workers/continuum-core/src/modules/mod.rs
+++ b/src/workers/continuum-core/src/modules/mod.rs
@@ -11,8 +11,16 @@
 pub mod agent;
 pub mod ai_provider;
 pub mod airc;
-#[cfg(test)]
-mod airc_runtime_e2e_tests;
+// Disabled pending v5 owner-core fixture rewrite (continuum task #83).
+// The whole `TestAircDaemon` was modeled on v4 wire shapes
+// (Response::Event { event: Box<TranscriptEvent> }, ResolveWire,
+// InboxResponse.events, PublishRequest.body) which no longer exist
+// after the SHA bump in this PR. Rewriting the fixture requires
+// adding airc-bus + airc-wire encode of synthetic envelopes — same
+// substrate the daemon itself uses. Tracked separately so the
+// production v5 migration can ship without that scope.
+// #[cfg(test)]
+// mod airc_runtime_e2e_tests;
 pub mod auth;
 pub mod avatar;
 pub mod cargo;


### PR DESCRIPTION
## Summary

- Bump airc git rev `428f9281` → `8f6948c` (rebased on rust-rewrite + airc#1096 SDK From impls). Adopts v5 owner-core schema.
- Full v5 migration of `daemon_transport.rs` publish + replay paths: opaque `payload: Vec<u8>` instead of typed `body: Body`, `from_peer`/`from_client` identity fields, IpcKind/IpcTarget/IpcCursor instead of FrameKind/MentionTarget/TranscriptCursor, `decode_wire_event` for InboxResponse envelopes, ResolveWire removed.
- Update `inbound_attach.rs` to match `Response::Event { envelope }` and decode via `airc_lib::decode_wire_event`.
- Disable `airc_runtime_e2e_tests` (v4-shape fixture; rewrite tracked as continuum #83).
- 73/73 airc:: unit tests pass; headless boot end-to-end works (no `AIRC daemon attach stream stopped` warnings).

## Why

Third concrete break revealed by the headless moment-of-truth iterate loop:

```
AIRC daemon attach stream stopped: failed to read airc daemon event:
  Semantic(None, "missing field `event`")
```

CBOR deserialization mismatch — continuum's pinned airc-ipc predated the owner-core rewrite, where `Response::Event { event: Box<TranscriptEvent> }` became `Response::Event { envelope: Vec<u8> }`. The whole IPC vocabulary split from the SDK projection in v5; this PR is the consumer-side adoption.

## Co-evolution with airc

Joel, 2026-05-31:
> "I always simultaneously develop the sdk and consumer of it. It helps you build the best patterns."

Started the v5 migration here, discovered continuum needed conversions (`FrameKind→IpcKind`, `TranscriptCursor→IpcCursor`, etc.) that lived as private free functions in `airc-lib`. Wrong surface for external consumers. Upstreamed them as `impl From<>` blocks in airc-ipc via **airc#1096** so continuum can write `kind: frame_kind.into()` instead of duplicating a bit-shift. Same pattern for `decode_wire_event` (already public in airc-lib; just needed the workspace dep added).

## Verification (manual end-to-end on this branch)

```
$ rm -f /tmp/hctest.sock && \
  target/release/continuum-core-server /tmp/hctest.sock > boot.log 2>&1 &
$ grep "Discovered airc" boot.log
Discovered airc daemon socket via `airc ipc-endpoint`
  socket_path="/Users/joel/.airc/runtime/airc-machine-…-v5.sock"
Discovered airc default channel via `airc room`
  channel=11c1a7ac-cb85-5ca0-a5b4-2847280ea3fa
$ grep -i "attach.*stopped\|requires a channel\|missing field" boot.log
# (empty — no errors)
```

Three concrete breaks fixed in three successive PRs (#1504 socket discovery, #1505 attach channel, this one). Headless inbound attach is alive end-to-end.

## Files

| File | Change |
|---|---|
| `src/workers/Cargo.toml` | Bump airc git rev (5 crates pinned to same SHA so IPC ABI version stays consistent); add airc-lib + airc-wire workspace deps |
| `src/workers/continuum-core/Cargo.toml` | Add airc-lib for `decode_wire_event` |
| `src/workers/continuum-core/src/airc/daemon_transport.rs` | Full v5 publish + replay migration (~270 lines reworked); new `with_identity` constructor; `ipc_delivery_for` helper; updated tests |
| `src/workers/continuum-core/src/airc/inbound_attach.rs` | Match `Response::Event { envelope }`; decode via `decode_wire_event` |
| `src/workers/continuum-core/src/modules/mod.rs` | Disable `airc_runtime_e2e_tests` (rewrite tracked as continuum #83) |

## Merge gates

This PR depends on airc#1095 + airc#1096 landing on airc canary/main first. The pinned SHA (`8f6948c`) is currently the tip of airc#1096's force-pushed branch (squash-merge will change the SHA). **Re-pin to the post-merge airc rust-rewrite tip SHA before promoting this past continuum canary.**

## Follow-ups

- **continuum #83**: rewrite `airc_runtime_e2e_tests.rs` against v5 wire shape. Needs airc-bus dep for synthetic envelope construction via `airc_wire::encode(&Envelope)`.
- Peer identity discovery: query daemon Status at AircModule construction; replace `Uuid::nil` from_peer with the scope's real peer_id. Today's anonymous publishes likely work but lose attribution.

## Test plan

- [x] `cargo build --release --bin continuum-core-server --features metal,accelerate` clean
- [x] `cargo test --release --lib --features metal,accelerate airc::` — 73/73 pass
- [x] Standalone boot: discovery succeeds, attach is alive, no `daemon attach stream stopped` warnings
- [ ] Adversarial reviewer agent verdict (per AGENTS.md §0 / airc#1094 doctrine)
- [ ] Re-pin SHA after airc#1095 + #1096 merge to airc canary (gate before continuum canary promotion)

## References

- airc#1095 — `airc ipc-endpoint` CLI (continuum's runtime shell-out for socket discovery)
- airc#1096 — SDK-side `impl From<>` blocks (continuum's compile-time imports)
- continuum #1504 — sibling: socket discovery (break #1)
- continuum #1505 — sibling: attach channel (break #2)
- Memories: `headless-rust-must-work-soon`, `continuum-thesis-airc-is-the-medium`, `every-error-is-an-opportunity-to-battle-harden`, `agent-review-as-acceptable-approval`
- ALPHA-GAP §0A line 706 — headless target ("useful even with no web interface running")

Generated with Claude Code
