### PR TITLE
feat(positron): generalize run_session + Connection over SessionSubstrate (render integration, half 1)

### DIFF
--- a/core/continuum-positron/src/connection.rs
+++ b/core/continuum-positron/src/connection.rs
@@ -43,8 +43,8 @@ use positron_core::wire::{CommandEnvelope, CommandSource};
 
 use crate::dispatch::CommandDispatch;
 use crate::observer::{apply_observe, ObserverRegistration};
+use crate::cache::StateSource;
 use crate::session::{apply_subscribe, Subscription};
-use crate::substrate::Substrate;
 
 /// One client session's substrate-recorded state. Cheap to construct
 /// fresh; mutated in place as `ClientMessage`s arrive.
@@ -71,15 +71,15 @@ impl Connection {
     /// Single dispatch point — the variant match is exhaustive per
     /// `[[no-fallbacks-ever]]`. Async because `apply_command` is
     /// async (the dispatcher may be remote).
-    pub async fn handle<D: CommandDispatch + ?Sized>(
+    pub async fn handle<D: CommandDispatch + ?Sized, S: StateSource>(
         &mut self,
         msg: ClientMessage,
-        substrate: &Substrate,
+        source: &S,
         dispatcher: &D,
     ) -> Result<Vec<ServerMessage>, String> {
         match &msg {
-            ClientMessage::Subscribe { .. } => self.handle_subscribe(msg, substrate),
-            ClientMessage::Observe { .. } => self.handle_observe(msg, substrate),
+            ClientMessage::Subscribe { .. } => self.handle_subscribe(msg, source),
+            ClientMessage::Observe { .. } => self.handle_observe(msg, source),
             ClientMessage::Command(_) => self.handle_command(msg, dispatcher).await,
         }
     }
@@ -88,12 +88,12 @@ impl Connection {
     /// per the declarative-replace doctrine; returns snapshot
     /// frames per the snapshot-then-live + exact-equality-skip
     /// rule.
-    pub fn handle_subscribe(
+    pub fn handle_subscribe<S: StateSource>(
         &mut self,
         msg: ClientMessage,
-        substrate: &Substrate,
+        source: &S,
     ) -> Result<Vec<ServerMessage>, String> {
-        let (sub, frames) = apply_subscribe(substrate.cache(), msg)?;
+        let (sub, frames) = apply_subscribe(source, msg)?;
         self.subscription = sub;
         Ok(frames)
     }
@@ -101,12 +101,12 @@ impl Connection {
     /// Handle an `Observe` frame. Inserts (replaces) the observer's
     /// registration under its `observer_id`; returns snapshot
     /// frames per the same resync contract.
-    pub fn handle_observe(
+    pub fn handle_observe<S: StateSource>(
         &mut self,
         msg: ClientMessage,
-        substrate: &Substrate,
+        source: &S,
     ) -> Result<Vec<ServerMessage>, String> {
-        let (reg, frames) = apply_observe(substrate.cache(), msg)?;
+        let (reg, frames) = apply_observe(source, msg)?;
         // HashMap::insert replaces the prior value if any — exactly
         // the protocol's declarative-replace semantics for observers.
         self.observers.insert(reg.observer_id.clone(), reg);
@@ -226,6 +226,7 @@ impl Connection {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::substrate::Substrate;
     use async_trait::async_trait;
     use positron_core::session::KindRevision;
     use positron_core::wire::{

--- a/core/continuum-positron/src/session_task.rs
+++ b/core/continuum-positron/src/session_task.rs
@@ -56,7 +56,7 @@ use tokio::task::JoinHandle;
 
 use crate::connection::Connection;
 use crate::dispatch::CommandDispatch;
-use crate::substrate::Substrate;
+use crate::scoping::SessionSubstrate;
 
 /// How fast a kind's live `State` frames are forwarded on this
 /// connection.
@@ -191,14 +191,15 @@ async fn forward_kind(
 ///
 /// `D` is the dispatcher's type; passing an `Arc<dyn CommandDispatch>`
 /// binds `D = dyn CommandDispatch`.
-pub async fn run_session<D>(
+pub async fn run_session<D, S>(
     mut inbound: mpsc::Receiver<ClientMessage>,
     outbound: mpsc::Sender<ServerMessage>,
-    substrate: Substrate,
+    substrate: S,
     dispatcher: Arc<D>,
 ) -> Result<(), String>
 where
     D: CommandDispatch + ?Sized,
+    S: SessionSubstrate,
 {
     let mut conn = Connection::new();
     let mut forwarders: HashMap<String, Forwarder> = HashMap::new();
@@ -216,7 +217,7 @@ where
             HashMap::new();
         for kind in frame_kinds(&msg) {
             if !forwarders.contains_key(&kind) && !pending.contains_key(&kind) {
-                pending.insert(kind.clone(), substrate.broadcast().subscribe(&kind));
+                pending.insert(kind.clone(), substrate.subscribe_kind(&kind));
             }
         }
 
@@ -246,9 +247,9 @@ where
 /// rates: spawn new kinds (reusing the pre-attached receiver so the
 /// no-lost-update guarantee holds), restart kinds whose rate changed,
 /// and abort kinds no longer wanted.
-fn reconcile_forwarders(
+fn reconcile_forwarders<S: SessionSubstrate>(
     conn: &Connection,
-    substrate: &Substrate,
+    substrate: &S,
     outbound: &mpsc::Sender<ServerMessage>,
     forwarders: &mut HashMap<String, Forwarder>,
     mut pending: HashMap<String, watch::Receiver<Option<Arc<StateEnvelope>>>>,
@@ -270,7 +271,7 @@ fn reconcile_forwarders(
         // latest.
         let rx = pending
             .remove(kind)
-            .unwrap_or_else(|| substrate.broadcast().subscribe(kind));
+            .unwrap_or_else(|| substrate.subscribe_kind(kind));
         let handle = tokio::spawn(forward_kind(rx, *rate, outbound.clone()));
         forwarders.insert(
             kind.clone(),
@@ -300,6 +301,7 @@ fn reconcile_forwarders(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::substrate::Substrate;
     use async_trait::async_trait;
     use positron_core::session::KindRevision;
     use positron_core::wire::{CommandEnvelope, CommandSource, ObserverSpec, StateLayer};


### PR DESCRIPTION
The type-level half of the last-mile render integration — mechanical, behavior-preserving, existing tests
are the net:
- Connection::handle / handle_subscribe / handle_observe now take &impl StateSource (drop the .cache()),
  so they read from whatever source is passed — a plain Substrate OR the composite.
- run_session<D> → run_session<D, S: SessionSubstrate>; reconcile_forwarders<S: SessionSubstrate>; both
  use substrate.subscribe_kind(kind) so the live broadcast routes by kind too, not just the read.

Result: a CompositeCache(node, for_citizen(me)) can now flow straight through the session loop — reads and
live updates both route per-kind to the right store. Existing callers pass a Substrate (which implements
SessionSubstrate) and are unchanged: 103 positron tests green, continuum-core compiles clean, zero warnings.

NEXT (half 2, behavioral): thread PerUserSubstrates + the ?me citizen through serve → handle_ws_connection,
build the CompositeCache per connection, spawn the nav projector for the citizen → Asha's nav (and yours)
renders, then screenshot/glass-box/airc-iterate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
