### PR TITLE
fix(substrate): strip hardware identity from today's code + docs

### DIFF
--- a/apps/cli/src/grid_smoke.rs
+++ b/apps/cli/src/grid_smoke.rs
@@ -38,8 +38,9 @@
 //! ## Doctrinal alignment
 //!
 //! - `[[host-the-seemingly-impossible]]` — the Tron-grid frame.
-//!   Intel Mac dispatches at the 5090 and ALL of these are expected
-//!   to compose by construction, not by special-case wiring.
+//!   A constrained-locally host dispatches at a GPU-rich peer and
+//!   ALL of these are expected to compose by construction, not by
+//!   special-case wiring.
 //! - `[[commands-are-kernel-level-and-compose]]` — the harness
 //!   doesn't care WHICH command it dispatches; same `Commands.execute()`
 //!   primitive every other CLI / persona / sentinel uses.
@@ -199,12 +200,12 @@ pub fn default_battery() -> Vec<GridSmokeSpec> {
         },
         // Real inference dispatch — the proof PR #1563 covered for
         // HeuristicInferenceAdapter, now run against whatever adapter
-        // the target peer has. If the target is the 5090 running
-        // Qwen3.5, this row's response IS Qwen3.5. If the target is
-        // an Intel Mac with only the heuristic registered, this
-        // row's response starts with [heuristic:...]. The validator
-        // just confirms the wire-shape; the operator reads the
-        // summary line to see WHO answered.
+        // the target peer has. If the target is a GPU host running
+        // a real LLM, this row's response IS that model. If the
+        // target only has the heuristic registered, the response
+        // starts with [heuristic:...]. The validator just confirms
+        // the wire-shape; the operator reads the summary line to
+        // see WHO answered.
         GridSmokeSpec {
             name: "ai/generate (one-word reply)",
             path: "ai/generate",

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -64,8 +64,9 @@ enum Command {
     /// (or the full JSON via --json).
     ///
     /// If the substrate has an AircRemoteInferenceAdapter registered,
-    /// the inference will transparently run on a remote peer (e.g., the
-    /// operator's 5090); the CLI doesn't know or care.
+    /// the inference will transparently run on a remote peer (the
+    /// operator's GPU-rich grid host, for example); the CLI doesn't
+    /// know or care.
     Generate {
         /// User-side prompt. Becomes a single user message in the
         /// TextGenerationRequest.

--- a/core/continuum-core/src/inference/airc_remote/adapter.rs
+++ b/core/continuum-core/src/inference/airc_remote/adapter.rs
@@ -70,7 +70,8 @@ impl AircRemoteInferenceAdapter {
 
     /// Pin every request to a specific peer. Use when the
     /// substrate's higher layer has decided this adapter
-    /// instance is the "route to Joel's 5090" channel.
+    /// instance is the dedicated route to one remote inference peer
+    /// (e.g. the operator's GPU-rich grid host).
     pub fn with_target_peer(mut self, peer: impl Into<String>) -> Self {
         self.default_target_peer = Some(peer.into());
         self
@@ -437,7 +438,7 @@ mod tests {
             })
         });
         let adapter = AircRemoteInferenceAdapter::new(transport)
-            .with_target_peer("joels-5090");
+            .with_target_peer("test-remote-peer");
         let _ = adapter.generate_text(req("anything")).await.unwrap();
         // The test verifies via the stub's served_by echo; the
         // adapter overwrites response.provider to airc-remote, so

--- a/core/continuum-core/src/inference/airc_remote/transport.rs
+++ b/core/continuum-core/src/inference/airc_remote/transport.rs
@@ -501,9 +501,9 @@ mod tests {
     async fn local_adapter_transport_with_custom_peer_id() {
         let heuristic: Arc<dyn AIProviderAdapter> =
             Arc::new(HeuristicInferenceAdapter::new());
-        let transport = LocalAdapterTransport::with_peer_id(heuristic, "joels-5090");
+        let transport = LocalAdapterTransport::with_peer_id(heuristic, "test-remote-peer");
         let resp = transport.send_request(req("hi")).await.unwrap();
-        assert_eq!(resp.served_by, "joels-5090");
+        assert_eq!(resp.served_by, "test-remote-peer");
         // Suppress the unused Uuid import warning when this test
         // doesn't construct a Uuid itself.
         let _ = Uuid::nil();

--- a/core/continuum-core/tests/airc_remote_inference_roundtrip.rs
+++ b/core/continuum-core/tests/airc_remote_inference_roundtrip.rs
@@ -3,17 +3,19 @@
 //! `CommandRequestHandler::parse_envelope` + `send_reply` paths
 //! (mirroring `ai/generate` on the remote substrate).
 //!
-//! This is the live wire proof that an Intel Mac persona can dispatch
-//! inference at `airc://<rtx5090>/ai/generate` and get a typed response
-//! back, with the substrate's real parser in the loop on both ends.
+//! This is the live wire proof that a local persona can dispatch
+//! inference at `airc://<remote-peer>/ai/generate` and get a typed
+//! response back, with the substrate's real parser in the loop on
+//! both ends.
 //!
 //! ## Topology
 //!
-//! - peer_a = "the 5090" — substrate, hosts ai/generate. Test stubs the
-//!   responder so we control the canned `TextGenerationResponse` and
-//!   can assert the request's wire shape (path, kind, params, headers)
-//!   that AircLiveTransport emits.
-//! - peer_b = "the Intel Mac" — has an AircRemoteInferenceAdapter
+//! - peer_a = the remote inference host — substrate, hosts ai/generate.
+//!   Test stubs the responder so we control the canned
+//!   `TextGenerationResponse` and can assert the request's wire
+//!   shape (path, kind, params, headers) that AircLiveTransport
+//!   emits.
+//! - peer_b = the local caller — has an AircRemoteInferenceAdapter
 //!   wrapping AircLiveTransport pointed at peer_a. Persona-side code
 //!   (well, the test) calls adapter.generate_text(request).
 //!
@@ -218,10 +220,10 @@ async fn airc_remote_inference_adapter_round_trips_against_substrate() {
         .expect("fixture setup should succeed");
 
     let canned = TextGenerationResponse {
-        text: "pong from the 5090".to_string(),
+        text: "pong from the remote peer".to_string(),
         finish_reason: FinishReason::Stop,
-        model: "qwen3.5-4b-code-forged".to_string(),
-        provider: "llamacpp-on-5090".to_string(),
+        model: "test-model".to_string(),
+        provider: "test-remote-llamacpp".to_string(),
         usage: UsageMetrics {
             input_tokens: 12,
             output_tokens: 7,


### PR DESCRIPTION
Joel called this out: 'Is 5090 coded into the repo? That would be weird.' Yes — I let GPU-specific narrative and operator-personal labels leak into substrate source + test fixtures + doc-strings across today's PRs (#1560, #1561, #1563, #1564). None load-bearing, but the repo should be hardware-agnostic.

## Replacements (one PR, surgical edits)

- adapter.rs / transport.rs: test fixture string `joels-5090` -> `test-remote-peer` (3 sites). Doc "route to Joel's 5090" -> generic remote-inference-peer description.
- roundtrip integration test: peer labels generic ("remote inference host" / "local caller"), canned response strings replaced (`pong from the remote peer` / `test-model` / `test-remote-llamacpp`).
- apps/cli/src/main.rs: Generate doc `(e.g., the operator's 5090)` -> generic GPU-rich grid host.
- apps/cli/src/grid_smoke.rs: module doc + ai/generate row comment use generic categories.

## Out of scope (intentionally kept)

- Older codebase doctrine attributions (`Joel's never-swallow-errors`) — they name doctrine origin, fine.
- Task #85 mentioning 5090 — it's a real airc bug ticket about that hardware.

## Verified

```
grep -rn '5090\|joels-' on touched files     -> zero hits
cargo check -p continuum-cli                  -> clean (1.94s)
```

## Lesson

Any hardware-specific identity is narrative scaffolding, not substrate truth. The substrate is hardware-agnostic; tests use neutral labels; docs describe categories, not specific units.

Generated with Claude Code