### PR TITLE
feat(inference): InferenceCoordinatorModule — stand up the lane coordinator + register its pool with the production broker (slice 4)

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -894,21 +894,31 @@ pub fn start_server(
         // Until opens route through the coordinator (follow-up slice) the
         // pool is armed but idle (usage 0 → Normal tier → broker no-ops),
         // which is the correct inert state for the not-yet-trafficked path.
-        if let Some(m) = runtime
+        let coordinator_pool_registered = runtime
             .registry()
             .module_of_type::<crate::modules::inference_coordinator_module::InferenceCoordinatorModule>()
-        {
-            if let Some(cm) = m
-                .as_any()
-                .downcast_ref::<crate::modules::inference_coordinator_module::InferenceCoordinatorModule>(
-                ) {
-                cm.register_with_broker(&broker);
-                log_info!(
-                    "ipc",
-                    "server",
-                    "InferenceCoordinator lanes registered as ResourcePool ('inference-lanes') with PressureBroker"
-                );
-            }
+            .and_then(|m| {
+                m.as_any()
+                    .downcast_ref::<crate::modules::inference_coordinator_module::InferenceCoordinatorModule>()
+                    .map(|cm| cm.register_with_broker(&broker))
+            })
+            .is_some();
+        if coordinator_pool_registered {
+            log_info!(
+                "ipc",
+                "server",
+                "InferenceCoordinator lanes registered as ResourcePool ('inference-lanes') with PressureBroker"
+            );
+        } else {
+            // Mirrors the parent broker-fetch failure log: a load-bearing
+            // registration that silently no-ops would hide the lane pool
+            // from pressure relief. Unreachable today (the module is
+            // registered unconditionally above) but logged for symmetry.
+            log_error!(
+                "ipc",
+                "server",
+                "InferenceCoordinatorModule not retrievable after registration — lane pool won't appear on the broker"
+            );
         }
     } else {
         log_error!(

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -810,6 +810,16 @@ pub fn start_server(
     runtime.register(Arc::new(
         crate::modules::pressure_broker_module::PressureBrokerModule::new(),
     ));
+    // InferenceCoordinatorModule — stands up the multi-persona-one-model
+    // lane coordinator. Registered before the broker block below so its
+    // CoordinatorResourcePool can be attached to the broker in the same
+    // pass, closing the realistic-lane pressure→eviction loop in
+    // production. Realistic-floor budget today; governor-informed when the
+    // SubstrateGovernor lands. Opens/generates route through the same
+    // coordinator Arc via the handle module in a follow-up slice.
+    runtime.register(Arc::new(
+        crate::modules::inference_coordinator_module::InferenceCoordinatorModule::with_realistic_floor(),
+    ));
     // Register DiskPressureMonitor with the broker as a signal-only
     // ResourcePool — `evict_at_least` returns 0 (the monitor doesn't
     // own files), but the broker emits typed PressureAlert events on
@@ -877,6 +887,29 @@ pub fn start_server(
             "server",
             "Disk + Memory pressure monitors registered as ResourcePools ('disk-root', 'sys-memory') with PressureBroker"
         );
+
+        // Register the inference lane coordinator's pool so the broker's
+        // tick drives lane eviction (expired → Hard → Graceful, never an
+        // active Pinned lane) the same way it drives disk/Docker eviction.
+        // Until opens route through the coordinator (follow-up slice) the
+        // pool is armed but idle (usage 0 → Normal tier → broker no-ops),
+        // which is the correct inert state for the not-yet-trafficked path.
+        if let Some(m) = runtime
+            .registry()
+            .module_of_type::<crate::modules::inference_coordinator_module::InferenceCoordinatorModule>()
+        {
+            if let Some(cm) = m
+                .as_any()
+                .downcast_ref::<crate::modules::inference_coordinator_module::InferenceCoordinatorModule>(
+                ) {
+                cm.register_with_broker(&broker);
+                log_info!(
+                    "ipc",
+                    "server",
+                    "InferenceCoordinator lanes registered as ResourcePool ('inference-lanes') with PressureBroker"
+                );
+            }
+        }
     } else {
         log_error!(
             "ipc",

--- a/core/continuum-core/src/modules/inference_coordinator_module.rs
+++ b/core/continuum-core/src/modules/inference_coordinator_module.rs
@@ -1,0 +1,193 @@
+//! InferenceCoordinatorModule — singleton bootstrap for the
+//! `InferenceCoordinator` (the multi-persona-one-model lane substrate).
+//!
+//! Closes the last-mile wiring gap on the realistic-lane build
+//! (INFERENCE-LANES-REALISTIC.md): the coordinator, its
+//! `evict_under_pressure` walk, and the `CoordinatorResourcePool` bridge
+//! (`ResourcePool::evict_at_least → evict_under_pressure`) were all built
+//! and unit-tested, but nothing stood the coordinator up in production or
+//! registered its pool with the live `PressureBroker`. Without that, the
+//! coordinator existed but no broker tick ever drove its lane eviction.
+//!
+//! This module is that bootstrap, mirroring
+//! `modules/pressure_broker_module.rs` exactly:
+//!   1. Singleton instantiated at server boot, registered on the runtime
+//!      like any other `ServiceModule`.
+//!   2. Owns the `Arc<InferenceCoordinator>` so a single instance is shared
+//!      — the broker drives its pool, and (follow-up) the handle module
+//!      routes `ai/inference/{open,generate,close}` through the SAME Arc.
+//!   3. `register_with_broker()` wraps the coordinator in a
+//!      `CoordinatorResourcePool` and registers it on the broker, so the
+//!      broker's existing 5s tier-monitoring tick fires lane eviction the
+//!      same way it fires VRAM eviction on the Docker tier.
+//!
+//! Why a wrapper module vs a global: every other substrate singleton in
+//! this server (gpu_manager, the PressureBroker itself) lives behind a
+//! `ServiceModule`. Following that pattern keeps the boot sequence in
+//! `ipc/mod.rs` uniform and gives the coordinator the same lifecycle
+//! treatment as everything else. Per Joel (2026-06-14): "It lies in
+//! continuum as a service module yes."
+//!
+//! Deferred to a follow-up slice on this thread:
+//!   - Route `InferenceHandleModule` through `with_coordinator(self.coordinator())`
+//!     so opens actually create lanes (until then the registered pool is
+//!     armed but idle — usage 0, so the broker never needs to act on it).
+//!   - Governor-informed `CoordinatorConfig` (hardware-class → lane budget)
+//!     once the `SubstrateGovernor` emits its `TierConfig`s; today the
+//!     module uses the documented `realistic_floor_default()`.
+
+use crate::inference::coordinator::{CoordinatorConfig, InferenceCoordinator};
+use crate::inference::coordinator_pool::CoordinatorResourcePool;
+use crate::inference::footprint_registry::FootprintRegistry;
+use crate::inference::handle_store::InferenceHandleStore;
+use crate::paging::{PressureBroker, ResourcePool};
+use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
+use async_trait::async_trait;
+use serde_json::Value;
+use std::any::Any;
+use std::sync::Arc;
+
+pub struct InferenceCoordinatorModule {
+    coordinator: Arc<InferenceCoordinator>,
+}
+
+impl InferenceCoordinatorModule {
+    /// Construct from an explicit `CoordinatorConfig` with a fresh
+    /// `FootprintRegistry` + `InferenceHandleStore`. Tests use this to pin
+    /// a deterministic budget; production uses `with_realistic_floor`.
+    pub fn new(config: CoordinatorConfig) -> Self {
+        let footprint = Arc::new(FootprintRegistry::new());
+        let handle_store = Arc::new(InferenceHandleStore::new());
+        let coordinator = Arc::new(InferenceCoordinator::new(footprint, handle_store, config));
+        Self { coordinator }
+    }
+
+    /// Production constructor — the documented "realistic floor" budget
+    /// (UnifiedMemory, 4 concurrent lanes, ~64KB/token FP16 KV). Swap for a
+    /// governor-informed config when the `SubstrateGovernor` lands.
+    pub fn with_realistic_floor() -> Self {
+        Self::new(CoordinatorConfig::realistic_floor_default())
+    }
+
+    /// Borrow the coordinator so the boot sequence can hand the SAME `Arc`
+    /// to the handle module (`with_coordinator`) — keeping one coordinator
+    /// instance behind both the command surface and the pressure pool.
+    pub fn coordinator(&self) -> Arc<InferenceCoordinator> {
+        self.coordinator.clone()
+    }
+
+    /// Register this coordinator's lanes as a `ResourcePool` on `broker` so
+    /// pressure drives lane eviction. Called once at boot from `ipc/mod.rs`
+    /// after both this module and the `PressureBrokerModule` exist. The pool
+    /// reports `usage = open lanes' KV bytes`, `capacity = lane budget`; the
+    /// broker's tick reads `pressure()` and fires `evict_at_least` (→
+    /// `evict_under_pressure`) when the tier crosses its act threshold.
+    pub fn register_with_broker(&self, broker: &PressureBroker) {
+        broker.register(
+            Arc::new(CoordinatorResourcePool::new(self.coordinator.clone()))
+                as Arc<dyn ResourcePool>,
+        );
+    }
+}
+
+#[async_trait]
+impl ServiceModule for InferenceCoordinatorModule {
+    fn config(&self) -> ModuleConfig {
+        ModuleConfig {
+            name: "inference-coordinator",
+            priority: ModulePriority::Normal,
+            // No routed command surface yet — opens/generates/closes flow
+            // through `InferenceHandleModule`, which (follow-up) shares this
+            // module's coordinator Arc. The broker drives eviction on its
+            // own tick, so this module needs no tick of its own.
+            command_prefixes: &[],
+            event_subscriptions: &[],
+            needs_dedicated_thread: false,
+            max_concurrency: 0,
+            tick_interval: None,
+        }
+    }
+
+    async fn initialize(&self, _ctx: &ModuleContext) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn handle_command(&self, command: &str, _params: Value) -> Result<CommandResult, String> {
+        Err(format!(
+            "inference-coordinator: no routed commands (got '{command}'); \
+             open/generate/close route through the inference handle module"
+        ))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cognition::adaptive_throughput::{ResourceClass, TargetSilicon, ThroughputLaneBudget};
+    use crate::paging::{BrokerConfig, PressureBroker};
+
+    fn test_config() -> CoordinatorConfig {
+        CoordinatorConfig {
+            lane_budgets: vec![ThroughputLaneBudget {
+                resource_class: ResourceClass::LocalGeneration,
+                target_silicon: TargetSilicon::Cpu,
+                max_concurrency: 8,
+                max_cost_units: 50_000,
+            }],
+            bytes_per_token: 1,
+            lease_duration_ms: 5_000_000,
+            default_target_silicon: TargetSilicon::Cpu,
+        }
+    }
+
+    /// What this catches: the module's declared config drifting from the
+    /// substrate contract — a routed command_prefix would make the runtime
+    /// route IPC here (there is no command surface yet), and a stray
+    /// tick_interval would spin a tick the broker already owns.
+    #[test]
+    fn config_declares_no_commands_and_no_tick() {
+        let m = InferenceCoordinatorModule::new(test_config());
+        let cfg = m.config();
+        assert_eq!(cfg.name, "inference-coordinator");
+        assert!(cfg.command_prefixes.is_empty());
+        assert!(cfg.tick_interval.is_none());
+    }
+
+    /// What this catches: `coordinator()` handing back a different instance
+    /// than the one the module owns — the whole point is ONE coordinator
+    /// shared between the pressure pool and (follow-up) the handle module.
+    #[test]
+    fn coordinator_getter_returns_the_owned_instance() {
+        let m = InferenceCoordinatorModule::new(test_config());
+        let a = m.coordinator();
+        let b = m.coordinator();
+        assert!(Arc::ptr_eq(&a, &b), "getter must return the same Arc");
+        assert!(
+            Arc::ptr_eq(&a, &m.coordinator),
+            "getter must return the module's owned coordinator"
+        );
+    }
+
+    /// What this catches: `register_with_broker` not actually registering a
+    /// pool (the whole realization — without this the broker never drives
+    /// lane eviction). After registration the broker must see the
+    /// `inference-lanes` tier in its snapshot.
+    #[test]
+    fn register_with_broker_adds_the_coordinator_pool() {
+        let m = InferenceCoordinatorModule::new(test_config());
+        let broker = PressureBroker::new(BrokerConfig::default());
+        assert!(broker.snapshot().pools.is_empty());
+        m.register_with_broker(&broker);
+        let pools = broker.snapshot().pools;
+        assert_eq!(pools.len(), 1);
+        assert_eq!(
+            pools[0].name,
+            crate::inference::coordinator_pool::TIER_NAME,
+            "registered pool must be the inference-lanes tier"
+        );
+    }
+}

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -43,6 +43,7 @@ pub mod grid;
 pub mod health;
 pub mod hippocampus;
 pub mod inference;
+pub mod inference_coordinator_module;
 pub mod live;
 pub mod logger;
 pub mod mcp;

--- a/core/continuum-core/src/runtime/runtime.rs
+++ b/core/continuum-core/src/runtime/runtime.rs
@@ -739,6 +739,7 @@ pub const MODULES: &[(&str, ModuleCategory)] = &[
     ("pressure-broker", ModuleCategory::Core),
     // AI / inference
     ("inference", ModuleCategory::Core),
+    ("inference-coordinator", ModuleCategory::Core),
     ("inference-llm", ModuleCategory::Core),
     ("ai_provider", ModuleCategory::Core),
     ("embedding", ModuleCategory::Core),


### PR DESCRIPTION
**Slice 4** — the last-mile production wiring. The `InferenceCoordinator`, its `evict_under_pressure` walk, and the `CoordinatorResourcePool` bridge (`ResourcePool::evict_at_least → evict_under_pressure`) were all built + unit-tested, but **nothing stood the coordinator up in production or registered its pool with the live `PressureBroker`** — so the broker tick never drove lane eviction. This closes that gap.

Per Joel: *"It lies in continuum as a service module yes."*

### New module — `modules/inference_coordinator_module.rs`
A `ServiceModule` mirroring `pressure_broker_module.rs`:
- owns the single `Arc<InferenceCoordinator>`,
- `coordinator()` getter (so the handle module can later share the same instance),
- `register_with_broker()` wraps it as a `CoordinatorResourcePool` and registers it on the broker.
- No command surface, no own tick — the broker drives eviction on its existing 5s tick.

### Boot wiring
- `ipc/mod.rs`: registered right after `PressureBrokerModule`; its pool registered inside the same broker block as the disk/memory pools.
- `runtime.rs` MODULES manifest: `("inference-coordinator", Core)` so the boot-time A.2.2 cross-check stays honest.
- `modules/mod.rs`: declared.

### Scope (honest)
This **arms** the pressure→eviction loop in production. It stays **inert** (usage 0 → Normal tier → broker no-ops) until opens route through this coordinator — the explicit **next slice**, which intersects the "handle_module isn't prod-registered today, only `InferenceModule` is" question (surfacing before building).

### Validation (rust:1.95, continuum-core `--lib`)
`test result: ok. 3 passed; 0 failed` (config contract, single-instance getter, pool-registration puts `inference-lanes` on the broker) · whole lib compiles (ipc + runtime + module) · `CARGO_EXIT=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)