### PR TITLE
feat(web): persona tile — the palette (color > monochrome), per-faculty hues

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -381,6 +381,14 @@ export class ChatWidget extends LitElement {
       flex: none;
       font-variant-numeric: tabular-nums;
     }
+    /* Warm the PAR (model-size) meter amber — SPD stays cyan, so the two read apart (palette > mono). */
+    .stat[data-key='size'] .stat-fill {
+      background: linear-gradient(90deg, rgba(255, 176, 32, 0.5), #ffb020);
+      box-shadow: 0 0 4px rgba(255, 176, 32, 0.5);
+    }
+    .stat[data-key='size'] .stat-val {
+      color: #ffb020;
+    }
     /* RIGHT pane of the 3-pane persona row — cognition diamond + genome bars, pushed right,
        ~one avatar tall so the row stays COMPACT (not a tall stack). */
     .cog-cluster {
@@ -398,9 +406,10 @@ export class ChatWidget extends LitElement {
       height: 28px;
       flex: none;
     }
+    /* Each triangle sets its own hue inline (Focus cyan / Reason amber / Recall green /
+       Act orange) — a soft neutral glow keeps the colours popping without a cyan halo. */
     .cog-tri {
-      fill: var(--content-accent);
-      filter: drop-shadow(0 0 2px rgba(0, 212, 255, 0.55));
+      filter: drop-shadow(0 0 1.5px rgba(255, 255, 255, 0.25));
     }
     /* Genome — a compact 2-column chip of tiny gene cells (base model shows an empty chip). */
     .genome {

--- a/apps/web/src/render/parts.ts
+++ b/apps/web/src/render/parts.ts
@@ -102,15 +102,16 @@ export function cognitionDiamond(v: Readonly<Record<string, number>>): TemplateR
   // FOUR distinct triangles pointing out like a compass (N=Focus, E=Reason, S=Recall,
   // W=Act), a gap in the centre — so it reads as four, and a strong faculty burns bright
   // while a dim one nearly vanishes (the SHAPE is the mind). No more solid blob.
-  const lit = (k: string) => 0.12 + 0.88 * (Math.max(0, Math.min(100, v[k] ?? 0)) / 100);
+  const lit = (k: string) => 0.14 + 0.86 * (Math.max(0, Math.min(100, v[k] ?? 0)) / 100);
   const pct = (k: string) => Math.round(Math.max(0, Math.min(100, v[k] ?? 0)));
-  const tri = (pts: string, k: string, label: string) =>
-    svg`<polygon points="${pts}" class="cog-tri" style="opacity:${lit(k)}"><title>${label} ${pct(k)}</title></polygon>`;
+  // Each faculty its own hue (color > monochrome) — readable by colour AND position.
+  const tri = (pts: string, k: string, label: string, color: string) =>
+    svg`<polygon points="${pts}" class="cog-tri" style="fill:${color};opacity:${lit(k)}"><title>${label} ${pct(k)}</title></polygon>`;
   return html`<svg viewBox="0 0 40 40" class="cog-diamond" aria-label="cognition">
-    ${tri('20,2 12,15 28,15', 'focus', 'Focus')}
-    ${tri('38,20 25,12 25,28', 'reason', 'Reason')}
-    ${tri('20,38 12,25 28,25', 'recall', 'Recall')}
-    ${tri('2,20 15,12 15,28', 'act', 'Act')}
+    ${tri('20,2 12,15 28,15', 'focus', 'Focus', '#00d4ff')}
+    ${tri('38,20 25,12 25,28', 'reason', 'Reason', '#ffb020')}
+    ${tri('20,38 12,25 28,25', 'recall', 'Recall', '#3fb950')}
+    ${tri('2,20 15,12 15,28', 'act', 'Act', '#ff6a3d')}
   </svg>`;
 }
 
@@ -147,7 +148,7 @@ export function personaReadout(v: Readonly<Record<string, number>>): TemplateRes
   return html`<span class="stat-grid">
     ${stats.map(([k, label]) => {
       const val = Math.round(Math.max(0, Math.min(100, v[k] ?? 0)));
-      return html`<span class="stat" title="${label} ${val}">
+      return html`<span class="stat" data-key=${k} title="${label} ${val}">
         <span class="stat-label">${label}</span>
         <span class="stat-bar"><span class="stat-fill" style="width:${val}%"></span></span>
         <span class="stat-val">${val}</span>


### PR DESCRIPTION
"Color is better than monochrome if you have the right palette." Applied the reference sheet's cyan +
amber + green + orange:
- COGNITION DIAMOND — each faculty its own hue: Focus cyan / Reason amber / Recall green / Act orange.
  Now readable by COLOUR and position at a glance, not one cyan blob; a soft neutral glow keeps the
  colours popping.
- ENGINE METERS — SPD cyan, PAR amber, so the two gauges read apart.
- GENOME — keeps the cyan+orange dual-tone chip.

Same vitals map, so this palette carries to every surface (the "has to do mobile" + terminal + ARVR-later
point): mobile Flutter + ANSI terminal both do colour, and the neutral cell already flows there — the
persona glass box renders in the same palette everywhere. Verified via ?demo. Typecheck clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
