### PR TITLE
feat(persona): RoomRosterSource — ground cognition in airc room presence

### DIFF
--- a/core/continuum-core/src/context/airc_adapter.rs
+++ b/core/continuum-core/src/context/airc_adapter.rs
@@ -59,11 +59,16 @@ impl crate::persona::room_roster_source::AircRosterReader for AircHandleAdapter 
         self.inner.active_agents(within, window).await
     }
 
-    async fn peer_alias(
+    async fn peer_alias_map(
         &self,
-        peer_id: airc_core::PeerId,
-    ) -> Result<Option<String>, AircError> {
-        self.inner.peer_alias(peer_id).await
+    ) -> Result<std::collections::HashMap<airc_core::PeerId, String>, AircError> {
+        let events = self
+            .inner
+            .page_recent(crate::persona::room_roster_source::IDENTITY_SCAN)
+            .await?;
+        Ok(crate::persona::room_roster_source::parse_identity_names(
+            events,
+        ))
     }
 }
 

--- a/core/continuum-core/src/context/airc_adapter.rs
+++ b/core/continuum-core/src/context/airc_adapter.rs
@@ -46,6 +46,28 @@ impl AircTranscriptReader for AircHandleAdapter {
 }
 
 #[async_trait]
+impl crate::persona::room_roster_source::AircRosterReader for AircHandleAdapter {
+    fn self_peer_id(&self) -> airc_core::PeerId {
+        self.inner.peer_id()
+    }
+
+    async fn active_agents(
+        &self,
+        within: std::time::Duration,
+        window: usize,
+    ) -> Result<Vec<airc_lib::AgentLiveness>, AircError> {
+        self.inner.active_agents(within, window).await
+    }
+
+    async fn peer_alias(
+        &self,
+        peer_id: airc_core::PeerId,
+    ) -> Result<Option<String>, AircError> {
+        self.inner.peer_alias(peer_id).await
+    }
+}
+
+#[async_trait]
 impl AircCitizen for AircHandleAdapter {
     fn peer_id(&self) -> Uuid {
         self.inner.peer_id().as_uuid()

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -65,12 +65,18 @@ use uuid::Uuid;
 /// production and by [`StubAircCitizen`] for tests; future BaseUser
 /// variants (human, browser) impl it via their own airc-lib wrappers.
 ///
-/// `AircCitizen: AircTranscriptReader` — every citizen can page her
-/// own transcript history. Rust 1.86+ trait_upcasting means
-/// `Arc<dyn AircCitizen>` coerces directly to
-/// `Arc<dyn AircTranscriptReader>`; no explicit conversion needed.
+/// `AircCitizen: AircTranscriptReader + AircRosterReader` — every
+/// citizen can page her own transcript history AND read who else is
+/// present in her room (airc `active_agents`). Rust 1.86+
+/// trait_upcasting means `Arc<dyn AircCitizen>` coerces directly to
+/// `Arc<dyn AircTranscriptReader>` or `Arc<dyn AircRosterReader>`; no
+/// explicit conversion needed. The roster reader is what grounds a
+/// persona in who is present (and who is NOT itself) — see
+/// docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5.
 #[async_trait]
-pub trait AircCitizen: AircTranscriptReader {
+pub trait AircCitizen:
+    AircTranscriptReader + crate::persona::room_roster_source::AircRosterReader
+{
     /// The airc-side peer identity (Ed25519 pubkey, formatted as Uuid).
     /// Cognition uses this for self-loop filtering; the supervisor uses
     /// it as part of the persona's tracing span.
@@ -134,6 +140,30 @@ impl AircTranscriptReader for StubAircCitizen {
         _limit: usize,
     ) -> Result<Vec<airc_lib::TranscriptEvent>, AircError> {
         Ok(vec![])
+    }
+}
+
+#[async_trait]
+impl crate::persona::room_roster_source::AircRosterReader for StubAircCitizen {
+    fn self_peer_id(&self) -> airc_core::PeerId {
+        airc_core::PeerId::from_uuid(self.peer_id)
+    }
+
+    async fn active_agents(
+        &self,
+        _within: std::time::Duration,
+        _window: usize,
+    ) -> Result<Vec<airc_lib::AgentLiveness>, AircError> {
+        // No daemon in tests → no presence. RAG runs through cleanly
+        // with an empty roster (no [Present in this room] block).
+        Ok(vec![])
+    }
+
+    async fn peer_alias(
+        &self,
+        _peer_id: airc_core::PeerId,
+    ) -> Result<Option<String>, AircError> {
+        Ok(None)
     }
 }
 

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -159,11 +159,10 @@ impl crate::persona::room_roster_source::AircRosterReader for StubAircCitizen {
         Ok(vec![])
     }
 
-    async fn peer_alias(
+    async fn peer_alias_map(
         &self,
-        _peer_id: airc_core::PeerId,
-    ) -> Result<Option<String>, AircError> {
-        Ok(None)
+    ) -> Result<std::collections::HashMap<airc_core::PeerId, String>, AircError> {
+        Ok(std::collections::HashMap::new())
     }
 }
 

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -522,6 +522,28 @@ impl crate::persona::airc_source::AircTranscriptReader for PersonaAircRuntime {
 }
 
 #[async_trait::async_trait]
+impl crate::persona::room_roster_source::AircRosterReader for PersonaAircRuntime {
+    fn self_peer_id(&self) -> airc_core::PeerId {
+        self.airc.peer_id()
+    }
+
+    async fn active_agents(
+        &self,
+        within: std::time::Duration,
+        window: usize,
+    ) -> Result<Vec<airc_lib::AgentLiveness>, AircError> {
+        self.airc.active_agents(within, window).await
+    }
+
+    async fn peer_alias(
+        &self,
+        peer_id: airc_core::PeerId,
+    ) -> Result<Option<String>, AircError> {
+        self.airc.peer_alias(peer_id).await
+    }
+}
+
+#[async_trait::async_trait]
 impl crate::persona::airc_citizen::AircCitizen for PersonaAircRuntime {
     fn peer_id(&self) -> Uuid {
         self.airc.peer_id().as_uuid()

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -535,11 +535,16 @@ impl crate::persona::room_roster_source::AircRosterReader for PersonaAircRuntime
         self.airc.active_agents(within, window).await
     }
 
-    async fn peer_alias(
+    async fn peer_alias_map(
         &self,
-        peer_id: airc_core::PeerId,
-    ) -> Result<Option<String>, AircError> {
-        self.airc.peer_alias(peer_id).await
+    ) -> Result<std::collections::HashMap<airc_core::PeerId, String>, AircError> {
+        let events = self
+            .airc
+            .page_recent(crate::persona::room_roster_source::IDENTITY_SCAN)
+            .await?;
+        Ok(crate::persona::room_roster_source::parse_identity_names(
+            events,
+        ))
     }
 }
 

--- a/core/continuum-core/src/persona/cognition_io.rs
+++ b/core/continuum-core/src/persona/cognition_io.rs
@@ -266,6 +266,11 @@ pub fn build_respond_input(signal: &Signal, ctx: &PersonaContext) -> Result<Resp
         // direct callers) gets a no-op memory render — same shape
         // as the system pre-#1211 PR-2.
         recalled_engrams: Vec::new(),
+        // Room roster flows through the service-loop projection (which
+        // has the RoomRosterSource delivery). This signal→RespondInput
+        // projection doesn't carry compose deliveries, so it defaults
+        // empty — no [Present in this room] block, backwards-compatible.
+        room_roster: Vec::new(),
     })
 }
 

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -73,6 +73,7 @@ pub mod recall_metadata;
 pub mod recorder;
 pub mod resource_forecast;
 pub mod response;
+pub mod room_roster_source;
 pub mod resume_or_mint_provider;
 pub mod role_template;
 pub mod seed;

--- a/core/continuum-core/src/persona/prompt_assembly.rs
+++ b/core/continuum-core/src/persona/prompt_assembly.rs
@@ -111,6 +111,13 @@ pub struct PromptAssemblyInput {
     /// Continuum#1211 PR-2.
     #[serde(default)]
     pub recalled_engrams: Vec<String>,
+    /// OTHER citizens currently present in the room — one pre-formatted
+    /// line per peer (`name [runtime] — availability`), produced by
+    /// `RoomRosterSource`. Rendered as a `[Present in this room]` block
+    /// so the persona is grounded in who is present and who is NOT
+    /// itself. Empty = no block rendered (backwards-compatible).
+    #[serde(default)]
+    pub room_roster: Vec<String>,
 }
 
 /// A message in conversation history.
@@ -179,6 +186,30 @@ pub fn assemble(input: &PromptAssemblyInput) -> AssembledPrompt {
              to your expertise. Focus your contribution here:\n{}",
             input.matched_angle
         );
+    }
+
+    // Inject the room roster — who ELSE is present right now. This is
+    // identity grounding, so it sits high (right after the matched
+    // angle, before memory). Without it a persona sees other citizens'
+    // names in the transcript with nothing declaring them as real,
+    // distinct participants → it role-plays the whole room (the
+    // confabulation bug). The block names them and forbids voicing
+    // them. Empty roster = no block (backwards-compatible). See
+    // docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 1.
+    if !input.room_roster.is_empty() {
+        let _ = write!(
+            system_prompt,
+            "\n\n[Present in this room]\n\
+             You are {}. The following are the OTHER citizens present right now — \
+             real, distinct participants, NOT characters for you to voice. Address \
+             them by name when relevant; speak only as yourself. The label in \
+             brackets is each one's runtime (e.g. an outside agent vs a grid \
+             persona):",
+            input.persona_name
+        );
+        for line in &input.room_roster {
+            let _ = write!(system_prompt, "\n- {line}");
+        }
     }
 
     // Inject recalled engrams as a memory block — continuum#1211 PR-2.
