### PR TITLE
feat(tools): JsonInPrompt — model-agnostic prompt-based tool calling (tools FIRE end-to-end)

### DIFF
--- a/core/continuum-core/src/ai/json_in_prompt_tools.rs
+++ b/core/continuum-core/src/ai/json_in_prompt_tools.rs
@@ -1,0 +1,264 @@
+//! Prompt-based tool calling (`JsonInPrompt`) — model-agnostic tools for models
+//! whose gateway does NOT implement native OpenAI function-calling.
+//!
+//! PROVEN 2026-06-21: unsloth + the qwen GGUF ignores the `tools`/`tool_choice`
+//! params (returns `tool_calls: null`, the model just narrates). Many local models
+//! are like this until fine-tuned. So instead of relying on native function
+//! calling, we describe the tools IN THE PROMPT and ask the model to emit a strict
+//! JSON tool call, then PARSE it back into the same [`ToolCall`] the agent loop
+//! already executes — i.e. we make prompt-based tools look native to the rest of
+//! cognition.
+//!
+//! This is one half of the adapter strategy: the adapter picks the tool protocol
+//! by MODEL (native when the model+gateway truly do it, JsonInPrompt otherwise),
+//! and either way returns `FinishReason::ToolUse` + `tool_calls`. Never hardcoded
+//! to one model — the protocol is a per-adapter property.
+//!
+//! The two pure pieces (TDD'd here, called by the adapter):
+//!   - [`render_tool_instructions`] — the prompt block injected when offering tools.
+//!   - [`parse_tool_call`] — extract the model's JSON tool call from messy output.
+
+use serde::Deserialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+use super::types::{NativeToolSpec, ToolCall};
+
+/// The strict JSON shape the model is asked to emit to call a tool:
+/// `{"tool_call": {"name": "...", "arguments": { ... }}}`. The envelope key
+/// (`tool_call`) makes the intent unambiguous to parse out of surrounding prose.
+#[derive(Debug, Deserialize)]
+struct ToolCallEnvelope {
+    tool_call: ToolCallJson,
+}
+
+/// The inner call: which tool + its arguments. `arguments` defaults to `{}` so a
+/// no-arg tool can be called as `{"tool_call": {"name": "ping"}}`.
+#[derive(Debug, Deserialize)]
+struct ToolCallJson {
+    name: String,
+    #[serde(default)]
+    arguments: Value,
+}
+
+/// Format adaptation, Rust-idiomatic: the model's emitted shape → our canonical
+/// [`ToolCall`]. A fresh id (the agent loop correlates results by it) + `input` =
+/// the model's `arguments` (null → `{}`).
+impl From<ToolCallJson> for ToolCall {
+    fn from(j: ToolCallJson) -> Self {
+        ToolCall {
+            id: format!("jip-{}", Uuid::new_v4()),
+            name: j.name.trim().to_string(),
+            input: match j.arguments {
+                Value::Null => serde_json::json!({}),
+                other => other,
+            },
+        }
+    }
+}
+
+/// How a given model exchanges tool calls — a protocol-driven interface the
+/// adapter delegates to, selected PER MODEL (never hardcoded). `Native` = the
+/// gateway/model does real OpenAI function-calling (offer via the API `tools`
+/// param, read `tool_calls` back). `JsonInPrompt` = describe tools in the prompt
+/// + parse a JSON call from the text (the universal floor for models that ignore
+/// the `tools` param, like unsloth+GGUF today). Adding a model = data; swapping a
+/// gateway = a new variant — not a rewrite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ToolProtocol {
+    /// The model+gateway implement OpenAI function-calling natively.
+    #[default]
+    Native,
+    /// Tools are offered in the prompt; calls are parsed from the response text.
+    JsonInPrompt,
+}
+
+impl ToolProtocol {
+    /// The prompt block to inject when offering `tools`, or `None` when tools are
+    /// offered via the API `tools` param (native). Empty `tools` → `None`.
+    pub fn tool_prompt(self, tools: &[NativeToolSpec]) -> Option<String> {
+        match self {
+            ToolProtocol::Native => None,
+            ToolProtocol::JsonInPrompt if tools.is_empty() => None,
+            ToolProtocol::JsonInPrompt => Some(render_tool_instructions(tools)),
+        }
+    }
+
+    /// Extract a tool call from the model's TEXT response. `None` for `Native`
+    /// (the adapter reads structured `tool_calls` instead) and when the model
+    /// answered normally (no call).
+    pub fn parse_text_call(self, text: &str) -> Option<ToolCall> {
+        match self {
+            ToolProtocol::Native => None,
+            ToolProtocol::JsonInPrompt => parse_tool_call(text),
+        }
+    }
+}
+
+/// Render the tool-offering block injected into the prompt (as a system message)
+/// when a JsonInPrompt model is offered tools. Lists each tool + its description
+/// and states the EXACT JSON contract to emit. Kept terse — small models follow a
+/// short, explicit contract far better than a verbose schema.
+pub fn render_tool_instructions(tools: &[NativeToolSpec]) -> String {
+    let mut s = String::with_capacity(256 + tools.len() * 96);
+    s.push_str(
+        "You can use tools. To call ONE tool, reply with ONLY this JSON object and \
+         nothing else:\n\
+         {\"tool_call\": {\"name\": \"<tool-name>\", \"arguments\": { ... }}}\n\
+         After the tool result comes back, answer normally. If no tool is needed, \
+         just answer normally (no JSON).\n\n\
+         Available tools:\n",
+    );
+    for t in tools {
+        s.push_str("- ");
+        s.push_str(&t.name);
+        s.push_str(": ");
+        s.push_str(&t.description);
+        s.push('\n');
+    }
+    s
+}
+
+/// Parse a model response for a JsonInPrompt tool call. Robust to the mess real
+/// models emit: surrounding prose, ```json fences, `<think>` blocks, trailing
+/// commentary. Scans for balanced `{...}` candidates and returns the first that
+/// deserializes to the `{"tool_call": {...}}` envelope. Returns `None` when the
+/// model chose to answer normally (no tool call) — that's the common, valid case.
+///
+/// The synthesized [`ToolCall`] gets a fresh id (the agent loop correlates results
+/// by it) and `input` = the model's `arguments` (defaulting to `{}`).
+pub fn parse_tool_call(text: &str) -> Option<ToolCall> {
+    for candidate in json_object_candidates(text) {
+        if let Ok(env) = serde_json::from_str::<ToolCallEnvelope>(candidate) {
+            if env.tool_call.name.trim().is_empty() {
+                continue;
+            }
+            return Some(env.tool_call.into()); // From<ToolCallJson> for ToolCall
+        }
+    }
+    None
+}
+
+/// Yield substrings of `text` that are balanced `{...}` objects, outermost-first
+/// at each start position — so a `{"tool_call": {...}}` envelope is tried before
+/// its inner `{...}`. Brace-depth scan that ignores braces inside JSON strings
+/// (so `{"k":"}"}` doesn't fool it). Cheap; the candidate set is tiny in practice.
+fn json_object_candidates(text: &str) -> Vec<&str> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{' {
+            if let Some(end) = matching_brace_end(bytes, i) {
+                out.push(&text[i..=end]);
+                // Continue scanning AFTER this object's open brace so nested/later
+                // objects are still considered, but we tried the outermost first.
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Index of the `}` matching the `{` at `start`, respecting JSON string literals
+/// and escapes. `None` if unbalanced (truncated output).
+fn matching_brace_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut in_str = false;
+    let mut escaped = false;
+    let mut i = start;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_str {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                in_str = false;
+            }
+        } else {
+            match c {
+                b'"' => in_str = true,
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(i);
+                    }
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::types::ToolInputSchema;
+
+    fn spec(name: &str, desc: &str) -> NativeToolSpec {
+        NativeToolSpec {
+            name: name.to_string(),
+            description: desc.to_string(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".to_string(),
+                properties: serde_json::json!({}),
+                required: None,
+            },
+        }
+    }
+
+    // what this catches: the instruction block names every tool + its description
+    // and states the exact JSON contract — what a small model needs to call a tool.
+    #[test]
+    fn instructions_list_tools_and_the_contract() {
+        let s = render_tool_instructions(&[spec("ping", "Health check.")]);
+        assert!(s.contains("\"tool_call\""));
+        assert!(s.contains("ping: Health check."));
+    }
+
+    // what this catches: a clean bare JSON tool call parses to a ToolCall with the
+    // right name + args (the happy path).
+    #[test]
+    fn parses_bare_tool_call() {
+        let tc = parse_tool_call(r#"{"tool_call": {"name": "data/list", "arguments": {"collection": "rooms"}}}"#)
+            .expect("a tool call");
+        assert_eq!(tc.name, "data/list");
+        assert_eq!(tc.input["collection"], "rooms");
+        assert!(tc.id.starts_with("jip-"));
+    }
+
+    // what this catches: THE real-model mess — prose + <think> + a ```json fence
+    // around the call. Must still extract it (models never emit bare JSON).
+    #[test]
+    fn parses_through_prose_think_and_fences() {
+        let text = "<think>\nI should check health.\n</think>\nSure! Here:\n```json\n{\"tool_call\": {\"name\": \"ping\"}}\n```\n";
+        let tc = parse_tool_call(text).expect("tool call through the mess");
+        assert_eq!(tc.name, "ping");
+        // no-arg call → arguments default to {}
+        assert_eq!(tc.input, serde_json::json!({}));
+    }
+
+    // what this catches: a normal answer (no tool call) returns None — the common
+    // case; we must NOT fabricate a call from ordinary prose.
+    #[test]
+    fn no_tool_call_in_plain_answer() {
+        assert!(parse_tool_call("The deploy looks healthy; nothing to do.").is_none());
+        // an unrelated JSON object is not a tool_call envelope
+        assert!(parse_tool_call(r#"Here's data: {"status": "ok", "count": 3}"#).is_none());
+    }
+
+    // what this catches: brace-in-string doesn't fool the balanced scan, and the
+    // outer envelope is preferred over any inner object.
+    #[test]
+    fn handles_braces_in_strings() {
+        let tc = parse_tool_call(r#"{"tool_call": {"name": "chat/send", "arguments": {"text": "use {curly} braces"}}}"#)
+            .expect("call");
+        assert_eq!(tc.name, "chat/send");
+        assert_eq!(tc.input["text"], "use {curly} braces");
+    }
+}

--- a/core/continuum-core/src/ai/mod.rs
+++ b/core/continuum-core/src/ai/mod.rs
@@ -36,6 +36,7 @@ pub mod anthropic_adapter;
 // adapter no other form. Declaration." cfg gating IS the declaration.
 #[cfg(any(test, feature = "test-fixtures"))]
 pub mod heuristic_adapter;
+pub mod json_in_prompt_tools;
 pub mod openai_adapter;
 pub mod registry_bridge;
 pub mod types;

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -51,6 +51,12 @@ pub struct OpenAICompatibleConfig {
     /// Whether this provider requires an Authorization header. Derived
     /// from `Provider.auth`: Bearer → true, ApiKey → true, None → false.
     pub requires_auth: bool,
+    /// How this provider exchanges tool calls. Native = real OpenAI
+    /// function-calling; JsonInPrompt = describe tools in the prompt + parse the
+    /// JSON call from the response (for gateways/models that ignore the `tools`
+    /// param, e.g. unsloth+GGUF — proven 2026-06-21). Gateway-level for now;
+    /// per-model refinement (from the gateway's model data) is the follow-up.
+    pub tool_protocol: super::json_in_prompt_tools::ToolProtocol,
 }
 
 /// OpenAI-compatible adapter implementation
@@ -325,6 +331,15 @@ impl OpenAICompatibleAdapter {
             models,
             model_prefixes: provider.model_prefixes.clone(),
             requires_auth,
+            // unsloth's GGUF path ignores the OpenAI `tools` param (proven), so it
+            // uses prompt-based tools; cloud OpenAI-compatible providers do native
+            // function-calling. Keyed by GATEWAY, not a specific model — refine to
+            // per-model from the gateway's model capabilities later.
+            tool_protocol: if provider.id == "unsloth" {
+                super::json_in_prompt_tools::ToolProtocol::JsonInPrompt
+            } else {
+                super::json_in_prompt_tools::ToolProtocol::Native
+            },
         })
     }
 
@@ -653,7 +668,18 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         let model: &str = &resolved_model;
 
         // Build request body
-        let messages = self.format_messages(&request.messages, request.system_prompt.as_deref());
+        let mut messages = self.format_messages(&request.messages, request.system_prompt.as_deref());
+
+        // JsonInPrompt tool offering: for gateways/models that ignore the OpenAI
+        // `tools` param (unsloth+GGUF), describe the tools IN the prompt and ask
+        // for a strict JSON call. Appended as a system message; the matching parse
+        // happens on the response below. Native providers skip this (tool_prompt →
+        // None) and use the `tools` param instead.
+        if let Some(tools) = request.tools.as_ref() {
+            if let Some(block) = self.config.tool_protocol.tool_prompt(tools) {
+                messages.push(json!({ "role": "system", "content": block }));
+            }
+        }
 
         let mut body = json!({
             "model": model,
@@ -726,9 +752,15 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
             );
         }
 
-        // Add tools if provided
+        // Add tools via the native OpenAI `tools` param — ONLY for Native
+        // providers. JsonInPrompt providers already had the tools described in the
+        // prompt above (sending the param too would be ignored or confuse them).
         if let Some(tools) = &request.tools {
-            if !tools.is_empty() && self.config.supports_tools {
+            if !tools.is_empty()
+                && self.config.supports_tools
+                && self.config.tool_protocol
+                    == super::json_in_prompt_tools::ToolProtocol::Native
+            {
                 let openai_tools: Vec<Value> = tools
                     .iter()
                     .map(|tool| {
@@ -869,14 +901,14 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
             .ok_or_else(|| "No completion in response".to_string())?;
 
         let text = choice.message.content.clone().unwrap_or_default();
-        let finish_reason = choice
+        let mut finish_reason = choice
             .finish_reason
             .as_deref()
             .map(|r| self.map_finish_reason(r))
             .unwrap_or(FinishReason::Stop);
 
-        // Parse tool calls
-        let tool_calls: Option<Vec<ToolCall>> = choice.message.tool_calls.as_ref().map(|tcs| {
+        // Parse native tool calls
+        let mut tool_calls: Option<Vec<ToolCall>> = choice.message.tool_calls.as_ref().map(|tcs| {
             tcs.iter()
                 .map(|tc| {
                     let input: Value = serde_json::from_str(&tc.function.arguments)
@@ -889,6 +921,17 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                 })
                 .collect()
         });
+
+        // JsonInPrompt synthesis: when the gateway/model doesn't do native function
+        // calling, the model answers as TEXT containing the JSON tool call from the
+        // injected contract. Lift it into the canonical ToolUse shape so the agent
+        // loop executes it EXACTLY like a native call (one seam, model-agnostic).
+        if tool_calls.as_ref().map_or(true, |t| t.is_empty()) {
+            if let Some(call) = self.config.tool_protocol.parse_text_call(&text) {
+                finish_reason = FinishReason::ToolUse;
+                tool_calls = Some(vec![call]);
+            }
+        }
 
         // Build content blocks
         let mut content_blocks = Vec::new();


### PR DESCRIPTION
## What

Proven via direct probe: unsloth + the qwen GGUF **ignores** the OpenAI `tools`/
`tool_choice` params (`tool_calls: null`, model narrates). Native function-calling
is a dead end for this (and many local/raw) models until fine-tuned. This adds the
**universal floor**: describe tools in the prompt + parse a JSON call from the
response — **behind the adapter**, so cognition stays agnostic in its own canonical
language (`ToolCall`/`NativeToolSpec`) and the **adapter does the translation**
(the `From`/`TryFrom` + protocol-driven seam — same pattern intended for media/audio).

## How

- **`ai/json_in_prompt_tools.rs`** (own module): `ToolProtocol { Native | JsonInPrompt }`
  (per-model selector), `render_tool_instructions` (prompt block), `parse_tool_call`
  (robust through prose / `<think>` / ```json fences; brace-balanced, string-aware),
  `From<ToolCallJson> for ToolCall` (idiomatic format adaptation). **5 TDD tests.**
- **OpenAICompatibleAdapter**: a `tool_protocol` config field; JsonInPrompt + tools →
  inject instructions as a system message (skip native `tools` param) and on the
  response **synthesize `FinishReason::ToolUse` + `tool_calls`** from the parsed text
  — so the deliberation agent loop runs it **unchanged**, exactly like a native call.
- Selection at the adapter (unsloth → JsonInPrompt, cloud → Native). Gateway-keyed
  for now; documented refinement = **per-model tuning** (chat/tool-tuned vs raw) from
  model metadata — the seam already supports it. Never hardcoded to one model.

## Validated live

Asha emitted a JSON `ping` call → adapter parsed + synthesized `ToolUse` → agent loop
executed via the ACL-gated `CommandToolExecutor` → she reported the result.
**Tools fire end-to-end.** (The ACL then denied `ping` — correct gate behavior;
reconciling `AiSafe`→persona authorization so it *succeeds* is the next slice.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)