### PR TITLE
feat(routing): EventPublishAdapter — the emit() landing (4th SDK verb)

### DIFF
--- a/core/continuum-core/src/routing/airc_event_adapters.rs
+++ b/core/continuum-core/src/routing/airc_event_adapters.rs
@@ -49,11 +49,12 @@ use airc_lib::Airc;
 use async_trait::async_trait;
 
 use super::airc_event_publisher::{
-    build_subscribe_ack, build_unsubscribe_ack, parse_subscribe_envelope,
-    parse_unsubscribe_envelope, EventPublisherState, ParsedSubscribe, ParsedUnsubscribe,
+    build_publish_ack, build_subscribe_ack, build_unsubscribe_ack, parse_publish_envelope,
+    parse_subscribe_envelope, parse_unsubscribe_envelope, AircEventPublisher, EventPublisherState,
+    ParsedPublish, ParsedSubscribe, ParsedUnsubscribe,
 };
 use super::{
-    AllowAllPolicy, AuthPolicy, CallerIdentity, RouteDecision, Verdict,
+    AllowAllPolicy, AuthPolicy, CallerIdentity, RouteDecision, Verdict, EVENT_PUBLISH_BODY_HINT,
     EVENT_SUBSCRIBE_BODY_HINT, EVENT_UNSUBSCRIBE_BODY_HINT,
 };
 
@@ -62,6 +63,9 @@ pub const SUBSCRIBE_ADAPTER_NAME: &str = "continuum.event.subscribe";
 
 /// Stable adapter name for the unsubscribe path.
 pub const UNSUBSCRIBE_ADAPTER_NAME: &str = "continuum.event.unsubscribe";
+
+/// Stable adapter name for the publish path.
+pub const PUBLISH_ADAPTER_NAME: &str = "continuum.event.publish";
 
 /// ConsumerAdapter for the subscribe path. Registered with the
 /// airc adapter registry as claiming
