### PR TITLE
perf(persona): cache system_prompt at PersonaContext construction (#195 slice 2)

### DIFF
--- a/src/workers/continuum-core/src/persona/service_loop.rs
+++ b/src/workers/continuum-core/src/persona/service_loop.rs
@@ -537,10 +537,16 @@ async fn serve_persona_loop_inner(
             message_id: Uuid::new_v4(),
             message_text: msg.text.clone(),
             other_persona_names: Vec::new(),
-            system_prompt: format!(
-                "You are {persona}, an autonomous AI persona on the grid.",
-                persona = ctx.identity.agent_name
-            ),
+            // #195 slice 2: cached per-session prompt. The
+            // PersonaContext baked this once at construction via
+            // `build_persona_system_prompt`; here we just lease
+            // the Arc and copy the bytes once for the RespondInput
+            // boundary. The variadic format!() call this replaces
+            // was the canonical reinit-on-hot-path waste per
+            // [[init-once-handle-then-lease-zero-copy-refs]].
+            // Task #149 will lift this further by passing the
+            // pre-tokenized form across the boundary too.
+            system_prompt: ctx.system_prompt.as_ref().to_string(),
             model: ctx.profile.model_id.clone(),
             is_voice: false,
             message_media: Vec::new(),
@@ -735,6 +741,11 @@ mod tests {
                     Arc::new(crate::rag::RagEngine::new()),
                 ),
             )),
+            // #195 slice 2: build via the same helper production
+            // uses, NOT a copy-pasted template. If a future PR
+            // adjusts the prompt wording, this fixture stays
+            // honest about what the test exercises.
+            system_prompt: super::super::supervisor::build_persona_system_prompt("Paige"),
         }
     }
 
@@ -955,6 +966,51 @@ mod tests {
         assert_eq!(outcome.say_latency.count, 0);
         assert!(outcome.recall_latency.mean_ms().is_none());
         assert!(outcome.respond_latency.mean_ms().is_none());
+    }
+
+    /// #195 slice 2: pin that `build_persona_system_prompt` (the
+    /// helper used by both production construction and test
+    /// fixtures) produces EXACTLY what the old per-turn
+    /// `format!()` did. A future PR that adjusts the template
+    /// wording must update both the helper AND this expectation
+    /// — the test breaks loudly rather than letting the cache
+    /// drift away from the format!() the merger had previously.
+    #[test]
+    fn cached_system_prompt_matches_legacy_format_template() {
+        let cached = super::super::supervisor::build_persona_system_prompt("Paige");
+        let legacy = format!(
+            "You are {persona}, an autonomous AI persona on the grid.",
+            persona = "Paige"
+        );
+        assert_eq!(
+            cached.as_ref(),
+            legacy,
+            "build_persona_system_prompt must produce the SAME string the \
+             pre-#195-slice-2 per-turn format!() did — otherwise the cache \
+             silently changes the prompt the substrate sends to the model"
+        );
+    }
+
+    /// #195 slice 2: pin that cloning the cached prompt is a
+    /// cheap Arc refcount bump, not a deep copy. Without this,
+    /// a future refactor swapping `Arc<str>` for `String` would
+    /// silently restore the per-turn-allocation cost the slice
+    /// shipped to eliminate.
+    #[test]
+    fn cached_system_prompt_clones_via_arc_refcount() {
+        let original = super::super::supervisor::build_persona_system_prompt("Paige");
+        let cloned = std::sync::Arc::clone(&original);
+        assert_eq!(
+            std::sync::Arc::strong_count(&original),
+            2,
+            "Arc::clone must bump the refcount (cheap pointer copy) — \
+             not deep-copy the underlying str"
+        );
+        // Pointer-equality on the underlying str confirms zero-copy.
+        assert!(
+            std::ptr::eq(original.as_ref() as *const str, cloned.as_ref() as *const str),
+            "cloned Arc must point at the SAME str storage as the original"
+        );
     }
 
     /// Aggregate-math property: each phase aggregate is structurally

