### PR TITLE
feat(context): ClaudeContext — first non-persona substrate citizen (Slice 3 of #142)

### DIFF
--- a/src/workers/continuum-core/src/bin/claude_join_demo.rs
+++ b/src/workers/continuum-core/src/bin/claude_join_demo.rs
@@ -24,9 +24,12 @@
 //!   same label across runs resumes the same keypair.
 //! - `CONTINUUM_ROOM` — room to join (default `"continuum"`)
 
-use continuum_core::airc::{discover_airc_socket, discover_default_channel};
+use continuum_core::airc::{
+    discover_airc_socket, discover_default_channel, discover_default_room_name,
+};
 use continuum_core::context::{ClaudeContext, ClaudeMetadata, Context};
 use std::path::PathBuf;
+use std::process;
 
 fn continuum_root() -> PathBuf {
     if let Ok(root) = std::env::var("CONTINUUM_ROOT") {
@@ -64,9 +67,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let socket_path = match discover_airc_socket().await {
         Ok(p) => p,
         Err(e) => {
-            println!("⚠️  Cannot reach the airc daemon: {e}");
-            println!("    Remedy: install + run `airc join`.");
-            return Ok(());
+            eprintln!("⚠️  Cannot reach the airc daemon: {e}");
+            eprintln!("    Remedy: install + run `airc join`.");
+            process::exit(2);
         }
     };
     println!("✓ airc daemon discovered at {}", socket_path.display());
@@ -74,15 +77,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let default_channel = match discover_default_channel().await {
         Ok(uuid) => uuid,
         Err(e) => {
-            println!("⚠️  Cannot determine default room: {e}");
-            println!("    Remedy: run `airc room <name>`.");
-            return Ok(());
+            eprintln!("⚠️  Cannot determine default room: {e}");
+            eprintln!("    Remedy: run `airc room <name>`.");
+            process::exit(2);
         }
     };
     println!("✓ default channel resolved: {default_channel}");
 
+    let env_room = std::env::var("CONTINUUM_ROOM").ok();
+    let room_name = match env_room {
+        Some(name) => name,
+        None => match discover_default_room_name().await {
+            Ok(name) => name,
+            Err(e) => {
+                eprintln!("⚠️  Cannot determine default room name: {e}");
+                eprintln!("    Remedy: run `airc room <name>` so the daemon knows the canonical name,");
+                eprintln!("            or set CONTINUUM_ROOM=<name> explicitly.");
+                process::exit(2);
+            }
+        },
+    };
+    println!("✓ room name resolved: {room_name}");
+
     // 2. Bootstrap the Claude context. ClaudeContext::bootstrap does
-    //    the home-mkdir + airc-lib attach_as + Identity construction.
+    //    the home-mkdir + airc-lib attach_as + Airc::join (by NAME,
+    //    not UUID-as-string, per the recurring hazard documented in
+    //    PersonaAircRuntime::bootstrap) + Identity construction.
     let root = continuum_root();
     let label = instance_label();
     let ctx = match ClaudeContext::bootstrap(
@@ -90,6 +110,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &label,
         socket_path.clone(),
         default_channel,
+        Some(&room_name),
         ClaudeMetadata {
             model_id: Some("claude-opus-4-7".to_string()),
         },
@@ -98,8 +119,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         Ok(c) => c,
         Err(e) => {
-            println!("⚠️  ClaudeContext::bootstrap failed: {e}");
-            return Ok(());
+            eprintln!("⚠️  ClaudeContext::bootstrap failed: {e}");
+            process::exit(2);
         }
     };
     let identity = ctx.identity();
@@ -108,23 +129,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         identity.agent_name, identity.id, identity.kind, identity.source
     );
 
-    // 3. Join the operator's room. Same name-derives-channel
-    //    discipline as airc_chat_demo — join by NAME, not by UUID-
-    //    as-string, so the channel matches what `airc room` reports.
-    //    Reach the join through the underlying Arc<Airc> via the
-    //    citizen's say/subscribe — the demo just needs to land a
-    //    message in the same channel the operator's reading.
-    //
-    //    Note: `Airc::join` lives on `airc_lib::Airc`, not on the
-    //    AircCitizen trait surface. For a polished bootstrap path
-    //    we'd plumb a `join(&str)` method through; for THIS demo we
-    //    rely on the fact that airc-lib's `attach_as` already
-    //    associates the daemon with the home's default channel for
-    //    publish purposes — the operator's room name resolves via
-    //    daemon-side state set by `airc room`.
-    //
-    //    A polished follow-up adds an explicit room.join() through
-    //    the Context trait so this isn't bin-specific knowledge.
+    // 3. Bootstrap already joined the room by NAME (correct channel
+    //    derivation). Compose + post the message via the Context's
+    //    airc handle.
 
     let claude_short: String = identity.id.to_string().chars().take(8).collect();
     let message = format!(
@@ -143,11 +150,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!();
             println!("Verify: `airc inbox --limit 5` should show the message authored");
             println!("by peer_id={} — a DIFFERENT peer_id than the host's.", identity.id);
+            Ok(())
         }
         Err(e) => {
-            println!("⚠️  say failed: {e}");
+            eprintln!("⚠️  say failed: {e}");
+            process::exit(2);
         }
     }
-
-    Ok(())
 }

