### PR TITLE
feat(runtime): dispatch_background — fire-and-poll command dispatch with a first-class UUID handle

### DIFF
--- a/core/continuum-core/src/runtime/command_events.rs
+++ b/core/continuum-core/src/runtime/command_events.rs
@@ -77,6 +77,22 @@ pub struct CommandCompletedEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub error: Option<String>,
+
+    /// The dispatch handle (UUID) when this command was fired as a TRACKED background
+    /// dispatch (`CommandExecutor::dispatch_background`). Absent for ordinary synchronous
+    /// commands, which stay thin. Lets a subscriber — e.g. a persona that sent a sentinel
+    /// away — match this completion to the exact call it dispatched, and reuse the same
+    /// handle in a follow-up command (cancel/query).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "string")]
+    pub handle: Option<uuid::Uuid>,
+
+    /// The command's JSON result, included ONLY for tracked background dispatches — so the
+    /// dispatcher gets the outcome from the event itself, no second call. Absent for
+    /// synchronous commands (the caller already holds the return value).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "unknown")]
+    pub result: Option<serde_json::Value>,
 }
 
 /// The canonical bus topic for command-completion events.
@@ -96,6 +112,8 @@ mod tests {
             duration_ms: 42,
             success: true,
             error: None,
+            handle: None,
+            result: None,
         };
         let wire = serde_json::to_value(&original).expect("serialize");
         assert_eq!(wire["commandName"], "chat/send");
@@ -104,6 +122,14 @@ mod tests {
         assert!(
             !wire.as_object().unwrap().contains_key("error"),
             "error elided when None"
+        );
+        assert!(
+            !wire.as_object().unwrap().contains_key("handle"),
+            "handle elided when None — sync commands stay thin"
+        );
+        assert!(
+            !wire.as_object().unwrap().contains_key("result"),
+            "result elided when None"
         );
 
         let parsed: CommandCompletedEvent =
@@ -118,6 +144,8 @@ mod tests {
             duration_ms: 7,
             success: false,
             error: Some("handle not found".to_string()),
+            handle: None,
+            result: None,
         };
         let wire = serde_json::to_value(&original).expect("serialize");
         assert_eq!(wire["success"], false);

--- a/core/continuum-core/src/runtime/command_executor.rs
+++ b/core/continuum-core/src/runtime/command_executor.rs
@@ -252,8 +252,38 @@ impl CommandExecutor {
             command.path(),
             &outcome,
             start.elapsed().as_millis() as u64,
+            None, // synchronous: the caller holds the return value
         );
         outcome
+    }
+
+    /// Fire a command in the BACKGROUND: return a handle (UUID) immediately, run the
+    /// dispatch on a spawned task, and on completion emit `command:completed` carrying the
+    /// handle AND the result. A subscriber — e.g. a persona that sent a sentinel, a
+    /// compile, or a debugger away — matches the completion by handle and folds the outcome
+    /// in when it lands, never blocking the turn. This is the fire-and-poll shape (#86): the
+    /// caller does not await the work. The handle is reusable in a follow-up command
+    /// (cancel/query/attach), which is why it's a plain UUID ([[commands-are-agency-algs-are-pathways]]).
+    pub fn dispatch_background(
+        self: &std::sync::Arc<Self>,
+        command: impl Into<CommandUri>,
+        params: Value,
+        caller: Option<crate::routing::CallerIdentity>,
+    ) -> uuid::Uuid {
+        let handle = uuid::Uuid::new_v4();
+        let command: CommandUri = command.into();
+        let this = std::sync::Arc::clone(self);
+        tokio::spawn(async move {
+            let start = std::time::Instant::now();
+            let outcome = this.dispatch(&command, params, caller.as_ref()).await;
+            this.emit_command_completed(
+                command.path(),
+                &outcome,
+                start.elapsed().as_millis() as u64,
+                Some(handle),
+            );
+        });
+        handle
     }
 
     /// Routing decision on a [`CommandUri`]. Local URIs go through the
