### PR TITLE
feat(positron): O5-1 — ChatViewState IS a positron ViewState (the type bridge)

### DIFF
--- a/core/continuum-positron/src/chat.rs
+++ b/core/continuum-positron/src/chat.rs
@@ -291,9 +291,45 @@ pub struct ChatViewState {
     pub roster: Vec<RosterSlotView>,
 }
 
+/// `ChatViewState` IS a positron `ViewState` — the type-level bridge
+/// that lets renderers (positron-lit's `LitHost`) and AI observers
+/// (the O6 perception bridge) key off the SAME contract, not a
+/// continuum-private shape. This is the "first real `ViewState`" the
+/// positron roadmap's O5 names: until now the crate only *framed*
+/// payloads into `StateEnvelope`s; here the payload gains its identity
+/// under positron's own trait.
+///
+/// The `Clone + Send + Sync + Debug + 'static` bound the trait requires
+/// is already satisfied by the struct's derives + its owned-data fields
+/// (`Uuid` / `String` / `Vec`), so no new bounds are introduced.
+impl positron_core::ViewState for ChatViewState {
+    fn kind(&self) -> &'static str {
+        // Single-source the wire string through `KnownKind` — the same
+        // "chat" the `StateEnvelope.kind` carries — so the trait's view
+        // of the kind can never drift from the envelope's. Per
+        // `[[strong-typing-across-boundaries]]`: the string is encoded
+        // once, at the typed kind seam.
+        crate::kinds::KnownKind::Chat.wire_name()
+    }
+
+    // `revision()` is intentionally the trait default (`None`): in
+    // continuum's substrate the monotonic chat revision is an
+    // ENVELOPE-level counter (`Revisions` keyed by `KnownKind`, framed
+    // in by `StateBuilder`), NOT a payload field. The `ViewState`
+    // trait's revision is satisfied at the envelope layer where the
+    // counter actually lives; carrying a copy on the payload struct
+    // would be two sources of truth for one counter (the exact drift
+    // `[[compression]]` forbids). So the standalone payload honestly
+    // reports "no self-carried revision" and the envelope supplies the
+    // real one. See `kinds::RevisionKey` for the one-counter-per-kind
+    // semantics.
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::kinds::KnownKind;
+    use positron_core::ViewState as _;
 
     #[test]
     fn sender_kind_wire_shape_is_tagged() {
@@ -424,5 +460,38 @@ mod tests {
         let json = serde_json::to_string(&state).unwrap();
         let back: ChatViewState = serde_json::from_str(&json).unwrap();
         assert_eq!(back, state);
+    }
+
+    #[test]
+    fn chat_view_state_is_a_positron_view_state() {
+        // what this catches: regression where `ChatViewState` stops
+        // being a positron `ViewState` (the impl deleted, or `kind()`
+        // hand-rolled to a literal that drifts from the wire name).
+        // Renderers (positron-lit's `LitHost`) and the O6 observer
+        // bridge route/subscribe off `ViewState::kind()`; if it stops
+        // equalling the `StateEnvelope.kind` the substrate emits
+        // (`KnownKind::Chat.wire_name()`), a widget silently receives
+        // state it can't match to a renderer. Also pins `revision()`
+        // to the trait default (`None`): the chat revision is an
+        // envelope-level counter, never a payload field — a future
+        // `revision` field on the struct would be a second source of
+        // truth for one counter.
+        let state = ChatViewState {
+            room_id: Uuid::from_u128(0xa),
+            room_name: "general".into(),
+            messages: vec![],
+            roster: vec![],
+        };
+        assert_eq!(state.kind(), "chat");
+        assert_eq!(
+            state.kind(),
+            KnownKind::Chat.wire_name(),
+            "ViewState::kind() must single-source the wire name, never a drifting literal"
+        );
+        assert_eq!(
+            state.revision(),
+            None,
+            "revision is an envelope-level counter, not a payload field"
+        );
     }
 }


### PR DESCRIPTION
## O5-1 — the first real `ViewState`

The positron roadmap's O5 (`ContinuumHost`) opens with *"the first real `ViewState`."* This lands exactly that, and nothing more — the conspicuously-absent type-level bridge:

```rust
impl positron_core::ViewState for ChatViewState { fn kind(&self) -> &'static str { KnownKind::Chat.wire_name() } }
```

`continuum-positron` already owned `ChatViewState` (the typed chat payload that fills `StateEnvelope.payload` for `kind="chat"`), but it only ever got **framed** into an envelope by `StateBuilder` — the payload had no identity under positron's own contract. Renderers (positron-lit's `LitHost`) route state to a renderer by `ViewState::kind()`, and the O6 AI-observer bridge will subscribe perception by the same method. Until now nothing continuum-side satisfied that trait.

### Two decisions, both pinned by the new test
- **`kind()` single-sources the wire name** via `KnownKind::Chat.wire_name()` — the same `"chat"` the `StateEnvelope.kind` already carries, so the trait's view of the kind can't drift from the envelope's (`[[strong-typing-across-boundaries]]` / `[[compression]]`). Not a hand-rolled literal.
- **`revision()` stays the trait default `None`** — deliberately. In continuum's substrate the monotonic chat revision is an **envelope-level** counter (`Revisions` keyed by `KnownKind`, framed in by `StateBuilder`), not a payload field. Putting a copy on the struct would be two sources of truth for one counter. The standalone payload honestly reports "no self-carried revision"; the envelope supplies the real one.

The trait's `Clone + Send + Sync + Debug + 'static` bound is already met by the struct's derives + owned-data fields — no new bounds. **No wire-type change** (trait impl only), so no ts-rs regen.

### Layering note (a correction to the naive O5 plan)
The substrate crate's own `lib.rs` documents: *"Host side (positron-lit, Fable's lane): consumes `StateEnvelope`, renders Lit widgets."* A positron `Host` is the **renderer-side** role (consumes state, produces commands) — the opposite of this **substrate** crate (produces state, consumes commands). So O5-1 is the layering-correct half; a `ContinuumHost: Host` impl does **not** belong inside the substrate crate. The "session ↔ Commands/Events lowering" (production `CommandDispatch` over continuum-core's `CommandExecutor`) and the `RgbaFrame` reconcile are **continuum-core** follow-on slices — see the crate's own "Remaining (slice 2D-3)" list.

### Validation
`cargo test -p continuum-positron chat::` → **11/11 pass** incl. the new `chat_view_state_is_a_positron_view_state`. Zero new warnings.

Task #117 (positron O1..O6 build-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)