### PR TITLE
fix(boot): honest airc-background-install messages — node up, restart to join (self-healing re-attach is a follow)

### DIFF
--- a/core/continuum-core/src/airc/discovery.rs
+++ b/core/continuum-core/src/airc/discovery.rs
@@ -76,7 +76,7 @@ pub enum DiscoveryError {
     InstallFailed(String),
     #[error("auto-install suppressed via {AIRC_DISABLE_AUTOINSTALL}=1 — install airc manually: curl -fsSL {AIRC_INSTALL_URL} | bash")]
     AutoInstallDisabled,
-    #[error("airc not on PATH — bootstrapping it in the background; the node is up but not yet a grid peer (a later discovery attaches once the install lands)")]
+    #[error("airc not on PATH — bootstrapping it in the background; the node is UP (local commands work) but not yet a grid peer. Restart the core once the install completes to join airc (self-healing re-attach without restart is a follow-up).")]
     AutoInstallInProgress,
     #[error("`airc ipc-endpoint` failed: {0}")]
     EndpointCommandFailed(String),
@@ -122,13 +122,15 @@ pub async fn discover_airc_socket() -> Result<PathBuf, DiscoveryError> {
     // Still fail loud (named error) — we just don't HANG to do it.
     warn!(
         "airc not found on PATH — bootstrapping it in the BACKGROUND from \
-         {AIRC_INSTALL_URL}; boot continues, airc joins once installed. \
+         {AIRC_INSTALL_URL}; boot continues (node is up, local commands work). \
+         Restart the core once it lands to join airc as a grid peer. \
          Set {AIRC_DISABLE_AUTOINSTALL}=1 to opt out."
     );
     tokio::spawn(async {
         match auto_install_airc().await {
             Ok(()) => info!(
-                "airc background bootstrap installed — will attach on the next discovery pass"
+                "airc background bootstrap installed — restart the core to join airc \
+                 (or wait for the self-healing re-discovery tick once that lands)"
             ),
             Err(e) => warn!("airc background bootstrap failed: {e}"),
         }

--- a/core/continuum-core/src/airc/discovery_state.rs
+++ b/core/continuum-core/src/airc/discovery_state.rs
@@ -127,7 +127,7 @@ pub enum DiscoveryFailure {
     #[error("airc binary not on PATH and auto-install was disabled (CONTINUUM_NO_AUTOINSTALL=1)")]
     AutoInstallDisabled,
 
-    #[error("airc not on PATH — installing in the background; node is up, will attach as a grid peer once the install lands")]
+    #[error("airc not on PATH — installing in the background; node is UP (local commands work), restart the core once the install completes to join airc as a grid peer")]
     AutoInstallInProgress,
 
     #[error("airc binary install failed: {0}")]


### PR DESCRIPTION
Follow-up to #1855. Its messages over-promised "will attach on the next discovery pass" — but AircModule has
`tick_interval: None` and discovers ONCE, so there IS no next pass: on a fresh box the backgrounded airc
install lands but the core doesn't re-join airc without a RESTART. Corrected the operator-facing strings
(DiscoveryError + DiscoveryFailure AutoInstallInProgress + the warn/info logs) to say exactly that — the node
is UP and local commands work, restart to become a grid peer once the install completes.

The real self-healing re-attach (rejoin without restart) is a genuine follow, not a tick: AircModule's
[[no-fallbacks-ever]] doctrine refuses partial attach, so it needs full transport reconstruction
(Store→Daemon transport swap + re-propagate the socket to the persona manager), not a spawn_daemon_attach
retry. Tracked in the grid-node-resilience memory. Message-only change; crate compiles.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
