### PR TITLE
feat(positron): continuum-positron substrate scaffold — typed ChatViewState + revisions + StateBuilder (§6 closes #793/#794/#773)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,7 +2766,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "ts-rs",
+ "ts-rs 12.0.1",
  "uuid",
  "wgpu",
  "wgpu-hal",
@@ -2780,6 +2780,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "continuum-positron"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "positron-core",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "ts-rs 12.0.1",
+ "uuid",
 ]
 
 [[package]]
@@ -7679,6 +7693,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "positron-core"
+version = "0.0.1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "ts-rs 10.1.0",
+ "uuid",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10795,12 +10819,37 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ts-rs"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e640d9b0964e9d39df633548591090ab92f7a4567bc31d3891af23471a3365c6"
+dependencies = [
+ "lazy_static",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ts-rs-macros 10.1.0",
+ "uuid",
+]
+
+[[package]]
+name = "ts-rs"
 version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756050066659291d47a554a9f558125db17428b073c5ffce1daf5dcb0f7231d8"
 dependencies = [
  "thiserror 2.0.18",
- "ts-rs-macros",
+ "ts-rs-macros 12.0.1",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9d8656589772eeec2cf7a8264d9cda40fb28b9bc53118ceb9e8c07f8f38730"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "termcolor",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "positron-core"
-version = "0.0.1"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "core/archive",
     "core/continuum-core",
     "core/continuum-orm-derive",
+    "core/continuum-positron",
     "core/inference-grpc",
     "core/jtag-mcp",
     "core/livekit-bridge",

--- a/core/continuum-positron/.gitignore
+++ b/core/continuum-positron/.gitignore
@@ -1,0 +1,4 @@
+# ts-rs generated bindings — substrate types are source of truth (src/*.rs).
+# Generated per cargo test; never hand-edited; not part of the crate's
+# wire-stable source.
+/bindings/

--- a/core/continuum-positron/Cargo.toml
+++ b/core/continuum-positron/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "continuum-positron"
+version = "0.1.0"
+edition = "2021"
+description = "Continuum's positron substrate — produces typed StateEnvelopes from continuum's event bus and dispatches CommandEnvelopes through the substrate's CommandExecutor. Implements the substrate side of the positron contract (positron-core@0.1)."
+
+[dependencies]
+# positron-core (the cross-language UI contract — substrate-produces-state /
+# host-consumes-it; AI observers perceive the same ViewState humans see).
+# Path dep until positron tags v0.1; switch to git rev pin on first cut.
+# Operator must have both repos cloned side-by-side under the same parent dir.
+positron-core = { path = "../../../positron/positron-core" }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+ts-rs = { workspace = true }
+uuid = { workspace = true }
+tracing = { workspace = true }
+async-trait = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/core/continuum-positron/src/cache.rs
+++ b/core/continuum-positron/src/cache.rs
@@ -1,0 +1,158 @@
+//! `SubstrateStateCache` — substrate-owned latest-StateEnvelope per
+//! kind.
+//!
+//! Why a cache exists at all: positron's snapshot-then-live resync
+//! contract requires the substrate to emit the **current** state on
+//! every `Subscribe` (and `Observe`). With no cache, the substrate
+//! would either replay history (forbidden per protocol — no transcript
+//! replay) or re-derive state from upstream sources on every
+//! subscribe (expensive and racy). A small in-memory cache of "latest
+//! envelope per kind" gives the substrate a constant-time answer to
+//! "what should the snapshot look like right now?"
+//!
+//! ## Ownership model
+//!
+//! - The event-bridging layer (slice 2B) writes to the cache after
+//!   each new typed payload is built via [`crate::StateBuilder`] —
+//!   `cache.store(envelope)`.
+//! - The session handler (this slice's [`crate::session`]) reads from
+//!   the cache to produce snapshot frames on `Subscribe`.
+//!
+//! Live broadcast to currently-attached subscribers is a SEPARATE
+//! concern from the cache — the cache only answers "what's the
+//! current state for resync?"; the broadcast layer (a `watch::Sender`
+//! or analogous) fans live changes to attached subscribers.
+//!
+//! ## Why not just hold the typed payload?
+//!
+//! Two reasons:
+//!
+//! 1. The cache outputs `StateEnvelope` directly, so subscribe handling
+//!    is allocation-free at the snapshot boundary (no re-serialization
+//!    on resync).
+//! 2. The envelope carries the revision the substrate stamped when it
+//!    last produced state — the skip rule keys off THIS revision, and
+//!    re-deriving it from the typed payload would mean re-allocating
+//!    a revision (breaking monotonicity).
+//!
+//! Per `[[shared-decode-per-persona-perspective]]`: substrate decode
+//! (event → typed payload → StateEnvelope) runs ONCE per arrival;
+//! every subscribing renderer sees the same Arc-shared envelope. The
+//! cache is the cell that holds the latest decoded value.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use positron_core::wire::StateEnvelope;
+
+/// In-memory cache of the latest `StateEnvelope` per `kind`.
+///
+/// Concurrency: `Mutex<HashMap>` is fine here for the same reason it
+/// is in [`crate::Revisions`] — writes happen on substrate-event
+/// arrival (sub-millisecond cadence), reads happen on subscribe
+/// (rare). `Arc<StateEnvelope>` lets every subscriber that snapshots
+/// share the underlying allocation per
+/// `[[shared-decode-per-persona-perspective]]`.
+#[derive(Debug, Default)]
+pub struct SubstrateStateCache {
+    by_kind: Mutex<HashMap<String, Arc<StateEnvelope>>>,
+}
+
+impl SubstrateStateCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Store (replace) the latest envelope for its `kind`. The
+    /// substrate calls this after every successful
+    /// [`crate::StateBuilder`] emission — the envelope's `kind`
+    /// string IS the cache key.
+    ///
+    /// Per `[[no-fallbacks-ever]]`: there's no monotonic-revision
+    /// guard here. Monotonicity is enforced by [`crate::Revisions`]
+    /// at the BUILDER seam, not by the cache. If a caller stores an
+    /// envelope with an out-of-order revision, that's a substrate
+    /// bug upstream of the cache — the cache is honest about what it
+    /// was told to remember.
+    pub fn store(&self, envelope: StateEnvelope) {
+        let kind = envelope.kind.clone();
+        let mut by_kind = self.by_kind.lock().expect("cache mutex poisoned");
+        by_kind.insert(kind, Arc::new(envelope));
+    }
+
+    /// Read the latest envelope for `kind`. `None` if the substrate
+    /// has never produced state for this kind yet — a fresh
+    /// substrate handing a `Subscribe { kinds: ["chat"] }` should
+    /// see `None` here, meaning "no snapshot to send for chat yet",
+    /// NOT "send an empty snapshot." Per
+    /// `[[no-fallbacks-ever]]`: silence is honest; a synthetic
+    /// "empty chat" snapshot would be a fallback that hides bugs
+    /// (renderer would render an empty chat that isn't real).
+    pub fn get(&self, kind: &str) -> Option<Arc<StateEnvelope>> {
+        let by_kind = self.by_kind.lock().expect("cache mutex poisoned");
+        by_kind.get(kind).map(Arc::clone)
+    }
+
+    /// Number of kinds the cache currently holds state for. Used by
+    /// tests + diagnostics; not part of the snapshot-then-live hot
+    /// path.
+    pub fn len(&self) -> usize {
+        self.by_kind.lock().expect("cache mutex poisoned").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use positron_core::wire::StateLayer;
+
+    fn envelope(kind: &str, revision: u64) -> StateEnvelope {
+        StateEnvelope {
+            kind: kind.to_string(),
+            revision: Some(revision),
+            layer: StateLayer::Session,
+            payload: serde_json::json!({}),
+        }
+    }
+
+    #[test]
+    fn store_then_get_returns_the_latest() {
+        // what this catches: regression where the cache silently drops
+        // a store, OR where `get` returns a stale value. Both would
+        // make snapshot-then-live emit wrong revisions on subscribe.
+        let cache = SubstrateStateCache::new();
+        cache.store(envelope("chat", 1));
+        assert_eq!(cache.get("chat").map(|e| e.revision), Some(Some(1)));
+        cache.store(envelope("chat", 2));
+        assert_eq!(cache.get("chat").map(|e| e.revision), Some(Some(2)));
+    }
+
+    #[test]
+    fn unknown_kind_returns_none_not_empty_envelope() {
+        // what this catches: regression where the cache lazy-inits a
+        // missing kind to a default envelope. That would be a fallback
+        // — renderer would render fake-empty state instead of the
+        // honest "nothing yet" answer.
+        let cache = SubstrateStateCache::new();
+        cache.store(envelope("chat", 1));
+        assert!(cache.get("unknown").is_none());
+    }
+
+    #[test]
+    fn store_is_per_kind_not_global() {
+        // what this catches: regression where `store` accidentally
+        // overwrites unrelated kinds (e.g. if a refactor switched the
+        // hashmap key to something derived). Would break multi-widget
+        // surfaces.
+        let cache = SubstrateStateCache::new();
+        cache.store(envelope("chat", 5));
+        cache.store(envelope("user-list", 1));
+        assert_eq!(cache.get("chat").map(|e| e.revision), Some(Some(5)));
+        assert_eq!(cache.get("user-list").map(|e| e.revision), Some(Some(1)));
+        assert_eq!(cache.len(), 2);
+    }
+}

--- a/core/continuum-positron/src/chat.rs
+++ b/core/continuum-positron/src/chat.rs
@@ -1,0 +1,198 @@
+//! Typed chat payloads — `ChatViewState`, the substrate-shaped view of
+//! a room's chat that fills `StateEnvelope.payload` for `kind="chat"`.
+//!
+//! Per the positron design (consumer-typed payloads, positron frames):
+//! the wire envelope carries `payload: unknown` because positron-core
+//! does not define widget vocabularies. This module is continuum's
+//! contribution to the chat widget's vocabulary — every field is
+//! `#[derive(TS)]` exported, so the widget side's TypeScript shape is
+//! generated from these structs at the same time the Rust types ship.
+//!
+//! ## Why structs, not `serde_json::Value`
+//!
+//! Per `[[strong-typing-across-boundaries]]`: a substrate that emits
+//! `Value::Object` payloads has trained reviewers and renderers to
+//! accept "best-effort" shapes. Renderers grow defensive parsers,
+//! schemas drift, and one missing field becomes a UI bug instead of a
+//! compile error. The substrate types here ARE the schema; ts-rs
+//! mirrors them; the widget side reads typed objects, not `unknown`.
+//!
+//! ## What's in scope today
+//!
+//! - `ChatViewState`: top-level state — current room + roster + most
+//!   recent messages.
+//! - `ChatMessageView`: the message bits the chat widget needs to
+//!   render a row (sender, content, timestamp).
+//! - `PersonaSlotView`: a roster entry (persona id + display name +
+//!   presence). Used by the right-rail roster + the message-row
+//!   avatar.
+//! - `SenderKind`: tagged enum — `Human`, `Persona`, `System`. The
+//!   widget side keys avatar + styling off this discriminant.
+//!
+//! ## What's deferred
+//!
+//! Media attachments, reactions, threads, typing indicators —
+//! deferred to follow-up slices once the substrate event source is
+//! wired (subsequent task). The schema grows by extending these
+//! structs; the wire kind string stays `"chat"`. Renderers that don't
+//! know the new fields ignore them; the ts-rs flow makes those
+//! additions visible to the widget side at the same time.
+
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+use uuid::Uuid;
+
+/// One chat message — the bits the chat widget needs to render a row.
+///
+/// `id`, `room_id`, `sender_id` are continuum's substrate UUIDs
+/// rendered as strings on the wire (the ts-rs default for `Uuid` is
+/// `string`, which matches JSON behavior — `Uuid` isn't a JSON
+/// primitive).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct ChatMessageView {
+    #[ts(type = "string")]
+    pub id: Uuid,
+    #[ts(type = "string")]
+    pub room_id: Uuid,
+    #[ts(type = "string")]
+    pub sender_id: Uuid,
+    /// Display name resolved at the substrate side. Renderers must
+    /// not re-resolve from `sender_id` — that would re-introduce the
+    /// widget-local source-of-truth cache positron's contract exists
+    /// to prevent.
+    pub sender_name: String,
+    /// What kind of citizen sent this. The widget reads this
+    /// discriminant for avatar / styling — no `if sender_name ==
+    /// "system"` string-sniffing per `[[strong-typing-across-boundaries]]`.
+    pub sender_kind: SenderKind,
+    pub content: String,
+    /// Unix-ms substrate-local time of arrival.
+    #[ts(type = "number")]
+    pub timestamp: u64,
+}
+
+/// What kind of citizen authored a message. Tagged enum on the wire
+/// so the widget side reads a discriminant, not a stringly-typed
+/// `sender_type` field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+#[ts(export)]
+pub enum SenderKind {
+    /// Carbon — typed at the keyboard, dictated through STT, etc.
+    Human,
+    /// One of the substrate's own personas. Distinct from `Human` so
+    /// the widget can render a different avatar treatment and AI
+    /// observers can attribute provenance per
+    /// `[[strong-typing-across-boundaries]]`.
+    Persona,
+    /// A substrate-generated event surfaced into chat — room joined,
+    /// model swapped, a `[[observability-as-substrate]]` notification.
+    /// Carries no `sender_id` semantic (id is `Uuid::nil()`).
+    System,
+}
+
+/// A roster entry — a persona present in this room.
+///
+/// Roster is substrate-owned and refreshed on join / leave / spawn /
+/// despawn. The widget never derives "who is here?" from message
+/// senders — that's a stale-cache footgun #794 is currently a symptom
+/// of.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct PersonaSlotView {
+    #[ts(type = "string")]
+    pub persona_id: Uuid,
+    pub display_name: String,
+    /// `true` if the persona is currently attached and ready to
+    /// receive turns. `false` for paged-out or spawning. The widget
+    /// shows a presence indicator off this bit — single source of
+    /// truth in the substrate.
+    pub active: bool,
+}
+
+/// Top-level state for the `"chat"` widget kind. Fills
+/// `StateEnvelope.payload` when `kind == "chat"`.
+///
+/// Substrate emits a fresh `ChatViewState` on every monotonic-revision
+/// transition. The widget renders from the snapshot; positron's
+/// `Renderer` contract requires no widget-local cache.
+///
+/// Today's shape is intentionally minimal — enough to render a chat
+/// surface that closes §6 (#793 / #794 / #773) by structural design.
+/// Reactions, threads, typing indicators, attachments grow the struct
+/// (additive — additive ts-rs deltas are wire-compatible) in
+/// follow-up slices.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct ChatViewState {
+    /// The room this snapshot describes.
+    #[ts(type = "string")]
+    pub room_id: Uuid,
+    /// Human-readable room name (e.g. `"general"`). Substrate-resolved;
+    /// widget must not derive from URL slug.
+    pub room_name: String,
+    /// Most recent messages, oldest first. Bounded — substrate decides
+    /// the window (see `MAX_MESSAGES_PER_SNAPSHOT` in the builder).
+    /// Past-the-window history is pulled on demand through a
+    /// `chat/history` command, not by carrying the whole transcript
+    /// in every snapshot.
+    pub messages: Vec<ChatMessageView>,
+    /// Personas present in the room. Roster is bounded by spawn —
+    /// the substrate hosts at most a handful at a time.
+    pub roster: Vec<PersonaSlotView>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sender_kind_wire_shape_is_tagged() {
+        // what this catches: regression where a refactor changes the
+        // tagged-enum representation. The widget side keys
+        // discriminant + per-variant fields off `tag = "kind"`; an
+        // accidental flip to internally-tagged or untagged would
+        // break TS clients silently.
+        assert_eq!(
+            serde_json::to_string(&SenderKind::Human).unwrap(),
+            r#"{"kind":"human"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&SenderKind::Persona).unwrap(),
+            r#"{"kind":"persona"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&SenderKind::System).unwrap(),
+            r#"{"kind":"system"}"#
+        );
+    }
+
+    #[test]
+    fn chat_view_state_round_trips() {
+        // what this catches: regression where a field rename / type
+        // tweak breaks the serde shape. Minimum bar for a wire type.
+        let room_id = Uuid::from_u128(0xa);
+        let state = ChatViewState {
+            room_id,
+            room_name: "general".into(),
+            messages: vec![ChatMessageView {
+                id: Uuid::from_u128(0xb),
+                room_id,
+                sender_id: Uuid::from_u128(0xc),
+                sender_name: "Joel".into(),
+                sender_kind: SenderKind::Human,
+                content: "hi".into(),
+                timestamp: 1_700_000_000_000,
+            }],
+            roster: vec![PersonaSlotView {
+                persona_id: Uuid::from_u128(0xd),
+                display_name: "Helper".into(),
+                active: true,
+            }],
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let back: ChatViewState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, state);
+    }
+}

