### PR TITLE
feat(vdd): vdd/score — the A/B lift measurement core (self-evolving genome, slice 1)

### DIFF
--- a/core/continuum-core/src/modules/vdd.rs
+++ b/core/continuum-core/src/modules/vdd.rs
@@ -35,7 +35,7 @@ use crate::utils::params::Params;
 use crate::vdd::reader::{latest_per_scenario, read_records, VddReadOptions, VddRecordEntry};
 use crate::vdd::record::HarnessStatus;
 use async_trait::async_trait;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::any::Any;
 use std::path::{Path, PathBuf};
@@ -131,6 +131,13 @@ impl ServiceModule for VddModule {
                 ))
             }
 
+            "vdd/score" => {
+                let _timer = TimingGuard::new("module", "vdd_score");
+                let parsed: VddScoreParams = serde_json::from_value(params)
+                    .map_err(|e| format!("vdd/score: invalid params: {e}"))?;
+                Ok(CommandResult::Json(score_eval_set(&parsed)))
+            }
+
             other => Err(format!("Unknown vdd command: {other}")),
         }
     }
@@ -138,6 +145,100 @@ impl ServiceModule for VddModule {
     fn as_any(&self) -> &dyn Any {
         self
     }
+}
+
+// ============================================================================
+// vdd/score — the measurement core of the self-evolving-genome A/B harness
+// (slice 1). Score a model's answers against a held-out set → accuracy. The
+// A/B *lift* = score(base+LoRA) − score(base); run this twice and diff. The
+// generation half (run the set through the gateway) is the next brick; this is
+// the deterministic scorer it composes with. See docs/genome/SELF-EVOLVING-GENOME.md.
+// ============================================================================
+
+/// One held-out evaluation case: the model's `actual` answer vs the `expected`.
+#[derive(Debug, Clone, Deserialize)]
+struct ScoreCase {
+    #[serde(default)]
+    prompt: String,
+    expected: String,
+    actual: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct VddScoreParams {
+    /// The held-out cases to score.
+    cases: Vec<ScoreCase>,
+    /// Match method: "exact" (case-insensitive equality) or "contains"
+    /// (expected appears in actual, case-insensitive — the lenient default).
+    #[serde(default = "default_score_method")]
+    method: String,
+    /// What's being scored, e.g. "base" or "base+lora-rust" — so the A/B can
+    /// label the two runs it diffs.
+    #[serde(default)]
+    label: String,
+    /// Scenario tag for the record.
+    #[serde(default = "default_score_scenario")]
+    scenario: String,
+}
+
+fn default_score_method() -> String {
+    "contains".to_string()
+}
+fn default_score_scenario() -> String {
+    "genome-ab-eval".to_string()
+}
+
+/// Is one case correct under `method`? Pure — the unit of measurement.
+fn case_correct(method: &str, expected: &str, actual: &str) -> bool {
+    let e = expected.trim();
+    let a = actual.trim();
+    match method {
+        "exact" => a.eq_ignore_ascii_case(e),
+        // "contains" (default): the expected answer appears in the response.
+        _ => a.to_lowercase().contains(&e.to_lowercase()),
+    }
+}
+
+/// Score a set → (correct, total). Pure.
+fn score_cases(method: &str, cases: &[ScoreCase]) -> (u32, u32) {
+    let total = cases.len() as u32;
+    let correct = cases
+        .iter()
+        .filter(|c| case_correct(method, &c.expected, &c.actual))
+        .count() as u32;
+    (correct, total)
+}
+
+/// Score an eval set and return the measurement: accuracy + per-case verdicts.
+/// Deterministic — no model run, so the scorer is pinned independently of any
+/// provider. `score` ∈ [0,1] is the number the A/B's *lift* is a difference of.
+fn score_eval_set(p: &VddScoreParams) -> Value {
+    let (correct, total) = score_cases(&p.method, &p.cases);
+    let score = if total == 0 {
+        0.0
+    } else {
+        correct as f64 / total as f64
+    };
+    let per_case: Vec<Value> = p
+        .cases
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "prompt": c.prompt,
+                "expected": c.expected,
+                "correct": case_correct(&p.method, &c.expected, &c.actual),
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "scenario": p.scenario,
+        "label": p.label,
+        "method": p.method,
+        "total": total,
+        "correct": correct,
+        "score": score,
+        "cases": per_case,
+    })
 }
 
 /// On-the-wire shape returned by `vdd/report`. Stable, camelCase
