### PR TITLE
feat(#6): RoomPurposeSource seam — de-hardcode the projection's purpose (the gene, slice 1)

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -3,6 +3,8 @@ use crate::gpu::GpuMemoryManager;
 use crate::modules::agent::AgentModule;
 use crate::modules::ai_provider::AIProviderModule;
 use crate::modules::airc::AircModule;
+use crate::modules::airc_bridge_directive::AircBridgeDirectiveModule;
+use crate::modules::airc_bridge_dispatch::AircBridgeDispatchModule;
 use crate::modules::auth::ExternalWebviewAuthModule;
 use crate::modules::avatar::AvatarModule;
 use crate::modules::channel::{ChannelModule, ChannelState};
@@ -15,8 +17,6 @@ use crate::modules::events::EventsModule;
 use crate::modules::forge::ForgeModule;
 use crate::modules::gpu::GpuModule;
 use crate::modules::grid::GridModule;
-use crate::modules::airc_bridge_directive::AircBridgeDirectiveModule;
-use crate::modules::airc_bridge_dispatch::AircBridgeDispatchModule;
 use crate::modules::health::HealthModule;
 use crate::modules::launch_mode::LaunchModeModule;
 use crate::modules::live::{VoiceModule, VoiceState};
@@ -114,6 +114,7 @@ pub mod positron_presence;
 pub mod positron_source;
 pub mod positron_wall_source;
 pub mod protocol;
+pub mod room_purpose;
 pub mod vitals_emitter;
 pub mod ws;
 
@@ -884,9 +885,9 @@ pub fn start_server(
     // daemon (which plans off its snapshot) and the `models/*` command surface
     // (which mutates it). One owner, one live universe: a `models/pull` that
     // flips a model Ready is seen by the very next serving tick — no reboot.
-    let model_catalog = Arc::new(
-        crate::model_registry::live::ModelCatalog::from_registry(crate::model_registry::global()),
-    );
+    let model_catalog = Arc::new(crate::model_registry::live::ModelCatalog::from_registry(
+        crate::model_registry::global(),
+    ));
 
     // The ONE per-machine resource authority (#56). Its VRAM ceiling comes from
     // the LIVE GpuMonitor (`gpu::monitor::detect()` — Metal + every NVIDIA host),
@@ -1006,12 +1007,9 @@ pub fn start_server(
                 .map(|bm| bm.broker())
         });
     if let Some(broker) = broker_arc {
-        broker.register(
-            disk_pressure_monitor.clone() as Arc<dyn crate::paging::pool::ResourcePool>
-        );
-        broker.register(
-            pressure_monitor.clone() as Arc<dyn crate::paging::pool::ResourcePool>
-        );
+        broker
+            .register(disk_pressure_monitor.clone() as Arc<dyn crate::paging::pool::ResourcePool>);
+        broker.register(pressure_monitor.clone() as Arc<dyn crate::paging::pool::ResourcePool>);
 
         // Wire the resource authority's per-kind lease pools onto the broker so
         // cross-resource pressure relief reaches VRAM/RAM/disk leases: when a
@@ -1219,9 +1217,8 @@ pub fn start_server(
 
     // Shared state for per-persona cognition (unified: engine + inbox + rate limiter + sleep + adapters + genome)
     let rag_engine = Arc::new(RagEngine::new());
-    let cognition_state = Arc::new(
-        CognitionState::new(rag_engine.clone()).with_gpu_manager(gpu_manager.clone()),
-    );
+    let cognition_state =
+        Arc::new(CognitionState::new(rag_engine.clone()).with_gpu_manager(gpu_manager.clone()));
     let personas = cognition_state.personas.clone();
     runtime.register(Arc::new(CognitionModule::new(cognition_state)));
 
@@ -1277,12 +1274,10 @@ pub fn start_server(
     // (tearing it down would freeze the avatar mid-call) and sheds the renderer
     // only when nothing is rendering. Shares the same live-session lifecycle as
     // voice, so both sides of a call are protected together.
-    resource_daemon.add_consumer(Arc::new(
-        crate::modules::bevy_consumer::BevyConsumer::new(
-            voice_state.resource_lifecycle.clone(),
-            gpu_manager.clone(),
-        ),
-    ));
+    resource_daemon.add_consumer(Arc::new(crate::modules::bevy_consumer::BevyConsumer::new(
+        voice_state.resource_lifecycle.clone(),
+        gpu_manager.clone(),
+    )));
     runtime.register(Arc::new(VoiceModule::new(voice_state)));
 
     // Phase 3: CodeModule (wraps file engines and shell sessions per-persona)
@@ -1487,7 +1482,9 @@ pub fn start_server(
         // the SAME registry (cheap Clone over an inner Arc) so a work command can
         // resolve the calling persona's live airc runtime. Registered before the
         // executor is built so its typed commands land on the one registry.
-        runtime.register(Arc::new(crate::modules::work::WorkModule::new(registry.clone())));
+        runtime.register(Arc::new(crate::modules::work::WorkModule::new(
+            registry.clone(),
+        )));
         // SubstrateGovernor — the deterministic cognitive-region scheduler daemon.
         // Schedules the ChannelDigestRegion: per live persona it pre-stages the
         // persona's current-channel digest into the SHARED digest buffer
@@ -1496,7 +1493,8 @@ pub fn start_server(
         let digest_region: Arc<dyn crate::runtime::BrainRegion> = Arc::new(
             crate::cognition::channel_digest_region::ChannelDigestRegion::with_buffer(
                 crate::cognition::channel_substrate::global_channel_digest_builder(),
-                Arc::new(registry.clone()) as Arc<dyn crate::cognition::channel_digest_region::PersonaChannelReader>,
+                Arc::new(registry.clone())
+                    as Arc<dyn crate::cognition::channel_digest_region::PersonaChannelReader>,
                 crate::cognition::channel_substrate::global_channel_digest_buffer(),
             ),
         );
@@ -1588,9 +1586,7 @@ pub fn start_server(
             ),
         );
         let rag_inspect_module = std::sync::Arc::new(
-            crate::modules::persona_rag_inspect::PersonaRagInspectModule::new(
-                rag_inspect_resolver,
-            ),
+            crate::modules::persona_rag_inspect::PersonaRagInspectModule::new(rag_inspect_resolver),
         );
         runtime.register(rag_inspect_module);
         log_info!(
@@ -1941,19 +1937,18 @@ pub fn start_server(
                 // a failed re-home leaves personas on their prior (still-live)
                 // binding rather than a silent wrong-brain, and retries on the
                 // next snapshot edge ([[fallbacks-are-illegal-fail-loud]]).
-                let adapter =
-                    match crate::persona::supervisor::build_served_adapter(&snap).await {
-                        Ok(a) => a,
-                        Err(e) => {
-                            tracing::warn!(
-                                model = %active,
-                                error = %e,
-                                "served-model re-home: adapter build failed — personas stay \
-                                 on their prior binding; will retry on the next snapshot edge"
-                            );
-                            continue;
-                        }
-                    };
+                let adapter = match crate::persona::supervisor::build_served_adapter(&snap).await {
+                    Ok(a) => a,
+                    Err(e) => {
+                        tracing::warn!(
+                            model = %active,
+                            error = %e,
+                            "served-model re-home: adapter build failed — personas stay \
+                             on their prior binding; will retry on the next snapshot edge"
+                        );
+                        continue;
+                    }
+                };
                 let n = crate::cognition::persona_workspace::global().re_home_all(
                     adapter,
                     Some(active.clone()),
@@ -2321,13 +2316,11 @@ pub fn start_server(
                                             // commands over TCP). peer_id is nil (no
                                             // verified peer); trust comes from the Tcp
                                             // source, not the id.
-                                            let caller = Some(
-                                                crate::routing::CallerIdentity::tcp(
-                                                    crate::identity::PeerId::from_uuid(
-                                                        uuid::Uuid::nil(),
-                                                    ),
+                                            let caller = Some(crate::routing::CallerIdentity::tcp(
+                                                crate::identity::PeerId::from_uuid(
+                                                    uuid::Uuid::nil(),
                                                 ),
-                                            );
+                                            ));
                                             if let Err(e) = handle_client(stream, state, caller) {
                                                 log_error!(
                                                     "ipc",
@@ -2419,7 +2412,10 @@ pub fn start_server(
                 // persona hosting; if airc discovery gave us neither, the
                 // roster has no source and we log the skip (not a silent
                 // fallback — an honestly-disabled projection).
-                match node_presence_deps.clone().zip(persona_bootstrap_room_name.clone()) {
+                match node_presence_deps
+                    .clone()
+                    .zip(persona_bootstrap_room_name.clone())
+                {
                     Some(((daemon_socket, room_id), room_name)) => {
                         let continuum_root =
                             crate::modules::persona_instance_manager::resolve_continuum_root();
@@ -2443,7 +2439,10 @@ pub fn start_server(
                         // bus the chat projection reads, so those readouts breathe as
                         // meters on the who-panel card. Reads the workspace registry
                         // itself (where residents run); the projection folds by id.
-                        vitals_emitter::spawn_vitals_emitter(&state.rt_handle, projection_bus.clone());
+                        vitals_emitter::spawn_vitals_emitter(
+                            &state.rt_handle,
+                            projection_bus.clone(),
+                        );
 
                         // Wall projector: the consuming half of `wall:changed`.
                         // A dedicated node reader (own home + identity, distinct

--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -82,8 +82,7 @@ use uuid::Uuid;
 
 use airc_lib::{AgentAvailabilityState, RoomMember};
 use continuum_positron::{
-    ChatMessageView, ChatViewState, Provenance, RosterSlotView, SenderKind, StateBuilder,
-    Substrate,
+    ChatMessageView, ChatViewState, Provenance, RosterSlotView, SenderKind, StateBuilder, Substrate,
 };
 
 use crate::runtime::MessageBus;
@@ -258,7 +257,10 @@ pub(crate) fn roster_slot_from_member(member: &RoomMember) -> RosterSlotView {
         // Neutral presence facts carried straight through — the fields Rail B
         // used to drop. `availability` is airc's stable label (or `None` when
         // unreported); `last_seen_ms` is the raw recency signal.
-        availability: member.availability.map(availability_label).map(str::to_owned),
+        availability: member
+            .availability
+            .map(availability_label)
+            .map(str::to_owned),
         last_seen_ms: member.last_seen_ms,
         // airc's `RoomMember` carries no vitals — a continuum persona's live
         // `PersonaState` (energy/attention/compute) arrives on its OWN
@@ -277,10 +279,7 @@ pub(crate) fn roster_slot_from_member(member: &RoomMember) -> RosterSlotView {
 /// construction" contract, enforced instead of hoped for). Shared by the chat
 /// / wall / kanban projector test mods: one wire-shape source, even in tests.
 #[cfg(test)]
-pub(crate) fn test_presence_payload(
-    room: Uuid,
-    roster: Vec<RosterSlotView>,
-) -> serde_json::Value {
+pub(crate) fn test_presence_payload(room: Uuid, roster: Vec<RosterSlotView>) -> serde_json::Value {
     serde_json::to_value(AircPresenceUpdate {
         room_id: room,
         room_name: "general".to_string(),
@@ -382,6 +381,11 @@ struct ChatProjection {
     /// into each slot at `store` time, surviving roster churn. A member with no
     /// entry simply has empty vitals (no meter), never a fabricated one.
     vitals: HashMap<Uuid, BTreeMap<String, u8>>,
+    /// Resolves this room's activity **purpose** (the `Content` dispatch key) — #6.
+    /// The projection no longer hardcodes `"chat"`; it routes through this seam so a
+    /// foundry / scada / academy room reports its own recipe-defined purpose with NO
+    /// projection change once the real (recipe-backed) resolver is injected.
+    purpose_source: crate::ipc::room_purpose::SharedRoomPurpose,
 }
 
 impl ChatProjection {
@@ -397,6 +401,9 @@ impl ChatProjection {
             messages: VecDeque::new(),
             roster: Vec::new(),
             vitals: HashMap::new(),
+            // Default resolver (every room → "chat") until the recipe-backed source
+            // lands; injecting a real one is a one-line change here, no call-site churn.
+            purpose_source: crate::ipc::room_purpose::default_source(),
         }
     }
 
@@ -511,16 +518,16 @@ impl ChatProjection {
         let view = ChatViewState {
             room_id,
             room_name: self.room_name.clone(),
-            // Every room is a chat room today. `RoomPurposeSource` (task #6)
-            // will resolve this from the room's recipe/nature so a foundry /
-            // scada / academy room reports its own purpose and the client's
-            // Content primitive dispatches on it (ACTIVITY-ROOM-PATTERNS.md).
-            purpose: "chat".to_string(),
+            // The room's activity purpose — resolved through the `RoomPurposeSource`
+            // seam (#6), NOT hardcoded. Today the default answers "chat" for every
+            // room; when the recipe-backed resolver is injected, a foundry / scada /
+            // academy room reports its own purpose and the client's Content primitive
+            // dispatches on it (ACTIVITY-ROOM-PATTERNS.md) with no change here.
+            purpose: self.purpose_source.purpose_for(room_id),
             messages: self.messages.iter().cloned().collect(),
             roster,
         };
-        self.substrate
-            .store(self.builder.session(view));
+        self.substrate.store(self.builder.session(view));
     }
 }
 
@@ -689,17 +696,27 @@ mod tests {
         let asha = Uuid::from_u128(0xb);
 
         // Roster arrives first — no vitals yet.
-        match classify(PRESENCE_UPDATED, &presence_one(room, asha, "Asha", "agent", json!({}))).unwrap()
+        match classify(
+            PRESENCE_UPDATED,
+            &presence_one(room, asha, "Asha", "agent", json!({})),
+        )
+        .unwrap()
         {
             ProjectionInput::Presence(u) => p.apply_presence(u),
             _ => panic!("presence:updated must classify as Presence"),
         }
-        assert!(current_chat(&substrate).roster[0].vitals.is_empty(), "no vitals before any radiate");
+        assert!(
+            current_chat(&substrate).roster[0].vitals.is_empty(),
+            "no vitals before any radiate"
+        );
 
         // Asha radiates her vitals.
         let radiated = serde_json::to_value(PersonaVitalsUpdate {
             member_id: asha,
-            vitals: BTreeMap::from([("energy".to_string(), 80u8), ("attention".to_string(), 90u8)]),
+            vitals: BTreeMap::from([
+                ("energy".to_string(), 80u8),
+                ("attention".to_string(), 90u8),
+            ]),
         })
         .unwrap();
         match classify(PERSONA_VITALS, &radiated).unwrap() {
@@ -711,7 +728,11 @@ mod tests {
         assert_eq!(slot.vitals.get("attention"), Some(&90));
 
         // A fresh presence snapshot replaces the roster wholesale — vitals stay.
-        match classify(PRESENCE_UPDATED, &presence_one(room, asha, "Asha", "agent", json!({}))).unwrap()
+        match classify(
+            PRESENCE_UPDATED,
+            &presence_one(room, asha, "Asha", "agent", json!({})),
+        )
+        .unwrap()
         {
             ProjectionInput::Presence(u) => p.apply_presence(u),
             _ => panic!("presence:updated must classify as Presence"),
@@ -735,13 +756,19 @@ mod tests {
         let mut p = ChatProjection::new(substrate.clone());
         let room = Uuid::from_u128(0xa);
         let sender = Uuid::from_u128(0xd);
-        if let ProjectionInput::Message(m) =
-            classify(CHAT_POSTED, &posted_from(room, Uuid::from_u128(0xb), sender, "hi")).unwrap()
+        if let ProjectionInput::Message(m) = classify(
+            CHAT_POSTED,
+            &posted_from(room, Uuid::from_u128(0xb), sender, "hi"),
+        )
+        .unwrap()
         {
             p.apply_message(m);
         }
         // Provisional before the card.
-        assert_eq!(current_chat(&substrate).messages[0].sender_kind, SenderKind::Human);
+        assert_eq!(
+            current_chat(&substrate).messages[0].sender_kind,
+            SenderKind::Human
+        );
         // Card arrives via presence: Agent named Helper carrying a badge.
         let presence = presence_one(
             room,
@@ -757,7 +784,9 @@ mod tests {
         assert_eq!(msg.sender_name, "Helper");
         assert_eq!(msg.sender_kind, SenderKind::Agent);
         assert_eq!(
-            msg.integrations.get("continuum.persona_id").map(String::as_str),
+            msg.integrations
+                .get("continuum.persona_id")
+                .map(String::as_str),
             Some("helper-1"),
             "opaque badge resolved from the card"
         );
@@ -777,8 +806,11 @@ mod tests {
         if let ProjectionInput::Presence(u) = classify(PRESENCE_UPDATED, &presence).unwrap() {
             p.apply_presence(u);
         }
-        if let ProjectionInput::Message(m) =
-            classify(CHAT_POSTED, &posted_from(room, Uuid::from_u128(0xb), sender, "hi")).unwrap()
+        if let ProjectionInput::Message(m) = classify(
+            CHAT_POSTED,
+            &posted_from(room, Uuid::from_u128(0xb), sender, "hi"),
+        )
+        .unwrap()
         {
             p.apply_message(m);
         }
@@ -821,7 +853,10 @@ mod tests {
         assert_eq!(view.roster[0].display_name, "Helper");
         assert_eq!(view.roster[0].kind, SenderKind::Agent);
         assert_eq!(
-            view.roster[0].integrations.get("continuum.persona_id").map(String::as_str),
+            view.roster[0]
+                .integrations
+                .get("continuum.persona_id")
+                .map(String::as_str),
             Some("helper-1")
         );
         assert!(view.roster[0].active);
@@ -845,13 +880,17 @@ mod tests {
         let room = Uuid::from_u128(0xa);
         let sender = Uuid::from_u128(0xd);
         // Message before the card → provenance honestly unresolved.
-        if let ProjectionInput::Message(m) =
-            classify(CHAT_POSTED, &posted_from(room, Uuid::from_u128(0xb), sender, "hi")).unwrap()
+        if let ProjectionInput::Message(m) = classify(
+            CHAT_POSTED,
+            &posted_from(room, Uuid::from_u128(0xb), sender, "hi"),
+        )
+        .unwrap()
         {
             p.apply_message(m);
         }
         assert_eq!(
-            current_chat(&substrate).messages[0].provenance.runtime, "",
+            current_chat(&substrate).messages[0].provenance.runtime,
+            "",
             "unresolved provenance is empty, not fabricated"
         );
         // Presence folds the card carrying a runtime origin.
@@ -957,8 +996,11 @@ mod tests {
         let m = Uuid::from_u128(0xb);
 
         // Room A: member m present + radiating vitals.
-        if let ProjectionInput::Presence(u) =
-            classify(PRESENCE_UPDATED, &presence_one(room_a, m, "Asha", "agent", json!({}))).unwrap()
+        if let ProjectionInput::Presence(u) = classify(
+            PRESENCE_UPDATED,
+            &presence_one(room_a, m, "Asha", "agent", json!({})),
+        )
+        .unwrap()
         {
             p.apply_presence(u);
         }
@@ -970,17 +1012,26 @@ mod tests {
         if let ProjectionInput::Vitals(v) = classify(PERSONA_VITALS, &radiated).unwrap() {
             p.apply_vitals(v);
         }
-        assert_eq!(current_chat(&substrate).roster[0].vitals.get("energy"), Some(&70));
+        assert_eq!(
+            current_chat(&substrate).roster[0].vitals.get("energy"),
+            Some(&70)
+        );
 
         // Same member id focuses room B → the vitals map is cleared, no leak.
-        if let ProjectionInput::Presence(u) =
-            classify(PRESENCE_UPDATED, &presence_one(room_b, m, "Asha", "agent", json!({}))).unwrap()
+        if let ProjectionInput::Presence(u) = classify(
+            PRESENCE_UPDATED,
+            &presence_one(room_b, m, "Asha", "agent", json!({})),
+        )
+        .unwrap()
         {
             p.apply_presence(u);
         }
         let view = current_chat(&substrate);
         assert_eq!(view.room_id, room_b);
-        assert!(view.roster[0].vitals.is_empty(), "vitals leaked from room A into room B");
+        assert!(
+            view.roster[0].vitals.is_empty(),
+            "vitals leaked from room A into room B"
+        );
     }
 
     #[test]
@@ -1010,21 +1061,13 @@ mod tests {
         {
             p.apply_message(m);
         }
-        let r1 = substrate
-            .cache()
-            .get(ChatViewState::KIND)
-            .unwrap()
-            .revision;
+        let r1 = substrate.cache().get(ChatViewState::KIND).unwrap().revision;
         if let ProjectionInput::Message(m) =
             classify(CHAT_POSTED, &posted(room, Uuid::from_u128(0x2), "two")).unwrap()
         {
             p.apply_message(m);
         }
-        let r2 = substrate
-            .cache()
-            .get(ChatViewState::KIND)
-            .unwrap()
-            .revision;
+        let r2 = substrate.cache().get(ChatViewState::KIND).unwrap().revision;
         assert!(r2 > r1, "revision must advance: {r1:?} -> {r2:?}");
     }
 }

--- a/core/continuum-core/src/ipc/room_purpose.rs
+++ b/core/continuum-core/src/ipc/room_purpose.rs
@@ -1,0 +1,61 @@
+//! `RoomPurposeSource` — the ONE seam that resolves a room's **purpose** (#6).
+//!
+//! A room's purpose is its activity nature — `"chat"`, `"foundry"`, `"scada"`, … — and
+//! it is **recipe-defined, never an enum** ([[room-purpose-is-per-recipe-not-an-enum]]):
+//! a room instantiates a recipe (`RecipeDefinitionShape`), and the recipe's nature IS the
+//! purpose. The positron chat projection dispatches its `Content` on this string, so this
+//! is the seam that makes `activity = room = content = tab` real.
+//!
+//! This is deliberately a **trait**, resolved in ONE place, so the projection never
+//! hardcodes a purpose (it did — `positron_source.rs` said `"chat"` for every room). Today
+//! the default honestly answers `"chat"` (the only recipe live end-to-end); when the
+//! room→recipe store lands, a `RecipeRoomPurpose` impl plugs in here and *every* room —
+//! foundry, scada, academy — reports its own purpose with **zero projection change**. That
+//! is the engine move: de-hardcode once, and the whole dispatch follows the data.
+
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// Resolves a room id → its activity purpose (the `Content` dispatch key).
+pub trait RoomPurposeSource: Send + Sync {
+    /// The room's purpose. MUST be total — an unknown room resolves to the honest
+    /// default (`"chat"`), never a fabricated or panicking value; a room the resolver
+    /// has never seen is simply a plain chat room until its recipe says otherwise.
+    fn purpose_for(&self, room_id: Uuid) -> String;
+}
+
+/// The default until the room→recipe store exists: every room is a chat room. Honest,
+/// not fabricated — `"chat"` is the one recipe wired end-to-end today. Swapped for a
+/// `RecipeRoomPurpose` (reads the room's recipe) in the next brick, no call-site change.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DefaultRoomPurpose;
+
+impl RoomPurposeSource for DefaultRoomPurpose {
+    fn purpose_for(&self, _room_id: Uuid) -> String {
+        "chat".to_string()
+    }
+}
+
+/// The shared handle the projection holds. `Arc<dyn …>` so the concrete resolver is
+/// injected at boot and swapped without touching the projection.
+pub type SharedRoomPurpose = Arc<dyn RoomPurposeSource>;
+
+/// The process default resolver.
+pub fn default_source() -> SharedRoomPurpose {
+    Arc::new(DefaultRoomPurpose)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the default is total + honest — ANY room resolves to "chat"
+    // (never a panic, never a fabricated purpose), so the projection can drop its
+    // hardcode and route through the seam with identical behavior until recipes land.
+    #[test]
+    fn default_resolves_every_room_to_chat() {
+        let src = default_source();
+        assert_eq!(src.purpose_for(Uuid::from_u128(0)), "chat");
+        assert_eq!(src.purpose_for(Uuid::from_u128(42)), "chat");
+    }
+}


### PR DESCRIPTION
First slice of the gene (#6). The positron chat projection hardcoded `purpose: "chat"` for every room. This introduces the ONE seam that resolves room → purpose (the Content dispatch key):

- `ipc/room_purpose.rs` (NEW) — `trait RoomPurposeSource { purpose_for(room_id) -> String }` + `DefaultRoomPurpose` (every room → "chat", honest not fabricated) + `default_source()`. Purpose is an **open String** (recipe-defined, never an enum) — the doctrine answer to the open-value-vs-enum question IntelMac/BigMama raised on airc.
- `ChatProjection` routes through `purpose_for(room_id)` instead of the hardcode. No signature change → zero call-site churn; the real recipe-backed resolver injects later as a one-line change.

Behavior identical today; when the resolver injects, foundry/scada/academy rooms dispatch their own Content with no projection edit. Engine-first: de-hardcode once, dispatch follows the data. 57 ipc tests green + new seam test. Per ALPHA-COMPLETION-BLUEPRINT Workstream C brick 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)