### PR TITLE
refactor(persona/ai): pull throwaway test scaffolding into system-level primitives

### DIFF
--- a/src/workers/continuum-core/src/ai/heuristic_adapter.rs
+++ b/src/workers/continuum-core/src/ai/heuristic_adapter.rs
@@ -80,12 +80,89 @@ const CHARS_PER_TOKEN: usize = 4;
 
 /// The adapter struct itself. No mutable state, no clock access, no
 /// external resources — instances are cheap and interchangeable.
+///
+/// Configuration knobs are all opt-in via builder methods; production
+/// callers use `HeuristicInferenceAdapter::new()` and pay zero cost
+/// for the unused knobs. Tests, replay rigs, simulated-slow-network
+/// scenarios, and warmup-failure substrate diagnostics set them via
+/// `.with_*` methods.
+///
+/// Per [[test-fixtures-are-system-primitives]]: validation behaviors
+/// (delay injection, warmup failure, etc.) belong on the production
+/// primitive, not as bespoke `#[cfg(test)]` clones. The same struct
+/// powers the CI heuristic path, latency-floor regression tests,
+/// supervisor warmup-error tests, and any future component that
+/// needs a deterministic adapter with controllable timing.
 #[derive(Debug, Default)]
-pub struct HeuristicInferenceAdapter;
+pub struct HeuristicInferenceAdapter {
+    /// Sleep injected before every `generate_text` returns. 0 (default)
+    /// is the production-cheap shape. Setting this is useful for
+    /// latency-floor regression tests + simulating slow-network
+    /// adapters (e.g., a future cross-grid inference adapter that
+    /// pays a real round-trip).
+    inject_delay_ms: u64,
+    /// If Some, `warmup()` returns Err with this reason. Production
+    /// uses None (warmup succeeds with no-op). Tests + diagnostic
+    /// substrate paths use this to exercise the
+    /// `SupervisorError::AdapterWarmup` typed-failure path.
+    warmup_failure: Option<String>,
+    /// Optional counter incremented on every `warmup()` call. Shared
+    /// `Arc<AtomicUsize>` so a test can register the same counter
+    /// across multiple adapters built by a factory and assert "warmup
+    /// was called N times across the substrate." Per
+    /// [[test-fixtures-are-system-primitives]] this is the observer
+    /// hook that lets the supervisor tests verify the
+    /// init-once-handle-then-lease contract without resorting to
+    /// bespoke FakeAdapter types.
+    warmup_observer: Option<std::sync::Arc<std::sync::atomic::AtomicUsize>>,
+    /// Same shape for `generate_text` — counts substrate-side hot-path
+    /// inference calls so tests can assert per-turn counts.
+    generate_observer: Option<std::sync::Arc<std::sync::atomic::AtomicUsize>>,
+}
 
 impl HeuristicInferenceAdapter {
+    /// Zero-config constructor — what production code uses.
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    /// Inject a real `tokio::time::sleep` before every `generate_text`
+    /// returns. Used by per-turn latency tests to verify the metric
+    /// reflects actual wall-clock, and by simulated-network scenarios
+    /// to model adapters that pay real round-trip cost.
+    pub fn with_delay_ms(mut self, ms: u64) -> Self {
+        self.inject_delay_ms = ms;
+        self
+    }
+
+    /// Make `warmup()` return Err with this reason. Used by supervisor
+    /// + service-loop tests to exercise the typed `AdapterWarmup`
+    /// failure path per [[no-fallbacks-ever]].
+    pub fn with_warmup_failure(mut self, reason: impl Into<String>) -> Self {
+        self.warmup_failure = Some(reason.into());
+        self
+    }
+
+    /// Register a shared counter that increments on every `warmup()`
+    /// call. The same `Arc<AtomicUsize>` can be passed to multiple
+    /// adapters so tests can assert substrate-wide warmup invocation
+    /// counts without bespoke factory state.
+    pub fn with_warmup_observer(
+        mut self,
+        counter: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Self {
+        self.warmup_observer = Some(counter);
+        self
+    }
+
+    /// Register a shared counter that increments on every
+    /// `generate_text()` call.
+    pub fn with_generate_observer(
+        mut self,
+        counter: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Self {
+        self.generate_observer = Some(counter);
+        self
     }
 
     /// Pull the last user message's text (or "" if absent). Walks
@@ -243,6 +320,22 @@ impl AIProviderAdapter for HeuristicInferenceAdapter {
         Ok(())
     }
 
+    async fn warmup(&self) -> Result<(), String> {
+        // Observer fires before the failure check so tests can assert
+        // "warmup was attempted" independent of "warmup succeeded."
+        if let Some(c) = &self.warmup_observer {
+            c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+        // Production: succeeds with no-op (default `warmup_failure: None`).
+        // Test / diagnostic: caller used `.with_warmup_failure(reason)`
+        // — return Err with that reason so the supervisor surfaces
+        // `SupervisorError::AdapterWarmup` per [[no-fallbacks-ever]].
+        if let Some(reason) = &self.warmup_failure {
+            return Err(reason.clone());
+        }
+        Ok(())
+    }
+
     async fn shutdown(&mut self) -> Result<(), String> {
         Ok(())
     }
@@ -251,6 +344,20 @@ impl AIProviderAdapter for HeuristicInferenceAdapter {
         &self,
         request: TextGenerationRequest,
     ) -> Result<TextGenerationResponse, String> {
+        // Observer fires for substrate-side hot-path inference call
+        // counts.
+        if let Some(c) = &self.generate_observer {
+            c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+        // Inject real wall-clock if the caller configured a delay. Used
+        // by latency-floor regression tests to verify the substrate's
+        // turn_latency metric reflects actual elapsed time, and by
+        // future simulated-network adapters. Production callers use
+        // `new()` with delay=0 and pay zero overhead.
+        if self.inject_delay_ms > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(self.inject_delay_ms))
+                .await;
+        }
         let model = request
             .model
             .clone()

--- a/src/workers/continuum-core/src/persona/airc_citizen.rs
+++ b/src/workers/continuum-core/src/persona/airc_citizen.rs
@@ -111,6 +111,20 @@ impl StubAircCitizen {
     pub fn new(peer_id: Uuid) -> Self {
         Self { peer_id }
     }
+
+    /// Convenience: a `runtime_lookup` closure for
+    /// `materialize_adapters` that returns a fresh stub for every
+    /// persona_id queried. Substrate-level helper per
+    /// [[test-fixtures-are-system-primitives]] — every supervisor
+    /// test that exercises materialize_adapters without a real airc
+    /// daemon leases this closure shape.
+    pub fn fresh_lookup(
+    ) -> impl Fn(Uuid) -> Option<std::sync::Arc<dyn AircCitizen>> + Clone {
+        |_pid| {
+            Some(std::sync::Arc::new(Self::new(Uuid::new_v4()))
+                as std::sync::Arc<dyn AircCitizen>)
+        }
+    }
 }
 
 #[async_trait]

--- a/src/workers/continuum-core/src/persona/mod.rs
+++ b/src/workers/continuum-core/src/persona/mod.rs
@@ -17,6 +17,17 @@ pub mod airc_admission;
 pub mod airc_citizen;
 pub mod airc_persona_conversation;
 pub mod airc_runtime;
+// `scripted_*` are SYSTEM-level test/replay primitives per
+// [[test-fixtures-are-system-primitives]] — ubiquitous across every
+// test in the substrate, never bespoke per module. They're gated to
+// the SAME cfg as `HeuristicInferenceAdapter` they depend on, because
+// Joel (2026-06-01): "You mix this fake shit in and it's going live
+// ALL THE TIME. The fake shit is a CHOSEN model adapter no other
+// form. Declaration." cfg gating IS the declaration.
+#[cfg(any(test, feature = "test-fixtures"))]
+pub mod scripted_adapter_factory;
+#[cfg(any(test, feature = "test-fixtures"))]
+pub mod scripted_conversation;
 pub mod airc_runtime_registry;
 pub mod airc_source;
 pub mod allocator;

--- a/src/workers/continuum-core/src/persona/scripted_adapter_factory.rs
+++ b/src/workers/continuum-core/src/persona/scripted_adapter_factory.rs
@@ -1,0 +1,254 @@
+//! `ScriptedPersonaAdapterFactory` — system-level closure-based
+//! `PersonaAdapterFactory`. Every test, replay path, demo binary, or
+//! ad-hoc tooling that needs a non-production adapter factory leases
+//! this one struct.
+//!
+//! Per [[test-fixtures-are-system-primitives]]: one configurable
+//! primitive at the system level, not N bespoke factories per test
+//! module. Subsumes the pre-#1517 `OkFactory` / `ErrFactory` /
+//! `WarmupFailingFactory` (all of which were `#[cfg(test)]` cancer
+//! shaped) into one expressive constructor.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use crate::persona::scripted_adapter_factory::ScriptedPersonaAdapterFactory;
+//! use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
+//!
+//! // Always-succeeds factory with the deterministic heuristic adapter:
+//! let f = ScriptedPersonaAdapterFactory::heuristic();
+//!
+//! // Always-rejects factory:
+//! let f = ScriptedPersonaAdapterFactory::always_fails(
+//!     "simulated factory rejection",
+//! );
+//!
+//! // Warmup-failure factory (verifies SupervisorError::AdapterWarmup):
+//! let f = ScriptedPersonaAdapterFactory::heuristic_with_warmup_failure(
+//!     "simulated warmup failure",
+//! );
+//!
+//! // Slow factory (verifies turn_latency captures real elapsed time):
+//! let f = ScriptedPersonaAdapterFactory::heuristic_with_delay_ms(80);
+//!
+//! // Per-profile dynamic behavior (e.g., one profile succeeds, the
+//! // other refuses):
+//! let f = ScriptedPersonaAdapterFactory::custom(|profile| {
+//!     if profile.persona_name == "Pax" {
+//!         Err("Pax adapter refused".to_string())
+//!     } else {
+//!         Ok(Arc::new(HeuristicInferenceAdapter::new()))
+//!     }
+//! });
+//! ```
+//!
+//! ## Doctrine
+//!
+//! - [[test-fixtures-are-system-primitives]]: this is THE factory
+//!   for non-LlamaCpp persona-adapter materialization paths.
+//! - [[no-fallbacks-ever]]: every failure mode is explicit; no
+//!   default substitution.
+//! - The `builds` counter is part of the system API — tests assert
+//!   the supervisor called the factory the expected number of times.
+
+use crate::ai::adapter::AIProviderAdapter;
+use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
+use crate::persona::inference_profile::PersonaInferenceProfile;
+use crate::persona::supervisor::PersonaAdapterFactory;
+use async_trait::async_trait;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+type BuildFn =
+    dyn Fn(&PersonaInferenceProfile) -> Result<Arc<dyn AIProviderAdapter>, String>
+        + Send
+        + Sync;
+
+/// Closure-based factory. Public, system-level, ubiquitous.
+pub struct ScriptedPersonaAdapterFactory {
+    build: Box<BuildFn>,
+    builds: AtomicUsize,
+}
+
+impl ScriptedPersonaAdapterFactory {
+    /// Build with an explicit closure. Use this when no preset fits —
+    /// e.g., per-profile dynamic behavior, mixing adapter types,
+    /// returning different adapters by role.
+    pub fn custom<F>(build: F) -> Self
+    where
+        F: Fn(&PersonaInferenceProfile) -> Result<Arc<dyn AIProviderAdapter>, String>
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self {
+            build: Box::new(build),
+            builds: AtomicUsize::new(0),
+        }
+    }
+
+    /// Every profile gets a fresh, zero-config
+    /// `HeuristicInferenceAdapter`. The pre-#1517 `OkFactory` shape.
+    pub fn heuristic() -> Self {
+        Self::custom(|_profile| Ok(Arc::new(HeuristicInferenceAdapter::new())))
+    }
+
+    /// Heuristic adapter whose `generate_text` sleeps `delay_ms`
+    /// before returning. Used by per-turn latency regression tests
+    /// to verify the substrate's `turn_latency` metric reflects
+    /// actual wall-clock.
+    pub fn heuristic_with_delay_ms(delay_ms: u64) -> Self {
+        Self::custom(move |_profile| {
+            Ok(Arc::new(HeuristicInferenceAdapter::new().with_delay_ms(delay_ms)))
+        })
+    }
+
+    /// Heuristic adapter whose `warmup` returns Err. Used by
+    /// supervisor tests to exercise the typed `AdapterWarmup` failure
+    /// path per [[no-fallbacks-ever]].
+    pub fn heuristic_with_warmup_failure(reason: impl Into<String>) -> Self {
+        let reason = reason.into();
+        Self::custom(move |_profile| {
+            Ok(Arc::new(
+                HeuristicInferenceAdapter::new().with_warmup_failure(reason.clone()),
+            ))
+        })
+    }
+
+    /// Always rejects with this message. The pre-#1517 `ErrFactory`
+    /// shape — exercises `SupervisorError::AdapterFactory`.
+    pub fn always_fails(reason: impl Into<String>) -> Self {
+        let reason = reason.into();
+        Self::custom(move |_profile| Err(reason.clone()))
+    }
+
+    /// Heuristic factory paired with shared warmup + generate counters.
+    /// Each adapter built by this factory wires the same counters in
+    /// via `HeuristicInferenceAdapter::with_warmup_observer` /
+    /// `with_generate_observer`. Tests assert substrate-wide
+    /// invocation counts (e.g., "warmup ran N times across N slots")
+    /// without bespoke factory state.
+    pub fn heuristic_with_counters() -> (Self, ObservedCounts) {
+        let counts = ObservedCounts::new();
+        let warmup = counts.warmups.clone();
+        let generate = counts.generates.clone();
+        let factory = Self::custom(move |_profile| {
+            Ok(Arc::new(
+                HeuristicInferenceAdapter::new()
+                    .with_warmup_observer(warmup.clone())
+                    .with_generate_observer(generate.clone()),
+            ))
+        });
+        (factory, counts)
+    }
+
+    /// How many `build_adapter` calls landed against this factory.
+    /// Tests assert exact counts to verify per-slot semantics.
+    pub fn build_count(&self) -> usize {
+        self.builds.load(Ordering::SeqCst)
+    }
+}
+
+/// Observable counters returned alongside a factory built by
+/// [`ScriptedPersonaAdapterFactory::heuristic_with_counters`]. Per
+/// [[test-fixtures-are-system-primitives]] the counts are part of
+/// the substrate's testability surface — every test asserting
+/// "warmup ran N times" leases this same pair.
+#[derive(Debug, Clone)]
+pub struct ObservedCounts {
+    pub warmups: Arc<AtomicUsize>,
+    pub generates: Arc<AtomicUsize>,
+}
+
+impl ObservedCounts {
+    fn new() -> Self {
+        Self {
+            warmups: Arc::new(AtomicUsize::new(0)),
+            generates: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+    pub fn warmups(&self) -> usize {
+        self.warmups.load(Ordering::SeqCst)
+    }
+    pub fn generates(&self) -> usize {
+        self.generates.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl PersonaAdapterFactory for ScriptedPersonaAdapterFactory {
+    async fn build_adapter(
+        &self,
+        profile: &PersonaInferenceProfile,
+    ) -> Result<Arc<dyn AIProviderAdapter>, String> {
+        self.builds.fetch_add(1, Ordering::SeqCst);
+        (self.build)(profile)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persona::hw_tier_descriptor::HwTierCategory;
+    use crate::persona::inference_profile::SamplingProfile;
+    use uuid::Uuid;
+
+    fn fake_profile(name: &str, model_id: &str) -> PersonaInferenceProfile {
+        PersonaInferenceProfile {
+            persona_id: Uuid::new_v4(),
+            persona_name: name.to_string(),
+            model_id: model_id.to_string(),
+            gguf_local_path: None,
+            tier_category: HwTierCategory::Compat,
+            tier_id: "test".to_string(),
+            context_length: 2048,
+            n_ubatch: 512,
+            n_batch: 512,
+            n_seq_max: 1,
+            n_gpu_layers: 0,
+            sampling: SamplingProfile::chat_defaults(),
+            chat_template: None,
+            stop_sequences: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn heuristic_returns_heuristic_adapter_and_counts_builds() {
+        let f = ScriptedPersonaAdapterFactory::heuristic();
+        assert_eq!(f.build_count(), 0);
+        let a1 = f.build_adapter(&fake_profile("Paige", "model-a")).await;
+        assert!(a1.is_ok());
+        assert_eq!(f.build_count(), 1);
+        let a2 = f.build_adapter(&fake_profile("Pax", "model-b")).await;
+        assert!(a2.is_ok());
+        assert_eq!(f.build_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn always_fails_returns_typed_error() {
+        let f = ScriptedPersonaAdapterFactory::always_fails("nope");
+        let result = f.build_adapter(&fake_profile("Paige", "model-a")).await;
+        // Don't use `expect_err` — Arc<dyn AIProviderAdapter> doesn't
+        // impl Debug, so unwrap_err's panic-message would fail to
+        // compile. Pattern-match instead.
+        match result {
+            Err(msg) => assert!(msg.contains("nope")),
+            Ok(_) => panic!("expected Err"),
+        }
+        assert_eq!(f.build_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn custom_per_profile_dispatch() {
+        let f = ScriptedPersonaAdapterFactory::custom(|profile| {
+            if profile.persona_name == "Pax" {
+                Err("Pax refused".to_string())
+            } else {
+                Ok(Arc::new(HeuristicInferenceAdapter::new()))
+            }
+        });
+        assert!(f.build_adapter(&fake_profile("Paige", "m")).await.is_ok());
+        assert!(f.build_adapter(&fake_profile("Pax", "m")).await.is_err());
+        assert_eq!(f.build_count(), 2);
+    }
+}

--- a/src/workers/continuum-core/src/persona/scripted_conversation.rs
+++ b/src/workers/continuum-core/src/persona/scripted_conversation.rs
@@ -1,0 +1,267 @@
+//! `ScriptedConversation` — system-level `PersonaConversation` impl
+//! that feeds a pre-baked queue of events, records every `say()` call,
+//! and exposes configurable prime behavior.
+//!
+//! Per [[test-fixtures-are-system-primitives]]: every test, replay
+//! rig, demo binary, and future tool that needs a controllable
+//! conversation surface leases THIS struct. There is no
+//! `#[cfg(test)]` bespoke variant — that's the cancer this primitive
+//! exists to refuse.
+//!
+//! ## Replaces
+//!
+//! Pre-#1517 the substrate had three bespoke `#[cfg(test)]` impls
+//! across `service_loop::tests`: `StubConversation`,
+//! `UnprimedConversation`, `FailingPrimeConversation`. All three
+//! collapse into builder configurations of this one type.
+//!
+//! ## Shape
+//!
+//! ```ignore
+//! use crate::persona::scripted_conversation::ScriptedConversation;
+//! use crate::persona::service_loop::IncomingMessage;
+//!
+//! // Happy path: one inbound, then stream end.
+//! let mut c = ScriptedConversation::new()
+//!     .with_events(vec![
+//!         Ok(Some(IncomingMessage { lamport: 1, peer_id: pid, text: "hello".into() })),
+//!         Ok(None),
+//!     ]);
+//! c.prime().await?;
+//! let msg = c.next_message().await?;
+//!
+//! // Prime failure: substrate refuses to start the loop.
+//! let mut c = ScriptedConversation::new()
+//!     .with_prime_failure("simulated airc daemon unreachable");
+//!
+//! // Unprimed-call detection: next_message yields a typed err if
+//! // the caller forgot to prime first (mirrors AircPersonaConversation).
+//! let mut c = ScriptedConversation::new()
+//!     .with_events(vec![Ok(Some(msg))])
+//!     .require_prime_before_next_message();
+//! // Calling next_message without prime() first → Err.
+//! ```
+//!
+//! ## Doctrine
+//!
+//! - [[test-fixtures-are-system-primitives]]: this is THE conversation
+//!   stub. Lease, never reinvent.
+//! - [[no-fallbacks-ever]]: every behavior is explicit (prime success
+//!   vs failure, require-prime vs not); no silent defaults.
+//! - [[every-error-is-an-opportunity-to-battle-harden]]: configurable
+//!   failure modes mean every regression test can lock the contract
+//!   it cares about.
+
+use crate::persona::service_loop::{IncomingMessage, PersonaConversation};
+use async_trait::async_trait;
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+/// System-level, configurable `PersonaConversation` impl. Public
+/// because every test in the substrate leases it; not behind
+/// `#[cfg(test)]`.
+pub struct ScriptedConversation {
+    high_water: u64,
+    events: Mutex<VecDeque<Result<Option<IncomingMessage>, String>>>,
+    said: Mutex<Vec<String>>,
+    primed: AtomicUsize,
+    prime_result: Mutex<Result<(), String>>,
+    /// When set, `next_message` returns Err if called before `prime`
+    /// — mirrors `AircPersonaConversation`'s caller-primes contract.
+    require_prime: bool,
+}
+
+impl Default for ScriptedConversation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ScriptedConversation {
+    /// Empty conversation: no events queued, prime succeeds, no
+    /// pre-prime requirement. Builder methods configure the rest.
+    pub fn new() -> Self {
+        Self {
+            high_water: 0,
+            events: Mutex::new(VecDeque::new()),
+            said: Mutex::new(Vec::new()),
+            primed: AtomicUsize::new(0),
+            prime_result: Mutex::new(Ok(())),
+            require_prime: false,
+        }
+    }
+
+    /// Replace the queued events. Each entry is what `next_message`
+    /// yields on its next call:
+    /// - `Ok(Some(msg))` → loop processes the message
+    /// - `Ok(None)` → stream ends; loop returns cleanly
+    /// - `Err(_)` → transient error; loop records and continues
+    ///
+    /// When the queue drains, subsequent `next_message` calls yield
+    /// `Ok(None)` so the loop never hangs.
+    pub fn with_events(
+        self,
+        events: Vec<Result<Option<IncomingMessage>, String>>,
+    ) -> Self {
+        *self.events.lock().unwrap() = VecDeque::from(events);
+        self
+    }
+
+    /// Set the pre-attach high-water mark — what `high_water_mark`
+    /// returns. Defaults to 0 (no pre-attach history).
+    pub fn with_high_water(mut self, hw: u64) -> Self {
+        self.high_water = hw;
+        self
+    }
+
+    /// Make `prime()` return Err with this reason. Used by tests that
+    /// verify prime-failure short-circuits the spawn path
+    /// (`spawn_persona_service` returns Err; supervisor records
+    /// `BootSlotFailure`).
+    pub fn with_prime_failure(self, reason: impl Into<String>) -> Self {
+        *self.prime_result.lock().unwrap() = Err(reason.into());
+        self
+    }
+
+    /// Reject `next_message` calls until `prime()` has been invoked at
+    /// least once — mirrors `AircPersonaConversation`'s caller-primes
+    /// contract per [[no-fallbacks-ever]]. Used by the regression
+    /// test that locks the absence of the belt-and-suspenders prime.
+    pub fn require_prime_before_next_message(mut self) -> Self {
+        self.require_prime = true;
+        self
+    }
+
+    /// How many times `prime()` has been called. Tests assert this is
+    /// exactly 1 to verify the caller-primes contract (one prime per
+    /// loop invocation, no belt-and-suspenders).
+    pub fn primed_count(&self) -> usize {
+        self.primed.load(Ordering::SeqCst)
+    }
+
+    /// Snapshot of every text the loop posted via `say()`. Tests
+    /// assert reply content + count.
+    pub fn said(&self) -> Vec<String> {
+        self.said.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl PersonaConversation for ScriptedConversation {
+    async fn prime(&mut self) -> Result<(), String> {
+        self.primed.fetch_add(1, Ordering::SeqCst);
+        self.prime_result.lock().unwrap().clone()
+    }
+
+    async fn high_water_mark(&self, _limit: usize) -> Result<u64, String> {
+        Ok(self.high_water)
+    }
+
+    async fn next_message(&mut self) -> Result<Option<IncomingMessage>, String> {
+        if self.require_prime && self.primed.load(Ordering::SeqCst) == 0 {
+            // Mirror AircPersonaConversation's typed-err shape. CRITICAL:
+            // drain ONE event from the queue before returning Err. The
+            // service loop counts this as `turns_errored` and continues;
+            // if we didn't drain, the same Err would fire forever and
+            // the loop would hang. Substrate-correct semantics: each
+            // call consumes one queue item regardless of whether it
+            // surfaces an event or an err. Per [[no-fallbacks-ever]] the
+            // contract is "queue progress per call", not "queue progress
+            // per success."
+            let drained = self.events.lock().unwrap().pop_front();
+            return match drained {
+                Some(_) => Err(
+                    "ScriptedConversation::next_message called before prime() — \
+                     caller must invoke prime() before iterating"
+                        .to_string(),
+                ),
+                None => Ok(None),
+            };
+        }
+        self.events
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or(Ok(None))
+    }
+
+    async fn say(&self, text: &str) -> Result<(), String> {
+        self.said.lock().unwrap().push(text.to_string());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn one_msg() -> IncomingMessage {
+        IncomingMessage {
+            lamport: 1,
+            peer_id: Uuid::new_v4(),
+            text: "hello".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn default_prime_succeeds_and_counts() {
+        let mut c = ScriptedConversation::new();
+        assert_eq!(c.primed_count(), 0);
+        c.prime().await.expect("default prime ok");
+        assert_eq!(c.primed_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn with_prime_failure_returns_err() {
+        let mut c = ScriptedConversation::new()
+            .with_prime_failure("simulated daemon unreachable");
+        let err = c.prime().await.expect_err("must err");
+        assert!(err.contains("simulated daemon unreachable"));
+        assert_eq!(c.primed_count(), 1, "prime still counts attempts");
+    }
+
+    #[tokio::test]
+    async fn events_drain_then_yield_none() {
+        let mut c = ScriptedConversation::new()
+            .with_events(vec![Ok(Some(one_msg())), Ok(None)]);
+        assert!(c.next_message().await.unwrap().is_some());
+        assert!(c.next_message().await.unwrap().is_none());
+        // Past end → still Ok(None), never hangs.
+        assert!(c.next_message().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn require_prime_before_next_message_enforced() {
+        // TWO events queued — first call (unprimed) drains the first
+        // event AND returns Err. Second call (post-prime) returns the
+        // second event. The drain-on-err semantics are load-bearing:
+        // without them the service loop would re-fire the same Err
+        // every iteration and never make progress.
+        let mut c = ScriptedConversation::new()
+            .with_events(vec![Ok(Some(one_msg())), Ok(Some(one_msg()))])
+            .require_prime_before_next_message();
+        let err = c.next_message().await.expect_err("unprimed err");
+        assert!(err.contains("called before prime()"));
+        c.prime().await.expect("prime ok");
+        assert!(
+            c.next_message().await.unwrap().is_some(),
+            "post-prime call gets the SECOND event; first was drained by the Err path"
+        );
+    }
+
+    #[tokio::test]
+    async fn say_records_in_order() {
+        let c = ScriptedConversation::new();
+        c.say("one").await.unwrap();
+        c.say("two").await.unwrap();
+        assert_eq!(c.said(), vec!["one".to_string(), "two".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn high_water_mark_passes_through() {
+        let c = ScriptedConversation::new().with_high_water(42);
+        assert_eq!(c.high_water_mark(0).await.unwrap(), 42);
+    }
+}

--- a/src/workers/continuum-core/src/persona/service_loop.rs
+++ b/src/workers/continuum-core/src/persona/service_loop.rs
@@ -398,177 +398,37 @@ async fn next_event(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ai::adapter::{
-        AdapterCapabilities, AIProviderAdapter as _, ApiStyle,
-    };
-    use crate::ai::types::{
-        EmbeddingRequest, EmbeddingResponse, FinishReason, HealthStatus, ModelInfo,
-        TextGenerationRequest, TextGenerationResponse, UsageMetrics,
-    };
+    use crate::ai::HeuristicInferenceAdapter;
     use crate::modules::persona_instance_manager::PersonaInstanceInfo;
+    use crate::persona::airc_citizen::StubAircCitizen;
     use crate::persona::airc_source::AircTranscriptReader;
     use crate::persona::identity_provider::PersonaIdentitySource;
     use crate::persona::role_template::RoleId;
+    use crate::persona::scripted_conversation::ScriptedConversation;
     use crate::persona::supervisor::HostedPersona;
-    use airc_lib::{AircError, TranscriptEvent};
-    use std::collections::VecDeque;
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Mutex;
 
-    /// Stub conversation: feeds a pre-baked queue of events; records
-    /// every `say` call for assertions. `primed` records whether the
-    /// loop called `prime` at startup — the contract is one call per
-    /// loop invocation.
-    struct StubConversation {
-        high_water: u64,
-        events: Mutex<VecDeque<Result<Option<IncomingMessage>, String>>>,
-        said: Mutex<Vec<String>>,
-        primed: AtomicUsize,
-    }
+    // Bespoke `StubConversation` / `CannedAdapter` / `EmptyReader` /
+    // `fake_hosted` / `fake_hosted_with_delay` deleted per
+    // [[test-fixtures-are-system-primitives]]. The substrate's
+    // ubiquitous primitives now power every test below:
+    //   * `ScriptedConversation` for the `PersonaConversation` impl
+    //     (with `.with_events`, `.with_high_water`,
+    //     `.with_prime_failure`, `.require_prime_before_next_message`)
+    //   * `HeuristicInferenceAdapter` for the adapter (with
+    //     `.with_delay_ms` for the honest-latency test)
+    //   * `StubAircCitizen` for the AircTranscriptReader — citizens
+    //     are also transcript readers via the trait's supertrait
+    //     bound, so it doubles as the empty-transcript reader
+    //   * `hosted_with_adapter` is the local-helper-of-helpers
+    //     wrapping HostedPersona — small, no impls
 
-    #[async_trait]
-    impl PersonaConversation for StubConversation {
-        async fn prime(&mut self) -> Result<(), String> {
-            // No stream to open — the stub yields events from an
-            // in-memory queue. The substrate's prime() contract is
-            // satisfied trivially. Records that prime was called so
-            // tests can assert the loop honors the contract.
-            self.primed.fetch_add(1, Ordering::SeqCst);
-            Ok(())
-        }
-        async fn high_water_mark(&self, _limit: usize) -> Result<u64, String> {
-            Ok(self.high_water)
-        }
-        async fn next_message(&mut self) -> Result<Option<IncomingMessage>, String> {
-            self.events
-                .lock()
-                .unwrap()
-                .pop_front()
-                .unwrap_or(Ok(None))
-        }
-        async fn say(&self, text: &str) -> Result<(), String> {
-            self.said.lock().unwrap().push(text.to_string());
-            Ok(())
-        }
-    }
-
-    /// Stub adapter: every generate_text returns a canned response.
-    /// Used so the inspect_persona_rag_with_inference call has
-    /// something to return without loading a GGUF.
-    ///
-    /// `inject_delay_ms` injects an awaitable sleep so the latency
-    /// metric test can assert that recorded ms reflect REAL elapsed
-    /// time — not just that `record()` is being called with whatever
-    /// happens to fall out of `Instant::elapsed`. Without this, the
-    /// metric test would be fake-demo-shaped (passing on plumbing,
-    /// silent on correctness).
-    struct CannedAdapter {
-        reply: String,
-        calls: AtomicUsize,
-        inject_delay_ms: u64,
-    }
-
-    #[async_trait]
-    impl AIProviderAdapter for CannedAdapter {
-        fn provider_id(&self) -> &str {
-            "canned"
-        }
-        fn name(&self) -> &str {
-            "canned"
-        }
-        fn capabilities(&self) -> AdapterCapabilities {
-            AdapterCapabilities {
-                supports_text_generation: true,
-                supports_chat: true,
-                is_local: true,
-                ..Default::default()
-            }
-        }
-        fn api_style(&self) -> ApiStyle {
-            ApiStyle::Local
-        }
-        fn default_model(&self) -> &str {
-            "canned-model"
-        }
-        async fn initialize(&mut self) -> Result<(), String> {
-            Ok(())
-        }
-        async fn shutdown(&mut self) -> Result<(), String> {
-            Ok(())
-        }
-        async fn generate_text(
-            &self,
-            _request: TextGenerationRequest,
-        ) -> Result<TextGenerationResponse, String> {
-            self.calls.fetch_add(1, Ordering::SeqCst);
-            if self.inject_delay_ms > 0 {
-                tokio::time::sleep(std::time::Duration::from_millis(self.inject_delay_ms))
-                    .await;
-            }
-            Ok(TextGenerationResponse {
-                text: self.reply.clone(),
-                model: "canned-model".to_string(),
-                provider: "canned".to_string(),
-                finish_reason: FinishReason::Stop,
-                usage: UsageMetrics {
-                    input_tokens: 1,
-                    output_tokens: 1,
-                    total_tokens: 2,
-                    estimated_cost: None,
-                },
-                response_time_ms: 0,
-                request_id: "canned-request".to_string(),
-                content: None,
-                tool_calls: None,
-                routing: None,
-                error: None,
-            })
-        }
-        async fn create_embedding(
-            &self,
-            _request: EmbeddingRequest,
-        ) -> Result<EmbeddingResponse, String> {
-            Err("canned does not embed".into())
-        }
-        async fn health_check(&self) -> HealthStatus {
-            HealthStatus::default()
-        }
-        async fn get_available_models(&self) -> Vec<ModelInfo> {
-            vec![]
-        }
-    }
-
-    /// Stub reader: always returns an empty transcript — RAG layer
-    /// still runs through; the inference adapter still gets called.
-    struct EmptyReader;
-
-    #[async_trait]
-    impl AircTranscriptReader for EmptyReader {
-        async fn page_recent(
-            &self,
-            _limit: usize,
-        ) -> Result<Vec<TranscriptEvent>, AircError> {
-            Ok(vec![])
-        }
-    }
-
-    fn fake_hosted(persona_peer_id: Uuid, reply: &str) -> HostedPersona {
-        fake_hosted_with_delay(persona_peer_id, reply, 0)
-    }
-
-    fn fake_hosted_with_delay(
+    fn hosted_with_adapter(
         persona_peer_id: Uuid,
-        reply: &str,
-        inject_delay_ms: u64,
+        adapter: Arc<dyn AIProviderAdapter>,
     ) -> HostedPersona {
         use crate::persona::hw_tier_descriptor::HwTierCategory;
         use crate::persona::inference_profile::{PersonaInferenceProfile, SamplingProfile};
-        let adapter = CannedAdapter {
-            reply: reply.to_string(),
-            calls: AtomicUsize::new(0),
-            inject_delay_ms,
-        };
         let persona_id = Uuid::new_v4();
         // Build a profile shaped like the LCD Compat tier — the
         // substrate's lowest common denominator. Test exercises the
@@ -601,17 +461,23 @@ mod tests {
                 source: PersonaIdentitySource::FreshlyMinted,
             },
             profile,
-            adapter: Arc::new(adapter),
-            // Service-loop tests drive the loop through `StubConversation`
-            // directly — the citizen handle is never touched. A
-            // [`StubAircCitizen`] satisfies the type without standing
-            // up a real airc daemon; per [[no-fallbacks-ever]] this
-            // replaces the previous `Option<Arc<PersonaAircRuntime>>`
-            // smell with a typed stub.
-            runtime: Arc::new(
-                crate::persona::airc_citizen::StubAircCitizen::new(persona_peer_id),
-            ),
+            adapter,
+            // System-level `StubAircCitizen` satisfies the trait
+            // without standing up a real airc daemon per
+            // [[test-fixtures-are-system-primitives]].
+            runtime: Arc::new(StubAircCitizen::new(persona_peer_id)),
         }
+    }
+
+    fn hosted_with_heuristic(persona_peer_id: Uuid) -> HostedPersona {
+        hosted_with_adapter(persona_peer_id, Arc::new(HeuristicInferenceAdapter::new()))
+    }
+
+    fn hosted_with_delay_ms(persona_peer_id: Uuid, delay_ms: u64) -> HostedPersona {
+        hosted_with_adapter(
+            persona_peer_id,
+            Arc::new(HeuristicInferenceAdapter::new().with_delay_ms(delay_ms)),
+        )
     }
 
     fn fixed_now() -> u64 {
@@ -624,31 +490,22 @@ mod tests {
     async fn replies_to_inbound_from_other_peer() {
         let persona_peer = Uuid::new_v4();
         let other_peer = Uuid::new_v4();
-        let hosted = fake_hosted(persona_peer, "yes, hi.");
+        let hosted = hosted_with_heuristic(persona_peer);
 
-        let mut conversation = StubConversation {
-            high_water: 0,
-            events: Mutex::new(VecDeque::from(vec![
-                Ok(Some(IncomingMessage {
-                    lamport: 1,
-                    peer_id: other_peer,
-                    text: "hello?".to_string(),
-                })),
-                Ok(None),
-            ])),
-            said: Mutex::new(vec![]),
-            primed: AtomicUsize::new(0),
-        };
+        let mut conversation = ScriptedConversation::new().with_events(vec![
+            Ok(Some(IncomingMessage {
+                lamport: 1,
+                peer_id: other_peer,
+                text: "hello?".to_string(),
+            })),
+            Ok(None),
+        ]);
 
-        // Caller-primes contract: direct callers of serve_persona_loop
-        // (tests, demo binaries) prime explicitly before iterating.
-        // The supervisor's spawn_persona_service path does this at the
-        // supervisor level. Per [[no-fallbacks-ever]] there's only ONE
-        // place that primes per code path; the loop assumes the
-        // contract is honored.
+        // Caller-primes contract per [[no-fallbacks-ever]] — explicit.
         conversation.prime().await.expect("prime ok");
 
-        let reader: Arc<dyn AircTranscriptReader> = Arc::new(EmptyReader);
+        let reader: Arc<dyn AircTranscriptReader> =
+            Arc::new(StubAircCitizen::new(Uuid::new_v4()));
         let opts = ServeOptions {
             page_recent_limit: 10,
             rag_fetch_limit: 10,
@@ -662,9 +519,18 @@ mod tests {
         assert_eq!(outcome.turns_replied, 1);
         assert_eq!(outcome.turns_skipped, 0);
         assert_eq!(outcome.turns_errored, 0);
-        let said = conversation.said.lock().unwrap();
+        let said = conversation.said();
         assert_eq!(said.len(), 1);
-        assert_eq!(said[0], "yes, hi.");
+        // HeuristicInferenceAdapter responses are shaped
+        // `[heuristic:<hash>] ack: "<echo>"`. Per
+        // [[test-fixtures-are-system-primitives]] we verify the
+        // shape, not the literal text — the substrate's deterministic
+        // adapter wired through cleanly.
+        assert!(
+            said[0].contains("[heuristic:") && said[0].contains("ack:"),
+            "reply must come from HeuristicInferenceAdapter: {}",
+            said[0]
+        );
         // The loop primes the conversation exactly once at boot —
         // before any high_water_mark or next_message call. Per
         // [[persona-webrtc-all-tiers-latency-obsessed]] this is what
@@ -672,7 +538,7 @@ mod tests {
         // path. If a future refactor regresses to lazy subscribe, the
         // primed count drops to 0 and this test fails loudly.
         assert_eq!(
-            conversation.primed.load(Ordering::SeqCst),
+            conversation.primed_count(),
             1,
             "serve_persona_loop must call prime() exactly once at boot"
         );
@@ -715,25 +581,21 @@ mod tests {
     async fn latency_metric_reflects_real_wall_clock() {
         let persona_peer = Uuid::new_v4();
         let other_peer = Uuid::new_v4();
-        let hosted = fake_hosted_with_delay(persona_peer, "ok.", 80);
+        let hosted = hosted_with_delay_ms(persona_peer, 80);
 
-        let mut conversation = StubConversation {
-            high_water: 0,
-            events: Mutex::new(VecDeque::from(vec![
-                Ok(Some(IncomingMessage {
-                    lamport: 1,
-                    peer_id: other_peer,
-                    text: "ping?".to_string(),
-                })),
-                Ok(None),
-            ])),
-            said: Mutex::new(vec![]),
-            primed: AtomicUsize::new(0),
-        };
+        let mut conversation = ScriptedConversation::new().with_events(vec![
+            Ok(Some(IncomingMessage {
+                lamport: 1,
+                peer_id: other_peer,
+                text: "ping?".to_string(),
+            })),
+            Ok(None),
+        ]);
 
         conversation.prime().await.expect("prime ok");
 
-        let reader: Arc<dyn AircTranscriptReader> = Arc::new(EmptyReader);
+        let reader: Arc<dyn AircTranscriptReader> =
+            Arc::new(StubAircCitizen::new(Uuid::new_v4()));
         let opts = ServeOptions {
             page_recent_limit: 10,
             rag_fetch_limit: 10,
@@ -823,42 +685,24 @@ mod tests {
     async fn loop_without_caller_prime_surfaces_typed_error_per_turn() {
         let persona_peer = Uuid::new_v4();
         let other_peer = Uuid::new_v4();
-        let hosted = fake_hosted(persona_peer, "unused");
+        let hosted = hosted_with_heuristic(persona_peer);
 
-        struct UnprimedConversation {
-            events: Mutex<VecDeque<()>>,
-        }
-        #[async_trait]
-        impl PersonaConversation for UnprimedConversation {
-            async fn prime(&mut self) -> Result<(), String> {
-                // Test deliberately never calls this — we're verifying
-                // the loop does NOT call it implicitly.
-                panic!("test contract: prime must NOT be invoked by the loop");
-            }
-            async fn high_water_mark(&self, _limit: usize) -> Result<u64, String> {
-                Ok(0)
-            }
-            async fn next_message(&mut self) -> Result<Option<IncomingMessage>, String> {
-                // Mimics AircPersonaConversation's typed-err shape when
-                // unprimed. After one error the queue drains and the
-                // loop ends.
-                let mut q = self.events.lock().unwrap();
-                if q.pop_front().is_some() {
-                    Err("called before prime() — caller must invoke prime() first".to_string())
-                } else {
-                    Ok(None)
-                }
-            }
-            async fn say(&self, _text: &str) -> Result<(), String> {
-                panic!("say must not be called when next_message errors");
-            }
-        }
+        // System primitive: `require_prime_before_next_message` makes
+        // `ScriptedConversation` mirror `AircPersonaConversation`'s
+        // caller-primes contract — next_message returns Err if prime
+        // wasn't called first. Substitutes the bespoke
+        // UnprimedConversation per [[test-fixtures-are-system-primitives]].
+        let mut conversation = ScriptedConversation::new()
+            .with_events(vec![Ok(Some(IncomingMessage {
+                lamport: 1,
+                peer_id: other_peer,
+                text: "would-be-message".to_string(),
+            }))])
+            .require_prime_before_next_message();
 
-        let mut conversation = UnprimedConversation {
-            events: Mutex::new(VecDeque::from(vec![()])),
-        };
-        let _ = other_peer;
-        let reader: Arc<dyn AircTranscriptReader> = Arc::new(EmptyReader);
+        // INTENTIONALLY do NOT prime — verify the loop doesn't auto-prime.
+        let reader: Arc<dyn AircTranscriptReader> =
+            Arc::new(StubAircCitizen::new(Uuid::new_v4()));
         let outcome = serve_persona_loop(
             &hosted,
             &mut conversation,
@@ -885,27 +729,20 @@ mod tests {
     #[tokio::test]
     async fn skips_self_loop_messages() {
         let persona_peer = Uuid::new_v4();
-        let hosted = fake_hosted(persona_peer, "should not be sent.");
+        let hosted = hosted_with_heuristic(persona_peer);
 
-        let mut conversation = StubConversation {
-            high_water: 0,
-            events: Mutex::new(VecDeque::from(vec![
-                Ok(Some(IncomingMessage {
-                    lamport: 1,
-                    peer_id: persona_peer, // SELF
-                    text: "my own echo".to_string(),
-                })),
-                Ok(None),
-            ])),
-            said: Mutex::new(vec![]),
-            primed: AtomicUsize::new(0),
-        };
-
-        // Caller-primes contract per [[no-fallbacks-ever]] — explicit,
-        // not safety-net.
+        let mut conversation = ScriptedConversation::new().with_events(vec![
+            Ok(Some(IncomingMessage {
+                lamport: 1,
+                peer_id: persona_peer, // SELF
+                text: "my own echo".to_string(),
+            })),
+            Ok(None),
+        ]);
         conversation.prime().await.expect("prime ok");
 
-        let reader: Arc<dyn AircTranscriptReader> = Arc::new(EmptyReader);
+        let reader: Arc<dyn AircTranscriptReader> =
+            Arc::new(StubAircCitizen::new(Uuid::new_v4()));
         let outcome = serve_persona_loop(
             &hosted,
             &mut conversation,
@@ -922,7 +759,7 @@ mod tests {
         assert_eq!(outcome.turns_replied, 0);
         assert_eq!(outcome.turns_skipped, 1);
         assert_eq!(outcome.turns_errored, 0);
-        assert!(conversation.said.lock().unwrap().is_empty());
+        assert!(conversation.said().is_empty());
     }
 
     /// Pre-watermark guard: messages with lamport <= high_water are
@@ -931,11 +768,11 @@ mod tests {
     async fn skips_messages_below_high_water_mark() {
         let persona_peer = Uuid::new_v4();
         let other_peer = Uuid::new_v4();
-        let hosted = fake_hosted(persona_peer, "fresh reply.");
+        let hosted = hosted_with_heuristic(persona_peer);
 
-        let mut conversation = StubConversation {
-            high_water: 100, // pre-attach history was up to lamport=100
-            events: Mutex::new(VecDeque::from(vec![
+        let mut conversation = ScriptedConversation::new()
+            .with_high_water(100) // pre-attach history was up to lamport=100
+            .with_events(vec![
                 Ok(Some(IncomingMessage {
                     lamport: 50, // BEFORE attach
                     peer_id: other_peer,
@@ -952,16 +789,11 @@ mod tests {
                     text: "new".to_string(),
                 })),
                 Ok(None),
-            ])),
-            said: Mutex::new(vec![]),
-            primed: AtomicUsize::new(0),
-        };
-
-        // Caller-primes contract per [[no-fallbacks-ever]] — explicit,
-        // not safety-net.
+            ]);
         conversation.prime().await.expect("prime ok");
 
-        let reader: Arc<dyn AircTranscriptReader> = Arc::new(EmptyReader);
+        let reader: Arc<dyn AircTranscriptReader> =
+            Arc::new(StubAircCitizen::new(Uuid::new_v4()));
         let outcome = serve_persona_loop(
             &hosted,
             &mut conversation,
@@ -981,7 +813,7 @@ mod tests {
             "lamport=50 and lamport=100 both pre-mark"
         );
         assert_eq!(outcome.turns_errored, 0);
-        assert_eq!(conversation.said.lock().unwrap().len(), 1);
+        assert_eq!(conversation.said().len(), 1);
     }
 
     /// Transient transport error increments turns_errored AND the
@@ -993,28 +825,21 @@ mod tests {
     async fn transient_next_message_error_does_not_kill_loop() {
         let persona_peer = Uuid::new_v4();
         let other_peer = Uuid::new_v4();
-        let hosted = fake_hosted(persona_peer, "ok.");
+        let hosted = hosted_with_heuristic(persona_peer);
 
-        let mut conversation = StubConversation {
-            high_water: 0,
-            events: Mutex::new(VecDeque::from(vec![
-                Err("stream lag".to_string()),
-                Ok(Some(IncomingMessage {
-                    lamport: 1,
-                    peer_id: other_peer,
-                    text: "after lag".to_string(),
-                })),
-                Ok(None),
-            ])),
-            said: Mutex::new(vec![]),
-            primed: AtomicUsize::new(0),
-        };
-
-        // Caller-primes contract per [[no-fallbacks-ever]] — explicit,
-        // not safety-net.
+        let mut conversation = ScriptedConversation::new().with_events(vec![
+            Err("stream lag".to_string()),
+            Ok(Some(IncomingMessage {
+                lamport: 1,
+                peer_id: other_peer,
+                text: "after lag".to_string(),
+            })),
+            Ok(None),
+        ]);
         conversation.prime().await.expect("prime ok");
 
-        let reader: Arc<dyn AircTranscriptReader> = Arc::new(EmptyReader);
+        let reader: Arc<dyn AircTranscriptReader> =
+            Arc::new(StubAircCitizen::new(Uuid::new_v4()));
         let outcome = serve_persona_loop(
             &hosted,
             &mut conversation,
@@ -1031,6 +856,6 @@ mod tests {
         assert_eq!(outcome.turns_replied, 1);
         assert_eq!(outcome.turns_errored, 1);
         assert_eq!(outcome.turns_skipped, 0);
-        assert_eq!(conversation.said.lock().unwrap().len(), 1);
+        assert_eq!(conversation.said().len(), 1);
     }
 }

--- a/src/workers/continuum-core/src/persona/supervisor.rs
+++ b/src/workers/continuum-core/src/persona/supervisor.rs
@@ -365,200 +365,23 @@ pub async fn materialize_adapters(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ai::adapter::{AdapterCapabilities, ApiStyle};
-    use crate::ai::types::{
-        EmbeddingRequest, EmbeddingResponse, HealthStatus, ModelInfo, TextGenerationRequest,
-        TextGenerationResponse,
-    };
     use crate::modules::persona_instance_manager::PersonaInstanceInfo;
-    use crate::persona::airc_citizen::{AircCitizen, StubAircCitizen};
+    use crate::persona::airc_citizen::StubAircCitizen;
     use crate::persona::hw_tier_descriptor::HwTierCategory;
     use crate::persona::identity_provider::PersonaIdentitySource;
     use crate::persona::inference_profile::{PersonaInferenceProfile, SamplingProfile};
+    use crate::persona::scripted_adapter_factory::ScriptedPersonaAdapterFactory;
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use uuid::Uuid;
 
-    /// Synthesize a stub citizen for any persona_id — the supervisor
-    /// tests exercise the materialization pipeline, not the airc
-    /// transport, so any peer_id works. Per slice 13.5's AircCitizen
-    /// extraction, the closure returns the trait object directly; no
-    /// `Option<Arc<PersonaAircRuntime>>` smell, no `.expect`.
-    fn stub_citizen_lookup() -> impl Fn(Uuid) -> Option<Arc<dyn AircCitizen>> {
-        |_pid| Some(Arc::new(StubAircCitizen::new(Uuid::new_v4())) as Arc<dyn AircCitizen>)
-    }
-
-    /// Minimal fake adapter — implements just enough of the trait to
-    /// satisfy the trait object boundary. `warmup_total` is shared
-    /// across the OkFactory's spawned adapters so the supervisor
-    /// test can assert that warmup() was called for each successfully
-    /// materialized adapter per [[init-once-handle-then-lease-zero-copy-refs]].
-    struct FakeAdapter {
-        provider_id: String,
-        warmup_total: Arc<AtomicUsize>,
-    }
-
-    #[async_trait]
-    impl AIProviderAdapter for FakeAdapter {
-        fn provider_id(&self) -> &str {
-            &self.provider_id
-        }
-        fn name(&self) -> &str {
-            "fake"
-        }
-        fn capabilities(&self) -> AdapterCapabilities {
-            AdapterCapabilities::default()
-        }
-        fn api_style(&self) -> ApiStyle {
-            ApiStyle::Local
-        }
-        fn default_model(&self) -> &str {
-            "fake-model"
-        }
-        async fn initialize(&mut self) -> Result<(), String> {
-            Ok(())
-        }
-        async fn warmup(&self) -> Result<(), String> {
-            // Increment the shared counter so the supervisor test
-            // can assert "warmup was called once per successfully-
-            // materialized adapter." If a future refactor forgets
-            // to call warmup in materialize_adapters, the counter
-            // drops to 0 and the regression test fails loudly.
-            self.warmup_total.fetch_add(1, Ordering::SeqCst);
-            Ok(())
-        }
-        async fn shutdown(&mut self) -> Result<(), String> {
-            Ok(())
-        }
-        async fn generate_text(
-            &self,
-            _request: TextGenerationRequest,
-        ) -> Result<TextGenerationResponse, String> {
-            Err("fake adapter does not generate".into())
-        }
-        async fn create_embedding(
-            &self,
-            _request: EmbeddingRequest,
-        ) -> Result<EmbeddingResponse, String> {
-            Err("fake adapter does not embed".into())
-        }
-        async fn health_check(&self) -> HealthStatus {
-            HealthStatus::default()
-        }
-        async fn get_available_models(&self) -> Vec<ModelInfo> {
-            vec![]
-        }
-    }
-
-    /// Always-succeeds factory — returns a `FakeAdapter` tagged with
-    /// the profile's `model_id` so tests can verify each persona got
-    /// its own adapter (not one shared instance leaking). The shared
-    /// `warmup_total` counter tracks how many of those adapters had
-    /// `warmup()` called by the supervisor.
-    struct OkFactory {
-        builds: AtomicUsize,
-        warmup_total: Arc<AtomicUsize>,
-    }
-
-    impl OkFactory {
-        fn new() -> Self {
-            Self {
-                builds: AtomicUsize::new(0),
-                warmup_total: Arc::new(AtomicUsize::new(0)),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl PersonaAdapterFactory for OkFactory {
-        async fn build_adapter(
-            &self,
-            profile: &PersonaInferenceProfile,
-        ) -> Result<Arc<dyn AIProviderAdapter>, String> {
-            self.builds.fetch_add(1, Ordering::SeqCst);
-            Ok(Arc::new(FakeAdapter {
-                provider_id: profile.model_id.clone(),
-                warmup_total: self.warmup_total.clone(),
-            }))
-        }
-    }
-
-    /// Factory that always rejects — verifies AdapterFactory error
-    /// path threading.
-    struct ErrFactory;
-
-    #[async_trait]
-    impl PersonaAdapterFactory for ErrFactory {
-        async fn build_adapter(
-            &self,
-            _profile: &PersonaInferenceProfile,
-        ) -> Result<Arc<dyn AIProviderAdapter>, String> {
-            Err("simulated factory rejection".into())
-        }
-    }
-
-    /// Factory that builds an adapter whose warmup() always fails.
-    /// Verifies the `SupervisorError::AdapterWarmup` variant fires
-    /// when an adapter refuses to warm at boot.
-    struct WarmupFailingFactory;
-
-    struct WarmupFailingAdapter;
-
-    #[async_trait]
-    impl AIProviderAdapter for WarmupFailingAdapter {
-        fn provider_id(&self) -> &str {
-            "warmup-failing"
-        }
-        fn name(&self) -> &str {
-            "warmup-failing"
-        }
-        fn capabilities(&self) -> AdapterCapabilities {
-            AdapterCapabilities::default()
-        }
-        fn api_style(&self) -> ApiStyle {
-            ApiStyle::Local
-        }
-        fn default_model(&self) -> &str {
-            "wf-model"
-        }
-        async fn initialize(&mut self) -> Result<(), String> {
-            Ok(())
-        }
-        async fn warmup(&self) -> Result<(), String> {
-            Err("simulated warmup failure".to_string())
-        }
-        async fn shutdown(&mut self) -> Result<(), String> {
-            Ok(())
-        }
-        async fn generate_text(
-            &self,
-            _request: TextGenerationRequest,
-        ) -> Result<TextGenerationResponse, String> {
-            panic!("generate_text must not be reachable on failed-warmup adapter")
-        }
-        async fn create_embedding(
-            &self,
-            _request: EmbeddingRequest,
-        ) -> Result<EmbeddingResponse, String> {
-            Err("no embeddings".into())
-        }
-        async fn health_check(&self) -> HealthStatus {
-            HealthStatus::default()
-        }
-        async fn get_available_models(&self) -> Vec<ModelInfo> {
-            vec![]
-        }
-    }
-
-    #[async_trait]
-    impl PersonaAdapterFactory for WarmupFailingFactory {
-        async fn build_adapter(
-            &self,
-            _profile: &PersonaInferenceProfile,
-        ) -> Result<Arc<dyn AIProviderAdapter>, String> {
-            Ok(Arc::new(WarmupFailingAdapter))
-        }
-    }
+    // Bespoke `FakeAdapter` / `OkFactory` / `ErrFactory` /
+    // `WarmupFailingFactory` / `WarmupFailingAdapter` deleted per
+    // [[test-fixtures-are-system-primitives]] — every test below
+    // leases `ScriptedPersonaAdapterFactory` (built on the
+    // production-runnable `HeuristicInferenceAdapter`) plus
+    // `StubAircCitizen::fresh_lookup`. Adapter behaviors (warmup
+    // success/failure, factory rejection, counter observation) come
+    // from the system primitives' builder methods.
 
     fn fake_instance(name: &str) -> PersonaInstanceInfo {
         PersonaInstanceInfo {
@@ -608,21 +431,28 @@ mod tests {
             },
         ];
 
-        let factory = OkFactory::new();
-        let hosted = materialize_adapters(plans, &factory, stub_citizen_lookup()).await;
+        let factory = ScriptedPersonaAdapterFactory::heuristic();
+        let hosted =
+            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup()).await;
 
         assert_eq!(hosted.len(), 2);
-        assert_eq!(factory.builds.load(Ordering::SeqCst), 2);
+        assert_eq!(factory.build_count(), 2);
 
         let helper = hosted[0].as_ref().expect("Helper hosted");
         assert_eq!(helper.role, RoleId::Helper);
         assert_eq!(helper.identity.agent_name, "Paige");
-        assert_eq!(helper.adapter.provider_id(), "model-a");
+        assert_eq!(
+            helper.adapter.provider_id(),
+            crate::ai::HEURISTIC_PROVIDER_ID
+        );
 
         let coder = hosted[1].as_ref().expect("Coder hosted");
         assert_eq!(coder.role, RoleId::Coder);
         assert_eq!(coder.identity.agent_name, "Pax");
-        assert_eq!(coder.adapter.provider_id(), "model-b");
+        assert_eq!(
+            coder.adapter.provider_id(),
+            crate::ai::HEURISTIC_PROVIDER_ID
+        );
     }
 
     /// A row that arrives with `Err(profile)` from slice 8 passes
@@ -647,12 +477,13 @@ mod tests {
             },
         ];
 
-        let factory = OkFactory::new();
-        let hosted = materialize_adapters(plans, &factory, stub_citizen_lookup()).await;
+        let factory = ScriptedPersonaAdapterFactory::heuristic();
+        let hosted =
+            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup()).await;
 
         assert_eq!(hosted.len(), 2);
         // Factory called exactly once — for the Ok row only.
-        assert_eq!(factory.builds.load(Ordering::SeqCst), 1);
+        assert_eq!(factory.build_count(), 1);
         assert!(hosted[0].is_ok(), "Helper still materializes");
         match &hosted[1] {
             Err(SupervisorError::Profile {
@@ -680,8 +511,10 @@ mod tests {
             profile: Ok(fake_profile("Paige", "model-a")),
         }];
 
-        let factory = ErrFactory;
-        let hosted = materialize_adapters(plans, &factory, stub_citizen_lookup()).await;
+        let factory =
+            ScriptedPersonaAdapterFactory::always_fails("simulated factory rejection");
+        let hosted =
+            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup()).await;
 
         assert_eq!(hosted.len(), 1);
         match &hosted[0] {
@@ -703,10 +536,10 @@ mod tests {
     /// no factory calls fire.
     #[tokio::test]
     async fn empty_plans_yields_empty_hosted() {
-        let factory = OkFactory::new();
+        let factory = ScriptedPersonaAdapterFactory::heuristic();
         let hosted = materialize_adapters(vec![], &factory, |_| None).await;
         assert!(hosted.is_empty());
-        assert_eq!(factory.builds.load(Ordering::SeqCst), 0);
+        assert_eq!(factory.build_count(), 0);
     }
 
     /// Missing-runtime path: when `runtime_lookup` returns `None` for
@@ -730,7 +563,7 @@ mod tests {
             profile: Ok(fake_profile("Paige", "model-a")),
         }];
 
-        let factory = OkFactory::new();
+        let factory = ScriptedPersonaAdapterFactory::heuristic();
         // `|_| None` here is the substrate-bug shape we're locking in:
         // the registry exists but doesn't contain this persona_id.
         let hosted = materialize_adapters(plans, &factory, |_| None).await;
@@ -740,7 +573,7 @@ mod tests {
         // adapter construction is expensive (model load), the
         // substrate refuses early.
         assert_eq!(
-            factory.builds.load(Ordering::SeqCst),
+            factory.build_count(),
             0,
             "factory must not run when runtime lookup fails"
         );
@@ -782,20 +615,21 @@ mod tests {
             },
         ];
 
-        let factory = OkFactory::new();
+        let factory = ScriptedPersonaAdapterFactory::heuristic();
         // Lookup returns Some only for Paige; Pax goes RuntimeMissing.
-        let lookup = move |pid: Uuid| -> Option<Arc<dyn AircCitizen>> {
+        let lookup = move |pid: Uuid| -> Option<Arc<dyn crate::persona::airc_citizen::AircCitizen>> {
             if pid == pax_persona_id {
                 None
             } else {
-                Some(Arc::new(StubAircCitizen::new(Uuid::new_v4())) as Arc<dyn AircCitizen>)
+                Some(Arc::new(StubAircCitizen::new(Uuid::new_v4()))
+                    as Arc<dyn crate::persona::airc_citizen::AircCitizen>)
             }
         };
         let hosted = materialize_adapters(plans, &factory, lookup).await;
 
         assert_eq!(hosted.len(), 2);
         // Factory ran exactly once — for Paige, not Pax.
-        assert_eq!(factory.builds.load(Ordering::SeqCst), 1);
+        assert_eq!(factory.build_count(), 1);
         assert!(hosted[0].is_ok(), "Paige materializes cleanly");
         match &hosted[1] {
             Err(SupervisorError::RuntimeMissing {
@@ -833,17 +667,17 @@ mod tests {
             },
         ];
 
-        let factory = OkFactory::new();
-        let warmup_counter = factory.warmup_total.clone();
-        let hosted = materialize_adapters(plans, &factory, stub_citizen_lookup()).await;
+        let (factory, counts) = ScriptedPersonaAdapterFactory::heuristic_with_counters();
+        let hosted =
+            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup()).await;
 
         // Both slots materialize cleanly.
         assert_eq!(hosted.len(), 2);
         assert!(hosted.iter().all(|r| r.is_ok()));
         // Every adapter was built AND warmed.
-        assert_eq!(factory.builds.load(Ordering::SeqCst), 2);
+        assert_eq!(factory.build_count(), 2);
         assert_eq!(
-            warmup_counter.load(Ordering::SeqCst),
+            counts.warmups(),
             2,
             "warmup() must be called once per successfully-materialized adapter"
         );
@@ -861,8 +695,11 @@ mod tests {
             profile: Ok(fake_profile("Paige", "model-a")),
         }];
 
-        let factory = WarmupFailingFactory;
-        let hosted = materialize_adapters(plans, &factory, stub_citizen_lookup()).await;
+        let factory = ScriptedPersonaAdapterFactory::heuristic_with_warmup_failure(
+            "simulated warmup failure",
+        );
+        let hosted =
+            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup()).await;
 
         assert_eq!(hosted.len(), 1);
         match &hosted[0] {
@@ -889,31 +726,33 @@ mod tests {
     /// `Profile` / `AdapterFactory` / `RuntimeMissing` already enforce.
     #[tokio::test]
     async fn warmup_failure_does_not_taint_sibling_slots() {
-        // Slot 0: OkFactory adapter that warms cleanly.
-        // Slot 1: WarmupFailingFactory adapter that refuses to warm.
-        // We test them with two separate calls (one per factory) since
-        // materialize_adapters takes one factory; assert each plan's
-        // outcome independently.
-        let factory_ok = OkFactory::new();
-        let warmup_ok = factory_ok.warmup_total.clone();
+        let (factory_ok, ok_counts) =
+            ScriptedPersonaAdapterFactory::heuristic_with_counters();
         let ok_plan = vec![MaterializedPersonaPlan {
             role: RoleId::Helper,
             instance: fake_instance("Paige"),
             profile: Ok(fake_profile("Paige", "model-a")),
         }];
         let hosted_ok =
-            materialize_adapters(ok_plan, &factory_ok, stub_citizen_lookup()).await;
+            materialize_adapters(ok_plan, &factory_ok, StubAircCitizen::fresh_lookup())
+                .await;
         assert!(hosted_ok[0].is_ok(), "ok-warmup adapter materializes");
-        assert_eq!(warmup_ok.load(Ordering::SeqCst), 1);
+        assert_eq!(ok_counts.warmups(), 1);
 
-        let factory_fail = WarmupFailingFactory;
+        let factory_fail = ScriptedPersonaAdapterFactory::heuristic_with_warmup_failure(
+            "simulated warmup failure",
+        );
         let fail_plan = vec![MaterializedPersonaPlan {
             role: RoleId::Coder,
             instance: fake_instance("Pax"),
             profile: Ok(fake_profile("Pax", "model-b")),
         }];
-        let hosted_fail =
-            materialize_adapters(fail_plan, &factory_fail, stub_citizen_lookup()).await;
+        let hosted_fail = materialize_adapters(
+            fail_plan,
+            &factory_fail,
+            StubAircCitizen::fresh_lookup(),
+        )
+        .await;
         assert!(
             matches!(hosted_fail[0], Err(SupervisorError::AdapterWarmup { .. })),
             "warmup-failing adapter fails its own slot"


### PR DESCRIPTION
## Summary

Per Joel 2026-06-02: "Your validation and tests belong in the system itself. The harnesses are in place in the real deal or surrounding other layers and modules. You gotta think LONG term and make these elegant too. It's why we had record and repeat of live persona and rag. Can't be done without. We should look at these as just as important as architecture and also Ubiquitous"

PRs #1512–#1516 each introduced bespoke `#[cfg(test)]` fixtures — `FakeAdapter`, `OkFactory`, `CannedAdapter`, `StubConversation`, `EmptyReader`, plus 5 more. Each one re-implemented behavior the substrate could legitimately want from production code paths (replay rigs, ad-hoc tooling, future diagnostic adapters). That's the scaffolding cancer this PR refuses.

Per [[test-fixtures-are-system-primitives]] every test in the substrate now leases ONE system primitive instead of inventing a bespoke variant. The same shape that made `StubAircCitizen`, `RecordingRagSource`, `ReplayRagSource`, and `HeuristicInferenceAdapter` right is now applied uniformly.

## New / extended system primitives

### `ai/heuristic_adapter.rs` (extended)

`HeuristicInferenceAdapter` gains opt-in builder methods:
- `.with_delay_ms(ms)` — inject real wall-clock sleep before `generate_text` returns. Production callers use `new()` and pay zero cost.
- `.with_warmup_failure(reason)` — make `warmup()` return Err. Exercises `SupervisorError::AdapterWarmup` per [[no-fallbacks-ever]].
- `.with_warmup_observer(Arc<AtomicUsize>)` / `.with_generate_observer(...)` — shared counters for substrate-wide invocation assertions.

### `persona/scripted_adapter_factory.rs` (new)

`ScriptedPersonaAdapterFactory`: closure-based `PersonaAdapterFactory`. Constructors:
- `::custom(F)` — arbitrary per-profile closure
- `::heuristic()` / `::heuristic_with_delay_ms(ms)` / `::heuristic_with_warmup_failure(reason)`
- `::always_fails(reason)` — factory itself rejects
- `::heuristic_with_counters()` — paired with `ObservedCounts`

### `persona/scripted_conversation.rs` (new)

`ScriptedConversation`: configurable `PersonaConversation`.
- `.with_events(...)` / `.with_high_water(N)` / `.with_prime_failure(reason)` / `.require_prime_before_next_message()`
- Observables: `.primed_count()` / `.said()`

### `persona/airc_citizen.rs` (extended)

`StubAircCitizen::fresh_lookup()` — closure returning fresh stub for any persona_id. Replaces per-test `stub_citizen_lookup()` helpers.

### gating

`scripted_*` primitives gated behind `cfg(any(test, feature = "test-fixtures"))` — same gate as `HeuristicInferenceAdapter` per Joel (2026-06-01): "The fake shit is a CHOSEN model adapter no other form. Declaration."

## Test module rewires

- **`persona/supervisor.rs`**: deleted ~170 lines of bespoke types. All 9 tests use `ScriptedPersonaAdapterFactory::{heuristic,always_fails,heuristic_with_warmup_failure,heuristic_with_counters}` + `StubAircCitizen::fresh_lookup`.
- **`persona/service_loop.rs`**: deleted ~120 lines. All 8 tests use `ScriptedConversation` + `HeuristicInferenceAdapter::new().with_delay_ms(...)` + `StubAircCitizen` (which doubles as the AircTranscriptReader via supertrait).
- **`persona/airc_persona_conversation.rs`**: already clean.

## Test plan

- [x] `persona::scripted_adapter_factory::` 3/3 pass
- [x] `persona::scripted_conversation::` 6/6 pass
- [x] `persona::supervisor::` 9/9 pass
- [ ] `persona::service_loop::` pending (running at PR-time)
- [ ] Full persona suite verification

## Stacked on

PR #1516 (`feat/adapter-warmup-at-boot`). This is the doctrine cleanup; latency vectors (#149 system prompt pre-tokenize, etc.) resume after this lands.

## Follow-up filed

`#155` — apply same doctrine to `runtime/command_executor.rs::CannedModule` (different layer, same anti-pattern).

Closes #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
