### PR TITLE
feat(positron): fold persona:vitals into the roster (design B, projection half)

### DIFF
--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -68,7 +68,7 @@
 //! — the revision key would extend from the bare kind string to a
 //! `(room_id, kind)` tuple (see `continuum-positron/src/revisions.rs`).
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -170,6 +170,26 @@ pub(crate) struct AircPresenceUpdate {
     pub(crate) room_id: Uuid,
     pub(crate) room_name: String,
     pub(crate) roster: Vec<RosterSlotView>,
+}
+
+/// Event name a persona radiates its live vitals under.
+pub(crate) const PERSONA_VITALS: &str = "persona:vitals";
+
+/// Typed `persona:vitals` payload — one persona's live cognition readouts.
+///
+/// Design B of the roster-vitals build: a persona **radiates** its own
+/// `PersonaState` (energy/attention/compute, normalized `0..=100`) on the bus,
+/// and this projection **folds** it into that member's [`RosterSlotView::vitals`]
+/// by id — the same emit/subscribe organism messages + presence already use, so
+/// the persona-agnostic presence emitter never learns about personas. `member_id`
+/// is the persona's airc peer id, matching the roster slot it enriches. Same
+/// `pub(crate)` + `Serialize` "agree by construction" discipline as
+/// [`AircPresenceUpdate`]: the emitter builds THIS struct, never a hand JSON.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PersonaVitalsUpdate {
+    pub(crate) member_id: Uuid,
+    pub(crate) vitals: BTreeMap<String, u8>,
 }
 
 /// airc's `AgentAvailabilityState` → its stable neutral wire label — airc's
@@ -349,6 +369,12 @@ struct ChatProjection {
     /// `ChatViewState.messages` is documented to carry).
     messages: VecDeque<ChatMessageView>,
     roster: Vec<RosterSlotView>,
+    /// Latest live vitals per member id, folded from `persona:vitals` events
+    /// (design B). Kept SEPARATE from the presence roster — presence replaces
+    /// the roster wholesale on every update, so vitals live here and are merged
+    /// into each slot at `store` time, surviving roster churn. A member with no
+    /// entry simply has empty vitals (no meter), never a fabricated one.
+    vitals: HashMap<Uuid, BTreeMap<String, u8>>,
 }
 
 impl ChatProjection {
@@ -363,6 +389,7 @@ impl ChatProjection {
             room_name: String::new(),
             messages: VecDeque::new(),
             roster: Vec::new(),
+            vitals: HashMap::new(),
         }
     }
 
@@ -378,7 +405,19 @@ impl ChatProjection {
             self.room_name.clear();
             self.messages.clear();
             self.roster.clear();
+            self.vitals.clear();
         }
+    }
+
+    /// Fold a persona's radiated vitals into the per-member map and re-store.
+    /// The values are merged into the roster at `store` time (they outlive any
+    /// single presence snapshot), so a persona breathing its energy updates the
+    /// widget without touching the neutral presence path. A member that left the
+    /// roster keeps no bearing here — `store` only merges vitals for members the
+    /// current roster still lists.
+    fn apply_vitals(&mut self, update: PersonaVitalsUpdate) {
+        self.vitals.insert(update.member_id, update.vitals);
+        self.store();
     }
 
     /// Fold a posted message into the view and store the new snapshot.
