### PR TITLE
feat(benchmarks): formalize the opponent benchmark as zero-dependency extras; drop Hermes from the core catalog

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,54 @@
+# Continuum benchmarks — repeatable, honest, zero-dependency
+
+An **extras** path. Nothing here is compiled into `continuum-core` or shipped in the product;
+it is tooling for measuring ourselves against external systems. Run it, don't depend on it.
+
+## The one hard rule
+
+**We never depend on any opponent — Hermes, unsloth, a cloud API, anything. Ever.**
+
+Opponents are **external, optional `/v1` endpoints you bring**. This harness imports nothing
+from the product and the product imports nothing from here. An opponent is a URL — a local
+`llama-server`, an unsloth gateway, ollama, a cloud API, or an **airc node** exposing an
+OpenAI-compatible `/v1`. That last one is the point: it also proves *grid encapsulation* —
+any model, ours or an opponent's, is just a node reachable over the same seam.
+
+## What it measures
+
+`coder/` — the Rust coder gym (`docs/genome/humaneval-rs.jsonl`, HumanEval-Rust): each task's
+answer is **compiled and run against a hidden test** (`rustc` — real pass/fail, no self-report,
+no exit-code masking). Two rows, same tasks, same grader:
+
+| runner | what it scores | how the model is reached |
+|---|---|---|
+| `coder/run_ours.sh` | OUR system (RAG + tools + PX + act→observe loop) | the local model the running core serves |
+| `coder/oneshot_opponent.py` | an opponent, one-shot | any external `/v1` URL you provide |
+
+The comparison is deliberately fair-with-an-asterisk: `run_ours.sh` runs the *whole system*;
+`oneshot_opponent.py` runs the opponent *one-shot* (its plain inference). The gap includes both
+model-fit (we pick the best local model for the ask — the thing cloud can't do) and system lift.
+To isolate the *system* lift, point `oneshot_opponent.py` at the SAME local model the core serves
+and diff it against `run_ours.sh`.
+
+## Run it
+
+```bash
+# 1. OURS — a core must be up serving your local model (cu ping → ok), model warm.
+benchmarks/coder/run_ours.sh "Qwen2.5-Coder-14B (ours)" 40
+
+# 2. AN OPPONENT — spin its /v1 up yourself (any backend), then:
+python3 benchmarks/coder/oneshot_opponent.py \
+    --endpoint http://127.0.0.1:8080/v1 --model hermes-3-8b \
+    --label "Hermes-3-8B" --limit 40
+
+# 3. Paste both rows into coder/SCOREBOARD.md.
+```
+
+Requirements: `rustc` on PATH (grading), `python3` (stdlib only). No pip installs, no product runtime
+for the opponent side.
+
+## Adding an opponent
+
+There is no code to add — an opponent is a config line (endpoint + model + label). Stand it up
+however you like (that is *your* dependency, never ours) and point the harness at it. See
+`coder/SCOREBOARD.md` for the running results.

--- a/benchmarks/coder/SCOREBOARD.md
+++ b/benchmarks/coder/SCOREBOARD.md
@@ -1,0 +1,26 @@
+# Coder gym scoreboard — HumanEval-Rust (compile + run graded)
+
+Reproduce with `run_ours.sh` (ours) and `oneshot_opponent.py` (opponents). Same tasks, same
+grader. Opponents are external `/v1` endpoints — we never depend on any of them.
+
+## 40-task slice (HumanEval_0 … HumanEval_39)
+
+| model / system | passed | pass@1 | via | notes |
+|---|---|---|---|---|
+| **Qwen2.5-Coder-14B — OURS** | 35/40 | **88%** | Continuum system | our best-fit local coder, full stack |
+| Hermes-3-Llama-3.1-8B | 17/40 | 42% | our system, one-shot serve | general model, not a code specialist |
+
+*First local head-to-head (2026-07). Ours more than doubles Hermes on the coder gym with a
+valid grader and zero inference errors on either side. The margin is dominated by model-fit
+(specialist vs generalist) — that IS our thesis (pick/tune the best-fit local model, the move
+cloud can't make), not a system-lift claim. Isolate system lift by running the SAME model both
+one-shot and through `run_ours.sh`.*
+
+## Pending
+
+- **unsloth** — score via `oneshot_opponent.py` against an unsloth `/v1` gateway (external).
+- **Hermes via external `/v1`** — re-measure one-shot through the standalone harness (fully
+  decoupled from our serving) to confirm the number off the product entirely.
+- **System-lift isolation** — same local model, one-shot vs `run_ours.sh`, to attribute the
+  gap between model-fit and our loop/PX.
+- **airc-node opponent** — reach a model over an airc peer's `/v1` (grid-encapsulation proof).

--- a/benchmarks/coder/oneshot_opponent.py
+++ b/benchmarks/coder/oneshot_opponent.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+oneshot_opponent.py — score an EXTERNAL model on the Rust coder gym via its OpenAI-compatible
+/v1 endpoint. One-shot: the model gets each task once, its answer is compiled + run against the
+task's hidden test, pass = exit 0.
+
+ZERO DEPENDENCY, BY DESIGN. This harness imports NOTHING from the Continuum product and requires
+no Continuum runtime. The opponent is just a URL you bring (a local llama-server, an unsloth
+gateway, ollama, a cloud API, or an airc node exposing /v1). We never depend on Hermes or unsloth
+or any opponent — ever; they are optional, external, and reached only through this standalone tool.
+Stdlib + `rustc` on PATH is all it needs.
+
+Usage:
+  python3 oneshot_opponent.py \
+      --endpoint http://127.0.0.1:8080/v1 \
+      --model hermes-3-8b \
+      --label "Hermes-3-8B" \
+      --gym ../../docs/genome/humaneval-rs.jsonl \
+      --limit 40
+
+Emits a JSON result and prints a one-line scoreboard row. Compare against OURS, produced by
+`run_ours.sh` (which runs the SAME gym through the Continuum system). Same tasks, same grader.
+"""
+import argparse, json, os, re, subprocess, sys, tempfile, time, urllib.request, urllib.error
+
+def chat(endpoint, model, prompt, api_key, max_tokens, timeout):
+    body = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.0,          # greedy — a deterministic, reproducible measurement
+        "max_tokens": max_tokens,
+    }).encode()
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(endpoint.rstrip("/") + "/chat/completions", data=body, headers=headers)
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        d = json.load(r)
+    return d["choices"][0]["message"]["content"] or ""
+
+def extract_code(text):
+    """The model's answer → compilable Rust. Prefer a fenced ```rust block; else the whole text."""
+    m = re.search(r"```(?:rust)?\s*\n(.*?)```", text, re.S)
+    return (m.group(1) if m else text).strip()
+
+def grade(answer_code, test_body, workdir):
+    """Mirror the Continuum grader: answer + `fn main() { <test> }` → rustc → run. Pass = exit 0."""
+    prog = f"{answer_code}\n\nfn main() {{\n{test_body}\n}}\n"
+    src = os.path.join(workdir, "prog.rs")
+    binp = os.path.join(workdir, "prog_bin")
+    with open(src, "w") as f:
+        f.write(prog)
+    c = subprocess.run(["rustc", "--edition", "2021", src, "-o", binp],
+                       capture_output=True, text=True, timeout=60)
+    if c.returncode != 0:
+        return False, "compile error: " + (c.stderr.strip().splitlines() or [""])[0][:120]
+    r = subprocess.run([binp], capture_output=True, text=True, timeout=30)
+    return (r.returncode == 0), ("tests passed" if r.returncode == 0
+                                 else "test failed: " + (r.stderr.strip()[:120] or "assertion"))
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--endpoint", required=True, help="OpenAI-compatible base, e.g. http://127.0.0.1:8080/v1")
+    ap.add_argument("--model", required=True, help="model name the endpoint expects")
+    ap.add_argument("--label", required=True, help="scoreboard label, e.g. 'Hermes-3-8B'")
+    ap.add_argument("--gym", default=os.path.join(os.path.dirname(__file__), "..", "..", "docs", "genome", "humaneval-rs.jsonl"))
+    ap.add_argument("--limit", type=int, default=40)
+    ap.add_argument("--max-tokens", type=int, default=1024)
+    ap.add_argument("--timeout", type=int, default=120)
+    ap.add_argument("--api-key", default=os.environ.get("OPPONENT_API_KEY", ""))
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    tasks = [json.loads(l) for l in open(args.gym) if l.strip()][:args.limit]
+    results, passed, infra_err = [], 0, 0
+    for i, t in enumerate(tasks):
+        try:
+            answer = chat(args.endpoint, args.model, t["prompt"], args.api_key, args.max_tokens, args.timeout)
+        except (urllib.error.URLError, TimeoutError, KeyError) as e:
+            infra_err += 1
+            results.append({"id": t["id"], "ok": False, "grade": f"endpoint error: {e}"})
+            print(f"  {t['id'][:30]:30} ENDPOINT-ERR", file=sys.stderr)
+            continue
+        with tempfile.TemporaryDirectory() as wd:
+            ok, g = grade(extract_code(answer), t.get("test", ""), wd)
+        passed += ok
+        results.append({"id": t["id"], "ok": ok, "grade": g})
+        print(f"  {t['id'][:30]:30} {'PASS' if ok else 'fail'}  {g[:50]}", file=sys.stderr)
+
+    n = len(tasks) or 1
+    out = {"label": args.label, "endpoint": args.endpoint, "model": args.model,
+           "tasks": len(tasks), "passed": passed, "pass_rate": passed / n,
+           "endpoint_errors": infra_err, "results": results}
+    if args.out:
+        json.dump(out, open(args.out, "w"), indent=2)
+    print(f"\n| {args.label} | {passed}/{len(tasks)} | {passed/n:.0%} | one-shot /v1 | endpoint-errs {infra_err} |")
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/coder/run_ours.sh
+++ b/benchmarks/coder/run_ours.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# run_ours.sh — score OUR system on the Rust coder gym, through the full Continuum stack
+# (RAG + tools + PX + the persona's own act→observe loop). This is the "ours" row; opponents
+# are scored by oneshot_opponent.py against an external /v1. Same gym, same grader (rustc
+# compile+run via the eval's test_grade), so the numbers are directly comparable.
+#
+# Prereq: a running core serving the local model you want to measure (`cu ping` returns ok).
+# We warm-check the model first — a cold model 500s and would report a false 0 (learned the
+# hard way). Never trust a run with inference errors.
+set -euo pipefail
+
+CU="${CU:-$HOME/.continuum/cache/cargo-target/debug/cu}"
+PERSONA="${PERSONA:-90e758b2-3cf3-45c1-b100-de7c4ab5a549}"
+GYM="${GYM:-$(cd "$(dirname "$0")/../.." && pwd)/docs/genome/humaneval-rs.jsonl}"
+LABEL="${1:-ours}"
+LIMIT="${2:-40}"
+MAX_ACTS="${MAX_ACTS:-6}"
+
+slice="$(mktemp /tmp/coder_gym_XXXX.jsonl)"
+head -n "$LIMIT" "$GYM" > "$slice"
+
+# Warm-gate: the eval fails LOUD ("inference failed") on a cold model, so make sure it answers.
+port="$(ps aux | grep '[l]lama-server' | grep -oE '\-\-port [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+if [ -n "${port:-}" ]; then
+  warm="$(curl -s -m 25 "http://127.0.0.1:${port}/v1/chat/completions" \
+    -H 'Content-Type: application/json' \
+    -d '{"messages":[{"role":"user","content":"hi"}],"max_tokens":4}' 2>/dev/null | grep -c '"content"' || true)"
+  [ "${warm:-0}" = "1" ] || { echo "model not warm on :$port — wait for load, then retry" >&2; exit 1; }
+fi
+
+echo "running OUR system on $LIMIT tasks (max_acts=$MAX_ACTS)…" >&2
+"$CU" cognition/eval --persona_id "$PERSONA" --eval_set "$slice" --max_acts "$MAX_ACTS" --max_retries 0 2>&1 \
+  | python3 -c "
+import sys,json,re
+m=re.search(r'\{.*\}',sys.stdin.read(),re.S); d=json.loads(m.group(0)) if m else {}
+res=d.get('results') or []
+inf=sum(1 for x in res if 'inference failed' in str(x.get('grade','')))
+p=sum(1 for x in res if x.get('ok'))
+print(f'| $LABEL | {p}/{len(res)} | {d.get(\"pass_rate\",0):.0%} | Continuum system | inf-errs {inf} |')
+"
+rm -f "$slice"

--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -435,31 +435,11 @@ pub fn models() -> Vec<Model> {
             stop_sequences: &["<|im_end|>", "<|endoftext|>"],
             ..ModelSpec::default()
         }),