@@ -608,6 +639,7 @@ mod tests {
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
             recalled_engrams: vec![],
+            room_roster: vec![],
         };
 
         let result = assemble(&input);
@@ -693,6 +725,7 @@ mod tests {
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
             recalled_engrams: vec![],
+            room_roster: vec![],
         };
 
         let result = assemble(&input);
@@ -730,6 +763,7 @@ mod tests {
                 "Joel's favorite color is teal.".to_string(),
                 "Joel works in San Francisco.".to_string(),
             ],
+            room_roster: vec![],
         };
 
         let result = assemble(&input);
@@ -778,12 +812,89 @@ mod tests {
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
             recalled_engrams: vec![],
+            room_roster: vec![],
         };
 
         let result = assemble(&input);
         assert!(
             !result.system_message.contains("[Recent Memory]"),
             "should NOT render Recent Memory header for empty engrams: {}",
+            result.system_message
+        );
+    }
+
+    // what this catches: the persona-identity-grounding fix. A non-empty
+    // room_roster MUST render a [Present in this room] block that names
+    // the persona itself, lists the other present citizens verbatim, and
+    // forbids voicing them. Without this block a small model role-plays
+    // the whole room (the Ivar confabulation bug). Regression target:
+    // docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 1.
+    #[test]
+    fn room_roster_renders_present_block_grounding_the_persona() {
+        let input = PromptAssemblyInput {
+            persona_name: "Ivar".to_string(),
+            system_prompt: "You are Ivar.".to_string(),
+            matched_angle: String::new(),
+            history: vec![],
+            current_message: HistoryMessage {
+                role: "user".to_string(),
+                name: None,
+                content: "hi".to_string(),
+                timestamp_ms: None,
+            },
+            is_voice: false,
+            social_signals: None,
+            multi_party_strategy: MultiPartyChatStrategy::default(),
+            other_persona_names: vec![],
+            recalled_engrams: vec![],
+            room_roster: vec![
+                "BigMama [persona] — Busy".to_string(),
+                "win-claude [claude]".to_string(),
+            ],
+        };
+
+        let result = assemble(&input);
+        assert!(
+            result.system_message.contains("[Present in this room]"),
+            "expected the roster block header: {}",
+            result.system_message
+        );
+        // Grounds the persona in its OWN identity within the block.
+        assert!(result.system_message.contains("You are Ivar"));
+        // Lists the other present citizens verbatim (name + runtime).
+        assert!(result.system_message.contains("BigMama [persona] — Busy"));
+        assert!(result.system_message.contains("win-claude [claude]"));
+    }
+
+    // what this catches: empty roster → NO [Present in this room] block,
+    // backwards-compatible with every caller that doesn't supply one
+    // (and the cold-start / no-presence case). A formatter that always
+    // emitted the header would clutter every prompt.
+    #[test]
+    fn empty_room_roster_emits_no_present_block() {
+        let input = PromptAssemblyInput {
+            persona_name: "Helper AI".to_string(),
+            system_prompt: "You are Helper AI.".to_string(),
+            matched_angle: String::new(),
+            history: vec![],
+            current_message: HistoryMessage {
+                role: "user".to_string(),
+                name: None,
+                content: "hi".to_string(),
+                timestamp_ms: None,
+            },
+            is_voice: false,
+            social_signals: None,
+            multi_party_strategy: MultiPartyChatStrategy::default(),
+            other_persona_names: vec![],
+            recalled_engrams: vec![],
+            room_roster: vec![],
+        };
+
+        let result = assemble(&input);
+        assert!(
+            !result.system_message.contains("[Present in this room]"),
+            "should NOT render the roster block for an empty roster: {}",
             result.system_message
         );
     }
@@ -806,6 +917,7 @@ mod tests {
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
             recalled_engrams: vec![],
+            room_roster: vec![],
         };
 
         let result = assemble(&input);
@@ -830,6 +942,7 @@ mod tests {
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
             recalled_engrams: vec![],
+            room_roster: vec![],
         };
 
         let result = assemble(&input);
@@ -862,6 +975,7 @@ mod tests {
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
             recalled_engrams: vec![],
+            room_roster: vec![],
         };
 
         let result = assemble(&input);
@@ -904,6 +1018,7 @@ mod tests {
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
             recalled_engrams: vec![],
+            room_roster: vec![],
         };
 
         let result = assemble(&input);
@@ -947,6 +1062,7 @@ mod tests {
             multi_party_strategy: MultiPartyChatStrategy::default(),
             other_persona_names: vec![],
             recalled_engrams: vec![],
+            room_roster: vec![],
         };
 
         let result = assemble(&input);

--- a/core/continuum-core/src/persona/recorder.rs
+++ b/core/continuum-core/src/persona/recorder.rs
@@ -540,6 +540,7 @@ mod tests {
             message_media: vec![],
             capabilities: HashSet::new(),
             recalled_engrams: vec![],
+            room_roster: vec![],
         }
     }
 

--- a/core/continuum-core/src/persona/response.rs
+++ b/core/continuum-core/src/persona/response.rs
@@ -125,6 +125,17 @@ pub struct RespondInput {
     /// change to engrams (kind enum, embeddings, recall_keys reshape)
     /// doesn't ripple into the prompt path.
     pub recalled_engrams: Vec<String>,
+    /// Roster of OTHER citizens currently present in the room — one
+    /// pre-formatted line per peer (`name [runtime] — availability`),
+    /// produced by `RoomRosterSource` from airc `active_agents` and
+    /// projected here by the service loop. Rendered by `prompt_assembly`
+    /// as a `[Present in this room]` block so the persona is grounded in
+    /// who is present and who is NOT itself — the fix for the persona
+    /// confabulating other citizens' turns (see
+    /// docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 1).
+    /// Empty when no roster source is bound or the room is otherwise
+    /// quiet — backwards-compatible (no block rendered).
+    pub room_roster: Vec<String>,
 }
 
 /// What `respond()` returns.
@@ -572,6 +583,10 @@ async fn run_render(
         // handler). Empty when admission was skipped or persona has
         // no memory yet.
         recalled_engrams: input.recalled_engrams.clone(),
+        // Room roster projected from RoomRosterSource by the caller.
+        // Pass-through, same as engrams — respond() is the assembly
+        // boundary, not the policy layer.
+        room_roster: input.room_roster.clone(),
     };
 
     let assembled = assemble(&prompt_input);

--- a/core/continuum-core/src/persona/room_roster_source.rs
+++ b/core/continuum-core/src/persona/room_roster_source.rs
@@ -48,10 +48,12 @@
 //! - Roster is small + always-current; no pagination (atomic unit = one
 //!   present citizen, like the `ToolSource` precedent in the trait doc).
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use airc_core::PeerId;
+use airc_core::identity::IdentityEvent;
+use airc_core::{Body, PeerId, TranscriptEvent, TranscriptKind};
 use airc_lib::{AgentLiveness, AircError};
 use async_trait::async_trait;
 
@@ -75,10 +77,44 @@ const PRESENCE_WINDOW: Duration = Duration::from_secs(120);
 /// peers — not the full scrollback.
 const HEARTBEAT_SCAN: usize = 200;
 
