### PR TITLE
feat(grid): ensure-docker preflight — make "Docker is up" dependable + self-healing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "desktop:legacy": "bash tools/scripts/parallel-start.sh",
     "stop": "bash tools/scripts/system-stop.sh",
     "install:continuum": "bash tools/scripts/install.sh",
-    "setup:git-hooks": "bash tools/scripts/setup-git-hooks.sh"
+    "setup:git-hooks": "bash tools/scripts/setup-git-hooks.sh",
+    "docker:ensure": "bash scripts/ensure-docker.sh"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.76",

--- a/scripts/ensure-docker.sh
+++ b/scripts/ensure-docker.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# ensure-docker.sh — make "Docker is up" dependable.
+#
+# Continuum's grid IS Docker-based (sandboxed single-machine clusters, the
+# AWS-containers / k8s shape), so a wedged Docker engine isn't an
+# inconvenience — it's the grid being down. This preflight probes the
+# daemon and, if it's not responding, RECOVERS it, then verifies. Loud and
+# bounded throughout: a hung daemon can never stall the caller, and a
+# genuine failure exits non-zero with the exact state + next step.
+#
+# The Windows recovery is the recipe proven by hand on BIGMAMA, where
+# Docker Desktop's GUI/backend processes hang such that a normal
+# restart/close "does nothing" (they don't respond) — only a force-kill +
+# clean WSL cycle + fresh relaunch clears it.
+#
+# Usage:
+#   scripts/ensure-docker.sh            # probe; recover if down
+#   PROBE_TIMEOUT=8 BOOT_WAIT=120 scripts/ensure-docker.sh
+#   scripts/ensure-docker.sh --probe-only   # exit 0/1 on liveness, no recovery
+#
+# Exit: 0 = Docker responding (already, or after recovery); 1 = still down.
+
+set -uo pipefail
+
+PROBE_TIMEOUT="${PROBE_TIMEOUT:-8}"   # seconds; a wedged `docker` hangs, so cap it
+BOOT_WAIT="${BOOT_WAIT:-120}"         # seconds to wait for the engine after a recovery kick
+POLL="${POLL:-4}"                     # seconds between post-recovery probes
+
+log() { printf 'ensure-docker: %s\n' "$*" >&2; }
+
+_os() {
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) echo windows ;;
+    Darwin)               echo macos ;;
+    Linux)                echo linux ;;
+    *)                    echo unknown ;;
+  esac
+}
+
+# Bounded liveness probe. A wedged daemon makes `docker version` hang
+# indefinitely, so we run it in the background and reap it after
+# PROBE_TIMEOUT. Deliberately NOT using `timeout(1)` — it's absent on stock
+# macOS, and depending on it would defeat the point of being dependable.
+_docker_responds() {
+  ( docker version --format '{{.Server.Version}}' >/dev/null 2>&1 ) &
+  local pid=$! waited=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$PROBE_TIMEOUT" ]; then
+      kill -TERM "$pid" 2>/dev/null
+      sleep 1
+      kill -KILL "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null || true
+      return 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid"
+}
+
+_server_version() {
+  # Best-effort, also bounded via the probe convention; empty on failure.
+  ( docker version --format '{{.Server.Version}}' 2>/dev/null ) &
+  local pid=$! waited=0 out
+  while kill -0 "$pid" 2>/dev/null; do
+    [ "$waited" -ge "$PROBE_TIMEOUT" ] && { kill -KILL "$pid" 2>/dev/null; break; }
+    sleep 1; waited=$((waited + 1))
+  done
+  wait "$pid" 2>/dev/null || true
+}
+
+_recover_windows() {
+  log "Docker Desktop appears hung — force-killing its processes (a normal restart can't clear a hung process)…"
+  # Force-kill the USER-owned GUI/backend processes. com.docker.service and
+  # wslservice are privileged (need elevation) — we skip them; a fresh
+  # Docker Desktop launch drives the already-installed service itself.
+  powershell.exe -NoProfile -NonInteractive -Command '
+    foreach ($n in @("Docker Desktop","com.docker.backend","com.docker.build","com.docker.dev-envs","com.docker.cli","vpnkit","dockerd")) {
+      Get-Process -Name $n -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    }' >/dev/null 2>&1 || true
+
+  log "wsl --shutdown (clean engine-distro state)…"
+  wsl.exe --shutdown >/dev/null 2>&1 || true
+
+  log "relaunching Docker Desktop…"
+  local dd
+  for dd in \
+    "/c/Program Files/Docker/Docker/Docker Desktop.exe" \
+    "$LOCALAPPDATA/Docker/Docker Desktop.exe" \
+    "/c/Program Files/Docker/Docker/frontend/Docker Desktop.exe"; do
+    if [ -n "${dd:-}" ] && [ -x "$dd" ]; then
+      ( "$dd" >/dev/null 2>&1 & )
+      return 0
+    fi
+  done
+  # Fall back to letting Windows resolve the install path.
+  powershell.exe -NoProfile -NonInteractive -Command 'Start-Process "Docker Desktop"' >/dev/null 2>&1 \
+    || log "could not locate Docker Desktop.exe — launch it manually"
+}
+
+_recover_macos() {
+  log "(re)launching Docker Desktop…"
+  pkill -f "Docker Desktop" >/dev/null 2>&1 || true   # clear a possible hang
+  open -a Docker >/dev/null 2>&1 \
+    || open -a "Docker Desktop" >/dev/null 2>&1 \
+    || log "could not open the Docker app — launch it manually"
+}
+
+_recover_linux() {
+  log "starting the docker daemon…"
+  if command -v systemctl >/dev/null 2>&1; then
+    sudo -n systemctl start docker >/dev/null 2>&1 \
+      || systemctl --user start docker >/dev/null 2>&1 \
+      || log "could not start docker (try: sudo systemctl start docker)"
+  else
+    log "no systemctl found — start your docker daemon manually (e.g. 'sudo service docker start')"
+  fi
+}
+
+_diagnose_windows() {
+  log "WSL distro state (docker-desktop should be 'Running'):"
+  wsl.exe -l -v 2>/dev/null | tr -d '\000' | sed 's/^/  /' >&2 || true
+  log "next: open Docker Desktop manually; if it stays stuck, Troubleshoot (🐞) → Restart, then Reset to factory defaults."
+}
+
+main() {
+  if [ "${1:-}" = "--probe-only" ]; then
+    if _docker_responds; then log "Docker is up (server $(_server_version))"; exit 0; fi
+    log "Docker not responding"; exit 1
+  fi
+
+  if _docker_responds; then
+    log "Docker already up (server $(_server_version)) — nothing to do."
+    return 0
+  fi
+
+  local os; os="$(_os)"
+  log "Docker not responding — attempting recovery on ${os}…"
+  case "$os" in
+    windows) _recover_windows ;;
+    macos)   _recover_macos ;;
+    linux)   _recover_linux ;;
+    *)       log "unknown OS — cannot auto-recover Docker"; return 1 ;;
+  esac
+
+  log "waiting up to ${BOOT_WAIT}s for the engine to come up…"
+  local waited=0
+  while [ "$waited" -lt "$BOOT_WAIT" ]; do
+    if _docker_responds; then
+      log "Docker is up after recovery (server $(_server_version)). ✔"
+      return 0
+    fi
+    sleep "$POLL"
+    waited=$((waited + POLL))
+    log "…still booting (${waited}s/${BOOT_WAIT}s)"
+  done
+
+  log "ERROR: Docker still not responding after ${BOOT_WAIT}s of recovery."
+  [ "$os" = "windows" ] && _diagnose_windows
+  return 1
+}
+
+main "$@"