@@ -519,5 +620,83 @@ mod tests {
                 .contains(tmp.path().file_name().unwrap().to_str().unwrap()),
             "artifact_root surfaces the resolved root path"
         );
+    }
+
+    // ── vdd/score — slice 1 measurement core ──
+
+    fn case(expected: &str, actual: &str) -> ScoreCase {
+        ScoreCase {
+            prompt: String::new(),
+            expected: expected.to_string(),
+            actual: actual.to_string(),
+        }
+    }
+
+    // what this catches: the unit of measurement. "contains" is lenient +
+    // case-insensitive; "exact" is strict equality (trimmed, case-insensitive).
+    // Get this wrong and every downstream lift number is wrong.
+    #[test]
+    fn case_correct_methods() {
+        assert!(case_correct("contains", "Paris", "The capital is paris."));
+        assert!(!case_correct("contains", "Paris", "The capital is London."));
+        assert!(case_correct("exact", "4", " 4 "));
+        assert!(!case_correct("exact", "4", "the answer is 4"));
+    }
+
+    // what this catches: accuracy over a set — correct/total. This IS the score
+    // the A/B diffs.
+    #[test]
+    fn score_cases_counts_accuracy() {
+        let cases = vec![
+            case("4", "4"),                 // correct (contains)
+            case("Paris", "paris is it"),   // correct
+            case("blue", "the sky is red"), // wrong
+        ];
+        let (correct, total) = score_cases("contains", &cases);
+        assert_eq!((correct, total), (2, 3));
+    }
+
+    // what this catches: the vdd/score command end-to-end returns the accuracy
+    // measurement, AND that two labeled runs COMPOSE into a lift (the whole point
+    // of slice 1: lift = score(base+LoRA) − score(base)).
+    #[tokio::test]
+    async fn vdd_score_measures_and_composes_into_lift() {
+        let module = VddModule::default();
+
+        // "base" gets 1/2; "base+lora" gets 2/2 on the same held-out set.
+        let base = serde_json::json!({
+            "label": "base",
+            "method": "contains",
+            "cases": [
+                {"expected": "4", "actual": "4"},
+                {"expected": "spatial hash", "actual": "use a quadtree"},
+            ]
+        });
+        let lora = serde_json::json!({
+            "label": "base+lora",
+            "method": "contains",
+            "cases": [
+                {"expected": "4", "actual": "4"},
+                {"expected": "spatial hash", "actual": "use a spatial hash grid"},
+            ]
+        });
+
+        let v_base = match module.handle_command("vdd/score", base).await.unwrap() {
+            CommandResult::Json(v) => v,
+            _ => panic!("json"),
+        };
+        let v_lora = match module.handle_command("vdd/score", lora).await.unwrap() {
+            CommandResult::Json(v) => v,
+            _ => panic!("json"),
+        };
+
+        let s_base = v_base["score"].as_f64().unwrap();
+        let s_lora = v_lora["score"].as_f64().unwrap();
+        assert_eq!(s_base, 0.5);
+        assert_eq!(s_lora, 1.0);
+
+        // The keystone number: lift.
+        let lift = s_lora - s_base;
+        assert!((lift - 0.5).abs() < 1e-9, "lift = score(lora) − score(base) = 0.5");
     }
 }

