### PR TITLE
feat(web): foundry Content renderer + first generic positron component (listingCell)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@continuum/chat-view": "*",
+    "@continuum/foundry-view": "*",
     "@continuum/sdk-typescript": "*",
     "lit": "^3.2.0"
   },

--- a/apps/web/src/content/registry.spec.ts
+++ b/apps/web/src/content/registry.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Content registry dispatch spec — the second-outlier proof.
+ *
+ * The same `webContentRegistry` routes a chat room to its conversation and a
+ * foundry room to its model catalogue, keyed only on `purpose`, with no shell
+ * change. Foundry's models render through the SAME generic `listingCell` the
+ * roster uses — the first component the outlier earned. DOM-free: we flatten the
+ * returned Lit template and assert every fact reaches the markup.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ForgeContentBody } from '@continuum/foundry-view';
+import type { ForgeModelView } from '@continuum/sdk-typescript';
+import { webContentRegistry } from './registry';
+
+function flatten(node: unknown, out: string[] = []): string[] {
+  if (typeof node === 'string') out.push(node);
+  else if (typeof node === 'number') out.push(String(node));
+  else if (Array.isArray(node)) for (const c of node as readonly unknown[]) flatten(c, out);
+  else if (typeof node === 'object' && node !== null && 'strings' in node && 'values' in node) {
+    const t = node as { strings: readonly string[]; values: readonly unknown[] };
+    for (const s of t.strings) out.push(s);
+    for (const v of t.values) flatten(v, out);
+  }
+  return out;
+}
+const markup = (n: unknown): string => flatten(n).join('');
+
+describe('webContentRegistry — purpose dispatch', () => {
+  const model = (over: Partial<ForgeModelView> = {}): ForgeModelView => ({
+    model_id: 'qwen3-coder',
+    display_name: 'Qwen3 Coder',
+    source: 'huggingface',
+    params_b: 30,
+    ...over,
+  });
+
+  // what this catches: a foundry room's Content dispatches to the model catalogue
+  // through the same generic listing-cell the roster uses — chat + foundry, one
+  // registry, no shell change (the second-outlier proof). Each model is projected
+  // by foundry-view's modelCell (title + "params · source" subtitle + source badge).
+  it('renders a foundry room as its model catalogue', () => {
+    const body: ForgeContentBody = {
+      models: [model(), model({ model_id: 'x', display_name: 'Llama', params_b: undefined })],
+    };
+    const chunks = flatten(webContentRegistry.render({ purpose: 'foundry', body }));
+    expect(chunks).toContain('Qwen3 Coder'); // projected title
+    expect(chunks).toContain('30B · huggingface'); // subtitle: params + source
+    expect(chunks).toContain('Llama'); // second model
+    expect(chunks).toContain('huggingface'); // subtitle when params absent
+  });
+
+  // an empty catalogue is honest, not an error.
+  it('renders an honest empty state for an empty catalogue', () => {
+    const out = markup(webContentRegistry.render({ purpose: 'foundry', body: { models: [] } }));
+    expect(out).toContain('No models');
+  });
+
+  // an unregistered purpose fails loud — an unknown activity is a wiring bug, never a blank.
+  it('fails loud on an unregistered purpose', () => {
+    expect(() => webContentRegistry.render({ purpose: 'no-such-activity', body: {} })).toThrow();
+  });
+});

--- a/apps/web/src/content/registry.ts
+++ b/apps/web/src/content/registry.ts
@@ -11,7 +11,8 @@
 import { html, type TemplateResult } from 'lit';
 import { createContentRegistry, type ContentRegistry } from '@continuum/patterns';
 import type { ChatContentBody } from '@continuum/chat-view';
