### PR TITLE
fix(probes): rolling-log fmt-layer default — disarm the disk bomb (#211)

### DIFF
--- a/src/workers/Cargo.lock
+++ b/src/workers/Cargo.lock
@@ -2665,6 +2665,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "ts-rs",
  "uuid",
@@ -9835,6 +9836,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10562,6 +10569,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src/workers/Cargo.toml
+++ b/src/workers/Cargo.toml
@@ -119,6 +119,11 @@ thiserror = "2"
 # Logging/tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Rolling-file writer for the fmt layer so operators don't need to
+# remember to `2>/dev/null`. Pinned to 0.2 — Builder::max_log_files
+# (used in routing/tracing_init.rs) requires ≥0.2.4. See
+# `[[never-redirect-substrate-stderr]]` doctrine memory for why.
+tracing-appender = "0.2"
 
 # Embedding (fastembed)
 fastembed = "5"

--- a/src/workers/continuum-core/Cargo.toml
+++ b/src/workers/continuum-core/Cargo.toml
@@ -114,6 +114,7 @@ earshot = "0.1"  # Fast VAD (WebRTC-style)
 msedge-tts.workspace = true  # Edge-TTS (free Microsoft TTS API)
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing-appender.workspace = true
 rand.workspace = true  # For test audio generation
 ts-rs.workspace = true  # TypeScript type generation
 

--- a/src/workers/continuum-core/src/main.rs
+++ b/src/workers/continuum-core/src/main.rs
@@ -123,6 +123,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // env var SHOULD see this confirmation.
         eprintln!("[continuum-core-server] probes landing at {}", path.display());
     }
+    // Per `[[never-redirect-substrate-stderr]]`: the substrate now
+    // owns its tracing fmt-layer log persistence via a rolling-file
+    // sink under `~/.continuum/logs/` (or `$CONTINUUM_LOG_DIR`).
+    // Surfacing the path at boot prevents the "where are my logs?"
+    // confusion for anyone migrating off the (forbidden)
+    // `npm start 2>&1 | tee /tmp/server.log` pattern.
+    if let Some(ref dir) = probe_install.log_dir {
+        eprintln!(
+            "[continuum-core-server] logs landing at {}/continuum-core-server.YYYY-MM-DD.log (rolling daily, retention 7)",
+            dir.display()
+        );
+    }
+    // CRITICAL: hold the non-blocking writer's WorkerGuard for the
+    // process lifetime. Dropping it flushes + shuts down the
+    // background writer thread; we MUST keep it alive so tail-of-
+    // process log lines reach disk. Underscore-prefixed binding
+    // keeps Rust quiet about "unused" while still binding (vs.
+    // `let _ = ...` which drops immediately).
+    let _log_writer_guard = probe_install.fmt_writer_guard;
 
     // ORT panic-filter deferred to A.2.2 (lands together with the
     // libonnxruntime dlopen probe + 🔊/🔇 voice subsystem indicator

--- a/src/workers/continuum-core/src/routing/tracing_init.rs
+++ b/src/workers/continuum-core/src/routing/tracing_init.rs
@@ -85,10 +85,26 @@ pub struct ProbeTracingConfig {
     /// set = "no filter, every class passes" per the sink's
     /// [`class_passes_filter`](super::probe_file_sink) rules.
     pub probe_classes: HashSet<String>,
-    /// `EnvFilter` directive applied to the fmt (stderr) layer when
+    /// `EnvFilter` directive applied to the fmt layer when
     /// `RUST_LOG` is unset. `"info"` for production servers; `"warn"`
     /// for noisy tests. Empty string falls back to `"info"`.
     pub default_filter: String,
+    /// Directory the fmt layer's rolling log writer drains to. When
+    /// `Some`, the substrate writes its tracing firehose to a
+    /// `daily`-rotated file under this directory (max 7 files
+    /// retained) — operator never has to redirect stderr, the
+    /// substrate manages its own log persistence.
+    ///
+    /// When `None` (e.g. unit tests where an external subscriber
+    /// already captures events), the fmt layer falls back to stderr.
+    /// Production callers should always set this.
+    ///
+    /// Per `[[never-redirect-substrate-stderr]]` (Joel 2026-06-07):
+    /// the operator-facing `> /tmp/server.log 2>&1` pattern ate a
+    /// host's disk in minutes by capturing the full tracing firehose
+    /// at `RUST_LOG=info`. Substrate owns log persistence; shell
+    /// redirects are forbidden.
+    pub log_dir: Option<PathBuf>,
 }
 
 impl ProbeTracingConfig {
@@ -112,25 +128,62 @@ impl ProbeTracingConfig {
                     .collect::<HashSet<_>>()
             })
             .unwrap_or_default();
