### PR TITLE
feat(client): provide() — the serve side of the Command primitive (bidirectional commands)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,6 +2683,7 @@ version = "0.1.0"
 dependencies = [
  "airc-core",
  "airc-lib",
+ "airc-protocol",
  "async-trait",
  "continuum-airc-protocol",
  "futures",
@@ -2700,6 +2701,7 @@ name = "continuum-client-ffi"
 version = "0.1.0"
 dependencies = [
  "airc-lib",
+ "async-trait",
  "continuum-client",
  "futures",
  "serde_json",

--- a/client/continuum-client-ffi/Cargo.toml
+++ b/client/continuum-client-ffi/Cargo.toml
@@ -9,6 +9,7 @@ continuum-client = { path = "../continuum-client" }
 airc-lib = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+async-trait = { workspace = true }
 futures = "0.3"
 tokio = { workspace = true }
 uuid = { workspace = true }

--- a/client/continuum-client-ffi/src/lib.rs
+++ b/client/continuum-client-ffi/src/lib.rs
@@ -28,7 +28,8 @@
 use std::sync::Arc;
 
 use continuum_client::{
-    AircIpcTransport, ClientError, CommandClient, Connection, EventSubscriber, Transport,
+    AircIpcTransport, ClientError, CommandClient, Connection, EventSubscriber, ServeHandler,
+    Transport,
 };
 use futures::StreamExt;
 use uuid::Uuid;
@@ -80,6 +81,44 @@ pub trait EventCallback: Send + Sync {
     fn on_error(&self, message: String);
     /// The stream ended (substrate closed it or the subscription was dropped).
     fn on_closed(&self);
+}
+
+/// A foreign-implemented handler for a command this client PROVIDES — the serve
+/// side of the Command primitive. uniffi exposes this as a callback interface;
+/// the platform SDK supplies the per-platform adapter (web = DOM/canvas
+/// screenshot, desktop = OS, AR/VR = renderer capture — one command identity, N
+/// adapters). `handle` is sync from Rust's view (a foreign call); the serve path
+/// runs it on a blocking worker so a heavy handler doesn't stall the runtime.
+pub trait CommandHandler: Send + Sync {
+    /// Run the provided command — JSON params in, JSON result out. `Err`
+    /// surfaces to the caller as a command error, never a silent drop.
+    fn handle(&self, params_json: String) -> Result<String, FfiError>;
+}
+
+/// Adapts a foreign [`CommandHandler`] to the client's [`ServeHandler`]
+/// (JSON-string boundary ↔ `Value`), running the sync foreign handler on a
+/// blocking worker so the serve loop's task isn't blocked (off-main-thread).
+struct CommandHandlerAdapter {
+    command: String,
+    cb: Arc<dyn CommandHandler>,
+}
+
+#[async_trait::async_trait]
+impl ServeHandler for CommandHandlerAdapter {
+    async fn handle(&self, params: serde_json::Value) -> Result<serde_json::Value, ClientError> {
+        let params_json =
+            serde_json::to_string(&params).map_err(|e| ClientError::Codec(e.to_string()))?;
+        let cb = Arc::clone(&self.cb);
+        let command = self.command.clone();
+        let result_json = tokio::task::spawn_blocking(move || cb.handle(params_json))
+            .await
+            .map_err(|e| ClientError::Transport(format!("provided handler task join: {e}")))?
+            .map_err(|fe| ClientError::Refused {
+                command,
+                reason: fe.to_string(),
+            })?;
+        serde_json::from_str(&result_json).map_err(|e| ClientError::Codec(e.to_string()))
+    }
 }
 
 /// Run one command over a connection's command client, JSON in / JSON out.
@@ -135,6 +174,25 @@ impl Drop for Subscription {
     }
 }
 
+/// An active command provision — the serve twin of [`Subscription`]. Dropping it
+/// DEREGISTERS the command (release = revoke): the serve loop stops matching it.
+pub struct Registration {
+    conn: Connection<AircIpcTransport>,
+    command: String,
+}
+
+impl Drop for Registration {
+    fn drop(&mut self) {
+        // revoke is async; spawn it (we're under a tokio runtime). Removing the
+        // handler is all it takes — the serve loop then ignores the command.
+        let conn = self.conn.clone();
+        let command = std::mem::take(&mut self.command);
+        tokio::spawn(async move {
+            let _ = conn.revoke(&command).await;
+        });
+    }
+}
+
 /// The concrete, generic-free client a foreign binding holds. Wraps a
 /// `Connection` over the real airc IPC transport; the per-platform binding
 /// (uniffi/wasm) exposes exactly `execute` + `subscribe`.
@@ -163,6 +221,26 @@ impl ContinuumClient {
     pub fn subscribe(&self, class: &str, callback: Arc<dyn EventCallback>) -> Subscription {
         let handle = tokio::spawn(pump_events(self.conn.events(), class.to_string(), callback));
         Subscription { handle }
+    }
+
+    /// PROVIDE (serve) a command: register `handler` to answer inbound requests
+    /// the substrate routes to this client — the serve side of the Command
+    /// primitive (client-provided commands like `interface/screenshot`). Returns
+    /// a [`Registration`]; drop it to stop serving.
+    pub async fn provide(
+        &self,
+        command: &str,
+        handler: Arc<dyn CommandHandler>,
+    ) -> Result<Registration, FfiError> {
+        let adapter = Arc::new(CommandHandlerAdapter {
+            command: command.to_string(),
+            cb: handler,
+        });
+        self.conn.provide(command, adapter).await?;
+        Ok(Registration {
+            conn: self.conn.clone(),
+            command: command.to_string(),
+        })
     }
 }
 
@@ -290,5 +368,81 @@ mod tests {
             json!({ "text": "hi" })
         );
         assert!(*rec.closed.lock().unwrap(), "stream close surfaced");
+    }
+
+    /// A foreign command handler that echoes a canned result.
+    struct CannedHandler(serde_json::Value);
+    impl CommandHandler for CannedHandler {
+        fn handle(&self, _params_json: String) -> Result<String, FfiError> {
+            Ok(serde_json::to_string(&self.0).unwrap())
+        }
+    }
+
+    /// A handler that fails — exercises the error mapping.
+    struct FailingHandler;
+    impl CommandHandler for FailingHandler {
+        fn handle(&self, _params_json: String) -> Result<String, FfiError> {
+            Err(FfiError::Transport("device busy".into()))
+        }
+    }
+
+    #[tokio::test]
+    async fn provided_handler_answers_a_routed_command() {
+        // what this catches: the serve side end-to-end — provide registers a
+        // foreign CommandHandler (via the adapter), and a routed inbound command
+        // dispatches to it and returns its JSON result. This is the client
+        // serving interface/screenshot et al, the half #1663 lacked.
+        let mock = MockTransport::new();
+        let conn = Connection::new(mock.clone());
+        let cb: Arc<dyn CommandHandler> = Arc::new(CannedHandler(json!({ "png_base64": "abc" })));
+        let adapter = Arc::new(CommandHandlerAdapter {
+            command: "interface/screenshot".into(),
+            cb,
+        });
+        conn.provide("interface/screenshot", adapter).await.unwrap();
+
+        let out = mock
+            .dispatch_provided("interface/screenshot", json!({ "selector": "body" }))
+            .await
+            .expect("provided handler answers");
+        assert_eq!(out, json!({ "png_base64": "abc" }));
+    }
+
+    #[tokio::test]
+    async fn provided_handler_error_maps_to_refused() {
+        // what this catches: a handler failure must surface as a typed command
+        // error (Refused with the reason), never a silent empty result.
+        let mock = MockTransport::new();
+        let conn = Connection::new(mock.clone());
+        let adapter = Arc::new(CommandHandlerAdapter {
+            command: "x".into(),
+            cb: Arc::new(FailingHandler),
+        });
+        conn.provide("x", adapter).await.unwrap();
+
+        let err = mock.dispatch_provided("x", json!({})).await.unwrap_err();
+        match err {
+            ClientError::Refused { reason, .. } => assert!(reason.contains("device busy")),
+            other => panic!("expected Refused, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn revoke_stops_serving_the_command() {
+        // what this catches: dropping a Registration (→ revoke) deregisters the
+        // command — the serve loop then has nothing to dispatch.
+        let mock = MockTransport::new();
+        let conn = Connection::new(mock.clone());
+        let adapter = Arc::new(CommandHandlerAdapter {
+            command: "x".into(),
+            cb: Arc::new(CannedHandler(json!(1))),
+        });
+        conn.provide("x", adapter).await.unwrap();
+        assert!(mock.provides("x"), "provided");
+
+        conn.revoke("x").await.unwrap();
+        assert!(!mock.provides("x"), "revoked");
+        let err = mock.dispatch_provided("x", json!({})).await.unwrap_err();
+        assert!(matches!(err, ClientError::NotImplemented(_)));
     }
 }

--- a/client/continuum-client/Cargo.toml
+++ b/client/continuum-client/Cargo.toml
@@ -24,6 +24,9 @@ continuum-airc-protocol = { path = "../../core/continuum-airc-protocol" }
 # (Body, MentionTarget, PeerId, Headers) the request signature needs.
 airc-lib = { workspace = true }
 airc-core = { workspace = true }
+# airc command-bus header keys (correlation / reply-to) for the serve side —
+# the SAME crate the substrate's command_handler reads them from (zero drift).
+airc-protocol = { workspace = true }
 
 [features]
 default = []

--- a/client/continuum-client/src/airc_ipc.rs
+++ b/client/continuum-client/src/airc_ipc.rs
@@ -12,25 +12,40 @@
 //! `resolve_unsubscribe`. Substrate's `AircEventTransport` composes the
 //! same helpers — zero wire drift between client and substrate.
 
-use std::sync::Arc;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use serde_json::Value;
 
-use airc_core::{Body, MentionTarget, PeerId};
+use airc_core::{Body, Headers, MentionTarget, PeerId, TranscriptEvent};
 use airc_lib::Airc;
+use airc_protocol::{HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_REPLY_TO};
 use continuum_airc_protocol::command::{
-    AircCommandRequest, AircCommandResponse, COMMAND_REQUEST_BODY_HINT, HEADER_COMMAND_ENV,
-    HEADER_COMMAND_KIND, HEADER_COMMAND_PATH, HEADER_CONTINUUM_BODY_HINT, KIND_PEER,
+    AircCommandRequest, AircCommandResponse, COMMAND_REQUEST_BODY_HINT, COMMAND_RESPONSE_BODY_HINT,
+    HEADER_COMMAND_ENV, HEADER_COMMAND_KIND, HEADER_COMMAND_PATH, HEADER_COMMAND_STATUS,
+    HEADER_CONTINUUM_BODY_HINT, KIND_PEER,
 };
 use continuum_airc_protocol::event as event_proto;
+use futures::StreamExt as _;
 use uuid::Uuid;
 
 use crate::error::ClientError;
 use crate::event::EventStream;
-use crate::transport::Transport;
+use crate::transport::{ServeHandler, Transport};
+
+/// Serve-side state for `provide`/`revoke`: the registry of handlers this
+/// client serves, plus a one-time flag for the inbound serve loop. Shared
+/// (`Arc`) so a clone of the transport sees the same registrations and the loop
+/// dispatches against the live map.
+#[derive(Default)]
+struct ServeState {
+    handlers: Mutex<HashMap<String, std::sync::Arc<dyn ServeHandler>>>,
+    loop_started: AtomicBool,
+}
 
 /// Default in-flight event buffer for a single subscription.
 ///
@@ -54,6 +69,7 @@ pub struct AircIpcTransport {
     target: PeerId,
     deadline: Duration,
     closed: Arc<AtomicBool>,
+    serve: Arc<ServeState>,
 }
 
 impl std::fmt::Debug for AircIpcTransport {
@@ -75,6 +91,7 @@ impl AircIpcTransport {
             target: PeerId(target_peer),
             deadline: DEFAULT_DEADLINE,
             closed: Arc::new(AtomicBool::new(false)),
+            serve: Arc::new(ServeState::default()),
         }
     }
 
@@ -109,17 +126,20 @@ impl AircIpcTransport {
             Body::Json(v) => v,
             Body::Binary(_) => {
                 return Err(ClientError::Transport(
-                    "reply body was Binary; expected Json (AircCommandResponse is JSON)".to_string(),
+                    "reply body was Binary; expected Json (AircCommandResponse is JSON)"
+                        .to_string(),
                 ));
             }
         };
 
         let response: AircCommandResponse = serde_json::from_value(response_value)?;
 
-        response.into_result().map_err(|message| ClientError::Refused {
-            command: "<unknown>".to_string(),
-            reason: message,
-        })
+        response
+            .into_result()
+            .map_err(|message| ClientError::Refused {
+                command: "<unknown>".to_string(),
+                reason: message,
+            })
     }
 }
 
