### PR TITLE
feat(provisioning): glass-box boot report — provisioning runs LIVE, sees the real artifact cache

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1674,6 +1674,16 @@ pub fn start_server(
         // TODO #52) AND decides the model + lanes from an honest budget +
         // on-disk footprints with GPU-residency. The spawner obeys the plan —
         // no hardcoded tier/model/lanes. (Supersedes the #1645 tier-clamp fix.)
+        // Glass-box: surface the artifact cache state at boot so the real provisioning
+        // picture (what weights/avatars are present, how much disk) is visible without
+        // a debugger ([[never-blind-feedback-driven-iteration]]). First live use of the
+        // provisioning system on the running core. `eprintln!` (not the category logger)
+        // so a boot summary is UNCONDITIONALLY visible in the server log, regardless of
+        // which log categories the operator has enabled.
+        eprintln!(
+            "📦 artifact cache at boot: {}",
+            crate::provisioning::Provisioner::default().cache_report()
+        );
         let (hw_cap, tier_cat, tier_id) = serving_daemon.detected_tier();
         // The plan is the single grouped source of truth (model + lanes +
         // host-fit served window). Pass it by reference to the spawner per

--- a/core/continuum-core/src/provisioning/provisioner.rs
+++ b/core/continuum-core/src/provisioning/provisioner.rs
@@ -75,6 +75,33 @@ impl Provisioner {
         reconcile(&entries, budget_bytes)
     }
 
+    /// A human-readable snapshot of the artifact cache — per kind, how many artifacts
+    /// are present on disk vs catalogued, and the bytes they occupy. For the boot-time
+    /// glass-box log so the real cache state is visible without a debugger
+    /// ([[never-blind-feedback-driven-iteration]]).
+    pub fn cache_report(&self) -> String {
+        let mut parts = Vec::new();
+        for source in &self.sources {
+            let specs = source.catalog();
+            let mut present = 0usize;
+            let mut bytes = 0u64;
+            for spec in &specs {
+                if let DiskState::Present { bytes: b, .. } = source.disk_state(&spec.id) {
+                    present += 1;
+                    bytes += b;
+                }
+            }
+            parts.push(format!(
+                "{:?} {}/{} present ({} MiB)",
+                source.kind(),
+                present,
+                specs.len(),
+                bytes / (1 << 20)
+            ));
+        }
+        parts.join(" · ")
+    }
+
     /// Find an artifact's on-disk state across the sources (first present wins).
     fn locate(&self, id: &str) -> Option<DiskState> {
         self.sources


### PR DESCRIPTION
The provisioning system was fully unit-tested but had NEVER run on the live core. Wired `Provisioner.cache_report()`
into the boot path so the real cache state is surfaced at startup — first live use of the abstraction against
real disk.

Live-verified on a real reboot:
  📦 artifact cache at boot: Model 6/9 present (16106 MiB) · Avatar 8/8 present (132 MiB)
Real truth: 6 of 9 catalogued models on disk (~16 GB), all 8 avatars present (the ones #1871 fetched). The
ArtifactSource → disk_state path is proven end-to-end, not mocked.

Glass-box caught a bug in the doing ([[never-blind-feedback-driven-iteration]]): the first attempt used
`log_info!("ipc",…)`, which routes to an OPT-IN category that's disabled — the line fired but was invisible
(serving ran right after it, proving the section executed). A boot summary must be unconditionally visible, so
it's `eprintln!` now (like the [MEMLEAK] lines that reach the server log). A unit test would've been green while
the log went nowhere — exactly why we run the real system.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
