### PR TITLE
feat(serving): throttle cable slice 2 — serving mode auto-downshifts from live memory pressure

### DIFF
--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -300,11 +300,13 @@ impl ServingDaemonModule {
         let raw = live_host_budget(&self.system, &self.resource_daemon);
         // Reserve headroom per the machine drive mode so the autonomic plan LEAVES room
         // for the other personas' KV + render + LiveKit — the resiliency fix that keeps a
-        // crowded call from OOM-ing the shared pool. Default Comfort; a follow-up drives
-        // the mode from the ScalingPolicy / live pressure. (The pin fit-gate keeps the RAW
-        // budget via `live_host_budget` directly — "can this model fit at all" is a
-        // different question than "how much should the shared base claim right now".)
-        let mode = crate::provisioning::PowerMode::Comfort;
+        // crowded call from OOM-ing the shared pool. The mode is driven from LIVE pressure
+        // (Eco when free memory is tight, Comfort at normal headroom) so the base reserves
+        // harder exactly when the pool is strained — auto-downshift. (The pin fit-gate
+        // keeps the RAW budget via `live_host_budget` directly — "can this model fit at
+        // all" is a different question than "how much should the shared base claim now".)
+        let available = self.system.snapshot().memory.available_bytes;
+        let mode = crate::provisioning::serving_mode_for_pressure(available);
         HostBudget {
             usable_bytes: (raw.usable_bytes as f64 * mode.serving_fraction()) as u64,
             perf_cores: raw.perf_cores,

--- a/core/continuum-core/src/provisioning/mod.rs
+++ b/core/continuum-core/src/provisioning/mod.rs
@@ -30,7 +30,7 @@ pub use cache::{reconcile, CacheDecision, CacheEntry, ProvisionPlan};
 pub use downloader::{DownloadError, Downloader};
 pub use fetch::{fetch_and_place, FetchError};
 pub use model_catalog::{
-    budget_for_mode, parse_quant, plan_family_fetch, plan_model_fetch, select_best_fit, select_for_mode,
+    budget_for_mode, parse_quant, plan_family_fetch, plan_model_fetch, select_best_fit, select_for_mode, serving_mode_for_pressure,
     CatalogError, GgufCandidate, ModelFamily, ModelFetchPlan, PowerMode,
 };
 pub use model_source::ModelSource;

--- a/core/continuum-core/src/provisioning/model_catalog.rs
+++ b/core/continuum-core/src/provisioning/model_catalog.rs
@@ -247,6 +247,21 @@ pub fn budget_for_mode(total_bytes: u64, mode: PowerMode) -> u64 {
     }
 }
 
+/// The shared-base serving mode from live memory pressure — the auto-downshift. When
+/// free memory is tight (many personas resident, a game opened), drop to Eco so the base
+/// claims less and the rest of the call's KV + render still fit; at normal headroom stay
+/// Comfort. This is the load test's exact failure mode (KV ceiling under a crowd) handled
+/// automatically: serving reserves harder precisely when the pool is under strain, never
+/// grabbing its way into an OOM. 8 GiB matches the `DefaultScalingPolicy` starved-box line.
+pub fn serving_mode_for_pressure(available_bytes: u64) -> PowerMode {
+    const TIGHT: u64 = 8 * (1 << 30);
+    if available_bytes < TIGHT {
+        PowerMode::Eco
+    } else {
+        PowerMode::Comfort
+    }
+}
+
 /// The model-weight budget (bytes) derivable from a machine's total memory — the pure
 /// policy, so the caller passes `SystemResourceMonitor::memory().total` (the ONE resource
 /// authority — never a parallel probe) and gets a conservative weights budget. Reserves
@@ -488,6 +503,14 @@ mod tests {
         assert!(PowerMode::Comfort.serving_fraction() < PowerMode::Sport.serving_fraction());
         assert!(PowerMode::Sport.serving_fraction() < PowerMode::Performance.serving_fraction());
         assert_eq!(PowerMode::Performance.serving_fraction(), 1.0);
+    }
+
+    // what this catches: the auto-downshift — tight free memory picks Eco (reserve
+    // hardest), roomy picks Comfort. The base reserves harder exactly under strain.
+    #[test]
+    fn serving_downshifts_to_eco_under_pressure() {
+        assert_eq!(serving_mode_for_pressure(4 * (1 << 30)), PowerMode::Eco);
+        assert_eq!(serving_mode_for_pressure(32 * (1 << 30)), PowerMode::Comfort);
     }
 
     // what this catches: LIVE misfit-hardware proof — THIS machine's real memory → budget


### PR DESCRIPTION
Slice 1 reserved serving headroom at a hardcoded Comfort. Slice 2 makes the mode respond to live conditions:
`serving_mode_for_pressure(available_bytes)` returns Eco when free memory is tight (< 8 GiB — a crowd resident,
a game opened) and Comfort at normal headroom. `host_budget()` reads the live available and picks the mode each
plan, so the shared base reserves HARDER exactly when the pool is strained — the load test's KV-ceiling failure
mode handled automatically, not by a fixed constant.

8 GiB matches the DefaultScalingPolicy starved-box line — one pressure threshold, not two.

Live-verified on the load-bearing serving path: rebooted with 29.3 GiB free → correctly picks Comfort → serving
healthy (--parallel 4, 32K context, ping ok). Under a game that ate the RAM it would pick Eco and reserve 45%
instead of 20%, leaving room rather than OOM-ing.

Next: slice 3 feeds catalog quant candidates so serving picks the drive-mode quant (our Q8), then the LoRA layer
on the shared base — the multiplier.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
