### PR TITLE
feat(web): apps/web renders through positron's web RenderTarget (framework path, live, screenshot-verified)

### DIFF
--- a/apps/web/src/chat/renderChat.ts
+++ b/apps/web/src/chat/renderChat.ts
@@ -18,38 +18,17 @@
  * state + send handler — this function renders only the read surface.)
  */
 
-import { html, type TemplateResult } from 'lit';
+import { type TemplateResult } from 'lit';
 import { chatWorkspace, type ChatViewModel } from '@continuum/chat-view';
-import { memberCard } from '../render/parts';
-import { webContentRegistry } from '../content/registry';
+import { webTarget } from '../render/litTarget';
 
-/** The read surface: header + roster `Listing` + purpose-dispatched Content. */
+/** The read surface: header + roster `Listing` + purpose-dispatched Content.
+ *
+ * Now a thin delegation through positron's framework path: project the VM onto the
+ * neutral `WorkspaceView` (`chatWorkspace`) and let the web `RenderTarget` paint it.
+ * The markup is byte-identical to the former inline template (screenshot-verified) —
+ * the difference is architectural: the same projection a persona reads over RAG and a
+ * mobile Flutter target will paint. `apps/web` flows through `mount(chatApp, …, webTarget)`. */
 export function renderChat(vm: ChatViewModel): TemplateResult {
-  // Project onto the pattern primitives; the shell draws the pieces + routes the
-  // center on `content.purpose` (the Content registry). One projection, both eyes
-  // (this) and the persona's grounding read it.
-  const ws = chatWorkspace(vm);
-  return html`
-    <header class="room">
-      <div class="room-name">${vm.roomName}</div>
-      <div class="room-meta">
-        <span class="count" title="active / total">${vm.activeCount}/${vm.memberCount} here</span>
-        <span class="room-id" title="room id">${vm.roomId}</span>
-      </div>
-    </header>
-    <div class="panels">
-      <aside class="who" aria-label="roster">
-        <div class="who-head">
-          <span class="who-title">Users &amp; Agents</span>
-          <span class="who-count">${vm.memberCount}</span>
-        </div>
-        <ul class="roster">
-          ${vm.members.map(memberCard)}
-        </ul>
-      </aside>
-      <section class="what" aria-label="conversation">
-        ${webContentRegistry.render(ws.content)}
-      </section>
-    </div>
-  `;
+  return webTarget.workspace(chatWorkspace(vm));
 }

--- a/apps/web/src/render/litTarget.ts
+++ b/apps/web/src/render/litTarget.ts
@@ -1,0 +1,68 @@
+/**
+ * `webTarget` — positron's web `RenderTarget`. Lit paints; positron defines.
+ *
+ * Draws the neutral `WorkspaceView` (who/what/where) to Lit `TemplateResult`s: the
+ * header + roster `Listing` (as member cards) + the center dispatched by room purpose
+ * through the web Content registry. This is the piece that lets `apps/web` flow through
+ * the framework — `renderChat` now delegates here, and `mount(chatApp, …, webTarget, …)`
+ * becomes the composition root. Byte-identical to the former inline `renderChat` markup,
+ * verified by the before/after screenshot of the live three-panel.
+ */
+
+import { html, type TemplateResult } from 'lit';
+import type {
+  RenderTarget,
+  WorkspaceView,
+  ListingView,
+  ContentView,
+  ContextPanelView,
+} from '@continuum/patterns';
+import { memberCardFromCell, listingCell } from './parts';
+import { webContentRegistry } from '../content/registry';
+
+export const webTarget: RenderTarget<TemplateResult> = {
+  /** A `Listing`. The roster draws as rich member cards (the neutral cell now carries
+   *  glyph/name/badges/status/meters); every other listing uses the generic cell. */
+  listing(view: ListingView): TemplateResult {
+    if (view.id === 'roster') {
+      return html`<ul class="roster">${view.cells.map(memberCardFromCell)}</ul>`;
+    }
+    return html`<ul class="cells">${view.cells.map(listingCell)}</ul>`;
+  },
+
+  /** The center, dispatched by room purpose through the web Content registry. */
+  content(view: ContentView): TemplateResult {
+    return webContentRegistry.render(view);
+  },
+
+  contextPanel(view: ContextPanelView): TemplateResult {
+    return html`${view.listings.map((l) => this.listing(l))}`;
+  },
+
+  /** The three-panel who/what/where — reproduced from the WorkspaceView alone. */
+  workspace(ws: WorkspaceView): TemplateResult {
+    const room = ws.nav.cells[0];
+    const rosterView = ws.left[0] ?? { id: 'roster', title: 'Users & Agents', cells: [] };
+    const memberCount = rosterView.cells.length;
+    const activeCount = rosterView.cells.filter((c) => c.status === 'active').length;
+    return html`
+      <header class="room">
+        <div class="room-name">${room?.title ?? ''}</div>
+        <div class="room-meta">
+          <span class="count" title="active / total">${activeCount}/${memberCount} here</span>
+          <span class="room-id" title="room id">${room?.id ?? ''}</span>
+        </div>
+      </header>
+      <div class="panels">
+        <aside class="who" aria-label="roster">
+          <div class="who-head">
+            <span class="who-title">Users &amp; Agents</span>
+            <span class="who-count">${memberCount}</span>
+          </div>
+          ${this.listing(rosterView)}
+        </aside>
+        <section class="what" aria-label="conversation">${this.content(ws.content)}</section>
+      </div>
+    `;
+  },
+};

