### PR TITLE
feat(install): autowire the unsloth gateway key with minimal manual steps

### DIFF
--- a/tools/scripts/install.sh
+++ b/tools/scripts/install.sh
@@ -536,6 +536,14 @@ else
   esac
 fi
 
+# Autowire the gateway credential with minimal manual steps (env/config →
+# CLI auto-mint → paste-and-validate). Non-blocking + non-fatal: if unsloth
+# isn't running yet (or the user skips), Continuum still runs with another
+# provider and the key can be set later in config.env.
+if [ "${CONTINUUM_NO_UNSLOTH:-0}" != "1" ]; then
+  mod_unsloth_gateway_key "$CONFIG_FILE"
+fi
+
 # ============================================================================
 # Tailscale mesh VPN (multi-tower networking)
 # ============================================================================

--- a/tools/scripts/lib/install-common.sh
+++ b/tools/scripts/lib/install-common.sh
@@ -602,3 +602,111 @@ ic_describe_hardware() {
   printf '  GPU path:   %s\n'             "${IC_GPU_PATH:-undecided}"
   printf '  Model tier: %s\n'             "${IC_MODEL_TIER:-undecided}"
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unsloth gateway key autowire — limit manual steps.
+#
+# Continuum reaches ALL models through unsloth's OpenAI-compatible /v1 with ONE
+# credential (UNSLOTH_API_KEY). This captures it with as few manual steps as
+# possible and persists it to config.env. Fully NON-BLOCKING + NON-FATAL: no
+# key just means the gateway provider won't register; Continuum still runs with
+# another provider (solve-for-public-users).
+#
+# Capture ladder (most-automated first):
+#   1. Already in env or config.env (validated)  → keep it.
+#   2. unsloth CLI auto-mint (a model is loaded)  → `unsloth connect claude
+#      --no-launch` prints UNSLOTH_API_KEY=sk-...; we parse it. (--no-launch
+#      prints the env without launching the agent. Borrowing the `claude`
+#      target purely to trigger unsloth's own key mint.)
+#   3. Interactive paste prompt (TTY only)        → open Studio, user creates a
+#      key, enter + validate (Claude-Code-style). Skipped headless/CI.
+# Every captured key is validated against /v1/models (200) before persisting.
+#
+# NOTE (config.env single-owner, task #34): the installer is a legitimate
+# *bootstrap* writer of config.env; runtime owner stays Rust config_env.rs.
+
+_unsloth_base_url() { printf '%s' "${UNSLOTH_BASE_URL:-http://127.0.0.1:8888/v1}"; }
+
+# key valid? — 200 from /v1/models with this bearer token.
+_unsloth_key_valid() {  # $1=base_url  $2=key
+  curl -sf --max-time 5 -o /dev/null -H "Authorization: Bearer $2" "$1/models" 2>/dev/null
+}
+
+# CLI auto-mint — prints a freshly-minted key, or nothing. Needs a model loaded.
+_unsloth_cli_mint_key() {
+  command -v unsloth >/dev/null 2>&1 || return 0
+  unsloth connect claude --no-launch 2>/dev/null \
+    | grep -oE 'sk-unsloth-[A-Za-z0-9]+' | head -1
+}
+
+# Persist KEY to config.env (idempotent upsert; matches config_env.rs format).
+_unsloth_persist_key() {  # $1=config_file  $2=key
+  local f="$1" k="$2"
+  touch "$f"
+  if grep -q '^UNSLOTH_API_KEY=' "$f" 2>/dev/null; then
+    sed "s|^UNSLOTH_API_KEY=.*|UNSLOTH_API_KEY=$k|" "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+  else
+    printf '\n# unsloth universal model gateway\nUNSLOTH_API_KEY=%s\n' "$k" >> "$f"
+  fi
+  grep -q '^UNSLOTH_BASE_URL=' "$f" 2>/dev/null \
+    || printf 'UNSLOTH_BASE_URL=http://127.0.0.1:8888/v1\n' >> "$f"
+}
+
+_unsloth_open_studio() {  # $1=url
+  case "$(uname -s)" in
+    Darwin) open "$1" >/dev/null 2>&1 || true ;;
+    *)      command -v xdg-open >/dev/null 2>&1 && xdg-open "$1" >/dev/null 2>&1 || true ;;
+  esac
+}
+
+# Main entry — call after the unsloth install step. Never fails the installer.
+mod_unsloth_gateway_key() {  # $1=config_file
+  local config_file="$1"
+  local base_url; base_url="$(_unsloth_base_url)"
+  local studio_url="${base_url%/v1}"
+
+  # 1) already configured + valid?
+  local existing="${UNSLOTH_API_KEY:-}"
+  [ -z "$existing" ] && existing="$(grep -E '^UNSLOTH_API_KEY=.+' "$config_file" 2>/dev/null | head -1 | cut -d= -f2-)"
+  if [ -n "$existing" ] && _unsloth_key_valid "$base_url" "$existing"; then
+    ok "unsloth gateway key already configured + valid"
+    return 0
+  fi
+
+  # Gateway must be reachable to mint/validate.
+  if ! curl -sf --max-time 3 -o /dev/null "$studio_url/" 2>/dev/null; then
+    warn "unsloth Studio not reachable at $studio_url — start it (\`unsloth studio -p 8888\`), then re-run; gateway key not set yet"
+    return 0
+  fi
+
+  # 2) CLI auto-mint (most-automated — works once a model is loaded in Studio).
+  local minted; minted="$(_unsloth_cli_mint_key)"
+  if [ -n "$minted" ] && _unsloth_key_valid "$base_url" "$minted"; then
+    _unsloth_persist_key "$config_file" "$minted"
+    ok "unsloth gateway key minted via CLI + persisted to config.env"
+    return 0
+  fi
+
+  # 3) Interactive paste prompt (TTY only — never blocks headless/CI installs).
+  if [ -t 0 ] && [ "${CONTINUUM_NONINTERACTIVE:-0}" != "1" ]; then
+    _unsloth_open_studio "$studio_url"
+    info "Opened unsloth Studio ($studio_url). Create an API key there, then paste it:"
+    local tries=0 entered
+    while [ "$tries" -lt 3 ]; do
+      printf '  UNSLOTH_API_KEY (Enter to skip): '
+      read -r entered || break
+      [ -z "$entered" ] && { warn "skipped — set UNSLOTH_API_KEY later in $config_file"; return 0; }
+      if _unsloth_key_valid "$base_url" "$entered"; then
+        _unsloth_persist_key "$config_file" "$entered"
+        ok "unsloth gateway key validated + persisted to config.env"
+        return 0
+      fi
+      warn "that key did not validate against $base_url — try again"
+      tries=$((tries + 1))
+    done
+    warn "no valid key after 3 tries — set UNSLOTH_API_KEY later in $config_file"
+  else
+    info "Non-interactive install — set UNSLOTH_API_KEY in $config_file (or env) to enable the unsloth gateway"
+  fi
+  return 0
+}