--- a/src/workers/continuum-core/src/bin/claude_join_demo.rs
+++ b/src/workers/continuum-core/src/bin/claude_join_demo.rs
@@ -1,0 +1,153 @@
+//! claude_join_demo — proves Slice 3 of #142 end-to-end.
+//!
+//! A Claude Code session boots a `ClaudeContext`, gets its OWN
+//! airc identity (keypair under `~/.continuum/claudes/<label>/airc/`),
+//! joins the operator's current room, posts a single "Claude
+//! entered the grid" message signed by THAT keypair, and exits.
+//!
+//! After running, the operator can verify via `airc inbox` that the
+//! message was authored by a DIFFERENT peer_id than the host's —
+//! the visible payoff of the Identity + Context + Slice-1B work:
+//! every actor instance now has its own substrate identity, not the
+//! host's.
+//!
+//! ## Run
+//!
+//! ```bash
+//! cargo run --bin claude_join_demo --features metal,accelerate
+//! ```
+//!
+//! Env vars:
+//! - `CONTINUUM_ROOT` — defaults to `~/.continuum`
+//! - `CONTINUUM_CLAUDE_LABEL` — instance label (default
+//!   `"default"`). Different labels produce different identities;
+//!   same label across runs resumes the same keypair.
+//! - `CONTINUUM_ROOM` — room to join (default `"continuum"`)
+
+use continuum_core::airc::{discover_airc_socket, discover_default_channel};
+use continuum_core::context::{ClaudeContext, ClaudeMetadata, Context};
+use std::path::PathBuf;
+
+fn continuum_root() -> PathBuf {
+    if let Ok(root) = std::env::var("CONTINUUM_ROOT") {
+        return PathBuf::from(root);
+    }
+    dirs::home_dir()
+        .expect("home directory")
+        .join(".continuum")
+}
+
+fn instance_label() -> String {
+    std::env::var("CONTINUUM_CLAUDE_LABEL").unwrap_or_else(|_| "default".to_string())
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_max_level(tracing::Level::INFO)
+        .with_writer(std::io::stderr)
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+
+    println!("=== claude_join_demo ===");
+    println!("Proving Slice 3 of #142: Claude as a first-class substrate citizen.");
+    println!();
+
+    // 1. Discover the airc daemon + the operator's current room.
+    let socket_path = match discover_airc_socket().await {
+        Ok(p) => p,
+        Err(e) => {
+            println!("⚠️  Cannot reach the airc daemon: {e}");
+            println!("    Remedy: install + run `airc join`.");
+            return Ok(());
+        }
+    };
+    println!("✓ airc daemon discovered at {}", socket_path.display());
+
+    let default_channel = match discover_default_channel().await {
+        Ok(uuid) => uuid,
+        Err(e) => {
+            println!("⚠️  Cannot determine default room: {e}");
+            println!("    Remedy: run `airc room <name>`.");
+            return Ok(());
+        }
+    };
+    println!("✓ default channel resolved: {default_channel}");
+
+    // 2. Bootstrap the Claude context. ClaudeContext::bootstrap does
+    //    the home-mkdir + airc-lib attach_as + Identity construction.
+    let root = continuum_root();
+    let label = instance_label();
+    let ctx = match ClaudeContext::bootstrap(
+        &root,
+        &label,
+        socket_path.clone(),
+        default_channel,
+        ClaudeMetadata {
+            model_id: Some("claude-opus-4-7".to_string()),
+        },
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            println!("⚠️  ClaudeContext::bootstrap failed: {e}");
+            return Ok(());
+        }
+    };
+    let identity = ctx.identity();
+    println!(
+        "✓ ClaudeContext ready: agent_name={} peer_id={} kind={:?} source={:?}",
+        identity.agent_name, identity.id, identity.kind, identity.source
+    );
+
+    // 3. Join the operator's room. Same name-derives-channel
+    //    discipline as airc_chat_demo — join by NAME, not by UUID-
+    //    as-string, so the channel matches what `airc room` reports.
+    //    Reach the join through the underlying Arc<Airc> via the
+    //    citizen's say/subscribe — the demo just needs to land a
+    //    message in the same channel the operator's reading.
+    //
+    //    Note: `Airc::join` lives on `airc_lib::Airc`, not on the
+    //    AircCitizen trait surface. For a polished bootstrap path
+    //    we'd plumb a `join(&str)` method through; for THIS demo we
+    //    rely on the fact that airc-lib's `attach_as` already
+    //    associates the daemon with the home's default channel for
+    //    publish purposes — the operator's room name resolves via
+    //    daemon-side state set by `airc room`.
+    //
+    //    A polished follow-up adds an explicit room.join() through
+    //    the Context trait so this isn't bin-specific knowledge.
+
+    let claude_short: String = identity.id.to_string().chars().take(8).collect();
+    let message = format!(
+        "Claude-Opus-4.7-{ts} entered the grid as {short} (peer_id {full})",
+        ts = now_ms(),
+        short = claude_short,
+        full = identity.id,
+    );
+
+    println!();
+    println!("Publishing: {message}");
+
+    match ctx.airc().say(&message).await {
+        Ok(event_id) => {
+            println!("✓ posted event_id={event_id}");
+            println!();
+            println!("Verify: `airc inbox --limit 5` should show the message authored");
+            println!("by peer_id={} — a DIFFERENT peer_id than the host's.", identity.id);
+        }
+        Err(e) => {
+            println!("⚠️  say failed: {e}");
+        }
+    }
+
+    Ok(())
+}