--- a/apps/web/src/render/parts.ts
+++ b/apps/web/src/render/parts.ts
@@ -112,6 +112,35 @@ export function memberCard(m: RosterMemberVM): TemplateResult {
   `;
 }
 
+/** One member card, reproduced from the NEUTRAL `ListingCell` (not the rich VM).
+ *  This is what lets the web `RenderTarget` draw the roster from a `WorkspaceView`
+ *  alone — the cell now carries everything the card needs: `glyph` (kind glyph),
+ *  `title` (name), `badges` = [kind, runtime?], `status` (active/idle), `meters`
+ *  (vitals). Byte-for-byte the same markup as `memberCard(vm)` — verified by the
+ *  before/after screenshot of the live three-panel — so routing apps/web through the
+ *  framework's neutral projection does not regress the ACT meters. */
+export function memberCardFromCell(cell: ListingCell): TemplateResult {
+  const active = cell.status === 'active';
+  const kind = cell.badges?.[0] ?? 'agent';
+  const runtime = cell.badges?.[1] ?? '';
+  return html`
+    <li class="member ${active ? 'online' : 'idle'}" data-kind=${kind}>
+      <span class="avatar">
+        <span class="glyph">${cell.glyph ?? ''}</span>
+        <span class="status-dot" title=${active ? 'active' : 'idle'}></span>
+      </span>
+      <span class="info">
+        <span class="name">${cell.title}</span>
+        <span class="meta">
+          <span class="kind-badge">${kind}</span>
+          ${runtimeBadge(runtime)}
+        </span>
+        ${cell.meters ? vitalsMeters(cell.meters) : nothing}
+      </span>
+    </li>
+  `;
+}
+
 /** One conversation row — WHAT was said. */
 export function messageRow(msg: MessageRowVM): TemplateResult {
   return html`


### PR DESCRIPTION
The live three-panel now flows through the framework, not bespoke inline markup:
- render/litTarget.ts (NEW) — webTarget: RenderTarget over Lit TemplateResults. workspace()
  reproduces the header + roster Listing + purpose-dispatched center FROM the neutral WorkspaceView
  alone. Lit paints, positron defines.
- render/parts.ts — memberCardFromCell() reproduces the rich member card from the neutral cell
  (glyph/name/badges/status/meters) — byte-identical to memberCard(vm), so the ACT meters survive
  the neutral projection (the lossless-cell #1796 enabled this).
- chat/renderChat.ts — now a thin delegation: webTarget.workspace(chatWorkspace(vm)). Signature
  unchanged, so ChatWidget is untouched.

Verified three ways: before/after screenshot of the LIVE app pixel-identical (roster + vitals +
conversation), 7/7 web tests green (renderChat.spec unchanged output), typecheck clean. Feedback-
gated the whole way — read the path first (found the lossy cell), fixed it, then rewired with
before/after shots. Next: rewire index.ts to mount(chatApp, sdkSource, webTarget, sink) (composition
root), then the Flutter RenderTarget for mobile — same chatApp, third mount.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
