### PR TITLE
feat(probes): time_probe! macro — safe one-line async timing

### DIFF
--- a/docs/architecture/RTOS-DEBUGGER-PROBES.md
+++ b/docs/architecture/RTOS-DEBUGGER-PROBES.md
@@ -8,7 +8,8 @@ The **probe macros** are the substrate's RTOS debugger:
 
 - `probe!(class = "...", field = val, ...)` — a non-blocking breakpoint. Snapshots the named variables at the call site, routes by `class` to subscribers + a disk log.
 - `time_sync!("phase_name", { ... })` — RAII timing for a synchronous block. The wrapped block's duration becomes a timing probe at scope exit.
-- `time_async!("category", "operation", future)` — RAII timing for an async future (RAII guard, lives in `crate::logging`).
+- `time_probe!("phase_name", future)` — substrate-tracing timing for an async future. Safe-by-construction (`.instrument(span).await` shape — no `_enter` guard held across `.await`). Emits to the same `timing` probe class as `time_sync!`, so operators see sync + async timings on one flat timeline. Prefer this over the bare `.instrument(info_span!(...))` form when sprinkling async timings — the verbose form gets skipped when adding probes in a hurry.
+- `time_async!("category", "operation", future)` — RAII timing for an async future via `crate::logging::TimingGuard`. Different shape from `time_probe!` (logging crate's own logger vs substrate probe stream). Use `time_probe!` for cognition / substrate timing; use `time_async!` for the legacy logging-crate-bound timing.
 - `stack!()` — the URI ancestry at this point: which dispatched command's context are we in.
 
 Each probe call is **one line at the seam**. Easy enough to add that the cognition code grows probes the way it grows lines — that's the only way debugging concurrent code stays sustainable. Per Joel 2026-06-06: "Easy one liners or it won't happen."

--- a/docs/architecture/RTOS-DEBUGGER-PROBES.md
+++ b/docs/architecture/RTOS-DEBUGGER-PROBES.md
@@ -148,9 +148,30 @@ let result = time_sync!("recall_l2", {
     cognition.admission.recall_scored(now_ms, 8)
 });
 
-// Around a timing-critical future (async):
+// Around a timing-critical future (async, substrate probe stream):
+let analysis = time_probe!("cognition.analyze", analyze(input));
+let response = time_probe!("inference.generate", adapter.generate_text(req));
+
+// Around a timing-critical future (logging-crate RAII shape — legacy):
 let analysis = time_async!("cognition", "analyze", analyze(input));
 ```
+
+Both async forms exist for historical reasons: `time_probe!` is the
+substrate's tracing-span shape (composes with `ProbeRouterLayer` +
+`JsonlProbeFileSink`); `time_async!` is the `crate::logging`'s RAII
+TimingGuard shape (logs to the logging crate's own logger). For new
+cognition seams prefer `time_probe!` — that's what the rest of the
+probe pipeline consumes.
+
+> **Persistence caveat:** `time_sync!` and `time_probe!` emit
+> tracing SPANS, not events. The current `ProbeRouterLayer` and
+> `JsonlProbeFileSink` only implement `on_event` — they do NOT yet
+> capture span-close events. Task #196 wires the missing
+> `on_close` so timing spans persist to the JSONL log; until then,
+> the timing macros work for `tracing`-native consumers (e.g.
+> `tracing_subscriber::fmt`) but timings won't appear in the JTAG
+> probe log. The macro lands here so the call shape is stable
+> when the routing side ships.
 
 ### Convention rules
 

--- a/src/workers/continuum-core/src/routing/macros.rs
+++ b/src/workers/continuum-core/src/routing/macros.rs
@@ -119,27 +119,68 @@ macro_rules! time_sync {
     }};
 }
 
-// For **async** timing in the substrate's URI-context-aware shape,
-// use `.instrument(span).await` directly at the call site:
-//
-//   let span = tracing::info_span!("time", name = "phase", probe_class = "timing");
-//   let result = my_future.instrument(span).await;
-//
-// This is the pattern `CommandExecutor::dispatch` uses (per the
-// d1cf19dc5 fix) — `_enter` is never held across an await. A macro
-// for it isn't added at this layer because:
-//   1. `crate::logging::time_async!` already exists with a different
-//      shape (RAII TimingGuard with category/operation, NOT a tracing
-//      span). Reusing the name would collide.
-//   2. The direct `.instrument(span).await` form is two lines and
-//      already idiomatic. The previous `time!` macro silently broke
-//      across `.await` precisely because consumers reached for the
-//      one-liner — making it impossible to misuse here is the goal.
-//
-// Per PR #1529 reviewer 2 fix: removed the substrate-wide foot-gun
-// where `time!("infer", run_inference(...).await)` held `_enter`
-// across the inner await, breaking URI_STACK. The renamed
-// `time_sync!` makes the sync-only contract explicit.
+/// Explicit timing for an **async future** — safe-by-construction
+/// companion to [`time_sync!`].
+///
+/// Per Joel 2026-06-06 `[[refine-tools-as-you-use-them]]`: every
+/// async timing site in the cognition path was an
+/// `.instrument(info_span!("time", name=..., probe_class="timing"))
+/// .await` ceremony. Three lines plus a `use tracing::Instrument`
+/// import. Nobody writes those when adding a new seam in a hurry —
+/// the result was that async cognition stages stayed untimed. This
+/// macro collapses that to one line.
+///
+/// ```ignore
+/// use continuum_core::time_probe;
+///
+/// // Wrap any future expression:
+/// let analysis = time_probe!("cognition.analyze", analyze(input));
+///
+/// // Inline complex expressions just as cleanly:
+/// let response = time_probe!("inference.generate",
+///     adapter.generate_text(request));
+/// ```
+///
+/// ## Why this isn't `time_async!`
+///
+/// The name `time_async!` is taken by `crate::logging::time_async!`
+/// which has a DIFFERENT shape (RAII `TimingGuard` with
+/// `category` + `operation`, NOT a tracing span). The two
+/// macros serve different observability paths — RAII to the
+/// logging crate's own logger vs tracing-span to the substrate's
+/// probe routing. Keeping distinct names prevents accidental
+/// substitution.
+///
+/// ## Why this is safe across `.await`
+///
+/// The previous substrate-wide foot-gun (PR #1529 reviewer 2 fix)
+/// was a `time!` macro that expanded to `let _enter = span.enter();
+/// $body` where `$body` contained `.await`. Holding `_enter` across
+/// `.await` broke `URI_STACK`. THIS macro expands to
+/// `$future.instrument(span).await` — the future itself enters /
+/// exits the span via `Future::poll` boundaries, never holding a
+/// scope guard across an await suspension. Same shape
+/// `CommandExecutor::dispatch` uses (per the `d1cf19dc5` fix).
+///
+/// ## Where it lands
+///
+/// Emits the same `timing` probe class as `time_sync!`. Operators
+/// filter both sync + async timings together via
+/// `CONTINUUM_PROBE_CLASSES=timing` and see one flat timeline of
+/// every instrumented seam.
+#[macro_export]
+macro_rules! time_probe {
+    ($name:expr, $future:expr) => {{
+        use ::tracing::Instrument as _;
+        $future
+            .instrument(::tracing::info_span!(
+                "time",
+                name = $name,
+                probe_class = "timing",
+            ))
+            .await
+    }};
+}
 
 /// Returns the substrate's "call stack" at this point as a
 /// `Vec<String>` of URI frames from the dispatch root to here.
@@ -242,6 +283,50 @@ mod tests {
     #[test]
     fn time_expression_returns_expression_value() {
         let result = crate::time_sync!("test_phase", 21 * 2);
+        assert_eq!(result, 42);
+    }
+
+    /// `time_probe!` wraps a future and yields the future's value
+    /// at the call site — i.e. the macro is value-transparent so
+    /// switching `expr.await` to `time_probe!("seam", expr)` is a
+    /// pure observability addition with no shape change.
+    ///
+    /// Uses `block_on` rather than `#[tokio::test]` to keep the test
+    /// dep-light — the macro doesn't care about the executor, just
+    /// that the call shape compiles + returns the inner future's
+    /// value.
+    #[test]
+    fn time_probe_returns_inner_future_value() {
+        async fn produces_forty_two() -> i32 {
+            42
+        }
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime");
+        let result = runtime.block_on(async {
+            crate::time_probe!("test_phase", produces_forty_two())
+        });
+        assert_eq!(result, 42);
+    }
+
+    /// Multiple nested `time_probe!` calls compose — the inner
+    /// span becomes a child of the outer span, same as
+    /// `time_sync!` nesting. Tests the macro's hygiene + that
+    /// the value flows through both layers.
+    #[test]
+    fn time_probe_nested_compose_and_return_inner_value() {
+        async fn doubled(x: i32) -> i32 {
+            x * 2
+        }
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime");
+        let result = runtime.block_on(async {
+            let outer = crate::time_probe!("outer", async {
+                crate::time_probe!("inner", doubled(21))
+            });
+            outer
+        });
         assert_eq!(result, 42);
     }
 

--- a/src/workers/continuum-core/src/routing/macros.rs
+++ b/src/workers/continuum-core/src/routing/macros.rs
@@ -166,19 +166,51 @@ macro_rules! time_sync {
 ///
 /// Emits the same `timing` probe class as `time_sync!`. Operators
 /// filter both sync + async timings together via
-/// `CONTINUUM_PROBE_CLASSES=timing` and see one flat timeline of
-/// every instrumented seam.
+/// `CONTINUUM_PROBE_CLASSES=timing` and see one flat timeline.
+///
+/// **Substrate gaps tracked separately:** task #196 (probe Layers
+/// only implement `on_event`, not `on_close` — span-close events
+/// from `time_sync!` + `time_probe!` don't yet reach the JSONL log
+/// or broadcast subscribers; the call shape lands here, the
+/// routing side follows). Task #197 (flat `timing` class vs the
+/// substrate's hierarchical class taxonomy — picking the
+/// convention is its own design decision). Don't rely on the
+/// timing probe being persistable until #196 lands.
+///
+/// ## Cost
+///
+/// Low — but NOT zero. `info_span!` allocates a `Span` struct +
+/// attaches the `name` + `probe_class` fields regardless of
+/// whether a subscriber is registered. `Instrumented<F>` wraps
+/// the future, adding ~24 bytes per call site and one branch on
+/// every `poll`. Tracing's `release_max_level_*` cargo features
+/// compile out the `event!` body, but the `Instrumented<F>`
+/// wrapper persists at runtime even at max-level-off. Acceptable
+/// for cognition seams (Qwen inference dominates wall-clock by
+/// 4-5 orders of magnitude); audit per task #198 if sprinkled
+/// into a hot loop.
+///
+/// ## Field names
+///
+/// The span carries `seam = $name` (the seam identifier as a
+/// dotted path, e.g. `"cognition.analyze.inference"`) and
+/// `probe_class = "timing"`. `seam` is chosen over the more-
+/// natural `name` to avoid field-name collision with other
+/// probes that already use `name` for different purposes
+/// (`probe!(class="state", name="active_persona", ...)`). All
+/// `jq` queries should filter on `.fields.seam`.
 #[macro_export]
 macro_rules! time_probe {
     ($name:expr, $future:expr) => {{
-        use ::tracing::Instrument as _;
-        $future
-            .instrument(::tracing::info_span!(
+        ::tracing::Instrument::instrument(
+            $future,
+            ::tracing::info_span!(
                 "time",
-                name = $name,
+                seam = $name,
                 probe_class = "timing",
-            ))
-            .await
+            ),
+        )
+        .await
     }};
 }
 
@@ -307,6 +339,26 @@ mod tests {
             crate::time_probe!("test_phase", produces_forty_two())
         });
         assert_eq!(result, 42);
+    }
+
+    /// `time_probe!` MUST pass `Result<T, E>` futures through
+    /// unchanged — `.instrument()` preserves the inner future's
+    /// `Output` type, but a test that uses an infallible future
+    /// can't prove that. Pin the error-path explicitly per
+    /// `[[no-fallbacks-ever]]`: substrate refuses to silently
+    /// swallow errors at any seam.
+    #[test]
+    fn time_probe_propagates_error_from_inner_future() {
+        async fn fails() -> Result<i32, &'static str> {
+            Err("intentional")
+        }
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime");
+        let result: Result<i32, &str> = runtime.block_on(async {
+            crate::time_probe!("test_error_path", fails())
+        });
+        assert_eq!(result, Err("intentional"));
     }
 
     /// Multiple nested `time_probe!` calls compose — the inner


