### PR TITLE
feat(serving): surface the serving-mode transition — watch the dynamic scaling kick

### DIFF
--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -307,6 +307,18 @@ impl ServingDaemonModule {
         // all" is a different question than "how much should the shared base claim now".)
         let available = self.system.snapshot().memory.available_bytes;
         let mode = crate::provisioning::serving_mode_for_pressure(available);
+        // Observability: emit ONLY on a mode TRANSITION so the dynamic scaling is visible
+        // without spamming the hot plan tick ([[never-blind-feedback-driven-iteration]]).
+        // This is the seam a learned / LLM policy will report through — watch it kick down
+        // under load, and later watch a smarter policy make a better call.
+        {
+            use std::sync::atomic::{AtomicU8, Ordering};
+            static LAST_MODE: AtomicU8 = AtomicU8::new(u8::MAX);
+            let m = mode as u8;
+            if LAST_MODE.swap(m, Ordering::Relaxed) != m {
+                eprintln!("🎛 serving mode → {:?} ({} GiB free)", mode, available / (1 << 30));
+            }
+        }
         HostBudget {
             usable_bytes: (raw.usable_bytes as f64 * mode.serving_fraction()) as u64,
             perf_cores: raw.perf_cores,


### PR DESCRIPTION
The mode pick was silent. Now `host_budget()` emits `🎛 serving mode → {mode} ({N} GiB free)` on a TRANSITION
only (static AtomicU8 last-mode, no hot-tick spam) — so the dynamic scaling is visible: watch it kick down to
Eco under load and, later, watch a smarter (learned / LLM) policy make a better call through the SAME seam. This
is the instrument the realistic multi-persona scenarios need to see the system adapt, not guess.

Live-verified: reboot with 49 GiB free → `🎛 serving mode → Comfort (49 GiB free)` in the server log.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
