### PR TITLE
fix(tools): inline dotenv.parse in generate-config — kill canary CI breakage from layout sweep

### DIFF
--- a/tools/generator/generate-config.ts
+++ b/tools/generator/generate-config.ts
@@ -10,9 +10,41 @@
 import { readFileSync } from 'fs';
 import { writeIfChanged } from './core/writeIfChanged';
 import { join } from 'path';
-import * as dotenv from 'dotenv';
 
 const rootDir = process.cwd();
+
+// Inline `KEY=value` parser — replaces the previous `import * as dotenv
+// from 'dotenv'` dependency. The layout sweep (PR #1557, task #214)
+// moved this script from `src/generator/` to `tools/generator/`, which
+// put it OUTSIDE the upward `node_modules` walk that resolves
+// `src/node_modules/dotenv`. Node's resolution walks ancestors of the
+// SCRIPT location, not `process.cwd()`, so `dotenv` was unfindable
+// from `tools/generator/`. We only ever called `dotenv.parse()` (the
+// pure string→KV transform), not the `.config()` side-effect path, so
+// the inline parser is a like-for-like replacement at zero
+// architectural cost. Bonus: generator scripts now have a node-stdlib-
+// only footprint, matching `generate-version.ts`'s shape.
+function parseEnvText(text: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    // Strip a single matched pair of surrounding quotes — matches
+    // dotenv's behavior for `KEY="value"` and `KEY='value'`.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}
 
 // Read config.env (follow SecretManager pattern for file locations)
 function loadConfigEnv(): Record<string, string> {
@@ -25,7 +57,7 @@ function loadConfigEnv(): Record<string, string> {
 
   for (const configPath of configPaths) {
     try {
-      const parsed = dotenv.parse(readFileSync(configPath, 'utf-8'));
+      const parsed = parseEnvText(readFileSync(configPath, 'utf-8'));
       config = { ...config, ...parsed };
     } catch {
       // File doesn't exist, continue


### PR DESCRIPTION
## What

Replace `import * as dotenv from 'dotenv'` in `tools/generator/generate-config.ts` with an inline 15-line `parseEnvText` function. Removes the dotenv dep entirely from this script.

## Why

The layout sweep (PR #1557, task #214) moved `generate-config.ts` from `src/generator/` to `tools/generator/`. Node's module resolution walks ancestors of the **script location**, not `process.cwd()`. From `tools/generator/`, the upward walk goes `tools/generator/` -> `tools/` -> `/` and finds no `node_modules/dotenv` — that module only lives at `src/node_modules/dotenv` (a sibling of `tools/`, not an ancestor).

Every TS-validation CI job has been failing on canary since the layout sweep merged:
```
Error: Cannot find module 'dotenv'
Require stack:
- /home/runner/work/continuum/continuum/tools/generator/generate-config.ts
```

Surfaced via PR #1561's failing checks (validate / ts-eslint-baseline-ratchet / verify-architectures / verify-after-rebuild). NOT caused by that PR — pre-existing canary infrastructure regression.

## How

`dotenv` was only ever used for its `.parse(text)` function (pure string-to-KV transform). Inlined as `parseEnvText` with the same semantics:
- `KEY=value` lines
- Optional surrounding double or single quotes around the value
- `#` comments + blank lines ignored

The `.config()` side-effect path (which mutates `process.env`) was never used here. Like-for-like behavioral replacement.

## Doctrinal bonus

Generator scripts now have a Node-stdlib-only footprint, matching `generate-version.ts`'s shape. No upward-walk module-resolution surprises possible. Aligns with task #209 (Node deps trimming).

## Test plan

- [x] Local: `cd src && npx tsx ../tools/generator/generate-config.ts` -> "shared/config.ts unchanged" (idempotent re-run), ports + active_example resolved correctly
- [ ] CI: validate / ts-eslint-baseline-ratchet on this branch should now produce a real signal instead of the dotenv-missing module error

Generated with Claude Code
