### PR TITLE
feat(foundry-view): client foundry projection onto the pattern primitives (outlier B, client half)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "sdk/typescript",
         "packages/patterns",
         "packages/chat-view",
+        "packages/foundry-view",
         "apps/web",
         "apps/tui",
         "apps/desktop"
@@ -120,6 +121,10 @@
     },
     "node_modules/@continuum/desktop": {
       "resolved": "apps/desktop",
+      "link": true
+    },
+    "node_modules/@continuum/foundry-view": {
+      "resolved": "packages/foundry-view",
       "link": true
     },
     "node_modules/@continuum/patterns": {
@@ -4117,6 +4122,18 @@
     },
     "packages/chat-view": {
       "name": "@continuum/chat-view",
+      "version": "0.1.0",
+      "dependencies": {
+        "@continuum/patterns": "*",
+        "@continuum/sdk-typescript": "*"
+      },
+      "devDependencies": {
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "packages/foundry-view": {
+      "name": "@continuum/foundry-view",
       "version": "0.1.0",
       "dependencies": {
         "@continuum/patterns": "*",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "sdk/typescript",
     "packages/patterns",
     "packages/chat-view",
+    "packages/foundry-view",
     "apps/web",
     "apps/tui",
     "apps/desktop"
@@ -16,8 +17,8 @@
     "dev:desktop": "npm run dev -w @continuum/desktop",
     "build:clients": "npm run build -w @continuum/sdk-typescript && npm run build -w @continuum/web",
     "lint:clients": "eslint --max-warnings 0 packages apps/web apps/tui sdk/typescript",
-    "typecheck:clients": "npm run typecheck -w @continuum/sdk-typescript && npm run typecheck -w @continuum/chat-view && npm run typecheck -w @continuum/web && npm run typecheck -w @continuum/tui",
-    "test:clients": "npm test -w @continuum/sdk-typescript && npm test -w @continuum/chat-view && npm test -w @continuum/tui && npm test -w @continuum/web",
+    "typecheck:clients": "npm run typecheck -w @continuum/sdk-typescript && npm run typecheck -w @continuum/chat-view && npm run typecheck -w @continuum/foundry-view && npm run typecheck -w @continuum/web && npm run typecheck -w @continuum/tui",
+    "test:clients": "npm test -w @continuum/sdk-typescript && npm test -w @continuum/chat-view && npm test -w @continuum/foundry-view && npm test -w @continuum/tui && npm test -w @continuum/web",
     "check:clients": "npm run vendor:views:check -w @continuum/sdk-typescript && npm run lint:clients && npm run typecheck:clients && npm run test:clients",
     "stop": "bash tools/scripts/system-stop.sh",
     "install:continuum": "bash tools/scripts/install.sh",

--- a/packages/foundry-view/ForgeState.ts
+++ b/packages/foundry-view/ForgeState.ts
@@ -1,0 +1,41 @@
+/**
+ * `ForgeState` — a `ForgeViewState` payload lifted into a positron `ViewState`.
+ *
+ * Mirror of `@continuum/chat-view`'s `ChatState`: on the wire the `kind`/`revision`
+ * live on the `StateEnvelope`, not the payload, so a client merges them onto the
+ * `ForgeViewState` once at the seam where a `StateConnection` sink hands the
+ * envelope to a renderer. That merged object is `ForgeState`. Single-sourced here
+ * so the subscription and the render seam can't drift.
+ */
+
+import type { ForgeViewState, StateEnvelope } from '@continuum/sdk-typescript';
+
+/** A `ForgeViewState` carrying the envelope's `kind`/`revision` — the positron
+ *  `ViewState` shape a foundry renderer consumes. */
+export type ForgeState = ForgeViewState & {
+  readonly kind: string;
+  readonly revision?: number;
+};
+
+/** The wire `kind` string the foundry widget subscribes to and renders. Single-
+ *  sourced so the subscription and the render seam can't drift. */
+export const FOUNDRY_KIND = 'foundry';
+
+/**
+ * Lift a `foundry` `StateEnvelope` into a `ForgeState`. Fails loud on a kind
+ * mismatch — a `StateConnection` routes by kind, so a non-foundry envelope reaching
+ * here is a wiring bug, never something to coerce ([[fallbacks-are-illegal-fail-loud]]).
+ */
+export function forgeStateFromEnvelope(envelope: StateEnvelope): ForgeState {
+  if (envelope.kind !== FOUNDRY_KIND) {
+    throw new Error(
+      `forgeStateFromEnvelope: expected kind '${FOUNDRY_KIND}', got '${envelope.kind}'. ` +
+        'A non-foundry envelope reached the foundry merge seam — check the StateConnection routing.',
+    );
+  }
+  return {
+    ...(envelope.payload as ForgeViewState),
+    kind: envelope.kind,
+    revision: envelope.revision,
+  };
+}

--- a/packages/foundry-view/index.ts
+++ b/packages/foundry-view/index.ts
@@ -1,0 +1,16 @@
+/**
+ * `@continuum/foundry-view` — the shared, framework-free foundry projection.
+ *
+ * Mirror of `@continuum/chat-view` for the `foundry` widget kind: the
+ * envelope→state merge (`forgeStateFromEnvelope` / `FOUNDRY_KIND` / `ForgeState`)
+ * and the projections onto the consumer-neutral pattern primitives (the model
+ * `Listing`, the foundry `Content`/`ContextPanel`). Renderers live in the clients;
+ * this package holds NO transport, NO DOM, NO ANSI — only the wire decode +
+ * projection, typed against `@continuum/sdk-typescript` and `@continuum/patterns`.
+ */
+
+export { FOUNDRY_KIND, forgeStateFromEnvelope } from './ForgeState';
+export type { ForgeState } from './ForgeState';
+
+export { modelsListing, foundryContextPanel, foundryContent } from './patternProjections';
+export type { ForgeContentBody } from './patternProjections';

--- a/packages/foundry-view/package.json
+++ b/packages/foundry-view/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@continuum/foundry-view",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared foundry projection for Continuum clients — the framework-free decode + projections that turn a positron foundry StateEnvelope (kind=\"foundry\", ForgeViewState) into the consumer-neutral pattern primitives (the model Listing, foundry Content/ContextPanel). Mirror of @continuum/chat-view; consumed by apps/web, apps/tui, and the persona RAG renderer. Holds NO transport, NO DOM, NO ANSI.",
+  "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@continuum/patterns": "*",
+    "@continuum/sdk-typescript": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/foundry-view/patternProjections.spec.ts
+++ b/packages/foundry-view/patternProjections.spec.ts
@@ -9,12 +9,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { ForgeState } from './ForgeState';
-import {
-  modelsListing,
-  foundryContextPanel,
-  foundryContent,
-  type ForgeContentBody,
-} from './patternProjections';
+import { modelsListing, foundryContextPanel, foundryContent } from './patternProjections';
 
 const state: ForgeState = {
   kind: 'foundry',
@@ -62,7 +57,9 @@ describe('foundry → pattern projections', () => {
   it('keys Content by the room purpose', () => {
     const content = foundryContent(state);
     expect(content.purpose).toBe('foundry');
-    const body = content.body as ForgeContentBody;
-    expect(body.models).toHaveLength(2);
+    // `foundryContent` returns `ContentView<ForgeContentBody>`, so `body` is already
+    // typed — no cast needed (unlike the chat spec, where the body is opaque at the
+    // `WorkspaceView` boundary).
+    expect(content.body.models).toHaveLength(2);
   });
 });

--- a/packages/foundry-view/patternProjections.spec.ts
+++ b/packages/foundry-view/patternProjections.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Foundry → pattern-primitive projection tests.
+ *
+ * Proves the foundry activity expresses itself on the consumer-neutral primitives
+ * (ACTIVITY-ROOM-PATTERNS.md outlier B): the model catalogue is a `Listing`, that
+ * Listing is the foundry `ContextPanel`, and `Content` is keyed by the room's
+ * `purpose`. Projections take `ForgeState`, so these fixtures need no live wiring.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ForgeState } from './ForgeState';
+import {
+  modelsListing,
+  foundryContextPanel,
+  foundryContent,
+  type ForgeContentBody,
+} from './patternProjections';
+
+const state: ForgeState = {
+  kind: 'foundry',
+  revision: 1,
+  room_id: 'room-f',
+  room_name: 'foundry',
+  purpose: 'foundry',
+  models: [
+    { model_id: 'Qwen/Qwen3-4B', display_name: 'Qwen3 4B', source: 'huggingface', params_b: 4 },
+    { model_id: 'local/asha', display_name: 'Asha', source: 'local' }, // params_b absent = unknown
+  ],
+};
+
+describe('foundry → pattern projections', () => {
+  // what this catches: the catalogue projects to the model `Listing` — id/name carry
+  // through, the subtitle labels params+source when known, and an unknown param count
+  // (absent) yields just the source, never a fabricated "0B".
+  it('projects the catalogue into the model Listing', () => {
+    const l = modelsListing(state);
+    expect(l.id).toBe('models');
+    expect(l.title).toBe('Models');
+    expect(l.cells).toHaveLength(2);
+    const [qwen, asha] = l.cells;
+    expect(qwen).toMatchObject({
+      id: 'Qwen/Qwen3-4B',
+      title: 'Qwen3 4B',
+      subtitle: '4B · huggingface',
+      badges: ['huggingface'],
+    });
+    expect(asha?.subtitle).toBe('local');
+  });
+
+  // what this catches: the model Listing is the foundry ContextPanel (the right-hand
+  // list), not bespoke — the same primitive chat uses for its context.
+  it('puts the model Listing in the ContextPanel', () => {
+    const ctx = foundryContextPanel(state);
+    expect(ctx.listings).toHaveLength(1);
+    expect(ctx.listings[0]?.id).toBe('models');
+  });
+
+  // what this catches: Content is keyed by the room's purpose ("foundry"), so a
+  // target's Content registry dispatches on it — the same dispatch chat uses, a
+  // different body. Foundry renders on the SAME shell as chat, only Content/Context
+  // differ.
+  it('keys Content by the room purpose', () => {
+    const content = foundryContent(state);
+    expect(content.purpose).toBe('foundry');
+    const body = content.body as ForgeContentBody;
+    expect(body.models).toHaveLength(2);
+  });
+});

--- a/packages/foundry-view/patternProjections.ts
+++ b/packages/foundry-view/patternProjections.ts
@@ -1,0 +1,67 @@
+/**
+ * Foundry → pattern-primitive projections.
+ *
+ * The client half of foundry as outlier B (ACTIVITY-ROOM-PATTERNS.md): a
+ * `ForgeViewState` (kind="foundry") projected onto the consumer-neutral primitives
+ * (`@continuum/patterns`), exactly as `@continuum/chat-view` does for chat. The
+ * foundry room's model catalogue is the **model `Listing`** (the "HF model list on
+ * the right" — a `ContextPanel`), and its `Content` is keyed by the room's
+ * `purpose`. Same primitives as chat, different data → the same rows render on any
+ * `RenderTarget` (web, terminal, or a persona's grounding).
+ */
+
+import type {
+  ListingView,
+  ListingCell,
+  ContentView,
+  ContextPanelView,
+} from '@continuum/patterns';
+import type { ForgeModelView } from '@continuum/sdk-typescript';
+import type { ForgeState } from './ForgeState';
+
+/** One catalogue model → a `Listing` cell. The projection resolves the display
+ *  fields (subtitle from params + source); a target only draws them. */
+function modelCell(m: ForgeModelView): ListingCell {
+  // `params_b` is optional (0-is-unknown → absent, honest); label with it when known.
+  const subtitle = m.params_b != null ? `${m.params_b}B · ${m.source}` : m.source;
+  return {
+    id: m.model_id,
+    title: m.display_name,
+    subtitle,
+    badges: [m.source],
+    status: 'none',
+  };
+}
+
+/** The foundry model catalogue projected as the `Listing` primitive — the same
+ *  primitive the chat roster and rooms list use, different data. This is the
+ *  workbench's right-hand context list. */
+export function modelsListing(state: ForgeState): ListingView {
+  return {
+    id: 'models',
+    title: 'Models',
+    cells: state.models.map(modelCell),
+  };
+}
+
+/** The foundry `ContextPanel` — today the model `Listing`; recipe/run widgets join
+ *  it additively. */
+export function foundryContextPanel(state: ForgeState): ContextPanelView {
+  return { listings: [modelsListing(state)] };
+}
+
+/** The foundry activity's `Content` body. `Content` is keyed by the room's
+ *  `purpose` ("foundry"), so a target's registered foundry renderer draws it. Today
+ *  the body is the model set (the config/recipe centre widgets grow it additively);
+ *  a chat room would carry a different purpose + body with no shell change. */
+export interface ForgeContentBody {
+  readonly models: readonly ForgeModelView[];
+}
+
+/** The foundry room's `Content`, dispatched by `purpose`. */
+export function foundryContent(state: ForgeState): ContentView<ForgeContentBody> {
+  return {
+    purpose: state.purpose,
+    body: { models: state.models },
+  };
+}

--- a/packages/foundry-view/tsconfig.json
+++ b/packages/foundry-view/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "//": "Typecheck config for @continuum/chat-view. Mirrors the SDK's strict contract; compiles against the SDK source (@continuum/sdk-typescript resolves to ./index.ts, no build step). This package is framework-free and platform-neutral, so NO DOM lib — it must typecheck the same under a browser bundler (apps/web) and under Node (apps/tui). tsc is --noEmit typecheck only; each consumer's bundler/runtime owns transpilation.",
+  "//": "Typecheck config for @continuum/foundry-view. Mirrors the SDK's strict contract; compiles against the SDK source (@continuum/sdk-typescript resolves to ./index.ts, no build step). This package is framework-free and platform-neutral, so NO DOM lib — it must typecheck the same under a browser bundler (apps/web) and under Node (apps/tui). tsc is --noEmit typecheck only; each consumer's bundler/runtime owns transpilation.",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",

--- a/packages/foundry-view/tsconfig.json
+++ b/packages/foundry-view/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "//": "Typecheck config for @continuum/chat-view. Mirrors the SDK's strict contract; compiles against the SDK source (@continuum/sdk-typescript resolves to ./index.ts, no build step). This package is framework-free and platform-neutral, so NO DOM lib — it must typecheck the same under a browser bundler (apps/web) and under Node (apps/tui). tsc is --noEmit typecheck only; each consumer's bundler/runtime owns transpilation.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
`@continuum/foundry-view` — the client half of foundry, mirroring `@continuum/chat-view` for kind="foundry" (unblocked by #80's Forge vendoring).

- `ForgeState` + `forgeStateFromEnvelope`/`FOUNDRY_KIND` (fail-loud on kind mismatch).
- `modelsListing` — the model catalogue as the `Listing` primitive (honest params subtitle).
- `foundryContextPanel` — the model Listing as the right-hand context.
- `foundryContent` — foundry `Content` keyed by `purpose` so a target's registry dispatches on it.

Proves foundry renders on the SAME primitives/shell as chat — only Content + Context differ. Framework-free; 3 tests; wired into the clients gate (green).

Next to go live: #6 (structured purpose) + ModelCatalog watch→publish, then web/tui RenderTargets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)