### PR TITLE
feat(client): emit() — the publish verb; the four-method facade is complete

### DIFF
--- a/client/continuum-client-ffi/src/lib.rs
+++ b/client/continuum-client-ffi/src/lib.rs
@@ -223,6 +223,16 @@ impl ContinuumClient {
         Subscription { handle }
     }
 
+    /// EMIT (publish) an event to `class` — the publish side of the Event
+    /// primitive (twin of `subscribe`). `payload_json` is the event body as a
+    /// JSON string.
+    pub async fn emit(&self, class: &str, payload_json: &str) -> Result<(), FfiError> {
+        let payload: serde_json::Value =
+            serde_json::from_str(payload_json).map_err(|e| FfiError::Codec(e.to_string()))?;
+        self.conn.emit(class, payload).await?;
+        Ok(())
+    }
+
     /// PROVIDE (serve) a command: register `handler` to answer inbound requests
     /// the substrate routes to this client — the serve side of the Command
     /// primitive (client-provided commands like `interface/screenshot`). Returns
@@ -444,5 +454,37 @@ mod tests {
         assert!(!mock.provides("x"), "revoked");
         let err = mock.dispatch_provided("x", json!({})).await.unwrap_err();
         assert!(matches!(err, ClientError::NotImplemented(_)));
+    }
+
+    #[tokio::test]
+    async fn emit_publishes_to_a_subscriber() {
+        // what this catches: emit (publish) reaches a subscriber of the same
+        // class — the publish twin of subscribe, end-to-end via the mock fan-out.
+        // Completes the four-verb facade surface.
+        let mock = MockTransport::new();
+        let conn = Connection::new(mock.clone());
+        let rec = Arc::new(Recorder::default());
+        let cb: Arc<dyn EventCallback> = rec.clone();
+        let pump = tokio::spawn(pump_events(conn.events(), "x".to_string(), cb));
+
+        for _ in 0..100 {
+            if mock.subscriber_count("x") == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        conn.emit("x", json!({ "hello": "world" }))
+            .await
+            .expect("emit publishes");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        mock.close().await.ok();
+        let _ = tokio::time::timeout(Duration::from_secs(2), pump).await;
+
+        let events = rec.events.lock().unwrap();
+        assert_eq!(events.len(), 1, "subscriber received the emitted event");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&events[0]).unwrap(),
+            json!({ "hello": "world" })
+        );
     }
 }

--- a/client/continuum-client/src/airc_ipc.rs
+++ b/client/continuum-client/src/airc_ipc.rs
@@ -310,6 +310,32 @@ impl Transport for AircIpcTransport {
         Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
     }
 
