### PR TITLE
feat(web): persona tile → compact 3-pane row (not tall) — matches the legacy HUD density

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -290,14 +290,15 @@ export class ChatWidget extends LitElement {
     /* Live genome-energy meters — the old persona-tile INT/NRG/QUE bars, reborn
      * sci-fi: a thin cyan bar per vital with a moving glint on live agents. The
      * readout that makes a persona feel alive in the roster. */
-    /* The rich persona readout — cognition diamond + genome bars + engine gauges, in a row.
-       Each part appears only when its data is present ([[design-the-persona-as-a-being]]). */
-    .readout {
+    /* RIGHT pane of the 3-pane persona row — cognition diamond + genome bars, pushed right,
+       ~one avatar tall so the row stays COMPACT (not a tall stack). */
+    .cog-cluster {
       display: flex;
       align-items: center;
-      gap: 9px;
-      margin-top: 5px;
-      flex-wrap: wrap;
+      gap: 6px;
+      flex: none;
+      margin-left: auto;
+      padding-left: 8px;
     }
     /* Cognition diamond — four faculties (Focus/Reason/Recall/Act) as four lit triangles;
        the SHAPE is the shape of the mind that instant. */
@@ -305,10 +306,11 @@ export class ChatWidget extends LitElement {
       width: 30px;
       height: 30px;
       flex: none;
+      filter: drop-shadow(0 0 3px rgba(0, 212, 255, 0.4));
     }
     .cog-quad {
       fill: var(--content-accent);
-      stroke: rgba(0, 0, 0, 0.45);
+      stroke: rgba(0, 0, 0, 0.5);
       stroke-width: 0.7;
     }
     .cog-outline {
@@ -317,16 +319,17 @@ export class ChatWidget extends LitElement {
       stroke-width: 1;
       opacity: 0.55;
     }
-    /* Genome bars — one filled segment per loaded LoRA gene (the base model shows none). */
+    /* Genome bars — a compact equalizer, one segment per loaded LoRA gene (base model = empty). */
     .genome {
       display: inline-flex;
       gap: 2px;
-      align-items: center;
+      align-items: flex-end;
       flex: none;
+      height: 28px;
     }
     .gene {
       width: 3px;
-      height: 13px;
+      height: 28px;
       border-radius: 1px;
       background: var(--border-subtle);
     }
@@ -334,16 +337,12 @@ export class ChatWidget extends LitElement {
       background: var(--content-accent);
       box-shadow: 0 0 4px var(--content-accent);
     }
-    .readout .vitals {
-      flex: 1;
-      min-width: 72px;
-      margin-top: 0;
-    }
+    /* CENTER pane — the horizontal engine gauges (SPD/PAR), compact. */
     .vitals {
       display: flex;
       flex-direction: column;
       gap: 2px;
-      margin-top: 4px;
+      margin-top: 3px;
     }
     .vital {
       display: flex;

--- a/apps/web/src/render/parts.ts
+++ b/apps/web/src/render/parts.ts
@@ -161,10 +161,9 @@ export function genomeBlock(v: Readonly<Record<string, number>>): TemplateResult
 export function personaReadout(v: Readonly<Record<string, number>>): TemplateResult | typeof nothing {
   const hasCog = COGNITION.some((k) => (v[k] ?? 0) > 0);
   const genome = genomeBlock(v);
-  const meters = vitalsMeters(v);
-  if (!hasCog && genome === nothing && meters === nothing) return nothing;
-  return html`<span class="readout">
-    ${hasCog ? cognitionDiamond(v) : nothing}${genome}${meters}
+  if (!hasCog && genome === nothing) return nothing;
+  return html`<span class="cog-cluster">
+    ${hasCog ? cognitionDiamond(v) : nothing}${genome}
   </span>`;
 }
 
@@ -183,8 +182,9 @@ export function memberCard(m: RosterMemberVM): TemplateResult {
           <span class="kind-badge">${kindLabel(m.kind)}</span>
           ${runtimeBadge(m.runtime)}
         </span>
-        ${personaReadout(m.vitals)}
+        ${vitalsMeters(m.vitals)}
       </span>
+      ${personaReadout(m.vitals)}
     </li>
   `;
 }
@@ -212,8 +212,9 @@ export function memberCardFromCell(cell: ListingCell): TemplateResult {
           <span class="kind-badge">${kind}</span>
           ${runtimeBadge(runtime)}
         </span>
-        ${cell.meters ? personaReadout(cell.meters) : nothing}
+        ${cell.meters ? vitalsMeters(cell.meters) : nothing}
       </span>
+      ${cell.meters ? personaReadout(cell.meters) : nothing}
     </li>
   `;
 }


### PR DESCRIPTION
"Yikes. Still tall." → fixed. Restructured the persona row from a vertical stack into the legacy's
3-pane layout (docs/images/sidebar-personas.png): LEFT = avatar (state ring + mood emoji), CENTER =
name + badges + the horizontal engine gauges (SPD speed / PAR params), RIGHT = cognition diamond +
genome equalizer, pushed right and sized ~one avatar tall so the row stays compact. Diamond glows
(drop-shadow); genome renders as a compact vertical equalizer.

Verified at desktop width via ?demo: three tight rows, each with distinct ring/emoji/diamond/genome +
SPD/PAR. Typecheck clean. Same neutral vitals map, so the cognition-emission slice still lights it all
up with real data. Next: tighten further + carry the 3-pane to mobile/RAG; then the Rust wiring.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
