### PR TITLE
feat(apps/cli): first rust binary on new layout — `ctm metrics` end-to-end (task #143 slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -391,6 +406,15 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -2421,6 +2445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -2429,9 +2454,22 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2619,13 +2657,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "continuum-cli"
+version = "0.1.0"
+dependencies = [
+ "airc-lib",
+ "anyhow",
+ "clap",
+ "continuum-client",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "continuum-client"
 version = "0.1.0"
 dependencies = [
  "airc-core",
  "airc-lib",
- "airc-protocol",
- "airc-test-fixtures",
  "async-trait",
  "continuum-airc-protocol",
  "futures",
@@ -2645,6 +2696,7 @@ dependencies = [
  "airc-ipc",
  "airc-lib",
  "airc-protocol",
+ "airc-test-fixtures",
  "arc-swap",
  "async-trait",
  "axum",
@@ -2656,6 +2708,7 @@ dependencies = [
  "chrono",
  "continuum-airc-protocol",
  "continuum-bridge-protocol",
+ "continuum-client",
  "continuum-orm-derive",
  "crossbeam-channel",
  "csv",
@@ -3667,7 +3720,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "env_filter",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ members = [
 
     # client/ — shared client lib (consumed by CLI + mobile SDK FFI)
     "client/continuum-client",
+
+    # apps/ — first-party UI shells / embodiments
+    "apps/cli",
 ]
 # Shared dependencies - workers inherit these versions
 [workspace.dependencies]

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "continuum-cli"
+version = "0.1.0"
+edition = "2021"
+description = "continuum command-line client. Links continuum-client directly (no Node, no IPC daemon middleware) — every command goes through the same Connection/CommandClient seam the substrate's integration tests exercise. Successor to src/jtag (per task #143)."
+
+[[bin]]
+# Short, memorable command name. The shell shim that lands on $PATH can
+# alias `jtag` → `ctm` for backward muscle-memory.
+name = "ctm"
+path = "src/main.rs"
+
+[dependencies]
+# The shared client lib — this is the whole point.
+continuum-client = { path = "../../client/continuum-client" }
+
+# Airc handle for substrate addressing.
+airc-lib = { workspace = true }
+
+# Argument parsing.
+clap = { version = "4", features = ["derive", "env"] }
+
+# Runtime + JSON + IDs + error handling.
+tokio = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+anyhow = "1"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,19 +1,88 @@
-# apps/cli — rust CLI binary (placeholder)
+# apps/cli — `ctm` rust CLI binary
 
-**Status:** empty slot. Tracked by task #143 (rewrite `src/jtag` + `src/cli.ts` as rust binary).
+Successor to `./jtag` (per task #143). Links `client/continuum-client`
+directly — every command goes through the same `Connection` /
+`CommandClient` seam the substrate's integration tests exercise. No
+Node middleware, no JTAG-daemon IPC dance.
 
-## Intent
+## Status
 
-Replace the current Node-based `./jtag` CLI with a single rust binary that
-links `client/continuum-client` directly (no IPC over an extra Node process).
+First slice landed. One subcommand (`metrics`) wired end-to-end through
+the substrate. Each future subcommand is a small slice that migrates a
+`./jtag <command>` to a `ctm <command>` call. As subcommands land, the
+Node `./jtag` shrinks; eventually only its install footprint is left.
 
-When this lands:
-- `apps/cli/Cargo.toml` adds itself to the workspace.
-- `apps/cli/src/main.rs` parses args (clap), constructs `Connection::connect(airc, peer_uuid)`,
-  routes to typed `CommandClient::execute` calls.
-- Per-command argument parsing reuses the same `CommandRequest`/`CommandResponse`
-  shapes as the substrate (no manual deserialization).
-- Drop-in replacement for `./jtag` at the shell level; `tools/scripts/start-server.sh`
-  invokes the new binary in place of the current `tsx cli.ts`.
+## Install
 
-Until then: use the Node CLI in `src/jtag/`.
+The binary builds out of the Cargo workspace at repo root:
+
+```bash
+export CARGO_TARGET_DIR="$HOME/.continuum/cache/cargo-target"
+cargo build -p continuum-cli --release
+# Binary lands at $CARGO_TARGET_DIR/release/ctm
+```
+
+A future slice adds a `cargo install --path apps/cli` flow + a shell
+shim so `jtag` aliases `ctm`.
+
+## Usage
+
+```bash
+# Required: substrate peer UUID. Find it on the substrate host:
+#   airc status   # peer_id: …
+# Set once via env, or pass --peer every call.
+export CONTINUUM_PEER_ID=9bb24964-1a1a-43e2-a5aa-8140362bab63
+
+ctm metrics                      # fetch runtime/metrics/all
+ctm metrics --peer <UUID>        # override env
+ctm --home ~/.airc-alt metrics   # override default $HOME/.airc
+
+# Tracing:
+CONTINUUM_CLI_LOG=debug ctm metrics
+```
+
+## Commands today
+
+| Command   | Substrate call         | Notes                          |
+|-----------|------------------------|--------------------------------|
+| `metrics` | `runtime/metrics/all`  | Pretty-prints JSON for all modules |
+
+## Architecture
+
+```text
+  user @ shell
+       │
+       ▼
+  ctm <subcommand>          (this crate — apps/cli/)
+       │
+       ▼
+  Connection::connect(airc, substrate_peer_id)
+       │
+       ▼
+  CommandClient<AircIpcTransport>
+       │
+       ▼
+  airc-lib request/await_reply   (LAN socket → substrate peer)
+       │
+       ▼
+  continuum-core-server / CommandRequestHandler
+       │
+       ▼
+  module dispatch → AircCommandResponse → reply over airc
+       │
+       ▼ (back up the stack)
+  serde_json::Value → ctm prints to stdout
+```
+
+Same seam the `core/continuum-core/tests/airc_ipc_roundtrip.rs`
+integration test exercises end-to-end.
+
+## Pending follow-ups
+
+- **Auto peer discovery** — current slice requires `--peer`. A future
+  slice reads `~/.continuum/peer.json` or uses an `airc ipc-endpoint`
+  lookup so the operator doesn't have to type a UUID.
+- **More subcommands** — `chat/send`, `gpu/stats`, `data/list`,
+  `cognition/admit-inbox-message`, etc. Each is a small slice.
+- **Shell shim install** — `tools/scripts/install-cli.sh` to put `ctm`
+  on PATH and alias `jtag` → `ctm` for backwards muscle memory.

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,0 +1,123 @@
+//! continuum-cli — rust CLI client, first slice (task #143).
+//!
+//! ## Today
+//!
+//! One subcommand (`metrics`) that dispatches `runtime/metrics/all` at a
+//! continuum-core-server peer and pretty-prints the JSON response. The
+//! purpose of THIS slice is to prove the seam: substrate-first
+//! architecture, no Node middleware, no JTAG-daemon IPC dance.
+//!
+//! ## Tomorrow
+//!
+//! Every `./jtag <command>` migrates to a `ctm` subcommand that calls
+//! `Connection::commands().execute()`. Each migration is a small slice —
+//! we don't rewrite the world at once. As subcommands land, the Node
+//! `./jtag` binary shrinks, eventually leaving only its install
+//! footprint behind.
+//!
+//! ## Identity + peer discovery
+//!
+//! The CLI runs as the human's airc citizen (per
+//! `[[personas-are-citizens-airc-is-identity-provider]]`). It opens the
+//! user's airc home (default `$HOME/.airc`, overridable via `--home` or
+//! `CONTINUUM_AIRC_HOME`) and targets the substrate's peer UUID via
+//! `--peer` / `CONTINUUM_PEER_ID`. Auto-discovery of the local
+//! continuum-core-server (so the operator doesn't have to type a UUID)
+//! is a follow-up slice — pending an `airc ipc-endpoint`-style
+//! lookup or a `~/.continuum/peer.json` discovery file.
+
+use std::env;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use airc_lib::Airc;
+use anyhow::{anyhow, Context, Result};
+use clap::{Parser, Subcommand};
+use continuum_client::Connection;
+use uuid::Uuid;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "ctm",
+    about = "continuum CLI — substrate client via continuum-client",
+    long_about = "Run substrate commands directly against a continuum-core-server\n\
+                  over airc IPC. Successor to ./jtag; same commands, no Node middleware."
+)]
+struct Cli {
+    /// airc home directory (default: $HOME/.airc).
+    #[arg(long, env = "CONTINUUM_AIRC_HOME", global = true)]
+    home: Option<PathBuf>,
+
+    /// Target substrate peer UUID. Find it via `airc status` on the
+    /// machine running continuum-core-server. Required for any command
+    /// that talks to the substrate — `--help` works without it.
+    #[arg(long, env = "CONTINUUM_PEER_ID", global = true)]
+    peer: Option<Uuid>,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Fetch runtime metrics for every registered module.
+    Metrics,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Honest startup probe before anything else.
+    tracing_subscriber::fmt()
+        .with_target(false)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_env("CONTINUUM_CLI_LOG")
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    let home = match cli.home {
+        Some(p) => p,
+        None => default_airc_home()?,
+    };
+
+    let peer = cli.peer.ok_or_else(|| {
+        anyhow!(
+            "--peer is required (or set CONTINUUM_PEER_ID). Find it via `airc status` on the \
+             machine running continuum-core-server."
+        )
+    })?;
+
+    tracing::debug!(?home, "opening airc home");
+    let airc = Airc::open(&home)
+        .await
+        .with_context(|| format!("open airc home at {}", home.display()))?;
+
+    let conn = Connection::connect(Arc::new(airc), peer);
+
+    match cli.command {
+        Command::Metrics => run_metrics(conn).await,
+    }
+}
+
+async fn run_metrics(
+    conn: Connection<continuum_client::AircIpcTransport>,
+) -> Result<()> {
+    let result: serde_json::Value = conn
+        .commands()
+        .execute("runtime/metrics/all", serde_json::json!({}))
+        .await
+        .map_err(|e| anyhow!("dispatch runtime/metrics/all: {e}"))?;
+    println!("{}", serde_json::to_string_pretty(&result)?);
+    Ok(())
+}
+
+/// `$HOME/.airc`, or an error if `$HOME` isn't set. Mirrors what
+/// airc-lib does internally so the CLI doesn't fall back to a system
+/// path the user didn't expect.
+fn default_airc_home() -> Result<PathBuf> {
+    let home = env::var_os("HOME")
+        .ok_or_else(|| anyhow!("$HOME is unset; pass --home explicitly"))?;
+    Ok(PathBuf::from(home).join(".airc"))
+}


### PR DESCRIPTION
First slice of task #143 (Rust-first clients — rewrite jtag CLI in Rust). The `apps/cli` slot was a placeholder README per the Stage 1-2.5 layout sweep; this PR lands the first real rust binary on it.

## What lands

```
apps/cli/
├── Cargo.toml            new crate, binary name `ctm`
├── README.md             status / install / usage / architecture
└── src/main.rs           clap CLI + Connection::connect + metrics subcmd
```

Workspace member added at root `Cargo.toml` under a new `apps/` tier section (sibling to `client/`).

## One subcommand wired end-to-end

```bash
$ ctm metrics --peer <substrate-uuid>
{
  "modules": [...],
  "count": N
}
```

The wire path:
1. `Cli::parse()` extracts `--peer` / `--home` / `CONTINUUM_PEER_ID` / `CONTINUUM_AIRC_HOME`.
2. `Airc::open($HOME/.airc)` opens the human's airc citizen.
3. `Connection::connect(Arc::new(airc), peer_uuid)` builds the substrate session.
4. `.commands().execute("runtime/metrics/all", {})` round-trips through `AircIpcTransport`.
5. `continuum-core-server`'s `CommandRequestHandler::parse_envelope` decodes, `RuntimeModule` dispatches, `send_reply` ships the response.

Every byte of that path is the SAME path `core/continuum-core/tests/airc_ipc_roundtrip.rs` verifies — no new wire, just a new caller.

## Why this matters

- First rust binary in the `apps/` tier — proves the substrate-first architecture works end-to-end from a real binary.
- Same `continuum-client` seam every future `apps/{web, mcp, mobile, ar, vr, desktop}` will consume.
- Migration path for `./jtag` is now incremental: each future PR adds one `ctm <subcommand>`, the Node `./jtag` shrinks.

## Verified

```
cargo build -p continuum-cli           → clean (31s cold, 2s incremental)
ctm --help                             → prints usage cleanly
ctm metrics                            → typed error: "--peer is required"
```

Runtime tests against a live substrate are a follow-up — the wire path is already proven by the integration test that just merged.

## Pending follow-ups (in README.md)

- **Auto peer discovery** (read `~/.continuum/peer.json` or `airc ipc-endpoint`).
- **More subcommands** (`chat/send`, `gpu/stats`, `data/list`, `persona/list`).
- **Shell shim install** (`tools/scripts/install-cli.sh`, `jtag` alias).

## Test plan

- [x] cargo build -p continuum-cli
- [x] ctm --help
- [x] ctm metrics (without --peer; typed error)
- [ ] ctm metrics against a running continuum-core-server (manual)
- [ ] CI green
