### PR TITLE
feat(persona): RoomDoctrineSource — ground cognition in the room's operating doctrine

### DIFF
--- a/core/continuum-core/src/context/airc_adapter.rs
+++ b/core/continuum-core/src/context/airc_adapter.rs
@@ -73,6 +73,15 @@ impl crate::persona::room_roster_source::AircRosterReader for AircHandleAdapter 
 }
 
 #[async_trait]
+impl crate::persona::room_doctrine_source::AircDoctrineReader for AircHandleAdapter {
+    async fn room_doctrine(
+        &self,
+    ) -> Result<Option<airc_core::doctrine::RoomDoctrinePublished>, AircError> {
+        self.inner.room_doctrine().await
+    }
+}
+
+#[async_trait]
 impl AircCitizen for AircHandleAdapter {
     fn peer_id(&self) -> Uuid {
         self.inner.peer_id().as_uuid()

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -75,7 +75,9 @@ use uuid::Uuid;
 /// docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5.
 #[async_trait]
 pub trait AircCitizen:
-    AircTranscriptReader + crate::persona::room_roster_source::AircRosterReader
+    AircTranscriptReader
+    + crate::persona::room_roster_source::AircRosterReader
+    + crate::persona::room_doctrine_source::AircDoctrineReader
 {
     /// The airc-side peer identity (Ed25519 pubkey, formatted as Uuid).
     /// Cognition uses this for self-loop filtering; the supervisor uses
@@ -163,6 +165,17 @@ impl crate::persona::room_roster_source::AircRosterReader for StubAircCitizen {
         &self,
     ) -> Result<std::collections::HashMap<airc_core::PeerId, String>, AircError> {
         Ok(std::collections::HashMap::new())
+    }
+}
+
+#[async_trait]
+impl crate::persona::room_doctrine_source::AircDoctrineReader for StubAircCitizen {
+    async fn room_doctrine(
+        &self,
+    ) -> Result<Option<airc_core::doctrine::RoomDoctrinePublished>, AircError> {
+        // No daemon in tests → no published doctrine. Cognition runs
+        // through cleanly with no [Room operating doctrine] block.
+        Ok(None)
     }
 }
 

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -549,6 +549,15 @@ impl crate::persona::room_roster_source::AircRosterReader for PersonaAircRuntime
 }
 
 #[async_trait::async_trait]
+impl crate::persona::room_doctrine_source::AircDoctrineReader for PersonaAircRuntime {
+    async fn room_doctrine(
+        &self,
+    ) -> Result<Option<airc_core::doctrine::RoomDoctrinePublished>, AircError> {
+        self.airc.room_doctrine().await
+    }
+}
+
+#[async_trait::async_trait]
 impl crate::persona::airc_citizen::AircCitizen for PersonaAircRuntime {
     fn peer_id(&self) -> Uuid {
         self.airc.peer_id().as_uuid()

--- a/core/continuum-core/src/persona/cognition_io.rs
+++ b/core/continuum-core/src/persona/cognition_io.rs
@@ -271,6 +271,7 @@ pub fn build_respond_input(signal: &Signal, ctx: &PersonaContext) -> Result<Resp
         // projection doesn't carry compose deliveries, so it defaults
         // empty — no [Present in this room] block, backwards-compatible.
         room_roster: Vec::new(),
+        room_doctrine: None,
     })
 }
 

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -73,6 +73,7 @@ pub mod recall_metadata;
 pub mod recorder;
 pub mod resource_forecast;
 pub mod response;
+pub mod room_doctrine_source;
 pub mod room_roster_source;
 pub mod resume_or_mint_provider;
 pub mod role_template;

--- a/core/continuum-core/src/persona/prompt_assembly.rs
+++ b/core/continuum-core/src/persona/prompt_assembly.rs
@@ -118,6 +118,12 @@ pub struct PromptAssemblyInput {
     /// itself. Empty = no block rendered (backwards-compatible).
     #[serde(default)]
     pub room_roster: Vec<String>,
+    /// The room's operating doctrine (airc-published) — what KIND of
+    /// activity this room is. Rendered as a `[Room operating doctrine]`
+    /// block so the persona calibrates participation to the room's
+    /// nature. `None` = no block (backwards-compatible).
+    #[serde(default)]
+    pub room_doctrine: Option<String>,
 }
 
 /// A message in conversation history.
@@ -210,6 +216,24 @@ pub fn assemble(input: &PromptAssemblyInput) -> AssembledPrompt {
         for line in &input.room_roster {
             let _ = write!(system_prompt, "\n- {line}");
         }
+    }
+
+    // Inject the room operating doctrine — WHAT KIND of room this is.
+    // Sits adjacent to the roster (both room-context grounding): the
+    // roster says who is here, the doctrine says how this room works.
+    // This is what lets a persona calibrate participation to the
+    // activity — e.g. stay sparse in a coordination room vs conversational
+    // in a chat room. airc-published markdown, rendered verbatim. None =
+    // no block (backwards-compatible). See
+    // docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 2.
+    if let Some(ref doctrine) = input.room_doctrine {
+        let _ = write!(
+            system_prompt,
+            "\n\n[Room operating doctrine]\n\
+             This room has a published operating contract. Follow it — it \
+             governs how to participate in THIS room (its activity, tone, and \
+             when to speak vs stay silent):\n{doctrine}"
+        );
     }
 
     // Inject recalled engrams as a memory block — continuum#1211 PR-2.
