### PR TITLE
fix(tools): offer == authorized — persona never shown a tool it can't run

### DIFF
--- a/core/continuum-core/src/cognition/persona_tools.rs
+++ b/core/continuum-core/src/cognition/persona_tools.rs
@@ -27,11 +27,28 @@
 //! later, exactly where it belongs.
 
 use crate::ai::types::{NativeToolSpec, ToolInputSchema};
+use crate::modules::grid::acl::is_command_authorized;
+use crate::modules::grid::node::TrustLevel;
 use crate::sdk_codegen::{command_registry, AccessLevel, CommandDescriptor};
 use serde_json::json;
 
-/// The persona's tool surface: every `AiSafe` command, projected to a tool spec.
-/// Dynamic — derived from the live [`command_registry`], nothing hardcoded.
+/// The persona's tool surface: every command it is AUTHORIZED to run at `trust`,
+/// projected to a tool spec. **Offer == authorized, by construction** — a persona
+/// is NEVER shown a tool the gate would refuse (no "offer ping then deny it"). The
+/// SAME [`is_command_authorized`] the executor enforces decides what's offered, so
+/// the two can't drift, and opening a command to a trust level auto-adds it here.
+/// Dynamic from the live [`command_registry`]; nothing hardcoded.
+pub fn authorized_tool_specs(trust: TrustLevel) -> Vec<NativeToolSpec> {
+    command_registry()
+        .iter()
+        .filter(|d| is_command_authorized(d.name, trust))
+        .map(descriptor_to_tool_spec)
+        .collect()
+}
+
+/// The `AiSafe`-only surface — retained for callers/diagnostics that specifically
+/// want the declared-safe set. Personas should use [`authorized_tool_specs`] so
+/// the offer matches what they can actually run.
 pub fn ai_safe_tool_specs() -> Vec<NativeToolSpec> {
     command_registry()
         .iter()

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -152,8 +152,15 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
         cfg.adapter,
     );
     if let Some(executor) = cfg.tool_executor {
+        // Offer EXACTLY what this persona is authorized to run (offer ==
+        // authorized) — never a tool the gate would refuse. A persona is an airc
+        // caller (Provisional trust, per GridTrustAuthPolicy); widening what a
+        // persona can do = opening more commands to Provisional, which auto-widens
+        // this surface (no second list to keep in sync).
         deliberation = deliberation
-            .with_tools(super::persona_tools::ai_safe_tool_specs())
+            .with_tools(super::persona_tools::authorized_tool_specs(
+                crate::modules::grid::node::TrustLevel::Provisional,
+            ))
             .with_tool_executor(executor);
     }
     faculties.push(Arc::new(deliberation));


### PR DESCRIPTION
## What

Offering a tool then having the ACL deny it (the live *"I tried ping but got a policy
error"* lameness) is bad design. The persona's tool surface now **derives from the
same gate the executor enforces**:

```
authorized_tool_specs(trust) = command_registry.filter(is_command_authorized(cmd, trust))
```

**Offer == authorized, by construction** — they can't drift, and opening a command to
a trust level auto-adds it to the surface (no second list). The live persona offers
`authorized_tool_specs(Provisional)` (its airc trust).

## Next (the real ask)
This is the coherence fix. **Widening** what personas can do (the surface is still
thin) is the next slice: open more of the ~250-command catalog to personas — broad
for trusted local citizens, gate only the sensitive/destructive. With this change,
widening = "authorize more at Provisional" and the offer follows automatically.

persona_tools tests green; binary compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)