### PR TITLE
test(sentinel): isolate checkpoint tests via CONTINUUM_CHECKPOINT_DIR (#205)

### DIFF
--- a/src/workers/continuum-core/src/modules/sentinel/checkpoint.rs
+++ b/src/workers/continuum-core/src/modules/sentinel/checkpoint.rs
@@ -2,13 +2,22 @@
 //!
 //! Atomic writes: serialize → write to .tmp → rename.
 //! Storage: ~/.continuum/sentinel/checkpoints/{handle}.json
+//! (or `$CONTINUUM_CHECKPOINT_DIR` when set — tests use this to
+//! redirect writes to a per-process tempdir so `cargo test` never
+//! touches the developer's real home.)
 
 use std::path::PathBuf;
 
 use super::types::{PipelineCheckpoint, PipelineStatus};
 
-/// Base directory for checkpoint storage
+/// Base directory for checkpoint storage.
+///
+/// Production: `~/.continuum/sentinel/checkpoints/`.
+/// Tests / dev tools: set `CONTINUUM_CHECKPOINT_DIR` to redirect.
 fn checkpoints_dir() -> PathBuf {
+    if let Some(override_dir) = std::env::var_os("CONTINUUM_CHECKPOINT_DIR") {
+        return PathBuf::from(override_dir);
+    }
     let home = dirs::home_dir().expect("Failed to resolve home directory");
     home.join(".continuum").join("sentinel").join("checkpoints")
 }
@@ -137,6 +146,25 @@ mod tests {
     use super::*;
     use crate::modules::sentinel::types::*;
     use std::collections::HashMap;
+    use std::sync::OnceLock;
+
+    /// Per-process tempdir installed into `CONTINUUM_CHECKPOINT_DIR` the
+    /// first time any test in this module runs. Kept alive (and unique
+    /// per `cargo test` invocation) by the `OnceLock` — `TempDir`'s
+    /// Drop deletes it when the process exits. Without this isolation
+    /// the tests below polluted `~/.continuum/sentinel/checkpoints/`
+    /// on the developer's real home and flaked on machines where that
+    /// directory was root-owned from prior docker-compose bind-mounts.
+    fn ensure_checkpoint_dir_isolated() {
+        static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+        let dir = DIR.get_or_init(|| {
+            tempfile::tempdir().expect("create checkpoint test tempdir")
+        });
+        // Set every call: cargo runs tests in parallel and any other
+        // test that clears CONTINUUM_CHECKPOINT_DIR could race us;
+        // re-setting per test keeps the contract local.
+        std::env::set_var("CONTINUUM_CHECKPOINT_DIR", dir.path());
+    }
 
     fn make_test_checkpoint(handle: &str) -> PipelineCheckpoint {
         PipelineCheckpoint {
@@ -189,6 +217,7 @@ mod tests {
 
     #[test]
     fn test_save_load_checkpoint() {
+        ensure_checkpoint_dir_isolated();
         let handle = format!(
             "test-ckpt-{}",
             uuid::Uuid::new_v4().to_string()[..8].to_string()
@@ -208,6 +237,7 @@ mod tests {
 
     #[test]
     fn test_list_checkpoints() {
+        ensure_checkpoint_dir_isolated();
         let handle = format!(
             "test-list-{}",
             uuid::Uuid::new_v4().to_string()[..8].to_string()
@@ -223,6 +253,7 @@ mod tests {
 
     #[test]
     fn test_recover_interrupted() {
+        ensure_checkpoint_dir_isolated();
         let handle = format!(
             "test-recover-{}",
             uuid::Uuid::new_v4().to_string()[..8].to_string()


### PR DESCRIPTION
## Summary

Reapplies the fix from closed PR #971 against current canary. Three `modules::sentinel::checkpoint::tests` were writing to the developer's real `~/.continuum/sentinel/checkpoints/` — visible as residual `test-list-*.json` files surviving across runs (Jun 3 + Jun 5 timestamps on this machine).

## Fix (32-line diff)

- `checkpoints_dir()` reads `CONTINUUM_CHECKPOINT_DIR` first; falls back to the production `~/.continuum/sentinel/checkpoints/` path unchanged when the env var is unset. **Production code path unaffected.**
- `tests::ensure_checkpoint_dir_isolated()` installs a per-process `tempfile::TempDir` into the env var (held alive by `OnceLock` so Drop fires at process exit). Every test calls it at entry.

## Why two failure modes matter

1. **Root-owned home directory pollution** — on machines where docker compose bind-mounted `$HOME` and chmod'd subdirs under root, the tests fail to write → prepush flake.
2. **Cross-test interference** — `test_list_checkpoints` asserts the freshly-written handle appears in the listing, but pre-existing `test-*.json` files from prior runs leak into that listing and could mask real regressions.

## Validation

- 3/3 `modules::sentinel::checkpoint::tests` pass with isolation active
- Confirmed post-fix that no new files appear under `~/.continuum/sentinel/`
- Old pollution (test-list-1b048c92.json from Jun 3, etc.) still visible — fix prevents future pollution, doesn't clean historical state

## Provenance

Carried forward from PR #971 (closed today as too stale to rebase). Substrate task #205 marks the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
