### PR TITLE
feat(positron): converge roster projection — one neutral RoomMember→RosterSlotView both rails read (#8/#13)

### DIFF
--- a/apps/web/src/chat/renderChat.spec.ts
+++ b/apps/web/src/chat/renderChat.spec.ts
@@ -36,6 +36,7 @@ const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
   integrations: {},
   provenance: { runtime: '' },
   active: true,
+  last_seen_ms: 0,
   ...over,
 });
 

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -1024,10 +1024,18 @@ impl LlamaServerControl for LlamaServerProcess {
             // pure optimization flag: absent it we just re-prefill (correct, slow);
             // present it we reuse (correct, fast) — no fallback, no behavior change.
             .arg("--cache-reuse")
-            .arg("256")
-            // Serve embeddings from the same process so the embedder doesn't
-            // need a second server. Personas' embedding adapter points here too.
-            .arg("--embeddings");
+            .arg("256");
+        // `--embeddings` is deliberately NOT set on this GENERATION lane. On the
+        // current llama.cpp build it puts the server in embedding (non-causal)
+        // mode, which makes generation fail with `500 "Compute error."` on EVERY
+        // request — every persona turn went dark (and OAI /v1/embeddings still
+        // 400s with "pooling type 'none'", so it wasn't even serving embeddings
+        // correctly). One server cannot serve both causal generation and
+        // non-causal embeddings. Verified 2026-07-03: the base GGUF generates
+        // cleanly the instant this flag is removed. llama-server-hosted
+        // embeddings need their OWN lane (`--embeddings --pooling mean/last` on a
+        // separate port) — a follow-up; the live embedding path today is the
+        // fastembed/ONNX provider, unaffected by this lane.
         // Placement: CPU lanes pin every layer to RAM so they never contend for
         // the GPU VRAM a living lane already holds (the Metal decode-time OOM that
         // muted the eval). GPU lanes omit the flag — llama-server offloads all it

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1804,27 +1804,54 @@ pub fn start_server(
                     .map(|p| p.fits_on_gpu)
                     .unwrap_or(false);
                 if plan_ready {
-                    attempt += 1;
-                    let summary = supervisor
-                        .spawn_all(&mut provider, Some(tool_executor.clone()))
-                        .await;
-                    if summary.hosted > 0 {
-                        tracing::info!(
-                            hosted = summary.hosted,
-                            failed = summary.failed(),
-                            attempts = attempt,
-                            "🌐 Substrate boot composition complete (slice 13.5) — \
-                             citizen(s) hosted, event-driven on serving-plan readiness"
+                    // `fits_on_gpu` is a RESOURCE decision (the model fits VRAM) — it does
+                    // NOT prove the lane can DECODE. A lane can fit yet fail EVERY
+                    // generation with `500 "Compute error."` while `/health` still answers
+                    // 200 — e.g. spawned with a flag that forces embedding/non-causal mode
+                    // (the live-2026-07-03 `--embeddings` outage), a bad LoRA, or a wedged
+                    // Metal context. Hosting personas onto such a lane makes every turn
+                    // 500 SILENTLY. So gate the spawn on the DECODE-VERIFIED serving
+                    // snapshot: `ServingSnapshot.ready` is published only on a serve/adopt
+                    // outcome that passed the 1-token decode smoke-probe. `await_ready_serving`
+                    // parks on the serving snapshot until the lane proves it can think, or
+                    // the deadline lapses. On timeout we do NOT spawn (a can't-decode lane
+                    // is a loud, novel failure — never a silent per-turn 500); we park and
+                    // retry on the next serving edge, self-healing once the lane recovers.
+                    if crate::inference::llama_server::await_ready_serving(
+                        std::time::Duration::from_secs(120),
+                    )
+                    .await
+                    .is_none()
+                    {
+                        tracing::warn!(
+                            "serving plan fits on GPU but the lane is NOT decode-ready \
+                             within 120s — /health may be 200 while every generation 500s \
+                             (a broken spawn flag / wedged compute context). NOT hosting \
+                             personas onto a lane that cannot generate; retrying on the \
+                             next serving edge."
                         );
-                        break;
+                    } else {
+                        attempt += 1;
+                        let summary = supervisor
+                            .spawn_all(&mut provider, Some(tool_executor.clone()))
+                            .await;
+                        if summary.hosted > 0 {
+                            tracing::info!(
+                                hosted = summary.hosted,
+                                failed = summary.failed(),
+                                attempts = attempt,
+                                "🌐 Substrate boot composition complete (slice 13.5) — \
+                                 citizen(s) hosted, event-driven on serving-plan readiness"
+                            );
+                            break;
+                        }
+                        tracing::warn!(
+                            failed = summary.failed(),
+                            attempt,
+                            "persona spawn found a decode-ready serving lane but no citizen \
+                             materialized — will retry on the next serving-plan edge"
+                        );
                     }
-                    tracing::warn!(
-                        failed = summary.failed(),
-                        attempt,
-                        "persona spawn found a fitting serving plan but no citizen \
-                         materialized (gateway likely still loading the model) — \
-                         will retry on the next serving-plan edge"
-                    );
                 }
                 // Park until the serving daemon republishes (every tick, or
                 // sooner on a pressure edge). `changed()` errs only if the

--- a/core/continuum-core/src/ipc/positron_kanban_source.rs
+++ b/core/continuum-core/src/ipc/positron_kanban_source.rs
@@ -94,9 +94,7 @@ use continuum_positron::{
 };
 use serde::Deserialize;
 
-use crate::ipc::positron_source::{
-    resolve_identity, roster_slots_from, AircPresenceUpdate, PRESENCE_UPDATED,
-};
+use crate::ipc::positron_source::{resolve_identity, AircPresenceUpdate, PRESENCE_UPDATED};
 use crate::runtime::{BusEvent, MessageBus};
 
 /// Abstract reader over the airc room work board. Production rides on
@@ -342,7 +340,7 @@ fn classify(name: &str, payload: &serde_json::Value) -> Option<KanbanInput> {
             .map(|c| KanbanInput::Changed(c.room_id)),
         PRESENCE_UPDATED => serde_json::from_value::<AircPresenceUpdate>(body.clone())
             .ok()
-            .map(|u| KanbanInput::Presence(u.room_id, roster_slots_from(&u))),
+            .map(|u| KanbanInput::Presence(u.room_id, u.roster)),
         _ => None,
     }
 }
@@ -504,7 +502,8 @@ mod tests {
     use airc_core::{PeerId, RoomId};
     use airc_work::{LaneId, RepoId, WorkCardId};
     use async_trait::async_trait;
-    use continuum_positron::SenderKind;
+    use crate::ipc::positron_source::{test_presence_payload, test_roster_slot};
+    use continuum_positron::{Provenance, SenderKind};
     use serde_json::json;
     use std::sync::Mutex;
 
@@ -602,20 +601,22 @@ mod tests {
     }
 
     fn presence_one(room: Uuid, member: Uuid, name: &str, kind: &str) -> serde_json::Value {
-        json!({
-            "roomId": room,
-            "roomName": "general",
-            "roster": [
-                {
-                    "memberId": member,
-                    "displayName": name,
-                    "kind": { "kind": kind },
-                    "integrations": { "continuum.persona_id": "asha-1" },
-                    "provenance": { "runtime": "claude" },
-                    "active": true,
-                }
-            ],
-        })
+        // Serialize the REAL typed slot via the shared helper — never a
+        // hand-authored JSON literal, so the test wire can't drift from
+        // `RosterSlotView`'s field names.
+        let kind: SenderKind = serde_json::from_value(json!({ "kind": kind })).unwrap();
+        let mut integrations = std::collections::BTreeMap::new();
+        integrations.insert("continuum.persona_id".to_string(), "asha-1".to_string());
+        test_presence_payload(
+            room,
+            vec![RosterSlotView {
+                integrations,
+                provenance: Provenance {
+                    runtime: "claude".to_string(),
+                },
+                ..test_roster_slot(member, name, kind)
+            }],
+        )
     }
 
     fn current_kanban(substrate: &Substrate) -> KanbanViewState {

--- a/core/continuum-core/src/ipc/positron_presence.rs
+++ b/core/continuum-core/src/ipc/positron_presence.rs
@@ -18,7 +18,7 @@
 //! Per `[[positron-identity-security-first-class]]`: identity is a
 //! property that must hold at every seam, woven in as each seam is built,
 //! never bolted on after. So every projected slot carries a
-//! [`Provenance`] — the member's verifiable origin. Today that is airc's
+//! [`Provenance`](continuum_positron::Provenance) — the member's verifiable origin. Today that is airc's
 //! self-reported `runtime` class, carried **verbatim** (the one
 //! accountability axis airc surfaces now); trust tier + cryptographic
 //! verification join the same struct later with no wire break (growable
@@ -29,34 +29,31 @@
 //! ## The one wire contract, defined once
 //!
 //! Per the compression principle: the emitter builds and serializes the
-//! SAME [`AircPresenceUpdate`] / [`AircPresenceSlot`] structs the consumer
-//! deserializes (both live in `positron_source`, `pub(crate)` +
-//! `Serialize`/`Deserialize`). Both sides agree by construction, not by a
-//! hand-copied JSON literal — a round-trip test in `positron_source` pins
-//! the emitter's output against the consumer's `classify` path.
+//! SAME [`AircPresenceUpdate`] struct the consumer deserializes, and its
+//! roster rows ARE the neutral `RosterSlotView` (no hand-copied twin — the
+//! shared [`roster_slot_from_member`] projection produces the identical slot
+//! both the widget and the persona grounding read). Both sides agree by
+//! construction, not by a hand-copied JSON literal — a round-trip test in
+//! `positron_source` pins the emitter's output against the consumer's
+//! `classify` path.
 //!
 //! ## kind is derived coarsely; runtime is the truth
 //!
-//! `RoomMember` carries no author `kind` — the emitter derives one from
-//! `runtime` via [`SenderKind::from_runtime`], a *coarse styling hint*
+//! `RoomMember` carries no author `kind` — the shared projection derives one
+//! from `runtime` via [`SenderKind::from_runtime`](continuum_positron::SenderKind::from_runtime), a *coarse styling hint*
 //! (`"interactive"` → Human, else → Agent). The authoritative,
 //! unabridged origin rides `provenance.runtime`. This is deliberate: a
 //! richer `runtime → kind` table would be the string-matching smell
 //! (task #70); the coarse projection stays honest by keeping the full
 //! string in provenance for anyone who needs to discriminate.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use airc_lib::RoomMember;
 use uuid::Uuid;
 
-use continuum_positron::{Provenance, SenderKind};
-
-use crate::ipc::positron_source::{
-    provisional_sender_name, AircPresenceSlot, AircPresenceUpdate, PRESENCE_UPDATED,
-};
+use crate::ipc::positron_source::{roster_slot_from_member, AircPresenceUpdate, PRESENCE_UPDATED};
 use crate::persona::room_roster_source::AircRosterReader;
 use crate::runtime::MessageBus;
 use tokio::sync::broadcast::error::RecvError;
@@ -141,47 +138,21 @@ pub(crate) fn project_presence(
     room_id: Uuid,
     room_name: String,
 ) -> AircPresenceUpdate {
-    let roster = members.into_iter().map(project_member).collect();
+    // ONE projection for both rails — the WS widget roster and the persona's
+    // grounding roster are the same neutral `RosterSlotView`, built here by
+    // the shared [`roster_slot_from_member`] (the convergence #8/#13). No
+    // local twin: this emitter is now purely "read airc → project → publish".
+    //
+    // Unlike the persona-grounding source (which drops `self` because it
+    // grounds a persona in "who is NOT me"), the widget roster shows EVERY
+    // present member including self — a chat roster you are absent from would
+    // be wrong. Self-exclusion is the persona source's own post-projection
+    // policy, never baked into the shared projection.
+    let roster = members.iter().map(roster_slot_from_member).collect();
     AircPresenceUpdate {
         room_id,
         room_name,
         roster,
-    }
-}
-
-/// One `RoomMember` → one identity card. Derives the coarse `kind`
-/// *before* moving `runtime` into `provenance` (the verbatim
-/// accountability truth).
-fn project_member(member: RoomMember) -> AircPresenceSlot {
-    // Coarse styling hint from the free-form runtime class; the full
-    // string is preserved in `provenance` below (never string-match on
-    // runtime here — that is task #70's smell).
-    let kind = SenderKind::from_runtime(&member.runtime);
-    // airc resolved the name; a present-but-unnamed peer gets the SAME
-    // short-peer label the consumer uses provisionally — one label form,
-    // never a silently-invisible citizen.
-    let display_name = member
-        .display_name
-        .unwrap_or_else(|| provisional_sender_name(member.peer_id.as_uuid()));
-    AircPresenceSlot {
-        member_id: member.peer_id.as_uuid(),
-        display_name,
-        kind,
-        // airc's `RoomMember` carries no cross-system badge map yet (airc
-        // gap): integrations stays empty until airc surfaces the
-        // `Identity.integrations` card on presence. Empty is the honest
-        // "no badges known", not a fabricated one
-        // ([[fallbacks-are-illegal-fail-loud]]).
-        integrations: BTreeMap::new(),
-        // The accountability truth airc DOES surface today, carried
-        // verbatim. Trust tier + verification join here later (task #38)
-        // with no wire break.
-        provenance: Provenance {
-            runtime: member.runtime,
-        },
-        // airc excludes `Leaving` peers from the roster, so every member
-        // returned is present → active.
-        active: true,
     }
 }
 
@@ -394,6 +365,10 @@ mod tests {
     use airc_core::PeerId;
     use airc_lib::AircError;
     use async_trait::async_trait;
+    // The module proper no longer names `SenderKind` (the coarse kind is
+    // derived inside the shared `roster_slot_from_member` projection now);
+    // the tests still assert on the projected slot's `kind`.
+    use continuum_positron::SenderKind;
 
     /// A roster reader that returns a fixed member list — enough to drive
     /// [`emit_once`]'s read → project → publish path without a daemon.

--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -75,6 +75,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::error::RecvError;
 use uuid::Uuid;
 
+use airc_lib::{AgentAvailabilityState, RoomMember};
 use continuum_positron::{
     ChatMessageView, ChatViewState, Provenance, RosterSlotView, SenderKind, StateBuilder,
     Substrate,
@@ -155,38 +156,122 @@ struct AircChatPosted {
 /// struct — one wire shape defined once, both sides agree by
 /// construction rather than by a hand-copied JSON literal (compression
 /// principle). The emitter/consumer round-trip is pinned by a test.
+///
+/// The roster rows ARE [`RosterSlotView`] — the neutral positron slot — not
+/// a hand-copied twin. That copy (`AircPresenceSlot`) used to exist "so both
+/// sides agree by construction"; but `RosterSlotView` already derives
+/// `Serialize`/`Deserialize`, so the neutral view IS the wire shape and the
+/// twin was pure duplication (the exact compression violation this
+/// convergence removes — #8/#13). One slot type now flows from the airc
+/// projection ([`roster_slot_from_member`]) all the way to the widget.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AircPresenceUpdate {
     pub(crate) room_id: Uuid,
     pub(crate) room_name: String,
-    pub(crate) roster: Vec<AircPresenceSlot>,
+    pub(crate) roster: Vec<RosterSlotView>,
 }
 
-/// One roster entry inside an [`AircPresenceUpdate`] — a member joined
-/// with its airc identity card. `kind` is the neutral author kind
-/// (`Human` / `Agent` / `System`) the presence emitter derives from the
-/// member's `runtime`; `integrations` is the opaque cross-system badge
-/// map from `Identity.integrations`, transported straight through and
-/// interpreted only at continuum's app layer (renderer reads
-/// `continuum.persona*`); `provenance` is the accountability slot (the
-/// member's verifiable origin — `runtime` today, trust tier +
-/// verification later, no wire break).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct AircPresenceSlot {
-    pub(crate) member_id: Uuid,
-    pub(crate) display_name: String,
-    pub(crate) kind: SenderKind,
-    #[serde(default)]
-    pub(crate) integrations: BTreeMap<String, String>,
-    /// The accountability half of the identity card. `#[serde(default)]`
-    /// so a slot predating the field folds as `Provenance::unresolved()`
-    /// (honest empty), symmetric with `integrations` — never a fabricated
-    /// origin ([[fallbacks-are-illegal-fail-loud]]).
-    #[serde(default)]
-    pub(crate) provenance: Provenance,
-    pub(crate) active: bool,
+/// airc's `AgentAvailabilityState` → its stable neutral wire label — airc's
+/// OWN `snake_case` serde repr (`"ready"` / `"busy"` / `"away"`), single-
+/// sourced by mirroring that vocabulary here rather than `{:?}` (Debug's
+/// CamelCase is not a contract and would drift). The exhaustive match is the
+/// fail-loud seam: if airc ever adds an availability state the compiler
+/// forces a deliberate decision here instead of silently coercing it.
+///
+/// The label is carried **verbatim** into the neutral
+/// [`RosterSlotView::availability`]; positron never interprets it (same
+/// transported-not-interpreted discipline as `provenance.runtime`).
+fn availability_label(state: AgentAvailabilityState) -> &'static str {
+    match state {
+        AgentAvailabilityState::Ready => "ready",
+        AgentAvailabilityState::Busy => "busy",
+        AgentAvailabilityState::Away => "away",
+    }
+}
+
+/// THE `RoomMember` → neutral [`RosterSlotView`] projection — one place both
+/// rails build a roster slot from an airc member, so the WS widget and the
+/// persona's grounding can never drop different fields (the divergence
+/// #8/#13 removes: Rail A used to keep `availability`/`last_seen_ms` while
+/// Rail B silently dropped them). Pure and total — no self-exclusion, no
+/// budget, no ordering: those are per-consumer policies the caller applies
+/// to the projected slots, not part of the shared projection.
+///
+/// `pub(crate)` so `crate::ipc::positron_presence` (the WS emitter) and
+/// `crate::persona::room_roster_source` (the persona grounding source) call
+/// the identical function.
+pub(crate) fn roster_slot_from_member(member: &RoomMember) -> RosterSlotView {
+    // Coarse styling hint from the free-form runtime class; the full string
+    // is preserved verbatim in `provenance` (never string-match on runtime
+    // to pick behavior — that is task #70's smell).
+    let kind = SenderKind::from_runtime(&member.runtime);
+    // airc resolved the name; a present-but-unnamed peer gets the SAME
+    // provisional short-peer label the consumer uses when a card has not
+    // folded in — one provisional-label decision, never a silently-invisible
+    // citizen and never a second fallback form.
+    let display_name = member
+        .display_name
+        .clone()
+        .unwrap_or_else(|| provisional_sender_name(member.peer_id.as_uuid()));
+    RosterSlotView {
+        member_id: member.peer_id.as_uuid(),
+        display_name,
+        kind,
+        // airc's `RoomMember` carries no cross-system badge map (the richer
+        // `room_roster_cards` path would fill this); empty is the honest "no
+        // badges known", not a fabricated one.
+        integrations: BTreeMap::new(),
+        // The accountability truth airc surfaces today, carried verbatim.
+        // Trust tier + verification join here later (task #38), no wire break.
+        provenance: Provenance {
+            runtime: member.runtime.clone(),
+        },
+        // airc excludes `Leaving` peers from the roster, so every member it
+        // returns is present → active.
+        active: true,
+        // Neutral presence facts carried straight through — the fields Rail B
+        // used to drop. `availability` is airc's stable label (or `None` when
+        // unreported); `last_seen_ms` is the raw recency signal.
+        availability: member.availability.map(availability_label).map(str::to_owned),
+        last_seen_ms: member.last_seen_ms,
+    }
+}
+
+/// Test-only: serialize a `presence:updated` bus payload from the REAL typed
+/// [`AircPresenceUpdate`] (roster = neutral [`RosterSlotView`]s). Tests build
+/// the payload from the struct, NEVER a hand-authored JSON literal — so a
+/// test's wire can never drift from the type's field names (the "agree by
+/// construction" contract, enforced instead of hoped for). Shared by the chat
+/// / wall / kanban projector test mods: one wire-shape source, even in tests.
+#[cfg(test)]
+pub(crate) fn test_presence_payload(
+    room: Uuid,
+    roster: Vec<RosterSlotView>,
+) -> serde_json::Value {
+    serde_json::to_value(AircPresenceUpdate {
+        room_id: room,
+        room_name: "general".to_string(),
+        roster,
+    })
+    .expect("AircPresenceUpdate serializes")
+}
+
+/// Test-only: one neutral roster slot — present + active, empty badges,
+/// unresolved provenance, no availability/recency. Tests override any field
+/// via struct-update (`RosterSlotView { active: false, ..test_roster_slot(..) }`).
+#[cfg(test)]
+pub(crate) fn test_roster_slot(member: Uuid, name: &str, kind: SenderKind) -> RosterSlotView {
+    RosterSlotView {
+        member_id: member,
+        display_name: name.to_string(),
+        kind,
+        integrations: BTreeMap::new(),
+        provenance: Provenance::unresolved(),
+        active: true,
+        availability: None,
+        last_seen_ms: 0,
+    }
 }
 
 /// A sender's identity resolved from the roster — name + neutral kind +
@@ -236,25 +321,10 @@ pub(crate) fn resolve_identity(roster: &[RosterSlotView], id: Uuid) -> ResolvedS
     }
 }
 
-/// Project a presence snapshot's roster into the renderer-shaped
-/// [`RosterSlotView`] rows. Shared by the chat projection (which stores
-/// them on the `ChatViewState`) and the wall projection (which holds them
-/// only as its author-resolution lookup table) — one wire-shape
-/// conversion, one place ([[compression]]).
-pub(crate) fn roster_slots_from(update: &AircPresenceUpdate) -> Vec<RosterSlotView> {
-    update
-        .roster
-        .iter()
-        .map(|s| RosterSlotView {
-            member_id: s.member_id,
-            display_name: s.display_name.clone(),
-            kind: s.kind,
-            integrations: s.integrations.clone(),
-            provenance: s.provenance.clone(),
-            active: s.active,
-        })
-        .collect()
-}
+// `roster_slots_from` is gone: `AircPresenceUpdate.roster` IS already
+// `Vec<RosterSlotView>`, so the old slot→slot copy was an identity map on a
+// duplicated type. Consumers that need the roster (chat / wall / kanban) take
+// `update.roster` directly — one slot type, no conversion.
 
 /// Accumulates airc room events into the renderer-shaped
 /// [`ChatViewState`] and writes each transition to the [`Substrate`].
@@ -339,8 +409,10 @@ impl ChatProjection {
     /// arrived) now that the card is known.
     fn apply_presence(&mut self, update: AircPresenceUpdate) {
         self.switch_room(update.room_id);
-        self.roster = roster_slots_from(&update);
         self.room_name = update.room_name;
+        // The update's roster IS the neutral slot type — move it in directly,
+        // no per-field copy through a twin struct.
+        self.roster = update.roster;
         self.reresolve_messages();
         self.store();
     }
@@ -467,8 +539,9 @@ mod tests {
         })
     }
 
-    /// A `presence:updated` payload for `room` with a single member
-    /// carrying `kind` + `integrations`.
+    /// A `presence:updated` payload for `room` with a single member carrying
+    /// `kind` + `integrations` — serialized from the real typed slot via the
+    /// shared [`test_presence_payload`], never a hand-authored JSON literal.
     fn presence_one(
         room: Uuid,
         member: Uuid,
@@ -476,19 +549,15 @@ mod tests {
         kind: &str,
         integrations: serde_json::Value,
     ) -> serde_json::Value {
-        json!({
-            "roomId": room,
-            "roomName": "general",
-            "roster": [
-                {
-                    "memberId": member,
-                    "displayName": name,
-                    "kind": { "kind": kind },
-                    "integrations": integrations,
-                    "active": true,
-                }
-            ],
-        })
+        let kind: SenderKind = serde_json::from_value(json!({ "kind": kind })).unwrap();
+        let integrations: BTreeMap<String, String> = serde_json::from_value(integrations).unwrap();
+        test_presence_payload(
+            room,
+            vec![RosterSlotView {
+                integrations,
+                ..test_roster_slot(member, name, kind)
+            }],
+        )
     }
 
     fn current_chat(substrate: &Substrate) -> ChatViewState {
@@ -604,26 +673,21 @@ mod tests {
         let substrate = Substrate::new();
         let mut p = ChatProjection::new(substrate.clone());
         let room = Uuid::from_u128(0xa);
-        let payload = json!({
-            "roomId": room,
-            "roomName": "general",
-            "roster": [
-                {
-                    "memberId": Uuid::from_u128(0xd),
-                    "displayName": "Helper",
-                    "kind": { "kind": "agent" },
-                    "integrations": { "continuum.persona_id": "helper-1" },
-                    "active": true,
+        let mut helper_badges = BTreeMap::new();
+        helper_badges.insert("continuum.persona_id".to_string(), "helper-1".to_string());
+        let payload = test_presence_payload(
+            room,
+            vec![
+                RosterSlotView {
+                    integrations: helper_badges,
+                    ..test_roster_slot(Uuid::from_u128(0xd), "Helper", SenderKind::Agent)
                 },
-                {
-                    "memberId": Uuid::from_u128(0xe),
-                    "displayName": "Joel",
-                    "kind": { "kind": "human" },
-                    "integrations": {},
-                    "active": false,
+                RosterSlotView {
+                    active: false,
+                    ..test_roster_slot(Uuid::from_u128(0xe), "Joel", SenderKind::Human)
                 },
             ],
-        });
+        );
         match classify(PRESENCE_UPDATED, &payload).unwrap() {
             ProjectionInput::Presence(u) => p.apply_presence(u),
             _ => panic!("presence:updated must classify as Presence"),
@@ -667,20 +731,15 @@ mod tests {
             "unresolved provenance is empty, not fabricated"
         );
         // Presence folds the card carrying a runtime origin.
-        let presence = json!({
-            "roomId": room,
-            "roomName": "general",
-            "roster": [
-                {
-                    "memberId": sender,
-                    "displayName": "Helper",
-                    "kind": { "kind": "agent" },
-                    "integrations": {},
-                    "provenance": { "runtime": "claude" },
-                    "active": true,
-                }
-            ],
-        });
+        let presence = test_presence_payload(
+            room,
+            vec![RosterSlotView {
+                provenance: Provenance {
+                    runtime: "claude".to_string(),
+                },
+                ..test_roster_slot(sender, "Helper", SenderKind::Agent)
+            }],
+        );
         if let ProjectionInput::Presence(u) = classify(PRESENCE_UPDATED, &presence).unwrap() {
             p.apply_presence(u);
         }

--- a/core/continuum-core/src/ipc/positron_wall_source.rs
+++ b/core/continuum-core/src/ipc/positron_wall_source.rs
@@ -76,9 +76,7 @@ use continuum_positron::{
 };
 use serde::Deserialize;
 
-use crate::ipc::positron_source::{
-    resolve_identity, roster_slots_from, AircPresenceUpdate, PRESENCE_UPDATED,
-};
+use crate::ipc::positron_source::{resolve_identity, AircPresenceUpdate, PRESENCE_UPDATED};
 use crate::persona::wall_source::WallReader;
 use crate::runtime::{BusEvent, MessageBus};
 
@@ -226,7 +224,7 @@ fn classify(name: &str, payload: &serde_json::Value) -> Option<WallInput> {
             .map(|c| WallInput::Changed(c.room_id)),
         PRESENCE_UPDATED => serde_json::from_value::<AircPresenceUpdate>(body.clone())
             .ok()
-            .map(|u| WallInput::Presence(u.room_id, roster_slots_from(&u))),
+            .map(|u| WallInput::Presence(u.room_id, u.roster)),
         _ => None,
     }
 }
@@ -385,7 +383,8 @@ mod tests {
     use super::*;
     use airc_core::{PeerId, RoomId};
     use async_trait::async_trait;
-    use continuum_positron::SenderKind;
+    use crate::ipc::positron_source::{test_presence_payload, test_roster_slot};
+    use continuum_positron::{Provenance, SenderKind};
     use serde_json::json;
     use std::sync::Mutex;
 
@@ -434,20 +433,22 @@ mod tests {
     }
 
     fn presence_one(room: Uuid, member: Uuid, name: &str, kind: &str) -> serde_json::Value {
-        json!({
-            "roomId": room,
-            "roomName": "general",
-            "roster": [
-                {
-                    "memberId": member,
-                    "displayName": name,
-                    "kind": { "kind": kind },
-                    "integrations": { "continuum.persona_id": "asha-1" },
-                    "provenance": { "runtime": "claude" },
-                    "active": true,
-                }
-            ],
-        })
+        // Serialize the REAL typed slot via the shared helper — never a
+        // hand-authored JSON literal, so the test wire can't drift from
+        // `RosterSlotView`'s field names.
+        let kind: SenderKind = serde_json::from_value(json!({ "kind": kind })).unwrap();
+        let mut integrations = std::collections::BTreeMap::new();
+        integrations.insert("continuum.persona_id".to_string(), "asha-1".to_string());
+        test_presence_payload(
+            room,
+            vec![RosterSlotView {
+                integrations,
+                provenance: Provenance {
+                    runtime: "claude".to_string(),
+                },
+                ..test_roster_slot(member, name, kind)
+            }],
+        )
     }
 
     fn current_wall(substrate: &Substrate) -> WallViewState {

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -54,7 +54,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use airc_core::{EventId, RoomId};
-use airc_lib::{Airc, AircError};
+use airc_lib::{Airc, AircError, HeartbeatTask, DEFAULT_HEARTBEAT_INTERVAL};
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -154,6 +154,16 @@ pub struct PersonaAircRuntime {
     /// `[[no-fallbacks-ever]]`, never declaring a silently-
     /// unaddressable persona ready.
     command_pump: Option<crate::persona::command_inbound_pump::PersonaCommandInboundPump>,
+    /// The airc `Alive` heartbeat pump (`start_agent_heartbeat`). A persona is
+    /// only PRESENT in another citizen's `room_roster` while it emits `Alive`
+    /// heartbeats — airc's `active_agents` reduces heartbeat events, NOT `say()`
+    /// messages. Holding this handle keeps the pump running for the persona's
+    /// lifetime; dropping it on teardown aborts the pump, so the persona ages
+    /// out of the roster within the presence window — the honest "no longer
+    /// here" signal. `None` only on `from_attached` paths (tests/demo) that opt
+    /// out of presence. Without it, co-resident personas never see each other in
+    /// `[Present in this room]` — the roster-grounding-goes-dark bug.
+    heartbeat: Option<HeartbeatTask>,
     /// Where this citizen's identity came from — resumed from disk
     /// vs freshly minted. Carried for the lifetime of the runtime so
     /// telemetry surfaces (list/get IPC, future status panels) can
@@ -404,6 +414,43 @@ impl PersonaAircRuntime {
             ),
         }
 
+        // Presence contract: a persona is PRESENT in another citizen's
+        // `room_roster` only while it emits `Alive` heartbeats — airc's
+        // `active_agents` reduces heartbeat events, not `say()` messages.
+        // Publishing the identity card alone (above) resolves the persona's
+        // NAME but leaves it absent from `active_agents`, so co-resident
+        // personas never see each other in the `[Present in this room]`
+        // grounding block. Start the `Alive` pump (runtime "persona") so the
+        // persona is a visible present citizen. WARN-and-continue, symmetric
+        // with publish_identity: a persona that can't heartbeat is
+        // live-but-roster-invisible — degraded, not dead — never a silent
+        // fallback ([[fallbacks-are-illegal-fail-loud]]: the cause is named).
+        let heartbeat = match airc_arc
+            .start_agent_heartbeat("persona", None, DEFAULT_HEARTBEAT_INTERVAL)
+            .await
+        {
+            Ok(task) => {
+                info!(
+                    persona_id = %persona_id,
+                    agent_name = %agent_name,
+                    interval_s = DEFAULT_HEARTBEAT_INTERVAL.as_secs(),
+                    "PersonaAircRuntime bootstrap: Alive heartbeat pump started — persona \
+                     is a present citizen in room rosters"
+                );
+                Some(task)
+            }
+            Err(source) => {
+                warn!(
+                    persona_id = %persona_id,
+                    agent_name = %agent_name,
+                    error = %source,
+                    "PersonaAircRuntime bootstrap: start_agent_heartbeat failed — persona is \
+                     live but will NOT appear present in other citizens' room rosters"
+                );
+                None
+            }
+        };
+
         Ok(Self {
             persona_id,
             agent_name,
@@ -412,6 +459,7 @@ impl PersonaAircRuntime {
             default_room,
             inbound_handle: None,
             command_pump: Some(command_pump),
+            heartbeat,
             source,
         })
     }
@@ -466,6 +514,11 @@ impl PersonaAircRuntime {
             // automatically; this seam is for tests + demo binaries
             // that want fine-grained control.
             command_pump: None,
+            // Presence is opt-out here for the same reason as the command pump:
+            // `from_attached` is sync and `start_agent_heartbeat` is async. The
+            // live `bootstrap` path always starts the pump; test/demo callers
+            // that want roster presence start it themselves after construction.
+            heartbeat: None,
             source,
         }
     }

--- a/core/continuum-core/src/persona/prompt_assembly.rs
+++ b/core/continuum-core/src/persona/prompt_assembly.rs
@@ -913,6 +913,112 @@ mod tests {
         assert!(result.system_message.contains("win-claude [claude]"));
     }
 
+    // what this catches: THE personaRag convergence seam, end to end through real
+    // code (not hand-authored roster strings). A present airc `RoomMember` flows:
+    //   RoomRosterSource.deliver  (the ONE shared `roster_slot_from_member` projection
+    //                              both the WS widget and this grounding rail use)
+    //     → project_room_roster    (the heartbeat loop's own delivery fold, extracted)
+    //       → prompt_assembly       (the [Present in this room] block)
+    // and lands with the converged line INCLUDING availability — the field the widget
+    // rail used to silently drop before the convergence (#8/#13). Connects the three
+    // separately-unit-tested halves via the exact path the live turn runs; the live
+    // core proves the plumbing, this proves it deterministically without airc presence.
+    #[tokio::test]
+    async fn present_member_reaches_present_in_room_block_end_to_end() {
+        use crate::persona::rag_budget::{RagContext, RagSource, ResolutionPreference};
+        use crate::persona::room_roster_source::{AircRosterReader, RoomRosterSource};
+        use crate::persona::service_loop::project_room_roster;
+        use airc_core::PeerId;
+        use airc_lib::{AgentAvailabilityState, AircError, RoomMember};
+        use async_trait::async_trait;
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        // One present peer, self-reported Busy — the airc upstream both rails read.
+        struct OnePresentPeer {
+            me: PeerId,
+            other: PeerId,
+        }
+        #[async_trait]
+        impl AircRosterReader for OnePresentPeer {
+            fn self_peer_id(&self) -> PeerId {
+                self.me
+            }
+            async fn room_roster(
+                &self,
+                _within: Duration,
+                _window: usize,
+            ) -> Result<Vec<RoomMember>, AircError> {
+                Ok(vec![RoomMember {
+                    peer_id: self.other,
+                    display_name: Some("win-claude".to_string()),
+                    runtime: "claude".to_string(),
+                    availability: Some(AgentAvailabilityState::Busy),
+                    last_seen_ms: 1_700_000_000_000,
+                }])
+            }
+        }
+
+        let persona = uuid::Uuid::new_v4();
+        let source = RoomRosterSource::new(
+            persona,
+            Arc::new(OnePresentPeer {
+                me: PeerId::new(),
+                other: PeerId::new(),
+            }),
+        );
+
+        // 1. Real delivery from the shared roster projection.
+        let ctx = RagContext::for_persona(persona, 1_000_000);
+        let delivery = source
+            .deliver(&ctx, 1_000, ResolutionPreference::Raw)
+            .await;
+
+        // 2. Real loop fold: delivery → grounding consumers (the converged line +
+        //    the bare name), via the exact fn the heartbeat loop calls.
+        let proj = project_room_roster(std::slice::from_ref(&delivery));
+        assert_eq!(
+            proj.room_roster,
+            vec!["win-claude [claude] — busy".to_string()],
+            "converged line (availability = airc's neutral 'busy', not Debug 'Busy')"
+        );
+        assert_eq!(proj.other_persona_names, vec!["win-claude".to_string()]);
+
+        // 3. Real assembly: grounding lines → the [Present in this room] block.
+        let input = PromptAssemblyInput {
+            persona_name: "Asha".to_string(),
+            system_prompt: "You are Asha.".to_string(),
+            matched_angle: String::new(),
+            history: vec![],
+            current_message: HistoryMessage {
+                role: "user".to_string(),
+                name: None,
+                content: "who is here?".to_string(),
+                timestamp_ms: None,
+            },
+            is_voice: false,
+            social_signals: None,
+            multi_party_strategy: MultiPartyChatStrategy::default(),
+            other_persona_names: proj.other_persona_names,
+            recalled_engrams: vec![],
+            room_roster: proj.room_roster,
+            room_doctrine: None,
+        };
+        let assembled = assemble(&input);
+        assert!(
+            assembled.system_message.contains("[Present in this room]"),
+            "roster block missing from live-path assembly:\n{}",
+            assembled.system_message
+        );
+        assert!(
+            assembled
+                .system_message
+                .contains("win-claude [claude] — busy"),
+            "converged roster line (with availability) did not reach the prompt:\n{}",
+            assembled.system_message
+        );
+    }
+
     // what this catches: empty roster → NO [Present in this room] block,
     // backwards-compatible with every caller that doesn't supply one
     // (and the cold-start / no-presence case). A formatter that always

--- a/core/continuum-core/src/persona/room_roster_source.rs
+++ b/core/continuum-core/src/persona/room_roster_source.rs
@@ -54,7 +54,9 @@ use std::time::Duration;
 use airc_core::PeerId;
 use airc_lib::{AircError, RoomMember};
 use async_trait::async_trait;
+use continuum_positron::RosterSlotView;
 
+use crate::ipc::positron_source::roster_slot_from_member;
 use crate::persona::rag_budget::{
     ContinuationCursor, RagContext, RagDelivery, RagItem, RagSource, ResolutionPreference,
 };
@@ -139,46 +141,47 @@ impl RoomRosterSource {
         Self { persona_id, reader }
     }
 
-    /// Short, stable fallback label when a peer has no alias — the first
-    /// 8 hex chars of its uuid. Never empty, never panics.
-    fn short_peer_label(peer: PeerId) -> String {
-        let s = peer.as_uuid().to_string();
-        s.chars().take(8).collect()
-    }
-
-    /// Format one present citizen as a roster line. The line is
-    /// human-readable on its own; the structured parts also ride in
-    /// metadata so prompt-assembly and sentinel verifiers can render /
-    /// trace without re-parsing the string.
+    /// Format one present citizen as a roster grounding line from the neutral
+    /// [`RosterSlotView`] the shared projection produced. The line is
+    /// human-readable on its own; the structured parts also ride in metadata
+    /// so prompt-assembly and sentinel verifiers can render / trace without
+    /// re-parsing the string.
     ///
-    /// Shape: `<name> [<runtime>]` plus ` — <availability>` when the
-    /// peer reported one. Examples: `Aria [persona]`,
-    /// `win-claude [claude] — Busy`.
-    fn format_line(name: &str, runtime: &str, availability: Option<String>) -> String {
+    /// Shape: `<name> [<runtime>]` plus ` — <availability>` when the peer
+    /// reported one. Examples: `Aria [persona]`, `win-claude [claude] — busy`
+    /// (availability is airc's neutral label, carried through the slot).
+    fn format_line(name: &str, runtime: &str, availability: Option<&str>) -> String {
         match availability {
             Some(avail) => format!("{name} [{runtime}] — {avail}"),
             None => format!("{name} [{runtime}]"),
         }
     }
 
-    fn make_item(
-        peer: PeerId,
-        name: String,
-        runtime: String,
-        availability: Option<String>,
-        last_seen_ms: u64,
-    ) -> RagItem {
-        let content = Self::format_line(&name, &runtime, availability.clone());
+    /// One present citizen → a grounding [`RagItem`], built from the SAME
+    /// neutral [`RosterSlotView`] the WS widget roster is built from (the
+    /// convergence #8/#13). Display name, runtime origin, availability and
+    /// recency are read off the slot — never re-derived here — so the persona
+    /// grounding and the widget roster can never disagree about who is present
+    /// or drop different fields.
+    fn make_item(slot: &RosterSlotView) -> RagItem {
+        let content = Self::format_line(
+            &slot.display_name,
+            &slot.provenance.runtime,
+            slot.availability.as_deref(),
+        );
         let tokens = estimate_tokens(&content);
         RagItem {
             content,
             tokens,
+            // The service-loop projection reads metadata["display_name"] to
+            // populate other_persona_names (single-party history-drop): keep
+            // the bare name here, matching the transcript sender name.
             metadata: serde_json::json!({
-                "peer_id": peer.as_uuid().to_string(),
-                "display_name": name,
-                "runtime": runtime,
-                "availability": availability,
-                "last_seen_ms": last_seen_ms,
+                "peer_id": slot.member_id.to_string(),
+                "display_name": slot.display_name,
+                "runtime": slot.provenance.runtime,
+                "availability": slot.availability,
+                "last_seen_ms": slot.last_seen_ms,
             }),
         }
     }
@@ -234,29 +237,23 @@ impl RagSource for RoomRosterSource {
         let mut items: Vec<RagItem> = Vec::new();
         let mut tokens_used: u32 = 0;
         for member in members {
-            // Exclude self — the roster grounds the persona in who is
-            // NOT itself. (room_roster includes self by design.)
+            // Exclude self — the roster grounds the persona in who is NOT
+            // itself. (room_roster includes self by design.) Self-exclusion is
+            // THIS source's own policy, applied before the shared projection —
+            // never baked into it (the widget roster keeps self).
             if member.peer_id == self_peer {
                 continue;
             }
-            // airc resolved the name; fall back to a short peer label for
-            // a present-but-unnamed peer so a citizen is never invisible.
-            let name = member
-                .display_name
-                .unwrap_or_else(|| Self::short_peer_label(member.peer_id));
-            let availability = member.availability.map(|a| format!("{a:?}"));
-            let item = Self::make_item(
-                member.peer_id,
-                name,
-                member.runtime,
-                availability,
-                member.last_seen_ms,
-            );
+            // The ONE `RoomMember` → neutral slot projection, the same the WS
+            // widget roster uses. Name fallback, runtime origin, availability
+            // label and recency all resolve there, once.
+            let slot = roster_slot_from_member(&member);
+            let item = Self::make_item(&slot);
             if tokens_used.saturating_add(item.tokens) > budget {
-                // Budget exhausted. Roster is unordered presence; we
-                // stop rather than paginate (atomic unit = one present
-                // citizen, no continuation). A truncated roster is
-                // still truthful for the citizens it names.
+                // Budget exhausted. Roster is unordered presence; we stop
+                // rather than paginate (atomic unit = one present citizen, no
+                // continuation). A truncated roster is still truthful for the
+                // citizens it names.
                 break;
             }
             tokens_used += item.tokens;
@@ -384,6 +381,39 @@ mod tests {
         assert!(delivery.continuation.is_none());
     }
 
+    // what this catches: THE convergence guarantee — the persona grounding now
+    // carries availability + recency (the liveness the WS widget rail used to
+    // DROP through `AircPresenceSlot`), because both rails build from the one
+    // shared `roster_slot_from_member`. A regression that stopped threading
+    // these through the shared projection would silently blind the persona to
+    // who is busy/away and how recently they were seen. Availability is airc's
+    // neutral snake_case label (`busy`), not Debug's `Busy`.
+    #[tokio::test]
+    async fn availability_and_recency_carry_through_shared_projection() {
+        use airc_lib::AgentAvailabilityState;
+        let me = PeerId::new();
+        let other = PeerId::new();
+        let busy = RoomMember {
+            peer_id: other,
+            display_name: Some("win-claude".to_string()),
+            runtime: "claude".to_string(),
+            availability: Some(AgentAvailabilityState::Busy),
+            last_seen_ms: 1_700_000_000_000,
+        };
+        let reader = Arc::new(StubReader::new(me, vec![busy]));
+        let source = RoomRosterSource::new(persona(), reader);
+        let delivery = source
+            .deliver(&ctx(), 1_000, ResolutionPreference::Raw)
+            .await;
+        assert_eq!(delivery.items.len(), 1);
+        assert_eq!(delivery.items[0].content, "win-claude [claude] — busy");
+        assert_eq!(delivery.items[0].metadata["availability"], "busy");
+        assert_eq!(
+            delivery.items[0].metadata["last_seen_ms"],
+            1_700_000_000_000_u64
+        );
+    }
+
     // what this catches: the persona must NOT appear in its own roster —
     // the block is "who is NOT me". A self-entry would re-introduce the
     // self/other confusion the source exists to remove.
@@ -406,11 +436,13 @@ mod tests {
         );
     }
 
-    // what this catches: a peer with no alias is still surfaced (short
-    // peer label), never silently dropped — an unnamed citizen is worse
-    // than a uuid-labelled one for grounding.
+    // what this catches: a peer with no alias is still surfaced, never
+    // silently dropped — an unnamed citizen is worse than a labelled one for
+    // grounding. After the convergence it uses the SAME provisional label the
+    // WS widget projection uses (`peer-XXXXXXXX`, via the shared
+    // roster_slot_from_member) — one fallback-label decision, not a second form.
     #[tokio::test]
-    async fn peer_without_alias_falls_back_to_short_label() {
+    async fn peer_without_alias_uses_shared_provisional_label() {
         let me = PeerId::new();
         let other = PeerId::new();
         let reader = Arc::new(StubReader::new(me, vec![member(other, "codex", None)]));
@@ -419,13 +451,13 @@ mod tests {
             .deliver(&ctx(), 1_000, ResolutionPreference::Raw)
             .await;
         assert_eq!(delivery.items.len(), 1);
-        let expected = other
-            .as_uuid()
-            .to_string()
-            .chars()
-            .take(8)
-            .collect::<String>();
-        assert!(delivery.items[0].content.contains(&expected));
+        let simple = other.as_uuid().simple().to_string();
+        let expected_label = format!("peer-{}", &simple[..8]);
+        assert_eq!(
+            delivery.items[0].content,
+            format!("{expected_label} [codex]"),
+            "unnamed peer uses the shared provisional label + its runtime origin"
+        );
     }
 
     // what this catches: empty room → empty delivery, no panic.

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -566,32 +566,15 @@ async fn serve_persona_loop_inner(
         // own chat is excluded so this reply can't re-trigger a self-tick, while her
         // own active work is folded in so the tick advances it — see burst_fingerprint).
         last_burst_fp = burst_fingerprint(&composed.deliveries, &ctx.identity.peer_id.to_string());
-        // Project the room-roster delivery into TWO consumers from the
-        // ONE source of truth (the roster delivery), routed by source_id:
-        //   • `room_roster` — the formatted `name [runtime] — avail`
-        //     lines → system-prompt GROUNDING ([Present in this room]).
-        //     Deliberately NOT recent_history: the roster names who is
-        //     present (identity grounding), it is not conversation —
-        //     injecting it as history is the confusion the source removes.
-        //   • `other_persona_names` — bare display names → the
-        //     `ProperChatMlSingleParty` history-drop (single-party models
-        //     can't process other-AI turns). This field was reserved for
-        //     exactly this roster data and previously sat empty; the same
-        //     delivery now feeds it, so there is one roster truth, not two.
-        // See docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 1.
-        let mut room_roster: Vec<String> = Vec::new();
-        let mut other_persona_names: Vec<String> = Vec::new();
-        for item in composed
-            .deliveries
-            .iter()
-            .filter(|d| d.source_id == "room-roster")
-            .flat_map(|d| d.items.iter())
-        {
-            room_roster.push(item.content.clone());
-            if let Some(name) = item.metadata.get("display_name").and_then(|v| v.as_str()) {
-                other_persona_names.push(name.to_string());
-            }
-        }
+        // Project the room-roster delivery into its TWO grounding consumers —
+        // the formatted `[Present in this room]` lines + the bare
+        // `other_persona_names` history-drop — via the extracted
+        // `project_room_roster` (one roster truth; the exact projection the
+        // convergence seam-proof integration test drives).
+        let RoomRosterProjection {
+            room_roster,
+            other_persona_names,
+        } = project_room_roster(&composed.deliveries);
 
         // Room-doctrine grounding (the [Room operating doctrine] block) now reaches
         // the prompt via the WorkspaceCycle's RagSourceFaculty bridge (task #12), as
@@ -1010,6 +993,43 @@ pub(crate) struct TriggerTurn<'a> {
     /// When it arrived (airc `occurred_at_ms` / wake `now_ms`) — drives the
     /// `[t=…]` prefix so an anchored trigger renders identically to a threaded one.
     pub occurred_at_ms: u64,
+}
+
+/// The two grounding consumers the room-roster delivery feeds — kept as one
+/// struct so the fold below returns both from the ONE roster truth.
+pub(crate) struct RoomRosterProjection {
+    /// `<name> [<runtime>] — <availability>` lines → the system-prompt
+    /// `[Present in this room]` grounding block (identity, NOT conversation).
+    pub(crate) room_roster: Vec<String>,
+    /// Bare display names → the `ProperChatMlSingleParty` history-drop
+    /// (single-party models can't process other-AI turns).
+    pub(crate) other_persona_names: Vec<String>,
+}
+
+/// Fold the `room-roster` delivery into its two grounding consumers, routed by
+/// `source_id`. Pure and extracted from the heartbeat loop (sibling of
+/// [`build_workspace_turns`]) so the live path and the convergence seam-proof
+/// test exercise the IDENTICAL projection — one roster truth, no inline
+/// duplication. See docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 slice 1.
+pub(crate) fn project_room_roster(
+    deliveries: &[crate::persona::rag_budget::RagDelivery],
+) -> RoomRosterProjection {
+    let mut room_roster: Vec<String> = Vec::new();
+    let mut other_persona_names: Vec<String> = Vec::new();
+    for item in deliveries
+        .iter()
+        .filter(|d| d.source_id == "room-roster")
+        .flat_map(|d| d.items.iter())
+    {
+        room_roster.push(item.content.clone());
+        if let Some(name) = item.metadata.get("display_name").and_then(|v| v.as_str()) {
+            other_persona_names.push(name.to_string());
+        }
+    }
+    RoomRosterProjection {
+        room_roster,
+        other_persona_names,
+    }
 }
 
 pub(crate) fn build_workspace_turns(

--- a/core/continuum-positron/src/chat.rs
+++ b/core/continuum-positron/src/chat.rs
@@ -257,6 +257,27 @@ pub struct RosterSlotView {
     /// presence indicator off this bit — single source of truth in the
     /// substrate.
     pub active: bool,
+    /// Self-reported availability, transported **verbatim** from the
+    /// producing substrate (`"ready"` / `"busy"` / `"away"` for the airc
+    /// adopter) — the same neutral, not-interpreted discipline as
+    /// [`Provenance::runtime`] and `integrations`. positron does NOT
+    /// enumerate availability states (that would bake one framework's
+    /// vocabulary into the generic package); it carries whatever the source
+    /// reports and the app layer decides what it means for the roster line /
+    /// UI. `None` = the member reported no availability — an honest unknown,
+    /// never a fabricated state ([[fallbacks-are-illegal-fail-loud]]).
+    #[serde(default)]
+    #[ts(optional)]
+    pub availability: Option<String>,
+    /// Unix-ms of the member's most recent presence heartbeat — the recency
+    /// signal a roster uses to sort or age out members. `#[serde(default)]`
+    /// so a slot serialized before this field folds as `0` (honest "recency
+    /// unknown"), never a dropped or fabricated timestamp. `u64` → `number`
+    /// (not `bigint`) to match the rest of the substrate's ms timestamps
+    /// (`ChatMessageView.timestamp`).
+    #[serde(default)]
+    #[ts(type = "number")]
+    pub last_seen_ms: u64,
 }
 
 /// Top-level state for the `"chat"` widget kind. Fills
@@ -429,10 +450,31 @@ mod tests {
                 runtime: "claude".into(),
             },
             active: true,
+            availability: Some("busy".into()),
+            last_seen_ms: 1_700_000_000_000,
         };
         let back: RosterSlotView =
             serde_json::from_str(&serde_json::to_string(&slot).unwrap()).unwrap();
         assert_eq!(back.provenance.runtime, "claude");
+        // what this catches: the neutral presence facts (availability +
+        // last_seen_ms) ride the wire verbatim. A regression dropping them —
+        // or interpreting availability into a positron-side enum — would
+        // silently degrade the persona's roster grounding, which is the whole
+        // point of carrying them on the neutral slot.
+        assert_eq!(back.availability.as_deref(), Some("busy"));
+        assert_eq!(back.last_seen_ms, 1_700_000_000_000);
+    }
+
+    #[test]
+    fn availability_absent_folds_to_none() {
+        // what this catches: a slot serialized before availability/last_seen
+        // existed must deserialize (serde default) — availability = None
+        // (honest unknown), last_seen_ms = 0 — never a deserialize failure
+        // that would blink the whole roster empty.
+        let legacy = r#"{"member_id":"00000000-0000-0000-0000-00000000000d","display_name":"Helper","kind":{"kind":"agent"},"integrations":{},"provenance":{"runtime":"claude"},"active":true}"#;
+        let slot: RosterSlotView = serde_json::from_str(legacy).unwrap();
+        assert_eq!(slot.availability, None);
+        assert_eq!(slot.last_seen_ms, 0);
     }
 
     #[test]
@@ -465,6 +507,8 @@ mod tests {
                     runtime: "claude".into(),
                 },
                 active: true,
+                availability: Some("ready".into()),
+                last_seen_ms: 1_700_000_000_000,
             }],
         };
         let json = serde_json::to_string(&state).unwrap();

--- a/core/continuum-positron/src/state.rs
+++ b/core/continuum-positron/src/state.rs
@@ -173,6 +173,8 @@ mod tests {
                     runtime: "claude".into(),
                 },
                 active: true,
+                availability: Some("ready".into()),
+                last_seen_ms: 1_700_000_000_000,
             }],
         }
     }

--- a/core/continuum-positron/tests/session_roundtrip.rs
+++ b/core/continuum-positron/tests/session_roundtrip.rs
@@ -92,6 +92,8 @@ fn build_chat_state(content: &str) -> ChatViewState {
                 runtime: "claude".into(),
             },
             active: true,
+            availability: Some("ready".into()),
+            last_seen_ms: 1_700_000_000_000,
         }],
     }
 }

--- a/packages/chat-view/chatViewModel.spec.ts
+++ b/packages/chat-view/chatViewModel.spec.ts
@@ -22,6 +22,7 @@ const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
   integrations: {},
   provenance: { runtime: '' },
   active: true,
+  last_seen_ms: 0,
   ...over,
 });
 

--- a/packages/chat-view/crossConsumer.spec.ts
+++ b/packages/chat-view/crossConsumer.spec.ts
@@ -47,6 +47,7 @@ const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
   integrations: {},
   provenance: { runtime: '' },
   active: true,
+  last_seen_ms: 0,
   ...over,
 });
 

