### PR TITLE
feat(boot): adapter selection reports via boot_status (e9f50a36 A4)

### DIFF
--- a/src/workers/continuum-core/src/modules/ai_provider.rs
+++ b/src/workers/continuum-core/src/modules/ai_provider.rs
@@ -184,6 +184,63 @@ impl AIProviderModule {
 ///
 /// Hoisted out of both `ai/generate` and the convenience `generate_text` so
 /// the two paths report the same diagnosis.
+/// Pure projection of the AdapterRegistry's `available()` set → a
+/// boot-status `(kind, detail)` pair. Card e9f50a36 slice A4.
+///
+/// Mapping:
+/// - **Empty** → `Failed`, `"no inference adapter registered — add API keys to ~/.continuum/config.env or pull a local GGUF"`.
+///   The substrate has zero inference capability; persona cognition
+///   on `FullCitizen` / `FailFast` will refuse to boot downstream.
+/// - **No local llamacpp-* providers** → `Degraded`, `"cloud only:
+///   <names> (no local fallback if cloud is unreachable)"`. The
+///   substrate runs but has no offline path — a single network
+///   outage takes down inference. Operator wants to know.
+/// - **At least one local provider** → `Ok`, `"<names> (N
+///   providers)"`. Mixed cloud + local OR local-only both land
+///   here; the substrate has at least one offline fallback.
+///
+/// The kind ordering matches the rest of the slice A boot lines:
+/// Failed >Degraded > Ok per `BootStatusKind`'s total ordering, so a
+/// sentinel computing "worst kind across boot" with `.max()` reports
+/// the right verdict.
+fn render_adapter_boot_status(
+    available: &[&str],
+) -> (
+    crate::runtime::boot_status::BootStatusKind,
+    String,
+) {
+    use crate::runtime::boot_status::BootStatusKind;
+    if available.is_empty() {
+        return (
+            BootStatusKind::Failed,
+            "no inference adapter registered — add API keys to \
+             ~/.continuum/config.env or pull a local GGUF"
+                .to_string(),
+        );
+    }
+    // The llamacpp-local provider is registered once per GGUF on
+    // disk; it's the offline path. If NONE of the registered
+    // providers start with `llamacpp-`, the substrate has cloud-only
+    // inference — degraded, even though it's "working" right now.
+    let has_local = available
+        .iter()
+        .any(|name| name.starts_with("llamacpp-") || *name == "llamacpp-local");
+    let names_joined = available.join(", ");
+    if has_local {
+        (
+            BootStatusKind::Ok,
+            format!("{names_joined} ({} providers)", available.len()),
+        )
+    } else {
+        (
+            BootStatusKind::Degraded,
+            format!(
+                "cloud only: {names_joined} (no local fallback if cloud unreachable)"
+            ),
+        )
+    }
+}
+
 fn select_failure_message(
     registry: &AdapterRegistry,
     requested_provider: Option<&str>,
@@ -584,6 +641,15 @@ impl AIProviderModule {
             self.log()
                 .warn("No providers available! Add API keys to ~/.continuum/config.env");
         }
+
+        // Boot status report (card e9f50a36 slice A4): a single line
+        // naming the registered adapters so the operator sees what
+        // inference capabilities the substrate actually has, not
+        // what *should* be available. Empty = Failed (no inference
+        // possible). All cloud + no local = Degraded (no offline
+        // path). Mixed or local-only = Ok.
+        let (kind, detail) = render_adapter_boot_status(&available);
+        crate::runtime::boot_status::boot_status("adapter", kind, &detail);
 
         Ok(())
     }
@@ -1119,4 +1185,75 @@ pub async fn generate_text(
     });
 
     Ok(response)
