### PR TITLE
Unit 3b-ii: feed + wire the positron kanban projector live

### DIFF
--- a/core/continuum-core/src/airc/inbound_attach.rs
+++ b/core/continuum-core/src/airc/inbound_attach.rs
@@ -13,6 +13,7 @@ use airc_lib::decode_wire_event;
 use tracing::warn;
 
 use crate::airc::realtime_wire::{bus_event_from_envelope, envelope_from_event};
+use crate::ipc::positron_kanban_source::KANBAN_CHANGED;
 use crate::ipc::positron_source::CHAT_POSTED;
 use crate::ipc::positron_wall_source::WALL_CHANGED;
 use crate::runtime::MessageBus;
@@ -106,13 +107,16 @@ pub async fn publish_transcript_event(
         // a non-message never fabricates a chat event.
         Ok(None) => {
             // Classify the plain airc event into a positron projection
-            // signal. A message → `chat:posted`; a wall post → `wall:changed`
-            // (a re-read cue, not the content). An event is at most one of
-            // these; anything else is not ours here → skip. Classification,
-            // never a fallback — a non-matching kind fabricates nothing.
+            // signal. A message → `chat:posted`; a wall post → `wall:changed`;
+            // a work-board event → `kanban:changed` (all re-read cues, not the
+            // content). An event is at most one of these; anything else is not
+            // ours here → skip. Classification, never a fallback — a
+            // non-matching kind fabricates nothing.
             if let Some((name, payload)) = chat_posted_from_message(event) {
                 bus.publish_async_only(name, payload);
             } else if let Some((name, payload)) = wall_changed_from_event(event) {
+                bus.publish_async_only(name, payload);
+            } else if let Some((name, payload)) = kanban_changed_from_event(event) {
                 bus.publish_async_only(name, payload);
             }
             return Ok(());
@@ -177,6 +181,32 @@ fn wall_changed_from_event(
         "roomId": event.room_id.as_uuid(),
     });
     Some((WALL_CHANGED, payload))
+}
+
+/// Project an airc work-board event into the `kanban:changed` bus signal
+/// the positron kanban projection consumes (`AircKanbanChanged` in
+/// `ipc/positron_kanban_source.rs`). Returns `None` for any non-work event.
+///
+/// Work events are not a `TranscriptKind` variant — they ride the transcript
+/// stream discriminated by a body-hint header, so we ask airc-work's
+/// authoritative `transcript_is_work_event` rather than matching a kind (the
+/// header set is airc-work's contract to own, not ours to re-derive).
+///
+/// Like the wall cue, the signal carries ONLY the `room_id`: the board fold
+/// (`Airc::work_board_complete`) cannot be reconstructed from a single work
+/// delta, so the consumer RE-READS the authoritative board rather than
+/// trusting this event's body. We emit a change *cue*, not the delta — the
+/// same re-read-not-fold discipline the kanban projector documents.
+fn kanban_changed_from_event(
+    event: &airc_core::TranscriptEvent,
+) -> Option<(&'static str, serde_json::Value)> {
+    if !airc_work::transcript_is_work_event(event) {
+        return None;
+    }
+    let payload = serde_json::json!({
+        "roomId": event.room_id.as_uuid(),
+    });
+    Some((KANBAN_CHANGED, payload))
 }
 
 #[cfg(test)]
