### PR TITLE
feat(adapter): arc 1 — typed protocol descriptors on AdapterCapabilities

### DIFF
--- a/src/workers/continuum-core/src/ai/adapter.rs
+++ b/src/workers/continuum-core/src/ai/adapter.rs
@@ -88,7 +88,110 @@ impl Default for AdapterConfig {
     }
 }
 
-/// AI provider adapter capabilities
+/// How the adapter ACCEPTS tool-call requests. This is arc 1's pivot
+/// insurance: cognition asks "can you do tools?" and the substrate
+/// routes accordingly — no special-casing per adapter, no "if openai
+/// then ..." branches. Per `[[adapter-pattern-is-the-pivot-insurance]]`.
+///
+/// The substrate's tool-execution loop reads this and either:
+/// 1. Calls the adapter natively (NativeFunctionCalling, JsonMode) and
+///    parses the structured response, OR
+/// 2. Wraps tool descriptors into the prompt itself (JsonInPrompt,
+///    XmlTags) and parses tool calls out of the text output stream
+///
+/// Adapters declare ONE protocol — the best they natively support.
+/// Bridged protocols (e.g., wrapping JsonInPrompt over a base model that
+/// could do better) belong in cognition's compose phase, not here.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ToolCallProtocol {
+    /// No tool calling at all — caller must implement tool execution
+    /// out-of-band or skip tool use. Pure-text completion adapters
+    /// (HeuristicAdapter, embedding-only models).
+    #[default]
+    None,
+    /// Tools described in the system/user prompt as JSON schema; the
+    /// model emits JSON in its text output, substrate parses. Works on
+    /// any text model with sufficient instruction-following. The
+    /// fallback any prompt-driven model can fulfill.
+    JsonInPrompt,
+    /// Provider's native JSON mode (`response_format = json_object`) —
+    /// the model is constrained at sampling time to emit valid JSON.
+    /// Stronger guarantee than JsonInPrompt; weaker than function calling.
+    JsonMode,
+    /// Native function calling primitives — provider returns structured
+    /// tool_calls in its API response shape (OpenAI tools, Anthropic
+    /// tool_use). The substrate consumes them directly without parsing.
+    NativeFunctionCalling,
+    /// XML-style tool tags inside text output — Anthropic's pre-tool-use
+    /// pattern. Substrate parses `<tool>...</tool>` blocks.
+    XmlTags,
+}
+
+/// How the adapter ACCEPTS structured-output schemas. Same shape as
+/// `ToolCallProtocol` — cognition asks "can you constrain output to
+/// this schema?" and routes accordingly. Independent of tool calling
+/// because some adapters support schemas without tools (and vice versa).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum StructuredOutputProtocol {
+    /// No structured-output enforcement. Substrate must validate + retry.
+    #[default]
+    None,
+    /// JSON Schema enforced by the provider (OpenAI structured outputs).
+    /// Strongest guarantee — the API rejects invalid outputs.
+    JsonSchema,
+    /// Grammar-constrained sampling (llama.cpp `--grammar` / GBNF).
+    /// Local-model strength: the sampler refuses tokens that violate
+    /// the grammar.
+    GrammarConstrained,
+    /// Schema described in the prompt; substrate parses + retries on
+    /// invalid. Always-available fallback for text models.
+    PromptOnly,
+}
+
+/// Which modalities the adapter handles. The pivot insurance for
+/// sensory parity per `[[ai-namespace-multimodal-crutches]]`: lesser
+/// models declare `vision_in = false` here; the substrate's
+/// VisionDescriptionService bridges by rendering an image description
+/// into text BEFORE the adapter sees the request. Same for STT (audio
+/// → text) and TTS (text → audio). Capability declared honestly =
+/// bridges applied correctly = LCD personas get the same sensory
+/// experience as Claude.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ModalitySet {
+    /// Accepts text input (system + user messages, raw prompts).
+    pub text_in: bool,
+    /// Produces text output (the common case).
+    pub text_out: bool,
+    /// Accepts image input natively (base64 or URL).
+    pub vision_in: bool,
+    /// Accepts audio input natively (audio file or raw samples).
+    pub audio_in: bool,
+    /// Produces audio output natively (TTS-equivalent).
+    pub audio_out: bool,
+}
+
+impl ModalitySet {
+    /// Text-only modality (most LLMs).
+    pub const TEXT_ONLY: Self = Self {
+        text_in: true,
+        text_out: true,
+        vision_in: false,
+        audio_in: false,
+        audio_out: false,
+    };
+}
+
+/// AI provider adapter capabilities — the typed surface the substrate's
+/// coordinator consults when routing a workload to the best-fit adapter.
+///
+/// Arc 1 (card 42bd9367): added typed protocol descriptors
+/// (`tool_call_protocol`, `structured_output_protocol`, `modalities`)
+/// alongside the legacy bool flags. The bool flags are retained for
+/// existing callers; new selectors should consult the typed fields.
+/// Per `[[adapter-pattern-is-the-pivot-insurance]]`: every ML-touching
+/// capability sits behind this trait so the substrate can pivot
+/// (swap framework, swap model, swap provider) by declaration, not
+/// rewrite.
 #[derive(Debug, Clone, Default)]
 pub struct AdapterCapabilities {
     pub supports_text_generation: bool,
@@ -101,6 +204,26 @@ pub struct AdapterCapabilities {
     pub supports_image_generation: bool,
     pub is_local: bool,
     pub max_context_window: u32,
+
+    // ─── Arc 1: typed protocol descriptors (card 42bd9367) ─────────────────
+    /// Tool-calling protocol the adapter NATIVELY supports. Cognition's
+    /// tool loop routes through this. `None` means the substrate either
+    /// skips tools or wraps via prompt-text emulation in compose phase.
+    pub tool_call_protocol: ToolCallProtocol,
+    /// Structured-output protocol the adapter NATIVELY supports.
+    /// Independent of tool calling. `None` means schema validation +
+    /// retry happen in cognition.
+    pub structured_output_protocol: StructuredOutputProtocol,
+    /// Modalities the adapter handles natively. Modalities NOT in this
+    /// set are bridged by the substrate before the adapter sees the
+    /// request (vision → VisionDescriptionService, audio_in → STT,
+    /// audio_out → TTS). LCD personas get sensory parity via bridges
+    /// per `[[ai-namespace-multimodal-crutches]]`.
+    pub modalities: ModalitySet,
+    /// Maximum tokens the adapter will emit in a single response.
+    /// Distinct from `max_context_window` (input + output limit).
+    /// Used by cognition to bound the compose phase.
+    pub max_output_tokens: u32,
 }
 
 /// LoRA capabilities reported by adapters

--- a/src/workers/continuum-core/src/ai/anthropic_adapter.rs
+++ b/src/workers/continuum-core/src/ai/anthropic_adapter.rs
@@ -268,6 +268,19 @@ impl AIProviderAdapter for AnthropicAdapter {
             supports_image_generation: false,
             is_local: false,
             max_context_window: 200000,
+
+            // Arc 1: Anthropic ships native function calling (tool_use blocks)
+            // + native JSON Schema enforcement. Vision-in native; audio bridged.
+            tool_call_protocol: crate::ai::adapter::ToolCallProtocol::NativeFunctionCalling,
+            structured_output_protocol: crate::ai::adapter::StructuredOutputProtocol::JsonSchema,
+            modalities: crate::ai::adapter::ModalitySet {
+                text_in: true,
+                text_out: true,
+                vision_in: true,
+                audio_in: false,
+                audio_out: false,
+            },
+            max_output_tokens: 8192,
         }
     }
 

