### PR TITLE
fix(runtime): no-fallbacks — refuse silent TS fallthrough in CommandExecutor (task #219)

### DIFF
--- a/core/continuum-core/src/modules/chat/mod.rs
+++ b/core/continuum-core/src/modules/chat/mod.rs
@@ -487,14 +487,16 @@ impl ServiceModule for ChatModule {
 
             // ── Staged migration stubs ──────────────────────────────
             //
-            // The remaining commands still own their TS
-            // implementations until their own follow-up PRs land. The
-            // kernel router currently sees `chat/` claim these names
-            // (per `command_prefixes` above) but the handler returns
-            // a typed error so consumers know to keep using the TS
-            // path until migration completes. The back-compat
-            // `collaboration/chat/*` strings reach the same TS impl
-            // through the existing CommandRouterServer bridge.
+            // The remaining commands still own their TS implementations
+            // until their own follow-up PRs land. The kernel router
+            // currently sees `chat/` claim these names (per
+            // `command_prefixes` above) so the chat module's handler
+            // returns a typed error with the upstream TS command name —
+            // callers that need this surface go through the explicit
+            // `CommandExecutor::execute_ts_json` API per
+            // [[no-fallbacks-ever]] (task #219). The implicit dispatch
+            // chain no longer crosses the bridge silently; the chat
+            // module owns the prefix and emits a deterministic error.
             //
             // When each migration PR lands, swap the stub arm for a
             // real handler using the envelope pattern above.

--- a/core/continuum-core/src/routing/command_handler.rs
+++ b/core/continuum-core/src/routing/command_handler.rs
@@ -660,9 +660,10 @@ mod tests {
         };
 
         // The path doesn't resolve to a module, so execute_with_caller
-        // returns an error from the TS-bridge fallthrough. We don't
-        // care about that — the gate ran FIRST, recorded the caller,
-        // and that's the property under test.
+        // returns a typed CommandNotFound error per [[no-fallbacks-ever]]
+        // (task #219 removed the silent TS fallthrough). We don't care
+        // about that error here — the gate ran FIRST, recorded the
+        // caller, and that's the property under test.
         let _ = CommandRequestHandler::process_request_via(&executor, &parsed).await;
 
         let observed = captured.lock().unwrap().clone();

--- a/core/continuum-core/src/runtime/command_executor.rs
+++ b/core/continuum-core/src/runtime/command_executor.rs
@@ -57,14 +57,23 @@ const TS_COMMAND_SOCKET: &str = "/tmp/jtag-command-router.sock";
 ///    `command_prefixes` include this command. If found, the module's
 ///    `handle_command` runs locally.
 ///
-/// 3. **TypeScript via Unix socket**. If no Rust module owns the
-///    command, fall through to the existing `CommandRouterServer` IPC
-///    bridge. This preserves backwards compatibility with every
-///    TS-implemented command in `src/commands/`.
+/// 3. **No silent TS fallthrough.** If no Rust module owns the command,
+///    `execute_inner` returns a typed `Err` naming the missing command.
+///    Per `[[no-fallbacks-ever]]` + `[[rust-is-the-core-node-is-the-shell]]`:
+///    a substrate that silently routes unmigrated commands to a TS
+///    bridge appears "broken in headless mode" the day someone forgets
+///    to bring up `CommandRouterServer`, when the real bug was the
+///    silent dependency. Callers that EXPLICITLY want the TS bridge
+///    use [`Self::execute_ts`] / [`Self::execute_ts_json`] — those
+///    public methods stay live for the handful of remaining TS-only
+///    call sites (sentinel steps, grid retry, ai_provider TS
+///    fallthrough for unmigrated cloud adapters). The implicit chain
+///    is Rust-only.
 ///
 /// The chain is the same primitive for every transport: local Rust,
-/// remote Rust over grid, remote Rust over airc, TS over IPC. Adding a
-/// transport is adding an interceptor; no kernel changes needed.
+/// remote Rust over grid, remote Rust over airc. Adding a transport is
+/// adding an interceptor; no kernel changes needed. Adding a "fallback
+/// to other transports" is forbidden.
 pub struct CommandExecutor {
     /// Rust module registry (for Rust-implemented commands).
     registry: Arc<ModuleRegistry>,
@@ -364,13 +373,32 @@ impl CommandExecutor {
                 .await;
         }
 
-        // 3. Fall through to TypeScript via Unix socket.
-        log.debug(&format!(
-            "Routing '{}' to TypeScript via CommandRouterServer",
-            command
+        // 3. No Rust module owns this command. Refuse to silently
+        //    route to the TS bridge — that path was the
+        //    [[no-fallbacks-ever]] violation flagged as task #219. A
+        //    substrate that silently routes unmigrated commands to
+        //    `CommandRouterServer` appears "broken in headless mode"
+        //    the day the operator forgets to bring up the TS host,
+        //    when the real bug was the silent dependency. Surface a
+        //    typed `CommandNotFound` error naming the command + the
+        //    explicit escape hatch.
+        //
+        //    Callers that KNOW their command is TS-only use
+        //    `execute_ts_json` (or `execute_ts`) directly — those
+        //    public methods stay live for the documented TS-only
+        //    call sites.
+        log.warn(&format!(
+            "no Rust module handles command '{command}' — refusing silent TS fallthrough"
         ));
-        let json = self.execute_ts_command(command, params).await?;
-        Ok(CommandResult::Json(json))
+        Err(format!(
+            "no Rust module handles command: '{command}'. \
+             The implicit TS-bridge fallthrough is disabled per \
+             [[no-fallbacks-ever]]. If this command is intentionally \
+             implemented in TypeScript, the caller must invoke \
+             `CommandExecutor::execute_ts_json` (or `execute_ts`) \
+             explicitly. If this command should be in Rust, register a \
+             `ServiceModule` whose `command_prefixes` covers it."
+        ))
     }
 
     /// Publish a `command:completed` event on the bus (when wired).
@@ -716,16 +744,17 @@ mod tests {
     #[tokio::test]
     async fn airc_interceptor_declines_when_no_airc_target_params() {
         // The airc interceptor at the head of the chain must NOT block
-        // existing local-Rust or TS commands that don't carry airc
-        // routing params. This is the back-compat guarantee that lets
-        // the airc interceptor be safely installed at init_executor.
+        // existing local-Rust commands that don't carry airc routing
+        // params. This is the back-compat guarantee that lets the airc
+        // interceptor be safely installed at init_executor.
         //
         // Without a registered Rust module for "test/cmd", the executor
-        // will fall through past the airc interceptor (Decline) past the
-        // registry (no match) and try to connect to the TS bridge,
-        // which fails in tests because the socket doesn't exist. That
-        // failure is expected: the test is asserting the airc
-        // interceptor did NOT short-circuit, NOT that TS dispatch works.
+        // walks the interceptor chain (airc Declines because no
+        // aircPeer in params), then the registry (no match), then
+        // returns CommandNotFound per [[no-fallbacks-ever]] (task #219).
+        // The test is asserting the airc interceptor did NOT
+        // short-circuit — the failure source MUST be the registry miss,
+        // NOT the airc interceptor.
         let registry = Arc::new(ModuleRegistry::new());
         let executor =
             CommandExecutor::new(registry).with_interceptor(Arc::new(AircInterceptor::new()));
@@ -737,16 +766,21 @@ mod tests {
             )
             .await;
 
-        // We expect the TS bridge connection to fail (no socket in tests).
-        // The IMPORTANT assertion is that the failure came from the TS
-        // bridge, NOT from the airc interceptor — proving the airc
-        // interceptor declined cleanly and the chain fell through.
-        let err = result.expect_err("TS bridge will fail in tests; that's OK");
+        // Failure must be the CommandNotFound shape (no Rust module),
+        // not the airc interceptor short-circuiting. The substring
+        // "no Rust module handles command" is the contract we depend on
+        // — if the airc interceptor had wrongly intercepted, the error
+        // would mention "airc" instead.
+        let err = result.expect_err("command has no Rust handler; expect typed error");
         assert!(
-            !err.contains("airc"),
-            "error must come from TS bridge fallthrough, not from airc \
-             interceptor — otherwise the airc interceptor incorrectly \
-             intercepted a non-airc command. err: {err}"
+            err.contains("no Rust module handles command"),
+            "error must come from registry miss (the no-fallbacks surface), \
+             not from airc interceptor. err: {err}"
+        );
+        assert!(
+            !err.contains("aircPeer") && !err.contains("airc interceptor"),
+            "error must NOT mention airc routing — proves the airc \
+             interceptor declined cleanly. err: {err}"
         );
     }
 
@@ -778,6 +812,57 @@ mod tests {
         assert!(
             err.contains("peer-id"),
             "error must echo the target so the caller can correlate logs: {err}"
+        );
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // No-fallbacks contract (task #219)
+    // ════════════════════════════════════════════════════════════════
+
+    // what this catches: a command not handled by any interceptor and
+    // not registered in the Rust module registry returns a typed
+    // `CommandNotFound`-shaped error per [[no-fallbacks-ever]]. Pre-
+    // PR #1584 the executor silently routed to the TS bridge on
+    // `/tmp/jtag-command-router.sock`, which in headless mode
+    // surfaced as a cryptic "Failed to connect" error and in
+    // hybrid-host mode silently delegated to TS — both breaking the
+    // mental model. The fix: refuse the implicit fallthrough,
+    // surface a typed error that names the missing command and the
+    // explicit escape hatch (`execute_ts_json`).
+    #[tokio::test]
+    async fn unknown_command_returns_typed_no_fallback_error_not_ts_attempt() {
+        let registry = Arc::new(ModuleRegistry::new());
+        let executor = CommandExecutor::new(registry);
+
+        let err = executor
+            .execute("totally/made-up/command", Value::Null)
+            .await
+            .expect_err("unknown command must produce a typed error");
+
+        // Must NOT mention the TS socket or "CommandRouterServer" —
+        // those strings would prove the implicit fallthrough was
+        // still alive. Substring assertions over exact-string
+        // matches so we don't pin too tightly on phrasing.
+        assert!(
+            !err.contains("CommandRouterServer"),
+            "error must NOT attempt the TS fallthrough: {err}"
+        );
+        assert!(
+            !err.contains("/tmp/jtag-command-router.sock"),
+            "error must NOT mention the TS socket path: {err}"
+        );
+
+        // MUST name the missing command so operators know what to
+        // migrate or remove.
+        assert!(
+            err.contains("totally/made-up/command"),
+            "error must name the missing command: {err}"
+        );
+        // MUST point at the explicit escape hatch so a caller that
+        // genuinely meant to hit TS knows what method to call.
+        assert!(
+            err.contains("execute_ts_json") || err.contains("execute_ts"),
+            "error must point at the explicit TS-bridge API: {err}"
         );
     }
 
@@ -942,12 +1027,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ts_bridge_failure_still_emits_completed_event() {
-        // When all 3 dispatch tiers fail (no interceptor handled,
-        // no Rust module registered, TS socket missing in tests) —
-        // the event should still emit with success=false + the TS
-        // connection error. Telemetry must cover every dispatch
-        // path's terminal state.
+    async fn no_rust_module_failure_still_emits_completed_event() {
+        // When all dispatch tiers fail (no interceptor handled, no
+        // Rust module registered, no implicit fallthrough per task
+        // #219) — the event should still emit with success=false +
+        // the typed CommandNotFound error. Telemetry must cover
+        // every dispatch path's terminal state, including the new
+        // no-fallback surface.
         let registry = Arc::new(ModuleRegistry::new());
         let bus = Arc::new(MessageBus::new());
         let mut rx = bus.receiver();
@@ -956,8 +1042,10 @@ mod tests {
         let err = executor
             .execute("nonexistent/command", serde_json::json!({}))
             .await
-            .expect_err("TS socket missing in tests");
-        // Don't assert specific TS error text; just confirm it's an Err.
+            .expect_err("unknown command produces typed error");
+        // Don't pin specific error text here; just confirm it's an
+        // Err. The dedicated `unknown_command_returns_typed_no_fallback_error_not_ts_attempt`
+        // test pins the exact contract.
         let _ = err;
 
         let event = next_command_completed(&mut rx).await;
@@ -965,7 +1053,7 @@ mod tests {
         assert!(!event.success);
         assert!(
             event.error.is_some(),
-            "TS bridge failure path must populate error: {event:?}"
+            "no-fallback failure path must populate error: {event:?}"
         );
     }
 

--- a/core/continuum-core/src/runtime/command_executor.rs
+++ b/core/continuum-core/src/runtime/command_executor.rs
@@ -1,24 +1,34 @@
-//! CommandExecutor — Universal command execution for ALL continuum-core processes
+//! CommandExecutor — universal command execution for substrate-internal callers
 //!
-//! This is the foundational primitive that allows ANY spawned task (sentinels,
-//! background jobs, etc.) to execute ANY command in the system, regardless of
-//! whether it's implemented in Rust or TypeScript.
+//! Foundational primitive that lets any spawned task (sentinels, persona
+//! loops, background jobs) dispatch any command in the substrate. The
+//! implicit dispatch chain is **Rust-only** per `[[no-fallbacks-ever]]`
+//! (task #219). Commands that have no Rust handler produce a typed
+//! `CommandNotFound` error — there is no silent fallthrough to a TS
+//! host.
 //!
 //! Usage:
 //! ```rust
-//! // Works for Rust modules
+//! // Implicit dispatch — Rust modules + interceptors only.
+//! // Unknown commands return Err("no Rust module handles command: ...").
 //! runtime::execute_command_json("health-check", json!({})).await?;
 //!
-//! // Works for TypeScript commands (via CommandRouterServer)
-//! runtime::execute_command_json("screenshot", json!({"querySelector": "body"})).await?;
-//!
-//! // Sentinel doesn't know or care where command is implemented
+//! // Explicit TS-bridge dispatch — for the ~6 documented TS-only call
+//! // sites that knowingly target a TypeScript handler.
+//! // executor.execute_ts_json("ai/agent", params).await?;
 //! ```
 //!
 //! Architecture:
-//! - Rust modules: Routed directly through ModuleRegistry
-//! - TypeScript commands: Routed via Unix socket to CommandRouterServer
-//!   (socket: /tmp/jtag-command-router.sock)
+//! - Implicit chain: interceptors (airc, grid, ...) → Rust module
+//!   registry → typed `CommandNotFound` error. Substrate-internal.
+//! - Explicit TS bridge: `execute_ts` / `execute_ts_json` public
+//!   methods over Unix socket `/tmp/jtag-command-router.sock`. Used
+//!   only by the documented TS-only call sites (sentinel steps, grid
+//!   connection retry, ai_provider cloud-adapter fallthrough).
+//!
+//! Per `[[rust-is-the-core-node-is-the-shell]]`: substrate dispatch
+//! ends at the Rust registry. TS is an explicit-API destination, not
+//! a silent dependency.
 
 use serde_json::Value;
 use std::sync::Arc;
@@ -822,7 +832,7 @@ mod tests {
     // what this catches: a command not handled by any interceptor and
     // not registered in the Rust module registry returns a typed
     // `CommandNotFound`-shaped error per [[no-fallbacks-ever]]. Pre-
-    // PR #1584 the executor silently routed to the TS bridge on
+    // PR #1585 the executor silently routed to the TS bridge on
     // `/tmp/jtag-command-router.sock`, which in headless mode
     // surfaced as a cryptic "Failed to connect" error and in
     // hybrid-host mode silently delegated to TS — both breaking the


### PR DESCRIPTION
## Summary

Closes task #219 — the [[no-fallbacks-ever]] violation in `CommandExecutor`.

Before: when no Rust module owned a command, `execute_inner` silently routed to the TS bridge at `/tmp/jtag-command-router.sock`. Two failure modes — in headless mode this surfaced as a cryptic "Failed to connect" error; in hybrid-host mode it silently delegated to TS — both breaking the substrate's "Rust is the core" mental model.

After: the executor refuses the implicit fallthrough and returns a typed error naming the missing command and the explicit escape hatch. Callers that genuinely want the TS bridge continue using `execute_ts` / `execute_ts_json` directly.

## What changed

- `runtime/command_executor.rs`:
  - Doctrine docstring rewritten — "No silent TS fallthrough" replaces "TypeScript via Unix socket" item.
  - `execute_inner` step 3: typed Err instead of silent `execute_ts_command` call.
  - Existing `airc_interceptor_declines_when_no_airc_target_params` test updated for the new error shape.
  - New regression test: `unknown_command_returns_typed_no_fallback_error_not_ts_attempt` pins the contract (error must NOT mention TS socket, MUST name the missing command, MUST point at the explicit API).
  - Renamed `ts_bridge_failure_still_emits_completed_event` → `no_rust_module_failure_still_emits_completed_event`.

- `routing/command_handler.rs`:
  - Comment reference updated from "TS-bridge fallthrough" to "[[no-fallbacks-ever]] task #219".

## Architecture-proof linkage

This PR provides a **shape-1 unit-level invariant proof** for the "No silent TS fallthrough" doctrine clause in [`SUBSTRATE-DOCTRINE-ORGANIC-FLOW.md`](docs/architecture/SUBSTRATE-DOCTRINE-ORGANIC-FLOW.md). Per the matrix in [`PROVING-THE-DOCTRINE.md`](docs/architecture/PROVING-THE-DOCTRINE.md), this clause flips from 🟡 to ✅.

(Both docs land in PR #1584 — `docs/proof-discipline` branch.)

## Test plan

- [x] `cargo check -p continuum-core --lib --features metal,accelerate` — clean
- [x] `cargo test runtime::command_executor` — 86/86 pass
- [x] `cargo test routing::command_handler modules::grid` — pass
- [x] Full lib suite: 4324/4325 pass. The one failure is `routing::uri_layer::tests::no_subscriber_returns_empty_chain`, the known global tracing subscriber pollution flake (task #203). Confirmed passes in isolation.
- [ ] Adversarial reviewer on canary

## Doctrine alignment

- `[[no-fallbacks-ever]]` — implicit fallthrough was the textbook violation; this PR closes it.
- `[[rust-is-the-core-node-is-the-shell]]` — substrate dispatch ends at the Rust registry. TS is an explicit-API destination, not a silent dependency.
- `[[headless-rust-must-work-soon]]` — headless boot no longer appears broken just because no TS host is around.

## Related

- Task #219 (this PR)
- Builds on #224 (GLOBAL_EXECUTOR deletion), #225/#226/#227 (TS migration campaign)
- Next-up: task #229 (delete dead TS cloud-adapter dirs) extends the cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
