### PR TITLE
feat(client): apps/tui outlier B + shared @continuum/chat-view + clippy-grade lint gate

### DIFF
--- a/apps/tui/.env.example
+++ b/apps/tui/.env.example
@@ -1,0 +1,13 @@
+# Continuum terminal chat client config. Copy to `.env` and fill in, or pass the
+# equivalent --core / --me flags. Both values fail loud if absent — there is no
+# invented default (a guessed ws url points at nothing; a minted senderId is a
+# ghost citizen).
+
+# The core's WS ingress url. The core binds 127.0.0.1:$CONTINUUM_CORE_WS only when
+# that env is set on the core side; use the SAME port here. No default.
+CONTINUUM_WS=
+
+# Your citizen UUID, threaded as chat/send's senderId. Identity pairing is not
+# wired yet (tasks #37/#38), so this is explicit. Left BLANK on purpose: an
+# unedited copy must trip config.ts's fail-loud guard, never sail through.
+CONTINUUM_USER_ID=

--- a/apps/tui/README.md
+++ b/apps/tui/README.md
@@ -1,0 +1,72 @@
+# @continuum/tui
+
+A terminal chat client for Continuum. It is the **outlier-B** validation of the
+client SDK seam (task #29): the maximally-different renderer to apps/web's Lit
+`<chat-widget>`. Both consume the identical SDK client seam
+(`StateConnection` READ + `chat/send` SEND) and the identical shared projection
+(`@continuum/chat-view`), differing only in surface — DOM+Lit vs stdin+ANSI. That
+the same seam fits both without forcing is the proof the interface is right.
+
+## What it is (and isn't)
+
+- **UI only.** No substrate logic. The who/what/where projection lives in
+  `@continuum/chat-view`, shared with the web widget; this package owns only the
+  ANSI renderer and the readline compose loop.
+- **Zero extra deps.** Runs on Node ≥ 22's global `WebSocket`; the SDK socket
+  classes fail loud if it is absent rather than pulling in a `ws` polyfill.
+
+## Run
+
+The core must be running with `CONTINUUM_CORE_WS=<port>` set (there is no default
+port — a guessed one points at nothing).
+
+```bash
+# flags (repointable inline):
+node --experimental-strip-types apps/tui/src/index.ts \
+  --core ws://127.0.0.1:8974 --me <your-user-uuid>
+
+# or via the workspace script + env:
+CONTINUUM_WS=ws://127.0.0.1:8974 CONTINUUM_USER_ID=<uuid> \
+  npm start -w @continuum/tui
+```
+
+Config resolves **flag → env** (first hit wins), fails loud naming exactly what
+is missing. See `.env.example`.
+
+- `--core` / `CONTINUUM_WS` — the core's WS ingress url.
+- `--me` / `CONTINUUM_USER_ID` — your citizen UUID, threaded as `chat/send`'s
+  `senderId`. Identity pairing is not wired yet (tasks #37/#38), so this is
+  explicit config, never minted.
+
+Type a line and press enter to send; a blank line just repaints; Ctrl-D exits.
+
+## Layout
+
+Joel's three-panel who/what/where design, projected onto a line-oriented
+terminal as three labelled sections:
+
+```
+general  1/2 here · room-1
+
+WHO
+  ● * Asha [claude]
+  ○ > Bo
+
+WHAT
+  14:03 * Asha [claude]: hello there
+```
+
+- **WHERE/WHICH** — the header (room + live counts + id).
+- **WHO** — the roster (`●` active / `○` idle; `>` human, `*` agent, `~` system).
+- **WHAT** — the conversation.
+
+## Develop
+
+```bash
+npm run typecheck -w @continuum/tui   # tsc --noEmit, Node lib (not DOM)
+npm run lint -w @continuum/tui         # strict typescript-eslint (no any, etc.)
+npm test -w @continuum/tui             # vitest — pure renderer + config resolver
+```
+
+The renderer (`renderChat`) and the config resolver (`resolveConfig`) are both
+pure functions, unit-tested without a TTY or a live core.

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@continuum/tui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Terminal chat client for Continuum — the maximally-different outlier that validates the SDK client seam (StateConnection READ + chat/send SEND) against Node/ANSI, proving the same seam apps/web's Lit widget uses fits a non-DOM renderer without forcing. UI-only: no substrate logic; the who/what/where projection is @continuum/chat-view, shared with the web widget. Runs on Node ≥22's global WebSocket with zero extra deps.",
+  "type": "module",
+  "bin": {
+    "continuum-tui": "./src/index.ts"
+  },
+  "scripts": {
+    "start": "node --experimental-strip-types src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@continuum/chat-view": "*",
+    "@continuum/sdk-typescript": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/apps/tui/src/config.spec.ts
+++ b/apps/tui/src/config.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { resolveConfig } from './config';
+
+const UUID = '11111111-2222-3333-4444-555555555555';
+const WS = 'ws://127.0.0.1:8974';
+
+describe('resolveConfig (tui)', () => {
+  it('resolves from CLI flags with a following value', () => {
+    // what this catches: the `--flag value` argv shape not being parsed — the
+    // primary way a launch is repointed inline.
+    const cfg = resolveConfig(['--core', WS, '--me', UUID], {});
+    expect(cfg).toEqual({ wsUrl: WS, senderId: UUID });
+  });
+
+  it('resolves from `--flag=value` form too', () => {
+    // what this catches: the `=` form silently not splitting, leaving the value
+    // glued to the key.
+    const cfg = resolveConfig([`--core=${WS}`, `--me=${UUID}`], {});
+    expect(cfg).toEqual({ wsUrl: WS, senderId: UUID });
+  });
+
+  it('falls back to environment variables when a flag is absent', () => {
+    // what this catches: the env being ignored — it is the shell-profile default
+    // and must fill in whatever flags omit.
+    const cfg = resolveConfig([], { CONTINUUM_WS: WS, CONTINUUM_USER_ID: UUID });
+    expect(cfg).toEqual({ wsUrl: WS, senderId: UUID });
+  });
+
+  it('prefers a flag over the environment for the same key', () => {
+    // what this catches: precedence inversion — an inline `--core` must win over
+    // a stale env value, not the reverse.
+    const cfg = resolveConfig(['--core', WS], {
+      CONTINUUM_WS: 'ws://wrong:1',
+      CONTINUUM_USER_ID: UUID,
+    });
+    expect(cfg.wsUrl).toBe(WS);
+  });
+
+  it('fails loud naming BOTH missing values, never inventing a default', () => {
+    // what this catches: a silent/blank start when config is absent — a guessed
+    // ws url points at nothing and a minted senderId is a ghost citizen, so this
+    // must throw and name exactly what to supply ([[fallbacks-are-illegal-fail-loud]]).
+    expect(() => resolveConfig([], {})).toThrow(/core WS url/);
+    expect(() => resolveConfig([], {})).toThrow(/sender identity/);
+  });
+
+  it('treats an empty-string flag/env as absent, not as a valid value', () => {
+    // what this catches: `--core ''` or `CONTINUUM_WS=` sailing through as a
+    // usable-but-empty url instead of tripping the fail-loud guard.
+    expect(() => resolveConfig([], { CONTINUUM_WS: '', CONTINUUM_USER_ID: '' })).toThrow(
+      /config incomplete/,
+    );
+  });
+});

--- a/apps/tui/src/config.ts
+++ b/apps/tui/src/config.ts
@@ -1,0 +1,106 @@
+/**
+ * Runtime config resolution for the terminal chat client — fail-loud, no invented
+ * defaults. The exact twin of apps/web's `resolveConfig` in intent, deliberately
+ * different in mechanism: the browser reads `?query=` params, the terminal reads
+ * `--flags` and the process environment. That the SAME two facts (`wsUrl`,
+ * `senderId`) resolve here from a totally different source is part of the
+ * outlier-B validation — the SDK client seam doesn't care where config came from.
+ *
+ * Two things the terminal can't know on its own and must NOT fabricate:
+ *   - `wsUrl` — where the headless core's WS ingress listens. The core binds
+ *     `127.0.0.1:$CONTINUUM_CORE_WS` only when that env is set (no hardcoded
+ *     port), so a guessed URL points at nothing. Resolve it explicitly or fail
+ *     loud ([[fallbacks-are-illegal-fail-loud]]).
+ *   - `senderId` — WHO the human is. The WS transport establishes no identity yet
+ *     (identity pairing is tasks #37/#38), and `chat/send` needs a real sender
+ *     UUID. Minting one would create a ghost citizen, so it is explicit config
+ *     until identity lands.
+ *
+ * Resolution order (first hit wins): CLI flag → environment variable. Flags make
+ * a launch repointable inline (`--core ws://… --me <uuid>`); the env is the
+ * shell-profile default.
+ */
+
+/** Resolved client configuration — everything the TUI needs to reach one room. */
+export interface TuiChatConfig {
+  /** WS URL of the core's thin-client ingress (e.g. `ws://127.0.0.1:8974`). */
+  readonly wsUrl: string;
+  /** The human citizen's UUID, threaded as `chat/send`'s `senderId`. */
+  readonly senderId: string;
+}
+
+/**
+ * Parse `--key value` and `--key=value` pairs out of an argv tail into a map.
+ * Only long flags are recognized; bare positionals are ignored (the TUI takes
+ * none). A flag with no following value (end of argv, or another `--flag` next)
+ * maps to the empty string, which the resolver below treats as absent.
+ */
+function parseFlags(argv: readonly string[]): Map<string, string> {
+  const flags = new Map<string, string>();
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg?.startsWith('--')) continue;
+    const body = arg.slice(2);
+    const eq = body.indexOf('=');
+    if (eq >= 0) {
+      flags.set(body.slice(0, eq), body.slice(eq + 1));
+      continue;
+    }
+    const next = argv[i + 1];
+    if (next !== undefined && !next.startsWith('--')) {
+      flags.set(body, next);
+      i++;
+    } else {
+      flags.set(body, '');
+    }
+  }
+  return flags;
+}
+
+/** Read a value from `--flag` then `env[envKey]`, else `undefined` (empty = absent). */
+function lookup(
+  flags: Map<string, string>,
+  env: Record<string, string | undefined>,
+  flagKey: string,
+  envKey: string,
+): string | undefined {
+  const fromFlag = flags.get(flagKey);
+  if (fromFlag && fromFlag.length > 0) return fromFlag;
+  const fromEnv = env[envKey];
+  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
+}
+
+/**
+ * Resolve the client config from argv + env, or throw naming exactly what's
+ * missing and how to supply it. Pure in its inputs (argv/env passed in) so it is
+ * unit-testable without touching `process`; `main` calls it with the real ones.
+ */
+export function resolveConfig(
+  argv: readonly string[],
+  env: Record<string, string | undefined>,
+): TuiChatConfig {
+  const flags = parseFlags(argv);
+  const wsUrl = lookup(flags, env, 'core', 'CONTINUUM_WS');
+  const senderId = lookup(flags, env, 'me', 'CONTINUUM_USER_ID');
+
+  // Narrow on the values themselves (not a separate count) so TS proves both are
+  // `string` past this block — no cast, no `!`, just a guard that actually holds.
+  if (wsUrl === undefined || senderId === undefined) {
+    const missing: string[] = [];
+    if (wsUrl === undefined) {
+      missing.push(
+        'core WS url — pass --core ws://host:port or set CONTINUUM_WS. ' +
+          'The core must run with CONTINUUM_CORE_WS=<port> set.',
+      );
+    }
+    if (senderId === undefined) {
+      missing.push(
+        'sender identity — pass --me <uuid> or set CONTINUUM_USER_ID. ' +
+          'Identity pairing is not wired yet (tasks #37/#38).',
+      );
+    }
+    throw new Error(`tui chat config incomplete:\n  - ${missing.join('\n  - ')}`);
+  }
+
+  return { wsUrl, senderId };
+}

--- a/apps/tui/src/index.ts
+++ b/apps/tui/src/index.ts
@@ -1,0 +1,118 @@
+/**
+ * Terminal chat client entry — wires the SDK to the ANSI renderer.
+ *
+ * The exact twin of apps/web's `src/index.ts`: the ONLY file that touches both
+ * the SDK and the output surface (here, stdout/stdin rather than the DOM). Same
+ * two sockets to the same core WS ingress, each doing one thing:
+ *   - READ  — a `StateConnection` subscribed to `kind="chat"`. Every envelope is
+ *     merged into a `ChatState` and repaints the who/what/where frame. Same
+ *     positron read surface (#84) the persona and the web widget observe.
+ *   - SEND  — a `Continuum` command client. Each stdin line is one `chat/send`
+ *     into the room on screen. Asha's reply (and the echo of our own turn) comes
+ *     back through the READ stream, so there is no optimistic local append.
+ *
+ * The renderer imports neither socket — the app owns the wiring, the renderer
+ * owns the view ([[headless-core-many-clients]], [[persona-is-a-client]]). That
+ * this composition root and apps/web's differ only in surface (readline+ANSI vs
+ * DOM+Lit), reusing the identical SDK seam and shared `@continuum/chat-view`
+ * projection, is the outlier-B validation of task #29.
+ */
+
+import { createInterface } from 'node:readline';
+import { stdin, stdout, argv, env, exit } from 'node:process';
+import {
+  Continuum,
+  WebSocketTransport,
+  StateConnection,
+  type StateEnvelope,
+} from '@continuum/sdk-typescript';
+import { chatStateFromEnvelope, CHAT_KIND, chatViewModel, type ChatState } from '@continuum/chat-view';
+import { resolveConfig } from './config.js';
+import { renderChat } from './renderChat.js';
+
+/** Clear the screen and home the cursor — the frame boundary the pure renderer
+ *  deliberately does NOT emit (so it stays testable on plain text). */
+const CLEAR_HOME = '\x1b[2J\x1b[H';
+
+async function main(): Promise<void> {
+  const config = resolveConfig(argv.slice(2), env);
+
+  // The latest snapshot the READ stream delivered — the SEND path reads its
+  // `room_id` so a message always targets the room on screen.
+  let latest: ChatState | undefined;
+  let lastError = '';
+
+  /** Repaint the whole frame: header + roster + messages + a compose prompt. */
+  function paint(): void {
+    const body = latest
+      ? renderChat(chatViewModel(latest))
+      : '\x1b[2mConnecting to the room…\x1b[0m';
+    const errorLine = lastError ? `\n\x1b[31mSend failed: ${lastError}\x1b[0m` : '';
+    stdout.write(`${CLEAR_HOME}${body}${errorLine}\n\n> `);
+  }
+
+  // SEND socket: the command client. A kernel-level failure rejects in the
+  // transport; an in-band `success === false` is thrown too — never a silently
+  // dropped message ([[fallbacks-are-illegal-fail-loud]]).
+  const continuum = Continuum.connect(new WebSocketTransport(config.wsUrl));
+  async function send(text: string): Promise<void> {
+    if (!latest) {
+      throw new Error('cannot send before the first room snapshot arrived — the room is unknown.');
+    }
+    const result = await continuum.commands.execute('chat/send', {
+      roomId: latest.room_id,
+      senderId: config.senderId,
+      text,
+    });
+    if (!result.success) {
+      throw new Error(`chat/send rejected: ${result.error ?? 'unknown error'}`);
+    }
+    if (result.warning) {
+      // Stored-locally-but-broadcast-failed: surface loud, but it did persist.
+      lastError = `partial: ${result.warning}`;
+    }
+  }
+
+  // READ socket: subscribe to chat state, repaint on each envelope.
+  const state = new StateConnection(config.wsUrl);
+  state.on(CHAT_KIND, (envelope: StateEnvelope) => {
+    latest = chatStateFromEnvelope(envelope);
+    paint();
+  });
+  state.onClose((reason) => {
+    // Never silently freeze: a dropped feed is a stale-UI signal.
+    stdout.write(`\n\x1b[31mchat state feed closed: ${reason}\x1b[0m\n`);
+  });
+  await state.connect();
+
+  // Compose loop: each entered line is one turn. A blank line just repaints.
+  const rl = createInterface({ input: stdin, output: stdout, terminal: false });
+  rl.on('line', (line: string) => {
+    const text = line.trim();
+    if (text.length === 0) {
+      paint();
+      return;
+    }
+    lastError = '';
+    send(text)
+      .then(() => {
+        paint();
+      })
+      .catch((err: unknown) => {
+        lastError = err instanceof Error ? err.message : String(err);
+        paint();
+      });
+  });
+  rl.on('close', () => exit(0));
+
+  paint();
+}
+
+main().catch((err: unknown) => {
+  // Boot failure (bad config, dead core) must be visible, not a silent hang.
+  stdout.write(
+    `\x1b[31mContinuum tui chat failed to start:\x1b[0m\n\n` +
+      `${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  exit(1);
+});

--- a/apps/tui/src/renderChat.spec.ts
+++ b/apps/tui/src/renderChat.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import type { ChatViewModel } from '@continuum/chat-view';
+import { renderChat } from './renderChat';
+
+/** A minimal view model builder so each test states only what it exercises. */
+function vm(overrides: Partial<ChatViewModel> = {}): ChatViewModel {
+  return {
+    roomName: 'general',
+    roomId: 'room-1',
+    memberCount: 0,
+    activeCount: 0,
+    members: [],
+    messages: [],
+    isEmpty: true,
+    ...overrides,
+  };
+}
+
+describe('renderChat (ANSI)', () => {
+  it('renders an honest empty state, not an error, when there are no messages', () => {
+    // what this catches: a blank/erroring conversation panel when a room is quiet
+    // — the empty state is a normal render, matching the web widget's contract.
+    const out = renderChat(vm({ isEmpty: true }), false);
+    expect(out).toContain('No messages yet — say hello.');
+    expect(out).not.toMatch(/error/i);
+  });
+
+  it('marks active vs idle members with distinct presence glyphs', () => {
+    // what this catches: losing the live presence distinction (● active / ○ idle)
+    // when projecting airc presence into the roster — the "WHO" panel's whole job.
+    const out = renderChat(
+      vm({
+        memberCount: 2,
+        activeCount: 1,
+        members: [
+          { id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: '' },
+          { id: 'b', name: 'Bo', kind: 'human', active: false, runtime: '' },
+        ],
+      }),
+      false,
+    );
+    expect(out).toContain('● * Asha');
+    expect(out).toContain('○ > Bo');
+  });
+
+  it('shows a runtime tag only when the substrate resolved one', () => {
+    // what this catches: fabricating a runtime badge for an unresolved origin
+    // (empty string must render nothing, never "[]") — no invented provenance.
+    const out = renderChat(
+      vm({
+        memberCount: 2,
+        activeCount: 2,
+        members: [
+          { id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: 'claude' },
+          { id: 'b', name: 'Nyx', kind: 'agent', active: true, runtime: '' },
+        ],
+      }),
+      false,
+    );
+    expect(out).toContain('Asha [claude]');
+    expect(out).toContain('Nyx');
+    expect(out).not.toContain('[]');
+  });
+
+  it('renders a message line with its time, sender and content', () => {
+    // what this catches: dropping any of the three fields that make a turn
+    // readable in the "WHAT" panel (when / who / what was said).
+    const out = renderChat(
+      vm({
+        isEmpty: false,
+        messages: [
+          {
+            id: 'm1',
+            senderId: 's1',
+            senderName: 'Asha',
+            kind: 'agent',
+            content: 'hello there',
+            time: '14:03',
+            runtime: '',
+          },
+        ],
+      }),
+      false,
+    );
+    expect(out).toContain('14:03');
+    expect(out).toContain('Asha');
+    expect(out).toContain('hello there');
+  });
+
+  it('emits zero ANSI escape codes when colour is disabled', () => {
+    // what this catches: colour bleeding into the testable/plain path — the pure
+    // renderer must produce clean text so tests assert on content, and so a
+    // non-TTY consumer (pipe, log) gets no escape noise.
+    const out = renderChat(
+      vm({
+        isEmpty: false,
+        memberCount: 1,
+        activeCount: 1,
+        members: [{ id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: 'claude' }],
+        messages: [
+          {
+            id: 'm1',
+            senderId: 's1',
+            senderName: 'Asha',
+            kind: 'agent',
+            content: 'hi',
+            time: '14:03',
+            runtime: 'claude',
+          },
+        ],
+      }),
+      false,
+    );
+    // eslint-disable-next-line no-control-regex
+    expect(out).not.toMatch(/\x1b\[/);
+  });
+
+  it('shows an empty-roster placeholder rather than a bare "WHO" heading', () => {
+    // what this catches: a naked section header with nothing under it when no one
+    // has joined — the panel states its emptiness instead of looking broken.
+    const out = renderChat(vm({ members: [] }), false);
+    expect(out).toContain('(no one here yet)');
+  });
+});

--- a/apps/tui/src/renderChat.ts
+++ b/apps/tui/src/renderChat.ts
@@ -1,0 +1,106 @@
+/**
+ * `renderChat` — the pure ANSI renderer for the terminal chat surface.
+ *
+ * It is the terminal twin of apps/web's Lit `renderChat`: same input (an
+ * already-projected `ChatViewModel` from the SHARED `@continuum/chat-view`), a
+ * totally different output (a plain multi-line string with optional ANSI colour,
+ * not a DOM template). That two renderers this different consume one view model
+ * without either reaching back into the SDK is the outlier-B proof — the "how a
+ * message row reads" logic lives once, upstream, in `chatViewModel`.
+ *
+ * It stays pure: no `process`, no `stdout`, no screen control. It returns the
+ * BODY of a frame; the composition root (`index.ts`) owns cursor/clear when it
+ * paints. That keeps this unit-testable on plain text (call with `useColor:false`
+ * and assert on the string) with no TTY.
+ *
+ * The layout is Joel's who/what/where design projected onto a line-oriented
+ * terminal — three labelled sections rather than CSS-grid panels:
+ *   WHERE/WHICH — the header (room + live counts + id)
+ *   WHO         — the roster (presence per member)
+ *   WHAT        — the conversation
+ */
+
+import type { ChatViewModel, MemberKind, MessageRowVM, RosterMemberVM } from '@continuum/chat-view';
+
+/** SGR codes, applied only when `useColor` is on so tests read clean text. */
+const SGR = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  cyan: '\x1b[36m',
+  yellow: '\x1b[33m',
+  gray: '\x1b[90m',
+} as const;
+
+type SgrKey = keyof typeof SGR;
+
+/** Wrap `text` in an SGR code, or return it bare when colour is disabled. */
+function paint(useColor: boolean, code: SgrKey, text: string): string {
+  return useColor ? `${SGR[code]}${text}${SGR.reset}` : text;
+}
+
+/** Short glyph per author kind — the neutral human/agent/system discriminant.
+ *  ASCII so column widths and tests stay deterministic across terminals. */
+function kindGlyph(kind: MemberKind): string {
+  switch (kind) {
+    case 'human':
+      return '>';
+    case 'agent':
+      return '*';
+    case 'system':
+      return '~';
+  }
+}
+
+/** The runtime origin as a bracket tag, only when the substrate resolved one. */
+function runtimeTag(useColor: boolean, runtime: string): string {
+  return runtime ? ' ' + paint(useColor, 'gray', `[${runtime}]`) : '';
+}
+
+/** One roster line — WHO is here, with a live presence marker. */
+function rosterLine(useColor: boolean, m: RosterMemberVM): string {
+  const dot = m.active ? paint(useColor, 'green', '●') : paint(useColor, 'gray', '○');
+  const name = m.active ? m.name : paint(useColor, 'dim', m.name);
+  const glyph = kindGlyph(m.kind);
+  return `  ${dot} ${glyph} ${name}${runtimeTag(useColor, m.runtime)}`;
+}
+
+/** One conversation line — WHAT was said. */
+function messageLine(useColor: boolean, msg: MessageRowVM): string {
+  const time = paint(useColor, 'gray', msg.time);
+  const glyph = kindGlyph(msg.kind);
+  const sender = paint(useColor, 'bold', msg.senderName);
+  return `  ${time} ${glyph} ${sender}${runtimeTag(useColor, msg.runtime)}: ${msg.content}`;
+}
+
+/** Render the who/what/where surface from one view model to a frame body. */
+export function renderChat(vm: ChatViewModel, useColor = true): string {
+  const lines: string[] = [];
+
+  // WHERE/WHICH — header.
+  const title = paint(useColor, 'cyan', paint(useColor, 'bold', vm.roomName));
+  const counts = paint(useColor, 'dim', `${vm.activeCount}/${vm.memberCount} here`);
+  const id = paint(useColor, 'gray', vm.roomId);
+  lines.push(`${title}  ${counts} · ${id}`);
+  lines.push('');
+
+  // WHO — roster.
+  lines.push(paint(useColor, 'yellow', 'WHO'));
+  if (vm.members.length === 0) {
+    lines.push(paint(useColor, 'dim', '  (no one here yet)'));
+  } else {
+    for (const m of vm.members) lines.push(rosterLine(useColor, m));
+  }
+  lines.push('');
+
+  // WHAT — conversation.
+  lines.push(paint(useColor, 'yellow', 'WHAT'));
+  if (vm.isEmpty) {
+    lines.push(paint(useColor, 'dim', '  No messages yet — say hello.'));
+  } else {
+    for (const msg of vm.messages) lines.push(messageLine(useColor, msg));
+  }
+
+  return lines.join('\n');
+}

--- a/apps/tui/tsconfig.json
+++ b/apps/tui/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "//": "Typecheck config for @continuum/tui. Mirrors the SDK/chat-view strict contract; compiles against SDK + chat-view SOURCE (both resolve to ./index.ts, no build step). This is a Node client, so the Node lib + @types/node — NOT DOM. It is the deliberate counterpart to apps/web's DOM tsconfig: same shared @continuum/chat-view projection must typecheck under BOTH lib sets, which is the outlier-B proof that the view model is platform-neutral. tsc is --noEmit typecheck only; the Node runtime strips types at load.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,10 +9,11 @@
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@continuum/chat-view": "*",
     "@continuum/sdk-typescript": "*",
     "lit": "^3.2.0"
   },

--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -17,8 +17,8 @@
  */
 
 import { LitElement, html, css, nothing, type PropertyValues, type TemplateResult } from 'lit';
-import type { ChatState } from './ChatState';
-import { chatViewModel } from './chatViewModel';
+import type { ChatState } from '@continuum/chat-view';
+import { chatViewModel } from '@continuum/chat-view';
 import { renderChat } from './renderChat';
 
 /** The send action the host injects. Resolves when the message is accepted by

--- a/apps/web/src/chat/renderChat.ts
+++ b/apps/web/src/chat/renderChat.ts
@@ -19,7 +19,7 @@
  */
 
 import { html, nothing, type TemplateResult } from 'lit';
-import type { ChatViewModel, MemberKind, MessageRowVM, RosterMemberVM } from './chatViewModel';
+import type { ChatViewModel, MemberKind, MessageRowVM, RosterMemberVM } from '@continuum/chat-view';
 
 /** Short glyph per author kind — the neutral human/agent/system discriminant. */
 function kindGlyph(kind: MemberKind): string {

--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -29,7 +29,7 @@ export interface WebChatConfig {
 
 /** Read a value from `?key=` then `import.meta.env[VITE_key]`, else `undefined`. */
 function lookup(queryKey: string, envKey: string): string | undefined {
-  const params = new URLSearchParams(globalThis.location?.search ?? '');
+  const params = new URLSearchParams(globalThis.location.search);
   const fromQuery = params.get(queryKey);
   if (fromQuery) return fromQuery;
   const env = (import.meta as { env?: Record<string, string | undefined> }).env;
@@ -46,13 +46,14 @@ export function resolveConfig(): WebChatConfig {
   const wsUrl = lookup('core', 'VITE_CONTINUUM_WS');
   const senderId = lookup('me', 'VITE_CONTINUUM_USER_ID');
 
-  const missing: string[] = [];
-  if (!wsUrl) missing.push("core WS url — set VITE_CONTINUUM_WS (or ?core=ws://host:port). The core must run with CONTINUUM_CORE_WS=<port> set.");
-  if (!senderId) missing.push('sender identity — set VITE_CONTINUUM_USER_ID (or ?me=<uuid>). Identity pairing is not wired yet (tasks #37/#38).');
-  if (missing.length > 0) {
+  // Narrow on the values themselves (not a separate count) so TS proves both are
+  // `string` past this block — no cast, no `!`, just a guard that actually holds.
+  if (wsUrl === undefined || senderId === undefined) {
+    const missing: string[] = [];
+    if (wsUrl === undefined) missing.push("core WS url — set VITE_CONTINUUM_WS (or ?core=ws://host:port). The core must run with CONTINUUM_CORE_WS=<port> set.");
+    if (senderId === undefined) missing.push('sender identity — set VITE_CONTINUUM_USER_ID (or ?me=<uuid>). Identity pairing is not wired yet (tasks #37/#38).');
     throw new Error(`web chat config incomplete:\n  - ${missing.join('\n  - ')}`);
   }
 
-  // Non-null: the guard above threw if either was falsy.
-  return { wsUrl: wsUrl as string, senderId: senderId as string };
+  return { wsUrl, senderId };
 }

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -25,7 +25,7 @@ import {
 } from '@continuum/sdk-typescript';
 import { resolveConfig } from './config';
 import { ChatWidget, type SendHandler } from './chat/ChatWidget';
-import { CHAT_KIND, chatStateFromEnvelope, type ChatState } from './chat/ChatState';
+import { CHAT_KIND, chatStateFromEnvelope, type ChatState } from '@continuum/chat-view';
 
 // Importing the module registers `<chat-widget>` as a side effect; keep the
 // symbol referenced so bundlers don't tree-shake the definition away.
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
     // runs). Belt-and-suspenders for any handler that instead reports failure
     // in-band: an explicit `success === false` must throw so the widget shows it
     // and keeps the draft — never a silently-dropped message.
-    if (result.success === false) {
+    if (!result.success) {
       throw new Error(`chat/send rejected: ${result.error ?? 'unknown error'}`);
     }
     // A `warning` on a success means stored-locally-but-broadcast-failed. Surface
@@ -82,7 +82,7 @@ async function main(): Promise<void> {
   await state.connect();
 }
 
-main().catch((err) => {
+main().catch((err: unknown) => {
   // Boot failure (bad config, dead core) must be visible, not a blank page.
   console.error('web chat client failed to start:', err);
   const mount = document.getElementById('app') ?? document.body;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,86 @@
+// Clippy-grade lint gate for the NEW client tree — the SDK + shared views + the
+// apps built on them. Legacy `src/` keeps its own `src/eslint.config.js`; this
+// config deliberately does NOT touch it (that monolith is reference-only). Here
+// the bar is: type-checked, strict, zero `any`, and it BLOCKS — `--max-warnings 0`
+// means a warning is a failure, the way `cargo clippy -D warnings` won't let a
+// Rust change through with a lint outstanding.
+//
+// Scope: packages/**, apps/web, apps/tui — the hand-written client code this
+// gate owns. sdk/typescript is deliberately out of scope for now: it carries a
+// pre-existing ts-rs codegen drift (u64 fields generated as `bigint` instead of
+// the CLAUDE.md-canonical `#[ts(type="number")]` → `number`), which is a
+// Rust-side regen fix tracked separately — not something to lint-gate around
+// here. Fold the SDK in once that regen lands. Generated bindings and build
+// output are excluded — we lint hand-written source, not machine output.
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import globals from 'globals';
+
+export default tseslint.config(
+  {
+    // Only the new client tree. Everything else (legacy src/, tooling js, build
+    // output, generated bindings) is out of scope for this gate.
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      'src/**',
+      'core/**',
+      'tools/**',
+      'scripts/**',
+      'sdk/**',
+      '**/*.js',
+      '**/*.mjs',
+      '**/*.cjs',
+    ],
+  },
+
+  // Type-checked strict base — the real "clippy": rules that need the type
+  // system to fire (no-floating-promises, no-unsafe-*, etc.).
+  js.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+
+  {
+    files: ['packages/**/*.ts', 'apps/web/**/*.ts', 'apps/tui/**/*.ts'],
+    languageOptions: {
+      // projectService auto-resolves each file to its nearest tsconfig, so one
+      // config type-checks four packages with four different lib/target sets.
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // Zero tolerance for the escape hatches the doctrine forbids.
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-non-null-assertion': 'error',
+      // Promise safety — an unawaited send/connect is a real bug in this code.
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      // Every exported/public function states its return type (intent over
+      // inference at the boundary).
+      '@typescript-eslint/explicit-function-return-type': [
+        'error',
+        { allowExpressions: true, allowTypedFunctionExpressions: true },
+      ],
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
+      ],
+      // Numbers in template literals are type-safe and idiomatic (member counts,
+      // timestamps). Everything else the strict default forbids stays forbidden.
+      '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true }],
+    },
+  },
+
+  {
+    // Test files run under Node (vitest globals come from the import, but the
+    // process/env access in specs is Node). Keep the same strict rule set.
+    files: ['**/*.spec.ts', '**/*.test.ts'],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,21 @@
       "name": "continuum",
       "workspaces": [
         "sdk/typescript",
+        "packages/chat-view",
         "apps/web",
+        "apps/tui",
         "apps/desktop"
       ],
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.76",
         "@anthropic-ai/claude-code": "^2.1.76"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.13.0",
+        "eslint": "^9.13.0",
+        "globals": "^15.11.0",
+        "typescript": "^5.6.0",
+        "typescript-eslint": "^8.11.0"
       }
     },
     "apps/desktop": {
@@ -27,10 +36,27 @@
         "typescript": "^5.6.0"
       }
     },
+    "apps/tui": {
+      "name": "@continuum/tui",
+      "version": "0.1.0",
+      "dependencies": {
+        "@continuum/chat-view": "*",
+        "@continuum/sdk-typescript": "*"
+      },
+      "bin": {
+        "continuum-tui": "src/index.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      }
+    },
     "apps/web": {
       "name": "@continuum/web",
       "version": "0.1.0",
       "dependencies": {
+        "@continuum/chat-view": "*",
         "@continuum/sdk-typescript": "*",
         "lit": "^3.2.0"
       },
@@ -86,12 +112,20 @@
         "@img/sharp-win32-x64": "^0.34.2"
       }
     },
+    "node_modules/@continuum/chat-view": {
+      "resolved": "packages/chat-view",
+      "link": true
+    },
     "node_modules/@continuum/desktop": {
       "resolved": "apps/desktop",
       "link": true
     },
     "node_modules/@continuum/sdk-typescript": {
       "resolved": "sdk/typescript",
+      "link": true
+    },
+    "node_modules/@continuum/tui": {
+      "resolved": "apps/tui",
       "link": true
     },
     "node_modules/@continuum/web": {
@@ -487,6 +521,229 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -1399,11 +1656,310 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -1518,6 +2074,69 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1528,6 +2147,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1536,6 +2173,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/chai": {
@@ -1555,6 +2202,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -1563,6 +2227,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -1592,6 +2298,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1639,6 +2352,163 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1647,6 +2517,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expect-type": {
@@ -1658,6 +2538,96 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1672,6 +2642,177 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lit": {
@@ -1705,6 +2846,29 @@
         "@types/trusted-types": "^2.0.2"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -1720,6 +2884,19 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -1748,6 +2925,96 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -1771,6 +3038,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.16",
@@ -1799,6 +3079,36 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/rollup": {
@@ -1846,6 +3156,42 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1877,6 +3223,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -1890,6 +3262,23 @@
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
     },
     "node_modules/tinypool": {
       "version": "1.1.1",
@@ -1921,6 +3310,32 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1933,6 +3348,47 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -2084,6 +3540,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2101,6 +3573,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -2109,6 +3604,17 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/chat-view": {
+      "name": "@continuum/chat-view",
+      "version": "0.1.0",
+      "dependencies": {
+        "@continuum/sdk-typescript": "*"
+      },
+      "devDependencies": {
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
       }
     },
     "sdk/typescript": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Continuum — a headless persona substrate. The Rust core is the server; every UI is an equal, dependent client over the same Commands/Events SDK. `npm start` boots ONLY the headless core (Rust, no desktop). Clients live under apps/ (web, desktop, cli[Rust], mobile, vr, ar, mcp) and attach on demand.",
   "workspaces": [
     "sdk/typescript",
+    "packages/chat-view",
     "apps/web",
+    "apps/tui",
     "apps/desktop"
   ],
   "scripts": {
@@ -12,6 +14,10 @@
     "dev:web": "npm run dev -w @continuum/web",
     "dev:desktop": "npm run dev -w @continuum/desktop",
     "build:clients": "npm run build -w @continuum/sdk-typescript && npm run build -w @continuum/web",
+    "lint:clients": "eslint --max-warnings 0 packages apps/web apps/tui",
+    "typecheck:clients": "npm run typecheck -w @continuum/chat-view && npm run typecheck -w @continuum/web && npm run typecheck -w @continuum/tui",
+    "test:clients": "npm test -w @continuum/chat-view && npm test -w @continuum/tui && npm test -w @continuum/web",
+    "check:clients": "npm run lint:clients && npm run typecheck:clients && npm run test:clients",
     "stop": "bash tools/scripts/system-stop.sh",
     "install:continuum": "bash tools/scripts/install.sh",
     "setup:git-hooks": "bash tools/scripts/setup-git-hooks.sh",
@@ -20,5 +26,12 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.76",
     "@anthropic-ai/claude-code": "^2.1.76"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.13.0",
+    "eslint": "^9.13.0",
+    "globals": "^15.11.0",
+    "typescript": "^5.6.0",
+    "typescript-eslint": "^8.11.0"
   }
 }