@@ -349,6 +379,49 @@ mod tests {
         // A cue, not the content: the board is re-read authoritatively.
         assert!(delivered.payload.get("body").is_none());
         assert!(delivered.payload.get("category").is_none());
+    }
+
+    #[tokio::test]
+    async fn work_board_event_projects_thin_kanban_changed_signal() {
+        // what this catches: the kanban classification arm (task #117 Unit
+        // 3b-ii). A work-board change rides the transcript as a
+        // `TranscriptKind::System` event carrying airc-work's body-hint
+        // header — NOT a dedicated TranscriptKind — so the classifier
+        // discriminates via airc-work's own `transcript_is_work_event`, not
+        // a kind match. This must project a `kanban:changed` bus signal
+        // carrying ONLY the room_id: the re-read cue the positron kanban
+        // projector folds by re-reading the authoritative board
+        // (`work_board_complete`), never reconstructing the fold from one
+        // delta. A regression that drops this arm silently freezes every
+        // rendered kanban board. Built via the real producer
+        // (`encode_work_event`) so a header-contract drift fails HERE, and
+        // asserts the chat/wall arms yield first for the System kind + JSON
+        // body (no chat/wall misclassification of a work event).
+        let work_event = airc_work::WorkEvent::CardStateChanged(airc_work::CardStateChanged {
+            card_id: airc_work::WorkCardId::new(),
+            state: airc_work::CardState::Open,
+            changed_by: PeerId::from_u128(3),
+            changed_at_ms: 100,
+        });
+        let (headers, body) =
+            airc_work::encode_work_event(&work_event).expect("work event encodes for the fixture");
+
+        let bus = MessageBus::new();
+        let mut receiver = bus.receiver();
+        let mut event = transcript_event(Some(body), headers);
+        event.kind = TranscriptKind::System;
+
+        publish_transcript_event(&event, &bus).await.unwrap();
+
+        let delivered = timeout(Duration::from_millis(200), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(delivered.name, "kanban:changed");
+        assert_eq!(delivered.payload["roomId"], Uuid::from_u128(2).to_string());
+        // A cue, not the content: the board is re-read authoritatively.
+        assert!(delivered.payload.get("cards").is_none());
+        assert!(delivered.payload.get("state").is_none());
     }
 
     #[tokio::test]

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -2418,8 +2418,34 @@ pub fn start_server(
                             .join("airc");
                         positron_wall_source::spawn_node_wall_projector(
                             &state.rt_handle,
-                            daemon_socket,
+                            daemon_socket.clone(),
                             wall_home,
+                            room_id.as_uuid(),
+                            room_name.clone(),
+                            ws_substrate.clone(),
+                            projection_bus.clone(),
+                        );
+
+                        // Kanban projector: the consuming half of
+                        // `kanban:changed`. Its own node reader (distinct home
+                        // + identity from presence and wall) re-reads the
+                        // airc-work-owned board fold (`work_board_complete`) on
+                        // each change and stores it as `kind="kanban"`, so a
+                        // chat window shows the room's work board with zero
+                        // resident personas. Same (socket, room) precondition
+                        // as presence/wall — an empty roster leaves card
+                        // authors provisionally labelled, but the board still
+                        // renders. Wired here TOGETHER with the inbound
+                        // classification so the projector goes live fed.
+                        let kanban_home = continuum_root
+                            .join("citizens")
+                            .join("node")
+                            .join("kanban")
+                            .join("airc");
+                        positron_kanban_source::spawn_node_kanban_projector(
+                            &state.rt_handle,
+                            daemon_socket,
+                            kanban_home,
                             room_id.as_uuid(),
                             room_name,
                             ws_substrate.clone(),


### PR DESCRIPTION
## Unit 3b-ii — kanban projector goes live, *fed*

3b-i registered `positron_kanban_source` and landed it inert (mod + compile + test only). This unit feeds it and wires it into boot **together**, so the projector is never a live-but-unfed no-op.

### Inbound classification (`airc/inbound_attach.rs`)
Work-board changes are **not** a `TranscriptKind` variant — they ride the transcript as a `TranscriptKind::System` event discriminated by airc-work's body-hint header. So the new `kanban_changed_from_event` asks airc-work's authoritative `transcript_is_work_event(event)` rather than matching a kind — the header set is airc-work's contract to own, not ours to re-derive.

It emits a thin `kanban:changed` cue carrying **only** the `room_id` — the same re-read-not-fold discipline as the wall cue. The board fold (`Airc::work_board_complete`) can't be reconstructed from a single delta, so the projector re-reads the authoritative board on the cue.

Added to the `Ok(None)` classification chain after chat/wall. Both yield first for a work event — chat on `kind != Message` **and** the JSON body carrying no `text` field; wall on `kind != WallPostPublished` — so a work event never misclassifies as chat or wall.

### Boot wiring (`ipc/mod.rs`)
`spawn_node_kanban_projector` is spawned alongside presence + wall under the same `(daemon_socket, room)` precondition, with its own reader home (`citizens/node/kanban/airc`, joined by NAME). The wall spawn's previously-moved args (`daemon_socket`, `room_name`, `projection_bus`) become `.clone()`; kanban is the final consumer. A chat window now shows the room's work board with **zero resident personas**.

### Test
`work_board_event_projects_thin_kanban_changed_signal` mirrors the wall classification test, built via the real producer (`encode_work_event`) so a header-contract drift fails in the test. Asserts the cue is thin (no `cards`/`state` content) and carries the room_id.

- 7 `inbound_attach` tests green (incl. the new one)
- 9 `positron_kanban_source` projector tests green
- `cargo check -p continuum-core --features metal,accelerate` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)