### PR TITLE
fix(models): derive local GGUF paths from the model id, drop the hardcoded absolute paths

### DIFF
--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -427,9 +427,9 @@ pub fn models() -> Vec<Model> {
                 Capability::Streaming,
             ],
             gguf_hint: Some("huggingface.co/bartowski/Qwen2.5-Coder-14B-Instruct-GGUF"),
-            gguf_local_path: Some(
-                "~/.continuum/genome/models/qwen2.5-coder-14b-instruct/Qwen2.5-Coder-14B-Instruct-Q4_K_M.gguf",
-            ),
+            // gguf_local_path DERIVED, not hardcoded: resolve_gguf matches this id to
+            // its dir under ~/.continuum/genome/models/ (identity-token subset) and
+            // falls back to the HF cache via gguf_hint — no baked absolute path or quant.
             chat_template: Some(QWEN35_CHAT_TEMPLATE),
             multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
             stop_sequences: &["<|im_end|>", "<|endoftext|>"],
@@ -500,9 +500,7 @@ pub fn models() -> Vec<Model> {
             // above is serving-only; MLX/PEFT fine-tuning + the custodian convert
             // resolve THIS HF repo (cached, MLX-ready) through the canonical id.
             hf_source: Some("unsloth/Qwen2.5-0.5B-Instruct"),
-            gguf_local_path: Some(
-                "~/.continuum/genome/models/qwen2.5-0.5b-instruct/qwen2.5-0.5b-instruct-q4_k_m.gguf",
-            ),
+            // gguf_local_path DERIVED from the id under genome/models (see coder-14b above).
             multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
             ..ModelSpec::default()
         }),
@@ -525,9 +523,7 @@ pub fn models() -> Vec<Model> {
             tokens_per_second: 0.0,
             capabilities: &[Capability::Embedding],
             gguf_hint: Some("huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF"),
-            gguf_local_path: Some(
-                "~/.continuum/genome/models/qwen3-embedding-0.6b/Qwen3-Embedding-0.6B-Q8_0.gguf",
-            ),
+            // gguf_local_path DERIVED from the id under genome/models (see coder-14b above).
             ..ModelSpec::default()
         }),
     ]

--- a/core/continuum-core/src/model_registry/registry.rs
+++ b/core/continuum-core/src/model_registry/registry.rs
@@ -296,4 +296,46 @@ mod tests {
             assert_eq!(model.gguf_local_path.as_deref(), Some(gguf.as_path()));
         });
     }
+
+    // what this catches: the coder-14b teacher resolves its serving GGUF by DERIVING
+    // the path from its id under ~/.continuum/genome/models/ — with NO hardcoded
+    // gguf_local_path in the catalog (removed). Proves the unhardcoding: drop the
+    // baked absolute path + quant, and the registry still finds the model by id
+    // (where download-models.sh lands it).
+    #[test]
+    fn coder_14b_resolves_by_id_derivation_without_hardcoded_path() {
+        let home = tempfile::tempdir().unwrap();
+        crate::model_registry::artifacts::with_test_home(home.path(), || {
+            // Place the GGUF where the provisioner lands it: genome/models/<dir>/.
+            let dir = home
+                .path()
+                .join(".continuum/genome/models/qwen2.5-coder-14b-instruct");
+            std::fs::create_dir_all(&dir).unwrap();
+            write_empty_gguf(&dir.join("Qwen2.5-Coder-14B-Instruct-Q4_K_M.gguf"));
+
+            let spec = catalog::models()
+                .into_iter()
+                .find(|m| m.id == "continuum-ai/qwen2.5-coder-14b-instruct-GGUF")
+                .expect("coder-14b in catalog");
+            // The catalog carries NO hardcoded path anymore.
+            assert!(
+                spec.gguf_local_path.is_none(),
+                "coder-14b catalog spec must have no hardcoded gguf_local_path"
+            );
+
+            let reg = Registry::from_catalog(vec![spec], catalog::providers())
+                .expect("registry loads");
+            let model = reg
+                .model("continuum-ai/qwen2.5-coder-14b-instruct-GGUF")
+                .expect("coder-14b registered");
+            let resolved = model
+                .gguf_local_path
+                .as_deref()
+                .expect("must resolve a GGUF by id-derivation");
+            assert!(
+                resolved.ends_with("Qwen2.5-Coder-14B-Instruct-Q4_K_M.gguf"),
+                "resolved by id-derivation under genome/models, got {resolved:?}"
+            );
+        });
+    }
 }


### PR DESCRIPTION
Unhardcode-models slice 1. Three catalog entries baked an absolute gguf_local_path with a specific quant
(coder-14b teacher, 0.5b trainable base, 0.6b embedder) — brittle hardcodes that pin a machine-specific path.
The registry already resolves via `resolve_from_local_model_roots(model_id)` (identity-token subset match under
~/.continuum/genome/models/) → HF cache via gguf_hint, so the hardcoded path was redundant. Removed all three;
resolution now DERIVES the serving path from the id (where download-models.sh lands the model), no baked
path/quant.

Verified: new `coder_14b_resolves_by_id_derivation_without_hardcoded_path` (mock genome/models dir → resolves by
id); the existing stale-path→HF-cache test still green; and LIVE — rebooted the core and llama-server spawned
with the derived path `-m .../qwen2.5-coder-14b-instruct/...Q4_K_M.gguf`, ping ok. No serving regression.

The 2 vision entries (qwen2-vl-7b, qwen2.5-omni-7b) keep their paths for now — they point at a non-standard
~/models/ root and are part of the vision-serving work (real VL, not YOLO crutches).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
