### PR TITLE
feat(chat-view): chatApp — the chat portal as a first-class defineApp (define-once, real activity)

### DIFF
--- a/packages/chat-view/chatApp.spec.ts
+++ b/packages/chat-view/chatApp.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * chatApp spec — the chat portal, defined ONCE, rendered through a RenderTarget.
+ *
+ * Proves the framework path end-to-end for a REAL activity: `chatApp` (a `defineApp`)
+ * projects a `ChatState` snapshot → the neutral who/what/where `WorkspaceView`, and a
+ * `RenderTarget` draws it. Browser-free — the target here is a string stand-in for
+ * web/mobile/RAG, so this pins the define-once composition without a DOM.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  mount,
+  createContentRegistry,
+  type RenderTarget,
+  type WorkspaceView,
+  type ListingView,
+  type ContentView,
+  type ContextPanelView,
+  type AppSource,
+} from '@continuum/patterns';
+import { chatApp } from './chatApp';
+import type { ChatState, ChatContentBody } from './index';
+import type { ChatMessageView, RosterSlotView, SenderKind } from '@continuum/sdk-typescript';
+
+const kind = (k: SenderKind['kind']): SenderKind => ({ kind: k });
+
+const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
+  member_id: 'm-1',
+  display_name: 'Asha',
+  kind: kind('agent'),
+  integrations: {},
+  provenance: { runtime: '' },
+  active: true,
+  last_seen_ms: 0,
+  vitals: {},
+  ...over,
+});
+
+const message = (over: Partial<ChatMessageView> = {}): ChatMessageView => ({
+  id: 'msg-1',
+  room_id: 'room-1',
+  sender_id: 's-1',
+  sender_name: 'Joel',
+  sender_kind: kind('human'),
+  integrations: {},
+  provenance: { runtime: '' },
+  content: 'hello',
+  timestamp: 0,
+  ...over,
+});
+
+const chatState = (over: Partial<ChatState> = {}): ChatState => ({
+  kind: 'chat',
+  revision: 3,
+  room_id: 'room-1',
+  room_name: 'general',
+  purpose: 'chat',
+  messages: [],
+  roster: [],
+  ...over,
+});
+
+/** A string RenderTarget — a browser-free stand-in for web/mobile/RAG. Stringifies the
+ *  content body so we assert on projected text without pinning VM field names. */
+function stringTarget(): RenderTarget<string> {
+  const content = createContentRegistry<string>();
+  content.register<ChatContentBody>('chat', (b) => JSON.stringify(b.messages));
+  const listing = (v: ListingView): string => `${v.title}[${v.cells.map((c) => c.title).join(',')}]`;
+  return {
+    listing,
+    content: (v: ContentView) => content.render(v),
+    contextPanel: (v: ContextPanelView) => `ctx:${v.listings.length}`,
+    workspace: (v: WorkspaceView) =>
+      `nav=${listing(v.nav)} who=${v.left.map(listing).join('|')} what=${content.render(v.content)}`,
+  };
+}
+
+describe('chatApp — the chat portal defined once, rendered on a target', () => {
+  // what this catches: chatApp composes chatViewModel + chatWorkspace into a defineApp
+  // whose project() yields a WorkspaceView a RenderTarget draws to who/what/where. A
+  // broken composition (wrong order, dropped purpose) would fail-loud on content dispatch
+  // or lose the roster/room/messages — this is the framework path proven for a real activity.
+  it('projects a chat snapshot to who / what / where through a target', () => {
+    const state = chatState({
+      roster: [
+        member({ member_id: 'a', display_name: 'Asha' }),
+        member({ member_id: 'b', display_name: 'Solenne' }),
+      ],
+      messages: [message({ id: 'x', sender_name: 'Asha', content: 'working on vitals' })],
+    });
+    const src: AppSource<ChatState> = (onState) => {
+      onState(state);
+      return () => {};
+    };
+
+    let out = '';
+    mount(chatApp, src, stringTarget(), (o) => (out = o));
+
+    expect(out).toContain('Asha'); // who
+    expect(out).toContain('Solenne'); // who
+    expect(out).toContain('general'); // where (room in nav)
+    expect(out).toContain('working on vitals'); // what (the message content survives projection)
+  });
+});

