### PR TITLE
feat(governor): TierConfig + tier_configs_for — first realization slice (priority #3)

### DIFF
--- a/core/continuum-core/src/genome/tier.rs
+++ b/core/continuum-core/src/genome/tier.rs
@@ -120,7 +120,10 @@ impl EvictionPolicy {
 /// the tier triggers eviction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "../../../protocol/typescript/genome/TierCapacity.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/genome/TierCapacity.ts"
+)]
 pub struct TierCapacity {
     /// Bytes currently in use by this tier's backing store.
     #[ts(type = "number")]
@@ -230,6 +233,133 @@ impl std::fmt::Display for TierError {
 }
 
 impl std::error::Error for TierError {}
+
+/// One typed entry in the governor's `Vec<TierConfig>`. Per
+/// GENOME-FOUNDRY-SENTINEL Part 2: the cache hierarchy is a SEQUENCE
+/// of tier roles parameterized by hardware class, NOT a fixed L1..L5
+/// enum. Discrete-GPU hardware emits five entries (Fast/Warm/Bench/
+/// Cold/Frozen). UMA hardware emits four — `Warm` is structurally
+/// omitted because Fast and Warm would share the same physical bytes
+/// and an `Fast→Warm` eviction would be a no-op.
+///
+/// Subsystems address tiers by `role`, never by index. That's what
+/// makes the "L1→L2 eviction on UMA" failure mode structurally
+/// impossible: there is no `Warm` entry in the vec on UMA, so no
+/// caller can name one.
+///
+/// `backing` is intentionally absent at this slice. The realization
+/// ladder is:
+///   1. (THIS SLICE) shape + structural-absence invariant — every
+///      subsystem can address tiers by role, the type system
+///      guarantees UMA-omits-Warm.
+///   2. NEXT SLICE: TierStore handle threading — `backing` becomes
+///      `Arc<dyn TierStore>` populated by the genome subsystem at boot.
+///   3. LATER: policy_file TOML loading writes real `configured_limit`
+///      bytes from the per-hardware-anchor numbers in the doc
+///      (M2 Air: Fast 2 LoRA layers + 2k KV tokens; 5090: Fast 8 + 16k;
+///      etc.). Today's `tier_configs_for` returns `configured_limit = 0`
+///      across the board — the shape is right, the numbers come later.
+///
+/// The compression principle: a TierConfig is the singular substrate
+/// description of "one tier on this hardware." Capacity + eviction
+/// policy + (eventually) backing store live together because they're
+/// the same logical decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/genome/TierConfig.ts"
+)]
+pub struct TierConfig {
+    /// Which named role this entry fills. Address by this, never by
+    /// vec index.
+    pub role: TierRole,
+    /// Current/configured byte capacity. Today's
+    /// `tier_configs_for` returns zeros — TOML loading fills real
+    /// numbers in a follow-up slice. Subsystems should never assume
+    /// `configured_limit > 0` until the governor has loaded a policy.
+    pub capacity: TierCapacity,
+    /// Per-role canonical eviction policy from
+    /// `EvictionPolicy::canonical_for(role)`. A future slice may let
+    /// the policy file override this per-installation; today the
+    /// canonical mapping is the single source.
+    pub eviction: EvictionPolicy,
+}
+
+/// Build the governor's `Vec<TierConfig>` for the given hardware
+/// class. The vec length is structurally hardware-determined:
+///
+/// - **UMA** (`HardwareClass.uma == true`) → 4 entries:
+///   `[Fast, Bench, Cold, Frozen]`. `Warm` is OMITTED because Fast
+///   and Warm would share the same physical bytes — an `Fast→Warm`
+///   eviction would be a no-op.
+/// - **Discrete-GPU** (`uma == false`) → 5 entries:
+///   `[Fast, Warm, Bench, Cold, Frozen]`. Full ladder. `Warm` is the
+///   PCIe-attached host RAM tier the GPU reaches via copy.
+///
+/// Order is invariant: `Fast` is always index 0, `Frozen` always last.
+/// Subsystems that page across tiers walk in role order. The realization
+/// pins this order with `tier_configs_for_uma_has_no_warm` /
+/// `tier_configs_for_discrete_has_warm`.
+///
+/// Today's emission has all `capacity.configured_limit = 0`. The shape
+/// is correct; the numbers are a future slice via policy_file TOML
+/// (per the per-hardware-anchor table in GENOME-FOUNDRY-SENTINEL.md
+/// Part 2 "Hardware Anchors"). A caller that depends on real capacity
+/// values today is using `tier_configs_for` before the policy has
+/// loaded — that's a startup ordering bug to surface at the caller,
+/// not papered over here.
+///
+/// Eviction policy comes from the canonical per-role table —
+/// `EvictionPolicy::canonical_for(role)`. The doc's per-role table:
+/// Fast=LruWithinTurn, Warm=LruAcrossTurns{100}, Bench=LfuPlusRecency,
+/// Cold=DemandAlignedWithRefinedPreference, Frozen=AppendOnlyGcOnSleep.
+pub fn tier_configs_for(hw: &crate::governor::types::HardwareClass) -> Vec<TierConfig> {
+    // UMA test: `HardwareClass` doesn't yet expose `uma: bool`
+    // explicitly — the implicit invariant from `classify_hardware`
+    // (governor/types.rs:372) is `vram_mb == 0` ⇒ UMA, since UMA
+    // targets report zero VRAM by spec (the governor draws inference
+    // budget from `system_ram_mb`). Discrete GPUs always report a
+    // non-zero VRAM. Promoting `uma` to an explicit `HardwareClass`
+    // field is a future ergonomics PR; today this implicit contract
+    // is what the rest of the substrate relies on.
+    let is_uma = hw.vram_mb == 0;
+
+    // The order is invariant — Fast first, Frozen last. Warm sits
+    // between Fast and Bench when present.
+    let roles: &[TierRole] = if is_uma {
+        // UMA: four roles. Warm omitted by design (not "configured to
+        // zero" — structurally absent).
+        &[
+            TierRole::Fast,
+            TierRole::Bench,
+            TierRole::Cold,
+            TierRole::Frozen,
+        ]
+    } else {
+        // Discrete-GPU: full five-role ladder.
+        &[
+            TierRole::Fast,
+            TierRole::Warm,
+            TierRole::Bench,
+            TierRole::Cold,
+            TierRole::Frozen,
+        ]
+    };
+
+    roles
+        .iter()
+        .copied()
+        .map(|role| TierConfig {
+            role,
+            capacity: TierCapacity {
+                current_used: 0,
+                configured_limit: 0,
+            },
+            eviction: EvictionPolicy::canonical_for(role),
+        })
+        .collect()
+}
 
 #[cfg(test)]
 mod tests {
@@ -379,5 +509,165 @@ mod tests {
             "got {json}"
         );
         assert!(json.contains("\"role\":\"warm\""), "got {json}");
+    }
+
+    // ── tier_configs_for: realization-priority #3 first slice ──
+    //
+    // GENOME-FOUNDRY-SENTINEL.md Part 2 Hardware Anchors: UMA → 4
+    // tier roles (no Warm), discrete-GPU → 5 (full ladder). The
+    // structural-absence invariant — "an Fast→Warm eviction on UMA
+    // is structurally impossible because there is no Warm tier" — is
+    // load-bearing. These tests pin it.
+
+    use crate::governor::types::{HardwareClass, PowerSource, TargetSilicon, ThermalClass};
+
+    /// Minimal fixture for UMA hardware. The realization keys on
+    /// `vram_mb == 0` per `classify_hardware`'s implicit contract;
+    /// other fields are populated with sensible defaults so the
+    /// fixture survives a `HardwareClass` shape extension.
+    fn uma_fixture() -> HardwareClass {
+        HardwareClass {
+            silicon: TargetSilicon::AppleM,
+            silicon_model: "M2".to_string(),
+            vram_mb: 0,
+            system_ram_mb: 16 * 1024,
+            power_source: PowerSource::Plugged,
+            thermal_class: ThermalClass::ThinAndLight,
+            battery_pct: Some(100),
+            thermal_headroom_pct: Some(80),
+        }
+    }
+
+    /// Discrete-GPU fixture. `vram_mb > 0` is the implicit signal
+    /// classify_hardware uses to mark a target as non-UMA.
+    fn discrete_fixture() -> HardwareClass {
+        HardwareClass {
+            silicon: TargetSilicon::NvidiaCuda,
+            silicon_model: "RTX 5090".to_string(),
+            vram_mb: 32 * 1024,
+            system_ram_mb: 64 * 1024,
+            power_source: PowerSource::Plugged,
+            thermal_class: ThermalClass::Workstation,
+            battery_pct: None,
+            thermal_headroom_pct: Some(90),
+        }
+    }
+
+    /// THE load-bearing invariant. UMA hardware MUST emit 4 entries
+    /// with no Warm — the doc's "Fast→Warm eviction on UMA is
+    /// structurally impossible" line is the entire point. If this
+    /// regresses, the substrate has lost its hardware-class
+    /// portability and Vision Pro / iOS / M-series MacBooks will
+    /// page through a no-op tier.
+    #[test]
+    fn tier_configs_for_uma_has_no_warm() {
+        let cfgs = tier_configs_for(&uma_fixture());
+        assert_eq!(
+            cfgs.len(),
+            4,
+            "UMA must emit exactly 4 tiers (Fast/Bench/Cold/Frozen), got {cfgs:?}"
+        );
+        assert!(
+            !cfgs.iter().any(|c| c.role == TierRole::Warm),
+            "UMA must structurally omit Warm — got {cfgs:?}"
+        );
+        // Order pin: Fast first, Frozen last.
+        assert_eq!(cfgs.first().map(|c| c.role), Some(TierRole::Fast));
+        assert_eq!(cfgs.last().map(|c| c.role), Some(TierRole::Frozen));
+    }
+
+    /// Discrete-GPU MUST emit all 5 tiers including Warm. The 5090
+    /// + Vulkan + CUDA + AMD ROCm all share this shape — Warm is the
+    /// PCIe-attached host RAM the accelerator reaches via copy.
+    #[test]
+    fn tier_configs_for_discrete_has_warm() {
+        let cfgs = tier_configs_for(&discrete_fixture());
+        assert_eq!(
+            cfgs.len(),
+            5,
+            "discrete-GPU must emit exactly 5 tiers, got {cfgs:?}"
+        );
+        let roles: Vec<TierRole> = cfgs.iter().map(|c| c.role).collect();
+        assert_eq!(
+            roles,
+            vec![
+                TierRole::Fast,
+                TierRole::Warm,
+                TierRole::Bench,
+                TierRole::Cold,
+                TierRole::Frozen,
+            ],
+            "discrete tier order must be Fast/Warm/Bench/Cold/Frozen"
+        );
+    }
+
+    /// Every emitted TierConfig MUST carry the canonical eviction
+    /// policy from `EvictionPolicy::canonical_for(role)`. A future
+    /// PR may let policy_file TOML override the policy per-
+    /// installation, but the substrate's default-from-role mapping
+    /// is the single source for this slice. If it regresses, a
+    /// caller that did `EvictionPolicy::canonical_for(c.role)` to
+    /// double-check would suddenly disagree with the emitted config.
+    #[test]
+    fn tier_configs_for_uses_canonical_eviction_policy_per_role() {
+        for cfgs in [
+            tier_configs_for(&uma_fixture()),
+            tier_configs_for(&discrete_fixture()),
+        ] {
+            for cfg in &cfgs {
+                assert_eq!(
+                    cfg.eviction,
+                    EvictionPolicy::canonical_for(cfg.role),
+                    "tier {:?} must carry canonical eviction policy, got {:?}",
+                    cfg.role,
+                    cfg.eviction
+                );
+            }
+        }
+    }
+
+    /// This slice ships SHAPE, not numbers. The configured_limit MUST
+    /// be 0 across the board — real values come from policy_file
+    /// TOML loading in a follow-up slice. A regression here (a
+    /// well-meaning PR baking in default capacity numbers) would
+    /// silently establish "wrong" defaults that subsystems start
+    /// believing before the policy loader has run.
+    #[test]
+    fn tier_configs_for_emits_zero_capacity_until_policy_file_loads() {
+        for cfgs in [
+            tier_configs_for(&uma_fixture()),
+            tier_configs_for(&discrete_fixture()),
+        ] {
+            for cfg in &cfgs {
+                assert_eq!(
+                    cfg.capacity.current_used, 0,
+                    "shape-only slice: current_used must be 0, got {cfg:?}"
+                );
+                assert_eq!(
+                    cfg.capacity.configured_limit, 0,
+                    "shape-only slice: configured_limit must be 0 \
+                     (policy_file TOML fills this in a follow-up), got {cfg:?}"
+                );
+            }
+        }
+    }
+
+    /// The substrate doctrine: subsystems address tiers by role, not
+    /// by ordinal. This test exercises that — given an arbitrary
+    /// hardware class, find the Fast tier by role lookup. The fact
+    /// that this works the SAME WAY on UMA and discrete (despite
+    /// different vec lengths) is the architectural point.
+    #[test]
+    fn tier_configs_for_addressable_by_role_uniformly_across_hardware() {
+        for hw in [uma_fixture(), discrete_fixture()] {
+            let cfgs = tier_configs_for(&hw);
+            let fast = cfgs.iter().find(|c| c.role == TierRole::Fast);
+            assert!(fast.is_some(), "Fast must exist on every hardware class");
+            let frozen = cfgs.iter().find(|c| c.role == TierRole::Frozen);
+            assert!(
+                frozen.is_some(),
+                "Frozen must exist on every hardware class"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

First realization slice on the SubstrateGovernor lane (realization-priority #3, per BIGMAMA's deconflict). GENOME-FOUNDRY-SENTINEL.md Part 2 prescribes a per-hardware-class `Vec<TierConfig>` — discrete-GPU emits five entries (`Fast`/`Warm`/`Bench`/`Cold`/`Frozen`), UMA emits four (no `Warm`). The Rust code is identical across hardware; only the vec shape varies.

This is the substrate's hardware-portability spine: subsystems address tiers by role, never by ordinal, and the type system makes "Fast→Warm eviction on UMA" structurally impossible because there is no Warm entry on UMA.

## Scope

This slice adds the SHAPE with the structural-absence invariant locked at the type/test level. It deliberately does NOT:

- change `GovernorPolicy` (keeps the legacy `tier_sizes: TierSizes` for now — converting GovernorPolicy is a follow-up slice once consumers can read TierConfig);
- change downstream consumers;
- bake real capacity numbers (`configured_limit = 0` across the board — TOML loading fills this in a follow-up).

Numbers without the shape are premature; the shape without the numbers is correct.

## Changes

`core/continuum-core/src/genome/tier.rs`:

- New `pub struct TierConfig { role, capacity, eviction }` with `ts-rs` export. The `backing` field is deferred to the next slice (when TierStore handles thread through).
- New `pub fn tier_configs_for(hw: &HardwareClass) -> Vec<TierConfig>`. UMA is keyed via `hw.vram_mb == 0` — the existing implicit contract from `classify_hardware`, documented inline so a future PR that promotes `uma: bool` to a HardwareClass field doesn't silently invert this.
- 5 regression tests pinning the load-bearing invariants:
  - `tier_configs_for_uma_has_no_warm` — 4 entries, no Warm, Fast first / Frozen last
  - `tier_configs_for_discrete_has_warm` — 5 entries in canonical order
  - `tier_configs_for_uses_canonical_eviction_policy_per_role` — every emitted config carries `EvictionPolicy::canonical_for(role)`
  - `tier_configs_for_emits_zero_capacity_until_policy_file_loads` — "shape, not numbers" gate
  - `tier_configs_for_addressable_by_role_uniformly_across_hardware` — substrate-doctrine smoke: same role lookup works on both hardware classes despite different vec lengths

## Verified

`cargo test -p continuum-core --lib tier_configs --features metal,accelerate` → 5/5 green on rust 1.95 (Mac). `cargo fmt` clean.

## Compose

Lands the "shape" half of realization-priority #3 (SubstrateGovernor). Next slices:

1. Wire `TierConfig` into `GovernorPolicy` (replace / supplement `tier_sizes: TierSizes`).
2. `policy_file` TOML loader fills real `configured_limit` from the per-hardware anchor numbers in the doc (M2 Air: Fast=2 LoRA layers + 2k KV tokens; 5090: Fast=8+16k; etc.).
3. Thread `TierBackingRef` into TierConfig once TierStore handles exist.

Independent of BIGMAMA's slice-3 (`PressureBroker::relieve()` phase-2 with `revoke_leases_for`) and the coordinator/lease-revocation reconcile lane. No overlap in touched files.

## Test plan

- [ ] CI green on continuum-rust-tests workflow (assumes #1616 has landed; otherwise relies on adversarial review).
- [ ] Follow-up slice can pick up `TierConfig` and wire it into `GovernorPolicy`.
- [ ] A future PR that promotes `uma: bool` to a HardwareClass field updates `tier_configs_for` to use it directly (the inline comment names this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
