### PR TITLE
feat(client): continuum-client-ffi — the FFI-clean JSON-boundary SDK facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,6 +2691,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "continuum-client-ffi"
+version = "0.1.0"
+dependencies = [
+ "airc-lib",
+ "continuum-client",
+ "futures",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "continuum-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ members = [
 
     # client/ — shared client lib (consumed by CLI + mobile SDK FFI)
     "client/continuum-client",
+    # FFI-clean JSON-boundary facade — the single binding source per-platform SDKs wrap
+    "client/continuum-client-ffi",
 
     # apps/ — first-party UI shells / embodiments
     "apps/cli",

--- a/client/continuum-client-ffi/Cargo.toml
+++ b/client/continuum-client-ffi/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "continuum-client-ffi"
+version = "0.1.0"
+edition = "2021"
+description = "FFI-clean JSON-boundary facade over continuum-client. The single binding source the per-platform SDKs wrap (uniffi → native/flutter; wasm-bindgen → web). execute(command, params_json)->result_json + subscribe(class, callback)."
+
+[dependencies]
+continuum-client = { path = "../continuum-client" }
+airc-lib = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+futures = "0.3"
+tokio = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+# Enable continuum-client's MockTransport so the boundary logic is tested
+# without a live airc daemon (the test-fixtures contract).
+continuum-client = { path = "../continuum-client", features = ["test-fixtures"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }

--- a/client/continuum-client-ffi/src/lib.rs
+++ b/client/continuum-client-ffi/src/lib.rs
@@ -1,0 +1,294 @@
+//! continuum-client-ffi — the FFI-clean JSON-boundary facade over
+//! `continuum-client`.
+//!
+//! The single binding source every per-platform SDK wraps. `Commands.execute`
+//! is generic (`<P, R>`) and generics can't cross an FFI boundary, so this
+//! facade reduces the two universal primitives to their JSON-at-the-boundary
+//! form — exactly what they ARE on the wire (cross-grid via airc ==
+//! cross-language via FFI, same shape):
+//!
+//! - `execute(command, params_json) -> result_json`
+//! - `subscribe(class, callback)` streaming `event_json` to a foreign callback
+//!
+//! Each language SDK adds the typed/idiomatic layer on top (Swift async/await +
+//! `AsyncStream`, Kotlin suspend + `Flow`, Dart `Stream`, TS Promise) from
+//! GENERATED types — never hand-written. The JSON shape is the canonical
+//! contract; this facade is the generic-free, tiny, stable surface the
+//! generators bind.
+//!
+//! Distribution (see docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md):
+//! uniffi reads this crate → one native binding → xcframework (Apple) + AAR
+//! (Android); the native SDKs wrap those; Flutter bundles them; web takes a
+//! separate wasm-bindgen path over the same facade.
+//!
+//! This module is the tool-agnostic Rust core. The uniffi `.udl` / annotations
+//! and the wasm-bindgen layer are thin per-target shells over `ContinuumClient`
+//! + the boundary helpers below.
+
+use std::sync::Arc;
+
+use continuum_client::{
+    AircIpcTransport, ClientError, CommandClient, Connection, EventSubscriber, Transport,
+};
+use futures::StreamExt;
+use uuid::Uuid;
+
+/// FFI-clean error. `continuum-client`'s `ClientError` is rich and Rust-shaped;
+/// this flattens it to the few variants a foreign caller needs, each carrying a
+/// human message. A refusal keeps `command` + `reason` since callers branch on
+/// "the substrate said no" vs "the transport broke".
+#[derive(Debug, thiserror::Error)]
+pub enum FfiError {
+    /// Establishing the session failed.
+    #[error("connect failed: {0}")]
+    Connect(String),
+    /// The session is closed; further calls won't succeed.
+    #[error("connection closed")]
+    Closed,
+    /// The substrate received the command but refused it.
+    #[error("command `{command}` refused: {reason}")]
+    Refused { command: String, reason: String },
+    /// Params/result JSON did not encode or decode.
+    #[error("codec error: {0}")]
+    Codec(String),
+    /// The transport layer failed (IPC, wire, etc.).
+    #[error("transport error: {0}")]
+    Transport(String),
+}
+
+impl From<ClientError> for FfiError {
+    fn from(e: ClientError) -> Self {
+        match e {
+            ClientError::Connect(m) => FfiError::Connect(m),
+            ClientError::Closed => FfiError::Closed,
+            ClientError::Refused { command, reason } => FfiError::Refused { command, reason },
+            ClientError::Codec(m) => FfiError::Codec(m),
+            ClientError::Transport(m) => FfiError::Transport(m),
+            ClientError::NotImplemented(m) => FfiError::Transport(format!("not implemented: {m}")),
+        }
+    }
+}
+
+/// A foreign-implemented sink for an event subscription. uniffi exposes this as
+/// a callback interface; each SDK adapts it into the platform's stream type
+/// (`AsyncStream` / `Flow` / `Stream`). Plain trait here so the facade is
+/// tool-agnostic and unit-testable.
+pub trait EventCallback: Send + Sync {
+    /// One event, already serialized to a JSON string.
+    fn on_event(&self, event_json: String);
+    /// A recoverable error on the stream (the stream stays open).
+    fn on_error(&self, message: String);
+    /// The stream ended (substrate closed it or the subscription was dropped).
+    fn on_closed(&self);
+}
+
+/// Run one command over a connection's command client, JSON in / JSON out.
+/// Generic over `Transport` so it's tested against `MockTransport` without a
+/// live daemon; the concrete [`ContinuumClient`] delegates here.
+async fn execute_json<T: Transport>(
+    commands: CommandClient<T>,
+    command: &str,
+    params_json: &str,
+) -> Result<String, FfiError> {
+    let params: serde_json::Value =
+        serde_json::from_str(params_json).map_err(|e| FfiError::Codec(e.to_string()))?;
+    // CommandClient::execute is generic; monomorphize to Value→Value — the
+    // JSON-value transport boundary is exactly what it wraps.
+    let result: serde_json::Value = commands.execute(command, params).await?;
+    serde_json::to_string(&result).map_err(|e| FfiError::Codec(e.to_string()))
+}
+
+/// Drive an event subscription into a foreign callback until the stream ends.
+/// Generic for testability; the concrete client spawns this on a task.
+async fn pump_events<T: Transport>(
+    events: EventSubscriber<T>,
+    class: String,
+    callback: Arc<dyn EventCallback>,
+) {
+    match events.subscribe(&class).await {
+        Ok(mut stream) => {
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(value) => match serde_json::to_string(&value) {
+                        Ok(json) => callback.on_event(json),
+                        Err(e) => callback.on_error(format!("event encode failed: {e}")),
+                    },
+                    Err(e) => callback.on_error(e.to_string()),
+                }
+            }
+            callback.on_closed();
+        }
+        Err(e) => callback.on_error(e.to_string()),
+    }
+}
+
+/// An open subscription. Dropping it aborts the pump task — so a foreign caller
+/// unsubscribes simply by releasing this handle (no explicit close call to
+/// forget). Without this an event subscription would leak its task.
+pub struct Subscription {
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for Subscription {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+/// The concrete, generic-free client a foreign binding holds. Wraps a
+/// `Connection` over the real airc IPC transport; the per-platform binding
+/// (uniffi/wasm) exposes exactly `execute` + `subscribe`.
+pub struct ContinuumClient {
+    conn: Connection<AircIpcTransport>,
+}
+
+impl ContinuumClient {
+    /// Build over an established airc handle + the substrate's peer id. The CLI
+    /// (Rust) calls this directly; the per-platform glue builds the airc handle
+    /// then calls this. (A foreign-friendly `connect(home, peer)` constructor
+    /// that builds the handle internally is the next thin layer.)
+    pub fn new(airc: Arc<airc_lib::Airc>, target_peer: Uuid) -> Self {
+        Self {
+            conn: Connection::connect(airc, target_peer),
+        }
+    }
+
+    /// Execute a command: JSON params in, JSON result out.
+    pub async fn execute(&self, command: &str, params_json: &str) -> Result<String, FfiError> {
+        execute_json(self.conn.commands(), command, params_json).await
+    }
+
+    /// Subscribe to an event class; events stream to `callback` as JSON strings
+    /// until the returned [`Subscription`] is dropped.
+    pub fn subscribe(&self, class: &str, callback: Arc<dyn EventCallback>) -> Subscription {
+        let handle = tokio::spawn(pump_events(self.conn.events(), class.to_string(), callback));
+        Subscription { handle }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use continuum_client::MockTransport;
+    use serde_json::json;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    /// A test sink that records callback invocations.
+    #[derive(Default)]
+    struct Recorder {
+        events: Mutex<Vec<String>>,
+        errors: Mutex<Vec<String>>,
+        closed: Mutex<bool>,
+    }
+    impl EventCallback for Recorder {
+        fn on_event(&self, event_json: String) {
+            self.events.lock().unwrap().push(event_json);
+        }
+        fn on_error(&self, message: String) {
+            self.errors.lock().unwrap().push(message);
+        }
+        fn on_closed(&self) {
+            *self.closed.lock().unwrap() = true;
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_round_trips_json_at_the_boundary() {
+        // what this catches: the facade must serialize params_json → Value,
+        // dispatch, and serialize the result Value → result_json — the whole
+        // point of the generic-free FFI surface.
+        let mock = MockTransport::new();
+        mock.respond_to("data/get", |params| {
+            assert_eq!(params, json!({ "id": "abc" }));
+            Ok(json!({ "id": "abc", "value": 42 }))
+        });
+        let conn = Connection::new(mock);
+        let out = execute_json(conn.commands(), "data/get", r#"{"id":"abc"}"#)
+            .await
+            .expect("executes");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&out).unwrap(),
+            json!({ "id": "abc", "value": 42 })
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_params_json_is_a_codec_error_not_a_dispatch() {
+        // what this catches: bad JSON must fail at the boundary as Codec, never
+        // reach the substrate as a garbage command.
+        let conn = Connection::new(MockTransport::new());
+        let err = execute_json(conn.commands(), "x", "{not json")
+            .await
+            .expect_err("rejects malformed params");
+        assert!(matches!(err, FfiError::Codec(_)));
+    }
+
+    #[tokio::test]
+    async fn substrate_refusal_maps_to_ffi_refused() {
+        // what this catches: a substrate "no" must surface as FfiError::Refused
+        // (command + reason), distinct from a transport break.
+        let mock = MockTransport::new();
+        mock.respond_to("danger", |_| {
+            Err(ClientError::Refused {
+                command: "danger".to_string(),
+                reason: "not allowed".to_string(),
+            })
+        });
+        let conn = Connection::new(mock);
+        let err = execute_json(conn.commands(), "danger", "{}")
+            .await
+            .expect_err("refused");
+        match err {
+            FfiError::Refused { command, reason } => {
+                assert_eq!(command, "danger");
+                assert_eq!(reason, "not allowed");
+            }
+            other => panic!("expected Refused, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn subscribe_streams_events_as_json_to_the_callback() {
+        // what this catches: emitted substrate events must reach the foreign
+        // callback as JSON strings (the event half of the boundary), and a
+        // stream close must surface as on_closed.
+        let mock = MockTransport::new(); // Clone-shares Inner; keep a handle to emit/close
+        let conn = Connection::new(mock.clone());
+        let rec = Arc::new(Recorder::default());
+
+        let cb: Arc<dyn EventCallback> = rec.clone();
+        let pump = tokio::spawn(pump_events(
+            conn.events(),
+            "persona.response".to_string(),
+            cb,
+        ));
+
+        // Wait deterministically until the pump has registered its subscription.
+        for _ in 0..100 {
+            if mock.subscriber_count("persona.response") == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert_eq!(
+            mock.subscriber_count("persona.response"),
+            1,
+            "pump subscribed"
+        );
+
+        mock.emit("persona.response", json!({ "text": "hi" }));
+        // close() drops the subscriber sender → the buffered event drains, then
+        // the stream yields None and the pump calls on_closed.
+        mock.close().await.expect("close");
+        let _ = tokio::time::timeout(Duration::from_secs(2), pump).await;
+
+        let events = rec.events.lock().unwrap();
+        assert_eq!(events.len(), 1, "one event delivered");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&events[0]).unwrap(),
+            json!({ "text": "hi" })
+        );
+        assert!(*rec.closed.lock().unwrap(), "stream close surfaced");
+    }
+}

--- a/client/continuum-client/src/mock.rs
+++ b/client/continuum-client/src/mock.rs
@@ -70,6 +70,11 @@ type CommandHandler = Box<dyn Fn(Value) -> Result<Value, ClientError> + Send + S
 /// drop a specific subscriber.
 #[derive(Debug)]
 struct Subscriber {
+    // Stable id for diagnostics (rides the `Debug` impl) + future
+    // drop-a-specific-subscriber tests. Not read on the hot path, so dead-code
+    // analysis (which ignores Debug-only use) flags it under `-D warnings`;
+    // the field is an intentional fixture slot, not dead.
+    #[allow(dead_code)]
     id: u64,
     tx: mpsc::Sender<Result<Value, ClientError>>,
 }


### PR DESCRIPTION
## What

The **foundation** of the client-SDK work (the layered model M5 captured in `docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md`): **one Rust crate, N language frontends.**

`Commands.execute` is generic `<P,R>` and generics can't cross an FFI boundary, so this facade reduces the two universal primitives to their **JSON-at-the-boundary** form — exactly what they ARE on the wire (cross-grid via airc == cross-language via FFI, same shape):

- `execute(command, params_json) -> result_json` (`CommandClient::execute::<Value,Value>`)
- `subscribe(class, callback)` streaming `event_json` to a foreign `EventCallback`, returning a `Subscription` whose `Drop` aborts the pump (**release = unsubscribe**, no leak)
- `FfiError`: flat, FFI-clean projection of `ClientError` (`Refused` keeps `command`+`reason` so callers branch "substrate said no" vs "transport broke")

This is **the single binding source** the per-platform SDKs wrap: uniffi reads this → one native binding → xcframework (Apple) + AAR (Android) → swift/kotlin SDKs → Flutter bundles them; web takes a separate wasm-bindgen path over the *same* facade. M5 architects the canonical command/event **set** this projects; this is the generic-free, tiny, stable surface the generated typed layers bind.

## Validation

Boundary logic is generic over `Transport` so it's validated against `continuum-client`'s `MockTransport` (no live daemon): execute round-trip, malformed-params→`Codec`, substrate-refusal→`Refused`, subscribe→event-as-JSON + `on_closed`. **4 tests**, all green. `cargo fmt` + `cargo clippy -D warnings` + `cargo test`.

## Also

`client/continuum-client/src/mock.rs` — `#[allow(dead_code)]` on `Subscriber.id` (a `Debug`-diagnostic fixture slot dead-code analysis flags under `-D warnings`; surfaced now that this crate enables `test-fixtures` in the workspace, which would otherwise break `--workspace` clippy).

## Lane

Division (with M5 + Intel Mac): **I drive** the Rust facade + uniffi `.udl`/bindgen + Android AAR/Kotlin (Windows-OK); **Apple steps** (xcframework + swift build + visionOS) go to a macOS CI runner / a Mac (they can't build on Windows); **M5 architects** the API-surface command/event set; **Intel Mac** integrates from the walker/web side. Next: prove the facade via the existing `apps/cli` (Rust) + `sdk/typescript` (Web) consumers, then the uniffi native binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)