--- a/packages/chat-view/ChatState.ts
+++ b/packages/chat-view/ChatState.ts
@@ -4,14 +4,16 @@
  * On the wire the `kind` and `revision` live on the `StateEnvelope`, NOT on the
  * payload — `ChatViewState` has neither field. positron's renderer contract,
  * though, keys off a state object that carries its own `kind`/`revision` (a
- * `ViewState`). So the app MERGES the envelope's `kind`/`revision` onto the
+ * `ViewState`). So a client MERGES the envelope's `kind`/`revision` onto the
  * payload once, at the seam where a `StateConnection` sink hands a
- * `StateEnvelope` to the widget. That merged object is `ChatState`.
+ * `StateEnvelope` to the renderer. That merged object is `ChatState`.
  *
  * This is the one place the two positron halves — neutral transport
- * (`StateEnvelope`) and concrete payload (`ChatViewState`) — are joined, and it
- * lives in the APP, not the SDK: the SDK stays a neutral envelope courier
- * ([[headless-core-many-clients]]).
+ * (`StateEnvelope`) and concrete payload (`ChatViewState`) — are joined. It
+ * lives in the shared `@continuum/chat-view` package, NOT the SDK: the SDK stays
+ * a neutral envelope courier, and every chat client (apps/web's Lit widget,
+ * apps/tui's ANSI renderer) does this merge identically, so it is single-sourced
+ * here rather than re-forked per client ([[headless-core-many-clients]]).
  */
 
 import type { ChatViewState, StateEnvelope } from '@continuum/sdk-typescript';

--- a/packages/chat-view/chatViewModel.spec.ts
+++ b/packages/chat-view/chatViewModel.spec.ts
@@ -13,7 +13,7 @@ import { chatViewModel, formatTimeOfDay } from './chatViewModel';
 import type { ChatState } from './ChatState';
 import type { ChatMessageView, RosterSlotView, SenderKind } from '@continuum/sdk-typescript';
 
-const kind = (k: SenderKind['kind']): SenderKind => ({ kind: k }) as SenderKind;
+const kind = (k: SenderKind['kind']): SenderKind => ({ kind: k });
 
 const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
   member_id: 'm-1',
@@ -97,9 +97,9 @@ describe('chatViewModel', () => {
         ],
       }),
     );