+}
+
+#[cfg(test)]
+mod boot_status_tests {
+    use super::*;
+    use crate::runtime::boot_status::BootStatusKind;
+
+    /// Empty registry = no inference at all. The substrate has
+    /// nothing to route to. Operator action lives in the detail.
+    #[test]
+    fn empty_registry_reports_failed_with_remediation() {
+        let (kind, detail) = render_adapter_boot_status(&[]);
+        assert_eq!(kind, BootStatusKind::Failed);
+        assert!(
+            detail.contains("config.env") && detail.contains("GGUF"),
+            "detail must name both remediation paths: {detail:?}"
+        );
+    }
+
+    /// Cloud-only (no `llamacpp-*` provider registered) = `Degraded`.
+    /// The substrate is "working" but a single network blip kills
+    /// inference for every persona. Operator wants to know.
+    #[test]
+    fn cloud_only_reports_degraded_with_no_local_fallback_note() {
+        let providers = ["anthropic", "openai", "groq"];
+        let (kind, detail) = render_adapter_boot_status(&providers);
+        assert_eq!(kind, BootStatusKind::Degraded);
+        assert!(
+            detail.contains("cloud only"),
+            "detail must say cloud-only: {detail:?}"
+        );
+        assert!(
+            detail.contains("no local fallback"),
+            "detail must call out the missing fallback: {detail:?}"
+        );
+    }
+
+    /// At least one llamacpp-* provider registered = `Ok`. The
+    /// substrate has offline inference even if the WAN goes down.
+    /// The detail names the providers so the operator can verify
+    /// which forge model is loaded without poking the registry.
+    #[test]
+    fn local_present_reports_ok() {
+        let providers = ["anthropic", "llamacpp-qwen3-coder", "openai"];
+        let (kind, detail) = render_adapter_boot_status(&providers);
+        assert_eq!(kind, BootStatusKind::Ok);
+        assert!(
+            detail.contains("llamacpp-qwen3-coder"),
+            "detail must name the local provider so the operator \
+             can spot wrong-model-loaded at a glance: {detail:?}"
+        );
+        assert!(
+            detail.contains("3 providers"),
+            "detail must include count for quick visual scan: {detail:?}"
+        );
+    }
+
+    /// Local-only also reports Ok — a host with no API keys but
+    /// a local GGUF is the "M1 32GB offline" doctrine case Joel's
+    /// canonical workflow targets.
+    #[test]
+    fn local_only_reports_ok_without_cloud_warning() {
+        let providers = ["llamacpp-qwen3-coder"];
+        let (kind, detail) = render_adapter_boot_status(&providers);
+        assert_eq!(kind, BootStatusKind::Ok);
+        assert!(
+            !detail.contains("cloud"),
+            "local-only must not mention cloud in the detail (no \
+             warning to surface): {detail:?}"
+        );
+    }
 }

