### PR TITLE
build(cargo): slice 3 — shared CARGO_TARGET_DIR for airc worktrees

### DIFF
--- a/scripts/airc-shared-target-opt-in.sh
+++ b/scripts/airc-shared-target-opt-in.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# airc-shared-target-opt-in.sh
+#
+# Per build-time doctrine slice 3 (src/workers/.cargo/config.toml):
+# collapse N per-worktree target/ dirs into ONE shared
+# `~/.airc/cargo-target`. Run once on this machine; the policy then
+# travels with every airc worktree this peer claims.
+#
+# WHY: each airc worktree carries its own 5-10 GB target/ dir; with
+# 10 active worktrees the dev-artifact sprawl can saturate the disk
+# (observed: 2026-06-05 disk-full incident blocked a mid-build PR
+# fix). Shared target collapses that to ONE tree.
+#
+# TRADE-OFFS (cargo target lock is real):
+#   - Sequential builds: concurrent `cargo build` calls across
+#     worktrees serialize on the target lock. Invisible for the
+#     typical one-PR-at-a-time flow.
+#   - Branch-switch rebuilds when Cargo.lock differs.
+#   - Composes with slice 1 (sccache) + slice 2 (linker selection).
+#
+# WHAT THIS SCRIPT DOES:
+#   1. Creates ~/.airc/cargo-target/ if missing.
+#   2. Writes a one-line CARGO_TARGET_DIR export into the user's
+#      shell init (zshrc / bashrc — auto-detected).
+#   3. Reports current usage (before/after).
+#
+# WHAT THIS SCRIPT DOES NOT DO:
+#   - Edit src/workers/.cargo/config.toml (that's checked-in opt-in
+#     guidance; not a per-machine action).
+#   - Delete existing per-worktree target/ dirs (operator decision;
+#     see the optional cleanup step below).
+#   - Sync sccache settings (slice 1 has its own opt-in).
+#
+# USAGE:
+#   ./scripts/airc-shared-target-opt-in.sh           # interactive
+#   ./scripts/airc-shared-target-opt-in.sh --no-prompt   # CI/scripts
+
+set -euo pipefail
+
+SHARED_TARGET="${SHARED_TARGET_OVERRIDE:-$HOME/.airc/cargo-target}"
+NO_PROMPT=false
+for arg in "$@"; do
+    case "$arg" in
+        --no-prompt) NO_PROMPT=true ;;
+        --help|-h)
+            sed -n '1,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "unknown arg: $arg (use --help)" >&2; exit 2 ;;
+    esac
+done
+
+confirm() {
+    if "$NO_PROMPT"; then return 0; fi
+    read -r -p "$1 [y/N] " ans
+    [[ "$ans" =~ ^[Yy]$ ]]
+}
+
+echo "airc shared CARGO_TARGET_DIR opt-in"
+echo "==================================="
+echo "shared target dir : $SHARED_TARGET"
+echo
+
+# Step 1 — create shared target dir
+if [[ -d "$SHARED_TARGET" ]]; then
+    echo "[1/3] shared target already exists at $SHARED_TARGET"
+else
+    echo "[1/3] creating $SHARED_TARGET"
+    mkdir -p "$SHARED_TARGET"
+fi
+echo
+
+# Step 2 — write shell init export
+SHELL_RC=""
+case "${SHELL##*/}" in
+    zsh)  SHELL_RC="$HOME/.zshrc" ;;
+    bash) SHELL_RC="$HOME/.bashrc" ;;
+    *)    SHELL_RC="$HOME/.profile" ;;
+esac
+
+EXPORT_LINE="export CARGO_TARGET_DIR=\"$SHARED_TARGET\"  # airc shared target (slice 3)"
+
+if grep -Fq "airc shared target (slice 3)" "$SHELL_RC" 2>/dev/null; then
+    echo "[2/3] $SHELL_RC already has the export line — skipping"
+else
+    if confirm "[2/3] append CARGO_TARGET_DIR export to $SHELL_RC?"; then
+        printf '\n%s\n' "$EXPORT_LINE" >> "$SHELL_RC"
+        echo "      added. source it now or open a new shell:"
+        echo "      source $SHELL_RC"
+    else
+        echo "[2/3] skipped — to apply manually, append this line to your shell init:"
+        echo "      $EXPORT_LINE"
+    fi
+fi
+echo
+
+# Step 3 — report current per-worktree target sprawl
+WORKTREE_ROOT="$HOME/.airc/worktrees"
+if [[ -d "$WORKTREE_ROOT" ]]; then
+    echo "[3/3] current per-worktree target/ sprawl (reclaimable on next clean build):"
+    found_any=false
+    for wt_target in "$WORKTREE_ROOT"/*/src/workers/target; do
+        if [[ -d "$wt_target" ]]; then
+            found_any=true
+            size=$(du -sh "$wt_target" 2>/dev/null | cut -f1)
+            printf "      %s  %s\n" "$size" "$wt_target"
+        fi
+    done
+    if ! "$found_any"; then
+        echo "      none — all worktrees are already without their own target/ dir."
+    else
+        echo
+        echo "      to reclaim now: rm -rf those paths. Subsequent builds will"
+        echo "      compile into $SHARED_TARGET instead."
+    fi
+else
+    echo "[3/3] no airc worktrees at $WORKTREE_ROOT — nothing to report."
+fi
+
+echo
+echo "done. verify after opening a new shell:"
+echo "  echo \$CARGO_TARGET_DIR    # should print $SHARED_TARGET"
+echo "  cd \$(any airc worktree)/src && cargo build -v 2>&1 | head -5"

--- a/src/workers/.cargo/config.toml
+++ b/src/workers/.cargo/config.toml
@@ -61,3 +61,54 @@
 # [target.aarch64-unknown-linux-gnu]
 # linker = "clang"
 # rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+# ─── Slice 3: shared CARGO_TARGET_DIR across airc worktrees ──────────
+#
+# Per [[local-worktree-is-temp-dir]] + the disk-full incident on
+# 2026-06-05 (a stuck Docker daemon mid-build cascaded into 100% disk
+# usage; root cause was each airc worktree carrying its own 5-10 GB
+# target/ dir × ~10 worktrees = 50-100 GB of dev artifact sprawl).
+#
+# Collapse N target/ dirs into ONE shared `~/.airc/cargo-target`. Each
+# airc worktree compiles into and reads from the same target tree.
+#
+# Trade-offs (open about them; cargo's lock semantics are real):
+#   - Sequential builds only — concurrent `cargo build` invocations
+#     across worktrees will serialize on the shared target lock. For
+#     the typical one-PR-at-a-time flow this is invisible.
+#   - Branch-switch rebuilds when Cargo.lock changes (different
+#     dependency sets need different artifacts). Cargo handles this
+#     by rebuilding the affected crates; the cache absorbs the rest.
+#   - Composes with slice 1 (sccache caches rustc invocations) and
+#     slice 2 (linker selection) — all three slices stack.
+#
+# Why this is config and not env-only: putting CARGO_TARGET_DIR in
+# .cargo/config.toml [env] section makes the policy travel with the
+# worktree, so `airc work claim` → `cd worktree` → `cargo test` Just
+# Works without remembering to export anything.
+#
+# Why opt-in (commented): single-target-dir is a tradeoff, not a
+# universal win. Devs with one-worktree-only flows lose nothing by
+# leaving it off; devs juggling many concurrent airc worktrees gain
+# the most by turning it on. Per [[no-fallbacks-ever]] + the
+# slice-1/slice-2 doctrine: ship the lever, document the trade, let
+# operators choose.
+#
+# To opt in:
+#   1. mkdir -p ~/.airc/cargo-target
+#   2. Uncomment the [env] block below.
+#   3. Optionally: scripts/airc-shared-target-opt-in.sh wires this
+#      into every existing airc worktree's local config.
+#
+# Verify after opt-in:
+#   - cargo build -v 2>&1 | grep -E '(Compiling|Finished) .* in '
+#   - du -sh ~/.airc/cargo-target/   # one shared tree, not N
+#   - du -sh ~/.airc/worktrees/*/src/workers/target  # should be empty/absent
+#
+# [env]
+# CARGO_TARGET_DIR = { value = "/Users/YOUR-USERNAME/.airc/cargo-target", force = false }
+#
+# Note on the absolute path: cargo config does NOT expand `~` or
+# environment variables in [env] values (cargo issue #14149). The
+# `force = false` lets a per-shell CARGO_TARGET_DIR export override
+# this — useful for one-shot builds against a clean target.


