### PR TITLE
fix(#84): positron carries human chat turns (Case A completeness) + glass-box probe

### DIFF
--- a/core/continuum-core/src/airc/inbound_attach.rs
+++ b/core/continuum-core/src/airc/inbound_attach.rs
@@ -12,7 +12,10 @@ use airc_ipc::{codec::read_frame, AttachRequest, AttachStart, DaemonClient, Resp
 use airc_lib::decode_wire_event;
 use tracing::warn;
 
-use crate::airc::realtime_wire::{bus_event_from_envelope, envelope_from_event};
+use crate::airc::realtime::AircRealtimeEnvelope;
+use crate::airc::realtime_wire::{
+    bus_event_from_envelope, chat_transcript_message, envelope_from_event,
+};
 use crate::ipc::positron_kanban_source::KANBAN_CHANGED;
 use crate::ipc::positron_source::CHAT_POSTED;
 use crate::ipc::positron_wall_source::WALL_CHANGED;
@@ -137,11 +140,56 @@ pub async fn publish_transcript_event(
             return Ok(());
         }
     };
-    let Some(bus_event) = bus_event_from_envelope(&envelope) else {
-        return Ok(());
-    };
-    bus.publish_async_only(&bus_event.name, bus_event.payload);
+    // Case A — a Continuum realtime envelope. Two shapes reach the bus:
+    //  - EventBridge payload → republish under its inline `eventName`.
+    //  - chat_transcript (a human `chat/send`, the web client — the
+    //    `Body::Json` shape) → project to the SAME thin `chat:posted` the
+    //    plain-text sibling emits. Without this arm, human chat lines reach
+    //    the daemon transcript and the persona (which learned to read the
+    //    envelope) but never the positron `ChatViewState` — the room would
+    //    show persona replies to structurally-invisible questions. Converge
+    //    on ONE `chat:posted`, two wire shapes, mirroring the receive-side
+    //    `perceptual_from_event`. Anything else is not ours here → skip.
+    if let Some(bus_event) = bus_event_from_envelope(&envelope) {
+        bus.publish_async_only(&bus_event.name, bus_event.payload);
+    } else if let Some((name, payload)) = chat_posted_from_envelope(&envelope, event) {
+        crate::probe!(
+            class = "airc.chat.projected",
+            sender_id = %payload["senderId"],
+            room_id = %event.room_id.as_uuid(),
+            event_id = %event.event_id.as_uuid(),
+            "chat_transcript envelope projected to chat:posted for positron"
+        );
+        bus.publish_async_only(name, payload);
+    }
     Ok(())
+}
+
+/// Project a `chat_transcript` envelope (a human `chat/send`, the web
+/// client — the `Body::Json` room-message shape) into the SAME thin
+/// `chat:posted` payload the plain-text sibling
+/// [`chat_posted_from_message`] emits. Returns `None` for any other
+/// envelope (EventBridge, presence, media-control) — it is not a chat line.
+///
+/// Identity-free like its sibling: `senderId` is the envelope's logical
+/// sender (recovered by [`chat_transcript_message`], falling back to the
+/// relaying transport peer), name/kind resolved downstream from the
+/// roster. `messageId`/`roomId`/`timestamp` are airc's transcript facts
+/// (`event_id`/`room_id`/`occurred_at_ms`) — IDENTICAL to the plain-text
+/// projection, so both wire shapes yield the same `chat:posted` identity.
+fn chat_posted_from_envelope(
+    envelope: &AircRealtimeEnvelope,
+    event: &airc_core::TranscriptEvent,
+) -> Option<(&'static str, serde_json::Value)> {
+    let (sender_id, content) = chat_transcript_message(envelope, event.peer_id.as_uuid())?;
+    let payload = serde_json::json!({
+        "messageId": event.event_id.as_uuid(),
+        "roomId": event.room_id.as_uuid(),
+        "senderId": sender_id,
+        "content": content,
+        "timestamp": event.occurred_at_ms,
+    });
+    Some((CHAT_POSTED, payload))
 }
 
 /// Project a plain airc chat message into the THIN `chat:posted` bus