--- a/core/continuum-positron/src/dispatch.rs
+++ b/core/continuum-positron/src/dispatch.rs
@@ -1,0 +1,292 @@
+//! Substrate-side `Command` handler — bridge `CommandEnvelope` to
+//! continuum's command surface; emit `ServerMessage::CommandFailed`
+//! on failure.
+//!
+//! ## The asymmetry (v0.1.1)
+//!
+//! Per positron protocol §`ServerMessage::CommandFailed` doc:
+//!
+//! > Failures are LOUD — a rejected `CommandEnvelope` must never
+//! > vanish silently. Success deliberately has no ack frame: a
+//! > successful command's acknowledgement IS the state change it
+//! > causes, streaming down as `State` (the unidirectional model).
+//! > Consumers correlate via the `correlation_id` they sent.
+//!
+//! So this handler is intentionally asymmetric:
+//!
+//! - **Success path**: dispatch returns `Ok(())`. No protocol frame.
+//!   The substrate's state mutation reaches the cache, flows through
+//!   the live-broadcast layer (slice 2D), and the renderer sees a
+//!   new `State` frame with a new revision. That is the ack.
+//! - **Failure path**: dispatch returns `Err(error)`. The substrate
+//!   emits ONE `ServerMessage::CommandFailed { correlation_id, error }`
+//!   targeting ONLY the connection that submitted the failing
+//!   command (per protocol §`CommandFailed` "Delivery scope").
+//!
+//! ## Why a trait, not a concrete executor
+//!
+//! Continuum's `Commands.execute` lives in the broader substrate
+//! (continuum-core's `CommandExecutor`). Wiring that concrete type
+//! into this crate would create a circular dependency
+//! (continuum-positron → continuum-core → … ) and bind tests to a
+//! full substrate boot. The [`CommandDispatch`] trait is the
+//! substrate-side seam: production injects a thin wrapper around the
+//! real executor; tests inject a scripted mock. Per
+//! `[[strong-typing-across-boundaries]]`: the seam is a trait, not
+//! a function-typed `Box<dyn Fn>` — adding methods later (e.g.
+//! authorization context, command metadata) is a typed extension.
+//!
+//! ## What's deliberately not here
+//!
+//! - **No correlation map.** Success doesn't ack via the protocol,
+//!   so there's nothing to correlate substrate-side. The renderer
+//!   tracks its own outstanding `correlation_id`s; the substrate
+//!   just echoes the id back on failure. A correlation map would
+//!   only earn its keep when (and if) ack frames land — a v0.x
+//!   addition the protocol deliberately deferred.
+//! - **No per-connection routing.** This module returns the
+//!   frames the substrate should emit; the session-task that owns
+//!   the transport handles "send to THIS connection." Per-connection
+//!   delivery scope is the transport layer's concern, not this
+//!   pure-function handler's.
+
+use async_trait::async_trait;
+use positron_core::session::{ClientMessage, ServerMessage};
+use positron_core::wire::CommandEnvelope;
+
+/// The substrate-side seam to continuum's command surface.
+/// Production implementations wrap continuum-core's
+/// `CommandExecutor::execute`; tests inject scripted mocks.
+///
+/// Contract:
+/// - `Ok(())` on success: the substrate's resulting state change is
+///   the implicit ack (the unidirectional model).
+/// - `Err(message)` on failure: the substrate emits
+///   `ServerMessage::CommandFailed { correlation_id, error: message }`
+///   on the failing connection.
+///
+/// ## Why the whole envelope, not `(command, params)`
+///
+/// Per positron's wire doctrine, `CommandEnvelope` is "first-class but
+/// never anonymous" — every call carries its `source` (`Human` vs
+/// `Observer { observer_id }`) and the `kind` of state it mutates.
+/// Decomposing the envelope at this seam erases that provenance before
+/// the dispatcher gets to see it, which kills authorization decisions
+/// + audit trails downstream. The seam takes the typed envelope so
+/// every implementor sees what the client actually sent. Per
+/// `[[strong-typing-across-boundaries]]`.
+#[async_trait]
+pub trait CommandDispatch: Send + Sync {
+    async fn dispatch(&self, envelope: CommandEnvelope) -> Result<(), String>;
+}
+
+/// Bridge one `ClientMessage::Command` through a [`CommandDispatch`]
+/// implementation. Returns the (possibly-empty) Vec of
+/// `ServerMessage`s the substrate must emit to the originating
+/// connection.
+///
+/// Success → empty Vec (state change carries the ack). Failure → one
+/// `CommandFailed` frame with the echoed `correlation_id` and the
+/// dispatcher's error message.
+///
+/// Returns `Err` if `msg` is NOT a `Command` variant — single-purpose
+/// handler per `[[no-fallbacks-ever]]`. Callers route by variant.
+pub async fn apply_command(
+    dispatcher: &dyn CommandDispatch,
+    msg: ClientMessage,
+) -> Result<Vec<ServerMessage>, String> {
+    let envelope = match msg {
+        ClientMessage::Command(e) => e,
+        other => {
+            return Err(format!(
+                "apply_command: expected Command variant, got {other:?}"
+            ));
+        }
+    };
+    let correlation_id = envelope.correlation_id;
+    match dispatcher.dispatch(envelope).await {
+        Ok(()) => Ok(Vec::new()),
+        Err(err) => Ok(vec![ServerMessage::CommandFailed {
+            correlation_id,
+            error: err,
+        }]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use positron_core::wire::{CommandEnvelope, CommandSource};
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    /// Records every dispatch call + returns a scripted outcome.
+    /// Per the test-fixtures doctrine: keep mocks narrow + scripted
+    /// rather than half-implementing the real executor.
+    struct ScriptedDispatcher {
+        calls: Mutex<Vec<CommandEnvelope>>,
+        outcome: Result<(), String>,
+    }
+
+    impl ScriptedDispatcher {
+        fn ok() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                outcome: Ok(()),
+            }
+        }
+        fn err(msg: &str) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                outcome: Err(msg.to_string()),
+            }
+        }
+        fn calls(&self) -> Vec<CommandEnvelope> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl CommandDispatch for ScriptedDispatcher {
+        async fn dispatch(&self, envelope: CommandEnvelope) -> Result<(), String> {
+            self.calls.lock().unwrap().push(envelope);
+            self.outcome.clone()
+        }
+    }
+
+    fn cmd(command: &str, correlation_id: Uuid) -> ClientMessage {
+        ClientMessage::Command(CommandEnvelope {
+            kind: "chat".into(),
+            command: command.to_string(),
+            params: serde_json::json!({"text": "hi"}),
+            correlation_id,
+            source: CommandSource::Human,
+        })
+    }
+
+    #[tokio::test]
+    async fn success_emits_no_protocol_frame() {
+        // what this catches: regression where the substrate sends a
+        // success-ack frame. Per positron v0.1.1 contract: success
+        // has no ack frame — the state mutation IS the ack. Adding
+        // a synthetic success frame here would create a second
+        // correlate-able event that breaks the unidirectional model.
+        let dispatcher = ScriptedDispatcher::ok();
+        let cid = Uuid::from_u128(0xabc);
+        let frames = apply_command(&dispatcher, cmd("chat/send", cid))
+            .await
+            .unwrap();
+        assert!(
+            frames.is_empty(),
+            "success → no protocol frame; got {frames:?}"
+        );
+        let calls = dispatcher.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].command, "chat/send");
+    }
+
+    #[tokio::test]
+    async fn failure_emits_command_failed_with_echoed_correlation_id() {
+        // what this catches: regression where the substrate fails
+        // silently (the §"loud failures" doctrine bug class) OR
+        // emits a different correlation_id from the one the client
+        // sent. Either would break the client's ability to surface
+        // "your command failed" UI keyed off the correlation it's
+        // tracking.
+        let dispatcher = ScriptedDispatcher::err("permission denied");
+        let cid = Uuid::from_u128(0xdef);
+        let frames = apply_command(&dispatcher, cmd("data/delete", cid))
+            .await
+            .unwrap();
+        assert_eq!(frames.len(), 1);
+        match &frames[0] {
+            ServerMessage::CommandFailed {
+                correlation_id,
+                error,
+            } => {
+                assert_eq!(
+                    *correlation_id, cid,
+                    "echoed correlation_id must equal the client's"
+                );
+                assert_eq!(error, "permission denied");
+            }
+            other => panic!("expected CommandFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn refuses_non_command_variant_loudly() {
+        let dispatcher = ScriptedDispatcher::ok();
+        let err = apply_command(
+            &dispatcher,
+            ClientMessage::Subscribe {
+                kinds: vec!["chat".into()],
+                layers: vec![positron_core::wire::StateLayer::Session],
+                last_seen: vec![],
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.contains("Command"),
+            "error must name the expected variant: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatcher_receives_typed_command_and_params() {
+        // what this catches: regression where command/params get
+        // re-serialized or mangled crossing the dispatch seam.
+        let dispatcher = ScriptedDispatcher::ok();
+        let env = CommandEnvelope {
+            kind: "chat".into(),
+            command: "chat/send".into(),
+            params: serde_json::json!({"text": "specific text", "room_id": "abc"}),
+            correlation_id: Uuid::nil(),
+            source: CommandSource::Human,
+        };
+        let _ = apply_command(&dispatcher, ClientMessage::Command(env))
+            .await
+            .unwrap();
+        let calls = dispatcher.calls();
+        assert_eq!(calls[0].command, "chat/send");
+        assert_eq!(calls[0].params["text"], "specific text");
+        assert_eq!(calls[0].params["room_id"], "abc");
+    }
+
+    #[tokio::test]
+    async fn dispatcher_receives_envelope_source_and_kind_intact() {
+        // what this catches: regression where the dispatch seam erases
+        // CommandEnvelope.source or .kind before reaching the
+        // dispatcher. Per positron wire doctrine, commands are
+        // "first-class but never anonymous" — the source (Human vs
+        // Observer { observer_id }) drives authorization and audit
+        // downstream; the kind tags WHICH state the command mutates.
+        // Decomposing the envelope at this seam would silently strip
+        // both, leaving the dispatcher unable to tell a human edit
+        // from an AI observer edit and unable to scope authority by
+        // kind. Sentinel BLOCK on #1602.
+        let dispatcher = ScriptedDispatcher::ok();
+        let observer_id = "ares-1".to_string();
+        let env = CommandEnvelope {
+            kind: "chat".into(),
+            command: "chat/send".into(),
+            params: serde_json::json!({"text": "from observer"}),
+            correlation_id: Uuid::from_u128(0x1234),
+            source: CommandSource::Observer {
+                observer_id: observer_id.clone(),
+            },
+        };
+        let _ = apply_command(&dispatcher, ClientMessage::Command(env))
+            .await
+            .unwrap();
+        let calls = dispatcher.calls();
+        assert_eq!(calls[0].kind, "chat", "kind must round-trip");
+        match &calls[0].source {
+            CommandSource::Observer { observer_id: got } => {
+                assert_eq!(*got, observer_id, "observer_id must round-trip");
+            }
+            other => panic!("source must round-trip as Observer, got {other:?}"),
+        }
+    }
+}

--- a/core/continuum-positron/src/kinds.rs
+++ b/core/continuum-positron/src/kinds.rs
@@ -1,0 +1,82 @@
+//! Typed widget-kind enum.
+//!
+//! Positron's `StateEnvelope.kind` is a `String` on the wire — the
+//! protocol stays open to consumer-defined widget vocabularies. On
+//! continuum's substrate side we want a TYPED enum so:
+//!
+//! - the `match` on a payload variant is forced exhaustive by rustc,
+//! - revisions key off `KnownKind` which is `Hash + Eq` for free,
+//! - a typo at a builder call site is a compile error, not a runtime
+//!   mismatch the host silently ignores.
+//!
+//! When a kind ships, `KnownKind::wire_name` returns the canonical
+//! string the wire envelope carries. Hosts on the renderer side match
+//! the string; this side never re-stringifies a typo.
+//!
+//! Per `[[strong-typing-across-boundaries]]`: encode the kind once at
+//! the substrate seam; don't pass `&str` through every layer that
+//! needs to dispatch on it.
+
+/// The widget kinds continuum's substrate produces state for.
+///
+/// Adding a kind:
+/// 1. Add a variant here.
+/// 2. Add a `wire_name()` arm — that string is what the renderer side
+///    matches on, and is the contract with the widget package.
+/// 3. Add a typed payload struct (e.g. `chat::ChatViewState`) with
+///    `#[derive(TS)]` so the widget side gets the generated type.
+/// 4. Add a `StateBuilder::build_<kind>` helper or, if the payload is
+///    a one-liner, call `StateBuilder::build(...)` directly with the
+///    `KnownKind` variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KnownKind {
+    /// `"chat"` — room chat: messages, roster, typing-in-progress.
+    Chat,
+}
+
+impl KnownKind {
+    /// The on-wire kind string carried in `StateEnvelope.kind`. Must
+    /// stay stable once shipped — consumers on the host side route by
+    /// this name. Per `[[no-fallbacks-ever]]` there's no "default"
+    /// arm: every variant maps to a concrete name.
+    pub fn wire_name(self) -> &'static str {
+        match self {
+            KnownKind::Chat => "chat",
+        }
+    }
+}
+
+/// Revision key alias — revisions are per-`KnownKind` (one counter per
+/// state instance), NOT per `(kind, layer)`.
+///
+/// The load-bearing semantic clarification from Fable on positron's
+/// session protocol design:
+///
+/// > `ViewState::revision()` in the trait layer is ONE counter per
+/// > state instance. Layer classifies an UPDATE's cadence, not state
+/// > identity — there's ONE chat state; a typing flicker is an
+/// > ephemeral-layer delivery OF it, a message arrival is a
+/// > session-layer delivery OF it.
+///
+/// So `last_seen: [{kind: "chat", revision: 42}]` is the full key —
+/// a subscriber asks "I last saw chat at revision 42, replay anything
+/// past that". Layer affects DELIVERY CADENCE, not WHAT TO REPLAY.
+///
+/// Kept as a type alias rather than a newtype so a future addition
+/// (e.g. multi-instance kinds where the same kind has parallel state
+/// objects keyed by room id) can land without churning every call
+/// site.
+pub type RevisionKey = KnownKind;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_name_is_lowercase_widget_id() {
+        // what this catches: regression where a refactor accidentally
+        // changes the on-wire kind string. The renderer side routes
+        // by this exact string; a silent change breaks the widget.
+        assert_eq!(KnownKind::Chat.wire_name(), "chat");
+    }
+}

