### PR TITLE
feat(provisioning): provision_model — the execute end of the catalog, proven live

### DIFF
--- a/core/continuum-core/src/provisioning/mod.rs
+++ b/core/continuum-core/src/provisioning/mod.rs
@@ -31,7 +31,7 @@ pub use downloader::{DownloadError, Downloader};
 pub use fetch::{fetch_and_place, FetchError};
 pub use model_catalog::{
     budget_for_mode, parse_quant, plan_family_fetch, plan_model_fetch, select_best_fit, select_for_mode, serving_mode_for_pressure,
-    CatalogError, GgufCandidate, ModelFamily, ModelFetchPlan, PowerMode,
+    CatalogError, GgufCandidate, ModelFamily, ModelFetchPlan, PowerMode, ProvisionModelError, provision_model,
 };
 pub use model_source::ModelSource;
 pub use provisioner::{EvictionReport, Provisioner};

--- a/core/continuum-core/src/provisioning/model_catalog.rs
+++ b/core/continuum-core/src/provisioning/model_catalog.rs
@@ -356,6 +356,43 @@ pub async fn plan_family_fetch(
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ProvisionModelError {
+    #[error(transparent)]
+    Catalog(#[from] CatalogError),
+    #[error(transparent)]
+    Fetch(#[from] super::FetchError),
+}
+
+/// The EXECUTE end of the catalog: plan the hardware-fit download for `repo` at `mode`,
+/// then fetch the chosen quant into `dest_dir`, returning the placed path. Composes
+/// `plan_model_fetch` (which quant fits) + `fetch_and_place` (download → verify → atomic).
+/// This is how a persona that needs a bigger brain (Maximum) actually GETS one — the last
+/// mile between "we own the catalog" and a model on disk ready to serve. Idempotent: a
+/// present file is a Downloader cache-hit, no re-fetch.
+pub async fn provision_model(
+    client: &reqwest::Client,
+    downloader: &super::Downloader,
+    repo: &str,
+    total_memory_bytes: u64,
+    mode: PowerMode,
+    dest_dir: &std::path::Path,
+    progress: &dyn super::downloader::ProgressSink,
+) -> Result<std::path::PathBuf, ProvisionModelError> {
+    let plan = plan_model_fetch(client, repo, total_memory_bytes, mode).await?;
+    let dest = dest_dir.join(&plan.filename);
+    let spec = super::ArtifactSpec {
+        id: normalize_repo(repo),
+        url: plan.url,
+        source_kind: super::SourceKind::Direct,
+        size_bytes: Some(plan.size_bytes),
+        checksum: None, // HF lfs.oid (sha256) is available — verify-after-fetch is a refinement
+        license: None,
+    };
+    super::fetch_and_place(&spec, &dest, downloader, progress).await?;
+    Ok(dest)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -455,6 +492,32 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, CatalogError::NoneFit { .. }));
+    }
+
+    // what this catches: LIVE end-to-end — the EXECUTE path actually downloads a real model
+    // (plan → fetch → placed on disk). A small 0.5B repo so it's fast; proves the same path
+    // that fetches a 32B coder. Run: `-- --ignored provision_model_live`.
+    #[tokio::test]
+    #[ignore]
+    async fn provision_model_live_downloads_a_small_model() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = reqwest::Client::new();
+        let dl = crate::provisioning::Downloader::default();
+        let path = provision_model(
+            &client,
+            &dl,
+            "bartowski/Qwen2.5-0.5B-Instruct-GGUF",
+            64 * (1 << 30), // spacious machine → Comfort picks the largest 0.5B quant
+            PowerMode::Comfort,
+            dir.path(),
+            &crate::provisioning::downloader::NoopProgress,
+        )
+        .await
+        .expect("provision a small model end-to-end");
+        assert!(path.exists(), "the model file landed on disk");
+        let bytes = std::fs::metadata(&path).unwrap().len();
+        println!("✅ provisioned {} ({} MiB)", path.display(), bytes >> 20);
+        assert!(bytes > 50_000_000, "a real multi-hundred-MB GGUF, not an error page");
     }
 
     // what this catches: the budget policy reserves headroom + scales with the machine —


### PR DESCRIPTION
The last mile between "we own the catalog" and a model on disk ready to serve.
`provision_model(client, downloader, repo, total_mem, mode, dest_dir, progress)` composes the two proven halves:
`plan_model_fetch` (which quant fits this machine at this drive mode) → `fetch_and_place` (download → verify →
atomic). Idempotent (a present file is a Downloader cache-hit).

Verified LIVE end-to-end (not composition-by-inspection): downloaded a real Qwen2.5-0.5B GGUF — the catalog
queried the repo, picked Q8_0 (largest quant fitting a 64 GB machine at Comfort), fetched 506 MiB, placed it on
disk, in ~15s. The SAME path fetches a 32B coder — this is the download half of the escalate-and-retest thesis
(can a stronger brain drive a task to done where the 14B looped).

Next for that test: wire drive-mode → serving so a provisioned bigger model actually loads + serves (throttle
cable slice 3). Then hand the team the same task and watch.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
