### PR TITLE
fix(compose): drop the old-Node UI chain + repoint stale ./src contexts (container-first, desktop-only) — config-validated

### DIFF
--- a/docker-compose.mac.yml
+++ b/docker-compose.mac.yml
@@ -56,18 +56,7 @@ services:
     deploy:
       replicas: 0
 
-  # node-server runs in Docker on Mac (containerized per Option B).
-  # It needs to reach the NATIVE continuum-core-server on the host.
-  # Unix sockets don't traverse Docker Desktop's VM boundary on Mac, so
-  # continuum-core binds an additional TCP listener on 127.0.0.1:9100
-  # (via CONTINUUM_CORE_TCP=9100 exported by install.sh before `npm start`),
-  # and node-server connects to that via host.docker.internal (Docker
-  # Desktop's standard alias for the host).
-  #
-  # No postgres override needed — postgres is now opt-in via the `postgres`
-  # compose profile, and node-server no longer connects to any DB directly
-  # (all data ops go through continuum-core via IPC with opaque handles).
-  node-server:
-    environment:
-      # Added for Mac: overrides the default Unix-socket path lookup.
-      - CONTINUUM_CORE_URL=tcp://host.docker.internal:9100
+  # node-server removed with the old-Node UI chain (base compose). On Mac the
+  # reliable client is the native Tauri DESKTOP attaching to the native
+  # continuum-core's WS ingress directly — no containerized web service to
+  # override here. (continuum-core still runs native on Mac: replicas:0 above.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,13 @@ services:
   # ── Model Init (downloads voice/avatar/scene models on first run) ──
   model-init:
     build:
-      context: ./src
-      dockerfile: ../docker/model-init.Dockerfile
+      # context moved src → legacy/src (#1840); dockerfile path is relative to
+      # the context, so ../docker → ../../docker to stay at repo-root/docker.
+      # NOTE (Linux work): models.json lives at legacy/src/shared/models.json
+      # today — a follow should source the model catalog from a new-world home,
+      # not the frozen legacy tree. Build-verify on a Linux box.
+      context: ./legacy/src
+      dockerfile: ../../docker/model-init.Dockerfile
     image: ghcr.io/cambriantech/continuum-model-init:${CONTINUUM_IMAGE_TAG:-latest}
     # One-time downloader. Fixed budget — doesn't scale with host RAM.
     mem_limit: ${MODEL_INIT_MEM:-2g}
@@ -98,8 +103,14 @@ services:
         # avatar-provisioning story lands (LFS, model-init download,
         # or curl from a CC0 URL in CI before docker build) per the
         # gap noted in PR891-E2E-VALIDATION.md.
-        shared: ./src/shared
-        shared-generated: ./src/shared/generated
+        # moved src → legacy/src (#1840). NOTE (Linux work): shared/models.json IS
+        # at legacy/src/shared, but shared-generated/entity_schemas.json is a
+        # GENERATED file (ts-rs / cargo test), gitignored — NOT present in the
+        # legacy tree on a clean checkout. The core image build needs that file
+        # generated (or sourced from a new-world home) FIRST. This is the deepest
+        # container-path gap the src move exposed; must be build-verified on Linux.
+        shared: ./legacy/src/shared
+        shared-generated: ./legacy/src/shared/generated
       args:
         # --no-default-features excludes livekit-webrtc (handled by livekit-bridge).
         # load-dynamic-ort loads ONNX Runtime as shared lib (runtime discovery).
@@ -183,66 +194,14 @@ services:
       timeout: 3s
       retries: 5
 
