### PR TITLE
feat(positron): defineApp + mount — the define-once keystone (framework moment)

### DIFF
--- a/packages/patterns/app.spec.ts
+++ b/packages/patterns/app.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  defineApp,
+  mount,
+  createContentRegistry,
+  type WorkspaceView,
+  type RenderTarget,
+  type ListingView,
+  type ContentView,
+  type ContextPanelView,
+  type AppSource,
+} from './index';
+
+/** A tiny domain state for the test — the app's input. */
+interface RoomState {
+  room: string;
+  people: string[];
+  message: string;
+}
+
+/** The app, defined ONCE: project domain state → the neutral who/what/where view-model.
+ *  Zero dependency on any target or SDK — the whole point. */
+const app = defineApp<RoomState>({
+  universe: 'test',
+  project: (s): WorkspaceView => ({
+    nav: { id: 'rooms', title: 'Rooms', cells: [{ id: s.room, title: s.room }] },
+    left: [
+      { id: 'roster', title: 'Users & Agents', cells: s.people.map((p) => ({ id: p, title: p })) },
+    ],
+    content: { purpose: 'chat', body: { text: s.message } },
+    context: { listings: [] },
+  }),
+});
+
+/** Two DIFFERENT render targets over the SAME view-model — the outliers that validate
+ *  "define once → many modalities". Each owns its content registry (per-target renderers). */
+function makeTarget(label: string): RenderTarget<string> {
+  const content = createContentRegistry<string>();
+  content.register<{ text: string }>('chat', (b) => `${label}:msg(${b.text})`);
+  const listing = (v: ListingView) =>
+    `${label}:list(${v.title}:${v.cells.map((c) => c.title).join(',')})`;
+  return {
+    listing,
+    content: (v: ContentView) => content.render(v),
+    contextPanel: (v: ContextPanelView) => `${label}:ctx(${v.listings.length})`,
+    workspace: (v: WorkspaceView) =>
+      `${label}:ws[nav=${listing(v.nav)} left=${v.left.map(listing).join('|')} ${content.render(v.content)}]`,
+  };
+}
+
+/** A source that pushes one state synchronously; returns a counting teardown. */
+function oneShotSource(state: RoomState, onTeardown?: () => void): AppSource<RoomState> {
+  return (onState) => {
+    onState(state);
+    return () => onTeardown?.();
+  };
+}
+
+describe('defineApp / mount — define once, render on every modality', () => {
+  // what this catches: the framework keystone. ONE AppDefinition renders through TWO
+  // distinct RenderTargets off the SAME project(). If mount coupled the app to a target
+  // (baked a DOM/Lit/Flutter assumption into defineApp), the two outputs could not diverge
+  // by target while sharing an identical projection. This is the "web + mobile + RAG from
+  // one app" proof at the contract level — before any real Lit/Flutter renderer exists.
+  it('renders one app definition through two distinct targets', () => {
+    const state: RoomState = { room: 'general', people: ['Asha', 'Solenne'], message: 'hi' };
+    const src = oneShotSource(state);
+
+    let web = '';
+    let rag = '';
+    mount(app, src, makeTarget('WEB'), (out) => (web = out));
+    mount(app, src, makeTarget('RAG'), (out) => (rag = out));
+
+    // Same projection (people + message present in both); different target formatting.
+    expect(web).toContain('Asha,Solenne');
+    expect(web).toContain('msg(hi)');
+    expect(web.startsWith('WEB:')).toBe(true);
+    expect(rag.startsWith('RAG:')).toBe(true);
+    // The two outputs are IDENTICAL except the target label — same who/what/where,
+    // different surface. That equivalence IS "define once → all modalities".
+    expect(web.replace(/WEB/g, 'X')).toBe(rag.replace(/RAG/g, 'X'));
+  });
+
+  // what this catches: mount must return a working teardown (unsubscribes the source),
+  // or long-lived mounts leak subscriptions on route/room changes.
+  it('mount returns a teardown that unsubscribes the source', () => {
+    let torn = 0;
+    const src = oneShotSource({ room: 'r', people: [], message: '' }, () => (torn += 1));
+    const stop = mount(app, src, makeTarget('T'), () => {});
+    stop();
+    expect(torn).toBe(1);
+  });
+});

