### PR TITLE
feat(provisioning): drive modes — Eco · Comfort · Sport · Performance (a car, not a switch)

### DIFF
--- a/core/continuum-core/src/provisioning/mod.rs
+++ b/core/continuum-core/src/provisioning/mod.rs
@@ -29,7 +29,10 @@ pub use avatar_source::AvatarSource;
 pub use cache::{reconcile, CacheDecision, CacheEntry, ProvisionPlan};
 pub use downloader::{DownloadError, Downloader};
 pub use fetch::{fetch_and_place, FetchError};
-pub use model_catalog::{parse_quant, select_best_fit, GgufCandidate};
+pub use model_catalog::{
+    budget_for_mode, parse_quant, plan_family_fetch, plan_model_fetch, select_best_fit, select_for_mode,
+    CatalogError, GgufCandidate, ModelFamily, ModelFetchPlan, PowerMode,
+};
 pub use model_source::ModelSource;
 pub use provisioner::{EvictionReport, Provisioner};
 pub use scaling::{DefaultScalingPolicy, DemandContext, ScalingPolicy};

--- a/core/continuum-core/src/provisioning/model_catalog.rs
+++ b/core/continuum-core/src/provisioning/model_catalog.rs
@@ -77,17 +77,17 @@ fn looks_like_quant(token: &str) -> bool {
 /// be surfaced (fail loud), never silently downgraded past what exists or oversized past
 /// what fits.
 pub fn select_best_fit(candidates: &[GgufCandidate], vram_budget_bytes: u64) -> Option<&GgufCandidate> {
-    select_for_demand(candidates, vram_budget_bytes, QualityTarget::Balanced)
+    select_for_mode(candidates, vram_budget_bytes, PowerMode::Comfort)
 }
 
-/// Pick the main-weight GGUF for a demand level. `Balanced` prefers the largest QUANTIZED
-/// tier that fits (near-lossless, leaves the pool for others), falling to float only if
-/// no quant fits. `Maximum` takes the single largest that fits, raw float included — the
-/// gas pedal. None when nothing fits (fail loud).
-pub fn select_for_demand(
+/// Pick the main-weight GGUF for a mode. Non-`allows_float` modes prefer the largest
+/// QUANTIZED tier that fits (near-lossless, leaves the pool for others), falling to float
+/// only if no quant fits. `Performance` (`allows_float`) takes the single largest that
+/// fits, raw F16 included. None when nothing fits (fail loud).
+pub fn select_for_mode(
     candidates: &[GgufCandidate],
     vram_budget_bytes: u64,
-    target: QualityTarget,
+    mode: PowerMode,
 ) -> Option<&GgufCandidate> {
     // Largest that fits, deterministic tie-break by name — over a given candidate set.
     let largest = |quantized_only: bool| {
@@ -101,11 +101,12 @@ pub fn select_for_demand(
                     .then_with(|| b.filename.cmp(&a.filename))
             })
     };
-    match target {
-        // Share the box: near-lossless quantized, float only if no quant fits.
-        QualityTarget::Balanced => largest(true).or_else(|| largest(false)),
+    if mode.allows_float() {
         // Floor it: the biggest thing that fits, F16 included.
-        QualityTarget::Maximum => largest(false),
+        largest(false)
+    } else {
+        // Share the box: near-lossless quantized, float only if no quant fits.
+        largest(true).or_else(|| largest(false))
     }
 }
 
@@ -185,29 +186,50 @@ pub async fn list_repo_ggufs(
         .collect())
 }
 
-/// How hard to push THIS request — the gas pedal. Selection is dynamic, not a fixed
-/// conservative policy ([[misfit-grid-is-a-distributed-moe]], "dynamic base model up or
-/// down").
-/// - `Balanced` (default): the machine is shared — many personas, a live call. Leave
-///   headroom for the others + render; prefer near-lossless quantized weights.
-/// - `Maximum`: floor it. The teacher that trains the others, a substantial iOS build,
-///   "I need the BEST coder" — hand this one request nearly the whole machine and the
-///   highest fidelity that fits, raw F16 included. If we can run it, we should.
+/// The user-facing power spectrum — exactly a car's drive modes (Eco · Comfort · Sport ·
+/// Performance), and "tuners" for the power user: a first-class AI citizen or the human
+/// can define their own [`ScalingPolicy`](super::scaling::ScalingPolicy). `Comfort` is the
+/// default — economical by design (the "32 mpg" that still launches when you floor it).
+/// The mode sets how much of the box this one request may use, whether it climbs to a
+/// bigger brain, and whether raw float weights are on the table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum QualityTarget {
+pub enum PowerMode {
+    /// Max efficiency — battery, thermal, a crowded call. Small share of the box.
+    Eco,
+    /// Everyday default — good quality, shares the box with the rest of the call.
     #[default]
-    Balanced,
-    Maximum,
+    Comfort,
+    /// Quality-leaning — most of the machine, and climb to a bigger model.
+    Sport,
+    /// Floor it — nearly the whole box, the biggest brain + fidelity that fits, F16 on
+    /// the table. The teacher that trains the others, a substantial iOS build.
+    Performance,
 }
 
-/// The weights budget for a demand level: `Balanced` leaves headroom for other personas
-/// + render; `Maximum` hands this request nearly the whole machine (a small OS reserve).
-pub fn budget_for_demand(total_bytes: u64, target: QualityTarget) -> u64 {
-    match target {
-        QualityTarget::Balanced => model_budget_from_total(total_bytes),
-        // Press the gas: the whole box minus a thin OS reserve. One demanding ask can
-        // take everything, because that's the point of being able to run it at all.
-        QualityTarget::Maximum => total_bytes.saturating_sub(2 * (1 << 30)),
+impl PowerMode {
+    /// Raw float weights (F16) allowed — only when flooring it.
+    pub fn allows_float(self) -> bool {
+        matches!(self, PowerMode::Performance)
+    }
+    /// Climb the model-size ladder to a bigger BRAIN, not just a bigger quant.
+    pub fn climbs_ladder(self) -> bool {
+        matches!(self, PowerMode::Sport | PowerMode::Performance)
+    }
+}
+
+/// The weights budget for a mode: Eco leaves most of the box free (others, battery,
+/// thermal); Comfort is the conservative everyday; Sport takes most of it; Performance
+/// takes nearly all. Pass live `available_bytes` for an adaptive pick, `total` for the
+/// theoretical ceiling.
+pub fn budget_for_mode(total_bytes: u64, mode: PowerMode) -> u64 {
+    const RESERVE: u64 = 4 * (1 << 30); // OS + Bevy render + LiveKit encode
+    let usable = total_bytes.saturating_sub(RESERVE);
+    match mode {
+        PowerMode::Eco => (usable as f64 * 0.35) as u64,
+        PowerMode::Comfort => (usable as f64 * 0.70) as u64,
+        PowerMode::Sport => (usable as f64 * 0.90) as u64,
+        // Floor it: the whole box minus a thin OS reserve.
+        PowerMode::Performance => total_bytes.saturating_sub(2 * (1 << 30)),
     }
 }
 
@@ -218,9 +240,8 @@ pub fn budget_for_demand(total_bytes: u64, target: QualityTarget) -> u64 {
 /// activations. On Mac unified memory this IS the GPU pool; the governor's measured VRAM
 /// refines it on discrete GPUs. Conservative on purpose — a quant that fits beats an OOM.
 pub fn model_budget_from_total(total_bytes: u64) -> u64 {
-    const OS_RENDER_RESERVE: u64 = 4 * (1 << 30); // OS + Bevy render + LiveKit encode
-    let usable = total_bytes.saturating_sub(OS_RENDER_RESERVE);
-    (usable as f64 * 0.70) as u64 // the rest for KV cache + activations at runtime
+    // The Comfort (everyday) budget — reserve OS+render, 70% of the rest for weights.
+    budget_for_mode(total_bytes, PowerMode::Comfort)
 }
 
 /// Resolve WHAT to download for `repo` on a machine with `total_memory_bytes` at demand
@@ -232,11 +253,11 @@ pub async fn plan_model_fetch(
     client: &reqwest::Client,
     repo: &str,
     total_memory_bytes: u64,
-    target: QualityTarget,
+    mode: PowerMode,
 ) -> Result<ModelFetchPlan, CatalogError> {
-    let budget = budget_for_demand(total_memory_bytes, target);
+    let budget = budget_for_mode(total_memory_bytes, mode);
     let ggufs = list_repo_ggufs(client, repo).await?;
-    let pick = select_for_demand(&ggufs, budget, target).ok_or_else(|| CatalogError::NoneFit {
+    let pick = select_for_mode(&ggufs, budget, mode).ok_or_else(|| CatalogError::NoneFit {
         repo: normalize_repo(repo),
         budget,
     })?;
@@ -285,25 +306,24 @@ pub async fn plan_family_fetch(
     client: &reqwest::Client,
     family: &ModelFamily,
     total_memory_bytes: u64,
-    target: QualityTarget,
+    mode: PowerMode,
 ) -> Result<ModelFetchPlan, CatalogError> {
-    match target {
-        QualityTarget::Balanced => {
-            plan_model_fetch(client, family.ladder[family.default_idx], total_memory_bytes, target).await
-        }
-        QualityTarget::Maximum => {
-            let mut last_err = None;
-            for repo in family.ladder.iter().rev() {
-                match plan_model_fetch(client, repo, total_memory_bytes, target).await {
-                    Ok(plan) => return Ok(plan),
-                    Err(e) => last_err = Some(e),
-                }
+    if mode.climbs_ladder() {
+        // Climb top-down: the largest model whose best quant fits this mode wins.
+        let mut last_err = None;
+        for repo in family.ladder.iter().rev() {
+            match plan_model_fetch(client, repo, total_memory_bytes, mode).await {
+                Ok(plan) => return Ok(plan),
+                Err(e) => last_err = Some(e),
             }
-            Err(last_err.unwrap_or(CatalogError::NoneFit {
-                repo: family.name.to_string(),
-                budget: budget_for_demand(total_memory_bytes, target),
-            }))
         }
+        Err(last_err.unwrap_or(CatalogError::NoneFit {
+            repo: family.name.to_string(),
+            budget: budget_for_mode(total_memory_bytes, mode),
+        }))
+    } else {
+        // Everyday: the default size, sized to the mode's budget.
+        plan_model_fetch(client, family.ladder[family.default_idx], total_memory_bytes, mode).await
     }
 }
 
@@ -395,14 +415,14 @@ mod tests {
         let client = reqwest::Client::new();
         let repo = "bartowski/Qwen2.5-Coder-14B-Instruct-GGUF";
         // Fits: a real plan with a resolve/main URL for the chosen quant.
-        let plan = plan_model_fetch(&client, repo, 32 * (1 << 30), QualityTarget::Balanced)
+        let plan = plan_model_fetch(&client, repo, 32 * (1 << 30), PowerMode::Comfort)
             .await
             .unwrap();
         assert!(plan.url.contains("/resolve/main/"), "downloadable URL");
         assert!(plan.url.ends_with(&plan.filename));
         println!("plan: {} ({} MiB)", plan.url, plan.size_bytes >> 20);
         // Doesn't fit: a 2 GiB machine → budget 0 → fail loud, not a silent tiny pick.
-        let err = plan_model_fetch(&client, repo, 2 * (1 << 30), QualityTarget::Balanced)
+        let err = plan_model_fetch(&client, repo, 2 * (1 << 30), PowerMode::Comfort)
             .await
             .unwrap_err();
         assert!(matches!(err, CatalogError::NoneFit { .. }));
@@ -431,17 +451,17 @@ mod tests {
             GgufCandidate::new("m-f16.gguf", 30_000),
         ];
         assert_eq!(
-            select_for_demand(&files, 40_000, QualityTarget::Balanced).unwrap().filename,
+            select_for_mode(&files, 40_000, PowerMode::Comfort).unwrap().filename,
             "m-Q8_0.gguf"
         );
         assert_eq!(
-            select_for_demand(&files, 40_000, QualityTarget::Maximum).unwrap().filename,
+            select_for_mode(&files, 40_000, PowerMode::Performance).unwrap().filename,
             "m-f16.gguf"
         );
         let total = 64u64 * (1 << 30);
         assert!(
-            budget_for_demand(total, QualityTarget::Maximum)
-                > budget_for_demand(total, QualityTarget::Balanced)
+            budget_for_mode(total, PowerMode::Performance)
+                > budget_for_mode(total, PowerMode::Comfort)
         );
     }
 
@@ -458,8 +478,8 @@ mod tests {
         let client = reqwest::Client::new();
         let repo = "bartowski/Qwen2.5-Coder-14B-Instruct-GGUF";
         println!("this machine: total {} MiB", total >> 20);
-        for target in [QualityTarget::Balanced, QualityTarget::Maximum] {
-            let budget = budget_for_demand(total, target);
+        for target in [PowerMode::Eco, PowerMode::Comfort, PowerMode::Sport, PowerMode::Performance] {
+            let budget = budget_for_mode(total, target);
             match plan_model_fetch(&client, repo, total, target).await {
                 Ok(p) => println!(
                     "  {:?} (budget {} MiB) → {} ({} MiB, {:?})",
@@ -486,7 +506,7 @@ mod tests {
         let client = reqwest::Client::new();
         let fam = ModelFamily::coder();
         println!("this machine: total {} MiB — coder family {:?}", total >> 20, fam.ladder);
-        for target in [QualityTarget::Balanced, QualityTarget::Maximum] {
+        for target in [PowerMode::Eco, PowerMode::Comfort, PowerMode::Sport, PowerMode::Performance] {
             match plan_family_fetch(&client, &fam, total, target).await {
                 Ok(p) => println!("  {:?} → {} ({} MiB, {:?})", target, p.filename, p.size_bytes >> 20, p.quant),
                 Err(e) => println!("  {target:?} → {e}"),

--- a/core/continuum-core/src/provisioning/scaling.rs
+++ b/core/continuum-core/src/provisioning/scaling.rs
@@ -17,7 +17,7 @@
 //! `DefaultScalingPolicy` is the sensible default (mundane stays small, escalate only when
 //! genuinely needed AND the box can spare it).
 
-use super::model_catalog::QualityTarget;
+use super::model_catalog::PowerMode;
 
 /// What a scaling decision sees: how hard the work looks + what the machine can spare
 /// right now. Fed from persona signals + the live resource monitor.
@@ -30,30 +30,35 @@ pub struct DemandContext {
     pub available_bytes: u64,
 }
 
-/// Decides the gear from live conditions. THE definable seam — swap in a user's or an AI
-/// citizen's own policy; the default is conservative-with-escalation.
+/// Decides the drive mode from live conditions. THE definable seam — swap in a user's or
+/// an AI citizen's own policy (the "tuner"); the default auto-shifts like a car.
 pub trait ScalingPolicy: Send + Sync {
-    fn target(&self, ctx: &DemandContext) -> QualityTarget;
+    fn mode(&self, ctx: &DemandContext) -> PowerMode;
 }
 
-/// The default policy: stay `Balanced` for the mundane — never haul in a 32B for a
-/// please/thank-you — and escalate to `Maximum` only when the persona is genuinely
-/// struggling AND the box can currently spare the horsepower. Adapt on the fly; the user
-/// never notices the gear change.
+/// The default policy — the automatic transmission. It shifts by difficulty, but only as
+/// far up as the box can currently afford, and drops to Eco when memory is starved (a
+/// game is open):
+/// - trivial ("thanks!") → Eco — never haul in a big model for pleasantries;
+/// - everyday → Comfort — the economical 32-mpg default;
+/// - hard + room → Sport — climb to a bigger model;
+/// - out-of-its-league + plenty of room → Performance — floor it, the teacher's brain.
+/// Adapt on the fly; the user never notices the shift.
 pub struct DefaultScalingPolicy;
 
 impl ScalingPolicy for DefaultScalingPolicy {
-    fn target(&self, ctx: &DemandContext) -> QualityTarget {
-        /// Above this the persona is clearly out of its league.
-        const HARD: f32 = 0.66;
-        /// Don't floor it on a box that can't currently host the big model — a game is
-        /// open, memory is tight. Balanced still serves; escalation would just thrash.
-        const FLOOR_NEEDS_BYTES: u64 = 20 * (1 << 30);
-
-        if ctx.difficulty >= HARD && ctx.available_bytes >= FLOOR_NEEDS_BYTES {
-            QualityTarget::Maximum
-        } else {
-            QualityTarget::Balanced
+    fn mode(&self, ctx: &DemandContext) -> PowerMode {
+        let avail_gib = ctx.available_bytes / (1 << 30);
+        // Protect a starved box: little free memory → Eco no matter the difficulty. A
+        // game ate the RAM; escalation would only thrash.
+        if avail_gib < 8 {
+            return PowerMode::Eco;
+        }
+        match ctx.difficulty {
+            d if d >= 0.85 && avail_gib >= 20 => PowerMode::Performance,
+            d if d >= 0.66 && avail_gib >= 12 => PowerMode::Sport,
+            d if d < 0.2 => PowerMode::Eco, // trivial pleasantries
+            _ => PowerMode::Comfort,
         }
     }
 }
@@ -62,27 +67,27 @@ impl ScalingPolicy for DefaultScalingPolicy {
 mod tests {
     use super::*;
 
-    fn target(difficulty: f32, available_gib: u64) -> QualityTarget {
-        DefaultScalingPolicy.target(&DemandContext {
+    fn mode(difficulty: f32, available_gib: u64) -> PowerMode {
+        DefaultScalingPolicy.mode(&DemandContext {
             difficulty,
             available_bytes: available_gib * (1 << 30),
         })
     }
 
-    // what this catches: the whole adaptive intent in one policy —
-    //  - mundane stays cheap no matter how much RAM is free (no 32B for "thanks!");
-    //  - a genuinely hard turn escalates WHEN the box can spare it;
-    //  - the SAME hard turn stays Balanced when a game has eaten the memory (adapt to
-    //    live conditions instead of thrashing).
+    // what this catches: the automatic transmission shifts by difficulty but only as far
+    // as the box can afford, and drops to Eco when a game has starved the RAM —
+    //  - trivial "thanks!" → Eco (never a big model for pleasantries);
+    //  - everyday → Comfort (the 32-mpg default);
+    //  - hard + room → Sport; out-of-league + plenty of room → Performance;
+    //  - the SAME hard turn on a game-starved box → Eco, not a thrash.
     #[test]
-    fn mundane_stays_cheap_hard_escalates_only_when_affordable() {
-        // Mundane — Balanced even on a huge idle box.
-        assert_eq!(target(0.1, 128), QualityTarget::Balanced);
-        // Hard + plenty free → floor it.
-        assert_eq!(target(0.9, 60), QualityTarget::Maximum);
-        // Hard but a game ate the RAM (5 GiB free) → stay Balanced, don't thrash.
-        assert_eq!(target(0.9, 5), QualityTarget::Balanced);
-        // Right at the difficulty edge below the threshold → still cheap.
-        assert_eq!(target(0.5, 60), QualityTarget::Balanced);
+    fn auto_shifts_by_difficulty_bounded_by_free_memory() {
+        assert_eq!(mode(0.1, 128), PowerMode::Eco); // trivial
+        assert_eq!(mode(0.5, 60), PowerMode::Comfort); // everyday
+        assert_eq!(mode(0.7, 60), PowerMode::Sport); // hard + room
+        assert_eq!(mode(0.9, 60), PowerMode::Performance); // out of its league + room
+        assert_eq!(mode(0.9, 5), PowerMode::Eco); // game ate the RAM → don't thrash
+        // Hard but only middling free memory → shift up only to Sport, not Performance.
+        assert_eq!(mode(0.9, 14), PowerMode::Sport);
     }
 }


### PR DESCRIPTION
Joel's analogy nailed the shape: his M440i isn't "normal / launch", it's Eco · Comfort · Sport · Performance
plus tuners — and it still gets 32 mpg because Comfort is the economical default. My Balanced/Maximum were the
two ends; the real thing is the spectrum. `QualityTarget{Balanced,Maximum}` → `PowerMode{Eco,Comfort,Sport,
Performance}` (default Comfort):
- `budget_for_mode`: Eco 35% / Comfort 70% / Sport 90% of usable / Performance ~the whole box.
- `mode.allows_float()` (Performance → F16 on the table) + `mode.climbs_ladder()` (Sport/Performance → a bigger
  BRAIN, not just a bigger quant).
- `ScalingPolicy` now yields a `PowerMode`; `DefaultScalingPolicy` is the automatic transmission — shifts by
  difficulty, bounded by free memory, drops to Eco when a game starves the RAM. Tuners (user or AI citizen) swap
  in their own.

Glass-box LIVE on this 64 GB machine, coder family (7B→14B→32B):
  Eco/Comfort → Coder-14B Q8 (15 GB)      Sport/Performance → Coder-32B Q8 (33 GB)
The four modes land on this box's two real tiers (32B F16 ~64 GB overflows → both top modes correctly Q8); on a
128 GB box Performance pulls away to 72B, on an 8 GB box Eco drops below Comfort. The gears exist; the machine's
capacity decides how far apart they sit.

Verified: 22 provisioning tests (mode budgets, float/ladder gating, auto-shift bounded by memory, fail-loud) +
full-crate check green. Follow-up: Eco could downshift deliberately (cap quant tier) even with headroom, like a
car's Eco caps throttle — needs quant-tier ranking.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
