### PR TITLE
perf(persona): drop per-turn format!()+lowercase — use canonical RoleId::as_str() (#195 slice 3)

### DIFF
--- a/src/workers/continuum-core/src/persona/service_loop.rs
+++ b/src/workers/continuum-core/src/persona/service_loop.rs
@@ -530,7 +530,18 @@ async fn serve_persona_loop_inner(
         let respond_input = crate::persona::response::RespondInput {
             persona: crate::cognition::PersonaSlot {
                 persona_id: ctx.identity.persona_id,
-                specialty: format!("{:?}", ctx.role).to_lowercase(),
+                // #195 slice 3: drop the per-turn
+                // `format!("{:?}", ctx.role).to_lowercase()` —
+                // RoleId already exposes the canonical specialty
+                // string via `as_str() -> &'static str` (pinned in
+                // role_template.rs). The only per-turn cost is
+                // one `String::from` of a static str. No cache
+                // needed; the source IS the cache. A behavior-
+                // preservation test in `mod tests` pins
+                // `role.as_str() == format!("{:?}", role).to_lowercase()`
+                // for every RoleId variant so this swap is
+                // provably safe and stays safe.
+                specialty: ctx.role.as_str().to_string(),
                 display_name: ctx.identity.agent_name.clone(),
             },
             turn_context,
@@ -1011,6 +1022,64 @@ mod tests {
             std::ptr::eq(original.as_ref() as *const str, cloned.as_ref() as *const str),
             "cloned Arc must point at the SAME str storage as the original"
         );
+    }
+
+    /// #195 slice 3: pin that the migration from
+    /// `format!("{:?}", role).to_lowercase()` to `role.as_str()`
+    /// in `serve_persona_loop_inner` is byte-for-byte
+    /// behavior-preserving for EVERY current `RoleId` variant.
+    ///
+    /// Non-circular: the two sides are independently-derived —
+    /// the left is the new direct production path (a hand-
+    /// curated `match role { ... }` in `role_template.rs::as_str`),
+    /// the right is the pre-slice-3 Debug-format + Unicode
+    /// lowercase chain. They are equal today by careful design
+    /// of `as_str()`; if a future PR adds a `RoleId` variant
+    /// whose `as_str()` choice DOESN'T match the legacy
+    /// Debug+lowercase, this test breaks loudly so the author
+    /// makes an explicit decision (update the test to record
+    /// the intentional divergence, or align `as_str()` with
+    /// the legacy form).
+    ///
+    /// The exhaustive `match` matcher (no wildcard) makes the
+    /// compiler force a new variant to appear here at the same
+    /// time it appears in `RoleId`, so the `variants` array
+    /// stays complete by construction.
+    #[test]
+    fn role_as_str_preserves_pre_slice3_specialty_format_for_each_role() {
+        // RoleId is already in scope via `use crate::persona::role_template::RoleId`
+        // at the top of the test module — no per-test import needed.
+        let variants: &[RoleId] = &[
+            RoleId::Helper,
+            RoleId::Coder,
+            RoleId::Sentinel,
+            RoleId::Custom,
+        ];
+        for role in variants {
+            let direct = role.as_str();
+            let legacy = format!("{:?}", role).to_lowercase();
+            assert_eq!(
+                direct, legacy,
+                "RoleId::{:?}.as_str() must produce the SAME string \
+                 the pre-#195-slice-3 per-turn \
+                 format!(\"{{:?}}\", role).to_lowercase() did — \
+                 otherwise switching the service loop's specialty \
+                 source from Debug+lowercase to as_str() silently \
+                 changes what downstream prompt assembly reads",
+                role
+            );
+        }
+        // Compile-time exhaustiveness: a new RoleId variant
+        // forces a new arm here, which forces the author to add
+        // it to the `variants` array above. The arms each touch
+        // the variant explicitly (no `_` wildcard) so the
+        // compiler rejects silent drift.
+        let _ = |role: RoleId| match role {
+            RoleId::Helper => (),
+            RoleId::Coder => (),
+            RoleId::Sentinel => (),
+            RoleId::Custom => (),
+        };
     }
 
     /// Aggregate-math property: each phase aggregate is structurally


### PR DESCRIPTION
## Summary

Slice 3 of task #195 (inference latency perfection campaign). Drop the per-turn `format!("{:?}", ctx.role).to_lowercase()` from `serve_persona_loop_inner` and read the canonical `RoleId::as_str()` directly. No new field on `PersonaContext`, no cache plumbing — `as_str()`'s `&'static str` IS the cache.

## What ships (one-line behavior change + one test)

```rust
// service_loop.rs, in RespondInput construction:
// was: specialty: format!("{:?}", ctx.role).to_lowercase()
specialty: ctx.role.as_str().to_string(),
```

Per-turn cost drops from `format!()` (variadic macro + Debug formatter + heap alloc) + `.to_lowercase()` (second alloc + Unicode lowercase walk) to a single `String::from` of a static `&'static str`.

## Why this shape (not a cache)

Initial draft of slice 3 added a `PersonaContext.specialty: Arc<str>` cache populated by a `build_persona_specialty(role)` helper. Three adversarial reviewers correctly flagged:

1. **Caching the wrong source.** `RoleId::as_str()` is the documented, intentionally-stable specialty derivation (kebab-case identifier, pinned by an explicit `match` in `role_template.rs`). Caching the Debug+lowercase chain instead couples prompt assembly to the derived-Debug format — a future variant rename or wrapper struct could silently break the specialty with no test failure.
2. **The cache test was a tautology.** The helper was `Arc::from(format!("{:?}", role).to_lowercase())` and the test compared its output to `format!("{:?}", role).to_lowercase()` — comparing the helper to its own implementation.

The revised slice picks the right source and the right contract: use `role.as_str()` directly. No cache because the static-str pointer IS already pre-computed at compile time. The new test is non-circular: it compares two independently-derived strings (`role.as_str()` from `role_template.rs::match`, vs the pre-slice-3 derived-Debug chain).

## Test

`role_as_str_preserves_pre_slice3_specialty_format_for_each_role`:

- Pins that for EVERY `RoleId` variant (Helper, Coder, Sentinel, Custom), `role.as_str()` produces byte-identical output to the pre-slice-3 `format!("{:?}", role).to_lowercase()`. **Non-circular.**
- Compile-time exhaustiveness: a closure-typed `|role: RoleId| match role { ... }` with NO wildcard arm forces a new RoleId variant to be added here AND to the `variants` array. (Initial draft's "cosmetic exhaustiveness" — matching on a literal `RoleId::Helper` — was fixed.)

## Out of scope

- No `display_name` change. `String::clone` of a fixed-per-session name has the same per-turn cost cache-or-not; the smell is `RespondInput`'s `String`-typed field, not the source. Lift when `RespondInput`'s type changes (#149-adjacent).
- No prompt-template change. Substrate keeps the existing specialty-string contract verbatim; the migration is provably behavior-preserving.

## Doctrine

- `[[init-once-handle-then-lease-zero-copy-refs]]` — canonical "init-once" here is the compile-time `match` in `RoleId::as_str()`. Per-turn cost is a `&'static str` deref + one `String::from` (memcpy of 6-9 static bytes). Doesn't get cheaper without changing `RespondInput`'s type signature.
- `[[observability-is-half-the-architecture]]` — slice 1's `respond_latency` aggregate will tell us if this + cumulative slice-2/3+ wins are moving the needle on real persona turns.
- `[[no-fallbacks-ever]]` — no graceful-degradation; the behavior-preservation test breaks loudly if either side drifts.

card: `0d780926`
parent task: #195
slice 1: #1532 (merged)
slice 2: #1533 (merged)