@@ -446,15 +476,24 @@ impl CommandExecutor {
         command: &str,
         outcome: &Result<CommandResult, String>,
         duration_ms: u64,
+        handle: Option<uuid::Uuid>,
     ) {
         let Some(bus) = self.bus.as_ref() else {
             return;
         };
+        // The result rides the event ONLY for a tracked background dispatch (handle set),
+        // so the dispatcher learns the outcome from the event itself — no second call. Sync
+        // commands stay thin: the caller already holds the return value.
+        let result = handle
+            .and(outcome.as_ref().ok())
+            .and_then(|r| r.to_json_value().ok());
         let event = CommandCompletedEvent {
             command_name: command.to_string(),
             duration_ms,
             success: outcome.is_ok(),
             error: outcome.as_ref().err().cloned(),
+            handle,
+            result,
         };
         match serde_json::to_value(&event) {
             Ok(payload) => bus.publish_async_only(COMMAND_COMPLETED_TOPIC, payload),
@@ -1109,6 +1148,39 @@ mod tests {
             event.duration_ms < 500,
             "trivial dispatch should be fast: {} ms",
             event.duration_ms
+        );
+        // A synchronous dispatch stays thin: no handle, no result on the event (the caller
+        // already holds the return value).
+        assert_eq!(event.handle, None, "sync command carries no dispatch handle");
+        assert_eq!(event.result, None, "sync command's result is not duplicated onto the event");
+    }
+
+    // what this catches: dispatch_background returns a handle IMMEDIATELY (fire-and-poll)
+    // and its completion event carries BOTH the handle and the result — so a subscriber
+    // (a persona that sent a sentinel away) matches the completion to its dispatch and
+    // folds the outcome in without a second call. This is the producer for the WM async
+    // recency channel.
+    #[tokio::test]
+    async fn dispatch_background_completion_carries_handle_and_result() {
+        let registry = Arc::new(ModuleRegistry::new());
+        registry.register(Arc::new(CannedModule {
+            canned: Ok(serde_json::json!({ "built": true, "warnings": 0 })),
+        }));
+        let bus = Arc::new(MessageBus::new());
+        let mut rx = bus.receiver();
+        let executor = Arc::new(CommandExecutor::new(registry).with_message_bus(bus));
+
+        // Fire in the background — returns a handle immediately, does not await the work.
+        let handle = executor.dispatch_background("canned/ping", serde_json::json!({}), None);
+
+        let event = next_command_completed(&mut rx).await;
+        assert_eq!(event.command_name, "canned/ping");
+        assert!(event.success);
+        assert_eq!(event.handle, Some(handle), "completion carries the dispatch handle");
+        assert_eq!(
+            event.result,
+            Some(serde_json::json!({ "built": true, "warnings": 0 })),
+            "completion carries the result — no second call needed"
         );
     }
 

--- a/protocol/typescript/runtime/CommandCompletedEvent.ts
+++ b/protocol/typescript/runtime/CommandCompletedEvent.ts
@@ -37,4 +37,18 @@ success: boolean,
  * `Err(String)` value that bubbled out of the dispatch chain.
  * Absent on success.
  */
-error?: string, };
+error?: string, 
+/**
+ * The dispatch handle (UUID) when this command was fired as a TRACKED background
+ * dispatch (`CommandExecutor::dispatch_background`). Absent for ordinary synchronous
+ * commands, which stay thin. Lets a subscriber — e.g. a persona that sent a sentinel
+ * away — match this completion to the exact call it dispatched, and reuse the same
+ * handle in a follow-up command (cancel/query).
+ */
+handle?: string, 
+/**
+ * The command's JSON result, included ONLY for tracked background dispatches — so the
+ * dispatcher gets the outcome from the event itself, no second call. Absent for
+ * synchronous commands (the caller already holds the return value).
+ */
+result?: unknown, };


### PR DESCRIPTION
The producer for the async recency channel (#66), built RIGHT at the universal command layer so ANY client
benefits, not just personas. `CommandExecutor::dispatch_background(command, params, caller) -> Uuid` returns a
handle immediately and runs the dispatch on a spawned task; the caller never blocks (the fire-and-poll shape,
#86). On completion, the existing `command:completed` event carries the handle AND the result, so a subscriber
matches the completion to its exact dispatch and folds the outcome in without a second call.

`CommandCompletedEvent` gains `handle: Option<Uuid>` + `result: Option<Value>` — populated ONLY for tracked
background dispatches; synchronous commands stay thin (both None, elided on the wire — the caller already holds
the return value). The handle is a plain UUID precisely so it's reusable in a follow-up command (cancel/query/
attach) — handles + events, the pattern already under every command ([[commands-are-agency-algs-are-pathways]]).

Tested: dispatch_background returns a handle and its completion event carries that handle + the result; a
synchronous dispatch carries neither; the wire round-trip elides both when None. ts-rs binding regenerated
(handle?: string, result?: unknown).

This is the PRODUCER; the persona-side listener (subscribe command:completed → filter to this persona's handles
→ record_dispatch_event into working memory) is the final connecting slice — pure reuse of Connection::subscribe.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
