### PR TITLE
feat(security): attenuate positron AI observers — confused-deputy clamp

### DIFF
--- a/core/continuum-core/src/ipc/positron_dispatch.rs
+++ b/core/continuum-core/src/ipc/positron_dispatch.rs
@@ -31,11 +31,42 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use continuum_airc_protocol::AircCommandRequest;
-use continuum_positron::{CommandDispatch, CommandEnvelope};
+use continuum_positron::{CommandDispatch, CommandEnvelope, CommandSource};
 
 use crate::identity::PeerId;
 use crate::routing::{CallerIdentity, CommandRequestHandler};
 use crate::runtime::CommandExecutor;
+
+/// Map a positron [`CommandSource`] onto the [`CallerIdentity`] the dispatch
+/// owner gates against — the confused-deputy seam.
+///
+/// A positron session multiplexes two principals over ONE socket: the human at
+/// the surface, and any AI **observer** perceiving that surface. They must not
+/// share authority. Both ride the same anonymous socket today (a nil peer_id,
+/// pre-GH-auth), so the peer_id can't distinguish them — the SOURCE does:
+///
+/// - [`Human`](CommandSource::Human) → [`CallerIdentity::ws`]: the socket's own
+///   unauthenticated identity, which a future GH-auth handshake (task #29)
+///   elevates through the trust bridge.
+/// - [`Observer`](CommandSource::Observer) → [`CallerIdentity::positron_observer`]:
+///   an attenuated identity clamped at Provisional that NEVER rises with socket
+///   auth, so the AI observing a human's screen can never inherit the human's
+///   elevated authority (see
+///   [`CallerSource::PositronObserver`](crate::routing::CallerSource::PositronObserver)).
+///
+/// Pure + total so the security-relevant decision is unit-tested in isolation,
+/// not buried behind an executor.
+fn caller_for_source(source: CommandSource) -> CallerIdentity {
+    // The same anonymous socket peer for both — trust diverges on the source,
+    // never the peer_id.
+    let socket_peer = PeerId::from_uuid(uuid::Uuid::nil());
+    match source {
+        CommandSource::Human => CallerIdentity::ws(socket_peer),
+        CommandSource::Observer { observer_id } => {
+            CallerIdentity::positron_observer(socket_peer, observer_id)
+        }
+    }
+}
 
 /// Bridges a positron [`CommandEnvelope`] onto continuum's command
 /// surface. Holds the same `Arc<CommandExecutor>` the WS RPC path and
@@ -64,10 +95,11 @@ impl CommandDispatch for ExecutorDispatch {
             envelope.params,
         );
 
-        // Same Provisional ceiling as every other WS-originated call:
-        // trust comes from the source (unauthenticated remote socket),
-        // not from the envelope. A later GH-auth handshake raises it.
-        let caller = CallerIdentity::ws(PeerId::from_uuid(uuid::Uuid::nil()));
+        // Trust comes from the envelope's SOURCE, not the socket: a human keeps
+        // the socket's own (unauthenticated) Ws identity; an AI observer gets an
+        // attenuated identity clamped strictly below any authority that socket
+        // can ever reach — the confused-deputy defense (see `caller_for_source`).
+        let caller = caller_for_source(envelope.source);
 
         let response =
             CommandRequestHandler::execute_command_request(&self.executor, &request, caller).await;
@@ -77,5 +109,44 @@ impl CommandDispatch for ExecutorDispatch {
         // one CommandFailed. Discard the success Value: the ack is the
         // state mutation, not a return payload.
         response.into_result().map(|_value| ())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routing::CallerSource;
+
+    // what this catches: the confused-deputy seam at the positron→continuum
+    // boundary. A `Human` envelope must carry the socket's own `Ws` identity (which
+    // GH-auth can later elevate), and an `Observer` envelope must carry an
+    // ATTENUATED `PositronObserver` identity — a DIFFERENT source, so the trust
+    // policy clamps it below the human (grid_trust_policy proves the ceiling half).
+    // A regression that collapsed both to `ws(nil)` — the pre-attenuation behavior —
+    // would let an AI observing a human's screen inherit the human's authority the
+    // moment the socket authenticates. The observer_id must also survive for audit.
+    #[test]
+    fn observer_and_human_sources_map_to_distinct_attenuated_identities() {
+        let human = caller_for_source(CommandSource::Human);
+        assert!(
+            matches!(human.source, CallerSource::Ws),
+            "a human command keeps the socket's own Ws identity"
+        );
+
+        let observer = caller_for_source(CommandSource::Observer {
+            observer_id: "asha-brain".to_string(),
+        });
+        assert!(
+            matches!(&observer.source, CallerSource::PositronObserver { observer_id } if observer_id == "asha-brain"),
+            "an observer command is stamped PositronObserver, carrying the audit id"
+        );
+
+        // Both ride the same anonymous socket peer today — the SOURCE is the only
+        // thing that diverges the trust ceiling, never the peer_id.
+        assert_eq!(human.peer_id, observer.peer_id, "same socket, different principal");
+        assert!(
+            !matches!(observer.source, CallerSource::Ws),
+            "the observer must NOT be indistinguishable from the human socket"
+        );
     }
 }

