### PR TITLE
feat(sessions): context_id envelope tier + session()/scoped() client surface

### DIFF
--- a/client/continuum-client-ffi/src/lib.rs
+++ b/client/continuum-client-ffi/src/lib.rs
@@ -29,10 +29,14 @@ use std::sync::Arc;
 
 use continuum_client::{
     AircIpcTransport, ClientError, CommandClient, Connection, EventSubscriber, ServeHandler,
-    Transport,
+    SessionIdentity, Transport,
 };
 use futures::StreamExt;
 use uuid::Uuid;
+
+/// Re-export so every per-platform binding reads the one identity record:
+/// `{ userId?, sessionId? }`. The FFI surface for `ContinuumClient::session`.
+pub use continuum_client::SessionIdentity as Session;
 
 /// FFI-clean error. `continuum-client`'s `ClientError` is rich and Rust-shaped;
 /// this flattens it to the few variants a foreign caller needs, each carrying a
@@ -211,7 +215,26 @@ impl ContinuumClient {
         }
     }
 
-    /// Execute a command: JSON params in, JSON result out.
+    /// WHO this client acts as — citizen (`userId`) + session instance
+    /// (`sessionId`). Readonly; surfaces the identity established at connect
+    /// (airc pairing / handshake, or the persona's own id). Each platform SDK
+    /// presents it idiomatically; the record shape is identical everywhere.
+    pub fn session(&self) -> SessionIdentity {
+        self.conn.session()
+    }
+
+    /// Return a client SCOPED to a conversation/room (`context_id`, the third
+    /// ID tier). The scoped client's verbs auto-stamp `contextId` so callers
+    /// never re-thread the scope — a persona services a room as a scoped client
+    /// exactly the way a UI client does. Shares the same transport + identity.
+    pub fn scoped(&self, context_id: Uuid) -> ContinuumClient {
+        ContinuumClient {
+            conn: self.conn.scoped(context_id),
+        }
+    }
+
+    /// Execute a command: JSON params in, JSON result out. Stamps `contextId`
+    /// when this client is `scoped`.
     pub async fn execute(&self, command: &str, params_json: &str) -> Result<String, FfiError> {
         execute_json(self.conn.commands(), command, params_json).await
     }

--- a/client/continuum-client/src/command.rs
+++ b/client/continuum-client/src/command.rs
@@ -3,18 +3,36 @@
 use std::sync::Arc;
 
 use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
 
 use crate::error::ClientError;
 use crate::transport::Transport;
 
 /// Issues commands against a continuum substrate over `T`.
