### PR TITLE
feat(positron): brick 1 — room purpose as data (the Content dispatch key)

### DIFF
--- a/apps/web/src/chat/renderChat.spec.ts
+++ b/apps/web/src/chat/renderChat.spec.ts
@@ -98,7 +98,7 @@ describe('renderChat (Lit)', () => {
   it('renders room, roster, and messages from a seam-projected snapshot', () => {
     const vm = project({
       room_id: 'room-1',
-      room_name: 'general',
+      room_name: 'general', purpose: 'chat',
       roster: [
         member({ member_id: 'asha', display_name: 'Asha', kind: kind('agent'), provenance: { runtime: 'claude' } }),
         member({ member_id: 'joel', display_name: 'Joel', kind: kind('human'), active: false }),
@@ -134,7 +134,7 @@ describe('renderChat (Lit)', () => {
   // string, not an error and not a bare void — matching the ANSI renderer's
   // "No messages yet — say hello." contract exactly.
   it('renders an honest empty state when there are no messages', () => {
-    const vm = project({ room_id: 'room-1', room_name: 'general', roster: [], messages: [] });
+    const vm = project({ room_id: 'room-1', room_name: 'general', purpose: 'chat', roster: [], messages: [] });
     const text = markup(vm);
     expect(text).toContain('No messages yet — say hello.');
     expect(text).not.toMatch(/error/i);
@@ -147,7 +147,7 @@ describe('renderChat (Lit)', () => {
   it('badges a resolved runtime once and never fabricates one for the unresolved', () => {
     const vm = project({
       room_id: 'room-1',
-      room_name: 'general',
+      room_name: 'general', purpose: 'chat',
       roster: [
         member({ member_id: 'asha', display_name: 'Asha', provenance: { runtime: 'claude' } }),
         member({ member_id: 'nyx', display_name: 'Nyx', provenance: { runtime: '' } }),

--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -444,6 +444,11 @@ impl ChatProjection {
         let view = ChatViewState {
             room_id,
             room_name: self.room_name.clone(),
+            // Every room is a chat room today. `RoomPurposeSource` (task #6)
+            // will resolve this from the room's recipe/nature so a foundry /
+            // scada / academy room reports its own purpose and the client's
+            // Content primitive dispatches on it (ACTIVITY-ROOM-PATTERNS.md).
+            purpose: "chat".to_string(),
             messages: self.messages.iter().cloned().collect(),
             roster: self.roster.clone(),
         };

--- a/core/continuum-positron/src/chat.rs
+++ b/core/continuum-positron/src/chat.rs
@@ -301,6 +301,16 @@ pub struct ChatViewState {
     /// Human-readable room name (e.g. `"general"`). Substrate-resolved;
     /// widget must not derive from URL slug.
     pub room_name: String,
+    /// The room's **activity purpose** — the content-dispatch key
+    /// (`"chat"`, `"foundry"`, `"scada"`, …). Per
+    /// `docs/architecture/ACTIVITY-ROOM-PATTERNS.md`, `activity == room ==
+    /// content == tab`: a client's `Content` primitive dispatches on this to
+    /// pick the room's central widget(s), so adding an activity is a purpose
+    /// value + a registered renderer, never a shell change. Neutral/opaque
+    /// here — positron transports the value, continuum sets it (from the
+    /// room's recipe/nature via `RoomPurposeSource`, task #6); it defaults to
+    /// `"chat"` until a recipe names another purpose.
+    pub purpose: String,
     /// Most recent messages, oldest first. Bounded — substrate decides
     /// the window (see `MAX_MESSAGES_PER_SNAPSHOT` in the builder).
     /// Past-the-window history is pulled on demand through a
@@ -485,6 +495,7 @@ mod tests {
         let state = ChatViewState {
             room_id,
             room_name: "general".into(),
+            purpose: "chat".into(),
             messages: vec![ChatMessageView {
                 id: Uuid::from_u128(0xb),
                 room_id,
@@ -534,6 +545,7 @@ mod tests {
         let state = ChatViewState {
             room_id: Uuid::from_u128(0xa),
             room_name: "general".into(),
+            purpose: "chat".into(),
             messages: vec![],
             roster: vec![],
         };

--- a/core/continuum-positron/src/state.rs
+++ b/core/continuum-positron/src/state.rs
@@ -163,6 +163,7 @@ mod tests {
         ChatViewState {
             room_id,
             room_name: "general".into(),
+            purpose: "chat".into(),
             messages: Vec::new(),
             roster: vec![RosterSlotView {
                 member_id: Uuid::from_u128(1),

--- a/core/continuum-positron/tests/session_roundtrip.rs
+++ b/core/continuum-positron/tests/session_roundtrip.rs
@@ -70,6 +70,7 @@ fn build_chat_state(content: &str) -> ChatViewState {
     ChatViewState {
         room_id,
         room_name: "general".into(),
+        purpose: "chat".into(),
         messages: vec![ChatMessageView {
             id: message_id,
             room_id,

--- a/packages/chat-view/chatViewModel.spec.ts
+++ b/packages/chat-view/chatViewModel.spec.ts
@@ -44,6 +44,7 @@ const state = (over: Partial<ChatState> = {}): ChatState => ({
   revision: 3,
   room_id: 'room-1',
   room_name: 'general',
+  purpose: 'chat',
   messages: [],
   roster: [],
   ...over,

--- a/packages/chat-view/chatViewModel.ts
+++ b/packages/chat-view/chatViewModel.ts
@@ -53,6 +53,10 @@ export interface MessageRowVM {
 export interface ChatViewModel {
   readonly roomName: string;
   readonly roomId: string;
+  /** The room's activity purpose (the Content dispatch key — "chat", "foundry"…).
+   *  Today always "chat"; when RoomPurposeSource (#6) lands, a client's `Content`
+   *  registry dispatches on it (ACTIVITY-ROOM-PATTERNS.md). */
+  readonly purpose: string;
   readonly memberCount: number;
   readonly activeCount: number;
   readonly members: readonly RosterMemberVM[];
@@ -99,6 +103,7 @@ export function chatViewModel(state: ChatState): ChatViewModel {
   return {
     roomName: state.room_name,
     roomId: state.room_id,
+    purpose: state.purpose,
     memberCount: members.length,
     activeCount: members.filter((m) => m.active).length,
     members,

--- a/packages/chat-view/crossConsumer.spec.ts
+++ b/packages/chat-view/crossConsumer.spec.ts
@@ -103,6 +103,7 @@ class StreamConsumer {
 const SNAPSHOT: StateEnvelope = chatEnvelope(1, {
   room_id: 'room-1',
   room_name: 'general',
+  purpose: 'chat',
   roster: [
     member({ member_id: 'asha', display_name: 'Asha', kind: kind('agent'), provenance: { runtime: 'claude' } }),
     member({ member_id: 'joel', display_name: 'Joel', kind: kind('human'), active: false }),
@@ -115,6 +116,7 @@ const SNAPSHOT: StateEnvelope = chatEnvelope(1, {
 const DELTA: StateEnvelope = chatEnvelope(2, {
   room_id: 'room-1',
   room_name: 'general',
+  purpose: 'chat',
   roster: [
     member({ member_id: 'asha', display_name: 'Asha', kind: kind('agent'), provenance: { runtime: 'claude' } }),
     member({ member_id: 'joel', display_name: 'Joel', kind: kind('human'), active: true }),

--- a/protocol/typescript/positron/ChatViewState.ts
+++ b/protocol/typescript/positron/ChatViewState.ts
@@ -27,6 +27,18 @@ room_id: string,
  */
 room_name: string, 
 /**
+ * The room's **activity purpose** — the content-dispatch key
+ * (`"chat"`, `"foundry"`, `"scada"`, …). Per
+ * `docs/architecture/ACTIVITY-ROOM-PATTERNS.md`, `activity == room ==
+ * content == tab`: a client's `Content` primitive dispatches on this to
+ * pick the room's central widget(s), so adding an activity is a purpose
+ * value + a registered renderer, never a shell change. Neutral/opaque
+ * here — positron transports the value, continuum sets it (from the
+ * room's recipe/nature via `RoomPurposeSource`, task #6); it defaults to
+ * `"chat"` until a recipe names another purpose.
+ */
+purpose: string, 
+/**
  * Most recent messages, oldest first. Bounded — substrate decides
  * the window (see `MAX_MESSAGES_PER_SNAPSHOT` in the builder).
  * Past-the-window history is pulled on demand through a

--- a/sdk/typescript/generated/views/ChatViewState.ts
+++ b/sdk/typescript/generated/views/ChatViewState.ts
@@ -25,7 +25,17 @@ room_id: string,
  * Human-readable room name (e.g. `"general"`). Substrate-resolved;
  * widget must not derive from URL slug.
  */
-room_name: string, 
+room_name: string,
+/**
+ * The room's **activity purpose** — the content-dispatch key
+ * (`"chat"`, `"foundry"`, `"scada"`, …). Per
+ * `docs/architecture/ACTIVITY-ROOM-PATTERNS.md`, `activity == room ==
+ * content == tab`: a client's `Content` primitive dispatches on this to
+ * pick the room's central widget(s). Neutral/opaque here — positron
+ * transports the value, continuum sets it (from the room's recipe via
+ * `RoomPurposeSource`, task #6); defaults to `"chat"`.
+ */
+purpose: string,
 /**
  * Most recent messages, oldest first. Bounded — substrate decides
  * the window (see `MAX_MESSAGES_PER_SNAPSHOT` in the builder).


### PR DESCRIPTION
Makes `activity == room == content == tab` (ACTIVITY-ROOM-PATTERNS.md) **literal**: the room's projected state now carries `purpose` — the content-dispatch key a client's `Content` primitive keys on. Adding an activity = a purpose value + a registered renderer, never a shell change.

- `ChatViewState` gains `purpose: String` (neutral/opaque — positron transports, continuum sets).
- The live projection populates `"chat"` today; `RoomPurposeSource` (#6) resolves it from the room recipe next.
- ts-rs regenerated + SDK copy synced (the two-location drift is #80).
- `ChatViewModel` exposes `purpose` → the `@continuum/patterns` Content registry has its key.

Verified: positron tests green, core check exit 0, chat-view + web typecheck clean, lint green, all client tests pass.

Next: foundry as outlier B (second purpose + content projection), then the Rust RAG RenderTarget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)