### PR TITLE
fix(inference): coordinator covers MacIntelMetal — canary --features metal was broken

### DIFF
--- a/core/continuum-core/src/inference/coordinator.rs
+++ b/core/continuum-core/src/inference/coordinator.rs
@@ -132,16 +132,23 @@ impl CoordinatorConfig {
 /// lane scheduler.
 ///
 /// `AppleM` → `UnifiedMemory` (Apple-silicon shared accelerator memory);
-/// every discrete-GPU class (`NvidiaCuda` / `AmdRocm` / `IntelVulkan`) →
-/// `Gpu`; `None` (no accelerator detected) → `Cpu`. `Cpu` is the HONEST
-/// classification, not a silent floor — a GPU-or-bust caller inspects the
-/// result and refuses rather than quietly serving CPU.
+/// every discrete/Metal GPU class (`NvidiaCuda` / `AmdRocm` / `IntelVulkan` /
+/// `MacIntelMetal`) → `Gpu`; `None` (no accelerator detected) → `Cpu`. `Cpu`
+/// is the HONEST classification, not a silent floor — a GPU-or-bust caller
+/// inspects the result and refuses rather than quietly serving CPU.
+///
+/// `MacIntelMetal` (Intel Mac with a Metal-addressable discrete/integrated
+/// GPU — task #52) maps to `Gpu`, NOT `UnifiedMemory`: it is a real GPU, but
+/// not Apple-silicon shared memory. Added when the governor gained the
+/// variant (#1624); this match is in the `--features metal` build path, so
+/// the no-metal Linux CI did not catch the non-exhaustive gap.
 pub fn coordinator_silicon_for(detected: GovernorSilicon) -> TargetSilicon {
     match detected {
         GovernorSilicon::AppleM => TargetSilicon::UnifiedMemory,
         GovernorSilicon::NvidiaCuda
         | GovernorSilicon::AmdRocm
-        | GovernorSilicon::IntelVulkan => TargetSilicon::Gpu,
+        | GovernorSilicon::IntelVulkan
+        | GovernorSilicon::MacIntelMetal => TargetSilicon::Gpu,
         GovernorSilicon::None => TargetSilicon::Cpu,
     }
 }


### PR DESCRIPTION
## Problem
`cargo check -p continuum-core --features metal,accelerate` **fails to compile on canary**: `error[E0004]: non-exhaustive patterns: TargetSilicon::MacIntelMetal not covered` at `inference/coordinator.rs:140`.

#1624 added the `MacIntelMetal` governor variant (Intel Mac w/ Metal GPU, task #52) and updated `policy_selector.rs`, but missed `coordinator_silicon_for`'s match. That match is in the **`--features metal` path**, and the Linux CI (`cargo test -p continuum-core --lib`, no metal) runs without it — so the break shipped green. The GPU-first build path has been down on canary since.

## Fix
Map `MacIntelMetal → TargetSilicon::Gpu` (it's a real Metal-addressable GPU, **not** Apple-silicon `UnifiedMemory`). One match arm + doc.

## Validation
`cargo check -p continuum-core --features metal,accelerate` → **Finished, 0 errors** (on a fresh M5 Pro). Caught precisely because this box builds the metal path the Linux CI can't.

## Note
Cross-OS/feature-matrix gap: consider adding a macOS/`--features metal` build to CI so metal-only breaks don't ship green again.