### PR TITLE
ci(typescript): ts-rs binding drift guard (task #62)

### DIFF
--- a/.github/workflows/ts-rs-binding-drift-guard.yml
+++ b/.github/workflows/ts-rs-binding-drift-guard.yml
@@ -1,0 +1,117 @@
+# ts-rs binding-drift guard.
+#
+# Why this exists: the substrate ships Rust types with `#[derive(TS)]`
+# annotations and a `#[ts(export_to = "../../../protocol/typescript/...")]`
+# attribute. `cargo test` regenerates those .ts files as a side effect
+# of running the per-type `export_bindings_*` tests. If an author adds
+# a new field or variant to a Rust type but forgets to commit the
+# regenerated .ts file, the TypeScript wire shape drifts silently:
+#
+#   - Mac/Linux dev: cargo test regenerates the .ts file locally,
+#     looks fine, ships PR without the .ts in the diff.
+#   - Reviewer: sees only the Rust change, approves.
+#   - Downstream TS consumer at runtime: hits the new variant /
+#     missing field, no compile-time guard fires (the .ts file is
+#     stale).
+#
+# This workflow protects against that. After `cargo test`, it runs
+# `git diff --exit-code` over `protocol/typescript/` (the ts-rs export
+# root). Non-empty diff = the test run regenerated bindings that the
+# PR didn't commit. Fail with a message telling the author what to do.
+#
+# Caught by today's session: a near-miss on continuum #1624 (Mac Intel
+# classify_silicon fix) where TargetSilicon gained a variant but the
+# regenerated `protocol/typescript/governor/TargetSilicon.ts` was not
+# in the initial push. Had to amend. This guard makes that mistake
+# impossible to land.
+name: ts-rs Binding Drift Guard
+
+on:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'core/**'
+      - 'protocol/typescript/**'
+      - '.github/workflows/ts-rs-binding-drift-guard.yml'
+  push:
+    branches: [canary, main]
+
+concurrency:
+  group: ts-rs-drift-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  ts-rs-drift:
+    name: ts-rs binding drift detector
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup show
+          rustc --version
+          cargo --version
+
+      - name: System deps (mirrors continuum-core.Dockerfile builder)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake pkg-config libssl-dev libpq-dev protobuf-compiler \
+            libclang-dev clang build-essential \
+            libglib2.0-dev libasound2-dev libva-dev
+
+      # Reuses the same cargo cache key the continuum-rust-tests
+      # workflow does so the two workflows warm each other's targets.
+      - name: Cache cargo state
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-rust1.95-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-rust1.95-
+
+      # The export_bindings_* tests are the ts-rs side effect: each runs
+      # `TS::export()` on a type, writing the .ts file to its
+      # `#[ts(export_to = ...)]` path. We filter by name pattern so this
+      # workflow doesn't pay the cost of running the full unit-test
+      # suite — that's #1616's job. Same `--skip` shape as #1616 so a
+      # GPU/env-var-required test doesn't fail this run.
+      - name: cargo test (regenerate ts-rs bindings only)
+        run: |
+          cargo test -p continuum-core --lib export_bindings -- \
+            --skip 'gpu::memory_manager::' \
+            --skip 'modules::gpu::' \
+            --skip 'modules::persona_allocator::' \
+            --skip 'persona::allocator::tests::test_allocate'
+
+      # The actual gate. After regenerating, the working tree's
+      # ts-rs export dir MUST match what was committed. Any diff means
+      # the PR author edited a Rust type and forgot to commit the
+      # regenerated .ts. The error message names the fix verbatim so
+      # the author can re-run + re-commit + push without spelunking
+      # CI logs.
+      - name: Verify protocol/typescript/ in sync with Rust source
+        run: |
+          if ! git diff --exit-code protocol/typescript/; then
+            echo "::error::ts-rs binding drift detected. Some Rust types"
+            echo "were modified but their regenerated TypeScript bindings"
+            echo "(in protocol/typescript/) were not committed."
+            echo ""
+            echo "Fix: run cargo test locally to regenerate, then:"
+            echo "  git add protocol/typescript/"
+            echo "  git commit --amend --no-edit"
+            echo "  git push --force-with-lease"
+            echo ""
+            echo "Or: include the regenerated .ts files in a follow-up commit."
+            exit 1
+          fi
+          echo "✓ protocol/typescript/ is in sync with Rust source"


### PR DESCRIPTION
## Summary

Implements task #62: substrate-doctrine CI guard against ts-rs binding drift. The substrate has Rust types annotated with `#[derive(TS)]` and `#[ts(export_to = "../../../protocol/typescript/...")]`. `cargo test` regenerates those .ts files as a side effect. When an author adds a field or variant to a Rust type but forgets to commit the regenerated .ts, the wire shape drifts silently:

- Mac/Linux dev: `cargo test` regenerates locally, looks fine, ships PR without the .ts in the diff.
- Reviewer: sees only the Rust change, approves.
- Downstream TS consumer at runtime: hits the new variant / missing field; no compile-time guard fires.

Today's session had a near-miss on continuum #1624 (Mac Intel `classify_silicon` fix) — `TargetSilicon` gained `MacIntelMetal` but the regenerated `protocol/typescript/governor/TargetSilicon.ts` was not in the initial push. I had to amend. This guard makes that mistake impossible to land.

## Changes

`.github/workflows/ts-rs-binding-drift-guard.yml`:

- Triggers on PRs touching `Cargo.toml/Cargo.lock`, `rust-toolchain.toml`, `core/**`, or `protocol/typescript/**`.
- Picks up Rust 1.95 from `rust-toolchain.toml` (#1614).
- Runs ONLY the `export_bindings_*` tests (cheap — same skip patterns as #1616's CI gate so GPU/env-var tests don't fail this run).
- Then `git diff --exit-code protocol/typescript/`. Non-empty diff means the test run regenerated bindings that the PR did NOT commit. Fail with a verbatim fix-recipe in the error log:

```
ts-rs binding drift detected. Some Rust types were modified but their
regenerated TypeScript bindings (in protocol/typescript/) were not
committed.

Fix: run cargo test locally to regenerate, then:
  git add protocol/typescript/
  git commit --amend --no-edit
  git push --force-with-lease
```

## Composes

- #1614 (toolchain pin)
- #1616 (unit-test CI gate) — same skip patterns
- #1624 (the near-miss this workflow would have caught at CI)

## Test plan

- [ ] CI green on this PR (no Rust changes ⇒ no regeneration ⇒ no drift).
- [ ] Future PR that modifies a `#[derive(TS)]` Rust type without committing the regenerated .ts gets a red gate with the fix recipe.
- [ ] After #1616 lands, both the unit-test gate AND this drift gate run on every PR — substrate hygiene by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
