### PR TITLE
feat(engram): key engrams by context (room) within the persona's identity

### DIFF
--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -210,6 +210,7 @@ mod tests {
         let state = Arc::new(AdmissionState::new(recall_meta.clone()));
         let id = Uuid::new_v4();
         let engram = Engram {
+            context_id: None,
             id,
             kind: EngramKind::Episodic,
             content: "the deploy pipeline went green after the 4pm fix".to_string(),

--- a/core/continuum-core/src/cognition/recall_faculty.rs
+++ b/core/continuum-core/src/cognition/recall_faculty.rs
@@ -268,6 +268,7 @@ mod tests {
             let id = Uuid::new_v4();
             ids.push(id);
             let engram = Engram {
+                context_id: None,
                 id,
                 kind: EngramKind::Episodic,
                 content: format!("memory body number {i}"),
@@ -456,6 +457,7 @@ mod tests {
             let mut mk = |content: &str, salience: f32, age_ms: u64| {
                 let id = Uuid::new_v4();
                 state.push_for_test(Engram {
+                    context_id: None,
                     id,
                     kind: EngramKind::Episodic,
                     content: content.to_string(),
@@ -628,6 +630,7 @@ mod tests {
             let mut mk = |content: &str, salience: f32, age: u64| {
                 let id = Uuid::new_v4();
                 state.push_for_test(Engram {
+                    context_id: None,
                     id,
                     kind: EngramKind::Episodic,
                     content: content.to_string(),

--- a/core/continuum-core/src/cognition/should_respond_module.rs
+++ b/core/continuum-core/src/cognition/should_respond_module.rs
@@ -118,6 +118,7 @@ mod tests {
         let state = Arc::new(AdmissionState::new(recall_meta.clone()));
         let id = Uuid::new_v4();
         let engram = Engram {
+            context_id: None,
             id,
             kind: EngramKind::Episodic,
             content: "we agreed to ship the deploy fix after review".to_string(),

--- a/core/continuum-core/src/persona/admission/mod.rs
+++ b/core/continuum-core/src/persona/admission/mod.rs
@@ -199,6 +199,10 @@ pub struct AdmissionContext<'a> {
     /// Wall-clock (epoch ms) at the start of this admission attempt.
     /// Recipes use this for `admitted_at_ms` + quarantine expiry.
     pub now_ms: u64,
+    /// The room/conversation this admission happens in (the contextId), so the
+    /// minted engram is keyed to its room within the persona's identity. `None`
+    /// for contextless admissions. See IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md A.
+    pub context_id: Option<Uuid>,
     /// Content-hash dedup oracle (recipe consults).
     pub seen_content: &'a dyn SeenContentLookup,
     /// Wire-event replay oracle (gate consults).
@@ -215,9 +219,17 @@ impl<'a> AdmissionContext<'a> {
         Self {
             config,
             now_ms: now_ms(),
+            context_id: None,
             seen_content,
             seen_events,
         }
+    }
+
+    /// Scope this admission to a room/conversation (the contextId), so minted
+    /// engrams are keyed to their room within the persona's identity.
+    pub fn with_context(mut self, context_id: Uuid) -> Self {
+        self.context_id = Some(context_id);
+        self
     }
 }
 
@@ -384,6 +396,7 @@ pub fn build_engram_from_candidate(
 ) -> Engram {
     Engram {
         id: Uuid::new_v4(),
+        context_id: ctx.context_id,
         kind: candidate.kind,
         content: candidate.content.clone(),
         origin: candidate.origin.clone(),
@@ -563,11 +576,39 @@ mod tests {
         events: &'a InMemoryEvents,
     ) -> AdmissionContext<'a> {
         AdmissionContext {
+            context_id: None,
             config,
             now_ms: FIXED_NOW_MS,
             seen_content: content,
             seen_events: events,
         }
+    }
+
+    // ── context (room) carried onto the engram ──────────────────────────
+
+    // what this catches: an admitted engram carries its ROOM (contextId) from
+    // the admission context, so a persona's memory is keyed to the conversation
+    // it happened in (within the persona's identity), not contextless. Regression
+    // here = engrams lose their room and per-room recall can't scope. See
+    // docs/architecture/IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md Part A.
+    #[test]
+    fn admitted_engram_carries_its_room_context() {
+        let cfg = AdmissionConfig::permissive_v1();
+        let content = InMemoryContent::default();
+        let events = InMemoryEvents::default();
+        let room = Uuid::new_v4();
+        let ctx = permissive_ctx(&cfg, &content, &events).with_context(room);
+        let cand = candidate(
+            "remember this",
+            TrustState::ApprovedPeer,
+            EngramOrigin::Airc(airc_ref("msg-ctx", "sig", "hash", "v1")),
+        );
+        let engram = build_engram_from_candidate(&cand, &ctx);
+        assert_eq!(
+            engram.context_id,
+            Some(room),
+            "engram must carry the room it was admitted in"
+        );
     }
 
     // ── envelope verification ───────────────────────────────────────────
@@ -717,6 +758,7 @@ mod tests {
         let content = InMemoryContent::default();
         let events = InMemoryEvents::default();
         let ctx = AdmissionContext {
+            context_id: None,
             config: &cfg,
             now_ms: FIXED_NOW_MS,
             seen_content: &content,

--- a/core/continuum-core/src/persona/admission/recipes.rs
+++ b/core/continuum-core/src/persona/admission/recipes.rs
@@ -204,6 +204,7 @@ mod tests {
         events: &'a InMemoryEvents,
     ) -> AdmissionContext<'a> {
         AdmissionContext {
+            context_id: None,
             config: cfg,
             seen_content: content,
             seen_events: events,

--- a/core/continuum-core/src/persona/admission_persistence.rs
+++ b/core/continuum-core/src/persona/admission_persistence.rs
@@ -402,6 +402,7 @@ mod tests {
 
     fn sample_engram(content: &str) -> Engram {
         Engram {
+            context_id: None,
             id: Uuid::new_v4(),
             kind: EngramKind::Episodic,
             content: content.to_string(),

--- a/core/continuum-core/src/persona/admission_state.rs
+++ b/core/continuum-core/src/persona/admission_state.rs
@@ -833,6 +833,7 @@ mod tests {
 
     fn synthetic_engram_with_chat_origin(content: &str) -> Engram {
         Engram {
+            context_id: None,
             id: Uuid::new_v4(),
             kind: EngramKind::Episodic,
             content: content.to_string(),
@@ -852,6 +853,7 @@ mod tests {
 
     fn synthetic_engram_with_airc_origin(content: &str, message_id: &str) -> Engram {
         Engram {
+            context_id: None,
             id: Uuid::new_v4(),
             kind: EngramKind::Episodic,
             content: content.to_string(),

--- a/core/continuum-core/src/persona/engram.rs
+++ b/core/continuum-core/src/persona/engram.rs
@@ -78,6 +78,17 @@ pub struct Engram {
     #[entity(primary_key)]
     pub id: Uuid,
 
+    /// The room/conversation this memory belongs to — the contextId, the
+    /// third ID tier (see docs/architecture/IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md
+    /// Part A). A persona's engram store IS its identity's memory; within that one
+    /// identity, memory is sub-keyed by context (room) so recall can scope to a
+    /// conversation. Indexed: per-room recall is a common filter. `None` for
+    /// engrams with no room (self-reflection, contextless admissions). NEVER a
+    /// session id — context is durable, session is ephemeral.
+    #[ts(optional, type = "string")]
+    #[entity(indexed)]
+    pub context_id: Option<Uuid>,
+
     /// Engram category — episodic vs semantic vs procedural vs meta.
     /// Indexed: recall by kind ("show me all Episodic engrams") is a
     /// common filter.
@@ -524,6 +535,7 @@ mod tests {
 
     fn sample_engram() -> Engram {
         Engram {
+            context_id: None,
             id: Uuid::nil(),
             kind: EngramKind::Episodic,
             content: "Test content".to_string(),

--- a/core/continuum-core/src/persona/engram_source.rs
+++ b/core/continuum-core/src/persona/engram_source.rs
@@ -295,6 +295,7 @@ mod tests {
         // source's scoring + packing behavior.
         for i in 0..count {
             let engram = Engram {
+                context_id: None,
                 id: Uuid::new_v4(),
                 kind: EngramKind::Episodic,
                 content: format!("engram body number {i}"),

--- a/core/continuum-core/src/persona/inbox_admission.rs
+++ b/core/continuum-core/src/persona/inbox_admission.rs
@@ -259,7 +259,11 @@ impl<R: IsMemorable> InboxAdmissionRunner<R> {
         trace: Option<&mut CognitionTrace>,
     ) -> Result<AdmissionDecision, AdmissionError> {
         let candidate = inbox_message_to_candidate(msg, &self.trust_mapping);
-        let ctx = AdmissionContext::new(&self.config, seen_content, seen_events);
+        // Scope the admission to the message's room (the contextId), so the
+        // minted engram is keyed to its conversation within the persona's
+        // identity (per IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md Part A).
+        let ctx = AdmissionContext::new(&self.config, seen_content, seen_events)
+            .with_context(msg.room_id);
         AdmissionGate::admit(&candidate, &self.recipe, &ctx, trace)
     }
 }

--- a/core/continuum-core/src/persona/recall_metadata.rs
+++ b/core/continuum-core/src/persona/recall_metadata.rs
@@ -905,6 +905,7 @@ mod tests {
             .expect("metadata store");
 
         let engram = Engram {
+            context_id: None,
             id: Uuid::new_v4(),
             kind: EngramKind::Episodic,
             content: "anchor".to_string(),

--- a/core/continuum-core/src/persona/unified.rs
+++ b/core/continuum-core/src/persona/unified.rs
@@ -482,6 +482,7 @@ mod tests {
 
     fn make_test_engram(now_ms: u64, idx: usize) -> Engram {
         Engram {
+            context_id: None,
             id: Uuid::new_v4(),
             kind: EngramKind::Episodic,
             content: format!("test engram body {idx}"),

--- a/protocol/typescript/persona/Engram.ts
+++ b/protocol/typescript/persona/Engram.ts
@@ -24,6 +24,16 @@ export type Engram = {
  */
 id: string, 
 /**
+ * The room/conversation this memory belongs to — the contextId, the
+ * third ID tier (see docs/architecture/IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md
+ * Part A). A persona's engram store IS its identity's memory; within that one
+ * identity, memory is sub-keyed by context (room) so recall can scope to a
+ * conversation. Indexed: per-room recall is a common filter. `None` for
+ * engrams with no room (self-reflection, contextless admissions). NEVER a
+ * session id — context is durable, session is ephemeral.
+ */
+contextId?: string, 
+/**
  * Engram category — episodic vs semantic vs procedural vs meta.
  * Indexed: recall by kind ("show me all Episodic engrams") is a
  * common filter.


### PR DESCRIPTION
## Step 4b of the identity model

A persona's engram store **is** its identity's memory ([IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md Part A](../blob/canary/docs/architecture/IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md): `persona ⟷ engram db = one identity`). Within that one identity, memory must be sub-keyed by **context (room)** — never session — so recall can scope to a conversation and a persona's memory stays organized as it moves across rooms (and, later, across the grid).

## ORM-only, no migration

- `Engram` gains `context_id: Option<Uuid>` (indexed). **Pure entity field** — the ORM owns persistence; the SQLite adapter's `evolve_table_schema` auto-`ALTER`s the column on an existing `engrams.sqlite` (old rows → NULL → `None`). No hand-written SQL, no migration, no recreate.
- `AdmissionContext` gains `context_id` + a `with_context(room)` builder; `build_engram_from_candidate` stamps it onto the minted engram.
- The **live** admission path (`inbox_admission::admit`) scopes to `msg.room_id`, so chat-driven engrams carry their room. `context_id` is never a session id (durable context vs ephemeral session — A.5).
- ts-rs binding regenerated: `Engram.ts` gains `contextId?: string` (Rust-macro artifact, CI binding-drift guard satisfied).

## Test

`admitted_engram_carries_its_room_context` asserts the room flows from the admission context onto the engram. Full `cargo test -p continuum-core --lib`: **4600 pass**; the only failure is the known parallelism flake `record_turn_writes_fixture_json_under_home` (task #7 — passes in isolation), unrelated.

Completes #39 (the part b that was gated on migration — purist no-migration ruling unblocked it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)