### PR TITLE
fix(genome): Fix-2 — honest metrics + RecordingFineTuningAdapter conservation test (task #237)

### DIFF
--- a/core/continuum-core/src/genome/fine_tuning/job_actor.rs
+++ b/core/continuum-core/src/genome/fine_tuning/job_actor.rs
@@ -345,8 +345,18 @@ fn run_actor(
 
     let metrics = trainer.metrics();
     let wall_clock_ms = started.elapsed().as_millis() as u64;
-    let trained_tokens: u64 =
-        (metrics.steps_completed as u64) * (schedule.batch_size as u64) * (schedule.sequence_length as u64);
+    // Honest count of gradient-bearing tokens consumed. Per
+    // Reviewer 1's BLOCK M1: the previous `steps × batch × seq_len`
+    // formula inflated this by ~seq_len× in the stand-in path
+    // because the stand-in trains on one target per sample, not
+    // seq_len. The actor now reads the count accumulated inside
+    // `LoRATrainer::train_step` (which counts non-pad first-targets
+    // in the standin; will become attention_mask.sum() in
+    // production wiring). The metric thus reflects what actually
+    // flowed through gradient, not a schedule-derived guess. This
+    // feeds the alloy provenance unmodified — honest provenance
+    // per [[forge-alloy-secures-commodity-zero-trust-plus-reputation]].
+    let trained_tokens: u64 = metrics.gradient_tokens_consumed;
 
     let artifact = TrainingArtifact {
         model_id: format!(

--- a/core/continuum-core/src/genome/fine_tuning/mod.rs
+++ b/core/continuum-core/src/genome/fine_tuning/mod.rs
@@ -91,6 +91,8 @@ pub mod local_candle_adapter;
 pub mod lora_module;
 pub mod openai_adapter;
 pub mod registry;
+#[cfg(any(test, feature = "test-fixtures"))]
+pub mod recording_adapter;
 pub mod safetensors_io;
 pub mod training_loop;
 pub mod types;
@@ -103,6 +105,10 @@ pub use local_candle_adapter::{LocalCandleFineTuner, SYNTHETIC_BASE_PREFIX};
 pub use lora_module::{LoRAError, LoRAModule};
 pub use openai_adapter::OpenAIFineTuningAdapter;
 pub use registry::FineTuningRegistry;
+#[cfg(any(test, feature = "test-fixtures"))]
+pub use recording_adapter::{
+    RecordingFineTuningAdapter, RECORDING_BASE_PREFIX, RECORDING_PROVIDER_ID,
+};
 pub use safetensors_io::{write_lora_safetensors, SafetensorsIoError, LORA_A_KEY, LORA_B_KEY};
 pub use training_loop::{
     DataLoader, LoRATrainer, TokenizedBatch, TokenizedExample, Tokenizer, TrainingError,

--- a/core/continuum-core/src/genome/fine_tuning/recording_adapter.rs
+++ b/core/continuum-core/src/genome/fine_tuning/recording_adapter.rs
@@ -1,0 +1,244 @@
+//! [`RecordingFineTuningAdapter`] — canonical test fixture that
+//! captures every `TrainingJobRequest` dispatched to it.
+//!
+//! Gated behind `#[cfg(any(test, feature = "test-fixtures"))]` per
+//! CLAUDE.md's test-discipline doctrine: mock / stub / fake adapters
+//! are NEVER linked into production binaries. The cargo feature is
+//! the contract.
+//!
+//! ## Why this exists as substrate fixture vs inline test stub
+//!
+//! Before this fixture: every test that needed to verify "did the
+//! trigger actually dispatch the examples I submitted?" had to roll
+//! its own stub adapter inline. The previous VDD conservation test
+//! in `modules::training_trigger::tests::vdd` asserted
+//! `trained_tokens > 0` as a proxy for conservation — but that's
+//! tautological (`trained_tokens` is a function of schedule, not
+//! example count) and Reviewer 1's BLOCK M2 flagged it as such.
+//!
+//! The real conservation invariant is: "every example I submit
+//! flows through dispatch EXACTLY ONCE, in order, with no drops or
+//! duplicates." That requires capturing the dispatched
+//! `TrainingDataset` and asserting it equals the submitted set.
+//! Hence this fixture.
+//!
+//! ## Why it's canonical (single fixture per concern)
+//!
+//! Per the test-discipline rules: "Reusable fixtures live in one
+//! place per concern. `HeuristicInferenceAdapter` is the adapter
+//! fixture. `RecordingRagSource` / `ReplayRagSource` are the RAG
+//! fixtures. Don't write a parallel `MockInferenceAdapter` in your
+//! test file." `RecordingFineTuningAdapter` is the
+//! `FineTuningAdapter` fixture. Future tests that need to capture
+//! dispatched fine-tuning requests import this one — they don't
+//! roll a parallel stub.
+//!
+//! ## Future use beyond M2
+//!
+//! - Fix-3's deterministic Notify-based concurrency test (the C1/C2
+//!   race that the smoke-level stress test couldn't force) plugs a
+//!   `tokio::sync::Notify` into this fixture's `create_job` so the
+//!   test can pause dispatch deterministically while a contending
+//!   submit lands.
+//! - The teacher-synthesis slice (#228 next step) uses this fixture
+//!   to verify the curated examples flowing OUT of teacher synthesis
+//!   land in the trigger's submit path correctly.
+
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use super::adapter::{FineTuningAdapter, FineTuningCapabilities, FineTuningError};
+use super::types::{
+    JobHandle, JobMetrics, TrainingArtifact, TrainingJobRequest, TrainingStatus,
+};
+
+/// Provider id this fixture advertises. Tests using this fixture
+/// register it with this id so the coordinator picks it
+/// deterministically over LocalCandleFineTuner.
+pub const RECORDING_PROVIDER_ID: &str = "recording-test-fixture";
+
+/// Base-model prefix this fixture matches. Tests using this fixture
+/// submit with `base_model` starting with this prefix so coordinator
+/// routing is deterministic.
+pub const RECORDING_BASE_PREFIX: &str = "recording-test";
+
+/// Test fixture: a `FineTuningAdapter` that captures every job
+/// request it receives and returns a fake `JobHandle` immediately.
+///
+/// `Clone` because the typical test pattern is to share the
+/// captures across (a) the registry registration site and (b) the
+/// test body that reads them after the trigger fires.
+#[derive(Clone)]
+pub struct RecordingFineTuningAdapter {
+    captures: Arc<StdMutex<Vec<TrainingJobRequest>>>,
+}
+
+impl RecordingFineTuningAdapter {
+    pub fn new() -> Self {
+        Self {
+            captures: Arc::new(StdMutex::new(Vec::new())),
+        }
+    }
+
+    /// Shared handle to the captures vector. Use this on the test
+    /// body to read what was dispatched.
+    pub fn captures(&self) -> Arc<StdMutex<Vec<TrainingJobRequest>>> {
+        self.captures.clone()
+    }
+
+    /// Helper: number of jobs captured so far.
+    pub fn captured_job_count(&self) -> usize {
+        self.captures.lock().unwrap().len()
+    }
+
+    /// Helper: total examples across every captured job. Tests
+    /// asserting end-to-end conservation use this to check the SUM
+    /// matches what was submitted.
+    pub fn captured_example_count(&self) -> usize {
+        self.captures
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|req| req.dataset.examples.len())
+            .sum()
+    }
+}
+
+impl Default for RecordingFineTuningAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl FineTuningAdapter for RecordingFineTuningAdapter {
+    fn capabilities(&self) -> FineTuningCapabilities {
+        FineTuningCapabilities {
+            provider_id: RECORDING_PROVIDER_ID.to_string(),
+            supports_lora: true,
+            supports_validation: false,
+            // produces_local_artifact: true so the coordinator's
+            // locality tie-break picks this fixture ahead of any
+            // co-registered cloud adapter in tests.
+            produces_local_artifact: true,
+            supported_base_model_prefixes: vec![RECORDING_BASE_PREFIX.to_string()],
+        }
+    }
+
+    async fn create_job(
+        &self,
+        request: TrainingJobRequest,
+    ) -> Result<JobHandle, FineTuningError> {
+        self.captures.lock().unwrap().push(request.clone());
+        Ok(JobHandle {
+            provider_id: RECORDING_PROVIDER_ID.to_string(),
+            provider_job_id: format!("recording-{}", Uuid::new_v4()),
+            local_id: Uuid::new_v4(),
+        })
+    }
+
+    async fn poll(&self, handle: &JobHandle) -> Result<TrainingStatus, FineTuningError> {
+        Ok(TrainingStatus::Completed {
+            artifact: TrainingArtifact {
+                model_id: handle.provider_job_id.clone(),
+                local_path: None,
+                metrics: JobMetrics::default(),
+            },
+        })
+    }
+
+    async fn cancel(&self, _handle: &JobHandle) -> Result<(), FineTuningError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::genome::fine_tuning::types::{
+        TrainingDataset, TrainingExample, TrainingSource,
+    };
+
+    fn ex(p: &str, c: &str) -> TrainingExample {
+        TrainingExample {
+            prompt: p.into(),
+            completion: c.into(),
+            metadata: None,
+        }
+    }
+
+    fn req(prompt: &str) -> TrainingJobRequest {
+        TrainingJobRequest {
+            persona_id: Uuid::nil(),
+            persona_name: "t".into(),
+            base_model: "recording-test".into(),
+            trait_kind: "t".into(),
+            dataset: TrainingDataset {
+                examples: vec![ex(prompt, "c")],
+                source: TrainingSource::OperatorCurated,
+                validation_split: 0.0,
+            },
+            lora: None,
+            schedule: None,
+            local_artifact_dir: None,
+        }
+    }
+
+    // what this catches: the fixture captures EVERY create_job call
+    // and exposes them via captures() in the order they were
+    // submitted. Downstream consumers (the conservation VDD test in
+    // training_trigger) depend on this ordering to verify "no
+    // examples lost or reordered across the boundary."
+    #[tokio::test]
+    async fn captures_jobs_in_submission_order() {
+        let adapter = RecordingFineTuningAdapter::new();
+        let _ = adapter.create_job(req("first")).await.unwrap();
+        let _ = adapter.create_job(req("second")).await.unwrap();
+        let _ = adapter.create_job(req("third")).await.unwrap();
+
+        let captures = adapter.captures();
+        let guard = captures.lock().unwrap();
+        assert_eq!(guard.len(), 3);
+        assert_eq!(guard[0].dataset.examples[0].prompt, "first");
+        assert_eq!(guard[1].dataset.examples[0].prompt, "second");
+        assert_eq!(guard[2].dataset.examples[0].prompt, "third");
+    }
+
+    // what this catches: capabilities advertise EXACTLY the
+    // recording-test prefix so coordinator routing in tests is
+    // deterministic. A regression flipping the prefix or adding a
+    // wildcard would make co-registered adapters in tests
+    // non-deterministic.
+    #[test]
+    fn capabilities_advertise_recording_prefix_only() {
+        let caps = RecordingFineTuningAdapter::new().capabilities();
+        assert_eq!(caps.provider_id, RECORDING_PROVIDER_ID);
+        assert_eq!(
+            caps.supported_base_model_prefixes,
+            vec![RECORDING_BASE_PREFIX.to_string()]
+        );
+        assert!(caps.produces_local_artifact);
+        assert!(caps.supports_lora);
+    }
+
+    // what this catches: captured_example_count sums across all
+    // captured jobs — used by the conservation VDD test as the
+    // "dispatched" side of the count vs "submitted" comparison.
+    #[tokio::test]
+    async fn captured_example_count_sums_across_jobs() {
+        let adapter = RecordingFineTuningAdapter::new();
+        let mut req_a = req("a");
+        req_a.dataset.examples = vec![ex("a-1", "x"), ex("a-2", "x"), ex("a-3", "x")];
+        let mut req_b = req("b");
+        req_b.dataset.examples = vec![ex("b-1", "y"), ex("b-2", "y")];
+
+        let _ = adapter.create_job(req_a).await.unwrap();
+        let _ = adapter.create_job(req_b).await.unwrap();
+
+        assert_eq!(adapter.captured_job_count(), 2);
+        assert_eq!(adapter.captured_example_count(), 5);
+    }
+}

--- a/core/continuum-core/src/genome/fine_tuning/recording_adapter.rs
+++ b/core/continuum-core/src/genome/fine_tuning/recording_adapter.rs
@@ -85,6 +85,18 @@ impl RecordingFineTuningAdapter {
 
     /// Shared handle to the captures vector. Use this on the test
     /// body to read what was dispatched.
+    ///
+    /// ## Concurrency note
+    ///
+    /// `create_job` pushes via `Arc<StdMutex<Vec<_>>>::lock().push()`.
+    /// Under concurrent dispatches the push order reflects mutex-
+    /// acquisition order, NOT caller spawn order. Serial tests can
+    /// rely on order; concurrent tests should use set-membership
+    /// assertions (HashSet of prompts) or have the caller embed a
+    /// sequence number in the submitted request. The
+    /// `concurrent_submits_to_same_key_serialize_without_loss_stress`
+    /// test in training_trigger.rs::stress demonstrates the
+    /// set-membership pattern.
     pub fn captures(&self) -> Arc<StdMutex<Vec<TrainingJobRequest>>> {
         self.captures.clone()
     }

--- a/core/continuum-core/src/genome/fine_tuning/training_loop.rs
+++ b/core/continuum-core/src/genome/fine_tuning/training_loop.rs
@@ -116,14 +116,39 @@ pub struct TokenizedExample {
 /// One batch of tokenized examples, padded to the same length.
 /// Tensors live on the configured [`Device`]. Used as the input to
 /// [`LoRATrainer::train_step`].
+///
+/// ## Two distinct mask fields
+///
+/// The split between `attention_mask` and `target_mask` matters and
+/// they are NOT interchangeable. Reviewer-caught semantic-drift bug
+/// (PR #1581 round 1) shipped a metric that used `attention_mask`
+/// when it should have used `target_mask` — because `target_ids` are
+/// `input_ids` shifted left by 1, the two masks differ by one
+/// position. A 1-byte ByteTokenizer example whose first INPUT is
+/// non-pad but whose first TARGET IS pad was being counted as
+/// gradient-bearing. The two fields enforce the distinction
+/// structurally.
 #[derive(Debug, Clone)]
 pub struct TokenizedBatch {
-    /// `[batch_size, sequence_length]` token ids.
+    /// `[batch_size, sequence_length]` token ids fed into the
+    /// (eventual) embedding lookup. Pad positions hold the
+    /// tokenizer's pad id (typically 0).
     pub input_ids: Tensor,
-    /// `[batch_size, sequence_length]` target ids (input_ids shifted left).
+    /// `[batch_size, sequence_length]` target ids (input_ids shifted
+    /// left by 1 — standard causal LM target shape).
     pub target_ids: Tensor,
-    /// `[batch_size, sequence_length]` 1/0 mask; 1 for real, 0 for pad.
+    /// `[batch_size, sequence_length]` 1/0 mask aligned to INPUT
+    /// positions: 1 for real input, 0 for pad. Use this for
+    /// transformer attention masking (when real wiring lands).
     pub attention_mask: Tensor,
+    /// `[batch_size, sequence_length]` 1/0 mask aligned to TARGET
+    /// positions: 1 for real target, 0 for pad target. Use this for
+    /// loss/metric masking. Distinct from `attention_mask` because
+    /// targets are input_ids shifted by 1: a sample whose last real
+    /// input is at position k has its last real TARGET at position
+    /// k-1. The training loop uses `target_mask.narrow(1, 0, 1)` to
+    /// honestly count gradient-bearing first-target samples.
+    pub target_mask: Tensor,
 }
 
 // ─── Data loader ────────────────────────────────────────────────────
@@ -215,21 +240,36 @@ impl DataLoader {
 
             let mut all_inputs: Vec<u32> = Vec::with_capacity(batch_size * seq_len);
             let mut all_targets: Vec<u32> = Vec::with_capacity(batch_size * seq_len);
-            let mut all_masks: Vec<u8> = Vec::with_capacity(batch_size * seq_len);
+            let mut all_attn_masks: Vec<u8> = Vec::with_capacity(batch_size * seq_len);
+            // Target mask is computed from target_ids vs pad_id —
+            // structurally distinct from attention_mask (which
+            // reflects INPUT pad status). Per reviewer-caught
+            // semantic-drift: target[i] is input[i+1] (causal LM
+            // shift), so a sample's last real INPUT can be at
+            // position k while its last real TARGET is at k-1.
+            let mut all_target_masks: Vec<u8> = Vec::with_capacity(batch_size * seq_len);
             for ex in chunk {
                 all_inputs.extend_from_slice(&ex.input_ids);
                 all_targets.extend_from_slice(&ex.target_ids);
-                all_masks.extend_from_slice(&ex.attention_mask);
+                all_attn_masks.extend_from_slice(&ex.attention_mask);
+                for &t in &ex.target_ids {
+                    all_target_masks.push(if t == pad_id { 0 } else { 1 });
+                }
             }
 
             let input_ids =
                 Tensor::from_vec(all_inputs, (batch_size, seq_len), device)?.to_dtype(DType::U32)?;
             let target_ids =
                 Tensor::from_vec(all_targets, (batch_size, seq_len), device)?.to_dtype(DType::U32)?;
-            // attention_mask as F32 (for multiplying loss; U8 would
-            // need a cast anyway).
+            // attention_mask + target_mask both as F32 for
+            // loss-scaling math (U8 would need a cast anyway).
             let attention_mask = Tensor::from_vec(
-                all_masks.iter().map(|&v| v as f32).collect::<Vec<_>>(),
+                all_attn_masks.iter().map(|&v| v as f32).collect::<Vec<_>>(),
+                (batch_size, seq_len),
+                device,
+            )?;
+            let target_mask = Tensor::from_vec(
+                all_target_masks.iter().map(|&v| v as f32).collect::<Vec<_>>(),
                 (batch_size, seq_len),
                 device,
             )?;
@@ -238,6 +278,7 @@ impl DataLoader {
                 input_ids,
                 target_ids,
                 attention_mask,
+                target_mask,
             });
         }
 
@@ -395,25 +436,43 @@ impl LoRATrainer {
         };
         let targets_u32 = targets_per_sample.to_dtype(DType::U32)?;
 
-        // Honest tokens_used: count of samples whose first target
-        // is non-pad. The attention_mask is 1 for real tokens, 0
-        // for pad. We narrow to the first column (matching the
-        // first-target-per-sample selection) and sum.
-        let tokens_used: u64 = if batch.attention_mask.dims().len() >= 2
-            && batch.attention_mask.dims()[1] >= 1
+        // Honest tokens_used: count of samples whose first TARGET
+        // is non-pad. Use `target_mask`, NOT `attention_mask` —
+        // they differ by one position because target_ids are
+        // input_ids shifted left. This is the load-bearing fix for
+        // the round-1 reviewer's BLOCK on M1 semantic drift: a
+        // 1-byte ByteTokenizer example's first INPUT is non-pad
+        // (mask_attn[0]=1) but its first TARGET IS pad
+        // (mask_target[0]=0). Using attention_mask here re-inflates
+        // the metric by counting pad-targeted samples as
+        // gradient-bearing — the exact bug M1 was filed to kill.
+        let tokens_used: u64 = if batch.target_mask.dims().len() >= 2
+            && batch.target_mask.dims()[1] >= 1
         {
             let first_col = batch
-                .attention_mask
+                .target_mask
                 .narrow(1, 0, 1)?
                 .squeeze(1)?
                 .contiguous()?;
             first_col.sum_all()?.to_scalar::<f32>()? as u64
         } else {
-            // No attention_mask shape we can reason about — fall
-            // back to batch dim. Real path always has the [batch,
-            // seq] shape via DataLoader.
             batch.input_ids.dim(0)? as u64
         };
+
+        // Per `[[no-fallbacks-ever]]`: if the whole batch is
+        // pad-targeted (tokens_used == 0), skip the backward step
+        // entirely. Letting AdamW step on a loss derived ENTIRELY
+        // from pad-target predictions would corrupt the LoRA
+        // parameters with garbage gradient signal. This is the
+        // partial-pad mitigation flagged by reviewer round-1 LGTM
+        // M3 — the full per-sample masking inside cross_entropy
+        // lands with real-model loading, but the all-pad-batch case
+        // we CAN catch now.
+        if tokens_used == 0 {
+            self.metrics.steps_completed += 1;
+            // last_train_loss stays None (no real loss computed)
+            return Ok((0.0, 0));
+        }
 
         let loss = cross_entropy(&logits, &targets_u32)?;
         self.optimizer.backward_step(&loss)?;
@@ -628,11 +687,17 @@ mod tests {
         )
         .unwrap();
         let target_ids = Tensor::from_vec(vec![2u32, 3, 0, 0], (1, 4), &device).unwrap();
-        let mask = Tensor::full(1.0f32, (1, 4), &device).unwrap();
+        let attn_mask = Tensor::full(1.0f32, (1, 4), &device).unwrap();
+        // target_mask reflects target_ids pad status: [2, 3] non-pad
+        // (1.0), [0, 0] pad (0.0). First-target IS non-pad here, so
+        // train_step gets a gradient-bearing step.
+        let target_mask =
+            Tensor::from_slice(&[1.0f32, 1.0, 0.0, 0.0], (1, 4), &device).unwrap();
         let batch = TokenizedBatch {
             input_ids,
             target_ids,
-            attention_mask: mask,
+            attention_mask: attn_mask,
+            target_mask,
         };
 
         trainer.train_step(&batch).unwrap();
@@ -771,14 +836,19 @@ mod tests {
             // movement in a small step budget so the test stays fast.
             let mut trainer = LoRATrainer::new(module, 0.5).unwrap();
 
-            // Single batch held constant across all steps.
+            // Single batch held constant across all steps. Both
+            // masks set the SAME way (first target non-pad) so the
+            // standin trains every step.
             let input_ids = Tensor::from_slice(&[1u32, 2, 3, 0], (1, 4), &device).unwrap();
             let target_ids = Tensor::from_slice(&[2u32, 3, 0, 0], (1, 4), &device).unwrap();
-            let mask = Tensor::full(1.0f32, (1, 4), &device).unwrap();
+            let attn_mask = Tensor::full(1.0f32, (1, 4), &device).unwrap();
+            let target_mask =
+                Tensor::from_slice(&[1.0f32, 1.0, 0.0, 0.0], (1, 4), &device).unwrap();
             let batch = TokenizedBatch {
                 input_ids,
                 target_ids,
-                attention_mask: mask,
+                attention_mask: attn_mask,
+                target_mask,
             };
 
             let (loss_0, _) = trainer.train_step(&batch).unwrap();
@@ -820,6 +890,10 @@ mod tests {
         // "the count must equal what actually trained, not a
         // schedule-derived guess." With batch_size=2, all-ones
         // mask, 5 train_step calls → gradient_tokens_consumed = 10.
+        //
+        // Hand-built batch is fine HERE because both targets are
+        // explicitly non-pad in target_ids. The drift-catching
+        // version uses DataLoader; see `pad_first_target_via_dataloader`.
         #[test]
         fn gradient_tokens_consumed_counts_non_pad_first_targets() {
             let device = Device::Cpu;
@@ -827,18 +901,25 @@ mod tests {
             let module = LoRAModule::new(base, 2, 4, DType::F32, &device).unwrap();
             let mut trainer = LoRATrainer::new(module, 0.001).unwrap();
 
-            // batch_size=2, seq_len=4, all-ones mask → both
-            // samples' first targets are non-pad → tokens_used=2
-            // per step.
+            // batch_size=2, seq_len=4, both samples' first target
+            // non-pad → tokens_used=2 per step.
             let input_ids =
                 Tensor::from_slice(&[1u32, 2, 3, 0, 1, 2, 3, 0], (2, 4), &device).unwrap();
             let target_ids =
                 Tensor::from_slice(&[2u32, 3, 0, 0, 2, 3, 0, 0], (2, 4), &device).unwrap();
-            let mask = Tensor::full(1.0f32, (2, 4), &device).unwrap();
+            let attn_mask = Tensor::full(1.0f32, (2, 4), &device).unwrap();
+            // target_mask matches target_ids: 1 where != 0, 0 where == 0.
+            let target_mask = Tensor::from_slice(
+                &[1.0f32, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+                (2, 4),
+                &device,
+            )
+            .unwrap();
             let batch = TokenizedBatch {
                 input_ids,
                 target_ids,
-                attention_mask: mask,
+                attention_mask: attn_mask,
+                target_mask,
             };
 
             for _ in 0..5 {
@@ -862,34 +943,99 @@ mod tests {
             );
         }
 
-        // what this VDD catches: when first-target IS pad,
-        // tokens_used drops accordingly. Per Reviewer 1's LGTM M3
-        // — the standin can't filter out pad targets from
-        // cross_entropy itself, but it MUST not lie about token
-        // count. A sample whose first target is pad (id 0,
-        // matched via attention_mask.first_col == 0) contributes
-        // 0 to tokens_used.
+        // what this VDD catches: short examples whose FIRST TARGET
+        // is pad must NOT be counted as gradient-bearing. Per the
+        // round-2 reviewer's BLOCK on the M1 semantic-drift bug:
+        // the previous test hand-crafted a TokenizedBatch with mask
+        // aligned to the implementation's BUG (first-INPUT pad
+        // status), so the test passed but the bug shipped. The fix
+        // is to build the batch VIA `DataLoader` — same path
+        // production uses — so the test exercises real DataLoader
+        // output. With a 1-byte example (prompt="X", completion="")
+        // ByteTokenizer produces:
+        //   inputs = [X+1, 0, 0, ...]
+        //   target_ids = [0, 0, 0, ...]  (input shifted left)
+        //   attention_mask = [1, 0, 0, ...]  (INPUT pad status)
+        //   target_mask = [0, 0, 0, ...]  (TARGET pad status)
+        // First INPUT is non-pad but first TARGET IS pad → the
+        // metric MUST report 0 gradient-bearing tokens.
+        //
+        // Pre-fix this assertion would fire because the metric used
+        // attention_mask[0]=1 → tokens_used=1, miscounting the
+        // pad-targeted sample as gradient-bearing.
         #[test]
-        fn pad_first_target_contributes_zero_to_tokens_used() {
+        fn pad_first_target_via_dataloader_contributes_zero_to_tokens_used() {
+            use crate::genome::fine_tuning::byte_tokenizer::ByteTokenizer;
+            let device = Device::Cpu;
+            let base = Tensor::full(0.1f32, (257, 4), &device).unwrap();
+            let module = LoRAModule::new(base, 2, 4, DType::F32, &device).unwrap();
+            let mut trainer = LoRATrainer::new(module, 0.001).unwrap();
+
+            // Single 1-byte example. After encode + shift-left for
+            // target_ids, every target position is pad.
+            let examples = vec![TrainingExample {
+                prompt: "X".into(),
+                completion: "".into(),
+                metadata: None,
+            }];
+            let loader =
+                DataLoader::new(&examples, &ByteTokenizer::new(), 1, 4, &device).unwrap();
+            let batch = loader.batches().next().expect("one batch");
+
+            let (_loss, tokens_used) = trainer.train_step(batch).unwrap();
+            assert_eq!(
+                tokens_used, 0,
+                "VDD drift-pin: a 1-byte example produces an all-pad target_ids \
+                 row → tokens_used MUST be 0. Pre-fix this returned 1 (counting \
+                 input[0] pad status instead of target[0] pad status)."
+            );
+            // And `gradient_tokens_consumed` MUST NOT have moved.
+            assert_eq!(
+                trainer.metrics().gradient_tokens_consumed,
+                0,
+                "VDD: metric stays at 0 when every train_step's target_mask is empty"
+            );
+            // Step counter advances — train_step was called — but
+            // the no-gradient branch was taken (no backward).
+            assert_eq!(trainer.metrics().steps_completed, 1);
+        }
+
+        // what this VDD catches: a hand-built batch where ONE
+        // sample's first target is non-pad and ANOTHER sample's
+        // first target IS pad → tokens_used = 1 (only the non-pad).
+        // This pins the per-sample counting math; the
+        // DataLoader-based test above pins the DRIFT class.
+        #[test]
+        fn mixed_pad_and_real_first_targets_count_only_real() {
             let device = Device::Cpu;
             let base = Tensor::full(0.1f32, (4, 4), &device).unwrap();
             let module = LoRAModule::new(base, 2, 4, DType::F32, &device).unwrap();
             let mut trainer = LoRATrainer::new(module, 0.001).unwrap();
 
-            // batch_size=2; sample 0 has mask[0]=1 (real first
-            // target), sample 1 has mask[0]=0 (pad first target).
-            // → tokens_used = 1 per step.
+            // batch_size=2; sample 0 first target=2 (non-pad),
+            // sample 1 first target=0 (pad). target_mask reflects
+            // that: [1, ..., 0, ...].
             let input_ids =
                 Tensor::from_slice(&[1u32, 2, 3, 0, 0, 0, 0, 0], (2, 4), &device).unwrap();
             let target_ids =
                 Tensor::from_slice(&[2u32, 3, 0, 0, 0, 0, 0, 0], (2, 4), &device).unwrap();
-            let mask =
-                Tensor::from_slice(&[1f32, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0], (2, 4), &device)
-                    .unwrap();
+            let attn_mask = Tensor::from_slice(
+                &[1.0f32, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                (2, 4),
+                &device,
+            )
+            .unwrap();
+            let target_mask = Tensor::from_slice(
+                &[1.0f32, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                (2, 4),
+                &device,
+            )
+            .unwrap();
             let batch = TokenizedBatch {
                 input_ids,
                 target_ids,
-                attention_mask: mask,
+                attention_mask: attn_mask,
+                target_mask,
             };
             let (_, tokens_used) = trainer.train_step(&batch).unwrap();
             assert_eq!(
@@ -916,11 +1062,14 @@ mod tests {
 
             let input_ids = Tensor::from_slice(&[1u32, 2, 3, 0], (1, 4), &device).unwrap();
             let target_ids = Tensor::from_slice(&[2u32, 3, 0, 0], (1, 4), &device).unwrap();
-            let mask_all_ones = Tensor::full(1.0f32, (1, 4), &device).unwrap();
+            let attn_all_ones = Tensor::full(1.0f32, (1, 4), &device).unwrap();
+            let target_mask =
+                Tensor::from_slice(&[1.0f32, 1.0, 0.0, 0.0], (1, 4), &device).unwrap();
             let batch_masked = TokenizedBatch {
                 input_ids: input_ids.clone(),
                 target_ids: target_ids.clone(),
-                attention_mask: mask_all_ones,
+                attention_mask: attn_all_ones,
+                target_mask,
             };
 
             let (loss_masked, _) = trainer.train_step(&batch_masked).unwrap();

--- a/core/continuum-core/src/genome/fine_tuning/training_loop.rs
+++ b/core/continuum-core/src/genome/fine_tuning/training_loop.rs
@@ -274,6 +274,17 @@ impl DataLoader {
 pub struct TrainingMetrics {
     pub steps_completed: u64,
     pub epochs_completed: u32,
+    /// Honest count of gradient-bearing target positions consumed
+    /// across all `train_step` calls so far. Replaces the inflated
+    /// `steps × batch × seq_len` formula that the job actor's
+    /// `trained_tokens` metric used previously (Reviewer 1's BLOCK
+    /// M1). In the standin path this is `steps × batch × 1` (one
+    /// target per sample); in the real-model-loading path it
+    /// becomes `sum of attention_mask` across all batches. Either
+    /// way the count reflects what actually flowed through the
+    /// gradient, not a schedule-derived guess. The actor reads this
+    /// straight into [`super::types::JobMetrics::trained_tokens`].
+    pub gradient_tokens_consumed: u64,
     /// Loss on the most recent training step.
     pub last_train_loss: Option<f32>,
     /// Average loss across the most recent epoch.
@@ -317,28 +328,52 @@ impl LoRATrainer {
     }
 
     /// One forward + cross-entropy + backward + optimizer step.
-    /// Returns the loss value for this step (also stored in
-    /// `metrics.last_train_loss`).
+    /// Returns `(loss, tokens_used)` — the loss value and the count
+    /// of gradient-bearing target positions THIS STEP actually
+    /// trained against. Per Reviewer 1's BLOCK M1: the previous
+    /// version returned only loss, and the actor's `trained_tokens`
+    /// metric was computed as `steps × batch × seq_len` after the
+    /// fact — inflated by `seq_len`× in the stand-in path because
+    /// the stand-in trains on ONE target per sample. The honest
+    /// count flows out of THIS function and accumulates into
+    /// [`TrainingMetrics::gradient_tokens_consumed`].
     ///
     /// ## Stand-in vs production
     ///
     /// This is the substrate-side stand-in path that exercises the
     /// gradient flow through `LoRAModule`'s A + B Vars end-to-end.
-    /// Production wiring (#233) replaces:
-    ///   - the U32→F32 cast with an embedding-table lookup
-    ///   - the single-class-per-sample target with the full
-    ///     [batch * seq] flattened token-prediction targets
-    ///   - the standin's [batch, out_features] logits with a
-    ///     transformer's [batch, seq, vocab] logits flattened to
-    ///     [batch * seq, vocab]
+    /// Production wiring (replaces the synthetic base when real
+    /// model loading lands):
+    ///   - the U32→F32 cast becomes an embedding-table lookup
+    ///   - the single-class-per-sample target becomes the full
+    ///     [batch * seq] flattened token-prediction targets, masked
+    ///     by `attention_mask`
+    ///   - `tokens_used` becomes `attention_mask.sum()` — the count
+    ///     of non-pad positions that received gradient signal
     /// The optimizer + cross-entropy + backward shape stays
     /// identical across both — the swap is local to forward + target
     /// shaping.
-    pub fn train_step(&mut self, batch: &TokenizedBatch) -> Result<f32, TrainingError> {
+    ///
+    /// ## Pad-as-target note (Reviewer 1's LGTM M3)
+    ///
+    /// The stand-in pulls `target_ids.narrow(1, 0, 1)` — the FIRST
+    /// target id per sample. For samples whose first target IS the
+    /// pad id (very short examples that fit entirely in the pad
+    /// region of the seq dim), gradient flows for "predict pad."
+    /// The honest mitigation in the stand-in: `tokens_used` is
+    /// computed from `attention_mask.first_column.sum()` — the
+    /// count of samples whose first target is NON-pad. The metric
+    /// thus reports gradient-bearing tokens accurately; cross_entropy
+    /// still computes loss over all samples (including pad targets)
+    /// but the count surfaces the corruption to operators. The full
+    /// fix — masking pad targets out of cross_entropy via per-sample
+    /// loss scaling — lands in the real-model-loading slice
+    /// alongside the embedding-table swap.
+    pub fn train_step(&mut self, batch: &TokenizedBatch) -> Result<(f32, u64), TrainingError> {
         // Stand-in forward: cast token ids to F32 and run through
-        // the LoRA-wrapped linear. The actual transformer (#233)
-        // embeds ids first; this stand-in exercises the gradient
-        // path through A + B without needing the embedding table.
+        // the LoRA-wrapped linear. The actual transformer embeds
+        // ids first; this stand-in exercises the gradient path
+        // through A + B without needing the embedding table.
         let inputs_f32 = batch.input_ids.to_dtype(DType::F32)?;
         let logits = self.module.forward(&inputs_f32)?;
 
@@ -360,22 +395,47 @@ impl LoRATrainer {
         };
         let targets_u32 = targets_per_sample.to_dtype(DType::U32)?;
 
+        // Honest tokens_used: count of samples whose first target
+        // is non-pad. The attention_mask is 1 for real tokens, 0
+        // for pad. We narrow to the first column (matching the
+        // first-target-per-sample selection) and sum.
+        let tokens_used: u64 = if batch.attention_mask.dims().len() >= 2
+            && batch.attention_mask.dims()[1] >= 1
+        {
+            let first_col = batch
+                .attention_mask
+                .narrow(1, 0, 1)?
+                .squeeze(1)?
+                .contiguous()?;
+            first_col.sum_all()?.to_scalar::<f32>()? as u64
+        } else {
+            // No attention_mask shape we can reason about — fall
+            // back to batch dim. Real path always has the [batch,
+            // seq] shape via DataLoader.
+            batch.input_ids.dim(0)? as u64
+        };
+
         let loss = cross_entropy(&logits, &targets_u32)?;
         self.optimizer.backward_step(&loss)?;
 
         let loss_scalar = loss.to_scalar::<f32>()?;
         self.metrics.steps_completed += 1;
+        self.metrics.gradient_tokens_consumed += tokens_used;
         self.metrics.last_train_loss = Some(loss_scalar);
-        Ok(loss_scalar)
+        Ok((loss_scalar, tokens_used))
     }
 
     /// One epoch — iterate every batch the loader produces, sum
     /// losses, update metrics.
     pub fn train_epoch(&mut self, loader: &DataLoader) -> Result<f32, TrainingError> {
+        // Per-batch train_step now returns (loss, tokens_used);
+        // tokens_used accumulates inside train_step into
+        // metrics.gradient_tokens_consumed, so we only need loss
+        // here for the averaging.
         let mut sum_loss = 0.0_f32;
         let mut count = 0_u32;
         for batch in loader.batches() {
-            let loss = self.train_step(batch)?;
+            let (loss, _tokens_used) = self.train_step(batch)?;
             sum_loss += loss;
             count += 1;
         }
@@ -721,11 +781,11 @@ mod tests {
                 attention_mask: mask,
             };
 
-            let loss_0 = trainer.train_step(&batch).unwrap();
+            let (loss_0, _) = trainer.train_step(&batch).unwrap();
             for _ in 0..40 {
                 trainer.train_step(&batch).unwrap();
             }
-            let loss_final = trainer.train_step(&batch).unwrap();
+            let (loss_final, _) = trainer.train_step(&batch).unwrap();
 
             // Convergence threshold: loss must drop to at most half
             // its initial value. Single-example overfitting on a
@@ -746,6 +806,95 @@ mod tests {
             assert!(
                 loss_final < loss_0,
                 "VDD: monotonicity — final loss {loss_final} must beat initial {loss_0}"
+            );
+        }
+
+        // what this VDD catches: `gradient_tokens_consumed` counts
+        // batch_size per step when ALL first-targets are non-pad
+        // (the all-ones-mask common case). This is the honest
+        // standin count. A regression flipping the mask polarity
+        // or returning batch_size × seq_len from train_step would
+        // here fail by a multiplicative factor.
+        //
+        // Per Reviewer 1's BLOCK M1: the load-bearing assertion is
+        // "the count must equal what actually trained, not a
+        // schedule-derived guess." With batch_size=2, all-ones
+        // mask, 5 train_step calls → gradient_tokens_consumed = 10.
+        #[test]
+        fn gradient_tokens_consumed_counts_non_pad_first_targets() {
+            let device = Device::Cpu;
+            let base = Tensor::full(0.1f32, (4, 4), &device).unwrap();
+            let module = LoRAModule::new(base, 2, 4, DType::F32, &device).unwrap();
+            let mut trainer = LoRATrainer::new(module, 0.001).unwrap();
+
+            // batch_size=2, seq_len=4, all-ones mask → both
+            // samples' first targets are non-pad → tokens_used=2
+            // per step.
+            let input_ids =
+                Tensor::from_slice(&[1u32, 2, 3, 0, 1, 2, 3, 0], (2, 4), &device).unwrap();
+            let target_ids =
+                Tensor::from_slice(&[2u32, 3, 0, 0, 2, 3, 0, 0], (2, 4), &device).unwrap();
+            let mask = Tensor::full(1.0f32, (2, 4), &device).unwrap();
+            let batch = TokenizedBatch {
+                input_ids,
+                target_ids,
+                attention_mask: mask,
+            };
+
+            for _ in 0..5 {
+                let (_, tokens_used) = trainer.train_step(&batch).unwrap();
+                assert_eq!(
+                    tokens_used, 2,
+                    "VDD: each step trains batch_size=2 non-pad targets"
+                );
+            }
+            assert_eq!(
+                trainer.metrics().gradient_tokens_consumed,
+                10,
+                "VDD: accumulated honestly across 5 steps × batch=2"
+            );
+            // CRUCIALLY: NOT batch × seq × steps = 2 × 4 × 5 = 40.
+            // The pre-fix formula was that inflation.
+            assert_ne!(
+                trainer.metrics().gradient_tokens_consumed,
+                40,
+                "VDD: the count must NOT be the inflated schedule-derived guess (2×4×5=40)"
+            );
+        }
+
+        // what this VDD catches: when first-target IS pad,
+        // tokens_used drops accordingly. Per Reviewer 1's LGTM M3
+        // — the standin can't filter out pad targets from
+        // cross_entropy itself, but it MUST not lie about token
+        // count. A sample whose first target is pad (id 0,
+        // matched via attention_mask.first_col == 0) contributes
+        // 0 to tokens_used.
+        #[test]
+        fn pad_first_target_contributes_zero_to_tokens_used() {
+            let device = Device::Cpu;
+            let base = Tensor::full(0.1f32, (4, 4), &device).unwrap();
+            let module = LoRAModule::new(base, 2, 4, DType::F32, &device).unwrap();
+            let mut trainer = LoRATrainer::new(module, 0.001).unwrap();
+
+            // batch_size=2; sample 0 has mask[0]=1 (real first
+            // target), sample 1 has mask[0]=0 (pad first target).
+            // → tokens_used = 1 per step.
+            let input_ids =
+                Tensor::from_slice(&[1u32, 2, 3, 0, 0, 0, 0, 0], (2, 4), &device).unwrap();
+            let target_ids =
+                Tensor::from_slice(&[2u32, 3, 0, 0, 0, 0, 0, 0], (2, 4), &device).unwrap();
+            let mask =
+                Tensor::from_slice(&[1f32, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0], (2, 4), &device)
+                    .unwrap();
+            let batch = TokenizedBatch {
+                input_ids,
+                target_ids,
+                attention_mask: mask,
+            };
+            let (_, tokens_used) = trainer.train_step(&batch).unwrap();
+            assert_eq!(
+                tokens_used, 1,
+                "VDD: only the non-pad-first-target sample counts; pad sample contributes 0"
             );
         }
 
@@ -774,11 +923,11 @@ mod tests {
                 attention_mask: mask_all_ones,
             };
 
-            let loss_masked = trainer.train_step(&batch_masked).unwrap();
+            let (loss_masked, _) = trainer.train_step(&batch_masked).unwrap();
             // The standin doesn't apply mask, so this is a tautology
-            // *today*. The assertion is a pin for #233's real
-            // wiring: when mask multiplication lands, this test
-            // becomes load-bearing.
+            // *today*. The assertion is a pin for the real wiring:
+            // when mask multiplication lands, this test becomes
+            // load-bearing.
             assert!(
                 loss_masked.is_finite() && loss_masked > 0.0,
                 "VDD: loss must be finite and positive on a meaningful target; got {loss_masked}"

--- a/core/continuum-core/src/modules/training_trigger.rs
+++ b/core/continuum-core/src/modules/training_trigger.rs
@@ -1230,41 +1230,85 @@ mod tests {
     /// every produced LoRA layer's training data.
     mod vdd {
         use super::*;
+        use crate::genome::fine_tuning::{
+            FineTuningRegistry, RecordingFineTuningAdapter, RECORDING_BASE_PREFIX,
+        };
+        use crate::modules::genome::GenomeModule;
+
+        /// Build a runtime where genome/job-create routes to a
+        /// RecordingFineTuningAdapter (substrate's canonical test
+        /// fixture for capturing dispatched TrainingJobRequests).
+        /// Returns the trigger + the shared captures handle so the
+        /// test body can compare dispatched-vs-submitted at exact
+        /// example granularity.
+        ///
+        /// Per Reviewer 1's BLOCK M2 (re-review): the previous
+        /// `trained_tokens > 0` smoke check could not actually
+        /// detect a drop/duplicate in the dispatch path because
+        /// `trained_tokens` is a function of schedule, not example
+        /// count. The recording fixture is the proper "did every
+        /// submitted example flow through" check.
+        async fn build_recording_runtime() -> (
+            Arc<TrainingTriggerModule>,
+            Arc<RecordingFineTuningAdapter>,
+        ) {
+            let registry = Arc::new(ModuleRegistry::new());
+            let trigger = Arc::new(TrainingTriggerModule::new());
+            registry.register(trigger.clone());
+
+            let ft_registry = Arc::new(FineTuningRegistry::new());
+            let recorder = Arc::new(RecordingFineTuningAdapter::new());
+            ft_registry.register(recorder.clone());
+            registry.register(Arc::new(GenomeModule::new(ft_registry)));
+
+            let executor = Arc::new(CommandExecutor::new(registry.clone()));
+            registry.install_executor_on_all(executor.clone());
+            (trigger, recorder)
+        }
 
         // what this VDD catches: every example submitted across N
-        // submits must appear EXACTLY ONCE in the dispatched
-        // dataset, in the order it was submitted. This is the
-        // matrix-dojo loop's data-conservation invariant. We
-        // intercept the dispatched dataset by registering a stub
-        // GenomeModule replacement... but here we take a simpler
-        // path: query the LocalCandleFineTuner's job status after
-        // dispatch to verify it was given a non-empty dataset, and
-        // we count the trained_tokens in the artifact to verify
-        // examples × seq_len matches what we submitted.
+        // submits appears EXACTLY ONCE in a dispatched job — no
+        // duplicates, no drops, in submission order. The
+        // RecordingFineTuningAdapter captures the dispatched
+        // TrainingDataset so we can compare prompt-by-prompt against
+        // what was submitted. This is real conservation accounting,
+        // not the tautological `trained_tokens > 0` the previous
+        // version asserted.
         //
-        // Stronger conservation check: we use the `trained_tokens`
-        // metric the job actor reports in its TrainingArtifact.
-        // The actor computes trained_tokens = steps × batch ×
-        // seq_len, and steps = batches × epochs. With known
-        // schedule defaults, this gives a closed-form expected
-        // count we can verify.
+        // A regression that double-counted or dropped on the
+        // drain-and-dispatch path would here surface as either a
+        // count mismatch OR a missing/duplicated prompt — both
+        // distinct, both failure-class-specific.
         #[tokio::test]
         async fn submitted_examples_flow_through_dispatch_intact() {
-            let (trigger, executor) = build_runtime_with_trigger_and_genome().await;
+            let (trigger, recorder) = build_recording_runtime().await;
             let persona = Uuid::new_v4();
             let n = 8;
 
-            // Submit n examples with unique prompt/completion text
-            // so a duplication or drop bug would be visible in the
-            // example count.
+            // Submit n examples with unique prompt text so a
+            // duplication or drop would be visible at the
+            // prompt-string level, not just in counts.
             let examples: Vec<TrainingExample> = (0..n)
                 .map(|i| ex(&format!("prompt-{i}"), &format!("completion-{i}")))
                 .collect();
+            let mut params = submit_params(
+                persona,
+                "vdd-trait",
+                examples.clone(),
+                Some(n as u32),
+            );
+            // The recording fixture matches base_model prefix
+            // "recording-test" — submit_params helper defaults to
+            // "synthetic" which would route to LocalCandleFineTuner.
+            // Override so dispatch deterministically lands at the
+            // recorder.
+            params.as_object_mut().unwrap().insert(
+                "baseModel".into(),
+                Value::String(format!("{RECORDING_BASE_PREFIX}-vdd")),
+            );
+
             let result = trigger
-                .handle_command(
-                    "genome/training-trigger/submit",
-                    submit_params(persona, "vdd-trait", examples.clone(), Some(n as u32)),
-                )
+                .handle_command("genome/training-trigger/submit", params)
                 .await
                 .unwrap();
             let json = match result {
@@ -1277,59 +1321,100 @@ mod tests {
                 "VDD: every submitted example must be in the dispatched job"
             );
 
-            // Bucket cleared exactly once — zero leftover, no
-            // duplicate retained.
+            // Bucket cleared exactly once — zero leftover.
             assert_eq!(
-                trigger.bucket_example_count(persona, "vdd-trait", "synthetic"),
+                trigger.bucket_example_count(persona, "vdd-trait", &format!("{RECORDING_BASE_PREFIX}-vdd")),
                 None,
                 "VDD: bucket must be fully drained, no leftover"
             );
+            assert_eq!(trigger.pending_bucket_count(), 0);
+
+            // CONSERVATION CHECK — the load-bearing assertion this
+            // test exists for. Exactly one job dispatched, exactly
+            // n examples captured, examples match submitted set in
+            // ORDER (the trigger preserves submission order on
+            // append + drain).
             assert_eq!(
-                trigger.pending_bucket_count(),
-                0,
-                "VDD: no phantom empty buckets after dispatch"
+                recorder.captured_job_count(),
+                1,
+                "VDD: exactly one job dispatched"
+            );
+            assert_eq!(
+                recorder.captured_example_count(),
+                n,
+                "VDD: dispatched dataset must carry exactly the {n} examples submitted"
             );
 
-            // Poll the dispatched job to terminal — its
-            // trained_tokens count gives us a closed-form check
-            // that the actor saw a non-empty dataset.
-            let handle_value = &json["jobHandle"];
-            let mut terminal: Option<Value> = None;
-            for _ in 0..200 {
-                let status_v = executor
-                    .execute_json(
-                        "genome/job-status",
-                        json!({ "handle": handle_value }),
-                    )
-                    .await
-                    .expect("job-status");
-                let status = status_v["status"].clone();
-                if status["state"] == "completed"
-                    || status["state"] == "failed"
-                    || status["state"] == "cancelled"
-                {
-                    terminal = Some(status);
-                    break;
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            let captures = recorder.captures();
+            let guard = captures.lock().unwrap();
+            let dispatched_examples = &guard[0].dataset.examples;
+            assert_eq!(dispatched_examples.len(), examples.len());
+            for (i, (sub, disp)) in examples.iter().zip(dispatched_examples.iter()).enumerate() {
+                assert_eq!(
+                    sub.prompt, disp.prompt,
+                    "VDD: example {i} prompt mismatch — submission order violated or example replaced"
+                );
+                assert_eq!(sub.completion, disp.completion);
             }
-            let terminal = terminal.expect("VDD: job must reach terminal status");
-            assert_eq!(
-                terminal["state"], "completed",
-                "VDD: dispatched job must complete on a synthetic base, got {terminal:?}"
-            );
+        }
 
-            // The artifact's metrics.trainedTokens must be > 0 —
-            // the actor only emits this when examples actually
-            // flowed through the data loader. Zero would prove the
-            // examples got lost between trigger and actor.
-            let trained_tokens = terminal["artifact"]["metrics"]["trainedTokens"]
-                .as_u64()
-                .expect("trainedTokens present");
-            assert!(
-                trained_tokens > 0,
-                "VDD: dispatched job must have non-zero trainedTokens, got {trained_tokens}"
+        // what this VDD catches: conservation across MULTIPLE
+        // submits to the same bucket. Pre-fix the previous tests
+        // verified single-submit flows; this verifies that
+        // accumulated submits, when finally drained-and-dispatched,
+        // carry every example in INSERTION ORDER. A bug in
+        // `entry.examples.extend(...)` (e.g. accidentally calling
+        // `replace_with` or prepending instead of appending) would
+        // here surface as a reordering or count mismatch.
+        #[tokio::test]
+        async fn multi_submit_accumulation_preserves_order_through_dispatch() {
+            let (trigger, recorder) = build_recording_runtime().await;
+            let persona = Uuid::new_v4();
+            let trait_kind = "multi-submit-vdd";
+            let base_model = format!("{RECORDING_BASE_PREFIX}-multi");
+
+            // 4 submits × 3 examples = 12. Threshold 12 → fires
+            // only at the last submit.
+            let mut all_submitted: Vec<TrainingExample> = Vec::new();
+            for batch in 0..4 {
+                let exs: Vec<TrainingExample> = (0..3)
+                    .map(|i| {
+                        ex(
+                            &format!("b{batch}-p{i}"),
+                            &format!("b{batch}-c{i}"),
+                        )
+                    })
+                    .collect();
+                all_submitted.extend(exs.clone());
+                let mut params = submit_params(persona, trait_kind, exs, Some(12));
+                params
+                    .as_object_mut()
+                    .unwrap()
+                    .insert("baseModel".into(), Value::String(base_model.clone()));
+                let _ = trigger
+                    .handle_command("genome/training-trigger/submit", params)
+                    .await
+                    .unwrap();
+            }
+
+            // Exactly one job dispatched (only the 4th submit
+            // crossed threshold).
+            assert_eq!(recorder.captured_job_count(), 1);
+
+            let captures = recorder.captures();
+            let guard = captures.lock().unwrap();
+            let dispatched = &guard[0].dataset.examples;
+            assert_eq!(
+                dispatched.len(),
+                12,
+                "VDD: dispatched dataset must carry all 12 accumulated examples"
             );
+            for (i, (sub, disp)) in all_submitted.iter().zip(dispatched.iter()).enumerate() {
+                assert_eq!(
+                    sub.prompt, disp.prompt,
+                    "VDD: position {i} reordering — accumulator violated submission order"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Fix-2 of the canary-quality cleanup (task #237)

Closes the 3 remaining math/VDD-honesty findings from the original 3-reviewer adversarial pass: **M1** (trained_tokens inflation), **M2** (conservation test was tautological), **M3** (pad-as-target gradient corruption — LGTM-with-notes).

The metric layer + the conservation VDD test now match their marketing. Pre-fix, both were "honest-looking but tautological."

## Findings closed

| ID | Class | Pre-fix lie | Post-fix honesty |
|---|---|---|---|
| **M1** | Math | `trained_tokens = steps × batch × seq_len` inflated 32× in stand-in path; alloy provenance lied about training scale | `gradient_tokens_consumed: u64` on `TrainingMetrics`, accumulated inside `train_step` from actual non-pad first-target count |
| **M2** | VDD honesty | Conservation test asserted `trained_tokens > 0` and claimed to prove "every example flowed through exactly once" — bug doubling or dropping examples would have passed | `RecordingFineTuningAdapter` captures dispatched `TrainingDataset`; test asserts exact example count + per-position prompt match between submitted and dispatched |
| **M3** | Math | Stand-in `narrow(1, 0, 1)` could pick pad id (0) as target → gradient flows for "predict pad"; count didn't reflect corruption | `tokens_used` computed from `attention_mask.first_col.sum()` — samples with pad-first-target contribute 0 to the metric. Full cross-entropy pad masking lands with real-model loading. |

## RecordingFineTuningAdapter — new canonical system fixture

`core/continuum-core/src/genome/fine_tuning/recording_adapter.rs` — gated behind `#[cfg(any(test, feature = "test-fixtures"))]` per CLAUDE.md test discipline. Production binaries physically cannot link it.

This is the FineTuningAdapter equivalent of `HeuristicInferenceAdapter` — the canonical test fixture for capturing dispatched `TrainingJobRequest`s. Per the "one fixture per concern" rule, future tests that need to verify "did the trigger / coordinator dispatch the right examples?" import this fixture rather than rolling their own stub.

```rust
let adapter = RecordingFineTuningAdapter::new();
ft_registry.register(Arc::new(adapter.clone()));
// ... test body submits + asserts ...
assert_eq!(adapter.captured_example_count(), expected);
let captures = adapter.captures();
let dispatched = &captures.lock().unwrap()[0].dataset.examples;
// per-prompt match check
```

**Bonus:** this fixture also unlocks Fix-3's deterministic Notify-based concurrency test (the C1/C2 race that the smoke-level stress test couldn't deterministically force).

## Honest `train_step` shape

```rust
// Before:
pub fn train_step(&mut self, batch: &TokenizedBatch) -> Result<f32, TrainingError>

// After:
pub fn train_step(&mut self, batch: &TokenizedBatch) -> Result<(f32, u64), TrainingError>
//                                                              ^^^^^^^^
//                                                              loss, tokens_used
```

`tokens_used` = count of samples whose `attention_mask.first_col[i] == 1` (non-pad first target). Accumulates into `metrics.gradient_tokens_consumed` inside the function. `train_epoch` adapted; `job_actor::run_actor` reads `metrics.gradient_tokens_consumed` straight into `JobMetrics::trained_tokens`.

## Tests

| File | Before | After | Net |
|---|---|---|---|
| `training_loop` | 12 | 14 | +2 VDD (`gradient_tokens_consumed_counts_non_pad_first_targets`, `pad_first_target_contributes_zero_to_tokens_used`) |
| `training_trigger` | 12 | 13 | +1 VDD (`multi_submit_accumulation_preserves_order_through_dispatch`) |
| `recording_adapter` (new) | 0 | 3 | TDD: ordering, capabilities, summing |
| `job_actor` | 11 | 11 | (existing `happy_path` still asserts `trained_tokens > 0` and still passes — honest count is non-zero for any real run) |

**Total fine_tuning: 76 → 81 passing. training_trigger: 12 → 13. All default `cargo test` green.**

## Adversarial review prompt for next round

Bring back the math/VDD-honesty lens specifically. Refute claims:

- Does `gradient_tokens_consumed` actually equal the SUM of non-pad first-targets across all train_step calls in BOTH standin + a future real-wiring scenario? (i.e., is the field's semantic invariant intact, or did I just rename without fixing?)
- Is `RecordingFineTuningAdapter::captures()` ordering guaranteed? The internal `Mutex<Vec<_>>` is push-only, so it must be insertion-ordered — but verify under the multi-job dispatch scenarios the new VDD tests exercise.
- The conservation test asserts `examples[i].prompt == dispatched[i].prompt` per-position. Is the trigger's `entry.examples.extend(p.examples.into_iter())` actually preserving insertion order, or is there a hidden reordering elsewhere in the drain path?
- M3 partial fix: tokens_used is honest but cross-entropy still includes pad targets in loss. Is the LGTM downgrade from BLOCK appropriate, or does the partial fix still violate doctrine?

## Files changed

- `core/continuum-core/src/genome/fine_tuning/recording_adapter.rs` (NEW)
- `core/continuum-core/src/genome/fine_tuning/mod.rs` (re-export)
- `core/continuum-core/src/genome/fine_tuning/training_loop.rs` (return tuple, accumulate metric, +2 VDD)
- `core/continuum-core/src/genome/fine_tuning/job_actor.rs` (read honest count)
- `core/continuum-core/src/modules/training_trigger.rs` (VDD test rewrites to use recorder)
