### PR TITLE
test(clients): cross-consumer proof — web + terminal off one chat seam

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/apps/web/src/chat/renderChat.spec.ts
+++ b/apps/web/src/chat/renderChat.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * renderChat (Lit) unit spec — the web surface of the shared chat seam.
+ *
+ * The terminal twin of apps/tui's renderChat.spec: same input (a `ChatViewModel`
+ * from the SHARED `@continuum/chat-view`), a totally different output (a Lit
+ * `TemplateResult`, not an ANSI string). Together the two specs prove the
+ * north-star's 2/3 — web and terminal render the IDENTICAL seam-produced model,
+ * differing only in surface.
+ *
+ * To keep this DOM-free (no jsdom, no `@lit-labs/ssr`), it drives the model
+ * through the REAL read pipe both clients run — `chatViewModel ∘
+ * chatStateFromEnvelope` off a `StateEnvelope` — then flattens the returned
+ * template tree (its static `strings` + interpolated `values`, recursively) and
+ * asserts every model fact reaches the markup. That proves the web renderer
+ * faithfully carries what the seam produced, without a browser.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { chatStateFromEnvelope, chatViewModel, CHAT_KIND } from '@continuum/chat-view';
+import type { ChatViewModel } from '@continuum/chat-view';
+import type {
+  ChatMessageView,
+  ChatViewState,
+  RosterSlotView,
+  SenderKind,
+  StateEnvelope,
+} from '@continuum/sdk-typescript';
+import { renderChat } from './renderChat';
+
+const kind = (k: SenderKind['kind']): SenderKind => ({ kind: k });
+
+const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
+  member_id: 'm-1',
+  display_name: 'Asha',
+  kind: kind('agent'),
+  integrations: {},
+  provenance: { runtime: '' },
+  active: true,
+  ...over,
+});
+
+const message = (over: Partial<ChatMessageView> = {}): ChatMessageView => ({
+  id: 'msg-1',
+  room_id: 'room-1',
+  sender_id: 's-1',
+  sender_name: 'Joel',
+  sender_kind: kind('human'),
+  integrations: {},
+  provenance: { runtime: '' },
+  content: 'hello',
+  timestamp: 0,
+  ...over,
+});
+
+/** Project a `ChatViewState` payload through the exact pipe apps/web's index.ts
+ *  runs, so the renderer is fed what the seam actually produces. */
+const project = (payload: ChatViewState): ChatViewModel => {
+  const env: StateEnvelope = { kind: CHAT_KIND, revision: 1, layer: 'ephemeral', payload };
+  return chatViewModel(chatStateFromEnvelope(env));
+};
+
+/** A Lit `TemplateResult` exposes its static `strings` and interpolated `values`.
+ *  We read them structurally rather than render to DOM. */
+interface LitTemplateLike {
+  readonly strings: readonly string[];
+  readonly values: readonly unknown[];
+}
+function isTemplateLike(node: object): node is LitTemplateLike {
+  return 'strings' in node && 'values' in node;
+}
+
+/** Flatten a Lit template tree to every string that would reach the markup — the
+ *  static chunks plus every interpolated primitive, following nested templates
+ *  and `.map` arrays. `nothing`/symbols/objects with no text contribute nothing. */
+function flatten(node: unknown, out: string[] = []): string[] {
+  if (typeof node === 'string') {
+    out.push(node);
+  } else if (typeof node === 'number') {
+    out.push(String(node));
+  } else if (Array.isArray(node)) {
+    for (const child of node as readonly unknown[]) flatten(child, out);
+  } else if (typeof node === 'object' && node !== null && isTemplateLike(node)) {
+    for (const s of node.strings) out.push(s);
+    for (const v of node.values) flatten(v, out);
+  }
+  return out;
+}
+
+/** The full flattened markup text of a rendered view model. */
+const markup = (vm: ChatViewModel): string => flatten(renderChat(vm)).join('');
+
+describe('renderChat (Lit)', () => {
+  // what this catches: the three panels must all reach the markup from one
+  // seam-projected snapshot — room (where), each roster member (who), each
+  // message (what). A regression dropping a facet would blank a whole panel, and
+  // it must match the terminal renderer's contract fact-for-fact.
+  it('renders room, roster, and messages from a seam-projected snapshot', () => {
+    const vm = project({
+      room_id: 'room-1',
+      room_name: 'general',
+      roster: [
+        member({ member_id: 'asha', display_name: 'Asha', kind: kind('agent'), provenance: { runtime: 'claude' } }),
+        member({ member_id: 'joel', display_name: 'Joel', kind: kind('human'), active: false }),
+      ],
+      messages: [
+        message({ id: 'm1', sender_name: 'Joel', sender_kind: kind('human'), content: 'hi Asha', timestamp: 0 }),
+      ],
+    });
+    const chunks = flatten(renderChat(vm));
+
+    // Every model fact is interpolated, so it appears as its OWN chunk. flatten
+    // pushes all static template strings first, then all interpolated values —
+    // static/value adjacency is NOT preserved — so assert exact chunk membership,
+    // never a joined-string substring. (A substring '1' would be satisfied by the
+    // '1' in 'room-1'; a substring 'active' by the header's static
+    // title="active / total" — both would pass with a broken count/roster.)
+    // WHERE: room identity + the active/total counts.
+    expect(chunks).toContain('general'); // roomName
+    expect(chunks).toContain('room-1'); // roomId
+    expect(chunks).toContain('1'); // activeCount value (1 of 2 present at snapshot)
+    expect(chunks).toContain('2'); // memberCount value
+    // WHO: both members, each presence rendered as its own 'active'/'idle' value.
+    expect(chunks).toContain('Asha');
+    expect(chunks).toContain('Joel');
+    expect(chunks).toContain('active'); // Asha present
+    expect(chunks).toContain('idle'); // Joel idle
+    // WHAT: the turn's sender, content and time all reach the markup as values.
+    expect(chunks).toContain('hi Asha');
+    expect(chunks).toContain('00:00');
+  });
+
+  // what this catches: an empty conversation must draw the honest empty-state
+  // string, not an error and not a bare void — matching the ANSI renderer's
+  // "No messages yet — say hello." contract exactly.
+  it('renders an honest empty state when there are no messages', () => {
+    const vm = project({ room_id: 'room-1', room_name: 'general', roster: [], messages: [] });
+    const text = markup(vm);
+    expect(text).toContain('No messages yet — say hello.');
+    expect(text).not.toMatch(/error/i);
+  });
+
+  // what this catches: a runtime badge must appear ONLY when the substrate
+  // resolved an origin — an unresolved '' runtime must inject no badge (no
+  // fabricated provenance, [[positron-identity-security-first-class]]). The badge
+  // markup (`class="runtime"`) must appear exactly once for one resolved member.
+  it('badges a resolved runtime once and never fabricates one for the unresolved', () => {
+    const vm = project({
+      room_id: 'room-1',
+      room_name: 'general',
+      roster: [
+        member({ member_id: 'asha', display_name: 'Asha', provenance: { runtime: 'claude' } }),
+        member({ member_id: 'nyx', display_name: 'Nyx', provenance: { runtime: '' } }),
+      ],
+      messages: [],
+    });
+    const chunks = flatten(renderChat(vm));
+    const badgeCount = chunks.filter((c) => c.includes('class="runtime"')).length;
+    expect(badgeCount).toBe(1); // only Asha's resolved origin, never Nyx's ''
+    expect(chunks.join('')).toContain('claude');
+  });
+});

