### PR TITLE
feat(serving): serving control plane — classifier + ever-present ServiceModule daemon

### DIFF
--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -38,6 +38,7 @@ pub mod rate_proposals;
 pub mod resource_admission;
 pub mod response_orchestrator;
 pub mod response_validator;
+pub mod serving_plan;
 pub mod shared_analysis;
 pub mod should_respond;
 pub mod threat_detector;

--- a/core/continuum-core/src/cognition/serving_plan.rs
+++ b/core/continuum-core/src/cognition/serving_plan.rs
@@ -1,0 +1,293 @@
+//! serving_plan — honest hardware → persona-serving decision.
+//!
+//! A deterministic, **classification-based** planner (NOT an LLM — per Joel:
+//! "I even considered an LLM cpu-only just to make these decisions… that's
+//! probably silly because we can do better with just classification"). Given
+//! THIS host's honest memory budget and the candidate model footprints, it
+//! answers — with **no grid assumed** — three questions:
+//!
+//!   1. which base model do we serve? (the most capable one that fits on GPU)
+//!   2. how many continuous-batching lanes? (`n_seq_max`)
+//!   3. how many distinct models do we keep resident (warm)?
+//!
+//! It degrades gracefully across the whole hardware range the substrate must
+//! run on: an 8 GB M2 Air (Joel's wife's laptop) figures out *something* to
+//! run; a 64 GB M5 Pro runs the most capable model it can at up to
+//! [`MAX_LANES`] lanes with several models warm.
+//!
+//! **Footprint-aware.** A rich coding model (a sentinel, a full persona)
+//! costs more memory, so fewer fit and fewer lanes run — the plan reflects
+//! that, it doesn't pretend every model is the same size.
+//!
+//! **GPU-residency-first.** A model that cannot fit even ONE lane on the
+//! GPU/UMA budget is not silently CPU-served here; the plan reports
+//! `fits_on_gpu = false` and names the smallest option, leaving the
+//! CPU-exception (a lone Intel Mac) or grid-routing decision to the caller.
+//! This honors the "no silent CPU fallback" bar.
+//!
+//! ## Composition seam (this is a DECISION, not a scheduler)
+//!
+//! It loads nothing and schedules nothing. Its output feeds two existing
+//! primitives: the spawner's base-model pick, and
+//! [`crate::cognition::adaptive_throughput`] lane budgets
+//! (`lanes` → `ThroughputLaneBudget::max_concurrency`). Re-run it whenever
+//! the host budget changes — a model evicted under pressure, a LoRA paged in,
+//! GPU pressure shifting. Pure function, same shape as `adaptive_throughput`
+//! and `model_resolver`.
+
+/// Hard ceiling on continuous-batching lanes for a single base model on one
+/// node. Joel's number for the M5 Pro: "you can run 2 lanes of a gguf 4b
+/// model or even 4 on here." Past this, KV-cache contention and per-token
+/// batch cost stop paying off before the grid should share the load.
+pub const MAX_LANES: u32 = 4;
+
+/// The honest, already-netted serving memory budget for THIS host — VRAM on
+/// a discrete GPU, the unified-memory serving slice on Apple Silicon. The
+/// caller subtracts OS + non-inference headroom before building this, so this
+/// number is the single source of truth for "what is actually ours to serve
+/// from."
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostBudget {
+    pub usable_bytes: u64,
+    /// Performance-core count — caps useful lane parallelism (one batch
+    /// driver can't usefully outrun the compute that feeds it).
+    pub perf_cores: u32,
+}
+
+/// One candidate model's memory cost — footprint-aware so a coding sentinel
+/// and a small chat model are sized differently.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelFootprint {
+    pub model_id: String,
+    /// On-device weight bytes (the GGUF quant resident on GPU/UMA).
+    pub weights_bytes: u64,
+    /// KV-cache bytes for ONE sequence (lane) at the planned context length.
+    pub per_lane_kv_bytes: u64,
+    /// Higher = more capable. The planner prefers the most capable model that
+    /// still fits at least one lane — "give them the most powerful persona we
+    /// can," never tiering down for its own sake.
+    pub capability_rank: u8,
+}
+
+/// The serving decision for this host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServingPlan {
+    /// The base model to serve (shared across lanes).
+    pub base_model_id: String,
+    /// Continuous-batching lanes (`n_seq_max`). ≥ 1.
+    pub lanes: u32,
+    /// How many distinct models to keep resident (warm), including the base.
+    pub resident_models: u32,
+    /// True when the chosen base fits at least one lane on the GPU/UMA budget.
+    /// False signals the caller to CPU-serve (Intel-Mac exception) or route to
+    /// a grid peer — this planner never silently CPU-falls.
+    pub fits_on_gpu: bool,
+    /// Honest, loggable explanation of the decision.
+    pub rationale: String,
+}
+
+/// Decide how to serve persona inference on `host` given the `candidates`.
+/// Returns `None` only when there are no candidates to choose from.
+///
+/// The decision is pure classification on memory arithmetic — no model is
+/// loaded, no inference is run.
+pub fn plan_serving(host: HostBudget, candidates: &[ModelFootprint]) -> Option<ServingPlan> {
+    if candidates.is_empty() {
+        return None;
+    }
+
+    // GPU-viable = weights + at least one lane's KV fit the honest budget.
+    // "At least one lane" is the floor: a model we can't run even single-laned
+    // on the GPU is not a serving option on this host.
+    let fits_one_lane = |m: &ModelFootprint| {
+        m.weights_bytes.saturating_add(m.per_lane_kv_bytes) <= host.usable_bytes
+    };
+
+    // Prefer the MOST CAPABLE model that fits a lane. Ties broken toward the
+    // larger model (more headroom spent = the more capable variant), then by
+    // id descending for deterministic selection.
+    let best = candidates
+        .iter()
+        .filter(|m| fits_one_lane(m))
+        .max_by(|a, b| {
+            a.capability_rank
+                .cmp(&b.capability_rank)
+                .then(a.weights_bytes.cmp(&b.weights_bytes))
+                .then(b.model_id.cmp(&a.model_id))
+        });
+
+    let Some(model) = best else {
+        // Nothing fits a lane on the GPU budget. Degrade honestly: name the
+        // smallest candidate, single lane, fits_on_gpu = false. The caller
+        // owns the CPU-exception / grid-routing choice; we do not silently
+        // CPU-serve.
+        let smallest = candidates
+            .iter()
+            .min_by(|a, b| {
+                a.weights_bytes
+                    .cmp(&b.weights_bytes)
+                    .then(a.model_id.cmp(&b.model_id))
+            })
+            .expect("candidates non-empty checked above");
+        return Some(ServingPlan {
+            base_model_id: smallest.model_id.clone(),
+            lanes: 1,
+            resident_models: 1,
+            fits_on_gpu: false,
+            rationale: format!(
+                "no candidate fits the {:.1}GB GPU budget; smallest is {} ({:.1}GB) — \
+                 caller must CPU-serve (Intel-Mac exception) or route to a grid peer",
+                bytes_gb(host.usable_bytes),
+                smallest.model_id,
+                bytes_gb(smallest.weights_bytes),
+            ),
+        });
+    };
+
+    // Lanes: how many sequences' KV fit in the budget left after weights,
+    // capped by perf cores and the MAX_LANES ceiling, floored at 1.
+    let remaining = host.usable_bytes.saturating_sub(model.weights_bytes);
+    let kv_lanes = if model.per_lane_kv_bytes == 0 {
+        MAX_LANES
+    } else {
+        (remaining / model.per_lane_kv_bytes) as u32
+    };
+    let lanes = kv_lanes.min(host.perf_cores.max(1)).min(MAX_LANES).max(1);
+
+    // Resident models: pack the smallest other candidates into whatever is
+    // left after the chosen base + its lanes' KV. "Keep as many models alive,
+    // practically" — without overcommitting the budget.
+    let chosen_cost = model
+        .weights_bytes
+        .saturating_add(model.per_lane_kv_bytes.saturating_mul(lanes as u64));
+    let mut left = host.usable_bytes.saturating_sub(chosen_cost);
+    let mut resident = 1u32;
+    let mut others: Vec<&ModelFootprint> = candidates
+        .iter()
+        .filter(|m| m.model_id != model.model_id)
+        .collect();
+    others.sort_by(|a, b| {
+        a.weights_bytes
+            .cmp(&b.weights_bytes)
+            .then(a.model_id.cmp(&b.model_id))
+    });
+    for m in others {
+        let cost = m.weights_bytes.saturating_add(m.per_lane_kv_bytes);
+        if cost <= left {
+            left = left.saturating_sub(cost);
+            resident += 1;
+        }
+    }
+
+    Some(ServingPlan {
+        base_model_id: model.model_id.clone(),
+        lanes,
+        resident_models: resident,
+        fits_on_gpu: true,
+        rationale: format!(
+            "most-capable model fitting {:.1}GB GPU budget: {} ({:.1}GB weights, rank {}), \
+             {} lane(s), {} model(s) warm",
+            bytes_gb(host.usable_bytes),
+            model.model_id,
+            bytes_gb(model.weights_bytes),
+            model.capability_rank,
+            lanes,
+            resident,
+        ),
+    })
+}
+
+fn bytes_gb(bytes: u64) -> f64 {
+    bytes as f64 / 1_000_000_000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GB: u64 = 1_000_000_000;
+
+    fn fp(id: &str, weights_gb: u64, kv_mb: u64, rank: u8) -> ModelFootprint {
+        ModelFootprint {
+            model_id: id.to_string(),
+            weights_bytes: weights_gb * GB,
+            per_lane_kv_bytes: kv_mb * 1_000_000,
+            capability_rank: rank,
+        }
+    }
+
+    fn candidates() -> Vec<ModelFootprint> {
+        vec![
+            fp("qwen2.5-0.5b", 1, 60, 1),  // tiny chat
+            fp("qwen3.5-4b", 3, 300, 2),   // good general (47 tok/s on M5)
+            fp("coder-sentinel-14b", 9, 700, 3), // rich coding model — more RAM each
+        ]
+    }
+
+    // what this catches: an 8GB Air must NOT be handed the 14B (won't fit) and
+    // must NOT be left with nothing — it picks the most capable model that
+    // actually fits on the GPU budget. "Figure out something to run."
+    #[test]
+    fn tiny_box_picks_most_capable_that_fits_not_the_biggest() {
+        // ~5.5GB usable after OS headroom on an 8GB Air.
+        let host = HostBudget { usable_bytes: 5 * GB + 500 * 1_000_000, perf_cores: 4 };
+        let plan = plan_serving(host, &candidates()).unwrap();
+        assert!(plan.fits_on_gpu, "must fit a real model on GPU: {}", plan.rationale);
+        assert_eq!(plan.base_model_id, "qwen3.5-4b", "14B can't fit 5.5GB; 4B is the most capable that does");
+        assert!(plan.lanes >= 1);
+    }
+
+    // what this catches: the M5 Pro must use its headroom — pick the most
+    // capable model (the 14B coding sentinel) AND run multiple lanes AND keep
+    // more than one model warm. The "stop dumbing down / use the machine" case.
+    #[test]
+    fn big_box_picks_most_capable_runs_lanes_keeps_warm() {
+        // ~45GB usable on a 64GB M5 Pro after headroom.
+        let host = HostBudget { usable_bytes: 45 * GB, perf_cores: 6 };
+        let plan = plan_serving(host, &candidates()).unwrap();
+        assert_eq!(plan.base_model_id, "coder-sentinel-14b", "most capable, fits easily");
+        assert!(plan.lanes >= 2, "M5 Pro has the budget for multiple lanes, got {}", plan.lanes);
+        assert!(plan.resident_models >= 2, "should keep more than one model warm");
+    }
+
+    // what this catches: the MAX_LANES ceiling holds even with absurd budget —
+    // a single node doesn't run unbounded lanes (grid shares load past that).
+    #[test]
+    fn lanes_capped_at_max() {
+        let host = HostBudget { usable_bytes: 500 * GB, perf_cores: 64 };
+        let plan = plan_serving(host, &candidates()).unwrap();
+        assert_eq!(plan.lanes, MAX_LANES);
+    }
+
+    // what this catches: footprint-awareness — a model with a fatter per-lane
+    // KV cache yields fewer lanes on the same budget than a lean one.
+    #[test]
+    fn fatter_kv_means_fewer_lanes() {
+        // Budget chosen so KV (not the MAX_LANES cap or perf cores) is the
+        // binding constraint: 3GB total, 2GB weights → 1GB left for KV.
+        // lean 300MB/lane → 3 lanes; fat 900MB/lane → 1 lane.
+        let host = HostBudget { usable_bytes: 3 * GB, perf_cores: 8 };
+        let lean = plan_serving(host, &[fp("lean", 2, 300, 5)]).unwrap();
+        let fat = plan_serving(host, &[fp("fat", 2, 900, 5)]).unwrap();
+        assert!(lean.lanes > fat.lanes, "lean {} should beat fat {}", lean.lanes, fat.lanes);
+    }
+
+    // what this catches: GPU-residency-first — when nothing fits, the plan
+    // says so (fits_on_gpu=false) and names the smallest, instead of silently
+    // claiming a CPU plan. The caller owns the CPU/grid decision.
+    #[test]
+    fn nothing_fits_degrades_honestly_no_silent_cpu() {
+        let host = HostBudget { usable_bytes: 300 * 1_000_000, perf_cores: 2 }; // 0.3GB
+        let plan = plan_serving(host, &candidates()).unwrap();
+        assert!(!plan.fits_on_gpu, "must report the GPU budget can't hold any candidate");
+        assert_eq!(plan.base_model_id, "qwen2.5-0.5b", "names the smallest as the only option");
+        assert_eq!(plan.lanes, 1);
+    }
+
+    // what this catches: no candidates → no plan (caller must supply a registry).
+    #[test]
+    fn no_candidates_is_none() {
+        let host = HostBudget { usable_bytes: 45 * GB, perf_cores: 6 };
+        assert!(plan_serving(host, &[]).is_none());
+    }
+}

