### PR TITLE
feat(provisioning): eviction executor — the Provisioner reclaims finite misfit disk

### DIFF
--- a/core/continuum-core/src/provisioning/mod.rs
+++ b/core/continuum-core/src/provisioning/mod.rs
@@ -26,7 +26,7 @@ pub use avatar_source::AvatarSource;
 pub use cache::{reconcile, CacheDecision, CacheEntry, ProvisionPlan};
 pub use downloader::{DownloadError, Downloader};
 pub use model_source::ModelSource;
-pub use provisioner::Provisioner;
+pub use provisioner::{EvictionReport, Provisioner};
 
 /// What kind of artifact this is — for routing + human-readable provisioning reports.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/core/continuum-core/src/provisioning/provisioner.rs
+++ b/core/continuum-core/src/provisioning/provisioner.rs
@@ -8,8 +8,23 @@
 //! `cu provision` command drives it, and the core self-provisions on launch.
 
 use super::{
-    reconcile, ArtifactSource, AvatarSource, CacheDecision, CacheEntry, ModelSource, ProvisionPlan,
+    reconcile, ArtifactSource, AvatarSource, CacheDecision, CacheEntry, DiskState, ModelSource,
+    ProvisionPlan,
 };
+
+/// Outcome of an eviction pass — bytes freed per artifact, and any per-file errors
+/// (batch-resilient: one locked file must not block reclaiming the rest).
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct EvictionReport {
+    pub freed: Vec<(String, u64)>,
+    pub errors: Vec<(String, String)>,
+}
+
+impl EvictionReport {
+    pub fn total_freed(&self) -> u64 {
+        self.freed.iter().map(|(_, b)| b).sum()
+    }
+}
 
 /// Owns the artifact catalog across all sources + turns a demand plan into a cache
 /// decision. Sources are trait objects so voices/binaries slot in with no changes.
@@ -59,6 +74,35 @@ impl Provisioner {
         }
         reconcile(&entries, budget_bytes)
     }
+
+    /// Find an artifact's on-disk state across the sources (first present wins).
+    fn locate(&self, id: &str) -> Option<DiskState> {
+        self.sources
+            .iter()
+            .map(|s| s.disk_state(id))
+            .find(|d| d.is_present())
+    }
+
+    /// ACT on `decision.evict`: delete the evicted artifacts' files, freeing disk. Only
+    /// touches ids the reconcile marked evictable (unpinned, by construction) — the
+    /// pinned/needed set is never deleted. Batch-resilient + fail-loud: a delete error
+    /// on one file is recorded and the pass continues (a locked file mustn't block
+    /// reclaiming the rest), never silently swallowed. This is the "finite misfit disk"
+    /// reclaim — the counterpart to the Downloader's fetch.
+    pub fn execute_evictions(&self, decision: &CacheDecision) -> EvictionReport {
+        let mut report = EvictionReport::default();
+        for id in &decision.evict {
+            match self.locate(id) {
+                Some(DiskState::Present { path, bytes }) => match std::fs::remove_file(&path) {
+                    Ok(()) => report.freed.push((id.clone(), bytes)),
+                    Err(e) => report.errors.push((id.clone(), e.to_string())),
+                },
+                // Already gone — nothing to reclaim, not an error.
+                _ => {}
+            }
+        }
+        report
+    }
 }
 
 #[cfg(test)]
@@ -103,6 +147,10 @@ mod tests {
         DiskState::Present { path: PathBuf::from("/x"), bytes }
     }
 
+    fn present_at(path: PathBuf, bytes: u64) -> DiskState {
+        DiskState::Present { path, bytes }
+    }
+
     // what this catches: the orchestrator threads pin (from the plan) + disk_state
     // (from each source) into the reconcile — so a needed-but-absent model is FETCHED,
     // an unpinned cached avatar is EVICTED to fit the budget, and the pinned model is
@@ -139,5 +187,28 @@ mod tests {
         let ids = prov.all_ids();
         assert!(ids.iter().any(|i| i == "continuum-ai/qwen2.5-coder-14b-instruct-GGUF"));
         assert!(ids.iter().any(|i| i.starts_with("vroid-")), "avatars present too");
+    }
+
+    // what this catches: eviction ACTS — the evicted artifact's real file is deleted
+    // and its bytes reported freed, closing the "finite misfit disk" reclaim loop.
+    #[test]
+    fn execute_evictions_deletes_files_and_reports_freed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let f = dir.path().join("evictable.vrm");
+        std::fs::write(&f, vec![0u8; 1234]).unwrap();
+        let src = MockSource {
+            kind: ArtifactKind::Avatar,
+            specs: vec![("evictable".into(), present_at(f.clone(), 1234))],
+        };
+        let prov = Provisioner::new(vec![Box::new(src)]);
+        let decision = CacheDecision {
+            fetch: vec![],
+            evict: vec!["evictable".into()],
+            shortfall_bytes: 0,
+        };
+        let report = prov.execute_evictions(&decision);
+        assert_eq!(report.total_freed(), 1234);
+        assert!(!f.exists(), "evicted file must actually be deleted");
+        assert!(report.errors.is_empty());
     }
 }


### PR DESCRIPTION
Provisioning slice 5, the wire-up's clean half: `Provisioner.execute_evictions(decision)` ACTS on
`CacheDecision.evict` — locates each evicted artifact across the sources (first-present) and deletes its file,
reporting bytes freed. Only touches ids the reconcile marked evictable (unpinned by construction — the pinned
set is never deleted). Batch-resilient + fail-loud: a delete error on one file is recorded and the pass
continues (a locked file mustn't block reclaiming the rest), never silently swallowed.

This closes the "finite misfit disk" reclaim loop — the counterpart to the Downloader's fetch. Now the cache
side is whole: reconcile decides, evict frees.

Verified: `execute_evictions_deletes_files_and_reports_freed` — a real temp file is deleted and its bytes
reported. The FETCH half (wire Downloader + resolve HF-repo→file for models + zip-extract for avatars +
dest_path derivation) is the next focused slice; then demand-plan + `cu provision` drive it end-to-end.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