-        // Hermes-3-Llama-3.1-8B — the benchmark opponent (Nous Research's agentic/tool-use
-        // flagship). Registered so we can serve it and run the SAME coder gym through our
-        // OWN system for an honest head-to-head vs our served model. Llama-3.1 arch, ChatML
-        // prompt format (same template). ~5 GB at Q4_K_M. NOTE: general model, not a code
-        // specialist — the fair read is agentic tool-use, not raw HumanEval.
-        model(ModelSpec {
-            id: "NousResearch/Hermes-3-Llama-3.1-8B-GGUF",
-            name: "Hermes-3-Llama-3.1-8B (benchmark opponent)",
-            provider: "llama-server",
-            arch: Arch::Llama,
-            context_window: 32_768,
-            max_output_tokens: 8192,
-            tokens_per_second: 18.0,
-            capabilities: &[
-                Capability::TextGeneration,
-                Capability::Chat,
-                Capability::ToolUse,
-                Capability::Streaming,
-            ],
-            gguf_hint: Some("huggingface.co/bartowski/Hermes-3-Llama-3.1-8B-GGUF"),
-            chat_template: Some(QWEN35_CHAT_TEMPLATE),
-            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
-            stop_sequences: &["<|im_end|>", "<|eot_id|>", "<|endoftext|>"],
-            ..ModelSpec::default()
-        }),
+        // NOTE: benchmark OPPONENTS (Hermes, unsloth, cloud models) are DELIBERATELY absent
+        // from this catalog — we never depend on either, ever. They are scored as external,
+        // optional /v1 endpoints by the standalone harness in `benchmarks/coder/`, which
+        // imports nothing from the product. Zero coupling by construction.
+        //
         // Qwen2.5-Coder-32B — downloaded (~20 GB Q4_K_M) and the KV fit-gate fix lets it
         // serve, but DELIBERATELY NOT registered yet: measured live it DECLINES a directed
         // coding task (emits a bare "PASS") instead of acting, so serving it as the live