--- a/src/workers/continuum-core/src/ai/heuristic_adapter.rs
+++ b/src/workers/continuum-core/src/ai/heuristic_adapter.rs
@@ -332,6 +332,14 @@ impl AIProviderAdapter for HeuristicInferenceAdapter {
             is_local: true,
             // Effectively unlimited — we never reject by length.
             max_context_window: u32::MAX,
+
+            // Arc 1 typed descriptors: heuristic is a deterministic
+            // text-only adapter — no protocols beyond text I/O.
+            tool_call_protocol: crate::ai::adapter::ToolCallProtocol::None,
+            structured_output_protocol:
+                crate::ai::adapter::StructuredOutputProtocol::None,
+            modalities: crate::ai::adapter::ModalitySet::TEXT_ONLY,
+            max_output_tokens: 4096,
         }
     }
 

--- a/src/workers/continuum-core/src/ai/openai_adapter.rs
+++ b/src/workers/continuum-core/src/ai/openai_adapter.rs
@@ -500,11 +500,13 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
     }
 
     fn capabilities(&self) -> AdapterCapabilities {
+        let supports_tools = self.config.supports_tools;
+        let supports_vision = self.config.supports_vision;
         AdapterCapabilities {
             supports_text_generation: true,
             supports_chat: true,
-            supports_tool_use: self.config.supports_tools,
-            supports_vision: self.config.supports_vision,
+            supports_tool_use: supports_tools,
+            supports_vision,
             supports_streaming: true,
             supports_embeddings: self.config.provider_id == "openai",
             supports_audio: false,
@@ -516,6 +518,29 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                 .first()
                 .map(|m| m.context_window)
                 .unwrap_or(128000),
+
+            // Arc 1: OpenAI-compatible providers (OpenAI, DeepSeek, Together,
+            // Fireworks, Groq, xAI, Mistral) support native function calling
+            // when supports_tools is set, and JSON Schema for structured output.
+            // Vision-in when supports_vision is set; rest goes through bridges.
+            tool_call_protocol: if supports_tools {
+                crate::ai::adapter::ToolCallProtocol::NativeFunctionCalling
+            } else {
+                crate::ai::adapter::ToolCallProtocol::None
+            },
+            structured_output_protocol: if supports_tools {
+                crate::ai::adapter::StructuredOutputProtocol::JsonSchema
+            } else {
+                crate::ai::adapter::StructuredOutputProtocol::PromptOnly
+            },
+            modalities: crate::ai::adapter::ModalitySet {
+                text_in: true,
+                text_out: true,
+                vision_in: supports_vision,
+                audio_in: false,
+                audio_out: false,
+            },
+            max_output_tokens: 16_384,
         }
     }
 

