### PR TITLE
refactor(inference): collapse coordinator's revocation ladder onto the single disruption_rank (slice 3)

### DIFF
--- a/core/continuum-core/src/inference/coordinator.rs
+++ b/core/continuum-core/src/inference/coordinator.rs
@@ -621,7 +621,6 @@ impl InferenceCoordinator {
         struct EvictCandidate {
             handle_id: Uuid,
             acquired_at_ms: u64,
-            class: LaneClass,
             rank: u8,
             bytes: u64,
         }
@@ -638,7 +637,6 @@ impl InferenceCoordinator {
                 Some(EvictCandidate {
                     handle_id: lane.handle_id(),
                     acquired_at_ms: lane.lease().acquired_at_ms,
-                    class: lane.class(),
                     rank,
                     bytes: (lane.seed_kv_tokens() as u64).saturating_mul(bytes_per_token),
                 })

--- a/core/continuum-core/src/inference/coordinator.rs
+++ b/core/continuum-core/src/inference/coordinator.rs
@@ -59,6 +59,7 @@ use crate::inference::handle_store::{InferenceHandleStore, OpenSessionRequest};
 use crate::inference::kv_quant::Residency;
 use crate::inference::lane::{Lane, LaneClass};
 use crate::inference::recipe_budget::TaskKind;
+use crate::paging::lease_revocation::disruption_rank;
 use crate::runtime::cell_shapes::HandleRef;
 
 /// Configuration the coordinator needs at construction.
@@ -597,53 +598,60 @@ impl InferenceCoordinator {
     /// the conversation ends. Operator's escape valve: lease
     /// expiry — when a pinned lease expires (lease.expires_at_ms <
     /// now_ms), step 1 collects it like any other expired lease.
+    ///
+    /// The tier ordering above is NOT re-encoded here — it comes from the
+    /// single revocation-ladder definition,
+    /// [`disruption_rank`](crate::paging::lease_revocation::disruption_rank),
+    /// shared with `select_leases_to_revoke`. This method is one
+    /// *selection strategy* over that ladder (oldest-first, ungated,
+    /// lane-aware); the broker-style strategy is another.
     pub fn evict_under_pressure(&self, target_bytes: u64, now_ms: u64) -> EvictionResult {
         // Snapshot lane references so we don't hold DashMap entries
         // while we mutate. We need (handle_id, lease_acquired_at_ms,
-        // class, expired?, bytes_to_free).
+        // class, revocation rank, bytes_to_free).
+        //
+        // `rank` comes from the SINGLE revocation-ladder definition
+        // (`disruption_rank`) — NOT a parallel inline class→tier match.
+        // `disruption_rank` reads `lease.revocation_policy`, which
+        // `open_lane` sets from `LaneClass::revocation_policy()`, so the
+        // ranks are identical to the former inline tier() (expired=0,
+        // Hard=1, Graceful=2) while keeping the ladder defined once. An
+        // active `Pinned` lane returns `None` here and is filtered out
+        // entirely (the substrate contract: pressure never evicts it).
         struct EvictCandidate {
             handle_id: Uuid,
             acquired_at_ms: u64,
             class: LaneClass,
-            expired: bool,
+            rank: u8,
             bytes: u64,
         }
         let bytes_per_token = self.config.bytes_per_token;
         let mut candidates: Vec<EvictCandidate> = self
             .lanes
             .iter()
-            .map(|entry| {
+            .filter_map(|entry| {
                 let lane = entry.value();
-                let expired = lane.is_expired(now_ms);
-                EvictCandidate {
+                // None = active Pinned (Realtime, unexpired) → never a
+                // pressure-eviction candidate. Expired leases of any
+                // policy rank 0 (their holder is gone).
+                let rank = disruption_rank(lane.lease(), now_ms)?;
+                Some(EvictCandidate {
                     handle_id: lane.handle_id(),
                     acquired_at_ms: lane.lease().acquired_at_ms,
                     class: lane.class(),
-                    expired,
+                    rank,
                     bytes: (lane.seed_kv_tokens() as u64).saturating_mul(bytes_per_token),
-                }
+                })
             })
             .collect();
 
-        // Three tiers, each sorted by acquired_at_ms ascending
-        // (oldest first). Pinned lanes are excluded entirely unless
-        // expired (in which case they go in tier 1).
+        // Least-disruptive first (rank ascending: expired → Hard →
+        // Graceful), and within a rank oldest-first by acquisition time —
+        // the coordinator's fairness choice (drain the longest-running
+        // lane of a class before younger ones).
         candidates.sort_by(|a, b| {
-            // Sort key: (tier_rank, acquired_at_ms).
-            // tier_rank: 0 = expired, 1 = Hard, 2 = Graceful, 3 = Pinned (excluded later)
-            fn tier(c: &EvictCandidate) -> u8 {
-                if c.expired {
-                    0
-                } else {
-                    match c.class {
-                        LaneClass::Background | LaneClass::Sentinel => 1,
-                        LaneClass::Interactive => 2,
-                        LaneClass::Realtime => 3,
-                    }
-                }
-            }
-            tier(a)
-                .cmp(&tier(b))
+            a.rank
+                .cmp(&b.rank)
                 .then(a.acquired_at_ms.cmp(&b.acquired_at_ms))
         });
 
@@ -653,16 +661,13 @@ impl InferenceCoordinator {
             if bytes_freed >= target_bytes {
                 break;
             }
-            // Pinned + not expired → skip (substrate contract).
-            if cand.class == LaneClass::Realtime && !cand.expired {
-                continue;
-            }
-            let reason = if cand.expired {
-                EvictionReason::LeaseExpired
-            } else if matches!(cand.class, LaneClass::Background | LaneClass::Sentinel) {
-                EvictionReason::PressureHard
-            } else {
-                EvictionReason::PressureGraceful
+            // Reason derives from the shared rank: 0 = expired lease
+            // reclaim, 1 = Hard (Background/Sentinel) under pressure,
+            // 2 = Graceful (Interactive) under pressure.
+            let reason = match cand.rank {
+                0 => EvictionReason::LeaseExpired,
+                1 => EvictionReason::PressureHard,
+                _ => EvictionReason::PressureGraceful,
             };
 
             // Snapshot the lane's persona + task + lease_id BEFORE

--- a/core/continuum-core/src/paging/lease_revocation.rs
+++ b/core/continuum-core/src/paging/lease_revocation.rs
@@ -41,7 +41,15 @@ use crate::paging::broker::PressureTier;
 /// Expiry is checked before policy so an expired `Pinned` lease is still
 /// rank 0 (its holder is gone; the pin no longer protects anything),
 /// matching [`ThroughputLease::is_reclaimable`].
-fn disruption_rank(lease: &ThroughputLease, now_ms: u64) -> Option<u8> {
+///
+/// This is the **single definition of the revocation ladder** (expired →
+/// Hard → Graceful, never active Pinned). Both selection strategies share
+/// it: `select_leases_to_revoke` (broker-style — largest-first within rank,
+/// `PressureTier`-gated) and `InferenceCoordinator::evict_under_pressure`
+/// (lane-style — oldest-first, ungated, lane-aware side effects). Keep the
+/// ladder defined ONCE here; a consumer that re-encodes class→tier inline
+/// is the duplication this `pub` exists to prevent.
+pub fn disruption_rank(lease: &ThroughputLease, now_ms: u64) -> Option<u8> {
     if lease.is_expired(now_ms) {
         return Some(0);
     }


### PR DESCRIPTION
**Slice 3** — compression. The revocation ladder (expired → Hard → Graceful, never an active Pinned lane) was defined **twice**:
- `paging/lease_revocation::disruption_rank` (slice 1 #1613) — reads `lease.revocation_policy`, consumed by `select_leases_to_revoke`.
- a parallel inline `fn tier(class)` inside `InferenceCoordinator::evict_under_pressure` — mapped `LaneClass`→tier.

Two encodings of one policy → drift risk. This collapses them onto the single definition.

### Change
- `disruption_rank` is now `pub` — **the** shared ladder.
- `evict_under_pressure` builds candidates via `disruption_rank(lane.lease(), now_ms)?` (`None` = active Pinned → filtered out), sorts by `(rank, acquired_at_ms)`, derives `EvictionReason` from rank. Inline `tier()` + the separate Realtime-skip deleted.

### Behavior-preserving (the precondition I verified)
- `open_lane` sets `revocation_policy: class.revocation_policy()` — `Realtime→Pinned`, `Interactive→Graceful`, `Background|Sentinel→Hard` (lane.rs:114).
- `lane.is_expired` delegates to `lease.is_expired` (lane.rs:211).

So `disruption_rank(lease)` yields **identical** ranks to the former inline `tier(class)` (expired=0, Hard=1, Graceful=2, active-Pinned=excluded). The coordinator keeps its own **selection strategy** (oldest-first, ungated, lane-aware events) on top of the shared ladder — distinct from `select_leases_to_revoke`'s broker-style strategy (largest-first, `PressureTier`-gated). **One ladder, two strategies.**

### Validation (rust:1.95, continuum-core `--lib`)
`test result: ok. 46 passed; 0 failed` (full `inference::coordinator` + `lease_revocation` suites) · `CARGO_EXIT=0` · behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)