### PR TITLE
feat(eval): runtime retry-budget param → one-command unsloth-vs-ours A/B; serve the model that works

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -430,6 +430,14 @@ pub struct CognitionEvalParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional, type = "number")]
     pub max_acts: Option<u32>,
+    /// Agentic-recovery budget: how many times a FAILED test-graded task is handed its
+    /// compiler/test output to fix before it scores a miss. Default [`MAX_FAIL_RETRIES`].
+    /// Set `0` for the ONE-SHOT baseline (what plain inference / unsloth gets on the same
+    /// weights) — so a `0` vs `N` A/B on the identical model+benchmark measures exactly the
+    /// edge our agentic loop adds, repeatably, from one param.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
+    pub max_retries: Option<u32>,
     /// Free-text label for THIS run, written to the progress ledger so a trend
     /// line is readable: "baseline", "taught show-output", "genome v2", etc.
     /// The ledger is how you "mark improvement as you go" — every eval leaves a
@@ -682,6 +690,7 @@ impl ActionCommand for CognitionEval {
         };
 
         let max_acts = p.max_acts.unwrap_or(DEFAULT_MAX_ACTS) as usize;
+        let max_retries = p.max_retries.unwrap_or(MAX_FAIL_RETRIES);
         let total = tasks.len() as u32;
         let rate = |score: u32| if total > 0 { score as f64 / total as f64 } else { 0.0 };
 
@@ -704,7 +713,7 @@ impl ActionCommand for CognitionEval {
         // separate, deliberate decision, never a side effect of measuring it.
         if let Some(gene) = &p.gene {
             cycle.page_out();
-            let (base_score, _) = run_pass(&cycle, &isolation, &tasks, room, max_acts).await;
+            let (base_score, _) = run_pass(&cycle, &isolation, &tasks, room, max_acts, max_retries).await;
 
             // Both arms start each task from the pre-eval memory frame — `run_pass`
             // rewinds the admission frame before EVERY task (per-task isolation), so
@@ -717,7 +726,7 @@ impl ActionCommand for CognitionEval {
                 scale: gene.scale.unwrap_or(1.0),
             }]);
             let (gene_score, gene_results) =
-                run_pass(&cycle, &isolation, &tasks, room, max_acts).await;
+                run_pass(&cycle, &isolation, &tasks, room, max_acts, max_retries).await;
             cycle.page_out();
 
             // Guard drops here: her memory frame + real persistence sink restored.