--- a/tools/scripts/continuum.sh
+++ b/tools/scripts/continuum.sh
@@ -40,9 +40,25 @@ refresh_tailscale_status() {
   fi
 }
 
+# Continuum's grid IS Docker (sandboxed single-machine clusters), so a dead
+# or wedged engine is the grid being down — and a normal `docker compose`
+# call against a hung daemon just hangs. Run the dependable preflight first:
+# it probes the engine and, if it's down, recovers it (force-kills a hung
+# Docker Desktop + clean WSL cycle + relaunch on Windows; relaunch/start on
+# mac/linux), then verifies — failing LOUD if it truly can't come up.
+ensure_docker() {
+  local preflight="$DIR/scripts/ensure-docker.sh"
+  [ -f "$preflight" ] || return 0   # tolerate older checkouts without the preflight
+  bash "$preflight" || {
+    echo "❌ Docker engine is not available and could not be recovered — see ensure-docker messages above." >&2
+    exit 1
+  }
+}
+
 case "${1:-}" in
   up|start)
     refresh_tailscale_status
+    ensure_docker
     cd "$DIR" && docker compose up -d
     echo "⏳ Waiting for services..."
     for i in $(seq 1 30); do
@@ -176,6 +192,7 @@ case "${1:-}" in
   "")
     # No args: open browser if not already open, start if not running
     refresh_tailscale_status
+    ensure_docker
     cd "$DIR"
     if ! docker compose ps widget-server 2>/dev/null | grep -q "healthy"; then
       docker compose up -d


### PR DESCRIPTION
Continuum's grid **is** Docker (sandboxed single-machine clusters — the k8s/AWS-containers shape), so a wedged engine is the grid being down, and a `docker compose` call against a hung daemon just **hangs** with no recovery. This makes "Docker is up" a dependable, self-healing precondition.

## What it does

**`scripts/ensure-docker.sh`** — probe the engine; if it's down, recover it; verify. Loud + bounded throughout.

- **Bounded liveness probe** — a wedged `docker version` hangs forever, so it's run background-and-reaped with a hard cap. *No* dependency on `timeout(1)` (absent on stock macOS — depending on it would defeat the point).
- **Per-platform recovery.** Windows is the recipe **proven by hand this session** on BigMama, where Docker Desktop's GUI/backend processes hang such that a normal restart/close does *nothing*: force-kill the user-owned `Docker Desktop`/`com.docker.*` processes → `wsl --shutdown` (clean engine-distro) → relaunch Docker Desktop. macOS: `pkill` a hang + `open -a Docker`. Linux: `systemctl start docker`.
- **Poll** until the engine answers (≤120s), else **fail non-zero** with the exact state (Windows: the WSL distro table) + the next manual step.
- `--probe-only` for a no-recovery liveness check.

**Wired into `tools/scripts/continuum.sh`** before both grid-start paths (`up` and the no-arg auto-start) — so the grid never silently starts against a dead engine — and exposed as **`npm run docker:ensure`**.

## Validation

- Happy path: reports `server 29.5.3`, exit 0; `--probe-only` exit 0.
- Both scripts `bash -n` clean.
- The Windows recovery sequence is exactly what revived a fully-wedged Docker Desktop on BigMama this session (force-kill 8 hung processes → wsl shutdown → relaunch → engine came up at `Server 29.5.3`).

This is the "further self-healing" + "started/restarted should be a requirement" you called for — now enforced automatically before the grid comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)