### PR TITLE
feat(web): persona tile → live game HUD — avatar state ring + mood emoji + cognition/genome/engine

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -176,6 +176,30 @@ export class ChatWidget extends LitElement {
       border-color: var(--border-accent);
       box-shadow: 0 0 6px rgba(0, 212, 255, 0.18);
     }
+    /* Live inference-state ring — the game HUD's status halo, matching the chat header's
+       "Asha is thinking…". The border carries the state colour; the glow layers over it. */
+    .member .avatar[data-state='thinking'] {
+      border-color: var(--content-accent);
+    }
+    .member .avatar[data-state='active'] {
+      border-color: #3fb950;
+    }
+    .member .avatar[data-state='error'] {
+      border-color: #f85149;
+      box-shadow: 0 0 0 1px #f85149, 0 0 8px rgba(248, 81, 73, 0.55);
+    }
+    .member .avatar[data-state='idle'] {
+      opacity: 0.7;
+    }
+    /* Emotional-event emoji, over the avatar. */
+    .emoji-overlay {
+      position: absolute;
+      bottom: -4px;
+      right: -5px;
+      font-size: 14px;
+      line-height: 1;
+      filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.85));
+    }
     /* A slow breathing "cognition" glow on a LIVE agent — the sci-fi signal that
      * this is a living mind present in the room, not a static row. Paired with the
      * comet arc below; both idle out when the agent goes offline. */

--- a/apps/web/src/render/parts.ts
+++ b/apps/web/src/render/parts.ts
@@ -65,6 +65,31 @@ export function runtimeBadge(runtime: string): TemplateResult | typeof nothing {
   return runtime ? html`<span class="runtime" title="runtime origin">${runtime}</span>` : nothing;
 }
 
+/** The avatar's live inference state — the SAME signal the chat header's "Asha is thinking…"
+ *  reads. Drives the ring colour + pulse. Real thinking/error events are the wiring
+ *  (persona:vitals emitting `error`/inference state); today derived from activity/reason
+ *  (thinking) + presence (active/idle). */
+export function avatarState(v: Readonly<Record<string, number>>, active: boolean): string {
+  if ((v.error ?? 0) > 0) return 'error';
+  if ((v.activity ?? 0) > 25 || (v.reason ?? 0) > 55) return 'thinking';
+  return active ? 'active' : 'idle';
+}
+
+/** An emoji over the avatar for an emotional event. Today a proxy for the dominant cognitive
+ *  faculty; real emotion events (mood/reaction) wire in later — that's the hard part. */
+function emojiOverlay(v: Readonly<Record<string, number>>): TemplateResult | typeof nothing {
+  const faces: Array<[string, number]> = [
+    ['🎯', v.focus ?? 0],
+    ['🤔', v.reason ?? 0],
+    ['💭', v.recall ?? 0],
+    ['⚡', v.act ?? 0],
+  ];
+  faces.sort((a, b) => b[1] - a[1]);
+  const top = faces[0];
+  if (!top || top[1] < 66) return nothing;
+  return html`<span class="emoji-overlay">${top[0]}</span>`;
+}
+
 
 /** The live genome-energy meters — one thin glowing bar per vital the persona
  *  surfaces (energy/attention/compute). Renders nothing when the member reports
@@ -148,9 +173,9 @@ export function personaReadout(v: Readonly<Record<string, number>>): TemplateRes
 export function memberCard(m: RosterMemberVM): TemplateResult {
   return html`
     <li class="member ${m.active ? 'online' : 'idle'}" data-kind=${m.kind}>
-      <span class="avatar">
+      <span class="avatar" data-state=${avatarState(m.vitals, m.active)}>
         <span class="glyph">${kindGlyph(m.kind)}</span>
-        <span class="status-dot" title=${m.active ? 'active' : 'idle'}></span>
+        ${emojiOverlay(m.vitals)}
       </span>
       <span class="info">
         <span class="name">${m.name}</span>
@@ -177,9 +202,9 @@ export function memberCardFromCell(cell: ListingCell): TemplateResult {
   const runtime = cell.badges?.[1] ?? '';
   return html`
     <li class="member ${active ? 'online' : 'idle'}" data-kind=${kind}>
-      <span class="avatar">
+      <span class="avatar" data-state=${avatarState(cell.meters ?? {}, active)}>
         <span class="glyph">${cell.glyph ?? ''}</span>
-        <span class="status-dot" title=${active ? 'active' : 'idle'}></span>
+        ${emojiOverlay(cell.meters ?? {})}
       </span>
       <span class="info">
         <span class="name">${cell.title}</span>


### PR DESCRIPTION
Iterating the user-list widget toward the legacy sci-fi HUD (cyberpunk/Tron, packed with dynamic info):
- AVATAR STATE RING — the live inference-state halo (thinking = cyan, active = green, error = red,
  idle = dim), the SAME signal as the chat header's "Asha is thinking…". avatarState() derives it from
  activity/reason + presence today; real thinking/error events are the wiring (the hard part).
- MOOD EMOJI over the avatar — an emotional-event overlay; today a proxy for the dominant cognitive
  faculty (🎯 focus / 🤔 reason / 💭 recall / ⚡ act), so each persona reads differently at a glance.
- COGNITION DIAMOND + GENOME BARS + ENGINE GAUGES (SPD/PAR) from the prior slice.

All dynamic, all from the vitals map — so the moment the cognition-emission slice wires real
focus/reason/recall/act/speed/size/state events, the whole HUD comes alive with truth. Verified via
?demo (explicit preview flag): three personas render distinct rings, emojis, diamonds. Typecheck clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
