### PR TITLE
feat(config): declare unsloth as the universal model gateway in config.env template

### DIFF
--- a/src/config.env.example
+++ b/src/config.env.example
@@ -41,10 +41,26 @@ LOG_TO_FILES=1
 LOG_FILE_MODE=clean
 
 # ============================================
-# API KEYS
+# MODEL GATEWAY — UNSLOTH (recommended)
 # ============================================
-# Add your API keys below. At least one is required for AI responses.
-# Leave blank if not using a provider.
+# Continuum reaches ALL models through unsloth, the universal model gateway:
+# it serves local models (llama.cpp) AND fans out to cloud providers using the
+# provider keys you configure INSIDE unsloth Studio. So you only need ONE
+# credential here — continuum talks to unsloth's OpenAI-compatible /v1.
+#
+# Setup (install opens unsloth Studio for you):
+#   1. unsloth Studio runs at the base URL below (default http://127.0.0.1:8888).
+#   2. In Studio, add your provider keys (OpenAI, etc.) and create an API key.
+#   3. Paste that key as UNSLOTH_API_KEY (install can capture it automatically).
+UNSLOTH_API_KEY=
+# Where unsloth serves its OpenAI-compatible API (include the /v1 suffix).
+UNSLOTH_BASE_URL=http://127.0.0.1:8888/v1
+
+# ============================================
+# API KEYS (legacy / optional — prefer the unsloth gateway above)
+# ============================================
+# Direct per-provider keys. Only needed if you are NOT routing a provider
+# through unsloth. Leave blank to let the unsloth gateway own all models.
 
 # Anthropic (Claude models) - https://console.anthropic.com/
 ANTHROPIC_API_KEY=


### PR DESCRIPTION
## Lean into the simplification
Per direction — **let unsloth control all models**. It serves local models (llama.cpp) and fans out to cloud providers using the keys configured inside unsloth Studio. So continuum needs **one** credential, not a per-provider list. New-user setup becomes "just open unsloth Studio, configure keys there, paste the one key."

## What
`src/config.env.example` now leads with a **MODEL GATEWAY — UNSLOTH** section:
- `UNSLOTH_API_KEY` — the single credential continuum needs
- `UNSLOTH_BASE_URL` — default `http://127.0.0.1:8888/v1`

…and demotes the per-provider `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`/… block to *legacy / optional — prefer the unsloth gateway*. Both readers already auto-load `*_API_KEY` (Rust `secrets.rs` + the `config_env.rs` owner), so no code change is needed for the keys to load.

## Mechanism slices (tracked separately)
- #31 — `UnslothInferenceAdapter` as the universal gateway adapter (now unblocked; key is wired locally)
- #33 — install autowire: open Studio window + capture `UNSLOTH_API_KEY` via `config_env::upsert`
- #34 — config.env single-owner: Rust `config_env.rs` sole writer; deprecate the TS `SecretManager.set` path

See memory `unsloth-universal-model-gateway`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)