### PR TITLE
feat(chat): syntax-highlighted + expandable code blocks (web)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@continuum/chat-view": "*",
     "@continuum/foundry-view": "*",
     "@continuum/sdk-typescript": "*",
+    "highlight.js": "^11.11.1",
     "lit": "^3.2.0"
   },
   "devDependencies": {

--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -392,6 +392,105 @@ export class ChatWidget extends LitElement {
     }
     /* Fenced code + commands — personas speak these constantly; a monospace block reads
        as an action, not noise. Scrolls inside itself so a long command never widens the bubble. */
+    /* Expandable code block — a summary bar you can toggle; long commands/outputs stay
+       collapsed so they never bury the conversation. */
+    .code-collapsible {
+      margin: 7px 0 3px;
+      background: rgba(0, 0, 0, 0.32);
+      border: 1px solid var(--border-subtle);
+      border-radius: 7px;
+      overflow: hidden;
+    }
+    .code-collapsible summary {
+      cursor: pointer;
+      padding: 6px 11px;
+      font-family: var(--font-mono);
+      font-size: 10px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--content-secondary);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      list-style: none;
+      user-select: none;
+    }
+    .code-collapsible summary::-webkit-details-marker {
+      display: none;
+    }
+    .code-collapsible summary::before {
+      content: '▸';
+      color: var(--content-accent);
+      font-size: 9px;
+    }
+    .code-collapsible[open] summary::before {
+      content: '▾';
+    }
+    .code-collapsible .code-count {
+      margin-left: auto;
+      opacity: 0.7;
+      text-transform: none;
+      letter-spacing: 0;
+    }
+    .code-collapsible pre {
+      margin: 0;
+      padding: 2px 11px 10px;
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 12.5px;
+      line-height: 1.5;
+      color: var(--content-accent);
+    }
+    .code-collapsible pre code {
+      white-space: pre;
+    }
+    /* highlight.js dark palette (github-dark), scoped into the shadow root. */
+    .hljs {
+      color: #c9d1d9;
+    }
+    .hljs-comment,
+    .hljs-quote {
+      color: #8b949e;
+      font-style: italic;
+    }
+    .hljs-keyword,
+    .hljs-selector-tag,
+    .hljs-built_in,
+    .hljs-name,
+    .hljs-tag {
+      color: #ff7b72;
+    }
+    .hljs-string,
+    .hljs-attr,
+    .hljs-template-tag,
+    .hljs-addition {
+      color: #a5d6ff;
+    }
+    .hljs-title,
+    .hljs-section,
+    .hljs-type {
+      color: #d2a8ff;
+    }
+    .hljs-number,
+    .hljs-literal,
+    .hljs-variable,
+    .hljs-selector-attr {
+      color: #79c0ff;
+    }
+    .hljs-symbol,
+    .hljs-bullet,
+    .hljs-meta {
+      color: #56d364;
+    }
+    .hljs-attribute {
+      color: #ffa657;
+    }
+    .hljs-emphasis {
+      font-style: italic;
+    }
+    .hljs-strong {
+      font-weight: 600;
+    }
     .code-block {
       margin: 7px 0 3px;
       padding: 8px 11px;

--- a/apps/web/src/render/parts.ts
+++ b/apps/web/src/render/parts.ts
@@ -8,6 +8,8 @@
  */
 
 import { html, nothing, type TemplateResult } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import hljs from 'highlight.js/lib/common';
 import type { ListingCell } from '@continuum/patterns';
 import type { MemberKind, MessageRowVM, RosterMemberVM } from '@continuum/chat-view';
 
@@ -149,12 +151,25 @@ export function memberCardFromCell(cell: ListingCell): TemplateResult {
  *  auto-escapes every interpolation, so the code text is inert (no HTML injection). */
 export function formatContent(text: string): TemplateResult {
   const parts: TemplateResult[] = [];
-  const fence = /```[^\n]*\n?([\s\S]*?)```/g;
+  const fence = /```([\w+#.-]*)[ \t]*\n?([\s\S]*?)```/g;
   let last = 0;
   let m: RegExpExecArray | null;
   while ((m = fence.exec(text)) !== null) {
     if (m.index > last) parts.push(inlineCode(text.slice(last, m.index)));
-    parts.push(html`<pre class="code-block"><code>${(m[1] ?? '').replace(/\n+$/, '')}</code></pre>`);
+    const lang = (m[1] ?? '').toLowerCase();
+    const code = (m[2] ?? '').replace(/\n+$/, '');
+    const n = code.length === 0 ? 0 : code.split('\n').length;
+    // Syntax-highlight (fence language, else auto-detect); hljs escapes the code, so the
+    // resulting HTML is inert for unsafeHTML. Expandable: short blocks open, long ones
+    // collapse behind a summary so a big command/output never buries the conversation.
+    const highlighted =
+      lang && hljs.getLanguage(lang)
+        ? hljs.highlight(code, { language: lang, ignoreIllegals: true }).value
+        : hljs.highlightAuto(code).value;
+    parts.push(html`<details class="code-collapsible" ?open=${n <= 3}>
+      <summary>${lang || 'code'}<span class="code-count">${n} ${n === 1 ? 'line' : 'lines'}</span></summary>
+      <pre><code class="hljs">${unsafeHTML(highlighted)}</code></pre>
+    </details>`);
     last = fence.lastIndex;
   }
   if (last < text.length) parts.push(inlineCode(text.slice(last)));

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@continuum/chat-view": "*",
         "@continuum/foundry-view": "*",
         "@continuum/sdk-typescript": "*",
+        "highlight.js": "^11.11.1",
         "lit": "^3.2.0"
       },
       "devDependencies": {
@@ -2741,6 +2742,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ignore": {


### PR DESCRIPTION
Iterating on the code formatting. formatContent now captures the fence language, syntax-highlights
via highlight.js (fence language, else auto-detect; hljs escapes the code, so the HTML is inert for
unsafeHTML) with a github-dark palette scoped into the shadow root, and wraps each block in a native
<details> so it's EXPANDABLE — short blocks open, long commands/outputs collapse behind a summary
(lang · N lines) so they never bury the conversation. Inline `code` still renders as a chip.

Verified: inline chip live on web (Solenne's `commands/list`), typecheck clean. Fenced-block highlighting
uses the standard hljs→unsafeHTML path (the current web snapshot just had no fenced block in frame — the
live code messages are visible on mobile). Mobile syntax-highlighting is the next iteration.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
