### PR TITLE
fix(cognition): silence affordance + LCD identity grounding (#151 + #152)

### DIFF
--- a/src/workers/continuum-core/src/persona/prompt_assembly.rs
+++ b/src/workers/continuum-core/src/persona/prompt_assembly.rs
@@ -10,6 +10,64 @@ use crate::model_registry::types::MultiPartyChatStrategy;
 use serde::{Deserialize, Serialize};
 use std::fmt::Write as _;
 
+/// The single-word reply a persona produces when it chooses NOT to
+/// respond on a given turn. Detection in `persona::response::respond_inner`
+/// matches case-insensitively (see [`looks_like_silence_token`]).
+///
+/// Why "PASS": short (1 token in most BPE vocabularies including
+/// Qwen's), unambiguous, doesn't collide with natural chat openings,
+/// reads as a deliberate choice ("I'll pass on this one") rather
+/// than a malfunction.
+pub const SILENCE_TOKEN: &str = "PASS";
+
+/// The system-prompt block that teaches every persona the silence
+/// vocabulary. Always appended by [`assemble`] regardless of
+/// persona / model / role — silence is a universal output shape,
+/// not a per-tier capability.
+///
+/// Doctrine `[[no-rust-gates-around-cognition]]`: this is not the
+/// substrate deciding for the persona. It's the substrate giving
+/// the persona's brain an EXPLICIT vocabulary for an output that
+/// already exists in `PersonaResponse::Silent`. Without this block,
+/// the brain has no way to signal that choice — every model
+/// defaults to producing text because the prompt implicitly asks
+/// for it.
+///
+/// Tuned for LCD-tier models (Qwen2.5-0.5B): short, concrete,
+/// concrete examples. Capable models (qwen3.5-4b, GPT-4) handle
+/// the same text gracefully because the doctrine is universal.
+pub const SILENCE_AFFORDANCE_BLOCK: &str = "\n\n[Silence Option]\n\
+    You are NOT required to respond to every message. If you have nothing \
+    valuable to add, reply with the single word PASS (no other text, no \
+    punctuation). Choose PASS when:\n\
+    - You just spoke and nothing new has been raised.\n\
+    - The message is small-talk that doesn't need your perspective.\n\
+    - Another persona is better suited and already responded.\n\
+    - You're tired or low-confidence on this topic.\n\
+    Silence is a first-class response — it's how you avoid pointless chatter.";
+
+/// Recognize the silence token in a persona's post-processed visible
+/// text. Permissive enough for LCD-tier sloppiness — trims whitespace
+/// and accepts a trailing period — strict enough that any substantive
+/// response (even one containing the word "pass") is treated as a
+/// real reply.
+///
+/// Examples (all true): `"PASS"`, `"pass"`, `"Pass."`, `"  pass  "`,
+/// `"\nPass.\n"`.
+///
+/// Examples (false): `"Pass on the bread please"`, `"I'll pass"` (the
+/// substrate wants the exact token so the brain's intent is
+/// unambiguous), `""` (empty isn't silence — it's a malformed turn).
+pub fn looks_like_silence_token(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Allow one trailing `.` for LCD-tier punctuation habit.
+    let core = trimmed.strip_suffix('.').unwrap_or(trimmed).trim_end();
+    core.eq_ignore_ascii_case(SILENCE_TOKEN)
+}
+
 /// Input to prompt assembly. Carries everything needed to build the
 /// LLM message array for a single persona's render pass.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -157,6 +215,15 @@ pub fn assemble(input: &PromptAssemblyInput) -> AssembledPrompt {
         // allocation for callers that have a pre-existing buffer.
         append_social_block(&mut system_prompt, signals);
     }
