### PR TITLE
fix(cognition): scope persona tool calls to the turn's room, not nil

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -190,15 +190,20 @@ impl LlmDeliberationFaculty {
         }
     }
 
-    /// Context for tool execution this tick. session/context ids are nil for now
-    /// (the Workspace cycle isn't session-scoped yet); they thread in when the
-    /// recipe-executor passes the live session — a follow-up, flagged not faked.
-    fn tool_context(&self) -> ToolExecutionContext {
+    /// Context for tool execution this tick. `context_id` is the room the turn
+    /// acts within (`ws.room_id`, the third ID tier) — so the persona's hands
+    /// scope every command to the SAME room the turn is about, never a phantom
+    /// `nil` room (the `scoped(nil)` bug). `session_id` stays nil deliberately:
+    /// it is the EPHEMERAL connection instance and is NEVER load-bearing for
+    /// where a tool action lands (per IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md A.5,
+    /// session never feeds trust or scope); it threads in only if/when a stable
+    /// session token is needed, separate from context.
+    fn tool_context(&self, ws: &Workspace) -> ToolExecutionContext {
         ToolExecutionContext {
             persona_id: self.persona_id,
             persona_name: self.persona_name.clone(),
             session_id: uuid::Uuid::nil(),
-            context_id: uuid::Uuid::nil(),
+            context_id: ws.room_id,
             caller_context: serde_json::Value::Null,
             persona_config: super::tool_executor::PersonaMediaConfigLite {
                 auto_load_media: false,
@@ -222,6 +227,7 @@ impl LlmDeliberationFaculty {
         &self,
         resp: &TextGenerationResponse,
         messages: &mut Vec<ChatMessage>,
+        ws: &Workspace,
     ) -> bool {
         if self.tools.is_empty() {
             return false;
@@ -241,7 +247,7 @@ impl LlmDeliberationFaculty {
         // then the results — the agent transcript the model reasons over next.
         messages.push(ChatMessage::assistant_tool_use(&calls));
         match executor
-            .execute_native_batch(&calls, &self.tool_context(), TOOL_RESULT_MAX_CHARS)
+            .execute_native_batch(&calls, &self.tool_context(ws), TOOL_RESULT_MAX_CHARS)
             .await
         {
             Ok(outcome) => {
@@ -410,7 +416,7 @@ impl Faculty for LlmDeliberationFaculty {
 
             if wants_tools
                 && iterations < self.max_tool_iterations
-                && self.try_tool_round(&resp, &mut messages).await
+                && self.try_tool_round(&resp, &mut messages, ws).await
             {
                 iterations += 1;
                 continue; // tools answered → re-generate over their results
@@ -603,6 +609,9 @@ mod tests {
     /// loop consumes native `tool_calls` and never parses or stores here.
     struct RecordingExecutor {
         calls: Mutex<Vec<ToolCall>>,
+        /// The contextId (room) the executor was handed — proves tool calls are
+        /// scoped to the turn's room, not a phantom nil.
+        seen_context: Mutex<Option<Uuid>>,
         result_content: String,
     }
 
@@ -611,9 +620,10 @@ mod tests {
         async fn execute_native_batch(
             &self,
             calls: &[ToolCall],
-            _ctx: &ToolExecutionContext,
+            ctx: &ToolExecutionContext,
             _max_result_chars: usize,
         ) -> Result<NativeBatchOutcome, ToolError> {
+            *self.seen_context.lock().unwrap() = Some(ctx.context_id);
             self.calls.lock().unwrap().extend_from_slice(calls);
             let results = calls
                 .iter()
@@ -669,6 +679,7 @@ mod tests {
         ]));
         let executor = Arc::new(RecordingExecutor {
             calls: Mutex::new(Vec::new()),
+            seen_context: Mutex::new(None),
             result_content: "deploy.md: fix merged 4pm, pipeline green".to_string(),
         });
 
@@ -709,6 +720,46 @@ mod tests {
             threaded,
             "re-prompt must thread the tool result back to the model"
         );
+    }
+
+    // what this catches: the nil-scope bug — tool calls MUST be scoped to the
+    // room the turn is for (ws.room_id = contextId), not Uuid::nil() (a phantom
+    // room). Regression here = a persona's hands act in the wrong room, which is
+    // both a correctness bug and a security one (commands land outside the
+    // authorized context). See IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md A.6 step 3.
+    #[tokio::test]
+    async fn tool_calls_are_scoped_to_the_turns_room() {
+        let persona = Uuid::new_v4();
+        let room = Uuid::new_v4();
+        let call = ToolCall {
+            id: "t1".to_string(),
+            name: "code/read".to_string(),
+            input: json!({ "path": "deploy.md" }),
+        };
+        let adapter = Arc::new(ScriptedAdapter::new(vec![
+            make_response(FinishReason::ToolUse, "", Some(vec![call])),
+            make_response(FinishReason::Stop, "done", None),
+        ]));
+        let executor = Arc::new(RecordingExecutor {
+            calls: Mutex::new(Vec::new()),
+            seen_context: Mutex::new(None),
+            result_content: "ok".to_string(),
+        });
+        let faculty = LlmDeliberationFaculty::new(persona, "Ivar", "You are Ivar.", adapter)
+            .with_tools(vec![read_tool()])
+            .with_tool_executor(executor.clone());
+
+        // Run the turn IN a specific room — the contextId the persona acts within.
+        let ws = Workspace::in_room("teammate asks: status?", room);
+        faculty.contribute(&ws).await.expect("verdict");
+
+        let seen = *executor.seen_context.lock().unwrap();
+        assert_eq!(
+            seen,
+            Some(room),
+            "tool execution must be scoped to the turn's room (contextId), not nil"
+        );
+        assert_ne!(seen, Some(Uuid::nil()), "must not be the phantom nil room");
     }
 
     // what this catches: the can_act gate. Tools authorized but NO executor

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -401,6 +401,7 @@ mod tests {
         // ---- EXACTLY what the LLM was fed (reconstruct the pre-deliberation ws) ----
         let context_ws = Workspace {
             world_state: burst.to_string(),
+            room_id: trace.room_id,
             broadcast: trace.context_broadcast.clone(),
         };
         let view = delib.prompt_view(&context_ws);

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures_util::future::join_all;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// Identifier for a cognitive faculty — a *structural name* (like a brain
 /// region), NOT a cognition decision. `Custom` keeps the set open so new
@@ -138,14 +139,31 @@ pub struct Workspace {
     /// The consolidated burst / world-state at service time. Opaque to the
     /// core — the channel/recipe adapter shapes it.
     pub world_state: String,
+    /// The CONTEXT this tick reasons within — the room/conversation the turn is
+    /// for (the third ID tier, contextId; see
+    /// docs/architecture/IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md Part A). Faculties
+    /// scope their actions to it: the deliberation faculty stamps tool calls with
+    /// this room so a persona's hands act in the SAME room the turn is about, not
+    /// a phantom `nil` room. `Uuid::nil()` only in faculty-isolation tests that
+    /// don't run in a room. NEVER a session id — context is durable, session is
+    /// ephemeral and never load-bearing for where an action lands.
+    pub room_id: Uuid,
     /// What entered the bounded workspace and is broadcast (the persona's "now").
     pub broadcast: Vec<Contribution>,
 }
 
 impl Workspace {
     pub fn new(world_state: impl Into<String>) -> Self {
+        Self::in_room(world_state, Uuid::nil())
+    }
+
+    /// Construct scoped to a specific room/context (the contextId the turn acts
+    /// within). The live persona path always uses this; `new` is the nil-room
+    /// shorthand for faculty-isolation tests.
+    pub fn in_room(world_state: impl Into<String>, room_id: Uuid) -> Self {
         Self {
             world_state: world_state.into(),
+            room_id,
             broadcast: Vec::new(),
         }
     }
@@ -249,6 +267,9 @@ impl Arbiter for SalienceArbiter {
 #[derive(Debug, Clone)]
 pub struct WorkspaceTrace {
     pub world_state: String,
+    /// The room/context this tick reasoned within (contextId) — so a replayed
+    /// trace correlates to the room it happened in, not a floating burst.
+    pub room_id: Uuid,
     /// ALL bids this tick, winners and losers, across BOTH phases — the full
     /// competition (perception phase-1 context bids + deliberation phase-2 bids).
     pub bids: Vec<Contribution>,
@@ -325,7 +346,19 @@ impl WorkspaceCycle {
     /// is never blind to recall. Still one tick over the consolidated burst, still
     /// `O(capacity)` for the bounded context — no per-event slowdown.
     pub async fn run(&self, world_state: impl Into<String>) -> Workspace {
-        let mut ws = Workspace::new(world_state);
+        self.run_in_room(world_state, Uuid::nil()).await
+    }
+
+    /// Same as [`run`](Self::run) but scoped to a room/context (the contextId the
+    /// turn acts within). The live persona path uses THIS so the deliberation
+    /// faculty stamps tool calls with the real room — `run` is the nil-room
+    /// shorthand for tests that aren't room-scoped.
+    pub async fn run_in_room(
+        &self,
+        world_state: impl Into<String>,
+        room_id: Uuid,
+    ) -> Workspace {
+        let mut ws = Workspace::in_room(world_state, room_id);
 
         // --- Phase 1: perception. Context faculties react to the raw world-state. ---
         let perception: Vec<&Arc<dyn Faculty>> = self
@@ -369,6 +402,7 @@ impl WorkspaceCycle {
         all_bids.extend(decision_bids);
         self.capture.record(&WorkspaceTrace {
             world_state: ws.world_state.clone(),
+            room_id: ws.room_id,
             bids: all_bids,
             context_broadcast,
             broadcast: ws.broadcast.clone(),

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -710,7 +710,18 @@ async fn serve_persona_loop_inner(
                 // WHERE). Recall (the persona's own memories) is injected by the
                 // RecallFaculty inside the cycle — so "given this RAG, do I have
                 // what I need?" is: this burst + recalled memory.
-                let ws = cycle.run(workspace_burst).await;
+                // Scope the cognition tick to the room this turn is FOR (the
+                // contextId), so the deliberation faculty stamps tool calls with
+                // it and the persona's hands act in the real room, not a phantom
+                // nil one. The serviced room is `ctx.identity.default_room` — the
+                // same room the burst header above declares. (IncomingMessage
+                // carries no per-message room yet; a per-message contextId on the
+                // cognition input is the deeper fix — A.6 / the missing context
+                // axis. Today default_room is the correct available context.)
+                // See IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md A.6 step 3.
+                let ws = cycle
+                    .run_in_room(workspace_burst, ctx.identity.default_room)
+                    .await;
                 phase_timings.respond_ms = respond_started.elapsed().as_millis() as u64;
                 match ws.decision() {
                     Some(crate::cognition::workspace::Decision::Speak { text })


### PR DESCRIPTION
## Problem (correctness + security)

The deliberation faculty built `ToolExecutionContext` with `context_id = Uuid::nil()`, so `command_executor`'s `scoped(ctx.context_id)` scoped **every persona tool call to a phantom nil room.** A persona's hands acted in the wrong room — and, per the trust model, that's a **security** bug too: commands land outside the authorized context.

This is the cognition instance of the identity-model work: per [IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md Part A](../blob/canary/docs/architecture/IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md) (airc #1273), **Context (the room / `contextId`) is the third ID tier and must be carried, never dropped to nil** — and never conflated with Session (which stays nil here, deliberately: it's ephemeral and not load-bearing for scope/trust, per A.5). A.6 step 3.

## Fix

Thread the turn's room through the cognition cycle:
- `Workspace` gains `room_id` (the contextId the tick reasons within). `Workspace::new` is the nil-room shorthand for faculty-isolation tests; `Workspace::in_room` / `WorkspaceCycle::run_in_room` carry the real room.
- `WorkspaceTrace` gains `room_id` so a replayed trace correlates to its room.
- `LlmDeliberationFaculty::tool_context(ws)` stamps `context_id = ws.room_id`; `session_id` stays `nil` deliberately.
- `service_loop` runs the cycle via `run_in_room(burst, ctx.identity.default_room)` — the room the burst header already declares.

### Note surfaced (not fixed here)
`IncomingMessage` carries no per-message room (`lamport`, `peer_id`, `text` only) — itself an instance of the missing context axis on the cognition input. A per-message `contextId` is the deeper follow-up; today `default_room` is the correct available context.

## Test

`tool_calls_are_scoped_to_the_turns_room` asserts the executor receives `context_id == the turn's room` (and never nil) — the regression guard for the nil-scope bug.

Full `cargo test -p continuum-core --lib`: **4599 pass**; the only failure is the known parallelism flake `record_turn_writes_fixture_json_under_home` (task #7 — passes in isolation, confirmed), unrelated to this change. No `#[derive(TS)]` types touched (ts-rs binding guard unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)