### PR TITLE
test(arch): close two nits from #1589 review (pub-use prefix + symmetry)

### DIFF
--- a/core/continuum-core/tests/architecture_engine_os_layering.rs
+++ b/core/continuum-core/tests/architecture_engine_os_layering.rs
@@ -96,6 +96,11 @@ fn scan_for_violations(src_root: &Path) -> Vec<Violation> {
         };
         for (idx, raw_line) in content.lines().enumerate() {
             let trimmed = raw_line.trim_start();
+            // Strip a leading `pub ` so `pub use crate::runtime::<sub>::*`
+            // (re-export from an intermediate module) is also caught — that
+            // shape leaks the same engine-internal path through the consumer's
+            // public surface.
+            let trimmed = trimmed.trim_start_matches("pub ");
             // Match both `use crate::runtime::<sub>::*` and
             // `use super::runtime::<sub>::*` (the latter is unusual
             // but possible from intermediate modules).
@@ -238,4 +243,53 @@ fn runtime_internal_submodule_use_is_allowed() {
             "FORBIDDEN_RUNTIME_SUBMODULES is stale: '{sub}' not declared in runtime/mod.rs"
         );
     }
+}
+
+// proves: engine-OS layering (symmetric closure — every submodule declared
+// in runtime/mod.rs is tracked in FORBIDDEN_RUNTIME_SUBMODULES, so a NEW
+// submodule added without updating this list doesn't open a silent gap)
+#[test]
+fn every_runtime_submodule_is_tracked() {
+    let root = src_root();
+    let mod_rs = root.join("runtime").join("mod.rs");
+    let mod_content = fs::read_to_string(&mod_rs).expect("read runtime/mod.rs");
+
+    let mut declared: Vec<String> = Vec::new();
+    for raw_line in mod_content.lines() {
+        let line = raw_line.trim_start();
+        // `pub(crate) mod` is internal-only; the layering rule applies to
+        // submodules consumers could reach for (i.e. `pub mod`).
+        let Some(rest) = line.strip_prefix("pub mod ") else {
+            continue;
+        };
+        let Some(name) = rest.split(';').next() else {
+            continue;
+        };
+        let name = name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        declared.push(name.to_string());
+    }
+
+    assert!(
+        !declared.is_empty(),
+        "parser failed: no `pub mod X;` lines found in runtime/mod.rs"
+    );
+
+    let tracked: std::collections::HashSet<&str> =
+        FORBIDDEN_RUNTIME_SUBMODULES.iter().copied().collect();
+
+    let untracked: Vec<&String> = declared.iter().filter(|d| !tracked.contains(d.as_str())).collect();
+
+    assert!(
+        untracked.is_empty(),
+        "Engine-OS layering gap: runtime submodules declared in \
+         runtime/mod.rs but NOT tracked in FORBIDDEN_RUNTIME_SUBMODULES: \
+         {untracked:?}. A new submodule was added without extending the \
+         ratchet list — consumers could `use crate::runtime::<new>::Item` \
+         and the ratchet wouldn't catch it. Add each name to \
+         FORBIDDEN_RUNTIME_SUBMODULES and rebaseline GRANDFATHERED_VIOLATIONS \
+         if any callers already reach in."
+    );
 }

--- a/core/continuum-core/tests/architecture_engine_os_layering.rs
+++ b/core/continuum-core/tests/architecture_engine_os_layering.rs
@@ -96,11 +96,17 @@ fn scan_for_violations(src_root: &Path) -> Vec<Violation> {
         };
         for (idx, raw_line) in content.lines().enumerate() {
             let trimmed = raw_line.trim_start();
-            // Strip a leading `pub ` so `pub use crate::runtime::<sub>::*`
-            // (re-export from an intermediate module) is also caught — that
-            // shape leaks the same engine-internal path through the consumer's
-            // public surface.
-            let trimmed = trimmed.trim_start_matches("pub ");
+            // Strip any leading visibility modifier so all four shapes are
+            // caught: `use ...`, `pub use ...`, `pub(crate) use ...`,
+            // `pub(super) use ...`. Each one leaks the same engine-internal
+            // path through the consumer's (re-)export surface. Order matters:
+            // strip the longer `pub(crate)` / `pub(super)` forms first so
+            // they don't fall through to the shorter `pub ` matcher with a
+            // leftover `(crate) ` / `(super) ` prefix.
+            let trimmed = trimmed
+                .trim_start_matches("pub(crate) ")
+                .trim_start_matches("pub(super) ")
+                .trim_start_matches("pub ");
             // Match both `use crate::runtime::<sub>::*` and
             // `use super::runtime::<sub>::*` (the latter is unusual
             // but possible from intermediate modules).
@@ -262,10 +268,15 @@ fn every_runtime_submodule_is_tracked() {
         let Some(rest) = line.strip_prefix("pub mod ") else {
             continue;
         };
-        let Some(name) = rest.split(';').next() else {
+        // Take the first whitespace-delimited token, then strip a trailing
+        // `;`. This handles `pub mod X;`, `pub mod X; // comment`, AND the
+        // inline `pub mod X { ... }` shape (mod with body) — extracting just
+        // `X` in all three cases. Plain `split(';')` alone would yield
+        // `X { ... }` for the inline-body case.
+        let Some(name) = rest.split_whitespace().next() else {
             continue;
         };
-        let name = name.trim();
+        let name = name.trim_end_matches(';');
         if name.is_empty() {
             continue;
         }


### PR DESCRIPTION
## Summary

Two adversarial-review nits from PR #1589's APPROVE-WITH-NITS verdict, shipped as their own tiny ratchet PR.

- **Nit 1 — `pub use` prefix bypass.** Scanner missed `pub use crate::runtime::<sub>::*` re-exports from intermediate modules. Fix: strip a leading `pub ` after `trim_start()`.
- **Nit 3 — symmetric closure.** New test `every_runtime_submodule_is_tracked` parses `pub mod X;` from `runtime/mod.rs` and asserts each name is in `FORBIDDEN_RUNTIME_SUBMODULES`. Closes the "future PR adds new submodule, ratchet doesn't notice" silent gap.

Both are defense-in-depth on a ratchet that was already correct for today's tree. Grandfathered count stays at **29** — these don't fix existing violations, they close future-shaped holes.

Nit 2 (inline `crate::runtime::<sub>::Item` references) deferred — wants its own ratchet field; tracked under task #240.

## Test plan

- [x] `cargo test -p continuum-core --test architecture_engine_os_layering --features metal,accelerate` — 3/3 pass; was 2/2
- [x] Manual sanity: every `pub mod X;` in `runtime/mod.rs` is tracked

## Doctrine alignment

- `[[no-fallbacks-ever]]` — the ratchet IS the engine-OS layering's no-fallback equivalent at the build-graph layer
- `[[abstract-into-literal-design-principle]]` — recipe ships with literal first state of 29 grandfathered; every PR ratchets down

## Related

- Closes nit 1 + nit 3 from PR #1589's adversarial review
- Task #240 — architecture-test matrix, second proof rolling forward
- Nit 2 inline references → follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
