### PR TITLE
feat(inference): cross-node GPU-first offload guardrail

### DIFF
--- a/core/continuum-core/src/inference_capability/registry.rs
+++ b/core/continuum-core/src/inference_capability/registry.rs
@@ -75,6 +75,27 @@ impl NodeCapabilityRegistry {
         })
     }
 
+    /// Like [`find_capable`], but ALSO requires the node to have a GPU
+    /// backend (Metal/CUDA/Vulkan). This is the cross-node GPU-first
+    /// guardrail (Joel's "GPU-first ALWAYS", promoted from per-node to
+    /// ACROSS-node; no_cpu_fallback contract, the OFFLOAD path): a weak
+    /// node OFFLOADS heavy inference to a GPU peer, never a CPU-only peer.
+    /// When this returns empty, the routing mechanism must REFUSE the
+    /// offload (deny loud) rather than fall back to a CPU peer that
+    /// `find_capable` would still surface.
+    ///
+    /// `find_capable` stays GPU-agnostic on purpose — the routing
+    /// mechanism owns peer *selection*; this method is the *invariant* on
+    /// top: the contract guarantees the picked offload peer is a GPU peer.
+    pub fn find_gpu_capable<'a>(
+        &'a self,
+        kind: &'a InferenceKind,
+        min_free_vram_bytes: u64,
+    ) -> impl Iterator<Item = &'a NodeCapability> + 'a {
+        self.find_capable(kind, min_free_vram_bytes)
+            .filter(|node| node.hardware.has_gpu())
+    }
+
     /// Evict every node whose `last_updated_ms` is older than `cutoff_ms`.
     /// Returns the count of evicted nodes. PR-2's announcer ticks the TTL
     /// on broker cadence; this is the helper it calls.
@@ -199,6 +220,83 @@ mod tests {
             v
         };
         assert_eq!(want_any, vec!["big-llamacpp", "small-llamacpp"]);
+    }
+
+    /// What this catches: the cross-node GPU-first guardrail (no_cpu_fallback
+    /// offload path). A CPU-only peer (no Metal/CUDA/Vulkan) that advertises
+    /// the right kind + VRAM is still surfaced by `find_capable` (GPU-agnostic,
+    /// the mechanism's concern) but MUST be excluded by `find_gpu_capable`.
+    /// If it weren't, a weak node could offload a heavy job onto a CPU peer —
+    /// the exact "GPU-first ALWAYS" violation this guardrail forbids. Empty
+    /// result = the routing mechanism must DENY, not CPU-serve.
+    #[test]
+    fn find_gpu_capable_excludes_cpu_only_peers() {
+        let mut r = NodeCapabilityRegistry::new();
+        let mut cpu_only = mk_node("cpu-box", kinds::LLAMACPP, 32_000_000_000, 100);
+        cpu_only.hardware.has_metal = false;
+        cpu_only.hardware.has_cuda = false;
+        cpu_only.hardware.has_vulkan = false;
+        r.upsert(cpu_only);
+
+        let llamacpp = InferenceKind::from(kinds::LLAMACPP);
+        // GPU-agnostic find still surfaces it (mechanism's job to pick)...
+        assert_eq!(r.find_capable(&llamacpp, 1).count(), 1);
+        // ...but the GPU-first guardrail leaves NO eligible offload target.
+        assert_eq!(
+            r.find_gpu_capable(&llamacpp, 1).count(),
+            0,
+            "CPU-only peer must NOT be an eligible offload target — offload must be DENIED, not CPU-served"
+        );
+    }
+
+    /// What this catches: with a real GPU peer present, find_gpu_capable
+    /// returns ONLY it (the CPU-only peer is filtered out). Pairs with the
+    /// exclusion test to pin the full invariant: GPU peer => route there;
+    /// only CPU peers => empty => deny.
+    #[test]
+    fn find_gpu_capable_returns_gpu_peer_not_cpu_peer() {
+        let mut r = NodeCapabilityRegistry::new();
+        // mk_node defaults has_metal: true => a GPU (Apple Silicon) peer.
+        r.upsert(mk_node("gpu-mac", kinds::LLAMACPP, 24_000_000_000, 100));
+        let mut cpu_only = mk_node("cpu-box", kinds::LLAMACPP, 64_000_000_000, 100);
+        cpu_only.hardware.has_metal = false;
+        r.upsert(cpu_only);
+
+        let llamacpp = InferenceKind::from(kinds::LLAMACPP);
+        let gpu: Vec<&str> = r
+            .find_gpu_capable(&llamacpp, 1)
+            .map(|n| n.node_id.as_str())
+            .collect();
+        assert_eq!(
+            gpu,
+            vec!["gpu-mac"],
+            "only the GPU peer is an eligible offload target, even though cpu-box has more VRAM"
+        );
+    }
+
+    /// What this catches: a CUDA node (no metal) and a Vulkan node both
+    /// count as GPU peers — the guardrail is backend-agnostic, it just
+    /// requires SOME GPU. Guards against a future regression that hardcodes
+    /// has_metal only and silently drops CUDA/Vulkan offload targets.
+    #[test]
+    fn find_gpu_capable_accepts_cuda_and_vulkan_not_just_metal() {
+        let mut r = NodeCapabilityRegistry::new();
+        let mut cuda = mk_node("cuda-5090", kinds::LLAMACPP, 32_000_000_000, 100);
+        cuda.hardware.has_metal = false;
+        cuda.hardware.has_cuda = true;
+        r.upsert(cuda);
+        let mut vulkan = mk_node("vulkan-amd", kinds::LLAMACPP, 24_000_000_000, 100);
+        vulkan.hardware.has_metal = false;
+        vulkan.hardware.has_vulkan = true;
+        r.upsert(vulkan);
+
+        let llamacpp = InferenceKind::from(kinds::LLAMACPP);
+        let mut ids: Vec<&str> = r
+            .find_gpu_capable(&llamacpp, 1)
+            .map(|n| n.node_id.as_str())
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["cuda-5090", "vulkan-amd"]);
     }
 
     /// What this catches: find_capable on a kind no node advertises

