### PR TITLE
feat(reliability): system-scope service (LaunchDaemon / systemd system) — survives LOGOUT; airc REQUIRED not disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "setup:rust": "bash tools/scripts/setup-rust.sh",
     "setup:git-hooks": "bash tools/scripts/setup-git-hooks.sh",
     "service:install": "bash tools/scripts/install-service.sh install",
+    "service:install:system": "bash tools/scripts/install-service.sh install --system",
     "service:uninstall": "bash tools/scripts/install-service.sh uninstall",
     "service:status": "bash tools/scripts/install-service.sh status",
     "docker:ensure": "bash scripts/ensure-docker.sh",

--- a/tools/scripts/install-service.sh
+++ b/tools/scripts/install-service.sh
@@ -2,159 +2,191 @@
 # install-service.sh — install the Continuum core as a REBOOT-SURVIVING OS service.
 #
 # Reliability spine #2 (upstart): a grid node must come back on its own after a
-# reboot or a crash — never "the persona died because the Mac slept and nobody
-# ran `cu start` again" ([[grid-node-resilience]]). This installs the headless
-# core under the platform's supervisor so it (a) starts at login/boot and (b) is
-# restarted if it dies.
+# reboot, a crash, OR a user logout — never "the persona died because someone
+# logged off the machine" (the literal BIGMAMA failure, [[grid-node-resilience]]).
 #
-# Outlier-validated: launchd (macOS) is the fully-built + on-this-machine-tested
-# path; systemd (Linux) is written to the same contract for the grid nodes; other
-# platforms fail loud with the manual command rather than pretend.
+# Two scopes:
+#   user (default)   macOS LaunchAgent (~/Library/LaunchAgents) / Linux systemd --user.
+#                    No sudo. Survives CRASH (KeepAlive) + reboot-then-LOGIN
+#                    (RunAtLoad). Dies on logout / boot-without-login.
+#   --system          macOS LaunchDaemon (/Library/LaunchDaemons, runs as you at boot)
+#                    / Linux systemd system unit. Needs sudo. Survives LOGOUT +
+#                    boot-without-login — the real unattended grid-node answer.
+#
+# airc is the nervous system, not optional: this REQUIRES airc on PATH (ensured,
+# never disabled) so the core finds it instantly at boot (`which airc`) and never
+# does a blocking boot-time network install.
 #
 # Usage:
-#   bash tools/scripts/install-service.sh            # install + start
-#   bash tools/scripts/install-service.sh uninstall  # stop + remove
-#   bash tools/scripts/install-service.sh status      # is it loaded / running?
-#
-# Env:
-#   CONTINUUM_CORE_BIN   explicit path to continuum-core-server (else auto-resolved)
-#   CONTINUUM_SOCKET     IPC socket (default /tmp/continuum-core.sock)
+#   bash tools/scripts/install-service.sh [install|uninstall|status] [--system]
 set -euo pipefail
 
-ACTION="${1:-install}"
+# ── args ──
+ACTION="install"; SCOPE="user"
+for a in "$@"; do
+  case "$a" in
+    install|uninstall|status) ACTION="$a" ;;
+    --system) SCOPE="system" ;;
+    *) echo "usage: $0 [install|uninstall|status] [--system]" >&2; exit 2 ;;
+  esac
+done
+
 LABEL="com.continuum.core"
 SOCKET="${CONTINUUM_SOCKET:-/tmp/continuum-core.sock}"
 DATA="$HOME/.continuum"
 LOG_DIR="$DATA/logs"
+SVC_USER="$(id -un)"
 
-# ── Resolve the core binary a service can exec (fail loud — never guess) ──
-# Order: explicit override → installed system paths → dev cargo target. A service
-# points at a BUILT binary (it must not `cargo build` on every boot); if none
-# exists we refuse and tell the user to build/install first.
+# ── airc is REQUIRED (the nervous system): ensure present, never disable ──
+require_airc() {
+  command -v airc >/dev/null 2>&1 && return 0
+  echo "✗ airc not found on PATH. airc is the identity/rooms/event substrate — the core needs it." >&2
+  echo "  Install it first, then re-run:  curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash" >&2
+  exit 1
+}
+
+# ── Resolve the core binary a service can exec (fail loud — never guess, never build-on-boot) ──
 resolve_core_bin() {
   if [ -n "${CONTINUUM_CORE_BIN:-}" ]; then
     [ -x "$CONTINUUM_CORE_BIN" ] || { echo "CONTINUUM_CORE_BIN set but not executable: $CONTINUUM_CORE_BIN" >&2; return 1; }
     echo "$CONTINUUM_CORE_BIN"; return 0
   fi
-  local tgt="${CARGO_TARGET_DIR:-$DATA/cache/cargo-target}"
-  local p
-  for p in \
-    /usr/local/bin/continuum-core-server \
-    "$DATA/bin/continuum-core-server" \
-    "$tgt/release/continuum-core-server" \
-    "$tgt/debug/continuum-core-server"; do
+  local tgt="${CARGO_TARGET_DIR:-$DATA/cache/cargo-target}" p
+  for p in /usr/local/bin/continuum-core-server "$DATA/bin/continuum-core-server" \
+           "$tgt/release/continuum-core-server" "$tgt/debug/continuum-core-server"; do
     [ -x "$p" ] && { echo "$p"; return 0; }
   done
   return 1
 }
 
