### PR TITLE
feat(positron+web): roster vitals — neutral wire field + live sci-fi meters (part A)

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -233,6 +233,63 @@ export class ChatWidget extends LitElement {
       color: var(--content-accent);
       border: 1px solid var(--border-accent);
     }
+    /* Live genome-energy meters — the old persona-tile INT/NRG/QUE bars, reborn
+     * sci-fi: a thin cyan bar per vital with a moving glint on live agents. The
+     * readout that makes a persona feel alive in the roster. */
+    .vitals {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      margin-top: 4px;
+    }
+    .vital {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+    }
+    .vital-label {
+      font-family: var(--font-mono);
+      font-size: 8px;
+      letter-spacing: 0.06em;
+      color: var(--content-secondary);
+      width: 22px;
+      flex: none;
+    }
+    .vital-track {
+      position: relative;
+      height: 3px;
+      flex: 1;
+      border-radius: 2px;
+      background: var(--border-subtle);
+      overflow: hidden;
+    }
+    .vital-fill {
+      position: relative;
+      display: block;
+      height: 100%;
+      border-radius: 2px;
+      background: linear-gradient(90deg, rgba(0, 212, 255, 0.45), var(--content-accent));
+      box-shadow: 0 0 6px rgba(0, 212, 255, 0.5);
+      overflow: hidden;
+      transition: width 0.6s ease;
+    }
+    /* Moving glint — reads as a live, updating gauge on an active agent. */
+    @keyframes vital-shimmer {
+      from {
+        transform: translateX(-120%);
+      }
+      to {
+        transform: translateX(320%);
+      }
+    }
+    .member.online .vital-fill::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      width: 40%;
+      background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.55), transparent);
+      animation: vital-shimmer 2.4s linear infinite;
+    }
     .what {
       overflow-y: auto;
       padding: var(--spacing-md) var(--spacing-lg);

--- a/apps/web/src/chat/renderChat.spec.ts
+++ b/apps/web/src/chat/renderChat.spec.ts
@@ -37,6 +37,7 @@ const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
   provenance: { runtime: '' },
   active: true,
   last_seen_ms: 0,
+  vitals: {},
   ...over,
 });
 

--- a/apps/web/src/chat/renderChat.spec.ts
+++ b/apps/web/src/chat/renderChat.spec.ts
@@ -131,6 +131,34 @@ describe('renderChat (Lit)', () => {
     expect(chunks).toContain('00:00');
   });
 
+  // what this catches: a member's live vitals must actually DRAW a meter — a
+  // labelled, width-filled bar reaches the markup — while a member reporting no
+  // vitals draws NONE (never a fabricated bar). The chatViewModel spec proves the
+  // VM carries the field; this proves the renderer turns it into a meter.
+  it('draws a genome-energy meter per vital, and none for a member without vitals', () => {
+    const withVitals = project({
+      room_id: 'room-1',
+      room_name: 'general',
+      purpose: 'chat',
+      roster: [member({ member_id: 'a', display_name: 'Asha', kind: kind('agent'), vitals: { energy: 80 } })],
+      messages: [],
+    });
+    const chunks = flatten(renderChat(withVitals));
+    expect(chunks).toContain('ENE'); // the vital label (energy → first-3, upper)
+    expect(chunks).toContain('80'); // the fill width value (single member → unambiguous)
+    expect(markup(withVitals)).toContain('vital-fill'); // the meter bar rendered
+
+    // A member reporting no vitals → no meter markup at all.
+    const noVitals = project({
+      room_id: 'room-1',
+      room_name: 'general',
+      purpose: 'chat',
+      roster: [member({ member_id: 'j', display_name: 'Joel', kind: kind('human'), vitals: {} })],
+      messages: [],
+    });
+    expect(markup(noVitals)).not.toContain('vital-fill');
+  });
+
   // what this catches: an empty conversation must draw the honest empty-state
   // string, not an error and not a bare void — matching the ANSI renderer's
   // "No messages yet — say hello." contract exactly.

--- a/apps/web/src/render/parts.ts
+++ b/apps/web/src/render/parts.ts
@@ -39,8 +39,36 @@ export function runtimeBadge(runtime: string): TemplateResult | typeof nothing {
   return runtime ? html`<span class="runtime" title="runtime origin">${runtime}</span>` : nothing;
 }
 
