### PR TITLE
feat(render): render governor — idle faces throttle under load, speakers stay full-fps (14 personas viable)

### DIFF
--- a/core/continuum-core/src/live/video/bevy_renderer/animation/cadence.rs
+++ b/core/continuum-core/src/live/video/bevy_renderer/animation/cadence.rs
@@ -3,8 +3,66 @@
 use bevy::prelude::*;
 
 use super::super::scene::SlotRegistry;
-use super::super::types::{ActiveSpeechClips, RenderSchedule};
+use super::super::types::{ActiveSpeechClips, RenderSchedule, SharedMemoryStats};
 use super::components::*;
+
+/// The render governor's policy: given how many slots are ACTIVE and how many are
+/// SPEAKING, decide how often the IDLE slots should render (`idle_cadence`).
+///
+/// [[multimodal-live-mode-is-a-latency-obsession]] made concrete: a moving mouth at
+/// low fps is the ONE thing an eye catches, so speakers always render every frame
+/// (cadence 1) and consume the frame budget first. Idle faces (breathing, listening)
+/// are near-static — dropping them to 1/N fps is unnoticed, so they share whatever
+/// budget the speakers leave. This is the render's CBAR-DVFS knob that keeps 14
+/// personas viable on one machine: 1 speaker in a small call renders full-fps; a
+/// crowded call throttles the idle faces, never the talker.
+///
+/// The `FULL_FPS_BUDGET` (how many slots a machine can render every frame) is a sane
+/// single-machine default here ("priorities are what they are, non-grid first"); a
+/// follow-up feeds it from the CBAR governor / measured GPU headroom.
+pub fn adaptive_idle_cadence(active_slots: usize, speaking_slots: usize) -> u32 {
+    const FULL_FPS_BUDGET: usize = 4;
+    const MAX_CADENCE: u32 = 8;
+
+    let idle = active_slots.saturating_sub(speaking_slots);
+    let left = FULL_FPS_BUDGET.saturating_sub(speaking_slots).max(1);
+    if idle <= left {
+        1 // light enough — every face renders smooth
+    } else {
+        // ceil(idle / left), clamped: the more idle faces pile onto the remaining
+        // budget, the slower each one renders.
+        let raw = (idle + left - 1) / left;
+        (raw as u32).clamp(1, MAX_CADENCE)
+    }
+}
+
+/// The render-governor SYSTEM: each tick, count the active + speaking slots and store
+/// the policy's `idle_cadence` into `desired_idle_cadence`. `sync_idle_cadence` then
+/// applies it to the `RenderSchedule`, and `manage_render_cadence` gates the cameras.
+/// Without this, `desired_idle_cadence` stays at its init value (1) forever and idle
+/// faces never throttle — the adaptive machinery was built but never driven.
+pub(in crate::live::video::bevy_renderer) fn govern_idle_cadence(
+    registry: Res<SlotRegistry>,
+    speech_clips: Res<ActiveSpeechClips>,
+    stats: Res<SharedMemoryStats>,
+) {
+    let mut active = 0usize;
+    let mut speaking = 0usize;
+    for (slot, slot_data) in &registry.slots {
+        if !slot_data.is_active() {
+            continue;
+        }
+        active += 1;
+        if speech_clips.clips.contains_key(slot) {
+            speaking += 1;
+        }
+    }
+    let cadence = adaptive_idle_cadence(active, speaking);
+    stats
+        .0
+        .desired_idle_cadence
+        .store(cadence, std::sync::atomic::Ordering::Relaxed);
+}
 
 /// Staggered render cadence — controls which cameras render each frame.
 pub(in crate::live::video::bevy_renderer) fn manage_render_cadence(
@@ -32,5 +90,31 @@ pub(in crate::live::video::bevy_renderer) fn manage_render_cadence(
         if let Ok(mut camera) = cameras.get_mut(cam_entity) {
             camera.is_active = should_render;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::adaptive_idle_cadence;
+
+    // what this catches: the "managed for misfits" invariant — a light call renders
+    // every face smooth, a crowded call throttles the IDLE faces (never the speaker),
+    // so 14 personas stay viable on one machine. Speakers (a moving mouth) never drop.
+    #[test]
+    fn cadence_light_smooth_heavy_throttles_idle_never_speaker() {
+        // Under budget → everything smooth (cadence 1).
+        assert_eq!(adaptive_idle_cadence(2, 1), 1, "1 speaker, small call → full fps");
+        assert_eq!(adaptive_idle_cadence(4, 0), 1, "4 idle within budget → smooth");
+        // Crowded call → idle faces throttle.
+        assert!(
+            adaptive_idle_cadence(14, 2) > 1,
+            "14 active / 2 speaking must throttle the idle faces"
+        );
+        // More idle pressure → cadence never decreases (monotonic).
+        assert!(adaptive_idle_cadence(14, 1) >= adaptive_idle_cadence(8, 1));
+        // All speakers → no idle to throttle → cadence 1 (speakers never self-throttle).
+        assert_eq!(adaptive_idle_cadence(4, 4), 1);
+        // Clamped so a runaway count can't make idle render effectively never.
+        assert!(adaptive_idle_cadence(100, 0) <= 8);
     }
 }

--- a/core/continuum-core/src/live/video/bevy_renderer/animation/mod.rs
+++ b/core/continuum-core/src/live/video/bevy_renderer/animation/mod.rs
@@ -51,7 +51,7 @@ pub(super) enum AnimationSet {
 pub(super) use blinking::animate_blinking;
 pub(super) use body_gestures::{animate_body_gestures, drive_cognitive_gestures};
 pub(super) use breathing::animate_breathing;
-pub(super) use cadence::manage_render_cadence;
+pub(super) use cadence::{govern_idle_cadence, manage_render_cadence};
 pub(super) use camera::animate_idle;
 pub(super) use expression::animate_expression;
 pub(super) use eye_gaze::animate_eye_gaze;

--- a/core/continuum-core/src/live/video/bevy_renderer/app.rs
+++ b/core/continuum-core/src/live/video/bevy_renderer/app.rs
@@ -81,6 +81,10 @@ pub(super) fn run_bevy_app(
                 process_commands,
                 monitor_load_states,
                 update_memory_stats,
+                // Render governor: set the desired idle cadence from live load
+                // (active/speaking slots) so idle faces throttle under a crowded call
+                // while the speaker stays full-fps. sync_idle_cadence applies it.
+                animation::govern_idle_cadence,
                 sync_idle_cadence,
                 scene::room::populate_rooms,
             ),


### PR DESCRIPTION
Render-governor slice 1 ([[multimodal-live-mode-is-a-latency-obsession]]). The adaptive-cadence MACHINERY was
already built — `desired_idle_cadence` (atomic) → `sync_idle_cadence` → `manage_render_cadence` gates each
slot's camera, rendering speakers every frame + idle slots every Nth (staggered). But NOTHING ever wrote
`desired_idle_cadence`; it stayed at its init value (1), so idle faces always rendered every frame and the
throttle never engaged. The adaptive rails existed with no driver.

Added the missing POLICY: `adaptive_idle_cadence(active, speaking)` + a `govern_idle_cadence` system that counts
the live active/speaking slots each tick and stores the cadence. A moving mouth at low fps is the one thing an
eye catches, so speakers always render full-fps and take the frame budget first; idle faces (breathing,
listening) share what's left, dropping to 1/N fps — unnoticed. So a small call renders every face smooth
(cadence 1), a crowded 14-persona call throttles the idle faces (never the talker) to stay viable on one
machine. The FULL_FPS_BUDGET is a sane single-machine default ("non-grid first"); a follow-up feeds it from the
CBAR governor's measured GPU headroom, and window-adequate resolution is the second lever.

Verified: unit test (light→smooth, crowded→throttle-idle, speakers-never-throttle, monotonic, clamped); LIVE —
rebooted, render still HEALTHY (coverage 100%), correctly no throttle at 2 personas (under budget), no
regression.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
