### PR TITLE
feat(positron): ListingCell.meters — make the neutral cell lossless (unblocks regression-free rewire)

### DIFF
--- a/packages/chat-view/patternProjections.spec.ts
+++ b/packages/chat-view/patternProjections.spec.ts
@@ -48,6 +48,16 @@ describe('chat → pattern projections', () => {
     expect(l.cells[1]).toMatchObject({ title: 'Joel', glyph: '🧑', status: 'idle', badges: ['human'] });
   });
 
+  // what this catches: a member's vitals ride along as neutral cell `meters`, so a
+  // target draws the ACT bars from the Listing alone — the projection is LOSSLESS and
+  // the rich view-model never has to cross the render boundary. A member with no vitals
+  // carries no `meters` key (absent, not an empty object), so targets draw no meter.
+  it('carries member vitals as neutral cell meters, absent when empty', () => {
+    const cells = rosterListing(vm).cells;
+    expect(cells[0]?.meters).toEqual({ energy: 80, attention: 90 });
+    expect(cells[1]).not.toHaveProperty('meters');
+  });
+
   // what this catches: the focused room projects to the nav `Listing` (the tab
   // bar / channel-attention), carrying its purpose as the cell group.
   it('projects the focused room into the nav Listing', () => {

--- a/packages/chat-view/patternProjections.ts
+++ b/packages/chat-view/patternProjections.ts
@@ -31,11 +31,15 @@ function kindGlyph(kind: MemberKind): string {
   }
 }
 
-/** One roster member → a `Listing` cell (the people-Listing cell template). */
+/** One roster member → a `Listing` cell (the people-Listing cell template). The
+ *  member's genome-energy vitals ride along as neutral cell `meters` so a target draws
+ *  the ACT bars from the Listing alone — the projection is LOSSLESS, no rich view-model
+ *  crosses the render boundary. */
 function rosterCell(m: RosterMemberVM): ListingCell {
   const badges = m.runtime ? [m.kind, m.runtime] : [m.kind];
   const status: CellStatus = m.active ? 'active' : 'idle';
-  return { id: m.id, title: m.name, glyph: kindGlyph(m.kind), badges, status };
+  const cell: ListingCell = { id: m.id, title: m.name, glyph: kindGlyph(m.kind), badges, status };
+  return Object.keys(m.vitals).length > 0 ? { ...cell, meters: m.vitals } : cell;
 }
 
 /** The chat activity's `who` panel projected as the `Listing` primitive. Same shape

--- a/packages/patterns/index.ts
+++ b/packages/patterns/index.ts
@@ -45,6 +45,11 @@ export interface ListingCell {
   readonly status?: CellStatus;
   /** Optional grouping/category key (the "bookmarked menus + categories" axis). */
   readonly group?: string;
+  /** Optional named gauges (0–100), drawn as bars/meters by a target — a member's
+   *  genome-energy vitals, a model's download %, a room's activity. Keeps the neutral
+   *  cell LOSSLESS so rich rows (the roster's ACT meters) survive the projection instead
+   *  of forcing the rich view-model across the boundary. Empty/absent = no meters. */
+  readonly meters?: Readonly<Record<string, number>>;
 }
 
 /** The `Listing` pattern — a repeating list. The SAME shape backs the users list,


### PR DESCRIPTION
Reading the live render path (feedback before code) found the gap: renderChat draws the roster
from the RICH ChatViewModel (with vitals), but the neutral ListingCell had no vitals field — so
routing apps/web purely through the neutral WorkspaceView would REGRESS the ACT meters. The cell
was lossy. Fix (the abstraction emerging to carry what rendering needs):
- ListingCell gains an optional `meters` gauge map — GENERIC (member vitals, model download %,
  room activity), not chat-specific. Drawn as bars by a target.
- rosterCell projects the member's vitals into meters (absent when empty), so a target draws the
  ACT bars from the Listing ALONE — no rich view-model crosses the render boundary.
Now the neutral projection is lossless, so the live mount(chatApp) rewire is regression-free.
17/17 chat-view + 5/5 patterns green, typecheck clean. Next: extract the Lit RenderTarget from
renderChat, rewire apps/web onto mount(chatApp), shot-verify.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