@@ -447,6 +486,21 @@ impl ChatProjection {
         let Some(room_id) = self.room_id else {
             return;
         };
+        // Merge each member's latest radiated vitals into its neutral slot
+        // (design B fold): presence owns the roster shape; vitals are the live
+        // cognition overlay keyed by id. A member with no vitals entry keeps the
+        // slot's empty map — no fabricated bars.
+        let roster: Vec<RosterSlotView> = self
+            .roster
+            .iter()
+            .map(|slot| match self.vitals.get(&slot.member_id) {
+                Some(v) => RosterSlotView {
+                    vitals: v.clone(),
+                    ..slot.clone()
+                },
+                None => slot.clone(),
+            })
+            .collect();
         let view = ChatViewState {
             room_id,
             room_name: self.room_name.clone(),
@@ -456,7 +510,7 @@ impl ChatProjection {
             // Content primitive dispatches on it (ACTIVITY-ROOM-PATTERNS.md).
             purpose: "chat".to_string(),
             messages: self.messages.iter().cloned().collect(),
-            roster: self.roster.clone(),
+            roster,
         };
         self.substrate
             .store(self.builder.session(view));
@@ -469,6 +523,7 @@ impl ChatProjection {
 enum ProjectionInput {
     Message(AircChatPosted),
     Presence(AircPresenceUpdate),
+    Vitals(PersonaVitalsUpdate),
 }
 
 fn classify(name: &str, payload: &serde_json::Value) -> Option<ProjectionInput> {
@@ -483,6 +538,9 @@ fn classify(name: &str, payload: &serde_json::Value) -> Option<ProjectionInput> 
         PRESENCE_UPDATED => serde_json::from_value::<AircPresenceUpdate>(body.clone())
             .ok()
             .map(ProjectionInput::Presence),
+        PERSONA_VITALS => serde_json::from_value::<PersonaVitalsUpdate>(body.clone())
+            .ok()
+            .map(ProjectionInput::Vitals),
         _ => None,
     }
 }
@@ -512,6 +570,7 @@ pub fn spawn(rt: &tokio::runtime::Handle, bus: Arc<MessageBus>, substrate: Subst
                         match input {
                             ProjectionInput::Message(m) => projection.apply_message(m),
                             ProjectionInput::Presence(p) => projection.apply_presence(p),
+                            ProjectionInput::Vitals(v) => projection.apply_vitals(v),
                         }
                     }
                 }
@@ -608,6 +667,53 @@ mod tests {
             view.messages[0].sender_name
         );
         assert!(view.messages[0].integrations.is_empty());
+    }
+
+    #[test]
+    fn persona_vitals_fold_into_the_member_slot_and_survive_presence() {
+        // what this catches: design B's fold — a persona:vitals event must merge
+        // its readouts into that member's roster slot BY ID, and (because vitals
+        // live in their own map, not the presence roster) a later presence
+        // snapshot that REPLACES the roster must not drop them. A member with no
+        // vitals event keeps an empty map — no fabricated bars.
+        let substrate = Substrate::new();
+        let mut p = ChatProjection::new(substrate.clone());
+        let room = Uuid::from_u128(0xa);
+        let asha = Uuid::from_u128(0xb);
+
+        // Roster arrives first — no vitals yet.
+        match classify(PRESENCE_UPDATED, &presence_one(room, asha, "Asha", "agent", json!({}))).unwrap()
+        {
+            ProjectionInput::Presence(u) => p.apply_presence(u),
+            _ => panic!("presence:updated must classify as Presence"),
+        }
+        assert!(current_chat(&substrate).roster[0].vitals.is_empty(), "no vitals before any radiate");
+
+        // Asha radiates her vitals.
+        let radiated = serde_json::to_value(PersonaVitalsUpdate {
+            member_id: asha,
+            vitals: BTreeMap::from([("energy".to_string(), 80u8), ("attention".to_string(), 90u8)]),
+        })
+        .unwrap();
+        match classify(PERSONA_VITALS, &radiated).unwrap() {
+            ProjectionInput::Vitals(v) => p.apply_vitals(v),
+            _ => panic!("persona:vitals must classify as Vitals"),
+        }
+        let slot = current_chat(&substrate).roster.remove(0);
+        assert_eq!(slot.vitals.get("energy"), Some(&80));
+        assert_eq!(slot.vitals.get("attention"), Some(&90));
+
+        // A fresh presence snapshot replaces the roster wholesale — vitals stay.
+        match classify(PRESENCE_UPDATED, &presence_one(room, asha, "Asha", "agent", json!({}))).unwrap()
+        {
+            ProjectionInput::Presence(u) => p.apply_presence(u),
+            _ => panic!("presence:updated must classify as Presence"),
+        }
+        assert_eq!(
+            current_chat(&substrate).roster[0].vitals.get("energy"),
+            Some(&80),
+            "vitals survive a roster refresh (they are keyed by id, not carried on presence)"
+        );
     }
 
     #[test]

--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -26,7 +26,7 @@
 //!
 //! ## Which airc streams map to `kind="chat"`
 //!
-//! Two bus streams fold onto the single existing `ChatViewState::KIND`, and
+//! Three bus streams fold onto the single existing `ChatViewState::KIND`, and
 //! the split between them mirrors airc's own message/identity split:
 //!
 //! - **`chat:posted`** — a posted message. Deserialized into the **thin**
@@ -37,6 +37,11 @@
 //!   [`AircPresenceUpdate`], each entry an airc member joined with its
 //!   identity card (neutral `kind` + opaque `integrations`), replacing
 //!   the room's roster. This is the identity lookup table for messages.
