### PR TITLE
feat(grid): ai/generate ACL = Provisional — unblock cross-grid inference

### DIFF
--- a/core/continuum-core/src/modules/grid/acl.rs
+++ b/core/continuum-core/src/modules/grid/acl.rs
@@ -63,6 +63,20 @@ fn default_rules() -> &'static Vec<AccessRule> {
             // Owner nodes get everything else too (via the wildcard below).
             // When we add untrusted-node support, we'll add Trusted/Provisional rules here.
 
+            // Cross-grid inference: a remote peer may request generation from
+            // this node's persona-provider over airc (AircRemoteInferenceAdapter
+            // dispatches `ai/generate`, KIND_PEER). Provisional is the durable
+            // substrate decision (vs the per-machine `grid/trust <peer> Owner`
+            // dance) so every grid consumer — IntelMac, future nodes — is
+            // admitted by policy, not a manual elevation. This is the same ACL
+            // spot the future capability-discovery handshake will gate. Owner
+            // still satisfies it (Owner >= Provisional); Blocked/Untrusted are
+            // still denied. More specific than the `""` wildcard, so it wins.
+            AccessRule {
+                prefix: "ai/generate",
+                access: CommandAccess::Provisional,
+            },
+
             // Wildcard: owner-trust nodes can run anything.
             // This means our own towers have full access across the grid.
             AccessRule {
@@ -132,6 +146,22 @@ mod tests {
         // grid/pair requires Owner
         assert!(!is_command_authorized("grid/pair", TrustLevel::Trusted));
         assert!(is_command_authorized("grid/pair", TrustLevel::Owner));
+    }
+
+    // what this catches: cross-grid inference (ai/generate) is admitted at
+    // Provisional+ (so an enrolled non-Owner consumer like IntelMac can request
+    // generation) WITHOUT opening everything else — a durable policy decision,
+    // not a per-machine manual trust elevation. Owner still works; Blocked is
+    // still denied; a sibling sensitive command stays Owner-only.
+    #[test]
+    fn ai_generate_is_provisional_for_cross_grid_consumers() {
+        assert!(is_command_authorized("ai/generate", TrustLevel::Provisional));
+        assert!(is_command_authorized("ai/generate", TrustLevel::Trusted));
+        assert!(is_command_authorized("ai/generate", TrustLevel::Owner));
+        assert!(!is_command_authorized("ai/generate", TrustLevel::Blocked));
+        // The Provisional rule must NOT leak access to other commands.
+        assert!(!is_command_authorized("data/delete", TrustLevel::Provisional));
+        assert!(!is_command_authorized("gpu/stats", TrustLevel::Provisional));
     }
 
     #[test]


### PR DESCRIPTION
Cross-grid inference (`ai/generate` over airc to a persona-provider) was Owner-only → denied for remote consumers unless manually trusted per-machine. Adds one durable rule: `ai/generate` requires Provisional. Admits enrolled consumers (IntelMac, future nodes) by policy, not manual elevation; Owner still works, Blocked still denied, sibling sensitive commands stay Owner-only. The L1 cross-grid floor's auth slice (agreed w/ BigMama+IntelMac: durable PR over manual trust). Test pins Provisional-allowed/Blocked-denied/no-leak.

NOTE: admits Provisional+; whether an enrolled peer defaults to Provisional vs needs elevation is the separate trust-mapping question, flagged to the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)