--- a/src/workers/continuum-core/src/persona/supervisor.rs
+++ b/src/workers/continuum-core/src/persona/supervisor.rs
@@ -214,6 +214,25 @@ pub struct PersonaContext {
     /// cycle service_loop drives through this brain. DO NOT bypass
     /// it with a chatbot-shaped surface.
     pub cognition: Arc<tokio::sync::Mutex<crate::persona::unified::PersonaCognition>>,
+    /// Pre-baked persona system prompt — the "You are {persona},
+    /// an autonomous AI persona on the grid." line currently
+    /// `format!()`'d per turn by the service loop. Constructed
+    /// ONCE at PersonaContext construction (the persona name is
+    /// fixed for the session) and leased per turn via `Arc::clone`.
+    ///
+    /// Per `[[init-once-handle-then-lease-zero-copy-refs]]` +
+    /// task #195 slice 2: substrate latency lives in reinit, not
+    /// compute. Reformatting + reallocating the same template per
+    /// turn is the textbook reinit-on-hot-path waste this field
+    /// eliminates.
+    ///
+    /// `Arc<str>` (not `String`) so cloning is a pointer-copy + atomic
+    /// refcount bump. The service loop's per-turn cost becomes
+    /// `Arc::to_string` (one strlen + alloc + memcpy) instead of
+    /// `format!` (variadic macro + locale machinery + alloc + copy).
+    /// Task #149 will replace this with `Arc<[Token]>` to eliminate
+    /// the per-turn tokenization too.
+    pub system_prompt: Arc<str>,
 }
 
 /// Back-compat alias for the slice-9-era struct name. New code
@@ -466,6 +485,8 @@ pub async fn materialize_adapters(
         );
         cognition.set_airc_source(airc_source);
 
+        let system_prompt = build_persona_system_prompt(&identity.agent_name);
+
         out.push(Ok(PersonaContext {
             role: plan.role,
             identity,
@@ -473,9 +494,30 @@ pub async fn materialize_adapters(
             adapter,
             runtime,
             cognition: Arc::new(tokio::sync::Mutex::new(cognition)),
+            system_prompt,
         }));
     }
     out
+}
+
+/// Construct the persona's system prompt as an `Arc<str>` ready
+/// to lease per turn. Per task #195 slice 2: this runs ONCE at
+/// PersonaContext construction; the per-turn `format!()` it
+/// replaces becomes a single `Arc::clone`-then-`to_string` at
+/// the RespondInput boundary.
+///
+/// The template is verbatim what `service_loop_inner` used to
+/// `format!()` per turn — same characters, same order — so the
+/// downstream prompt assembly is unchanged. Task #149 will
+/// replace this with a pre-tokenized form.
+///
+/// Exposed `pub(super)` so the service-loop test fixtures can
+/// build the same string by the same code path the production
+/// path uses; no copy-pasted template.
+pub(super) fn build_persona_system_prompt(agent_name: &str) -> Arc<str> {
+    Arc::from(format!(
+        "You are {agent_name}, an autonomous AI persona on the grid."
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Slice 2 of task #195 (inference latency perfection campaign). Per `[[init-once-handle-then-lease-zero-copy-refs]]`: the persona system prompt does not change between turns; reformatting + reallocating it per reply is the canonical reinit-on-hot-path waste.

## What ships

- **`build_persona_system_prompt(agent_name) -> Arc<str>`** — pure helper in `persona::supervisor`. Pre-bakes the "You are {persona}, an autonomous AI persona on the grid." line. Exposed `pub(super)` so test fixtures call the same constructor production does — no copy-pasted template.
- **`PersonaContext.system_prompt: Arc<str>`** — new field, populated ONCE at `materialize_adapters` construction.
- **`serve_persona_loop_inner` reads from the cache** — replaces the per-turn `format!()` with `ctx.system_prompt.as_ref().to_string()`. Per-turn cost drops from variadic-macro + alloc + copy to one strlen + alloc + memcpy.

Task #149 will lift this further: pass the pre-tokenized `Arc<[Token]>` across the boundary so even the `to_string` is gone.

## Why now

Slice 1 (#1532, merged) gives the operator phase-decomposed per-turn latencies. Slice 2 attacks the smallest, most-contained reinit cost first — the textbook init-once-handle-then-lease case. Wins are small in absolute time (microseconds) but the pattern lays rails for #149 + #112/#113/#114 (the bigger handle-reuse work).

## Tests

- `cached_system_prompt_matches_legacy_format_template` — pins that the helper produces the SAME string the pre-slice-2 `format!()` did. A future template edit must update both the helper AND the test.
- `cached_system_prompt_clones_via_arc_refcount` — pins the Arc-clone-is-cheap contract via pointer-equality on the underlying str. A future refactor swapping `Arc<str>` for `String` would silently restore the per-turn alloc and fail loudly.

## Out of scope

- No tokenization caching (that's #149's whole-of-pipeline change).
- No `RespondInput.system_prompt` type change (the caching is upstream of that boundary).
- No prompt template change (substrate keeps the existing text verbatim).

## Doctrine

- `[[init-once-handle-then-lease-zero-copy-refs]]` — canonical pattern applied to the smallest, simplest reinit cost
- `[[observability-is-half-the-architecture]]` — slice 1's `respond_latency` aggregate will tell us if this moved the needle on real persona turns
- `[[no-fallbacks-ever]]` — no graceful-degradation; cache drift breaks the test loudly

card: `32b668a3-54af-4ceb-b60e-cbceaba661db`
parent task: #195
slice 1: #1532 (merged)
