### PR TITLE
docs+chore: factory README + npm run ship/shot aliases; SOTA roadmap (always improve to state of the art)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "stop": "bash tools/scripts/system-stop.sh",
     "install:continuum": "bash tools/scripts/install.sh",
     "setup:git-hooks": "bash tools/scripts/setup-git-hooks.sh",
-    "docker:ensure": "bash scripts/ensure-docker.sh"
+    "docker:ensure": "bash scripts/ensure-docker.sh",
+    "ship": "node scripts/ship.mjs",
+    "shot": "node scripts/shot.mjs"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.76",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,46 @@
+# The factory — dev-loop automation
+
+> Build the factory *with* the product, keep it **state of the art**, and make it run
+> **everywhere the product does** (Windows / macOS / Linux). These tools exist so the
+> repetitive loops cost one command, not eleven, and so the same leverage is available to
+> every citizen — human or persona ([[build-the-factory-as-you-build-the-car]]). Cross-platform
+> by rule: Node or Rust, never bash + OS-specific paths ([[solve-for-public-users]]).
+
+## The two loops, one command each
+
+| Loop | Command | What it does |
+|---|---|---|
+| **Edit → canary** | `node scripts/ship.mjs ["title" ["body"]]` | Push the current feature branch → open a PR into canary → wait for CI → squash-merge → delete branch → sync local canary. Refuses canary/main; a red PR **cannot** be merged (blocks on branch protection; never `--no-verify`/`--admin`). |
+| **See it (never blind)** | `node scripts/shot.mjs [url] [out.png]` | Headless screenshot of a running URL → PNG. OS-detected Chrome/Chromium/Edge; wall-clock guard so a live-WebSocket page can't hang the capture. Default URL `http://localhost:5173/`. |
+
+Typical brick: make the change → validate (cargo test / the live app) → `node scripts/shot.mjs …` to *see* it → `node scripts/ship.mjs "feat(x): …"`. Both are dogfooded (each has shipped itself).
+
+### shot.mjs — seeing the live app
+
+```
+node scripts/shot.mjs "http://localhost:5173/?core=ws://localhost:8974&me=<uuid>" /tmp/app.png
+```
+The web app fails loud if `?core=ws://host:port` (the core WS) or `?me=<uuid>` (sender identity)
+is missing — that error boundary IS the diagnostic. Env: `CHROME`, `SHOT_SIZE` (default `1600,1000`),
+`SHOT_BUDGET_MS` (SPA settle, default `6000`).
+
+## SOTA roadmap — the factory improves toward state of the art
+
+The bar keeps rising; never let a tool sit at "good enough." Known next steps:
+
+1. **`npm run ship` / `npm run shot`** aliases at the root for discoverability (the CLAUDE.md
+   "generators create discoverable systems" ethos).
+2. **A `boot` leg** — one command to build + start the core + web + serving so the see-it loop is
+   runnable from a cold clone (today the stack must already be up). The missing third leg.
+3. **`shot` wait-conditions** — replace the wall-clock guard with a real readiness signal (a DOM
+   marker / CDP `Page.loadEventFired`) so captures are deterministic, not time-boxed.
+4. **cu-native** — fold these into the Rust core as `cu ship` / `cu shot` commands so a **persona
+   (Asha) runs the exact same factory** a human does — the endgame ([[build-the-factory-as-you-build-the-car]]).
+
+5. **Port the rest of the factory off bash** — the existing npm scripts (`start`, `stop`,
+   `install:continuum`, `setup:git-hooks`, `docker:ensure`) all shell out to `bash tools/scripts/*.sh`,
+   which needs Git Bash/WSL on Windows. The whole factory layer should follow `ship`/`shot` to
+   cross-platform Node (or `cu`), so a cold Windows clone works with zero bash. Broader Windows debt.
+
+Discoverable: `npm run ship` / `npm run shot` (cross-platform aliases for the `.mjs` tools).
+Retired: `ship.sh`, `shot.sh` (macOS-only bash — replaced by the portable `.mjs` above).


### PR DESCRIPTION
State-of-the-art tooling is discoverable + documented + portable, not tribal knowledge:
- scripts/README.md — the factory index: the two one-command loops (ship/shot), how to shoot
  the live app, and a SOTA ROADMAP so the bar keeps rising (npm aliases, a boot leg, real
  wait-conditions over the wall-clock guard, cu-native so Asha runs the same factory, and
  porting the rest of the npm-script layer off bash — the broader Windows debt).
- package.json — 'npm run ship' / 'npm run shot' (cross-platform aliases).

Factory improves toward state of the art, always. Dogfooded: shipped by ship.mjs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