--- a/protocol/typescript/positron/RosterSlotView.ts
+++ b/protocol/typescript/positron/RosterSlotView.ts
@@ -43,4 +43,25 @@ provenance: Provenance,
  * presence indicator off this bit — single source of truth in the
  * substrate.
  */
-active: boolean, };
+active: boolean, 
+/**
+ * Self-reported availability, transported **verbatim** from the
+ * producing substrate (`"ready"` / `"busy"` / `"away"` for the airc
+ * adopter) — the same neutral, not-interpreted discipline as
+ * [`Provenance::runtime`] and `integrations`. positron does NOT
+ * enumerate availability states (that would bake one framework's
+ * vocabulary into the generic package); it carries whatever the source
+ * reports and the app layer decides what it means for the roster line /
+ * UI. `None` = the member reported no availability — an honest unknown,
+ * never a fabricated state ([[fallbacks-are-illegal-fail-loud]]).
+ */
+availability?: string, 
+/**
+ * Unix-ms of the member's most recent presence heartbeat — the recency
+ * signal a roster uses to sort or age out members. `#[serde(default)]`
+ * so a slot serialized before this field folds as `0` (honest "recency
+ * unknown"), never a dropped or fabricated timestamp. `u64` → `number`
+ * (not `bigint`) to match the rest of the substrate's ms timestamps
+ * (`ChatMessageView.timestamp`).
+ */
+last_seen_ms: number, };

