### PR TITLE
feat(probes): instrument inference seam + prompt assembly (#206, #195)

### DIFF
--- a/docs/architecture/RTOS-DEBUGGER-PROBES.md
+++ b/docs/architecture/RTOS-DEBUGGER-PROBES.md
@@ -53,7 +53,15 @@ A stable set of `class` values so probes from different files compose into a coh
 - `persona.response.exit` — final PersonaResponse: decision, text length
 
 **Prompt assembly** (`persona/prompt_assembly.rs`):
-- `persona.prompt.assemble` — final composition stats: system_message length, message_count, estimated_tokens
+- `persona.prompt.assemble` — final composition stats: persona, system_message_len, message_count, estimated_tokens, matched_angle_present, engrams_count, social_signals_present, voice_mode, multi_party_strategy
+
+**Inference adapter** (`inference/llamacpp_adapter.rs::generate_text`):
+- `inference.generate.enter` — adapter received request: model, persona_id, msg_count, max_tokens, has_system_prompt, parts_image, parts_audio
+- `inference.generate.exit` — adapter returning: model, tokens_out, text_len, duration_ms, tok_per_sec
+- Timing seams (emit on the `timing` class with `seam` field):
+  - `inference.render_chat` — synchronous chat-template rendering (sub-ms typically, but cumulative)
+  - `inference.forward.text` — pure-text LLM forward pass through the scheduler (the dominant cost on LCD tier — 95%+)
+  - `inference.forward.multimodal` — mtmd single-flight path (text+image / text+audio)
 
 **Cognition: shared analysis** (`cognition/shared_analysis/mod.rs`):
 - `cognition.analyze.enter` — input fingerprint, known_specialties count
@@ -215,9 +223,9 @@ What is INCOMPLETE — the sprinkle that turns the JTAG hardware into a working 
 - [x] `persona/response.rs::run_render` — assembled prompt verbatim + composition stats
 - [x] `cognition/shared_analysis/mod.rs::analyze` — entry, single-specialty noop, L1 cache hit, parsed angles (empty vs non-empty count)
 - [x] `persona/service_loop.rs::serve_persona_loop_inner` — `turn.start` / `turn.spoke` (with full phase decomposition recall+admit+compose+respond+say) / `turn.silent` (with reason) / `turn.error` (with stage=respond|say) — **wired in this PR**
-- [ ] `persona/prompt_assembly.rs::assemble` — final composition stats (system_message length, message count, est tokens, matched_angle present, engrams count, social_signals present) — covered indirectly by `persona.response.render.prompt`; standalone probe TBD if assembly logic grows
+- [x] `persona/prompt_assembly.rs::assemble` — final composition stats wired at the function tail (system_message_len, message_count, estimated_tokens, matched_angle_present, engrams_count, social_signals_present, voice_mode, multi_party_strategy)
 - [ ] `cognition/response_orchestrator.rs::score_persona` — per-persona score + matched_angles + decision reason — note: the score_persona gate is currently bypassed (response.rs:288–300); probes go in if/when it's re-wired
-- [ ] `ai/llama_cpp_adapter::generate_text` — request fingerprint + raw output + finish_reason — covered indirectly by `persona.response.render.prompt` (in) + `persona.response.render.raw` (out); adapter-level probe TBD when we need per-batch visibility
+- [x] `inference/llamacpp_adapter.rs::generate_text` — entry probe (`inference.generate.enter`) + timing probes around `render_chat` and the two `forward.*` spawn_blocking paths + exit probe (`inference.generate.exit`) carrying `tok_per_sec`. This is the dominant-cost seam on LCD tier per the inference-latency campaign (task #195).
 
 Each gets a small commit that adds the probes + updates this manual's checklist. The proof-of-value for each commit: enable the file sink, run the multi-persona scenario, `jq` the relevant class, see the variable snapshots.
 

--- a/src/workers/continuum-core/src/inference/llamacpp_adapter.rs
+++ b/src/workers/continuum-core/src/inference/llamacpp_adapter.rs
@@ -862,6 +862,26 @@ impl AIProviderAdapter for LlamaCppAdapter {
                 parts_audio,
                 parts_other,
             ));
+
+            // RTOS probe: inference entry seam. The persona service loop
+            // talks through `adapter.generate_text`; this is where the
+            // wall-clock cost actually accrues. Class taxonomy lives in
+            // docs/architecture/RTOS-DEBUGGER-PROBES.md. Per
+            // [[jtag-probes-are-rtos-debugger]]: name the surrounding
+            // vars so the operator filtering on
+            // `class=="inference.generate.enter"` has the request
+            // fingerprint without grepping logs.
+            crate::probe!(
+                class = "inference.generate.enter",
+                model = request.model.as_deref().unwrap_or("?"),
+                persona_id = request.persona_id.as_deref().unwrap_or(""),
+                msg_count = request.messages.len(),
+                max_tokens = request.max_tokens.unwrap_or(0),
+                has_system_prompt = request.system_prompt.is_some(),
+                parts_image = parts_image,
+                parts_audio = parts_audio,
+                "generate_text entry"
+            );
         }
 
         let mut collected_media: Vec<(llama::MediaKind, Vec<u8>)> = Vec::new();
