### PR TITLE
feat(web): mobile app layer — installable PWA on the shared positron template

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,18 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <!-- Mobile app-layer (PWA): the same positron web template, installable + standalone
+         on a phone. First mobile surface on the one app template; Tauri-mobile native
+         shell is the next app layer. [[joel-crossplatform-native-background]] -->
+    <meta name="theme-color" content="#16161a" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Continuum" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
+    <link rel="apple-touch-icon" href="/icon.svg" />
     <title>Continuum — Chat</title>
     <style>
       html,

--- a/apps/web/public/icon.svg
+++ b/apps/web/public/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Continuum">
+  <rect width="512" height="512" rx="112" fill="#16161a"/>
+  <circle cx="256" cy="256" r="132" fill="none" stroke="#40e0ff" stroke-width="26" opacity="0.9"/>
+  <circle cx="256" cy="256" r="120" fill="none" stroke="#40e0ff" stroke-width="10" opacity="0.25"/>
+  <circle cx="256" cy="256" r="46" fill="#39d98a"/>
+</svg>

--- a/apps/web/public/manifest.webmanifest
+++ b/apps/web/public/manifest.webmanifest
@@ -1,0 +1,14 @@
+{
+  "name": "Continuum",
+  "short_name": "Continuum",
+  "description": "A distributed AI world that runs on your hardware.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#16161a",
+  "theme_color": "#16161a",
+  "icons": [
+    { "src": "/icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ]
+}


### PR DESCRIPTION
'Add mobile soon', step 1. positron is the RN-like layer for all citizens with ONE app template;
desktop is the first app layer, mobile is the same template on a phone host. The web app was
already viewport-correct + responsive (the 720px collapse) — this makes it a real mobile APP:
- public/icon.svg — brand icon (cyan ring + green core, the grid-citizen motif), scalable.
- public/manifest.webmanifest — name/standalone/theme, served at / by vite (200, correct MIME).
- index.html — theme-color + apple/mobile-web-app meta + viewport-fit=cover (notches) + manifest
  link + apple-touch-icon.

Validated: manifest+icon serve 200, display=standalone, typecheck clean. NEXT app layer (native):
Tauri-mobile (desktop already uses Tauri) — the same template + the Rust core via uniffi, per
[[joel-crossplatform-native-background]]. One template, web/desktop first, mobile now → native next.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