@@ -96,6 +100,29 @@ pub struct EventSubscribeAdapter {
 pub struct EventUnsubscribeAdapter {
     airc: Arc<Airc>,
     state: Arc<EventPublisherState>,
+}
+
+/// ConsumerAdapter for the publish path — the `emit` half of the Event
+/// primitive. Registered with the airc adapter registry as claiming
+/// [`EVENT_PUBLISH_BODY_HINT`].
+///
+/// Holds the [`AircEventPublisher`] (the fan-out engine over the shared
+/// subscription registry) so an inbound publish reaches every matching
+/// subscriber, and an `Arc<dyn AuthPolicy>` so every inbound publish is
+/// gated through the same substrate-wide chokepoint subscribe uses.
+///
+/// Publish is a WRITE: unlike subscribe (which only registers the
+/// caller's own interest), a publish MUTATES every subscriber's stream
+/// by fanning an event out to it. Without the gate, any peer that can
+/// reach this node could inject events onto ANY topic — including
+/// internal substrate signals other personas act on. The gate runs on
+/// the synthetic URI `events/<topic>/publish`, so operators author
+/// publish policy with the same path-prefix matching as every other
+/// surface.
+pub struct EventPublishAdapter {
+    airc: Arc<Airc>,
+    publisher: Arc<AircEventPublisher>,
+    policy: Arc<dyn AuthPolicy>,
 }
 
 impl EventSubscribeAdapter {
@@ -204,6 +231,101 @@ impl EventUnsubscribeAdapter {
     }
 }
 
+impl EventPublishAdapter {
+    /// Build a publish adapter against an existing airc handle +
+    /// publisher, with [`AllowAllPolicy`] as the default gate. The
+    /// publisher carries the shared `EventPublisherState`, so a publish
+    /// fans out to exactly the subscriptions the subscribe adapter
+    /// registered. Builder-style `with_policy` swaps the gate.
+    pub fn new(airc: Arc<Airc>, publisher: Arc<AircEventPublisher>) -> Arc<Self> {
+        Arc::new(Self {
+            airc,
+            publisher,
+            policy: Arc::new(AllowAllPolicy),
+        })
+    }
+
+    /// Replace the auth policy. Operators wire their substrate gate here
+    /// at boot — the same `Arc<dyn AuthPolicy>` instance shared with the
+    /// subscribe adapter, so read (subscribe) and write (publish) are
+    /// governed by one policy.
+    pub fn with_policy(
+        airc: Arc<Airc>,
+        publisher: Arc<AircEventPublisher>,
+        policy: Arc<dyn AuthPolicy>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            airc,
+            publisher,
+            policy,
+        })
+    }
+
+    /// Gate an inbound publish — the security seam, pure and exposed
+    /// `pub` so the WRITE contract is testable without airc.
+    ///
+    /// Refuses an empty topic upfront (it would fan out to nothing —
+    /// silent; refused per `[[no-fallbacks-ever]]`), then runs the
+    /// caller through the AuthPolicy on the synthetic URI
+    /// `events/<topic>/publish`. Returns `Ok(())` when allowed, or a
+    /// typed `AdapterError::Consumer` when the topic is empty or the
+    /// policy refuses (`Forbidden`/`Deferred`).
+    pub fn gate_publish(
+        policy: &dyn AuthPolicy,
+        parsed: &ParsedPublish,
+    ) -> Result<(), AdapterError> {
+        if parsed.request.topic.is_empty() {
+            return Err(AdapterError::Consumer(
+                "EventPublishAdapter: topic must not be empty — an empty topic fans \
+                 out to nothing; refuse upfront per [[no-fallbacks-ever]]"
+                    .to_string(),
+            ));
+        }
+
+        let caller = CallerIdentity::airc(parsed.caller_peer_id.0);
+        let decision = RouteDecision::Local {
+            path: format!("events/{}/publish", parsed.request.topic),
+            query: None,
+            fragment: None,
+        };
+        match policy.gate(&decision, Some(&caller)) {
+            Verdict::Allowed => Ok(()),
+            Verdict::Forbidden { reason } => Err(AdapterError::Consumer(format!(
+                "EventPublishAdapter: forbidden by policy ({reason:?}) — \
+                 caller peer={} topic={:?}",
+                parsed.caller_peer_id.0, parsed.request.topic
+            ))),
+            Verdict::Deferred {
+                reason,
+                prompt_target_env,
+            } => Err(AdapterError::Consumer(format!(
+                "EventPublishAdapter: deferred by policy ({reason:?}, prompt_target_env={prompt_target_env:?}) — \
+                 caller peer={} topic={:?}",
+                parsed.caller_peer_id.0, parsed.request.topic
+            ))),
+        }
+    }
+
+    /// Gate, fan out, ack. Gated FIRST (no fan-out on a refused publish),
+    /// then the payload is fanned to every matching subscriber, and the
+    /// ack carries the delivered count back to the caller's `emit()`.
+    async fn process_publish(
+        &self,
+        parsed: &ParsedPublish,
+    ) -> Result<(Headers, Body), AdapterError> {
+        Self::gate_publish(&*self.policy, parsed)?;
+
+        let delivered = self
+            .publisher
+            .publish(&parsed.request.topic, parsed.request.payload.clone())
+            .await
+            .map_err(AdapterError::Consumer)?;
+
+        build_publish_ack(&parsed.request.topic, delivered as u64)
+            .map_err(|e| AdapterError::Consumer(format!("build_publish_ack: {e}")))
+    }
+}
+
 #[async_trait]
 impl ConsumerAdapter for EventSubscribeAdapter {
     fn name(&self) -> &'static str {
@@ -246,13 +368,35 @@ impl ConsumerAdapter for EventUnsubscribeAdapter {
     }
 }
 