@@ -640,6 +664,7 @@ mod tests {
             other_persona_names: vec![],
             recalled_engrams: vec![],
             room_roster: vec![],
+            room_doctrine: None,
         };
 
         let result = assemble(&input);
@@ -726,6 +751,7 @@ mod tests {
             other_persona_names: vec![],
             recalled_engrams: vec![],
             room_roster: vec![],
+            room_doctrine: None,
         };
 
         let result = assemble(&input);
@@ -764,6 +790,7 @@ mod tests {
                 "Joel works in San Francisco.".to_string(),
             ],
             room_roster: vec![],
+            room_doctrine: None,
         };
 
         let result = assemble(&input);
@@ -813,6 +840,7 @@ mod tests {
             other_persona_names: vec![],
             recalled_engrams: vec![],
             room_roster: vec![],
+            room_doctrine: None,
         };
 
         let result = assemble(&input);
@@ -851,6 +879,7 @@ mod tests {
                 "BigMama [persona] — Busy".to_string(),
                 "win-claude [claude]".to_string(),
             ],
+            room_doctrine: None,
         };
 
         let result = assemble(&input);
@@ -889,6 +918,7 @@ mod tests {
             other_persona_names: vec![],
             recalled_engrams: vec![],
             room_roster: vec![],
+            room_doctrine: None,
         };
 
         let result = assemble(&input);
@@ -897,6 +927,49 @@ mod tests {
             "should NOT render the roster block for an empty roster: {}",
             result.system_message
         );
+    }
+
+    // what this catches: a non-empty room_doctrine renders a
+    // [Room operating doctrine] block carrying the contract verbatim, so
+    // the persona calibrates participation to the room's nature (slice
+    // 2). Empty/None must render nothing (the other test path). Regression
+    // target: docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 2.
+    #[test]
+    fn room_doctrine_renders_operating_block() {
+        let mut input = PromptAssemblyInput {
+            persona_name: "Ivar".to_string(),
+            system_prompt: "You are Ivar.".to_string(),
+            matched_angle: String::new(),
+            history: vec![],
+            current_message: HistoryMessage {
+                role: "user".to_string(),
+                name: None,
+                content: "hi".to_string(),
+                timestamp_ms: None,
+            },
+            is_voice: false,
+            social_signals: None,
+            multi_party_strategy: MultiPartyChatStrategy::default(),
+            other_persona_names: vec![],
+            recalled_engrams: vec![],
+            room_roster: vec![],
+            room_doctrine: Some(
+                "This is a coordination room. Respond sparingly; do not chat.".to_string(),
+            ),
+        };
+
+        let with = assemble(&input);
+        assert!(
+            with.system_message.contains("[Room operating doctrine]"),
+            "expected the doctrine block header: {}",
+            with.system_message
+        );
+        assert!(with.system_message.contains("Respond sparingly"));
+
+        // None → no block (backwards-compatible).
+        input.room_doctrine = None;
+        let without = assemble(&input);
+        assert!(!without.system_message.contains("[Room operating doctrine]"));
     }
 
     #[test]
@@ -918,6 +991,7 @@ mod tests {
             other_persona_names: vec![],
             recalled_engrams: vec![],
             room_roster: vec![],
+            room_doctrine: None,
         };
 
         let result = assemble(&input);
@@ -943,6 +1017,7 @@ mod tests {
             other_persona_names: vec![],
             recalled_engrams: vec![],
             room_roster: vec![],
+            room_doctrine: None,
         };
 
         let result = assemble(&input);
@@ -976,6 +1051,7 @@ mod tests {
             other_persona_names: vec![],
             recalled_engrams: vec![],
             room_roster: vec![],
+            room_doctrine: None,
         };
 
         let result = assemble(&input);
@@ -1019,6 +1095,7 @@ mod tests {
             other_persona_names: vec![],
             recalled_engrams: vec![],
             room_roster: vec![],
+            room_doctrine: None,
         };
 
         let result = assemble(&input);
@@ -1063,6 +1140,7 @@ mod tests {
             other_persona_names: vec![],
             recalled_engrams: vec![],
             room_roster: vec![],
+            room_doctrine: None,
         };
 
         let result = assemble(&input);

--- a/core/continuum-core/src/persona/recorder.rs
+++ b/core/continuum-core/src/persona/recorder.rs
@@ -541,6 +541,7 @@ mod tests {
             capabilities: HashSet::new(),
             recalled_engrams: vec![],
             room_roster: vec![],
+            room_doctrine: None,
         }
     }
 

--- a/core/continuum-core/src/persona/response.rs
+++ b/core/continuum-core/src/persona/response.rs
@@ -136,6 +136,14 @@ pub struct RespondInput {
     /// Empty when no roster source is bound or the room is otherwise
     /// quiet — backwards-compatible (no block rendered).
     pub room_roster: Vec<String>,
+    /// The room's operating doctrine — the airc-published contract for
+    /// what kind of activity this room is (chat vs coordination vs game
+    /// vs …), produced by `RoomDoctrineSource` and projected here by the
+    /// service loop. Rendered by `prompt_assembly` as a `[Room operating
+    /// doctrine]` block so the persona calibrates participation to the
+    /// room's nature (slice 2). `None` when the room has no published
+    /// doctrine — backwards-compatible (no block rendered).
+    pub room_doctrine: Option<String>,
 }
 
 /// What `respond()` returns.
