### PR TITLE
feat(avatar): single-source avatar catalog — download provisions from AVATAR_CATALOG, no url/gender drift

### DIFF
--- a/core/continuum-core/src/live/avatar/catalog.rs
+++ b/core/continuum-core/src/live/avatar/catalog.rs
@@ -19,6 +19,11 @@ use std::path::{Path, PathBuf};
 /// as exploding geometry. Only VRM 0.x models (83 joints) work in the headless pipeline.
 ///
 /// Gender distribution (static): 6 Female, 2 Male
+// The provisioning source: all current models are CC0 VRoid Studio avatars fetched as
+// zips from OpenGameArt (https://opengameart.org/content/vroid-studio-cc0-models). The
+// `url`/`source_kind`/`license` fields make THIS the single source of truth for the
+// download — `download-avatar-models.sh` provisions from the JSON projection of this
+// catalog, so adding an avatar is one entry here, not an edit in two places.
 pub const AVATAR_CATALOG: &[AvatarModel] = &[
     AvatarModel {
         id: "vroid-female-base",
@@ -30,6 +35,9 @@ pub const AVATAR_CATALOG: &[AvatarModel] = &[
             gender: AvatarGender::Female,
             energy: EnergyLevel::Moderate,
         },
+        url: concat!("https://opengameart.org/sites/default/files", "/base_female.zip"),
+        source_kind: "vroid-zip",
+        license: "CC0",
     },
     AvatarModel {
         id: "vroid-male-base",
@@ -41,6 +49,9 @@ pub const AVATAR_CATALOG: &[AvatarModel] = &[
             gender: AvatarGender::Male,
             energy: EnergyLevel::Moderate,
         },
+        url: concat!("https://opengameart.org/sites/default/files", "/base_male.zip"),
+        source_kind: "vroid-zip",
+        license: "CC0",
     },
     AvatarModel {
         id: "vroid-sakurada",
@@ -52,6 +63,9 @@ pub const AVATAR_CATALOG: &[AvatarModel] = &[
             gender: AvatarGender::Male,
             energy: EnergyLevel::Energetic,
         },
+        url: concat!("https://opengameart.org/sites/default/files", "/sakurada_fumiriya.zip"),
+        source_kind: "vroid-zip",
+        license: "CC0",
     },
     AvatarModel {
         id: "vroid-shino",
@@ -63,6 +77,9 @@ pub const AVATAR_CATALOG: &[AvatarModel] = &[
             gender: AvatarGender::Female,
             energy: EnergyLevel::Calm,
         },
+        url: concat!("https://opengameart.org/sites/default/files", "/sendagaya_shino.zip"),
+        source_kind: "vroid-zip",
+        license: "CC0",
     },
     AvatarModel {
         id: "vroid-darkness",
@@ -74,6 +91,9 @@ pub const AVATAR_CATALOG: &[AvatarModel] = &[
             gender: AvatarGender::Female,
             energy: EnergyLevel::Calm,
         },
+        url: concat!("https://opengameart.org/sites/default/files", "/avatarsample_d_darkness.zip"),
+        source_kind: "vroid-zip",
+        license: "CC0",
     },
     AvatarModel {
         id: "vroid-sample-d",
@@ -85,6 +105,9 @@ pub const AVATAR_CATALOG: &[AvatarModel] = &[
             gender: AvatarGender::Female,
             energy: EnergyLevel::Moderate,
         },
+        url: concat!("https://opengameart.org/sites/default/files", "/avatarsample_d_0.zip"),
+        source_kind: "vroid-zip",
+        license: "CC0",
     },
     AvatarModel {
         id: "vroid-sample-e",
@@ -96,6 +119,9 @@ pub const AVATAR_CATALOG: &[AvatarModel] = &[
             gender: AvatarGender::Female,
             energy: EnergyLevel::Energetic,
         },
+        url: concat!("https://opengameart.org/sites/default/files", "/avatarsample_e.zip"),
+        source_kind: "vroid-zip",
+        license: "CC0",
     },
     AvatarModel {
         id: "vroid-sample-f",
@@ -107,6 +133,9 @@ pub const AVATAR_CATALOG: &[AvatarModel] = &[
             gender: AvatarGender::Female,
             energy: EnergyLevel::Moderate,
         },
+        url: concat!("https://opengameart.org/sites/default/files", "/avatarsample_f.zip"),
+        source_kind: "vroid-zip",
+        license: "CC0",
     },
 ];
 
