### PR TITLE
chore(positron): cargo fmt the crate (rustfmt 1.9.0, no behavior change)

### DIFF
--- a/core/continuum-positron/src/broadcast.rs
+++ b/core/continuum-positron/src/broadcast.rs
@@ -210,7 +210,9 @@ mod tests {
         // The first send transitions None → Some(env). The waiting
         // receiver wakes through normal watch semantics.
         b.send(envelope("chat", 1));
-        rx.changed().await.expect("first send wakes early subscriber");
+        rx.changed()
+            .await
+            .expect("first send wakes early subscriber");
         let first = rx
             .borrow_and_update()
             .clone()
@@ -324,11 +326,8 @@ mod tests {
         // user_rx.changed() would hang — assert it's NOT ready.
         // tokio::select with a deadline is the right shape for a
         // negative test.
-        let did_change = tokio::time::timeout(
-            std::time::Duration::from_millis(50),
-            user_rx.changed(),
-        )
-        .await;
+        let did_change =
+            tokio::time::timeout(std::time::Duration::from_millis(50), user_rx.changed()).await;
         assert!(
             did_change.is_err(),
             "user-list receiver must not see chat's send"
@@ -380,11 +379,8 @@ mod tests {
 
         // user-list cold-start subscriber MUST still be at None — no
         // user-list send has happened yet.
-        let did_change = tokio::time::timeout(
-            std::time::Duration::from_millis(50),
-            user_rx.changed(),
-        )
-        .await;
+        let did_change =
+            tokio::time::timeout(std::time::Duration::from_millis(50), user_rx.changed()).await;
         assert!(
             did_change.is_err(),
             "user-list cold-start subscriber must not wake on chat's send"

--- a/core/continuum-positron/src/chat.rs
+++ b/core/continuum-positron/src/chat.rs
@@ -77,7 +77,10 @@ use uuid::Uuid;
 /// `string`, which matches JSON behavior — `Uuid` isn't a JSON
 /// primitive).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../protocol/typescript/positron/ChatMessageView.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/ChatMessageView.ts"
+)]
 pub struct ChatMessageView {
     #[ts(type = "string")]
     pub id: Uuid,
@@ -129,7 +132,10 @@ pub struct ChatMessageView {
 /// learning continuum (see module docs).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case", tag = "kind")]
-#[ts(export, export_to = "../../../protocol/typescript/positron/SenderKind.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/SenderKind.ts"
+)]
 pub enum SenderKind {
     /// Carbon — typed at the keyboard, dictated through STT, etc.
     Human,
@@ -196,7 +202,10 @@ impl SenderKind {
 /// not interpreted here — the app layer decides what a given runtime
 /// means for trust, exactly as it does for `integrations`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../protocol/typescript/positron/Provenance.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/Provenance.ts"
+)]
 pub struct Provenance {
     /// The producer's self-reported runtime class, verbatim from airc
     /// presence (`"claude"` / `"codex"` / `"interactive"` / …). The
@@ -232,7 +241,10 @@ impl Provenance {
 /// `member_id` + `kind` + opaque `integrations`, never a
 /// continuum-specific "persona" field.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../protocol/typescript/positron/RosterSlotView.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/RosterSlotView.ts"
+)]
 pub struct RosterSlotView {
     #[ts(type = "string")]
     pub member_id: Uuid,
@@ -293,7 +305,10 @@ pub struct RosterSlotView {
 /// (additive — additive ts-rs deltas are wire-compatible) in
 /// follow-up slices.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../protocol/typescript/positron/ChatViewState.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/ChatViewState.ts"
+)]
 pub struct ChatViewState {
     /// The room this snapshot describes.
     #[ts(type = "string")]

--- a/core/continuum-positron/src/kanban.rs
+++ b/core/continuum-positron/src/kanban.rs
@@ -73,7 +73,10 @@ use crate::chat::{Provenance, SenderKind};
 /// airc `CardState` → this at the seam.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
-#[ts(export, export_to = "../../../protocol/typescript/positron/KanbanCardState.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/KanbanCardState.ts"
+)]
 pub enum KanbanCardState {
     Open,
     Claimed,
@@ -87,7 +90,10 @@ pub enum KanbanCardState {
 /// A lane's state — mirrors airc's `LaneState` variant-for-variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
-#[ts(export, export_to = "../../../protocol/typescript/positron/KanbanLaneState.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/KanbanLaneState.ts"
+)]
 pub enum KanbanLaneState {
     Planned,
     Active,
@@ -104,7 +110,10 @@ pub enum KanbanLaneState {
 /// crosses the boundary; the consumer sorts on the string values.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
-#[ts(export, export_to = "../../../protocol/typescript/positron/KanbanPriority.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/KanbanPriority.ts"
+)]
 pub enum KanbanPriority {
     P0,
     P1,
@@ -117,7 +126,10 @@ pub enum KanbanPriority {
 /// number); the branch pair is a build detail the board face doesn't
 /// need. `None` until a PR is opened for the card.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../protocol/typescript/positron/KanbanPullRequest.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/KanbanPullRequest.ts"
+)]
 pub struct KanbanPullRequest {
     /// Repository the PR targets, as airc's `RepoId` display string
     /// (e.g. `"CambrianTech/continuum"`). Opaque to positron.
@@ -135,7 +147,10 @@ pub struct KanbanPullRequest {
 /// for `Uuid`) — airc's `WorkCardId` / `PeerId` projected to their inner
 /// UUIDs at the seam.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../protocol/typescript/positron/KanbanCardView.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/KanbanCardView.ts"
+)]
 pub struct KanbanCardView {
     /// Stable id of the card across its event history — the anchor a
     /// renderer keys a board row on, and the key a lane's `card_ids`
@@ -210,7 +225,10 @@ pub struct KanbanCardView {
 /// One lane on the work board — a named grouping of cards (a swimlane /
 /// epic / milestone). Projected from airc's `LaneRecord`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../protocol/typescript/positron/KanbanLaneView.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/KanbanLaneView.ts"
+)]
 pub struct KanbanLaneView {
     #[ts(type = "string")]
     pub lane_id: Uuid,
@@ -236,7 +254,10 @@ pub struct KanbanLaneView {
 /// by absence, never a stale merged entry — the same "full snapshot,
 /// replace not merge" discipline the wall board and chat roster use.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../protocol/typescript/positron/KanbanViewState.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/KanbanViewState.ts"
+)]
 pub struct KanbanViewState {
     #[ts(type = "string")]
     pub room_id: Uuid,

--- a/core/continuum-positron/src/session_task.rs
+++ b/core/continuum-positron/src/session_task.rs
@@ -272,7 +272,13 @@ fn reconcile_forwarders(
             .remove(kind)
             .unwrap_or_else(|| substrate.broadcast().subscribe(kind));
         let handle = tokio::spawn(forward_kind(rx, *rate, outbound.clone()));
-        forwarders.insert(kind.clone(), Forwarder { handle, rate: *rate });
+        forwarders.insert(
+            kind.clone(),
+            Forwarder {
+                handle,
+                rate: *rate,
+            },
+        );
     }
 
     // Abort forwarders whose kind is no longer subscribed or observed.
@@ -365,7 +371,12 @@ mod tests {
 
         let (in_tx, in_rx) = mpsc::channel(8);
         let (out_tx, mut out_rx) = mpsc::channel(8);
-        let task = tokio::spawn(run_session(in_rx, out_tx, substrate.clone(), ScriptedDispatcher::ok()));
+        let task = tokio::spawn(run_session(
+            in_rx,
+            out_tx,
+            substrate.clone(),
+            ScriptedDispatcher::ok(),
+        ));
 
         in_tx.send(subscribe(&["chat"])).await.unwrap();
 
@@ -374,12 +385,20 @@ mod tests {
         // read — that the forwarder's receiver is already attached at
         // revision 1.
         let snapshot = out_rx.recv().await.expect("snapshot frame");
-        assert_eq!(state_rev(&snapshot), Some(1), "snapshot is the current revision");
+        assert_eq!(
+            state_rev(&snapshot),
+            Some(1),
+            "snapshot is the current revision"
+        );
 
         // A later store must arrive live, exactly once, at revision 2.
         substrate.store(envelope("chat", 2));
         let live = out_rx.recv().await.expect("live frame");
-        assert_eq!(state_rev(&live), Some(2), "the store fanned out as a live State frame");
+        assert_eq!(
+            state_rev(&live),
+            Some(2),
+            "the store fanned out as a live State frame"
+        );
 
         drop(in_tx);
         task.await.unwrap().unwrap();
@@ -398,7 +417,12 @@ mod tests {
 
         let (in_tx, in_rx) = mpsc::channel(8);
         let (out_tx, mut out_rx) = mpsc::channel(8);
-        let task = tokio::spawn(run_session(in_rx, out_tx, substrate.clone(), ScriptedDispatcher::ok()));
+        let task = tokio::spawn(run_session(
+            in_rx,
+            out_tx,
+            substrate.clone(),
+            ScriptedDispatcher::ok(),
+        ));
 
         in_tx.send(subscribe(&["chat"])).await.unwrap();
         let _snapshot = out_rx.recv().await.expect("snapshot");
@@ -432,7 +456,12 @@ mod tests {
 
         let (in_tx, in_rx) = mpsc::channel(8);
         let (out_tx, mut out_rx) = mpsc::channel(8);
-        let task = tokio::spawn(run_session(in_rx, out_tx, substrate.clone(), ScriptedDispatcher::ok()));
+        let task = tokio::spawn(run_session(
+            in_rx,
+            out_tx,
+            substrate.clone(),
+            ScriptedDispatcher::ok(),
+        ));
 
         in_tx.send(subscribe(&["chat"])).await.unwrap();
         let _ = out_rx.recv().await.expect("chat snapshot");
@@ -472,7 +501,12 @@ mod tests {
 
         let (in_tx, in_rx) = mpsc::channel(8);
         let (out_tx, mut out_rx) = mpsc::channel(8);
-        let task = tokio::spawn(run_session(in_rx, out_tx, substrate.clone(), ScriptedDispatcher::ok()));
+        let task = tokio::spawn(run_session(
+            in_rx,
+            out_tx,
+            substrate.clone(),
+            ScriptedDispatcher::ok(),
+        ));
 
         in_tx
             .send(ClientMessage::Observe {
@@ -514,7 +548,12 @@ mod tests {
 
         let (in_tx, in_rx) = mpsc::channel(8);
         let (out_tx, mut out_rx) = mpsc::channel(8);
-        let task = tokio::spawn(run_session(in_rx, out_tx, substrate.clone(), Arc::clone(&dispatcher)));
+        let task = tokio::spawn(run_session(
+            in_rx,
+            out_tx,
+            substrate.clone(),
+            Arc::clone(&dispatcher),
+        ));
 
         let cid = Uuid::from_u128(0xbeef);
         in_tx
@@ -530,13 +569,20 @@ mod tests {
 
         let frame = out_rx.recv().await.expect("a frame");
         match frame {
-            ServerMessage::CommandFailed { correlation_id, error } => {
+            ServerMessage::CommandFailed {
+                correlation_id,
+                error,
+            } => {
                 assert_eq!(correlation_id, cid);
                 assert_eq!(error, "policy denied");
             }
             other => panic!("expected CommandFailed, got {other:?}"),
         }
-        assert_eq!(dispatcher.call_count(), 1, "the command reached the dispatcher");
+        assert_eq!(
+            dispatcher.call_count(),
+            1,
+            "the command reached the dispatcher"
+        );
 
         drop(in_tx);
         task.await.unwrap().unwrap();
@@ -555,7 +601,12 @@ mod tests {
 
         let (in_tx, in_rx) = mpsc::channel(8);
         let (out_tx, mut out_rx) = mpsc::channel(8);
-        let task = tokio::spawn(run_session(in_rx, out_tx, substrate.clone(), ScriptedDispatcher::ok()));
+        let task = tokio::spawn(run_session(
+            in_rx,
+            out_tx,
+            substrate.clone(),
+            ScriptedDispatcher::ok(),
+        ));
 
         // Reconnect already at revision 7 → snapshot skipped.
         in_tx

--- a/core/continuum-positron/src/state.rs
+++ b/core/continuum-positron/src/state.rs
@@ -115,11 +115,7 @@ impl StateBuilder {
     ///
     /// The kind is read from `payload.kind()` — the view's own `KIND`
     /// const — so it can never disagree with the payload type.
-    pub fn build<P: ViewState + Serialize>(
-        &self,
-        layer: StateLayer,
-        payload: P,
-    ) -> StateEnvelope {
+    pub fn build<P: ViewState + Serialize>(&self, layer: StateLayer, payload: P) -> StateEnvelope {
         // Read the kind from the payload itself (its `KIND` const)
         // before we consume `payload` into JSON. `kind()` is a
         // `&'static str`, which is exactly the key `Revisions` wants —

--- a/core/continuum-positron/src/substrate.rs
+++ b/core/continuum-positron/src/substrate.rs
@@ -103,10 +103,7 @@ mod tests {
         // always returns a Receiver; the value is wrapped in Option to
         // distinguish "no state yet" (None) from "state exists" (Some).
         let rx = substrate.broadcast().subscribe("chat");
-        let env = rx
-            .borrow()
-            .clone()
-            .expect("broadcast populated by store");
+        let env = rx.borrow().clone().expect("broadcast populated by store");
         assert_eq!(env.revision, Some(1));
     }
 

--- a/core/continuum-positron/src/wall.rs
+++ b/core/continuum-positron/src/wall.rs
@@ -62,7 +62,10 @@ use crate::chat::{Provenance, SenderKind};
 /// `post_id`, `room_id`, `author_id` are continuum's substrate UUIDs
 /// rendered as strings on the wire (the ts-rs default for `Uuid`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../protocol/typescript/positron/WallPostView.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/WallPostView.ts"
+)]
 pub struct WallPostView {
     /// Stable id across this post's supersede chain — the anchor a
     /// renderer keys a board row on. A revision generates a NEW
@@ -125,7 +128,10 @@ pub struct WallPostView {
 /// a stale merged entry — the same "full snapshot, replace not merge"
 /// discipline the chat roster uses for presence.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../protocol/typescript/positron/WallViewState.ts")]
+#[ts(
+    export,
+    export_to = "../../../protocol/typescript/positron/WallViewState.ts"
+)]
 pub struct WallViewState {
     #[ts(type = "string")]
     pub room_id: Uuid,
@@ -182,10 +188,7 @@ mod tests {
             author_id: Uuid::from_u128(2),
             author_name: "Asha".to_string(),
             author_kind: SenderKind::Agent,
-            integrations: BTreeMap::from([(
-                "continuum.persona".to_string(),
-                "asha".to_string(),
-            )]),
+            integrations: BTreeMap::from([("continuum.persona".to_string(), "asha".to_string())]),
             provenance: Provenance::unresolved(),
             body: "Always fail loud; never gate around a missing precondition.".to_string(),
             timestamp: 1_720_000_000_000,


### PR DESCRIPTION
Pure formatting cleanup — the `continuum-positron` crate had accumulated drift from the pinned rustfmt 1.9.0 (flagged in the #1759 review). Zero behavior change; 88 crate tests green. Keeps future feature diffs free of incidental fmt churn.

Mechanical (`cargo fmt` output, verified fmt-canonical) so no agent review needed — the diff is whitespace/attr-wrapping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)