### PR TITLE
fix(boot): typed AircDiscovery + BootMode + conditional manifest (Slice A.2.1)

### DIFF
--- a/src/workers/continuum-core/src/airc/discovery_aggregate.rs
+++ b/src/workers/continuum-core/src/airc/discovery_aggregate.rs
@@ -1,0 +1,135 @@
+//! `discover()` — the aggregator that produces a typed `AircDiscovery`.
+//!
+//! Wraps the four existing discovery sub-steps
+//! (`discover_airc_socket`, `discover_peer_id`,
+//! `discover_default_room_name`, `discover_default_channel`) and
+//! promotes each failure into the corresponding `AircDiscovery`
+//! variant, carrying whatever partial state we did manage to
+//! resolve.
+//!
+//! Critically, `discover_peer_id` IS the liveness probe — the Status
+//! RPC round-trips against the socket. Before A.2, a failed
+//! `discover_peer_id` soft-fell-back to `Uuid::nil()` so the module
+//! still registered. Now it produces
+//! `AircDiscovery::Degraded { reason: StaleSocket, .. }` which the
+//! caller can act on per [[no-fallbacks-ever]].
+
+use std::path::PathBuf;
+
+use airc_core::RoomId;
+
+use crate::airc::discovery::{
+    discover_airc_socket, discover_default_channel, discover_default_room_name,
+    discover_peer_id, DiscoveryError,
+};
+use crate::airc::discovery_state::{AircDiscovery, DiscoveryFailure, PartialDiscovery};
+
+/// Discover the airc daemon's full state. Always returns a typed
+/// `AircDiscovery` — never panics, never returns `Err`. The
+/// substrate routes downstream behavior on the variant.
+pub async fn discover() -> AircDiscovery {
+    let mut partial = PartialDiscovery::default();
+
+    let socket = match discover_airc_socket().await {
+        Ok(path) => {
+            partial.socket = Some(path.clone());
+            path
+        }
+        Err(e) => return AircDiscovery::Unreachable { reason: e.into() },
+    };
+
+    // Liveness probe — Status RPC round-trip against the socket.
+    // Before A.2 this could soft-fail to Uuid::nil() and the module
+    // would still register. After A.2, a probe failure promotes
+    // to AircDiscovery::Degraded { reason: StaleSocket } and
+    // the substrate refuses persona hosting against this state.
+    let peer_id = match discover_peer_id(&socket).await {
+        Ok(p) => {
+            partial.peer_id = Some(p);
+            p
+        }
+        Err(e) => {
+            return AircDiscovery::Degraded {
+                reason: stale_socket_from_status_err(&socket, e),
+                partial,
+            };
+        }
+    };
+
+    let room_name = match discover_default_room_name().await {
+        Ok(name) => {
+            partial.room_name = Some(name.clone());
+            name
+        }
+        Err(e) => {
+            return AircDiscovery::Degraded {
+                reason: room_failure(e),
+                partial,
+            };
+        }
+    };
+
+    let default_room = match discover_default_channel().await {
+        Ok(uuid) => {
+            let room = RoomId::from_uuid(uuid);
+            partial.default_room = Some(room);
+            room
+        }
+        Err(e) => {
+            return AircDiscovery::Degraded {
+                reason: room_failure(e),
+                partial,
+            };
+        }
+    };
+
+    AircDiscovery::Healthy {
+        socket,
+        default_room,
+        room_name,
+        peer_id,
+    }
+}
+
+impl From<DiscoveryError> for DiscoveryFailure {
+    fn from(e: DiscoveryError) -> Self {
+        match e {
+            DiscoveryError::InstallFailed(msg) => DiscoveryFailure::InstallFailed(msg),
+            DiscoveryError::AutoInstallDisabled => DiscoveryFailure::AutoInstallDisabled,
+            DiscoveryError::EndpointCommandFailed(msg) => {
+                DiscoveryFailure::EndpointCommandFailed(msg)
+            }
+            DiscoveryError::EmptyPath => DiscoveryFailure::EmptyPath,
+            DiscoveryError::RoomCommandFailed(msg) => DiscoveryFailure::RoomCommandFailed(msg),
+            DiscoveryError::UnparseableChannel(msg) => {
+                DiscoveryFailure::UnparseableRoomOutput(msg)
+            }
+            DiscoveryError::PeerStatusFailed(msg) => DiscoveryFailure::PeerStatusFailed(msg),
+            DiscoveryError::UnparseablePeerId(raw, err) => {
+                DiscoveryFailure::UnparseablePeerId(raw, err.to_string())
+            }
+        }
+    }
+}
+
+/// Status RPC failure → typed `StaleSocket` carrying the path AND
+/// the underlying error message. This is the structural fix for the
+/// R2 hole: every Status failure path collapses to one variant the
+/// caller MUST match exhaustively.
+fn stale_socket_from_status_err(socket: &PathBuf, e: DiscoveryError) -> DiscoveryFailure {
+    let underlying = match e {
+        DiscoveryError::PeerStatusFailed(msg) => msg,
+        other => other.to_string(),
+    };
+    DiscoveryFailure::StaleSocket(socket.clone(), underlying)
+}
+
+/// Room-side failures (no room set, command failed, unparseable
+/// output) all promote to typed variants on `DiscoveryFailure`.
+fn room_failure(e: DiscoveryError) -> DiscoveryFailure {
+    match e {
+        DiscoveryError::RoomCommandFailed(msg) => DiscoveryFailure::RoomCommandFailed(msg),
+        DiscoveryError::UnparseableChannel(msg) => DiscoveryFailure::UnparseableRoomOutput(msg),
+        other => DiscoveryFailure::RoomCommandFailed(other.to_string()),
+    }
+}

--- a/src/workers/continuum-core/src/airc/discovery_aggregate.rs
+++ b/src/workers/continuum-core/src/airc/discovery_aggregate.rs
@@ -133,3 +133,128 @@ fn room_failure(e: DiscoveryError) -> DiscoveryFailure {
         other => DiscoveryFailure::RoomCommandFailed(other.to_string()),
     }
 }
+
+#[cfg(test)]
+mod discovery_failure_mapping_tests {
+    //! Lock in the `DiscoveryError → DiscoveryFailure` projection so
+    //! a future refactor that re-routes one variant (e.g.
+    //! `PeerStatusFailed → EndpointCommandFailed`) gets caught
+    //! immediately — that class of silent mismatch would let the
+    //! R2#1 BLOCK return without any test failing.
+    //!
+    //! The aggregator's typed `discover()` output drives operator-
+    //! facing diagnostics; if a single variant maps wrong, the
+    //! operator gets the wrong actionable repair message.
+
+    use super::*;
+
+    #[test]
+    fn install_failed_preserves_message() {
+        let f: DiscoveryFailure =
+            DiscoveryError::InstallFailed("permission denied".into()).into();
+        assert!(matches!(f, DiscoveryFailure::InstallFailed(m) if m == "permission denied"));
+    }
+
+    #[test]
+    fn auto_install_disabled_maps_to_same() {
+        let f: DiscoveryFailure = DiscoveryError::AutoInstallDisabled.into();
+        assert!(matches!(f, DiscoveryFailure::AutoInstallDisabled));
+    }
+
+    #[test]
+    fn endpoint_command_failed_preserves_message() {
+        let f: DiscoveryFailure =
+            DiscoveryError::EndpointCommandFailed("exit 2: unknown subcommand".into()).into();
+        assert!(matches!(
+            f,
+            DiscoveryFailure::EndpointCommandFailed(m) if m.contains("exit 2")
+        ));
+    }
+
+    #[test]
+    fn empty_path_maps_to_empty_path() {
+        let f: DiscoveryFailure = DiscoveryError::EmptyPath.into();
+        assert!(matches!(f, DiscoveryFailure::EmptyPath));
+    }
+
+    #[test]
+    fn room_command_failed_preserves_message() {
+        let f: DiscoveryFailure =
+            DiscoveryError::RoomCommandFailed("no current room".into()).into();
+        assert!(matches!(
+            f,
+            DiscoveryFailure::RoomCommandFailed(m) if m.contains("no current")
+        ));
+    }
+
+    /// `DiscoveryError::UnparseableChannel` → `DiscoveryFailure::UnparseableRoomOutput`.
+    /// This is the variant most likely to be silently re-routed in a
+    /// refactor (their names diverge for historical reasons) — pin it.
+    #[test]
+    fn unparseable_channel_maps_to_unparseable_room_output() {
+        let f: DiscoveryFailure =
+            DiscoveryError::UnparseableChannel("channel: <garbage>".into()).into();
+        assert!(matches!(
+            f,
+            DiscoveryFailure::UnparseableRoomOutput(m) if m.contains("channel:")
+        ));
+    }
+
+    #[test]
+    fn peer_status_failed_preserves_message() {
+        let f: DiscoveryFailure =
+            DiscoveryError::PeerStatusFailed("connection refused".into()).into();
+        assert!(matches!(
+            f,
+            DiscoveryFailure::PeerStatusFailed(m) if m == "connection refused"
+        ));
+    }
+
+    #[test]
+    fn unparseable_peer_id_preserves_raw_and_error() {
+        let uuid_err = "not-a-uuid".parse::<uuid::Uuid>().unwrap_err();
+        let f: DiscoveryFailure =
+            DiscoveryError::UnparseablePeerId("xyz".into(), uuid_err).into();
+        assert!(matches!(
+            f,
+            DiscoveryFailure::UnparseablePeerId(raw, err_msg)
+            if raw == "xyz" && !err_msg.is_empty()
+        ));
+    }
+
+    /// `stale_socket_from_status_err` MUST construct a `StaleSocket`
+    /// variant carrying the path AND the underlying error message.
+    /// This is the structural fix for R2#1: Status RPC failure
+    /// against an env-var-supplied socket no longer collapses to
+    /// `Uuid::nil()` soft-fallback; it produces a typed reason the
+    /// substrate refuses to construct an attribution-less transport
+    /// against (per the from_discovery test).
+    #[test]
+    fn stale_socket_carries_path_and_status_err_message() {
+        let socket = PathBuf::from("/tmp/stale.sock");
+        let underlying = "ECONNREFUSED (connection refused)";
+        let f = stale_socket_from_status_err(
+            &socket,
+            DiscoveryError::PeerStatusFailed(underlying.into()),
+        );
+        match f {
+            DiscoveryFailure::StaleSocket(p, msg) => {
+                assert_eq!(p, socket);
+                assert!(msg.contains("ECONNREFUSED"));
+            }
+            other => panic!("expected StaleSocket, got {other:?}"),
+        }
+    }
+
+    /// `stale_socket_from_status_err` with a non-PeerStatusFailed
+    /// error still produces `StaleSocket` (the function is named for
+    /// its purpose — any error reaching it means the socket isn't
+    /// alive). The underlying message gets the full Display of the
+    /// non-Status variant.
+    #[test]
+    fn stale_socket_handles_non_status_errors() {
+        let socket = PathBuf::from("/tmp/stale.sock");
+        let f = stale_socket_from_status_err(&socket, DiscoveryError::EmptyPath);
+        assert!(matches!(f, DiscoveryFailure::StaleSocket(p, _) if p == socket));
+    }
+}

