### PR TITLE
feat(bench): register Hermes-3-Llama-3.1-8B as a benchmark opponent — first local head-to-head

### DIFF
--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -435,6 +435,31 @@ pub fn models() -> Vec<Model> {
             stop_sequences: &["<|im_end|>", "<|endoftext|>"],
             ..ModelSpec::default()
         }),
+        // Hermes-3-Llama-3.1-8B — the benchmark opponent (Nous Research's agentic/tool-use
+        // flagship). Registered so we can serve it and run the SAME coder gym through our
+        // OWN system for an honest head-to-head vs our served model. Llama-3.1 arch, ChatML
+        // prompt format (same template). ~5 GB at Q4_K_M. NOTE: general model, not a code
+        // specialist — the fair read is agentic tool-use, not raw HumanEval.
+        model(ModelSpec {
+            id: "NousResearch/Hermes-3-Llama-3.1-8B-GGUF",
+            name: "Hermes-3-Llama-3.1-8B (benchmark opponent)",
+            provider: "llama-server",
+            arch: Arch::Llama,
+            context_window: 32_768,
+            max_output_tokens: 8192,
+            tokens_per_second: 18.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Streaming,
+            ],
+            gguf_hint: Some("huggingface.co/bartowski/Hermes-3-Llama-3.1-8B-GGUF"),
+            chat_template: Some(QWEN35_CHAT_TEMPLATE),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            stop_sequences: &["<|im_end|>", "<|eot_id|>", "<|endoftext|>"],
+            ..ModelSpec::default()
+        }),
         // Qwen2.5-Coder-32B — downloaded (~20 GB Q4_K_M) and the KV fit-gate fix lets it
         // serve, but DELIBERATELY NOT registered yet: measured live it DECLINES a directed
         // coding task (emits a bare "PASS") instead of acting, so serving it as the live


### PR DESCRIPTION
Nous Hermes-3-Llama-3.1-8B registered as a servable local model (Llama-3.1 arch, ChatML, ~5GB Q4_K_M) so we can
run the SAME coder gym through our OWN system for an honest local-vs-local head-to-head.

First result (HumanEval-Rust, 40 tasks, single-pass, valid test_grade — real compile+run, 0 inference errors):
  OUR local (Qwen2.5-Coder-14B): 88%
  Hermes-3-Llama-3.1-8B:         42%

Honest read: much of the gap is MODEL-FIT — Hermes-3 is a general model, we serve a code specialist (and 14B vs
8B). That's not a trick; it IS the thesis (pick/tune the best-fit local model for the ask — the thing cloud can't
do). It is NOT "our loop made an equal model win" — the purer system claim is to run Hermes THROUGH our agentic
loop + PX and show the lift, which the unsloth /v1 adapter (#31) makes a one-seam swap. Local beats Hermes on the
coder task; the deeper agentic-tool-use comparison is the follow-up.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
