### PR TITLE
feat(tools): per-command headless DESCRIPTION → richer dynamic persona tool surface

### DIFF
--- a/core/continuum-core/src/cognition/persona_tools.rs
+++ b/core/continuum-core/src/cognition/persona_tools.rs
@@ -48,9 +48,15 @@ pub fn ai_safe_tool_specs() -> Vec<NativeToolSpec> {
 pub fn descriptor_to_tool_spec(d: &CommandDescriptor) -> NativeToolSpec {
     NativeToolSpec {
         name: d.name.to_string(),
-        // Best-effort until commands declare a description: name the command and
-        // its param type so the model has a handle. Real description slots here.
-        description: format!("Command `{}` (params: {}).", d.name, d.params.name),
+        // The command's own declared DESCRIPTION (headless, compartmentalized) when
+        // present; otherwise fall back to a name + param-type handle so the model
+        // still has something. A command becomes a GOOD tool simply by declaring
+        // `const DESCRIPTION` in its own file — no change here.
+        description: if d.description.is_empty() {
+            format!("Command `{}` (params: {}).", d.name, d.params.name)
+        } else {
+            d.description.to_string()
+        },
         // Open object — the command validates its own typed params. A declared
         // param JSON schema replaces this when the metadata mechanism lands.
         input_schema: ToolInputSchema {

--- a/core/continuum-core/src/modules/chat/types.rs
+++ b/core/continuum-core/src/modules/chat/types.rs
@@ -188,6 +188,9 @@ pub struct ChatSendCommand;
 impl crate::sdk_codegen::CommandSpec for ChatSendCommand {
     const NAME: &'static str = "chat/send";
     const ACCESS_LEVEL: crate::sdk_codegen::AccessLevel = crate::sdk_codegen::AccessLevel::AiSafe;
+    const DESCRIPTION: &'static str =
+        "Send a chat message to a room. Use to post a message addressed to others; \
+         params carry the room and the message text.";
     const WIRE: crate::sdk_codegen::WireShape = crate::sdk_codegen::WireShape::Enveloped;
     type Params = ChatSendParams;
     type Result = ChatSendResult;
@@ -201,6 +204,9 @@ pub struct ChatPollCommand;
 impl crate::sdk_codegen::CommandSpec for ChatPollCommand {
     const NAME: &'static str = "chat/poll";
     const ACCESS_LEVEL: crate::sdk_codegen::AccessLevel = crate::sdk_codegen::AccessLevel::AiSafe;
+    const DESCRIPTION: &'static str =
+        "Fetch recent messages for a room — read the latest conversation. Params \
+         carry the room and how many messages to retrieve.";
     const WIRE: crate::sdk_codegen::WireShape = crate::sdk_codegen::WireShape::Enveloped;
     type Params = ChatPollParams;
     type Result = ChatPollResult;

--- a/core/continuum-core/src/modules/data.rs
+++ b/core/continuum-core/src/modules/data.rs
@@ -3719,6 +3719,9 @@ pub struct DataListCommand;
 impl crate::sdk_codegen::CommandSpec for DataListCommand {
     const NAME: &'static str = "data/list";
     const ACCESS_LEVEL: crate::sdk_codegen::AccessLevel = crate::sdk_codegen::AccessLevel::AiSafe;
+    const DESCRIPTION: &'static str =
+        "List entities from a data collection (rooms, users, messages, …). Params \
+         carry the collection name and optional ordering/filtering.";
     const WIRE: crate::sdk_codegen::WireShape = crate::sdk_codegen::WireShape::Bare;
     type Params = DataListParams;
     type Result = DataListResult;

--- a/core/continuum-core/src/modules/health.rs
+++ b/core/continuum-core/src/modules/health.rs
@@ -43,6 +43,8 @@ pub struct PingCommand;
 impl crate::sdk_codegen::CommandSpec for PingCommand {
     const NAME: &'static str = "ping";
     const ACCESS_LEVEL: crate::sdk_codegen::AccessLevel = crate::sdk_codegen::AccessLevel::AiSafe;
+    const DESCRIPTION: &'static str =
+        "Health check: confirm the substrate is alive and responding. Returns a pong.";
     const WIRE: crate::sdk_codegen::WireShape = crate::sdk_codegen::WireShape::Bare;
     type Params = PingParams;
     type Result = PingResult;

--- a/core/continuum-core/src/sdk_codegen/mod.rs
+++ b/core/continuum-core/src/sdk_codegen/mod.rs
@@ -158,6 +158,14 @@ pub trait CommandSpec {
     const NAME: &'static str;
     /// The capability this command requires.
     const ACCESS_LEVEL: AccessLevel;
+    /// One-line, model-facing description of what this command DOES — surfaced
+    /// into a persona's DYNAMIC tool surface (`command_registry × AiSafe`,
+    /// `cognition::persona_tools`) so the reasoner knows when to call it. This is
+    /// HEADLESS metadata (a Rust const), declared by the command itself in its own
+    /// file (compartmentalized, like its `ACCESS_LEVEL`) — nothing to do with the
+    /// TS emitter. Defaults to empty; the tool projection falls back to a
+    /// name-based description when unset, so existing commands need no change.
+    const DESCRIPTION: &'static str = "";
     /// The handler's ACTUAL wire convention — decides whether the generated
     /// surface is enveloped or bare. MUST match what the handler really does
     /// (a mismatch is a type that lies about the wire).
@@ -225,6 +233,10 @@ fn module_of(output_path: &Path) -> String {
 pub struct CommandDescriptor {
     pub name: &'static str,
     pub access_level: AccessLevel,
+    /// Headless, model-facing description (from [`CommandSpec::DESCRIPTION`]) —
+    /// what the persona tool surface shows the reasoner. Empty when the command
+    /// hasn't declared one yet.
+    pub description: &'static str,
     /// The handler's real wire convention (decides envelope wrapping).
     pub wire: WireShape,
     pub params: TypeRef,
@@ -257,6 +269,7 @@ impl CommandDescriptor {
         Self {
             name: C::NAME,
             access_level: C::ACCESS_LEVEL,
+            description: C::DESCRIPTION,
             wire: C::WIRE,
             params,
             result,


### PR DESCRIPTION
## What

The persona's tools carried near-useless descriptions (`"Command \`data/list\`
(params: DataListParams)."`) — a model can't tell what a tool *does* from that, so
it narrates instead of calling. This adds real, model-facing descriptions the
**Rust-native + dynamic + compartmentalized** way (no TypeScript, no central list):

- **`CommandSpec::DESCRIPTION`** — a headless `&'static str` const (default `""`),
  part of the command **framework** (the part kept always-compiled in the
  ts-codegen quarantine; *not* the TS emitter). Each command declares its own in
  its **own file**, exactly like its `ACCESS_LEVEL`.
- **`CommandDescriptor`** carries it (`of::<C>()` captures `C::DESCRIPTION`); the
  dynamic projection (`persona_tools::descriptor_to_tool_spec`) uses it, falling
  back to the name+param handle when unset — so a command becomes a good tool just
  by declaring the const.

Declared on the first AiSafe commands a persona reaches for: `ping`, `chat/send`,
`chat/poll`, `data/list`. The rest light up incrementally as each declares its own.

## Scope

`input_schema` stays permissive (the command validates its own typed params); a
Rust-native param schema is a separate later slice. This is the **description
half** — the biggest single lift for "which tool, and when."

## Tests
15 `sdk_codegen` + 2 `persona_tools` tests green; binary compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)