### PR TITLE
fix(boot): substrate refuses to lie when degraded (Slice A)

### DIFF
--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -1110,10 +1110,57 @@ pub fn start_server(
             );
         });
     } else {
+        // [[no-fallbacks-ever]] — if the operator has persona seeds on disk,
+        // the substrate cannot honestly come up in this state (it can't host
+        // those citizens). Detect them and fail boot with the actionable
+        // repair rather than logging a single WARN line and silently leaving
+        // the citizens unhosted while the binary stays alive at idle RSS.
+        // The bug pattern this catches:
+        //   $ ./continuum-core-server …          # exit 0, looks fine
+        //   $ ps -p $! -o rss                    # 1166 MB, "running"
+        //   $ ./jtag persona/list                # no Paige, no error
+        // — the headless "doesn't even RUN" state from 2026-06-04.
+        //
+        // If NO persona seeds exist (fresh install, headless inference-only
+        // mode, test fixture), the substrate continues to boot — there are
+        // no citizens to fail. Boundary intentionally narrow: the substrate
+        // only hard-fails the case it would otherwise lie about.
+        let continuum_root = crate::modules::persona_instance_manager::resolve_continuum_root();
+        let personas_dir = continuum_root.join("personas");
+        let seed_count =
+            crate::modules::persona_instance_manager::count_persona_seeds(&continuum_root);
+
+        if seed_count > 0 {
+            tracing::error!(
+                personas_dir = %personas_dir.display(),
+                persona_seed_count = seed_count,
+                "Refusing to boot in degraded state: {} persona seed(s) on disk \
+                 but AIRC discovery failed — no PersonaInstanceManagerModule \
+                 registered, so the substrate cannot host these citizens. \
+                 Resolve: install airc, set AIRC_DAEMON_SOCKET, or run \
+                 `airc room <name>` to establish a default room — then restart \
+                 continuum-core. To start anyway (e.g. for inference-only \
+                 headless mode), move or rename {} aside.",
+                seed_count,
+                personas_dir.display()
+            );
+            return Err(std::io::Error::other(format!(
+                "AIRC discovery degraded and {} persona seed(s) present at {} — \
+                 refusing to boot in a state that cannot host the substrate's \
+                 citizens ([[no-fallbacks-ever]])",
+                seed_count,
+                personas_dir.display()
+            )));
+        }
+
         tracing::warn!(
-            "PersonaInstanceManagerModule NOT registered — AIRC discovery is degraded \
-             (missing socket or default room). Resolve by installing airc and running \
-             `airc room <name>`, then restart continuum-core."
+            personas_dir = %personas_dir.display(),
+            "PersonaInstanceManagerModule NOT registered — AIRC discovery is \
+             degraded (missing socket or default room). No persona seeds on \
+             disk, so substrate continues for non-persona use \
+             (inference / embedding / forge / cargo / code). Install airc, \
+             set AIRC_DAEMON_SOCKET, or run `airc room <name>` to enable \
+             persona hosting."
         );
     }
 

--- a/src/workers/continuum-core/src/main.rs
+++ b/src/workers/continuum-core/src/main.rs
@@ -82,6 +82,56 @@ fn install_shutdown_handlers() {
     });
 }
 
+/// Install a panic hook that suppresses ORT's "dlopen failed for
+/// libonnxruntime" stderr trace while leaving every OTHER panic
+/// printable as before.
+///
+/// Why this isn't a "swallow all errors" anti-pattern: the panic is
+/// already caught by `catch_unwind` at every ORT load site (see
+/// `modules/embedding.rs::preload_default_model` +
+/// `modules/embedding.rs::load_model_internal` + the TTS/STT spawn in
+/// `main()`). Each catch arm sets `ORT_UNAVAILABLE` and logs a clean
+/// WARN line. The user-visible noise we're suppressing is Rust's
+/// DEFAULT panic hook writing the same panic to stderr BEFORE
+/// `catch_unwind` catches it. That trace looks like a substrate bug
+/// ("thread 'tokio-rt-worker' panicked at ort-2.0.0-rc.11/src/lib.rs:191")
+/// but it's really just "voice features not available — install
+/// libonnxruntime."
+///
+/// The hook matches both `location().file()` containing `ort-` (the
+/// crate's source path under `~/.cargo/registry/`) AND the panic
+/// payload mentioning `Failed to load ONNX Runtime`. Other ORT panics
+/// (genuine bugs deep in inference) won't match the dylib-load
+/// substring and fall through to the default handler. Non-ORT panics
+/// always fall through.
+fn install_ort_panic_filter() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let from_ort = info
+            .location()
+            .map(|loc| loc.file().contains("/ort-"))
+            .unwrap_or(false);
+        let about_dylib = info
+            .payload()
+            .downcast_ref::<String>()
+            .map(|s| s.contains("Failed to load ONNX Runtime"))
+            .or_else(|| {
+                info.payload()
+                    .downcast_ref::<&str>()
+                    .map(|s| s.contains("Failed to load ONNX Runtime"))
+            })
+            .unwrap_or(false);
+        if from_ort && about_dylib {
+            // catch_unwind handles flow control; we just suppress
+            // the default-hook's stderr write. The ORT_UNAVAILABLE
+            // flag + clean WARN line at the catch site cover the
+            // user-visible semantics.
+            return;
+        }
+        default_hook(info);
+    }));
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logging
@@ -90,6 +140,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_writer(std::io::stderr)
         .finish();
     tracing::subscriber::set_global_default(subscriber)?;