### PR DESCRIPTION
## Why
New-user automation for the unsloth universal model gateway — capture `UNSLOTH_API_KEY` with **as few manual steps as possible** and persist it to config.env. No more hand-editing config.

## Capture ladder (most-automated first)
Each candidate is **validated against `/v1/models` (200)** before persisting:
1. `UNSLOTH_API_KEY` already in env or config.env (and still valid) → keep it.
2. **CLI auto-mint** — `unsloth connect claude --no-launch` prints `UNSLOTH_API_KEY=sk-...` (unsloth mints + remembers it); we parse it. Works once a model is loaded in Studio.
3. **Paste prompt (TTY only)** — open Studio, user creates a key, enter + validate (Claude-Code-style, 3 tries). Skipped headless/CI.

## Grounded in what unsloth actually exposes
- No REST key-mint endpoint (`/studio/api/keys` is just the SPA).
- `auth.db` stores key **hashes**, not plaintext — can't read a key back out.
- The CLI is the only programmatic mint, and it needs a loaded model.

So full zero-touch isn't possible; this gets as close as the engine allows.

## Shape
- Shared helper `mod_unsloth_gateway_key` in `install-common.sh` (both installers source it), wired into the `[8/9]` unsloth step.
- **Non-blocking + non-fatal**: no key → the gateway provider just doesn't register; Continuum runs with another provider; headless/CI never blocks.

## Validation
- `bash -n` clean on both files.
- Live: `_unsloth_key_valid` → 200 against the running `/v1`; `mod_unsloth_gateway_key` short-circuits with "✓ already configured + valid".

## Remaining (#33)
Port the unsloth install + this key step into the **public root `install.sh`** (the `curl` path) — currently only in the tower installer. config.env single-owner (#34): the installer is a legitimate bootstrap writer; runtime owner stays Rust `config_env.rs`.

See memory `unsloth-universal-model-gateway`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)