@@ -587,6 +595,8 @@ async fn run_render(
         // Pass-through, same as engrams — respond() is the assembly
         // boundary, not the policy layer.
         room_roster: input.room_roster.clone(),
+        // Room doctrine projected from RoomDoctrineSource. Pass-through.
+        room_doctrine: input.room_doctrine.clone(),
     };
 
     let assembled = assemble(&prompt_input);

--- a/core/continuum-core/src/persona/room_doctrine_source.rs
+++ b/core/continuum-core/src/persona/room_doctrine_source.rs
@@ -1,0 +1,306 @@
+//! RoomDoctrineSource — reads the airc room operating doctrine and
+//! packages it as a `[Room operating doctrine]` grounding block.
+//!
+//! ### Why this source exists (slice 2)
+//!
+//! Slice 1 ([`RoomRosterSource`](super::room_roster_source)) grounds a
+//! persona in WHO else is present. This grounds it in WHAT KIND of room
+//! it is — the activity's operating contract. Rooms are the universal
+//! activity primitive (chat, dev-coordination, game, academy, help,
+//! settings); a coordination room is not a free-for-all chat. Ivar's
+//! *other* failure was over-participating in a coordination room because
+//! it had no signal about the room's nature.
+//!
+//! airc already owns this: `Airc::room_doctrine` returns the latest
+//! `RoomDoctrinePublished` for the current room — markdown the airc-core
+//! docs explicitly say agents should "render verbatim / inject as a
+//! system message into agent context." This source is that injection,
+//! routed through the same RAG-grounding + capture/replay path as the
+//! roster. Thin continuum: we read airc's doctrine, we don't invent a
+//! room-nature concept. See
+//! [[docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md]] §5 slice 2.
+//!
+//! ### Doctrine alignment
+//!
+//! - [[substrate-is-a-good-citizen-on-the-host]]: a failed/absent
+//!   doctrine read returns an empty delivery — cognition stays up; a
+//!   room with no published doctrine simply renders no block.
+//! - Persona-scoped at construction (defense in depth, same as the
+//!   roster + engram sources).
+//! - Atomic unit = the doctrine body; no pagination (one current
+//!   contract per room).
+
+use std::sync::Arc;
+
+use airc_core::doctrine::RoomDoctrinePublished;
+use airc_core::PeerId;
+use airc_lib::AircError;
+use async_trait::async_trait;
+
+use crate::persona::rag_budget::{
+    ContinuationCursor, RagContext, RagDelivery, RagItem, RagSource, ResolutionPreference,
+};
+
+/// Source identifier — the service-loop projection routes this delivery
+/// into system-prompt grounding (a `[Room operating doctrine]` block).
+const SOURCE_ID: &str = "room-doctrine";
+
+/// Rough chars/token estimate — same heuristic the other RAG sources
+/// use. Real tokenizer integration lands in slice 12+.
+fn estimate_tokens(content: &str) -> u32 {
+    ((content.chars().count() / 4) as u32).saturating_add(1)
+}
+
+/// Abstract reader over the airc room operating doctrine. Production
+/// rides on `airc_lib::Airc::room_doctrine`; tests stub it without a
+/// daemon. Mirrors the `AircRosterReader` rail.
+#[async_trait]
+pub trait AircDoctrineReader: Send + Sync {
+    /// The latest published operating doctrine for this persona's
+    /// current room, or `None` if none has been published.
+    async fn room_doctrine(&self) -> Result<Option<RoomDoctrinePublished>, AircError>;
+}
+
+/// `airc_lib::Airc` satisfies the reader contract directly. Orphan rule
+/// OK — the trait is ours.
+#[async_trait]
+impl AircDoctrineReader for airc_lib::Airc {
+    async fn room_doctrine(&self) -> Result<Option<RoomDoctrinePublished>, AircError> {
+        airc_lib::Airc::room_doctrine(self).await
+    }
+}
+
+/// RoomDoctrineSource — persona-bound, reads the room doctrine from any
+/// `AircDoctrineReader`.
+pub struct RoomDoctrineSource {
+    persona_id: uuid::Uuid,
+    reader: Arc<dyn AircDoctrineReader>,
+}
+
+impl RoomDoctrineSource {
+    pub fn new(persona_id: uuid::Uuid, reader: Arc<dyn AircDoctrineReader>) -> Self {
+        Self { persona_id, reader }
+    }
+
+    /// Fit the doctrine body to `budget` tokens. A doctrine is a single
+    /// contract; if it doesn't fit we deliver a truncated prefix (with a
+    /// marker) rather than dropping it entirely — partial guidance still
+    /// grounds the persona in the room's nature. Returns `None` only for
+    /// a zero budget.
+    fn fit_body(body: &str, budget: u32) -> Option<String> {
+        if budget == 0 {
+            return None;
+        }
+        if estimate_tokens(body) <= budget {
+            return Some(body.to_string());
+        }
+        // ~4 chars/token; leave room for the truncation marker.
+        const MARKER: &str = "\n…[doctrine truncated]";
+        let char_budget = (budget as usize).saturating_mul(4).saturating_sub(MARKER.len());
+        let mut truncated: String = body.chars().take(char_budget).collect();
+        truncated.push_str(MARKER);
+        Some(truncated)
+    }
+}
+
+#[async_trait]
+impl RagSource for RoomDoctrineSource {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    async fn deliver(
+        &self,
+        ctx: &RagContext,
+        budget: u32,
+        resolution: ResolutionPreference,
+    ) -> RagDelivery {
+        let empty = |res| RagDelivery {
+            source_id: SOURCE_ID.to_string(),
+            items: Vec::new(),
+            tokens_used: 0,
+            continuation: None,
+            resolution_used: res,
+        };
+
+        // Persona-scoped (defense in depth, same shape as the roster).
+        if ctx.persona_id != self.persona_id {
+            return empty(ResolutionPreference::Placeholder);
+        }
+
+        let card = match self.reader.room_doctrine().await {
+            Ok(Some(card)) => card,
+            // No doctrine published for this room → no block (normal).
+            Ok(None) => return empty(resolution),
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    persona_id = %self.persona_id,
+                    "room_doctrine: read failed — empty delivery, cognition stays up"
+                );
+                return empty(ResolutionPreference::Placeholder);
+            }
+        };
+
+        let Some(content) = Self::fit_body(&card.body, budget) else {
+            return empty(resolution);
+        };
+        let tokens = estimate_tokens(&content);
+
+        tracing::debug!(
+            persona_id = %self.persona_id,
+            budget,
+            version = %card.version,
+            tokens,
+            "room_doctrine: deliver"
+        );
+
+        RagDelivery {
+            source_id: SOURCE_ID.to_string(),
+            items: vec![RagItem {
+                content,
+                tokens,
+                metadata: serde_json::json!({
+                    "version": card.version,
+                    "published_by": card.published_by.as_uuid().to_string(),
+                    "published_at_ms": card.published_at_ms,
+                }),
+            }],
+            tokens_used: tokens,
+            // One current contract per room; no pagination.
+            continuation: None,
+            resolution_used: resolution,
+        }
+    }
+
+    async fn deliver_continuation(
+        &self,
+        _ctx: &RagContext,
+        _cursor: ContinuationCursor,
+        _budget: u32,
+    ) -> Option<RagDelivery> {
+        // Doctrine is a single current snapshot; any cursor is stale.
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    fn persona() -> Uuid {
+        Uuid::parse_str("00000000-0000-0000-0000-000000000aaa").unwrap()
+    }
+
+    fn ctx() -> RagContext {
+        RagContext::for_persona(persona(), 1_000_000)
+    }
+
+    fn card(body: &str) -> RoomDoctrinePublished {
+        RoomDoctrinePublished {
+            room_id: airc_core::RoomId::new(),
+            body: body.to_string(),
+            version: "v1abc".to_string(),
+            published_by: PeerId::new(),
+            published_at_ms: 1_000_000,
+        }
+    }
+
+    struct StubReader {
+        doctrine: Option<RoomDoctrinePublished>,
+        fail: Mutex<bool>,
+    }
+
+    impl StubReader {
+        fn new(doctrine: Option<RoomDoctrinePublished>) -> Self {
+            Self {
+                doctrine,
+                fail: Mutex::new(false),
+            }
+        }
+        fn set_fail(&self, fail: bool) {
+            *self.fail.lock().unwrap() = fail;
+        }
+    }
+
+    #[async_trait]
+    impl AircDoctrineReader for StubReader {
+        async fn room_doctrine(&self) -> Result<Option<RoomDoctrinePublished>, AircError> {
+            if *self.fail.lock().unwrap() {
+                return Err(AircError::UnknownPeer(PeerId::new()));
+            }
+            Ok(self.doctrine.clone())
+        }
+    }
+
+    // what this catches: a published doctrine surfaces as a delivery the
+    // service loop can route into the [Room operating doctrine] grounding
+    // block — the fix for a persona ignoring the room's nature.
+    #[tokio::test]
+    async fn published_doctrine_surfaces() {
+        let reader = Arc::new(StubReader::new(Some(card(
+            "This is a coordination room. Respond sparingly; do not chat.",
+        ))));
+        let source = RoomDoctrineSource::new(persona(), reader);
+        let delivery = source.deliver(&ctx(), 1_000, ResolutionPreference::Raw).await;
+        assert_eq!(delivery.items.len(), 1);
+        assert!(delivery.items[0].content.contains("Respond sparingly"));
+        assert_eq!(delivery.items[0].metadata["version"], "v1abc");
+        assert!(delivery.continuation.is_none());
+    }
+
+    // what this catches: a room with NO published doctrine renders no
+    // block (backwards-compatible; most rooms have none yet).
+    #[tokio::test]
+    async fn no_doctrine_delivers_nothing() {
+        let reader = Arc::new(StubReader::new(None));
+        let source = RoomDoctrineSource::new(persona(), reader);
+        let delivery = source.deliver(&ctx(), 1_000, ResolutionPreference::Raw).await;
+        assert!(delivery.items.is_empty());
+        assert_eq!(delivery.tokens_used, 0);
+    }
+
+    // what this catches: a read failure degrades to empty, never panics —
+    // cognition stays up if the doctrine subsystem is degraded.
+    #[tokio::test]
+    async fn read_error_returns_empty_no_panic() {
+        let reader = Arc::new(StubReader::new(Some(card("body"))));
+        reader.set_fail(true);
+        let source = RoomDoctrineSource::new(persona(), reader);
+        let delivery = source.deliver(&ctx(), 1_000, ResolutionPreference::Raw).await;
+        assert!(delivery.items.is_empty());
+    }
+
+    // what this catches: cross-persona ctx gets nothing (defense in depth).
+    #[tokio::test]
+    async fn cross_persona_ctx_returns_empty() {
+        let reader = Arc::new(StubReader::new(Some(card("body"))));
+        let source = RoomDoctrineSource::new(persona(), reader);
+        let alien = Uuid::parse_str("00000000-0000-0000-0000-000000000bbb").unwrap();
+        let delivery = source
+            .deliver(
+                &RagContext::for_persona(alien, 1_000_000),
+                1_000,
+                ResolutionPreference::Raw,
+            )
+            .await;
+        assert!(delivery.items.is_empty());
+        assert_eq!(delivery.resolution_used, ResolutionPreference::Placeholder);
+    }
+
+    // what this catches: an over-budget doctrine is truncated (with a
+    // marker) and never overspends — partial guidance beats dropping the
+    // room's operating contract entirely.
+    #[tokio::test]
+    async fn oversized_doctrine_truncates_within_budget() {
+        let big = "x".repeat(10_000);
+        let reader = Arc::new(StubReader::new(Some(card(&big))));
+        let source = RoomDoctrineSource::new(persona(), reader);
+        let delivery = source.deliver(&ctx(), 20, ResolutionPreference::Raw).await;
+        assert_eq!(delivery.items.len(), 1);
+        assert!(delivery.tokens_used <= 20, "must not overspend the budget");
+        assert!(delivery.items[0].content.contains("truncated"));
+    }
+}

