### PR TITLE
feat(probes): sprinkle LLM-boundary visibility into persona::response + cognition::shared_analysis (#151)

### DIFF
--- a/docs/architecture/RTOS-DEBUGGER-PROBES.md
+++ b/docs/architecture/RTOS-DEBUGGER-PROBES.md
@@ -170,13 +170,13 @@ The infrastructure exists (Slice P, #176/#177): `routing/macros.rs` (macros), `r
 
 What is INCOMPLETE — the sprinkle that turns the JTAG hardware into a working debugger:
 
-- [ ] `persona/service_loop.rs::serve_persona_loop_inner` — turn boundaries, recall + admit + compose + respond + say (with timings)
-- [ ] `persona/response.rs::respond_inner` — entry, analyze result, render output, post-process, exit
-- [ ] `persona/response.rs::run_render` — assembled prompt size + presence of each block, raw model output stats
-- [ ] `persona/prompt_assembly.rs::assemble` — final composition stats (system_message length, message count, est tokens, matched_angle present, engrams count, social_signals present)
-- [ ] `cognition/shared_analysis/mod.rs::analyze` — entry, single-flight join, cache hit/miss, parsed angles per specialty
-- [ ] `cognition/response_orchestrator.rs::score_persona` — per-persona score + matched_angles + decision reason
-- [ ] `ai/llama_cpp_adapter::generate_text` — request fingerprint + raw output + finish_reason
+- [x] `persona/response.rs::respond_inner` — entry, analyze result, raw LLM output (full text), exit-spoke — **wired in this PR**
+- [x] `persona/response.rs::run_render` — assembled prompt verbatim + composition stats — **wired in this PR**
+- [x] `cognition/shared_analysis/mod.rs::analyze` — entry, single-specialty noop, L1 cache hit, parsed angles (empty vs non-empty count) — **wired in this PR**
+- [ ] `persona/service_loop.rs::serve_persona_loop_inner` — turn boundaries, recall + admit + compose + respond + say (with timings) — next PR
+- [ ] `persona/prompt_assembly.rs::assemble` — final composition stats (system_message length, message count, est tokens, matched_angle present, engrams count, social_signals present) — covered indirectly by `persona.response.render.prompt`; standalone probe TBD if assembly logic grows
+- [ ] `cognition/response_orchestrator.rs::score_persona` — per-persona score + matched_angles + decision reason — note: the score_persona gate is currently bypassed (response.rs:288–300); probes go in if/when it's re-wired
+- [ ] `ai/llama_cpp_adapter::generate_text` — request fingerprint + raw output + finish_reason — covered indirectly by `persona.response.render.prompt` (in) + `persona.response.render.raw` (out); adapter-level probe TBD when we need per-batch visibility
 
 Each gets a small commit that adds the probes + updates this manual's checklist. The proof-of-value for each commit: enable the file sink, run the multi-persona scenario, `jq` the relevant class, see the variable snapshots.
 

--- a/src/workers/continuum-core/src/cognition/shared_analysis/mod.rs
+++ b/src/workers/continuum-core/src/cognition/shared_analysis/mod.rs
@@ -100,7 +100,35 @@ pub async fn analyze(input: AnalysisInput) -> Result<SharedAnalysis, AnalysisErr
     // suggested_angles gracefully (one-specialty rooms have no
     // angle to inject — the render proceeds with system_prompt
     // alone).
+    // RTOS-debugger breakpoint: analyze entry. The subconscious
+    // stage gating every persona's "should I weigh in" decision.
+    // Captures the input fingerprint so an operator can correlate
+    // multiple personas hitting the same single-flight cache.
+    // Per docs/architecture/RTOS-DEBUGGER-PROBES.md class taxonomy.
+    crate::probe!(
+        class = "cognition.analyze.enter",
+        message_id = %input.message_id,
+        room_id = %input.room_id,
+        text_len = input.text.len(),
+        history_count = input.recent_history.len(),
+        known_specialties_count = input.known_specialties.len(),
+        "analyze entry"
+    );
+
     if input.known_specialties.len() <= 1 {
+        // RTOS-debugger breakpoint: the substrate skipped the LLM
+        // call because a single-specialty room has nothing for
+        // orchestration to do. The persona's render proceeds with
+        // empty suggested_angles. Critical to distinguish "I chose
+        // silence because no angle matched" vs "I chose silence
+        // because analyze was skipped" — they look identical
+        // downstream without this probe.
+        crate::probe!(
+            class = "cognition.analyze.noop_single_specialty",
+            message_id = %input.message_id,
+            specialties_seen = ?input.known_specialties,
+            "skipped LLM — single-specialty room"
+        );
         let now = now_ms();
         return Ok(SharedAnalysis {
             message_id: input.message_id,
@@ -126,6 +154,19 @@ pub async fn analyze(input: AnalysisInput) -> Result<SharedAnalysis, AnalysisErr
         if !is_stale(&cached) {
             let mut hit = cached.clone();
             hit.from_cache = true;
+            // RTOS-debugger breakpoint: cache hit means N-1 personas
+            // in this room skip the LLM call entirely — one of the
+            // substrate's biggest correctness/perf wins. If hit-rate
+            // is low across a run, the cache key is too granular
+            // (continuum#1206 history-inclusion bug).
+            crate::probe!(
+                class = "cognition.analyze.cache_hit",
+                message_id = %input.message_id,
+                cache_key = %cache_key,
+                model_used = %hit.model_used,
+                angles_count = hit.suggested_angles.len(),
+                "L1 cache hit"
+            );
             return Ok(hit);
         }
         // Stale: drop and fall through to re-analysis.
@@ -272,6 +313,32 @@ async fn run_analysis(
     let stripped = strip_think_blocks(&response.text);
     let parsed = parse_model_output(&stripped, &input.known_specialties)?;
     let duration_ms = start.elapsed().map(|d| d.as_millis() as u64).unwrap_or(0);
+
+    // RTOS-debugger breakpoint: the analyze LLM finished and we
+    // parsed its output. Surfaces the per-specialty angle decision
+    // (count of empty vs non-empty angles) — the key signal
+    // shaping which personas the orchestrator picks as responders.
+    // If at LCD tier every angle comes back non-empty for trivial
+    // messages, this probe is where the diagnosis starts.
+    let empty_angles: usize = parsed
+        .suggested_angles
+        .values()
+        .filter(|v| v.is_empty())
+        .count();
+    let non_empty_angles = parsed.suggested_angles.len().saturating_sub(empty_angles);
+    crate::probe!(
+        class = "cognition.analyze.parse",
+        message_id = %input.message_id,
+        model_used = %response.model,
+        analyze_duration_ms = duration_ms,
+        angles_total = parsed.suggested_angles.len(),
+        angles_non_empty = non_empty_angles,
+        angles_empty = empty_angles,
+        intent = ?parsed.intent,
+        summary_len = parsed.summary.len(),
+        key_concepts_count = parsed.key_concepts.len(),
+        "parsed analyze output"
+    );
 
     Ok(SharedAnalysis {
         message_id: input.message_id,

--- a/src/workers/continuum-core/src/persona/response.rs
+++ b/src/workers/continuum-core/src/persona/response.rs
@@ -236,6 +236,24 @@ async fn respond_inner(
 ) -> Result<PersonaResponse, String> {
     use crate::persona::trace::{SEAM_ANALYZE, SEAM_INFERENCE, SEAM_POST_PROCESS};
 
+    // RTOS-debugger breakpoint: respond cycle entry. Captures who's
+    // responding to what, plus the size of the contextual inputs the
+    // brain will see. See docs/architecture/RTOS-DEBUGGER-PROBES.md
+    // class taxonomy for the stable name.
+    crate::probe!(
+        class = "persona.response.enter",
+        persona = %input.persona.display_name,
+        persona_id = %input.persona.persona_id,
+        room_id = %input.turn_context.room_id,
+        message_id = %input.message_id,
+        message_text_len = input.message_text.len(),
+        history_count = input.turn_context.recent_history.len(),
+        known_specialties = input.turn_context.known_specialties.len(),
+        media_count = input.message_media.len(),
+        recalled_engrams = input.recalled_engrams.len(),
+        "respond_inner entry"
+    );
+
     // 1. Shared analysis (cached per message+room+history fingerprint).
     //    Provides matched-angle hints for the prompt — informational,
     //    NOT gating. The persona's own model is the only thing that
@@ -285,6 +303,30 @@ async fn respond_inner(
         }),
     );
 
+    // RTOS-debugger breakpoint: what the analyze stage gave THIS
+    // persona to work with. The matched-angle is the substrate's
+    // signal that THIS persona's specialty is relevant — empty
+    // string means "no specific perspective for you in this turn",
+    // which materially shapes the render below.
+    let matched_angle_for_probe = analysis
+        .suggested_angles
+        .get(&input.persona.specialty)
+        .cloned()
+        .unwrap_or_default();
+    crate::probe!(
+        class = "persona.response.analyze.result",
+        persona = %input.persona.display_name,
+        specialty = %input.persona.specialty,
+        from_cache = analysis.from_cache,
+        model_used = %analysis.model_used,
+        analyze_duration_ms = now_ms().saturating_sub(analyze_start),
+        suggested_angles_count = analysis.suggested_angles.len(),
+        matched_angle_present = !matched_angle_for_probe.is_empty(),
+        matched_angle_len = matched_angle_for_probe.len(),
+        intent = ?analysis.intent,
+        "analyze result for persona"
+    );
+
     // 2. Render. No external "should this persona respond" gate. Joel
     //    rule (2026-04-22): personas emulate humans — they choose
     //    themselves whether to engage. The earlier `score_persona`
@@ -317,6 +359,25 @@ async fn respond_inner(
         }),
     );
 
+    // RTOS-debugger breakpoint: what came OUT of the LLM. The
+    // single most diagnostic snapshot in the cognition cycle —
+    // every bug report about persona behavior ultimately compares
+    // "what the model produced" against "what it should have
+    // produced." Capture the raw text in full (truncation lives
+    // in the operator's jq query, not here) so a later replay
+    // can reconstruct the model's actual output verbatim. Per
+    // [[jtag-probes-are-rtos-debugger]]: "what's going in and
+    // out of an LLM."
+    crate::probe!(
+        class = "persona.response.render.raw",
+        persona = %input.persona.display_name,
+        model_used = %raw_response.model_used,
+        raw_text_len = raw_response.text.len(),
+        raw_text = %raw_response.text,
+        inference_ms = inference_ms,
+        "LLM produced raw output"
+    );
+
     let post_start = now_ms();
     let (think_stripped_text, think_count) = strip_thinks_emit_events(
         &raw_response.text,
@@ -335,12 +396,31 @@ async fn respond_inner(
         }),
     );
 
+    let total_ms = now_ms().saturating_sub(total_start);
+
+    // RTOS-debugger breakpoint: the persona's final answer to
+    // "what does this turn produce?" Pair with `persona.response.enter`
+    // (same persona_id + message_id) for a complete turn record.
+    crate::probe!(
+        class = "persona.response.exit.spoke",
+        persona = %input.persona.display_name,
+        persona_id = %input.persona.persona_id,
+        message_id = %input.message_id,
+        visible_text_len = visible_text.len(),
+        visible_text = %visible_text,
+        think_blocks = think_count,
+        model_used = %raw_response.model_used,
+        total_ms = total_ms,
+        inference_ms = inference_ms,
+        "spoke"
+    );
+
     Ok(PersonaResponse::Spoke {
         persona_id: input.persona.persona_id,
         text: visible_text,
         model_used: raw_response.model_used,
         inference_ms,
-        total_ms: now_ms().saturating_sub(total_start),
+        total_ms,
         think_blocks_emitted: think_count,
     })
 }
@@ -417,6 +497,12 @@ async fn run_render(
         .map(|m| m.multi_party_strategy.clone())
         .unwrap_or_default();
 
+    // Capture probe signals BEFORE moving matched_angle + history
+    // into PromptAssemblyInput. Bool + usize are Copy; the probe
+    // below reads from these locals after the move.
+    let matched_angle_present_for_probe = !matched_angle.is_empty();
+    let history_count_for_probe = history.len();
+
     let prompt_input = PromptAssemblyInput {
         persona_name: input.persona.display_name.clone(),
         system_prompt: input.system_prompt.clone(),
@@ -437,6 +523,29 @@ async fn run_render(
     };
 
     let assembled = assemble(&prompt_input);
+
+    // RTOS-debugger breakpoint: what's going INTO the LLM. Captures
+    // the assembled prompt verbatim so an operator can read exactly
+    // what the model was asked to do — the most informative single
+    // snapshot for cognition bugs (missing instructions, drifted
+    // template, wrong angle injection, social-block absence). Per
+    // [[jtag-probes-are-rtos-debugger]]: "what's going in and out
+    // of an LLM." Going-in lives here; going-out lives in the
+    // `persona.response.render.raw` probe above.
+    crate::probe!(
+        class = "persona.response.render.prompt",
+        persona = %input.persona.display_name,
+        specialty = %input.persona.specialty,
+        model = %input.model,
+        system_message_len = assembled.system_message.len(),
+        system_message = %assembled.system_message,
+        message_count = assembled.messages.len(),
+        estimated_tokens = assembled.estimated_tokens,
+        matched_angle_present = matched_angle_present_for_probe,
+        engrams_count = input.recalled_engrams.len(),
+        history_count = history_count_for_probe,
+        "prompt assembled for inference"
+    );
 
     // 3. Build the inference request from the assembled prompt.
     //


### PR DESCRIPTION
## Summary

Follow-up to PR #1535 (foundation, merged). Wires the first batch of probes into the cognition seams Joel named as the diagnostic target: "we what's going in and out of an LLM or its subconscious processes, where they're slow or incorrect."

Per `[[jtag-probes-are-rtos-debugger]]`: probes are non-blocking breakpoints with variable inspection. None of these change behavior — they observe state, don't decide it. Per `[[no-rust-gates-around-cognition]]`: every probe in this slice is read-only state capture; none changes flow.

## What gets wired (5 new probes across 2 files)

### `persona::response::respond_inner`

- **`persona.response.enter`** — turn entry: persona / persona_id / room_id / message_id / message_text_len / history_count / known_specialties / media_count / recalled_engrams. Pair with `persona.response.exit.spoke` (same message_id) for a complete turn record.
- **`persona.response.analyze.result`** — what the analyze stage gave THIS persona. from_cache / model_used / analyze_duration_ms / suggested_angles_count / **matched_angle_present** / intent. Critical signal: a tiny model returning non-empty angles for every specialty on every message is the echo-storm root cause.
- **`persona.response.exit.spoke`** — final answer: visible_text + len / think_blocks / model_used / total_ms / inference_ms.

### `persona::response::run_render`

- **`persona.response.render.prompt`** — **what's going INTO the LLM.** Captures `assembled.system_message` verbatim plus message_count, estimated_tokens, matched_angle_present, engrams_count, history_count. The single most informative snapshot for cognition bugs (missing instructions, drifted template, wrong angle injection, social-block absence).
- **`persona.response.render.raw`** — **what came OUT of the LLM.** Captures `raw_response.text` verbatim before any post-process. Pair with `.render.prompt` to reconstruct the exact model contract for every turn.

### `cognition::shared_analysis::analyze` (the "subconscious" stage)

- **`cognition.analyze.enter`** — input fingerprint at entry. Correlates N personas hitting the single-flight cache via the same message_id.
- **`cognition.analyze.noop_single_specialty`** — short-circuit fired (single-specialty room → empty angles, no LLM call). Distinguishes "I chose silence because no angle matched" from "analyze didn't run" — identical downstream without this signal.
- **`cognition.analyze.cache_hit`** — L1 hit → N-1 personas skip the LLM. Hit-rate is load-bearing for multi-persona rooms.
- **`cognition.analyze.parse`** — the parsed angle decision shape: total / non-empty / empty + intent / summary_len / key_concepts_count + analyze_duration_ms. The diagnostic starting point for "why is every persona responding to a trivial greeting?" — empty-vs-non-empty ratio shows whether the LCD-tier model defaults to filling every angle.

## Manual updated

`docs/architecture/RTOS-DEBUGGER-PROBES.md` sprinkle checklist now shows which seams are wired (`response_inner`, `run_render`, `shared_analysis`) and which are still pending (service_loop turn boundaries + timing).

## Build / tests

Build clean with `--features metal`. Sink tests 5/5 pass (no new ones — these are probe call-sites, not new infrastructure; their value is operational, exercised by the existing scenarios that will use `CONTINUUM_PROBE_FILE` + `CONTINUUM_PROBE_CLASSES`).

## Doctrine

- `[[jtag-probes-are-rtos-debugger]]` — RTOS-style breakpoints with variable inspection. One line at each seam.
- `[[no-rust-gates-around-cognition]]` — probes OBSERVE, they do not decide.

card: `8d7ca5c3`
parent task: #151 (debug the silence-affordance bug INSIDE the cognition by reading the LLM's actual in/out)
foundation: #1535 (merged)