@@ -917,7 +937,13 @@ impl AIProviderAdapter for LlamaCppAdapter {
                 content,
             });
         }
-        let prompt = llama::render_chat(template.as_deref(), &messages, true)?;
+        // RTOS probe: chat-template rendering is synchronous + small,
+        // but cumulative across thousands of turns it can shadow real
+        // bottlenecks. Bracketing it lets the operator subtract it
+        // from `inference.forward.*` cleanly.
+        let prompt = crate::time_sync!("inference.render_chat", {
+            llama::render_chat(template.as_deref(), &messages, true)
+        })?;
 
         // No hardcoded cap. If the caller didn't specify, the model can
         // decode up to its trained context. Capping silently at 2048 was
@@ -963,7 +989,11 @@ impl AIProviderAdapter for LlamaCppAdapter {
             .and_then(|s| uuid::Uuid::parse_str(s).ok());
         let result: Result<(String, usize), String> = if collected_media.is_empty() {
             // Pure-text path: scheduler-managed continuous batching.
-            tokio::task::spawn_blocking(move || {
+            // RTOS timing probe: this is the actual LLM forward pass —
+            // by far the dominant cost (95%+ on LCD tier per
+            // 2026-06-06 baseline). `time_probe!` wraps the JoinHandle
+            // future cleanly across the `.await`.
+            crate::time_probe!("inference.forward.text", tokio::task::spawn_blocking(move || {
                 let stop_refs: Vec<&str> = stop_for_closure.iter().map(|s| s.as_str()).collect();
                 backend_for_blocking.generate_for_persona(
                     persona_id,
@@ -973,8 +1003,7 @@ impl AIProviderAdapter for LlamaCppAdapter {
                     &stop_refs,
                     &[],
                 )
-            })
-            .await
+            }))
             .map_err(|e| format!("generate task panicked: {e}"))?
         } else {
             // Multimodal path: bypass the scheduler — media tokens have
@@ -998,7 +1027,11 @@ impl AIProviderAdapter for LlamaCppAdapter {
                 ));
             }
             let (kind, media_bytes) = collected_media.into_iter().next().unwrap();
-            tokio::task::spawn_blocking(move || {
+            // RTOS timing probe: mtmd path runs single-flight (no
+            // scheduler batching for media) so the timing here is
+            // direct end-to-end. Separate seam from the text path so
+            // operators can `jq` text-only vs mtmd cost distinctly.
+            crate::time_probe!("inference.forward.multimodal", tokio::task::spawn_blocking(move || {
                 let stop_refs: Vec<&str> = stop_for_closure.iter().map(|s| s.as_str()).collect();
                 match kind {
                     llama::MediaKind::Image => backend_for_blocking.generate_with_image(
@@ -1016,8 +1049,7 @@ impl AIProviderAdapter for LlamaCppAdapter {
                         &stop_refs,
                     ),
                 }
-            })
-            .await
+            }))
             .map_err(|e| format!("generate_with_media task panicked: {e}"))?
         };
         let (text, tokens) = result?;
@@ -1029,6 +1061,23 @@ impl AIProviderAdapter for LlamaCppAdapter {
             0.0
         };
         *self.last_throughput_tok_s.write() = tok_per_sec;
+
+        // RTOS probe: inference exit seam. Pair with
+        // `inference.generate.enter` via the same span ancestry. The
+        // critical campaign metric is `tok_per_sec` — every probe
+        // here carries it so a `jq` over `inference.generate.exit`
+        // events is the latency dashboard. `text_len` lets the
+        // operator catch the silent-truncation class of bug where
+        // the model stops short of EOS.
+        crate::probe!(
+            class = "inference.generate.exit",
+            model = backend.model_id(),
+            tokens_out = tokens,
+            text_len = text.len(),
+            duration_ms = elapsed.as_millis() as u64,
+            tok_per_sec = tok_per_sec,
+            "generate_text exit"
+        );
 
         // No tail-strip. Previously this hand-rolled `text.rfind(stop)` and
         // truncated — only existed to clean up the special tokens that

--- a/src/workers/continuum-core/src/persona/prompt_assembly.rs
+++ b/src/workers/continuum-core/src/persona/prompt_assembly.rs
@@ -261,6 +261,27 @@ pub fn assemble(input: &PromptAssemblyInput) -> AssembledPrompt {
     let msg_tokens: usize = messages.iter().map(|m| m.content.len() / 4).sum();
     let estimated_tokens = system_tokens + msg_tokens;
 
+    // RTOS probe: prompt-assembly seam. Per docs/architecture/
+    // RTOS-DEBUGGER-PROBES.md taxonomy. The system_message length
+    // is the leading indicator for "why is prefill slow" — when
+    // engrams or social signals grow unbounded the prefill cost
+    // grows quadratically with prompt length. Operators filter on
+    // `class == "persona.prompt.assemble"` to see the composition
+    // shape per turn.
+    crate::probe!(
+        class = "persona.prompt.assemble",
+        persona = %input.persona_name,
+        system_message_len = system_prompt.len(),
+        message_count = messages.len(),
+        estimated_tokens = estimated_tokens,
+        matched_angle_present = !input.matched_angle.is_empty(),
+        engrams_count = input.recalled_engrams.len(),
+        social_signals_present = input.social_signals.is_some(),
+        voice_mode = input.is_voice,
+        multi_party_strategy = ?input.multi_party_strategy,
+        "prompt assembled"
+    );
+
     AssembledPrompt {
         system_message: system_prompt,
         messages,


### PR DESCRIPTION
## Summary

Iteration 1 of the inference-latency campaign (#195). With #196's on_close fix already merged, `time_sync!` / `time_probe!` spans persist to the JSONL sink end-to-end — so the timing data this commit produces is now captureable for the first time.

## What's instrumented

### `inference/llamacpp_adapter.rs::generate_text`
The dominant cost on LCD tier (95%+ wall-clock per 2026-06-06 baseline). Until this PR the function was a black box from the operator's POV — `tok_per_sec` lived in a private `RwLock<f64>` (last-throughput-only).

- **`inference.generate.enter`** — request fingerprint at entry (model, persona_id, msg_count, max_tokens, has_system_prompt, parts_image, parts_audio)
- **`time_sync!("inference.render_chat", ...)`** — chat-template rendering (sub-ms typically, but cumulative)
- **`time_probe!("inference.forward.text", ...)`** — pure-text scheduler-managed forward pass
- **`time_probe!("inference.forward.multimodal", ...)`** — mtmd single-flight path (image / audio)
- **`inference.generate.exit`** — carries the headline metric `tok_per_sec` plus duration_ms, tokens_out, text_len, model. A `jq` filter on this class IS the latency dashboard

### `persona/prompt_assembly.rs::assemble`
The leading indicator for "why is prefill slow." Carries `system_message_len`, `message_count`, `estimated_tokens`, `matched_angle_present`, `engrams_count`, `social_signals_present`, `voice_mode`, `multi_party_strategy`.

## Manual update

`docs/architecture/RTOS-DEBUGGER-PROBES.md`:
- Added the new classes to the taxonomy (with full field lists)
- Marked the prompt-assembly + llamacpp-adapter checklist items DONE per the doc's "When you add a probe, update this manual" rule

## Doctrine alignment

- **`[[jtag-probes-are-rtos-debugger]]`** — every site names surrounding vars the way a breakpoint inspector would. One-liners; macros do the plumbing.
- **`[[no-rust-gates-around-cognition]]`** — probes observe, they DO NOT decide. Zero control-flow change. The existing `runtime::logger` + `last_throughput_tok_s` paths are untouched.
- **`[[init-once-handle-then-lease-zero-copy-refs]]`** — macros expand to `tracing::event!` / `info_span!` which inherit `release_max_level_*` compile-time gates. Zero cost when off.

## Validation

- `cargo check --features metal,accelerate` — clean
- `cargo test --lib persona::prompt_assembly` — 12/12 pass
- `cargo test --lib inference::llamacpp` — 12/12 pass
- 24/24 green across the two modules this PR touches

## Next iteration (separate slice)

Run a real continuum boot with `CONTINUUM_PROBE_FILE=/tmp/continuum-probes.jsonl` + `CONTINUUM_PROBE_CLASSES=inference,persona.prompt,timing`. Exercise the persona service loop. `jq` the JSONL to identify the dominant bottleneck. Optimize that. Iterate.

Reference: substrate task #206 (this PR), task #195 (the campaign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