+#[async_trait]
+impl ConsumerAdapter for EventPublishAdapter {
+    fn name(&self) -> &'static str {
+        PUBLISH_ADAPTER_NAME
+    }
+
+    fn body_hint(&self) -> &'static str {
+        EVENT_PUBLISH_BODY_HINT
+    }
+
+    async fn on_envelope(&self, envelope: TranscriptEvent) -> Result<(), AdapterError> {
+        let parsed = parse_publish_envelope(&envelope)?;
+        let (headers, body) = self.process_publish(&parsed).await?;
+        self.airc
+            .reply(parsed.reply_to, parsed.correlation_id, headers, body)
+            .await
+            .map_err(|e| AdapterError::Io(format!("airc reply (publish ack): {e}")))?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::routing::{
-        AircEventSubscribe, AircEventSubscribeAck, AircEventUnsubscribe, AircEventUnsubscribeAck,
-        ClosurePolicy, ForbiddenReason, HEADER_CONTINUUM_BODY_HINT, HEADER_EVENT_KIND,
-        HEADER_EVENT_SUBSCRIPTION_ID, HEADER_EVENT_TOPIC, EVENT_ACK_BODY_HINT,
+        AircEventPublish, AircEventPublishAck, AircEventSubscribe, AircEventSubscribeAck,
+        AircEventUnsubscribe, AircEventUnsubscribeAck, ClosurePolicy, ForbiddenReason,
+        HEADER_CONTINUUM_BODY_HINT, HEADER_EVENT_KIND, HEADER_EVENT_SUBSCRIPTION_ID,
+        HEADER_EVENT_TOPIC, EVENT_ACK_BODY_HINT,
     };
     use airc_core::PeerId;
     use std::sync::{Arc as StdArc, Mutex};
@@ -468,6 +612,8 @@ mod tests {
         // would vanish.
         assert_eq!(SUBSCRIBE_ADAPTER_NAME, "continuum.event.subscribe");
         assert_eq!(UNSUBSCRIBE_ADAPTER_NAME, "continuum.event.unsubscribe");
+        assert_eq!(PUBLISH_ADAPTER_NAME, "continuum.event.publish");
+        assert_eq!(EVENT_PUBLISH_BODY_HINT, "continuum.event.publish.v1");
 
         // The body_hint accessors must match the protocol-side
         // constants the caller-side AircEventTransport stamps.
@@ -673,5 +819,175 @@ mod tests {
             "URI shape must be events/<topic>/subscribe so policies can match \
              prefix authoring stays stable across refactors"
         );
+    }
+
+    // ─── EventPublishAdapter::gate_publish (the WRITE gate) ───────────
+    //
+    // process_publish's fan-out half is the async glue over
+    // AircEventPublisher::publish, whose composition is covered without
+    // airc by airc_event_publisher::build_publish_envelopes tests. Here
+    // we test the security-critical seam — the gate — directly.
+
+    #[test]
+    fn gate_publish_threads_caller_into_gate() {
+        let captured: StdArc<Mutex<Option<CallerIdentity>>> = StdArc::new(Mutex::new(None));
+        let captured_clone = captured.clone();
+
+        let policy = ClosurePolicy::new(
+            "record-caller-event-publish",
+            move |_decision: &RouteDecision, caller: Option<&CallerIdentity>| {
+                *captured_clone.lock().unwrap() = caller.cloned();
+                Verdict::Allowed
+            },
+        );
+
+        let sender_peer_id = PeerId::new();
+        let parsed = ParsedPublish {
+            caller_peer_id: sender_peer_id,
+            reply_to: PeerId::new(),
+            correlation_id: Uuid::new_v4(),
+            request: AircEventPublish {
+                topic: "cognition/analyze/complete".into(),
+                payload: serde_json::json!({ "k": 1 }),
+            },
+        };
+
+        EventPublishAdapter::gate_publish(&policy, &parsed)
+            .expect("AllowAll-style verdict → gate_publish succeeds");
+
+        let observed = captured
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("AuthPolicy::gate must have been invoked with Some(caller)");
+        assert_eq!(
+            observed.peer_id, sender_peer_id.0,
+            "caller's peer_id must match the envelope sender — a publish is a \
+             WRITE; the gate must see who is emitting"
+        );
+        assert!(
+            matches!(observed.source, crate::routing::CallerSource::Airc),
+            "caller source must be Airc (cross-grid), not Local: {observed:?}"
+        );
+    }
+
+    #[test]
+    fn gate_publish_refuses_empty_topic_with_typed_error() {
+        let parsed = ParsedPublish {
+            caller_peer_id: PeerId::new(),
+            reply_to: PeerId::new(),
+            correlation_id: Uuid::new_v4(),
+            request: AircEventPublish {
+                topic: "".into(),
+                payload: serde_json::json!({}),
+            },
+        };
+
+        let err = EventPublishAdapter::gate_publish(&allow_all(), &parsed)
+            .expect_err("empty topic must refuse");
+        match err {
+            AdapterError::Consumer(msg) => assert!(
+                msg.contains("topic must not be empty"),
+                "error names the missing piece: {msg}"
+            ),
+            other => panic!("expected Consumer error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gate_publish_refuses_when_policy_forbids() {
+        let policy = ClosurePolicy::new("forbid-everything", |_decision, _caller| {
+            Verdict::Forbidden {
+                reason: ForbiddenReason::NoPermissionForUri("events/internal/publish".into()),
+            }
+        });
+
+        let parsed = ParsedPublish {
+            caller_peer_id: PeerId::new(),
+            reply_to: PeerId::new(),
+            correlation_id: Uuid::new_v4(),
+            request: AircEventPublish {
+                topic: "events/internal".into(),
+                payload: serde_json::json!({}),
+            },
+        };
+
+        let err = EventPublishAdapter::gate_publish(&policy, &parsed)
+            .expect_err("Forbidden verdict must refuse");
+        match err {
+            AdapterError::Consumer(msg) => {
+                assert!(
+                    msg.contains("forbidden by policy"),
+                    "error must signal policy refusal: {msg}"
+                );
+                assert!(
+                    msg.contains("NoPermissionForUri"),
+                    "error must include the typed reason: {msg}"
+                );
+            }
+            other => panic!("expected Consumer error, got {other:?}"),
+        }
+    }
+
+    /// The synthetic URI the gate sees: `events/<topic>/publish` — the
+    /// WRITE twin of `.../subscribe`. Pin it so a future change to the URI
+    /// construction can't silently break publish policies that match on
+    /// the path prefix.
+    #[test]
+    fn gate_publish_decision_path_is_stable() {
+        let observed: StdArc<Mutex<Option<String>>> = StdArc::new(Mutex::new(None));
+        let observed_clone = observed.clone();
+
+        let policy = ClosurePolicy::new("record-decision-path", move |decision, _caller| {
+            if let RouteDecision::Local { path, .. } = decision {
+                *observed_clone.lock().unwrap() = Some(path.clone());
+            }
+            Verdict::Allowed
+        });
+
+        let parsed = ParsedPublish {
+            caller_peer_id: PeerId::new(),
+            reply_to: PeerId::new(),
+            correlation_id: Uuid::new_v4(),
+            request: AircEventPublish {
+                topic: "cognition/score/persona-scored".into(),
+                payload: serde_json::json!({}),
+            },
+        };
+
+        EventPublishAdapter::gate_publish(&policy, &parsed).expect("allowed");
+        let path = observed.lock().unwrap().clone().expect("policy saw a Local decision");
+        assert_eq!(
+            path, "events/cognition/score/persona-scored/publish",
+            "URI shape must be events/<topic>/publish — the WRITE twin of \
+             subscribe — so publish policy prefix authoring stays stable"
+        );
+    }
+
+    // what this catches: the publish ack carries BOTH the topic and the
+    // fan-out count back to the caller's emit(). A drift that drops
+    // `delivered` would make emit() unable to report how many subscribers
+    // an event reached.
+    #[test]
+    fn build_publish_ack_carries_topic_and_delivered_count() {
+        let (headers, body) = build_publish_ack("metrics/cpu", 3).expect("ack");
+
+        assert_eq!(headers.get(HEADER_EVENT_KIND).map(String::as_str), Some("ack"));
+        assert_eq!(
+            headers.get(HEADER_EVENT_TOPIC).map(String::as_str),
+            Some("metrics/cpu")
+        );
+        assert_eq!(
+            headers.get(HEADER_CONTINUUM_BODY_HINT).map(String::as_str),
+            Some(EVENT_ACK_BODY_HINT)
+        );
+
+        let ack: AircEventPublishAck = serde_json::from_value(match body {
+            Body::Json(v) => v,
+            other => panic!("expected Json, got {other:?}"),
+        })
+        .expect("decode");
+        assert_eq!(ack.topic, "metrics/cpu");
+        assert_eq!(ack.delivered, 3);
     }
 }

--- a/core/continuum-core/src/routing/airc_event_protocol.rs
+++ b/core/continuum-core/src/routing/airc_event_protocol.rs
@@ -12,8 +12,9 @@
 //! `RouteKind` dependency.
 
 pub use continuum_airc_protocol::event::{
-    AircEventDeliver, AircEventSubscribe, AircEventSubscribeAck, AircEventUnsubscribe,
-    AircEventUnsubscribeAck, EVENT_ACK_BODY_HINT, EVENT_DELIVER_BODY_HINT,
-    EVENT_SUBSCRIBE_BODY_HINT, EVENT_UNSUBSCRIBE_BODY_HINT, HEADER_EVENT_KIND,
-    HEADER_EVENT_SUBSCRIPTION_ID, HEADER_EVENT_TOPIC,
+    AircEventDeliver, AircEventPublish, AircEventPublishAck, AircEventSubscribe,
+    AircEventSubscribeAck, AircEventUnsubscribe, AircEventUnsubscribeAck, EVENT_ACK_BODY_HINT,
+    EVENT_DELIVER_BODY_HINT, EVENT_PUBLISH_BODY_HINT, EVENT_SUBSCRIBE_BODY_HINT,
+    EVENT_UNSUBSCRIBE_BODY_HINT, HEADER_EVENT_KIND, HEADER_EVENT_SUBSCRIPTION_ID,
+    HEADER_EVENT_TOPIC,
 };

--- a/core/continuum-core/src/routing/airc_event_publisher.rs
+++ b/core/continuum-core/src/routing/airc_event_publisher.rs
@@ -73,9 +73,10 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use super::{
-    AircEventDeliver, AircEventSubscribe, AircEventSubscribeAck, AircEventUnsubscribe,
-    AircEventUnsubscribeAck, EVENT_ACK_BODY_HINT, EVENT_DELIVER_BODY_HINT, HEADER_CONTINUUM_BODY_HINT,
-    HEADER_EVENT_KIND, HEADER_EVENT_SUBSCRIPTION_ID, HEADER_EVENT_TOPIC,
+    AircEventDeliver, AircEventPublish, AircEventPublishAck, AircEventSubscribe,
+    AircEventSubscribeAck, AircEventUnsubscribe, AircEventUnsubscribeAck, EVENT_ACK_BODY_HINT,
+    EVENT_DELIVER_BODY_HINT, HEADER_CONTINUUM_BODY_HINT, HEADER_EVENT_KIND,
+    HEADER_EVENT_SUBSCRIPTION_ID, HEADER_EVENT_TOPIC,
 };
 
 // ─── Public state machine ──────────────────────────────────────────
@@ -405,6 +406,17 @@ pub struct ParsedUnsubscribe {
     pub request: AircEventUnsubscribe,
 }
 
+/// Parsed pieces of an inbound publish envelope — the `emit` half of
+/// the Event primitive. Same shape as [`ParsedSubscribe`] with the
+/// publish body (topic + payload to fan out).
+#[derive(Debug, Clone)]
+pub struct ParsedPublish {
+    pub caller_peer_id: PeerId,
+    pub reply_to: PeerId,
+    pub correlation_id: Uuid,
+    pub request: AircEventPublish,
+}
+
 /// Parse an inbound subscribe `TranscriptEvent` into
 /// [`ParsedSubscribe`]. Pure function — every refusal branch is
 /// testable without airc.
@@ -535,6 +547,66 @@ pub fn parse_unsubscribe_envelope(
     })
 }
 
