### PR TITLE
feat(forge): stream live mlx step/loss to forge/train-status — watch the gene form (glass box)

### DIFF
--- a/core/continuum-core/src/forge/mlx_job.rs
+++ b/core/continuum-core/src/forge/mlx_job.rs
@@ -28,7 +28,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use tokio::sync::watch;
 
 use crate::forge::mlx_train::MlxTrainOutput;
-use crate::forge::protocol::TrainStatus;
+use crate::forge::protocol::{TrainProgress, TrainStatus};
 use crate::runtime::MessageBus;
 
 /// Bus topic: a native training run has started (payload `{jobId}`).
@@ -75,7 +75,9 @@ fn running(job_id: &str) -> TrainStatus {
 /// bus. The returned job_id is the handle a caller keeps.
 pub fn spawn_train_job<F>(job_id: String, bus: Option<Arc<MessageBus>>, train: F) -> String
 where
-    F: FnOnce() -> Result<MlxTrainOutput, String> + Send + 'static,
+    F: FnOnce(&(dyn Fn(u64, Option<f64>) + Send + Sync)) -> Result<MlxTrainOutput, String>
+        + Send
+        + 'static,
 {
     let (tx, rx) = watch::channel(running(&job_id));
     *registry().lock().unwrap_or_else(|e| e.into_inner()) = Some(rx);
@@ -86,8 +88,23 @@ where
 
     let jid = job_id.clone();
     tokio::task::spawn_blocking(move || {
+        // Live progress: the trainer calls this per step; we publish it to the watch
+        // so `forge/train-status` shows the gene forming in real time (no poll).
+        let publish = |step: u64, loss: Option<f64>| {
+            let _ = tx.send(TrainStatus {
+                job_id: jid.clone(),
+                phase: "training".into(),
+                is_training_running: true,
+                details: TrainProgress {
+                    step,
+                    loss,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+        };
         // The blocking mlx subprocess wait lives HERE, off the async executor.
-        match train() {
+        match train(&publish) {
             Ok(output) => {
                 let _ = tx.send(TrainStatus {
                     job_id: jid.clone(),
@@ -162,7 +179,7 @@ mod tests {
     #[tokio::test]
     async fn fire_and_emit_success_then_failure_transitions() {
         // success: spawn returns the handle immediately; trainer completes off-thread.
-        let jid = spawn_train_job("job-ok".into(), None, || Ok(fake_output()));
+        let jid = spawn_train_job("job-ok".into(), None, |_progress| Ok(fake_output()));
         assert_eq!(jid, "job-ok");
         let s = drive_until("completed").await;
         assert_eq!(s.phase, "completed", "reached terminal completed");
@@ -170,7 +187,9 @@ mod tests {
         assert!(s.error.is_none());
 
         // failure: a failing trainer names the error, never a silent completed.
-        spawn_train_job("job-err".into(), None, || Err("mlx_lm.lora exploded".into()));
+        spawn_train_job("job-err".into(), None, |_progress| {
+            Err("mlx_lm.lora exploded".into())
+        });
         let f = drive_until("failed").await;
         assert_eq!(f.phase, "failed");
         assert!(!f.is_training_running);

--- a/core/continuum-core/src/forge/mlx_train.rs
+++ b/core/continuum-core/src/forge/mlx_train.rs
@@ -295,6 +295,7 @@ pub fn prepare_base_for_mlx(
 pub fn run_mlx_train(
     spec: &MlxTrainSpec,
     env: &MlxTrainEnv,
+    on_progress: &(dyn Fn(u64, Option<f64>) + Sync),
 ) -> Result<MlxTrainOutput, String> {
     // --- preconditions (fail AT the missing precondition, naming it) ---
     if !env.python.is_file() {
@@ -359,18 +360,42 @@ pub fn run_mlx_train(
     std::fs::write(&config_path, build_lora_config_yaml(spec))
         .map_err(|e| format!("write MLX train config {}: {e}", config_path.display()))?;
 
-    // --- spawn the trainer ---
+    // --- spawn the trainer, STREAMING stdout for live progress ---
+    // mlx_lm.lora prints `Iter N: Train loss X, …` lines as it trains; we parse them
+    // and publish step/loss to `on_progress` so `forge/train-status` shows the gene
+    // forming in real time (the "watch it learn" glass box). stderr is drained on a
+    // side thread (avoids a pipe-full deadlock) and kept for the failure message.
     let args = build_train_args(spec, &config_path);
-    let output = std::process::Command::new(&env.python)
+    let mut child = std::process::Command::new(&env.python)
         .args(&args)
-        .output()
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
         .map_err(|e| format!("spawn mlx_lm.lora: {e}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "mlx_lm.lora failed ({}):\n{}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        ));
+
+    let stderr = child.stderr.take();
+    let stderr_handle = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut buf = String::new();
+        if let Some(mut s) = stderr {
+            let _ = s.read_to_string(&mut buf);
+        }
+        buf
+    });
+
+    if let Some(stdout) = child.stdout.take() {
+        use std::io::BufRead;
+        for line in std::io::BufReader::new(stdout).lines().map_while(Result::ok) {
+            if let Some((step, loss)) = parse_mlx_progress(&line) {
+                on_progress(step, loss);
+            }
+        }
+    }
+
+    let status = child.wait().map_err(|e| format!("wait mlx_lm.lora: {e}"))?;
+    let stderr_out = stderr_handle.join().unwrap_or_default();
+    if !status.success() {
+        return Err(format!("mlx_lm.lora failed ({status}):\n{stderr_out}"));
     }
 
     // --- verify the adapter actually landed (no partial-success) ---
@@ -395,9 +420,42 @@ pub fn run_mlx_train(
     })
 }
 
+/// Parse an mlx_lm.lora progress line into `(step, loss)`. mlx_lm prints e.g.
+/// `Iter 10: Train loss 2.345, Learning Rate 1.000e-05, …`. Returns `None` for any
+/// non-train-loss line (val lines, banners) — a parse miss is silent because
+/// progress is best-effort; the terminal result on disk is the truth.
+fn parse_mlx_progress(line: &str) -> Option<(u64, Option<f64>)> {
+    let rest = line.trim().strip_prefix("Iter ")?;
+    let (iter_str, after) = rest.split_once(':')?;
+    let step: u64 = iter_str.trim().parse().ok()?;
+    let loss = after
+        .split_once("Train loss ")
+        .and_then(|(_, tail)| tail.trim_start().split([',', ' ']).next())
+        .and_then(|n| n.parse::<f64>().ok())?;
+    Some((step, Some(loss)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the mlx_lm progress parser reads real step/loss from a
+    // Train-loss line and returns None for Val-only / banner lines — so live
+    // `forge/train-status` shows honest training progress and never a garbage step.
+    #[test]
+    fn parses_mlx_train_loss_lines_only() {
+        assert_eq!(
+            parse_mlx_progress("Iter 10: Train loss 2.345, Learning Rate 1.000e-05, It/sec 1.2"),
+            Some((10, Some(2.345)))
+        );
+        assert_eq!(
+            parse_mlx_progress("Iter 20: Val loss 2.1, Val took 3.4s"),
+            None,
+            "val-only lines carry no train loss → skipped"
+        );
+        assert_eq!(parse_mlx_progress("Starting training..."), None);
+        assert_eq!(parse_mlx_progress("Iter oops: Train loss 1.0"), None);
+    }
 
     fn spec() -> MlxTrainSpec {
         MlxTrainSpec {
@@ -525,7 +583,7 @@ mod tests {
         let env = MlxTrainEnv {
             python: PathBuf::from("/nonexistent/python3"),
         };
-        let err = run_mlx_train(&spec(), &env).unwrap_err();
+        let err = run_mlx_train(&spec(), &env, &|_, _| {}).unwrap_err();
         assert!(err.contains("interpreter"), "err: {err}");
     }
 

--- a/core/continuum-core/src/modules/forge.rs
+++ b/core/continuum-core/src/modules/forge.rs
@@ -623,7 +623,9 @@ fn run_train_native_mlx(
     // no poll, never block the caller on a multi-minute train (also task #86).
     let job_id = format!("mlx-{}", p.adapter_name);
     let out_dir = adapter_out.display().to_string();
-    crate::forge::mlx_job::spawn_train_job(job_id.clone(), bus, move || run_mlx_train(&spec, &env));
+    crate::forge::mlx_job::spawn_train_job(job_id.clone(), bus, move |on_progress| {
+        run_mlx_train(&spec, &env, on_progress)
+    });
     Ok(CommandResult::Json(json!({
         "engine": "mlx",
         "jobId": job_id,


### PR DESCRIPTION
forge/train-status showed details all-zero until terminal because run_mlx_train blocked on .output().
Now it STREAMS: the mlx_lm.lora subprocess runs with piped stdout, we parse its `Iter N: Train loss X`
lines and publish step/loss to the job watch as it trains — so forge/train-status (a watch READ, still no
poll) shows the gene forming in real time. stderr is drained on a side thread (no pipe-full deadlock) and
kept for the failure message, so the fail-loud error quality is preserved.

- forge/mlx_train.rs: run_mlx_train takes an `on_progress(step, loss)` callback + streams stdout;
  parse_mlx_progress reads Train-loss lines only (Val/banner lines → None; a parse miss is silent since the
  on-disk adapter is the truth). Parser unit-tested.
- forge/mlx_job.rs: spawn_train_job's trainer fn now receives a progress publisher that sends TrainProgress
  to the watch during the run.
- modules/forge.rs: the native-train closure threads the callback into run_mlx_train.

LIVE-verified (cu, real 4B train, 50 iters): forge/train-status streamed step=10 loss=0.9 → step=40 loss=0.0
→ completed. All forge::mlx_ tests green (incl. the new parser test + the fire-and-emit lifecycle test).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
