### PR TITLE
feat(positron): toMobileScreen — the mobile adaptation rule, verified without a simulator

### DIFF
--- a/packages/chat-view/mobileScreen.spec.ts
+++ b/packages/chat-view/mobileScreen.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * toMobileScreen spec — the mobile adaptation rule, verified without a simulator.
+ *
+ * The SAME chatApp WorkspaceView the desktop paints as a three-panel, the mobile rule
+ * derives into a phone-native MobileScreen: conversation full-screen (primary), the roster
+ * behind a bottom-nav tab (Who), each cell stripped to presence (no dossier badges/meters).
+ * A Flutter/Swift/Kotlin painter renders MobileScreen → native widgets; this test proves the
+ * RULE is right before any Dart is written. Pixels are the grid's last mile; the rule is here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toMobileScreen } from '@continuum/patterns';
+import { chatApp } from './chatApp';
+import type { ChatState } from './index';
+import type { ChatMessageView, RosterSlotView, SenderKind } from '@continuum/sdk-typescript';
+
+const kind = (k: SenderKind['kind']): SenderKind => ({ kind: k });
+const member = (over: Partial<RosterSlotView> = {}): RosterSlotView => ({
+  member_id: 'm-1', display_name: 'Asha', kind: kind('agent'), integrations: {},
+  provenance: { runtime: 'persona' }, active: true, last_seen_ms: 0,
+  vitals: { activity: 42 }, ...over,
+});
+const message = (over: Partial<ChatMessageView> = {}): ChatMessageView => ({
+  id: 'msg-1', room_id: 'room-1', sender_id: 's-1', sender_name: 'Asha',
+  sender_kind: kind('agent'), integrations: {}, provenance: { runtime: 'persona' },
+  content: 'working on vitals', timestamp: 0, ...over,
+});
+const chatState = (over: Partial<ChatState> = {}): ChatState => ({
+  kind: 'chat', revision: 3, room_id: 'room-1', room_name: 'general',
+  purpose: 'chat', messages: [], roster: [], ...over,
+});
+
+describe('toMobileScreen — the mobile adaptation rule', () => {
+  // what this catches: mobile crammed as a shrunk desktop instead of a designed phone UX.
+  // The rule must make the conversation primary, push the roster to a bottom-nav tab, and
+  // DROP the per-cell dossier (badges/meters) a phone row can't afford — presence, not a
+  // dossier. If the rule leaked the three-panel or kept the dossier, the native painter would
+  // inherit a bad UX. The rule is verified here; the simulator only paints it.
+  it('makes conversation primary, roster a Who tab, and drops the dossier', () => {
+    const state = chatState({
+      roster: [member({ member_id: 'a', display_name: 'Asha' })],
+      messages: [message()],
+    });
+    const screen = toMobileScreen(chatApp.project(state));
+
+    expect(screen.title).toBe('general'); // app bar = room
+    expect(screen.primary.purpose).toBe('chat'); // conversation owns the screen
+    expect(screen.tabs.length).toBe(1); // the roster listing → one bottom-nav tab
+
+    const rosterCell = screen.tabs[0]?.cells[0];
+    expect(rosterCell?.title).toBe('Asha'); // presence kept
+    expect(rosterCell?.status).toBeDefined();
+    expect(rosterCell?.badges).toBeUndefined(); // dossier dropped
+    expect(rosterCell?.meters).toBeUndefined(); // vitals meters dropped for the phone
+  });
+});

--- a/packages/patterns/index.ts
+++ b/packages/patterns/index.ts
@@ -209,6 +209,56 @@ export function createRagTarget(content: ContentRegistry<string>): RenderTarget<
   };
 }
 
+// ── Mobile adaptation rule — authored + tested ONCE, every native painter inherits it ──
+
+/** One bottom-nav destination on the mobile shell: a secondary listing (Who / Where) the
+ *  phone reveals one tab at a time — never all panels crammed at once. */
+export interface MobileTab {
+  readonly id: string;
+  readonly title: string;
+  readonly cells: readonly ListingCell[];
+}
+
+/** The MOBILE adaptation of a `WorkspaceView`: the primary content owns the screen; the
+ *  secondary listings become bottom-nav tabs; per-cell **dossier** detail (badges, meters,
+ *  subtitle) is DROPPED — a phone shows presence, not a dossier. A native painter (Flutter,
+ *  Swift, Kotlin) consumes THIS; the rule that produces it lives + is tested here, so the
+ *  native app is a thin painter, not a place UX decisions are re-made
+ *  ([[best-ux-per-portal-not-identical-projection]]). */
+export interface MobileScreen {
+  readonly title: string;
+  readonly primary: ContentView;
+  readonly tabs: readonly MobileTab[];
+}
+
+/**
+ * `toMobileScreen` — the `@media (modality: mobile)` rule as a pure, testable function.
+ * Derives a phone-native layout from the SAME neutral `WorkspaceView` the desktop paints as
+ * a three-panel: conversation full-screen (`primary`), the who/where listings behind a
+ * bottom nav (`tabs`), each cell stripped to presence essentials (id, title, glyph, status)
+ * — the dossier badges/meters a desktop row can afford are dropped. Authored once; the
+ * Flutter/Swift/Kotlin painter renders `MobileScreen` → native widgets. Verifiable without a
+ * simulator — the rule is logic, the pixels are the grid's last mile.
+ */
+export function toMobileScreen(ws: WorkspaceView): MobileScreen {
+  const presenceOnly = (c: ListingCell): ListingCell => ({
+    id: c.id,
+    title: c.title,
+    ...(c.glyph !== undefined ? { glyph: c.glyph } : {}),
+    ...(c.status !== undefined ? { status: c.status } : {}),
+  });
+  const tab = (v: ListingView): MobileTab => ({
+    id: v.id,
+    title: v.title,
+    cells: v.cells.map(presenceOnly),
+  });
+  return {
+    title: ws.nav.cells[0]?.title ?? '',
+    primary: ws.content,
+    tabs: ws.left.map(tab),
+  };
+}
+
 /** Build an empty content-dispatch table for a target. Fail-loud on unknown purpose. */
 export function createContentRegistry<Out>(): ContentRegistry<Out> {
   const table = new Map<string, ContentRenderer<Out>>();


### PR DESCRIPTION
The way this framework was built for: the mobile UX is a RULE authored + tested once, not a
per-app design and not blind native code. toMobileScreen derives a phone-native MobileScreen from
the SAME chatApp WorkspaceView the desktop paints as a three-panel — conversation full-screen
(primary), the who/where listings behind a bottom nav (tabs), each cell stripped to presence
(id/title/glyph/status; the dossier badges/meters a desktop row affords are DROPPED). A Flutter/
Swift/Kotlin painter renders MobileScreen → native widgets; the RULE is proven here before any Dart.

Same discipline as createRagTarget: verify the logic with a test, not pixels. The native screenshot
is the grid's last mile — the IosSimShot (xcrun simctl) + android capture adapters (task #94) are
already real and waiting for a toolchain box + the app that consumes MobileScreen. 19/19 chat-view +
5/5 patterns green, typecheck clean. Mobile's essence is real and correct; the simulator only paints it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
