### PR TITLE
feat(persona): wire the async-dispatch channel LIVE — personas send long-running commands away, not block

### DIFF
--- a/core/continuum-core/src/cognition/act_observe.rs
+++ b/core/continuum-core/src/cognition/act_observe.rs
@@ -131,6 +131,18 @@ fn all_calls_already_satisfied(recent: &[String], calls: &[ToolCall]) -> bool {
 /// hands or the executor errors. The admission is best-effort: an un-admitted
 /// observation still flows back via the returned text, so re-perception works
 /// regardless; admission is what makes it durable long-term memory.
+/// Commands that run long enough that BLOCKING the turn on them starves the mind — they
+/// are DISPATCHED in the background (fire-and-poll) and stream their result back into
+/// working memory via the dispatch listener when they finish. Seed set; the durable home is
+/// a per-command `long_running` flag on the command spec (#86). Matched on the slash form
+/// (models may emit the underscore form — normalize before calling).
+fn is_long_running(command: &str) -> bool {
+    matches!(
+        command,
+        "code/cargo/check" | "code/cargo/test" | "cognition/full-evaluate" | "forge/train"
+    )
+}
+
 pub async fn apply_act(
     cycle: &WorkspaceCycle,
     calls: &[ToolCall],
@@ -192,9 +204,48 @@ pub async fn apply_act(
         },
     };
 
+    // Long-running commands are DISPATCHED in the background (fire-and-poll): the turn never
+    // blocks on a compile/train/eval, and the result streams back into working memory via the
+    // dispatch listener when it lands. Requires the core executor (a live persona's hands
+    // expose it; harnesses don't → everything runs synchronously). No long-running calls —
+    // the overwhelmingly common case — means `fg_calls == calls` and this is inert.
+    let mut bg_notes: Vec<String> = Vec::new();
+    let fg_calls: Vec<ToolCall> = match body.executor.command_executor() {
+        Some(exec) => {
+            let mut fg = Vec::with_capacity(calls.len());
+            for call in calls {
+                let cmd = call.name.replace('_', "/");
+                if is_long_running(&cmd) {
+                    let handle = exec.dispatch_background(cmd.clone(), call.input.clone(), None);
+                    body.working_memory.record_dispatch_event(
+                        handle,
+                        &cmd,
+                        "dispatched — running",
+                        crate::cognition::working_memory::DispatchStatus::Running,
+                    );
+                    bg_notes.push(format!(
+                        "I dispatched {cmd} in the background (handle {handle}). I should NOT wait \
+                         on it — the result will appear in my working memory when it completes, and \
+                         I can carry on meanwhile."
+                    ));
+                    crate::probe!(
+                        class = "persona.act.dispatched_background",
+                        persona = %body.persona_name,
+                        command = %cmd,
+                        "long-running command dispatched fire-and-poll; result streams back to working memory"
+                    );
+                } else {
+                    fg.push(call.clone());
+                }
+            }
+            fg
+        }
+        None => calls.to_vec(),
+    };
+
     let outcome = match body
         .executor
-        .execute_native_batch(calls, &ctx, RESULT_FOLD_MAX_CHARS)
+        .execute_native_batch(&fg_calls, &ctx, RESULT_FOLD_MAX_CHARS)
         .await
     {
         Ok(o) => o,
@@ -214,7 +265,7 @@ pub async fn apply_act(
     // this is the persona observing her OWN hands — the engram reads like a memory
     // of acting, not a log line.
     let mut observation = String::new();
-    for (i, call) in calls.iter().enumerate() {
+    for (i, call) in fg_calls.iter().enumerate() {
         let result = outcome.results.get(i);
         let body_text = match result {
             Some(r) => r.content.as_str(),
@@ -228,6 +279,12 @@ pub async fn apply_act(
             intent.trim(),
             body_text.trim(),
         ));
+    }
+    // The background dispatches are part of what she just did — record them as
+    // proprioception so the mind knows it sent them away (and won't re-dispatch or block).
+    for note in &bg_notes {
+        observation.push_str(note);
+        observation.push_str("\n\n");
     }
     let observation = observation.trim().to_string();
 
@@ -538,6 +595,19 @@ fn now_ms() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the long-running set matches the REAL command names (the live bug
+    // was `cargo/test` vs the actual `code/cargo/test`), and ordinary fast commands are NOT
+    // backgrounded — so a `code/read` still returns synchronously in the same turn.
+    #[test]
+    fn long_running_set_matches_real_command_names() {
+        assert!(is_long_running("code/cargo/test"));
+        assert!(is_long_running("code/cargo/check"));
+        assert!(is_long_running("cognition/full-evaluate"));
+        assert!(!is_long_running("code/read"), "a file read stays synchronous");
+        assert!(!is_long_running("chat/send"));
+        assert!(!is_long_running("cargo/test"), "the wrong short name must NOT match");
+    }
     use crate::cognition::tool_executor::{
         NativeBatchOutcome, ParsedToolBatch, ToolError, ToolExecutionContext, ToolExecutor,
         ToolOutcome,

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -234,6 +234,21 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     // turns record nothing). Built HERE (before recall) so recall can share it in and
     // suppress an engram the recency channel already carries — see below.
     let working_memory = Arc::new(WorkingMemory::new(DEFAULT_WORKING_MEMORY_CAPACITY));
+    // Async-dispatch listener (LIVE personas only): fold completions of THIS persona's
+    // background dispatches back into working memory by handle, so a compile/train/sentinel
+    // it sent away streams its result into the mind when it lands ([[persona-async-dispatch-channel]]).
+    // Gated on `cfg.defer_recall` — true ONLY on the supervisor spawn; eval forks + harnesses
+    // set it false — AND a running tokio runtime, so an eval fork or a sync test never spawns
+    // a leaked bus listener. Needs the core executor + its bus, exposed by the persona's hands.
+    if cfg.defer_recall && tokio::runtime::Handle::try_current().is_ok() {
+        if let Some(bus) = tool_executor
+            .as_ref()
+            .and_then(|t| t.command_executor())
+            .and_then(|exec| exec.message_bus())
+        {
+            super::dispatch_listener::spawn(bus, Arc::clone(&working_memory));
+        }
+    }
     let recall = RecallFaculty::new(cfg.persona_id, cfg.admission)
         .with_embedder(embedder)
         // Budget recall by the served model's capability: a tight 4B window

--- a/core/continuum-core/src/cognition/tool_executor/command_executor.rs
+++ b/core/continuum-core/src/cognition/tool_executor/command_executor.rs
@@ -65,11 +65,17 @@ pub struct CommandToolExecutor {
     /// persona's identity; cheap to clone (shares one `Arc<transport>`), so each
     /// concurrent tool call in a batch gets its own scoped view with no contention.
     conn: Connection<InProcessTransport>,
+    /// The SAME core `CommandExecutor` the connection dispatches through, held directly so
+    /// the persona's hands can (a) fire a long-running command via `dispatch_background`
+    /// (fire-and-poll, not block the turn) and (b) reach `message_bus()` for the
+    /// async-dispatch listener. `None` when built from a bare `Connection` (harnesses,
+    /// mocks) — those run every command synchronously. [[persona-async-dispatch-channel]]
+    core: Option<Arc<CommandExecutor>>,
 }
 
 impl CommandToolExecutor {
     pub fn new(conn: Connection<InProcessTransport>) -> Self {
-        Self { conn }
+        Self { conn, core: None }
     }
 
     /// Build a persona's hands over the uniform client: a
@@ -91,11 +97,20 @@ impl CommandToolExecutor {
         // airc inbound pump stamps `Airc`); only this local spawn path mints it.
         // `persona` is the persona's bare-Uuid id; the gate identity is the canonical
         // PeerId (== peer_id by invariant). Convert at this spawn boundary.
+        let core = executor.clone();
         let transport = InProcessTransport::new(
             executor,
             Some(CallerIdentity::local_persona(crate::identity::PeerId::from_uuid(persona))),
         );
-        Self::new(Connection::new(transport))
+        Self {
+            conn: Connection::new(transport),
+            core: Some(core),
+        }
+    }
+
+    /// The core executor behind these hands, if any (a live persona's; not a harness's).
+    pub fn core_executor(&self) -> Option<Arc<CommandExecutor>> {
+        self.core.clone()
     }
 }
 
@@ -267,6 +282,10 @@ fn persona_tool_error(attempted: &str, raw: String) -> String {
 
 #[async_trait]
 impl ToolExecutor for CommandToolExecutor {
+    fn command_executor(&self) -> Option<Arc<CommandExecutor>> {
+        self.core_executor()
+    }
+
     async fn execute_native_batch(
         &self,
         calls: &[NativeToolCall],
@@ -398,6 +417,25 @@ mod tests {
     use serde_json::json;
     use std::any::Any;
     use std::sync::Arc;
+
+    // what this catches: a live persona's hands (built via for_persona) EXPOSE the core
+    // executor, so apply_act can fire a long-running command in the background; a bare
+    // Connection-built executor (harness) does NOT — it runs every command synchronously.
+    // This is the reachability seam that lets a persona send a sentinel/compile away.
+    #[test]
+    fn for_persona_hands_expose_core_executor_for_dispatch() {
+        let exec = Arc::new(CommandExecutor::new(Arc::new(ModuleRegistry::new())));
+        let hands = CommandToolExecutor::for_persona(exec, uuid::Uuid::new_v4());
+        assert!(
+            hands.command_executor().is_some(),
+            "live persona hands expose the core executor for fire-and-poll dispatch"
+        );
+        let bare = CommandToolExecutor::new(hands.conn.clone());
+        assert!(
+            bare.command_executor().is_none(),
+            "harness hands (bare Connection) run every command synchronously"
+        );
+    }
 
     /// Minimal module that echoes its params back under `test/echo`.
     struct EchoModule;

--- a/core/continuum-core/src/cognition/tool_executor/mod.rs
+++ b/core/continuum-core/src/cognition/tool_executor/mod.rs
@@ -77,6 +77,17 @@ pub trait ToolExecutor: Send + Sync {
         max_result_chars: usize,
     ) -> Result<NativeBatchOutcome, ToolError>;
 
+    /// The core `CommandExecutor` behind these hands, if any. A live persona's executor
+    /// returns `Some` — enabling fire-and-poll `dispatch_background` for long-running
+    /// commands and `message_bus()` for the async-dispatch listener that folds their
+    /// results back into working memory ([[persona-async-dispatch-channel]]). Harnesses and
+    /// mocks return the default `None` and simply run every command synchronously.
+    fn command_executor(
+        &self,
+    ) -> Option<std::sync::Arc<crate::runtime::command_executor::CommandExecutor>> {
+        None
+    }
+
     /// Parse tool calls from a raw AI response string (XML-fallback path
     /// for models that don't emit native tool_use blocks). Returns
     /// extracted calls + cleaned-of-tool-blocks text + parse-time


### PR DESCRIPTION
The final attachment of the async handle/event channel (#66 sink / #67 producer / #68 consumer). A live persona
that invokes a long-running command — `code/cargo/test`, `code/cargo/check`, `cognition/full-evaluate`,
`forge/train` — now dispatches it in the BACKGROUND (fire-and-poll) and its result streams back into working
memory by handle when it lands, instead of blocking the turn.

The clean thread (the core executor was walled off from cognition — global accessor removed, hidden behind the
client Connection): `CommandToolExecutor` now stores its core `Arc<CommandExecutor>` (it already had it at
`for_persona`) and exposes it via a new `ToolExecutor::command_executor()` (default None — harnesses/mocks run
sync). `apply_act` partitions long-running calls off to `dispatch_background` + `record_dispatch_event(..Running)`
and records a "dispatched — carry on" proprioception note; the rest run synchronously as before (no long-running
call → inert, zero behavior change). The per-persona listener spawns in `build_workspace_cycle`, gated on
`cfg.defer_recall` (live only — never the eval fork) + a running tokio runtime, folding completions back by handle.

Verified: full crate compiles; act_observe (10) + command_executor (12) + dispatch_listener + working_memory all
green; two new seam tests — a live persona's hands expose the core executor (harness hands don't), and the
long-running set matches the REAL command names (caught the live bug: `code/cargo/test`, not `cargo/test`). Live:
core boots clean, a normal turn still works (Asha answered "Four") — the apply_act change is safe.

NOT yet observed end-to-end live: a persona actually invoking a long-running command. Asha narrated "Running
cargo test…" and declined rather than emitting the tool call — the 14B competence gap (+ my wrong command names,
now fixed), not a wiring fault. The pipe is proven at every seam and safe live; a correct invocation now
backgrounds. Full end-to-end demo is gated on the model reliably emitting a long-running tool call (escalation/
training). Caveat: `dispatch_background` caller identity is `None` (local trust) for now — thread the persona
CallerIdentity as a follow-up. [[persona-async-dispatch-channel]]

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
