### PR TITLE
feat(patterns): chat room composes into a Workspace (outlier-B groundwork)

### DIFF
--- a/packages/chat-view/index.ts
+++ b/packages/chat-view/index.ts
@@ -25,5 +25,7 @@ export type {
 } from './chatViewModel';
 
 // The chat activity expressed on the consumer-neutral pattern primitives
-// (ACTIVITY-ROOM-PATTERNS.md): the roster IS the `Listing` primitive.
-export { rosterListing } from './patternProjections';
+// (ACTIVITY-ROOM-PATTERNS.md): the roster IS the `Listing`, and the whole room
+// composes into a `Workspace` (nav + left + purpose-keyed content + context).
+export { rosterListing, roomsListing, chatWorkspace } from './patternProjections';
+export type { ChatContentBody } from './patternProjections';

--- a/packages/chat-view/patternProjections.spec.ts
+++ b/packages/chat-view/patternProjections.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Chat → pattern-primitive projection tests.
+ *
+ * Proves the chat activity expresses itself on the consumer-neutral primitives
+ * (ACTIVITY-ROOM-PATTERNS.md): the roster is a `Listing`, the room is a nav
+ * `Listing` cell, and the whole room composes into a `Workspace` whose `Content`
+ * is keyed by the room's `purpose`. Projections take the flat `ChatViewModel`, so
+ * these fixtures need no wire types.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ChatViewModel } from './chatViewModel';
+import { rosterListing, roomsListing, chatWorkspace } from './patternProjections';
+
+const vm: ChatViewModel = {
+  roomName: 'general',
+  roomId: 'room-1',
+  purpose: 'chat',
+  memberCount: 2,
+  activeCount: 1,
+  members: [
+    { id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: 'persona' },
+    { id: 'j', name: 'Joel', kind: 'human', active: false, runtime: '' },
+  ],
+  messages: [
+    { id: 'm1', senderId: 'a', senderName: 'Asha', kind: 'agent', content: 'hi', time: '00:00', runtime: 'persona' },
+  ],
+  isEmpty: false,
+};
+
+describe('chat → pattern projections', () => {
+  // what this catches: the roster projects to the people-`Listing` — the cell
+  // template resolves glyph/badges/status so a target only draws them.
+  it('projects the roster into the people Listing', () => {
+    const l = rosterListing(vm);
+    expect(l.id).toBe('roster');
+    expect(l.title).toBe('Users & Agents');
+    expect(l.cells).toHaveLength(2);
+    const asha = l.cells[0]!;
+    expect(asha).toMatchObject({
+      id: 'a',
+      title: 'Asha',
+      glyph: '🤖',
+      status: 'active',
+      badges: ['agent', 'persona'],
+    });
+    // a human with no runtime carries just its kind badge, idle status
+    expect(l.cells[1]).toMatchObject({ title: 'Joel', glyph: '🧑', status: 'idle', badges: ['human'] });
+  });
+
+  // what this catches: the focused room projects to the nav `Listing` (the tab
+  // bar / channel-attention), carrying its purpose as the cell group.
+  it('projects the focused room into the nav Listing', () => {
+    const nav = roomsListing(vm);
+    expect(nav.id).toBe('rooms');
+    expect(nav.cells).toHaveLength(1);
+    expect(nav.cells[0]).toMatchObject({ id: 'room-1', title: 'general', status: 'active', group: 'chat' });
+  });
+
+  // what this catches: the whole room composes into a Workspace — nav + left
+  // people-Listing + Content keyed by the room's purpose + an (empty) context.
+  // This is the data spine a RenderTarget draws; foundry slots in as a different
+  // purpose + content body with NO shell change.
+  it('composes the room into a Workspace with purpose-keyed Content', () => {
+    const ws = chatWorkspace(vm);
+    expect(ws.nav.id).toBe('rooms');
+    expect(ws.left).toHaveLength(1);
+    expect(ws.left[0]!.id).toBe('roster');
+    expect(ws.content.purpose).toBe('chat');
+    const body = ws.content.body as { messages: unknown[]; isEmpty: boolean };
+    expect(body.messages).toHaveLength(1);
+    expect(body.isEmpty).toBe(false);
+    expect(ws.context.listings).toHaveLength(0);
+  });
+});

