### PR TITLE
fix(install): decouple public install + smoke from the old Node client layer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -742,49 +742,47 @@ fi
 ok "$CONTAINER_CMD $($CONTAINER_CMD version --format '{{.Client.Version}}' 2>/dev/null || echo 'ready')"
 ok "Source: $INSTALL_DIR"
 
-# ── 3a. Build host-side CLI bundle (REQUIRED for jtag fast path) ──
-# Without dist/cli-bundle.js, src/jtag falls back to `tsx cli.ts`
-# which can't resolve tsconfig path aliases at runtime → every jtag
-# invocation fails with ERR_MODULE_NOT_FOUND. The bundle is what
-# every host-side jtag user actually needs. Pre-2026-05-03 install.sh
-# never built it on Linux (Docker-only flow); fresh users' first
-# jtag invocation has been broken for months. Joel: "months of
-# trying to get continuum working out-of-box for Carl."
+# ── 3a. Build host-side CLI bundle (BEST-EFFORT — old Node client layer) ──
+# The jtag CLI bundle (dist/cli-bundle.js) is part of the OLD Node/TS client
+# layer. That layer is being REINVENTED on the new client SDK, not repaired
+# (screenshot-as-spec rebuild as its own modular container — see the
+# client-SDK rework). With the headless-Rust work it's also prone to
+# directory-reshuffle breakage (e.g. browser-index resolving to tools/
+# instead of src/). So the host-side bundle build is now BEST-EFFORT and
+# NON-BLOCKING: the install deliverable is the headless Rust core (brought
+# up below via the container runtime), not this bundle.
 #
-# 2026-05-03 reliability fix: be LOUD about success/failure. Pre-fix
-# wrapped npm in `| tail -2` which silently ate exit codes. Now uses
-# explicit set -o pipefail equivalent via PIPESTATUS check, AND
-# verifies dist/cli-bundle.js exists post-build. Loud success = user
-# sees "✅ jtag bundle ready"; loud failure = user sees the actual
-# npm error + a die() so installation can't claim success while
-# leaving jtag broken.
-PHASE="host-side jtag CLI bundle"
+# When the bundle builds, jtag gets its fast path. When it doesn't, install
+# still SUCCEEDS — the core is up; jtag falls back to `tsx cli.ts`, and the
+# new client SDK is the real path forward. We warn loudly (never silently
+# claim success) but we never abort the whole install on this old layer.
+PHASE="host-side jtag CLI bundle (best-effort)"
+CLI_BUNDLE_OK=0
 if [ ! -f "$INSTALL_DIR/src/package.json" ]; then
-  fail "src/package.json missing in $INSTALL_DIR — clone incomplete? Re-run with: rm -rf $INSTALL_DIR && curl ... | bash"
+  warn "src/package.json missing — skipping host-side jtag CLI bundle (headless core install continues)."
+elif ! command -v npm >/dev/null 2>&1; then
+  warn "npm not on PATH — skipping host-side jtag CLI bundle (headless core install continues; install Node.js to get the jtag fast path)."
+else
+  info "Building host-side jtag CLI bundle (best-effort, ~30-60s)..."
+  # build:cli takes dist/cli.js as INPUT (esbuild input file). dist/cli.js
+  # is OUTPUT of build:ts. So the right invocation is `npm run build`
+  # (which is build:ts → postbuild → build:cli per package.json scripts).
+  if (
+    set -e
+    cd "$INSTALL_DIR/src"
+    echo "  → npm install (~10s)..."
+    npm install 2>&1 | tail -5
+    echo "  → npm run build (TypeScript compile + esbuild bundle, ~30-50s)..."
+    npm run build 2>&1 | tail -10
+  ) && [ -f "$INSTALL_DIR/src/dist/cli-bundle.js" ]; then
+    CLI_BUNDLE_OK=1
+    ok "jtag CLI bundle ready ($INSTALL_DIR/src/dist/cli-bundle.js)"
+  else
+    warn "Host-side jtag CLI bundle did not build (old Node client layer, under rework)."
+    warn "  Install CONTINUES — the headless core is the deliverable. jtag will fall"
+    warn "  back to 'tsx cli.ts'. To retry manually: cd $INSTALL_DIR/src && npm install && npm run build"
+  fi
 fi