--- a/src/workers/continuum-core/src/modules/ai_provider.rs
+++ b/src/workers/continuum-core/src/modules/ai_provider.rs
@@ -182,33 +182,65 @@ impl AIProviderModule {
 ///   - "asked for local but DMR is down" (Docker Desktop needs to be running)
 ///   - "asked for a specific provider/model that isn't here" (existing message)
 ///
-/// Hoisted out of both `ai/generate` and the convenience `generate_text` so
-/// the two paths report the same diagnosis.
+/// The set of provider ids that count as "offline / network-
+/// independent" for the boot-status `adapter:` line. A host with
+/// any of these registered has an inference path that survives a
+/// WAN outage and is reported as `Ok` regardless of which cloud
+/// providers also registered.
+///
+/// Sourced from the substrate's actual provider-id constants — NOT
+/// a hand-rolled prefix match — so a rename in `LLAMACPP_PROVIDER_ID`
+/// or a future `LOCAL_*` constant lands the boot-status check
+/// automatically. PR #1553 round 1 reviewer caught two failure
+/// modes the prefix shape produced:
+///
+/// 1. `"docker-model-runner"` (DMR) didn't start with `llamacpp-`,
+///    so a host running DMR-only got `Degraded: "cloud only ..."` —
+///    factually false. DMR runs against localhost:12434, network-
+///    independent.
+/// 2. The `register_adapters` flow uses the single
+///    `LLAMACPP_PROVIDER_ID = "llamacpp-local"` constant — there is
+///    no per-model `"llamacpp-qwen3-coder"` registered name. The
+///    prefix matched anyway by coincidence; the prior tests pinned
+///    a string shape that production never produces.
+///
+/// Identifier strings, not a trait check on `dyn AIProviderAdapter`,
+/// because the registry's `available()` returns `Vec<&str>` of
+/// provider ids — the trait isn't reachable from the helper without
+/// holding the registry lock. The trait-method refactor
+/// (`AIProviderAdapter::is_offline_path()`) is a follow-up.
+const OFFLINE_PROVIDER_IDS: &[&str] = &[
+    crate::inference::LLAMACPP_PROVIDER_ID,
+    // DMR registers under "docker-model-runner". Localhost via
+    // Docker Desktop's model runner socket — survives a WAN
+    // outage as long as Docker Desktop is running.
+    "docker-model-runner",
+];
+
 /// Pure projection of the AdapterRegistry's `available()` set → a
 /// boot-status `(kind, detail)` pair. Card e9f50a36 slice A4.
 ///
 /// Mapping:
-/// - **Empty** → `Failed`, `"no inference adapter registered — add API keys to ~/.continuum/config.env or pull a local GGUF"`.
-///   The substrate has zero inference capability; persona cognition
-///   on `FullCitizen` / `FailFast` will refuse to boot downstream.
-/// - **No local llamacpp-* providers** → `Degraded`, `"cloud only:
-///   <names> (no local fallback if cloud is unreachable)"`. The
+/// - **Empty** → `Failed`. The substrate has zero inference
+///   capability; persona cognition on `FullCitizen` / `FailFast`
+///   will refuse to boot downstream.
+/// - **No offline provider registered** → `Degraded`, `"cloud only:
+///   <names> (no local fallback if cloud unreachable)"`. The
 ///   substrate runs but has no offline path — a single network
 ///   outage takes down inference. Operator wants to know.
-/// - **At least one local provider** → `Ok`, `"<names> (N
-///   providers)"`. Mixed cloud + local OR local-only both land
-///   here; the substrate has at least one offline fallback.
+/// - **At least one offline provider** (`llamacpp-local`,
+///   `docker-model-runner`, etc — see [`OFFLINE_PROVIDER_IDS`]) →
+///   `Ok`, `"<names> (N providers)"`. Mixed cloud + offline OR
+///   offline-only both land here; substrate has at least one path
+///   that survives WAN loss.
 ///
 /// The kind ordering matches the rest of the slice A boot lines:
-/// Failed >Degraded > Ok per `BootStatusKind`'s total ordering, so a
-/// sentinel computing "worst kind across boot" with `.max()` reports
-/// the right verdict.
+/// `Ok < Degraded < Failed` per `BootStatusKind`'s derived `Ord`,
+/// so a sentinel computing "worst kind across boot" with `.max()`
+/// reports the right verdict.
 fn render_adapter_boot_status(
     available: &[&str],
-) -> (
-    crate::runtime::boot_status::BootStatusKind,
-    String,
-) {
+) -> (crate::runtime::boot_status::BootStatusKind, String) {
     use crate::runtime::boot_status::BootStatusKind;
     if available.is_empty() {
         return (
@@ -218,15 +250,11 @@ fn render_adapter_boot_status(
                 .to_string(),
         );
     }
-    // The llamacpp-local provider is registered once per GGUF on
-    // disk; it's the offline path. If NONE of the registered
-    // providers start with `llamacpp-`, the substrate has cloud-only
-    // inference — degraded, even though it's "working" right now.
-    let has_local = available
+    let has_offline = available
         .iter()
-        .any(|name| name.starts_with("llamacpp-") || *name == "llamacpp-local");
+        .any(|name| OFFLINE_PROVIDER_IDS.contains(name));
     let names_joined = available.join(", ");
-    if has_local {
+    if has_offline {
         (
             BootStatusKind::Ok,
             format!("{names_joined} ({} providers)", available.len()),
@@ -234,9 +262,7 @@ fn render_adapter_boot_status(
     } else {
         (
             BootStatusKind::Degraded,
-            format!(
-                "cloud only: {names_joined} (no local fallback if cloud unreachable)"
-            ),
+            format!("cloud only: {names_joined} (no local fallback if cloud unreachable)"),
         )
     }
 }
@@ -1204,7 +1230,7 @@ mod boot_status_tests {
         );
     }
 
-    /// Cloud-only (no `llamacpp-*` provider registered) = `Degraded`.
+    /// Cloud-only (no offline provider registered) = `Degraded`.
     /// The substrate is "working" but a single network blip kills
     /// inference for every persona. Operator wants to know.
     #[test]
@@ -1222,17 +1248,25 @@ mod boot_status_tests {
         );
     }
 
-    /// At least one llamacpp-* provider registered = `Ok`. The
-    /// substrate has offline inference even if the WAN goes down.
-    /// The detail names the providers so the operator can verify
-    /// which forge model is loaded without poking the registry.
+    /// `LLAMACPP_PROVIDER_ID` registered = `Ok`. PR #1553 round 1
+    /// reviewer caught the prior test using a fictitious
+    /// `"llamacpp-qwen3-coder"` id that production never emits —
+    /// `register_adapters` uses the single `LLAMACPP_PROVIDER_ID`
+    /// constant ("llamacpp-local") and multiplexes models within
+    /// the adapter. Pinning the actual constant here protects
+    /// against a future rename silently changing the boot-status
+    /// classification.
     #[test]
-    fn local_present_reports_ok() {
-        let providers = ["anthropic", "llamacpp-qwen3-coder", "openai"];
+    fn llamacpp_local_reports_ok() {
+        let providers = [
+            "anthropic",
+            crate::inference::LLAMACPP_PROVIDER_ID,
+            "openai",
+        ];
         let (kind, detail) = render_adapter_boot_status(&providers);
         assert_eq!(kind, BootStatusKind::Ok);
         assert!(
-            detail.contains("llamacpp-qwen3-coder"),
+            detail.contains(crate::inference::LLAMACPP_PROVIDER_ID),
             "detail must name the local provider so the operator \
              can spot wrong-model-loaded at a glance: {detail:?}"
         );
@@ -1242,12 +1276,40 @@ mod boot_status_tests {
         );
     }
 
+    /// PR #1553 round 1 reviewer's primary BLOCK: DMR is
+    /// network-independent (runs against `localhost:12434` via
+    /// Docker Desktop's model runner socket). The prior prefix
+    /// match shape misclassified a DMR-only host as `Degraded:
+    /// "cloud only ..."` — a load-bearing observability lie. With
+    /// the `OFFLINE_PROVIDER_IDS` set this case correctly reports
+    /// `Ok`.
+    ///
+    /// Pins the exact production registration id from
+    /// `model_registry/catalog.rs:471` so a future provider-id
+    /// drift fails this test instead of silently misclassifying.
+    #[test]
+    fn dmr_only_reports_ok_not_cloud_only() {
+        let providers = ["docker-model-runner"];
+        let (kind, detail) = render_adapter_boot_status(&providers);
+        assert_eq!(
+            kind,
+            BootStatusKind::Ok,
+            "DMR is localhost-only (network-independent) and must \
+             classify as an offline provider, not as a cloud lie. \
+             Got {kind:?} for detail {detail:?}"
+        );
+        assert!(
+            !detail.contains("cloud"),
+            "DMR-only must not surface a cloud-fallback warning: {detail:?}"
+        );
+    }
+
     /// Local-only also reports Ok — a host with no API keys but
     /// a local GGUF is the "M1 32GB offline" doctrine case Joel's
     /// canonical workflow targets.
     #[test]
     fn local_only_reports_ok_without_cloud_warning() {
-        let providers = ["llamacpp-qwen3-coder"];
+        let providers = [crate::inference::LLAMACPP_PROVIDER_ID];
         let (kind, detail) = render_adapter_boot_status(&providers);
         assert_eq!(kind, BootStatusKind::Ok);
         assert!(


### PR DESCRIPTION
## Summary

Card `e9f50a36` slice A4. **Stacked on #1552 → #1551 → #1550.**

After `AIProviderModule::register_adapters` walks every cloud API key + every local llamacpp-* GGUF, it now emits a single `boot_status("adapter", ...)` line so the operator sees what inference capabilities the substrate **actually** has — not what *should* be available given the keys / models it thinks it configured.

## What an operator sees

```text
# Empty: substrate has zero inference path
[continuum-core-server] adapter: ✗ no inference adapter registered — add API keys to ~/.continuum/config.env or pull a local GGUF

# Cloud only: substrate works but one network blip kills inference
[continuum-core-server] adapter: ⚠ cloud only: anthropic, openai, groq (no local fallback if cloud unreachable)

# At least one local: offline path exists, mixed or local-only both Ok
[continuum-core-server] adapter: ✓ anthropic, llamacpp-qwen3-coder, openai (3 providers)
```

## Why Degraded for cloud-only

Today's substrate works "fine" in cloud-only mode — until it doesn't. A single DNS hiccup, an expired API key, or a provider outage takes down inference for every persona at once. The substrate KNOWS this is a fragile state at boot time (it walked the registry, it sees no `llamacpp-*` provider). Surfacing it as `⚠` instead of `✓` is the kind of honest reporting the e9f50a36 slice is for — the operator can decide whether to pull a GGUF or accept the risk, but they shouldn't have to guess the state from secondary symptoms two weeks later when the WAN goes down.

## What changed

- `crates/continuum-core/src/modules/ai_provider.rs`:
  - New pure helper `render_adapter_boot_status(available: &[&str]) -> (BootStatusKind, String)`. Empty → Failed. No `llamacpp-*` → Degraded. At least one local → Ok. The string `"llamacpp-"` prefix is the marker — matches `register_adapters`'s `LLAMACPP_PROVIDER_ID`-driven registration loop.
  - Single `boot_status("adapter", kind, detail)` call at the end of `register_adapters`, right after the existing "AIProviderModule initialized with N providers" log.
- 4 unit tests pin the rendering for each case + the operator-facing detail strings.

## Test plan

- [x] `cargo test -p continuum-core --lib modules::ai_provider::boot_status_tests` — 4/4 green.
- [x] `cargo build -p continuum-core` clean.

## Composition

Depends on #1552 → #1551 → #1550. Merge order: #1550 → #1551 → #1552 → #1553.

After this slice the operator's boot view is:

```text
[continuum-core-server] probes: ✓ landing at /tmp/probes.jsonl
[continuum-core-server] logs: ✓ /Users/joel/.continuum/logs/...log (rolling daily, retention 7)
[continuum-core-server] boot-mode: ✓ full-citizen (...)
[continuum-core-server] airc: ✓ socket=/Users/joel/.airc/runtime/airc.sock peer=12345678 room=general
[continuum-core-server] adapter: ✓ anthropic, llamacpp-qwen3-coder, openai (3 providers)
[continuum-core-server] persona-home: ⚠ migrated Paige: …   ← only after legacy layout detected
```

Last remaining e9f50a36 slice: `model` (GGUF availability with exact download URL on miss).