--- a/core/continuum-core/src/inference_capability/types.rs
+++ b/core/continuum-core/src/inference_capability/types.rs
@@ -106,6 +106,21 @@ pub struct HardwareProfile {
     pub system_ram_bytes: u64,
 }
 
+impl HardwareProfile {
+    /// True when this node has ANY GPU backend (Metal / CUDA / Vulkan).
+    ///
+    /// This is the eligibility predicate for the cross-node GPU-first
+    /// guardrail (Joel's "GPU-first ALWAYS", promoted from per-node to
+    /// ACROSS-node; no_cpu_fallback contract, offload path): a CPU-only
+    /// node (all three false) must NEVER be an eligible offload target for
+    /// a heavy inference job — the substrate refuses rather than silently
+    /// degrade a remote peer to CPU. Mirrors the per-node residency-gate
+    /// GPU refusal at the cross-node boundary.
+    pub fn has_gpu(&self) -> bool {
+        self.has_metal || self.has_cuda || self.has_vulkan
+    }
+}
+
 /// One inference capability this node can take. Composed by
 /// `probe_inference_capabilities` from a `HardwareProfile`; advertised by
 /// PR-2's grid announcer; scored by PR-3's router.
@@ -236,6 +251,42 @@ mod tests {
         assert!(j.contains("\"systemRamBytes\":64000000000"));
         let back: HardwareProfile = serde_json::from_str(&j).unwrap();
         assert_eq!(back, h);
+    }
+
+    /// What this catches: HardwareProfile::has_gpu() is true for ANY GPU
+    /// backend (Metal OR CUDA OR Vulkan) and false only when all three are
+    /// absent. This predicate is the cross-node GPU-first guardrail's
+    /// eligibility test (no_cpu_fallback offload path) — a regression that
+    /// checked only has_metal would mis-classify CUDA/Vulkan GPU peers as
+    /// ineligible, or a flipped condition would let CPU-only peers through.
+    #[test]
+    fn has_gpu_true_for_any_backend_false_for_cpu_only() {
+        let cpu_only = HardwareProfile {
+            platform: "cpu-box".into(),
+            has_metal: false,
+            has_cuda: false,
+            has_vulkan: false,
+            free_vram_bytes: 0,
+            total_vram_bytes: 0,
+            cpu_cores: 8,
+            system_ram_bytes: 16_000_000_000,
+        };
+        assert!(!cpu_only.has_gpu(), "all-false = CPU-only = no GPU");
+        assert!(HardwareProfile {
+            has_metal: true,
+            ..cpu_only.clone()
+        }
+        .has_gpu());
+        assert!(HardwareProfile {
+            has_cuda: true,
+            ..cpu_only.clone()
+        }
+        .has_gpu());
+        assert!(HardwareProfile {
+            has_vulkan: true,
+            ..cpu_only.clone()
+        }
+        .has_gpu());
     }
 
     /// What this catches: InferenceCapability full round-trip with the

