### PR TITLE
feat(tui): love the terminal interface — ● live header, drop the raw UUID

### DIFF
--- a/apps/tui/src/ansiTarget.ts
+++ b/apps/tui/src/ansiTarget.ts
@@ -77,7 +77,7 @@ export function createAnsiTarget(useColor = true): RenderTarget<string> {
       const activeCount = roster.filter((c) => c.status === 'active').length;
       const lines: string[] = [];
       lines.push(
-        `${paint('cyan', paint('bold', room?.title ?? ''))}  ${paint('dim', `${activeCount}/${roster.length} here`)} · ${paint('gray', room?.id ?? '')}`,
+        `${paint('cyan', paint('bold', room?.title ?? ''))}  ${paint('dim', `${activeCount}/${roster.length} here`)} · ${paint('green', '●')} ${paint('dim', 'live')}`,
       );
       lines.push('');
       lines.push(paint('yellow', 'WHO'));


### PR DESCRIPTION
Same critical love-pass as the desktop (#1806), applied to the terminal: the header dropped the
raw room UUID (an eyesore in any surface) for a green `● live` marker — cambriantech  3/3 here · ● live.
Consistent presence language across web + terminal now. Verified: 12/12 tui tests green, live frame
confirms. RAG grounding is already concise/lovable for its purpose (a natural-language grounding block);
mobile strip polished in #1805. Every interface given the designer's-eye pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