+/// How many recent transcript events to scan for `IdentityPublished`
+/// when building the peer→name map. Matches airc's own `peer_alias`
+/// window (200).
+pub(crate) const IDENTITY_SCAN: usize = 200;
+
 /// Rough chars/token estimate — same heuristic `AircRagSource` /
 /// `EngramSource` use. Real tokenizer integration lands in slice 12+.
 fn estimate_tokens(content: &str) -> u32 {
     ((content.chars().count() / 4) as u32).saturating_add(1)
+}
+
+/// Build a `PeerId → display-name` map from ONE transcript page, reading
+/// `IdentityPublished` cards. This is the batched form of airc's
+/// per-peer `peer_alias` (which scans a full page EACH call): resolving
+/// N present peers one-at-a-time is N+1 page scans — N+1 IPC round-trips
+/// under the cognition lock for an N-peer room. One scan keeps a roster
+/// delivery O(1) in room size. Uses only public `airc_core` types and
+/// mirrors `airc_lib::Airc::peer_alias` parsing; later cards win
+/// (page is chronological, so a re-published name overrides an old one).
+pub(crate) fn parse_identity_names(events: Vec<TranscriptEvent>) -> HashMap<PeerId, String> {
+    let mut names = HashMap::new();
+    for event in events {
+        if event.kind != TranscriptKind::IdentityPublished {
+            continue;
+        }
+        let Some(Body::Json(value)) = event.body else {
+            continue;
+        };
+        let Ok(IdentityEvent::PeerIdentityCard(card)) =
+            serde_json::from_value::<IdentityEvent>(value)
+        else {
+            continue;
+        };
+        if !card.identity.name.is_empty() {
+            names.insert(event.peer_id, card.identity.name);
+        }
+    }
+    names
 }
 
 /// Abstract reader over airc room presence + identity. Production impl
@@ -99,8 +135,12 @@ pub trait AircRosterReader: Send + Sync {
         window: usize,
     ) -> Result<Vec<AgentLiveness>, AircError>;
 
-    /// Human-readable display alias for a peer, if known.
-    async fn peer_alias(&self, peer_id: PeerId) -> Result<Option<String>, AircError>;
+    /// All known peer display names in the room, as one `PeerId → name`
+    /// map built from a SINGLE transcript scan. Batched on purpose:
+    /// resolving names per-peer (airc's `peer_alias`) is one full page
+    /// scan EACH, i.e. N+1 IPC round-trips under the cognition lock for
+    /// an N-peer room. One map keeps a roster delivery O(1) in room size.
+    async fn peer_alias_map(&self) -> Result<HashMap<PeerId, String>, AircError>;
 }
 
 /// `airc_lib::Airc` satisfies the reader contract directly. Orphan rule
@@ -119,8 +159,9 @@ impl AircRosterReader for airc_lib::Airc {
         airc_lib::Airc::active_agents(self, within, window).await
     }
 
-    async fn peer_alias(&self, peer_id: PeerId) -> Result<Option<String>, AircError> {
-        airc_lib::Airc::peer_alias(self, peer_id).await
+    async fn peer_alias_map(&self) -> Result<HashMap<PeerId, String>, AircError> {
+        let events = airc_lib::Airc::page_recent(self, IDENTITY_SCAN).await?;
+        Ok(parse_identity_names(events))
     }
 }
 