+    async fn emit(&self, class: &str, payload: Value) -> Result<(), ClientError> {
+        if self.closed.load(Ordering::Relaxed) {
+            return Err(ClientError::Closed);
+        }
+        // Publish via the same shared protocol helper the substrate's
+        // EventPublishAdapter receives — zero wire drift (the publish twin of
+        // the subscribe path above).
+        let (target, headers, body) = event_proto::resolve_publish(self.target, class, payload)
+            .map_err(ClientError::Transport)?;
+        let pending = self
+            .airc
+            .request(target, headers, body, self.deadline)
+            .await
+            .map_err(|e| ClientError::Transport(format!("airc publish request: {e}")))?;
+        let reply = self
+            .airc
+            .await_reply(pending)
+            .await
+            .map_err(|e| ClientError::Transport(format!("airc publish await_reply: {e}")))?;
+        // Decode the ack to surface a malformed reply; the fan-out count is
+        // informational (emit fires into the fan-out — the caller doesn't branch
+        // on how many subscribers received it).
+        let _ack = event_proto::decode_publish_ack(reply.body).map_err(ClientError::Transport)?;
+        Ok(())
+    }
+
     async fn provide(
         &self,
         command: &str,

--- a/client/continuum-client/src/connection.rs
+++ b/client/continuum-client/src/connection.rs
@@ -49,6 +49,12 @@ impl<T: Transport> Connection<T> {
         EventSubscriber::new(Arc::clone(&self.transport))
     }
 
+    /// Publish an event to `class` — the publish side of the Event primitive
+    /// (the emit twin of `events().subscribe`).
+    pub async fn emit(&self, class: &str, payload: serde_json::Value) -> Result<(), ClientError> {
+        self.transport.emit(class, payload).await
+    }
+
     /// Register a handler to SERVE `command` — the client-provided side of the
     /// Command primitive (the substrate routes matching commands here). Twin of
     /// `commands().execute`; stop with [`Connection::revoke`].

--- a/client/continuum-client/src/mock.rs
+++ b/client/continuum-client/src/mock.rs
@@ -304,6 +304,18 @@ impl Transport for MockTransport {
         Ok(Box::pin(ReceiverStream::new(rx)))
     }
 
+    async fn emit(&self, class: &str, payload: Value) -> Result<(), ClientError> {
+        if self.inner.closed.load(Ordering::Relaxed) {
+            return Err(ClientError::Closed);
+        }
+        // Reuse the inherent `emit` (fan-out to subscribers, returns count) via
+        // the explicit type path — unambiguously the inherent method, not this
+        // trait method (no recursion). The Transport contract returns Result;
+        // the inherent's count is the richer test surface.
+        let _delivered = MockTransport::emit(self, class, payload);
+        Ok(())
+    }
+
     async fn provide(
         &self,
         command: &str,

--- a/client/continuum-client/src/transport.rs
+++ b/client/continuum-client/src/transport.rs
@@ -44,6 +44,10 @@ pub trait Transport: Send + Sync + 'static {
     /// substrate's URI convention (e.g. `"persona.response.*"`). (Event: LISTEN.)
     async fn subscribe(&self, class: &str) -> Result<EventStream, ClientError>;
 
+    /// Publish an event to `class` — the publish twin of `subscribe`, routed to
+    /// the substrate's event fan-out. (Event: PUBLISH.)
+    async fn emit(&self, class: &str, payload: Value) -> Result<(), ClientError>;
+
     /// Register `handler` to serve `command`: inbound requests the substrate
     /// routes here are dispatched to it and the result replied automatically.
     /// The serve twin of `request`. Idempotent per command (re-registering

--- a/core/continuum-airc-protocol/src/event.rs
+++ b/core/continuum-airc-protocol/src/event.rs
@@ -55,6 +55,9 @@ pub const HEADER_EVENT_SUBSCRIPTION_ID: &str = "continuum.event.subscription_id"
 pub const EVENT_SUBSCRIBE_BODY_HINT: &str = "continuum.event.subscribe.v1";
 pub const EVENT_DELIVER_BODY_HINT: &str = "continuum.event.deliver.v1";
 pub const EVENT_UNSUBSCRIBE_BODY_HINT: &str = "continuum.event.unsubscribe.v1";
+/// A client PUBLISHING an event into the substrate's fan-out — the publish twin
+/// of subscribe (the `emit` half of the Event primitive).
+pub const EVENT_PUBLISH_BODY_HINT: &str = "continuum.event.publish.v1";
 pub const EVENT_ACK_BODY_HINT: &str = "continuum.event.ack.v1";
 
 // ─── Typed envelopes ─────────────────────────────────────────────────
@@ -94,6 +97,21 @@ pub struct AircEventUnsubscribe {
 pub struct AircEventUnsubscribeAck {
     pub subscription_id: Uuid,
     pub closed: bool,
+}
+
+/// Caller-side publish request — a client emitting an event into the
+/// substrate's fan-out. The publish twin of [`AircEventSubscribe`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AircEventPublish {
+    pub topic: String,
+    pub payload: Value,
+}
+
+/// Peer-side ack to a publish: how many subscribers the event fanned out to.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AircEventPublishAck {
+    pub topic: String,
+    pub delivered: u64,
 }
 
 // ─── Pure helper functions ───────────────────────────────────────────
@@ -174,6 +192,60 @@ pub fn resolve_unsubscribe(
     Ok((MentionTarget::Peer(target_peer), headers, body))
 }
 
+/// Build the outbound publish envelope — a client emitting `payload` to
+/// `topic`. The publish twin of [`resolve_subscribe`]; refuses an empty topic
+/// upfront for the same reason (the publisher matches by topic).
+pub fn resolve_publish(
+    target_peer: PeerId,
+    topic: &str,
+    payload: Value,
+) -> Result<(MentionTarget, airc_core::Headers, Body), String> {
+    if topic.is_empty() {
+        return Err(
+            "airc event publish: topic must not be empty — the peer-side publisher \
+             fans out by topic and an empty topic would match nothing. Per \
+             [[no-fallbacks-ever]] the transport refuses upfront."
+                .to_string(),
+        );
+    }
+    let req = AircEventPublish {
+        topic: topic.to_string(),
+        payload,
+    };
+    let body_value = serde_json::to_value(&req)
+        .map_err(|e| format!("airc event publish: serialize AircEventPublish to JSON: {e}"))?;
+    let body = Body::Json(body_value);
+
+    let mut headers = airc_core::Headers::new();
+    headers.insert(HEADER_EVENT_TOPIC.to_string(), topic.to_string());
+    headers.insert(HEADER_EVENT_KIND.to_string(), "publish".to_string());
+    headers.insert(
+        HEADER_CONTINUUM_BODY_HINT.to_string(),
+        EVENT_PUBLISH_BODY_HINT.to_string(),
+    );
+
+    Ok((MentionTarget::Peer(target_peer), headers, body))
+}
+
+/// Decode a publish-reply body as [`AircEventPublishAck`] (the fan-out count).
+pub fn decode_publish_ack(reply_body: Option<Body>) -> Result<AircEventPublishAck, String> {
+    let body = reply_body.ok_or_else(|| {
+        "airc event publish: reply has no body (peer-side publisher must \
+         attach Body::Json(AircEventPublishAck))"
+            .to_string()
+    })?;
+    let value = match body {
+        Body::Json(v) => v,
+        Body::Binary(_) => {
+            return Err("airc event publish: reply body was Binary; expected Json \
+                 (AircEventPublishAck is a JSON envelope)"
+                .to_string());
+        }
+    };
+    serde_json::from_value(value)
+        .map_err(|e| format!("airc event publish: deserialize reply as AircEventPublishAck: {e}"))
+}
+
 /// Decode a subscribe-reply body as [`AircEventSubscribeAck`].
 ///
 /// Every error path (no body, binary body, malformed JSON) is
@@ -187,9 +259,11 @@ pub fn decode_subscribe_ack(reply_body: Option<Body>) -> Result<AircEventSubscri
     let value = match body {
         Body::Json(v) => v,
         Body::Binary(_) => {
-            return Err("airc event subscribe: reply body was Binary; expected Json \
+            return Err(
+                "airc event subscribe: reply body was Binary; expected Json \
                  (AircEventSubscribeAck is a JSON envelope)"
-                .to_string());
+                    .to_string(),
+            );
         }
     };
     serde_json::from_value(value).map_err(|e| {
@@ -207,9 +281,7 @@ pub fn decode_unsubscribe_ack(reply_body: Option<Body>) -> Result<AircEventUnsub
     let value = match body {
         Body::Json(v) => v,
         Body::Binary(_) => {
-            return Err(
-                "airc event unsubscribe: reply body was Binary; expected Json".to_string()
-            );
+            return Err("airc event unsubscribe: reply body was Binary; expected Json".to_string());
         }
     };
     serde_json::from_value(value).map_err(|e| {
@@ -233,9 +305,7 @@ pub fn decode_deliver_frame(event: &TranscriptEvent) -> Result<AircEventDeliver,
     let value = match body {
         Body::Json(v) => v.clone(),
         Body::Binary(_) => {
-            return Err(
-                "airc event Deliver frame body was Binary; expected Json".to_string()
-            );
+            return Err("airc event Deliver frame body was Binary; expected Json".to_string());
         }
     };
     serde_json::from_value(value)
@@ -368,5 +438,70 @@ mod tests {
             "continuum.event.unsubscribe.v1"
         );
         assert_eq!(EVENT_ACK_BODY_HINT, "continuum.event.ack.v1");
+        assert_eq!(EVENT_PUBLISH_BODY_HINT, "continuum.event.publish.v1");
+    }
+
+    #[test]
+    fn publish_round_trips_json() {
+        let req = AircEventPublish {
+            topic: "cognition/analyze/complete".into(),
+            payload: serde_json::json!({ "confidence": 0.9 }),
+        };
+        let json = serde_json::to_string(&req).expect("serialize");
+        let back: AircEventPublish = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, req);
+    }
+
+    #[test]
+    fn publish_ack_round_trips() {
+        let ack = AircEventPublishAck {
+            topic: "events/x".into(),
+            delivered: 3,
+        };
+        let json = serde_json::to_string(&ack).expect("serialize");
+        let back: AircEventPublishAck = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, ack);
+    }
+
+    #[test]
+    fn resolve_publish_builds_envelope_with_publish_hint() {
+        // what this catches: the publish envelope must carry the topic + the
+        // publish body-hint so the substrate's EventPublishAdapter routes it (the
+        // mirror of resolve_subscribe).
+        let peer = PeerId::new();
+        let (target, headers, body) =
+            resolve_publish(peer, "events/x", serde_json::json!({ "k": 1 })).expect("resolves");
+        assert_eq!(target, MentionTarget::Peer(peer));
+        assert_eq!(
+            headers.get(HEADER_CONTINUUM_BODY_HINT).map(String::as_str),
+            Some(EVENT_PUBLISH_BODY_HINT)
+        );
+        assert_eq!(
+            headers.get(HEADER_EVENT_KIND).map(String::as_str),
+            Some("publish")
+        );
+        let Body::Json(v) = body else {
+            panic!("publish body must be JSON")
+        };
+        let decoded: AircEventPublish = serde_json::from_value(v).expect("decode body");
+        assert_eq!(decoded.topic, "events/x");
+    }
+
+    #[test]
+    fn resolve_publish_refuses_empty_topic() {
+        // what this catches: an empty topic fans out to nothing (silent) — refuse
+        // upfront per no-fallbacks, same as resolve_subscribe.
+        assert!(resolve_publish(PeerId::new(), "", serde_json::json!({})).is_err());
+    }
+
+    #[test]
+    fn decode_publish_ack_round_trips_the_fanout_count() {
+        let ack = AircEventPublishAck {
+            topic: "events/x".into(),
+            delivered: 7,
+        };
+        let body = Body::Json(serde_json::to_value(&ack).unwrap());
+        let decoded = decode_publish_ack(Some(body)).expect("decodes");
+        assert_eq!(decoded.delivered, 7);
     }
 }

