### PR TITLE
fix(persona): close the LIVE coherence gap — gender anchors on the NAME, not the random peer_id

### DIFF
--- a/core/continuum-core/src/live/avatar/selection.rs
+++ b/core/continuum-core/src/live/avatar/selection.rs
@@ -80,7 +80,9 @@ pub fn select_avatar_for_voice(
 /// mismatch unrepresentable by construction. (The batch path `select_avatar_for_agent`
 /// already did this + adds cross-persona dedup; this is the stateless sibling.)
 pub fn select_avatar_by_identity(identity: &str) -> &'static AvatarModel {
-    let gender = gender_from_identity(identity);
+    // Name-anchored gender first (coherence), id-hash only as a fallback for
+    // unregistered / unisex / custom-named identities.
+    let gender = registered_gender(identity).unwrap_or_else(|| gender_from_identity(identity));
     // Neuter (they/them): presentation isn't constrained to masc/fem, so ANY avatar
     // is coherent — draw from the full pool (no filter, no warn). When neuter-tagged
     // VRMs are added, the Female/Male filter below will start preferring them.
@@ -111,6 +113,43 @@ pub fn select_avatar_by_identity(identity: &str) -> &'static AvatarModel {
 static AVATAR_ALLOCATION: std::sync::Mutex<Option<HashMap<String, usize>>> =
     std::sync::Mutex::new(None);
 
+/// Identity → the persona's coherent gender, derived from its NAME at the one
+/// moment name + identity co-occur (voice-session registration).
+///
+/// [[procedural-persona-genesis]] coherence anchor. A persona's name is the stable,
+/// persisted, user-visible truth; its live `peer_id` is a random tag airc mints
+/// independently (`PeerId::new()`), so the two need not agree in gender. The
+/// stateless selection paths (profile snapshot, live video pump) only ever hold the
+/// peer_id — so left alone they'd fall back to an id-hash gender that can mismatch
+/// the name (a feminine "Asha" on a masculine VRM). By capturing the NAME-derived
+/// gender ONCE, keyed by identity, every later selection (snapshot, pump, voice)
+/// resolves the SAME gender by id — coherent with each other AND with the name.
+static PERSONA_GENDER: std::sync::Mutex<Option<HashMap<String, AvatarGender>>> =
+    std::sync::Mutex::new(None);
+
+/// Capture a persona's name-anchored gender, keyed by its live identity. Call this
+/// when a persona's identity + display name are both in hand (voice-session
+/// registration). A unisex/custom name (`gender_from_name` → `None`) records
+/// nothing, so those fall back to the id-hash gender.
+pub fn register_persona_gender(identity: &str, name: &str) {
+    if let Some(gender) = crate::persona::name_generator::gender_from_name(name) {
+        let mut guard = PERSONA_GENDER.lock().unwrap();
+        guard
+            .get_or_insert_with(HashMap::new)
+            .insert(identity.to_string(), gender);
+    }
+}
+
+/// The name-anchored gender for an identity, if one was registered. This is the
+/// coherence source every avatar/voice selection consults FIRST.
+pub fn registered_gender(identity: &str) -> Option<AvatarGender> {
+    PERSONA_GENDER
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|m| m.get(identity).copied())
+}
+
 /// Select the best avatar for an agent, avoiding model reuse across personas.
 ///
 /// Algorithm (3-phase, gender-coherent):
@@ -131,9 +170,9 @@ pub fn select_avatar_for_agent(identity: &str, voice: Option<&str>) -> &'static 
         return &AVATAR_CATALOG[idx];
     }
 
-    // Resolve gender: voice name > deterministic from identity
-    let gender = voice
-        .and_then(gender_from_voice_name)
+    // Resolve gender: registered name-anchored gender > voice name > id hash.
+    let gender = registered_gender(identity)
+        .or_else(|| voice.and_then(gender_from_voice_name))
         .unwrap_or_else(|| gender_from_identity(identity));
 
     // Filter catalog to matching gender
@@ -388,9 +427,9 @@ pub fn select_dynamic_avatar(identity: &str, voice: Option<&str>) -> &'static Dy
         return &models[idx];
     }
 
-    // Resolve gender: voice name > deterministic from identity
-    let gender = voice
-        .and_then(gender_from_voice_name)
+    // Resolve gender: registered name-anchored gender > voice name > id hash.
+    let gender = registered_gender(identity)
+        .or_else(|| voice.and_then(gender_from_voice_name))
         .unwrap_or_else(|| gender_from_identity(identity));
 
     // Filter catalog to matching gender
@@ -557,6 +596,37 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn registered_name_gender_overrides_id_hash() {
+        // what this catches: the LIVE coherence gap — a persona's avatar keys on its
+        // random peer_id, whose gender need not match the persona's NAME. After the
+        // live layer registers the name-anchored gender, select_avatar_by_identity must
+        // honor the NAME's gender, not the id-hash — so a feminine-named persona keeps a
+        // feminine face even when its peer_id happens to hash Male.
+        use crate::persona::name_generator::{agent_name_from_identity, gender_from_name};
+
+        // A name unambiguously in the FEMALE pool (via a Female-hashing identity).
+        let female_name = (0..500)
+            .find_map(|i| {
+                let name = agent_name_from_identity(&format!("fem-src-{i}"));
+                (gender_from_name(name) == Some(AvatarGender::Female)).then_some(name)
+            })
+            .expect("a female-pool name exists");
+        // A DIFFERENT identity whose raw id-hash gender is Male (the mismatch case).
+        let male_id = (0..500)
+            .map(|i| format!("male-id-{i}"))
+            .find(|id| gender_from_identity(id) == AvatarGender::Male)
+            .expect("a Male-hashing identity exists");
+
+        register_persona_gender(&male_id, female_name);
+        let avatar = select_avatar_by_identity(&male_id);
+        assert_eq!(
+            avatar.voice_profile.gender,
+            AvatarGender::Female,
+            "registered female NAME must override the Male id-hash → female avatar"
+        );
     }
 
     #[test]

