### PR TITLE
docs(planning): HEADLESS-PERSONA-HOST-LOOP — slice 13 design

### DIFF
--- a/docs/planning/HEADLESS-PERSONA-HOST-LOOP.md
+++ b/docs/planning/HEADLESS-PERSONA-HOST-LOOP.md
@@ -1,10 +1,10 @@
 # Headless Persona Host Loop — #133 Slice 13 Design
 
-**Status:** Design (slice 13 not yet implemented). Captures the wire-up plan + the cleanup model verified during slice-12 review.
+**Status:** Design (slice 13 not yet implemented). Revised 2026-06-02 in response to PR #1510 review.
 
 **Tracks:** #133 ("LCD-first substrate spawn path"), #121 ("PersonaSpawnerModule"). Reads on top of the merged slices 5–12.
 
-**Adjacent issues:** task #52 (Governor classify_silicon misclassifies Mac Intel as AppleM), task #82 (CBOR Response::Event schema mismatch).
+**Adjacent issues:** task #52 (Governor classify_silicon misclassifies Mac Intel as AppleM), task #82 (CBOR Response::Event schema mismatch), task #88 (Disk pressure as substrate concern).
 
 ---
 
@@ -13,15 +13,56 @@
 After slices 5–12, the substrate has:
 
 - **Planning** (slice 7): `PersonaSpawnerModule::plan() → Vec<DesiredRole>`
-- **Bootstrap** (slice 8): `bootstrap_planned(...) → Vec<MaterializedPersonaPlan>` — turns plan rows into airc identities via `PersonaInstanceManagerModule::bootstrap_one`
-- **Adapter materialization** (slice 9): `materialize_adapters(plans, factory) → Vec<HostedPersona>`
+- **Bootstrap-and-plan** (slice 8): `bootstrap_planned(...) → Vec<MaterializedPersonaPlan>` — turns plan rows into airc identities via `PersonaInstanceManagerModule::bootstrap_one`, plus the per-row inference profile.
+- **Adapter materialization** (slice 9): `materialize_adapters(plans, factory) → Vec<Result<HostedPersona, SupervisorError>>` with structured per-slot error variants.
 - **Service loop** (slice 10): `serve_persona_loop(hosted, conversation, reader, opts)`
 - **Production conversation** (slice 11): `AircPersonaConversation::new(runtime)`
 - **Spawn helper** (slice 12): `spawn_persona_service(hosted, runtime, opts, rt_handle) → JoinHandle<Result<ServeOutcome, String>>`
 
-What's missing: **nothing in `continuum-core` actually calls this composition at boot.** The existing IPC boot loop at `crate::ipc::start_server` (≈line 1024–1089) calls `bootstrap_one(&intent)` and then *only logs* — it never starts hosting the persona on the grid.
+What's missing: **nothing in `continuum-core` actually composes this at boot.** The existing IPC boot loop at `crate::ipc::start_server` (≈line 1024–1089) calls `bootstrap_one(&intent)` and then *only logs* — it never starts hosting the persona on the grid.
 