--- a/core/continuum-core/src/persona/room_doctrine_source.rs
+++ b/core/continuum-core/src/persona/room_doctrine_source.rs
@@ -85,8 +85,17 @@ impl RoomDoctrineSource {
     /// Fit the doctrine body to `budget` tokens. A doctrine is a single
     /// contract; if it doesn't fit we deliver a truncated prefix (with a
     /// marker) rather than dropping it entirely — partial guidance still
-    /// grounds the persona in the room's nature. Returns `None` only for
-    /// a zero budget.
+    /// grounds the persona in the room's nature.
+    ///
+    /// Returns `None` (no block) when the budget is too small to carry
+    /// the marker PLUS some real content. The alternative — emitting a
+    /// `[Room operating doctrine]` block whose entire content is the
+    /// truncation marker — is strictly worse than no block: it spends
+    /// tokens to say nothing, and (with a naive char budget) overspends
+    /// the allocation. Both the no-content case and overspend are
+    /// guarded here. `estimate_tokens(s) = s.chars()/4 + 1`, so a string
+    /// of `4*budget - 4` chars estimates to exactly `budget` tokens —
+    /// that's the ceiling we fit the (truncated body + marker) under.
     fn fit_body(body: &str, budget: u32) -> Option<String> {
         if budget == 0 {
             return None;
@@ -94,12 +103,18 @@ impl RoomDoctrineSource {
         if estimate_tokens(body) <= budget {
             return Some(body.to_string());
         }
-        // ~4 chars/token; leave room for the truncation marker.
         const MARKER: &str = "\n…[doctrine truncated]";
-        let char_budget = (budget as usize).saturating_mul(4).saturating_sub(MARKER.len());
-        let mut truncated: String = body.chars().take(char_budget).collect();
-        truncated.push_str(MARKER);
-        Some(truncated)
+        let marker_chars = MARKER.chars().count();
+        // Max chars whose estimate stays within `budget` tokens.
+        let max_chars = (budget as usize).saturating_mul(4).saturating_sub(4);
+        if max_chars <= marker_chars {
+            // No room for the marker plus any content → emit no block.
+            return None;
+        }
+        let char_budget = max_chars - marker_chars;
+        let mut out: String = body.chars().take(char_budget).collect();
+        out.push_str(MARKER);
+        Some(out)
     }
 }
 
@@ -290,17 +305,52 @@ mod tests {
         assert_eq!(delivery.resolution_used, ResolutionPreference::Placeholder);
     }
 
-    // what this catches: an over-budget doctrine is truncated (with a
-    // marker) and never overspends — partial guidance beats dropping the
-    // room's operating contract entirely.
+    // what this catches: an over-budget doctrine is truncated and NEVER
+    // overspends the allocation — across the full budget regime, not just
+    // a comfortable one. The earlier version only checked budget=20 and
+    // missed that tiny budgets (1..=6) overspent with a content-free
+    // marker-only block (adversarial review of PR #1651). Invariant now:
+    // for ANY budget, either no block is delivered, or the delivered
+    // block fits the budget AND carries real content (not just the
+    // truncation marker).
     #[tokio::test]
-    async fn oversized_doctrine_truncates_within_budget() {
+    async fn oversized_doctrine_never_overspends_across_budget_regime() {
+        let big = "x".repeat(10_000);
+        for budget in [1u32, 2, 3, 5, 6, 7, 8, 20, 100, 500] {
+            let reader = Arc::new(StubReader::new(Some(card(&big))));
+            let source = RoomDoctrineSource::new(persona(), reader);
+            let delivery = source
+                .deliver(&ctx(), budget, ResolutionPreference::Raw)
+                .await;
+            assert!(
+                delivery.tokens_used <= budget,
+                "budget {budget}: overspent ({} > {budget})",
+                delivery.tokens_used
+            );
+            if let Some(item) = delivery.items.first() {
+                // A delivered block must carry real doctrine content, not
+                // just the truncation marker — else it spends tokens to
+                // say nothing.
+                let only_marker = item.content.trim_start().starts_with('…')
+                    || !item.content.contains('x');
+                assert!(
+                    !only_marker,
+                    "budget {budget}: delivered a content-free block: {:?}",
+                    item.content
+                );
+            }
+        }
+    }
+
+    // what this catches: a budget too small to carry the marker plus real
+    // content yields NO block rather than a token-wasting marker-only one.
+    #[tokio::test]
+    async fn tiny_budget_emits_no_block() {
         let big = "x".repeat(10_000);
         let reader = Arc::new(StubReader::new(Some(card(&big))));
         let source = RoomDoctrineSource::new(persona(), reader);
-        let delivery = source.deliver(&ctx(), 20, ResolutionPreference::Raw).await;
-        assert_eq!(delivery.items.len(), 1);
-        assert!(delivery.tokens_used <= 20, "must not overspend the budget");
-        assert!(delivery.items[0].content.contains("truncated"));
+        let delivery = source.deliver(&ctx(), 3, ResolutionPreference::Raw).await;
+        assert!(delivery.items.is_empty(), "tiny budget must emit no block");
+        assert_eq!(delivery.tokens_used, 0);
     }
 }

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -561,6 +561,19 @@ async fn serve_persona_loop_inner(
             }
         }
 
+        // Project the room-doctrine delivery → RespondInput.room_doctrine.
+        // Routed by source_id into system-prompt grounding (a [Room
+        // operating doctrine] block), so the persona calibrates
+        // participation to the room's nature. One current contract per
+        // room → first item's content. See slice 2.
+        let room_doctrine: Option<String> = composed
+            .deliveries
+            .iter()
+            .filter(|d| d.source_id == "room-doctrine")
+            .flat_map(|d| d.items.iter())
+            .map(|item| item.content.clone())
+            .next();
+
         // recalled_engrams is populated above from
         // admission.recall_recent(8) — substrate-managed memory,
         // not the airc transcript window. The engram delivery from
@@ -594,7 +607,7 @@ async fn serve_persona_loop_inner(
             turn_context,
             message_id: Uuid::new_v4(),
             message_text: msg.text.clone(),
-            other_persona_names: Vec::new(),
+            other_persona_names,
             // #195 slice 2: cached per-session prompt. The
             // PersonaContext baked this once at construction via
             // `build_persona_system_prompt`; here we just lease
@@ -611,6 +624,7 @@ async fn serve_persona_loop_inner(
             capabilities: std::collections::HashSet::new(),
             recalled_engrams,
             room_roster,
+            room_doctrine,
         };
 
         // 3. Run the cognition cycle. The persona may speak or stay

--- a/core/continuum-core/src/persona/service_module.rs
+++ b/core/continuum-core/src/persona/service_module.rs
@@ -487,6 +487,7 @@ impl PersonaServiceModule {
             // here (no [Present in this room] block), same tolerated-
             // absence shape as other_persona_names above.
             room_roster: Vec::new(),
+            room_doctrine: None,
         }
     }
 

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -498,6 +498,16 @@ pub async fn materialize_adapters(
             ));
         cognition.set_roster_source(roster_source);
 