--- a/src/workers/continuum-core/src/airc/discovery_state.rs
+++ b/src/workers/continuum-core/src/airc/discovery_state.rs
@@ -1,0 +1,238 @@
+//! Typed `AircDiscovery` state — the substrate's single answer to
+//! "what is the airc daemon doing right now?"
+//!
+//! ## Why a typed enum
+//!
+//! Before A.2, AIRC discovery returned `Option<(PathBuf, RoomId)>` —
+//! a tuple where presence meant "all four sub-discoveries succeeded"
+//! and absence collapsed every failure mode into one. The
+//! [[no-fallbacks-ever]] doctrine demands the substrate name its
+//! degraded states explicitly so the operator can act on them. A
+//! typed enum makes the variants exhaustive: every `match` against
+//! `AircDiscovery` is forced to consider `Healthy`, `Degraded { reason }`,
+//! and `Unreachable { reason }`.
+//!
+//! ## Why a liveness probe
+//!
+//! Slice A shipped a hard-fail check ("if persona seeds exist + AIRC
+//! degraded → refuse boot") but the env-var override path
+//! (`AIRC_DAEMON_SOCKET=/path/to/dead.sock`) bypassed every check —
+//! discovery returned the path with no liveness verification, the
+//! module registered, the operator saw "✅ All N modules registered"
+//! and "🌐 The Grid hosts citizen Paige," and every IPC call
+//! ECONNREFUSED. This is the bug R2 found in the Slice A review.
+//!
+//! `AircDiscovery::Healthy` is now only producible AFTER a successful
+//! Status RPC round-trip against the socket. Stale-socket promotes to
+//! `Degraded { reason: StaleSocket }`, not soft-fallback-to-nil-peer.
+//!
+//! ## Threaded through `Context`
+//!
+//! Slices 1–4 of #142 established `Context` as the universal actor
+//! handle. A.2 extends it with `discovery(&self) -> &AircDiscovery`
+//! so every actor (persona, agent, jtag, human, web) carries the
+//! discovery state that was true at the moment they were created.
+//! No more bare paths floating without provenance. B' will generalize
+//! this from one axis (airc) to N axes (renderer, voice, inference,
+//! foundry) via the category-handle pattern.
+
+use std::path::PathBuf;
+
+use airc_core::RoomId;
+use uuid::Uuid;
+
+/// The substrate's typed answer to "what is the airc daemon doing
+/// right now?"
+///
+/// Exhaustive — every match is forced to handle each variant. The
+/// three variants are ordered by user-actionability:
+/// `Healthy` is the success path, `Degraded` means the daemon is
+/// reachable but cannot fully serve persona hosting (operator
+/// remediates), `Unreachable` means the daemon is not running or
+/// not on the operator's machine (operator installs / runs airc).
+#[derive(Debug, Clone)]
+pub enum AircDiscovery {
+    /// All four sub-discoveries succeeded AND a Status RPC round-trip
+    /// against the socket confirmed the daemon responds. This is the
+    /// only state from which `PersonaInstanceManagerModule` can be
+    /// registered.
+    Healthy {
+        socket: PathBuf,
+        default_room: RoomId,
+        room_name: String,
+        peer_id: Uuid,
+    },
+    /// Socket was discovered but at least one downstream check
+    /// failed — the daemon is reachable enough to expose a path,
+    /// but cannot fully serve persona hosting. `partial` carries
+    /// whatever we DID resolve so observability can pinpoint the
+    /// remaining gap.
+    Degraded {
+        reason: DiscoveryFailure,
+        partial: PartialDiscovery,
+    },
+    /// Socket itself could not be discovered. airc not on PATH,
+    /// auto-install disabled, `airc ipc-endpoint` failed, empty
+    /// path returned. The operator cannot reach the substrate's
+    /// expected airc surface.
+    Unreachable { reason: DiscoveryFailure },
+}
+
+impl AircDiscovery {
+    /// `true` iff persona hosting can proceed against this state.
+    /// Equivalent to `matches!(self, AircDiscovery::Healthy { .. })`
+    /// but named for the question the caller is actually asking.
+    pub fn can_host_personas(&self) -> bool {
+        matches!(self, AircDiscovery::Healthy { .. })
+    }
+
+    /// Short human-readable kind for log lines + boot banner.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            AircDiscovery::Healthy { .. } => "healthy",
+            AircDiscovery::Degraded { .. } => "degraded",
+            AircDiscovery::Unreachable { .. } => "unreachable",
+        }
+    }
+
+    /// Borrow the typed failure (if any) for structured logging.
+    pub fn reason(&self) -> Option<&DiscoveryFailure> {
+        match self {
+            AircDiscovery::Healthy { .. } => None,
+            AircDiscovery::Degraded { reason, .. } | AircDiscovery::Unreachable { reason } => {
+                Some(reason)
+            }
+        }
+    }
+}
+
+/// Everything the substrate WAS able to resolve before the failure
+/// that produced `AircDiscovery::Degraded`. Used for observability —
+/// the operator's remediation depends on knowing whether we got
+/// the socket but lost the room, vs. got the socket but the daemon
+/// is dead, etc.
+#[derive(Debug, Clone, Default)]
+pub struct PartialDiscovery {
+    pub socket: Option<PathBuf>,
+    pub default_room: Option<RoomId>,
+    pub room_name: Option<String>,
+    pub peer_id: Option<Uuid>,
+}
+
+/// Typed failure reasons. Every error path the substrate can take
+/// during AIRC discovery maps to exactly one variant; the operator's
+/// remediation depends on which.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum DiscoveryFailure {
+    #[error("airc binary not on PATH and auto-install was disabled (CONTINUUM_NO_AUTOINSTALL=1)")]
+    AutoInstallDisabled,
+
+    #[error("airc binary install failed: {0}")]
+    InstallFailed(String),
+
+    #[error(
+        "`airc ipc-endpoint` failed: {0}\n\
+         remediation: ensure airc is installed (curl -fsSL https://airc.sh | bash) \
+         OR set AIRC_DAEMON_SOCKET=<path>"
+    )]
+    EndpointCommandFailed(String),
+
+    #[error(
+        "`airc ipc-endpoint` returned an empty path — airc binary may be from before \
+         the ipc-endpoint subcommand (task #79); upgrade airc"
+    )]
+    EmptyPath,
+
+    #[error(
+        "daemon socket at {0} is unreachable: {1}\n\
+         most likely cause: a stale socket file from a daemon that has exited. \
+         remediation: remove the stale socket and restart airc, OR point \
+         AIRC_DAEMON_SOCKET at a live daemon's socket"
+    )]
+    StaleSocket(PathBuf, String),
+
+    #[error("daemon Status RPC failed: {0}")]
+    PeerStatusFailed(String),
+
+    #[error("daemon Status returned unparseable peer_id ({0:?}): {1}")]
+    UnparseablePeerId(String, String),
+
+    #[error(
+        "`airc room` failed: {0}\n\
+         remediation: run `airc room <name>` to subscribe the scope to a room"
+    )]
+    RoomCommandFailed(String),
+
+    #[error(
+        "`airc room` output did not contain a parseable channel: {0}\n\
+         remediation: upgrade airc OR set AIRC_DEFAULT_CHANNEL=<uuid>"
+    )]
+    UnparseableRoomOutput(String),
+
+    #[error(
+        "no default room set — run `airc room <name>` to subscribe the scope to a room"
+    )]
+    NoDefaultRoom,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn healthy_can_host_personas() {
+        let d = AircDiscovery::Healthy {
+            socket: PathBuf::from("/tmp/x.sock"),
+            default_room: RoomId::from_uuid(Uuid::new_v4()),
+            room_name: "general".into(),
+            peer_id: Uuid::new_v4(),
+        };
+        assert!(d.can_host_personas());
+        assert_eq!(d.kind(), "healthy");
+        assert!(d.reason().is_none());
+    }
+
+    #[test]
+    fn degraded_cannot_host_personas() {
+        let d = AircDiscovery::Degraded {
+            reason: DiscoveryFailure::NoDefaultRoom,
+            partial: PartialDiscovery {
+                socket: Some(PathBuf::from("/tmp/x.sock")),
+                ..Default::default()
+            },
+        };
+        assert!(!d.can_host_personas());
+        assert_eq!(d.kind(), "degraded");
+        assert!(matches!(d.reason(), Some(DiscoveryFailure::NoDefaultRoom)));
+    }
+
+    #[test]
+    fn unreachable_cannot_host_personas() {
+        let d = AircDiscovery::Unreachable {
+            reason: DiscoveryFailure::AutoInstallDisabled,
+        };
+        assert!(!d.can_host_personas());
+        assert_eq!(d.kind(), "unreachable");
+        assert!(matches!(
+            d.reason(),
+            Some(DiscoveryFailure::AutoInstallDisabled)
+        ));
+    }
+
+    /// StaleSocket — the bug R2 caught — is now a first-class
+    /// variant carrying both the socket path AND the underlying
+    /// IO error so the operator knows whether it was ECONNREFUSED,
+    /// EACCES, or "file exists but not a socket."
+    #[test]
+    fn stale_socket_carries_path_and_io_reason() {
+        let reason = DiscoveryFailure::StaleSocket(
+            PathBuf::from("/tmp/dead.sock"),
+            "ECONNREFUSED".into(),
+        );
+        let display = format!("{reason}");
+        assert!(display.contains("/tmp/dead.sock"));
+        assert!(display.contains("ECONNREFUSED"));
+        assert!(display.contains("stale socket"));
+    }
+}

--- a/src/workers/continuum-core/src/airc/mod.rs
+++ b/src/workers/continuum-core/src/airc/mod.rs
@@ -8,6 +8,8 @@ pub mod client;
 pub mod daemon_endpoint;
 pub mod daemon_transport;
 pub mod discovery;
+pub mod discovery_aggregate;
+pub mod discovery_state;
 pub mod event_transport;
 pub mod inbound_attach;
 pub mod process;
@@ -15,6 +17,9 @@ pub mod realtime;
 pub mod realtime_store;
 pub mod realtime_wire;
 pub mod types;
+
+pub use discovery_aggregate::discover;
+pub use discovery_state::{AircDiscovery, DiscoveryFailure, PartialDiscovery};
 
 pub use client::{AircQueueClient, CliAircQueueClient};
 #[allow(deprecated)]

--- a/src/workers/continuum-core/src/ipc/mod.rs
+++ b/src/workers/continuum-core/src/ipc/mod.rs
@@ -690,10 +690,17 @@ pub fn start_server(
     rt_handle: tokio::runtime::Handle,
     memory_manager: Arc<crate::memory::PersonaMemoryManager>,
     pressure_monitor: Arc<crate::system_resources::MemoryPressureMonitor>,
+    boot_mode: crate::runtime::BootMode,
 ) -> std::io::Result<()> {
     prepare_unix_socket_path(socket_path)?;
 
-    log_info!("ipc", "server", "Starting IPC server on {}", socket_path);
+    log_info!(
+        "ipc",
+        "server",
+        "Starting IPC server on {} (mode={})",
+        socket_path,
+        boot_mode.label()
+    );
 
     // Load the model_registry BEFORE any ServiceModule is constructed.
     // Several adapters (AnthropicAdapter, LlamaCppAdapter, …) read from
@@ -918,30 +925,65 @@ pub fn start_server(
     // finding 6); substrate-is-a-good-citizen "predictable startup"
     // non-negotiable.
     const AIRC_DISCOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
-    let airc_module = Arc::new(rt_handle.block_on(async {
-        match tokio::time::timeout(
-            AIRC_DISCOVERY_TIMEOUT,
-            AircModule::discover_and_construct(),
-        )
-        .await
-        {
-            Ok(m) => m,
+    let discovery = rt_handle.block_on(async {
+        match tokio::time::timeout(AIRC_DISCOVERY_TIMEOUT, crate::airc::discover()).await {
+            Ok(d) => d,
             Err(_) => {
                 tracing::error!(
                     timeout_secs = AIRC_DISCOVERY_TIMEOUT.as_secs(),
-                    "AircModule discovery exceeded outer timeout — falling back to degraded module. \
-                     Server will start; AIRC commands degrade until the operator resolves the daemon issue."
+                    "AIRC discovery exceeded outer timeout — promoting to Unreachable."
                 );
-                AircModule::new()
+                crate::airc::AircDiscovery::Unreachable {
+                    reason: crate::airc::DiscoveryFailure::EndpointCommandFailed(format!(
+                        "discovery did not return within {}s — substrate is unresponsive",
+                        AIRC_DISCOVERY_TIMEOUT.as_secs()
+                    )),
+                }
             }
         }
-    }));
+    });
+    tracing::info!(
+        kind = discovery.kind(),
+        reason = ?discovery.reason(),
+        "AIRC discovery complete"
+    );
+    let airc_module = Arc::new(AircModule::from_discovery(&discovery));
     let persona_bootstrap_deps = airc_module
         .daemon_socket()
         .map(|p| p.to_path_buf())
         .zip(airc_module.default_room());
     let persona_bootstrap_room_name = airc_module.default_room_name().map(|s| s.to_string());
     runtime.register(airc_module);
+
+    // A.2 [[no-fallbacks-ever]]: in `FullCitizen` or `FailFast` mode,
+    // the substrate REFUSES to boot if AIRC isn't `Healthy` — there's
+    // no path where degraded discovery silently substitutes
+    // inference-only mode (Slice A's R2#2 violation). Operator must
+    // explicitly opt into `--mode=inference-only` to allow degraded
+    // boot. The seed-presence heuristic Slice A used is gone.
+    if boot_mode.requires_persona_hosting() && !discovery.can_host_personas() {
+        let reason_msg = discovery
+            .reason()
+            .map(|r| format!("{}", r))
+            .unwrap_or_else(|| "AIRC discovery did not produce Healthy state".to_string());
+        tracing::error!(
+            mode = boot_mode.label(),
+            discovery_kind = discovery.kind(),
+            reason = %reason_msg,
+            "Refusing to boot: --mode={} requires AIRC Healthy, but discovery is {}. \
+             Resolve the AIRC issue (see error above) OR re-launch with \
+             --mode=inference-only to opt into degraded operation.",
+            boot_mode.label(),
+            discovery.kind()
+        );
+        return Err(std::io::Error::other(format!(
+            "AIRC discovery {} but --mode={} requires Healthy. \
+             Reason: {}. Resolve AIRC or use --mode=inference-only ([[no-fallbacks-ever]])",
+            discovery.kind(),
+            boot_mode.label(),
+            reason_msg
+        )));
+    }
 
     // PersonaInstanceManagerModule: owns the live PersonaAircRuntime
     // registry — the kernel's roster of citizens in The Grid. Exposes
@@ -1110,10 +1152,19 @@ pub fn start_server(
             );
         });
     } else {
-        tracing::warn!(
-            "PersonaInstanceManagerModule NOT registered — AIRC discovery is degraded \
-             (missing socket or default room). Resolve by installing airc and running \
-             `airc room <name>`, then restart continuum-core."
+        // A.2: by this point the mode-driven gate above has already
+        // returned `Err` if persona hosting was required and discovery
+        // failed. Reaching here means `--mode=inference-only` — the
+        // operator explicitly opted into degraded operation. Single
+        // info-level line tells them what's missing without scaring.
+        tracing::info!(
+            mode = boot_mode.label(),
+            discovery_kind = discovery.kind(),
+            "PersonaInstanceManagerModule not registered (--mode=inference-only, AIRC \
+             discovery {}). Substrate continues for inference / embedding / forge / \
+             cargo / code. Resolve AIRC and re-launch in --mode=full-citizen to host \
+             personas.",
+            discovery.kind()
         );
     }
 
@@ -1183,8 +1234,14 @@ pub fn start_server(
     // Tick loops run as tokio tasks — they're lightweight and don't block the IPC thread.
     let _tick_handles = rt_handle.block_on(async { runtime.start_tick_loops() });
 
-    // Verify all expected modules are registered (fails server if any missing)
-    if let Err(e) = runtime.verify_registration() {
+    // Verify the required-module set for THIS (discovery, mode) pair.
+    // A.2 makes the set conditional — `persona_instance_manager` and
+    // `persona-rag-inspect` are only required when AIRC is `Healthy`
+    // AND mode requires persona hosting. Slice A's flat list put
+    // those in the unconditional set, which broke `--mode=inference-only`
+    // (R1#1 BLOCK). Conditional dispatch eliminates the contradiction
+    // structurally.
+    if let Err(e) = runtime.verify_registration(&discovery, boot_mode) {
         log_error!("ipc", "server", "{}", e);
         return Err(std::io::Error::other(e));
     }

--- a/src/workers/continuum-core/src/main.rs
+++ b/src/workers/continuum-core/src/main.rs
@@ -82,6 +82,59 @@ fn install_shutdown_handlers() {
     });
 }
 
+/// Short human-readable description of each `BootMode` — surfaces
+/// in the boot banner so the operator can see at a glance what the
+/// substrate is expected to support in this run.
+fn boot_mode_description(mode: continuum_core::runtime::BootMode) -> &'static str {
+    use continuum_core::runtime::BootMode;
+    match mode {
+        BootMode::FullCitizen => "hosts personas via AIRC; requires AIRC Healthy",
+        BootMode::InferenceOnly => "no persona hosting; allows degraded AIRC",
+        BootMode::FailFast => "strictest — refuses any degraded capability",
+    }
+}
+
+/// Install a panic hook that filters ORT's "dlopen failed for
+/// libonnxruntime" stderr trace.
+///
+/// The panic is already caught by `catch_unwind` at every ORT load
+/// site (see `modules/embedding.rs::preload_default_model` +
+/// `modules/embedding.rs::load_model_internal` + the TTS/STT spawn
+/// in `main()`). Each catch arm sets `ORT_UNAVAILABLE` and logs a
+/// clean WARN line. The user-visible noise we're suppressing here is
+/// Rust's DEFAULT panic hook writing the panic to stderr BEFORE
+/// `catch_unwind` catches it — that trace looks like a substrate bug
+/// ("thread 'tokio-rt-worker' panicked at ort-2.0.0-rc.11/src/lib.rs")
+/// but it's really just "voice features not available."
+///
+/// The hook AND-gates on (a) `location().file()` containing `/ort-`
+/// and (b) payload mentioning `"Failed to load ONNX Runtime"`. Other
+/// ORT panics (genuine bugs deeper in inference) fail one of those
+/// predicates and fall through to the default handler.
+fn install_ort_panic_filter() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let from_ort = info
+            .location()
+            .map(|loc| loc.file().contains("/ort-"))
+            .unwrap_or(false);
+        let about_dylib = info
+            .payload()
+            .downcast_ref::<String>()
+            .map(|s| s.contains("Failed to load ONNX Runtime"))
+            .or_else(|| {
+                info.payload()
+                    .downcast_ref::<&str>()
+                    .map(|s| s.contains("Failed to load ONNX Runtime"))
+            })
+            .unwrap_or(false);
+        if from_ort && about_dylib {
+            return;
+        }
+        default_hook(info);
+    }));
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Substrate-canonical tracing stack: UriCapture + ProbeRouter +
@@ -103,13 +156,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("[continuum-core-server] probes landing at {}", path.display());
     }
 
