### PR TITLE
feat(vdd): JsonlWorkspaceCaptureSink — make the LIVE brain observable (#14)

### DIFF
--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -57,6 +57,7 @@ pub mod types;
 pub mod validate_response;
 pub mod vision_describe;
 pub mod workspace;
+pub mod workspace_capture;
 
 pub use adaptive_throughput::*;
 pub use model_resolver::*;

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -158,11 +158,37 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     }
     faculties.push(Arc::new(deliberation));
 
-    WorkspaceCycle::new(
+    let cycle = WorkspaceCycle::new(
         faculties,
         Arc::new(SalienceArbiter),
         cfg.capacity.unwrap_or(DEFAULT_WORKSPACE_CAPACITY),
-    )
+    );
+
+    // Make the LIVE brain observable: capture every tick's full competition (all
+    // bids incl. losers, the assembled context the decider saw, the decision) to
+    // a per-persona JSONL. The always-on recorder watches the legacy respond()
+    // path; THIS is what instruments the path that actually runs. Best-effort —
+    // if the fixtures dir can't be opened we log and run with Noop capture; a
+    // persona's mind never fails to assemble over an observability hiccup.
+    match std::env::var("HOME").map(|h| {
+        std::path::Path::new(&h).join(".continuum/fixtures/workspace-traces")
+    }) {
+        Ok(dir) => match super::workspace_capture::JsonlWorkspaceCaptureSink::open(
+            &dir,
+            cfg.persona_id,
+        ) {
+            Ok(sink) => cycle.with_capture(Arc::new(sink)),
+            Err(e) => {
+                tracing::warn!(
+                    persona_id = %cfg.persona_id,
+                    error = %e,
+                    "workspace trace capture unavailable; running with Noop capture"
+                );
+                cycle
+            }
+        },
+        Err(_) => cycle, // HOME unset — opt-out, no capture (no warning spam)
+    }
 }
 
 /// Persona-scoped registry of continuous minds. One `Arc<WorkspaceCycle>` per

