### PR TITLE
fix(governor): MacIntelMetal variant + correct classify_silicon (task #52)

### DIFF
--- a/core/continuum-core/src/governor/policy_selector.rs
+++ b/core/continuum-core/src/governor/policy_selector.rs
@@ -168,6 +168,11 @@ fn range_contains(token: &str, prefix: &str, value: u64) -> Result<bool, PolicyS
 fn silicon_token(silicon: TargetSilicon) -> &'static str {
     match silicon {
         TargetSilicon::AppleM => "apple-m",
+        // Mac Intel chassis + discrete GPU via Metal driver (task #52).
+        // Tier policy matches the discrete-GPU shape, not UMA — the
+        // policy_file matcher can target this row separately from
+        // apple-m if a Mac Intel deployment needs its own tuning.
+        TargetSilicon::MacIntelMetal => "mac-intel-metal",
         TargetSilicon::NvidiaCuda => "nvidia-cuda",
         TargetSilicon::AmdRocm => "amd-rocm",
         TargetSilicon::IntelVulkan => "intel-vulkan",

--- a/core/continuum-core/src/governor/types.rs
+++ b/core/continuum-core/src/governor/types.rs
@@ -48,6 +48,21 @@ pub enum TargetSilicon {
     /// Apple Silicon (M1/M2/M3/M4/M5 + descendants). UMA — system_ram
     /// and "vram" are the same physical pool.
     AppleM,
+    /// Mac Intel chassis with a discrete GPU (typically AMD Polaris /
+    /// Vega / Navi) exposed through Apple's Metal driver, not CUDA or
+    /// Vulkan. NOT UMA — Intel CPU + discrete VRAM. Examples:
+    /// MacBookPro15,1 with Radeon Pro 555X; iMac (Intel, 2019) with
+    /// Radeon Pro 580X; Mac Pro (2019) with W6800X Duo. The hardware
+    /// reports `has_metal: true` exactly like Apple Silicon does, but
+    /// the tier policy is the discrete-GPU shape (5 tier roles
+    /// including Warm), NOT the UMA-class 4-tier shape. Caller
+    /// distinguishes via the platform architecture string in
+    /// HardwareProfile (`macos-arm64-*` = AppleM, `macos-x86_64-*` =
+    /// MacIntelMetal). Without this variant, classify_silicon falls
+    /// to `AppleM` for any host with `has_metal: true` and the entire
+    /// downstream governor + tier_configs pipeline picks the wrong
+    /// shape (task #52).
+    MacIntelMetal,
     /// NVIDIA CUDA. Discrete VRAM separate from system RAM.
     NvidiaCuda,
     /// AMD ROCm. Discrete VRAM separate from system RAM. Less mature
@@ -395,7 +410,37 @@ pub fn classify_hardware(profile: &HardwareProfile) -> HardwareClass {
 /// build). ROCm detection is left for PR-2 (requires rocm-smi probe).
 fn classify_silicon(profile: &HardwareProfile) -> TargetSilicon {
     if profile.has_metal {
-        TargetSilicon::AppleM
+        // Bug fix for task #52: `has_metal: true` is reported by BOTH
+        // Apple Silicon (UMA) AND Mac Intel hosts with a discrete GPU
+        // exposed through Apple's Metal driver (Joel's MacBookPro15,1 +
+        // Radeon Pro 555X is the canonical example). Pre-fix, both
+        // shipped as `AppleM`, so `classify_hardware` then forced
+        // `vram_mb = 0`, and `tier_configs_for` returned the UMA
+        // 4-tier shape (no Warm) on a host that's actually
+        // discrete-GPU and needs the 5-tier shape including Warm.
+        //
+        // The differentiator is the platform string's architecture
+        // hint. Apple Silicon platforms include `arm64` / `aarch64`
+        // (e.g. `macos-arm64-air`, `macos-arm64-m5pro`). Mac Intel
+        // includes `x86_64` (`macos-x86_64-pro`,
+        // `macos-x86_64-macbookpro15`). The hw_probe upstream sets
+        // these reliably per task #47.
+        //
+        // Default-to-AppleM-when-uncertain is intentional: the
+        // dominant Metal-shipping target IS Apple Silicon today,
+        // and on a future Apple-on-Apple host we'd rather lean UMA
+        // than treat it as discrete. The fallback only fires when
+        // the platform string is silent on architecture — at which
+        // point the upstream hw_probe has a separate bug to surface.
+        let platform_lower = profile.platform.to_lowercase();
+        let is_mac_intel = platform_lower.contains("x86_64")
+            || platform_lower.contains("x86-64")
+            || platform_lower.contains("intel");
+        if is_mac_intel {
+            TargetSilicon::MacIntelMetal
+        } else {
+            TargetSilicon::AppleM
+        }
     } else if profile.has_cuda {
         TargetSilicon::NvidiaCuda
     } else if profile.has_vulkan {
@@ -457,6 +502,25 @@ mod tests {
             total_vram_bytes: 48 * 1024 * 1024 * 1024,
             cpu_cores: 16,
             system_ram_bytes: 64 * 1024 * 1024 * 1024,
+        }
+    }
+
+    /// Mac Intel chassis (MacBookPro15,1 = the canonical task #52
+    /// regression target) with an AMD discrete GPU exposed via Metal.
+    /// The hardware reports `has_metal: true` exactly like Apple
+    /// Silicon, but the platform string carries `x86_64`. Joel's
+    /// actual hardware ships this profile.
+    fn mac_intel_macbookpro15() -> HardwareProfile {
+        HardwareProfile {
+            platform: "macos-x86_64-macbookpro15".into(),
+            has_metal: true,
+            has_cuda: false,
+            has_vulkan: false,
+            // Radeon Pro 555X is the discrete GPU; 4 GiB GDDR5.
+            free_vram_bytes: 3 * 1024 * 1024 * 1024,
+            total_vram_bytes: 4 * 1024 * 1024 * 1024,
+            cpu_cores: 6,
+            system_ram_bytes: 16 * 1024 * 1024 * 1024,
         }
     }
 
@@ -526,6 +590,46 @@ mod tests {
         assert_eq!(
             classify_hardware(&m5_pro_workstation()).silicon,
             TargetSilicon::AppleM
+        );
+    }
+
+    /// Task #52 regression: Mac Intel chassis with `has_metal: true`
+    /// must classify as `MacIntelMetal`, NOT `AppleM`. Pre-fix, the
+    /// `if profile.has_metal { TargetSilicon::AppleM }` branch swallowed
+    /// every metal-capable host into the UMA bucket — including Joel's
+    /// MacBookPro15,1 with Radeon Pro 555X — and forced `vram_mb = 0`,
+    /// then `tier_configs_for` emitted the UMA 4-tier shape on a
+    /// discrete-GPU host. Misclassification cascaded through the
+    /// substrate's governor + paging policy.
+    #[test]
+    fn mac_intel_classifies_as_mac_intel_metal_not_apple_m() {
+        let cls = classify_hardware(&mac_intel_macbookpro15());
+        assert_eq!(
+            cls.silicon,
+            TargetSilicon::MacIntelMetal,
+            "Mac Intel with discrete GPU via Metal must be \
+             MacIntelMetal, NOT AppleM (task #52 regression). \
+             classify_silicon got: {:?}",
+            cls.silicon
+        );
+    }
+
+    /// Same regression cross-checked via the downstream side-effect:
+    /// `classify_hardware` zeros `vram_mb` on AppleM (UMA spec) but
+    /// must preserve real VRAM on MacIntelMetal. The misclassification
+    /// pre-fix manifested HERE — Joel's machine reported `vram_mb = 0`
+    /// despite having 4 GiB of GDDR5 on the Radeon, and the governor's
+    /// inference budget then drew from system_ram instead of VRAM.
+    #[test]
+    fn mac_intel_preserves_real_vram_mb() {
+        let cls = classify_hardware(&mac_intel_macbookpro15());
+        let expected_mb = mac_intel_macbookpro15().total_vram_bytes / (1024 * 1024);
+        assert_eq!(
+            cls.vram_mb, expected_mb,
+            "Mac Intel with discrete GPU must report real VRAM, not 0 \
+             (the AppleM UMA branch must not swallow discrete hosts). \
+             Got: vram_mb={}, expected_mb={}",
+            cls.vram_mb, expected_mb
         );
     }
 

--- a/protocol/typescript/governor/TargetSilicon.ts
+++ b/protocol/typescript/governor/TargetSilicon.ts
@@ -5,4 +5,4 @@
  * typed + named — no silent "guess where we are" per the no_silent_fallback
  * rule the rest of the substrate honors.
  */
-export type TargetSilicon = "apple-m" | "nvidia-cuda" | "amd-rocm" | "intel-vulkan" | "none";
+export type TargetSilicon = "apple-m" | "mac-intel-metal" | "nvidia-cuda" | "amd-rocm" | "intel-vulkan" | "none";


### PR DESCRIPTION
## Summary

Fixes task #52: the governor's `classify_silicon` was misclassifying Mac Intel hosts (Joel's MacBookPro15,1 with Radeon Pro 555X is the canonical example) as `AppleM`. The bug keyed on `has_metal: true` alone, but on Mac Intel `has_metal` is ALSO true — Apple's Metal driver exposes the discrete AMD GPU.

Misclassification cascaded:

```
has_metal=true on Mac Intel
  → classify_silicon → AppleM (WRONG)
  → classify_hardware → vram_mb = 0 (UMA branch)
  → tier_configs_for → 4-tier UMA shape (no Warm)
```

So Joel's host inferred against the wrong governor policy + paging shape, and the 4 GiB of GDDR5 on the Radeon reported as "no VRAM" downstream.

## Changes

1. New `TargetSilicon::MacIntelMetal` variant (`governor/types.rs`). Doc names the canonical hardware + tier policy semantics (discrete-GPU shape, not UMA).
2. `classify_silicon` differentiates via the platform string's architecture hint. `has_metal && platform contains x86_64/intel` → `MacIntelMetal`; `has_metal && (arm64 / default)` → `AppleM`. Per task #47 the `hw_probe` already sets the platform string reliably.
3. Two regression tests in `governor::types::tests`:
   - `mac_intel_classifies_as_mac_intel_metal_not_apple_m` — pins the load-bearing TargetSilicon discrimination.
   - `mac_intel_preserves_real_vram_mb` — pins the downstream side-effect: Joel's machine must report real VRAM, not 0.
4. `policy_selector::silicon_token` extended to emit `"mac-intel-metal"` so policy_file matchers can target this row separately from `apple-m` for per-deployment tuning.

The `vram_mb` zeroing branch in `classify_hardware` is already gated on `AppleM` explicitly, so `MacIntelMetal` naturally falls through to the real-VRAM branch — no wire change needed there.

## Verified

`cargo test -p continuum-core --lib governor::types --features metal,accelerate` → 38/38 green on rust 1.95. The two new regression tests each go red if the pre-fix classifier is reverted.

## TS-rs consumer note

This adds a new variant to `TargetSilicon`. TypeScript consumers using exhaustive switch/match on the enum will need a new branch for `"mac-intel-metal"`. That's intentional — the substrate's wire shape extending should force consumers to acknowledge the new hardware class rather than silently fall back to a wrong default.

## Test plan

- [ ] CI green (the new continuum-rust-tests workflow from #1616 will gate this if it merges first).
- [ ] Joel's MacBookPro15,1 reports `vram_mb: 4096` on next boot (instead of 0).
- [ ] `tier_configs_for` on that host returns the 5-tier discrete-GPU shape (no longer the UMA 4-tier shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
