### PR TITLE
fix(code): un-ban real languages in code/write — .swift and friends were blocked

### DIFF
--- a/core/continuum-core/src/code/types.rs
+++ b/core/continuum-core/src/code/types.rs
@@ -343,8 +343,27 @@ pub const GLOB_MAX_MATCHES: usize = 5_000;
 
 /// Allowed file extensions for write operations.
 pub const ALLOWED_EXTENSIONS: &[&str] = &[
-    "ts", "tsx", "js", "jsx", "json", "md", "css", "html", "rs", "toml", "yaml", "yml", "txt",
-    "sh", "py",
+    // web / TS-JS
+    "ts", "tsx", "js", "jsx", "mjs", "cjs", "json", "jsonc", "css", "scss", "sass", "less",
+    "html", "htm", "vue", "svelte", "astro", "graphql", "gql", "wasm",
+    // systems / native
+    "rs", "c", "h", "cpp", "cc", "cxx", "hpp", "hh", "go", "zig",
+    // Apple / mobile — the reason this list was too small (iPhone apps need these)
+    "swift", "m", "mm", "kt", "kts", "java", "gradle", "xcconfig", "plist", "entitlements",
+    "storyboard", "xib", "pbxproj", "dart", "podspec",
+    // scripting / other langs
+    "py", "pyi", "rb", "php", "pl", "lua", "r", "jl", "ex", "exs", "erl", "scala", "clj",
+    "hs", "ml", "fs", "cs", "vb", "groovy", "nim", "cr",
+    // shell / build
+    "sh", "bash", "zsh", "fish", "bat", "ps1", "mk", "cmake", "make", "bazel", "bzl", "just",
+    "dockerfile", "containerfile",
+    // config / data / markup
+    "toml", "yaml", "yml", "ini", "cfg", "conf", "properties", "env", "xml", "csv", "tsv",
+    "proto", "sql", "prisma", "tf", "hcl", "lock",
+    // docs / text
+    "md", "mdx", "markdown", "txt", "rst", "adoc", "text", "log",
+    // dotfiles / no-extension configs commonly needed
+    "gitignore", "gitattributes", "editorconfig", "npmrc", "nvmrc", "prettierrc", "eslintrc",
 ];
 
 /// Maximum file size for write operations (1MB).


### PR DESCRIPTION
Glass-box of a live coding turn showed the true blocker (a TOOL, not the model): the persona emitted a correct
`code/write{file_path:"add.swift", content: <correct Swift>}` and got back
`code/write: [internal] Security: Extension '.swift' not allowed for 'add.swift'`. The ALLOWED_EXTENSIONS
allowlist was web-dev-biased (ts/js/rs/py/…) with NO swift, C/C++, Obj-C, Go, Java, Kotlin, etc. — you cannot
build an iPhone app when the file tool bans .swift.

Expanded the allowlist to cover real source + config across systems/native, Apple/mobile (swift, m, mm, kt,
plist, xcconfig, pbxproj, storyboard…), scripting, shell/build, config/data/markup, and common dotfiles.
Binaries stay excluded by omission (the allowlist is source-code-shaped, not executables). This is the concrete
"shitty tools" fix — the RAG faithfully carried the error back (the full-result fix works); the tool just
refused a language a coder obviously needs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
