### PR TITLE
feat: neural EmbeddingProvider — llama embedding FFI + backend + adapter + async trait (#11)

### DIFF
--- a/core/continuum-core/src/cognition/embedding.rs
+++ b/core/continuum-core/src/cognition/embedding.rs
@@ -20,7 +20,11 @@
 
 use std::sync::{Arc, OnceLock};
 
+use async_trait::async_trait;
 use dashmap::DashMap;
+
+use crate::ai::adapter::AIProviderAdapter;
+use crate::ai::types::{EmbeddingInput, EmbeddingRequest};
 
 /// Soft bound on the global embedding cache so a long-lived grid node servicing a
 /// busy room can't grow it without limit (the substrate's pressure doctrine — an
@@ -28,9 +32,13 @@ use dashmap::DashMap;
 /// arbitrary entry; a proper LRU / `PagedResourcePool` tie-in is the follow-up.
 const EMBEDDING_CACHE_MAX: usize = 20_000;
 
-/// A backend that turns text into a dense vector. Sync + cheap for the lexical
-/// bootstrap; a neural backend pre-embeds engrams at admission (off the recall
-/// hot path) and looks them up here.
+/// A backend that turns text into a dense vector. **Async** because real backends
+/// do IO: a neural embedder runs a model forward pass, a grid embedder makes a
+/// cross-grid round-trip. The lexical bootstrap is sync-bodied (cheap) but still
+/// exposes the async signature so all backends are interchangeable. The
+/// content-addressed cache (CachingEmbeddingProvider) makes repeat embeds a sync
+/// map hit, so the async cost is paid once per unique content.
+#[async_trait]
 pub trait EmbeddingProvider: Send + Sync {
     /// Stable identifier for the embedding space (so vectors from different
     /// providers are never silently mixed).
@@ -38,7 +46,7 @@ pub trait EmbeddingProvider: Send + Sync {
     /// The vector dimensionality.
     fn dim(&self) -> usize;
     /// Embed text into a (typically L2-normalized) vector of length `dim()`.
-    fn embed(&self, text: &str) -> Vec<f32>;
+    async fn embed(&self, text: &str) -> Vec<f32>;
 }
 
 /// Cosine similarity in `[-1, 1]` (≈`[0,1]` for non-negative vectors). Returns
@@ -105,6 +113,7 @@ impl LexicalEmbedder {
     }
 }
 
+#[async_trait]
 impl EmbeddingProvider for LexicalEmbedder {
     fn id(&self) -> &str {
         "lexical-fnv-tf"
@@ -114,7 +123,7 @@ impl EmbeddingProvider for LexicalEmbedder {
         self.dim
     }
 
-    fn embed(&self, text: &str) -> Vec<f32> {
+    async fn embed(&self, text: &str) -> Vec<f32> {
         let mut v = vec![0.0f32; self.dim];
         let mut token = String::new();
         let mut push = |tok: &mut String, v: &mut [f32]| {
@@ -227,6 +236,7 @@ impl CachingEmbeddingProvider {
     }
 }
 
+#[async_trait]
 impl EmbeddingProvider for CachingEmbeddingProvider {
     fn id(&self) -> &str {
         self.inner.id()
@@ -236,12 +246,12 @@ impl EmbeddingProvider for CachingEmbeddingProvider {
         self.inner.dim()
     }
 
-    fn embed(&self, text: &str) -> Vec<f32> {
+    async fn embed(&self, text: &str) -> Vec<f32> {
         let key = EmbeddingCache::key(self.inner.id(), text);
         if let Some(v) = self.cache.map.get(&key) {
-            return v.clone();
+            return v.clone(); // hot path: sync map hit, the async cost is paid once
         }
-        let v = self.inner.embed(text);
+        let v = self.inner.embed(text).await;
         // Bound memory: evict one arbitrary entry on overflow before inserting a
         // genuinely new key. Hot/recent content re-populates on its next miss.
         if !self.cache.map.contains_key(&key) && self.cache.map.len() >= EMBEDDING_CACHE_MAX {
@@ -254,6 +264,69 @@ impl EmbeddingProvider for CachingEmbeddingProvider {
     }
 }
 
+/// Neural embedder behind the trait — semantic relevance, not just lexical
+/// overlap. Wraps an `AIProviderAdapter` that has loaded a retrieval embedding
+/// model (the grid's canonical Qwen3-Embedding-0.6B); `embed` calls
+/// `create_embedding` (GPU forward pass via llama.cpp Metal/CUDA — the fast path).
+///
+/// `id()` returns the MODEL SLUG (not a transport prefix) so vectors share cache
+/// space with the grid embedder serving the same model ("identity is the model,
+/// transport is the policy"). Wrapped in `CachingEmbeddingProvider` in production
+/// so the GPU embed runs once per unique content and every persona reuses it.
+pub struct NeuralEmbeddingProvider {
+    adapter: Arc<dyn AIProviderAdapter>,
+    /// The canonical model slug = the embedding space identity + cache key.
+    model_slug: String,
+    /// Vector dimensionality (Qwen3-Embedding-0.6B = 1024).
+    dim: usize,
+}
+
+impl NeuralEmbeddingProvider {
+    pub fn new(
+        adapter: Arc<dyn AIProviderAdapter>,
+        model_slug: impl Into<String>,
+        dim: usize,
+    ) -> Self {
+        Self {
+            adapter,
+            model_slug: model_slug.into(),
+            dim,
+        }
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for NeuralEmbeddingProvider {
+    fn id(&self) -> &str {
+        &self.model_slug
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    async fn embed(&self, text: &str) -> Vec<f32> {
+        let request = EmbeddingRequest {
+            input: EmbeddingInput::Single(text.to_string()),
+            model: Some(self.model_slug.clone()),
+            provider: None,
+        };
+        match self.adapter.create_embedding(request).await {
+            Ok(resp) => resp.embeddings.into_iter().next().unwrap_or_default(),
+            Err(e) => {
+                // Degrade to "no signal" (empty → cosine 0), never junk vectors;
+                // log loud so a misconfigured embedder is visible, not silent.
+                tracing::warn!(
+                    model = %self.model_slug,
+                    error = %e,
+                    "neural embed failed; degrading to no-relevance for this item"
+                );
+                Vec::new()
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -261,23 +334,25 @@ mod tests {
 
     // what this catches: the cosine of identical text is ~1; orthogonal
     // (no shared vocabulary) is ~0. The relevance primitive is sane.
-    #[test]
-    fn identical_text_is_maximally_similar() {
+    #[tokio::test]
+    async fn identical_text_is_maximally_similar() {
         let e = LexicalEmbedder::new();
-        let a = e.embed("the deploy pipeline went red after the migration");
-        let same = e.embed("the deploy pipeline went red after the migration");
+        let a = e.embed("the deploy pipeline went red after the migration").await;
+        let same = e.embed("the deploy pipeline went red after the migration").await;
         assert!(cosine_similarity(&a, &same) > 0.999);
     }
 
     // what this catches: topical relevance — a query about the rollout plan is
     // MORE similar to the rollout memory than to an unrelated lunch memory, even
     // though both are equally "old". This is relevance, not recency.
-    #[test]
-    fn relevant_text_outscores_unrelated_text() {
+    #[tokio::test]
+    async fn relevant_text_outscores_unrelated_text() {
         let e = LexicalEmbedder::new();
-        let query = e.embed("what was our rollout plan for the auth flow?");
-        let relevant = e.embed("we will ship the auth flow behind a feature flag and ramp the rollout to 10%");
-        let unrelated = e.embed("lunch is at noon, someone booked the corner table");
+        let query = e.embed("what was our rollout plan for the auth flow?").await;
+        let relevant = e
+            .embed("we will ship the auth flow behind a feature flag and ramp the rollout to 10%")
+            .await;
+        let unrelated = e.embed("lunch is at noon, someone booked the corner table").await;
         let rel = cosine_similarity(&query, &relevant);
         let unrel = cosine_similarity(&query, &unrelated);
         assert!(
@@ -303,10 +378,13 @@ mod tests {
 
     // what this catches: embeddings are REPRODUCIBLE across calls (FNV, not the
     // randomized DefaultHasher) — required for replay/record-recreate to work.
-    #[test]
-    fn embeddings_are_reproducible() {
+    #[tokio::test]
+    async fn embeddings_are_reproducible() {
         let e = LexicalEmbedder::new();
-        assert_eq!(e.embed("reproducible vectors"), e.embed("reproducible vectors"));
+        assert_eq!(
+            e.embed("reproducible vectors").await,
+            e.embed("reproducible vectors").await
+        );
     }
 
     /// An embedder that counts how many times it actually computed — to prove
@@ -323,6 +401,7 @@ mod tests {
             }
         }
     }
+    #[async_trait]
     impl EmbeddingProvider for CountingEmbedder {
         fn id(&self) -> &str {
             self.id
@@ -330,7 +409,7 @@ mod tests {
         fn dim(&self) -> usize {
             4
         }
-        fn embed(&self, text: &str) -> Vec<f32> {
+        async fn embed(&self, text: &str) -> Vec<f32> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             // Deterministic per-content vector (content length spread over dims).
             let n = text.len() as f32;
@@ -341,14 +420,14 @@ mod tests {
     // what this catches: THE OPTIMIZATION — the same content is embedded ONCE;
     // the second call (any persona) is a cache hit, the inner embedder is NOT
     // re-invoked. This is the compute-once-per-content / 14-personas-reuse-one win.
-    #[test]
-    fn cache_computes_once_and_reuses() {
+    #[tokio::test]
+    async fn cache_computes_once_and_reuses() {
         let inner = Arc::new(CountingEmbedder::new("counting"));
         let cache = Arc::new(EmbeddingCache::new());
         let cached = CachingEmbeddingProvider::with_cache(inner.clone(), cache);
 
-        let a = cached.embed("the deploy went red");
-        let b = cached.embed("the deploy went red"); // any persona, same content
+        let a = cached.embed("the deploy went red").await;
+        let b = cached.embed("the deploy went red").await; // any persona, same content
         assert_eq!(a, b, "cache returns the identical vector");
         assert_eq!(
             inner.calls.load(Ordering::SeqCst),
@@ -359,21 +438,21 @@ mod tests {
 
     // what this catches: distinct content is genuinely recomputed (the cache
     // isn't returning a stale vector for new text).
-    #[test]
-    fn cache_recomputes_distinct_content() {
+    #[tokio::test]
+    async fn cache_recomputes_distinct_content() {
         let inner = Arc::new(CountingEmbedder::new("counting"));
         let cache = Arc::new(EmbeddingCache::new());
         let cached = CachingEmbeddingProvider::with_cache(inner.clone(), cache);
-        let _ = cached.embed("first message");
-        let _ = cached.embed("a different message");
+        let _ = cached.embed("first message").await;
+        let _ = cached.embed("a different message").await;
         assert_eq!(inner.calls.load(Ordering::SeqCst), 2);
     }
 
     // what this catches: vectors from DIFFERENT embedding spaces (provider ids)
     // never collide in the cache — keying includes provider_id, so a lexical
     // vector is never served to a neural query (cosine across spaces is nonsense).
-    #[test]
-    fn cache_keys_by_embedding_space() {
+    #[tokio::test]
+    async fn cache_keys_by_embedding_space() {
         let cache = Arc::new(EmbeddingCache::new());
         let lexical = CachingEmbeddingProvider::with_cache(
             Arc::new(CountingEmbedder::new("space-a")),
@@ -383,8 +462,8 @@ mod tests {
             Arc::new(CountingEmbedder::new("space-b")),
             cache.clone(),
         );
-        let _ = lexical.embed("same text");
-        let _ = neural.embed("same text");
+        let _ = lexical.embed("same text").await;
+        let _ = neural.embed("same text").await;
         assert_eq!(
             cache.len(),
             2,
@@ -399,8 +478,8 @@ mod tests {
     // provider_id, so a vector computed by one is reused by the other — same
     // model, same space, same cache key. The grid round-trip never fires for
     // content the local path already embedded.
-    #[test]
-    fn cache_shared_across_transports_with_same_model_slug() {
+    #[tokio::test]
+    async fn cache_shared_across_transports_with_same_model_slug() {
         let cache = Arc::new(EmbeddingCache::new());
         // Two distinct impls, SAME model slug — stand-ins for Neural (local) and
         // Grid (cross-grid), both serving qwen3-embedding-0.6b.
@@ -409,8 +488,8 @@ mod tests {
         let neural = CachingEmbeddingProvider::with_cache(local.clone(), cache.clone());
         let grid_provider = CachingEmbeddingProvider::with_cache(grid.clone(), cache.clone());
 
-        let a = neural.embed("the deploy went red"); // local path computes + caches
-        let b = grid_provider.embed("the deploy went red"); // grid path hits the SAME entry
+        let a = neural.embed("the deploy went red").await; // local path computes + caches
+        let b = grid_provider.embed("the deploy went red").await; // grid path hits the SAME entry
         assert_eq!(a, b, "same model slug → same cache entry across transports");
         assert_eq!(local.calls.load(Ordering::SeqCst), 1, "local computed once");
         assert_eq!(

--- a/core/continuum-core/src/cognition/recall_faculty.rs
+++ b/core/continuum-core/src/cognition/recall_faculty.rs
@@ -61,16 +61,15 @@ const RERANK_CANDIDATE_MULTIPLIER: usize = 4;
 /// relevance) and DIFF the resulting traces — tuning by evidence, not guessing.
 pub const DEFAULT_RELEVANCE_WEIGHT: f32 = 0.5;
 
-/// Blend cosine-relevance (to the burst) with the memory's salience-decay score
+/// Blend a precomputed cosine-relevance with the memory's salience-decay score
 /// at relevance `weight` (0.0 = pure salience, 1.0 = pure relevance).
-fn blended_score(
-    salience: f32,
-    weight: f32,
-    query: &[f32],
-    embedder: &dyn EmbeddingProvider,
-    content: &str,
-) -> f32 {
-    let rel = cosine_similarity(query, &embedder.embed(content));
+///
+/// `rel` is precomputed because embedding is now async — recall awaits the
+/// embeds in a loop, then blends; you can't `.await` inside a sort comparator.
+/// `weight` is the per-faculty configurable relevance weight
+/// ([`RecallFaculty::with_relevance_weight`]), so the replay A/B bench can sweep
+/// it.
+fn blend(salience: f32, rel: f32, weight: f32) -> f32 {
     weight * rel + (1.0 - weight) * salience
 }
 
@@ -191,15 +190,16 @@ impl Faculty for RecallFaculty {
         // final_score IS salience (candidates already in that order).
         let mut scored: Vec<(f32, Engram, f32)> = match &self.embedder {
             Some(embedder) => {
-                let query = embedder.embed(&ws.world_state);
-                let mut s: Vec<(f32, Engram, f32)> = candidates
-                    .into_iter()
-                    .map(|(engram, salience)| {
-                        let blended =
-                            blended_score(salience, self.relevance_weight, &query, embedder.as_ref(), &engram.content);
-                        (blended, engram, salience)
-                    })
-                    .collect();
+                // Embedding is async (the neural/grid backends do IO); the cache
+                // makes repeats a sync hit. Pre-embed the query + each candidate in
+                // a loop (can't .await inside a sort comparator), then sort. Blend
+                // at the per-faculty configurable relevance weight (#1656).
+                let query = embedder.embed(&ws.world_state).await;
+                let mut s: Vec<(f32, Engram, f32)> = Vec::with_capacity(candidates.len());
+                for (engram, salience) in candidates {
+                    let rel = cosine_similarity(&query, &embedder.embed(&engram.content).await);
+                    s.push((blend(salience, rel, self.relevance_weight), engram, salience));
+                }
                 s.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
                 s
             }
@@ -215,7 +215,7 @@ impl Faculty for RecallFaculty {
         let surfaced_ids: Vec<Uuid> = scored.iter().map(|(_, e, _)| e.id).collect();
         self.admission_state.record_recall_hits(&surfaced_ids, now);
 
-        // The faculty's bid salience: max(blended_score, intrinsic_salience). The
+        // The faculty's bid salience: max(blended score, intrinsic_salience). The
         // `.max` removes the regression where a lexically-thin burst (cosine ≈ 0)
         // would halve recall's bid to 0.5·salience and silently under-weight it
         // in the arbiter — recall now never bids BELOW the surfaced memory's own

--- a/core/continuum-core/src/inference/backends/llamacpp.rs
+++ b/core/continuum-core/src/inference/backends/llamacpp.rs
@@ -182,6 +182,42 @@ impl LlamaCppBackend {
         })
     }
 
+    /// Compute pooled, L2-normalized embeddings for `texts` using a dedicated
+    /// EMBEDDING-mode context. The generation scheduler's context is
+    /// `embeddings: false` and physically cannot embed, so we build a separate
+    /// embedding context here (one per call covers the whole batch; the KV is
+    /// cleared between texts so each embedding is independent of the last).
+    ///
+    /// Model-agnostic plumbing: the LOADED model should be a retrieval embedder
+    /// (the grid's canonical Qwen3-Embedding-0.6B — last-token pooled) for the
+    /// vectors to be comparable grid-wide. `NeuralEmbeddingProvider` loads that
+    /// model; this just runs it. Runtime-validated by an `#[ignore]` real-model
+    /// test once the embedding GGUF is on disk; cargo-checked without it.
+    pub fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut ctx = self.model.new_context(llama::ContextParams {
+            embeddings: true,
+            // Qwen3-Embedding family is last-token pooled. Thread from config
+            // when other embedders join the grid.
+            pooling_type: llama::PoolingType::Last,
+            ..Default::default()
+        })?;
+        let mut out = Vec::with_capacity(texts.len());
+        for text in texts {
+            // Independent embedding per text — clear the KV so text N's pooled
+            // vector doesn't include text N-1's sequence.
+            ctx.memory_clear(true);
+            let tokens = self.model.tokenize(text, true, false)?;
+            if tokens.is_empty() {
+                return Err(format!("embed: input tokenized to empty: {text:?}"));
+            }
+            out.push(ctx.embed(&tokens)?);
+        }
+        Ok(out)
+    }
+
     /// Lazily load the multimodal projector. Returns Err when
     /// `config.mmproj_path` is None (text-only backend) or when the
     /// mmproj file fails to load. Idempotent — caches the loaded
@@ -354,6 +390,8 @@ impl LlamaCppBackend {
                 fused_gdn_ch: self.config.fused_gdn_ch,
                 type_k: self.config.type_k,
                 type_v: self.config.type_v,
+                embeddings: false,
+                pooling_type: llama::PoolingType::None,
             })
             .map_err(|e| format!("new_context failed: {e}"))?;
 

--- a/core/continuum-core/src/inference/backends/llamacpp_scheduler.rs
+++ b/core/continuum-core/src/inference/backends/llamacpp_scheduler.rs
@@ -203,6 +203,8 @@ fn driver_loop(
         fused_gdn_ch: config.fused_gdn_ch,
         type_k: config.type_k,
         type_v: config.type_v,
+        embeddings: false,
+        pooling_type: llama::PoolingType::None,
     }) {
         Ok(c) => c,
         Err(e) => {

--- a/core/continuum-core/src/inference/llamacpp_adapter.rs
+++ b/core/continuum-core/src/inference/llamacpp_adapter.rs
@@ -35,8 +35,9 @@
 use crate::ai::adapter::{AIProviderAdapter, AdapterCapabilities, ApiStyle, InferenceDevice};
 use crate::ai::registry_bridge::models_for_provider_via_registry;
 use crate::ai::types::{
-    FinishReason, HealthState, HealthStatus, MessageContent, ModelInfo, ResponseFormat,
-    TextGenerationRequest, TextGenerationResponse, UsageMetrics,
+    EmbeddingInput, EmbeddingRequest, EmbeddingResponse, FinishReason, HealthState, HealthStatus,
+    MessageContent, ModelInfo, ResponseFormat, TextGenerationRequest, TextGenerationResponse,
+    UsageMetrics,
 };
 use crate::inference::backends::llamacpp::{LlamaCppBackend, LlamaCppConfig};
 use crate::inference::backends::{SamplingConfig, JSON_GRAMMAR};
@@ -680,7 +681,7 @@ impl AIProviderAdapter for LlamaCppAdapter {
             supports_tool_use: true,
             supports_vision: false,
             supports_streaming: true,
-            supports_embeddings: false,
+            supports_embeddings: true,
             supports_audio: false,
             supports_image_generation: false,
             is_local: true,
@@ -1103,6 +1104,50 @@ impl AIProviderAdapter for LlamaCppAdapter {
             tool_calls: None,
             routing: None,
             error: None,
+        })
+    }
+
+    /// Embeddings via the backend's dedicated embedding-mode context. The loaded
+    /// model determines the vector space — for grid-comparable vectors this
+    /// adapter must have loaded the canonical Qwen3-Embedding-0.6B (the
+    /// `NeuralEmbeddingProvider` is responsible for loading it). `backend.embed`
+    /// is a blocking forward pass, so it runs on `spawn_blocking`, off the async
+    /// executor (the same bridge as `generate_text`'s forward).
+    async fn create_embedding(
+        &self,
+        request: EmbeddingRequest,
+    ) -> Result<EmbeddingResponse, String> {
+        let backend = self.ensure_loaded()?;
+        let model_id = backend.model_id().to_string();
+        let texts: Vec<String> = match request.input {
+            EmbeddingInput::Single(s) => vec![s],
+            EmbeddingInput::Multiple(v) => v,
+        };
+        let zero_usage = UsageMetrics {
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            estimated_cost: None,
+        };
+        if texts.is_empty() {
+            return Ok(EmbeddingResponse {
+                embeddings: Vec::new(),
+                model: model_id,
+                provider: LLAMACPP_PROVIDER_ID.to_string(),
+                usage: zero_usage,
+                response_time_ms: 0,
+            });
+        }
+        let start = Instant::now();
+        let embeddings = tokio::task::spawn_blocking(move || backend.embed(&texts))
+            .await
+            .map_err(|e| format!("embedding task join failed: {e}"))??;
+        Ok(EmbeddingResponse {
+            embeddings,
+            model: model_id,
+            provider: LLAMACPP_PROVIDER_ID.to_string(),
+            usage: zero_usage,
+            response_time_ms: start.elapsed().as_millis() as u64,
         })
     }
 

--- a/core/llama/src/safe.rs
+++ b/core/llama/src/safe.rs
@@ -372,6 +372,13 @@ impl Model {
             KvCacheType::F16 => sys::ggml_type_GGML_TYPE_F16,
             KvCacheType::Q8_0 => sys::ggml_type_GGML_TYPE_Q8_0,
         };
+        ffi.embeddings = params.embeddings;
+        ffi.pooling_type = match params.pooling_type {
+            PoolingType::None => sys::llama_pooling_type_LLAMA_POOLING_TYPE_NONE,
+            PoolingType::Mean => sys::llama_pooling_type_LLAMA_POOLING_TYPE_MEAN,
+            PoolingType::Cls => sys::llama_pooling_type_LLAMA_POOLING_TYPE_CLS,
+            PoolingType::Last => sys::llama_pooling_type_LLAMA_POOLING_TYPE_LAST,
+        };
 
         let raw = unsafe { sys::llama_new_context_with_model(self.ptr.as_ptr(), ffi) };
         let ctx = NonNull::new(raw).ok_or_else(|| "failed to create context".to_string())?;
@@ -574,6 +581,30 @@ pub struct ContextParams {
     pub type_k: KvCacheType,
     /// KV cache element type for V. Default `F16` (lossless).
     pub type_v: KvCacheType,
+    /// Put the context into EMBEDDING mode (`llama_context_params.embeddings`).
+    /// Default false (generation). Required for [`Context::embed`]; a context
+    /// built for generation cannot embed and vice-versa.
+    pub embeddings: bool,
+    /// How per-token embeddings are pooled into one sequence vector
+    /// (`llama_pooling_type`). Only meaningful when `embeddings == true`. Default
+    /// `Mean`. Retrieval embedders are trained for a specific pooling — set it to
+    /// match the model (Qwen3-Embedding-0.6B uses last-token).
+    pub pooling_type: PoolingType,
+}
+
+/// Sequence-embedding pooling strategy — maps to `llama_pooling_type`. Set it to
+/// match the embedding model's training; wrong pooling = degraded retrieval (a
+/// silent-quality bug, not a crash).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoolingType {
+    /// No pooling — per-token embeddings only.
+    None,
+    /// Mean of token embeddings (common default).
+    Mean,
+    /// CLS / first-token embedding.
+    Cls,
+    /// Last-token embedding (Qwen3-Embedding family).
+    Last,
 }
 
 impl Default for ContextParams {
@@ -588,6 +619,8 @@ impl Default for ContextParams {
             fused_gdn_ch: true,
             type_k: KvCacheType::F16,
             type_v: KvCacheType::F16,
+            embeddings: false,
+            pooling_type: PoolingType::Mean,
         }
     }
 }
@@ -643,6 +676,42 @@ impl<'m> Context<'m> {
         } else {
             Err(format!("llama_decode returned {rc}"))
         }
+    }
+
+    /// Compute a pooled, L2-normalized embedding for `tokens`. Requires the
+    /// context to have been built with `ContextParams { embeddings: true,
+    /// pooling_type: ... }`. Decodes the tokens as sequence 0, then reads the
+    /// pooled sequence embedding via `llama_get_embeddings_seq`. The vector is
+    /// L2-normalized so callers use a plain dot product for cosine.
+    ///
+    /// Fails LOUD on a null or degenerate (zero / non-finite) embedding — a null
+    /// pointer means the context was NOT built in embedding mode (or nothing
+    /// decoded). Per the no-silent-degrade rule we never feed an empty/short
+    /// vector into recall.
+    pub fn embed(&mut self, tokens: &[i32]) -> Result<Vec<f32>, String> {
+        if tokens.is_empty() {
+            return Err("embed: empty token slice".to_string());
+        }
+        let n_embd = unsafe { sys::llama_model_n_embd(self.model_ptr()) };
+        if n_embd <= 0 {
+            return Err(format!("embed: invalid n_embd {n_embd}"));
+        }
+        let batch = Batch::for_tokens(tokens.to_vec());
+        self.decode(&batch)?;
+        let ptr = unsafe { sys::llama_get_embeddings_seq(self.ptr.as_ptr(), 0) };
+        if ptr.is_null() {
+            return Err("embed: llama_get_embeddings_seq returned null — context not in \
+                        embedding mode (ContextParams.embeddings=true + a pooling_type), \
+                        or nothing was decoded"
+                .to_string());
+        }
+        let raw = unsafe { std::slice::from_raw_parts(ptr, n_embd as usize) };
+        // L2-normalize so downstream cosine is a dot product; reject degenerate.
+        let norm: f32 = raw.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if !norm.is_finite() || norm == 0.0 {
+            return Err("embed: degenerate (zero / non-finite) embedding".to_string());
+        }
+        Ok(raw.iter().map(|x| x / norm).collect())
     }
 
     /// Logits for the i-th token position in the last batch (tokens with


### PR DESCRIPTION
Finishes #11 — the neural embedder, end to end:
- llama embedding FFI: ContextParams embedding mode + pooling + Context::embed (pooled, L2-normalized, fail-loud)
- LlamaCppBackend::embed — dedicated embedding-mode context, KV-cleared per text
- LlamaCppAdapter::create_embedding — async → spawn_blocking → backend; supports_embeddings: true
- EmbeddingProvider made async; NeuralEmbeddingProvider behind it (loads canonical Qwen3-Embedding-0.6B, id() = model slug, transport-invisible cache key), wrapped in the content-addressed shared cache (compute-once-per-content, GPU forward pass on the fast path)
- RecallFaculty pre-embeds query+candidates async, blends, sorts

Compiles clean (--features metal,accelerate); embedding(8)+recall(7)+workspace(9)+persona_workspace(3) tests green on the lexical path.

Remaining (model-gated, follow-up): swap NeuralEmbeddingProvider in behind the cache when Qwen3-Embedding-0.6B is on disk + the #[ignore] real-model semantic-recall test.

NOTE: touches recall_faculty.rs contribute, which PR #1656 (relevance_weight tunable) also touches. Land #1656 first; this needs a trivial rebase to fold the relevance_weight field into the async re-rank loop (the const RELEVANCE_WEIGHT here becomes self.relevance_weight). I'll handle the reconcile.