--- a/src/workers/continuum-core/src/inference/airc_remote/adapter.rs
+++ b/src/workers/continuum-core/src/inference/airc_remote/adapter.rs
@@ -96,6 +96,16 @@ impl AIProviderAdapter for AircRemoteInferenceAdapter {
             is_local: false,
             // Unknown; defer to whatever the peer can do.
             max_context_window: u32::MAX,
+
+            // Arc 1: remote peer adapter — without a capability-discovery
+            // handshake (future card), we don't know what protocols the
+            // peer's adapter supports. Defer to None / TEXT_ONLY as the
+            // safe-floor; the substrate refines once the peer reports.
+            tool_call_protocol: crate::ai::adapter::ToolCallProtocol::None,
+            structured_output_protocol:
+                crate::ai::adapter::StructuredOutputProtocol::None,
+            modalities: crate::ai::adapter::ModalitySet::TEXT_ONLY,
+            max_output_tokens: 4096,
         }
     }
 

--- a/src/workers/continuum-core/src/inference/llamacpp_adapter.rs
+++ b/src/workers/continuum-core/src/inference/llamacpp_adapter.rs
@@ -685,6 +685,17 @@ impl AIProviderAdapter for LlamaCppAdapter {
             supports_image_generation: false,
             is_local: true,
             max_context_window: max_ctx,
+
+            // Arc 1: llama.cpp tools are prompt-driven (no native protocol);
+            // structured output via GBNF grammar-constrained sampling, which
+            // IS native to llama.cpp. Vision-in handled by mmproj adapter
+            // when loaded; not declared here at the text-LLM layer.
+            // Audio bridged via STT (whisper) / TTS in the substrate.
+            tool_call_protocol: crate::ai::adapter::ToolCallProtocol::JsonInPrompt,
+            structured_output_protocol:
+                crate::ai::adapter::StructuredOutputProtocol::GrammarConstrained,
+            modalities: crate::ai::adapter::ModalitySet::TEXT_ONLY,
+            max_output_tokens: 4096,
         }
     }
 


### PR DESCRIPTION
feat(adapter): arc 1 — typed protocol descriptors on AdapterCapabilities (card 42bd9367)

The bool-flag `AdapterCapabilities` (supports_tool_use, supports_vision, etc.)
was unsigned about HOW each capability is provided — fine for "is the
feature available" questions, useless for "which protocol does cognition
need to speak." Arc 1 of the substrate plan addresses this directly.

This commit adds three typed descriptors alongside the existing bool
flags (kept for back-compat; new selectors should consult the typed
fields):

- `tool_call_protocol: ToolCallProtocol` — enumerates HOW the adapter
  accepts tool calls. None / JsonInPrompt / JsonMode /
  NativeFunctionCalling / XmlTags. Cognition's tool loop routes through
  this without special-casing per adapter name.

- `structured_output_protocol: StructuredOutputProtocol` — None /
  JsonSchema / GrammarConstrained (llama.cpp GBNF) / PromptOnly. Lets
  cognition pick the right enforcement strategy per workload per adapter.

- `modalities: ModalitySet` — typed text_in/text_out/vision_in/audio_in/
  audio_out booleans declaring what the adapter handles NATIVELY.
  Modalities NOT in the set get bridged by the substrate
  (VisionDescriptionService, STT, TTS) before the adapter sees the
  request. LCD personas get sensory parity via bridges per the
  [[ai-namespace-multimodal-crutches]] doctrine.

- `max_output_tokens: u32` — distinct from `max_context_window`; bounds
  the compose phase.

Each existing adapter declares truthfully:

- **HeuristicAdapter** — TEXT_ONLY, no tool protocol, no structured
  output. Substrate doesn't try to use it for what it can't do.
- **OpenAI-compatible** (OpenAI/DeepSeek/Together/Fireworks/Groq/xAI/
  Mistral) — NativeFunctionCalling + JsonSchema when supports_tools.
  Vision-in native when supports_vision.
- **Anthropic** — NativeFunctionCalling (tool_use blocks) +
  JsonSchema. Vision-in native.
- **LlamaCpp** — JsonInPrompt (prompt-driven tool emulation) +
  GrammarConstrained (GBNF). Vision-in handled by mmproj adapter
  separately.
- **AircRemoteAdapter** — defers to None / TEXT_ONLY until a
  capability-discovery handshake card lands (future work).

Per [[adapter-pattern-is-the-pivot-insurance]]: every ML-touching
capability sits behind this trait so the substrate pivots (swap
framework, swap model, swap provider) by declaration, not rewrite.
Arc 2 (#122 LoRA paging) and arc 3 (teacher routing) build on this.

Tests: 48/48 ai:: tests pass; no behavior changes (existing capability
queries continue to work via bool flags; new typed fields are purely
additive).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
