### PR TITLE
feat(provisioning): ArtifactSource trait — one abstraction for every downloadable artifact (cache-aware)

### DIFF
--- a/core/continuum-core/src/lib.rs
+++ b/core/continuum-core/src/lib.rs
@@ -56,6 +56,7 @@ pub mod orm;
 pub mod paging;
 pub mod paths;
 pub mod persona;
+pub mod provisioning;
 pub mod rag;
 pub mod resources;
 pub mod routing;

--- a/core/continuum-core/src/provisioning/avatar_source.rs
+++ b/core/continuum-core/src/provisioning/avatar_source.rs
@@ -1,0 +1,80 @@
+//! `ArtifactSource` for avatars — over the `AVATAR_CATALOG` (#1871). This is the
+//! pattern the whole provisioning system generalizes from: a single-source catalog
+//! carrying `{id, url, source_kind, license}` + a derived local path.
+
+use super::{disk_state_of, ArtifactKind, ArtifactSource, ArtifactSpec, DiskState, SourceKind};
+use crate::live::avatar::catalog::{avatar_model_path, AVATAR_CATALOG};
+
+/// Provisions VRM/GLB avatars from `AVATAR_CATALOG`.
+pub struct AvatarSource;
+
+impl ArtifactSource for AvatarSource {
+    fn kind(&self) -> ArtifactKind {
+        ArtifactKind::Avatar
+    }
+
+    fn catalog(&self) -> Vec<ArtifactSpec> {
+        AVATAR_CATALOG
+            .iter()
+            .map(|m| ArtifactSpec {
+                id: m.id.to_string(),
+                url: m.url.to_string(),
+                source_kind: parse_source_kind(m.source_kind),
+                // VRM sizes aren't pinned in the catalog; known once on disk.
+                size_bytes: None,
+                checksum: None,
+                license: Some(m.license.to_string()),
+            })
+            .collect()
+    }
+
+    fn disk_state(&self, id: &str) -> DiskState {
+        match AVATAR_CATALOG.iter().find(|m| m.id == id) {
+            Some(m) => disk_state_of(avatar_model_path(m.filename)),
+            None => DiskState::Absent,
+        }
+    }
+}
+
+/// Map the catalog's `source_kind` string onto the fetch strategy.
+fn parse_source_kind(kind: &str) -> SourceKind {
+    match kind {
+        "vroid-zip" => SourceKind::Zip,
+        _ => SourceKind::Direct,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the avatar catalog projects cleanly onto ArtifactSpec — every
+    // entry yields a non-empty id + url and a known source_kind, so the generic
+    // Downloader/Provisioner can consume avatars with no avatar-specific code.
+    #[test]
+    fn avatar_source_projects_the_whole_catalog() {
+        let src = AvatarSource;
+        assert_eq!(src.kind(), ArtifactKind::Avatar);
+        let specs = src.catalog();
+        assert_eq!(specs.len(), AVATAR_CATALOG.len());
+        assert!(specs.len() >= 8, "expected the 8 vroid avatars");
+        for s in &specs {
+            assert!(!s.id.is_empty(), "spec has no id");
+            assert!(s.url.starts_with("http"), "{} has no url", s.id);
+            assert_eq!(s.license.as_deref(), Some("CC0"));
+        }
+    }
+
+    // what this catches: disk_state derives the path from the id (never hardcoded) and
+    // reports Absent for an unknown id — the cache-reasoning primitive.
+    #[test]
+    fn avatar_disk_state_derives_and_reports_absent_for_unknown() {
+        let src = AvatarSource;
+        assert_eq!(src.disk_state("definitely-not-an-avatar-id"), DiskState::Absent);
+        // A real catalog id resolves to a concrete path decision (present/absent
+        // depending on whether it's been provisioned) — the point is it doesn't panic
+        // and it's derived, not hardcoded.
+        let real = AVATAR_CATALOG[0].id;
+        let _ = src.disk_state(real);
+    }
+}

--- a/core/continuum-core/src/provisioning/mod.rs
+++ b/core/continuum-core/src/provisioning/mod.rs
@@ -1,0 +1,120 @@
+//! Provisioning — one Rust loader/cache for every downloadable artifact.
+//!
+//! See `docs/architecture/PROVISIONING-SYSTEM.md`. This replaces the pile of
+//! install/download shell scripts with ONE abstraction: a model download and an
+//! avatar download are the same operation over different catalogs.
+//!
+//! ## It's a CACHE, not just a downloader
+//!
+//! Disk is finite on the misfit grid (a MacBook Air is not the 16 TB store). The
+//! artifact store is a **cache**: the currently-needed set (active personas' models,
+//! their avatars/voices) is PINNED and guaranteed present ("we need what we need"),
+//! while everything else is evictable when space runs short — LRU/least-needed first,
+//! the same shape as the genome pager. So every `ArtifactSource` must answer not just
+//! "where does this come from" but "is it on disk, and how big" (`disk_state`) — the
+//! reasoning primitive the cache manager (a later slice) needs to budget + evict.
+
+use std::path::PathBuf;
+
+pub mod avatar_source;
+pub mod model_source;
+
+pub use avatar_source::AvatarSource;
+pub use model_source::ModelSource;
+
+/// What kind of artifact this is — for routing + human-readable provisioning reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactKind {
+    /// LLM / VLM / embedding weights (GGUF).
+    Model,
+    /// A VRM/GLB avatar mesh.
+    Avatar,
+    /// A TTS/voice model.
+    Voice,
+    /// An executable the runtime shells out to (e.g. llama-server).
+    Binary,
+}
+
+/// How the `Downloader` (a later slice) must fetch `url`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceKind {
+    /// A Hugging Face repo — resolve the file(s) + fetch (the model path).
+    HfFile,
+    /// A zip archive to download + extract (the VRoid VRM path).
+    Zip,
+    /// A direct file URL.
+    Direct,
+}
+
+/// One downloadable artifact, projected from an `ArtifactSource`'s catalog. The
+/// single source of truth for "where does this come from + how do I verify it" —
+/// never a hardcoded local path (that's DERIVED via `disk_state`).
+#[derive(Debug, Clone)]
+pub struct ArtifactSpec {
+    /// Stable id (matches the catalog id — the resolver key).
+    pub id: String,
+    /// Where to fetch it from.
+    pub url: String,
+    /// How to fetch it.
+    pub source_kind: SourceKind,
+    /// On-disk size in bytes, if known ahead of download — the cache budget input.
+    /// Often `None` until the file exists (HF file sizes need a HEAD; the quant
+    /// footprint is param-count-derivable for models — a later refinement).
+    pub size_bytes: Option<u64>,
+    /// Content checksum for verify-after-download, if the catalog pins one.
+    pub checksum: Option<String>,
+    /// License identifier (e.g. "CC0").
+    pub license: Option<String>,
+}
+
+/// Whether an artifact is on disk right now, and how big — the cache-reasoning
+/// primitive. The path is always DERIVED (from the id / catalog), never hardcoded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiskState {
+    /// Present locally — the cache can serve it, or evict it if unpinned.
+    Present { path: PathBuf, bytes: u64 },
+    /// Not on disk — the provisioner must fetch it if it's needed.
+    Absent,
+}
+
+impl DiskState {
+    pub fn is_present(&self) -> bool {
+        matches!(self, DiskState::Present { .. })
+    }
+    /// Bytes this artifact occupies on disk (0 if absent) — the cache's reclaim input.
+    pub fn bytes(&self) -> u64 {
+        match self {
+            DiskState::Present { bytes, .. } => *bytes,
+            DiskState::Absent => 0,
+        }
+    }
+}
+
+/// A catalog of one kind of downloadable artifact. The ONE abstraction models,
+/// avatars, voices, and binaries all implement — so the `Downloader` +
+/// `Provisioner` (later slices) treat them uniformly instead of a bespoke shell
+/// script each. Two maximally-different impls (`AvatarSource` = zip/VRM,
+/// `ModelSource` = HF/GGUF) validate the abstraction before the rest exist.
+pub trait ArtifactSource: Send + Sync {
+    /// What kind of artifact this source provides.
+    fn kind(&self) -> ArtifactKind;
+
+    /// The full catalog — the single source of truth for what's available + where
+    /// it comes from. Adding an artifact is one catalog entry (the #1871 rule).
+    fn catalog(&self) -> Vec<ArtifactSpec>;
+
+    /// Is artifact `id` on disk right now, and how big? The cache-reasoning primitive
+    /// — the path is DERIVED, never a hardcoded absolute path.
+    fn disk_state(&self, id: &str) -> DiskState;
+}
+
+/// Helper for impls: the on-disk size of a file, or `Absent` if it doesn't exist.
+pub(crate) fn disk_state_of(path: PathBuf) -> DiskState {
+    match std::fs::metadata(&path) {
+        Ok(meta) if meta.is_file() => DiskState::Present {
+            bytes: meta.len(),
+            path,
+        },
+        _ => DiskState::Absent,
+    }
+}

