### PR TITLE
fix(install): native install no longer aborts on retired build:ts/build:cli (FATAL, install-audit #1/#2)

### DIFF
--- a/tools/scripts/install.sh
+++ b/tools/scripts/install.sh
@@ -493,21 +493,23 @@ if [ "$SKIP_BUILD" = "0" ]; then
     exit 1
   fi
 
-  echo -e "  Building TypeScript..."
-  npm run build:ts 2>&1 | tail -1
+  # The old `build:ts` / `build:cli` scripts left with the retired Node shell
+  # (moved to legacy/src, #1840) — they no longer exist in the root package.json.
+  # Calling them under `set -eo pipefail` made `npm run` exit non-zero ("Missing
+  # script") and ABORTED the whole native install (install-audit FATAL). The
+  # current TS deliverables are the client SDK + web app; build them BEST-EFFORT
+  # in an `if` (so a client-build failure can never abort a headless-core install —
+  # the Rust core below is the deliverable). The `if` condition also shields the
+  # pipeline from `set -e`.
+  echo -e "  Building clients (SDK + web, best-effort)..."
+  if npm run build:clients 2>&1 | tail -3; then
+    echo -e "  ${GREEN}✅ clients built${NC}"
+  else
+    echo -e "  ${YELLOW}⚠  client build skipped/failed — headless core install continues${NC}"
+  fi
 
-  # Build the CLI bundle too. Without it, src/jtag falls back to
-  # `tsx` resolution which can't resolve tsconfig path aliases (e.g.,
-  # @system/core/types/SystemScopes) at runtime — fast post-clone
-  # invocations of jtag fail with ERR_MODULE_NOT_FOUND. Bundle path
-  # is what every production invocation should use. Caught 2026-05-02
-  # via PR #1012 chat.log artifact: carl-install-smoke chat-probe
-  # was failing this exact way on every CI run.
-  echo -e "  Building CLI bundle..."
-  npm run build:cli 2>&1 | tail -1
-
-  echo -e "  Building Rust workers..."
-  bash scripts/setup-rust.sh 2>&1 | tail -5
+  echo -e "  Building Rust core + workers..."
+  bash "$SCRIPT_DIR/setup-rust.sh" 2>&1 | tail -5
 fi
 
 # ============================================================================


### PR DESCRIPTION
A parallel install audit found the fresh-native-install killer: tools/scripts/install.sh (the
`npm run install:continuum` path) called `npm run build:ts` + `npm run build:cli` — scripts that left with the
retired Node shell (moved to legacy/src, #1840) and no longer exist in the root package.json. Under this
script's `set -eo pipefail`, `npm run` exits non-zero ("Missing script") → pipefail propagates → `set -e`
ABORTS the whole install. A fresh native install could never finish.

- Replace both dead calls with a BEST-EFFORT `npm run build:clients` (the current TS deliverable — SDK + web,
  which DO exist in root package.json), wrapped in an `if` so a client-build failure can never abort a
  headless-core install (the Rust core is the deliverable) and the `if` condition shields the pipeline from
  `set -e`.
- Harden the Rust build call: `bash scripts/setup-rust.sh` → `bash "$SCRIPT_DIR/setup-rust.sh"` (absolute via
  the script's own dir) so it no longer depends on the fragile PROJECT_DIR/cwd resolution (audit #3).

Verified: `bash -n` OK; zero build:ts/build:cli call sites remain; build:clients exists in root package.json;
the guard makes it non-fatal either way. Reliability spine #1 (install). Credit: parallel install-audit agent.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
