### PR TITLE
feat(benchmarks): benchmark CATALOG — manage collections like the model catalog (list/pull/resolve by name)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -74,3 +74,19 @@ python3 benchmarks/matrix.py benchmarks/config.json
 
 This is the system to run across many models and many benchmarks — individuals first, then
 teams that scale and learn — and chart it, repeatably.
+
+## Benchmark catalog (manage collections like the model catalog)
+
+Benchmarks are large managed artifacts, catalogued and pulled by name — not vendored.
+
+```bash
+python3 benchmarks/catalog.py list                 # what's known + cached
+python3 benchmarks/catalog.py pull humaneval        # fetch + cache a large one
+python3 benchmarks/catalog.py resolve humaneval-rs  # name → local path
+```
+
+A matrix benchmark references a catalog entry by name (`"catalog": "humaneval"`) and the runner
+pulls + caches it on demand into `~/.continuum/benchmarks/`. Add a respected collection
+(SWE-bench, LiveCodeBench, MBPP, …) = one `KNOWN` entry with its `grader`. Big datasets cache
+like a model, never bloat the repo. Later a Rust `benchmark/*` command wraps the SAME registry
+so a persona can call a competition by name.

--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+catalog.py — the benchmark CATALOG. Manage benchmark collections the way we manage the model
+catalog and databases: LIST what's known, PULL (download + cache) the large ones on demand,
+RESOLVE a name → a local dataset. Public and reproducible — anyone gets the same benchmark by
+the same name, and (like models) big collections are fetched once and cached, not vendored.
+
+Design mirrors the model catalog on purpose:
+  • declarative registry of KNOWN benchmarks (name → source, grader, size) — one entry to add one;
+  • a shared cache under ~/.continuum/benchmarks/ (like ~/.continuum model dirs);
+  • fetch-on-demand + fail-loud (never a silent stub);
+  • a `grader` per benchmark (how a solution is scored) so the matrix/opponent runner knows how
+    to judge it — `rust` (compile+run, live today) or `python`/others as the catalog grows.
+
+This is the management layer the reproducible matrix reads from. Later a Rust `benchmark/*`
+command can wrap the SAME registry so a PERSONA can call a competition by name.
+
+CLI:
+  python3 benchmarks/catalog.py list
+  python3 benchmarks/catalog.py pull humaneval
+  python3 benchmarks/catalog.py resolve humaneval-rs
+"""
+import gzip
+import io
+import json
+import os
+import sys
+import urllib.request
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CACHE = os.path.expanduser("~/.continuum/benchmarks")
+
+# The known benchmark collections. `grader`: how a solution is scored. `kind`: where it lives.
+#   local — vendored in-repo (small, canonical).
+#   url   — fetched + cached on demand (may be .gz).
+# Add a benchmark = add one entry. Add a respected collection (SWE-bench, LiveCodeBench, …) as a
+# `url`/`hf` entry with its grader; big ones cache like a model, never bloat the repo.
+KNOWN = {
+    "humaneval-rs": {
+        "desc": "HumanEval ported to Rust — 164 tasks, graded by rustc compile+run.",
+        "kind": "local",
+        "path": "docs/genome/humaneval-rs.jsonl",
+        "grader": "rust",
+        "tasks": 164,
+    },
+    "humaneval": {
+        "desc": "OpenAI HumanEval (Python) — the original, 164 tasks. Grader: python exec.",
+        "kind": "url",
+        "url": "https://github.com/openai/human-eval/raw/master/data/HumanEval.jsonl.gz",
+        "gz": True,
+        "grader": "python",
+        "tasks": 164,
+    },
+    "mbpp": {
+        "desc": "MBPP (Mostly Basic Python Problems) — ~974 tasks. Grader: python exec.",
+        "kind": "url",
+        "url": "https://raw.githubusercontent.com/google-research/google-research/master/mbpp/mbpp.jsonl",
+        "grader": "python",
+        "tasks": 974,
+    },
+}
+
+
+def _cache_path(name):
+    return os.path.join(CACHE, f"{name}.jsonl")
+
+
+def pull(name):
+    """Fetch + cache a benchmark. Local ones resolve in-repo (nothing to fetch)."""
+    if name not in KNOWN:
+        raise SystemExit(f"unknown benchmark '{name}'. Known: {', '.join(sorted(KNOWN))}")
+    spec = KNOWN[name]
+    if spec["kind"] == "local":
+        p = os.path.join(REPO, spec["path"])
+        if not os.path.isfile(p):
+            raise SystemExit(f"vendored benchmark '{name}' missing at {p}")
+        return p
+    # url
+    dst = _cache_path(name)
+    if os.path.isfile(dst) and os.path.getsize(dst) > 0:
+        return dst
+    os.makedirs(CACHE, exist_ok=True)
+    print(f"pulling {name} from {spec['url']} …", file=sys.stderr)
+    raw = urllib.request.urlopen(spec["url"], timeout=120).read()
+    if spec.get("gz"):
+        raw = gzip.GzipFile(fileobj=io.BytesIO(raw)).read()
+    with open(dst, "wb") as f:
+        f.write(raw)
+    n = sum(1 for _ in open(dst))
+    print(f"cached {name}: {n} lines → {dst}", file=sys.stderr)
+    return dst
+
+
+def resolve(name):
+    """Name → local dataset path (pulling + caching if needed). The one call the matrix uses."""
+    return pull(name)
+
+
+def grader_of(name):
+    return KNOWN.get(name, {}).get("grader", "unknown")
+
+
+def list_():
+    rows = ["| name | grader | tasks | cached | description |", "|---|---|---|---|---|"]
+    for name, s in sorted(KNOWN.items()):
+        if s["kind"] == "local":
+            cached = "in-repo" if os.path.isfile(os.path.join(REPO, s["path"])) else "MISSING"
+        else:
+            cached = "yes" if os.path.isfile(_cache_path(name)) else "no (pull)"
+        rows.append(f"| {name} | {s['grader']} | {s['tasks']} | {cached} | {s['desc']} |")
+    return "\n".join(rows)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: catalog.py {list | pull <name> | resolve <name>}", file=sys.stderr)
+        raise SystemExit(2)
+    cmd = sys.argv[1]
+    if cmd == "list":
+        print(list_())
+    elif cmd in ("pull", "resolve") and len(sys.argv) == 3:
+        print(resolve(sys.argv[2]) if cmd == "resolve" else pull(sys.argv[2]))
+    else:
+        print("usage: catalog.py {list | pull <name> | resolve <name>}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/config.example.json
+++ b/benchmarks/config.example.json
@@ -1,17 +1,15 @@
 {
-  "_comment": "Reproducible benchmark matrix. Copy to config.json and edit. Opponents are EXTERNAL /v1 endpoints you bring up yourself (a local llama-server, unsloth gateway, ollama, cloud API, or an airc node) — never a dependency of ours. 'ours' runs through a live Continuum core. Fill each runner's `published` map with the model's OWN published score for a benchmark (from its model card / paper) to render it next to what we measured identically.",
-
+  "_comment": "Reproducible benchmark matrix. Copy to config.json and edit. Opponents are EXTERNAL /v1 endpoints you bring up yourself (a local llama-server, unsloth gateway, ollama, cloud API, or an airc node) \u2014 never a dependency of ours. 'ours' runs through a live Continuum core. Fill each runner's `published` map with the model's OWN published score for a benchmark (from its model card / paper) to render it next to what we measured identically.",
   "benchmarks": [
     {
       "name": "humaneval-rs",
-      "gym": "docs/genome/humaneval-rs.jsonl",
+      "catalog": "humaneval-rs",
       "limit": 40,
       "max_acts": 6,
       "max_retries": 0,
       "timeout": 5400
     }
   ],
-
   "runners": [
     {
       "kind": "ours",

--- a/benchmarks/matrix.py
+++ b/benchmarks/matrix.py
@@ -29,10 +29,20 @@ import argparse, json, os, re, subprocess, sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(HERE)
+sys.path.insert(0, HERE)
+import catalog  # the benchmark catalog — pull/resolve by name, like the model catalog
 
 
 def _resolve(p):
     return p if os.path.isabs(p) else os.path.join(REPO, p)
+
+
+def bench_path(bench):
+    """A benchmark is referenced by `catalog` name (pulled + cached on demand) or an explicit
+    `gym` path. Catalog-by-name is the reproducible default; managed like the model catalog."""
+    if bench.get("catalog"):
+        return catalog.resolve(bench["catalog"])
+    return _resolve(bench["gym"])
 
 
 def run_opponent(r, bench):
@@ -40,7 +50,7 @@ def run_opponent(r, bench):
     cmd = [
         sys.executable, os.path.join(HERE, "coder", "oneshot_opponent.py"),
         "--endpoint", r["endpoint"], "--model", r["model"], "--label", r["label"],
-        "--gym", _resolve(bench["gym"]), "--limit", str(bench.get("limit", 40)),
+        "--gym", bench_path(bench), "--limit", str(bench.get("limit", 40)),
     ]
     if r.get("api_key"):
         cmd += ["--api-key", r["api_key"]]
@@ -54,7 +64,7 @@ def run_opponent(r, bench):
 def run_ours(r, bench):
     """Score a benchmark THROUGH the Continuum core (full system), via cu cognition/eval."""
     cu = r.get("cu", os.path.expanduser("~/.continuum/cache/cargo-target/debug/cu"))
-    gym = _resolve(bench["gym"])
+    gym = bench_path(bench)
     limit = bench.get("limit", 40)
     slice_path = f"/tmp/mtx_{os.getpid()}_{bench['name']}.jsonl"
     with open(gym) as f, open(slice_path, "w") as o:


### PR DESCRIPTION
Joel: benchmarks are large managed artifacts too — catalogue them, pull on demand, resolve by name; public and
reproducible so the world replicates us exactly; later persona-callable as competitions.

- benchmarks/catalog.py — a declarative registry (KNOWN: name → source, grader, tasks), mirroring the model
  catalog: list what's known + cached, pull (download + cache to ~/.continuum/benchmarks/, gz-aware, fail-loud) the
  big ones on demand, resolve a name → local path. Seeded with humaneval-rs (in-repo), humaneval + mbpp (pull).
  Each entry carries its `grader` (rust today; python/others as it grows). Add a respected collection (SWE-bench,
  LiveCodeBench, …) = ONE entry — big datasets cache like a model, never bloat the repo.
- matrix.py now references a benchmark by `catalog` name (pulled/cached on demand) or an explicit gym path.
- README documents list/pull/resolve and the "one entry to add a collection" contract.

The reproducible measurement system now scales across a variety of known benchmark collections, managed — not
hand-wired. A future Rust benchmark/* command wraps the SAME registry so a persona can run a competition by name.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
