### PR TITLE
feat(tui): terminal renders through positron's ANSI RenderTarget — same chatApp, second surface

### DIFF
--- a/apps/tui/src/ansiTarget.ts
+++ b/apps/tui/src/ansiTarget.ts
@@ -1,0 +1,91 @@
+/**
+ * `createAnsiTarget` — positron's terminal `RenderTarget`. The ANSI twin of apps/web's
+ * `webTarget`: it draws the SAME neutral `WorkspaceView` (who/what/where), but to a
+ * plain multi-line string instead of Lit markup. One `chatApp`, mounted here, renders
+ * the terminal frame; mounted on `webTarget`, the browser three-panel. Define once,
+ * paint per surface.
+ *
+ * The roster's ANSI glyph is derived from the member KIND (carried on the neutral cell
+ * as `badges[0]`), so the terminal picks its own ASCII marker (`* > ~`) while the web
+ * cell keeps its emoji — the target owns the glyph, the cell owns the data. Pure: no
+ * `process`/`stdout`; returns a frame body. `useColor` is closed over so the target
+ * satisfies `RenderTarget<string>` (no per-call flag).
+ */
+
+import { createContentRegistry, type RenderTarget, type WorkspaceView, type ListingView, type ListingCell, type ContentView, type ContextPanelView } from '@continuum/patterns';
+import type { ChatContentBody, MessageRowVM, MemberKind } from '@continuum/chat-view';
+
+const SGR = {
+  reset: '\x1b[0m', bold: '\x1b[1m', dim: '\x1b[2m',
+  green: '\x1b[32m', cyan: '\x1b[36m', yellow: '\x1b[33m', gray: '\x1b[90m',
+} as const;
+type SgrKey = keyof typeof SGR;
+
+/** ASCII glyph per author kind — deterministic column widths across terminals. */
+function kindGlyph(kind: string): string {
+  switch (kind as MemberKind) {
+    case 'human': return '>';
+    case 'agent': return '*';
+    case 'system': return '~';
+    default: return '*';
+  }
+}
+
+/** Build a terminal target for one colour setting. */
+export function createAnsiTarget(useColor = true): RenderTarget<string> {
+  const paint = (code: SgrKey, text: string): string =>
+    useColor ? `${SGR[code]}${text}${SGR.reset}` : text;
+  const runtimeTag = (runtime: string): string => (runtime ? ' ' + paint('gray', `[${runtime}]`) : '');
+
+  /** One roster line from the NEUTRAL cell — WHO is here, with a live presence marker. */
+  const rosterLine = (c: ListingCell): string => {
+    const active = c.status === 'active';
+    const dot = active ? paint('green', '●') : paint('gray', '○');
+    const name = active ? c.title : paint('dim', c.title);
+    const kind = c.badges?.[0] ?? 'agent';
+    const runtime = c.badges?.[1] ?? '';
+    return `  ${dot} ${kindGlyph(kind)} ${name}${runtimeTag(runtime)}`;
+  };
+
+  const messageLine = (msg: MessageRowVM): string => {
+    const time = paint('gray', msg.time);
+    const sender = paint('bold', msg.senderName);
+    return `  ${time} ${kindGlyph(msg.kind)} ${sender}${runtimeTag(msg.runtime)}: ${msg.content}`;
+  };
+
+  const content = createContentRegistry<string>();
+  content.register<ChatContentBody>('chat', (body) =>
+    body.isEmpty
+      ? paint('dim', '  No messages yet — say hello.')
+      : body.messages.map(messageLine).join('\n'),
+  );
+
+  return {
+    listing(view: ListingView): string {
+      if (view.cells.length === 0) return paint('dim', '  (no one here yet)');
+      return view.cells.map(rosterLine).join('\n');
+    },
+    content(view: ContentView): string {
+      return content.render(view);
+    },
+    contextPanel(_view: ContextPanelView): string {
+      return '';
+    },
+    workspace(ws: WorkspaceView): string {
+      const room = ws.nav.cells[0];
+      const roster = ws.left[0]?.cells ?? [];
+      const activeCount = roster.filter((c) => c.status === 'active').length;
+      const lines: string[] = [];
+      lines.push(
+        `${paint('cyan', paint('bold', room?.title ?? ''))}  ${paint('dim', `${activeCount}/${roster.length} here`)} · ${paint('gray', room?.id ?? '')}`,
+      );
+      lines.push('');
+      lines.push(paint('yellow', 'WHO'));
+      lines.push(this.listing(ws.left[0] ?? { id: 'roster', title: '', cells: [] }));
+      lines.push('');
+      lines.push(paint('yellow', 'WHAT'));
+      lines.push(this.content(ws.content));
+      return lines.join('\n');
+    },
+  };
+}

