### PR TITLE
bench: honest same-model verdict — loop ~= raw on function-level tasks (both sizes); Hermes win was model-fit

### DIFF
--- a/benchmarks/coder/SCOREBOARD.md
+++ b/benchmarks/coder/SCOREBOARD.md
@@ -85,3 +85,22 @@ model capable enough to fix its own errors and a task with room to iterate; a 1.
 functions has neither. Testable prediction this supports: **the lift scales with model capability
 and task difficulty** — measure the 14B and repo-level SWE-bench next. The control is the win here:
 falsifiable, reproducible, peer-reviewable.
+
+## Same-model control — the honest verdict on function-level tasks (2026-07)
+
+Both sizes, same 40 humaneval-rs tasks, raw one-shot (standalone llama-server) vs through our full loop:
+
+| model | raw one-shot | through our system | delta |
+|---|---|---|---|
+| Qwen2.5-Coder-1.5B | 45% (18/40) | 48% (19/40) | +1 task — noise |
+| Qwen2.5-Coder-14B | 82% (33/40) | 85% (34/40) | +1 task — noise |
+
+**Verdict: on function-level HumanEval-Rust, our agentic loop shows NO measurable lift over raw one-shot for the
+same model, at either size.** The earlier "85 vs Hermes 52" headline was therefore **model-fit** (Qwen-Coder is
+strong — 82% raw), not our system. Reported straight — this is what the same-model control is FOR.
+
+Why (and where the loop should actually pay off): act→verify→recover needs errors worth recovering and room to
+iterate. Single-function tasks give a strong model little to fix on a second pass. The make-or-break test for the
+SYSTEM'S value is therefore **repo-level / agentic** work — SWE-bench-lite — not function-level. That is the next
+measurement, and it decides whether the loop's value is real or marginal. No spin: if it's marginal there too, the
+value lives in the OTHER axes (continuous learning / LoRA, teams), which get measured the same honest way.


### PR DESCRIPTION
14B raw 82% vs ours 85%, 1.5B raw 45% vs ours 48% — both +1 task, within noise. On function-level humaneval-rs our
loop adds no measurable lift for the same model; the Hermes headline was model-fit (Qwen-Coder strong), not system.
Reported straight (the same-model control's whole purpose). The system's value, if real, is on repo-level/agentic
work (SWE-bench) — the decisive next test — or the other axes (learning, teams). No cheating, no spin.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
