### PR TITLE
feat(capture): cu screenshot any interface from a CLI call (operator scope + render wait)

### DIFF
--- a/core/continuum-core/src/commands/interface/capture/mod.rs
+++ b/core/continuum-core/src/commands/interface/capture/mod.rs
@@ -94,8 +94,22 @@ pub fn capture_root() -> std::io::Result<PathBuf> {
     Ok(home.join(".continuum").join("captures"))
 }
 
+/// Capture-dir scope for a caller: a persona's `peer_id`, or `"local"` for the
+/// owner-by-locality operator. The local Unix-socket `cu` path carries no persona
+/// identity ([[handle_client]] stamps `None` — "the operator on the box"), yet the
+/// operator is a first-class caller who can `cu interface/capture` any interface
+/// from a CLI call. A remote (TCP) caller always carries a `peer_id`, so `"local"`
+/// only ever names the trusted local socket. Not a fallback
+/// ([[fallbacks-are-illegal-fail-loud]]): the operator is a real caller, just not a
+/// persona — so we name their scope, never mint a ghost citizen or silently no-op.
+fn capture_scope(caller: Option<&crate::routing::auth_policy::CallerIdentity>) -> String {
+    caller
+        .map(|c| c.peer_id.to_string())
+        .unwrap_or_else(|| "local".to_string())
+}
+
 /// `interface/capture` — drive a target and screenshot it. AiSafe; scopes output
-/// to the caller's own persona id.
+/// to the caller (a persona's peer_id, or `"local"` for the box operator).
 #[derive(Default)]
 pub struct Capture;
 
@@ -113,15 +127,9 @@ impl ActionCommand for Capture {
     type Output = CaptureResult;
 
     async fn run(&self, ctx: &Ctx, params: CaptureParams) -> Result<CaptureResult, CommandError> {
-        let persona_id = ctx
-            .caller
-            .as_ref()
-            .map(|c| c.peer_id)
-            .ok_or_else(|| {
-                CommandError::Invalid(
-                    "interface/capture needs an authenticated caller to scope captures to".into(),
-                )
-            })?;
+        // Scope the capture to the caller — a persona's peer_id, or "local" for the
+        // owner-by-locality operator (`cu interface/capture` from the box).
+        let scope = capture_scope(ctx.caller.as_ref());
 
         // Resolve the adapter — fails loud listing valid targets on a typo.
         let adapter = screenshotter::resolve(&params.target).map_err(CommandError::Invalid)?;
@@ -132,10 +140,10 @@ impl ActionCommand for Capture {
             return Err(CommandError::Invalid(reason));
         }
 
-        // Per-persona capture dir = the scope.
+        // Caller-scoped capture dir = the scope.
         let dir = capture_root()
             .map_err(|e| CommandError::Internal(e.to_string()))?
-            .join(persona_id.to_string());
+            .join(&scope);
         tokio::fs::create_dir_all(&dir)
             .await
             .map_err(|e| CommandError::Internal(format!("create capture dir: {e}")))?;
@@ -177,21 +185,18 @@ mod tests {
         assert_eq!(Capture::NAME, "interface/capture");
     }
 
-    // what this catches: with no authenticated caller there is no persona to scope
-    // captures to — it must refuse before touching any adapter or the filesystem.
-    #[tokio::test]
-    async fn refuses_without_a_caller() {
-        let err = Capture
-            .run(
-                &Ctx::default(),
-                CaptureParams {
-                    target: "web".into(),
-                    ..Default::default()
-                },
-            )
-            .await
-            .expect_err("must refuse");
-        assert!(matches!(err, CommandError::Invalid(_)));
+    // what this catches: capture scoping — a persona scopes to its peer_id, and the
+    // owner-by-locality operator (no persona caller, the local `cu` path) scopes to
+    // "local" instead of being refused. That "local" scope is what lets
+    // `cu interface/capture` screenshot any interface from a CLI call.
+    #[test]
+    fn caller_scope_is_persona_id_or_local() {
+        assert_eq!(capture_scope(None), "local");
+        let pid = Uuid::from_u128(7);
+        let persona = crate::routing::auth_policy::CallerIdentity::local_persona(
+            crate::identity::PeerId::from_uuid(pid),
+        );
+        assert_eq!(capture_scope(Some(&persona)), pid.to_string());
     }
 
     // what this catches: an unknown target is rejected with a named, listing

--- a/core/continuum-core/src/commands/interface/capture/web.rs
+++ b/core/continuum-core/src/commands/interface/capture/web.rs
@@ -36,6 +36,16 @@ const CAPTURE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 /// How often to check whether the screenshot file has been written + settled.
 const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(150);
 
+/// Let an async / single-page app settle before the screenshot. Headless Chrome
+/// captures at the load event by default — far too early for a JS app that mounts,
+/// opens a WebSocket, waits for the first state frame, and only THEN renders (an
+/// empty page otherwise — the failure this fixes). `--virtual-time-budget` advances
+/// the page's timers/microtasks and holds the screenshot until the budget is spent
+/// or the page goes idle, so the RENDERED content is what lands in the PNG. 3s is
+/// ample for a localhost socket round-trip + first paint; a genuinely stuck page
+/// still bounds out via `CAPTURE_TIMEOUT`.
+const RENDER_SETTLE_MS: u64 = 3000;
+
 /// Where a Chromium-family browser typically lives, in probe order. macOS app
 /// bundles first (no `$PATH` entry), then the Linux bare names resolved via
 /// `$PATH`. All are the same engine and honor `--headless=new --screenshot`; the
@@ -111,6 +121,9 @@ impl Screenshotter for WebShot {
             .arg("--headless=new")
             .arg("--disable-gpu")
             .arg("--hide-scrollbars")
+            // Wait for the app to render (mount → WS connect → first frame) before
+            // the screenshot fires — otherwise we capture a blank pre-render page.
+            .arg(format!("--virtual-time-budget={RENDER_SETTLE_MS}"))
             .arg(format!("--window-size={},{}", req.width, req.height))
             .arg(format!("--screenshot={out}"))
             .arg(url)


### PR DESCRIPTION
Makes `cu interface/capture` usable as "screenshot any interface via a CLI call": (1) scope owner-by-locality operator captures to `local` instead of refusing a persona-less caller, (2) `--virtual-time-budget` so async/SPA pages render before capture. Verified: renders + saves a PNG (static page proven). Web app itself still renders blank in-browser (separate web-client bug — same chat-view pipe renders fine via terminal + node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)