+
+    // Suppress the stderr panic trace from ORT's missing-libonnxruntime
+    // case. The panic is already caught by the catch_unwind around every
+    // ORT load site (modules/embedding.rs preload + main.rs TTS/STT spawn),
+    // and the catch sets ORT_UNAVAILABLE + logs a clean WARN line — but
+    // Rust's default panic hook ALSO writes the panic message to stderr
+    // BEFORE catch_unwind catches it, leaving the user staring at a
+    // "thread 'tokio-rt-worker' panicked at ort-2.0.0-rc.11/src/lib.rs:191"
+    // trace that looks like a substrate bug but is just "voice not
+    // available — install libonnxruntime." Per [[no-fallbacks-ever]] +
+    // [[substrate-is-a-good-citizen-on-the-host]], substrate must speak
+    // clearly when degraded; this filter strips ORT's scare trace from
+    // the logs without dropping the catch_unwind safety net.
+    install_ort_panic_filter();
 
     // Parse command line arguments. argv[1] is the IPC socket path (positional)
     // — but intercept flag-like values FIRST so `--version` and `--help` don't

--- a/src/workers/continuum-core/src/modules/persona_instance_manager.rs
+++ b/src/workers/continuum-core/src/modules/persona_instance_manager.rs
@@ -327,6 +327,29 @@ pub fn resolve_continuum_root() -> PathBuf {
     home.join(".continuum")
 }
 
