### PR TITLE
fix(ci): replace Docker-based pr-size-labeler with pure-JS github-script

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -26,18 +26,64 @@ jobs:
         sync-labels: true
       continue-on-error: true  # Don't fail the workflow if labeling fails
 
+    # Size labeling is done inline via the GitHub API instead of a
+    # Docker-based action. The previous `codelytv/pr-size-labeler@v1`
+    # built a Docker image from `alpine:3.15` at every workflow run,
+    # which failed whenever Docker Hub rate-limited the anonymous pull
+    # — and `continue-on-error` on the step doesn't catch failures in
+    # GitHub Actions' Docker-image setup phase, so the whole job went
+    # red on transient Docker Hub blips. Pure-JS via actions/github-script
+    # has no external image dependency.
     - name: Add size label
-      uses: codelytv/pr-size-labeler@v1
+      uses: actions/github-script@v7
       with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        xs_label: 'size: XS'
-        xs_max_size: 10
-        s_label: 'size: S'
-        s_max_size: 50
-        m_label: 'size: M'
-        m_max_size: 250
-        l_label: 'size: L'
-        l_max_size: 500
-        xl_label: 'size: XL'
-        fail_if_xl: false
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          // Size thresholds match the previous codelytv config so existing
+          // labels stay meaningful across the cutover.
+          const THRESHOLDS = [
+            { label: 'size: XS', max: 10 },
+            { label: 'size: S',  max: 50 },
+            { label: 'size: M',  max: 250 },
+            { label: 'size: L',  max: 500 },
+            { label: 'size: XL', max: Infinity },
+          ];
+
+          const { owner, repo } = context.repo;
+          const pr = context.payload.pull_request;
+          if (!pr) {
+            core.info('No pull_request payload — skipping size label.');
+            return;
+          }
+
+          // additions + deletions is what codelytv used; matches the
+          // historical category meaning so a "size: M" today is the same
+          // shape as a "size: M" from last week.
+          const totalChanges = (pr.additions || 0) + (pr.deletions || 0);
+          const chosen = THRESHOLDS.find(t => totalChanges <= t.max).label;
+          core.info(`PR #${pr.number}: ${totalChanges} changes → ${chosen}`);
+
+          // Sync semantics: remove other size labels first, then add the
+          // chosen one. Avoids stale labels lingering on PRs that grow.
+          const sizeLabels = THRESHOLDS.map(t => t.label);
+          const current = (pr.labels || []).map(l => l.name);
+          const toRemove = current.filter(n => sizeLabels.includes(n) && n !== chosen);
+
+          for (const name of toRemove) {
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: pr.number, name,
+              });
+            } catch (e) {
+              // 404 just means the label was already gone (race with
+              // another labeler) — harmless, don't poison the run.
+              if (e.status !== 404) throw e;
+            }
+          }
+
+          if (!current.includes(chosen)) {
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: pr.number, labels: [chosen],
+            });
+          }
       continue-on-error: true  # Don't fail the workflow if labeling fails


### PR DESCRIPTION
## Summary

Replace the Docker-based `codelytv/pr-size-labeler@v1` with a pure-JS `actions/github-script@v7` step. Same thresholds (XS≤10, S≤50, M≤250, L≤500, XL anything larger), same labels, same sync semantics — no Docker.

## Why

`codelytv/pr-size-labeler@v1` builds an `alpine:3.15` image from Docker Hub at every workflow invocation. When Docker Hub rate-limits or its registry times out (regular occurrence), the action fails during image build **before** the `with:` inputs are even processed, so `continue-on-error: true` on the step doesn't contain the failure — the whole `label-pr` job goes red.

PR #1547 hit this earlier today:

```
failed to resolve source metadata for docker.io/library/alpine:3.15:
failed to do request: Head "https://registry-1.docker.io/v2/library/alpine/manifests/3.15":
dial tcp 54.158.241.65:443: i/o timeout
```

Red `label-pr` checks across the PR list are an active reliability lie — they look like real failures and mask the green substantive checks (`validate`, etc).

## What changed

- `.github/workflows/pr-labeler.yml`:
  - `Add size label` step now uses `actions/github-script@v7` instead of `codelytv/pr-size-labeler@v1`.
  - Inline script reads `additions + deletions` from the PR payload, picks the size category against the same thresholds (preserves historical label meaning across the cutover), removes stale size labels, applies the chosen one via `github.rest.issues.{addLabels,removeLabel}`.
  - `continue-on-error: true` retained as defense in depth — if the GH API itself flakes, the labeler still doesn't poison the PR view.

## Test plan

- [ ] On the first PR merged after this lands, confirm `label-pr` passes and the correct `size: M` (or whichever) label appears.
- [ ] Confirm stale `size:` labels are removed when a PR grows from `size: S` → `size: M`.
- [x] YAML lints clean (no schema changes — just inline script body).
