### PR TITLE
feat(startup): system/launch-mode IPC command — headless-native, Rust-only

### DIFF
--- a/core/continuum-core/src/config_env.rs
+++ b/core/continuum-core/src/config_env.rs
@@ -1,0 +1,176 @@
+//! config_env — read + UPSERT `~/.continuum/config.env` from the Rust core.
+//!
+//! [`crate::secrets`] is the read-only, cached-at-startup reader (API keys
+//! loaded into a map once at boot). This is its mutable counterpart: a fresh
+//! single-key read and a portable upsert writer, for runtime commands that
+//! change a persisted setting (e.g. `system/launch-mode`).
+//!
+//! Three runtimes touch this one file — the bash bootstrap (`bin/continuum`
+//! `config_set`), the Node desktop (`SecretManager`), and the Rust core (here).
+//! They all agree on the format (`KEY=value` lines, `#` comments, blank lines
+//! skipped) and the path, so a thin per-runtime accessor is coherence, not
+//! duplication: the headless Rust server must be able to read/write the setting
+//! with no Node and no shell in the loop.
+//!
+//! The `*_in` / `*_from` variants take an explicit path and hold ALL the logic
+//! so they unit-test against a temp file; the bare [`read`] / [`upsert`] are
+//! thin `dirs::home_dir()` wrappers.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Path to `~/.continuum/config.env` (mirrors [`crate::secrets`]).
+pub fn config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".continuum").join("config.env"))
+}
+
+/// Read one key's value, fresh from disk. `None` if the file or key is absent.
+/// Comments/blank lines skipped; value trimmed; last assignment wins (matching
+/// the shell `source` semantics the bootstrap relies on).
+pub fn read(key: &str) -> Option<String> {
+    read_from(&config_path()?, key)
+}
+
+/// Upsert one key, preserving every other line. Creates the dir + file if
+/// missing. Replaces the FIRST existing assignment in place (keeps file order),
+/// drops any duplicates, appends if absent.
+pub fn upsert(key: &str, value: &str) -> Result<(), String> {
+    let path = config_path().ok_or("config_env: cannot resolve home dir")?;
+    upsert_in(&path, key, value)
+}
+
+/// Path-taking core of [`read`] — testable without touching `$HOME`.
+pub fn read_from(path: &Path, key: &str) -> Option<String> {
+    let content = fs::read_to_string(path).ok()?;
+    let mut found = None;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some((k, v)) = trimmed.split_once('=') {
+            if k.trim() == key {
+                found = Some(v.trim().to_string());
+            }
+        }
+    }
+    found
+}
+
+/// Path-taking core of [`upsert`] — testable without touching `$HOME`. Writes
+/// through a temp file + rename so a concurrent reader never sees a half-write.
+pub fn upsert_in(path: &Path, key: &str, value: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("config_env: create_dir_all {parent:?}: {e}"))?;
+    }
+    let existing = fs::read_to_string(path).unwrap_or_default();
+
+    let mut out = String::new();
+    let mut replaced = false;
+    for line in existing.lines() {
+        let trimmed = line.trim();
+        let is_assignment_for_key = !trimmed.starts_with('#')
+            && trimmed
+                .split_once('=')
+                .map(|(k, _)| k.trim() == key)
+                .unwrap_or(false);
+        if is_assignment_for_key {
+            if !replaced {
+                out.push_str(key);
+                out.push('=');
+                out.push_str(value);
+                out.push('\n');
+                replaced = true;
+            }
+            // drop this (and any later duplicate) assignment line
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    if !replaced {
+        out.push_str(key);
+        out.push('=');
+        out.push_str(value);
+        out.push('\n');
+    }
+
+    let tmp = path.with_extension("env.tmp");
+    {
+        let mut f = fs::File::create(&tmp).map_err(|e| format!("config_env: create {tmp:?}: {e}"))?;
+        f.write_all(out.as_bytes())
+            .map_err(|e| format!("config_env: write {tmp:?}: {e}"))?;
+    }
+    fs::rename(&tmp, path).map_err(|e| format!("config_env: rename {tmp:?} -> {path:?}: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_config() -> PathBuf {
+        // Unique per test via thread id + a counter — no Date/rand needed.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let n = N.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("continuum-config-env-test-{n}/config.env"))
+    }
+
+    /// What this catches: a freshly written key reads back, and a sibling key is
+    /// untouched — the get/set round-trip + non-destructiveness the command relies on.
+    #[test]
+    fn upsert_then_read_roundtrips_and_preserves_siblings() {
+        let p = tmp_config();
+        upsert_in(&p, "HTTP_PORT", "9000").unwrap();
+        upsert_in(&p, "CONTINUUM_LAUNCH_MODE", "headless").unwrap();
+        assert_eq!(read_from(&p, "HTTP_PORT").as_deref(), Some("9000"));
+        assert_eq!(read_from(&p, "CONTINUUM_LAUNCH_MODE").as_deref(), Some("headless"));
+        let _ = fs::remove_dir_all(p.parent().unwrap());
+    }
+
+    /// What this catches: upsert REPLACES (not duplicates) — exactly one line per
+    /// key after re-setting, or the shell `source` (last-wins) and our reader
+    /// could disagree across runtimes.
+    #[test]
+    fn upsert_replaces_in_place_no_duplicates() {
+        let p = tmp_config();
+        upsert_in(&p, "CONTINUUM_LAUNCH_MODE", "ui").unwrap();
+        upsert_in(&p, "CONTINUUM_LAUNCH_MODE", "headless").unwrap();
+        let content = fs::read_to_string(&p).unwrap();
+        let count = content
+            .lines()
+            .filter(|l| l.trim_start().starts_with("CONTINUUM_LAUNCH_MODE="))
+            .count();
+        assert_eq!(count, 1, "expected exactly one assignment line, got:\n{content}");
+        assert_eq!(read_from(&p, "CONTINUUM_LAUNCH_MODE").as_deref(), Some("headless"));
+        let _ = fs::remove_dir_all(p.parent().unwrap());
+    }
+
+    /// What this catches: comments + blank lines survive an upsert (we never
+    /// clobber the human-authored config.env scaffold the installer writes).
+    #[test]
+    fn upsert_preserves_comments_and_blanks() {
+        let p = tmp_config();
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(&p, "# Continuum Configuration\n\nHTTP_PORT=9000\n").unwrap();
+        upsert_in(&p, "CONTINUUM_LAUNCH_MODE", "headless").unwrap();
+        let content = fs::read_to_string(&p).unwrap();
+        assert!(content.contains("# Continuum Configuration"), "comment dropped:\n{content}");
+        assert!(content.contains("HTTP_PORT=9000"), "sibling dropped:\n{content}");
+        let _ = fs::remove_dir_all(p.parent().unwrap());
+    }
+
+    /// What this catches: missing file/key reads as None (the command defaults to
+    /// 'auto'), and comments are not mistaken for assignments.
+    #[test]
+    fn read_missing_is_none_and_comments_ignored() {
+        let p = tmp_config();
+        assert_eq!(read_from(&p, "CONTINUUM_LAUNCH_MODE"), None);
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(&p, "# CONTINUUM_LAUNCH_MODE=ui (this is a comment)\n").unwrap();
+        assert_eq!(read_from(&p, "CONTINUUM_LAUNCH_MODE"), None);
+        let _ = fs::remove_dir_all(p.parent().unwrap());
+    }
+}

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -17,6 +17,7 @@ use crate::modules::forge::ForgeModule;
 use crate::modules::gpu::GpuModule;
 use crate::modules::grid::GridModule;
 use crate::modules::health::HealthModule;
+use crate::modules::launch_mode::LaunchModeModule;
 use crate::modules::inference::InferenceModule;
 use crate::modules::live::{VoiceModule, VoiceState};
 use crate::modules::logger::LoggerModule;
@@ -759,6 +760,12 @@ pub fn start_server(
 
     // Phase 1: HealthModule (stateless)
     runtime.register(Arc::new(HealthModule::new()));
+
+    // LaunchModeModule (stateless) — system/launch-mode/{get,set}. Headless-native
+    // runtime lever for the headless-vs-UI launch preference; persists
+    // CONTINUUM_LAUNCH_MODE to config.env (same key bin/continuum reads) and emits
+    // system:launch-mode:changed so a running UI can attach/tear down its overlay.
+    runtime.register(Arc::new(LaunchModeModule::new()));
 
     // ExternalWebviewAuthModule — OAuth 2.0 + PKCE via system browser.
     // Landed in 26ab8c0ad; re-enabling after merge from feat/mac-docker-model-runner

--- a/core/continuum-core/src/lib.rs
+++ b/core/continuum-core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod code;
 pub mod cognition;
 pub mod comms;
 pub mod concurrency;
+pub mod config_env;
 pub mod context;
 pub mod contracts;
 pub mod events;

--- a/core/continuum-core/src/modules/launch_mode.rs
+++ b/core/continuum-core/src/modules/launch_mode.rs
@@ -1,0 +1,199 @@
+//! LaunchModeModule — `system/launch-mode/{get,set}` IPC commands.
+//!
+//! The launch preference (`headless` | `ui` | `auto`) lives in ONE place:
+//! `CONTINUUM_LAUNCH_MODE` in `~/.continuum/config.env` — the same key the
+//! pre-core `bin/continuum` bootstrap resolver reads/writes, so boot-time and
+//! runtime agree on one truth. This module is the RUNTIME lever: any surface
+//! (CLI, menu-bar tray, desktop Grid tab, mobile, and personas via the SDK)
+//! sets the mode through this command, and a `system:launch-mode:changed` event
+//! lets a running UI attach or tear down its own overlay (the "UI turns itself
+//! off when the last human leaves" behavior).
+//!
+//! Headless-native by design: continuum-core owns this with ZERO Node
+//! dependency — the Node desktop is a dependent client that calls it over IPC,
+//! never the reverse. That's why it lives in the Rust core and reuses
+//! [`crate::config_env`] (the in-core config.env reader/writer) rather than the
+//! TypeScript `SecretManager`.
+//!
+//! This is DISTINCT from the substrate boot `--mode`
+//! (full-citizen/inference-only/fail-fast), which stays explicit and is never
+//! guessed (`[[no-fallbacks-ever]]`). `auto` resolution into a concrete
+//! `headless`/`ui` is the shell's boot-time job (`bin/continuum has_display`),
+//! kept in one place — this command reports/persists the stored setting.
+
+use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use std::any::Any;
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+/// config.env key — MUST match `bin/continuum` and the TS `SecretManager`.
+const LAUNCH_MODE_KEY: &str = "CONTINUUM_LAUNCH_MODE";
+/// Bus topic a running UI subscribes to so it can attach/tear down its overlay.
+const CHANGED_EVENT: &str = "system:launch-mode:changed";
+
+pub struct LaunchModeModule {
+    /// Captured during `initialize` so `handle_command` (which has no ctx) can
+    /// publish the changed-event. Same pattern as `CodeModule`.
+    bus: OnceLock<Arc<crate::runtime::MessageBus>>,
+}
+
+impl LaunchModeModule {
+    pub fn new() -> Self {
+        Self {
+            bus: OnceLock::new(),
+        }
+    }
+
+    /// Canonicalize a raw setting to one of the three valid modes. `None` for
+    /// anything else — the caller decides whether that's a default (`get`) or a
+    /// hard error (`set`).
+    fn normalize_mode(raw: &str) -> Option<&'static str> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "headless" => Some("headless"),
+            "ui" => Some("ui"),
+            "auto" => Some("auto"),
+            _ => None,
+        }
+    }
+}
+
+impl Default for LaunchModeModule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ServiceModule for LaunchModeModule {
+    fn config(&self) -> ModuleConfig {
+        ModuleConfig {
+            name: "launch-mode",
+            priority: ModulePriority::Normal,
+            command_prefixes: &["system/launch-mode/"],
+            event_subscriptions: &[],
+            needs_dedicated_thread: false,
+            max_concurrency: 0,
+            tick_interval: None,
+        }
+    }
+
+    async fn initialize(&self, ctx: &ModuleContext) -> Result<(), String> {
+        let _ = self.bus.set(ctx.bus.clone());
+        Ok(())
+    }
+
+    async fn handle_command(&self, command: &str, params: Value) -> Result<CommandResult, String> {
+        match command {
+            // Report the stored launch mode. Unset (or unrecognized) → "auto".
+            "system/launch-mode/get" => {
+                let (mode, source) = match crate::config_env::read(LAUNCH_MODE_KEY) {
+                    Some(raw) => match Self::normalize_mode(&raw) {
+                        Some(m) => (m.to_string(), "config"),
+                        None => ("auto".to_string(), "default"),
+                    },
+                    None => ("auto".to_string(), "default"),
+                };
+                Ok(CommandResult::Json(json!({
+                    "success": true,
+                    "mode": mode,
+                    "source": source,
+                })))
+            }
+
+            // Persist a new launch mode + emit the changed event.
+            "system/launch-mode/set" => {
+                let raw = params
+                    .get("mode")
+                    .and_then(|v| v.as_str())
+                    .ok_or("system/launch-mode/set requires a 'mode' string param (headless|ui|auto)")?;
+                let mode = Self::normalize_mode(raw).ok_or_else(|| {
+                    format!("invalid mode '{raw}'. Expected one of: headless, ui, auto")
+                })?;
+
+                let previous = crate::config_env::read(LAUNCH_MODE_KEY)
+                    .and_then(|raw| Self::normalize_mode(&raw).map(str::to_string))
+                    .unwrap_or_default();
+
+                crate::config_env::upsert(LAUNCH_MODE_KEY, mode)?;
+
+                // Fire-and-forget: a running UI tears down/attaches its overlay.
+                if let Some(bus) = self.bus.get() {
+                    bus.publish_async_only(
+                        CHANGED_EVENT,
+                        json!({ "mode": mode, "previousMode": previous }),
+                    );
+                }
+
+                Ok(CommandResult::Json(json!({
+                    "success": true,
+                    "mode": mode,
+                    "previousMode": previous,
+                    "applied": true,
+                })))
+            }
+
+            other => Err(format!("LaunchModeModule: unknown command '{other}'")),
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// What this catches: the three valid modes canonicalize (case-insensitively)
+    /// and everything else is rejected — the deny-by-default validation the `set`
+    /// path leans on so a bad value never reaches config.env.
+    #[test]
+    fn normalize_accepts_only_the_three_modes() {
+        assert_eq!(LaunchModeModule::normalize_mode("headless"), Some("headless"));
+        assert_eq!(LaunchModeModule::normalize_mode("UI"), Some("ui"));
+        assert_eq!(LaunchModeModule::normalize_mode("  Auto "), Some("auto"));
+        assert_eq!(LaunchModeModule::normalize_mode("banana"), None);
+        assert_eq!(LaunchModeModule::normalize_mode(""), None);
+    }
+
+    /// What this catches: the command surface is stable — the module only claims
+    /// the system/launch-mode/ prefix (so it can't shadow other system commands).
+    #[test]
+    fn config_claims_only_launch_mode_prefix() {
+        let m = LaunchModeModule::new();
+        assert_eq!(m.config().command_prefixes, &["system/launch-mode/"]);
+    }
+
+    /// What this catches: an unknown subcommand fails loudly rather than silently
+    /// succeeding (every-error-is-an-opportunity-to-battle-harden).
+    #[tokio::test]
+    async fn unknown_command_errors() {
+        let m = LaunchModeModule::new();
+        let err = m
+            .handle_command("system/launch-mode/frobnicate", json!({}))
+            .await
+            .expect_err("unknown subcommand must error");
+        assert!(err.contains("unknown command"), "got: {err}");
+    }
+
+    /// What this catches: `set` with no/blank mode is rejected with a message
+    /// naming the valid values — not a silent no-op write.
+    #[tokio::test]
+    async fn set_without_mode_is_rejected() {
+        let m = LaunchModeModule::new();
+        let err = m
+            .handle_command("system/launch-mode/set", json!({}))
+            .await
+            .expect_err("missing mode must error");
+        assert!(err.contains("mode"), "got: {err}");
+
+        let err2 = m
+            .handle_command("system/launch-mode/set", json!({ "mode": "sideways" }))
+            .await
+            .expect_err("invalid mode must error");
+        assert!(err2.contains("headless"), "error should name valid modes: {err2}");
+    }
+}

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -44,6 +44,7 @@ pub mod health;
 pub mod hippocampus;
 pub mod inference;
 pub mod inference_coordinator_module;
+pub mod launch_mode;
 pub mod live;
 pub mod logger;
 pub mod mcp;


### PR DESCRIPTION
## What

The **runtime lever** for the headless-vs-UI launch preference, as a Rust IPC command in continuum-core — `system/launch-mode/{get,set}`.

## Why Rust, not TS

The headless server is **independent of Node entirely**; the Node desktop is a dependent client that calls the core over IPC, never the reverse. So a headless-only node (or a persona) must be able to read/set its own launch mode with no Node in the loop — this belongs in the Rust core, not the TS command layer. (The bash `bin/continuum` resolver in #1636 is the unavoidable *pre-core bootstrap*; this is the *runtime* command.)

## Pieces

- **`modules/launch_mode.rs`** — `LaunchModeModule` (ServiceModule, registered next to `HealthModule`):
  - `system/launch-mode/get` → reports stored `CONTINUUM_LAUNCH_MODE` (`auto` when unset).
  - `system/launch-mode/set` → validates `headless|ui|auto`, persists, emits **`system:launch-mode:changed`** so a running UI attaches / tears down its own overlay (the "UI turns itself off when the last human leaves" behavior).
- **`config_env.rs`** — in-core config.env **reader + upsert writer**: the mutable counterpart to the read-only, cached-at-startup `secrets.rs`. Same key + `KEY=value` format the `bin/continuum` bootstrap and the TS `SecretManager` use, so all three runtimes (shell / Node / Rust) agree on one truth — coherence across runtimes, not duplication.

## The architecture it embodies

One config.env setting, edited by **any first-class citizen** — CLI, menu-bar tray, desktop Grid tab, mobile, **persona via the SDK** — through the one command; the changed-event is the UI-visible feedback. (Joel's rule: UI-manipulable action → command, UI-visible feedback → event.) Distinct from the substrate boot `--mode` (full-citizen/inference-only/fail-fast), which stays explicit and is never guessed (`[[no-fallbacks-ever]]`).

## Tests

8 unit tests, green under `--features metal,accelerate`: config.env round-trip / upsert-in-place (no duplicates) / comment+sibling preservation / missing-file → None; mode normalization; deny unknown subcommand; reject missing & invalid mode.

## Relationship to other PRs

Builds on #1636 (the bash bootstrap resolver reads the same key). Part of the headless-first startup-consolidation lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)