### PR TITLE
feat(persona): give the persona HANDS — wire tool execution into the live brain (#15)

### DIFF
--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -61,6 +61,15 @@ pub struct PersonaBrainConfig {
     ///
     /// [`resolve_recall_embedder`]: super::embedding::resolve_recall_embedder
     pub embedder: Option<Arc<dyn EmbeddingProvider>>,
+    /// The persona's HANDS. `Some` → the deliberation faculty is offered the
+    /// dynamic `AiSafe` tool surface ([`ai_safe_tool_specs`]) and routes the
+    /// model's tool calls through this executor (a `CommandToolExecutor` carrying
+    /// the persona's identity, so the `GridTrustAuthPolicy` ACL gates execution).
+    /// `None` → speak-only (no tools offered) — the safe default for harnesses and
+    /// for any persona whose spawn path hasn't built an executor.
+    ///
+    /// [`ai_safe_tool_specs`]: super::persona_tools::ai_safe_tool_specs
+    pub tool_executor: Option<Arc<dyn crate::cognition::tool_executor::ToolExecutor>>,
 }
 
 /// A grounding [`RagSource`] plus the [`SaliencePolicy`] under which it competes
@@ -131,12 +140,23 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     }
 
     // The reasoner runs in phase 2 over everything the perception tier surfaced.
-    faculties.push(Arc::new(LlmDeliberationFaculty::new(
+    // With a tool executor (the persona's HANDS), it's offered the dynamic AiSafe
+    // tool surface and can ACT, not just speak — every tool call routed through
+    // the persona's identity-bearing executor, so the ACL gates what it may do.
+    // Without one, it's speak-only (the safe default). The tool SURFACE is the
+    // single source of truth (`command_registry × AiSafe`), never hardcoded.
+    let mut deliberation = LlmDeliberationFaculty::new(
         cfg.persona_id,
         cfg.persona_name,
         cfg.system_prompt,
         cfg.adapter,
-    )));
+    );
+    if let Some(executor) = cfg.tool_executor {
+        deliberation = deliberation
+            .with_tools(super::persona_tools::ai_safe_tool_specs())
+            .with_tool_executor(executor);
+    }
+    faculties.push(Arc::new(deliberation));
 
     WorkspaceCycle::new(
         faculties,
@@ -259,6 +279,7 @@ mod tests {
             capacity: None,
             grounding_sources: Vec::new(),
             embedder: None,
+            tool_executor: None,
         }
     }
 

--- a/core/continuum-core/src/cognition/should_respond_module.rs
+++ b/core/continuum-core/src/cognition/should_respond_module.rs
@@ -159,6 +159,7 @@ mod tests {
             capacity: None,
             grounding_sources: Vec::new(),
             embedder: None,
+            tool_executor: None,
         });
         registry
     }

--- a/core/continuum-core/src/cognition/tool_executor/command_executor.rs
+++ b/core/continuum-core/src/cognition/tool_executor/command_executor.rs
@@ -45,8 +45,10 @@ use super::types::{
 };
 use super::ToolExecutor;
 use crate::ai::types::{ToolCall as NativeToolCall, ToolResult as NativeToolResult};
-use crate::runtime::InProcessTransport;
+use crate::routing::CallerIdentity;
+use crate::runtime::{CommandExecutor, InProcessTransport};
 use continuum_client::{ClientError, Connection};
+use std::sync::Arc;
 
 /// Routes a persona's native tool calls to core commands through the uniform
 /// `continuum_client` [`Connection`] over the local [`InProcessTransport`]. The