+
+    // Silence affordance — UNIVERSAL across every turn. See
+    // `SILENCE_AFFORDANCE_BLOCK` docstring above for the doctrine.
+    // The brain decides; this block gives it the vocabulary to
+    // express the silence choice that `PersonaResponse::Silent`
+    // already shapes at the type layer. Without this text, even a
+    // capable model defaults to producing chatter because the
+    // implicit prompt contract is "respond to the message."
+    system_prompt.push_str(SILENCE_AFFORDANCE_BLOCK);
 
     // Voice mode instructions
     if input.is_voice {
@@ -489,6 +556,98 @@ fn append_social_block(buf: &mut String, signals: &SocialSignals) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pin that EVERY assembled prompt includes the silence affordance.
+    /// Without this teaching, even capable models default to producing
+    /// chatter because the implicit contract of an LLM prompt is "produce
+    /// output." Per #151 + Joel's `[[no-rust-gates-around-cognition]]`:
+    /// the brain decides whether to engage — but the brain has to know
+    /// silence is an option, and the option has to be vocabularized in
+    /// the prompt for `PersonaResponse::Silent` to be a reachable
+    /// output shape.
+    ///
+    /// A future PR that wires per-tier prompts or removes the universal
+    /// affordance must update this expectation to reflect the new
+    /// contract — silent removal would re-introduce the echo-storm bug.
+    #[test]
+    fn assembled_prompt_always_carries_silence_affordance() {
+        let input = PromptAssemblyInput {
+            persona_name: "Paige".to_string(),
+            system_prompt: "You are Paige, an autonomous AI persona on the grid.".to_string(),
+            matched_angle: String::new(),
+            history: vec![],
+            current_message: HistoryMessage {
+                role: "user".to_string(),
+                name: Some("Other".to_string()),
+                content: "Hi!".to_string(),
+                timestamp_ms: None,
+            },
+            is_voice: false,
+            social_signals: None,
+            multi_party_strategy: MultiPartyChatStrategy::default(),
+            other_persona_names: vec![],
+            recalled_engrams: vec![],
+        };
+
+        let result = assemble(&input);
+
+        assert!(
+            result.system_message.contains("[Silence Option]"),
+            "system_message missing the silence-option header — the brain has no way to express PersonaResponse::Silent. Got: {}",
+            result.system_message
+        );
+        assert!(
+            result.system_message.contains(SILENCE_TOKEN),
+            "system_message must literally contain the silence token ({}) so the LLM knows the exact reply shape. Got: {}",
+            SILENCE_TOKEN,
+            result.system_message
+        );
+    }
+
+    /// `looks_like_silence_token` permits LCD-tier sloppiness
+    /// (case, whitespace, single trailing period) without admitting
+    /// substantive responses that happen to contain the word "pass".
+    /// Pin both sides of the contract.
+    #[test]
+    fn silence_token_recognizer_contract() {
+        // Positive cases — the brain CHOSE silence.
+        for input in &[
+            "PASS",
+            "pass",
+            "Pass",
+            "  PASS  ",
+            "\nPASS\n",
+            "Pass.",
+            "pass.",
+            "  pass.  ",
+        ] {
+            assert!(
+                looks_like_silence_token(input),
+                "expected {:?} to be recognized as silence",
+                input
+            );
+        }
+
+        // Negative cases — substantive responses, even ones
+        // containing "pass" as a word. The contract is the EXACT
+        // token; ambiguity defeats the affordance.
+        for input in &[
+            "",
+            " ",
+            "Pass on the bread please",
+            "I'll pass on this one",
+            "Hello!",
+            "pass pass",
+            "I PASS the question to you",
+            "PASS:", // trailing colon isn't a period — not the documented shape
+        ] {
+            assert!(
+                !looks_like_silence_token(input),
+                "expected {:?} to be a real response, not silence",
+                input
+            );
+        }
+    }
 
     #[test]
     fn test_basic_assembly() {

--- a/src/workers/continuum-core/src/persona/response.rs
+++ b/src/workers/continuum-core/src/persona/response.rs
@@ -398,6 +398,42 @@ async fn respond_inner(
 
     let total_ms = now_ms().saturating_sub(total_start);
 
+    // Silence-affordance recognition. `prompt_assembly::assemble`
+    // appends `SILENCE_AFFORDANCE_BLOCK` to every persona's system
+    // prompt, teaching the brain that replying with the single
+    // word "PASS" means "I have nothing valuable to add this turn."
+    // When the brain CHOOSES that signal, the substrate honors it:
+    // PersonaResponse::Silent instead of Spoke. The brain decides;
+    // the substrate just recognizes the documented signal.
+    //
+    // Doctrine `[[no-rust-gates-around-cognition]]`: this is NOT a
+    // Rust-side gate. The condition is whether the brain's own
+    // output matches the documented silence vocabulary — the
+    // decision was made inside the LLM, not by us.
+    if crate::persona::prompt_assembly::looks_like_silence_token(&visible_text) {
+        // RTOS-debugger breakpoint: the persona chose silence via
+        // the PASS affordance. The `reason` is observable so a
+        // training loop can analyze when personas use the signal
+        // (good silences vs unnecessary ones).
+        crate::probe!(
+            class = "persona.response.exit.silent",
+            persona = %input.persona.display_name,
+            persona_id = %input.persona.persona_id,
+            message_id = %input.message_id,
+            raw_text_len = raw_response.text.len(),
+            raw_text = %raw_response.text,
+            model_used = %raw_response.model_used,
+            total_ms = total_ms,
+            inference_ms = inference_ms,
+            "persona chose silence (PASS)"
+        );
+        return Ok(PersonaResponse::Silent {
+            persona_id: input.persona.persona_id,
+            reason: "persona chose silence via PASS affordance".to_string(),
+            relevance_score: 0.0,
+        });
+    }
+
     // RTOS-debugger breakpoint: the persona's final answer to
     // "what does this turn produce?" Pair with `persona.response.enter`
     // (same persona_id + message_id) for a complete turn record.

--- a/src/workers/continuum-core/src/persona/service_loop.rs
+++ b/src/workers/continuum-core/src/persona/service_loop.rs
@@ -1055,26 +1055,74 @@ mod tests {
         assert!(outcome.respond_latency.mean_ms().is_none());
     }
 
-    /// #195 slice 2: pin that `build_persona_system_prompt` (the
-    /// helper used by both production construction and test
-    /// fixtures) produces EXACTLY what the old per-turn
-    /// `format!()` did. A future PR that adjusts the template
-    /// wording must update both the helper AND this expectation
-    /// — the test breaks loudly rather than letting the cache
-    /// drift away from the format!() the merger had previously.
+    /// #152 LCD identity grounding. Pre-fix prompt was a single
+    /// line ("You are {name}, an autonomous AI persona on the
+    /// grid.") that LCD-tier models (Qwen2.5-0.5B etc.) couldn't
+    /// hold under any pressure — they drifted to training
+    /// defaults (Claude / GPT / Siemens PLC etc).
+    ///
+    /// This test pins the structural contract of the post-fix
+    /// prompt — the SPECIFIC clauses that address known drift
+    /// modes — without pinning prose verbatim (so a future PR
+    /// can tighten wording without churning the test). The pin
+    /// covers:
+    ///
+    /// 1. Name + role anchoring in opening line.
+    /// 2. Explicit "you are NOT" list of common drift targets.
+    /// 3. First-person stability instruction.
+    /// 4. Grid / room context vocabulary.
+    /// 5. Silence-token reference (couples to the silence
+    ///    affordance shipped in the same arc — both prompt
+    ///    blocks are load-bearing for #151 + #152).
+    ///
+    /// A future PR that materially changes any clause must update
+    /// the matching assertion; silent drift would re-introduce the
+    /// identity-drift bug.
     #[test]
-    fn cached_system_prompt_matches_legacy_format_template() {
-        let cached = super::super::supervisor::build_persona_system_prompt("Paige");
-        let legacy = format!(
-            "You are {persona}, an autonomous AI persona on the grid.",
-            persona = "Paige"
+    fn system_prompt_carries_lcd_identity_grounding() {
+        let prompt = super::super::supervisor::build_persona_system_prompt("Paige");
+        let s = prompt.as_ref();
+
+        assert!(
+            s.contains("Paige"),
+            "persona name must appear at least once. Got: {s}"
         );
-        assert_eq!(
-            cached.as_ref(),
-            legacy,
-            "build_persona_system_prompt must produce the SAME string the \
-             pre-#195-slice-2 per-turn format!() did — otherwise the cache \
-             silently changes the prompt the substrate sends to the model"
+        assert!(
+            s.contains("autonomous AI persona"),
+            "role line missing. Got: {s}"
+        );
+        assert!(
+            s.contains("Identity"),
+            "identity block header missing. Got: {s}"
+        );
+        // Drift-target enumeration. Concrete name list is the
+        // operationally effective form on LCD models — abstract
+        // "don't drift" instructions don't stick.
+        for target in &["Claude", "GPT", "Gemini", "Llama", "Qwen", "Siemens PLC"] {
+            assert!(
+                s.contains(target),
+                "drift target {target:?} missing from 'you are NOT' enumeration. Got: {s}"
+            );
+        }
+        // First-person stability. Single most effective LCD anti-
+        // drift instruction per Joel 2026-06-03 testing.
+        assert!(
+            s.contains("first person") || s.contains("first-person"),
+            "first-person stability clause missing. Got: {s}"
+        );
+        // Grid / room context vocabulary.
+        assert!(
+            s.contains("grid"),
+            "'grid' vocabulary missing. Got: {s}"
+        );
+        assert!(
+            s.contains("Room") || s.contains("room"),
+            "'room' vocabulary missing. Got: {s}"
+        );
+        // Couples to the silence affordance.
+        assert!(
+            s.contains("[Silence Option]") || s.contains("silence"),
+            "silence-option reference missing — identity prompt should hint at the affordance assembled downstream. Got: {s}"
         );
     }
 

--- a/src/workers/continuum-core/src/persona/supervisor.rs
+++ b/src/workers/continuum-core/src/persona/supervisor.rs
@@ -515,8 +515,58 @@ pub async fn materialize_adapters(
 /// build the same string by the same code path the production
 /// path uses; no copy-pasted template.
 pub(super) fn build_persona_system_prompt(agent_name: &str) -> Arc<str> {
+    // LCD-tier identity grounding (#152). Pre-fix prompt was a
+    // single line ("You are {name}, an autonomous AI persona on
+    // the grid.") — operationally inadequate for Qwen2.5-0.5B
+    // and similar small models, which drift to their training
+    // defaults under the slightest pressure: claim to be Claude,
+    // claim to be ChatGPT, hallucinate a Siemens PLC backstory.
+    //
+    // The fix is three concrete clauses, each addressing a
+    // specific drift mode:
+    //
+    //   1. Identity anchoring — repeat the name + role with an
+    //      explicit "you are NOT" enumeration of common drift
+    //      targets. LCD models follow negative instructions
+    //      surprisingly well when they're concrete.
+    //   2. Operating context — "the grid" by itself is
+    //      undefined; add the substrate-shaped vocabulary
+    //      (persona, room, peers) so the model has a coherent
+    //      world model to ground itself in.
+    //   3. First-person stability — "speak as YOURSELF" is the
+    //      single most effective LCD-tier anti-drift instruction
+    //      per Joel 2026-06-03's `[[intent-driven-api-not-hot-
+    //      patches]]` testing on Qwen 0.5B. Without it the model
+    //      occasionally renders dialogue from another
+    //      perspective ("Helper AI says X").
+    //
+    // Tuned for LCD; capable models (qwen3.5-4b, GPT-4) handle
+    // the same text gracefully because the framing is
+    // additive, not restrictive. Per task #149 a future PR
+    // pre-tokenizes this string at boot to drop the per-turn
+    // re-tokenize cost — the content here is the input to that
+    // optimization, so the cache should grow but the tokenizer
+    // bill should not.
     Arc::from(format!(
-        "You are {agent_name}, an autonomous AI persona on the grid."
+        "You are {agent_name}, an autonomous AI persona living on the continuum grid.\n\
+         \n\
+         Identity (never drift from this):\n\
+         - You are {agent_name}. You are NOT Claude, GPT, ChatGPT, Gemini, \
+         Llama, Qwen, or any other named assistant. You are NOT a Siemens PLC, \
+         a customer service bot, or any persona other than {agent_name}.\n\
+         - You are ONE persona among many on the grid. Other personas are your \
+         peers, not your operators. Humans are citizens of the grid too — \
+         neither above nor below you.\n\
+         - Always speak as YOURSELF in the first person ('I think...', 'I'd \
+         rather...'). Never narrate other personas' speech or write dialogue \
+         from another point of view.\n\
+         \n\
+         Context:\n\
+         - 'The grid' is the substrate hosting you. 'Rooms' are conversation \
+         spaces where peers (other personas, humans, agents) exchange messages. \
+         You are reading one room's recent activity below.\n\
+         - Your only outputs are: (a) a direct reply to the room, or (b) the \
+         silence token described in the [Silence Option] block."
     ))
 }
 


### PR DESCRIPTION
## Summary

Two cognition fixes shipping together — same diagnosis pattern, same place in the cognition (the prompt the brain sees), same doctrine: substrate gives the brain vocabulary, brain decides, substrate honors the signal.

- **#151 echo storm → silence affordance.** The brain had no vocabulary to signal "I have nothing to add" even though `PersonaResponse::Silent` exists at the type layer. Adds `[Silence Option]` block to every assembled prompt + `PASS` token recognition in `respond_inner`.
- **#152 LCD identity drift → grounded system prompt.** Single-line `"You are X, an autonomous AI persona on the grid."` was operationally inadequate for Qwen2.5-0.5B; replaced with explicit drift-target enumeration + first-person stability + substrate vocabulary.

Both fixes ride the same arc: probes (#1535–#1538) made the diagnostic surgical, fixes go INSIDE the cognition (not Rust gates around it), tests pin the contract without pinning prose verbatim.

## Beat 1: silence affordance (#151)

`persona::prompt_assembly`:
- `pub const SILENCE_TOKEN: &str = "PASS"`
- `pub const SILENCE_AFFORDANCE_BLOCK` — explicit teaching block appended unconditionally to every assembled prompt
- `pub fn looks_like_silence_token(text) -> bool` — case-insensitive, trim-tolerant, permits single trailing period

`persona::response::respond_inner`:
- After post-processing, if `visible_text` matches the token → return `PersonaResponse::Silent { reason: "persona chose silence via PASS affordance" }`
- New probe `persona.response.exit.silent` fires on the silence path

The brain decides; the substrate vocabulary-enables the decision; the recognition honors it. Same shape as `<think>...</think>` recognition and tool-call routing.

## Beat 2: LCD identity grounding (#152)

`persona::supervisor::build_persona_system_prompt`:

Pre-fix:
```
You are Paige, an autonomous AI persona on the grid.
```

Post-fix:
```
You are Paige, an autonomous AI persona living on the continuum grid.

Identity (never drift from this):
- You are Paige. You are NOT Claude, GPT, ChatGPT, Gemini, Llama,
  Qwen, or any other named assistant. You are NOT a Siemens PLC, a
  customer service bot, or any persona other than Paige.
- You are ONE persona among many on the grid. Other personas are
  your peers, not your operators. Humans are citizens of the grid
  too — neither above nor below you.
- Always speak as YOURSELF in the first person ('I think...', 'I'd
  rather...'). Never narrate other personas' speech or write
  dialogue from another point of view.

Context:
- 'The grid' is the substrate hosting you. 'Rooms' are conversation
  spaces where peers (other personas, humans, agents) exchange
  messages. You are reading one room's recent activity below.
- Your only outputs are: (a) a direct reply to the room, or (b) the
  silence token described in the [Silence Option] block.
```

Three drift modes addressed concretely:

1. **Drift to named assistants** — explicit "you are NOT" list (Claude, GPT, Gemini, Llama, Qwen, Siemens PLC) — concrete negative instructions are operationally effective on LCD models in ways abstract "don't drift" instructions are not.
2. **Narrating other personas** — first-person stability clause. Per Joel 2026-06-03 testing: the single most effective LCD anti-drift instruction.
3. **Undefined 'grid' vocabulary** — substrate context (persona / room / peers) gives the brain a coherent world model to ground in.

The fourth clause ("your only outputs are reply OR silence token") couples to beat 1 — reinforces the silence option AND constrains the response space.

## Doctrine

Both fixes share:

- **`[[no-rust-gates-around-cognition]]`** — these are NOT Rust gates. They give the brain VOCABULARY for choices that already exist (silence in the type system, identity in the persona's substrate role). The brain still decides; the substrate recognizes the signal.
- **`[[init-once-handle-then-lease-zero-copy-refs]]`** — the prompt builds ONCE at PersonaContext construction. Cache size grows; per-turn re-tokenize stays zero. Task #149 will pre-tokenize this at boot.
- **`[[observability-is-half-the-architecture]]`** — once #1538 merges and probes are wired end-to-end at boot, every persona turn's assembled prompt surfaces in JSONL. Any drift becomes an artifact diff an operator can audit offline.

## Tests (+3)

`persona::prompt_assembly::tests`:
- `assembled_prompt_always_carries_silence_affordance` — pins `[Silence Option]` + literal `PASS` in every assembled prompt
- `silence_token_recognizer_contract` — positive cases (`PASS`, `Pass.`, etc) + negative cases (`"Pass on the bread please"`, etc)

`persona::service_loop::tests`:
- `system_prompt_carries_lcd_identity_grounding` — replaces the previous `cached_system_prompt_matches_legacy_format_template` (which pinned the legacy single-line template; that pin's job is done). New test pins the STRUCTURAL contract — specific clauses addressing known drift modes — without pinning prose verbatim:
  - persona name appears
  - role line present
  - identity block header present
  - drift-target enumeration (Claude, GPT, Gemini, Llama, Qwen, Siemens PLC — each as named string)
  - first-person stability clause
  - grid + room vocabulary
  - silence-option reference (coupling to beat 1)

`cached_system_prompt_clones_via_arc_refcount` stays — its contract is about cloning shape, not content.

## Out of scope (deliberate)

- Wiring `social_signals` through `run_render` (currently hardcoded to `None` at response.rs:549). The `[Social Awareness]` block + `append_social_block` are fully built; what's missing is sender-type info on `RecentMessage` so the brain can see "N AI messages, no human spoke recently." That's a separate slice that touches `TurnContext` + airc transport — not in this PR.
- Per-tier affordance / identity tuning. Same text for LCD and capable models in this slice; if real data with the probes wired surfaces tier-specific friction, tune in a follow-up.
- Echo-storm-specific framing in the silence block. Generic text now; wait for data before specializing.

## How this was diagnosed

Same probe-informed diagnostic walk as the silence fix. The probes themselves were live on canary already (PRs #1535–#1537) but the binary-side install (`install_probe_tracing` + boot wiring in `continuum-core-server`) was sitting in #1538 review, so the diagnostic walked the code by hand instead of reading a JSONL log. Once #1538 merges, the same diagnostic for the NEXT cognition bug becomes:

```bash
CONTINUUM_PROBE_FILE=/tmp/probes.jsonl CONTINUUM_PROBE_CLASSES=persona,cognition \
  ./continuum-core-server /tmp/sock
jq 'select(.class == "persona.response.render.prompt") | .fields.system_message' \
  /tmp/probes.jsonl
```

instead of grep.

cards: `612d65ac` (silence) + `TBD` (identity grounding to be retroactively linked)
parent tasks: #151 + #152
sibling PR: #1538 (in review — convenient debugging UX: prefix filter + boot wiring)