### PR TITLE
feat(patterns): @continuum/patterns — consumer-neutral widget pattern contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "continuum",
       "workspaces": [
         "sdk/typescript",
+        "packages/patterns",
         "packages/chat-view",
         "apps/web",
         "apps/tui",
@@ -119,6 +120,10 @@
     },
     "node_modules/@continuum/desktop": {
       "resolved": "apps/desktop",
+      "link": true
+    },
+    "node_modules/@continuum/patterns": {
+      "resolved": "packages/patterns",
       "link": true
     },
     "node_modules/@continuum/sdk-typescript": {
@@ -4114,8 +4119,17 @@
       "name": "@continuum/chat-view",
       "version": "0.1.0",
       "dependencies": {
+        "@continuum/patterns": "*",
         "@continuum/sdk-typescript": "*"
       },
+      "devDependencies": {
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "packages/patterns": {
+      "name": "@continuum/patterns",
+      "version": "0.1.0",
       "devDependencies": {
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Continuum — a headless persona substrate. The Rust core is the server; every UI is an equal, dependent client over the same Commands/Events SDK. `npm start` boots ONLY the headless core (Rust, no desktop). Clients live under apps/ (web, desktop, cli[Rust], mobile, vr, ar, mcp) and attach on demand.",
   "workspaces": [
     "sdk/typescript",
+    "packages/patterns",
     "packages/chat-view",
     "apps/web",
     "apps/tui",

--- a/packages/chat-view/index.ts
+++ b/packages/chat-view/index.ts
@@ -23,3 +23,7 @@ export type {
   RosterMemberVM,
   MessageRowVM,
 } from './chatViewModel';
+
+// The chat activity expressed on the consumer-neutral pattern primitives
+// (ACTIVITY-ROOM-PATTERNS.md): the roster IS the `Listing` primitive.
+export { rosterListing } from './patternProjections';

--- a/packages/chat-view/package.json
+++ b/packages/chat-view/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@continuum/patterns": "*",
     "@continuum/sdk-typescript": "*"
   },
   "devDependencies": {

--- a/packages/chat-view/patternProjections.ts
+++ b/packages/chat-view/patternProjections.ts
@@ -1,0 +1,43 @@
+/**
+ * Chat → pattern-primitive projections.
+ *
+ * Proves ACTIVITY-ROOM-PATTERNS.md's thesis on the chat activity: the roster is not a
+ * bespoke widget — it is the `Listing` primitive (`@continuum/patterns`). This maps
+ * the chat view model's members into a `ListingView` (the people-Listing), so the same
+ * rows render on any `RenderTarget`: web member-cards, an ANSI list, or a persona's
+ * grounding block. The projection resolves the display fields (glyph, badges, status);
+ * a target only draws them.
+ */
+
+import type { ListingView, ListingCell, CellStatus } from '@continuum/patterns';
+import type { ChatViewModel, MemberKind, RosterMemberVM } from './chatViewModel';
+
+/** Leading glyph per member kind — the neutral human/agent/system discriminant, as a
+ *  display token the Listing carries (targets draw it, they don't re-derive it). */
+function kindGlyph(kind: MemberKind): string {
+  switch (kind) {
+    case 'human':
+      return '🧑';
+    case 'agent':
+      return '🤖';
+    case 'system':
+      return '⚙️';
+  }
+}
+
+/** One roster member → a `Listing` cell (the people-Listing cell template). */
+function rosterCell(m: RosterMemberVM): ListingCell {
+  const badges = m.runtime ? [m.kind, m.runtime] : [m.kind];
+  const status: CellStatus = m.active ? 'active' : 'idle';
+  return { id: m.id, title: m.name, glyph: kindGlyph(m.kind), badges, status };
+}
+
+/** The chat activity's `who` panel projected as the `Listing` primitive. Same shape
+ *  the rooms/DMs list and Foundry's model list use — one primitive, different data. */
+export function rosterListing(vm: ChatViewModel): ListingView {
+  return {
+    id: 'roster',
+    title: 'Users & Agents',
+    cells: vm.members.map(rosterCell),
+  };
+}

--- a/packages/patterns/index.ts
+++ b/packages/patterns/index.ts
@@ -1,0 +1,146 @@
+/**
+ * `@continuum/patterns` — the consumer-neutral widget pattern contract.
+ *
+ * The precedence-winning code expression of `docs/architecture/ACTIVITY-ROOM-PATTERNS.md`.
+ * A "widget" is NOT a component; it is a **pattern** — a projection of who/what/where
+ * that renders to any consumer. This package holds only the **shapes** (the "props")
+ * and the **render contract**; it has NO DOM, NO ANSI, NO RAG specifics, and no
+ * dependencies. Each surface (apps/web Lit, apps/tui ANSI, the Rust persona RAG
+ * renderer, a future mobile shell) implements a `RenderTarget` over these shapes.
+ *
+ * The four primitives — everything decomposes into these:
+ *   - `Listing`      — a repeating list (users, rooms/DMs, HF-models, cohorts…). One
+ *                      primitive, reused everywhere a list appears.
+ *   - `Content`      — the centre, **dispatched by room purpose** (a MIME-type handler).
+ *   - `ContextPanel` — the right-hand activity widgets (often themselves Listings).
+ *   - `Workspace`    — the shell: the rooms-`Listing` (tab bar == channel-attention)
+ *                      + left listings + focused-room content + context panel.
+ *
+ * The thesis: `activity == airc room == content == tab`, and RAG is a peer
+ * `RenderTarget` alongside web/mobile/terminal — so the human's UI and the persona's
+ * grounding are ONE projection that cannot drift.
+ */
+
+// ── Listing ────────────────────────────────────────────────────────────────
+
+/** Presence/liveness of a listing cell, when it has one (a member is active/idle;
+ *  a room has unread; a model is loaded). `'none'` = the cell carries no status dot. */
+export type CellStatus = 'active' | 'idle' | 'none';
+
+/** One already-projected row of a `Listing`. Display fields only — the projection
+ *  (e.g. `rosterListing` in `@continuum/chat-view`) has already resolved names,
+ *  glyphs, and badges from the domain state; a `RenderTarget` only draws these. */
+export interface ListingCell {
+  /** Stable identity of the item this cell represents (member id, room id, model id). */
+  readonly id: string;
+  /** Primary label (a person's name, a room name, a model name). */
+  readonly title: string;
+  /** Optional secondary line (a role, a last-seen, a param count). */
+  readonly subtitle?: string;
+  /** Optional leading glyph — an emoji/icon token (the avatar in a people listing). */
+  readonly glyph?: string;
+  /** Optional short tags (kind, runtime, provider) — the target styles them. */
+  readonly badges?: readonly string[];
+  /** Optional presence/liveness; `'none'` draws no status indicator. */
+  readonly status?: CellStatus;
+  /** Optional grouping/category key (the "bookmarked menus + categories" axis). */
+  readonly group?: string;
+}
+
+/** The `Listing` pattern — a repeating list. The SAME shape backs the users list,
+ *  the rooms/DMs list, Foundry's HF-model list, and (in RAG) a categorized grounding
+ *  menu. Different data + cells, one primitive, every surface. */
+export interface ListingView {
+  /** Which listing this is (`"roster"`, `"rooms"`, `"hf-models"`) — targets may key on it. */
+  readonly id: string;
+  /** Panel header ("Users & Agents", "Rooms", "Models"). */
+  readonly title: string;
+  /** The rows, already projected. */
+  readonly cells: readonly ListingCell[];
+}
+
+// ── Content (dispatched by room purpose) ─────────────────────────────────────
+
+/** The `Content` pattern — the centre of a workspace, selected by the room's
+ *  **purpose** (the content-type / MIME key: `"chat"`, `"foundry"`, `"scada"`…).
+ *  `body` is purpose-specific and opaque here; a per-purpose renderer registered on
+ *  the target interprets it. This is what makes "any activity is a room": the purpose
+ *  chooses the transform, not a bespoke container. */
+export interface ContentView<Body = unknown> {
+  /** The room purpose — the dispatch key. */
+  readonly purpose: string;
+  /** Purpose-specific payload the registered content renderer understands. */
+  readonly body: Body;
+}
+
+// ── ContextPanel + Workspace ─────────────────────────────────────────────────
+
+/** The right-hand `ContextPanel` — activity-scoped supporting widgets. Today a set
+ *  of `Listing`s (Foundry's HF-models, a chat thread's participants); richer widget
+ *  kinds join this union as they land. */
+export interface ContextPanelView {
+  readonly listings: readonly ListingView[];
+}
+
+/** The `Workspace` shell — the whole who/what/where for one focused room. `nav` is
+ *  the rooms-`Listing`: the tab bar for a human, the channel-attention set for a
+ *  persona. `left`/`content`/`context` are the three zones. */
+export interface WorkspaceView {
+  /** The rooms-`Listing` — tab bar == persona channel-attention (one nav primitive). */
+  readonly nav: ListingView;
+  /** Left-panel listings (users, rooms/DMs) — identical across every activity. */
+  readonly left: readonly ListingView[];
+  /** The focused room's content, dispatched by its purpose. */
+  readonly content: ContentView;
+  /** The right-hand supporting widgets for the focused activity. */
+  readonly context: ContextPanelView;
+}
+
+// ── RenderTarget — the consumer-neutral render contract ──────────────────────
+
+/** A per-purpose content renderer: given the `ContentView.body` and its purpose,
+ *  produce this target's output. Registered on a `ContentRegistry` — the MIME table. */
+export type ContentRenderer<Out, Body = unknown> = (body: Body, purpose: string) => Out;
+
+/** The content-dispatch table for one target: `purpose → renderer`. `render` looks up
+ *  by `view.purpose` and **fails loud** on an unregistered purpose — an unknown
+ *  activity is a wiring bug, never a silent blank ([[fallbacks-are-illegal-fail-loud]]). */
+export interface ContentRegistry<Out> {
+  register<Body>(purpose: string, renderer: ContentRenderer<Out, Body>): void;
+  render(view: ContentView): Out;
+}
+
+/** A consumer that renders the patterns to its own output type `Out` — web
+ *  (a Lit `TemplateResult`), terminal (a `string` of cells), mobile (a native node),
+ *  RAG (a grounding block `string`). One contract, every surface. The `content`
+ *  method dispatches through the target's `ContentRegistry`, so adding an activity is
+ *  registering a content renderer — never a new target. */
+export interface RenderTarget<Out> {
+  listing(view: ListingView): Out;
+  content(view: ContentView): Out;
+  contextPanel(view: ContextPanelView): Out;
+  workspace(view: WorkspaceView): Out;
+}
+
+/** Build an empty content-dispatch table for a target. Fail-loud on unknown purpose. */
+export function createContentRegistry<Out>(): ContentRegistry<Out> {
+  const table = new Map<string, ContentRenderer<Out>>();
+  return {
+    register<Body>(purpose: string, renderer: ContentRenderer<Out, Body>): void {
+      if (table.has(purpose)) {
+        throw new Error(`content renderer already registered for purpose "${purpose}"`);
+      }
+      table.set(purpose, renderer as ContentRenderer<Out>);
+    },
+    render(view: ContentView): Out {
+      const renderer = table.get(view.purpose);
+      if (!renderer) {
+        const known = [...table.keys()].join(', ') || '(none)';
+        throw new Error(
+          `no content renderer for room purpose "${view.purpose}" — registered: ${known}`,
+        );
+      }
+      return renderer(view.body, view.purpose);
+    },
+  };
+}

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@continuum/patterns",
+  "version": "0.1.0",
+  "private": true,
+  "description": "The consumer-neutral widget pattern contract (docs/architecture/ACTIVITY-ROOM-PATTERNS.md). Framework-free shapes — Listing / Content(dispatch-by-purpose) / ContextPanel / Workspace — plus the RenderTarget contract each surface (web Lit, tui ANSI, the Rust persona RAG renderer, mobile) implements. A widget is a pattern projected to any consumer; the human's UI and the persona's grounding are ONE projection. Holds NO DOM, NO ANSI, NO RAG specifics, and no dependencies.",
+  "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/patterns/patterns.spec.ts
+++ b/packages/patterns/patterns.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * The pattern-primitive proof: ONE projection, many render targets.
+ *
+ * The whole thesis of ACTIVITY-ROOM-PATTERNS.md is that a pattern is a
+ * consumer-neutral transform — the human's UI and the persona's grounding are the
+ * same projection rendered two ways. These tests build two minimal `RenderTarget`s
+ * (a web-like HTML string, a RAG-like grounding block) and prove the SAME shapes
+ * render correctly to both, that `Content` dispatches on room purpose, and that an
+ * unregistered purpose fails loud.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createContentRegistry,
+  type ListingView,
+  type ContentView,
+  type WorkspaceView,
+  type ContextPanelView,
+  type ContentRegistry,
+  type RenderTarget,
+} from './index';
+
+/** A sample roster projected to a Listing — the people-Listing the chat activity uses. */
+const roster: ListingView = {
+  id: 'roster',
+  title: 'Users & Agents',
+  cells: [
+    { id: 'a', title: 'Asha', glyph: '🤖', badges: ['agent', 'persona'], status: 'active' },
+    { id: 'j', title: 'Joel', glyph: '🧑', badges: ['human'], status: 'idle' },
+  ],
+};
+
+/** A web-like target: the primitives → an HTML string. Content dispatches through the
+ *  registry it is built with, so adding an activity is registering a renderer. */
+function htmlTarget(content: ContentRegistry<string>): RenderTarget<string> {
+  const self: RenderTarget<string> = {
+    listing: (v) =>
+      `<section class="listing" data-id="${v.id}"><h3>${v.title}</h3><ul>` +
+      v.cells
+        .map((c) => `<li data-status="${c.status ?? 'none'}">${c.glyph ?? ''} ${c.title}</li>`)
+        .join('') +
+      `</ul></section>`,
+    content: (v) => content.render(v),
+    contextPanel: (v) => v.listings.map((l) => self.listing(l)).join(''),
+    workspace: (v) =>
+      `<nav>${self.listing(v.nav)}</nav><aside>${v.left.map((l) => self.listing(l)).join('')}</aside>` +
+      `<main>${self.content(v.content)}</main><section>${self.contextPanel(v.context)}</section>`,
+  };
+  return self;
+}
+
+/** A RAG target: the SAME shapes → a persona-grounding markdown block. */
+function ragTarget(content: ContentRegistry<string>): RenderTarget<string> {
+  const self: RenderTarget<string> = {
+    listing: (v) =>
+      `## ${v.title}\n` +
+      v.cells
+        .map(
+          (c) =>
+            `- ${c.title}${c.status === 'active' ? ' (here)' : ''}` +
+            (c.badges?.length ? ` [${c.badges.join(', ')}]` : ''),
+        )
+        .join('\n'),
+    content: (v) => content.render(v),
+    contextPanel: (v) => v.listings.map((l) => self.listing(l)).join('\n\n'),
+    workspace: (v) =>
+      `${self.listing(v.nav)}\n\n${v.left.map((l) => self.listing(l)).join('\n\n')}\n\n` +
+      `${self.content(v.content)}\n\n${self.contextPanel(v.context)}`,
+  };
+  return self;
+}
+
+describe('pattern primitives — one projection, many render targets', () => {
+  // what this catches: the SAME ListingView renders correctly to a web (HTML) target
+  // AND a RAG (grounding) target — the consumer-neutrality thesis (eyes and mind from
+  // one projection). If a primitive leaked a surface assumption, one would break.
+  it('renders one Listing to both a web target and a RAG target', () => {
+    const web = htmlTarget(createContentRegistry<string>()).listing(roster);
+    expect(web).toContain('<h3>Users & Agents</h3>');
+    expect(web).toContain('🤖 Asha');
+    expect(web).toContain('data-status="active"');
+
+    const rag = ragTarget(createContentRegistry<string>()).listing(roster);
+    expect(rag).toBe('## Users & Agents\n- Asha (here) [agent, persona]\n- Joel [human]');
+  });
+
+  // what this catches: Content dispatches on room PURPOSE (the MIME handler) and fails
+  // loud on an unregistered purpose — an unknown activity is a wiring bug, never a
+  // silent blank ([[fallbacks-are-illegal-fail-loud]]).
+  it('dispatches Content by purpose and fails loud on an unknown one', () => {
+    const reg = createContentRegistry<string>();
+    reg.register<{ text: string }>('chat', (b) => `conversation: ${b.text}`);
+    reg.register<{ recipe: string }>('foundry', (b) => `config for ${b.recipe}`);
+
+    expect(reg.render({ purpose: 'chat', body: { text: 'hi' } })).toBe('conversation: hi');
+    expect(reg.render({ purpose: 'foundry', body: { recipe: 'qwen' } })).toBe('config for qwen');
+    expect(() => reg.render({ purpose: 'scada', body: {} })).toThrow(
+      /no content renderer for room purpose "scada"/,
+    );
+  });
+
+  // what this catches: a full Workspace composes nav + left listings + purpose-content
+  // + context on a target with NO bespoke per-activity code — the shell is identical
+  // across activities; only Content/Context vary with the room's purpose.
+  it('composes a full Workspace from the primitives on one target', () => {
+    const content = createContentRegistry<string>();
+    content.register<{ text: string }>('chat', (b) => `<p>${b.text}</p>`);
+    const target = htmlTarget(content);
+
+    const ws: WorkspaceView = {
+      nav: { id: 'rooms', title: 'Rooms', cells: [{ id: 'general', title: 'general', status: 'active' }] },
+      left: [roster],
+      content: { purpose: 'chat', body: { text: 'hello' } } satisfies ContentView<{ text: string }>,
+      context: { listings: [] } satisfies ContextPanelView,
+    };
+
+    const out = target.workspace(ws);
+    expect(out).toContain('general'); // nav (rooms-Listing == tab bar)
+    expect(out).toContain('Asha'); // left people-Listing
+    expect(out).toContain('<p>hello</p>'); // Content dispatched by purpose "chat"
+  });
+});

--- a/packages/patterns/tsconfig.json
+++ b/packages/patterns/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "//": "Typecheck config for @continuum/patterns. Mirrors @continuum/chat-view: framework-free and platform-neutral, so NO DOM lib — it must typecheck identically under a browser bundler (apps/web), Node (apps/tui), and any future consumer. tsc is --noEmit typecheck only.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
The code spine of `ACTIVITY-ROOM-PATTERNS.md`. Four primitives — **Listing / Content(dispatch-by-purpose) / ContextPanel / Workspace** — as framework-free shapes + a `RenderTarget<Out>` each surface implements (web / terminal / **RAG** / mobile). `ContentRegistry` is the purpose→renderer MIME table, fail-loud on an unknown purpose.

**Proof (3 green tests):** the same `ListingView` renders to both a web target and a RAG target (eyes-and-mind consumer-neutrality); Content dispatches by purpose + throws on unknown; a full Workspace composes with zero per-activity code.

Chat expressed on it: `@continuum/chat-view` now exports `rosterListing(vm)` — the roster IS the `Listing` primitive (outlier A).

Framework first; visuals later. Next: room-purpose as data (#6/#89), then foundry as outlier B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)