+///
+/// Carries the optional `context_id` of the scope it was handed out from
+/// (`Connection::scoped(ctx).commands()`). When set, `execute` stamps it into
+/// the request envelope as the `contextId` sibling — the third ID tier — so the
+/// substrate scopes per-context state (per-room memory, per-thread recall)
+/// without the caller threading it onto every call. Identity (`userId` /
+/// `sessionId`) is kernel-injected from the connection; only `contextId` is
+/// client-supplied, so only it is stamped here.
 pub struct CommandClient<T: Transport> {
     transport: Arc<T>,
+    context_id: Option<Uuid>,
 }
 
 impl<T: Transport> CommandClient<T> {
-    pub(crate) fn new(transport: Arc<T>) -> Self {
-        Self { transport }
+    /// Build a command client over `transport`, optionally scoped to a
+    /// conversation/room. When `context_id` is `Some`, `execute` stamps it into
+    /// every request envelope (the third ID tier). `Connection::commands` is the
+    /// only caller — it passes the connection's scope.
+    pub(crate) fn with_context(transport: Arc<T>, context_id: Option<Uuid>) -> Self {
+        Self {
+            transport,
+            context_id,
+        }
     }
 
     /// Execute a command with typed params and result. Serializes params
@@ -25,8 +43,27 @@ impl<T: Transport> CommandClient<T> {
         P: Serialize,
         R: DeserializeOwned,
     {
-        let params_value = serde_json::to_value(params)?;
+        let mut params_value = serde_json::to_value(params)?;
+        self.stamp_context(&mut params_value);
         let result_value = self.transport.request(command, params_value).await?;
         Ok(serde_json::from_value(result_value)?)
+    }
+
+    /// Stamp `contextId` into the request envelope when this client is scoped.
+    /// The envelope reads it as a sibling of the flattened params
+    /// (`command_envelope.rs`), so it must be an object — which command params
+    /// always are. A non-object params value (degenerate) is left untouched
+    /// rather than silently wrapped: better the scope is visibly absent than
+    /// the params shape corrupted.
+    fn stamp_context(&self, params: &mut Value) {
+        let Some(context_id) = self.context_id else {
+            return;
+        };
+        if let Value::Object(map) = params {
+            map.insert(
+                "contextId".to_string(),
+                Value::String(context_id.to_string()),
+            );
+        }
     }
 }

--- a/client/continuum-client/src/connection.rs
+++ b/client/continuum-client/src/connection.rs
@@ -8,23 +8,38 @@ use crate::airc_ipc::AircIpcTransport;
 use crate::command::CommandClient;
 use crate::error::ClientError;
 use crate::event::EventSubscriber;
+use crate::session::SessionIdentity;
 use crate::transport::{ServeHandler, Transport};
 
 /// One session against a continuum substrate. Generic over the wire so
 /// the same code drives local airc IPC, remote airc grid, and the
 /// `MockTransport` used in downstream tests.
+///
+/// A connection carries WHO it acts as (`identity`: userId + sessionId) and,
+/// optionally, WHERE — the conversation/room `context_id` a [`scoped`] view is
+/// bound to. The 4 verbs hang off this one object; `scoped(ctx)` returns another
+/// connection over the SAME transport with the context set, so every client —
+/// UI, CLI, persona — uses the identical `connect → session → scoped(context)`
+/// shape (`[[persona-is-a-client]]`).
+///
+/// [`scoped`]: Connection::scoped
 pub struct Connection<T: Transport> {
     transport: Arc<T>,
+    identity: SessionIdentity,
+    context_id: Option<Uuid>,
 }
 
 // Manual `Clone` (not derived): a connection is cheap to clone — it shares the
 // one `Arc<T>` transport. Derived `Clone` would wrongly require `T: Clone`;
 // `Arc<T>` is `Clone` regardless. Cloning lets a `provide` registration hold a
-// handle to revoke on drop without re-establishing the session.
+// handle to revoke on drop without re-establishing the session, and is how
+// `scoped` returns a context-bound view over the same wire.
 impl<T: Transport> Clone for Connection<T> {
     fn clone(&self) -> Self {
         Self {
             transport: Arc::clone(&self.transport),
+            identity: self.identity.clone(),
+            context_id: self.context_id,
         }
     }
 }
@@ -32,16 +47,55 @@ impl<T: Transport> Clone for Connection<T> {
 impl<T: Transport> Connection<T> {
     /// Build a connection over an already-established transport. Higher-
     /// level constructors (e.g. `connect_local`, `connect_remote`) will
-    /// wrap this once the airc transport impls land.
+    /// wrap this once the airc transport impls land. Identity is unknown
+    /// until the establishing layer sets it via [`with_identity`].
+    ///
+    /// [`with_identity`]: Connection::with_identity
     pub fn new(transport: T) -> Self {
         Self {
             transport: Arc::new(transport),
+            identity: SessionIdentity::unknown(),
+            context_id: None,
         }
     }
 
-    /// Typed command dispatcher for this connection.
+    /// Set the identity this connection acts as — called by the establishing
+    /// layer (airc pairing / substrate handshake for a UI client; the spawn
+    /// path for a persona, which knows its own citizen id). The SDK surfaces
+    /// what's established; it never fabricates identity.
+    pub fn with_identity(mut self, identity: SessionIdentity) -> Self {
+        self.identity = identity;
+        self
+    }
+
+    /// WHO this connection acts as — citizen (`userId`) + session instance
+    /// (`sessionId`). Surfaced uniformly across every client + persona.
+    pub fn session(&self) -> SessionIdentity {
+        self.identity.clone()
+    }
+
+    /// The conversation/room this connection is scoped to, if any (the third
+    /// ID tier). `None` on an unscoped connection.
+    pub fn context_id(&self) -> Option<Uuid> {
+        self.context_id
+    }
+
+    /// Return a view of this connection SCOPED to a conversation/room — its
+    /// command + event verbs auto-stamp `contextId` (the third ID tier) so
+    /// callers never re-thread the scope. Shares the same transport + identity;
+    /// only the context differs. This is how a persona services a room (scoped
+    /// to that room's contextId) the same way a browser tab does.
+    pub fn scoped(&self, context_id: Uuid) -> Self {
+        Self {
+            transport: Arc::clone(&self.transport),
+            identity: self.identity.clone(),
+            context_id: Some(context_id),
+        }
+    }
+
+    /// Typed command dispatcher for this connection, scoped to its context.
     pub fn commands(&self) -> CommandClient<T> {
-        CommandClient::new(Arc::clone(&self.transport))
+        CommandClient::with_context(Arc::clone(&self.transport), self.context_id)
     }
 
     /// Typed event subscriber for this connection.
@@ -50,8 +104,19 @@ impl<T: Transport> Connection<T> {
     }
 
     /// Publish an event to `class` — the publish side of the Event primitive
-    /// (the emit twin of `events().subscribe`).
-    pub async fn emit(&self, class: &str, payload: serde_json::Value) -> Result<(), ClientError> {
+    /// (the emit twin of `events().subscribe`). When this connection is scoped,
+    /// `contextId` is stamped into the payload (the same third-tier scope the
+    /// command path stamps), so an emitted event carries the conversation it
+    /// belongs to.
+    pub async fn emit(&self, class: &str, mut payload: serde_json::Value) -> Result<(), ClientError> {
+        if let Some(context_id) = self.context_id {
+            if let serde_json::Value::Object(map) = &mut payload {
+                map.insert(
+                    "contextId".to_string(),
+                    serde_json::Value::String(context_id.to_string()),
+                );
+            }
+        }
         self.transport.emit(class, payload).await
     }
 
@@ -87,5 +152,110 @@ impl Connection<AircIpcTransport> {
     /// the running server.
     pub fn connect(airc: Arc<airc_lib::Airc>, target_peer: Uuid) -> Self {
         Self::new(AircIpcTransport::new(airc, target_peer))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock::MockTransport;
+    use futures::StreamExt;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    // what this catches: a SCOPED connection stamps contextId (the third ID
+    // tier) into the command envelope as a sibling of params — the mechanism the
+    // substrate reads it from (command_envelope.rs). Regression here un-scopes
+    // every per-context handler silently.
+    #[tokio::test]
+    async fn scoped_connection_stamps_context_id_into_command_envelope() {
+        let captured: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+        let cap = Arc::clone(&captured);
+        let mock = MockTransport::new();
+        mock.respond_to("chat/send", move |params| {
+            *cap.lock().unwrap() = Some(params);
+            Ok(json!({ "ok": true }))
+        });
+        let ctx = Uuid::new_v4();
+
+        let conn = Connection::new(mock).scoped(ctx);
+        let _: serde_json::Value = conn
+            .commands()
+            .execute("chat/send", json!({ "text": "hi" }))
+            .await
+            .expect("execute");
+
+        let sent = captured.lock().unwrap().clone().expect("handler saw params");
+        assert_eq!(sent["text"], "hi", "command params survive intact");
+        assert_eq!(
+            sent["contextId"],
+            json!(ctx.to_string()),
+            "scoped connection stamps contextId as an envelope sibling"
+        );
+    }
+
+    // what this catches: an UNSCOPED connection sends NO contextId — context is
+    // opt-in via scoped(), never leaked onto a bare connection.
+    #[tokio::test]
+    async fn unscoped_connection_omits_context_id() {
+        let captured: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+        let cap = Arc::clone(&captured);
+        let mock = MockTransport::new();
+        mock.respond_to("ping", move |params| {
+            *cap.lock().unwrap() = Some(params);
+            Ok(json!({}))
+        });
+
+        let conn = Connection::new(mock); // not scoped
+        let _: serde_json::Value = conn.commands().execute("ping", json!({})).await.expect("execute");
+
+        let sent = captured.lock().unwrap().clone().expect("handler saw params");
+        assert!(
+            sent.get("contextId").is_none(),
+            "unscoped connection must not stamp contextId"
+        );
+    }
+
+    // what this catches: session() surfaces the established identity; an
+    // un-established connection is honestly unknown (None/None), never fabricated.
+    #[tokio::test]
+    async fn session_surfaces_established_identity() {
+        let unknown = Connection::new(MockTransport::new());
+        assert_eq!(unknown.session(), SessionIdentity::unknown());
+        assert_eq!(unknown.context_id(), None);
+
+        let id = SessionIdentity::new(Uuid::new_v4(), Uuid::new_v4());
+        let known = Connection::new(MockTransport::new()).with_identity(id.clone());
+        assert_eq!(known.session(), id);
+    }
+
+    // what this catches: scoped() carries identity forward + sets context, and
+    // does NOT mutate the parent — a persona scoped to a room is the same citizen.
+    #[tokio::test]
+    async fn scoped_preserves_identity_and_leaves_parent_unscoped() {
+        let id = SessionIdentity::new(Uuid::new_v4(), Uuid::new_v4());
+        let ctx = Uuid::new_v4();
+        let conn = Connection::new(MockTransport::new()).with_identity(id.clone());
+
+        let scoped = conn.scoped(ctx);
+        assert_eq!(scoped.session(), id, "same citizen, now scoped");
+        assert_eq!(scoped.context_id(), Some(ctx));
+        assert_eq!(conn.context_id(), None, "parent connection stays unscoped");
+    }
+
+    // what this catches: an emitted event from a scoped connection carries its
+    // contextId in the payload — the event knows the conversation it belongs to.
+    #[tokio::test]
+    async fn scoped_connection_stamps_context_id_into_emitted_event() {
+        let mock = MockTransport::new();
+        let ctx = Uuid::new_v4();
+        let conn = Connection::new(mock.clone()).scoped(ctx);
+
+        let mut stream = mock.subscribe("room:msg").await.expect("subscribe");
+        conn.emit("room:msg", json!({ "text": "hi" })).await.expect("emit");
+
+        let ev = stream.next().await.expect("event").expect("ok");
+        assert_eq!(ev["text"], "hi");
+        assert_eq!(ev["contextId"], json!(ctx.to_string()));
     }
 }

--- a/client/continuum-client/src/lib.rs
+++ b/client/continuum-client/src/lib.rs
@@ -13,6 +13,7 @@ pub mod error;
 pub mod event;
 #[cfg(any(test, feature = "test-fixtures"))]
 pub mod mock;
+pub mod session;
 pub mod transport;
 
 pub use airc_ipc::AircIpcTransport;
@@ -22,4 +23,5 @@ pub use error::ClientError;
 pub use event::EventSubscriber;
 #[cfg(any(test, feature = "test-fixtures"))]
 pub use mock::MockTransport;
+pub use session::SessionIdentity;
 pub use transport::{ServeHandler, Transport};

--- a/client/continuum-client/src/session.rs
+++ b/client/continuum-client/src/session.rs
@@ -1,0 +1,48 @@
+//! Session identity — WHO a connection is acting as.
+//!
+//! The first two tiers of the ID hierarchy (CLAUDE.md): `userId` (the permanent
+//! citizen) and `sessionId` (this connection instance). The third tier —
+//! `contextId` (the conversation/room scope) — is NOT here: it's per-scope, not
+//! per-connection, so it lives on a scoped [`Connection`](crate::Connection),
+//! not in the identity.
+//!
+//! Both fields are `Option` because identity is ESTABLISHED, not assumed: a
+//! freshly-built connection may not yet know its identity until the establishing
+//! layer sets it (`Connection::with_identity`) — the airc pairing / substrate
+//! handshake for a UI client, or the spawn path for a persona (which knows its
+//! own citizen id). The SDK surfaces what's known; it never fabricates identity.
+//!
+//! This is uniform across EVERY client — UI, CLI, and personas alike. A persona
+//! is a citizen with a `SessionIdentity` just like a browser tab
+//! (`[[persona-is-a-client]]`).
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// The identity a [`Connection`](crate::Connection) acts as — citizen + session
+/// instance. Surfaced by `Connection::session()`; the FFI facade re-exports it
+/// as a record so every language SDK reads the same `{ userId?, sessionId? }`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionIdentity {
+    /// The permanent citizen — set from the airc pairing / substrate mapping
+    /// (or the persona's own id). `None` until established.
+    pub user_id: Option<Uuid>,
+    /// This connection instance (the "browser tab" tier). `None` until
+    /// established by the connecting layer.
+    pub session_id: Option<Uuid>,
+}
+
+impl SessionIdentity {
+    /// An unestablished identity — the connection doesn't yet know who it is.
+    pub fn unknown() -> Self {
+        Self::default()
+    }
+
+    /// Build a fully-known identity (citizen + session instance).
+    pub fn new(user_id: Uuid, session_id: Uuid) -> Self {
+        Self {
+            user_id: Some(user_id),
+            session_id: Some(session_id),
+        }
+    }
+}

--- a/core/continuum-core/src/runtime/command_envelope.rs
+++ b/core/continuum-core/src/runtime/command_envelope.rs
@@ -142,6 +142,25 @@ pub struct CommandRequest<P> {
     /// reading this can scope per-user state (e.g., per-persona work).
     #[serde(rename = "userId", skip_serializing_if = "Option::is_none", default)]
     pub user_id: Option<Uuid>,
+
+    /// Conversation / room scope this command operates within — the THIRD
+    /// ID tier (userId > sessionId > contextId, CLAUDE.md ID hierarchy).
+    ///
+    /// UNLIKE `session_id`/`user_id` — which the kernel injects from the
+    /// connection (the substrate knows WHO you are from the airc pairing) —
+    /// `context_id` is CLIENT-SUPPLIED: the caller scopes a sequence of ops
+    /// to a conversation via the SDK's scoped client (`Continuum.scoped(ctx)`),
+    /// and it rides as an envelope sibling so handlers scope per-context state
+    /// (per-room memory, per-thread recall) without it polluting command
+    /// params. First-class for every citizen — a persona servicing a room is
+    /// a citizen scoped to that room's contextId, the same shape a browser tab
+    /// uses (this is what fills the persona cognition's tool_context).
+    #[serde(
+        rename = "contextId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub context_id: Option<Uuid>,
 }
 
 impl<P> CommandRequest<P>
@@ -172,6 +191,7 @@ impl<P> CommandRequest<P> {
             handle: None,
             session_id: None,
             user_id: None,
+            context_id: None,
         }
     }
 
@@ -187,6 +207,13 @@ impl<P> CommandRequest<P> {
 
     pub fn with_user(mut self, user_id: Uuid) -> Self {
         self.user_id = Some(user_id);
+        self
+    }
+
+    /// Scope this request to a conversation/room (the third ID tier). The SDK's
+    /// scoped client stamps it; handlers read it for per-context state.
+    pub fn with_context(mut self, context_id: Uuid) -> Self {
+        self.context_id = Some(context_id);
         self
     }
 
@@ -401,7 +428,10 @@ mod tests {
         assert_eq!(req.params.model, "qwen");
         assert_eq!(req.params.max_tokens, 512);
         assert!(
-            req.handle.is_none() && req.session_id.is_none() && req.user_id.is_none(),
+            req.handle.is_none()
+                && req.session_id.is_none()
+                && req.user_id.is_none()
+                && req.context_id.is_none(),
             "envelope fields default to None when absent in the wire JSON"
         );
     }
@@ -458,6 +488,35 @@ mod tests {
         assert_eq!(req.handle, Some(handle));
         assert_eq!(req.session_id, Some(session_id));
         assert_eq!(req.user_id, Some(user_id));
+    }
+
+    // what this catches: the THIRD ID tier (contextId) parses from the flat wire
+    // envelope as a sibling of sessionId/userId, and the builder attaches it.
+    // contextId is CLIENT-supplied (the SDK's scoped client stamps it), so unlike
+    // session/user it must survive a round-trip from the caller's JSON. A drift
+    // that drops it would silently un-scope every per-context handler (per-room
+    // memory, per-thread recall, a persona's tool_context).
+    #[test]
+    fn request_parses_and_builds_context_id_third_tier() {
+        let context_id = Uuid::new_v4();
+        // From flat wire JSON (the caller stamped contextId alongside params).
+        let value = json!({
+            "model": "qwen",
+            "max_tokens": 256,
+            "contextId": context_id.to_string(),
+        });
+        let req = CommandRequest::<StartParams>::from_value(value).expect("parse must succeed");
+        assert_eq!(req.context_id, Some(context_id));
+        // Round-trips back out under the camelCase wire key.
+        let back = serde_json::to_value(&req).expect("serialize");
+        assert_eq!(back["contextId"], json!(context_id.to_string()));
+        // And the builder attaches it.
+        let built = CommandRequest::new(StartParams {
+            model: "q".into(),
+            max_tokens: 1,
+        })
+        .with_context(context_id);
+        assert_eq!(built.context_id, Some(context_id));
     }
 
     // ── CommandResponse<T> ───────────────────────────────────────────


### PR DESCRIPTION
## What

The sessions layer foundation, built lowest-out. The ID hierarchy is **userId > sessionId > contextId** (CLAUDE.md), and it's **uniform across every client AND persona** (Joel: *"the clients all have identical connects and contexts etc, personas have same — first class citizens and all"*). One shape: `connect → session → scoped(context)`.

### 1. Core envelope (`command_envelope.rs`)
`context_id` — the third ID tier. The deliberate asymmetry: `session_id`/`user_id` are **kernel-injected** (the substrate knows WHO you are from the airc pairing), `context_id` is **client-supplied** (you scope the conversation). Rides as an envelope sibling (`contextId`, serde flatten). `serde(default)` → back-compatible.

### 2. Client surface (`continuum-client`)
- `SessionIdentity { user_id?, session_id? }` (new `session.rs`) — WHO a connection acts as. Both `Option` because identity is **established, not assumed** — the SDK surfaces what's known, never fabricates.
- `Connection.session()` — readonly accessor.
- `Connection.with_identity(id)` — the establishing layer sets it (airc pairing for a UI client; the spawn path for a persona).
- `Connection.scoped(context_id)` — a context-bound view over the same transport + identity; its verbs auto-stamp `contextId`. Parent stays unscoped.
- `CommandClient` stamps `contextId` as an envelope sibling — **no Transport signature change**. `emit()` stamps the payload too.

### 3. FFI facade (`continuum-client-ffi` — the uniffi binding surface)
- `ContinuumClient.session() -> SessionIdentity` (record).
- `ContinuumClient.scoped(context_id) -> ContinuumClient` (returns Self — no new interface object, no verb/callback changes). **Shape locked with BigMama for bind-once.**

## The access invariant it preserves

Only `contextId` is client-stamped; identity stays kernel-injected. Every caller — human, persona, a new client — goes through the one facade + one `AuthPolicy` gate with its own identity. No client-forged identity, no bypass: access is complete and hole-free by construction. A persona's tool executor is just another client (this fills its `tool_context`).

## Test

`cargo test -p continuum-client` (23) + `-p continuum-client-ffi` (8) + envelope (16) green; clippy clean.

## Next

TS facade `.session`/`.scoped()` + conformance dimension 6; then the persona `TsIpcToolExecutor` composed as a scoped client (task #15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)