### PR TITLE
fix(boot): module init no longer cascades or hangs — per-module timeout + loud aggregate (reliability audit #2/#3)

### DIFF
--- a/core/continuum-core/src/runtime/runtime.rs
+++ b/core/continuum-core/src/runtime/runtime.rs
@@ -124,22 +124,60 @@ impl Runtime {
         let modules = self.registry.list_modules();
         info!("Initializing {} modules...", modules.len());
 
+        // Per-module init deadline. A module's `initialize()` is meant to be fast
+        // (in-memory wiring; heavy work is detached / tick-driven), so 60s is a
+        // wedged-init backstop, NOT a normal budget — it bounds the airc-120s-hang
+        // class per-module so ONE hung init can't stall the whole boot + socket
+        // bind. Generous to never false-positive a legitimately slow init.
+        const PER_MODULE_INIT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(60);
+
+        // Collect failures instead of cascading. The old `return Err` on the FIRST
+        // failure skipped EVERY module after it → a silently half-booted core
+        // (audit finding). Each module now inits independently; a failure is
+        // recorded LOUDLY and we keep going so the rest of the substrate comes up.
+        let mut failures: Vec<String> = Vec::new();
         for name in &modules {
             if let Some(module) = self.registry.get_by_name(name) {
-                match module.initialize(&ctx).await {
-                    Ok(_) => {
+                match tokio::time::timeout(PER_MODULE_INIT_DEADLINE, module.initialize(&ctx)).await {
+                    Ok(Ok(_)) => {
                         info!("  {} initialized", name);
                     }
-                    Err(e) => {
-                        error!("  {} initialization failed: {}", name, e);
-                        return Err(format!("Module '{}' failed to initialize: {}", name, e));
+                    Ok(Err(e)) => {
+                        error!("  ✗ {} initialization FAILED: {}", name, e);
+                        failures.push(format!("{name}: {e}"));
+                    }
+                    Err(_) => {
+                        error!(
+                            "  ✗ {} init TIMED OUT after {}s (wedged) — skipped so the rest boot",
+                            name,
+                            PER_MODULE_INIT_DEADLINE.as_secs()
+                        );
+                        failures.push(format!(
+                            "{name}: init timed out after {}s",
+                            PER_MODULE_INIT_DEADLINE.as_secs()
+                        ));
                     }
                 }
             }
         }
 
-        info!("All {} modules initialized", modules.len());
-        Ok(())
+        if failures.is_empty() {
+            info!("All {} modules initialized", modules.len());
+            Ok(())
+        } else {
+            // Fail LOUD with the COMPLETE failure set (never just the first, never
+            // silent). The caller decides whether a degraded boot is acceptable;
+            // either way the operator sees every module that failed. The main.rs
+            // boot deadline still backstops a failure that prevents socket bind.
+            let summary = format!(
+                "{}/{} modules FAILED to initialize — core is DEGRADED: [{}]",
+                failures.len(),
+                modules.len(),
+                failures.join("; ")
+            );
+            error!("⚠ {summary}");
+            Err(summary)
+        }
     }
 
     /// Await a named module's `ready_edge()`. Returns `Ok(())` as soon as


### PR DESCRIPTION
runtime.initialize() `return Err`'d on the FIRST module that failed init — which skipped EVERY module after
it, then the caller (ipc/mod.rs) swallowed the error and bound the socket anyway → a silently half-booted
core where one early failure hid the rest and disabled everything downstream. And a single hung
`initialize()` stalled the whole loop + the socket bind (the airc-120s class, generalized).

Fix (well-thought-out, no blast-radius crash):
- Each module inits INDEPENDENTLY — a failure is recorded LOUDLY (`✗ X initialization FAILED`) and the loop
  keeps going, so the rest of the substrate still comes up.
- Each `initialize()` is wrapped in a 60s per-module deadline (`tokio::time::timeout`) — a wedged init is
  skipped + named (`✗ X init TIMED OUT`), not left to stall boot. 60s is a backstop, not a budget (inits are
  meant to be fast; heavy work is detached/tick-driven).
- On any failure, return the COMPLETE aggregate summary (`N/M modules FAILED … [list]`) — the caller logs it
  loud, so a degraded boot is fully visible instead of first-failure-only-then-silent.
- Not a blanket crash: the core still binds + serves (resilient to one optional module failing); the main.rs
  boot deadline (#1858) still backstops a failure that prevents socket bind entirely.

Verified: 26 runtime tests green; normal boot ~44s with all modules clean (no false degraded-summary), core
responsive. Credit: parallel reliability-audit agent. Reliability spine: startup foolproofing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
