### PR TITLE
fix(install): wire the missing `setup:rust` npm script + correct the README native path (#1 fresh-dev blocker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ One command -- bootstraps WSL2 + Docker Desktop via winget if missing, auto-togg
 <details>
 <summary>Development (from source)</summary>
 
-Requires Node.js 20+. `npm run setup:rust` provisions the rest of the native build chain — Rust nightly, **cmake**, and the **vendored git submodules** (llama.cpp/whisper.cpp) that `continuum-core` compiles. Same Docker Desktop AI toggles apply — `npm start` uses the same DMR for inference; the difference is `continuum-core` runs natively from `cargo` instead of from the published image.
+Requires Node.js 20+. `npm run setup:rust` provisions the rest of the native build chain — the pinned Rust toolchain (1.95, via `rust-toolchain.toml`), **cmake**, and the **vendored git submodules** (llama.cpp/whisper.cpp) that `continuum-core` compiles. Same Docker Desktop AI toggles apply — `npm start` uses the same DMR for inference; the difference is `continuum-core` runs natively from `cargo` instead of from the published image.
 
 ```bash
-cd continuum/src
+cd continuum
 npm install
-npm run setup:rust        # Rust nightly + cmake + vendored submodules (native build prereqs)
+npm run setup:rust        # pinned Rust 1.95 + cmake + vendored submodules (native build prereqs)
 npm run setup:git-hooks   # optional, for commit/pre-push validation
 npm start
 ```

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "check:clients": "npm run vendor:views:check -w @continuum/sdk-typescript && npm run lint:clients && npm run typecheck:clients && npm run test:clients",
     "stop": "bash tools/scripts/system-stop.sh",
     "install:continuum": "bash tools/scripts/install.sh",
+    "setup:rust": "bash tools/scripts/setup-rust.sh",
     "setup:git-hooks": "bash tools/scripts/setup-git-hooks.sh",
     "docker:ensure": "bash scripts/ensure-docker.sh",
     "ship": "node scripts/ship.mjs",


### PR DESCRIPTION
A fresh dev following the README's native install hit `npm error Missing script: "setup:rust"` on the very
first build step — dead in the water. The script (tools/scripts/setup-rust.sh: rustup + cmake + vendored
llama.cpp/whisper.cpp submodules, idempotent) EXISTED; it was just never mapped in package.json.

- package.json: add "setup:rust": "bash tools/scripts/setup-rust.sh".
- README: `cd continuum/src` → `cd continuum` (src moved to legacy/ #1840; npm runs from root); "Rust nightly"
  → the pinned 1.95 toolchain (rust-toolchain.toml), which is what actually builds.

Verified: `npm run setup:rust` now resolves + runs idempotently on a set-up machine (rust ✓ cmake ✓ vendored
submodules ✓) — no "Missing script", no breakage. First real brick of the reliability spine (#1 install).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
