### PR TITLE
feat(mcp): Rust-native MCP server (slice 1 — protocol handler, headless, no Node)

### DIFF
--- a/core/continuum-core/Cargo.toml
+++ b/core/continuum-core/Cargo.toml
@@ -309,6 +309,11 @@ unexpected_cfgs = "allow"
 tokio-test = "0.4"
 tempfile = "3"                   # Temp directories for code module tests
 
+# Enable continuum-client's test-fixtures (the `mock` transport) in TEST builds
+# only — production links the regular dep above without it. Lets tests drive a
+# real `Connection` over `MockTransport` (e.g. the MCP ConnectionDispatch test).
+continuum-client = { path = "../../client/continuum-client", features = ["test-fixtures"] }
+
 # Cross-airc integration tests (tests/airc_ipc_roundtrip.rs). The fixture
 # spawns two real Airc peers on LAN loopback. `continuum-client` is now a
 # regular dependency (see [dependencies]) because `InProcessTransport` — the

--- a/core/continuum-core/src/bin/continuum-mcp.rs
+++ b/core/continuum-core/src/bin/continuum-mcp.rs
@@ -1,28 +1,29 @@
 //! `continuum-mcp` — the headless-Rust MCP server entrypoint.
 //!
 //! An MCP client (unsloth Studio, Claude Code, …) spawns this as a stdio
-//! subprocess; it attaches to the running continuum core over airc IPC and
-//! exposes continuum's commands as MCP tools. This is the Rust-native
-//! replacement for `src/mcp-server.ts` — no Node in the loop.
+//! subprocess; it connects to the running local core over its IPC socket and
+//! exposes continuum's commands as MCP tools. Rust-native replacement for
+//! `src/mcp-server.ts` — no Node in the loop.
 //!
-//! It is a thin glue bin: all logic lives in [`continuum_core::modules`] —
-//! [`McpServer`] (typed JSON-RPC protocol), [`StdioRunner`] (the byte loop), and
-//! [`ConnectionDispatch`] (forwards each tool call to the core over a
-//! `continuum_client::Connection`, gated like any caller).
+//! It is a thin glue bin: all logic lives in [`continuum_core`] —
+//! [`McpServer`] (typed JSON-RPC protocol), [`StdioRunner`] (the byte loop),
+//! [`ConnectionDispatch`] (forwards each tool call to the core), and
+//! [`CoreIpcTransport`] (the direct-IPC connection).
 //!
-//! ## Configuration — turnkey by default (auto-discovers the local core)
+//! ## Transport: direct to the local core's IPC socket
 //!
-//! With **no config at all** the server auto-discovers the running local core
-//! via airc ([`continuum_core::airc::discover`]) — the same liveness probe the
-//! core uses — so the MCP client config can be just `command: "continuum-mcp"`.
-//! No manual peer-id/socket lookup (that lookup was the friction that bred
-//! unreliability). Each value is overridable via env when needed:
+//! A local sidecar is the *same machine-account peer* as the core, so routing a
+//! command "to that peer" over airc doesn't reach the core's handler (it times
+//! out — live finding 2026-06-19). So `continuum-mcp` talks to the core's IPC
+//! socket DIRECTLY via [`CoreIpcTransport`] — simpler and airc-independent.
+//! (Cross-grid MCP — addressing a *remote* core over airc — is a later path; a
+//! remote core is a distinct peer, so it doesn't hit the self-peer issue.)
 //!
-//! - `CONTINUUM_SOCKET` — airc daemon socket. Default: discovered.
-//! - `CONTINUUM_PEER`   — the core's airc peer id (UUID). Default: discovered.
-//! - `CONTINUUM_HOME`   — airc scope/home dir. Default: `$AIRC_HOME`, else
-//!   `$HOME/.airc`.
-//! - `CONTINUUM_AGENT`  — this client's agent name. Default: `continuum-mcp`.
+//! ## Configuration
+//!
+//! - `CONTINUUM_CORE_SOCKET` — the core's IPC socket. Default
+//!   `/tmp/continuum-core.sock` (matches `start-server.sh`). The MCP client
+//!   config can be just `command: "continuum-mcp"`.
 //!
 //! ## stdout discipline
 //!
@@ -30,82 +31,27 @@
 //! go to stderr. The runner writes solely to stdout; nothing else here prints
 //! there.
 
-use std::path::PathBuf;
-use std::sync::Arc;
-
 use continuum_client::Connection;
-use continuum_core::airc::{discover, AircDiscovery};
 use continuum_core::modules::mcp_protocol::McpServer;
 use continuum_core::modules::mcp_transport::{ConnectionDispatch, StdioRunner};
-use uuid::Uuid;
+use continuum_core::runtime::core_ipc_transport::CoreIpcTransport;
 
 const SERVER_NAME: &str = "continuum-mcp";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Resolve socket + peer: env override wins, else auto-discover the local core.
-/// Discovery is the canonical liveness probe — if the core isn't up (or the
-/// socket is stale) it fails loud here rather than hanging on a bad target.
-async fn resolve_target() -> Result<(String, Uuid), String> {
-    let env_socket = std::env::var("CONTINUUM_SOCKET").ok();
-    let env_peer = std::env::var("CONTINUUM_PEER").ok();
-
-    // Both supplied → use them (no discovery round-trip needed).
-    if let (Some(socket), Some(peer_str)) = (&env_socket, &env_peer) {
-        let peer = Uuid::parse_str(peer_str)
-            .map_err(|e| format!("CONTINUUM_PEER is not a valid UUID: {e}"))?;
-        return Ok((socket.clone(), peer));
-    }
-
-    // Otherwise discover the local core, then let any env value override.
-    match discover().await {
-        AircDiscovery::Healthy { socket, peer_id, .. } => {
-            let socket = env_socket.unwrap_or_else(|| socket.to_string_lossy().into_owned());
-            let peer = match env_peer {
-                Some(p) => Uuid::parse_str(&p)
-                    .map_err(|e| format!("CONTINUUM_PEER is not a valid UUID: {e}"))?,
-                None => peer_id,
-            };
-            Ok((socket, peer))
-        }
-        other => Err(format!(
-            "could not discover a healthy local core ({}); is `npm start` running? \
-             Override with CONTINUUM_SOCKET + CONTINUUM_PEER.",
-            other.kind()
-        )),
-    }
-}
-
-/// Resolve the airc scope/home: `CONTINUUM_HOME`, else `AIRC_HOME`, else
-/// `$HOME/.airc` (the machine-account scope the core attaches under).
-fn resolve_home() -> Result<PathBuf, String> {
-    if let Ok(h) = std::env::var("CONTINUUM_HOME") {
-        return Ok(PathBuf::from(h));
-    }
-    if let Ok(h) = std::env::var("AIRC_HOME") {
-        return Ok(PathBuf::from(h));
-    }
-    let home = std::env::var("HOME").map_err(|_| {
-        "cannot resolve airc home: set CONTINUUM_HOME (or HOME/AIRC_HOME)".to_string()
-    })?;
-    Ok(PathBuf::from(home).join(".airc"))
-}
+const DEFAULT_CORE_SOCKET: &str = "/tmp/continuum-core.sock";
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    let agent = std::env::var("CONTINUUM_AGENT").unwrap_or_else(|_| SERVER_NAME.to_string());
-    let home = resolve_home()?;
-    let (socket, peer) = resolve_target().await?;
+    let socket =
+        std::env::var("CONTINUUM_CORE_SOCKET").unwrap_or_else(|_| DEFAULT_CORE_SOCKET.to_string());
 
-    // Diagnostics → stderr only (stdout is the JSON-RPC channel).
-    eprintln!(
-        "{SERVER_NAME} {SERVER_VERSION}: attaching to core at {socket} as '{agent}' (peer {peer})"
-    );
+    // Diagnostics → stderr only (stdout is the JSON-RPC channel). The connection
+    // is lazy: a missing/dead core surfaces as a typed error on the first tool
+    // call (and the MCP client sees it), not a startup hang.
+    eprintln!("{SERVER_NAME} {SERVER_VERSION}: serving MCP over stdio; core IPC socket = {socket}");
 
