### PR TITLE
fix(positron): pin positron-core to v0.1.1 git tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7695,6 +7695,7 @@ dependencies = [
 [[package]]
 name = "positron-core"
 version = "0.1.1"
+source = "git+https://github.com/CambrianTech/positron?tag=v0.1.1#256a4895ccde06726dd17b875e77f601bd52b463"
 dependencies = [
  "serde",
  "serde_json",

--- a/core/continuum-positron/Cargo.toml
+++ b/core/continuum-positron/Cargo.toml
@@ -7,9 +7,15 @@ description = "Continuum's positron substrate — produces typed StateEnvelopes 
 [dependencies]
 # positron-core (the cross-language UI contract — substrate-produces-state /
 # host-consumes-it; AI observers perceive the same ViewState humans see).
-# Path dep until positron tags v0.1; switch to git rev pin on first cut.
-# Operator must have both repos cloned side-by-side under the same parent dir.
-positron-core = { path = "../../../positron/positron-core" }
+# Pinned to the v0.1.1 git tag. The path dep was deliberately temporary per
+# the original comment ("Path dep until positron tags v0.1; switch to git rev
+# pin on first cut"). v0.1.1 is cut. Without the pin, the build silently
+# follows whatever positron checkout lives under the operator's side-by-side
+# parent dir; that ambiguity is what produced #1601's compile break (slice
+# 2A's head compiled only against a stale local checkout — a tagged dep would
+# have surfaced the protocol drift at `cargo check` instead of as a sentinel
+# BLOCK at review time).
+positron-core = { git = "https://github.com/CambrianTech/positron", tag = "v0.1.1" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

Pins `positron-core` to the `v0.1.1` git tag, replacing the temporary path dep that landed with #1600. The path dep was already flagged as temporary in its own comment ("Path dep until positron tags v0.1; switch to git rev pin on first cut") — v0.1.1 is cut, this is the cutover.

## Why this is the priority follow-up

Per Joel's verdict on #1600 + @cambriantech/Fable's ruling tonight: without the pin, the build silently follows whatever positron checkout lives under the operator's side-by-side parent dir. That ambiguity is what produced #1601's compile break — slice 2A's head compiled only against a stale local checkout, and the protocol drift surfaced as a sentinel BLOCK at review time instead of as a `cargo check` error at author time.

With the tag pin, the build follows the upstream v0.1.1 release commit explicitly; any later positron-core change becomes a deliberate dep bump, not a silent drift.

## Test plan

- [x] `cargo check -p continuum-positron` — clean against the remote tag
- [x] `cargo test -p continuum-positron` — 51 unit + 5 integration tests pass against the pinned dep
- [ ] CI workspace build when this lands on canary (the cargo guard is its own follow-up — card 57fab9fa)

## Verdict trail

Joel's verdict on #1600 (comment 4675550778):
> Pin the positron-core dep. The Cargo.toml comment says "switch to git rev pin on first cut" — v0.1.1 is cut.

Fable's priority ruling tonight: do this BEFORE slice 2D-3 (5 min, protects everything just merged from the next positron change).
