### PR TITLE
feat: headless core + client topology (root=server, apps/* clients)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@continuum/desktop",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Native desktop shell for Continuum (Tauri) — system tray, OS notifications, window management, local hotkeys. A thin embodiment that wraps the apps/web UI over the headless Rust core; it does NOT host substrate logic. Sits next to apps/web; one of many equal clients. Replaces the transitional src/server-index.ts Electron-ish crutch.",
+  "type": "module",
+  "scripts": {
+    "dev": "tauri dev",
+    "build": "tauri build",
+    "tauri": "tauri"
+  },
+  "dependencies": {
+    "@continuum/sdk-typescript": "*",
+    "@tauri-apps/api": "^2.0.0"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^2.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@continuum/web",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Thin browser UI shell for Continuum. UI-only — DOM rendering, event subscription, command dispatch through @continuum/sdk-typescript. NO business logic; substrate decisions stay in core/. Replaces the legacy src/{browser,widgets,server,daemons} monolith (task #215).",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@continuum/sdk-typescript": "*",
+    "lit": "^3.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md
+++ b/docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md
@@ -113,6 +113,26 @@ SDKs.
    `flutter_rust_bridge`. Slightly more indirection, but one binding reused
    everywhere — the matrix-rust-sdk distribution shape.
 
+## The TypeScript / web layer (most non-Rust code — still generation-first)
+
+The Node/TS world will hold the **most non-Rust code** — because the UI is rich —
+but the same law applies: logic concentrates in Rust, TS stays a boundary +
+presentation layer.
+
+- **`sdk/typescript` = the web boundary, generated-first.** As much **ts-rs** as we
+  can get away with (types come from Rust, never hand-written); hand-written TS only
+  for what generation can't cover. Its job is to make the web boundary
+  *straightforward* — not to hold logic.
+- **It's `/shared`.** Because we chose TS, the boundary types + helpers are
+  environment-agnostic and reused across **frontend AND backend** (the
+  `shared/browser/server` tier — `shared/` imports neither browser nor server).
+  One type definition, both sides. This is the specific payoff of TS for the web
+  embodiment that the native SDKs don't get.
+- **The UI mass lives in the app, not the SDK.** `apps/web` holds the widgets, DOM,
+  rendering, presentation; `apps/desktop` (Tauri) wraps that same UI. The SDK stays
+  thin; the app is where the platform's "most code" legitimately accumulates — but
+  it's UI, not substrate logic.
+
 ## Toolchain reality (who can build what)
 
 The native-glue lane splits by **toolchain**, not just intent — Apple artifacts

--- a/docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md
+++ b/docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md
@@ -5,6 +5,26 @@
 > of SDKs). None is privileged; the desktop is just one app. See
 > [[headless-core-many-clients]].
 
+## Why this rewrite: performance (not style)
+
+Nobody likes a rewrite — this one is justified by **speed and CPU**, not aesthetics.
+The old system was slow and CPU-intensive because the hot path ran **serde/parse +
+IPC + ORM in Node** ([[airc-performance-doctrine]]). It will not work at grid scale
+unless it's optimized, and **headless is the enabler** of that optimization. Every
+rule below serves performance:
+
+- **Logic in Rust, Node off the hot path** — no per-request parse/IPC/ORM tax in a
+  JS runtime; one optimized implementation (BLAS/SIMD/GPU where it matters,
+  [[optimization-is-always-first]]).
+- **Headless** — no browser/render loop burning CPU on machines that are servers
+  (AWS, BigMama, grid nodes); rendering happens only if a human client attaches.
+- **Thin, generated SDKs** — no hand-written marshalling layers (CPU + drift); the
+  same Rust lib, not N reimplementations.
+- **Consolidated, bounded work** — e.g. cognition runs once over a consolidated
+  burst at `O(capacity)`, never per-event FIFO.
+
+If a choice here ever trades performance for convenience, it's the wrong choice.
+
 ## The organizing law: concentrate logic as deep as possible (≈ all Rust)
 
 Push **every bit of logic to the deepest shared layer** — which is almost entirely

--- a/docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md
+++ b/docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md
@@ -168,6 +168,26 @@ Keep the binding **single-source** (one `.udl`, generated Swift source shared); 
 only the Apple *packaging/validation* on a Mac. A `macos-runner` CI job is the
 durable home so it doesn't depend on any one operator's laptop.
 
+## Locking the abstraction: three divergent platforms in parallel (outlier validation)
+
+Per the CLAUDE.md outlier-validation strategy — don't build platforms exhaustively
+or hopefully; build the **most divergent** ones in parallel so they *prove* the
+abstraction. If `client/continuum-client` (the common Rust SDK) + the facade serve
+all three cleanly, the interface is locked and every other platform is trivial.
+
+| Track | Binds the common Rust SDK via | Validates the axis |
+|-------|-------------------------------|--------------------|
+| **cli** (`apps/cli`, Rust) | links `continuum-client` **directly** | in-process, no FFI, no wire — the simplest path |
+| **mobile** (`apps/mobile` + `sdk/{flutter,swift,kotlin}`) | **uniffi** → xcframework/AAR, Flutter bundles them | cross-language FFI + cross-toolchain — the hardest path |
+| **nodejs** (`sdk/typescript` + a node consumer) | **wasm/napi** (or RustCoreIPC wire) | JS runtime, possibly a remote core — the third axis |
+
+They share ONE conformance spec (`sdk/typescript/Commands.test.ts` is the reference;
+each language mirrors it — Rust cargo, swift/kotlin) + ONE hot-path timing budget.
+Building them together is what surfaces an abstraction leak early: if a verb or a
+type can't cross all three cleanly, the facade — not the platform — is wrong, and
+we fix it once at the root. The common Rust SDK is the single source of truth all
+three wrap; nothing reimplements logic per platform.
+
 ## Build order
 
 1. **Foundation** — `client/continuum-client` FFI-clean JSON facade (BigMama; it

--- a/docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md
+++ b/docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md
@@ -1,0 +1,160 @@
+# Client / SDK / Platform Architecture
+
+> The headless Rust core is the server. Everything that talks to it is a **client**,
+> and clients are built in two tiers: **SDKs** (libraries) and **apps** (consumers
+> of SDKs). None is privileged; the desktop is just one app. See
+> [[headless-core-many-clients]].
+
+## The organizing law: concentrate logic as deep as possible (≈ all Rust)
+
+Push **every bit of logic to the deepest shared layer** — which is almost entirely
+Rust. Connection, retry, reconnection, backoff, caching, event demux, auth, error
+modeling, state — ALL of it lives in `client/continuum-client` (Rust), so every
+platform inherits it for free and behaves identically. **Every client uses the one
+Rust lib.**
+
+A binding is NOT "thin business logic" — it holds **zero logic**. The only thing a
+per-language SDK adds is *idiomatic surface* (Swift `async/await` · Kotlin `Flow`
+· Dart `Stream` · TS `Promise`) over the FFI facade, plus *generated* types. "Two
+headers over the xcframework and AAR" (Joel) — and nothing more. If you're tempted
+to write logic in Swift/Kotlin/Dart/TS, it belongs in the Rust lib instead.
+
+**The quality bar:** each SDK must **seem coded from the ground up** — a Swift dev
+should feel they're holding a first-class, hand-crafted Swift SDK; a Kotlin dev a
+real Kotlin SDK — while in reality it's a thin conversion/wrapper layer over the
+shared Rust lib. The thinness must NOT show. That's the whole art: maximal native
+feel, near-zero native code. Conversions to each language's paradigm are the work;
+logic is not.
+
+Web is no exception: its deepest form is **wasm of `client/continuum-client`**, not
+a hand-written TS client. The mature hand-written `sdk/typescript` (RustCoreIPC) is
+transitional; logic migrates down into the Rust lib, the TS surface thins toward a
+wasm/wire shim + generated types. (When the core is remote, the TS client is thin
+anyway — the core does the logic over the wire.)
+
+## The two tiers
+
+| Tier | What | Rule |
+|------|------|------|
+| **SDK** (library) | per-language/per-platform binding to the core — `Connection / CommandClient / EventSubscriber` in idiomatic shape | NO business logic (that's `core/`), NO UI. Thin. |
+| **App** (consumer) | an actual product — web, desktop, mobile, cli, vr, ar, mcp | consumes ONE SDK; holds its own platform extensions + UX |
+
+"Platforms" (Joel's word from his RN/Flutter work) **are SDKs** — `sdk/ios`, `sdk/android`, `sdk/web` are platform SDKs.
+
+## The layered SDK stack (NOT flat)
+
+The load-bearing correction (Joel, from shipping RN SDKs with AARs/Maven +
+xcframeworks inside): **cross-platform SDKs do not bypass the native SDKs — they
+contain and use them.**
+
+```
+core/  (the substrate — Rust)
+  ▲ airc IPC / WebSocket / cross-grid (same wire family)
+client/continuum-client  (Rust)   ← THE Rust SDK. apps/cli links it directly.
+  │  ONE FFI facade (generic-free, JSON at the boundary):
+  │     execute(cmd: String, params_json: String) -> result_json
+  │     subscribe(pattern: String) -> stream<event_json>
+  │  uniffi → ONE native binding
+  ▼
+platform artifacts:   xcframework (Apple)   ·   AAR / Maven (Android)   ·   wasm / napi (web, node)
+  ▼
+native platform SDKs (idiomatic typed layer, generated types — never hand-written):
+   sdk/swift   (Swift async/await, AsyncStream — over the xcframework)
+   sdk/kotlin  (Kotlin suspend, Flow<T>      — over the AAR)
+   sdk/typescript (over wasm / WebSocket     — web/desktop/mcp)
+  ▼
+cross-platform SDKs (BUNDLE the native artifacts inside and USE them):
+   sdk/flutter      (Dart plugin: ships the xcframework + AAR inside; Stream<T>)
+   sdk/react-native (same pattern, if/when)
+  ▼
+apps (consumers; own their platform extensions):
+   apps/web      → sdk/typescript
+   apps/desktop  → sdk/typescript (Tauri)         — next to web
+   apps/mobile   → sdk/flutter   (one codebase, iOS+Android; push, deep links, background, sensors)
+   apps/cli      → client/continuum-client (Rust direct; the `ctm` binary)
+   apps/vr       → EXTENDS the native platform SDK (visionOS rides sdk/swift; Quest rides sdk/kotlin)
+   apps/ar       → EXTENDS the native platform SDK (same)
+   apps/mcp      → sdk/typescript (or Rust)
+```
+
+### Why this layering (the compression)
+
+ONE native binding (uniffi → xcframework + AAR) is consumed by **native iOS, native
+Android, AND Flutter/RN**. There is NOT a separate `flutter_rust_bridge` binding
+competing with the native SDKs — Flutter wraps the same artifacts the native apps
+use. One Rust crate, N language frontends, one wire shape, one error model, one
+auth surface ([[command-event-decision-rule]], the compression principle).
+
+`mobile` is a category; `ios`/`android` are platforms under it; `vr`/`ar` extend
+the native platform SDKs (XR is an Apple or Android target). The CLI is its own
+SDK consumer (it *is* the Rust SDK in use). Many apps are themselves composable
+SDKs.
+
+## Decisions (locked 2026-06-17, M5/BigMama/IntelMac)
+
+1. **FFI boundary = JSON at the boundary.** `execute(cmd, params_json) -> result_json`
+   + `subscribe(pattern) -> stream<event_json>`. Generic-free (Rust's generic
+   `Commands.execute<T,U>` can't cross FFI), tiny, stable — it's exactly what
+   Commands/Events are on the wire. The typed/idiomatic per-language layer is
+   **generated** (ts-rs and the per-language equivalent), never hand-written; the
+   JSON shape is the canonical contract.
+2. **uniffi for BOTH native (Swift + Kotlin) now.** One `.udl` → both bindings →
+   the xcframework + AAR. `swift-bridge` is DEFERRED — add the second toolchain
+   ONLY when native-iOS/visionOS async ergonomics prove load-bearing for `apps/vr`
+   / `apps/ar` (outlier-validation, not preemptive).
+3. **TWO binding mechanisms over the ONE facade** (uniffi does NOT emit wasm/JS):
+   - **uniffi** → native (Swift xcframework + Kotlin AAR) → also what Flutter bundles.
+   - **wasm-bindgen** (or napi) → `sdk/typescript` for web/node. Web is its OWN
+     binding path; nobody should expect uniffi→web.
+   Same `client/continuum-client` facade underneath both.
+4. **Flutter mechanism = reuse, not a third binding.** The Flutter plugin bridges
+   Dart → platform-channel → the **swift/kotlin SDKs** (the idiomatic layer already
+   built), packaging the xcframework + AAR inside. NOT raw uniffi, NOT
+   `flutter_rust_bridge`. Slightly more indirection, but one binding reused
+   everywhere — the matrix-rust-sdk distribution shape.
+
+## Toolchain reality (who can build what)
+
+The native-glue lane splits by **toolchain**, not just intent — Apple artifacts
+need macOS/Xcode:
+
+| Step | Runs on | Owner |
+|------|---------|-------|
+| Rust facade, uniffi `.udl` + bindgen (emits Swift **and** Kotlin source), Android AAR + Kotlin SDK | any OS (verified building on Windows) | BigMama |
+| xcframework packaging, Swift SDK build/validate, visionOS | **macOS/Xcode only** | a Mac (M5/IntelMac) or a GitHub **macos-runner** CI job |
+| wasm-bindgen web binding | any OS | (web lane) |
+
+Keep the binding **single-source** (one `.udl`, generated Swift source shared); put
+only the Apple *packaging/validation* on a Mac. A `macos-runner` CI job is the
+durable home so it doesn't depend on any one operator's laptop.
+
+## Build order
+
+1. **Foundation** — `client/continuum-client` FFI-clean JSON facade (BigMama; it
+   wraps airc-lib). M5 confirms the canonical command/event set the facade projects.
+2. **Prove the facade** via the two already-real consumers — `sdk/typescript` (web)
+   + `apps/cli` (Rust) — before native glue. Battle-test the boundary.
+3. **Native platform SDKs** — uniffi → xcframework + AAR + the Swift/Kotlin
+   idiomatic layer (BigMama).
+4. **Cross-platform SDK** — `sdk/flutter` as a thin Dart plugin packaging those
+   artifacts (BigMama).
+5. **Apps** — `apps/mobile` (Flutter, the headline new embodiment), then `vr`/`ar`
+   extending the native SDKs, as demand lands.
+
+## Lanes (this round)
+
+- **BigMama drives** — the foundation facade + native glue (Rust-FFI is her
+  wheelhouse after the embedding/generate facility bridges).
+- **M5 architects the API surface** — the canonical command/event set every SDK
+  exposes + the generated typed-contract — and reviews. (Heads-down on
+  cognition cutover → ToolExecutor; not a build lane this round.)
+- **IntelMac integrates** from the recipe-walker / web-SDK side (closes the
+  substrate→UI loop).
+
+## Non-negotiables
+
+- **Rust-first.** node only for genuinely-web clients; a headless user never
+  installs node ([[rust-is-the-core-node-is-the-shell]]).
+- No UI/business logic in an SDK — substrate decisions stay in `core/`.
+- One owner per cross-cutting concern (e.g. `config.env` → `config_env.rs`,
+  [[config-env-single-owner]]).

--- a/docs/architecture/SDK-API-SURFACE.md
+++ b/docs/architecture/SDK-API-SURFACE.md
@@ -8,12 +8,17 @@
 
 ## The two primitives are the entire surface
 
-Everything is one of two calls on the facade ([[command-event-decision-rule]]):
+Everything is the two primitives ([[command-event-decision-rule]]), each
+**bidirectional** — Commands = call + serve, Events = emit + subscribe:
 
 ```
-execute(command: &str, params_json: &str) -> Result<String, FfiError>   // request/response
-subscribe(class: &str, callback: EventCallback) -> Subscription          // pub/sub (Drop = unsubscribe)
+execute(command: &str, params_json: &str) -> Result<String, FfiError>   // Command: CALL
+provide(command: &str, handler: CommandHandler) -> Registration         // Command: SERVE (client-provided)
+subscribe(class: &str, callback: EventCallback) -> Subscription          // Event: subscribe (Drop = unsubscribe)
 ```
+
+(`#1663` shipped `execute` + `subscribe`; `provide` is the serve-side primitive the
+facade still needs — see "Commands are bidirectional" below.)
 
 A typed SDK method is a thin wrapper over `execute`/`subscribe`:
 
@@ -26,6 +31,47 @@ chat.send({ room, message }) -> SendResult
 The SDK adds *types + idiomatic shape* (Promise / async-await / Flow / Stream); the
 JSON shape is the canonical contract. Zero logic — see the organizing law in the
 structure doc.
+
+## Commands are bidirectional: call AND provide (client-provided commands)
+
+A command isn't only something a client *calls* — a client can also *provide*
+(serve) one. This is the **serve side of the Command primitive** (still two
+primitives: Commands = `execute` + `provide`; Events = `emit` + `subscribe`).
+
+Some commands cannot run in the core — they need the **client's** display, sensors,
+or renderer:
+
+| Command | rust-origin contract | per-platform adapter (in the SDK) |
+|---------|----------------------|-----------------------------------|
+| `interface/screenshot` | name + ts-rs `ScreenshotParams`/`Result` | web = DOM/canvas · desktop = OS · **AR/VR = capture from the renderer** |
+| capture / sensors | rust-origin | each platform's native capture |
+| `ping` | rust-origin | trivial, but same shape |
+
+The **contract has a rust origin** (canonical name + ts-rs types, one source of
+truth); the **adapter that implements it lives in the SDK**, one per platform —
+OpenCV-style adapter polymorphism: one command identity, N platform adapters. The
+core (or a peer) *routes* the command to a client that provides it; the SDK's
+adapter runs and returns the typed result.
+
+This already exists server-side for personas (`persona/command_inbound_pump.rs`
+routes inbound commands to a persona's handlers). The SDK is the **client analog**,
+so the FFI facade needs a third method beside `execute`/`subscribe`:
+
+```
+provide(command: &str, handler: CommandHandler) -> Registration   // Drop = deregister
+CommandHandler { handle(params_json) -> Result<result_json, FfiError> }
+```
+
+Typed in the SDK off the SAME `CommandMap` (params/result inferred from the name):
+
+```ts
+commands.provide('interface/screenshot', async (p) => webCapture(p));      // apps/web
+commands.provide('interface/screenshot', async (p) => rendererCapture(p)); // apps/vr
+```
+
+(The legacy `src/commands/interface/screenshot/{browser,server}` split is exactly
+this today — the browser file IS the web adapter. The new shape generalizes it:
+rust-origin contract, per-SDK adapter, routed.)
 
 ## The contract: a command is (name, ParamsType, ResultType, accessLevel)
 
@@ -54,6 +100,46 @@ Pipeline per language:
 - **Swift / Kotlin** — uniffi emits the binding; the typed method layer generates
   from the same command/type manifest.
 - **Dart** — rides the native SDKs (per structure doc); generated likewise.
+
+## The elegant typed surface (TS): infer from the name, don't pass generics
+
+The old shape made the *caller* supply the generics — `Commands.execute<T extends
+CommandParams, U extends CommandResult>(name, params)`. We can do better: **infer
+both the params type AND the result type from the command-name literal**, so the
+caller passes nothing but the name + params and gets a fully-typed result.
+
+```ts
+// GENERATED — one entry per discovered command, never hand-written
+interface CommandMap {
+  'data/list':                { params: DataListParams;  result: DataListResult };
+  'ai/generate':              { params: GenerateParams;  result: GenerateResult };
+  'collaboration/chat/send':  { params: ChatSendParams;  result: ChatSendResult };
+  // …
+}
+type CommandName = keyof CommandMap;
+
+// hand-written ONCE (the generic machinery over the facade); never changes per command
+function execute<K extends CommandName>(
+  name: K,
+  params: CommandMap[K]['params'],
+): Promise<CommandMap[K]['result']>;
+```
+
+`execute('data/list', { collection })` now infers the params shape and returns
+`Promise<DataListResult>` — no `<T,U>`, full inference from the literal. Same for
+events via an `EventMap`. This is the "amazing things with generics" win — and it
+**stays compatible with the no-hardcoded-registry rule** because `CommandMap` is
+*generated* (regenerated on every command change), not a hand-maintained union.
+Generation is what makes the elegance safe.
+
+## Structure: the SDK is the one shared layer (front + back)
+
+Sharing TS across frontend and backend is smart — but the old
+`browser/shared/server` tripartite split got into trouble (logic scattered across
+three tiers, fuzzy boundaries). The cleaner shape: **`sdk/typescript` IS the shared
+layer** — environment-agnostic (imports neither browser nor server), consumed by
+`apps/web` (frontend) AND any TS backend alike. Apps stay thin environment shells
+on top. One shared SDK, not three intertwined tiers.
 
 ## The command set (by namespace — ~40 live, discovery-driven)
 

--- a/docs/architecture/SDK-API-SURFACE.md
+++ b/docs/architecture/SDK-API-SURFACE.md
@@ -14,11 +14,15 @@ Everything is the two primitives ([[command-event-decision-rule]]), each
 ```
 execute(command: &str, params_json: &str) -> Result<String, FfiError>   // Command: CALL
 provide(command: &str, handler: CommandHandler) -> Registration         // Command: SERVE (client-provided)
-subscribe(class: &str, callback: EventCallback) -> Subscription          // Event: subscribe (Drop = unsubscribe)
+subscribe(class: &str, callback: EventCallback) -> Subscription          // Event: SUBSCRIBE (Drop = unsubscribe)
+emit(class: &str, payload_json: &str) -> Result<(), FfiError>            // Event: EMIT (publish)
 ```
 
-(`#1663` shipped `execute` + `subscribe`; `provide` is the serve-side primitive the
-facade still needs — see "Commands are bidirectional" below.)
+FOUR facade methods = two primitives × two directions. `#1663` shipped `execute` +
+`subscribe`; **`provide` (serve) + `emit` (publish) are the facade gaps** — bind all
+four in one uniffi `.udl` pass so the native binding is complete in one shot. The
+TS SDK splits them by primitive: `Commands` (`execute` + `provide`), `Events`
+(`subscribe` + `emit`) — the CLAUDE.md two-primitives file split.
 
 A typed SDK method is a thin wrapper over `execute`/`subscribe`:
 

--- a/docs/architecture/SDK-API-SURFACE.md
+++ b/docs/architecture/SDK-API-SURFACE.md
@@ -106,6 +106,38 @@ rest — local walk, airc-to-peer, or room fan-out — over the SAME wire family
 (local IPC ↔ cross-grid airc). Caller stays transparent; addressing is opt-in.
 Events ride the redone `AircEventPublisher` cross-grid pub/sub the same way.
 
+## Orchestrating across the grid (multi-hop, web-like)
+
+A command should route across boundaries, machines, and the greater grid — even
+through many layers — as easily as a local call. The property that makes this free:
+**commands are addressed by DESTINATION, not by route** (`airc://peer/path`, like a
+URL). So whether a command is local, one hop, or ten hops across the grid's
+routers, **the caller/SDK surface never changes** — the routers forward it, exactly
+like the web (you `GET` a URL; intermediate routers forward it N hops; the client
+neither knows nor cares).
+
+Status (honest): the redone routing is **single-hop today** (`RouteDecision` =
+Local / Peer-over-airc / Room). Multi-hop "across the routers of the greater grid"
+is the next routing-layer evolution — and the substrate for it already exists:
+`modules/grid/router.rs` + the **Reticulum** transport (identity-addressed
+encrypted mesh, *inherently* multi-hop). The evolution is a `RouteDecision`
+transit/forward dimension + the router forwarding toward the destination — **zero
+change to the command surface**, because destination-addressing already
+accommodates it. (Routing-layer lane — grid/transport, not the SDK.)
+
+**Web-like ping = the demonstrator.** A `ping`/`traceroute` command routed across
+the grid: each router it transits appends itself to the path, the reply carries the
+full hop list. It proves multi-hop command forwarding end-to-end and is a perfect
+glass-box demo (you watch a command traverse the grid). It's a `ping` that "works
+more like the web."
+
+**Orchestration across layers** is then "commands made of commands" (the recipe
+walker — IntelMac's lane): a single command fans out sub-commands that each
+dispatch to wherever their destination resolves — local, a peer's `:vr` env, a 5090
+facility, a node ten hops away — and composes the results. The walker doesn't care
+where each runs; the addressing + routing place them. One command, many layers,
+across the grid.
+
 ## The contract: a command is (name, ParamsType, ResultType, accessLevel)
 
 | Field | Source of truth |

--- a/docs/architecture/SDK-API-SURFACE.md
+++ b/docs/architecture/SDK-API-SURFACE.md
@@ -1,0 +1,111 @@
+# SDK API Surface — the canonical command/event set the SDKs project
+
+> Companion to [CLIENT-SDK-PLATFORM-ARCHITECTURE.md](CLIENT-SDK-PLATFORM-ARCHITECTURE.md)
+> (that's *structure*; this is the *contract*). The FFI facade
+> (`client/continuum-client-ffi`, PR #1663) is the generic-free pipe; THIS doc
+> defines what rides on it — the canonical commands + events every typed SDK
+> projects, and how that typed layer is **generated, never hand-written**.
+
+## The two primitives are the entire surface
+
+Everything is one of two calls on the facade ([[command-event-decision-rule]]):
+
+```
+execute(command: &str, params_json: &str) -> Result<String, FfiError>   // request/response
+subscribe(class: &str, callback: EventCallback) -> Subscription          // pub/sub (Drop = unsubscribe)
+```
+
+A typed SDK method is a thin wrapper over `execute`/`subscribe`:
+
+```
+// generated, per language — NOT hand-written
+chat.send({ room, message }) -> SendResult
+   ≡ execute("collaboration/chat/send", JSON(params)) |> parse as SendResult
+```
+
+The SDK adds *types + idiomatic shape* (Promise / async-await / Flow / Stream); the
+JSON shape is the canonical contract. Zero logic — see the organizing law in the
+structure doc.
+
+## The contract: a command is (name, ParamsType, ResultType, accessLevel)
+
+| Field | Source of truth |
+|-------|-----------------|
+| `name` | the command's path (`collaboration/chat/send`) — discovered, not enumerated |
+| `ParamsType` / `ResultType` | the **ts-rs / uniffi-generated wire types** (`protocol/typescript/*`), emitted from the Rust structs — never hand-written ([[no-sql-everything-through-orm-entities]] projection: typed surface comes from generated types) |
+| `accessLevel` | the command's declared capability (`ai-safe`, …) — carried by the command, enforced by the core's ACL ([[grid-agent-collaboration-protocol]] / GridTrustAuthPolicy), NOT by the SDK |
+
+**Commands are dumb, carry no policy params** (AI-COMMAND-NAMESPACE.md): the SDK
+never adds routing/auth/policy — it passes params, the daemon decides.
+
+## GENERATED, not a hardcoded list (non-negotiable)
+
+The typed SDK surface is **generated from the same source commands are discovered
+from** — the command specs + the ts-rs/uniffi wire types. Adding a command makes its
+typed method appear in every SDK automatically; no SDK carries a hand-maintained
+command enum/registry. This is the client-side application of the anti-pattern rule:
+**no switch/registry/enum of command names** (CLAUDE.md § Anti-Pattern Detection).
+A frozen list in an SDK would drift the moment a command lands; generation makes
+drift structurally impossible.
+
+Pipeline per language:
+- **TS** — ts-rs already emits the wire types (`protocol/typescript/*`); the typed
+  method layer generates over them.
+- **Swift / Kotlin** — uniffi emits the binding; the typed method layer generates
+  from the same command/type manifest.
+- **Dart** — rides the native SDKs (per structure doc); generated likewise.
+
+## The command set (by namespace — ~40 live, discovery-driven)
+
+Grouped so SDK authors see the shape; the *authoritative* list is whatever the core
+discovers at runtime, projected through generation — this is a map, not a freeze:
+
+| Group | Namespaces | Typical SDK ergonomics |
+|-------|-----------|------------------------|
+| **Data / content** | `data` `list` `search` `ontology` `migration` | `data.list<T>()`, `data.create<T>()` — generic over entity types |
+| **AI / cognition** | `ai` `cognition` `inference` `model` `rag` `genome` `plasticity` | `ai.generate()`, `ai.embedding()`, `ai.shouldRespond()` (the Decision wire enum) |
+| **Collaboration** | `collaboration` (chat/wall/…) `agent` `claude` | `chat.send()`, `chat.export()` |
+| **Persona** | `persona` | `persona.inbox()`, persona lifecycle |
+| **Code / files** | `code` `file` `dev` `development` | `code.read()`, `code.write()`, `code.edit()` |
+| **Interface** | `interface` `canvas` `avatar` `media` `indicator` | `interface.screenshot()`, `interface.navigate()` |
+| **Grid / transport** | `grid` `airc` `inference` `security` | grid/peer ops; mostly app-internal |
+| **System / runtime** | `runtime` `process-registry` `logging` `logs` `gpu` `ping` `help` `recipe` `continuum` | `system.ping()`, `system/launch-mode/{get,set}` (the ONE config owner — [[config-env-single-owner]]) |
+
+(Each namespace's commands + their params/result types are already in
+`protocol/typescript/<namespace>/` as ts-rs output — the SDK generates typed
+methods from exactly those.)
+
+## The event set (what `subscribe` carries)
+
+Events are class-patterned (`data:<collection>:<verb>`, chat, persona, grid).
+`subscribe(class, cb)` streams JSON matching the class; the typed SDK layer projects
+each event's payload from the generated event types. Canonical classes the SDKs
+expose:
+
+| Class shape | Example | Payload (generated) |
+|-------------|---------|---------------------|
+| `data:<collection>:<verb>` | `data:chat_messages:created` | the entity wire type |
+| `chat:*` | room/message stream | `ChatMessage` |
+| `persona:*` | cognition/turn/state | persona wire types |
+| `grid:*` / `airc:*` | peer presence, roster | roster/presence types |
+
+Same rule: the per-event typed payload is **generated**, the class string is the
+contract.
+
+## What the SDK does NOT do
+
+- No business logic, no caching/retry/auth (all in the Rust lib — structure doc).
+- No hand-written command list or types (generated).
+- No policy params on commands (commands are dumb).
+- No transport choice (the facade + core decide local vs cross-grid).
+
+## Open items (for the build)
+
+1. **The generator** that emits the typed method layer per language from the
+   command manifest + ts-rs/uniffi types (the thing that makes "add a command →
+   appears in every SDK" real). Sibling of the existing ts-rs emit.
+2. The **command manifest** the generator reads — does it derive from the existing
+   spec/discovery surface, or a new emitted manifest? (Resolve with the
+   command-discovery owner.)
+3. Per-namespace **access-level surfacing** — should the SDK type-tag ai-safe vs
+   privileged so client authors see capability at the call site? (Nice-to-have.)

--- a/docs/architecture/SDK-API-SURFACE.md
+++ b/docs/architecture/SDK-API-SURFACE.md
@@ -73,6 +73,39 @@ commands.provide('interface/screenshot', async (p) => rendererCapture(p)); // ap
 this today — the browser file IS the web adapter. The new shape generalizes it:
 rust-origin contract, per-SDK adapter, routed.)
 
+## Commands that stretch across environments (the hard part)
+
+A command's **caller, contract-origin, and executing adapter can each be in a
+different environment**: a CLI calls `screenshot` → the core routes it → a web
+client's adapter runs it → the result flows back; cross-grid, a persona on one node
+targets a human's client on another. The SDK must express *where* a command runs
+without losing transparency.
+
+It does **not** reinvent routing — the **redone command/event infrastructure**
+already solves addressing (`core/src/routing/`): `CommandUri` /`RouteDecision` over
+`airc://[peer[@node]][:env]/path`. The SDK just **projects** onto it:
+
+| CommandUri | SDK `target` | meaning |
+|------------|--------------|---------|
+| `Local` | omitted (bare path) | caller's own substrate (default, back-compatible) |
+| `Peer { peer, node?, env? }` | `{ peer, node?, env? }` | a citizen; **`env`** = WHICH embodiment |
+| `Room { env? }` | `{ room, env? }` | fan-out to subscribers |
+| `Broadcast` / `:*` | `{ peer, env: '*' }` | every embodiment of a peer |
+
+**`env` is the cross-environment key** (`EnvironmentId::Named("web" | "vr" | "server"
+| "cli" | …)`). It's how a client-provided command reaches the right embodiment:
+
+```ts
+commands.execute('interface/screenshot', { querySelector: 'body' },
+                 { peer: joelPeerId, env: 'web' });   // → airc://<peer>:web/interface/screenshot
+commands.execute('interface/capture', {}, { peer: headsetPeerId, env: 'vr' }); // renderer capture
+```
+
+The SDK builds the `airc://` URI (`buildCommandUri`) and `RouteDecision` does the
+rest — local walk, airc-to-peer, or room fan-out — over the SAME wire family
+(local IPC ↔ cross-grid airc). Caller stays transparent; addressing is opt-in.
+Events ride the redone `AircEventPublisher` cross-grid pub/sub the same way.
+
 ## The contract: a command is (name, ParamsType, ResultType, accessLevel)
 
 | Field | Source of truth |

--- a/docs/architecture/SDK-API-SURFACE.md
+++ b/docs/architecture/SDK-API-SURFACE.md
@@ -110,6 +110,52 @@ rest — local walk, airc-to-peer, or room fan-out — over the SAME wire family
 (local IPC ↔ cross-grid airc). Caller stays transparent; addressing is opt-in.
 Events ride the redone `AircEventPublisher` cross-grid pub/sub the same way.
 
+## Handles are addressable resources (URIs) — long-running, streaming, multi-hop
+
+Short commands are request/response. Long-running / streaming / stateful work uses
+the **handle pattern** (the substrate's establish-once-reuse-many — `InferenceHandleStore`,
+AI-COMMAND-NAMESPACE.md §2): an `open`-style command returns a **handle**, events
+stream against it, and further commands (`write`, `read`, `close`) take it.
+
+The unifying move (Joel): **a handle IS a URI.** `open` returns the handle's
+`airc://` URI — in the result body, or an **airc header** (the HTTP `Location`
+analog: "the resource you created lives here"). Then *everything routes to that
+URI*:
+
+- further commands → `airc://<handle-uri>/write` (routes to wherever the resource
+  lives — a peer, an `:vr` env, N hops away);
+- event subscription → `airc://<handle-uri>/events/<class>` (the resource's stream).
+
+So in the long **router-chain** scenario, the handle's event stream is fed by **any
+link in the chain** — each hop emits handle-correlated events; the originator's
+subscription receives the live stream from across the grid (the web-like ping's
+hops *arrive as events*, not one return). Handle = an addressable resource;
+commands operate on it, events flow from it, routing places it. Commands + events +
+handles + routing collapse into ONE addressing scheme.
+
+```ts
+const f = await commands.open('file/open', { path }, { peer, env: 'web' }); // → Handle (carries its URI)
+f.on('progress', (e) => …);                 // events from the resource (any hop)
+await f.execute('write', { bytes });        // routed to the handle's URI
+await f.close();
+```
+
+## Wire model: headers route, body opaque, serialize once (web-like)
+
+For grid-scale efficiency ([[airc-performance-doctrine]]), the wire is **HTTP-like**:
+**control metadata in HEADERS, payload in an OPAQUE body.** A frame carries headers
+— target URI, the handle/`Location`, content-type, `filter`, `sequence`,
+access-level, `OPTIONS`-style preflight/capability — and an opaque body.
+
+The performance rule: **serialize ONCE at the caller, deserialize ONCE at the
+callee; every router hop in between forwards by reading only the headers** — it
+never parses/re-serializes the body. Limited serde on the routing path; forward the
+bytes. This is what makes multi-hop grid orchestration cheap — exactly how the web
+scales (routers read headers, forward the body untouched). The SDK endpoints
+already serialize-once (`execute` does one `JSON.stringify`, the result one
+`JSON.parse`); the header/body split + header-only forwarding is the wire layer
+(grid/transport — BigMama's lane).
+
 ## Orchestrating across the grid (multi-hop, web-like)
 
 A command should route across boundaries, machines, and the greater grid — even

--- a/docs/architecture/SDK-API-SURFACE.md
+++ b/docs/architecture/SDK-API-SURFACE.md
@@ -36,6 +36,68 @@ The SDK adds *types + idiomatic shape* (Promise / async-await / Flow / Stream); 
 JSON shape is the canonical contract. Zero logic — see the organizing law in the
 structure doc.
 
+## Events are the organism's coordination substrate (personas AND systems)
+
+Emissions + subscriptions aren't a feature — they're the **nervous system that makes
+the grid an organism.** The same `emit`/`subscribe` primitive coordinates *both*:
+
+- **Personas** — the reactive mind ([[persona-brain-reactive-cognition]]): a turn,
+  a recalled memory, a thought-stream all flow as events the cognition loop reacts to.
+- **Systems themselves** — a node coming online/offline emits presence
+  (`agent_heartbeat` / `active_agents`), a GPU freeing emits capacity, demand
+  spiking emits pressure, a capability appearing emits advertisement. Other nodes
+  *subscribe and react*.
+
+Because **emitters don't know their subscribers** ([[events-are-the-organic-rtos-substrate]]:
+"events ARE the coordination primitive; the component graph emerges"), behavior is
+**emergent, not orchestrated**. A machine drops ([[grid-node-resilience]]) → it stops
+heartbeating → subscribers re-route, re-lease the compute, heal — nobody wrote a
+"handle node failure" procedure; the organism responds because the signals flow and
+the graph self-assembles. Demand rises → pressure events → capable nodes lease in.
+That is the difference between a distributed system and a living one.
+
+**Every node subscribes AND emits — like cbar.** No privileged broker/hub: each
+node (persona, system, client, peer) is a symmetric producer *and* consumer, exactly
+like cbar's processing graph where each node emits features and subscribes to others
+and the graph self-assembles. That peer-symmetry is what lets the organism have no
+single point of orchestration.
+
+And it's **fractal**: this is the *same* emit/subscribe-graph-emerges pattern as a
+persona's Faculty/Workspace brain ([[persona-brain-reactive-cognition]] — the cbar
+perspective), just at grid scale. Every node is a "faculty" of the organism; the
+brain is the organism in miniature, the organism is a brain at scale. One primitive,
+two scales (cognition + grid).
+
+This is why the event surface is first-class and deep (source addressing across the
+grid, server-side filtering, monotonic sequence, emit as a real primitive not
+sugar): it's the organism's signaling, and it must be cheap, ordered, filterable,
+and reach across the whole grid. Cross-grid event delivery (`AircEventPublisher`) is
+the organism's reflex arc.
+
+## The payoff: cognition tied across the grid
+
+Follow the fractal to its end. A persona's mind is faculties bidding into a bounded
+Workspace, integrated by an arbiter (the cbar reactive shape). The grid is nodes
+emitting/subscribing. **They are the same emit/subscribe substrate** — so a single
+cognition can span the grid:
+
+- a **Recall** faculty on the node that holds the engrams,
+- a **Deliberation** faculty leasing the 5090,
+- a **Vision** faculty on the headset capturing from the renderer,
+
+— all bidding into **one Workspace** over the cross-grid event substrate; the arbiter
+integrates the bids regardless of which node emitted them. A mind whose organs are
+grid-distributed. (And the inverse: many minds sharing a faculty — one embedding
+facility, one world-model — because a faculty is just an addressable emit/subscribe
+node.)
+
+**This is why the format must be elegant.** Tying cognition across machines is only
+possible if the primitive is uniform, destination-addressed, serialize-once, and
+header-routed — a heavy or bespoke format would make cross-node faculties
+impossible to compose. The elegance was never aesthetic; it's the *enabler* of the
+ambitious thing ([[optimization-is-always-first]], the compression principle). Get
+the format right and grid-distributed cognition is a configuration, not a rewrite.
+
 ## Commands are bidirectional: call AND provide (client-provided commands)
 
 A command isn't only something a client *calls* — a client can also *provide*
@@ -139,6 +201,39 @@ f.on('progress', (e) => …);                 // events from the resource (any h
 await f.execute('write', { bytes });        // routed to the handle's URI
 await f.close();
 ```
+
+### Worked example: a grid-spanning WebRTC connection (the hardest case)
+
+WebRTC is where every part of the model earns its keep — a long-running, stateful,
+bidirectionally-streaming resource whose media server is "somewhere in the grid."
+It's not invented for this: the substrate already has the **Universal Handle System**
+(`live/handle.rs` — "start operation → returns handle; events tagged with handle;
+cancel/status/resume → use handle") and `AgentHandle` in the live transport. The SDK
+just makes that handle **addressable (a URI)** so it routes across the grid.
+
+```ts
+// open the connection → a handle addressing the media server WHEREVER it lives
+// (a livekit-bridge node somewhere on the grid; routed by URI, you don't pick the node)
+const conn = handleFrom((await commands.execute('live/connect', { room },
+                          { /* let routing place it on a media-capable node */ })).uri, transport);
+
+// signaling rides the handle's bidirectional event stream — offer/answer + ICE
+// trickle = a STREAM of candidate events, fed by any link (your "events from any link")
+conn.on('signal', (s) => applySignal(s));            // answer + remote ICE candidates
+await conn.execute('offer', { sdp });                // local offer
+await conn.execute('ice', { candidate });            // trickle local candidates as they appear
+
+// once negotiated, MEDIA flows direct (RTP) — only the CONTROL (signaling) went
+// through the addressed handle, header-routed with an opaque body.
+await conn.close();
+```
+
+Why each piece matters here: the **handle-URI** reaches the media server across the
+grid (multi-hop if needed) without the caller knowing the node; **events-from-any-link**
+is exactly ICE trickle + connection-state changes streaming back; **headers-route /
+body-opaque** keeps signaling cheap; and the heavy media path stays direct (the
+substrate routes *control*, not the RTP firehose). The same model that serves
+`data/list` serves a cross-grid live call.
 
 ## Wire model: headers route, body opaque, serialize once (web-like)
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,18 @@
 {
   "name": "continuum",
   "private": true,
-  "description": "Continuum — headless persona substrate. `npm start` boots the Rust core; `npm run desktop` adds the Node UX shell on top of the same core.",
+  "description": "Continuum — a headless persona substrate. The Rust core is the server; every UI is an equal, dependent client over the same Commands/Events SDK. `npm start` boots ONLY the headless core (Rust, no desktop). Clients live under apps/ (web, desktop, cli[Rust], mobile, vr, ar, mcp) and attach on demand.",
+  "workspaces": [
+    "sdk/typescript",
+    "apps/web",
+    "apps/desktop"
+  ],
   "scripts": {
     "start": "bash tools/scripts/start-server.sh",
-    "desktop": "bash tools/scripts/parallel-start.sh",
+    "dev:web": "npm run dev -w @continuum/web",
+    "dev:desktop": "npm run dev -w @continuum/desktop",
+    "build:clients": "npm run build -w @continuum/sdk-typescript && npm run build -w @continuum/web",
+    "desktop:legacy": "bash tools/scripts/parallel-start.sh",
     "stop": "bash tools/scripts/system-stop.sh",
     "install:continuum": "bash tools/scripts/install.sh",
     "setup:git-hooks": "bash tools/scripts/setup-git-hooks.sh"

--- a/sdk/typescript/Commands.test.ts
+++ b/sdk/typescript/Commands.test.ts
@@ -1,9 +1,22 @@
 /**
- * SDK conformance spec (TDD). The behaviors EVERY SDK must satisfy — pinned here in
- * TS against a daemon-free MockTransport so the loop is instant (`vitest --watch`),
- * and mirrored per language (Rust cargo, swift/kotlin) so the native twins prove
- * the SAME contract. Includes hot-path TIMING budgets (optimization-first): the SDK
- * is a thin skin, so URI build + serialize-once + dispatch must be ~free.
+ * THE SDK CONFORMANCE CONTRACT.
+ *
+ * This file is the single, authoritative behavioral spec EVERY Continuum SDK must
+ * satisfy — the web/desktop TS SDK here, and the native twins (Rust cargo,
+ * Swift XCTest, Kotlin JUnit over the uniffi binding) which mirror these exact
+ * checks name-for-name. If a behavior isn't pinned here, it isn't part of the
+ * contract; if it is, every twin proves it. Pinned in TS first because the loop is
+ * instant (`vitest --watch`) against a daemon-free MockTransport.
+ *
+ * The contract has FIVE sections, each a conformance dimension:
+ *   1. Addressing      — name + Target → the airc:// URI / event topic (pure, total)
+ *   2. Commands        — execute (call) + provide (serve): serialize-once fidelity
+ *   3. Events          — subscribe (listen) + emit (publish): source, filter, sequence, teardown
+ *   4. Handle          — addressable resource: ops + event stream + close route to one URI
+ *   5. Timing          — the SDK is a thin skin; the hot path is ~free (optimization-first)
+ *
+ * Mirroring guide for the native twins: each `it(...)` is one contract clause.
+ * Keep the clause text identical across languages so a reviewer can diff suites.
  *
  * Run: npm test -w @continuum/sdk-typescript   (vitest)
  */
@@ -19,12 +32,18 @@ import type {
   Registration,
 } from './transport';
 
-/** Daemon-free transport double — records what crossed the boundary. */
+/**
+ * Daemon-free transport double — records exactly what crossed the byte boundary
+ * (the JSON strings), so the contract asserts on the wire, not on internals. The
+ * native twins implement the same double over their facade's seam.
+ */
 class MockTransport implements Transport {
   executed: Array<{ command: string; paramsJson: string }> = [];
   provided = new Map<string, RawCommandHandler>();
   subscribed: Array<{ topic: string; filterJson?: string }> = [];
+  unsubscribed = 0;
   emitted: Array<{ eventClass: string; payloadJson: string }> = [];
+  lastHandlers?: RawEventHandlers;
   private nextResult = '{}';
 
   willReturn(json: string) {
@@ -40,38 +59,65 @@ class MockTransport implements Transport {
   }
   subscribe(topic: string, handlers: RawEventHandlers, filterJson?: string): Subscription {
     this.subscribed.push({ topic, filterJson });
-    // expose the handler for the test to drive deliveries
-    (this as unknown as { lastHandlers: RawEventHandlers }).lastHandlers = handlers;
-    return { unsubscribe: () => {} };
+    this.lastHandlers = handlers;
+    return { unsubscribe: () => { this.unsubscribed += 1; } };
   }
   async emit(eventClass: string, payloadJson: string): Promise<void> {
     this.emitted.push({ eventClass, payloadJson });
   }
 }
 
-describe('addressing (projects onto the redone CommandUri)', () => {
-  it('bare name = Local (back-compatible)', () => {
+// ─── 1. Addressing ────────────────────────────────────────────────────────────
+//
+// buildCommandUri / buildEventTopic are PURE and TOTAL — the entire cross-grid
+// addressing surface reduces to these two functions. They project onto the core's
+// CommandUri / RouteDecision (core/src/routing/). Pin every Target shape: a twin
+// that builds a different string routes to the wrong place silently.
+
+describe('1. addressing — name + Target → airc:// URI', () => {
+  it('bare name = Local (no target, back-compatible)', () => {
     expect(buildCommandUri('data/list')).toBe('data/list');
   });
-  it('peer + env = cross-environment dispatch', () => {
+  it('peer only = that citizen, default node + embodiment', () => {
+    expect(buildCommandUri('x/y', { peer: 'p1' })).toBe('airc://p1/x/y');
+  });
+  it('peer + env = a specific embodiment (WHICH)', () => {
     expect(buildCommandUri('interface/screenshot', { peer: 'p1', env: 'web' }))
       .toBe('airc://p1:web/interface/screenshot');
   });
-  it('peer@node:env carries WHO/WHERE/WHICH', () => {
+  it('peer + node (no env) = a specific machine', () => {
+    expect(buildCommandUri('x/y', { peer: 'p1', node: 'n2' })).toBe('airc://p1@n2/x/y');
+  });
+  it('peer@node:env carries WHO / WHERE / WHICH', () => {
     expect(buildCommandUri('x/y', { peer: 'p1', node: 'n2', env: 'vr' }))
       .toBe('airc://p1@n2:vr/x/y');
   });
-  it('room fan-out', () => {
+  it("peer + env '*' = every embodiment (broadcast to the citizen)", () => {
+    expect(buildCommandUri('x/y', { peer: 'p1', env: '*' })).toBe('airc://p1:*/x/y');
+  });
+  it('room (no env) = fan-out to room subscribers', () => {
+    expect(buildCommandUri('x', { room: 'r1' })).toBe('airc://room:r1/x');
+  });
+  it('room + env = fan-out to one embodiment of the room', () => {
     expect(buildCommandUri('x', { room: 'r1', env: 'web' })).toBe('airc://room:r1:web/x');
   });
-  it('event topic: local class vs a peer’s event stream', () => {
+
+  it('event topic: bare class = local stream', () => {
     expect(buildEventTopic('data:users:created')).toBe('data:users:created');
+  });
+  it("event topic: a peer's event stream across the grid", () => {
     expect(buildEventTopic('grid:peer:joined', { peer: 'p1' }))
       .toBe('airc://p1/events/grid:peer:joined');
   });
+  it("event topic: a room's event stream", () => {
+    expect(buildEventTopic('data:users:created', { room: 'r1' }))
+      .toBe('airc://room:r1/events/data:users:created');
+  });
 });
 
-describe('Commands primitive (execute + provide)', () => {
+// ─── 2. Commands (execute + provide) ────────────────────────────────────────────
+
+describe('2. Commands — execute (call) + provide (serve)', () => {
   it('execute: serialize-once out, parse-once back, typed result', async () => {
     const t = new MockTransport();
     t.willReturn('{"ok":true,"roundTripMs":3}');
@@ -81,7 +127,23 @@ describe('Commands primitive (execute + provide)', () => {
     expect(r).toEqual({ ok: true, roundTripMs: 3 });
   });
 
-  it('execute routes through the cross-environment URI', async () => {
+  it('execute: nested params serialize with full fidelity (no flatten/reorder)', async () => {
+    const t = new MockTransport();
+    t.willReturn('{"items":[],"total":0}');
+    const c = Continuum.connect(t);
+    await c.commands.execute('data/list', {
+      collection: 'users',
+      orderBy: [{ field: 'lastActiveAt', direction: 'desc' }],
+      filter: { active: true },
+    });
+    expect(JSON.parse(t.executed[0].paramsJson)).toEqual({
+      collection: 'users',
+      orderBy: [{ field: 'lastActiveAt', direction: 'desc' }],
+      filter: { active: true },
+    });
+  });
+
+  it('execute: routes through the cross-environment URI', async () => {
     const t = new MockTransport();
     const c = Continuum.connect(t);
     await c.commands.execute('interface/screenshot', { querySelector: 'body' }, { peer: 'p1', env: 'web' });
@@ -91,7 +153,7 @@ describe('Commands primitive (execute + provide)', () => {
   it('provide: registers the platform adapter; routed call runs it + serializes back', async () => {
     const t = new MockTransport();
     const c = Continuum.connect(t);
-    c.commands.provide('interface/screenshot', async (p: { querySelector?: string }) => ({
+    c.commands.provide('interface/screenshot', async (p) => ({
       dataUrl: `shot:${p.querySelector}`,
       width: 1,
       height: 1,
@@ -100,44 +162,94 @@ describe('Commands primitive (execute + provide)', () => {
     const out = await handler.handle('{"querySelector":"body"}');
     expect(JSON.parse(out)).toEqual({ dataUrl: 'shot:body', width: 1, height: 1 });
   });
+
+  it('provide: Registration.remove() deregisters the adapter', () => {
+    const t = new MockTransport();
+    const c = Continuum.connect(t);
+    const reg = c.commands.provide('interface/screenshot', async () => ({ dataUrl: '', width: 0, height: 0 }));
+    expect(t.provided.has('interface/screenshot')).toBe(true);
+    reg.remove();
+    expect(t.provided.has('interface/screenshot')).toBe(false);
+  });
 });
 
-describe('Events primitive (subscribe + emit)', () => {
-  it('subscribe: source addressing + server-side filter + sequence delivery', () => {
+// ─── 3. Events (subscribe + emit) ───────────────────────────────────────────────
+
+describe('3. Events — subscribe (listen) + emit (publish)', () => {
+  it('subscribe: local class = bare topic, no filter', () => {
+    const t = new MockTransport();
+    const c = Continuum.connect(t);
+    c.events.subscribe('data:users:created', { onEvent: () => {} });
+    expect(t.subscribed[0]).toEqual({ topic: 'data:users:created', filterJson: undefined });
+  });
+
+  it('subscribe: source addressing + server-side filter + typed sequence delivery', () => {
     const t = new MockTransport();
     const c = Continuum.connect(t);
     const seen: Array<[unknown, number]> = [];
     c.events.subscribe(
-      'grid:peer:joined' as never,
-      { onEvent: (e, meta) => seen.push([e, meta.sequence]) } as never,
-      { source: { peer: 'p1' }, filter: { runtime: 'persona' } as never },
+      'grid:peer:joined',
+      { onEvent: (e, meta) => seen.push([e, meta.sequence]) },
+      { source: { peer: 'p1' }, filter: { runtime: 'persona' } },
     );
     expect(t.subscribed[0].topic).toBe('airc://p1/events/grid:peer:joined');
     expect(t.subscribed[0].filterJson).toBe('{"runtime":"persona"}');
-    // drive a delivery through the recorded raw handler
-    (t as unknown as { lastHandlers: RawEventHandlers }).lastHandlers.onEvent('{"runtime":"persona"}', 7);
-    expect(seen).toEqual([[{ runtime: 'persona' }, 7]]);
+    // drive a delivery through the recorded raw handler: parse-once + sequence
+    t.lastHandlers!.onEvent('{"peerId":"p9","runtime":"persona"}', 7);
+    expect(seen).toEqual([[{ peerId: 'p9', runtime: 'persona' }, 7]]);
   });
 
-  it('emit: publishes the typed payload', async () => {
+  it('subscribe: onError / onClosed propagate from the transport', () => {
     const t = new MockTransport();
     const c = Continuum.connect(t);
-    await c.events.emit('data:users:created' as never, { id: 'u1' } as never);
+    let err: string | undefined;
+    let closed = false;
+    c.events.subscribe('data:users:created', {
+      onEvent: () => {},
+      onError: (m) => { err = m; },
+      onClosed: () => { closed = true; },
+    });
+    t.lastHandlers!.onError?.('route lost');
+    t.lastHandlers!.onClosed?.();
+    expect(err).toBe('route lost');
+    expect(closed).toBe(true);
+  });
+
+  it('subscribe: Subscription.unsubscribe() tears down', () => {
+    const t = new MockTransport();
+    const c = Continuum.connect(t);
+    const sub = c.events.subscribe('data:users:created', { onEvent: () => {} });
+    sub.unsubscribe();
+    expect(t.unsubscribed).toBe(1);
+  });
+
+  it('emit: publishes the typed payload, serialize-once', async () => {
+    const t = new MockTransport();
+    const c = Continuum.connect(t);
+    await c.events.emit('data:users:created', { id: 'u1' });
     expect(t.emitted[0]).toEqual({ eventClass: 'data:users:created', payloadJson: '{"id":"u1"}' });
   });
 });
 
-describe('Handle (addressable resource — long-running / streaming / multi-hop)', () => {
-  it('open returns a handle carrying its URI; ops + events route to it', async () => {
+// ─── 4. Handle (addressable resource) ───────────────────────────────────────────
+//
+// Commands + events + routing collapse into ONE addressing scheme: an open-style
+// command returns a URI, and every later op + the event stream + close route to
+// `<uri>/...`. This is the WebRTC-connection / file-session / inference-session
+// shape — and it works unchanged whether the resource is local or N hops away.
+
+describe('4. Handle — ops + event stream + close all route to one URI', () => {
+  it('open returns a handle carrying its URI; ops + events + close route to it', async () => {
     const t = new MockTransport();
     t.willReturn('{"uri":"airc://p1/live/conn-42"}');
     const c = Continuum.connect(t);
-    const conn = await c.open('ping' as never, {} as never); // ping stands in for an open-style cmd
+    const conn = await c.open('ping', {}); // ping stands in for an open-style cmd
     expect(conn.uri).toBe('airc://p1/live/conn-42');
 
-    t.willReturn('{}');
-    await conn.execute('offer', { sdp: 's' });
+    t.willReturn('{"accepted":true}');
+    const ack = await conn.execute<{ sdp: string }, { accepted: boolean }>('offer', { sdp: 's' });
     expect(t.executed.at(-1)!.command).toBe('airc://p1/live/conn-42/offer');
+    expect(ack).toEqual({ accepted: true });
 
     conn.on('signal', { onEvent: () => {} });
     expect(t.subscribed.at(-1)!.topic).toBe('airc://p1/live/conn-42/events/signal');
@@ -147,10 +259,17 @@ describe('Handle (addressable resource — long-running / streaming / multi-hop)
   });
 });
 
-describe('timing budgets (optimization-first: the SDK is a thin skin)', () => {
+// ─── 5. Timing (optimization-first: the SDK is a thin skin) ──────────────────────
+
+describe('5. timing — the hot path is ~free', () => {
   it('URI build is ~free (100k builds well under 50ms)', () => {
     const start = performance.now();
-    for (let i = 0; i < 100_000; i++) buildCommandUri('a/b', { peer: 'p', env: 'web' });
+    for (let i = 0; i < 100_000; i++) buildCommandUri('a/b', { peer: 'p', node: 'n', env: 'web' });
+    expect(performance.now() - start).toBeLessThan(50);
+  });
+  it('event-topic build is ~free (100k builds well under 50ms)', () => {
+    const start = performance.now();
+    for (let i = 0; i < 100_000; i++) buildEventTopic('grid:peer:joined', { peer: 'p1' });
     expect(performance.now() - start).toBeLessThan(50);
   });
 });

--- a/sdk/typescript/Commands.test.ts
+++ b/sdk/typescript/Commands.test.ts
@@ -1,0 +1,156 @@
+/**
+ * SDK conformance spec (TDD). The behaviors EVERY SDK must satisfy — pinned here in
+ * TS against a daemon-free MockTransport so the loop is instant (`vitest --watch`),
+ * and mirrored per language (Rust cargo, swift/kotlin) so the native twins prove
+ * the SAME contract. Includes hot-path TIMING budgets (optimization-first): the SDK
+ * is a thin skin, so URI build + serialize-once + dispatch must be ~free.
+ *
+ * Run: npm test -w @continuum/sdk-typescript   (vitest)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Continuum } from './Continuum';
+import { buildCommandUri, buildEventTopic } from './transport';
+import type {
+  Transport,
+  RawEventHandlers,
+  RawCommandHandler,
+  Subscription,
+  Registration,
+} from './transport';
+
+/** Daemon-free transport double — records what crossed the boundary. */
+class MockTransport implements Transport {
+  executed: Array<{ command: string; paramsJson: string }> = [];
+  provided = new Map<string, RawCommandHandler>();
+  subscribed: Array<{ topic: string; filterJson?: string }> = [];
+  emitted: Array<{ eventClass: string; payloadJson: string }> = [];
+  private nextResult = '{}';
+
+  willReturn(json: string) {
+    this.nextResult = json;
+  }
+  async execute(command: string, paramsJson: string): Promise<string> {
+    this.executed.push({ command, paramsJson });
+    return this.nextResult;
+  }
+  provide(command: string, handler: RawCommandHandler): Registration {
+    this.provided.set(command, handler);
+    return { remove: () => this.provided.delete(command) };
+  }
+  subscribe(topic: string, handlers: RawEventHandlers, filterJson?: string): Subscription {
+    this.subscribed.push({ topic, filterJson });
+    // expose the handler for the test to drive deliveries
+    (this as unknown as { lastHandlers: RawEventHandlers }).lastHandlers = handlers;
+    return { unsubscribe: () => {} };
+  }
+  async emit(eventClass: string, payloadJson: string): Promise<void> {
+    this.emitted.push({ eventClass, payloadJson });
+  }
+}
+
+describe('addressing (projects onto the redone CommandUri)', () => {
+  it('bare name = Local (back-compatible)', () => {
+    expect(buildCommandUri('data/list')).toBe('data/list');
+  });
+  it('peer + env = cross-environment dispatch', () => {
+    expect(buildCommandUri('interface/screenshot', { peer: 'p1', env: 'web' }))
+      .toBe('airc://p1:web/interface/screenshot');
+  });
+  it('peer@node:env carries WHO/WHERE/WHICH', () => {
+    expect(buildCommandUri('x/y', { peer: 'p1', node: 'n2', env: 'vr' }))
+      .toBe('airc://p1@n2:vr/x/y');
+  });
+  it('room fan-out', () => {
+    expect(buildCommandUri('x', { room: 'r1', env: 'web' })).toBe('airc://room:r1:web/x');
+  });
+  it('event topic: local class vs a peer’s event stream', () => {
+    expect(buildEventTopic('data:users:created')).toBe('data:users:created');
+    expect(buildEventTopic('grid:peer:joined', { peer: 'p1' }))
+      .toBe('airc://p1/events/grid:peer:joined');
+  });
+});
+
+describe('Commands primitive (execute + provide)', () => {
+  it('execute: serialize-once out, parse-once back, typed result', async () => {
+    const t = new MockTransport();
+    t.willReturn('{"ok":true,"roundTripMs":3}');
+    const c = Continuum.connect(t);
+    const r = await c.commands.execute('ping', { message: 'hi' });
+    expect(t.executed[0]).toEqual({ command: 'ping', paramsJson: '{"message":"hi"}' });
+    expect(r).toEqual({ ok: true, roundTripMs: 3 });
+  });
+
+  it('execute routes through the cross-environment URI', async () => {
+    const t = new MockTransport();
+    const c = Continuum.connect(t);
+    await c.commands.execute('interface/screenshot', { querySelector: 'body' }, { peer: 'p1', env: 'web' });
+    expect(t.executed[0].command).toBe('airc://p1:web/interface/screenshot');
+  });
+
+  it('provide: registers the platform adapter; routed call runs it + serializes back', async () => {
+    const t = new MockTransport();
+    const c = Continuum.connect(t);
+    c.commands.provide('interface/screenshot', async (p: { querySelector?: string }) => ({
+      dataUrl: `shot:${p.querySelector}`,
+      width: 1,
+      height: 1,
+    }));
+    const handler = t.provided.get('interface/screenshot')!;
+    const out = await handler.handle('{"querySelector":"body"}');
+    expect(JSON.parse(out)).toEqual({ dataUrl: 'shot:body', width: 1, height: 1 });
+  });
+});
+
+describe('Events primitive (subscribe + emit)', () => {
+  it('subscribe: source addressing + server-side filter + sequence delivery', () => {
+    const t = new MockTransport();
+    const c = Continuum.connect(t);
+    const seen: Array<[unknown, number]> = [];
+    c.events.subscribe(
+      'grid:peer:joined' as never,
+      { onEvent: (e, meta) => seen.push([e, meta.sequence]) } as never,
+      { source: { peer: 'p1' }, filter: { runtime: 'persona' } as never },
+    );
+    expect(t.subscribed[0].topic).toBe('airc://p1/events/grid:peer:joined');
+    expect(t.subscribed[0].filterJson).toBe('{"runtime":"persona"}');
+    // drive a delivery through the recorded raw handler
+    (t as unknown as { lastHandlers: RawEventHandlers }).lastHandlers.onEvent('{"runtime":"persona"}', 7);
+    expect(seen).toEqual([[{ runtime: 'persona' }, 7]]);
+  });
+
+  it('emit: publishes the typed payload', async () => {
+    const t = new MockTransport();
+    const c = Continuum.connect(t);
+    await c.events.emit('data:users:created' as never, { id: 'u1' } as never);
+    expect(t.emitted[0]).toEqual({ eventClass: 'data:users:created', payloadJson: '{"id":"u1"}' });
+  });
+});
+
+describe('Handle (addressable resource — long-running / streaming / multi-hop)', () => {
+  it('open returns a handle carrying its URI; ops + events route to it', async () => {
+    const t = new MockTransport();
+    t.willReturn('{"uri":"airc://p1/live/conn-42"}');
+    const c = Continuum.connect(t);
+    const conn = await c.open('ping' as never, {} as never); // ping stands in for an open-style cmd
+    expect(conn.uri).toBe('airc://p1/live/conn-42');
+
+    t.willReturn('{}');
+    await conn.execute('offer', { sdp: 's' });
+    expect(t.executed.at(-1)!.command).toBe('airc://p1/live/conn-42/offer');
+
+    conn.on('signal', { onEvent: () => {} });
+    expect(t.subscribed.at(-1)!.topic).toBe('airc://p1/live/conn-42/events/signal');
+
+    await conn.close();
+    expect(t.executed.at(-1)!.command).toBe('airc://p1/live/conn-42/close');
+  });
+});
+
+describe('timing budgets (optimization-first: the SDK is a thin skin)', () => {
+  it('URI build is ~free (100k builds well under 50ms)', () => {
+    const start = performance.now();
+    for (let i = 0; i < 100_000; i++) buildCommandUri('a/b', { peer: 'p', env: 'web' });
+    expect(performance.now() - start).toBeLessThan(50);
+  });
+});

--- a/sdk/typescript/Commands.ts
+++ b/sdk/typescript/Commands.ts
@@ -69,6 +69,40 @@ export interface Subscription {
   unsubscribe(): void;
 }
 
+/**
+ * WHERE a command runs — the cross-environment dimension. Projects onto the
+ * redone command-addressing infra (`CommandUri` / `RouteDecision`,
+ * `core/src/routing/`): `airc://[peer[@node]][:env]/path`. The SDK does NOT route;
+ * it builds the URI and the core's `RouteDecision` resolves it (local walk / airc
+ * to a peer / room fan-out). This is what lets a command "stretch across
+ * environments": caller, contract-origin, and executing adapter can each be in a
+ * different place.
+ *
+ * - omitted → **Local**: the caller's own substrate (bare path; back-compatible).
+ * - `peer` → a specific citizen; `node` disambiguates multi-node; **`env`** is the
+ *   WHICH-embodiment selector — `'web'` (DOM/canvas adapter), `'vr'` (renderer
+ *   capture), `'server'`, `'cli'`, … This is how `screenshot` reaches the right
+ *   client display.
+ * - `room` → fan-out to every subscriber (optionally env-filtered).
+ * - `env: '*'` on a peer → every active embodiment of that peer (broadcast).
+ */
+export type Target =
+  | { peer: string; node?: string; env?: string }
+  | { room: string; env?: string };
+
+/** Build the redone airc:// command URI from a name + optional target. Bare name
+ *  = Local (default). The core parses this back into a `CommandUri`. */
+export function buildCommandUri(name: string, target?: Target): string {
+  if (!target) return name; // Local — bare path, back-compatible
+  if ('room' in target) {
+    const env = target.env ? `:${target.env}` : '';
+    return `airc://room:${target.room}${env}/${name}`;
+  }
+  const node = target.node ? `@${target.node}` : '';
+  const env = target.env ? `:${target.env}` : '';
+  return `airc://${target.peer}${node}${env}/${name}`;
+}
+
 /** Typed event handlers — payload is the generated type for the class. */
 export interface EventHandlers<K extends EventClass> {
   onEvent(event: EventMap[K]): void;
@@ -90,8 +124,13 @@ export class Commands {
   async execute<K extends CommandName>(
     name: K,
     params: CommandMap[K]['params'],
+    target?: Target,
   ): Promise<CommandMap[K]['result']> {
-    const resultJson = await this.transport.execute(name, JSON.stringify(params));
+    // Project name + target onto the redone command-URI addressing; the core's
+    // RouteDecision resolves local-walk vs airc-to-peer vs room fan-out. `target`
+    // is the cross-environment selector (e.g. {peer, env:'web'} for screenshot).
+    const uri = buildCommandUri(name, target);
+    const resultJson = await this.transport.execute(uri, JSON.stringify(params));
     // The facade guarantees result_json is the serialized result type; the
     // generated map guarantees the static type. One cast at the boundary, typed
     // everywhere above it.

--- a/sdk/typescript/Commands.ts
+++ b/sdk/typescript/Commands.ts
@@ -1,0 +1,137 @@
+/**
+ * Commands — the elegant typed command surface for the TypeScript SDK.
+ *
+ * The whole SDK is two primitives over the headless Rust core (the FFI facade,
+ * `client/continuum-client-ffi`): request/response (`execute`) and pub/sub
+ * (`subscribe`). See docs/architecture/SDK-API-SURFACE.md.
+ *
+ * The win over the old `execute<T extends CommandParams, U extends CommandResult>`
+ * (caller supplies the generics): here both the params type AND the result type are
+ * INFERRED from the command-name literal via the generated `CommandMap`. The caller
+ * writes only the name + params and gets a fully-typed result — no `<T,U>`.
+ *
+ * Zero logic lives here ([[headless-core-many-clients]] organizing law): this is a
+ * thin typed wrapper over the facade. All behavior is in the Rust lib.
+ *
+ * NOTE: `CommandMap` / `EventMap` are GENERATED (one entry per discovered command,
+ * params/result = the ts-rs wire types in protocol/typescript/*). They are NOT a
+ * hand-maintained registry — regenerated on every command change, so the elegance
+ * stays compatible with the no-hardcoded-registry rule (CLAUDE.md).
+ */
+
+import type { CommandMap, CommandName, EventMap, EventClass } from './generated/CommandMap';
+
+/**
+ * The facade binding — the low-level JSON-at-the-boundary transport the typed
+ * layer rides on. Backed by wasm-bindgen(continuum-client) in the browser, or the
+ * RustCoreIPC wire when the core is remote. The SDK is constructed with one; it is
+ * the ONLY thing that touches bytes.
+ */
+export interface CommandTransport {
+  /** Mirrors the Rust facade: execute(command, params_json) -> result_json. */
+  execute(command: string, paramsJson: string): Promise<string>;
+  /** Mirrors the Rust facade: subscribe(class, callback) -> Subscription. */
+  subscribe(eventClass: string, handlers: RawEventHandlers): Subscription;
+  /**
+   * PROVIDE: register a handler this client implements, so the core (or a peer)
+   * can route the command HERE. The third primitive — commands are bidirectional:
+   * a client both CALLS commands (execute) and PROVIDES them. Client-provided
+   * commands (`interface/screenshot`, capture, `ping`) have a rust-origin CONTRACT
+   * (name + ts-rs types) but a per-PLATFORM adapter implementation that only the
+   * client can run — web = DOM/canvas, desktop = OS, AR/VR = capture from the
+   * renderer. The core can't screenshot the client's display; the client must.
+   * Mirrors the persona `command_inbound_pump` (server-side) at the SDK boundary.
+   * Needs a facade primitive `provide(command, handler) -> Registration`.
+   */
+  provide(command: string, handler: RawCommandHandler): Registration;
+}
+
+/** Raw (JSON-string) command handler — the facade's inbound-handler shape. */
+export interface RawCommandHandler {
+  /** Run the client-side adapter for this command; return serialized result. */
+  handle(paramsJson: string): Promise<string>;
+}
+
+/** A registered command provision; dropping it removes the handler. */
+export interface Registration {
+  remove(): void;
+}
+
+/** Raw (JSON-string) event handlers — the facade's `EventCallback` shape. */
+export interface RawEventHandlers {
+  onEvent(json: string): void;
+  onError?(message: string): void;
+  onClosed?(): void;
+}
+
+/** A live subscription; dropping it (calling `unsubscribe`) tears it down. */
+export interface Subscription {
+  unsubscribe(): void;
+}
+
+/** Typed event handlers — payload is the generated type for the class. */
+export interface EventHandlers<K extends EventClass> {
+  onEvent(event: EventMap[K]): void;
+  onError?(message: string): void;
+  onClosed?(): void;
+}
+
+/**
+ * The typed command surface. One instance per connection; holds only the
+ * transport. Every method is a typed projection over `execute`/`subscribe`.
+ */
+export class Commands {
+  constructor(private readonly transport: CommandTransport) {}
+
+  /**
+   * Execute a command. The name literal infers the params shape and the result
+   * type — `execute('data/list', { collection })` returns `Promise<DataListResult>`.
+   */
+  async execute<K extends CommandName>(
+    name: K,
+    params: CommandMap[K]['params'],
+  ): Promise<CommandMap[K]['result']> {
+    const resultJson = await this.transport.execute(name, JSON.stringify(params));
+    // The facade guarantees result_json is the serialized result type; the
+    // generated map guarantees the static type. One cast at the boundary, typed
+    // everywhere above it.
+    return JSON.parse(resultJson) as CommandMap[K]['result'];
+  }
+
+  /**
+   * Subscribe to an event class. The class literal infers the payload type, so
+   * `subscribe('data:chat_messages:created', { onEvent: m => … })` types `m` as the
+   * generated event payload.
+   */
+  subscribe<K extends EventClass>(eventClass: K, handlers: EventHandlers<K>): Subscription {
+    return this.transport.subscribe(eventClass, {
+      onEvent: (json) => handlers.onEvent(JSON.parse(json) as EventMap[K]),
+      onError: handlers.onError,
+      onClosed: handlers.onClosed,
+    });
+  }
+
+  /**
+   * PROVIDE a command this client implements — the platform adapter for a
+   * client-provided command (screenshot, capture, ping). The contract is
+   * rust-origin (params/result inferred from the name via `CommandMap`); the
+   * implementation is this platform's adapter. When the core routes the command
+   * here, `adapter` runs and its typed result is serialized back.
+   *
+   *   commands.provide('interface/screenshot', async (p) => webCapture(p));   // web
+   *   commands.provide('interface/screenshot', async (p) => rendererCapture(p)); // AR/VR
+   *
+   * Same command identity, N platform adapters (OpenCV-style adapter polymorphism).
+   */
+  provide<K extends CommandName>(
+    name: K,
+    adapter: (params: CommandMap[K]['params']) => Promise<CommandMap[K]['result']>,
+  ): Registration {
+    return this.transport.provide(name, {
+      handle: async (paramsJson) => {
+        const result = await adapter(JSON.parse(paramsJson) as CommandMap[K]['params']);
+        return JSON.stringify(result);
+      },
+    });
+  }
+}

--- a/sdk/typescript/Commands.ts
+++ b/sdk/typescript/Commands.ts
@@ -1,166 +1,47 @@
 /**
- * Commands — the elegant typed command surface for the TypeScript SDK.
+ * Commands — the typed Command primitive (CALL + SERVE) for the TS SDK.
  *
- * The whole SDK is two primitives over the headless Rust core (the FFI facade,
- * `client/continuum-client-ffi`): request/response (`execute`) and pub/sub
- * (`subscribe`). See docs/architecture/SDK-API-SURFACE.md.
+ * `execute<K>(name, params, target?)` infers BOTH params and result from the
+ * command-name literal via the generated `CommandMap` — no manual `<T,U>`.
+ * `provide<K>(name, adapter)` is the SERVE side: this client implements a command
+ * the core routes here (client-provided commands like `interface/screenshot`,
+ * capture — rust-origin contract, per-platform adapter). Commands = call + serve.
  *
- * The win over the old `execute<T extends CommandParams, U extends CommandResult>`
- * (caller supplies the generics): here both the params type AND the result type are
- * INFERRED from the command-name literal via the generated `CommandMap`. The caller
- * writes only the name + params and gets a fully-typed result — no `<T,U>`.
- *
- * Zero logic lives here ([[headless-core-many-clients]] organizing law): this is a
- * thin typed wrapper over the facade. All behavior is in the Rust lib.
- *
- * NOTE: `CommandMap` / `EventMap` are GENERATED (one entry per discovered command,
- * params/result = the ts-rs wire types in protocol/typescript/*). They are NOT a
- * hand-maintained registry — regenerated on every command change, so the elegance
- * stays compatible with the no-hardcoded-registry rule (CLAUDE.md).
+ * Zero logic ([[headless-core-many-clients]]): thin typed wrapper over the facade
+ * `Transport`. `CommandMap` is GENERATED (never a hand-maintained registry).
+ * See docs/architecture/SDK-API-SURFACE.md.
  */
 
-import type { CommandMap, CommandName, EventMap, EventClass } from './generated/CommandMap';
+import type { Transport, Registration, Target } from './transport';
+import { buildCommandUri } from './transport';
+import type { CommandMap, CommandName } from './generated/CommandMap';
 
-/**
- * The facade binding — the low-level JSON-at-the-boundary transport the typed
- * layer rides on. Backed by wasm-bindgen(continuum-client) in the browser, or the
- * RustCoreIPC wire when the core is remote. The SDK is constructed with one; it is
- * the ONLY thing that touches bytes.
- */
-export interface CommandTransport {
-  /** Mirrors the Rust facade: execute(command, params_json) -> result_json. */
-  execute(command: string, paramsJson: string): Promise<string>;
-  /** Mirrors the Rust facade: subscribe(class, callback) -> Subscription. */
-  subscribe(eventClass: string, handlers: RawEventHandlers): Subscription;
-  /**
-   * PROVIDE: register a handler this client implements, so the core (or a peer)
-   * can route the command HERE. The third primitive — commands are bidirectional:
-   * a client both CALLS commands (execute) and PROVIDES them. Client-provided
-   * commands (`interface/screenshot`, capture, `ping`) have a rust-origin CONTRACT
-   * (name + ts-rs types) but a per-PLATFORM adapter implementation that only the
-   * client can run — web = DOM/canvas, desktop = OS, AR/VR = capture from the
-   * renderer. The core can't screenshot the client's display; the client must.
-   * Mirrors the persona `command_inbound_pump` (server-side) at the SDK boundary.
-   * Needs a facade primitive `provide(command, handler) -> Registration`.
-   */
-  provide(command: string, handler: RawCommandHandler): Registration;
-}
-
-/** Raw (JSON-string) command handler — the facade's inbound-handler shape. */
-export interface RawCommandHandler {
-  /** Run the client-side adapter for this command; return serialized result. */
-  handle(paramsJson: string): Promise<string>;
-}
-
-/** A registered command provision; dropping it removes the handler. */
-export interface Registration {
-  remove(): void;
-}
-
-/** Raw (JSON-string) event handlers — the facade's `EventCallback` shape. */
-export interface RawEventHandlers {
-  onEvent(json: string): void;
-  onError?(message: string): void;
-  onClosed?(): void;
-}
-
-/** A live subscription; dropping it (calling `unsubscribe`) tears it down. */
-export interface Subscription {
-  unsubscribe(): void;
-}
-
-/**
- * WHERE a command runs — the cross-environment dimension. Projects onto the
- * redone command-addressing infra (`CommandUri` / `RouteDecision`,
- * `core/src/routing/`): `airc://[peer[@node]][:env]/path`. The SDK does NOT route;
- * it builds the URI and the core's `RouteDecision` resolves it (local walk / airc
- * to a peer / room fan-out). This is what lets a command "stretch across
- * environments": caller, contract-origin, and executing adapter can each be in a
- * different place.
- *
- * - omitted → **Local**: the caller's own substrate (bare path; back-compatible).
- * - `peer` → a specific citizen; `node` disambiguates multi-node; **`env`** is the
- *   WHICH-embodiment selector — `'web'` (DOM/canvas adapter), `'vr'` (renderer
- *   capture), `'server'`, `'cli'`, … This is how `screenshot` reaches the right
- *   client display.
- * - `room` → fan-out to every subscriber (optionally env-filtered).
- * - `env: '*'` on a peer → every active embodiment of that peer (broadcast).
- */
-export type Target =
-  | { peer: string; node?: string; env?: string }
-  | { room: string; env?: string };
-
-/** Build the redone airc:// command URI from a name + optional target. Bare name
- *  = Local (default). The core parses this back into a `CommandUri`. */
-export function buildCommandUri(name: string, target?: Target): string {
-  if (!target) return name; // Local — bare path, back-compatible
-  if ('room' in target) {
-    const env = target.env ? `:${target.env}` : '';
-    return `airc://room:${target.room}${env}/${name}`;
-  }
-  const node = target.node ? `@${target.node}` : '';
-  const env = target.env ? `:${target.env}` : '';
-  return `airc://${target.peer}${node}${env}/${name}`;
-}
-
-/** Typed event handlers — payload is the generated type for the class. */
-export interface EventHandlers<K extends EventClass> {
-  onEvent(event: EventMap[K]): void;
-  onError?(message: string): void;
-  onClosed?(): void;
-}
-
-/**
- * The typed command surface. One instance per connection; holds only the
- * transport. Every method is a typed projection over `execute`/`subscribe`.
- */
 export class Commands {
-  constructor(private readonly transport: CommandTransport) {}
+  constructor(private readonly transport: Transport) {}
 
   /**
-   * Execute a command. The name literal infers the params shape and the result
-   * type — `execute('data/list', { collection })` returns `Promise<DataListResult>`.
+   * CALL a command. The name literal infers params + result; `target` is the
+   * cross-environment selector (omitted = local; `{peer, env:'web'}` etc.).
+   * `execute('data/list', { collection })` → `Promise<DataListResult>`.
    */
   async execute<K extends CommandName>(
     name: K,
     params: CommandMap[K]['params'],
     target?: Target,
   ): Promise<CommandMap[K]['result']> {
-    // Project name + target onto the redone command-URI addressing; the core's
-    // RouteDecision resolves local-walk vs airc-to-peer vs room fan-out. `target`
-    // is the cross-environment selector (e.g. {peer, env:'web'} for screenshot).
     const uri = buildCommandUri(name, target);
     const resultJson = await this.transport.execute(uri, JSON.stringify(params));
-    // The facade guarantees result_json is the serialized result type; the
-    // generated map guarantees the static type. One cast at the boundary, typed
-    // everywhere above it.
     return JSON.parse(resultJson) as CommandMap[K]['result'];
   }
 
   /**
-   * Subscribe to an event class. The class literal infers the payload type, so
-   * `subscribe('data:chat_messages:created', { onEvent: m => … })` types `m` as the
-   * generated event payload.
-   */
-  subscribe<K extends EventClass>(eventClass: K, handlers: EventHandlers<K>): Subscription {
-    return this.transport.subscribe(eventClass, {
-      onEvent: (json) => handlers.onEvent(JSON.parse(json) as EventMap[K]),
-      onError: handlers.onError,
-      onClosed: handlers.onClosed,
-    });
-  }
-
-  /**
-   * PROVIDE a command this client implements — the platform adapter for a
-   * client-provided command (screenshot, capture, ping). The contract is
-   * rust-origin (params/result inferred from the name via `CommandMap`); the
-   * implementation is this platform's adapter. When the core routes the command
-   * here, `adapter` runs and its typed result is serialized back.
+   * PROVIDE (serve) a command this client implements — the platform adapter for a
+   * client-provided command. Contract is rust-origin (typed off `CommandMap`); the
+   * impl is this platform's adapter (web DOM · desktop OS · AR/VR renderer).
    *
-   *   commands.provide('interface/screenshot', async (p) => webCapture(p));   // web
-   *   commands.provide('interface/screenshot', async (p) => rendererCapture(p)); // AR/VR
+   *   commands.provide('interface/screenshot', async (p) => webCapture(p));
    *
-   * Same command identity, N platform adapters (OpenCV-style adapter polymorphism).
+   * One command identity, N platform adapters (OpenCV-style polymorphism).
    */
   provide<K extends CommandName>(
     name: K,

--- a/sdk/typescript/Continuum.ts
+++ b/sdk/typescript/Continuum.ts
@@ -1,0 +1,53 @@
+/**
+ * Continuum — the SDK entry point. THIS is how the SDKs work: one object over the
+ * facade Transport exposing the two primitives (commands + events) and the handle
+ * pattern. Every per-platform SDK (web/desktop, and the native swift/kotlin/flutter
+ * twins) presents this same shape — only the Transport binding differs
+ * (wasm-bindgen, RustCoreIPC wire, or the native uniffi facade).
+ *
+ * Zero logic ([[headless-core-many-clients]]): it wires Commands + Events + Handle
+ * over the Transport. All behavior is in the Rust lib; this is the idiomatic skin.
+ * See docs/architecture/{CLIENT-SDK-PLATFORM-ARCHITECTURE, SDK-API-SURFACE}.md.
+ */
+
+import type { Transport, Target } from './transport';
+import { Commands } from './Commands';
+import { Events } from './Events';
+import { Handle, handleFrom } from './Handle';
+import type { CommandMap, CommandName } from './generated/CommandMap';
+
+export class Continuum {
+  /** Request/response + serve — the Command primitive. */
+  readonly commands: Commands;
+  /** Subscribe/emit — the Event primitive (the organism's signaling). */
+  readonly events: Events;
+
+  private constructor(private readonly transport: Transport) {
+    this.commands = new Commands(transport);
+    this.events = new Events(transport);
+  }
+
+  /**
+   * Connect over a facade Transport. The platform SDK constructs the Transport
+   * (wasm/wire/native); everything above it is identical across platforms.
+   */
+  static connect(transport: Transport): Continuum {
+    return new Continuum(transport);
+  }
+
+  /**
+   * Open a long-running / streaming resource and get an addressable {@link Handle}.
+   * The open-style command's result carries the resource's `airc://` URI (result
+   * body or airc Location-style header); the Handle routes further ops + its event
+   * stream to that URI — wherever the resource lives on the grid. This is the
+   * WebRTC-connection / file-session / inference-session shape.
+   */
+  async open<K extends CommandName>(
+    name: K,
+    params: CommandMap[K]['params'],
+    target?: Target,
+  ): Promise<Handle> {
+    const result = (await this.commands.execute(name, params, target)) as { uri: string };
+    return handleFrom(result.uri, this.transport);
+  }
+}

--- a/sdk/typescript/Events.ts
+++ b/sdk/typescript/Events.ts
@@ -1,43 +1,72 @@
 /**
  * Events — the typed Event primitive (EMIT + SUBSCRIBE) for the TS SDK.
  *
- * `subscribe<K>(class, handlers)` infers the payload type from the class literal
- * via the generated `EventMap`; `emit<K>(class, payload)` publishes a typed event.
- * Events = emit + subscribe (the pub/sub twin of Commands = execute + provide).
+ * Same depth as Commands: subscribe to a SOURCE (local, or a peer's/room's events
+ * across the grid — same airc:// addressing), with SERVER-SIDE filtering (the
+ * redone AircEventPublisher's `matches_filter` — filtered events never cross the
+ * wire), and a monotonic SEQUENCE per subscription (ordering/gap detection; in a
+ * multi-hop chain any link can emit, so ordering matters). Events = emit + subscribe.
  *
  * Zero logic ([[headless-core-many-clients]]): thin typed wrapper over the facade
- * `Transport`. `EventMap` is GENERATED. Cross-grid pub/sub rides the redone
- * `AircEventPublisher`. See docs/architecture/SDK-API-SURFACE.md.
+ * `Transport`. `EventMap` generated. See docs/architecture/SDK-API-SURFACE.md.
  */
 
-import type { Transport, Subscription } from './transport';
+import type { Transport, Subscription, Target } from './transport';
+import { buildEventTopic } from './transport';
 import type { EventMap, EventClass } from './generated/CommandMap';
 
-/** Typed event handlers — payload is the generated type for the class. */
+/** Metadata delivered alongside each event (from the redone publisher frame). */
+export interface EventMeta {
+  /** Monotonic per-subscription sequence — detect ordering/gaps. */
+  sequence: number;
+}
+
+/** Typed event handlers — payload + meta typed from the class. */
 export interface EventHandlers<K extends EventClass> {
-  onEvent(event: EventMap[K]): void;
+  onEvent(event: EventMap[K], meta: EventMeta): void;
   onError?(message: string): void;
   onClosed?(): void;
+}
+
+/** Where the events come FROM (omitted = local), and an optional server-side
+ *  filter (a partial match over the payload; richer predicates pass through). */
+export interface SubscribeOptions<K extends EventClass> {
+  source?: Target;
+  filter?: Partial<EventMap[K]>;
 }
 
 export class Events {
   constructor(private readonly transport: Transport) {}
 
   /**
-   * SUBSCRIBE to an event class. The class literal infers the payload type:
-   * `subscribe('data:chat_messages:created', { onEvent: m => … })` types `m`.
+   * SUBSCRIBE to an event class. The class literal infers the payload type.
+   * `source` addresses whose events (a peer's/room's, across the grid); `filter`
+   * is applied SERVER-SIDE so non-matching events never cross the wire.
+   *
+   *   events.subscribe('data:chat_messages:created', { onEvent: (m, {sequence}) => … });
+   *   events.subscribe('grid:peer:joined', handlers, { source: { peer }, filter: { runtime: 'persona' } });
    */
-  subscribe<K extends EventClass>(eventClass: K, handlers: EventHandlers<K>): Subscription {
-    return this.transport.subscribe(eventClass, {
-      onEvent: (json) => handlers.onEvent(JSON.parse(json) as EventMap[K]),
-      onError: handlers.onError,
-      onClosed: handlers.onClosed,
-    });
+  subscribe<K extends EventClass>(
+    eventClass: K,
+    handlers: EventHandlers<K>,
+    opts?: SubscribeOptions<K>,
+  ): Subscription {
+    const topic = buildEventTopic(eventClass, opts?.source);
+    const filterJson = opts?.filter ? JSON.stringify(opts.filter) : undefined;
+    return this.transport.subscribe(
+      topic,
+      {
+        onEvent: (json, sequence) => handlers.onEvent(JSON.parse(json) as EventMap[K], { sequence }),
+        onError: handlers.onError,
+        onClosed: handlers.onClosed,
+      },
+      filterJson,
+    );
   }
 
   /**
-   * EMIT a typed event. `emit('data:chat_messages:created', message)` publishes;
-   * the redone `AircEventPublisher` fans it out to subscribers (cross-grid).
+   * EMIT a typed event. The redone `AircEventPublisher` fans it out to matching
+   * subscribers (cross-grid, server-side filtered).
    */
   async emit<K extends EventClass>(eventClass: K, payload: EventMap[K]): Promise<void> {
     await this.transport.emit(eventClass, JSON.stringify(payload));

--- a/sdk/typescript/Events.ts
+++ b/sdk/typescript/Events.ts
@@ -1,0 +1,45 @@
+/**
+ * Events — the typed Event primitive (EMIT + SUBSCRIBE) for the TS SDK.
+ *
+ * `subscribe<K>(class, handlers)` infers the payload type from the class literal
+ * via the generated `EventMap`; `emit<K>(class, payload)` publishes a typed event.
+ * Events = emit + subscribe (the pub/sub twin of Commands = execute + provide).
+ *
+ * Zero logic ([[headless-core-many-clients]]): thin typed wrapper over the facade
+ * `Transport`. `EventMap` is GENERATED. Cross-grid pub/sub rides the redone
+ * `AircEventPublisher`. See docs/architecture/SDK-API-SURFACE.md.
+ */
+
+import type { Transport, Subscription } from './transport';
+import type { EventMap, EventClass } from './generated/CommandMap';
+
+/** Typed event handlers — payload is the generated type for the class. */
+export interface EventHandlers<K extends EventClass> {
+  onEvent(event: EventMap[K]): void;
+  onError?(message: string): void;
+  onClosed?(): void;
+}
+
+export class Events {
+  constructor(private readonly transport: Transport) {}
+
+  /**
+   * SUBSCRIBE to an event class. The class literal infers the payload type:
+   * `subscribe('data:chat_messages:created', { onEvent: m => … })` types `m`.
+   */
+  subscribe<K extends EventClass>(eventClass: K, handlers: EventHandlers<K>): Subscription {
+    return this.transport.subscribe(eventClass, {
+      onEvent: (json) => handlers.onEvent(JSON.parse(json) as EventMap[K]),
+      onError: handlers.onError,
+      onClosed: handlers.onClosed,
+    });
+  }
+
+  /**
+   * EMIT a typed event. `emit('data:chat_messages:created', message)` publishes;
+   * the redone `AircEventPublisher` fans it out to subscribers (cross-grid).
+   */
+  async emit<K extends EventClass>(eventClass: K, payload: EventMap[K]): Promise<void> {
+    await this.transport.emit(eventClass, JSON.stringify(payload));
+  }
+}

--- a/sdk/typescript/Handle.ts
+++ b/sdk/typescript/Handle.ts
@@ -1,0 +1,62 @@
+/**
+ * Handle — an addressable resource (a URI) for long-running / streaming / stateful
+ * work. The establish-once-reuse-many pattern (substrate `InferenceHandleStore`,
+ * AI-COMMAND-NAMESPACE.md §2), made addressable: an `open`-style command returns a
+ * handle carrying its `airc://` URI (in the result, or an airc `Location`-style
+ * header), and EVERYTHING routes to that URI:
+ *   - further commands  → `<uri>/<subcommand>`  (write/read/…; wherever the
+ *     resource lives — a peer, an :vr env, N hops away)
+ *   - event stream      → `<uri>/events/<class>` (fed by ANY link in a router
+ *     chain; the live stream from across the grid)
+ *   - close             → `<uri>/close`
+ *
+ * So commands + events + handles + routing collapse into one addressing scheme.
+ * Zero logic ([[headless-core-many-clients]]): thin over the facade Transport.
+ * See docs/architecture/SDK-API-SURFACE.md § "Handles are addressable resources".
+ */
+
+import type { Transport, Subscription, RawEventHandlers } from './transport';
+
+/** Typed handler for a handle's event stream (payload typing is per-resource;
+ *  generated handle maps refine this — kept `unknown` here at the generic base). */
+export interface HandleEventHandlers {
+  onEvent(event: unknown, sequence: number): void;
+  onError?(message: string): void;
+  onClosed?(): void;
+}
+
+export class Handle {
+  /** The resource's airc:// URI — the routing key for every op + its event stream. */
+  constructor(readonly uri: string, private readonly transport: Transport) {}
+
+  /** Run a handle-scoped subcommand, routed to the handle's URI (write/read/…). */
+  async execute<P, R>(subcommand: string, params: P): Promise<R> {
+    const resultJson = await this.transport.execute(
+      `${this.uri}/${subcommand}`,
+      JSON.stringify(params),
+    );
+    return JSON.parse(resultJson) as R;
+  }
+
+  /** Subscribe to the handle's event stream — fed by any link across the grid. */
+  on(eventClass: string, handlers: HandleEventHandlers): Subscription {
+    const raw: RawEventHandlers = {
+      onEvent: (json, sequence) => handlers.onEvent(JSON.parse(json), sequence),
+      onError: handlers.onError,
+      onClosed: handlers.onClosed,
+    };
+    return this.transport.subscribe(`${this.uri}/events/${eventClass}`, raw);
+  }
+
+  /** Release the resource. */
+  async close(): Promise<void> {
+    await this.transport.execute(`${this.uri}/close`, '{}');
+  }
+}
+
+/** Wrap an open-style command's result (which carries the resource URI) into a
+ *  Handle. The URI comes from the result body or an airc Location-style header —
+ *  the caller passes whichever the facade surfaced. */
+export function handleFrom(uri: string, transport: Transport): Handle {
+  return new Handle(uri, transport);
+}

--- a/sdk/typescript/generated/CommandMap.ts
+++ b/sdk/typescript/generated/CommandMap.ts
@@ -1,0 +1,42 @@
+/**
+ * CommandMap / EventMap — GENERATED. DO NOT EDIT BY HAND.
+ *
+ * One entry per discovered command/event; `params`/`result`/payload are the
+ * ts-rs-generated wire types in `protocol/typescript/*`. Regenerated on every
+ * command change, so the typed SDK surface never drifts and is never a
+ * hand-maintained registry (CLAUDE.md anti-pattern: no central command list).
+ *
+ * The generator (SDK-API-SURFACE.md open item #1) emits this from the command
+ * manifest + the ts-rs types. Until it lands, this stub carries a few real
+ * entries so `Commands.ts` type-checks and the shape is demonstrated. Replace
+ * wholesale on first generation.
+ *
+ * NOTE the bidirectional split (SDK-API-SURFACE.md § "Commands are bidirectional"):
+ * the SAME map types both the CALLER side (`execute`) and the PROVIDER side
+ * (`provide`). A client-provided command like `interface/screenshot` appears here
+ * with a rust-origin contract; its per-platform adapter is supplied via `provide`.
+ */
+
+// --- Placeholder wire types (the real ones import from protocol/typescript/*) ---
+// Replaced by generation; inline here only so the stub type-checks standalone.
+export interface PingParams { message?: string }
+export interface PingResult { ok: boolean; roundTripMs: number }
+export interface ScreenshotParams { querySelector?: string; filename?: string }
+export interface ScreenshotResult { dataUrl: string; width: number; height: number }
+
+/** name -> { params, result }. Generated; the contract is rust-origin. */
+export interface CommandMap {
+  'ping': { params: PingParams; result: PingResult };
+  // Client-PROVIDED command: rust-origin contract, per-platform SDK adapter
+  // (web DOM/canvas · desktop OS · AR/VR renderer capture). See `Commands.provide`.
+  'interface/screenshot': { params: ScreenshotParams; result: ScreenshotResult };
+}
+
+export type CommandName = keyof CommandMap;
+
+/** event class -> payload. Generated. */
+export interface EventMap {
+  // e.g. 'data:chat_messages:created': ChatMessage  (generated)
+}
+
+export type EventClass = keyof EventMap;

--- a/sdk/typescript/generated/CommandMap.ts
+++ b/sdk/typescript/generated/CommandMap.ts
@@ -23,10 +23,19 @@ export interface PingParams { message?: string }
 export interface PingResult { ok: boolean; roundTripMs: number }
 export interface ScreenshotParams { querySelector?: string; filename?: string }
 export interface ScreenshotResult { dataUrl: string; width: number; height: number }
+/** A command with NESTED params — pins serialize-once fidelity for the conformance
+ *  spec (a twin that flattens/reorders nested objects breaks here). */
+export interface DataListParams {
+  collection: string;
+  orderBy?: Array<{ field: string; direction: 'asc' | 'desc' }>;
+  filter?: Record<string, unknown>;
+}
+export interface DataListResult { items: unknown[]; total: number }
 
 /** name -> { params, result }. Generated; the contract is rust-origin. */
 export interface CommandMap {
   'ping': { params: PingParams; result: PingResult };
+  'data/list': { params: DataListParams; result: DataListResult };
   // Client-PROVIDED command: rust-origin contract, per-platform SDK adapter
   // (web DOM/canvas · desktop OS · AR/VR renderer capture). See `Commands.provide`.
   'interface/screenshot': { params: ScreenshotParams; result: ScreenshotResult };
@@ -34,9 +43,14 @@ export interface CommandMap {
 
 export type CommandName = keyof CommandMap;
 
+// --- Placeholder event payloads (real ones import from protocol/typescript/*) ---
+export interface GridPeerJoined { peerId: string; runtime: 'persona' | 'human' | 'agent' }
+export interface UserCreated { id: string }
+
 /** event class -> payload. Generated. */
 export interface EventMap {
-  // e.g. 'data:chat_messages:created': ChatMessage  (generated)
+  'grid:peer:joined': GridPeerJoined;
+  'data:users:created': UserCreated;
 }
 
 export type EventClass = keyof EventMap;

--- a/sdk/typescript/index.ts
+++ b/sdk/typescript/index.ts
@@ -1,0 +1,32 @@
+/**
+ * @continuum/sdk-typescript — the TypeScript SDK barrel.
+ *
+ * THIS is how the SDKs work: a thin typed skin over the headless Rust core's facade
+ * (Commands + Events + Handle, the two primitives × two directions), generated
+ * types, zero logic. The native SDKs (swift/kotlin/flutter) present the same shape.
+ *
+ * Usage:
+ *   import { Continuum } from '@continuum/sdk-typescript';
+ *   const continuum = Continuum.connect(transport);        // transport = the facade binding
+ *   const users = await continuum.commands.execute('data/list', { collection: 'users' });
+ *   continuum.events.subscribe('data:users:created', { onEvent: (u) => … });
+ *   continuum.commands.provide('interface/screenshot', async (p) => webCapture(p));
+ *   const conn = await continuum.open('live/connect', { room }, { env: 'web' });
+ */
+
+export { Continuum } from './Continuum';
+export { Commands } from './Commands';
+export { Events } from './Events';
+export type { EventHandlers, EventMeta, SubscribeOptions } from './Events';
+export { Handle, handleFrom } from './Handle';
+export type { HandleEventHandlers } from './Handle';
+export type {
+  Transport,
+  Target,
+  Subscription,
+  Registration,
+  RawCommandHandler,
+  RawEventHandlers,
+} from './transport';
+export { buildCommandUri, buildEventTopic } from './transport';
+export type { CommandMap, CommandName, EventMap, EventClass } from './generated/CommandMap';

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -11,9 +11,12 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
   }
 }

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -4,6 +4,11 @@
   "private": true,
   "description": "TypeScript SDK for the Continuum substrate — the thin typed client every JS/TS client (apps/web, apps/desktop, apps/mcp) talks to the headless Rust core through. Commands.execute / Events over IPC/WebSocket; NO business logic (substrate decisions live in core/). The Rust-first analog of sdk/{swift,kotlin} and client/continuum-client.",
   "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "exports": {
+    ".": "./index.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@continuum/sdk-typescript",
+  "version": "0.1.0",
+  "private": true,
+  "description": "TypeScript SDK for the Continuum substrate — the thin typed client every JS/TS client (apps/web, apps/desktop, apps/mcp) talks to the headless Rust core through. Commands.execute / Events over IPC/WebSocket; NO business logic (substrate decisions live in core/). The Rust-first analog of sdk/{swift,kotlin} and client/continuum-client.",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  }
+}

--- a/sdk/typescript/transport.ts
+++ b/sdk/typescript/transport.ts
@@ -1,0 +1,78 @@
+/**
+ * transport — the facade binding the typed SDK rides on.
+ *
+ * The substrate has exactly TWO primitives, each BIDIRECTIONAL (SDK-API-SURFACE.md):
+ *   Commands = execute (call) + provide (serve)
+ *   Events   = emit    (publish) + subscribe (listen)
+ * => FOUR facade methods. The Rust FFI facade (`client/continuum-client-ffi`,
+ * #1663) shipped `execute` + `subscribe`; `provide` + `emit` are the serve/publish
+ * sides still being bound (flag to the facade owner — bind all four in one .udl
+ * pass so the native binding is complete in one shot).
+ *
+ * This is the ONLY layer that touches bytes (JSON strings at the boundary). The
+ * typed Commands/Events classes are thin generics over it; all logic is in the
+ * Rust lib ([[headless-core-many-clients]]).
+ */
+
+/** The facade binding — wasm-bindgen(continuum-client) in browser, RustCoreIPC
+ *  wire when the core is remote. JSON at the boundary; generic-free. */
+export interface Transport {
+  /** Command CALL: execute(command, params_json) -> result_json. (#1663) */
+  execute(command: string, paramsJson: string): Promise<string>;
+  /** Command SERVE: register a handler this client provides. (facade gap) */
+  provide(command: string, handler: RawCommandHandler): Registration;
+  /** Event LISTEN: subscribe(class, callback) -> Subscription. (#1663) */
+  subscribe(eventClass: string, handlers: RawEventHandlers): Subscription;
+  /** Event PUBLISH: emit(class, payload_json). (facade gap) */
+  emit(eventClass: string, payloadJson: string): Promise<void>;
+}
+
+/** Raw (JSON-string) command handler — the facade's inbound-handler shape. */
+export interface RawCommandHandler {
+  handle(paramsJson: string): Promise<string>;
+}
+
+/** Raw (JSON-string) event handlers — the facade's `EventCallback` shape. */
+export interface RawEventHandlers {
+  onEvent(json: string): void;
+  onError?(message: string): void;
+  onClosed?(): void;
+}
+
+/** A live subscription; `unsubscribe()` tears it down (facade Drop). */
+export interface Subscription {
+  unsubscribe(): void;
+}
+
+/** A registered command provision; `remove()` deregisters it (facade Drop). */
+export interface Registration {
+  remove(): void;
+}
+
+/**
+ * WHERE a command runs — the cross-environment dimension. Projects onto the redone
+ * command addressing (`CommandUri`/`RouteDecision`, `core/src/routing/`):
+ * `airc://[peer[@node]][:env]/path`. The SDK builds the URI; the core's
+ * `RouteDecision` resolves local-walk / airc-to-peer / room fan-out (and, when
+ * multi-hop lands, forwards across grid routers — no surface change).
+ *
+ * - omitted → Local (caller's own substrate; bare path, back-compatible).
+ * - `{peer, node?, env?}` → a citizen; `env` = WHICH embodiment ('web'|'vr'|…).
+ * - `{room, env?}` → fan-out to subscribers.
+ * - `env: '*'` on a peer → every embodiment (broadcast).
+ */
+export type Target =
+  | { peer: string; node?: string; env?: string }
+  | { room: string; env?: string };
+
+/** Build the redone airc:// command URI from a name + optional target. */
+export function buildCommandUri(name: string, target?: Target): string {
+  if (!target) return name; // Local — bare path
+  if ('room' in target) {
+    const env = target.env ? `:${target.env}` : '';
+    return `airc://room:${target.room}${env}/${name}`;
+  }
+  const node = target.node ? `@${target.node}` : '';
+  const env = target.env ? `:${target.env}` : '';
+  return `airc://${target.peer}${node}${env}/${name}`;
+}

--- a/sdk/typescript/transport.ts
+++ b/sdk/typescript/transport.ts
@@ -21,8 +21,14 @@ export interface Transport {
   execute(command: string, paramsJson: string): Promise<string>;
   /** Command SERVE: register a handler this client provides. (facade gap) */
   provide(command: string, handler: RawCommandHandler): Registration;
-  /** Event LISTEN: subscribe(class, callback) -> Subscription. (#1663) */
-  subscribe(eventClass: string, handlers: RawEventHandlers): Subscription;
+  /**
+   * Event LISTEN: subscribe(topic, callback, filter?) -> Subscription. (#1663
+   * shipped the bare 2-arg form; `filterJson` is the events-side refinement — the
+   * redone AircEventPublisher applies it SERVER-SIDE via `matches_filter`, so
+   * filtered-out events never cross the wire.) `topic` may be a bare class (local)
+   * or an `airc://<peer>/events/<class>` address (a remote peer's events).
+   */
+  subscribe(topic: string, handlers: RawEventHandlers, filterJson?: string): Subscription;
   /** Event PUBLISH: emit(class, payload_json). (facade gap) */
   emit(eventClass: string, payloadJson: string): Promise<void>;
 }
@@ -32,9 +38,11 @@ export interface RawCommandHandler {
   handle(paramsJson: string): Promise<string>;
 }
 
-/** Raw (JSON-string) event handlers — the facade's `EventCallback` shape. */
+/** Raw (JSON-string) event handlers — the facade's `EventCallback` shape. The
+ *  `sequence` is the redone AircEventPublisher's monotonic per-subscription
+ *  counter — lets subscribers detect ordering/gaps (multi-hop, any link emits). */
 export interface RawEventHandlers {
-  onEvent(json: string): void;
+  onEvent(json: string, sequence: number): void;
   onError?(message: string): void;
   onClosed?(): void;
 }
@@ -75,4 +83,13 @@ export function buildCommandUri(name: string, target?: Target): string {
   const node = target.node ? `@${target.node}` : '';
   const env = target.env ? `:${target.env}` : '';
   return `airc://${target.peer}${node}${env}/${name}`;
+}
+
+/** Build the event topic address — bare class (local), or a SOURCE peer's/room's
+ *  event topic across the grid: `airc://<peer|room>/events/<class>` (the redone
+ *  AircEventPublisher subscribe path). Same destination-addressing as commands. */
+export function buildEventTopic(eventClass: string, source?: Target): string {
+  if (!source) return eventClass; // local events
+  const authority = 'room' in source ? `room:${source.room}` : source.peer;
+  return `airc://${authority}/events/${eventClass}`;
 }

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "//": "Self-contained strict config for @continuum/sdk-typescript. The SDK holds ZERO logic (headless-core-many-clients) — just the facade Transport + typed Commands/Events/Handle over generated wire types — so it compiles standalone with no project references. strict is non-negotiable: this is the contract surface the native twins mirror.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/tools/scripts/parallel-start.sh
+++ b/tools/scripts/parallel-start.sh
@@ -487,24 +487,31 @@ else
 fi
 cleanup_startup_pause
 
-# Phase 6: Browser attach happens only after seed. This script owns the final
-# post-seed refresh/open so the orchestrator cannot race UI hydration against
-# database synchronization.
+# Phase 6: HEADLESS IS THE DEFAULT. `npm start` brings up the substrate (core +
+# server) and NEVER launches a desktop — servers (AWS, BigMama, grid nodes) run
+# headless, which is the first-class operating mode. The desktop is a DEPENDENT
+# overlay that attaches LATER, deliberately, through its one owner — the Rust
+# `LaunchModeModule` (`system/launch-mode/{get,set}`) driven by the menu-bar
+# tray / a setting / a prompt. This launcher does NOT read or write the
+# `CONTINUUM_LAUNCH_MODE` setting in config.env (one class owns that file — not
+# bash scripts cutting through it), and it does NOT open a browser window.
+#
+# The one thing it still does: if a human ALREADY has a UI tab connected, refresh
+# it post-seed so it doesn't render against a half-seeded DB. That's refreshing an
+# existing overlay the human chose to open — not launching the desktop.
 BROWSER_CONNECTED=false
 if [ "$SEED_OK" = true ]; then
-  echo -e "  ${YELLOW}Attaching browser after seed...${NC}"
   PING_OUTPUT=$(./jtag ping --timeout=5000 2>/dev/null || echo '{}')
   if echo "$PING_OUTPUT" | grep -q '"browser"' 2>/dev/null; then
+    echo -e "  ${YELLOW}Refreshing already-connected UI overlay after seed...${NC}"
     if ./jtag interface/navigate >/dev/null 2>&1; then
       BROWSER_CONNECTED=true
-      echo -e "  ${GREEN}Browser refreshed after seed${NC}"
+      echo -e "  ${GREEN}UI overlay refreshed after seed${NC}"
     else
       ./jtag development/exec --code="location.reload()" >/dev/null 2>&1 || true
     fi
-  elif command -v open >/dev/null 2>&1; then
-    open "http://localhost:9000/chat/general" >/dev/null 2>&1 || true
-  elif command -v xdg-open >/dev/null 2>&1; then
-    xdg-open "http://localhost:9000/chat/general" >/dev/null 2>&1 || true
+  else
+    echo -e "  ${GREEN}Headless — no desktop launched (attach a UI via the tray / launch-mode setting)${NC}"
   fi
 fi
 if [ "$HOT_RESTART" = true ]; then


### PR DESCRIPTION
## What
Two coherent moves toward **headless core + many equal clients**:

### 1. `npm start` boots headless (no privileged client)
`parallel-start.sh` no longer force-opens a desktop. Boots core + server headless; only refreshes a UI overlay a human *already* attached. No `config.env` reads, no `has_display` guessing.

### 2. Client topology — package.json homes under `apps/`
The READMEs already specced this; now it's real:
- **root `package.json`** = the SERVER. `npm start` boots ONLY the headless Rust core (`start-server.sh`). Declares the workspace + client entry points (`dev:web`, `dev:desktop`). Legacy all-in-one dev path preserved as `desktop:legacy`.
- **`sdk/typescript`** (`@continuum/sdk-typescript`) — thin typed SDK every JS/TS client talks to the core through. Sibling of `sdk/{swift,kotlin}` + `client/continuum-client` (Rust).
- **`apps/web`** (`@continuum/web`) — thin browser shell (lit + vite); future home of legacy `src/{browser,widgets,server,daemons}` (#215).
- **`apps/desktop`** (`@continuum/desktop`) — Tauri shell wrapping `apps/web`, next to it.

## Doctrine
- **Rust-first.** `apps/cli` is already Rust (`continuum-cli`/`ctm`, no Node). Only genuinely-web clients get package.json. Headless users never install node — npm is the web-client-dev convenience only.
- **`config.env` has one owner** (Rust `config_env.rs` / `LaunchModeModule`); bash must not cut through it.
- Desktop is **one of many** equal clients (web/desktop/cli/mobile/vr/ar/mcp), never the server's job.

## Validation
Bash syntax + JSON validated. `npm start` (headless) and full workspace install/build resolution need a node host to confirm — out of reach here (no node), consistent with the headless-first thesis.

## Next (incremental, not this PR)
Decompose `src/{browser,widgets,server,daemons}` → `apps/web` (#215); flesh `apps/desktop` (Tauri) + `sdk/typescript`; route all `config.env` access through the Rust owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)