### PR TITLE
fix(memory): carry context (room) through consolidation, not session

### DIFF
--- a/core/continuum-core/src/memory/consolidation_adapter.rs
+++ b/core/continuum-core/src/memory/consolidation_adapter.rs
@@ -68,6 +68,13 @@ pub struct ConsolidatedMemory {
     pub id: Uuid,
     pub persona_id: Uuid,
     pub session_id: Uuid,
+    /// The room/conversation this memory belongs to (the contextId — the
+    /// third ID tier). Durable memory is keyed by (persona, context), NOT by
+    /// session: a session dies on reconnect but the persona must still recall
+    /// this room's memory. Sourced from the originating `Thought.context_id`.
+    /// `None` when the source thought carried no room (rare). See
+    /// docs/architecture/IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md A.6 step 4.
+    pub context_id: Option<Uuid>,
     /// Coerced down to a finite vocabulary at the corpus boundary;
     /// the adapter picks the best-fit type for each emitted memory.
     pub memory_type: MemoryType,

--- a/core/continuum-core/src/memory/consolidation_pipeline.rs
+++ b/core/continuum-core/src/memory/consolidation_pipeline.rs
@@ -54,12 +54,27 @@ pub fn to_corpus_memory(memory: &ConsolidatedMemory) -> CorpusMemory {
             }
             .to_string(),
             content: memory.content.clone(),
-            context: serde_json::json!({
-                "sessionId": memory.session_id.to_string(),
-                "synthesizedFrom": memory.synthesized_from.iter()
-                    .map(|u| u.to_string())
-                    .collect::<Vec<_>>(),
-            }),
+            // Tag the memory with its ROOM (contextId) — what recall scores on
+            // (recall.rs reads "roomId"). Previously this emitted only
+            // "sessionId", so the room bonus NEVER matched and memory lost its
+            // room affinity on reconnect. Emit the canonical "contextId" plus the
+            // "roomId" key recall reads today; keep sessionId as labelled session
+            // metadata (NOT a context substitute). Omit the room keys entirely
+            // when there's no context rather than writing nil.
+            context: {
+                let mut ctx = serde_json::json!({
+                    "sessionId": memory.session_id.to_string(),
+                    "synthesizedFrom": memory.synthesized_from.iter()
+                        .map(|u| u.to_string())
+                        .collect::<Vec<_>>(),
+                });
+                if let Some(context_id) = memory.context_id {
+                    let id = context_id.to_string();
+                    ctx["contextId"] = serde_json::json!(id);
+                    ctx["roomId"] = serde_json::json!(id);
+                }
+                ctx
+            },
             timestamp: ms_to_rfc3339(memory.timestamp_ms),
             importance: memory.importance,
             access_count: 0,
@@ -282,10 +297,12 @@ mod tests {
         // `MemoryType::Decision => "decision"` with
         // `MemoryType::Decision => "observation"` → memory_type
         // assertion fails. Reverted.
+        let room = Uuid::from_u128(0xC0);
         let m = ConsolidatedMemory {
             id: Uuid::from_u128(100),
             persona_id: Uuid::from_u128(42),
             session_id: Uuid::from_u128(7),
+            context_id: Some(room),
             memory_type: MemoryType::Decision,
             content: "chose path A".to_string(),
             importance: 0.9,
@@ -298,6 +315,19 @@ mod tests {
         let cm = to_corpus_memory(&m);
         assert_eq!(cm.record.memory_type, "decision");
         assert_eq!(cm.record.content, "chose path A");
+        // what this catches: the memory carries its ROOM under the key recall
+        // scores on ("roomId") + the canonical "contextId". Regression here =
+        // recall's room bonus silently never matches and memory loses room
+        // affinity on reconnect (it used to emit only "sessionId").
+        assert_eq!(
+            cm.record.context["roomId"].as_str(),
+            Some(room.to_string().as_str()),
+            "memory must carry its room under the key recall reads"
+        );
+        assert_eq!(
+            cm.record.context["contextId"].as_str(),
+            Some(room.to_string().as_str())
+        );
         assert_eq!(cm.record.importance, 0.9);
         assert_eq!(cm.record.tags, vec!["code".to_string()]);
         assert_eq!(cm.record.source.as_deref(), Some("consolidation"));

--- a/core/continuum-core/src/memory/raw_adapter.rs
+++ b/core/continuum-core/src/memory/raw_adapter.rs
@@ -36,6 +36,10 @@ impl ConsolidationAdapter for RawMemoryAdapter {
                 id: Uuid::new_v4(),
                 persona_id: context.persona_id,
                 session_id: context.session_id,
+                // Carry the thought's room forward as the memory's context — so
+                // recall can find it by room after a reconnect. 1:1 here, so each
+                // memory keeps its own thought's context_id.
+                context_id: t.context_id,
                 memory_type: MemoryType::from_thought_type(&t.thought_type),
                 content: t.content.clone(),
                 importance: t.importance,


### PR DESCRIPTION
## Problem (latent data-loss — fixed before it ships)

The memory consolidation boundary dropped the room. `ConsolidatedMemory` carried only `session_id`, and `to_corpus_memory()` emitted `"sessionId"` into the memory's context bag — but `recall.rs` scores its room bonus by reading **`"roomId"`**. So a consolidated memory's room affinity **never matched**: memory orphans from its conversation, and on reconnect would key off a dead session.

Per [IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md A.6 step 4](../blob/canary/docs/architecture/IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md): durable memory must be keyed by **(identity, context)**, never session.

## Fix

The source already had the room — `Thought.context_id` existed but was ignored at the adapter. Carry it through:
- `ConsolidatedMemory` gains `context_id: Option<Uuid>` (the room).
- `raw_adapter` maps `t.context_id → memory.context_id` (1:1, exact room).
- `to_corpus_memory` emits the canonical `"contextId"` **plus** the `"roomId"` key recall already reads; `sessionId` stays as labelled session metadata (not a context substitute); room keys omitted (not nil) when absent.
- `recall.rs` unchanged — it already reads `"roomId"`; the producer was wrong.

All structs are plain (`#[derive(Debug, Clone)]`) — **no ts-rs binding or sqlite schema change** (pure in-memory + JSON bag).

## Honest scope

The consolidation pipeline (`run_consolidation_pass`/`to_corpus_memory`) is **not yet live-wired** (only test callers; no production `Thought` producer). So this fixes a **latent** bug: the boundary now carries context correctly so the data-loss can never go live when the pipeline is wired. The `Engram` ORM `context_id` field (sqlite schema migration + ts-rs regen) is the separate deliberate follow-up — **task #39 part (b)**.

## Test

`to_corpus_memory` carries the room under both `"roomId"` (what recall reads) and `"contextId"`. `memory::` suite: **71 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)