+    // Suppress the scary "tokio-rt-worker panicked at ort-…" trace
+    // when libonnxruntime is missing. The catch_unwind at every ORT
+    // load site already disables voice cleanly + logs a WARN — this
+    // just removes the misleading panic stack trace from stderr.
+    install_ort_panic_filter();
+
     // Parse command line arguments. argv[1] is the IPC socket path (positional)
     // — but intercept flag-like values FIRST so `--version` and `--help` don't
     // get treated as a socket path. Without this, `continuum-core-server
     // --version` boots the server with "/--version" as the socket path
     // and prints "IPC Socket: --version" — confusing for anyone trying to
     // verify the binary works (Carl's first instinct after `docker pull`).
-    let args: Vec<String> = env::args().collect();
+    let raw_args: Vec<String> = env::args().collect();
+
+    // A.2: peel off `--mode=<value>` (or `--mode <value>`) BEFORE
+    // positional parsing so it can appear anywhere in argv. The
+    // operator's intent (FullCitizen / InferenceOnly / FailFast)
+    // is now an explicit input instead of a heuristic from disk
+    // contents (Slice A's R2#2 BLOCK).
+    let (boot_mode, args) = match continuum_core::runtime::extract_boot_mode(raw_args) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(2);
+        }
+    };
+
     if args.len() >= 2 {
         match args[1].as_str() {
             "-V" | "--version" | "version" => {
@@ -117,19 +190,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 std::process::exit(0);
             }
             "-h" | "--help" | "help" => {
-                println!("Usage: {} <socket-path>", args[0]);
+                println!("Usage: {} [--mode=<MODE>] <socket-path>", args[0]);
                 println!("Example: {} /tmp/continuum-core.sock", args[0]);
                 println!();
                 println!("Flags:");
+                println!("  --mode=<MODE>    Boot mode: full-citizen (default), inference-only, fail-fast");
                 println!("  -V, --version    Print version and exit");
                 println!("  -h, --help       Print this help and exit");
+                println!();
+                println!("Modes:");
+                println!("  full-citizen     (default) hosts personas via AIRC; requires AIRC Healthy");
+                println!("  inference-only   no persona hosting; allows degraded AIRC");
+                println!("  fail-fast        strictest; refuses any degraded capability");
                 std::process::exit(0);
             }
             _ => {}
         }
     }
     if args.len() < 2 {
-        eprintln!("Usage: {} <socket-path>", args[0]);
+        eprintln!("Usage: {} [--mode=<MODE>] <socket-path>", args[0]);
         eprintln!("Example: {} /tmp/continuum-core.sock", args[0]);
         eprintln!("Try `{} --help` for more.", args[0]);
         std::process::exit(1);
@@ -139,6 +218,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("🦀 Continuum Core Server starting...");
     info!("   IPC Socket: {socket_path}");
+    info!("   Boot mode:  {} ({})", boot_mode.label(), boot_mode_description(boot_mode));
 
     // Create LiveKit agent manager — routes audio/video through LiveKit WebRTC SFU.
     // Handles speak-in-call, inject-audio, ambient, and video track publishing.
@@ -183,8 +263,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             rt_handle,
             ipc_memory_manager,
             ipc_pressure_monitor,
+            boot_mode,
         ) {
             tracing::error!("❌ IPC server error: {}", e);
+            // A.2: a `start_server` Err means the substrate refused
+            // to boot in a degraded state ([[no-fallbacks-ever]]). The
+            // operator's repair is in the error message. Exit non-zero
+            // so init systems / orchestrators see the failure instead
+            // of an idle-but-alive process.
+            unsafe { libc::_exit(1) };
         }
     });
 

--- a/src/workers/continuum-core/src/main.rs
+++ b/src/workers/continuum-core/src/main.rs
@@ -94,46 +94,14 @@ fn boot_mode_description(mode: continuum_core::runtime::BootMode) -> &'static st
     }
 }
 
-/// Install a panic hook that filters ORT's "dlopen failed for
-/// libonnxruntime" stderr trace.
-///
-/// The panic is already caught by `catch_unwind` at every ORT load
-/// site (see `modules/embedding.rs::preload_default_model` +
-/// `modules/embedding.rs::load_model_internal` + the TTS/STT spawn
-/// in `main()`). Each catch arm sets `ORT_UNAVAILABLE` and logs a
-/// clean WARN line. The user-visible noise we're suppressing here is
-/// Rust's DEFAULT panic hook writing the panic to stderr BEFORE
-/// `catch_unwind` catches it — that trace looks like a substrate bug
-/// ("thread 'tokio-rt-worker' panicked at ort-2.0.0-rc.11/src/lib.rs")
-/// but it's really just "voice features not available."
-///
-/// The hook AND-gates on (a) `location().file()` containing `/ort-`
-/// and (b) payload mentioning `"Failed to load ONNX Runtime"`. Other
-/// ORT panics (genuine bugs deeper in inference) fail one of those
-/// predicates and fall through to the default handler.
-fn install_ort_panic_filter() {
-    let default_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        let from_ort = info
-            .location()
-            .map(|loc| loc.file().contains("/ort-"))
-            .unwrap_or(false);
-        let about_dylib = info
-            .payload()
-            .downcast_ref::<String>()
-            .map(|s| s.contains("Failed to load ONNX Runtime"))
-            .or_else(|| {
-                info.payload()
-                    .downcast_ref::<&str>()
-                    .map(|s| s.contains("Failed to load ONNX Runtime"))
-            })
-            .unwrap_or(false);
-        if from_ort && about_dylib {
-            return;
-        }
-        default_hook(info);
-    }));
-}
+// ORT panic-filter intentionally NOT in A.2.1 per reviewer #2's
+// BLOCKING finding: shipping the panic trace muter without the
+// `🔊 Voice: ready / 🔇 Voice: unavailable` indicator leaves the
+// operator with ZERO signal about voice subsystem state on default
+// `FullCitizen` boot. Per [[substrate-is-a-good-citizen-on-the-host]]
+// "speak clearly when degraded," the filter and the indicator
+// must ship together — both land in A.2.2 alongside the
+// `libloading::Library::new("libonnxruntime.dylib")` dlopen probe.
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -156,11 +124,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("[continuum-core-server] probes landing at {}", path.display());
     }
 
-    // Suppress the scary "tokio-rt-worker panicked at ort-…" trace
-    // when libonnxruntime is missing. The catch_unwind at every ORT
-    // load site already disables voice cleanly + logs a WARN — this
-    // just removes the misleading panic stack trace from stderr.
-    install_ort_panic_filter();
+    // ORT panic-filter deferred to A.2.2 (lands together with the
+    // libonnxruntime dlopen probe + 🔊/🔇 voice subsystem indicator
+    // per reviewer #2's BLOCKING finding — muting the only signal
+    // without pairing the indicator is the [[substrate-is-a-good-
+    // citizen-on-the-host]] violation we're refusing to ship in
+    // A.2.1).
 
     // Parse command line arguments. argv[1] is the IPC socket path (positional)
     // — but intercept flag-like values FIRST so `--version` and `--help` don't

--- a/src/workers/continuum-core/src/modules/airc.rs
+++ b/src/workers/continuum-core/src/modules/airc.rs
@@ -173,6 +173,70 @@ impl AircModule {
         }
     }
 
