### PR TITLE
chore(sdk_codegen): gate the legacy TypeScript-SDK emitter behind off-by-default ts-codegen

### DIFF
--- a/core/continuum-core/Cargo.toml
+++ b/core/continuum-core/Cargo.toml
@@ -228,6 +228,13 @@ objc = "0.2"    # Objective-C runtime — for Metal APIs not wrapped by metal cr
 # only crates into their dep tree on every host.
 default = ["livekit-webrtc"]
 livekit-webrtc = ["dep:livekit", "dep:livekit-api"]
+# Legacy TypeScript-SDK generator (sdk_codegen::emit). OFF by default: nothing
+# live consumes its output (the new client SDKs are independent), so it's pure
+# CI/compile cost + a tempting-but-wrong extension point. The HEADLESS command
+# framework (registry, dispatch, descriptors, AccessLevel) is always compiled;
+# only the .ts emitter + its tests are gated here. Regenerate the TS SDK with
+# `cargo test --features ts-codegen` on the (rare) occasions it's needed.
+ts-codegen = []
 metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal", "llama/metal", "ort/coreml"]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda", "llama/cuda", "ort/cuda"]
 # Vulkan is llama.cpp-only (Candle has no Vulkan backend). Used by the

--- a/core/continuum-core/src/sdk_codegen/mod.rs
+++ b/core/continuum-core/src/sdk_codegen/mod.rs
@@ -52,11 +52,18 @@ use std::path::Path;
 
 use ts_rs::{Config, Dependency, TS};
 
+/// The legacy TypeScript-SDK emitter — OFF by default (`ts-codegen` feature).
+/// Nothing live consumes its output; the headless command framework below is
+/// always compiled. See the `ts-codegen` feature note in Cargo.toml.
+#[cfg(feature = "ts-codegen")]
 pub mod emit;
 pub mod events;
 pub mod handler;
+#[cfg(feature = "ts-codegen")]
 pub use emit::write_typescript_sdk;
-pub use events::{event_registry, generate_event_api, generate_event_map, EventDescriptor, EventSpec};
+pub use events::{event_registry, EventDescriptor, EventSpec};
+#[cfg(feature = "ts-codegen")]
+pub use events::{generate_event_api, generate_event_map};
 pub use handler::{dispatch, CommandError, CommandHandler, Ctx, Outcome};
 
 /// The capability a command declares.


### PR DESCRIPTION
## What

The ts-rs **TypeScript-SDK generator** is no longer load-bearing: the new client
SDKs (web/mobile/cli on the shared `continuum-client` base) are independent, and a
read-only scope confirmed **nothing live imports its output** (`protocol/typescript/`
is generated-then-only-vendored; the headless command framework has zero dependency
on the emitter). It's pure CI/compile cost — and a recurring wrong-place extension
point.

## Change

Gate `sdk_codegen::emit` (the `.ts` writer + the cargo-test SDK-regeneration test) +
the `generate_event_*` re-exports behind a new **off-by-default `ts-codegen`** feature.

**Always compiled (unchanged):** the headless command framework —
`CommandSpec`/`CommandDescriptor`, `command_registry`, `register_command!`,
`dispatch`, `handler`, `AccessLevel`, `EventSpec`/`event_registry`. I.e. everything
the persona's **dynamic AiSafe tool surface** (`ai_safe_tool_specs → command_registry`)
and runtime dispatch depend on.

## Effect
- Default `cargo test` no longer runs the side-effecting SDK regeneration.
- Regenerate explicitly with `cargo test --features ts-codegen` when (rarely) needed.

## Validated
- Default build + `sdk_codegen` (15) + `persona_tools` (2) + `dispatch` (5) tests green.
- The `--features ts-codegen` path still compiles (regen intact).
- Nothing outside `sdk_codegen` calls the emitter → no caller breaks.

## Scope
Does **not** remove ts-rs (600+ unrelated `#[derive(TS)]` observability types still
use it) — that's a separate, larger call. This is the safe quarantine that stops the
generator from being default-build cost and a tempting wrong path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)