### PR TITLE
fix(setup): fresh-machine hardening — install airc + correct Docker resource/AI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,12 @@ One command -- bootstraps WSL2 + Docker Desktop via winget if missing, auto-togg
 <details>
 <summary>Development (from source)</summary>
 
-Requires Node.js 20+ and Rust nightly. Same Docker Desktop AI toggles apply — `npm start` uses the same DMR for inference; the difference is `continuum-core` runs natively from `cargo` instead of from the published image.
+Requires Node.js 20+. `npm run setup:rust` provisions the rest of the native build chain — Rust nightly, **cmake**, and the **vendored git submodules** (llama.cpp/whisper.cpp) that `continuum-core` compiles. Same Docker Desktop AI toggles apply — `npm start` uses the same DMR for inference; the difference is `continuum-core` runs natively from `cargo` instead of from the published image.
 
 ```bash
 cd continuum/src
 npm install
+npm run setup:rust        # Rust nightly + cmake + vendored submodules (native build prereqs)
 npm run setup:git-hooks   # optional, for commit/pre-push validation
 npm start
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -209,6 +209,14 @@ for key in ('EnableDockerAI', 'EnableInference', 'EnableInferenceGPUVariant', 'E
     if cfg.get(key) is not True:
         cfg[key] = True
         changed = True
+# Resource Saver pauses the Docker VM when idle (default ON, 5min) — fatal
+# for a persistent grid/inference node: DMR + personas would sleep. Disable
+# it (real key is PascalCase UseResourceSaver), unless the user opts to keep
+# it via CONTINUUM_DOCKER_KEEP_RESOURCE_SAVER=1. Non-clobbering: if it's
+# already False, no change.
+if os.environ.get('CONTINUUM_DOCKER_KEEP_RESOURCE_SAVER') != '1' and cfg.get('UseResourceSaver') is not False:
+    cfg['UseResourceSaver'] = False
+    changed = True
 if changed:
     shutil.copy2(path, path + '.continuum-bak')
     with open(path, 'w') as f:
@@ -220,7 +228,7 @@ else:
   )
 
   if [ "$AI_SETTINGS_STATUS" = "changed" ]; then
-    echo "   Docker Desktop AI settings enabled (GPU-backed inference + host-side TCP)"
+    echo "   Docker Desktop tuned (inference on; Resource Saver off so the grid node stays awake)"
     echo "   Restarting Docker Desktop so the toggles apply ..."
     docker desktop restart >/dev/null 2>&1 || true
     for _ in $(seq 1 30); do

--- a/setup.sh
+++ b/setup.sh
@@ -23,6 +23,31 @@ else
   PLATFORM="linux"
 fi
 
+# ── Ensure airc (mesh backbone) ───────────────────
+# Continuum rides airc as its event bus, identity mesh, and cross-grid
+# transport. A fresh user must get airc WITHOUT a separate manual step.
+# Delegate to airc's OWN installer (single source of truth — never re-implement
+# airc's prereq/auth logic here). Download-then-run (not `curl | bash`) keeps
+# stdin attached to the terminal, so airc's interactive steps (Homebrew, gh
+# auth login) still work when driven from setup.sh. Override the branch with
+# AIRC_CHANNEL (defaults to main, the released line).
+if ! command -v airc &>/dev/null; then
+  echo "⏳ airc not found — installing the mesh backbone (delegating to airc's installer)..."
+  AIRC_INSTALLER="$(mktemp)"
+  if curl -fsSL "https://raw.githubusercontent.com/CambrianTech/airc/${AIRC_CHANNEL:-main}/install.sh" -o "$AIRC_INSTALLER" \
+     && bash "$AIRC_INSTALLER"; then
+    rm -f "$AIRC_INSTALLER"
+    echo "✅ airc installed"
+  else
+    rm -f "$AIRC_INSTALLER"
+    echo "❌ airc install failed — continuum needs airc as its backbone."
+    echo "   See https://github.com/CambrianTech/airc and re-run setup.sh."
+    exit 1
+  fi
+else
+  echo "✅ airc found ($(command -v airc))"
+fi
+
 # ── Check Docker ──────────────────────────────────
 if ! command -v docker &>/dev/null; then
   echo "❌ Docker not found."

--- a/setup.sh
+++ b/setup.sh
@@ -82,23 +82,29 @@ DOCKER_MEM=$(docker info --format '{{.MemTotal}}' 2>/dev/null || echo "0")
 DOCKER_MEM_GB=$((DOCKER_MEM / 1073741824))
 MIN_MEM_GB=8
 
-if [ "$DOCKER_MEM_GB" -lt "$MIN_MEM_GB" ] && [ "$DOCKER_MEM_GB" -gt 0 ]; then
-  echo ""
-  echo "⚠️  Docker VM has ${DOCKER_MEM_GB}GB RAM (minimum ${MIN_MEM_GB}GB needed)."
-  echo ""
+# Target = half system RAM (min 8GB), CPUs = half cores (min 2). Computed
+# BEFORE the gate so we can compare against it. Override with
+# CONTINUUM_DOCKER_MEM_GB / CONTINUUM_DOCKER_CPUS — scripts set sane
+# defaults; the user can still change them in Docker Desktop or via env.
+if [[ "$PLATFORM" == "mac" ]]; then
+  SYS_MEM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%d", $1/1073741824}')
+  SYS_CPUS=$(sysctl -n hw.ncpu 2>/dev/null || echo "4")
+else
+  SYS_MEM_GB=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{printf "%d", $2/1048576}')
+  SYS_CPUS=$(nproc 2>/dev/null || echo "4")
+fi
+TARGET_MEM=${CONTINUUM_DOCKER_MEM_GB:-$((SYS_MEM_GB / 2))}
+TARGET_CPUS=${CONTINUUM_DOCKER_CPUS:-$((SYS_CPUS / 2))}
+[ "$TARGET_MEM" -lt "$MIN_MEM_GB" ] && TARGET_MEM="$MIN_MEM_GB"
+[ "$TARGET_CPUS" -lt 2 ] && TARGET_CPUS=2
 
-  # Detect system RAM and offer to fix
-  if [[ "$PLATFORM" == "mac" ]]; then
-    SYS_MEM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%d", $1/1073741824}')
-    SYS_CPUS=$(sysctl -n hw.ncpu 2>/dev/null || echo "4")
-  else
-    SYS_MEM_GB=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{printf "%d", $2/1048576}')
-    SYS_CPUS=$(nproc 2>/dev/null || echo "4")
-  fi
-  TARGET_MEM=$((SYS_MEM_GB / 2))
-  TARGET_CPUS=$((SYS_CPUS / 2))
-  [ "$TARGET_MEM" -lt "$MIN_MEM_GB" ] && TARGET_MEM="$MIN_MEM_GB"
-  [ "$TARGET_CPUS" -lt 2 ] && TARGET_CPUS=2
+# Bump when Docker's current allocation is below target — NOT just below the
+# 8GB floor. The old `-lt MIN_MEM_GB` check left a 64GB host stuck at Docker's
+# 8GB default forever (8 -lt 8 is false). 2GB tolerance avoids re-bump churn.
+if [ "$DOCKER_MEM_GB" -gt 0 ] && [ "$DOCKER_MEM_GB" -lt "$((TARGET_MEM - 2))" ]; then
+  echo ""
+  echo "⚠️  Docker VM has ${DOCKER_MEM_GB}GB RAM; continuum target is ${TARGET_MEM}GB (½ of ${SYS_MEM_GB}GB system)."
+  echo ""
 
   DOCKER_UPDATED=false
 
@@ -160,10 +166,10 @@ print('   Updated: memoryInGB=${TARGET_MEM}, numberCPUs=${TARGET_CPUS}')
       python3 -c "
 import json
 d = json.load(open('$DD_FILE'))
-d['memoryMiB'] = $TARGET_MEM_MIB
-d['cpus'] = $TARGET_CPUS
+d['MemoryMiB'] = $TARGET_MEM_MIB
+d['Cpus'] = $TARGET_CPUS
 json.dump(d, open('$DD_FILE', 'w'), indent=2)
-print('   Updated: memoryMiB=${TARGET_MEM_MIB}, cpus=${TARGET_CPUS}')
+print('   Updated: MemoryMiB=${TARGET_MEM_MIB}, Cpus=${TARGET_CPUS}')
 " 2>/dev/null && DOCKER_UPDATED=true
       if [ "$DOCKER_UPDATED" = true ]; then
         echo "   Restart Docker Desktop to apply. (Or: osascript -e 'quit app \"Docker\"' && open -a Docker)"
@@ -199,7 +205,7 @@ path = os.path.expanduser('$DD_FILE')
 with open(path) as f:
     cfg = json.load(f)
 changed = False
-for key in ('EnableDockerAI', 'EnableInferenceGPUVariant', 'EnableInferenceTCP'):
+for key in ('EnableDockerAI', 'EnableInference', 'EnableInferenceGPUVariant', 'EnableInferenceTCP'):
     if cfg.get(key) is not True:
         cfg[key] = True
         changed = True

--- a/tools/scripts/setup-rust.sh
+++ b/tools/scripts/setup-rust.sh
@@ -57,6 +57,29 @@ else
 fi
 
 # ============================================================================
+# Step 3.5: Native build prereqs — cmake + vendored git submodules
+# ============================================================================
+# continuum-core compiles vendored llama.cpp/whisper.cpp via cmake. On a fresh
+# clone the submodules are empty (no CMakeLists.txt) and cmake may be absent —
+# either one makes `cargo build` (and therefore `npm start`) fail. Ensure both.
+
+echo -e "${YELLOW}3.5 Checking cmake + vendored submodules...${NC}"
+
+if command -v cmake &>/dev/null; then
+  echo -e "   ${GREEN}✅ cmake installed${NC}"
+else
+  echo -e "   ${YELLOW}⚠️  cmake not found. Installing...${NC}"
+  preflight_pkg_install cmake
+  echo -e "   ${GREEN}✅ cmake installed${NC}"
+fi
+
+# `git submodule update` is a no-op if already initialized; git resolves the
+# repo root regardless of cwd, so this is safe to run from tools/scripts.
+echo -e "   ${YELLOW}Initializing vendored submodules (llama.cpp, whisper.cpp)...${NC}"
+git submodule update --init --recursive
+echo -e "   ${GREEN}✅ Vendored submodules ready${NC}"
+
+# ============================================================================
 # Step 4: Build all Rust workers
 # ============================================================================
 


### PR DESCRIPTION
Fresh-machine `setup.sh` fixes, all found by running it on a clean 64GB Apple Silicon Mac.

## C1 — setup.sh now installs airc (the mesh backbone)
continuum rides airc; setup.sh had zero airc references. Now ensures airc by **delegating to airc's own installer** (download-then-run, keeps stdin a TTY so airc's prompts fire; `AIRC_CHANNEL` overridable). Closes #1629.

## C4 — Docker memory/CPU config was a silent no-op
- **Wrong key case:** wrote camelCase `memoryMiB`/`cpus`; Docker Desktop's real keys are PascalCase **`MemoryMiB`/`Cpus`** (confirmed: a GUI change wrote `"MemoryMiB": 32768`). Docker ignored the camelCase keys → memory/cpu **never applied**.
- **Threshold:** only bumped when `< 8GB`; Docker's default *is* 8 and `8 -lt 8` is false → a 64GB host stayed at 8GB forever. Now bumps when below target (½ system RAM), 2GB tolerance.
- Env-overridable: `CONTINUUM_DOCKER_MEM_GB` / `CONTINUUM_DOCKER_CPUS`.

## C5 — disable Resource Saver for persistent grid nodes
Resource Saver (default ON, 5min) pauses the Docker VM when idle → DMR + personas sleep. Now sets **`UseResourceSaver=false`** (confirmed key). Env opt-out `CONTINUUM_DOCKER_KEEP_RESOURCE_SAVER=1`; non-clobbering.

## C6 — AI key `EnableInference` was missing
The inference toggle's real key is `EnableInference` (+ `EnableDockerAI`); setup.sh's list omitted it. Added (kept GPUVariant/TCP keys — harmless if phantom, safe if valid).

**Design:** scripts set GPU-first defaults; the user can still change everything in Docker Desktop or via env vars (flexible + non-clobbering), mirroring the Windows install.ps1 approach.

> Note: native dev-from-source build also needs `cmake` + `git submodule update --init` (findings C2/C3) — those belong in the dev bootstrap/README, tracked separately.