### PR TITLE
feat(unsloth): auto-fuel the engine at startup (#24 wiring)

### DIFF
--- a/core/continuum-core/src/inference/unsloth_control.rs
+++ b/core/continuum-core/src/inference/unsloth_control.rs
@@ -90,6 +90,61 @@ pub async fn ensure_model_loaded(api: &dyn UnslothControl, desired_model: &str) 
     }
 }
 
+/// Startup decision: should boot fuel the engine, and with which model?
+/// Pure + inspectable so the config logic is TDD-tested apart from any I/O —
+/// we never hardcode a machine-specific model path; the model is config-driven.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StartupModelAction {
+    /// `UNSLOTH_MODEL` is set + non-empty → ensure this model is loaded at boot.
+    Ensure(String),
+    /// No model configured → skip auto-fuel (with the reason, for the log). The
+    /// engine stays as-is; a persona's first inference will surface the empty
+    /// engine, and the operator can set `UNSLOTH_MODEL` to auto-fuel next boot.
+    Skip(String),
+}
+
+/// Decide the boot action from the configured `UNSLOTH_MODEL` value. Trims
+/// whitespace; an unset OR blank value → [`StartupModelAction::Skip`]. No
+/// default model is baked in — auto-picking from `/api/hub/cached-models` is a
+/// future enhancement, not a hardcoded path.
+pub fn startup_model_action(configured: Option<String>) -> StartupModelAction {
+    match configured.map(|s| s.trim().to_string()) {
+        Some(model) if !model.is_empty() => StartupModelAction::Ensure(model),
+        _ => StartupModelAction::Skip(
+            "UNSLOTH_MODEL unset — skipping auto-fuel; set it to load a model at boot".to_string(),
+        ),
+    }
+}
+
+/// Boot convenience: read `UNSLOTH_MODEL` from config, and if set, ensure unsloth
+/// has it loaded (delegating to [`ensure_model_loaded`] over the real HTTP
+/// surface). Degrade-safe end to end — logs the outcome and never panics, so it
+/// can be spawned as a fire-and-forget startup task. Returns the action taken so
+/// callers/tests can assert without scraping logs.
+pub async fn ensure_startup_model() -> StartupModelAction {
+    let action = startup_model_action(config_env::read("UNSLOTH_MODEL"));
+    match &action {
+        StartupModelAction::Ensure(model) => {
+            let outcome = ensure_model_loaded(&UnslothHttp::from_config(), model).await;
+            match &outcome {
+                EnsureOutcome::AlreadyLoaded => {
+                    tracing::info!(target: "unsloth", model = %model, "startup: model already loaded");
+                }
+                EnsureOutcome::Loaded { model } => {
+                    tracing::info!(target: "unsloth", model = %model, "startup: loaded model into engine");
+                }
+                EnsureOutcome::Degraded { reason } => {
+                    tracing::warn!(target: "unsloth", %reason, "startup: model auto-fuel degraded — substrate continues on fallback");
+                }
+            }
+        }
+        StartupModelAction::Skip(reason) => {
+            tracing::info!(target: "unsloth", %reason, "startup: skipping model auto-fuel");
+        }
+    }
+    action
+}
+
 /// Real reqwest impl of [`UnslothControl`] over unsloth's HTTP surface.
 pub struct UnslothHttp {
     /// Host root (no `/v1`), e.g. `http://127.0.0.1:8888`.
@@ -251,5 +306,46 @@ mod tests {
             }
             other => panic!("expected Degraded, got {other:?}"),
         }
