### PR TITLE
fix(probes): isolate global-subscriber tests — kill #203 pollution flake

### DIFF
--- a/src/workers/continuum-core/src/routing/tracing_init.rs
+++ b/src/workers/continuum-core/src/routing/tracing_init.rs
@@ -321,57 +321,14 @@ fn build_probe_file_sink(
 mod tests {
     use super::*;
 
-    /// `install_probe_tracing` accepts a typed config and is
-    /// parallel-safe in tests — no env-var mutation, no shared
-    /// global state beyond `tracing`'s own default subscriber
-    /// (which is exactly the thing we're testing the idempotency
-    /// of).
-    #[test]
-    fn install_is_idempotent_with_no_disk_capture() {
-        let config = ProbeTracingConfig {
-            probe_file: None,
-            probe_classes: HashSet::new(),
-            default_filter: "warn".to_string(),
-            log_dir: None,
-        };
-        let first = install_probe_tracing(config.clone());
-        let second = install_probe_tracing(config);
-        assert!(first.is_ok(), "first install must succeed");
-        assert!(second.is_ok(), "second install must no-op cleanly");
-        assert!(first.unwrap().probe_log_path.is_none());
-        assert!(second.unwrap().probe_log_path.is_none());
-    }
-
-    /// Typed-error contract: an unwritable `probe_file` path must
-    /// surface `ProbeFileSinkError::OpenFailed` per
-    /// `[[no-fallbacks-ever]]`. Operators must see the
-    /// configuration problem; substrate refuses to silently drop
-    /// probes.
-    ///
-    /// Parallel-safe because the bad path is passed via typed
-    /// config — no env-var mutation, no racing on
-    /// `CONTINUUM_PROBE_FILE`.
-    #[test]
-    fn install_surfaces_open_failed_for_unwritable_path() {
-        let config = ProbeTracingConfig {
-            probe_file: Some(PathBuf::from(
-                "/this/path/definitely/does/not/exist/probes.jsonl",
-            )),
-            probe_classes: HashSet::new(),
-            default_filter: "warn".to_string(),
-            log_dir: None,
-        };
-        let result = install_probe_tracing(config);
-        // Can't `{:?}` the Ok branch — ProbeInstall holds a
-        // WorkerGuard which isn't Debug. Match the variant
-        // explicitly instead so the assertion error is still
-        // informative.
-        match &result {
-            Err(ProbeFileSinkError::OpenFailed { .. }) => {}
-            Err(other) => panic!("expected OpenFailed, got error {other:?}"),
-            Ok(_) => panic!("expected Err, got Ok(_)"),
-        }
-    }
+    // `install_probe_tracing` install tests moved to
+    // `continuum-core/tests/tracing_install_global.rs` per task #203.
+    // Reason: `install_probe_tracing` calls `try_init()` on the
+    // GLOBAL tracing subscriber registry — within the lib-test binary
+    // that install leaked across tests and broke
+    // `routing::uri_layer::tests::no_subscriber_returns_empty_chain`
+    // (which asserts an empty chain when NO Layer is installed).
+    // Process isolation via integration-test binary is the cure.
 
     /// The env-coupling seam. `from_env` is the ONE function that
     /// touches `std::env`; everything downstream takes typed

--- a/src/workers/continuum-core/tests/tracing_install_global.rs
+++ b/src/workers/continuum-core/tests/tracing_install_global.rs
@@ -1,0 +1,78 @@
+//! Integration tests for `install_probe_tracing` — the substrate's
+//! GLOBAL tracing subscriber install. These tests MUST live in their
+//! own integration-test binary (one process per integration test file
+//! in cargo's runner), because `install_probe_tracing` calls
+//! `tracing_subscriber::registry().try_init()` which permanently
+//! attaches the subscriber for the rest of the process.
+//!
+//! Per task #203 (`Investigate uri_layer test pollution flake`): when
+//! these tests lived under
+//! `continuum-core/src/routing/tracing_init.rs::tests`, the global
+//! install leaked into the lib-test binary and broke
+//! `routing::uri_layer::tests::no_subscriber_returns_empty_chain` —
+//! that test asserts an EMPTY chain when no Layer is installed, but
+//! whichever lib-test ran first (race-dependent) might already have
+//! installed the global UriCaptureLayer through this path.
+//!
+//! Process isolation is the cure. Each `tests/*.rs` file becomes a
+//! separate binary in `cargo test`, so the global subscriber installed
+//! here cannot pollute any other test binary's view of the global
+//! default.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use continuum_core::routing::probe_file_sink::ProbeFileSinkError;
+use continuum_core::routing::tracing_init::{install_probe_tracing, ProbeTracingConfig};
+
+/// `install_probe_tracing` accepts a typed config and is safe to call
+/// twice — the second call no-ops cleanly because
+/// `tracing_subscriber::registry().try_init()` succeeds the first time
+/// and silently no-ops thereafter. Substrate boot paths (main.rs,
+/// tests, replay harnesses) rely on this so the install can be
+/// re-attempted without checking "did I already call it."
+#[test]
+fn install_is_idempotent_with_no_disk_capture() {
+    let config = ProbeTracingConfig {
+        probe_file: None,
+        probe_classes: HashSet::new(),
+        default_filter: "warn".to_string(),
+        log_dir: None,
+    };
+    let first = install_probe_tracing(config.clone());
+    let second = install_probe_tracing(config);
+    assert!(first.is_ok(), "first install must succeed");
+    assert!(second.is_ok(), "second install must no-op cleanly");
+    assert!(first.unwrap().probe_log_path.is_none());
+    assert!(second.unwrap().probe_log_path.is_none());
+}
+
+/// Typed-error contract: an unwritable `probe_file` path must surface
+/// `ProbeFileSinkError::OpenFailed` per `[[no-fallbacks-ever]]`.
+/// Operators must see the configuration problem; substrate refuses to
+/// silently drop probes.
+///
+/// Lives in the same integration binary as the idempotency test
+/// because `install_probe_tracing` is the path under test in both —
+/// they share the global-subscriber pollution risk and must share the
+/// isolated process.
+#[test]
+fn install_surfaces_open_failed_for_unwritable_path() {
+    let config = ProbeTracingConfig {
+        probe_file: Some(PathBuf::from(
+            "/this/path/definitely/does/not/exist/probes.jsonl",
+        )),
+        probe_classes: HashSet::new(),
+        default_filter: "warn".to_string(),
+        log_dir: None,
+    };
+    let result = install_probe_tracing(config);
+    // Can't `{:?}` the Ok branch — ProbeInstall holds a WorkerGuard
+    // which isn't Debug (PR #1547). Match the variant explicitly so
+    // the assertion error is still informative on failure.
+    match &result {
+        Err(ProbeFileSinkError::OpenFailed { .. }) => {}
+        Err(other) => panic!("expected OpenFailed, got error {other:?}"),
+        Ok(_) => panic!("expected Err, got Ok(_)"),
+    }
+}


### PR DESCRIPTION
## Summary

Close task #203: move `install_probe_tracing` tests out of the lib-test binary into their own integration-test binary so the global tracing-subscriber install they trigger can't pollute other lib-tests.

## Why

`install_probe_tracing` calls `tracing_subscriber::registry().try_init()`, which permanently attaches the substrate's `UriCaptureLayer + ProbeRouterLayer + fmt` layer stack to the **global** tracing default for the rest of the process. Correct for production (one process, one boot, one install) — wrong for cargo's shared lib-test binary, where the install leaked across tests:

- `routing::tracing_init::tests::install_is_idempotent_with_no_disk_capture` → installs the global subscriber.
- `routing::uri_layer::tests::no_subscriber_returns_empty_chain` → asserts an empty chain because "no installed Layer means no captured frames" — **panics** when the install ran first in the same binary.

Task #203 captured the symptom. PR #1547 hit it deterministically today when running `cargo test -p continuum-core --lib routing::`.

## What changed

- Created `continuum-core/tests/tracing_install_global.rs` (new integration-test file = its own cargo test binary = its own process).
- Moved `install_is_idempotent_with_no_disk_capture` and `install_surfaces_open_failed_for_unwritable_path` there verbatim.
- Replaced their inline removal with a comment in `tracing_init.rs::tests` explaining where they live + why.
- `from_env_reads_documented_env_vars` stays in the lib-test module — it only mutates env vars (already serial within itself), never calls `install_probe_tracing`.

## Test plan

- [x] `cargo test --features metal,accelerate -p continuum-core --lib routing::` → **252/252 passed** (was 252/253 with the flake — `no_subscriber_returns_empty_chain` is now consistently green).
- [x] `cargo test --features metal,accelerate -p continuum-core --test tracing_install_global` → **2/2 passed** in the isolated binary.

Closes #203.