@@ -784,7 +793,7 @@ impl ActionCommand for CognitionEval {
         // Single pass: measure whatever genome is currently paged in (base by
         // default) — the plain coder number, no A/B. Still isolated, so a plain
         // baseline run is reproducible and leaves her memory untouched.
-        let (score, results) = run_pass(&cycle, &isolation, &tasks, room, max_acts).await;
+        let (score, results) = run_pass(&cycle, &isolation, &tasks, room, max_acts, max_retries).await;
         drop(isolation);
         let verify = self_verify_rate(&results);
         let agg = speed_latency_aggregates(&results);
@@ -998,6 +1007,7 @@ async fn run_pass(
     tasks: &[EvalTask],
     room: Uuid,
     max_acts: usize,
+    max_retries: u32,
 ) -> (u32, Vec<EvalTaskResult>) {
     let mut pass = 0u32;
     let mut results = Vec::with_capacity(tasks.len());
@@ -1111,7 +1121,7 @@ async fn run_pass(
         let mut total_acts = settled.acts as u32;
         let mut attempt = 1u32;
         while !ok
-            && attempt <= MAX_FAIL_RETRIES
+            && attempt <= max_retries
             && t.test.is_some()
             && settled.inference_error.is_none()
         {

--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -435,30 +435,28 @@ pub fn models() -> Vec<Model> {
             stop_sequences: &["<|im_end|>", "<|endoftext|>"],
             ..ModelSpec::default()
         }),
-        // Qwen2.5-Coder-32B — the real-work coder. The 14B fails non-trivial tasks (a
-        // correct LRU cache) even with agentic recovery; the 32B is the model real coding
-        // needs on this 64 GB box. ~20 GB at Q4_K_M, so plan_serving picks it as
-        // most-capable-that-fits once pulled. Same serving lane + chat template as the 14B.
-        model(ModelSpec {
-            id: "continuum-ai/qwen2.5-coder-32b-instruct-GGUF",
-            name: "Qwen2.5-Coder-32B-Instruct",
-            provider: "llama-server",
-            arch: Arch::Qwen2,
-            context_window: 32_768,
-            max_output_tokens: 8192,
-            tokens_per_second: 8.0,
-            capabilities: &[
-                Capability::TextGeneration,
-                Capability::Chat,
-                Capability::ToolUse,
-                Capability::Streaming,
-            ],
-            gguf_hint: Some("huggingface.co/bartowski/Qwen2.5-Coder-32B-Instruct-GGUF"),
-            chat_template: Some(QWEN35_CHAT_TEMPLATE),
-            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
-            stop_sequences: &["<|im_end|>", "<|endoftext|>"],
-            ..ModelSpec::default()
-        }),
+        // Qwen2.5-Coder-32B — downloaded (~20 GB Q4_K_M) and the KV fit-gate fix lets it
+        // serve, but DELIBERATELY NOT registered yet: measured live it DECLINES a directed
+        // coding task (emits a bare "PASS") instead of acting, so serving it as the live
+        // coder is strictly WORSE than the 14B, which reliably uses its tools. Kept verbatim
+        // so re-enabling is a one-line uncomment ONCE its act-reflex is trained (the genome
+        // loop over the DoD + recovery harness). Until then plan_serving keeps the 14B — the
+        // model that actually works.
+        // model(ModelSpec {
+        //     id: "continuum-ai/qwen2.5-coder-32b-instruct-GGUF",
+        //     name: "Qwen2.5-Coder-32B-Instruct",
+        //     provider: "llama-server",
+        //     arch: Arch::Qwen2,
+        //     context_window: 32_768,
+        //     max_output_tokens: 8192,
+        //     tokens_per_second: 8.0,
+        //     capabilities: &[Capability::TextGeneration, Capability::Chat, Capability::ToolUse, Capability::Streaming],
+        //     gguf_hint: Some("huggingface.co/bartowski/Qwen2.5-Coder-32B-Instruct-GGUF"),
+        //     chat_template: Some(QWEN35_CHAT_TEMPLATE),
+        //     multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+        //     stop_sequences: &["<|im_end|>", "<|endoftext|>"],
+        //     ..ModelSpec::default()
+        // }),
         model(ModelSpec {
             id: "qwen2-vl-7b-instruct",
             name: "Qwen2-VL-7B-Instruct (in-process)",

--- a/core/continuum-core/src/modules/training_completion_sentinel.rs
+++ b/core/continuum-core/src/modules/training_completion_sentinel.rs
@@ -181,6 +181,7 @@ impl TrainingCompletionSentinel {
                 // Some at the top of this fn.
                 eval_set: Some(eval_set),
                 max_acts: None,
+                max_retries: None,
                 note: Some(format!(
                     "L3 auto-eval (gene={}, base={}, provider={})",
                     job.trait_kind, job.base_model, job.handle.provider_id


### PR DESCRIPTION
Makes the agentic-recovery budget a runtime eval param (max_retries), defaulting to MAX_FAIL_RETRIES.
Set 0 for the ONE-SHOT baseline — exactly what plain inference (unsloth) gets on the same weights — so a
0-vs-N run on the identical model+benchmark measures the edge our loop adds, repeatably, from one param.
This is the scoreboard for "measurably better than unsloth."

Also disables the Coder-32B catalog row (kept verbatim, commented): measured live it DECLINES a directed
coding task (bare "PASS") instead of acting, so serving it is strictly worse than the 14B, which reliably
uses its tools. plan_serving keeps the 14B until the 32B's act-reflex is trained. The KV fit-gate fix stays.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
