### PR TITLE
feat(web): the cosmos universe — a world in MOTION (living generative starfield)

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -20,6 +20,7 @@ import { LitElement, html, css, nothing, type PropertyValues, type TemplateResul
 import type { ChatState } from '@continuum/chat-view';
 import { chatViewModel } from '@continuum/chat-view';
 import { renderChat } from './renderChat';
+import '../render/CosmosBackdrop'; // registers <cosmos-backdrop> for the cosmos universe
 
 /** The send action the host injects. Resolves when the message is accepted by
  *  the core; rejects (fails loud) on a transport/command error the widget shows. */
@@ -608,6 +609,70 @@ export class ChatWidget extends LitElement {
     :host([data-universe='forge']) input {
       color: #efdcc0;
     }
+
+    /* ── UNIVERSE: cosmos ── a universe that MOVES. <cosmos-backdrop> paints a living
+       starfield + constellation network behind translucent glass panels, so the citizens
+       converse afloat in a breathing cosmos. A world in motion, not a colour swap. */
+    :host([data-universe='cosmos']) {
+      position: relative;
+      color: #dfe6ff;
+      background: #05010f;
+    }
+    :host([data-universe='cosmos']) .room,
+    :host([data-universe='cosmos']) .panels,
+    :host([data-universe='cosmos']) form.compose {
+      position: relative;
+      z-index: 1;
+    }
+    :host([data-universe='cosmos']) .room {
+      background: rgba(5, 3, 20, 0.5);
+      backdrop-filter: blur(3px);
+      border-bottom: 1px solid rgba(140, 160, 255, 0.25);
+    }
+    :host([data-universe='cosmos']) .room-name {
+      color: #cfe0ff;
+      letter-spacing: 0.12em;
+      text-shadow: 0 0 12px rgba(120, 160, 255, 0.9);
+    }
+    :host([data-universe='cosmos']) .who {
+      background: rgba(8, 6, 26, 0.4);
+      backdrop-filter: blur(3px);
+      border-color: rgba(140, 160, 255, 0.18);
+    }
+    :host([data-universe='cosmos']) .sender {
+      color: #bcccff;
+      text-shadow: 0 0 8px rgba(120, 160, 255, 0.6);
+    }
+    :host([data-universe='cosmos']) .content {
+      background: rgba(12, 10, 34, 0.46);
+      border: 1px solid rgba(150, 170, 255, 0.28);
+      box-shadow: 0 0 16px rgba(90, 120, 255, 0.1);
+      backdrop-filter: blur(4px);
+    }
+    :host([data-universe='cosmos']) form.compose {
+      background: rgba(8, 6, 26, 0.55);
+      backdrop-filter: blur(4px);
+      border-top-color: rgba(140, 160, 255, 0.2);
+    }
+    :host([data-universe='cosmos']) .live-dot {
+      background: #9ab8ff;
+      box-shadow: 0 0 10px #9ab8ff, 0 0 22px rgba(120, 160, 255, 0.6);
+    }
+    :host([data-universe='cosmos']) .avatar {
+      box-shadow: 0 0 12px rgba(150, 170, 255, 0.5);
+      border-radius: 50%;
+    }
+    :host([data-universe='cosmos']) .status-dot {
+      box-shadow: 0 0 8px currentColor;
+    }
+    :host([data-universe='cosmos']) .who-title,
+    :host([data-universe='cosmos']) .name {
+      color: #c8d4ff;
+      text-shadow: 0 0 6px rgba(120, 160, 255, 0.4);
+    }
+    :host([data-universe='cosmos']) input {
+      color: #dfe6ff;
+    }
   `;
 
   override render(): TemplateResult {
@@ -626,7 +691,9 @@ export class ChatWidget extends LitElement {
       const cause = err instanceof Error ? err.message : String(err);
       return html`<div class="render-error">Interface error rendering this room: ${cause}</div>`;
     }
+    const cosmos = this.getAttribute('data-universe') === 'cosmos';
     return html`
+      ${cosmos ? html`<cosmos-backdrop></cosmos-backdrop>` : nothing}
       ${surface}
       ${this._sendError ? html`<div class="send-error">${this._sendError}</div>` : nothing}
       <form class="compose" @submit=${this.onSubmit}>

--- a/apps/web/src/render/CosmosBackdrop.ts
+++ b/apps/web/src/render/CosmosBackdrop.ts
@@ -1,0 +1,160 @@
+/**
+ * <cosmos-backdrop> — a LIVING generative starfield for the 'cosmos' universe.
+ *
+ * Not a CSS skin: an animated canvas where the citizens converse among drifting,
+ * twinkling stars linked by a faint constellation network that forms + dissolves as they
+ * move — the grid as a breathing mind ([[universe-is-an-experience-not-a-theme]]). Owns
+ * its own requestAnimationFrame lifecycle and sits behind the translucent chat panels.
+ * A universe can be a whole world in MOTION, not just a colour.
+ */
+
+import { LitElement, html, css } from 'lit';
+
+interface Star {
+  x: number;
+  y: number;
+  r: number; // radius (px)
+  vx: number;
+  vy: number;
+  phase: number; // twinkle offset
+}
+
+export class CosmosBackdrop extends LitElement {
+  static override styles = css`
+    :host {
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+      overflow: hidden;
+      pointer-events: none;
+    }
+    canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+  `;
+
+  private _canvas?: HTMLCanvasElement;
+  private _ctx?: CanvasRenderingContext2D | null;
+  private _stars: Star[] = [];
+  private _raf = 0;
+  private _t0 = 0;
+
+  override render() {
+    return html`<canvas></canvas>`;
+  }
+
+  override firstUpdated(): void {
+    this._canvas = this.renderRoot.querySelector('canvas') ?? undefined;
+    this._ctx = this._canvas?.getContext('2d');
+    this._resize();
+    window.addEventListener('resize', this._resize);
+    this._t0 = performance.now();
+    this._raf = requestAnimationFrame(this._loop);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    cancelAnimationFrame(this._raf);
+    window.removeEventListener('resize', this._resize);
+  }
+
+  private _resize = (): void => {
+    if (!this._canvas) return;
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const w = this.offsetWidth || 1200;
+    const h = this.offsetHeight || 800;
+    this._canvas.width = w * dpr;
+    this._canvas.height = h * dpr;
+    this._ctx?.setTransform(dpr, 0, 0, dpr, 0, 0);
+    const count = Math.max(30, Math.min(110, Math.round((w * h) / 15000)));
+    this._stars = Array.from({ length: count }, () => ({
+      x: Math.random() * w,
+      y: Math.random() * h,
+      r: 0.5 + Math.random() * 1.6,
+      vx: (Math.random() - 0.5) * 0.09,
+      vy: (Math.random() - 0.5) * 0.09,
+      phase: Math.random() * Math.PI * 2,
+    }));
+  };
+
+  private _loop = (t: number): void => {
+    const ctx = this._ctx;
+    if (!ctx) return;
+    const w = this.offsetWidth;
+    const h = this.offsetHeight;
+    const time = (t - this._t0) / 1000;
+
+    // deep space
+    ctx.fillStyle = '#05010f';
+    ctx.fillRect(0, 0, w, h);
+
+    // nebula — soft additive blooms that slowly breathe
+    ctx.globalCompositeOperation = 'lighter';
+    const blobs: [number, number, string, number][] = [
+      [w * 0.22, h * 0.24, 'rgba(90,40,180,', 340],
+      [w * 0.80, h * 0.34, 'rgba(30,90,205,', 380],
+      [w * 0.55, h * 0.82, 'rgba(185,40,140,', 320],
+    ];
+    for (const [bx, by, col, r] of blobs) {
+      const pulse = 0.1 + 0.05 * Math.sin(time * 0.3 + bx * 0.01);
+      const g = ctx.createRadialGradient(bx, by, 0, bx, by, r);
+      g.addColorStop(0, `${col}${pulse})`);
+      g.addColorStop(1, `${col}0)`);
+      ctx.fillStyle = g;
+      ctx.fillRect(0, 0, w, h);
+    }
+
+    // drift + wrap
+    for (const s of this._stars) {
+      s.x += s.vx;
+      s.y += s.vy;
+      if (s.x < 0) s.x += w;
+      else if (s.x > w) s.x -= w;
+      if (s.y < 0) s.y += h;
+      else if (s.y > h) s.y -= h;
+    }
+
+    // constellation network — lines between near stars, forming + dissolving
+    const LINK = 130;
+    ctx.lineWidth = 1;
+    for (let i = 0; i < this._stars.length; i++) {
+      for (let j = i + 1; j < this._stars.length; j++) {
+        const a = this._stars[i];
+        const b = this._stars[j];
+        if (!a || !b) continue;
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        const d2 = dx * dx + dy * dy;
+        if (d2 < LINK * LINK) {
+          const alpha = (1 - Math.sqrt(d2) / LINK) * 0.16;
+          ctx.strokeStyle = `rgba(120,180,255,${alpha})`;
+          ctx.beginPath();
+          ctx.moveTo(a.x, a.y);
+          ctx.lineTo(b.x, b.y);
+          ctx.stroke();
+        }
+      }
+    }
+
+    // stars — twinkle with a soft glow
+    for (const s of this._stars) {
+      const tw = 0.5 + 0.5 * Math.sin(time * 1.6 + s.phase);
+      ctx.fillStyle = `rgba(215,228,255,${0.45 * tw + 0.35})`;
+      ctx.shadowColor = 'rgba(150,190,255,0.9)';
+      ctx.shadowBlur = 4 + 3 * tw;
+      ctx.beginPath();
+      ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.shadowBlur = 0;
+    ctx.globalCompositeOperation = 'source-over';
+
+    this._raf = requestAnimationFrame(this._loop);
+  };
+}
+
+if (!customElements.get('cosmos-backdrop')) {
+  customElements.define('cosmos-backdrop', CosmosBackdrop);
+}


### PR DESCRIPTION
Be more creative: a universe that isn't a CSS skin but is genuinely ALIVE. <cosmos-backdrop> is an
animated canvas (own requestAnimationFrame lifecycle) painting a drifting, twinkling starfield linked
by a constellation network that forms + dissolves as the stars move — a soft nebula breathing behind
it. The chat panels go translucent glass (backdrop-filter blur), so the citizens converse AFLOAT in a
living cosmos, the grid as a connected mind ([[universe-is-an-experience-not-a-theme]], [[the-grid-is-alive]]).

?universe=cosmos, same seam as tron/forge (universe key → skin) + one backdrop element, zero app-
definition change. Three worlds now — cold neon grid, warm forge, living cosmos — proving a universe
can be static OR animated, a colour OR a whole moving place. Screenshot-verified at 1280px (stars +
constellation lines + floating glass panels visible); typecheck clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
