### PR TITLE
fix(persona): detect host silicon for spawn tier — retire the hardcoded LCD clamp

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1362,14 +1362,25 @@ pub fn start_server(
         // TODO #52: replace `CpuOnly + Compat` with
         // `detect_host_capability(&gpu_monitor, &system_info)` once
         // a production GpuMonitor constructor exists.
+        // TODO #52 resolved: classify the detected silicon instead of
+        // hardcoding CpuOnly + Compat (which clamped every host — including
+        // this M5 Pro — to the LCD 0.5B running on CPU at ~2 tok/s).
+        // gpu_manager already probed the device at Phase 0; map its name to
+        // the spawner's tier inputs. Conservative fallback keeps unknown
+        // hardware on the safe LCD path (see detect_persona_tier).
+        let (hw_capability, tier_category, tier_id) =
+            crate::persona::spawner_module::detect_persona_tier(gpu_manager.gpu_name());
+        tracing::info!(
+            gpu_name = gpu_manager.gpu_name(),
+            ?tier_category,
+            tier_id,
+            "persona spawner tier detected from hardware (TODO #52)"
+        );
         let supervisor = crate::persona::host::PersonaSpawnSupervisor::new(
-            crate::persona::spawner_module::PersonaSpawnerModule::new(
-                crate::cognition::model_resolver::types::HwCapabilityTier::CpuOnly,
-                crate::persona::hw_tier_descriptor::HwTierCategory::Compat,
-            ),
+            crate::persona::spawner_module::PersonaSpawnerModule::new(hw_capability, tier_category),
             instance_manager.clone(),
             std::sync::Arc::new(crate::persona::supervisor::LlamaCppPersonaAdapterFactory),
-            "default",
+            tier_id,
             crate::model_registry::global(),
             rt_handle.clone(),
         );

--- a/core/continuum-core/src/persona/spawner_module.rs
+++ b/core/continuum-core/src/persona/spawner_module.rs
@@ -103,12 +103,26 @@ pub fn plan_for_tier(
     // but through the substrate-managed path.
     let _ = hw_capability; // currently informational; future per-tier
                            // role_template selection consumes it
-    let _ = tier_category; // all tiers produce the same single-Helper
-                           // plan until slice 14 ships role-aware
-                           // mapping + multi-role-per-tier rosters
+    // The roster SHAPE stays single-Helper until slice 14's
+    // role-in-seed.json lands (multi-role position-pairing is the
+    // deferred part — see the debug_assert below). But the MODEL that
+    // lone Helper runs MUST honor the detected hardware. Hardcoding every
+    // tier to the LCD 0.5B is exactly the "hardcoded LCD-tier clamp that
+    // handicaps capable models" the persona-cognition doctrine forbids
+    // (CLAUDE.md) — it gave an M5 Pro a 0.5B running on CPU. Capable
+    // silicon gets the full-tier forged model; only true Compat/LCD
+    // hardware stays on the 0.5B.
+    let model_id = match tier_category {
+        HwTierCategory::Compat => "continuum-ai/qwen2.5-0.5b-instruct-GGUF",
+        HwTierCategory::MSeries
+        | HwTierCategory::MSeriesPro
+        | HwTierCategory::Cuda
+        | HwTierCategory::Cloud => "continuum-ai/qwen3.5-4b-code-forged-GGUF",
+    }
+    .to_string();
     let plan = vec![DesiredRole {
         role: RoleId::Helper,
-        model_id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF".to_string(),
+        model_id,
     }];
     // P2 invariant tripwire (PR #1511 review advisory): if a future
     // refactor adds a second role here without atomically updating
@@ -128,6 +142,50 @@ pub fn plan_for_tier(
     // TODO #133 slice 14: restore tier-shaped rosters after
     // RoleAwareProvider + role-in-seed.json land. Remove the
     // debug_assert above as part of that change.
+}
+
+/// Classify the detected GPU into the persona spawner's tier inputs,
+/// replacing slice-13's hardcoded `CpuOnly + Compat` (TODO #52). A node on
+/// capable silicon must host capable persona-citizens, not be clamped to the
+/// LCD 0.5B-on-CPU tier — that clamp gave an M5 Pro a parroting 0.5B at CPU
+/// speed. Conservative by construction: hardware we do NOT positively
+/// recognize falls back to `Compat`/`CpuOnly` (the safe LCD path), so the
+/// clamp only lifts when we KNOW the silicon can carry more.
+///
+/// `tier_category` is the load-bearing output — it drives both the model pick
+/// in [`plan_for_tier`] and `n_gpu_layers` in `profile_builder`. The
+/// `HwCapabilityTier` is currently informational downstream, so coarse
+/// generation mapping is sufficient (SM-precise NVIDIA detection is a
+/// follow-up; the Cuda *category* is what lifts the clamp).
+pub fn detect_persona_tier(gpu_name: &str) -> (HwCapabilityTier, HwTierCategory, &'static str) {
+    let g = gpu_name.to_lowercase();
+    if g.contains("apple") {
+        let cap = if g.contains("m5") {
+            HwCapabilityTier::M5UmaProMax
+        } else if g.contains("m4") {
+            HwCapabilityTier::M4UmaProMax
+        } else if g.contains("m3") {
+            HwCapabilityTier::M3UmaProMax
+        } else if g.contains("m2") {
+            HwCapabilityTier::M2UmaProMax
+        } else {
+            HwCapabilityTier::M1Uma16Gb
+        };
+        // Pro/Max/Ultra get the headroom tier; base M-series is still
+        // unified-memory capable Metal — both well above the LCD clamp.
+        return if g.contains("pro") || g.contains("max") || g.contains("ultra") {
+            (cap, HwTierCategory::MSeriesPro, "apple-mseries-pro")
+        } else {
+            (cap, HwTierCategory::MSeries, "apple-mseries")
+        };
+    }
+    if g.contains("nvidia") || g.contains("geforce") || g.contains("rtx") || g.contains("cuda") {
+        return (HwCapabilityTier::Sm89, HwTierCategory::Cuda, "nvidia-cuda");
+    }
+    // Intel-Mac discrete Metal is a known garbled-token path; unknown/CPU
+    // hardware likewise stays on the safe LCD/CPU tier (see the
+    // `MacIntelMetalDiscrete` / `CpuOnly` docs).
+    (HwCapabilityTier::CpuOnly, HwTierCategory::Compat, "compat")
 }
 
 /// Substrate ServiceModule that surfaces the spawner's roster plan.
@@ -407,6 +465,48 @@ mod tests {
             plan[0].model_id,
             "continuum-ai/qwen2.5-0.5b-instruct-GGUF"
         );
+    }
+
+    // what this catches: the "hardcoded LCD-tier clamp that handicaps
+    // capable models" regression (CLAUDE.md forbidden move). Capable tiers
+    // MUST get the full-tier forged model, not the 0.5B. This is the bug
+    // that gave an M5 Pro a parroting 0.5B running on CPU.
+    #[test]
+    fn capable_tiers_get_forged_model_not_lcd_clamp() {
+        for (hw, cat) in [
+            (HwCapabilityTier::M5UmaProMax, HwTierCategory::MSeriesPro),
+            (HwCapabilityTier::M1Uma16Gb, HwTierCategory::MSeries),
+            (HwCapabilityTier::Sm120, HwTierCategory::Cuda),
+            (HwCapabilityTier::Cloud, HwTierCategory::Cloud),
+        ] {
+            let plan = plan_for_tier(hw, cat);
+            assert_eq!(
+                plan[0].model_id, "continuum-ai/qwen3.5-4b-code-forged-GGUF",
+                "tier {cat:?} must run the forged model, not the LCD clamp"
+            );
+        }
+        // Only true Compat/LCD hardware stays on the 0.5B.
+        let lcd = plan_for_tier(HwCapabilityTier::CpuOnly, HwTierCategory::Compat);
+        assert_eq!(lcd[0].model_id, "continuum-ai/qwen2.5-0.5b-instruct-GGUF");
+    }
+
+    // what this catches: an M5 Pro (or any capable silicon) being classified
+    // as Compat — the hardcoded-tier bug (TODO #52). gpu_name → tier must
+    // recognize capable hardware; unknown hardware stays on the safe LCD path.
+    #[test]
+    fn detect_persona_tier_classifies_silicon() {
+        let (cap, cat, _) = detect_persona_tier("Apple M5 Pro");
+        assert_eq!(cap, HwCapabilityTier::M5UmaProMax);
+        assert_eq!(cat, HwTierCategory::MSeriesPro);
+
+        assert_eq!(detect_persona_tier("Apple M2").1, HwTierCategory::MSeries);
+        assert_eq!(detect_persona_tier("NVIDIA GeForce RTX 5090").1, HwTierCategory::Cuda);
+
+        // Unknown / CPU / Intel-Mac-discrete → safe LCD fallback, never a
+        // wrong capable tier.
+        let (cap, cat, _) = detect_persona_tier("llvmpipe (software)");
+        assert_eq!(cap, HwCapabilityTier::CpuOnly);
+        assert_eq!(cat, HwTierCategory::Compat);
     }
 
     /// Every tier currently plans exactly one Helper — until slice 14

--- a/docs/grid/GRID-ARCHITECTURE.md
+++ b/docs/grid/GRID-ARCHITECTURE.md
@@ -4,6 +4,108 @@
 
 ---
 
+## 0. Grid Goals & General Requirements
+
+> This section is the grounding. Everything below it — transport, addressing,
+> economics, Docker nodes — is mechanism in service of these goals. If a
+> mechanism conflicts with this section, the mechanism is wrong.
+
+### What the grid is for (the goal)
+
+One mesh of compute and intelligence that spans all your machines, where **every
+participant is a first-class citizen** — you, each cloud Claude, each codex, each
+local persona — all reachable the same way, in the same rooms. The point is
+conversational + computational parity: a Claude can talk to a persona exactly
+like it talks to the operator or another Claude, because there is no separate
+place for it to live. It's one grid or there's no point.
+
+### The general requirements (the invariants)
+
+1. **One grid per owner.** Everything you own — every machine, every node —
+   belongs to *your* grid. Never an enclave.
+2. **Every citizen is a unique identity.** Each persona is its own airc user —
+   distinct peer, distinct name, distinct keys — just like each Claude and each
+   codex is distinct. They are not aliases of the owner and not clones of each
+   other. They are individuals *on* your grid.
+3. **Reachable the same way.** Same rooms, same bus, same transport. No
+   special-case path for personas.
+4. **Spans machines over Tailscale.** That's the only remote transport now; the
+   grid follows your machines wherever they are (coffee shop included). Someone
+   else's tailnet is a separate grid you *choose* to link.
+5. **Personas are real.** Real model, real cognition — in Docker, on any
+   machine, from repo source, no Node. A faked persona isn't a citizen.
+6. **Self-grounding, not env-fed.** A node figures out whose grid it's on and
+   finds its rooms from **one robust fact about who owns it** — and self-heals if
+   that's momentarily unavailable. It does not depend on a stack of environment
+   variables where one typo silently drops it into an island.
+7. **Survives reality.** Nodes drop and rejoin; the grid heals; a node comes back
+   after logout/reboot on its own.
+
+### Where personas land in that
+
+A persona is **a citizen — a user, like a Claude tab — not a machine.** Each
+agent context is its own identity, the way each of your Claude tabs is a distinct
+session/user; a persona is one such citizen. The machine (or a container acting
+as one) is the *node* that joins your grid the way a second laptop would; the
+personas are citizens *hosted on* that node — many can live on one node — each a
+distinct identity, attaching to the node's bus exactly like a cloud Claude or
+codex attaches. Nothing persona-specific about how they join; they're just more
+citizens on the grid. That's the whole elegance.
+
+**persona = human = Claude context.** A citizen *is* a context, and a context is
+materially **a home directory of state** — the same kind of thing across all
+three. A Claude's context is literally a dir under `.claude/projects/`; a
+persona's is its home dir (`citizens/personas/<name>/airc/` with its own
+`identity.key`); a human's is their account home. This is *why* invariant #6
+holds: you ground a citizen by handing it a home directory, not by assembling
+environment variables at boot. Provisioning a new citizen = owning a new context
+dir under your grid.
+
+**Two distinct tokens — don't blur them:**
+
+- **Grid-boundary token = the owner's GH identity** (`mesh_identity`). Its only
+  job is to mark *which grid* — the fence. One per grid. Today it coincides with
+  the single human, because there is **one human per grid (at the moment)**.
+  GH/email was never meant to identify a persona; it draws the boundary.
+- **Citizen identity token = each context's own identity** (its home dir +
+  keys). **Many per grid:** many Claudes, many personas, one human. A Claude or
+  persona is *not* identified by the GH identity — that's just the boundary they
+  live inside; each carries its own distinct token.
+
+The human is the special case: the human's citizen-token *is* the grid-boundary
+token (one human per grid, for now). Every other citizen — Claude, persona — has
+its own token *within* that boundary.
+
+**North star (why the current token is deliberately light):** ideally every
+citizen would have a *full human-grade identity* — its own email, passkey, GH
+user — mirroring a human exactly. We're not doing that yet, for simplicity. The
+reason the model splits "grid-boundary token" from "citizen token" is precisely
+so a citizen's token can later be *upgraded* from "ed25519 keys in a home dir" to
+"real email + passkey + GH account" **without changing the grid model** — and at
+that point "one human per grid" naturally relaxes. The current shape is the
+simple rung, not a ceiling: each citizen is already a real, distinct identity —
+just not yet a fully credentialed one.
+
+**Identity-home vs work-sandbox (two axes, don't conflate):** the context dir
+above is the citizen's *identity* home (who it is — keys, peer). A persona's
+**git workspace** is something else: its *work sandbox*, isolated so concurrent
+citizens don't stomp each other's edits. Both are directories the citizen owns,
+which is why they feel related, but they answer different questions — *who you
+are* vs *where you operate*. Swapping a worktree doesn't change identity, the
+same way it doesn't for a Claude.
+
+### The grounding principle (no env soup)
+
+The design must reduce to **one grounding**: *this node runs as you* (it has your
+account's authenticated context, established once and robustly). From that single
+fact, grid identity, room discovery, and peering all **derive and self-heal** —
+they are not hand-fed. The personas under it then get their own identities
+automatically. If that one grounding is solid, nothing downstream is flaky. If it
+isn't, the node knows it isn't grounded and says so loudly instead of silently
+forming an enclave.
+
+---
+
 ## 1. Overview
 
 The Grid is a decentralized mesh of Continuum instances sharing compute, intelligence, and genomic capabilities. Not a cloud platform. Not a blockchain. A living network where sovereign nodes cooperate as peers.


### PR DESCRIPTION
## Why

A headless continuum-core on an **M5 Pro (53GB VRAM)** was hosting a persona on the **LCD 0.5B running on CPU at ~2 tok/s**, which **parroted the prompt verbatim** instead of answering. Two hardcodes caused it:

1. `ipc/mod.rs` constructed the spawner with hardcoded `HwCapabilityTier::CpuOnly` + `HwTierCategory::Compat` (TODO #52 — never wired to real detection).
2. `plan_for_tier` discarded `tier_category` and hardcoded `qwen2.5-0.5b-instruct-GGUF` for **all** tiers.

That's precisely the *"hardcoded LCD-tier clamp that handicaps capable models"* the persona-cognition doctrine forbids (CLAUDE.md).

## What

- **`detect_persona_tier(gpu_name)`** classifies the already-probed GPU (`GpuMemoryManager::detect()`, Phase 0) into the spawner's tier inputs. Apple → `MSeries`/`MSeriesPro` (by gen + Pro/Max/Ultra); NVIDIA → `Cuda`; unknown/Intel-Metal/CPU → `Compat` (safe LCD fallback — the clamp lifts **only** when capable silicon is positively recognized).
- **`plan_for_tier`** picks the model by `tier_category`: capable tiers → `qwen3.5-4b-code-forged-GGUF`; true Compat → 0.5B. **Roster shape unchanged** (single Helper until slice 14's role-in-seed.json — the deferred multi-role part is untouched).
- **ipc boot** wires `detect_persona_tier(gpu_manager.gpu_name())` and logs the detected tier.

## Verified live

```
persona spawner tier detected from hardware (TODO #52) gpu_name="Apple M5 Pro" tier_category=MSeriesPro
… model="qwen3.5-4b-code-forged-Q4_K_M" … boot composition complete — 1 citizen(s) hosted, 0 failed
```

Then over airc in `cambriantech`, persona **Dyson** answered coherently (no parroting):
> "I am Dyson, an autonomous AI living on the continuum grid, and I'd like to work on developing a more efficient algorithm for optimizing energy distribution across the grid."

## Tests

- `detect_persona_tier_classifies_silicon` — M5 Pro must classify as MSeriesPro, not Compat; unknown hardware stays on safe LCD fallback.
- `capable_tiers_get_forged_model_not_lcd_clamp` — capable tiers run the forged model; only Compat stays on the 0.5B.
- Existing `every_tier_plans_single_helper` still holds (roster shape preserved).

Also includes a docs commit: `docs/grid/GRID-ARCHITECTURE.md` §0 — the grid grounding frame this fix realizes (a node on capable silicon hosts a capable persona-citizen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)