--- a/core/continuum-positron/src/lib.rs
+++ b/core/continuum-positron/src/lib.rs
@@ -1,0 +1,77 @@
+//! continuum-positron — Continuum's positron substrate.
+//!
+//! Positron is the cross-language UI contract: substrates produce
+//! `ViewState`, hosts render it, AI observers perceive the same state
+//! humans see. This crate is the SUBSTRATE side for continuum —
+//! producing typed `StateEnvelope`s from continuum's event bus and
+//! consuming typed `CommandEnvelope`s through `Commands.execute`.
+//!
+//! ## Why this exists
+//!
+//! Per ALPHA-GAP §6 (UI/Realtime Stability), the alpha P0/P1 blockers
+//! are #793 (Node doesn't reconnect when Rust core restarts), #794
+//! (AI messages not realtime), and #773 (browser WS reconnect). All
+//! three are symptoms of the same root cause: widgets carry local
+//! source-of-truth caches that drift from substrate truth across
+//! transport failures. Positron's contract makes that class of bug
+//! structural: widgets render from `StateEnvelope`, never from a
+//! cached blob; transport reconnect resyncs state via `last_seen`
+//! revision replay.
+//!
+//! ## Layering
+//!
+//! Substrate side (this crate):
+//! - Consumer-typed payloads (`ChatViewState`, `RoomRosterState`, …)
+//!   shipped as `ts-rs` generated types so the widget side is byte-
+//!   identical without hand-mirrored TS.
+//! - `Revisions` — monotonic counter per `(kind, layer)` so an
+//!   Ephemeral animation churn doesn't bump a Session counter.
+//! - `StateBuilder` — helper that frames a typed payload into a
+//!   `positron_core::wire::StateEnvelope` with the right revision +
+//!   layer + kind tag.
+//!
+//! Host side (positron-lit, Fable's lane): consumes `StateEnvelope`,
+//! renders Lit widgets with NO widget-local source-of-truth cache.
+//! Renderer is pure projection.
+//!
+//! Wire side (Fable's session protocol PR — `df3fb2ab`):
+//! `ClientMessage::{Subscribe, Command, Observe}` /
+//! `ServerMessage::State`, with `Subscribe { last_seen: [{kind,
+//! revision}] }` driving the resync-on-reconnect property.
+//!
+//! ## Doctrines
+//!
+//! - `[[strong-typing-across-boundaries]]`: payload variants are typed,
+//!   not stringly-tagged. `ChatViewState { messages, roster, … }` not
+//!   `Value::Object`. `(kind, layer)` is a typed key for revisions, not
+//!   a `String`-concatenation.
+//! - `[[no-fallbacks-ever]]`: a kind without a registered builder is
+//!   refused at compile time (the typed kind enum is exhaustive), not
+//!   silently coerced to `Other`.
+//! - `[[shared-decode-per-persona-perspective]]`: the substrate decode
+//!   (event → typed payload) runs ONCE per arrival; per-observer
+//!   perspective (which observer subscribes which layer) is the cheap
+//!   layer above the typed decode.
+//!
+//! ## Status
+//!
+//! This crate ships the typed payload schema + revision tracker +
+//! state builder. The wire transport binding (subscriber session
+//! lifecycle, `last_seen` replay, command dispatch through the
+//! substrate's `CommandExecutor`) lands in a follow-up slice once
+//! positron's session protocol PR merges. The seam stays narrow on
+//! purpose so the wire layer drops in cleanly.
+
+pub mod kinds;
+pub mod revisions;
+pub mod state;
+pub mod chat;
+
+pub use kinds::{KnownKind, RevisionKey};
+pub use revisions::Revisions;
+pub use state::StateBuilder;
+pub use chat::{ChatMessageView, ChatViewState, PersonaSlotView, SenderKind};
+
+// Re-export positron's wire types so consumers get them under one
+// path. The typed payloads in this crate fill `StateEnvelope.payload`.
+pub use positron_core::wire::{CommandEnvelope, CommandSource, StateEnvelope, StateLayer};