@@ -188,6 +217,9 @@ impl ModelManifest {
             .as_str()
         {
             "male" | "m" => AvatarGender::Male,
+            // Neuter (they/them) round-trips from the catalog projection ([[procedural-persona-genesis]]);
+            // without this arm a "neutral" manifest would silently read as Female.
+            "neutral" | "n" | "they" => AvatarGender::Neutral,
             _ => AvatarGender::Female,
         }
     }
@@ -610,6 +642,59 @@ mod tests {
     #[test]
     fn test_avatar_catalog_has_8_models() {
         assert_eq!(AVATAR_CATALOG.len(), 8);
+    }
+
+    // what this catches: the single-source invariant — every catalog entry must be
+    // PROVISIONABLE (a non-empty url + a known source_kind + a license) AND
+    // gender-tagged. This is what makes "add one AVATAR_CATALOG entry" the whole
+    // workflow for a new avatar ([[persona-visual-identity]] additions-first-class).
+    #[test]
+    fn every_catalog_entry_is_provisionable_and_tagged() {
+        for m in AVATAR_CATALOG {
+            assert!(m.url.starts_with("http"), "{} has no download url", m.id);
+            assert!(
+                matches!(m.source_kind, "vroid-zip" | "vrm"),
+                "{} has unknown source_kind '{}'",
+                m.id,
+                m.source_kind
+            );
+            assert!(!m.license.is_empty(), "{} has no license", m.id);
+            assert!(m.filename.ends_with(".vrm"), "{} filename not .vrm", m.id);
+        }
+    }
+
+    // Projects AVATAR_CATALOG → tools/scripts/avatar-catalog.json — the ts-rs pattern:
+    // the Rust catalog is the source of truth; download-avatar-models.sh reads THIS
+    // projection (via jq) instead of a hardcoded URL list. Runs on `cargo test`; commit
+    // the result alongside catalog changes. Deterministic content, so concurrent test
+    // writes are byte-identical.
+    #[test]
+    fn generate_avatar_catalog_json() {
+        let avatars: Vec<serde_json::Value> = AVATAR_CATALOG
+            .iter()
+            .map(|m| {
+                serde_json::json!({
+                    "id": m.id,
+                    "name": m.name,
+                    "filename": m.filename,
+                    "url": m.url,
+                    "sourceKind": m.source_kind,
+                    "gender": format!("{:?}", m.voice_profile.gender).to_lowercase(),
+                    "style": format!("{:?}", m.style).to_lowercase(),
+                    "license": m.license,
+                })
+            })
+            .collect();
+        let doc = serde_json::json!({
+            "_comment": "GENERATED from AVATAR_CATALOG (catalog.rs) by `cargo test generate_avatar_catalog_json`. Do not hand-edit — add avatars in catalog.rs and regenerate.",
+            "avatars": avatars,
+        });
+        let json = serde_json::to_string_pretty(&doc).unwrap() + "\n";
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tools/scripts/avatar-catalog.json"
+        );
+        std::fs::write(path, json).expect("write avatar-catalog.json projection");
     }
 
     #[test]

--- a/core/continuum-core/src/live/avatar/types.rs
+++ b/core/continuum-core/src/live/avatar/types.rs
@@ -19,6 +19,17 @@ pub struct AvatarModel {
     pub style: AvatarStyle,
     /// Voice characteristics this model matches best
     pub voice_profile: VoiceProfile,
+    /// Provisioning URL — where this avatar is downloaded from. THE single source of
+    /// truth for the download (no longer hardcoded in download-avatar-models.sh);
+    /// [[persona-visual-identity]] "additions are first-class": add one entry here and
+    /// it downloads, gets gender-tagged, and the coherent draw picks it up.
+    pub url: &'static str,
+    /// How to fetch `url`: "vroid-zip" (download a zip, extract the .vrm) or "vrm"
+    /// (direct .vrm file). The provisioner branches on this, so a new avatar from a
+    /// different source is a pure data change.
+    pub source_kind: &'static str,
+    /// License identifier (all current models are CC0).
+    pub license: &'static str,
 }
 
 /// Dynamic avatar model — discovered at runtime from filesystem + manifest.