--- a/apps/tui/src/renderChat.spec.ts
+++ b/apps/tui/src/renderChat.spec.ts
@@ -34,8 +34,8 @@ describe('renderChat (ANSI)', () => {
         memberCount: 2,
         activeCount: 1,
         members: [
-          { id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: '' },
-          { id: 'b', name: 'Bo', kind: 'human', active: false, runtime: '' },
+          { id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: '', vitals: {} },
+          { id: 'b', name: 'Bo', kind: 'human', active: false, runtime: '', vitals: {} },
         ],
       }),
       false,
@@ -52,8 +52,8 @@ describe('renderChat (ANSI)', () => {
         memberCount: 2,
         activeCount: 2,
         members: [
-          { id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: 'claude' },
-          { id: 'b', name: 'Nyx', kind: 'agent', active: true, runtime: '' },
+          { id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: 'claude', vitals: {} },
+          { id: 'b', name: 'Nyx', kind: 'agent', active: true, runtime: '', vitals: {} },
         ],
       }),
       false,
@@ -97,7 +97,7 @@ describe('renderChat (ANSI)', () => {
         isEmpty: false,
         memberCount: 1,
         activeCount: 1,
-        members: [{ id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: 'claude' }],
+        members: [{ id: 'a', name: 'Asha', kind: 'agent', active: true, runtime: 'claude', vitals: {} }],
         messages: [
           {
             id: 'm1',

--- a/apps/tui/src/renderChat.ts
+++ b/apps/tui/src/renderChat.ts
@@ -20,87 +20,16 @@
  *   WHAT        — the conversation
  */
 
-import type { ChatViewModel, MemberKind, MessageRowVM, RosterMemberVM } from '@continuum/chat-view';
+import { chatWorkspace, type ChatViewModel } from '@continuum/chat-view';
+import { createAnsiTarget } from './ansiTarget';
 
-/** SGR codes, applied only when `useColor` is on so tests read clean text. */
-const SGR = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  green: '\x1b[32m',
-  cyan: '\x1b[36m',
-  yellow: '\x1b[33m',
-  gray: '\x1b[90m',
-} as const;
-
-type SgrKey = keyof typeof SGR;
-
-/** Wrap `text` in an SGR code, or return it bare when colour is disabled. */
-function paint(useColor: boolean, code: SgrKey, text: string): string {
-  return useColor ? `${SGR[code]}${text}${SGR.reset}` : text;
-}
-
-/** Short glyph per author kind — the neutral human/agent/system discriminant.
- *  ASCII so column widths and tests stay deterministic across terminals. */
-function kindGlyph(kind: MemberKind): string {
-  switch (kind) {
-    case 'human':
-      return '>';
-    case 'agent':
-      return '*';
-    case 'system':
-      return '~';
-  }
-}
-
-/** The runtime origin as a bracket tag, only when the substrate resolved one. */
-function runtimeTag(useColor: boolean, runtime: string): string {
-  return runtime ? ' ' + paint(useColor, 'gray', `[${runtime}]`) : '';
-}
-
-/** One roster line — WHO is here, with a live presence marker. */
-function rosterLine(useColor: boolean, m: RosterMemberVM): string {
-  const dot = m.active ? paint(useColor, 'green', '●') : paint(useColor, 'gray', '○');
-  const name = m.active ? m.name : paint(useColor, 'dim', m.name);
-  const glyph = kindGlyph(m.kind);
-  return `  ${dot} ${glyph} ${name}${runtimeTag(useColor, m.runtime)}`;
-}
-
-/** One conversation line — WHAT was said. */
-function messageLine(useColor: boolean, msg: MessageRowVM): string {
-  const time = paint(useColor, 'gray', msg.time);
-  const glyph = kindGlyph(msg.kind);
-  const sender = paint(useColor, 'bold', msg.senderName);
-  return `  ${time} ${glyph} ${sender}${runtimeTag(useColor, msg.runtime)}: ${msg.content}`;
-}
-
-/** Render the who/what/where surface from one view model to a frame body. */
+/** Render the who/what/where surface from one view model to a frame body.
+ *
+ * Now a thin delegation through positron's framework path: project the VM onto the
+ * neutral `WorkspaceView` (`chatWorkspace`) and let the terminal `RenderTarget` paint
+ * it. Output is byte-identical to the former inline renderer (verified by the tui specs
+ * + `npm run frame`) — the difference is architectural: the SAME projection the web
+ * `webTarget` paints as Lit and a persona reads over RAG. One `chatApp`, per-surface paint. */
 export function renderChat(vm: ChatViewModel, useColor = true): string {
-  const lines: string[] = [];
-
-  // WHERE/WHICH — header.
-  const title = paint(useColor, 'cyan', paint(useColor, 'bold', vm.roomName));
-  const counts = paint(useColor, 'dim', `${vm.activeCount}/${vm.memberCount} here`);
-  const id = paint(useColor, 'gray', vm.roomId);
-  lines.push(`${title}  ${counts} · ${id}`);
-  lines.push('');
-
-  // WHO — roster.
-  lines.push(paint(useColor, 'yellow', 'WHO'));
-  if (vm.members.length === 0) {
-    lines.push(paint(useColor, 'dim', '  (no one here yet)'));
-  } else {
-    for (const m of vm.members) lines.push(rosterLine(useColor, m));
-  }
-  lines.push('');
-
-  // WHAT — conversation.
-  lines.push(paint(useColor, 'yellow', 'WHAT'));
-  if (vm.isEmpty) {
-    lines.push(paint(useColor, 'dim', '  No messages yet — say hello.'));
-  } else {
-    for (const msg of vm.messages) lines.push(messageLine(useColor, msg));
-  }
-
-  return lines.join('\n');
+  return createAnsiTarget(useColor).workspace(chatWorkspace(vm));
 }


### PR DESCRIPTION
The terminal joins the framework, exactly as web did. createAnsiTarget(useColor): RenderTarget<string>
draws the SAME neutral WorkspaceView (who/what/where) to a frame string; renderChat now delegates
createAnsiTarget(useColor).workspace(chatWorkspace(vm)). So ONE chatApp renders on web (Lit,
TemplateResult) AND terminal (ANSI, string) — define once, paint per surface. The tui derives its
ASCII glyph (* > ~) from the member KIND (badges[0]) while web keeps its emoji — the target owns the
glyph, the neutral cell owns the data.

Verified: live `npm run frame` byte-identical (WHO/WHAT/header, the three personas), 12/12 tui tests
green (they assert exact ANSI strings), typecheck clean. Feedback caught a real gap: the tui spec's
member fixtures predate `vitals` and lacked it, so routing through rosterCell (which reads m.vitals)
crashed — completed the fixtures (also fixes their latent type errors). Next: index.ts composition
roots onto mount(chatApp, source, target, sink); then the Flutter RenderTarget for mobile.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