+/// Parse an inbound publish `TranscriptEvent` into [`ParsedPublish`].
+/// Pure function — the `emit` twin of [`parse_subscribe_envelope`],
+/// same header/body refusal branches for the publish body.
+pub fn parse_publish_envelope(envelope: &TranscriptEvent) -> Result<ParsedPublish, AdapterError> {
+    let caller_peer_id = envelope.peer_id;
+
+    let reply_to_raw = envelope.headers.get(HEADER_AIRC_REPLY_TO).ok_or_else(|| {
+        AdapterError::Consumer(format!(
+            "missing required header {HEADER_AIRC_REPLY_TO} on inbound event publish envelope"
+        ))
+    })?;
+    let reply_to_uuid: Uuid = reply_to_raw.parse().map_err(|e| {
+        AdapterError::Consumer(format!(
+            "header {HEADER_AIRC_REPLY_TO}={reply_to_raw:?} is not a valid UUID: {e}"
+        ))
+    })?;
+    let reply_to = PeerId(reply_to_uuid);
+
+    let correlation_raw = envelope
+        .headers
+        .get(HEADER_AIRC_CORRELATION_ID)
+        .ok_or_else(|| {
+            AdapterError::Consumer(format!(
+                "missing required header {HEADER_AIRC_CORRELATION_ID} on inbound event publish envelope"
+            ))
+        })?;
+    let correlation_id: Uuid = correlation_raw.parse().map_err(|e| {
+        AdapterError::Consumer(format!(
+            "header {HEADER_AIRC_CORRELATION_ID}={correlation_raw:?} is not a valid UUID: {e}"
+        ))
+    })?;
+
+    let body = envelope.body.as_ref().ok_or_else(|| {
+        AdapterError::Consumer(
+            "inbound event publish envelope has no body (expected Body::Json(AircEventPublish))"
+                .to_string(),
+        )
+    })?;
+
+    let body_value = match body {
+        Body::Json(v) => v.clone(),
+        Body::Binary(_) => {
+            return Err(AdapterError::Consumer(
+                "inbound event publish body was Binary; expected Json(AircEventPublish)".to_string(),
+            ));
+        }
+    };
+
+    let request: AircEventPublish = serde_json::from_value(body_value).map_err(|e| {
+        AdapterError::Consumer(format!("decode AircEventPublish from body JSON: {e}"))
+    })?;
+
+    Ok(ParsedPublish {
+        caller_peer_id,
+        reply_to,
+        correlation_id,
+        request,
+    })
+}
+
 /// Build the `(Headers, Body)` for a subscribe ack reply. Pure
 /// function — used by the ConsumerAdapter (next commit) when
 /// replying via `Airc::reply`.
