### PR TITLE
chore(package): npm start IS headless; npm run desktop adds Node UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "name": "continuum",
   "private": true,
+  "description": "Continuum — headless persona substrate. `npm start` boots the Rust core; `npm run desktop` adds the Node UX shell on top of the same core.",
   "scripts": {
-    "start": "bash src/scripts/parallel-start.sh",
+    "start": "bash src/scripts/start-server.sh",
+    "desktop": "bash src/scripts/parallel-start.sh",
     "stop": "bash src/scripts/system-stop.sh",
     "install:continuum": "bash src/scripts/install.sh",
     "setup:git-hooks": "bash src/scripts/setup-git-hooks.sh"


### PR DESCRIPTION
Single canonical entry. `npm start` boots the Rust substrate directly via `scripts/start-server.sh`. `npm run desktop` adds the Node UX shell on top via `scripts/parallel-start.sh`.

Contributors discover the right entry from `package.json` instead of having to suss out which of five `start*` variants in `src/package.json` matches their intent.

Doctrine: [[headless-rust-must-work-soon]] + [[rust-is-the-core-node-is-the-shell]].

🤖 Generated with [Claude Code](https://claude.com/claude-code)