### PR TITLE
feat(probes): service_loop turn boundaries + phase decomposition (#151 sprinkle 2)

### DIFF
--- a/docs/architecture/RTOS-DEBUGGER-PROBES.md
+++ b/docs/architecture/RTOS-DEBUGGER-PROBES.md
@@ -170,10 +170,10 @@ The infrastructure exists (Slice P, #176/#177): `routing/macros.rs` (macros), `r
 
 What is INCOMPLETE — the sprinkle that turns the JTAG hardware into a working debugger:
 
-- [x] `persona/response.rs::respond_inner` — entry, analyze result, raw LLM output (full text), exit-spoke — **wired in this PR**
-- [x] `persona/response.rs::run_render` — assembled prompt verbatim + composition stats — **wired in this PR**
-- [x] `cognition/shared_analysis/mod.rs::analyze` — entry, single-specialty noop, L1 cache hit, parsed angles (empty vs non-empty count) — **wired in this PR**
-- [ ] `persona/service_loop.rs::serve_persona_loop_inner` — turn boundaries, recall + admit + compose + respond + say (with timings) — next PR
+- [x] `persona/response.rs::respond_inner` — entry, analyze result, raw LLM output (full text), exit-spoke
+- [x] `persona/response.rs::run_render` — assembled prompt verbatim + composition stats
+- [x] `cognition/shared_analysis/mod.rs::analyze` — entry, single-specialty noop, L1 cache hit, parsed angles (empty vs non-empty count)
+- [x] `persona/service_loop.rs::serve_persona_loop_inner` — `turn.start` / `turn.spoke` (with full phase decomposition recall+admit+compose+respond+say) / `turn.silent` (with reason) / `turn.error` (with stage=respond|say) — **wired in this PR**
 - [ ] `persona/prompt_assembly.rs::assemble` — final composition stats (system_message length, message count, est tokens, matched_angle present, engrams count, social_signals present) — covered indirectly by `persona.response.render.prompt`; standalone probe TBD if assembly logic grows
 - [ ] `cognition/response_orchestrator.rs::score_persona` — per-persona score + matched_angles + decision reason — note: the score_persona gate is currently bypassed (response.rs:288–300); probes go in if/when it's re-wired
 - [ ] `ai/llama_cpp_adapter::generate_text` — request fingerprint + raw output + finish_reason — covered indirectly by `persona.response.render.prompt` (in) + `persona.response.render.raw` (out); adapter-level probe TBD when we need per-batch visibility

--- a/src/workers/continuum-core/src/persona/service_loop.rs
+++ b/src/workers/continuum-core/src/persona/service_loop.rs
@@ -370,6 +370,23 @@ async fn serve_persona_loop_inner(
         // `turn_latency` (sample-set identical).
         let mut phase_timings = PhaseTimings::default();
 
+        // RTOS-debugger breakpoint: turn entry at the service-loop
+        // level. Pair with `persona.turn.spoke` /
+        // `persona.turn.silent` / `persona.turn.error` (same lamport)
+        // for the complete per-turn record. The `respond_inner`-level
+        // probes (`persona.response.enter` etc.) live INSIDE the
+        // cognition; this one names the airc-boundary turn.
+        crate::probe!(
+            class = "persona.turn.start",
+            persona = %ctx.identity.agent_name,
+            persona_id = %ctx.identity.persona_id,
+            room_id = %ctx.identity.default_room,
+            lamport = msg.lamport,
+            peer_id = %msg.peer_id,
+            text_len = msg.text.len(),
+            "turn started"
+        );
+
         // ===========================================================
         // The brain services the turn through the canonical cognition
         // pipeline — `persona::response::respond(RespondInput)`. This
@@ -582,6 +599,18 @@ async fn serve_persona_loop_inner(
                     error = %e,
                     "respond cycle failed"
                 );
+                // RTOS-debugger breakpoint: turn failed somewhere
+                // inside the cognition cycle. Pair with the inner
+                // `persona.response.enter` probe (same persona +
+                // message_id) to find which stage threw.
+                crate::probe!(
+                    class = "persona.turn.error",
+                    persona = %ctx.identity.agent_name,
+                    lamport = msg.lamport,
+                    stage = "respond",
+                    error = %e,
+                    "respond cycle failed"
+                );
                 outcome.turns_errored += 1;
                 continue;
             }
@@ -593,6 +622,21 @@ async fn serve_persona_loop_inner(
                     lamport = msg.lamport,
                     reason = %reason,
                     "persona chose silence — substrate honors decision"
+                );
+                // RTOS-debugger breakpoint: persona chose silence as
+                // its own cognitive output (the canonical
+                // PersonaResponse::Silent path, not the substrate
+                // skipping the turn). The `reason` field is the
+                // persona's own explanation — load-bearing for
+                // diagnosing "why didn't this persona respond?"
+                // vs "why is no persona responding to anything?"
+                // (which is a cognition.analyze.parse signal).
+                crate::probe!(
+                    class = "persona.turn.silent",
+                    persona = %ctx.identity.agent_name,
+                    lamport = msg.lamport,
+                    reason = %reason,
+                    "persona chose silence"
                 );
                 outcome.turns_skipped += 1;
                 continue;
@@ -610,11 +654,43 @@ async fn serve_persona_loop_inner(
                 error = %e,
                 "say failed"
             );
+            // RTOS-debugger breakpoint: cognition succeeded, airc
+            // publish failed. Distinct error stage from
+            // `stage="respond"`.
+            crate::probe!(
+                class = "persona.turn.error",
+                persona = %ctx.identity.agent_name,
+                lamport = msg.lamport,
+                stage = "say",
+                error = %e,
+                "airc publish failed"
+            );
             outcome.turns_errored += 1;
             continue;
         }
         let turn_duration_ms = turn_started.elapsed().as_millis() as u64;
         outcome.turn_latency.record(turn_duration_ms);
+
+        // RTOS-debugger breakpoint: turn completed successfully.
+        // The phase fields below are the per-phase decomposition
+        // from #195 slice 1 — together they let an operator find
+        // bottlenecks (recall is slow? compose is slow?) without
+        // a separate timing probe per stage. Per Joel
+        // [[jtag-probes-are-rtos-debugger]]: "timing of anything,
+        // so we can hunt down bottlenecks."
+        crate::probe!(
+            class = "persona.turn.spoke",
+            persona = %ctx.identity.agent_name,
+            lamport = msg.lamport,
+            response_len = response_text.len(),
+            turn_duration_ms = turn_duration_ms,
+            recall_ms = phase_timings.recall_ms,
+            admit_ms = phase_timings.admit_ms,
+            compose_ms = phase_timings.compose_ms,
+            respond_ms = phase_timings.respond_ms,
+            say_ms = phase_timings.say_ms,
+            "turn complete"
+        );
         // Per #195 slice 1: record the phase decomposition. Same
         // sample set as `turn_latency` — only successful replies
         // reach this point.


### PR DESCRIPTION
## Summary

Follow-up to PR #1535 (foundation) + #1536 (sprinkle 1 — both merged). Wires probes at the per-persona service-loop turn boundaries so an operator can reconstruct every turn as a complete record (start → spoke/silent/error) and find phase-level bottlenecks from one JSONL log.

Per Joel's RTOS-debugger framing `[[jtag-probes-are-rtos-debugger]]`: "timing of anything, so we can hunt down bottlenecks." The `persona.turn.spoke` probe carries the full 5-phase decomposition (`recall_ms` + `admit_ms` + `compose_ms` + `respond_ms` + `say_ms`) so one `jq` query surfaces which phase is dominating wall-clock without N separate timing blocks.

## What gets wired (4 new probes)

- **`persona.turn.start`** — turn entry at the airc boundary (after self-loop / pre-watermark filters, before any cognition call). persona / persona_id / room_id / lamport / peer_id / text_len. Pair with the spoke/silent/error variants (same lamport) for the complete turn record.
- **`persona.turn.spoke`** — turn completed successfully with FULL phase decomposition: response_len / turn_duration_ms / recall_ms / admit_ms / compose_ms / respond_ms / say_ms. The bottleneck-hunting workhorse.
- **`persona.turn.silent`** — persona's own cognitive output was Silence (`PersonaResponse::Silent` from the canonical cycle). reason (verbatim from the brain) + lamport + persona.
- **`persona.turn.error`** — turn failed downstream of cognition entry. `stage = "respond" | "say"` distinguishes a cognition-cycle failure from an airc-publish failure.

## Manual updated

`docs/architecture/RTOS-DEBUGGER-PROBES.md` checklist now shows `persona/service_loop.rs::serve_persona_loop_inner` as wired. Remaining open items (`prompt_assembly` standalone, `score_persona` re-wire, `llama_cpp_adapter` per-batch) are noted as covered indirectly by the existing probes — re-evaluate when a real debug session needs deeper visibility there.

## Build / tests

Build clean with `--features metal`. Sink tests 5/5 pass (no new infrastructure; these are call sites against the existing JsonlProbeFileSink). The probes are operationally exercised by any scenario that runs `serve_persona_loop` with `CONTINUUM_PROBE_FILE` set.

## Doctrine

- `[[jtag-probes-are-rtos-debugger]]` — RTOS breakpoints with variable inspection + timing.
- `[[no-rust-gates-around-cognition]]` — every probe in this slice is read-only state capture; none changes flow.

card: `b390a821`
parent task: #151
foundation: #1535 (merged)
sprinkle 1: #1536 (merged)
