### PR TITLE
feat(forge): event-driven native training job (mlx_job) + relocate genome types to protocol (task #52)

### DIFF
--- a/core/continuum-core/src/forge/mlx_job.rs
+++ b/core/continuum-core/src/forge/mlx_job.rs
@@ -1,0 +1,179 @@
+//! `forge::mlx_job` — the event-driven training JOB around the proven, synchronous
+//! mlx_lm.lora path ([`crate::forge::mlx_train::run_mlx_train`], task #32's owned
+//! loop, +5.1pts).
+//!
+//! ## Fire-and-EMIT, never poll (Joel: "not a fan of polling")
+//! `run_mlx_train` blocks until the subprocess exits. This wraps it so a caller
+//! gets a handle IMMEDIATELY: the blocking run is offloaded to `spawn_blocking`,
+//! and lifecycle transitions are published two ways:
+//!   1. a `watch` channel → [`current_train_status`] is a cheap READ of the latest
+//!      (what `ai/inference`-style status commands project — never a poll loop),
+//!   2. the airc bus (`forge.train.{started,done,failed}`) → consumers SUBSCRIBE
+//!      (the L3 completion sentinel, any UI, and remote grid towers that offloaded
+//!      the run all react to the SAME event — local and cross-grid, no polling).
+//!
+//! ## Single-resident
+//! One native train at a time on a host (it saturates the GPU/UMA). A second
+//! `train_start` while one runs REPLACES the observed handle — the caller is
+//! expected to gate on [`current_train_status`]`.is_training_running` first.
+//!
+//! ## Why the trainer is injected
+//! `spawn_train_job` takes the training work as a closure so the lifecycle
+//! (started → completed/failed transitions + emits) is unit-tested WITHOUT a real
+//! multi-minute mlx run. Production passes a closure over `run_mlx_train`; tests
+//! pass a fake returning `Ok`/`Err`.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tokio::sync::watch;
+
+use crate::forge::mlx_train::MlxTrainOutput;
+use crate::forge::protocol::TrainStatus;
+use crate::runtime::MessageBus;
+
+/// Bus topic: a native training run has started (payload `{jobId}`).
+pub const EV_TRAIN_STARTED: &str = "forge.train.started";
+/// Bus topic: a run finished successfully (payload `{jobId, adapterDir, …}`) —
+/// the L3 sentinel's cue to convert → eval → page-in.
+pub const EV_TRAIN_DONE: &str = "forge.train.done";
+/// Bus topic: a run failed (payload `{jobId, error}`).
+pub const EV_TRAIN_FAILED: &str = "forge.train.failed";
+
+/// The single-resident live-training observation seam. Holds the latest job's
+/// watch receiver so [`current_train_status`] (and the `ForgeCustodian::train_status`
+/// projection) READ it — never a poll loop. `None` = no native run yet this boot.
+static ACTIVE_JOB: OnceLock<Mutex<Option<watch::Receiver<TrainStatus>>>> = OnceLock::new();
+
+fn registry() -> &'static Mutex<Option<watch::Receiver<TrainStatus>>> {
+    ACTIVE_JOB.get_or_init(|| Mutex::new(None))
+}
+
+/// The current native training status — a READ of the last published watch value.
+/// Honest empty ([`TrainStatus::default`], `phase: ""`) when nothing has run.
+pub fn current_train_status() -> TrainStatus {
+    registry()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .as_ref()
+        .map(|rx| rx.borrow().clone())
+        .unwrap_or_default()
+}
+
+fn running(job_id: &str) -> TrainStatus {
+    TrainStatus {
+        job_id: job_id.to_string(),
+        phase: "training".into(),
+        is_training_running: true,
+        message: "native mlx_lm.lora run in progress".into(),
+        ..Default::default()
+    }
+}
+
+/// Spawn the training work as a tracked, event-emitting job. Returns immediately
+/// (the blocking `train` closure runs on a blocking thread). Publishes `training`
+/// now, then `completed`/`failed` on the watch AND (if `bus` is `Some`) the airc
+/// bus. The returned job_id is the handle a caller keeps.
+pub fn spawn_train_job<F>(job_id: String, bus: Option<Arc<MessageBus>>, train: F) -> String
+where
+    F: FnOnce() -> Result<MlxTrainOutput, String> + Send + 'static,
+{
+    let (tx, rx) = watch::channel(running(&job_id));
+    *registry().lock().unwrap_or_else(|e| e.into_inner()) = Some(rx);
+
+    if let Some(bus) = &bus {
+        bus.publish_async_only(EV_TRAIN_STARTED, serde_json::json!({ "jobId": job_id }));
+    }
+
+    let jid = job_id.clone();
+    tokio::task::spawn_blocking(move || {
+        // The blocking mlx subprocess wait lives HERE, off the async executor.
+        match train() {
+            Ok(output) => {
+                let _ = tx.send(TrainStatus {
+                    job_id: jid.clone(),
+                    phase: "completed".into(),
+                    is_training_running: false,
+                    message: format!("adapter: {}", output.adapter_dir.display()),
+                    ..Default::default()
+                });
+                if let Some(bus) = &bus {
+                    bus.publish_async_only(
+                        EV_TRAIN_DONE,
+                        serde_json::json!({
+                            "jobId": jid,
+                            "adapterDir": output.adapter_dir.display().to_string(),
+                            "adaptersSafetensors": output.adapters_safetensors.display().to_string(),
+                            "adapterConfig": output.adapter_config.display().to_string(),
+                        }),
+                    );
+                }
+            }
+            Err(e) => {
+                let _ = tx.send(TrainStatus {
+                    job_id: jid.clone(),
+                    phase: "failed".into(),
+                    is_training_running: false,
+                    error: Some(e.clone()),
+                    ..Default::default()
+                });
+                if let Some(bus) = &bus {
+                    bus.publish_async_only(
+                        EV_TRAIN_FAILED,
+                        serde_json::json!({ "jobId": jid, "error": e }),
+                    );
+                }
+            }
+        }
+    });
+
+    job_id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn fake_output() -> MlxTrainOutput {
+        MlxTrainOutput {
+            adapter_dir: PathBuf::from("/tmp/adapter"),
+            adapters_safetensors: PathBuf::from("/tmp/adapter/adapters.safetensors"),
+            adapter_config: PathBuf::from("/tmp/adapter/adapter_config.json"),
+        }
+    }
+
+    async fn drive_until(phase: &str) -> TrainStatus {
+        for _ in 0..200 {
+            if current_train_status().phase == phase {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        current_train_status()
+    }
+
+    // what this catches: the job is FIRE-AND-EMIT — spawn returns immediately with a
+    // handle while the (blocking) trainer runs off-thread, the watch transitions
+    // training → completed with NO polling, and a FAILING trainer publishes `failed`
+    // with the error NAMED (never a silent Completed for a genome that never trained
+    // — the exact silent break the Unsloth excision must never introduce). One
+    // sequential test because the registry is single-resident by design (one native
+    // train per host) — parallel scenarios would legitimately clobber each other.
+    #[tokio::test]
+    async fn fire_and_emit_success_then_failure_transitions() {
+        // success: spawn returns the handle immediately; trainer completes off-thread.
+        let jid = spawn_train_job("job-ok".into(), None, || Ok(fake_output()));
+        assert_eq!(jid, "job-ok");
+        let s = drive_until("completed").await;
+        assert_eq!(s.phase, "completed", "reached terminal completed");
+        assert!(!s.is_training_running);
+        assert!(s.error.is_none());
+
+        // failure: a failing trainer names the error, never a silent completed.
+        spawn_train_job("job-err".into(), None, || Err("mlx_lm.lora exploded".into()));
+        let f = drive_until("failed").await;
+        assert_eq!(f.phase, "failed");
+        assert!(!f.is_training_running);
+        assert_eq!(f.error.as_deref(), Some("mlx_lm.lora exploded"));
+    }
+}

--- a/core/continuum-core/src/forge/mod.rs
+++ b/core/continuum-core/src/forge/mod.rs
@@ -15,6 +15,7 @@ pub mod endpoint;
 pub mod gene_handle;
 pub mod grid_custodian;
 pub mod lora_convert;
+pub mod mlx_job;
 pub mod mlx_train;
 pub mod protocol;
 pub mod recipe;

--- a/core/continuum-core/src/forge/protocol.rs
+++ b/core/continuum-core/src/forge/protocol.rs
@@ -98,6 +98,150 @@ pub struct ExportResult {
     pub details: Value,
 }
 
+// ── Genome training-lifecycle types (relocated from the retired
+// inference/unsloth_forge.rs — task #52). The organism-facing contract for
+// train/status/package/probe, home'd HERE beside the export contract so the ONE
+// forge protocol module is the single source of truth every custodian impl
+// (NativeMlxCustodian, ForgeCustodianHttp) speaks. Engine-neutral; not Unsloth-
+// specific (the Unsloth wire bodies died with the module). ────────────────────
+
+/// A training run the organism kicks off on a custodian. The recipe
+/// (`ForgeRecipe`) fills these; the organism never picks the engine — the
+/// custodian dispatches MLX vs CUDA from `model_name` + its own hardware.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgeTrainRequest {
+    /// Base model id/path to fine-tune (the same id the gateway serves with).
+    pub model_name: String,
+    /// `"lora"` (the pageable genome layer — default) | `"full"`.
+    pub training_type: String,
+    /// Dataset format the custodian parses, e.g. `"sharegpt"` / `"alpaca"`.
+    pub format_type: String,
+    /// Local dataset file paths (e.g. the ShareGPT JSONL from `dataset/from-turns`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub local_datasets: Vec<String>,
+    pub num_epochs: u32,
+    /// Learning rate as a STRING (e.g. `"1e-05"`) — passed through verbatim.
+    pub learning_rate: String,
+    pub batch_size: u32,
+    pub gradient_accumulation_steps: u32,
+    pub max_seq_length: u32,
+    /// 4-bit base load (QLoRA) — the custodian's memory/quality knob.
+    pub load_in_4bit: bool,
+    /// LoRA path (vs full fine-tune). The genome layer is a LoRA.
+    pub use_lora: bool,
+    /// Genome knobs sent EXPLICITLY — the recipe owns them, never silent defaults.
+    pub lora_r: u32,
+    pub lora_alpha: u32,
+    pub lora_dropout: f64,
+}
+
+/// The handle a custodian returns when a run starts — the organism keeps the
+/// `job_id` to observe [`TrainStatus`]. Byte custody stays custodian-side.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TrainHandle {
+    #[serde(default)]
+    pub job_id: String,
+    #[serde(default)]
+    pub message: String,
+}
+
+/// Live training status — the inspectable progress of a run. `phase` is
+/// `"idle"`/`"training"`/…; `details` carries step/loss for the metric stream.
+/// Sourced from the job actor's published watch snapshot — a READ, never a poll.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TrainStatus {
+    #[serde(default)]
+    pub job_id: String,
+    #[serde(default)]
+    pub phase: String,
+    #[serde(default)]
+    pub is_training_running: bool,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub details: TrainProgress,
+}
+
+/// The numeric progress inside a run (`status.details`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TrainProgress {
+    #[serde(default)]
+    pub epoch: f64,
+    #[serde(default)]
+    pub step: u64,
+    #[serde(default)]
+    pub total_steps: u64,
+    #[serde(default)]
+    pub loss: Option<f64>,
+}
+
+/// What to package a trained checkpoint INTO — the genetic OUTCOME the organism
+/// names. The custodian owns the HOW; continuum declares the target form. A
+/// custodian that emits a new family of layers extends THIS enum, never the call.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GenomeFormat {
+    /// The pageable LoRA genome layer (adapter as-is, PEFT/safetensors).
+    Lora { base_model_id: Option<String> },
+    /// A fused + quantized standalone GGUF (`quantization` e.g. `"Q4_K_M"`).
+    Gguf { quantization: String },
+    /// A GGUF LoRA *adapter* — the pageable gene `llama-server --lora` loads and
+    /// the per-request `"lora":[{id,scale}]` dial scales. DISTINCT from [`Gguf`]
+    /// (a fused standalone model): this is the adapter ALONE, the thing the genome
+    /// pages in/out over a shared base — the SUPPLY side of the page-in loop
+    /// (`cognition/eval`'s `gene` pages exactly this in to measure lift).
+    /// `base_model_id` is REQUIRED (a GGUF LoRA with no base is meaningless — the
+    /// invariant lives in the type). `outtype` = adapter weight type (`"f16"`).
+    GgufLora {
+        base_model_id: String,
+        outtype: String,
+    },
+}
+
+/// Package a trained checkpoint into a genome artifact — the ONE export surface.
+/// `checkpoint`/`save_directory` are custodian-owned handles; the organism never
+/// touches the bytes. `push_to_hub`/`repo_id` ride the genome-market publish path.
+#[derive(Debug, Clone)]
+pub struct PackageRequest {
+    pub checkpoint: String,
+    pub save_directory: String,
+    pub format: GenomeFormat,
+    pub max_seq_length: u32,
+    pub load_in_4bit: bool,
+    pub push_to_hub: bool,
+    pub repo_id: Option<String>,
+}
+
+/// The LoRA catalog a custodian owns. `outputs_dir` is the byte-custody root —
+/// the proof the trained bytes live custodian-side.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LoraCatalog {
+    #[serde(default)]
+    pub loras: Vec<Value>,
+    #[serde(default)]
+    pub outputs_dir: String,
+}
+
+/// What a forge custodian can do RIGHT NOW — DISCOVERED by probing, never declared
+/// by config. A forge daemon routes grid forge demand against this: don't dispatch
+/// to a `busy` custodian; prefer one that already `held_genes` the base; treat
+/// `!reachable` as "route elsewhere or fail loud". The fabric's self-organizing
+/// primitive at the forge tier (`[[model-endpoint-fabric-adapter-router]]`).
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ForgeCapability {
+    /// The custodian answered the probe (reachable + healthy).
+    pub reachable: bool,
+    /// A run is in flight — a new train would queue/contend for the engine.
+    pub busy: bool,
+    /// The current run's phase (`"idle"`/`"training"`/…) for the fleet snapshot.
+    pub phase: String,
+    /// How many trained LoRA genome layers this custodian already holds.
+    pub held_genes: usize,
+    /// The byte-custody root (proof the bytes live custodian-side).
+    pub outputs_dir: String,
+}
+
 /// `GET /health` response — liveness + capability + contract version + the
 /// readiness/capacity detail a router (the model-endpoint fabric) scores against.
 ///