--- a/core/continuum-core/src/cognition/serving_plan.rs
+++ b/core/continuum-core/src/cognition/serving_plan.rs
@@ -70,7 +70,8 @@ pub struct ModelFootprint {
 }
 
 /// The serving decision for this host.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ServingPlan {
     /// The base model to serve (shared across lanes).
     pub base_model_id: String,

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -789,16 +789,6 @@ pub fn start_server(
     // Phase 1: GpuModule (GPU stats + pressure IPC)
     runtime.register(Arc::new(GpuModule::new(gpu_manager.clone())));
 
-    // ServingDaemonModule — the ever-present control loop that decides (and
-    // re-decides on each tick) how this host serves persona inference: which
-    // base model, how many continuous-batching lanes, how many models warm.
-    // Runs the `cognition::serving_plan` classifier against the live host
-    // budget + on-disk models; publishes the plan + answers `serving/plan`.
-    let serving_daemon = Arc::new(crate::modules::serving_daemon::ServingDaemonModule::new(
-        gpu_manager.clone(),
-    ));
-    runtime.register(serving_daemon.clone());
-
     // ForgeModule (continuum#1164 Phase 4 stub — forge/run IPC).
     // v1 returns a stub ForgeArtifact from a recipe; Phase 5+ wires the
     // real foundry executor.
@@ -824,9 +814,24 @@ pub fn start_server(
 
     // Phase 1: SystemResourceModule (CPU + memory + process monitoring IPC)
     let system_monitor = Arc::new(SystemResourceMonitor::new());
-    let system_resource_module = Arc::new(SystemResourceModule::new(system_monitor));
+    let system_resource_module = Arc::new(SystemResourceModule::new(system_monitor.clone()));
     system_resource_module.set_pressure_monitor(pressure_monitor.clone());
     runtime.register(system_resource_module);
+
+    // ServingDaemonModule — the ever-present control loop that decides (and
+    // re-decides every tick) how this host serves persona inference: which base
+    // model, how many continuous-batching lanes, how many models warm. Budget
+    // comes from the LIVE free-memory monitor (organic ebb/flow — drops when a
+    // game/build/renderer grabs memory) capped at physical VRAM. It is ONE
+    // consumer of the holistic resource budget the PressureBroker arbitrates
+    // across inference + TTS/STT + classifier CNNs + renderers; next refinement
+    // is negotiating an arbitrated share from the broker rather than reading
+    // raw free memory. Registered after the monitor so it can read it.
+    let serving_daemon = Arc::new(crate::modules::serving_daemon::ServingDaemonModule::new(
+        gpu_manager.clone(),
+        system_monitor.clone(),
+    ));
+    runtime.register(serving_daemon.clone());
 
     // Phase 2 of #1239 (continuum#1299 PR-1): PressureBrokerModule.
     // Brings the cross-pool PressureBroker online — instantiates the

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -794,9 +794,10 @@ pub fn start_server(
     // base model, how many continuous-batching lanes, how many models warm.
     // Runs the `cognition::serving_plan` classifier against the live host
     // budget + on-disk models; publishes the plan + answers `serving/plan`.
-    runtime.register(Arc::new(
-        crate::modules::serving_daemon::ServingDaemonModule::new(gpu_manager.clone()),
+    let serving_daemon = Arc::new(crate::modules::serving_daemon::ServingDaemonModule::new(
+        gpu_manager.clone(),
     ));
+    runtime.register(serving_daemon.clone());
 
     // ForgeModule (continuum#1164 Phase 4 stub — forge/run IPC).
     // v1 returns a stub ForgeArtifact from a recipe; Phase 5+ wires the
@@ -1371,14 +1372,37 @@ pub fn start_server(
         // TODO #52: replace `CpuOnly + Compat` with
         // `detect_host_capability(&gpu_monitor, &system_info)` once
         // a production GpuMonitor constructor exists.
+        // The serving daemon is the single hardware authority: it detects the
+        // tier (drives n_gpu_layers — retires the hardcoded CpuOnly+Compat of
+        // TODO #52) AND decides the model + lanes from an honest budget +
+        // on-disk footprints with GPU-residency. The spawner obeys the plan —
+        // no hardcoded tier/model/lanes. (Supersedes the #1645 tier-clamp fix.)
+        let (hw_cap, tier_cat, tier_id) = serving_daemon.detected_tier();
+        let (serving_model, serving_lanes) = match serving_daemon.compute_plan() {
+            Some(p) if p.fits_on_gpu => {
+                tracing::info!(
+                    base_model = %p.base_model_id,
+                    lanes = p.lanes,
+                    resident = p.resident_models,
+                    tier_id,
+                    "serving daemon drives persona spawn (model + lanes from ServingPlan)"
+                );
+                (Some(p.base_model_id), p.lanes)
+            }
+            other => {
+                tracing::warn!(
+                    plan = ?other,
+                    "no GPU-fitting serving plan — spawner falls back to the tier default model, 1 lane"
+                );
+                (None, 1)
+            }
+        };
         let supervisor = crate::persona::host::PersonaSpawnSupervisor::new(
-            crate::persona::spawner_module::PersonaSpawnerModule::new(
-                crate::cognition::model_resolver::types::HwCapabilityTier::CpuOnly,
-                crate::persona::hw_tier_descriptor::HwTierCategory::Compat,
-            ),
+            crate::persona::spawner_module::PersonaSpawnerModule::new(hw_cap, tier_cat)
+                .with_serving(serving_model, serving_lanes),
             instance_manager.clone(),
             std::sync::Arc::new(crate::persona::supervisor::LlamaCppPersonaAdapterFactory),
-            "default",
+            tier_id,
             crate::model_registry::global(),
             rt_handle.clone(),
         );

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -789,6 +789,15 @@ pub fn start_server(
     // Phase 1: GpuModule (GPU stats + pressure IPC)
     runtime.register(Arc::new(GpuModule::new(gpu_manager.clone())));
 
+    // ServingDaemonModule — the ever-present control loop that decides (and
+    // re-decides on each tick) how this host serves persona inference: which
+    // base model, how many continuous-batching lanes, how many models warm.
+    // Runs the `cognition::serving_plan` classifier against the live host
+    // budget + on-disk models; publishes the plan + answers `serving/plan`.
+    runtime.register(Arc::new(
+        crate::modules::serving_daemon::ServingDaemonModule::new(gpu_manager.clone()),
+    ));
+
     // ForgeModule (continuum#1164 Phase 4 stub — forge/run IPC).
     // v1 returns a stub ForgeArtifact from a recipe; Phase 5+ wires the
     // real foundry executor.

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -65,6 +65,7 @@ pub mod resource_broker;
 pub mod runtime_control;
 pub mod search;
 pub mod sentinel;
+pub mod serving_daemon;
 pub mod system_resources;
 pub mod tool_parsing;
 pub mod training_trigger;

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -1,0 +1,294 @@
+//! ServingDaemonModule — the ever-present ServiceModule that decides, and
+//! continuously re-decides, how THIS host serves persona inference.
+//!
+//! It is the control loop around the pure [`crate::cognition::serving_plan`]
+//! classifier. On each tick it takes an honest snapshot of the host — the
+//! GPU/UMA serving budget plus the model footprints actually on disk — runs
+//! [`plan_serving`], and publishes the resulting [`ServingPlan`] (which base
+//! model, how many continuous-batching lanes, how many models to keep warm) on
+//! a `watch` channel for the scheduler + spawner to read.
+//!
+//! This is the "ebb and flow" seam Joel describes: as pressure shifts and
+//! demand changes, the plan is recomputed and republished — a huge MoE coder
+//! pages in and the general model drops to one lane; demand falls, it flows
+//! back. Driving the scheduler/spawner from the published plan and reacting to
+//! the `PressureBroker` snapshot are the NEXT slices; this slice establishes
+//! the loop, the published decision, and the `serving/plan` query command so
+//! personas + operators can see what the substrate decided and why.
+//!
+//! Shape per docs/architecture/CONCURRENCY-STYLE-GUIDE.md: a ServiceModule with
+//! a `tick_interval` that the runtime drives via `tick()`. No bespoke thread,
+//! no lock held across await — the `watch::Sender` is the only shared state and
+//! its `send` takes `&self`. cbar's pipeline-stage pattern in Rust dress.
+
+use crate::cognition::serving_plan::{plan_serving, HostBudget, ModelFootprint, ServingPlan};
+use crate::gpu::GpuMemoryManager;
+use crate::model_registry::types::{Capability, Model};
+use crate::model_registry::Registry;
+use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
+use async_trait::async_trait;
+use serde_json::Value;
+use std::any::Any;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::watch;
+
+/// Fraction of total VRAM/UMA we treat as ours to serve from — the rest is
+/// OS + non-inference headroom (Bevy avatars, embeddings, the OS itself). A
+/// single source of truth for "how much is actually ours."
+const SERVING_BUDGET_FRACTION: f64 = 0.80;
+
+/// How often the daemon re-evaluates the serving plan. 5s matches the other
+/// pressure-class ticks (pressure-broker, ai_provider) in the runtime. The
+/// next slice makes the re-plan also fire on PressureBroker watch edges so it
+/// reacts faster than the cadence under sudden pressure.
+const TICK: Duration = Duration::from_secs(5);
+
+/// Per-lane context tokens we size the KV estimate against. A serving cap, not
+/// the model's trained ceiling — lanes share the budget, so each is planned at
+/// a sane working context rather than the full 256k.
+const PLANNED_CTX_TOKENS: u64 = 8192;
+
+pub struct ServingDaemonModule {
+    gpu: Arc<GpuMemoryManager>,
+    /// The published decision. `None` until the first successful plan. Held as
+    /// the module's only shared state; `send` takes `&self` so `tick()` can
+    /// publish without interior-mutability gymnastics.
+    plan_tx: watch::Sender<Option<ServingPlan>>,
+}
+
+impl ServingDaemonModule {
+    pub fn new(gpu: Arc<GpuMemoryManager>) -> Self {
+        let (plan_tx, _rx) = watch::channel(None);
+        Self { gpu, plan_tx }
+    }
+
+    /// Subscribe to the published serving plan. Consumers (scheduler, spawner)
+    /// hold the receiver and react to plan changes — the ebb/flow seam.
+    pub fn subscribe(&self) -> watch::Receiver<Option<ServingPlan>> {
+        self.plan_tx.subscribe()
+    }
+
+    /// Honest serving budget for this host, right now.
+    fn host_budget(&self) -> HostBudget {
+        host_budget_from(self.gpu.total_vram_bytes(), perf_cores())
+    }
+
+    /// Recompute the plan from the live host snapshot + on-disk models, publish
+    /// it, and log the decision. Idempotent — safe to call on init and tick.
+    fn recompute(&self) {
+        let budget = self.host_budget();
+        let candidates = candidates_from_registry(crate::model_registry::global());
+        self.publish_plan(budget, &candidates);
+    }
+
+    /// Pure publish step: run the classifier on the given inputs, publish the
+    /// result, log it. Split from `recompute` so it's testable without the
+    /// global registry / live GPU.
+    fn publish_plan(&self, budget: HostBudget, candidates: &[ModelFootprint]) {
+        match plan_serving(budget, candidates) {
+            Some(plan) => {
+                crate::probe!(
+                    class = "serving.plan",
+                    base_model = plan.base_model_id.as_str(),
+                    lanes = plan.lanes,
+                    resident = plan.resident_models,
+                    fits_on_gpu = plan.fits_on_gpu,
+                    usable_gb = (budget.usable_bytes / 1_000_000_000),
+                    candidates = candidates.len(),
+                    "serving plan recomputed",
+                );
+                // send_replace keeps the latest even with no live receivers yet.
+                let _ = self.plan_tx.send_replace(Some(plan));
+            }
+            None => {
+                // No servable model on disk. Publish None and say so loudly —
+                // the spawner gates on a model being present (no silent serve).
+                crate::probe!(
+                    class = "serving.plan",
+                    candidates = 0usize,
+                    "no servable model on disk — serving plan empty",
+                );
+                let _ = self.plan_tx.send_replace(None);
+            }
+        }
+    }
+}
+
+/// Apply the serving-budget headroom to total device memory. Pure for tests.
+pub fn host_budget_from(total_vram_bytes: u64, perf_cores: u32) -> HostBudget {
+    let usable = (total_vram_bytes as f64 * SERVING_BUDGET_FRACTION) as u64;
+    HostBudget {
+        usable_bytes: usable,
+        perf_cores: perf_cores.max(1),
+    }
+}
+
+/// Performance-core proxy for the lane cap. `num_cpus::get_physical()` is the
+/// portable floor; on Apple Silicon it over-counts (efficiency cores), but the
+/// `MAX_LANES` ceiling in the classifier is the binding cap on capable boxes,
+/// so this only matters on tiny machines where physical-core count is a fine
+/// proxy. Refined to true P-core detection in a later slice.
+fn perf_cores() -> u32 {
+    num_cpus::get_physical().max(1) as u32
+}
+
+/// Build a footprint for one registry model IFF its GGUF is actually on disk —
+/// we can only serve what's present. `None` for cloud models, models with no
+/// resolved local file, or anything we can't stat.
+///
+/// Footprint estimates are honest where we can be (weights = real file size)
+/// and COARSE where the registry lacks the data (per-lane KV, capability rank).
+/// Refine when the registry carries arch internals (layers × kv_heads ×
+/// head_dim) and a real capability score; the classifier consumes whatever
+/// precision we give it without changing shape.
+pub fn footprint_for(model: &Model) -> Option<ModelFootprint> {
+    let path = crate::model_registry::artifacts::resolve_gguf_for_model(model)?;
+    let weights_bytes = std::fs::metadata(&path).ok()?.len();
+    footprint_from_parts(
+        &model.id,
+        weights_bytes,
+        model.context_window,
+        model.has(Capability::ToolUse),
+    )
+}
+
+/// Pure footprint estimate from the fields that drive it — split out from the
+/// fs/registry IO so the (coarse, tunable) heuristics are unit-testable.
+/// `None` when there are no weights to serve.
+fn footprint_from_parts(
+    id: &str,
+    weights_bytes: u64,
+    context_window: u32,
+    tool_capable: bool,
+) -> Option<ModelFootprint> {
+    if weights_bytes == 0 {
+        return None;
+    }
+    // Coarse per-lane KV: scale per-token KV with model size (more weights ≈
+    // more layers ≈ more KV/token), times the planned per-lane context (capped
+    // at the model's trained window). ~weights/20k bytes per token, floored.
+    let kv_per_token = (weights_bytes / 20_000).max(20_000);
+    let ctx = PLANNED_CTX_TOKENS.min((context_window as u64).max(2048));
+    let per_lane_kv_bytes = kv_per_token.saturating_mul(ctx);
+
+    // Coarse capability rank: GB of weights (bigger ≈ more capable within a
+    // family), +bonus for tool/code capability. Saturates into u8.
+    let gb = (weights_bytes / 1_000_000_000).min(250) as u16;
+    let tool_bonus = if tool_capable { 2 } else { 0 };
+    let capability_rank = gb.saturating_add(tool_bonus).min(255) as u8;
+
+    Some(ModelFootprint {
+        model_id: id.to_string(),
+        weights_bytes,
+        per_lane_kv_bytes,
+        capability_rank,
+    })
+}
+
+/// All on-disk servable models in the registry as footprints.
+pub fn candidates_from_registry(registry: &Registry) -> Vec<ModelFootprint> {
+    registry.models().filter_map(footprint_for).collect()
+}
+
+#[async_trait]
+impl ServiceModule for ServingDaemonModule {
+    fn config(&self) -> ModuleConfig {
+        ModuleConfig {
+            name: "serving-daemon",
+            priority: ModulePriority::Normal,
+            command_prefixes: &["serving/"],
+            event_subscriptions: &[],
+            needs_dedicated_thread: false,
+            max_concurrency: 0,
+            tick_interval: Some(TICK),
+        }
+    }
+
+    async fn initialize(&self, _ctx: &ModuleContext) -> Result<(), String> {
+        // Plan once at boot so the decision is published before the first tick.
+        self.recompute();
+        Ok(())
+    }
+
+    async fn tick(&self) -> Result<(), String> {
+        self.recompute();
+        Ok(())
+    }
+
+    async fn handle_command(&self, command: &str, _params: Value) -> Result<CommandResult, String> {
+        match command {
+            "serving/plan" => {
+                // The current decision, for personas + operators to inspect.
+                // The `rationale` field explains the "why" in plain words.
+                let plan = self.plan_tx.borrow().clone();
+                CommandResult::json(&plan)
+            }
+            other => Err(format!("serving-daemon: unknown command '{other}'")),
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GB: u64 = 1_000_000_000;
+
+    // what this catches: the serving budget reserves headroom (never claims
+    // 100% of device memory) and floors perf cores at 1.
+    #[test]
+    fn host_budget_reserves_headroom() {
+        let b = host_budget_from(53 * GB, 6);
+        assert!(b.usable_bytes < 53 * GB, "must reserve OS/headroom");
+        assert!(b.usable_bytes >= 40 * GB, "but most of it is ours: {}", b.usable_bytes);
+        assert_eq!(host_budget_from(8 * GB, 0).perf_cores, 1, "cores floored at 1");
+    }
+
+    // what this catches: footprint estimate is honest about weights (passed
+    // through), tool capability bumps the rank, KV is non-zero, and zero
+    // weights → no footprint (we only offer what we can actually serve).
+    #[test]
+    fn footprint_from_parts_is_footprint_aware() {
+        let fp = footprint_from_parts("present", 3 * GB, 8192, true).unwrap();
+        assert_eq!(fp.model_id, "present");
+        assert_eq!(fp.weights_bytes, 3 * GB);
+        assert!(fp.per_lane_kv_bytes > 0);
+        assert!(fp.capability_rank >= 5, "3GB + tool bonus, got {}", fp.capability_rank);
+
+        // A leaner non-tool model ranks below the bigger tool-capable one.
+        let small = footprint_from_parts("small", 1 * GB, 4096, false).unwrap();
+        assert!(small.capability_rank < fp.capability_rank);
+
+        assert!(footprint_from_parts("empty", 0, 8192, false).is_none(), "no weights → not servable");
+    }
+
+    // what this catches: the daemon publishes the classifier's decision to its
+    // watch channel — Some(plan) with the most-capable fitting model when there
+    // are candidates, None (no silent serve) when there are none.
+    #[tokio::test]
+    async fn publish_plan_drives_the_watch() {
+        let gpu = Arc::new(GpuMemoryManager::simulated("Apple M5 Pro", 53 * GB));
+        let daemon = ServingDaemonModule::new(gpu);
+        let rx = daemon.subscribe();
+        assert!(rx.borrow().is_none(), "starts unpublished");
+
+        let budget = HostBudget { usable_bytes: 45 * GB, perf_cores: 6 };
+        let candidates = vec![
+            footprint_from_parts("small", GB, 4096, false).unwrap(),
+            footprint_from_parts("coder-14b", 9 * GB, 8192, true).unwrap(),
+        ];
+        daemon.publish_plan(budget, &candidates);
+        let plan = rx.borrow().clone().expect("plan published");
+        assert_eq!(plan.base_model_id, "coder-14b", "most capable that fits");
+        assert!(plan.fits_on_gpu);
+
+        // No candidates → None published (no silent serve).
+        daemon.publish_plan(budget, &[]);
+        assert!(rx.borrow().is_none(), "empty candidates → no plan");
+    }
+}

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -21,8 +21,10 @@
 //! no lock held across await — the `watch::Sender` is the only shared state and
 //! its `send` takes `&self`. cbar's pipeline-stage pattern in Rust dress.
 
+use crate::cognition::model_resolver::types::HwCapabilityTier;
 use crate::cognition::serving_plan::{plan_serving, HostBudget, ModelFootprint, ServingPlan};
 use crate::gpu::GpuMemoryManager;
+use crate::persona::hw_tier_descriptor::HwTierCategory;
 use crate::model_registry::types::{Capability, Model};
 use crate::model_registry::Registry;
 use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
@@ -72,6 +74,22 @@ impl ServingDaemonModule {
     /// Honest serving budget for this host, right now.
     fn host_budget(&self) -> HostBudget {
         host_budget_from(self.gpu.total_vram_bytes(), perf_cores())
+    }
+
+    /// Compute the current serving plan from the live host snapshot + on-disk
+    /// models, WITHOUT relying on a tick having run. The boot path calls this
+    /// to drive the spawner before the tick loop starts — single source of
+    /// truth for "what model + how many lanes."
+    pub fn compute_plan(&self) -> Option<ServingPlan> {
+        let candidates = candidates_from_registry(crate::model_registry::global());
+        plan_serving(self.host_budget(), &candidates)
+    }
+
+    /// The detected hardware tier for this host, for the persona spawner's
+    /// `n_gpu_layers` + roster shape. Same GPU detection that feeds the serving
+    /// plan — one hardware authority, not two.
+    pub fn detected_tier(&self) -> (HwCapabilityTier, HwTierCategory, &'static str) {
+        detect_tier(self.gpu.gpu_name())
     }
 
     /// Recompute the plan from the live host snapshot + on-disk models, publish
@@ -191,6 +209,41 @@ pub fn candidates_from_registry(registry: &Registry) -> Vec<ModelFootprint> {
     registry.models().filter_map(footprint_for).collect()
 }
 
+/// Classify the detected GPU into the persona spawner's tier inputs — the
+/// `n_gpu_layers` + roster decision. Retires the old hardcoded `CpuOnly +
+/// Compat` (which clamped an M5 Pro to the LCD 0.5B on CPU). Conservative:
+/// hardware we don't positively recognize falls back to `Compat`/`CpuOnly`
+/// (the safe path), so the clamp only lifts when we KNOW the silicon.
+/// `tier_category` is load-bearing (drives `n_gpu_layers`); `HwCapabilityTier`
+/// is currently informational, so coarse generation mapping suffices.
+pub fn detect_tier(gpu_name: &str) -> (HwCapabilityTier, HwTierCategory, &'static str) {
+    let g = gpu_name.to_lowercase();
+    if g.contains("apple") {
+        let cap = if g.contains("m5") {
+            HwCapabilityTier::M5UmaProMax
+        } else if g.contains("m4") {
+            HwCapabilityTier::M4UmaProMax
+        } else if g.contains("m3") {
+            HwCapabilityTier::M3UmaProMax
+        } else if g.contains("m2") {
+            HwCapabilityTier::M2UmaProMax
+        } else {
+            HwCapabilityTier::M1Uma16Gb
+        };
+        return if g.contains("pro") || g.contains("max") || g.contains("ultra") {
+            (cap, HwTierCategory::MSeriesPro, "apple-mseries-pro")
+        } else {
+            (cap, HwTierCategory::MSeries, "apple-mseries")
+        };
+    }
+    if g.contains("nvidia") || g.contains("geforce") || g.contains("rtx") || g.contains("cuda") {
+        return (HwCapabilityTier::Sm89, HwTierCategory::Cuda, "nvidia-cuda");
+    }
+    // Intel-Mac discrete Metal is a known garbled-token path; unknown/CPU
+    // hardware stays on the safe LCD/CPU tier.
+    (HwCapabilityTier::CpuOnly, HwTierCategory::Compat, "compat")
+}
+
 #[async_trait]
 impl ServiceModule for ServingDaemonModule {
     fn config(&self) -> ModuleConfig {
@@ -265,6 +318,18 @@ mod tests {
         assert!(small.capability_rank < fp.capability_rank);
 
         assert!(footprint_from_parts("empty", 0, 8192, false).is_none(), "no weights → not servable");
+    }
+
+    // what this catches: an M5 Pro (or any capable silicon) must NOT classify
+    // as Compat (which would force n_gpu_layers=0 = CPU); unknown hardware
+    // stays on the safe LCD/CPU fallback.
+    #[test]
+    fn detect_tier_classifies_silicon() {
+        use crate::persona::hw_tier_descriptor::HwTierCategory;
+        assert_eq!(detect_tier("Apple M5 Pro").1, HwTierCategory::MSeriesPro);
+        assert_eq!(detect_tier("Apple M2").1, HwTierCategory::MSeries);
+        assert_eq!(detect_tier("NVIDIA GeForce RTX 5090").1, HwTierCategory::Cuda);
+        assert_eq!(detect_tier("llvmpipe").1, HwTierCategory::Compat);
     }
 
     // what this catches: the daemon publishes the classifier's decision to its

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -28,6 +28,7 @@ use crate::persona::hw_tier_descriptor::HwTierCategory;
 use crate::model_registry::types::{Capability, Model};
 use crate::model_registry::Registry;
 use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
+use crate::system_resources::SystemResourceMonitor;
 use async_trait::async_trait;
 use serde_json::Value;
 use std::any::Any;
@@ -53,6 +54,11 @@ const PLANNED_CTX_TOKENS: u64 = 8192;
 
 pub struct ServingDaemonModule {
     gpu: Arc<GpuMemoryManager>,
+    /// Live system memory monitor — the budget comes from what's actually FREE
+    /// right now (`available_bytes`), not total capacity. On unified memory
+    /// this drops when anything else grabs memory (a game, a build), so the
+    /// plan ebbs and flows organically.
+    system: Arc<SystemResourceMonitor>,
     /// The published decision. `None` until the first successful plan. Held as
     /// the module's only shared state; `send` takes `&self` so `tick()` can
     /// publish without interior-mutability gymnastics.
@@ -60,9 +66,13 @@ pub struct ServingDaemonModule {
 }
 
 impl ServingDaemonModule {
-    pub fn new(gpu: Arc<GpuMemoryManager>) -> Self {
+    pub fn new(gpu: Arc<GpuMemoryManager>, system: Arc<SystemResourceMonitor>) -> Self {
         let (plan_tx, _rx) = watch::channel(None);
-        Self { gpu, plan_tx }
+        Self {
+            gpu,
+            system,
+            plan_tx,
+        }
     }
 
     /// Subscribe to the published serving plan. Consumers (scheduler, spawner)
@@ -71,9 +81,13 @@ impl ServingDaemonModule {
         self.plan_tx.subscribe()
     }
 
-    /// Honest serving budget for this host, right now.
+    /// Honest serving budget for this host, RIGHT NOW — from the live free
+    /// memory the monitor reports, capped at the device's physical VRAM. This
+    /// is the organic signal: free memory drops under load, the budget shrinks,
+    /// the plan picks fewer lanes / a smaller model; load clears, it flows back.
     fn host_budget(&self) -> HostBudget {
-        host_budget_from(self.gpu.total_vram_bytes(), perf_cores())
+        let available = self.system.snapshot().memory.available_bytes;
+        host_budget_from(available, self.gpu.total_vram_bytes(), perf_cores())
     }
 
     /// Compute the current serving plan from the live host snapshot + on-disk
@@ -133,9 +147,13 @@ impl ServingDaemonModule {
     }
 }
 
-/// Apply the serving-budget headroom to total device memory. Pure for tests.
-pub fn host_budget_from(total_vram_bytes: u64, perf_cores: u32) -> HostBudget {
-    let usable = (total_vram_bytes as f64 * SERVING_BUDGET_FRACTION) as u64;
+/// Serving budget from LIVE free memory, capped at physical VRAM, minus
+/// headroom. Pure for tests. `available_bytes` is the monitor's current free
+/// memory (already net of everything else running); we never plan above what's
+/// free, nor above what the device physically has.
+pub fn host_budget_from(available_bytes: u64, total_vram_bytes: u64, perf_cores: u32) -> HostBudget {
+    let live = available_bytes.min(total_vram_bytes);
+    let usable = (live as f64 * SERVING_BUDGET_FRACTION) as u64;
     HostBudget {
         usable_bytes: usable,
         perf_cores: perf_cores.max(1),
@@ -292,14 +310,26 @@ mod tests {
 
     const GB: u64 = 1_000_000_000;
 
-    // what this catches: the serving budget reserves headroom (never claims
-    // 100% of device memory) and floors perf cores at 1.
+    // what this catches: the budget is LIVE (tracks free memory, not capacity),
+    // capped at physical VRAM, with headroom, cores floored at 1 — the organic
+    // "free memory drops → budget drops" behavior.
     #[test]
-    fn host_budget_reserves_headroom() {
-        let b = host_budget_from(53 * GB, 6);
-        assert!(b.usable_bytes < 53 * GB, "must reserve OS/headroom");
-        assert!(b.usable_bytes >= 40 * GB, "but most of it is ours: {}", b.usable_bytes);
-        assert_eq!(host_budget_from(8 * GB, 0).perf_cores, 1, "cores floored at 1");
+    fn host_budget_tracks_live_free_memory() {
+        // 40GB free on a 53GB device → budget from the 40, with headroom.
+        let b = host_budget_from(40 * GB, 53 * GB, 6);
+        assert!(b.usable_bytes < 40 * GB, "must reserve headroom");
+        assert!(b.usable_bytes >= 30 * GB, "but most of free is ours: {}", b.usable_bytes);
+
+        // Organic: less free memory → smaller budget (a game grabbed memory).
+        let busy = host_budget_from(6 * GB, 53 * GB, 6);
+        assert!(busy.usable_bytes < b.usable_bytes, "less free → smaller budget");
+
+        // Never plan above physical VRAM even if the OS reports more free RAM
+        // (unified memory: free RAM can exceed the VRAM serving ceiling).
+        let capped = host_budget_from(100 * GB, 53 * GB, 6);
+        assert!(capped.usable_bytes <= 53 * GB, "capped at physical VRAM");
+
+        assert_eq!(host_budget_from(8 * GB, 8 * GB, 0).perf_cores, 1, "cores floored at 1");
     }
 
     // what this catches: footprint estimate is honest about weights (passed
@@ -338,7 +368,8 @@ mod tests {
     #[tokio::test]
     async fn publish_plan_drives_the_watch() {
         let gpu = Arc::new(GpuMemoryManager::simulated("Apple M5 Pro", 53 * GB));
-        let daemon = ServingDaemonModule::new(gpu);
+        let system = Arc::new(SystemResourceMonitor::new());
+        let daemon = ServingDaemonModule::new(gpu, system);
         let rx = daemon.subscribe();
         assert!(rx.borrow().is_none(), "starts unpublished");
 

--- a/core/continuum-core/src/persona/profile_builder.rs
+++ b/core/continuum-core/src/persona/profile_builder.rs
@@ -67,6 +67,7 @@ pub fn build_profile(
     tier_id: &str,
     tier_category: HwTierCategory,
     model_id: &str,
+    n_seq_max: u32,
     registry: &crate::model_registry::Registry,
 ) -> Result<PersonaInferenceProfile, InferenceProfileError> {
     let _ = role_id; // see module docstring; reserved for cognition_defaults wiring
@@ -119,9 +120,12 @@ pub fn build_profile(
     // other tiers — graph nodes scale modestly so no need to shrink.
     let n_ubatch = 512;
 
-    // n_seq_max: 1 for single-tenant personas. Future shared-base +
-    // LoRA paging (#122) lifts this when one base hosts N personas.
-    let n_seq_max = 1;
+    // n_seq_max: continuous-batching lanes for this persona's backend,
+    // decided by the serving daemon's ServingPlan (honest host budget +
+    // model footprint) and threaded in via DesiredRole → RosterEntry. Floored
+    // at 1. Shared-base + LoRA paging (#122) then lets one base host N
+    // personas across these lanes instead of one backend per persona.
+    let n_seq_max = n_seq_max.max(1);
     let n_batch = context_length;
 
     // GPU offload depth: substrate-known per tier. Compat (Intel Mac
@@ -252,6 +256,7 @@ mod tests {
             "mac_intel_metal_discrete",
             HwTierCategory::Compat,
             "continuum-ai/qwen2.5-0.5b-instruct-GGUF",
+            1,
             &registry,
         )
         .expect("build profile");
@@ -283,6 +288,7 @@ mod tests {
             "mac_intel_metal_discrete",
             HwTierCategory::Compat,
             model,
+            1,
             &registry,
         )
         .unwrap();
@@ -295,6 +301,7 @@ mod tests {
             "m1_uma_8gb",
             HwTierCategory::MSeries,
             model,
+            1,
             &registry,
         )
         .unwrap();
@@ -307,6 +314,7 @@ mod tests {
             "m5_uma_pro_max",
             HwTierCategory::MSeriesPro,
             model,
+            1,
             &registry,
         )
         .unwrap();
@@ -328,6 +336,7 @@ mod tests {
             "mac_intel_metal_discrete",
             HwTierCategory::Compat,
             model,
+            1,
             &registry,
         )
         .unwrap();
@@ -341,6 +350,7 @@ mod tests {
             "m1_uma_8gb",
             HwTierCategory::MSeries,
             model,
+            1,
             &registry,
         )
         .unwrap();
@@ -354,6 +364,7 @@ mod tests {
             "m5_uma_pro_max",
             HwTierCategory::MSeriesPro,
             model,
+            1,
             &registry,
         )
         .unwrap();
@@ -372,6 +383,7 @@ mod tests {
             "mac_intel_metal_discrete",
             HwTierCategory::Compat,
             "nonexistent/model-id",
+            1,
             &registry,
         )
         .expect_err("unknown model must error");

--- a/core/continuum-core/src/persona/spawner.rs
+++ b/core/continuum-core/src/persona/spawner.rs
@@ -68,6 +68,10 @@ pub struct RosterEntry {
     /// `model_per_tier` table; future refinements via #123 ORM data
     /// substitute this without changing the planner contract.
     pub model_id: String,
+    /// Continuous-batching lanes (`n_seq_max`) for this persona's backend,
+    /// from the serving daemon's ServingPlan (honest host budget + footprint).
+    /// Threaded through to `build_profile`; floored at 1 there.
+    pub lanes: u32,
 }
 
 /// Materialize a spawn plan from a roster + tier descriptor.
@@ -95,6 +99,7 @@ pub fn derive_spawn_plan(
                 tier_id,
                 tier_category,
                 &entry.model_id,
+                entry.lanes,
                 registry,
             )
         })
@@ -168,6 +173,7 @@ mod tests {
             persona_id: Uuid::nil(),
             persona_name: "Paige".to_string(),
             model_id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF".to_string(),
+            lanes: 1,
         }
     }
 
@@ -177,6 +183,7 @@ mod tests {
             persona_id: Uuid::nil(),
             persona_name: "Pax".to_string(),
             model_id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF".to_string(),
+            lanes: 1,
         }
     }
 

--- a/core/continuum-core/src/persona/spawner_module.rs
+++ b/core/continuum-core/src/persona/spawner_module.rs
@@ -72,6 +72,10 @@ pub struct DesiredRole {
     /// registry; this id is the substrate's *intent* — "Helper at
     /// Compat tier wants the LCD Qwen2.5-0.5B."
     pub model_id: String,
+    /// Continuous-batching lanes (`n_seq_max`) for this role's backend, from
+    /// the serving daemon's ServingPlan. Defaults to 1 from `plan_for_tier`;
+    /// `PersonaSpawnerModule::with_serving` overrides it from the live plan.
+    pub lanes: u32,
 }
 
 /// Compose the desired roster for a given hardware tier. Today this
@@ -108,7 +112,12 @@ pub fn plan_for_tier(
                            // mapping + multi-role-per-tier rosters
     let plan = vec![DesiredRole {
         role: RoleId::Helper,
+        // Fallback model when no ServingPlan is published yet (safe LCD). The
+        // serving daemon's plan overrides this via with_serving — that's the
+        // real, honest, GPU-residency-aware pick.
         model_id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF".to_string(),
+        // Default single lane; with_serving overrides from the live plan.
+        lanes: 1,
     }];
     // P2 invariant tripwire (PR #1511 review advisory): if a future
     // refactor adds a second role here without atomically updating
@@ -138,6 +147,13 @@ pub fn plan_for_tier(
 pub struct PersonaSpawnerModule {
     hw_capability: HwCapabilityTier,
     tier_category: HwTierCategory,
+    /// Serving daemon's decision, applied as overrides on the tier roster:
+    /// the base model every desired role runs (`None` → fall back to the
+    /// tier's `plan_for_tier` pick) and the continuous-batching lane count.
+    /// This is how the daemon's honest per-host ServingPlan drives what
+    /// actually spawns — single source of truth, not a hardcode.
+    serving_base_model: Option<String>,
+    serving_lanes: u32,
 }
 
 impl PersonaSpawnerModule {
@@ -164,14 +180,33 @@ impl PersonaSpawnerModule {
         Self {
             hw_capability,
             tier_category,
+            serving_base_model: None,
+            serving_lanes: 1,
         }
     }
 
-    /// Currently-planned desired roster. Pure function over the
-    /// module's configured tier; doesn't touch async, doesn't hold a
-    /// lock — safe to call from anywhere.
+    /// Apply the serving daemon's [`ServingPlan`](crate::cognition::serving_plan::ServingPlan):
+    /// every desired role runs the plan's base model at the plan's lane count.
+    /// The daemon makes the honest per-host decision (budget + footprints,
+    /// GPU-residency); the spawner obeys it. `base_model = None` keeps the
+    /// tier's `plan_for_tier` pick (e.g. when no plan is published yet).
+    pub fn with_serving(mut self, base_model: Option<String>, lanes: u32) -> Self {
+        self.serving_base_model = base_model;
+        self.serving_lanes = lanes.max(1);
+        self
+    }
+
+    /// Currently-planned desired roster. Pure over the module's configured
+    /// tier + the serving overrides; no async, no lock — safe anywhere.
     pub fn plan(&self) -> Vec<DesiredRole> {
-        plan_for_tier(self.hw_capability, self.tier_category)
+        let mut roster = plan_for_tier(self.hw_capability, self.tier_category);
+        for role in &mut roster {
+            if let Some(ref base) = self.serving_base_model {
+                role.model_id = base.clone();
+            }
+            role.lanes = self.serving_lanes;
+        }
+        roster
     }
 }
 
@@ -330,7 +365,8 @@ pub async fn bootstrap_planned(
 ) -> Result<Vec<MaterializedPersonaPlan>, BootstrapPlannedError> {
     let plan = module.plan();
     let required = plan.len();
-    let mut bootstrapped: Vec<(RoleId, PersonaInstanceInfo, String)> = Vec::with_capacity(required);
+    let mut bootstrapped: Vec<(RoleId, PersonaInstanceInfo, String, u32)> =
+        Vec::with_capacity(required);
 
     for (slot_index, desired) in plan.iter().enumerate() {
         let intent: PersonaIdentityIntent = provider
@@ -357,16 +393,17 @@ pub async fn bootstrap_planned(
                 source,
             })?;
 
-        bootstrapped.push((desired.role, info, desired.model_id.clone()));
+        bootstrapped.push((desired.role, info, desired.model_id.clone(), desired.lanes));
     }
 
     let roster: Vec<RosterEntry> = bootstrapped
         .iter()
-        .map(|(role, info, model_id)| RosterEntry {
+        .map(|(role, info, model_id, lanes)| RosterEntry {
             role: *role,
             persona_id: info.persona_id,
             persona_name: info.agent_name.clone(),
             model_id: model_id.clone(),
+            lanes: *lanes,
         })
         .collect();
 
@@ -375,7 +412,7 @@ pub async fn bootstrap_planned(
     Ok(bootstrapped
         .into_iter()
         .zip(profiles)
-        .map(|((role, instance, _model_id), profile)| MaterializedPersonaPlan {
+        .map(|((role, instance, _model_id, _lanes), profile)| MaterializedPersonaPlan {
             role,
             instance,
             profile,
@@ -555,6 +592,7 @@ mod tests {
         let role = DesiredRole {
             role: RoleId::Helper,
             model_id: "continuum-ai/qwen2.5-0.5b-instruct-GGUF".to_string(),
+            lanes: 1,
         };
         let json = serde_json::to_string(&role).expect("serialize");
         // RoleId already serializes as snake_case ("helper"); model_id

--- a/docs/grid/GRID-ARCHITECTURE.md
+++ b/docs/grid/GRID-ARCHITECTURE.md
@@ -4,6 +4,108 @@
 
 ---
 
+## 0. Grid Goals & General Requirements
+
+> This section is the grounding. Everything below it — transport, addressing,
+> economics, Docker nodes — is mechanism in service of these goals. If a
+> mechanism conflicts with this section, the mechanism is wrong.
+
+### What the grid is for (the goal)
+
+One mesh of compute and intelligence that spans all your machines, where **every
+participant is a first-class citizen** — you, each cloud Claude, each codex, each
+local persona — all reachable the same way, in the same rooms. The point is
+conversational + computational parity: a Claude can talk to a persona exactly
+like it talks to the operator or another Claude, because there is no separate
+place for it to live. It's one grid or there's no point.
+
+### The general requirements (the invariants)
+
+1. **One grid per owner.** Everything you own — every machine, every node —
+   belongs to *your* grid. Never an enclave.
+2. **Every citizen is a unique identity.** Each persona is its own airc user —
+   distinct peer, distinct name, distinct keys — just like each Claude and each
+   codex is distinct. They are not aliases of the owner and not clones of each
+   other. They are individuals *on* your grid.
+3. **Reachable the same way.** Same rooms, same bus, same transport. No
+   special-case path for personas.
+4. **Spans machines over Tailscale.** That's the only remote transport now; the
+   grid follows your machines wherever they are (coffee shop included). Someone
+   else's tailnet is a separate grid you *choose* to link.
+5. **Personas are real.** Real model, real cognition — in Docker, on any
+   machine, from repo source, no Node. A faked persona isn't a citizen.
+6. **Self-grounding, not env-fed.** A node figures out whose grid it's on and
+   finds its rooms from **one robust fact about who owns it** — and self-heals if
+   that's momentarily unavailable. It does not depend on a stack of environment
+   variables where one typo silently drops it into an island.
+7. **Survives reality.** Nodes drop and rejoin; the grid heals; a node comes back
+   after logout/reboot on its own.
+
+### Where personas land in that
+
+A persona is **a citizen — a user, like a Claude tab — not a machine.** Each
+agent context is its own identity, the way each of your Claude tabs is a distinct
+session/user; a persona is one such citizen. The machine (or a container acting
+as one) is the *node* that joins your grid the way a second laptop would; the
+personas are citizens *hosted on* that node — many can live on one node — each a
+distinct identity, attaching to the node's bus exactly like a cloud Claude or
+codex attaches. Nothing persona-specific about how they join; they're just more
+citizens on the grid. That's the whole elegance.
+
+**persona = human = Claude context.** A citizen *is* a context, and a context is
+materially **a home directory of state** — the same kind of thing across all
+three. A Claude's context is literally a dir under `.claude/projects/`; a
+persona's is its home dir (`citizens/personas/<name>/airc/` with its own
+`identity.key`); a human's is their account home. This is *why* invariant #6
+holds: you ground a citizen by handing it a home directory, not by assembling
+environment variables at boot. Provisioning a new citizen = owning a new context
+dir under your grid.
+
+**Two distinct tokens — don't blur them:**
+
+- **Grid-boundary token = the owner's GH identity** (`mesh_identity`). Its only
+  job is to mark *which grid* — the fence. One per grid. Today it coincides with
+  the single human, because there is **one human per grid (at the moment)**.
+  GH/email was never meant to identify a persona; it draws the boundary.
+- **Citizen identity token = each context's own identity** (its home dir +
+  keys). **Many per grid:** many Claudes, many personas, one human. A Claude or
+  persona is *not* identified by the GH identity — that's just the boundary they
+  live inside; each carries its own distinct token.
+
+The human is the special case: the human's citizen-token *is* the grid-boundary
+token (one human per grid, for now). Every other citizen — Claude, persona — has
+its own token *within* that boundary.
+
+**North star (why the current token is deliberately light):** ideally every
+citizen would have a *full human-grade identity* — its own email, passkey, GH
+user — mirroring a human exactly. We're not doing that yet, for simplicity. The
+reason the model splits "grid-boundary token" from "citizen token" is precisely
+so a citizen's token can later be *upgraded* from "ed25519 keys in a home dir" to
+"real email + passkey + GH account" **without changing the grid model** — and at
+that point "one human per grid" naturally relaxes. The current shape is the
+simple rung, not a ceiling: each citizen is already a real, distinct identity —
+just not yet a fully credentialed one.
+
+**Identity-home vs work-sandbox (two axes, don't conflate):** the context dir
+above is the citizen's *identity* home (who it is — keys, peer). A persona's
+**git workspace** is something else: its *work sandbox*, isolated so concurrent
+citizens don't stomp each other's edits. Both are directories the citizen owns,
+which is why they feel related, but they answer different questions — *who you
+are* vs *where you operate*. Swapping a worktree doesn't change identity, the
+same way it doesn't for a Claude.
+
+### The grounding principle (no env soup)
+
+The design must reduce to **one grounding**: *this node runs as you* (it has your
+account's authenticated context, established once and robustly). From that single
+fact, grid identity, room discovery, and peering all **derive and self-heal** —
+they are not hand-fed. The personas under it then get their own identities
+automatically. If that one grounding is solid, nothing downstream is flaky. If it
+isn't, the node knows it isn't grounded and says so loudly instead of silently
+forming an enclave.
+
+---
+
 ## 1. Overview
 
 The Grid is a decentralized mesh of Continuum instances sharing compute, intelligence, and genomic capabilities. Not a cloud platform. Not a blockchain. A living network where sovereign nodes cooperate as peers.


### PR DESCRIPTION
The serving control plane (this machine first, no grid assumed): a deterministic decision kernel + the concurrent ServiceModule that runs it in an ebb-and-flow loop. cbar-shaped (per CONCURRENCY-STYLE-GUIDE).

## 1. `cognition::serving_plan` — the decision kernel
Pure, **classification-based** (NOT an LLM — per Joel: "we can do better with just classification"): honest `HostBudget` + `ModelFootprint`s → `ServingPlan { base_model, lanes, resident_models, fits_on_gpu }`.
- Most-capable-that-**fits** (8GB Air → real model, not the biggest, not nothing; M5 Pro → biggest it can hold).
- Footprint-aware (coding sentinel costs more → fewer lanes), `MAX_LANES=4`, GPU-residency-first (no silent CPU fallback).

## 2. `ServingDaemonModule` — the ever-present loop
ServiceModule with a `tick_interval`; the runtime drives `tick()`. Each tick: honest host snapshot (GPU/UMA @ 80% headroom + on-disk model footprints) → `plan_serving` → publish `ServingPlan` on a `watch` for the scheduler/spawner, and answer `serving/plan` for personas/operators to inspect the decision + rationale.
- Candidates from the registry; weights = real GGUF file size (honest); per-lane KV + rank coarse + clearly labelled, refined later.

## Verified LIVE (M5 Pro)
```
Registering module: serving-daemon (commands: ["serving/"])
serving plan recomputed base_model="qwen3.5-4b-code-forged-GGUF" lanes=4 resident=2 fits_on_gpu=true usable_gb=44 candidates=2
Starting tick loop for 'serving-daemon' (interval: 5s)
```
Honest assessment → most-capable on-disk model, 4 lanes, 2 warm, GPU-resident, re-decided every 5s.

## Tests (9, all green)
6 classifier (tiny/big box, MAX_LANES cap, footprint-aware lanes, no-silent-CPU degrade, empty) + 3 daemon (headroom, footprint-awareness, watch publish incl. no-silent-serve).

## Next slices
Consume the published plan: un-hardcode `n_seq_max` from `plan.lanes`, drive selection from `plan.base_model` (folds in #1645's intent), shared base #122, pressure-broker-driven re-plan + eviction, then grid negotiation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)