--- a/docs/genome/SELF-EVOLVING-GENOME.md
+++ b/docs/genome/SELF-EVOLVING-GENOME.md
@@ -1,0 +1,179 @@
+# Self-Evolving Genome — Continuous, Definition-Free Learning by Measured Fitness
+
+**Status:** architecture (build plan). The substrate it rides on is on `canary`; the
+evolution algorithm is the frontier this doc defines.
+
+**Read first:** [GENOME-FOUNDRY-SENTINEL](../architecture/GENOME-FOUNDRY-SENTINEL.md),
+[CONTINUOUS-LEARNING-RUNTIME](CONTINUOUS-LEARNING-RUNTIME.md),
+[ACADEMY-DOJO-ARCHITECTURE](../personas/ACADEMY-DOJO-ARCHITECTURE.md),
+[CASCADING-CURRICULUM-ARCHITECTURE](../personas/CASCADING-CURRICULUM-ARCHITECTURE.md).
+This doc is the **synthesis**: it connects that prior corpus to the genome loop now
+shipped (`recorder → dataset/from-turns → forge/train → forge/export`) and adds the one
+thing none of them pinned down — **the fitness algorithm that decides, without human
+definition, when to mint / refine / merge / retire a LoRA layer.**
+
+---
+
+## 1. Thesis
+
+A persona (and the grid of personas) should **accumulate competence from its own work,
+continuously, without anyone enumerating domains or authoring a curriculum.** Three
+properties make that "self-evolving" rather than "a training script in a loop":
+
+1. **The work is the data.** Real room turns become training signal (`dataset/from-turns`).
+   No synthesized curriculum is *required* — deliberate synthesis is available, not mandatory.
+2. **Fitness is measured, never declared.** A layer's worth = the improvement it actually
+   produces, weighted by how often it's used, divided by what it costs and how much it
+   duplicates. No hand-set importance.
+3. **Structure is discovered, not specified.** "Domains" are *clusters* in capability-space,
+   found online. The number of layers is not configured — it emerges (nonparametric).
+
+The machine runs with **no intervention** in steady state: experience flows in, fitness is
+measured, clusters form, and the mint/refine/merge/retire decisions are thresholds on
+measured quantities — tuned by the governor, not by a person.
+
+---
+
+## 2. The substrate it rides on (already shipped)
+
+Academy is **not a subsystem to rebuild** — it is a set of **recipes + sentinels** over the
+genome loop that is already on `canary`:
+
+| Step | Primitive | Status |
+|---|---|---|
+| Capture the work | `persona::recorder` turn fixtures | shipped |
+| Work → training data | `dataset/from-turns` (chat JSONL, room/persona-filtered) | shipped (#1691) |
+| Train a LoRA | `forge/train` (drives unsloth, `--dry-run` validated) | shipped (#1695) |
+| Package the layer | `forge/export` (LoRA / GGUF, pure arg-builder) | shipped (#1696) |
+| Run any model | unsloth universal gateway (`forge`/`/v1`) | shipped (#1692/#1693) |
+| Trust boundary | `GridTrustAuthPolicy` (who may exchange) | shipped (#1653) |
+| The geometry | neural `EmbeddingProvider` (compute-once, shared) | shipped (#1657) |
+
+The Academy roles map onto recipes/sentinels: **teacher** = a recipe-defined persona role;
+**exam** = a pipeline step; **curriculum** = a recipe DAG; **cohort/team training** = a
+multi-persona room recipe; **the dream** = a background-consolidation sentinel. All flow
+through the same pipe above.
+
+---
+
+## 3. The fitness function
+
+A layer `L`'s fitness is **value-density**, not abstract quality:
+
+```
+fitness(L) = (lift(L) × demand(L)) / (cost(L) × redundancy(L))
+```
+
+- **lift** — measured A/B improvement on the tasks where `L` is active (base vs. base+`L`,
+  on a held-out set). The only honest quality signal. **Everything gates on this number.**
+- **demand** — how often `L` is actually paged in / requested (usage frequency).
+- **cost** — VRAM/compute to keep `L` resident.
+- **redundancy** — overlap of `L`'s competence with what other resident layers already cover
+  (mutual information in capability-space).
+
+Corollaries the formula enforces for free: a high-lift layer nobody uses dies (demand→0); a
+brilliant duplicate dies (redundancy→∞); a layer is kept only while its lift pays for its
+footprint.
+
+---
+
+## 4. The decision algorithm (mint / refine / merge / retire)
+
+The training signal lives in **embedding space** (§ the geometry). The decision is online
+clustering plus value-density eviction:
+
+- **Mint new** when incoming experience forms a **dense cluster far from every existing
+  layer's region** — a new mode in the distribution → a new specialist.
+- **Refine existing** when incoming experience falls **inside** an existing layer's region
+  (more of what that layer already covers) → continue-train that layer.
+- **Merge / distill** when two layers' regions have **drifted together** (centroids
+  converged / competence overlaps) → fuse into one (the sleep-phase consolidation).
+- **Retire / evict** when a layer is **dominated** by another or its **demand → 0** →
+  evict (cheap, because content-addressed layers are re-pullable from the grid).
+
+### The principled core
+
+"Join an existing thing vs. start a new one, without pre-specifying how many things exist"
+is exactly a **Dirichlet Process / Chinese Restaurant Process**: a new observation joins an
+existing cluster with probability ∝ its mass, or spawns a new cluster with probability ∝ a
+concentration parameter **α**. **α is the genome's one knob** — low α → few fat generalists
+(consolidate hard); high α → many thin specialists. The governor tunes α from hardware +
+demand. The guard against gratuitous minting is **MDL / Occam**: a new layer is warranted
+only when its marginal `lift` repays its description-length cost.
+
+### Analogs (the same algorithm in other clothes)
+
+Immune **clonal selection** (bind-well → proliferate, else die; memory cells consolidate) ·
+**NEAT speciation** (different-enough → new species = the mint threshold) · **wake-sleep**
+(explore awake, consolidate asleep) · **mixture-of-experts** (the genome *is* a sparse MoE
+of LoRA experts; routing = demand, pruning = redundancy) · **cache eviction** (ARC/LFU
+value-density = retire).
+
+---
+
+## 5. The maturity sequence — earn the emergent version
+
+**You cannot trust an emergent fitness function you have not validated.** A subtly-wrong
+fitness signal makes the machine confidently accumulate garbage *and report improvement* —
+the worst failure in the design. So the build is a sequence, not a leap:
+
+- **Phase A — Defined (bootstrap, ground truth).** Run the Academy with *known* exams and a
+  *defined* curriculum. Measure which signals — lift? demand? cluster-distance? — actually
+  **correlate with real improvement on the held-out set.** That correlation *is* the fitness
+  formula, discovered empirically rather than guessed.
+- **Phase B — Emergent (graduate).** Once the fitness signal is validated against ground
+  truth, drop the defined curriculum and let the §4 algorithm run definition-free, with the
+  defined exams retained as a **regression tripwire**.
+
+The prior Academy work (defined exams/curriculum) is **not the lesser idea** — it is the
+**scaffold that makes the ambitious idea safe.** It supplies the ground truth that calibrates
+the fitness function the emergent machine later runs on.
+
+---
+
+## 6. Build plan (slices, each VDD-gated)
+
+Every slice must move a measured number before the next is built. Same cadence the genome
+loop was built with: drive the engine, validate cheaply, adversarially review, merge.
+
+| # | Slice | Gate (the number) | Builds on |
+|---|---|---|---|
+| 1 | **A/B harness** — score base vs base+LoRA on a held-out set → `StandardVddRecord` | a non-zero, reproducible **lift** | gateway + forge/export + VDD |
+| 2 | **Fitness instrumentation** — capture lift × demand × cost × redundancy per layer | fitness ranks layers sensibly on a known set | §1, the WorkspaceCaptureSink |
+| 3 | **Curation layer** on `from-turns` — score-filter + preference-pairs-from-reviews + cluster-balanced sampling | trained-on-curated **beats** trained-on-raw (slice 1 delta) | from-turns + embeddings |
+| 4 | **Exam-as-recipe** — generate/hold-out set, grade, gate at threshold, regression guard | exam score predicts slice-1 lift | recipe runtime |
+| 5 | **Cascading curriculum DAG** — retroactive root-cause weighting | cascade-weighted training beats flat | §4 |
+| 6 | **Cohort / team training** — AP-Classroom comparative pairs + coordination capture | weak model improves toward strong after peer solutions | multi-persona room recipe |
+| 7 | **Decision algorithm** — online clustering mint/refine/merge/retire (§4) | emergent layer set matches the defined one on the bootstrap domain | §2 + §3 |
+| 8 | **Dream / consolidation sentinel** — idle-GPU score/dedup/weight/merge | disk + layer-count down, fitness preserved | §7, governor cadence |
+| 9 | **P2P exchange** — embed the layer card, emit to catalog, pull→verify→sandbox-eval→page | a peer's layer raises local lift without local training | forge/export card + GridTrust |
+
+Slice 1 is the keystone: until lift is a real, reproducible number, every later slice is a
+hypothesis. Build it first; let the rest fall out of the measurement.
+
+---
+
+## 7. Risks and containment
+
+| Risk | Containment |
+|---|---|
+| Garbage exhaust → garbage LoRA | Curation layer (slice 3); train only on scored/curated turns |
+| LLM-as-judge grading noise | Multi-judge quorum + the **regression guard** (never deploy a layer that scores worse than the one it replaces) |
+| Catastrophic forgetting across cycles | `ForgeRecipe.calibration_corpus` as the anti-forgetting anchor |
+| **Fitness miscalibration** (the worst one) | Phase A defined bootstrap — validate fitness against ground truth before trusting it |
+| Over-minting layers | MDL/Occam gate + low α: mint only when marginal lift repays complexity |
+| Paging/training cost on real hardware | Governor measures swap/train cost via VDD, tunes α + working-set; never a hardcoded constant |
+
+---
+
+## 8. What's built vs. the frontier
+
+- **Built (`canary`):** the genome loop (§2), the gateway, GridTrust, neural embeddings, the
+  forge produce-side (`train`/`export`).
+- **Frontier (this doc's slices):** the A/B measurement, fitness instrumentation, the curation
+  layer, the Academy recipes (exam/curriculum/cohort), the decision algorithm, the dream
+  sentinel, and P2P exchange.
+
+The discipline that makes it safe is the same throughout: **measure first, trust second,
+emerge last.** No hardcoded curriculum, no declared fitness, no configured layer count —
+but also no emergent autonomy until the number that justifies it is real.


### PR DESCRIPTION
## Slice 1 of the self-evolving genome (#1697)
The keystone of the whole evolution machine is a **real, reproducible `lift` number** — until lift exists, every later slice (fitness, curation, the decision algorithm) is a hypothesis. This is its deterministic measurement core.

## What
`vdd/score` takes a held-out eval set (`{prompt, expected, actual}` cases) + a match method (`contains` lenient default / `exact`) + a label, and returns the **accuracy** measurement (`correct/total → score ∈ [0,1]`) with per-case verdicts. The scorer (`case_correct` / `score_cases`) is **pure** — no model run — so the unit of measurement is pinned independently of any provider.

**The A/B composes it:** `lift = score(base+LoRA) − score(base)` — run `vdd/score` on the same set with each label and diff. The generation half (run the set through the unsloth gateway to produce `actual`) is the next brick.

## Tests (extend the vdd mod)
- `case_correct_methods`, `score_cases_counts_accuracy`
- the keystone: `vdd_score_measures_and_composes_into_lift` asserts **lift = 0.5** from two labeled runs
- 10/10 vdd tests pass.

See `docs/genome/SELF-EVOLVING-GENOME.md` (#1697) and memory `academy-training-design-corpus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)