--- a/packages/patterns/index.ts
+++ b/packages/patterns/index.ts
@@ -122,6 +122,62 @@ export interface RenderTarget<Out> {
   workspace(view: WorkspaceView): Out;
 }
 
+// ── defineApp / mount — define an app ONCE, render it on every modality ───────
+
+/**
+ * An app, **defined once**: given domain `State`, `project` it to the neutral
+ * who/what/where `WorkspaceView` — plus its `universe` (look/lore key a target maps
+ * to styling). That is the ENTIRE app: purely neutral, ZERO dependency on the SDK,
+ * the DOM, Flutter, or any target. The same `AppDefinition` mounts to web (Lit),
+ * mobile (Flutter), terminal (ANSI), and RAG — the frameworks paint, positron
+ * defines ([[three-separable-layers-recipe-positron-universe]]).
+ */
+export interface AppDefinition<State> {
+  /** Domain state → the neutral view-model. The app's "what to show". */
+  readonly project: (state: State) => WorkspaceView;
+  /** Universe key (look/lore); a target maps it to its styling. Optional. */
+  readonly universe?: string;
+}
+
+/** A live data source: pushes `State` on every change, returns an unsubscribe.
+ *  Injected at `mount` so the SAME app runs against a real core, a replay, or a test
+ *  fixture — the app never names its source ([[logical-portability-for-unknown-future-integrations]]). */
+export type AppSource<State> = (onState: (state: State) => void) => () => void;
+
+/** A surface sink: receives the target's rendered `Out` on each change and puts it on
+ *  screen (DOM replace, ANSI write, a RAG buffer). Target-specific; the app is not. */
+export type AppSink<Out> = (out: Out) => void;
+
+/**
+ * The framework seam: normalize/return a typed app definition. Identity today; the
+ * single place future validation (universe resolution, activity-coverage checks)
+ * hangs off — build now in a shape that welcomes the future.
+ */
+export function defineApp<State>(def: AppDefinition<State>): AppDefinition<State> {
+  return def;
+}
+
+/**
+ * Mount an app onto ONE modality: `source → project → target.workspace → sink`.
+ * The SAME `app` + `source` mounts to ANY `RenderTarget` — **define once, render
+ * everywhere.** Returns a teardown (unsubscribes the source).
+ *
+ * ```ts
+ * const app = defineApp({ project: chatWorkspace });          // once
+ * mount(app, sdkSource, webTarget,     el.replaceChildren);   // web (Lit)
+ * mount(app, sdkSource, flutterTarget, flutterSink);          // mobile (Flutter)
+ * mount(app, sdkSource, ragTarget,     ragBuffer);            // agents (RAG)
+ * ```
+ */
+export function mount<State, Out>(
+  app: AppDefinition<State>,
+  source: AppSource<State>,
+  target: RenderTarget<Out>,
+  sink: AppSink<Out>,
+): () => void {
+  return source((state) => sink(target.workspace(app.project(state))));
+}
+
 /** Build an empty content-dispatch table for a target. Fail-loud on unknown purpose. */
 export function createContentRegistry<Out>(): ContentRegistry<Out> {
   const table = new Map<string, ContentRenderer<Out>>();


### PR DESCRIPTION
The elevation that turns positron from 'our plumbing' into a framework. An app is defined
ONCE — defineApp({ project: State -> WorkspaceView, universe? }) — utterly neutral: zero
dependency on the SDK, DOM, Flutter, or any target. mount(app, source, target, sink) wires
source -> project -> target.workspace -> sink, so the SAME app renders on ANY RenderTarget:
web(Lit), mobile(Flutter), terminal(ANSI), agents(RAG). The frameworks paint; positron defines.
source injected at mount (real core / replay / test) — the app never names its data.

Proven by outlier-validation: app.spec.ts mounts ONE app through TWO distinct string targets;
the outputs are identical except the target label = same who/what/where, different surface =
'define once -> all modalities' at the contract level. 5/5 patterns tests green, typecheck clean.

Next: refactor apps/web onto it (Lit RenderTarget<TemplateResult> + ChatState->WorkspaceView
project), then a Flutter RenderTarget for mobile — same defineApp, third mount.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
