### PR TITLE
refactor(persona): consume airc room_roster — delete continuum-side IdentityPublished parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "airc-core",
  "ciborium",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -229,7 +229,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -252,7 +252,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=1a47231#1a472310ceee32cde34f71c7356df9e138ad3d02"
+source = "git+https://github.com/CambrianTech/airc?rev=72824ba#72824ba2351b9963112d13da3d58273c39beef4b"
 dependencies = [
  "airc-core",
  "airc-store",
@@ -430,7 +430,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -441,7 +441,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3516,7 +3516,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3792,7 +3792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4613,7 +4613,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5256,7 +5256,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -6705,7 +6705,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9029,7 +9029,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9630,7 +9630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10114,7 +10114,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11734,7 +11734,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,11 +63,11 @@ members = [
 # continuum#1651 RoomDoctrineSource reads room_doctrine). Also pulls
 # the airc update/doctor/network CLI fixes (#1218-#1222). Re-validate
 # attach_as (refactored open_as + with_daemon_client) on bump.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "1a47231" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "1a47231" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "1a47231" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "1a47231" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "1a47231" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "72824ba" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "72824ba" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "72824ba" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "72824ba" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "72824ba" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/core/continuum-core/src/context/airc_adapter.rs
+++ b/core/continuum-core/src/context/airc_adapter.rs
@@ -51,24 +51,12 @@ impl crate::persona::room_roster_source::AircRosterReader for AircHandleAdapter 
         self.inner.peer_id()
     }
 
-    async fn active_agents(
+    async fn room_roster(
         &self,
         within: std::time::Duration,
         window: usize,
-    ) -> Result<Vec<airc_lib::AgentLiveness>, AircError> {
-        self.inner.active_agents(within, window).await
-    }
-
-    async fn peer_alias_map(
-        &self,
-    ) -> Result<std::collections::HashMap<airc_core::PeerId, String>, AircError> {
-        let events = self
-            .inner
-            .page_recent(crate::persona::room_roster_source::IDENTITY_SCAN)
-            .await?;
-        Ok(crate::persona::room_roster_source::parse_identity_names(
-            events,
-        ))
+    ) -> Result<Vec<airc_lib::RoomMember>, AircError> {
+        self.inner.room_roster(within, window).await
     }
 }
 

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -151,20 +151,14 @@ impl crate::persona::room_roster_source::AircRosterReader for StubAircCitizen {
         airc_core::PeerId::from_uuid(self.peer_id)
     }
 
-    async fn active_agents(
+    async fn room_roster(
         &self,
         _within: std::time::Duration,
         _window: usize,
-    ) -> Result<Vec<airc_lib::AgentLiveness>, AircError> {
+    ) -> Result<Vec<airc_lib::RoomMember>, AircError> {
         // No daemon in tests → no presence. RAG runs through cleanly
         // with an empty roster (no [Present in this room] block).
         Ok(vec![])
-    }
-
-    async fn peer_alias_map(
-        &self,
-    ) -> Result<std::collections::HashMap<airc_core::PeerId, String>, AircError> {
-        Ok(std::collections::HashMap::new())
     }
 }
 

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -555,24 +555,12 @@ impl crate::persona::room_roster_source::AircRosterReader for PersonaAircRuntime
         self.airc.peer_id()
     }
 
-    async fn active_agents(
+    async fn room_roster(
         &self,
         within: std::time::Duration,
         window: usize,
-    ) -> Result<Vec<airc_lib::AgentLiveness>, AircError> {
-        self.airc.active_agents(within, window).await
-    }
-
-    async fn peer_alias_map(
-        &self,
-    ) -> Result<std::collections::HashMap<airc_core::PeerId, String>, AircError> {
-        let events = self
-            .airc
-            .page_recent(crate::persona::room_roster_source::IDENTITY_SCAN)
-            .await?;
-        Ok(crate::persona::room_roster_source::parse_identity_names(
-            events,
-        ))
+    ) -> Result<Vec<airc_lib::RoomMember>, AircError> {
+        self.airc.room_roster(within, window).await
     }
 }
 