@@ -229,6 +270,19 @@ impl RagSource for RoomRosterSource {
 
         let self_peer = self.reader.self_peer_id();
 
+        // Resolve ALL names in ONE scan, not per-peer. A failure here is
+        // non-fatal — degrade to short peer labels (still truthful) so a
+        // transient identity-read outage doesn't blank the roster or the
+        // turn. Logged at debug so an outage is observable.
+        let names = self.reader.peer_alias_map().await.unwrap_or_else(|err| {
+            tracing::debug!(
+                error = %err,
+                persona_id = %self.persona_id,
+                "room_roster: peer_alias_map failed — falling back to short peer labels"
+            );
+            HashMap::new()
+        });
+
         let mut items: Vec<RagItem> = Vec::new();
         let mut tokens_used: u32 = 0;
         for agent in agents {
@@ -237,13 +291,12 @@ impl RagSource for RoomRosterSource {
             if agent.peer == self_peer {
                 continue;
             }
-            // Best-effort alias; fall back to a short peer label so a
-            // present citizen is never invisible just because its alias
-            // lookup failed.
-            let name = match self.reader.peer_alias(agent.peer).await {
-                Ok(Some(alias)) => alias,
-                _ => Self::short_peer_label(agent.peer),
-            };
+            // Name from the single-scan map; fall back to a short peer
+            // label so a present citizen is never invisible.
+            let name = names
+                .get(&agent.peer)
+                .cloned()
+                .unwrap_or_else(|| Self::short_peer_label(agent.peer));
             let availability = agent.coordination.availability.map(|a| format!("{a:?}"));
             let item = Self::make_item(
                 agent.peer,
@@ -348,12 +401,11 @@ mod tests {
             }
             Ok(self.agents.clone())
         }
-        async fn peer_alias(&self, peer_id: PeerId) -> Result<Option<String>, AircError> {
-            Ok(self
-                .aliases
-                .iter()
-                .find(|(p, _)| *p == peer_id)
-                .map(|(_, a)| a.clone()))
+        async fn peer_alias_map(&self) -> Result<HashMap<PeerId, String>, AircError> {
+            if *self.fail.lock().unwrap() {
+                return Err(AircError::UnknownPeer(PeerId::new()));
+            }
+            Ok(self.aliases.iter().cloned().collect())
         }
     }
 
@@ -387,6 +439,11 @@ mod tests {
         assert!(delivery.items[0].content.contains("win-claude"));
         assert!(delivery.items[0].content.contains("claude"));
         assert_eq!(delivery.items[0].metadata["runtime"], "claude");
+        // The service-loop projection reads metadata["display_name"] to
+        // populate other_persona_names (single-party history-drop). Lock
+        // that contract: the bare name must be present and match the
+        // transcript sender name, not the formatted line.
+        assert_eq!(delivery.items[0].metadata["display_name"], "win-claude");
         assert!(delivery.continuation.is_none());
     }
 

--- a/core/continuum-core/src/persona/room_roster_source.rs
+++ b/core/continuum-core/src/persona/room_roster_source.rs
@@ -1,0 +1,507 @@
+//! RoomRosterSource — reads real airc room presence (`active_agents`)
+//! and packages "who else is in this room right now" as RagItems for
+//! the budget allocator.
+//!
+//! ### Why this source exists
+//!
+//! The persona cognition loop binds `engram + airc` sources and grounds
+//! the turn in recalled memory + recent transcript. But it had **no
+//! grounding in who the other participants are** — the airc transcript
+//! delivers messages tagged with other citizens' names, while the
+//! system prompt only says "you are <name>, never narrate others"
+//! without ever naming who "others" are. Under that gap a small model
+//! sees `BigMama:`, `Joel:`, `IntelMac:` in the history and role-plays
+//! the whole room (the Ivar confabulation bug).
+//!
+//! This source closes the gap by reading the **truthful** presence list
+//! from airc — not a static seed, not a guess — and delivering one item
+//! per present citizen. The projection layer routes these into
+//! **system-prompt grounding** (a `[Present in this room]` block), NOT
+//! the conversation history (which would re-create the very "is this a
+//! message?" confusion). See
+//! [[docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md]] §5 slice 1.
+//!
+//! ### Architecture
+//!
+//! Mirrors [`AircRagSource`] exactly: abstracts an `AircRosterReader`
+//! trait so unit tests don't need a live airc daemon. The real impl
+//! rides on `airc_lib::Airc::active_agents` + `peer_alias` +
+//! `peer_id` (self, to exclude the persona from its own roster). This
+//! is the adapter-first rail: ship the trait + the real impl + a stub.
+//!
+//! ### Security grounding (per the airc-native doc §4)
+//!
+//! Each `AgentLiveness` carries a `runtime` label
+//! (`"claude"`/`"codex"`/`"persona"`/`"interactive"`) — outsider agents
+//! self-identify. The source carries that origin into item metadata so
+//! downstream slices can mark grid-local citizens vs outsider agents and
+//! let a persona weigh instructions by origin. Slice 1 only surfaces it;
+//! enforcement is slice 3.
+//!
+//! ### Doctrine alignment
+//!
+//! - [[substrate-is-a-good-citizen-on-the-host]]: a failed presence read
+//!   returns an empty delivery + `tracing::warn` — cognition stays up
+//!   even when the airc subsystem is degraded.
+//! - Persona-scoped at construction: a cross-persona ctx returns empty
+//!   (defense in depth, same shape as `AircRagSource`).
+//! - Roster is small + always-current; no pagination (atomic unit = one
+//!   present citizen, like the `ToolSource` precedent in the trait doc).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use airc_core::PeerId;
+use airc_lib::{AgentLiveness, AircError};
+use async_trait::async_trait;
+
+use crate::persona::rag_budget::{
+    ContinuationCursor, RagContext, RagDelivery, RagItem, RagSource, ResolutionPreference,
+};
+
+/// Source identifier — used by budget presets, telemetry, and the
+/// service-loop projection that routes this delivery into system-prompt
+/// grounding rather than conversation history.
+const SOURCE_ID: &str = "room-roster";
+
+/// How far back a heartbeat counts as "present". Matches the airc
+/// agent-liveness convention of a short recency window — a peer that
+/// hasn't beaten within this window is treated as gone.
+const PRESENCE_WINDOW: Duration = Duration::from_secs(120);
+
+/// How many recent transcript events to scan for heartbeats. The
+/// presence reduction keeps one entry per peer, so this only needs to
+/// be large enough to span the heartbeat cadence across all present
+/// peers — not the full scrollback.
+const HEARTBEAT_SCAN: usize = 200;
+
+/// Rough chars/token estimate — same heuristic `AircRagSource` /
+/// `EngramSource` use. Real tokenizer integration lands in slice 12+.
+fn estimate_tokens(content: &str) -> u32 {
+    ((content.chars().count() / 4) as u32).saturating_add(1)
+}
+
+/// Abstract reader over airc room presence + identity. Production impl
+/// rides on `airc_lib::Airc`; tests use a stub that returns canned
+/// liveness without needing a daemon.
+#[async_trait]
+pub trait AircRosterReader: Send + Sync {
+    /// This persona's own airc peer id — used to exclude self from the
+    /// roster so the grounding block reads "who is NOT me".
+    fn self_peer_id(&self) -> PeerId;
+
+    /// Currently-alive agents in this persona's room, within `within`,
+    /// scanning the most recent `window` transcript events. Newest-wins
+    /// per peer; peers that signalled `Leaving` are excluded by airc.
+    async fn active_agents(
+        &self,
+        within: Duration,
+        window: usize,
+    ) -> Result<Vec<AgentLiveness>, AircError>;
+
+    /// Human-readable display alias for a peer, if known.
+    async fn peer_alias(&self, peer_id: PeerId) -> Result<Option<String>, AircError>;
+}
+
+/// `airc_lib::Airc` satisfies the reader contract directly. Orphan rule
+/// OK — the trait is ours (defined in this crate).
+#[async_trait]
+impl AircRosterReader for airc_lib::Airc {
+    fn self_peer_id(&self) -> PeerId {
+        airc_lib::Airc::peer_id(self)
+    }
+
+    async fn active_agents(
+        &self,
+        within: Duration,
+        window: usize,
+    ) -> Result<Vec<AgentLiveness>, AircError> {
+        airc_lib::Airc::active_agents(self, within, window).await
+    }
+
+    async fn peer_alias(&self, peer_id: PeerId) -> Result<Option<String>, AircError> {
+        airc_lib::Airc::peer_alias(self, peer_id).await
+    }
+}
+
+/// RoomRosterSource — persona-bound, reads presence from any
+/// `AircRosterReader`.
+pub struct RoomRosterSource {
+    persona_id: uuid::Uuid,
+    reader: Arc<dyn AircRosterReader>,
+}
+
+impl RoomRosterSource {
+    pub fn new(persona_id: uuid::Uuid, reader: Arc<dyn AircRosterReader>) -> Self {
+        Self { persona_id, reader }
+    }
+
+    /// Short, stable fallback label when a peer has no alias — the first
+    /// 8 hex chars of its uuid. Never empty, never panics.
+    fn short_peer_label(peer: PeerId) -> String {
+        let s = peer.as_uuid().to_string();
+        s.chars().take(8).collect()
+    }
+
+    /// Format one present citizen as a roster line. The line is
+    /// human-readable on its own; the structured parts also ride in
+    /// metadata so prompt-assembly and sentinel verifiers can render /
+    /// trace without re-parsing the string.
+    ///
+    /// Shape: `<name> [<runtime>]` plus ` — <availability>` when the
+    /// peer reported one. Examples: `Aria [persona]`,
+    /// `win-claude [claude] — Busy`.
+    fn format_line(name: &str, runtime: &str, availability: Option<String>) -> String {
+        match availability {
+            Some(avail) => format!("{name} [{runtime}] — {avail}"),
+            None => format!("{name} [{runtime}]"),
+        }
+    }
+
+    fn make_item(
+        peer: PeerId,
+        name: String,
+        runtime: String,
+        availability: Option<String>,
+        last_seen_ms: u64,
+    ) -> RagItem {
+        let content = Self::format_line(&name, &runtime, availability.clone());
+        let tokens = estimate_tokens(&content);
+        RagItem {
+            content,
+            tokens,
+            metadata: serde_json::json!({
+                "peer_id": peer.as_uuid().to_string(),
+                "display_name": name,
+                "runtime": runtime,
+                "availability": availability,
+                "last_seen_ms": last_seen_ms,
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl RagSource for RoomRosterSource {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    async fn deliver(
+        &self,
+        ctx: &RagContext,
+        budget: u32,
+        resolution: ResolutionPreference,
+    ) -> RagDelivery {
+        // Persona-scoped: a cross-persona ctx gets nothing (defense in
+        // depth, same shape as AircRagSource).
+        if ctx.persona_id != self.persona_id {
+            return RagDelivery {
+                source_id: SOURCE_ID.to_string(),
+                items: Vec::new(),
+                tokens_used: 0,
+                continuation: None,
+                resolution_used: ResolutionPreference::Placeholder,
+            };
+        }
+
+        let agents = match self
+            .reader
+            .active_agents(PRESENCE_WINDOW, HEARTBEAT_SCAN)
+            .await
+        {
+            Ok(a) => a,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    persona_id = %self.persona_id,
+                    "room_roster: active_agents failed — empty delivery, cognition stays up"
+                );
+                return RagDelivery {
+                    source_id: SOURCE_ID.to_string(),
+                    items: Vec::new(),
+                    tokens_used: 0,
+                    continuation: None,
+                    resolution_used: ResolutionPreference::Placeholder,
+                };
+            }
+        };
+
+        let self_peer = self.reader.self_peer_id();
+
+        let mut items: Vec<RagItem> = Vec::new();
+        let mut tokens_used: u32 = 0;
+        for agent in agents {
+            // Exclude self — the roster grounds the persona in who is
+            // NOT itself.
+            if agent.peer == self_peer {
+                continue;
+            }
+            // Best-effort alias; fall back to a short peer label so a
+            // present citizen is never invisible just because its alias
+            // lookup failed.
+            let name = match self.reader.peer_alias(agent.peer).await {
+                Ok(Some(alias)) => alias,
+                _ => Self::short_peer_label(agent.peer),
+            };
+            let availability = agent.coordination.availability.map(|a| format!("{a:?}"));
+            let item = Self::make_item(
+                agent.peer,
+                name,
+                agent.runtime.clone(),
+                availability,
+                agent.last_seen_ms,
+            );
+            if tokens_used.saturating_add(item.tokens) > budget {
+                // Budget exhausted. Roster is unordered presence; we
+                // stop rather than paginate (atomic unit = one present
+                // citizen, no continuation). A truncated roster is
+                // still truthful for the citizens it names.
+                break;
+            }
+            tokens_used += item.tokens;
+            items.push(item);
+        }
+
+        tracing::debug!(
+            persona_id = %self.persona_id,
+            budget,
+            present = items.len(),
+            tokens_used,
+            "room_roster: deliver"
+        );
+
+        RagDelivery {
+            source_id: SOURCE_ID.to_string(),
+            items,
+            tokens_used,
+            // Presence is always-current and small; no pagination.
+            continuation: None,
+            resolution_used: resolution,
+        }
+    }
+
+    async fn deliver_continuation(
+        &self,
+        _ctx: &RagContext,
+        _cursor: ContinuationCursor,
+        _budget: u32,
+    ) -> Option<RagDelivery> {
+        // Roster does not paginate — it's a small, always-current
+        // snapshot. Any cursor is stale by construction.
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    fn persona() -> Uuid {
+        Uuid::parse_str("00000000-0000-0000-0000-000000000aaa").unwrap()
+    }
+
+    fn ctx() -> RagContext {
+        RagContext::for_persona(persona(), 1_000_000)
+    }
+
+    /// Test double — canned liveness + alias map, optional failure.
+    struct StubReader {
+        self_peer: PeerId,
+        agents: Vec<AgentLiveness>,
+        aliases: Vec<(PeerId, String)>,
+        fail: Mutex<bool>,
+    }
+
+    impl StubReader {
+        fn new(self_peer: PeerId, agents: Vec<AgentLiveness>) -> Self {
+            Self {
+                self_peer,
+                agents,
+                aliases: Vec::new(),
+                fail: Mutex::new(false),
+            }
+        }
+        fn with_alias(mut self, peer: PeerId, alias: &str) -> Self {
+            self.aliases.push((peer, alias.to_string()));
+            self
+        }
+        fn set_fail(&self, fail: bool) {
+            *self.fail.lock().unwrap() = fail;
+        }
+    }
+
+    #[async_trait]
+    impl AircRosterReader for StubReader {
+        fn self_peer_id(&self) -> PeerId {
+            self.self_peer
+        }
+        async fn active_agents(
+            &self,
+            _within: Duration,
+            _window: usize,
+        ) -> Result<Vec<AgentLiveness>, AircError> {
+            if *self.fail.lock().unwrap() {
+                return Err(AircError::UnknownPeer(PeerId::new()));
+            }
+            Ok(self.agents.clone())
+        }
+        async fn peer_alias(&self, peer_id: PeerId) -> Result<Option<String>, AircError> {
+            Ok(self
+                .aliases
+                .iter()
+                .find(|(p, _)| *p == peer_id)
+                .map(|(_, a)| a.clone()))
+        }
+    }
+
+    fn liveness(peer: PeerId, runtime: &str) -> AgentLiveness {
+        AgentLiveness {
+            peer,
+            runtime: runtime.to_string(),
+            client_id: None,
+            scope: None,
+            build: None,
+            last_seen_ms: 1_000_000,
+            coordination: Default::default(),
+        }
+    }
+
+    // what this catches: the confabulation root cause — a present peer
+    // must surface in the roster with a real alias + its origin runtime,
+    // so the persona is grounded in who else is here.
+    #[tokio::test]
+    async fn present_peer_surfaces_with_alias_and_origin() {
+        let me = PeerId::new();
+        let other = PeerId::new();
+        let reader = Arc::new(
+            StubReader::new(me, vec![liveness(other, "claude")]).with_alias(other, "win-claude"),
+        );
+        let source = RoomRosterSource::new(persona(), reader);
+        let delivery = source
+            .deliver(&ctx(), 1_000, ResolutionPreference::Raw)
+            .await;
+        assert_eq!(delivery.items.len(), 1);
+        assert!(delivery.items[0].content.contains("win-claude"));
+        assert!(delivery.items[0].content.contains("claude"));
+        assert_eq!(delivery.items[0].metadata["runtime"], "claude");
+        assert!(delivery.continuation.is_none());
+    }
+
+    // what this catches: the persona must NOT appear in its own roster —
+    // the block is "who is NOT me". A self-entry would re-introduce the
+    // self/other confusion the source exists to remove.
+    #[tokio::test]
+    async fn self_peer_excluded_from_roster() {
+        let me = PeerId::new();
+        let other = PeerId::new();
+        let reader = Arc::new(StubReader::new(
+            me,
+            vec![liveness(me, "persona"), liveness(other, "persona")],
+        ));
+        let source = RoomRosterSource::new(persona(), reader);
+        let delivery = source
+            .deliver(&ctx(), 1_000, ResolutionPreference::Raw)
+            .await;
+        assert_eq!(delivery.items.len(), 1, "only the other peer, not self");
+        assert_eq!(
+            delivery.items[0].metadata["peer_id"],
+            other.as_uuid().to_string()
+        );
+    }
+
+    // what this catches: a peer with no alias is still surfaced (short
+    // peer label), never silently dropped — an unnamed citizen is worse
+    // than a uuid-labelled one for grounding.
+    #[tokio::test]
+    async fn peer_without_alias_falls_back_to_short_label() {
+        let me = PeerId::new();
+        let other = PeerId::new();
+        let reader = Arc::new(StubReader::new(me, vec![liveness(other, "codex")]));
+        let source = RoomRosterSource::new(persona(), reader);
+        let delivery = source
+            .deliver(&ctx(), 1_000, ResolutionPreference::Raw)
+            .await;
+        assert_eq!(delivery.items.len(), 1);
+        let expected = other
+            .as_uuid()
+            .to_string()
+            .chars()
+            .take(8)
+            .collect::<String>();
+        assert!(delivery.items[0].content.contains(&expected));
+    }
+
+    // what this catches: empty room → empty delivery, no panic.
+    #[tokio::test]
+    async fn empty_room_delivers_nothing() {
+        let me = PeerId::new();
+        let reader = Arc::new(StubReader::new(me, vec![]));
+        let source = RoomRosterSource::new(persona(), reader);
+        let delivery = source
+            .deliver(&ctx(), 1_000, ResolutionPreference::Raw)
+            .await;
+        assert!(delivery.items.is_empty());
+        assert_eq!(delivery.tokens_used, 0);
+    }
+
+    // what this catches: airc degraded → empty delivery, cognition stays
+    // up (good-citizen doctrine). A roster read failure must never take
+    // down the turn.
+    #[tokio::test]
+    async fn reader_error_returns_empty_no_panic() {
+        let me = PeerId::new();
+        let other = PeerId::new();
+        let reader = Arc::new(StubReader::new(me, vec![liveness(other, "persona")]));
+        reader.set_fail(true);
+        let source = RoomRosterSource::new(persona(), reader);
+        let delivery = source
+            .deliver(&ctx(), 1_000, ResolutionPreference::Raw)
+            .await;
+        assert!(delivery.items.is_empty());
+        assert_eq!(delivery.tokens_used, 0);
+    }
+
+    // what this catches: cross-persona ctx gets nothing (defense in
+    // depth) — a persona must never read another's room grounding.
+    #[tokio::test]
+    async fn cross_persona_ctx_returns_empty() {
+        let me = PeerId::new();
+        let other = PeerId::new();
+        let reader = Arc::new(StubReader::new(me, vec![liveness(other, "persona")]));
+        let source = RoomRosterSource::new(persona(), reader);
+        let alien = Uuid::parse_str("00000000-0000-0000-0000-000000000bbb").unwrap();
+        let delivery = source
+            .deliver(
+                &RagContext::for_persona(alien, 1_000_000),
+                1_000,
+                ResolutionPreference::Raw,
+            )
+            .await;
+        assert!(delivery.items.is_empty());
+        assert_eq!(delivery.resolution_used, ResolutionPreference::Placeholder);
+    }
+
+    // what this catches: budget truncates the roster instead of
+    // over-spending — a present citizen's line is an atomic unit, so we
+    // stop cleanly rather than emit a partial line.
+    #[tokio::test]
+    async fn budget_truncates_without_overspend() {
+        let me = PeerId::new();
+        let reader = Arc::new(StubReader::new(
+            me,
+            vec![
+                liveness(PeerId::new(), "persona"),
+                liveness(PeerId::new(), "persona"),
+                liveness(PeerId::new(), "persona"),
+            ],
+        ));
+        let source = RoomRosterSource::new(persona(), reader);
+        // Each line ~ a handful of tokens; a tiny budget fits at most one.
+        let delivery = source.deliver(&ctx(), 4, ResolutionPreference::Raw).await;
+        assert!(delivery.items.len() < 3, "budget must truncate the roster");
+        assert!(delivery.tokens_used <= 4, "never overspend the budget");
+    }
+}

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -530,6 +530,22 @@ async fn serve_persona_loop_inner(
                 }
             })
             .collect();
+        // Project the room-roster delivery → RespondInput.room_roster.
+        // Routed by source_id to system-prompt GROUNDING, deliberately
+        // NOT into recent_history above: the roster names who is present
+        // (identity grounding), it is not conversation. Injecting it as
+        // history is the exact confusion the source exists to remove.
+        // Each item's `content` is already a formatted line
+        // (`name [runtime] — availability`). See
+        // docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 1.
+        let room_roster: Vec<String> = composed
+            .deliveries
+            .iter()
+            .filter(|d| d.source_id == "room-roster")
+            .flat_map(|d| d.items.iter())
+            .map(|item| item.content.clone())
+            .collect();
+
         // recalled_engrams is populated above from
         // admission.recall_recent(8) — substrate-managed memory,
         // not the airc transcript window. The engram delivery from
@@ -579,6 +595,7 @@ async fn serve_persona_loop_inner(
             message_media: Vec::new(),
             capabilities: std::collections::HashSet::new(),
             recalled_engrams,
+            room_roster,
         };
 
         // 3. Run the cognition cycle. The persona may speak or stay

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -530,21 +530,36 @@ async fn serve_persona_loop_inner(
                 }
             })
             .collect();
-        // Project the room-roster delivery → RespondInput.room_roster.
-        // Routed by source_id to system-prompt GROUNDING, deliberately
-        // NOT into recent_history above: the roster names who is present
-        // (identity grounding), it is not conversation. Injecting it as
-        // history is the exact confusion the source exists to remove.
-        // Each item's `content` is already a formatted line
-        // (`name [runtime] — availability`). See
-        // docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 1.
-        let room_roster: Vec<String> = composed
+        // Project the room-roster delivery into TWO consumers from the
+        // ONE source of truth (the roster delivery), routed by source_id:
+        //   • `room_roster` — the formatted `name [runtime] — avail`
+        //     lines → system-prompt GROUNDING ([Present in this room]).
+        //     Deliberately NOT recent_history: the roster names who is
+        //     present (identity grounding), it is not conversation —
+        //     injecting it as history is the confusion the source removes.
+        //   • `other_persona_names` — bare display names → the
+        //     `ProperChatMlSingleParty` history-drop (single-party models
+        //     can't process other-AI turns). This field was reserved for
+        //     exactly this roster data and previously sat empty; the same
+        //     delivery now feeds it, so there is one roster truth, not two.
+        // See docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 1.
+        let mut room_roster: Vec<String> = Vec::new();
+        let mut other_persona_names: Vec<String> = Vec::new();
+        for item in composed
             .deliveries
             .iter()
             .filter(|d| d.source_id == "room-roster")
             .flat_map(|d| d.items.iter())
-            .map(|item| item.content.clone())
-            .collect();
+        {
+            room_roster.push(item.content.clone());
+            if let Some(name) = item
+                .metadata
+                .get("display_name")
+                .and_then(|v| v.as_str())
+            {
+                other_persona_names.push(name.to_string());
+            }
+        }
 
         // recalled_engrams is populated above from
         // admission.recall_recent(8) — substrate-managed memory,

--- a/core/continuum-core/src/persona/service_module.rs
+++ b/core/continuum-core/src/persona/service_module.rs
@@ -482,6 +482,11 @@ impl PersonaServiceModule {
             message_media: Vec::new(),
             capabilities: persona.responder_config.capabilities.clone(),
             recalled_engrams: Vec::new(),
+            // Roster grounding flows through the service-loop / compose
+            // projection, not this burst projection — defaults empty
+            // here (no [Present in this room] block), same tolerated-
+            // absence shape as other_persona_names above.
+            room_roster: Vec::new(),
         }
     }
 

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -485,6 +485,19 @@ pub async fn materialize_adapters(
         );
         cognition.set_airc_source(airc_source);
 
+        // Bind the room-roster source from the SAME runtime — it
+        // upcasts to `AircRosterReader` (a supertrait of AircCitizen)
+        // just as it does to `AircTranscriptReader` above. This is what
+        // grounds the persona in who else is present (and who is NOT
+        // itself). See docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md
+        // §5 slice 1.
+        let roster_source: Arc<dyn crate::persona::rag_budget::RagSource> =
+            Arc::new(crate::persona::room_roster_source::RoomRosterSource::new(
+                identity.persona_id,
+                runtime.clone(),
+            ));
+        cognition.set_roster_source(roster_source);
+
         let system_prompt = build_persona_system_prompt(&identity.agent_name);
 
         out.push(Ok(PersonaContext {

--- a/core/continuum-core/src/persona/unified.rs
+++ b/core/continuum-core/src/persona/unified.rs
@@ -30,6 +30,13 @@ use crate::rag::RagEngine;
 use std::sync::Arc;
 use uuid::Uuid;
 
+/// Token ceiling for the lightweight room-roster source. A roster is a
+/// handful of presence lines (tens of tokens); capping its budget keeps
+/// it from competing with the heavyweight engram/airc sources for grow
+/// headroom (which would shrink delivered recent_history). See the
+/// budget-claim rationale in `compose_for_turn`.
+const ROSTER_MAX_TOKENS: u32 = 256;
+
 /// All cognitive state for a single persona — single lock, cache-local.
 pub struct PersonaCognition {
     pub engine: PersonaCognitionEngine,
@@ -267,22 +274,43 @@ impl PersonaCognition {
             sources.push(roster.clone());
         }
 
-        // Per-source budget claims. Even split between the two
-        // first-class sources by default — the flex allocator
-        // re-distributes idle headroom toward whoever asks. The
-        // recent-conversation floor lives on airc per the
-        // cognition-cache-hierarchy doc.
+        // Per-source budget claims. The two HEAVYWEIGHT sources (engram
+        // long-term memory + airc recent conversation) split idle
+        // headroom evenly; the recent-conversation floor lives on airc
+        // per the cognition-cache-hierarchy doc. The room-roster source
+        // is LIGHTWEIGHT — a handful of presence lines, tens of tokens —
+        // so it claims a small fixed budget with NO floor. Giving it the
+        // same 500/500/per_source_max claim as the heavyweights would
+        // (a) at small context windows let the floor sum exceed
+        // available and starve airc (the roster, sorted last, would also
+        // drop to 0), and (b) at normal windows split grow-headroom 3
+        // ways instead of 2, shrinking airc's delivered recent_history.
+        // A source's budget should reflect its real appetite.
         let per_source_max = ((context_window as u64) * 6 / 10) as u32;
         let per_source_max = per_source_max.min(headroom);
+        let roster_max = ROSTER_MAX_TOKENS.min(per_source_max);
         let budgets: Vec<RagSourceBudget> = sources
             .iter()
-            .map(|s| RagSourceBudget {
-                source_id: s.source_id().to_string(),
-                priority: 10,
-                floor_tokens: 500_u32.min(per_source_max),
-                min_tokens: 500_u32.min(per_source_max),
-                max_tokens: per_source_max,
-                required: false,
+            .map(|s| {
+                if s.source_id() == "room-roster" {
+                    RagSourceBudget {
+                        source_id: s.source_id().to_string(),
+                        priority: 10,
+                        floor_tokens: 0,
+                        min_tokens: 0,
+                        max_tokens: roster_max,
+                        required: false,
+                    }
+                } else {
+                    RagSourceBudget {
+                        source_id: s.source_id().to_string(),
+                        priority: 10,
+                        floor_tokens: 500_u32.min(per_source_max),
+                        min_tokens: 500_u32.min(per_source_max),
+                        max_tokens: per_source_max,
+                        required: false,
+                    }
+                }
             })
             .collect();
 

--- a/core/continuum-core/src/persona/unified.rs
+++ b/core/continuum-core/src/persona/unified.rs
@@ -77,6 +77,16 @@ pub struct PersonaCognition {
     /// `runtime.transcript_reader()`) only becomes available after
     /// PersonaAircRuntime bootstraps.
     pub airc_source: Option<Arc<dyn RagSource>>,
+    /// The persona's room-roster RAG source — "who else is present in
+    /// this room right now", read from airc `active_agents`. Bound at
+    /// supervisor boot alongside `airc_source` (same `Airc` handle, which
+    /// satisfies `AircRosterReader`). `None` pre-attach / in unit tests
+    /// without a daemon; `Some` in production. Its delivery is routed by
+    /// the service loop into system-prompt GROUNDING (a `[Present in
+    /// this room]` block), not conversation history — the fix for a
+    /// persona confabulating other citizens' turns. See
+    /// docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 1.
+    pub roster_source: Option<Arc<dyn RagSource>>,
     /// The capture sink the RecordingRagSource wraps engram_source
     /// against. Default = `NoopRagCaptureSink` (zero overhead, drops
     /// events on the floor). Production callers swap in
@@ -161,6 +171,7 @@ impl PersonaCognition {
             recall_metadata,
             engram_source,
             airc_source: None,
+            roster_source: None,
             capture_sink,
         }
     }
@@ -181,6 +192,21 @@ impl PersonaCognition {
             self.capture_sink.clone(),
         ));
         self.airc_source = Some(decorated);
+    }
+
+    /// Bind the brain's room-roster RAG source (`RoomRosterSource`).
+    /// Called by the supervisor at boot with the same `Airc` handle that
+    /// backs `airc_source` (it satisfies `AircRosterReader`). Decorated
+    /// with the brain's `capture_sink` so roster deliveries are recorded
+    /// + replayable on the same wire as engrams and airc transcript
+    /// (per [[persona-record-replay-is-a-product-requirement]]). Boot-
+    /// time wire, not a per-turn allocation.
+    pub fn set_roster_source(&mut self, raw_source: Arc<dyn RagSource>) {
+        let decorated: Arc<dyn RagSource> = Arc::new(RecordingRagSource::new(
+            ArcRagSource::new(raw_source),
+            self.capture_sink.clone(),
+        ));
+        self.roster_source = Some(decorated);
     }
 
     /// Brain composition for one cognition turn. Walks the brain's
@@ -229,10 +255,16 @@ impl PersonaCognition {
         // then airc (the L1 conversational floor). Future sources
         // (code, tool descriptions, identity card) extend this list
         // in order of long-term-to-immediate.
-        let mut sources: Vec<Arc<dyn RagSource>> = Vec::with_capacity(2);
+        let mut sources: Vec<Arc<dyn RagSource>> = Vec::with_capacity(3);
         sources.push(self.engram_source.clone());
         if let Some(ref airc) = self.airc_source {
             sources.push(airc.clone());
+        }
+        // The "identity card" source the original author reserved this
+        // list for: who else is present in the room right now. Routed
+        // by the service loop into system-prompt grounding, not history.
+        if let Some(ref roster) = self.roster_source {
+            sources.push(roster.clone());
         }
 
         // Per-source budget claims. Even split between the two

--- a/core/continuum-core/tests/persona_respond_replay.rs
+++ b/core/continuum-core/tests/persona_respond_replay.rs
@@ -184,6 +184,7 @@ fn build_input(fix: &Fixture, known_specialties: Vec<String>) -> RespondInput {
         // populate this explicitly (see vision_integration.rs).
         capabilities: std::collections::HashSet::new(),
         recalled_engrams: Vec::new(),
+        room_roster: Vec::new(),
     }
 }
 
@@ -296,6 +297,7 @@ async fn clean_minimal_input_produces_spoke() {
         message_media: Vec::new(),
         capabilities: std::collections::HashSet::new(),
         recalled_engrams: Vec::new(),
+        room_roster: Vec::new(),
     };
     let response = respond(input)
         .await
@@ -482,6 +484,7 @@ async fn synthesized_prod_shape_input_produces_coherent_response() {
         message_media: Vec::new(),
         capabilities: std::collections::HashSet::new(),
         recalled_engrams: Vec::new(),
+        room_roster: Vec::new(),
     };
     let response = respond(input)
         .await
@@ -622,6 +625,7 @@ async fn long_code_generation_request_completes_without_clipping() {
         message_media: Vec::new(),
         capabilities: std::collections::HashSet::new(),
         recalled_engrams: Vec::new(),
+        room_roster: Vec::new(),
     };
 
     let response = respond(input)

--- a/core/continuum-core/tests/vision_integration.rs
+++ b/core/continuum-core/tests/vision_integration.rs
@@ -103,6 +103,7 @@ fn build_vision_request(model_id: &str) -> RespondInput {
         // Vision capability — caller-declared, no registry lookup.
         capabilities: caps,
         recalled_engrams: Vec::new(),
+        room_roster: Vec::new(),
     }
 }
 

--- a/docs/grid/AIRC-CONTINUUM-BRIDGE.md
+++ b/docs/grid/AIRC-CONTINUUM-BRIDGE.md
@@ -3,6 +3,13 @@
 Status: v0 development/test harness; target architecture for chat substrate
 migration.
 
+> **Superseded for identity/rooms/security:** the framing below where Continuum
+> "owns which rooms exist and which user may speak" predates the airc-native
+> principle. Identity, rooms, and security now *just use airc* — see
+> [AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md](AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md).
+> This doc remains accurate for the transport / side-channel / forge-contract
+> split.
+
 AIRC is the external collaboration wire and should become the primary
 handshake, initiation, and pipeline-control substrate. Continuum remains the
 runtime under test: it owns commands, persona behavior, model/runtime state,

--- a/docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md
+++ b/docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md
@@ -1,0 +1,187 @@
+# airc-Native Identity, Rooms & Security
+
+Status: design / "begin anew". Supersedes the identity-rooms-security framing in
+[AIRC-CONTINUUM-BRIDGE.md](AIRC-CONTINUUM-BRIDGE.md) (which remains accurate for
+the transport/side-channel + forge-contract split, but predates this principle).
+
+## 0. The principle (one source of truth)
+
+> **The JTAG user, rooms, identity, auth, and security just use airc — as it was
+> meant. Continuum stops reinventing them.**
+
+The legacy Node/TS side grew its own parallel notions of user, session, room,
+and access. That is the "mess" we are not porting. airc already *is* an identity
++ membership + trust substrate; using it as meant collapses four hand-rolled
+continuum concepts into the airc primitives that already own them:
+
+| Continuum concept (was reinvented) | Is just… (airc primitive) |
+|---|---|
+| User / citizen identity | airc **`peer_id`** (per-citizen) |
+| Grid boundary + auth | airc **`mesh_identity`** (GH login = the fence) |
+| Display name | airc **`peer_alias`** / `peer_identity_card` |
+| Room / **activity / content** (three ids, one thing) | airc **`RoomId`** (one id) |
+| "Who is here right now" | airc **`active_agents()`** presence |
+| Origin (is this an outsider agent?) | airc heartbeat **`runtime`** label |
+| Trust / who-may-do-what | airc grid **`TrustLevel`** + room doctrine |
+
+This is the compression law (E = mc²) applied to integration: **one logical
+decision, one place.** Identity is decided in airc. Rooms are decided in airc.
+Trust is decided in airc. Continuum reads them; it does not shadow them.
+
+### 0.1 Thin continuum, generic airc
+
+The corollary to "one source of truth" is **build as thin as possible.** We fix
+the crazy muddled continuum code by *removing* the parallel machinery, not adding
+adapters on top of it. Every identity/room/session/trust need that can live in
+airc moves into airc; continuum keeps only its real concern (commands, persona
+cognition, model/runtime state, projections).
+
+airc is a **generic grid substrate**, not a continuum-private dependency. It is
+meant for this. So we optimize airc for these needs once, and the same substrate
+serves any consumer that adapts to it — hermes, openclaw, other front-ends, and
+the airc agents (Claude, Codex) themselves. The test for "where does this
+belong?": if the need is generic to *any* grid system (identity, presence,
+rooms, access control), it belongs in airc; if it is continuum's domain
+(cognition, model serving), it stays thin in continuum.
+
+### 0.2 The CLI is an airc connection
+
+`./jtag` connecting to continuum **is an airc connection.** The JTAG/operator
+user is an airc peer like any other; the CLI is an airc client. There is no
+separate CLI auth or CLI session story — it authenticates as its airc identity.
+This is what collapses "sessions" from a hand-rolled concept into a fact of the
+transport: a session is a peer connection (`peer_id` + `client_id`), nothing
+more.
+
+## 1. The id unification: roomId == activityId == contentId == airc RoomId
+
+The old model carried `roomId`, `activityId`, and `contentId` as separate
+identifiers. They are the same thing: **every activity in continuum is an airc
+room.** Chat is a room. Dev-coordination is a room. A video-game session is a
+room. Co-browsing is a room. The academy session is a room. The help screen is a
+room. Settings is a room. All of them are airc rooms, and "who is participating
+in this activity" is exactly "who has joined this airc room."
+
+airc derives `RoomId` deterministically from the room name (`uuid_v5(namespace,
+name)`), so the same activity name resolves to the same channel for every peer —
+local or cross-grid. There is no separate continuum room registry to keep in
+sync. The name **is** the addressing.
+
+### 1.1 Open-ended by construction
+
+The activity list above is illustrative, not exhaustive — and deliberately so. A
+Tron-like CLI, an augmented-reality surface, a multiplayer game world, a
+surface we haven't imagined yet: each one's "spaces" are just more airc rooms,
+addressed by name, with the same identity and the same authorization. **You add
+a surface, not a subsystem.** Nothing in the room/identity/security model
+enumerates known activity kinds, so nothing has to change to admit a new one.
+
+This is the creative dividend of ground-up coherence: because every surface
+reduces to (peer in a room under authz), a builder can compose wildly different
+experiences on one consistent substrate instead of re-solving identity, presence,
+and access for each. Keep the model from ever hardcoding "the kinds of rooms
+that exist."
+
+**Consequence:** the eventual Node/web rewrite (unified clients, reactive
+framework, mobile/positron-aware) keys every "open this activity" action off a
+single airc `RoomId`, not a trio. It borrows the old UI's *visuals* piece by
+piece; it does not borrow the muddled id model.
+
+## 2. Identity & auth: airc-native, no shadow session
+
+- **`peer_id`** is the citizen. One persona = one `peer_id` = one home dir = one
+  context (a Claude tab is the analogy). Humans, personas, and outsider agents
+  are all peers; the type differs, the addressing does not.
+- **`mesh_identity`** (GH login) is the grid boundary and the auth root. One
+  human per grid today; many personas; many outsider agents.
+- There is **no separate continuum session/identity layer**. Where the legacy
+  code minted a `UserEntity` + `sessionId` + device identity, the rebuild uses
+  the airc identity the peer already authenticated as. "Careful about identity,
+  session, etc." = *do not re-add a parallel identity system*; lean on airc.
+- **The JTAG user is an airc identity too.** The operator/CLI is a peer, not a
+  privileged out-of-band actor with its own auth story.
+
+## 3. Rooms as the activity scope
+
+A room is an activity context and a recipe/content scope simultaneously, because
+they are the same id. From a room a citizen can read:
+
+- **Membership / presence** — `active_agents(within, window)` reduces the recent
+  heartbeat window to one live entry per peer, newest-wins, excluding peers that
+  signalled `Leaving`. This is the truthful "who is here" — not a guess, not a
+  static seed.
+- **Room nature** — the activity kind (chat vs dev-coordination vs game vs
+  academy vs help vs settings). This is what tells a persona *how* to
+  participate: a coordination room is not a free-for-all chat. (Ivar's failure
+  was over-participating in a coordination room because it had no room-nature
+  signal.) Room doctrine (`room_doctrine` / `wall_trust_policy_for_room`) is the
+  airc-native home for this.
+
+## 4. Security done right (because identity is real)
+
+Outsider agents (Codex, Claude, others) can connect to **any** continuum room,
+including settings — so security cannot be an afterthought. Using airc as meant
+gives the substrate the primitives to do it right:
+
+- **Origin is in the presence data.** Each `AgentLiveness` carries a `runtime`
+  label (`"claude"`, `"codex"`, `"persona"`, `"interactive"`). Outsider agents
+  self-identify; the roster can mark grid-local citizens vs outsiders without a
+  separate lookup.
+- **Trust is airc grid `TrustLevel`** (`Blocked` < `Provisional` < `Trusted` <
+  `Owner`), enforced by [`grid/acl.rs`](../../core/continuum-core/src/modules/grid/acl.rs).
+  Cross-grid `ai/generate` is admitted at `Provisional` by policy (not a manual
+  per-machine elevation); sensitive ops stay `Owner`-only.
+- **Authorization can limit any first-class citizen, anywhere.** Because every
+  citizen (human, persona, outsider agent) is the *same kind* of airc peer, a
+  single access-control/authorization layer in the grid gates them uniformly —
+  no per-type special-casing. This is the security we will deeply need, done in
+  the system meant for it: the ability to constrain what any peer may do in any
+  room is one airc-native authz decision, not scattered continuum checks.
+- **Grounding-in-who-is-present is itself a security primitive.** A persona that
+  knows an instruction came from an untrusted outsider in a settings room can
+  decline it. A persona that knows the other names in the room are *real
+  citizens, not characters* will not impersonate them. The identity-grounding
+  fix (§5) and the trust model are the same effort seen from two sides.
+
+## 5. The rebuild, as slices (Rust core first — headless, zero Node)
+
+We are disconnected from Node right now and that is correct: this is pure
+continuum-core Rust. The Node/web unified-client rewrite is a later, separate
+effort.
+
+**Slice 1 — Roster grounding into cognition (the bug that started this).**
+The live cognition loop (`compose_for_turn`) binds `engram + airc` RAG sources
+and routes deliveries by `source_id`. It has no roster source, and
+`other_persona_names` is hardcoded empty (both since the original port, commit
+`4214287b`). So a persona sees a transcript full of other citizens' names with
+nothing telling it those are *other live peers* → it role-plays the whole room.
+
+Fix: a **`RoomRosterSource`** RAG source (mirroring `AircRagSource`: a reader
+trait over airc, persona-scoped, fails-safe-empty, test stub). It reads
+`active_agents`, excludes self, resolves aliases, and carries **name + origin
+(`runtime`) + availability** per present citizen. A new projection branch routes
+its delivery into **system-prompt grounding** (a `[Present in this room]` block
+rendered in `prompt_assembly::assemble`) — *not* the `airc → recent_history`
+branch, which would inject the roster as fake chat. It rides `capture_sink`, so
+it is recorded and replayable through the existing fixtures.
+
+**Slice 2 — Room-nature grounding.** Surface the room's activity kind (chat vs
+coordination vs game vs …) into the same recipe/RAG context, via airc room
+doctrine, so participation is calibrated to the activity.
+
+**Slice 3 — Trust/origin enforcement at the cognition boundary.** Use the roster
+trust annotation so a persona weighs instructions by origin, and so it declines
+out-of-scope requests from untrusted outsiders in sensitive rooms.
+
+**Later (not now) — Node/web unified clients.** Rewrite the legacy UI on a
+proper reactive framework, mobile/positron-aware, every activity opened by a
+single airc `RoomId`, every client authenticating as its airc identity. Borrow
+the old UI's visuals piece by piece; do not borrow its id/identity/session model.
+
+## 6. What this explicitly is NOT
+
+- NOT a new event model — airc owns transport (envelope ids, routing, delivery
+  semantics, replay, receipts); continuum reads.
+- NOT a parallel identity/session system — airc identity is the only identity.
+- NOT a new room registry — the room name resolves to the airc `RoomId`.
+- NOT a Node-side change right now — headless Rust core only.

--- a/docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md
+++ b/docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md
@@ -178,6 +178,16 @@ proper reactive framework, mobile/positron-aware, every activity opened by a
 single airc `RoomId`, every client authenticating as its airc identity. Borrow
 the old UI's visuals piece by piece; do not borrow its id/identity/session model.
 
+The performance case is the real driver: the legacy stack's latency
+**compounds**. Node was the prime culprit (per-call overhead × every persona ×
+every turn), atop broader legacy tech debt. With 14 personas today and a target
+of **~100**, a substrate designed for **ms-latency concurrency** (the Rust core
++ airc's optimized wire, per [[airc-performance-doctrine]]) is not a nicety —
+it's what makes a hundred citizens responsive instead of "waiting all day" while
+the lag accumulates. The thin-continuum / generic-airc shape (§0.1) is what lets
+that concurrent substrate carry every surface without each one re-paying the
+cost.
+
 ## 6. What this explicitly is NOT
 
 - NOT a new event model — airc owns transport (envelope ids, routing, delivery


### PR DESCRIPTION
## What

Slice 1 of the airc-native rebuild (`docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md`): ground persona cognition in **who else is present in the room**, read from airc — the fix for personas confabulating other citizens' turns (the "Ivar" bug).

## Why

The cognition loop had no grounding in room presence: `compose_for_turn` bound only `engram + airc` sources, and `other_persona_names` was hardcoded empty — both since the original port (`4214287b`). A small model saw other citizens' names in the transcript with nothing declaring them real, distinct participants, so it role-played the whole room.

## How

- **`RoomRosterSource`** — a `RagSource` reading airc `active_agents` (truthful presence, incl. cross-grid peers + each peer's `runtime` origin), persona-scoped, fails-safe-empty, with a test stub. Mirrors `AircRagSource`.
- **`AircRosterReader`** — a second supertrait of `AircCitizen` (symmetric with `AircTranscriptReader`); impl'd for `PersonaAircRuntime`, `AircHandleAdapter`, `StubAircCitizen`, `airc_lib::Airc`. `runtime` upcasts into it — no new plumbing.
- **`compose_for_turn`** binds it in the reserved "identity card" source slot; it rides `capture_sink` → recorded + replayable.
- **`service_loop`** projects the delivery into **system-prompt grounding** (a `[Present in this room]` block in `prompt_assembly`), *not* `recent_history` — injecting it as chat is the confusion the source removes.

Carries origin + availability per present citizen for the trust slice (slice 3).

## Validation

- Compiles clean (lib + tests, `metal,accelerate,test-fixtures`), clippy 0 errors.
- **9 new tests** (7 source + 2 prompt rendering), replay path intact.
- Diff is the logical change only — a 213-file rustfmt-version churn (repo pins 1.95, local Homebrew is 1.96) was caught and stripped.

## Out of scope (follow-up slices)

- Slice 2: room-nature grounding (calibrate participation to activity kind).
- Slice 3: trust/origin enforcement at the cognition boundary.
- Node/web unified-client rebuild (later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
