### PR TITLE
feat(persona): route reasoning through unsloth (native tools) + one owner for the unsloth endpoint

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -140,6 +140,18 @@ impl OpenAICompatibleAdapter {
         self
     }
 
+    /// The host root that request URLs append `/v1/...` to — the runtime override
+    /// if set, else the configured base. ONE resolution point for all request
+    /// sites (was copy-pasted 4×). The value is already canonical (bare host): the
+    /// catalog stores bare hosts, and the unsloth gateway is registered with the
+    /// single [`unsloth_base_url`](crate::inference::unsloth_control::unsloth_base_url)
+    /// accessor — so no per-site normalization is needed or wanted here.
+    fn api_base(&self) -> &str {
+        self.runtime_base_url
+            .as_deref()
+            .unwrap_or(self.config.base_url.as_str())
+    }
+
     /// Fetch the live model list from the provider's /v1/models endpoint.
     /// Used by adapters that have dynamic catalogs (DMR above all — the list
     /// changes every time the user runs `docker model pull`). Populates
@@ -147,10 +159,7 @@ impl OpenAICompatibleAdapter {
     /// data is preferred over empty data. Never silently succeeds with an
     /// empty set — returns Err if the endpoint responds with nothing.
     async fn refresh_runtime_models(&self) -> Result<(), String> {
-        let base_url = self
-            .runtime_base_url
-            .as_deref()
-            .unwrap_or(self.config.base_url.as_str());
+        let base_url = self.api_base();
         let url = format!("{}/v1/models", base_url);
 
         let mut req = self.client.get(&url);
@@ -753,10 +762,7 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         }
 
         // Make request - use runtime base URL if set, otherwise config base URL
-        let base_url = self
-            .runtime_base_url
-            .as_deref()
-            .unwrap_or(self.config.base_url.as_str());
+        let base_url = self.api_base();
         let url = format!("{}/v1/chat/completions", base_url);
 
         let mut request_builder = self
@@ -956,10 +962,7 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
 
         let body = build_embedding_body(&request.input, &model);
 
-        let base_url = self
-            .runtime_base_url
-            .as_deref()
-            .unwrap_or(self.config.base_url.as_str());
+        let base_url = self.api_base();
         let url = format!("{base_url}/v1/embeddings");
 
         let mut request_builder = self
@@ -1021,10 +1024,7 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         let start = Instant::now();
 
         // Try to list models as health check
-        let base_url = self
-            .runtime_base_url
-            .as_deref()
-            .unwrap_or(self.config.base_url.as_str());
+        let base_url = self.api_base();
         let url = format!("{}/v1/models", base_url);
 
         let mut request_builder = self

--- a/core/continuum-core/src/inference/unsloth_control.rs
+++ b/core/continuum-core/src/inference/unsloth_control.rs
@@ -25,8 +25,30 @@ use serde_json::json;
 
 use crate::config_env;
 
-/// Default unsloth host when `UNSLOTH_BASE_URL` is unset.
-const DEFAULT_HOST: &str = "http://127.0.0.1:8888";
+/// Default unsloth host when `UNSLOTH_BASE_URL` is unset. THE one constant for
+/// the default endpoint — referenced by [`unsloth_base_url`] and the provider
+/// catalog, so the default lives in exactly one place.
+pub const DEFAULT_HOST: &str = "http://127.0.0.1:8888";
+
+/// **THE one accessor for the unsloth endpoint.** The single place that reads the
+/// `UNSLOTH_BASE_URL` setting (or [`DEFAULT_HOST`]) and returns the canonical
+/// **host root** (no trailing `/v1`, no trailing slash). Every consumer asks
+/// `unsloth_control` for this — the keystone's HTTP client AND the gateway
+/// adapter registration — so the endpoint lives in ONE form, read in ONE place.
+/// No other module reads `UNSLOTH_BASE_URL` or strips `/v1` on its own.
+///
+/// Callers append their own path: serving is `{base}/v1/...`, management is
+/// `{base}/api/...`. Accepting an operator-pasted `…/v1` and normalizing it here
+/// (once) is why there is no double-`/v1` 405 anywhere.
+pub fn unsloth_base_url() -> String {
+    let raw = config_env::read("UNSLOTH_BASE_URL").unwrap_or_else(|| DEFAULT_HOST.to_string());
+    let trimmed = raw.trim_end_matches('/');
+    trimmed
+        .strip_suffix("/v1")
+        .unwrap_or(trimmed)
+        .trim_end_matches('/')
+        .to_string()
+}
 
 /// What `ensure_model_loaded` did — the inspectable outcome.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -154,18 +176,12 @@ pub struct UnslothHttp {
 }
 
 impl UnslothHttp {
-    /// Build from config: `UNSLOTH_BASE_URL` (the `/v1` URL) + `UNSLOTH_API_KEY`.
-    /// We derive the host root by stripping a trailing `/v1`, since the model
-    /// management lives under `/api/*` and serving under `/v1/*` on the same host.
+    /// Build from config via the single [`unsloth_base_url`] accessor (host root)
+    /// + `UNSLOTH_API_KEY`. No env read or `/v1` handling here — that lives in the
+    /// one accessor.
     pub fn from_config() -> Self {
-        let base = config_env::read("UNSLOTH_BASE_URL").unwrap_or_else(|| DEFAULT_HOST.to_string());
-        let host = base
-            .trim_end_matches('/')
-            .trim_end_matches("/v1")
-            .trim_end_matches('/')
-            .to_string();
         Self {
-            host,
+            host: unsloth_base_url(),
             api_key: config_env::read("UNSLOTH_API_KEY"),
             client: reqwest::Client::new(),
         }

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1423,7 +1423,11 @@ pub fn start_server(
             crate::persona::spawner_module::PersonaSpawnerModule::new(hw_cap, tier_cat)
                 .with_serving(serving_model, serving_lanes),
             instance_manager.clone(),
-            std::sync::Arc::new(crate::persona::supervisor::LlamaCppPersonaAdapterFactory),
+            // Persona reasoning routes through the unsloth gateway: native
+            // function-calling (the persona's HANDS actually fire) for free,
+            // vs the in-process llama.cpp adapter which silently dropped tools.
+            // Joel 2026-06-21; [[unsloth-universal-model-gateway]].
+            std::sync::Arc::new(crate::persona::supervisor::UnslothPersonaAdapterFactory),
             tier_id,
             crate::model_registry::global(),
             rt_handle.clone(),

--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -534,7 +534,11 @@ pub fn providers() -> Vec<Provider> {
         provider(ProviderSpec {
             id: "unsloth",
             name: "Unsloth (universal model gateway)",
-            base_url: "http://127.0.0.1:8888/v1",
+            // THE one constant for the default endpoint. At registration the
+            // adapter is given the runtime value from `unsloth_control::unsloth_base_url()`
+            // (the single accessor), so the endpoint has one owner; this is just
+            // the compile-time default, kept identical via the shared const.
+            base_url: crate::inference::unsloth_control::DEFAULT_HOST,
             api_key_env: Some("UNSLOTH_API_KEY"),
             default_model: Some("continuum-ai/qwen3.5-4b-code-forged-GGUF"),
             auth: AuthKind::Bearer,

--- a/core/continuum-core/src/modules/ai_provider.rs
+++ b/core/continuum-core/src/modules/ai_provider.rs
@@ -372,7 +372,11 @@ impl AIProviderModule {
         // is a separate routing-policy change.
         if get_secret("UNSLOTH_API_KEY").is_some() {
             self.log().info("Registering Unsloth gateway adapter");
-            let mut a = OpenAICompatibleAdapter::from_registry("unsloth");
+            // Base URL comes from the ONE owner of the unsloth endpoint
+            // (`unsloth_control::unsloth_base_url`) — not the catalog literal — so
+            // there is a single source of truth for where unsloth lives.
+            let mut a = OpenAICompatibleAdapter::from_registry("unsloth")
+                .with_runtime_base_url(crate::inference::unsloth_control::unsloth_base_url());
             match a.initialize().await {
                 Ok(()) => registry.register(Arc::new(a), 9),
                 Err(e) => self.log().warn(&format!("Unsloth initialize failed: {e} — not registered")),

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -86,6 +86,36 @@ impl PersonaAdapterFactory for LlamaCppPersonaAdapterFactory {
     }
 }
 
+/// Routes a persona's reasoning through the **unsloth gateway** (the
+/// OpenAI-compatible `/v1` adapter). Chosen 2026-06-21 (Joel) over teaching the
+/// in-process llama.cpp adapter tool-calling: unsloth does **native function
+/// calling for free** (the OpenAI-compatible adapter already sends `tools` +
+/// parses `tool_calls` → `FinishReason::ToolUse`), so the persona's HANDS
+/// actually fire instead of the model narrating fake tool use. Aligns with
+/// "lean on unsloth, delete redundant code" ([[unsloth-universal-model-gateway]]):
+/// the in-process chat path becomes redundant (a later delete).
+///
+/// All personas share the one gateway adapter (it's a meta-provider); the model
+/// served is unsloth's loaded model (`UNSLOTH_MODEL` — point it at the 4b
+/// code-forged GGUF so reasoning isn't downgraded to the 0.5B). Requests carry
+/// `model: None`, so unsloth uses its loaded model.
+pub struct UnslothPersonaAdapterFactory;
+
+#[async_trait]
+impl PersonaAdapterFactory for UnslothPersonaAdapterFactory {
+    async fn build_adapter(
+        &self,
+        _profile: &PersonaInferenceProfile,
+    ) -> Result<Arc<dyn AIProviderAdapter>, String> {
+        let mut adapter = crate::ai::openai_adapter::OpenAICompatibleAdapter::from_registry("unsloth");
+        adapter
+            .initialize()
+            .await
+            .map_err(|e| format!("Unsloth persona adapter initialize failed: {e}"))?;
+        Ok(Arc::new(adapter))
+    }
+}
+
 /// One row of the supervisor's roster — and the substrate's
 /// per-persona context object. Analog of Android's `Context`:
 /// the single struct every persona-scoped function reads from.


### PR DESCRIPTION
## What (two coupled changes, validated live — no 405, persona reasons through unsloth)

**1. Persona inference → the unsloth gateway.** The in-process llama.cpp adapter
advertised `supports_tool_use: true` but **silently dropped `request.tools`** (no
prompt injection, never parsed a call, always `finish_reason=Stop`) — so the
persona's hands could never fire; it *narrated* fake tool use. The
OpenAI-compatible adapter unsloth uses **already** sends `tools` + parses
`tool_calls` → `FinishReason::ToolUse`, so routing reasoning there gives native
function-calling for free (lean on unsloth; don't carry redundant tool-calling
code). New `UnslothPersonaAdapterFactory`, wired in the ipc spawn.

**2. ONE owner for the unsloth endpoint.** It was read in multiple divergent forms
(`config.env` `…/v1` **and** the catalog literal `…/v1`) while every request site
appends `/v1` → `/v1/v1/…` → **405 Method Not Allowed** (caught by the live
workspace-trace capture). Fixed at the root, not with scattered normalization:
- `unsloth_control::unsloth_base_url()` is **the single accessor** — the only place
  that reads `UNSLOTH_BASE_URL` (or `DEFAULT_HOST`) and returns the canonical bare
  host. Keystone + gateway-adapter registration both call it.
- `DEFAULT_HOST` is **the one constant**; the catalog references it.
- `api_base()` resolves the base in **one place** (was copy-pasted 4×).

## Validated / Still pending

✅ No 405; deliberation produces a decision through unsloth.
⏳ Tools don't fire **yet** — two follow-up slices: the dynamic AiSafe tool specs
carry empty description/schema (each command must declare its own, surfaced via
`command_registry` — keep it **dynamic + compartmentalized**), and unsloth must
serve a **capable model** (the 4b, not the 0.5b currently loaded — routing while
0.5b is loaded is a reasoning downgrade until provisioned).

## Note
`openai_adapter.rs` is a 1100-line monolith — flagged for modularization (own task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)