### PR TITLE
fix(install): jtag-bin link is non-fatal when old Node jtag is absent — unblocks carl-install-smoke + handoff

### DIFF
--- a/docs/CARL-INSTALL-SMOKE-HANDOFF.md
+++ b/docs/CARL-INSTALL-SMOKE-HANDOFF.md
@@ -1,0 +1,67 @@
+# carl-install-smoke — handoff (root-caused; #1 fatal fixed; verify the rest on WSL/Linux)
+
+`carl-install-smoke` (the `curl install.sh | bash` gate — Carl's REAL entry point, not the docker-compose
+gate) has been RED for 8+ runs on canary. This is reliability-spine #1 (install). Root-caused from the CI
+artifact; the blocking fatal is fixed + unit-verified here on macOS. What remains needs a real Linux/WSL run
+to verify — that's your part.
+
+## The #1 fatal — FIXED + unit-verified
+The install.log from a failed run (`gh run download <run-id>`) ends exactly at:
+```
+✗ [jtag-bin] source binary missing at: /tmp/carl-smoke-XXXX/src/jtag
+```
+`mod_jtag_bin_link` (`tools/scripts/lib/install-common.sh`) called `module_fail` (which does `exit 1`) when
+`src/jtag` was absent. But `src/jtag` is the **old Node CLI**, moved to `legacy/` (#1840) — it is NOT part of
+a headless-core install. So the installer aborted at ~49s on an optional, retired client.
+
+**Fix (this PR):** that branch now `module_skip`s + `return 0`. Unit-verified in isolation:
+`mod_jtag_bin_link /nonexistent → RETURN CODE: 0` (was `exit 1`). install.sh now proceeds past the jtag step
+to `compose up`. The `continuum` / `cu` CLIs still link (those succeeded in the log); only the old `jtag` is
+skipped.
+
+## Your job on WSL/Linux — verify the smoke goes green
+Reproduce the exact gate:
+```bash
+# from a clean checkout of this branch, on WSL2/Linux with Docker:
+CONTINUUM_REF=$(git rev-parse HEAD) \
+CONTINUUM_IMAGE_TAG=canary \
+bash scripts/ci/carl-install-smoke.sh
+```
+Exit-code map (from the script header):
+- **1** — install.sh failed. **This was the jtag-bin fatal → fixed.** Confirm it's gone.
+- **2** — install.sh ok but continuum-core IPC socket never came up. **Most likely the next thing to hit** —
+  the core container has to come up healthy (`test -S /root/.continuum/sockets/continuum-core.sock`). If it
+  hangs, check `continuum-core.log` (the smoke uploads per-container logs as artifacts on failure).
+- **4/5/6** — ADVISORY by default (old Node web client + jtag-chat e2e). The "silent inference failure /
+  didn't reply" line in the workflow is this advisory path — do NOT let it block you unless
+  `CARL_CHECK_WEB_CLIENT=1`. It exercises the retired web client.
+
+## The compression landmine you'll want to know about
+There are **TWO different `install.sh`** and they've drifted independently (no sync mechanism):
+- **repo-root `install.sh`** — 1183 lines. This is what `curl … | bash` fetches (raw.githubusercontent) and
+  what the smoke runs. **This is the one that matters.**
+- **`tools/scripts/install.sh`** — 747 lines. What `npm run install:continuum` runs. (I de-staled THIS one in
+  #1848 — Unsloth step, `cd src`/`jtag` messages — but it is NOT the file the smoke exercises.)
+
+They share the `tools/scripts/lib/install-common.sh` helpers (which is why the one-line fix above lands for
+both). But the two top-level scripts are a real single-source-of-truth violation. **Recommended follow:**
+reconcile them — ideally the repo-root `install.sh` becomes a thin wrapper that sources the shared library +
+`tools/scripts/install.sh` logic, so "one logical installer, one place." Don't do it blind — do it with the
+smoke loop green so you can prove parity.
+
+## Lower-priority cleanup in repo-root install.sh (cosmetic, non-fatal)
+Stale `src/shared/models.json` references in COMMENTS + user-facing strings (lines ~248, 442, 458, 461, 515,
+517) — models.json now lives at `legacy/src/shared/models.json` and is read by the `model-init` container
+(fixed in #1851). These are comments/echoes, not fatal, but worth truing up when you touch the file.
+
+## What's already done + verified (so you don't redo it)
+- **Container BUILD path build-proven on macOS** (`docker build`, real): core image contexts were vestigial →
+  deleted (#1850); model-init context fixed → builds clean (#1851). `docker compose config` green base/+mac/+gpu.
+- The jtag-bin fatal → fixed + unit-verified (this PR).
+- Native genome forge complete + live (Unsloth deleted) — unrelated to install, but that's why `src/` moved.
+
+## The instruments you have
+- `gh run download <run-id> -D <dir>` — pulls the smoke's artifacts (install.log + per-container logs +
+  page/chat). The install.log is the ground truth for install.sh failures; the `continuum-core.log` for
+  exit-2.
+- `gh run list --branch canary --workflow "Carl Install Smoke"` — the red/green history.

--- a/tools/scripts/lib/install-common.sh
+++ b/tools/scripts/lib/install-common.sh
@@ -303,7 +303,13 @@ mod_continuum_bin_link() {
 mod_jtag_bin_link() {
   local src="$1"
   if [ -z "$src" ] || [ ! -f "$src" ]; then
-    module_fail "jtag-bin" "source binary missing at: $src"
+    # The old Node `jtag` CLI moved to legacy/ (#1840) and is NOT part of a
+    # headless-core install. Its absence must not abort the installer — the
+    # core plus the `continuum` / `cu` CLIs are the deliverable. Skip, don't
+    # fail (this is the exact fatal that reddened carl-install-smoke: install.sh
+    # died here on `✗ [jtag-bin] source binary missing at .../src/jtag`).
+    module_skip "jtag-bin" "old Node jtag CLI not present ($src) — use 'cu' / 'continuum'"
+    return 0
   fi
 
   # Idempotency: existing symlink already points at this src.


### PR DESCRIPTION
carl-install-smoke (the `curl install.sh | bash` gate = Carl's REAL entry) has been RED for 8+ runs. Pulled
the CI install.log artifact (`gh run download`) and root-caused it — NOT a guess: install.sh dies at exactly

    ✗ [jtag-bin] source binary missing at: /tmp/carl-smoke-XXXX/src/jtag

`mod_jtag_bin_link` (tools/scripts/lib/install-common.sh) called `module_fail` → `exit 1` when `src/jtag` is
absent. But `src/jtag` is the OLD Node CLI, moved to legacy/ (#1840) — not part of a headless-core install.
So the installer aborted at ~49s on an optional, retired client.

- install-common.sh: the missing/empty-source branch now `module_skip`s + `return 0` (the core plus the
  `continuum` / `cu` CLIs are the deliverable; the old `jtag` is optional). Unit-verified in isolation on
  macOS: `mod_jtag_bin_link /nonexistent → RETURN CODE: 0` (was `exit 1`), empty arg → 0 too.
- docs/CARL-INSTALL-SMOKE-HANDOFF.md: full handoff for the WSL-equipped follow — the root cause, the fix, the
  repro command (`bash scripts/ci/carl-install-smoke.sh`), the exit-code map (1 fixed → next likely 2, the
  IPC-socket-up check; 4/5/6 advisory), the TWO-install.sh compression landmine (repo-root 1183-line curl
  entry vs tools/scripts 747-line npm entry — independent drift to reconcile), and the stale-comment cleanup.

This gets install.sh past the fatal so `compose up` runs; a real Linux/WSL smoke run verifies it green from
here (that's the handoff). Reliability spine #1 (install).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
