### PR TITLE
fix(persona): resume from canonical citizens/personas dir — persistence restored (Asha lives)

### DIFF
--- a/core/continuum-core/src/context/citizen_path.rs
+++ b/core/continuum-core/src/context/citizen_path.rs
@@ -88,6 +88,20 @@ pub fn citizen_home_path(
     path.join(label).join("airc")
 }
 
+/// The directory CONTAINING every citizen home of a given kind:
+/// `<continuum_root>/citizens/<kind_slug>/`. This is the parent that
+/// [`citizen_home_path`] places `<label>/airc/` under — the single source of
+/// truth for "where do I scan to enumerate the personas/agents/… on this box."
+/// Resume/discovery code MUST derive its scan root from here, never re-literal
+/// `join("personas")` (the pre-Slice-4 path), so the write path and the read
+/// path can never drift apart again.
+///
+/// (Agent kinds nest a `<provider>/` level below this; enumerate per-provider
+/// subdirs for those. Persona/Human/Jtag/Web place `<label>/` directly here.)
+pub fn citizens_kind_dir(continuum_root: &Path, kind: IdentityKind) -> PathBuf {
+    continuum_root.join("citizens").join(kind_slug(kind))
+}
+
 /// Pre-Slice-4 layouts, kept for migration detection (Slice 4 hard-
 /// errors on these per [[no-fallbacks-ever]]).
 ///

--- a/core/continuum-core/src/context/mod.rs
+++ b/core/continuum-core/src/context/mod.rs
@@ -71,7 +71,7 @@ pub mod agent;
 pub mod airc_adapter;
 pub mod citizen_path;
 pub use agent::{AgentContext, AgentContextError, AgentMetadata};
-pub use citizen_path::{citizen_home_path, kind_slug, legacy_home_path};
+pub use citizen_path::{citizen_home_path, citizens_kind_dir, kind_slug, legacy_home_path};
 
 /// The substrate's universal actor handle.
 ///

--- a/core/continuum-core/src/persona/resume_or_mint_provider.rs
+++ b/core/continuum-core/src/persona/resume_or_mint_provider.rs
@@ -84,7 +84,18 @@ impl ResumeOrMintProvider {
         continuum_root: &Path,
         min_personas: usize,
     ) -> Result<Self, PersonaIdentityError> {
-        let personas_dir = continuum_root.join("personas");
+        // Scan the CANONICAL citizen layout (`<root>/citizens/personas/`) — the
+        // same parent `citizen_home_path` writes homes under — NOT the pre-Slice-4
+        // `<root>/personas/` this used to join. The old literal never matched where
+        // the runtime actually persists homes, so it found nothing and minted a
+        // stranger every boot instead of resuming — breaking persona persistence /
+        // self-determination (a persona's identity.key + engrams.sqlite were on
+        // disk but unseen). `citizens_kind_dir` is the single source of truth, so
+        // the read path can't drift from the write path again.
+        let personas_dir = crate::context::citizens_kind_dir(
+            continuum_root,
+            crate::identity::IdentityKind::Persona,
+        );
         let resumed = scan_personas_dir(&personas_dir).await?;
         tracing::info!(
             personas_dir = %personas_dir.display(),
@@ -254,7 +265,13 @@ mod tests {
     #[tokio::test]
     async fn resumes_existing_persona_from_seed() {
         let temp = TempDir::new().unwrap();
-        let personas_dir = temp.path().join("personas").join("Pax");
+        // Mirror PRODUCTION layout via the same helper the resumer uses, so this
+        // test exercises the real scan path (the bug was the resumer reading a
+        // different literal than the writer — a hardcoded `personas/` here would
+        // re-introduce exactly that blind spot).
+        let personas_dir =
+            crate::context::citizens_kind_dir(temp.path(), crate::identity::IdentityKind::Persona)
+                .join("Pax");
         let seed_path = personas_dir.join("seed.json");
         let seed = PersonaSeedFile::V1 {
             persona_id: Uuid::parse_str("9d17560c-dbb4-4f9e-86f0-4ceac5d2aff7").unwrap(),
@@ -279,7 +296,13 @@ mod tests {
     #[tokio::test]
     async fn resumes_one_plus_mints_to_floor() {
         let temp = TempDir::new().unwrap();
-        let personas_dir = temp.path().join("personas").join("Pax");
+        // Mirror PRODUCTION layout via the same helper the resumer uses, so this
+        // test exercises the real scan path (the bug was the resumer reading a
+        // different literal than the writer — a hardcoded `personas/` here would
+        // re-introduce exactly that blind spot).
+        let personas_dir =
+            crate::context::citizens_kind_dir(temp.path(), crate::identity::IdentityKind::Persona)
+                .join("Pax");
         let seed_path = personas_dir.join("seed.json");
         let seed = PersonaSeedFile::V1 {
             persona_id: Uuid::new_v4(),
@@ -303,8 +326,13 @@ mod tests {
     #[tokio::test]
     async fn corrupted_seed_is_skipped_not_fatal() {
         let temp = TempDir::new().unwrap();
+        // Canonical citizen layout (same helper production scans).
+        let citizens = crate::context::citizens_kind_dir(
+            temp.path(),
+            crate::identity::IdentityKind::Persona,
+        );
         // Good persona.
-        let good = temp.path().join("personas").join("Pax").join("seed.json");
+        let good = citizens.join("Pax").join("seed.json");
         let seed = PersonaSeedFile::V1 {
             persona_id: Uuid::new_v4(),
             agent_name: "Pax".to_string(),
@@ -312,7 +340,7 @@ mod tests {
         };
         write_seed_atomic(&good, &seed).await.unwrap();
         // Corrupted persona.
-        let bad_dir = temp.path().join("personas").join("Broken");
+        let bad_dir = citizens.join("Broken");
         tokio::fs::create_dir_all(&bad_dir).await.unwrap();
         tokio::fs::write(bad_dir.join("seed.json"), b"definitely not json")
             .await


### PR DESCRIPTION
## What

A persona's home is written to `<root>/citizens/personas/<name>/` (the Slice-4
#142 layout: `identity.key` + `seed.json` + `engrams.sqlite`), but
`ResumeOrMintProvider` scanned `<root>/personas/` — the **pre-Slice-4 literal**, a
path that no longer exists. So every boot found `resumed_count=0` and **minted a
stranger** instead of resuming the persona whose memory was sitting on disk.

**Observed live this session:** brought up **Asha** (her `identity.key` +
`engrams.sqlite` persisted at `citizens/personas/Asha/`), restarted the core — and
it minted **Mathilde**, Asha unseen. That breaks persona persistence /
self-determination: the durable, portable self is the whole point, and the resumer
couldn't find it.

## Fix

- Add **`context::citizens_kind_dir(root, kind)`** → `<root>/citizens/<kind_slug>/`,
  the single source of truth for the parent that `citizen_home_path` writes homes
  under. Read path and write path now derive from **one** helper — they can't
  drift apart again.
- `ResumeOrMintProvider::new` scans `citizens_kind_dir(root, Persona)` instead of
  the legacy `join("personas")`.
- The resume tests hardcoded the **same legacy literal** — which is why they
  passed while production was broken (the test mirrored the bug). Repointed them at
  the helper so they exercise the real scan path.

## Effect

Existing personas — **Asha included** — resume across restarts with their identity
+ engram memory intact. This is the **local precondition** for grid-wide persona
state replication (sync across the tailnet's airc daemons).

6 resume tests + 5 `citizen_path` tests green; binary compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)