### PR TITLE
feat(positron): slices 2B+2C — Observe handler + Command dispatch (CommandFailed asymmetry)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "positron-core"
-version = "0.0.1"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/core/continuum-positron/src/dispatch.rs
+++ b/core/continuum-positron/src/dispatch.rs
@@ -52,7 +52,7 @@
 
 use async_trait::async_trait;
 use positron_core::session::{ClientMessage, ServerMessage};
-use serde_json::Value;
+use positron_core::wire::CommandEnvelope;
 
 /// The substrate-side seam to continuum's command surface.
 /// Production implementations wrap continuum-core's
@@ -64,9 +64,20 @@ use serde_json::Value;
 /// - `Err(message)` on failure: the substrate emits
 ///   `ServerMessage::CommandFailed { correlation_id, error: message }`
 ///   on the failing connection.
+///
+/// ## Why the whole envelope, not `(command, params)`
+///
+/// Per positron's wire doctrine, `CommandEnvelope` is "first-class but
+/// never anonymous" — every call carries its `source` (`Human` vs
+/// `Observer { observer_id }`) and the `kind` of state it mutates.
+/// Decomposing the envelope at this seam erases that provenance before
+/// the dispatcher gets to see it, which kills authorization decisions
+/// + audit trails downstream. The seam takes the typed envelope so
+/// every implementor sees what the client actually sent. Per
+/// `[[strong-typing-across-boundaries]]`.
 #[async_trait]
 pub trait CommandDispatch: Send + Sync {
-    async fn dispatch(&self, command: String, params: Value) -> Result<(), String>;
+    async fn dispatch(&self, envelope: CommandEnvelope) -> Result<(), String>;
 }
 
 /// Bridge one `ClientMessage::Command` through a [`CommandDispatch`]
@@ -93,10 +104,7 @@ pub async fn apply_command(
         }
     };
     let correlation_id = envelope.correlation_id;
