### PR TITLE
feat(web): vitals meter value readout — the sci-fi gauge shows its number (build→screenshot→iterate)

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -271,9 +271,19 @@ export class ChatWidget extends LitElement {
       width: 22px;
       flex: none;
     }
+    /* Numeric readout — the old sci-fi gauge showed the value, not just a bar. */
+    .vital-value {
+      font-family: var(--font-mono);
+      font-size: 8px;
+      color: var(--content-accent);
+      width: 16px;
+      text-align: right;
+      flex: none;
+      font-variant-numeric: tabular-nums;
+    }
     .vital-track {
       position: relative;
-      height: 3px;
+      height: 4px;
       flex: 1;
       border-radius: 2px;
       background: var(--border-subtle);

--- a/apps/web/src/render/parts.ts
+++ b/apps/web/src/render/parts.ts
@@ -77,16 +77,18 @@ function vitalsMeters(vitals: Record<string, number>): TemplateResult | typeof n
   if (entries.length === 0) return nothing;
   return html`
     <span class="vitals">
-      ${entries.map(
-        ([key, pct]) => html`
+      ${entries.map(([key, pct]) => {
+        const clamped = Math.max(0, Math.min(100, pct));
+        return html`
           <span class="vital" title="${key} ${pct}%">
             <span class="vital-label">${vitalTag(key)}</span>
             <span class="vital-track">
-              <span class="vital-fill" style="width:${Math.max(0, Math.min(100, pct))}%"></span>
+              <span class="vital-fill" style="width:${clamped}%"></span>
             </span>
+            <span class="vital-value">${Math.round(clamped)}</span>
           </span>
-        `,
-      )}
+        `;
+      })}
     </span>
   `;
 }


### PR DESCRIPTION
First sophistication increment on the persona tile, feedback-driven: the ACT meter now shows its
numeric value beside the bar (font-mono, accent, tabular-nums) + a slightly taller track (3→4px),
closer to the old-interface gauges. Verified live: screenshot shows `ACT ▁ 0` on Solenne/Asha — the
0 is honest (activity is genuinely 0 mid-static-conversation; it pulses when they cycle). Multi-meter
(INT/NRG/ATN) + genome block await substrate data (personas emit only `activity` today). Typecheck clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