--- a/packages/chat-view/chatApp.ts
+++ b/packages/chat-view/chatApp.ts
@@ -1,0 +1,28 @@
+/**
+ * The CHAT PORTAL, defined ONCE as a positron app.
+ *
+ * `chatApp` is the first real `defineApp` consumer: it projects a chat snapshot
+ * (`ChatState`) → the neutral who/what/where `WorkspaceView` by composing the two
+ * pieces that already exist — `chatViewModel` (snapshot → render-ready VM) and
+ * `chatWorkspace` (VM → the neutral shell). Nothing here knows about the DOM, Lit,
+ * Flutter, ANSI, or the SDK.
+ *
+ * Mount it on ANY `RenderTarget` and the SAME three-panel portal renders everywhere:
+ * ```ts
+ * mount(chatApp, sdkSource, webTarget,     domSink);      // web   (Lit)
+ * mount(chatApp, sdkSource, flutterTarget, flutterSink);  // mobile(Flutter)
+ * mount(chatApp, sdkSource, ragTarget,     ragBuffer);    // agents(RAG)
+ * ```
+ * Define once, render on every modality.
+ */
+
+import { defineApp, type AppDefinition } from '@continuum/patterns';
+import { chatViewModel } from './chatViewModel';
+import { chatWorkspace } from './patternProjections';
+import type { ChatState } from './ChatState';
+
+/** The chat portal: `ChatState → WorkspaceView`, universe `continuum`. */
+export const chatApp: AppDefinition<ChatState> = defineApp<ChatState>({
+  universe: 'continuum',
+  project: (state) => chatWorkspace(chatViewModel(state)),
+});

--- a/packages/chat-view/chatViewModel.spec.ts
+++ b/packages/chat-view/chatViewModel.spec.ts
@@ -83,9 +83,9 @@ describe('chatViewModel', () => {
         ],
       }),
     );
-    expect(vm.members[0].vitals).toEqual({ energy: 80, attention: 90 });
-    expect(vm.members[1].vitals).toEqual({});
-    expect(vm.members[2].vitals).toEqual({});
+    expect(vm.members[0]?.vitals).toEqual({ energy: 80, attention: 90 });
+    expect(vm.members[1]?.vitals).toEqual({});
+    expect(vm.members[2]?.vitals).toEqual({});
   });
 
   // what this catches: activeCount counts only present members — it drives the

--- a/packages/chat-view/index.ts
+++ b/packages/chat-view/index.ts
@@ -29,3 +29,7 @@ export type {
 // composes into a `Workspace` (nav + left + purpose-keyed content + context).
 export { rosterListing, roomsListing, chatWorkspace } from './patternProjections';
 export type { ChatContentBody } from './patternProjections';
+
+// The chat activity as a positron app, defined ONCE — mount it on any RenderTarget
+// (web/mobile/terminal/RAG). The first real `defineApp` consumer.
+export { chatApp } from './chatApp';


### PR DESCRIPTION
The first real defineApp consumer. chatApp composes the two pieces that already existed
(chatViewModel: snapshot→VM, chatWorkspace: VM→neutral WorkspaceView) into one define-once
app: project ChatState → who/what/where. Zero dependency on DOM/Lit/Flutter/SDK — mount it on
ANY RenderTarget (web/mobile/terminal/RAG) and the same three-panel portal renders everywhere.
Proven end-to-end: chatApp.spec.ts projects a real ChatState fixture (roster + room + messages)
through a string target and asserts who(Asha,Solenne)/where(general)/what(message) all render.
16/16 chat-view tests green, typecheck clean (+ boy-scout fix of 3 pre-existing optional-chain
gaps in chatViewModel.spec.ts). Next: the Lit RenderTarget<TemplateResult> + rewire apps/web
onto mount(chatApp, ...), screenshot-verified; then the Flutter RenderTarget for mobile.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
