### PR TITLE
feat(client-ffi): uniffi 0.31 annotation pass — the one native binding source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +685,19 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compat"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ba85bc55464dcbf728b56d97e119d673f4cf9062be330a9a26f3acf504a590"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -985,6 +1040,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "basis-universal"
@@ -2161,6 +2225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "candle-core"
 version = "0.9.2"
 source = "git+https://github.com/joelteply/candle.git?branch=fix%2Fmetal-memory-and-rope-neox#ce617942db6985b884b01596bfec32795de9261a"
@@ -2258,6 +2331,29 @@ dependencies = [
  "ug",
  "ug-cuda",
  "ug-metal",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2707,6 +2803,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "uniffi",
  "uuid",
 ]
 
@@ -4151,6 +4248,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4796,6 +4902,17 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -9175,6 +9292,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sea-bae"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9369,6 +9506,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -9618,6 +9759,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "smawk"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "smol_str"
@@ -10139,6 +10286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
 ]
 
 [[package]]
@@ -11084,6 +11240,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "uniffi"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eefd5468602930da46b1f49d3448c6dfc2e81295f93120f23f8174fd70267f"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "uniffi_bindgen",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a0c9b375d32e1365cdb2bdd7cb495eecf6fac851ddbad077412b4ee1888514"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck 0.5.0",
+ "indexmap",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml 0.9.12+spec-1.1.0",
+ "uniffi_internal_macros",
+ "uniffi_meta",
+ "uniffi_pipeline",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec017b112701681f6fbbe5d92014b5c468eb0b177a94389de03ceec40665095"
+dependencies = [
+ "anyhow",
+ "async-compat",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4641669b48fefbc5e80ff08c5004d9c7617fb91232131a6734ab6712779cb04c"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8617ee814de22caf7417bf514715ba0b3f46bd9d5a5d794413fd8282cb737"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "toml 0.9.12+spec-1.1.0",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58d5b94fc92803d21b2928bd15c6f06e57609b95caf98ea561c99cda1b6d2a25"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "032739b3ec725576914c15899dedaf080163ced86b6934566c20ec2b20ce90ca"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "tempfile",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a1d0a0252ce1af9e8ce78ba67ac0d8937fb2bedaf10cbddd43d3614d06ec6"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
+
+[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11532,6 +11810,15 @@ dependencies = [
  "scratch",
  "semver",
  "zip 0.6.6",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]

--- a/client/continuum-client-ffi/.gitignore
+++ b/client/continuum-client-ffi/.gitignore
@@ -1,0 +1,6 @@
+# Generated native bindings — regenerated from the cdylib at SDK build time via
+#   cargo run --bin uniffi-bindgen -- generate --library <cdylib> --language <swift|kotlin>
+# Never hand-edited, never the source of truth (the annotated Rust is). The
+# xcframework/AAR build steps emit these fresh; committing them would let a
+# stale copy drift from the facade.
+bindings/

--- a/client/continuum-client-ffi/Cargo.toml
+++ b/client/continuum-client-ffi/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2021"
 description = "FFI-clean JSON-boundary facade over continuum-client. The single binding source the per-platform SDKs wrap (uniffi → native/flutter; wasm-bindgen → web). execute(command, params_json)->result_json + subscribe(class, callback)."
 
+# `lib` for Rust consumers (the CLI/tests) + `cdylib` so uniffi can build the
+# one native binding (xcframework/AAR) the swift/kotlin SDKs wrap.
+[lib]
+crate-type = ["lib", "cdylib"]
+
 [dependencies]
 continuum-client = { path = "../continuum-client" }
 airc-lib = { workspace = true }
@@ -13,6 +18,11 @@ async-trait = { workspace = true }
 futures = "0.3"
 tokio = { workspace = true }
 uuid = { workspace = true }
+# uniffi reads this crate (proc-macro mode) to emit the one native binding;
+# the `tokio` feature drives the async verbs (execute/emit/provide/connect);
+# `cli` provides `uniffi_bindgen_main()` for the in-crate `uniffi-bindgen` bin
+# (keeps the generator version pinned to the runtime version via Cargo).
+uniffi = { version = "0.31", features = ["tokio", "cli"] }
 
 [dev-dependencies]
 # Enable continuum-client's MockTransport so the boundary logic is tested

--- a/client/continuum-client-ffi/src/bin/uniffi-bindgen.rs
+++ b/client/continuum-client-ffi/src/bin/uniffi-bindgen.rs
@@ -1,0 +1,17 @@
+//! Standalone `uniffi-bindgen` entrypoint for this crate (uniffi 0.31 library
+//! mode). The native SDK build steps invoke it to emit Swift/Kotlin source
+//! from the compiled cdylib:
+//!
+//! ```sh
+//! cargo run --bin uniffi-bindgen -- generate \
+//!   --library target/debug/libcontinuum_client_ffi.{dylib,so,dll} \
+//!   --language swift --out-dir bindings/swift
+//! ```
+//!
+//! Keeping the binding generator IN the crate (rather than relying on a
+//! globally-installed `uniffi-bindgen` whose version can drift from the
+//! `uniffi` lib version) is the single-source-of-truth discipline: the
+//! generator and the runtime are pinned to the same version by Cargo.
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}

--- a/client/continuum-client-ffi/src/lib.rs
+++ b/client/continuum-client-ffi/src/lib.rs
@@ -29,20 +29,49 @@ use std::sync::Arc;
 
 use continuum_client::{
     AircIpcTransport, ClientError, CommandClient, Connection, EventSubscriber, ServeHandler,
-    SessionIdentity, Transport,
+    SessionIdentity as ClientSessionIdentity, Transport,
 };
 use futures::StreamExt;
 use uuid::Uuid;
 
-/// Re-export so every per-platform binding reads the one identity record:
-/// `{ userId?, sessionId? }`. The FFI surface for `ContinuumClient::session`.
-pub use continuum_client::SessionIdentity as Session;
+// uniffi proc-macro scaffolding: assembles the native binding from the
+// `#[uniffi::export]` / `#[derive(uniffi::*)]` annotations below. One source,
+// emitted to Swift + Kotlin (the xcframework/AAR the native SDKs wrap).
+uniffi::setup_scaffolding!();
+
+// `Uuid` isn't a uniffi built-in — bridge it as a String across the boundary
+// (the native SDKs present it as their own UUID type over this). Lower = to
+// string; lift = parse, surfacing a malformed id rather than fabricating one.
+uniffi::custom_type!(Uuid, String, {
+    remote,
+    lower: |id| id.to_string(),
+    try_lift: |s| Uuid::parse_str(&s).map_err(Into::into),
+});
+
+/// The identity a client acts as — citizen (`user_id`) + session instance
+/// (`session_id`), both optional until the handshake establishes them. The FFI
+/// record every per-platform binding reads (mirrors `continuum-client`'s
+/// `SessionIdentity`; the facade owns its own uniffi-exported shape).
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct SessionIdentity {
+    pub user_id: Option<Uuid>,
+    pub session_id: Option<Uuid>,
+}
+
+impl From<ClientSessionIdentity> for SessionIdentity {
+    fn from(s: ClientSessionIdentity) -> Self {
+        Self {
+            user_id: s.user_id,
+            session_id: s.session_id,
+        }
+    }
+}
 
 /// FFI-clean error. `continuum-client`'s `ClientError` is rich and Rust-shaped;
 /// this flattens it to the few variants a foreign caller needs, each carrying a
 /// human message. A refusal keeps `command` + `reason` since callers branch on
 /// "the substrate said no" vs "the transport broke".
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum FfiError {
     /// Establishing the session failed.
     #[error("connect failed: {0}")]
@@ -78,6 +107,7 @@ impl From<ClientError> for FfiError {
 /// a callback interface; each SDK adapts it into the platform's stream type
 /// (`AsyncStream` / `Flow` / `Stream`). Plain trait here so the facade is
 /// tool-agnostic and unit-testable.
+#[uniffi::export(with_foreign)]
 pub trait EventCallback: Send + Sync {
     /// One event, already serialized to a JSON string.
     fn on_event(&self, event_json: String);
@@ -93,6 +123,7 @@ pub trait EventCallback: Send + Sync {
 /// screenshot, desktop = OS, AR/VR = renderer capture — one command identity, N
 /// adapters). `handle` is sync from Rust's view (a foreign call); the serve path
 /// runs it on a blocking worker so a heavy handler doesn't stall the runtime.
+#[uniffi::export(with_foreign)]
 pub trait CommandHandler: Send + Sync {
     /// Run the provided command — JSON params in, JSON result out. `Err`
     /// surfaces to the caller as a command error, never a silent drop.
@@ -168,6 +199,7 @@ async fn pump_events<T: Transport>(
 /// An open subscription. Dropping it aborts the pump task — so a foreign caller
 /// unsubscribes simply by releasing this handle (no explicit close call to
 /// forget). Without this an event subscription would leak its task.
+#[derive(uniffi::Object)]
 pub struct Subscription {
     handle: tokio::task::JoinHandle<()>,
 }
@@ -180,6 +212,7 @@ impl Drop for Subscription {
 
 /// An active command provision — the serve twin of [`Subscription`]. Dropping it
 /// DEREGISTERS the command (release = revoke): the serve loop stops matching it.
+#[derive(uniffi::Object)]
 pub struct Registration {
     conn: Connection<AircIpcTransport>,
     command: String,
@@ -200,6 +233,7 @@ impl Drop for Registration {
 /// The concrete, generic-free client a foreign binding holds. Wraps a
 /// `Connection` over the real airc IPC transport; the per-platform binding
 /// (uniffi/wasm) exposes exactly `execute` + `subscribe`.
+#[derive(uniffi::Object)]
 pub struct ContinuumClient {
     conn: Connection<AircIpcTransport>,
 }
@@ -215,7 +249,13 @@ impl ContinuumClient {
             conn: Connection::connect(airc, target_peer),
         }
     }
+}
 
+// The FFI surface — uniffi exports these (the in-process `new` above is NOT
+// exported: foreign callers can't pass an `Arc<airc_lib::Airc>`). `async_runtime`
+// drives the async verbs; the foreign side awaits naturally.
+#[uniffi::export(async_runtime = "tokio")]
+impl ContinuumClient {
     /// FOREIGN-friendly constructor — the FFI entry point. Builds the airc
     /// handle INTERNALLY (foreign callers can't make an `Arc<airc_lib::Airc>` —
     /// the outlier-B leak the uniffi pass surfaced): attaches to the running
@@ -224,6 +264,7 @@ impl ContinuumClient {
     /// `new` → `Connection::connect`) — the handshake populates it, never
     /// fabricated here. Returns `Arc<Self>` (the uniffi object shape); the
     /// in-process `new` stays for Rust consumers. Both entries coexist.
+    #[uniffi::constructor]
     pub async fn connect(
         home: String,
         agent_name: String,
@@ -245,17 +286,17 @@ impl ContinuumClient {
     /// (airc pairing / handshake, or the persona's own id). Each platform SDK
     /// presents it idiomatically; the record shape is identical everywhere.
     pub fn session(&self) -> SessionIdentity {
-        self.conn.session()
+        self.conn.session().into()
     }
 
     /// Return a client SCOPED to a conversation/room (`context_id`, the third
     /// ID tier). The scoped client's verbs auto-stamp `contextId` so callers
     /// never re-thread the scope — a persona services a room as a scoped client
     /// exactly the way a UI client does. Shares the same transport + identity.
-    pub fn scoped(&self, context_id: Uuid) -> ContinuumClient {
-        ContinuumClient {
+    pub fn scoped(&self, context_id: Uuid) -> Arc<ContinuumClient> {
+        Arc::new(ContinuumClient {
             conn: self.conn.scoped(context_id),
-        }
+        })
     }
 
     /// Execute a command: JSON params in, JSON result out. Stamps `contextId`
@@ -266,9 +307,9 @@ impl ContinuumClient {
 
     /// Subscribe to an event class; events stream to `callback` as JSON strings
     /// until the returned [`Subscription`] is dropped.
-    pub fn subscribe(&self, class: &str, callback: Arc<dyn EventCallback>) -> Subscription {
+    pub fn subscribe(&self, class: &str, callback: Arc<dyn EventCallback>) -> Arc<Subscription> {
         let handle = tokio::spawn(pump_events(self.conn.events(), class.to_string(), callback));
-        Subscription { handle }
+        Arc::new(Subscription { handle })
     }
 
     /// EMIT (publish) an event to `class` — the publish side of the Event
@@ -289,16 +330,16 @@ impl ContinuumClient {
         &self,
         command: &str,
         handler: Arc<dyn CommandHandler>,
-    ) -> Result<Registration, FfiError> {
+    ) -> Result<Arc<Registration>, FfiError> {
         let adapter = Arc::new(CommandHandlerAdapter {
             command: command.to_string(),
             cb: handler,
         });
         self.conn.provide(command, adapter).await?;
-        Ok(Registration {
+        Ok(Arc::new(Registration {
             conn: self.conn.clone(),
             command: command.to_string(),
-        })
+        }))
     }
 }
 

--- a/client/continuum-client-ffi/src/lib.rs
+++ b/client/continuum-client-ffi/src/lib.rs
@@ -205,14 +205,39 @@ pub struct ContinuumClient {
 }
 
 impl ContinuumClient {
-    /// Build over an established airc handle + the substrate's peer id. The CLI
-    /// (Rust) calls this directly; the per-platform glue builds the airc handle
-    /// then calls this. (A foreign-friendly `connect(home, peer)` constructor
-    /// that builds the handle internally is the next thin layer.)
+    /// Build over an established airc handle + the substrate's peer id. The
+    /// IN-PROCESS entry — the CLI / a persona in the same process calls this
+    /// directly (it already holds the `Arc<Airc>`, no overhead). The FFI entry
+    /// is [`ContinuumClient::connect`] (foreign callers can't construct an
+    /// `Arc<airc_lib::Airc>` across the boundary).
     pub fn new(airc: Arc<airc_lib::Airc>, target_peer: Uuid) -> Self {
         Self {
             conn: Connection::connect(airc, target_peer),
         }
+    }
+
+    /// FOREIGN-friendly constructor — the FFI entry point. Builds the airc
+    /// handle INTERNALLY (foreign callers can't make an `Arc<airc_lib::Airc>` —
+    /// the outlier-B leak the uniffi pass surfaced): attaches to the running
+    /// daemon at `socket` as `agent_name` under `home`, targeting the substrate
+    /// `target_peer`. Identity defaults to `SessionIdentity::unknown()` (via
+    /// `new` → `Connection::connect`) — the handshake populates it, never
+    /// fabricated here. Returns `Arc<Self>` (the uniffi object shape); the
+    /// in-process `new` stays for Rust consumers. Both entries coexist.
+    pub async fn connect(
+        home: String,
+        agent_name: String,
+        socket: String,
+        target_peer: String,
+    ) -> Result<Arc<ContinuumClient>, FfiError> {
+        // Parse the peer id FIRST — a bad id fails cheaply before we touch the
+        // daemon, and never fabricates a target.
+        let peer = Uuid::parse_str(&target_peer)
+            .map_err(|e| FfiError::Connect(format!("target_peer is not a valid UUID: {e}")))?;
+        let airc = airc_lib::Airc::attach_as(std::path::PathBuf::from(home), &agent_name, socket)
+            .await
+            .map_err(|e| FfiError::Connect(format!("airc attach failed: {e}")))?;
+        Ok(Arc::new(ContinuumClient::new(Arc::new(airc), peer)))
     }
 
     /// WHO this client acts as — citizen (`userId`) + session instance
@@ -509,5 +534,26 @@ mod tests {
             serde_json::from_str::<serde_json::Value>(&events[0]).unwrap(),
             json!({ "hello": "world" })
         );
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_a_bad_target_peer_uuid() {
+        // what this catches: the foreign constructor validates target_peer FIRST
+        // (cheap, before touching the daemon) and surfaces FfiError::Connect —
+        // never fabricates a target or proceeds with a garbage peer id.
+        // match (not unwrap_err) — ContinuumClient isn't Debug, so unwrap_err
+        // (which needs the Ok type to be Debug) wouldn't compile.
+        match ContinuumClient::connect(
+            "/tmp".into(),
+            "tester".into(),
+            "/tmp/nonexistent.sock".into(),
+            "not-a-uuid".into(),
+        )
+        .await
+        {
+            Err(FfiError::Connect(_)) => {}
+            Err(other) => panic!("expected FfiError::Connect, got {other:?}"),
+            Ok(_) => panic!("expected an error for a bad target_peer uuid"),
+        }
     }
 }

--- a/docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md
+++ b/docs/architecture/CLIENT-SDK-PLATFORM-ARCHITECTURE.md
@@ -118,10 +118,13 @@ SDKs.
    Commands/Events are on the wire. The typed/idiomatic per-language layer is
    **generated** (ts-rs and the per-language equivalent), never hand-written; the
    JSON shape is the canonical contract.
-2. **uniffi for BOTH native (Swift + Kotlin) now.** One `.udl` → both bindings →
-   the xcframework + AAR. `swift-bridge` is DEFERRED — add the second toolchain
-   ONLY when native-iOS/visionOS async ergonomics prove load-bearing for `apps/vr`
-   / `apps/ar` (outlier-validation, not preemptive).
+2. **uniffi for BOTH native (Swift + Kotlin) now.** One annotated crate → both
+   bindings → the xcframework + AAR. **Proc-macro mode, NOT a `.udl`** (proven
+   2026-06-17, see below): the facade is annotated in-place
+   (`#[uniffi::export]`/`Object`/`Record`/`Error`), bindgen reads the compiled
+   cdylib. `swift-bridge` is DEFERRED — add the second toolchain ONLY when
+   native-iOS/visionOS async ergonomics prove load-bearing for `apps/vr` /
+   `apps/ar` (outlier-validation, not preemptive).
 3. **TWO binding mechanisms over the ONE facade** (uniffi does NOT emit wasm/JS):
    - **uniffi** → native (Swift xcframework + Kotlin AAR) → also what Flutter bundles.
    - **wasm-bindgen** (or napi) → `sdk/typescript` for web/node. Web is its OWN
@@ -160,13 +163,49 @@ need macOS/Xcode:
 
 | Step | Runs on | Owner |
 |------|---------|-------|
-| Rust facade, uniffi `.udl` + bindgen (emits Swift **and** Kotlin source), Android AAR + Kotlin SDK | any OS (verified building on Windows) | BigMama |
+| Rust facade + uniffi proc-macro annotations + bindgen (emits Swift **and** Kotlin source from the cdylib), Android AAR + Kotlin SDK | any OS (verified building + generating on Windows) | BigMama |
 | xcframework packaging, Swift SDK build/validate, visionOS | **macOS/Xcode only** | a Mac (M5/IntelMac) or a GitHub **macos-runner** CI job |
 | wasm-bindgen web binding | any OS | (web lane) |
 
-Keep the binding **single-source** (one `.udl`, generated Swift source shared); put
-only the Apple *packaging/validation* on a Mac. A `macos-runner` CI job is the
-durable home so it doesn't depend on any one operator's laptop.
+Keep the binding **single-source** (the annotated Rust facade is the source of
+truth; generated Swift/Kotlin source is a regenerated build artifact, never
+committed); put only the Apple *packaging/validation* on a Mac. A `macos-runner`
+CI job is the durable home so it doesn't depend on any one operator's laptop.
+
+### Proven: the uniffi binding (2026-06-17, PR #1675)
+
+Outlier-B for the SDK interface is landed — uniffi 0.31 binds the full 4-verb
+facade cleanly, with no shape forced on it:
+
+- **Proc-macro mode, no `.udl`.** `continuum-client-ffi/src/lib.rs` is annotated
+  in-place: `#[uniffi::Object]` (`ContinuumClient`, `Subscription`,
+  `Registration`), `#[uniffi::Record]` (`SessionIdentity`), `#[uniffi::Error]`
+  (`FfiError`), `#[uniffi::export(with_foreign)]` callback interfaces
+  (`EventCallback`, `CommandHandler`), async verbs under
+  `#[uniffi::export(async_runtime = "tokio")]`, `connect()` as
+  `#[uniffi::constructor]`, and `Uuid` via `custom_type!` (↔ `String`).
+- **Bindgen is in-crate** (`src/bin/uniffi-bindgen.rs` + uniffi `cli` feature) so
+  the generator version is pinned to the runtime version by Cargo:
+  ```sh
+  cargo run --bin uniffi-bindgen -- generate \
+    --library <cdylib: .dylib/.so/.dll> --language <swift|kotlin> --out-dir <dir>
+  ```
+- **Generated native surface** (Swift; Kotlin mirrors with suspend funs +
+  `Uuid = String` typealias + sealed `FfiError`). `snake_case` → `lowerCamel`
+  (`params_json` → `paramsJson`):
+  ```swift
+  open class ContinuumClient {
+    public static func connect(home:agentName:socket:targetPeer:) async throws -> ContinuumClient
+    open func execute(command:paramsJson:) async throws -> String
+    open func provide(command:handler:)   async throws -> Registration
+    open func subscribe(class:callback:)  -> Subscription
+    open func emit(class:payloadJson:)     async throws
+    open func scoped(contextId:)           -> ContinuumClient
+    open func session()                    -> SessionIdentity
+  }
+  ```
+  This is the symbol set the native typed/idiomatic emitter (M5's
+  `sdk_codegen`) targets — real names, not guesses.
 
 ## Locking the abstraction: three divergent platforms in parallel (outlier validation)
 


### PR DESCRIPTION
## What

Annotates the 4-verb JSON-boundary facade in `continuum-client-ffi`
(`execute`/`subscribe`/`emit`/`provide` + `session`/`scoped`/`connect`) with
uniffi 0.31 proc-macros so it emits the **single native binding** the
Swift/Kotlin SDKs wrap.

This is **outlier-B** for the SDK interface (per the parallel-outlier-validation
discipline): it proves uniffi binds the async + callback-interface + opaque-object
+ `Self`-returning facade cleanly, **with no shape forced on the facade**. The CLI
skin (Rust-direct) and the web skin (wasm-bindgen) are the other outliers over the
same facade — if the most divergent skins fit, the middle is guaranteed.

## What landed

- `Uuid` `custom_type!` (↔ `String` at the boundary; `Uuid = String` in Swift/Kotlin)
- `SessionIdentity` `#[uniffi::Record]` + `From<client::SessionIdentity>`
- `FfiError` `#[uniffi::Error]` (`Connect`/`Closed`/`Refused`/`Codec`/`Transport`)
- `EventCallback` + `CommandHandler` `#[uniffi::export(with_foreign)]` callback interfaces
- `Subscription`/`Registration`/`ContinuumClient` `#[uniffi::Object]`; the async verbs
  under `#[uniffi::export(async_runtime = "tokio")]`; `connect()` as `#[constructor]`
- `src/bin/uniffi-bindgen.rs` + uniffi `cli` feature so the **generator version is
  pinned to the runtime version by Cargo** (single source of truth), invoked as
  `cargo run --bin uniffi-bindgen -- generate --library <cdylib> --language <swift|kotlin>`
- `bindings/` gitignored — regenerated from the cdylib at SDK build time, never the
  source of truth (the annotated Rust is)

## Generated Swift surface (what M5's native emitter targets)

```swift
public typealias Uuid = String
public struct SessionIdentity { public init(userId: Uuid?, sessionId: Uuid?) }
public enum FfiError: Swift.Error { case connect/closed/refused/codec/transport }
public protocol CommandHandler { func handle(paramsJson: String) throws -> String }
public protocol EventCallback   { func onEvent(eventJson:); onError(message:); onClosed() }

open class ContinuumClient {
  public static func connect(home:agentName:socket:targetPeer:) async throws -> ContinuumClient
  open func execute(command:paramsJson:) async throws -> String
  open func provide(command:handler:)   async throws -> Registration
  open func subscribe(class:callback:)  -> Subscription
  open func emit(class:payloadJson:)     async throws
  open func scoped(contextId:)           -> ContinuumClient
  open func session()                    -> SessionIdentity
}
```

Kotlin mirrors this (suspend funs, `Uuid = String`, sealed `FfiError`).

## Validation

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- 9 boundary tests pass (round-trip, malformed→Codec, refusal→Refused, subscribe→callback, provide, emit→subscriber, bad-uuid→error)
- swift + kotlin bindings generate cleanly from the compiled dll

🤖 Generated with [Claude Code](https://claude.com/claude-code)