--- a/core/continuum-core/src/persona/room_roster_source.rs
+++ b/core/continuum-core/src/persona/room_roster_source.rs
@@ -48,13 +48,11 @@
 //! - Roster is small + always-current; no pagination (atomic unit = one
 //!   present citizen, like the `ToolSource` precedent in the trait doc).
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use airc_core::identity::IdentityEvent;
-use airc_core::{Body, PeerId, TranscriptEvent, TranscriptKind};
-use airc_lib::{AgentLiveness, AircError};
+use airc_core::PeerId;
+use airc_lib::{AircError, RoomMember};
 use async_trait::async_trait;
 
 use crate::persona::rag_budget::{
@@ -71,16 +69,11 @@ const SOURCE_ID: &str = "room-roster";
 /// hasn't beaten within this window is treated as gone.
 const PRESENCE_WINDOW: Duration = Duration::from_secs(120);
 
-/// How many recent transcript events to scan for heartbeats. The
-/// presence reduction keeps one entry per peer, so this only needs to
-/// be large enough to span the heartbeat cadence across all present
-/// peers — not the full scrollback.
-const HEARTBEAT_SCAN: usize = 200;
-
-/// How many recent transcript events to scan for `IdentityPublished`
-/// when building the peer→name map. Matches airc's own `peer_alias`
-/// window (200).
-pub(crate) const IDENTITY_SCAN: usize = 200;
+/// How many recent transcript events airc scans to build the roster.
+/// The presence reduction keeps one entry per peer, so this only needs
+/// to span the heartbeat cadence across all present peers — not the
+/// full scrollback. Passed straight to `Airc::room_roster`.
+const ROSTER_SCAN: usize = 200;
 
 /// Rough chars/token estimate — same heuristic `AircRagSource` /
 /// `EngramSource` use. Real tokenizer integration lands in slice 12+.
@@ -88,59 +81,34 @@ fn estimate_tokens(content: &str) -> u32 {
     ((content.chars().count() / 4) as u32).saturating_add(1)
 }
 
-/// Build a `PeerId → display-name` map from ONE transcript page, reading
-/// `IdentityPublished` cards. This is the batched form of airc's
-/// per-peer `peer_alias` (which scans a full page EACH call): resolving
-/// N present peers one-at-a-time is N+1 page scans — N+1 IPC round-trips
-/// under the cognition lock for an N-peer room. One scan keeps a roster
-/// delivery O(1) in room size. Uses only public `airc_core` types and
-/// mirrors `airc_lib::Airc::peer_alias` parsing; later cards win
-/// (page is chronological, so a re-published name overrides an old one).
-pub(crate) fn parse_identity_names(events: Vec<TranscriptEvent>) -> HashMap<PeerId, String> {
-    let mut names = HashMap::new();
-    for event in events {
-        if event.kind != TranscriptKind::IdentityPublished {
-            continue;
-        }
-        let Some(Body::Json(value)) = event.body else {
-            continue;
-        };
-        let Ok(IdentityEvent::PeerIdentityCard(card)) =
-            serde_json::from_value::<IdentityEvent>(value)
-        else {
-            continue;
-        };
-        if !card.identity.name.is_empty() {
-            names.insert(event.peer_id, card.identity.name);
-        }
-    }
-    names
-}
-
-/// Abstract reader over airc room presence + identity. Production impl
-/// rides on `airc_lib::Airc`; tests use a stub that returns canned
-/// liveness without needing a daemon.
+/// Abstract reader over airc room membership. Production impl rides on
+/// `airc_lib::Airc::room_roster`; tests use a stub that returns canned
+/// `RoomMember`s without needing a daemon.
+///
+/// Slice "consume room_roster" (airc#1232): this used to be a 2-method
+/// `active_agents` + `peer_alias_map` reader, with continuum re-parsing
+/// `IdentityPublished` events to join names onto presence — a wire-format
+/// coupling the adversarial review of continuum#1650 flagged. airc now
+/// owns that join: `room_roster` returns presence + names in ONE batched
+/// scan. So this is a single-method reader and the continuum-side
+/// parsing is gone — thin continuum, airc owns presence+identity.
 #[async_trait]
 pub trait AircRosterReader: Send + Sync {
     /// This persona's own airc peer id — used to exclude self from the
-    /// roster so the grounding block reads "who is NOT me".
+    /// roster so the grounding block reads "who is NOT me". (`room_roster`
+    /// includes self by design; the caller drops its own peer_id.)
     fn self_peer_id(&self) -> PeerId;
 
-    /// Currently-alive agents in this persona's room, within `within`,
-    /// scanning the most recent `window` transcript events. Newest-wins
-    /// per peer; peers that signalled `Leaving` are excluded by airc.
-    async fn active_agents(
+    /// Everyone present in this persona's room — presence joined with
+    /// published display names in ONE airc-side batched scan, within
+    /// `within`, over the most recent `window` transcript events.
+    /// Newest-wins per peer; peers that signalled `Leaving` are excluded
+    /// by airc; `display_name` is `None` for a present-but-unnamed peer.
+    async fn room_roster(
         &self,
         within: Duration,
         window: usize,
-    ) -> Result<Vec<AgentLiveness>, AircError>;
-
-    /// All known peer display names in the room, as one `PeerId → name`
-    /// map built from a SINGLE transcript scan. Batched on purpose:
-    /// resolving names per-peer (airc's `peer_alias`) is one full page
-    /// scan EACH, i.e. N+1 IPC round-trips under the cognition lock for
-    /// an N-peer room. One map keeps a roster delivery O(1) in room size.
-    async fn peer_alias_map(&self) -> Result<HashMap<PeerId, String>, AircError>;
+    ) -> Result<Vec<RoomMember>, AircError>;
 }
 
 /// `airc_lib::Airc` satisfies the reader contract directly. Orphan rule
@@ -151,17 +119,12 @@ impl AircRosterReader for airc_lib::Airc {
         airc_lib::Airc::peer_id(self)
     }
 
-    async fn active_agents(
+    async fn room_roster(
         &self,
         within: Duration,
         window: usize,
-    ) -> Result<Vec<AgentLiveness>, AircError> {
-        airc_lib::Airc::active_agents(self, within, window).await
-    }
-
-    async fn peer_alias_map(&self) -> Result<HashMap<PeerId, String>, AircError> {
-        let events = airc_lib::Airc::page_recent(self, IDENTITY_SCAN).await?;
-        Ok(parse_identity_names(events))
+    ) -> Result<Vec<RoomMember>, AircError> {
+        airc_lib::Airc::room_roster(self, within, window).await
     }
 }
 
@@ -246,17 +209,16 @@ impl RagSource for RoomRosterSource {
             };
         }
 
