### PR TITLE
feat(positron): createRagTarget — proof the AUTOMATIC per-surface model works (RAG rule, authored once)

### DIFF
--- a/packages/chat-view/ragTarget.spec.ts
+++ b/packages/chat-view/ragTarget.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * ragTarget spec — proof the AUTOMATIC per-surface model works.
+ *
+ * The SAME `chatApp` + `WorkspaceView` that `webTarget` renders as a three-panel and
+ * `ansiTarget` renders as WHO/WHAT sections, the RAG rule (`createRagTarget`) renders as
+ * a concise grounding block for a persona's LLM context — room + who + primary content,
+ * ALL chrome dropped. One definition, per-modality RULES, entirely different appropriate
+ * output — like `@media (modality: rag)`. No per-app RAG design; the rule is authored once.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mount, createRagTarget, createContentRegistry, type AppSource } from '@continuum/patterns';
+import { chatApp } from './chatApp';
+import type { ChatState, ChatContentBody } from './index';
+import type { ChatMessageView, RosterSlotView, SenderKind } from '@continuum/sdk-typescript';
+
+const kind = (k: SenderKind['kind']): SenderKind => ({ kind: k });
+const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
+  member_id: 'm-1', display_name: 'Asha', kind: kind('agent'), integrations: {},
+  provenance: { runtime: '' }, active: true, last_seen_ms: 0, vitals: {}, ...over,
+});
+const message = (over: Partial<ChatMessageView> = {}): ChatMessageView => ({
+  id: 'msg-1', room_id: 'room-1', sender_id: 's-1', sender_name: 'Joel',
+  sender_kind: kind('human'), integrations: {}, provenance: { runtime: '' },
+  content: 'hello', timestamp: 0, ...over,
+});
+const chatState = (over: Partial<ChatState> = {}): ChatState => ({
+  kind: 'chat', revision: 3, room_id: 'room-1', room_name: 'general',
+  purpose: 'chat', messages: [], roster: [], ...over,
+});
+
+describe('createRagTarget — the RAG rule derives concise grounding automatically', () => {
+  // what this catches: the RAG rule collapses the semantic WorkspaceView to room + who +
+  // primary content, dropping nav/secondary/context chrome — a fundamentally different,
+  // agent-appropriate output than the human targets, from the identical chatApp. If the
+  // rule leaked chrome (WHO/Users & Agents headings) or dropped the who/content, RAG grounding
+  // would be either bloated or useless. This is the automatic-per-surface model, demonstrated.
+  it('renders room + who + primary content concisely, dropping all chrome', () => {
+    const state = chatState({
+      roster: [
+        member({ member_id: 'a', display_name: 'Asha' }),
+        member({ member_id: 'b', display_name: 'Solenne' }),
+      ],
+      messages: [message({ id: 'x', sender_name: 'Asha', content: 'working on vitals' })],
+    });
+
+    const content = createContentRegistry<string>();
+    content.register<ChatContentBody>('chat', (b) =>
+      b.isEmpty ? 'No messages yet.' : `latest: "${b.messages[b.messages.length - 1]?.content}"`,
+    );
+    const rag = createRagTarget(content);
+    const src: AppSource<ChatState> = (onState) => {
+      onState(state);
+      return () => {};
+    };
+
+    let grounding = '';
+    mount(chatApp, src, rag, (o) => (grounding = o));
+
+    expect(grounding).toContain('You are in "general" with Asha, Solenne'); // room + who
+    expect(grounding).toContain('latest: "working on vitals"'); // primary content
+    expect(grounding).not.toContain('WHO'); // no terminal chrome
+    expect(grounding).not.toContain('Users & Agents'); // no web chrome
+    expect(grounding.split('\n').length).toBeLessThan(4); // concise — a grounding block, not a screen
+  });
+});

--- a/packages/patterns/index.ts
+++ b/packages/patterns/index.ts
@@ -183,6 +183,32 @@ export function mount<State, Out>(
   return source((state) => sink(target.workspace(app.project(state))));
 }
 
+/**
+ * `createRagTarget` — a reusable **RAG adaptation rule**, authored ONCE, that any app
+ * inherits. It proves the automatic-per-surface model ([[best-ux-per-portal-not-identical-projection]]):
+ * given the SAME semantic `WorkspaceView` that web renders as a three-panel and terminal as
+ * WHO/WHAT sections, this derives an entirely different, surface-appropriate output — a
+ * **concise grounding block for a persona's LLM context** — automatically, by RULE, not by
+ * per-app design. The rule: *room + who + primary content; DROP the nav, the secondary
+ * listings, the context chrome* — only what an agent needs to act now. `content` dispatches
+ * the primary body through the caller's registry (the app supplies a concise renderer).
+ */
+export function createRagTarget(content: ContentRegistry<string>): RenderTarget<string> {
+  const names = (v: ListingView): string => v.cells.map((c) => c.title).join(', ');
+  return {
+    // In a grounding block a Listing collapses to just its members' names — no rows, no chrome.
+    listing: (view: ListingView): string => names(view),
+    content: (view: ContentView): string => content.render(view),
+    // Context chrome is dropped entirely — an agent grounds on who + what, not side widgets.
+    contextPanel: (_view: ContextPanelView): string => '',
+    workspace: (ws: WorkspaceView): string => {
+      const room = ws.nav.cells[0]?.title ?? 'a room';
+      const who = ws.left[0] && ws.left[0].cells.length > 0 ? names(ws.left[0]) : 'no one else';
+      return `You are in "${room}" with ${who}.\n${content.render(ws.content)}`;
+    },
+  };
+}
+
 /** Build an empty content-dispatch table for a target. Fail-loud on unknown purpose. */
 export function createContentRegistry<Out>(): ContentRegistry<Out> {
   const table = new Map<string, ContentRenderer<Out>>();


### PR DESCRIPTION
"Might as well try" → it works. createRagTarget is a reusable RAG adaptation RULE (concise grounding:
room + who + primary content; DROP nav/secondary/context chrome), authored ONCE, that any app inherits.
Proof: the SAME chatApp + WorkspaceView that webTarget renders as a three-panel and ansiTarget as
WHO/WHAT sections, the RAG rule renders as:
  You are in "general" with Asha, Solenne.
  latest: "working on vitals"
— entirely different, agent-appropriate output, DERIVED automatically by rule, no per-app RAG design.
That's @media (modality: rag) working: one semantic definition, per-modality rules, best UX per portal
automatically ([[best-ux-per-portal-not-identical-projection]]). 18/18 chat-view + 5/5 patterns green,
typecheck clean. The RenderTarget as an adaptive renderer, not a bespoke design — demonstrated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