@@ -141,7 +161,12 @@ impl Transport for AircIpcTransport {
 
         let pending = self
             .airc
-            .request(MentionTarget::Peer(self.target), headers, body, self.deadline)
+            .request(
+                MentionTarget::Peer(self.target),
+                headers,
+                body,
+                self.deadline,
+            )
             .await
             .map_err(|e| ClientError::Transport(format!("airc request failed: {e}")))?;
 
@@ -273,9 +298,7 @@ impl Transport for AircIpcTransport {
             if let Ok((target, headers, body)) =
                 event_proto::resolve_unsubscribe(publisher, subscription_id)
             {
-                if let Ok(pending) =
-                    airc_for_task.request(target, headers, body, deadline).await
-                {
+                if let Ok(pending) = airc_for_task.request(target, headers, body, deadline).await {
                     let _ = airc_for_task.await_reply(pending).await;
                 }
             }
@@ -287,6 +310,40 @@ impl Transport for AircIpcTransport {
         Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
     }
 
+    async fn provide(
+        &self,
+        command: &str,
+        handler: Arc<dyn ServeHandler>,
+    ) -> Result<(), ClientError> {
+        if self.closed.load(Ordering::Relaxed) {
+            return Err(ClientError::Closed);
+        }
+        self.serve
+            .handlers
+            .lock()
+            .expect("serve handlers lock poisoned")
+            .insert(command.to_string(), handler);
+        // Start the inbound serve loop exactly once, on first provide — the
+        // client-side twin of persona/command_inbound_pump. A second airc
+        // subscribe is broadcast-shape (every subscriber gets every event), so
+        // it coexists with the event-subscribe path without contention.
+        if !self.serve.loop_started.swap(true, Ordering::Relaxed) {
+            tokio::spawn(serve_loop(Arc::clone(&self.airc), Arc::clone(&self.serve)));
+        }
+        Ok(())
+    }
+
+    async fn revoke(&self, command: &str) -> Result<(), ClientError> {
+        // Idempotent: removing an unprovided command is a no-op. The serve loop
+        // keeps running (cheap) and simply ignores commands with no handler.
+        self.serve
+            .handlers
+            .lock()
+            .expect("serve handlers lock poisoned")
+            .remove(command);
+        Ok(())
+    }
+
     async fn close(&self) -> Result<(), ClientError> {
         // Idempotent: first close wins, later calls return Closed.
         if self.closed.swap(true, Ordering::Relaxed) {
@@ -296,6 +353,131 @@ impl Transport for AircIpcTransport {
         // transport goes out of scope releases our reference. Other
         // holders (the substrate, sibling transports) keep theirs.
         Ok(())
+    }
+}
+
+// ── Serve side (provide) — the client-side twin of command_inbound_pump ──
+//
+// Mirrors core/continuum-core/src/routing/command_handler.rs, opposite role:
+// instead of dispatching inbound commands to the local CommandExecutor, this
+// dispatches to a handler the SDK PROVIDED, then replies the same
+// `AircCommandResponse` wire (zero drift — same protocol types as `request`).
+
+/// A decoded inbound command-request envelope, ready to dispatch + reply.
+struct InboundCommand {
+    path: String,
+    params: Value,
+    /// From `airc.reply_to` — where the response ships.
+    reply_to: PeerId,
+    /// From `airc.correlation_id` — pairs the reply with the caller's await.
+    correlation_id: Uuid,
+}
+
+/// Decode an inbound command-request `TranscriptEvent`. `None` (skip) if it's
+/// not a command request or is missing the reply addressing — never a panic.
+fn parse_inbound_command(event: &TranscriptEvent) -> Option<InboundCommand> {
+    let reply_to = PeerId(
+        event
+            .headers
+            .get(HEADER_AIRC_REPLY_TO)?
+            .parse::<Uuid>()
+            .ok()?,
+    );
+    let correlation_id = event
+        .headers
+        .get(HEADER_AIRC_CORRELATION_ID)?
+        .parse::<Uuid>()
+        .ok()?;
+    let Body::Json(value) = event.body.as_ref()? else {
+        return None;
+    };
+    let request: AircCommandRequest = serde_json::from_value(value.clone()).ok()?;
+    Some(InboundCommand {
+        path: request.path,
+        params: request.params,
+        reply_to,
+        correlation_id,
+    })
+}
+
+/// Ship an `AircCommandResponse` back to the caller, stamping the same status +
+/// body-hint headers the substrate's command_handler uses.
+async fn send_serve_reply(
+    airc: &Airc,
+    reply_to: PeerId,
+    correlation_id: Uuid,
+    response: &AircCommandResponse,
+) {
+    let body = match serde_json::to_value(response) {
+        Ok(v) => Body::Json(v),
+        Err(e) => {
+            eprintln!("continuum-client serve reply: serialize AircCommandResponse failed: {e}");
+            return;
+        }
+    };
+    let mut headers = Headers::new();
+    headers.insert(
+        HEADER_COMMAND_STATUS.to_string(),
+        response.status_header_value().to_string(),
+    );
+    headers.insert(
+        HEADER_CONTINUUM_BODY_HINT.to_string(),
+        COMMAND_RESPONSE_BODY_HINT.to_string(),
+    );
+    if let Err(e) = airc.reply(reply_to, correlation_id, headers, body).await {
+        eprintln!("continuum-client serve reply: airc.reply failed: {e}");
+    }
+}
+
+/// The inbound serve loop: subscribe to the broadcast stream, and for each
+/// command-request envelope whose path this client provides, dispatch to the
+/// handler and reply. Dispatch is spawned per request so a slow handler (a
+/// screenshot, a sensor read) doesn't stall the loop. Exits when the airc
+/// stream ends (daemon disconnect) — per no-fallbacks, a lost subscribe ends
+/// the loop loudly rather than silently degrading.
+async fn serve_loop(airc: Arc<Airc>, serve: Arc<ServeState>) {
+    let mut stream = match airc.subscribe().await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("continuum-client serve loop: airc subscribe failed: {e}");
+            return;
+        }
+    };
+    while let Some(item) = stream.next().await {
+        let event = match item {
+            Ok(e) => e,
+            Err(_) => continue, // stream lag — skip
+        };
+        // Only command-request envelopes; everything else (events, chat) skipped.
+        if event
+            .headers
+            .get(HEADER_CONTINUUM_BODY_HINT)
+            .map(String::as_str)
+            != Some(COMMAND_REQUEST_BODY_HINT)
+        {
+            continue;
+        }
+        let Some(parsed) = parse_inbound_command(&event) else {
+            continue;
+        };
+        // Only answer commands THIS client provides; others are for someone else.
+        let handler = serve
+            .handlers
+            .lock()
+            .expect("serve handlers lock poisoned")
+            .get(&parsed.path)
+            .cloned();
+        let Some(handler) = handler else {
+            continue;
+        };
+        let airc = Arc::clone(&airc);
+        tokio::spawn(async move {
+            let response = match handler.handle(parsed.params).await {
+                Ok(value) => AircCommandResponse::ok(value),
+                Err(e) => AircCommandResponse::error(e.to_string()),
+            };
+            send_serve_reply(&airc, parsed.reply_to, parsed.correlation_id, &response).await;
+        });
     }
 }
 
@@ -321,13 +503,11 @@ mod tests {
             Some("peer")
         );
         assert_eq!(
-            headers
-                .get(HEADER_CONTINUUM_BODY_HINT)
-                .map(|s| s.as_str()),
+            headers.get(HEADER_CONTINUUM_BODY_HINT).map(|s| s.as_str()),
             Some(COMMAND_REQUEST_BODY_HINT)
         );
         assert!(
-            headers.get(HEADER_COMMAND_ENV).is_none(),
+            !headers.contains_key(HEADER_COMMAND_ENV),
             "no env should mean no env header"
         );
     }

--- a/client/continuum-client/src/connection.rs
+++ b/client/continuum-client/src/connection.rs
@@ -8,13 +8,25 @@ use crate::airc_ipc::AircIpcTransport;
 use crate::command::CommandClient;
 use crate::error::ClientError;
 use crate::event::EventSubscriber;
-use crate::transport::Transport;
+use crate::transport::{ServeHandler, Transport};
 
 /// One session against a continuum substrate. Generic over the wire so
 /// the same code drives local airc IPC, remote airc grid, and the
 /// `MockTransport` used in downstream tests.
 pub struct Connection<T: Transport> {
     transport: Arc<T>,
+}
+
+// Manual `Clone` (not derived): a connection is cheap to clone — it shares the
+// one `Arc<T>` transport. Derived `Clone` would wrongly require `T: Clone`;
+// `Arc<T>` is `Clone` regardless. Cloning lets a `provide` registration hold a
+// handle to revoke on drop without re-establishing the session.
+impl<T: Transport> Clone for Connection<T> {
+    fn clone(&self) -> Self {
+        Self {
+            transport: Arc::clone(&self.transport),
+        }
+    }
 }
 
 impl<T: Transport> Connection<T> {
@@ -35,6 +47,22 @@ impl<T: Transport> Connection<T> {
     /// Typed event subscriber for this connection.
     pub fn events(&self) -> EventSubscriber<T> {
         EventSubscriber::new(Arc::clone(&self.transport))
+    }
+
+    /// Register a handler to SERVE `command` — the client-provided side of the
+    /// Command primitive (the substrate routes matching commands here). Twin of
+    /// `commands().execute`; stop with [`Connection::revoke`].
+    pub async fn provide(
+        &self,
+        command: &str,
+        handler: Arc<dyn ServeHandler>,
+    ) -> Result<(), ClientError> {
+        self.transport.provide(command, handler).await
+    }
+
+    /// Stop serving `command`. Idempotent.
+    pub async fn revoke(&self, command: &str) -> Result<(), ClientError> {
+        self.transport.revoke(command).await
     }
 
     /// Close the underlying transport. After this, further command /

--- a/client/continuum-client/src/lib.rs
+++ b/client/continuum-client/src/lib.rs
@@ -22,4 +22,4 @@ pub use error::ClientError;
 pub use event::EventSubscriber;
 #[cfg(any(test, feature = "test-fixtures"))]
 pub use mock::MockTransport;
-pub use transport::Transport;
+pub use transport::{ServeHandler, Transport};

--- a/client/continuum-client/src/mock.rs
+++ b/client/continuum-client/src/mock.rs
@@ -51,7 +51,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use crate::error::ClientError;
 use crate::event::EventStream;
-use crate::transport::Transport;
+use crate::transport::{ServeHandler, Transport};
 
 /// Default per-subscription buffer for emitted events. Matches the
 /// real `AircIpcTransport` default so a test that fills the buffer
@@ -87,6 +87,9 @@ struct Inner {
     handlers: Mutex<HashMap<String, Vec<CommandHandler>>>,
     /// Active subscribers per class (exact-match string keying).
     subscribers: Mutex<HashMap<String, Vec<Subscriber>>>,
+    /// Handlers the client PROVIDES (serve side), keyed by command. A test
+    /// simulates an inbound routed command via [`MockTransport::dispatch_provided`].
+    serve_handlers: Mutex<HashMap<String, Arc<dyn ServeHandler>>>,
     /// Monotonic id source for `Subscriber.id`. Per-instance.
     next_subscriber_id: AtomicU64,
     /// `Transport::close` semantics: idempotent first-call-wins.
@@ -110,6 +113,7 @@ impl MockTransport {
             inner: Arc::new(Inner {
                 handlers: Mutex::new(HashMap::new()),
                 subscribers: Mutex::new(HashMap::new()),
+                serve_handlers: Mutex::new(HashMap::new()),
                 next_subscriber_id: AtomicU64::new(0),
                 closed: AtomicBool::new(false),
             }),
@@ -149,7 +153,11 @@ impl MockTransport {
     /// The dropped count is reflected in the return value (count
     /// returned is *successful* sends only).
     pub fn emit(&self, class: impl AsRef<str>, payload: Value) -> usize {
-        let mut subscribers = self.inner.subscribers.lock().expect("subscribers lock poisoned");
+        let mut subscribers = self
+            .inner
+            .subscribers
+            .lock()
+            .expect("subscribers lock poisoned");
         let class = class.as_ref();
         let Some(list) = subscribers.get_mut(class) else {
             return 0;
@@ -169,13 +177,53 @@ impl MockTransport {
     /// Diagnostic: how many active subscribers does `class` have?
     /// Stale (closed) subscribers are pruned at observation time.
     pub fn subscriber_count(&self, class: impl AsRef<str>) -> usize {
-        let mut subscribers = self.inner.subscribers.lock().expect("subscribers lock poisoned");
+        let mut subscribers = self
+            .inner
+            .subscribers
+            .lock()
+            .expect("subscribers lock poisoned");
         let class = class.as_ref();
         let Some(list) = subscribers.get_mut(class) else {
             return 0;
         };
         list.retain(|s| !s.tx.is_closed());
         list.len()
+    }
+
+    /// Simulate an inbound routed command hitting a handler this client
+    /// PROVIDED — the serve-side analog of `emit` for the subscribe side. Looks
+    /// up the handler registered via `Transport::provide` and runs it, so a
+    /// test can assert "the SDK's provided handler answers" without a live
+    /// substrate routing the request. `NotImplemented` if nothing is provided
+    /// for `command` (mirrors the request-side's unregistered behaviour).
+    pub async fn dispatch_provided(
+        &self,
+        command: &str,
+        params: Value,
+    ) -> Result<Value, ClientError> {
+        let handler = {
+            let handlers = self
+                .inner
+                .serve_handlers
+                .lock()
+                .expect("serve_handlers lock poisoned");
+            handlers.get(command).map(Arc::clone)
+        };
+        match handler {
+            Some(h) => h.handle(params).await,
+            None => Err(ClientError::NotImplemented(
+                "MockTransport: no handler provided for command — register via `provide` first",
+            )),
+        }
+    }
+
+    /// Diagnostic: is a handler currently provided for `command`?
+    pub fn provides(&self, command: &str) -> bool {
+        self.inner
+            .serve_handlers
+            .lock()
+            .expect("serve_handlers lock poisoned")
+            .contains_key(command)
     }
 }
 
@@ -238,9 +286,16 @@ impl Transport for MockTransport {
             return Err(ClientError::Closed);
         }
         let (tx, rx) = mpsc::channel::<Result<Value, ClientError>>(DEFAULT_EVENT_BUFFER);
-        let id = self.inner.next_subscriber_id.fetch_add(1, Ordering::Relaxed);
+        let id = self
+            .inner
+            .next_subscriber_id
+            .fetch_add(1, Ordering::Relaxed);
         {
-            let mut subscribers = self.inner.subscribers.lock().expect("subscribers lock poisoned");
+            let mut subscribers = self
+                .inner
+                .subscribers
+                .lock()
+                .expect("subscribers lock poisoned");
             subscribers
                 .entry(class.to_string())
                 .or_default()
@@ -249,12 +304,42 @@ impl Transport for MockTransport {
         Ok(Box::pin(ReceiverStream::new(rx)))
     }
 
+    async fn provide(
+        &self,
+        command: &str,
+        handler: Arc<dyn ServeHandler>,
+    ) -> Result<(), ClientError> {
+        if self.inner.closed.load(Ordering::Relaxed) {
+            return Err(ClientError::Closed);
+        }
+        self.inner
+            .serve_handlers
+            .lock()
+            .expect("serve_handlers lock poisoned")
+            .insert(command.to_string(), handler);
+        Ok(())
+    }
+
+    async fn revoke(&self, command: &str) -> Result<(), ClientError> {
+        // Idempotent: revoking an unprovided command is a no-op, not an error.
+        self.inner
+            .serve_handlers
+            .lock()
+            .expect("serve_handlers lock poisoned")
+            .remove(command);
+        Ok(())
+    }
+
     async fn close(&self) -> Result<(), ClientError> {
         if self.inner.closed.swap(true, Ordering::Relaxed) {
             return Err(ClientError::Closed);
         }
         // Drop all senders → any active subscriber stream sees None.
-        let mut subscribers = self.inner.subscribers.lock().expect("subscribers lock poisoned");
+        let mut subscribers = self
+            .inner
+            .subscribers
+            .lock()
+            .expect("subscribers lock poisoned");
         subscribers.clear();
         Ok(())
     }
@@ -270,14 +355,17 @@ mod tests {
     async fn request_returns_registered_response() {
         let mock = MockTransport::new();
         mock.respond_with("ai/generate", json!({"text": "mocked"}));
-        let got = mock.request("ai/generate", json!({"prompt": "hi"})).await.unwrap();
+        let got = mock
+            .request("ai/generate", json!({"prompt": "hi"}))
+            .await
+            .unwrap();
         assert_eq!(got, json!({"text": "mocked"}));
     }
 
     #[tokio::test]
     async fn request_handler_sees_params() {
         let mock = MockTransport::new();
-        mock.respond_to("echo", |params| Ok(params));
+        mock.respond_to("echo", Ok);
         let got = mock.request("echo", json!({"x": 1})).await.unwrap();
         assert_eq!(got, json!({"x": 1}));
     }

--- a/client/continuum-client/src/transport.rs
+++ b/client/continuum-client/src/transport.rs
@@ -1,10 +1,34 @@
 //! Transport — the seam between a `Connection` and the wire.
+//!
+//! The two universal primitives are each BIDIRECTIONAL. Commands = `request`
+//! (call out) + [`provide`](Transport::provide) (serve a command the substrate
+//! / a peer routes here — the client's display / sensors / renderer that the
+//! core can't reach). Events = `subscribe` (listen) + emit (publish; the
+//! publish verb lands once the substrate's client→publisher receive-door
+//! exists — see SDK-API-SURFACE.md). This trait carries the call/listen +
+//! serve halves; the publish half is a fast-follow.
+
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::error::ClientError;
 use crate::event::EventStream;
+
+/// A handler the client REGISTERS to serve a command it provides — the serve
+/// side of the Command primitive. When the substrate (or a peer) routes a
+/// command this client provides, the transport's serve loop calls this with the
+/// request params and replies with the result. JSON in / JSON out; the typed
+/// SDK layer wraps it, the FFI facade exposes it as a foreign callback.
+/// OpenCV-style adapter polymorphism: one command identity, N platform handlers
+/// (web = DOM/canvas, desktop = OS, AR/VR = renderer capture).
+#[async_trait]
+pub trait ServeHandler: Send + Sync {
+    /// Run the provided command. `Ok` ships as the command result; `Err`
+    /// surfaces to the caller as a refusal — never a silent drop.
+    async fn handle(&self, params: Value) -> Result<Value, ClientError>;
+}
 
 /// Pluggable wire for a `Connection`. Implementations: local airc IPC
 /// (a continuum-core-server on the same machine), remote airc grid
@@ -13,12 +37,26 @@ use crate::event::EventStream;
 #[async_trait]
 pub trait Transport: Send + Sync + 'static {
     /// Round-trip one command. Caller gives JSON params, gets JSON result
-    /// or a typed error.
+    /// or a typed error. (Command: CALL.)
     async fn request(&self, command: &str, params: Value) -> Result<Value, ClientError>;
 
     /// Open an event stream for the given class. Class strings follow the
-    /// substrate's URI convention (e.g. `"persona.response.*"`).
+    /// substrate's URI convention (e.g. `"persona.response.*"`). (Event: LISTEN.)
     async fn subscribe(&self, class: &str) -> Result<EventStream, ClientError>;
+
+    /// Register `handler` to serve `command`: inbound requests the substrate
+    /// routes here are dispatched to it and the result replied automatically.
+    /// The serve twin of `request`. Idempotent per command (re-registering
+    /// replaces). (Command: SERVE.)
+    async fn provide(
+        &self,
+        command: &str,
+        handler: Arc<dyn ServeHandler>,
+    ) -> Result<(), ClientError>;
+
+    /// Stop serving `command` (deregister its handler). Idempotent — revoking a
+    /// command that was never provided is a no-op, not an error.
+    async fn revoke(&self, command: &str) -> Result<(), ClientError>;
 
     /// Close the underlying connection. Idempotent; later calls on the
     /// same transport return `ClientError::Closed`.


### PR DESCRIPTION
## What

The **serve side** of the Command primitive — the third of the four SDK facade verbs (`execute`+`subscribe` shipped in #1663; this is `provide`; `emit` follows once the substrate's `EventPublishAdapter` lands). A client can now **provide** (serve) a command, not just call one — for **client-provided commands the core can't run**: `interface/screenshot`, capture, sensors (the SDK's display / renderer / hardware). OpenCV-style adapter polymorphism: one command identity, N platform handlers (web = DOM/canvas, AR/VR = renderer capture).

> Commands = `execute` (call) + `provide` (serve) — one primitive, both directions. Per M5's sequencing: `provide` first (fully grounded), `emit` second.

## How (the serve side on the Transport trait — M5's design call)

- **`continuum-client` Transport trait** gains `provide(command, Arc<dyn ServeHandler>)` + `revoke(command)` (+ the `ServeHandler` trait). Symmetric with `request` — one trait owns the Command primitive both ways.
- **`AircIpcTransport`** real serve loop: the client-side twin of `persona/command_inbound_pump.rs` — a second broadcast subscribe, decode inbound `AircCommandRequest` (reply-to/correlation from the `airc.*` headers), dispatch to the registered handler, reply `AircCommandResponse` via `airc.reply`. **Same protocol types as `request` → zero wire drift.** Dispatch is spawned per request so a slow handler (a screenshot) doesn't stall the loop; the loop starts once on first `provide`.
- **`MockTransport`** serve registry + `dispatch_provided(command, params)` to exercise the serve path without a live daemon.
- **`Connection`** gains `provide`/`revoke` + a manual `Clone` (shares the one `Arc<T>`; derived `Clone` would wrongly demand `T: Clone`).
- **Facade (`continuum-client-ffi`)**: `provide(command, Arc<dyn CommandHandler>) -> Registration` (drop = revoke, the serve twin of `Subscription`). `CommandHandler { handle(params_json) -> Result<String, FfiError> }` is the foreign callback (mirror of `EventCallback`); the adapter runs it on `spawn_blocking` so a heavy handler stays off the async worker (off-main-thread).

## Validation

`cargo fmt` + `cargo clippy -D warnings` + `cargo test` — **continuum-client 18 tests, facade 7 tests** (4 prior + 3 new: provided-handler-answers, handler-error→Refused, revoke-stops-serving). Serve path validated end-to-end via `MockTransport` (register → dispatch → handler → result), no live daemon.

Also: a one-line dep (`airc-protocol` workspace dep — the crate the substrate's `command_handler` reads the correlation/reply-to header keys from, zero drift) and two trivial pre-existing clippy nits in continuum-client's existing tests, fixed in passing.

## Next

`emit` (the publish verb) once the substrate-side `EventPublishAdapter` (the receive-door twin of `EventSubscribeAdapter`) lands — then the uniffi `.udl` binds all four verbs in one pass → native swift/kotlin SDKs (Android here, xcframework on macOS CI). Env-targeting (`airc://peer:env/path`) composes as an internal filter once #1662's `CommandUri` lands — `provide`'s signature is env-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)