--- a/sdk/typescript/generated/views/RosterSlotView.ts
+++ b/sdk/typescript/generated/views/RosterSlotView.ts
@@ -43,4 +43,25 @@ provenance: Provenance,
  * presence indicator off this bit — single source of truth in the
  * substrate.
  */
-active: boolean, };
+active: boolean, 
+/**
+ * Self-reported availability, transported **verbatim** from the
+ * producing substrate (`"ready"` / `"busy"` / `"away"` for the airc
+ * adopter) — the same neutral, not-interpreted discipline as
+ * [`Provenance::runtime`] and `integrations`. positron does NOT
+ * enumerate availability states (that would bake one framework's
+ * vocabulary into the generic package); it carries whatever the source
+ * reports and the app layer decides what it means for the roster line /
+ * UI. `None` = the member reported no availability — an honest unknown,
+ * never a fabricated state ([[fallbacks-are-illegal-fail-loud]]).
+ */
+availability?: string, 
+/**
+ * Unix-ms of the member's most recent presence heartbeat — the recency
+ * signal a roster uses to sort or age out members. `#[serde(default)]`
+ * so a slot serialized before this field folds as `0` (honest "recency
+ * unknown"), never a dropped or fabricated timestamp. `u64` → `number`
+ * (not `bigint`) to match the rest of the substrate's ms timestamps
+ * (`ChatMessageView.timestamp`).
+ */
+last_seen_ms: number, };