--- a/core/continuum-core/src/routing/auth_policy.rs
+++ b/core/continuum-core/src/routing/auth_policy.rs
@@ -118,6 +118,52 @@ pub enum CallerSource {
     /// until then it is honestly labeled `Ws` (distinct from `Tcp` for
     /// telemetry) but shares Tcp's Provisional ceiling.
     Ws,
+    /// The caller is an AI **observer** acting through a positron session — an
+    /// agent that PERCEIVES a human's UI (the same typed `ViewState`s the human
+    /// sees) and issues a command back through a `positron` `CommandEnvelope`
+    /// whose `source` was `Observer { observer_id }`. `observer_id` names WHICH
+    /// observer acted (provenance/audit — a confused deputy is only defensible
+    /// if you can name it).
+    ///
+    /// ## The confused-deputy clamp (why this is its own source)
+    ///
+    /// An observer rides the SAME unauthenticated socket as the human whose UI
+    /// it perceives — today a nil-peer [`Ws`](CallerSource::Ws) connection. If
+    /// it inherited that transport's identity, then the moment a GH-auth
+    /// handshake (task #29) elevated the human's socket, the AI observing that
+    /// human's screen would silently inherit the human's elevated authority —
+    /// the textbook confused-deputy escalation. So an observer is stamped with
+    /// its OWN source that resolves to a FIXED [`TrustLevel::Provisional`](crate::modules::grid::node::TrustLevel::Provisional)
+    /// ceiling which NEVER consults the trust bridge (see
+    /// [`grid_trust_policy`](crate::routing::grid_trust_policy)). The human's
+    /// authority can rise; the AI watching the human cannot ride it up.
+    ///
+    /// Today `Ws` and `PositronObserver` both resolve to `Provisional`, so the
+    /// ceilings are equal — but the divergence is STRUCTURAL: it activates as
+    /// soon as socket authentication elevates the human's `Ws` ceiling above
+    /// Provisional.
+    ///
+    /// ## Precondition: the source declaration must be authenticated (task #29)
+    ///
+    /// This `CallerSource` is locally minted — the ONLY place it is stamped is
+    /// the local positron dispatch path
+    /// ([`CallerIdentity::positron_observer`], via `caller_for_source`); the
+    /// inbound airc/ws pumps stamp [`Airc`](CallerSource::Airc)/[`Ws`](CallerSource::Ws).
+    /// But WHICH identity that path mints is selected by the positron
+    /// `CommandEnvelope`'s `source` discriminant, which is a client-declared,
+    /// wire-deserialized field. So the clamp presumes an HONEST source: a
+    /// compromised observer that self-labels `source: Human` would be minted
+    /// `Ws`, not `PositronObserver`. This is harmless while `Ws` == `Provisional`
+    /// (both floors), but the clamp is only COMPLETE once that source
+    /// declaration is authenticated — the same task #29 handshake that raises
+    /// the `Ws` ceiling must also bind the positron principal so `Human` can't be
+    /// forged. Until then this is a tracked precondition, NOT an "unforgeable
+    /// over the wire" guarantee.
+    PositronObserver {
+        /// Which positron observer issued the command (audit/provenance). Does
+        /// NOT affect the trust ceiling — every observer is clamped identically.
+        observer_id: String,
+    },
 }
 
 /// Caller identity passed to the auth gate. Cross-grid dispatches
@@ -203,6 +249,22 @@ impl CallerIdentity {
         Self {
             peer_id,
             source: CallerSource::Ws,
+            granted_capabilities: Vec::new(),
+        }
+    }
+
+    /// Construct a POSITRON-OBSERVER caller identity — an AI observer acting
+    /// through a positron session over an unauthenticated socket. `peer_id` is
+    /// the socket's peer (nil today, same as the human's `ws` connection);
+    /// `observer_id` names which observer acted (audit). Resolves to a FIXED
+    /// [`Provisional`](crate::modules::grid::node::TrustLevel::Provisional)
+    /// ceiling that NEVER rises with socket authentication — the confused-deputy
+    /// defense (see [`CallerSource::PositronObserver`]). Only the local positron
+    /// dispatch path calls this; a remote peer can't present it.
+    pub fn positron_observer(peer_id: PeerId, observer_id: String) -> Self {
+        Self {
+            peer_id,
+            source: CallerSource::PositronObserver { observer_id },
             granted_capabilities: Vec::new(),
         }
     }
