### PR TITLE
feat(benchmarks): reproducible matrix system — runners × benchmarks → a chart, published claims side-by-side

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -52,3 +52,25 @@ for the opponent side.
 There is no code to add — an opponent is a config line (endpoint + model + label). Stand it up
 however you like (that is *your* dependency, never ours) and point the harness at it. See
 `coder/SCOREBOARD.md` for the running results.
+
+## The matrix (reproducible — runners × benchmarks → a chart)
+
+`matrix.py` replaces the hand-run one-offs: one command runs every (runner × benchmark)
+pair from a config and emits `CHART.md` + `results.json`.
+
+```bash
+cp benchmarks/config.example.json benchmarks/config.json   # edit runners + benchmarks
+python3 benchmarks/matrix.py benchmarks/config.json
+```
+
+- A **runner** is `ours` (through the Continuum core) or `opponent` (an external `/v1` you
+  bring up — llama-server, unsloth gateway, ollama, cloud, or an airc node). A future
+  **team** runner (coordinated personas on one plan) drops in with no charting change.
+- Put a model's **own published number** for a benchmark in its `published` map and the chart
+  renders `_(claim …)_` beside what we measured identically — so an "amazing claim" meets a
+  real, common benchmark reproduced the same way. Take them on their numbers.
+- Add a benchmark = one config entry + a gym file. Add an opponent = one config line (stand
+  its endpoint up yourself; that is your dependency, never ours).
+
+This is the system to run across many models and many benchmarks — individuals first, then
+teams that scale and learn — and chart it, repeatably.

--- a/benchmarks/config.example.json
+++ b/benchmarks/config.example.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "Reproducible benchmark matrix. Copy to config.json and edit. Opponents are EXTERNAL /v1 endpoints you bring up yourself (a local llama-server, unsloth gateway, ollama, cloud API, or an airc node) — never a dependency of ours. 'ours' runs through a live Continuum core. Fill each runner's `published` map with the model's OWN published score for a benchmark (from its model card / paper) to render it next to what we measured identically.",
+
+  "benchmarks": [
+    {
+      "name": "humaneval-rs",
+      "gym": "docs/genome/humaneval-rs.jsonl",
+      "limit": 40,
+      "max_acts": 6,
+      "max_retries": 0,
+      "timeout": 5400
+    }
+  ],
+
+  "runners": [
+    {
+      "kind": "ours",
+      "label": "Qwen2.5-Coder-14B (our system)",
+      "persona": "90e758b2-3cf3-45c1-b100-de7c4ab5a549",
+      "cu": "~/.continuum/cache/cargo-target/debug/cu",
+      "published": {}
+    },
+    {
+      "kind": "opponent",
+      "label": "Hermes-3-Llama-3.1-8B",
+      "endpoint": "http://127.0.0.1:8090/v1",
+      "model": "hermes-3",
+      "published": {}
+    }
+  ]
+}