--- a/packages/chat-view/crossConsumer.spec.ts
+++ b/packages/chat-view/crossConsumer.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * Cross-consumer conformance — the shared READ pipe both chat clients run.
+ *
+ * The north-star for task #29 is proving web + terminal + personaRag consume ONE
+ * SDK seam. This spec pins the part web and terminal genuinely SHARE: the
+ * read-path pipe that turns a `chat` `StateEnvelope` off the wire into the
+ * `ChatViewModel` a renderer draws. Both composition roots run this exact pipe,
+ * verbatim, inside their `StateConnection.on(CHAT_KIND)` sink:
+ *
+ *   apps/web/src/index.ts:74-77  latest = chatStateFromEnvelope(env); widget.state = latest
+ *                                (the Lit widget then draws renderChat(chatViewModel(latest)))
+ *   apps/tui/src/index.ts:78-81  latest = chatStateFromEnvelope(env); paint()
+ *                                (paint draws renderChat(chatViewModel(latest)))
+ *
+ * So `chatViewModel(chatStateFromEnvelope(env))` IS the shared seam. It lives
+ * once here in `@continuum/chat-view` (the compression rule — one place computes
+ * "what a chat snapshot becomes") and is tested here from the WIRE — the gap
+ * neither sibling spec covers: chatViewModel.spec starts from a hand-built
+ * `ChatState` (never an envelope), and StateConnection.spec proves socket
+ * framing/routing (never the merge+project). Two independent consumers folding
+ * the SAME scripted envelope stream through this pipe MUST stay byte-identical;
+ * that identity is precisely what "web and terminal off one seam" means.
+ *
+ * Each surface's own rendering is proven in its own package: apps/tui's
+ * renderChat.spec (ANSI) and apps/web's renderChat.spec (Lit). This file proves
+ * the MODEL those two renderers both receive is one canonical value.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CHAT_KIND, chatStateFromEnvelope } from './ChatState';
+import { chatViewModel } from './chatViewModel';
+import type { ChatViewModel } from './chatViewModel';
+import type {
+  ChatMessageView,
+  ChatViewState,
+  RosterSlotView,
+  SenderKind,
+  StateEnvelope,
+} from '@continuum/sdk-typescript';
+
+const kind = (k: SenderKind['kind']): SenderKind => ({ kind: k });
+
+const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
+  member_id: 'm-1',
+  display_name: 'Asha',
+  kind: kind('agent'),
+  integrations: {},
+  provenance: { runtime: '' },
+  active: true,
+  ...over,
+});
+
+const message = (over: Partial<ChatMessageView> = {}): ChatMessageView => ({
+  id: 'msg-1',
+  room_id: 'room-1',
+  sender_id: 's-1',
+  sender_name: 'Joel',
+  sender_kind: kind('human'),
+  integrations: {},
+  provenance: { runtime: '' },
+  content: 'hello',
+  timestamp: 0,
+  ...over,
+});
+
+/** A `chat` state frame exactly as `StateConnection` hands to a `CHAT_KIND` sink:
+ *  the payload is a bare `ChatViewState` (no kind/revision — those ride the
+ *  envelope), and the merge is what grafts them on. */
+const chatEnvelope = (revision: number, payload: ChatViewState): StateEnvelope => ({
+  kind: CHAT_KIND,
+  revision,
+  layer: 'ephemeral',
+  payload,
+});
+
+/**
+ * The shared read-path closure both `index.ts` sinks run, verbatim. Every chat
+ * client is `chatViewModel ∘ chatStateFromEnvelope` over each delivered envelope
+ * — the single seam this spec pins.
+ */
+const readPath = (env: StateEnvelope): ChatViewModel =>
+  chatViewModel(chatStateFromEnvelope(env));
+
+/**
+ * One consumer of the state stream — models a client's `.on(CHAT_KIND)` sink: it
+ * folds each envelope through the shared pipe and keeps the latest model, exactly
+ * as apps/web (→ `widget.state`) and apps/tui (→ `paint`) do. Two of these,
+ * driven by the same stream, are the "web consumer" and "terminal consumer".
+ */
+class StreamConsumer {
+  readonly models: ChatViewModel[] = [];
+  latest?: ChatViewModel;
+  deliver(env: StateEnvelope): void {
+    this.latest = readPath(env);
+    this.models.push(this.latest);
+  }
+}
+
+/** The scripted wire: an opening snapshot, then a live delta that adds a turn and
+ *  flips a member's presence — the minimal stream that exercises merge + project
+ *  across a revision transition. */
+const SNAPSHOT: StateEnvelope = chatEnvelope(1, {
+  room_id: 'room-1',
+  room_name: 'general',
+  roster: [
+    member({ member_id: 'asha', display_name: 'Asha', kind: kind('agent'), provenance: { runtime: 'claude' } }),
+    member({ member_id: 'joel', display_name: 'Joel', kind: kind('human'), active: false }),
+  ],
+  messages: [
+    message({ id: 'm1', sender_id: 'joel', sender_name: 'Joel', sender_kind: kind('human'), content: 'hi Asha', timestamp: 0 }),
+  ],
+});
+
+const DELTA: StateEnvelope = chatEnvelope(2, {
+  room_id: 'room-1',
+  room_name: 'general',
+  roster: [
+    member({ member_id: 'asha', display_name: 'Asha', kind: kind('agent'), provenance: { runtime: 'claude' } }),
+    member({ member_id: 'joel', display_name: 'Joel', kind: kind('human'), active: true }),
+  ],
+  messages: [
+    message({ id: 'm1', sender_id: 'joel', sender_name: 'Joel', sender_kind: kind('human'), content: 'hi Asha', timestamp: 0 }),
+    message({
+      id: 'm2',
+      sender_id: 'asha',
+      sender_name: 'Asha',
+      sender_kind: kind('agent'),
+      provenance: { runtime: 'claude' },
+      content: 'hello Joel',
+      timestamp: 9 * 3600_000 + 5 * 60_000,
+    }),
+  ],
+});
+
+describe('cross-consumer read pipe', () => {
+  // what this catches: the whole reason chat-view exists — two clients built on
+  // the same seam must derive the IDENTICAL view model from the same wire, or the
+  // "one seam, many surfaces" claim is false. A regression that let one consumer's
+  // pipe drift (an app doing its own merge/projection instead of this shared one)
+  // would make these two folds diverge.
+  it('two independent consumers fold one wire stream to byte-identical models', () => {
+    const web = new StreamConsumer();
+    const tui = new StreamConsumer();
+
+    for (const env of [SNAPSHOT, DELTA]) {
+      web.deliver(env);
+      tui.deliver(env);
+    }
+
+    expect(web.models).toEqual(tui.models);
+    expect(web.latest).toEqual(tui.latest);
+  });
+
+  // what this catches: the pipe must project the WIRE snapshot into the exact
+  // three-panel model both renderers draw — room (where), roster (who), messages
+  // (what) — starting from a StateEnvelope, the path no sibling spec covers.
+  it('projects the opening snapshot into the canonical view model', () => {
+    const vm = readPath(SNAPSHOT);
+    expect(vm.roomName).toBe('general');
+    expect(vm.roomId).toBe('room-1');
+    expect(vm.memberCount).toBe(2);
+    expect(vm.activeCount).toBe(1); // Joel idle at snapshot
+    expect(vm.members.map((m) => m.id)).toEqual(['asha', 'joel']);
+    expect(vm.messages.map((m) => m.content)).toEqual(['hi Asha']);
+    expect(vm.isEmpty).toBe(false);
+  });
+
+  // what this catches: a live delta must fully replace the model (positron emits a
+  // fresh snapshot per revision — no widget-local accumulation). The added turn
+  // appears, the flipped presence updates activeCount, and the empty-state clears.
+  it('advances to the delta as a full fresh snapshot, not an accumulation', () => {
+    const web = new StreamConsumer();
+    web.deliver(SNAPSHOT);
+    web.deliver(DELTA);
+
+    const vm = web.latest;
+    expect(vm?.messages.map((m) => m.content)).toEqual(['hi Asha', 'hello Joel']);
+    expect(vm?.activeCount).toBe(2); // Joel now present
+    expect(vm?.messages[1]?.time).toBe('09:05'); // deterministic UTC HH:MM off the wire timestamp
+  });
+
+  // what this catches: the ChatState merge seam — kind/revision live on the
+  // ENVELOPE, never the ChatViewState payload, so the pipe must graft the
+  // envelope's revision onto the model. A regression reading revision off the
+  // payload (where it does not exist) would surface undefined and defeat cheap
+  // change-detection.
+  it('carries the envelope revision (not the payload) onto the model', () => {
+    expect(readPath(SNAPSHOT).revision).toBe(1);
+    expect(readPath(DELTA).revision).toBe(2);
+  });
+
+  // what this catches: a non-chat envelope reaching the chat merge is a
+  // StateConnection routing bug and must fail loud, never be coerced into a chat
+  // model ([[fallbacks-are-illegal-fail-loud]]). Guards the seam both apps trust
+  // the router to uphold.
+  it('fails loud when a non-chat envelope reaches the pipe', () => {
+    const wrong: StateEnvelope = { kind: 'wall', revision: 1, layer: 'ephemeral', payload: {} };
+    expect(() => readPath(wrong)).toThrow(/expected kind 'chat'/);
+  });
+});


