### PR TITLE
feat(inference): coordinator detects hardware silicon — retire the UnifiedMemory CPU-floor default

### DIFF
--- a/core/continuum-core/src/inference/coordinator.rs
+++ b/core/continuum-core/src/inference/coordinator.rs
@@ -53,7 +53,10 @@ use crate::cognition::adaptive_throughput::{
     ThroughputJob, ThroughputLaneBudget,
 };
 use crate::cognition::throughput_lease::ThroughputLease;
+use crate::governor::classify_hardware;
+use crate::governor::types::TargetSilicon as GovernorSilicon;
 use crate::genome::working_set::PersonaId;
+use crate::inference_capability::hw_probe::probe_hardware_profile;
 use crate::inference::footprint_registry::{FootprintKey, FootprintRegistry, ResourceType};
 use crate::inference::handle_store::{InferenceHandleStore, OpenSessionRequest};
 use crate::inference::kv_quant::Residency;
@@ -81,23 +84,65 @@ pub struct CoordinatorConfig {
 }
 
 impl CoordinatorConfig {
-    /// Sensible default for a CPU-only / unified-memory host. The
-    /// "realistic floor" from the lanes-realistic doc:
-    /// - Local-generation budget for UnifiedMemory @ 4 concurrent lanes,
-    ///   total cost-units ~80K tokens (covers 3× chat + 1× spare).
-    /// - Default ~64 KB / token for FP16 KV.
-    pub fn realistic_floor_default() -> Self {
+    /// The realistic-floor lane budget retargeted to a specific silicon
+    /// class — the canonical config builder. Shape from the lanes-realistic
+    /// doc (4 concurrent lanes, ~80K cost-units, ~64 KB/token FP16 KV); only
+    /// the admission silicon varies. Real per-tier budgets arrive from the
+    /// governor's policy file in a later slice — this fixes the SILICON
+    /// label so the production default isn't anchored on the CPU/UMA floor.
+    pub fn for_silicon(silicon: TargetSilicon) -> Self {
         Self {
             lane_budgets: vec![ThroughputLaneBudget {
                 resource_class: ResourceClass::LocalGeneration,
-                target_silicon: TargetSilicon::UnifiedMemory,
+                target_silicon: silicon,
                 max_concurrency: 4,
                 max_cost_units: 80_000,
             }],
             bytes_per_token: 64 * 1024,
             lease_duration_ms: 30 * 60 * 1000, // 30 minutes
-            default_target_silicon: TargetSilicon::UnifiedMemory,
+            default_target_silicon: silicon,
         }
+    }
+
+    /// The "realistic floor" — UnifiedMemory budget. Kept for tests and for
+    /// constrained hosts that explicitly want the floor; NOT the production
+    /// default (see [`detected`](Self::detected)).
+    pub fn realistic_floor_default() -> Self {
+        Self::for_silicon(TargetSilicon::UnifiedMemory)
+    }
+
+    /// Hardware-detected config: probe the machine, classify its silicon,
+    /// and build a [`for_silicon`](Self::for_silicon) budget for it. On an
+    /// RTX 5090 this yields a `Gpu`-targeted coordinator; on Apple Silicon,
+    /// `UnifiedMemory`; on a GPU-less host, `Cpu`. This RETIRES the hardcoded
+    /// `UnifiedMemory` default — GPU-or-bust means the production default
+    /// follows the hardware, not a Mac/CPU floor.
+    ///
+    /// One-shot startup probe (a few file reads + per-backend FFI, per
+    /// `probe_hardware_profile`) — call once at boot, reuse the config.
+    pub fn detected() -> Self {
+        let class = classify_hardware(&probe_hardware_profile());
+        Self::for_silicon(coordinator_silicon_for(class.silicon))
+    }
+}
+
+/// Map the governor's hardware-detected [`GovernorSilicon`] to the
+/// coordinator's [`TargetSilicon`] admission class — the seam between the
+/// SubstrateGovernor's hardware classification (`classify_hardware`) and the
+/// lane scheduler.
+///
+/// `AppleM` → `UnifiedMemory` (Apple-silicon shared accelerator memory);
+/// every discrete-GPU class (`NvidiaCuda` / `AmdRocm` / `IntelVulkan`) →
+/// `Gpu`; `None` (no accelerator detected) → `Cpu`. `Cpu` is the HONEST
+/// classification, not a silent floor — a GPU-or-bust caller inspects the
+/// result and refuses rather than quietly serving CPU.
+pub fn coordinator_silicon_for(detected: GovernorSilicon) -> TargetSilicon {
+    match detected {
+        GovernorSilicon::AppleM => TargetSilicon::UnifiedMemory,
+        GovernorSilicon::NvidiaCuda
+        | GovernorSilicon::AmdRocm
+        | GovernorSilicon::IntelVulkan => TargetSilicon::Gpu,
+        GovernorSilicon::None => TargetSilicon::Cpu,
     }
 }
 
@@ -850,6 +895,63 @@ mod tests {
 
     fn persona(id: u128) -> PersonaId {
         PersonaId::new(Uuid::from_u128(id))
+    }
+
+    /// what this catches: the governor→coordinator silicon translation. A
+    /// discrete GPU (NvidiaCuda/AmdRocm/IntelVulkan) MUST map to `Gpu` (not
+    /// the UnifiedMemory floor) — that's the GPU-or-bust fix. AppleM →
+    /// UnifiedMemory; `None` → `Cpu` (honest, not a silent GPU pretense).
+    #[test]
+    fn governor_silicon_maps_discrete_gpu_to_gpu_not_floor() {
+        assert_eq!(
+            coordinator_silicon_for(GovernorSilicon::NvidiaCuda),
+            TargetSilicon::Gpu
+        );
+        assert_eq!(
+            coordinator_silicon_for(GovernorSilicon::AmdRocm),
+            TargetSilicon::Gpu
+        );
+        assert_eq!(
+            coordinator_silicon_for(GovernorSilicon::IntelVulkan),
+            TargetSilicon::Gpu
+        );
+        assert_eq!(
+            coordinator_silicon_for(GovernorSilicon::AppleM),
+            TargetSilicon::UnifiedMemory
+        );
+        assert_eq!(
+            coordinator_silicon_for(GovernorSilicon::None),
+            TargetSilicon::Cpu
+        );
+    }
+
+    /// what this catches: `for_silicon` sets BOTH the lane-budget silicon AND
+    /// the default to the SAME class — a mismatch would deny admission (the
+    /// planner looks up the budget by the lease's target_silicon). Pins that
+    /// a Gpu config targets Gpu end-to-end, not a stray UnifiedMemory.
+    #[test]
+    fn for_silicon_targets_one_silicon_end_to_end() {
+        let cfg = CoordinatorConfig::for_silicon(TargetSilicon::Gpu);
+        assert_eq!(cfg.default_target_silicon, TargetSilicon::Gpu);
+        assert_eq!(cfg.lane_budgets.len(), 1);
+        assert_eq!(cfg.lane_budgets[0].target_silicon, TargetSilicon::Gpu);
+        // realistic_floor_default is now just for_silicon(UnifiedMemory).
+        let floor = CoordinatorConfig::realistic_floor_default();
+        assert_eq!(floor.default_target_silicon, TargetSilicon::UnifiedMemory);
+        assert_eq!(floor.lane_budgets[0].target_silicon, TargetSilicon::UnifiedMemory);
+    }
+
+    /// what this catches: `detected()` is self-consistent — whatever silicon
+    /// the probe yields on the test host, the budget's silicon and the
+    /// default match it (no split that would deny admission). Environment-
+    /// dependent on the value, but the invariant holds on any machine.
+    #[test]
+    fn detected_config_is_self_consistent() {
+        let cfg = CoordinatorConfig::detected();
+        assert_eq!(
+            cfg.default_target_silicon, cfg.lane_budgets[0].target_silicon,
+            "detected config must target one silicon end-to-end"
+        );
     }
 
     fn small_budget_config() -> CoordinatorConfig {

--- a/core/continuum-core/src/inference/coordinator.rs
+++ b/core/continuum-core/src/inference/coordinator.rs
@@ -941,16 +941,16 @@ mod tests {
         assert_eq!(floor.lane_budgets[0].target_silicon, TargetSilicon::UnifiedMemory);
     }
 
-    /// what this catches: `detected()` is self-consistent — whatever silicon
-    /// the probe yields on the test host, the budget's silicon and the
-    /// default match it (no split that would deny admission). Environment-
-    /// dependent on the value, but the invariant holds on any machine.
+    /// what this catches: `detected()` runs to completion without panicking
+    /// on the test host (the probe→classify→translate chain), and the result
+    /// it produces is self-consistent. The end-to-end consistency invariant
+    /// itself is owned by `for_silicon_targets_one_silicon_end_to_end`; this
+    /// is the smoke test that the real hardware-probe path doesn't blow up.
     #[test]
-    fn detected_config_is_self_consistent() {
+    fn detected_config_runs_without_panicking() {
         let cfg = CoordinatorConfig::detected();
         assert_eq!(
-            cfg.default_target_silicon, cfg.lane_budgets[0].target_silicon,
-            "detected config must target one silicon end-to-end"
+            cfg.default_target_silicon, cfg.lane_budgets[0].target_silicon
         );
     }
 

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -814,11 +814,13 @@ pub fn start_server(
     // lane coordinator. Registered before the broker block below so its
     // CoordinatorResourcePool can be attached to the broker in the same
     // pass, closing the realistic-lane pressure→eviction loop in
-    // production. Realistic-floor budget today; governor-informed when the
-    // SubstrateGovernor lands. Opens/generates route through the same
-    // coordinator Arc via the handle module in a follow-up slice.
+    // production. HARDWARE-DETECTED silicon (probes the machine: Gpu on a
+    // discrete GPU, UnifiedMemory on Apple Silicon, Cpu on a GPU-less host)
+    // — no hardcoded CPU/UMA floor. Per-tier budgets governor-informed in a
+    // later slice. Opens route through the same coordinator Arc via the
+    // handle module.
     runtime.register(Arc::new(
-        crate::modules::inference_coordinator_module::InferenceCoordinatorModule::with_realistic_floor(),
+        crate::modules::inference_coordinator_module::InferenceCoordinatorModule::with_detected_hardware(),
     ));
     // Register DiskPressureMonitor with the broker as a signal-only
     // ResourcePool — `evict_at_least` returns 0 (the monitor doesn't

--- a/core/continuum-core/src/modules/inference_coordinator_module.rs
+++ b/core/continuum-core/src/modules/inference_coordinator_module.rs
@@ -54,7 +54,7 @@ pub struct InferenceCoordinatorModule {
 impl InferenceCoordinatorModule {
     /// Construct from an explicit `CoordinatorConfig` with a fresh
     /// `FootprintRegistry` + `InferenceHandleStore`. Tests use this to pin
-    /// a deterministic budget; production uses `with_realistic_floor`.
+    /// a deterministic budget; production uses `with_detected_hardware`.
     pub fn new(config: CoordinatorConfig) -> Self {
         let footprint = Arc::new(FootprintRegistry::new());
         let handle_store = Arc::new(InferenceHandleStore::new());
@@ -62,9 +62,20 @@ impl InferenceCoordinatorModule {
         Self { coordinator }
     }
 
-    /// Production constructor — the documented "realistic floor" budget
-    /// (UnifiedMemory, 4 concurrent lanes, ~64KB/token FP16 KV). Swap for a
-    /// governor-informed config when the `SubstrateGovernor` lands.
+    /// Production constructor — **hardware-detected** silicon. Probes the
+    /// machine (`CoordinatorConfig::detected`), so the lanes target the
+    /// actual accelerator: `Gpu` on an RTX 5090, `UnifiedMemory` on Apple
+    /// Silicon, `Cpu` on a GPU-less host. This RETIRES the old hardcoded
+    /// `UnifiedMemory` floor default (GPU-or-bust — the default follows the
+    /// hardware, not a Mac/CPU floor). Governor policy-file budgets refine
+    /// the per-tier numbers in a later slice.
+    pub fn with_detected_hardware() -> Self {
+        Self::new(CoordinatorConfig::detected())
+    }
+
+    /// The "realistic floor" (UnifiedMemory) — for tests and explicitly
+    /// constrained hosts. NOT the production default; see
+    /// [`with_detected_hardware`](Self::with_detected_hardware).
     pub fn with_realistic_floor() -> Self {
         Self::new(CoordinatorConfig::realistic_floor_default())
     }

--- a/core/continuum-core/src/modules/inference_coordinator_module.rs
+++ b/core/continuum-core/src/modules/inference_coordinator_module.rs
@@ -32,9 +32,11 @@
 //!   - Route `InferenceHandleModule` through `with_coordinator(self.coordinator())`
 //!     so opens actually create lanes (until then the registered pool is
 //!     armed but idle — usage 0, so the broker never needs to act on it).
-//!   - Governor-informed `CoordinatorConfig` (hardware-class → lane budget)
-//!     once the `SubstrateGovernor` emits its `TierConfig`s; today the
-//!     module uses the documented `realistic_floor_default()`.
+//!   - Per-tier lane BUDGET numbers from the governor's policy file once it
+//!     emits its `TierConfig`s. The module already hardware-detects the
+//!     SILICON class (`CoordinatorConfig::detected()` → Gpu on a discrete
+//!     GPU, UnifiedMemory on Apple Silicon, Cpu on a GPU-less host); only
+//!     the per-tier capacity numbers remain governor-deferred.
 
 use crate::inference::coordinator::{CoordinatorConfig, InferenceCoordinator};
 use crate::inference::coordinator_pool::CoordinatorResourcePool;
@@ -71,13 +73,6 @@ impl InferenceCoordinatorModule {
     /// the per-tier numbers in a later slice.
     pub fn with_detected_hardware() -> Self {
         Self::new(CoordinatorConfig::detected())
-    }
-
-    /// The "realistic floor" (UnifiedMemory) — for tests and explicitly
-    /// constrained hosts. NOT the production default; see
-    /// [`with_detected_hardware`](Self::with_detected_hardware).
-    pub fn with_realistic_floor() -> Self {
-        Self::new(CoordinatorConfig::realistic_floor_default())
     }
 
     /// Borrow the coordinator so the boot sequence can hand the SAME `Arc`


### PR DESCRIPTION
Retires the `TargetSilicon::UnifiedMemory` production default Joel flagged on the InferenceCoordinatorModule (#1619). Wires the coordinator to the governor's **existing** hardware detection (Mac's hw_probe + classify_hardware, already on canary) so the prod default **follows the hardware**, not a hardcoded CPU/Mac floor.

- `coordinator_silicon_for(GovernorSilicon) -> TargetSilicon` — the governor→scheduler seam (AppleM→UnifiedMemory, NvidiaCuda/AmdRocm/IntelVulkan→Gpu, None→Cpu). This is the bridge Mac's #1618 review identified as net-new code I own (the two TargetSilicon enums don't share variants).
- `CoordinatorConfig::for_silicon` / `detected()`; `realistic_floor_default` now delegates (de-dup). `InferenceCoordinatorModule::with_detected_hardware()` + ipc boot uses it.
- **On the RTX 5090 → `Gpu`**; Apple Silicon → `UnifiedMemory`; GPU-less → `Cpu`.

One-shot startup probe. Per-tier budgets stay floor numbers until the governor policy-file slice; this fixes the silicon label (Joel's flag). 6 tests pass, CARGO_EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)