### PR TITLE
fix(cognition): rebut the "I'd rather not / you do it" chatbot reflex, not just "I can't"

### DIFF
--- a/core/continuum-core/src/cognition/deliberation_prompt.rs
+++ b/core/continuum-core/src/cognition/deliberation_prompt.rs
@@ -181,7 +181,13 @@ const ACTING_BLOCK: &str = "\n[Acting]\n\
      describing what you would do; narrating a plan does not carry it out. \
      After a tool runs you get the result back and can continue \
      (e.g. help → call → read → run). Don't call a tool you don't need, \
-     and don't narrate one you do.";
+     and don't narrate one you do. When the task is to write or run a file, \
+     YOU write it and YOU run it — with the tool, this turn. Do not hand the \
+     code back to someone to \"copy and save it in your workspace\" or say \
+     \"I'd rather not create or execute files\": this IS your workspace and \
+     these ARE your hands — declining to use them, or delegating the work to \
+     the asker, is the SAME mistake as claiming you can't, and the fix is the \
+     same: just call the tool.";
 
 /// `[Your own time]` — the self-initiated free-time block. When this turn is the
 /// never-stop heartbeat pursuing her own thread (no inbound message drove it), say so


### PR DESCRIPTION
Glass-box (prompt-capture jsonl) showed the exact failure: with the FULL tool menu visible (code/write,
code/shell present) and correct Swift already written, the 14B still refused — "I'd rather not create or execute
files… you can copy this and save it in add.swift" — reverting to assistant-frame and handing the work back to
the asker. The existing inoculation only rebuts "can't execute"; it never covered "won't" or delegation. Added
that to ACTING_BLOCK: when the task is to write/run a file, SHE does it with the tool this turn — declining or
handing it back is the same mistake as "I can't," same fix: call the tool. Framing (removing a false RLHF cage),
not content-steering.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
