### PR TITLE
docs: capture the canon into READMEs — positron engine README + docs canon index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,19 @@
 
 ---
 
+## Start here — the canonical architecture (precedence-winning)
+
+How the whole thing composes. Read these first; on architecture questions they win.
+
+1. **[THE-ORGANISM.md](THE-ORGANISM.md)** — recipes are DNA; an activity / curriculum / persona / artifact / team all *grow* from one gene. **Continuum is recipe-driven** (a room = `recipe.instantiate()`).
+2. **[THE-GRID-IS-ALIVE.md](THE-GRID-IS-ALIVE.md)** — the metaverse of synthetic citizens (the published papers + past prototypes fused): a Tron grid of rooms, minds you walk into as consoles, avatars, universes.
+3. **[design/POSITRON-EVERY-CITIZEN.md](design/POSITRON-EVERY-CITIZEN.md)** — positron: one interface every citizen (human / persona / agent) *perceives and operates*; the **Surface**; the **Universe axis** (an experience, not a theme — it *contains* the color tokens and transcends every surface: motion, sound, embodiment "talk to the orc," lore = a RAG layer).
+4. **[planning/ALPHA-COMPLETION-BLUEPRINT.md](planning/ALPHA-COMPLETION-BLUEPRINT.md)** — the governing execution plan to the alive README; supersedes the older scattered planning docs.
+
+**The four separable layers** (compose, never couple): **Recipe** = logic+content (continuum substrate) · **Positron** = render+operate ([general engine](../packages/patterns/README.md)) · **Universe** = experience+lore+embodiment (general — works *outside* continuum; a company or a game ships its own) · **Continuum** = composes them into the living organism.
+
+---
+
 ## Structure
 
 ```

--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -1,0 +1,55 @@
+# @continuum/patterns — Positron
+
+**The consumer-neutral render + operate engine.** Positron is *not* a UI library and *not*
+continuum-specific — it is a general engine for **AI-inhabited interfaces** that render to every
+surface and are operated by every citizen (human, persona, agent). You declare *intent*; a
+`RenderTarget` emits the surface.
+
+> Canon: [`docs/design/POSITRON-EVERY-CITIZEN.md`](../../docs/design/POSITRON-EVERY-CITIZEN.md) ·
+> [`docs/THE-ORGANISM.md`](../../docs/THE-ORGANISM.md) ·
+> [`docs/planning/ALPHA-COMPLETION-BLUEPRINT.md`](../../docs/planning/ALPHA-COMPLETION-BLUEPRINT.md)
+
+## The three axes
+
+An actual rendered experience is **`Surface × RenderTarget × Universe`**:
+
+- **Surface** = *what* — a room/activity as `{ state, affordances (= commands), presence, projections }`.
+  `Workspace` (the shell) · `Listing` (repeating rows) · `Content` (center, dispatched by room
+  **purpose** — a MIME handler) · `ContextPanel` (right widgets). One projection; every citizen reads it.
+- **RenderTarget** = *where* — web (Lit), terminal (ANSI), the persona's **RAG** grounding, mobile,
+  AR/VR. `RenderTarget<Out>` implements the primitives for one surface. **RAG is a peer target**: the
+  human's UI and the persona's perception are the *same projection*.
+- **Universe** = *the world it feels like* — Tron / LOTR / Star Trek / a company's brand. Contains a
+  theme (which contains the color tokens) and transcends it with motion, sound, spatial language,
+  **embodiment** (you talk to *the orc* running the forge), and **lore (= a RAG layer)**. Positron is
+  built to support universes from day one; a component re-skins by universe with **zero activity change**.
+
+## Two hard rules (keep the engine general)
+
+1. **No continuum specifics leak in.** This package must never import a continuum-only concept — it
+   renders *structure*, not domain. That is what lets positron ship to anyone building cross-surface
+   AI UI (a Vapio-style IVR, a game, an enterprise portal), independent of continuum's substrate.
+2. **Presence + operation are one stream.** A control isn't "the human's button" — it *is* a command.
+   Clicking it and a persona invoking it are the same `Command`; the surface streams *who is here /
+   attending / acting*, so every citizen inhabits and operates it. No one left out.
+
+## The primitives (this package)
+
+`Listing`/`ListingCell`/`ListingView` · `Content`/`ContentView<Body>` (dispatched by `purpose`) ·
+`ContextPanel`/`ContextPanelView` · `Workspace`/`WorkspaceView` · `RenderTarget<Out>` ·
+`createContentRegistry<Out>()` (fail-loud on an unregistered purpose).
+
+```ts
+import { createContentRegistry, type ContentView } from '@continuum/patterns';
+const registry = createContentRegistry<TemplateResult>();
+registry.register('chat', (body) => renderConversation(body));   // a chat room's center
+registry.register('foundry', (body) => renderModels(body));       // a foundry room's center
+// The shell calls registry.render(workspace.content); purpose routes it. Same shell, any activity.
+```
+
+## Status
+
+Contract built + proven under two outliers (chat + foundry). The generic `listingCell` (in the web
+target) is the first extracted component. Next: the **Universe axis** scaffolding + the component
+library, per the blueprint. The render *contract* is right; the framework grows onto it — engine, not
+vanilla pages.


### PR DESCRIPTION
Workstream A of ALPHA-COMPLETION-BLUEPRINT: makes the settled architecture legible. New packages/patterns/README.md (positron = general render+operate engine, Surface × RenderTarget × Universe, universe-ready, no continuum leak). docs/README.md gains a precedence-winning canon 'Start here' + the four separable layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)