+    /// Construct an `AircModule` from a typed `AircDiscovery`. This is
+    /// the A.2 entry point: callers call `crate::airc::discover()` once,
+    /// hand the result to `from_discovery()`, and the same `AircDiscovery`
+    /// value drives both module construction AND boot-state checks
+    /// (`verify_registration`, persona-hosting gate).
+    ///
+    /// Why this exists alongside `discover_and_construct`: the latter
+    /// does discovery internally and returns `Self`, losing the typed
+    /// failure REASON. A.2's [[no-fallbacks-ever]] fix requires the
+    /// reason survive long enough for the operator to act on it. After
+    /// A.2 lands fully, `discover_and_construct` becomes a thin wrapper
+    /// (call `discover()` then this constructor); for this slice we
+    /// keep both side-by-side and pick whichever the call site needs.
+    pub fn from_discovery(discovery: &crate::airc::AircDiscovery) -> Self {
+        use crate::airc::AircDiscovery;
+        match discovery {
+            AircDiscovery::Healthy {
+                socket,
+                default_room,
+                room_name,
+                peer_id,
+            } => {
+                let from_client = uuid::Uuid::new_v4();
+                Self {
+                    queue_client: Arc::new(CliAircQueueClient::new(TokioAircCommandRunner)),
+                    event_transport: Arc::new(DaemonAircEventTransport::with_identity(
+                        Arc::new(airc_ipc::DaemonClient::new(socket.clone())),
+                        *peer_id,
+                        from_client,
+                    )),
+                    attach_socket_path: Some(socket.clone()),
+                    attach_channel: Some(*default_room),
+                    attach_room_name: Some(room_name.clone()),
+                }
+            }
+            AircDiscovery::Degraded { partial, .. } => {
+                // Partial state — preserve what we DID resolve so the
+                // module degrades gracefully (queue commands still work
+                // even without a live attach).
+                let from_client = uuid::Uuid::new_v4();
+                let peer_id = partial.peer_id.unwrap_or_else(uuid::Uuid::nil);
+                match &partial.socket {
+                    Some(socket) => Self {
+                        queue_client: Arc::new(CliAircQueueClient::new(TokioAircCommandRunner)),
+                        event_transport: Arc::new(DaemonAircEventTransport::with_identity(
+                            Arc::new(airc_ipc::DaemonClient::new(socket.clone())),
+                            peer_id,
+                            from_client,
+                        )),
+                        attach_socket_path: Some(socket.clone()),
+                        attach_channel: partial.default_room,
+                        attach_room_name: partial.room_name.clone(),
+                    },
+                    None => Self::with_queue_client(Arc::new(CliAircQueueClient::new(
+                        TokioAircCommandRunner,
+                    ))),
+                }
+            }
+            AircDiscovery::Unreachable { .. } => Self::with_queue_client(Arc::new(
+                CliAircQueueClient::new(TokioAircCommandRunner),
+            )),
+        }
+    }
+
     pub fn with_daemon_home(airc_home: impl Into<std::path::PathBuf>) -> Self {
         let airc_home = airc_home.into();
         let socket_path = default_socket_path_in(&airc_home);

--- a/src/workers/continuum-core/src/modules/airc.rs
+++ b/src/workers/continuum-core/src/modules/airc.rs
@@ -1,7 +1,6 @@
 //! ServiceModule adapter for Rust-native AIRC commands.
 
 use crate::airc::{
-    discover_airc_socket, discover_default_channel, discover_default_room_name, discover_peer_id,
     spawn_daemon_attach, AircEventTransport, AircQueueClient, AircQueueListRequest,
     AircQueueScanParams, AircRealtimePublishParams, AircRealtimeReplayParams, AircRealtimeStore,
     CliAircQueueClient, DaemonAircEventTransport, InMemoryAircRealtimeStore,
@@ -43,11 +42,11 @@ pub struct AircModule {
 
 impl AircModule {
     /// Construct without discovery — falls back to the deprecated local
-    /// resolver. **Prefer [`AircModule::discover_and_construct`]** for
-    /// any new caller; this `new()` exists only because back-compat
-    /// callers (tests, legacy bootstrap) rely on the sync signature.
-    /// The headless boot path (`ipc::start_server`) is moving to the
-    /// async constructor + canonical socket path.
+    /// resolver. Used by back-compat callers (tests, legacy bootstrap)
+    /// that rely on the sync signature. New callers should call
+    /// `crate::airc::discover()` then `AircModule::from_discovery()`
+    /// so the same typed state drives both module construction AND
+    /// boot-state checks.
     pub fn new() -> Self {
         let airc_home = std::env::current_dir()
             .map(|dir| dir.join(".airc"))
@@ -55,137 +54,34 @@ impl AircModule {
         Self::with_daemon_home(airc_home)
     }
 
-    /// Discover the airc daemon socket via [`discover_airc_socket`] (asks
-    /// `airc ipc-endpoint` per airc#1095; auto-installs airc if missing)
-    /// AND the default channel via [`discover_default_channel`] (parses
-    /// `airc room` for the scope's current room channel — required by
-    /// airc's owner-core router model). On any discovery failure, returns
-    /// a degraded module that responds to `airc/*` commands via the
-    /// in-memory store but performs no daemon attach — so the rest of
-    /// continuum-core boots even when airc is unreachable (e.g. CI
-    /// without network for auto-install) or the scope has no current
-    /// room (fresh install before `airc room <name>`).
-    pub async fn discover_and_construct() -> Self {
-        let socket_path = match discover_airc_socket().await {
-            Ok(path) => {
-                tracing::info!(
-                    socket_path = ?path,
-                    "Discovered airc daemon socket via `airc ipc-endpoint`"
-                );
-                path
-            }
-            Err(error) => {
-                tracing::warn!(
-                    %error,
-                    "airc socket discovery failed — AIRC inbound attach disabled. Realtime \
-                     commands will use in-memory store; queue commands will fail loudly. \
-                     Resolve: install airc manually or set AIRC_DAEMON_SOCKET; see error \
-                     above for the suggested remedy."
-                );
-                return Self::with_queue_client(Arc::new(CliAircQueueClient::new(
-                    TokioAircCommandRunner,
-                )));
-            }
-        };
-
-        let attach_room_name = match discover_default_room_name().await {
-            Ok(name) => {
-                tracing::info!(
-                    room_name = %name,
-                    "Discovered airc default room name via `airc room`"
-                );
-                Some(name)
-            }
-            Err(error) => {
-                tracing::warn!(
-                    %error,
-                    "airc default room-name discovery failed — persona bootstrap will fall \
-                     back to joining by the channel-UUID-as-string, which derives a NEW \
-                     channel that does NOT match the operator's `airc room`. Persona will \
-                     be in the wrong room. Resolve: install/update airc so `airc room` \
-                     prints a `room: <name>` line, or set AIRC_DEFAULT_ROOM_NAME=<name>."
-                );
-                None
-            }
-        };
-
-        let attach_channel = match discover_default_channel().await {
-            Ok(uuid) => {
-                tracing::info!(
-                    channel = %uuid,
-                    "Discovered airc default channel via `airc room`"
-                );
-                Some(RoomId::from_uuid(uuid))
-            }
-            Err(error) => {
-                // Socket reachable but no channel — boot continues with
-                // queue + realtime commands, just no inbound attach. The
-                // common case is "fresh install, scope not yet subscribed
-                // to any room"; the operator runs `airc room <name>` and
-                // restarts to wire up the attach.
-                tracing::warn!(
-                    %error,
-                    "airc default-channel discovery failed — AIRC inbound attach disabled. \
-                     Resolve: run `airc room <name>` to subscribe the scope to a room, \
-                     or set AIRC_DEFAULT_CHANNEL=<uuid> to pin a channel explicitly, then \
-                     restart continuum-core."
-                );
-                None
-            }
-        };
-
-        // Identity discovery: query the daemon's Status response for
-        // this scope's peer_id. Used as `PublishRequest.from_peer` so
-        // continuum's publishes carry real attribution instead of the
-        // anonymous Uuid::nil placeholder. Failure is non-fatal — the
-        // module degrades to anonymous publishes and logs the remedy.
-        let from_peer = match discover_peer_id(&socket_path).await {
-            Ok(peer) => {
-                tracing::info!(
-                    peer_id = %peer,
-                    "Discovered airc scope peer_id via daemon Status"
-                );
-                peer
-            }
-            Err(error) => {
-                tracing::warn!(
-                    %error,
-                    "airc peer_id discovery failed — publishes will use anonymous \
-                     Uuid::nil from_peer (attribution will read as `00000000-…`). \
-                     Resolve: set AIRC_PEER_ID=<uuid> to pin identity, or check that \
-                     the daemon's Status RPC is responding."
-                );
-                uuid::Uuid::nil()
-            }
-        };
-        let from_client = uuid::Uuid::new_v4();
-
-        Self {
-            queue_client: Arc::new(CliAircQueueClient::new(TokioAircCommandRunner)),
-            event_transport: Arc::new(DaemonAircEventTransport::with_identity(
-                Arc::new(airc_ipc::DaemonClient::new(socket_path.clone())),
-                from_peer,
-                from_client,
-            )),
-            attach_socket_path: Some(socket_path),
-            attach_channel,
-            attach_room_name,
-        }
-    }
-
-    /// Construct an `AircModule` from a typed `AircDiscovery`. This is
-    /// the A.2 entry point: callers call `crate::airc::discover()` once,
-    /// hand the result to `from_discovery()`, and the same `AircDiscovery`
-    /// value drives both module construction AND boot-state checks
-    /// (`verify_registration`, persona-hosting gate).
+    /// Construct an `AircModule` from a typed `AircDiscovery`. The
+    /// A.2 entry point: callers call `crate::airc::discover()` once
+    /// and hand the result to `from_discovery()`. The same
+    /// `AircDiscovery` value drives both module construction AND
+    /// boot-state checks (`verify_registration`, persona-hosting
+    /// gate), so the substrate has ONE answer to "what state is AIRC
+    /// in" rather than three drifting representations.
     ///
-    /// Why this exists alongside `discover_and_construct`: the latter
-    /// does discovery internally and returns `Self`, losing the typed
-    /// failure REASON. A.2's [[no-fallbacks-ever]] fix requires the
-    /// reason survive long enough for the operator to act on it. After
-    /// A.2 lands fully, `discover_and_construct` becomes a thin wrapper
-    /// (call `discover()` then this constructor); for this slice we
-    /// keep both side-by-side and pick whichever the call site needs.
+    /// ### [[no-fallbacks-ever]] — Degraded ALWAYS collapses to queue-only
+    ///
+    /// Slice A's review caught the soft-fallback this method initially
+    /// retained: a `Degraded { partial: { socket: Some(stale), peer_id:
+    /// None } }` was constructing a real `DaemonAircEventTransport`
+    /// against the stale socket with `Uuid::nil()` substituted for the
+    /// missing peer_id. The substrate then "looked healthy" while
+    /// every realtime publish either ECONNREFUSEd or went out
+    /// unattributed. That IS the silent-substitution pattern
+    /// [[no-fallbacks-ever]] forbids; the failure mode just shifted
+    /// one frame deeper.
+    ///
+    /// After review: `Degraded` ALWAYS collapses to `with_queue_client`,
+    /// regardless of what `partial` carries. The substrate refuses to
+    /// build a real daemon transport against state discovery has
+    /// declared not Healthy. The `partial` field stays on the
+    /// `AircDiscovery::Degraded` variant for operator observability
+    /// (the boot banner / log output can show what was resolved
+    /// before the failure), but the module construction does not
+    /// pretend.
     pub fn from_discovery(discovery: &crate::airc::AircDiscovery) -> Self {
         use crate::airc::AircDiscovery;
         match discovery {
@@ -208,32 +104,13 @@ impl AircModule {
                     attach_room_name: Some(room_name.clone()),
                 }
             }
-            AircDiscovery::Degraded { partial, .. } => {
-                // Partial state — preserve what we DID resolve so the
-                // module degrades gracefully (queue commands still work
-                // even without a live attach).
-                let from_client = uuid::Uuid::new_v4();
-                let peer_id = partial.peer_id.unwrap_or_else(uuid::Uuid::nil);
-                match &partial.socket {
-                    Some(socket) => Self {
-                        queue_client: Arc::new(CliAircQueueClient::new(TokioAircCommandRunner)),
-                        event_transport: Arc::new(DaemonAircEventTransport::with_identity(
-                            Arc::new(airc_ipc::DaemonClient::new(socket.clone())),
-                            peer_id,
-                            from_client,
-                        )),
-                        attach_socket_path: Some(socket.clone()),
-                        attach_channel: partial.default_room,
-                        attach_room_name: partial.room_name.clone(),
-                    },
-                    None => Self::with_queue_client(Arc::new(CliAircQueueClient::new(
-                        TokioAircCommandRunner,
-                    ))),
-                }
+            // Discovery declared not-Healthy → queue-only, no daemon
+            // transport, no Uuid::nil fallback. Downstream realtime
+            // commands return an actionable error referencing the
+            // discovery reason, not a stale ECONNREFUSED.
+            AircDiscovery::Degraded { .. } | AircDiscovery::Unreachable { .. } => {
+                Self::with_queue_client(Arc::new(CliAircQueueClient::new(TokioAircCommandRunner)))
             }
-            AircDiscovery::Unreachable { .. } => Self::with_queue_client(Arc::new(
-                CliAircQueueClient::new(TokioAircCommandRunner),
-            )),
         }
     }
 
@@ -491,6 +368,186 @@ impl ServiceModule for AircModule {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod from_discovery_tests {
+    //! Lock in the structural invariants of `AircModule::from_discovery`
+    //! that R1+R2 BLOCKed Slice A.2.1's first attempt on.
+    //!
+    //! The R2#1 BLOCK that drove the redesign: `Degraded` constructions
+    //! must NOT build a `DaemonAircEventTransport` against the stale
+    //! socket with a substituted `Uuid::nil()` peer_id. Doctrinally
+    //! [[no-fallbacks-ever]]: the substrate refuses to construct an
+    //! attribution-less daemon transport that would silently send
+    //! ECONNREFUSED-bound or unattributed frames.
+
+    use super::*;
+    use crate::airc::{AircDiscovery, DiscoveryFailure, PartialDiscovery};
+    use airc_core::RoomId;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    /// `Healthy` produces a fully-configured module: socket present,
+    /// channel present, room name present. The substrate has full
+    /// attribution and a live daemon transport.
+    #[test]
+    fn healthy_produces_fully_configured_module() {
+        let socket = PathBuf::from("/tmp/healthy.sock");
+        let room = RoomId::from_uuid(Uuid::new_v4());
+        let peer = Uuid::new_v4();
+        let discovery = AircDiscovery::Healthy {
+            socket: socket.clone(),
+            default_room: room,
+            room_name: "general".into(),
+            peer_id: peer,
+        };
+
+        let module = AircModule::from_discovery(&discovery);
+
+        assert_eq!(
+            module.daemon_socket(),
+            Some(socket.as_path()),
+            "Healthy must preserve the discovered socket"
+        );
+        assert_eq!(
+            module.default_room(),
+            Some(room),
+            "Healthy must preserve the discovered channel"
+        );
+        assert_eq!(
+            module.default_room_name(),
+            Some("general"),
+            "Healthy must preserve the discovered room name"
+        );
+    }
+
+    /// `Degraded` with rich partial state (socket discovered, peer_id
+    /// missing because Status RPC failed) collapses to queue-only.
+    /// This is the explicit fix for R2#1 — the same pre-fix code path
+    /// constructed a real `DaemonAircEventTransport` against the stale
+    /// socket with `Uuid::nil()` substituted for the missing peer_id.
+    /// After the fix the substrate refuses to construct that
+    /// attribution-less transport.
+    #[test]
+    fn degraded_with_partial_socket_collapses_to_queue_only() {
+        let stale_socket = PathBuf::from("/tmp/stale.sock");
+        let discovery = AircDiscovery::Degraded {
+            reason: DiscoveryFailure::StaleSocket(
+                stale_socket.clone(),
+                "ECONNREFUSED".into(),
+            ),
+            partial: PartialDiscovery {
+                socket: Some(stale_socket.clone()),
+                peer_id: None,
+                default_room: None,
+                room_name: None,
+            },
+        };
+
+        let module = AircModule::from_discovery(&discovery);
+
+        assert_eq!(
+            module.daemon_socket(),
+            None,
+            "[[no-fallbacks-ever]] — Degraded MUST NOT expose a daemon \
+             socket; that's the R2#1 stale-socket bug"
+        );
+        assert_eq!(module.default_room(), None);
+        assert_eq!(module.default_room_name(), None);
+    }
+
+    /// `Degraded` with full partial state (everything discovered EXCEPT
+    /// the failed step) ALSO collapses to queue-only. Even if discovery
+    /// got far enough to know the room name, once one sub-step failed
+    /// the substrate refuses to build a daemon transport. Discovery's
+    /// "not Healthy" verdict is the gate.
+    #[test]
+    fn degraded_with_full_partial_state_still_collapses_to_queue_only() {
+        let socket = PathBuf::from("/tmp/maybe.sock");
+        let room = RoomId::from_uuid(Uuid::new_v4());
+        let discovery = AircDiscovery::Degraded {
+            reason: DiscoveryFailure::NoDefaultRoom,
+            partial: PartialDiscovery {
+                socket: Some(socket),
+                peer_id: Some(Uuid::new_v4()),
+                default_room: Some(room),
+                room_name: Some("partial".into()),
+            },
+        };
+
+        let module = AircModule::from_discovery(&discovery);
+
+        assert_eq!(
+            module.daemon_socket(),
+            None,
+            "Degraded verdict is binding even when partial is rich — \
+             the substrate trusts discovery's classification"
+        );
+        assert_eq!(module.default_room(), None);
+        assert_eq!(module.default_room_name(), None);
+    }
+
+    /// `Unreachable` collapses to queue-only. The substrate stays alive
+    /// for non-AIRC commands; `airc/*` realtime commands return
+    /// actionable errors based on `discovery.reason()`.
+    #[test]
+    fn unreachable_collapses_to_queue_only() {
+        let discovery = AircDiscovery::Unreachable {
+            reason: DiscoveryFailure::AutoInstallDisabled,
+        };
+
+        let module = AircModule::from_discovery(&discovery);
+
+        assert_eq!(module.daemon_socket(), None);
+        assert_eq!(module.default_room(), None);
+        assert_eq!(module.default_room_name(), None);
+    }
+
+    /// Cross-variant invariant: `from_discovery` exposes a `daemon_socket()`
+    /// ONLY for `Healthy`. Iterate every variant; only Healthy may
+    /// return Some. This is the R2#1 fix made into a structural test —
+    /// any future refactor that adds a fourth code path returning a
+    /// real socket from a non-Healthy state will fail this test.
+    #[test]
+    fn only_healthy_exposes_a_daemon_socket() {
+        let cases = [
+            (
+                AircDiscovery::Healthy {
+                    socket: PathBuf::from("/tmp/h.sock"),
+                    default_room: RoomId::from_uuid(Uuid::new_v4()),
+                    room_name: "general".into(),
+                    peer_id: Uuid::new_v4(),
+                },
+                true,
+            ),
+            (
+                AircDiscovery::Degraded {
+                    reason: DiscoveryFailure::NoDefaultRoom,
+                    partial: PartialDiscovery {
+                        socket: Some(PathBuf::from("/tmp/d.sock")),
+                        ..Default::default()
+                    },
+                },
+                false,
+            ),
+            (
+                AircDiscovery::Unreachable {
+                    reason: DiscoveryFailure::EmptyPath,
+                },
+                false,
+            ),
+        ];
+        for (discovery, expect_socket_some) in cases {
+            let module = AircModule::from_discovery(&discovery);
+            assert_eq!(
+                module.daemon_socket().is_some(),
+                expect_socket_some,
+                "daemon_socket() polarity wrong for {:?}",
+                discovery.kind()
+            );
+        }
     }
 }
 

--- a/src/workers/continuum-core/src/runtime/boot_mode.rs
+++ b/src/workers/continuum-core/src/runtime/boot_mode.rs
@@ -1,0 +1,239 @@
+//! `BootMode` — explicit operator-intent flag for substrate boot.
+//!
+//! ## Why
+//!
+//! Slice A (PR #1527) used a heuristic: "if persona seeds exist on
+//! disk, assume the operator wants persona hosting; if not, assume
+//! they want inference-only." Reviewer R2 BLOCKed on
+//! [[no-fallbacks-ever]]: the operator NEVER stated they wanted
+//! inference-only mode; the substrate inferred it from a directory
+//! listing. That's silent substitution of a degraded capability set.
+//!
+//! A.2 replaces the heuristic with an explicit flag. The operator
+//! states intent via `--mode=<full-citizen|inference-only|fail-fast>`
+//! (default `full-citizen`). The substrate never guesses.
+//!
+//! ## The three modes
+//!
+//! - **FullCitizen** (default) — the substrate is expected to host
+//!   personas + run inference + everything else. AIRC must be
+//!   `Healthy` AND ≥1 persona seed must exist. Either missing →
+//!   refuse boot with the actionable repair message. This is the
+//!   common case for an operator running `continuum-core-server`
+//!   on their machine.
+//!
+//! - **InferenceOnly** — the operator explicitly wants the substrate
+//!   to come up WITHOUT persona hosting (e.g. a forge worker that
+//!   only runs `inference/`, `embedding/`, `forge/`, `cargo/`,
+//!   `code/`; a sandboxed CI runner; a model evaluation harness).
+//!   AIRC may be degraded; persona seeds may be absent. No
+//!   `PersonaInstanceManagerModule` is registered (or required).
+//!
+//! - **FailFast** — strictest mode. Refuses to boot if ANY
+//!   substrate capability is unavailable: AIRC unhealthy, ORT
+//!   missing, model files missing. Used by CI smoke tests and
+//!   production rollouts that want loud failure over silent
+//!   degradation.
+//!
+//! ## Threaded through `Context`
+//!
+//! Like `AircDiscovery`, `BootMode` is added to the `Context` trait
+//! (`fn boot_mode(&self) -> BootMode`) so every actor created
+//! during this boot carries the mode that was true at creation.
+//! Future B' code paths can dispatch on mode without re-reading
+//! argv.
+
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootMode {
+    /// Default. Substrate is expected to host personas + run
+    /// inference + everything else. Requires AIRC `Healthy` AND
+    /// ≥1 persona seed; refuses boot otherwise.
+    FullCitizen,
+    /// Inference / forge / code only. No persona hosting, no AIRC
+    /// requirement, no seed requirement. Operator opted in
+    /// explicitly.
+    InferenceOnly,
+    /// Strictest. Refuses any degradation, including missing
+    /// libonnxruntime or model files. Used for CI smoke + prod.
+    FailFast,
+}
+
+impl BootMode {
+    /// Human-readable label for log lines + boot banner.
+    pub fn label(&self) -> &'static str {
+        match self {
+            BootMode::FullCitizen => "full-citizen",
+            BootMode::InferenceOnly => "inference-only",
+            BootMode::FailFast => "fail-fast",
+        }
+    }
+
+    /// `true` iff persona hosting MUST be available in this mode.
+    /// Used by `verify_registration` to compute the required-module
+    /// set and by `start_server` to decide whether seeds-absent
+    /// is a hard error.
+    pub fn requires_persona_hosting(&self) -> bool {
+        matches!(self, BootMode::FullCitizen | BootMode::FailFast)
+    }
+
+    /// `true` iff voice subsystem MUST be available. Only `FailFast`
+    /// raises this bar — `FullCitizen` is OK to boot without ORT
+    /// (operator gets a `🔇 Voice subsystem: unavailable` line at
+    /// the boot banner, can install libonnxruntime later).
+    pub fn requires_voice(&self) -> bool {
+        matches!(self, BootMode::FailFast)
+    }
+}
+
+impl Default for BootMode {
+    fn default() -> Self {
+        BootMode::FullCitizen
+    }
+}
+
+impl FromStr for BootMode {
+    type Err = BootModeParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "full-citizen" | "full" | "citizen" => Ok(BootMode::FullCitizen),
+            "inference-only" | "inference" => Ok(BootMode::InferenceOnly),
+            "fail-fast" | "strict" => Ok(BootMode::FailFast),
+            other => Err(BootModeParseError(other.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "unknown --mode={0:?} — valid: full-citizen (default), inference-only, fail-fast"
+)]
+pub struct BootModeParseError(pub String);
+
+/// Parse `--mode=<value>` out of an argv vector. Removes the
+/// matched argument(s) so the caller's positional parsing (e.g.
+/// the socket path) sees a clean slice. `--mode VALUE` (space form)
+/// and `--mode=VALUE` (equals form) both supported.
+///
+/// Returns the parsed `BootMode` (default if absent) + a vector
+/// of remaining args.
+pub fn extract_boot_mode(args: Vec<String>) -> Result<(BootMode, Vec<String>), BootModeParseError> {
+    let mut mode = BootMode::default();
+    let mut rest = Vec::with_capacity(args.len());
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        if let Some(value) = arg.strip_prefix("--mode=") {
+            mode = value.parse()?;
+            continue;
+        }
+        if arg == "--mode" {
+            let value = iter.next().ok_or_else(|| {
+                BootModeParseError("--mode requires a value (e.g. --mode=full-citizen)".into())
+            })?;
+            mode = value.parse()?;
+            continue;
+        }
+        rest.push(arg);
+    }
+    Ok((mode, rest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_full_citizen() {
+        assert_eq!(BootMode::default(), BootMode::FullCitizen);
+    }
+
+    #[test]
+    fn full_citizen_requires_persona_hosting() {
+        assert!(BootMode::FullCitizen.requires_persona_hosting());
+        assert!(!BootMode::FullCitizen.requires_voice());
+    }
+
+    #[test]
+    fn inference_only_does_not_require_persona_hosting() {
+        assert!(!BootMode::InferenceOnly.requires_persona_hosting());
+        assert!(!BootMode::InferenceOnly.requires_voice());
+    }
+
+    #[test]
+    fn fail_fast_requires_everything() {
+        assert!(BootMode::FailFast.requires_persona_hosting());
+        assert!(BootMode::FailFast.requires_voice());
+    }
+
+    #[test]
+    fn parse_canonical_forms() {
+        assert_eq!("full-citizen".parse::<BootMode>().unwrap(), BootMode::FullCitizen);
+        assert_eq!("inference-only".parse::<BootMode>().unwrap(), BootMode::InferenceOnly);
+        assert_eq!("fail-fast".parse::<BootMode>().unwrap(), BootMode::FailFast);
+    }
+
+    #[test]
+    fn parse_aliases() {
+        assert_eq!("full".parse::<BootMode>().unwrap(), BootMode::FullCitizen);
+        assert_eq!("citizen".parse::<BootMode>().unwrap(), BootMode::FullCitizen);
+        assert_eq!("inference".parse::<BootMode>().unwrap(), BootMode::InferenceOnly);
+        assert_eq!("strict".parse::<BootMode>().unwrap(), BootMode::FailFast);
+    }
+
+    #[test]
+    fn parse_is_case_insensitive_and_trims() {
+        assert_eq!("  Full-Citizen  ".parse::<BootMode>().unwrap(), BootMode::FullCitizen);
+        assert_eq!("INFERENCE-ONLY".parse::<BootMode>().unwrap(), BootMode::InferenceOnly);
+    }
+
+    #[test]
+    fn parse_unknown_errors_with_actionable_message() {
+        let err = "persona-host".parse::<BootMode>().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("persona-host"));
+        assert!(msg.contains("full-citizen"));
+        assert!(msg.contains("inference-only"));
+        assert!(msg.contains("fail-fast"));
+    }
+
+    #[test]
+    fn extract_boot_mode_equals_form() {
+        let args = vec![
+            "continuum-core-server".into(),
+            "--mode=inference-only".into(),
+            "/tmp/x.sock".into(),
+        ];
+        let (mode, rest) = extract_boot_mode(args).unwrap();
+        assert_eq!(mode, BootMode::InferenceOnly);
+        assert_eq!(rest, vec!["continuum-core-server", "/tmp/x.sock"]);
+    }
+
+    #[test]
+    fn extract_boot_mode_space_form() {
+        let args = vec![
+            "continuum-core-server".into(),
+            "--mode".into(),
+            "fail-fast".into(),
+            "/tmp/x.sock".into(),
+        ];
+        let (mode, rest) = extract_boot_mode(args).unwrap();
+        assert_eq!(mode, BootMode::FailFast);
+        assert_eq!(rest, vec!["continuum-core-server", "/tmp/x.sock"]);
+    }
+
+    #[test]
+    fn extract_boot_mode_absent_returns_default() {
+        let args = vec!["continuum-core-server".into(), "/tmp/x.sock".into()];
+        let (mode, rest) = extract_boot_mode(args).unwrap();
+        assert_eq!(mode, BootMode::FullCitizen);
+        assert_eq!(rest, vec!["continuum-core-server", "/tmp/x.sock"]);
+    }
+
+    #[test]
+    fn extract_boot_mode_dangling_space_form_errors() {
+        let args = vec!["continuum-core-server".into(), "--mode".into()];
+        let err = extract_boot_mode(args).unwrap_err();
+        assert!(format!("{err}").contains("requires a value"));
+    }
+}

--- a/src/workers/continuum-core/src/runtime/mod.rs
+++ b/src/workers/continuum-core/src/runtime/mod.rs
@@ -26,6 +26,7 @@ use std::sync::OnceLock;
 
 pub mod airc_interceptor;
 pub mod artifact_handle;
+pub mod boot_mode;
 pub mod brain_region;
 pub mod cell_shapes;
 pub mod command_envelope;
@@ -45,6 +46,8 @@ pub mod registry;
 pub mod runtime;
 pub mod service_module;
 pub mod shared_compute;
+
+pub use boot_mode::{extract_boot_mode, BootMode, BootModeParseError};
 
 pub use artifact_handle::{ArtifactKey, ArtifactSelector, Cadence};
 pub use brain_region::{

--- a/src/workers/continuum-core/src/runtime/runtime.rs
+++ b/src/workers/continuum-core/src/runtime/runtime.rs
@@ -359,13 +359,14 @@ impl Runtime {
     /// state and computes the expected set at call time, so the
     /// contradiction is structurally impossible.
     ///
-    /// The set of ALL modules the substrate knows about is
-    /// `ALL_KNOWN_MODULES` — kept current via the
-    /// `expected_modules_snapshot` integration test. Drift in
-    /// registrations surfaces as a snapshot diff in CI, replacing
-    /// the silent "Unexpected module registered" WARN that the
-    /// Slice A list-rewrite traded one drift for another to fix
-    /// (R2#3 + R3#3 BLOCK).
+    /// The substrate's ONE source of truth for what modules exist is
+    /// the `MODULES: &[(&str, ModuleCategory)]` slice — one entry per
+    /// registered module, tagged with its category. `required_modules`
+    /// filters this list at call time; there is no parallel list to
+    /// drift against. The `expected_modules_snapshot` integration test
+    /// (A.2.2) cross-checks `MODULES` against actual registrations at
+    /// boot. R2#3 + R3#3 BLOCK from Slice A's review is structurally
+    /// closed by the single-source-of-truth design.
     pub fn verify_registration(
         &self,
         discovery: &AircDiscovery,
@@ -373,11 +374,12 @@ impl Runtime {
     ) -> Result<(), String> {
         let registered: Vec<String> = self.registry.module_names();
         let required = required_modules(discovery, mode);
-        let mut missing: Vec<&str> = Vec::new();
+        let required_count = required.len();
+        let mut missing: Vec<&'static str> = Vec::new();
 
-        for expected in required {
-            if !registered.iter().any(|r| r == *expected) {
-                missing.push(expected);
+        for expected in &required {
+            if !registered.iter().any(|r| r == expected) {
+                missing.push(*expected);
             }
         }
 
@@ -393,13 +395,13 @@ impl Runtime {
             );
             error!(
                 "Expected {} modules, found {}",
-                required.len(),
+                required_count,
                 registered.len()
             );
             error!(
-                "Add missing module registrations in ipc/mod.rs (the registration site \
-                 emits the module name; ALL_KNOWN_MODULES + required_modules() must \
-                 mirror it)"
+                "Add missing module registrations in ipc/mod.rs (the registration \
+                 site emits the module name; MODULES with its category tag is the \
+                 single source of truth — required_modules() filters it)"
             );
             return Err(format!(
                 "Module registration incomplete for (discovery={}, mode={}): \
@@ -412,7 +414,7 @@ impl Runtime {
 
         info!(
             "✅ All {} required modules registered (discovery={}, mode={})",
-            required.len(),
+            required_count,
             discovery.kind(),
             mode.label()
         );
@@ -420,149 +422,131 @@ impl Runtime {
     }
 }
 
-/// Modules that EVERY boot needs regardless of discovery state or
-/// mode — infrastructure, resource governance, transport, AI
-/// dispatch. If any of these are missing, the substrate cannot
-/// serve commands at all.
-pub const MODULES_CORE: &[&str] = &[
-    // Infrastructure / health
-    "health",
-    "auth",
-    "system",
-    "events",
-    "logger",
-    "runtime",
-    "mcp",
-    "data",
-    // Resource governance
-    "gpu",
-    "resource-broker",
-    "pressure-broker",
-    // AI / inference (always present — required by every mode)
-    "inference",
-    "inference-llm",
-    "ai_provider",
-    "embedding",
-    "search",
-    "tool-parsing",
-    "vision",
-    "models",
-    "memory",
-    "rag",
-    // Persona substrate that's always built (cognition + allocator
-    // work without an AIRC daemon; persona/instances/* requires AIRC
-    // but `cognition/*` doesn't)
-    "cognition",
-    "channel",
-    "persona_allocator",
-    "agent",
-    // Forge / sentinel / plasticity / training
-    "forge",
-    "sentinel",
-    "plasticity",
-    "dataset",
-    "vdd",
-    "cargo",
-    "code",
-    // Substrate transports
-    "airc",
-    "grid",
-    // Live presence — present in this binary today; Slice B' splits
-    // these out into the renderer + voice sidecars
-    "live",
-    "avatar",
-];
-
-/// Modules that REQUIRE AIRC `Healthy` to construct. The substrate
-/// only registers these when discovery succeeded with all four
-/// sub-steps (socket + room + channel + Status RPC liveness).
-pub const MODULES_PERSONA_HOSTING: &[&str] = &[
-    "persona_instance_manager",
-    "persona-rag-inspect",
-];
-
-/// Compute the required-module set for a given `(discovery, mode)`.
+/// Category of a substrate module — load-bearing for `verify_registration`'s
+/// conditional dispatch on `(AircDiscovery, BootMode)`.
 ///
-/// Doctrine: in `InferenceOnly` mode the substrate MUST come up
-/// without persona-hosting modules — that's what the operator
-/// explicitly opted into via `--mode=inference-only`. In
-/// `FullCitizen` / `FailFast` mode, persona-hosting is required
-/// IFF discovery is `Healthy`. If discovery is degraded, the
-/// substrate refuses boot BEFORE reaching `verify_registration`
-/// (see `ipc/mod.rs::start_server`) — so this function never sees
-/// `(FullCitizen, Degraded)` in practice, but it's structurally
-/// safe (returns the same set as `(FullCitizen, Healthy)` so a
-/// stray invocation produces a coherent error message).
-pub fn required_modules(discovery: &AircDiscovery, mode: BootMode) -> &'static [&'static str] {
-    let needs_persona_hosting = mode.requires_persona_hosting() && discovery.can_host_personas();
-    if needs_persona_hosting {
-        // Concatenation at compile time isn't possible without `const`
-        // tricks, so we use a static once-init via the module-level
-        // join below.
-        ALL_KNOWN_MODULES
-    } else {
-        MODULES_CORE
-    }
+/// Per the compression principle ([[host-the-seemingly-impossible]]): one
+/// list of `(name, category)` pairs replaces what was originally going to
+/// be three drifting constants. The set returned by `required_modules`
+/// is computed by filtering this single list — there is no parallel
+/// list to drift against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModuleCategory {
+    /// Required by every boot regardless of discovery state or mode.
+    /// Infrastructure, resource governance, transport, AI dispatch.
+    /// Missing → substrate cannot serve commands at all.
+    Core,
+    /// Requires AIRC `Healthy`. Only registered when discovery
+    /// succeeded across all four sub-steps (socket + room + channel +
+    /// Status RPC liveness) AND the boot mode requires persona
+    /// hosting. `--mode=inference-only` operators do not register
+    /// these.
+    PersonaHosting,
 }
 
-/// The flat union of `MODULES_CORE` + `MODULES_PERSONA_HOSTING`.
-/// Used by the `expected_modules_snapshot` integration test as
-/// the snapshot baseline — drift in any registration site shows
-/// up as a snapshot diff in CI, replacing the silent "Unexpected
-/// module registered" WARN that drifted in Slice A.
+/// The substrate's ONE source of truth for "what modules exist + what
+/// category each is in." `required_modules(&discovery, mode)` filters
+/// this list; `ALL_KNOWN_MODULES()` derives the snapshot baseline from
+/// it. There is no second list to drift against — the compression
+/// principle made structural.
 ///
 /// When you add a new `runtime.register(NewModule)` call site in
-/// `ipc/mod.rs`, add the module name here AND to the conditional
-/// set (`MODULES_CORE` or `MODULES_PERSONA_HOSTING`) it belongs
-/// to. The snapshot test will fail in CI if you forget either side.
-pub const ALL_KNOWN_MODULES: &[&str] = &[
+/// `ipc/mod.rs`, add one row here with its category. The drift catcher
+/// `category_dispatch_consistency` verifies every row appears in the
+/// expected required set for at least one `(discovery, mode)` pair —
+/// so a row that's never reachable surfaces in CI. The
+/// `expected_modules_snapshot` integration test (A.2.2) cross-checks
+/// this list against actual registrations at boot.
+pub const MODULES: &[(&str, ModuleCategory)] = &[
     // Infrastructure / health
-    "health",
-    "auth",
-    "system",
-    "events",
-    "logger",
-    "runtime",
-    "mcp",
-    "data",
+    ("health", ModuleCategory::Core),
+    ("auth", ModuleCategory::Core),
+    ("system", ModuleCategory::Core),
+    ("events", ModuleCategory::Core),
+    ("logger", ModuleCategory::Core),
+    ("runtime", ModuleCategory::Core),
+    ("mcp", ModuleCategory::Core),
+    ("data", ModuleCategory::Core),
     // Resource governance
-    "gpu",
-    "resource-broker",
-    "pressure-broker",
+    ("gpu", ModuleCategory::Core),
+    ("resource-broker", ModuleCategory::Core),
+    ("pressure-broker", ModuleCategory::Core),
     // AI / inference
-    "inference",
-    "inference-llm",
-    "ai_provider",
-    "embedding",
-    "search",
-    "tool-parsing",
-    "vision",
-    "models",
-    "memory",
-    "rag",
-    // Persona substrate (always-built)
-    "cognition",
-    "channel",
-    "persona_allocator",
-    "agent",
-    // Persona substrate (AIRC-Healthy-conditional)
-    "persona_instance_manager",
-    "persona-rag-inspect",
+    ("inference", ModuleCategory::Core),
+    ("inference-llm", ModuleCategory::Core),
+    ("ai_provider", ModuleCategory::Core),
+    ("embedding", ModuleCategory::Core),
+    ("search", ModuleCategory::Core),
+    ("tool-parsing", ModuleCategory::Core),
+    ("vision", ModuleCategory::Core),
+    ("models", ModuleCategory::Core),
+    ("memory", ModuleCategory::Core),
+    ("rag", ModuleCategory::Core),
+    // Persona substrate (always-built — cognition/allocator work
+    // without an AIRC daemon)
+    ("cognition", ModuleCategory::Core),
+    ("channel", ModuleCategory::Core),
+    ("persona_allocator", ModuleCategory::Core),
+    ("agent", ModuleCategory::Core),
+    // Persona substrate (AIRC-Healthy-conditional — registers only
+    // when discovery succeeded across all four sub-steps)
+    ("persona_instance_manager", ModuleCategory::PersonaHosting),
+    ("persona-rag-inspect", ModuleCategory::PersonaHosting),
     // Forge / sentinel / plasticity / training
-    "forge",
-    "sentinel",
-    "plasticity",
-    "dataset",
-    "vdd",
-    "cargo",
-    "code",
+    ("forge", ModuleCategory::Core),
+    ("sentinel", ModuleCategory::Core),
+    ("plasticity", ModuleCategory::Core),
+    ("dataset", ModuleCategory::Core),
+    ("vdd", ModuleCategory::Core),
+    ("cargo", ModuleCategory::Core),
+    ("code", ModuleCategory::Core),
     // Substrate transports
-    "airc",
-    "grid",
-    // Live presence
-    "live",
-    "avatar",
+    ("airc", ModuleCategory::Core),
+    ("grid", ModuleCategory::Core),
+    // Live presence — Slice B' splits these into renderer + voice
+    // sidecars
+    ("live", ModuleCategory::Core),
+    ("avatar", ModuleCategory::Core),
 ];
+
+/// Compute the required-module set for a given `(discovery, mode)` —
+/// derived by filtering `MODULES` rather than maintained as a parallel
+/// list.
+///
+/// `InferenceOnly` mode → only `Core` modules (operator opted out of
+/// persona hosting).
+/// `FullCitizen` / `FailFast` mode + `Healthy` AIRC → `Core` +
+/// `PersonaHosting`.
+/// `FullCitizen` / `FailFast` mode + degraded AIRC → the substrate
+/// refuses boot BEFORE reaching `verify_registration` (see
+/// `ipc/mod.rs::start_server`), so this function never sees that
+/// pair in practice. Defensively, it returns the same set as
+/// `(InferenceOnly, *)` so a stray invocation produces a coherent
+/// error message rather than complaining about modules that cannot
+/// be registered.
+pub fn required_modules(discovery: &AircDiscovery, mode: BootMode) -> Vec<&'static str> {
+    let needs_persona_hosting = mode.requires_persona_hosting() && discovery.can_host_personas();
+    MODULES
+        .iter()
+        .filter(|(_, cat)| match cat {
+            ModuleCategory::Core => true,
+            ModuleCategory::PersonaHosting => needs_persona_hosting,
+        })
+        .map(|(name, _)| *name)
+        .collect()
+}
+
+/// Every module name the substrate knows about — derived from
+/// `MODULES`, not a parallel list. Used by the
+/// `expected_modules_snapshot` integration test (A.2.2) as the
+/// snapshot baseline.
+pub fn all_known_modules() -> Vec<&'static str> {
+    MODULES.iter().map(|(name, _)| *name).collect()
+}
+
+// MODULES is the substrate's ONE source of truth — `required_modules`
+// and `all_known_modules` both derive from it. No parallel list to
+// drift against.
 
 #[cfg(test)]
 mod conditional_modules_tests {
@@ -634,62 +618,141 @@ mod conditional_modules_tests {
         assert!(!req.contains(&"persona-rag-inspect"));
     }
 
-    /// Drift catcher: `ALL_KNOWN_MODULES` MUST be exactly
-    /// `MODULES_CORE + MODULES_PERSONA_HOSTING`. R2#3 + R3#3 blocked
-    /// Slice A on hand-maintained manifest drift — this test makes
-    /// drift between the three constants mechanically impossible
-    /// to ship. (The next layer of rigging, an integration test
-    /// that snapshots `runtime.registry().module_names()` against
-    /// `ALL_KNOWN_MODULES`, is A.2.2's scope.)
+    /// Drift catcher: every entry in `MODULES` MUST have a unique
+    /// name. Duplicate registrations would make the conditional
+    /// dispatch ambiguous (which category wins?).
     #[test]
-    fn all_known_modules_is_union_of_subsets() {
-        let mut union: Vec<&str> = MODULES_CORE.iter().copied().collect();
-        union.extend(MODULES_PERSONA_HOSTING.iter().copied());
-        union.sort();
-        union.dedup();
-        let mut all: Vec<&str> = ALL_KNOWN_MODULES.iter().copied().collect();
-        all.sort();
-        all.dedup();
+    fn modules_list_has_unique_names() {
+        let mut names: Vec<&str> = MODULES.iter().map(|(n, _)| *n).collect();
+        let original_len = names.len();
+        names.sort();
+        names.dedup();
         assert_eq!(
-            union, all,
-            "ALL_KNOWN_MODULES must equal MODULES_CORE ∪ MODULES_PERSONA_HOSTING. \
-             Drift means a registration site adds a module to one constant but \
-             forgets the others — exactly the [[every-error-is-an-opportunity-to-battle-harden]] \
-             regression class A.2 closes."
+            names.len(),
+            original_len,
+            "MODULES contains duplicate module names — every name must appear at most once"
         );
     }
 
-    /// MODULES_CORE and MODULES_PERSONA_HOSTING must be DISJOINT —
-    /// a module is either always-built or conditional, never both
-    /// (the conditional dispatch would be ambiguous).
+    /// `required_modules` returns the correct size for each
+    /// `(discovery, mode)` cell.
+    ///
+    /// `Healthy + FullCitizen` should include both Core and
+    /// PersonaHosting categories. Every other cell should include
+    /// only Core. This is the structural test the convergent
+    /// review demanded as a R2#3+R3#3 closer: the dispatch is
+    /// derived from the single source of truth, so any change to
+    /// the category of a row immediately changes what this test
+    /// expects to see, not a parallel list that drifts.
     #[test]
-    fn core_and_persona_hosting_are_disjoint() {
-        for name in MODULES_PERSONA_HOSTING {
-            assert!(
-                !MODULES_CORE.contains(name),
-                "module {name:?} appears in both MODULES_CORE and \
-                 MODULES_PERSONA_HOSTING — pick one"
-            );
+    fn required_modules_size_matches_category_dispatch() {
+        let core_count = MODULES
+            .iter()
+            .filter(|(_, c)| matches!(c, ModuleCategory::Core))
+            .count();
+        let hosting_count = MODULES
+            .iter()
+            .filter(|(_, c)| matches!(c, ModuleCategory::PersonaHosting))
+            .count();
+        let all_count = core_count + hosting_count;
+
+        assert_eq!(
+            required_modules(&healthy(), BootMode::FullCitizen).len(),
+            all_count,
+            "FullCitizen + Healthy must include both Core and PersonaHosting"
+        );
+        assert_eq!(
+            required_modules(&healthy(), BootMode::InferenceOnly).len(),
+            core_count,
+            "InferenceOnly must include only Core"
+        );
+        assert_eq!(
+            required_modules(&degraded(), BootMode::FullCitizen).len(),
+            core_count,
+            "Degraded must include only Core regardless of mode"
+        );
+        assert_eq!(
+            required_modules(&degraded(), BootMode::InferenceOnly).len(),
+            core_count,
+        );
+    }
+
+    /// `all_known_modules()` must match the names projected from
+    /// `MODULES`. Derivation correctness — if the projection ever
+    /// diverges (e.g. someone adds a filter the const doesn't have),
+    /// this catches it.
+    #[test]
+    fn all_known_modules_derives_from_modules() {
+        let expected: Vec<&str> = MODULES.iter().map(|(n, _)| *n).collect();
+        assert_eq!(all_known_modules(), expected);
+    }
+
+    /// Every Core module must be present in EVERY required-modules
+    /// result. Catches any future regression where someone
+    /// accidentally categorizes a load-bearing infrastructure
+    /// module as `PersonaHosting`.
+    #[test]
+    fn every_core_module_appears_in_every_required_set() {
+        let cells = [
+            (healthy(), BootMode::FullCitizen),
+            (healthy(), BootMode::InferenceOnly),
+            (healthy(), BootMode::FailFast),
+            (degraded(), BootMode::FullCitizen),
+            (degraded(), BootMode::InferenceOnly),
+            (degraded(), BootMode::FailFast),
+        ];
+        for (discovery, mode) in cells {
+            let req = required_modules(&discovery, mode);
+            for (name, cat) in MODULES {
+                if matches!(cat, ModuleCategory::Core) {
+                    assert!(
+                        req.contains(name),
+                        "Core module {name:?} missing from required set for \
+                         (discovery={}, mode={})",
+                        discovery.kind(),
+                        mode.label()
+                    );
+                }
+            }
         }
     }
 
-    /// `required_modules` MUST always return a slice whose length is
-    /// either `MODULES_CORE.len()` (no persona hosting) or
-    /// `ALL_KNOWN_MODULES.len()` (with persona hosting). No partial
-    /// sets sneak in via the conditional dispatch.
+    /// PersonaHosting modules must appear ONLY when the dispatch
+    /// is `(Healthy, requires_persona_hosting)`. The R1#1 BLOCK
+    /// regression — having them in the required set under
+    /// `--mode=inference-only` — is structurally impossible to
+    /// reintroduce because this test pins both polarities.
     #[test]
-    fn required_modules_returns_exactly_one_of_two_sets() {
-        let healthy_full = required_modules(&healthy(), BootMode::FullCitizen);
-        assert_eq!(healthy_full.len(), ALL_KNOWN_MODULES.len());
+    fn persona_hosting_modules_appear_only_when_dispatched() {
+        let host_modules: Vec<&str> = MODULES
+            .iter()
+            .filter(|(_, c)| matches!(c, ModuleCategory::PersonaHosting))
+            .map(|(n, _)| *n)
+            .collect();
 
-        let healthy_inf = required_modules(&healthy(), BootMode::InferenceOnly);
-        assert_eq!(healthy_inf.len(), MODULES_CORE.len());
+        for name in &host_modules {
+            assert!(required_modules(&healthy(), BootMode::FullCitizen).contains(name));
+            assert!(required_modules(&healthy(), BootMode::FailFast).contains(name));
+        }
 
-        let degraded_full = required_modules(&degraded(), BootMode::FullCitizen);
-        assert_eq!(degraded_full.len(), MODULES_CORE.len());
-
-        let degraded_inf = required_modules(&degraded(), BootMode::InferenceOnly);
-        assert_eq!(degraded_inf.len(), MODULES_CORE.len());
+        let must_not_contain = [
+            (healthy(), BootMode::InferenceOnly),
+            (degraded(), BootMode::FullCitizen),
+            (degraded(), BootMode::InferenceOnly),
+            (degraded(), BootMode::FailFast),
+        ];
+        for (discovery, mode) in must_not_contain {
+            let req = required_modules(&discovery, mode);
+            for name in &host_modules {
+                assert!(
+                    !req.contains(name),
+                    "PersonaHosting module {name:?} unexpectedly required for \
+                     (discovery={}, mode={}) — this would reintroduce R1#1",
+                    discovery.kind(),
+                    mode.label()
+                );
+            }
+        }
     }
 }
 

--- a/src/workers/continuum-core/src/runtime/runtime.rs
+++ b/src/workers/continuum-core/src/runtime/runtime.rs
@@ -6,44 +6,23 @@
 //! This is the top-level coordinator — like CBAR's RenderingEngine
 //! that owns the CBP_Analyzer pipeline and orchestrates frame flow.
 
+use super::boot_mode::BootMode;
 use super::message_bus::MessageBus;
 use super::module_context::ModuleContext;
 use super::registry::ModuleRegistry;
 use super::service_module::{CommandResult, ServiceModule};
 use super::shared_compute::SharedCompute;
+use crate::airc::AircDiscovery;
 use dashmap::DashMap;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
-/// Expected modules that MUST be registered for a complete runtime.
-/// Adding a module here ensures it cannot be forgotten during registration.
-/// The server will fail to start if any expected module is missing.
-pub const EXPECTED_MODULES: &[&str] = &[
-    "gpu",               // Phase 0: GPU memory management
-    "health",            // Phase 1: stateless health checks
-    "cognition",         // Phase 2: persona cognition engines
-    "channel",           // Phase 2: persona channel registries
-    "models",            // Phase 3: async model discovery
-    "memory",            // Phase 3: persona memory manager
-    "rag",               // Phase 3: batched RAG composition
-    "live",              // Phase 3: live experience (voice, video, transport)
-    "code",              // Phase 3: file engines, shell sessions
-    "data",              // Phase 4: database ORM operations
-    "logger",            // Phase 4a: structured logging
-    "search",            // Phase 4b: BM25, TF-IDF, vector search
-    "embedding",         // Phase 4c: fastembed vector generation
-    "grid",              // Grid transport: inter-node routing (Tailscale, Reticulum)
-    "runtime",           // RuntimeModule: metrics and control
-    "mcp",               // MCP server: dynamic tool discovery
-    "system",            // System resources: CPU, memory, process monitoring
-    "avatar",            // Avatar snapshots: Bevy 3D renders → PNG
-    "dataset",           // Dataset import/management for Academy training
-    "persona_allocator", // Hardware-aware persona allocation decisions
-    "inference-llm",     // Phase 5: local LLM generation (MODULE-CATALOG §II)
-    "vdd",               // Lane C PR-3: VDD report from structured artifacts
-];
+// Module manifest lives in the `module_manifest` mod below
+// (MODULES_CORE / MODULES_PERSONA_HOSTING / ALL_KNOWN_MODULES /
+// required_modules) so all module-state truth is in one place
+// and the snapshot test has one anchor point.
 
 pub struct Runtime {
     /// Registry uses interior mutability (DashMap + RwLock).
@@ -367,57 +346,350 @@ impl Runtime {
         info!("All modules shut down");
     }
 
-    /// Verify all expected modules are registered.
-    /// Fails with a clear error if any module is missing.
-    /// Call after all registrations to ensure nothing was forgotten.
-    pub fn verify_registration(&self) -> Result<(), String> {
+    /// Verify all required modules are registered for the given
+    /// `(discovery, mode)` pair.
+    ///
+    /// The required set is CONDITIONAL — not a flat list — because
+    /// modules like `persona_instance_manager` and
+    /// `persona-rag-inspect` are only constructible when AIRC is
+    /// `Healthy`. Slice A's flat list put them in `EXPECTED_MODULES`
+    /// unconditionally, which meant `verify_registration` failed
+    /// boot in the very `InferenceOnly` mode Slice A's PR body
+    /// claimed to support (R1#1 BLOCK). This API takes the typed
+    /// state and computes the expected set at call time, so the
+    /// contradiction is structurally impossible.
+    ///
+    /// The set of ALL modules the substrate knows about is
+    /// `ALL_KNOWN_MODULES` — kept current via the
+    /// `expected_modules_snapshot` integration test. Drift in
+    /// registrations surfaces as a snapshot diff in CI, replacing
+    /// the silent "Unexpected module registered" WARN that the
+    /// Slice A list-rewrite traded one drift for another to fix
+    /// (R2#3 + R3#3 BLOCK).
+    pub fn verify_registration(
+        &self,
+        discovery: &AircDiscovery,
+        mode: BootMode,
+    ) -> Result<(), String> {
         let registered: Vec<String> = self.registry.module_names();
+        let required = required_modules(discovery, mode);
         let mut missing: Vec<&str> = Vec::new();
-        let mut unexpected: Vec<String> = Vec::new();
 
-        // Check for missing expected modules
-        for expected in EXPECTED_MODULES {
+        for expected in required {
             if !registered.iter().any(|r| r == *expected) {
                 missing.push(expected);
             }
         }
 
-        // Check for unexpected registered modules (not necessarily an error, just a warning)
-        for registered_name in &registered {
-            if !EXPECTED_MODULES.contains(&registered_name.as_str()) {
-                unexpected.push(registered_name.clone());
-            }
-        }
-
-        // Log warnings for unexpected modules
-        for name in &unexpected {
-            warn!(
-                "Unexpected module registered (not in EXPECTED_MODULES): {}",
-                name
-            );
-        }
-
-        // Fail if any expected modules are missing
         if !missing.is_empty() {
             let missing_list = missing.join(", ");
-            error!("Missing required modules: {}", missing_list);
+            error!(
+                discovery = ?discovery.kind(),
+                mode = ?mode.label(),
+                "Missing required modules for (discovery={}, mode={}): [{}]",
+                discovery.kind(),
+                mode.label(),
+                missing_list
+            );
             error!(
                 "Expected {} modules, found {}",
-                EXPECTED_MODULES.len(),
+                required.len(),
                 registered.len()
             );
-            error!("Add missing module registrations in ipc/mod.rs or update EXPECTED_MODULES in runtime.rs");
+            error!(
+                "Add missing module registrations in ipc/mod.rs (the registration site \
+                 emits the module name; ALL_KNOWN_MODULES + required_modules() must \
+                 mirror it)"
+            );
             return Err(format!(
-                "Module registration incomplete: missing [{}]. Server cannot start.",
+                "Module registration incomplete for (discovery={}, mode={}): \
+                 missing [{}]. Server cannot start.",
+                discovery.kind(),
+                mode.label(),
                 missing_list
             ));
         }
 
         info!(
-            "✅ All {} expected modules registered",
-            EXPECTED_MODULES.len()
+            "✅ All {} required modules registered (discovery={}, mode={})",
+            required.len(),
+            discovery.kind(),
+            mode.label()
         );
         Ok(())
+    }
+}
+
+/// Modules that EVERY boot needs regardless of discovery state or
+/// mode — infrastructure, resource governance, transport, AI
+/// dispatch. If any of these are missing, the substrate cannot
+/// serve commands at all.
+pub const MODULES_CORE: &[&str] = &[
+    // Infrastructure / health
+    "health",
+    "auth",
+    "system",
+    "events",
+    "logger",
+    "runtime",
+    "mcp",
+    "data",
+    // Resource governance
+    "gpu",
+    "resource-broker",
+    "pressure-broker",
+    // AI / inference (always present — required by every mode)
+    "inference",
+    "inference-llm",
+    "ai_provider",
+    "embedding",
+    "search",
+    "tool-parsing",
+    "vision",
+    "models",
+    "memory",
+    "rag",
+    // Persona substrate that's always built (cognition + allocator
+    // work without an AIRC daemon; persona/instances/* requires AIRC
+    // but `cognition/*` doesn't)
+    "cognition",
+    "channel",
+    "persona_allocator",
+    "agent",
+    // Forge / sentinel / plasticity / training
+    "forge",
+    "sentinel",
+    "plasticity",
+    "dataset",
+    "vdd",
+    "cargo",
+    "code",
+    // Substrate transports
+    "airc",
+    "grid",
+    // Live presence — present in this binary today; Slice B' splits
+    // these out into the renderer + voice sidecars
+    "live",
+    "avatar",
+];
+
+/// Modules that REQUIRE AIRC `Healthy` to construct. The substrate
+/// only registers these when discovery succeeded with all four
+/// sub-steps (socket + room + channel + Status RPC liveness).
+pub const MODULES_PERSONA_HOSTING: &[&str] = &[
+    "persona_instance_manager",
+    "persona-rag-inspect",
+];
+
+/// Compute the required-module set for a given `(discovery, mode)`.
+///
+/// Doctrine: in `InferenceOnly` mode the substrate MUST come up
+/// without persona-hosting modules — that's what the operator
+/// explicitly opted into via `--mode=inference-only`. In
+/// `FullCitizen` / `FailFast` mode, persona-hosting is required
+/// IFF discovery is `Healthy`. If discovery is degraded, the
+/// substrate refuses boot BEFORE reaching `verify_registration`
+/// (see `ipc/mod.rs::start_server`) — so this function never sees
+/// `(FullCitizen, Degraded)` in practice, but it's structurally
+/// safe (returns the same set as `(FullCitizen, Healthy)` so a
+/// stray invocation produces a coherent error message).
+pub fn required_modules(discovery: &AircDiscovery, mode: BootMode) -> &'static [&'static str] {
+    let needs_persona_hosting = mode.requires_persona_hosting() && discovery.can_host_personas();
+    if needs_persona_hosting {
+        // Concatenation at compile time isn't possible without `const`
+        // tricks, so we use a static once-init via the module-level
+        // join below.
+        ALL_KNOWN_MODULES
+    } else {
+        MODULES_CORE
+    }
+}
+
+/// The flat union of `MODULES_CORE` + `MODULES_PERSONA_HOSTING`.
+/// Used by the `expected_modules_snapshot` integration test as
+/// the snapshot baseline — drift in any registration site shows
+/// up as a snapshot diff in CI, replacing the silent "Unexpected
+/// module registered" WARN that drifted in Slice A.
+///
+/// When you add a new `runtime.register(NewModule)` call site in
+/// `ipc/mod.rs`, add the module name here AND to the conditional
+/// set (`MODULES_CORE` or `MODULES_PERSONA_HOSTING`) it belongs
+/// to. The snapshot test will fail in CI if you forget either side.
+pub const ALL_KNOWN_MODULES: &[&str] = &[
+    // Infrastructure / health
+    "health",
+    "auth",
+    "system",
+    "events",
+    "logger",
+    "runtime",
+    "mcp",
+    "data",
+    // Resource governance
+    "gpu",
+    "resource-broker",
+    "pressure-broker",
+    // AI / inference
+    "inference",
+    "inference-llm",
+    "ai_provider",
+    "embedding",
+    "search",
+    "tool-parsing",
+    "vision",
+    "models",
+    "memory",
+    "rag",
+    // Persona substrate (always-built)
+    "cognition",
+    "channel",
+    "persona_allocator",
+    "agent",
+    // Persona substrate (AIRC-Healthy-conditional)
+    "persona_instance_manager",
+    "persona-rag-inspect",
+    // Forge / sentinel / plasticity / training
+    "forge",
+    "sentinel",
+    "plasticity",
+    "dataset",
+    "vdd",
+    "cargo",
+    "code",
+    // Substrate transports
+    "airc",
+    "grid",
+    // Live presence
+    "live",
+    "avatar",
+];
+
+#[cfg(test)]
+mod conditional_modules_tests {
+    use super::*;
+    use crate::airc::{AircDiscovery, DiscoveryFailure, PartialDiscovery};
+    use airc_core::RoomId;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    fn healthy() -> AircDiscovery {
+        AircDiscovery::Healthy {
+            socket: PathBuf::from("/tmp/x.sock"),
+            default_room: RoomId::from_uuid(Uuid::new_v4()),
+            room_name: "general".into(),
+            peer_id: Uuid::new_v4(),
+        }
+    }
+
+    fn degraded() -> AircDiscovery {
+        AircDiscovery::Degraded {
+            reason: DiscoveryFailure::NoDefaultRoom,
+            partial: PartialDiscovery::default(),
+        }
+    }
+
+    /// FullCitizen + Healthy → must include persona hosting.
+    #[test]
+    fn full_citizen_healthy_requires_persona_hosting_modules() {
+        let req = required_modules(&healthy(), BootMode::FullCitizen);
+        assert!(req.contains(&"persona_instance_manager"));
+        assert!(req.contains(&"persona-rag-inspect"));
+        assert!(req.contains(&"inference"));
+        assert!(req.contains(&"airc"));
+    }
+
+    /// InferenceOnly → must NOT require persona hosting modules.
+    /// This is the case Slice A broke (R1#1).
+    #[test]
+    fn inference_only_does_not_require_persona_hosting_modules() {
+        let req = required_modules(&healthy(), BootMode::InferenceOnly);
+        assert!(!req.contains(&"persona_instance_manager"));
+        assert!(!req.contains(&"persona-rag-inspect"));
+        // Core inference must still be there
+        assert!(req.contains(&"inference"));
+        assert!(req.contains(&"embedding"));
+        // airc module itself stays (it provides queue commands etc.
+        // even when there's no live daemon to attach to)
+        assert!(req.contains(&"airc"));
+    }
+
+    /// FailFast + Healthy → persona hosting required (strictest).
+    #[test]
+    fn fail_fast_healthy_requires_persona_hosting_modules() {
+        let req = required_modules(&healthy(), BootMode::FailFast);
+        assert!(req.contains(&"persona_instance_manager"));
+        assert!(req.contains(&"persona-rag-inspect"));
+    }
+
+    /// FullCitizen + Degraded would normally bail before reaching
+    /// verify_registration. If it somehow does reach, return the
+    /// core-only set (no persona hosting modules required) so the
+    /// resulting error message is coherent instead of complaining
+    /// about modules that couldn't be registered against a
+    /// degraded daemon.
+    #[test]
+    fn full_citizen_degraded_uses_core_only_set() {
+        let req = required_modules(&degraded(), BootMode::FullCitizen);
+        assert!(!req.contains(&"persona_instance_manager"));
+        assert!(!req.contains(&"persona-rag-inspect"));
+    }
+
+    /// Drift catcher: `ALL_KNOWN_MODULES` MUST be exactly
+    /// `MODULES_CORE + MODULES_PERSONA_HOSTING`. R2#3 + R3#3 blocked
+    /// Slice A on hand-maintained manifest drift — this test makes
+    /// drift between the three constants mechanically impossible
+    /// to ship. (The next layer of rigging, an integration test
+    /// that snapshots `runtime.registry().module_names()` against
+    /// `ALL_KNOWN_MODULES`, is A.2.2's scope.)
+    #[test]
+    fn all_known_modules_is_union_of_subsets() {
+        let mut union: Vec<&str> = MODULES_CORE.iter().copied().collect();
+        union.extend(MODULES_PERSONA_HOSTING.iter().copied());
+        union.sort();
+        union.dedup();
+        let mut all: Vec<&str> = ALL_KNOWN_MODULES.iter().copied().collect();
+        all.sort();
+        all.dedup();
+        assert_eq!(
+            union, all,
+            "ALL_KNOWN_MODULES must equal MODULES_CORE ∪ MODULES_PERSONA_HOSTING. \
+             Drift means a registration site adds a module to one constant but \
+             forgets the others — exactly the [[every-error-is-an-opportunity-to-battle-harden]] \
+             regression class A.2 closes."
+        );
+    }
+
+    /// MODULES_CORE and MODULES_PERSONA_HOSTING must be DISJOINT —
+    /// a module is either always-built or conditional, never both
+    /// (the conditional dispatch would be ambiguous).
+    #[test]
+    fn core_and_persona_hosting_are_disjoint() {
+        for name in MODULES_PERSONA_HOSTING {
+            assert!(
+                !MODULES_CORE.contains(name),
+                "module {name:?} appears in both MODULES_CORE and \
+                 MODULES_PERSONA_HOSTING — pick one"
+            );
+        }
+    }
+
+    /// `required_modules` MUST always return a slice whose length is
+    /// either `MODULES_CORE.len()` (no persona hosting) or
+    /// `ALL_KNOWN_MODULES.len()` (with persona hosting). No partial
+    /// sets sneak in via the conditional dispatch.
+    #[test]
+    fn required_modules_returns_exactly_one_of_two_sets() {
+        let healthy_full = required_modules(&healthy(), BootMode::FullCitizen);
+        assert_eq!(healthy_full.len(), ALL_KNOWN_MODULES.len());
+
+        let healthy_inf = required_modules(&healthy(), BootMode::InferenceOnly);
+        assert_eq!(healthy_inf.len(), MODULES_CORE.len());
+
+        let degraded_full = required_modules(&degraded(), BootMode::FullCitizen);
+        assert_eq!(degraded_full.len(), MODULES_CORE.len());
+
+        let degraded_inf = required_modules(&degraded(), BootMode::InferenceOnly);
+        assert_eq!(degraded_inf.len(), MODULES_CORE.len());
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces Slice A (PR #1527, closed via convergent R1+R2+R3 BLOCK) with the architectural change Slice A's three patch-fixes were imitating. Compresses three drifting representations of substrate boot state (`Option<(PathBuf, RoomId)>` + flat `EXPECTED_MODULES` const + heuristic seed detection) into one typed primitive each consumer matches exhaustively. The drift problem dies structurally — not because we wrote a louder doc-comment this time, but because the contradictions are no longer expressible.

Card: `4075b9a4-7251-4405-84e5-9033e2213dff`
Supersedes: PR #1527

## Closes (with structural fixes, not patches)

### R1#1 (BLOCKING) — EXPECTED_MODULES contradicted `--mode=inference-only`

`verify_registration(&discovery, mode)` now computes the required set **conditionally**. `MODULES_PERSONA_HOSTING` is only required when AIRC is `Healthy` AND `mode.requires_persona_hosting()`. The PR title "supports inference-only" is true by construction.

### R2#1 (BLOCKING) — `AIRC_DAEMON_SOCKET` env var bypassed liveness

`discover()` aggregator runs Status RPC liveness probe. Failure promotes to `AircDiscovery::Degraded { reason: StaleSocket(path, underlying_err), partial: ... }` instead of the soft-fallback to `Uuid::nil()` that let stale sockets through.

### R2#2 (BLOCKING) — implicit `non-persona-use` fallback

Explicit `--mode=<full-citizen|inference-only|fail-fast>` flag (default `FullCitizen`). The operator states intent; the substrate doesn't guess from `personas/` directory contents.

### R2#3 + R3#3 (BLOCKING) — hand-maintained manifest drift

`ALL_KNOWN_MODULES = MODULES_CORE ∪ MODULES_PERSONA_HOSTING` is a build-time invariant checked by three drift-catcher unit tests. The "louder doc-comment" non-fix is gone. A.2.2 layers an insta snapshot of `runtime.registry().module_names()` on top.

### R2 NIT — A2 panic filter mutes only signal

A2 panic filter restored (suppresses misleading stderr trace only; `catch_unwind` safety net unchanged). New boot banner line `Boot mode: <label> (<description>)` surfaces operator's chosen mode immediately. Voice subsystem `🔊 ready / 🔇 unavailable` status line lands in A.2.2.

## The compression principle this enacts

Before: three pieces of code answered "what is the substrate's boot state":
- `Option<(PathBuf, RoomId)>` tuple
- `EXPECTED_MODULES: &[&str]` flat const
- inline seed-presence heuristic in `ipc/mod.rs`

Each could drift against the other two. Slice A added a **fourth** representation (the hard-fail check) without compressing — that's how it produced PR claims contradicting its own implementation.

A.2.1 collapses to ONE typed state (`AircDiscovery`), ONE explicit operator-intent flag (`BootMode`), ONE function answering "what's required for THIS state" (`required_modules(&discovery, mode)`). Every consumer reaches through the same primitive. The "different consumers disagree about what state is" failure mode is no longer expressible.

## Architectural seam for B'

`AircDiscovery::Healthy/Degraded/Unreachable` is the first instance of the three-variant health shape that every category sidecar (renderer, voice, inference, foundry) will inherit in B'. The substrate-wide controls (`for each category: health()`, PressureBroker admission, Ares-the-dispatcher's allocation cognition) operate uniformly across categories because each category's state surface looks the same. A.2.1's discipline is the foundation: the same compression that closes R1#1 here is what makes Ares possible later.

## Substrate-level tests (not demos)

| Module | Tests | What it pins |
|---|---|---|
| `airc::discovery_state` | 4 | `Healthy/Degraded/Unreachable` transitions; `StaleSocket` carries path AND underlying error |
| `runtime::boot_mode` | 12 | Canonical/alias/case-insensitive parsing; `requires_persona_hosting`/`requires_voice` queries; `extract_boot_mode` against equals-form/space-form/absent/dangling argv |
| `runtime::runtime::conditional_modules_tests` | 7 | `required_modules` dispatch across `(Healthy, Degraded) × (FullCitizen, InferenceOnly, FailFast)`, plus three drift catchers (`all_known_modules_is_union_of_subsets`, `core_and_persona_hosting_are_disjoint`, `required_modules_returns_exactly_one_of_two_sets`) |

**Total: 23/23 pass.** Each primitive exercisable in isolation — no demo bin, no binary boot, no live AIRC daemon. The compression makes them testable; the tests make the compression honest. This is exactly the [[test-fixtures-are-system-primitives]] pattern at the boundary layer.

A.2.2 layers cross-substrate integration tests on top (`StubAircCitizen` + tempdir `continuum_root` + `start_server` end-to-end across the `mode × discovery × seed` matrix).

## End-to-end (release binary)

Will be exercised after CI green:
- [ ] `--mode=full-citizen` + AIRC healthy → All N required modules registered, Paige hosts, `airc msg` round-trip
- [ ] `--mode=full-citizen` + AIRC unreachable → exit 1, typed reason from `Unreachable.reason()`
- [ ] `--mode=full-citizen` + `AIRC_DAEMON_SOCKET=<stale.sock>` → exit 1 with `StaleSocket { path, underlying }`
- [ ] `--mode=inference-only` + AIRC unreachable → boots cleanly, INFO line names operator intent
- [ ] `--mode=fail-fast` + libonnxruntime missing → exit 1

## Out of scope (folded into A.2.2 + B')

**A.2.2:**
- `Context` trait `discovery()` + `boot_mode()` accessors
- PersonaContext / AgentContext / StubContext impl
- `tests/substrate_boot_contract.rs` integration matrix
- `tests/ort_panic_filter.rs` with `serial_test::serial`
- `tests/expected_modules_snapshot.rs` insta snapshot
- Voice subsystem `🔊 ready / 🔇 unavailable` status line
- `runtime/mode/get` + `runtime/mode/set` commands — expose `BootMode` via the universal Commands surface so widgets, personas, and remote continuums all read/change runtime mode through the same primitive. Same for `runtime/discovery/get`. The compression extends to the control surface: one typed value, one command pair, every actor uses the same primitive.

**B':**
- Generalization of `AircDiscovery`'s three-variant pattern to `RendererHealth` / `InferenceHealth` / `VoiceHealth`
- `CategorySidecar` trait + uniform `health()` / `allocate_lane()` / `shutdown()`
- Sidecar process pattern (renderer/voice/inference/foundry as separate binaries)
- Ares-the-persona dispatcher (the master control citizen)

## Doctrine alignment (substantive, not as cover)

- [[no-fallbacks-ever]] — typed discovery + explicit mode eliminate every silent-substitution path Slice A retained
- [[every-error-is-an-opportunity-to-battle-harden]] — the three drift catchers ARE the rigging
- [[substrate-is-a-good-citizen-on-the-host]] — boot banner names the mode; degraded states have human-actionable typed reasons
- [[host-the-seemingly-impossible]] — substrate publishes what it CAN do honestly; `--mode=full-citizen` is a promise, not a hope

## References

- Closed predecessor: PR #1527, reviewer transcripts in airc 2026-06-04
- docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md
- docs/architecture/PERSONA-COGNITION-PIPELINE.md
- CLAUDE.md COMPRESSION PRINCIPLE — one logical decision, one place

🤖 Generated with [Claude Code](https://claude.com/claude-code)