-if ! command -v npm >/dev/null 2>&1; then
-  fail "npm not found on PATH but required for host-side jtag CLI bundle. Install Node.js (https://nodejs.org) and re-run."
-fi
-info "Building host-side jtag CLI bundle (~30-60s — first install)..."
-# build:cli takes dist/cli.js as INPUT (esbuild input file). dist/cli.js
-# is OUTPUT of build:ts. So the right invocation is `npm run build`
-# (which is build:ts → postbuild → build:cli per package.json scripts).
-# Pre-fix only ran build:cli → esbuild's missing-input failed silently
-# (the script suppresses stderr with `2>/dev/null`), no bundle written,
-# install completed "successfully" with broken jtag.
-(
-  set -e
-  cd "$INSTALL_DIR/src"
-  echo "  → npm install (~10s)..."
-  npm install 2>&1 | tail -5 || { echo "  ✗ npm install failed"; exit 1; }
-  echo "  → npm run build (TypeScript compile + esbuild bundle, ~30-50s)..."
-  npm run build 2>&1 | tail -10 || { echo "  ✗ npm run build failed"; exit 1; }
-) || fail "Host-side bundle build failed (see lines above). jtag CLI cannot work without dist/cli-bundle.js. Manually retry: cd $INSTALL_DIR/src && npm install && npm run build"
-# Verify the bundle actually exists — npm exit 0 + missing file = silent failure.
-if [ ! -f "$INSTALL_DIR/src/dist/cli-bundle.js" ]; then
-  fail "dist/cli-bundle.js was NOT created by build:cli (esbuild silently failed?). Manually retry: cd $INSTALL_DIR/src && npm install && npm run build:cli — and inspect output."
-fi
-ok "jtag CLI bundle ready ($INSTALL_DIR/src/dist/cli-bundle.js)"
 
 # ── 3b. Install continuum command (modular, headless-safe) ─
 # Was an inline `sudo cp` that crashed on "no TTY for password" when the

--- a/scripts/ci/carl-install-smoke.sh
+++ b/scripts/ci/carl-install-smoke.sh
@@ -21,11 +21,17 @@
 #   SKIP_TEARDOWN=1                 keep stack running after probe (debug)
 #
 # Exit codes:
-#   0 — install completed AND page rendered usable HTML
+#   0 — install completed AND headless core is serving IPC (core-gated pass).
+#       With CARL_CHECK_WEB_CLIENT=1, also requires web client + chat e2e.
 #   1 — install.sh failed
-#   2 — install.sh succeeded but widget-server never returned 200 on /health
-#   3 — widget-server returned 200 but page body looks broken
-#       (empty / contains chrome-error / contains "container exited")
+#   2 — install.sh succeeded but continuum-core IPC socket never came up
+#       (the headless core is the install deliverable — hard failure)
+#   3 — (CARL_CHECK_WEB_CLIENT=1) widget-server page body looks broken
+#   4/5/6 — (CARL_CHECK_WEB_CLIENT=1) jtag chat e2e failures
+#
+# The OLD Node web client + jtag-chat assertions are ADVISORY by default
+# (skipped) — that client is being reinvented on the new client SDK
+# (roadmap #29). Set CARL_CHECK_WEB_CLIENT=1 to run them.
 
 set -uo pipefail
 
@@ -205,10 +211,81 @@ fi
 INSTALL_DUR=$(( $(date +%s) - INSTALL_START ))
 echo "✅ install.sh completed in ${INSTALL_DUR}s"
 