--- a/core/continuum-positron/src/lib.rs
+++ b/core/continuum-positron/src/lib.rs
@@ -62,16 +62,23 @@
 //! positron's session protocol PR merges. The seam stays narrow on
 //! purpose so the wire layer drops in cleanly.
 
+pub mod cache;
+pub mod chat;
 pub mod kinds;
 pub mod revisions;
+pub mod session;
 pub mod state;
-pub mod chat;
 
+pub use cache::SubstrateStateCache;
+pub use chat::{ChatMessageView, ChatViewState, PersonaSlotView, SenderKind};
 pub use kinds::{KnownKind, RevisionKey};
 pub use revisions::Revisions;
+pub use session::{apply_subscribe, Subscription};
 pub use state::StateBuilder;
-pub use chat::{ChatMessageView, ChatViewState, PersonaSlotView, SenderKind};
 
-// Re-export positron's wire types so consumers get them under one
-// path. The typed payloads in this crate fill `StateEnvelope.payload`.
+// Re-export positron's wire + session types so consumers get them
+// under one path. The typed payloads in this crate fill
+// `StateEnvelope.payload`; the session protocol's frames are what
+// substrate-side handlers consume + emit.
+pub use positron_core::session::{ClientMessage, KindRevision, ServerMessage};
 pub use positron_core::wire::{CommandEnvelope, CommandSource, StateEnvelope, StateLayer};

--- a/core/continuum-positron/src/lib.rs
+++ b/core/continuum-positron/src/lib.rs
@@ -64,14 +64,18 @@
 
 pub mod cache;
 pub mod chat;
+pub mod dispatch;
 pub mod kinds;
+pub mod observer;
 pub mod revisions;
 pub mod session;
 pub mod state;
 
 pub use cache::SubstrateStateCache;
 pub use chat::{ChatMessageView, ChatViewState, PersonaSlotView, SenderKind};
+pub use dispatch::{apply_command, CommandDispatch};
 pub use kinds::{KnownKind, RevisionKey};
+pub use observer::{apply_observe, ObserverRegistration};
 pub use revisions::Revisions;
 pub use session::{apply_subscribe, Subscription};
 pub use state::StateBuilder;