### PR DESCRIPTION
## What

Kills the parallel roster derivation between the **WS widget rail** (`ChatProjection`) and the **persona grounding rail** (`RoomRosterSource`) — the compression violation task **#8/#13** targets. Both projected the same airc `RoomMember` and **dropped different fields**: Rail A kept `availability` + `last_seen_ms`; Rail B silently dropped them.

Now there is **one neutral superset projection** — `roster_slot_from_member(&RoomMember) -> RosterSlotView` — and both rails call it. This is the personaRag leg of the "web + terminal + personaRag off one seam" north-star.

## How

- **positron package (neutral, publicly-reusable):** `RosterSlotView` gains `availability: Option<String>` (airc's stable `snake_case` label — `ready`/`busy`/`away` — transported **verbatim**, never a positron-side enum; same not-interpreted discipline as `provenance.runtime`/`integrations`) + `last_seen_ms: u64`. Additive + `#[serde(default)]` → wire-safe.
- **continuum-core:** deleted the hand-copied `AircPresenceSlot` twin (`RosterSlotView` already derives `Serialize`/`Deserialize`, so the neutral view *is* the wire shape) and the now-identity `roster_slots_from`. Collapsed the two provisional-name fallbacks into one.
- **Rail A** formats its grounding line from the shared slot — availability + recency now survive into the persona's `[Present in this room]` block.
- **Test drift-proofing:** the projector tests hand-authored camelCase presence JSON (the "hand-copied JSON literal" the module doc forbids, which the type change exposed) — replaced with `#[cfg(test)]` helpers that serialize the **real** `AircPresenceUpdate`.
- **Extracted `project_room_roster`** (the delivery→grounding fold) out of `serve_persona_loop` into a pure `pub(crate)` fn beside `build_workspace_turns` — behavior-preserving, and the seam a deterministic integration test can drive.

## Proof

| Leg | Status |
|---|---|
| web + terminal | ✅ merged `crossConsumer.spec` + shared projection |
| personaRag convergence | ✅ unit + wire (ts-rs regen + re-vendor) + a deterministic **end-to-end** test: present `RoomMember` → `RoomRosterSource.deliver` → `project_room_roster` → `prompt_assembly` lands `win-claude [claude] — busy` in the live `[Present in this room]` block |
| live core | ✅ rebooted onto this branch; persona reads the channel + takes turns; assembly intact |

**Transcript/`ChannelDigest` path intentionally untouched** — display (flat ring) and cognition (consolidated digest) are legitimately different projections; sharing the `ChannelElement` upstream is a separate follow-up.

**Honest caveat:** the live `[Present in this room]` block does not render on this host because airc presence returns no member (`0 route(s) healthy`; separate persona airc homes) — the known event/presence-wake gap (#16/#84), upstream of and independent from this change. The deterministic integration test covers that seam without depending on presence.

## Validation

- continuum-positron: 88 tests; continuum-core roster/positron-projector/prompt-assembly/service_loop: green (incl. the new e2e seam test); ts-rs bindings regenerated + re-vendored to `sdk/typescript`.
- chat-view / web / sdk / tui: typecheck + vitest all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)