+        // log_dir: `CONTINUUM_LOG_DIR` env var overrides; otherwise
+        // default to `~/.continuum/logs/`. The substrate owning log
+        // persistence is the doctrine — even on a fresh box where
+        // the env var is unset, npm start writes to a managed file
+        // not stderr-unbounded. Only when neither the env var is set
+        // NOR a home directory resolvable (containerized envs with
+        // HOME unset, certain CI shapes) does this remain `None` and
+        // fmt falls back to stderr — that's an explicit "no managed
+        // log dir for this run" outcome, not a silent default.
+        let log_dir = std::env::var(ENV_LOG_DIR)
+            .ok()
+            .map(PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|h| h.join(".continuum").join("logs")));
         Self {
             probe_file,
             probe_classes,
             default_filter: default_filter.to_string(),
+            log_dir,
         }
     }
 }
+
+/// Env var name for the fmt-layer rolling-log directory. Operator
+/// override of the `~/.continuum/logs/` default. Set this in
+/// containerized environments where `$HOME` isn't the right place.
+pub const ENV_LOG_DIR: &str = "CONTINUUM_LOG_DIR";
 
 /// Result of the install — tells the caller whether disk capture is
 /// active so it can be logged at boot ("probes landing at
 /// /tmp/x.jsonl" is the kind of one-line confirmation that prevents
 /// the "I set the env var, where are my probes" confusion).
-#[derive(Debug)]
 pub struct ProbeInstall {
     /// Path the JSONL sink is writing to, if `CONTINUUM_PROBE_FILE`
     /// was set and the file opened successfully. `None` = no disk
     /// capture this run (env var unset, OR test path where a
     /// caller-provided subscriber is already installed).
     pub probe_log_path: Option<PathBuf>,
+    /// Directory the fmt-layer rolling-log writer is draining to,
+    /// when `config.log_dir` was supplied and writable. The substrate
+    /// writes `continuum-core-server.<date>.log` files there with
+    /// `Rotation::DAILY` + `max_log_files(7)` retention. `None` =
+    /// fmt layer fell back to stderr (test path with no managed log
+    /// dir). Use this to print a "logs landing at <path>" line at
+    /// boot.
+    pub log_dir: Option<PathBuf>,
+    /// `WorkerGuard` for the non-blocking rolling-log writer. Must
+    /// be held alive for the process lifetime — dropping it flushes
+    /// + shuts down the background writer thread, so the caller
+    /// (`main.rs`) stashes this in a `let _guard = ...;` binding at
+    /// process scope. Dropping early loses tail-of-process log
+    /// lines.
+    ///
+    /// `None` when fmt fell back to stderr (no rolling writer to
+    /// keep alive). Field deliberately not `Debug` — `WorkerGuard`
+    /// isn't Debug; the `ProbeInstall` derive is gone above.
+    pub fmt_writer_guard: Option<tracing_appender::non_blocking::WorkerGuard>,
 }
 
 /// Install the substrate's canonical tracing stack on the GLOBAL
@@ -174,39 +227,94 @@ pub fn install_probe_tracing(
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter));
 