@@ -582,6 +654,30 @@ pub fn build_unsubscribe_ack(
         HEADER_EVENT_SUBSCRIPTION_ID.to_string(),
         subscription_id.to_string(),
     );
+    headers.insert(
+        HEADER_CONTINUUM_BODY_HINT.to_string(),
+        EVENT_ACK_BODY_HINT.to_string(),
+    );
+
+    Ok((headers, body))
+}
+
+/// Build the `(Headers, Body)` for a publish ack reply. Pure
+/// function — the `emit` twin of [`build_subscribe_ack`]. Carries the
+/// fan-out count (`delivered`) so the caller's `emit()` learns how many
+/// subscribers the event reached.
+pub fn build_publish_ack(topic: &str, delivered: u64) -> Result<(Headers, Body), String> {
+    let ack = AircEventPublishAck {
+        topic: topic.to_string(),
+        delivered,
+    };
+    let body_value =
+        serde_json::to_value(&ack).map_err(|e| format!("serialize AircEventPublishAck: {e}"))?;
+    let body = Body::Json(body_value);
+
+    let mut headers = Headers::new();
+    headers.insert(HEADER_EVENT_KIND.to_string(), "ack".to_string());
+    headers.insert(HEADER_EVENT_TOPIC.to_string(), topic.to_string());
     headers.insert(
         HEADER_CONTINUUM_BODY_HINT.to_string(),
         EVENT_ACK_BODY_HINT.to_string(),

--- a/core/continuum-core/src/routing/mod.rs
+++ b/core/continuum-core/src/routing/mod.rs
@@ -50,20 +50,20 @@ pub use airc_command_protocol::{
     HEADER_COMMAND_STATUS, HEADER_CONTINUUM_BODY_HINT,
 };
 pub use airc_event_protocol::{
-    AircEventDeliver, AircEventSubscribe, AircEventSubscribeAck, AircEventUnsubscribe,
-    AircEventUnsubscribeAck, EVENT_ACK_BODY_HINT, EVENT_DELIVER_BODY_HINT,
-    EVENT_SUBSCRIBE_BODY_HINT, EVENT_UNSUBSCRIBE_BODY_HINT, HEADER_EVENT_KIND,
-    HEADER_EVENT_SUBSCRIPTION_ID, HEADER_EVENT_TOPIC,
+    AircEventDeliver, AircEventPublish, AircEventPublishAck, AircEventSubscribe,
+    AircEventSubscribeAck, AircEventUnsubscribe, AircEventUnsubscribeAck, EVENT_ACK_BODY_HINT,
+    EVENT_DELIVER_BODY_HINT, EVENT_PUBLISH_BODY_HINT, EVENT_SUBSCRIBE_BODY_HINT,
+    EVENT_UNSUBSCRIBE_BODY_HINT, HEADER_EVENT_KIND, HEADER_EVENT_SUBSCRIPTION_ID, HEADER_EVENT_TOPIC,
 };
 pub use airc_event_adapters::{
-    EventSubscribeAdapter, EventUnsubscribeAdapter, SUBSCRIBE_ADAPTER_NAME,
-    UNSUBSCRIBE_ADAPTER_NAME,
+    EventPublishAdapter, EventSubscribeAdapter, EventUnsubscribeAdapter, PUBLISH_ADAPTER_NAME,
+    SUBSCRIBE_ADAPTER_NAME, UNSUBSCRIBE_ADAPTER_NAME,
 };
 pub use airc_event_publisher::{
-    build_deliver_frame, build_subscribe_ack, build_unsubscribe_ack, matches_filter,
-    parse_subscribe_envelope, parse_unsubscribe_envelope, ActiveSubscription,
-    AircEventPublisher, EventPublisherState, MatchedSubscription, ParsedSubscribe,
-    ParsedUnsubscribe,
+    build_deliver_frame, build_publish_ack, build_subscribe_ack, build_unsubscribe_ack,
+    matches_filter, parse_publish_envelope, parse_subscribe_envelope, parse_unsubscribe_envelope,
+    ActiveSubscription, AircEventPublisher, EventPublisherState, MatchedSubscription, ParsedPublish,
+    ParsedSubscribe, ParsedUnsubscribe,
 };
 pub use airc_event_transport::{
     AircEventTransport, EventSubscription, DEFAULT_DELIVERY_QUEUE_CAPACITY,


### PR DESCRIPTION
## What

The client-side `emit()` (BigMama, #1666) builds an `AircEventPublish` envelope. This is its **peer-side landing** — the `ConsumerAdapter` that receives a publish, gates it, fans it out to every matching subscriber, and acks the delivered count.

Completes the Event primitive's **write** half on the core:

| primitive | read | write |
|---|---|---|
| Command | execute (#1663) | provide (#1664) |
| Event | subscribe (#1663) | **publish (this PR)** |

## Built lowest-level-out, mirroring subscribe line-for-line

- **protocol** (`continuum-airc-protocol`, already on canary): `AircEventPublish`, `AircEventPublishAck`, `EVENT_PUBLISH_BODY_HINT`, `resolve_publish`, `decode_publish_ack` — single source of truth for the wire shape.
- **`routing/airc_event_protocol.rs` + `mod.rs`**: re-export the publish symbols beside the subscribe ones.
- **`routing/airc_event_publisher.rs`**: `ParsedPublish` + `parse_publish_envelope` (twin of `parse_subscribe_envelope`) + `build_publish_ack` (twin of `build_subscribe_ack`, carrying the fan-out count).
- **`routing/airc_event_adapters.rs`**: `EventPublishAdapter` — `gate_publish` (pure WRITE-gate seam) + `process_publish` (gate → `AircEventPublisher::publish` fan-out → ack) + the `ConsumerAdapter` impl claiming `EVENT_PUBLISH_BODY_HINT`.

## Why publish is gated as a WRITE

Unlike subscribe (registers the caller's *own* interest), a publish **mutates every subscriber's stream**. It runs through the same `AuthPolicy` chokepoint on the synthetic URI `events/<topic>/publish` — without it, any reachable peer could inject events onto **any** topic, including internal substrate signals other personas act on. Empty topic refused upfront (`[[no-fallbacks-ever]]`).

## Test

`cargo test -p continuum-core --lib --features metal,accelerate,test-fixtures routing::airc_event_adapters::tests` → 15 passed (4 new publish-gate/ack tests + the existing subscribe suite). Clippy clean on touched files. The async fan-out half composes `AircEventPublisher::publish`, covered without airc by the existing `build_publish_envelopes` tests.

## Scope

Boot wiring (`register_consumer_adapter` for the whole event surface) is the same not-yet-present integration step the subscribe/unsubscribe adapters await — this lands the publish adapter **ready to register beside them**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)