### PR TITLE
feat(positron): slice 2D-2 — Substrate coordinator + Connection state machine

### DIFF
--- a/core/continuum-positron/Cargo.toml
+++ b/core/continuum-positron/Cargo.toml
@@ -17,6 +17,7 @@ ts-rs = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
-
-[dev-dependencies]
+# `tokio::sync::watch` is the per-kind live-broadcast primitive (Fable's
+# design call on the positron protocol — latest-wins coalescing IS the
+# spec; broadcast's ring buffer would buffer needless copies).
 tokio = { workspace = true }

--- a/core/continuum-positron/src/broadcast.rs
+++ b/core/continuum-positron/src/broadcast.rs
@@ -1,0 +1,298 @@
+//! Per-kind live broadcast — substrate-side fan-out of state changes
+//! to attached session tasks.
+//!
+//! ## Why `tokio::sync::watch` (and not `broadcast`)
+//!
+//! Per Fable's design call on the airc grid (positron protocol +
+//! session-protocol PR):
+//!
+//! > `watch` per kind — and not as a compromise; it IS the protocol.
+//! > StateEnvelopes are complete snapshots, so latest-wins coalescing
+//! > isn't a degradation, it's the spec — an intermediate envelope a
+//! > receiver never saw is dead weight, not data loss. `broadcast`
+//! > would buffer N intermediates nobody should ever render (needless
+//! > copies) and bolt on a Lagged error path watch structurally avoids.
+//!
+//! So this module wires `tokio::sync::watch::Sender<Arc<StateEnvelope>>`
+//! ONE-per-kind. When the substrate produces a new envelope for a
+//! kind, every connection currently subscribed to that kind's stream
+//! sees the new value at its own pace. Slow consumers see the latest;
+//! fast consumers see every distinct revision.
+//!
+//! ## Lazy per-kind init
+//!
+//! `tokio::sync::watch::channel(initial)` requires an initial value, so
+//! we don't pre-allocate senders for kinds that may never produce
+//! state. Instead the first `send()` for a kind creates that kind's
+//! sender (using the new envelope as the initial value). Subsequent
+//! sends update through the existing sender.
+//!
+//! `subscribe(kind)` returns `None` if no envelope has ever been sent
+//! for `kind` — honest answer per `[[no-fallbacks-ever]]`. Callers
+//! pair `subscribe` with the snapshot-then-live flow:
+//! 1. `apply_subscribe` retrieves the current snapshot from
+//!    [`SubstrateStateCache`] (which itself returns `None` for
+//!    no-state-yet kinds).
+//! 2. `Broadcast::subscribe(kind)` attaches a `watch::Receiver` for
+//!    subsequent updates. If both return `None`, the connection
+//!    silently waits — the first state-store for that kind will both
+//!    populate the cache and (re-creating the sender if needed) emit
+//!    the first watch update.
+//!
+//! ## Coordination with [`crate::SubstrateStateCache`]
+//!
+//! Cache and Broadcast are SEPARATE concerns:
+//! - Cache: snapshot-on-subscribe (cold path).
+//! - Broadcast: subsequent updates (live path).
+//!
+//! Substrate code that produces new state pushes to BOTH:
+//!
+//! ```ignore
+//! let env = builder.session(KnownKind::Chat, chat_state);
+//! cache.store(env.clone());
+//! broadcast.send(Arc::new(env));
+//! ```
+//!
+//! A `Substrate` coordinator wrapping both lands in slice 2D-2
+//! alongside the per-connection session task. Slice 2D-1 (this PR)
+//! ships the primitive in isolation so its single concern (per-kind
+//! watch fan-out) is testable on its own.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use positron_core::wire::StateEnvelope;
+use tokio::sync::watch;
+
+/// Per-kind live broadcast — `tokio::sync::watch::Sender<Arc<StateEnvelope>>`
+/// per kind, lazy-initialized on first send for that kind.
+///
+/// Cheap to share via `Arc`. Internal `Mutex<HashMap>` is held only
+/// briefly during send/subscribe — not across `await`.
+#[derive(Debug, Default)]
+pub struct Broadcast {
+    by_kind: Mutex<HashMap<String, watch::Sender<Arc<StateEnvelope>>>>,
+}
+
+impl Broadcast {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Send `envelope` as the latest state for its kind. The kind is
+    /// read from `envelope.kind` — no need to pass it separately.
+    ///
+    /// First send for a kind lazy-initializes that kind's
+    /// `watch::Sender` (using `envelope` as the initial value). The
+    /// initial receiver from `watch::channel` is immediately dropped
+    /// — actual subscribers attach via [`Broadcast::subscribe`] and
+    /// always get a fresh `Receiver` keyed off the persisted Sender.
+    ///
+    /// Subsequent sends for the same kind update the existing watch
+    /// sender. Subscribers see the latest value; slow subscribers
+    /// see fewer-than-N intermediates, which is correct per the
+    /// protocol's snapshot semantics.
+    pub fn send(&self, envelope: Arc<StateEnvelope>) {
+        let kind = envelope.kind.clone();
+        let mut by_kind = self.by_kind.lock().expect("Broadcast mutex poisoned");
+        match by_kind.get(&kind) {
+            Some(sender) => {
+                // `send_replace` always updates the watched value
+                // and notifies any current receivers, regardless of
+                // whether receivers exist. `send` (the other method)
+                // is a no-op when the channel is closed (no live
+                // receivers) — that would silently lose state-no-
+                // subscribers-yet updates, which is precisely the
+                // moment between substrate-start and first-session-
+                // attach we MUST get right per `[[no-fallbacks-ever]]`.
+                // Returns the old value; we drop it.
+                let _ = sender.send_replace(envelope);
+            }
+            None => {
+                let (sender, _rx) = watch::channel(envelope);
+                by_kind.insert(kind, sender);
+            }
+        }
+    }
+
+    /// Attach a receiver for `kind`'s live updates. Returns `None` if
+    /// no envelope has ever been sent for this kind — honest answer
+    /// per `[[no-fallbacks-ever]]`. Sessions pair this with
+    /// `apply_subscribe` snapshot frames; the typical control flow:
+    ///
+    /// 1. Run `apply_subscribe(cache, msg)` — returns snapshot frames
+    ///    if the cache has state for the requested kinds.
+    /// 2. For each kind in the new subscription, call
+    ///    `broadcast.subscribe(kind)`. If `Some`, spawn the live-
+    ///    forwarding task. If `None`, no live stream yet — the next
+    ///    substrate `store()` for that kind will create both the
+    ///    cache entry AND the watch sender, and a future resubscribe
+    ///    catches up via the snapshot path.
+    pub fn subscribe(&self, kind: &str) -> Option<watch::Receiver<Arc<StateEnvelope>>> {
+        let by_kind = self.by_kind.lock().expect("Broadcast mutex poisoned");
+        by_kind.get(kind).map(|s| s.subscribe())
+    }
+
+    /// Diagnostic: how many kinds have at least one envelope sent.
+    /// Used by tests; not part of the hot path.
+    pub fn kinds_active(&self) -> usize {
+        self.by_kind.lock().expect("Broadcast mutex poisoned").len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use positron_core::wire::StateLayer;
+
+    fn envelope(kind: &str, revision: u64) -> Arc<StateEnvelope> {
+        Arc::new(StateEnvelope {
+            kind: kind.to_string(),
+            revision: Some(revision),
+            layer: StateLayer::Session,
+            payload: serde_json::json!({"rev": revision}),
+        })
+    }
+
+    #[tokio::test]
+    async fn subscribe_before_any_send_returns_none() {
+        // what this catches: regression where the broadcast lazy-
+        // initializes a sender on subscribe. That would let
+        // subscribers attach against an empty stream and wait
+        // forever for an initial value — looks like a bug at the
+        // session-task layer but is actually a broadcast-layer
+        // anti-fallback violation here.
+        let b = Broadcast::new();
+        assert!(b.subscribe("chat").is_none());
+        assert_eq!(b.kinds_active(), 0);
+    }
+
+    #[tokio::test]
+    async fn first_send_creates_kind_subsequent_sends_update() {
+        // what this catches: regression where the kind's
+        // watch::Sender gets re-created on every send (would drop
+        // existing receivers) OR where subsequent sends are silently
+        // ignored (would leave the receiver pinned to the initial
+        // value).
+        let b = Broadcast::new();
+        b.send(envelope("chat", 1));
+        assert_eq!(b.kinds_active(), 1);
+
+        let mut rx = b.subscribe("chat").expect("attach after first send");
+        // borrow_and_update marks current value as seen so the next
+        // changed() actually awaits the NEXT change.
+        let initial = rx.borrow_and_update().clone();
+        assert_eq!(initial.revision, Some(1));
+
+        b.send(envelope("chat", 2));
+        rx.changed().await.expect("change signal");
+        let next = rx.borrow_and_update().clone();
+        assert_eq!(next.revision, Some(2));
+
+        b.send(envelope("chat", 3));
+        rx.changed().await.expect("change signal");
+        let next = rx.borrow_and_update().clone();
+        assert_eq!(next.revision, Some(3));
+
+        // Still one kind active — sends didn't create new entries.
+        assert_eq!(b.kinds_active(), 1);
+    }
+
+    #[tokio::test]
+    async fn multiple_subscribers_each_see_latest() {
+        // what this catches: regression where multiple Receivers
+        // for the same Sender don't all see new values. The protocol
+        // claim is "every attached subscriber sees the latest" —
+        // a refactor that broke fan-out would silently degrade.
+        let b = Broadcast::new();
+        b.send(envelope("chat", 1));
+
+        let mut a = b.subscribe("chat").unwrap();
+        let mut c = b.subscribe("chat").unwrap();
+
+        // Reset their watermarks so the next .changed() awaits.
+        a.borrow_and_update();
+        c.borrow_and_update();
+
+        b.send(envelope("chat", 2));
+        a.changed().await.unwrap();
+        c.changed().await.unwrap();
+        assert_eq!(a.borrow().revision, Some(2));
+        assert_eq!(c.borrow().revision, Some(2));
+    }
+
+    #[tokio::test]
+    async fn send_with_no_subscribers_is_not_an_error() {
+        // what this catches: regression where the substrate panics
+        // or errors when no session is attached. That would block
+        // the substrate event bus on consumer presence — exactly
+        // the substrate-consumer coupling the watch primitive
+        // exists to prevent.
+        let b = Broadcast::new();
+        b.send(envelope("chat", 1));
+        b.send(envelope("chat", 2)); // no-subscribers state
+        b.send(envelope("chat", 3));
+        // After: a fresh subscriber sees the latest, not history.
+        let rx = b.subscribe("chat").unwrap();
+        assert_eq!(
+            rx.borrow().revision,
+            Some(3),
+            "fresh subscriber sees latest, no history replay"
+        );
+    }
+
+    #[tokio::test]
+    async fn kinds_are_independent_streams() {
+        // what this catches: regression where a send to one kind
+        // wakes another kind's subscribers (cross-talk) OR where
+        // the kinds share a single counter (would couple them in
+        // unexpected ways). Each kind is its own watch::channel.
+        let b = Broadcast::new();
+        b.send(envelope("chat", 1));
+        b.send(envelope("user-list", 1));
+        assert_eq!(b.kinds_active(), 2);
+
+        let mut chat_rx = b.subscribe("chat").unwrap();
+        let mut user_rx = b.subscribe("user-list").unwrap();
+        chat_rx.borrow_and_update();
+        user_rx.borrow_and_update();
+
+        // Send only on chat — user-list receiver MUST NOT wake.
+        b.send(envelope("chat", 2));
+        chat_rx.changed().await.unwrap();
+        assert_eq!(chat_rx.borrow().revision, Some(2));
+        // user_rx.changed() would hang — assert it's NOT ready.
+        // tokio::select with a deadline is the right shape for a
+        // negative test.
+        let did_change = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            user_rx.changed(),
+        )
+        .await;
+        assert!(
+            did_change.is_err(),
+            "user-list receiver must not see chat's send"
+        );
+    }
+
+    #[tokio::test]
+    async fn dropped_receivers_dont_break_subsequent_sends() {
+        // what this catches: regression where the watch::Sender
+        // gets dropped when all its receivers go away, and a
+        // subsequent send for that kind silently fails. The Sender
+        // is stored in the HashMap — it persists across receiver
+        // lifecycles.
+        let b = Broadcast::new();
+        b.send(envelope("chat", 1));
+        let rx = b.subscribe("chat").unwrap();
+        drop(rx);
+
+        // Send again; no receivers but the Sender persists.
+        b.send(envelope("chat", 2));
+
+        // A fresh subscribe attaches to the SAME persistent Sender,
+        // sees the latest revision (2), not stale (1).
+        let rx = b.subscribe("chat").unwrap();
+        assert_eq!(rx.borrow().revision, Some(2));
+    }
+}