-    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
-
-    // Build the optional file sink BEFORE the registry chain so we
-    // can either include it or skip it cleanly. None = no disk
-    // capture this run (caller didn't ask). Path supplied but
-    // unwritable = typed error surfaced to caller per
-    // `[[no-fallbacks-ever]]`.
-    let (file_sink, probe_log_path) = match config.probe_file {
-        Some(path) => {
-            let sink = JsonlProbeFileSink::new(&path, config.probe_classes)?;
-            (Some(sink), Some(path))
+    // Build the fmt-layer writer. When the operator supplied a
+    // log_dir (production path: `~/.continuum/logs/` from
+    // `ProbeTracingConfig::from_env`), drain through
+    // `tracing_appender::rolling::daily` + `non_blocking`. Rotation
+    // daily, retention 7 files — operator never has to clean up,
+    // disk usage stays bounded. The `WorkerGuard` MUST be held alive
+    // by the caller for the process lifetime; we hand it back in
+    // `ProbeInstall`.
+    //
+    // When log_dir is None (test path), fall back to stderr — the
+    // test harness already captures stderr through `cargo test`
+    // shape, no rolling-file needed.
+    //
+    // Per `[[never-redirect-substrate-stderr]]`: the stderr path
+    // exists ONLY for tests + explicit operator opt-out. Production
+    // boots should always have `log_dir = Some(...)` set so the
+    // substrate manages its own log persistence and any operator
+    // shell redirect captures an empty stream.
+    let (log_dir_out, fmt_writer_guard) = match config.log_dir.as_ref() {
+        Some(dir) => {
+            // Refuse to silently fall back if the configured dir
+            // can't be created. `[[no-fallbacks-ever]]`: surface a
+            // typed error so the operator gets the exact path that
+            // failed.
+            std::fs::create_dir_all(dir).map_err(|e| ProbeFileSinkError::OpenFailed {
+                path: dir.clone(),
+                source: e,
+            })?;
+            let file_appender = tracing_appender::rolling::Builder::new()
+                .rotation(tracing_appender::rolling::Rotation::DAILY)
+                .filename_prefix("continuum-core-server")
+                .filename_suffix("log")
+                .max_log_files(7)
+                .build(dir)
+                .map_err(|e| ProbeFileSinkError::OpenFailed {
+                    path: dir.clone(),
+                    // tracing_appender's InitError doesn't implement
+                    // io::Error directly; wrap its Display.
+                    source: std::io::Error::other(e.to_string()),
+                })?;
+            let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+            let fmt_layer = tracing_subscriber::fmt::layer().with_writer(non_blocking);
+            let probe_file_sink = build_probe_file_sink(&config.probe_file, config.probe_classes.clone())?;
+            let registry = tracing_subscriber::registry()
+                .with(UriCaptureLayer::new())
+                .with(ProbeRouterLayer::new())
+                .with(probe_file_sink)
+                .with(fmt_layer.with_filter(env_filter));
+            let _ = registry.try_init();
+            (Some(dir.clone()), Some(guard))
         }
-        None => (None, None),
+        None => {
+            let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+            let probe_file_sink = build_probe_file_sink(&config.probe_file, config.probe_classes.clone())?;
+            let registry = tracing_subscriber::registry()
+                .with(UriCaptureLayer::new())
+                .with(ProbeRouterLayer::new())
+                .with(probe_file_sink)
+                .with(fmt_layer.with_filter(env_filter));
+            let _ = registry.try_init();
+            (None, None)
+        }
     };
 
-    // Compose the registry. The fmt layer wraps the env-filter so
-    // RUST_LOG governs human-facing output; probe layers see EVERY
-    // event regardless of RUST_LOG (probes are structured records,
-    // not text logs — they're filtered by class via
-    // CONTINUUM_PROBE_CLASSES, not by tracing's level system).
-    let registry = tracing_subscriber::registry()
-        .with(UriCaptureLayer::new())
-        .with(ProbeRouterLayer::new())
-        .with(file_sink) // Option<JsonlProbeFileSink>: tracing's Layer impl handles None
-        .with(fmt_layer.with_filter(env_filter));
+    let probe_log_path = config.probe_file;
 
-    // try_init succeeds the first call, no-ops on subsequent calls.
-    // Errors here mean another subscriber was already installed —
-    // benign for repeated init from tests, so we drop the error
-    // intentionally to keep the helper idempotent.
-    let _ = registry.try_init();
+    Ok(ProbeInstall {
+        probe_log_path,
+        log_dir: log_dir_out,
+        fmt_writer_guard,
+    })
+}
 
-    Ok(ProbeInstall { probe_log_path })
+/// Shared helper — both fmt-writer branches need the same probe
+/// file sink built up. Pulled out so the registry-build sites stay
+/// readable and so a future test can swap the sink construction
+/// independently.
+fn build_probe_file_sink(
+    probe_file: &Option<PathBuf>,
+    probe_classes: HashSet<String>,
+) -> Result<Option<JsonlProbeFileSink>, ProbeFileSinkError> {
+    match probe_file.as_ref() {
+        Some(path) => {
+            let sink = JsonlProbeFileSink::new(path, probe_classes)?;
+            Ok(Some(sink))
+        }
+        None => Ok(None),
+    }
 }
 
 #[cfg(test)]
@@ -224,6 +332,7 @@ mod tests {
             probe_file: None,
             probe_classes: HashSet::new(),
             default_filter: "warn".to_string(),
+            log_dir: None,
         };
         let first = install_probe_tracing(config.clone());
         let second = install_probe_tracing(config);
@@ -250,13 +359,18 @@ mod tests {
             )),
             probe_classes: HashSet::new(),
             default_filter: "warn".to_string(),
+            log_dir: None,
         };
         let result = install_probe_tracing(config);