@@ -66,6 +68,23 @@ pub struct CommandToolExecutor {
 impl CommandToolExecutor {
     pub fn new(conn: Connection<InProcessTransport>) -> Self {
         Self { conn }
+    }
+
+    /// Build a persona's hands over the uniform client: a
+    /// `Connection<InProcessTransport>` carrying the persona's OWN
+    /// [`CallerIdentity`], dispatching through the **substrate's wired**
+    /// [`CommandExecutor`] (the one `start_server` built with the
+    /// [`GridTrustAuthPolicy`](crate::routing::GridTrustAuthPolicy) + interceptors).
+    ///
+    /// Taking the wired executor — NOT a fresh `CommandExecutor::new(registry)`,
+    /// which has an AllowAll default policy and no interceptors — is the
+    /// load-bearing security choice: the identity makes the persona gated AS
+    /// ITSELF, so an Owner-gated command (`data/delete`, `grid/trust`) is REFUSED
+    /// at execution even though it may appear in the tool surface. Offer = the
+    /// `AiSafe` surface; execute = authorized-by-identity ([[persona-is-a-client]]).
+    pub fn for_persona(executor: Arc<CommandExecutor>, persona: Uuid) -> Self {
+        let transport = InProcessTransport::new(executor, Some(CallerIdentity::airc(persona)));
+        Self::new(Connection::new(transport))
     }
 }
 
@@ -196,7 +215,6 @@ impl ToolExecutor for CommandToolExecutor {
 mod tests {
     use super::*;
     use crate::cognition::tool_executor::types::PersonaMediaConfigLite;
-    use crate::routing::CallerIdentity;
     use crate::runtime::{
         CommandExecutor, CommandResult, ModuleConfig, ModuleContext, ModulePriority,
         ModuleRegistry, ServiceModule,
@@ -260,9 +278,10 @@ mod tests {
     /// lands in the next slice of #15 — this executor is not yet wired into
     /// cognition.
     fn exec_over(registry: Arc<ModuleRegistry>, persona: Uuid) -> CommandToolExecutor {
+        // Exercises the SAME production factory the spawn path uses, over an
+        // executor built from this test registry.
         let executor = Arc::new(CommandExecutor::new(registry));
-        let transport = InProcessTransport::new(executor, Some(CallerIdentity::airc(persona)));
-        CommandToolExecutor::new(Connection::new(transport))
+        CommandToolExecutor::for_persona(executor, persona)
     }
 
     fn executor_with_echo() -> CommandToolExecutor {

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1259,7 +1259,12 @@ pub fn start_server(
     // spawned supervisor task can safely dereference `executor()` in
     // its eventual `bootstrap_one` calls. None in `--mode=inference-only`
     // where personas are not hosted at all.
-    let mut persona_supervisor_executor_ready_tx: Option<tokio::sync::oneshot::Sender<()>> = None;
+    // Carries the WIRED executor (GridTrustAuthPolicy + interceptors) to the
+    // persona supervisor task once it's built — both the readiness signal AND the
+    // executor the personas' hands ride. One channel, two jobs (order + payload).
+    let mut persona_supervisor_executor_ready_tx: Option<
+        tokio::sync::oneshot::Sender<Arc<crate::runtime::CommandExecutor>>,
+    > = None;
 
     if let Some((daemon_socket, default_room)) = persona_bootstrap_deps {
         let continuum_root = crate::modules::persona_instance_manager::resolve_continuum_root();
@@ -1440,22 +1445,26 @@ pub fn start_server(
         // The spawn task literally cannot reach `executor()` before
         // the global is initialized — the ordering is enforced by
         // the channel, not by relative I/O latency.
-        let (executor_ready_tx, executor_ready_rx) = tokio::sync::oneshot::channel::<()>();
+        let (executor_ready_tx, executor_ready_rx) =
+            tokio::sync::oneshot::channel::<Arc<crate::runtime::CommandExecutor>>();
         persona_supervisor_executor_ready_tx = Some(executor_ready_tx);
         rt_handle.spawn(async move {
-            // Wait for the IPC thread to signal `init_executor` done.
-            // If the sender is dropped without sending (substrate
-            // shutdown mid-boot), exit cleanly without attempting
-            // to bootstrap personas against an uninitialized
-            // executor.
-            if executor_ready_rx.await.is_err() {
-                tracing::warn!(
-                    "persona supervisor task aborting: executor-ready signal dropped \
-                     before fire (substrate shutdown mid-boot? init_executor never \
-                     reached?). No personas bootstrapped this run."
-                );
-                return;
-            }
+            // Wait for the IPC thread to deliver the WIRED executor (this both
+            // gates ordering AND hands us the executor the personas' hands ride).
+            // If the sender is dropped without sending (substrate shutdown
+            // mid-boot), exit cleanly without bootstrapping personas against an
+            // uninitialized executor.
+            let tool_executor = match executor_ready_rx.await {
+                Ok(ex) => ex,
+                Err(_) => {
+                    tracing::warn!(
+                        "persona supervisor task aborting: executor-ready signal dropped \
+                         before fire (substrate shutdown mid-boot? init_executor never \
+                         reached?). No personas bootstrapped this run."
+                    );
+                    return;
+                }
+            };
             use crate::persona::resume_or_mint_provider::ResumeOrMintProvider;
             let mut provider =
                 match ResumeOrMintProvider::new(&continuum_root_for_boot, 1).await {
@@ -1470,7 +1479,9 @@ pub fn start_server(
                         return;
                     }
                 };
-            let summary = supervisor.spawn_all(&mut provider).await;
+            let summary = supervisor
+                .spawn_all(&mut provider, Some(tool_executor))
+                .await;
             tracing::info!(
                 hosted = summary.hosted,
                 failed = summary.failed(),
@@ -1679,7 +1690,9 @@ pub fn start_server(
     // means the receiver was dropped — substrate shutdown mid-boot —
     // and the supervisor already exited; ignoring is correct.
     if let Some(tx) = persona_supervisor_executor_ready_tx.take() {
-        let _ = tx.send(());
+        // Deliver the WIRED executor (GridTrustAuthPolicy + interceptors) — the
+        // personas' hands ride exactly this, so the ACL gates what they touch.
+        let _ = tx.send(Arc::clone(&executor));
     }
 
     let listener = UnixListener::bind(socket_path)?;

--- a/core/continuum-core/src/persona/host.rs
+++ b/core/continuum-core/src/persona/host.rs
@@ -259,6 +259,11 @@ impl PersonaSpawnSupervisor {
     pub async fn spawn_all(
         &self,
         provider: &mut dyn PersonaIdentityProvider,
+        // The substrate's wired `CommandExecutor` (GridTrustAuthPolicy +
+        // interceptors), delivered through the executor-ready oneshot. Each
+        // persona's HANDS are built over it (identity-scoped), so the ACL gates
+        // what they may do. `None` → personas spawn speak-only (no hands).
+        tool_command_executor: Option<Arc<crate::runtime::CommandExecutor>>,
     ) -> BootSummary {
         let plans = match bootstrap_planned(
             &self.spawner,
@@ -302,11 +307,28 @@ impl PersonaSpawnSupervisor {
         // [[personas-are-citizens-airc-is-identity-provider]] the
         // citizen type is what the substrate carries; the concrete
         // runtime is one impl among future BaseUser variants.
-        let hosted_results = materialize_adapters(plans, &*self.factory, move |pid| {
-            registry_for_lookup
-                .get(pid)
-                .map(|r| r as Arc<dyn crate::persona::airc_citizen::AircCitizen>)
-        })
+        // Per-persona HANDS: a CommandToolExecutor over the wired executor,
+        // scoped to the persona's identity (so the ACL gates it). Cheap — each is
+        // an Arc bump on the shared executor + connection. `None` executor →
+        // every persona is speak-only.
+        let tool_exec_source = tool_command_executor.clone();
+        let hosted_results = materialize_adapters(
+            plans,
+            &*self.factory,
+            move |pid| {
+                registry_for_lookup
+                    .get(pid)
+                    .map(|r| r as Arc<dyn crate::persona::airc_citizen::AircCitizen>)
+            },
+            move |pid| {
+                tool_exec_source.clone().map(|ex| {
+                    Arc::new(crate::cognition::tool_executor::CommandToolExecutor::for_persona(
+                        ex, pid,
+                    ))
+                        as Arc<dyn crate::cognition::tool_executor::ToolExecutor>
+                })
+            },
+        )
         .await;
 
         let mut summary = BootSummary::default();

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -401,6 +401,15 @@ pub async fn materialize_adapters(
     plans: Vec<MaterializedPersonaPlan>,
     factory: &dyn PersonaAdapterFactory,
     runtime_lookup: impl Fn(uuid::Uuid) -> Option<Arc<dyn AircCitizen>>,
+    // The persona's HANDS, built per persona by the caller (the `ipc` bootstrap,
+    // which holds the command `ModuleRegistry`). Closure DI keeps the supervisor
+    // decoupled from the command runtime — same shape as `runtime_lookup`. Returns
+    // `None` → that persona is speak-only. The executor carries the persona's
+    // identity, so the `GridTrustAuthPolicy` ACL gates what its hands may touch.
+    tool_executor_for: impl Fn(
+        uuid::Uuid,
+    )
+        -> Option<Arc<dyn crate::cognition::tool_executor::ToolExecutor>>,
 ) -> Vec<Result<PersonaContext, SupervisorError>> {
     let mut out = Vec::with_capacity(plans.len());
     for (slot_index, plan) in plans.into_iter().enumerate() {
@@ -590,6 +599,9 @@ pub async fn materialize_adapters(
                             doctrine_source,
                         ),
                     ],
+                    // The persona's HANDS — built by the caller for THIS persona's
+                    // identity (None → speak-only). What turns "talks" into "acts".
+                    tool_executor: tool_executor_for(identity.persona_id),
                 },
             )),
         );
@@ -783,7 +795,7 @@ mod tests {
 
         let factory = ScriptedPersonaAdapterFactory::heuristic();
         let hosted =
-            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup()).await;
+            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup(), |_| None).await;
 
         assert_eq!(hosted.len(), 2);
         assert_eq!(factory.build_count(), 2);
@@ -829,7 +841,7 @@ mod tests {
 
         let factory = ScriptedPersonaAdapterFactory::heuristic();
         let hosted =
-            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup()).await;
+            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup(), |_| None).await;
 
         assert_eq!(hosted.len(), 2);
         // Factory called exactly once — for the Ok row only.
@@ -864,7 +876,7 @@ mod tests {
         let factory =
             ScriptedPersonaAdapterFactory::always_fails("simulated factory rejection");
         let hosted =
-            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup()).await;
+            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup(), |_| None).await;
 
         assert_eq!(hosted.len(), 1);
         match &hosted[0] {
@@ -887,7 +899,7 @@ mod tests {
     #[tokio::test]
     async fn empty_plans_yields_empty_hosted() {
         let factory = ScriptedPersonaAdapterFactory::heuristic();
-        let hosted = materialize_adapters(vec![], &factory, |_| None).await;
+        let hosted = materialize_adapters(vec![], &factory, |_| None, |_| None).await;
         assert!(hosted.is_empty());
         assert_eq!(factory.build_count(), 0);
     }
@@ -916,7 +928,7 @@ mod tests {
         let factory = ScriptedPersonaAdapterFactory::heuristic();
         // `|_| None` here is the substrate-bug shape we're locking in:
         // the registry exists but doesn't contain this persona_id.
-        let hosted = materialize_adapters(plans, &factory, |_| None).await;
+        let hosted = materialize_adapters(plans, &factory, |_| None, |_| None).await;
 
         assert_eq!(hosted.len(), 1);
         // Factory MUST NOT be called when the runtime lookup fails —
@@ -975,7 +987,7 @@ mod tests {
                     as Arc<dyn crate::persona::airc_citizen::AircCitizen>)
             }
         };
-        let hosted = materialize_adapters(plans, &factory, lookup).await;
+        let hosted = materialize_adapters(plans, &factory, lookup, |_| None).await;
 
         assert_eq!(hosted.len(), 2);
         // Factory ran exactly once — for Paige, not Pax.
@@ -1019,7 +1031,7 @@ mod tests {
 
         let (factory, counts) = ScriptedPersonaAdapterFactory::heuristic_with_counters();
         let hosted =
-            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup()).await;
+            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup(), |_| None).await;
 
         // Both slots materialize cleanly.
         assert_eq!(hosted.len(), 2);
@@ -1049,7 +1061,7 @@ mod tests {
             "simulated warmup failure",
         );
         let hosted =
-            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup()).await;
+            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup(), |_| None).await;
 
         assert_eq!(hosted.len(), 1);
         match &hosted[0] {
@@ -1084,7 +1096,7 @@ mod tests {
             profile: Ok(fake_profile("Paige", "model-a")),
         }];
         let hosted_ok =
-            materialize_adapters(ok_plan, &factory_ok, StubAircCitizen::fresh_lookup())
+            materialize_adapters(ok_plan, &factory_ok, StubAircCitizen::fresh_lookup(), |_| None)
                 .await;
         assert!(hosted_ok[0].is_ok(), "ok-warmup adapter materializes");
         assert_eq!(ok_counts.warmups(), 1);
@@ -1101,6 +1113,7 @@ mod tests {
             fail_plan,
             &factory_fail,
             StubAircCitizen::fresh_lookup(),
+            |_| None,
         )
         .await;
         assert!(


### PR DESCRIPTION
## What

The deliberation faculty could already **decide** to act (it emits native
`tool_use` calls), but `build_workspace_cycle` constructed it **speak-only** — no
executor, so the live persona could talk but never touch the world. This wires the
persona's **nervous system**: the model's tool calls now route to the core's
command surface (the same catalog the MCP server exposes).

## The chain

- **`CommandToolExecutor::for_persona(executor, persona)`** — production factory.
  Takes the substrate's **wired** `Arc<CommandExecutor>` (the one `start_server`
  builds with `GridTrustAuthPolicy` + interceptors), **not** a fresh
  `CommandExecutor::new` (AllowAll default, no interceptors). This is the
  load-bearing **security** choice: the transport carries
  `CallerIdentity::airc(persona)`, so the persona is gated **as itself** — an
  Owner-gated command (`data/delete`, `grid/trust`) is **refused at execution**
  even if it appears in the tool surface.
- **`PersonaBrainConfig.tool_executor`** — `Some` → `build_workspace_cycle` offers
  the dynamic AiSafe tool surface (`ai_safe_tool_specs()` = `command_registry ×
  AiSafe`, nothing hardcoded) and wires the executor; `None` → speak-only (safe
  default).
- **`materialize_adapters`** gains a `tool_executor_for` closure (same closure-DI
  shape as `runtime_lookup`) — keeps the supervisor decoupled from the command
  runtime.
- The wired executor reaches the spawn task through the **existing executor-ready
  oneshot**: it now carries `Arc<CommandExecutor>` instead of `()` — one channel,
  both the ordering gate **and** the payload the hands ride.

## Security model (stated)

**Offer = the AiSafe surface; Execute = authorized-by-identity** through
`GridTrustAuthPolicy`. Two independent layers, so a broad tool surface never
widens what a persona may actually *do*.

## Tests

Covered by composition (each layer independently tested):
- `for_persona` via the 20 `command_executor` tests
- identity→ACL path via `in_process_transport::scoped_persona_client_dispatches_with_identity_and_context`
- acts-then-speaks via `llm_deliberation_faculty::persona_acts_then_speaks_threading_tool_results`

Binary + `persona_workspace` + `supervisor` all green. (Live end-to-end — Asha
running a real command — is the integration proof, to validate on the running core.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)