### PR DESCRIPTION
## Summary

`time_probe!` macro for one-line async timing — substrate refinement caught during cognition work per `[[refine-tools-as-you-use-them]]`. Companion to `time_sync!`; both emit to the substrate's `timing` probe class.

**Revised after the reviewer mandate flagged real issues.** Three adversarial reviewers per `[[reviewer-mandate-elegance-and-substrate-viability]]` all BLOCKED with substantive findings. The mandate worked — it surfaced both in-scope macro fixes AND deeper substrate gaps the substrate has been carrying silently.

## What's in this PR (after revision)

- `time_probe!("seam.path", future)` — collapses three-line `.instrument(info_span!(...)).await` ceremony to one line. Same `timing` probe class as `time_sync!`.
- Field is `seam` (not `name`) so it doesn't collide with other probes' use of `name`.
- Fully-qualified `::tracing::Instrument::instrument(future, span).await` expansion — no hidden `use` import inside macro body.
- Honest cost docstring: ~24 bytes per call site, one extra branch per poll, `Span` allocates regardless of subscriber state. Acceptable for cognition seams (Qwen dominates wall-clock by 4-5 orders of magnitude); benchmark per task #198 before sprinkling into a hot loop.
- Manual updated to show `time_probe!` alongside `time_sync!` in the "How to add a probe" example block, with explicit persistence caveat (see follow-up #196).

## Tests (3 passing)

- `time_probe_returns_inner_future_value` — value transparency
- `time_probe_propagates_error_from_inner_future` (NEW) — `Result` futures don't get errors swallowed per `[[no-fallbacks-ever]]`
- `time_probe_nested_compose_and_return_inner_value` — nested spans compose

## Reviewer findings — what's in vs follow-up

| Finding | Status |
|---|---|
| Field `name` collision risk | Fixed — renamed to `seam` |
| Hidden `use ... as _` inside macro | Fixed — fully-qualified call |
| Docstring overclaim "zero cost" | Fixed — honest cost section |
| No error-path test | Fixed — new test |
| Manual example missing `time_probe!` | Fixed |
| `ProbeRouterLayer` / `JsonlProbeFileSink` only do `on_event` — span-close events from `time_sync!` + `time_probe!` aren't actually persisted to JSONL today | Tracked as **task #196**. The macro docstring + manual carry the caveat. |
| Flat `timing` class vs hierarchical taxonomy (`CONTINUUM_PROBE_CLASSES=cognition` won't catch cognition timings) | Tracked as **task #197** |
| Per-event HashMap allocation under multi-persona load | Tracked as **task #198** — audit + bench before broad sprinkle |

## Why revise rather than withdraw

The call-site shape (`time_probe!("seam", future)`) is stable. The routing-side gap (#196) is its own slice worth doing right. Shipping the macro now means: when #196 lands, every existing `time_sync!` AND `time_probe!` call site starts emitting JSONL with zero further code changes. The docstring + manual carry the caveat so no one mistakes the macro for an end-to-end shipping observability primitive — yet.

## How the reviewer mandate worked

Per `[[reviewer-mandate-elegance-and-substrate-viability]]`, three adversarial reviewers were spawned with explicit prompts naming the seven lens dimensions (architecture / design / traits / modularity / speed / Intel-Mac viability / probe coverage). All three found different real issues that pure correctness review would have missed:

- **Architecture** reviewer caught the hidden `use` import + naming subtleties + the missing integration verification
- **Speed-viability** reviewer caught the docstring overclaim + the Layer's HashMap allocation pressure (now tracked)
- **Probe-coverage** reviewer caught the field collision + the class taxonomy violation + the missing adoption story (now tracked)

The mandate is now in `[[reviewer-mandate-elegance-and-substrate-viability]]` so future PRs get the same depth of review by default.

## Doctrine

- `[[refine-tools-as-you-use-them]]` — substrate refinement caught while doing cognition work; ship both ends
- `[[reviewer-mandate-elegance-and-substrate-viability]]` — adversarial reviewers find depth that pure correctness review misses
- `[[no-fallbacks-ever]]` — error-path test pinned; no silent swallowing
- `[[jtag-probes-are-rtos-debugger]]` — "easy one-liners or it won't happen"; this is the async one-liner

cards: substrate refinement under `[[refine-tools-as-you-use-them]]`
companion PRs: #1538 (boot wiring + typed-config) + #1539 (silence affordance + identity grounding)
follow-up tasks: #196 (span-close persistence) + #197 (class taxonomy) + #198 (allocation audit)