### PR TITLE
build(toolchain): pin rust 1.95 — unblock continuum-core unit tests on stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,6 +2643,7 @@ dependencies = [
 name = "continuum-airc-protocol"
 version = "0.1.0"
 dependencies = [
+ "airc-core",
  "serde",
  "serde_json",
  "uuid",
@@ -2684,6 +2685,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tracing",
  "uuid",
 ]

--- a/docker/continuum-core-cuda.Dockerfile
+++ b/docker/continuum-core-cuda.Dockerfile
@@ -21,7 +21,7 @@
 FROM nvidia/cuda:12.8.0-devel-ubuntu22.04 AS chef
 
 # Rust + build-time system libs. Unlike the CPU variant which uses
-# rust:1.89-bookworm (Debian base with a lot of -dev libs pre-installed),
+# rust:1.95-bookworm (Debian base with a lot of -dev libs pre-installed),
 # this CUDA builder image is nvidia/cuda:...ubuntu22.04 — a minimal
 # Ubuntu with just the CUDA toolchain. We need every -dev we rely on.
 #
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libclang-dev clang build-essential git \
     libglib2.0-dev libasound2-dev libva-dev \
     && rm -rf /var/lib/apt/lists/*
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.89
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.95
 ENV PATH=/root/.cargo/bin:$PATH
 RUN cargo install cargo-chef --locked
 WORKDIR /app

--- a/docker/continuum-core-vulkan.Dockerfile
+++ b/docker/continuum-core-vulkan.Dockerfile
@@ -31,7 +31,7 @@
 # Same multi-stage shape as the cuda variant — collapsing planner+builder
 # leaves stub binaries in target/ that cargo treats as "fresh" (mtime newer
 # than the later COPY .), producing a 436KB shell binary. Don't collapse.
-FROM rust:1.89-bookworm AS chef
+FROM rust:1.95-bookworm AS chef
 
 # System deps for compilation.
 #

--- a/docker/continuum-core.Dockerfile
+++ b/docker/continuum-core.Dockerfile
@@ -13,7 +13,7 @@
 # Source changes rebuild in ~2-3 minutes.
 
 # ── Stage 1: Chef (dependency cache tool) ───────────────────
-FROM rust:1.89-bookworm AS chef
+FROM rust:1.95-bookworm AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /app
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,23 @@
+# Project-wide Rust toolchain pin.
+#
+# Why this exists: Cargo.lock requires rtc-mdns 0.20.0-alpha.1, which uses
+# `Ipv4Addr::from_octets` from the `ip_from` library feature (tracking issue
+# #131360). That method only stabilized in a recent stable release; older
+# stable toolchains (e.g. the rust:1.89-bookworm pin that previously lived in
+# docker/continuum-core.Dockerfile) hit E0658 "use of unstable library feature"
+# when compiling rtc-mdns transitively via livekit-webrtc → rtc-* stack.
+#
+# Picking "1.95" rather than "stable" because:
+#   - 1.95.0 is the toolchain the Mac dev environment ships and where
+#     `cargo test -p continuum-core --lib` is known to work end-to-end;
+#   - pinning a concrete number keeps Docker/CI/Joel/BIGMAMA-Windows all on
+#     the same compiler so a future rustup update on one host doesn't
+#     silently shift build behavior for everyone else.
+#
+# When bumping: update docker/continuum-core.Dockerfile,
+# docker/continuum-core-vulkan.Dockerfile, and the rust:<ver> reference in
+# docker/continuum-core-cuda.Dockerfile in the same commit.
+[toolchain]
+channel = "1.95"
+profile = "minimal"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

BIGMAMA's dogfood validation on continuum #1613 surfaced toolchain drift: the three continuum-core Dockerfiles pin `rust:1.89-bookworm`, but `Cargo.lock` requires `rtc-mdns 0.20.0-alpha.1` which uses `Ipv4Addr::from_octets` (tracking issue [#131360](https://github.com/rust-lang/rust/issues/131360)). On 1.89 + 1.90 stable, `cargo build/test -p continuum-core` dies compiling rtc-mdns with `E0658`.

The CPU Dockerfile builds release bins that may resolve features differently, hiding this in CI. Real `cargo test -p continuum-core` on the project pinned toolchain is broken today.

No `rust-toolchain.toml` existed at the repo root, so cargo picks whatever rustc is on `PATH`. Joel Mac (1.95.0 stable) compiles + runs `cargo test -p continuum-core --lib` end-to-end — 8/8 green on `lease_revocation` per the #1613 validation thread.

## Changes

- `rust-toolchain.toml` (new) — pin channel `1.95`, profile `minimal`, components `rustfmt` + `clippy`. Doc comment names the failure shape so a future bump knows what to verify.
- `docker/continuum-core.Dockerfile` — `rust:1.89-bookworm` → `rust:1.95-bookworm`
- `docker/continuum-core-vulkan.Dockerfile` — same bump
- `docker/continuum-core-cuda.Dockerfile` — `--default-toolchain 1.89` → `1.95` and the stale "1.89-bookworm" comment

## Verified

- `cargo check -p continuum-core --lib --features metal,accelerate` on the pinned 1.95 toolchain: clean (60 warnings, 0 errors); rtc-mdns transitive dep compiles fine.
- `cargo test -p continuum-core --lib lease_revocation --features metal,accelerate` on the lease-revocation branch (separately): 8/8 green, 0.00s exec.

## Test plan

- [ ] CI green on Linux Docker build (this is the case the 1.89 pin broke).
- [ ] BIGMAMA self-validates continuum-core unit tests under Docker once this lands.
- [ ] Spot-check `rustup` picks up the pin: `cd continuum && rustup show` reports 1.95.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
