### PR TITLE
feat(mobile): the phone is a REAL live client — Dart StateConnection → live core over WS

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- The app is a live client of the continuum core over a WebSocket. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="continuum_mobile"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/apps/mobile/lib/live.dart
+++ b/apps/mobile/lib/live.dart
@@ -1,0 +1,104 @@
+// live.dart — the Dart mirror of the web SDK's StateConnection. Opens a WebSocket to the
+// continuum core, subscribes to kind='chat', and maps each ChatViewState snapshot into a
+// MobileScreen. This is what makes the phone a REAL client of the live room, not a static
+// demo — the same positron state seam the web + terminal read, now on Android.
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart' show Icons;
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'main.dart';
+
+class LiveConnection {
+  final String url;
+  final void Function(MobileScreen) onScreen;
+  WebSocketChannel? _ch;
+
+  LiveConnection(this.url, this.onScreen);
+
+  void connect() {
+    try {
+      final ch = WebSocketChannel.connect(Uri.parse(url));
+      _ch = ch;
+      ch.stream.listen(_onMessage, onError: (_) {}, onDone: () {});
+      // The subscribe frame — same shape as StateConnection.buildSubscribe().
+      ch.sink.add(jsonEncode({
+        'type': 'subscribe',
+        'kinds': ['chat'],
+        'layers': ['ephemeral', 'session', 'persistent', 'semantic'],
+        'last_seen': <dynamic>[],
+      }));
+    } catch (_) {
+      // No core reachable — the app stays on its sample data (honest offline).
+    }
+  }
+
+  void dispose() => _ch?.sink.close();
+
+  void _onMessage(dynamic data) {
+    try {
+      final msg = jsonDecode(data as String) as Map<String, dynamic>;
+      if (msg['type'] != 'state' || msg['kind'] != 'chat') return;
+      onScreen(_fromChat(msg['payload'] as Map<String, dynamic>));
+    } catch (_) {
+      // A malformed frame has no room to render — drop it, keep the last good screen.
+    }
+  }
+
+  MobileScreen _fromChat(Map<String, dynamic> p) {
+    final messages = ((p['messages'] as List?) ?? const []).map((m) {
+      final mm = m as Map<String, dynamic>;
+      return ChatMessage(
+        (mm['sender_name'] as String?) ?? '?',
+        _hhmm(mm['timestamp']),
+        _text(mm['content']),
+      );
+    }).toList();
+    final who = ((p['roster'] as List?) ?? const []).map((r) {
+      final rr = r as Map<String, dynamic>;
+      return MobileCell(
+        (rr['display_name'] as String?) ?? '?',
+        '🤖',
+        (rr['active'] as bool?) ?? false,
+      );
+    }).toList();
+    return MobileScreen(
+      (p['room_name'] as String?) ?? 'room',
+      messages,
+      [
+        MobileTab('chat', 'Chat', Icons.chat_bubble_outline, const []),
+        MobileTab('who', 'Who', Icons.people_outline, who),
+        MobileTab('where', 'Where', Icons.tag, const []),
+      ],
+    );
+  }
+
+  // Content may be a plain string or a `{"text":"…"}` envelope — surface the text.
+  String _text(dynamic c) {
+    if (c is String) {
+      if (c.startsWith('{')) {
+        try {
+          final j = jsonDecode(c);
+          if (j is Map && j['text'] is String) return j['text'] as String;
+        } catch (_) {/* not JSON — use raw */}
+      }
+      return c;
+    }
+    if (c is Map && c['text'] is String) return c['text'] as String;
+    return c?.toString() ?? '';
+  }
+
+  String _hhmm(dynamic ts) {
+    final int ms = ts is int
+        ? ts
+        : ts is double
+            ? ts.toInt()
+            : ts is String
+                ? (int.tryParse(ts) ?? 0)
+                : 0;
+    if (ms == 0) return '';
+    final d = DateTime.fromMillisecondsSinceEpoch(ms).toLocal();
+    return '${d.hour.toString().padLeft(2, '0')}:${d.minute.toString().padLeft(2, '0')}';
+  }
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -12,10 +12,17 @@
 
 import 'package:flutter/material.dart';
 
+import 'live.dart';
+
 void main() => runApp(const ContinuumMobileApp());
 
 // The active universe (from the URL, so a web build can switch worlds).
 final bool _tron = Uri.base.queryParameters['universe'] == 'tron';
+
+// The core's state WS. On the Android emulator, 10.0.2.2 is the host loopback; override
+// with --dart-define=CORE_WS=ws://host:8974 for a device or a different host.
+const String _coreWs =
+    String.fromEnvironment('CORE_WS', defaultValue: 'ws://10.0.2.2:8974');
 
 // ── The mobile view-model (Dart mirror of patterns.MobileScreen) ──
 class MobileCell {
@@ -135,10 +142,27 @@ class MobileScreenView extends StatefulWidget {
 
 class _MobileScreenViewState extends State<MobileScreenView> {
   int _tab = 0;
+  MobileScreen _screen = sample; // sample until the first live snapshot arrives
+  LiveConnection? _live;
+
+  @override
+  void initState() {
+    super.initState();
+    _live = LiveConnection(_coreWs, (screen) {
+      if (mounted) setState(() => _screen = screen);
+    })
+      ..connect();
+  }
+
+  @override
+  void dispose() {
+    _live?.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final s = sample;
+    final s = _screen;
     final whoCount = s.tabs.firstWhere((t) => t.id == 'who').cells.length;
     return Scaffold(
       backgroundColor: _scaffoldBg,

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -192,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -208,6 +224,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.2.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  web_socket_channel:
+    dependency: "direct main"
+    description:
+      name: web_socket_channel
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
 sdks:
   dart: ">=3.12.2 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  web_socket_channel: ^3.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Mobile stopped being a static demo and became a real client of the grid. lib/live.dart is the Dart
mirror of the web SDK's StateConnection: opens a WebSocket to the core, sends the same subscribe frame
({type:'subscribe', kinds:['chat'], layers:[…]}), and maps each incoming ChatViewState snapshot →
MobileScreen (room_name → title, messages → conversation, roster → Who tab; unwraps {"text":…} content,
formats real timestamps). main.dart connects on init and swaps sample→live on the first snapshot;
falls back to sample when offline (honest). Manifest: INTERNET + usesCleartextTraffic for the ws://
emulator→host link (10.0.2.2, overridable via --dart-define=CORE_WS).

Verified END TO END via the android-shot loop: the emulator app shows the ACTUAL live cambriantech
conversation (Asha, real 07:44/07:47 messages about `code/list`), NOT the sample — the same room the
web + terminal read, now on a native Android phone. flutter analyze clean. Mobile is officially in the
iteration loop: change → android-shot → see it live.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