-# ── The one legal ORT dylib path (the core links onnxruntime dynamically) ──
-ort_dylib() {
-  case "$(uname -s)" in
-    Darwin) echo "/opt/homebrew/lib/libonnxruntime.dylib" ;;
-    *)      echo "$DATA/lib/libonnxruntime.so" ;;
-  esac
+ort_dylib() { case "$(uname -s)" in Darwin) echo "/opt/homebrew/lib/libonnxruntime.dylib";; *) echo "$DATA/lib/libonnxruntime.so";; esac; }
+
+# The wrapper command the supervisor runs: airc + toolchain on PATH so the core
+# finds airc at boot (no blocking install), config.env sourced, ORT set, core
+# exec'd in the FOREGROUND so the supervisor owns its lifecycle.
+core_wrapper() {
+  # if/then/fi (not `&&`) so the string is valid XML unescaped inside the plist.
+  echo "export PATH=\"$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.cargo/bin:\$PATH\"; if [ -f \"$DATA/config.env\" ]; then set -a; . \"$DATA/config.env\"; set +a; fi; export ORT_DYLIB_PATH=\"$(ort_dylib)\"; exec \"$1\" \"$SOCKET\""
 }
 
-# ── macOS: LaunchAgent (per-user; survives logout→login + reboot) ──
-mac_plist() { echo "$HOME/Library/LaunchAgents/$LABEL.plist"; }
+# ════════════════════════ macOS ════════════════════════
+mac_agent_plist() { echo "$HOME/Library/LaunchAgents/$LABEL.plist"; }
+mac_daemon_plist() { echo "/Library/LaunchDaemons/$LABEL.plist"; }
 
