### PR TITLE
fix(ci): bound the cargo cache — rust-cache, not raw target/ caching

### DIFF
--- a/.github/workflows/continuum-rust-tests.yml
+++ b/.github/workflows/continuum-rust-tests.yml
@@ -71,21 +71,21 @@ jobs:
             libclang-dev clang build-essential \
             libglib2.0-dev libasound2-dev libva-dev
 
-      # Cache cargo registry + git index + target dir. Hashing Cargo.lock
-      # invalidates when any dep changes; restore-keys keeps a warm-ish
-      # cache across lock bumps. The target dir is the big one — a cold
-      # continuum-core build is ~3-6 minutes; a warm rebuild after a
-      # single-file change is well under a minute.
+      # Cargo cache via Swatinem/rust-cache — NOT a raw actions/cache of `target`.
+      # The old approach cached the ENTIRE `target/` dir (incl. continuum-core's
+      # own multi-GB debug artifacts) with restore-keys fallback, so the cache
+      # grew unboundedly across lock bumps until the ~5.6 GB tarball overflowed
+      # the runner's ~14 GB disk on restore ("No space left on device"). rust-cache
+      # caches the DEPENDENCY artifacts + registry/git but prunes the workspace
+      # crates' own output (the big, fast-to-rebuild part) and cleans before save,
+      # so the cache stays small + bounded. `shared-key` keeps the two Rust
+      # workflows warming each other (replaces the old shared cache key).
       - name: Cache cargo state
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-rust1.95-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-${{ runner.os }}-rust1.95-
+          shared-key: continuum-rust-1.95
+          # Key already includes Cargo.lock hash + rustc; this caps any drift.
+          cache-on-failure: true
 
       # `--lib` runs unit tests only — skips integration/doc tests + the
       # workers binaries. This is the minimum gate; broader coverage comes

--- a/.github/workflows/ts-rs-binding-drift-guard.yml
+++ b/.github/workflows/ts-rs-binding-drift-guard.yml
@@ -66,18 +66,16 @@ jobs:
             libclang-dev clang build-essential \
             libglib2.0-dev libasound2-dev libva-dev
 
-      # Reuses the same cargo cache key the continuum-rust-tests
-      # workflow does so the two workflows warm each other's targets.
+      # Shares the rust-cache `shared-key` with continuum-rust-tests so the two
+      # workflows warm each other — but via Swatinem/rust-cache, which prunes the
+      # workspace crates' own (multi-GB) target output instead of caching all of
+      # `target/`. The old raw actions/cache of the full `target/` dir grew
+      # unboundedly until it overflowed the runner disk on restore.
       - name: Cache cargo state
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-rust1.95-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-${{ runner.os }}-rust1.95-
+          shared-key: continuum-rust-1.95
+          cache-on-failure: true
 
       # The export_bindings_* tests are the ts-rs side effect: each runs
       # `TS::export()` on a type, writing the .ts file to its


### PR DESCRIPTION
## Problem
CI dying with **`No space left on device`** restoring a **~5.6 GB cargo cache** that overflows the GitHub runner's ~14 GB disk — failing `cargo test -p continuum-core --lib` and leaving PRs `UNSTABLE`.

## Root cause
Both Rust workflows cached the **entire `target/` dir** (incl. continuum-core's own multi-GB debug artifacts) via raw `actions/cache` **with `restore-keys` fallback**. Every run layered more in; nothing was ever evicted → a monotonically growing cache that finally crossed the disk ceiling. A cache that only grows is a time bomb.

## Fix
Replace with **`Swatinem/rust-cache@v2`** in both `continuum-rust-tests.yml` + `ts-rs-binding-drift-guard.yml`. It caches dependency artifacts + registry/git (slow, rarely change) but **prunes the workspace crates' own output** (big, fast to rebuild) and cleans before save — so the cache stays small and **bounded by design**. `shared-key: continuum-rust-1.95` keeps the two workflows warming each other (replaces the old shared key).

Unblocks #1678 (events) and every other Rust PR currently failing on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)