@@ -457,6 +519,27 @@ mod tests {
         let local = CallerIdentity::local(id);
         assert_eq!(local.peer_id, id);
         assert!(matches!(local.source, CallerSource::Local));
+    }
+
+    #[test]
+    fn positron_observer_carries_its_observer_id_and_no_grants() {
+        // what this catches: regression where the positron-observer constructor
+        // (a) loses the observer_id that names WHICH AI acted (audit/provenance
+        // for confused-deputy accountability), or (b) starts populating
+        // granted_capabilities — which would be an unverified escalation, since
+        // an observer presents no owner-signed grant. The trust CLAMP itself is
+        // pinned in grid_trust_policy; here we pin the identity's shape.
+        let id = PeerId::new();
+        let obs = CallerIdentity::positron_observer(id, "asha-brain".to_string());
+        assert_eq!(obs.peer_id, id);
+        assert!(
+            matches!(&obs.source, CallerSource::PositronObserver { observer_id } if observer_id == "asha-brain"),
+            "observer_id must survive into the source for audit"
+        );
+        assert!(
+            obs.granted_capabilities.is_empty(),
+            "an observer presents no verified grant — capabilities stay empty"
+        );
     }
 
     #[test]

--- a/core/continuum-core/src/routing/grid_trust_policy.rs
+++ b/core/continuum-core/src/routing/grid_trust_policy.rs
@@ -147,6 +147,24 @@ impl GridTrustAuthPolicy {
                         None => TrustLevel::Provisional,
                     }
                 }
+                // An AI observer acting through a positron session is CLAMPED at
+                // Provisional and — unlike Ws above — deliberately does NOT consult
+                // the trust bridge. This is the confused-deputy defense: the
+                // observer rides the same socket as the human whose UI it perceives,
+                // so if it resolved through `trust_of(peer_id)` it would inherit the
+                // human's authority the instant a GH-auth handshake elevated that
+                // socket. The AI watching a human's screen must never ride the
+                // human's authority up. Fixed floor, no bridge lookup.
+                //
+                // TODO(task #29): this clamp presumes an HONEST source. The
+                // `PositronObserver` discriminant is selected by the positron
+                // envelope's client-declared `source` field (see
+                // `CallerSource::PositronObserver` docs). The same GH-auth
+                // handshake that raises the `Ws` ceiling must also authenticate
+                // the positron principal, or a compromised observer defeats this
+                // clamp by self-labeling `source: Human`. Harmless today (Ws ==
+                // Provisional); load-bearing the instant socket auth lands.
+                CallerSource::PositronObserver { .. } => TrustLevel::Provisional,
             },
         }
     }
@@ -191,6 +209,12 @@ pub fn caller_trust(caller: Option<&CallerIdentity>) -> TrustLevel {
             // Provisional ceiling as TCP (AiSafe surface, never Owner-gated) until
             // the GH-auth handshake (task #29) authenticates the socket.
             CallerSource::Ws => AIRC_CALLER_CEILING,
+            // A positron AI observer is clamped at the SAME Provisional ceiling —
+            // AiSafe surface only, never Owner-gated. The confused-deputy divergence
+            // from Ws (never rising with socket auth) lives in `resolve_trust`, which
+            // is the bridge-consulting path; this static offer==authorized surface is
+            // already the floor, so observer and Ws coincide here.
+            CallerSource::PositronObserver { .. } => AIRC_CALLER_CEILING,
         },
     }
 }