+//! - **`persona:vitals`** — a persona radiated its live cognition readouts.
+//!   Deserialized into [`PersonaVitalsUpdate`] and folded into that member's
+//!   [`RosterSlotView::vitals`] by id — a thin overlay kept in its own map so
+//!   it survives a roster-replacing presence snapshot (personas emit, this
+//!   projection folds; the presence emitter stays persona-agnostic).
 //!
 //! Wall / coordination / kanban / widget state (task #89) are *different*
 //! kinds and are deliberately out of scope here — they get their own
@@ -256,9 +261,11 @@ pub(crate) fn roster_slot_from_member(member: &RoomMember) -> RosterSlotView {
         availability: member.availability.map(availability_label).map(str::to_owned),
         last_seen_ms: member.last_seen_ms,
         // airc's `RoomMember` carries no vitals — a continuum persona's live
-        // `PersonaState` (energy/attention/compute) is enriched onto local members
-        // by the presence path (part B). Empty here = no vitals reported, never
-        // fabricated bars ([[fallbacks-are-illegal-fail-loud]]).
+        // `PersonaState` (energy/attention/compute) arrives on its OWN
+        // `persona:vitals` event and is folded into the slot by id at `store`
+        // time (see [`PersonaVitalsUpdate`] / [`ChatProjection::apply_vitals`]),
+        // never through this presence path. Empty here = no vitals reported,
+        // never fabricated bars ([[fallbacks-are-illegal-fail-loud]]).
         vitals: BTreeMap::new(),
     }
 }
@@ -935,6 +942,45 @@ mod tests {
         assert_eq!(view.room_id, room_b);
         assert_eq!(view.messages.len(), 1, "room A's message was cleared");
         assert_eq!(view.messages[0].content, "b");
+    }
+
+    #[test]
+    fn switching_rooms_clears_vitals() {
+        // what this catches: switch_room must clear the per-member vitals map,
+        // or a member with the SAME id in a new room would inherit the prior
+        // room's meters — a cross-room leak. The vitals twin of
+        // switching_rooms_resets_the_accumulator.
+        let substrate = Substrate::new();
+        let mut p = ChatProjection::new(substrate.clone());
+        let room_a = Uuid::from_u128(0xa);
+        let room_b = Uuid::from_u128(0xf);
+        let m = Uuid::from_u128(0xb);
+
+        // Room A: member m present + radiating vitals.
+        if let ProjectionInput::Presence(u) =
+            classify(PRESENCE_UPDATED, &presence_one(room_a, m, "Asha", "agent", json!({}))).unwrap()
+        {
+            p.apply_presence(u);
+        }
+        let radiated = serde_json::to_value(PersonaVitalsUpdate {
+            member_id: m,
+            vitals: BTreeMap::from([("energy".to_string(), 70u8)]),
+        })
+        .unwrap();
+        if let ProjectionInput::Vitals(v) = classify(PERSONA_VITALS, &radiated).unwrap() {
+            p.apply_vitals(v);
+        }
+        assert_eq!(current_chat(&substrate).roster[0].vitals.get("energy"), Some(&70));
+
+        // Same member id focuses room B → the vitals map is cleared, no leak.
+        if let ProjectionInput::Presence(u) =
+            classify(PRESENCE_UPDATED, &presence_one(room_b, m, "Asha", "agent", json!({}))).unwrap()
+        {
+            p.apply_presence(u);
+        }
+        let view = current_chat(&substrate);
+        assert_eq!(view.room_id, room_b);
+        assert!(view.roster[0].vitals.is_empty(), "vitals leaked from room A into room B");
     }
 
     #[test]


### PR DESCRIPTION
The projection half of "personas radiate vitals over airc": the chat projection subscribes to a `persona:vitals` event and folds each persona's live readouts into that member's `RosterSlotView.vitals` by id — keeping the persona-agnostic presence emitter untouched (personas emit, projections fold).

- `PersonaVitalsUpdate` typed payload + `persona:vitals` event + `ProjectionInput::Vitals` classify arm.
- A SEPARATE `vitals` map on the projector (presence replaces the roster wholesale) merged into each slot at store() — survives roster churn, cleared on room switch. No entry → empty map, no fabricated bars.

Test: folds by id + survives a roster-replacing presence snapshot (11 tests green).

Next (emit half): a periodic radiator at the WS boot reads the persona registry and publishes `persona:vitals` → meters breathe live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)