### PR TITLE
feat(positron): runtime wall projector (task #89 Unit 2)

### DIFF
--- a/core/continuum-core/src/airc/inbound_attach.rs
+++ b/core/continuum-core/src/airc/inbound_attach.rs
@@ -14,6 +14,7 @@ use tracing::warn;
 
 use crate::airc::realtime_wire::{bus_event_from_envelope, envelope_from_event};
 use crate::ipc::positron_source::CHAT_POSTED;
+use crate::ipc::positron_wall_source::WALL_CHANGED;
 use crate::runtime::MessageBus;
 
 pub fn spawn_daemon_attach(
@@ -104,7 +105,14 @@ pub async fn publish_transcript_event(
         // ours here → skip. This is classification, not a fallback —
         // a non-message never fabricates a chat event.
         Ok(None) => {
+            // Classify the plain airc event into a positron projection
+            // signal. A message → `chat:posted`; a wall post → `wall:changed`
+            // (a re-read cue, not the content). An event is at most one of
+            // these; anything else is not ours here → skip. Classification,
+            // never a fallback — a non-matching kind fabricates nothing.
             if let Some((name, payload)) = chat_posted_from_message(event) {
+                bus.publish_async_only(name, payload);
+            } else if let Some((name, payload)) = wall_changed_from_event(event) {
                 bus.publish_async_only(name, payload);
             }
             return Ok(());
@@ -147,6 +155,28 @@ fn chat_posted_from_message(
         "timestamp": event.occurred_at_ms,
     });
     Some((CHAT_POSTED, payload))
+}
+
+/// Project a `WallPostPublished` transcript event into the `wall:changed`
+/// bus signal the positron wall projection consumes (`AircWallChanged` in
+/// `ipc/positron_wall_source.rs`). Returns `None` for any other kind.
+///
+/// The signal carries ONLY the `room_id`: the pinned board is airc's
+/// supersede projection (`Airc::wall_posts`), which cannot be
+/// reconstructed from a single delta, so the consumer RE-READS the
+/// authoritative board rather than trusting this event's body. This is
+/// why we emit a change *cue*, not the post content — the exact
+/// re-read-not-fold discipline the wall projector documents.
+fn wall_changed_from_event(
+    event: &airc_core::TranscriptEvent,
+) -> Option<(&'static str, serde_json::Value)> {
+    if event.kind != TranscriptKind::WallPostPublished {
+        return None;
+    }
+    let payload = serde_json::json!({
+        "roomId": event.room_id.as_uuid(),
+    });
+    Some((WALL_CHANGED, payload))
 }
 
 #[cfg(test)]
@@ -291,6 +321,34 @@ mod tests {
         assert!(timeout(Duration::from_millis(20), receiver.recv())
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    async fn wall_post_event_projects_thin_wall_changed_signal() {
+        // what this catches: the wall classification arm (task #89 Unit 2).
+        // A `WallPostPublished` transcript event (no continuum envelope)
+        // must project a `wall:changed` bus signal carrying ONLY the
+        // room_id — the re-read cue the positron wall projector folds. The
+        // signal must NOT carry post content (the supersede-projected board
+        // is re-read from airc, never reconstructed from one delta). A
+        // regression that drops this arm silently stops every pinned board
+        // from ever updating on the renderer.
+        let bus = MessageBus::new();
+        let mut receiver = bus.receiver();
+        let mut event = transcript_event(None, Default::default());
+        event.kind = TranscriptKind::WallPostPublished;
+
+        publish_transcript_event(&event, &bus).await.unwrap();
+
+        let delivered = timeout(Duration::from_millis(200), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(delivered.name, "wall:changed");
+        assert_eq!(delivered.payload["roomId"], Uuid::from_u128(2).to_string());
+        // A cue, not the content: the board is re-read authoritatively.
+        assert!(delivered.payload.get("body").is_none());
+        assert!(delivered.payload.get("category").is_none());
     }
 
     #[tokio::test]

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -110,6 +110,7 @@ pub mod diagnostics;
 pub mod positron_dispatch;
 pub mod positron_presence;
 pub mod positron_source;
+pub mod positron_wall_source;
 pub mod protocol;
 pub mod ws;
 
@@ -2384,18 +2385,43 @@ pub fn start_server(
                 // fallback — an honestly-disabled projection).
                 match node_presence_deps.clone().zip(persona_bootstrap_room_name.clone()) {
                     Some(((daemon_socket, room_id), room_name)) => {
-                        let node_home =
-                            crate::modules::persona_instance_manager::resolve_continuum_root()
-                                .join("citizens")
-                                .join("node")
-                                .join("presence")
-                                .join("airc");
+                        let continuum_root =
+                            crate::modules::persona_instance_manager::resolve_continuum_root();
+                        let node_home = continuum_root
+                            .join("citizens")
+                            .join("node")
+                            .join("presence")
+                            .join("airc");
                         positron_presence::spawn_node_presence_emitter(
                             &state.rt_handle,
-                            daemon_socket,
+                            daemon_socket.clone(),
                             node_home,
                             room_id.as_uuid(),
+                            room_name.clone(),
+                            projection_bus.clone(),
+                        );
+
+                        // Wall projector: the consuming half of `wall:changed`.
+                        // A dedicated node reader (own home + identity, distinct
+                        // from the presence lurker) re-reads the airc-owned
+                        // supersede-projected board on each change and stores it
+                        // as `kind="wall"`, so a chat window shows its pinned
+                        // board with zero resident personas. Same (socket, room)
+                        // precondition as presence — an empty roster would leave
+                        // wall authors provisionally labelled, but the board
+                        // itself still renders.
+                        let wall_home = continuum_root
+                            .join("citizens")
+                            .join("node")
+                            .join("wall")
+                            .join("airc");
+                        positron_wall_source::spawn_node_wall_projector(
+                            &state.rt_handle,
+                            daemon_socket,
+                            wall_home,
+                            room_id.as_uuid(),
                             room_name,
+                            ws_substrate.clone(),
                             projection_bus,
                         );
                     }

--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -192,11 +192,67 @@ pub(crate) struct AircPresenceSlot {
 /// opaque badges + accountability provenance. A struct (not an
 /// ever-widening tuple) so adding the next identity axis is a field, not
 /// a re-thread of every call site.
-struct ResolvedSender {
-    name: String,
-    kind: SenderKind,
-    integrations: BTreeMap<String, String>,
-    provenance: Provenance,
+///
+/// `pub(crate)` because the wall projection
+/// (`crate::ipc::positron_wall_source`) resolves a pinned post's AUTHOR
+/// the same way this projection resolves a message's SENDER — one
+/// identity-resolution decision, one place ([[compression]]).
+pub(crate) struct ResolvedSender {
+    pub(crate) name: String,
+    pub(crate) kind: SenderKind,
+    pub(crate) integrations: BTreeMap<String, String>,
+    pub(crate) provenance: Provenance,
+}
+
+/// Resolve an identity (a message sender OR a wall-post author) from the
+/// room roster. A member present in the roster (its `presence:updated`
+/// card folded in) resolves richly — name, neutral kind, opaque badges,
+/// accountability provenance. A member whose card has not folded in yet
+/// resolves **provisionally**: a short peer-id label, neutral `Human`,
+/// empty badges, unresolved provenance — a provisional projection pending
+/// authoritative truth, never a fabricated identity
+/// ([[fallbacks-are-illegal-fail-loud]]). Upgraded in place the instant
+/// the card lands (see `reresolve_messages`, and the wall projector's
+/// re-render on presence).
+///
+/// A free function over `&[RosterSlotView]` (not a method) so both the
+/// chat and wall projections share the exact resolution — the compression
+/// point of extracting it.
+pub(crate) fn resolve_identity(roster: &[RosterSlotView], id: Uuid) -> ResolvedSender {
+    match roster.iter().find(|s| s.member_id == id) {
+        Some(slot) => ResolvedSender {
+            name: slot.display_name.clone(),
+            kind: slot.kind,
+            integrations: slot.integrations.clone(),
+            provenance: slot.provenance.clone(),
+        },
+        None => ResolvedSender {
+            name: provisional_sender_name(id),
+            kind: SenderKind::Human,
+            integrations: BTreeMap::new(),
+            provenance: Provenance::unresolved(),
+        },
+    }
+}
+
+/// Project a presence snapshot's roster into the renderer-shaped
+/// [`RosterSlotView`] rows. Shared by the chat projection (which stores
+/// them on the `ChatViewState`) and the wall projection (which holds them
+/// only as its author-resolution lookup table) — one wire-shape
+/// conversion, one place ([[compression]]).
+pub(crate) fn roster_slots_from(update: &AircPresenceUpdate) -> Vec<RosterSlotView> {
+    update
+        .roster
+        .iter()
+        .map(|s| RosterSlotView {
+            member_id: s.member_id,
+            display_name: s.display_name.clone(),
+            kind: s.kind,
+            integrations: s.integrations.clone(),
+            provenance: s.provenance.clone(),
+            active: s.active,
+        })
+        .collect()
 }
 
 /// Accumulates airc room events into the renderer-shaped
@@ -248,31 +304,6 @@ impl ChatProjection {
         }
     }
 
-    /// Resolve a sender's display name / kind / badges / provenance from
-    /// the roster. The roster is airc presence joined with identity cards
-    /// (`presence:updated`); a sender present there renders richly. A
-    /// sender whose card has not folded in yet renders **provisionally**
-    /// — a short peer-id label, neutral `Human`, empty badges, unresolved
-    /// provenance — upgraded in place the instant presence lands. This is
-    /// a provisional projection pending authoritative truth, never a
-    /// fabricated identity ([[fallbacks-are-illegal-fail-loud]]).
-    fn resolve_sender(&self, sender_id: Uuid) -> ResolvedSender {
-        match self.roster.iter().find(|s| s.member_id == sender_id) {
-            Some(slot) => ResolvedSender {
-                name: slot.display_name.clone(),
-                kind: slot.kind,
-                integrations: slot.integrations.clone(),
-                provenance: slot.provenance.clone(),
-            },
-            None => ResolvedSender {
-                name: provisional_sender_name(sender_id),
-                kind: SenderKind::Human,
-                integrations: BTreeMap::new(),
-                provenance: Provenance::unresolved(),
-            },
-        }
-    }
-
     /// Fold a posted message into the view and store the new snapshot.
     /// Idempotent on `message_id`: a redelivered event (the bus is
     /// best-effort) does not double-append. Identity is resolved from the
@@ -282,7 +313,7 @@ impl ChatProjection {
         if self.messages.iter().any(|m| m.id == msg.message_id) {
             return;
         }
-        let resolved = self.resolve_sender(msg.sender_id);
+        let resolved = resolve_identity(&self.roster, msg.sender_id);
         self.messages.push_back(ChatMessageView {
             id: msg.message_id,
             room_id: msg.room_id,
@@ -307,19 +338,8 @@ impl ChatProjection {
     /// arrived) now that the card is known.
     fn apply_presence(&mut self, update: AircPresenceUpdate) {
         self.switch_room(update.room_id);
+        self.roster = roster_slots_from(&update);
         self.room_name = update.room_name;
-        self.roster = update
-            .roster
-            .into_iter()
-            .map(|s| RosterSlotView {
-                member_id: s.member_id,
-                display_name: s.display_name,
-                kind: s.kind,
-                integrations: s.integrations,
-                provenance: s.provenance,
-                active: s.active,
-            })
-            .collect();
         self.reresolve_messages();
         self.store();
     }

--- a/core/continuum-core/src/ipc/positron_wall_source.rs
+++ b/core/continuum-core/src/ipc/positron_wall_source.rs
@@ -78,7 +78,7 @@ use crate::ipc::positron_source::{
     resolve_identity, roster_slots_from, AircPresenceUpdate, PRESENCE_UPDATED,
 };
 use crate::persona::wall_source::WallReader;
-use crate::runtime::MessageBus;
+use crate::runtime::{BusEvent, MessageBus};
 
 /// Bus event signalling that a `WallPostPublished` transcript event landed
 /// for a room — the projector's cue to RE-READ the authoritative board.
@@ -248,9 +248,29 @@ async fn run_wall_loop(
     let mut projection = WallProjection::new(substrate, room_id, reader);
     // Initial authoritative read — render the current board immediately.
     projection.reload().await;
-    loop {
-        match rx.recv().await {
-            Ok(event) => match classify(&event.name, &event.payload) {
+    while let LoopStep::Continue = fold_recv(&mut projection, room_id, rx.recv().await).await {}
+}
+
+/// Whether the consume loop keeps folding after one bus receive.
+#[derive(Debug, PartialEq, Eq)]
+enum LoopStep {
+    Continue,
+    Stop,
+}
+
+/// Fold ONE bus receive into the projection — the loop's entire per-event
+/// decision, factored out so the room-guard / `Lagged` / `Closed` branches
+/// are unit-testable without racing a live broadcast channel (the loop
+/// itself is an infinite `recv().await`, so the branches would otherwise be
+/// trust-me). Pure control-flow over the projection; no bus access.
+async fn fold_recv(
+    projection: &mut WallProjection,
+    room_id: Uuid,
+    recv: Result<BusEvent, RecvError>,
+) -> LoopStep {
+    match recv {
+        Ok(event) => {
+            match classify(&event.name, &event.payload) {
                 // Re-read only when the change is for OUR room (defensive
                 // room guard; the node observes exactly this room today).
                 Some(WallInput::Changed(rid)) if rid == room_id => projection.reload().await,
@@ -258,13 +278,17 @@ async fn run_wall_loop(
                     projection.apply_roster(roster)
                 }
                 _ => {}
-            },
-            // Fell behind the broadcast buffer: the projection is a
-            // last-good cache of a live stream, not guaranteed delivery.
-            // Re-read to re-establish a coherent board, then keep folding.
-            Err(RecvError::Lagged(_)) => projection.reload().await,
-            Err(RecvError::Closed) => break,
+            }
+            LoopStep::Continue
         }
+        // Fell behind the broadcast buffer: the projection is a last-good
+        // cache of a live stream, not guaranteed delivery. Re-read to
+        // re-establish a coherent board, then keep folding.
+        Err(RecvError::Lagged(_)) => {
+            projection.reload().await;
+            LoopStep::Continue
+        }
+        Err(RecvError::Closed) => LoopStep::Stop,
     }
 }
 
@@ -360,19 +384,30 @@ mod tests {
     /// driven without a daemon (mirrors `wall_source::tests::StubReader`).
     struct StubReader {
         posts: Mutex<Vec<WallPostPublished>>,
+        fail: Mutex<bool>,
     }
 
     impl StubReader {
         fn new(posts: Vec<WallPostPublished>) -> Arc<Self> {
             Arc::new(Self {
                 posts: Mutex::new(posts),
+                fail: Mutex::new(false),
             })
+        }
+        /// Flip the reader into failure mode — the next `wall_posts()`
+        /// returns a terminal-shaped `AircError` (mirrors
+        /// `wall_source::tests::StubReader::set_fail`).
+        fn set_fail(&self, fail: bool) {
+            *self.fail.lock().unwrap() = fail;
         }
     }
 
     #[async_trait]
     impl WallReader for StubReader {
         async fn wall_posts(&self) -> Result<Vec<WallPostPublished>, airc_lib::AircError> {
+            if *self.fail.lock().unwrap() {
+                return Err(airc_lib::AircError::UnknownPeer(PeerId::new()));
+            }
             Ok(self.posts.lock().unwrap().clone())
         }
     }
@@ -536,5 +571,96 @@ mod tests {
         }
         let r2 = substrate.cache().get(KnownKind::Wall.wire_name()).unwrap().revision;
         assert!(r2 > r1, "revision must advance: {r1:?} -> {r2:?}");
+    }
+
+    #[tokio::test]
+    async fn read_error_keeps_the_last_good_board() {
+        // what this catches: the projector's DISTINCT resilience contract —
+        // a `wall_posts()` read failure must keep the last-good board on the
+        // widget, never blink it empty. This is the difference from the
+        // RagSource path (which reads fresh each turn); here a stale board is
+        // the honest render while the reader reconnects. A regression that
+        // cleared `posts` on error, or stored an empty view, would flash the
+        // board blank on every transient airc hiccup
+        // ([[fallbacks-are-illegal-fail-loud]]: resilience, never a
+        // fabricated empty substitute).
+        let substrate = Substrate::new();
+        let room = RoomId::new();
+        let author = PeerId::new();
+        let reader = StubReader::new(vec![post(room, author, "plan", "v1")]);
+        let mut p = WallProjection::new(substrate.clone(), room.as_uuid(), reader.clone());
+        p.reload().await;
+        assert_eq!(current_wall(&substrate).posts.len(), 1);
+
+        // The reader goes down mid-stream; the re-read fails.
+        reader.set_fail(true);
+        p.reload().await;
+
+        let view = current_wall(&substrate);
+        assert_eq!(view.posts.len(), 1, "last-good board survives a read error");
+        assert_eq!(view.posts[0].body, "v1");
+    }
+
+    #[tokio::test]
+    async fn lagged_re_reads_to_re_establish_coherence() {
+        // what this catches: the projector's one behavioral improvement over
+        // the chat projection — on a broadcast `Lagged` (fell behind the
+        // buffer) it RE-READS the authoritative board rather than `continue`-
+        // ing on a possibly-stale one. A refactor that flipped this back to a
+        // silent continue would leave the board stale after any burst. Drives
+        // the exact loop decision via `fold_recv` (no racing a live channel).
+        let substrate = Substrate::new();
+        let room = RoomId::new();
+        let author = PeerId::new();
+        let reader = StubReader::new(vec![]);
+        let mut p = WallProjection::new(substrate.clone(), room.as_uuid(), reader.clone());
+        p.reload().await;
+        assert!(current_wall(&substrate).posts.is_empty());
+
+        // Board gains a post while the loop was behind; a Lagged arrives.
+        reader.posts.lock().unwrap().push(post(room, author, "plan", "caught up"));
+        let step = fold_recv(&mut p, room.as_uuid(), Err(RecvError::Lagged(3))).await;
+        assert_eq!(step, LoopStep::Continue);
+        assert_eq!(
+            current_wall(&substrate).posts.len(),
+            1,
+            "Lagged must trigger an authoritative re-read, not a stale continue"
+        );
+    }
+
+    #[tokio::test]
+    async fn closed_channel_stops_the_loop_and_foreign_room_is_not_re_read() {
+        // what this catches: two loop-guard branches that are otherwise
+        // trust-me (the loop is an infinite recv). (1) A `Closed` bus stops
+        // the loop (Stop) — no spin. (2) A `wall:changed` for a DIFFERENT
+        // room is NOT re-read: the defensive room guard drops it, so a foreign
+        // room's churn can't thrash this projector's board.
+        let substrate = Substrate::new();
+        let room = RoomId::new();
+        let author = PeerId::new();
+        let reader = StubReader::new(vec![post(room, author, "plan", "mine")]);
+        let mut p = WallProjection::new(substrate.clone(), room.as_uuid(), reader.clone());
+        p.reload().await;
+
+        // A change for some OTHER room: the board must not re-read/change.
+        let other = Uuid::from_u128(0xdead);
+        let foreign = BusEvent {
+            name: WALL_CHANGED.to_string(),
+            payload: json!({ "roomId": other }),
+        };
+        // Even if the board content changed underneath, a foreign event must
+        // not fold it in.
+        reader.posts.lock().unwrap().clear();
+        let step = fold_recv(&mut p, room.as_uuid(), Ok(foreign)).await;
+        assert_eq!(step, LoopStep::Continue);
+        assert_eq!(
+            current_wall(&substrate).posts.len(),
+            1,
+            "a foreign room's wall:changed must not re-read our board"
+        );
+
+        // A closed bus stops the loop.
+        let step = fold_recv(&mut p, room.as_uuid(), Err(RecvError::Closed)).await;
+        assert_eq!(step, LoopStep::Stop);
     }
 }

--- a/core/continuum-core/src/ipc/positron_wall_source.rs
+++ b/core/continuum-core/src/ipc/positron_wall_source.rs
@@ -1,0 +1,540 @@
+//! The airc → positron **wall projection** (task #89 — the room's pinned
+//! shared documents as renderer-shaped `WallViewState`).
+//!
+//! ## What this is
+//!
+//! The sibling of [`crate::ipc::positron_source`]: that consumer projects
+//! the room's *conversation* (`kind="chat"`); this one projects the room's
+//! *pinned board* — the plan, the coding instructions, the agenda, the
+//! principles, the recipe (`kind="wall"`). Both are passive consumers of
+//! the airc room stream on the `MessageBus`, off the transport hot path,
+//! writing a renderer-shaped snapshot to the thin-client [`Substrate`]
+//! that WS sessions read.
+//!
+//! ## Why this projector RE-READS instead of folding deltas
+//!
+//! The wall is event-sourced with a **supersede chain**: a revision
+//! publishes a new `WallPostPublished` pointing at the prior, an unpin
+//! archives with an empty body, and the *currently-pinned* board is the
+//! projection of that whole chain. That supersede walk is **airc-owned**
+//! (`Airc::wall_posts` — private projection internals in airc-lib). So,
+//! unlike the chat projection (which folds each `chat:posted` into a ring
+//! it owns), this projector does NOT re-implement the supersede fold — it
+//! **re-reads** airc's authoritative `wall_posts()` through the existing
+//! [`WallReader`] seam on each wall change. One supersede impl, in airc
+//! ([[compression]]); the continuum side is a cache of airc's truth, never
+//! a second store of it ([[airc-native-identity-rooms-security]]).
+//!
+//! ## The two bus streams it folds
+//!
+//! - **`wall:changed`** — a `WallPostPublished` transcript event landed
+//!   for this room (emitted by
+//!   [`crate::airc::inbound_attach::publish_transcript_event`] when it
+//!   sees `TranscriptKind::WallPostPublished`). The projector RE-READS the
+//!   board via `wall_posts()` and re-projects. The signal carries only the
+//!   `room_id`; the post content comes from the authoritative re-read,
+//!   never from the signal (the supersede projection can't be reconstructed
+//!   from one delta).
+//! - **`presence:updated`** — the room roster changed. The wall carries
+//!   only a `published_by` peer id, never an author name (identity is a
+//!   presence fact, not a content fact — the exact discipline
+//!   `AircChatPosted` follows). So the projector holds the roster as its
+//!   **author-resolution lookup table** and re-projects when it changes, so
+//!   a post pinned before its author's card arrived UPGRADES from a
+//!   provisional peer-id label to the real name in place. This reuses the
+//!   SAME `presence:updated` stream and the SAME identity resolver the chat
+//!   projection uses ([[compression]]).
+//!
+//! ## Attribution is woven in from day one
+//!
+//! A pinned document is an authored, accountable act — per
+//! `[[positron-identity-security-first-class]]` each projected post carries
+//! the author's neutral kind + opaque badges + accountability provenance,
+//! resolved from the roster by [`resolve_identity`] exactly as a chat
+//! sender is. positron stays neutral (an AI author is an `Agent`; whose
+//! agent rides `integrations`), read at the app layer.
+//!
+//! ## Single focused room
+//!
+//! The projector is bound to ONE room at construction — the node's
+//! bootstrap room, the same room its [`WallReader`] handle joined and the
+//! same room the presence emitter serves. A `wall:changed` /
+//! `presence:updated` for any other room is ignored (a defensive room
+//! guard; today the node observes exactly this room). Per-room instancing
+//! is the same deferred `RevisionKey` note the chat projection carries.
+
+use std::sync::Arc;
+
+use airc_core::doctrine::WallPostPublished;
+use tokio::sync::broadcast::error::RecvError;
+use uuid::Uuid;
+
+use continuum_positron::{
+    KnownKind, RosterSlotView, StateBuilder, Substrate, WallPostView, WallViewState,
+};
+use serde::Deserialize;
+
+use crate::ipc::positron_source::{
+    resolve_identity, roster_slots_from, AircPresenceUpdate, PRESENCE_UPDATED,
+};
+use crate::persona::wall_source::WallReader;
+use crate::runtime::MessageBus;
+
+/// Bus event signalling that a `WallPostPublished` transcript event landed
+/// for a room — the projector's cue to RE-READ the authoritative board.
+///
+/// `pub(crate)` because the EMITTER
+/// (`airc::inbound_attach::publish_transcript_event`) and this CONSUMER
+/// must agree on the wire name — one string, one source of truth
+/// ([[compression]]), exactly as
+/// [`crate::ipc::positron_source::CHAT_POSTED`] is shared.
+pub(crate) const WALL_CHANGED: &str = "wall:changed";
+
+/// Typed `wall:changed` payload. Deliberately carries ONLY the `room_id`:
+/// the post content is never trusted from the signal (the supersede
+/// projection can't be reconstructed from a single delta), so the
+/// projector re-reads `wall_posts()` for the authoritative board. camelCase
+/// matches the bus JSON convention.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AircWallChanged {
+    room_id: Uuid,
+}
+
+/// Accumulates the room's pinned board into the renderer-shaped
+/// [`WallViewState`] and writes each transition to the [`Substrate`].
+///
+/// Holds the last authoritative `posts` read (airc-owned supersede
+/// projection) plus the roster it resolves authors against. Not `Clone` —
+/// one owner per projection; the consume loop owns it.
+struct WallProjection {
+    substrate: Substrate,
+    builder: StateBuilder,
+    /// The single room this projector describes (the node's bootstrap
+    /// room). Fixed at construction — the `WallReader` handle is joined to
+    /// exactly this room.
+    room_id: Uuid,
+    /// Last authoritative board read from `wall_posts()` — the airc-owned
+    /// supersede projection, never a continuum-folded copy.
+    posts: Vec<WallPostPublished>,
+    /// Author-resolution lookup table (from `presence:updated`). NOT stored
+    /// on the view — the wall view carries resolved authors, not the whole
+    /// roster (a wall widget renders documents, not a member list).
+    roster: Vec<RosterSlotView>,
+    reader: Arc<dyn WallReader>,
+}
+
+impl WallProjection {
+    fn new(substrate: Substrate, room_id: Uuid, reader: Arc<dyn WallReader>) -> Self {
+        Self {
+            substrate,
+            // Sole writer of the `wall` kind → its own standalone
+            // `Revisions` well is the authoritative monotonic source for
+            // that kind (same discipline as the chat projection).
+            builder: StateBuilder::standalone(),
+            room_id,
+            posts: Vec::new(),
+            roster: Vec::new(),
+            reader,
+        }
+    }
+
+    /// Re-read the authoritative board via the [`WallReader`] and store the
+    /// re-projected view. A read error keeps the last-good board on the
+    /// widget rather than blinking it empty — the reader (`airc_lib::Airc`)
+    /// owns reconnection ([[persona-airc-resilience]]); a transient failure
+    /// must not fabricate an empty board ([[fallbacks-are-illegal-fail-loud]]:
+    /// resilience, never a fabricated substitute).
+    async fn reload(&mut self) {
+        match self.reader.wall_posts().await {
+            Ok(posts) => {
+                self.posts = posts;
+                self.store();
+            }
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    room_id = %self.room_id,
+                    "positron_wall: wall_posts read failed — keeping last board (reader owns reconnection)"
+                );
+            }
+        }
+    }
+
+    /// Replace the author-resolution roster and re-project, so any post
+    /// pinned before its author's card arrived upgrades from a provisional
+    /// label to the resolved name in place.
+    fn apply_roster(&mut self, roster: Vec<RosterSlotView>) {
+        self.roster = roster;
+        self.store();
+    }
+
+    /// Project one airc `WallPostPublished` into a renderer-shaped
+    /// [`WallPostView`], resolving the author from the current roster.
+    fn project_post(&self, post: &WallPostPublished) -> WallPostView {
+        let author_id = post.published_by.as_uuid();
+        let resolved = resolve_identity(&self.roster, author_id);
+        WallPostView {
+            post_id: post.post_id,
+            room_id: post.room_id.as_uuid(),
+            category: post.category.clone(),
+            author_id,
+            author_name: resolved.name,
+            author_kind: resolved.kind,
+            integrations: resolved.integrations,
+            provenance: resolved.provenance,
+            body: post.body.clone(),
+            timestamp: post.published_at_ms,
+        }
+    }
+
+    /// Frame the current board as a `wall` `StateEnvelope` and write it to
+    /// the substrate (cache + live broadcast). Persistent-tier: the wall is
+    /// long-lived pinned state (< 1 Hz), not the user-perceivable chat
+    /// cadence.
+    fn store(&self) {
+        let posts = self.posts.iter().map(|p| self.project_post(p)).collect();
+        let view = WallViewState {
+            room_id: self.room_id,
+            posts,
+        };
+        self.substrate
+            .store(self.builder.persistent(KnownKind::Wall, view));
+    }
+}
+
+/// A bus event classified into a wall projection input, or `None` when the
+/// event is not one this projection folds. Pure — no substrate side effect,
+/// no reader I/O — so it's unit-testable without a live bus or daemon.
+enum WallInput {
+    /// A wall change landed for this `room_id` — cue to re-read the board.
+    Changed(Uuid),
+    /// The room roster changed (for this `room_id`) — new author lookup.
+    Presence(Uuid, Vec<RosterSlotView>),
+}
+
+fn classify(name: &str, payload: &serde_json::Value) -> Option<WallInput> {
+    // The airc bus wraps event bodies under a `payload` key (see
+    // `positron_source::classify`); accept a nested `payload` object, else
+    // the top-level value — one unwrap convention across the projections.
+    let body = payload.get("payload").unwrap_or(payload);
+    match name {
+        WALL_CHANGED => serde_json::from_value::<AircWallChanged>(body.clone())
+            .ok()
+            .map(|c| WallInput::Changed(c.room_id)),
+        PRESENCE_UPDATED => serde_json::from_value::<AircPresenceUpdate>(body.clone())
+            .ok()
+            .map(|u| WallInput::Presence(u.room_id, roster_slots_from(&u))),
+        _ => None,
+    }
+}
+
+/// Run the wall projection consume loop against an already-attached
+/// [`WallReader`]. Subscribes to the bus, does an initial authoritative
+/// read (so the board renders at boot without waiting for a change), then
+/// folds `wall:changed` / `presence:updated` for its room.
+///
+/// The receiver is taken BEFORE the initial read so a change racing the
+/// boot read is still caught by the loop (a redundant re-read is idempotent
+/// — it just re-reads the same authoritative board). Runs for the process
+/// lifetime.
+async fn run_wall_loop(
+    substrate: Substrate,
+    room_id: Uuid,
+    reader: Arc<dyn WallReader>,
+    bus: Arc<MessageBus>,
+) {
+    let mut rx = bus.receiver();
+    let mut projection = WallProjection::new(substrate, room_id, reader);
+    // Initial authoritative read — render the current board immediately.
+    projection.reload().await;
+    loop {
+        match rx.recv().await {
+            Ok(event) => match classify(&event.name, &event.payload) {
+                // Re-read only when the change is for OUR room (defensive
+                // room guard; the node observes exactly this room today).
+                Some(WallInput::Changed(rid)) if rid == room_id => projection.reload().await,
+                Some(WallInput::Presence(rid, roster)) if rid == room_id => {
+                    projection.apply_roster(roster)
+                }
+                _ => {}
+            },
+            // Fell behind the broadcast buffer: the projection is a
+            // last-good cache of a live stream, not guaranteed delivery.
+            // Re-read to re-establish a coherent board, then keep folding.
+            Err(RecvError::Lagged(_)) => projection.reload().await,
+            Err(RecvError::Closed) => break,
+        }
+    }
+}
+
+/// Fixed identity name for the node-level wall reader. Like the presence
+/// reader, it attaches as a **heartbeat-less lurker** (reads the daemon's
+/// authoritative transcript without ever appearing in the roster) — a
+/// distinct name from the presence reader so the two node lurkers hold
+/// independent keypairs and neither's lifecycle blinks the other.
+const NODE_WALL_READER_NAME: &str = "continuum-wall";
+
+/// Attach a node-level wall reader and run the wall projection for one
+/// room. The **consuming half** of the `wall:changed` stream: it subscribes
+/// to the bus (fed by `inbound_attach`) and re-reads the airc-owned board
+/// on each change.
+///
+/// Mirrors [`crate::ipc::positron_presence::spawn_node_presence_emitter`]:
+/// a dedicated node reader (not a persona's handle) so the wall renders
+/// with **zero resident personas** — a chat window with no persona present
+/// still shows its pinned board. A failed attach/join means the projection
+/// can't start; it logs the cause loudly and the task exits (the WS server
+/// is optional → a disabled feature, not a substrate-wide panic;
+/// [[fallbacks-are-illegal-fail-loud]]: no fabricated board is ever
+/// substituted).
+pub fn spawn_node_wall_projector(
+    rt: &tokio::runtime::Handle,
+    daemon_socket: std::path::PathBuf,
+    node_home: std::path::PathBuf,
+    room_id: Uuid,
+    room_name: String,
+    substrate: Substrate,
+    bus: Arc<MessageBus>,
+) {
+    rt.spawn(async move {
+        if let Err(err) = tokio::fs::create_dir_all(&node_home).await {
+            tracing::error!(
+                error = %err,
+                home = %node_home.display(),
+                "positron_wall: cannot create node reader home — wall projection disabled"
+            );
+            return;
+        }
+        let airc = match airc_lib::Airc::attach_as(
+            node_home.clone(),
+            NODE_WALL_READER_NAME,
+            daemon_socket,
+        )
+        .await
+        {
+            Ok(airc) => airc,
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    home = %node_home.display(),
+                    "positron_wall: node reader attach failed — wall projection disabled"
+                );
+                return;
+            }
+        };
+        // Join by NAME (never UUID-as-string, which derives a DIFFERENT
+        // channel — the recurring hazard `positron_presence` documents).
+        // The reader must share the operator's channel or its wall reads
+        // land in an empty derived room.
+        if let Err(err) = airc.join(&room_name).await {
+            tracing::error!(
+                error = %err,
+                room = %room_name,
+                "positron_wall: node reader could not join room — wall projection disabled"
+            );
+            return;
+        }
+        // `airc_lib::Airc` satisfies `WallReader` directly (impl in
+        // `persona::wall_source`) — reuse it, no adapter.
+        let reader: Arc<dyn WallReader> = Arc::new(airc);
+        tracing::info!(
+            %room_id,
+            room = %room_name,
+            "positron_wall: node reader attached — projecting kind=wall"
+        );
+        run_wall_loop(substrate, room_id, reader, bus).await;
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{PeerId, RoomId};
+    use async_trait::async_trait;
+    use continuum_positron::SenderKind;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    /// A `WallReader` stub returning canned posts — lets the projection be
+    /// driven without a daemon (mirrors `wall_source::tests::StubReader`).
+    struct StubReader {
+        posts: Mutex<Vec<WallPostPublished>>,
+    }
+
+    impl StubReader {
+        fn new(posts: Vec<WallPostPublished>) -> Arc<Self> {
+            Arc::new(Self {
+                posts: Mutex::new(posts),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl WallReader for StubReader {
+        async fn wall_posts(&self) -> Result<Vec<WallPostPublished>, airc_lib::AircError> {
+            Ok(self.posts.lock().unwrap().clone())
+        }
+    }
+
+    fn post(room: RoomId, author: PeerId, category: &str, body: &str) -> WallPostPublished {
+        WallPostPublished {
+            room_id: room,
+            post_id: Uuid::new_v4(),
+            category: category.to_string(),
+            body: body.to_string(),
+            supersedes: None,
+            published_by: author,
+            published_at_ms: 1_700_000_000_000,
+        }
+    }
+
+    fn presence_one(room: Uuid, member: Uuid, name: &str, kind: &str) -> serde_json::Value {
+        json!({
+            "roomId": room,
+            "roomName": "general",
+            "roster": [
+                {
+                    "memberId": member,
+                    "displayName": name,
+                    "kind": { "kind": kind },
+                    "integrations": { "continuum.persona_id": "asha-1" },
+                    "provenance": { "runtime": "claude" },
+                    "active": true,
+                }
+            ],
+        })
+    }
+
+    fn current_wall(substrate: &Substrate) -> WallViewState {
+        let env = substrate
+            .cache()
+            .get(KnownKind::Wall.wire_name())
+            .expect("a wall envelope must be stored");
+        serde_json::from_value(env.payload.clone()).expect("payload is a WallViewState")
+    }
+
+    #[tokio::test]
+    async fn reload_projects_the_board_into_the_substrate() {
+        // what this catches: regression where a wall re-read does not reach
+        // the substrate as a WallViewState — the whole point of the wall
+        // projection. With no presence yet, the author renders provisionally
+        // (short peer-id label, neutral Human) — the honest pending-truth
+        // state, never a fabricated author.
+        let substrate = Substrate::new();
+        let room = RoomId::new();
+        let author = PeerId::new();
+        let reader = StubReader::new(vec![post(room, author, "plan", "Ship the wall slice.")]);
+        let mut p = WallProjection::new(substrate.clone(), room.as_uuid(), reader);
+        p.reload().await;
+
+        let view = current_wall(&substrate);
+        assert_eq!(view.room_id, room.as_uuid());
+        assert_eq!(view.posts.len(), 1);
+        assert_eq!(view.posts[0].category, "plan");
+        assert_eq!(view.posts[0].body, "Ship the wall slice.");
+        assert_eq!(view.posts[0].author_id, author.as_uuid());
+        assert_eq!(view.posts[0].author_kind, SenderKind::Human);
+        assert!(
+            view.posts[0].author_name.starts_with("peer-"),
+            "provisional author label until presence, got {}",
+            view.posts[0].author_name
+        );
+        assert!(view.posts[0].integrations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn author_upgrades_in_place_when_presence_folds_the_card() {
+        // what this catches: the attribution-woven-in contract — a post
+        // pinned before its author's card arrives renders provisionally,
+        // then UPGRADES (name + kind + badges + provenance) the instant
+        // presence folds the card. A regression that dropped the re-project
+        // on presence would leave the author stuck as "peer-xxxx"/Human
+        // forever, unattributable. [[positron-identity-security-first-class]].
+        let substrate = Substrate::new();
+        let room = RoomId::new();
+        let author = PeerId::new();
+        let reader = StubReader::new(vec![post(room, author, "rules", "Fail loud.")]);
+        let mut p = WallProjection::new(substrate.clone(), room.as_uuid(), reader);
+        p.reload().await;
+        assert_eq!(current_wall(&substrate).posts[0].author_kind, SenderKind::Human);
+
+        // Card arrives via presence: Agent named Asha carrying a badge.
+        let presence = presence_one(room.as_uuid(), author.as_uuid(), "Asha", "agent");
+        match classify(PRESENCE_UPDATED, &presence).expect("presence classifies") {
+            WallInput::Presence(rid, roster) => {
+                assert_eq!(rid, room.as_uuid());
+                p.apply_roster(roster);
+            }
+            _ => panic!("presence:updated must classify as Presence"),
+        }
+        let view = current_wall(&substrate);
+        assert_eq!(view.posts[0].author_name, "Asha");
+        assert_eq!(view.posts[0].author_kind, SenderKind::Agent);
+        assert_eq!(
+            view.posts[0].integrations.get("continuum.persona_id").map(String::as_str),
+            Some("asha-1"),
+            "opaque badge resolved from the card"
+        );
+        assert_eq!(
+            view.posts[0].provenance.runtime, "claude",
+            "accountability provenance resolved from the card"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_board_is_projected_not_an_error() {
+        // what this catches: a room with nothing pinned projects an empty
+        // board (not a skipped store, not an error) — the honest-empty
+        // contract the WallViewState type documents. A renderer subscribed
+        // to kind=wall must still receive a snapshot so it can clear a
+        // stale board.
+        let substrate = Substrate::new();
+        let room = RoomId::new();
+        let reader = StubReader::new(vec![]);
+        let mut p = WallProjection::new(substrate.clone(), room.as_uuid(), reader);
+        p.reload().await;
+        let view = current_wall(&substrate);
+        assert_eq!(view.room_id, room.as_uuid());
+        assert!(view.posts.is_empty());
+    }
+
+    #[test]
+    fn foreign_room_and_malformed_events_are_skipped() {
+        // what this catches: regression where a non-wall event, or a
+        // wall:changed missing the room_id, gets classified into a spurious
+        // re-read. Per [[fallbacks-are-illegal-fail-loud]]: an event that
+        // can't deserialize into the contract is not-a-wall-event → None.
+        // (Room-mismatch filtering is enforced in the loop, tested via the
+        // room_id the Changed/Presence inputs carry.)
+        assert!(classify("media:frame", &json!({ "bytes": 4 })).is_none());
+        assert!(classify(WALL_CHANGED, &json!({ "nope": true })).is_none());
+        let room = Uuid::from_u128(0xa);
+        match classify(WALL_CHANGED, &json!({ "roomId": room })).expect("classifies") {
+            WallInput::Changed(rid) => assert_eq!(rid, room),
+            _ => panic!("wall:changed must classify as Changed"),
+        }
+    }
+
+    #[tokio::test]
+    async fn revision_advances_monotonically_across_stores() {
+        // what this catches: regression where successive wall projections
+        // stamp a stale or non-monotonic revision — the session-protocol
+        // last_seen replay routes by revision, so a flat revision would stop
+        // the wall widget from seeing updates.
+        let substrate = Substrate::new();
+        let room = RoomId::new();
+        let author = PeerId::new();
+        let reader = StubReader::new(vec![post(room, author, "plan", "v1")]);
+        let mut p = WallProjection::new(substrate.clone(), room.as_uuid(), reader);
+        p.reload().await;
+        let r1 = substrate.cache().get(KnownKind::Wall.wire_name()).unwrap().revision;
+        // A presence fold re-projects → a second store, revision advances.
+        let presence = presence_one(room.as_uuid(), author.as_uuid(), "Asha", "agent");
+        if let WallInput::Presence(_, roster) = classify(PRESENCE_UPDATED, &presence).unwrap() {
+            p.apply_roster(roster);
+        }
+        let r2 = substrate.cache().get(KnownKind::Wall.wire_name()).unwrap().revision;
+        assert!(r2 > r1, "revision must advance: {r1:?} -> {r2:?}");
+    }
+}

--- a/core/continuum-core/src/runtime/mod.rs
+++ b/core/continuum-core/src/runtime/mod.rs
@@ -88,7 +88,7 @@ pub use governor_bus::{publish_persona_scheduled, PersonaScheduled, PERSONA_SCHE
 pub use grid_interceptor::GridInterceptor;
 pub use in_process_transport::InProcessTransport;
 pub use late_bound::LateBound;
-pub use message_bus::MessageBus;
+pub use message_bus::{BusEvent, MessageBus};
 pub use module_context::ModuleContext;
 pub use orientation_shares::{
     apportion, orientation_index, OrientationCounts, OrientationShares, ORIENTATIONS,


### PR DESCRIPTION
## What

The runtime **wall projector** — the sibling of the chat projection (task #89 Unit 2, following the merged Unit 1 wall contract #1734). It projects the room's pinned board (airc `WallPostPublished` supersede chain) into a renderer-shaped `kind="wall"` `WallViewState` on the thin-client substrate, so a wall widget is **defined once** for web / terminal / mobile / AI-observer surfaces.

## How

- **`ipc/positron_wall_source.rs` (new)** — `WallProjection` folds two bus streams for one room:
  - **`wall:changed`** → RE-READ airc's authoritative `Airc::wall_posts()` through the existing `WallReader` seam. It never re-implements the supersede fold (one supersede impl, in airc — the continuum side is a cache of airc's truth). The signal carries only `room_id`; the board comes from the authoritative re-read, never from one delta.
  - **`presence:updated`** → the wall carries only a `published_by` peer id, so the projector resolves each author's name / kind / badges / provenance from the roster exactly as the chat projection resolves a sender, and re-projects so a post pinned before its author's card arrived **upgrades in place**. Attribution woven in from day one.
- **`airc/inbound_attach.rs`** — added `wall_changed_from_event`: a `TranscriptKind::WallPostPublished` event classifies into a thin `wall:changed` re-read cue (room-id only, no content).
- **`ipc/positron_source.rs`** — compression: extracted `resolve_identity` + `roster_slots_from` as `pub(crate)` helpers, reused by both projections (one identity-resolution decision, one place). Chat behavior unchanged.
- **`ipc/mod.rs`** — spawn-wired under the same `(socket, room)` precondition as the presence emitter, with a dedicated node `continuum-wall` heartbeat-less lurker as its `WallReader` so the board renders with zero resident personas.

## Doctrine

- **Fail loud, no fabrication** — a read failure keeps the last-good board (reader owns reconnection); a failed node-reader attach disables the projection loudly. Never an empty/fabricated board.
- **Re-read, not re-fold** — the supersede projection stays airc-owned.

## Tests

- 5 wall-projector: project-into-substrate, author-upgrades-on-presence, empty-board-is-valid, foreign/malformed-skip, monotonic-revision.
- 1 inbound-attach classification (`wall:changed` cue, no content).
- Regression-safe: chat projection (10) and inbound-attach (now 6) still green.

`cargo check --features metal,accelerate -p continuum-core` clean; targeted tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)