### PR TITLE
feat(cognition): dispatch_listener — fold background-command completions into the mind by handle

### DIFF
--- a/core/continuum-core/src/cognition/dispatch_listener.rs
+++ b/core/continuum-core/src/cognition/dispatch_listener.rs
@@ -1,0 +1,145 @@
+//! The persona's async-dispatch listener — the consumer that closes the loop between
+//! [`CommandExecutor::dispatch_background`] (#67, the producer) and the WorkingMemory async
+//! recency channel (#66, the sink).
+//!
+//! A persona sends a long-running command away — a sentinel, a compile, a debugger — via
+//! `dispatch_background`, which returns a UUID handle immediately and registers it in the
+//! persona's [`WorkingMemory`] (`record_dispatch_event(..Running)`). This listener, spawned
+//! once per persona, is subscribed to `command:completed` on the core bus; when a completion
+//! carries a handle THIS persona registered, it folds the result in via
+//! `record_dispatch_event(..Done/Failed)` — so the outcome streams back into the mind on the
+//! next heartbeat, never blocking. It is pure REUSE of the pattern already under every
+//! command: emit an event on a handle, subscribe, fold it in.
+//! [[commands-are-agency-algs-are-pathways]] [[act-results-need-a-recency-channel-not-semantic-recall]]
+
+use std::sync::Arc;
+
+use crate::cognition::working_memory::{DispatchStatus, WorkingMemory};
+use crate::runtime::command_events::{CommandCompletedEvent, COMMAND_COMPLETED_TOPIC};
+use crate::runtime::message_bus::MessageBus;
+
+/// Max chars of a dispatched command's result folded back into the mind — a compile log or
+/// a sentinel's report is bounded so one huge result can't dominate the perception. The
+/// full result is recoverable via the command's own handle if the mind needs more.
+const DISPATCH_RESULT_MAX_CHARS: usize = 4_000;
+
+/// Render a command result Value into the compact text the mind reads. A JSON string is
+/// shown bare (no quotes); anything else is compact JSON. Bounded by
+/// `DISPATCH_RESULT_MAX_CHARS`.
+fn summarize_result(value: &serde_json::Value) -> String {
+    let raw = match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    };
+    if raw.chars().count() > DISPATCH_RESULT_MAX_CHARS {
+        raw.chars().take(DISPATCH_RESULT_MAX_CHARS).collect::<String>() + " …[truncated]"
+    } else {
+        raw
+    }
+}
+
+/// Fold ONE completion event into the persona's working memory, IF the persona owns its
+/// handle. Returns `true` when it was ours and recorded. Split out from the loop so it is
+/// deterministically testable without a live bus.
+pub fn fold_completion(wm: &WorkingMemory, ev: CommandCompletedEvent) -> bool {
+    // Only tracked background dispatches carry a handle; sync commands don't.
+    let Some(handle) = ev.handle else {
+        return false;
+    };
+    // Only OUR handles — the WM registered the label at dispatch time. Other clients'
+    // completions on the shared bus are not ours to fold.
+    let Some(label) = wm.dispatched_label(handle) else {
+        return false;
+    };
+    let (content, status) = if ev.success {
+        let body = ev
+            .result
+            .as_ref()
+            .map(summarize_result)
+            .unwrap_or_else(|| "done".to_string());
+        (body, DispatchStatus::Done)
+    } else {
+        let body = ev.error.unwrap_or_else(|| "failed".to_string());
+        (body, DispatchStatus::Failed)
+    };
+    wm.record_dispatch_event(handle, &label, &content, status);
+    true
+}
+
+/// Spawn the listener for one persona. Holds the persona's `WorkingMemory` (Arc) and a bus
+/// receiver; runs until the process exits. A broadcast lag or a non-parsing payload is
+/// skipped, never fatal — the mind keeps perceiving. Idempotent per persona: spawn once at
+/// persona bring-up.
+pub fn spawn(bus: Arc<MessageBus>, working_memory: Arc<WorkingMemory>) {
+    let mut rx = bus.receiver();
+    tokio::spawn(async move {
+        loop {
+            let event = match rx.recv().await {
+                Ok(e) => e,
+                // `Lagged` (slow consumer) or `Closed` — for a broadcast bus, keep going;
+                // a closed bus only happens at shutdown, when this task is torn down anyway.
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+            };
+            if event.name != COMMAND_COMPLETED_TOPIC {
+                continue;
+            }
+            let Ok(ev) = serde_json::from_value::<CommandCompletedEvent>(event.payload) else {
+                continue;
+            };
+            fold_completion(&working_memory, ev);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(handle: Option<uuid::Uuid>, success: bool, result: serde_json::Value) -> CommandCompletedEvent {
+        CommandCompletedEvent {
+            command_name: "cargo/build".to_string(),
+            duration_ms: 10,
+            success,
+            error: if success { None } else { Some("link error".to_string()) },
+            handle,
+            result: if success { Some(result) } else { None },
+        }
+    }
+
+    // what this catches: the listener folds a completion for a handle THIS persona
+    // dispatched into working memory (Running → Done + result), and IGNORES handles it
+    // never dispatched (another client's, or a sync command with no handle) — so a persona
+    // only ever hears back about the sentinels IT sent away.
+    #[test]
+    fn folds_own_handles_ignores_others() {
+        let wm = WorkingMemory::new(8);
+        let mine = uuid::Uuid::from_u128(1);
+        let not_mine = uuid::Uuid::from_u128(2);
+
+        // The persona dispatched `mine` — registered as Running.
+        wm.record_dispatch_event(mine, "cargo build", "dispatched…", DispatchStatus::Running);
+
+        // A completion for a handle we never dispatched → ignored.
+        assert!(!fold_completion(&wm, ev(Some(not_mine), true, serde_json::json!("ok"))));
+        // A synchronous completion (no handle) → ignored.
+        assert!(!fold_completion(&wm, ev(None, true, serde_json::json!("ok"))));
+
+        // Our handle completes → folded in as Done with the result.
+        assert!(fold_completion(
+            &wm,
+            ev(Some(mine), true, serde_json::json!("0 errors, 0 warnings"))
+        ));
+        let snap = wm.dispatched_snapshot();
+        let ours = snap.iter().find(|(h, ..)| *h == mine).unwrap();
+        assert_eq!(ours.3, DispatchStatus::Done);
+        assert_eq!(ours.2, "0 errors, 0 warnings", "the result streamed back to the mind");
+
+        // A failure on our handle folds in as Failed with the error.
+        assert!(fold_completion(&wm, ev(Some(mine), false, serde_json::Value::Null)));
+        let snap = wm.dispatched_snapshot();
+        let ours = snap.iter().find(|(h, ..)| *h == mine).unwrap();
+        assert_eq!(ours.3, DispatchStatus::Failed);
+        assert_eq!(ours.2, "link error");
+    }
+}

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -39,6 +39,7 @@ pub mod deferred_faculty;
 pub mod deliberation_budget;
 pub mod deliberation_parse;
 pub mod deliberation_prompt;
+pub mod dispatch_listener;
 pub mod dream_consolidation;
 pub mod embedding;
 pub mod eval;

--- a/core/continuum-core/src/cognition/working_memory.rs
+++ b/core/continuum-core/src/cognition/working_memory.rs
@@ -237,6 +237,14 @@ impl WorkingMemory {
         }
     }
 
+    /// The label of a dispatched handle THIS persona owns, or `None` if the handle isn't
+    /// ours (never dispatched here, or already evicted). The async-dispatch listener uses
+    /// it to claim ONLY its own completions off the shared `command:completed` bus — other
+    /// clients' handles, and this persona's synchronous commands, are ignored.
+    pub fn dispatched_label(&self, handle: Uuid) -> Option<String> {
+        self.dispatched.lock().get(&handle).map(|a| a.label.clone())
+    }
+
     /// Snapshot of dispatched (background) commands — `(handle, label, latest, status)`,
     /// most-recently-updated last. The faculty renders these so the mind sees what it sent
     /// away and where each stands; the handle is reusable in a follow-up command.


### PR DESCRIPTION
The consumer that closes the loop between dispatch_background (#67, producer) and the WM async recency channel
(#66, sink). `fold_completion(wm, event)` takes a `command:completed` event and, IF the persona owns its handle
(registered in the WM's dispatched map at dispatch time), records the result via `record_dispatch_event` —
Done+result on success, Failed+error otherwise. Other clients' completions and this persona's synchronous
commands (no handle) are ignored, so a persona only ever hears back about the sentinels/compiles/debuggers IT
sent away. `spawn(bus, wm)` runs it on the core bus (`CommandExecutor::message_bus()`), lag/close-safe.

Pure reuse of the pattern already under every command: emit on a handle, subscribe, fold it in. Adds
`WorkingMemory::dispatched_label` (handle → owned label, the ownership filter). Result folded back is bounded
(4k) so one huge log can't dominate perception.

Tested deterministically (no live bus): a persona's own handle folds Running→Done+result and Running→Failed+
error; a handle it never dispatched and a sync (no-handle) completion are both ignored.

All three pieces of the async handle/event channel are now built + green: #66 sink, #67 producer, this consumer.
The final attachment — spawn() in the persona runtime + the executor auto-backgrounding long_running commands —
is the live wiring, which I'll verify against the personas before calling it done.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