@@ -289,6 +337,73 @@ mod tests {
             .unwrap();
         assert_eq!(delivered.name, "persona:ready");
         assert_eq!(delivered.payload["data"]["personaId"], "helper-ai");
+    }
+
+    /// Build the `chat_transcript` envelope exactly as `chat/send` →
+    /// `airc/realtime-publish` does: a `Body::Json` continuum envelope
+    /// whose inline carries the human message + its logical `senderId`.
+    fn chat_transcript_envelope(sender: Uuid, text: &str) -> AircRealtimeEnvelope {
+        AircRealtimeEnvelope::new(
+            "evt-1".to_string(),
+            Uuid::from_u128(2),
+            sender.to_string(),
+            100,
+            AircRealtimePayload::ExistingSchema {
+                payload: AircRealtimePayloadRef::inline(
+                    AircRealtimeSchema::ChatTranscript,
+                    json!({
+                        "messageId": Uuid::from_u128(0x3).to_string(),
+                        "text": text,
+                        "senderId": sender.to_string(),
+                        "replyToId": serde_json::Value::Null,
+                    }),
+                ),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn chat_transcript_envelope_projects_chat_posted() {
+        // what this catches: the Case-A completeness fix (task #84). A human
+        // `chat/send` publishes a `chat_transcript` envelope (Body::Json,
+        // as_text()==None) — NOT the plain-text shape a persona `say` uses.
+        // It must project to the SAME thin `chat:posted` the plain-text
+        // sibling emits so the positron read surface carries human turns,
+        // not just persona/peer turns. A regression that reverts the
+        // `else if chat_posted_from_envelope` arm makes human questions
+        // structurally invisible in `ChatViewState` (the room shows only
+        // the persona's replies). senderId must be the envelope's LOGICAL
+        // sender, never the relaying transport peer (PeerId 3).
+        let bus = MessageBus::new();
+        let mut receiver = bus.receiver();
+        let sender = Uuid::from_u128(0x5e);
+        let envelope = chat_transcript_envelope(sender, "is anyone there?");
+        let event = transcript_event(
+            Some(Body::Json(serde_json::to_value(&envelope).unwrap())),
+            headers_for_envelope(&envelope),
+        );
+
+        publish_transcript_event(&event, &bus).await.unwrap();
+
+        let delivered = timeout(Duration::from_millis(200), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(delivered.name, "chat:posted");
+        assert_eq!(delivered.payload["content"], "is anyone there?");
+        // messageId/roomId/timestamp are airc transcript facts — identical
+        // to the plain-text projection (event_id/room_id/occurred_at_ms).
+        assert_eq!(
+            delivered.payload["messageId"],
+            Uuid::from_u128(1).to_string()
+        );
+        assert_eq!(delivered.payload["roomId"], Uuid::from_u128(2).to_string());
+        assert_eq!(delivered.payload["timestamp"], 100);
+        // the LOGICAL sender the envelope carries, not transport PeerId 3.
+        assert_eq!(delivered.payload["senderId"], sender.to_string());
+        // identity-free like its sibling: no fabricated name/kind.
+        assert!(delivered.payload.get("senderName").is_none());
+        assert!(delivered.payload.get("senderKind").is_none());
     }
 
     #[tokio::test]

--- a/core/continuum-core/src/airc/inbound_attach.rs
+++ b/core/continuum-core/src/airc/inbound_attach.rs
@@ -113,6 +113,17 @@ pub async fn publish_transcript_event(
             // ours here → skip. Classification, never a fallback — a
             // non-matching kind fabricates nothing.
             if let Some((name, payload)) = chat_posted_from_message(event) {
+                // task #84: the persona-turn / plain-airc-message stream into
+                // the room. This is the seam a client's live read surface
+                // (positron ChatViewState) is fed from — probe it so the turn
+                // stream is glass-box (did the say traverse daemon→attach→bus?).
+                crate::probe!(
+                    class = "airc.chat.projected",
+                    sender_id = %event.peer_id.as_uuid(),
+                    room_id = %event.room_id.as_uuid(),
+                    event_id = %event.event_id.as_uuid(),
+                    "plain airc message projected to chat:posted for positron"
+                );
                 bus.publish_async_only(name, payload);
             } else if let Some((name, payload)) = wall_changed_from_event(event) {
                 bus.publish_async_only(name, payload);

--- a/core/continuum-core/src/airc/realtime_wire.rs
+++ b/core/continuum-core/src/airc/realtime_wire.rs
@@ -98,3 +98,139 @@ pub fn bus_event_from_envelope(envelope: &AircRealtimeEnvelope) -> Option<BusEve
         payload: inline.clone(),
     })
 }
+
+/// Recover the `(logical sender, text)` from a decoded `chat_transcript`
+/// envelope — the `Body::Json` shape `chat/send` (a human, the web client,
+/// any non-`say` caller) publishes. Returns `None` for any other envelope
+/// (EventBridge, presence, media-control) — a non-`chat_transcript`
+/// fabricates nothing.
+///
+/// The sender falls back to `fallback_peer` (the transport peer that
+/// relayed the publish) when `inline.senderId` is absent. Both are real
+/// identities — this is attribution recovery of a present-but-relayed
+/// sender, NOT a fabricated default for a missing one
+/// ([[fallbacks-are-illegal-fail-loud]]).
+///
+/// This is the ONE decoder for the `chat_transcript` wire shape. Both the
+/// persona perception path (`perceptual_from_event`) and the positron
+/// projection path (`chat_posted_from_envelope`) read a human chat line
+/// through it — the receive-side symmetry of the plain-text/`say` sibling.
+/// A prior fix taught only the persona to read this shape; the positron
+/// read surface had the identical structural blindness (human chat lines
+/// reached the transcript but never `ChatViewState`) until it too routed
+/// through this decoder.
+pub fn chat_transcript_message(
+    envelope: &AircRealtimeEnvelope,
+    fallback_peer: uuid::Uuid,
+) -> Option<(uuid::Uuid, String)> {
+    let AircRealtimePayload::ExistingSchema { payload } = &envelope.payload else {
+        return None;
+    };
+    if payload.schema != AircRealtimeSchema::ChatTranscript {
+        return None;
+    }
+    let inline = payload.inline.as_ref()?;
+    let text = inline.get("text").and_then(serde_json::Value::as_str)?;
+    let sender = inline
+        .get("senderId")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|s| uuid::Uuid::parse_str(s).ok())
+        .unwrap_or(fallback_peer);
+    Some((sender, text.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the ONE chat_transcript decoder recovers the
+    // logical sender + text from the Body::Json shape chat/send publishes.
+    // This is the seam that keeps human chat lines from being structurally
+    // invisible to BOTH persona perception and the positron read surface.
+    // A regression that renamed the `chat_transcript` schema tag or the
+    // inline `text`/`senderId` fields silently drops every human message
+    // from the room.
+    #[test]
+    fn chat_transcript_message_recovers_sender_and_text() {
+        let sender = uuid::Uuid::from_u128(0x5e).to_string();
+        let relay = uuid::Uuid::from_u128(0x4e);
+        // Encode exactly as chat/send → airc/realtime-publish builds it.
+        let envelope: AircRealtimeEnvelope = serde_json::from_value(serde_json::json!({
+            "eventId": uuid::Uuid::from_u128(0x1).to_string(),
+            "roomId": uuid::Uuid::from_u128(0x2).to_string(),
+            "sourceId": sender,
+            "createdAtMs": 100,
+            "delivery": "durable",
+            "payload": {
+                "kind": "existing_schema",
+                "payload": {
+                    "schema": "chat_transcript",
+                    "inline": {
+                        "messageId": uuid::Uuid::from_u128(0x3).to_string(),
+                        "text": "is anyone there?",
+                        "senderId": sender,
+                        "replyToId": serde_json::Value::Null,
+                    }
+                }
+            },
+        }))
+        .expect("chat/send envelope shape must decode into AircRealtimeEnvelope");
+
+        let (recovered, text) =
+            chat_transcript_message(&envelope, relay).expect("chat_transcript must decode");
+        assert_eq!(recovered.to_string(), sender, "logical sender, not the relay");
+        assert_eq!(text, "is anyone there?");
+    }
+
+    // what this catches: attribution recovery, not fabrication. When the
+    // inline omits senderId, the sender falls back to the transport peer
+    // that relayed the publish — a real identity, never a nil/default.
+    #[test]
+    fn chat_transcript_message_falls_back_to_transport_peer() {
+        let relay = uuid::Uuid::from_u128(0x4e);
+        let envelope: AircRealtimeEnvelope = serde_json::from_value(serde_json::json!({
+            "eventId": uuid::Uuid::from_u128(0x1).to_string(),
+            "roomId": uuid::Uuid::from_u128(0x2).to_string(),
+            "sourceId": uuid::Uuid::from_u128(0x5e).to_string(),
+            "createdAtMs": 100,
+            "delivery": "durable",
+            "payload": {
+                "kind": "existing_schema",
+                "payload": {
+                    "schema": "chat_transcript",
+                    "inline": { "text": "hello" }
+                }
+            },
+        }))
+        .expect("envelope must decode");
+
+        let (recovered, text) =
+            chat_transcript_message(&envelope, relay).expect("chat_transcript must decode");
+        assert_eq!(recovered, relay, "omitted senderId recovers to the relay peer");
+        assert_eq!(text, "hello");
+    }
+
+    // what this catches: classification, not fallback. A non-chat_transcript
+    // envelope (here EventBridge) must yield None from this decoder — it is
+    // NOT a chat line and must never be projected as one.
+    #[test]
+    fn non_chat_transcript_envelope_is_none() {
+        let envelope: AircRealtimeEnvelope = serde_json::from_value(serde_json::json!({
+            "eventId": uuid::Uuid::from_u128(0x1).to_string(),
+            "roomId": uuid::Uuid::from_u128(0x2).to_string(),
+            "sourceId": uuid::Uuid::from_u128(0x5e).to_string(),
+            "createdAtMs": 100,
+            "delivery": "durable",
+            "payload": {
+                "kind": "existing_schema",
+                "payload": {
+                    "schema": "event_bridge_payload",
+                    "inline": { "eventName": "chat:posted" }
+                }
+            },
+        }))
+        .expect("envelope must decode");
+
+        assert!(chat_transcript_message(&envelope, uuid::Uuid::from_u128(0x4e)).is_none());
+    }
+}

--- a/core/continuum-core/src/persona/airc_persona_conversation.rs
+++ b/core/continuum-core/src/persona/airc_persona_conversation.rs
@@ -49,7 +49,6 @@ use airc_core::TranscriptEvent;
 use airc_lib::EventStream;
 use async_trait::async_trait;
 use futures::StreamExt;
-use serde_json::Value;
 use std::sync::Arc;
 use uuid::Uuid;
 

--- a/core/continuum-core/src/persona/airc_persona_conversation.rs
+++ b/core/continuum-core/src/persona/airc_persona_conversation.rs
@@ -42,8 +42,7 @@
 //! persona at boot, before any of them have necessarily attached to
 //! their rooms yet.
 
-use crate::airc::realtime::{AircRealtimePayload, AircRealtimeSchema};
-use crate::airc::realtime_wire::envelope_from_event;
+use crate::airc::realtime_wire::{chat_transcript_message, envelope_from_event};
 use crate::persona::airc_citizen::AircCitizen;
 use crate::persona::service_loop::{IncomingMessage, PersonaConversation};
 use airc_core::TranscriptEvent;
@@ -273,28 +272,19 @@ fn perceptual_from_event(event: &TranscriptEvent) -> Option<IncomingMessage> {
         });
     }
 
-    // Path 2 — a structured chat_transcript envelope (chat/send).
+    // Path 2 — a structured chat_transcript envelope (chat/send). The
+    // envelope decode + logical-sender/text recovery is the ONE
+    // `chat_transcript_message` decoder in `realtime_wire` — shared with
+    // the positron projection path (`chat_posted_from_envelope`), the
+    // receive-side symmetry of Path 1. A prior fix taught only this
+    // perception path to read the envelope; the positron read surface had
+    // the identical blindness until it too routed through this decoder.
     let envelope = envelope_from_event(event).ok().flatten()?;
-    let AircRealtimePayload::ExistingSchema { payload } = &envelope.payload else {
-        return None;
-    };
-    if payload.schema != AircRealtimeSchema::ChatTranscript {
-        return None;
-    }
-    let inline = payload.inline.as_ref()?;
-    let text = inline.get("text").and_then(Value::as_str)?;
-    // Prefer the logical sender the envelope carries; fall back to the
-    // transport peer that relayed the publish. Both are real identities —
-    // this is attribution recovery, not a fabricated default.
-    let peer_id = inline
-        .get("senderId")
-        .and_then(Value::as_str)
-        .and_then(|s| Uuid::parse_str(s).ok())
-        .unwrap_or_else(|| event.peer_id.as_uuid());
+    let (peer_id, text) = chat_transcript_message(&envelope, event.peer_id.as_uuid())?;
     Some(IncomingMessage {
         lamport: event.lamport,
         peer_id,
-        text: text.to_string(),
+        text,
     })
 }
 


### PR DESCRIPTION
## What & why

The positron `ChatViewState` — the read surface the three-panel UI (#29) will
build on — was **incomplete**: it carried persona `say` turns and external airc
peer posts, but silently **dropped human `chat/send` turns**.

A human message publishes a `chat_transcript` envelope (`Body::Json`). At the
`publish_transcript_event` Case A branch, `bus_event_from_envelope` returns
`None` (schema is `chat_transcript`, not `EventBridgePayload`) → the turn was
dropped before ever reaching `chat:posted`. So the room rendered persona
replies to **structurally-invisible questions** — the exact blindness
`perceptual_from_event` documents and had fixed for *persona perception only*,
never for the positron projection.

## The fix (compression-correct: one decoder, two consumers)

- **`chat_transcript_message`** — extracted as the ONE decoder for the
  `chat_transcript` wire shape, a sibling of `bus_event_from_envelope` in
  `realtime_wire.rs`. Recovers `(logical sender, text)`; sender falls back to
  the relaying transport peer (attribution recovery of a present-but-relayed
  identity, **not** a fabricated default — [[fallbacks-are-illegal-fail-loud]]).
- **`perceptual_from_event`** (perception) refactored to route through it,
  deleting its inlined duplicate decode.
- **`chat_posted_from_envelope`** (positron projection) routes through the same
  decoder; wired into Case A so a `chat_transcript` envelope projects to the
  **same** thin `chat:posted` the plain-text sibling emits (identical
  `messageId`/`roomId`/`timestamp` transcript facts, identity-free).
- Probe class `airc.chat.projected` on the new arm (the original glass-box probe).

Converges on **ONE `chat:posted`, two wire shapes** — the send-side mirror of
`perceptual_from_event`'s two receive paths (#8). positron is now the COMPLETE
read surface (persona + human turns) — solid ground for #29.

## Tests (all green, zero regressions)

- `realtime_wire`: decoder recovers sender+text / falls back to relay peer /
  non-`chat_transcript` → `None`.
- `inbound_attach`: `chat_transcript` envelope projects `chat:posted` with the
  **logical** sender (not the transport peer), identity-free like its sibling.
- `perceptual`: refactored path still perceives with the true sender.
- 11 neighboring `inbound_attach`/`perceptual` tests unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)