### PR DESCRIPTION
The heart of the Unsloth forge replacement — the piece the whole native genome loop hangs off.

Two landmines found + avoided (verified by reading, not assumed): (a) the two `ForgeCustodian` traits
diverge — the native one does only health+gguf-export; the full train lifecycle lived on the dying Unsloth
client; (b) `genome/fine_tuning/job_actor` is event-driven but trains a SYNTHETIC random tensor ("stand-in
module construction… next slice loads the real base") — wiring forge/train onto it would emit Completed for
a garbage genome, the exact silent break to never introduce.

So this gives the PROVEN mlx path (forge/mlx_train::run_mlx_train, task #32, +5.1pts) the event lifecycle it
lacked, done right:
- forge/mlx_job.rs — FIRE-AND-EMIT, never poll (Joel's ask): spawn_train_job runs the blocking mlx_lm
  subprocess on spawn_blocking, returns a handle immediately, and publishes training → completed/failed over
  a watch (current_train_status = a READ, not a poll loop) AND the airc bus (forge.train.{started,done,failed})
  so consumers SUBSCRIBE — the L3 sentinel, UIs, and remote grid towers that offloaded the run all react to
  the SAME event, local or cross-grid. Single-resident. Trainer injected so the lifecycle is unit-tested
  without a multi-minute run: success→completed, failure→failed-with-named-error (no silent Completed).
- forge/protocol.rs — the genome-lifecycle types (ForgeTrainRequest/TrainHandle/TrainStatus/TrainProgress/
  GenomeFormat/PackageRequest/LoraCatalog/ForgeCapability) relocated here beside the export contract (the
  SSoT every custodian impl speaks); ExportResult reconciled with the existing duplicate.

Additive + green (crate compiles, mlx_job lifecycle test passes) — does NOT touch the live forge/train path
yet. Next: unify the ForgeCustodian trait onto NativeMlxCustodian (using this job) + ForgeCustodianHttp
(grid peer), rewire modules/forge.rs, delete unsloth_control.rs + unsloth_forge.rs, gate on a LIVE
forge/train → Completed event → page-in.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
