### PR TITLE
fix(persona): register name-anchored gender at SPAWN, not just voice-session — profile pic coherent from birth

### DIFF
--- a/core/continuum-core/src/modules/persona_instance_manager.rs
+++ b/core/continuum-core/src/modules/persona_instance_manager.rs
@@ -305,6 +305,17 @@ impl PersonaInstanceManagerModule {
             );
         }
 
+        // Register the persona's NAME-anchored gender at SPAWN, keyed by its identity
+        // (persona_id == peer_id, the same string the live avatar/voice sites key on).
+        // This makes the profile snapshot + every avatar/voice selection coherent with
+        // the visible name from BIRTH — not only once the persona joins a voice session
+        // ([[procedural-persona-genesis]] coherence anchor; the profile pic is shown in
+        // rosters/tiles with no call in play).
+        crate::live::avatar::selection::register_persona_gender(
+            &runtime.persona_id().to_string(),
+            runtime.agent_name(),
+        );
+
         let info = PersonaInstanceInfo::from_runtime(&runtime);
         self.registry.register(runtime);
         Ok(info)


### PR DESCRIPTION
Follow-up to #1868. That fix populated the gender resolver only at voice-session registration, so a persona
that hadn't joined a call had no registered gender → its profile snapshot fell back to the id-hash gender and
could still mismatch its name. But the profile pic is shown in rosters/tiles with NO call in play — exactly the
surface Joel cares about ("becomes their profile pic and bio").

Register the persona's name-anchored gender at the spawn-completion point (`bootstrap_one`, where peer_id +
agent_name are both finalized), keyed by `persona_id` (== peer_id, the same string the live avatar/voice sites
key on). Every persona is now coherent from BIRTH, call or no call. The voice-session registration stays as a
complementary top-up for any call participant.

Swept all non-test `gender_from_identity` sites: the three avatar-selection paths + the voice path now resolve
registered-gender > voice-hint > id-hash; the only remaining bare call is `catalog.rs` classifying a VRM
*filename stem* (not a persona), which is correct. Compiles clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
