### PR TITLE
feat(continuum-core): headless persona host loop (#133 slice 13)

### DIFF
--- a/src/workers/continuum-core/src/airc/discovery.rs
+++ b/src/workers/continuum-core/src/airc/discovery.rs
@@ -206,6 +206,70 @@ pub async fn discover_default_channel() -> Result<uuid::Uuid, DiscoveryError> {
     parse_channel_from_room_output(&String::from_utf8_lossy(&out.stdout))
 }
 
+/// Discover the airc scope's current room NAME (the human-readable
+/// name like "continuum"). The substrate's persona bootstrap uses
+/// this for `Airc::join(name)` because joining by `name` derives the
+/// canonical channel; joining by UUID-as-string derives a NEW
+/// channel from the string, landing the persona in a different room
+/// than the one the operator sees in `airc room`. See PR #1511
+/// integration trace: substrate-hosted persona joined channel
+/// `5d33e2a7` (derived from the UUID string) when the operator was
+/// publishing to `11c1a7ac` (the real `continuum` channel).
+///
+/// Resolution order:
+///  1. `$AIRC_DEFAULT_ROOM_NAME` env override.
+///  2. Parse `airc room` output for the `room: <name>` line.
+pub async fn discover_default_room_name() -> Result<String, DiscoveryError> {
+    const AIRC_DEFAULT_ROOM_NAME_ENV: &str = "AIRC_DEFAULT_ROOM_NAME";
+    if let Some(raw) = std::env::var_os(AIRC_DEFAULT_ROOM_NAME_ENV) {
+        let raw = raw.to_string_lossy().trim().to_string();
+        if !raw.is_empty() {
+            return Ok(raw);
+        }
+    }
+    let call = TokioCommand::new("airc").arg("room").output();
+    let out = timeout(DISCOVERY_SUBPROCESS_DEADLINE, call)
+        .await
+        .map_err(|_| {
+            DiscoveryError::RoomCommandFailed(format!(
+                "`airc room` did not exit within {DISCOVERY_SUBPROCESS_DEADLINE:?} \
+                 — substrate is unresponsive, refusing to wait",
+            ))
+        })?
+        .map_err(|e| DiscoveryError::RoomCommandFailed(e.to_string()))?;
+    if !out.status.success() {
+        return Err(DiscoveryError::RoomCommandFailed(format!(
+            "exit {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    parse_room_name_from_room_output(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Extract the `room: <name>` line from `airc room` stdout. Same
+/// human-prose format as the channel parser; if airc renames either
+/// label the parsers fail loudly rather than silently misreading.
+fn parse_room_name_from_room_output(stdout: &str) -> Result<String, DiscoveryError> {
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        let Some(rest) = trimmed
+            .strip_prefix("room:")
+            .or_else(|| trimmed.strip_prefix("Room:"))
+            .or_else(|| trimmed.strip_prefix("ROOM:"))
+        else {
+            continue;
+        };
+        let name = rest.trim();
+        if !name.is_empty() {
+            return Ok(name.to_string());
+        }
+    }
+    Err(DiscoveryError::UnparseableChannel(format!(
+        "no `room: <name>` line in stdout: {stdout:?}"
+    )))
+}
+
 /// Extract the `channel: <uuid>` line from `airc room` stdout.
 ///
 /// Output today (from airc rust-rewrite branch, as of this PR):

--- a/src/workers/continuum-core/src/airc/mod.rs
+++ b/src/workers/continuum-core/src/airc/mod.rs
@@ -20,7 +20,8 @@ pub use client::{AircQueueClient, CliAircQueueClient};
 #[allow(deprecated)]
 pub use daemon_endpoint::default_socket_path_in;
 pub use discovery::{
-    discover_airc_socket, discover_default_channel, discover_peer_id, DiscoveryError,
+    discover_airc_socket, discover_default_channel, discover_default_room_name, discover_peer_id,
+    DiscoveryError,
 };
 pub use daemon_transport::{AircDaemonClient, DaemonAircEventTransport};
 pub use event_transport::{AircEventTransport, StoreAircEventTransport};

--- a/src/workers/continuum-core/src/bin/airc_chat_demo.rs
+++ b/src/workers/continuum-core/src/bin/airc_chat_demo.rs
@@ -333,7 +333,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //    persona the spawner planned.
     let hosted = HostedPersona {
         role: RoleId::Helper,
-        instance: PersonaInstanceInfo {
+        identity: PersonaInstanceInfo {
             persona_id,
             agent_name: agent.clone(),
             peer_id: persona_id,
@@ -341,7 +341,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             default_room: room.channel.as_uuid(),
             source: PersonaIdentitySource::FreshlyMinted,
         },
+        profile: profile.clone(),
         adapter,
+        runtime: Some(runtime.clone()),
     };
     let mut conversation = AircPersonaConversation::new(runtime);
 

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -1021,11 +1021,72 @@ pub fn start_server(
         // on; the operator can re-fire via the
         // `persona/instances/bootstrap` command once the underlying
         // issue (disk full, daemon down, corrupted seed) is resolved.
+        // ── Slice 13: substrate-managed persona hosting ──────────────
+        //
+        // Composes slices 7-12 into the production boot path:
+        //
+        //   PersonaSpawnerModule::plan_for_tier (slice 7)
+        //     → bootstrap_planned (slice 8): mints/resumes airc identities
+        //     → materialize_adapters (slice 9): builds inference adapters
+        //     → spawn_persona_service (slice 12): runs the serve_persona_loop
+        //     → PersonaAircRuntimeRegistry::attach_service_loop (slice 13 Q3):
+        //       parks the JoinHandle in the slot alongside the runtime
+        //
+        // BEFORE slice 13: this boot loop called `bootstrap_one` per
+        // persona and logged a welcome — the persona was reachable via
+        // `airc peers` but never responded. Mute citizens.
+        //
+        // AFTER slice 13 (this code): each planned persona gets her
+        // serve_persona_loop running on rt_handle, with the JoinHandle
+        // owned by the registry slot for orderly shutdown.
+        //
+        // Per the design doc HEADLESS-PERSONA-HOST-LOOP.md (PR #1510):
+        //   - P2 (in effect): plan_for_tier returns single Helper until
+        //     slice 14 lands role-in-seed.json.
+        //   - Q1 (applied): bootstrap_planned takes &Registry.
+        //   - Q3 (applied): single registry keyspace owns runtime +
+        //     service loop.
+        //   - P1 (deferred): tokio::signal::ctrl_c wiring lands in a
+        //     follow-up alongside the Runtime::shutdown caller.
+        //     Slot-level shutdown_slot is available via the registry
+        //     and exercised by the persona/instances/* IPC commands.
+        //   - Q2 (deferred): detect_host_capability needs a production
+        //     GpuMonitor constructor that doesn't exist yet (see TODO
+        //     below). For now slice 13 uses CpuOnly + Compat, which
+        //     produces the LCD Qwen2.5-0.5B Helper for all tiers. When
+        //     the GpuMonitor construction lands, swap the hardcoded
+        //     tier for `detect_host_capability(&gpu_monitor, &system_info)`.
+        //   - P3 (deferred): ResourceBroker.acquire admission for each
+        //     adapter spawn is its own slice. Current LCD case (1
+        //     persona × ~500 MiB GGUF) is well within all supported
+        //     tiers' headroom; broker admission becomes load-bearing
+        //     when multi-persona returns in slice 14.
         let bootstrap_handle = instance_manager.clone();
+        let registry_for_lookup = instance_manager.registry().clone();
+        let rt_handle_for_spawn = rt_handle.clone();
         let continuum_root_for_boot = crate::modules::persona_instance_manager::resolve_continuum_root();
         rt_handle.spawn(async move {
-            use crate::persona::identity_provider::PersonaIdentityProvider;
+            use crate::persona::host::spawn_persona_service;
+            use crate::persona::hw_tier_descriptor::HwTierCategory;
             use crate::persona::resume_or_mint_provider::ResumeOrMintProvider;
+            use crate::persona::service_loop::ServeOptions;
+            use crate::persona::spawner_module::{bootstrap_planned, PersonaSpawnerModule};
+            use crate::persona::supervisor::{
+                materialize_adapters, LlamaCppPersonaAdapterFactory,
+            };
+
+            // TODO #52: replace with detect_host_capability once a
+            // production GpuMonitor constructor exists. The current
+            // CpuOnly/Compat default produces the LCD Helper for all
+            // tiers, which is also what plan_for_tier returns under
+            // P2's single-Helper constraint (see slice 14).
+            let host_capability =
+                crate::cognition::model_resolver::types::HwCapabilityTier::CpuOnly;
+            let tier_category = HwTierCategory::Compat;
+            let tier_id = "default".to_string();
+
+            let spawner = PersonaSpawnerModule::new(host_capability, tier_category);
+
             let mut provider = match ResumeOrMintProvider::new(&continuum_root_for_boot, 1).await {
                 Ok(p) => p,
                 Err(e) => {
@@ -1038,54 +1099,104 @@ pub fn start_server(
                     return;
                 }
             };
-            loop {
-                let intent = match provider.next_persona().await {
-                    Ok(Some(i)) => i,
-                    Ok(None) => break,
-                    Err(e) => {
-                        tracing::warn!(
-                            error = %e,
-                            "Provider yielded error mid-iteration — stopping boot bootstrap. \
-                             Server stays up; remaining citizens can be bootstrapped via IPC."
+
+            let plans = match bootstrap_planned(
+                &spawner,
+                &bootstrap_handle,
+                &mut provider,
+                &tier_id,
+                crate::model_registry::global(),
+            )
+            .await
+            {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "slice 13 boot: bootstrap_planned failed — no personas hosted. \
+                         Server stays up; fire `persona/instances/bootstrap` manually \
+                         after resolving the underlying issue."
+                    );
+                    return;
+                }
+            };
+
+            let factory: std::sync::Arc<
+                dyn crate::persona::supervisor::PersonaAdapterFactory,
+            > = std::sync::Arc::new(LlamaCppPersonaAdapterFactory);
+            let hosted_results = materialize_adapters(plans, &*factory).await;
+
+            let mut hosted_count: usize = 0;
+            let mut failed_count: usize = 0;
+            for (slot_idx, result) in hosted_results.into_iter().enumerate() {
+                match result {
+                    Ok(hosted) => {
+                        let persona_id = hosted.instance.persona_id;
+                        let agent_name = hosted.instance.agent_name.clone();
+                        let role = hosted.role;
+                        let Some(runtime) = registry_for_lookup.get(persona_id) else {
+                            tracing::error!(
+                                slot = slot_idx,
+                                persona_id = %persona_id,
+                                "slice 13 boot: runtime missing post-bootstrap — \
+                                 substrate invariant violation"
+                            );
+                            failed_count += 1;
+                            continue;
+                        };
+                        let handle = spawn_persona_service(
+                            hosted,
+                            runtime,
+                            ServeOptions::default(),
+                            rt_handle_for_spawn.clone(),
                         );
-                        return;
-                    }
-                };
-                let label = match intent.source {
-                    crate::persona::identity_provider::PersonaIdentitySource::ResumedFromDisk => {
-                        "resumed"
-                    }
-                    crate::persona::identity_provider::PersonaIdentitySource::FreshlyMinted => {
-                        "freshly minted"
-                    }
-                };
-                match bootstrap_handle.bootstrap_one(&intent).await {
-                    Ok(info) => {
+                        if let Err(e) = registry_for_lookup
+                            .attach_service_loop(persona_id, handle)
+                            .await
+                        {
+                            tracing::error!(
+                                slot = slot_idx,
+                                persona_id = %persona_id,
+                                error = e,
+                                "slice 13 boot: attach_service_loop failed — persona \
+                                 will not respond on the grid"
+                            );
+                            failed_count += 1;
+                            continue;
+                        }
+                        hosted_count += 1;
                         tracing::info!(
-                            persona_id = %info.persona_id,
-                            agent_name = %info.agent_name,
-                            peer_id = %info.peer_id,
-                            home = %info.home.display(),
-                            default_room = %info.default_room,
-                            source = ?info.source,
-                            "🌐 The Grid welcomes a {} citizen: {} (peer_id={})",
-                            label,
-                            info.agent_name,
-                            info.peer_id
+                            persona_id = %persona_id,
+                            agent_name = %agent_name,
+                            role = ?role,
+                            slot = slot_idx,
+                            "🌐 The Grid hosts citizen {} (slot {}, role {:?}) — substrate \
+                             service-loop attached",
+                            agent_name,
+                            slot_idx,
+                            role,
                         );
                     }
-                    Err(e) => {
+                    Err(err) => {
                         tracing::warn!(
-                            error = %e,
-                            persona_id = %intent.persona_id,
-                            agent_name = %intent.agent_name,
-                            "Boot-time bootstrap failed for {} — server stays up, other \
-                             citizens (if any) will still be attempted.",
-                            intent.agent_name
+                            slot = slot_idx,
+                            error = ?err,
+                            "slice 13 boot: slot materialization failed; sibling \
+                             slots still attempted"
                         );
+                        failed_count += 1;
                     }
                 }
             }
+
+            tracing::info!(
+                hosted = hosted_count,
+                failed = failed_count,
+                "🌐 Substrate boot composition complete (slice 13) — \
+                 {} citizen(s) hosted, {} failed",
+                hosted_count,
+                failed_count,
+            );
         });
     } else {
         tracing::warn!(

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -940,6 +940,7 @@ pub fn start_server(
         .daemon_socket()
         .map(|p| p.to_path_buf())
         .zip(airc_module.default_room());
+    let persona_bootstrap_room_name = airc_module.default_room_name().map(|s| s.to_string());
     runtime.register(airc_module);
 
     // PersonaInstanceManagerModule: owns the live PersonaAircRuntime
@@ -960,6 +961,7 @@ pub fn start_server(
                 registry,
                 daemon_socket,
                 default_room,
+                persona_bootstrap_room_name.clone(),
                 continuum_root,
             ),
         );

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -1111,11 +1111,32 @@ pub fn start_server(
             {
                 Ok(p) => p,
                 Err(e) => {
+                    // BLOCKER 2 (PR #1511 review finding #2):
+                    // `bootstrap_planned` registers each persona via
+                    // `bootstrap_one` BEFORE the next slot's mint
+                    // runs. If slot k fails, slots 0..k-1 are already
+                    // in the registry but with no service loop
+                    // attached — mute citizens. We MUST orderly-drain
+                    // them (no service loop to abort yet, but the
+                    // registry entry + Arc<Airc> still need to drop
+                    // so the wire subscriber tears down).
+                    let already_registered = registry_for_lookup.ids();
+                    let orphans = already_registered.len();
+                    for orphan_id in already_registered {
+                        // `shutdown_slot` handles "no service loop"
+                        // gracefully (handle_opt is None) and drops
+                        // the Arc cleanly. This is the orderly path
+                        // even when only the Arc needs dropping.
+                        let _ = registry_for_lookup.shutdown_slot(orphan_id).await;
+                    }
                     tracing::error!(
                         error = %e,
-                        "slice 13 boot: bootstrap_planned failed — no personas hosted. \
-                         Server stays up; fire `persona/instances/bootstrap` manually \
-                         after resolving the underlying issue."
+                        orphans_drained = orphans,
+                        "slice 13 boot: bootstrap_planned failed; {} partially-registered \
+                         personas drained from the registry. Server stays up; fire \
+                         `persona/instances/bootstrap` manually after resolving the \
+                         underlying issue.",
+                        orphans,
                     );
                     return;
                 }
@@ -1150,16 +1171,29 @@ pub fn start_server(
                             ServeOptions::default(),
                             rt_handle_for_spawn.clone(),
                         );
-                        if let Err(e) = registry_for_lookup
+                        if let Err((returned_handle, reason)) = registry_for_lookup
                             .attach_service_loop(persona_id, handle)
                             .await
                         {
+                            // BLOCKER 1 (PR #1511 review finding #1):
+                            // JoinHandle::drop detaches the task
+                            // rather than aborting it. Without this
+                            // orderly drain the loop keeps running
+                            // untracked — the boot log would lie that
+                            // "will not respond" while the loop in
+                            // fact does respond (just outside the
+                            // registry's view, so shutdown_slot can't
+                            // find it). attach_service_loop hands the
+                            // handle back exactly so we can do this.
+                            returned_handle.abort();
+                            let _ = returned_handle.await;
                             tracing::error!(
                                 slot = slot_idx,
                                 persona_id = %persona_id,
-                                error = e,
-                                "slice 13 boot: attach_service_loop failed — persona \
-                                 will not respond on the grid"
+                                reason = reason,
+                                "slice 13 boot: attach_service_loop failed; spawned \
+                                 task drained. Persona registered but unattended — \
+                                 fire `persona/instances/bootstrap` to retry."
                             );
                             failed_count += 1;
                             continue;

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -1147,29 +1147,30 @@ pub fn start_server(
             let factory: std::sync::Arc<
                 dyn crate::persona::supervisor::PersonaAdapterFactory,
             > = std::sync::Arc::new(LlamaCppPersonaAdapterFactory);
-            let hosted_results = materialize_adapters(plans, &*factory).await;
+            // The supervisor needs a runtime lookup to fold the live
+            // Arc<PersonaAircRuntime> into each PersonaContext —
+            // that's how `&ctx` carries the airc handle. Closure
+            // captures the slice-13 registry view; substrate
+            // invariant is "runtime exists post-bootstrap_one".
+            let registry_for_materialize = registry_for_lookup.clone();
+            let hosted_results = materialize_adapters(plans, &*factory, |pid| {
+                registry_for_materialize.get(pid)
+            })
+            .await;
 
             let mut hosted_count: usize = 0;
             let mut failed_count: usize = 0;
             for (slot_idx, result) in hosted_results.into_iter().enumerate() {
                 match result {
                     Ok(hosted) => {
-                        let persona_id = hosted.instance.persona_id;
-                        let agent_name = hosted.instance.agent_name.clone();
+                        // `hosted` is the PersonaContext — it already
+                        // carries the airc runtime as `hosted.runtime`,
+                        // per the `&ctx` doctrine. No separate lookup.
+                        let persona_id = hosted.identity.persona_id;
+                        let agent_name = hosted.identity.agent_name.clone();
                         let role = hosted.role;
-                        let Some(runtime) = registry_for_lookup.get(persona_id) else {
-                            tracing::error!(
-                                slot = slot_idx,
-                                persona_id = %persona_id,
-                                "slice 13 boot: runtime missing post-bootstrap — \
-                                 substrate invariant violation"
-                            );
-                            failed_count += 1;
-                            continue;
-                        };
                         let handle = spawn_persona_service(
                             hosted,
-                            runtime,
                             ServeOptions::default(),
                             rt_handle_for_spawn.clone(),
                         );

--- a/src/workers/continuum-core/src/model_registry/catalog.rs
+++ b/src/workers/continuum-core/src/model_registry/catalog.rs
@@ -356,6 +356,32 @@ pub fn models() -> Vec<Model> {
             multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
             ..ModelSpec::default()
         }),
+        // LCD model — the substrate's lowest-common-denominator base
+        // per [[lcd-model-qwen25-05b-and-foundry-lora]]. Qwen2.5 0.5B
+        // Instruct Q4_K_M GGUF, ~468 MiB. Runs on any tier including
+        // CPU-only and Intel Mac mac-cpu-only. Substrate slice 13's
+        // boot composition asks for this model_id explicitly via
+        // `PersonaSpawnerModule::plan_for_tier`.
+        model(ModelSpec {
+            id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF",
+            name: "Qwen2.5-0.5B-Instruct (LCD, in-process)",
+            provider: "llamacpp-local",
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 4096,
+            tokens_per_second: 60.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::Streaming,
+            ],
+            gguf_hint: Some("huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF"),
+            gguf_local_path: Some(
+                "~/.continuum/genome/models/qwen2.5-0.5b-instruct/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+            ),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            ..ModelSpec::default()
+        }),
     ]
 }
 

--- a/src/workers/continuum-core/src/modules/airc.rs
+++ b/src/workers/continuum-core/src/modules/airc.rs
@@ -1,11 +1,11 @@
 //! ServiceModule adapter for Rust-native AIRC commands.
 
 use crate::airc::{
-    discover_airc_socket, discover_default_channel, discover_peer_id, spawn_daemon_attach,
-    AircEventTransport, AircQueueClient, AircQueueListRequest, AircQueueScanParams,
-    AircRealtimePublishParams, AircRealtimeReplayParams, AircRealtimeStore, CliAircQueueClient,
-    DaemonAircEventTransport, InMemoryAircRealtimeStore, StoreAircEventTransport,
-    TokioAircCommandRunner,
+    discover_airc_socket, discover_default_channel, discover_default_room_name, discover_peer_id,
+    spawn_daemon_attach, AircEventTransport, AircQueueClient, AircQueueListRequest,
+    AircQueueScanParams, AircRealtimePublishParams, AircRealtimeReplayParams, AircRealtimeStore,
+    CliAircQueueClient, DaemonAircEventTransport, InMemoryAircRealtimeStore,
+    StoreAircEventTransport, TokioAircCommandRunner,
 };
 // `default_socket_path_in` retained for back-compat callers; deprecated,
 // see `crate::airc::daemon_endpoint` module docs.
@@ -31,6 +31,14 @@ pub struct AircModule {
     /// channel in the owner-core model". Discovered via
     /// [`discover_default_channel`] alongside the socket path.
     attach_channel: Option<RoomId>,
+    /// Human-readable name of the default room (e.g. `"continuum"`).
+    /// Used by the persona instance manager to join via
+    /// `Airc::join(name)` — joining by the UUID-as-string derives a
+    /// new channel from the string (caught by PR #1511 integration
+    /// test: persona landed in derived channel `5d33e2a7…` when
+    /// operator publishes go to `11c1a7ac…`). Discovered via
+    /// [`discover_default_room_name`] alongside the socket + channel.
+    attach_room_name: Option<String>,
 }
 
 impl AircModule {
@@ -77,6 +85,27 @@ impl AircModule {
                 return Self::with_queue_client(Arc::new(CliAircQueueClient::new(
                     TokioAircCommandRunner,
                 )));
+            }
+        };
+
+        let attach_room_name = match discover_default_room_name().await {
+            Ok(name) => {
+                tracing::info!(
+                    room_name = %name,
+                    "Discovered airc default room name via `airc room`"
+                );
+                Some(name)
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "airc default room-name discovery failed — persona bootstrap will fall \
+                     back to joining by the channel-UUID-as-string, which derives a NEW \
+                     channel that does NOT match the operator's `airc room`. Persona will \
+                     be in the wrong room. Resolve: install/update airc so `airc room` \
+                     prints a `room: <name>` line, or set AIRC_DEFAULT_ROOM_NAME=<name>."
+                );
+                None
             }
         };
 
@@ -140,6 +169,7 @@ impl AircModule {
             )),
             attach_socket_path: Some(socket_path),
             attach_channel,
+            attach_room_name,
         }
     }
 
@@ -151,6 +181,7 @@ impl AircModule {
             event_transport: Arc::new(DaemonAircEventTransport::new(socket_path.clone())),
             attach_socket_path: Some(socket_path),
             attach_channel: None,
+            attach_room_name: None,
         }
     }
 
@@ -162,6 +193,7 @@ impl AircModule {
             ))),
             attach_socket_path: None,
             attach_channel: None,
+            attach_room_name: None,
         }
     }
 
@@ -174,6 +206,7 @@ impl AircModule {
             event_transport: Arc::new(StoreAircEventTransport::new(realtime_store)),
             attach_socket_path: None,
             attach_channel: None,
+            attach_room_name: None,
         }
     }
 
@@ -186,6 +219,7 @@ impl AircModule {
             event_transport,
             attach_socket_path: None,
             attach_channel: None,
+            attach_room_name: None,
         }
     }
 
@@ -207,6 +241,15 @@ impl AircModule {
     /// expect your general room and theirs to be the same room").
     pub fn default_room(&self) -> Option<RoomId> {
         self.attach_channel
+    }
+
+    /// The human-readable name of the default room (e.g. `"continuum"`),
+    /// if discovered. Used by the persona instance manager to join via
+    /// `Airc::join(name)` — joining by the channel's UUID-as-string
+    /// would derive a NEW channel and land the persona in the wrong
+    /// room. Per PR #1511 integration trace.
+    pub fn default_room_name(&self) -> Option<&str> {
+        self.attach_room_name.as_deref()
     }
 }
 

--- a/src/workers/continuum-core/src/modules/persona_instance_manager.rs
+++ b/src/workers/continuum-core/src/modules/persona_instance_manager.rs
@@ -110,6 +110,15 @@ pub struct PersonaInstanceManagerModule {
     registry: PersonaAircRuntimeRegistry,
     daemon_socket: PathBuf,
     default_room: RoomId,
+    /// Human-readable room name (e.g. `"continuum"`). Used by
+    /// `PersonaAircRuntime::bootstrap` when joining the room, because
+    /// `Airc::join(name)` derives the canonical channel from the
+    /// name. If `None`, bootstrap falls back to joining by the
+    /// channel-UUID-as-string, which derives a NEW channel that
+    /// does NOT match the operator's `airc room` — persona lands in
+    /// the wrong room and can't see the operator's messages. PR #1511
+    /// integration test confirmed this empirically.
+    default_room_name: Option<String>,
     continuum_root: PathBuf,
 }
 
@@ -118,9 +127,9 @@ impl PersonaInstanceManagerModule {
     ///
     /// `registry` is shared (cheap to clone — internal `Arc<DashMap>`)
     /// so callers can hand other modules a view of the same roster.
-    /// `daemon_socket` and `default_room` come from
-    /// [`crate::modules::airc::AircModule::daemon_socket`] /
-    /// [`default_room`] — discovered at server boot.
+    /// `daemon_socket`, `default_room`, and `default_room_name` come
+    /// from [`crate::modules::airc::AircModule`]'s discovery:
+    /// [`daemon_socket`] / [`default_room`] / [`default_room_name`].
     /// `continuum_root` is where persona homes get carved out
     /// (typically `~/.continuum/`, env-overridable via
     /// `CONTINUUM_ROOT`).
@@ -128,12 +137,14 @@ impl PersonaInstanceManagerModule {
         registry: PersonaAircRuntimeRegistry,
         daemon_socket: PathBuf,
         default_room: RoomId,
+        default_room_name: Option<String>,
         continuum_root: PathBuf,
     ) -> Self {
         Self {
             registry,
             daemon_socket,
             default_room,
+            default_room_name,
             continuum_root,
         }
     }
@@ -174,6 +185,7 @@ impl PersonaInstanceManagerModule {
             &self.continuum_root,
             self.daemon_socket.clone(),
             self.default_room,
+            self.default_room_name.clone(),
             intent.source,
         )
         .await?;
@@ -326,6 +338,7 @@ mod tests {
             registry,
             PathBuf::from("/nonexistent/socket"),
             RoomId::from_uuid(Uuid::nil()),
+            None,
             PathBuf::from("/tmp/continuum-test"),
         );
         let cfg = module.config();
@@ -348,6 +361,7 @@ mod tests {
             registry,
             PathBuf::from("/nonexistent/socket"),
             RoomId::from_uuid(Uuid::nil()),
+            None,
             PathBuf::from("/tmp/continuum-test"),
         );
         let params = serde_json::json!({"personaId": Uuid::new_v4().to_string()});
@@ -363,6 +377,7 @@ mod tests {
             registry,
             PathBuf::from("/nonexistent/socket"),
             RoomId::from_uuid(Uuid::nil()),
+            None,
             PathBuf::from("/tmp/continuum-test"),
         );
         let res = module
@@ -384,6 +399,7 @@ mod tests {
             registry,
             PathBuf::from("/nonexistent/socket"),
             RoomId::from_uuid(Uuid::nil()),
+            None,
             PathBuf::from("/tmp/continuum-test"),
         );
         let res = module

--- a/src/workers/continuum-core/src/persona/airc_runtime.rs
+++ b/src/workers/continuum-core/src/persona/airc_runtime.rs
@@ -134,6 +134,7 @@ impl PersonaAircRuntime {
         continuum_root: &Path,
         daemon_socket: PathBuf,
         default_room: RoomId,
+        default_room_name: Option<String>,
         source: crate::persona::identity_provider::PersonaIdentitySource,
     ) -> Result<Self, PersonaAircRuntimeError> {
         let agent_name = agent_name.into();
@@ -165,8 +166,35 @@ impl PersonaAircRuntime {
         // Join the default room. From the daemon's perspective the
         // persona is now an enrolled participant — `airc peers`
         // from another scope MUST list this peer_id.
+        //
+        // CRITICAL: `Airc::join(name)` calls `ChannelName::new(name)`
+        // which DERIVES a channel UUID from the name. If we pass the
+        // UUID-as-string of the operator's channel, that string gets
+        // interpreted as a name and produces a DIFFERENT channel.
+        // The persona then sits in the derived channel while the
+        // operator publishes into the canonical one — they never
+        // see each other. Joining by NAME (e.g. "continuum") lands
+        // both in the same channel. PR #1511 integration test caught
+        // this; demo binary in slice 11 reshaped via `from_attached`
+        // explicitly to work around the same hazard.
+        let join_target = match default_room_name.as_deref() {
+            Some(name) => name.to_string(),
+            None => {
+                tracing::warn!(
+                    persona_id = %persona_id,
+                    agent_name = %agent_name,
+                    room_id = %default_room.as_uuid(),
+                    "PersonaAircRuntime bootstrap: no default_room_name supplied — \
+                     falling back to joining by UUID-as-string, which derives a NEW \
+                     channel. Persona will likely land in the wrong room. Resolve: \
+                     ensure AircModule discovers default_room_name (via `airc room` \
+                     output's `room: <name>` line) and threads it through here.",
+                );
+                default_room.as_uuid().to_string()
+            }
+        };
         let room = airc
-            .join(&default_room.as_uuid().to_string())
+            .join(&join_target)
             .await
             .map_err(|source| PersonaAircRuntimeError::Join {
                 agent_name: agent_name.clone(),

--- a/src/workers/continuum-core/src/persona/airc_runtime_registry.rs
+++ b/src/workers/continuum-core/src/persona/airc_runtime_registry.rs
@@ -14,42 +14,84 @@
 //! provider]]). It is NOT a broker that forwards messages on behalf
 //! of personas (that anti-pattern is named for refusal in
 //! [[personas-are-citizens-airc-is-identity-provider]] §
-//! "anti-patterns"). It is a lookup table — `(persona_id) ->
-//! Arc<PersonaAircRuntime>`.
+//! "anti-patterns"). It is a lookup table — `(persona_id) -> slot`.
+//!
+//! ### What's in a slot (slice 13)
+//!
+//! Each slot owns the persona's `Arc<PersonaAircRuntime>` AND
+//! optionally a `JoinHandle` for the [`serve_persona_loop`] task
+//! that's hosting her. Pairing them in one keyspace is the design
+//! resolution from PR #1510's slice-13 review — having two parallel
+//! registries (one for runtimes, one for service loops) keyed on the
+//! same `persona_id` would have been a compression failure per
+//! [[organization-purity-as-we-migrate]].
+//!
+//! The cleanup chain that the supervisor invokes on shutdown:
+//! 1. `shutdown_slot(persona_id).await` — aborts the service-loop
+//!    JoinHandle, awaits its drain.
+//! 2. The slot's `Arc<PersonaAircRuntime>` drops, which drops
+//!    `Arc<Airc>`, which drops the `inner.subscribers` map inside
+//!    airc-lib, which aborts the daemon-attached wire-subscriber
+//!    tasks. **Both steps are required** — `.abort()` alone leaves
+//!    the daemon-side wire subscription alive until the Arc itself
+//!    drops via registry removal.
 //!
 //! ### Concurrency
 //!
 //! `DashMap` for lock-free reads on the hot path (every cognition
 //! turn looks up its persona's runtime). Per-key writes are
-//! synchronized internally.
+//! synchronized internally. The per-slot `service_loop` slot uses
+//! `tokio::sync::Mutex` so the shutdown path can `take()` the
+//! JoinHandle without blocking the dispatcher.
 //!
 //! ### What this registry holds
 //!
-//! `Arc<PersonaAircRuntime>` only. Never `LocalIdentity`, never
-//! `Keypair`, never secret key bytes. The runtime owns the Arc
+//! `Arc<PersonaSlot>` only. Never `LocalIdentity`, never `Keypair`,
+//! never secret key bytes. The runtime inside the slot owns the Arc
 //! handle to `airc_lib::Airc`, which holds the identity internally.
 //! Continuum-side code that needs to publish as a persona reaches
 //! into `runtime.airc()` and calls airc-lib directly — no
-//! `sendAs(persona_id, text)` wrapper here. The "id-keyed
-//! dispatch" is just registry lookup + direct call on the resolved
-//! handle.
+//! `sendAs(persona_id, text)` wrapper here.
 
 use std::sync::Arc;
 
 use dashmap::DashMap;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::persona::airc_runtime::PersonaAircRuntime;
+use crate::persona::service_loop::ServeOutcome;
+
+/// One slot in The Grid's roster — a persona's airc presence plus
+/// (optionally) the supervising tokio task that's running her
+/// service loop.
+///
+/// Slot lifetime: created on `register`, dropped on `remove`. The
+/// service loop's lifetime is contained: attached via
+/// `attach_service_loop`, taken back during shutdown by
+/// `shutdown_slot`. The slot itself outlives both, simplifying
+/// the cleanup contract per the doc-comment above.
+pub struct PersonaSlot {
+    /// The persona's airc runtime. Cognition + dispatch paths
+    /// clone this Arc.
+    pub runtime: Arc<PersonaAircRuntime>,
+    /// The substrate's serve loop task. `None` before the supervisor
+    /// attaches one (e.g., the persona was bootstrapped but the boot
+    /// composition hadn't yet wired her loop), `Some` once attached.
+    /// Taken back to `None` during `shutdown_slot`.
+    service_loop: Mutex<Option<JoinHandle<Result<ServeOutcome, String>>>>,
+}
 
 /// Registry of personas currently online in The Grid.
 ///
 /// Threadsafe by construction (`DashMap` for the inner map +
-/// `Arc<PersonaAircRuntime>` for the values). Cheap to clone the
-/// registry handle and pass it to N modules — each gets a view of
-/// the same shared roster.
+/// `Arc<PersonaSlot>` for the values). Cheap to clone the registry
+/// handle and pass it to N modules — each gets a view of the same
+/// shared roster.
 #[derive(Default, Clone)]
 pub struct PersonaAircRuntimeRegistry {
-    inner: Arc<DashMap<Uuid, Arc<PersonaAircRuntime>>>,
+    inner: Arc<DashMap<Uuid, Arc<PersonaSlot>>>,
 }
 
 impl PersonaAircRuntimeRegistry {
@@ -59,29 +101,35 @@ impl PersonaAircRuntimeRegistry {
     }
 
     /// Add a persona to the roster. Idempotent: if the persona is
-    /// already present, the existing Arc is replaced with the new
-    /// one (the caller is responsible for ensuring the old runtime
-    /// is properly shut down first). Returns the inserted Arc so the
-    /// caller can keep a reference for cognition wiring.
+    /// already present, the existing slot is replaced (the caller is
+    /// responsible for ensuring the old slot is properly shut down
+    /// first via `shutdown_slot`). Returns the inserted Arc to the
+    /// runtime so the caller can keep a reference for cognition
+    /// wiring — the slot itself is internal.
     pub fn register(&self, runtime: PersonaAircRuntime) -> Arc<PersonaAircRuntime> {
-        let arc = Arc::new(runtime);
-        let persona_id = arc.persona_id();
-        let agent_name = arc.agent_name().to_string();
-        self.inner.insert(persona_id, arc.clone());
+        let runtime_arc = Arc::new(runtime);
+        let persona_id = runtime_arc.persona_id();
+        let agent_name = runtime_arc.agent_name().to_string();
+        let slot = Arc::new(PersonaSlot {
+            runtime: runtime_arc.clone(),
+            service_loop: Mutex::new(None),
+        });
+        self.inner.insert(persona_id, slot);
         tracing::info!(
             persona_id = %persona_id,
             agent_name = %agent_name,
             "registry: {agent_name} entered The Grid (roster size now {})",
             self.inner.len(),
         );
-        arc
+        runtime_arc
     }
 
     /// Look up a persona's runtime by their continuum persona_id.
     /// Returns `None` if the persona isn't online (never registered,
-    /// or already shut down).
+    /// or already shut down). Preserves the pre-slice-13 contract —
+    /// callers get the `Arc<PersonaAircRuntime>` directly.
     pub fn get(&self, persona_id: Uuid) -> Option<Arc<PersonaAircRuntime>> {
-        self.inner.get(&persona_id).map(|entry| entry.clone())
+        self.inner.get(&persona_id).map(|entry| entry.runtime.clone())
     }
 
     /// Look up a persona by their airc agent_name. Scans the
@@ -92,31 +140,116 @@ impl PersonaAircRuntimeRegistry {
     pub fn get_by_agent_name(&self, agent_name: &str) -> Option<Arc<PersonaAircRuntime>> {
         self.inner
             .iter()
-            .find(|entry| entry.value().agent_name() == agent_name)
-            .map(|entry| entry.value().clone())
+            .find(|entry| entry.value().runtime.agent_name() == agent_name)
+            .map(|entry| entry.value().runtime.clone())
     }
 
-    /// Remove a persona from the roster. The caller is responsible
-    /// for orderly shutdown of the runtime (drop the Arc, await
-    /// its tasks). Returns the removed Arc if present.
+    /// Attach a service-loop `JoinHandle` to the persona's slot. The
+    /// handle is `.abort()`-ed and awaited during `shutdown_slot`.
+    ///
+    /// Errors:
+    /// - `Err("no slot")` if the persona isn't in the registry.
+    /// - `Err("already attached")` if a service loop is already
+    ///   attached. The caller is responsible for `shutdown_slot`-ing
+    ///   the prior loop before attaching a replacement; the registry
+    ///   refuses silent overwrites to avoid leaking the prior task.
+    pub async fn attach_service_loop(
+        &self,
+        persona_id: Uuid,
+        handle: JoinHandle<Result<ServeOutcome, String>>,
+    ) -> Result<(), &'static str> {
+        let slot = self
+            .inner
+            .get(&persona_id)
+            .ok_or("no slot")?
+            .clone();
+        let mut loop_slot = slot.service_loop.lock().await;
+        if loop_slot.is_some() {
+            return Err("already attached");
+        }
+        *loop_slot = Some(handle);
+        Ok(())
+    }
+
+    /// Check whether a slot's service-loop task has resolved (either
+    /// successfully or with an error). Used by the supervisor's
+    /// periodic poller (slice-13 Q7) to detect crashed loops without
+    /// blocking on each `JoinHandle`. Returns `None` if the slot
+    /// doesn't exist or has no service loop attached.
+    pub async fn is_service_loop_finished(&self, persona_id: Uuid) -> Option<bool> {
+        let slot = self.inner.get(&persona_id)?.clone();
+        let loop_slot = slot.service_loop.lock().await;
+        loop_slot.as_ref().map(|h| h.is_finished())
+    }
+
+    /// Orderly shutdown of one persona's slot:
+    /// 1. Take the service-loop JoinHandle out of the slot.
+    /// 2. `.abort()` it and await its drain (yielding `ServeOutcome`
+    ///    or the cancellation error — discarded; the supervisor
+    ///    already published `persona:boot:summary` for live state).
+    /// 3. Remove the slot from the registry, dropping the
+    ///    `Arc<PersonaSlot>` and (when it's the last reference) the
+    ///    `Arc<PersonaAircRuntime>` it contained. That Arc drop
+    ///    cascades to `Arc<Airc>` drop → `inner.subscribers` drop
+    ///    inside airc-lib → wire-subscriber tasks abort.
+    ///
+    /// Returns the `Arc<PersonaAircRuntime>` that was in the slot, in
+    /// case the caller wants to observe pre-drop state.
+    /// Returns `None` if the persona wasn't registered.
+    pub async fn shutdown_slot(&self, persona_id: Uuid) -> Option<Arc<PersonaAircRuntime>> {
+        let slot_arc = self.inner.get(&persona_id)?.clone();
+        let handle_opt = {
+            let mut loop_slot = slot_arc.service_loop.lock().await;
+            loop_slot.take()
+        };
+        if let Some(handle) = handle_opt {
+            handle.abort();
+            // Awaiting an aborted handle resolves to Err(JoinError);
+            // discard — we did the shutdown intentionally.
+            let _ = handle.await;
+        }
+        let (_, slot_owned) = self.inner.remove(&persona_id)?;
+        let agent_name = slot_owned.runtime.agent_name().to_string();
+        tracing::info!(
+            persona_id = %persona_id,
+            agent_name = %agent_name,
+            "registry: {agent_name} left The Grid (roster size now {})",
+            self.inner.len(),
+        );
+        Some(slot_owned.runtime.clone())
+    }
+
+    /// Synchronous remove WITHOUT touching the service loop. Use
+    /// only when the slot's loop has already terminated naturally
+    /// (e.g., observed via `is_service_loop_finished` returning
+    /// `Some(true)`). Orderly shutdown should use `shutdown_slot`
+    /// instead per the doc-comment on the registry.
     pub fn remove(&self, persona_id: Uuid) -> Option<Arc<PersonaAircRuntime>> {
-        self.inner.remove(&persona_id).map(|(_, arc)| {
+        self.inner.remove(&persona_id).map(|(_, slot)| {
             tracing::info!(
                 persona_id = %persona_id,
-                agent_name = %arc.agent_name(),
+                agent_name = %slot.runtime.agent_name(),
                 "registry: {} left The Grid (roster size now {})",
-                arc.agent_name(),
+                slot.runtime.agent_name(),
                 self.inner.len(),
             );
-            arc
+            slot.runtime.clone()
         })
     }
 
-    /// Iterate over all currently-online personas. Cheap snapshot
-    /// — each yielded Arc is independent; iteration doesn't hold a
-    /// lock on the map.
+    /// Iterate over all currently-online persona runtimes. Cheap
+    /// snapshot — each yielded Arc is independent; iteration doesn't
+    /// hold a lock on the map. Returns the runtime Arc directly, not
+    /// the slot, since most consumers just want the airc handle.
     pub fn iter(&self) -> impl Iterator<Item = Arc<PersonaAircRuntime>> + '_ {
-        self.inner.iter().map(|entry| entry.value().clone())
+        self.inner.iter().map(|entry| entry.value().runtime.clone())
+    }
+
+    /// Iterate over all currently-registered persona_ids. Useful for
+    /// the supervisor's periodic poll (Q7) without cloning N Arcs
+    /// when only the ids are needed.
+    pub fn ids(&self) -> Vec<Uuid> {
+        self.inner.iter().map(|entry| *entry.key()).collect()
     }
 
     /// Count of personas currently online.
@@ -153,5 +286,39 @@ mod tests {
         assert_eq!(Arc::strong_count(&registry.inner), 2);
         drop(cloned);
         assert_eq!(Arc::strong_count(&registry.inner), 1);
+    }
+
+    /// `attach_service_loop` fails fast when the slot doesn't exist.
+    /// Catches the "we forgot to register before attaching" bug
+    /// (supervisor must register first).
+    #[tokio::test]
+    async fn attach_service_loop_errors_when_no_slot() {
+        let registry = PersonaAircRuntimeRegistry::new();
+        let nonexistent = Uuid::new_v4();
+        let handle = tokio::spawn(async { Ok(ServeOutcome::default()) });
+        let result = registry.attach_service_loop(nonexistent, handle).await;
+        assert_eq!(result, Err("no slot"));
+    }
+
+    /// `is_service_loop_finished` returns `None` when the slot
+    /// doesn't exist — distinguishes from `Some(true)` (registered
+    /// + loop done) and `Some(false)` (registered + loop running).
+    #[tokio::test]
+    async fn is_service_loop_finished_returns_none_for_missing_slot() {
+        let registry = PersonaAircRuntimeRegistry::new();
+        assert_eq!(
+            registry.is_service_loop_finished(Uuid::new_v4()).await,
+            None
+        );
+    }
+
+    /// `shutdown_slot` on a missing persona is a no-op returning
+    /// `None`. Matters because the supervisor may race a poller
+    /// against an external `remove` — neither should panic.
+    #[tokio::test]
+    async fn shutdown_slot_returns_none_for_missing_persona() {
+        let registry = PersonaAircRuntimeRegistry::new();
+        let removed = registry.shutdown_slot(Uuid::new_v4()).await;
+        assert!(removed.is_none());
     }
 }

--- a/src/workers/continuum-core/src/persona/airc_runtime_registry.rs
+++ b/src/workers/continuum-core/src/persona/airc_runtime_registry.rs
@@ -147,25 +147,43 @@ impl PersonaAircRuntimeRegistry {
     /// Attach a service-loop `JoinHandle` to the persona's slot. The
     /// handle is `.abort()`-ed and awaited during `shutdown_slot`.
     ///
-    /// Errors:
-    /// - `Err("no slot")` if the persona isn't in the registry.
-    /// - `Err("already attached")` if a service loop is already
-    ///   attached. The caller is responsible for `shutdown_slot`-ing
-    ///   the prior loop before attaching a replacement; the registry
-    ///   refuses silent overwrites to avoid leaking the prior task.
+    /// On error returns the handle BACK to the caller so it can
+    /// orderly-drain it (`abort()` + `await`). `JoinHandle::drop`
+    /// detaches rather than aborts — silently dropping the handle
+    /// leaks a running tokio task per [[organization-purity-as-we-
+    /// migrate]] (and PR #1511 review finding #1). The caller's
+    /// orderly-drain pattern:
+    ///
+    /// ```ignore
+    /// match registry.attach_service_loop(persona_id, handle).await {
+    ///     Ok(()) => { /* tracked by registry */ }
+    ///     Err((handle, reason)) => {
+    ///         handle.abort();
+    ///         let _ = handle.await;
+    ///         tracing::warn!(reason, "attach failed, handle drained");
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Error reasons:
+    /// - `"no slot"` if the persona isn't in the registry.
+    /// - `"already attached"` if a service loop is already attached.
+    ///   The caller is responsible for `shutdown_slot`-ing the prior
+    ///   loop before attaching a replacement; the registry refuses
+    ///   silent overwrites to avoid leaking the prior task.
     pub async fn attach_service_loop(
         &self,
         persona_id: Uuid,
         handle: JoinHandle<Result<ServeOutcome, String>>,
-    ) -> Result<(), &'static str> {
-        let slot = self
-            .inner
-            .get(&persona_id)
-            .ok_or("no slot")?
-            .clone();
+    ) -> Result<(), (JoinHandle<Result<ServeOutcome, String>>, &'static str)> {
+        let Some(slot_ref) = self.inner.get(&persona_id) else {
+            return Err((handle, "no slot"));
+        };
+        let slot = slot_ref.clone();
+        drop(slot_ref); // release the DashMap read guard before awaiting the Mutex
         let mut loop_slot = slot.service_loop.lock().await;
         if loop_slot.is_some() {
-            return Err("already attached");
+            return Err((handle, "already attached"));
         }
         *loop_slot = Some(handle);
         Ok(())
@@ -288,16 +306,29 @@ mod tests {
         assert_eq!(Arc::strong_count(&registry.inner), 1);
     }
 
-    /// `attach_service_loop` fails fast when the slot doesn't exist.
-    /// Catches the "we forgot to register before attaching" bug
-    /// (supervisor must register first).
+    /// `attach_service_loop` fails fast when the slot doesn't exist
+    /// AND hands the handle back so the caller can drain it. The
+    /// handed-back handle is intact (`is_finished()` false until the
+    /// caller aborts) — proves no implicit detach happened.
     #[tokio::test]
-    async fn attach_service_loop_errors_when_no_slot() {
+    async fn attach_service_loop_errors_with_handle_when_no_slot() {
         let registry = PersonaAircRuntimeRegistry::new();
         let nonexistent = Uuid::new_v4();
-        let handle = tokio::spawn(async { Ok(ServeOutcome::default()) });
-        let result = registry.attach_service_loop(nonexistent, handle).await;
-        assert_eq!(result, Err("no slot"));
+        // Long-lived task so we can verify the handle is still live
+        // when it comes back to us.
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            Ok(ServeOutcome::default())
+        });
+        let (returned_handle, reason) = registry
+            .attach_service_loop(nonexistent, handle)
+            .await
+            .expect_err("must error when slot missing");
+        assert_eq!(reason, "no slot");
+        // The handle came back live — caller hasn't drained it yet.
+        assert!(!returned_handle.is_finished());
+        returned_handle.abort();
+        let _ = returned_handle.await;
     }
 
     /// `is_service_loop_finished` returns `None` when the slot

--- a/src/workers/continuum-core/src/persona/host.rs
+++ b/src/workers/continuum-core/src/persona/host.rs
@@ -50,7 +50,6 @@
 //!   the scheduling pool. No hidden thread spawns.
 
 use crate::persona::airc_persona_conversation::AircPersonaConversation;
-use crate::persona::airc_runtime::PersonaAircRuntime;
 use crate::persona::airc_source::AircTranscriptReader;
 use crate::persona::service_loop::{serve_persona_loop, ServeOptions, ServeOutcome};
 use crate::persona::supervisor::HostedPersona;
@@ -78,11 +77,20 @@ use tokio::task::JoinHandle;
 /// every turn. Re-spawning with a fresh adapter is the supervisor's
 /// signal that the prior task should be aborted first.
 pub fn spawn_persona_service(
-    hosted: HostedPersona,
-    runtime: Arc<PersonaAircRuntime>,
+    ctx: HostedPersona,
     opts: ServeOptions,
     rt_handle: tokio::runtime::Handle,
 ) -> JoinHandle<Result<ServeOutcome, String>> {
+    // Production callers always populate `ctx.runtime` from the
+    // post-bootstrap registry; the `Option` exists only so test
+    // fixtures can build PersonaContexts without a live airc.
+    // `expect` here is the substrate's "this is a programmer error"
+    // signal — if a None reaches this site in prod, the boot path
+    // skipped a step it shouldn't have.
+    let runtime = ctx
+        .runtime
+        .clone()
+        .expect("spawn_persona_service requires ctx.runtime — None is test-only");
     // Up-cast the persona's Arc<Airc> to Arc<dyn AircTranscriptReader>.
     // `impl AircTranscriptReader for airc_lib::Airc` already exists
     // in airc_source.rs (line 74), so this is a zero-cost type-level
@@ -90,6 +98,6 @@ pub fn spawn_persona_service(
     let reader: Arc<dyn AircTranscriptReader> = runtime.airc().clone();
     let mut conversation = AircPersonaConversation::new(runtime);
     rt_handle.spawn(async move {
-        serve_persona_loop(&hosted, &mut conversation, reader, opts).await
+        serve_persona_loop(&ctx, &mut conversation, reader, opts).await
     })
 }

--- a/src/workers/continuum-core/src/persona/profile_builder.rs
+++ b/src/workers/continuum-core/src/persona/profile_builder.rs
@@ -67,7 +67,7 @@ pub fn build_profile(
     tier_id: &str,
     tier_category: HwTierCategory,
     model_id: &str,
-    registry: &Arc<crate::model_registry::Registry>,
+    registry: &crate::model_registry::Registry,
 ) -> Result<PersonaInferenceProfile, InferenceProfileError> {
     let _ = role_id; // see module docstring; reserved for cognition_defaults wiring
 

--- a/src/workers/continuum-core/src/persona/rag_inspect.rs
+++ b/src/workers/continuum-core/src/persona/rag_inspect.rs
@@ -85,7 +85,11 @@ pub struct RagInspectionRequest {
 impl RagInspectionRequest {
     /// Sensible defaults for "show me what this persona would see
     /// right now at a typical 32k context model." Caller can mutate
-    /// any field after this.
+    /// any field after this. Prefer [`Self::for_persona`] when you
+    /// already have a [`PersonaInferenceProfile`] in hand — that
+    /// path threads the profile's actual context_length through so
+    /// the RAG layer never asks for more tokens than the adapter
+    /// can decode.
     pub fn defaults_for(persona_id: Uuid, persona_name: String, now_ms: u64) -> Self {
         Self {
             persona_id,
@@ -97,6 +101,56 @@ impl RagInspectionRequest {
             },
             airc_floor: 500,
             airc_max: 20_000,
+            airc_priority: 10,
+            airc_required: true,
+            airc_fetch_limit: 100,
+            now_ms,
+            trace_path: None,
+        }
+    }
+
+    /// Derive the inspection request from the persona's inference
+    /// profile — the single source of truth for context budgets.
+    /// `&PersonaInferenceProfile` is the substrate's persona-shape
+    /// context object (analogous to Android's `Context`); every
+    /// downstream layer that needs an inference-shape knob reads
+    /// from this struct instead of copying fields or holding
+    /// duplicate constants.
+    ///
+    /// The derivation:
+    /// - `context_window` = `profile.context_length` (no overflow
+    ///   risk — the RAG layer can never ask for more than the
+    ///   adapter was loaded with).
+    /// - `airc_max` = at most 60% of the runtime context, AND at
+    ///   most what's left after the system + completion reserve.
+    ///   The 60% factor mirrors the `defaults_for` ratio
+    ///   (20_000 / 32_768 ≈ 0.61) so the relative budget shape
+    ///   stays consistent across tier-clamped contexts.
+    /// - `airc_floor` clamps to `airc_max` so floor ≤ max always.
+    pub fn for_persona(
+        persona_id: Uuid,
+        persona_name: String,
+        now_ms: u64,
+        profile: &crate::persona::inference_profile::PersonaInferenceProfile,
+    ) -> Self {
+        let reserved = ReservedTokens {
+            system: 400,
+            completion: 4_000,
+        };
+        let context_window = profile.context_length;
+        let headroom = context_window
+            .saturating_sub(reserved.system + reserved.completion)
+            .max(512);
+        let airc_max = ((context_window as u64) * 6 / 10) as u32;
+        let airc_max = airc_max.min(headroom);
+        let airc_floor = 500_u32.min(airc_max);
+        Self {
+            persona_id,
+            persona_name,
+            context_window,
+            reserved,
+            airc_floor,
+            airc_max,
             airc_priority: 10,
             airc_required: true,
             airc_fetch_limit: 100,

--- a/src/workers/continuum-core/src/persona/service_loop.rs
+++ b/src/workers/continuum-core/src/persona/service_loop.rs
@@ -165,9 +165,9 @@ pub async fn serve_persona_loop(
         .await
         .map_err(|e| format!("high_water_mark failed: {e}"))?;
 
-    let persona_id = hosted.instance.persona_id;
-    let persona_peer_id = hosted.instance.peer_id;
-    let agent_name = hosted.instance.agent_name.clone();
+    let persona_id = hosted.identity.persona_id;
+    let persona_peer_id = hosted.identity.peer_id;
+    let agent_name = hosted.identity.agent_name.clone();
     // Slice 9 sized `HostedPersona.adapter` as `Arc<dyn ...>` exactly
     // so the loop can clone-and-share with the RAG inspector turn by
     // turn without rebuilding the adapter each time.
@@ -187,7 +187,18 @@ pub async fn serve_persona_loop(
             continue;
         }
 
-        let mut req = RagInspectionRequest::defaults_for(persona_id, agent_name.clone(), (opts.now_ms)());
+        // Profile is the single source of truth for inference shape
+        // (substrate's `&ctx` doctrine — never copy fields out,
+        // never derive duplicates). `for_persona` produces a RAG
+        // request shaped by the profile's actual context_length —
+        // unlike `defaults_for` which would set a 32k budget that
+        // overflows tier-clamped adapters (PR #1511 trace).
+        let mut req = RagInspectionRequest::for_persona(
+            persona_id,
+            agent_name.clone(),
+            (opts.now_ms)(),
+            &hosted.profile,
+        );
         req.airc_fetch_limit = opts.rag_fetch_limit;
 
         let inspection = match inspect_persona_rag_with_inference(
@@ -393,21 +404,49 @@ mod tests {
     }
 
     fn fake_hosted(persona_peer_id: Uuid, reply: &str) -> HostedPersona {
+        use crate::persona::hw_tier_descriptor::HwTierCategory;
+        use crate::persona::inference_profile::{PersonaInferenceProfile, SamplingProfile};
         let adapter = CannedAdapter {
             reply: reply.to_string(),
             calls: AtomicUsize::new(0),
         };
+        let persona_id = Uuid::new_v4();
+        // Build a profile shaped like the LCD Compat tier — the
+        // substrate's lowest common denominator. Test exercises the
+        // same `&ctx` derivation path production uses; no hardcoded
+        // budget constants outside `profile_builder`.
+        let profile = PersonaInferenceProfile {
+            persona_id,
+            persona_name: "Paige".to_string(),
+            model_id: "fake-model".to_string(),
+            gguf_local_path: None,
+            tier_category: HwTierCategory::Compat,
+            tier_id: "test_fixture".to_string(),
+            context_length: 2048,
+            n_ubatch: 512,
+            n_batch: 2048,
+            n_seq_max: 1,
+            n_gpu_layers: 0,
+            sampling: SamplingProfile::chat_defaults(),
+            chat_template: None,
+            stop_sequences: vec![],
+        };
         HostedPersona {
             role: RoleId::Helper,
-            instance: PersonaInstanceInfo {
-                persona_id: Uuid::new_v4(),
+            identity: PersonaInstanceInfo {
+                persona_id,
                 agent_name: "Paige".to_string(),
                 peer_id: persona_peer_id,
                 home: PathBuf::from("/tmp/fake-service-loop"),
                 default_room: Uuid::nil(),
                 source: PersonaIdentitySource::FreshlyMinted,
             },
+            profile,
             adapter: Arc::new(adapter),
+            // Test fixtures don't run through `spawn_persona_service`,
+            // so the runtime stub is None. Production paths always
+            // populate this from the registry post-bootstrap.
+            runtime: None,
         }
     }
 

--- a/src/workers/continuum-core/src/persona/spawner.rs
+++ b/src/workers/continuum-core/src/persona/spawner.rs
@@ -83,7 +83,7 @@ pub fn derive_spawn_plan(
     roster: &[RosterEntry],
     tier_id: &str,
     tier_category: HwTierCategory,
-    registry: &Arc<crate::model_registry::Registry>,
+    registry: &crate::model_registry::Registry,
 ) -> Vec<Result<PersonaInferenceProfile, InferenceProfileError>> {
     roster
         .iter()

--- a/src/workers/continuum-core/src/persona/spawner_module.rs
+++ b/src/workers/continuum-core/src/persona/spawner_module.rs
@@ -507,6 +507,7 @@ mod tests {
             crate::persona::PersonaAircRuntimeRegistry::default(),
             PathBuf::from("/dev/null/unused"),
             airc_core::RoomId::from_uuid(uuid::Uuid::nil()),
+            None,
             PathBuf::from("/dev/null/unused"),
         );
 

--- a/src/workers/continuum-core/src/persona/spawner_module.rs
+++ b/src/workers/continuum-core/src/persona/spawner_module.rs
@@ -318,7 +318,7 @@ pub async fn bootstrap_planned(
     instance_manager: &PersonaInstanceManagerModule,
     provider: &mut dyn crate::persona::identity_provider::PersonaIdentityProvider,
     tier_id: &str,
-    registry: &Arc<crate::model_registry::Registry>,
+    registry: &crate::model_registry::Registry,
 ) -> Result<Vec<MaterializedPersonaPlan>, BootstrapPlannedError> {
     let plan = module.plan();
     let required = plan.len();

--- a/src/workers/continuum-core/src/persona/spawner_module.rs
+++ b/src/workers/continuum-core/src/persona/spawner_module.rs
@@ -87,40 +87,31 @@ pub fn plan_for_tier(
     hw_capability: HwCapabilityTier,
     tier_category: HwTierCategory,
 ) -> Vec<DesiredRole> {
-    // Slot the substrate's LCD as Helper + Coder on Compat. Per Joel
-    // (#133): "no MacBooks left behind." Even the weakest hardware
-    // gets multi-persona on day one.
+    // Slice 13 ships SINGLE-PERSONA-per-plan. The Coder slot is
+    // deferred to slice 14 because ResumeOrMintProvider's
+    // scan_personas_dir sorts alphabetically (line 200 of
+    // resume_or_mint_provider.rs), so on boot 2 the
+    // position-pairing of [Helper, Coder] against the disk-yielded
+    // alphabetic persona order flips role assignments — Bart
+    // (random-derived from peer_id) becomes Helper when he was
+    // bootstrapped as Coder, etc. PR #1510 review caught this; the
+    // load-bearing fix is role-in-seed.json (slice 14).
+    //
+    // Re-enable [Helper, Coder] (and richer rosters for higher
+    // tiers) when slice 14 lands. Until then the substrate hosts ONE
+    // Helper persona per tier — the demo-binary level of coverage,
+    // but through the substrate-managed path.
     let _ = hw_capability; // currently informational; future per-tier
                            // role_template selection consumes it
-    match tier_category {
-        HwTierCategory::Compat => vec![
-            DesiredRole {
-                role: RoleId::Helper,
-                model_id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF".to_string(),
-            },
-            DesiredRole {
-                role: RoleId::Coder,
-                model_id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF".to_string(),
-            },
-        ],
-        // Other tiers: Helper + Coder for now, same model selection
-        // pending tier-specific role_template wiring (#123). Slice 8+
-        // will refine — MSeriesPro can fit Qwen2.5-7B; Cuda Sm120 can
-        // fit Qwen2.5-14B + Sentinel + Researcher.
-        HwTierCategory::MSeries
-        | HwTierCategory::MSeriesPro
-        | HwTierCategory::Cuda
-        | HwTierCategory::Cloud => vec![
-            DesiredRole {
-                role: RoleId::Helper,
-                model_id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF".to_string(),
-            },
-            DesiredRole {
-                role: RoleId::Coder,
-                model_id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF".to_string(),
-            },
-        ],
-    }
+    let _ = tier_category; // all tiers produce the same single-Helper
+                           // plan until slice 14 ships role-aware
+                           // mapping + multi-role-per-tier rosters
+    vec![DesiredRole {
+        role: RoleId::Helper,
+        model_id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF".to_string(),
+    }]
+    // TODO #133 slice 14: restore tier-shaped rosters after
+    // RoleAwareProvider + role-in-seed.json land.
 }
 
 /// Substrate ServiceModule that surfaces the spawner's roster plan.
@@ -382,30 +373,31 @@ mod tests {
     /// Compat tier produces the LCD roster: Helper + Coder both on
     /// Qwen2.5-0.5B. The canonical Intel-Mac startup state #133
     /// targets.
+    ///
+    /// Slice 13 update: temporarily single-Helper while ResumeOrMint-
+    /// Provider's alphabetical sort + position-pairing hazard is
+    /// resolved in slice 14. Coder will be re-added once
+    /// role-in-seed.json lands.
     #[test]
-    fn compat_tier_plans_helper_and_coder_on_lcd() {
+    fn compat_tier_plans_single_helper_on_lcd() {
         let plan = plan_for_tier(
             HwCapabilityTier::MacIntelMetalDiscrete,
             HwTierCategory::Compat,
         );
-        assert_eq!(plan.len(), 2);
+        assert_eq!(plan.len(), 1);
         assert_eq!(plan[0].role, RoleId::Helper);
-        assert_eq!(plan[1].role, RoleId::Coder);
         assert_eq!(
             plan[0].model_id,
             "continuum-ai/qwen2.5-0.5b-instruct-GGUF"
         );
-        assert_eq!(
-            plan[1].model_id,
-            "continuum-ai/qwen2.5-0.5b-instruct-GGUF"
-        );
     }
 
-    /// Every tier currently plans Helper + Coder — verifies the
-    /// "no MacBooks (or anyone) left behind" floor that Joel set on
-    /// 2026-06-01. Slice 8+ refines each tier's roster.
+    /// Every tier currently plans exactly one Helper — until slice 14
+    /// lands role-in-seed.json + RoleAwareProvider, multi-role plans
+    /// would mis-pair roles on boot 2 (alphabetic-disk-order vs
+    /// plan-order). Single role per tier is the safe floor for now.
     #[test]
-    fn every_tier_plans_at_least_helper_and_coder() {
+    fn every_tier_plans_single_helper() {
         for (hw, cat) in [
             (HwCapabilityTier::CpuOnly, HwTierCategory::Compat),
             (HwCapabilityTier::M1Uma8Gb, HwTierCategory::MSeries),
@@ -414,16 +406,31 @@ mod tests {
             (HwCapabilityTier::Cloud, HwTierCategory::Cloud),
         ] {
             let plan = plan_for_tier(hw, cat);
-            assert!(plan.len() >= 2, "tier {cat:?} planned only {} roles", plan.len());
-            assert!(
-                plan.iter().any(|r| r.role == RoleId::Helper),
-                "tier {cat:?} missing Helper"
-            );
-            assert!(
-                plan.iter().any(|r| r.role == RoleId::Coder),
-                "tier {cat:?} missing Coder"
+            assert_eq!(plan.len(), 1, "tier {cat:?} planned {} roles, want 1", plan.len());
+            assert_eq!(
+                plan[0].role,
+                RoleId::Helper,
+                "tier {cat:?} first slot must be Helper"
             );
         }
+    }
+
+    /// Regression test for the position-pairing hazard (PR #1510 review
+    /// finding #2). Pinned `#[ignore]` until slice 14 lands role-in-
+    /// seed.json + RoleAwareProvider. The body documents what slice
+    /// 14 must restore: tier-shaped multi-role rosters that survive
+    /// boot 2's alphabetic persona order without flipping roles.
+    #[test]
+    #[ignore = "tracks #133 slice 14 — role-in-seed.json + RoleAwareProvider"]
+    fn slice_14_restores_helper_plus_coder_for_compat() {
+        let plan = plan_for_tier(
+            HwCapabilityTier::MacIntelMetalDiscrete,
+            HwTierCategory::Compat,
+        );
+        // When slice 14 ships, this assertion becomes the live spec:
+        assert_eq!(plan.len(), 2);
+        assert!(plan.iter().any(|r| r.role == RoleId::Helper));
+        assert!(plan.iter().any(|r| r.role == RoleId::Coder));
     }
 
     /// ServiceModule.plan() is the same as the free function with the
@@ -513,7 +520,10 @@ mod tests {
                 assert_eq!(slot_index, 0);
                 assert_eq!(role, RoleId::Helper);
                 assert_eq!(provided, 0);
-                assert_eq!(required, 2);
+                // Slice 13 P2: single-Helper plan until slice 14 lands
+                // role-in-seed.json. `required` reflects the current
+                // plan size; updates to 2 when Coder returns.
+                assert_eq!(required, 1);
             }
             other => panic!("expected IdentityProviderExhausted, got {other:?}"),
         }

--- a/src/workers/continuum-core/src/persona/spawner_module.rs
+++ b/src/workers/continuum-core/src/persona/spawner_module.rs
@@ -106,12 +106,28 @@ pub fn plan_for_tier(
     let _ = tier_category; // all tiers produce the same single-Helper
                            // plan until slice 14 ships role-aware
                            // mapping + multi-role-per-tier rosters
-    vec![DesiredRole {
+    let plan = vec![DesiredRole {
         role: RoleId::Helper,
         model_id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF".to_string(),
-    }]
+    }];
+    // P2 invariant tripwire (PR #1511 review advisory): if a future
+    // refactor adds a second role here without atomically updating
+    // ResumeOrMintProvider's role mapping, position-pairing will
+    // silently mis-pair roles on boot 2 (alphabetic disk order vs
+    // plan order). The debug_assert catches the regression at the
+    // producer in debug + test builds. Slice 14 removes this when
+    // role-in-seed.json makes multi-role plans safe.
+    debug_assert!(
+        plan.len() <= 1,
+        "plan_for_tier returned {} roles before slice 14's role-in-seed.json \
+         landed — position-pairing against ResumeOrMintProvider's alphabetic \
+         disk order would flip role identity on boot 2. See #133 slice 14.",
+        plan.len()
+    );
+    plan
     // TODO #133 slice 14: restore tier-shaped rosters after
-    // RoleAwareProvider + role-in-seed.json land.
+    // RoleAwareProvider + role-in-seed.json land. Remove the
+    // debug_assert above as part of that change.
 }
 
 /// Substrate ServiceModule that surfaces the spawner's roster plan.

--- a/src/workers/continuum-core/src/persona/supervisor.rs
+++ b/src/workers/continuum-core/src/persona/supervisor.rs
@@ -41,6 +41,7 @@
 //!   declared intent and the adapter materializes that.
 
 use crate::ai::adapter::AIProviderAdapter;
+use crate::persona::airc_runtime::PersonaAircRuntime;
 use crate::persona::inference_profile::{InferenceProfileError, PersonaInferenceProfile};
 use crate::persona::role_template::RoleId;
 use crate::persona::spawner_module::MaterializedPersonaPlan;
@@ -85,23 +86,112 @@ impl PersonaAdapterFactory for LlamaCppPersonaAdapterFactory {
     }
 }
 
-/// One row of the supervisor's roster: a persona with airc identity
-/// allocated AND a usable inference adapter constructed. Slice 10's
-/// per-persona subscribe-loop takes a `Vec<HostedPersona>` and binds
-/// each to its room.
-pub struct HostedPersona {
+/// One row of the supervisor's roster — and the substrate's
+/// per-persona context object. Analog of Android's `Context`:
+/// the single struct every persona-scoped function reads from.
+///
+/// ## The `&ctx` doctrine
+///
+/// Persona/cognition/RAG/inference/supervisor functions take
+/// `&PersonaContext` and read what they need. They MUST NOT extract
+/// individual fields and pass them as separate arguments — that
+/// fragments the substrate's source of truth and creates drift.
+/// Every derived shape (a RAG inspection request, a sampling spec
+/// adjustment, a log scope) is produced from `&ctx` via a named
+/// constructor whose name says `for_persona`/`for_ctx`.
+///
+/// ## The substrate's actor model — this IS the airc user
+///
+/// Per `[[personas-are-citizens-airc-is-identity-provider]]`:
+/// "Personas, humans, Claude/OpenClaw/Hermes are the same kind of
+/// citizen." Every actor in the substrate is an airc user.
+///
+/// The substrate's eventual shape (task #142) is a `BaseUser` that
+/// carries the airc props every actor has — peer_id, identity,
+/// runtime, home, default_room — plus per-actor extensions:
+///   - `PersonaContext` = `BaseUser` + (role, profile, adapter)
+///   - `HumanUserContext` = `BaseUser` + UI session + human ID card
+///   - `WebUserContext` = `BaseUser` + tab/session id + auth scope
+///
+/// Same base, different extensions. Past designs that scattered
+/// actor state across multiple ad-hoc structs are explicitly the
+/// anti-pattern this struct exists to prevent (Joel 2026-06-02 —
+/// "design got out of control due to not using a shared object for
+/// all state info required for a persona OR user"). For slice 13,
+/// `PersonaContext` already carries the airc props (via `runtime`)
+/// + persona extensions — so the BaseUser extraction is purely a
+/// rename + trait extraction, additive only.
+///
+/// ## What's in the context
+///
+/// - `identity` — substrate-stable persona_id + airc-side
+///   peer_id/agent_name/home dir + the room she joined at bootstrap.
+/// - `role` — Helper / Coder / Sentinel / Custom. Cognition reads it
+///   to shape prompts.
+/// - `profile` — the inference shape: `context_length`, `n_ubatch`,
+///   sampling, `model_id`, `stop_sequences`, `chat_template`. The
+///   single source of truth for the persona's compute envelope.
+/// - `adapter` — the inference adapter, hot for generate_text. `Arc`
+///   so the service loop can clone-share it with the RAG layer.
+/// - `runtime` — the persona's `Arc<PersonaAircRuntime>` (her grid
+///   presence). The service loop subscribes through this; `say()`
+///   posts through this. Cognition reads `runtime.airc().peer_id()`
+///   for self-filtering.
+///
+/// ## Type-alias note
+///
+/// The struct used to be named `HostedPersona` (slice 9). The rename
+/// to `PersonaContext` signals the design role; `pub type
+/// HostedPersona = PersonaContext;` below keeps slice-9-era callers
+/// compiling without a sweeping rename. New code should use
+/// `PersonaContext` directly.
+pub struct PersonaContext {
     /// Role identity (Helper / Coder / Sentinel / Custom).
     pub role: RoleId,
-    /// airc identity allocation result — peer_id, agent_name, home,
-    /// default room. Copied from the bootstrap step.
-    pub instance: crate::modules::persona_instance_manager::PersonaInstanceInfo,
+    /// The airc-side citizen identity — peer_id, agent_name, home,
+    /// default_room, source (resumed vs minted). This is the
+    /// substrate's universal actor identity per
+    /// `[[personas-are-citizens-airc-is-identity-provider]]`. Same
+    /// type for personas, humans, browsers — everyone has a
+    /// `.identity`. Token/auth state lives inside.
+    pub identity: crate::modules::persona_instance_manager::PersonaInstanceInfo,
+    /// The single source of truth for this persona's inference
+    /// shape — context window, ubatch, sampling, model id, stop
+    /// sequences, etc. Produced by slice-5 `build_profile`. Every
+    /// downstream layer that needs an inference-shape knob
+    /// (service-loop's RAG request, future supervisor health
+    /// commands, replay) reads from this struct — no second copy,
+    /// no derived constants. PR #1511 integration trace caught the
+    /// failure mode of letting the RAG layer's own 32k default
+    /// override the adapter's 2k context_length: llama_decode
+    /// returned -1 because the prompt budget exceeded what the
+    /// adapter was loaded with. The fix is structural — the
+    /// profile is the single source.
+    pub profile: PersonaInferenceProfile,
     /// The inference adapter, ready to receive `generate_text` calls.
     /// `Arc` so the service-loop (#133 slice 10) can clone-and-share
     /// the adapter with the RAG inspector. #122 (shared base) keeps
     /// the same `Arc<dyn ...>` shape — only the concrete adapter
     /// inside changes.
     pub adapter: Arc<dyn AIProviderAdapter>,
+    /// The persona's `Arc<PersonaAircRuntime>` — her grid presence.
+    /// The service loop subscribes through `runtime.airc().subscribe()`
+    /// and posts replies through `runtime.say(text)`. Cognition uses
+    /// `runtime.airc().peer_id()` for self-filtering. Held here so
+    /// `&ctx` is the one handle every layer needs.
+    ///
+    /// `None` only in tests — production materialize_adapters always
+    /// fills this from the registry post-bootstrap. Cleaner trait
+    /// abstraction (`Arc<dyn AircHandle>`) lands with task #142's
+    /// BaseUser hierarchy; for slice 13 the Option keeps the
+    /// supervisor + service-loop tests building without standing up
+    /// a real airc daemon fixture.
+    pub runtime: Option<Arc<PersonaAircRuntime>>,
 }
+
+/// Back-compat alias for the slice-9-era struct name. New code
+/// should write `PersonaContext` directly.
+pub type HostedPersona = PersonaContext;
 
 /// Structured error per failed slot. The two failure modes are:
 ///
@@ -150,7 +240,8 @@ pub enum SupervisorError {
 pub async fn materialize_adapters(
     plans: Vec<MaterializedPersonaPlan>,
     factory: &dyn PersonaAdapterFactory,
-) -> Vec<Result<HostedPersona, SupervisorError>> {
+    runtime_lookup: impl Fn(uuid::Uuid) -> Option<Arc<PersonaAircRuntime>>,
+) -> Vec<Result<PersonaContext, SupervisorError>> {
     let mut out = Vec::with_capacity(plans.len());
     for (slot_index, plan) in plans.into_iter().enumerate() {
         let profile = match plan.profile {
@@ -164,11 +255,15 @@ pub async fn materialize_adapters(
                 continue;
             }
         };
+        let identity = plan.instance;
+        let runtime = runtime_lookup(identity.persona_id);
         match factory.build_adapter(&profile).await {
-            Ok(adapter) => out.push(Ok(HostedPersona {
+            Ok(adapter) => out.push(Ok(PersonaContext {
                 role: plan.role,
-                instance: plan.instance,
+                identity,
+                profile,
                 adapter,
+                runtime,
             })),
             Err(message) => out.push(Err(SupervisorError::AdapterFactory {
                 slot_index,
@@ -332,19 +427,19 @@ mod tests {
         let factory = OkFactory {
             builds: AtomicUsize::new(0),
         };
-        let hosted = materialize_adapters(plans, &factory).await;
+        let hosted = materialize_adapters(plans, &factory, |_| None).await;
 
         assert_eq!(hosted.len(), 2);
         assert_eq!(factory.builds.load(Ordering::SeqCst), 2);
 
         let helper = hosted[0].as_ref().expect("Helper hosted");
         assert_eq!(helper.role, RoleId::Helper);
-        assert_eq!(helper.instance.agent_name, "Paige");
+        assert_eq!(helper.identity.agent_name, "Paige");
         assert_eq!(helper.adapter.provider_id(), "model-a");
 
         let coder = hosted[1].as_ref().expect("Coder hosted");
         assert_eq!(coder.role, RoleId::Coder);
-        assert_eq!(coder.instance.agent_name, "Pax");
+        assert_eq!(coder.identity.agent_name, "Pax");
         assert_eq!(coder.adapter.provider_id(), "model-b");
     }
 
@@ -373,7 +468,7 @@ mod tests {
         let factory = OkFactory {
             builds: AtomicUsize::new(0),
         };
-        let hosted = materialize_adapters(plans, &factory).await;
+        let hosted = materialize_adapters(plans, &factory, |_| None).await;
 
         assert_eq!(hosted.len(), 2);
         // Factory called exactly once — for the Ok row only.
@@ -406,7 +501,7 @@ mod tests {
         }];
 
         let factory = ErrFactory;
-        let hosted = materialize_adapters(plans, &factory).await;
+        let hosted = materialize_adapters(plans, &factory, |_| None).await;
 
         assert_eq!(hosted.len(), 1);
         match &hosted[0] {
@@ -431,7 +526,7 @@ mod tests {
         let factory = OkFactory {
             builds: AtomicUsize::new(0),
         };
-        let hosted = materialize_adapters(vec![], &factory).await;
+        let hosted = materialize_adapters(vec![], &factory, |_| None).await;
         assert!(hosted.is_empty());
         assert_eq!(factory.builds.load(Ordering::SeqCst), 0);
     }


### PR DESCRIPTION
## Summary

Slice 13 of #133 — the IPC-boot rewire that finally makes `continuum-core` host personas headlessly. Before this PR, the boot loop at `ipc/mod.rs:1024-1089` called `bootstrap_one` per persona and logged a welcome — the persona was reachable via `airc peers` but never responded. After this PR, the boot path composes slices 7-12 into one substrate-managed pipeline; each planned persona ends up with a tokio task running her serve loop.

Implements the revised HEADLESS-PERSONA-HOST-LOOP design (PR #1510 + reviewer fixes).

## What's in the PR

Four commits stacked, each independently reviewable:

1. **`71429daae` Q1** — `bootstrap_planned` / `derive_spawn_plan` / `build_profile` take `&Registry` instead of `&Arc<Registry>`. Smaller change than migrating the OnceLock<Registry> singleton; deref-coercion handles test sites transparently.
2. **`3f843aada` Q3** — `PersonaAircRuntimeRegistry` extended: each slot now holds `runtime + service_loop` together. New methods: `attach_service_loop`, `is_service_loop_finished`, `shutdown_slot` (orderly abort + await + remove). Old keyspace duplication concern resolved.
3. **`f940fa47d` P2** — `plan_for_tier` returns single Helper for all tiers until slice 14 lands role-in-seed.json. Position-pairing hazard from PR #1510 review is named in the commit body; regression test pinned `#[ignore]`.
4. **`8611bae56` boot composition** — the IPC boot loop replaced with the substrate pipeline. Old welcome-log-only path deleted per [[organization-purity-as-we-migrate]].

## Status against design doc

**Applied** ✅: Q1, Q3, P2, boot composition.

**Deferred with TODO markers** (sub-slices):
- **Q2** (`detect_host_capability` wiring): no production `GpuMonitor` constructor exists today — only tests build one. Slice 13 uses `HwCapabilityTier::CpuOnly + HwTierCategory::Compat` as a safe floor (which produces the LCD Helper anyway). TODO #52.
- **P1** (`tokio::signal::ctrl_c` → `Runtime::shutdown`): per-slot shutdown is available via `PersonaAircRuntimeRegistry::shutdown_slot` and used by `persona/instances/*` IPC commands. Server-level signal handler is its own sub-slice.
- **P3** (`ResourceBroker.acquire` admission): current LCD case is 1 persona × ~500 MiB GGUF, well within all tiers' headroom. Becomes load-bearing when multi-persona returns in slice 14.

These three deferred items are named at top of the boot composition's doc-comment so the next author doesn't have to re-discover the gaps.

## Cleanup model (critical, per PR #1510 review)

`PersonaAircRuntimeRegistry::shutdown_slot` is the orderly cleanup path. The cascade:
1. Take `JoinHandle` from slot.
2. `abort()` + `await` (drains).
3. Slot drops → `Arc<PersonaAircRuntime>` drops → `Arc<Airc>` drops → `inner.subscribers` map drops → daemon-attached wire-subscriber tasks abort.

**`abort()` alone is insufficient** — the wire subscriber stays in `Arc<Airc>.inner.subscribers` until the Arc itself drops via registry removal. Both steps are required; the registry's `shutdown_slot` is the one place that does them in order.

## Reference docs
- [docs/planning/HEADLESS-PERSONA-HOST-LOOP.md](docs/planning/HEADLESS-PERSONA-HOST-LOOP.md) — the load-bearing design (PR #1510)
- [docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md](docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md)
- [docs/planning/ALPHA-GAP-ANALYSIS.md](docs/planning/ALPHA-GAP-ANALYSIS.md)

## Test plan

- [x] `cargo test persona::airc_runtime_registry` — 5 passed (new tests for attach/shutdown/is_finished failure modes)
- [x] `cargo test persona::service_loop` — 4 passed
- [x] `cargo test persona::supervisor` — 4 passed
- [x] `cargo test persona::spawner` — 9 passed + 1 ignored
- [x] `cargo test persona::spawner_module` — 5 passed + 1 ignored (slice 14 regression test)
- [x] `cargo test persona::profile_builder` — 4 passed
- [x] `cargo test persona::host` — 0 tests (composition seam, exercised by boot)
- [ ] CI confirms cross-platform builds
- [ ] Real-airc smoke (post-merge, in a continuum-core checkout with a running airc daemon)

## Memories worth refreshing on review

- [[no-fallbacks-ever]] — per-slot errors stay errored, no substitution
- [[no-stdio-piping-for-process-ipc]] — substrate talks only via typed sockets + airc-lib
- [[substrate-is-a-good-citizen-on-the-host]] — caller controls scheduling pool
- [[observability-is-half-the-architecture]] — slot-level shutdown is honest about why it left
- [[organization-purity-as-we-migrate]] — old welcome-log-only path DELETED, not kept beside
- [[commands-are-dumb-daemons-are-smart]] — spawn helper trivial; registry + boot do the smart work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
