### PR TITLE
fix(test): vision_integration registers adapter as Arc, not Box

### DIFF
--- a/core/continuum-core/tests/vision_integration.rs
+++ b/core/continuum-core/tests/vision_integration.rs
@@ -172,7 +172,7 @@ async fn vision_roundtrip_local_qwen2_vl() {
         use continuum_core::ai::adapter::AIProviderAdapter;
         let registry_arc = continuum_core::modules::ai_provider::global_registry();
         let mut registry = registry_arc.write().await;
-        let adapter: Box<dyn AIProviderAdapter> = Box::new(
+        let adapter: std::sync::Arc<dyn AIProviderAdapter> = std::sync::Arc::new(
             continuum_core::inference::llamacpp_adapter::LlamaCppAdapter::with_model_id(
                 model_path.clone(),
                 model_id.to_string(),


### PR DESCRIPTION
## What

`AdapterRegistry::register` takes `Arc<dyn AIProviderAdapter>` (`ai/adapter.rs:575`), but `tests/vision_integration.rs:182` still passed a `Box` → `E0308`. Fixed to `Arc::new` (fully qualified, no new import). This was the **one genuine stale-test breakage** in the continuum-core test suite.

## Context — the full "investigate all errors" sweep

Running `cargo test -p continuum-core --no-run` surfaced 7 "broken" test files. Investigation:

- **6 were not bugs** — `architecture_demand_pull_cognition`, `airc_remote_inference_end_to_end`, `architecture_killer_loop_burst_cognition`, `persona_command_inbound_pump`, `persona_respond_replay`, `llamacpp_metal_throughput` use **fixture-gated** instrumentation (`compute_calls` / `compute_call_count` / `HeuristicInferenceAdapter`, all `#[cfg(any(test, feature = "test-fixtures"))]`). They simply require **`--features test-fixtures`** to compile (the canonical test invocation). With that feature the whole `--no-run` suite is clean.
- **1 was a real bug** — this Box→Arc, now fixed.

Also confirmed: the `cargo test -p continuum-core --lib` red on PR #1636 was a **CI flake** — #1635 (identical bridge_protocol Rust) and #1639 (same + more) both pass that check; #1636 added only a bash commit on top, which can't break a cargo build.

Verified locally: `cargo test -p continuum-core --no-run --features metal,accelerate,test-fixtures` → all test binaries compile, zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)