### PR TITLE
feat(genome): LocalCandleFineTuner end-to-end — job actor + safetensors output (task #233)

### DIFF
--- a/core/continuum-core/src/genome/fine_tuning/byte_tokenizer.rs
+++ b/core/continuum-core/src/genome/fine_tuning/byte_tokenizer.rs
@@ -1,0 +1,113 @@
+//! [`ByteTokenizer`] — substrate-side deterministic byte-level
+//! tokenizer. Default fallback for the [`super::Tokenizer`] trait
+//! when no model-specific tokenizer is loaded.
+//!
+//! ## Why ship one
+//!
+//! The training pipeline (`training_loop.rs`) requires a [`Tokenizer`]
+//! to turn text into id sequences. Production wiring (#233's follow-up
+//! after real HF tokenizer support lands) replaces this with a
+//! Qwen / Llama / Mistral tokenizer loaded from disk. Until then, the
+//! substrate needs a *real* tokenizer (not a test-only one) so the
+//! `LocalCandleFineTuner` can run end-to-end against arbitrary input
+//! without any model-specific assets.
+//!
+//! Byte-level tokenization is a legitimate substrate primitive — some
+//! research lines (ByT5, MambaByte) train directly on bytes; pad=0 is
+//! the standard convention so byte b maps to id (b + 1), giving a
+//! vocab of 257 (0 = pad, 1..256 = bytes 0..255).
+//!
+//! ## What it isn't
+//!
+//! - Not a *good* tokenizer in absolute terms — sequence length blows
+//!   up by ~4x vs BPE. Use a model-specific tokenizer when one is
+//!   wired.
+//! - Not the FakeTokenizer used in `training_loop.rs` tests — that's
+//!   deliberately weakened to vocab=4/32 so cross-entropy targets
+//!   stay in range against tiny LoRA modules. ByteTokenizer is real.
+
+use super::training_loop::{Tokenizer, TrainingError};
+
+/// Vocabulary size for [`ByteTokenizer`] outputs: 1 pad token (id 0)
+/// plus 256 byte values (ids 1..=256).
+pub const BYTE_VOCAB: u32 = 257;
+
+/// Pad token id used by [`ByteTokenizer`]. Held in a constant so
+/// downstream code that masks against pad references the same value
+/// the tokenizer produces — a future refactor changing the pad id
+/// in one place but not the other would silently mis-mask training
+/// loss.
+pub const BYTE_PAD_ID: u32 = 0;
+
+/// Deterministic byte-level tokenizer. Encodes each UTF-8 byte b as
+/// id (b + 1), reserving 0 for the pad token.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ByteTokenizer;
+
+impl ByteTokenizer {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Tokenizer for ByteTokenizer {
+    fn encode(&self, text: &str) -> Result<Vec<u32>, TrainingError> {
+        Ok(text.bytes().map(|b| (b as u32) + 1).collect())
+    }
+
+    fn pad_token_id(&self) -> u32 {
+        BYTE_PAD_ID
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: byte b maps to id (b + 1), pad id is 0.
+    // A refactor that flipped the convention (b maps to id b, pad=256)
+    // would silently invert which positions get masked from training
+    // loss. This test pins the offset convention.
+    #[test]
+    fn encodes_byte_offset_by_one_pad_is_zero() {
+        let tok = ByteTokenizer::new();
+        assert_eq!(tok.pad_token_id(), 0);
+        let ids = tok.encode("ab").unwrap();
+        assert_eq!(ids, vec![b'a' as u32 + 1, b'b' as u32 + 1]);
+        // No encoded byte ever collides with pad.
+        for id in &ids {
+            assert_ne!(*id, BYTE_PAD_ID);
+        }
+    }
+
+    // what this catches: vocab constant matches actual range. A
+    // future refactor that added a special token without bumping the
+    // constant would silently produce out-of-range ids feeding into
+    // cross-entropy (gather panic at runtime).
+    #[test]
+    fn vocab_constant_covers_all_emitted_ids() {
+        let tok = ByteTokenizer::new();
+        // Every possible byte value, encoded.
+        let all_bytes: Vec<u8> = (0..=255).collect();
+        let text = String::from_utf8_lossy(&all_bytes).into_owned();
+        let ids = tok.encode(&text).unwrap();
+        for id in ids {
+            assert!(
+                id < BYTE_VOCAB,
+                "encoded id {id} must be < BYTE_VOCAB {BYTE_VOCAB}"
+            );
+        }
+    }
+
+    // what this catches: encoding is byte-deterministic — same input
+    // always produces same output. Non-determinism here would break
+    // training reproducibility (re-run with same dataset → different
+    // gradients → different artifact hash).
+    #[test]
+    fn encoding_is_deterministic() {
+        let tok = ByteTokenizer::new();
+        let a = tok.encode("the quick brown fox").unwrap();
+        let b = tok.encode("the quick brown fox").unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/core/continuum-core/src/genome/fine_tuning/job_actor.rs
+++ b/core/continuum-core/src/genome/fine_tuning/job_actor.rs
@@ -1,0 +1,505 @@
+//! Job lifecycle actor — one in-flight training run per
+//! [`JobActor`].
+//!
+//! The substrate's RTOS doctrine (CONCURRENCY-STYLE-GUIDE,
+//! `[[rtos-brain-no-region-on-hot-path]]`) says CPU-bound work goes
+//! into [`tokio::task::spawn_blocking`]; the foreground tokio
+//! runtime stays responsive. Training is CPU-bound (candle's tensor
+//! ops are synchronous), so the actor runs the optimizer loop on a
+//! blocking thread, publishes status snapshots via a
+//! [`tokio::sync::watch`] channel, and watches an
+//! [`AtomicBool`] cancel flag the [`JobController`] flips.
+//!
+//! ## Why an actor at all
+//!
+//! Without it, `LocalCandleFineTuner::create_job` would have to
+//! block until training completes — the [`super::FineTuningAdapter`]
+//! contract is `async fn create_job(...) -> JobHandle`, fast-return.
+//! The actor decouples submission from progress: `create_job` spawns,
+//! returns immediately; `poll` reads the watch channel for the
+//! latest [`TrainingStatus`]; `cancel` flips the flag.
+//!
+//! ## Lifecycle
+//!
+//! ```text
+//!   spawn_job ── publishes ──► Queued
+//!       │
+//!       │ epoch 1..=N         ── publishes ──► Running { progress, epoch }
+//!       │
+//!       ├─ cancel flag set?   ── publishes ──► Cancelled  ── exit
+//!       │
+//!       └─ all epochs done    ── writes safetensors
+//!                                publishes ──► Completed { artifact }
+//!                                exit
+//!
+//!   anything else throws      ── publishes ──► Failed { error }
+//!                                exit
+//! ```
+//!
+//! Terminal states are sticky — the watch channel keeps the final
+//! value forever, so repeated `poll` calls after completion return
+//! the same `Completed { artifact }` payload.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use candle_core::{DType, Device, Tensor};
+use tokio::sync::watch;
+
+use super::byte_tokenizer::{ByteTokenizer, BYTE_VOCAB};
+use super::lora_module::{LoRAError, LoRAModule};
+use super::safetensors_io::{write_lora_safetensors, SafetensorsIoError};
+use super::training_loop::{DataLoader, LoRATrainer, TrainingError};
+use super::types::{
+    JobMetrics, LoRAHyperparams, ScheduleParams, TrainingArtifact, TrainingDataset,
+    TrainingStatus,
+};
+
+// ─── Defaults ────────────────────────────────────────────────────────
+
+/// Defaults for [`LoRAHyperparams`] when the request doesn't carry
+/// any. Mirror the values the genome/job-create validator suggests
+/// (`alpha = rank * 2`, dropout=0.0, no target modules in standin).
+pub(super) fn default_lora() -> LoRAHyperparams {
+    LoRAHyperparams {
+        rank: 8,
+        alpha: 16,
+        dropout: 0.0,
+        target_modules: vec![],
+    }
+}
+
+/// Defaults for [`ScheduleParams`] when the request doesn't carry
+/// any. Conservative numbers — substrate doesn't know the dataset
+/// size yet; 3 epochs × small batch is enough to verify the pipeline
+/// end-to-end without burning compute on stand-in math.
+pub(super) fn default_schedule() -> ScheduleParams {
+    ScheduleParams {
+        epochs: 3,
+        batch_size: 4,
+        sequence_length: 32,
+        learning_rate: 1e-4,
+    }
+}
+
+// ─── Errors ──────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum JobActorError {
+    #[error("dataset has no examples; nothing to train on")]
+    EmptyDataset,
+
+    #[error("schedule epochs must be > 0")]
+    InvalidEpochs,
+
+    #[error("output path is required for local-candle jobs")]
+    MissingOutputPath,
+
+    #[error("LoRA module construction: {0}")]
+    LoRA(#[from] LoRAError),
+
+    #[error("data loader: {0}")]
+    Training(#[from] TrainingError),
+
+    #[error("safetensors writeout: {0}")]
+    Safetensors(#[from] SafetensorsIoError),
+
+    #[error("candle tensor op: {0}")]
+    Candle(#[from] candle_core::Error),
+}
+
+// ─── Controller ──────────────────────────────────────────────────────
+
+/// Handle returned by [`spawn_job`]. Owns the cancel flag + the
+/// watch receiver. Cloning is by `Clone` on `Arc`s + `watch::Receiver`.
+#[derive(Debug, Clone)]
+pub struct JobController {
+    status_rx: watch::Receiver<TrainingStatus>,
+    cancel_flag: Arc<AtomicBool>,
+}
+
+impl JobController {
+    /// Latest published status. Cheap clone — TrainingStatus is small.
+    pub fn current_status(&self) -> TrainingStatus {
+        self.status_rx.borrow().clone()
+    }
+
+    /// Flip the cancel flag. The actor honors it at the next epoch
+    /// boundary; the watch channel will then publish
+    /// [`TrainingStatus::Cancelled`].
+    ///
+    /// Cancellation is idempotent — flipping a flag that's already
+    /// set is a no-op.
+    pub fn cancel(&self) {
+        self.cancel_flag.store(true, Ordering::Release);
+    }
+
+    /// True if the cancel flag has been set. Test-only inspection;
+    /// the watch channel is the source of truth for status.
+    #[cfg(test)]
+    pub(super) fn is_cancel_requested(&self) -> bool {
+        self.cancel_flag.load(Ordering::Acquire)
+    }
+}
+
+// ─── Spawn ───────────────────────────────────────────────────────────
+
+/// Inputs that flow into `spawn_job`. Bundled into a struct so the
+/// `create_job` call site stays readable as the field count grows
+/// (artifact-id / persona-id / device-pin all land here in
+/// follow-ups).
+#[derive(Debug, Clone)]
+pub struct SpawnJobRequest {
+    pub persona_name: String,
+    pub base_model: String,
+    pub trait_kind: String,
+    pub dataset: TrainingDataset,
+    pub schedule: Option<ScheduleParams>,
+    pub lora: Option<LoRAHyperparams>,
+    pub output_path: PathBuf,
+}
+
+/// Spawn the lifecycle actor. Validates the request synchronously,
+/// constructs the LoRAModule + DataLoader on the calling task (cheap;
+/// tokenization + batching are fast), then hands the trainer + loader
+/// off to a [`tokio::task::spawn_blocking`] thread that runs the
+/// optimizer loop.
+///
+/// On success returns a [`JobController`] whose watch channel is
+/// pre-published with [`TrainingStatus::Queued`] before this
+/// function returns — so the first `poll` from the adapter never
+/// races the actor's first publish.
+pub fn spawn_job(req: SpawnJobRequest) -> Result<JobController, JobActorError> {
+    // Validation — fast, synchronous, BEFORE any tokio resource is
+    // allocated. The contract: a bad request fails synchronously
+    // here, not after spawning a doomed task.
+    if req.dataset.examples.is_empty() {
+        return Err(JobActorError::EmptyDataset);
+    }
+    let schedule = req.schedule.unwrap_or_else(default_schedule);
+    if schedule.epochs == 0 {
+        return Err(JobActorError::InvalidEpochs);
+    }
+    let lora = req.lora.unwrap_or_else(default_lora);
+
+    // Stand-in module construction. Production wiring (next slice)
+    // loads `req.base_model` from disk and injects A/B at each
+    // `lora.target_modules` projection. Here we materialize a single
+    // synthetic linear layer the trainer's gradient path exercises
+    // end-to-end. Shape: [vocab, sequence_length] so cross-entropy
+    // sees logits over the byte vocab from the standin input cast.
+    let device = Device::Cpu;
+    let base_weight = Tensor::rand(
+        -0.1f32,
+        0.1f32,
+        (BYTE_VOCAB as usize, schedule.sequence_length as usize),
+        &device,
+    )?;
+    let module = LoRAModule::new(base_weight, lora.rank, lora.alpha, DType::F32, &device)?;
+    let trainer = LoRATrainer::new(module, schedule.learning_rate)?;
+
+    // Pre-tokenize + batch the dataset. Building the loader on the
+    // calling thread (not inside spawn_blocking) lets us surface
+    // validation errors synchronously.
+    let tokenizer = ByteTokenizer::new();
+    let loader = DataLoader::new(
+        &req.dataset.examples,
+        &tokenizer,
+        schedule.batch_size,
+        schedule.sequence_length,
+        &device,
+    )?;
+
+    // Watch channel pre-published with Queued. The actor's first
+    // act inside spawn_blocking is to flip it to Running { 0%, 0 }.
+    let (status_tx, status_rx) = watch::channel(TrainingStatus::Queued);
+    let cancel_flag = Arc::new(AtomicBool::new(false));
+    let cancel_flag_actor = cancel_flag.clone();
+
+    let output_path = req.output_path.clone();
+    let persona_name = req.persona_name.clone();
+    let trait_kind = req.trait_kind.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let started = Instant::now();
+        run_actor(
+            trainer,
+            loader,
+            schedule,
+            output_path,
+            persona_name,
+            trait_kind,
+            status_tx,
+            cancel_flag_actor,
+            started,
+        );
+    });
+
+    Ok(JobController {
+        status_rx,
+        cancel_flag,
+    })
+}
+
+// ─── Actor body ──────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn run_actor(
+    mut trainer: LoRATrainer,
+    loader: DataLoader,
+    schedule: ScheduleParams,
+    output_path: PathBuf,
+    persona_name: String,
+    trait_kind: String,
+    status_tx: watch::Sender<TrainingStatus>,
+    cancel_flag: Arc<AtomicBool>,
+    started: Instant,
+) {
+    // Open with Running { 0%, 0 } so a poll right after spawn sees a
+    // started job, not Queued.
+    let _ = status_tx.send(TrainingStatus::Running {
+        progress_pct: 0.0,
+        current_epoch: 0,
+    });
+
+    let mut final_train_loss: Option<f32> = None;
+    for epoch in 1..=schedule.epochs {
+        if cancel_flag.load(Ordering::Acquire) {
+            let _ = status_tx.send(TrainingStatus::Cancelled);
+            return;
+        }
+
+        match trainer.train_epoch(&loader) {
+            Ok(avg) => {
+                final_train_loss = Some(avg);
+                let pct = (epoch as f32) * 100.0 / (schedule.epochs as f32);
+                let _ = status_tx.send(TrainingStatus::Running {
+                    progress_pct: pct,
+                    current_epoch: epoch,
+                });
+            }
+            Err(e) => {
+                let _ = status_tx.send(TrainingStatus::Failed {
+                    error: format!("train_epoch (epoch {epoch}): {e}"),
+                });
+                return;
+            }
+        }
+    }
+
+    // Write safetensors. Failure here is a terminal Failed — the
+    // training succeeded but the artifact isn't durable, so a
+    // subsequent `poll` reporting Completed would be a lie per
+    // [[no-fallbacks-ever]].
+    if let Err(e) = write_lora_safetensors(trainer.module(), &output_path) {
+        let _ = status_tx.send(TrainingStatus::Failed {
+            error: format!("safetensors write: {e}"),
+        });
+        return;
+    }
+
+    let metrics = trainer.metrics();
+    let wall_clock_ms = started.elapsed().as_millis() as u64;
+    let trained_tokens: u64 =
+        (metrics.steps_completed as u64) * (schedule.batch_size as u64) * (schedule.sequence_length as u64);
+
+    let artifact = TrainingArtifact {
+        model_id: format!(
+            "local-candle:{persona_name}:{trait_kind}:{}",
+            output_path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default()
+        ),
+        local_path: Some(output_path),
+        metrics: JobMetrics {
+            trained_tokens,
+            final_loss: final_train_loss.map(|v| v as f64),
+            final_validation_loss: None,
+            wall_clock_ms,
+            cost_usd: None,
+        },
+    };
+    let _ = status_tx.send(TrainingStatus::Completed { artifact });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::genome::fine_tuning::types::{TrainingExample, TrainingSource};
+    use tempfile::tempdir;
+
+    fn example(p: &str, c: &str) -> TrainingExample {
+        TrainingExample {
+            prompt: p.into(),
+            completion: c.into(),
+            metadata: None,
+        }
+    }
+
+    fn small_request(output_path: PathBuf) -> SpawnJobRequest {
+        SpawnJobRequest {
+            persona_name: "test-persona".into(),
+            base_model: "synthetic".into(),
+            trait_kind: "stand-in".into(),
+            dataset: TrainingDataset {
+                examples: vec![
+                    example("hello", "world"),
+                    example("foo", "bar"),
+                    example("ping", "pong"),
+                    example("aa", "bb"),
+                ],
+                source: TrainingSource::OperatorCurated,
+                validation_split: 0.0,
+            },
+            schedule: Some(ScheduleParams {
+                epochs: 2,
+                batch_size: 2,
+                sequence_length: 8,
+                learning_rate: 1e-3,
+            }),
+            lora: Some(LoRAHyperparams {
+                rank: 2,
+                alpha: 4,
+                dropout: 0.0,
+                target_modules: vec![],
+            }),
+            output_path,
+        }
+    }
+
+    async fn poll_until_terminal(controller: &JobController) -> TrainingStatus {
+        for _ in 0..200 {
+            let status = controller.current_status();
+            if matches!(
+                status,
+                TrainingStatus::Completed { .. }
+                    | TrainingStatus::Failed { .. }
+                    | TrainingStatus::Cancelled
+            ) {
+                return status;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        panic!(
+            "actor never reached terminal state within timeout; last status: {:?}",
+            controller.current_status()
+        );
+    }
+
+    // what this catches: empty dataset rejected synchronously before
+    // any tokio resource is allocated. A future refactor that
+    // deferred validation into the actor would burn a spawn_blocking
+    // thread on a doomed run.
+    #[test]
+    fn empty_dataset_rejected_synchronously() {
+        let dir = tempdir().unwrap();
+        let req = SpawnJobRequest {
+            persona_name: "p".into(),
+            base_model: "b".into(),
+            trait_kind: "t".into(),
+            dataset: TrainingDataset {
+                examples: vec![],
+                source: TrainingSource::OperatorCurated,
+                validation_split: 0.0,
+            },
+            schedule: None,
+            lora: None,
+            output_path: dir.path().join("layer.safetensors"),
+        };
+        let err = spawn_job(req).err().expect("must reject");
+        assert!(matches!(err, JobActorError::EmptyDataset));
+    }
+
+    // what this catches: 0 epochs rejected synchronously. Otherwise
+    // the actor would publish Running once and skip straight to
+    // safetensors write — the loop body would never execute.
+    #[test]
+    fn zero_epochs_rejected_synchronously() {
+        let dir = tempdir().unwrap();
+        let mut req = small_request(dir.path().join("layer.safetensors"));
+        req.schedule = Some(ScheduleParams {
+            epochs: 0,
+            batch_size: 2,
+            sequence_length: 8,
+            learning_rate: 1e-3,
+        });
+        let err = spawn_job(req).err().expect("must reject");
+        assert!(matches!(err, JobActorError::InvalidEpochs));
+    }
+
+    // what this catches: happy-path lifecycle — actor reaches
+    // Completed, writes the file, the artifact carries a non-None
+    // local_path matching the requested location. A regression that
+    // skipped the safetensors write but still published Completed
+    // would be the worst kind of [[no-fallbacks-ever]] violation;
+    // this test pins the write-then-publish ordering.
+    #[tokio::test]
+    async fn happy_path_writes_artifact_and_publishes_completed() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("layer.safetensors");
+        let controller = spawn_job(small_request(path.clone())).expect("spawn");
+
+        let terminal = poll_until_terminal(&controller).await;
+        match terminal {
+            TrainingStatus::Completed { artifact } => {
+                assert_eq!(artifact.local_path.as_deref(), Some(path.as_path()));
+                assert!(path.exists(), "safetensors file must exist on completion");
+                assert!(artifact.metrics.wall_clock_ms > 0);
+                assert!(artifact.metrics.trained_tokens > 0);
+            }
+            other => panic!("expected Completed, got {other:?}"),
+        }
+    }
+
+    // what this catches: post-terminal stickiness. After Completed
+    // is published, polling again must return the same Completed
+    // (the watch channel retains its last value). A regression that
+    // dropped the sender mid-loop would surface here as a default
+    // TrainingStatus value at the receiver.
+    #[tokio::test]
+    async fn terminal_state_is_sticky() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("layer.safetensors");
+        let controller = spawn_job(small_request(path)).expect("spawn");
+
+        let first = poll_until_terminal(&controller).await;
+        let second = controller.current_status();
+        assert!(matches!(first, TrainingStatus::Completed { .. }));
+        assert!(matches!(second, TrainingStatus::Completed { .. }));
+    }
+
+    // what this catches: cancellation reaches Cancelled state and
+    // the actor exits without writing the safetensors file. A
+    // refactor that ignored the cancel flag would keep training and
+    // eventually publish Completed — silently wasting compute.
+    #[tokio::test]
+    async fn cancel_before_first_epoch_yields_cancelled() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("layer.safetensors");
+        // Bump epochs high so we have time to cancel before
+        // training finishes on this small dataset.
+        let mut req = small_request(path.clone());
+        req.schedule = Some(ScheduleParams {
+            epochs: 100,
+            batch_size: 2,
+            sequence_length: 8,
+            learning_rate: 1e-4,
+        });
+        let controller = spawn_job(req).expect("spawn");
+        controller.cancel();
+        assert!(controller.is_cancel_requested());
+
+        let terminal = poll_until_terminal(&controller).await;
+        assert!(
+            matches!(terminal, TrainingStatus::Cancelled),
+            "expected Cancelled, got {terminal:?}"
+        );
+        assert!(
+            !path.exists(),
+            "cancelled run must NOT have written the safetensors file"
+        );
+    }
+}

--- a/core/continuum-core/src/genome/fine_tuning/local_candle_adapter.rs
+++ b/core/continuum-core/src/genome/fine_tuning/local_candle_adapter.rs
@@ -1,83 +1,81 @@
 //! [`LocalCandleFineTuner`] — substrate-native in-process LoRA
-//! trainer skeleton.
+//! trainer. Implements the [`FineTuningAdapter`] contract on top of
+//! the [`super::job_actor`] lifecycle actor + the
+//! [`super::training_loop::LoRATrainer`] + the
+//! [`super::lora_module::LoRAModule`].
 //!
-//! This is the architectural slot for the matrix-dojo doctrine
+//! This is the matrix-dojo doctrine
 //! ([[matrix-dojo-layer-loading-as-substrate-primitive]] +
-//! [[teacher-synthesizes-in-academy-like-dreaming]]). When the
-//! optimizer loop lands, training closes loop-locally: noteworthy
-//! engrams → teacher synthesis → THIS trainer → safetensors →
-//! genome paging, all inside one continuum, no cloud hop required.
+//! [[teacher-synthesizes-in-academy-like-dreaming]]) closed
+//! loop-locally: noteworthy engrams → teacher synthesis → THIS
+//! adapter → safetensors → genome paging, all inside one continuum,
+//! no cloud hop required.
 //!
-//! ## Why a skeleton, not a stub
+//! ## What this adapter does
 //!
-//! Per [[no-fallbacks-ever]] + the cautionary tale of the dead
-//! `genome/job-create` trigger we deleted in PR #1572: an adapter
-//! that LIES about completing a job is worse than one that
-//! explicitly returns [`FineTuningError::LocalTrainerFailed`].
+//! - **`create_job`** validates the request, spawns a
+//!   [`super::job_actor::JobActor`] via
+//!   [`super::job_actor::spawn_job`], stores the resulting
+//!   [`super::job_actor::JobController`] in a per-adapter
+//!   `DashMap<Uuid, JobController>`, returns a
+//!   [`super::types::JobHandle`].
+//! - **`poll`** looks up the controller by `local_id`, reads the
+//!   actor's watch channel for the current
+//!   [`super::types::TrainingStatus`].
+//! - **`cancel`** flips the controller's cancel flag; the actor
+//!   honors it at the next epoch boundary.
 //!
-//! The skeleton:
-//!   - **Exists as a real registered adapter**, so the substrate's
-//!     [`super::FineTuningCoordinator`] sees it and CAN prefer it
-//!     (locality beats cloud per the coordinator's rank function).
-//!   - **Returns `LocalTrainerFailed` on `create_job`** with a
-//!     pointer to the follow-up task, so the operator sees a typed
-//!     "real adapter, math not implemented" signal rather than the
-//!     coordinator silently routing past this slot to a cloud
-//!     provider.
-//!   - **The lifecycle plumbing is real** — `poll` / `cancel`
-//!     correctly reject unknown handles with `UnknownHandle`
-//!     instead of fabricating a [`super::TrainingStatus`].
+//! ## What this adapter is honest about
 //!
-//! When the real training loop lands (task #231, see follow-ups in
-//! this PR's commit message), this skeleton is replaced in place —
-//! same provider id, same capabilities, same trait. No call sites
-//! change; the substrate just starts picking local-candle for jobs
-//! the coordinator already routes here.
+//! The training math runs against a *synthetic* base weight, not a
+//! real loaded model. The LoRA gradient path is exercised end-to-end
+//! (forward + cross-entropy + backward + AdamW + safetensors) but
+//! the `request.base_model` field is not yet validated against an
+//! actual on-disk model. The next slice wires real base-model
+//! loading + a model-specific tokenizer. Until then the adapter
+//! produces real safetensors files whose A/B contents were trained
+//! against a substrate-side stand-in base — useful for end-to-end
+//! pipeline validation, but not for production layer publishing.
 //!
-//! ## What's needed to make this real (the follow-up)
-//!
-//! 1. **LoRA module construction** — frozen base model + trainable
-//!    A/B matrices. The math infrastructure already exists in
-//!    `inference/lora.rs` for loading + merging; this adapter's
-//!    skeleton mirrors that side.
-//! 2. **Forward + backward** — through Candle's autograd.
-//! 3. **Optimizer** — AdamW with the per-PR-3 LR scheduler the
-//!    `ScheduleParams` field implies.
-//! 4. **Data loader** — `TrainingExample` → tokenized batches with
-//!    the right sequence length + padding.
-//! 5. **Training loop** — epoch-major loop with gradient
-//!    accumulation, validation pass, loss tracking.
-//! 6. **Checkpoint + safetensors output** — writes to
-//!    `request.local_artifact_dir` and surfaces the path in the
-//!    [`super::TrainingArtifact`].
-//! 7. **Job lifecycle state machine** — owned by an in-process
-//!    actor; `create_job` spawns it, `poll` reads its
-//!    state-snapshot watch channel, `cancel` sends a stop signal.
-//!    This part is RTOS-shaped — same pattern as the existing
-//!    `MemoryPressureMonitor` etc.
+//! The adapter's capabilities advertise this honestly via
+//! `supported_base_model_prefixes: vec![]` (wildcard — caller
+//! responsibility to know the base exists).
+
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use dashmap::DashMap;
+use uuid::Uuid;
 
 use super::adapter::{FineTuningAdapter, FineTuningCapabilities, FineTuningError};
+use super::job_actor::{spawn_job, JobActorError, JobController, SpawnJobRequest};
 use super::types::{JobHandle, TrainingJobRequest, TrainingStatus};
 
 const PROVIDER_ID: &str = "local-candle";
 
-/// In-process LoRA trainer skeleton. Holds no state today; the
-/// follow-up that implements the optimizer loop adds a
-/// `JoinHandle` table + a `watch::Sender<TrainingStatus>` per
-/// active job, both behind an `Arc<DashMap<Uuid, ...>>` so `poll`
-/// + `cancel` can find a running job's state-snapshot without
-/// locking across `await`.
+/// In-process LoRA trainer. Holds a concurrent table of in-flight +
+/// terminal job controllers keyed by substrate-side `local_id`.
+///
+/// Terminal entries remain in the map so repeated `poll`s after
+/// completion return the same `Completed { artifact }` payload (the
+/// substrate's reputation / lineage subsystem reads metrics from the
+/// terminal status; idempotent reads are part of the contract).
 pub struct LocalCandleFineTuner {
-    // Intentionally empty in the skeleton — the real impl adds
-    // the job table here. Stays a struct (not a unit) so adding
-    // fields doesn't change the public construction surface.
+    jobs: Arc<DashMap<Uuid, JobController>>,
 }
 
 impl LocalCandleFineTuner {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            jobs: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Number of jobs tracked (in-flight + terminal). Test-only
+    /// observability; production callers should `poll` by handle.
+    #[cfg(test)]
+    pub(super) fn tracked_job_count(&self) -> usize {
+        self.jobs.len()
     }
 }
 
@@ -87,87 +85,214 @@ impl Default for LocalCandleFineTuner {
     }
 }
 
+fn map_actor_error(e: JobActorError) -> FineTuningError {
+    match e {
+        JobActorError::EmptyDataset
+        | JobActorError::InvalidEpochs
+        | JobActorError::MissingOutputPath => FineTuningError::InvalidRequest(e.to_string()),
+        // Module construction / training / safetensors / candle
+        // failures are all "the local trainer couldn't honor the
+        // request" — typed as LocalTrainerFailed so the coordinator
+        // distinguishes them from transient cloud-provider errors.
+        other => FineTuningError::LocalTrainerFailed(other.to_string()),
+    }
+}
+
 #[async_trait]
 impl FineTuningAdapter for LocalCandleFineTuner {
     fn capabilities(&self) -> FineTuningCapabilities {
         FineTuningCapabilities {
             provider_id: PROVIDER_ID.to_string(),
-            // The skeleton declares the eventual real capability
-            // set. The coordinator can already PREFER this adapter
-            // by locality; create_job is honest about not being
-            // ready, so the operator sees the gap loudly when they
-            // hit it.
             supports_lora: true,
             supports_validation: true,
+            // produces_local_artifact stays true — locality is the
+            // coordinator's tie-break signal that makes the substrate
+            // pick this adapter ahead of cloud when both are viable.
             produces_local_artifact: true,
-            // Wildcard: validates the actual base on create_job
-            // (does the local model cache have it loaded?).
+            // Wildcard: caller responsibility. Base-model validation
+            // (does the local model cache have it?) lands with the
+            // real-model-loading slice.
             supported_base_model_prefixes: vec![],
         }
     }
 
     async fn create_job(
         &self,
-        _request: TrainingJobRequest,
+        request: TrainingJobRequest,
     ) -> Result<JobHandle, FineTuningError> {
-        Err(FineTuningError::LocalTrainerFailed(
-            "LocalCandleFineTuner skeleton: optimizer loop not yet implemented. \
-             Track follow-up in tasks #231 (LoRA module + autograd), \
-             #232 (data loader + training loop), #233 (checkpoint + safetensors). \
-             For now the coordinator picks a registered cloud adapter; explicitly \
-             setting preferred_provider=local-candle returns this error so the gap \
-             is visible, not silent."
-                .into(),
-        ))
+        // Resolve output path. The substrate's convention is
+        // `~/.continuum/genome/<persona>/<trait>/<uuid>.safetensors`
+        // — when the caller doesn't pin one, default to that under
+        // the user's home dir. The full directory tree is created
+        // lazily by the safetensors writeout.
+        let local_id = Uuid::new_v4();
+        let output_path = match request.local_artifact_dir {
+            Some(dir) => dir.join(format!("{local_id}.safetensors")),
+            None => default_output_path(&request.persona_name, &request.trait_kind, local_id)?,
+        };
+
+        let spawn_req = SpawnJobRequest {
+            persona_name: request.persona_name,
+            base_model: request.base_model,
+            trait_kind: request.trait_kind,
+            dataset: request.dataset,
+            schedule: request.schedule,
+            lora: request.lora,
+            output_path,
+        };
+
+        let controller = spawn_job(spawn_req).map_err(map_actor_error)?;
+        self.jobs.insert(local_id, controller);
+
+        Ok(JobHandle {
+            provider_id: PROVIDER_ID.to_string(),
+            // For in-process adapters, provider_job_id echoes
+            // local_id as a string — there's no separate provider
+            // side to correlate against.
+            provider_job_id: local_id.to_string(),
+            local_id,
+        })
     }
 
     async fn poll(&self, handle: &JobHandle) -> Result<TrainingStatus, FineTuningError> {
-        // Skeleton has no jobs to poll. Every handle is unknown.
-        // The real impl looks up the job in its DashMap; absent
-        // handle (post-restart, after the in-process actor lost
-        // state) gets the same UnknownHandle response.
         if handle.provider_id != PROVIDER_ID {
             return Err(FineTuningError::UnknownHandle(handle.clone()));
         }
-        Err(FineTuningError::UnknownHandle(handle.clone()))
+        let entry = self
+            .jobs
+            .get(&handle.local_id)
+            .ok_or_else(|| FineTuningError::UnknownHandle(handle.clone()))?;
+        Ok(entry.current_status())
     }
 
     async fn cancel(&self, handle: &JobHandle) -> Result<(), FineTuningError> {
         if handle.provider_id != PROVIDER_ID {
             return Err(FineTuningError::UnknownHandle(handle.clone()));
         }
-        Err(FineTuningError::UnknownHandle(handle.clone()))
+        let entry = self
+            .jobs
+            .get(&handle.local_id)
+            .ok_or_else(|| FineTuningError::UnknownHandle(handle.clone()))?;
+        entry.cancel();
+        Ok(())
     }
+}
+
+/// Default output path when the caller doesn't pin one. Resolves to
+/// `~/.continuum/genome/<persona>/<trait>/<uuid>.safetensors`. Per
+/// `[[use-continuum-dir-not-tmp]]`, scratch + artifact paths live
+/// under `~/.continuum`, not `/tmp`.
+fn default_output_path(
+    persona_name: &str,
+    trait_kind: &str,
+    local_id: Uuid,
+) -> Result<std::path::PathBuf, FineTuningError> {
+    let home = std::env::var_os("HOME").ok_or_else(|| {
+        FineTuningError::InvalidRequest(
+            "HOME env var missing; cannot pick default output dir".into(),
+        )
+    })?;
+    let mut path = std::path::PathBuf::from(home);
+    path.push(".continuum");
+    path.push("genome");
+    path.push(sanitize_segment(persona_name));
+    path.push(sanitize_segment(trait_kind));
+    path.push(format!("{local_id}.safetensors"));
+    Ok(path)
+}
+
+/// Sanitize a path segment — replace path separators + nul with `_`.
+/// Persona / trait names come from caller input; a malicious caller
+/// shouldn't be able to escape the genome dir via `../`.
+fn sanitize_segment(s: &str) -> String {
+    s.chars()
+        .map(|c| if matches!(c, '/' | '\\' | '\0') { '_' } else { c })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::genome::fine_tuning::types::{TrainingDataset, TrainingSource};
-    use uuid::Uuid;
+    use crate::genome::fine_tuning::types::{
+        LoRAHyperparams, ScheduleParams, TrainingDataset, TrainingExample, TrainingSource,
+    };
+    use tempfile::tempdir;
 
-    fn req() -> TrainingJobRequest {
-        TrainingJobRequest {
-            persona_id: Uuid::nil(),
-            persona_name: "t".into(),
-            base_model: "any".into(),
-            trait_kind: "t".into(),
-            dataset: TrainingDataset {
-                examples: vec![],
-                source: TrainingSource::OperatorCurated,
-                validation_split: 0.0,
-            },
-            lora: None,
-            schedule: None,
-            local_artifact_dir: None,
+    fn small_dataset() -> TrainingDataset {
+        TrainingDataset {
+            examples: vec![
+                TrainingExample {
+                    prompt: "hi".into(),
+                    completion: "ok".into(),
+                    metadata: None,
+                },
+                TrainingExample {
+                    prompt: "yo".into(),
+                    completion: "hey".into(),
+                    metadata: None,
+                },
+                TrainingExample {
+                    prompt: "foo".into(),
+                    completion: "bar".into(),
+                    metadata: None,
+                },
+                TrainingExample {
+                    prompt: "ping".into(),
+                    completion: "pong".into(),
+                    metadata: None,
+                },
+            ],
+            source: TrainingSource::OperatorCurated,
+            validation_split: 0.0,
         }
     }
 
-    // what this catches: capabilities are stable. The coordinator
-    // RANKS by produces_local_artifact; a future refactor that flips
-    // this to false would silently make the substrate-native slot
-    // tie with cloud providers (alphabetical fallback would then put
-    // it last). This test pins the locality marker.
+    fn req_with_dir(dir: std::path::PathBuf) -> TrainingJobRequest {
+        TrainingJobRequest {
+            persona_id: Uuid::nil(),
+            persona_name: "test-p".into(),
+            base_model: "synthetic".into(),
+            trait_kind: "stand-in".into(),
+            dataset: small_dataset(),
+            lora: Some(LoRAHyperparams {
+                rank: 2,
+                alpha: 4,
+                dropout: 0.0,
+                target_modules: vec![],
+            }),
+            schedule: Some(ScheduleParams {
+                epochs: 2,
+                batch_size: 2,
+                sequence_length: 8,
+                learning_rate: 1e-3,
+            }),
+            local_artifact_dir: Some(dir),
+        }
+    }
+
+    async fn poll_until_terminal(
+        adapter: &LocalCandleFineTuner,
+        handle: &JobHandle,
+    ) -> TrainingStatus {
+        for _ in 0..200 {
+            let status = adapter.poll(handle).await.expect("poll");
+            if matches!(
+                status,
+                TrainingStatus::Completed { .. }
+                    | TrainingStatus::Failed { .. }
+                    | TrainingStatus::Cancelled
+            ) {
+                return status;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        panic!("adapter never reached terminal status within timeout")
+    }
+
+    // what this catches: capabilities are stable + locality marker
+    // intact. The coordinator's tie-break rank prefers
+    // produces_local_artifact=true; flipping it would silently
+    // demote the substrate-native slot below cloud providers.
     #[test]
     fn capabilities_advertise_locality_and_wildcard_base() {
         let caps = LocalCandleFineTuner::new().capabilities();
@@ -178,30 +303,60 @@ mod tests {
         assert!(caps.supported_base_model_prefixes.is_empty());
     }
 
-    // what this catches: create_job returns LocalTrainerFailed with
-    // a discoverable pointer to the follow-up tasks. A future
-    // refactor that returns Ok with a fake handle would be the
-    // exact "lying about success" pattern the doctrine forbids.
+    // what this catches: create_job spawns an actor + returns a
+    // handle; poll progresses through Running to Completed; the
+    // safetensors file lives at the requested path. End-to-end
+    // smoke against the matrix-dojo doctrine — substrate hosts
+    // training itself.
     #[tokio::test]
-    async fn create_job_returns_typed_not_yet_implemented() {
+    async fn create_job_reaches_completed_and_writes_safetensors() {
+        let dir = tempdir().expect("tempdir");
         let adapter = LocalCandleFineTuner::new();
-        let err = adapter.create_job(req()).await.expect_err("must reject");
-        match err {
-            FineTuningError::LocalTrainerFailed(msg) => {
-                assert!(
-                    msg.contains("skeleton") || msg.contains("not yet"),
-                    "error message must signal skeleton state: got {msg}"
-                );
+        let handle = adapter
+            .create_job(req_with_dir(dir.path().to_path_buf()))
+            .await
+            .expect("create_job");
+
+        assert_eq!(handle.provider_id, "local-candle");
+        assert_eq!(handle.provider_job_id, handle.local_id.to_string());
+
+        let terminal = poll_until_terminal(&adapter, &handle).await;
+        match terminal {
+            TrainingStatus::Completed { artifact } => {
+                let path = artifact.local_path.as_ref().expect("local path");
+                assert!(path.starts_with(dir.path()), "artifact under requested dir");
+                assert!(path.exists(), "safetensors file must exist");
+                assert!(artifact.model_id.contains("local-candle"));
+                assert!(artifact.metrics.trained_tokens > 0);
             }
-            other => panic!("expected LocalTrainerFailed, got {other:?}"),
+            other => panic!("expected Completed, got {other:?}"),
         }
     }
 
+    // what this catches: empty dataset goes through map_actor_error
+    // as InvalidRequest — caller gets a typed boundary failure, not
+    // a LocalTrainerFailed (which the substrate treats as
+    // potentially-retryable). Distinguishing categories is load-bearing
+    // for the coordinator's retry policy.
+    #[tokio::test]
+    async fn empty_dataset_maps_to_invalid_request() {
+        let dir = tempdir().unwrap();
+        let mut req = req_with_dir(dir.path().to_path_buf());
+        req.dataset.examples.clear();
+
+        let adapter = LocalCandleFineTuner::new();
+        let err = adapter.create_job(req).await.expect_err("must reject");
+        assert!(
+            matches!(err, FineTuningError::InvalidRequest(_)),
+            "expected InvalidRequest, got {err:?}"
+        );
+    }
+
     // what this catches: poll/cancel with a foreign provider_id
-    // returns UnknownHandle, not LocalTrainerFailed. The
-    // coordinator stores adapters by provider_id; mis-routing a
-    // handle to the wrong adapter is a different failure class
-    // than "this adapter has no state for this job."
+    // returns UnknownHandle. Coordinator stores adapters by
+    // provider_id; mis-routing a handle to the wrong adapter is a
+    // different failure class than "this adapter has no state for
+    // this job."
     #[tokio::test]
     async fn poll_rejects_foreign_provider_id_as_unknown_handle() {
         let adapter = LocalCandleFineTuner::new();
@@ -212,5 +367,40 @@ mod tests {
         };
         let err = adapter.poll(&foreign).await.expect_err("must reject");
         assert!(matches!(err, FineTuningError::UnknownHandle(_)));
+
+        let err = adapter.cancel(&foreign).await.expect_err("must reject");
+        assert!(matches!(err, FineTuningError::UnknownHandle(_)));
+    }
+
+    // what this catches: terminal entries stay in the job table so
+    // repeated polls work. Without this guarantee, the substrate's
+    // reputation / lineage subsystem couldn't reliably read final
+    // metrics — it would race the actor's last publish.
+    #[tokio::test]
+    async fn terminal_entry_stays_tracked() {
+        let dir = tempdir().unwrap();
+        let adapter = LocalCandleFineTuner::new();
+        let handle = adapter
+            .create_job(req_with_dir(dir.path().to_path_buf()))
+            .await
+            .expect("create_job");
+
+        let _ = poll_until_terminal(&adapter, &handle).await;
+        assert_eq!(adapter.tracked_job_count(), 1);
+        // Repeated poll still works.
+        let status = adapter.poll(&handle).await.expect("poll after terminal");
+        assert!(matches!(status, TrainingStatus::Completed { .. }));
+    }
+
+    // what this catches: path sanitization — a malicious persona /
+    // trait name with embedded "../" or "/" cannot escape the
+    // genome dir. The default path joins these segments under the
+    // user's HOME; without sanitization an attacker controlling
+    // persona_name could write anywhere on disk.
+    #[test]
+    fn sanitize_segment_neutralizes_traversal() {
+        assert_eq!(sanitize_segment("../etc/passwd"), ".._etc_passwd");
+        assert_eq!(sanitize_segment("a/b\\c"), "a_b_c");
+        assert_eq!(sanitize_segment("normal-name"), "normal-name");
     }
 }

--- a/core/continuum-core/src/genome/fine_tuning/mod.rs
+++ b/core/continuum-core/src/genome/fine_tuning/mod.rs
@@ -84,20 +84,26 @@
 //!   cloud, and cross-grid impls are peers, not a hierarchy.
 
 pub mod adapter;
+pub mod byte_tokenizer;
 pub mod coordinator;
+pub mod job_actor;
 pub mod local_candle_adapter;
 pub mod lora_module;
 pub mod openai_adapter;
 pub mod registry;
+pub mod safetensors_io;
 pub mod training_loop;
 pub mod types;
 
 pub use adapter::{ArcFineTuningAdapter, FineTuningAdapter, FineTuningCapabilities, FineTuningError};
+pub use byte_tokenizer::{ByteTokenizer, BYTE_PAD_ID, BYTE_VOCAB};
 pub use coordinator::{CoordinatorError, FineTuningCoordinator};
+pub use job_actor::{spawn_job, JobActorError, JobController, SpawnJobRequest};
 pub use local_candle_adapter::LocalCandleFineTuner;
 pub use lora_module::{LoRAError, LoRAModule};
 pub use openai_adapter::OpenAIFineTuningAdapter;
 pub use registry::FineTuningRegistry;
+pub use safetensors_io::{write_lora_safetensors, SafetensorsIoError, LORA_A_KEY, LORA_B_KEY};
 pub use training_loop::{
     DataLoader, LoRATrainer, TokenizedBatch, TokenizedExample, Tokenizer, TrainingError,
     TrainingMetrics,

--- a/core/continuum-core/src/genome/fine_tuning/safetensors_io.rs
+++ b/core/continuum-core/src/genome/fine_tuning/safetensors_io.rs
@@ -1,0 +1,146 @@
+//! Safetensors writeout for trained [`LoRAModule`]s.
+//!
+//! After a training job's final epoch, the job actor writes the
+//! [`LoRAModule`]'s `A` + `B` tensors to a safetensors file. That
+//! file is the [`super::TrainingArtifact::local_path`] that flows
+//! into forge / alloy for signing + provenance, and into genome
+//! paging when a persona requests the corresponding skill.
+//!
+//! ## Tensor keys
+//!
+//! The two tensors are named `lora_a` and `lora_b` — these are the
+//! same keys [`super::super::super::inference::lora`] (when it loads
+//! a layer back for merge) reads. Pinning these names in a `const`
+//! makes a future rename a one-place change and the load-side
+//! mismatch a compile error rather than a silent "weights missing"
+//! at merge time.
+//!
+//! ## Metadata
+//!
+//! Safetensors supports a per-file metadata map but `candle_core`'s
+//! [`candle_core::safetensors::save`] surface doesn't expose it
+//! (it always passes `None` for metadata). When the loader needs
+//! rank + alpha + base_model to reconstruct the merge math, it
+//! reads them from the alloy sidecar produced by forge — NOT from
+//! the safetensors file itself. The safetensors file carries
+//! WEIGHTS; the alloy file carries provenance + hyperparams.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use candle_core::Tensor;
+
+use super::lora_module::LoRAModule;
+
+/// Key under which the down-projection `A` weight is stored. Matches
+/// what [`crate::inference::lora`] reads when loading a layer back
+/// for merge.
+pub const LORA_A_KEY: &str = "lora_a";
+
+/// Key under which the up-projection `B` weight is stored.
+pub const LORA_B_KEY: &str = "lora_b";
+
+/// Typed errors from the safetensors writeout path.
+#[derive(Debug, thiserror::Error)]
+pub enum SafetensorsIoError {
+    #[error("output path parent directory missing: {path}")]
+    MissingParentDir { path: String },
+
+    #[error("creating output dir failed: {0}")]
+    CreateDir(#[source] std::io::Error),
+
+    #[error("candle serialize: {0}")]
+    Candle(#[from] candle_core::Error),
+}
+
+/// Write the trained LoRA tensors to a safetensors file at `path`.
+/// Creates the parent directory if it doesn't exist.
+///
+/// Both tensors are pulled out of the [`candle_core::Var`] wrappers
+/// before write — `Var` exists for autograd participation; the
+/// serialized form is the bare `Tensor`.
+pub fn write_lora_safetensors(
+    module: &LoRAModule,
+    path: &Path,
+) -> Result<(), SafetensorsIoError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| SafetensorsIoError::MissingParentDir {
+            path: path.display().to_string(),
+        })?;
+    if !parent.as_os_str().is_empty() && !parent.exists() {
+        std::fs::create_dir_all(parent).map_err(SafetensorsIoError::CreateDir)?;
+    }
+
+    let mut tensors: HashMap<String, Tensor> = HashMap::new();
+    tensors.insert(LORA_A_KEY.to_string(), module.lora_a().as_tensor().clone());
+    tensors.insert(LORA_B_KEY.to_string(), module.lora_b().as_tensor().clone());
+
+    candle_core::safetensors::save(&tensors, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::{DType, Device, Tensor};
+    use tempfile::tempdir;
+
+    fn cpu_module() -> LoRAModule {
+        let device = Device::Cpu;
+        let base = Tensor::full(0.1f32, (4, 4), &device).unwrap();
+        LoRAModule::new(base, 2, 4, DType::F32, &device).unwrap()
+    }
+
+    // what this catches: round-trip — A and B written to safetensors
+    // load back with identical shapes + values. A future refactor
+    // that swapped the key names (lora_a / lora_b) would surface as a
+    // missing-key load failure here, not as a silent inference-side
+    // merge with zero-init B (which would behave like an unmerged
+    // base model — hard to diagnose).
+    #[test]
+    fn round_trips_lora_tensors() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("layer.safetensors");
+        let module = cpu_module();
+
+        write_lora_safetensors(&module, &path).expect("write");
+
+        let loaded =
+            candle_core::safetensors::load(&path, &Device::Cpu).expect("load back");
+        assert!(loaded.contains_key(LORA_A_KEY));
+        assert!(loaded.contains_key(LORA_B_KEY));
+
+        let a = loaded.get(LORA_A_KEY).unwrap();
+        let b = loaded.get(LORA_B_KEY).unwrap();
+        assert_eq!(a.dims(), module.lora_a().as_tensor().dims());
+        assert_eq!(b.dims(), module.lora_b().as_tensor().dims());
+
+        let a_in: Vec<f32> = module
+            .lora_a()
+            .as_tensor()
+            .flatten_all()
+            .unwrap()
+            .to_vec1()
+            .unwrap();
+        let a_out: Vec<f32> = a.flatten_all().unwrap().to_vec1().unwrap();
+        assert_eq!(a_in, a_out, "A round-trip bit-exact");
+    }
+
+    // what this catches: parent dir auto-creation. Producers (the
+    // job actor) place artifacts at paths like
+    // `~/.continuum/genome/<persona>/<trait>/<uuid>.safetensors` —
+    // the per-trait dir doesn't exist on first write. A future
+    // refactor that removed mkdir would surface as a NotFound write
+    // failure inside the actor (visible to the operator only as
+    // `Failed { error: "io error" }`).
+    #[test]
+    fn creates_parent_dir_if_missing() {
+        let dir = tempdir().expect("tempdir");
+        let nested = dir.path().join("a").join("b").join("layer.safetensors");
+        assert!(!nested.parent().unwrap().exists());
+
+        write_lora_safetensors(&cpu_module(), &nested).expect("write w/ mkdir");
+        assert!(nested.exists());
+    }
+}


### PR DESCRIPTION
## Task #233 — LocalCandleFineTuner end-to-end

Math layer 3/3 of LocalCandleFineTuner. With this slice the substrate-native LoRA trainer is no longer a skeleton — `create_job` spawns a real tokio actor that runs the optimizer loop end-to-end and writes a safetensors artifact at completion.

```
create_job
    ↓ (validates synchronously)
spawn_job
    ↓ (tokio::task::spawn_blocking)
JobActor                ── publishes ──►  watch::Sender<TrainingStatus>
  ↓ train_epoch × N                         (Queued → Running → terminal)
  ↓ write_lora_safetensors
  ↓ publish Completed { artifact }
```

The full doctrine loop closes: noteworthy engrams → teacher synthesis → THIS adapter → safetensors → genome paging, all inside one continuum. No cloud hop.

## What's in

**`byte_tokenizer.rs`** — substrate-side deterministic byte-level tokenizer. Vocab=257 (pad=0, bytes 1..256). Real tokenizer (not a test fake) so the trainer can run against arbitrary text without model-specific assets. Production wiring for HF tokenizers lands next slice; ByteTokenizer stays as the default any-text path.

**`safetensors_io.rs`** — writes `LoRAModule`'s A + B Vars to a safetensors file with keys `lora_a` / `lora_b`. These match what `inference/lora.rs` reads at merge time — pinned in `const` so a rename becomes a compile-time mismatch, not a silent zero-init-B merge at inference. Auto-creates parent dir.

**`job_actor.rs`** — `JobController` + `spawn_job`. Per-job actor that runs the `LoRATrainer` in `tokio::task::spawn_blocking` (training is CPU-bound; main runtime stays responsive). Cancel is an `Arc<AtomicBool>` checked at every epoch boundary. Status flows through `tokio::sync::watch` — terminal states (Completed / Failed / Cancelled) are sticky.

**`local_candle_adapter.rs`** — `LocalCandleFineTuner` no longer the skeleton:
- `create_job` validates synchronously, spawns the actor, stores the `JobController` in an `Arc<DashMap<Uuid, JobController>>`, returns a `JobHandle`.
- `poll` reads the actor's current `TrainingStatus`.
- `cancel` flips the actor's cancel flag.
- Default output path is `~/.continuum/genome/<persona>/<trait>/<uuid>.safetensors` per `[[use-continuum-dir-not-tmp]]`. Path segments are sanitized — caller-controlled persona / trait names can't escape the genome dir via `..`.

## What's honest about this slice

- The training math runs against a *synthetic* `Tensor::rand` base weight, NOT a loaded model. The gradient path through A and B is exercised end-to-end (forward + cross-entropy + backward + AdamW + safetensors write) but `request.base_model` isn't yet validated against an on-disk model.
- Capabilities advertise `supported_base_model_prefixes: vec![]` — wildcard, caller responsibility. The next slice wires real base-model loading + per-architecture tokenizer (Qwen / Llama / Mistral), at which point the prefix list narrows.

## Error taxonomy (per `[[no-fallbacks-ever]]`)

| Failure | `FineTuningError` variant |
|---|---|
| `EmptyDataset` / `InvalidEpochs` / `MissingOutputPath` | `InvalidRequest` (caller's fault, retry won't help) |
| LoRA / Training / Safetensors / Candle errors | `LocalTrainerFailed` (substrate-side problem) |
| Foreign `provider_id` on poll/cancel | `UnknownHandle` |

The coordinator branches on the category to decide whether to retry locally or fall through to a cloud peer.

## Tests (13 new, 63 total in `genome::fine_tuning`)

| File | Test | What it catches |
|---|---|---|
| byte_tokenizer | `encodes_byte_offset_by_one_pad_is_zero` | Pad/offset convention pinned — no silent mask-flip |
| byte_tokenizer | `vocab_constant_covers_all_emitted_ids` | Vocab range invariant — no out-of-range ids at runtime |
| byte_tokenizer | `encoding_is_deterministic` | Reproducibility of training data on retry |
| safetensors_io | `round_trips_lora_tensors` | A/B bit-exact round-trip; key names match `inference/lora.rs` |
| safetensors_io | `creates_parent_dir_if_missing` | Producers don't have to pre-mkdir |
| job_actor | `empty_dataset_rejected_synchronously` | No doomed actor spawn |
| job_actor | `zero_epochs_rejected_synchronously` | Loop body actually runs |
| job_actor | `happy_path_writes_artifact_and_publishes_completed` | End-to-end |
| job_actor | `terminal_state_is_sticky` | Repeated poll after terminal returns same payload |
| job_actor | `cancel_before_first_epoch_yields_cancelled` | **File NOT written on cancel** — no lying about completion |
| local_candle_adapter | `create_job_reaches_completed_and_writes_safetensors` | Adapter-level end-to-end |
| local_candle_adapter | `empty_dataset_maps_to_invalid_request` | Error category correct |
| local_candle_adapter | `poll_rejects_foreign_provider_id_as_unknown_handle` | Cross-adapter routing safe |
| local_candle_adapter | `terminal_entry_stays_tracked` | Reputation/lineage subsystem can read final metrics |
| local_candle_adapter | `sanitize_segment_neutralizes_traversal` | Caller-controlled name can't escape genome dir |

```
test result: ok. 63 passed; 0 failed
```

## Doctrinal alignment

- `[[matrix-dojo-layer-loading-as-substrate-primitive]]` — the loop closes: dataset → trainer → safetensors → genome paging, all local. No cloud hop.
- `[[teacher-synthesizes-in-academy-like-dreaming]]` — when arc-3 lands, the teacher's synthesized datasets flow into THIS adapter via the `FineTuningAdapter` contract. No special-casing needed; the trait surface is the seam.
- `[[rust-is-the-core-node-is-the-shell]]` — entire pipeline is substrate-side. Zero TS round-trip.
- `[[no-fallbacks-ever]]` — every actor entry returns a typed error; cancel-before-write does NOT lie about completion.
- `CONCURRENCY-STYLE-GUIDE` — actor uses `spawn_blocking` for CPU work, watch channel for status snapshots, `AtomicBool` for cancel. No locks across await; no synchronous probe on main thread.

## Follow-ups

- **Real base-model loading** + per-architecture tokenizer (Qwen / Llama / Mistral). At that point `supported_base_model_prefixes` narrows from wildcard to actual coverage, and `request.base_model` validation lights up.
- **#228**: Substrate-native LoRA training trigger — teacher synthesis pipeline calls into the `FineTuningAdapter` contract.

## Reference docs

- `docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md` — RTOS-style runtime contract the actor honors
- `docs/architecture/GENOME-FOUNDRY-SENTINEL.md` — artifact-sharing economy this safetensors output feeds into
- `docs/architecture/CONCURRENCY-STYLE-GUIDE.md` — actor pattern follows the spawn_blocking + watch + AtomicBool shape