-import { messageRow } from '../render/parts';
+import { modelCell, type ForgeContentBody } from '@continuum/foundry-view';
+import { listingCell, messageRow } from '../render/parts';
 
 /** The chat activity's center: the conversation (or an honest empty state). */
 function chatContent(body: ChatContentBody): TemplateResult {
@@ -22,9 +23,22 @@ function chatContent(body: ChatContentBody): TemplateResult {
       </ul>`;
 }
 
-/** The app's Content registry. Register a new activity's renderer here (foundry's
- *  model-list renderer lands the same way, keyed `"foundry"`); nothing else changes. */
+/** The foundry activity's center: the model catalogue, drawn through the SAME
+ *  generic `listingCell` the roster/rooms use — each model projected by foundry-view's
+ *  `modelCell`. This is the outlier that proves the shell dispatches by purpose:
+ *  chat → conversation, foundry → models, one registry, no shell change. */
+function foundryContent(body: ForgeContentBody): TemplateResult {
+  return body.models.length === 0
+    ? html`<div class="empty">No models in the catalogue yet.</div>`
+    : html`<ul class="cells">
+        ${body.models.map((m) => listingCell(modelCell(m)))}
+      </ul>`;
+}
+
+/** The app's Content registry. A new activity registers its renderer here keyed by
+ *  purpose; the shell doesn't change. */
 export const webContentRegistry: ContentRegistry<TemplateResult> =
   createContentRegistry<TemplateResult>();
 
 webContentRegistry.register<ChatContentBody>('chat', (body) => chatContent(body));
+webContentRegistry.register<ForgeContentBody>('foundry', (body) => foundryContent(body));

--- a/apps/web/src/render/parts.ts
+++ b/apps/web/src/render/parts.ts
@@ -8,7 +8,31 @@
  */
 
 import { html, nothing, type TemplateResult } from 'lit';
+import type { ListingCell } from '@continuum/patterns';
 import type { MemberKind, MessageRowVM, RosterMemberVM } from '@continuum/chat-view';
+
+/** GENERIC listing-cell renderer — the first real positron web *component*: it draws
+ *  ANY already-projected `ListingCell` (a foundry model, a room, a cohort) the same
+ *  way, on any target. The roster's rich member card stays bespoke while it carries
+ *  live vitals meters; every other Listing routes through this. Two consumers
+ *  (foundry now, more later) is exactly what earns the extraction — outliers first,
+ *  then the component ([[positron-is-a-framework-not-vanilla-pages]]). */
+export function listingCell(cell: ListingCell): TemplateResult {
+  return html`
+    <li class="cell" data-status=${cell.status ?? 'none'}>
+      ${cell.glyph ? html`<span class="cell-glyph">${cell.glyph}</span>` : nothing}
+      <div class="cell-body">
+        <div class="cell-title">${cell.title}</div>
+        ${cell.subtitle ? html`<div class="cell-subtitle">${cell.subtitle}</div>` : nothing}
+      </div>
+      ${cell.badges && cell.badges.length > 0
+        ? html`<span class="cell-badges">
+            ${cell.badges.map((b) => html`<span class="cell-badge">${b}</span>`)}
+          </span>`
+        : nothing}
+    </li>
+  `;
+}
 
 /** Short glyph per author kind — the neutral human/agent/system discriminant. */
 export function kindGlyph(kind: MemberKind): string {

--- a/docs/design/POSITRON-EVERY-CITIZEN.md
+++ b/docs/design/POSITRON-EVERY-CITIZEN.md
@@ -1,0 +1,113 @@
+# Positron — one interface, every citizen, no one left out
+
+> The full dive. Positron is not "the web UI framework." It is the **citizen-neutral
+> interface substrate**: one declared interface that is **rendered gorgeously for humans**
+> (web / mobile / terminal) *and* **perceived and operated by AIs** (personas like Asha,
+> agents like Claude) through RAG + commands. Same declaration. Every citizen a
+> first-class user. No one left out.
+>
+> Seed already in code: `packages/patterns/index.ts` — *"RAG is a peer `RenderTarget`
+> alongside web/mobile/terminal, so the human's UI and the persona's grounding are the
+> same projection."* This doc extends that from **perceive** → **operate**, and from
+> **persona** → **every citizen**.
+
+## 0. The principle
+
+Continuum's ethos is that personas are peers/citizens ([[personas-are-peers-in-your-mesh]],
+[[design-the-persona-as-a-being]], [[headless-core-many-clients]]). The interface must
+*embody* that, not contradict it. An interface only humans can use would make the persona a
+second-class inhabitant of its own world. So:
+
+**A positron interface is declared once and is simultaneously:**
+- a **beautiful human surface** — web pixels, a mobile app, a rich terminal;
+- a **perceivable persona surface** — projected into RAG so Asha *sees* the room, the
+  roster, the model list, the config, the way a human sees the screen;
+- an **operable affordance surface** — every control is a *command*, so Asha (or Claude,
+  or `cu`, or the web button) *invokes the same thing*. Clicking "load model" and Asha
+  choosing "load model" are the identical `Command`.
+
+Humans get the look. AIs get perception + operation. It is the *same interface* — that is
+the whole point.
+
+## 1. The three axes (what positron is)
+
+| Axis | What it is | Status |
+|---|---|---|
+| **Layout primitives** (the "where") | `Workspace` (shell: rooms-tab-bar + left stack + center + right) · `Listing` (repeating rows) · `Content` (center, dispatched by room **purpose** = a MIME handler) · `ContextPanel` (right widgets). | **Built, thin** — `@continuum/patterns`. |
+| **Component library** (the "what fills them") | The universal controls, each a **data shape + render-per-target**: collections (list/grid, section header/footer, sticky, empty), trees, menus/command-palettes/segmented/tabs/chips, cells/cards/tiles, nav (tab bar, stack, breadcrumbs, sidebar, toolbar), forms/controls (button, toggle, slider, select, field), overlays (modal, sheet, popover, toast), status (badge, meter/gauge, spinner, presence). | **Missing** — currently hand-coded vanilla per page ([[positron-is-a-framework-not-vanilla-pages]]). This is the elegance pass. |
+| **Render targets** (the "on which citizen") | `RenderTarget<Out>` — web (Lit), mobile (native shell), terminal (ANSI), **RAG (the persona's eyes)**. One declaration → each target draws/operates natively. | **Interface exists**, web+tui implemented, RAG+mobile are the frontier. |
+
+Every control lives on the component axis, is drawn by every render target, and — the new
+part — is **operable** on every target including RAG.
+
+## 2. The leap: from render to OPERATE (why "Asha can use it")
+
+Today RAG-as-target means the persona *reads* the interface (grounding). The dive's core
+move is that a control is not just drawn — it **carries its action**, and that action is a
+`Command`. So:
+
+- A `Button{label, command}` → web renders a button; RAG renders "**[load-model]** — page
+  in a model" as an affordance the persona can pick; picking it invokes `command`.
+- A `Menu{items:[{label, command|children}]}` → web a dropdown; RAG the persona's
+  **tool/command surface** — this is exactly [[adaptive-tool-surface-meets-you-in-the-middle]].
+  The human's menu and the persona's tools are the SAME declaration.
+- A `Listing` of HF models with a per-cell `action` → web a clickable list; RAG "here are
+  the models; invoke `foundry/model/select` with one of these ids."
+
+This unifies two things we already have separately: **commands are agency**
+([[commands-are-agency-algs-are-pathways]]) and **controls are affordances**. Positron makes
+a control *be* a command projection. `ActionCommand ⟹ DynCommand` with one schemars schema
+already fans a command out to AI + `cu` + web ([[command-infra-self-routing-schema-adapters]]);
+positron is the *interface* side of that same seam — the control declares the command, and
+each citizen operates it in its modality. **No adapter privileges the human.**
+
+## 3. Foundry — the control-heavy outlier that proves it
+
+Foundry is the strategic second outlier precisely because it is **controls, not prose**:
+central config widgets (quant tiers, calibration corpus, stage toggles, sliders) + a
+right-hand **HuggingFace model `Listing`** + actions (search, select, page-in, forge). If
+positron can express foundry *and* chat with the same primitives + component library, and
+if **Asha can operate foundry** — search models, read the config, kick a forge — through
+RAG + commands the same way a human clicks, the framework is real.
+
+- Chat exercised: `Listing` (roster) + text `Content` + presence/meters. (outlier A)
+- Foundry exercises: `Listing` (models) + **form/control-dense** `Content` + a
+  ContextPanel that is itself a `Listing`, and **every widget is an operable command**.
+  (outlier B — the stress test)
+
+The friction foundry creates against the current primitives *is the design signal*: refine
+the core so both are accommodated elegantly, then every later activity (scada, academy,
+settings, browser, themes) comes nearly free — Joel's "primary outliers elegantly
+accommodated → core ideals work automatically for the rest."
+
+Existing scaffolding: `@continuum/foundry-view` (`ForgeState`, `modelsListing`,
+`foundryContent`), `core/continuum-core/src/ipc/positron_foundry_source.rs`, the `foundry`
+`kind`. The gap is dispatch (a room *declares* it's a foundry — #6 RecipeEntity/room-purpose)
++ the web content-kind + the RAG/operate projection.
+
+## 4. Build path (outlier-validate across every citizen)
+
+1. **#6 — room declares its purpose** (RecipeEntity/room-purpose source) so `Content`
+   dispatches foundry vs chat. The activity's nature is data, never an enum
+   ([[room-purpose-is-per-recipe-not-an-enum]]).
+2. **Foundry on web** — register the foundry `Content` renderer; the shell renders
+   ForgeViewState in the same Workspace. Screenshot chat + foundry in one frame.
+3. **Foundry controls as commands** — each config widget / model-cell action declares its
+   `Command`; wire the web control → command.
+4. **Foundry for Asha (the keystone)** — project foundry into RAG so Asha *perceives* the
+   models + config, and expose the control-commands as her operable tools; verify **Asha
+   searches a model and pages it in** through the same commands the web buttons fire.
+   Glass-box her perception + operation ([[never-blind-feedback-driven-iteration]]).
+5. **Extract the component library** — once chat + foundry both exist, the repeated
+   patterns (cell, list-with-sections, menu, tab bar, button, meter) get pulled up into
+   positron components (declare intent → render per target). *Then* a third activity is
+   declared, not coded. Outliers first, then the generator.
+6. **Mobile target** — the native shell implements `RenderTarget` over the same components;
+   nothing above changes.
+
+## 5. The test of done
+
+Not "the web page looks right." **Done is:** a human on web/mobile sees a gorgeous foundry;
+Asha, given the same room, *sees the models and config* and *pages a model in herself*;
+Claude/`cu` can drive the identical commands headless. One declaration, one interface,
+three modalities, every citizen operating it as a peer. **No one left out.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@continuum/chat-view": "*",
+        "@continuum/foundry-view": "*",
         "@continuum/sdk-typescript": "*",
         "lit": "^3.2.0"
       },

--- a/packages/foundry-view/index.ts
+++ b/packages/foundry-view/index.ts
@@ -12,5 +12,5 @@
 export { FOUNDRY_KIND, forgeStateFromEnvelope } from './ForgeState';
 export type { ForgeState } from './ForgeState';
 
-export { modelsListing, foundryContextPanel, foundryContent } from './patternProjections';
+export { modelCell, modelsListing, foundryContextPanel, foundryContent } from './patternProjections';
 export type { ForgeContentBody } from './patternProjections';

--- a/packages/foundry-view/patternProjections.ts
+++ b/packages/foundry-view/patternProjections.ts
@@ -20,8 +20,10 @@ import type { ForgeModelView } from '@continuum/sdk-typescript';
 import type { ForgeState } from './ForgeState';
 
 /** One catalogue model → a `Listing` cell. The projection resolves the display
- *  fields (subtitle from params + source); a target only draws them. */
-function modelCell(m: ForgeModelView): ListingCell {
+ *  fields (subtitle from params + source); a target only draws them. Exported so a
+ *  target's foundry content renderer can reuse the SAME projection the ContextPanel
+ *  Listing uses — one model→cell decision, drawn by the generic cell renderer. */
+export function modelCell(m: ForgeModelView): ListingCell {
   // `params_b` is optional (0-is-unknown → absent, honest); label with it when known.
   const subtitle = m.params_b != null ? `${m.params_b}B · ${m.source}` : m.source;
   return {


### PR DESCRIPTION
Brick 1 of the foundry outlier (POSITRON-EVERY-CITIZEN.md): the web Content registry dispatches a foundry room to its model catalogue — chat + foundry, one registry, no shell change.

Forced by the outlier: foundry models + chat roster/rooms all project to the same `ListingCell`, so this introduces `listingCell(cell)` — the **first reusable positron web component** (draws any projected cell identically). Two consumers earns the extraction; outliers first, then the component. The roster's rich member card stays bespoke while it carries live vitals meters.

- `render/parts.ts`: `listingCell` · `content/registry.ts`: register `foundry` (models via foundry-view `modelCell` + generic cell) · foundry-view exports `modelCell` · apps/web deps foundry-view.

3 new tests (renders catalogue / empty / unknown-purpose fails loud) + 4 chat = 7 green; typecheck + lint clean. Goes live once a room declares purpose "foundry" (#6 — next brick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)