### PR TITLE
fix(eval): recovery now actually fires on real (dod_shell) tasks + writes the fix, not narrates it

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1122,15 +1122,25 @@ async fn run_pass(
         let mut attempt = 1u32;
         while !ok
             && attempt <= max_retries
-            && t.test.is_some()
+            && (t.test.is_some() || t.dod_shell.is_some())
             && settled.inference_error.is_none()
         {
+            // For a dod_shell task the grader checks the FILE she wrote, so the fix must be
+            // SAVED with the tool, not narrated as a code fence (glass-box: on recovery she
+            // produced the correct fix — added the missing derive — but as a bare ```rust```
+            // block, so it never landed). Direct her to re-write the file with the tool.
+            let fix_directive = if t.dod_shell.is_some() {
+                "Fix the code so every check passes, then use your code/write tool AGAIN to \
+                 save the COMPLETE corrected file to the SAME path as before (do not just \
+                 paste the code — it must be written to the file to be re-tested)."
+            } else {
+                "Fix the code so every test passes, then reply with the COMPLETE corrected \
+                 solution (not a diff)."
+            };
             let fix_prompt = format!(
-                "Your previous solution did NOT pass the tests.\n\n\
-                 TASK:\n{}\n\nYOUR SOLUTION:\n{}\n\nTEST / COMPILER OUTPUT:\n{}\n\n\
-                 Fix the code so every test passes, then reply with the COMPLETE corrected \
-                 solution (not a diff).",
-                t.prompt, answer, grade,
+                "Your previous solution did NOT pass.\n\n\
+                 TASK:\n{}\n\nYOUR SOLUTION:\n{}\n\nTEST / COMPILER OUTPUT:\n{}\n\n{}",
+                t.prompt, answer, grade, fix_directive,
             );
             let delivery = crate::persona::rag_budget::RagDelivery {
                 source_id: "airc".to_string(),


### PR DESCRIPTION
Glass-box on a real mini-project (a recursive-descent expression evaluator) exposed two bugs that made agentic
recovery a NO-OP on real tasks:

1. GUARD BUG: the retry loop was gated on `t.test.is_some()`, but real-task DoD grading uses `dod_shell`
   (test: None). So recovery NEVER entered for dod_shell tasks — the compiler error was fed into a void
   (confirmed: 0/14 recovery turns had the fix_prompt in the actual LLM prompt). The model re-emitted
   byte-identical broken code every "retry". Fix: gate on `(t.test.is_some() || t.dod_shell.is_some())`.
   After the fix, glass-box confirms the compiler error reaches her AND she produces the correct fix
   (added the missing `#[derive(Debug, PartialEq)]` the errors demanded).

2. NARRATE-THE-FIX BUG: on recovery she output the corrected code as a bare ```rust``` fence, not a code/write
   call, so a dod_shell grade (which checks the FILE) never saw it. Fix: for dod_shell tasks the fix directive
   now tells her to use code/write AGAIN to save the corrected file to the same path. After the fix she writes
   each iteration and converges (4 compile errors → 1).

Remaining (honest): the 14B still THRASHES on multi-error convergence — fixes one error, reintroduces another —
and 4 retries wasn't enough room to land all fixes simultaneously. That's the model/budget frontier (more retries,
a stronger model, or training the act-reflex), not a wiring bug. The recovery MACHINE now works end to end on real
tasks; before this it was dark.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