--- a/src/workers/continuum-core/src/context/claude.rs
+++ b/src/workers/continuum-core/src/context/claude.rs
@@ -1,0 +1,336 @@
+//! `ClaudeContext` — first non-persona Context kind. Slice 3 of #142.
+//!
+//! Per Joel 2026-06-04: "You'll get visibility inside continuum and
+//! vice versa." This is where it lands: a Claude Code session
+//! constructed via `ClaudeContext::bootstrap` gets its OWN airc
+//! identity (Ed25519 keypair under
+//! `~/.continuum/claudes/<label>/airc/`, peer_id from the keypair).
+//! Any substrate-visible action it takes (`ctx.airc().say(...)`,
+//! `ctx.airc().subscribe()`, future card creation, future commit
+//! authorship) is signed by THIS Claude's keypair, not the host
+//! operator's.
+//!
+//! From `airc inbox`, operators see the distinct peer_id and can
+//! tell that THIS specific Claude instance did the work — the
+//! audit trail Joel has been building rooms-as-history toward
+//! becomes accurate per
+//! [[airc-is-the-session-not-a-feature]].
+//!
+//! ## What this slice IS
+//!
+//! - `ClaudeContext` struct holding `Identity` + airc citizen handle
+//!   + (placeholder) `ClaudeMetadata` extension. Implements the
+//!   `Context` trait from Slice 2 cleanly — second concrete kind
+//!   after `PersonaContext`.
+//! - `ClaudeContext::bootstrap` — the canonical entry point. Resolves
+//!   the home, calls `airc_lib::Airc::attach_as` (resume-or-mint
+//!   per airc-lib semantics), constructs the Identity from the
+//!   keypair's peer_id (post-Slice-1B: peer_id IS the substrate id),
+//!   returns the ClaudeContext.
+//! - Inline `AircHandleAdapter` — bridges `Arc<airc_lib::Airc>` into
+//!   `dyn AircCitizen` (the substrate's polymorphic surface).
+//!   Private to this module per outlier-validation discipline; lifted
+//!   to a shared location when JtagContext / HumanContext need the
+//!   same shape.
+//!
+//! ## What this slice is NOT
+//!
+//! - NOT JtagContext / HumanContext concrete types — same outlier
+//!   discipline, added when consumers appear or when the jtag CLI
+//!   Rust rewrite (#143) lands.
+//! - NOT Identity-entity ORM persistence on bootstrap. The Identity
+//!   is constructed in-memory and lives for the lifetime of the
+//!   ClaudeContext; persisting to `OrmStore<Identity>` is a focused
+//!   follow-up when a consumer needs query-by-id across process
+//!   restarts.
+//! - NOT a tool-use harness or model-tier serialization. The
+//!   `ClaudeMetadata` field is a placeholder struct; extensions are
+//!   added per CLAUDE.md's outlier-validation discipline (build for
+//!   intent, not pre-emptively).
+//! - NOT multi-instance-per-machine arbitration. If two Claude
+//!   sessions on the same host want different identities, they
+//!   bootstrap with different `instance_label`s. Same label across
+//!   restarts = same persistent identity (airc-lib's attach_as
+//!   resumes from disk).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use airc_core::EventId;
+use airc_lib::{Airc, AircError};
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::context::Context;
+use crate::identity::{Identity, IdentityKind, IdentitySource};
+use crate::persona::airc_citizen::AircCitizen;
+use crate::persona::airc_source::AircTranscriptReader;
+
+/// Errors during ClaudeContext bootstrap. Each variant carries
+/// enough operator-facing context to act on without grepping logs,
+/// per the constitutional-design doctrine ("every error has a path
+/// forward").
+#[derive(Debug, thiserror::Error)]
+pub enum ClaudeContextError {
+    #[error("failed to create claude airc home {0}: {1}")]
+    HomeCreate(PathBuf, std::io::Error),
+    #[error("airc-lib attach_as failed for claude {agent_name:?} at {home:?}: {source}")]
+    Attach {
+        agent_name: String,
+        home: PathBuf,
+        #[source]
+        source: AircError,
+    },
+}
+
+/// Placeholder extension for Claude-kind state. Per the CLAUDE.md
+/// outlier-validation discipline, this stays minimal until a
+/// downstream consumer needs more (tool-use harness wiring,
+/// model-tier metadata, capability flags). Currently just declares
+/// "this is a Claude instance" structurally.
+#[derive(Debug, Clone, Default)]
+pub struct ClaudeMetadata {
+    /// The model identifier this instance is running as
+    /// (e.g. "claude-opus-4-7"). Optional because the bootstrap
+    /// doesn't always know — caller sets it when they do.
+    pub model_id: Option<String>,
+}
+
+/// A Claude Code session as a first-class substrate citizen.
+///
+/// Implements `Context`, so any substrate API taking `&dyn Context`
+/// accepts a `ClaudeContext` cleanly — the same shape that personas
+/// flow through. The validation moment for Slice 2's trait per
+/// CLAUDE.md outlier discipline: PersonaContext and ClaudeContext
+/// both fit Context without forcing.
+pub struct ClaudeContext {
+    identity: Identity,
+    airc: Arc<dyn AircCitizen>,
+    #[allow(dead_code)] // Field used through getters once consumers appear.
+    metadata: ClaudeMetadata,
+}
+
+impl ClaudeContext {
+    /// Bootstrap a Claude Code session's substrate presence.
+    ///
+    /// Steps:
+    /// 1. Resolve home at `<continuum_root>/claudes/<instance_label>/airc/`
+    ///    and `tokio::fs::create_dir_all` it. Per
+    ///    [[personas-are-citizens-airc-is-identity-provider]] this
+    ///    is a sibling-not-nested layout — Claude's airc home lives
+    ///    alongside personas under one continuum root, not inside
+    ///    any other actor's scope.
+    /// 2. Call `Airc::attach_as(home, agent_name, daemon_socket)`.
+    ///    airc-lib's identity ceremony resumes the keypair if
+    ///    `identity.key` exists, or mints a fresh one if not. Either
+    ///    way the substrate gets a real Ed25519 keypair the Claude
+    ///    session now owns.
+    /// 3. Construct `Identity` with `id = peer_id` per
+    ///    [[persona-identity-derives-from-source-id]] (post-Slice-1B
+    ///    the cryptographic keypair IS the substrate identity).
+    ///    `source` reflects whether airc-lib resumed or minted.
+    /// 4. Wrap `Arc<Airc>` in `AircHandleAdapter` → `Arc<dyn
+    ///    AircCitizen>` so the Context surface returns the polymorphic
+    ///    handle every substrate API expects.
+    ///
+    /// On failure, returns a typed `ClaudeContextError` with the
+    /// operator-actionable detail. No silent fallback per
+    /// [[no-fallbacks-ever]].
+    pub async fn bootstrap(
+        continuum_root: &Path,
+        instance_label: impl Into<String>,
+        daemon_socket: PathBuf,
+        default_room: Uuid,
+        metadata: ClaudeMetadata,
+    ) -> Result<Self, ClaudeContextError> {
+        let instance_label = instance_label.into();
+        let agent_name = format!("claude-{instance_label}");
+        let home = continuum_root
+            .join("claudes")
+            .join(&instance_label)
+            .join("airc");
+        tokio::fs::create_dir_all(&home)
+            .await
+            .map_err(|e| ClaudeContextError::HomeCreate(home.clone(), e))?;
+
+        // Detect whether the keypair already exists on disk. airc-lib's
+        // attach_as is resume-or-mint either way; we just observe the
+        // outcome for telemetry honesty per
+        // [[substrate-is-a-good-citizen-on-the-host]].
+        let identity_key_path = home.join("identity.key");
+        let pre_existed = tokio::fs::try_exists(&identity_key_path)
+            .await
+            .unwrap_or(false);
+
+        let airc = Airc::attach_as(home.clone(), agent_name.clone(), daemon_socket)
+            .await
+            .map_err(|source| ClaudeContextError::Attach {
+                agent_name: agent_name.clone(),
+                home: home.clone(),
+                source,
+            })?;
+
+        let peer_id = airc.peer_id().as_uuid();
+        let source = if pre_existed {
+            IdentitySource::ResumedFromDisk
+        } else {
+            IdentitySource::FreshlyMinted
+        };
+
+        let identity = Identity {
+            id: peer_id,
+            kind: IdentityKind::Claude,
+            agent_name: agent_name.clone(),
+            home_path: home.to_string_lossy().into_owned(),
+            default_room,
+            source,
+        };
+
+        let airc_arc: Arc<dyn AircCitizen> =
+            Arc::new(AircHandleAdapter::new(Arc::new(airc)));
+
+        tracing::info!(
+            peer_id = %peer_id,
+            agent_name = %agent_name,
+            home = %home.display(),
+            source = ?source,
+            "ClaudeContext bootstrap: identity ready"
+        );
+
+        Ok(Self {
+            identity,
+            airc: airc_arc,
+            metadata,
+        })
+    }
+}
+
+impl Context for ClaudeContext {
+    fn identity(&self) -> std::borrow::Cow<'_, Identity> {
+        std::borrow::Cow::Borrowed(&self.identity)
+    }
+
+    fn airc(&self) -> &Arc<dyn AircCitizen> {
+        &self.airc
+    }
+}
+
+// ─── AircHandleAdapter ─────────────────────────────────────────────────
+//
+// Bridges `Arc<airc_lib::Airc>` into `dyn AircCitizen + dyn
+// AircTranscriptReader`. PersonaAircRuntime has its own equivalent
+// inline impl (carrying persona-specific lifecycle state); this is
+// the kind-agnostic shape Claude / future Codex / future Jtag /
+// future Human / future Web all use. Private to this module per
+// CLAUDE.md outlier discipline — lift to a shared `context::
+// airc_adapter` module the first time a second non-persona kind
+// (JtagContext or similar) wants the same struct.
+
+struct AircHandleAdapter {
+    inner: Arc<Airc>,
+}
+
+impl AircHandleAdapter {
+    fn new(inner: Arc<Airc>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl AircTranscriptReader for AircHandleAdapter {
+    async fn page_recent(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<airc_lib::TranscriptEvent>, AircError> {
+        self.inner.page_recent(limit).await
+    }
+}
+
+#[async_trait]
+impl AircCitizen for AircHandleAdapter {
+    fn peer_id(&self) -> Uuid {
+        self.inner.peer_id().as_uuid()
+    }
+
+    async fn subscribe(&self) -> Result<airc_lib::EventStream, AircError> {
+        self.inner.subscribe().await
+    }
+
+    async fn say(&self, text: &str) -> Result<EventId, AircError> {
+        self.inner.say(text).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persona::airc_citizen::StubAircCitizen;
+
+    /// `ClaudeContext` satisfies `Context` — projects its stored
+    /// Identity (the `Cow::Borrowed` zero-clone case Slice 2 set up)
+    /// and exposes the airc handle. Constructed without going
+    /// through `bootstrap` (which needs a real airc daemon) — we
+    /// use the stub citizen to prove the trait surface fits.
+    #[test]
+    fn claude_context_implements_context_zero_clone() {
+        let peer_id = Uuid::new_v4();
+        let identity = Identity {
+            id: peer_id,
+            kind: IdentityKind::Claude,
+            agent_name: "claude-test".to_string(),
+            home_path: "/tmp/claude-test/airc".to_string(),
+            default_room: Uuid::new_v4(),
+            source: IdentitySource::FreshlyMinted,
+        };
+        let stub: Arc<dyn AircCitizen> = Arc::new(StubAircCitizen::new(peer_id));
+        let ctx = ClaudeContext {
+            identity: identity.clone(),
+            airc: stub,
+            metadata: ClaudeMetadata::default(),
+        };
+
+        // identity() is Cow::Borrowed — zero-clone per Slice 2's
+        // shape; we observe by checking matches::matches!.
+        let observed = ctx.identity();
+        assert!(matches!(observed, std::borrow::Cow::Borrowed(_)));
+        let observed = observed.as_ref();
+        assert_eq!(observed.id, peer_id);
+        assert_eq!(observed.kind, IdentityKind::Claude);
+        assert_eq!(observed.agent_name, "claude-test");
+
+        // airc() exposes the stub citizen we wrapped — round-trip.
+        assert_eq!(ctx.airc().peer_id(), peer_id);
+    }
+
+    /// `ClaudeContext` and `StubContext` are the second-outlier pair
+    /// Slice 2 deferred from validating. Both implement `Context`;
+    /// both carry distinct kind tags; both expose identity + airc
+    /// the same way. The substrate's universal-handle contract is
+    /// now validated across the persona-kind shape (PersonaContext)
+    /// AND a non-persona kind (ClaudeContext) — the trait fits
+    /// future variants (HumanContext, JtagContext) without forcing.
+    #[test]
+    fn claude_context_and_persona_context_satisfy_same_context_trait() {
+        let peer_id_a = Uuid::new_v4();
+        let identity_a = Identity {
+            id: peer_id_a,
+            kind: IdentityKind::Claude,
+            agent_name: "claude".to_string(),
+            home_path: "/tmp/a".to_string(),
+            default_room: Uuid::new_v4(),
+            source: IdentitySource::FreshlyMinted,
+        };
+        let stub_a: Arc<dyn AircCitizen> = Arc::new(StubAircCitizen::new(peer_id_a));
+        let claude = ClaudeContext {
+            identity: identity_a,
+            airc: stub_a,
+            metadata: ClaudeMetadata::default(),
+        };
+
+        // Box<dyn Context> would fail to compile if Slice 3 broke
+        // the trait's object-safety. This line IS the proof.
+        let boxed: Box<dyn Context> = Box::new(claude);
+        assert_eq!(boxed.identity().as_ref().kind, IdentityKind::Claude);
+        assert_eq!(boxed.airc().peer_id(), peer_id_a);
+    }
+}

--- a/src/workers/continuum-core/src/context/claude.rs
+++ b/src/workers/continuum-core/src/context/claude.rs
@@ -81,6 +81,13 @@ pub enum ClaudeContextError {
         #[source]
         source: AircError,
     },
+    #[error("failed to join room {room_name:?} as claude {agent_name:?}: {source}")]
+    Join {
+        agent_name: String,
+        room_name: String,
+        #[source]
+        source: AircError,
+    },
 }
 
 /// Placeholder extension for Claude-kind state. Per the CLAUDE.md
@@ -141,6 +148,7 @@ impl ClaudeContext {
         instance_label: impl Into<String>,
         daemon_socket: PathBuf,
         default_room: Uuid,
+        room_name: Option<&str>,
         metadata: ClaudeMetadata,
     ) -> Result<Self, ClaudeContextError> {
         let instance_label = instance_label.into();
@@ -149,18 +157,23 @@ impl ClaudeContext {
             .join("claudes")
             .join(&instance_label)
             .join("airc");
+
+        // Detect resume vs mint BEFORE create_dir_all by checking the
+        // per-instance_label home dir itself, NOT identity.key. Per
+        // the per-label home convention
+        // (<continuum_root>/claudes/<instance_label>/airc/), the
+        // home dir's existence is a clean proxy for "has this
+        // specific Claude label been bootstrapped before?" — without
+        // the (key_exists, agent_not_stored) edge case that bites
+        // when probing identity.key directly. Edge cases (manually
+        // populated home with no airc state) report as
+        // `ResumedFromDisk` here, which is the more operator-honest
+        // default since SOMEONE staged that directory deliberately.
+        let home_pre_existed = tokio::fs::try_exists(&home).await.unwrap_or(false);
+
         tokio::fs::create_dir_all(&home)
             .await
             .map_err(|e| ClaudeContextError::HomeCreate(home.clone(), e))?;
-
-        // Detect whether the keypair already exists on disk. airc-lib's
-        // attach_as is resume-or-mint either way; we just observe the
-        // outcome for telemetry honesty per
-        // [[substrate-is-a-good-citizen-on-the-host]].
-        let identity_key_path = home.join("identity.key");
-        let pre_existed = tokio::fs::try_exists(&identity_key_path)
-            .await
-            .unwrap_or(false);
 
         let airc = Airc::attach_as(home.clone(), agent_name.clone(), daemon_socket)
             .await
@@ -170,8 +183,26 @@ impl ClaudeContext {
                 source,
             })?;
 
+        // Join the room by NAME (not by UUID-as-string). Per
+        // PersonaAircRuntime::bootstrap's hard-won lesson at
+        // `persona/airc_runtime.rs:170-179` and the empirical catch
+        // in card 800ce5bd: `Airc::join(uuid_str)` DERIVES a fresh
+        // channel uuid from the string, landing the subscription on
+        // a different channel than the operator's. The room_name
+        // path is the canonical one — passing `None` skips the join
+        // for callers that have already joined some other way.
+        if let Some(name) = room_name {
+            airc.join(name)
+                .await
+                .map_err(|source| ClaudeContextError::Join {
+                    agent_name: agent_name.clone(),
+                    room_name: name.to_string(),
+                    source,
+                })?;
+        }
+
         let peer_id = airc.peer_id().as_uuid();
-        let source = if pre_existed {
+        let source = if home_pre_existed {
             IdentitySource::ResumedFromDisk
         } else {
             IdentitySource::FreshlyMinted

--- a/src/workers/continuum-core/src/context/mod.rs
+++ b/src/workers/continuum-core/src/context/mod.rs
@@ -67,6 +67,9 @@ use std::sync::Arc;
 use crate::identity::Identity;
 use crate::persona::airc_citizen::AircCitizen;
 
+pub mod claude;
+pub use claude::{ClaudeContext, ClaudeContextError, ClaudeMetadata};
+
 /// The substrate's universal actor handle.
 ///
 /// Every substrate API that produces substrate-visible effect takes
@@ -141,17 +144,18 @@ pub fn log_actor_action(ctx: &dyn Context, action: &str) {
 /// every test that needs a `&dyn Context` leases THIS rather than
 /// inventing a bespoke variant.
 ///
-/// Note on outlier-validation discipline: `StubContext`'s trait-
-/// surface shape (stored Identity + Arc<dyn AircCitizen>) is the
-/// same shape `PersonaContext` projects post-Slice-1B. The genuine
-/// outlier validation — a Context impl that materially diverges
-/// from "stored identity + stored citizen" — arrives with Slice 3
-/// (`ClaudeContext`, `JtagContext`, etc.) where the citizen handle
-/// may be borrowed from an ambient session or synthesized on
-/// demand from a session token. Until then this struct proves the
-/// trait COMPILES across two impls; it does not yet prove the
-/// interface is right for kinds whose airc handle isn't
-/// long-lived-owned.
+/// Outlier-validation status (CLAUDE.md discipline): `Context` is
+/// now validated across:
+/// - `PersonaContext` (persona kind, transitional synthesizes from
+///   `PersonaInstanceInfo`, returns `Cow::Owned`)
+/// - `ClaudeContext` (Slice 3, non-persona kind, stores Identity
+///   directly, returns `Cow::Borrowed`)
+/// - `StubContext` (test fixture, stores Identity, returns
+///   `Cow::Borrowed`)
+/// Three impls with different storage shapes and Cow semantics all
+/// satisfy the trait without forcing — the interface is validated.
+/// Future variants (HumanContext, JtagContext, WebContext) slot
+/// into the same shape.
 ///
 /// `pub` (not `#[cfg(test)]`) so production code that wants a
 /// no-substrate-effect Context for benchmarks or replay can use it


### PR DESCRIPTION
## Summary

**Slice 3 of #142** — `ClaudeContext`: first non-persona substrate citizen. A Claude Code session constructed via `ClaudeContext::bootstrap` gets its OWN airc identity (Ed25519 keypair under `~/.continuum/claudes/<label>/airc/`). Any substrate-visible action (`ctx.airc().say(...)`, future card creation, future commit authorship) signs with THIS Claude's keypair — not the host operator's.

From `airc inbox`, operators see the distinct peer_id and can tell THIS specific Claude instance did the work. The visible payoff of Identity + Context + Slice-1B is now real.

## What changes

### `src/workers/continuum-core/src/context/claude.rs` (new)

- `ClaudeContext` — second concrete Context kind. Stores Identity (returns `Cow::Borrowed` — zero clone) + `Arc<dyn AircCitizen>` + `ClaudeMetadata` extension.
- `ClaudeContext::bootstrap(continuum_root, instance_label, daemon_socket, default_room, metadata)` — resolves home, calls `airc_lib::Airc::attach_as` (resume-or-mint), constructs Identity with `id = peer_id`, returns ClaudeContext.
- `AircHandleAdapter` (private) — bridges `Arc<airc_lib::Airc>` → `dyn AircCitizen`. Lifted to shared scope when JtagContext/HumanContext need it per outlier discipline.

### `src/workers/continuum-core/src/context/mod.rs`

- `pub mod claude;` registered with re-exports
- `StubContext` doc updated — the outlier-validation note Slice 2 deferred is now resolved (three impls validate the trait)

### `src/workers/continuum-core/src/bin/claude_join_demo.rs` (new)

End-to-end demo. Bootstraps ClaudeContext, posts a "Claude entered the grid" message, exits. Operator verifies `airc inbox` shows the message from a DIFFERENT peer_id than the host's.

## Outlier validation (the moment Slice 2 deferred)

Per CLAUDE.md: "if both fit cleanly, interface is proven."

- **PersonaContext** — Cow::Owned via synthesis, persona-specific extensions
- **ClaudeContext** — Cow::Borrowed via stored Identity, ClaudeMetadata extension
- **StubContext** — Cow::Borrowed via stored Identity, no extension

Three impls, different storage shapes, different Cow semantics, different kinds. All satisfy `Context` cleanly. Future variants (HumanContext, JtagContext, WebContext) slot into the same surface.

## Test plan

- [x] `context::claude::tests::claude_context_implements_context_zero_clone` — Cow::Borrowed semantics + identity round-trip
- [x] `context::claude::tests::claude_context_and_persona_context_satisfy_same_context_trait` — `Box<dyn Context>` accepts ClaudeContext (object-safety preserved)
- [x] `context::*` — 6/6 pass (was 4; +2 for Slice 3)
- [x] `persona::*` — 750/750 pass — zero regressions
- [x] `claude_join_demo` compiles with `metal,accelerate`
- [ ] CI green (will verify in PR checks)
- Manual (post-merge): run `claude_join_demo`, verify `airc inbox` shows message from a NEW peer_id

## What this does NOT do (deliberate scope)

- No JtagContext / HumanContext / WebContext yet — same outlier discipline; add when consumers appear
- No Identity-entity ORM persistence on bootstrap — focused follow-up when cross-process query-by-id is needed
- No tool-use harness wiring (ClaudeMetadata stays minimal)
- No explicit `room.join()` through Context trait — demo relies on airc-lib's daemon-default channel association; polished follow-up plumbs join through Context surface

## Doctrine

- `[[airc-is-the-session-not-a-feature]]` — every Claude session has its own identity
- `[[context-is-the-client-airc-token-is-identity]]` — Context primitive validated on second kind
- `[[personas-are-citizens-airc-is-identity-provider]]` — same shape, applied to Claude
- CLAUDE.md outlier-validation — second concrete kind validates the trait
- `[[no-fallbacks-ever]]` — typed errors, no silent degradation

## Parent

Task #142 (Substrate BaseUser/Context hierarchy). Builds on PR #1521 (Slice 1 — Identity), PR #1522 (Slice 2 — Context trait), PR #1523 (Slice 1B — Uuid collapse).

Targets `canary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
