### PR TITLE
feat(core): persona-vitals radiator — the meters breathe (design B emit half, LIVE)

### DIFF
--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -1124,6 +1124,14 @@ impl WorkspaceCycle {
         self.genome.load().as_ref().clone()
     }
 
+    /// This mind's monotonic service-tick count — how many `Workspace::cycle`
+    /// ticks it has serviced since spawn. The DELTA of this over an interval is
+    /// the persona's live "thinking tempo" (the roster **ACT** vital): a rising
+    /// count = actively servicing concerns, a flat count = idle. Read wait-free.
+    pub fn cycle_count(&self) -> u64 {
+        self.cycle_counter.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Clear the volatile working-memory scratch (the act/reasoning proprioception
     /// buffer), if this cycle has hands. Called at the boundary between disjoint
     /// concerns — e.g. each independent task in a `cognition/eval` pass — so one

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -112,6 +112,7 @@ pub mod positron_foundry_source;
 pub mod positron_kanban_source;
 pub mod positron_presence;
 pub mod positron_source;
+pub mod vitals_emitter;
 pub mod positron_wall_source;
 pub mod protocol;
 pub mod ws;
@@ -2435,6 +2436,14 @@ pub fn start_server(
                             room_name.clone(),
                             projection_bus.clone(),
                         );
+
+                        // Roster-vitals radiator (design B emit half): sample each
+                        // resident persona's live WorkspaceCycle (service-tick tempo
+                        // + paged-in genome) and publish `persona:vitals` on the SAME
+                        // bus the chat projection reads, so those readouts breathe as
+                        // meters on the who-panel card. Reads the workspace registry
+                        // itself (where residents run); the projection folds by id.
+                        vitals_emitter::spawn_vitals_emitter(&state.rt_handle, projection_bus.clone());
 
                         // Wall projector: the consuming half of `wall:changed`.
                         // A dedicated node reader (own home + identity, distinct

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -112,9 +112,9 @@ pub mod positron_foundry_source;
 pub mod positron_kanban_source;
 pub mod positron_presence;
 pub mod positron_source;
-pub mod vitals_emitter;
 pub mod positron_wall_source;
 pub mod protocol;
+pub mod vitals_emitter;
 pub mod ws;
 
 use diagnostics::{current_rss_mb, dump_memory_report, log_command_rss_delta};

--- a/core/continuum-core/src/ipc/vitals_emitter.rs
+++ b/core/continuum-core/src/ipc/vitals_emitter.rs
@@ -1,0 +1,93 @@
+//! Persona-vitals radiator — the EMIT half of design B (the projection FOLD
+//! lives in [`crate::ipc::positron_source`]).
+//!
+//! A periodic task samples the live `WorkspaceCycle` registry — where resident
+//! personas actually run — and publishes a `persona:vitals` event per persona
+//! whose readouts CHANGED; the chat projection folds each into that member's
+//! roster slot by id. Personas emit, the projection folds, so the
+//! persona-agnostic presence emitter never learns about personas
+//! ([[grid-distributed-cognition]]). Mirrors the own-task + `interval` + bus
+//! shape of [`crate::ipc::positron_presence::spawn_presence_emitter`].
+//!
+//! **Vitals = what the living brain actually computes** (NOT a service_loop-era
+//! `PersonaState.energy` the `WorkspaceCycle` never tracks):
+//! - `activity` — the `cycle_count()` DELTA over the interval, the true
+//!   "thinking-right-now" pulse (idle = 0, busy = high).
+//! - `genome`   — the count of paged-in LoRA genes (`genome().len()`); omitted
+//!   for a base persona with none (an honest empty, never a fabricated bar).
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use std::time::Duration;
+
+use uuid::Uuid;
+
+use crate::cognition::persona_workspace;
+use crate::ipc::positron_source::{PersonaVitalsUpdate, PERSONA_VITALS};
+use crate::runtime::message_bus::MessageBus;
+
+/// Sample cadence. Vitals drift over seconds; the change-dedup keeps an idle
+/// room quiet on the bus + the chat-state revision well.
+const EMIT_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Calibration: service-ticks-per-interval that read as a FULL activity bar. A
+/// busy persona services several concern-ticks per `EMIT_INTERVAL`; this scales
+/// the per-interval delta to `0..=100`. Tuned against the glass-boxed real tick
+/// rate — NEVER guessed blind ([[never-blind-feedback-driven-iteration]]).
+const ACT_FULL_SCALE_TICKS: u64 = 6;
+/// Paged-in LoRA-gene count that reads as a FULL genome bar.
+const GEN_FULL_SCALE_GENES: usize = 6;
+
+fn pct_u64(v: u64, full: u64) -> u8 {
+    (v.saturating_mul(100) / full.max(1)).min(100) as u8
+}
+fn pct_usize(v: usize, full: usize) -> u8 {
+    (v.saturating_mul(100) / full.max(1)).min(100) as u8
+}
+
+/// Spawn the radiator on `rt`. Every [`EMIT_INTERVAL`] it samples each resident
+/// persona's live cognition tempo + genome load and publishes `persona:vitals`
+/// for those whose readouts changed. Runs for the process lifetime.
+pub fn spawn_vitals_emitter(rt: &tokio::runtime::Handle, bus: Arc<MessageBus>) {
+    rt.spawn(async move {
+        let mut ticker = tokio::time::interval(EMIT_INTERVAL);
+        let mut last_ticks: HashMap<Uuid, u64> = HashMap::new();
+        let mut last_vitals: HashMap<Uuid, BTreeMap<String, u8>> = HashMap::new();
+        loop {
+            ticker.tick().await;
+            let registry = persona_workspace::global();
+            for (id, _name) in registry.roster() {
+                let Some(cycle) = registry.get(&id) else {
+                    continue;
+                };
+                // ACTIVITY: the cycle-tick delta since we last sampled. First
+                // sample seeds `last` = now → delta 0 (honest "no history yet").
+                let ticks = cycle.cycle_count();
+                let delta = ticks.saturating_sub(last_ticks.get(&id).copied().unwrap_or(ticks));
+                last_ticks.insert(id, ticks);
+
+                let genome_len = cycle.genome().len();
+                let mut vitals = BTreeMap::new();
+                vitals.insert("activity".to_string(), pct_u64(delta, ACT_FULL_SCALE_TICKS));
+                // Omit genome entirely when the persona has none paged in — an
+                // honest missing meter, not a 0% fabricated one.
+                if genome_len > 0 {
+                    vitals.insert("genome".to_string(), pct_usize(genome_len, GEN_FULL_SCALE_GENES));
+                }
+
+                // Change-dedup: a stable persona radiates nothing.
+                if last_vitals.get(&id) == Some(&vitals) {
+                    continue;
+                }
+                last_vitals.insert(id, vitals.clone());
+                let update = PersonaVitalsUpdate { member_id: id, vitals };
+                match serde_json::to_value(&update) {
+                    Ok(payload) => bus.publish_async_only(PERSONA_VITALS, payload),
+                    Err(e) => {
+                        tracing::warn!(persona = %id, error = %e, "persona vitals serialize failed")
+                    }
+                }
+            }
+        }
+    });
+}

--- a/core/continuum-core/src/ipc/vitals_emitter.rs
+++ b/core/continuum-core/src/ipc/vitals_emitter.rs
@@ -55,38 +55,58 @@ pub fn spawn_vitals_emitter(rt: &tokio::runtime::Handle, bus: Arc<MessageBus>) {
         let mut last_vitals: HashMap<Uuid, BTreeMap<String, u8>> = HashMap::new();
         loop {
             ticker.tick().await;
-            let registry = persona_workspace::global();
-            for (id, _name) in registry.roster() {
-                let Some(cycle) = registry.get(&id) else {
-                    continue;
-                };
-                // ACTIVITY: the cycle-tick delta since we last sampled. First
-                // sample seeds `last` = now → delta 0 (honest "no history yet").
-                let ticks = cycle.cycle_count();
-                let delta = ticks.saturating_sub(last_ticks.get(&id).copied().unwrap_or(ticks));
-                last_ticks.insert(id, ticks);
+            // Wrap the (synchronous) sample in catch_unwind: the only realistic
+            // panic here is a POISONED registry lock — another thread panicked
+            // while holding `persona_workspace`'s `cycles` mutex — and one bad
+            // tick must NOT silently kill the radiator for the whole process
+            // lifetime (CONCURRENCY-STYLE-GUIDE quarantine box). Log + retry next
+            // interval. No `.await` inside, so unwind-safety is straightforward.
+            // (Unlike the presence emitter, there is no `presence:resync`-style
+            // path: the change-dedup means a chat projection that restarts sees no
+            // meter on an idle persona until its readout next changes — acceptable,
+            // since a missing bar on a genuinely-idle persona is honest, not blank.)
+            let sampled = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let registry = persona_workspace::global();
+                for (id, _name) in registry.roster() {
+                    let Some(cycle) = registry.get(&id) else {
+                        continue;
+                    };
+                    // ACTIVITY: the cycle-tick delta since we last sampled. First
+                    // sample seeds `last` = now → delta 0 ("no history yet").
+                    let ticks = cycle.cycle_count();
+                    let delta =
+                        ticks.saturating_sub(last_ticks.get(&id).copied().unwrap_or(ticks));
+                    last_ticks.insert(id, ticks);
 
-                let genome_len = cycle.genome().len();
-                let mut vitals = BTreeMap::new();
-                vitals.insert("activity".to_string(), pct_u64(delta, ACT_FULL_SCALE_TICKS));
-                // Omit genome entirely when the persona has none paged in — an
-                // honest missing meter, not a 0% fabricated one.
-                if genome_len > 0 {
-                    vitals.insert("genome".to_string(), pct_usize(genome_len, GEN_FULL_SCALE_GENES));
-                }
+                    let genome_len = cycle.genome().len();
+                    let mut vitals = BTreeMap::new();
+                    vitals.insert("activity".to_string(), pct_u64(delta, ACT_FULL_SCALE_TICKS));
+                    // Omit genome entirely when the persona has none paged in — an
+                    // honest missing meter, not a 0% fabricated one.
+                    if genome_len > 0 {
+                        vitals
+                            .insert("genome".to_string(), pct_usize(genome_len, GEN_FULL_SCALE_GENES));
+                    }
 
-                // Change-dedup: a stable persona radiates nothing.
-                if last_vitals.get(&id) == Some(&vitals) {
-                    continue;
-                }
-                last_vitals.insert(id, vitals.clone());
-                let update = PersonaVitalsUpdate { member_id: id, vitals };
-                match serde_json::to_value(&update) {
-                    Ok(payload) => bus.publish_async_only(PERSONA_VITALS, payload),
-                    Err(e) => {
-                        tracing::warn!(persona = %id, error = %e, "persona vitals serialize failed")
+                    // Change-dedup: a stable persona radiates nothing.
+                    if last_vitals.get(&id) == Some(&vitals) {
+                        continue;
+                    }
+                    last_vitals.insert(id, vitals.clone());
+                    let update = PersonaVitalsUpdate { member_id: id, vitals };
+                    match serde_json::to_value(&update) {
+                        Ok(payload) => bus.publish_async_only(PERSONA_VITALS, payload),
+                        Err(e) => {
+                            tracing::warn!(persona = %id, error = %e, "persona vitals serialize failed")
+                        }
                     }
                 }
+            }));
+            if sampled.is_err() {
+                tracing::warn!(
+                    "vitals radiator tick panicked (likely a poisoned registry lock) — \
+                     skipping, retrying next interval"
+                );
             }
         }
     });


### PR DESCRIPTION
Completes the roster genome-energy meters (wire #1769, fold #1770). Personas radiate live cognition state; the projection folds it; the card renders it.

**The design corrected itself under the glass box:** WorkspaceCycle holds no service-loop `PersonaState.energy` — its real live state is the monotonic service-tick counter + paged-in genome. Honest vitals:
- `activity` — `WorkspaceCycle::cycle_count()` delta over 2s (new accessor): the thinking-now pulse. Idle=0; **probed to 16** mid-turn.
- `genome` — `genome().len()` normalized; omitted when none paged in.

`ipc/vitals_emitter.rs` (own task + interval + dedup) reads `persona_workspace::global()`, publishes `persona:vitals` on the projection bus; scales calibrated against the glass-boxed tick rate.

**LIVE-VALIDATED** (rebuild→restart→probe+screenshot): Solenne + Asha render a pulsing ACT meter; Claude (external agent, no cycle) renders none — honest, no fabricated bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)