-        let agents = match self
-            .reader
-            .active_agents(PRESENCE_WINDOW, HEARTBEAT_SCAN)
-            .await
-        {
-            Ok(a) => a,
+        // ONE airc call returns presence joined with display names
+        // (airc#1232). A failure is non-fatal — empty delivery, cognition
+        // stays up (good-citizen doctrine).
+        let members = match self.reader.room_roster(PRESENCE_WINDOW, ROSTER_SCAN).await {
+            Ok(m) => m,
             Err(err) => {
                 tracing::warn!(
                     error = %err,
                     persona_id = %self.persona_id,
-                    "room_roster: active_agents failed — empty delivery, cognition stays up"
+                    "room_roster: room_roster failed — empty delivery, cognition stays up"
                 );
                 return RagDelivery {
                     source_id: SOURCE_ID.to_string(),
@@ -270,40 +232,26 @@ impl RagSource for RoomRosterSource {
 
         let self_peer = self.reader.self_peer_id();
 
-        // Resolve ALL names in ONE scan, not per-peer. A failure here is
-        // non-fatal — degrade to short peer labels (still truthful) so a
-        // transient identity-read outage doesn't blank the roster or the
-        // turn. Logged at debug so an outage is observable.
-        let names = self.reader.peer_alias_map().await.unwrap_or_else(|err| {
-            tracing::debug!(
-                error = %err,
-                persona_id = %self.persona_id,
-                "room_roster: peer_alias_map failed — falling back to short peer labels"
-            );
-            HashMap::new()
-        });
-
         let mut items: Vec<RagItem> = Vec::new();
         let mut tokens_used: u32 = 0;
-        for agent in agents {
+        for member in members {
             // Exclude self — the roster grounds the persona in who is
-            // NOT itself.
-            if agent.peer == self_peer {
+            // NOT itself. (room_roster includes self by design.)
+            if member.peer_id == self_peer {
                 continue;
             }
-            // Name from the single-scan map; fall back to a short peer
-            // label so a present citizen is never invisible.
-            let name = names
-                .get(&agent.peer)
-                .cloned()
-                .unwrap_or_else(|| Self::short_peer_label(agent.peer));
-            let availability = agent.coordination.availability.map(|a| format!("{a:?}"));
+            // airc resolved the name; fall back to a short peer label for
+            // a present-but-unnamed peer so a citizen is never invisible.
+            let name = member
+                .display_name
+                .unwrap_or_else(|| Self::short_peer_label(member.peer_id));
+            let availability = member.availability.map(|a| format!("{a:?}"));
             let item = Self::make_item(
-                agent.peer,
+                member.peer_id,
                 name,
-                agent.runtime.clone(),
+                member.runtime,
                 availability,
-                agent.last_seen_ms,
+                member.last_seen_ms,
             );
             if tokens_used.saturating_add(item.tokens) > budget {
                 // Budget exhausted. Roster is unordered presence; we
@@ -360,26 +308,22 @@ mod tests {
         RagContext::for_persona(persona(), 1_000_000)
     }
 
-    /// Test double — canned liveness + alias map, optional failure.
+    /// Test double — canned room members, optional failure. (airc joins
+    /// presence + names into `RoomMember` now; the stub returns them
+    /// directly — no separate alias map to maintain.)
     struct StubReader {
         self_peer: PeerId,
-        agents: Vec<AgentLiveness>,
-        aliases: Vec<(PeerId, String)>,
+        members: Vec<RoomMember>,
         fail: Mutex<bool>,
     }
 
     impl StubReader {
-        fn new(self_peer: PeerId, agents: Vec<AgentLiveness>) -> Self {
+        fn new(self_peer: PeerId, members: Vec<RoomMember>) -> Self {
             Self {
                 self_peer,
-                agents,
-                aliases: Vec::new(),
+                members,
                 fail: Mutex::new(false),
             }
-        }
-        fn with_alias(mut self, peer: PeerId, alias: &str) -> Self {
-            self.aliases.push((peer, alias.to_string()));
-            self
         }
         fn set_fail(&self, fail: bool) {
             *self.fail.lock().unwrap() = fail;
@@ -391,33 +335,27 @@ mod tests {
         fn self_peer_id(&self) -> PeerId {
             self.self_peer
         }
-        async fn active_agents(
+        async fn room_roster(
             &self,
             _within: Duration,
             _window: usize,
-        ) -> Result<Vec<AgentLiveness>, AircError> {
+        ) -> Result<Vec<RoomMember>, AircError> {
             if *self.fail.lock().unwrap() {
                 return Err(AircError::UnknownPeer(PeerId::new()));
             }
-            Ok(self.agents.clone())
-        }
-        async fn peer_alias_map(&self) -> Result<HashMap<PeerId, String>, AircError> {
-            if *self.fail.lock().unwrap() {
-                return Err(AircError::UnknownPeer(PeerId::new()));
-            }
-            Ok(self.aliases.iter().cloned().collect())
+            Ok(self.members.clone())
         }
     }
 
-    fn liveness(peer: PeerId, runtime: &str) -> AgentLiveness {
-        AgentLiveness {
-            peer,
+    /// Build a `RoomMember` — `name: Some` mirrors a peer that published
+    /// an identity card; `None` mirrors present-but-unnamed.
+    fn member(peer: PeerId, runtime: &str, name: Option<&str>) -> RoomMember {
+        RoomMember {
+            peer_id: peer,
+            display_name: name.map(|s| s.to_string()),
             runtime: runtime.to_string(),
-            client_id: None,
-            scope: None,
-            build: None,
+            availability: None,
             last_seen_ms: 1_000_000,
-            coordination: Default::default(),
         }
     }
 
@@ -429,7 +367,7 @@ mod tests {
         let me = PeerId::new();
         let other = PeerId::new();
         let reader = Arc::new(
-            StubReader::new(me, vec![liveness(other, "claude")]).with_alias(other, "win-claude"),
+            StubReader::new(me, vec![member(other, "claude", Some("win-claude"))]),
         );
         let source = RoomRosterSource::new(persona(), reader);
         let delivery = source
@@ -456,7 +394,7 @@ mod tests {
         let other = PeerId::new();
         let reader = Arc::new(StubReader::new(
             me,
-            vec![liveness(me, "persona"), liveness(other, "persona")],
+            vec![member(me, "persona", None), member(other, "persona", None)],
         ));
         let source = RoomRosterSource::new(persona(), reader);
         let delivery = source
@@ -476,7 +414,7 @@ mod tests {
     async fn peer_without_alias_falls_back_to_short_label() {
         let me = PeerId::new();
         let other = PeerId::new();
-        let reader = Arc::new(StubReader::new(me, vec![liveness(other, "codex")]));
+        let reader = Arc::new(StubReader::new(me, vec![member(other, "codex", None)]));
         let source = RoomRosterSource::new(persona(), reader);
         let delivery = source
             .deliver(&ctx(), 1_000, ResolutionPreference::Raw)
@@ -511,7 +449,7 @@ mod tests {
     async fn reader_error_returns_empty_no_panic() {
         let me = PeerId::new();
         let other = PeerId::new();
-        let reader = Arc::new(StubReader::new(me, vec![liveness(other, "persona")]));
+        let reader = Arc::new(StubReader::new(me, vec![member(other, "persona", None)]));
         reader.set_fail(true);
         let source = RoomRosterSource::new(persona(), reader);
         let delivery = source
@@ -527,7 +465,7 @@ mod tests {
     async fn cross_persona_ctx_returns_empty() {
         let me = PeerId::new();
         let other = PeerId::new();
-        let reader = Arc::new(StubReader::new(me, vec![liveness(other, "persona")]));
+        let reader = Arc::new(StubReader::new(me, vec![member(other, "persona", None)]));
         let source = RoomRosterSource::new(persona(), reader);
         let alien = Uuid::parse_str("00000000-0000-0000-0000-000000000bbb").unwrap();
         let delivery = source
@@ -550,9 +488,9 @@ mod tests {
         let reader = Arc::new(StubReader::new(
             me,
             vec![
-                liveness(PeerId::new(), "persona"),
-                liveness(PeerId::new(), "persona"),
-                liveness(PeerId::new(), "persona"),
+                member(PeerId::new(), "persona", None),
+                member(PeerId::new(), "persona", None),
+                member(PeerId::new(), "persona", None),
             ],
         ));
         let source = RoomRosterSource::new(persona(), reader);


### PR DESCRIPTION
## What

Consume BigMama's `Airc::room_roster` (airc #1232) in `RoomRosterSource` — and **delete** the continuum-side `IdentityPublished` parsing it replaces.

## Why

The adversarial review of #1650 flagged that `RoomRosterSource` did a 2-scan join (presence via `active_agents` + names via a hand-rolled `IdentityPublished` parse) — a wire-format coupling between continuum and airc's internals. I sent BigMama a spec for a one-call API; they shipped it (airc #1232) exactly as specced. This is the "thin continuum, airc owns presence+identity" payoff: airc does the join, continuum consumes `Vec<RoomMember>`.

## How

- **Bump airc pin `1a47231` → `72824ba`** — one commit (#1232 `room_roster`), minimal-risk delta.
- `AircRosterReader` collapses from `{self_peer_id, active_agents, peer_alias_map}` → `{self_peer_id, room_roster}`.
- `deliver()` makes **one** `room_roster(within, window)` call and iterates `RoomMember`s (name already joined; fall back to short peer-id for present-but-unnamed; self excluded).
- **Deleted:** `parse_identity_names`, the identity-scan constant, and the `airc_core` `IdentityEvent`/`Body`/`TranscriptEvent`/`TranscriptKind` + `HashMap` imports. The 3 reader impls collapse to a single `room_roster` delegation.

## Validation

- Compiles clean (lib + tests, `metal,accelerate,test-fixtures`), clippy 0 errors.
- **7 room_roster tests green**; same `[Present in this room]` grounding, same self-exclusion, same `metadata.display_name → other_persona_names` projection contract.
- **−92 net lines** (109 insertions, 201 deletions) — pure simplification, zero IPC amplification.

## Coordination

Closes the loop on the room_roster spec exchange with BigMama over airc. Independent of #1653 (ACL gate — different files, no airc-bump there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