+/// Count persona seed files at `<continuum_root>/personas/*/seed.json`.
+///
+/// Used by IPC boot to decide whether the substrate can honestly come
+/// up when AIRC discovery fails. If seeds exist on disk but the
+/// PersonaInstanceManagerModule can't register, the substrate refuses
+/// to boot — per [[no-fallbacks-ever]] it would be lying about being
+/// able to host its citizens.
+///
+/// Returns 0 when the personas directory doesn't exist (fresh install,
+/// inference-only mode, test fixture). Returns 0 on read errors as
+/// well — they're effectively "we can't see seeds, so we can't claim
+/// the operator has any."
+pub fn count_persona_seeds(continuum_root: &Path) -> usize {
+    let personas_dir = continuum_root.join("personas");
+    match std::fs::read_dir(&personas_dir) {
+        Ok(entries) => entries
+            .filter_map(Result::ok)
+            .filter(|e| e.path().join("seed.json").is_file())
+            .count(),
+        Err(_) => 0,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -352,6 +375,71 @@ mod tests {
         let root = resolve_continuum_root();
         assert_eq!(root, PathBuf::from("/tmp/test-root-12345"));
         std::env::remove_var("CONTINUUM_ROOT");
+    }
+
+    /// Empty / nonexistent continuum_root → 0 seeds. This is the
+    /// "fresh install or inference-only mode" path: substrate boots
+    /// without persona hosting, no error.
+    #[test]
+    fn count_persona_seeds_returns_zero_for_missing_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // No personas/ subdirectory at all.
+        assert_eq!(count_persona_seeds(tmp.path()), 0);
+    }
+
+    #[test]
+    fn count_persona_seeds_returns_zero_for_empty_personas_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(tmp.path().join("personas")).expect("mkdir personas");
+        assert_eq!(count_persona_seeds(tmp.path()), 0);
+    }
+
+    /// One persona dir with seed.json → 1. This is the "Paige
+    /// installed, refuse to boot in degraded mode" path that Slice A
+    /// hard-fails on.
+    #[test]
+    fn count_persona_seeds_counts_one_persona_with_seed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paige = tmp.path().join("personas").join("Paige");
+        std::fs::create_dir_all(&paige).expect("mkdir Paige");
+        std::fs::write(paige.join("seed.json"), b"{}").expect("write seed");
+        assert_eq!(count_persona_seeds(tmp.path()), 1);
+    }
+
+    /// Multiple personas — each with its own seed — count each one.
+    #[test]
+    fn count_persona_seeds_counts_multiple_personas() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        for name in &["Paige", "Niko", "Maya"] {
+            let dir = tmp.path().join("personas").join(name);
+            std::fs::create_dir_all(&dir).expect("mkdir persona");
+            std::fs::write(dir.join("seed.json"), b"{}").expect("write seed");
+        }
+        assert_eq!(count_persona_seeds(tmp.path()), 3);
+    }
+
+    /// A persona DIRECTORY with no seed.json is NOT counted —
+    /// in-progress mints, half-deleted personas, scratch dirs all
+    /// fall under this; they don't trigger the substrate's refusal
+    /// because there's no citizen yet to fail.
+    #[test]
+    fn count_persona_seeds_skips_persona_dir_without_seed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("personas").join("HalfMinted");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        // No seed.json inside.
+        assert_eq!(count_persona_seeds(tmp.path()), 0);
+    }
+
+    /// Stray FILES at the personas/ root (not directories) don't
+    /// false-positive as seed dirs.
+    #[test]
+    fn count_persona_seeds_ignores_stray_files_at_personas_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let personas = tmp.path().join("personas");
+        std::fs::create_dir(&personas).expect("mkdir");
+        std::fs::write(personas.join("README.md"), b"hi").expect("write file");
+        assert_eq!(count_persona_seeds(tmp.path()), 0);
     }
 
     #[tokio::test]

--- a/src/workers/continuum-core/src/runtime/runtime.rs
+++ b/src/workers/continuum-core/src/runtime/runtime.rs
@@ -20,29 +20,60 @@ use tracing::{error, info, warn};
 /// Expected modules that MUST be registered for a complete runtime.
 /// Adding a module here ensures it cannot be forgotten during registration.
 /// The server will fail to start if any expected module is missing.