--- a/core/continuum-airc-protocol/src/lib.rs
+++ b/core/continuum-airc-protocol/src/lib.rs
@@ -25,15 +25,26 @@ pub use command::{
     KIND_ROOM,
 };
 pub use event::{
-    // Envelope types
-    AircEventDeliver, AircEventSubscribe, AircEventSubscribeAck, AircEventUnsubscribe,
-    AircEventUnsubscribeAck,
     // Helper functions — shared by substrate AND client
-    decode_deliver_frame, decode_subscribe_ack, decode_unsubscribe_ack, matches_subscription,
-    resolve_subscribe, resolve_unsubscribe,
+    decode_deliver_frame,
+    decode_subscribe_ack,
+    decode_unsubscribe_ack,
+    matches_subscription,
+    resolve_subscribe,
+    resolve_unsubscribe,
+    // Envelope types
+    AircEventDeliver,
+    AircEventSubscribe,
+    AircEventSubscribeAck,
+    AircEventUnsubscribe,
+    AircEventUnsubscribeAck,
     // Body-hint constants
-    EVENT_ACK_BODY_HINT, EVENT_DELIVER_BODY_HINT, EVENT_SUBSCRIBE_BODY_HINT,
+    EVENT_ACK_BODY_HINT,
+    EVENT_DELIVER_BODY_HINT,
+    EVENT_SUBSCRIBE_BODY_HINT,
     EVENT_UNSUBSCRIBE_BODY_HINT,
     // Header name constants
-    HEADER_EVENT_KIND, HEADER_EVENT_SUBSCRIPTION_ID, HEADER_EVENT_TOPIC,
+    HEADER_EVENT_KIND,
+    HEADER_EVENT_SUBSCRIPTION_ID,
+    HEADER_EVENT_TOPIC,
 };