--- a/packages/chat-view/patternProjections.spec.ts
+++ b/packages/chat-view/patternProjections.spec.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { ChatViewModel } from './chatViewModel';
-import { rosterListing, roomsListing, chatWorkspace } from './patternProjections';
+import { rosterListing, roomsListing, chatWorkspace, type ChatContentBody } from './patternProjections';
 
 const vm: ChatViewModel = {
   roomName: 'general',
@@ -67,7 +67,9 @@ describe('chat → pattern projections', () => {
     expect(ws.left).toHaveLength(1);
     expect(ws.left[0]!.id).toBe('roster');
     expect(ws.content.purpose).toBe('chat');
-    const body = ws.content.body as { messages: unknown[]; isEmpty: boolean };
+    // `WorkspaceView.content.body` is deliberately opaque (`ContentView<unknown>`) at
+    // the workspace boundary; a chat-aware test narrows to the exported chat body.
+    const body = ws.content.body as ChatContentBody;
     expect(body.messages).toHaveLength(1);
     expect(body.isEmpty).toBe(false);
     expect(ws.context.listings).toHaveLength(0);

--- a/packages/chat-view/patternProjections.ts
+++ b/packages/chat-view/patternProjections.ts
@@ -9,8 +9,14 @@
  * a target only draws them.
  */
 
-import type { ListingView, ListingCell, CellStatus } from '@continuum/patterns';
-import type { ChatViewModel, MemberKind, RosterMemberVM } from './chatViewModel';
+import type {
+  ListingView,
+  ListingCell,
+  CellStatus,
+  ContentView,
+  WorkspaceView,
+} from '@continuum/patterns';
+import type { ChatViewModel, MemberKind, MessageRowVM, RosterMemberVM } from './chatViewModel';
 
 /** Leading glyph per member kind — the neutral human/agent/system discriminant, as a
  *  display token the Listing carries (targets draw it, they don't re-derive it). */
@@ -39,5 +45,43 @@ export function rosterListing(vm: ChatViewModel): ListingView {
     id: 'roster',
     title: 'Users & Agents',
     cells: vm.members.map(rosterCell),
+  };
+}
+
+/** The nav `Listing` — the rooms-Listing that is the tab bar for a human and the
+ *  channel-attention set for a persona (one nav primitive over room-space,
+ *  ACTIVITY-ROOM-PATTERNS.md). Today the client holds one focused room, so this is a
+ *  single active cell; when the client tracks multiple rooms/DMs it fills out with no
+ *  shape change (that is the point of `activity == room == tab`). */
+export function roomsListing(vm: ChatViewModel): ListingView {
+  return {
+    id: 'rooms',
+    title: 'Rooms',
+    cells: [{ id: vm.roomId, title: vm.roomName, status: 'active', group: vm.purpose }],
+  };
+}
+
+/** The chat activity's `Content` body — the conversation. `Content` is keyed by the
+ *  room's `purpose` (here `vm.purpose`, `"chat"`), so a target's registered chat
+ *  renderer draws these rows; a foundry room would carry a different purpose + body. */
+export interface ChatContentBody {
+  readonly messages: readonly MessageRowVM[];
+  readonly isEmpty: boolean;
+}
+
+/** The whole chat room as a `Workspace` — nav (rooms) + left (people) + content
+ *  (the conversation, dispatched by `purpose`) + an empty context panel. This is the
+ *  data spine a `RenderTarget` draws; every activity projects its own `Workspace` the
+ *  same way, so the shell is identical and only content/context vary. */
+export function chatWorkspace(vm: ChatViewModel): WorkspaceView {
+  const content: ContentView<ChatContentBody> = {
+    purpose: vm.purpose,
+    body: { messages: vm.messages, isEmpty: vm.isEmpty },
+  };
+  return {
+    nav: roomsListing(vm),
+    left: [rosterListing(vm)],
+    content,
+    context: { listings: [] },
   };
 }


### PR DESCRIPTION
Projects the chat activity onto the remaining pattern primitives: `roomsListing` (nav = tab bar == channel-attention) + `chatWorkspace` (nav + left people-`Listing` + `Content` keyed by room `purpose` + empty context) + `ChatContentBody`. The data spine every activity projects the same way — foundry slots in as a different purpose + content body + a context HF-model `Listing`, zero shell change. 3 new tests; chat-view typecheck + all tests + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)