### PR TITLE
feat(catalog): model size ladder (0.5B/1.5B/3B coders + general) + more benchmark collections

### DIFF
--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -66,6 +66,22 @@ pub fn known_benchmarks() -> &'static [BenchmarkSpec] {
             eval_set: None,
             source_url: Some("https://raw.githubusercontent.com/google-research/google-research/master/mbpp/mbpp.jsonl"),
         },
+        BenchmarkSpec {
+            name: "livecodebench",
+            description: "LiveCodeBench — contamination-free competitive-programming problems, refreshed over time.",
+            grader: Grader::Python,
+            tasks: 500,
+            eval_set: None,
+            source_url: Some("https://huggingface.co/datasets/livecodebench/code_generation_lite"),
+        },
+        BenchmarkSpec {
+            name: "swe-bench-lite",
+            description: "SWE-bench Lite — real GitHub issues + repos; a solution is a patch that makes the repo's tests pass. The agentic gold standard; grader is a repo test harness.",
+            grader: Grader::Python,
+            tasks: 300,
+            eval_set: None,
+            source_url: Some("https://huggingface.co/datasets/princeton-nlp/SWE-bench_Lite"),
+        },
     ]
 }
 

--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -435,6 +435,72 @@ pub fn models() -> Vec<Model> {
             stop_sequences: &["<|im_end|>", "<|endoftext|>"],
             ..ModelSpec::default()
         }),
+        // The Qwen2.5-Coder SIZE LADDER — 0.5B / 1.5B / 3B, so a weak box serves what it can and
+        // we can chart small→large on the same benchmark (what a MacBook — or a Pi — gets away
+        // with). plan_serving still picks the largest that FITS, so these only serve where the
+        // 14B/32B won't. Same Qwen2 arch + ChatML template; tiny GGUFs (~0.4–2 GB Q4_K_M).
+        model(ModelSpec {
+            id: "continuum-ai/qwen2.5-coder-3b-instruct-GGUF",
+            name: "Qwen2.5-Coder-3B-Instruct",
+            provider: "llama-server",
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 8192,
+            tokens_per_second: 45.0,
+            capabilities: &[Capability::TextGeneration, Capability::Chat, Capability::ToolUse, Capability::Streaming],
+            gguf_hint: Some("huggingface.co/bartowski/Qwen2.5-Coder-3B-Instruct-GGUF"),
+            chat_template: Some(QWEN35_CHAT_TEMPLATE),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            stop_sequences: &["<|im_end|>", "<|endoftext|>"],
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "continuum-ai/qwen2.5-coder-1.5b-instruct-GGUF",
+            name: "Qwen2.5-Coder-1.5B-Instruct",
+            provider: "llama-server",
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 8192,
+            tokens_per_second: 70.0,
+            capabilities: &[Capability::TextGeneration, Capability::Chat, Capability::ToolUse, Capability::Streaming],
+            gguf_hint: Some("huggingface.co/bartowski/Qwen2.5-Coder-1.5B-Instruct-GGUF"),
+            chat_template: Some(QWEN35_CHAT_TEMPLATE),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            stop_sequences: &["<|im_end|>", "<|endoftext|>"],
+            ..ModelSpec::default()
+        }),
+        model(ModelSpec {
+            id: "continuum-ai/qwen2.5-coder-0.5b-instruct-GGUF",
+            name: "Qwen2.5-Coder-0.5B-Instruct",
+            provider: "llama-server",
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 8192,
+            tokens_per_second: 110.0,
+            capabilities: &[Capability::TextGeneration, Capability::Chat, Capability::ToolUse, Capability::Streaming],
+            gguf_hint: Some("huggingface.co/bartowski/Qwen2.5-Coder-0.5B-Instruct-GGUF"),
+            chat_template: Some(QWEN35_CHAT_TEMPLATE),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            stop_sequences: &["<|im_end|>", "<|endoftext|>"],
+            ..ModelSpec::default()
+        }),
+        // A GENERAL (non-coder) model for the CATEGORY axis — same size class as a coder, so a
+        // chart shows specialist-vs-generalist at equal size (the model-fit thesis, measured).
+        model(ModelSpec {
+            id: "continuum-ai/qwen2.5-3b-instruct-GGUF",
+            name: "Qwen2.5-3B-Instruct (general)",
+            provider: "llama-server",
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 8192,
+            tokens_per_second: 45.0,
+            capabilities: &[Capability::TextGeneration, Capability::Chat, Capability::ToolUse, Capability::Streaming],
+            gguf_hint: Some("huggingface.co/bartowski/Qwen2.5-3B-Instruct-GGUF"),
+            chat_template: Some(QWEN35_CHAT_TEMPLATE),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            stop_sequences: &["<|im_end|>", "<|endoftext|>"],
+            ..ModelSpec::default()
+        }),
         // NOTE: benchmark OPPONENTS (Hermes, unsloth, cloud models) are DELIBERATELY absent
         // from this catalog — we never depend on either, ever. They are scored as external,
         // optional /v1 endpoints by the standalone harness in `benchmarks/coder/`, which


### PR DESCRIPTION
Populate both axes of the board so we can chart across sizes AND categories, repeatably.

MODELS — the Qwen2.5-Coder size ladder (0.5B / 1.5B / 3B) + a same-size GENERAL model (Qwen2.5-3B-Instruct):
- size axis: chart small→large on one benchmark — what a weak box (or a Pi) gets away with. plan_serving still
  picks the largest that FITS, so these only ever serve where the 14B/32B won't; a laptop serves what it can.
- category axis: coder-vs-generalist at equal size proves the model-fit thesis with a number, not a claim.
- all Qwen2 arch + ChatML; tiny GGUFs (~0.4–2 GB Q4_K_M), fast to pull.

BENCHMARKS — added livecodebench (contamination-free competitive) + swe-bench-lite (real GitHub issues, the
agentic gold standard) to the catalog alongside humaneval/mbpp. Catalogued + pullable now; runnable as their
graders land (humaneval-rs is the runnable rust-graded one today).

Compiles clean. Next: pull the ladder, chart small→large + coder-vs-general on humaneval-rs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