--- a/benchmarks/matrix.py
+++ b/benchmarks/matrix.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+matrix.py — reproducible benchmark MATRIX: runners × benchmarks → a chart.
+
+Runs every (runner, benchmark) pair from a config, collects pass@1, and emits CHART.md
+(a markdown table = the chart) + results.json. This replaces the manual one-off runs:
+one command reproduces the whole board.
+
+Runners (a runner is anything that can attempt a benchmark):
+  • "opponent" — an EXTERNAL OpenAI-compatible /v1 endpoint you bring up (a local
+    llama-server, an unsloth gateway, ollama, a cloud API, or an airc node). One-shot.
+    ZERO dependency on us — we never require it.
+  • "ours"     — a benchmark run THROUGH the Continuum core (full system: RAG + tools +
+    PX + act→observe), via `cu cognition/eval`. Warm-gated by the eval itself.
+  • (future)   — "team": a coordinated set of personas working one shared plan/kanban.
+    Same interface; drops into the matrix with no runner-specific charting code.
+
+Published claims: put a model's own published number for a benchmark in the config and it
+renders in the chart next to what WE measured — so an "amazing claim" meets a real, common
+benchmark we reproduced identically. Take them on their numbers.
+
+Requirements: python3 (stdlib), plus each opponent's /v1 up and (for "ours") a running core.
+`rustc` for the coder gym grader. No pip installs.
+
+Usage:
+  python3 benchmarks/matrix.py benchmarks/config.example.json
+"""
+import argparse, json, os, re, subprocess, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+
+
+def _resolve(p):
+    return p if os.path.isabs(p) else os.path.join(REPO, p)
+
+
+def run_opponent(r, bench):
+    """Score an external /v1 one-shot via the standalone harness."""
+    cmd = [
+        sys.executable, os.path.join(HERE, "coder", "oneshot_opponent.py"),
+        "--endpoint", r["endpoint"], "--model", r["model"], "--label", r["label"],
+        "--gym", _resolve(bench["gym"]), "--limit", str(bench.get("limit", 40)),
+    ]
+    if r.get("api_key"):
+        cmd += ["--api-key", r["api_key"]]
+    out = subprocess.run(cmd, capture_output=True, text=True, timeout=bench.get("timeout", 5400))
+    m = re.search(r"\|[^|]*\|\s*(\d+)/(\d+)\s*\|\s*(\d+)%", out.stdout)
+    if m:
+        return {"passed": int(m.group(1)), "total": int(m.group(2)), "pass_rate": int(m.group(3)) / 100}
+    return {"error": (out.stdout + "\n" + out.stderr).strip()[-240:]}
+
+
+def run_ours(r, bench):
+    """Score a benchmark THROUGH the Continuum core (full system), via cu cognition/eval."""
+    cu = r.get("cu", os.path.expanduser("~/.continuum/cache/cargo-target/debug/cu"))
+    gym = _resolve(bench["gym"])
+    limit = bench.get("limit", 40)
+    slice_path = f"/tmp/mtx_{os.getpid()}_{bench['name']}.jsonl"
+    with open(gym) as f, open(slice_path, "w") as o:
+        for i, line in enumerate(f):
+            if i >= limit:
+                break
+            o.write(line)
+    cmd = [
+        cu, "cognition/eval", "--persona_id", r["persona"], "--eval_set", slice_path,
+        "--max_acts", str(bench.get("max_acts", 6)), "--max_retries", str(bench.get("max_retries", 0)),
+    ]
+    out = subprocess.run(cmd, capture_output=True, text=True, timeout=bench.get("timeout", 5400))
+    try:
+        os.remove(slice_path)
+    except OSError:
+        pass
+    m = re.search(r"\{.*\}", out.stdout, re.S)
+    if not m:
+        return {"error": (out.stdout + "\n" + out.stderr).strip()[-240:]}
+    d = json.loads(m.group(0))
+    res = d.get("results") or []
+    inf = sum(1 for x in res if "inference failed" in str(x.get("grade", "")))
+    if inf:
+        return {"error": f"{inf} inference errors (cold model? the eval warm-gate should prevent this)"}
+    return {"passed": sum(1 for x in res if x.get("ok")), "total": len(res), "pass_rate": d.get("pass_rate", 0.0)}
+
+
+RUNNERS = {"opponent": run_opponent, "ours": run_ours}
+
+
+def cell(result, published):
+    if result is None:
+        return "—"
+    if "error" in result:
+        return f"ERR"
+    s = f"{result['pass_rate']:.0%}"
+    if published is not None:
+        s += f" _(claim {published:.0%})_"
+    return s
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("config")
+    ap.add_argument("--out", default=os.path.join(HERE, "CHART.md"))
+    ap.add_argument("--json", default=os.path.join(HERE, "results.json"))
+    args = ap.parse_args()
+
+    cfg = json.load(open(_resolve(args.config)))
+    benches = cfg["benchmarks"]
+    runners = cfg["runners"]
+
+    results = {}  # (runner_label, bench_name) -> result
+    for b in benches:
+        for r in runners:
+            fn = RUNNERS.get(r["kind"])
+            if not fn:
+                results[(r["label"], b["name"])] = {"error": f"unknown runner kind {r['kind']}"}
+                continue
+            print(f"→ {r['label']} × {b['name']} …", file=sys.stderr)
+            try:
+                results[(r["label"], b["name"])] = fn(r, b)
+            except Exception as e:  # a runner failing must not sink the whole matrix
+                results[(r["label"], b["name"])] = {"error": str(e)[-240:]}
+            print(f"   {cell(results[(r['label'], b['name'])], None)}", file=sys.stderr)
+
+    # Chart: rows = runners, cols = benchmarks.
+    lines = ["# Benchmark matrix", "",
+             "Reproduce: `python3 benchmarks/matrix.py <config.json>`. `_(claim …)_` = the "
+             "model's own published number for that benchmark, shown next to what we measured "
+             "identically. Opponents are external /v1 (zero dependency).", ""]
+    header = "| runner | " + " | ".join(b["name"] for b in benches) + " |"
+    sep = "|" + "---|" * (len(benches) + 1)
+    lines += [header, sep]
+    for r in runners:
+        row = [r["label"]]
+        for b in benches:
+            res = results.get((r["label"], b["name"]))
+            pub = (r.get("published") or {}).get(b["name"])
+            row.append(cell(res, pub))
+        lines.append("| " + " | ".join(row) + " |")
+    open(args.out, "w").write("\n".join(lines) + "\n")
+
+    json.dump(
+        {f"{k[0]} × {k[1]}": v for k, v in results.items()},
+        open(args.json, "w"), indent=2,
+    )
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stop being the harness by hand. matrix.py runs every (runner × benchmark) pair from a config and emits CHART.md +
results.json — one command reproduces the whole board.

- A runner is `ours` (through the Continuum core, via cu cognition/eval, warm-gated so numbers can't be false
  zeros) or `opponent` (an EXTERNAL /v1 you bring up — llama-server, unsloth gateway, ollama, cloud, or an airc
  node; never a dependency of ours). A future `team` runner (coordinated personas on one plan) drops into the same
  interface with zero charting change — the axis Joel wants: individuals first, then self-scaling learning teams.
- `published` per runner renders the model's OWN claimed number for a benchmark next to what we measured
  identically — so an "amazing claim" meets a real, common benchmark reproduced the same way. Take them on their
  numbers.
- Add a benchmark = one config entry + a gym file. Add an opponent = one config line. Charts across many models and
  many benchmarks, repeatably.

Validated live: `ours` on a 3-task slice → 3/3, CHART.md emitted, no inference errors (warm-gate held). This is the
"systems in place" that replaces the manual runs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