--- a/core/continuum-positron/src/broadcast.rs
+++ b/core/continuum-positron/src/broadcast.rs
@@ -19,25 +19,35 @@
 //! sees the new value at its own pace. Slow consumers see the latest;
 //! fast consumers see every distinct revision.
 //!
-//! ## Lazy per-kind init
+//! ## Lazy per-kind init — BOTH sides
 //!
 //! `tokio::sync::watch::channel(initial)` requires an initial value, so
-//! we don't pre-allocate senders for kinds that may never produce
-//! state. Instead the first `send()` for a kind creates that kind's
-//! sender (using the new envelope as the initial value). Subsequent
-//! sends update through the existing sender.
+//! the watched type is `Option<Arc<StateEnvelope>>`, with `None` as the
+//! cold-start placeholder. Lazy-init fires from EITHER side:
 //!
-//! `subscribe(kind)` returns `None` if no envelope has ever been sent
-//! for `kind` — honest answer per `[[no-fallbacks-ever]]`. Callers
-//! pair `subscribe` with the snapshot-then-live flow:
-//! 1. `apply_subscribe` retrieves the current snapshot from
+//! - First `send()` for a kind creates the sender with the new
+//!   envelope wrapped in `Some`.
+//! - First `subscribe()` for a kind that has never been sent creates
+//!   the sender with `None`. The first send AFTER that subscribe
+//!   transitions `None` → `Some(env)` — which IS a `watch::changed()`
+//!   notification, so the subscriber that arrived first wakes up.
+//!
+//! Without symmetric lazy-init (the original sketch only lazy-init'd
+//! on send), a renderer that subscribed BEFORE the substrate ever
+//! produced state for that kind would get `None` from this function,
+//! with no path to ever wake up when state finally arrived — the
+//! cold-start hole the Sentinel verdict on #1603 caught.
+//!
+//! `subscribe(kind)` therefore always returns a `Receiver`. Callers
+//! pair this with the snapshot-then-live flow:
+//! 1. `apply_subscribe(cache, msg)` retrieves the current snapshot from
 //!    [`SubstrateStateCache`] (which itself returns `None` for