--- a/tools/scripts/avatar-catalog.json
+++ b/tools/scripts/avatar-catalog.json
@@ -1,0 +1,85 @@
+{
+  "_comment": "GENERATED from AVATAR_CATALOG (catalog.rs) by `cargo test generate_avatar_catalog_json`. Do not hand-edit — add avatars in catalog.rs and regenerate.",
+  "avatars": [
+    {
+      "filename": "vroid-female-base.vrm",
+      "gender": "female",
+      "id": "vroid-female-base",
+      "license": "CC0",
+      "name": "Base Female",
+      "sourceKind": "vroid-zip",
+      "style": "anime",
+      "url": "https://opengameart.org/sites/default/files/base_female.zip"
+    },
+    {
+      "filename": "vroid-male-base.vrm",
+      "gender": "male",
+      "id": "vroid-male-base",
+      "license": "CC0",
+      "name": "Base Male",
+      "sourceKind": "vroid-zip",
+      "style": "anime",
+      "url": "https://opengameart.org/sites/default/files/base_male.zip"
+    },
+    {
+      "filename": "vroid-sakurada.vrm",
+      "gender": "male",
+      "id": "vroid-sakurada",
+      "license": "CC0",
+      "name": "Sakurada Fumiriya",
+      "sourceKind": "vroid-zip",
+      "style": "anime",
+      "url": "https://opengameart.org/sites/default/files/sakurada_fumiriya.zip"
+    },
+    {
+      "filename": "vroid-shino.vrm",
+      "gender": "female",
+      "id": "vroid-shino",
+      "license": "CC0",
+      "name": "Sendagaya Shino",
+      "sourceKind": "vroid-zip",
+      "style": "anime",
+      "url": "https://opengameart.org/sites/default/files/sendagaya_shino.zip"
+    },
+    {
+      "filename": "vroid-darkness.vrm",
+      "gender": "female",
+      "id": "vroid-darkness",
+      "license": "CC0",
+      "name": "Darkness",
+      "sourceKind": "vroid-zip",
+      "style": "anime",
+      "url": "https://opengameart.org/sites/default/files/avatarsample_d_darkness.zip"
+    },
+    {
+      "filename": "vroid-sample-d.vrm",
+      "gender": "female",
+      "id": "vroid-sample-d",
+      "license": "CC0",
+      "name": "Sample D",
+      "sourceKind": "vroid-zip",
+      "style": "anime",
+      "url": "https://opengameart.org/sites/default/files/avatarsample_d_0.zip"
+    },
+    {
+      "filename": "vroid-sample-e.vrm",
+      "gender": "female",
+      "id": "vroid-sample-e",
+      "license": "CC0",
+      "name": "Sample E",
+      "sourceKind": "vroid-zip",
+      "style": "anime",
+      "url": "https://opengameart.org/sites/default/files/avatarsample_e.zip"
+    },
+    {
+      "filename": "vroid-sample-f.vrm",
+      "gender": "female",
+      "id": "vroid-sample-f",
+      "license": "CC0",
+      "name": "Sample F",
+      "sourceKind": "vroid-zip",
+      "style": "anime",
+      "url": "https://opengameart.org/sites/default/files/avatarsample_f.zip"
+    }
+  ]
+}

--- a/tools/scripts/download-avatar-models.sh
+++ b/tools/scripts/download-avatar-models.sh
@@ -159,34 +159,42 @@ echo -e "${YELLOW}Checking VRM avatar models (8 CC0 models)...${NC}"
 # Source: https://opengameart.org/content/vroid-studio-cc0-models
 # ============================================================================
 
-echo -e "${YELLOW}VRoid Studio anime avatars (8 models):${NC}"
+# Provision avatars from the SINGLE-SOURCE catalog (avatar-catalog.json, generated from
+# AVATAR_CATALOG in core/continuum-core/src/live/avatar/catalog.rs). Adding an avatar
+# there + regenerating (`cargo test -p continuum-core generate_avatar_catalog_json`) is
+# the whole workflow — no hardcoded URLs here, no gender drift. Fail LOUD if jq or the
+# catalog is missing (never silently skip provisioning — a faceless persona is a bug).
+CATALOG="$SCRIPT_DIR/avatar-catalog.json"
+if ! command -v jq &> /dev/null; then
+  echo -e "${RED}✗ jq not found — required to read the avatar catalog. Install jq and re-run.${NC}" >&2
+  exit 1
+fi
+if [ ! -f "$CATALOG" ]; then
+  echo -e "${RED}✗ avatar catalog missing: $CATALOG${NC}" >&2
+  echo -e "${RED}  regenerate with: cargo test -p continuum-core generate_avatar_catalog_json${NC}" >&2
+  exit 1
+fi
 
