### PR TITLE
feat(cognition): is_circling — the stopping condition that ends a pleasantry spiral without blocking real work

### DIFF
--- a/core/continuum-core/src/cognition/self_repeat.rs
+++ b/core/continuum-core/src/cognition/self_repeat.rs
@@ -51,6 +51,37 @@ pub fn is_self_repeat(draft: &str, recent_outputs: &[String], threshold: f64) ->
         .any(|prev| text_similarity(draft, prev) >= threshold)
 }
 
+/// The default circling threshold: average mutual similarity across a persona's recent
+/// output. 0.5 separates a pleasantry loop (near-identical restatements → ~0.7) from real
+/// collaboration (varied, substantive → ~0.1–0.2).
+pub const CIRCLING_THRESHOLD: f64 = 0.5;
+
+/// True when the persona's OWN recent output is CIRCLING — its last `window` messages are
+/// mutually low-novelty, i.e. it keeps saying variations of the same thing. The live
+/// spiral was two personas politely complimenting each other forever; each was circling
+/// on its own trajectory. A circling persona should stop adding to the loop even though
+/// the room keeps pinging it — while genuine collaboration (varied, substantive replies)
+/// has low mutual similarity and sails through untouched, so this never blocks real work.
+///
+/// Trajectory counterpart to [`is_self_repeat`] (single draft): checks the persona's own
+/// recent messages against EACH OTHER, so it fires BEFORE generating another near-dup.
+pub fn is_circling(recent_outputs: &[&str], window: usize, threshold: f64) -> bool {
+    let n = recent_outputs.len();
+    if window < 2 || n < window {
+        return false; // not enough of my own recent turns to judge a trajectory
+    }
+    let recent = &recent_outputs[n - window..];
+    let mut total = 0.0;
+    let mut pairs = 0usize;
+    for i in 0..recent.len() {
+        for j in (i + 1)..recent.len() {
+            total += text_similarity(recent[i], recent[j]);
+            pairs += 1;
+        }
+    }
+    pairs > 0 && total / pairs as f64 >= threshold
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,6 +109,39 @@ mod tests {
 
         // No prior output → never a repeat.
         assert!(!is_self_repeat(repeat, &[], SELF_REPEAT_THRESHOLD));
+    }
+
+    // what this catches: THE stopping condition — a persona whose own recent output is
+    // the pleasantry loop (near-identical restatements, from the real live spiral) reads
+    // as circling and should stop; a persona doing genuine varied collaboration does NOT
+    // read as circling, so real work is never blocked. Directly reproduces + gates the
+    // Asha↔Anwen spiral.
+    #[test]
+    fn circling_flags_the_pleasantry_loop_not_real_collaboration() {
+        // Verbatim-ish from the live spiral — a persona's own successive replies.
+        let looping = [
+            "You're very welcome, Anwen! It's always a pleasure collaborating with someone as enthusiastic and driven as you. Looking forward to many more productive sessions together!",
+            "You're welcome, Anwen! It's always a pleasure to collaborate with someone as talented and enthusiastic as you. Looking forward to many more productive sessions together!",
+            "You're very welcome, Anwen! It's always a pleasure collaborating with someone as passionate and driven as you. Looking forward to many more productive sessions together!",
+        ];
+        assert!(
+            is_circling(&looping, 3, CIRCLING_THRESHOLD),
+            "a persona re-emitting pleasantries must read as circling → stop the spiral"
+        );
+
+        // Genuine collaboration — varied, substantive turns.
+        let working = [
+            "The eviction policy should weigh usage frequency times salience.",
+            "For the dedup, a counting bloom filter is O(1) and keeps memory flat.",
+            "Watch the false-positive rate though — cap the filter at 0.1% or we drop live genomes.",
+        ];
+        assert!(
+            !is_circling(&working, 3, CIRCLING_THRESHOLD),
+            "varied substantive collaboration must NOT read as circling — never block real work"
+        );
+
+        // Too few turns to judge a trajectory → never circling.
+        assert!(!is_circling(&looping[..1], 3, CIRCLING_THRESHOLD));
     }
 
     // what this catches: similarity is bounded, symmetric, and 1.0 for identical text.


### PR DESCRIPTION
Definitive diagnosis (probe-confirmed): the live self-talk spiral was NOT an attribution bug (self-exclusion
works — each persona's own post carries its own peer_id). It was the missing STOPPING CONDITION: two personas
having a real mutual conversation, each correctly replying to the other's genuinely-new message, forever, because
nobody ever decides "this is just pleasantries, I'll stay quiet."

`is_circling(recent_outputs, window, threshold)` is that decision, deterministic and reusing the existing
`text_similarity`: a persona whose own recent output is mutually low-novelty (it keeps restating the same thing)
is circling and should stop adding to the loop — the trajectory counterpart to `is_self_repeat` (single draft).
Crucially it does NOT block real collaboration: varied, substantive turns have low mutual similarity and sail
through, so coder-personas working together are untouched — only the spiral converges.

Verified in the harness against the REAL spiral: the actual Asha↔Anwen pleasantries read as circling; a genuine
technical collaboration (eviction policy → bloom filter → false-positive cap) does not; too-few-turns is never
circling.

Next slice: wire it into the response decision (a circling persona declines) using the existing analysis tools
(rag_inspect / VDD replay) rather than hand-rolled probes — then one live confirm.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