### PR DESCRIPTION
## Summary

Slice 3 of the build-time efficiency series (card 424deb5e). Collapses N per-worktree `target/` dirs into ONE shared `~/.airc/cargo-target`, mirroring the opt-in pattern from slices 1 (sccache) and 2 (linker selection).

## Why

Per `[[local-worktree-is-temp-dir]]` — worktrees are L1 cache, not durable state. Each airc worktree currently carries its own 5-10 GB `target/` dir. With ~10 active worktrees the dev-artifact sprawl reaches 50-100 GB.

**Direct observation today (2026-06-05):** a hung Docker daemon pinned `cargo test`, target/ accumulation across worktrees maxed the disk, the bash tool's output buffer couldn't write, and the metal_monitor #163 fix was blocked mid-build until manual cleanup.

Shared `CARGO_TARGET_DIR` is the structural fix — single biggest disk lever in the build-time efficiency series.

## What ships

### `src/workers/.cargo/config.toml` slice 3
Opt-in block (commented like slices 1+2) documenting the shared-target pattern, trade-offs, and composition with prior slices. Notes cargo issue #14149 (config doesn't expand `~` or env vars) as the reason absolute paths are required.

### `scripts/airc-shared-target-opt-in.sh`
Operator helper:
1. Creates `~/.airc/cargo-target/`
2. Appends `export CARGO_TARGET_DIR=...` to the user's shell init (auto-detects zsh/bash/sh, idempotent)
3. Reports current per-worktree target/ sprawl with sizes for reclaim