-  # ── Node Server (TypeScript) ──────────────────────────────
-  node-server:
-    build:
-      context: ./src
-      dockerfile: ../docker/node-server.Dockerfile
-    image: ghcr.io/cambriantech/continuum-node:${CONTINUUM_IMAGE_TAG:-latest}
-    restart: unless-stopped
-    # TS orchestrator + IPC buffers + RAG state. Scales with host RAM —
-    # install.sh sets NODE_SERVER_MEM to max(2, host_gb/8). Default 2g
-    # for manual docker compose users.
-    mem_limit: ${NODE_SERVER_MEM:-2g}
-    # depends_on omits postgres — it's in the `postgres` profile (opt-in).
-    # node-server doesn't connect to postgres directly anyway; all data ops
-    # flow through continuum-core via IPC with opaque handles.
-    depends_on:
-      continuum-core:
-        condition: service_healthy
-    ports:
-      - "${NODE_WS_PORT:-9001}:9001"   # WebSocket
-    volumes:
-      - ~/.continuum:/root/.continuum
-    environment:
-      # node-server never directly connects to a database — all data ops
-      # go through continuum-core via IPC, using opaque handles ('main' for
-      # the primary DB, persona UUIDs for per-persona DBs). Rust resolves
-      # handles to concrete backends. DATABASE_URL intentionally NOT set
-      # here: the old value leaked across the TS→Rust IPC boundary as a
-      # connection string and broke Mac Option B where docker-DNS doesn't
-      # resolve from the native host.
-      - NODE_ENV=production
-      - JTAG_SKIP_HTTP=1
-      - JTAG_NO_TLS=1
-      # Browser connects to LiveKit via host-mapped port, not Docker DNS.
-      # 'ws://livekit:7880' only resolves inside the Docker network;
-      # the browser runs on the host where 'livekit' doesn't resolve.
-      # localhost:7880 works because livekit binds that port to the host.
-      # Grid mode overrides via LIVEKIT_BROWSER_URL=ws://tailscale:7880.
-      - LIVEKIT_URL=${LIVEKIT_BROWSER_URL:-ws://localhost:7880}
-
-  # ── Widget Server (Vite) ──────────────────────────────────
-  widget-server:
-    build:
-      context: ./src
-      dockerfile: ../docker/widget-server.Dockerfile
-    image: ghcr.io/cambriantech/continuum-widgets:${CONTINUUM_IMAGE_TAG:-latest}
-    restart: unless-stopped
-    mem_limit: 512m
-    depends_on:
-      node-server:
-        condition: service_healthy
-    ports:
-      - "9003:9003"   # HTTP
-    volumes:
-      - ~/.continuum/config.env:/root/.continuum/config.env:ro
-    environment:
-      - JTAG_HTTP_PORT=9003
-      - JTAG_WEBSOCKET_PORT=${NODE_WS_PORT:-9001}
-      # WS proxy: widget-server forwards browser WebSocket to node-server container
-      - JTAG_WS_PROXY_HOST=node-server
-      - JTAG_WS_PROXY_PORT=9001
+  # ── (removed) Node Server + Widget Server — the old TS/Vite UI chain ──
+  # The old-Node UI serving stack (node-server WS orchestrator + widget-server
+  # Vite host) is deleted: the reliable client is the native Tauri DESKTOP that
+  # attaches to continuum-core's WS ingress directly (desktop-only — see
+  # [[reliability-spine-*]]). Both built from ./src (now legacy/src #1840) and
+  # served the retired web UI, so they die with it. Grid nodes run core-only; a
+  # desktop connects from anywhere. Web stays a dev-only vite convenience, not a
+  # container service.
 
   # ── LiveKit (WebRTC) — local mode ───────────────────────────
   # Dev server for voice/video. Behind `live` profile — text chat doesn't

--- a/docker/tailscale-serve.json
+++ b/docker/tailscale-serve.json
@@ -1,30 +1,10 @@
 {
   "TCP": {
-    "443": {
-      "HTTPS": true
-    },
-    "9001": {
-      "HTTPS": true
-    },
     "7880": {
       "HTTPS": true
     }
   },
   "Web": {
-    "${TS_CERT_DOMAIN}:443": {
-      "Handlers": {
-        "/": {
-          "Proxy": "http://widget-server:9003"
-        }
-      }
-    },
-    "${TS_CERT_DOMAIN}:9001": {
-      "Handlers": {
-        "/": {
-          "Proxy": "http://node-server:9001"
-        }
-      }
-    },
     "${TS_CERT_DOMAIN}:7880": {
       "Handlers": {
         "/": {

--- a/docs/CONTAINER-PATH-LINUX-VALIDATION.md
+++ b/docs/CONTAINER-PATH-LINUX-VALIDATION.md
@@ -1,0 +1,61 @@
+# Container path — Linux validation work (estimate)
+
+The container-first install is **config-validated on macOS** (`docker compose config` green for base /
+mac / gpu overlays; old-Node UI chain removed). But macOS has **no Docker GPU passthrough**, so the actual
+image **builds** and a real `docker compose up` can only be verified on a **Linux + NVIDIA** box (or WSL2
+for the Windows path). This file is the punch list for that session.
+
+Everything below is *build-time / run-time* — `docker compose config` cannot catch it (it parses the
+compose, it does not resolve build contexts or run containers).
+
+## 1. Core image build — the deepest gap (highest risk) — ~2–4h + a build
+`continuum-core-vulkan.Dockerfile` (and `-cuda`) copy `entity_schemas.json` from the `shared-generated`
+build context, now repointed to `legacy/src/shared/generated/`. **That file is GENERATED** (ts-rs / `cargo
+test`), gitignored — it is **NOT present in a clean checkout**, so `COPY --from=shared-generated
+entity_schemas.json` will fail the build. Two ways to fix, decide on the Linux box:
+- (a) Generate it before `docker build` — a CI/build step runs the bindings generator (`cargo test -p
+  continuum-core` emits it, or the new `protocol/typescript` generator) and stages it as the context; **or**
+- (b) Confirm the Rust core does not actually need `entity_schemas.json` at build (it's an old-Node
+  data-daemon artifact) and drop the `shared-generated` context + the Dockerfile `COPY`.
+- Also decide the right long-term home for `models.json` (currently `legacy/src/shared/models.json`) — it
+  should come from a new-world source, not the frozen legacy tree.
+
+## 2. model-init image — ~1–2h + a build
+Build context repointed `./src` → `./legacy/src` (dockerfile path `../docker` → `../../docker` to match).
+`models.json` IS at `legacy/src/shared/`, so it should resolve — but verify the `model-init.Dockerfile`
+still builds + downloads (whisper/voice/avatar) end-to-end, then move `models.json` off the legacy tree.
+
+## 3. Full `docker compose --profile gpu up` on Linux+NVIDIA — ~half-day, iterate
+Bring up `continuum-core-vulkan` (or `-cuda` via the gpu overlay) + `model-init` + `livekit` (live profile)
++ `forge-worker` + `inference`. Verify: core comes up healthy (socket + IPC ping), **GPU passthrough works**
+(nvidia runtime, `--gpus`), the resource daemons see the real GPU/VRAM (holistic view — never an isolated
+sandbox), and a persona can generate. This is the real "reliable upstart in a container" gate.
+
+## 4. Desktop → containerized-core WS (grid remote access) — ~2–4h + a 2-machine grid test
+The containerized core uses a **unix socket**; a remote Tauri desktop needs the core's **WS ingress on a
+TCP port** + (grid mode) Tailscale proxying it. `tailscale-serve.json` now proxies only livekit signaling
+(the old widget-server/node-server web proxies were removed). The desktop→core-WS grid proxy is **unbuilt** —
+expose the core's WS port in the container + add a Tailscale serve handler for it, then test from a second
+machine.
+
+## 5. `install.sh` on a fresh Ubuntu / WSL2 — ~2–3h, iterate
+Run the 9-step installer end-to-end on a clean box: system deps → node → rust → python ML → (postgres
+opt-in) → livekit → native engine note (now: llama-server + mlx, no Unsloth) → (tailscale opt-in). Confirm
+the final `npm start` + `cu ping` actually work (the message this PR fixed). WSL2 additionally exercises the
+`install.ps1` → `bootstrap.sh` handoff.
+
+## 6. postgres profile — ~1h
+Verify `docker compose --profile postgres up` + the core's `DATABASE_URL=postgres://…` path still works for
+the multi-writer grid case (default is SQLite; postgres is opt-in).
+
+## Rough total
+**~2 focused days on a Linux + NVIDIA box**, plus a WSL2 pass for the Windows install path. Item 1
+(entity_schemas.json generation) is the blocking one — the core image will not build until it's resolved.
+
+## What's already done (config-validated on macOS)
+- Removed the old-Node UI chain: `node-server` + `widget-server` services (+ the Mac override + the
+  Tailscale-serve web proxies that fronted them). Desktop-only: the native Tauri desktop attaches to the
+  core's WS directly; web stays a dev-only vite convenience.
+- Repointed the surviving stale `./src` build contexts (`model-init`, core `additional_contexts`) to
+  `legacy/src` with in-file NOTEs marking the Linux build-verify.
+- `docker compose config` green for base / `+mac` / `+gpu`; 0 old-Node services in the resolved config.


### PR DESCRIPTION
Container-first canonical path, config-validated on macOS (`docker compose config` green for base / +mac /
+gpu; 0 old-Node services in the resolved config). Full image BUILD + `up` needs a Linux+NVIDIA box (no
Docker GPU on Mac) — punch list in docs/CONTAINER-PATH-LINUX-VALIDATION.md.

- Removed the old-Node UI serving chain: `node-server` (TS WS orchestrator) + `widget-server` (Vite host)
  services, the Mac override's `node-server` block, and the Tailscale-serve web proxies (443→widget-server,
  9001→node-server) that fronted them. Desktop-only: the native Tauri desktop attaches to continuum-core's
  WS ingress directly; web stays a dev-only vite convenience, not a container service. Both built from ./src
  (now legacy/src #1840) and served the retired web UI.
- Repointed the surviving stale `./src` build contexts the legacy move broke — `model-init` context and the
  core's `additional_contexts` (shared / shared-generated) → `legacy/src` (+ dockerfile relative path fix),
  with in-file NOTEs flagging the Linux build-verify (esp. shared-generated/entity_schemas.json is a
  GENERATED file absent from a clean checkout — the core image won't build until that's resolved).
- tailscale-serve.json: keep only the livekit-grid signaling proxy (7880→7890).

Honest scope: this is the config-validatable half. The build/run half (core image build, GPU passthrough,
`compose up`, grid desktop→core-WS proxy, fresh-box install.sh) is estimated (~2 days Linux + a WSL pass) in
the doc — item 1 (entity_schemas.json generation) is the blocking gap. Reliability spine #1 (install).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