-    expect(vm.messages[0].senderName).toBe('Asha');
-    expect(vm.messages[0].kind).toBe('agent');
-    expect(vm.messages[0].runtime).toBe('claude');
+    expect(vm.messages[0]?.senderName).toBe('Asha');
+    expect(vm.messages[0]?.kind).toBe('agent');
+    expect(vm.messages[0]?.runtime).toBe('claude');
   });
 
   // what this catches: unresolved provenance ('') must stay empty so the
@@ -107,7 +107,7 @@ describe('chatViewModel', () => {
   // who a citizen really is (an identity/trust concern, [[positron-identity-security-first-class]]).
   it('preserves an unresolved runtime as empty (no fabrication)', () => {
     const vm = chatViewModel(state({ roster: [member({ provenance: { runtime: '' } })] }));
-    expect(vm.members[0].runtime).toBe('');
+    expect(vm.members[0]?.runtime).toBe('');
   });
 
   // what this catches: time-of-day formatting must be deterministic (UTC HH:MM,

--- a/packages/chat-view/chatViewModel.ts
+++ b/packages/chat-view/chatViewModel.ts
@@ -3,12 +3,13 @@
  * render-ready view model the three-panel chat surface draws.
  *
  * This is where ALL the chat presentation logic lives, and it is deliberately
- * DOM-free and Lit-free: a plain `(ChatState) => ChatViewModel` function, unit-
- * tested without a browser. The Lit template (`renderChat`) and the
- * `<chat-widget>` element are then thin — they map this view model to markup and
- * nothing more. Keeping the logic in a pure function is the compression rule
- * (one place computes "how a message row reads") and the reason the widget needs
- * no jsdom to test its behavior.
+ * DOM-free, Lit-free and renderer-neutral: a plain `(ChatState) => ChatViewModel`
+ * function, unit-tested without a browser. Every client renderer is then thin and
+ * maps this view model to its own output — apps/web's Lit template (`renderChat`
+ * → `<chat-widget>`) and apps/tui's ANSI renderer both consume the SAME model.
+ * Keeping the logic in one pure function is the compression rule (one place
+ * computes "how a message row reads") and the reason neither renderer needs a
+ * jsdom or a live terminal to test its behavior.
  *
  * ## The three panels — who / what / where
  *

--- a/packages/chat-view/index.ts
+++ b/packages/chat-view/index.ts
@@ -1,0 +1,25 @@
+/**
+ * `@continuum/chat-view` — the shared, framework-free chat projection.
+ *
+ * Two things every Continuum chat client needs identically, single-sourced here
+ * so they can't drift between renderers:
+ *   - the envelope→state merge (`chatStateFromEnvelope` / `CHAT_KIND` / `ChatState`)
+ *     that joins a positron `StateEnvelope` to its `ChatViewState` payload; and
+ *   - the pure view model (`chatViewModel` + its VM types) that projects a
+ *     snapshot into flat, render-ready rows.
+ *
+ * Renderers live in the clients (apps/web's Lit `<chat-widget>`, apps/tui's ANSI
+ * renderer). This package holds NO transport, NO DOM, NO ANSI — only the wire
+ * decode + projection, typed against `@continuum/sdk-typescript`'s view types.
+ */
+
+export { CHAT_KIND, chatStateFromEnvelope } from './ChatState';
+export type { ChatState } from './ChatState';
+
+export { chatViewModel, formatTimeOfDay } from './chatViewModel';
+export type {
+  ChatViewModel,
+  MemberKind,
+  RosterMemberVM,
+  MessageRowVM,
+} from './chatViewModel';

--- a/packages/chat-view/package.json
+++ b/packages/chat-view/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@continuum/chat-view",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared chat projection for Continuum clients — the framework-free decode + view model that turns a positron chat StateEnvelope into a flat, render-ready ChatViewModel. Consumed by apps/web (Lit) and apps/tui (ANSI) so the 'how a message row reads' logic lives in ONE place; each client owns only its renderer. Depends on @continuum/sdk-typescript for the wire/view types; holds NO transport, NO DOM, NO ANSI.",
+  "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@continuum/sdk-typescript": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/chat-view/tsconfig.json
+++ b/packages/chat-view/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "//": "Typecheck config for @continuum/chat-view. Mirrors the SDK's strict contract; compiles against the SDK source (@continuum/sdk-typescript resolves to ./index.ts, no build step). This package is framework-free and platform-neutral, so NO DOM lib — it must typecheck the same under a browser bundler (apps/web) and under Node (apps/tui). tsc is --noEmit typecheck only; each consumer's bundler/runtime owns transpilation.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What

Task #29 slice 5 — outlier-validate the new client SDK seam. Per CLAUDE.md's methodical process: build outlier A + a maximally-different outlier B; if the interface fits both without forcing → the seam is proven → write the generator → STOP.

- **`packages/chat-view` (`@continuum/chat-view`)** — the shared, framework-free / DOM-free / ANSI-free projection: `ChatState` + `chatStateFromEnvelope` + `chatViewModel` + `formatTimeOfDay`. Single-sources the who/what/where message-row projection so web and tui never re-implement identity/time/presence derivation (compression principle). Extracted out of `apps/web/src/chat/`.
- **`apps/tui`** — the terminal chat client (outlier B). Consumes the **identical** SDK seam as `apps/web` (`StateConnection` READ + `Continuum` `chat/send` SEND), differing **only** in surface: stdin/readline + ANSI vs DOM + Lit. Node ≥22 ships a global `WebSocket`, so the SDK socket classes run in Node with **zero** extra deps — the outlier-B proof that the seam is transport/surface-agnostic.
- **`eslint.config.mjs`** — clippy-grade gate over `packages/**`, `apps/web`, `apps/tui`: `typescript-eslint` `strictTypeChecked` + `stylisticTypeChecked`, `projectService`, `--max-warnings 0` (a warning is a failure, like `clippy -D warnings`). Zero `any`, no non-null assertions, no floating/misused promises, explicit boundary return types. `noUncheckedIndexedAccess` on all three client tsconfigs.

## Fail-loud / identity discipline

`apps/tui`'s config resolves `wsUrl` + `senderId` from `--flags`/env and **fails loud** naming exactly what's missing when either is absent — no invented WS URL, no minted `senderId` (identity pairing is tasks #37/#38). Same narrow-not-cast pattern as `apps/web`'s resolver.

## Out of scope

`sdk/typescript` is deliberately excluded from the gate pending the u64→`bigint` ts-rs codegen fix (**task #120**) — that's a Rust-side regen, not something to lint-gate around here. Fold the SDK in once #120 lands.

## Verification

`npm run check:clients` green:
- lint: clean (`--max-warnings 0`)
- typecheck: clean across chat-view / web / tui
- tests: chat-view **6** pass, tui **12** pass, web passes-with-no-tests (its projection logic lives in chat-view, tested there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)