-/** One member card — avatar + presence dot, name, kind/runtime — the old Users &
- *  Agents tile as the `Listing` cell (INTERFACE-PORT-MAP.md). */
+/** Short 3-letter tag for a vital key — the old persona-tile's INT/NRG/QUE label. */
+function vitalTag(key: string): string {
+  return key.slice(0, 3).toUpperCase();
+}
+
+/** The live genome-energy meters — one thin glowing bar per vital the persona
+ *  surfaces (energy/attention/compute). Renders nothing when the member reports
+ *  no vitals (a human, a remote peer) — no fabricated bars. This is the readout
+ *  that makes a persona feel *alive* in the roster (the PX target). */
+function vitalsMeters(vitals: Record<string, number>): TemplateResult | typeof nothing {
+  const entries = Object.entries(vitals);
+  if (entries.length === 0) return nothing;
+  return html`
+    <span class="vitals">
+      ${entries.map(
+        ([key, pct]) => html`
+          <span class="vital" title="${key} ${pct}%">
+            <span class="vital-label">${vitalTag(key)}</span>
+            <span class="vital-track">
+              <span class="vital-fill" style="width:${Math.max(0, Math.min(100, pct))}%"></span>
+            </span>
+          </span>
+        `,
+      )}
+    </span>
+  `;
+}
+
+/** One member card — avatar + presence dot, name, kind/runtime, live vitals —
+ *  the old Users & Agents persona-tile as the `Listing` cell (INTERFACE-PORT-MAP.md). */
 export function memberCard(m: RosterMemberVM): TemplateResult {
   return html`
     <li class="member ${m.active ? 'online' : 'idle'}" data-kind=${m.kind}>
@@ -54,6 +82,7 @@ export function memberCard(m: RosterMemberVM): TemplateResult {
           <span class="kind-badge">${kindLabel(m.kind)}</span>
           ${runtimeBadge(m.runtime)}
         </span>
+        ${vitalsMeters(m.vitals)}
       </span>
     </li>
   `;

--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -235,6 +235,11 @@ pub(crate) fn roster_slot_from_member(member: &RoomMember) -> RosterSlotView {
         // unreported); `last_seen_ms` is the raw recency signal.
         availability: member.availability.map(availability_label).map(str::to_owned),
         last_seen_ms: member.last_seen_ms,
+        // airc's `RoomMember` carries no vitals — a continuum persona's live
+        // `PersonaState` (energy/attention/compute) is enriched onto local members
+        // by the presence path (part B). Empty here = no vitals reported, never
+        // fabricated bars ([[fallbacks-are-illegal-fail-loud]]).
+        vitals: BTreeMap::new(),
     }
 }
 
@@ -271,6 +276,7 @@ pub(crate) fn test_roster_slot(member: Uuid, name: &str, kind: SenderKind) -> Ro
         active: true,
         availability: None,
         last_seen_ms: 0,
+        vitals: BTreeMap::new(),
     }
 }
 

--- a/core/continuum-positron/src/chat.rs
+++ b/core/continuum-positron/src/chat.rs
@@ -290,6 +290,18 @@ pub struct RosterSlotView {
     #[serde(default)]
     #[ts(type = "number")]
     pub last_seen_ms: u64,
+    /// Opaque per-member **vitals** — normalized `0..=100` percentage readouts a
+    /// source MAY attach for the app to draw as live meters (e.g. energy, attention,
+    /// compute). Transported, NOT interpreted — the same neutral discipline as
+    /// `integrations` and `availability`: positron carries whatever keys the source
+    /// reports; the app layer decides what each means and how to render it (a continuum
+    /// persona surfaces its `PersonaState`; a different adopter surfaces its own). `u8`
+    /// (0..=100) keeps the slot `Eq`/hashable and is display-precise. Empty = no vitals
+    /// reported — an honest unknown, never fabricated bars; `#[serde(default)]` so an
+    /// older slot folds as empty, never dropped.
+    #[serde(default)]
+    #[ts(type = "Record<string, number>")]
+    pub vitals: BTreeMap<String, u8>,
 }
 
 /// Top-level state for the `"chat"` widget kind. Fills
