### PR TITLE
feat(positron): composite read — session unions node + per-user substrate by kind (scoping A cont.)

### DIFF
--- a/core/continuum-positron/src/cache.rs
+++ b/core/continuum-positron/src/cache.rs
@@ -58,6 +58,24 @@ pub struct SubstrateStateCache {
     by_kind: Mutex<HashMap<String, Arc<StateEnvelope>>>,
 }
 
+/// The read seam the session serving needs: "give me the latest envelope for this
+/// kind." Implemented by [`SubstrateStateCache`] (one store) AND by the composite
+/// that unions a node substrate (per-ROOM kinds) with a citizen's per-user substrate
+/// (per-USER kinds), routed by kind — so `apply_subscribe`/`apply_observe` read both
+/// transparently without knowing there are two stores behind the kind. This is what
+/// lets a session see the room's chat AND its own nav, each from the right store.
+pub trait StateSource {
+    /// The latest envelope for `kind`, or `None` if no state exists for it yet
+    /// (honest silence — never a fabricated empty snapshot).
+    fn get_state(&self, kind: &str) -> Option<Arc<StateEnvelope>>;
+}
+
+impl StateSource for SubstrateStateCache {
+    fn get_state(&self, kind: &str) -> Option<Arc<StateEnvelope>> {
+        self.get(kind)
+    }
+}
+
 impl SubstrateStateCache {
     pub fn new() -> Self {
         Self::default()

--- a/core/continuum-positron/src/observer.rs
+++ b/core/continuum-positron/src/observer.rs
@@ -41,7 +41,7 @@ use std::collections::HashSet;
 use positron_core::session::{ClientMessage, ServerMessage};
 use positron_core::wire::{StateEnvelope, StateLayer};
 
-use crate::cache::SubstrateStateCache;
+use crate::cache::{StateSource, SubstrateStateCache};
 use crate::session::should_skip;
 
 /// One AI observer's substrate-recorded registration. Built by
@@ -84,7 +84,7 @@ impl ObserverRegistration {
 /// Returns `Err` if `msg` is NOT an `Observe` variant — single-
 /// purpose handler per [[no-fallbacks-ever]].
 pub fn apply_observe(
-    cache: &SubstrateStateCache,
+    cache: &impl StateSource,
     msg: ClientMessage,
 ) -> Result<(ObserverRegistration, Vec<ServerMessage>), String> {
     let (spec, last_seen) = match msg {
@@ -104,7 +104,7 @@ pub fn apply_observe(
     let mut snapshots: Vec<ServerMessage> = Vec::with_capacity(spec.kinds.len());
 
     for kind in &spec.kinds {
-        let Some(current) = cache.get(kind) else {
+        let Some(current) = cache.get_state(kind) else {
             // Same honest-silence semantic as subscribe: no cached
             // state for this kind → no snapshot to send this cycle.
             continue;

--- a/core/continuum-positron/src/scoping.rs
+++ b/core/continuum-positron/src/scoping.rs
@@ -17,11 +17,19 @@
 //! drift apart. Minimizing the human/persona gap starts with refusing to encode it.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
+use positron_core::wire::StateEnvelope;
 use uuid::Uuid;
 
+use crate::cache::StateSource;
 use crate::Substrate;
+
+/// Kinds that are PER-USER — routed to the citizen's own substrate. Everything
+/// else is per-room and stays on the node substrate. OPEN by data: a new per-user
+/// view (settings, the costume-per-activity pick) adds its kind string here, never
+/// a branch elsewhere. `nav` is the first.
+pub const PER_USER_KINDS: &[&str] = &["nav"];
 
 /// A registry of per-citizen substrates for per-user view kinds. One substrate
 /// per citizen, created on first use. Per-room kinds do NOT come here — they stay
@@ -55,6 +63,37 @@ impl PerUserSubstrates {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .len()
+    }
+}
+
+/// A read view that UNIONS a node substrate (per-room kinds) with a citizen's
+/// per-user substrate (per-user kinds), routed by kind. A session reads through
+/// this and never knows there are two stores — it asks for a kind, gets the right
+/// envelope. This is what lets one session see the room's `chat` AND its own `nav`,
+/// each from the correct store, with no session-code change (it just needs a
+/// [`StateSource`]). Holds two [`Substrate`] handles (Arc-shared — cheap clones).
+pub struct CompositeCache {
+    node: Substrate,
+    per_user: Substrate,
+}
+
+impl CompositeCache {
+    /// Union the shared node substrate with `citizen`'s per-user substrate.
+    pub fn new(node: Substrate, per_user: Substrate) -> Self {
+        Self { node, per_user }
+    }
+}
+
+impl StateSource for CompositeCache {
+    fn get_state(&self, kind: &str) -> Option<Arc<StateEnvelope>> {
+        // Per-user kinds come from the citizen's own store; everything else (the
+        // room's chat/wall/kanban) from the shared node store. Data-routed, no
+        // is-human / is-persona branch — the same union for every citizen.
+        if PER_USER_KINDS.contains(&kind) {
+            self.per_user.cache().get(kind)
+        } else {
+            self.node.cache().get(kind)
+        }
     }
 }
 
@@ -116,5 +155,46 @@ mod tests {
         let _h = reg.for_citizen(human);
         let _p = reg.for_citizen(persona);
         assert_eq!(reg.citizen_count(), 2);
+    }
+
+    #[derive(Debug, Clone, serde::Serialize)]
+    struct TinyRoom {
+        topic: String,
+    }
+    impl positron_core::ViewState for TinyRoom {
+        fn kind(&self) -> &'static str {
+            "chat"
+        }
+    }
+
+    // what this catches: the composite ROUTES by kind — per-room `chat` resolves
+    // from the node store, per-user `nav` from the citizen store — and it does not
+    // merge everything into one place (nav is never in node; chat never in per-user).
+    // This is the union that lets one session see the room AND its own nav.
+    #[test]
+    fn composite_routes_per_user_to_citizen_store_room_to_node() {
+        let node = Substrate::new();
+        let per_user = Substrate::new();
+        node.store(StateBuilder::standalone().session(TinyRoom {
+            topic: "general".into(),
+        }));
+        per_user.store(StateBuilder::standalone().session(TinyNav {
+            current: "room-a".into(),
+        }));
+        let composite = CompositeCache::new(node.clone(), per_user.clone());
+        assert!(
+            composite.get_state("chat").is_some(),
+            "per-room kind resolves from the node store"
+        );
+        assert!(
+            composite.get_state("nav").is_some(),
+            "per-user kind resolves from the citizen's own store"
+        );
+        // The union routes, it does not merge: each store holds only its own kinds.
+        assert!(node.cache().get("nav").is_none(), "nav never lands in the node store");
+        assert!(
+            per_user.cache().get("chat").is_none(),
+            "chat never lands in the per-user store"
+        );
     }
 }

--- a/core/continuum-positron/src/session.rs
+++ b/core/continuum-positron/src/session.rs
@@ -52,7 +52,7 @@ use std::sync::Arc;
 use positron_core::session::{ClientMessage, KindRevision, ServerMessage};
 use positron_core::wire::{StateEnvelope, StateLayer};
 
-use crate::cache::SubstrateStateCache;
+use crate::cache::{StateSource, SubstrateStateCache};
 
 /// One connection's current declared interest set. Created (or
 /// replaced) by [`apply_subscribe`]; consulted by the live-broadcast
@@ -134,7 +134,7 @@ impl Subscription {
 /// - It does not touch `Observe` or `Command` — separate handlers in
 ///   slice 2B.
 pub fn apply_subscribe(
-    cache: &SubstrateStateCache,
+    cache: &impl StateSource,
     msg: ClientMessage,
 ) -> Result<(Subscription, Vec<ServerMessage>), String> {
     let (kinds, layers, last_seen) = match msg {
@@ -154,7 +154,7 @@ pub fn apply_subscribe(
     let mut snapshots: Vec<ServerMessage> = Vec::with_capacity(kinds.len());
 
     for kind in &kinds {
-        let Some(current) = cache.get(kind) else {
+        let Some(current) = cache.get_state(kind) else {
             // No cached state for this kind yet. Per protocol §"Skip
             // rule" parenthetical: "The skip is purely an optimization;
             // when in doubt, send." Sending nothing when there IS


### PR DESCRIPTION
The read half of scoping A. A session must see the room's chat/wall/kanban (per-ROOM, node substrate) AND
its own nav (per-USER, citizen substrate) — from the correct store, transparently.
- StateSource trait (cache.rs): the one read seam apply_subscribe/apply_observe need — get_state(kind).
  SubstrateStateCache implements it (pass-through); apply_subscribe/apply_observe now take &impl StateSource
  instead of &SubstrateStateCache, so the node case is unchanged and a composite slots in.
- CompositeCache (scoping.rs): unions a node Substrate + a citizen's per-user Substrate, routing get_state
  by PER_USER_KINDS (nav today; settings/costume-pick add a string, never a branch). Data-routed, no
  is-human/is-persona branch — the identical union for every citizen.

97 positron tests green: the composite routes (chat→node, nav→citizen; each store holds only its kinds),
and every existing session/observer test still passes (genericization is transparent). NEXT: hand the
connection a CompositeCache per citizen + spawn the nav projector against for_citizen() + broadcast union →
Asha's nav (and yours) render live.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