-mac_install() {
-  local bin; bin="$(resolve_core_bin)" || {
-    echo "✗ no continuum-core-server binary found. Build it first (npm start / cu start), or set CONTINUUM_CORE_BIN." >&2
-    exit 1
-  }
-  mkdir -p "$LOG_DIR" "$(dirname "$(mac_plist)")"
-  # A tiny bash wrapper sources config.env (launchd can't) + sets ORT, then execs
-  # the core in the FOREGROUND so launchd owns its lifecycle (KeepAlive restarts).
-  cat > "$(mac_plist)" <<PLIST
+mac_write_plist() { # $1=path  $2=bin  $3=extra <dict> entries
+  local path="$1" bin="$2" extra="${3:-}"
+  cat <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>Label</key><string>$LABEL</string>
   <key>ProgramArguments</key>
-  <array>
-    <string>/bin/bash</string>
-    <string>-lc</string>
-    <string>export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.cargo/bin:\$PATH"; [ -f "$DATA/config.env" ] &amp;&amp; { set -a; . "$DATA/config.env"; set +a; }; export ORT_DYLIB_PATH="$(ort_dylib)"; export AIRC_DISABLE_AUTOINSTALL=1; exec "$bin" "$SOCKET"</string>
-  </array>
+  <array><string>/bin/bash</string><string>-lc</string><string>$(core_wrapper "$bin")</string></array>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
   <key>WorkingDirectory</key><string>$DATA</string>
   <key>StandardOutPath</key><string>$LOG_DIR/service.out.log</string>
   <key>StandardErrorPath</key><string>$LOG_DIR/service.err.log</string>
-  <key>ProcessType</key><string>Background</string>
+  <key>ProcessType</key><string>Background</string>$extra
 </dict>
 </plist>
 PLIST
-  # bootout any prior instance, then bootstrap into the per-user GUI domain.
-  launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
-  launchctl bootstrap "gui/$(id -u)" "$(mac_plist)"
-  launchctl enable "gui/$(id -u)/$LABEL" 2>/dev/null || true
-  echo "✓ installed launchd service '$LABEL' → $bin $SOCKET"
-  echo "  logs: $LOG_DIR/service.{out,err}.log   plist: $(mac_plist)"
+}
+
+mac_install() {
+  local bin; bin="$(resolve_core_bin)" || { echo "✗ no continuum-core-server binary — build it (npm start) or set CONTINUUM_CORE_BIN." >&2; exit 1; }
+  mkdir -p "$LOG_DIR"
+  if [ "$SCOPE" = "system" ]; then
+    # LaunchDaemon: system scope (survives logout), but runs AS the installing
+    # user with their HOME so it uses ~/.continuum (never root's).
+    local extra="
+  <key>UserName</key><string>$SVC_USER</string>
+  <key>EnvironmentVariables</key><dict><key>HOME</key><string>$HOME</string></dict>"
+    local tmp; tmp="$(mktemp)"
+    mac_write_plist "$(mac_daemon_plist)" "$bin" "$extra" > "$tmp"
+    plutil -lint "$tmp" >/dev/null
+    sudo launchctl bootout "system/$LABEL" 2>/dev/null || true
+    sudo install -m 0644 -o root -g wheel "$tmp" "$(mac_daemon_plist)"; rm -f "$tmp"
+    sudo launchctl bootstrap system "$(mac_daemon_plist)"
+    echo "✓ installed system LaunchDaemon '$LABEL' (survives logout) → $bin $SOCKET"
+  else
+    mkdir -p "$(dirname "$(mac_agent_plist)")"
+    mac_write_plist "$(mac_agent_plist)" "$bin" > "$(mac_agent_plist)"
+    plutil -lint "$(mac_agent_plist)" >/dev/null
+    launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+    launchctl bootstrap "gui/$(id -u)" "$(mac_agent_plist)"
+    launchctl enable "gui/$(id -u)/$LABEL" 2>/dev/null || true
+    echo "✓ installed user LaunchAgent '$LABEL' (crash + reboot-login) → $bin $SOCKET"
+  fi
+  echo "  logs: $LOG_DIR/service.{out,err}.log"
 }
 
 mac_uninstall() {
-  launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
-  rm -f "$(mac_plist)"
-  echo "✓ removed launchd service '$LABEL'"
+  sudo launchctl bootout "system/$LABEL" 2>/dev/null || true; sudo rm -f "$(mac_daemon_plist)" 2>/dev/null || true
+  launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true; rm -f "$(mac_agent_plist)"
+  echo "✓ removed '$LABEL' (both scopes)"
 }
 
 mac_status() {
-  if launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1; then
-    echo "✓ '$LABEL' is loaded"; launchctl print "gui/$(id -u)/$LABEL" 2>/dev/null | grep -iE "state|pid" | head -3
-  else
-    echo "✗ '$LABEL' not loaded"
-  fi
+  launchctl print "system/$LABEL" >/dev/null 2>&1 && { echo "✓ '$LABEL' loaded (system/LaunchDaemon)"; return; }
+  launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1 && echo "✓ '$LABEL' loaded (user/LaunchAgent)" || echo "✗ '$LABEL' not loaded"
 }
 
-# ── Linux: systemd user unit (grid nodes — written to contract, verify on Linux) ──
-linux_unit() { echo "$HOME/.config/systemd/user/continuum-core.service"; }
+# ════════════════════════ Linux ════════════════════════
+linux_user_unit() { echo "$HOME/.config/systemd/user/continuum-core.service"; }
+linux_system_unit() { echo "/etc/systemd/system/continuum-core.service"; }
 
-linux_install() {
-  local bin; bin="$(resolve_core_bin)" || {
-    echo "✗ no continuum-core-server binary found. Build/install it first, or set CONTINUUM_CORE_BIN." >&2
-    exit 1
-  }
-  mkdir -p "$LOG_DIR" "$(dirname "$(linux_unit)")"
-  cat > "$(linux_unit)" <<UNIT
+linux_unit_body() { # $1=bin  $2=User line (system only)
+  cat <<UNIT
 [Unit]
 Description=Continuum headless core (reboot-surviving)
 After=network.target
 
 [Service]
 Type=simple
-EnvironmentFile=-$DATA/config.env
+${2:-}EnvironmentFile=-$DATA/config.env
 Environment=ORT_DYLIB_PATH=$(ort_dylib)
-Environment=AIRC_DISABLE_AUTOINSTALL=1
-Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin:%h/.cargo/bin
+Environment=PATH=$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$HOME/.cargo/bin
 WorkingDirectory=$DATA
-ExecStart=$bin $SOCKET
+ExecStart=$1 $SOCKET
 Restart=always
 RestartSec=2
 
 [Install]
-WantedBy=default.target
+WantedBy=${3:-default.target}
 UNIT
-  systemctl --user daemon-reload
-  systemctl --user enable --now continuum-core.service
-  echo "✓ installed systemd --user service → $bin $SOCKET"
-  echo "  (enable lingering for boot-without-login: 'sudo loginctl enable-linger $USER')"
+}
+
+linux_install() {
+  local bin; bin="$(resolve_core_bin)" || { echo "✗ no continuum-core-server binary — build/install it or set CONTINUUM_CORE_BIN." >&2; exit 1; }
+  mkdir -p "$LOG_DIR"
+  if [ "$SCOPE" = "system" ]; then
+    linux_unit_body "$bin" "User=$SVC_USER
+" "multi-user.target" | sudo tee "$(linux_system_unit)" >/dev/null
+    sudo systemctl daemon-reload; sudo systemctl enable --now continuum-core.service
+    echo "✓ installed systemd SYSTEM service (survives logout) → $bin $SOCKET"
+  else
+    mkdir -p "$(dirname "$(linux_user_unit)")"
+    linux_unit_body "$bin" "" "default.target" > "$(linux_user_unit)"
+    systemctl --user daemon-reload; systemctl --user enable --now continuum-core.service
+    echo "✓ installed systemd --user service (crash + reboot-login) → $bin $SOCKET"
+    echo "  (boot-without-login: 'sudo loginctl enable-linger $SVC_USER', or use --system)"
+  fi
 }
 
 linux_uninstall() {
-  systemctl --user disable --now continuum-core.service 2>/dev/null || true
-  rm -f "$(linux_unit)"; systemctl --user daemon-reload 2>/dev/null || true
-  echo "✓ removed systemd --user service"
+  sudo systemctl disable --now continuum-core.service 2>/dev/null || true; sudo rm -f "$(linux_system_unit)" 2>/dev/null || true; sudo systemctl daemon-reload 2>/dev/null || true
+  systemctl --user disable --now continuum-core.service 2>/dev/null || true; rm -f "$(linux_user_unit)"; systemctl --user daemon-reload 2>/dev/null || true
+  echo "✓ removed continuum-core service (both scopes)"
 }
 
-linux_status() { systemctl --user status continuum-core.service --no-pager 2>&1 | head -6 || echo "✗ not installed"; }
+linux_status() { systemctl --user status continuum-core.service --no-pager 2>&1 | head -4; systemctl status continuum-core.service --no-pager 2>&1 | head -4; }
 
 # ── Dispatch ──
+[ "$ACTION" = "install" ] && require_airc
 case "$(uname -s)" in
-  Darwin) case "$ACTION" in install) mac_install;; uninstall) mac_uninstall;; status) mac_status;; *) echo "usage: $0 [install|uninstall|status]" >&2; exit 2;; esac ;;
-  Linux)  case "$ACTION" in install) linux_install;; uninstall) linux_uninstall;; status) linux_status;; *) echo "usage: $0 [install|uninstall|status]" >&2; exit 2;; esac ;;
-  *) echo "✗ No supervised-service path for $(uname -s) yet. Run the core manually or add a Windows Service (sc.exe create ContinuumCore binPath= \"…continuum-core-server $SOCKET\" start= auto)." >&2; exit 1 ;;
+  Darwin) case "$ACTION" in install) mac_install;; uninstall) mac_uninstall;; status) mac_status;; esac ;;
+  Linux)  case "$ACTION" in install) linux_install;; uninstall) linux_uninstall;; status) linux_status;; esac ;;
+  *) echo "✗ No supervised-service path for $(uname -s) yet. Add a Windows Service: sc.exe create ContinuumCore binPath= \"…continuum-core-server $SOCKET\" start= auto" >&2; exit 1 ;;
 esac