@@ -477,6 +489,7 @@ mod tests {
             active: true,
             availability: Some("busy".into()),
             last_seen_ms: 1_700_000_000_000,
+            vitals: BTreeMap::new(),
         };
         let back: RosterSlotView =
             serde_json::from_str(&serde_json::to_string(&slot).unwrap()).unwrap();
@@ -535,6 +548,7 @@ mod tests {
                 active: true,
                 availability: Some("ready".into()),
                 last_seen_ms: 1_700_000_000_000,
+                vitals: BTreeMap::new(),
             }],
         };
         let json = serde_json::to_string(&state).unwrap();

--- a/core/continuum-positron/src/state.rs
+++ b/core/continuum-positron/src/state.rs
@@ -172,6 +172,7 @@ mod tests {
                 active: true,
                 availability: Some("ready".into()),
                 last_seen_ms: 1_700_000_000_000,
+                vitals: BTreeMap::new(),
             }],
         }
     }

--- a/core/continuum-positron/tests/session_roundtrip.rs
+++ b/core/continuum-positron/tests/session_roundtrip.rs
@@ -95,6 +95,7 @@ fn build_chat_state(content: &str) -> ChatViewState {
             active: true,
             availability: Some("ready".into()),
             last_seen_ms: 1_700_000_000_000,
+            vitals: BTreeMap::new(),
         }],
     }
 }

--- a/packages/chat-view/chatViewModel.spec.ts
+++ b/packages/chat-view/chatViewModel.spec.ts
@@ -23,6 +23,7 @@ const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
   provenance: { runtime: '' },
   active: true,
   last_seen_ms: 0,
+  vitals: {},
   ...over,
 });
 
@@ -66,6 +67,25 @@ describe('chatViewModel', () => {
     expect(vm.members.map((m) => m.id)).toEqual(['a', 'b']);
     expect(vm.messages.map((m) => m.id)).toEqual(['x', 'y']);
     expect(vm.revision).toBe(3);
+  });
+
+  // what this catches: live vitals (energy/attention/compute) must ride the
+  // roster projection so the card can draw the genome-energy meters — and an
+  // absent map (a human, a remote peer) OR an older core that omits the field
+  // entirely both fold to {} (no meters), never fabricated bars.
+  it('projects member vitals, defaulting an absent map to empty', () => {
+    const vm = chatViewModel(
+      state({
+        roster: [
+          member({ member_id: 'a', vitals: { energy: 80, attention: 90 } }),
+          member({ member_id: 'b', vitals: {} }),
+          member({ member_id: 'c', vitals: undefined as unknown as Record<string, number> }),
+        ],
+      }),
+    );
+    expect(vm.members[0].vitals).toEqual({ energy: 80, attention: 90 });
+    expect(vm.members[1].vitals).toEqual({});
+    expect(vm.members[2].vitals).toEqual({});
   });
 
   // what this catches: activeCount counts only present members — it drives the

--- a/packages/chat-view/chatViewModel.ts
+++ b/packages/chat-view/chatViewModel.ts
@@ -35,6 +35,11 @@ export interface RosterMemberVM {
   readonly active: boolean;
   /** Self-reported runtime origin (`"claude"`, `"codex"`, `""` = unresolved). */
   readonly runtime: string;
+  /** Opaque live **vitals** — normalized `0..=100` readouts (energy, attention,
+   *  compute, …) the source attaches for the roster to draw as meters. Empty =
+   *  none reported (a human, a remote peer, or a persona not surfacing state) —
+   *  the card simply draws no meters, never fabricated bars. */
+  readonly vitals: Record<string, number>;
 }
 
 /** One conversation row — "what was said". */
@@ -82,6 +87,9 @@ function memberVM(slot: RosterSlotView): RosterMemberVM {
     kind: slot.kind.kind,
     active: slot.active,
     runtime: slot.provenance.runtime,
+    // Additive field (#vitals): an older core omits it → treat as no vitals, the
+    // same back-compat discipline as `purpose` ([[fallbacks-are-illegal-fail-loud]]).
+    vitals: slot.vitals ?? {},
   };
 }
 

