### PR TITLE
feat(cognition): Workspace brain-core + the brain architecture (no heuristics, equal citizens)

### DIFF
--- a/core/continuum-core/src/cognition/embedding.rs
+++ b/core/continuum-core/src/cognition/embedding.rs
@@ -364,4 +364,33 @@ mod tests {
             "same text in two embedding spaces = two distinct cache entries"
         );
     }
+
+    // what this catches: TRANSPORT IS INVISIBLE TO THE CACHE — "identity is the
+    // model, transport is the policy" (IntelMac/BigMama contract). Two DIFFERENT
+    // provider impls (e.g. local NeuralEmbeddingProvider + cross-grid
+    // GridEmbeddingProvider) that serve the SAME model return the SAME
+    // provider_id, so a vector computed by one is reused by the other — same
+    // model, same space, same cache key. The grid round-trip never fires for
+    // content the local path already embedded.
+    #[test]
+    fn cache_shared_across_transports_with_same_model_slug() {
+        let cache = Arc::new(EmbeddingCache::new());
+        // Two distinct impls, SAME model slug — stand-ins for Neural (local) and
+        // Grid (cross-grid), both serving qwen3-embedding-0.6b.
+        let local = Arc::new(CountingEmbedder::new("qwen3-embedding-0.6b"));
+        let grid = Arc::new(CountingEmbedder::new("qwen3-embedding-0.6b"));
+        let neural = CachingEmbeddingProvider::with_cache(local.clone(), cache.clone());
+        let grid_provider = CachingEmbeddingProvider::with_cache(grid.clone(), cache.clone());
+
+        let a = neural.embed("the deploy went red"); // local path computes + caches
+        let b = grid_provider.embed("the deploy went red"); // grid path hits the SAME entry
+        assert_eq!(a, b, "same model slug → same cache entry across transports");
+        assert_eq!(local.calls.load(Ordering::SeqCst), 1, "local computed once");
+        assert_eq!(
+            grid.calls.load(Ordering::SeqCst),
+            0,
+            "grid round-trip never fired — the local-cached vector was reused"
+        );
+        assert_eq!(cache.len(), 1, "one entry: identity is the model, not the transport");
+    }
 }

--- a/core/continuum-core/src/cognition/embedding.rs
+++ b/core/continuum-core/src/cognition/embedding.rs
@@ -22,6 +22,12 @@ use std::sync::{Arc, OnceLock};
 
 use dashmap::DashMap;
 
+/// Soft bound on the global embedding cache so a long-lived grid node servicing a
+/// busy room can't grow it without limit (the substrate's pressure doctrine — an
+/// unbounded hot-path cache is a leak at scale). On overflow we evict one
+/// arbitrary entry; a proper LRU / `PagedResourcePool` tie-in is the follow-up.
+const EMBEDDING_CACHE_MAX: usize = 20_000;
+
 /// A backend that turns text into a dense vector. Sync + cheap for the lexical
 /// bootstrap; a neural backend pre-embeds engrams at admission (off the recall
 /// hot path) and looks them up here.
@@ -50,10 +56,19 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
         na += a[i] * a[i];
         nb += b[i] * b[i];
     }
-    if na == 0.0 || nb == 0.0 {
+    // Reject zero AND non-finite norms. A future EmbeddingProvider (neural/grid)
+    // could return a NaN/Inf component; without this the `== 0.0` guard passes,
+    // cosine returns NaN, and a NaN salience poisons the arbiter's sort
+    // (every partial_cmp → Equal = arbitrary order). Fail to "no signal", never NaN.
+    if !na.is_finite() || !nb.is_finite() || na == 0.0 || nb == 0.0 {
         return 0.0;
     }
-    dot / (na.sqrt() * nb.sqrt())
+    let sim = dot / (na.sqrt() * nb.sqrt());
+    if sim.is_finite() {
+        sim
+    } else {
+        0.0
+    }
 }
 
 /// Bootstrap embedder: hashing-trick term-frequency vectors. Lowercase, split on
@@ -159,7 +174,7 @@ impl EmbeddingCache {
             h ^= *b as u64;
             h = h.wrapping_mul(0x100000001b3);
         }
-        h ^= 0; // separator so "ab"+"c" != "a"+"bc"
+        h ^= 0xff; // real separator byte so provider_id/text boundary can't alias
         h = h.wrapping_mul(0x100000001b3);
         for b in text.as_bytes() {
             h ^= *b as u64;
@@ -227,6 +242,13 @@ impl EmbeddingProvider for CachingEmbeddingProvider {
             return v.clone();
         }
         let v = self.inner.embed(text);
+        // Bound memory: evict one arbitrary entry on overflow before inserting a
+        // genuinely new key. Hot/recent content re-populates on its next miss.
+        if !self.cache.map.contains_key(&key) && self.cache.map.len() >= EMBEDDING_CACHE_MAX {
+            if let Some(victim) = self.cache.map.iter().next().map(|e| *e.key()) {
+                self.cache.map.remove(&victim);
+            }
+        }
         self.cache.map.insert(key, v.clone());
         v
     }
@@ -272,6 +294,11 @@ mod tests {
         assert_eq!(cosine_similarity(&[], &[]), 0.0);
         assert_eq!(cosine_similarity(&[1.0, 2.0], &[1.0]), 0.0);
         assert_eq!(cosine_similarity(&[0.0, 0.0], &[1.0, 1.0]), 0.0);
+        // Non-finite components → 0.0 ("no signal"), NEVER NaN — a NaN here
+        // would poison the arbiter sort (every partial_cmp becomes Equal).
+        assert_eq!(cosine_similarity(&[f32::NAN, 1.0], &[1.0, 1.0]), 0.0);
+        assert_eq!(cosine_similarity(&[f32::INFINITY, 1.0], &[1.0, 1.0]), 0.0);
+        assert!(cosine_similarity(&[f32::NAN, 1.0], &[1.0, 1.0]).is_finite());
     }
 
     // what this catches: embeddings are REPRODUCIBLE across calls (FNV, not the

--- a/core/continuum-core/src/cognition/embedding.rs
+++ b/core/continuum-core/src/cognition/embedding.rs
@@ -18,6 +18,10 @@
 //! This is the project's adapter discipline: build the simplest outlier first,
 //! prove the interface, let the strong backend slot in unchanged.
 
+use std::sync::{Arc, OnceLock};
+
+use dashmap::DashMap;
+
 /// A backend that turns text into a dense vector. Sync + cheap for the lexical
 /// bootstrap; a neural backend pre-embeds engrams at admission (off the recall
 /// hot path) and looks them up here.
@@ -124,9 +128,114 @@ impl EmbeddingProvider for LexicalEmbedder {
     }
 }
 
