### PR TITLE
fix(web): mobile-responsive collapse (verified) + canonical flex/grid overflow guards

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -91,6 +91,22 @@ export class ChatWidget extends LitElement {
       padding: var(--spacing-sm) 0;
       background: var(--sidebar-background);
     }
+    /* Responsive: below a phone breakpoint the fixed 2-column layout clips the
+       content off-screen. Collapse to a single column — the roster becomes a
+       capped, scrollable strip on top, and the content gets the full width.
+       One step toward the complex-widget-across-surfaces target; a drawer/toggle
+       can come later. (Found by dogfooding shot.mjs at 390px.) */
+    @media (max-width: 720px) {
+      .panels {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto 1fr;
+      }
+      .who {
+        border-right: none;
+        border-bottom: 1px solid var(--border-subtle);
+        max-height: 30vh;
+      }
+    }
     ul {
       list-style: none;
       margin: 0;
@@ -293,6 +309,10 @@ export class ChatWidget extends LitElement {
     .what {
       overflow-y: auto;
       padding: var(--spacing-md) var(--spacing-lg);
+      /* Grid items default to min-width:auto and won't shrink below their content,
+         so a long message makes .what overflow its track and clip at narrow widths.
+         min-width:0 lets it honor the track so the bubbles wrap within the viewport. */
+      min-width: 0;
     }
     .empty {
       color: var(--content-secondary);
@@ -306,6 +326,14 @@ export class ChatWidget extends LitElement {
     }
     .msg-glyph {
       flex: none;
+    }
+    /* The flex child holding the message text MUST be allowed to shrink below its
+       content's intrinsic width, or the bubble overflows its container and clips
+       (mid-word) instead of wrapping — the canonical flexbox min-width:auto trap.
+       Applies at every width; the bubble should never overflow the viewport. */
+    .msg-body {
+      min-width: 0;
+      flex: 1;
     }
     .msg-head {
       display: flex;


### PR DESCRIPTION
Dogfooding shot.mjs at 390px found the app was desktop-only: the fixed 2-column .panels
never reflowed, clipping the content off-screen. Fixes:
- @media (max-width:720px): collapse to single column; roster becomes a capped scrollable
  strip on top, content takes full width. VERIFIED via mobile screenshot (roster moved to
  top, content full-width).
- min-width:0 on .what (grid item) + .msg-body (flex child) — the canonical fix for flex/grid
  children not shrinking below content (min-width:auto trap). Correct-by-reasoning defensive
  guards; belong regardless.

Honest status: the collapse is screenshot-verified. A residual bubble-clip may persist in the
live shot that the min-width guards didn't visibly resolve — confirming it needs DOM/computed-
style inspection, not pixels (a shot.mjs instrument gap → SOTA factory roadmap). One step toward
the complex-widget-across-surfaces target; not the last. Typecheck clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