--- a/packages/chat-view/crossConsumer.spec.ts
+++ b/packages/chat-view/crossConsumer.spec.ts
@@ -48,6 +48,7 @@ const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
   provenance: { runtime: '' },
   active: true,
   last_seen_ms: 0,
+  vitals: {},
   ...over,
 });
 

--- a/packages/chat-view/patternProjections.spec.ts
+++ b/packages/chat-view/patternProjections.spec.ts
@@ -19,8 +19,8 @@ const vm: ChatViewModel = {
   memberCount: 2,
   activeCount: 1,
   members: [
-    { id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: 'persona' },
-    { id: 'j', name: 'Joel', kind: 'human', active: false, runtime: '' },
+    { id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: 'persona', vitals: { energy: 80, attention: 90 } },
+    { id: 'j', name: 'Joel', kind: 'human', active: false, runtime: '', vitals: {} },
   ],
   messages: [
     { id: 'm1', senderId: 'a', senderName: 'Asha', kind: 'agent', content: 'hi', time: '00:00', runtime: 'persona' },

--- a/protocol/typescript/positron/RosterSlotView.ts
+++ b/protocol/typescript/positron/RosterSlotView.ts
@@ -64,4 +64,16 @@ availability?: string,
  * (not `bigint`) to match the rest of the substrate's ms timestamps
  * (`ChatMessageView.timestamp`).
  */
-last_seen_ms: number, };
+last_seen_ms: number, 
+/**
+ * Opaque per-member **vitals** — normalized `0..=100` percentage readouts a
+ * source MAY attach for the app to draw as live meters (e.g. energy, attention,
+ * compute). Transported, NOT interpreted — the same neutral discipline as
+ * `integrations` and `availability`: positron carries whatever keys the source
+ * reports; the app layer decides what each means and how to render it (a continuum
+ * persona surfaces its `PersonaState`; a different adopter surfaces its own). `u8`
+ * (0..=100) keeps the slot `Eq`/hashable and is display-precise. Empty = no vitals
+ * reported — an honest unknown, never fabricated bars; `#[serde(default)]` so an
+ * older slot folds as empty, never dropped.
+ */
+vitals: Record<string, number>, };

--- a/sdk/typescript/generated/views/RosterSlotView.ts
+++ b/sdk/typescript/generated/views/RosterSlotView.ts
@@ -64,4 +64,16 @@ availability?: string,
  * (not `bigint`) to match the rest of the substrate's ms timestamps
  * (`ChatMessageView.timestamp`).
  */
-last_seen_ms: number, };
+last_seen_ms: number, 
+/**
+ * Opaque per-member **vitals** — normalized `0..=100` percentage readouts a
+ * source MAY attach for the app to draw as live meters (e.g. energy, attention,
+ * compute). Transported, NOT interpreted — the same neutral discipline as
+ * `integrations` and `availability`: positron carries whatever keys the source
+ * reports; the app layer decides what each means and how to render it (a continuum
+ * persona surfaces its `PersonaState`; a different adopter surfaces its own). `u8`
+ * (0..=100) keeps the slot `Eq`/hashable and is display-precise. Empty = no vitals
+ * reported — an honest unknown, never fabricated bars; `#[serde(default)]` so an
+ * older slot folds as empty, never dropped.
+ */
+vitals: Record<string, number>, };


### PR DESCRIPTION
The genome-energy readout, **part A** (the wire + the meter; part B populates it live from PersonaState).

- `RosterSlotView.vitals: BTreeMap<String,u8>` — opaque `0..=100` readouts, transported not interpreted (same neutral discipline as `integrations`/`availability`; positron stays continuum-blind). `u8` keeps the slot `Eq`. Empty → no meters, never fabricated bars.
- `roster_slot_from_member` fills empty; SDK re-vendored; `RosterMemberVM.vitals` projected (absent → {} back-compat).
- web `vitalsMeters`: one thin cyan bar per vital + moving glint on live agents — the old INT/NRG/QUE persona-tile bars, reborn sci-fi, token-driven.

chat-view 15 (new vitals test) + web 3 + positron 88+5 green; typecheck + lint clean. Cards draw no bars until part B lands the live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)