### PR TITLE
fix(web): persona tile — rework diamond + genome, kill redundant bars (shorter, cleaner)

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -353,47 +353,39 @@ export class ChatWidget extends LitElement {
     .cog-cluster {
       display: flex;
       align-items: center;
-      gap: 6px;
+      gap: 7px;
       flex: none;
       margin-left: auto;
       padding-left: 8px;
     }
-    /* Cognition diamond — four faculties (Focus/Reason/Recall/Act) as four lit triangles;
-       the SHAPE is the shape of the mind that instant. */
+    /* Cognition diamond — four triangles pointing out like a compass (Focus N / Reason E /
+       Recall S / Act W), each lit by its faculty value; the SHAPE is the mind that instant. */
     .cog-diamond {
-      width: 30px;
-      height: 30px;
-      flex: none;
-      filter: drop-shadow(0 0 3px rgba(0, 212, 255, 0.4));
-    }
-    .cog-quad {
-      fill: var(--content-accent);
-      stroke: rgba(0, 0, 0, 0.5);
-      stroke-width: 0.7;
-    }
-    .cog-outline {
-      fill: none;
-      stroke: var(--content-accent);
-      stroke-width: 1;
-      opacity: 0.55;
-    }
-    /* Genome bars — a compact equalizer, one segment per loaded LoRA gene (base model = empty). */
-    .genome {
-      display: inline-flex;
-      gap: 2px;
-      align-items: flex-end;
-      flex: none;
+      width: 28px;
       height: 28px;
+      flex: none;
+    }
+    .cog-tri {
+      fill: var(--content-accent);
+      filter: drop-shadow(0 0 2px rgba(0, 212, 255, 0.55));
+    }
+    /* Genome — a compact 2-column chip of tiny gene cells (base model shows an empty chip). */
+    .genome {
+      display: grid;
+      grid-template-columns: repeat(2, 5px);
+      grid-auto-rows: 5px;
+      gap: 2px;
+      flex: none;
     }
     .gene {
-      width: 3px;
-      height: 28px;
+      width: 5px;
+      height: 5px;
       border-radius: 1px;
       background: var(--border-subtle);
     }
     .gene.on {
       background: var(--content-accent);
-      box-shadow: 0 0 4px var(--content-accent);
+      box-shadow: 0 0 3px var(--content-accent);
     }
     /* CENTER pane — the horizontal engine gauges (SPD/PAR), compact. */
     .vitals {

--- a/apps/web/src/render/parts.ts
+++ b/apps/web/src/render/parts.ts
@@ -99,17 +99,18 @@ const COGNITION = ['focus', 'reason', 'recall', 'act'] as const;
  *  deep in thought skews toward Reason, one running tools skews toward Act. Dynamic from
  *  cognition events ([[design-the-persona-as-a-being]]). */
 export function cognitionDiamond(v: Readonly<Record<string, number>>): TemplateResult {
-  // Dramatic contrast so the SHAPE reads — a dim faculty nearly vanishes, a strong one
-  // burns bright. All-mid values used to fill in as one solid blob; this shows the mind.
-  const lit = (k: string) => 0.05 + 0.95 * (Math.max(0, Math.min(100, v[k] ?? 0)) / 100);
+  // FOUR distinct triangles pointing out like a compass (N=Focus, E=Reason, S=Recall,
+  // W=Act), a gap in the centre — so it reads as four, and a strong faculty burns bright
+  // while a dim one nearly vanishes (the SHAPE is the mind). No more solid blob.
+  const lit = (k: string) => 0.12 + 0.88 * (Math.max(0, Math.min(100, v[k] ?? 0)) / 100);
   const pct = (k: string) => Math.round(Math.max(0, Math.min(100, v[k] ?? 0)));
-  // corners N(20,2) E(38,20) S(20,38) W(2,20), meeting at centre (20,20).
+  const tri = (pts: string, k: string, label: string) =>
+    svg`<polygon points="${pts}" class="cog-tri" style="opacity:${lit(k)}"><title>${label} ${pct(k)}</title></polygon>`;
   return html`<svg viewBox="0 0 40 40" class="cog-diamond" aria-label="cognition">
-    ${svg`<polygon points="20,20 2,20 20,2" class="cog-quad" style="opacity:${lit('focus')}"><title>Focus ${pct('focus')}%</title></polygon>`}
-    ${svg`<polygon points="20,20 20,2 38,20" class="cog-quad" style="opacity:${lit('reason')}"><title>Reason ${pct('reason')}%</title></polygon>`}
-    ${svg`<polygon points="20,20 38,20 20,38" class="cog-quad" style="opacity:${lit('recall')}"><title>Recall ${pct('recall')}%</title></polygon>`}
-    ${svg`<polygon points="20,20 20,38 2,20" class="cog-quad" style="opacity:${lit('act')}"><title>Act ${pct('act')}%</title></polygon>`}
-    ${svg`<polygon points="20,2 38,20 20,38 2,20" class="cog-outline" />`}
+    ${tri('20,2 12,15 28,15', 'focus', 'Focus')}
+    ${tri('38,20 25,12 25,28', 'reason', 'Reason')}
+    ${tri('20,38 12,25 28,25', 'recall', 'Recall')}
+    ${tri('2,20 15,12 15,28', 'act', 'Act')}
   </svg>`;
 }
 
@@ -127,13 +128,9 @@ export function genomeBlock(v: Readonly<Record<string, number>>): TemplateResult
 /** The rich per-persona readout: cognition diamond + genome bars + the tempo/other meters.
  *  Each part appears only when its data is present — a persona with no cognition emitted yet
  *  simply shows its activity, honestly. */
-/** Every stat the glass-box tile can pack, in order — cognition faculties, then the engine.
- *  Each renders as a tiny label+bar+value; all present ones tile into a dense grid. */
+/** The engine meters shown as bars — the cognition faculties are the DIAMOND, not bars
+ *  (showing them both ways made the tile tall + redundant). Just speed + size here. */
 const STAT_ORDER: ReadonlyArray<readonly [string, string]> = [
-  ['focus', 'FOC'],
-  ['reason', 'REA'],
-  ['recall', 'REC'],
-  ['act', 'ACT'],
   ['speed', 'SPD'],
   ['size', 'PAR'],
 ];


### PR DESCRIPTION
"Still too tall and a mess. Genome/diamond need work." Root cause: the four cognition faculties were
shown TWICE — as FOC/REA/REC/ACT bars AND the diamond — which made it tall + redundant.
- Meters are now ENGINE-ONLY (SPD/PAR); the cognition faculties live solely in the diamond. One fewer
  block, three fewer bar-rows → the row is much shorter.
- DIAMOND reworked into four DISTINCT triangles pointing out like a compass (Focus N / Reason E /
  Recall S / Act W) with a gap in the centre — reads as four, and a strong faculty burns bright while a
  dim one fades (the shape is the mind), instead of the old solid cyan blob.
- GENOME reworked from a 28px equalizer into a compact 2-column chip of tiny gene cells (base model =
  empty chip) — no longer the tallest thing in the row.

Verified at desktop via ?demo: shorter rows, distinct compass diamonds, compact genome chips. Typecheck clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
