### PR TITLE
fix(avatar): snapshot waits 30s for a cold VRM load (was 5s) — profile pics render instead of timing out

### DIFF
--- a/core/continuum-core/src/modules/avatar.rs
+++ b/core/continuum-core/src/modules/avatar.rs
@@ -75,7 +75,13 @@ impl AvatarModule {
         // Skip initial frames (loading/black), then grab a good one.
         let mut best_frame = None;
         let mut frames_received = 0u32;
-        let max_wait = std::time::Duration::from_secs(5);
+        // A COLD VRM load doesn't emit frames until the model is parsed + the scene is
+        // instantiated (SceneInstanceReady) — observed ~15s on a 21MB VRM before the
+        // first healthy frame, then the 40-frame warmup skip below. 5s always failed
+        // cold (the live video pump succeeds only because it stays allocated). 30s
+        // covers cold load + warmup; the result is cached (png_path.exists() short-
+        // circuits) so this wait is paid once per avatar.
+        let max_wait = std::time::Duration::from_secs(30);
         let start = std::time::Instant::now();
 
         while start.elapsed() < max_wait {


### PR DESCRIPTION
The avatar/snapshot command waited only 5s for a usable frame, but a COLD VRM load doesn't emit frames until
the model is parsed + the scene instantiated (~15s on a 21MB VRM, SceneInstanceReady), then a 40-frame warmup
skip. So a first-time snapshot ALWAYS failed with "No usable frame after 5050ms (0 frames received)" — while the
live video pump succeeds only because it stays allocated across the warmup. 30s covers cold load + warmup; the
PNG is cached (png_path.exists() short-circuits) so the wait is paid once per avatar.

Proven live: with the fix, `avatar/snapshot` for a resumed persona (Asha, 90e758b2…) rendered a clean 101KB
PNG — a coherent female VRM matching her name-anchored gender (#1868), provisioned by the catalog-driven
download (#1871). Full chain green end to end: name → Female → vroid-darkness → downloaded → rendered.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