### PR DESCRIPTION
## What

**Step 1 of the "prove web + terminal + personaRag on one SDK seam" north-star.** Web and terminal already ride the identical seam (same `Continuum`/`WebSocketTransport` SEND, same `StateConnection` READ, same `@continuum/chat-view` projection — they differ only in renderer). This pins that shared read-path with a test, and closes web's zero-tests gap so both surfaces are covered before we wire the third consumer (Asha/personaRag, Step 2).

## The two proofs

**`packages/chat-view/crossConsumer.spec.ts`** — the shared seam, tested from the **wire**. `chatViewModel(chatStateFromEnvelope(env))` is the exact closure both composition roots run in their `StateConnection` `CHAT_KIND` sink (`apps/web/src/index.ts:74-77`, `apps/tui/src/index.ts:78-81`). Two independent consumers folding one scripted `StateEnvelope` stream (snapshot rev1 → live delta rev2) must derive **byte-identical** `ChatViewModel`s — that identity *is* "one seam, many surfaces". Also pins:
- the merge grafts the **envelope** revision onto a payload that carries none,
- a live delta is a full fresh snapshot (no widget-local accumulation),
- **fail-loud** on a wrong-`kind` envelope.

Covers the gap neither sibling spec touches: `chatViewModel.spec` starts from a hand-built `ChatState`; `StateConnection.spec` proves socket framing — neither runs merge+project from an envelope.

**`apps/web/src/chat/renderChat.spec.ts`** — the terminal twin of apps/tui's `renderChat.spec`: same seam-projected model, different surface (Lit `TemplateResult` vs ANSI). DOM-free (no `@lit-labs/ssr`) — flattens the template tree and asserts every model fact reaches the markup: three panels, presence, empty state, and a runtime badge that appears **only** for a resolved origin (never fabricated for an unresolved `''`). Drops apps/web's `--passWithNoTests` so an empty run now fails loud (lost coverage is a regression signal).

## Validation

`npm run test:clients` green — **sdk 44, chat-view 11, tui 12, web 3**. `lint:clients` (eslint `--max-warnings 0`) and `typecheck:clients` clean.

## Not in scope (Step 2, deferred, Joel-approved next)

Wiring `InProcessTransport` `subscribe`/`emit` + a persona state-subscription so Asha consumes the same room-state view — requires the persona/concurrency STOP-gate docs first. Client generator (task #29) waits until personaRag is on the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)