### PR TITLE
feat(serving): throttle cable slice 1 — drive mode reserves serving headroom (resiliency for crowded calls)

### DIFF
--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -297,7 +297,18 @@ impl ServingDaemonModule {
     /// Delegates to the free [`live_host_budget`] so the autonomic tick and the
     /// `serving/pin` fit-gate compute the budget from the ONE source.
     fn host_budget(&self) -> HostBudget {
-        live_host_budget(&self.system, &self.resource_daemon)
+        let raw = live_host_budget(&self.system, &self.resource_daemon);
+        // Reserve headroom per the machine drive mode so the autonomic plan LEAVES room
+        // for the other personas' KV + render + LiveKit — the resiliency fix that keeps a
+        // crowded call from OOM-ing the shared pool. Default Comfort; a follow-up drives
+        // the mode from the ScalingPolicy / live pressure. (The pin fit-gate keeps the RAW
+        // budget via `live_host_budget` directly — "can this model fit at all" is a
+        // different question than "how much should the shared base claim right now".)
+        let mode = crate::provisioning::PowerMode::Comfort;
+        HostBudget {
+            usable_bytes: (raw.usable_bytes as f64 * mode.serving_fraction()) as u64,
+            perf_cores: raw.perf_cores,
+        }
     }
 
     /// The servable candidates RIGHT NOW: the on-disk Ready models, MINUS any an

--- a/core/continuum-core/src/provisioning/model_catalog.rs
+++ b/core/continuum-core/src/provisioning/model_catalog.rs
@@ -215,6 +215,20 @@ impl PowerMode {
     pub fn climbs_ladder(self) -> bool {
         matches!(self, PowerMode::Sport | PowerMode::Performance)
     }
+
+    /// Fraction of currently-FREE memory the shared serving base may claim — the rest
+    /// is left for the other personas' KV cache, the renderer, and LiveKit. Eco leaves
+    /// the most (a crowded call, battery); Performance floors it (a solo demanding
+    /// session). This is the resiliency reserve that keeps 14 personas from OOM-ing the
+    /// pool: serving never grabs everything, so the KV of the rest of the call still fits.
+    pub fn serving_fraction(self) -> f64 {
+        match self {
+            PowerMode::Eco => 0.55,
+            PowerMode::Comfort => 0.80,
+            PowerMode::Sport => 0.92,
+            PowerMode::Performance => 1.0,
+        }
+    }
 }
 
 /// The weights budget for a mode: Eco leaves most of the box free (others, battery,
@@ -463,6 +477,17 @@ mod tests {
             budget_for_mode(total, PowerMode::Performance)
                 > budget_for_mode(total, PowerMode::Comfort)
         );
+    }
+
+    // what this catches: the serving reserve is monotonic (Eco leaves the most free for
+    // the rest of the call, Performance claims all of it) — the knob that keeps a crowded
+    // call from OOM-ing the shared pool.
+    #[test]
+    fn serving_fraction_is_monotonic_and_performance_takes_all() {
+        assert!(PowerMode::Eco.serving_fraction() < PowerMode::Comfort.serving_fraction());
+        assert!(PowerMode::Comfort.serving_fraction() < PowerMode::Sport.serving_fraction());
+        assert!(PowerMode::Sport.serving_fraction() < PowerMode::Performance.serving_fraction());
+        assert_eq!(PowerMode::Performance.serving_fraction(), 1.0);
     }
 
     // what this catches: LIVE misfit-hardware proof — THIS machine's real memory → budget


### PR DESCRIPTION
First cable of the "make what runs be what we chose" wiring, and the resiliency fix today's 8-persona load test
demanded. The load test proved the shared-base architecture (8 personas / 1×14B / 1.37 GB core) but showed KV
cache is the ceiling — serving grabbing 100% of free memory leaves nothing for the other personas' KV + render,
the OOM path at 14 personas.

`PowerMode::serving_fraction()` (Eco 0.55 / Comfort 0.80 / Sport 0.92 / Performance 1.0) is the reserve knob. The
autonomic `host_budget()` now scales its live-available budget by the mode (default Comfort → leave 20% for the
rest of the call). The pin fit-gate keeps the RAW `live_host_budget` — "can this model fit at all" is a different
question than "how much should the shared base claim right now".

Live-verified on the load-bearing serving path: rebooted, serving stays HEALTHY — llama-server --parallel 4 at
30K context, ping ok. The reserve applies without destabilizing serving.

Next cables: drive the mode from the ScalingPolicy / live pressure (not hardcoded Comfort), and feed catalog
quant candidates so serving picks the drive-mode quant, not just whatever's registered.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
