### PR TITLE
feat/tool feedback melds into cognition

### DIFF
--- a/core/continuum-core/src/cognition/tool_executor/command_executor.rs
+++ b/core/continuum-core/src/cognition/tool_executor/command_executor.rs
@@ -236,39 +236,58 @@ fn persona_tool_error(attempted: &str, raw: String) -> String {
     // emitted the underscore form, so normalize before matching/suggesting.
     let normalized = attempted.replace('_', "/");
 
-    // Unknown command: the substrate's dev-facing message is useless to her.
-    if raw.contains("no Rust module handles command") || raw.starts_with("no command") {
-        // A command whose full name ends with `/<attempted>` is almost certainly
-        // what she meant — she dropped the leading category (`cargo/check` →
-        // `code/cargo/check`). Suggest only AiSafe names (the surface she can
-        // call), deduped and ordered for a stable, leak-free hint.
-        let suffix = format!("/{normalized}");
-        let mut suggestions: Vec<&'static str> = command_registry()
+    // The exact how-to-call manual for a command SHE can run, rendered inline so the
+    // fix rides back in THIS observation — she retries next turn with no discovery
+    // detour (Joel: "feedback truly links back into cognition effectively"). Single
+    // source of truth: the same renderer `commands/help` uses.
+    let manual_for = |name: &str| -> Option<String> {
+        command_registry()
             .into_iter()
-            .filter(|d| d.access_level == AccessLevel::AiSafe && d.name.ends_with(&suffix))
+            .find(|d| d.name == name && d.access_level == AccessLevel::AiSafe)
+            .map(|d| crate::commands::help::render_ai_help(d.name, d.description, &d.params_schema))
+    };
+
+    // Unknown command: the substrate's dev-facing message is useless to her. Suggest
+    // the nearest AiSafe names (category + shared-segment match — catches both a
+    // dropped category `cargo/check`→`code/cargo/check` AND a wrong sibling
+    // `commands/describe`→`commands/help`), and INLINE the top match's manual so the
+    // right call is right there.
+    if raw.contains("no Rust module handles command") || raw.starts_with("no command") {
+        let ai_names: Vec<&'static str> = command_registry()
+            .into_iter()
+            .filter(|d| d.access_level == AccessLevel::AiSafe)
             .map(|d| d.name)
             .collect();
-        suggestions.sort_unstable();
-        suggestions.dedup();
-        let did_you_mean = match suggestions.as_slice() {
-            [] => String::new(),
-            [one] => format!(" Did you mean `{one}`?"),
-            many => format!(
-                " Did you mean one of: {}?",
-                many.iter().map(|n| format!("`{n}`")).collect::<Vec<_>>().join(", ")
-            ),
-        };
+        let suggestions = crate::commands::help::did_you_mean(&normalized, &ai_names);
+        if let ([best, ..], Some(manual)) =
+            (suggestions.as_slice(), suggestions.first().and_then(|b| manual_for(b)))
+        {
+            let list = suggestions
+                .iter()
+                .map(|n| format!("`{n}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let _ = best;
+            return format!(
+                "`{normalized}` is not a tool you can call. Closest: {list}.\n\n\
+                 Here is how to call the first one — retry with this shape:\n{manual}"
+            );
+        }
         return format!(
-            "`{normalized}` is not a tool you can call.{did_you_mean} \
-             Call `commands/list` (optionally with a `filter` keyword) to find the \
-             right tool, then `commands/help` with its exact name to see the \
-             arguments and an example before you retry."
+            "`{normalized}` is not a tool you can call. Call `commands/help` with no \
+             arguments for the full list of what you CAN call, then retry."
         );
     }
 
     // Bad/missing arguments: the `[invalid]` prefix means serde already named the
-    // offending field — reinforce the manual so she gets the exact shape + example.
+    // offending field — INLINE the exact shape + example so she fixes it in place
+    // instead of spending a turn on `commands/help`.
     if raw.contains("[invalid]") {
+        if let Some(manual) = manual_for(&normalized) {
+            return format!(
+                "{raw}\n\nHere is the correct call — fix your arguments and retry:\n{manual}"
+            );
+        }
         return format!(
             "{raw}\n→ Call `commands/help` with name \"{normalized}\" to see the \
              exact argument names, types, and a fill-in-the-blanks example, then retry."

--- a/core/continuum-core/src/commands/help.rs
+++ b/core/continuum-core/src/commands/help.rs
@@ -27,8 +27,39 @@ use crate::sdk_codegen::{command_registry, AccessLevel, ActionCommand, CommandEr
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS, JsonSchema)]
 pub struct CommandsHelpParams {
-    /// The command to explain, e.g. `code/read`.
-    pub name: String,
+    /// The command to explain, e.g. `code/read`. OMIT it to get an INDEX of every
+    /// command you can call (name + one-line description) — your starting point when
+    /// you don't yet know which tool to use.
+    #[serde(default)]
+    #[ts(optional)]
+    pub name: Option<String>,
+}
+
+/// Closest authorized command names to a miss — same category prefix (before `/`),
+/// or sharing a path segment. Cheap, dependency-free, and enough to unstick an agent
+/// that guessed a plausible-but-wrong name (e.g. `commands/describe` → `commands/help`).
+pub(crate) fn did_you_mean<'a>(query: &str, authorized: &[&'a str]) -> Vec<&'a str> {
+    let q = query.to_lowercase();
+    let q_prefix = q.split('/').next().unwrap_or(&q);
+    let q_segs: HashSet<&str> = q.split('/').filter(|s| !s.is_empty()).collect();
+    let mut scored: Vec<(u8, &str)> = authorized
+        .iter()
+        .filter_map(|name| {
+            let n = name.to_lowercase();
+            let n_prefix = n.split('/').next().unwrap_or(&n);
+            let shares_seg = n.split('/').any(|s| !s.is_empty() && q_segs.contains(s));
+            let score = if n_prefix == q_prefix {
+                2 // same category — strongest signal
+            } else if shares_seg {
+                1
+            } else {
+                return None;
+            };
+            Some((score, *name))
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(b.1)));
+    scored.into_iter().take(6).map(|(_, n)| n).collect()
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -45,7 +76,7 @@ pub struct CommandsHelpResult {
 /// envelope (with placeholder values typed from the schema) + an argument list.
 /// Pure function of (name, description, params JSON Schema) — same schema every
 /// other interface adapts from.
-fn render_ai_help(name: &str, description: &str, schema: &Value) -> String {
+pub(crate) fn render_ai_help(name: &str, description: &str, schema: &Value) -> String {
     let props = schema.get("properties").and_then(Value::as_object);
     let required: HashSet<&str> = schema
         .get("required")
@@ -107,17 +138,50 @@ impl ActionCommand for CommandsHelp {
 
     async fn run(&self, ctx: &Ctx, p: CommandsHelpParams) -> Result<CommandsHelpResult, CommandError> {
         let trust = caller_trust(ctx.caller.as_ref());
-        let d = command_registry()
+        // Everything THIS caller could actually run — the universe for both the index
+        // and did-you-mean (never leak commands above the caller's access).
+        let authorized: Vec<_> = command_registry()
             .into_iter()
-            // Only help for what THIS caller could actually run (don't teach the
-            // format of a command it isn't authorized to invoke).
-            .find(|d| d.name == p.name && is_command_authorized(d.name, trust))
-            .ok_or_else(|| {
-                CommandError::NotFound(format!(
-                    "no command '{}' available to you (unknown, or above your access)",
-                    p.name
-                ))
-            })?;
+            .filter(|d| is_command_authorized(d.name, trust))
+            .collect();
+
+        // No name → the INDEX: every command you can call, one line each. This is the
+        // orientation an agent needs FIRST; erroring here (the old "missing field name")
+        // dead-ends the very first discovery move.
+        let Some(name) = p.name.as_deref().filter(|s| !s.trim().is_empty()) else {
+            let mut lines: Vec<String> = authorized
+                .iter()
+                .map(|d| format!("- {} — {}", d.name, d.description))
+                .collect();
+            lines.sort();
+            let manual = format!(
+                "{} commands available to you. Call `commands/help` with a `name` for the \
+                 exact tool-call format of any one.\n\n{}",
+                lines.len(),
+                lines.join("\n"),
+            );
+            return Ok(CommandsHelpResult {
+                name: String::new(),
+                description: "index of all callable commands".to_string(),
+                access_level: "ai-safe".to_string(),
+                manual,
+            });
+        };
+
+        let Some(d) = authorized.iter().find(|d| d.name == name) else {
+            // Unknown/unauthorized name → don't dead-end; suggest the nearest callable
+            // commands so a plausible wrong guess still moves the agent forward.
+            let names: Vec<&str> = authorized.iter().map(|d| d.name).collect();
+            let suggestions = did_you_mean(name, &names);
+            let hint = if suggestions.is_empty() {
+                "Call `commands/help` with no name for the full index.".to_string()
+            } else {
+                format!("Did you mean: {}?", suggestions.join(", "))
+            };
+            return Err(CommandError::NotFound(format!(
+                "no command '{name}' available to you (unknown, or above your access). {hint}"
+            )));
+        };
 
         Ok(CommandsHelpResult {
             name: d.name.to_string(),


### PR DESCRIPTION
- **docs(eval): CORRECTION — the calc "pass_rate 1.0" in fix/eval-runs-production-path was a FALSE POSITIVE**
- **feat(cognition): tool feedback melds into the mind — help never dead-ends; errors teach the fix inline**