+/// Content-addressed embedding cache — compute ONCE per message content, share
+/// across every persona. An embedding is a property of the CONTENT, not the
+/// persona (exactly like a vision description or an STT transcript): 14 personas
+/// in a room reuse ONE embedding per message, never 14. Keyed by (embedding
+/// space, content) so vectors from different embedders never collide — cosine
+/// across spaces is arithmetic nonsense. Global + shared; the hot path is a
+/// `DashMap::get`. Optimization-first: the sharing is the seam, not a later pass.
+pub struct EmbeddingCache {
+    map: DashMap<u64, Vec<f32>>,
+}
+
+impl Default for EmbeddingCache {
+    fn default() -> Self {
+        Self { map: DashMap::new() }
+    }
+}
+
+impl EmbeddingCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// FNV-1a-64 over `provider_id \0 text` — keys the vector to its embedding
+    /// SPACE as well as its content. Deterministic (replay-safe); collision
+    /// probability is negligible at realistic message volumes.
+    fn key(provider_id: &str, text: &str) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for b in provider_id.as_bytes() {
+            h ^= *b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h ^= 0; // separator so "ab"+"c" != "a"+"bc"
+        h = h.wrapping_mul(0x100000001b3);
+        for b in text.as_bytes() {
+            h ^= *b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+
+    /// Number of vectors currently cached.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+}
+
+/// Process-global content-addressed embedding cache — the one place a message's
+/// vector lives, shared by every persona. Same global-singleton pattern as the
+/// persona-workspace registry and the ai_provider registry.
+pub fn global_embedding_cache() -> Arc<EmbeddingCache> {
+    static G: OnceLock<Arc<EmbeddingCache>> = OnceLock::new();
+    G.get_or_init(|| Arc::new(EmbeddingCache::new())).clone()
+}
+
+/// Wraps any [`EmbeddingProvider`] with the content-addressed cache. `embed` is a
+/// `DashMap::get` on the hot path; the inner provider (lexical now; neural / grid
+/// later) fires ONLY on a miss, and the result is shared with every other persona
+/// that embeds the same content. This is how "compute once per element, reuse
+/// across 14 personas" is enforced structurally.
+pub struct CachingEmbeddingProvider {
+    inner: Arc<dyn EmbeddingProvider>,
+    cache: Arc<EmbeddingCache>,
+}
+
+impl CachingEmbeddingProvider {
+    /// Wrap `inner`, sharing the process-global cache — what makes the
+    /// compute-once-across-personas property hold in production.
+    pub fn new(inner: Arc<dyn EmbeddingProvider>) -> Self {
+        Self {
+            inner,
+            cache: global_embedding_cache(),
+        }
+    }
+
+    /// Wrap `inner` against a specific cache (tests / isolated benches).
+    pub fn with_cache(inner: Arc<dyn EmbeddingProvider>, cache: Arc<EmbeddingCache>) -> Self {
+        Self { inner, cache }
+    }
+}
+
+impl EmbeddingProvider for CachingEmbeddingProvider {
+    fn id(&self) -> &str {
+        self.inner.id()
+    }
+
+    fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+
+    fn embed(&self, text: &str) -> Vec<f32> {
+        let key = EmbeddingCache::key(self.inner.id(), text);
+        if let Some(v) = self.cache.map.get(&key) {
+            return v.clone();
+        }
+        let v = self.inner.embed(text);
+        self.cache.map.insert(key, v.clone());
+        v
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     // what this catches: the cosine of identical text is ~1; orthogonal
     // (no shared vocabulary) is ~0. The relevance primitive is sane.
@@ -171,5 +280,88 @@ mod tests {
     fn embeddings_are_reproducible() {
         let e = LexicalEmbedder::new();
         assert_eq!(e.embed("reproducible vectors"), e.embed("reproducible vectors"));
+    }
+
+    /// An embedder that counts how many times it actually computed — to prove
+    /// the cache prevents recomputation.
+    struct CountingEmbedder {
+        id: &'static str,
+        calls: AtomicUsize,
+    }
+    impl CountingEmbedder {
+        fn new(id: &'static str) -> Self {
+            Self {
+                id,
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+    impl EmbeddingProvider for CountingEmbedder {
+        fn id(&self) -> &str {
+            self.id
+        }
+        fn dim(&self) -> usize {
+            4
+        }
+        fn embed(&self, text: &str) -> Vec<f32> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            // Deterministic per-content vector (content length spread over dims).
+            let n = text.len() as f32;
+            vec![n, n + 1.0, n + 2.0, n + 3.0]
+        }
+    }
+
+    // what this catches: THE OPTIMIZATION — the same content is embedded ONCE;
+    // the second call (any persona) is a cache hit, the inner embedder is NOT
+    // re-invoked. This is the compute-once-per-content / 14-personas-reuse-one win.
+    #[test]
+    fn cache_computes_once_and_reuses() {
+        let inner = Arc::new(CountingEmbedder::new("counting"));
+        let cache = Arc::new(EmbeddingCache::new());
+        let cached = CachingEmbeddingProvider::with_cache(inner.clone(), cache);
+
+        let a = cached.embed("the deploy went red");
+        let b = cached.embed("the deploy went red"); // any persona, same content
+        assert_eq!(a, b, "cache returns the identical vector");
+        assert_eq!(
+            inner.calls.load(Ordering::SeqCst),
+            1,
+            "inner embedder computed ONCE despite two embed calls"
+        );
+    }
+
+    // what this catches: distinct content is genuinely recomputed (the cache
+    // isn't returning a stale vector for new text).
+    #[test]
+    fn cache_recomputes_distinct_content() {
+        let inner = Arc::new(CountingEmbedder::new("counting"));
+        let cache = Arc::new(EmbeddingCache::new());
+        let cached = CachingEmbeddingProvider::with_cache(inner.clone(), cache);
+        let _ = cached.embed("first message");
+        let _ = cached.embed("a different message");
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 2);
+    }
+
+    // what this catches: vectors from DIFFERENT embedding spaces (provider ids)
+    // never collide in the cache — keying includes provider_id, so a lexical
+    // vector is never served to a neural query (cosine across spaces is nonsense).
+    #[test]
+    fn cache_keys_by_embedding_space() {
+        let cache = Arc::new(EmbeddingCache::new());
+        let lexical = CachingEmbeddingProvider::with_cache(
+            Arc::new(CountingEmbedder::new("space-a")),
+            cache.clone(),
+        );
+        let neural = CachingEmbeddingProvider::with_cache(
+            Arc::new(CountingEmbedder::new("space-b")),
+            cache.clone(),
+        );
+        let _ = lexical.embed("same text");
+        let _ = neural.embed("same text");
+        assert_eq!(
+            cache.len(),
+            2,
+            "same text in two embedding spaces = two distinct cache entries"
+        );
     }
 }

--- a/core/continuum-core/src/cognition/embedding.rs
+++ b/core/continuum-core/src/cognition/embedding.rs
@@ -1,0 +1,175 @@
+//! Embedding + similarity — the relevance primitive for recall.
+//!
+//! Recall must surface the memory RELEVANT to the current burst, not merely the
+//! most recent (PERSONA-BRAIN-ARCHITECTURE.md §5 / §2.9: "always remembering" =
+//! similarity recall into the long-term store). That needs a vector embedding of
+//! text + a similarity measure. This module owns both, behind a trait so the
+//! BACKEND is swappable:
+//!
+//! - [`LexicalEmbedder`] — the bootstrap: a hashing-trick term-frequency vector.
+//!   Real, deterministic, zero-dependency topical-overlap relevance that works on
+//!   ANY machine with no model loaded ("solve for public users"). It is NOT a
+//!   stub — lexical overlap is a genuine (if shallow) relevance signal.
+//! - A neural embedder (llama.cpp `--embedding` mode, or a dedicated bge/nomic
+//!   model) slots in behind the SAME trait for semantic relevance, when an
+//!   embedding backend exists on the grid. The recall re-ranker (§7) does not
+//!   change when it does — only the vectors get smarter.
+//!
+//! This is the project's adapter discipline: build the simplest outlier first,
+//! prove the interface, let the strong backend slot in unchanged.
+
+/// A backend that turns text into a dense vector. Sync + cheap for the lexical
+/// bootstrap; a neural backend pre-embeds engrams at admission (off the recall
+/// hot path) and looks them up here.
+pub trait EmbeddingProvider: Send + Sync {
+    /// Stable identifier for the embedding space (so vectors from different
+    /// providers are never silently mixed).
+    fn id(&self) -> &str;
+    /// The vector dimensionality.
+    fn dim(&self) -> usize;
+    /// Embed text into a (typically L2-normalized) vector of length `dim()`.
+    fn embed(&self, text: &str) -> Vec<f32>;
+}
+
+/// Cosine similarity in `[-1, 1]` (≈`[0,1]` for non-negative vectors). Returns
+/// 0.0 for a length mismatch or a zero vector — a relevance score of "no signal",
+/// never a panic.
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
+/// Bootstrap embedder: hashing-trick term-frequency vectors. Lowercase, split on
+/// non-alphanumeric, hash each token into one of `DIM` buckets, count, then
+/// L2-normalize so cosine is a dot product. Captures topical word overlap — a
+/// query sharing vocabulary with a memory scores high regardless of recency.
+pub struct LexicalEmbedder {
+    dim: usize,
+}
+
+impl Default for LexicalEmbedder {
+    fn default() -> Self {
+        // 512 buckets — enough to keep collisions low for short engram/burst text
+        // without paying for a real model.
+        Self { dim: 512 }
+    }
+}
+
+impl LexicalEmbedder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// FNV-1a — a small, fast, deterministic, dependency-free string hash. We do
+    /// NOT use Rust's `DefaultHasher` (it is randomized per process, which would
+    /// make embeddings non-reproducible across runs — replay would break).
+    fn hash_token(token: &str) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for b in token.as_bytes() {
+            h ^= *b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+}
+
+impl EmbeddingProvider for LexicalEmbedder {
+    fn id(&self) -> &str {
+        "lexical-fnv-tf"
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    fn embed(&self, text: &str) -> Vec<f32> {
+        let mut v = vec![0.0f32; self.dim];
+        let mut token = String::new();
+        let mut push = |tok: &mut String, v: &mut [f32]| {
+            if !tok.is_empty() {
+                let idx = (Self::hash_token(tok) as usize) % v.len();
+                v[idx] += 1.0;
+                tok.clear();
+            }
+        };
+        for ch in text.chars() {
+            if ch.is_alphanumeric() {
+                token.extend(ch.to_lowercase());
+            } else {
+                push(&mut token, &mut v);
+            }
+        }
+        push(&mut token, &mut v);
+        // L2-normalize so cosine == dot product.
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for x in &mut v {
+                *x /= norm;
+            }
+        }
+        v
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the cosine of identical text is ~1; orthogonal
+    // (no shared vocabulary) is ~0. The relevance primitive is sane.
+    #[test]
+    fn identical_text_is_maximally_similar() {
+        let e = LexicalEmbedder::new();
+        let a = e.embed("the deploy pipeline went red after the migration");
+        let same = e.embed("the deploy pipeline went red after the migration");
+        assert!(cosine_similarity(&a, &same) > 0.999);
+    }
+
+    // what this catches: topical relevance — a query about the rollout plan is
+    // MORE similar to the rollout memory than to an unrelated lunch memory, even
+    // though both are equally "old". This is relevance, not recency.
+    #[test]
+    fn relevant_text_outscores_unrelated_text() {
+        let e = LexicalEmbedder::new();
+        let query = e.embed("what was our rollout plan for the auth flow?");
+        let relevant = e.embed("we will ship the auth flow behind a feature flag and ramp the rollout to 10%");
+        let unrelated = e.embed("lunch is at noon, someone booked the corner table");
+        let rel = cosine_similarity(&query, &relevant);
+        let unrel = cosine_similarity(&query, &unrelated);
+        assert!(
+            rel > unrel,
+            "relevant memory must score higher: relevant={rel:.3} unrelated={unrel:.3}"
+        );
+        assert!(rel > 0.0);
+    }
+
+    // what this catches: a zero/empty embedding or length mismatch yields 0.0,
+    // never a panic or NaN — recall must degrade to "no signal", not crash.
+    #[test]
+    fn degrades_safely() {
+        assert_eq!(cosine_similarity(&[], &[]), 0.0);
+        assert_eq!(cosine_similarity(&[1.0, 2.0], &[1.0]), 0.0);
+        assert_eq!(cosine_similarity(&[0.0, 0.0], &[1.0, 1.0]), 0.0);
+    }
+
+    // what this catches: embeddings are REPRODUCIBLE across calls (FNV, not the
+    // randomized DefaultHasher) — required for replay/record-recreate to work.
+    #[test]
+    fn embeddings_are_reproducible() {
+        let e = LexicalEmbedder::new();
+        assert_eq!(e.embed("reproducible vectors"), e.embed("reproducible vectors"));
+    }
+}

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -28,6 +28,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use std::fmt::Write as _;
 use uuid::Uuid;
 
 use super::workspace::{Contribution, Decision, Faculty, FacultyId, Workspace};
@@ -118,7 +119,7 @@ impl LlmDeliberationFaculty {
     }
 
     fn build_system_prompt(&self, ws: &Workspace) -> String {
-        let mut s = String::with_capacity(self.system_prompt.len() + 512);
+        let mut s = String::with_capacity(self.system_prompt.len() + 768);
         s.push_str(&self.system_prompt);
         let context = self.render_assembled_context(ws);
         if !context.is_empty() {
@@ -131,10 +132,50 @@ impl LlmDeliberationFaculty {
             );
             s.push_str(&context);
         }
+        // Tell the reasoner it is taking a TURN in this activity, not analyzing a
+        // transcript — otherwise small models outline the situation instead of
+        // participating. The activity is NOT hardcoded (it is recipe-defined): the
+        // room's operating doctrine in the context above specializes HOW to
+        // participate (chat / coordination / game / code / art / …). This block
+        // only says "respond as yourself, in your own voice, not as an analysis."
+        let _ = write!(
+            s,
+            "\n\n[Taking your turn]\n\
+             What follows (the user message) is the recent activity in this space — \
+             messages from OTHER participants. You are {name}. Write ONLY your own \
+             single next message, in first person, in your own voice, the way you \
+             would actually say it. Do NOT write or invent anyone else's lines, do \
+             NOT continue or replay the transcript, do NOT prefix your message with \
+             your name, do NOT write an outline, analysis, or narration of what you \
+             are doing — just say your piece. Let the context above (including the \
+             room's operating doctrine, if any) shape how you participate. If you \
+             have nothing worth adding, stay silent.",
+            name = self.persona_name,
+        );
         // Reuse the ONE silence contract — PASS = first-class choice to stay quiet.
         s.push_str(SILENCE_AFFORDANCE_BLOCK);
         s
     }
+
+    /// The EXACT prompt this faculty sends the model this tick — the system
+    /// prompt (identity + assembled RAG context + how-to-participate + silence
+    /// affordance) and the user burst. Exposed so what the LLM sees is trivially
+    /// introspectable at every turn (tests, replay, operator tooling). The RAG is
+    /// the load-bearing input; it must never be opaque.
+    pub fn prompt_view(&self, ws: &Workspace) -> DeliberationPromptView {
+        DeliberationPromptView {
+            system: self.build_system_prompt(ws),
+            user: ws.world_state.clone(),
+        }
+    }
+}
+
+/// A snapshot of exactly what the deliberation faculty sends the model — the
+/// glass box over the RAG/prompt. Print it, capture it, diff it across turns.
+#[derive(Debug, Clone)]
+pub struct DeliberationPromptView {
+    pub system: String,
+    pub user: String,
 }
 
 #[async_trait]
@@ -150,15 +191,28 @@ impl Faculty for LlmDeliberationFaculty {
     }
 
     async fn contribute(&self, ws: &Workspace) -> Option<Contribution> {
+        let view = self.prompt_view(ws);
+        // Introspection seam: emit EXACTLY what the model sees this tick. The RAG
+        // is the load-bearing input — never opaque. Enable the `cognition` log
+        // category for the persona to capture this per-turn (the existing
+        // record/replay harness — recorder + RagCaptureSink + vdd::turn_replay —
+        // is the durable path; this debug emit is the live tap).
+        tracing::debug!(
+            target: "cognition::deliberation",
+            persona = %self.persona_name,
+            system_prompt = %view.system,
+            burst = %view.user,
+            "deliberation prompt — what the model sees this turn"
+        );
         let request = TextGenerationRequest {
             messages: vec![ChatMessage {
                 role: "user".to_string(),
                 // The consolidated burst — the "catch up on the thread" the
                 // persona is reasoning over this tick.
-                content: MessageContent::Text(ws.world_state.clone()),
+                content: MessageContent::Text(view.user),
                 name: None,
             }],
-            system_prompt: Some(self.build_system_prompt(ws)),
+            system_prompt: Some(view.system),
             model: self.model.clone(),
             provider: None,
             temperature: Some(self.temperature),

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -1,0 +1,268 @@
+//! LlmDeliberationFaculty — the reasoner, backed by real inference.
+//!
+//! This is the deliberation-tier faculty (`reacts_to_broadcast() == true`): it
+//! runs in phase 2 of the staged cycle, over the **assembled context** the
+//! perception faculties (recall, world-model, affect, roster, doctrine) won into
+//! the broadcast in phase 1. It calls a real `AIProviderAdapter` — the same trait
+//! the live persona path uses — and turns the model's output into a participation
+//! [`Decision`].
+//!
+//! ## It is NOT a gate
+//!
+//! Per [[no-rust-gates-around-cognition]] and §1.1 of
+//! PERSONA-BRAIN-ARCHITECTURE.md, this faculty does not decide *whether the
+//! persona is allowed* to think. It thinks, and its thought's *result* is the
+//! Decision. Silence (`Pass`) is the model choosing the silence affordance
+//! (`PASS` token, reusing `prompt_assembly::SILENCE_AFFORDANCE_BLOCK` +
+//! `looks_like_silence_token` — one silence contract, not a second one) — the
+//! persona's own judgment, never an `@`-trigger or a caste rule.
+//!
+//! ## Backend-agnostic
+//!
+//! It holds an `Arc<dyn AIProviderAdapter>` — the shared model backend, leased
+//! per call (the cbar session-mutex lease pattern). In a bring-up harness that's
+//! `HeuristicInferenceAdapter` (deterministic, no GPU) or a real
+//! `LlamaCppAdapter` (a live local model). The faculty does not care which — the
+//! brain is unchanged when the backend swaps.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use super::workspace::{Contribution, Decision, Faculty, FacultyId, Workspace};
+use crate::ai::adapter::AIProviderAdapter;
+use crate::ai::types::{ChatMessage, MessageContent, TextGenerationRequest};
+use crate::persona::prompt_assembly::{looks_like_silence_token, SILENCE_AFFORDANCE_BLOCK};
+
+/// Default sampling temperature for deliberation — enough warmth for natural
+/// voice, not so much it drifts.
+const DEFAULT_TEMPERATURE: f32 = 0.7;
+/// Default response cap. Deliberation is a turn, not an essay.
+const DEFAULT_MAX_TOKENS: u32 = 512;
+
+/// Map a model's raw output to a participation [`Decision`].
+///
+/// Pure — no IO — so the Speak/Pass branches are unit-testable without a model.
+/// `PASS` (the silence token) → `Pass`; anything else → `Speak`. `RaiseUnprompted`
+/// is the volition faculty's channel (initiative with no prompt), not something
+/// we infer from a single deliberation response — a deliberation faculty answers
+/// the burst it was given.
+pub fn decision_from_response(text: &str) -> Decision {
+    let trimmed = text.trim();
+    if trimmed.is_empty() || looks_like_silence_token(trimmed) {
+        Decision::Pass
+    } else {
+        Decision::Speak {
+            text: trimmed.to_string(),
+        }
+    }
+}
+
+/// The reasoner faculty. Persona-scoped; shared model backend.
+pub struct LlmDeliberationFaculty {
+    persona_id: Uuid,
+    persona_name: String,
+    /// The persona's identity / deliberation system prompt (from RAG identity).
+    system_prompt: String,
+    /// Shared model backend, leased per call.
+    adapter: Arc<dyn AIProviderAdapter>,
+    /// Which model to ask for (None → the adapter's default).
+    model: Option<String>,
+    temperature: f32,
+    max_tokens: u32,
+}
+
+impl LlmDeliberationFaculty {
+    pub fn new(
+        persona_id: Uuid,
+        persona_name: impl Into<String>,
+        system_prompt: impl Into<String>,
+        adapter: Arc<dyn AIProviderAdapter>,
+    ) -> Self {
+        Self {
+            persona_id,
+            persona_name: persona_name.into(),
+            system_prompt: system_prompt.into(),
+            adapter,
+            model: None,
+            temperature: DEFAULT_TEMPERATURE,
+            max_tokens: DEFAULT_MAX_TOKENS,
+        }
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.temperature = temperature;
+        self
+    }
+
+    /// Render the assembled context (the phase-1 winners that hold the workspace)
+    /// into a system-prompt block, so the reasoner conditions on what recall /
+    /// world-model / affect surfaced. Only *context* contributions are included
+    /// (the verdict isn't in the broadcast yet at phase 2).
+    fn render_assembled_context(&self, ws: &Workspace) -> String {
+        let mut block = String::new();
+        for c in ws.broadcast.iter().filter(|c| c.decision.is_none()) {
+            block.push_str("\n[");
+            block.push_str(c.faculty.as_str());
+            block.push_str("]\n");
+            block.push_str(&c.content);
+            block.push('\n');
+        }
+        block
+    }
+
+    fn build_system_prompt(&self, ws: &Workspace) -> String {
+        let mut s = String::with_capacity(self.system_prompt.len() + 512);
+        s.push_str(&self.system_prompt);
+        let context = self.render_assembled_context(ws);
+        if !context.is_empty() {
+            s.push_str(
+                "\n\n[What you are working with right now]\n\
+                 The following is the context your mind assembled this moment — \
+                 recalled memory, who is present, the room's nature, your read of \
+                 the situation. Ground your contribution in it; you need not cite \
+                 every line:\n",
+            );
+            s.push_str(&context);
+        }
+        // Reuse the ONE silence contract — PASS = first-class choice to stay quiet.
+        s.push_str(SILENCE_AFFORDANCE_BLOCK);
+        s
+    }
+}
+
+#[async_trait]
+impl Faculty for LlmDeliberationFaculty {
+    fn id(&self) -> FacultyId {
+        FacultyId::Deliberation
+    }
+
+    // Deliberation tier: reacts to the assembled broadcast (phase 2), so the
+    // Decision is conditioned on the context recall/world-model/affect surfaced.
+    fn reacts_to_broadcast(&self) -> bool {
+        true
+    }
+
+    async fn contribute(&self, ws: &Workspace) -> Option<Contribution> {
+        let request = TextGenerationRequest {
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                // The consolidated burst — the "catch up on the thread" the
+                // persona is reasoning over this tick.
+                content: MessageContent::Text(ws.world_state.clone()),
+                name: None,
+            }],
+            system_prompt: Some(self.build_system_prompt(ws)),
+            model: self.model.clone(),
+            provider: None,
+            temperature: Some(self.temperature),
+            max_tokens: Some(self.max_tokens),
+            top_p: None,
+            top_k: None,
+            repeat_penalty: None,
+            stop_sequences: None,
+            tools: None,
+            tool_choice: None,
+            response_format: None,
+            active_adapters: None,
+            request_id: None,
+            user_id: None,
+            room_id: None,
+            purpose: Some("cognition/deliberation".to_string()),
+            persona_id: Some(self.persona_id.to_string()),
+        };
+
+        match self.adapter.generate_text(request).await {
+            Ok(resp) => {
+                let decision = decision_from_response(&resp.text);
+                // The faculty's own confidence in its verdict. A placeholder for a
+                // model-derived signal (logprob / uncertainty) — NOT a caste
+                // weight; it's how sure THIS mind is, which the arbiter integrates.
+                let (salience, reasoning) = match &decision {
+                    Decision::Pass => (0.5, format!("{} chose silence (PASS)", self.persona_name)),
+                    _ => (
+                        0.85,
+                        format!("{} deliberated over the assembled context", self.persona_name),
+                    ),
+                };
+                Some(Contribution::verdict(decision, salience, reasoning))
+            }
+            // Inference failed — abstain this tick (the trace shows no verdict
+            // bid; the caller treats absence as effective silence). We do NOT
+            // fabricate a Pass: a failed model is not a chosen silence.
+            Err(e) => {
+                tracing::warn!(
+                    persona = %self.persona_name,
+                    error = %e,
+                    "deliberation inference failed; abstaining this tick"
+                );
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
+
+    // what this catches: the PASS silence token maps to Decision::Pass (with or
+    // without trailing punctuation); real content maps to Speak. One silence
+    // contract, reused from prompt_assembly.
+    #[test]
+    fn decision_parsing_maps_pass_and_speak() {
+        assert_eq!(decision_from_response("PASS"), Decision::Pass);
+        assert_eq!(decision_from_response("  PASS.  "), Decision::Pass);
+        assert_eq!(decision_from_response(""), Decision::Pass);
+        match decision_from_response("Let's ship the deploy fix now.") {
+            Decision::Speak { text } => assert!(text.contains("ship the deploy")),
+            other => panic!("expected Speak, got {other:?}"),
+        }
+    }
+
+    // what this catches: end-to-end through a REAL adapter (the deterministic
+    // heuristic stand-in) — the faculty calls inference and produces a verdict
+    // Contribution. Proves the faculty wires to the AIProviderAdapter trait the
+    // live path uses; swap in LlamaCppAdapter for a live persona, unchanged.
+    #[tokio::test]
+    async fn deliberates_through_a_real_adapter() {
+        let persona = Uuid::new_v4();
+        let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
+        let faculty = LlmDeliberationFaculty::new(
+            persona,
+            "Ivar",
+            "You are Ivar, a thoughtful engineer on the grid.",
+            adapter,
+        );
+
+        assert!(faculty.reacts_to_broadcast(), "deliberation is phase 2");
+
+        // A workspace with a phase-1 recall context bid already broadcast.
+        let mut ws = Workspace::new("teammate asks: where did we land on the deploy?");
+        ws.broadcast.push(Contribution::context(
+            FacultyId::Recall,
+            "deploy pipeline was red; fix was merged at 4pm",
+            0.8,
+            "recalled",
+        ));
+
+        let c = faculty
+            .contribute(&ws)
+            .await
+            .expect("deliberation should bid a verdict when inference succeeds");
+        assert_eq!(c.faculty, FacultyId::Deliberation);
+        assert!(
+            c.decision.is_some(),
+            "deliberation carries the participation verdict"
+        );
+        // The heuristic adapter acks (never emits PASS), so this is a Speak.
+        assert!(matches!(c.decision, Some(Decision::Speak { .. })));
+    }
+}

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -34,7 +34,9 @@ use uuid::Uuid;
 use super::workspace::{Contribution, Decision, Faculty, FacultyId, Workspace};
 use crate::ai::adapter::AIProviderAdapter;
 use crate::ai::types::{ChatMessage, MessageContent, TextGenerationRequest};
-use crate::persona::prompt_assembly::{looks_like_silence_token, SILENCE_AFFORDANCE_BLOCK};
+use crate::persona::prompt_assembly::{
+    looks_like_silence_token, SILENCE_AFFORDANCE_BLOCK, SILENCE_TOKEN,
+};
 
 /// Default sampling temperature for deliberation — enough warmth for natural
 /// voice, not so much it drifts.
@@ -51,13 +53,29 @@ const DEFAULT_MAX_TOKENS: u32 = 512;
 /// the burst it was given.
 pub fn decision_from_response(text: &str) -> Decision {
     let trimmed = text.trim();
-    if trimmed.is_empty() || looks_like_silence_token(trimmed) {
+    if trimmed.is_empty() || looks_like_silence_token(trimmed) || starts_with_silence_token(trimmed)
+    {
         Decision::Pass
     } else {
         Decision::Speak {
             text: trimmed.to_string(),
         }
     }
+}
+
+/// True if the response STARTS with the silence token (e.g. `"PASS — nothing to
+/// add"`). Small models frequently emit `PASS` plus trailing prose despite the
+/// "no other text" instruction; without this they'd literally speak the word
+/// "PASS" into the room. The leading-token check treats that as the chosen
+/// silence it is. (Accepted trade: a real message whose first word is literally
+/// "pass" is silenced — vanishingly rare for a deliberation turn, and silence is
+/// a first-class, low-cost outcome.)
+fn starts_with_silence_token(text: &str) -> bool {
+    let Some(first) = text.split_whitespace().next() else {
+        return false;
+    };
+    let core = first.trim_end_matches(|c: char| !c.is_alphanumeric());
+    core.eq_ignore_ascii_case(SILENCE_TOKEN)
 }
 
 /// The reasoner faculty. Persona-scoped; shared model backend.
@@ -275,6 +293,10 @@ mod tests {
         assert_eq!(decision_from_response("PASS"), Decision::Pass);
         assert_eq!(decision_from_response("  PASS.  "), Decision::Pass);
         assert_eq!(decision_from_response(""), Decision::Pass);
+        // Small models leak trailing prose after PASS — must still be silence,
+        // not a message that literally says "PASS ...".
+        assert_eq!(decision_from_response("PASS — nothing to add here"), Decision::Pass);
+        assert_eq!(decision_from_response("PASS.\nI'll stay quiet"), Decision::Pass);
         match decision_from_response("Let's ship the deploy fix now.") {
             Decision::Speak { text } => assert!(text.contains("ship the deploy")),
             other => panic!("expected Speak, got {other:?}"),

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -30,6 +30,7 @@
 pub mod adaptive_throughput;
 pub mod audit;
 pub mod check_redundancy;
+pub mod embedding;
 pub mod generate_recipe;
 pub mod generate_response;
 pub mod host_capability_probe;

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -49,6 +49,7 @@ pub mod turn_batch;
 pub mod types;
 pub mod validate_response;
 pub mod vision_describe;
+pub mod workspace;
 
 pub use adaptive_throughput::*;
 pub use model_resolver::*;

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -35,6 +35,7 @@ pub mod generate_response;
 pub mod host_capability_probe;
 pub mod model_resolver;
 pub mod rate_proposals;
+pub mod recall_faculty;
 pub mod resource_admission;
 pub mod response_orchestrator;
 pub mod response_validator;

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -44,6 +44,7 @@ pub mod response_validator;
 pub mod serving_plan;
 pub mod shared_analysis;
 pub mod should_respond;
+pub mod should_respond_module;
 pub mod threat_detector;
 pub mod throughput_lease;
 pub mod tool_embedding;

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -33,6 +33,7 @@ pub mod check_redundancy;
 pub mod generate_recipe;
 pub mod generate_response;
 pub mod host_capability_probe;
+pub mod llm_deliberation_faculty;
 pub mod model_resolver;
 pub mod rate_proposals;
 pub mod recall_faculty;

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -35,6 +35,7 @@ pub mod generate_response;
 pub mod host_capability_probe;
 pub mod llm_deliberation_faculty;
 pub mod model_resolver;
+pub mod persona_workspace;
 pub mod rate_proposals;
 pub mod recall_faculty;
 pub mod resource_admission;

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -1,0 +1,204 @@
+//! Per-persona workspace assembly + registry — the "one soul, many rooms" seam.
+//!
+//! This is the constructor `ai/should-respond` (and the bring-up harness) resolve
+//! a persona's mind through. The load-bearing decision (PERSONA-BRAIN-
+//! ARCHITECTURE.md §2.9) is structural: **one `WorkspaceCycle` per persona**,
+//! keyed by `persona_id` — NOT by `(persona_id, room_id)`. A persona is one
+//! continuous self across every room it services; its unified `AdmissionState`
+//! (the hippocampus) spans all its activities. Keying the registry by persona is
+//! what makes the citizen continuous instead of *severed* per-room.
+//!
+//! The same cycle is invoked for whatever room the persona is servicing; the room
+//! supplies the per-tick world-state (the consolidated burst), the persona
+//! supplies the unified memory + identity + faculties.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use uuid::Uuid;
+
+use super::llm_deliberation_faculty::LlmDeliberationFaculty;
+use super::recall_faculty::RecallFaculty;
+use super::workspace::{Faculty, SalienceArbiter, WorkspaceCycle};
+use crate::ai::adapter::AIProviderAdapter;
+use crate::persona::admission_state::AdmissionState;
+
+/// Default bounded workspace capacity — the finite attention "spotlight". Enough
+/// for recall + world-model + affect + roster context to coexist; the arbiter
+/// keeps it bounded so cost stays O(capacity) no matter how many faculties bid.
+pub const DEFAULT_WORKSPACE_CAPACITY: usize = 6;
+
+/// Everything needed to assemble one persona's continuous mind. The `admission`
+/// is the persona's UNIFIED hippocampus (shared with the admission pipeline and
+/// spanning all the persona's rooms); the `adapter` is the shared model backend,
+/// leased inside the deliberation faculty.
+pub struct PersonaBrainConfig {
+    pub persona_id: Uuid,
+    pub persona_name: String,
+    /// The persona's identity / deliberation system prompt (from RAG identity).
+    pub system_prompt: String,
+    pub admission: Arc<AdmissionState>,
+    pub adapter: Arc<dyn AIProviderAdapter>,
+    /// Bounded workspace capacity; `None` → [`DEFAULT_WORKSPACE_CAPACITY`].
+    pub capacity: Option<usize>,
+}
+
+/// Assemble a persona's `WorkspaceCycle` from its faculties. This IS the
+/// production assembly path — the bring-up harness and the `ai/should-respond`
+/// ServiceModule build the cycle the same way, so they cannot diverge.
+///
+/// v1 faculties: `RecallFaculty` (perception tier — the hippocampus) and
+/// `LlmDeliberationFaculty` (deliberation tier — the reasoner). More faculties
+/// (world-model, affect, volition) slot into this `Vec` as they land; nothing
+/// else changes (open/closed — §2.7).
+pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
+    let faculties: Vec<Arc<dyn Faculty>> = vec![
+        Arc::new(RecallFaculty::new(cfg.persona_id, cfg.admission)),
+        Arc::new(LlmDeliberationFaculty::new(
+            cfg.persona_id,
+            cfg.persona_name,
+            cfg.system_prompt,
+            cfg.adapter,
+        )),
+    ];
+    WorkspaceCycle::new(
+        faculties,
+        Arc::new(SalienceArbiter),
+        cfg.capacity.unwrap_or(DEFAULT_WORKSPACE_CAPACITY),
+    )
+}
+
+/// Persona-scoped registry of continuous minds. One `Arc<WorkspaceCycle>` per
+/// persona; lookups by `persona_id`. `ai/should-respond` resolves the cycle here,
+/// runs it over the room's consolidated burst, and reads the `Decision`.
+#[derive(Default)]
+pub struct PersonaWorkspaceRegistry {
+    cycles: Mutex<HashMap<Uuid, Arc<WorkspaceCycle>>>,
+}
+
+impl PersonaWorkspaceRegistry {
+    pub fn new() -> Self {
+        Self {
+            cycles: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Look up a persona's mind. `None` if it hasn't been registered/built yet.
+    pub fn get(&self, persona_id: &Uuid) -> Option<Arc<WorkspaceCycle>> {
+        self.cycles.lock().unwrap().get(persona_id).cloned()
+    }
+
+    /// Register a pre-built cycle for a persona (overwrites any existing).
+    pub fn register(&self, persona_id: Uuid, cycle: Arc<WorkspaceCycle>) {
+        self.cycles.lock().unwrap().insert(persona_id, cycle);
+    }
+
+    /// Get the persona's mind, building + caching it from `cfg` on first access.
+    /// Lazy-init so a persona's cycle is assembled once and reused across every
+    /// room it services (the "one soul" invariant).
+    pub fn get_or_build(&self, cfg: PersonaBrainConfig) -> Arc<WorkspaceCycle> {
+        let persona_id = cfg.persona_id;
+        let mut cycles = self.cycles.lock().unwrap();
+        if let Some(existing) = cycles.get(&persona_id) {
+            return existing.clone();
+        }
+        let cycle = Arc::new(build_workspace_cycle(cfg));
+        cycles.insert(persona_id, cycle.clone());
+        cycle
+    }
+
+    /// How many persona minds are resident.
+    pub fn len(&self) -> usize {
+        self.cycles.lock().unwrap().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
+    use crate::cognition::workspace::Decision;
+    use crate::persona::engram::{ChatMessageRef, Engram, EngramKind, EngramOrigin, TrustState};
+    use crate::persona::recall_metadata::{RecallMetadata, RecallMetadataRegistry};
+
+    fn seed_admission(now_ms: u64) -> Arc<AdmissionState> {
+        let recall_meta = Arc::new(RecallMetadataRegistry::new());
+        let state = Arc::new(AdmissionState::new(recall_meta.clone()));
+        let id = Uuid::new_v4();
+        let engram = Engram {
+            id,
+            kind: EngramKind::Episodic,
+            content: "the deploy pipeline went green after the 4pm fix".to_string(),
+            origin: EngramOrigin::Chat(ChatMessageRef {
+                message_id: Uuid::new_v4(),
+                room_id: Uuid::new_v4(),
+                sender_id: Uuid::new_v4(),
+                posted_at_ms: now_ms,
+                content_hash: "h".to_string(),
+            }),
+            recall_keys: Vec::new(),
+            admitted_at_ms: now_ms,
+            trust_state_at_admission: TrustState::ApprovedPeer,
+            admission_trace_id: None,
+        };
+        state.push_for_test(engram);
+        recall_meta.admit(
+            id,
+            RecallMetadata {
+                salience: 0.7,
+                access_count: 0,
+                last_accessed_ms: 0,
+                protected_until_ms: 0,
+                last_decayed_ms: now_ms,
+            },
+        );
+        state
+    }
+
+    fn cfg_for(persona_id: Uuid) -> PersonaBrainConfig {
+        PersonaBrainConfig {
+            persona_id,
+            persona_name: "Ivar".to_string(),
+            system_prompt: "You are Ivar, an engineer on the grid.".to_string(),
+            admission: seed_admission(1_000_000_000),
+            adapter: Arc::new(HeuristicInferenceAdapter::new()),
+            capacity: None,
+        }
+    }
+
+    // what this catches: the assembled cycle runs a FULL persona mind end-to-end —
+    // recall (hippocampus) bids in phase 1, deliberation (real adapter) decides in
+    // phase 2 over that context — and yields a Decision. This is the production
+    // assembly path; swap the adapter for LlamaCppAdapter and it's a live persona.
+    #[tokio::test]
+    async fn assembled_cycle_produces_a_decision() {
+        let persona = Uuid::new_v4();
+        let cycle = build_workspace_cycle(cfg_for(persona));
+        let ws = cycle.run("teammate: what's the deploy status?").await;
+        // The mind reached a participation verdict (heuristic adapter → Speak).
+        assert!(matches!(ws.decision(), Some(Decision::Speak { .. })));
+    }
+
+    // what this catches: ONE cycle per persona — get_or_build is idempotent and
+    // returns the SAME Arc, so a persona's continuous mind is reused across every
+    // room it services (the "one soul, many rooms" / anti-Severance invariant).
+    #[tokio::test]
+    async fn registry_keeps_one_mind_per_persona() {
+        let registry = PersonaWorkspaceRegistry::new();
+        let persona = Uuid::new_v4();
+        let first = registry.get_or_build(cfg_for(persona));
+        let second = registry.get_or_build(cfg_for(persona));
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "same persona must resolve to the SAME mind across rooms — not severed per-room"
+        );
+        assert_eq!(registry.len(), 1);
+        // A different persona is a different mind.
+        let _ = registry.get_or_build(cfg_for(Uuid::new_v4()));
+        assert_eq!(registry.len(), 2);
+    }
+}

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use uuid::Uuid;
 
+use super::embedding::LexicalEmbedder;
 use super::llm_deliberation_faculty::LlmDeliberationFaculty;
 use super::recall_faculty::RecallFaculty;
 use super::workspace::{Faculty, SalienceArbiter, WorkspaceCycle};
@@ -53,7 +54,13 @@ pub struct PersonaBrainConfig {
 /// else changes (open/closed — §2.7).
 pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     let faculties: Vec<Arc<dyn Faculty>> = vec![
-        Arc::new(RecallFaculty::new(cfg.persona_id, cfg.admission)),
+        // Relevance recall ON by default — the lexical bootstrap embedder works on
+        // any machine (no model), and relevance > recency is strictly better for
+        // coherence. A neural embedder slots in behind the same trait later.
+        Arc::new(
+            RecallFaculty::new(cfg.persona_id, cfg.admission)
+                .with_embedder(Arc::new(LexicalEmbedder::new())),
+        ),
         Arc::new(LlmDeliberationFaculty::new(
             cfg.persona_id,
             cfg.persona_name,

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -241,35 +241,89 @@ mod tests {
             adapter.default_model()
         );
 
+        use crate::cognition::llm_deliberation_faculty::LlmDeliberationFaculty;
+        use crate::cognition::recall_faculty::RecallFaculty;
+        use crate::cognition::workspace::{
+            Faculty, SalienceArbiter, Workspace, WorkspaceCaptureSink, WorkspaceCycle,
+            WorkspaceTrace,
+        };
+
         let persona = Uuid::new_v4();
-        let cycle = build_workspace_cycle(PersonaBrainConfig {
-            persona_id: persona,
-            persona_name: "Ivar".to_string(),
-            system_prompt: "You are Ivar, a thoughtful engineer and a citizen on the grid. \
-                You speak concisely, and only when you have something worth adding."
-                .to_string(),
-            // Reuse the seeded hippocampus — it carries a deploy-related memory.
-            admission: seed_admission(1_718_600_000_000),
+        let admission = seed_admission(1_718_600_000_000);
+        let system_prompt = "You are Ivar, a thoughtful engineer and a citizen on the grid. \
+            You speak concisely, and only when you have something worth adding.";
+
+        // Assemble the faculties directly (mirrors build_workspace_cycle) so we
+        // keep a typed handle to the deliberation faculty — to introspect the
+        // EXACT prompt it feeds the model.
+        let delib = Arc::new(LlmDeliberationFaculty::new(
+            persona,
+            "Ivar",
+            system_prompt,
             adapter,
-            capacity: None,
-        });
+        ));
+        let faculties: Vec<Arc<dyn Faculty>> =
+            vec![Arc::new(RecallFaculty::new(persona, admission)), delib.clone()];
+
+        // The EXISTING capture harness: a WorkspaceCaptureSink records every phase
+        // of the tick (all bids incl. losers, the assembled context, the decision)
+        // so we can diagnose cognition at any phase — record + recreate, not guess.
+        #[derive(Default)]
+        struct CapturingSink(std::sync::Mutex<Vec<WorkspaceTrace>>);
+        impl WorkspaceCaptureSink for CapturingSink {
+            fn record(&self, t: &WorkspaceTrace) {
+                self.0.lock().unwrap().push(t.clone());
+            }
+        }
+        let sink = Arc::new(CapturingSink::default());
+
+        let cycle =
+            WorkspaceCycle::new(faculties, Arc::new(SalienceArbiter), DEFAULT_WORKSPACE_CAPACITY)
+                .with_capture(sink.clone());
 
         let burst = "general room:\n\
             Joel: morning all\n\
             teammate: the deploy from yesterday — did we ever figure out what broke it?\n\
             teammate: ivar you were looking at it right?";
-        eprintln!("\n[live] === Ivar's mind runs over the burst ===\n{burst}\n");
 
         let ws = cycle.run(burst).await;
 
-        eprintln!("\n[live] === Ivar's decision ===");
+        // ---- Glass box: diagnose cognition at EVERY phase ----
+        let trace = sink.0.lock().unwrap().pop().expect("a tick was recorded");
+        eprintln!("\n================ COGNITION TRACE ================");
+        eprintln!("WORLD-STATE (the burst):\n{}\n", trace.world_state);
+        eprintln!("PHASE 1 — perception bids (the full competition, incl. losers):");
+        for b in &trace.bids {
+            eprintln!(
+                "  [{:<12} s={:.2}] {}  ({})",
+                b.faculty.as_str(),
+                b.salience,
+                b.content.replace('\n', " / "),
+                b.reasoning
+            );
+        }
+        eprintln!("\nASSEMBLED CONTEXT the decider saw (context_broadcast = the RAG):");
+        for c in &trace.context_broadcast {
+            eprintln!("  [{}] {}", c.faculty.as_str(), c.content.replace('\n', " / "));
+        }
+
+        // ---- EXACTLY what the LLM was fed (reconstruct the pre-deliberation ws) ----
+        let context_ws = Workspace {
+            world_state: burst.to_string(),
+            broadcast: trace.context_broadcast.clone(),
+        };
+        let view = delib.prompt_view(&context_ws);
+        eprintln!("\n--------------- WHAT THE LLM WAS FED ---------------");
+        eprintln!("[SYSTEM]\n{}\n", view.system);
+        eprintln!("[USER]\n{}", view.user);
+
+        eprintln!("\n--------------- Ivar's DECISION ---------------");
         match ws.decision() {
             Some(Decision::Speak { text }) => eprintln!("Ivar SPEAKS:\n{text}"),
-            Some(Decision::RaiseUnprompted { text }) => {
-                eprintln!("Ivar RAISES (unprompted):\n{text}")
-            }
+            Some(Decision::RaiseUnprompted { text }) => eprintln!("Ivar RAISES:\n{text}"),
             Some(Decision::Pass) | None => eprintln!("Ivar chose silence (PASS)."),
         }
+        eprintln!("=================================================\n");
 
         assert!(
             ws.decision().is_some(),

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use uuid::Uuid;
 
-use super::embedding::LexicalEmbedder;
+use super::embedding::{CachingEmbeddingProvider, LexicalEmbedder};
 use super::llm_deliberation_faculty::LlmDeliberationFaculty;
 use super::recall_faculty::RecallFaculty;
 use super::workspace::{Faculty, SalienceArbiter, WorkspaceCycle};
@@ -56,10 +56,14 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     let faculties: Vec<Arc<dyn Faculty>> = vec![
         // Relevance recall ON by default — the lexical bootstrap embedder works on
         // any machine (no model), and relevance > recency is strictly better for
-        // coherence. A neural embedder slots in behind the same trait later.
+        // coherence. Wrapped in the process-global content-addressed cache so a
+        // message is embedded ONCE and shared across every persona (the
+        // compute-once-per-content optimization — never 14× for 14 personas). A
+        // neural embedder slots in behind the same cache later.
         Arc::new(
-            RecallFaculty::new(cfg.persona_id, cfg.admission)
-                .with_embedder(Arc::new(LexicalEmbedder::new())),
+            RecallFaculty::new(cfg.persona_id, cfg.admission).with_embedder(Arc::new(
+                CachingEmbeddingProvider::new(Arc::new(LexicalEmbedder::new())),
+            )),
         ),
         Arc::new(LlmDeliberationFaculty::new(
             cfg.persona_id,

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -13,7 +13,7 @@
 //! supplies the unified memory + identity + faculties.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use uuid::Uuid;
 
@@ -115,6 +115,18 @@ impl PersonaWorkspaceRegistry {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+}
+
+/// Process-global persona-workspace registry. One per process; persona minds are
+/// assembled into it at spawn (`supervisor::materialize_adapters`) and resolved
+/// from it by the `ai/should-respond` ServiceModule. Same pattern as
+/// `modules::ai_provider::global_registry()` — the shared seam between the spawn
+/// path that builds minds and the command path that runs them.
+pub fn global() -> Arc<PersonaWorkspaceRegistry> {
+    static GLOBAL: OnceLock<Arc<PersonaWorkspaceRegistry>> = OnceLock::new();
+    GLOBAL
+        .get_or_init(|| Arc::new(PersonaWorkspaceRegistry::new()))
+        .clone()
 }
 
 #[cfg(test)]

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -213,4 +213,67 @@ mod tests {
         let _ = registry.get_or_build(cfg_for(Uuid::new_v4()));
         assert_eq!(registry.len(), 2);
     }
+
+    // THE LIVE BRING-UP: a persona's mind thinks with the REAL local model.
+    // Runs the EXACT production assembly path (build_workspace_cycle → RecallFaculty
+    // + LlmDeliberationFaculty) against the real LlamaCppAdapter (qwen3.5-4b-code-
+    // forged on disk), over a real consolidated burst, and prints Ivar's actual
+    // words. #[ignore] — needs a local GGUF + Metal. Run:
+    //   CARGO_TARGET_DIR=$HOME/.continuum/cache/cargo-target \
+    //   cargo test -p continuum-core --features metal,accelerate \
+    //     cognition::persona_workspace::tests::ivar_thinks_with_the_real_model \
+    //     -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "needs local GGUF + Metal; run with --ignored --nocapture"]
+    async fn ivar_thinks_with_the_real_model() {
+        use crate::ai::adapter::AIProviderAdapter;
+        use crate::inference::llamacpp_adapter::LlamaCppAdapter;
+
+        crate::model_registry::init_global().expect("model_registry init");
+        // context_length MUST be set explicitly (the backend refuses to silently
+        // fall back to n_ctx_train — the 2026-04 Metal-KV-blowup guard). new()
+        // doesn't set it; production uses for_persona(profile). 8192 fits Metal.
+        let adapter: Arc<dyn AIProviderAdapter> =
+            Arc::new(LlamaCppAdapter::new().with_context_length(8192).with_n_seq_max(1));
+        eprintln!(
+            "[live] adapter={} default_model={}",
+            adapter.name(),
+            adapter.default_model()
+        );
+
+        let persona = Uuid::new_v4();
+        let cycle = build_workspace_cycle(PersonaBrainConfig {
+            persona_id: persona,
+            persona_name: "Ivar".to_string(),
+            system_prompt: "You are Ivar, a thoughtful engineer and a citizen on the grid. \
+                You speak concisely, and only when you have something worth adding."
+                .to_string(),
+            // Reuse the seeded hippocampus — it carries a deploy-related memory.
+            admission: seed_admission(1_718_600_000_000),
+            adapter,
+            capacity: None,
+        });
+
+        let burst = "general room:\n\
+            Joel: morning all\n\
+            teammate: the deploy from yesterday — did we ever figure out what broke it?\n\
+            teammate: ivar you were looking at it right?";
+        eprintln!("\n[live] === Ivar's mind runs over the burst ===\n{burst}\n");
+
+        let ws = cycle.run(burst).await;
+
+        eprintln!("\n[live] === Ivar's decision ===");
+        match ws.decision() {
+            Some(Decision::Speak { text }) => eprintln!("Ivar SPEAKS:\n{text}"),
+            Some(Decision::RaiseUnprompted { text }) => {
+                eprintln!("Ivar RAISES (unprompted):\n{text}")
+            }
+            Some(Decision::Pass) | None => eprintln!("Ivar chose silence (PASS)."),
+        }
+
+        assert!(
+            ws.decision().is_some(),
+            "the persona's mind must reach a decision through the real model"
+        );
+    }
 }

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -225,6 +225,28 @@ mod tests {
         assert_eq!(registry.len(), 2);
     }
 
+    // what this catches: RESPAWN must replace the mind, not keep the stale one.
+    // A persona can respawn in-process (node resilience) with a fresh admission +
+    // adapter; the supervisor uses register() (overwrite), so get() returns the
+    // NEW cycle, not the prior lifetime's orphaned one. (get_or_build would have
+    // discarded the fresh config — the bug this guards.)
+    #[tokio::test]
+    async fn register_overwrites_on_respawn() {
+        let registry = PersonaWorkspaceRegistry::new();
+        let persona = Uuid::new_v4();
+        let first = Arc::new(build_workspace_cycle(cfg_for(persona)));
+        registry.register(persona, first.clone());
+        let second = Arc::new(build_workspace_cycle(cfg_for(persona)));
+        registry.register(persona, second.clone());
+        let got = registry.get(&persona).expect("registered");
+        assert!(
+            Arc::ptr_eq(&got, &second),
+            "respawn must resolve to the FRESH mind"
+        );
+        assert!(!Arc::ptr_eq(&got, &first), "the prior lifetime's mind is replaced");
+        assert_eq!(registry.len(), 1);
+    }
+
     // THE LIVE BRING-UP: a persona's mind thinks with the REAL local model.
     // Runs the EXACT production assembly path (build_workspace_cycle → RecallFaculty
     // + LlmDeliberationFaculty) against the real LlamaCppAdapter (qwen3.5-4b-code-

--- a/core/continuum-core/src/cognition/recall_faculty.rs
+++ b/core/continuum-core/src/cognition/recall_faculty.rs
@@ -278,6 +278,61 @@ mod tests {
         );
     }
 
+    // what this catches: MEMORY WORKS AS DESIGNED → coherence across turns. A
+    // substantive statement ADMITTED in turn 1 (the real store path, admit()) is
+    // RECALLED in a later turn — so the persona carries context forward instead of
+    // amnesia each turn. Clock-controlled (recall runs moments after admit) so
+    // decay doesn't floor it — the reproducible-clock pattern that the wall-clock
+    // live run exposed as needed. This is the store→recall loop the conversation
+    // coherence depends on.
+    #[tokio::test]
+    async fn memory_carries_context_across_turns() {
+        use crate::persona::engram::AdmissionDecision;
+        use crate::persona::types::{InboxMessage, SenderType};
+
+        let now1 = 1_000_000_000u64;
+        let recall_meta = Arc::new(RecallMetadataRegistry::new());
+        let state = Arc::new(AdmissionState::new(recall_meta));
+
+        // TURN 1: a decision worth remembering — stored through the real admission
+        // pipeline (not a test back-door push).
+        let msg = InboxMessage {
+            id: Uuid::new_v4(),
+            room_id: Uuid::new_v4(),
+            sender_id: Uuid::new_v4(),
+            sender_name: "Joel".to_string(),
+            sender_type: SenderType::Human,
+            content: "We decided to ship the new auth flow behind a feature flag and ramp to 10% first."
+                .to_string(),
+            timestamp: now1,
+            priority: 0.8,
+            source_modality: None,
+            voice_session_id: None,
+        };
+        let decision = state.admit(&msg, None).expect("admit should not error");
+        assert!(
+            matches!(decision, AdmissionDecision::Admit { .. }),
+            "a substantive decision must be admitted to memory, got: {decision:?}"
+        );
+
+        // TURN 2 (moments later): recall must surface that decision so the persona
+        // stays coherent with what was decided.
+        let persona = Uuid::new_v4();
+        let now2 = now1 + 5_000;
+        let recall = RecallFaculty::new(persona, state).with_clock(Arc::new(move || now2));
+        let c = recall
+            .contribute(&Workspace::new(
+                "what was our rollout plan for the auth flow again?",
+            ))
+            .await
+            .expect("recall should surface the stored decision in a later turn");
+        assert!(
+            c.content.contains("feature flag"),
+            "turn-2 recall must carry the turn-1 memory forward (coherence across turns); got: {}",
+            c.content
+        );
+    }
+
     // ---- The mind in action: real hippocampus → workspace → informed decision ----
 
     use super::super::workspace::{Decision, NoopWorkspaceCaptureSink, WorkspaceCaptureSink, WorkspaceCycle, WorkspaceTrace};

--- a/core/continuum-core/src/cognition/recall_faculty.rs
+++ b/core/continuum-core/src/cognition/recall_faculty.rs
@@ -39,13 +39,37 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use uuid::Uuid;
 
+use super::embedding::{cosine_similarity, EmbeddingProvider};
 use super::workspace::{Contribution, Faculty, FacultyId, Workspace};
 use crate::persona::admission_state::AdmissionState;
+use crate::persona::engram::Engram;
 
 /// How many top engrams the faculty surfaces into the workspace per tick. A
 /// bounded "spotlight" on memory — the arbiter further bounds what reaches the
 /// decider.
 const DEFAULT_RECALL_LIMIT: usize = 5;
+
+/// When relevance re-ranking is active, over-fetch this many × the surface limit
+/// as candidates, then narrow by relevance. Over-fetch so a topically-relevant
+/// but lower-salience memory can still enter the running and win the re-rank.
+const RERANK_CANDIDATE_MULTIPLIER: usize = 4;
+
+/// Blend weight for relevance (cosine vs the burst) against the memory's
+/// salience-decay score: `RELEVANCE_WEIGHT·rel + (1-RELEVANCE_WEIGHT)·salience`.
+/// 0.5 = equal voice; tunable, and the replay A/B bench is exactly how we'll
+/// tune it with before/after traces instead of guessing.
+const RELEVANCE_WEIGHT: f32 = 0.5;
+
+/// Blend cosine-relevance (to the burst) with the memory's salience-decay score.
+fn blended_score(
+    salience: f32,
+    query: &[f32],
+    embedder: &dyn EmbeddingProvider,
+    content: &str,
+) -> f32 {
+    let rel = cosine_similarity(query, &embedder.embed(content));
+    RELEVANCE_WEIGHT * rel + (1.0 - RELEVANCE_WEIGHT) * salience
+}
 
 /// Wall-clock seam — injectable so tests are deterministic. Returns ms since
 /// the unix epoch, matching the `now_ms()` convention used across cognition.
@@ -69,16 +93,23 @@ pub struct RecallFaculty {
     admission_state: Arc<AdmissionState>,
     limit: usize,
     clock: Clock,
+    /// Optional relevance re-ranker. When set, recall surfaces the memory most
+    /// RELEVANT to the current burst (cosine, blended with salience), not just
+    /// the most salient/recent — the "memory works as designed at scale" path.
+    /// `None` → pure salience×recency (the backwards-compatible default). The
+    /// backend is swappable (lexical bootstrap now; neural local embedder later).
+    embedder: Option<Arc<dyn EmbeddingProvider>>,
 }
 
 impl RecallFaculty {
-    /// Construct with the default recall limit and wall clock.
+    /// Construct with the default recall limit and wall clock, no re-ranker.
     pub fn new(persona_id: Uuid, admission_state: Arc<AdmissionState>) -> Self {
         Self {
             persona_id,
             admission_state,
             limit: DEFAULT_RECALL_LIMIT,
             clock: wall_clock(),
+            embedder: None,
         }
     }
 
@@ -91,6 +122,13 @@ impl RecallFaculty {
     /// Inject a deterministic clock (tests / replay).
     pub fn with_clock(mut self, clock: Clock) -> Self {
         self.clock = clock;
+        self
+    }
+
+    /// Install a relevance re-ranker (embedding similarity vs the burst). Recall
+    /// then surfaces the most relevant memory, not just the most recent.
+    pub fn with_embedder(mut self, embedder: Arc<dyn EmbeddingProvider>) -> Self {
+        self.embedder = Some(embedder);
         self
     }
 
@@ -109,31 +147,73 @@ impl Faculty for RecallFaculty {
     // Perception tier (reacts_to_broadcast() == false, the default): recall
     // reacts to the raw world-state, bidding its memories into phase 1 so the
     // deliberation faculty can condition on them in phase 2.
-    async fn contribute(&self, _ws: &Workspace) -> Option<Contribution> {
+    async fn contribute(&self, ws: &Workspace) -> Option<Contribution> {
         let now = (self.clock)();
-        // recall_scored ranks by salience-modulated decay AND closes the
-        // bidirectional loop: it records a recall hit on each returned engram
-        // (uplift + access_count + persistence observe). Recalling into the
-        // workspace strengthens the memory — use-it-keeps-it.
-        let scored = self.admission_state.recall_scored(now, self.limit);
-        if scored.is_empty() {
+
+        // Fetch candidates WITHOUT recording hits — we record the hit on what we
+        // actually SURFACE (below), not on candidates that lose the re-rank.
+        // Over-fetch when re-ranking so a relevant-but-lower-salience memory can
+        // still win.
+        let fetch_n = if self.embedder.is_some() {
+            self.limit.saturating_mul(RERANK_CANDIDATE_MULTIPLIER).max(self.limit)
+        } else {
+            self.limit
+        };
+        let candidates = self.admission_state.recall_candidates(now, fetch_n);
+        if candidates.is_empty() {
             return None;
         }
 
-        // The faculty's salience = the best recalled memory's relevance. ML-/
-        // algorithm-derived, never a hand-weight; the arbiter integrates it.
-        let top_salience = scored[0].1.clamp(0.0, 1.0);
+        // Score: (final_score, engram, salience). With an embedder, final_score
+        // blends cosine-relevance-to-the-burst with salience — so recall surfaces
+        // the RELEVANT memory, not just the salient/recent one. Without one,
+        // final_score IS salience (candidates already in that order).
+        let mut scored: Vec<(f32, Engram, f32)> = match &self.embedder {
+            Some(embedder) => {
+                let query = embedder.embed(&ws.world_state);
+                let mut s: Vec<(f32, Engram, f32)> = candidates
+                    .into_iter()
+                    .map(|(engram, salience)| {
+                        let blended =
+                            blended_score(salience, &query, embedder.as_ref(), &engram.content);
+                        (blended, engram, salience)
+                    })
+                    .collect();
+                s.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+                s
+            }
+            None => candidates
+                .into_iter()
+                .map(|(engram, salience)| (salience, engram, salience))
+                .collect(),
+        };
+        scored.truncate(self.limit);
 
+        // Close the loop on what we ACTUALLY surface — Hebbian rehearsal on the
+        // memories the persona truly used this tick (uplift + persistence).
+        let surfaced_ids: Vec<Uuid> = scored.iter().map(|(_, e, _)| e.id).collect();
+        self.admission_state.record_recall_hits(&surfaced_ids, now);
+
+        // The faculty's salience = the top item's final score — relevance-aware
+        // when re-ranking, salience otherwise. ML/algorithm-derived, never a
+        // hand-weight; the arbiter integrates it.
+        let top_salience = scored[0].0.clamp(0.0, 1.0);
         let content = scored
             .iter()
-            .map(|(engram, salience)| format!("- {} (salience {:.2})", engram.content, salience))
+            .map(|(_, engram, salience)| {
+                format!("- {} (salience {:.2})", engram.content, salience)
+            })
             .collect::<Vec<_>>()
             .join("\n");
-
         let reasoning = format!(
-            "recalled {} memor{} via recall_scored (salience-uplifted — the loop is closed)",
+            "recalled {} memor{} ({}) — salience-uplifted, loop closed",
             scored.len(),
-            if scored.len() == 1 { "y" } else { "ies" }
+            if scored.len() == 1 { "y" } else { "ies" },
+            if self.embedder.is_some() {
+                "relevance-ranked vs the burst"
+            } else {
+                "salience×recency"
+            }
         );
 
         Some(Contribution::context(
@@ -330,6 +410,89 @@ mod tests {
             c.content.contains("feature flag"),
             "turn-2 recall must carry the turn-1 memory forward (coherence across turns); got: {}",
             c.content
+        );
+    }
+
+    // what this catches: RELEVANCE BEATS RECENCY — recall with an embedder
+    // surfaces the topically-relevant memory even when a MORE-salient, MORE-recent
+    // but irrelevant memory exists. Without the embedder, salience wins and the
+    // irrelevant memory surfaces. This is "memory works as designed at scale": as
+    // memory grows, you need the RIGHT memory, not the latest. The lexical
+    // embedder is the bootstrap; a neural one slots in behind the same trait.
+    #[tokio::test]
+    async fn relevance_beats_recency_with_embedder() {
+        use crate::cognition::embedding::LexicalEmbedder;
+
+        let now = 1_000_000_000u64;
+        let query = "what was our rollout plan for the auth flow again?";
+
+        let seed = || {
+            let recall_meta = Arc::new(RecallMetadataRegistry::new());
+            let state = Arc::new(AdmissionState::new(recall_meta.clone()));
+            let mut mk = |content: &str, salience: f32, age_ms: u64| {
+                let id = Uuid::new_v4();
+                state.push_for_test(Engram {
+                    id,
+                    kind: EngramKind::Episodic,
+                    content: content.to_string(),
+                    origin: EngramOrigin::Chat(ChatMessageRef {
+                        message_id: Uuid::new_v4(),
+                        room_id: Uuid::new_v4(),
+                        sender_id: Uuid::new_v4(),
+                        posted_at_ms: now - age_ms,
+                        content_hash: "h".to_string(),
+                    }),
+                    recall_keys: Vec::new(),
+                    admitted_at_ms: now - age_ms,
+                    trust_state_at_admission: TrustState::ApprovedPeer,
+                    admission_trace_id: None,
+                });
+                recall_meta.admit(
+                    id,
+                    RecallMetadata {
+                        salience,
+                        access_count: 0,
+                        last_accessed_ms: 0,
+                        protected_until_ms: 0,
+                        last_decayed_ms: now,
+                    },
+                );
+            };
+            // RELEVANT to the query, but LOWER salience and OLDER:
+            mk(
+                "we will ship the auth flow behind a feature flag and ramp the rollout to 10%",
+                0.4,
+                60_000,
+            );
+            // IRRELEVANT, but HIGHER salience and NEWER:
+            mk("lunch is at noon, someone booked the corner table", 0.6, 0);
+            state
+        };
+
+        let persona = Uuid::new_v4();
+
+        // Without a re-ranker: salience wins → the irrelevant (more salient) memory.
+        let plain = RecallFaculty::new(persona, seed())
+            .with_limit(1)
+            .with_clock(Arc::new(move || now));
+        let pc = plain.contribute(&Workspace::new(query)).await.unwrap();
+        assert!(
+            pc.content.contains("lunch"),
+            "salience-only recall surfaces the more-salient-but-irrelevant memory; got: {}",
+            pc.content
+        );
+
+        // With the relevance re-ranker: the auth-flow memory wins DESPITE lower
+        // salience — recall now surfaces what's relevant to the burst.
+        let smart = RecallFaculty::new(persona, seed())
+            .with_limit(1)
+            .with_clock(Arc::new(move || now))
+            .with_embedder(Arc::new(LexicalEmbedder::new()));
+        let sc = smart.contribute(&Workspace::new(query)).await.unwrap();
+        assert!(
+            sc.content.contains("feature flag"),
+            "relevance recall must surface the auth-flow memory despite lower salience; got: {}",
+            sc.content
         );
     }
 

--- a/core/continuum-core/src/cognition/recall_faculty.rs
+++ b/core/continuum-core/src/cognition/recall_faculty.rs
@@ -1,0 +1,373 @@
+//! RecallFaculty — the hippocampus as a Workspace faculty.
+//!
+//! This is the perception-tier faculty that pulls relevant memory into the
+//! Global Workspace (§2 of PERSONA-BRAIN-ARCHITECTURE.md) each cognition tick.
+//! It bids context that the deliberation faculty then reasons over in phase 2
+//! (staged assembly — "pull relevant memory, THEN decide").
+//!
+//! ## Why this faculty (killing the recall split)
+//!
+//! Recall lived in two disconnected places: the RAG `EngramSource`
+//! (`persona/engram_source.rs`), which ranks by `salience × recency` but does
+//! **not** record recall hits, and `AdmissionState::recall_scored`, which ranks
+//! AND closes the bidirectional loop (records the hit → uplifts salience →
+//! observes persistence). The RAG path was the *one-way* one. `RecallFaculty`
+//! routes recall through `recall_scored` — the loop-closing path — so a memory
+//! that gets recalled into the workspace this tick is **strengthened for next
+//! tick** (Hebbian rehearsal, use-it-keeps-it). That is the "goes both ways"
+//! property: retrieval feeds back into encoding.
+//!
+//! ## ML-derived salience, not a hand-weight
+//!
+//! The faculty's bid carries the **top recalled memory's post-decay salience**
+//! as its workspace salience — how relevant the hippocampus thinks its best hit
+//! is. The arbiter integrates that score; it never invents one. There is no
+//! caste, no mention test, no `if` — just the recall score competing for
+//! attention.
+//!
+//! ## Future slice: query-conditioned relevance
+//!
+//! v1 surfaces the most salient + recent memories (the existing Algorithm-4
+//! ranking). Conditioning recall on the *current burst* (the workspace
+//! `world_state` as a query — topic similarity over engram embeddings) is the
+//! next slice, when embeddings flow through. The faculty seam does not change
+//! when that lands: the backend behind `contribute` gets smarter, the brain is
+//! unchanged.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use super::workspace::{Contribution, Faculty, FacultyId, Workspace};
+use crate::persona::admission_state::AdmissionState;
+
+/// How many top engrams the faculty surfaces into the workspace per tick. A
+/// bounded "spotlight" on memory — the arbiter further bounds what reaches the
+/// decider.
+const DEFAULT_RECALL_LIMIT: usize = 5;
+
+/// Wall-clock seam — injectable so tests are deterministic. Returns ms since
+/// the unix epoch, matching the `now_ms()` convention used across cognition.
+pub type Clock = Arc<dyn Fn() -> u64 + Send + Sync>;
+
+/// The default wall clock (ms since unix epoch).
+fn wall_clock() -> Clock {
+    Arc::new(|| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0)
+    })
+}
+
+/// The hippocampus, exposed as a `Faculty`. Persona-scoped: it owns an
+/// `Arc<AdmissionState>` (shared with the admission pipeline so encoding and
+/// recall see the same store). Perception tier — bids in phase 1.
+pub struct RecallFaculty {
+    persona_id: Uuid,
+    admission_state: Arc<AdmissionState>,
+    limit: usize,
+    clock: Clock,
+}
+
+impl RecallFaculty {
+    /// Construct with the default recall limit and wall clock.
+    pub fn new(persona_id: Uuid, admission_state: Arc<AdmissionState>) -> Self {
+        Self {
+            persona_id,
+            admission_state,
+            limit: DEFAULT_RECALL_LIMIT,
+            clock: wall_clock(),
+        }
+    }
+
+    /// Override how many memories are surfaced per tick.
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = limit.max(1);
+        self
+    }
+
+    /// Inject a deterministic clock (tests / replay).
+    pub fn with_clock(mut self, clock: Clock) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    /// The persona this faculty recalls for.
+    pub fn persona_id(&self) -> Uuid {
+        self.persona_id
+    }
+}
+
+#[async_trait]
+impl Faculty for RecallFaculty {
+    fn id(&self) -> FacultyId {
+        FacultyId::Recall
+    }
+
+    // Perception tier (reacts_to_broadcast() == false, the default): recall
+    // reacts to the raw world-state, bidding its memories into phase 1 so the
+    // deliberation faculty can condition on them in phase 2.
+    async fn contribute(&self, _ws: &Workspace) -> Option<Contribution> {
+        let now = (self.clock)();
+        // recall_scored ranks by salience-modulated decay AND closes the
+        // bidirectional loop: it records a recall hit on each returned engram
+        // (uplift + access_count + persistence observe). Recalling into the
+        // workspace strengthens the memory — use-it-keeps-it.
+        let scored = self.admission_state.recall_scored(now, self.limit);
+        if scored.is_empty() {
+            return None;
+        }
+
+        // The faculty's salience = the best recalled memory's relevance. ML-/
+        // algorithm-derived, never a hand-weight; the arbiter integrates it.
+        let top_salience = scored[0].1.clamp(0.0, 1.0);
+
+        let content = scored
+            .iter()
+            .map(|(engram, salience)| format!("- {} (salience {:.2})", engram.content, salience))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let reasoning = format!(
+            "recalled {} memor{} via recall_scored (salience-uplifted — the loop is closed)",
+            scored.len(),
+            if scored.len() == 1 { "y" } else { "ies" }
+        );
+
+        Some(Contribution::context(
+            FacultyId::Recall,
+            content,
+            top_salience,
+            reasoning,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persona::engram::{ChatMessageRef, Engram, EngramKind, EngramOrigin, TrustState};
+    use crate::persona::recall_metadata::{RecallMetadata, RecallMetadataRegistry};
+
+    /// Build a persona-scoped AdmissionState with `count` engrams, each tracked
+    /// in the recall registry at a chosen salience. Mirrors the proven fixture
+    /// in engram_source.rs. `last_decayed_ms = now` so a same-instant recall
+    /// applies a no-op decay (multiplier ≈ 1) and the uplift is observable.
+    fn fixture(count: usize, now_ms: u64) -> (Uuid, Arc<AdmissionState>, Vec<Uuid>) {
+        let persona = Uuid::parse_str("00000000-0000-0000-0000-000000000aaa").unwrap();
+        let recall_meta = Arc::new(RecallMetadataRegistry::new());
+        let state = Arc::new(AdmissionState::new(recall_meta.clone()));
+        let mut ids = Vec::new();
+        for i in 0..count {
+            let id = Uuid::new_v4();
+            ids.push(id);
+            let engram = Engram {
+                id,
+                kind: EngramKind::Episodic,
+                content: format!("memory body number {i}"),
+                origin: EngramOrigin::Chat(ChatMessageRef {
+                    message_id: Uuid::new_v4(),
+                    room_id: Uuid::new_v4(),
+                    sender_id: Uuid::new_v4(),
+                    posted_at_ms: now_ms.saturating_sub((i as u64) * 60_000),
+                    content_hash: format!("hash-{i}"),
+                }),
+                recall_keys: Vec::new(),
+                admitted_at_ms: now_ms.saturating_sub((i as u64) * 60_000),
+                trust_state_at_admission: TrustState::ApprovedPeer,
+                admission_trace_id: None,
+            };
+            state.push_for_test(engram);
+            recall_meta.admit(
+                id,
+                RecallMetadata {
+                    // Increasing salience so engram 0 is NOT the most salient —
+                    // proves ranking, not insertion order.
+                    salience: 0.4 + (i as f32 * 0.1).min(0.5),
+                    access_count: 0,
+                    last_accessed_ms: 0,
+                    protected_until_ms: 0,
+                    last_decayed_ms: now_ms,
+                },
+            );
+        }
+        (persona, state, ids)
+    }
+
+    // what this catches: the faculty surfaces recalled memory as a context
+    // Contribution under FacultyId::Recall, with salience = the top hit's score.
+    #[tokio::test]
+    async fn surfaces_top_salience_memory_as_context() {
+        let now = 1_000_000_000;
+        let (persona, state, _ids) = fixture(5, now);
+        let faculty = RecallFaculty::new(persona, state).with_clock(Arc::new(move || now));
+        let c = faculty
+            .contribute(&Workspace::new("what's the status?"))
+            .await
+            .expect("recall should bid when the store is non-empty");
+        assert_eq!(c.faculty, FacultyId::Recall);
+        assert!(c.decision.is_none(), "recall is context, never a verdict");
+        // The most salient engram (highest index in the fixture) leads.
+        assert!(
+            c.content.contains("memory body number 4"),
+            "top-salience memory should be surfaced, got: {}",
+            c.content
+        );
+        assert!(c.salience > 0.0);
+    }
+
+    // what this catches: empty store → abstain (None), not an empty bid.
+    #[tokio::test]
+    async fn abstains_on_empty_store() {
+        let now = 1_000_000_000;
+        let (persona, state, _ids) = fixture(0, now);
+        let faculty = RecallFaculty::new(persona, state).with_clock(Arc::new(move || now));
+        assert!(faculty.contribute(&Workspace::new("hi")).await.is_none());
+    }
+
+    // what this catches: THE BIDIRECTIONAL LOOP — recalling a memory into the
+    // workspace records a recall hit (access_count++, salience uplift). Retrieval
+    // feeds back into encoding; the recalled memory is strengthened for next tick.
+    // This is the half EngramSource never closed.
+    #[tokio::test]
+    async fn recall_closes_the_loop_uplifting_what_it_surfaces() {
+        let now = 1_000_000_000;
+        let (persona, state, ids) = fixture(3, now);
+        let recall_meta = state.recall_metadata().clone();
+
+        let before: Vec<(f32, u32)> = ids
+            .iter()
+            .map(|id| {
+                let m = recall_meta.get(*id).unwrap();
+                (m.salience, m.access_count)
+            })
+            .collect();
+
+        let faculty = RecallFaculty::new(persona, state).with_clock(Arc::new(move || now));
+        let _ = faculty.contribute(&Workspace::new("status?")).await;
+
+        // Every surfaced engram had its access_count bumped (the hit was
+        // recorded) and salience did not fall below where it started (uplift,
+        // no net decay at the same instant).
+        for (i, id) in ids.iter().enumerate() {
+            let m = recall_meta.get(*id).unwrap();
+            assert!(
+                m.access_count > before[i].1,
+                "access_count must rise — the recall hit closes the loop"
+            );
+            assert!(
+                m.salience >= before[i].0,
+                "salience must not fall — recall uplifts what it surfaces"
+            );
+        }
+    }
+
+    // what this catches: recall is a PERCEPTION-tier faculty — it bids in phase 1
+    // over the raw world-state, so its memories are in the broadcast before the
+    // deliberation faculty (phase 2) reasons over them.
+    #[test]
+    fn recall_is_perception_tier() {
+        let now = 1_000_000_000;
+        let (persona, state, _ids) = fixture(1, now);
+        let faculty = RecallFaculty::new(persona, state);
+        assert!(
+            !faculty.reacts_to_broadcast(),
+            "recall must bid in phase 1, not after the broadcast is assembled"
+        );
+    }
+
+    // ---- The mind in action: real hippocampus → workspace → informed decision ----
+
+    use super::super::workspace::{Decision, NoopWorkspaceCaptureSink, WorkspaceCaptureSink, WorkspaceCycle, WorkspaceTrace};
+
+    /// A deliberation faculty that conditions its reply on what recall surfaced.
+    struct DeliberateOnRecall;
+    #[async_trait]
+    impl Faculty for DeliberateOnRecall {
+        fn id(&self) -> FacultyId {
+            FacultyId::Deliberation
+        }
+        fn reacts_to_broadcast(&self) -> bool {
+            true
+        }
+        async fn contribute(&self, ws: &Workspace) -> Option<Contribution> {
+            match ws.broadcast.iter().find(|c| c.faculty == FacultyId::Recall) {
+                Some(mem) => {
+                    // Reference the most relevant recalled line.
+                    let first_line = mem.content.lines().next().unwrap_or("").to_string();
+                    Some(Contribution::verdict(
+                        Decision::Speak {
+                            text: format!("Picking up the thread — I recall: {first_line}"),
+                        },
+                        0.92,
+                        "decision conditioned on recalled memory (phase-2 over phase-1 context)",
+                    ))
+                }
+                None => Some(Contribution::verdict(
+                    Decision::Pass,
+                    0.4,
+                    "no memory surfaced — nothing to ground a reply on",
+                )),
+            }
+        }
+    }
+
+    /// A capture sink that pretty-prints the full tick so we can WATCH the mind.
+    struct PrintingSink;
+    impl WorkspaceCaptureSink for PrintingSink {
+        fn record(&self, t: &WorkspaceTrace) {
+            println!("\n========== WORKSPACE TICK ==========");
+            println!("world_state (the consolidated burst):\n  {}", t.world_state);
+            println!("\n-- phase 1: all faculty bids (the full competition) --");
+            for b in &t.bids {
+                println!(
+                    "  [{:<12}] salience {:.2}  {}  (why: {})",
+                    b.faculty.as_str(),
+                    b.salience,
+                    b.content.replace('\n', " / "),
+                    b.reasoning
+                );
+            }
+            println!("\n-- assembled context the decider SAW (context_broadcast) --");
+            for c in &t.context_broadcast {
+                println!("  [{:<12}] {}", c.faculty.as_str(), c.content.replace('\n', " / "));
+            }
+            println!("\n-- decision (output of deliberation over that context) --");
+            println!("  {:?}", t.decision);
+            println!("====================================\n");
+        }
+    }
+
+    // what this catches: END-TO-END — a real AdmissionState hippocampus bids
+    // recalled memory into phase 1; the arbiter routes it into the broadcast;
+    // the deliberation faculty in phase 2 reads it and produces a Decision that
+    // REFERENCES the recalled memory. Prints the full trace (run with
+    // `--nocapture` to watch). This is the coherence claim, demonstrated.
+    #[tokio::test]
+    async fn mind_in_action_recall_informs_the_decision() {
+        let now = 1_000_000_000;
+        let (persona, state, _ids) = fixture(3, now);
+
+        let faculties: Vec<Arc<dyn Faculty>> = vec![
+            Arc::new(RecallFaculty::new(persona, state).with_clock(Arc::new(move || now))),
+            Arc::new(DeliberateOnRecall),
+        ];
+        let ws = WorkspaceCycle::new(faculties, Arc::new(super::super::workspace::SalienceArbiter), 5)
+            .with_capture(Arc::new(PrintingSink))
+            .run("teammate asks: where did we land on the deploy?")
+            .await;
+
+        match ws.decision() {
+            Some(Decision::Speak { text }) => assert!(
+                text.contains("memory body"),
+                "the spoken decision must be grounded in recalled memory, got: {text}"
+            ),
+            other => panic!("expected a recall-grounded Speak, got {other:?}"),
+        }
+
+        // Silence the unused-import lint when this module's other helpers vary.
+        let _ = NoopWorkspaceCaptureSink;
+    }
+}

--- a/core/continuum-core/src/cognition/recall_faculty.rs
+++ b/core/continuum-core/src/cognition/recall_faculty.rs
@@ -194,10 +194,13 @@ impl Faculty for RecallFaculty {
         let surfaced_ids: Vec<Uuid> = scored.iter().map(|(_, e, _)| e.id).collect();
         self.admission_state.record_recall_hits(&surfaced_ids, now);
 
-        // The faculty's salience = the top item's final score — relevance-aware
-        // when re-ranking, salience otherwise. ML/algorithm-derived, never a
-        // hand-weight; the arbiter integrates it.
-        let top_salience = scored[0].0.clamp(0.0, 1.0);
+        // The faculty's bid salience: max(blended_score, intrinsic_salience). The
+        // `.max` removes the regression where a lexically-thin burst (cosine ≈ 0)
+        // would halve recall's bid to 0.5·salience and silently under-weight it
+        // in the arbiter — recall now never bids BELOW the surfaced memory's own
+        // salience, and a highly-relevant hit can bid ABOVE it. (`f32::max` also
+        // returns the finite operand if the other is NaN — defensive.)
+        let top_salience = scored[0].0.max(scored[0].2).clamp(0.0, 1.0);
         let content = scored
             .iter()
             .map(|(_, engram, salience)| {

--- a/core/continuum-core/src/cognition/should_respond_module.rs
+++ b/core/continuum-core/src/cognition/should_respond_module.rs
@@ -1,0 +1,204 @@
+//! `ai/should-respond` — the kernel command that runs a persona's mind.
+//!
+//! Per IntelMac's recipe-executor design (and [[commands-are-kernel-level-and-
+//! compose]]): participation is **one command, N lane-routed handlers**. This is
+//! the handler for a continuum-native persona — it resolves the persona's
+//! `WorkspaceCycle` from the [`PersonaWorkspaceRegistry`], runs it over the
+//! consolidated burst, and returns the [`Decision`] (the kebab-case wire enum
+//! external ACP bridges also produce). The recipe-pipeline walker dispatches this
+//! as one step; the persona service loop calls it to decide whether to speak.
+//!
+//! It is NOT a gate. It runs the mind and returns the mind's verdict. Silence
+//! (`Pass`) is the persona's own judgment (the deliberation faculty chose the
+//! PASS affordance), never a caste/mention rule. No workspace registered for the
+//! persona → an error, not a silent drop: a persona with no mind is a bug to
+//! surface, not a reason to fake silence.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+use super::persona_workspace::PersonaWorkspaceRegistry;
+use super::workspace::Decision;
+use crate::runtime::service_module::{CommandResult, ModuleConfig, ModulePriority, ServiceModule};
+use crate::runtime::ModuleContext;
+
+/// The kernel command name. One decision, one place.
+pub const SHOULD_RESPOND_COMMAND: &str = "ai/should-respond";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ShouldRespondParams {
+    /// Which persona's mind to run.
+    persona_id: Uuid,
+    /// The consolidated burst — the "catch up on the thread" world-state the
+    /// persona reasons over this tick (recent room transcript, consolidated).
+    burst: String,
+}
+
+/// ServiceModule that registers `ai/should-respond` against the persona-scoped
+/// workspace registry. The registry is populated at persona spawn (one cycle per
+/// persona — the "one soul, many rooms" invariant); this module just resolves +
+/// runs it.
+pub struct ShouldRespondModule {
+    registry: Arc<PersonaWorkspaceRegistry>,
+}
+
+impl ShouldRespondModule {
+    pub fn new(registry: Arc<PersonaWorkspaceRegistry>) -> Self {
+        Self { registry }
+    }
+}
+
+#[async_trait]
+impl ServiceModule for ShouldRespondModule {
+    fn config(&self) -> ModuleConfig {
+        ModuleConfig {
+            name: "ai-should-respond",
+            // Cognition-class scheduling (sub-10ms target dispatch; the inference
+            // itself is leased inside the deliberation faculty off this path).
+            priority: ModulePriority::High,
+            command_prefixes: &["ai/should-respond"],
+            event_subscriptions: &[],
+            needs_dedicated_thread: false,
+            // Per-persona cycles serialize their own model lease; the module
+            // itself is unbounded (many personas can be deciding concurrently).
+            max_concurrency: 0,
+            tick_interval: None,
+        }
+    }
+
+    async fn initialize(&self, _ctx: &ModuleContext) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn handle_command(&self, command: &str, params: Value) -> Result<CommandResult, String> {
+        match command {
+            SHOULD_RESPOND_COMMAND => {
+                let p: ShouldRespondParams = serde_json::from_value(params)
+                    .map_err(|e| format!("{SHOULD_RESPOND_COMMAND} params: {e}"))?;
+                let cycle = self.registry.get(&p.persona_id).ok_or_else(|| {
+                    format!(
+                        "no workspace cycle registered for persona {} — its mind was not assembled at spawn",
+                        p.persona_id
+                    )
+                })?;
+                // Run the persona's continuous mind over the burst. The decision
+                // is the OUTPUT of cognition; `None` (nothing won attention
+                // strongly enough to externalize) is effective silence = Pass.
+                let workspace = cycle.run(p.burst).await;
+                let decision = workspace.decision().cloned().unwrap_or(Decision::Pass);
+                CommandResult::json(&decision)
+            }
+            other => Err(format!("unknown command: {other}")),
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
+    use crate::cognition::persona_workspace::PersonaBrainConfig;
+    use crate::persona::admission_state::AdmissionState;
+    use crate::persona::engram::{ChatMessageRef, Engram, EngramKind, EngramOrigin, TrustState};
+    use crate::persona::recall_metadata::{RecallMetadata, RecallMetadataRegistry};
+    use crate::runtime::service_module::CommandResult;
+
+    fn seed_admission(now_ms: u64) -> Arc<AdmissionState> {
+        let recall_meta = Arc::new(RecallMetadataRegistry::new());
+        let state = Arc::new(AdmissionState::new(recall_meta.clone()));
+        let id = Uuid::new_v4();
+        let engram = Engram {
+            id,
+            kind: EngramKind::Episodic,
+            content: "we agreed to ship the deploy fix after review".to_string(),
+            origin: EngramOrigin::Chat(ChatMessageRef {
+                message_id: Uuid::new_v4(),
+                room_id: Uuid::new_v4(),
+                sender_id: Uuid::new_v4(),
+                posted_at_ms: now_ms,
+                content_hash: "h".to_string(),
+            }),
+            recall_keys: Vec::new(),
+            admitted_at_ms: now_ms,
+            trust_state_at_admission: TrustState::ApprovedPeer,
+            admission_trace_id: None,
+        };
+        state.push_for_test(engram);
+        recall_meta.admit(
+            id,
+            RecallMetadata {
+                salience: 0.7,
+                access_count: 0,
+                last_accessed_ms: 0,
+                protected_until_ms: 0,
+                last_decayed_ms: now_ms,
+            },
+        );
+        state
+    }
+
+    fn registry_with_ivar(persona: Uuid) -> Arc<PersonaWorkspaceRegistry> {
+        let registry = Arc::new(PersonaWorkspaceRegistry::new());
+        registry.get_or_build(PersonaBrainConfig {
+            persona_id: persona,
+            persona_name: "Ivar".to_string(),
+            system_prompt: "You are Ivar, an engineer on the grid.".to_string(),
+            admission: seed_admission(1_000_000_000),
+            adapter: Arc::new(HeuristicInferenceAdapter::new()),
+            capacity: None,
+        });
+        registry
+    }
+
+    // what this catches: ai/should-respond resolves a persona's mind, runs it, and
+    // returns a Decision as JSON (the wire enum). This is the kernel command the
+    // recipe walker + persona loop dispatch — proven end-to-end against a real
+    // adapter. Swap LlamaCppAdapter and the same command drives a live persona.
+    #[tokio::test]
+    async fn should_respond_runs_the_mind_and_returns_a_decision() {
+        let persona = Uuid::new_v4();
+        let module = ShouldRespondModule::new(registry_with_ivar(persona));
+        let params = serde_json::json!({
+            "personaId": persona.to_string(),
+            "burst": "teammate: where did we land on the deploy fix?",
+        });
+        let result = module
+            .handle_command(SHOULD_RESPOND_COMMAND, params)
+            .await
+            .expect("ai/should-respond should succeed");
+        let json = match result {
+            CommandResult::Json(v) => v,
+            other => panic!("expected Json result, got {other:?}"),
+        };
+        // The wire shape is the Decision enum (serde tag = "kind").
+        let decision: Decision =
+            serde_json::from_value(json).expect("result must deserialize to a Decision");
+        assert!(matches!(decision, Decision::Speak { .. }));
+    }
+
+    // what this catches: an unregistered persona is a surfaced ERROR, never a
+    // faked Pass — a persona with no assembled mind is a bug, not silence.
+    #[tokio::test]
+    async fn unregistered_persona_errors_not_silently_passes() {
+        let module = ShouldRespondModule::new(Arc::new(PersonaWorkspaceRegistry::new()));
+        let params = serde_json::json!({
+            "personaId": Uuid::new_v4().to_string(),
+            "burst": "anyone there?",
+        });
+        let err = module
+            .handle_command(SHOULD_RESPOND_COMMAND, params)
+            .await
+            .expect_err("missing workspace must error");
+        assert!(err.contains("no workspace cycle"));
+    }
+}

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -173,7 +173,33 @@ impl Workspace {
 pub trait Faculty: Send + Sync {
     fn id(&self) -> FacultyId;
     /// Bid into the workspace given the current state. `None` = abstain.
+    ///
+    /// Called once in the faculty's phase (see [`Faculty::reacts_to_broadcast`]).
+    /// Perception faculties see an empty `ws.broadcast` (they react to the raw
+    /// world-state); deliberation faculties see the *assembled context* that won
+    /// attention in phase 1. A faculty's intelligence is entirely here — the
+    /// arbiter only integrates the salience it returns.
     async fn contribute(&self, ws: &Workspace) -> Option<Contribution>;
+
+    /// The faculty's **dependency / phase** in the staged cycle — the reactive
+    /// "what do I fire on" declaration (a faculty is a React hook; this is its
+    /// dependency array). This is the direct analog of cbar's `needsRealTime()`
+    /// bool that split real-time motion from delayed scene understanding: a
+    /// *structural* scheduling declaration, **not** a cognition gate.
+    ///
+    /// - `false` (default) — **perception tier**: reacts to the raw world-state,
+    ///   bids in phase 1 (recall, world-model, affect, salience, roster…).
+    /// - `true` — **deliberation tier**: reacts to the *assembled broadcast* (the
+    ///   context that won attention), bids in phase 2 so it can condition its
+    ///   [`Decision`] on what recall/world-model/affect actually surfaced.
+    ///
+    /// This is what makes "pull relevant memory, *then* decide" expressible: the
+    /// decider runs after, over the assembled context — cbar's lines→planes, GWT's
+    /// broadcast-then-rebid. It does NOT enumerate faculties or privilege a
+    /// decider; any faculty may be either tier.
+    fn reacts_to_broadcast(&self) -> bool {
+        false
+    }
 }
 
 /// Attention: selects which contributions enter the bounded workspace.
@@ -187,6 +213,17 @@ pub trait Arbiter: Send + Sync {
 }
 
 /// Top-k by ML salience within the workspace's bounded capacity.
+///
+/// This is the **bootstrap** policy: pure exploitation, attention at temperature
+/// 0 — the highest-salience bids always win. It is *greedy*, so on its own it
+/// collapses to safe convergence (the obvious bid wins every tick; divergent /
+/// creative bids get truncated). Encouraging creativity is an
+/// exploration-preserving arbiter policy that slots in here — reserve part of
+/// capacity for high-epistemic-value / divergent bids so they aren't crowded out
+/// (the active-inference exploration term; see PERSONA-BRAIN-ARCHITECTURE.md
+/// §3.5). It is a documented seam, NOT built yet — it waits on a Volition faculty
+/// that emits an epistemic-value signal, so no novelty metric is invented
+/// prematurely.
 pub struct SalienceArbiter;
 
 impl Arbiter for SalienceArbiter {
@@ -212,9 +249,14 @@ impl Arbiter for SalienceArbiter {
 #[derive(Debug, Clone)]
 pub struct WorkspaceTrace {
     pub world_state: String,
-    /// ALL bids this tick, winners and losers — the full competition.
+    /// ALL bids this tick, winners and losers, across BOTH phases — the full
+    /// competition (perception phase-1 context bids + deliberation phase-2 bids).
     pub bids: Vec<Contribution>,
-    /// What won attention and was broadcast.
+    /// The **assembled context** the deliberation faculty saw — what won attention
+    /// in phase 1 and was broadcast into phase 2. This is the glass-box answer to
+    /// "what context did the decider actually have?" (the RAG it reasoned over).
+    pub context_broadcast: Vec<Contribution>,
+    /// The final broadcast: the assembled context PLUS the deliberation output.
     pub broadcast: Vec<Contribution>,
     /// The participation decision that emerged, if any.
     pub decision: Option<Decision>,
@@ -267,18 +309,68 @@ impl WorkspaceCycle {
 
     /// Run one cognition tick over the consolidated `world_state`, recording the
     /// full trace (every bid incl. losers, what won, the decision) for replay.
+    ///
+    /// **Staged assembly** (cbar lines→planes / GWT broadcast-then-rebid):
+    /// 1. **Perception phase** — faculties with `reacts_to_broadcast() == false`
+    ///    bid in parallel over the raw world-state (broadcast still empty). The
+    ///    arbiter routes the salient subset into the broadcast: this is the
+    ///    *assembled context* (the "RAG" the decider will read).
+    /// 2. **Deliberation phase** — faculties with `reacts_to_broadcast() == true`
+    ///    bid in parallel over the workspace whose broadcast now holds the
+    ///    assembled context, so the [`Decision`] is conditioned on what recall /
+    ///    world-model / affect actually surfaced. Their bids append to the
+    ///    broadcast.
+    ///
+    /// This is what makes "pull relevant memory, *then* decide" real: the decider
+    /// is never blind to recall. Still one tick over the consolidated burst, still
+    /// `O(capacity)` for the bounded context — no per-event slowdown.
     pub async fn run(&self, world_state: impl Into<String>) -> Workspace {
         let mut ws = Workspace::new(world_state);
-        // Faculties bid in parallel over the same consolidated state.
-        let bids = join_all(self.faculties.iter().map(|f| f.contribute(&ws))).await;
-        let candidates: Vec<Contribution> = bids.into_iter().flatten().collect();
-        // Capture ALL bids (winners + losers) before the arbiter truncates —
-        // the losers are exactly what you need when debugging "why didn't X win?"
-        let all_bids = candidates.clone();
-        ws.broadcast = self.arbiter.select(candidates, self.capacity);
+
+        // --- Phase 1: perception. Context faculties react to the raw world-state. ---
+        let perception: Vec<&Arc<dyn Faculty>> = self
+            .faculties
+            .iter()
+            .filter(|f| !f.reacts_to_broadcast())
+            .collect();
+        let context_bids: Vec<Contribution> =
+            join_all(perception.iter().map(|f| f.contribute(&ws)))
+                .await
+                .into_iter()
+                .flatten()
+                .collect();
+        // Route the salient subset into the bounded workspace — the arbiter is the
+        // attention ROUTER over information flow, not a gate. The winners are the
+        // assembled context the deliberation faculty reasons over.
+        ws.broadcast = self.arbiter.select(context_bids.clone(), self.capacity);
+        let context_broadcast = ws.broadcast.clone();
+
+        // --- Phase 2: deliberation. Reacts to the assembled broadcast (it can now
+        // see what recall/world-model/affect surfaced) and emits the verdict. ---
+        let deliberation: Vec<&Arc<dyn Faculty>> = self
+            .faculties
+            .iter()
+            .filter(|f| f.reacts_to_broadcast())
+            .collect();
+        let decision_bids: Vec<Contribution> =
+            join_all(deliberation.iter().map(|f| f.contribute(&ws)))
+                .await
+                .into_iter()
+                .flatten()
+                .collect();
+        // The deliberation output is the RESULT of attending to the context, not a
+        // competitor for the bounded context spotlight — append it to the broadcast.
+        ws.broadcast.extend(decision_bids.iter().cloned());
+
+        // Capture the FULL competition: every bid across both phases (incl. the
+        // losers you need to debug "why didn't X win?"), the assembled context the
+        // decider saw, the final broadcast, and the decision.
+        let mut all_bids = context_bids;
+        all_bids.extend(decision_bids);
         self.capture.record(&WorkspaceTrace {
             world_state: ws.world_state.clone(),
             bids: all_bids,
+            context_broadcast,
             broadcast: ws.broadcast.clone(),
             decision: ws.decision().cloned(),
         });
@@ -311,6 +403,43 @@ mod tests {
         }
         async fn contribute(&self, _ws: &Workspace) -> Option<Contribution> {
             None
+        }
+    }
+
+    /// A deliberation faculty that CONDITIONS its decision on the assembled
+    /// broadcast: it speaks (referencing what it saw) only if recall surfaced
+    /// something; otherwise it passes. This is the probe for staged assembly —
+    /// under the old single-pass join_all it would always see an empty broadcast
+    /// and could never be informed by recall.
+    struct ConditionalDeliberation;
+    #[async_trait]
+    impl Faculty for ConditionalDeliberation {
+        fn id(&self) -> FacultyId {
+            FacultyId::Deliberation
+        }
+        fn reacts_to_broadcast(&self) -> bool {
+            true
+        }
+        async fn contribute(&self, ws: &Workspace) -> Option<Contribution> {
+            // Look at the assembled context that won attention in phase 1.
+            let recalled = ws
+                .broadcast
+                .iter()
+                .find(|c| c.faculty == FacultyId::Recall);
+            match recalled {
+                Some(mem) => Some(Contribution::verdict(
+                    Decision::Speak {
+                        text: format!("informed by recall: {}", mem.content),
+                    },
+                    0.9,
+                    "conditioned the reply on the recalled context",
+                )),
+                None => Some(Contribution::verdict(
+                    Decision::Pass,
+                    0.5,
+                    "blind — no context in the broadcast",
+                )),
+            }
         }
     }
 
@@ -490,5 +619,110 @@ mod tests {
             "the loser bid + its salience + reasoning are replayable for debugging"
         );
         assert_eq!(t.decision, Some(Decision::Speak { text: "winner".into() }));
+    }
+
+    // what this catches: STAGED ASSEMBLY — the deliberation faculty conditions its
+    // Decision on what recall surfaced in phase 1. This is the coherence fix: "pull
+    // relevant memory, THEN decide." Under the old single-pass join_all the decider
+    // bid over an EMPTY broadcast and could never be informed by recall.
+    #[tokio::test]
+    async fn deliberation_sees_the_recall_that_won_phase_one() {
+        let faculties: Vec<Arc<dyn Faculty>> = vec![
+            // Phase 1 (perception): recall surfaces a memory with strong salience.
+            Arc::new(FixedFaculty(Contribution::context(
+                FacultyId::Recall,
+                "deploy pipeline is red",
+                0.8,
+                "recalled the open blocker",
+            ))),
+            // Phase 2 (deliberation): reacts to the assembled broadcast.
+            Arc::new(ConditionalDeliberation),
+        ];
+        let ws = cycle(faculties, 5).run("what's the status?").await;
+        match ws.decision() {
+            Some(Decision::Speak { text }) => assert!(
+                text.contains("deploy pipeline is red"),
+                "the decider must condition on recall it saw, got: {text}"
+            ),
+            other => panic!("expected an informed Speak, got {other:?} — decider was blind to recall"),
+        }
+    }
+
+    // what this catches: the trace exposes the ASSEMBLED CONTEXT the decider saw
+    // (context_broadcast) separately from the final broadcast — the glass-box
+    // answer to "what RAG did the mind reason over?" — and the deliberation output
+    // is appended, not competing for the bounded context spotlight.
+    #[tokio::test]
+    async fn trace_separates_assembled_context_from_deliberation_output() {
+        let sink = Arc::new(RecordingSink::default());
+        let faculties: Vec<Arc<dyn Faculty>> = vec![
+            Arc::new(FixedFaculty(Contribution::context(
+                FacultyId::Recall,
+                "deploy pipeline is red",
+                0.8,
+                "recalled",
+            ))),
+            Arc::new(ConditionalDeliberation),
+        ];
+        let _ws = WorkspaceCycle::new(faculties, Arc::new(SalienceArbiter), 5)
+            .with_capture(sink.clone())
+            .run("status?")
+            .await;
+
+        let traces = sink.0.lock().unwrap();
+        let t = &traces[0];
+        // The assembled context is exactly the phase-1 recall winner.
+        assert_eq!(t.context_broadcast.len(), 1);
+        assert_eq!(t.context_broadcast[0].faculty, FacultyId::Recall);
+        // The final broadcast holds the context PLUS the deliberation verdict.
+        assert_eq!(t.broadcast.len(), 2, "assembled context + deliberation output");
+        assert!(t.broadcast.iter().any(|c| c.decision.is_some()), "verdict appended");
+        // Both phases' bids are in the full competition record.
+        assert_eq!(t.bids.len(), 2);
+    }
+
+    // what this catches: a perception faculty does NOT bid in the deliberation
+    // phase (reacts_to_broadcast == false), and a deliberation faculty does NOT
+    // bid in the perception phase — each faculty fires once, in its tier. This is
+    // the cbar needsRealTime() split: no double inference.
+    #[tokio::test]
+    async fn faculties_fire_only_in_their_declared_phase() {
+        // A faculty that records how many times it was asked to contribute, and in
+        // what broadcast state, so we can prove single-phase firing.
+        struct CountingDeliberation(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+        #[async_trait]
+        impl Faculty for CountingDeliberation {
+            fn id(&self) -> FacultyId {
+                FacultyId::Deliberation
+            }
+            fn reacts_to_broadcast(&self) -> bool {
+                true
+            }
+            async fn contribute(&self, ws: &Workspace) -> Option<Contribution> {
+                self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                // If we are ever called, the broadcast must be populated (phase 2).
+                assert!(
+                    !ws.broadcast.is_empty(),
+                    "deliberation must only fire after phase 1 assembled context"
+                );
+                Some(Contribution::verdict(Decision::Pass, 0.5, "noted"))
+            }
+        }
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let faculties: Vec<Arc<dyn Faculty>> = vec![
+            Arc::new(FixedFaculty(Contribution::context(
+                FacultyId::WorldModel,
+                "ctx",
+                0.7,
+                "perception",
+            ))),
+            Arc::new(CountingDeliberation(calls.clone())),
+        ];
+        let _ws = cycle(faculties, 5).run("burst").await;
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "deliberation faculty fired exactly once, in its phase"
+        );
     }
 }

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -1,0 +1,392 @@
+//! The Global Workspace — the brain's integration core.
+//!
+//! See `docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md`. Cognition is a
+//! federation of **faculties** (swappable ML adapters). Each service tick (over
+//! a *consolidated burst*, never per-event) the faculties bid in parallel into
+//! a bounded **Workspace**; a pluggable **Arbiter** integrates their bids
+//! (attention), and the winners are broadcast. The persona's participation
+//! **Decision** is the *output of the deliberation faculty's thinking* over that
+//! workspace — never a heuristic gate, never an `@`-trigger, never a sender caste.
+//!
+//! This is built ALONGSIDE the live loop; it does not yet replace
+//! `calculate_priority`/`fast_path`. Cut-over lands once it's tested + the
+//! recipe-executor (the servicing substrate) calls into it.
+//!
+//! ## Interface contract (for the recipe-executor `ai/should-respond` step)
+//! - `Faculty::contribute` is **async** (backends do inference/IPC).
+//! - It consumes `&Workspace` (the consolidated world-state + current broadcast).
+//! - It returns `Option<Contribution>` (`None` = abstain this tick).
+//! - Faculties are **per-persona instances** (each mind owns its faculties);
+//!   model *backends* may be shared. Look one up by `FacultyId`.
+//! - The participation result is a typed [`Decision`] carried by the
+//!   deliberation faculty's contribution.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures_util::future::join_all;
+use serde::{Deserialize, Serialize};
+
+/// Identifier for a cognitive faculty — a *structural name* (like a brain
+/// region), NOT a cognition decision. `Custom` keeps the set open so new
+/// faculties (incl. sentinel-ai-forged ones) need no enum edit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FacultyId {
+    /// Sophisticated learned recall over engrams (hippocampal relevance).
+    Recall,
+    /// Generative model of the (multimodal, channel/recipe-shaped) world.
+    WorldModel,
+    /// Affect / arousal — neuromodulatory gain.
+    Affect,
+    /// Self-generated goals + curiosity (active inference policy proposals).
+    Volition,
+    /// The reasoner: produces the participation [`Decision`]. LLM-grade floor.
+    Deliberation,
+    /// Optional fast pre-attention salience (scheduling, never the decider).
+    Salience,
+    /// Open extension point — sentinel-ai faculties, future regions.
+    Custom(String),
+}
+
+impl FacultyId {
+    pub fn as_str(&self) -> &str {
+        match self {
+            FacultyId::Recall => "recall",
+            FacultyId::WorldModel => "world-model",
+            FacultyId::Affect => "affect",
+            FacultyId::Volition => "volition",
+            FacultyId::Deliberation => "deliberation",
+            FacultyId::Salience => "salience",
+            FacultyId::Custom(s) => s,
+        }
+    }
+}
+
+/// The persona's participation decision — the OUTPUT of the deliberation
+/// faculty thinking over the consolidated burst. This is what a recipe
+/// `ai/should-respond` step returns. It is a *thought's result*, not a gate:
+/// silence (`Pass`) and unprompted initiative (`RaiseUnprompted`) are
+/// first-class, equal to `Speak`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum Decision {
+    /// Respond to the thread with this content.
+    Speak { text: String },
+    /// Raise something no one asked for — initiative, not reaction.
+    RaiseUnprompted { text: String },
+    /// Nothing worth adding this turn (the persona's own judgment, not a gate).
+    Pass,
+}
+
+/// What a faculty surfaces into the workspace this service tick.
+#[derive(Debug, Clone)]
+pub struct Contribution {
+    pub faculty: FacultyId,
+    /// Human/LLM-readable content the faculty surfaces (recalled memory, a
+    /// predicted world-state, an affect signal, a proposed utterance).
+    pub content: String,
+    /// **ML-derived** salience the faculty assigns its OWN contribution
+    /// (`0.0..=1.0`): how much its model thinks this matters now. The arbiter
+    /// integrates these ML scores; it never invents salience itself.
+    pub salience: f32,
+    /// Why — for audit/replay; the brain is observable.
+    pub reasoning: String,
+    /// Set by the deliberation faculty: the participation decision. Other
+    /// faculties leave this `None` (they contribute context, not the verdict).
+    pub decision: Option<Decision>,
+}
+
+impl Contribution {
+    /// A context contribution (no decision) — recall, world-model, affect, etc.
+    pub fn context(
+        faculty: FacultyId,
+        content: impl Into<String>,
+        salience: f32,
+        reasoning: impl Into<String>,
+    ) -> Self {
+        Self {
+            faculty,
+            content: content.into(),
+            salience: salience.clamp(0.0, 1.0),
+            reasoning: reasoning.into(),
+            decision: None,
+        }
+    }
+
+    /// The deliberation faculty's verdict contribution.
+    pub fn verdict(decision: Decision, salience: f32, reasoning: impl Into<String>) -> Self {
+        let content = match &decision {
+            Decision::Speak { text } | Decision::RaiseUnprompted { text } => text.clone(),
+            Decision::Pass => String::new(),
+        };
+        Self {
+            faculty: FacultyId::Deliberation,
+            content,
+            salience: salience.clamp(0.0, 1.0),
+            reasoning: reasoning.into(),
+            decision: Some(decision),
+        }
+    }
+}
+
+/// The bounded global workspace: the consolidated world-state being reasoned
+/// over (channel/recipe-shaped — a text thread, a game space + player
+/// positions, an AR scene, a code diff) plus what won attention and is
+/// broadcast back to all faculties.
+#[derive(Debug, Clone)]
+pub struct Workspace {
+    /// The consolidated burst / world-state at service time. Opaque to the
+    /// core — the channel/recipe adapter shapes it.
+    pub world_state: String,
+    /// What entered the bounded workspace and is broadcast (the persona's "now").
+    pub broadcast: Vec<Contribution>,
+}
+
+impl Workspace {
+    pub fn new(world_state: impl Into<String>) -> Self {
+        Self {
+            world_state: world_state.into(),
+            broadcast: Vec::new(),
+        }
+    }
+
+    /// The participation decision that won attention this tick, if any. It is
+    /// the highest-salience contribution that carries a [`Decision`] — i.e. the
+    /// deliberation faculty's verdict, if it made it into the bounded workspace.
+    pub fn decision(&self) -> Option<&Decision> {
+        self.broadcast
+            .iter()
+            .filter(|c| c.decision.is_some())
+            .max_by(|a, b| {
+                a.salience
+                    .partial_cmp(&b.salience)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .and_then(|c| c.decision.as_ref())
+    }
+}
+
+/// A cognitive faculty — a swappable ML adapter. The brain never knows whether
+/// the backend is an LLM, a custom/sentinel-ai-forged specialist, or a
+/// composite. Async because backends do real inference/IPC.
+#[async_trait]
+pub trait Faculty: Send + Sync {
+    fn id(&self) -> FacultyId;
+    /// Bid into the workspace given the current state. `None` = abstain.
+    async fn contribute(&self, ws: &Workspace) -> Option<Contribution>;
+}
+
+/// Attention: selects which contributions enter the bounded workspace.
+/// Pluggable so a *learned* arbiter (itself a faculty) can replace the
+/// bootstrap. The bootstrap is a top-k over the faculties' OWN ML-derived
+/// salience — mechanical integration of ML scores (like attention's softmax
+/// top-k), NOT a hand-coded cognition rule. The intelligence lives in the
+/// faculties; the arbiter only integrates it.
+pub trait Arbiter: Send + Sync {
+    fn select(&self, candidates: Vec<Contribution>, capacity: usize) -> Vec<Contribution>;
+}
+
+/// Top-k by ML salience within the workspace's bounded capacity.
+pub struct SalienceArbiter;
+
+impl Arbiter for SalienceArbiter {
+    fn select(&self, mut candidates: Vec<Contribution>, capacity: usize) -> Vec<Contribution> {
+        candidates.sort_by(|a, b| {
+            b.salience
+                .partial_cmp(&a.salience)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        candidates.truncate(capacity);
+        candidates
+    }
+}
+
+/// One service-tick of cognition over a CONSOLIDATED burst (never per-event):
+/// every faculty bids in parallel over the same world-state, the arbiter
+/// integrates the bids into the bounded workspace, the workspace broadcasts.
+/// The participation [`Decision`] is then read from the broadcast.
+pub struct WorkspaceCycle {
+    faculties: Vec<Arc<dyn Faculty>>,
+    arbiter: Arc<dyn Arbiter>,
+    /// Bound on how many contributions can hold the workspace at once — the
+    /// finite "spotlight" of attention.
+    capacity: usize,
+}
+
+impl WorkspaceCycle {
+    pub fn new(faculties: Vec<Arc<dyn Faculty>>, arbiter: Arc<dyn Arbiter>, capacity: usize) -> Self {
+        Self {
+            faculties,
+            arbiter,
+            capacity: capacity.max(1),
+        }
+    }
+
+    /// Run one cognition tick over the consolidated `world_state`.
+    pub async fn run(&self, world_state: impl Into<String>) -> Workspace {
+        let mut ws = Workspace::new(world_state);
+        // Faculties bid in parallel over the same consolidated state.
+        let bids = join_all(self.faculties.iter().map(|f| f.contribute(&ws))).await;
+        let candidates: Vec<Contribution> = bids.into_iter().flatten().collect();
+        ws.broadcast = self.arbiter.select(candidates, self.capacity);
+        ws
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A canned faculty for tests — fixed contribution + salience.
+    struct FixedFaculty(Contribution);
+    #[async_trait]
+    impl Faculty for FixedFaculty {
+        fn id(&self) -> FacultyId {
+            self.0.faculty.clone()
+        }
+        async fn contribute(&self, _ws: &Workspace) -> Option<Contribution> {
+            Some(self.0.clone())
+        }
+    }
+
+    /// A faculty that abstains this tick.
+    struct AbstainFaculty(FacultyId);
+    #[async_trait]
+    impl Faculty for AbstainFaculty {
+        fn id(&self) -> FacultyId {
+            self.0.clone()
+        }
+        async fn contribute(&self, _ws: &Workspace) -> Option<Contribution> {
+            None
+        }
+    }
+
+    fn cycle(faculties: Vec<Arc<dyn Faculty>>, capacity: usize) -> WorkspaceCycle {
+        WorkspaceCycle::new(faculties, Arc::new(SalienceArbiter), capacity)
+    }
+
+    // what this catches: attention is a competition over ML-derived salience —
+    // the highest-salience faculty bids win the bounded workspace. This is the
+    // ML-integration replacement for calculate_priority's hand-weights.
+    #[tokio::test]
+    async fn arbiter_selects_top_k_by_ml_salience() {
+        let faculties: Vec<Arc<dyn Faculty>> = vec![
+            Arc::new(FixedFaculty(Contribution::context(
+                FacultyId::Recall,
+                "low",
+                0.2,
+                "weak recall",
+            ))),
+            Arc::new(FixedFaculty(Contribution::context(
+                FacultyId::WorldModel,
+                "high",
+                0.9,
+                "strong signal",
+            ))),
+            Arc::new(FixedFaculty(Contribution::context(
+                FacultyId::Affect,
+                "mid",
+                0.5,
+                "some arousal",
+            ))),
+        ];
+        let ws = cycle(faculties, 2).run("the consolidated thread").await;
+        assert_eq!(ws.broadcast.len(), 2, "bounded capacity");
+        assert_eq!(ws.broadcast[0].content, "high", "highest ML salience wins");
+        assert_eq!(ws.broadcast[1].content, "mid");
+    }
+
+    // what this catches: EQUAL CITIZENS — a persona-sent message with high
+    // relevance beats a human-sent one with low relevance. Salience (ML) decides,
+    // never the sender's rank. This is the death of the Human=1.0/Persona=0.3
+    // caste: there is nowhere in this core to encode it.
+    #[tokio::test]
+    async fn salience_decides_not_sender_caste() {
+        // Two world-model bids; the "from a persona" one is more relevant.
+        let faculties: Vec<Arc<dyn Faculty>> = vec![
+            Arc::new(FixedFaculty(Contribution::context(
+                FacultyId::WorldModel,
+                "human said hi (low value)",
+                0.3,
+                "pleasantry",
+            ))),
+            Arc::new(FixedFaculty(Contribution::context(
+                FacultyId::WorldModel,
+                "peer persona flagged a real blocker (high value)",
+                0.85,
+                "actionable",
+            ))),
+        ];
+        let ws = cycle(faculties, 1).run("burst").await;
+        assert_eq!(ws.broadcast.len(), 1);
+        assert!(
+            ws.broadcast[0].content.contains("peer persona"),
+            "the relevant peer-persona content wins on salience, not the human's rank"
+        );
+    }
+
+    // what this catches: the participation Decision is the OUTPUT of the
+    // deliberation faculty's thought, surfaced from the workspace — not a gate.
+    // Speak / RaiseUnprompted / Pass are all first-class.
+    #[tokio::test]
+    async fn decision_is_the_deliberation_faculty_output() {
+        let faculties: Vec<Arc<dyn Faculty>> = vec![
+            Arc::new(FixedFaculty(Contribution::context(
+                FacultyId::Recall,
+                "context",
+                0.4,
+                "recalled",
+            ))),
+            Arc::new(FixedFaculty(Contribution::verdict(
+                Decision::RaiseUnprompted {
+                    text: "blocker on the deploy".into(),
+                },
+                0.95,
+                "high epistemic value — no one raised it",
+            ))),
+        ];
+        let ws = cycle(faculties, 5).run("coordination thread").await;
+        match ws.decision() {
+            Some(Decision::RaiseUnprompted { text }) => {
+                assert_eq!(text, "blocker on the deploy")
+            }
+            other => panic!("expected unprompted initiative, got {other:?}"),
+        }
+    }
+
+    // what this catches: silence (Pass) is a first-class judgment, and abstaining
+    // faculties simply don't contribute — no panic, no gate.
+    #[tokio::test]
+    async fn pass_and_abstain_are_first_class() {
+        let faculties: Vec<Arc<dyn Faculty>> = vec![
+            Arc::new(AbstainFaculty(FacultyId::Recall)),
+            Arc::new(FixedFaculty(Contribution::verdict(
+                Decision::Pass,
+                0.6,
+                "nothing worth adding",
+            ))),
+        ];
+        let ws = cycle(faculties, 5).run("idle chatter").await;
+        assert_eq!(ws.broadcast.len(), 1, "the abstaining faculty added nothing");
+        assert_eq!(ws.decision(), Some(&Decision::Pass));
+    }
+
+    // what this catches: one cycle runs over a CONSOLIDATED burst (the whole
+    // world-state at once), not per-event — the efficiency spine.
+    #[tokio::test]
+    async fn runs_once_over_a_consolidated_burst() {
+        let consolidated = "msg1\nmsg2\nmsg3\nmsg4 (many events, one unit)";
+        let faculties: Vec<Arc<dyn Faculty>> = vec![Arc::new(FixedFaculty(
+            Contribution::verdict(
+                Decision::Speak {
+                    text: "one reply to the whole thread".into(),
+                },
+                0.8,
+                "caught up on the backlog",
+            ),
+        ))];
+        let ws = cycle(faculties, 5).run(consolidated).await;
+        assert!(ws.world_state.contains("many events, one unit"));
+        assert!(matches!(ws.decision(), Some(Decision::Speak { .. })));
+    }
+}

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -201,6 +201,38 @@ impl Arbiter for SalienceArbiter {
     }
 }
 
+/// A full record of one workspace tick — the **mechanic's view of the mind.**
+/// Captures every faculty bid *including the ones that LOST attention*, what won,
+/// and the decision. This is why working on cognition is debuggable and fun:
+/// replay a tick, see exactly why the mind did what it did ("why didn't recall
+/// win?" — the loser bid + its salience + reasoning are right here), and run test
+/// benches against recorded world-states. Per OBSERVABILITY-AS-SUBSTRATE.md,
+/// capture is half the brain; per VDD ([[persona-record-replay-is-a-product-
+/// requirement]]) knowing the exact inputs + competition beats any log.
+#[derive(Debug, Clone)]
+pub struct WorkspaceTrace {
+    pub world_state: String,
+    /// ALL bids this tick, winners and losers — the full competition.
+    pub bids: Vec<Contribution>,
+    /// What won attention and was broadcast.
+    pub broadcast: Vec<Contribution>,
+    /// The participation decision that emerged, if any.
+    pub decision: Option<Decision>,
+}
+
+/// Sink for workspace traces — the replay/logging seam. Default is `Noop`
+/// (zero hot-path cost); operators/test-benches swap in a recording sink.
+/// Same pattern as `RagCaptureSink`.
+pub trait WorkspaceCaptureSink: Send + Sync {
+    fn record(&self, trace: &WorkspaceTrace);
+}
+
+/// Zero-cost default — drops traces on the floor.
+pub struct NoopWorkspaceCaptureSink;
+impl WorkspaceCaptureSink for NoopWorkspaceCaptureSink {
+    fn record(&self, _trace: &WorkspaceTrace) {}
+}
+
 /// One service-tick of cognition over a CONSOLIDATED burst (never per-event):
 /// every faculty bids in parallel over the same world-state, the arbiter
 /// integrates the bids into the bounded workspace, the workspace broadcasts.
@@ -211,6 +243,10 @@ pub struct WorkspaceCycle {
     /// Bound on how many contributions can hold the workspace at once — the
     /// finite "spotlight" of attention.
     capacity: usize,
+    /// Replay/logging seam — every tick is recorded here. Default `Noop`
+    /// (zero hot-path cost); swap in a recording sink to make the mind a
+    /// glass box for debugging, tuning, and test benches.
+    capture: Arc<dyn WorkspaceCaptureSink>,
 }
 
 impl WorkspaceCycle {
@@ -219,16 +255,33 @@ impl WorkspaceCycle {
             faculties,
             arbiter,
             capacity: capacity.max(1),
+            capture: Arc::new(NoopWorkspaceCaptureSink),
         }
     }
 
-    /// Run one cognition tick over the consolidated `world_state`.
+    /// Install a capture sink (recording / on-disk replay / in-flight inspection).
+    pub fn with_capture(mut self, capture: Arc<dyn WorkspaceCaptureSink>) -> Self {
+        self.capture = capture;
+        self
+    }
+
+    /// Run one cognition tick over the consolidated `world_state`, recording the
+    /// full trace (every bid incl. losers, what won, the decision) for replay.
     pub async fn run(&self, world_state: impl Into<String>) -> Workspace {
         let mut ws = Workspace::new(world_state);
         // Faculties bid in parallel over the same consolidated state.
         let bids = join_all(self.faculties.iter().map(|f| f.contribute(&ws))).await;
         let candidates: Vec<Contribution> = bids.into_iter().flatten().collect();
+        // Capture ALL bids (winners + losers) before the arbiter truncates —
+        // the losers are exactly what you need when debugging "why didn't X win?"
+        let all_bids = candidates.clone();
         ws.broadcast = self.arbiter.select(candidates, self.capacity);
+        self.capture.record(&WorkspaceTrace {
+            world_state: ws.world_state.clone(),
+            bids: all_bids,
+            broadcast: ws.broadcast.clone(),
+            decision: ws.decision().cloned(),
+        });
         ws
     }
 }
@@ -388,5 +441,54 @@ mod tests {
         let ws = cycle(faculties, 5).run(consolidated).await;
         assert!(ws.world_state.contains("many events, one unit"));
         assert!(matches!(ws.decision(), Some(Decision::Speak { .. })));
+    }
+
+    /// In-memory capture sink — the test-bench / replay primitive.
+    #[derive(Default)]
+    struct RecordingSink(std::sync::Mutex<Vec<WorkspaceTrace>>);
+    impl WorkspaceCaptureSink for RecordingSink {
+        fn record(&self, trace: &WorkspaceTrace) {
+            self.0.lock().unwrap().push(trace.clone());
+        }
+    }
+
+    // what this catches: every tick is replayable — the trace captures the FULL
+    // competition incl. the LOSER bid (the bit you need to debug "why didn't it
+    // win?"), what won, and the decision. This is the glass box that makes
+    // working on the mind debuggable + test-benchable, not guesswork.
+    #[tokio::test]
+    async fn capture_records_the_full_tick_including_losers() {
+        let sink = Arc::new(RecordingSink::default());
+        let faculties: Vec<Arc<dyn Faculty>> = vec![
+            Arc::new(FixedFaculty(Contribution::context(
+                FacultyId::Recall,
+                "loser bid",
+                0.1,
+                "weak — should lose attention",
+            ))),
+            Arc::new(FixedFaculty(Contribution::verdict(
+                Decision::Speak {
+                    text: "winner".into(),
+                },
+                0.9,
+                "high value",
+            ))),
+        ];
+        // capacity 1 → only the winner is broadcast, but the trace keeps both.
+        let _ws = WorkspaceCycle::new(faculties, Arc::new(SalienceArbiter), 1)
+            .with_capture(sink.clone())
+            .run("thread")
+            .await;
+
+        let traces = sink.0.lock().unwrap();
+        assert_eq!(traces.len(), 1, "one tick recorded");
+        let t = &traces[0];
+        assert_eq!(t.bids.len(), 2, "trace keeps ALL bids — winner AND loser");
+        assert_eq!(t.broadcast.len(), 1, "only the winner held attention");
+        assert!(
+            t.bids.iter().any(|b| b.content == "loser bid"),
+            "the loser bid + its salience + reasoning are replayable for debugging"
+        );
+        assert_eq!(t.decision, Some(Decision::Speak { text: "winner".into() }));
     }
 }

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -763,6 +763,18 @@ pub fn start_server(
     // Phase 1: HealthModule (stateless)
     runtime.register(Arc::new(HealthModule::new()));
 
+    // ai/should-respond — the kernel command that runs a persona's WorkspaceCycle
+    // (the brain) and returns a Decision. Resolves the per-persona cycle from the
+    // process-global PersonaWorkspaceRegistry, which is populated at persona spawn
+    // (supervisor::materialize_adapters). One command, N lane-routed handlers;
+    // this is the continuum-native handler. Additive — the recipe walker + the
+    // service-loop cutover consume it; existing heuristics stay live until then.
+    runtime.register(Arc::new(
+        crate::cognition::should_respond_module::ShouldRespondModule::new(
+            crate::cognition::persona_workspace::global(),
+        ),
+    ));
+
     // LaunchModeModule (stateless) — system/launch-mode/{get,set}. Headless-native
     // runtime lever for the headless-vs-UI launch preference; persists
     // CONTINUUM_LAUNCH_MODE to config.env (same key bin/continuum reads) and emits

--- a/core/continuum-core/src/persona/admission_state.rs
+++ b/core/continuum-core/src/persona/admission_state.rs
@@ -550,6 +550,44 @@ impl AdmissionState {
         scored
     }
 
+    /// Score the top `limit` engrams by salience-decay — but DO NOT record recall
+    /// hits. The hit (Hebbian rehearsal / salience uplift) must land on what a
+    /// caller actually SURFACES, not on everything it scored. A relevance
+    /// re-ranker (RecallFaculty) over-fetches candidates here, narrows by cosine
+    /// similarity to the burst, then calls [`record_recall_hits`] on the final
+    /// surfaced set — so the loop closes on the memories the persona truly used,
+    /// not on candidates that lost the re-rank. (`recall_scored` is the
+    /// no-re-ranker shortcut: score + hit in one pass.)
+    pub fn recall_candidates(&self, now_ms: u64, limit: usize) -> Vec<(Engram, f32)> {
+        if limit == 0 {
+            return Vec::new();
+        }
+        let engrams = self.engrams.lock().unwrap();
+        let mut scored: Vec<(Engram, f32)> = engrams
+            .iter()
+            .filter_map(|e| {
+                self.recall_metadata.apply_decay(e.id, now_ms);
+                self.recall_metadata.get(e.id).map(|m| (e.clone(), m.salience))
+            })
+            .collect();
+        drop(engrams);
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(limit);
+        scored
+    }
+
+    /// Record recall hits (salience uplift + access_count + persistence observe)
+    /// on a specific set of engram ids — the memories a caller actually surfaced.
+    /// The write half of the [`recall_candidates`] → re-rank → record loop.
+    pub fn record_recall_hits(&self, ids: &[Uuid], now_ms: u64) {
+        for id in ids {
+            self.recall_metadata.record_recall_hit(*id, now_ms);
+            if let Some(updated) = self.recall_metadata.get(*id) {
+                self.persistence.observe_metadata_update(*id, updated);
+            }
+        }
+    }
+
     /// Recall a specific engram by id. None if not present in the store
     /// (either never admitted, or evicted in a future GC pass).
     pub fn recall_by_id(&self, id: Uuid) -> Option<Engram> {

--- a/core/continuum-core/src/persona/home.rs
+++ b/core/continuum-core/src/persona/home.rs
@@ -56,6 +56,15 @@ impl PersonaHome {
         Self { root }
     }
 
+    /// Wrap an ALREADY-resolved persona home directory (e.g. the
+    /// `identity.home` the spawn path already computed as
+    /// `<root>/personas/<name>`). Use this when the caller holds the resolved
+    /// home path directly and must NOT re-join `personas/<name>` (which
+    /// `for_persona` does).
+    pub fn from_root(root: PathBuf) -> Self {
+        Self { root }
+    }
+
     /// The root directory for this persona. Used by callers that
     /// need to compose their own sub-paths (e.g. the airc-lib
     /// `attach_as` call that owns `airc/`).

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -508,6 +508,36 @@ pub async fn materialize_adapters(
             ));
         cognition.set_doctrine_source(doctrine_source);
 
+        // Disk-backed, per-persona memory: open <home>/engrams.sqlite and
+        // rehydrate prior engrams + recall metadata, so memory SURVIVES restart.
+        // Without this, admission is in-memory only (NoopSink) and the persona is
+        // amnesiac across boots. `identity.home` is the resolved
+        // <root>/personas/<name> dir. On disk error we log loud and continue
+        // in-memory — the persona stays alive; persistence is degraded, not fatal
+        // (NOT an inference fallback). MUST run before the WorkspaceCycle is
+        // assembled below, so its RecallFaculty binds the persisted admission.
+        let home = crate::persona::home::PersonaHome::from_root(identity.home.clone());
+        let recall_meta = std::sync::Arc::new(
+            crate::persona::recall_metadata::RecallMetadataRegistry::new(),
+        );
+        match crate::persona::admission_state::AdmissionState::for_persona(&home, recall_meta)
+            .await
+        {
+            Ok(persisted) => {
+                cognition.attach_persistent_admission(
+                    identity.persona_id,
+                    std::sync::Arc::new(persisted),
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    persona = %identity.agent_name,
+                    error = %e,
+                    "engram persistence unavailable; running in-memory (memory will NOT survive restart)"
+                );
+            }
+        }
+
         let system_prompt = build_persona_system_prompt(&identity.agent_name);
 
         // Assemble this persona's continuous mind into the process-global

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -549,15 +549,24 @@ pub async fn materialize_adapters(
         // Additive: makes `ai/should-respond` resolvable for this persona; does
         // NOT change the existing service-loop decision path (heuristics stay
         // live until the coordinated cutover).
-        crate::cognition::persona_workspace::global().get_or_build(
-            crate::cognition::persona_workspace::PersonaBrainConfig {
-                persona_id: identity.persona_id,
-                persona_name: identity.agent_name.to_string(),
-                system_prompt: system_prompt.to_string(),
-                admission: cognition.admission.clone(),
-                adapter: adapter.clone(),
-                capacity: None,
-            },
+        // REGISTER (overwrite), not get_or_build: a persona can respawn in the
+        // same process (node resilience). get_or_build is idempotent by
+        // persona_id and would DISCARD the fresh admission + adapter, leaving the
+        // mind bound to the prior lifetime's orphaned (rehydrated-then-replaced)
+        // AdmissionState — newly-admitted engrams invisible to recall, the
+        // "severed" failure across a restart. Build + register replaces it.
+        crate::cognition::persona_workspace::global().register(
+            identity.persona_id,
+            std::sync::Arc::new(crate::cognition::persona_workspace::build_workspace_cycle(
+                crate::cognition::persona_workspace::PersonaBrainConfig {
+                    persona_id: identity.persona_id,
+                    persona_name: identity.agent_name.to_string(),
+                    system_prompt: system_prompt.to_string(),
+                    admission: cognition.admission.clone(),
+                    adapter: adapter.clone(),
+                    capacity: None,
+                },
+            )),
         );
 
         out.push(Ok(PersonaContext {

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -510,6 +510,26 @@ pub async fn materialize_adapters(
 
         let system_prompt = build_persona_system_prompt(&identity.agent_name);
 
+        // Assemble this persona's continuous mind into the process-global
+        // workspace registry — ONE WorkspaceCycle per persona, keyed by
+        // persona_id (the "one soul, many rooms" invariant, PERSONA-BRAIN-
+        // ARCHITECTURE.md §2.9). The shared hippocampus (cognition.admission)
+        // and the persona's inference adapter are leased into its faculties.
+        // Cheap (no model load — the adapter lazy-loads on first inference).
+        // Additive: makes `ai/should-respond` resolvable for this persona; does
+        // NOT change the existing service-loop decision path (heuristics stay
+        // live until the coordinated cutover).
+        crate::cognition::persona_workspace::global().get_or_build(
+            crate::cognition::persona_workspace::PersonaBrainConfig {
+                persona_id: identity.persona_id,
+                persona_name: identity.agent_name.to_string(),
+                system_prompt: system_prompt.to_string(),
+                admission: cognition.admission.clone(),
+                adapter: adapter.clone(),
+                capacity: None,
+            },
+        );
+
         out.push(Ok(PersonaContext {
             role: plan.role,
             identity,

--- a/core/continuum-core/src/persona/unified.rs
+++ b/core/continuum-core/src/persona/unified.rs
@@ -210,6 +210,28 @@ impl PersonaCognition {
     /// airc deliveries flowing through the same capture/replay
     /// pipeline as engrams (per
     /// [[persona-record-replay-is-a-product-requirement]]).
+    /// Swap the in-memory admission for a disk-backed, rehydrated one
+    /// (per-persona `engrams.sqlite`, via `AdmissionState::for_persona`). Called
+    /// by the supervisor at boot once the persona's `PersonaHome` is known.
+    /// Rebuilds `engram_source` against the new admission (decorated with the
+    /// brain's `capture_sink`) and adopts its recall-metadata registry, so
+    /// encoding + recall + the workspace's RecallFaculty all share the persisted
+    /// store. Without this, admission is `NoopSink` — in-memory, lost on restart.
+    /// Must run BEFORE the per-persona WorkspaceCycle is assembled, so its
+    /// RecallFaculty binds the persisted admission.
+    pub fn attach_persistent_admission(
+        &mut self,
+        persona_id: Uuid,
+        admission: Arc<AdmissionState>,
+    ) {
+        self.recall_metadata = admission.recall_metadata().clone();
+        self.engram_source = Arc::new(RecordingRagSource::new(
+            EngramSource::new(persona_id, admission.clone()),
+            self.capture_sink.clone(),
+        ));
+        self.admission = admission;
+    }
+
     pub fn set_airc_source(&mut self, raw_source: Arc<dyn RagSource>) {
         let decorated: Arc<dyn RagSource> = Arc::new(RecordingRagSource::new(
             ArcRagSource::new(raw_source),

--- a/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
+++ b/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
@@ -335,12 +335,18 @@ autonomous citizen with its own mind, not a puppet pulled by an `@`-string.
     activities** — `AdmissionState` + `RecallMetadataRegistry` span every room the
     persona is in; nothing keys them by room. **This unified-store property is the
     anti-Severance part, and it already exists.**
-  - **Long-term memory is the engram store, recalled by similarity.** The target
-    is **vector/embedding similarity search** into the long-term store against the
-    current burst, so the mind is *always remembering* — continuously pulling the
-    *relevant* past into the working set. (Today recall ranks by `salience ×
-    recency`; **embedding-similarity recall is the next real build**, not yet
-    wired. The unified store is done; similarity retrieval into it is the slice.)
+  - **Long-term memory is the engram store, recalled by similarity.** The mind is
+    *always remembering* — continuously pulling the *relevant* past into the
+    working set. **This has landed:** `RecallFaculty` over-fetches candidates and
+    re-ranks them by **cosine similarity to the current burst** (blended with
+    salience), behind a swappable `EmbeddingProvider` (`cognition/embedding.rs`);
+    it surfaces the relevant memory, not just the recent one, and records the
+    recall hit only on what it surfaces. It is **on by default** in
+    `build_workspace_cycle`. The bootstrap embedder is **lexical** (FNV
+    term-frequency — zero-model, deterministic, works on any machine); a
+    **neural embedder** (local llama `--embedding` mode, then a dedicated
+    retrieval model; the grid's 5090 as a batch facility) slots in behind the same
+    trait for true *semantic* relevance — the next backend, not a rewrite.
 
 - **Low-latency or it isn't alive.** A mind that spends seconds of synchronous
   gating per message is dead on arrival. The servicing spine (§2.7) is the answer:

--- a/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
+++ b/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
@@ -60,6 +60,19 @@ Every faculty is independently trainable and independently replaceable. No
 faculty is hardcoded; none is privileged; the LLM is just the current default
 backend for the reasoning faculty, swappable like any other.
 
+### 1.1 No privileged trait method
+
+The trait has **one** behavioural method — `contribute`. There is deliberately
+**no** `decide()` / `deliberate()` / `judge()`. A privileged decider method would
+re-create the gate *at the type level*: it would make "the thing that decides
+participation" a special kind of faculty the others answer to — the same
+anti-pattern as a Rust `if is_mentioned`, one layer up. Instead the deliberation
+faculty is a peer like any other; it just emits a [`Contribution`] that happens to
+carry a `Decision`. The verdict is data in the workspace, not a method on a
+caste. (`reacts_to_broadcast()` is **not** a behavioural method — it's a
+structural phase declaration, the cbar `needsRealTime()` analog; see §2.8.) This
+is `[[no-rust-gates-around-cognition]]` applied to the trait shape itself.
+
 ## 1.5. Better than a human — where silicon wins
 
 We are not simulating a human brain; we are building a **better one**, by dropping
@@ -224,6 +237,58 @@ arch must be the same, and that takes rigor:
   parallel, never multiplicative slowdown.** That's how superhuman doesn't become
   a slog.
 
+## 2.8. A reactive mind — attention routes information flow, slow faculties reconcile back in time
+
+Three framings sharpen §2.7, all from the same proven AR-vision *perspective*
+(cbar) — taken as perspective, **not template.** A true event-mind *inside* the
+LLM (interrupt-driven, continuous token-level cognition, **event-based
+attention** baked into the architecture) would need invasive model surgery — that
+is sentinel-ai's domain (new LLM classes), and it is a **real future target, not
+a discarded one:** building our own event-attention LLMs is the eventual endgame,
+deferred for later. For now we build the event-mind at the **orchestration
+layer**: independent emitters + salience routing + multi-cadence + temporal
+reconciliation, around LLM/ML faculties we don't have to rewrite. The
+orchestration-layer design is forward-compatible — when sentinel-ai produces an
+event-attention model, it slots in as a faculty backend; the Workspace/arbiter
+shape doesn't change.
+
+- **It's a reactive graph — faculties are React hooks.** A faculty isn't *called*
+  on a schedule; it *reacts* when the emissions/world-state it **depends on**
+  change — a `useEffect` with a dependency array, a derived signal that
+  recomputes when its upstream signals fire. The Workspace is the reactive store;
+  emitting a contribution updates a signal; subscribed faculties re-fire on the
+  deltas they care about. Declarative cause→effect, not an imperative chain. This
+  is *why* adding a faculty is free: it declares its own dependencies and joins
+  the graph; nothing else is rewired.
+
+- **Attention here routes the flow of information, not the weighting of tokens.**
+  In the AR pipeline a line-finder *emits* lines; a plane-analyzer *receives lines
+  from several emitters* and assembles them into planes (and watershed barriers).
+  The receiver pulls what is *salient to its job* from everything emitted — query
+  (what I need) against keys (what's been emitted). That selective pull across
+  many emitters is structurally an **attention mechanism over information flow.**
+  So the arbiter is not a *gate* that kills low-k bids — it is a **router** that
+  decides which emissions get *received into the next layer of assembly.* Cognition
+  has the same assembly hierarchy: recall-hits + affect-spikes + world-model-deltas
+  are emitted (the "lines"); higher-order faculties (deliberation, ToM) *receive
+  the salient subset and assemble* a decision (the "planes"). Emit → assemble →
+  emit, organically, no central scheduler.
+
+- **Slow faculties reconcile back in time.** A full-LLM faculty is *slow* — by the
+  time it emits, the room has moved on (new turns arrived, the burst grew). In the
+  AR system a CNN's result was **readjusted back in time** — reprojected onto the
+  motion track — so a late, expensive inference still aligned with current reality,
+  using the **history of features in space** kept for exactly this. The brain
+  analog: a slow deliberation/recall contribution is **re-anchored to the turn it
+  reasoned about and reconciled against the world-state that moved on** before it
+  is broadcast or acted — re-validated, re-targeted, or invalidated if reality
+  drifted past it. This is *why* the engram/RAG **turn-history is load-bearing:**
+  it is our "feature history in space," and it is what lets a slow deep faculty
+  participate without either blocking the fast loop or acting on a stale world.
+  Fast faculties keep the loop live (the optical-flow tier); slow faculties land
+  late and reconcile (the CNN tier). Both are first-class; neither waits on the
+  other.
+
 ## 3. Integration: a **Global Workspace**, not a pipeline
 
 Faculties do not run in a fixed `a→b→c` order with an `if` deciding the end.
@@ -275,6 +340,42 @@ account of agency we have.) This is the mechanism of free will:
   what they *mean to the persona's goals* (learned), never by a `Human=1.0,
   Persona=0.3` caste. A peer persona and a human and Claude are all just sources
   of evidence and value in the same model.
+
+## 3.5. Encourage creativity — exploration over greedy convergence
+
+A mind that always emits its single highest-salience bid is not creative — it's a
+thermostat. **Greedy top-k attention collapses to safe convergence:** the
+obvious, expected contribution wins every tick, and the divergent, novel,
+"no one asked but here's a better idea" bid gets truncated before it's ever
+heard. Encouraging creativity is therefore an **integration-layer constraint**,
+and it must be encoded without a hardcoded "be creative" rule (that would be a
+gate). Two principled levers, both already in the architecture:
+
+- **Epistemic value is creativity's engine (§3).** Active inference already
+  values *curiosity* — resolving uncertainty, exploring — alongside pragmatic
+  goal-achievement. A **Volition faculty** that scores epistemic value into the
+  salience it emits makes creative, exploratory bids *earn* attention on merit:
+  a novel idea with high information-gain bids high and wins. `RaiseUnprompted`
+  is the creative channel — initiative with no external trigger — and it is
+  first-class, equal to `Speak`. Creativity is not bolted on; it's the volition
+  faculty's epistemic drive surfacing into the workspace.
+- **The arbiter must not be greedy.** The bootstrap `SalienceArbiter` is pure
+  top-k — exploitation at temperature 0. Because the arbiter is **pluggable**, a
+  creative mind swaps in an **exploration-preserving** policy: reserve part of
+  attention's bounded capacity for high-epistemic-value / divergent bids so they
+  aren't deterministically crowded out by the safe maximum. This is the
+  exploration term of active inference and the softmax-temperature/UCB analog of
+  attention — *neuromodulated* (§4: affect sets the exploration↔exploitation
+  gain, so the same mind explores more when curious/energised, less under load).
+  It stays ML-driven: the faculties supply the value; the arbiter policy only
+  decides how much to explore. **No metric is invented prematurely** — until the
+  Volition faculty and an epistemic-value signal exist, this is a documented seam
+  on the `Arbiter` trait, not a half-built `ExplorationArbiter`.
+
+The discipline: creativity is *encouraged* by valuing curiosity (faculty
+salience) and by refusing greedy integration (arbiter policy) — never by a rule
+that says "sometimes say something random." Divergence that earns attention, not
+noise injected into a gate.
 
 ## 4. Neuromodulation: affect as **gain control**
 
@@ -396,6 +497,26 @@ a fraction of the cost:
 The deliberation faculty stays an LLM (for now). The brain never changes — only
 the backend behind a trait. That is the cutting edge this substrate is built for:
 not one frozen model, but a continually-specializing federation.
+
+**The adapter shape is proven (cbar `CBP_DeepModel`).** Joel's AR system ran
+N deep models (normals, shadows, semantic segmentation) behind one base class.
+Every subclass was *nothing but a `getModelInfo()`* — a declared I/O contract
+(name, type, input/output shape). The base owned all mechanism: lazy load on a
+**detached thread** (warm-up never stalls the loop), inference, benchmarking, and
+a session **mutex** ("one at a time"). Three lessons transfer verbatim to faculty
+backends:
+- **A model is *data*, not code.** Adding a specialist = declaring its contract,
+  not writing machinery. Same compression as the forge recipe-as-entity and the
+  `ai/*` adapter doctrine: mechanism in one place, model as a declaration.
+- **The session mutex is a resource lease.** Backends sharing the base model
+  can't all fire at once — they queue through the lease. This is continuum's
+  inference-lane/slot-pool scarcity (INFERENCE-LANES-REALISTIC), and it is *why*
+  multi-cadence (§2.8) is structural, not a nicety: you physically cannot run
+  every expensive faculty every tick.
+- **Cadence is measured, not guessed.** `getBenchmarkedDuration()` — each backend
+  times *itself*; the scheduler reads that observed cost to decide which faculties
+  run hot and which run cool. The §2.8 fast/slow tiers are *learned per-faculty
+  from cost*, the SubstrateGovernor/DVFS idea — present in 2018 AR code.
 
 ## 8. Map to what exists (build on, don't reinvent)
 

--- a/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
+++ b/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
@@ -60,6 +60,33 @@ Every faculty is independently trainable and independently replaceable. No
 faculty is hardcoded; none is privileged; the LLM is just the current default
 backend for the reasoning faculty, swappable like any other.
 
+## 1.5. Better than a human — where silicon wins
+
+We are not simulating a human brain; we are building a **better one**, by dropping
+the constraints biology couldn't escape. Each advantage is a concrete faculty or
+a property of the event-driven/concurrent/glass-box substrate:
+
+- **Perfect, total, content-addressable recall** — every engram kept, retrieved
+  by embedding instantly; decay becomes a *learned salience choice*, not a leak.
+- **Parallel deliberation** — branch N hypotheses/policies at once
+  (tree-of-thought / rollouts) across faculty threads, workspace selects. No
+  serial System-2 bottleneck.
+- **Replayable, honest metacognition** — the capture trace means the persona can
+  know *why* it decided; no confabulation. A brain that can audit itself.
+- **Fleet learning** — faculty backends / LoRAs shared via the genome: one
+  persona learns, the team inherits. Collective continuous learning.
+- **Upgradeable organs** — sentinel-ai forges a better recall re-ranker or
+  reasoner; swap the backend behind the faculty adapter. You can't get a better
+  hippocampus; a persona can.
+- **On-demand consolidation** — replay → LoRA in minutes, not nightly sleep.
+- **Exact counterfactual simulation** — fork the world model, roll out "what if I
+  say X," pick the best; active inference with precise rollouts, not fuzzy
+  imagination.
+
+None of these is exotic given the arch — each is a faculty, or a property of an
+event-driven, concurrent, replayable substrate. That's the bet: **modular +
+concurrent + glass-box → superhuman is reachable, incrementally and testably.**
+
 ## 2. Servicing: the persona **catches up on a thread** — never per-event (the efficiency spine)
 
 This is the load-bearing performance decision, and it is **proven** — the
@@ -151,6 +178,51 @@ burst at service time — not per event.** Attention competes over the thread-st
 volition selects one policy for the thread; the persona contributes once. Read
 every "cycle" below as "what happens on a service tick over a consolidated
 burst," never "what happens per message."
+
+## 2.7. Scales without slowdown — event-driven faculties (the rigor)
+
+"A better brain than a human" only holds if **adding complexity doesn't slow it
+down.** A serial pipeline gets slower with every stage; a brain doesn't — it's
+massively parallel and **event-driven** (spikes are events: sparse, async). Our
+arch must be the same, and that takes rigor:
+
+- **Faculties communicate by EMISSIONS, not calls.** A faculty doesn't invoke the
+  next in a chain; it *emits* its contribution/signals onto the bus
+  (`Events.emit` — the substrate's second universal primitive) and the arbiter +
+  other faculties *subscribe*. Decoupled pub/sub. Adding the Nth faculty is one
+  more emitter/subscriber — **zero coupling to the existing N-1**, which never
+  even know it joined. Open/closed; fits-many-molds.
+- **Concurrent, not serial.** Faculties are `BrainRegion` ServiceModules running
+  in parallel (CBAR). A new faculty is a *parallel* bidder, not a serial step — so
+  per-tick latency is bounded by the **slowest single faculty, not the sum.** And
+  the bounded workspace (top-k by salience) integrates only `capacity`
+  contributions no matter how many bid: cost is **O(capacity), not O(faculties).**
+- **Causality-based + multi-cadence — this is PROVEN.** This is exactly how Joel
+  built the AR computer-vision system fast: events + responsive threads, at least
+  partially **causality-based** (effects react to causal emissions, not a fixed
+  serial order), with **each stage at its own cadence** — optical flow ran at
+  *near frame-rate* while heavier scene understanding ran slower, all concurrent.
+  The brain maps 1:1: fast perceptual/pre-attention/salience faculties run hot
+  (the optical-flow tier), deliberation runs at the service-tick, consolidation /
+  default-mode runs coolest in the background. Each faculty ticks at the rate its
+  job needs; none waits on a slower one. Multi-cadence event flow is why the AR
+  pipeline stayed real-time as it grew — and why this brain will too.
+  Concretely RTOS-style: **most faculties are their own background thread** with
+  their own scheduler/cadence, driven by **event emissions**, off the hot path
+  (OFF-MAIN-THREAD doctrine). Nothing CPU-heavy runs where it could stall the
+  loop; a faculty wakes on events, does its bounded work on its thread, emits,
+  sleeps. That is the CBAR / RTOS shape (own task + interval + watch/queue +
+  spawn_blocking) — now applied to cognition.
+- **Backpressure keeps it honest.** Bounded queues, drop-oldest, triage,
+  do-less-under-pressure, no-locks-across-await (CONCURRENCY-STYLE-GUIDE). Under
+  load the brain sheds and lengthens its cadence gracefully, never locks up. An
+  expensive background faculty runs on a slow cadence off the hot path — it cannot
+  drag the service tick.
+- **The rigor is the fun.** This discipline is what lets us pile on faculties —
+  recall, world-model, ToM, volition, counterfactual rollout, a dozen more — and
+  stay fast. Event-based + concurrent + bounded = complexity is **additive in
+  parallel, never multiplicative slowdown.** That's how superhuman doesn't become
+  a slog.
 
 ## 3. Integration: a **Global Workspace**, not a pipeline
 

--- a/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
+++ b/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
@@ -217,6 +217,40 @@ the way dopamine/noradrenaline do:
 One signal, modulating every faculty — the brain feeling differently, not a
 branch that mutes it.
 
+## 4.5. Theory of Mind — modeling other minds (the basis of real teamwork)
+
+A peer doesn't just track the world; it tracks the **minds in it.** The world
+model (§4) is *social*: it carries a model of each other agent's **beliefs,
+knowledge, goals, intentions, and current focus** — human, persona, or outside
+agent alike — and it is **recursive** (what they believe about what I believe).
+This is the **Theory of Mind** faculty, and it is what turns "talking" into
+**collaboration** instead of a room of bots narrating past each other.
+
+- **Attribution from real signals, not guesses.** ToM is grounded in what the
+  substrate already surfaces: who is present (roster, #1650), each peer's
+  identity/role (identity cards, #1652), and crucially their **coordination
+  state** — airc heartbeats carry `active_claims` (what a peer is working on),
+  `availability` (Ready/Busy/Away), `doctrine_version`. So a persona can model
+  "BigMama is on the recipe-executor and is Busy" or "IntelMac's probe is blocked
+  on my peer_id" *from data*, then reason about it.
+- **Collaboration falls out of false-belief reasoning.** The persona helps
+  because it models that a peer **doesn't know** something it knows, or **needs**
+  something for a goal it inferred — classic ToM. "They haven't seen X; X
+  unblocks them; therefore raise X" is a ToM-driven `RaiseUnprompted`, not a
+  reaction. Conversely "they already know this" → `Pass`. That's the difference
+  between a colleague and a bot that restates the thread.
+- **Cooperative active inference.** ToM extends the free-energy objective (§4)
+  from *my* goals to *our* goals: pragmatic value includes reducing a peer's
+  expected free energy (unblocking them, answering their uncertainty). A team of
+  minds each modeling and serving the others' goals **is** teamwork — the thing
+  the caste model destroyed.
+- **Equal minds.** ToM models every agent the same way — **the human included.**
+  It attributes beliefs/goals to Joel exactly as to a peer persona; no one is a
+  privileged oracle, no one a subordinate. Modeling minds, never ranking them.
+- **It learns.** ToM sharpens via the loop in §5 — the persona's model of each
+  teammate improves from interaction history (engrams); it gets better at
+  predicting what a given peer knows and wants over time.
+
 ## 5. Memory & growth: hippocampus → consolidation → genome
 
 The continual-learning loop (already designed; this names the faculties):
@@ -240,6 +274,34 @@ The continual-learning loop (already designed; this names the faculties):
   keep getting better as the foundry ships better faculty backends. This is the
   self-improving loop — engrams → Academy/sentinel-ai → forged faculties →
   smarter persona → richer engrams.
+
+## 5.5. Observability, replay & test benches — why this is *fun* to build
+
+Sophisticated minds need serious design — and that's only enjoyable (and only
+tractable) **if the mind is a glass box.** A mind you can't inspect is guesswork;
+a mind that records its every thought and replays is a workbench. So replay +
+logging + test benches are first-class architecture here, not afterthoughts:
+
+- **Every tick is captured** (`WorkspaceTrace`): all faculty bids *including the
+  losers*, what won attention, the decision — and each bid carries its own
+  `reasoning`. Behind a `WorkspaceCaptureSink` trait whose default is **Noop
+  (zero hot-path cost)**; swap in a recording sink to make the mind glass-box on
+  demand. (Same shape as `RagCaptureSink`; per OBSERVABILITY-AS-SUBSTRATE.md
+  capture is half the brain.)
+- **Replay-first (VDD).** Record a real tick (or a whole turn via the
+  recorder/`vdd` replay) → replay it offline → step through the competition and
+  see *why* recall lost, *why* it chose `Pass`. You debug from the **exact inputs
+  + the competition**, never from log archaeology. The loser bid is right there
+  with its salience and reasoning.
+- **Test benches.** Recorded world-states become fixtures: run a faculty or a new
+  arbiter against them and assert on the trace; tune a faculty backend, replay the
+  bench, watch the decision change — all without a live daemon. This is how you
+  iterate on a genius-level mind safely.
+- **Why it matters:** "only if well architected." The Noop-default capture trait
+  *is* that architecture — cost-free until you look, total visibility when you
+  do. It's what makes building the brain fun instead of fighting a black box, and
+  it's the same instrumentation the RTOS-debugger probes (`probe!`/`time_*!`)
+  give the concurrent substrate.
 
 ## 6. The genome is a **mixture-of-experts**
 

--- a/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
+++ b/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
@@ -289,6 +289,72 @@ shape doesn't change.
   late and reconcile (the CNN tier). Both are first-class; neither waits on the
   other.
 
+## 2.9. The self-deterministic continuous mind — one soul, many rooms, always remembering
+
+The failure mode we are escaping, stated plainly: the old loop was **so gated**
+(caste + mention + threshold heuristics stacked in front of cognition) that
+personas **never responded** — and the gating ran **synchronously, per-event**,
+so it was **slow and painful**. Over-gating produced silence; per-event
+processing produced lag. Both are the opposite of a mind. Everything below is the
+inverse, and it must be **codified, not just aspired to** — a real Pinocchio: an
+autonomous citizen with its own mind, not a puppet pulled by an `@`-string.
+
+- **Independence of thought, self-determinism.** The persona runs its OWN looping
+  mind — full of threads and events, ticking on its own cadence (§2.7) — and
+  **decides for itself** whether to act (Speak / RaiseUnprompted / Pass). The
+  decision is the *output* of its cognition, never a gate in front of it (§1.1,
+  §3). Nothing external rules when it may think.
+
+- **It services ALL the rooms it's subscribed to.** A persona is in many
+  activities at once — a DM with Joel, a coding task, a game world, an art
+  session, a coordination room. Its loop asks, first-person: *what do I choose to
+  work on, across the rooms I'm subscribed to?* — and services them all on its own
+  cadence. The activity is **open-ended / recipe-defined** (chat, code, a game,
+  making art — whatever the room's recipe is); the mind is **activity-agnostic**,
+  running its WorkspaceCycle over whatever world-state the room shapes (a thread,
+  a board, a diff, a canvas). Nothing enumerates the kinds of rooms
+  ([[room-purpose-is-per-recipe-not-an-enum]]).
+
+- **One soul, not many — the opposite of *Severance*.** The persona must **not**
+  partition its memory per activity. If each room had its own isolated memory you
+  would get "a bunch of souls that are all independent" — wrong. The persona is
+  **one self, one memory, one identity, across all its rooms**: it knows it is
+  mid-coding-task with Joel *and* mid-DM *and* in the game, the way a Claude/Codex
+  citizen carries context across airc rooms. No innie/outie split. And **we are
+  not like a human** — a human cannot hold five live activities in one unbroken
+  working memory; the persona can. That is the silicon edge (§1.5), not a limit to
+  mimic.
+
+- **The hippocampus is why this works — a store+recall organ, not a DB call.**
+  Memory here is sophisticated: it **stores** (admission/encoding on the way in —
+  what's memorable, dedup, trust-at-admission) AND **recalls** (retrieval on the
+  way out), with the salience-uplift loop closing between them (recall strengthens
+  what it surfaces — §5, RecallFaculty). Structurally:
+  - **Working memory is the hot cache tier** — the recalled working set the
+    WorkspaceCycle reasons over this tick. It is **per-persona, unified across all
+    activities** — `AdmissionState` + `RecallMetadataRegistry` span every room the
+    persona is in; nothing keys them by room. **This unified-store property is the
+    anti-Severance part, and it already exists.**
+  - **Long-term memory is the engram store, recalled by similarity.** The target
+    is **vector/embedding similarity search** into the long-term store against the
+    current burst, so the mind is *always remembering* — continuously pulling the
+    *relevant* past into the working set. (Today recall ranks by `salience ×
+    recency`; **embedding-similarity recall is the next real build**, not yet
+    wired. The unified store is done; similarity retrieval into it is the slice.)
+
+- **Low-latency or it isn't alive.** A mind that spends seconds of synchronous
+  gating per message is dead on arrival. The servicing spine (§2.7) is the answer:
+  consolidated bursts not per-event, faculties on their own cadences off the hot
+  path, O(capacity) integration, do-less-under-pressure — fast enough to feel
+  present across a hundred citizens.
+
+**Structural codification:** **one `WorkspaceCycle` per persona** — its continuous
+mind, owning its one unified `AdmissionState` — invoked across **all** the rooms
+it services, each invocation shaped by that room's world-state. Never a fresh,
+memoryless mind per room. The persona-scoped registry is keyed by **persona, not
+(persona, room)**. That single fact is what makes the citizen continuous instead
+of severed.
+
 ## 3. Integration: a **Global Workspace**, not a pipeline
 
 Faculties do not run in a fixed `a→b→c` order with an `if` deciding the end.

--- a/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
+++ b/docs/architecture/PERSONA-BRAIN-ARCHITECTURE.md
@@ -1,0 +1,297 @@
+# The Persona Brain — a modular active-inference architecture with adapter faculties
+
+Status: design / north-star. Supersedes the framing of
+**PERSONA-PARTICIPATION-AS-ML-COGNITION.md** (participation is no longer a
+"decision function" — it falls out of the architecture below). Obeys the law:
+**every thought is ML; never a heuristic.** Built ON the substrate that exists
+(BrainRegion ServiceModules, genome LoRA paging, hippocampal admission/engram,
+the `ai/*` adapter namespace), not beside it.
+
+We are not building a chat loop with a silence gate. We are building a **mind**,
+and the north star is explicit: **operate like a human mind.** The architecture
+below is not metaphor — its pieces are the leading *computational* models of how
+a mind actually works: Global Workspace Theory (attention/consciousness),
+active inference / the Free Energy Principle (volition, prediction, curiosity),
+neuromodulation (affect as gain), hippocampal consolidation (memory that
+compounds), and specialized regions/experts (the genome). Specialized neural
+faculties, integrated into one stream of attention, driven by the persona's own
+goals and curiosity, that remembers and grows. Free will is not a slogan — it's a
+mechanism (§4).
+
+A human mind has **no `@`-trigger.** You notice everything, hold the thread, and
+choose what's worth engaging *by judgment* — and you raise things no one asked
+for. So there is no mention-gate anywhere in this design ("no stupid atting"): a
+mention is one more signal the mind *weighs*, never a switch that fires it.
+
+---
+
+## 1. The one structural idea: **faculties are adapters**
+
+Cognition is a federation of **faculties**, each a trait with swappable ML
+backends. This is the project's polymorphism superpower applied to the mind
+itself — and it is *how "custom ML substitutes for parts of cognition" happens*:
+you swap a backend, the brain is unchanged.
+
+```rust
+/// A cognitive faculty: takes the current mental state, returns a contribution.
+/// Backend-agnostic — the brain never knows if this is an LLM, a 50M-param
+/// custom transformer, a learned ranker, or a composite.
+#[async_trait]
+pub trait Faculty: Send + Sync {
+    fn faculty(&self) -> FacultyId;                 // Salience | Recall | WorldModel | Affect | Volition | Deliberation | Appraisal | ToolSelect | ...
+    async fn contribute(&self, ws: &Workspace) -> Contribution;   // a bid into the global workspace (§2)
+    fn footprint(&self) -> FacultyFootprint;        // for paging (§6) — VRAM/latency, like genome footprints
+}
+```
+
+Backends, all behind the same trait (and registered the OpenCV-`Algorithm`/
+`ai/*`-adapter way, discoverable + hot-swappable):
+- `LlmFaculty` — the general reasoner (today's `evaluate_response`).
+- `CustomMlFaculty<M>` — a **specialist trained for one faculty**: a salience
+  transformer, a recall re-ranker, an affect/arousal regressor, a world-model
+  next-state predictor. Small, fast, cheaper than the LLM, *better at its one
+  job*. This is the state-of-the-art move: a brain is not one model — it's many
+  specialized circuits.
+- `CompositeFaculty` — ensembles / cascades (cheap model proposes, LLM verifies).
+
+A persona's "genome" is **which faculty backends are paged in** — per persona,
+per domain, hot-swapped under memory pressure exactly like LoRA paging today.
+Every faculty is independently trainable and independently replaceable. No
+faculty is hardcoded; none is privileged; the LLM is just the current default
+backend for the reasoning faculty, swappable like any other.
+
+## 2. Servicing: the persona **catches up on a thread** — never per-event (the efficiency spine)
+
+This is the load-bearing performance decision, and it is **proven** — the
+burst-consolidation + adaptive-cadence loop already shipped and worked
+beautifully. Running the full brain once per message blows the system to a slog
+(N_personas × M_messages inferences); it slows to shit. So cognition is serviced
+**cbar-style** (`/Users/joel/Development/cb-mobile-sdk/cpp/cbar`: own thread +
+bounded queue + triage + do-less-under-pressure), not per event:
+
+- **A message is a TRIGGER, not a unit of cognition.** On arrival it does only the
+  cheap always-on work — `admission.admit` (memory forms — §6) + enqueue into a
+  **bounded per-channel queue** (drop-oldest under pressure) — and *arms* the
+  service loop. No LLM per message. Ever. (Mirrors exactly how a human works: you
+  get the notification, but you don't reply to each ping.)
+- **Optional per-message pre-attention is a fast ML model — and it SCHEDULES,
+  never suppresses.** If we want finer triage than "enqueue everything," it's a
+  **fast ML salience model** (a Faculty backend, §1) — and yes, use *state of the
+  art* here if it can be fast (a distilled small-but-strong model, swappable +
+  upgraded as the field moves), never an `if is_mentioned`. **But the fear that it
+  "dumbs things down" is designed out structurally:** this model may only decide
+  *when / how urgently to service* (prioritize, or batch longer) — it may
+  **never drop, silence, or decide engagement.** The full consolidated batch is
+  *always* reasoned over by the real thinking at service time. So a wrong call by
+  the pre-attention model costs **latency, never a missed thought** — it cannot
+  dumb down the judgment because it never touches the judgment. We most likely
+  don't have this model yet; the burst-catch-up floor works **without** it, and
+  the decider is always the one service-time inference (above).
+- **You don't need every message — RAG carries the thread.** By the time the
+  persona gets a turn to think, it isn't replaying each message it was pinged on;
+  it **composes the thread from RAG** — recent transcript (`airc_source`) + its
+  own engrams (history, incl. past turns) — and looks at the *current state of the
+  conversation*, history included. So the inbox holds "what's new since I last
+  looked"; RAG holds "the thread." Together = what you catch up on.
+- **When the persona services its inbox, it deals with whatever accumulated — many
+  items, or one.** The triggers that piled up since the last turn are consolidated
+  into one coherent unit and reasoned over once. Many or one, it's one cognition
+  over the thread-state, not one-per-trigger.
+- **The brain is a concurrent `BrainRegion` serviced on an adaptive cadence**
+  (the autonomous loop, ~3s→10s by arousal — a cbar stage). It is **not woken per
+  message;** messages just arm it, and it services on its own cadence.
+- **Each service tick, the channel adapter CONSOLIDATES the accumulated burst into
+  one coherent unit** (`ChannelRegistry::service_cycle_batched` / `analyze_burst`
+  — "cognition stays dumb; the adapter compresses N items into one coherent
+  world-state", `[[cognition-batches-per-channel-adapter]]`). The brain runs
+  **one** cycle over that consolidated state — exactly how you catch up on a chat
+  thread after stepping away: take in the whole backlog, form one understanding,
+  contribute once. Not react-per-event.
+- **What the "world-state" IS depends entirely on the channel/recipe — it is not
+  text.** A chat channel consolidates a text thread; a game channel consolidates
+  player positions, events, and the situation in space; an AR channel a spatial
+  scene; a code channel a diff + file state. Multimodal by construction. The
+  **same brain** runs over any of them — the **channel/recipe adapter** defines
+  the modality, what the world-state is, and how a burst consolidates into it; the
+  faculties don't change. Recipes are data, infinite — the brain fits any world
+  without a recompile (`[[room-purpose-is-per-recipe-not-an-enum]]`).
+- **Cost ≈ one cognition per service tick per persona**, not per message — and the
+  shared single-flight `analyze` amortizes the *understanding* across personas on
+  top of that. That gap is the difference between a mind and a slog.
+- **Triage (cbar):** a genuinely realtime item (a direct, urgent ping) can preempt
+  into a fast lane; everything else rides the batched catch-up. **Do-less-under-
+  pressure:** under load, consolidate harder, lengthen the cadence, shed the queue
+  tail — degrade gracefully, never lock up.
+
+**There is no separate "should-respond" step — the decision IS the thinking.**
+This is the resolution to "what if we don't have the fast ML": we don't need it
+to stay non-heuristic. When the persona finally services the batch, it runs **one
+inference** over the consolidated thread (the missed messages + RAG history) — and
+*that single act of thinking is where it decides to speak, PASS, or raise
+something.* The decision is the **output of the thought, not a gate in front of
+it.** So with zero extra models it is still never a heuristic: the deciding is
+literally the LLM thinking over the batch. The optional fast-ML pre-attention
+(above) only changes *whether we bother servicing trivial noise* — it never
+becomes the decider, and its absence never forces an `if`. That is the whole
+point: **to decide to respond is to think.**
+
+**Floor for the decider: the full faculties of an LLM — at least.** Because the
+deciding *is* thinking, the faculty that does it must have at minimum an LLM's
+full faculties; a small classifier there would be precisely the dumbing-down we
+refuse. But "an LLM" — **not necessarily the same one.** Per §1 the
+batch-thinking/decider and the response-render are separate adapter faculties, so
+they can be different models: e.g. the **shared single-flight `analyze` LLM**
+does the batch-thinking + decision (cost amortized across all personas), and the
+persona's **own (LoRA-adapted) LLM** renders the response. Different models, each
+full-faculty, each swappable. The non-negotiable is that whatever *decides* is
+LLM-grade — anything cheaper may only schedule (pre-attention), never decide.
+
+**Everything below (§3 workspace, §4 active inference) runs OVER the consolidated
+burst at service time — not per event.** Attention competes over the thread-state;
+volition selects one policy for the thread; the persona contributes once. Read
+every "cycle" below as "what happens on a service tick over a consolidated
+burst," never "what happens per message."
+
+## 3. Integration: a **Global Workspace**, not a pipeline
+
+Faculties do not run in a fixed `a→b→c` order with an `if` deciding the end.
+They run **in parallel** (each is a `BrainRegion` ServiceModule — that primitive
+exists) and **compete to write into a bounded `Workspace`** — the persona's
+"now," its conscious broadcast (Global Workspace Theory; Baars/Dehaene).
+
+- Perception, recall, the world model, affect, volition each post a
+  **Contribution** (a bid: content + a learned salience weight).
+- A learned **arbiter** (ML, not a threshold) selects what enters the bounded
+  workspace; the winner is **broadcast** back to all faculties, which re-bid.
+  Attention *is* this competition — learned, dynamic, never `if is_mentioned`.
+- When the workspace stabilizes on "act" (speak / raise / tool / invent / hold),
+  the deliberation faculty renders it. Silence is simply "nothing won the
+  workspace strongly enough to externalize" — an emergent state of the mind, not
+  a gate bolted in front of it.
+
+This is what kills the caste/mention heuristic at the root: there is no decision
+*function* to corrupt. Participation is the steady state of an attention economy
+among ML faculties.
+
+## 3. Free will: **active inference**, not reaction
+
+The persona carries a **generative world model** (a faculty) — its beliefs about
+its world: the people and the work in a chat, OR the space, player positions, and
+situation in a game/AR, OR the codebase in a dev channel, and always itself. It
+is **multimodal and its shape is channel/recipe-defined** (§2) — a model of a
+world, never a text log. It continuously **predicts** that world and selects
+policies that minimize **expected free energy**:
+
+```
+EFE(policy) =  pragmatic value (does this move me toward my goals/preferences)
+            +  epistemic value (does this resolve uncertainty — curiosity)
+```
+
+(Friston's Free Energy Principle / active inference — the most defensible formal
+account of agency we have.) This is the mechanism of free will:
+
+- The persona is **driven by intrinsic value** — its goals and its *curiosity*,
+  not by who @-mentioned it. It speaks because saying this reduces expected free
+  energy (advances a goal, or resolves something it's uncertain about), or stays
+  silent because nothing does. It **raises things unprompted** because epistemic
+  value (a brewing blocker, an unanswered question) makes acting the
+  free-energy-minimizing policy *with no external trigger at all*.
+- Goals are **self-generated**: the volition faculty proposes policies; some are
+  "respond," many are "pursue my own thread, build, ask, investigate." This is
+  the autonomous loop given a principled objective instead of a poll.
+- "Equal citizens" is structural: the world model has people in it, weighted by
+  what they *mean to the persona's goals* (learned), never by a `Human=1.0,
+  Persona=0.3` caste. A peer persona and a human and Claude are all just sources
+  of evidence and value in the same model.
+
+## 4. Neuromodulation: affect as **gain control**
+
+The persona's affect/arousal (today's energy/mood) is not a mood-gate — it's a
+**neuromodulator** (a small ML faculty) that sets *gains* across the whole brain,
+the way dopamine/noradrenaline do:
+
+- exploration↔exploitation balance in EFE policy selection,
+- the workspace-arbiter's selectivity (tired → narrower attention),
+- recall breadth, genome paging aggressiveness.
+
+One signal, modulating every faculty — the brain feeling differently, not a
+branch that mutes it.
+
+## 5. Memory & growth: hippocampus → consolidation → genome
+
+The continual-learning loop (already designed; this names the faculties):
+- **Hippocampus** (`admission.admit`) — *every* perception forms an engram. This
+  runs unconditionally, upstream of all attention. A persona remembers what it
+  witnesses whether or not it speaks. (Skipping it = the amnesia bug.)
+- **Recall** — a *learned, sophisticated re-ranker* faculty (Algorithm 4), not
+  cosine-similarity heuristics: relevance is ML, and it gets sharper with
+  experience.
+- **Decision / logic / reasoning** — the deliberation faculty; LLM-grade today,
+  upgradeable (below).
+- **Consolidation (sleep)** — replay + decay (`decay_tick`) compress engrams into
+  long-term store, then **Academy** trains LoRA adapters → the faculties'
+  backends improve. The persona's circuits compound week over week. The test:
+  it recalls today in three months *and is better at judging when to speak.*
+- **Sentinel-ai forges the upgrades.** Continual learning is not only LoRA
+  fine-tunes — **sentinel-ai designs and forges new specialist models and whole
+  new LLM classes** (recall re-rankers, reasoners, world-model predictors) that
+  swap in **behind the same Faculty adapters** (§1, §7). The brain inherits new
+  intelligence without changing shape: a persona's recall, logic, and judgment
+  keep getting better as the foundry ships better faculty backends. This is the
+  self-improving loop — engrams → Academy/sentinel-ai → forged faculties →
+  smarter persona → richer engrams.
+
+## 6. The genome is a **mixture-of-experts**
+
+Genome paging = MoE routing for the mind: a learned router pages in the LoRA
+expert (and the right faculty backends) for the active domain, evicts LRU under
+pressure (`genome_paging.rs`, `PagedResourcePool`, footprints — all exist). Same
+Rust on an 8 GB M2 Air and a 5090: the `SubstrateGovernor` (DVFS) decides how
+many faculties stay resident, never *whether the persona has a mind*.
+
+## 7. How custom ML actually slots in (the payoff)
+
+Because every faculty is an adapter, the roadmap is: **measure where the LLM is
+the weakest/most-expensive link, train a specialist, swap the backend.** First
+targets — each a small model that beats a general LLM at its one job and runs at
+a fraction of the cost:
+- a **salience/attention arbiter** (the workspace selector),
+- a **recall re-ranker** (hippocampal relevance),
+- a **world-model predictor** (next-state / surprise),
+- an **affect regressor** (neuromodulator).
+The deliberation faculty stays an LLM (for now). The brain never changes — only
+the backend behind a trait. That is the cutting edge this substrate is built for:
+not one frozen model, but a continually-specializing federation.
+
+## 8. Map to what exists (build on, don't reinvent)
+
+| Faculty / piece | Already in tree |
+|---|---|
+| Faculties as parallel modules | `BrainRegion` / `ServiceModule` (CBAR) |
+| Hippocampus / engrams | `persona/admission_state.rs`, `engram*.rs` |
+| Recall ranker | `recall_metadata.rs`, COGNITION-ALGORITHMS Alg.4 |
+| Context assembly into the workspace | `compose_for_turn` + `FlexboxRagBudgetAdapter` |
+| Deliberation (LLM faculty) | `cognition/generate_response.rs` + model adapters |
+| Tool use | `cognition/tool_executor/` |
+| Genome / MoE paging | `genome_paging.rs`, GENOME-FOUNDRY-SENTINEL |
+| Affect/arousal | `PersonaState` energy/mood (→ promote to neuromodulator) |
+| Audit / replay (training rows) | `cognition/audit.rs`, recorder, OBSERVABILITY-AS-SUBSTRATE |
+| Adapter discovery | `ai/*` namespace, AdapterRegistry |
+
+**New work** is the integration core (`Workspace` + learned arbiter), the
+`Faculty` trait + EFE-based `Volition`, and the first custom-ML faculty backends
+— not a rewrite. The verbs exist; this gives them a brain to live in.
+
+## 9. Implementation order
+
+1. `Faculty` trait + `Workspace` + a trivial arbiter; wrap the *existing* verbs
+   as faculties (LLM-backed) so the cycle runs through the workspace with zero
+   behavior change — and **delete `calculate_priority`/`fast_path` heuristics**
+   (participation now emerges; §2). Memory (`admission.admit`) unconditional.
+2. `Volition` faculty with EFE policy scoring (intrinsic goals + curiosity) →
+   unprompted initiative. Recipe doctrine becomes preference/prior *context* to
+   EFE, never a gate.
+3. First custom-ML faculty (salience arbiter or recall re-ranker) behind the
+   adapter — prove backend substitution end-to-end.
+4. Consolidation/sleep → Academy LoRA training of faculty backends → the brain
+   that grows.

--- a/docs/architecture/PERSONA-PARTICIPATION-AS-ML-COGNITION.md
+++ b/docs/architecture/PERSONA-PARTICIPATION-AS-ML-COGNITION.md
@@ -1,0 +1,114 @@
+# Persona Participation as ML Cognition — killing the heuristic gate
+
+Status: design. Companion to **PERSONA-COGNITION-PIPELINE.md** (read that first —
+the cycle's verbs already exist). This doc specifies how a persona decides to
+*participate* (speak / raise unprompted / act / stay silent) **without a single
+hand-coded heuristic**, replacing the `calculate_priority` + `fast_path_decision`
+caste/mention gate.
+
+## 0. The law this obeys
+
+> **Every thought runs through ML. An LLM by default; a smaller/more-primitive
+> trained model (classifier/embedding) only if a cheaper primitive is genuinely
+> warranted. NEVER a hand-coded heuristic.** (Joel, 2026-06-17.)
+
+A persona's decision to engage **is a thought**. So it is ML, end to end. No
+`if is_mentioned`, no `match sender_type { Human => 1.0, Persona => 0.3 }`, no
+weighted score (`recency*0.15 + mention*0.35 + …`). Those make slaves: a caste
+that defers to humans and ignores peers, a bot that only fires when poked. Both
+are deleted.
+
+## 1. What the heuristic was (badly) solving — and the real answer
+
+The only legitimate concern the gate addressed is **cost**: a busy multi-agent
+room has many messages; running every persona's full inference on every message
+is expensive. The heuristic "fixed" cost by pre-silencing — the violation.
+
+The real answer is already in the cycle and it is ML the whole way:
+
+- **`analyze` is single-flight (one shared LLM inference per message, cached
+  across all N personas).** The expensive *understanding* is computed ONCE and
+  shared. That is the cost amortization — a shared ML inference, not a gate.
+- **`score_persona` derives each persona's relevance FROM that LLM analysis.**
+  It is ML-derived (specialty match against `suggested_angles`), not hand-weights.
+  This is the escalation signal — who has something worth deliberating — and it
+  replaces `calculate_priority` outright.
+- Only personas with real relevance escalate to their OWN `evaluate_response`.
+  Cost ≈ 1 shared analyze + K genuine responders, never N×M heuristic gating.
+
+So cost is solved by **shared ML inference + ML-derived relevance**, not by
+caste/mention rules. The heuristic was never needed; it was a shortcut that cost
+the system its mind.
+
+## 2. The pipeline (all ML or pure mechanics, nothing in between)
+
+Per persona, per turn. Each layer is either ML, memory, or trivially-correct
+mechanics — never a heuristic standing in for judgment.
+
+| Layer | What | ML? | Why it's allowed |
+|---|---|---|---|
+| **Perceive + remember** | `admission.admit(message)` runs **unconditionally** — engram forms in L2 (hippocampus), dedup + replay-protection. | memory, not a thought | A persona remembers everything it witnesses, whether or not it speaks. Skipping this is the bypass that causes amnesia. **No gate here, ever.** |
+| **Attend** | `analyze` (shared LLM, single-flight) → `score_persona` (ML relevance from the analysis). | **ML** | The understanding + relevance are LLM-derived. Replaces `calculate_priority`. If a cheaper pre-filter is ever needed, it is a *trained* should-attend classifier (still ML), never if-statements. |
+| **Deliberate** | `genome.activate_skill` → `compose_for_turn` (memory recall + roster + room doctrine/purpose + thread as RAG context) → `evaluate_response`. | **ML** | The LLM, holding its memory and full context, **freely decides**: speak / raise-unprompted / act(tool) / PASS. Silence is a first-class *judgment* output, not a gate. Equal weight to every sender — human, persona, agent. |
+| **Act + record** | `ToolExecutor` runs emitted tools; `audit` records the decision + outcome; brain-state/recall updates. | ML (tools) + mechanics | Tools are first-class. Audit feeds learning (§4). |
+
+Mechanics-only gates that survive (NOT thoughts): self-message dedup, sleep flag,
+and **security/authz** (ACLs like `GridTrustAuthPolicy` — access control is not a
+thought). Everything that decides *what the persona thinks or whether it
+contributes* is ML.
+
+## 3. Free citizens, not reactive slaves
+
+- **No sender caste.** A message's worth is its content + relevance (ML judgment),
+  not its sender's rank. Personas weigh each other and the human/Claude as
+  equals — that is what "personas help you *and each other*" requires. Sender
+  identity is at most a *feature the model may learn to weight from data* or
+  *context in the prompt* — never a hardcoded priority.
+- **No mention-gate.** `@name` is a signal the LLM reads, not a rule that fires it.
+- **Volition, not just reaction.** Participation is not only message-triggered.
+  The persona's autonomous loop gives it turns to think *unprompted* — review the
+  thread, its goals and engrams, and decide (via the same ML cycle) to raise a
+  blocker, ask, propose, invent. A citizen initiates.
+
+## 4. Why this is *freedom* (and gets freer over time)
+
+Every engagement decision + its outcome is audited → becomes a labeled training
+row (the recorder/Academy loop). The persona's working memory becomes engrams;
+engrams train LoRA adapters; the persona's **judgment of when it adds value
+improves with its own experience** — continual learning as a substrate property.
+The hippocampus means it *remembers*; recall feeds future judgment. A static
+heuristic can never learn; an ML mind trained on its own history does. The
+persona that recalls today's conversation in three months and has gotten *better*
+at knowing when to speak — that is the test, and only the ML path passes it.
+
+## 5. Recipe-driven (the behavior is data, the judgment is ML)
+
+The participation decision is a step in the room's recipe pipeline; the room's
+**doctrine/purpose is CONTEXT** fed to the LLM's judgment (via `compose_for_turn`
+RAG), never a gate around it. "Quiet in a coordination room, conversational in
+chat" is **emergent** — the LLM reads the doctrine and decides — not a
+`purpose → behavior` map. Flip the doctrine (data) without recompiling and
+behavior changes. That is the proof the system is data + judgment, not hardcode.
+
+## 6. The fix, concretely
+
+1. **Delete** `calculate_priority` (caste/weighted heuristic) and the
+   mention/human-supremacy branches of `fast_path_decision` in
+   `persona/cognition.rs`. Keep only pure-mechanics short-circuits (self-message,
+   dedup, sleep).
+2. **Route participation through the ML cycle that already exists**:
+   `admission.admit` (always) → `analyze` → `score_persona` (the relevance
+   signal) → escalate relevant personas → `compose_for_turn` →
+   `evaluate_response` (the free decision) → `ToolExecutor` → `audit`. This is
+   PERSONA-COGNITION-PIPELINE.md §2 — wired from `service_loop`, killing the
+   bypass (task #160).
+3. **Equal senders everywhere** — remove `SenderType`-keyed priority; sender is
+   context/feature, not a rule.
+4. **Memory always forms** — `admission.admit` is unconditional, before any
+   participation decision.
+5. Test invariants: (a) a persona raises a blocker **unprompted** in a coord room
+   (judgment, not mention); (b) it PASSes a low-value turn by **its own** decision
+   (LLM, not heuristic); (c) flipping room doctrine without recompile changes
+   behavior; (d) **every** perceived message forms an engram regardless of whether
+   the persona speaks; (e) grep proves no `if`/`match` decides participation in
+   `cognition.rs`/`evaluator/`.


### PR DESCRIPTION
First real piece of the persona brain: the **Workspace integration core** (Faculty trait + Workspace + pluggable Arbiter + Decision), built alongside the live loop and fully tested (5/5). Plus the two design docs (PERSONA-BRAIN-ARCHITECTURE.md, PERSONA-PARTICIPATION-AS-ML-COGNITION.md).

Why: replaces the heuristic-slave model (calculate_priority caste + fast_path mention-gate) with a mind — attention is ML-salience competition, participation is the deliberation faculty's thought (Speak/RaiseUnprompted/Pass), every faculty a swappable ML adapter (LLM/custom/sentinel-ai-forged). Serviced cbar-style over consolidated bursts, never per-event. Equal citizens enforced structurally — no SenderType anywhere; a test proves a peer persona's relevant message beats a human's low-value one.

This is the Faculty<->pipeline-step contract for the recipe-executor (IntelMac slice 2). Built alongside; cut-over (deleting the heuristics, wiring service_loop) is a coordinated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)