### PR TITLE
docs(sdk): formalize the SDK tier — align READMEs to the locked architecture

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,21 +1,44 @@
-# client/ — shared rust client library
+# client/ — the shared Rust client library
 
-The seam between `core/` (substrate) and every embodiment. One rust
-crate, N language frontends, one connection / command / event API.
+The seam between `core/` (substrate) and every embodiment. One Rust crate holds
+all the client logic; N language frontends are thin skins over it. One
+connection / command / event API, one wire shape, one error model, one auth
+surface across every env.
+
+> Canonical layering + the binding decisions: **[docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md](../docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md)**.
+> The API surface every client presents: **[docs/architecture/SDK-API-SURFACE.md](../docs/architecture/SDK-API-SURFACE.md)**.
 
 ## Crates
 
-- **`continuum-client/`** — `Connection<T: Transport>` + `CommandClient` +
-  `EventSubscriber` + typed `ClientError`. `AircIpcTransport` is the
-  canonical local-substrate impl (over airc IPC, shares wire envelopes
-  with `core/continuum-airc-protocol`).
+- **`continuum-client/`** — the SDK. `Connection<T: Transport>` carrying identity
+  (`session()`) + conversation scope (`scoped(context)`), `CommandClient`,
+  `EventSubscriber`, typed `ClientError`. All connection/retry/scope/auth logic
+  lives here. Transports are locality-specific:
+  - `AircIpcTransport` — out-of-process / over the grid (airc IPC; shares wire
+    envelopes with `core/continuum-airc-protocol`).
+  - `InProcessTransport` (in `core/continuum-core/runtime`) — an in-core citizen
+    (a persona, the foundry) holding the SAME `Connection` over the core's own
+    `CommandExecutor`, no serialization. Same API, transport swapped by where you
+    are ([[persona-is-a-client]]).
+
+- **`continuum-client-ffi/`** — the FFI-clean facade over `continuum-client`:
+  reduces the generic `Connection` to the JSON-at-the-boundary form
+  (`execute(cmd, params_json) -> result_json`, `subscribe(class, callback)`,
+  `emit`, `provide`, `session()`, `scoped(context)`). Generic-free + stable so
+  one binding source serves every native SDK. **uniffi** reads this crate to emit
+  ONE native binding → xcframework (Apple) + AAR (Android); **wasm-bindgen** is
+  the separate web/node path (uniffi does not emit JS).
 
 ## Consumers
 
-- `apps/cli/` — Rust binary, links `continuum-client` directly (no SDK).
-- `sdk/{flutter,swift,kotlin,typescript}/` — language wrappers bridge
-  `continuum-client` to their platform's ecosystem via FFI.
+- `apps/cli/` — Rust binary; links `continuum-client` directly (no FFI — the
+  in-process, simplest leg).
+- `sdk/{swift,kotlin}/` — idiomatic skins over the uniffi xcframework / AAR.
+- `sdk/flutter/` — bundles the xcframework + AAR and wraps them (NOT a separate
+  binding).
+- `sdk/typescript/` — thin facade over a `Transport` (wasm-bindgen, or the wire
+  when the core is remote).
 
-The contract: anything that wants to talk to a continuum substrate
-crosses through this crate, ensuring one wire shape, one error model,
-one auth surface across every env.
+The contract: anything that talks to a continuum substrate crosses through this
+crate. The behavior every frontend must satisfy is pinned by the one executable
+conformance spec, `sdk/typescript/conformance.spec.ts`, mirrored per language.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,17 +1,55 @@
 # sdk/ — per-language SDKs over `client/continuum-client`
 
-Language wrappers that bridge `client/continuum-client` (rust) to the
-native ecosystem of each platform. CBAR-style: one shared core, N
-language frontends, mirrored API surface.
+Thin, idiomatic language skins over the one Rust client SDK. **All logic lives
+in `client/continuum-client`** ([[headless-core-many-clients]]); an SDK here holds
+ZERO logic — it converts the client's surface to its platform's conventions
+(Swift async/await, Kotlin coroutines/Flow, Dart streams, TS Promise) over
+generated types, nothing more. One shared core, N language frontends, ONE
+mirrored API surface.
 
