### PR TITLE
fix(eval): warm-gate — never measure a cold model (kills the false-zero that lies about the gap)

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -689,6 +689,64 @@ impl ActionCommand for CognitionEval {
                 )))?,
         };
 
+        // WARM-GATE — never measure a COLD model. A just-loaded or just-swapped lane 500s
+        // until its weights + KV are resident; firing the gym into it scores "inference
+        // failed" on every task — a false ZERO that would LIE about how far behind (or
+        // ahead) we are. A measurement that can't trust its own model is no measurement.
+        // Poll with a tiny throwaway deliberation until the lane answers, then run; if it
+        // never warms, fail LOUD rather than emit a bogus 0. (Cost is one cheap probe on a
+        // warm lane — the common case returns on the first try.)
+        {
+            let warm_room = Uuid::new_v4();
+            let probe_delivery = crate::persona::rag_budget::RagDelivery {
+                source_id: "airc".to_string(),
+                items: vec![crate::persona::rag_budget::RagItem {
+                    content: "ready check".to_string(),
+                    tokens: 0,
+                    metadata: serde_json::json!({ "peer_id": "peer", "occurred_at_ms": EVAL_EPOCH_MS }),
+                }],
+                tokens_used: 0,
+                continuation: None,
+                resolution_used: crate::persona::rag_budget::ResolutionPreference::Raw,
+            };
+            let mut warm = false;
+            for _ in 0..15u32 {
+                let burst = crate::cognition::workspace::Burst::from_turns(
+                    warm_room,
+                    crate::persona::service_loop::build_workspace_turns(
+                        std::slice::from_ref(&probe_delivery),
+                        "",
+                        "",
+                        None,
+                    ),
+                );
+                let probe = crate::cognition::act_observe::drive_to_settle(
+                    &cycle,
+                    burst,
+                    warm_room,
+                    0, // no acts — a bare deliberation is enough to prove the lane answers
+                    crate::cognition::workspace::TurnFraming::directed(),
+                )
+                .await;
+                if probe.inference_error.is_none() {
+                    warm = true;
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+            }
+            // Reset the volatile scratch the probe touched so task #1 starts from the same
+            // clean frame every other task does.
+            cycle.reset_working_memory();
+            if !warm {
+                return Err(CommandError::Internal(
+                    "serving lane not ready after ~60s of warm probes — refusing to run an \
+                     eval on a cold model (every task would score a false 'inference failed' \
+                     zero). Wait for the model to load, then retry."
+                        .to_string(),
+                ));
+            }
+        }
+
         let max_acts = p.max_acts.unwrap_or(DEFAULT_MAX_ACTS) as usize;
         let max_retries = p.max_retries.unwrap_or(MAX_FAIL_RETRIES);
         let total = tasks.len() as u32;


### PR DESCRIPTION
Structural rot found twice this session: right after a reboot/model-swap the served lane 500s until its weights
+ KV are resident, so an eval fired into it scores "inference failed" on EVERY task — a false pass_rate 0 that
would lie about how far behind (or ahead) we are vs an opponent. A benchmark that can't trust its own model is
worse than none.

cognition/eval now warm-gates before running: it polls the forked lane with a tiny throwaway deliberation (0 acts)
until the model answers, resets the scratch it touched, then runs. If the lane never warms in ~60s it fails LOUD
(refuses to emit a bogus 0) instead of reporting a fake miss. Cost on a warm lane is one cheap probe.

This is the first "make the engine run well" fix in service of "figure out how behind we are" — every gap number
from here is trustworthy or it's an explicit error, never a silent lie.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