### PR DESCRIPTION
Joel: we NEVER depend on an opponent (Hermes, unsloth, a cloud provider) — ever. Optional integrations that reach
what a user ALREADY runs are an asset; a FORCED dependency is the weakness. So:

- REVERT the Hermes catalog row — an opponent has no business in our shipped model registry (soft coupling). The
  catalog now carries a note explaining opponents live only in benchmarks/, reached as external /v1.
- NEW `benchmarks/` extras path — compiled into nothing, imported by nothing in the product:
  * `coder/oneshot_opponent.py` — score ANY external OpenAI-compatible /v1 (local llama-server, unsloth gateway,
    ollama, cloud API, or an airc node) on HumanEval-Rust, graded by real rustc compile+run. Python stdlib + rustc
    only; imports nothing from Continuum. The opponent is a URL you bring.
  * `coder/run_ours.sh` — score OUR system on the same gym through the full stack, warm-gated (a cold model 500s
    → false 0; never trust an inference-error run).
  * `SCOREBOARD.md` — seeded: ours (Qwen2.5-Coder-14B) 88% vs Hermes-3-8B 42%, with the honest model-fit asterisk.
  * `README.md` — the one hard rule (never depend), the transports (incl. airc-node = grid-encapsulation proof),
    how to add an opponent (a config line, no code).

Repeatable, intentional, and an appealing optional integration — not a dependency.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