@@ -482,6 +506,71 @@ mod tests {
         assert!(
             matches!(policy.gate(&decision("code/shell"), Some(&remote)), Verdict::Forbidden { .. }),
             "a remote Provisional peer is denied shell — no cross-grid RCE"
+        );
+    }
+
+    // what this catches: THE confused-deputy clamp for positron AI observers. An
+    // observer rides the SAME socket as the human whose UI it perceives. The
+    // load-bearing invariant: a `PositronObserver` NEVER consults the trust bridge,
+    // so it stays clamped at Provisional even when the SAME peer_id is registered
+    // Owner — whereas a `Ws` caller (the human on that socket) DOES resolve through
+    // the bridge and is elevated to Trusted (capped at REMOTE_TRUST_CEILING). Thus
+    // the moment socket auth exists, the human can run Privileged commands (bash)
+    // and the AI observing that human's screen CANNOT. A regression that routed the
+    // observer through the bridge would let a confused/compromised observer inherit
+    // the human's elevated authority — the exact escalation this variant exists to
+    // prevent. (Today, absent the bridge, both are plain Provisional; this test
+    // wires a bridge to prove the divergence is real and active, not just doc.)
+    #[test]
+    fn positron_observer_never_rides_the_human_socket_authority_up() {
+        use crate::modules::grid::node::TrustLevel;
+        use std::collections::HashMap;
+
+        struct MockTrust(HashMap<Uuid, TrustLevel>);
+        impl PeerTrustSource for MockTrust {
+            fn trust_of(&self, peer_id: Uuid) -> Option<TrustLevel> {
+                self.0.get(&peer_id).copied()
+            }
+        }
+
+        // One peer_id (the authenticated socket) registered as Owner.
+        let socket_peer = Uuid::new_v4();
+        let mut m = HashMap::new();
+        m.insert(socket_peer, TrustLevel::Owner);
+        let policy = GridTrustAuthPolicy::with_trust_source(Arc::new(MockTrust(m)));
+
+        // The human on that socket: Ws consults the bridge → elevated to Trusted
+        // (capped at REMOTE_TRUST_CEILING) → may run Privileged bash.
+        let human = CallerIdentity::ws(crate::identity::PeerId::from_uuid(socket_peer));
+        assert_eq!(
+            policy.gate(&decision("code/shell"), Some(&human)),
+            Verdict::Allowed,
+            "the authenticated human socket is elevated by the trust bridge"
+        );
+
+        // The AI observer riding the SAME socket: clamped at Provisional, bridge
+        // NOT consulted → denied bash even though the peer_id is Owner-registered.
+        let observer = CallerIdentity::positron_observer(
+            crate::identity::PeerId::from_uuid(socket_peer),
+            "asha-brain".to_string(),
+        );
+        assert_eq!(
+            caller_trust(Some(&observer)),
+            TrustLevel::Provisional,
+            "an observer is a fixed Provisional floor — never Owner/Trusted"
+        );
+        assert!(
+            matches!(
+                policy.gate(&decision("code/shell"), Some(&observer)),
+                Verdict::Forbidden { .. }
+            ),
+            "the AI observing a human's screen must NOT inherit the human's shell authority"
+        );
+        // But the observer can still do the AiSafe surface — it isn't muted, just capped.
+        assert_eq!(
+            policy.gate(&decision("ai/generate"), Some(&observer)),
+            Verdict::Allowed,
+            "an observer keeps the AiSafe surface (perceive + generate), just not privilege"
         );
     }
 


### PR DESCRIPTION
## What

A positron session multiplexes **two principals over one socket**: the human at the surface, and any AI **observer** that PERCEIVES that surface and acts back through a `CommandEnvelope`. They must not share authority.

Before this, `ExecutorDispatch` discarded `envelope.source` and minted a fixed `CallerIdentity::ws(nil)` for **both** — so the instant socket auth exists, an AI observing a human's screen would ride the human's authority up. That is the **confused-deputy escalation** (the Instagram-hack shape) positron exists to prevent.

## The fix (source-side, load-bearing)

- **`auth_policy.rs`** — new `CallerSource::PositronObserver { observer_id }` + `CallerIdentity::positron_observer` constructor. Empty `granted_capabilities` — the **tier clamp IS the attenuation**; that field is only ever for owner-signed escalation grants, never a deny-list. `observer_id` is audit-only, never affects the ceiling.
- **`grid_trust_policy.rs`** — both source→trust maps gain a `PositronObserver` arm. The divergence from `Ws` lives in `resolve_trust`: the observer is clamped at a **FIXED Provisional that NEVER consults the trust bridge**, so it cannot rise when the same `peer_id` is registered `Owner`. Today both `Ws` and observer are plain Provisional; the moment socket auth elevates the human's `Ws` socket, the observer stays put — the divergence is structural and activates automatically.
- **`positron_dispatch.rs`** — `ExecutorDispatch` now branches on `envelope.source` via a **pure, total** `caller_for_source()` helper: `Human → ws(nil)` (unchanged), `Observer → positron_observer(nil, id)`. Isolated as a pure mapping so the security decision is unit-tested without an executor.

The observer keeps the full AiSafe surface (perceive + `ai/generate`) — it is **capped, not muted**. Realizes "ceiling strictly below the human's" without overclaiming a strictly-lower-today number.

## Tests (one per touched file, each with `// what this catches:`)

- `positron_observer_carries_its_observer_id_and_no_grants` — constructor keeps the id, no grants.
- `positron_observer_never_rides_the_human_socket_authority_up` — **THE clamp**: same Owner-registered `peer_id` → `Ws` allowed `code/shell`, observer forbidden (bridge ignored); observer still allowed `ai/generate`.
- `observer_and_human_sources_map_to_distinct_attenuated_identities` — dispatch maps the two sources to distinct identities.

## Validation

`cargo check` clean + all 3 tests green (`--features metal,accelerate`). Pre-existing warnings only; no new ones from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)