--- a/core/continuum-core/src/provisioning/model_source.rs
+++ b/core/continuum-core/src/provisioning/model_source.rs
@@ -1,0 +1,86 @@
+//! `ArtifactSource` for model weights — the OUTLIER that validates the abstraction.
+//!
+//! Maximally different from `AvatarSource`: HF-repo source (not a zip URL), GGUF on
+//! disk (not a VRM), path resolved by identity-token match under the model roots +
+//! HF cache (not a filename lookup). If the ONE `ArtifactSource` trait fits both the
+//! avatar catalog AND this without forcing, the abstraction is proven and voices /
+//! binaries are trivial.
+
+use super::{disk_state_of, ArtifactKind, ArtifactSource, ArtifactSpec, DiskState, SourceKind};
+use crate::model_registry::artifacts::resolve_gguf_for_model_id;
+use crate::model_registry::catalog;
+
+/// Provisions GGUF model weights from `model_registry::catalog`. Only rows with a
+/// `gguf_hint` are provisionable artifacts (a download source); cloud/API models have
+/// no local weight to cache and are skipped.
+pub struct ModelSource;
+
+impl ArtifactSource for ModelSource {
+    fn kind(&self) -> ArtifactKind {
+        ArtifactKind::Model
+    }
+
+    fn catalog(&self) -> Vec<ArtifactSpec> {
+        catalog::models()
+            .into_iter()
+            .filter_map(|m| {
+                let url = m.gguf_hint?; // no hint ⇒ not a downloadable artifact
+                Some(ArtifactSpec {
+                    id: m.id,
+                    url,
+                    source_kind: SourceKind::HfFile,
+                    // GGUF footprint is param×quant-derivable; known exactly once on
+                    // disk. Left None here (a later refinement feeds the cache budget).
+                    size_bytes: None,
+                    checksum: None,
+                    license: None,
+                })
+            })
+            .collect()
+    }
+
+    fn disk_state(&self, id: &str) -> DiskState {
+        // resolve_gguf_for_model_id DERIVES the path (id-token match under
+        // ~/.continuum/genome/models/ → HF cache via hint) — never a hardcoded path.
+        match resolve_gguf_for_model_id(id) {
+            Some(path) => disk_state_of(path),
+            None => DiskState::Absent,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the model catalog projects onto the SAME ArtifactSpec the
+    // avatar catalog does — proving the trait fits a maximally-different source
+    // (HF/GGUF vs zip/VRM) without avatar- or model-specific shims. Every provisionable
+    // model yields a non-empty id + an HF url, and the teacher (coder-14b) is present.
+    #[test]
+    fn model_source_projects_provisionable_models() {
+        let src = ModelSource;
+        assert_eq!(src.kind(), ArtifactKind::Model);
+        let specs = src.catalog();
+        assert!(!specs.is_empty(), "no provisionable models");
+        for s in &specs {
+            assert!(!s.id.is_empty(), "spec has no id");
+            assert!(!s.url.is_empty(), "{} has no url", s.id);
+            assert_eq!(s.source_kind, SourceKind::HfFile);
+        }
+        assert!(
+            specs
+                .iter()
+                .any(|s| s.id == "continuum-ai/qwen2.5-coder-14b-instruct-GGUF"),
+            "the coder-14b teacher must be a provisionable artifact"
+        );
+    }
+
+    // what this catches: disk_state for an unknown model id is Absent (no panic, no
+    // hardcoded path) — the cache-reasoning primitive works for the outlier too.
+    #[test]
+    fn model_disk_state_absent_for_unknown_id() {
+        let src = ModelSource;
+        assert_eq!(src.disk_state("no-such-model-xyz"), DiskState::Absent);
+    }
+}

--- a/docs/architecture/PROVISIONING-SYSTEM.md
+++ b/docs/architecture/PROVISIONING-SYSTEM.md
@@ -95,6 +95,29 @@ workstation provisions the teacher + VL model. It composes with the inference-la
 planner (the lane daemon decides *how many* run; the provisioner ensures the weights
 are *on disk*).
 
+### 5. The store is a CACHE — the Provisioner owns disk, not just downloads
+
+Disk is finite on the misfit grid (a MacBook Air is not the 16 TB store), so the
+artifact store is a **cache**, and the Provisioner OWNS it — it's the disk authority
+for weights/avatars/voices, the way the ResourceGovernor owns VRAM ([[resource-authority-is-a-system-concern]]).
+
+- **Pin the needed set** — "we need what we need": the artifacts the *currently
+  active* personas + lanes require (the `ProvisionPlan`) are PINNED and guaranteed
+  present.
+- **Evict the rest** — everything unpinned is evictable cache. When fetching a needed
+  artifact would blow the disk budget, evict least-needed-first (LRU / last-used),
+  exactly the shape of the genome pager but for the whole on-disk store.
+- **`DiskState` is the reasoning primitive** — every `ArtifactSource` reports whether
+  an artifact is present + how many bytes, so the cache can compute "reclaimable if I
+  evict X, Y" against "need N more bytes for Z".
+- **Fail loud when it won't fit** — if the pinned/needed set doesn't fit even after
+  evicting everything unpinned, that's a hard truth about this machine (too many big
+  models for this disk) — name it, don't silently thrash ([[fallbacks-are-illegal-fail-loud]],
+  [[model-fit-is-the-priority-single-machine-first]]).
+
+So `provision(plan)` is really `reconcile(plan, disk_budget)`: ensure the pinned set
+is on disk, evicting unpinned cache as needed, refusing loudly if impossible.
+
 ## Invariants
 
 1. **Data-driven** — every artifact is a catalog entry, never a hardcoded path or a


