### PR TITLE
feat(avatar): studio backdrop polish — clean identity tint instead of the muddy dark wall

### DIFF
--- a/core/continuum-core/src/live/video/bevy_renderer/scene/builder.rs
+++ b/core/continuum-core/src/live/video/bevy_renderer/scene/builder.rs
@@ -24,7 +24,13 @@ pub fn room_color_from_identity(identity: &str) -> Color {
         .bytes()
         .fold(0u64, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u64));
     let hue = (hash % 360) as f32;
-    let saturation = 0.15 + (((hash >> 8) % 20) as f32 / 100.0);
-    let lightness = 0.08 + (((hash >> 16) % 10) as f32 / 100.0);
+    // Studio backdrop polish ([[persona-visual-identity]] render-well): a CLEAN,
+    // low-saturation identity tint — a subtle wash over a controlled dark value, not
+    // the old murky mid-saturation "dark wall" (sat 0.15–0.35 @ near-black 0.08–0.18
+    // read as muddy). Lower saturation kills the murk; a slightly lifted value gives
+    // a slate/charcoal-with-a-hint-of-hue that still lets a lit avatar pop while
+    // looking deliberate. Each persona keeps a unique, recognizable tint.
+    let saturation = 0.07 + (((hash >> 8) % 9) as f32 / 100.0); // 0.07–0.16
+    let lightness = 0.12 + (((hash >> 16) % 7) as f32 / 100.0); // 0.12–0.19
     Color::hsl(hue, saturation, lightness)
 }


### PR DESCRIPTION
Render-well polish ([[persona-visual-identity]]). The per-persona backdrop was a mid-saturation HSL at near-black
(sat 0.15–0.35, lightness 0.08–0.18) — it read as a muddy, murky "dark wall" behind the avatar. Lowered the
saturation (0.07–0.16) and lifted the value a touch (0.12–0.19): each persona now gets a clean slate/charcoal
backdrop with a subtle, recognizable identity tint, and a lit avatar pops against it cleanly.

Verified visually: re-rendered Asha's live snapshot before/after — the muddy green became a clean deep
charcoal-green, and her silver hair + pale skin stand out noticeably crisper. Local to the backdrop color (no
touch to the avatar render, camera, or the NV12/LiveKit color pipeline). Bigger render-well increments
(gradient backdrop, tonemapping, MSAA, tighter portrait crop) are follow-ups that need live-pipeline
verification since they're shared with the video pump.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