--- a/core/continuum-core/src/cognition/workspace_capture.rs
+++ b/core/continuum-core/src/cognition/workspace_capture.rs
@@ -1,0 +1,229 @@
+//! JSONL capture for live `WorkspaceCycle` ticks — the mechanic's glass box on
+//! the **live** brain.
+//!
+//! The always-on persona recorder (`persona::recorder`) watches the LEGACY
+//! `respond()` path. The live decision path is the [`WorkspaceCycle`], whose
+//! [`WorkspaceCaptureSink`] defaults to `Noop` — so today the real mind runs
+//! unobserved. This is the recording impl that fixes that: every tick → one
+//! JSONL line carrying **every faculty bid (winners AND losers)** with its
+//! content + salience, the **assembled context the decider actually saw** (the
+//! "RAG"), and the **decision**. So "did recall surface the engram into what the
+//! model reasoned over?" is a one-look answer, never a guess.
+//!
+//! Per OBSERVABILITY-AS-SUBSTRATE.md (capture is half the brain) + VDD: knowing
+//! the exact inputs + the full attention competition beats any log. Best-effort:
+//! a write failure is logged and dropped, NEVER fails the cognition turn —
+//! observability is not load-bearing ([[substrate-is-a-good-citizen-on-the-host]]).
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use uuid::Uuid;
+
+use super::workspace::{Contribution, Decision, WorkspaceCaptureSink, WorkspaceTrace};
+
+/// Bumped when the on-disk record shape changes (replay readers gate on it).
+const SCHEMA_VERSION: u32 = 1;
+
+/// One faculty's bid, projected to a serializable shape. The internal
+/// [`Contribution`] is intentionally NOT `Serialize` (it's a live cognition
+/// type) — we own the wire format here so the capture schema can evolve
+/// independently of the in-memory type.
+#[derive(Debug, Serialize)]
+struct BidRecord {
+    /// Which faculty bid (recall / world-model / deliberation / …).
+    faculty: String,
+    /// The faculty's self-assigned salience (0..=1) — why it won or lost.
+    salience: f32,
+    /// The faculty's audit reasoning.
+    reasoning: String,
+    /// The actual content it surfaced — for recall, THIS is the engram text the
+    /// decider would see; the load-bearing field for "was memory present?".
+    content: String,
+    /// True for the deliberation faculty's verdict bid (the one carrying a Decision).
+    is_decision: bool,
+}
+
+impl From<&Contribution> for BidRecord {
+    fn from(c: &Contribution) -> Self {
+        Self {
+            faculty: c.faculty.as_str().to_string(),
+            salience: c.salience,
+            reasoning: c.reasoning.clone(),
+            content: c.content.clone(),
+            is_decision: c.decision.is_some(),
+        }
+    }
+}
+
+/// One serialized workspace tick — the full mechanic's view of one turn's mind.
+#[derive(Debug, Serialize)]
+struct WorkspaceTraceRecord {
+    schema_version: u32,
+    captured_at_ms: u64,
+    persona_id: String,
+    room_id: String,
+    /// The consolidated burst the mind reasoned over this tick.
+    world_state: String,
+    /// EVERY bid this tick (winners + losers, both phases) — the full competition.
+    bids: Vec<BidRecord>,
+    /// The assembled context that won attention and reached the decider (the RAG).
+    context: Vec<BidRecord>,
+    /// The participation decision that emerged, if any (kebab-tagged).
+    decision: Option<Decision>,
+}
+
+/// Appends one JSON line per workspace tick to a per-persona JSONL file
+/// (`<dir>/<persona_id>.jsonl`). Mirrors `JsonlRagCaptureSink`'s shape.
+pub struct JsonlWorkspaceCaptureSink {
+    persona_id: Uuid,
+    file: Mutex<File>,
+}
+
+impl JsonlWorkspaceCaptureSink {
+    /// Open (create + append) the per-persona trace file under `dir`, creating
+    /// `dir` if needed. Returns an error only on filesystem failure; the caller
+    /// degrades to `Noop` capture on error (never fails persona spawn).
+    pub fn open(dir: &Path, persona_id: Uuid) -> std::io::Result<Self> {
+        std::fs::create_dir_all(dir)?;
+        let path = dir.join(format!("{persona_id}.jsonl"));
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self {
+            persona_id,
+            file: Mutex::new(file),
+        })
+    }
+
+    fn now_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0)
+    }
+}
+
+impl WorkspaceCaptureSink for JsonlWorkspaceCaptureSink {
+    fn record(&self, trace: &WorkspaceTrace) {
+        let rec = WorkspaceTraceRecord {
+            schema_version: SCHEMA_VERSION,
+            captured_at_ms: Self::now_ms(),
+            persona_id: self.persona_id.to_string(),
+            room_id: trace.room_id.to_string(),
+            world_state: trace.world_state.clone(),
+            bids: trace.bids.iter().map(BidRecord::from).collect(),
+            context: trace.context_broadcast.iter().map(BidRecord::from).collect(),
+            decision: trace.decision.clone(),
+        };
+        let line = match serde_json::to_string(&rec) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(target: "cognition::capture", error = %e, "workspace trace serialize failed; dropped");
+                return;
+            }
+        };
+        // Best-effort append; a failed write must never break the turn.
+        if let Ok(mut f) = self.file.lock() {
+            if let Err(e) = writeln!(f, "{line}") {
+                tracing::warn!(target: "cognition::capture", error = %e, "workspace trace write failed; dropped");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cognition::workspace::{Contribution, Decision, FacultyId};
+
+    // what this catches: THE core VDD property — a captured tick must round-trip
+    // to disk with every faculty's bid CONTENT intact (so "was the recalled engram
+    // actually present for the decider?" is answerable from the fixture), plus the
+    // assembled context and the decision. If this regresses, the live brain goes
+    // dark again and we're back to guessing from logs.
+    #[tokio::test]
+    async fn captures_bids_context_and_decision_to_jsonl() {
+        let dir = std::env::temp_dir().join(format!("ws-cap-{}", Uuid::new_v4()));
+        let persona = Uuid::new_v4();
+        let room = Uuid::new_v4();
+        let sink = JsonlWorkspaceCaptureSink::open(&dir, persona).unwrap();
+
+        let recall = Contribution {
+            faculty: FacultyId::Recall,
+            content: "the deploy went red after the auth migration".to_string(),
+            salience: 0.8,
+            reasoning: "relevant past engram".to_string(),
+            decision: None,
+        };
+        let verdict = Contribution {
+            faculty: FacultyId::Deliberation,
+            content: "Let's roll back the migration.".to_string(),
+            salience: 0.9,
+            reasoning: "decider".to_string(),
+            decision: Some(Decision::Speak {
+                text: "Let's roll back the migration.".to_string(),
+            }),
+        };
+        let trace = WorkspaceTrace {
+            world_state: "teammate: what should we do about the red deploy?".to_string(),
+            room_id: room,
+            bids: vec![recall.clone(), verdict.clone()],
+            context_broadcast: vec![recall.clone()],
+            broadcast: vec![recall, verdict],
+            decision: Some(Decision::Speak {
+                text: "Let's roll back the migration.".to_string(),
+            }),
+        };
+        sink.record(&trace);
+
+        // Read the one JSONL line back and assert the load-bearing fields survived.
+        let path = dir.join(format!("{persona}.jsonl"));
+        let body = std::fs::read_to_string(&path).unwrap();
+        let line = body.lines().next().expect("one trace line");
+        let v: serde_json::Value = serde_json::from_str(line).unwrap();
+
+        assert_eq!(v["persona_id"], persona.to_string());
+        assert_eq!(v["room_id"], room.to_string());
+        // The recall ENGRAM content is captured (the whole point — memory visibility).
+        let bids = v["bids"].as_array().unwrap();
+        assert!(
+            bids.iter().any(|b| b["faculty"] == "recall"
+                && b["content"]
+                    .as_str()
+                    .unwrap()
+                    .contains("auth migration")),
+            "recall bid content must be captured: {bids:?}"
+        );
+        // The assembled context (what the decider saw) is captured separately.
+        assert_eq!(v["context"].as_array().unwrap().len(), 1);
+        // The decision round-trips with its kebab tag.
+        assert_eq!(v["decision"]["kind"], "speak");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // what this catches: append semantics — two ticks = two JSONL lines, so a
+    // turn-by-turn history accumulates (replay reads line-by-line).
+    #[tokio::test]
+    async fn appends_one_line_per_tick() {
+        let dir = std::env::temp_dir().join(format!("ws-cap-{}", Uuid::new_v4()));
+        let persona = Uuid::new_v4();
+        let sink = JsonlWorkspaceCaptureSink::open(&dir, persona).unwrap();
+        let mk = |room| WorkspaceTrace {
+            world_state: "burst".to_string(),
+            room_id: room,
+            bids: vec![],
+            context_broadcast: vec![],
+            broadcast: vec![],
+            decision: None,
+        };
+        sink.record(&mk(Uuid::new_v4()));
+        sink.record(&mk(Uuid::new_v4()));
+        let body = std::fs::read_to_string(dir.join(format!("{persona}.jsonl"))).unwrap();
+        assert_eq!(body.lines().count(), 2, "one line per tick");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
## What

**VDD instrument, slice 1.** The always-on persona recorder watches the **legacy**
`respond()` path; the live decision path is the `WorkspaceCycle`, whose
`WorkspaceCaptureSink` defaulted to `Noop` — so the mind that actually runs ran
**unobserved.** (Confirmed by inspecting on-disk fixtures: the only captures are
`respond()`-path turns with `systemPrompt: null` — not the cycle.) That's why
diagnosing Asha's confabulation meant guessing from log lines.

## How

`JsonlWorkspaceCaptureSink` records **every `WorkspaceCycle` tick** to a per-persona
JSONL (`~/.continuum/fixtures/workspace-traces/<persona_id>.jsonl`):
- every faculty **bid incl. losers** — recall's bid *content* is the engram text
  the decider saw (the load-bearing field for "was memory actually present?")
- the **assembled context** that won attention (the RAG the decider read)
- the **decision**

Wired into `build_workspace_cycle` via the existing `with_capture` seam.
Best-effort: degrades to `Noop` on FS error, never fails persona spawn
(observability is not load-bearing).

## Why it matters

This is the measuring instrument the rest of the cognition work is validated
through — *half the work is harnesses.* It's also the **prerequisite for deleting
the legacy `respond()` fallback**: you instrument the real path before you remove
the dead one (legacy gets *deleted, not kept as a fallback* — next slice).

## Tests

Own module (`cognition/workspace_capture.rs`); `WorkspaceTraceRecord` owns the wire
format so it evolves independently of the live `Contribution` type. 2 tests:
bids+context+decision round-trip with content intact; one-line-per-tick append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)