### PR TITLE
fix(startup): repair stale workers/continuum-core paths — repeatable headless start

### DIFF
--- a/scripts/ratchets/check-ts-persona-cognition.sh
+++ b/scripts/ratchets/check-ts-persona-cognition.sh
@@ -9,8 +9,8 @@
 # Per Rust-first alpha contract (PR #1070, ALPHA-GAP-ANALYSIS.md "Rust
 # core owns behavior"): every PR touching the persona surface must
 # either keep the line count flat or shrink it. New cognition logic
-# belongs in Rust (`workers/continuum-core/src/persona/`,
-# `workers/continuum-core/src/cognition/`), not in this TS surface.
+# belongs in Rust (`core/continuum-core/src/persona/`,
+# `core/continuum-core/src/cognition/`), not in this TS surface.
 #
 # Modes:
 #   ./check-ts-persona-cognition.sh              # check + report; exit 0/1
@@ -108,8 +108,8 @@ if [[ "$DELTA" -gt 0 ]]; then
   echo "  Per Rust-first alpha contract (PR #1070, docs/planning/ALPHA-GAP-ANALYSIS.md)," >&2
   echo "  the TS persona surface must SHRINK or stay flat. New cognition logic belongs" >&2
   echo "  in Rust:" >&2
-  echo "    workers/continuum-core/src/persona/" >&2
-  echo "    workers/continuum-core/src/cognition/" >&2
+  echo "    core/continuum-core/src/persona/" >&2
+  echo "    core/continuum-core/src/cognition/" >&2
   echo "" >&2
   echo "  Options:" >&2
   echo "    1. Move the new code Rust-side." >&2

--- a/scripts/ratchets/check-ts-persona-forbidden-strings.sh
+++ b/scripts/ratchets/check-ts-persona-forbidden-strings.sh
@@ -154,8 +154,8 @@ if [[ "$ANY_GROWTH" -eq 1 ]]; then
   echo "" >&2
   echo "  Per Joel's no-fallbacks rule + Rust-first alpha contract (PR #1070)," >&2
   echo "  the TS persona surface must shed these patterns over time. Provider" >&2
-  echo "  resolution + admission belong in Rust (workers/continuum-core/src/cognition/," >&2
-  echo "  workers/continuum-core/src/persona/), NOT in TS." >&2
+  echo "  resolution + admission belong in Rust (core/continuum-core/src/cognition/," >&2
+  echo "  core/continuum-core/src/persona/), NOT in TS." >&2
   echo "" >&2
   echo "  Options:" >&2
   echo "    1. Move the pattern occurrence Rust-side." >&2