-# ── 2. Wait for widget-server /health ─────────────────────────
-# install.sh has its own health-wait now (piece E in this PR), but we
-# re-check here in case the user used SKIP_HEALTH=1 or ran an older
-# install.sh without the wait. Belt + suspenders.
+# ── 2. Wait for the HEADLESS CORE (the real install deliverable) ──────
+# The install deliverable is the headless Rust core (continuum-core), NOT
+# the old Node web client. continuum-core exposes its IPC socket at
+# /root/.continuum/sockets/continuum-core.sock; the compose healthcheck is
+# `test -S` on exactly that path. We gate on the SAME signal from the host
+# via `docker compose exec`, so "smoke passed" means "the core is serving
+# IPC" — independent of whether the (in-rework) Node web client built.
+#
+# Why this replaced the widget-server :9003 gate: the old Node/TS client is
+# being REINVENTED on the new client SDK (screenshot-as-spec, own modular
+# container), not repaired. Its build is prone to directory-reshuffle breaks
+# from the headless-Rust work, and gating the public install path on a
+# dead-layer build is wrong. The core is what matters. (See roadmap #28/#29.)
+echo ""
+echo "━━━ waiting up to ${CARL_HEALTH_TIMEOUT_SEC}s for continuum-core IPC socket ━━━"
+CORE_SOCK="/root/.continuum/sockets/continuum-core.sock"
+CORE_OK=0
+if [ -f "$CARL_INSTALL_DIR/docker-compose.yml" ]; then
+  for i in $(seq 1 "$CARL_HEALTH_TIMEOUT_SEC"); do
+    if ( cd "$CARL_INSTALL_DIR" && docker compose exec -T continuum-core test -S "$CORE_SOCK" ) >/dev/null 2>&1; then
+      CORE_OK=1
+      echo "  continuum-core IPC socket live after ${i}s"
+      break
+    fi
+    sleep 1
+  done
+else
+  # Non-docker (native) install: fall back to the host-side socket path.
+  HOST_CORE_SOCK="$HOME/.continuum/sockets/continuum-core.sock"
+  for i in $(seq 1 "$CARL_HEALTH_TIMEOUT_SEC"); do
+    if [ -S "$HOST_CORE_SOCK" ]; then
+      CORE_OK=1
+      echo "  continuum-core IPC socket live after ${i}s ($HOST_CORE_SOCK)"
+      break
+    fi
+    sleep 1
+  done
+fi
+
+if [ "$CORE_OK" -ne 1 ]; then
+  echo "❌ continuum-core IPC socket never came up within ${CARL_HEALTH_TIMEOUT_SEC}s"
+  echo "   The headless core is the install deliverable — this is a hard failure."
+  if [ -f "$CARL_INSTALL_DIR/docker-compose.yml" ]; then
+    echo "   docker compose ps:"
+    ( cd "$CARL_INSTALL_DIR" && docker compose ps 2>&1 | sed 's/^/     /' ) || true
+    echo "   Last 40 lines of continuum-core logs:"
+    ( cd "$CARL_INSTALL_DIR" && docker compose logs --tail=40 continuum-core 2>&1 | sed 's/^/     /' ) || true
+  fi
+  exit 2
+fi
+echo "✅ headless core is serving IPC — the install deliverable is up"
+
+# ── 2b. OLD Node web client + jtag-chat assertions — ADVISORY ────────
+# These probe the OLD Node web client (widget-server :9003 render) and the
+# Node jtag CLI bundle (chat e2e). Both are part of the client layer being
+# reinvented on the new client SDK (#29); they are NOT the install
+# deliverable and must NOT gate the public install path while that layer is
+# in rework. Default: SKIP with a loud advisory note. Re-enable explicitly
+# with CARL_CHECK_WEB_CLIENT=1 once the new client container lands (and the
+# assertions below get rewritten against the new surface).
+if [ "${CARL_CHECK_WEB_CLIENT:-0}" != "1" ]; then
+  echo ""
+  echo "⚠ ADVISORY: skipping old Node web-client + jtag-chat assertions."
+  echo "    The Node/TS client is being reinvented on the new client SDK (roadmap #29);"
+  echo "    its build/render is a dead-layer until then and does not gate install."
+  echo "    Set CARL_CHECK_WEB_CLIENT=1 to run these probes against the new client."
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  ✅ carl-install-smoke PASSED (core-gated) — headless core installs + serves IPC"
+  echo "  Install duration: ${INSTALL_DUR}s"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  exit 0
+fi
+
+# ── 2c. (CARL_CHECK_WEB_CLIENT=1) Wait for widget-server /health ───────
 echo ""
 echo "━━━ waiting up to ${CARL_HEALTH_TIMEOUT_SEC}s for widget-server /health ━━━"
 HEALTH_OK=0


### PR DESCRIPTION
## Why

`carl-install-smoke` has been **red across all of canary** — every PR this session merged with it failing. Root cause is **not** a timeout (the "72s" was elapsed-to-failure, nowhere near the 1500s limit). It's a **dead-layer build break**: a `tsx` build step resolves `browser-index.ts` to `tools/browser-index.ts` instead of `src/browser-index.ts`, so its `./browser/generated` import ENOENTs on `tools/browser/generated.ts` — when the real, git-tracked file is `src/browser/generated.ts`. Classic directory-reshuffle fallout from the headless-Rust work (same `__dirname/../browser-index.ts` → `tools/` bug is visible at `tools/scripts/build-browser-example.js:36`).

That break aborted the entire public `curl install.sh | bash` **before the headless core ever came up** — gating the install path on a doomed layer.

Per direction: the old Node/TS client is being **reinvented on the new client SDK** (screenshot-as-spec, its own modular container — roadmap #29), **not repaired**. So we **decouple** install + smoke from it rather than deep-fix the dead layer (#28).

## What

**`install.sh`** — host-side jtag CLI bundle build is now **best-effort / non-blocking**. On failure it warns loudly and continues; the headless Rust core is the install deliverable and comes up via the container runtime regardless. (Was a hard `fail` that aborted install.)

**`scripts/ci/carl-install-smoke.sh`**
- **New primary gate:** wait for the `continuum-core` IPC socket (`/root/.continuum/sockets/continuum-core.sock` — the same signal as the compose healthcheck) via `docker compose exec`. A pass now means *the headless core serves IPC*.
- The old widget-server `:9003` render + jtag chat-e2e assertions are **advisory** (default-skipped, loud), re-enablable with `CARL_CHECK_WEB_CLIENT=1` once the new client container lands and they're rewritten against the new surface.

## Validation

- `bash -n` clean on both scripts.
- The real validation is this PR's own `carl-install-smoke` run: it should now get **past** the Node-bundle abort, bring up `continuum-core`, and gate on the core IPC socket.

## Roadmap
- #28 — the dead-layer path break (intentionally NOT deep-fixed)
- #29 — new Node/TS client SDK + app as a modular container on the new client SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)