### PR TITLE
feat(px): the raw IPC unknown-command dead-end now guides — did-you-mean for every caller

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -422,10 +422,30 @@ fn handle_client<S: IpcStream>(
                         Err(e) => HandleResult::Json(Response::error(e)),
                     },
                     Some(Err(e)) => HandleResult::Json(Response::error(e)),
-                    None => HandleResult::Json(Response::error(format!(
-                        "Unknown command: '{}'. No module registered for this command prefix.",
-                        cmd
-                    ))),
+                    None => {
+                        // Don't dead-end with a developer-internal "no module registered"
+                        // (the discoverability lie): suggest the nearest commands the
+                        // caller can actually run, via the shared matcher — same PX every
+                        // caller gets, persona or CLI or MCP.
+                        let caller_trust = crate::routing::caller_trust(caller.as_ref());
+                        let names: Vec<&str> = crate::sdk_codegen::command_registry()
+                            .into_iter()
+                            .filter(|d| {
+                                crate::modules::grid::acl::is_command_authorized(d.name, caller_trust)
+                            })
+                            .map(|d| d.name)
+                            .collect();
+                        let suggestions = crate::commands::help::did_you_mean(cmd, &names);
+                        let hint = if suggestions.is_empty() {
+                            "Call `commands/help` with no arguments to list every command you can run."
+                                .to_string()
+                        } else {
+                            format!("Did you mean: {}?", suggestions.join(", "))
+                        };
+                        HandleResult::Json(Response::error(format!(
+                            "Unknown command: '{cmd}'. {hint}"
+                        )))
+                    }
                 }
             } else {
                 HandleResult::Json(Response::error(


### PR DESCRIPTION
The last dead-end in the discovery path: calling a non-existent command over IPC returned "No module registered for
this command prefix" (a dev-internal string the code itself flags as "a discoverability lie" at line 1311). Now it
routes through the SAME shared did_you_mean matcher — scoped to what THIS caller can run — so a wrong guess
(`commands/describe` → `commands/help`, `commands/list`) moves any caller forward: persona, CLI (cu/jtag), or MCP.

Completes the help/navigation PX pass: no orientation move dead-ends anywhere in the stack. One matcher
(commands::help::did_you_mean) is now the single source for suggestions across commands/help, the persona tool-error
seam, and raw IPC — compression, and uniform PX by construction.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
