### PR TITLE
fix(persona/allocator): isolate test_allocate_no_keys from host VRAM detection

### DIFF
--- a/src/workers/continuum-core/src/persona/allocator.rs
+++ b/src/workers/continuum-core/src/persona/allocator.rs
@@ -446,34 +446,6 @@ mod tests {
         Arc::new(GpuMemoryManager::detect())
     }
 
-    /// Deterministic GpuMemoryManager fixture — the test names what
-    /// budget the allocator is reasoning against, no host probe. Use
-    /// this for allocation-logic tests; reserve `test_gpu_manager()`
-    /// for tests that genuinely care about whatever the host reports.
-    fn test_gpu_manager_with_vram_gb(vram_gb: f64) -> Arc<GpuMemoryManager> {
-        let bytes_per_gb = 1024.0_f64 * 1024.0 * 1024.0;
-        let total_bytes = (vram_gb * bytes_per_gb) as u64;
-        // Mirror GpuMemoryManager::detect's split: 12% reserve, then
-        // the remainder split inference/tts/rendering as
-        // INFERENCE/TTS/RENDERING_BUDGET_PCT (resolved at runtime).
-        // Use simple even splits in tests — the allocator only reads
-        // `total_vram_bytes`, not the per-subsystem breakdown.
-        let reserve_bytes = total_bytes / 8;
-        let usable = total_bytes - reserve_bytes;
-        let third = usable / 3;
-        let (tx, rx) = tokio::sync::watch::channel(0.0_f32);
-        Arc::new(GpuMemoryManager::new_for_test(
-            total_bytes,
-            "test:synthetic".to_string(),
-            third, // inference
-            third, // tts
-            third, // rendering
-            reserve_bytes,
-            tx,
-            rx,
-        ))
-    }
-
     #[test]
     fn test_select_local_model() {
         assert_eq!(
@@ -527,12 +499,20 @@ mod tests {
         // detection. test_gpu_manager() calls GpuMemoryManager::detect()
         // which leaks host hardware into a pure-logic test — empirically
         // observed failing on Intel Mac + AMD Radeon Pro 560X (4 GB VRAM
-        // - 2 GB reserve = 2 GB usable, but every local persona needs
-        // 3 GB per catalog.json, so 0 local allocations and the
+        // - reserves = ~2 GB usable, but every local persona needs 3 GB
+        // per catalog.json, so 0 local allocations and the
         // `local_count >= 1` invariant blows up). The allocator's job is
         // "given a hardware budget, decide what to spawn"; the test
         // should hand it a known budget, not ask the OS.
-        let manager = test_gpu_manager_with_vram_gb(16.0);
+        //
+        // Sibling tests `test_allocate_5090_tier` + `test_allocate_m1_pro_tier`
+        // already use `GpuMemoryManager::simulated` for the same reason —
+        // 16 GiB is a comfortable mid-tier that fits today's largest local
+        // persona budget (5 GiB for `vision`) with room to spare.
+        let manager = Arc::new(GpuMemoryManager::simulated(
+            "test:synthetic",
+            16 * 1024 * 1024 * 1024,
+        ));
         let catalog = load_catalog();
         let result = allocate(&manager, &[], &catalog);
 

--- a/src/workers/continuum-core/src/persona/allocator.rs
+++ b/src/workers/continuum-core/src/persona/allocator.rs
@@ -446,6 +446,34 @@ mod tests {
         Arc::new(GpuMemoryManager::detect())
     }
 
+    /// Deterministic GpuMemoryManager fixture — the test names what
+    /// budget the allocator is reasoning against, no host probe. Use
+    /// this for allocation-logic tests; reserve `test_gpu_manager()`
+    /// for tests that genuinely care about whatever the host reports.
+    fn test_gpu_manager_with_vram_gb(vram_gb: f64) -> Arc<GpuMemoryManager> {
+        let bytes_per_gb = 1024.0_f64 * 1024.0 * 1024.0;
+        let total_bytes = (vram_gb * bytes_per_gb) as u64;
+        // Mirror GpuMemoryManager::detect's split: 12% reserve, then
+        // the remainder split inference/tts/rendering as
+        // INFERENCE/TTS/RENDERING_BUDGET_PCT (resolved at runtime).
+        // Use simple even splits in tests — the allocator only reads
+        // `total_vram_bytes`, not the per-subsystem breakdown.
+        let reserve_bytes = total_bytes / 8;
+        let usable = total_bytes - reserve_bytes;
+        let third = usable / 3;
+        let (tx, rx) = tokio::sync::watch::channel(0.0_f32);
+        Arc::new(GpuMemoryManager::new_for_test(
+            total_bytes,
+            "test:synthetic".to_string(),
+            third, // inference
+            third, // tts
+            third, // rendering
+            reserve_bytes,
+            tx,
+            rx,
+        ))
+    }
+
     #[test]
     fn test_select_local_model() {
         assert_eq!(
@@ -495,7 +523,16 @@ mod tests {
 
     #[test]
     fn test_allocate_no_keys() {
-        let manager = test_gpu_manager();
+        // Use a deterministic test fixture rather than real hardware
+        // detection. test_gpu_manager() calls GpuMemoryManager::detect()
+        // which leaks host hardware into a pure-logic test — empirically
+        // observed failing on Intel Mac + AMD Radeon Pro 560X (4 GB VRAM
+        // - 2 GB reserve = 2 GB usable, but every local persona needs
+        // 3 GB per catalog.json, so 0 local allocations and the
+        // `local_count >= 1` invariant blows up). The allocator's job is
+        // "given a hardware budget, decide what to spawn"; the test
+        // should hand it a known budget, not ask the OS.
+        let manager = test_gpu_manager_with_vram_gb(16.0);
         let catalog = load_catalog();
         let result = allocate(&manager, &[], &catalog);
 


### PR DESCRIPTION
## Summary
- `persona::allocator::tests::test_allocate_no_keys` was failing on Intel Mac + AMD Radeon Pro 560X. Root cause: the test fixture `test_gpu_manager()` calls `GpuMemoryManager::detect()` which probes the real Metal device. AMD's 4 GB VRAM minus reserves leaves 2 GB usable; every local persona in `catalog.json` needs 3 GB (`modelPreferences[0].vramBudgetGb`). Result: 0 local allocations, and the `local_count >= 1` invariant blows up.
- Adds `test_gpu_manager_with_vram_gb(vram_gb)` — deterministic fixture using `GpuMemoryManager::new_for_test`. Switches `test_allocate_no_keys` to 16 GB so it actually tests allocation logic, not host detection.
- Leaves `test_gpu_manager()` (real-detect) in place for tests that genuinely care about host probing.

## Why this isolation
The allocator's contract is "given a hardware budget, decide what to spawn." A pure-logic test should hand it a known budget, not ask the OS — otherwise the assertion drifts with whatever GPU happens to be installed. Per [[every-error-is-an-opportunity-to-battle-harden]] the fix adds the rigging that catches the class next time: any new allocation-logic test gets the deterministic fixture for free.

## What this PR does NOT fix
The architectural question — should Intel Mac with AMD discrete fall back to system RAM for inference budget? — is separate. Task #52 (Governor classify_silicon misclassifies Mac Intel as AppleM) tracks the substrate-side decision. This PR fixes the test isolation only.

## Reference docs
- `src/workers/continuum-core/src/persona/allocator.rs` — the file (no other changes)
- `src/workers/continuum-core/src/gpu/memory_manager.rs:491` — `new_for_test` constructor this PR consumes

## Test plan
- [x] Pre-fix: `cargo test persona::allocator::tests::test_allocate_no_keys` → `FAILED` (`Should create at least one local persona`)
- [x] Diagnostic-instrumented run confirmed AMD Radeon Pro 560X, 4 GB VRAM, 18 personas skipped (15 cloud-without-key + 3 local-no-VRAM-fit)
- [x] Post-fix: full `cargo test persona::allocator` → 12 passed; 0 failed
- [ ] CI verifies on Linux/CUDA + Linux/CPU paths via standard checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
