### PR TITLE
feat(persona): publish_identity at spawn — continuum half of airc #1222 spawn contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -91,13 +91,14 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "serde",
  "serde_json",
@@ -107,16 +108,17 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -128,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -142,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -158,7 +160,9 @@ dependencies = [
  "airc-work-store",
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "dashmap",
+ "fs2",
  "futures",
  "rtc",
  "rtc-media",
@@ -175,7 +179,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "airc-core",
  "ciborium",
@@ -189,7 +193,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -225,9 +229,10 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "airc-core",
+ "airc-diagnostics",
  "airc-protocol",
  "async-trait",
  "ed25519-dalek",
@@ -247,7 +252,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -258,7 +263,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -272,7 +277,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -285,7 +290,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f6ed190#f6ed19064f670fa9136e48e7491cf75db876a4bd"
+source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
 dependencies = [
  "airc-core",
  "airc-store",
@@ -425,7 +430,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -436,7 +441,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3511,7 +3516,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3787,7 +3792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4608,7 +4613,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5251,7 +5256,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6700,7 +6705,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9024,7 +9029,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9625,7 +9630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10109,7 +10114,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11729,7 +11734,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,15 +52,22 @@ members = [
 #   - PublishRequest.target: MentionTarget → IpcTarget (via .into())
 #   - ResolveWire removed (owner-core daemon owns channels)
 #
-# All on same SHA so IPC ABI version stays consistent. The pinned
-# SHA is currently the tip of the unmerged airc PR branch (#1095 +
-# #1096); re-pin to the post-merge SHA on airc canary/rust-rewrite
-# before merging this continuum PR past canary.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "f6ed190" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "f6ed190" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "f6ed190" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "f6ed190" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "f6ed190" }
+# All on same SHA so IPC ABI version stays consistent.
+#
+# 2026-06-16 bump f6ed190 → 1a47231 (airc canary tip): adopts the
+# #1222 spawn contract — `Airc::publish_identity()` — so a persona
+# publishes its identity card after subscribe and is grounded by NAME,
+# not an anonymous peer-id. This is the airc half of the persona
+# identity-grounding work (continuum#1650 RoomRosterSource resolves
+# names from the IdentityPublished events publish_identity emits;
+# continuum#1651 RoomDoctrineSource reads room_doctrine). Also pulls
+# the airc update/doctor/network CLI fixes (#1218-#1222). Re-validate
+# attach_as (refactored open_as + with_daemon_client) on bump.
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "1a47231" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "1a47231" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "1a47231" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "1a47231" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "1a47231" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/core/continuum-core/src/airc/inbound_attach.rs
+++ b/core/continuum-core/src/airc/inbound_attach.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use airc_core::RoomId;
-use airc_ipc::{codec::read_frame, AttachRequest, DaemonClient, Response};
+use airc_ipc::{codec::read_frame, AttachRequest, AttachStart, DaemonClient, Response};
 use airc_lib::decode_wire_event;
 use tracing::warn;
 
@@ -43,11 +43,13 @@ pub async fn run_daemon_attach(
     // Multi-room scopes will spawn one daemon_attach task per channel
     // they care about — single-attach today, per-room fan-out as a
     // follow-up when continuum rooms become first-class.
+    // airc#1222 bump: AttachRequest dropped Default for explicit
+    // builders. The prior `..default()` was `from_now: false` —
+    // FromTranscriptStart per airc-ipc's own "legacy meaning" doc — so
+    // preserve full-backlog semantics rather than silently switching to
+    // live-only (which would skip events on attach).
     let mut stream = client
-        .attach(AttachRequest {
-            channel: Some(channel),
-            ..AttachRequest::default()
-        })
+        .attach(AttachRequest::new(channel, AttachStart::FromTranscriptStart))
         .await
         .map_err(|error| format!("failed to attach to airc daemon: {error}"))?;
 

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -356,6 +356,34 @@ impl PersonaAircRuntime {
              persona is now addressable for cross-grid commands"
         );
 
+        // airc#1222 spawn contract: attach_as → join → subscribe →
+        // publish_identity. Now that the persona is attached, joined, and
+        // subscribed (the pump above), publish its identity card so it is
+        // grounded by NAME on the wire, not an anonymous peer-id. This is
+        // the continuum half of the contract; it's what lets every peer's
+        // RoomRosterSource (continuum#1650) resolve this persona's display
+        // name from the IdentityPublished event this emits. Seeds from the
+        // agent-name floor.
+        //
+        // WARN-and-continue, not fatal — asymmetric with the subscribe
+        // failure above (which IS fatal): a deaf persona is useless, but an
+        // anonymous-but-functional one is fine — it appears by peer-id in
+        // rosters until its identity card propagates / is re-published.
+        match airc_arc.publish_identity().await {
+            Ok(()) => info!(
+                persona_id = %persona_id,
+                agent_name = %agent_name,
+                "PersonaAircRuntime bootstrap: identity card published — grounded by name"
+            ),
+            Err(source) => warn!(
+                persona_id = %persona_id,
+                agent_name = %agent_name,
+                error = %source,
+                "PersonaAircRuntime bootstrap: publish_identity failed — persona is live \
+                 but will appear by peer-id in rosters until its identity card propagates"
+            ),
+        }
+
         Ok(Self {
             persona_id,
             agent_name,


### PR DESCRIPTION
## What

Wires the **continuum half of airc's #1222 spawn contract**: a persona now calls `publish_identity()` at spawn, so it's grounded by **name** on the wire instead of an anonymous peer-id.

## Why

BigMama shipped the spawn contract in airc #1222 (`attach_as → subscribe → publish_identity → grounded by name`), but continuum's `PersonaAircRuntime::bootstrap` never called `publish_identity`. Consequence: continuum personas published no `IdentityPublished` event, so every peer's `RoomRosterSource` (#1650) resolved **no display name** for them and fell back to short peer-ids. This is what makes the roster show "Ivar"/"BigMama" instead of `a1b2c3d4`.

## How

- **Bump airc pin `f6ed190 → 1a47231`** (canary tip) to get `Airc::publish_identity`. Pulls the airc CLI/daemon fixes #1218–#1222 too.
- `bootstrap` calls `publish_identity()` after the command pump subscribes — seeds the identity card from the agent-name floor + broadcasts it. **WARN-and-continue** on failure (anonymous-but-functional beats dead; asymmetric with the subscribe failure above, which stays fatal).
- **Behavior-preserving bump fix**: `AttachRequest` dropped `Default` for explicit builders. The prior `..default()` was `from_now: false` = `FromTranscriptStart` (airc's documented "legacy meaning"), so → `AttachRequest::new(channel, AttachStart::FromTranscriptStart)` — full backlog, not a silent switch to live-only.

## Validation

- Compiles clean (lib + tests, `metal,accelerate,test-fixtures`), clippy 0 errors.
- **295 airc + 13 persona-room unit tests pass** against the bumped airc — the dep bump is behavior-neutral apart from the one `AttachRequest` site.
- Integration coverage (a real spawn publishing identity) lands with the `TwoAircLoopback` harness (task #187, in flight) — `publish_identity` needs a live daemon, so it's not unit-testable here.

## Coordination

Completes the continuum side of the contract BigMama built airc-side. Next: consume BigMama's forthcoming `room_roster()` API (so `RoomRosterSource` drops its `IdentityPublished` parsing) once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