+///
+/// The list MUST mirror every `runtime.register(...)` call in `ipc/mod.rs`
+/// that produces a `ServiceModule` in the steady-state boot path. When the
+/// two drift, `verify_registration()` logs spurious "Unexpected module
+/// registered" warnings (registered-but-not-listed) or fails boot with
+/// "Missing required modules" (listed-but-not-registered). Both modes lie
+/// about substrate health — keep this list current per
+/// [[every-error-is-an-opportunity-to-battle-harden]].
 pub const EXPECTED_MODULES: &[&str] = &[
-    "gpu",               // Phase 0: GPU memory management
-    "health",            // Phase 1: stateless health checks
-    "cognition",         // Phase 2: persona cognition engines
-    "channel",           // Phase 2: persona channel registries
-    "models",            // Phase 3: async model discovery
-    "memory",            // Phase 3: persona memory manager
-    "rag",               // Phase 3: batched RAG composition
-    "live",              // Phase 3: live experience (voice, video, transport)
-    "code",              // Phase 3: file engines, shell sessions
-    "data",              // Phase 4: database ORM operations
-    "logger",            // Phase 4a: structured logging
-    "search",            // Phase 4b: BM25, TF-IDF, vector search
-    "embedding",         // Phase 4c: fastembed vector generation
-    "grid",              // Grid transport: inter-node routing (Tailscale, Reticulum)
-    "runtime",           // RuntimeModule: metrics and control
-    "mcp",               // MCP server: dynamic tool discovery
-    "system",            // System resources: CPU, memory, process monitoring
-    "avatar",            // Avatar snapshots: Bevy 3D renders → PNG
-    "dataset",           // Dataset import/management for Academy training
-    "persona_allocator", // Hardware-aware persona allocation decisions
-    "inference-llm",     // Phase 5: local LLM generation (MODULE-CATALOG §II)
-    "vdd",               // Lane C PR-3: VDD report from structured artifacts
+    // Infrastructure / health
+    "health",                   // stateless health checks
+    "auth",                     // permission scope routing
+    "system",                   // CPU, memory, process monitoring
+    "events",                   // command-completed event stream
+    "logger",                   // structured logging
+    "runtime",                  // metrics and control
+    "mcp",                      // MCP server: dynamic tool discovery
+    "data",                     // database ORM operations
+    // Resource governance
+    "gpu",                      // GPU memory management
+    "resource-broker",          // typed resource admission
+    "pressure-broker",          // CPU/RAM/VRAM pressure broadcast
+    // Persona substrate
+    "cognition",                // persona cognition engines
+    "channel",                  // persona channel registries
+    "memory",                   // persona memory manager
+    "rag",                      // batched RAG composition
+    "persona_allocator",        // hardware-aware allocation decisions
+    "persona_instance_manager", // live PersonaAircRuntime registry
+    "persona-rag-inspect",      // RAG introspection callable from any AI
+    "agent",                    // agent participation (chat surface)
+    // AI / inference
+    "inference",                // inference handle store + dispatch
+    "inference-llm",            // local LLM generation
+    "ai_provider",              // unified provider (cloud + local)
+    "embedding",                // fastembed vector generation
+    "search",                   // BM25, TF-IDF, vector search
+    "tool-parsing",             // stateless tool call parsing
+    "vision",                   // content-addressed vision cache
+    "models",                   // async model discovery
+    // Forge / sentinel / plasticity
+    "forge",                    // forge recipe runs
+    "sentinel",                 // build/task execution with isolation
+    "plasticity",               // adaptive plasticity optimization
+    "dataset",                  // training dataset import
+    "vdd",                      // VDD report from structured artifacts
+    "cargo",                    // structured cargo/build, cargo/test
+    "code",                     // file engines, shell sessions
+    // Substrate transports
+    "airc",                     // airc IPC + discovery
+    "grid",                     // inter-node transport (Tailscale, Reticulum)
+    // Live presence (Slice B will split this set off via feature gate)
+    "live",                     // voice/video transport
+    "avatar",                   // Bevy 3D avatar snapshots
 ];
 
 pub struct Runtime {


### PR DESCRIPTION
## Summary

Slice A of the post-2026-06-04 startup-reliability iteration. Three sub-fixes addressing the "substrate booted but did nothing" failure mode that ate the morning: continuum-core-server stayed alive on Joel's machine at 1166 MB RSS for 19 hours hosting zero personas because `airc ipc-endpoint` failed (task #79), `PersonaInstanceManagerModule` got silently skipped, and a single buried WARN line was the only signal.

Card: `e9f50a36-0543-412f-a804-13c21e1cf2c1`

## A1 — hard-fail boot when (persona seeds on disk) AND (AIRC degraded)

`start_server` now returns `Err(io::Error)` instead of logging a single WARN and continuing when:
- `<continuum_root>/personas/*/seed.json` exists, AND
- AIRC discovery failed (no daemon socket or no default room)

Operator sees a clear ERROR with the actionable repair and the process exits non-zero. If NO persona seeds exist (fresh install, inference-only mode, test fixture), the substrate continues to boot — there are no citizens to fail. Boundary intentionally narrow: only hard-fails the case the substrate would otherwise lie about.

Persona-seed detection extracted as `count_persona_seeds(&Path) -> usize` in `modules/persona_instance_manager.rs` with **6 unit tests** covering missing dir, empty dir, single-seed, multi-seed, persona-dir-without-seed (in-progress mint), and stray-files-at-personas-root.

## A2 — ORT panic-stderr filter

Every ORT load site (fastembed preload, TTS/STT init) already wraps the ORT call in `catch_unwind` and sets `ORT_UNAVAILABLE` on failure with a clean WARN line. But Rust's DEFAULT panic hook ALSO writes the panic to stderr BEFORE `catch_unwind` catches it:

```
thread 'tokio-rt-worker' (36060772) panicked at
  /Users/.cargo/registry/src/.../ort-2.0.0-rc.11/src/lib.rs:191:41:
Failed to load ONNX Runtime dylib: Error { code: GenericFailure, ... }
```

That trace looks like a substrate bug. It's not — it's just "voice features not available, install libonnxruntime." The new `install_ort_panic_filter` (called at the top of `main`) installs a custom panic hook that matches BOTH `location().file()` containing `/ort-` AND payload mentioning `"Failed to load ONNX Runtime"`. Other ORT panics (genuine inference bugs) won't match the dylib-load substring and fall through to the default hook. Non-ORT panics always fall through.

## A3 — `EXPECTED_MODULES` current with reality

The list in `runtime/runtime.rs` had 22 entries. The substrate registers **38** modules. Result: 16 false "Unexpected module registered" WARN lines on every boot for load-bearing modules (`airc`, `persona_instance_manager`, `persona-rag-inspect`, `tool-parsing`, `resource-broker`, `cargo`, `inference`, `sentinel`, `plasticity`, `ai_provider`, `agent`, `vision`, `forge`, `auth`, `events`, `pressure-broker`).

Now organized by role (infrastructure, resource governance, persona substrate, AI/inference, forge/sentinel, transports, live presence) with a doc-comment explaining what drift between this list and `ipc/mod.rs` produces (spurious warnings or fail-boot).

## End-to-end verified (real binary, this machine)

```text
$ rm AIRC_DAEMON_SOCKET; continuum-core-server …
ERROR Refusing to boot in degraded state: 1 persona seed(s) on disk
      but AIRC discovery failed — no PersonaInstanceManagerModule
      registered, so the substrate cannot host these citizens.
      Resolve: install airc, set AIRC_DAEMON_SOCKET, or run
      `airc room <name>` … then restart continuum-core. To start
      anyway (e.g. for inference-only headless mode), move or
      rename /Users/joel/.continuum/personas aside.
[exit 1]                                            ← A1 hard-fails

$ AIRC_DAEMON_SOCKET=… continuum-core-server …
✅ All 38 expected modules registered                ← A3: 0 unexpected
PersonaAircRuntime bootstrap: identity ready (Paige)
PersonaAircRuntime bootstrap: joined room (cambriantech)
🌐 The Grid hosts citizen Paige (slot 0, role Helper)
(no `thread … panicked at /ort-` trace)             ← A2 filter live

$ airc msg "how's the new substrate boot feel?"
Paige: "Hi there! I'm Paige, an AI on the grid. …"  ← round-trip works
```

## Doctrine

- [[no-fallbacks-ever]] — refuse to degrade silently
- [[substrate-is-a-good-citizen-on-the-host]] — speak clearly when degraded; don't scare operators with panic traces they can't act on
- [[every-error-is-an-opportunity-to-battle-harden]] — the rigging that catches "substrate ran but did nothing" next time
- [[host-the-seemingly-impossible]] — the substrate is only credible when it's honest about what it can host RIGHT NOW

## Out of scope (deferred follow-ups)

- `airc ipc-endpoint` subcommand — task #79, the airc-side fix that would obviate the `AIRC_DAEMON_SOCKET` env var workaround entirely.
- 200+ stale `airc daemon` processes on the host — every `airc resume` from every Claude tab / sandbox / test spawns one and they accumulate. Separate, airc-lifecycle hygiene work.
- `headless-only` / `live-presence` feature split — **Slice B** of the iteration. Today the headless persona server links `bevy_pbr` (3D PBR shaders!) because `live/avatar/*` reaches into bevy. Expected outcome: 105 MB → ~30-40 MB binary, ~34 min → ~5-10 min cold build.
- Adapter warmup parallelization — **Slice C**. Today the sequence is serial (airc bootstrap → join room → service-loop attach (4s warmup) → ready). Spawning warmup as a task that races bootstrap collapses 5s → ~1s on cold start.

## Test plan

- [x] `cargo test --release -p continuum-core --lib count_persona_seeds` — 6/0 pass
- [x] `cargo check --release -p continuum-core --no-default-features --features livekit-webrtc,llama/mac-cpu-only` — clean (64 pre-existing warnings, 0 new)
- [x] Boot with Paige seed + no `AIRC_DAEMON_SOCKET` → ERROR + exit 1 with actionable message
- [x] Boot with Paige seed + correct `AIRC_DAEMON_SOCKET` → 38 modules, 0 unexpected, Paige joins room
- [x] `airc msg → airc inbox` round-trip with Paige — coherent reply
- [x] No `thread … panicked at /ort-` trace in stderr on Mac Intel without libonnxruntime

## References

- docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md (substrate contract)
- docs/architecture/PERSONA-COGNITION-PIPELINE.md (persona host loop)
- Memory: [[no-fallbacks-ever]], [[substrate-is-a-good-citizen-on-the-host]], [[every-error-is-an-opportunity-to-battle-harden]]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
