### PR TITLE
refactor(client): unify the CALL verb to execute across every transport layer

### DIFF
--- a/client/continuum-client/src/airc_ipc.rs
+++ b/client/continuum-client/src/airc_ipc.rs
@@ -145,7 +145,7 @@ impl AircIpcTransport {
 
 #[async_trait]
 impl Transport for AircIpcTransport {
-    async fn request(&self, command: &str, params: Value) -> Result<Value, ClientError> {
+    async fn execute(&self, command: &str, params: Value) -> Result<Value, ClientError> {
         if self.closed.load(Ordering::Relaxed) {
             return Err(ClientError::Closed);
         }

--- a/client/continuum-client/src/command.rs
+++ b/client/continuum-client/src/command.rs
@@ -45,7 +45,7 @@ impl<T: Transport> CommandClient<T> {
     {
         let mut params_value = serde_json::to_value(params)?;
         self.stamp_context(&mut params_value);
-        let result_value = self.transport.request(command, params_value).await?;
+        let result_value = self.transport.execute(command, params_value).await?;
         Ok(serde_json::from_value(result_value)?)
     }
 

--- a/client/continuum-client/src/mock.rs
+++ b/client/continuum-client/src/mock.rs
@@ -259,7 +259,7 @@ impl std::fmt::Debug for MockTransport {
 
 #[async_trait]
 impl Transport for MockTransport {
-    async fn request(&self, command: &str, params: Value) -> Result<Value, ClientError> {
+    async fn execute(&self, command: &str, params: Value) -> Result<Value, ClientError> {
         if self.inner.closed.load(Ordering::Relaxed) {
             return Err(ClientError::Closed);
         }
@@ -364,47 +364,47 @@ mod tests {
     use serde_json::json;
 
     #[tokio::test]
-    async fn request_returns_registered_response() {
+    async fn execute_returns_registered_response() {
         let mock = MockTransport::new();
         mock.respond_with("ai/generate", json!({"text": "mocked"}));
         let got = mock
-            .request("ai/generate", json!({"prompt": "hi"}))
+            .execute("ai/generate", json!({"prompt": "hi"}))
             .await
             .unwrap();
         assert_eq!(got, json!({"text": "mocked"}));
     }
 
     #[tokio::test]
-    async fn request_handler_sees_params() {
+    async fn execute_handler_sees_params() {
         let mock = MockTransport::new();
         mock.respond_to("echo", Ok);
-        let got = mock.request("echo", json!({"x": 1})).await.unwrap();
+        let got = mock.execute("echo", json!({"x": 1})).await.unwrap();
         assert_eq!(got, json!({"x": 1}));
     }
 
     #[tokio::test]
-    async fn request_fifo_per_command() {
+    async fn execute_fifo_per_command() {
         let mock = MockTransport::new();
         mock.respond_with("c", json!(1));
         mock.respond_with("c", json!(2));
-        assert_eq!(mock.request("c", json!({})).await.unwrap(), json!(1));
-        assert_eq!(mock.request("c", json!({})).await.unwrap(), json!(2));
+        assert_eq!(mock.execute("c", json!({})).await.unwrap(), json!(1));
+        assert_eq!(mock.execute("c", json!({})).await.unwrap(), json!(2));
     }
 
     #[tokio::test]
-    async fn request_returns_not_implemented_when_unregistered() {
+    async fn execute_returns_not_implemented_when_unregistered() {
         let mock = MockTransport::new();
-        let err = mock.request("nope", json!({})).await.unwrap_err();
+        let err = mock.execute("nope", json!({})).await.unwrap_err();
         assert!(matches!(err, ClientError::NotImplemented(_)));
     }
 
     #[tokio::test]
-    async fn request_returns_closed_after_close() {
+    async fn execute_returns_closed_after_close() {
         let mock = MockTransport::new();
         mock.respond_with("c", json!(1));
         mock.close().await.unwrap();
         assert!(matches!(
-            mock.request("c", json!({})).await.unwrap_err(),
+            mock.execute("c", json!({})).await.unwrap_err(),
             ClientError::Closed
         ));
     }

--- a/client/continuum-client/src/transport.rs
+++ b/client/continuum-client/src/transport.rs
@@ -36,9 +36,11 @@ pub trait ServeHandler: Send + Sync {
 /// `test-fixtures`) for downstream unit tests.
 #[async_trait]
 pub trait Transport: Send + Sync + 'static {
-    /// Round-trip one command. Caller gives JSON params, gets JSON result
-    /// or a typed error. (Command: CALL.)
-    async fn request(&self, command: &str, params: Value) -> Result<Value, ClientError>;
+    /// Execute one command (the CALL verb). Caller gives JSON params, gets JSON
+    /// result or a typed error. Named `execute` to match the canonical primitive
+    /// (`Commands.execute()`) and the FFI/TS transports — one CALL verb across
+    /// every layer and language. (Command: CALL.)
+    async fn execute(&self, command: &str, params: Value) -> Result<Value, ClientError>;
 
     /// Open an event stream for the given class. Class strings follow the
     /// substrate's URI convention (e.g. `"persona.response.*"`). (Event: LISTEN.)

--- a/core/continuum-core/src/runtime/in_process_transport.rs
+++ b/core/continuum-core/src/runtime/in_process_transport.rs
@@ -98,7 +98,7 @@ fn command_result_to_value(command: &str, result: CommandResult) -> Result<Value
 
 #[async_trait]
 impl Transport for InProcessTransport {
-    async fn request(&self, command: &str, params: Value) -> Result<Value, ClientError> {
+    async fn execute(&self, command: &str, params: Value) -> Result<Value, ClientError> {
         if self.closed.load(Ordering::Relaxed) {
             return Err(ClientError::Closed);
         }
@@ -248,14 +248,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn request_after_close_errors() {
+    async fn execute_after_close_errors() {
         let registry = Arc::new(ModuleRegistry::new());
         registry.register(Arc::new(EchoModule));
         let executor = Arc::new(CommandExecutor::new(registry));
         let transport = InProcessTransport::new(executor, None);
 
         transport.close().await.expect("first close ok");
-        let err = transport.request("echo/run", json!({})).await.unwrap_err();
+        let err = transport.execute("echo/run", json!({})).await.unwrap_err();
         assert!(matches!(err, ClientError::Closed));
     }
 


### PR DESCRIPTION
## What

Coherence tighten on the SDK. The **CALL verb** was named inconsistently across layers:

| layer | verb (before) |
|---|---|
| `continuum-client::Transport` (Rust seam) | **`request`** ← odd one out |
| `continuum-client-ffi` | `execute` |
| `sdk/typescript` Transport | `execute` |
| canonical primitive / conformance spec | `execute` (`Commands.execute()`) |

The Rust transport seam and the TS transport seam are the **same architectural layer** but had different verb names for the same operation — the subtle drift that makes an SDK feel incoherent.

## Change

Renamed `Transport::request` → `Transport::execute` (trait + all three impls: `AircIpcTransport`, `MockTransport`, `InProcessTransport`) + the `CommandClient` caller + the test names. The CALL verb is now `execute` **everywhere**, matching the TS shape exactly (raw `Transport.execute` + typed `CommandClient`/`Commands.execute`).

**Not touched:** `airc_lib`'s own `Airc::request(target, headers, body, deadline)` (a different method on the airc handle) and unrelated `fn request(prompt)` test helpers.

## Test

`continuum-client` 23 · `continuum-client-ffi` 8 · `continuum-core::in_process_transport` 3 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)