### PR TITLE
fix(compose): model-init image builds again — scripts context → tools/scripts, models via additional-context (item 2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,13 +52,14 @@ services:
   # ── Model Init (downloads voice/avatar/scene models on first run) ──
   model-init:
     build:
-      # context moved src → legacy/src (#1840); dockerfile path is relative to
-      # the context, so ../docker → ../../docker to stay at repo-root/docker.
-      # NOTE (Linux work): models.json lives at legacy/src/shared/models.json
-      # today — a follow should source the model catalog from a new-world home,
-      # not the frozen legacy tree. Build-verify on a Linux box.
-      context: ./legacy/src
+      # The download scripts live in tools/scripts (#1840); models.json is in
+      # legacy/src/shared (not yet migrated). Context = the scripts' home; the
+      # model registry rides in as the `models` additional-context. dockerfile is
+      # relative to the context (tools/scripts/../../docker → repo-root/docker).
+      context: ./tools/scripts
       dockerfile: ../../docker/model-init.Dockerfile
+      additional_contexts:
+        models: ./legacy/src/shared
     image: ghcr.io/cambriantech/continuum-model-init:${CONTINUUM_IMAGE_TAG:-latest}
     # One-time downloader. Fixed budget — doesn't scale with host RAM.
     mem_limit: ${MODEL_INIT_MEM:-2g}

--- a/docker/model-init.Dockerfile
+++ b/docker/model-init.Dockerfile
@@ -17,16 +17,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Single source of truth for ALL models the system uses (chat / vision /
-# embedding / STT / TTS / VAD). Per Joel 2026-05-04:
-# "we MUST have this work from ONE source of truth"
-COPY shared/models.json shared/models.json
-COPY scripts/download-models.sh scripts/download-models.sh
+# Build context is ./tools/scripts (the scripts' home after #1840); models.json
+# comes from the `models` additional-context (./legacy/src/shared). Single source
+# of truth for ALL models (chat / vision / embedding / STT / TTS / VAD) — per Joel
+# 2026-05-04: "we MUST have this work from ONE source of truth".
+COPY --from=models models.json shared/models.json
+COPY download-models.sh scripts/download-models.sh
 # Avatar download (VRM files) — distinct from ML models, kept separate for now.
-COPY scripts/download-avatar-models.sh scripts/download-avatar-models.sh
-COPY scripts/generate-scene-models.ts scripts/generate-scene-models.ts
-COPY scripts/shared/ scripts/shared/
-COPY package.json package.json
+COPY download-avatar-models.sh scripts/download-avatar-models.sh
+# shared/preflight.sh is sourced by download-avatar-models.sh at runtime.
+COPY shared/ scripts/shared/
 
 RUN chmod +x scripts/download-models.sh scripts/download-avatar-models.sh
 

--- a/docs/CONTAINER-PATH-LINUX-VALIDATION.md
+++ b/docs/CONTAINER-PATH-LINUX-VALIDATION.md
@@ -19,10 +19,12 @@ has **zero** references in the Rust core. So the `additional_contexts` block (co
 throwaway image that the contexts resolved, and by the fact the native core has compiled all session reading
 exactly that `include_str!` path. Nothing to do on Linux here beyond the normal full build (item 3).
 
-## 2. model-init image — ~1–2h + a build
-Build context repointed `./src` → `./legacy/src` (dockerfile path `../docker` → `../../docker` to match).
-`models.json` IS at `legacy/src/shared/`, so it should resolve — but verify the `model-init.Dockerfile`
-still builds + downloads (whisper/voice/avatar) end-to-end, then move `models.json` off the legacy tree.
+## 2. model-init image — ✅ build-proven on macOS
+The download scripts had moved to `tools/scripts/` (not `legacy/src/scripts/`), so the build broke on the
+script COPYs (caught by an actual `docker build`). Fixed: context → `./tools/scripts`, `models.json` via a
+`models` additional-context (`./legacy/src/shared`), dead `generate-scene-models.ts` + `package.json` COPYs
+dropped. Image builds clean (`docker build` on macOS — `node:20-slim` is multi-arch, native arm64). The model
+DOWNLOAD is a runtime CMD, so only a real `up` on a network-connected box exercises the actual fetch (item 3).
 
 ## 3. Full `docker compose --profile gpu up` on Linux+NVIDIA — ~half-day, iterate
 Bring up `continuum-core-vulkan` (or `-cuda` via the gpu overlay) + `model-init` + `livekit` (live profile)


### PR DESCRIPTION
Caught by an actual `docker build` (not a guess): model-init's download scripts moved to tools/scripts with
#1840, but the Dockerfile still COPYd them from the context root (which #1849 had pointed at legacy/src) —
so `COPY scripts/download-models.sh` etc failed "not found". models.json is in legacy/src/shared; the scripts
in tools/scripts; two homes, no single small context covers both (and there's no .dockerignore, so a repo-
root context would ship the whole tree).

- docker-compose.yml: model-init context → ./tools/scripts (scripts' home); models.json rides in as the
  `models` additional-context (./legacy/src/shared).
- model-init.Dockerfile: COPY the scripts from the context root, `COPY --from=models models.json`, keep
  shared/ (download-avatar-models.sh sources shared/preflight.sh at runtime); DROP the dead
  generate-scene-models.ts + package.json COPYs (unused by the download CMD path).

Build-proven on macOS (`docker build` — node:20-slim native arm64): all COPYs resolve, image exports clean.
The model download is a runtime CMD, so the actual fetch is exercised by a real `up` (item 3). compose config
green base/+gpu. Reliability spine #1 — both container BUILD-side items (core image #1850, model-init) now
build-verified from this Mac; only GPU `up` / grid / fresh-OS install remain (genuinely Linux).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