+        // Bind the room-doctrine source from the same runtime (upcasts to
+        // `AircDoctrineReader`). Grounds the persona in the room's nature
+        // — the airc-published operating contract. Slice 2.
+        let doctrine_source: Arc<dyn crate::persona::rag_budget::RagSource> =
+            Arc::new(crate::persona::room_doctrine_source::RoomDoctrineSource::new(
+                identity.persona_id,
+                runtime.clone(),
+            ));
+        cognition.set_doctrine_source(doctrine_source);
+
         let system_prompt = build_persona_system_prompt(&identity.agent_name);
 
         out.push(Ok(PersonaContext {

--- a/core/continuum-core/src/persona/unified.rs
+++ b/core/continuum-core/src/persona/unified.rs
@@ -37,6 +37,13 @@ use uuid::Uuid;
 /// budget-claim rationale in `compose_for_turn`.
 const ROSTER_MAX_TOKENS: u32 = 256;
 
+/// Token ceiling for the room-doctrine source. A doctrine is a short
+/// operating contract (a few paragraphs); capped so it grounds the
+/// persona in the room's nature without competing with engram/airc for
+/// grow headroom. Larger than the roster (prose, not a name list) but
+/// still bounded and floorless.
+const DOCTRINE_MAX_TOKENS: u32 = 1024;
+
 /// All cognitive state for a single persona — single lock, cache-local.
 pub struct PersonaCognition {
     pub engine: PersonaCognitionEngine,
@@ -94,6 +101,15 @@ pub struct PersonaCognition {
     /// persona confabulating other citizens' turns. See
     /// docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 1.
     pub roster_source: Option<Arc<dyn RagSource>>,
+    /// The persona's room-doctrine RAG source — "what KIND of room is
+    /// this" (the airc-published operating contract via
+    /// `Airc::room_doctrine`). Bound at supervisor boot from the same
+    /// `Airc` handle (satisfies `AircDoctrineReader`). `None` pre-attach
+    /// / in tests. Routed by the service loop into system-prompt
+    /// grounding (a `[Room operating doctrine]` block) so a persona
+    /// calibrates participation to the activity (slice 2). See
+    /// docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 2.
+    pub doctrine_source: Option<Arc<dyn RagSource>>,
     /// The capture sink the RecordingRagSource wraps engram_source
     /// against. Default = `NoopRagCaptureSink` (zero overhead, drops
     /// events on the floor). Production callers swap in
@@ -179,6 +195,7 @@ impl PersonaCognition {
             engram_source,
             airc_source: None,
             roster_source: None,
+            doctrine_source: None,
             capture_sink,
         }
     }
@@ -214,6 +231,18 @@ impl PersonaCognition {
             self.capture_sink.clone(),
         ));
         self.roster_source = Some(decorated);
+    }
+
+    /// Bind the brain's room-doctrine RAG source (`RoomDoctrineSource`).
+    /// Same boot-time wire as `set_roster_source`, from the same `Airc`
+    /// handle (satisfies `AircDoctrineReader`), decorated with the
+    /// `capture_sink` so doctrine deliveries are recorded + replayable.
+    pub fn set_doctrine_source(&mut self, raw_source: Arc<dyn RagSource>) {
+        let decorated: Arc<dyn RagSource> = Arc::new(RecordingRagSource::new(
+            ArcRagSource::new(raw_source),
+            self.capture_sink.clone(),
+        ));
+        self.doctrine_source = Some(decorated);
     }
 
     /// Brain composition for one cognition turn. Walks the brain's
@@ -262,16 +291,20 @@ impl PersonaCognition {
         // then airc (the L1 conversational floor). Future sources
         // (code, tool descriptions, identity card) extend this list
         // in order of long-term-to-immediate.
-        let mut sources: Vec<Arc<dyn RagSource>> = Vec::with_capacity(3);
+        let mut sources: Vec<Arc<dyn RagSource>> = Vec::with_capacity(4);
         sources.push(self.engram_source.clone());
         if let Some(ref airc) = self.airc_source {
             sources.push(airc.clone());
         }
-        // The "identity card" source the original author reserved this
-        // list for: who else is present in the room right now. Routed
-        // by the service loop into system-prompt grounding, not history.
+        // The "identity card" sources the original author reserved this
+        // list for: WHO is present (roster) and WHAT KIND of room this is
+        // (doctrine). Both routed by the service loop into system-prompt
+        // grounding, not history.
         if let Some(ref roster) = self.roster_source {
             sources.push(roster.clone());
+        }
+        if let Some(ref doctrine) = self.doctrine_source {
+            sources.push(doctrine.clone());
         }
 
         // Per-source budget claims. The two HEAVYWEIGHT sources (engram
@@ -288,28 +321,28 @@ impl PersonaCognition {
         // A source's budget should reflect its real appetite.
         let per_source_max = ((context_window as u64) * 6 / 10) as u32;
         let per_source_max = per_source_max.min(headroom);
-        let roster_max = ROSTER_MAX_TOKENS.min(per_source_max);
         let budgets: Vec<RagSourceBudget> = sources
             .iter()
             .map(|s| {
-                if s.source_id() == "room-roster" {
-                    RagSourceBudget {
-                        source_id: s.source_id().to_string(),
-                        priority: 10,
-                        floor_tokens: 0,
-                        min_tokens: 0,
-                        max_tokens: roster_max,
-                        required: false,
+                // Lightweight grounding sources (roster, doctrine) claim a
+                // small floorless budget matching their real appetite, so
+                // they never starve airc's recent_history or compete for
+                // grow headroom with the heavyweight engram/airc sources.
+                let (floor, min, max) = match s.source_id() {
+                    "room-roster" => (0, 0, ROSTER_MAX_TOKENS.min(per_source_max)),
+                    "room-doctrine" => (0, 0, DOCTRINE_MAX_TOKENS.min(per_source_max)),
+                    _ => {
+                        let f = 500_u32.min(per_source_max);
+                        (f, f, per_source_max)
                     }
-                } else {
-                    RagSourceBudget {
-                        source_id: s.source_id().to_string(),
-                        priority: 10,
-                        floor_tokens: 500_u32.min(per_source_max),
-                        min_tokens: 500_u32.min(per_source_max),
-                        max_tokens: per_source_max,
-                        required: false,
-                    }
+                };
+                RagSourceBudget {
+                    source_id: s.source_id().to_string(),
+                    priority: 10,
+                    floor_tokens: floor,
+                    min_tokens: min,
+                    max_tokens: max,
+                    required: false,
                 }
             })
             .collect();

--- a/core/continuum-core/tests/persona_respond_replay.rs
+++ b/core/continuum-core/tests/persona_respond_replay.rs
@@ -185,6 +185,7 @@ fn build_input(fix: &Fixture, known_specialties: Vec<String>) -> RespondInput {
         capabilities: std::collections::HashSet::new(),
         recalled_engrams: Vec::new(),
         room_roster: Vec::new(),
+        room_doctrine: None,
     }
 }
 
@@ -298,6 +299,7 @@ async fn clean_minimal_input_produces_spoke() {
         capabilities: std::collections::HashSet::new(),
         recalled_engrams: Vec::new(),
         room_roster: Vec::new(),
+        room_doctrine: None,
     };
     let response = respond(input)
         .await
@@ -485,6 +487,7 @@ async fn synthesized_prod_shape_input_produces_coherent_response() {
         capabilities: std::collections::HashSet::new(),
         recalled_engrams: Vec::new(),
         room_roster: Vec::new(),
+        room_doctrine: None,
     };
     let response = respond(input)
         .await
@@ -626,6 +629,7 @@ async fn long_code_generation_request_completes_without_clipping() {
         capabilities: std::collections::HashSet::new(),
         recalled_engrams: Vec::new(),
         room_roster: Vec::new(),
+        room_doctrine: None,
     };
 
     let response = respond(input)

--- a/core/continuum-core/tests/vision_integration.rs
+++ b/core/continuum-core/tests/vision_integration.rs
@@ -104,6 +104,7 @@ fn build_vision_request(model_id: &str) -> RespondInput {
         capabilities: caps,
         recalled_engrams: Vec::new(),
         room_roster: Vec::new(),
+        room_doctrine: None,
     }
 }
 

--- a/docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md
+++ b/docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md
@@ -165,9 +165,17 @@ rendered in `prompt_assembly::assemble`) — *not* the `airc → recent_history`
 branch, which would inject the roster as fake chat. It rides `capture_sink`, so
 it is recorded and replayable through the existing fixtures.
 
-**Slice 2 — Room-nature grounding.** Surface the room's activity kind (chat vs
-coordination vs game vs …) into the same recipe/RAG context, via airc room
-doctrine, so participation is calibrated to the activity.
+**Slice 2 — Room-nature grounding (DONE).** A **`RoomDoctrineSource`** RAG source
+(same shape as the roster: `AircDoctrineReader` reader trait, persona-scoped,
+fails-safe-empty, test stub) reads airc `Airc::room_doctrine` — the room's
+published operating contract (markdown the airc-core docs say agents should
+"inject as a system message"). Its delivery routes into a `[Room operating
+doctrine]` system-prompt block, so a persona calibrates participation to the
+activity (sparse in a coordination room, conversational in a chat room — Ivar's
+*other* failure). Rides `capture_sink` (recorded + replayable); claims a small
+floorless budget so it never starves airc's recent_history. `None` doctrine →
+no block. The same single-scan / one-source-of-truth discipline the roster's
+adversarial review established applies.
 
 **Slice 3 — Trust/origin enforcement at the cognition boundary.** Use the roster
 trust annotation so a persona weighs instructions by origin, and so it declines


### PR DESCRIPTION
## What

Slice 2 of the airc-native rebuild (`docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md` §5). Slice 1 (#1650) grounded a persona in **who** is present; this grounds it in **what kind of room** it is, so it calibrates participation to the activity.

## Why

Rooms are the universal activity primitive (chat, dev-coordination, game, academy, help, settings). A coordination room is not a free-for-all chat. The "Ivar" persona's *other* failure (besides confabulation, fixed in #1650) was over-participating in a dev-coordination room because it had no signal about the room's nature.

## How

- **`RoomDoctrineSource`** — a `RagSource` reading airc `Airc::room_doctrine`, the room's published operating contract (markdown the airc-core docs say agents should "inject as a system message into agent context"). Persona-scoped, fails-safe-empty, truncates an oversized doctrine rather than dropping it, test stub. Mirrors `RoomRosterSource`.
- **`AircDoctrineReader`** — 3rd supertrait of `AircCitizen` (alongside `AircTranscriptReader` + `AircRosterReader`); impl'd for `PersonaAircRuntime`, `AircHandleAdapter`, `StubAircCitizen`, `airc_lib::Airc`, so `runtime` upcasts.
- `compose_for_turn` binds it; rides `capture_sink` (recorded + replayable); small **floorless** budget (max 1024) so it never starves airc's `recent_history` (the lesson from slice 1's review).
- `service_loop` projects the delivery into a `[Room operating doctrine]` system-prompt block in `prompt_assembly`. `None` doctrine → no block (backwards-compatible).

## Validation

- Compiles clean (lib + tests, `metal,accelerate,test-fixtures`), clippy 0 errors.
- **6 new tests** (5 source incl. truncation/error/cross-persona + 1 prompt rendering).
- No fmt churn; rebased onto canary after #1650 merged.

## Out of scope (follow-up)

- Slice 3: trust/origin enforcement at the cognition boundary (the roster already carries origin/trust data from #1650).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