--- a/core/continuum-core/tests/no_cpu_fallback_contract.rs
+++ b/core/continuum-core/tests/no_cpu_fallback_contract.rs
@@ -50,6 +50,17 @@ const ENFORCEMENT_SOURCE: &str = include_str!("../src/inference_capability/enfor
 
 const HW_PROBE_SOURCE: &str = include_str!("../src/inference_capability/hw_probe.rs");
 
+// Cross-node (offload) GPU-first guardrail — the 9th path. "GPU-first
+// ALWAYS" promoted from per-node to ACROSS-node: a weak node offloading a
+// heavy job must land on a GPU peer, never a CPU-only peer; if only CPU
+// peers are reachable the routing mechanism must REFUSE, not silently
+// degrade a remote peer to CPU. These constants pin the eligibility
+// predicate so a future PR can't drop it (or route heavy offload through
+// the GPU-agnostic `find_capable`) without breaking this gate.
+const CAPABILITY_TYPES_SOURCE: &str = include_str!("../src/inference_capability/types.rs");
+
+const CAPABILITY_REGISTRY_SOURCE: &str = include_str!("../src/inference_capability/registry.rs");
+
 #[test]
 fn llamacpp_default_config_requires_full_gpu_offload() {
     // The production load path is `LlamaCppConfig::default()` →
@@ -249,5 +260,34 @@ fn hw_probe_does_not_introduce_cpu_fallback() {
         "hw_probe.rs must expose build_hardware_profile so the residency gate can be tested \
          with synthetic profiles. Privatizing it would force every test to hit real \
          hardware — flaky + slow + wrong shape."
+    );
+}
+
+#[test]
+fn cross_node_offload_has_gpu_first_guardrail() {
+    // 9th no-CPU-fallback path: the OFFLOAD path. "GPU-first ALWAYS"
+    // promoted from per-node to ACROSS-node. The per-node gates above stop
+    // a single box from running CPU inference; this stops a weak box from
+    // OFFLOADING a heavy job onto a CPU-only peer over the grid. The
+    // guardrail is a GPU-class eligibility predicate that makes CPU-only
+    // peers ineligible offload targets — so when no GPU peer is reachable
+    // the routing mechanism must REFUSE rather than silently CPU-serve.
+    // (Behavioral tests live in inference_capability/{types,registry}.rs;
+    // these source assertions are the ratchet that stops a silent removal.)
+
+    assert!(
+        CAPABILITY_TYPES_SOURCE.contains("fn has_gpu"),
+        "HardwareProfile must expose has_gpu() (Metal || CUDA || Vulkan) — the eligibility \
+         predicate for the cross-node offload guardrail. Removing it (or narrowing it to \
+         has_metal only) lets a heavy job offload onto a CPU-only or mis-classified peer: \
+         the across-node 'GPU-first ALWAYS' violation."
+    );
+    assert!(
+        CAPABILITY_REGISTRY_SOURCE.contains("fn find_gpu_capable"),
+        "NodeCapabilityRegistry must expose find_gpu_capable() — the GPU-first offload \
+         selector that filters out CPU-only peers. If you removed it, or routing started \
+         using the GPU-agnostic find_capable() for heavy OFFLOAD selection, a weak node can \
+         silently offload to a CPU peer. Re-add the guardrail (and its registry tests) \
+         before removing this assertion."
     );
 }


### PR DESCRIPTION
## What

"GPU-first ALWAYS" promoted from **per-node** to **across-node**. When a weak node offloads a heavy inference job over the grid, it must land on a **GPU peer, never a CPU-only one**. If only CPU peers are reachable, the routing mechanism must **REFUSE (deny)**, not silently degrade a remote peer to CPU.

## How

- `HardwareProfile::has_gpu()` — `Metal || CUDA || Vulkan` eligibility predicate.
- `NodeCapabilityRegistry::find_gpu_capable()` — GPU-first offload selector. Leaves `find_capable()` GPU-agnostic on purpose: the routing **mechanism** owns peer *selection*; this is the **invariant** on top (guarantees the picked offload peer is a GPU peer).
- Behavioral tests: CPU-only peer ⇒ excluded (offload must deny, not CPU-serve); GPU peer ⇒ routes; CUDA + Vulkan both count (not just Metal).
- `no_cpu_fallback_contract.rs`: the **9th path** (the OFFLOAD path) ratchet — a future PR can't drop `has_gpu()`/`find_gpu_capable()`, or route heavy offload through GPU-agnostic `find_capable()`, without breaking the gate.

## Non-colliding

This is policy/contract **atop** airc-8a5e's GRID-INFERENCE-ROUTING *mechanism* (BIGMAMA confirmed the division). It rides the airc transport BIGMAMA is fixing in airc#1210.

## Validation

`cargo test -p continuum-core --features metal,accelerate`:
- `inference_capability` → **125 passed, 0 failed**
- `no_cpu_fallback_contract` → **10 passed, 0 failed** (incl. new `cross_node_offload_has_gpu_first_guardrail`)

(Surfaced fresh-Mac dev-build gaps in the process — cmake + git-submodule-init missing from the from-source docs; tracked separately.)