--- a/core/continuum-core/src/live/transport/bridge_client.rs
+++ b/core/continuum-core/src/live/transport/bridge_client.rs
@@ -280,7 +280,10 @@ impl LiveKitAgentManager {
             .await?;
 
         // TTS runs HERE in core (uses ort — safe, no webrtc in this process)
-        let gender = gender_from_identity(user_id);
+        // Name-anchored gender first so the voice matches the persona's NAME +
+        // avatar ([[procedural-persona-genesis]]); id-hash only as a fallback.
+        let gender = crate::live::avatar::selection::registered_gender(user_id)
+            .unwrap_or_else(|| gender_from_identity(user_id));
         let gender_str = match gender {
             AvatarGender::Male => "male",
             AvatarGender::Female => "female",

--- a/core/continuum-core/src/modules/live.rs
+++ b/core/continuum-core/src/modules/live.rs
@@ -132,6 +132,15 @@ impl ServiceModule for VoiceModule {
                     .map(|p| (p.user_id.to_string(), p.display_name.clone()))
                     .collect();
 
+                // Capture each persona's NAME-anchored gender keyed by its live
+                // identity — the one point where identity + display name co-occur.
+                // Every later avatar/voice selection resolves gender from this, so the
+                // profile snapshot, live video pump, and voice all agree with the
+                // visible NAME ([[procedural-persona-genesis]] coherence anchor).
+                for (user_id, display_name) in &ai_participants {
+                    crate::live::avatar::selection::register_persona_gender(user_id, display_name);
+                }
+
                 self.state
                     .voice_service
                     .register_session(session_id, room_id, participants)?;

--- a/core/continuum-core/src/persona/name_generator.rs
+++ b/core/continuum-core/src/persona/name_generator.rs
@@ -97,6 +97,26 @@ pub fn agent_name_from_identity(identity: &str) -> &'static str {
     }
 }
 
+/// Resolve a persona's gender from its NAME — which gendered pool the name belongs
+/// to. This is the coherence ANCHOR ([[procedural-persona-genesis]]): a persona's
+/// name is chosen before its keypair exists and is the stable, persisted,
+/// user-visible truth, whereas the live `peer_id` is a random tag assigned later
+/// (`airc-identity` mints `PeerId::new()`, independent of the name). So the name —
+/// not the peer_id — is what avatar/voice must cohere WITH, or a feminine "Asha"
+/// ends up with a masculine face. Returns `None` for a name in BOTH pools (a
+/// genuinely unisex draw, e.g. a Neutral persona) or NEITHER (custom/legacy name),
+/// letting the caller fall back to an id-hash gender for those.
+pub fn gender_from_name(name: &str) -> Option<AvatarGender> {
+    let in_female = FEMALE_NAMES.iter().any(|&n| n == name);
+    let in_male = MALE_NAMES.iter().any(|&n| n == name);
+    match (in_female, in_male) {
+        (true, false) => Some(AvatarGender::Female),
+        (false, true) => Some(AvatarGender::Male),
+        // Both (unisex) or neither (custom) → ambiguous; caller falls back.
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
The genesis coherence tests all passed, but they fed ONE identity string to every derivation function — the
live path never does. A trace (name ⇔ avatar/voice) found the gap: a persona's NAME is drawn from a throwaway
pre-keypair UUID that airc discards at bootstrap, while the live avatar + voice key on `user_id` = the peer_id.
Those are different ids, so a feminine "Asha" could get a masculine face/voice — coherence held only by 1-in-N
luck. Deeper: airc mints `PeerId::new()` RANDOMLY (independent of name AND keypair), and airc's identity is
fundamentally *name*-anchored (agent_name keys the home dir + coordinator store), so converging on peer_id would
need either a whois/display split or an airc-core change. The name is the true, stable, persisted, user-visible
anchor — so gender derives from IT.

- `gender_from_name` (name_generator.rs): which gendered pool a name belongs to (Female/Male; None for
  unisex/custom → caller falls back to id-hash).
- `register_persona_gender` / `registered_gender` (selection.rs): a resolver capturing each persona's
  name-anchored gender keyed by live identity, populated at the ONE point name + identity co-occur — voice-session
  registration (live.rs). Every selection consults it FIRST.
- All three avatar-selection paths + the voice gender resolution (bridge_client) now resolve
  registered-gender > voice-hint > id-hash, so the profile snapshot, live video pump, and voice all agree with
  each other AND with the visible NAME. No persona is ever renamed; no airc surgery.

Verified: `registered_name_gender_overrides_id_hash` — a female-pool name registered against a Male-hashing
identity yields a Female avatar (name wins). `profile_avatar_is_gender_coherent` still green (unregistered ids
fall back to id-hash). name_generator + projection suites green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