-    let airc = airc_lib::Airc::attach_as(home, &agent, socket)
-        .await
-        .map_err(|e| format!("airc attach failed: {e}"))?;
-    let connection = Connection::connect(Arc::new(airc), peer);
-
+    let transport = CoreIpcTransport::new(socket);
+    let connection = Connection::new(transport);
     let server = McpServer::new(
         ConnectionDispatch::new(connection),
         SERVER_NAME,
@@ -113,7 +59,6 @@ async fn main() -> Result<(), String> {
     );
     let runner = StdioRunner::new(server);
 
-    eprintln!("{SERVER_NAME}: ready — serving MCP over stdio");
     runner
         .run(tokio::io::stdin(), tokio::io::stdout())
         .await

--- a/core/continuum-core/src/bin/continuum-mcp.rs
+++ b/core/continuum-core/src/bin/continuum-mcp.rs
@@ -10,15 +10,19 @@
 //! [`ConnectionDispatch`] (forwards each tool call to the core over a
 //! `continuum_client::Connection`, gated like any caller).
 //!
-//! ## Configuration (env, fail-loud — no fallbacks)
+//! ## Configuration — turnkey by default (auto-discovers the local core)
 //!
-//! - `CONTINUUM_HOME`   — the airc scope/home dir (e.g. `~/.airc` or a repo `.airc`).
-//! - `CONTINUUM_SOCKET` — the core daemon's IPC socket path.
-//! - `CONTINUUM_PEER`   — the core's peer id (UUID) this client targets.
-//! - `CONTINUUM_AGENT`  — this client's agent name (default `continuum-mcp`).
+//! With **no config at all** the server auto-discovers the running local core
+//! via airc ([`continuum_core::airc::discover`]) — the same liveness probe the
+//! core uses — so the MCP client config can be just `command: "continuum-mcp"`.
+//! No manual peer-id/socket lookup (that lookup was the friction that bred
+//! unreliability). Each value is overridable via env when needed:
 //!
-//! MCP clients pass these via their server config's `env` block, mirroring how
-//! the old TS server received its connection config.
+//! - `CONTINUUM_SOCKET` — airc daemon socket. Default: discovered.
+//! - `CONTINUUM_PEER`   — the core's airc peer id (UUID). Default: discovered.
+//! - `CONTINUUM_HOME`   — airc scope/home dir. Default: `$AIRC_HOME`, else
+//!   `$HOME/.airc`.
+//! - `CONTINUUM_AGENT`  — this client's agent name. Default: `continuum-mcp`.
 //!
 //! ## stdout discipline
 //!
@@ -30,6 +34,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use continuum_client::Connection;
+use continuum_core::airc::{discover, AircDiscovery};
 use continuum_core::modules::mcp_protocol::McpServer;
 use continuum_core::modules::mcp_transport::{ConnectionDispatch, StdioRunner};
 use uuid::Uuid;
@@ -37,28 +42,66 @@ use uuid::Uuid;
 const SERVER_NAME: &str = "continuum-mcp";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Read a required env var or fail loud (no silent fallback — a misconfigured
-/// MCP server should refuse to start, not connect to the wrong place).
-fn require_env(key: &str) -> Result<String, String> {
-    std::env::var(key).map_err(|_| format!("missing required env var {key}"))
+/// Resolve socket + peer: env override wins, else auto-discover the local core.
+/// Discovery is the canonical liveness probe — if the core isn't up (or the
+/// socket is stale) it fails loud here rather than hanging on a bad target.
+async fn resolve_target() -> Result<(String, Uuid), String> {
+    let env_socket = std::env::var("CONTINUUM_SOCKET").ok();
+    let env_peer = std::env::var("CONTINUUM_PEER").ok();
+
+    // Both supplied → use them (no discovery round-trip needed).
+    if let (Some(socket), Some(peer_str)) = (&env_socket, &env_peer) {
+        let peer = Uuid::parse_str(peer_str)
+            .map_err(|e| format!("CONTINUUM_PEER is not a valid UUID: {e}"))?;
+        return Ok((socket.clone(), peer));
+    }
+
+    // Otherwise discover the local core, then let any env value override.
+    match discover().await {
+        AircDiscovery::Healthy { socket, peer_id, .. } => {
+            let socket = env_socket.unwrap_or_else(|| socket.to_string_lossy().into_owned());
+            let peer = match env_peer {
+                Some(p) => Uuid::parse_str(&p)
+                    .map_err(|e| format!("CONTINUUM_PEER is not a valid UUID: {e}"))?,
+                None => peer_id,
+            };
+            Ok((socket, peer))
+        }
+        other => Err(format!(
+            "could not discover a healthy local core ({}); is `npm start` running? \
+             Override with CONTINUUM_SOCKET + CONTINUUM_PEER.",
+            other.kind()
+        )),
+    }
+}
+
+/// Resolve the airc scope/home: `CONTINUUM_HOME`, else `AIRC_HOME`, else
+/// `$HOME/.airc` (the machine-account scope the core attaches under).
+fn resolve_home() -> Result<PathBuf, String> {
+    if let Ok(h) = std::env::var("CONTINUUM_HOME") {
+        return Ok(PathBuf::from(h));
+    }
+    if let Ok(h) = std::env::var("AIRC_HOME") {
+        return Ok(PathBuf::from(h));
+    }
+    let home = std::env::var("HOME").map_err(|_| {
+        "cannot resolve airc home: set CONTINUUM_HOME (or HOME/AIRC_HOME)".to_string()
+    })?;
+    Ok(PathBuf::from(home).join(".airc"))
 }
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    let home = require_env("CONTINUUM_HOME")?;
-    let socket = require_env("CONTINUUM_SOCKET")?;
-    let peer_str = require_env("CONTINUUM_PEER")?;
     let agent = std::env::var("CONTINUUM_AGENT").unwrap_or_else(|_| SERVER_NAME.to_string());
-
-    // Parse the peer id FIRST — a bad id fails cheaply before we touch the
-    // daemon, and never fabricates a target (mirrors continuum-client-ffi).
-    let peer = Uuid::parse_str(&peer_str)
-        .map_err(|e| format!("CONTINUUM_PEER is not a valid UUID: {e}"))?;
+    let home = resolve_home()?;
+    let (socket, peer) = resolve_target().await?;
 
     // Diagnostics → stderr only (stdout is the JSON-RPC channel).
-    eprintln!("{SERVER_NAME} {SERVER_VERSION}: attaching to core at {socket} as '{agent}' (peer {peer})");
+    eprintln!(
+        "{SERVER_NAME} {SERVER_VERSION}: attaching to core at {socket} as '{agent}' (peer {peer})"
+    );
 
-    let airc = airc_lib::Airc::attach_as(PathBuf::from(home), &agent, socket)
+    let airc = airc_lib::Airc::attach_as(home, &agent, socket)
         .await
         .map_err(|e| format!("airc attach failed: {e}"))?;
     let connection = Connection::connect(Arc::new(airc), peer);

--- a/core/continuum-core/src/bin/continuum-mcp.rs
+++ b/core/continuum-core/src/bin/continuum-mcp.rs
@@ -1,0 +1,79 @@
+//! `continuum-mcp` — the headless-Rust MCP server entrypoint.
+//!
+//! An MCP client (unsloth Studio, Claude Code, …) spawns this as a stdio
+//! subprocess; it attaches to the running continuum core over airc IPC and
+//! exposes continuum's commands as MCP tools. This is the Rust-native
+//! replacement for `src/mcp-server.ts` — no Node in the loop.
+//!
+//! It is a thin glue bin: all logic lives in [`continuum_core::modules`] —
+//! [`McpServer`] (typed JSON-RPC protocol), [`StdioRunner`] (the byte loop), and
+//! [`ConnectionDispatch`] (forwards each tool call to the core over a
+//! `continuum_client::Connection`, gated like any caller).
+//!
+//! ## Configuration (env, fail-loud — no fallbacks)
+//!
+//! - `CONTINUUM_HOME`   — the airc scope/home dir (e.g. `~/.airc` or a repo `.airc`).
+//! - `CONTINUUM_SOCKET` — the core daemon's IPC socket path.
+//! - `CONTINUUM_PEER`   — the core's peer id (UUID) this client targets.
+//! - `CONTINUUM_AGENT`  — this client's agent name (default `continuum-mcp`).
+//!
+//! MCP clients pass these via their server config's `env` block, mirroring how
+//! the old TS server received its connection config.
+//!
+//! ## stdout discipline
+//!
+//! MCP stdio framing means **only** JSON-RPC may go to stdout. All diagnostics
+//! go to stderr. The runner writes solely to stdout; nothing else here prints
+//! there.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use continuum_client::Connection;
+use continuum_core::modules::mcp_protocol::McpServer;
+use continuum_core::modules::mcp_transport::{ConnectionDispatch, StdioRunner};
+use uuid::Uuid;
+
+const SERVER_NAME: &str = "continuum-mcp";
+const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Read a required env var or fail loud (no silent fallback — a misconfigured
+/// MCP server should refuse to start, not connect to the wrong place).
+fn require_env(key: &str) -> Result<String, String> {
+    std::env::var(key).map_err(|_| format!("missing required env var {key}"))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let home = require_env("CONTINUUM_HOME")?;
+    let socket = require_env("CONTINUUM_SOCKET")?;
+    let peer_str = require_env("CONTINUUM_PEER")?;
+    let agent = std::env::var("CONTINUUM_AGENT").unwrap_or_else(|_| SERVER_NAME.to_string());
+
+    // Parse the peer id FIRST — a bad id fails cheaply before we touch the
+    // daemon, and never fabricates a target (mirrors continuum-client-ffi).
+    let peer = Uuid::parse_str(&peer_str)
+        .map_err(|e| format!("CONTINUUM_PEER is not a valid UUID: {e}"))?;
+
+    // Diagnostics → stderr only (stdout is the JSON-RPC channel).
+    eprintln!("{SERVER_NAME} {SERVER_VERSION}: attaching to core at {socket} as '{agent}' (peer {peer})");
+
+    let airc = airc_lib::Airc::attach_as(PathBuf::from(home), &agent, socket)
+        .await
+        .map_err(|e| format!("airc attach failed: {e}"))?;
+    let connection = Connection::connect(Arc::new(airc), peer);
+
+    let server = McpServer::new(
+        ConnectionDispatch::new(connection),
+        SERVER_NAME,
+        SERVER_VERSION,
+    );
+    let runner = StdioRunner::new(server);
+
+    eprintln!("{SERVER_NAME}: ready — serving MCP over stdio");
+    runner
+        .run(tokio::io::stdin(), tokio::io::stdout())
+        .await
+        .map_err(|e| format!("stdio loop error: {e}"))?;
+    Ok(())
+}

--- a/core/continuum-core/src/modules/mcp_protocol.rs
+++ b/core/continuum-core/src/modules/mcp_protocol.rs
@@ -5,6 +5,16 @@
 //! client (unsloth Studio, Claude Code) speaks JSON-RPC, and this handler turns
 //! each call into a continuum command dispatch — no Node, no TS in the loop.
 //!
+//! ## Strongly typed protocol
+//!
+//! Every MCP message shape is a real serde struct (`JsonRpcRequest`,
+//! `InitializeResult`, `ListToolsResult`, `CallToolParams`, `CallToolResult`,
+//! `ContentBlock`, …), parsed in and constructed out. Raw `serde_json::Value`
+//! appears ONLY at the two genuinely-dynamic seams: a tool call's `arguments`
+//! and a command's result payload (both are per-command JSON the protocol layer
+//! must pass through, not interpret). So the PROTOCOL is type-checked end to end;
+//! only the command payload it ferries is dynamic.
+//!
 //! ## The MCP server IS a client ([[persona-is-a-client]])
 //!
 //! The handler holds nothing but a [`CommandDispatch`] — the same
@@ -12,24 +22,22 @@
 //! module internals:
 //!
 //! - `tools/list` → `dispatch.execute("mcp/list-tools", {})` (the catalog in
-//!   [`super::mcp`] — single source of truth for "commands ARE tools").
+//!   [`super::mcp`] — single source of truth for "commands ARE tools"), and the
+//!   returned tools are validated into typed [`MCPTool`]s.
 //! - `tools/call` → maps the MCP tool name back to a command path and
 //!   `dispatch.execute(command, arguments)`.
 //!
-//! So this layer is pure protocol framing over the command verb. In production
-//! the `CommandDispatch` is a `continuum_client::Connection` over the in-process
-//! or airc transport (gated like any caller); in tests it's a mock. The
-//! transport + the stdio/HTTP bin that pumps bytes into [`McpServer::handle_message`]
-//! is the next slice — this slice is the protocol, pure and testable.
-//!
-//! ## Scope (slice 1)
-//!
-//! `initialize`, `notifications/initialized`, `tools/list`, `tools/call`, plus
-//! JSON-RPC error framing. Pure: a JSON-RPC message string in, an optional
-//! response string out (None for notifications). No transport, no process.
+//! In production the `CommandDispatch` is a `continuum_client::Connection` over
+//! the in-process or airc transport (gated like any caller); in tests a mock.
+//! The transport + the stdio/HTTP bin that pumps bytes into
+//! [`McpServer::handle_message`] is the next slice — this slice is the protocol,
+//! pure and testable.
 
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::mcp::MCPTool;
 
 /// The MCP protocol revision this server advertises. Bump as the spec moves;
 /// `2024-11-05` is the broadly-supported baseline (Claude Code, unsloth, etc.).
@@ -43,6 +51,125 @@ mod codes {
     pub const INVALID_PARAMS: i64 = -32602;
     pub const INTERNAL_ERROR: i64 = -32603;
 }
+
+// ─── JSON-RPC envelope (typed) ──────────────────────────────────────────────
+
+/// An inbound JSON-RPC 2.0 message. `id` absent ⇒ notification (no response).
+/// `params` stays `Value` here because its shape is method-dependent; each
+/// method deserializes it into its own typed params struct.
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest {
+    #[serde(default)]
+    id: Option<Value>,
+    method: String,
+    #[serde(default)]
+    params: Value,
+}
+
+/// A successful JSON-RPC response with a typed `result`.
+#[derive(Debug, Serialize)]
+struct JsonRpcSuccess<T: Serialize> {
+    jsonrpc: &'static str,
+    id: Value,
+    result: T,
+}
+
+/// A JSON-RPC error response.
+#[derive(Debug, Serialize)]
+struct JsonRpcErrorResponse {
+    jsonrpc: &'static str,
+    id: Value,
+    error: JsonRpcError,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcError {
+    code: i64,
+    message: String,
+}
+
+// ─── MCP method params / results (typed) ────────────────────────────────────
+
+/// `initialize` result — protocol version + capabilities + serverInfo, the
+/// handshake an MCP client requires before listing/calling tools.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InitializeResult {
+    protocol_version: &'static str,
+    capabilities: ServerCapabilities,
+    server_info: ServerInfo,
+}
+
+/// Capabilities this server advertises. We expose `tools` (continuum commands
+/// surfaced as MCP tools); the empty object is the MCP "supported, no sub-caps"
+/// shape.
+#[derive(Debug, Serialize)]
+struct ServerCapabilities {
+    tools: ToolsCapability,
+}
+
+#[derive(Debug, Serialize)]
+struct ToolsCapability {}
+
+#[derive(Debug, Serialize)]
+struct ServerInfo {
+    name: String,
+    version: String,
+}
+
+/// `tools/list` result — the typed tool catalog.
+#[derive(Debug, Serialize)]
+struct ListToolsResult {
+    tools: Vec<MCPTool>,
+}
+
+/// The catalog command (`mcp/list-tools`) result we deserialize the tools out of.
+#[derive(Debug, Deserialize)]
+struct CatalogResult {
+    #[serde(default)]
+    tools: Vec<MCPTool>,
+}
+
+/// `tools/call` params. `arguments` stays `Value`: it's the called command's
+/// own params, per-tool dynamic JSON the protocol passes straight through.
+#[derive(Debug, Deserialize)]
+struct CallToolParams {
+    name: String,
+    #[serde(default)]
+    arguments: Value,
+}
+
+/// `tools/call` result — content blocks + the tool-level error flag. A command
+/// refusal is `is_error: true` content (the model reads it), NOT a protocol error.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CallToolResult {
+    content: Vec<ContentBlock>,
+    is_error: bool,
+}
+
+impl CallToolResult {
+    /// One text block carrying a serialized JSON payload (a command result or an
+    /// error object), with the tool-error flag.
+    fn text(payload: &Value, is_error: bool) -> Self {
+        Self {
+            content: vec![ContentBlock::Text {
+                text: payload.to_string(),
+            }],
+            is_error,
+        }
+    }
+}
+
+/// An MCP content block. Tagged by `type`; `text` today, extensible (image,
+/// resource) as the server grows multi-modal tool results.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum ContentBlock {
+    Text { text: String },
+}
+
+// ─── dispatch seam ──────────────────────────────────────────────────────────
 
 /// The one verb the MCP server needs: dispatch a continuum command and get JSON
 /// back (or a refusal string). Implemented in production by a
@@ -64,8 +191,7 @@ pub trait CommandDispatch: Send + Sync {
 /// underscore names (`mcp_search_tools`, `mcp_tool_help`) whose real commands use
 /// a hyphen (`mcp/search-tools`, `mcp/tool-help`), so a blind `_`→`/` would
 /// produce `mcp/search/tools`. Map those explicitly; everything else is the
-/// general rule. (Tool names already use `_` for `/`, so a hyphen in a non-meta
-/// command name round-trips fine — only the meta-tools collide.)
+/// general rule.
 fn tool_name_to_command(tool_name: &str) -> String {
     match tool_name {
         "mcp_search_tools" => "mcp/search-tools".to_string(),
@@ -85,7 +211,11 @@ pub struct McpServer<D: CommandDispatch> {
 impl<D: CommandDispatch> McpServer<D> {
     /// Build a server over `dispatch`. `server_name`/`server_version` are
     /// surfaced in the `initialize` handshake's `serverInfo`.
-    pub fn new(dispatch: D, server_name: impl Into<String>, server_version: impl Into<String>) -> Self {
+    pub fn new(
+        dispatch: D,
+        server_name: impl Into<String>,
+        server_version: impl Into<String>,
+    ) -> Self {
         Self {
             dispatch,
             server_name: server_name.into(),
@@ -97,114 +227,134 @@ impl<D: CommandDispatch> McpServer<D> {
     /// (success or error), `None` for notifications (no `id`) — the transport
     /// writes `Some` back to the client and drops `None`.
     pub async fn handle_message(&self, message: &str) -> Option<String> {
-        let req: Value = match serde_json::from_str(message) {
+        // Parse the raw envelope first so we can recover `id` for error replies
+        // even when the typed deserialize below fails.
+        let raw: Value = match serde_json::from_str(message) {
             Ok(v) => v,
             Err(e) => {
-                // Parse error: no id available, per JSON-RPC reply with null id.
-                return Some(error_response(Value::Null, codes::PARSE_ERROR, &format!("parse error: {e}")));
+                return Some(error_response(
+                    Value::Null,
+                    codes::PARSE_ERROR,
+                    &format!("parse error: {e}"),
+                ));
+            }
+        };
+        let id = raw.get("id").cloned();
+
+        let req: JsonRpcRequest = match serde_json::from_value(raw) {
+            Ok(r) => r,
+            Err(e) => {
+                // Valid JSON but not a valid request (e.g. missing `method`).
+                return id.map(|id| {
+                    error_response(id, codes::INVALID_REQUEST, &format!("invalid request: {e}"))
+                });
             }
         };
 
-        let id = req.get("id").cloned();
-        let method = req.get("method").and_then(|m| m.as_str());
-
-        let Some(method) = method else {
-            return id.map(|id| error_response(id, codes::INVALID_REQUEST, "missing `method`"));
-        };
-
-        // Notifications (no id) get no response regardless of method.
-        let is_notification = id.is_none();
-
-        match method {
-            "initialize" => self.wrap(id, self.initialize_result()),
+        match req.method.as_str() {
+            "initialize" => self.wrap(req.id, Ok(self.initialize_result())),
             "notifications/initialized" | "initialized" => None,
-            "ping" => self.wrap(id, Ok(json!({}))),
+            "ping" => self.wrap(req.id, Ok(EmptyResult {})),
             "tools/list" => {
                 let result = self.tools_list().await;
-                self.wrap(id, result)
+                self.wrap(req.id, result)
             }
             "tools/call" => {
-                let params = req.get("params").cloned().unwrap_or(Value::Null);
-                let result = self.tools_call(params).await;
-                self.wrap(id, result)
+                let result = self.tools_call(req.params).await;
+                self.wrap(req.id, result)
             }
-            _ if is_notification => None,
-            _ => id.map(|id| {
-                error_response(id, codes::METHOD_NOT_FOUND, &format!("method not found: {method}"))
+            // Unknown method: notifications stay silent; requests get an error.
+            _ => req.id.map(|id| {
+                error_response(
+                    id,
+                    codes::METHOD_NOT_FOUND,
+                    &format!("method not found: {}", req.method),
+                )
             }),
         }
     }
 
-    /// Wrap a method result into a JSON-RPC response, or `None` for a
-    /// notification (no id). An `Err` becomes a JSON-RPC error response.
-    fn wrap(&self, id: Option<Value>, result: Result<Value, McpError>) -> Option<String> {
+    /// Wrap a typed method result into a JSON-RPC success/error response, or
+    /// `None` for a notification (no id).
+    fn wrap<T: Serialize>(&self, id: Option<Value>, result: Result<T, McpError>) -> Option<String> {
         let id = id?;
         Some(match result {
-            Ok(value) => json!({ "jsonrpc": "2.0", "id": id, "result": value }).to_string(),
+            Ok(value) => serde_json::to_string(&JsonRpcSuccess {
+                jsonrpc: "2.0",
+                id,
+                result: value,
+            })
+            .unwrap_or_else(|e| {
+                error_response(Value::Null, codes::INTERNAL_ERROR, &format!("serialize: {e}"))
+            }),
             Err(e) => error_response(id, e.code, &e.message),
         })
     }
 
-    /// The `initialize` handshake result — protocol version + capabilities +
-    /// serverInfo. We advertise the `tools` capability (this server exposes
-    /// continuum commands as tools).
-    fn initialize_result(&self) -> Result<Value, McpError> {
-        Ok(json!({
-            "protocolVersion": MCP_PROTOCOL_VERSION,
-            "capabilities": { "tools": {} },
-            "serverInfo": { "name": self.server_name, "version": self.server_version },
-        }))
-    }
-
-    /// `tools/list` → the catalog from `mcp/list-tools`, reshaped to the MCP
-    /// `{ tools: [...] }` envelope. The catalog's `MCPTool` shape already matches
-    /// MCP (`name`, `description`, `inputSchema`), so we pass the array through.
-    async fn tools_list(&self) -> Result<Value, McpError> {
-        let resp = self
-            .dispatch
-            .execute("mcp/list-tools", json!({}))
-            .await
-            .map_err(McpError::internal)?;
-        let tools = resp
-            .get("tools")
-            .cloned()
-            .unwrap_or_else(|| json!([]));
-        Ok(json!({ "tools": tools }))
-    }
-
-    /// `tools/call` → dispatch the underlying command, wrap its JSON result as an
-    /// MCP `CallToolResult` (`content: [{ type: "text", text }]`). A command
-    /// refusal becomes `isError: true` content (the MCP convention — the model
-    /// sees the failure rather than the call throwing at the protocol layer).
-    async fn tools_call(&self, params: Value) -> Result<Value, McpError> {
-        let name = params
-            .get("name")
-            .and_then(|n| n.as_str())
-            .ok_or_else(|| McpError::new(codes::INVALID_PARAMS, "tools/call: missing `name`"))?;
-        let arguments = params.get("arguments").cloned().unwrap_or_else(|| json!({}));
-
-        let command = tool_name_to_command(name);
-        match self.dispatch.execute(&command, arguments).await {
-            Ok(result) => Ok(tool_content(&result, false)),
-            // A refused command is a TOOL error, not a protocol error: surface it
-            // in the result content so the calling model can read + react.
-            Err(reason) => Ok(tool_content(&json!({ "error": reason }), true)),
+    fn initialize_result(&self) -> InitializeResult {
+        InitializeResult {
+            protocol_version: MCP_PROTOCOL_VERSION,
+            capabilities: ServerCapabilities {
+                tools: ToolsCapability {},
+            },
+            server_info: ServerInfo {
+                name: self.server_name.clone(),
+                version: self.server_version.clone(),
+            },
         }
     }
+
+    /// `tools/list` → the catalog from `mcp/list-tools`, validated into typed
+    /// [`MCPTool`]s. The catalog is the single source of truth (commands ARE
+    /// tools); deserializing it here also proves the catalog conforms to the
+    /// MCP tool shape.
+    async fn tools_list(&self) -> Result<ListToolsResult, McpError> {
+        let resp = self
+            .dispatch
+            .execute("mcp/list-tools", Value::Object(Default::default()))
+            .await
+            .map_err(McpError::internal)?;
+        let catalog: CatalogResult = serde_json::from_value(resp)
+            .map_err(|e| McpError::internal(format!("catalog shape: {e}")))?;
+        Ok(ListToolsResult {
+            tools: catalog.tools,
+        })
+    }
+
+    /// `tools/call` → dispatch the underlying command, wrap its JSON result as a
+    /// typed [`CallToolResult`]. A command refusal becomes `isError` content
+    /// (the MCP convention — the model sees the failure rather than the call
+    /// throwing at the protocol layer).
+    async fn tools_call(&self, params: Value) -> Result<CallToolResult, McpError> {
+        let params: CallToolParams = serde_json::from_value(params)
+            .map_err(|e| McpError::new(codes::INVALID_PARAMS, format!("tools/call params: {e}")))?;
+
+        let command = tool_name_to_command(&params.name);
+        Ok(match self.dispatch.execute(&command, params.arguments).await {
+            Ok(result) => CallToolResult::text(&result, false),
+            Err(reason) => CallToolResult::text(&serde_json::json!({ "error": reason }), true),
+        })
+    }
 }
 
-/// Build an MCP `CallToolResult` from a JSON payload: one text content block
-/// carrying the serialized JSON, plus the `isError` flag.
-fn tool_content(payload: &Value, is_error: bool) -> Value {
-    json!({
-        "content": [ { "type": "text", "text": payload.to_string() } ],
-        "isError": is_error,
-    })
-}
+/// Empty `{}` result (e.g. `ping`).
+#[derive(Debug, Serialize)]
+struct EmptyResult {}
 
 /// A JSON-RPC error response string.
 fn error_response(id: Value, code: i64, message: &str) -> String {
-    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } }).to_string()
+    serde_json::to_string(&JsonRpcErrorResponse {
+        jsonrpc: "2.0",
+        id,
+        error: JsonRpcError {
+            code,
+            message: message.to_string(),
+        },
+    })
+    .unwrap_or_else(|_| {
+        // Last-resort literal — serialization of this fixed shape can't realistically fail.
+        format!(r#"{{"jsonrpc":"2.0","id":null,"error":{{"code":{code},"message":"error"}}}}"#)
+    })
 }
 
 /// A protocol-level error (maps to a JSON-RPC `error` object).
@@ -215,7 +365,10 @@ struct McpError {
 
 impl McpError {
     fn new(code: i64, message: impl Into<String>) -> Self {
-        Self { code, message: message.into() }
+        Self {
+            code,
+            message: message.into(),
+        }
     }
     fn internal(message: impl Into<String>) -> Self {
         Self::new(codes::INTERNAL_ERROR, message)
@@ -225,6 +378,7 @@ impl McpError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
     use std::sync::Mutex;
 
     /// Mock dispatch: records the (command, params) it saw and returns a canned
@@ -258,7 +412,10 @@ mod tests {
     #[async_trait]
     impl CommandDispatch for MockDispatch {
         async fn execute(&self, command: &str, params: Value) -> Result<Value, String> {
-            self.calls.lock().unwrap().push((command.to_string(), params.clone()));
+            self.calls
+                .lock()
+                .unwrap()
+                .push((command.to_string(), params.clone()));
             if self.fail_on.as_deref() == Some(command) {
                 return Err(format!("{command}: refused by mock"));
             }
@@ -274,8 +431,8 @@ mod tests {
     }
 
     // what this catches: the initialize handshake returns the protocol version +
-    // tools capability + serverInfo — the shape an MCP client (unsloth/Claude
-    // Code) requires before it will list/call tools.
+    // tools capability + serverInfo — the typed shape an MCP client (unsloth/
+    // Claude Code) requires before it will list/call tools.
     #[tokio::test]
     async fn initialize_returns_capabilities_and_server_info() {
         let s = server(MockDispatch::new());
@@ -286,16 +443,19 @@ mod tests {
         let v: Value = serde_json::from_str(&resp).unwrap();
         assert_eq!(v["id"], 1);
         assert_eq!(v["result"]["protocolVersion"], MCP_PROTOCOL_VERSION);
-        assert!(v["result"]["capabilities"]["tools"].is_object(), "advertises tools capability");
+        assert!(
+            v["result"]["capabilities"]["tools"].is_object(),
+            "advertises tools capability"
+        );
         assert_eq!(v["result"]["serverInfo"]["name"], "continuum-mcp");
     }
 
     // what this catches: tools/list pulls from the catalog command (single source
-    // of truth — commands ARE tools) and reshapes to the MCP {tools:[...]} envelope.
+    // of truth — commands ARE tools), validates into typed MCPTool, and reshapes
+    // to the MCP {tools:[...]} envelope.
     #[tokio::test]
-    async fn tools_list_proxies_the_catalog_command() {
-        let d = MockDispatch::new();
-        let s = server(d);
+    async fn tools_list_proxies_and_types_the_catalog() {
+        let s = server(MockDispatch::new());
         let resp = s
             .handle_message(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#)
             .await
@@ -304,13 +464,13 @@ mod tests {
         let tools = v["result"]["tools"].as_array().expect("tools array");
         assert_eq!(tools.len(), 2);
         assert_eq!(tools[0]["name"], "ping");
-        // It dispatched the catalog command, not reached into module internals.
+        assert_eq!(tools[1]["inputSchema"]["type"], "object", "typed MCPTool round-trip");
         assert_eq!(s.dispatch.calls.lock().unwrap()[0].0, "mcp/list-tools");
     }
 
     // what this catches: tools/call maps the MCP tool name back to the command
     // path and dispatches it with the given arguments; the JSON result is wrapped
-    // as MCP text content. This is the core "MCP call → headless command" bridge.
+    // as a typed CallToolResult text block.
     #[tokio::test]
     async fn tools_call_maps_name_and_dispatches() {
         let s = server(MockDispatch::new());
@@ -322,13 +482,12 @@ mod tests {
             .unwrap();
         let v: Value = serde_json::from_str(&resp).unwrap();
         assert_eq!(v["result"]["isError"], false);
-        // dispatched the slashed command with the arguments verbatim
         let (cmd, params) = s.dispatch.calls.lock().unwrap()[0].clone();
         assert_eq!(cmd, "interface/screenshot");
         assert_eq!(params["querySelector"], "body");
-        // result wrapped as text content carrying the command's JSON
         let text = v["result"]["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("interface/screenshot"));
+        assert_eq!(v["result"]["content"][0]["type"], "text");
     }
 
     // what this catches: the meta-tool name exception (underscore tool name →
@@ -358,7 +517,23 @@ mod tests {
         let v: Value = serde_json::from_str(&resp).unwrap();
         assert!(v.get("error").is_none(), "not a protocol error");
         assert_eq!(v["result"]["isError"], true);
-        assert!(v["result"]["content"][0]["text"].as_str().unwrap().contains("refused"));
+        assert!(v["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("refused"));
+    }
+
+    // what this catches: missing `name` on tools/call is an INVALID_PARAMS
+    // protocol error (the typed CallToolParams deserialize fails loudly).
+    #[tokio::test]
+    async fn tools_call_missing_name_is_invalid_params() {
+        let s = server(MockDispatch::new());
+        let resp = s
+            .handle_message(r#"{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"arguments":{}}}"#)
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v["error"]["code"], codes::INVALID_PARAMS);
     }
 
     // what this catches: notifications (no id) get NO response; a request with an
@@ -366,12 +541,10 @@ mod tests {
     #[tokio::test]
     async fn notifications_silent_and_unknown_method_errors() {
         let s = server(MockDispatch::new());
-        // notifications/initialized is a notification → no response
         assert!(s
             .handle_message(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
             .await
             .is_none());
-        // unknown method WITH id → method-not-found error
         let resp = s
             .handle_message(r#"{"jsonrpc":"2.0","id":9,"method":"bogus/method"}"#)
             .await
@@ -380,14 +553,23 @@ mod tests {
         assert_eq!(v["error"]["code"], codes::METHOD_NOT_FOUND);
     }
 
-    // what this catches: malformed JSON yields a JSON-RPC parse error (null id),
-    // never a panic — the transport stays alive on garbage input.
+    // what this catches: malformed JSON → parse error (null id); valid JSON
+    // missing `method` → invalid request. Neither panics — the transport stays
+    // alive on garbage input.
     #[tokio::test]
-    async fn malformed_json_is_parse_error_not_panic() {
+    async fn malformed_and_invalid_requests_error_cleanly() {
         let s = server(MockDispatch::new());
-        let resp = s.handle_message("{not json").await.unwrap();
-        let v: Value = serde_json::from_str(&resp).unwrap();
-        assert_eq!(v["error"]["code"], codes::PARSE_ERROR);
-        assert!(v["id"].is_null());
+        let parse = s.handle_message("{not json").await.unwrap();
+        let pv: Value = serde_json::from_str(&parse).unwrap();
+        assert_eq!(pv["error"]["code"], codes::PARSE_ERROR);
+        assert!(pv["id"].is_null());
+
+        let invalid = s
+            .handle_message(r#"{"jsonrpc":"2.0","id":7,"params":{}}"#)
+            .await
+            .unwrap();
+        let iv: Value = serde_json::from_str(&invalid).unwrap();
+        assert_eq!(iv["error"]["code"], codes::INVALID_REQUEST);
+        assert_eq!(iv["id"], 7);
     }
 }

--- a/core/continuum-core/src/modules/mcp_protocol.rs
+++ b/core/continuum-core/src/modules/mcp_protocol.rs
@@ -1,0 +1,393 @@
+//! MCP JSON-RPC protocol handler — the headless-Rust MCP **server** brain.
+//!
+//! This is the Rust-native replacement for `src/mcp-server.ts` (871 lines of
+//! Node + `@modelcontextprotocol/sdk`). The command path stays headless: an MCP
+//! client (unsloth Studio, Claude Code) speaks JSON-RPC, and this handler turns
+//! each call into a continuum command dispatch — no Node, no TS in the loop.
+//!
+//! ## The MCP server IS a client ([[persona-is-a-client]])
+//!
+//! The handler holds nothing but a [`CommandDispatch`] — the same
+//! request/response verb every continuum client uses. It does NOT reach into
+//! module internals:
+//!
+//! - `tools/list` → `dispatch.execute("mcp/list-tools", {})` (the catalog in
+//!   [`super::mcp`] — single source of truth for "commands ARE tools").
+//! - `tools/call` → maps the MCP tool name back to a command path and
+//!   `dispatch.execute(command, arguments)`.
+//!
+//! So this layer is pure protocol framing over the command verb. In production
+//! the `CommandDispatch` is a `continuum_client::Connection` over the in-process
+//! or airc transport (gated like any caller); in tests it's a mock. The
+//! transport + the stdio/HTTP bin that pumps bytes into [`McpServer::handle_message`]
+//! is the next slice — this slice is the protocol, pure and testable.
+//!
+//! ## Scope (slice 1)
+//!
+//! `initialize`, `notifications/initialized`, `tools/list`, `tools/call`, plus
+//! JSON-RPC error framing. Pure: a JSON-RPC message string in, an optional
+//! response string out (None for notifications). No transport, no process.
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+/// The MCP protocol revision this server advertises. Bump as the spec moves;
+/// `2024-11-05` is the broadly-supported baseline (Claude Code, unsloth, etc.).
+const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// JSON-RPC error codes used by the handler (subset of the spec).
+mod codes {
+    pub const PARSE_ERROR: i64 = -32700;
+    pub const INVALID_REQUEST: i64 = -32600;
+    pub const METHOD_NOT_FOUND: i64 = -32601;
+    pub const INVALID_PARAMS: i64 = -32602;
+    pub const INTERNAL_ERROR: i64 = -32603;
+}
+
+/// The one verb the MCP server needs: dispatch a continuum command and get JSON
+/// back (or a refusal string). Implemented in production by a
+/// `continuum_client::Connection` (the MCP server is a client); in tests by a
+/// mock. This is the seam that keeps the command path headless — no Node, and no
+/// direct `CommandExecutor`/module coupling in the protocol layer.
+#[async_trait]
+pub trait CommandDispatch: Send + Sync {
+    async fn execute(&self, command: &str, params: Value) -> Result<Value, String>;
+}
+
+/// Translate an MCP tool name back to a continuum command path.
+///
+/// The catalog ([`super::mcp`]) mints tool names by `command.replace('/', "_")`,
+/// so the inverse is `replace('_', "/")` — `interface_screenshot` →
+/// `interface/screenshot`, `collaboration_chat_send` → `collaboration/chat/send`.
+///
+/// The `mcp_*` meta-tools are the documented exception: the catalog hardcodes
+/// underscore names (`mcp_search_tools`, `mcp_tool_help`) whose real commands use
+/// a hyphen (`mcp/search-tools`, `mcp/tool-help`), so a blind `_`→`/` would
+/// produce `mcp/search/tools`. Map those explicitly; everything else is the
+/// general rule. (Tool names already use `_` for `/`, so a hyphen in a non-meta
+/// command name round-trips fine — only the meta-tools collide.)
+fn tool_name_to_command(tool_name: &str) -> String {
+    match tool_name {
+        "mcp_search_tools" => "mcp/search-tools".to_string(),
+        "mcp_tool_help" => "mcp/tool-help".to_string(),
+        other => other.replace('_', "/"),
+    }
+}
+
+/// The MCP JSON-RPC protocol handler. Holds only the command dispatch — it's a
+/// client of the headless core, nothing more.
+pub struct McpServer<D: CommandDispatch> {
+    dispatch: D,
+    server_name: String,
+    server_version: String,
+}
+
+impl<D: CommandDispatch> McpServer<D> {
+    /// Build a server over `dispatch`. `server_name`/`server_version` are
+    /// surfaced in the `initialize` handshake's `serverInfo`.
+    pub fn new(dispatch: D, server_name: impl Into<String>, server_version: impl Into<String>) -> Self {
+        Self {
+            dispatch,
+            server_name: server_name.into(),
+            server_version: server_version.into(),
+        }
+    }
+
+    /// Handle one JSON-RPC message. Returns `Some(response_json)` for requests
+    /// (success or error), `None` for notifications (no `id`) — the transport
+    /// writes `Some` back to the client and drops `None`.
+    pub async fn handle_message(&self, message: &str) -> Option<String> {
+        let req: Value = match serde_json::from_str(message) {
+            Ok(v) => v,
+            Err(e) => {
+                // Parse error: no id available, per JSON-RPC reply with null id.
+                return Some(error_response(Value::Null, codes::PARSE_ERROR, &format!("parse error: {e}")));
+            }
+        };
+
+        let id = req.get("id").cloned();
+        let method = req.get("method").and_then(|m| m.as_str());
+
+        let Some(method) = method else {
+            return id.map(|id| error_response(id, codes::INVALID_REQUEST, "missing `method`"));
+        };
+
+        // Notifications (no id) get no response regardless of method.
+        let is_notification = id.is_none();
+
+        match method {
+            "initialize" => self.wrap(id, self.initialize_result()),
+            "notifications/initialized" | "initialized" => None,
+            "ping" => self.wrap(id, Ok(json!({}))),
+            "tools/list" => {
+                let result = self.tools_list().await;
+                self.wrap(id, result)
+            }
+            "tools/call" => {
+                let params = req.get("params").cloned().unwrap_or(Value::Null);
+                let result = self.tools_call(params).await;
+                self.wrap(id, result)
+            }
+            _ if is_notification => None,
+            _ => id.map(|id| {
+                error_response(id, codes::METHOD_NOT_FOUND, &format!("method not found: {method}"))
+            }),
+        }
+    }
+
+    /// Wrap a method result into a JSON-RPC response, or `None` for a
+    /// notification (no id). An `Err` becomes a JSON-RPC error response.
+    fn wrap(&self, id: Option<Value>, result: Result<Value, McpError>) -> Option<String> {
+        let id = id?;
+        Some(match result {
+            Ok(value) => json!({ "jsonrpc": "2.0", "id": id, "result": value }).to_string(),
+            Err(e) => error_response(id, e.code, &e.message),
+        })
+    }
+
+    /// The `initialize` handshake result — protocol version + capabilities +
+    /// serverInfo. We advertise the `tools` capability (this server exposes
+    /// continuum commands as tools).
+    fn initialize_result(&self) -> Result<Value, McpError> {
+        Ok(json!({
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": { "tools": {} },
+            "serverInfo": { "name": self.server_name, "version": self.server_version },
+        }))
+    }
+
+    /// `tools/list` → the catalog from `mcp/list-tools`, reshaped to the MCP
+    /// `{ tools: [...] }` envelope. The catalog's `MCPTool` shape already matches
+    /// MCP (`name`, `description`, `inputSchema`), so we pass the array through.
+    async fn tools_list(&self) -> Result<Value, McpError> {
+        let resp = self
+            .dispatch
+            .execute("mcp/list-tools", json!({}))
+            .await
+            .map_err(McpError::internal)?;
+        let tools = resp
+            .get("tools")
+            .cloned()
+            .unwrap_or_else(|| json!([]));
+        Ok(json!({ "tools": tools }))
+    }
+
+    /// `tools/call` → dispatch the underlying command, wrap its JSON result as an
+    /// MCP `CallToolResult` (`content: [{ type: "text", text }]`). A command
+    /// refusal becomes `isError: true` content (the MCP convention — the model
+    /// sees the failure rather than the call throwing at the protocol layer).
+    async fn tools_call(&self, params: Value) -> Result<Value, McpError> {
+        let name = params
+            .get("name")
+            .and_then(|n| n.as_str())
+            .ok_or_else(|| McpError::new(codes::INVALID_PARAMS, "tools/call: missing `name`"))?;
+        let arguments = params.get("arguments").cloned().unwrap_or_else(|| json!({}));
+
+        let command = tool_name_to_command(name);
+        match self.dispatch.execute(&command, arguments).await {
+            Ok(result) => Ok(tool_content(&result, false)),
+            // A refused command is a TOOL error, not a protocol error: surface it
+            // in the result content so the calling model can read + react.
+            Err(reason) => Ok(tool_content(&json!({ "error": reason }), true)),
+        }
+    }
+}
+
+/// Build an MCP `CallToolResult` from a JSON payload: one text content block
+/// carrying the serialized JSON, plus the `isError` flag.
+fn tool_content(payload: &Value, is_error: bool) -> Value {
+    json!({
+        "content": [ { "type": "text", "text": payload.to_string() } ],
+        "isError": is_error,
+    })
+}
+
+/// A JSON-RPC error response string.
+fn error_response(id: Value, code: i64, message: &str) -> String {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } }).to_string()
+}
+
+/// A protocol-level error (maps to a JSON-RPC `error` object).
+struct McpError {
+    code: i64,
+    message: String,
+}
+
+impl McpError {
+    fn new(code: i64, message: impl Into<String>) -> Self {
+        Self { code, message: message.into() }
+    }
+    fn internal(message: impl Into<String>) -> Self {
+        Self::new(codes::INTERNAL_ERROR, message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Mock dispatch: records the (command, params) it saw and returns a canned
+    /// result per command — so the protocol layer is tested without a core.
+    struct MockDispatch {
+        calls: Mutex<Vec<(String, Value)>>,
+        list_tools_result: Value,
+        fail_on: Option<String>,
+    }
+    impl MockDispatch {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                list_tools_result: json!({
+                    "success": true,
+                    "tools": [
+                        { "name": "ping", "description": "[JTAG] health", "inputSchema": { "type": "object", "properties": {} } },
+                        { "name": "interface_screenshot", "description": "[JTAG] shot", "inputSchema": { "type": "object", "properties": {} } }
+                    ],
+                    "count": 2
+                }),
+                fail_on: None,
+            }
+        }
+        fn failing(command: &str) -> Self {
+            let mut s = Self::new();
+            s.fail_on = Some(command.to_string());
+            s
+        }
+    }
+    #[async_trait]
+    impl CommandDispatch for MockDispatch {
+        async fn execute(&self, command: &str, params: Value) -> Result<Value, String> {
+            self.calls.lock().unwrap().push((command.to_string(), params.clone()));
+            if self.fail_on.as_deref() == Some(command) {
+                return Err(format!("{command}: refused by mock"));
+            }
+            match command {
+                "mcp/list-tools" => Ok(self.list_tools_result.clone()),
+                _ => Ok(json!({ "ok": true, "echoed": command })),
+            }
+        }
+    }
+
+    fn server(d: MockDispatch) -> McpServer<MockDispatch> {
+        McpServer::new(d, "continuum-mcp", "0.1.0")
+    }
+
+    // what this catches: the initialize handshake returns the protocol version +
+    // tools capability + serverInfo — the shape an MCP client (unsloth/Claude
+    // Code) requires before it will list/call tools.
+    #[tokio::test]
+    async fn initialize_returns_capabilities_and_server_info() {
+        let s = server(MockDispatch::new());
+        let resp = s
+            .handle_message(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#)
+            .await
+            .expect("initialize is a request, must respond");
+        let v: Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v["id"], 1);
+        assert_eq!(v["result"]["protocolVersion"], MCP_PROTOCOL_VERSION);
+        assert!(v["result"]["capabilities"]["tools"].is_object(), "advertises tools capability");
+        assert_eq!(v["result"]["serverInfo"]["name"], "continuum-mcp");
+    }
+
+    // what this catches: tools/list pulls from the catalog command (single source
+    // of truth — commands ARE tools) and reshapes to the MCP {tools:[...]} envelope.
+    #[tokio::test]
+    async fn tools_list_proxies_the_catalog_command() {
+        let d = MockDispatch::new();
+        let s = server(d);
+        let resp = s
+            .handle_message(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#)
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_str(&resp).unwrap();
+        let tools = v["result"]["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0]["name"], "ping");
+        // It dispatched the catalog command, not reached into module internals.
+        assert_eq!(s.dispatch.calls.lock().unwrap()[0].0, "mcp/list-tools");
+    }
+
+    // what this catches: tools/call maps the MCP tool name back to the command
+    // path and dispatches it with the given arguments; the JSON result is wrapped
+    // as MCP text content. This is the core "MCP call → headless command" bridge.
+    #[tokio::test]
+    async fn tools_call_maps_name_and_dispatches() {
+        let s = server(MockDispatch::new());
+        let resp = s
+            .handle_message(
+                r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"interface_screenshot","arguments":{"querySelector":"body"}}}"#,
+            )
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v["result"]["isError"], false);
+        // dispatched the slashed command with the arguments verbatim
+        let (cmd, params) = s.dispatch.calls.lock().unwrap()[0].clone();
+        assert_eq!(cmd, "interface/screenshot");
+        assert_eq!(params["querySelector"], "body");
+        // result wrapped as text content carrying the command's JSON
+        let text = v["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("interface/screenshot"));
+    }
+
+    // what this catches: the meta-tool name exception (underscore tool name →
+    // hyphen command) — a blind _→/ would wrongly produce mcp/search/tools.
+    #[tokio::test]
+    async fn tools_call_maps_meta_tool_hyphen_exception() {
+        let s = server(MockDispatch::new());
+        s.handle_message(
+            r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"mcp_search_tools","arguments":{"query":"chat"}}}"#,
+        )
+        .await
+        .unwrap();
+        assert_eq!(s.dispatch.calls.lock().unwrap()[0].0, "mcp/search-tools");
+    }
+
+    // what this catches: a refused command surfaces as isError content (the model
+    // sees the failure), NOT a JSON-RPC protocol error — the MCP convention.
+    #[tokio::test]
+    async fn tools_call_refusal_is_iserror_content_not_protocol_error() {
+        let s = server(MockDispatch::failing("data/wipe"));
+        let resp = s
+            .handle_message(
+                r#"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"data_wipe","arguments":{}}}"#,
+            )
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_str(&resp).unwrap();
+        assert!(v.get("error").is_none(), "not a protocol error");
+        assert_eq!(v["result"]["isError"], true);
+        assert!(v["result"]["content"][0]["text"].as_str().unwrap().contains("refused"));
+    }
+
+    // what this catches: notifications (no id) get NO response; a request with an
+    // unknown method gets a method-not-found error.
+    #[tokio::test]
+    async fn notifications_silent_and_unknown_method_errors() {
+        let s = server(MockDispatch::new());
+        // notifications/initialized is a notification → no response
+        assert!(s
+            .handle_message(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+            .await
+            .is_none());
+        // unknown method WITH id → method-not-found error
+        let resp = s
+            .handle_message(r#"{"jsonrpc":"2.0","id":9,"method":"bogus/method"}"#)
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v["error"]["code"], codes::METHOD_NOT_FOUND);
+    }
+
+    // what this catches: malformed JSON yields a JSON-RPC parse error (null id),
+    // never a panic — the transport stays alive on garbage input.
+    #[tokio::test]
+    async fn malformed_json_is_parse_error_not_panic() {
+        let s = server(MockDispatch::new());
+        let resp = s.handle_message("{not json").await.unwrap();
+        let v: Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v["error"]["code"], codes::PARSE_ERROR);
+        assert!(v["id"].is_null());
+    }
+}

--- a/core/continuum-core/src/modules/mcp_transport.rs
+++ b/core/continuum-core/src/modules/mcp_transport.rs
@@ -1,0 +1,202 @@
+//! MCP server transport — the byte layer that drives [`McpServer`] (slice 2).
+//!
+//! Slice 1 ([`super::mcp_protocol`]) is the pure protocol brain: a JSON-RPC
+//! message string in, an optional response string out. This slice gives it:
+//!
+//! - [`StdioRunner`] — the newline-delimited-JSON stdio loop MCP clients
+//!   (unsloth Studio, Claude Code) speak. Generic over any async reader/writer
+//!   so it's unit-tested with in-memory pipes, not a real process.
+//! - [`ConnectionDispatch`] — the production [`CommandDispatch`]: forwards each
+//!   MCP `tools/call` to the headless core over a `continuum_client::Connection`
+//!   (gated like any caller). This is what makes the MCP server *a client*
+//!   ([[persona-is-a-client]]) rather than a privileged backdoor.
+//!
+//! The thin `continuum-mcp` bin wires these together: attach to the core over
+//! airc IPC → `ConnectionDispatch` → `McpServer` → `StdioRunner::run(stdin,
+//! stdout)`. No Node anywhere — this replaces `src/mcp-server.ts`.
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+
+use continuum_client::transport::Transport;
+use continuum_client::Connection;
+
+use super::mcp_protocol::{CommandDispatch, McpServer};
+
+/// Drives an [`McpServer`] over a newline-delimited-JSON byte stream — the MCP
+/// stdio transport. Each inbound line is one JSON-RPC message; each response is
+/// written as one line. (MCP stdio framing is newline-delimited, not LSP
+/// Content-Length; `serde_json` emits no embedded newlines, so one-message-per-
+/// line holds.)
+pub struct StdioRunner<D: CommandDispatch> {
+    server: McpServer<D>,
+}
+
+impl<D: CommandDispatch> StdioRunner<D> {
+    pub fn new(server: McpServer<D>) -> Self {
+        Self { server }
+    }
+
+    /// Read JSON-RPC messages from `reader` line by line, dispatch each through
+    /// the server, and write each non-empty response (notifications produce
+    /// none) to `writer`, newline-terminated and flushed. Returns when the
+    /// reader hits EOF (client disconnected). Blank lines are skipped; a
+    /// malformed line still produces a JSON-RPC parse-error response (the loop
+    /// never dies on bad input — that's [`McpServer::handle_message`]'s job).
+    pub async fn run<R, W>(&self, reader: R, mut writer: W) -> std::io::Result<()>
+    where
+        R: tokio::io::AsyncRead + Unpin,
+        W: AsyncWrite + Unpin,
+    {
+        let mut lines = BufReader::new(reader).lines();
+        while let Some(line) = lines.next_line().await? {
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Some(response) = self.server.handle_message(&line).await {
+                writer.write_all(response.as_bytes()).await?;
+                writer.write_all(b"\n").await?;
+                writer.flush().await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The production [`CommandDispatch`]: forwards a command to the headless core
+/// over a `continuum_client::Connection`. The MCP server holds one of these, so
+/// every `tools/call` runs through the SAME gated command path any client uses —
+/// no Node, no privileged bypass.
+pub struct ConnectionDispatch<T: Transport> {
+    connection: Connection<T>,
+}
+
+impl<T: Transport> ConnectionDispatch<T> {
+    pub fn new(connection: Connection<T>) -> Self {
+        Self { connection }
+    }
+}
+
+#[async_trait]
+impl<T: Transport> CommandDispatch for ConnectionDispatch<T> {
+    async fn execute(&self, command: &str, params: Value) -> Result<Value, String> {
+        // Value→Value: the MCP layer ferries dynamic command JSON; the typed
+        // command surface is the SDK's concern, not the protocol bridge's.
+        self.connection
+            .commands()
+            .execute::<Value, Value>(command, params)
+            .await
+            .map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    /// Minimal dispatch for driving the stdio loop end-to-end.
+    struct EchoDispatch {
+        calls: Mutex<Vec<String>>,
+    }
+    impl EchoDispatch {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+    #[async_trait]
+    impl CommandDispatch for EchoDispatch {
+        async fn execute(&self, command: &str, _params: Value) -> Result<Value, String> {
+            self.calls.lock().unwrap().push(command.to_string());
+            match command {
+                "mcp/list-tools" => Ok(json!({ "tools": [] })),
+                _ => Ok(json!({ "ran": command })),
+            }
+        }
+    }
+
+    // what this catches: the stdio transport drives the protocol end-to-end over
+    // a byte stream — two newline-delimited requests in, two newline-delimited
+    // responses out, in order. This is the real wire shape MCP clients speak.
+    #[tokio::test]
+    async fn stdio_runner_pumps_newline_delimited_requests() {
+        let server = McpServer::new(EchoDispatch::new(), "continuum-mcp", "0.1.0");
+        let runner = StdioRunner::new(server);
+
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+            "\n",
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+            "\n",
+        );
+        let mut output: Vec<u8> = Vec::new();
+        runner
+            .run(input.as_bytes(), &mut output)
+            .await
+            .expect("run to EOF");
+
+        let out = String::from_utf8(output).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2, "one response line per request:\n{out}");
+        let r1: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(r1["id"], 1);
+        assert_eq!(r1["result"]["protocolVersion"], "2024-11-05");
+        let r2: Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(r2["id"], 2);
+        assert!(r2["result"]["tools"].is_array());
+    }
+
+    // what this catches: a notification (no id) produces NO output line, so the
+    // transport doesn't emit phantom responses; a following request still answers.
+    #[tokio::test]
+    async fn stdio_runner_skips_notifications_and_blank_lines() {
+        let server = McpServer::new(EchoDispatch::new(), "continuum-mcp", "0.1.0");
+        let runner = StdioRunner::new(server);
+
+        let input = concat!(
+            "\n", // blank line
+            r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+            "\n",
+            r#"{"jsonrpc":"2.0","id":7,"method":"ping"}"#,
+            "\n",
+        );
+        let mut output: Vec<u8> = Vec::new();
+        runner.run(input.as_bytes(), &mut output).await.unwrap();
+
+        let out = String::from_utf8(output).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 1, "only the ping request gets a response:\n{out}");
+        let v: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(v["id"], 7);
+    }
+
+    // what this catches: ConnectionDispatch forwards through a real
+    // continuum_client::Connection — a tools/call reaches the command path with
+    // its arguments and the command result comes back as tool content. Uses the
+    // client's MockTransport so it's the genuine Connection→CommandClient path,
+    // not a hand mock of the dispatch.
+    #[tokio::test]
+    async fn connection_dispatch_forwards_through_a_real_connection() {
+        use continuum_client::mock::MockTransport;
+
+        let mock = MockTransport::new();
+        mock.respond_with("interface/screenshot", json!({ "success": true, "dataUrl": "x" }));
+        let conn = Connection::new(mock);
+
+        let server = McpServer::new(ConnectionDispatch::new(conn), "continuum-mcp", "0.1.0");
+        let resp = server
+            .handle_message(
+                r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"interface_screenshot","arguments":{"querySelector":"body"}}}"#,
+            )
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v["result"]["isError"], false);
+        let text = v["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("dataUrl"), "command result ferried back: {text}");
+    }
+}

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -51,6 +51,7 @@ pub mod live;
 pub mod logger;
 pub mod mcp;
 pub mod mcp_protocol;
+pub mod mcp_transport;
 pub mod memory;
 pub mod models;
 pub mod persona_allocator;

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -50,6 +50,7 @@ pub mod launch_mode;
 pub mod live;
 pub mod logger;
 pub mod mcp;
+pub mod mcp_protocol;
 pub mod memory;
 pub mod models;
 pub mod persona_allocator;

--- a/core/continuum-core/src/runtime/core_ipc_transport.rs
+++ b/core/continuum-core/src/runtime/core_ipc_transport.rs
@@ -1,0 +1,351 @@
+//! `CoreIpcTransport` — a `continuum_client::Transport` that talks DIRECTLY to a
+//! running core's IPC socket (the `ipc::start_server` Unix socket).
+//!
+//! ## Why (the local-sidecar path)
+//!
+//! [`AircIpcTransport`](continuum_client::AircIpcTransport) routes commands over
+//! airc to a *peer* — the GRID/REMOTE path. A LOCAL sidecar (e.g. `continuum-mcp`
+//! spawned beside the core) is the *same machine-account peer* as the core, so
+//! addressing a command "to that peer" over airc doesn't route back to the core's
+//! own handler (it timed out — live finding 2026-06-19). The local sidecar must
+//! instead speak the core's IPC protocol on its Unix socket directly — which is
+//! also simpler and airc-independent (more reliable).
+//!
+//! ## Wire protocol (mirrors `ipc/mod.rs`)
+//!
+//! - **Request**: one newline-terminated JSON object — the command params
+//!   flattened with `command` + `requestId`. (The core's reader passes the whole
+//!   object to `route_command`.)
+//! - **Response**: a length-prefixed frame — `[u32 BE length][JSON payload]` where
+//!   the payload is `{ success, result, error, requestId }`.
+//!
+//! Both shapes are TYPED structs ([`IpcRequest`], [`IpcResponse`]) — no `json!`
+//! field-poking, so the wire contract is a struct, not magic.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+use tokio::sync::Mutex;
+
+use continuum_client::event::EventStream;
+use continuum_client::transport::{ServeHandler, Transport};
+use continuum_client::ClientError;
+
+/// Cap on a response frame, so a corrupt length prefix can't make us allocate
+/// gigabytes. Generous — large tool results (search dumps, file reads) fit well
+/// under this.
+const MAX_FRAME_BYTES: u32 = 64 * 1024 * 1024;
+
+/// Typed inbound request — the params object flattened with `command` +
+/// `requestId`. `params` MUST be a JSON object (commands always pass one); the
+/// transport normalizes a null/absent params to `{}` before constructing this.
+#[derive(Debug, Serialize)]
+struct IpcRequest<'a> {
+    #[serde(flatten)]
+    params: &'a Map<String, Value>,
+    command: &'a str,
+    #[serde(rename = "requestId")]
+    request_id: u64,
+}
+
+/// Typed response frame payload — the core's wire response. Decoupled from the
+/// core's internal `ipc::protocol::Response` (whose fields are crate-private):
+/// this is the client-side contract.
+#[derive(Debug, Deserialize)]
+struct IpcResponse {
+    success: bool,
+    #[serde(default)]
+    result: Option<Value>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+/// Direct connection to a core's IPC socket. Holds one lazily-opened stream
+/// behind a `Mutex` — the MCP stdio loop is sequential (one command at a time),
+/// so a single serialized connection is sufficient and keeps `requestId`
+/// correlation trivial (one outstanding request).
+pub struct CoreIpcTransport {
+    socket_path: PathBuf,
+    stream: Mutex<Option<UnixStream>>,
+    next_id: AtomicU64,
+}
+
+impl CoreIpcTransport {
+    /// Build a transport for the core listening at `socket_path` (e.g.
+    /// `/tmp/continuum-core.sock`). Connection is lazy — opened on first
+    /// `execute`, reopened if it drops.
+    pub fn new(socket_path: impl Into<PathBuf>) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+            stream: Mutex::new(None),
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    /// One request/response round-trip over a connected stream. On any I/O error
+    /// the caller drops the stream so the next call reconnects.
+    async fn round_trip(
+        stream: &mut UnixStream,
+        command: &str,
+        request_id: u64,
+        params: &Map<String, Value>,
+    ) -> Result<IpcResponse, ClientError> {
+        // ── write the newline-terminated request ──
+        let req = IpcRequest {
+            params,
+            command,
+            request_id,
+        };
+        let mut line = serde_json::to_vec(&req).map_err(|e| ClientError::Codec(e.to_string()))?;
+        line.push(b'\n');
+        stream
+            .write_all(&line)
+            .await
+            .map_err(|e| ClientError::Transport(format!("write request: {e}")))?;
+        stream
+            .flush()
+            .await
+            .map_err(|e| ClientError::Transport(format!("flush request: {e}")))?;
+
+        // ── read the length-prefixed response frame ──
+        let mut len_buf = [0u8; 4];
+        stream
+            .read_exact(&mut len_buf)
+            .await
+            .map_err(|e| ClientError::Transport(format!("read frame length: {e}")))?;
+        let len = u32::from_be_bytes(len_buf);
+        if len > MAX_FRAME_BYTES {
+            return Err(ClientError::Transport(format!(
+                "response frame too large ({len} bytes > {MAX_FRAME_BYTES} cap)"
+            )));
+        }
+        let mut payload = vec![0u8; len as usize];
+        stream
+            .read_exact(&mut payload)
+            .await
+            .map_err(|e| ClientError::Transport(format!("read frame payload: {e}")))?;
+
+        // JSON responses parse cleanly here. Binary frames (audio: JSON header +
+        // \0 + bytes) don't — they're not part of the command/tool path the MCP
+        // server uses, so surface a typed error rather than mis-parse.
+        serde_json::from_slice::<IpcResponse>(&payload).map_err(|e| {
+            ClientError::Codec(format!(
+                "response frame was not a JSON command response (binary results \
+                 aren't supported on the direct-IPC path): {e}"
+            ))
+        })
+    }
+}
+
+#[async_trait]
+impl Transport for CoreIpcTransport {
+    async fn execute(&self, command: &str, params: Value) -> Result<Value, ClientError> {
+        // Normalize params to an object (commands always carry one; null/absent → {}).
+        let params_map = match params {
+            Value::Object(m) => m,
+            Value::Null => Map::new(),
+            other => {
+                return Err(ClientError::Codec(format!(
+                    "command `{command}` params must be a JSON object, got {}",
+                    kind_of(&other)
+                )))
+            }
+        };
+        let request_id = self.next_id.fetch_add(1, Ordering::Relaxed);
+
+        let mut guard = self.stream.lock().await;
+        // Lazy connect / reconnect if the stream is absent.
+        if guard.is_none() {
+            let s = UnixStream::connect(&self.socket_path).await.map_err(|e| {
+                ClientError::Connect(format!(
+                    "connect to core IPC socket {}: {e}",
+                    self.socket_path.display()
+                ))
+            })?;
+            *guard = Some(s);
+        }
+
+        let stream = guard.as_mut().expect("just ensured connected");
+        let resp = match Self::round_trip(stream, command, request_id, &params_map).await {
+            Ok(r) => r,
+            Err(e) => {
+                // Drop the (possibly broken) stream so the next call reconnects.
+                *guard = None;
+                return Err(e);
+            }
+        };
+
+        if resp.success {
+            Ok(resp.result.unwrap_or(Value::Null))
+        } else {
+            Err(ClientError::Refused {
+                command: command.to_string(),
+                reason: resp.error.unwrap_or_else(|| "command failed".to_string()),
+            })
+        }
+    }
+
+    async fn subscribe(&self, _class: &str) -> Result<EventStream, ClientError> {
+        Err(ClientError::NotImplemented(
+            "CoreIpcTransport::subscribe — event streaming over the direct-IPC path is a follow-up",
+        ))
+    }
+
+    async fn emit(&self, _class: &str, _payload: Value) -> Result<(), ClientError> {
+        Err(ClientError::NotImplemented(
+            "CoreIpcTransport::emit — event publish over the direct-IPC path is a follow-up",
+        ))
+    }
+
+    async fn provide(
+        &self,
+        _command: &str,
+        _handler: std::sync::Arc<dyn ServeHandler>,
+    ) -> Result<(), ClientError> {
+        Err(ClientError::NotImplemented(
+            "CoreIpcTransport::provide — serving a command over the direct-IPC path is a follow-up",
+        ))
+    }
+
+    async fn revoke(&self, _command: &str) -> Result<(), ClientError> {
+        Ok(()) // idempotent: nothing is provided over this transport
+    }
+
+    async fn close(&self) -> Result<(), ClientError> {
+        *self.stream.lock().await = None;
+        Ok(())
+    }
+}
+
+/// Human-readable JSON kind for error messages.
+fn kind_of(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::net::UnixListener;
+
+    /// A minimal IPC server speaking the REAL wire protocol (newline JSON request
+    /// in, length-prefixed JSON frame out) — so the transport is tested against
+    /// the actual codec, not a mock of itself. Returns the temp socket path; the
+    /// server handles one connection, echoing each request's command+params back
+    /// as the result (or refusing a command named "refuse/me").
+    async fn spawn_echo_ipc_server() -> PathBuf {
+        // Unique per server instance — tests run in parallel in one binary, so a
+        // shared (pid-only) path would collide. A per-call atomic counter isolates them.
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("cc-coreipc-test-{}-{n}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).expect("bind test socket");
+        let path_ret = path.clone();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let (read_half, mut write_half) = stream.into_split();
+            let mut lines = BufReader::new(read_half).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let req: Value = serde_json::from_str(&line).expect("server: parse request");
+                let command = req.get("command").and_then(|c| c.as_str()).unwrap_or("");
+                let request_id = req.get("requestId").and_then(|r| r.as_u64());
+
+                // Build the response payload (typed shape mirrored as json for the
+                // server side — the SERVER is the core's role here).
+                let payload = if command == "refuse/me" {
+                    json!({ "success": false, "error": "refused by test server", "requestId": request_id })
+                } else {
+                    json!({ "success": true, "result": { "echoed": command, "saw": req }, "requestId": request_id })
+                };
+                let bytes = serde_json::to_vec(&payload).unwrap();
+                let len = (bytes.len() as u32).to_be_bytes();
+                write_half.write_all(&len).await.unwrap();
+                write_half.write_all(&bytes).await.unwrap();
+                write_half.flush().await.unwrap();
+            }
+        });
+
+        // Give the listener a moment to be ready before the client connects.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        path_ret
+    }
+
+    // what this catches: the full direct-IPC round-trip over the REAL wire codec —
+    // request is sent as a newline JSON object with command+requestId flattened
+    // onto the params, the length-prefixed response frame is read + parsed, and the
+    // inner result is returned. This is the path that fixes the airc self-peer
+    // timeout (the live finding) and the coverage the unit MockTransport couldn't give.
+    #[tokio::test]
+    async fn execute_round_trips_over_the_real_wire_codec() {
+        let socket = spawn_echo_ipc_server().await;
+        let transport = CoreIpcTransport::new(&socket);
+
+        let result = transport
+            .execute("chat/send", json!({ "room": "general", "text": "hi" }))
+            .await
+            .expect("round-trip ok");
+
+        // The server echoed our command + the full request it saw.
+        assert_eq!(result["echoed"], "chat/send");
+        // command + requestId were flattened onto the params on the wire.
+        assert_eq!(result["saw"]["command"], "chat/send");
+        assert_eq!(result["saw"]["room"], "general");
+        assert_eq!(result["saw"]["text"], "hi");
+        assert!(result["saw"]["requestId"].is_number(), "requestId stamped on the request");
+
+        let _ = std::fs::remove_file(&socket);
+    }
+
+    // what this catches: a core refusal (success:false + error) maps to
+    // ClientError::Refused carrying the command + reason — so the MCP layer can
+    // surface it as isError content rather than hanging or mis-reporting.
+    #[tokio::test]
+    async fn command_refusal_maps_to_refused_error() {
+        let socket = spawn_echo_ipc_server().await;
+        let transport = CoreIpcTransport::new(&socket);
+
+        let err = transport
+            .execute("refuse/me", json!({}))
+            .await
+            .expect_err("server refuses this command");
+        match err {
+            ClientError::Refused { command, reason } => {
+                assert_eq!(command, "refuse/me");
+                assert!(reason.contains("refused by test server"), "reason: {reason}");
+            }
+            other => panic!("expected Refused, got {other:?}"),
+        }
+        let _ = std::fs::remove_file(&socket);
+    }
+
+    // what this catches: non-object params are rejected with a clear typed error
+    // (commands always carry an object; a scalar would corrupt the flattened wire).
+    #[tokio::test]
+    async fn non_object_params_rejected_cleanly() {
+        let transport = CoreIpcTransport::new("/nonexistent.sock");
+        let err = transport
+            .execute("x/y", json!(42))
+            .await
+            .expect_err("scalar params rejected");
+        assert!(matches!(err, ClientError::Codec(_)), "got {err:?}");
+    }
+}

--- a/core/continuum-core/src/runtime/mod.rs
+++ b/core/continuum-core/src/runtime/mod.rs
@@ -35,6 +35,7 @@ pub mod command_events;
 pub mod command_executor;
 pub mod command_interceptor;
 pub mod control;
+pub mod core_ipc_transport;
 pub mod grid_interceptor;
 pub mod in_process_transport;
 pub mod late_bound;

--- a/docs/infrastructure/MCP-SERVER-HOOKUP.md
+++ b/docs/infrastructure/MCP-SERVER-HOOKUP.md
@@ -1,0 +1,114 @@
+# MCP Server Hookup (continuum-mcp) — Runbook
+
+**What:** `continuum-mcp` is the headless-Rust MCP server. An MCP client (unsloth
+Studio, Claude Code, …) spawns it over stdio; it auto-discovers the running local
+core and exposes continuum's commands as MCP tools. It **replaces the Node
+`src/mcp-server.ts`** — no Node in the loop.
+
+**Design:** [UNSLOTH-INTEGRATION.md](../architecture/UNSLOTH-INTEGRATION.md) §5
+(Seam 1). It's a *client* of the core ([persona-is-a-client]): `tools/list` →
+`mcp/list-tools`, `tools/call` → the command path, all through the same gate any
+caller hits.
+
+---
+
+## 1. Build
+
+`continuum-mcp` builds as part of `npm start` (per the all-bins-build-via-start
+rule — `tools/scripts/start-server.sh` builds it before launching the core):
+
+```bash
+cd src && npm start          # builds continuum-mcp + launches the core
+```
+
+The binary lands at `<cargo-target>/debug/continuum-mcp` (or `release/` when
+`CONTINUUM_RELEASE` is set). With the shared cache that's
+`~/.continuum/cache/cargo-target/debug/continuum-mcp`. Find the exact path:
+
+```bash
+ls "${CARGO_TARGET_DIR:-core/target}"/debug/continuum-mcp
+```
+
+## 2. Hook up an MCP client
+
+**Turnkey — no config needed.** With the core running, `continuum-mcp`
+auto-discovers it (airc liveness probe). The MCP client config is just the binary
+path:
+
+```jsonc
+// MCP client config (Claude Code ~/.claude.json, or unsloth Studio → Settings →
+// Connections → MCP). Use the ABSOLUTE path to the built binary.
+{
+  "mcpServers": {
+    "continuum": {
+      "command": "/Users/<you>/.continuum/cache/cargo-target/debug/continuum-mcp"
+    }
+  }
+}
+```
+
+That's it — no peer-id or socket to look up (that lookup was the friction that
+bred unreliability). Override only if you need to target a non-default core:
+
+```jsonc
+{
+  "mcpServers": {
+    "continuum": {
+      "command": ".../continuum-mcp",
+      "env": {
+        "CONTINUUM_SOCKET": "/path/to/airc-daemon.sock",  // default: discovered
+        "CONTINUUM_PEER":   "<core-airc-peer-uuid>",       // default: discovered
+        "CONTINUUM_HOME":   "/path/to/.airc",              // default: $AIRC_HOME, else $HOME/.airc
+        "CONTINUUM_AGENT":  "continuum-mcp"                // this client's agent name
+      }
+    }
+  }
+}
+```
+
+## 3. Verify
+
+In the MCP client, confirm the `continuum` server connects and lists tools, then
+call one:
+- `tools/list` shows continuum commands (e.g. `interface_screenshot`,
+  `collaboration_chat_send`, `mcp_search_tools`).
+- `tools/call` `mcp_search_tools {"query":"chat"}` returns matches.
+- A real command (e.g. `collaboration_chat_send`) runs and returns content.
+
+Manual smoke (stdio, no client) — initialize + list:
+
+```bash
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | "${CARGO_TARGET_DIR:-core/target}"/debug/continuum-mcp
+# Expect two JSON-RPC response lines: initialize result, then the tools array.
+```
+
+## 4. Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `could not discover a healthy local core` on startup | Core isn't running — `cd src && npm start`. Or the airc daemon socket is stale (`airc doctor --fix`). Or override `CONTINUUM_SOCKET` + `CONTINUUM_PEER`. |
+| Tools list empty | Catalog (`mcp/list-tools`) returned nothing — check the core started its module registry. |
+| A `tools/call` returns `isError` content | The command was refused (auth/params) — that's a tool error surfaced to the model, not a transport failure; read the content. |
+| Diagnostics polluting the client | They shouldn't — `continuum-mcp` writes diagnostics to **stderr**; only JSON-RPC goes to stdout. |
+
+---
+
+## 5. Retiring `src/mcp-server.ts` (gated on green)
+
+Once §3 verifies `continuum-mcp` against a real MCP client (unsloth Studio at
+`127.0.0.1:8888` and/or Claude Code), retire the Node server it replaces:
+
+1. Delete `src/mcp-server.ts` (871 lines of Node + `@modelcontextprotocol/sdk` +
+   `sharp`).
+2. Drop its `package.json` entries: `bin.mcp` (`./mcp-server.ts`) and the
+   `mcp` / `mcp:setup` scripts (and `@modelcontextprotocol/sdk` / `sharp` from
+   deps if unused elsewhere).
+3. Repoint any MCP client config / `tools/scripts/setup-mcp.sh` from
+   `npx tsx mcp-server.ts` to the `continuum-mcp` binary (§2).
+4. Confirm no remaining importers of `mcp-server.ts`.
+
+Do this as its own commit **after** the live green, so the cutover is reversible
+and never leaves the repo without a working MCP server.

--- a/tools/scripts/install.sh
+++ b/tools/scripts/install.sh
@@ -109,7 +109,7 @@ echo ""
 # Step 1: System dependencies
 # ============================================================================
 
-echo -e "${YELLOW}[1/8] System dependencies${NC}"
+echo -e "${YELLOW}[1/9] System dependencies${NC}"
 
 install_system_deps() {
   case "$PLATFORM" in
@@ -255,7 +255,7 @@ fi
 # Step 2: Node.js
 # ============================================================================
 
-echo -e "${YELLOW}[2/8] Node.js${NC}"
+echo -e "${YELLOW}[2/9] Node.js${NC}"
 
 install_node() {
   if command -v node &>/dev/null; then
@@ -289,7 +289,7 @@ install_node
 # Step 3: Rust
 # ============================================================================
 
-echo -e "${YELLOW}[3/8] Rust${NC}"
+echo -e "${YELLOW}[3/9] Rust${NC}"
 
 install_rust() {
   if command -v rustc &>/dev/null; then
@@ -310,7 +310,7 @@ export PATH="$HOME/.cargo/bin:$PATH"
 # Step 4: Python ML environment (if GPU detected)
 # ============================================================================
 
-echo -e "${YELLOW}[4/8] Python ML environment${NC}"
+echo -e "${YELLOW}[4/9] Python ML environment${NC}"
 
 VENV_DIR="$HOME/.continuum/venv"
 
@@ -363,7 +363,7 @@ fi
 # ============================================================================
 
 if [ "$SKIP_BUILD" = "0" ]; then
-  echo -e "${YELLOW}[5/8] Building Continuum${NC}"
+  echo -e "${YELLOW}[5/9] Building Continuum${NC}"
 
   echo -e "  Installing npm dependencies..."
   npm install --silent 2>&1 | tail -3
@@ -403,7 +403,7 @@ mkdir -p "$CONFIG_DIR/bin"
 # PostgreSQL
 # ============================================================================
 
-echo -e "${YELLOW}[6/8] PostgreSQL${NC}"
+echo -e "${YELLOW}[6/9] PostgreSQL${NC}"
 
 install_postgres() {
   # macOS: keg-only postgres may not be in PATH — find it
@@ -480,7 +480,7 @@ install_postgres
 # LiveKit SFU server (voice/video calls)
 # ============================================================================
 
-echo -e "${YELLOW}[7/8] LiveKit SFU${NC}"
+echo -e "${YELLOW}[7/9] LiveKit SFU${NC}"
 
 install_livekit() {
   if [ -f "$PROJECT_DIR/workers/livekit-server" ] || command -v livekit-server &>/dev/null; then
@@ -500,10 +500,47 @@ install_livekit() {
 install_livekit
 
 # ============================================================================
+# Unsloth — inference + LoRA-training engine (preferred local backend)
+# ============================================================================
+#
+# Unsloth (Apache-2.0 core; llama.cpp underneath — the backend Continuum already
+# targets) is the PREFERRED local inference + training engine: Continuum points
+# its AIProviderAdapter at unsloth's OpenAI-compatible /v1 and surfaces its
+# commands to unsloth chat over MCP (continuum-mcp). See
+# docs/architecture/UNSLOTH-INTEGRATION.md.
+#
+# Installed by default (it's the engine), but NON-FATAL and behind the adapter
+# boundary — Continuum still runs with another provider if this is absent
+# (solve-for-public-users). Skip with CONTINUUM_NO_UNSLOTH=1. Idempotent.
+# Real installer per unsloth docs: curl -fsSL https://unsloth.ai/install.sh | sh
+# (macOS/Linux). Runs as a local web server: `unsloth studio -p 8888`.
+echo -e "${YELLOW}[8/9] Unsloth (inference + training engine)${NC}"
+if [ "${CONTINUUM_NO_UNSLOTH:-0}" = "1" ]; then
+  echo -e "  ${GREEN}⏭  Skipped (CONTINUUM_NO_UNSLOTH=1).${NC}"
+elif command -v unsloth &>/dev/null; then
+  echo -e "  ${GREEN}✅ unsloth already installed${NC}"
+else
+  case "$PLATFORM" in
+    macos|linux|wsl)
+      # Non-fatal: a failed engine install must not abort the whole installer.
+      if curl -fsSL https://unsloth.ai/install.sh | sh; then
+        echo -e "  ${GREEN}✅ unsloth installed — launch: unsloth studio -p 8888${NC}"
+      else
+        echo -e "  ${YELLOW}⚠  unsloth install failed — Continuum still runs with another"
+        echo -e "     provider. Re-run later: curl -fsSL https://unsloth.ai/install.sh | sh${NC}"
+      fi
+      ;;
+    *)
+      echo -e "  ${YELLOW}⏭  Unsupported platform for the unsloth installer; skipping.${NC}"
+      ;;
+  esac
+fi
+
+# ============================================================================
 # Tailscale mesh VPN (multi-tower networking)
 # ============================================================================
 
-echo -e "${YELLOW}[8/8] Tailscale (grid mode only)${NC}"
+echo -e "${YELLOW}[9/9] Tailscale (grid mode only)${NC}"
 
 # Tailscale is OPTIONAL — it's the substrate for grid (multi-machine) mode
 # where peers reach each other for forge/inference distribution. Single-

--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -114,6 +114,17 @@ if [ -n "$CONTINUUM_RELEASE" ]; then
   PROFILE_LABEL="release"
 fi
 
+# ── Build the continuum-mcp bin ──────────────────────────────────────
+# The MCP server is a separate stdio bin that MCP clients (unsloth Studio,
+# Claude Code) SPAWN — it isn't launched by us, so it must exist on disk after
+# `npm start`. Build it here (same crate/manifest/features/profile as the core,
+# so it's a fast incremental once the core is built) rather than via a raw
+# `cargo build` — all Rust bins build through the npm start path. It replaces
+# the Node `src/mcp-server.ts`; an MCP client config points at the built binary.
+echo "▶ building continuum-mcp (Rust MCP server bin)"
+cargo build --manifest-path "$CORE_MANIFEST" --bin continuum-mcp $PROFILE_FLAG $CONTINUUM_FEATURES \
+  || echo "⚠ continuum-mcp build failed — MCP server unavailable (core still launches)" >&2
+
 echo "▶ continuum-core-server starting"
 echo "  profile:  $PROFILE_LABEL"
 echo "  features: $CONTINUUM_FEATURES"


### PR DESCRIPTION
## Why
The keystone for the **unsloth integration** and **coding personas**. The MCP server today is `src/mcp-server.ts` — **871 lines of Node** (`@modelcontextprotocol/sdk` + a WebSocket client to the core) that *also duplicates* the tool-catalog/search/help logic already in Rust (`modules/mcp.rs`). It's a forbidden Node dependency in the headless command path **and** a compression violation. This replaces its brain with headless Rust.

## Design — the MCP server IS a client
`McpServer` holds only a `CommandDispatch` verb; it does **not** reach into module internals ([[persona-is-a-client]]):
- `tools/list` → `execute("mcp/list-tools")` — `modules/mcp.rs` stays the single source of truth (commands ARE tools).
- `tools/call` → map MCP tool name → command path → `execute(command, arguments)`.

So it's pure JSON-RPC framing over the command verb. Production dispatch = a `continuum_client::Connection` (gated like any caller); tests = a mock. **No Node, no TS, no direct `CommandExecutor` coupling.**

## Scope (slice 1 — pure + tested)
`initialize` / `notifications/initialized` / `ping` / `tools/list` / `tools/call` + JSON-RPC error framing. `handle_message(json) -> Option<String>` (Some=request, None=notification). Handles the meta-tool hyphen exception (`mcp_search_tools`→`mcp/search-tools`), surfaces command refusals as MCP `isError` content (not protocol errors), and never panics on malformed JSON.

**7 unit tests** (initialize/list/call/meta-exception/refusal/notification/malformed) — all green.

## Next (slice 2)
stdio + HTTP/SSE transport bin → wire the dispatch to a `continuum_client::Connection` over the core, npm-start integration, then **retire `src/mcp-server.ts`**. Needs live validation (unsloth @`127.0.0.1:8888` + Claude Code).

Part of the grounded unsloth plan (UIs stay separate; brains bridge via MCP + OpenAI-compatible, both headless-Rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)