-//!    no-state-yet kinds).
-//! 2. `Broadcast::subscribe(kind)` attaches a `watch::Receiver` for
-//!    subsequent updates. If both return `None`, the connection
-//!    silently waits — the first state-store for that kind will both
-//!    populate the cache and (re-creating the sender if needed) emit
-//!    the first watch update.
+//!    no-state-yet kinds — that's correct; no snapshot to send).
+//! 2. `Broadcast::subscribe(kind)` attaches a `watch::Receiver`. The
+//!    initial value may be `None` (no state yet) or `Some(env)` (state
+//!    exists). Session tasks filter `None` (cold-start placeholder is
+//!    not a renderer-bound frame) and forward `Some(env)` as a live
+//!    `ServerMessage::State` frame on every `changed()` tick.
 //!
 //! ## Coordination with [`crate::SubstrateStateCache`]
 //!
@@ -64,14 +74,24 @@ use std::sync::{Arc, Mutex};
 use positron_core::wire::StateEnvelope;
 use tokio::sync::watch;
 
-/// Per-kind live broadcast — `tokio::sync::watch::Sender<Arc<StateEnvelope>>`
-/// per kind, lazy-initialized on first send for that kind.
+/// Per-kind live broadcast —
+/// `tokio::sync::watch::Sender<Option<Arc<StateEnvelope>>>` per kind,
+/// lazy-initialized by EITHER first-send or first-subscribe.
+///
+/// The `Option` wrapper is the cold-start placeholder: a subscriber
+/// that arrives before any state exists gets a `Receiver` whose
+/// initial value is `None`. The first `send` after that flips the
+/// watched value to `Some(env)`, which is a normal
+/// `watch::Receiver::changed()` notification — the early subscriber
+/// wakes up exactly when state finally arrives. Without this,
+/// renderers that subscribe before the first state-store would
+/// silently wait forever (the Sentinel-caught hole on #1603).
 ///
 /// Cheap to share via `Arc`. Internal `Mutex<HashMap>` is held only
 /// briefly during send/subscribe — not across `await`.
 #[derive(Debug, Default)]
 pub struct Broadcast {
-    by_kind: Mutex<HashMap<String, watch::Sender<Arc<StateEnvelope>>>>,
+    by_kind: Mutex<HashMap<String, watch::Sender<Option<Arc<StateEnvelope>>>>>,
 }
 
 impl Broadcast {
@@ -82,59 +102,71 @@ impl Broadcast {
     /// Send `envelope` as the latest state for its kind. The kind is
     /// read from `envelope.kind` — no need to pass it separately.
     ///
-    /// First send for a kind lazy-initializes that kind's
-    /// `watch::Sender` (using `envelope` as the initial value). The
-    /// initial receiver from `watch::channel` is immediately dropped
-    /// — actual subscribers attach via [`Broadcast::subscribe`] and
-    /// always get a fresh `Receiver` keyed off the persisted Sender.
+    /// If a sender already exists (created by a prior `send` OR by an
+    /// early `subscribe` waiting on cold-start), this transitions the
+    /// watched value to `Some(envelope)`. If `subscribe` had set the
+    /// initial value to `None`, that transition fires `changed()` for
+    /// the waiting subscribers. Otherwise it just replaces an older
+    /// `Some(_)`.
     ///
-    /// Subsequent sends for the same kind update the existing watch
-    /// sender. Subscribers see the latest value; slow subscribers
-    /// see fewer-than-N intermediates, which is correct per the
-    /// protocol's snapshot semantics.
+    /// If no sender exists yet, lazy-init with `Some(envelope)` as the
+    /// initial value — same shape as the original slice 2D-1.
+    ///
+    /// Uses `send_replace` (not `send`) so updates persist even when
+    /// no subscribers are currently attached — the substrate's event
+    /// bus does not block on consumer presence.
     pub fn send(&self, envelope: Arc<StateEnvelope>) {
         let kind = envelope.kind.clone();
         let mut by_kind = self.by_kind.lock().expect("Broadcast mutex poisoned");
         match by_kind.get(&kind) {
             Some(sender) => {
-                // `send_replace` always updates the watched value
-                // and notifies any current receivers, regardless of
-                // whether receivers exist. `send` (the other method)
-                // is a no-op when the channel is closed (no live
-                // receivers) — that would silently lose state-no-
-                // subscribers-yet updates, which is precisely the
-                // moment between substrate-start and first-session-
-                // attach we MUST get right per `[[no-fallbacks-ever]]`.
-                // Returns the old value; we drop it.
-                let _ = sender.send_replace(envelope);
+                let _ = sender.send_replace(Some(envelope));
             }
             None => {
-                let (sender, _rx) = watch::channel(envelope);
+                let (sender, _rx) = watch::channel(Some(envelope));
                 by_kind.insert(kind, sender);
             }
         }
     }
 
-    /// Attach a receiver for `kind`'s live updates. Returns `None` if
-    /// no envelope has ever been sent for this kind — honest answer
-    /// per `[[no-fallbacks-ever]]`. Sessions pair this with
-    /// `apply_subscribe` snapshot frames; the typical control flow:
+    /// Attach a receiver for `kind`'s live updates. ALWAYS returns a
+    /// `Receiver` — if no envelope has ever been sent for `kind`,
+    /// lazy-init a sender with initial value `None` and hand back a
+    /// receiver pinned to that None. The first `send` for this kind
+    /// will transition the watched value to `Some(env)` and wake the
+    /// subscriber via `changed()`.
     ///
-    /// 1. Run `apply_subscribe(cache, msg)` — returns snapshot frames
-    ///    if the cache has state for the requested kinds.
-    /// 2. For each kind in the new subscription, call
-    ///    `broadcast.subscribe(kind)`. If `Some`, spawn the live-
-    ///    forwarding task. If `None`, no live stream yet — the next
-    ///    substrate `store()` for that kind will create both the
-    ///    cache entry AND the watch sender, and a future resubscribe
-    ///    catches up via the snapshot path.
-    pub fn subscribe(&self, kind: &str) -> Option<watch::Receiver<Arc<StateEnvelope>>> {
-        let by_kind = self.by_kind.lock().expect("Broadcast mutex poisoned");
-        by_kind.get(kind).map(|s| s.subscribe())
+    /// Session tasks consume the stream as:
+    /// ```ignore
+    /// let mut rx = broadcast.subscribe(kind);
+    /// while rx.changed().await.is_ok() {
+    ///     if let Some(env) = rx.borrow_and_update().clone() {
+    ///         // forward Some(env) as ServerMessage::State
+    ///     }
+    ///     // None is the cold-start placeholder — not a frame.
+    /// }
+    /// ```
+    ///
+    /// The cache-and-broadcast pair stays decoupled: `apply_subscribe`
+    /// reads the cache for snapshot frames (returning `None` if no
+    /// cached state — correct silence per `[[no-fallbacks-ever]]`);
+    /// this method handles the live edge.
+    pub fn subscribe(&self, kind: &str) -> watch::Receiver<Option<Arc<StateEnvelope>>> {
+        let mut by_kind = self.by_kind.lock().expect("Broadcast mutex poisoned");
+        match by_kind.get(kind) {
+            Some(sender) => sender.subscribe(),
+            None => {
+                let (sender, rx) = watch::channel(None);
+                by_kind.insert(kind.to_string(), sender);
+                rx
+            }
+        }
     }
 
-    /// Diagnostic: how many kinds have at least one envelope sent.
-    /// Used by tests; not part of the hot path.
+    /// Diagnostic: how many kinds the broadcast knows about (either
+    /// because state has been sent for them OR because a subscriber
+    /// has lazy-init'd a cold-start placeholder). Used by tests; not
+    /// part of the hot path.
     pub fn kinds_active(&self) -> usize {
         self.by_kind.lock().expect("Broadcast mutex poisoned").len()
     }
@@ -155,16 +187,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn subscribe_before_any_send_returns_none() {
-        // what this catches: regression where the broadcast lazy-
-        // initializes a sender on subscribe. That would let
-        // subscribers attach against an empty stream and wait
-        // forever for an initial value — looks like a bug at the
-        // session-task layer but is actually a broadcast-layer
-        // anti-fallback violation here.
+    async fn subscribe_before_any_send_yields_none_then_wakes_on_first_send() {
+        // what this catches: the cold-start hole the Sentinel verdict
+        // on #1603 surfaced. A renderer that opens its Subscribe BEFORE
+        // the substrate has ever produced state for that kind needs a
+        // path to wake when state finally arrives. Previously subscribe
+        // returned None and the renderer waited forever — looked like
+        // a bug at the session-task layer but was actually a broadcast-
+        // primitive hole. With Option<Arc<StateEnvelope>> as the
+        // watched type and lazy-init from subscribe(), the early
+        // subscriber sees None initially, then changed() fires when
+        // the first send transitions None → Some(env).
         let b = Broadcast::new();
-        assert!(b.subscribe("chat").is_none());
-        assert_eq!(b.kinds_active(), 0);
+        let mut rx = b.subscribe("chat");
+        assert!(
+            rx.borrow_and_update().is_none(),
+            "cold-start placeholder is None"
+        );
+        // Lazy-init from subscribe counts the kind as known.
+        assert_eq!(b.kinds_active(), 1);
+
+        // The first send transitions None → Some(env). The waiting
+        // receiver wakes through normal watch semantics.
+        b.send(envelope("chat", 1));
+        rx.changed().await.expect("first send wakes early subscriber");
+        let first = rx
+            .borrow_and_update()
+            .clone()
+            .expect("first send populates Some(env)");
+        assert_eq!(first.revision, Some(1));
     }
 
     #[tokio::test]
@@ -178,20 +229,29 @@ mod tests {
         b.send(envelope("chat", 1));
         assert_eq!(b.kinds_active(), 1);
 
-        let mut rx = b.subscribe("chat").expect("attach after first send");
+        let mut rx = b.subscribe("chat");
         // borrow_and_update marks current value as seen so the next
         // changed() actually awaits the NEXT change.
-        let initial = rx.borrow_and_update().clone();
+        let initial = rx
+            .borrow_and_update()
+            .clone()
+            .expect("first send populated Some(env)");
         assert_eq!(initial.revision, Some(1));
 
         b.send(envelope("chat", 2));
         rx.changed().await.expect("change signal");
-        let next = rx.borrow_and_update().clone();
+        let next = rx
+            .borrow_and_update()
+            .clone()
+            .expect("Some(env) after send");
         assert_eq!(next.revision, Some(2));
 
         b.send(envelope("chat", 3));
         rx.changed().await.expect("change signal");
-        let next = rx.borrow_and_update().clone();
+        let next = rx
+            .borrow_and_update()
+            .clone()
+            .expect("Some(env) after send");
         assert_eq!(next.revision, Some(3));
 
         // Still one kind active — sends didn't create new entries.
@@ -207,8 +267,8 @@ mod tests {
         let b = Broadcast::new();
         b.send(envelope("chat", 1));
 
-        let mut a = b.subscribe("chat").unwrap();
-        let mut c = b.subscribe("chat").unwrap();
+        let mut a = b.subscribe("chat");
+        let mut c = b.subscribe("chat");
 
         // Reset their watermarks so the next .changed() awaits.
         a.borrow_and_update();
@@ -217,8 +277,8 @@ mod tests {
         b.send(envelope("chat", 2));
         a.changed().await.unwrap();
         c.changed().await.unwrap();
-        assert_eq!(a.borrow().revision, Some(2));
-        assert_eq!(c.borrow().revision, Some(2));
+        assert_eq!(a.borrow().as_ref().unwrap().revision, Some(2));
+        assert_eq!(c.borrow().as_ref().unwrap().revision, Some(2));
     }
 
     #[tokio::test]
@@ -233,9 +293,9 @@ mod tests {
         b.send(envelope("chat", 2)); // no-subscribers state
         b.send(envelope("chat", 3));
         // After: a fresh subscriber sees the latest, not history.
-        let rx = b.subscribe("chat").unwrap();
+        let rx = b.subscribe("chat");
         assert_eq!(
-            rx.borrow().revision,
+            rx.borrow().as_ref().unwrap().revision,
             Some(3),
             "fresh subscriber sees latest, no history replay"
         );
@@ -252,15 +312,15 @@ mod tests {
         b.send(envelope("user-list", 1));
         assert_eq!(b.kinds_active(), 2);
 
-        let mut chat_rx = b.subscribe("chat").unwrap();
-        let mut user_rx = b.subscribe("user-list").unwrap();
+        let mut chat_rx = b.subscribe("chat");
+        let mut user_rx = b.subscribe("user-list");
         chat_rx.borrow_and_update();
         user_rx.borrow_and_update();
 
         // Send only on chat — user-list receiver MUST NOT wake.
         b.send(envelope("chat", 2));
         chat_rx.changed().await.unwrap();
-        assert_eq!(chat_rx.borrow().revision, Some(2));
+        assert_eq!(chat_rx.borrow().as_ref().unwrap().revision, Some(2));
         // user_rx.changed() would hang — assert it's NOT ready.
         // tokio::select with a deadline is the right shape for a
         // negative test.
@@ -284,7 +344,7 @@ mod tests {
         // lifecycles.
         let b = Broadcast::new();
         b.send(envelope("chat", 1));
-        let rx = b.subscribe("chat").unwrap();
+        let rx = b.subscribe("chat");
         drop(rx);
 
         // Send again; no receivers but the Sender persists.
@@ -292,7 +352,43 @@ mod tests {
 
         // A fresh subscribe attaches to the SAME persistent Sender,
         // sees the latest revision (2), not stale (1).
-        let rx = b.subscribe("chat").unwrap();
-        assert_eq!(rx.borrow().revision, Some(2));
+        let rx = b.subscribe("chat");
+        assert_eq!(rx.borrow().as_ref().unwrap().revision, Some(2));
+    }
+
+    #[tokio::test]
+    async fn cold_start_subscribers_for_different_kinds_wake_independently() {
+        // what this catches: regression where lazy-init from subscribe
+        // accidentally coalesces multiple kinds onto one sender, or
+        // where the first send for ANY kind wakes all cold-start
+        // subscribers. Each kind's None → Some transition is its own
+        // event.
+        let b = Broadcast::new();
+        let mut chat_rx = b.subscribe("chat");
+        let mut user_rx = b.subscribe("user-list");
+        assert_eq!(b.kinds_active(), 2);
+        assert!(chat_rx.borrow_and_update().is_none());
+        assert!(user_rx.borrow_and_update().is_none());
+
+        b.send(envelope("chat", 1));
+        chat_rx.changed().await.expect("chat wakes");
+        assert_eq!(
+            chat_rx.borrow().as_ref().unwrap().revision,
+            Some(1),
+            "chat saw its own first send"
+        );
+
+        // user-list cold-start subscriber MUST still be at None — no
+        // user-list send has happened yet.
+        let did_change = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            user_rx.changed(),
+        )
+        .await;
+        assert!(
+            did_change.is_err(),
+            "user-list cold-start subscriber must not wake on chat's send"
+        );
+        assert!(user_rx.borrow().is_none());
     }
 }

--- a/core/continuum-positron/src/cache.rs
+++ b/core/continuum-positron/src/cache.rs
@@ -75,9 +75,19 @@ impl SubstrateStateCache {
     /// bug upstream of the cache — the cache is honest about what it
     /// was told to remember.
     pub fn store(&self, envelope: StateEnvelope) {
+        self.store_arc(Arc::new(envelope));
+    }
+
+    /// Like [`Self::store`] but accepts an `Arc<StateEnvelope>`
+    /// directly. Used by [`crate::Substrate::store`] so the cache
+    /// and broadcast layers share the SAME allocation rather than
+    /// each wrapping their own clone. Per
+    /// `[[shared-decode-per-persona-perspective]]`: one decoded
+    /// envelope, every consumer reads the same bytes.
+    pub fn store_arc(&self, envelope: Arc<StateEnvelope>) {
         let kind = envelope.kind.clone();
         let mut by_kind = self.by_kind.lock().expect("cache mutex poisoned");
-        by_kind.insert(kind, Arc::new(envelope));
+        by_kind.insert(kind, envelope);
     }
 
     /// Read the latest envelope for `kind`. `None` if the substrate

--- a/core/continuum-positron/src/connection.rs
+++ b/core/continuum-positron/src/connection.rs
@@ -135,7 +135,6 @@ mod tests {
     use positron_core::wire::{
         CommandEnvelope, CommandSource, ObserverSpec, StateEnvelope, StateLayer,
     };
-    use serde_json::Value;
     use std::sync::Mutex;
     use uuid::Uuid;
 
@@ -149,7 +148,7 @@ mod tests {
     }
 
     struct ScriptedDispatcher {
-        calls: Mutex<Vec<(String, Value)>>,
+        calls: Mutex<Vec<CommandEnvelope>>,
         outcome: Result<(), String>,
     }
 
@@ -173,8 +172,8 @@ mod tests {
 
     #[async_trait]
     impl CommandDispatch for ScriptedDispatcher {
-        async fn dispatch(&self, command: String, params: Value) -> Result<(), String> {
-            self.calls.lock().unwrap().push((command, params));
+        async fn dispatch(&self, envelope: CommandEnvelope) -> Result<(), String> {
+            self.calls.lock().unwrap().push(envelope);
             self.outcome.clone()
         }
     }

--- a/core/continuum-positron/src/connection.rs
+++ b/core/continuum-positron/src/connection.rs
@@ -1,0 +1,506 @@
+//! `Connection` — substrate-side state for one positron client
+//! session.
+//!
+//! One transport connection (WebSocket, UDS, airc subscription) maps
+//! to one `Connection` value. It owns:
+//!
+//! - The current [`Subscription`] (set by the latest `Subscribe`
+//!   frame; declarative-replace per positron protocol).
+//! - The current observer registrations, keyed by `observer_id` (a
+//!   single connection can host multiple observers; re-`Observe`
+//!   under the same id REPLACES that observer per protocol).
+//!
+//! ## What this slice ships (2D-2)
+//!
+//! Pure synchronous handlers that route a `ClientMessage` through
+//! the existing `apply_subscribe` / `apply_observe` / `apply_command`
+//! functions and update the connection's state accordingly.
+//!
+//! [`Connection::handle`] is the single dispatch point — match on
+//! the variant, delegate to the right handler, return the
+//! `Vec<ServerMessage>` the substrate must emit. Per
+//! `[[no-fallbacks-ever]]`: every variant is handled explicitly; an
+//! unknown variant (forward-compat frame from a newer client) would
+//! be caught at the wire deserialize layer, not silently swallowed
+//! here.
+//!
+//! ## What's deferred to slice 2D-3
+//!
+//! The async session task — a long-running future that reads
+//! `ClientMessage` from the transport's inbound stream, drives
+//! `Connection::handle`, attaches `watch::Receiver`s for the
+//! Subscription's kinds, fans the live envelopes through
+//! `ServerMessage::State` to the transport's outbound sink, and
+//! quantizes per-observer `budget_hz`. The state machine in this
+//! slice is the building block that task composes; making it
+//! testable as a sync state-mutation surface keeps the async loop's
+//! logic narrow (just plumbing).
+
+use std::collections::HashMap;
+
+use positron_core::session::{ClientMessage, ServerMessage};
+
+use crate::dispatch::CommandDispatch;
+use crate::observer::{apply_observe, ObserverRegistration};
+use crate::session::{apply_subscribe, Subscription};
+use crate::substrate::Substrate;
+
+/// One client session's substrate-recorded state. Cheap to construct
+/// fresh; mutated in place as `ClientMessage`s arrive.
+#[derive(Debug, Default)]
+pub struct Connection {
+    /// What this connection's renderer wants. Replaced wholesale on
+    /// every `Subscribe`.
+    pub subscription: Subscription,
+    /// Observers attached to this connection, keyed by
+    /// `observer_id`. Re-`Observe` under the same id REPLACES.
+    pub observers: HashMap<String, ObserverRegistration>,
+}
+
+impl Connection {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Apply a `ClientMessage` against the substrate. Returns the
+    /// `Vec<ServerMessage>` the substrate must emit (snapshots,
+    /// `CommandFailed` on Err). Mutates the connection's
+    /// `subscription` / `observers` state per the variant.
+    ///
+    /// Single dispatch point — the variant match is exhaustive per
+    /// `[[no-fallbacks-ever]]`. Async because `apply_command` is
+    /// async (the dispatcher may be remote).
+    pub async fn handle<D: CommandDispatch>(
+        &mut self,
+        msg: ClientMessage,
+        substrate: &Substrate,
+        dispatcher: &D,
+    ) -> Result<Vec<ServerMessage>, String> {
+        match &msg {
+            ClientMessage::Subscribe { .. } => self.handle_subscribe(msg, substrate),
+            ClientMessage::Observe { .. } => self.handle_observe(msg, substrate),
+            ClientMessage::Command(_) => self.handle_command(msg, dispatcher).await,
+        }
+    }
+
+    /// Handle a `Subscribe` frame. Replaces `self.subscription`
+    /// per the declarative-replace doctrine; returns snapshot
+    /// frames per the snapshot-then-live + exact-equality-skip
+    /// rule.
+    pub fn handle_subscribe(
+        &mut self,
+        msg: ClientMessage,
+        substrate: &Substrate,
+    ) -> Result<Vec<ServerMessage>, String> {
+        let (sub, frames) = apply_subscribe(substrate.cache(), msg)?;
+        self.subscription = sub;
+        Ok(frames)
+    }
+
+    /// Handle an `Observe` frame. Inserts (replaces) the observer's
+    /// registration under its `observer_id`; returns snapshot
+    /// frames per the same resync contract.
+    pub fn handle_observe(
+        &mut self,
+        msg: ClientMessage,
+        substrate: &Substrate,
+    ) -> Result<Vec<ServerMessage>, String> {
+        let (reg, frames) = apply_observe(substrate.cache(), msg)?;
+        // HashMap::insert replaces the prior value if any — exactly
+        // the protocol's declarative-replace semantics for observers.
+        self.observers.insert(reg.observer_id.clone(), reg);
+        Ok(frames)
+    }
+
+    /// Handle a `Command` frame. Returns the (possibly-empty)
+    /// `Vec<ServerMessage>`: empty on success (state change is the
+    /// implicit ack), one `CommandFailed` on Err. Per positron
+    /// protocol §"Delivery scope": the caller (slice 2D-3 async
+    /// session task) is responsible for emitting these frames ONLY
+    /// to this connection.
+    pub async fn handle_command<D: CommandDispatch>(
+        &mut self,
+        msg: ClientMessage,
+        dispatcher: &D,
+    ) -> Result<Vec<ServerMessage>, String> {
+        crate::dispatch::apply_command(dispatcher, msg).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use positron_core::session::KindRevision;
+    use positron_core::wire::{
+        CommandEnvelope, CommandSource, ObserverSpec, StateEnvelope, StateLayer,
+    };
+    use serde_json::Value;
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    fn envelope(kind: &str, revision: u64) -> StateEnvelope {
+        StateEnvelope {
+            kind: kind.to_string(),
+            revision: Some(revision),
+            layer: StateLayer::Session,
+            payload: serde_json::json!({"rev": revision}),
+        }
+    }
+
+    struct ScriptedDispatcher {
+        calls: Mutex<Vec<(String, Value)>>,
+        outcome: Result<(), String>,
+    }
+
+    impl ScriptedDispatcher {
+        fn ok() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                outcome: Ok(()),
+            }
+        }
+        fn err(msg: &str) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                outcome: Err(msg.to_string()),
+            }
+        }
+        fn call_count(&self) -> usize {
+            self.calls.lock().unwrap().len()
+        }
+    }
+
+    #[async_trait]
+    impl CommandDispatch for ScriptedDispatcher {
+        async fn dispatch(&self, command: String, params: Value) -> Result<(), String> {
+            self.calls.lock().unwrap().push((command, params));
+            self.outcome.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn subscribe_updates_state_and_emits_snapshot() {
+        // what this catches: regression where handle_subscribe
+        // forgets to write the new subscription state into self,
+        // OR forgets to emit the snapshot frames. Both halves must
+        // happen.
+        let substrate = Substrate::new();
+        substrate.store(envelope("chat", 1));
+
+        let mut conn = Connection::new();
+        let frames = conn
+            .handle_subscribe(
+                ClientMessage::Subscribe {
+                    kinds: vec!["chat".into()],
+                    layers: vec![StateLayer::Session],
+                    last_seen: vec![],
+                },
+                &substrate,
+            )
+            .unwrap();
+        assert_eq!(frames.len(), 1, "snapshot frame emitted");
+        assert!(conn.subscription.covers("chat", StateLayer::Session));
+    }
+
+    #[tokio::test]
+    async fn resubscribe_replaces_not_merges() {
+        // what this catches: regression where the connection's
+        // subscription accumulates kinds across Subscribes. Per
+        // positron protocol §"Subscribe is declarative (replace,
+        // not merge)" the new set REPLACES the old.
+        let substrate = Substrate::new();
+        substrate.store(envelope("chat", 1));
+        substrate.store(envelope("user-list", 1));
+
+        let mut conn = Connection::new();
+        conn.handle_subscribe(
+            ClientMessage::Subscribe {
+                kinds: vec!["chat".into()],
+                layers: vec![StateLayer::Session],
+                last_seen: vec![],
+            },
+            &substrate,
+        )
+        .unwrap();
+        assert!(conn.subscription.kinds.contains("chat"));
+
+        // Re-subscribe with a NEW set; "chat" should disappear.
+        conn.handle_subscribe(
+            ClientMessage::Subscribe {
+                kinds: vec!["user-list".into()],
+                layers: vec![StateLayer::Session],
+                last_seen: vec![],
+            },
+            &substrate,
+        )
+        .unwrap();
+        assert!(conn.subscription.kinds.contains("user-list"));
+        assert!(
+            !conn.subscription.kinds.contains("chat"),
+            "old subscription must be replaced, not merged"
+        );
+    }
+
+    #[tokio::test]
+    async fn observe_inserts_observer_by_id() {
+        // what this catches: regression where the observers map key
+        // changes (e.g. accidentally keying off kinds instead of
+        // observer_id). Per protocol, re-Observe under the same
+        // observer_id REPLACES that observer; under a different id
+        // adds a parallel one.
+        let substrate = Substrate::new();
+        substrate.store(envelope("chat", 1));
+
+        let mut conn = Connection::new();
+        let frames = conn
+            .handle_observe(
+                ClientMessage::Observe {
+                    spec: ObserverSpec {
+                        observer_id: "maya".into(),
+                        budget_hz: 4,
+                        kinds: vec!["chat".into()],
+                        layers: vec![StateLayer::Session],
+                    },
+                    last_seen: vec![],
+                },
+                &substrate,
+            )
+            .unwrap();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(conn.observers.len(), 1);
+        assert!(conn.observers.contains_key("maya"));
+        assert_eq!(conn.observers["maya"].budget_hz, 4);
+    }
+
+    #[tokio::test]
+    async fn reobserve_under_same_id_replaces_not_adds() {
+        // what this catches: regression where the substrate
+        // accumulates observers under the same id. Per protocol
+        // §"Observers resync identically" + declarative replace —
+        // re-Observe replaces.
+        let substrate = Substrate::new();
+        substrate.store(envelope("chat", 1));
+
+        let mut conn = Connection::new();
+        let spec = |budget_hz: u32, kinds: Vec<String>| ObserverSpec {
+            observer_id: "maya".into(),
+            budget_hz,
+            kinds,
+            layers: vec![StateLayer::Session],
+        };
+
+        conn.handle_observe(
+            ClientMessage::Observe {
+                spec: spec(4, vec!["chat".into()]),
+                last_seen: vec![],
+            },
+            &substrate,
+        )
+        .unwrap();
+        assert_eq!(conn.observers["maya"].budget_hz, 4);
+
+        // Re-observe at a higher budget. State must be REPLACED.
+        conn.handle_observe(
+            ClientMessage::Observe {
+                spec: spec(10, vec!["chat".into()]),
+                last_seen: vec![],
+            },
+            &substrate,
+        )
+        .unwrap();
+        assert_eq!(conn.observers.len(), 1, "still one observer entry");
+        assert_eq!(
+            conn.observers["maya"].budget_hz, 10,
+            "budget updated to latest spec"
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_observer_ids_coexist() {
+        let substrate = Substrate::new();
+        substrate.store(envelope("chat", 1));
+
+        let mut conn = Connection::new();
+        for id in ["maya", "helper", "coder"] {
+            conn.handle_observe(
+                ClientMessage::Observe {
+                    spec: ObserverSpec {
+                        observer_id: id.to_string(),
+                        budget_hz: 4,
+                        kinds: vec!["chat".into()],
+                        layers: vec![StateLayer::Session],
+                    },
+                    last_seen: vec![],
+                },
+                &substrate,
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            conn.observers.len(),
+            3,
+            "distinct observer_ids each get a registration"
+        );
+    }
+
+    #[tokio::test]
+    async fn command_success_emits_no_protocol_frame_in_connection_too() {
+        // what this catches: regression where the connection wrapper
+        // around apply_command adds a success-ack frame, breaking
+        // the unidirectional model at the connection layer even if
+        // apply_command itself is correct.
+        let dispatcher = ScriptedDispatcher::ok();
+        let mut conn = Connection::new();
+        let frames = conn
+            .handle_command(
+                ClientMessage::Command(CommandEnvelope {
+                    kind: "chat".into(),
+                    command: "chat/send".into(),
+                    params: serde_json::json!({"text": "hi"}),
+                    correlation_id: Uuid::nil(),
+                    source: CommandSource::Human,
+                }),
+                &dispatcher,
+            )
+            .await
+            .unwrap();
+        assert!(frames.is_empty());
+        assert_eq!(dispatcher.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn command_failure_emits_command_failed_at_connection_layer() {
+        // what this catches: regression where the connection wrapper
+        // swallows the CommandFailed frame. Per §"loud failures"
+        // every layer must propagate it to the eventual transport
+        // emit.
+        let dispatcher = ScriptedDispatcher::err("nope");
+        let mut conn = Connection::new();
+        let cid = Uuid::from_u128(0xfee1);
+        let frames = conn
+            .handle_command(
+                ClientMessage::Command(CommandEnvelope {
+                    kind: "chat".into(),
+                    command: "chat/send".into(),
+                    params: serde_json::json!({}),
+                    correlation_id: cid,
+                    source: CommandSource::Human,
+                }),
+                &dispatcher,
+            )
+            .await
+            .unwrap();
+        assert_eq!(frames.len(), 1);
+        match &frames[0] {
+            ServerMessage::CommandFailed {
+                correlation_id,
+                error,
+            } => {
+                assert_eq!(*correlation_id, cid);
+                assert_eq!(error, "nope");
+            }
+            other => panic!("expected CommandFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_dispatches_each_variant_correctly() {
+        // what this catches: regression where Connection::handle
+        // routes the wrong variant to the wrong handler (e.g.
+        // Subscribe → handle_command). The single dispatch point
+        // must be exhaustive per [[no-fallbacks-ever]] AND
+        // correctly-routed.
+        let substrate = Substrate::new();
+        substrate.store(envelope("chat", 1));
+        let dispatcher = ScriptedDispatcher::ok();
+        let mut conn = Connection::new();
+
+        // Subscribe → updates subscription + returns snapshot.
+        let frames = conn
+            .handle(
+                ClientMessage::Subscribe {
+                    kinds: vec!["chat".into()],
+                    layers: vec![StateLayer::Session],
+                    last_seen: vec![],
+                },
+                &substrate,
+                &dispatcher,
+            )
+            .await
+            .unwrap();
+        assert_eq!(frames.len(), 1);
+        assert!(conn.subscription.covers("chat", StateLayer::Session));
+
+        // Observe → adds observer + returns snapshot.
+        let frames = conn
+            .handle(
+                ClientMessage::Observe {
+                    spec: ObserverSpec {
+                        observer_id: "maya".into(),
+                        budget_hz: 4,
+                        kinds: vec!["chat".into()],
+                        layers: vec![StateLayer::Session],
+                    },
+                    last_seen: vec![],
+                },
+                &substrate,
+                &dispatcher,
+            )
+            .await
+            .unwrap();
+        assert_eq!(frames.len(), 1);
+        assert!(conn.observers.contains_key("maya"));
+
+        // Command success → empty Vec.
+        let frames = conn
+            .handle(
+                ClientMessage::Command(CommandEnvelope {
+                    kind: "chat".into(),
+                    command: "chat/send".into(),
+                    params: serde_json::json!({}),
+                    correlation_id: Uuid::nil(),
+                    source: CommandSource::Human,
+                }),
+                &substrate,
+                &dispatcher,
+            )
+            .await
+            .unwrap();
+        assert!(frames.is_empty());
+        assert_eq!(dispatcher.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn subscribe_with_matching_last_seen_skips_through_connection_layer() {
+        // what this catches: regression where the connection layer's
+        // handle_subscribe ignores last_seen. The skip rule MUST
+        // propagate from apply_subscribe through to the frames
+        // returned to the transport.
+        let substrate = Substrate::new();
+        substrate.store(envelope("chat", 7));
+
+        let mut conn = Connection::new();
+        let frames = conn
+            .handle_subscribe(
+                ClientMessage::Subscribe {
+                    kinds: vec!["chat".into()],
+                    layers: vec![StateLayer::Session],
+                    last_seen: vec![KindRevision {
+                        kind: "chat".into(),
+                        revision: 7,
+                    }],
+                },
+                &substrate,
+            )
+            .unwrap();
+        assert!(
+            frames.is_empty(),
+            "exact-equality skip rule must propagate through Connection"
+        );
+        assert!(
+            conn.subscription.covers("chat", StateLayer::Session),
+            "subscription state still updates even when snapshot skipped"
+        );
+    }
+}

--- a/core/continuum-positron/src/lib.rs
+++ b/core/continuum-positron/src/lib.rs
@@ -62,6 +62,7 @@
 //! positron's session protocol PR merges. The seam stays narrow on
 //! purpose so the wire layer drops in cleanly.
 
+pub mod broadcast;
 pub mod cache;
 pub mod chat;
 pub mod dispatch;
@@ -71,6 +72,7 @@ pub mod revisions;
 pub mod session;
 pub mod state;
 
+pub use broadcast::Broadcast;
 pub use cache::SubstrateStateCache;
 pub use chat::{ChatMessageView, ChatViewState, PersonaSlotView, SenderKind};
 pub use dispatch::{apply_command, CommandDispatch};

--- a/core/continuum-positron/src/lib.rs
+++ b/core/continuum-positron/src/lib.rs
@@ -65,22 +65,26 @@
 pub mod broadcast;
 pub mod cache;
 pub mod chat;
+pub mod connection;
 pub mod dispatch;
 pub mod kinds;
 pub mod observer;
 pub mod revisions;
 pub mod session;
 pub mod state;
+pub mod substrate;
 
 pub use broadcast::Broadcast;
 pub use cache::SubstrateStateCache;
 pub use chat::{ChatMessageView, ChatViewState, PersonaSlotView, SenderKind};
+pub use connection::Connection;
 pub use dispatch::{apply_command, CommandDispatch};
 pub use kinds::{KnownKind, RevisionKey};
 pub use observer::{apply_observe, ObserverRegistration};
 pub use revisions::Revisions;
 pub use session::{apply_subscribe, Subscription};
 pub use state::StateBuilder;
+pub use substrate::Substrate;
 
 // Re-export positron's wire + session types so consumers get them
 // under one path. The typed payloads in this crate fill

--- a/core/continuum-positron/src/substrate.rs
+++ b/core/continuum-positron/src/substrate.rs
@@ -99,9 +99,15 @@ mod tests {
         assert_eq!(cached.revision, Some(1));
 
         // Broadcast reflects it — a subscriber attaches and sees
-        // the latest value.
-        let rx = substrate.broadcast().subscribe("chat").expect("broadcast populated");
-        assert_eq!(rx.borrow().revision, Some(1));
+        // the latest value. Per the cold-start fix on #1603, subscribe
+        // always returns a Receiver; the value is wrapped in Option to
+        // distinguish "no state yet" (None) from "state exists" (Some).
+        let rx = substrate.broadcast().subscribe("chat");
+        let env = rx
+            .borrow()
+            .clone()
+            .expect("broadcast populated by store");
+        assert_eq!(env.revision, Some(1));
     }
 
     #[tokio::test]
@@ -115,9 +121,10 @@ mod tests {
         }
 
         let cached = substrate.cache().get("chat").unwrap();
-        let rx = substrate.broadcast().subscribe("chat").unwrap();
+        let rx = substrate.broadcast().subscribe("chat");
+        let live = rx.borrow().clone().expect("broadcast populated");
         assert_eq!(cached.revision, Some(5));
-        assert_eq!(rx.borrow().revision, Some(5));
+        assert_eq!(live.revision, Some(5));
     }
 
     #[tokio::test]
@@ -143,9 +150,11 @@ mod tests {
         // And new store flows through the shared parts.
         substrate.store(envelope("chat", 100));
         assert_eq!(cache.get("chat").unwrap().revision, Some(100));
-        assert_eq!(
-            broadcast.subscribe("chat").unwrap().borrow().revision,
-            Some(100)
-        );
+        let live = broadcast
+            .subscribe("chat")
+            .borrow()
+            .clone()
+            .expect("broadcast populated");
+        assert_eq!(live.revision, Some(100));
     }
 }

--- a/core/continuum-positron/src/substrate.rs
+++ b/core/continuum-positron/src/substrate.rs
@@ -1,0 +1,151 @@
+//! `Substrate` — the coordinator that owns the cache + broadcast pair.
+//!
+//! Two seams (cache + broadcast) for the snapshot-then-live protocol
+//! are correct as separate primitives — the cold path (snapshot on
+//! subscribe) and the live path (subsequent updates) have different
+//! concerns. But every substrate event that produces new state MUST
+//! hit BOTH seams or the system drifts:
+//!
+//! - Hit cache but not broadcast → live subscribers never see the
+//!   update.
+//! - Hit broadcast but not cache → next subscribe sees stale
+//!   snapshot, doesn't reconcile to current.
+//!
+//! `Substrate::store(envelope)` does both in one call so substrate
+//! code can't drift. Same allocation is shared between the cache
+//! entry and the broadcast value (via `Arc`), so the
+//! `[[shared-decode-per-persona-perspective]]` doctrine holds at
+//! this seam too — one envelope per substrate event, every consumer
+//! reads the same bytes.
+
+use std::sync::Arc;
+
+use positron_core::wire::StateEnvelope;
+
+use crate::broadcast::Broadcast;
+use crate::cache::SubstrateStateCache;
+
+/// The substrate-side coordinator. Owns the cache (for snapshot
+/// resync) and the broadcast (for live updates) as a pair; produces
+/// state through the single [`Self::store`] entry point so the two
+/// can't drift.
+///
+/// Cheap to share via `Arc`. Both internal primitives are
+/// `Arc`-shared themselves; cloning a `Substrate` only clones the
+/// `Arc`s.
+#[derive(Debug, Clone, Default)]
+pub struct Substrate {
+    cache: Arc<SubstrateStateCache>,
+    broadcast: Arc<Broadcast>,
+}
+
+impl Substrate {
+    /// Construct with fresh, empty cache + broadcast.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct from existing parts. Useful when the substrate's
+    /// boot composes the cache + broadcast separately (e.g. injecting
+    /// a pre-populated cache for tests).
+    pub fn from_parts(cache: Arc<SubstrateStateCache>, broadcast: Arc<Broadcast>) -> Self {
+        Self { cache, broadcast }
+    }
+
+    /// Substrate produces new state. Cache stores the snapshot;
+    /// broadcast fans out to live subscribers. Both via the SAME
+    /// `Arc<StateEnvelope>` allocation per `[[shared-decode-per-
+    /// persona-perspective]]`.
+    pub fn store(&self, envelope: StateEnvelope) {
+        let arc = Arc::new(envelope);
+        self.cache.store_arc(Arc::clone(&arc));
+        self.broadcast.send(arc);
+    }
+
+    pub fn cache(&self) -> &SubstrateStateCache {
+        &self.cache
+    }
+
+    pub fn broadcast(&self) -> &Broadcast {
+        &self.broadcast
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use positron_core::wire::StateLayer;
+
+    fn envelope(kind: &str, revision: u64) -> StateEnvelope {
+        StateEnvelope {
+            kind: kind.to_string(),
+            revision: Some(revision),
+            layer: StateLayer::Session,
+            payload: serde_json::json!({"rev": revision}),
+        }
+    }
+
+    #[tokio::test]
+    async fn store_hits_both_cache_and_broadcast() {
+        // what this catches: regression where `store` only hits one
+        // seam. Either silently loses live updates (broadcast missed)
+        // or silently serves stale snapshots (cache missed).
+        let substrate = Substrate::new();
+
+        substrate.store(envelope("chat", 1));
+
+        // Cache reflects it.
+        let cached = substrate.cache().get("chat").expect("cache populated");
+        assert_eq!(cached.revision, Some(1));
+
+        // Broadcast reflects it — a subscriber attaches and sees
+        // the latest value.
+        let rx = substrate.broadcast().subscribe("chat").expect("broadcast populated");
+        assert_eq!(rx.borrow().revision, Some(1));
+    }
+
+    #[tokio::test]
+    async fn cache_and_broadcast_see_identical_revisions_after_many_stores() {
+        // what this catches: regression where the two seams drift
+        // (cache at rev=3, broadcast at rev=2 or similar). Both must
+        // mirror the substrate's stream of envelopes exactly.
+        let substrate = Substrate::new();
+        for r in 1..=5 {
+            substrate.store(envelope("chat", r));
+        }
+
+        let cached = substrate.cache().get("chat").unwrap();
+        let rx = substrate.broadcast().subscribe("chat").unwrap();
+        assert_eq!(cached.revision, Some(5));
+        assert_eq!(rx.borrow().revision, Some(5));
+    }
+
+    #[tokio::test]
+    async fn from_parts_composes_externally_built_pieces() {
+        // what this catches: a future composition seam that needs to
+        // share a single cache across two substrates (e.g. for a
+        // test fixture that pre-populates state). `from_parts` keeps
+        // the API extensible.
+        let cache = Arc::new(SubstrateStateCache::new());
+        let broadcast = Arc::new(Broadcast::new());
+
+        // Pre-populate via the external cache reference.
+        cache.store(envelope("chat", 99));
+
+        let substrate = Substrate::from_parts(Arc::clone(&cache), Arc::clone(&broadcast));
+
+        // Substrate sees the pre-populated state.
+        assert_eq!(
+            substrate.cache().get("chat").map(|e| e.revision),
+            Some(Some(99))
+        );
+
+        // And new store flows through the shared parts.
+        substrate.store(envelope("chat", 100));
+        assert_eq!(cache.get("chat").unwrap().revision, Some(100));
+        assert_eq!(
+            broadcast.subscribe("chat").unwrap().borrow().revision,
+            Some(100)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Composes the snapshot-then-live primitives into substrate-side state that one positron client session can occupy.

Stacked on **#1603** (slice 2D-1 broadcast primitive). Stack: #1600 → #1601 → #1602 → #1603 → **#1604**.

## What ships

- **`Substrate`** — coordinator wrapping cache + broadcast. `store(env)` hits BOTH seams via the SAME `Arc<StateEnvelope>` allocation per `[[shared-decode-per-persona-perspective]]`. Substrate code can no longer accidentally hit one seam and not the other.

- **`SubstrateStateCache::store_arc`** — added to support the shared-allocation path. Old `cache.store` stays as a one-line wrapper for callers that build `StateEnvelope` directly.

- **`Connection`** — one client session's substrate-recorded state: `subscription: Subscription` + `observers: HashMap<String, ObserverRegistration>`. Single dispatch point: `Connection::handle(msg, substrate, dispatcher) -> Vec<ServerMessage>` matches every variant exhaustively and delegates to the existing `apply_*` primitives.

## Three load-bearing pins at the connection layer

The wrapper layer is exactly the surface where doctrine drift sneaks in. Each pin is one test:

- **`resubscribe_replaces_not_merges`** — the §"Subscribe is declarative (replace, not merge)" doctrine carried up from `Subscription::replace` to the connection's `subscription` field.
- **`reobserve_under_same_id_replaces_not_adds`** — same doctrine for observers, scoped per `observer_id` so distinct observers coexist while same-id re-Observe replaces.
- **`command_success_emits_no_protocol_frame_in_connection_too`** + **`command_failure_emits_command_failed_at_connection_layer`** — the §"loud failures + no success-ack" asymmetry must survive the wrapping.

## What this slice does NOT ship (slice 2D-3)

- Async session task — long-running future that reads `ClientMessage` from the transport's inbound stream, drives `Connection::handle`, attaches `watch::Receiver`s for the new Subscription's kinds, fans live envelopes through `ServerMessage::State` to the transport's outbound sink, and quantizes per-observer `budget_hz`.

The `Connection` state machine is the building block that the async task composes. Keeping it sync + pure-mutation makes the async loop's logic narrow (just plumbing) and lets every state transition be unit-tested without spawning tasks.

## Doctrines

- `[[no-fallbacks-ever]]` — every variant in `Connection::handle` is explicit; no `_ => …` arm.
- `[[shared-decode-per-persona-perspective]]` — `Substrate::store` shares one `Arc` allocation between cache and broadcast.
- `[[strong-typing-across-boundaries]]` — `CommandDispatch` is a trait; subscription / observer state are typed values.

## Test plan

- [x] `cargo test -p continuum-positron` — 54/54 green (49 lib + 5 integration). +12 new tests this slice (3 substrate + 9 connection).
- [x] `cargo check -p continuum-positron` — clean.
- [ ] CI workspace build when stack lands on canary.