### PR TITLE
feat(model_registry): add Mistral provider — cloud-inference now feature-complete in Rust

### DIFF
--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -245,6 +245,42 @@ pub fn models() -> Vec<Model> {
             ..ModelSpec::default()
         }),
         model(ModelSpec {
+            id: "mistral-large-latest",
+            name: "Mistral Large",
+            provider: "mistral",
+            arch: Arch::Mistral,
+            context_window: 131_072,
+            max_output_tokens: 8192,
+            tokens_per_second: 50.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.002,
+            cost_output_per_1k: 0.006,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "codestral-latest",
+            name: "Codestral",
+            provider: "mistral",
+            arch: Arch::Mistral,
+            context_window: 32_768,
+            max_output_tokens: 8192,
+            tokens_per_second: 60.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            cost_input_per_1k: 0.001,
+            cost_output_per_1k: 0.003,
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
             id: "docker.io/ai/qwen2.5:7B-Q4_K_M",
             name: "Qwen2.5 7B Q4_K_M (DMR)",
             provider: "docker-model-runner",
@@ -466,6 +502,16 @@ pub fn providers() -> Vec<Provider> {
             auth: AuthKind::Bearer,
             kind: ProviderKind::Cloud,
             model_prefixes: &["gemini"],
+        }),
+        provider(ProviderSpec {
+            id: "mistral",
+            name: "Mistral AI",
+            base_url: "https://api.mistral.ai",
+            api_key_env: Some("MISTRAL_API_KEY"),
+            default_model: Some("mistral-large-latest"),
+            auth: AuthKind::Bearer,
+            kind: ProviderKind::Cloud,
+            model_prefixes: &["mistral", "mixtral", "codestral", "open-mistral", "open-mixtral"],
         }),
         provider(ProviderSpec {
             id: "docker-model-runner",

--- a/core/continuum-core/src/model_registry/types.rs
+++ b/core/continuum-core/src/model_registry/types.rs
@@ -31,6 +31,10 @@ pub enum Arch {
     Gemini,
     Grok,
     Deepseek,
+    /// Mistral's own dense + MoE architecture line: Mistral 7B,
+    /// Mixtral 8x7B / 8x22B, Codestral, Mistral Large. Distinct from
+    /// Llama because of MoE routing semantics + tokenizer differences.
+    Mistral,
     /// Escape hatch for architectures we haven't enumerated yet. Models
     /// tagged `Unknown` cannot be dispatched by arch — callers MUST fall
     /// through to capability checks. Used sparingly.

--- a/core/continuum-core/src/modules/ai_provider.rs
+++ b/core/continuum-core/src/modules/ai_provider.rs
@@ -354,6 +354,15 @@ impl AIProviderModule {
             }
         }
 
+        if get_secret("MISTRAL_API_KEY").is_some() {
+            self.log().info("Registering Mistral adapter");
+            let mut a = OpenAICompatibleAdapter::from_registry("mistral");
+            match a.initialize().await {
+                Ok(()) => registry.register(Arc::new(a), 8),
+                Err(e) => self.log().warn(&format!("Mistral initialize failed: {e} — not registered")),
+            }
+        }
+
         // In-process llama.cpp adapter — bypasses DMR's container Metal toolchain,
         // which on M5 Pro fails to compile the tensor-API source (`has tensor=false`)
         // and falls back to a degraded path running at 22 tok/s. Our host-built

--- a/protocol/typescript/model_registry/Arch.ts
+++ b/protocol/typescript/model_registry/Arch.ts
@@ -9,4 +9,4 @@
  * for ("code should NEVER know the model" — code knows the ARCHETYPES
  * via this enum, models are data).
  */
-export type Arch = "qwen2" | "qwen3" | "qwen35" | "llama" | "claude" | "gpt" | "gemini" | "grok" | "deepseek" | "unknown";
+export type Arch = "qwen2" | "qwen3" | "qwen35" | "llama" | "claude" | "gpt" | "gemini" | "grok" | "deepseek" | "mistral" | "unknown";


### PR DESCRIPTION
Adds the one missing cloud provider in the Rust model_registry catalog. After merge, all 9 cloud providers (Anthropic, OpenAI, DeepSeek, Together, Groq, Fireworks, XAI, Google, Mistral) plus 2 local providers (DMR, llamacpp-local) run through the Rust adapter pool — TS adapter dirs are duplicates and can be deleted in a follow-up.

Reframes task #229: the work is verify-and-delete, not port-7-adapters.

See commit for full body.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>