-download_vroid_zip "vroid-female-base" \
-  "https://opengameart.org/sites/default/files/base_female.zip"
-
-download_vroid_zip "vroid-male-base" \
-  "https://opengameart.org/sites/default/files/base_male.zip"
-
-download_vroid_zip "vroid-sakurada" \
-  "https://opengameart.org/sites/default/files/sakurada_fumiriya.zip"
-
-download_vroid_zip "vroid-shino" \
-  "https://opengameart.org/sites/default/files/sendagaya_shino.zip"
-
-download_vroid_zip "vroid-darkness" \
-  "https://opengameart.org/sites/default/files/avatarsample_d_darkness.zip"
-
-download_vroid_zip "vroid-sample-d" \
-  "https://opengameart.org/sites/default/files/avatarsample_d_0.zip"
-
-download_vroid_zip "vroid-sample-e" \
-  "https://opengameart.org/sites/default/files/avatarsample_e.zip"
-
-download_vroid_zip "vroid-sample-f" \
-  "https://opengameart.org/sites/default/files/avatarsample_f.zip"
-
-# 100Avatars REMOVED — 2D flat models, look terrible next to 3D VRoid models.
-# Need proper 3D CC0 models to expand the catalog beyond 8.
+echo -e "${YELLOW}Provisioning avatars from catalog ($(jq '.avatars | length' "$CATALOG") entries):${NC}"
+# Process substitution (not a pipe) so the DOWNLOADED/EXISTING/FAILED counters, updated
+# inside the download_* fns, survive in THIS shell rather than a pipe subshell.
+while read -r entry; do
+  id=$(echo "$entry" | jq -r '.id')
+  url=$(echo "$entry" | jq -r '.url')
+  kind=$(echo "$entry" | jq -r '.sourceKind')
+  gender=$(echo "$entry" | jq -r '.gender')
+  name=$(echo "$entry" | jq -r '.name')
+  case "$kind" in
+    vroid-zip) download_vroid_zip "$id" "$url" ;;
+    vrm)       download_vrm "$id" "$url" ;;
+    *) echo -e "  ${RED}⚠ ${id}: unknown sourceKind '${kind}' — skipping${NC}" >&2 ;;
+  esac
+  # Drop a gender manifest next to the VRM so AvatarCatalog::discover() reads gender
+  # from DATA (the catalog), not an inferred filename hash. Idempotent.
+  if [ -f "$MODELS_DIR/${id}.vrm" ]; then
+    printf 'id = "%s"\nname = "%s"\ngender = "%s"\n' "$id" "$name" "$gender" > "$MODELS_DIR/${id}.toml"
+  fi
+done < <(jq -c '.avatars[]' "$CATALOG")
 
 # ============================================================================
 # Summary


### PR DESCRIPTION
Visual-identity slice 1 ([[persona-visual-identity]]): kill the two-source drift where the VRM URLs lived in
download-avatar-models.sh (name+url, NO gender) and the gender lived in the Rust AVATAR_CATALOG (gender, NO
url) — add an avatar and you had to edit two places or it'd be untagged.

Now AVATAR_CATALOG is THE single source: each entry carries `url` + `source_kind` + `license` alongside its
gender. A cargo test projects it to `tools/scripts/avatar-catalog.json` (the ts-rs codegen pattern), and the
download script reads THAT (jq, process-substitution so the counters survive the subshell), branches on
source_kind (vroid-zip | vrm), and drops a `<id>.toml` gender manifest next to each VRM — so
AvatarCatalog::discover() reads gender from DATA, not a filename-hash guess. Adding an avatar is now one
AVATAR_CATALOG entry + regenerate; it downloads, gets gender-tagged (incl. neutral), and the coherent draw
picks it up with zero other edits. Fail-loud if jq or the catalog is missing (a faceless persona is a bug).

Also fixed `ModelManifest::parse_gender` to round-trip `"neutral"` (post-#1865) instead of silently collapsing
it to Female.

Verified: `every_catalog_entry_is_provisionable_and_tagged` + `generate_avatar_catalog_json` (15 catalog tests
green); `bash -n` clean; dry-run of the jq loop extracts all 8 entries with URLs preserved and the counter
surviving (8, not 0).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