### PR DESCRIPTION
Follows #1853. Two corrections from Joel's review:

1. --system scope (the real BIGMAMA fix — logout/boot-without-login). `install-service.sh install --system`
   (npm run service:install:system): macOS LaunchDaemon in /Library/LaunchDaemons (runs AS the installing
   user via UserName + HOME so it still uses ~/.continuum, but system-managed so it survives that user's
   logout); Linux systemd SYSTEM unit (User=, WantedBy=multi-user.target). Default (no flag) stays the
   no-sudo user LaunchAgent / --user unit from #1853.

2. airc is the nervous system — we do NOT operate without it. Dropped the #1853 AIRC_DISABLE_AUTOINSTALL=1
   band-aid (which traded a boot hang for a node with no substrate). Instead: REQUIRE airc (fail loud at
   install if absent, pointing at its installer) and keep it on the service PATH so the core finds it via
   `which airc` at boot — no install, no 120s hang, full grid citizen.

Verified on this Mac (no sudo needed): the reworked USER LaunchAgent boots the core in ~12s with airc found
via PATH and NO disable, KeepAlive restart works (killed pid → relaunched), clean uninstall. The --system
daemon plist is well-formed (plutil-lint of the same wrapper passes) — its only extra step is the sudo
`launchctl bootstrap system`, which Joel runs to load it (I can't sudo non-interactively).

Test the daemon:  npm run service:install:system   (prompts for sudo; then `cu ping`, and it survives logout)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