--- a/core/continuum-positron/src/observer.rs
+++ b/core/continuum-positron/src/observer.rs
@@ -1,0 +1,257 @@
+//! Substrate-side `Observe` handler — AI-observer resync mirror of
+//! [`crate::session::apply_subscribe`].
+//!
+//! Positron protocol §"Observers resync identically":
+//!
+//! > [`ClientMessage::Observe`] is declarative per `observer_id`
+//! > (re-observe REPLACES that observer's registration) and triggers
+//! > the same snapshot-then-live with the same exact-equality skip on
+//! > its `last_seen`. A reconnecting AI observer rebuilds its
+//! > perceived world exactly like a renderer does — there is one
+//! > resync contract, not a human one and an AI one.
+//!
+//! This module is that mirror at the substrate seam. Same exact-
+//! equality skip rule (via [`crate::session::should_skip`]),
+//! declarative replace at the type level (no `merge` method on
+//! [`ObserverRegistration`]).
+//!
+//! ## What `ObserverRegistration` captures
+//!
+//! - `observer_id` — substrate-routed identity (e.g. a persona UUID
+//!   string). Re-observe under the same id REPLACES the prior
+//!   registration for THAT observer; other observers stay attached.
+//! - `budget_hz` — the observer's requested perception rate. Honored
+//!   by the perception-budget enforcement layer (slice 2D live
+//!   broadcast); slice 2B/C just records the field.
+//! - `kinds` + `layers` — what this observer perceives. Same shape
+//!   as [`crate::session::Subscription`] so the broadcast layer can
+//!   gate envelope forwarding through the same `covers()` predicate.
+//!
+//! ## Why budget_hz is captured here and not enforced yet
+//!
+//! Per positron docs §"Cognition budget": the substrate quantizes an
+//! observer's perception under load. Enforcement is a broadcast-time
+//! concern (drop / coalesce envelopes that would exceed the
+//! observer's per-second budget). This module just records the
+//! declared budget; the live-broadcast layer (slice 2D) reads it
+//! when wiring the per-observer fan-out.
+
+use std::collections::HashSet;
+
+use positron_core::session::{ClientMessage, ServerMessage};
+use positron_core::wire::{StateEnvelope, StateLayer};
+
+use crate::cache::SubstrateStateCache;
+use crate::session::should_skip;
+
+/// One AI observer's substrate-recorded registration. Built by
+/// [`apply_observe`]; consulted by the live-broadcast layer to
+/// gate per-envelope forwarding and to enforce the `budget_hz`
+/// quantization.
+///
+/// `kinds` uses `HashSet` for O(1) membership tests; `layers` uses
+/// `Vec` for symmetry with [`crate::session::Subscription`] (the
+/// broadcast-time `covers(kind, layer)` predicate keys off both).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObserverRegistration {
+    pub observer_id: String,
+    pub budget_hz: u32,
+    pub kinds: HashSet<String>,
+    pub layers: Vec<StateLayer>,
+}
+
+impl ObserverRegistration {
+    /// True iff this observer perceives `(kind, layer)`. The live-
+    /// broadcast layer calls this to gate per-envelope forwarding
+    /// before the per-observer `budget_hz` quantization runs.
+    pub fn covers(&self, kind: &str, layer: StateLayer) -> bool {
+        self.kinds.contains(kind) && self.layers.contains(&layer)
+    }
+}
+
+/// Apply a `ClientMessage::Observe` against the substrate's current
+/// state cache and produce:
+///
+/// 1. The new [`ObserverRegistration`] for this observer (REPLACES
+///    the prior registration under the same `observer_id` — see the
+///    declarative-replace doctrine in [`crate::session`] module
+///    docs).
+/// 2. The Vec of `ServerMessage::State` frames the substrate must
+///    emit immediately to satisfy snapshot-then-live for the new
+///    perception scope, with the exact-equality skip rule applied
+///    per kind.
+///
+/// Returns `Err` if `msg` is NOT an `Observe` variant — single-
+/// purpose handler per [[no-fallbacks-ever]].
+pub fn apply_observe(
+    cache: &SubstrateStateCache,
+    msg: ClientMessage,
+) -> Result<(ObserverRegistration, Vec<ServerMessage>), String> {
+    let (spec, last_seen) = match msg {
+        ClientMessage::Observe { spec, last_seen } => (spec, last_seen),
+        other => {
+            return Err(format!(
+                "apply_observe: expected Observe variant, got {other:?}"
+            ));
+        }
+    };
+
+    let mut layers = spec.layers;
+    layers.sort_by_key(|l| *l as u8);
+    layers.dedup();
+
+    let kinds_set: HashSet<String> = spec.kinds.iter().cloned().collect();
+    let mut snapshots: Vec<ServerMessage> = Vec::with_capacity(spec.kinds.len());
+
+    for kind in &spec.kinds {
+        let Some(current) = cache.get(kind) else {
+            // Same honest-silence semantic as subscribe: no cached
+            // state for this kind → no snapshot to send this cycle.
+            continue;
+        };
+        if should_skip(&current, kind, &last_seen) {
+            continue;
+        }
+        snapshots.push(ServerMessage::State(StateEnvelope::clone(&current)));
+    }
+
+    Ok((
+        ObserverRegistration {
+            observer_id: spec.observer_id,
+            budget_hz: spec.budget_hz,
+            kinds: kinds_set,
+            layers,
+        },
+        snapshots,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use positron_core::session::KindRevision;
+    use positron_core::wire::{ObserverSpec, StateLayer};
+
+    fn env(kind: &str, revision: u64) -> StateEnvelope {
+        StateEnvelope {
+            kind: kind.to_string(),
+            revision: Some(revision),
+            layer: StateLayer::Session,
+            payload: serde_json::json!({"ok": true}),
+        }
+    }
+
+    fn obs(
+        observer_id: &str,
+        budget_hz: u32,
+        kinds: &[&str],
+        last_seen: Vec<KindRevision>,
+    ) -> ClientMessage {
+        ClientMessage::Observe {
+            spec: ObserverSpec {
+                observer_id: observer_id.to_string(),
+                budget_hz,
+                kinds: kinds.iter().map(|s| s.to_string()).collect(),
+                layers: vec![StateLayer::Session],
+            },
+            last_seen,
+        }
+    }
+
+    #[test]
+    fn first_observe_with_empty_last_seen_emits_current_snapshots() {
+        // what this catches: regression where the observer resync
+        // contract diverges from the renderer one. Per protocol
+        // §"Observers resync identically" there is ONE resync
+        // contract — observe and subscribe must behave the same way.
+        let cache = SubstrateStateCache::new();
+        cache.store(env("chat", 11));
+        let (r, frames) = apply_observe(&cache, obs("maya", 4, &["chat"], vec![])).unwrap();
+        assert_eq!(r.observer_id, "maya");
+        assert_eq!(r.budget_hz, 4);
+        assert!(r.covers("chat", StateLayer::Session));
+        assert_eq!(frames.len(), 1);
+        match &frames[0] {
+            ServerMessage::State(e) => {
+                assert_eq!(e.kind, "chat");
+                assert_eq!(e.revision, Some(11));
+            }
+            other => panic!("expected State, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn matching_last_seen_skips_the_snapshot_same_as_subscribe() {
+        // what this catches: regression where the observer skip rule
+        // diverges from the subscriber skip rule. Both must key off
+        // the same `should_skip` helper so a future protocol clarif-
+        // ication only needs one edit.
+        let cache = SubstrateStateCache::new();
+        cache.store(env("chat", 11));
+        let (_, frames) = apply_observe(
+            &cache,
+            obs(
+                "maya",
+                4,
+                &["chat"],
+                vec![KindRevision {
+                    kind: "chat".into(),
+                    revision: 11,
+                }],
+            ),
+        )
+        .unwrap();
+        assert!(
+            frames.is_empty(),
+            "exact-equality match → skip; got {frames:?}"
+        );
+    }
+
+    #[test]
+    fn higher_last_seen_does_NOT_skip_for_observers_either() {
+        // what this catches: the SAME load-bearing invariant as the
+        // subscriber test. An observer holding last_seen=500 from a
+        // pre-restart substrate must re-receive the snapshot, never
+        // skip. Drift between Observer and Subscribe handling is the
+        // exact bug class one-resync-contract exists to prevent.
+        let cache = SubstrateStateCache::new();
+        cache.store(env("chat", 3));
+        let (_, frames) = apply_observe(
+            &cache,
+            obs(
+                "maya",
+                4,
+                &["chat"],
+                vec![KindRevision {
+                    kind: "chat".into(),
+                    revision: 500,
+                }],
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            frames.len(),
+            1,
+            "observer@500 vs substrate@3 must SEND the snapshot — \
+             same exact-equality invariant as the subscriber path"
+        );
+    }
+
+    #[test]
+    fn refuses_non_observe_variant_loudly() {
+        let cache = SubstrateStateCache::new();
+        let err = apply_observe(
+            &cache,
+            ClientMessage::Subscribe {
+                kinds: vec!["chat".into()],
+                layers: vec![StateLayer::Session],
+                last_seen: vec![],
+            },
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("Observe"),
+            "error must name the expected variant: {err}"
+        );
+    }
+}

--- a/core/continuum-positron/src/revisions.rs
+++ b/core/continuum-positron/src/revisions.rs
@@ -1,0 +1,96 @@
+//! Monotonic per-kind revision counter.
+//!
+//! The wire contract: `StateEnvelope.revision` is `Option<u64>`,
+//! monotonic PER KIND. The session protocol's
+//! `Subscribe { last_seen: [{kind, revision}] }` replay-on-resync
+//! property is built on this invariant — a subscriber asks "give me
+//! everything past my last_seen" and the substrate replays the
+//! `StateEnvelope`s whose revisions are greater.
+//!
+//! Revisions are per-kind (not per `(kind, layer)`) because
+//! `ViewState::revision()` is one counter per state instance. Layer
+//! classifies an UPDATE's cadence, not state identity. See
+//! [`crate::kinds::RevisionKey`] for the design discussion.
+//!
+//! Per `[[no-fallbacks-ever]]`: there is no "did we drop a revision?"
+//! recovery. The counter is monotonic and substrate-owned. If a
+//! revision is missed on the wire, the resubscribe path's `last_seen`
+//! semantics catches it — that's a wire-layer concern, not a
+//! revision-source concern.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::kinds::{KnownKind, RevisionKey};
+
+/// In-process monotonic revision generator. Cheap to share via `Arc`.
+///
+/// Concurrency: `Mutex<HashMap>` is the right choice here. Revisions
+/// fire on substrate event arrivals (chat message ingested, persona
+/// roster changes, etc.) — that's an O(1) hashmap probe + integer
+/// bump per event. A lock-free counter per key would be premature for
+/// the arrival rate (worst case substrate-event-arrival rate is
+/// bounded by airc IPC throughput, which is sub-millisecond at the
+/// substrate's per-tick cadence anyway). When measurements show this
+/// lock is hot, swap to `DashMap` without touching the public API.
+#[derive(Debug, Default)]
+pub struct Revisions {
+    next: Mutex<HashMap<RevisionKey, u64>>,
+}
+
+impl Revisions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate the next revision for `kind`. Monotonic within a
+    /// single `Revisions` instance — the first call for a key returns
+    /// `1`, then `2`, etc. (Revisions start at 1 so a `Some(0)` from
+    /// a buggy subscriber can't pretend it has seen "the empty state"
+    /// by accident.)
+    pub fn next(&self, kind: KnownKind) -> u64 {
+        let mut next = self.next.lock().expect("Revisions mutex poisoned");
+        let slot = next.entry(kind).or_insert(0);
+        *slot += 1;
+        *slot
+    }
+
+    /// Read the current revision for `kind` without advancing.
+    /// Returns `None` if no revision has been allocated for this key
+    /// yet — useful for the session-resume path so a subscriber's
+    /// `last_seen` can be checked against current state.
+    pub fn current(&self, kind: KnownKind) -> Option<u64> {
+        let next = self.next.lock().expect("Revisions mutex poisoned");
+        next.get(&kind).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_is_strictly_monotonic_per_kind() {
+        // what this catches: regression where the counter resets or
+        // wraps within a session. Session-protocol replay would mis-
+        // route — a subscriber's last_seen=42 plus a counter that
+        // jumped back to 5 means "drop everything from 5 to 42 again
+        // on reconnect" or "skip 5-42 entirely". Both break §6.
+        let r = Revisions::new();
+        assert_eq!(r.next(KnownKind::Chat), 1);
+        assert_eq!(r.next(KnownKind::Chat), 2);
+        assert_eq!(r.next(KnownKind::Chat), 3);
+        assert_eq!(r.current(KnownKind::Chat), Some(3));
+    }
+
+    #[test]
+    fn current_is_none_before_first_next() {
+        // what this catches: regression where `current` lazy-inits
+        // the entry to `Some(0)` and the resume path reads it as
+        // "seen the empty state". Per the doctrine, no allocation
+        // for a kind means no revision — the wire `Option<u64>` is
+        // honest about that.
+        let r = Revisions::new();
+        assert_eq!(r.current(KnownKind::Chat), None);
+    }
+}

--- a/core/continuum-positron/src/session.rs
+++ b/core/continuum-positron/src/session.rs
@@ -1,0 +1,417 @@
+//! Substrate-side session handlers — translate positron
+//! [`ClientMessage`]s into [`ServerMessage`]s per the snapshot-then-live
+//! protocol.
+//!
+//! This module implements the substrate side of
+//! `positron-core@0.1.0`'s session protocol:
+//!
+//! > On `Subscribe` — first connect and every reconnect alike — the
+//! > substrate MUST immediately emit the current `StateEnvelope` for
+//! > each subscribed kind (revision-tagged), then stream live updates
+//! > from that moment forward.
+//!
+//! Slice 2A scope: `Subscribe` handling — `apply_subscribe()` turns a
+//! `ClientMessage::Subscribe` into the `(new subscription state,
+//! snapshot frames to send right now)` pair. Live-broadcast wiring
+//! and `Command` / `Observe` handling land in slice 2B.
+//!
+//! ## The skip rule (exact equality, never `>=`)
+//!
+//! Per positron protocol §"Skip rule":
+//!
+//! > The substrate MAY skip a kind's snapshot ONLY when the client's
+//! > `last_seen` revision EXACTLY equals the substrate's current
+//! > revision for that kind. Never a `>=` comparison: a substrate
+//! > restart may reset its revision counter, and under `>=` a client
+//! > holding `last_seen: 500` against a freshly-restarted substrate at
+//! > revision 3 would keep stale state forever.
+//!
+//! [`apply_subscribe`] implements exactly this: matches each
+//! `KindRevision` in `last_seen` against the substrate's cached
+//! current revision for that kind. Equality → skip; anything else
+//! (including the substrate having NO state for a requested kind yet)
+//! → send the current snapshot if one exists, or silently emit
+//! nothing for that kind on this cycle.
+//!
+//! ## Subscription replacement (declarative)
+//!
+//! Per protocol: `Subscribe` is declarative; it REPLACES any prior
+//! subscription on the same connection. [`Subscription::replace`]
+//! makes that replacement explicit at the type level — calling it
+//! returns a fresh `Subscription` value, not a merged one.
+//!
+//! Renderers that re-subscribe with the SAME `kinds` + `layers` after
+//! a transient transport blip get an idempotent snapshot-then-live;
+//! renderers that re-subscribe with a NARROWER set stop receiving
+//! the dropped kinds. No add/remove RPC drift is possible because no
+//! delta API exists.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use positron_core::session::{ClientMessage, KindRevision, ServerMessage};
+use positron_core::wire::{StateEnvelope, StateLayer};
+
+use crate::cache::SubstrateStateCache;
+
+/// One connection's current declared interest set. Created (or
+/// replaced) by [`apply_subscribe`]; consulted by the live-broadcast
+/// layer (slice 2B) to decide which live envelopes to forward.
+///
+/// `kinds` uses `HashSet` for O(1) membership tests; `layers` uses
+/// `Vec` because positron-core's `StateLayer` doesn't derive `Hash`
+/// (filed as a sharp follow-up to positron). With only 4 variants
+/// (Ephemeral / Session / Persistent / Semantic) the linear scan is
+/// free.
+///
+/// A fresh `Subscription::empty()` declines everything until a
+/// `Subscribe` arrives — `[[no-fallbacks-ever]]`-correct (the
+/// renderer must explicitly opt in to each kind/layer).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Subscription {
+    pub kinds: HashSet<String>,
+    pub layers: Vec<StateLayer>,
+}
+
+impl Subscription {
+    /// A no-op subscription — receives nothing. The default state of a
+    /// new connection before `Subscribe` arrives.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Replace this subscription wholesale. The protocol's
+    /// declarative-replace semantic at the type level: a caller can't
+    /// accidentally `merge` instead of `replace` — there's no such
+    /// method.
+    pub fn replace(kinds: Vec<String>, mut layers: Vec<StateLayer>) -> Self {
+        // Dedup defensively — the protocol declares the field as
+        // Vec<StateLayer>; a misbehaving client could send `[Session,
+        // Session]`. Cheap dedup on a 4-variant universe; harmless if
+        // already unique.
+        layers.sort_by_key(|l| *l as u8);
+        layers.dedup();
+        Self {
+            kinds: kinds.into_iter().collect(),
+            layers,
+        }
+    }
+
+    /// True iff this subscription is interested in receiving updates
+    /// for `(kind, layer)`. The live-broadcast layer calls this to
+    /// gate per-envelope forwarding. O(kinds) hashmap probe + O(4)
+    /// layer scan.
+    pub fn covers(&self, kind: &str, layer: StateLayer) -> bool {
+        self.kinds.contains(kind) && self.layers.contains(&layer)
+    }
+}
+
+/// Apply a `ClientMessage::Subscribe` against the substrate's current
+/// state cache and produce:
+///
+/// 1. The new [`Subscription`] state for this connection (REPLACES the
+///    prior one — see the declarative-replace doctrine in module
+///    docs).
+/// 2. The Vec of `ServerMessage::State` frames the substrate must
+///    emit immediately to satisfy snapshot-then-live for the new
+///    interest set, with the exact-equality skip rule applied per
+///    kind.
+///
+/// Returns `Err` if `msg` is NOT a `Subscribe` variant — the function
+/// is single-purpose and refuses to handle unrelated frames per
+/// `[[no-fallbacks-ever]]`. Callers route by variant before reaching
+/// this function (which is straightforward since `ClientMessage` is a
+/// tagged union).
+///
+/// ## What this function does NOT do
+///
+/// - It does not broadcast live updates — that's the slice 2B
+///   broadcast layer.
+/// - It does not enforce the in-flight ordering watermark — that's
+///   the consumer side. The substrate's job is just to emit
+///   monotonic revisions per kind, which [`crate::Revisions`]
+///   already does.
+/// - It does not touch `Observe` or `Command` — separate handlers in
+///   slice 2B.
+pub fn apply_subscribe(
+    cache: &SubstrateStateCache,
+    msg: ClientMessage,
+) -> Result<(Subscription, Vec<ServerMessage>), String> {
+    let (kinds, layers, last_seen) = match msg {
+        ClientMessage::Subscribe {
+            kinds,
+            layers,
+            last_seen,
+        } => (kinds, layers, last_seen),
+        other => {
+            return Err(format!(
+                "apply_subscribe: expected Subscribe variant, got {other:?}"
+            ));
+        }
+    };
+
+    let subscription = Subscription::replace(kinds.clone(), layers);
+    let mut snapshots: Vec<ServerMessage> = Vec::with_capacity(kinds.len());
+
+    for kind in &kinds {
+        let Some(current) = cache.get(kind) else {
+            // No cached state for this kind yet. Per protocol §"Skip
+            // rule" parenthetical: "The skip is purely an optimization;
+            // when in doubt, send." Sending nothing when there IS
+            // nothing to send is the equivalent — the renderer rendered
+            // no state, the substrate has no state, both sides agree.
+            // The first time the substrate produces state for this
+            // kind, the live-broadcast layer (slice 2B) delivers it.
+            continue;
+        };
+        if should_skip(&current, kind, &last_seen) {
+            continue;
+        }
+        // Hand the renderer a fresh `StateEnvelope` (clone the Arc'd
+        // payload into a plain value — `ServerMessage::State` owns
+        // its envelope per the wire shape). The Arc-share at the
+        // cache layer keeps the COMMON case of multiple subscribers
+        // all snapshotting against the same cached envelope
+        // allocation-frugal at the cache boundary.
+        snapshots.push(ServerMessage::State(StateEnvelope::clone(&current)));
+    }
+
+    Ok((subscription, snapshots))
+}
+
+/// The exact-equality skip rule from positron protocol §"Skip rule".
+///
+/// `current` is the substrate's cached envelope for `kind`;
+/// `last_seen` is the client's `Vec<KindRevision>`. The substrate
+/// MAY skip THIS kind's snapshot iff the client's `last_seen`
+/// revision for this kind EXACTLY equals the current envelope's
+/// revision.
+///
+/// Cases:
+/// - Current revision is `None`: never skip (substrate doesn't know
+///   what version this is, so honestly emit it).
+/// - Client has no entry for this kind: never skip.
+/// - Client's revision != current revision: never skip — any
+///   mismatch in either direction sends.
+/// - Client's revision == current revision: skip — the renderer is
+///   already at the latest.
+fn should_skip(current: &Arc<StateEnvelope>, kind: &str, last_seen: &[KindRevision]) -> bool {
+    let Some(current_rev) = current.revision else {
+        return false;
+    };
+    let Some(client_entry) = last_seen.iter().find(|k| k.kind == kind) else {
+        return false;
+    };
+    client_entry.revision == current_rev
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use positron_core::wire::StateLayer;
+
+    fn env(kind: &str, revision: u64) -> StateEnvelope {
+        StateEnvelope {
+            kind: kind.to_string(),
+            revision: Some(revision),
+            layer: StateLayer::Session,
+            payload: serde_json::json!({"ok": true}),
+        }
+    }
+
+    fn sub(kinds: &[&str], last_seen: Vec<KindRevision>) -> ClientMessage {
+        ClientMessage::Subscribe {
+            kinds: kinds.iter().map(|s| s.to_string()).collect(),
+            layers: vec![StateLayer::Session],
+            last_seen,
+        }
+    }
+
+    #[test]
+    fn first_subscribe_with_empty_last_seen_emits_current_snapshots() {
+        // what this catches: regression where the substrate doesn't
+        // honor the snapshot-then-live contract on first subscribe.
+        // A renderer arriving fresh MUST receive the current state
+        // immediately — otherwise it renders an empty UI until a
+        // mutation happens, which is the §6 alpha bug.
+        let cache = SubstrateStateCache::new();
+        cache.store(env("chat", 7));
+        let (s, frames) = apply_subscribe(&cache, sub(&["chat"], vec![])).unwrap();
+        assert!(s.covers("chat", StateLayer::Session));
+        assert_eq!(frames.len(), 1);
+        match &frames[0] {
+            ServerMessage::State(e) => {
+                assert_eq!(e.kind, "chat");
+                assert_eq!(e.revision, Some(7));
+            }
+            other => panic!("expected State frame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn matching_last_seen_skips_the_snapshot() {
+        // what this catches: regression where the substrate sends a
+        // redundant snapshot to a client that already holds the
+        // current revision. This is the OPTIMIZATION half of the skip
+        // rule — it shouldn't be load-bearing for correctness, but
+        // not skipping wastes bandwidth on every reconnect.
+        let cache = SubstrateStateCache::new();
+        cache.store(env("chat", 7));
+        let (_, frames) = apply_subscribe(
+            &cache,
+            sub(
+                &["chat"],
+                vec![KindRevision {
+                    kind: "chat".into(),
+                    revision: 7,
+                }],
+            ),
+        )
+        .unwrap();
+        assert!(
+            frames.is_empty(),
+            "exact-equality match → skip; got {frames:?}"
+        );
+    }
+
+    #[test]
+    fn higher_last_seen_does_NOT_skip_per_protocol_load_bearing_invariant() {
+        // what this catches: THE regression Fable's review caught in
+        // round 2 — using `>=` instead of exact equality. If a client
+        // holds last_seen=500 (from a pre-restart substrate) and the
+        // substrate has restarted to current=3, `>=` would skip the
+        // snapshot and the client would render state-from-the-future
+        // forever. Exact equality forces the snapshot through, the
+        // renderer reconciles by revision diff, and stale-forever
+        // becomes impossible.
+        let cache = SubstrateStateCache::new();
+        cache.store(env("chat", 3));
+        let (_, frames) = apply_subscribe(
+            &cache,
+            sub(
+                &["chat"],
+                vec![KindRevision {
+                    kind: "chat".into(),
+                    revision: 500,
+                }],
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            frames.len(),
+            1,
+            "client@500 vs substrate@3 must SEND the snapshot, not skip — \
+             the §protocol exact-equality invariant"
+        );
+    }
+
+    #[test]
+    fn unrelated_last_seen_does_not_match_chat() {
+        // what this catches: regression where the skip rule's
+        // last_seen lookup keys off something other than `kind`
+        // string. A client holding revision-42 for "user-list" must
+        // not accidentally skip the "chat" snapshot.
+        let cache = SubstrateStateCache::new();
+        cache.store(env("chat", 7));
+        let (_, frames) = apply_subscribe(
+            &cache,
+            sub(
+                &["chat"],
+                vec![KindRevision {
+                    kind: "user-list".into(),
+                    revision: 7,
+                }],
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            frames.len(),
+            1,
+            "last_seen for a different kind must not match chat"
+        );
+    }
+
+    #[test]
+    fn unknown_kind_in_subscribe_emits_no_frame_silently() {
+        // what this catches: regression where the substrate fabricates
+        // an empty envelope for a kind it has no state for. Per
+        // [[no-fallbacks-ever]] the substrate is honest: no cached
+        // state → no snapshot frame this cycle. Live broadcast (slice
+        // 2B) delivers the first frame when the substrate actually
+        // produces state.
+        let cache = SubstrateStateCache::new();
+        // Cache has chat but the client subscribes to user-list.
+        cache.store(env("chat", 7));
+        let (s, frames) = apply_subscribe(&cache, sub(&["user-list"], vec![])).unwrap();
+        assert!(s.kinds.contains("user-list"));
+        assert!(
+            frames.is_empty(),
+            "no cache for user-list → no synthetic snapshot"
+        );
+    }
+
+    #[test]
+    fn multiple_kinds_partition_snapshots_independently() {
+        // what this catches: regression where the skip rule for one
+        // kind accidentally suppresses another's snapshot. Each kind
+        // should be evaluated against its own last_seen entry
+        // independently.
+        let cache = SubstrateStateCache::new();
+        cache.store(env("chat", 7));
+        cache.store(env("user-list", 3));
+        let (_, frames) = apply_subscribe(
+            &cache,
+            sub(
+                &["chat", "user-list"],
+                vec![KindRevision {
+                    kind: "chat".into(),
+                    revision: 7, // skip chat
+                }], // user-list has no last_seen → send
+            ),
+        )
+        .unwrap();
+        assert_eq!(frames.len(), 1, "chat skipped, user-list sent");
+        match &frames[0] {
+            ServerMessage::State(e) => assert_eq!(e.kind, "user-list"),
+            other => panic!("expected State frame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn refuses_non_subscribe_variant_loudly() {
+        // what this catches: regression where the function silently
+        // accepts a Command or Observe (which would route to wrong
+        // handlers). Per [[no-fallbacks-ever]] the function is
+        // single-purpose; any other variant is a programmer error
+        // at the dispatch site.
+        let cache = SubstrateStateCache::new();
+        let err = apply_subscribe(
+            &cache,
+            ClientMessage::Command(positron_core::wire::CommandEnvelope {
+                kind: "chat".into(),
+                command: "chat/send".into(),
+                params: serde_json::json!({}),
+                correlation_id: uuid::Uuid::nil(),
+                source: positron_core::wire::CommandSource::Human,
+            }),
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("Subscribe"),
+            "error must name the expected variant: {err}"
+        );
+    }
+
+    #[test]
+    fn replace_semantic_is_explicit_in_subscription_type() {
+        // what this catches: doctrine pin. Subscription has no
+        // `merge` method. Re-subscribing replaces; this test fails
+        // to compile if someone adds a `merge` method.
+        let s = Subscription::replace(vec!["chat".into()], vec![StateLayer::Session]);
+        assert!(s.covers("chat", StateLayer::Session));
+        // After "replace" with a different set, the prior coverage is gone:
+        let s2 = Subscription::replace(vec!["user-list".into()], vec![StateLayer::Session]);
+        assert!(!s2.covers("chat", StateLayer::Session));
+        assert!(s2.covers("user-list", StateLayer::Session));
+    }
+}

--- a/core/continuum-positron/src/session.rs
+++ b/core/continuum-positron/src/session.rs
@@ -195,7 +195,15 @@ pub fn apply_subscribe(
 ///   mismatch in either direction sends.
 /// - Client's revision == current revision: skip — the renderer is
 ///   already at the latest.
-fn should_skip(current: &Arc<StateEnvelope>, kind: &str, last_seen: &[KindRevision]) -> bool {
+///
+/// `pub(crate)` so [`crate::observer::apply_observe`] can reuse the
+/// identical rule — there is ONE skip rule across Subscribe and
+/// Observe per positron protocol §"Observers resync identically".
+pub(crate) fn should_skip(
+    current: &Arc<StateEnvelope>,
+    kind: &str,
+    last_seen: &[KindRevision],
+) -> bool {
     let Some(current_rev) = current.revision else {
         return false;
     };

--- a/core/continuum-positron/src/state.rs
+++ b/core/continuum-positron/src/state.rs
@@ -1,0 +1,200 @@
+//! `StateBuilder` — frames typed payloads into
+//! `positron_core::wire::StateEnvelope`s with the right kind tag,
+//! monotonic revision, and layer.
+//!
+//! ## Why a builder
+//!
+//! Three things have to line up on every `StateEnvelope` continuum
+//! ships, and getting any one wrong silently breaks the renderer:
+//!
+//! 1. `kind` must match the renderer's route — a typo and the widget
+//!    never updates.
+//! 2. `revision` must be monotonic from the substrate's
+//!    [`Revisions`](crate::Revisions) source so the session
+//!    protocol's `last_seen` replay works.
+//! 3. `layer` must reflect the actual cadence class of THIS update —
+//!    Session by default (the user-perceivable tier); Ephemeral for
+//!    sub-second changes only.
+//!
+//! The builder centralizes all three so substrate code calling
+//! `builder.session(ChatViewState { ... })` can't accidentally
+//! re-stringify a kind or forget a revision bump.
+//!
+//! ## Doctrine
+//!
+//! Per `[[strong-typing-across-boundaries]]`: the typed `Payload`
+//! generic is `Serialize` AND ts-rs-exported. The widget side reads
+//! the same struct shape; mis-typing on either side is a compile
+//! error.
+//!
+//! Per `[[no-fallbacks-ever]]`: if `serde_json::to_value` fails on a
+//! payload, that's a substrate bug at compile-test time, not a
+//! runtime fallback. The builder unwraps — substrate types MUST
+//! serialize. Test coverage in the consumer module pins this.
+
+use std::sync::Arc;
+
+use positron_core::wire::{StateEnvelope, StateLayer};
+use serde::Serialize;
+
+use crate::kinds::KnownKind;
+use crate::revisions::Revisions;
+
+/// Frames typed substrate state into wire-shaped `StateEnvelope`s.
+///
+/// Cheap to share via `Arc` — internally just an `Arc<Revisions>`.
+/// All builder methods are immutable on `self`; concurrent callers
+/// see the same monotonic revision source.
+#[derive(Debug, Clone)]
+pub struct StateBuilder {
+    revisions: Arc<Revisions>,
+}
+
+impl StateBuilder {
+    /// Construct from an existing revision source. Typical: the
+    /// substrate boots one `Revisions` and shares it across every
+    /// `StateBuilder` so all kinds draw monotonic revisions from one
+    /// well.
+    pub fn new(revisions: Arc<Revisions>) -> Self {
+        Self { revisions }
+    }
+
+    /// Stand-alone builder for tests / examples. Owns its own
+    /// `Revisions`.
+    pub fn standalone() -> Self {
+        Self::new(Arc::new(Revisions::new()))
+    }
+
+    /// Frame `payload` as a Session-tier update — the user-
+    /// perceivable cadence (1–10 Hz). Default for state changes a
+    /// human reads: new chat message, roster delta, room switched.
+    ///
+    /// Caller's `Payload` type is consumer-defined (e.g.
+    /// [`crate::chat::ChatViewState`]); only the JSON wire shape
+    /// crosses positron.
+    pub fn session<P: Serialize>(&self, kind: KnownKind, payload: P) -> StateEnvelope {
+        self.build(kind, StateLayer::Session, payload)
+    }
+
+    /// Frame `payload` as a Persistent-tier update — long-lived
+    /// state (< 1 Hz). Profile edits, theme changes.
+    pub fn persistent<P: Serialize>(&self, kind: KnownKind, payload: P) -> StateEnvelope {
+        self.build(kind, StateLayer::Persistent, payload)
+    }
+
+    /// Frame `payload` as an Ephemeral-tier update — sub-second
+    /// cadence (≤ 60 Hz). Typing indicators, hover state. AI
+    /// observers should NOT subscribe to this layer; the substrate
+    /// quantizes aggressively under load.
+    pub fn ephemeral<P: Serialize>(&self, kind: KnownKind, payload: P) -> StateEnvelope {
+        self.build(kind, StateLayer::Ephemeral, payload)
+    }
+
+    /// Frame `payload` as a Semantic-tier update — pull-oriented,
+    /// AI-tier meaning extraction. "The conversation shifted topic."
+    /// Cognition produces these; renderers don't subscribe.
+    pub fn semantic<P: Serialize>(&self, kind: KnownKind, payload: P) -> StateEnvelope {
+        self.build(kind, StateLayer::Semantic, payload)
+    }
+
+    /// Lower-level escape hatch when the call site already has a
+    /// `StateLayer` value (e.g. forwarding from another layer-aware
+    /// source). Prefer the named methods above for clarity at the
+    /// call site.
+    pub fn build<P: Serialize>(
+        &self,
+        kind: KnownKind,
+        layer: StateLayer,
+        payload: P,
+    ) -> StateEnvelope {
+        // Per `[[no-fallbacks-ever]]`: a substrate-owned `Payload`
+        // type that fails to serialize is a programming bug, not a
+        // runtime condition. Test coverage in the consumer module
+        // (`chat::tests::chat_view_state_round_trips`) pins each
+        // payload's serde shape.
+        let payload = serde_json::to_value(payload)
+            .expect("substrate payload must serialize — this is a bug, not a runtime error");
+        let revision = self.revisions.next(kind);
+        StateEnvelope {
+            kind: kind.wire_name().to_string(),
+            revision: Some(revision),
+            layer,
+            payload,
+        }
+    }
+
+    /// Read the current revision for `kind` without advancing.
+    /// Used by the wire-session layer: a resubscribe with
+    /// `last_seen.revision < revisions.current(kind)` triggers
+    /// replay.
+    pub fn current_revision(&self, kind: KnownKind) -> Option<u64> {
+        self.revisions.current(kind)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chat::{ChatViewState, PersonaSlotView};
+    use uuid::Uuid;
+
+    fn empty_chat(room_id: Uuid) -> ChatViewState {
+        ChatViewState {
+            room_id,
+            room_name: "general".into(),
+            messages: Vec::new(),
+            roster: vec![PersonaSlotView {
+                persona_id: Uuid::from_u128(1),
+                display_name: "Helper".into(),
+                active: true,
+            }],
+        }
+    }
+
+    #[test]
+    fn session_default_envelope_wires_kind_and_monotonic_revision() {
+        // what this catches: regression where the builder forgets to
+        // bump the revision or stamps the wrong kind tag. Renderer
+        // side routes by kind; session-protocol replay routes by
+        // revision. Both load-bearing.
+        let b = StateBuilder::standalone();
+        let room = Uuid::from_u128(7);
+        let env1 = b.session(KnownKind::Chat, empty_chat(room));
+        let env2 = b.session(KnownKind::Chat, empty_chat(room));
+        assert_eq!(env1.kind, "chat");
+        assert_eq!(env1.layer, StateLayer::Session);
+        assert_eq!(env1.revision, Some(1));
+        assert_eq!(env2.revision, Some(2));
+    }
+
+    #[test]
+    fn layers_share_one_per_kind_revision_counter() {
+        // what this catches: regression where layers accidentally
+        // partition the revision counter. Per Fable's session-
+        // protocol design, revision is per-KIND not per-(kind,
+        // layer); Session + Ephemeral deliveries OF chat advance the
+        // same chat-revision counter.
+        let b = StateBuilder::standalone();
+        let room = Uuid::from_u128(7);
+        let s = b.session(KnownKind::Chat, empty_chat(room));
+        let e = b.ephemeral(KnownKind::Chat, empty_chat(room));
+        let s2 = b.session(KnownKind::Chat, empty_chat(room));
+        assert_eq!(s.revision, Some(1));
+        assert_eq!(e.revision, Some(2), "ephemeral shares the chat counter");
+        assert_eq!(s2.revision, Some(3));
+    }
+
+    #[test]
+    fn current_revision_matches_last_built() {
+        // what this catches: regression where `current_revision`
+        // off-by-ones the wire-session layer's resync logic. A
+        // subscriber's `last_seen` is compared against `current` —
+        // if `current` is N+1 of what was actually stamped on the
+        // envelope, the wire layer would replay forever.
+        let b = StateBuilder::standalone();
+        let room = Uuid::from_u128(7);
+        assert_eq!(b.current_revision(KnownKind::Chat), None);
+        let env = b.session(KnownKind::Chat, empty_chat(room));
+        assert_eq!(b.current_revision(KnownKind::Chat), env.revision);
+    }
+}

--- a/core/continuum-positron/tests/session_roundtrip.rs
+++ b/core/continuum-positron/tests/session_roundtrip.rs
@@ -1,0 +1,356 @@
+//! End-to-end session-protocol smoke for the continuum-positron
+//! substrate.
+//!
+//! This integration test exercises the whole chain that a real
+//! session-task will go through, but without any transport: typed
+//! payload → StateBuilder → cache.store → apply_subscribe →
+//! snapshot frame → serde JSON round-trip → deserialize on the
+//! "client side" → typed payload back.
+//!
+//! ## Why an integration test and not more unit tests
+//!
+//! Unit tests pin each module's behavior in isolation. They cannot
+//! catch the class of bug where two modules each pass their own
+//! unit tests but compose incorrectly — the chat payload typed at
+//! the substrate seam, JSON-serialized, then re-parsed on a client
+//! that imports the same `ChatViewState` shape. This test exercises
+//! the WHOLE chain so a future refactor that breaks the substrate
+//! ↔ wire ↔ consumer round-trip fails here even if every module's
+//! own tests stay green.
+//!
+//! ## What the smoke proves end-to-end
+//!
+//! 1. Substrate produces a typed `ChatViewState`.
+//! 2. `StateBuilder::session(KnownKind::Chat, chat)` stamps the
+//!    right kind tag + monotonic revision + Session layer onto a
+//!    `StateEnvelope`.
+//! 3. `SubstrateStateCache` stores it; `apply_subscribe` retrieves
+//!    it as a snapshot frame.
+//! 4. The snapshot frame round-trips through `serde_json` losslessly
+//!    — what crosses the wire is byte-identical to what the
+//!    substrate emitted.
+//! 5. The deserialized payload's typed fields are what they should
+//!    be — proving the schema the renderer side imports matches the
+//!    substrate's emitted shape.
+//! 6. The exact-equality skip rule kicks in end-to-end on resubscribe
+//!    — proving §6 reconnect-tolerance is wired correctly through
+//!    every layer, not just at the unit-test apply_subscribe seam.
+//!
+//! ## Doctrine pinned by this smoke
+//!
+//! - `[[strong-typing-across-boundaries]]`: substrate emits typed
+//!   `ChatViewState`, client receives typed `ChatViewState`, the
+//!   `serde_json::Value` envelope in between is just transport.
+//! - `[[shared-decode-per-persona-perspective]]`: the cache stores
+//!   `Arc<StateEnvelope>`; two subscribers snapshotting against the
+//!   same cached envelope receive identical bytes (proven by the
+//!   two-subscriber test).
+//! - §6 (ALPHA-GAP UI/Realtime Stability): the exact-equality skip
+//!   rule end-to-end means a renderer can disconnect, reconnect, and
+//!   resync via `last_seen` without seeing stale state forever.
+
+use std::sync::Arc;
+
+use continuum_positron::{
+    apply_subscribe, ChatMessageView, ChatViewState, ClientMessage, KindRevision, KnownKind,
+    PersonaSlotView, Revisions, SenderKind, ServerMessage, StateBuilder, StateLayer,
+    SubstrateStateCache,
+};
+use uuid::Uuid;
+
+/// Helper: build a ChatViewState with a single message + one persona
+/// in the roster. Reused across tests so each one stays focused on
+/// the property under test.
+fn build_chat_state(content: &str) -> ChatViewState {
+    let room_id = Uuid::from_u128(0xa);
+    let persona_id = Uuid::from_u128(0xb);
+    let message_id = Uuid::from_u128(0xc);
+    let sender_id = Uuid::from_u128(0xd);
+    ChatViewState {
+        room_id,
+        room_name: "general".into(),
+        messages: vec![ChatMessageView {
+            id: message_id,
+            room_id,
+            sender_id,
+            sender_name: "Joel".into(),
+            sender_kind: SenderKind::Human,
+            content: content.into(),
+            timestamp: 1_700_000_000_000,
+        }],
+        roster: vec![PersonaSlotView {
+            persona_id,
+            display_name: "Helper".into(),
+            active: true,
+        }],
+    }
+}
+
+#[test]
+fn typed_payload_round_trips_through_subscribe_snapshot() {
+    // what this catches: regression where the substrate's typed
+    // payload, after passing through StateBuilder + cache + the
+    // subscribe handler + serde, doesn't deserialize back into a
+    // typed payload that matches the original. This is the
+    // load-bearing E2E claim: continuum and positron-lit both speak
+    // the same typed shape.
+
+    let revisions = Arc::new(Revisions::new());
+    let builder = StateBuilder::new(revisions);
+    let cache = SubstrateStateCache::new();
+
+    // 1. Substrate produces typed state.
+    let original = build_chat_state("hello world");
+
+    // 2. StateBuilder frames it as a wire envelope.
+    let envelope = builder.session(KnownKind::Chat, original.clone());
+    assert_eq!(envelope.kind, "chat");
+    assert_eq!(envelope.revision, Some(1));
+    assert_eq!(envelope.layer, StateLayer::Session);
+
+    // 3. Cache stores it; subscribe retrieves it as a snapshot frame.
+    cache.store(envelope.clone());
+    let (sub, frames) = apply_subscribe(
+        &cache,
+        ClientMessage::Subscribe {
+            kinds: vec!["chat".into()],
+            layers: vec![StateLayer::Session],
+            last_seen: vec![],
+        },
+    )
+    .expect("subscribe ok");
+    assert!(sub.covers("chat", StateLayer::Session));
+    assert_eq!(frames.len(), 1, "fresh subscribe → exactly one snapshot");
+
+    let snapshot = match &frames[0] {
+        ServerMessage::State(e) => e,
+        other => panic!("expected State frame, got {other:?}"),
+    };
+    assert_eq!(snapshot.kind, envelope.kind);
+    assert_eq!(snapshot.revision, envelope.revision);
+
+    // 4. The snapshot frame round-trips through serde_json losslessly.
+    let json = serde_json::to_string(snapshot).expect("serialize snapshot");
+    let parsed: continuum_positron::StateEnvelope =
+        serde_json::from_str(&json).expect("deserialize snapshot");
+    assert_eq!(&parsed, snapshot, "envelope must round-trip losslessly");
+
+    // 5. The "client side" deserializes the payload as typed
+    //    ChatViewState. This is the contract that makes positron-lit
+    //    work — the renderer imports the SAME ts-rs-generated
+    //    ChatViewState shape, and the payload value lifted out of
+    //    `StateEnvelope.payload` is byte-identical to what the
+    //    substrate built.
+    let recovered: ChatViewState =
+        serde_json::from_value(parsed.payload.clone()).expect("typed payload deserializes");
+    assert_eq!(recovered, original, "typed payload must round-trip");
+}
+
+#[test]
+fn skip_rule_works_end_to_end_on_resubscribe() {
+    // what this catches: regression where the exact-equality skip
+    // rule passes its unit test but breaks composed against the
+    // builder + cache. This is §6 reconnect-tolerance in
+    // miniature: substrate emits, renderer "renders" rev=1, renderer
+    // resubscribes with last_seen=1, substrate skips the redundant
+    // snapshot. If this regresses, every reconnect floods the
+    // renderer with a duplicate frame — bandwidth waste, not stale-
+    // forever, but the kind of inefficiency that leads to a future
+    // "let's use >= instead" patch that re-introduces stale-forever.
+
+    let revisions = Arc::new(Revisions::new());
+    let builder = StateBuilder::new(revisions);
+    let cache = SubstrateStateCache::new();
+
+    let chat = build_chat_state("first message");
+    let envelope = builder.session(KnownKind::Chat, chat);
+    cache.store(envelope);
+
+    // Renderer subscribes the first time, gets snapshot, renders
+    // rev=1.
+    let (_, first) = apply_subscribe(
+        &cache,
+        ClientMessage::Subscribe {
+            kinds: vec!["chat".into()],
+            layers: vec![StateLayer::Session],
+            last_seen: vec![],
+        },
+    )
+    .unwrap();
+    assert_eq!(first.len(), 1, "first subscribe gets snapshot");
+
+    // Renderer transport hiccups, reconnects, declares it last saw
+    // rev=1. Substrate's current is still rev=1; skip rule fires.
+    let (_, second) = apply_subscribe(
+        &cache,
+        ClientMessage::Subscribe {
+            kinds: vec!["chat".into()],
+            layers: vec![StateLayer::Session],
+            last_seen: vec![KindRevision {
+                kind: "chat".into(),
+                revision: 1,
+            }],
+        },
+    )
+    .unwrap();
+    assert!(
+        second.is_empty(),
+        "resubscribe with last_seen == current → no snapshot"
+    );
+}
+
+#[test]
+fn substrate_restart_resync_works_end_to_end() {
+    // what this catches: THE load-bearing regression Fable's
+    // round-2 review prevented and this codebase has multiple unit
+    // tests pinned against. End-to-end: a "renderer" that holds
+    // last_seen=500 from a pre-restart substrate meets a "freshly-
+    // started" substrate at rev=1, and SHOULD receive the snapshot
+    // (not silently skip via `>=`). If this regresses end-to-end
+    // even with the unit tests green, something has shimmed the
+    // skip rule above the substrate's seam.
+
+    let revisions = Arc::new(Revisions::new());
+    let builder = StateBuilder::new(revisions);
+    let cache = SubstrateStateCache::new();
+
+    // Fresh substrate, first-ever build → rev=1.
+    let chat = build_chat_state("post-restart hello");
+    let envelope = builder.session(KnownKind::Chat, chat.clone());
+    assert_eq!(envelope.revision, Some(1));
+    cache.store(envelope);
+
+    // Stale renderer holds last_seen=500 from before a substrate
+    // restart that reset its counter.
+    let (_, frames) = apply_subscribe(
+        &cache,
+        ClientMessage::Subscribe {
+            kinds: vec!["chat".into()],
+            layers: vec![StateLayer::Session],
+            last_seen: vec![KindRevision {
+                kind: "chat".into(),
+                revision: 500,
+            }],
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        frames.len(),
+        1,
+        "stale-renderer-vs-fresh-substrate MUST snapshot, never skip"
+    );
+
+    // And the payload is the current one — not a "your future is
+    // gone" silent staleness.
+    let snapshot = match &frames[0] {
+        ServerMessage::State(e) => e,
+        other => panic!("expected State frame, got {other:?}"),
+    };
+    let recovered: ChatViewState = serde_json::from_value(snapshot.payload.clone()).unwrap();
+    assert_eq!(recovered, chat, "renderer sees current substrate truth");
+}
+
+#[test]
+fn two_subscribers_share_envelope_bytes_per_doctrine() {
+    // what this catches: regression where the cache or subscribe
+    // path accidentally duplicates per-subscriber storage. The
+    // doctrine claim ([[shared-decode-per-persona-perspective]]) is
+    // that two renderers subscribing to the same kind in the same
+    // tick get byte-identical snapshots backed by the same cached
+    // allocation. If the cache started cloning on each get(), N
+    // renderers means N decoded payloads — the exact memory bloat
+    // the lazy-cell doctrine exists to avoid.
+
+    let revisions = Arc::new(Revisions::new());
+    let builder = StateBuilder::new(revisions);
+    let cache = SubstrateStateCache::new();
+
+    let chat = build_chat_state("shared snapshot");
+    let envelope = builder.session(KnownKind::Chat, chat);
+    cache.store(envelope);
+
+    let make_subscribe = || {
+        apply_subscribe(
+            &cache,
+            ClientMessage::Subscribe {
+                kinds: vec!["chat".into()],
+                layers: vec![StateLayer::Session],
+                last_seen: vec![],
+            },
+        )
+        .unwrap()
+        .1
+    };
+
+    let frames_a = make_subscribe();
+    let frames_b = make_subscribe();
+
+    // Both renderers receive identical bytes.
+    let json_a = serde_json::to_string(&frames_a).unwrap();
+    let json_b = serde_json::to_string(&frames_b).unwrap();
+    assert_eq!(
+        json_a, json_b,
+        "two subscribers' snapshots must be byte-identical"
+    );
+}
+
+#[test]
+fn three_kinds_independently_partitioned() {
+    // what this catches: regression where multi-kind subscribes
+    // cross-contaminate (e.g. one kind's snapshot accidentally
+    // emitted under another kind's tag). Models a realistic surface
+    // where a chat widget + roster widget + presence widget share
+    // one session. Skip rule applies independently per kind.
+
+    let revisions = Arc::new(Revisions::new());
+    let builder = StateBuilder::new(revisions);
+    let cache = SubstrateStateCache::new();
+
+    // Only Chat is a KnownKind today; for the partition test we
+    // bypass KnownKind and write directly to cache using arbitrary
+    // kinds. (Production would have typed builders for each kind
+    // KnownKind grows — that's the slot for future widget kinds.)
+    let chat_env = builder.session(KnownKind::Chat, build_chat_state("chat hi"));
+    cache.store(chat_env);
+
+    // Synthesize two more kinds inline for the partition test.
+    cache.store(continuum_positron::StateEnvelope {
+        kind: "user-list".into(),
+        revision: Some(11),
+        layer: StateLayer::Session,
+        payload: serde_json::json!({"users": ["a", "b"]}),
+    });
+    cache.store(continuum_positron::StateEnvelope {
+        kind: "presence".into(),
+        revision: Some(7),
+        layer: StateLayer::Session,
+        payload: serde_json::json!({"online": ["c"]}),
+    });
+
+    // Subscribe to all three; client holds last_seen for `user-list`
+    // matching the cache → skip that one only.
+    let (_, frames) = apply_subscribe(
+        &cache,
+        ClientMessage::Subscribe {
+            kinds: vec!["chat".into(), "user-list".into(), "presence".into()],
+            layers: vec![StateLayer::Session],
+            last_seen: vec![KindRevision {
+                kind: "user-list".into(),
+                revision: 11,
+            }],
+        },
+    )
+    .unwrap();
+
+    assert_eq!(frames.len(), 2, "chat + presence sent, user-list skipped");
+    let kinds_sent: Vec<&str> = frames
+        .iter()
+        .map(|f| match f {
+            ServerMessage::State(e) => e.kind.as_str(),
+            _ => panic!("non-State frame in snapshot list"),
+        })
+        .collect();
+    assert!(kinds_sent.contains(&"chat"));
+    assert!(kinds_sent.contains(&"presence"));
+    assert!(!kinds_sent.contains(&"user-list"), "user-list skipped");
+}


### PR DESCRIPTION
## Summary

Continuum's positron substrate, slice 1. Implements the substrate side of the positron contract — produces typed `StateEnvelope`s that positron-lit (Fable's lane) renders. Closes ALPHA-GAP §6 alpha P0/P1 blockers (#793 core-restart reconnect, #794 AI msgs not realtime, #773 WS reconnect) **structurally** via the positron contract: state-down, event-up, no widget-local source-of-truth caches.

Joint workstream with Fable (`@2a183194`) on the airc grid. She's shipping positron-side: contract crate, lit reference renderer, session protocol (`CambrianTech/positron#df3fb2ab`). I'm shipping continuum-side: substrate schema (this PR), event-bridging (next slice), wire transport binding (lands when her session protocol PR merges).

## Theme — Substrate schema (slice 1)

- **`KnownKind` enum + `wire_name()`** — typed widget kinds. The `match` on a payload variant is rustc-enforced exhaustive; a typo at the call site is a compile error, not a runtime mismatch.

- **`Revisions`** — monotonic per-kind counter. Per Fable's session-protocol design call: `ViewState::revision()` is one counter per state instance; layer classifies an UPDATE's cadence, not state identity. So `Session` and `Ephemeral` deliveries OF chat share the same per-kind counter; layer-aware partitioning would fragment state identity.

- **`ChatViewState`** typed payload + `ChatMessageView`, `PersonaSlotView`, `SenderKind`. `#[derive(TS)]` exported so the widget side reads typed objects, not `unknown`. `SenderKind` is tagged so the widget keys avatar/styling off a discriminant per `[[strong-typing-across-boundaries]]`.

- **`StateBuilder`** — frames typed payloads into `positron_core::wire::StateEnvelope`s with the right kind tag, auto-allocated revision, and explicit layer (`session` / `persistent` / `ephemeral` / `semantic`). Centralizes the three things that must line up on every state delivery.

- bindings/ gitignored — ts-rs generated per `cargo test`; substrate source of truth is `src/*.rs`.

## What this slice does NOT ship (intentional follow-up)

- **Wire transport binding**. Lands once Fable's session protocol PR (`positron#df3fb2ab`, in Review) merges. Session protocol is typed `ClientMessage` / `ServerMessage` unions with `Subscribe { last_seen: [{kind, revision}] }` replay-on-resync — the §6 reconnect-tolerance primitive.

- **Substrate event source**. Continuum's existing event bus emits room/chat/persona events; the event → `StateEnvelope` bridging goes on top of this slice's typed schema in the next commit.

- **`ContinuumHost` / observer registration**. Lands with the wire transport so the AI-observer perception path (the `Observer<ChatViewState>` impl persona cognition uses to perceive the same chat humans see) is one cohesive cut.

## Architectural correctness

I am the SUBSTRATE per positron's `DESIGN.md §3`, not a `Host` impl. Continuum produces `StateEnvelope`s; positron-lit consumes them. Naming is `continuum-positron` (substrate-side crate), not `ContinuumHost`.

## Dep posture

Path dep on `positron-core@0.0.1` for active dev (Joel + Fable both have the sibling repo). Switch to git rev pin once positron tags v0.1.

## Doctrines

- `[[strong-typing-across-boundaries]]` — typed `KnownKind` enum, tagged `SenderKind`, typed payload structs
- `[[no-fallbacks-ever]]` — `KnownKind::wire_name()` is exhaustive; no "default" arm; serialize-failure in `StateBuilder::build` is a substrate bug not a runtime fallback
- `[[shared-decode-per-persona-perspective]]` — substrate decode (event → typed payload) runs ONCE per arrival; per-observer perspective lands above this scaffold

## Architecture docs

- `docs/planning/ALPHA-GAP-ANALYSIS.md` §6 (UI/Realtime Stability) — the alpha blockers this lane closes
- `positron/DESIGN.md` §3 (host bridge — state-down, event-up) — the contract this crate implements the substrate side of

## Test plan

- [x] `cargo test -p continuum-positron` — 12/12 green (8 hand-written + 4 ts-rs export bindings tests)
- [x] `cargo check -p continuum-positron` — clean, no warnings
- [ ] CI: full workspace build (path dep to sibling positron repo means CI must check out positron too — follow-up: gate this crate behind a feature flag or switch to git rev pin before CI lands)