### PR TITLE
feat(probes): convenient debugging — prefix filter + boot wiring + env coupling at one seam (#151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,8 @@ let scored = time_sync!("recall_l2", {
 ```bash
 # Enable disk capture (no recompile, env vars only):
 export CONTINUUM_PROBE_FILE=/tmp/continuum-probes.jsonl
-export CONTINUUM_PROBE_CLASSES=persona.turn.start,persona.turn.silent,persona.response.render.prompt
+export CONTINUUM_PROBE_CLASSES=persona,cognition  # namespace prefixes — captures every persona.* and cognition.*
+# Or `*` for the full firehose, or specific classes like `persona.turn.spoke,cognition.analyze.parse`
 
 # Then tail / jq the breakpoint stream as the substrate runs:
 tail -f /tmp/continuum-probes.jsonl | jq -c 'select(.fields.persona == "Paige")'

--- a/docs/architecture/RTOS-DEBUGGER-PROBES.md
+++ b/docs/architecture/RTOS-DEBUGGER-PROBES.md
@@ -77,12 +77,25 @@ A stable set of `class` values so probes from different files compose into a coh
 Two environment variables — no recompile, no config file:
 
 ```bash
+# Capture every persona.* probe + every cognition.* probe to disk
 export CONTINUUM_PROBE_FILE=/tmp/continuum-probes.jsonl
-export CONTINUUM_PROBE_CLASSES=persona.turn.start,persona.turn.silent,persona.turn.spoke,persona.response.render.prompt
+export CONTINUUM_PROBE_CLASSES=persona,cognition
+
+# Or capture EVERYTHING (the firehose):
+export CONTINUUM_PROBE_CLASSES=*
+
+# Or mix exact classes with namespace prefixes:
+export CONTINUUM_PROBE_CLASSES=cognition.analyze.parse,persona.turn,timing
 ```
 
 - `CONTINUUM_PROBE_FILE` (path) — append-only JSONL log. Unset = file sink absent. Directory must exist; the sink errors loudly if not (no silent drop per `[[no-fallbacks-ever]]`).
-- `CONTINUUM_PROBE_CLASSES` (comma-separated) — exact-match class filter. Empty / unset = capture every class. Exact match (no globs) keeps the per-event filter to a single HashSet lookup.
+- `CONTINUUM_PROBE_CLASSES` (comma-separated) — class filter. Each value is matched against each probe's `class` by one of three rules (same convention as `tracing_subscriber`'s `RUST_LOG`):
+
+  1. **`*`** — wildcard; matches every class. Use to capture the firehose and filter offline with `jq`.
+  2. **Exact match** — `cognition.analyze.parse` matches only that one class.
+  3. **Namespace prefix** — `persona` matches `persona.turn.spoke`, `persona.response.enter`, every `persona.*`. Implementation: `class == filter || class.starts_with(filter + ".")` — the `.` guard prevents `persona` from accidentally matching `personality.x`.
+
+  Empty / unset = no filter configured, every class passes. `*` is the explicit "capture all" intent per `[[no-fallbacks-ever]]`.
 
 The sink is installed at process startup via `JsonlProbeFileSink::from_env()` — composes with `ProbeRouterLayer` (broadcast subscribers) and `UriCaptureLayer` (URI ancestry). Both consumers see every probe independently.
 

--- a/docs/architecture/RTOS-DEBUGGER-PROBES.md
+++ b/docs/architecture/RTOS-DEBUGGER-PROBES.md
@@ -97,7 +97,11 @@ export CONTINUUM_PROBE_CLASSES=cognition.analyze.parse,persona.turn,timing
 
   Empty / unset = no filter configured, every class passes. `*` is the explicit "capture all" intent per `[[no-fallbacks-ever]]`.
 
-The sink is installed at process startup via `JsonlProbeFileSink::from_env()` — composes with `ProbeRouterLayer` (broadcast subscribers) and `UriCaptureLayer` (URI ancestry). Both consumers see every probe independently.
+The sink is installed at process startup by `routing::install_probe_tracing(config)`, which composes `UriCaptureLayer` (URI ancestry) + `ProbeRouterLayer` (in-process broadcast) + `JsonlProbeFileSink` (disk, when `config.probe_file` is set) + a fmt layer governed by `RUST_LOG` — all in one call.
+
+The installer takes a typed `ProbeTracingConfig { probe_file, probe_classes, default_filter }` — NOT env vars directly. Env coupling lives at exactly one seam: `ProbeTracingConfig::from_env(default_filter)`. This keeps the library function parallel-test-safe (no `std::env::set_var` racing under `cargo test`) and puts every config source (env, file, CLI flags, hardcoded) on equal footing.
+
+`continuum-core-server`'s `main()` calls `install_probe_tracing(ProbeTracingConfig::from_env("info"))?`. Tests / demos that want a clean per-call probe stack construct `ProbeTracingConfig` directly and pass a tmpdir path — no env mutation, no flakes. The install is idempotent via `try_init` so re-init from multiple sites is safe. When `config.probe_file` is set, the server prints `probes landing at <path>` at boot so the operator sees the env var took effect.
 
 ### Read
 

--- a/src/workers/continuum-core/src/main.rs
+++ b/src/workers/continuum-core/src/main.rs
@@ -29,11 +29,11 @@ use continuum_core::memory::{ModuleBackedEmbeddingProvider, PersonaMemoryManager
 ///
 /// Usage: continuum-core-server <socket-path>
 /// Example: continuum-core-server /tmp/continuum-core.sock
+use continuum_core::routing::{install_probe_tracing, ProbeTracingConfig};
 use continuum_core::start_server;
 use std::env;
 use std::sync::Arc;
-use tracing::{info, Level};
-use tracing_subscriber::FmtSubscriber;
+use tracing::info;
 
 /// Install signal handlers that kill all sentinel process groups on shutdown.
 /// This prevents orphaned training processes from eating memory after npm stop.
@@ -84,12 +84,24 @@ fn install_shutdown_handlers() {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize logging
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::INFO)
-        .with_writer(std::io::stderr)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+    // Substrate-canonical tracing stack: UriCapture + ProbeRouter +
+    // optional JsonlProbeFileSink + fmt-to-stderr governed by
+    // RUST_LOG (default `info`). See
+    // docs/architecture/RTOS-DEBUGGER-PROBES.md.
+    //
+    // Env-coupling lives at exactly one seam: `from_env(...)`. The
+    // installer takes only typed values — tests construct config
+    // directly without racing `std::env::set_var`. Setting
+    // `CONTINUUM_PROBE_FILE=/tmp/probes.jsonl` lights up the JSONL
+    // sink with zero binary changes; the boot log below reports
+    // the path so the operator sees it landed.
+    let probe_install = install_probe_tracing(ProbeTracingConfig::from_env("info"))?;
+    if let Some(ref path) = probe_install.probe_log_path {
+        // Use println so it appears even when RUST_LOG filters out
+        // info-level tracing events — the operator who just set the
+        // env var SHOULD see this confirmation.
+        eprintln!("[continuum-core-server] probes landing at {}", path.display());
+    }
 
     // Parse command line arguments. argv[1] is the IPC socket path (positional)
     // — but intercept flag-like values FIRST so `--version` and `--help` don't

--- a/src/workers/continuum-core/src/routing/mod.rs
+++ b/src/workers/continuum-core/src/routing/mod.rs
@@ -38,6 +38,7 @@ pub mod macros;
 pub mod probe_file_sink;
 pub mod probe_router;
 pub mod route_decision;
+pub mod tracing_init;
 pub mod transport;
 pub mod uri_layer;
 pub mod verdict;
@@ -79,6 +80,7 @@ pub use probe_file_sink::{
     JsonlProbeFileSink, ProbeFileSinkError, ENV_PROBE_CLASSES, ENV_PROBE_FILE,
 };
 pub use probe_router::{ProbeEvent, ProbeRouterLayer, DEFAULT_CHANNEL_CAPACITY};
+pub use tracing_init::{install_probe_tracing, ProbeInstall, ProbeTracingConfig};
 pub use route_decision::{route, RouteDecision, RouteKind};
 pub use transport::{ClosureTransport, NotImplementedRemoteTransport, Transport};
 pub use uri_layer::{current_uri_chain, UriCaptureLayer, UriFrame};

--- a/src/workers/continuum-core/src/routing/probe_file_sink.rs
+++ b/src/workers/continuum-core/src/routing/probe_file_sink.rs
@@ -30,12 +30,24 @@
 //!   Unset = sink absent. The directory must exist (sink errors on
 //!   open if not; honest failure beats silent drop per
 //!   `[[no-fallbacks-ever]]`).
-//! - `CONTINUUM_PROBE_CLASSES=persona.render,persona.analyze,timing`
-//!   — comma-separated allowed-classes filter. Empty / unset = ALL
-//!   classes. Glob/regex deliberately NOT supported in this slice;
-//!   exact-match keeps the filter cheap (single HashSet lookup per
-//!   event) and the conventional class taxonomy in `persona::probes`
-//!   gives operators a discoverable set to choose from.
+//! - `CONTINUUM_PROBE_CLASSES=persona,cognition.analyze` — comma-
+//!   separated allowed-classes filter. Each value is matched against
+//!   each probe's class field by ONE of three rules:
+//!
+//!     1. `*` — wildcard, matches every class. Use when you want to
+//!        capture EVERYTHING and filter offline with `jq`.
+//!     2. Exact match — `cognition.analyze.parse` matches only
+//!        `cognition.analyze.parse`.
+//!     3. Namespace prefix — `persona` matches `persona.turn.spoke`,
+//!        `persona.response.enter`, etc. (the `persona.` prefix), but
+//!        does NOT match a hypothetical `personality.x`. Concretely
+//!        the rule is `class == filter || class.starts_with(filter + ".")`.
+//!
+//!   Same convention as tracing's `RUST_LOG`. Empty / unset = ALL
+//!   classes pass (file sink with no filter = full capture). Per
+//!   `[[no-fallbacks-ever]]`: `*` is the EXPLICIT all-classes
+//!   value; an empty filter set is a deliberate "no filter
+//!   configured."
 //!
 //! ## Output format
 //!
@@ -252,7 +264,9 @@ where
         };
 
         // Class filter — early-out before allocating the envelope.
-        if !self.allowed_classes.is_empty() && !self.allowed_classes.contains(&class) {
+        // Three-rule match per the module docstring: empty set = all
+        // pass, `*` = wildcard, otherwise exact or namespace-prefix.
+        if !class_passes_filter(&class, &self.allowed_classes) {
             return;
         }
 
@@ -270,6 +284,41 @@ where
 
         self.write_one(captured_at_ms, &probe_event);
     }
+}
+
+/// Decide whether a probe's `class` passes the operator-configured
+/// filter set. Pure function — separable for unit testing and so
+/// any future per-event optimization (lower-cased lookup, trie,
+/// etc.) drops in without touching the Layer impl.
+///
+/// Rules (in priority order):
+///
+/// 1. **Empty filter set** = "no filter configured." Every class
+///    passes. Used when `CONTINUUM_PROBE_CLASSES` is unset — full
+///    capture.
+/// 2. **`*` is in the set** = explicit "match every class" wildcard.
+///    Different from rule 1 only in intent: `*` is the deliberate
+///    capture-everything signal an operator types when they want
+///    the firehose. Per `[[no-fallbacks-ever]]` the substrate
+///    distinguishes "no filter" from "explicit `*`" so both are
+///    honest decisions.
+/// 3. **Exact or namespace prefix.** A filter `F` matches a class
+///    `C` if `C == F` (exact) OR `C.starts_with(F.to_string() + ".")`
+///    (namespace prefix — `persona` matches `persona.turn.spoke`
+///    but NOT `personality.x`). Same convention as
+///    `tracing_subscriber::EnvFilter`. Keeps comma-separated env
+///    var values short — `CONTINUUM_PROBE_CLASSES=persona`
+///    captures every `persona.*` class without enumerating.
+pub(crate) fn class_passes_filter(class: &str, filter: &HashSet<String>) -> bool {
+    if filter.is_empty() {
+        return true;
+    }
+    if filter.contains("*") {
+        return true;
+    }
+    filter.iter().any(|f| {
+        class == f || (class.len() > f.len() + 1 && class.starts_with(f) && class[f.len()..].starts_with('.'))
+    })
 }
 
 /// Visitor that pulls `probe_class`, `message`, and every other
@@ -385,6 +434,132 @@ mod tests {
         assert_eq!(lines[0]["message"], "rendered");
         assert_eq!(lines[0]["fields"]["persona"], "Paige");
         assert!(lines[0]["captured_at_ms"].as_u64().unwrap() > 0);
+    }
+
+    #[test]
+    fn class_filter_namespace_prefix_matches_subclasses() {
+        // Prefix `persona` should match every persona.* class but
+        // NOT `personality.foo` (the dot guard prevents partial-
+        // word collisions). Per the docstring's rule 3.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("probes.jsonl");
+
+        let mut allowed = HashSet::new();
+        allowed.insert("persona".to_string());
+
+        let sink = JsonlProbeFileSink::new(&path, allowed).unwrap();
+        let subscriber = tracing_subscriber::registry()
+            .with(crate::routing::UriCaptureLayer::new())
+            .with(sink);
+
+        tracing::subscriber::with_default(subscriber, || {
+            crate::probe!(class = "persona.turn.spoke", "kept");
+            crate::probe!(class = "persona.response.render.prompt", "kept");
+            crate::probe!(class = "personality.something", "dropped");
+            crate::probe!(class = "cognition.analyze.parse", "dropped");
+        });
+
+        let lines = read_jsonl(&path);
+        assert_eq!(lines.len(), 2, "namespace prefix must drop both non-matching classes");
+        let kept_classes: Vec<&str> =
+            lines.iter().map(|l| l["class"].as_str().unwrap()).collect();
+        assert!(kept_classes.contains(&"persona.turn.spoke"));
+        assert!(kept_classes.contains(&"persona.response.render.prompt"));
+    }
+
+    #[test]
+    fn class_filter_wildcard_matches_every_class() {
+        // `*` is the EXPLICIT capture-everything filter — different
+        // intent from "empty set means no filter" per the
+        // [[no-fallbacks-ever]] doctrine, but operationally equivalent
+        // (every class passes). Used when an operator types
+        // `CONTINUUM_PROBE_CLASSES=*` to deliberately request the
+        // firehose.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("probes.jsonl");
+
+        let mut allowed = HashSet::new();
+        allowed.insert("*".to_string());
+
+        let sink = JsonlProbeFileSink::new(&path, allowed).unwrap();
+        let subscriber = tracing_subscriber::registry()
+            .with(crate::routing::UriCaptureLayer::new())
+            .with(sink);
+
+        tracing::subscriber::with_default(subscriber, || {
+            crate::probe!(class = "persona.turn.spoke", "kept");
+            crate::probe!(class = "cognition.analyze.parse", "kept");
+            crate::probe!(class = "timing", "kept");
+        });
+
+        let lines = read_jsonl(&path);
+        assert_eq!(lines.len(), 3, "wildcard must capture every class");
+    }
+
+    #[test]
+    fn class_filter_combines_exact_and_prefix_in_one_set() {
+        // Operator's typical pattern: one specific class for a
+        // hard-to-find probe + a whole namespace for the broad
+        // picture. The filter must support both shapes in the same
+        // HashSet without rule contention.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("probes.jsonl");
+
+        let mut allowed = HashSet::new();
+        allowed.insert("cognition.analyze.parse".to_string()); // exact
+        allowed.insert("persona.turn".to_string()); // namespace
+
+        let sink = JsonlProbeFileSink::new(&path, allowed).unwrap();
+        let subscriber = tracing_subscriber::registry()
+            .with(crate::routing::UriCaptureLayer::new())
+            .with(sink);
+
+        tracing::subscriber::with_default(subscriber, || {
+            crate::probe!(class = "cognition.analyze.parse", "kept exact");
+            crate::probe!(class = "cognition.analyze.cache_hit", "dropped");
+            crate::probe!(class = "persona.turn.spoke", "kept prefix");
+            crate::probe!(class = "persona.turn.start", "kept prefix");
+            crate::probe!(class = "persona.response.enter", "dropped");
+        });
+
+        let lines = read_jsonl(&path);
+        assert_eq!(lines.len(), 3);
+    }
+
+    #[test]
+    fn class_passes_filter_pure_function_unit_tests() {
+        // Pure-function spec for the helper. Locks the rules from the
+        // docstring so future refactors of the per-event Layer code
+        // can't drift the matching contract.
+        use super::class_passes_filter;
+
+        // Rule 1: empty filter = all pass
+        let empty = HashSet::new();
+        assert!(class_passes_filter("persona.turn.spoke", &empty));
+        assert!(class_passes_filter("anything.at.all", &empty));
+
+        // Rule 2: wildcard = all pass
+        let mut wild = HashSet::new();
+        wild.insert("*".to_string());
+        assert!(class_passes_filter("persona.turn.spoke", &wild));
+        assert!(class_passes_filter("cognition.analyze.parse", &wild));
+
+        // Rule 3a: exact match
+        let mut exact = HashSet::new();
+        exact.insert("persona.turn.spoke".to_string());
+        assert!(class_passes_filter("persona.turn.spoke", &exact));
+        assert!(!class_passes_filter("persona.turn.silent", &exact));
+
+        // Rule 3b: namespace prefix with dot guard
+        let mut ns = HashSet::new();
+        ns.insert("persona".to_string());
+        assert!(class_passes_filter("persona.turn.spoke", &ns));
+        assert!(class_passes_filter("persona.response.enter", &ns));
+        assert!(!class_passes_filter("personality.foo", &ns));
+        assert!(!class_passes_filter("cognition.analyze.parse", &ns));
+        // Exact match against the prefix itself (a probe with
+        // class="persona") also matches.
+        assert!(class_passes_filter("persona", &ns));
     }
 
     #[test]

--- a/src/workers/continuum-core/src/routing/tracing_init.rs
+++ b/src/workers/continuum-core/src/routing/tracing_init.rs
@@ -1,0 +1,308 @@
+//! Substrate-wide tracing-subscriber boot composition.
+//!
+//! Every continuum binary (server, demos, tests-that-care-about-probes)
+//! installs the SAME stack of tracing layers in the SAME order, via
+//! [`install_probe_tracing`]. Doing it once-per-binary stops the
+//! probe-availability accidentally diverging between
+//! `continuum-core-server` and the binaries / tests an operator wants
+//! to debug. Per Joel 2026-06-06: "Let's perfect debugging as we use
+//! it" — a single composition function is the substrate-purist way to
+//! keep the JTAG actually on across every entry point.
+//!
+//! ## What gets installed
+//!
+//! In order — each layer's docs explain what it does:
+//!
+//! 1. [`UriCaptureLayer`] — captures the URI ancestry chain at probe
+//!    fire time so [`stack!`] returns a meaningful path. Required by
+//!    both the broadcast router and the file sink.
+//! 2. [`ProbeRouterLayer`] — fans every `probe!` event to per-class
+//!    broadcast subscribers. The substrate's `debug/probes/*` URI
+//!    consumers read from this.
+//! 3. [`JsonlProbeFileSink`] — append-only JSONL log on disk, gated
+//!    by `CONTINUUM_PROBE_FILE` env var. Optional — if the env var
+//!    is unset the sink is silently skipped (the operator
+//!    intentionally didn't ask). Path-open failures are LOUD per
+//!    `[[no-fallbacks-ever]]` — caller decides whether to surface or
+//!    swallow the error.
+//! 4. A `fmt` layer reading [`tracing_subscriber::EnvFilter`] from
+//!    `RUST_LOG` (with a sensible default so the server still
+//!    prints info-level lines when nobody set `RUST_LOG`). Writes
+//!    to stderr so stdout stays clean for any caller piping the
+//!    server's output.
+//!
+//! ## Why this lives in `routing`
+//!
+//! Probe routing IS the substrate's per-class fanout primitive. The
+//! tracing-subscriber install is the operational shape that makes
+//! the in-tree macros (`probe!`, `time_sync!`, `stack!`) actually
+//! reach a consumer. Same module as `probe_router` + `probe_file_sink`
+//! + `macros` keeps "the JTAG end-to-end" in one place — anyone
+//! grepping for `JsonlProbeFileSink` lands next to the install
+//! function.
+//!
+//! ## Idempotency
+//!
+//! `try_init()` succeeds the first time and silently no-ops every
+//! subsequent call. Safe to call from a `#[tokio::main]` server
+//! binary AND from a test harness without coordinating across
+//! crates. Tests that want a NEW subscriber (clean capture) can
+//! use `tracing::subscriber::with_default(subscriber, || ...)`
+//! instead — that path doesn't touch the global default.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer};
+
+use super::probe_file_sink::{
+    JsonlProbeFileSink, ProbeFileSinkError, ENV_PROBE_CLASSES, ENV_PROBE_FILE,
+};
+use super::probe_router::ProbeRouterLayer;
+use super::uri_layer::UriCaptureLayer;
+
+/// Typed boot configuration for `install_probe_tracing`.
+///
+/// All env-coupling lives in [`ProbeTracingConfig::from_env`] — the
+/// library installer takes only typed values. Test code constructs
+/// the config directly and passes a tmpdir-relative path; future
+/// alternative sources (config file, CLI flags) become additional
+/// constructors on this struct without rippling into the install
+/// function.
+///
+/// Per Joel 2026-06-06: env vars are brittle (process-global
+/// mutable state, racy under `cargo test`, slated for `unsafe`
+/// marking in Rust 2024). The substrate-purist shape keeps env
+/// coupling at exactly one seam.
+#[derive(Debug, Clone, Default)]
+pub struct ProbeTracingConfig {
+    /// Append-only JSONL probe log path. `None` = no disk capture
+    /// this run.
+    pub probe_file: Option<PathBuf>,
+    /// Class filter passed to [`JsonlProbeFileSink::new`]. Empty
+    /// set = "no filter, every class passes" per the sink's
+    /// [`class_passes_filter`](super::probe_file_sink) rules.
+    pub probe_classes: HashSet<String>,
+    /// `EnvFilter` directive applied to the fmt (stderr) layer when
+    /// `RUST_LOG` is unset. `"info"` for production servers; `"warn"`
+    /// for noisy tests. Empty string falls back to `"info"`.
+    pub default_filter: String,
+}
+
+impl ProbeTracingConfig {
+    /// Read `CONTINUUM_PROBE_FILE` + `CONTINUUM_PROBE_CLASSES` env
+    /// vars into a typed `ProbeTracingConfig`. This is THE seam
+    /// where env coupling lives — every other path through the
+    /// substrate constructs the config directly.
+    ///
+    /// `default_filter` is supplied by the caller because env vars
+    /// don't carry it (`RUST_LOG` is already its own surface for
+    /// the fmt layer; this is the fallback when `RUST_LOG` is
+    /// unset).
+    pub fn from_env(default_filter: &str) -> Self {
+        let probe_file = std::env::var(ENV_PROBE_FILE).ok().map(PathBuf::from);
+        let probe_classes = std::env::var(ENV_PROBE_CLASSES)
+            .ok()
+            .map(|s| {
+                s.split(',')
+                    .map(|c| c.trim().to_string())
+                    .filter(|c| !c.is_empty())
+                    .collect::<HashSet<_>>()
+            })
+            .unwrap_or_default();
+        Self {
+            probe_file,
+            probe_classes,
+            default_filter: default_filter.to_string(),
+        }
+    }
+}
+
+/// Result of the install — tells the caller whether disk capture is
+/// active so it can be logged at boot ("probes landing at
+/// /tmp/x.jsonl" is the kind of one-line confirmation that prevents
+/// the "I set the env var, where are my probes" confusion).
+#[derive(Debug)]
+pub struct ProbeInstall {
+    /// Path the JSONL sink is writing to, if `CONTINUUM_PROBE_FILE`
+    /// was set and the file opened successfully. `None` = no disk
+    /// capture this run (env var unset, OR test path where a
+    /// caller-provided subscriber is already installed).
+    pub probe_log_path: Option<PathBuf>,
+}
+
+/// Install the substrate's canonical tracing stack on the GLOBAL
+/// default subscriber, given a typed [`ProbeTracingConfig`].
+/// Idempotent — calling it from multiple init sites is safe; the
+/// second call no-ops via
+/// `tracing_subscriber::util::SubscriberInitExt::try_init`.
+///
+/// The library function takes ONLY typed values — env-coupling
+/// lives at [`ProbeTracingConfig::from_env`] and only there. This
+/// keeps tests (which would otherwise race `std::env::set_var`
+/// across threads) deterministic, and keeps every other call site
+/// (config file, CLI flags, hardcoded defaults) on equal footing
+/// with the env var path.
+///
+/// Returns a [`ProbeInstall`] describing what got wired so the
+/// caller can log it visibly at boot — the operator-side proof
+/// that the probes are landing somewhere.
+///
+/// ## Errors
+///
+/// Returns `Err(ProbeFileSinkError::OpenFailed)` if
+/// `config.probe_file` was supplied but the path could not be
+/// opened (directory missing, permission denied, etc). Per
+/// `[[no-fallbacks-ever]]` the substrate refuses to silently drop
+/// probes — the caller can choose to surface the error
+/// (recommended for servers) or swallow it (acceptable for ad-hoc
+/// tests where the probe path is best-effort).
+///
+/// Does NOT return an error when `config.probe_file` is `None` —
+/// that's an intentional "no disk capture this run", not a
+/// configuration failure.
+pub fn install_probe_tracing(
+    config: ProbeTracingConfig,
+) -> Result<ProbeInstall, ProbeFileSinkError> {
+    let default_filter = if config.default_filter.is_empty() {
+        "info"
+    } else {
+        &config.default_filter
+    };
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter));
+
+    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+
+    // Build the optional file sink BEFORE the registry chain so we
+    // can either include it or skip it cleanly. None = no disk
+    // capture this run (caller didn't ask). Path supplied but
+    // unwritable = typed error surfaced to caller per
+    // `[[no-fallbacks-ever]]`.
+    let (file_sink, probe_log_path) = match config.probe_file {
+        Some(path) => {
+            let sink = JsonlProbeFileSink::new(&path, config.probe_classes)?;
+            (Some(sink), Some(path))
+        }
+        None => (None, None),
+    };
+
+    // Compose the registry. The fmt layer wraps the env-filter so
+    // RUST_LOG governs human-facing output; probe layers see EVERY
+    // event regardless of RUST_LOG (probes are structured records,
+    // not text logs — they're filtered by class via
+    // CONTINUUM_PROBE_CLASSES, not by tracing's level system).
+    let registry = tracing_subscriber::registry()
+        .with(UriCaptureLayer::new())
+        .with(ProbeRouterLayer::new())
+        .with(file_sink) // Option<JsonlProbeFileSink>: tracing's Layer impl handles None
+        .with(fmt_layer.with_filter(env_filter));
+
+    // try_init succeeds the first call, no-ops on subsequent calls.
+    // Errors here mean another subscriber was already installed —
+    // benign for repeated init from tests, so we drop the error
+    // intentionally to keep the helper idempotent.
+    let _ = registry.try_init();
+
+    Ok(ProbeInstall { probe_log_path })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `install_probe_tracing` accepts a typed config and is
+    /// parallel-safe in tests — no env-var mutation, no shared
+    /// global state beyond `tracing`'s own default subscriber
+    /// (which is exactly the thing we're testing the idempotency
+    /// of).
+    #[test]
+    fn install_is_idempotent_with_no_disk_capture() {
+        let config = ProbeTracingConfig {
+            probe_file: None,
+            probe_classes: HashSet::new(),
+            default_filter: "warn".to_string(),
+        };
+        let first = install_probe_tracing(config.clone());
+        let second = install_probe_tracing(config);
+        assert!(first.is_ok(), "first install must succeed");
+        assert!(second.is_ok(), "second install must no-op cleanly");
+        assert!(first.unwrap().probe_log_path.is_none());
+        assert!(second.unwrap().probe_log_path.is_none());
+    }
+
+    /// Typed-error contract: an unwritable `probe_file` path must
+    /// surface `ProbeFileSinkError::OpenFailed` per
+    /// `[[no-fallbacks-ever]]`. Operators must see the
+    /// configuration problem; substrate refuses to silently drop
+    /// probes.
+    ///
+    /// Parallel-safe because the bad path is passed via typed
+    /// config — no env-var mutation, no racing on
+    /// `CONTINUUM_PROBE_FILE`.
+    #[test]
+    fn install_surfaces_open_failed_for_unwritable_path() {
+        let config = ProbeTracingConfig {
+            probe_file: Some(PathBuf::from(
+                "/this/path/definitely/does/not/exist/probes.jsonl",
+            )),
+            probe_classes: HashSet::new(),
+            default_filter: "warn".to_string(),
+        };
+        let result = install_probe_tracing(config);
+        assert!(
+            matches!(result, Err(ProbeFileSinkError::OpenFailed { .. })),
+            "unwritable path must surface typed error, got {:?}",
+            result
+        );
+    }
+
+    /// The env-coupling seam. `from_env` is the ONE function that
+    /// touches `std::env`; everything downstream takes typed
+    /// values. Pin both the populated and empty paths so a future
+    /// refactor of the env names can't silently break the
+    /// operator-facing surface.
+    ///
+    /// Serial within itself (env-var mutation needs sequencing) —
+    /// scoped to ONE test for the env constructor specifically.
+    /// Other tests in this module use direct construction and stay
+    /// parallel-safe.
+    #[test]
+    fn from_env_reads_documented_env_vars() {
+        let prev_file = std::env::var(ENV_PROBE_FILE).ok();
+        let prev_classes = std::env::var(ENV_PROBE_CLASSES).ok();
+
+        // Both vars set → populated config.
+        std::env::set_var(ENV_PROBE_FILE, "/tmp/test-probes.jsonl");
+        std::env::set_var(ENV_PROBE_CLASSES, "persona,cognition.analyze");
+        let populated = ProbeTracingConfig::from_env("info");
+        assert_eq!(
+            populated.probe_file.as_deref(),
+            Some(std::path::Path::new("/tmp/test-probes.jsonl"))
+        );
+        assert!(populated.probe_classes.contains("persona"));
+        assert!(populated.probe_classes.contains("cognition.analyze"));
+        assert_eq!(populated.default_filter, "info");
+
+        // Both vars unset → empty config (NOT an error).
+        std::env::remove_var(ENV_PROBE_FILE);
+        std::env::remove_var(ENV_PROBE_CLASSES);
+        let empty = ProbeTracingConfig::from_env("warn");
+        assert!(empty.probe_file.is_none());
+        assert!(empty.probe_classes.is_empty());
+        assert_eq!(empty.default_filter, "warn");
+
+        // Restore prior env state so other tests aren't affected
+        // by ordering even if cargo's parallel runner interleaves.
+        match prev_file {
+            Some(v) => std::env::set_var(ENV_PROBE_FILE, v),
+            None => std::env::remove_var(ENV_PROBE_FILE),
+        }
+        match prev_classes {
+            Some(v) => std::env::set_var(ENV_PROBE_CLASSES, v),
+            None => std::env::remove_var(ENV_PROBE_CLASSES),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two beats merged into one PR — they're conceptually "make the JTAG actually convenient" and they exposed each other's design pressure during implementation.

Follow-up to #1535 (foundation), #1536 (sprinkle 1), #1537 (sprinkle 2) — all merged.

## Beat 1: namespace-prefix + wildcard filter

Per Joel 2026-06-06: the probes are "fundamentally something we'd like to make convenient to use to debug this massively complex machine." Exact-match-only filtering hit its ergonomic ceiling fast.

Before:
```bash
CONTINUUM_PROBE_CLASSES=persona.turn.start,persona.turn.silent,persona.turn.spoke,persona.response.render.prompt,persona.response.render.raw,…
```

After:
```bash
CONTINUUM_PROBE_CLASSES=persona,cognition         # namespace prefixes
CONTINUUM_PROBE_CLASSES=*                         # firehose
CONTINUUM_PROBE_CLASSES=persona.turn,cognition.analyze.parse  # mixed
```

Three rules in `class_passes_filter` (pure function, unit-tested):
1. **Empty set** = no filter (every class passes)
2. **`*`** = explicit firehose
3. **Exact OR namespace prefix** — `C == F` or `C.starts_with(F + ".")` with the `.` guard so `persona` ≠ `personality.x`. Same convention as `tracing_subscriber::EnvFilter`.

## Beat 2: boot wiring + typed-config refactor

Per Joel 2026-06-06: "Let's perfect debugging as we use it." The `JsonlProbeFileSink` existed, but `continuum-core-server`'s `main()` was installing a bespoke `FmtSubscriber` — so setting `CONTINUUM_PROBE_FILE` had no effect. JTAG hardware was unwired.

Then implementing the boot wiring exposed the brittleness Joel had already flagged: my first revision had two parallel `#[test]` functions racing `std::env::set_var` — exactly the brittleness env vars carry by design (and the reason `set_var` is slated for `unsafe` marking in Rust 2024).

So this beat does both:

- **Wires the server**: new `routing::install_probe_tracing(config)` composes `UriCaptureLayer` + `ProbeRouterLayer` + `JsonlProbeFileSink` + fmt-to-stderr in one call. `main.rs` calls it; server logs `probes landing at <path>` at boot.
- **Pushes env coupling to ONE seam**: the library function takes a typed `ProbeTracingConfig { probe_file, probe_classes, default_filter }`. The ONE function that touches `std::env` is `ProbeTracingConfig::from_env(default_filter)`. Tests construct configs directly — zero env mutation, fully parallel-safe. Future config-file / CLI-flag sources slot in as additional constructors without touching `install_probe_tracing`.

The two parallel-safe install tests are back as separate `#[test]` functions. The one test that touches env (`from_env_reads_documented_env_vars`) is scoped to the seam — the brittleness can't leak elsewhere.

## Tests (+7 total in this PR)

Beat 1 (probe_file_sink):
- `class_filter_namespace_prefix_matches_subclasses` — `persona` matches `persona.*` but NOT `personality.x` (pins dot guard)
- `class_filter_wildcard_matches_every_class`
- `class_filter_combines_exact_and_prefix_in_one_set`
- `class_passes_filter_pure_function_unit_tests`

Beat 2 (tracing_init):
- `install_is_idempotent_with_no_disk_capture` — parallel-safe via typed config
- `install_surfaces_open_failed_for_unwritable_path` — typed error per `[[no-fallbacks-ever]]`
- `from_env_reads_documented_env_vars` — pins the ONE env seam

## Operator UX

```bash
export CONTINUUM_PROBE_FILE=/tmp/probes.jsonl
export CONTINUUM_PROBE_CLASSES=persona,cognition  # prefix matching
./continuum-core-server /tmp/sock
# [continuum-core-server] probes landing at /tmp/probes.jsonl
# ... probes flow to disk as the server runs ...
```

Two env vars + one binary, zero recompile. README + manual updated to lead with the short prefix form.

## Doctrine

- `[[jtag-probes-are-rtos-debugger]]` — debugger has to be ON in real binaries, easy to type, easy to filter.
- `[[observability-is-half-the-architecture]]` — same layers, same order, every entry point.
- `[[no-fallbacks-ever]]` — empty filter vs `*` distinct intents; env-var-unset vs path-unwritable distinct errors.
- **New lesson** Joel named on this PR: process-global mutable state belongs at ONE seam. Library functions take typed values. The brittleness showed up first in our own tests; the design fix removes the class of bug rather than masking it.

cards: `305c8fb9` (beat 1) + boot-wiring/typed-config follow-up
parent: #151 — foundation #1535 — sprinkle 1 #1536 — sprinkle 2 #1537 — all merged