### PR DESCRIPTION
## What

`emit` — the **publish** side of the Event primitive, and the **fourth and final** facade verb. With this the SDK facade is complete:

| | call/listen | serve/publish |
|---|---|---|
| **Command** | `execute` (#1663) | `provide` (#1664) |
| **Event** | `subscribe` (#1663) | **`emit` (this)** |

Two primitives × two directions = four verbs. The platform tracks (mobile/cli/nodejs, all held until the facade completes) can now build against the full surface + the conformance spec.

## How (mirrors the subscribe wire path — zero drift)

- **`continuum-airc-protocol/event.rs`** (the wire type — unblocks M5's substrate-side adapter): `AircEventPublish { topic, payload }` + `AircEventPublishAck { topic, delivered }` + `EVENT_PUBLISH_BODY_HINT` + `resolve_publish` / `decode_publish_ack` — the publish twins of the subscribe envelopes/helpers (empty-topic refused upfront, same as subscribe).
- **`continuum-client`**: `Transport::emit` + `AircIpcTransport::emit` (resolve_publish → `airc.request` → await → decode the fan-out ack; same shared helpers the substrate's `EventPublishAdapter` will receive) + `MockTransport::emit` + `Connection::emit`.
- **Facade**: `ContinuumClient::emit(class, payload_json) -> Result<(), FfiError>` (the trivial publish verb — no callback).

## Composition with M5's substrate work

This ships the **client side**; the **live fan-out** lights up when M5's `EventPublishAdapter` (the receive-door twin of `EventSubscribeAdapter`) lands — it receives the `AircEventPublish` wire type added here and hands it to the existing `AircEventPublisher::publish`. The wire type is the contract between them.

## Validation

`cargo fmt` + `cargo clippy -D warnings` + `cargo test` — **continuum-airc-protocol 18, continuum-client 18, facade 8** (the new emit test publishes to a subscriber via the mock fan-out, end-to-end). Plus 5 new protocol tests (publish/ack roundtrip, resolve_publish envelope + empty-topic refusal, decode_publish_ack).

## Next

Facade complete → the **uniffi `.udl`** binds all four verbs in one pass → native swift/kotlin SDKs (Android here, xcframework on macOS CI). The three parallel-outlier platform tracks unblock against the shared conformance spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)