+    }
+
+    // what this catches: a configured model name → Ensure(that model). This is
+    // the "automatic after the key" path — boot fuels the engine from config.
+    #[test]
+    fn configured_model_means_ensure() {
+        assert_eq!(
+            startup_model_action(Some("qwen2.5-0.5b".to_string())),
+            StartupModelAction::Ensure("qwen2.5-0.5b".to_string())
+        );
+    }
+
+    // what this catches: NO hardcoded default — unset config must Skip, not load
+    // some machine-specific path. Regression here = a baked-in model path that's
+    // wrong on every box but the one it was written on.
+    #[test]
+    fn unset_model_skips_no_hardcoded_default() {
+        match startup_model_action(None) {
+            StartupModelAction::Skip(_) => {}
+            other => panic!("expected Skip, got {other:?}"),
+        }
+    }
+
+    // what this catches: a blank/whitespace UNSLOTH_MODEL is treated as unset
+    // (config files love empty strings) — Skip, never attempt to load "".
+    #[test]
+    fn blank_model_is_treated_as_unset() {
+        match startup_model_action(Some("   ".to_string())) {
+            StartupModelAction::Skip(_) => {}
+            other => panic!("expected Skip for blank, got {other:?}"),
+        }
+    }
+
+    // what this catches: a configured value with surrounding whitespace is
+    // trimmed before use — `UNSLOTH_MODEL=qwen \n` must not request " qwen ".
+    #[test]
+    fn configured_model_is_trimmed() {
+        assert_eq!(
+            startup_model_action(Some("  qwen2.5-0.5b  ".to_string())),
+            StartupModelAction::Ensure("qwen2.5-0.5b".to_string())
+        );
     }
 }

--- a/core/continuum-core/src/main.rs
+++ b/core/continuum-core/src/main.rs
@@ -357,6 +357,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
+    // Auto-fuel unsloth (#24): "automatic after the key." unsloth Studio boots
+    // EMPTY — nothing serves until a model is loaded — so on startup we ensure
+    // the configured `UNSLOTH_MODEL` is loaded into the engine. Fire-and-forget
+    // and fully degrade-safe (UNSLOTH_MODEL unset → skip+log; engine down/load
+    // fails → degrade+log, the substrate stays up on its fallback path; never
+    // panics). Spawned concurrently so boot isn't gated on the engine.
+    tokio::spawn(async move {
+        continuum_core::inference::unsloth_control::ensure_startup_model().await;
+    });
+
     // Initialize TTS/STT in background (non-blocking - happens after startup)
     // Wrapped in catch_unwind because ORT panics (not errors) when libonnxruntime.dylib
     // is missing. A missing TTS/STT model must NEVER crash the entire server.


### PR DESCRIPTION
## What

Wires the #24 keystone (`ensure_model_loaded`, merged in #1712) into core
startup so the engine is fueled **automatically after the key** — the
"install → it's just running" UX.

unsloth Studio boots **EMPTY**: `/v1/models` returns `[]` and any inference
returns *"No GGUF model loaded"* until something loads one. On startup the core
now spawns `ensure_startup_model()`: it reads `UNSLOTH_MODEL` from config and,
if set, ensures that model is loaded into the engine over unsloth's HTTP
management surface.

## How

- **`startup_model_action(Option<String>) -> StartupModelAction`** — the pure,
  TDD-tested config decision. `set+non-empty → Ensure(model)`; `unset or blank
  → Skip(reason)`. **No hardcoded default model path** — auto-picking from
  `/api/hub/cached-models` is a future enhancement, not a baked-in path.
- **`ensure_startup_model()`** — dispatches on the action, delegating to
  `ensure_model_loaded` over the real HTTP surface (`UnslothHttp::from_config`),
  logging the outcome.
- **`main.rs`** — spawned fire-and-forget alongside the other boot tasks. Boot
  is never gated on the engine, and it's fully **degrade-safe**: engine down or
  load fails → degrade+log, the substrate stays up on its fallback path, never
  panics (#26).

## Tests

4 new unit tests over the pure config decision:
- `configured_model_means_ensure`
- `unset_model_skips_no_hardcoded_default`
- `blank_model_is_treated_as_unset`
- `configured_model_is_trimmed`

Existing keystone tests unchanged (8 pass total in `unsloth_control`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)