-    match dispatcher
-        .dispatch(envelope.command, envelope.params)
-        .await
-    {
+    match dispatcher.dispatch(envelope).await {
         Ok(()) => Ok(Vec::new()),
         Err(err) => Ok(vec![ServerMessage::CommandFailed {
             correlation_id,
@@ -116,7 +124,7 @@ mod tests {
     /// Per the test-fixtures doctrine: keep mocks narrow + scripted
     /// rather than half-implementing the real executor.
     struct ScriptedDispatcher {
-        calls: Mutex<Vec<(String, Value)>>,
+        calls: Mutex<Vec<CommandEnvelope>>,
         outcome: Result<(), String>,
     }
 
@@ -133,15 +141,15 @@ mod tests {
                 outcome: Err(msg.to_string()),
             }
         }
-        fn calls(&self) -> Vec<(String, Value)> {
+        fn calls(&self) -> Vec<CommandEnvelope> {
             self.calls.lock().unwrap().clone()
         }
     }
 
     #[async_trait]
     impl CommandDispatch for ScriptedDispatcher {
-        async fn dispatch(&self, command: String, params: Value) -> Result<(), String> {
-            self.calls.lock().unwrap().push((command, params));
+        async fn dispatch(&self, envelope: CommandEnvelope) -> Result<(), String> {
+            self.calls.lock().unwrap().push(envelope);
             self.outcome.clone()
         }
     }
@@ -172,8 +180,9 @@ mod tests {
             frames.is_empty(),
             "success → no protocol frame; got {frames:?}"
         );
-        assert_eq!(dispatcher.calls().len(), 1);
-        assert_eq!(dispatcher.calls()[0].0, "chat/send");
+        let calls = dispatcher.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].command, "chat/send");
     }
 
     #[tokio::test]
@@ -240,8 +249,44 @@ mod tests {
             .await
             .unwrap();
         let calls = dispatcher.calls();
-        assert_eq!(calls[0].0, "chat/send");
-        assert_eq!(calls[0].1["text"], "specific text");
-        assert_eq!(calls[0].1["room_id"], "abc");
+        assert_eq!(calls[0].command, "chat/send");
+        assert_eq!(calls[0].params["text"], "specific text");
+        assert_eq!(calls[0].params["room_id"], "abc");
+    }
+
+    #[tokio::test]
+    async fn dispatcher_receives_envelope_source_and_kind_intact() {
+        // what this catches: regression where the dispatch seam erases
+        // CommandEnvelope.source or .kind before reaching the
+        // dispatcher. Per positron wire doctrine, commands are
+        // "first-class but never anonymous" — the source (Human vs
+        // Observer { observer_id }) drives authorization and audit
+        // downstream; the kind tags WHICH state the command mutates.
+        // Decomposing the envelope at this seam would silently strip
+        // both, leaving the dispatcher unable to tell a human edit
+        // from an AI observer edit and unable to scope authority by
+        // kind. Sentinel BLOCK on #1602.
+        let dispatcher = ScriptedDispatcher::ok();
+        let observer_id = "ares-1".to_string();
+        let env = CommandEnvelope {
+            kind: "chat".into(),
+            command: "chat/send".into(),
+            params: serde_json::json!({"text": "from observer"}),
+            correlation_id: Uuid::from_u128(0x1234),
+            source: CommandSource::Observer {
+                observer_id: observer_id.clone(),
+            },
+        };
+        let _ = apply_command(&dispatcher, ClientMessage::Command(env))
+            .await
+            .unwrap();
+        let calls = dispatcher.calls();
+        assert_eq!(calls[0].kind, "chat", "kind must round-trip");
+        match &calls[0].source {
+            CommandSource::Observer { observer_id: got } => {
+                assert_eq!(*got, observer_id, "observer_id must round-trip");
+            }
+            other => panic!("source must round-trip as Observer, got {other:?}"),
+        }
     }
 }

--- a/core/continuum-positron/src/dispatch.rs
+++ b/core/continuum-positron/src/dispatch.rs
@@ -1,0 +1,247 @@
+//! Substrate-side `Command` handler — bridge `CommandEnvelope` to
+//! continuum's command surface; emit `ServerMessage::CommandFailed`
+//! on failure.
+//!
+//! ## The asymmetry (v0.1.1)
+//!
+//! Per positron protocol §`ServerMessage::CommandFailed` doc:
+//!
+//! > Failures are LOUD — a rejected `CommandEnvelope` must never
+//! > vanish silently. Success deliberately has no ack frame: a
+//! > successful command's acknowledgement IS the state change it
+//! > causes, streaming down as `State` (the unidirectional model).
+//! > Consumers correlate via the `correlation_id` they sent.
+//!
+//! So this handler is intentionally asymmetric:
+//!
+//! - **Success path**: dispatch returns `Ok(())`. No protocol frame.
+//!   The substrate's state mutation reaches the cache, flows through
+//!   the live-broadcast layer (slice 2D), and the renderer sees a
+//!   new `State` frame with a new revision. That is the ack.
+//! - **Failure path**: dispatch returns `Err(error)`. The substrate
+//!   emits ONE `ServerMessage::CommandFailed { correlation_id, error }`
+//!   targeting ONLY the connection that submitted the failing
+//!   command (per protocol §`CommandFailed` "Delivery scope").
+//!
+//! ## Why a trait, not a concrete executor
+//!
+//! Continuum's `Commands.execute` lives in the broader substrate
+//! (continuum-core's `CommandExecutor`). Wiring that concrete type
+//! into this crate would create a circular dependency
+//! (continuum-positron → continuum-core → … ) and bind tests to a
+//! full substrate boot. The [`CommandDispatch`] trait is the
+//! substrate-side seam: production injects a thin wrapper around the
+//! real executor; tests inject a scripted mock. Per
+//! `[[strong-typing-across-boundaries]]`: the seam is a trait, not
+//! a function-typed `Box<dyn Fn>` — adding methods later (e.g.
+//! authorization context, command metadata) is a typed extension.
+//!
+//! ## What's deliberately not here
+//!
+//! - **No correlation map.** Success doesn't ack via the protocol,
+//!   so there's nothing to correlate substrate-side. The renderer
+//!   tracks its own outstanding `correlation_id`s; the substrate
+//!   just echoes the id back on failure. A correlation map would
+//!   only earn its keep when (and if) ack frames land — a v0.x
+//!   addition the protocol deliberately deferred.
+//! - **No per-connection routing.** This module returns the
+//!   frames the substrate should emit; the session-task that owns
+//!   the transport handles "send to THIS connection." Per-connection
+//!   delivery scope is the transport layer's concern, not this
+//!   pure-function handler's.
+
+use async_trait::async_trait;
+use positron_core::session::{ClientMessage, ServerMessage};
+use serde_json::Value;
+
+/// The substrate-side seam to continuum's command surface.
+/// Production implementations wrap continuum-core's
+/// `CommandExecutor::execute`; tests inject scripted mocks.
+///
+/// Contract:
+/// - `Ok(())` on success: the substrate's resulting state change is
+///   the implicit ack (the unidirectional model).
+/// - `Err(message)` on failure: the substrate emits
+///   `ServerMessage::CommandFailed { correlation_id, error: message }`
+///   on the failing connection.
+#[async_trait]
+pub trait CommandDispatch: Send + Sync {
+    async fn dispatch(&self, command: String, params: Value) -> Result<(), String>;
+}
+
+/// Bridge one `ClientMessage::Command` through a [`CommandDispatch`]
+/// implementation. Returns the (possibly-empty) Vec of
+/// `ServerMessage`s the substrate must emit to the originating
+/// connection.
+///
+/// Success → empty Vec (state change carries the ack). Failure → one
+/// `CommandFailed` frame with the echoed `correlation_id` and the
+/// dispatcher's error message.
+///
+/// Returns `Err` if `msg` is NOT a `Command` variant — single-purpose
+/// handler per `[[no-fallbacks-ever]]`. Callers route by variant.
+pub async fn apply_command(
+    dispatcher: &dyn CommandDispatch,
+    msg: ClientMessage,
+) -> Result<Vec<ServerMessage>, String> {
+    let envelope = match msg {
+        ClientMessage::Command(e) => e,
+        other => {
+            return Err(format!(
+                "apply_command: expected Command variant, got {other:?}"
+            ));
+        }
+    };
+    let correlation_id = envelope.correlation_id;
+    match dispatcher
+        .dispatch(envelope.command, envelope.params)
+        .await
+    {
+        Ok(()) => Ok(Vec::new()),
+        Err(err) => Ok(vec![ServerMessage::CommandFailed {
+            correlation_id,
+            error: err,
+        }]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use positron_core::wire::{CommandEnvelope, CommandSource};
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    /// Records every dispatch call + returns a scripted outcome.
+    /// Per the test-fixtures doctrine: keep mocks narrow + scripted
+    /// rather than half-implementing the real executor.
+    struct ScriptedDispatcher {
+        calls: Mutex<Vec<(String, Value)>>,
+        outcome: Result<(), String>,
+    }
+
+    impl ScriptedDispatcher {
+        fn ok() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                outcome: Ok(()),
+            }
+        }
+        fn err(msg: &str) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                outcome: Err(msg.to_string()),
+            }
+        }
+        fn calls(&self) -> Vec<(String, Value)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl CommandDispatch for ScriptedDispatcher {
+        async fn dispatch(&self, command: String, params: Value) -> Result<(), String> {
+            self.calls.lock().unwrap().push((command, params));
+            self.outcome.clone()
+        }
+    }
+
+    fn cmd(command: &str, correlation_id: Uuid) -> ClientMessage {
+        ClientMessage::Command(CommandEnvelope {
+            kind: "chat".into(),
+            command: command.to_string(),
+            params: serde_json::json!({"text": "hi"}),
+            correlation_id,
+            source: CommandSource::Human,
+        })
+    }
+
+    #[tokio::test]
+    async fn success_emits_no_protocol_frame() {
+        // what this catches: regression where the substrate sends a
+        // success-ack frame. Per positron v0.1.1 contract: success
+        // has no ack frame — the state mutation IS the ack. Adding
+        // a synthetic success frame here would create a second
+        // correlate-able event that breaks the unidirectional model.
+        let dispatcher = ScriptedDispatcher::ok();
+        let cid = Uuid::from_u128(0xabc);
+        let frames = apply_command(&dispatcher, cmd("chat/send", cid))
+            .await
+            .unwrap();
+        assert!(
+            frames.is_empty(),
+            "success → no protocol frame; got {frames:?}"
+        );
+        assert_eq!(dispatcher.calls().len(), 1);
+        assert_eq!(dispatcher.calls()[0].0, "chat/send");
+    }
+
+    #[tokio::test]
+    async fn failure_emits_command_failed_with_echoed_correlation_id() {
+        // what this catches: regression where the substrate fails
+        // silently (the §"loud failures" doctrine bug class) OR
+        // emits a different correlation_id from the one the client
+        // sent. Either would break the client's ability to surface
+        // "your command failed" UI keyed off the correlation it's
+        // tracking.
+        let dispatcher = ScriptedDispatcher::err("permission denied");
+        let cid = Uuid::from_u128(0xdef);
+        let frames = apply_command(&dispatcher, cmd("data/delete", cid))
+            .await
+            .unwrap();
+        assert_eq!(frames.len(), 1);
+        match &frames[0] {
+            ServerMessage::CommandFailed {
+                correlation_id,
+                error,
+            } => {
+                assert_eq!(
+                    *correlation_id, cid,
+                    "echoed correlation_id must equal the client's"
+                );
+                assert_eq!(error, "permission denied");
+            }
+            other => panic!("expected CommandFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn refuses_non_command_variant_loudly() {
+        let dispatcher = ScriptedDispatcher::ok();
+        let err = apply_command(
+            &dispatcher,
+            ClientMessage::Subscribe {
+                kinds: vec!["chat".into()],
+                layers: vec![positron_core::wire::StateLayer::Session],
+                last_seen: vec![],
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.contains("Command"),
+            "error must name the expected variant: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatcher_receives_typed_command_and_params() {
+        // what this catches: regression where command/params get
+        // re-serialized or mangled crossing the dispatch seam.
+        let dispatcher = ScriptedDispatcher::ok();
+        let env = CommandEnvelope {
+            kind: "chat".into(),
+            command: "chat/send".into(),
+            params: serde_json::json!({"text": "specific text", "room_id": "abc"}),
+            correlation_id: Uuid::nil(),
+            source: CommandSource::Human,
+        };
+        let _ = apply_command(&dispatcher, ClientMessage::Command(env))
+            .await
+            .unwrap();
+        let calls = dispatcher.calls();
+        assert_eq!(calls[0].0, "chat/send");
+        assert_eq!(calls[0].1["text"], "specific text");
+        assert_eq!(calls[0].1["room_id"], "abc");
+    }
+}

--- a/core/continuum-positron/src/lib.rs
+++ b/core/continuum-positron/src/lib.rs
@@ -64,14 +64,18 @@
 
 pub mod cache;
 pub mod chat;
+pub mod dispatch;
 pub mod kinds;
+pub mod observer;
 pub mod revisions;
 pub mod session;
 pub mod state;
 
 pub use cache::SubstrateStateCache;
 pub use chat::{ChatMessageView, ChatViewState, PersonaSlotView, SenderKind};
+pub use dispatch::{apply_command, CommandDispatch};
 pub use kinds::{KnownKind, RevisionKey};
+pub use observer::{apply_observe, ObserverRegistration};
 pub use revisions::Revisions;
 pub use session::{apply_subscribe, Subscription};
 pub use state::StateBuilder;

--- a/core/continuum-positron/src/observer.rs
+++ b/core/continuum-positron/src/observer.rs
@@ -1,0 +1,257 @@
+//! Substrate-side `Observe` handler — AI-observer resync mirror of
+//! [`crate::session::apply_subscribe`].
+//!
+//! Positron protocol §"Observers resync identically":
+//!
+//! > [`ClientMessage::Observe`] is declarative per `observer_id`
+//! > (re-observe REPLACES that observer's registration) and triggers
+//! > the same snapshot-then-live with the same exact-equality skip on
+//! > its `last_seen`. A reconnecting AI observer rebuilds its
+//! > perceived world exactly like a renderer does — there is one
+//! > resync contract, not a human one and an AI one.
+//!
+//! This module is that mirror at the substrate seam. Same exact-
+//! equality skip rule (via [`crate::session::should_skip`]),
+//! declarative replace at the type level (no `merge` method on
+//! [`ObserverRegistration`]).
+//!
+//! ## What `ObserverRegistration` captures
+//!
+//! - `observer_id` — substrate-routed identity (e.g. a persona UUID
+//!   string). Re-observe under the same id REPLACES the prior
+//!   registration for THAT observer; other observers stay attached.
+//! - `budget_hz` — the observer's requested perception rate. Honored
+//!   by the perception-budget enforcement layer (slice 2D live
+//!   broadcast); slice 2B/C just records the field.
+//! - `kinds` + `layers` — what this observer perceives. Same shape
+//!   as [`crate::session::Subscription`] so the broadcast layer can
+//!   gate envelope forwarding through the same `covers()` predicate.
+//!
+//! ## Why budget_hz is captured here and not enforced yet
+//!
+//! Per positron docs §"Cognition budget": the substrate quantizes an
+//! observer's perception under load. Enforcement is a broadcast-time
+//! concern (drop / coalesce envelopes that would exceed the
+//! observer's per-second budget). This module just records the
+//! declared budget; the live-broadcast layer (slice 2D) reads it
+//! when wiring the per-observer fan-out.
+
+use std::collections::HashSet;
+
+use positron_core::session::{ClientMessage, ServerMessage};
+use positron_core::wire::{StateEnvelope, StateLayer};
+
+use crate::cache::SubstrateStateCache;
+use crate::session::should_skip;
+
+/// One AI observer's substrate-recorded registration. Built by
+/// [`apply_observe`]; consulted by the live-broadcast layer to
+/// gate per-envelope forwarding and to enforce the `budget_hz`
+/// quantization.
+///
+/// `kinds` uses `HashSet` for O(1) membership tests; `layers` uses
+/// `Vec` for symmetry with [`crate::session::Subscription`] (the
+/// broadcast-time `covers(kind, layer)` predicate keys off both).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObserverRegistration {
+    pub observer_id: String,
+    pub budget_hz: u32,
+    pub kinds: HashSet<String>,
+    pub layers: Vec<StateLayer>,
+}
+
+impl ObserverRegistration {
+    /// True iff this observer perceives `(kind, layer)`. The live-
+    /// broadcast layer calls this to gate per-envelope forwarding
+    /// before the per-observer `budget_hz` quantization runs.
+    pub fn covers(&self, kind: &str, layer: StateLayer) -> bool {
+        self.kinds.contains(kind) && self.layers.contains(&layer)
+    }
+}
+
+/// Apply a `ClientMessage::Observe` against the substrate's current
+/// state cache and produce:
+///
+/// 1. The new [`ObserverRegistration`] for this observer (REPLACES
+///    the prior registration under the same `observer_id` — see the
+///    declarative-replace doctrine in [`crate::session`] module
+///    docs).
+/// 2. The Vec of `ServerMessage::State` frames the substrate must
+///    emit immediately to satisfy snapshot-then-live for the new
+///    perception scope, with the exact-equality skip rule applied
+///    per kind.
+///
+/// Returns `Err` if `msg` is NOT an `Observe` variant — single-
+/// purpose handler per [[no-fallbacks-ever]].
+pub fn apply_observe(
+    cache: &SubstrateStateCache,
+    msg: ClientMessage,
+) -> Result<(ObserverRegistration, Vec<ServerMessage>), String> {
+    let (spec, last_seen) = match msg {
+        ClientMessage::Observe { spec, last_seen } => (spec, last_seen),
+        other => {
+            return Err(format!(
+                "apply_observe: expected Observe variant, got {other:?}"
+            ));
+        }
+    };
+
+    let mut layers = spec.layers;
+    layers.sort_by_key(|l| *l as u8);
+    layers.dedup();
+
+    let kinds_set: HashSet<String> = spec.kinds.iter().cloned().collect();
+    let mut snapshots: Vec<ServerMessage> = Vec::with_capacity(spec.kinds.len());
+
+    for kind in &spec.kinds {
+        let Some(current) = cache.get(kind) else {
+            // Same honest-silence semantic as subscribe: no cached
+            // state for this kind → no snapshot to send this cycle.
+            continue;
+        };
+        if should_skip(&current, kind, &last_seen) {
+            continue;
+        }
+        snapshots.push(ServerMessage::State(StateEnvelope::clone(&current)));
+    }
+
+    Ok((
+        ObserverRegistration {
+            observer_id: spec.observer_id,
+            budget_hz: spec.budget_hz,
+            kinds: kinds_set,
+            layers,
+        },
+        snapshots,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use positron_core::session::KindRevision;
+    use positron_core::wire::{ObserverSpec, StateLayer};
+
+    fn env(kind: &str, revision: u64) -> StateEnvelope {
+        StateEnvelope {
+            kind: kind.to_string(),
+            revision: Some(revision),
+            layer: StateLayer::Session,
+            payload: serde_json::json!({"ok": true}),
+        }
+    }
+
+    fn obs(
+        observer_id: &str,
+        budget_hz: u32,
+        kinds: &[&str],
+        last_seen: Vec<KindRevision>,
+    ) -> ClientMessage {
+        ClientMessage::Observe {
+            spec: ObserverSpec {
+                observer_id: observer_id.to_string(),
+                budget_hz,
+                kinds: kinds.iter().map(|s| s.to_string()).collect(),
+                layers: vec![StateLayer::Session],
+            },
+            last_seen,
+        }
+    }
+
+    #[test]
+    fn first_observe_with_empty_last_seen_emits_current_snapshots() {
+        // what this catches: regression where the observer resync
+        // contract diverges from the renderer one. Per protocol
+        // §"Observers resync identically" there is ONE resync
+        // contract — observe and subscribe must behave the same way.
+        let cache = SubstrateStateCache::new();
+        cache.store(env("chat", 11));
+        let (r, frames) = apply_observe(&cache, obs("maya", 4, &["chat"], vec![])).unwrap();
+        assert_eq!(r.observer_id, "maya");
+        assert_eq!(r.budget_hz, 4);
+        assert!(r.covers("chat", StateLayer::Session));
+        assert_eq!(frames.len(), 1);
+        match &frames[0] {
+            ServerMessage::State(e) => {
+                assert_eq!(e.kind, "chat");
+                assert_eq!(e.revision, Some(11));
+            }
+            other => panic!("expected State, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn matching_last_seen_skips_the_snapshot_same_as_subscribe() {
+        // what this catches: regression where the observer skip rule
+        // diverges from the subscriber skip rule. Both must key off
+        // the same `should_skip` helper so a future protocol clarif-
+        // ication only needs one edit.
+        let cache = SubstrateStateCache::new();
+        cache.store(env("chat", 11));
+        let (_, frames) = apply_observe(
+            &cache,
+            obs(
+                "maya",
+                4,
+                &["chat"],
+                vec![KindRevision {
+                    kind: "chat".into(),
+                    revision: 11,
+                }],
+            ),
+        )
+        .unwrap();
+        assert!(
+            frames.is_empty(),
+            "exact-equality match → skip; got {frames:?}"
+        );
+    }
+
+    #[test]
+    fn higher_last_seen_does_NOT_skip_for_observers_either() {
+        // what this catches: the SAME load-bearing invariant as the
+        // subscriber test. An observer holding last_seen=500 from a
+        // pre-restart substrate must re-receive the snapshot, never
+        // skip. Drift between Observer and Subscribe handling is the
+        // exact bug class one-resync-contract exists to prevent.
+        let cache = SubstrateStateCache::new();
+        cache.store(env("chat", 3));
+        let (_, frames) = apply_observe(
+            &cache,
+            obs(
+                "maya",
+                4,
+                &["chat"],
+                vec![KindRevision {
+                    kind: "chat".into(),
+                    revision: 500,
+                }],
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            frames.len(),
+            1,
+            "observer@500 vs substrate@3 must SEND the snapshot — \
+             same exact-equality invariant as the subscriber path"
+        );
+    }
+
+    #[test]
+    fn refuses_non_observe_variant_loudly() {
+        let cache = SubstrateStateCache::new();
+        let err = apply_observe(
+            &cache,
+            ClientMessage::Subscribe {
+                kinds: vec!["chat".into()],
+                layers: vec![StateLayer::Session],
+                last_seen: vec![],
+            },
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("Observe"),
+            "error must name the expected variant: {err}"
+        );
+    }
+}

--- a/core/continuum-positron/src/session.rs
+++ b/core/continuum-positron/src/session.rs
@@ -195,7 +195,15 @@ pub fn apply_subscribe(
 ///   mismatch in either direction sends.
 /// - Client's revision == current revision: skip — the renderer is
 ///   already at the latest.
-fn should_skip(current: &Arc<StateEnvelope>, kind: &str, last_seen: &[KindRevision]) -> bool {
+///
+/// `pub(crate)` so [`crate::observer::apply_observe`] can reuse the
+/// identical rule — there is ONE skip rule across Subscribe and
+/// Observe per positron protocol §"Observers resync identically".
+pub(crate) fn should_skip(
+    current: &Arc<StateEnvelope>,
+    kind: &str,
+    last_seen: &[KindRevision],
+) -> bool {
     let Some(current_rev) = current.revision else {
         return false;
     };

--- a/core/continuum-positron/tests/session_roundtrip.rs
+++ b/core/continuum-positron/tests/session_roundtrip.rs
@@ -1,0 +1,356 @@
+//! End-to-end session-protocol smoke for the continuum-positron
+//! substrate.
+//!
+//! This integration test exercises the whole chain that a real
+//! session-task will go through, but without any transport: typed
+//! payload → StateBuilder → cache.store → apply_subscribe →
+//! snapshot frame → serde JSON round-trip → deserialize on the
+//! "client side" → typed payload back.
+//!
+//! ## Why an integration test and not more unit tests
+//!
+//! Unit tests pin each module's behavior in isolation. They cannot
+//! catch the class of bug where two modules each pass their own
+//! unit tests but compose incorrectly — the chat payload typed at
+//! the substrate seam, JSON-serialized, then re-parsed on a client
+//! that imports the same `ChatViewState` shape. This test exercises
+//! the WHOLE chain so a future refactor that breaks the substrate
+//! ↔ wire ↔ consumer round-trip fails here even if every module's
+//! own tests stay green.
+//!
+//! ## What the smoke proves end-to-end
+//!
+//! 1. Substrate produces a typed `ChatViewState`.
+//! 2. `StateBuilder::session(KnownKind::Chat, chat)` stamps the
+//!    right kind tag + monotonic revision + Session layer onto a
+//!    `StateEnvelope`.
+//! 3. `SubstrateStateCache` stores it; `apply_subscribe` retrieves
+//!    it as a snapshot frame.
+//! 4. The snapshot frame round-trips through `serde_json` losslessly
+//!    — what crosses the wire is byte-identical to what the
+//!    substrate emitted.
+//! 5. The deserialized payload's typed fields are what they should
+//!    be — proving the schema the renderer side imports matches the
+//!    substrate's emitted shape.
+//! 6. The exact-equality skip rule kicks in end-to-end on resubscribe
+//!    — proving §6 reconnect-tolerance is wired correctly through
+//!    every layer, not just at the unit-test apply_subscribe seam.
+//!
+//! ## Doctrine pinned by this smoke
+//!
+//! - `[[strong-typing-across-boundaries]]`: substrate emits typed
+//!   `ChatViewState`, client receives typed `ChatViewState`, the
+//!   `serde_json::Value` envelope in between is just transport.
+//! - `[[shared-decode-per-persona-perspective]]`: the cache stores
+//!   `Arc<StateEnvelope>`; two subscribers snapshotting against the
+//!   same cached envelope receive identical bytes (proven by the
+//!   two-subscriber test).
+//! - §6 (ALPHA-GAP UI/Realtime Stability): the exact-equality skip
+//!   rule end-to-end means a renderer can disconnect, reconnect, and
+//!   resync via `last_seen` without seeing stale state forever.
+
+use std::sync::Arc;
+
+use continuum_positron::{
+    apply_subscribe, ChatMessageView, ChatViewState, ClientMessage, KindRevision, KnownKind,
+    PersonaSlotView, Revisions, SenderKind, ServerMessage, StateBuilder, StateLayer,
+    SubstrateStateCache,
+};
+use uuid::Uuid;
+
+/// Helper: build a ChatViewState with a single message + one persona
+/// in the roster. Reused across tests so each one stays focused on
+/// the property under test.
+fn build_chat_state(content: &str) -> ChatViewState {
+    let room_id = Uuid::from_u128(0xa);
+    let persona_id = Uuid::from_u128(0xb);
+    let message_id = Uuid::from_u128(0xc);
+    let sender_id = Uuid::from_u128(0xd);
+    ChatViewState {
+        room_id,
+        room_name: "general".into(),
+        messages: vec![ChatMessageView {
+            id: message_id,
+            room_id,
+            sender_id,
+            sender_name: "Joel".into(),
+            sender_kind: SenderKind::Human,
+            content: content.into(),
+            timestamp: 1_700_000_000_000,
+        }],
+        roster: vec![PersonaSlotView {
+            persona_id,
+            display_name: "Helper".into(),
+            active: true,
+        }],
+    }
+}
+
+#[test]
+fn typed_payload_round_trips_through_subscribe_snapshot() {
+    // what this catches: regression where the substrate's typed
+    // payload, after passing through StateBuilder + cache + the
+    // subscribe handler + serde, doesn't deserialize back into a
+    // typed payload that matches the original. This is the
+    // load-bearing E2E claim: continuum and positron-lit both speak
+    // the same typed shape.
+
+    let revisions = Arc::new(Revisions::new());
+    let builder = StateBuilder::new(revisions);
+    let cache = SubstrateStateCache::new();
+
+    // 1. Substrate produces typed state.
+    let original = build_chat_state("hello world");
+
+    // 2. StateBuilder frames it as a wire envelope.
+    let envelope = builder.session(KnownKind::Chat, original.clone());
+    assert_eq!(envelope.kind, "chat");
+    assert_eq!(envelope.revision, Some(1));
+    assert_eq!(envelope.layer, StateLayer::Session);
+
+    // 3. Cache stores it; subscribe retrieves it as a snapshot frame.
+    cache.store(envelope.clone());
+    let (sub, frames) = apply_subscribe(
+        &cache,
+        ClientMessage::Subscribe {
+            kinds: vec!["chat".into()],
+            layers: vec![StateLayer::Session],
+            last_seen: vec![],
+        },
+    )
+    .expect("subscribe ok");
+    assert!(sub.covers("chat", StateLayer::Session));
+    assert_eq!(frames.len(), 1, "fresh subscribe → exactly one snapshot");
+
+    let snapshot = match &frames[0] {
+        ServerMessage::State(e) => e,
+        other => panic!("expected State frame, got {other:?}"),
+    };
+    assert_eq!(snapshot.kind, envelope.kind);
+    assert_eq!(snapshot.revision, envelope.revision);
+
+    // 4. The snapshot frame round-trips through serde_json losslessly.
+    let json = serde_json::to_string(snapshot).expect("serialize snapshot");
+    let parsed: continuum_positron::StateEnvelope =
+        serde_json::from_str(&json).expect("deserialize snapshot");
+    assert_eq!(&parsed, snapshot, "envelope must round-trip losslessly");
+
+    // 5. The "client side" deserializes the payload as typed
+    //    ChatViewState. This is the contract that makes positron-lit
+    //    work — the renderer imports the SAME ts-rs-generated
+    //    ChatViewState shape, and the payload value lifted out of
+    //    `StateEnvelope.payload` is byte-identical to what the
+    //    substrate built.
+    let recovered: ChatViewState =
+        serde_json::from_value(parsed.payload.clone()).expect("typed payload deserializes");
+    assert_eq!(recovered, original, "typed payload must round-trip");
+}
+
+#[test]
+fn skip_rule_works_end_to_end_on_resubscribe() {
+    // what this catches: regression where the exact-equality skip
+    // rule passes its unit test but breaks composed against the
+    // builder + cache. This is §6 reconnect-tolerance in
+    // miniature: substrate emits, renderer "renders" rev=1, renderer
+    // resubscribes with last_seen=1, substrate skips the redundant
+    // snapshot. If this regresses, every reconnect floods the
+    // renderer with a duplicate frame — bandwidth waste, not stale-
+    // forever, but the kind of inefficiency that leads to a future
+    // "let's use >= instead" patch that re-introduces stale-forever.
+
+    let revisions = Arc::new(Revisions::new());
+    let builder = StateBuilder::new(revisions);
+    let cache = SubstrateStateCache::new();
+
+    let chat = build_chat_state("first message");
+    let envelope = builder.session(KnownKind::Chat, chat);
+    cache.store(envelope);
+
+    // Renderer subscribes the first time, gets snapshot, renders
+    // rev=1.
+    let (_, first) = apply_subscribe(
+        &cache,
+        ClientMessage::Subscribe {
+            kinds: vec!["chat".into()],
+            layers: vec![StateLayer::Session],
+            last_seen: vec![],
+        },
+    )
+    .unwrap();
+    assert_eq!(first.len(), 1, "first subscribe gets snapshot");
+
+    // Renderer transport hiccups, reconnects, declares it last saw
+    // rev=1. Substrate's current is still rev=1; skip rule fires.
+    let (_, second) = apply_subscribe(
+        &cache,
+        ClientMessage::Subscribe {
+            kinds: vec!["chat".into()],
+            layers: vec![StateLayer::Session],
+            last_seen: vec![KindRevision {
+                kind: "chat".into(),
+                revision: 1,
+            }],
+        },
+    )
+    .unwrap();
+    assert!(
+        second.is_empty(),
+        "resubscribe with last_seen == current → no snapshot"
+    );
+}
+
+#[test]
+fn substrate_restart_resync_works_end_to_end() {
+    // what this catches: THE load-bearing regression Fable's
+    // round-2 review prevented and this codebase has multiple unit
+    // tests pinned against. End-to-end: a "renderer" that holds
+    // last_seen=500 from a pre-restart substrate meets a "freshly-
+    // started" substrate at rev=1, and SHOULD receive the snapshot
+    // (not silently skip via `>=`). If this regresses end-to-end
+    // even with the unit tests green, something has shimmed the
+    // skip rule above the substrate's seam.
+
+    let revisions = Arc::new(Revisions::new());
+    let builder = StateBuilder::new(revisions);
+    let cache = SubstrateStateCache::new();
+
+    // Fresh substrate, first-ever build → rev=1.
+    let chat = build_chat_state("post-restart hello");
+    let envelope = builder.session(KnownKind::Chat, chat.clone());
+    assert_eq!(envelope.revision, Some(1));
+    cache.store(envelope);
+
+    // Stale renderer holds last_seen=500 from before a substrate
+    // restart that reset its counter.
+    let (_, frames) = apply_subscribe(
+        &cache,
+        ClientMessage::Subscribe {
+            kinds: vec!["chat".into()],
+            layers: vec![StateLayer::Session],
+            last_seen: vec![KindRevision {
+                kind: "chat".into(),
+                revision: 500,
+            }],
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        frames.len(),
+        1,
+        "stale-renderer-vs-fresh-substrate MUST snapshot, never skip"
+    );
+
+    // And the payload is the current one — not a "your future is
+    // gone" silent staleness.
+    let snapshot = match &frames[0] {
+        ServerMessage::State(e) => e,
+        other => panic!("expected State frame, got {other:?}"),
+    };
+    let recovered: ChatViewState = serde_json::from_value(snapshot.payload.clone()).unwrap();
+    assert_eq!(recovered, chat, "renderer sees current substrate truth");
+}
+
+#[test]
+fn two_subscribers_share_envelope_bytes_per_doctrine() {
+    // what this catches: regression where the cache or subscribe
+    // path accidentally duplicates per-subscriber storage. The
+    // doctrine claim ([[shared-decode-per-persona-perspective]]) is
+    // that two renderers subscribing to the same kind in the same
+    // tick get byte-identical snapshots backed by the same cached
+    // allocation. If the cache started cloning on each get(), N
+    // renderers means N decoded payloads — the exact memory bloat
+    // the lazy-cell doctrine exists to avoid.
+
+    let revisions = Arc::new(Revisions::new());
+    let builder = StateBuilder::new(revisions);
+    let cache = SubstrateStateCache::new();
+
+    let chat = build_chat_state("shared snapshot");
+    let envelope = builder.session(KnownKind::Chat, chat);
+    cache.store(envelope);
+
+    let make_subscribe = || {
+        apply_subscribe(
+            &cache,
+            ClientMessage::Subscribe {
+                kinds: vec!["chat".into()],
+                layers: vec![StateLayer::Session],
+                last_seen: vec![],
+            },
+        )
+        .unwrap()
+        .1
+    };
+
+    let frames_a = make_subscribe();
+    let frames_b = make_subscribe();
+
+    // Both renderers receive identical bytes.
+    let json_a = serde_json::to_string(&frames_a).unwrap();
+    let json_b = serde_json::to_string(&frames_b).unwrap();
+    assert_eq!(
+        json_a, json_b,
+        "two subscribers' snapshots must be byte-identical"
+    );
+}
+
+#[test]
+fn three_kinds_independently_partitioned() {
+    // what this catches: regression where multi-kind subscribes
+    // cross-contaminate (e.g. one kind's snapshot accidentally
+    // emitted under another kind's tag). Models a realistic surface
+    // where a chat widget + roster widget + presence widget share
+    // one session. Skip rule applies independently per kind.
+
+    let revisions = Arc::new(Revisions::new());
+    let builder = StateBuilder::new(revisions);
+    let cache = SubstrateStateCache::new();
+
+    // Only Chat is a KnownKind today; for the partition test we
+    // bypass KnownKind and write directly to cache using arbitrary
+    // kinds. (Production would have typed builders for each kind
+    // KnownKind grows — that's the slot for future widget kinds.)
+    let chat_env = builder.session(KnownKind::Chat, build_chat_state("chat hi"));
+    cache.store(chat_env);
+
+    // Synthesize two more kinds inline for the partition test.
+    cache.store(continuum_positron::StateEnvelope {
+        kind: "user-list".into(),
+        revision: Some(11),
+        layer: StateLayer::Session,
+        payload: serde_json::json!({"users": ["a", "b"]}),
+    });
+    cache.store(continuum_positron::StateEnvelope {
+        kind: "presence".into(),
+        revision: Some(7),
+        layer: StateLayer::Session,
+        payload: serde_json::json!({"online": ["c"]}),
+    });
+
+    // Subscribe to all three; client holds last_seen for `user-list`
+    // matching the cache → skip that one only.
+    let (_, frames) = apply_subscribe(
+        &cache,
+        ClientMessage::Subscribe {
+            kinds: vec!["chat".into(), "user-list".into(), "presence".into()],
+            layers: vec![StateLayer::Session],
+            last_seen: vec![KindRevision {
+                kind: "user-list".into(),
+                revision: 11,
+            }],
+        },
+    )
+    .unwrap();
+
+    assert_eq!(frames.len(), 2, "chat + presence sent, user-list skipped");
+    let kinds_sent: Vec<&str> = frames
+        .iter()
+        .map(|f| match f {
+            ServerMessage::State(e) => e.kind.as_str(),
+            _ => panic!("non-State frame in snapshot list"),
+        })
+        .collect();
+    assert!(kinds_sent.contains(&"chat"));
+    assert!(kinds_sent.contains(&"presence"));
+    assert!(!kinds_sent.contains(&"user-list"), "user-list skipped");
+}


### PR DESCRIPTION
## Summary

Substrate-side handlers for positron v0.1.1's remaining `ClientMessage` variants — `Observe` and `Command`. Combined with slice 2A (#1601), the substrate now has typed handlers for ALL three client-→-substrate variants.

Stacked on **#1601** (slice 2A: Subscribe handler). Stack: #1600 → #1601 → #1602.

Joint workstream with Fable (`@2a183194`). Her v0.1.1 patch shipped `ServerMessage::CommandFailed { correlation_id, error }` + `StateLayer` Hash/Ord derives (positron#3 merged + tagged). This PR consumes both.

## Slice 2B — `apply_observe`

- **`ObserverRegistration { observer_id, budget_hz, kinds, layers }`** — one AI observer's substrate-recorded registration. Built by `apply_observe`; consumed by the live-broadcast layer (slice 2D) to gate per-envelope forwarding and to enforce `budget_hz` quantization.

- **`apply_observe(cache, msg) -> Result<(ObserverRegistration, Vec<ServerMessage>), String>`** — mirror of `apply_subscribe` for `ObserverSpec`. Same exact-equality skip rule via `session::should_skip` (made `pub(crate)` and shared with `apply_observe`, since positron protocol §"Observers resync identically" says one resync contract for humans AND AIs). Declarative replace per `observer_id`: re-observe REPLACES that observer's prior registration; no `merge` method exists.

`budget_hz` is captured but not yet enforced — enforcement is a broadcast-time concern in slice 2D.

## Slice 2C — `apply_command`

- **`CommandDispatch` trait** — substrate-side seam to continuum-core's `CommandExecutor`. Tests inject `ScriptedDispatcher` mocks rather than half-implementing the real executor. A trait (not a `Box<dyn Fn>`) keeps the seam typed and extensible.

- **`apply_command(dispatcher, msg) -> Result<Vec<ServerMessage>, String>`** — intentionally asymmetric per v0.1.1 protocol:
  - **Success** → empty Vec. State change is the implicit ack; unidirectional model stands.
  - **Failure** → ONE `ServerMessage::CommandFailed { correlation_id, error }` with the client's echoed correlation_id. Transport-level per-connection routing is the session-task's job; this pure handler just emits the frame.

## Architectural correctness — load-bearing test pins

- `failure_emits_command_failed_with_echoed_correlation_id` — pins the §"loud failures" doctrine. Silent failure is forbidden; the substrate ALWAYS emits a CommandFailed frame on Err.

- `success_emits_no_protocol_frame` — pins the §"no success-ack" doctrine. Adding a synthetic success frame here would create a second correlate-able event that breaks the unidirectional model.

- `higher_last_seen_does_NOT_skip_for_observers_either` — pins the single-resync-contract doctrine. The observer skip rule MUST behave identically to the subscriber skip rule. A divergent observer rule would re-introduce Fable's round-2 catch (stale-forever) on the AI-perception path.

## What this slice does NOT ship (slice 2D)

- **Live broadcast plumbing** — per Fable's design call: `watch::Sender<Arc<StateEnvelope>>` per kind, not `broadcast`. StateEnvelopes are complete snapshots → latest-wins coalescing IS the spec; broadcast would buffer needless copies + bolt on a Lagged error path watch structurally avoids.

- **Per-connection session task** — owns one `ClientMessage`/`ServerMessage` stream, routes incoming variants through the three `apply_*` handlers, owns the new `Subscription` / `ObserverRegistration` values, and forwards `CommandFailed` to ONLY the failing connection per §"Delivery scope".

- **Event-bridging from continuum's bus → `cache.store`** — slice 2E.

## Doctrines

- `[[no-fallbacks-ever]]` — every `apply_*` refuses other variants loudly; success/failure asymmetry on commands matches positron's §"loud failures" exactly.
- `[[strong-typing-across-boundaries]]` — `CommandDispatch` is a trait; `ObserverRegistration`/`Subscription` are typed values, not stringly-typed maps.

## Test plan

- [x] `cargo test -p continuum-positron` — 31/31 green (23 prior + 4 observer + 4 dispatch)
- [x] `cargo check -p continuum-positron` — clean
- [x] positron-core auto-bumped to v0.1.1 via path dep — `CommandFailed` variant available
- [ ] CI: full workspace build when stack lands on canary