-Slice 13 is the rewire that makes the substrate actually host personas headlessly. The demo binary keeps working (slice 11 reshape) but stops being on the critical path. `npm start` with no demo binary running produces talking personas.
+Slice 13 is the rewire that makes the substrate actually host personas headlessly. The demo binary keeps working (slice 11 reshape) but stops being on the critical path.
+
+---
+
+## Hard prerequisites (must land BEFORE or AS PART OF slice 13)
+
+These are not optional. Without them the slice-13 wire-up is dead code.
+
+### P1. Server shutdown signal wired to `Runtime::shutdown`
+
+**Status:** missing. `Runtime::shutdown` exists at `runtime/runtime.rs:354`, but `grep -rn 'shutdown()' src/{ipc,bin}/` returns ZERO callers. The server has no `tokio::signal::ctrl_c()` → graceful shutdown today.
+
+**Consequence if skipped:** the supervisor's `.abort()` hook on each persona's `JoinHandle` becomes dead code — handles drop on process exit, daemon-attach tasks get reaped by tokio runtime drop instead of the orderly path. Wire subscribers leak until process death.
+
+**Required work in slice 13:** wire `tokio::signal::ctrl_c()` (or platform equivalent) in `ipc::start_server`'s main task to call `runtime.shutdown().await`. PersonaSupervisor's `shutdown()` impl then walks its `JoinHandle` collection.
+
+### P2. Single-persona-per-plan invariant (until slice 14)
+
+**Status:** the position-pairing of `provider.next_persona()` outputs to plan rows is **broken from boot 2 onward**.
+
+Trace:
+1. Boot 1: provider mints two fresh identities in plan order. `mint_fresh_intent()` (`resume_or_mint_provider.rs:134`) creates `Uuid::new_v4()` + derives `agent_name` from `agent_name_from_identity(uuid)`. Names are random per UUID.
+2. Plan order `[Helper, Coder]`, persona "Maya" (random) → slot 0 / Helper, "Bart" (random) → slot 1 / Coder. Both write `seed.json` to `personas/<name>/`.
+3. Boot 2: `scan_personas_dir` (`resume_or_mint_provider.rs:200`) calls `dir_entries.sort()` — alphabetical. Disk yields `[Bart, Maya]`. Position-pair: Bart=Helper (was Coder), Maya=Coder (was Helper). **Role identity flipped.**
+
+This is a pre-existing latent bug in `bootstrap_planned` (slice 8) but slice 13 is the first place where (persona_id, role) becomes load-bearing for cognition.
+
+**Slice 13 mitigation:** constrain `plan_for_tier` output to ONE row max via a `debug_assert!(plan.len() <= 1)` at the boot composition. `PersonaSpawnerModule::plan_for_tier` currently returns `[Helper, Coder]` for Compat (slice 7) — the Coder entry gets temporarily commented out behind a `// TODO #133 slice 14: re-enable when RoleAwareProvider lands` marker, and we ship the substrate hosting one Helper persona at all tiers.
+
+**Slice 14 owns:** writing `role: RoleId` into `seed.json` on mint, reading it on resume, refusing to boot if a seed is missing the role field. THEN `plan_for_tier` returns `[Helper, Coder]` again.
+
+This is a real regression in coverage vs the demo binary today (which hosts one persona but its role isn't substrate-typed). Slice 13 still ships the supervisor path; the multi-persona case waits one slice.
+
+### P3. ResourceBroker admission for adapter spawns
+
+**Status:** `modules/resource_broker.rs` exists. Slice 13's adapter materialization loop currently has no admission check.
+
+**Consequence if skipped:** even the LCD case loads ~500 MiB Q4_K_M GGUF per persona. Two personas = ~1 GiB. M5UmaProMax tier could be 5+. Substrate must consult the broker before each `factory.build_adapter()` call. Per [[substrate-is-a-good-citizen-on-the-host]].
+
+**Required work in slice 13:** add `broker.acquire(adapter_memory_budget).await?` before each `materialize_adapters` factory call. Per-slot rejection → mark slot as `RejectedByBroker` in `BootSummary`. The lease handle threads into `HostedPersona` so it releases when the conversation drops.
+
+This is materially new code, not pure composition. If P3 is too heavy for slice 13, the alternative is to gate slice 13 on landing P3 as a slice 12.5 first.
 
 ---
 
@@ -45,145 +86,186 @@ rt_handle.spawn(async move {
 
 The runtime is registered in `PersonaAircRuntimeRegistry`. Nothing pulls events from her airc subscribe stream. She's reachable via `airc peers` but never responds.
 
-### After (slice 13)
+### After (slice 13 — composes existing primitives)
+
+The "after" code uses `bootstrap_planned` (slice 8) + `materialize_adapters` (slice 9) directly, not an open-coded re-implementation. Net-new code is the loop over `Vec<HostedPersona>` calling `spawn_persona_service` with broker admission and slot-result accumulation:
 
 ```rust
+// Pre-boot composition (one-time, before the boot task)
+let host_capability = detect_host_capability(&gpu_monitor, &system_info);  // see Q2
+let tier_id = host_capability.tier_id();                                    // String
+let tier_category = HwTierCategory::from(host_capability);
+let model_registry: &'static Registry = model_registry::global();           // see Q1
+let factory: Arc<dyn PersonaAdapterFactory> = Arc::new(LlamaCppPersonaAdapterFactory);
+let spawner = PersonaSpawnerModule::new(host_capability, tier_category);
+
+// Boot task (replaces the existing 1024–1089 loop)
 let bootstrap_handle = instance_manager.clone();
 let registry_for_lookup = instance_manager.registry().clone();
-let model_registry = crate::model_registry::global_arc();  // see "open question 1"
-let hw_capability = HostCapabilityProbe::detect();         // see "open question 2"
-let tier_category = HwTierCategory::from(hw_capability);
-let factory: Arc<dyn PersonaAdapterFactory> = Arc::new(LlamaCppPersonaAdapterFactory);
-let spawner = PersonaSpawnerModule::new(hw_capability, tier_category);
-let plan = spawner.plan();  // Vec<DesiredRole>
-let mut hosted_handles: Vec<JoinHandle<Result<ServeOutcome, String>>> = Vec::new();
+let supervisor_for_handles = persona_supervisor.clone();  // see Q3
+let broker_for_admission = resource_broker.clone();        // see P3
 
 rt_handle.spawn(async move {
-    let mut provider = ResumeOrMintProvider::new(&continuum_root_for_boot, plan.len()).await?;
-    for (slot_index, desired) in plan.iter().enumerate() {
-        let Some(intent) = provider.next_persona().await? else {
-            tracing::warn!(slot=slot_index, "provider exhausted before plan complete");
-            break;
-        };
-        let info = match bootstrap_handle.bootstrap_one(&intent).await {
-            Ok(i) => i,
-            Err(e) => { tracing::warn!(error=%e, "bootstrap failed for slot {slot_index}"); continue; }
-        };
-        let Some(runtime) = registry_for_lookup.get(info.persona_id) else {
-            tracing::error!("runtime missing from registry post-bootstrap — substrate bug");
-            continue;
-        };
-        let profile = match build_profile(
-            info.persona_id, &info.agent_name, desired.role.as_str(),
-            &hw_capability_id_str, tier_category, &desired.model_id, &model_registry,
-        ) {
-            Ok(p) => p,
-            Err(e) => { tracing::warn!(error=%e, "profile failed for slot {slot_index}"); continue; }
-        };
-        let adapter = match factory.build_adapter(&profile).await {
-            Ok(a) => a,
-            Err(e) => { tracing::warn!(error=%e, "adapter failed for slot {slot_index}"); continue; }
-        };
-        let hosted = HostedPersona {
-            role: desired.role,
-            instance: info,
-            adapter,
-        };
-        let handle = spawn_persona_service(
-            hosted, runtime, ServeOptions::default(), rt_handle.clone(),
-        );
-        hosted_handles.push(handle);
-        tracing::info!("🌐 hosting slot {slot_index} as {} ({})", desired.role.as_str(), desired.model_id);
+    let mut provider = ResumeOrMintProvider::new(&continuum_root_for_boot, 1).await?;
+
+    // Slices 8 + 9 already do the heavy lifting — compose them.
+    let plans = bootstrap_planned(
+        &spawner, &bootstrap_handle, &mut provider, &tier_id, &model_registry_arc,
+    ).await?;  // returns Vec<MaterializedPersonaPlan>, structured per-slot errors threaded through
+
+    let hosted_results = materialize_adapters(plans, &*factory).await;
+    //                                              ↑ per #122 needs broker admission here too;
+    //                                                slice 13 adds the wrapper
+
+    let mut summary = BootSummary::default();
+    for (slot_idx, result) in hosted_results.into_iter().enumerate() {
+        match result {
+            Ok(hosted) => {
+                let Some(runtime) = registry_for_lookup.get(hosted.instance.persona_id) else {
+                    summary.failed.push((slot_idx, hosted.role, "runtime missing post-bootstrap".into()));
+                    continue;
+                };
+                let handle = spawn_persona_service(
+                    hosted.clone(), runtime, ServeOptions::default(), rt_handle.clone(),
+                );
+                supervisor_for_handles.register(hosted.instance.persona_id, handle);
+                summary.hosted += 1;
+            }
+            Err(err) => {
+                let (slot, role) = err.slot_and_role();
+                summary.failed.push((slot, role, err.to_string()));
+            }
+        }
     }
-    // Hand `hosted_handles` to shutdown hook (see "open question 3")
+    bus.publish(BusEvent::new("persona:boot:summary", summary.into()));  // see Q5
 });
 ```
 
+Net-new code in slice 13: ~25 lines of composition + the `BootSummary` struct + the `PersonaSupervisor::register` call surface. Everything else is composing existing primitives.
+
 ---
 
-## Cleanup model (verified during slice-12 review)
+## Cleanup model (corrected from PR #1510 review)
 
-Per the slice-12 reviewer's note (1), I traced the cleanup path through `airc_lib`:
+The slice-12 review noted this section was wrong on the specifics. Corrected:
 
-1. **`spawn_persona_service` → JoinHandle.abort()**: tokio cancels the task at the next await point. The task owns `hosted`, `runtime: Arc<PersonaAircRuntime>`, and `conversation: AircPersonaConversation`. All three drop in order.
-2. **`AircPersonaConversation::drop`**: drops its lazy `Option<EventStream>`.
-3. **`EventStream::drop`** (`airc-lib/src/stream.rs:12`): drops `BroadcastStream<Arc<TranscriptEvent>>`, which drops the `tokio::sync::broadcast::Receiver`. tokio's broadcast channel implementation automatically decrements the subscriber count when the receiver drops — **no manual unsubscribe needed**.
-4. **Wire-level subscription** (`messaging.rs:186` `ensure_wire_subscriber`): this is the per-room daemon-side subscription. It is **ref-counted across all local subscribers to the same room** — dropping one EventStream does NOT tear down the wire subscription. The wire subscriber tears down when the `Arc<PersonaAircRuntime>` (which holds the `Arc<Airc>`) reaches refcount 0, which happens when:
-   - The conversation drops (drops one reference)
-   - The supervisor's `Vec<HostedPersona>` drops or the slot gets `.abort()`-ed (drops the other reference held by `runtime: Arc<...>`)
+The actual cleanup chain on `JoinHandle.abort()`:
 
-**Conclusion:** dropping the JoinHandle alone is sufficient cleanup. No leak. The slice-12 reviewer's concern was reasonable but the architecture already handles it via Arc semantics + the broadcast channel's subscriber-count drop hook.
+1. **`abort()` on the JoinHandle**: tokio cancels the task at the next await point. Task drops, owning `hosted` + `conversation`.
+2. **`AircPersonaConversation::drop`**: drops the lazy `Option<EventStream>`.
+3. **`EventStream::drop`** (`airc-lib/src/stream.rs`): drops the `BroadcastStream<Arc<TranscriptEvent>>` (in-process broadcast receiver). Tokio's broadcast Receiver `drop` decrements the in-process subscriber count.
+4. **Wire subscriber** (`airc-lib/src/transport.rs:65 ensure_wire_subscriber`): **NOT dropped by EventStream alone.** The wire subscriber lives in `Arc<Airc>.inner.subscribers` (a `HashMap<PathBuf, WireSubscriber>`). It's idempotent on `subscribe()` — multiple local broadcast subscribers reuse the same wire subscriber. It tears down only via:
+   - Explicit `teardown_wire(&wire)` call (not the path we use), OR
+   - `Arc<Airc>` reaches refcount 0 (drops `inner.subscribers`).
 
-This SHOULD go into a doc-comment on `spawn_persona_service` so future authors don't re-derive it.
+**Practical implication for the supervisor:** **`.abort()` alone is INSUFFICIENT to release the daemon-side wire subscription.** The supervisor's shutdown path MUST also:
+
+```rust
+join_handle.abort();
+join_handle.await;  // drain the abort
+let runtime = registry.remove(persona_id);  // drops Arc<PersonaAircRuntime> → drops Arc<Airc>
+// Arc<Airc> drop → inner.subscribers drop → wire subscriber tasks drop
+```
+
+If the supervisor's `.abort()` runs but the registry still holds the `Arc<PersonaAircRuntime>`, the wire subscriber stays alive and the daemon keeps sending events into an in-process broadcast channel with no readers — events accumulate in the broadcast buffer until the channel's overflow policy kicks in.
+
+**This is a real architectural constraint** that the slice-13 PersonaSupervisor design has to honor. It's also Finding #4 (next section) — `PersonaAircRuntimeRegistry` is on the cleanup path, so the supervisor can't be orthogonal to it.
 
 ---
 
 ## Open questions for slice 13 implementation
 
-### 1. How does the boot path get an `Arc<Registry>` for `build_profile`?
+### Q1. How does the boot path get a `Registry` for `bootstrap_planned`?
 
-`build_profile` (slice 5) takes `&Arc<crate::model_registry::Registry>`. The current boot path calls `model_registry::init_global() → &'static Registry` at `ipc/mod.rs:705`. We need either:
+`bootstrap_planned` (slice 8) takes `&Arc<crate::model_registry::Registry>`. The current singleton is `OnceLock<Registry>` (`model_registry/singleton.rs:23`) returning `&'static Registry`.
 
-- **(A)** Add `model_registry::global_arc() → Arc<Registry>` (clones the inner state once). Tiny change, idiomatic.
-- **(B)** Refactor `build_profile` to take `&Registry`. Larger change; touches slice-5 signature + every caller.
+**Option A — Add `model_registry::global_arc() → Arc<Registry>`.** Requires changing the singleton storage from `OnceLock<Registry>` to `OnceLock<Arc<Registry>>` AND updating every existing caller of `global()` (the `&'static Registry` lifetime changes). **Not "tiny."**
 
-**Recommendation:** (A). The global registry is a singleton on a `'static`; wrapping it in an `Arc` once at boot is cheap. The `Arc` carries through every layer that needs it without signature changes.
+**Option B — Refactor `bootstrap_planned`'s signature to take `&Registry`.** One-callsite change inside slice 8. Touches `derive_spawn_plan` + `build_profile` (slice 6 + 5) too — they internally hold the `Arc` for cloning across roster entries.
 
-### 2. Where does `hw_capability: HwCapabilityTier` come from?
+**Revised recommendation (corrected from PR #1510 review):** **(B) is smaller** if we accept passing `&Registry` and using `Arc::new()` once internally in `build_profile` (cost: one Arc allocation per persona at boot). Option A's cost analysis was inverted in the first revision of this doc — singleton-storage migration is not "tiny."
 
-The substrate doesn't currently call `HostCapabilityProbe::detect()` at IPC boot. The closest existing primitive is `GpuMemoryManager::detect()` (which IS called for the AIProvider module). We need to either:
+### Q2. Where does `host_capability: HwCapabilityTier` come from?
 
-- **(A)** Add `HostCapabilityProbe::detect_at_boot()` — runs the hw_probe sequence, returns a `(HwCapabilityTier, HwTierCategory)` pair the spawner needs.
-- **(B)** Synthesize from `gpu_manager` we already have: pass through `gpu_manager.gpu_name()` → infer tier.
+The existing `cognition/host_capability_probe.rs:87 fn detect_host_capability(gpu_monitor, system_info) -> HwCapabilityTier` already does this work. No new struct needed.
 
-**Recommendation:** (A). The hw_probe is the substrate's source of truth for tier classification; reusing the GPU-name heuristic is a duplicate-of-(A) trap (the compression principle from CLAUDE.md). One probe at boot, one tier classification.
+**Recommendation:** call `detect_host_capability(&gpu_monitor, &system_info)` from the IPC boot path. ~3 lines.
 
-### 3. Where do `hosted_handles` go for shutdown?
+**Impact of task #52 (Mac Intel misclassification):** slice 13 inherits the misclassification — on Intel Mac with AMD discrete, `detect_host_capability` may classify wrong. Practical effect: the persona is hosted as the wrong tier's `RoleId::Helper` model. Substrate keeps running; persona-side performance is sub-optimal. Acceptable for slice 13; task #52 is the right place to fix the classifier, not slice 13.
 
-The boot task ends after spawning all handles. Without somewhere to send them, `.abort()` on server-stop is impossible (handles drop → tasks detach → wire subscriptions leak until the runtime Arc drops elsewhere).
+### Q3. Where do `hosted_handles` go for shutdown? Does `PersonaSupervisor` duplicate `PersonaAircRuntimeRegistry`?
 
-**Options:**
+`PersonaAircRuntimeRegistry` (`airc_runtime_registry.rs:50`) already holds `persona_id → Arc<PersonaAircRuntime>` — "who's currently online." The proposed PersonaSupervisor holds `persona_id → JoinHandle<...>` — "who's currently being served." **Same keyspace.** Per the compression principle this is a smell.
 
-- **(A)** A new `PersonaSupervisor` module stored on `runtime` (the IPC `ServiceModuleRuntime`). Owns the handles. On runtime shutdown, calls `.abort()` on each.
-- **(B)** Hand the handles to `PersonaAircRuntimeRegistry::remove(persona_id)` — make `remove` await-and-abort the associated task before returning. Tighter coupling; clean call site.
-- **(C)** Spawn a watcher task that joins all handles and exits when they all complete; sufficient for the "personas live as long as the server lives" case; doesn't help with selective abort.
+**Revised recommendation (per PR #1510 review):** **extend `PersonaAircRuntimeRegistry`** rather than introducing a parallel module. The `Arc<PersonaAircRuntime>` registration becomes an `Arc<HostedPersonaRuntime>` that owns both the airc runtime AND the optional service-loop `JoinHandle`:
 
-**Recommendation:** (A) for slice 13 — the supervisor lives at the same lifetime as `PersonaInstanceManagerModule` and owns "who's running right now." Slice 14+ can integrate (B) once the supervisor exposes its abort/respawn API.
+```rust
+pub struct HostedPersonaRuntime {
+    pub airc_runtime: Arc<PersonaAircRuntime>,
+    pub service_loop: Mutex<Option<JoinHandle<Result<ServeOutcome, String>>>>,
+}
+```
 
-### 4. ResumeOrMintProvider count + role mapping
+Registry's existing `remove(persona_id)` method becomes the natural shutdown path: aborts the JoinHandle, awaits drain, drops the Arc. The cleanup chain in the previous section flows through one place. No duplicate keyspace.
 
-Today's boot calls `ResumeOrMintProvider::new(&root, 1)` — minimum 1 persona. The plan from `PersonaSpawnerModule::plan_for_tier()` currently returns 2 entries (Helper + Coder both on LCD per slice 7). So provider count becomes `plan.len()`.
+This is a slice-13 modification to `airc_runtime_registry.rs` — small, additive, doesn't break existing callers (they're all reading the inner `Arc<PersonaAircRuntime>`).
 
-The deeper question: **role identity vs persona identity**. ResumeOrMintProvider yields `PersonaIdentityIntent { persona_id, agent_name, source }` — no role field. Slice 13 pairs the Nth intent with the Nth plan entry by position. That's reasonable for the LCD case (every persona at this tier is helper/coder) but doesn't survive once roles diverge (Sentinel runs on different hardware than Helper).
+### Q4. ResumeOrMintProvider count + role mapping → (see P2)
 
-**Slice 14 work:** RoleAwareProvider that yields `(PersonaIdentityIntent, RoleId)` pairs, possibly reading the role from seed.json. Out of scope here.
+Per P2, slice 13 ships with `plan.len() <= 1`. Slice 14 lands `RoleAwareProvider` + role-in-seed.json. Doc resolves to single-role until then.
 
-### 5. Error policy for per-slot failures
+### Q5. Error policy for per-slot failures
 
-Today's loop logs and continues. Per [[no-fallbacks-ever]] this is correct — the substrate refuses to substitute a default persona for a failed slot. But the boot path should at least surface a structured count: "tier planned N, M failed."
+Per [[no-fallbacks-ever]]: per-slot failures stay failed. Per [[observability-is-half-the-architecture]]: the boot path publishes a `BootSummary { planned, hosted, failed: Vec<(slot, role, error)> }` to the existing event bus.
 
-**Recommendation:** publish a `BootSummary { planned, hosted, failed: Vec<(slot, role, error)> }` event via the existing event bus. Operators see what happened without scraping logs. Per [[observability-is-half-the-architecture]].
+**Venue (corrected from PR #1510 review):** publish to `MessageBus::publish(BusEvent { name: "persona:boot:summary", payload })`. No declared subscribers in slice 13 — the event is for operator scraping via `events/recent` IPC. If a future module wants automated alerting (e.g., "more than 50% slots failed → page someone"), it subscribes then. This is a "log it now, react to it later" event per the substrate's standard observability pattern.
+
+### Q6. Hot-reload semantics for seed.json (NEW — was Finding #10)
+
+**Out of scope for slice 13.** The boot loop runs once and exits. New seed.json files appearing at runtime do NOT trigger re-scan. Operator can fire the existing `persona/instances/bootstrap` IPC command (`ipc/mod.rs:947`) to bring up a new persona ad-hoc. A filesystem-watcher path is reasonable future work but is its own design problem (race conditions on partial writes, etc.).
+
+### Q7. Wire-subscription failure mid-boot (NEW — was Finding #11)
+
+If `AircPersonaConversation::next_message`'s first call fails (daemon dies between bootstrap and service-loop start), `serve_persona_loop` returns `Err`, the `JoinHandle` resolves with `Err(...)`. Slice 13's design: the supervisor periodically inspects `JoinHandle::is_finished()` for each registered persona, and if a handle resolved with Err, logs + emits a `persona:host:failed` event + removes from the registry. This is a slice-13 polling task (every 5s say) rather than a JoinHandle-watch (which would need a separate listener task per persona). Polling is enough — the failure mode is rare and operator-investigated.
 
 ---
 
 ## Test plan for slice 13
 
-Existing slice 5–12 tests cover the composition pieces. New tests for slice 13:
+1. **`PersonaBootstrapper` trait split** — for stubbing `bootstrap_one` without an airc daemon. Modest scope; lets the boot composition test exercise the (registry-lookup, profile-build, adapter-build, spawn) chain on stubs.
+2. **Stub airc daemon for integration**: slice 12 already established the pattern (`StubConversation` in `service_loop.rs` tests). Slice 13's integration test wires a stub `PersonaInstanceManagerModule` + stub adapter factory + stub conversation through the boot composition function. Verifies BootSummary contents on happy + failure paths.
+3. **`Runtime::shutdown` test**: a small test that constructs a boot composition + invokes `runtime.shutdown().await` + asserts all JoinHandles are torn down + all wire subscribers gone (via stub airc).
+4. **Per-slot failure isolation**: stub adapter factory rejects slot 0; verify slots 1+ still spawn; BootSummary captures the slot-0 rejection.
+5. **`scan_personas_dir` boot-order test (REGRESSION)**: write the alphabetical-sort hazard into a fixture test that boots, restarts, asserts roles haven't flipped. Goes red until slice 14 lands role-in-seed.json. Pinned as `#[ignore = "tracks task #133 slice 14"]` until then.
 
-1. **Mock-bootstrap integration test**: stub `PersonaInstanceManagerModule` via a trait split (similar to how slice 9 introduced `PersonaAdapterFactory`). Verify the boot loop calls bootstrap N times, materializes adapters N times, spawns N handles. Slice 13 introduces a `PersonaBootstrapper` trait for this — modest scope.
-2. **Provider-exhausted test**: ResumeOrMintProvider yields M < N intents. Verify boot logs the deficit and proceeds with M handles, not N. Already exercised in slice 8's `bootstrap_planned_exhausted_provider_errors_with_slot_info` — slice 13's test just wraps that path.
-3. **Per-slot adapter-failure test**: stub factory rejects slot 1. Verify slot 0 + slot 2 still spawn; slot 1 logs structured error.
-
-Integration test happens through the IPC server itself (no stub airc daemon available). Slice 13 lands behind a `cfg(test)` guard that lets us inject the stubs at the boot composition point.
+Integration test happens via the IPC server itself — no real airc daemon, no real GGUF; the stub layer is the substrate's testability story.
 
 ---
 
 ## What slice 13 does NOT do
 
-- **Adapter pool sharing (#122 shared-base + LoRA paging)**: slice 13 builds one adapter per persona via `LlamaCppPersonaAdapterFactory`. On Intel Mac LCD this means 2 × Qwen2.5-0.5B GGUF loads. With Q4_K_M at ~468 MiB each, fine (~1 GiB). Shared base is #122's territory, not slice 13's.
-- **AircRemoteInferenceAdapter integration (#108 slice D/E)**: slice 13 routes every persona through the local adapter. Cross-grid inference is its own thread.
-- **Per-persona LoRA selection**: today's profile carries `model_id` but not a LoRA reference. #124 IdentityProjector + #126 first-connection ceremony land that.
-- **Role-aware provider**: noted in open question 4.
+- **Multi-persona-per-plan** — see P2. Single Helper per tier until slice 14.
+- **Shared-base / LoRA paging (#122)** — slice 13 builds one adapter per persona via `LlamaCppPersonaAdapterFactory`. Two adapters at LCD is fine (~1 GiB). Higher-tier multi-persona waits for #122.
+- **Cross-grid inference (#108)** — every persona routes through local adapter.
+- **Per-persona LoRA selection (#124, #126)** — today's profile carries `model_id` only.
+- **Hot-reload of seed.json** — see Q6.
+- **Filesystem-watcher persona introduction** — see Q6.
+- **Automated alerting on BootSummary failures** — see Q5; out of scope until a subscriber wants it.
+
+---
+
+## Slice-13 implementation checklist (extracted from above for the PR)
+
+- [ ] P1 — `tokio::signal::ctrl_c()` → `runtime.shutdown()` wired in `ipc::start_server`
+- [ ] P2 — `plan_for_tier` Compat tier returns `[Helper]` only; Coder entry commented with `// TODO #133 slice 14`; `debug_assert!(plan.len() <= 1)` at the boot composition
+- [ ] P3 — `ResourceBroker.acquire(...)` called before each `factory.build_adapter`; lease tied to `HostedPersona` lifetime
+- [ ] Q1 — `bootstrap_planned` signature takes `&Registry`, internal `Arc::new` once per call
+- [ ] Q2 — boot path calls `detect_host_capability(&gpu_monitor, &system_info)` directly
+- [ ] Q3 — `PersonaAircRuntimeRegistry` extended to hold `HostedPersonaRuntime { airc_runtime, service_loop }`; `remove(persona_id)` becomes the shutdown path
+- [ ] Q5 — `BootSummary` struct + `MessageBus::publish("persona:boot:summary", ...)` at boot composition end
+- [ ] Q7 — supervisor poller task checking `JoinHandle::is_finished()` per registered persona, every 5s
+- [ ] Boot loop at `ipc/mod.rs:1024-1089` REPLACED by the composition above (delete the welcome-log-only path per [[organization-purity-as-we-migrate]] — don't keep both)
+- [ ] Tests 1–5 from the test plan section land alongside
 
 ---
 
@@ -203,8 +285,9 @@ Integration test happens through the IPC server itself (no stub airc daemon avai
 - [[no-fallbacks-ever]] — per-slot errors stay errored
 - [[no-if-statements-use-llms-for-cognition]] — boot path filters substrate signals only; LLM judges everything else
 - [[no-stdio-piping-for-process-ipc]] — substrate talks only via typed sockets
-- [[substrate-is-a-good-citizen-on-the-host]] — caller controls scheduling pool
+- [[substrate-is-a-good-citizen-on-the-host]] — caller controls scheduling pool AND consults ResourceBroker before adapter spawn (P3)
 - [[observability-is-half-the-architecture]] — BootSummary as a first-class event
-- [[organization-purity-as-we-migrate]] — slice 13 deletes the welcome-log-only path; doesn't keep both
+- [[organization-purity-as-we-migrate]] — slice 13 deletes the welcome-log-only path; doesn't keep both. Also: don't reinvent `bootstrap_planned` / `materialize_adapters` — compose them.
 - [[constitutional-design-always-a-next-step]] — every open question has a recommendation
 - [[commands-are-dumb-daemons-are-smart]] — `spawn_persona_service` stays trivial; the smart roster reconciliation lives in the supervisor
+- [[every-error-is-an-opportunity-to-battle-harden]] — the position-pairing hazard (P2) gets a regression test that goes red until slice 14 lands

--- a/docs/planning/HEADLESS-PERSONA-HOST-LOOP.md
+++ b/docs/planning/HEADLESS-PERSONA-HOST-LOOP.md
@@ -25,17 +25,30 @@ Slice 13 is the rewire that makes the substrate actually host personas headlessl
 
 ---
 
-## Hard prerequisites (must land BEFORE or AS PART OF slice 13)
+## Slice 13 scope vs deferred follow-ups (REVISED per PR #1510 re-review)
 
-These are not optional. Without them the slice-13 wire-up is dead code.
+The original draft listed P1/P3/Q5/Q7 as "hard prerequisites that MUST land in slice 13." PR #1510 re-review #2 caught the divergence: the slice 13 implementation (#1511, now merged) explicitly defers all four with TODOs cited in the boot-composition preamble. This section accurately reflects what shipped vs what's deferred — and why the substrate is whole without them.
 
-### P1. Server shutdown signal wired to `Runtime::shutdown`
+### Shipped in slice 13 (PR #1511, merged 2026-06-02)
 
-**Status:** missing. `Runtime::shutdown` exists at `runtime/runtime.rs:354`, but `grep -rn 'shutdown()' src/{ipc,bin}/` returns ZERO callers. The server has no `tokio::signal::ctrl_c()` → graceful shutdown today.
+- **Q1**: `bootstrap_planned` / `derive_spawn_plan` / `build_profile` take `&Registry` instead of `&Arc<Registry>`.
+- **Q3**: `PersonaAircRuntimeRegistry` extended to `PersonaSlot { runtime, service_loop }`. `attach_service_loop`, `is_service_loop_finished`, `shutdown_slot` methods added. One keyspace owns both.
+- **P2**: `plan_for_tier` returns single Helper. `debug_assert!(plan.len() <= 1)` at the producer. `slice_14_restores_helper_plus_coder_for_compat` test pinned `#[ignore]` until slice 14.
+- **Boot composition**: `crate::ipc::start_server` boot loop replaced by `bootstrap_planned → materialize_adapters → spawn_persona_service → attach_service_loop`. Old welcome-log-only path deleted per [[organization-purity-as-we-migrate]].
+- **Q2 (partial)**: boot uses `HwCapabilityTier::CpuOnly + HwTierCategory::Compat` hardcoded. `detect_host_capability(&gpu_monitor, &system_info)` is a 3-line replacement once a production `GpuMonitor` constructor exists (no production callsite builds one today; only tests do). TODO in `ipc/mod.rs` cites task #52.
 
-**Consequence if skipped:** the supervisor's `.abort()` hook on each persona's `JoinHandle` becomes dead code — handles drop on process exit, daemon-attach tasks get reaped by tokio runtime drop instead of the orderly path. Wire subscribers leak until process death.
+### Deferred follow-ups (slice 13.5+)
 
-**Required work in slice 13:** wire `tokio::signal::ctrl_c()` (or platform equivalent) in `ipc::start_server`'s main task to call `runtime.shutdown().await`. PersonaSupervisor's `shutdown()` impl then walks its `JoinHandle` collection.
+- **P1**: `tokio::signal::ctrl_c()` → `Runtime::shutdown` is NOT wired in slice 13. Per-slot shutdown is available via `PersonaAircRuntimeRegistry::shutdown_slot` and exercised by `persona/instances/*` IPC commands. Server-level signal handler is its own sub-slice. **Consequence today:** server stops via process kill; tokio runtime drop reaps daemon-attach tasks. Per the cleanup-model section below this is sufficient against the pinned airc rev — `.abort()` (or drop) on the `EventStream`'s `DaemonAttachGuard` aborts the per-channel attach handles. No leak.
+- **P3**: `ResourceBroker.acquire` admission before `factory.build_adapter` is NOT in slice 13. Current LCD case is 1 persona × ~500 MiB GGUF, well within all supported tiers. Becomes load-bearing when multi-persona returns in slice 14 (where #122 shared-base + LoRA paging will need broker admission for the LoRA cache).
+- **Q5**: structured `BootSummary` event publishing is NOT in slice 13. The boot composition logs `hosted_count` / `failed_count` / per-slot `tracing::warn!` for now. Operator observability via log scraping. `MessageBus::publish("persona:boot:summary", ...)` is a slice-13.5 follow-up when a subscriber (alerter, dashboard) wants it.
+- **Q7**: per-persona `is_service_loop_finished` poller is NOT in slice 13. The registry exposes `is_service_loop_finished` so a supervisor poller can land later; for now operators observe via `persona/instances/list` (the registry surfaces the same data through the IPC command).
+
+### Why this divergence is acceptable
+
+Single-persona LCD is in-budget for all tiers. The supervisor's `shutdown_slot` (the orderly path that registry-removes + JoinHandle-aborts) is already exposed for the IPC commands. The cleanup-model section below shows that `.abort()` ALONE (the path tokio runtime drop takes) is sufficient against the pinned airc rev. P1/P3/Q5/Q7 are observability + back-pressure refinements, not invariants the slice-13 substrate violates.
+
+The original "Hard prerequisites" framing predates that verification. The implementation deferred them because the substrate doesn't break without them. The Q2 deferral (no production `GpuMonitor` constructor) is the only one tied to a genuine missing primitive; tasks #52 + slice 13.5 cover it.
 
 ### P2. Single-persona-per-plan invariant (until slice 14)
 
@@ -53,16 +66,6 @@ This is a pre-existing latent bug in `bootstrap_planned` (slice 8) but slice 13 
 **Slice 14 owns:** writing `role: RoleId` into `seed.json` on mint, reading it on resume, refusing to boot if a seed is missing the role field. THEN `plan_for_tier` returns `[Helper, Coder]` again.
 
 This is a real regression in coverage vs the demo binary today (which hosts one persona but its role isn't substrate-typed). Slice 13 still ships the supervisor path; the multi-persona case waits one slice.
-
-### P3. ResourceBroker admission for adapter spawns
-
-**Status:** `modules/resource_broker.rs` exists. Slice 13's adapter materialization loop currently has no admission check.
-
-**Consequence if skipped:** even the LCD case loads ~500 MiB Q4_K_M GGUF per persona. Two personas = ~1 GiB. M5UmaProMax tier could be 5+. Substrate must consult the broker before each `factory.build_adapter()` call. Per [[substrate-is-a-good-citizen-on-the-host]].
-
-**Required work in slice 13:** add `broker.acquire(adapter_memory_budget).await?` before each `materialize_adapters` factory call. Per-slot rejection → mark slot as `RejectedByBroker` in `BootSummary`. The lease handle threads into `HostedPersona` so it releases when the conversation drops.
-
-This is materially new code, not pure composition. If P3 is too heavy for slice 13, the alternative is to gate slice 13 on landing P3 as a slice 12.5 first.
 
 ---
 
@@ -117,59 +120,96 @@ rt_handle.spawn(async move {
     //                                              ↑ per #122 needs broker admission here too;
     //                                                slice 13 adds the wrapper
 
-    let mut summary = BootSummary::default();
+    let mut hosted_count: usize = 0;
+    let mut failed_count: usize = 0;
     for (slot_idx, result) in hosted_results.into_iter().enumerate() {
         match result {
             Ok(hosted) => {
-                let Some(runtime) = registry_for_lookup.get(hosted.instance.persona_id) else {
-                    summary.failed.push((slot_idx, hosted.role, "runtime missing post-bootstrap".into()));
-                    continue;
-                };
+                // `hosted` is the PersonaContext — already carries
+                // the airc runtime as `hosted.runtime` per the
+                // `&ctx` doctrine. No separate lookup.
+                let persona_id = hosted.identity.persona_id;
                 let handle = spawn_persona_service(
-                    hosted.clone(), runtime, ServeOptions::default(), rt_handle.clone(),
+                    hosted, ServeOptions::default(), rt_handle.clone(),
                 );
-                supervisor_for_handles.register(hosted.instance.persona_id, handle);
-                summary.hosted += 1;
+                if let Err((returned_handle, reason)) = registry_for_lookup
+                    .attach_service_loop(persona_id, handle)
+                    .await
+                {
+                    returned_handle.abort();
+                    let _ = returned_handle.await;
+                    tracing::error!(slot=slot_idx, persona_id=%persona_id, reason, "attach failed; handle drained");
+                    failed_count += 1;
+                    continue;
+                }
+                hosted_count += 1;
             }
             Err(err) => {
-                let (slot, role) = err.slot_and_role();
-                summary.failed.push((slot, role, err.to_string()));
+                tracing::warn!(slot=slot_idx, error=?err, "slot materialization failed");
+                failed_count += 1;
             }
         }
     }
-    bus.publish(BusEvent::new("persona:boot:summary", summary.into()));  // see Q5
+    tracing::info!(hosted=hosted_count, failed=failed_count, "🌐 Substrate boot composition complete (slice 13)");
 });
 ```
 
-Net-new code in slice 13: ~25 lines of composition + the `BootSummary` struct + the `PersonaSupervisor::register` call surface. Everything else is composing existing primitives.
+Net-new code in slice 13: ~25 lines of composition. Everything else is composing existing primitives — `bootstrap_planned` (slice 8), `materialize_adapters` (slice 9), `spawn_persona_service` (slice 12), `attach_service_loop` (slice 13 Q3). `BootSummary` event publishing is the **Q5 deferred follow-up** noted in the scope section above — for now slice 13 emits `tracing::info!` lines with the same counters; a structured `MessageBus::publish("persona:boot:summary", ...)` lands when a subscriber wants it.
 
 ---
 
-## Cleanup model (corrected from PR #1510 review)
+## Cleanup model (REVISED per PR #1510 re-review against pinned `f6ed190`)
 
-The slice-12 review noted this section was wrong on the specifics. Corrected:
+PR #1510 re-review #1 caught that the prior revision named the wrong cleanup mechanism. The actual mechanism against the airc rev pinned in `src/workers/Cargo.toml:44-48` (`f6ed190`) is `DaemonAttachGuard`, not the older `ensure_wire_subscriber` / `inner.subscribers` map.
 
-The actual cleanup chain on `JoinHandle.abort()`:
+### What actually fires the cleanup
 
-1. **`abort()` on the JoinHandle**: tokio cancels the task at the next await point. Task drops, owning `hosted` + `conversation`.
-2. **`AircPersonaConversation::drop`**: drops the lazy `Option<EventStream>`.
-3. **`EventStream::drop`** (`airc-lib/src/stream.rs`): drops the `BroadcastStream<Arc<TranscriptEvent>>` (in-process broadcast receiver). Tokio's broadcast Receiver `drop` decrements the in-process subscriber count.
-4. **Wire subscriber** (`airc-lib/src/transport.rs:65 ensure_wire_subscriber`): **NOT dropped by EventStream alone.** The wire subscriber lives in `Arc<Airc>.inner.subscribers` (a `HashMap<PathBuf, WireSubscriber>`). It's idempotent on `subscribe()` — multiple local broadcast subscribers reuse the same wire subscriber. It tears down only via:
-   - Explicit `teardown_wire(&wire)` call (not the path we use), OR
-   - `Arc<Airc>` reaches refcount 0 (drops `inner.subscribers`).
+Production subscribe (`airc-lib/src/messaging.rs:204 subscribe()`) is daemon-attached. It returns an `EventStream` whose internal `EventStreamInner::Daemon` variant holds a `DaemonAttachGuard` (`airc-lib/src/stream.rs:25-68`). The guard owns `Vec<JoinHandle<()>>` — the per-channel attach tasks spawned by `daemon_subscribe`.
 
-**Practical implication for the supervisor:** **`.abort()` alone is INSUFFICIENT to release the daemon-side wire subscription.** The supervisor's shutdown path MUST also:
-
+`DaemonAttachGuard::drop` (`stream.rs:62-68`):
 ```rust
-join_handle.abort();
-join_handle.await;  // drain the abort
-let runtime = registry.remove(persona_id);  // drops Arc<PersonaAircRuntime> → drops Arc<Airc>
-// Arc<Airc> drop → inner.subscribers drop → wire subscriber tasks drop
+impl Drop for DaemonAttachGuard {
+    fn drop(&mut self) {
+        for handle in &self.handles {
+            handle.abort();
+        }
+    }
+}
 ```
 
-If the supervisor's `.abort()` runs but the registry still holds the `Arc<PersonaAircRuntime>`, the wire subscriber stays alive and the daemon keeps sending events into an in-process broadcast channel with no readers — events accumulate in the broadcast buffer until the channel's overflow policy kicks in.
+When the `EventStream` drops, the guard drops, the per-channel attach tasks abort. IPC connections close at the next poll. **No leak.**
 
-**This is a real architectural constraint** that the slice-13 PersonaSupervisor design has to honor. It's also Finding #4 (next section) — `PersonaAircRuntimeRegistry` is on the cleanup path, so the supervisor can't be orthogonal to it.
+### The cleanup chain on `JoinHandle.abort()`
+
+1. **`abort()` on the spawned service-loop `JoinHandle`**: tokio cancels the task at the next await point.
+2. **Task drops**: `hosted` (PersonaContext) and `conversation` (AircPersonaConversation) drop.
+3. **`AircPersonaConversation::drop`**: drops the held `EventStream`.
+4. **`EventStream::drop` → `DaemonAttachGuard::drop`**: aborts each per-channel attach `JoinHandle`. Per-channel attach tasks tear down, IPC handles close.
+
+`.abort()` ALONE is sufficient.
+
+### What `shutdown_slot` adds (and why)
+
+`PersonaAircRuntimeRegistry::shutdown_slot(persona_id)` does the strictly-stronger sequence:
+1. Take the JoinHandle out of the slot.
+2. `abort()` it AND `await` the JoinHandle (drains cleanly — the abort path's cancellation Error is discarded; we did the shutdown intentionally).
+3. Remove the slot from the registry — drops `Arc<PersonaSlot>`, drops `Arc<PersonaAircRuntime>`, drops `Arc<Airc>` (once the last reference releases).
+
+The `await` step ensures the task has fully cancelled before the function returns — useful for orderly server shutdown where the next step depends on this persona being gone. The registry-remove step releases the in-substrate Arc references (so a follow-up `registry.get(persona_id)` correctly returns `None`).
+
+But the daemon-side IPC cleanup happens via the `DaemonAttachGuard` drop chain inside step 2 (the abort path) — the registry-remove is for in-substrate state hygiene, not for daemon-side teardown. Either path (just abort OR shutdown_slot) cleans up the daemon side. `shutdown_slot` adds the registry-remove + drain ordering on top.
+
+### Practical implication
+
+- **Tokio runtime drop on process exit** (slice 13's actual shutdown path until P1 lands): all task `JoinHandle`s drop, all daemon-attach tasks abort via the guard chain. Daemon sees the IPC connection close at its end of the socket. Clean enough for a server exit.
+- **Per-slot shutdown via `persona/instances/*` IPC commands**: uses `shutdown_slot`; orderly + drained + registry cleared. Operator-driven and load-bearing once slice 14 ships multi-persona.
+- **`P1` (slice 13.5)**: wires `tokio::signal::ctrl_c` → walk the registry → call `shutdown_slot` on each persona → then `runtime.shutdown()`. The orderly path for graceful Ctrl-C.
+
+### Architectural constraint (now corrected)
+
+The original "registry-remove is on the cleanup path" framing was wrong for the daemon-side teardown — it's on the in-substrate-state cleanup path. The daemon-side teardown is the `DaemonAttachGuard` drop chain. Both paths matter at different layers; conflating them was the doc's error.
+
+`PersonaAircRuntimeRegistry` is still the single keyspace owning per-persona lifetime info (Q3's resolution stands) — but it's not the sole authority on daemon-side resource release. That authority is the `DaemonAttachGuard` chain inside airc-lib. The substrate just has to let `EventStream` drop happen (which it does, on any abort or task drop).
 
 ---
 
@@ -254,18 +294,29 @@ Integration test happens via the IPC server itself — no real airc daemon, no r
 
 ---
 
-## Slice-13 implementation checklist (extracted from above for the PR)
+## Slice-13 status (PR #1511 merged 2026-06-02)
 
-- [ ] P1 — `tokio::signal::ctrl_c()` → `runtime.shutdown()` wired in `ipc::start_server`
-- [ ] P2 — `plan_for_tier` Compat tier returns `[Helper]` only; Coder entry commented with `// TODO #133 slice 14`; `debug_assert!(plan.len() <= 1)` at the boot composition
-- [ ] P3 — `ResourceBroker.acquire(...)` called before each `factory.build_adapter`; lease tied to `HostedPersona` lifetime
-- [ ] Q1 — `bootstrap_planned` signature takes `&Registry`, internal `Arc::new` once per call
-- [ ] Q2 — boot path calls `detect_host_capability(&gpu_monitor, &system_info)` directly
-- [ ] Q3 — `PersonaAircRuntimeRegistry` extended to hold `HostedPersonaRuntime { airc_runtime, service_loop }`; `remove(persona_id)` becomes the shutdown path
-- [ ] Q5 — `BootSummary` struct + `MessageBus::publish("persona:boot:summary", ...)` at boot composition end
-- [ ] Q7 — supervisor poller task checking `JoinHandle::is_finished()` per registered persona, every 5s
-- [ ] Boot loop at `ipc/mod.rs:1024-1089` REPLACED by the composition above (delete the welcome-log-only path per [[organization-purity-as-we-migrate]] — don't keep both)
-- [ ] Tests 1–5 from the test plan section land alongside
+**Shipped:**
+- [x] Q1 — `bootstrap_planned` signature takes `&Registry`
+- [x] Q3 — `PersonaAircRuntimeRegistry` extended to `PersonaSlot { runtime, service_loop }`; `attach_service_loop`, `is_service_loop_finished`, `shutdown_slot` methods
+- [x] P2 — `plan_for_tier` returns single Helper, `debug_assert!`, ignored slice-14 regression test
+- [x] Boot loop at `ipc/mod.rs` REPLACED by the composition above (per [[organization-purity-as-we-migrate]])
+- [x] Q2 (partial) — hardcoded `CpuOnly + Compat` with TODO citing task #52 + missing production `GpuMonitor` constructor
+
+**Plus integration polish in PR #1511:**
+- [x] Room-name discovery (`discover_default_room_name`) — fixes the join-by-uuid-as-string hazard that landed Paige in the wrong channel
+- [x] LCD model (`continuum-ai/qwen2.5-0.5b-instruct-GGUF`) added to `model_registry::catalog::models()`
+- [x] `PersonaContext` rename (was `HostedPersona`) + `RagInspectionRequest::for_persona(&profile)` single derivation site (the `&ctx` doctrine — see [[context-is-the-client-airc-token-is-identity]])
+
+**Deferred to slice 13.5+ (see Scope section above for reasoning):**
+- [ ] P1 — `tokio::signal::ctrl_c()` → `runtime.shutdown()` wired
+- [ ] P3 — `ResourceBroker.acquire(...)` admission before factory.build_adapter
+- [ ] Q5 — structured `BootSummary` `MessageBus::publish`
+- [ ] Q7 — supervisor poller checking `is_service_loop_finished` every 5s
+- [ ] Q2 completion — `detect_host_capability` once a production `GpuMonitor` constructor lands (task #52-adjacent)
+
+**Integration validation (2026-06-02):**
+- Substrate-hosted Paige replied in Joel's `continuum` room: "Hello Joel, thank you for testing the substrate-managed host loop. I'm here to assist with any questions or concerns you have." Full trace: airc msg → boot composition → AircPersonaConversation subscribe → RagInspectionRequest::for_persona(&ctx.profile) → inspect_persona_rag_with_inference → ctx.runtime.say. Five layers proved end-to-end on Intel Mac CPU-only.
 
 ---
 

--- a/docs/planning/HEADLESS-PERSONA-HOST-LOOP.md
+++ b/docs/planning/HEADLESS-PERSONA-HOST-LOOP.md
@@ -1,0 +1,210 @@
+# Headless Persona Host Loop — #133 Slice 13 Design
+
+**Status:** Design (slice 13 not yet implemented). Captures the wire-up plan + the cleanup model verified during slice-12 review.
+
+**Tracks:** #133 ("LCD-first substrate spawn path"), #121 ("PersonaSpawnerModule"). Reads on top of the merged slices 5–12.
+
+**Adjacent issues:** task #52 (Governor classify_silicon misclassifies Mac Intel as AppleM), task #82 (CBOR Response::Event schema mismatch).
+
+---
+
+## The moment-of-truth
+
+After slices 5–12, the substrate has:
+
+- **Planning** (slice 7): `PersonaSpawnerModule::plan() → Vec<DesiredRole>`
+- **Bootstrap** (slice 8): `bootstrap_planned(...) → Vec<MaterializedPersonaPlan>` — turns plan rows into airc identities via `PersonaInstanceManagerModule::bootstrap_one`
+- **Adapter materialization** (slice 9): `materialize_adapters(plans, factory) → Vec<HostedPersona>`
+- **Service loop** (slice 10): `serve_persona_loop(hosted, conversation, reader, opts)`
+- **Production conversation** (slice 11): `AircPersonaConversation::new(runtime)`
+- **Spawn helper** (slice 12): `spawn_persona_service(hosted, runtime, opts, rt_handle) → JoinHandle<Result<ServeOutcome, String>>`
+
+What's missing: **nothing in `continuum-core` actually calls this composition at boot.** The existing IPC boot loop at `crate::ipc::start_server` (≈line 1024–1089) calls `bootstrap_one(&intent)` and then *only logs* — it never starts hosting the persona on the grid.
+
+Slice 13 is the rewire that makes the substrate actually host personas headlessly. The demo binary keeps working (slice 11 reshape) but stops being on the critical path. `npm start` with no demo binary running produces talking personas.
+
+---
+
+## Boot flow before / after
+
+### Before (current `ipc/mod.rs:1024–1089`)
+
+```rust
+let bootstrap_handle = instance_manager.clone();
+rt_handle.spawn(async move {
+    let mut provider = ResumeOrMintProvider::new(&continuum_root_for_boot, 1).await?;
+    loop {
+        let intent = provider.next_persona().await?.unwrap();
+        match bootstrap_handle.bootstrap_one(&intent).await {
+            Ok(info) => tracing::info!(/* welcome log */),  // ← persona online but mute
+            Err(e) => tracing::warn!(/* boot failure */),
+        }
+    }
+});
+```
+
+The runtime is registered in `PersonaAircRuntimeRegistry`. Nothing pulls events from her airc subscribe stream. She's reachable via `airc peers` but never responds.
+
+### After (slice 13)
+
+```rust
+let bootstrap_handle = instance_manager.clone();
+let registry_for_lookup = instance_manager.registry().clone();
+let model_registry = crate::model_registry::global_arc();  // see "open question 1"
+let hw_capability = HostCapabilityProbe::detect();         // see "open question 2"
+let tier_category = HwTierCategory::from(hw_capability);
+let factory: Arc<dyn PersonaAdapterFactory> = Arc::new(LlamaCppPersonaAdapterFactory);
+let spawner = PersonaSpawnerModule::new(hw_capability, tier_category);
+let plan = spawner.plan();  // Vec<DesiredRole>
+let mut hosted_handles: Vec<JoinHandle<Result<ServeOutcome, String>>> = Vec::new();
+
+rt_handle.spawn(async move {
+    let mut provider = ResumeOrMintProvider::new(&continuum_root_for_boot, plan.len()).await?;
+    for (slot_index, desired) in plan.iter().enumerate() {
+        let Some(intent) = provider.next_persona().await? else {
+            tracing::warn!(slot=slot_index, "provider exhausted before plan complete");
+            break;
+        };
+        let info = match bootstrap_handle.bootstrap_one(&intent).await {
+            Ok(i) => i,
+            Err(e) => { tracing::warn!(error=%e, "bootstrap failed for slot {slot_index}"); continue; }
+        };
+        let Some(runtime) = registry_for_lookup.get(info.persona_id) else {
+            tracing::error!("runtime missing from registry post-bootstrap — substrate bug");
+            continue;
+        };
+        let profile = match build_profile(
+            info.persona_id, &info.agent_name, desired.role.as_str(),
+            &hw_capability_id_str, tier_category, &desired.model_id, &model_registry,
+        ) {
+            Ok(p) => p,
+            Err(e) => { tracing::warn!(error=%e, "profile failed for slot {slot_index}"); continue; }
+        };
+        let adapter = match factory.build_adapter(&profile).await {
+            Ok(a) => a,
+            Err(e) => { tracing::warn!(error=%e, "adapter failed for slot {slot_index}"); continue; }
+        };
+        let hosted = HostedPersona {
+            role: desired.role,
+            instance: info,
+            adapter,
+        };
+        let handle = spawn_persona_service(
+            hosted, runtime, ServeOptions::default(), rt_handle.clone(),
+        );
+        hosted_handles.push(handle);
+        tracing::info!("🌐 hosting slot {slot_index} as {} ({})", desired.role.as_str(), desired.model_id);
+    }
+    // Hand `hosted_handles` to shutdown hook (see "open question 3")
+});
+```
+
+---
+
+## Cleanup model (verified during slice-12 review)
+
+Per the slice-12 reviewer's note (1), I traced the cleanup path through `airc_lib`:
+
+1. **`spawn_persona_service` → JoinHandle.abort()**: tokio cancels the task at the next await point. The task owns `hosted`, `runtime: Arc<PersonaAircRuntime>`, and `conversation: AircPersonaConversation`. All three drop in order.
+2. **`AircPersonaConversation::drop`**: drops its lazy `Option<EventStream>`.
+3. **`EventStream::drop`** (`airc-lib/src/stream.rs:12`): drops `BroadcastStream<Arc<TranscriptEvent>>`, which drops the `tokio::sync::broadcast::Receiver`. tokio's broadcast channel implementation automatically decrements the subscriber count when the receiver drops — **no manual unsubscribe needed**.
+4. **Wire-level subscription** (`messaging.rs:186` `ensure_wire_subscriber`): this is the per-room daemon-side subscription. It is **ref-counted across all local subscribers to the same room** — dropping one EventStream does NOT tear down the wire subscription. The wire subscriber tears down when the `Arc<PersonaAircRuntime>` (which holds the `Arc<Airc>`) reaches refcount 0, which happens when:
+   - The conversation drops (drops one reference)
+   - The supervisor's `Vec<HostedPersona>` drops or the slot gets `.abort()`-ed (drops the other reference held by `runtime: Arc<...>`)
+
+**Conclusion:** dropping the JoinHandle alone is sufficient cleanup. No leak. The slice-12 reviewer's concern was reasonable but the architecture already handles it via Arc semantics + the broadcast channel's subscriber-count drop hook.
+
+This SHOULD go into a doc-comment on `spawn_persona_service` so future authors don't re-derive it.
+
+---
+
+## Open questions for slice 13 implementation
+
+### 1. How does the boot path get an `Arc<Registry>` for `build_profile`?
+
+`build_profile` (slice 5) takes `&Arc<crate::model_registry::Registry>`. The current boot path calls `model_registry::init_global() → &'static Registry` at `ipc/mod.rs:705`. We need either:
+
+- **(A)** Add `model_registry::global_arc() → Arc<Registry>` (clones the inner state once). Tiny change, idiomatic.
+- **(B)** Refactor `build_profile` to take `&Registry`. Larger change; touches slice-5 signature + every caller.
+
+**Recommendation:** (A). The global registry is a singleton on a `'static`; wrapping it in an `Arc` once at boot is cheap. The `Arc` carries through every layer that needs it without signature changes.
+
+### 2. Where does `hw_capability: HwCapabilityTier` come from?
+
+The substrate doesn't currently call `HostCapabilityProbe::detect()` at IPC boot. The closest existing primitive is `GpuMemoryManager::detect()` (which IS called for the AIProvider module). We need to either:
+
+- **(A)** Add `HostCapabilityProbe::detect_at_boot()` — runs the hw_probe sequence, returns a `(HwCapabilityTier, HwTierCategory)` pair the spawner needs.
+- **(B)** Synthesize from `gpu_manager` we already have: pass through `gpu_manager.gpu_name()` → infer tier.
+
+**Recommendation:** (A). The hw_probe is the substrate's source of truth for tier classification; reusing the GPU-name heuristic is a duplicate-of-(A) trap (the compression principle from CLAUDE.md). One probe at boot, one tier classification.
+
+### 3. Where do `hosted_handles` go for shutdown?
+
+The boot task ends after spawning all handles. Without somewhere to send them, `.abort()` on server-stop is impossible (handles drop → tasks detach → wire subscriptions leak until the runtime Arc drops elsewhere).
+
+**Options:**
+
+- **(A)** A new `PersonaSupervisor` module stored on `runtime` (the IPC `ServiceModuleRuntime`). Owns the handles. On runtime shutdown, calls `.abort()` on each.
+- **(B)** Hand the handles to `PersonaAircRuntimeRegistry::remove(persona_id)` — make `remove` await-and-abort the associated task before returning. Tighter coupling; clean call site.
+- **(C)** Spawn a watcher task that joins all handles and exits when they all complete; sufficient for the "personas live as long as the server lives" case; doesn't help with selective abort.
+
+**Recommendation:** (A) for slice 13 — the supervisor lives at the same lifetime as `PersonaInstanceManagerModule` and owns "who's running right now." Slice 14+ can integrate (B) once the supervisor exposes its abort/respawn API.
+
+### 4. ResumeOrMintProvider count + role mapping
+
+Today's boot calls `ResumeOrMintProvider::new(&root, 1)` — minimum 1 persona. The plan from `PersonaSpawnerModule::plan_for_tier()` currently returns 2 entries (Helper + Coder both on LCD per slice 7). So provider count becomes `plan.len()`.
+
+The deeper question: **role identity vs persona identity**. ResumeOrMintProvider yields `PersonaIdentityIntent { persona_id, agent_name, source }` — no role field. Slice 13 pairs the Nth intent with the Nth plan entry by position. That's reasonable for the LCD case (every persona at this tier is helper/coder) but doesn't survive once roles diverge (Sentinel runs on different hardware than Helper).
+
+**Slice 14 work:** RoleAwareProvider that yields `(PersonaIdentityIntent, RoleId)` pairs, possibly reading the role from seed.json. Out of scope here.
+
+### 5. Error policy for per-slot failures
+
+Today's loop logs and continues. Per [[no-fallbacks-ever]] this is correct — the substrate refuses to substitute a default persona for a failed slot. But the boot path should at least surface a structured count: "tier planned N, M failed."
+
+**Recommendation:** publish a `BootSummary { planned, hosted, failed: Vec<(slot, role, error)> }` event via the existing event bus. Operators see what happened without scraping logs. Per [[observability-is-half-the-architecture]].
+
+---
+
+## Test plan for slice 13
+
+Existing slice 5–12 tests cover the composition pieces. New tests for slice 13:
+
+1. **Mock-bootstrap integration test**: stub `PersonaInstanceManagerModule` via a trait split (similar to how slice 9 introduced `PersonaAdapterFactory`). Verify the boot loop calls bootstrap N times, materializes adapters N times, spawns N handles. Slice 13 introduces a `PersonaBootstrapper` trait for this — modest scope.
+2. **Provider-exhausted test**: ResumeOrMintProvider yields M < N intents. Verify boot logs the deficit and proceeds with M handles, not N. Already exercised in slice 8's `bootstrap_planned_exhausted_provider_errors_with_slot_info` — slice 13's test just wraps that path.
+3. **Per-slot adapter-failure test**: stub factory rejects slot 1. Verify slot 0 + slot 2 still spawn; slot 1 logs structured error.
+
+Integration test happens through the IPC server itself (no stub airc daemon available). Slice 13 lands behind a `cfg(test)` guard that lets us inject the stubs at the boot composition point.
+
+---
+
+## What slice 13 does NOT do
+
+- **Adapter pool sharing (#122 shared-base + LoRA paging)**: slice 13 builds one adapter per persona via `LlamaCppPersonaAdapterFactory`. On Intel Mac LCD this means 2 × Qwen2.5-0.5B GGUF loads. With Q4_K_M at ~468 MiB each, fine (~1 GiB). Shared base is #122's territory, not slice 13's.
+- **AircRemoteInferenceAdapter integration (#108 slice D/E)**: slice 13 routes every persona through the local adapter. Cross-grid inference is its own thread.
+- **Per-persona LoRA selection**: today's profile carries `model_id` but not a LoRA reference. #124 IdentityProjector + #126 first-connection ceremony land that.
+- **Role-aware provider**: noted in open question 4.
+
+---
+
+## Reference docs (canonical substrate)
+
+- [docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md](../architecture/CBAR-SUBSTRATE-ARCHITECTURE.md) — runtime contract every module inherits
+- [docs/architecture/GENOME-FOUNDRY-SENTINEL.md](../architecture/GENOME-FOUNDRY-SENTINEL.md) — tiered artifact sharing
+- [docs/architecture/AI-COMMAND-NAMESPACE.md](../architecture/AI-COMMAND-NAMESPACE.md) — every AI/ML thing under `ai/*`
+- [docs/architecture/INFERENCE-LANES-REALISTIC.md](../architecture/INFERENCE-LANES-REALISTIC.md) — realistic floor: ONE base, N persona lanes
+- [docs/planning/ALPHA-GAP-ANALYSIS.md](ALPHA-GAP-ANALYSIS.md) — lane-shaped roadmap
+- [docs/planning/AI-LANE-OPEN-QUESTIONS.md](AI-LANE-OPEN-QUESTIONS.md) — explicit punch list
+
+---
+
+## Memories worth refreshing on slice 13 implementation
+
+- [[no-fallbacks-ever]] — per-slot errors stay errored
+- [[no-if-statements-use-llms-for-cognition]] — boot path filters substrate signals only; LLM judges everything else
+- [[no-stdio-piping-for-process-ipc]] — substrate talks only via typed sockets
+- [[substrate-is-a-good-citizen-on-the-host]] — caller controls scheduling pool
+- [[observability-is-half-the-architecture]] — BootSummary as a first-class event
+- [[organization-purity-as-we-migrate]] — slice 13 deletes the welcome-log-only path; doesn't keep both
+- [[constitutional-design-always-a-next-step]] — every open question has a recommendation
+- [[commands-are-dumb-daemons-are-smart]] — `spawn_persona_service` stays trivial; the smart roster reconciliation lives in the supervisor


### PR DESCRIPTION
## Summary
Design doc for #133 slice 13 — the IPC-boot rewire that finally makes `continuum-core` host personas headlessly without the demo binary in the inner ring.

Net-additive: no code changes. Captures the boot wire-up plan + the cleanup model verified during PR #1508's slice-12 review, before touching the load-bearing `crate::ipc::start_server` flow.

## What's in the doc
- Before/after of the IPC boot loop showing the exact gap (current loop logs welcome, never starts the service loop).
- Cleanup model traced through `airc_lib::EventStream::drop` → `tokio::sync::broadcast::Receiver` auto-decrement; wire subscriber ref-counted across local subscribers. No leak.
- Five open questions with recommendations:
  1. `Arc<Registry>` for `build_profile` — add `model_registry::global_arc()`
  2. `HwCapabilityTier` source — `HostCapabilityProbe::detect_at_boot()`
  3. `hosted_handles` ownership — new `PersonaSupervisor` module
  4. ResumeOrMintProvider role-mapping — deferred to slice 14
  5. BootSummary event for per-slot failures
- Test plan: `PersonaBootstrapper` trait split for stubbing.
- Explicit non-goals + reference docs + memories worth refreshing.

## Why a design PR before the implementation PR
The boot loop is load-bearing. Reviewers should weigh in on the architectural choices (open questions 1-5) before I write 200 lines of wire-up that lock the answers in.

## Reference docs
- [docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md](docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md)
- [docs/architecture/INFERENCE-LANES-REALISTIC.md](docs/architecture/INFERENCE-LANES-REALISTIC.md)
- [docs/planning/ALPHA-GAP-ANALYSIS.md](docs/planning/ALPHA-GAP-ANALYSIS.md)

## Test plan
- [x] Doc compiles (markdown — N/A)
- [ ] CI standard checks (lint, validate) pass
- [ ] Joel reviews open questions 1-5 before slice 13 implementation begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)
