### PR TITLE
feat(positron): SessionSubstrate — composite routes read AND broadcast by kind (render prep)

### DIFF
--- a/core/continuum-positron/src/observer.rs
+++ b/core/continuum-positron/src/observer.rs
@@ -41,7 +41,7 @@ use std::collections::HashSet;
 use positron_core::session::{ClientMessage, ServerMessage};
 use positron_core::wire::{StateEnvelope, StateLayer};
 
-use crate::cache::{StateSource, SubstrateStateCache};
+use crate::cache::StateSource;
 use crate::session::should_skip;
 
 /// One AI observer's substrate-recorded registration. Built by
@@ -129,6 +129,7 @@ pub fn apply_observe(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cache::SubstrateStateCache;
     use positron_core::session::KindRevision;
     use positron_core::wire::{ObserverSpec, StateLayer};
 

--- a/core/continuum-positron/src/scoping.rs
+++ b/core/continuum-positron/src/scoping.rs
@@ -20,10 +20,35 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use positron_core::wire::StateEnvelope;
+use tokio::sync::watch;
 use uuid::Uuid;
 
 use crate::cache::StateSource;
 use crate::Substrate;
+
+/// What `run_session` needs from a substrate: the snapshot READ (via
+/// [`StateSource`]) AND the live BROADCAST subscription, both routed by kind. A
+/// plain [`Substrate`] implements it trivially (one store); [`CompositeCache`]
+/// routes each per-USER kind to the citizen's store and each per-ROOM kind to the
+/// node store — so a session's snapshot AND its live updates both come from the
+/// right place, transparently. This is the one seam the session serving loop
+/// generalizes over.
+pub trait SessionSubstrate: StateSource {
+    /// A live receiver for `kind`'s updates, from the store that owns that kind.
+    fn subscribe_kind(&self, kind: &str) -> watch::Receiver<Option<Arc<StateEnvelope>>>;
+}
+
+impl StateSource for Substrate {
+    fn get_state(&self, kind: &str) -> Option<Arc<StateEnvelope>> {
+        self.cache().get(kind)
+    }
+}
+
+impl SessionSubstrate for Substrate {
+    fn subscribe_kind(&self, kind: &str) -> watch::Receiver<Option<Arc<StateEnvelope>>> {
+        self.broadcast().subscribe(kind)
+    }
+}
 
 /// Kinds that are PER-USER — routed to the citizen's own substrate. Everything
 /// else is per-room and stays on the node substrate. OPEN by data: a new per-user
@@ -93,6 +118,19 @@ impl StateSource for CompositeCache {
             self.per_user.cache().get(kind)
         } else {
             self.node.cache().get(kind)
+        }
+    }
+}
+
+impl SessionSubstrate for CompositeCache {
+    fn subscribe_kind(&self, kind: &str) -> watch::Receiver<Option<Arc<StateEnvelope>>> {
+        // Same routing as the read: a per-user kind's LIVE updates come from the
+        // citizen's store, a per-room kind's from the node store — so the session
+        // streams both correctly, not just the initial snapshot.
+        if PER_USER_KINDS.contains(&kind) {
+            self.per_user.subscribe_kind(kind)
+        } else {
+            self.node.subscribe_kind(kind)
         }
     }
 }
@@ -195,6 +233,26 @@ mod tests {
         assert!(
             per_user.cache().get("chat").is_none(),
             "chat never lands in the per-user store"
+        );
+    }
+
+    // what this catches: LIVE nav updates (not just the subscribe snapshot) route
+    // from the citizen's store — a `nav` broadcast subscription taken through the
+    // composite fires when the CITIZEN substrate stores, so the session streams
+    // per-user updates from the right place.
+    #[test]
+    fn composite_broadcast_routes_per_user_updates_to_the_citizen_store() {
+        let node = Substrate::new();
+        let per_user = Substrate::new();
+        let composite = CompositeCache::new(node.clone(), per_user.clone());
+        let mut nav_rx = composite.subscribe_kind("nav");
+        // Store nav to the citizen store — the composite's nav subscriber must see it.
+        per_user.store(StateBuilder::standalone().session(TinyNav {
+            current: "room-a".into(),
+        }));
+        assert!(
+            nav_rx.borrow_and_update().is_some(),
+            "a per-user nav update reaches the composite's nav subscriber"
         );
     }
 }

--- a/core/continuum-positron/src/session.rs
+++ b/core/continuum-positron/src/session.rs
@@ -52,7 +52,7 @@ use std::sync::Arc;
 use positron_core::session::{ClientMessage, KindRevision, ServerMessage};
 use positron_core::wire::{StateEnvelope, StateLayer};
 
-use crate::cache::{StateSource, SubstrateStateCache};
+use crate::cache::StateSource;
 
 /// One connection's current declared interest set. Created (or
 /// replaced) by [`apply_subscribe`]; consulted by the live-broadcast
@@ -216,6 +216,7 @@ pub(crate) fn should_skip(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cache::SubstrateStateCache;
     use positron_core::wire::StateLayer;
 
     fn env(kind: &str, revision: u64) -> StateEnvelope {


### PR DESCRIPTION
The session serving loop uses the substrate for BOTH the snapshot read and the live broadcast, so the
composite must route both. SessionSubstrate = StateSource (read) + subscribe_kind (broadcast), the one
seam run_session will generalize over:
- impl for Substrate: get_state → cache, subscribe_kind → broadcast (a plain node substrate, trivially).
- impl for CompositeCache: per-USER kinds' read AND live updates route to the citizen's store, per-ROOM
  to the node store — so a session streams its own nav live, not just the subscribe snapshot, from the
  right place. Same data-routing, no is-human/is-persona branch.

98+5 tests green including the broadcast-routing proof (a per-user nav update reaches the composite's nav
subscriber). Cleaned the now-test-only SubstrateStateCache imports (zero warnings). NEXT + LAST: generalize
run_session/Connection over SessionSubstrate + thread PerUserSubstrates + the ?me citizen through serve →
build CompositeCache per connection + spawn the nav projector → Asha's nav renders, then screenshot/airc-iterate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
