### PR TITLE
fix(serving): --jinja ALWAYS — enable native tool rendering for every model, not just forged ones

### DIFF
--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -1064,12 +1064,24 @@ impl LlamaServerControl for LlamaServerProcess {
         // explicit override file, not a silent fallback: present → it's the
         // truth the GGUF should have carried; absent → the embedded template
         // stands.
+        // --jinja is UNCONDITIONAL: it makes llama-server render the `tools` we send and do
+        // grammar-constrained parsing of the model's NATIVE tool-call format, using the
+        // model's OWN chat template. That is the tool-trained shape a Qwen/Hermes/etc GGUF
+        // expects — infinitely more reliable than us reverse-engineering tool calls out of
+        // prose after the fact. A normal pulled GGUF carries a tool-capable embedded template;
+        // this switch was previously gated on a forge sidecar existing, so pulled models
+        // silently ran with tools DISABLED (the gateway ignored the `tools` param → the
+        // persona narrated tool calls instead of emitting them). The sidecar, when the forge
+        // wrote one, now OVERRIDES the embedded template (for forged GGUFs that shipped a
+        // thin, tool-less 208-char template) — present → override, absent → the embedded
+        // tool-capable template stands, tools ON either way.
+        cmd.arg("--jinja");
         if let Some(tpl) = gguf
             .parent()
             .map(|d| d.join("chat_template.jinja"))
             .filter(|p| p.is_file())
         {
-            cmd.arg("--jinja").arg("--chat-template-file").arg(tpl);
+            cmd.arg("--chat-template-file").arg(tpl);
         }
         // Load each trained genome layer into the `/lora-adapters` catalog at
         // index order; the per-request `"lora":[{id,scale}]` field pages them in.


### PR DESCRIPTION
Structural gap: llama-server's --jinja (which renders the `tools` we send AND parses the model's native tool-call
format via the model's own chat template) was gated on the FORGE having written a chat_template.jinja sidecar.
A normal pulled GGUF (Qwen, Hermes, …) got none → --jinja absent → llama-server silently IGNORED the `tools` param
→ the model was never shown its tools natively → it narrated tool calls (or declined) instead of emitting them.
The adapter already sends `tools` and reads `tool_calls`; --jinja was the missing switch.

Now --jinja is UNCONDITIONAL (uses the GGUF's embedded tool-capable template), with the forge sidecar as an
OVERRIDE for forged GGUFs that shipped a thin tool-less template. Verified live: with --jinja on, the 14B renders
the tool schema and emits a clean structured call `{"name":...,"arguments":...}` where before it narrated. (This
GGUF's template wraps the call oddly so llama-server didn't stamp finish=tool_calls; the universal text salvage's
BareFormat catches the inner JSON, so it executes — belt and suspenders.) A real structural reliability lift for
every tool-trained model, in service of "best possible for a given model."

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
