### PR TITLE
chore(persona): log name-anchored gender registration — make live coherence observable

### DIFF
--- a/core/continuum-core/src/live/avatar/selection.rs
+++ b/core/continuum-core/src/live/avatar/selection.rs
@@ -133,6 +133,12 @@ static PERSONA_GENDER: std::sync::Mutex<Option<HashMap<String, AvatarGender>>> =
 /// nothing, so those fall back to the id-hash gender.
 pub fn register_persona_gender(identity: &str, name: &str) {
     if let Some(gender) = crate::persona::name_generator::gender_from_name(name) {
+        clog_info!(
+            "🎭 coherence: persona '{}' ({}) → {:?} (name-anchored; avatar+voice will follow)",
+            name,
+            identity,
+            gender
+        );
         let mut guard = PERSONA_GENDER.lock().unwrap();
         guard
             .get_or_insert_with(HashMap::new)


### PR DESCRIPTION
Instrument `register_persona_gender` with a one-line info log ("🎭 coherence: persona 'Asha' (<id>) → Female").
Closes the feedback loop ([[never-blind-feedback-driven-iteration]]): when a persona spawns (or joins a voice
session) its name→gender resolution is now visible in the logs, so the coherence fix (#1868/#1869) can be
confirmed on any real spawn rather than only in unit tests. Verified the freshly-built core boots healthy with
the whole coherence change set (build 58s, ready ~14s, ping ok) — no boot regression; this env just seeds no
personas, so there was nothing to spawn-observe locally.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