### PR DESCRIPTION
Slice 1 of the provisioning system (PROVISIONING-SYSTEM.md). Extracts the ONE abstraction the pile of
download shell scripts should have been: `ArtifactSource` { kind, catalog() -> Vec<ArtifactSpec>, disk_state(id)
-> DiskState }. A model download and an avatar download become the same operation over different catalogs.

Validated by two MAXIMALLY-DIFFERENT impls (outlier discipline):
- `AvatarSource` over AVATAR_CATALOG (#1871) — zip/VRM source, filename-lookup path.
- `ModelSource` over model_registry::catalog — HF-repo source, id-token-match GGUF path (the outlier).
The trait fits both with zero per-type shims → abstraction proven; voices/binaries are now trivial.

Baked in Joel's cache insight from the start: the store is a CACHE on finite misfit-hardware disk, not a
downloader. `DiskState { Present{path,bytes} | Absent }` is the cache-reasoning primitive every source reports,
so the (later) Provisioner can budget + evict LRU while PINNING the needed set ("we need what we need") and
failing loud when it won't fit. Blueprint updated with the cache-ownership section.

Verified: 4 tests — both sources project the whole catalog onto ArtifactSpec, disk_state derives (never
hardcodes) + reports Absent for unknown ids. Next slices: the Downloader (one resumable/verified fetch), the
Prerequisite manifest, then the Provisioner/cache-manager + `cu provision`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
