### PR TITLE
feat(persona): GridTrustAuthPolicy — hard ACL gate on cross-grid command callers

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1645,7 +1645,15 @@ pub fn start_server(
     let executor = Arc::new(
         crate::runtime::CommandExecutor::new(runtime.registry_arc())
             .with_interceptor(Arc::new(crate::runtime::AircInterceptor::new()))
-            .with_interceptor(Arc::new(crate::runtime::GridInterceptor::new(grid_state))),
+            .with_interceptor(Arc::new(crate::runtime::GridInterceptor::new(grid_state)))
+            // Hard ACL gate (slice 3): replace the AllowAllPolicy default
+            // so cross-grid (airc) callers — incl. a persona's command
+            // inbound pump — are gated by the grid ACL, capped at
+            // Provisional. A remote room peer may request ai/generate and
+            // nothing privileged; local/substrate callers are unaffected.
+            // See routing/grid_trust_policy.rs + docs/grid/
+            // AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 3.
+            .with_policy(Arc::new(crate::routing::GridTrustAuthPolicy::new())),
     );
     runtime
         .registry()

--- a/core/continuum-core/src/routing/grid_trust_policy.rs
+++ b/core/continuum-core/src/routing/grid_trust_policy.rs
@@ -1,0 +1,138 @@
+//! `GridTrustAuthPolicy` — the production [`AuthPolicy`] that enforces
+//! the grid command ACL on **airc-sourced (cross-grid) callers**.
+//!
+//! ### Why this exists (slice 3 of the airc-native rebuild)
+//!
+//! The substrate ships [`AllowAllPolicy`](super::AllowAllPolicy) by
+//! default so call sites don't break before a real policy is installed.
+//! But a persona is **command-callable over airc**: its inbound pump
+//! ([`PersonaCommandInboundPump`](crate::persona::command_inbound_pump))
+//! forwards any `command-request` envelope from a room peer to the
+//! shared [`CommandExecutor`], which threads
+//! `CallerIdentity::airc(verified_sender)` into the gate. Under
+//! `AllowAllPolicy` that means an UNTRUSTED outsider agent in the room
+//! could address a privileged command (`data/delete`, `grid/trust`) to
+//! the persona and have it execute. This policy closes that — the hard
+//! gate Joel chose over soft prompt guidance.
+//!
+//! ### The policy
+//!
+//! - **Local / substrate callers** (`caller == None` or
+//!   `CallerSource::Local`) → `Allowed`. Local dispatch is the
+//!   substrate's own code; it is not the cross-grid attack surface.
+//! - **Airc callers** → enforce the grid ACL via
+//!   [`is_command_authorized`]. We cannot yet resolve a given airc
+//!   peer's exact grid `TrustLevel` (the airc-enrollment ↔ grid
+//!   `NodeRegistry` trust bridge is a separate slice — the registries
+//!   are decoupled today), so we **cap at `Provisional`** — the level
+//!   the cross-grid-inference rule (`ai/generate`, continuum#1649) is
+//!   admitted at. Net effect: a remote room peer may request generation
+//!   (`ai/generate`) and **nothing above it** — every `Owner`-gated
+//!   command (`data/delete`, `grid/pair`, `grid/trust`, and the `""`
+//!   wildcard that covers everything else) is denied regardless of who
+//!   sent it. Privileged ops must arrive through the owner's own trusted
+//!   local path, never an arbitrary room peer's command envelope.
+//!
+//! When the airc↔grid trust bridge lands, swap the hardcoded
+//! `Provisional` ceiling for the peer's resolved `TrustLevel` so a
+//! same-account Owner peer on another machine regains full access. Until
+//! then the conservative cap is the safe floor — consistent with the
+//! grid's "default to Blocked, elevate deliberately" posture.
+
+use super::auth_policy::{AuthPolicy, CallerIdentity, CallerSource};
+use super::{ForbiddenReason, RouteDecision, Verdict};
+use crate::modules::grid::acl::is_command_authorized;
+use crate::modules::grid::node::TrustLevel;
+
+/// Production auth policy: ACL-gates cross-grid (airc) callers, passes
+/// local/substrate callers. See module docs.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GridTrustAuthPolicy;
+
+impl GridTrustAuthPolicy {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// The trust ceiling applied to airc-sourced callers until the
+/// airc↔grid trust bridge can resolve a peer's real `TrustLevel`.
+/// `Provisional` admits `ai/generate` (continuum#1649) and denies every
+/// `Trusted`/`Owner` command.
+const AIRC_CALLER_CEILING: TrustLevel = TrustLevel::Provisional;
+
+impl AuthPolicy for GridTrustAuthPolicy {
+    fn gate(&self, decision: &RouteDecision, caller: Option<&CallerIdentity>) -> Verdict {
+        match caller {
+            // Substrate's own code — implicitly trusted.
+            None => Verdict::Allowed,
+            // Local caller — not the cross-grid surface this gate guards.
+            Some(c) if matches!(c.source, CallerSource::Local) => Verdict::Allowed,
+            // Cross-grid (airc) caller — enforce the grid ACL, capped.
+            Some(_) => {
+                let path = decision.path();
+                if is_command_authorized(path, AIRC_CALLER_CEILING) {
+                    Verdict::Allowed
+                } else {
+                    Verdict::Forbidden {
+                        reason: ForbiddenReason::NoPermissionForUri(path.to_string()),
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routing::{route, CommandUri};
+    use uuid::Uuid;
+
+    fn decision(path: &str) -> RouteDecision {
+        route(&CommandUri::local(path))
+    }
+
+    // what this catches: the hard ACL gate's reason for existing — a
+    // cross-grid (airc) caller can invoke ai/generate (the Provisional
+    // cross-grid-inference rule) but is DENIED every privileged command.
+    // Without this an untrusted room peer could data/delete via the
+    // persona's command-inbound pump.
+    #[test]
+    fn airc_caller_may_generate_but_not_privileged() {
+        let policy = GridTrustAuthPolicy::new();
+        let airc = CallerIdentity::airc(Uuid::new_v4());
+
+        assert_eq!(
+            policy.gate(&decision("ai/generate"), Some(&airc)),
+            Verdict::Allowed,
+            "cross-grid inference must stay admitted (continuum#1649)"
+        );
+
+        for privileged in ["data/delete", "grid/trust", "grid/pair", "gpu/stats"] {
+            match policy.gate(&decision(privileged), Some(&airc)) {
+                Verdict::Forbidden {
+                    reason: ForbiddenReason::NoPermissionForUri(uri),
+                } => assert_eq!(uri, privileged),
+                other => panic!("expected Forbidden for {privileged}, got {other:?}"),
+            }
+        }
+    }
+
+    // what this catches: local + substrate callers are NOT gated — the
+    // owner's own local path keeps full access; only the cross-grid
+    // surface is constrained. A regression that gated local callers
+    // would lock the operator out of their own substrate.
+    #[test]
+    fn local_and_substrate_callers_pass() {
+        let policy = GridTrustAuthPolicy::new();
+        // None = substrate's own code.
+        assert_eq!(policy.gate(&decision("data/delete"), None), Verdict::Allowed);
+        // Local caller.
+        let local = CallerIdentity::local(Uuid::new_v4());
+        assert_eq!(
+            policy.gate(&decision("data/delete"), Some(&local)),
+            Verdict::Allowed
+        );
+    }
+}

--- a/core/continuum-core/src/routing/grid_trust_policy.rs
+++ b/core/continuum-core/src/routing/grid_trust_policy.rs
@@ -38,6 +38,17 @@
 //! same-account Owner peer on another machine regains full access. Until
 //! then the conservative cap is the safe floor — consistent with the
 //! grid's "default to Blocked, elevate deliberately" posture.
+//!
+//! ### Scope: command surface only (for now)
+//!
+//! This policy gates the **command** surface. The airc **event-subscribe**
+//! surface (`routing/airc_event_adapters.rs`) runs its own
+//! `AuthPolicy::gate` but still defaults to `AllowAllPolicy` — a cross-grid
+//! peer's *subscriptions* are not yet gated by this policy (adversarial
+//! review of PR #1653, finding 3). That's intentionally out of scope here
+//! (subscribe is read-ish, and routing it through this gate would deny it
+//! — `events/*/subscribe` falls to the `""`=Owner wildcard). A follow-up
+//! installs a subscribe-appropriate policy on that surface.
 
 use super::auth_policy::{AuthPolicy, CallerIdentity, CallerSource};
 use super::{ForbiddenReason, RouteDecision, Verdict};
@@ -134,5 +145,33 @@ mod tests {
             policy.gate(&decision("data/delete"), Some(&local)),
             Verdict::Allowed
         );
+    }
+
+    // what this catches: the grid ACL matches by PREFIX, so the
+    // `ai/generate` Provisional rule is a NAMESPACE grant — any future
+    // `ai/generate*` path (e.g. `ai/generate/stream`) is also airc-
+    // callable at Provisional. Intentional (the cross-grid inference
+    // family); this test PINS it so the grant stays a conscious, reviewed
+    // decision rather than a silent surprise the day someone adds an
+    // `ai/generate-*` command (adversarial review of PR #1653, finding 1).
+    // If a future `ai/generate*` command should NOT be cross-grid-callable,
+    // tighten the acl.rs rule to exact-match — this test is the tripwire.
+    #[test]
+    fn ai_generate_is_a_provisional_namespace_grant() {
+        let policy = GridTrustAuthPolicy::new();
+        let airc = CallerIdentity::airc(Uuid::new_v4());
+        for granted in ["ai/generate", "ai/generate/stream"] {
+            assert_eq!(
+                policy.gate(&decision(granted), Some(&airc)),
+                Verdict::Allowed,
+                "{granted} is within the intentional ai/generate namespace grant"
+            );
+        }
+        // A sibling ai/* command OUTSIDE the namespace is still denied
+        // (falls to the ""=Owner wildcard) — the grant is scoped.
+        assert!(matches!(
+            policy.gate(&decision("ai/embedding"), Some(&airc)),
+            Verdict::Forbidden { .. }
+        ));
     }
 }

--- a/core/continuum-core/src/routing/mod.rs
+++ b/core/continuum-core/src/routing/mod.rs
@@ -33,6 +33,7 @@ pub mod auth_policy;
 pub mod command_handler;
 pub mod command_uri;
 pub mod environment;
+pub mod grid_trust_policy;
 #[macro_use]
 pub mod macros;
 pub mod probe_file_sink;
@@ -84,6 +85,7 @@ pub use probe_file_sink::{
 pub use probe_router::{ProbeEvent, ProbeRouterLayer, DEFAULT_CHANNEL_CAPACITY};
 pub use tracing_init::{install_probe_tracing, ProbeInstall, ProbeTracingConfig};
 pub use route_decision::{route, RouteDecision, RouteKind};
+pub use grid_trust_policy::GridTrustAuthPolicy;
 pub use transport::{ClosureTransport, NotImplementedRemoteTransport, Transport};
 pub use uri_layer::{current_uri_chain, UriCaptureLayer, UriFrame};
 pub use verdict::{DeferredReason, ForbiddenReason, Verdict};

--- a/docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md
+++ b/docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md
@@ -177,9 +177,19 @@ floorless budget so it never starves airc's recent_history. `None` doctrine →
 no block. The same single-scan / one-source-of-truth discipline the roster's
 adversarial review established applies.
 
-**Slice 3 — Trust/origin enforcement at the cognition boundary.** Use the roster
-trust annotation so a persona weighs instructions by origin, and so it declines
-out-of-scope requests from untrusted outsiders in sensitive rooms.
+**Slice 3 — Hard ACL gate on cross-grid callers (DONE).** Enforcement, not just
+prompt guidance: a persona is command-callable over airc (its inbound pump
+forwards any `command-request` envelope from a room peer to the shared
+`CommandExecutor`), and the executor shipped the `AllowAllPolicy` default — so an
+untrusted outsider could address a privileged command (`data/delete`,
+`grid/trust`) to the persona and have it execute. `GridTrustAuthPolicy`
+(`routing/grid_trust_policy.rs`) closes it on the existing `AuthPolicy` seam:
+local/substrate callers pass; **airc-sourced callers are gated by the grid ACL
+(`is_command_authorized`), capped at `Provisional`** — they may request
+`ai/generate` (continuum#1649) and *nothing* above it; every `Owner`-gated
+command is denied regardless of sender. Installed on the production executor at
+boot. When the airc↔grid trust bridge lands, the hardcoded ceiling becomes the
+peer's resolved `TrustLevel` (a same-account Owner peer regains full access).
 
 **Later (not now) — Node/web unified clients.** Rewrite the legacy UI on a
 proper reactive framework, mobile/positron-aware, every activity opened by a


### PR DESCRIPTION
## What

Slice 3 of the airc-native rebuild: a **hard ACL gate** on cross-grid (airc) command callers — enforcement, not prompt guidance.

## Why

A persona is command-callable over airc: its inbound pump forwards any `command-request` envelope from a room peer to the shared `CommandExecutor`, threading `CallerIdentity::airc(verified_sender)` into the auth gate. But the executor shipped the `AllowAllPolicy` default — so an **untrusted outsider agent in the room could address a privileged command** (`data/delete`, `grid/trust`) to the persona and have it execute. That's the gap this closes.

## How

- **`GridTrustAuthPolicy`** (`routing/grid_trust_policy.rs`) implements the existing `AuthPolicy` seam (no new plumbing):
  - local / substrate callers (`None` or `CallerSource::Local`) → `Allowed`
  - airc-sourced callers → gated by the grid ACL (`is_command_authorized`), **capped at `Provisional`** → may request `ai/generate` (#1649) and **nothing above it**; every `Owner`-gated command denied regardless of sender.
- Installed on the **production executor** (`ipc/mod.rs`) via `.with_policy`, replacing `AllowAllPolicy`. Local/test executors unaffected (still AllowAll).
- The cap is conservative because the airc-enrollment ↔ grid-`NodeRegistry` trust bridge is a separate slice; when it lands, the ceiling becomes the peer's resolved `TrustLevel` (a same-account Owner peer on another machine regains full access).

## Validation

- Compiles clean (lib + tests), clippy 0 errors.
- 2 new gate tests + **17 command-executor + 241 routing tests still green** (the global policy install regresses nothing — local callers pass).

## Note

Independent of #1652 (branched off canary; no airc bump needed — `is_command_authorized` is continuum-internal). Mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