-        assert!(
-            matches!(result, Err(ProbeFileSinkError::OpenFailed { .. })),
-            "unwritable path must surface typed error, got {:?}",
-            result
-        );
+        // Can't `{:?}` the Ok branch — ProbeInstall holds a
+        // WorkerGuard which isn't Debug. Match the variant
+        // explicitly instead so the assertion error is still
+        // informative.
+        match &result {
+            Err(ProbeFileSinkError::OpenFailed { .. }) => {}
+            Err(other) => panic!("expected OpenFailed, got error {other:?}"),
+            Ok(_) => panic!("expected Err, got Ok(_)"),
+        }
     }
 
     /// The env-coupling seam. `from_env` is the ONE function that
@@ -293,6 +407,20 @@ mod tests {
         assert!(empty.probe_file.is_none());
         assert!(empty.probe_classes.is_empty());
         assert_eq!(empty.default_filter, "warn");
+        // log_dir defaults to `~/.continuum/logs/` when neither
+        // `CONTINUUM_LOG_DIR` nor `dirs::home_dir()` failure forces
+        // None. CI runners always have HOME; the only None case is
+        // truly homeless environments. Pin the default so future
+        // refactors can't silently move logs back to stderr-default.
+        let log_dir = empty
+            .log_dir
+            .as_deref()
+            .expect("CI/dev environments have HOME — default must resolve");
+        assert!(
+            log_dir.ends_with(std::path::PathBuf::from(".continuum/logs")),
+            "default log_dir should end with .continuum/logs, got {}",
+            log_dir.display()
+        );
 
         // Restore prior env state so other tests aren't affected
         // by ordering even if cargo's parallel runner interleaves.


### PR DESCRIPTION
## Summary

The substrate's tracing fmt layer wrote unbounded to stderr, which made `npm start > /tmp/server.log 2>&1` (and `nohup ... 2>&1`) the only operator option for capturing logs. At `RUST_LOG=info` under multi-persona load that grew gigabytes per hour into one file — twice now it has eaten the host's disk mid-session.

Per `[[never-redirect-substrate-stderr]]` doctrine: **the substrate owns its log persistence.** Shell redirects of substrate stderr are now forbidden because the substrate provides its own managed rolling-file sink.

## What changed

- `ProbeTracingConfig.log_dir: Option<PathBuf>` + `CONTINUUM_LOG_DIR` env override.
- `from_env` defaults to `~/.continuum/logs/` (resolves via `dirs::home_dir()`).
- `tracing_appender::rolling::Builder` — `Rotation::DAILY`, `max_log_files(7)`, `non_blocking` background writer.
- `ProbeInstall.fmt_writer_guard: Option<WorkerGuard>` returned to `main.rs` so the writer thread lives the process lifetime.
- Boot line: `[continuum-core-server] logs landing at <dir>/continuum-core-server.YYYY-MM-DD.log (rolling daily, retention 7)` — so operators don't reflexively reach for a shell redirect.
- Refuses to silently fall back if the configured dir can't be created — surfaces `ProbeFileSinkError::OpenFailed` per `[[no-fallbacks-ever]]`.
- `ProbeInstall` loses its `Debug` derive (`WorkerGuard` isn't `Debug`); the one test that `{:?}`-formatted it now matches the error variant explicitly.

## Why

Two host-disk-fill incidents this session were directly caused by operator stderr redirection of an unbounded `RUST_LOG=info` firehose. The substrate already has the probe macros + per-module logger + JSONL sink that Joel and I built together — the fmt layer was the last unbounded write path. This closes it.

Reference docs:
- `docs/architecture/OBSERVABILITY-AS-SUBSTRATE.md` — substrate owns load-bearing decision capture
- `docs/architecture/RTOS-DEBUGGER-PROBES.md` — probe macros are the substrate's RTOS-style breakpoints
- `[[never-redirect-substrate-stderr]]` — auto-memory doctrine added this session

## Test plan

- [x] `cargo test -p continuum-core --lib routing::tracing_init` — 3/3 green
  - `install_is_idempotent_with_no_disk_capture`
  - `install_surfaces_open_failed_for_unwritable_path`
  - `from_env_reads_documented_env_vars` (pins the `~/.continuum/logs` default)
- [x] `cargo check --features metal,accelerate -p continuum-core` — green
- [ ] Manual: `npm start` → confirm `logs landing at ...` boot line, confirm file appears under `~/.continuum/logs/`, confirm rotation via `CONTINUUM_LOG_DIR=/tmp/test-rolling`.
- [ ] Confirm `tail -f ~/.continuum/logs/continuum-core-server.*.log` shows live stream.

Closes #211.