Modes: interactive (default) + `--no-prompt` for CI.

## Trade-offs (documented up front per no-fallbacks doctrine)

- **Sequential builds only**: cargo's target lock serializes concurrent `cargo build` across worktrees. Invisible for one-PR-at-a-time flow.
- **Branch-switch rebuilds**: when Cargo.lock differs between branches, affected crates rebuild. Cargo incremental + sccache (slice 1) absorb the rest.
- **Opt-in by design**: single-target-dir is a tradeoff, not a universal win. Devs with one-worktree flows lose nothing; devs juggling many gain the most.

## Composition with slices 1+2

- **Slice 1** (sccache): per-worktree target/ + shared rustc cache
- **Slice 2** (lld/mold linker): cuts link time from 30-60s to 2-5s
- **Slice 3** (this PR): collapses N target/ into ONE — stacks with slices 1+2

## What this PR does NOT do

- Does NOT delete existing per-worktree target/ — script reports them with sizes; reclaim is operator-driven
- Does NOT auto-set `CARGO_TARGET_DIR` from `airc work claim` — cross-repo airc-side work, tracked as follow-up
- Does NOT extend `airc work cleanup --force` to wipe target/ on Closed/Merged — also airc-side follow-up

## Test plan

- [x] Script runs cleanly in `--no-prompt` mode and reports current sprawl (verified 33 GB in fa25de80 worktree before this commit)
- [x] Script idempotent: re-runs detect the existing export line and skip
- [x] Cargo config slice 3 block is entirely commented — no build behavior change without operator opt-in
- [ ] Operator opt-in flow (after merge): run script → open new shell → `cargo build` from any airc worktree → verify build lands in shared tree

## Doctrine

- `[[local-worktree-is-temp-dir]]` — the architectural frame
- `[[every-error-is-an-opportunity-to-battle-harden]]` — today's disk-full incident drove the slice
- `[[organization-purity-as-we-migrate]]` — mirrors existing slice 1+2 pattern
- `[[no-fallbacks-ever]]` — opt-in shape; no silent "tries shared target, falls back" behavior

card: `80ef9cd1-5bb9-4777-a174-ced9926c8484`
