### PR TITLE
chore(docs): correct present-tense Unsloth lies in live code → llama-server truth (task #54)

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -1784,7 +1784,7 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
 
     /// Create embeddings over the OpenAI-compatible `/v1/embeddings` endpoint.
     /// This is the path continuum's neural recall ([`NeuralEmbeddingProvider`])
-    /// takes through the unsloth gateway — it replaces the in-process
+    /// takes through the local llama-server /v1 gateway — it replaces the in-process
     /// fastembed/ONNX embedder. Degrades to an `Err` (never panics) when the
     /// endpoint is unreachable or the model isn't an embedding model; the caller
     /// falls back to the lexical embedder.

--- a/core/continuum-core/src/cognition/generate_response.rs
+++ b/core/continuum-core/src/cognition/generate_response.rs
@@ -62,7 +62,7 @@ pub const UNKNOWN_MEMBERS: &str = "unknown members";
 const HOUR_GAP_THRESHOLD_MS: u64 = 60 * 60 * 1000;
 
 /// Routing sentinel for the best available local Qwen/llama.cpp runtime.
-// The inference gateway is unsloth (the sole inference path, [[unsloth-universal-model-gateway]]).
+// The inference gateway is our OWN llama-server (the sole local inference path; Unsloth excised).
 // Was "local" (the in-process llama.cpp adapter) — now gated off, so routing the turn
 // to "local" + a hardcoded model id that the gateway doesn't serve would hard-fail
 // select(). The turn binds to the llama-server gateway + the discovered served model

--- a/core/continuum-core/src/modules/ai_provider.rs
+++ b/core/continuum-core/src/modules/ai_provider.rs
@@ -509,13 +509,12 @@ impl AIProviderModule {
         // iteration order which is non-deterministic — caused a bug
         // where qwen3.5 got registered twice and qwen2-vl was skipped.
         // Now we iterate ALL rows uniformly.
-        // NO silent local-inference fallback. unsloth is THE inference path
-        // ([[unsloth-universal-model-gateway]]); unsloth itself serves our forged
-        // GGUF. The in-process llama.cpp adapter is OPT-IN ONLY
-        // (CONTINUUM_LOCAL_LLAMA=1) so the core never registers a local backend by
-        // default and never silently REVERTS to local when unsloth is absent — a
-        // missing gateway fails loud at select(), it does not get papered over with
-        // local inference ([[no-fallbacks-ever]]). Full removal tracked in task #41.
+        // NO silent local-inference fallback. Our OWN llama-server is THE inference
+        // path (Unsloth excised); it serves our forged GGUF over /v1. The in-process
+        // llama.cpp adapter is OPT-IN ONLY (CONTINUUM_LOCAL_LLAMA=1) so the core never
+        // registers a local backend by default and never silently REVERTS to local when
+        // the gateway is absent — a missing gateway fails loud at select(), it does not
+        // get papered over with local inference ([[no-fallbacks-ever]]).
         let local_llama_opt_in =
             crate::config_env::read("CONTINUUM_LOCAL_LLAMA").as_deref() == Some("1");
         if let Some(reg_arc) =

--- a/core/continuum-core/src/modules/dataset.rs
+++ b/core/continuum-core/src/modules/dataset.rs
@@ -359,8 +359,8 @@ impl DatasetService {
     /// flywheel: a persona's recorded room turns (the system prompt + the user
     /// message → the persona's spoken response) become SFT examples in the SAME
     /// `{messages:[{role,content}]}` format the CSV importer emits, then flow
-    /// through the SAME split/write/manifest path. The JSONL is unsloth's
-    /// canonical training input — train a LoRA genome on "chats like this one".
+    /// through the SAME split/write/manifest path. The JSONL is the canonical
+    /// ShareGPT/SFT training input — train a LoRA genome on "chats like this one".
     ///
     /// Source = the recorder's per-turn JSON captures (default
     /// `~/.continuum/fixtures/persona-respond`), NOT engrams — engrams are


### PR DESCRIPTION
Four comments in the live inference/cognition path claimed Unsloth "is THE inference
path" / "the sole inference path" / "the unsloth gateway" — present tense, as if current.
It isn't; our own llama-server is. Worst offender: generate_response.rs said "the inference
gateway is unsloth" one line above code that binds the turn to "the llama-server gateway" —
the comment contradicted its own body. These stale lies are precisely what re-infect a
fresh reader (human or AI) with a wrong mental model of the architecture.

Corrected to reflect reality (no behavior change, comment-only):
- cognition/generate_response.rs — gateway is our OWN llama-server, Unsloth excised.
- ai/openai_adapter.rs — neural embeddings go through the local llama-server /v1 gateway.
- modules/ai_provider.rs — llama-server is THE inference path; serves our forged GGUF.
- modules/dataset.rs — the SFT JSONL is the canonical ShareGPT format, not "unsloth's".

Historical/accurate references (forge/protocol.rs, forge/endpoint.rs — "excised by …")
are left as-is. The deeper module deletion (unsloth_control.rs / unsloth_forge.rs) is
gated on converging modules/forge.rs off them (task #52) and stays a separate careful slice.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