--- a/src/shared/models.json
+++ b/src/shared/models.json
@@ -2,7 +2,7 @@
   "_doc": "Single source of truth for all models the system uses. ALL consumers (install.sh, model-init download scripts, continuum-core Rust loader, persona seed) read from this file. To swap a model: edit ONE entry here. Personas store symbolic refs (e.g. 'local-default', 'vision-default') so changing the registry value automatically picks up everywhere on next inference call — seeded data does NOT need migration.",
   "_consumers": [
     "src/shared/ModelRegistry.ts (TS reader)",
-    "src/workers/continuum-core/src/inference/registry.rs (Rust reader)",
+    "core/continuum-core/src/inference/registry.rs (Rust reader)",
     "install.sh (resolves PERSONA_MODEL via tier)",
     "src/scripts/download-models.sh (model-init container — downloads all auto_download:true models)",
     "src/scripts/seed/personas.ts (resolves symbolic refs to current model on lookup)"

--- a/tools/generator/HelpFormatter.ts
+++ b/tools/generator/HelpFormatter.ts
@@ -260,7 +260,7 @@ FLAGS (with spec file):
   NOTE: For Rust IPC commands, the generator creates the TypeScript command
   scaffold. You still need:
   1. The Rust ServiceModule (handles the IPC command)
-  2. The IPC mixin (workers/continuum-core/bindings/modules/<name>.ts)
+  2. The IPC mixin (core/continuum-core/bindings/modules/<name>.ts)
   3. Wire mixin into RustCoreIPC.ts composition chain
   See docs/infrastructure/UNIFIED-GENERATOR-ARCHITECTURE.md for full details.
 

--- a/tools/generator/generate-audio-constants.ts
+++ b/tools/generator/generate-audio-constants.ts
@@ -11,9 +11,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const SOURCE_FILE = path.join(__dirname, '../shared/audio-constants.json');
-const TS_OUTPUT = path.join(__dirname, '../shared/AudioConstants.ts');
-const RUST_OUTPUT = path.join(__dirname, '../workers/continuum-core/src/audio_constants.rs');
+// Paths are relative to tools/generator/. Updated after the repo restructure
+// (commit 2cb63e019: src/workers/continuum-core → core/continuum-core; this
+// generator moved under tools/generator/). All three were stale ../shared and
+// ../workers paths that resolved to nonexistent tools/* dirs.
+const SOURCE_FILE = path.join(__dirname, '../../src/shared/audio-constants.json');
+const TS_OUTPUT = path.join(__dirname, '../../src/shared/AudioConstants.ts');
+const RUST_OUTPUT = path.join(__dirname, '../../core/continuum-core/src/audio_constants.rs');
 
 interface AudioConstants {
   AUDIO_SAMPLE_RATE: number;

--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -25,7 +25,13 @@
 
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+# Repo root is two up from tools/scripts/. (Was `dirname SCRIPT_DIR`, which
+# resolved to tools/ — stale since this script moved under tools/scripts/.)
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# continuum-core crate manifest. Restructured workers/continuum-core →
+# core/continuum-core (commit 2cb63e019); cwd-independent --manifest-path so the
+# headless start works from any directory.
+CORE_MANIFEST="$REPO_ROOT/core/continuum-core/Cargo.toml"
 
 # ── PATH + config ────────────────────────────────────────────────────
 [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
@@ -115,5 +121,4 @@ echo "  socket:   $CONTINUUM_SOCKET"
 echo "  airc:     room=${AIRC_DEFAULT_ROOM_NAME:-?} channel=${AIRC_DEFAULT_CHANNEL:-?}"
 echo ""
 
-cd "$PROJECT_DIR/workers/continuum-core"
-exec cargo run --bin continuum-core-server $PROFILE_FLAG $CONTINUUM_FEATURES -- "$CONTINUUM_SOCKET"
+exec cargo run --manifest-path "$CORE_MANIFEST" --bin continuum-core-server $PROFILE_FLAG $CONTINUUM_FEATURES -- "$CONTINUUM_SOCKET"


### PR DESCRIPTION
## Why (the critical one)

The `src/workers/continuum-core → core/continuum-core` restructure (2cb63e019) left **dead paths** in start/build tooling. The worst broke the **canonical headless start**:

`tools/scripts/start-server.sh` ended with `cd "$PROJECT_DIR/workers/continuum-core"` — but that dir moved to `core/continuum-core`, **and** `PROJECT_DIR` resolved to `tools/` (the script itself moved under `tools/scripts/`, so `dirname SCRIPT_DIR` = `tools`, not the repo root). Under `set -e`, that `cd` aborted the script **before the core ever launched** → `npm run start-server` and the repo-root `npm start` (the headless, Node-independent path the whole grid relies on) were **dead**.

**Fix:** `REPO_ROOT` is two levels up from `tools/scripts/`, and launch uses a **cwd-independent** `cargo run --manifest-path core/continuum-core/Cargo.toml --bin continuum-core-server`. Verified that manifest resolves `continuum-core` + the `continuum-core-server` bin.

## Swept the same root cause

- **`tools/generator/generate-audio-constants.ts`** — all three paths stale (`../shared` → `tools/shared`, `../workers` → `tools/workers`); the audio-constants single-source-of-truth generator would fail if run. Fixed to `../../src/shared` + `../../core/continuum-core` (targets verified present).
- **Stale doc strings** → `core/`: HelpFormatter IPC-mixin note, two persona-ratchet error messages, `models.json` source annotation.

## Validation

`bash -n` clean; `cargo metadata --manifest-path core/continuum-core/Cargo.toml` resolves the package + server bin. Node isn't installed on this host (headless-Rust-first), so the TS generator wasn't executed — but its 3 targets all exist at the computed paths.

Part of the "complete repeatable reliable starts" cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)