-| SDK | Bridge | Consumed by |
-|-----|--------|-------------|
-| `typescript/` | hand-written (today); flutter_rust_bridge alt later | `apps/web`, `apps/desktop` (Tauri), `apps/mcp` (Node MCP server) |
-| `flutter/` | `flutter_rust_bridge` — Dart over rust FFI | `apps/mobile`, `apps/ar`, `apps/vr` |
-| `swift/` | `swift-bridge` — Swift package | native iOS apps (when Flutter isn't enough) |
-| `kotlin/` | `uniffi` — `.aar` artifact | native Android apps |
+> Canonical layering + the binding decisions this table follows:
+> **[docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md](../docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md)**.
+> The API surface every SDK presents: **[docs/architecture/SDK-API-SURFACE.md](../docs/architecture/SDK-API-SURFACE.md)**.
 
-Each SDK's job is to give the platform's developers an idiomatic API
-shape (Dart streams, Swift async/await, Kotlin coroutines) over the
-same `Connection / CommandClient / EventSubscriber` primitives the rust
-client exposes. The substrate stays oblivious to language.
+## The binding layers
+
+```
+client/continuum-client        (Rust — the SDK; all logic)
+  └─ client/continuum-client-ffi   (uniffi-annotated facade; JSON at the boundary)
+       ├─ uniffi  → ONE native binding → xcframework (Apple) + AAR/Maven (Android)
+       └─ wasm-bindgen (or napi) → the web/node binding   (uniffi does NOT emit JS)
+```
+
+**ONE native binding (uniffi → xcframework + AAR) serves native iOS, native
+Android, AND Flutter.** There is NOT a separate `flutter_rust_bridge` binding.
+
+| SDK | Binding | Consumed by |
+|-----|---------|-------------|
+| `swift/` | idiomatic Swift over the **uniffi xcframework** (async/await + `AsyncStream`) | native iOS / visionOS apps |
+| `kotlin/` | idiomatic Kotlin over the **uniffi AAR** (suspend + `Flow`) | native Android / Quest apps |
+| `flutter/` | **bundles the xcframework + AAR** and wraps them via platform channels (Dart) — NOT `flutter_rust_bridge` | `apps/mobile`, `apps/ar`, `apps/vr` |
+| `typescript/` | thin facade over a `Transport` — **wasm-bindgen** of `continuum-client` for web, or the RustCoreIPC wire when the core is remote | `apps/web`, `apps/desktop`, `apps/mcp` |
+
+`swift-bridge` is DEFERRED — uniffi binds both native targets today; add a second
+toolchain only if visionOS/AR async ergonomics prove it load-bearing.
+
+## The contract
+
+Every SDK presents the same four-verb surface — `execute` / `provide` (Commands)
++ `subscribe` / `emit` (Events) — plus `session()` / `scoped(context)` and the
+addressable `Handle`. That surface is pinned by **one executable conformance
+spec**, `sdk/typescript/conformance.spec.ts`: each language SDK mirrors its
+clauses name-for-name (Rust `cargo test`, Swift `XCTest`, Kotlin `JUnit`). If a
+behavior isn't in the spec it isn't in the contract; if it is, every SDK proves
+it. That's what keeps N language skins from drifting into N subtly-different
+clients.
+
+## What an SDK is NOT
+
+- NOT a place for business logic, session/event handling, or auth — those live
+  once in the Rust client + the substrate, and an SDK that re-implements them is
+  the bug ([[lock-uniform-client-early]]).
+- NOT a home for legacy wire types or the old `RustCoreIPC` client — that lives
+  at `core/continuum-core/bindings/` and is being reworked into app code, not SDK
+  code. An SDK package is the facade + generated types + the conformance spec,
+  and nothing else.


### PR DESCRIPTION
## What

Consolidation + formalization for a coherent SDK. The *structure* was already sound (`client/` = Rust SDK + FFI; `sdk/` = language skins; `sdk/typescript` locked to facade-only). But the *formalization* had drifted — the tier READMEs contradicted the canonical `docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md`. That's dangerous precisely because `swift/kotlin/flutter` are still empty stubs: the README is the only spec they'll be built against, and it was wrong.

## Fixed

- **`client/README.md`** — was missing `continuum-client-ffi` entirely (the uniffi facade, the single native-binding source). Added it + `InProcessTransport` + the `session()`/`scoped()` surface + the binding layers (uniffi → xcframework/AAR; wasm → web).
- **`sdk/README.md`** — the bridge table was wrong: it claimed swift=`swift-bridge`, flutter=`flutter_rust_bridge`, typescript=hand-written. Corrected to the locked architecture: **one uniffi native binding (xcframework + AAR) serves native iOS + Android AND Flutter** (which bundles them — no separate frb); `swift-bridge` deferred; typescript = thin facade over wasm/wire. Added the `conformance.spec.ts` contract and the "an SDK holds zero logic / no legacy bindings" rule the `sdk/typescript` cleanup just enforced.

Both now defer to the canonical architecture docs as source of truth and name `conformance.spec.ts` as the cross-language lock. **Docs only, no code change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)