### PR TITLE
fix(serving): realistic KV/token estimate — unblock the 32B from the fit-gate; register Coder-32B

### DIFF
--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -435,6 +435,30 @@ pub fn models() -> Vec<Model> {
             stop_sequences: &["<|im_end|>", "<|endoftext|>"],
             ..ModelSpec::default()
         }),
+        // Qwen2.5-Coder-32B — the real-work coder. The 14B fails non-trivial tasks (a
+        // correct LRU cache) even with agentic recovery; the 32B is the model real coding
+        // needs on this 64 GB box. ~20 GB at Q4_K_M, so plan_serving picks it as
+        // most-capable-that-fits once pulled. Same serving lane + chat template as the 14B.
+        model(ModelSpec {
+            id: "continuum-ai/qwen2.5-coder-32b-instruct-GGUF",
+            name: "Qwen2.5-Coder-32B-Instruct",
+            provider: "llama-server",
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 8192,
+            tokens_per_second: 8.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            gguf_hint: Some("huggingface.co/bartowski/Qwen2.5-Coder-32B-Instruct-GGUF"),
+            chat_template: Some(QWEN35_CHAT_TEMPLATE),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            stop_sequences: &["<|im_end|>", "<|endoftext|>"],
+            ..ModelSpec::default()
+        }),
         model(ModelSpec {
             id: "qwen2-vl-7b-instruct",
             name: "Qwen2-VL-7B-Instruct (in-process)",

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -728,7 +728,13 @@ fn footprint_from_parts(
     // planner multiplies this by the window IT derives from the host budget —
     // we do NOT pre-collapse it against an assumed serving window here (no
     // PLANNED_CTX clamp; the served window is the planner's call, task #50).
-    let kv_per_token = (weights_bytes / 20_000).max(20_000);
+    // Realistic per-token KV. These Qwen coders use grouped-query attention (few KV
+    // heads), so KV is SMALL: ~200 KB/token for the 14B, ~260 KB/token for the 32B. The
+    // old `weights/20_000` gave ~1 MB/token for the 32B — 4× too high — which made a 32B
+    // that comfortably fits a 64 GB box read as ~32 GB of KV at 32k ctx and get falsely
+    // rejected by the fit-gate, so the planner kept a weaker model. `weights/80_000`
+    // (~110 KB for 14B, ~250 KB for 32B) tracks real Q4 GQA KV; still coarse, still floored.
+    let kv_per_token = (weights_bytes / 80_000).max(20_000);
 
     // Coarse capability rank: GB of weights (bigger ≈ more capable within a
     // family), +bonus for tool/code capability. Saturates into u8.


### PR DESCRIPTION
The fit-gate used kv_per_token = weights/20_000 ≈ 1 MB/token for a 20 GB model. At 32k ctx that read as
~32 GB of KV, so a Qwen2.5-Coder-32B that comfortably fits a 64 GB box was falsely rejected and plan_serving
kept the weaker 14B. These Qwen coders use grouped-query attention (few KV heads) → real KV is ~250 KB/token;
weights/80_000 tracks it. After the fix plan_serving correctly picks the 32B as most-capable-that-fits.

Also registers the Coder-32B catalog row (the 14B fails non-trivial real tasks; the 32B is the coder real work
needs on this box).

Honest note on what this did NOT fix: with the 32B serving, the real LRU task still failed — but on the model's
refusal/narration reflex, not capability. The glass-box shows the model either answering the directed exam with a
bare "PASS" (taking the participation-decline hatch) or NARRATING the tool call as prose (```rust``` block) instead
of emitting a structured code/write. That reliability reflex — decline-or-describe instead of act — is the real
wall, and it's a training/framing problem, not model size. Filed as the next target.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
