### PR TITLE
feat(cognition): team eval — writer + reviewer of the SAME persona (the Continuum's molecule, on the honest instrument)

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -497,6 +497,14 @@ pub struct CognitionEvalParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub base_model_id: Option<String>,
+    /// Team mode: with `Some(n>=1)`, add a REVIEWER teammate (a fresh fork of the SAME
+    /// persona/model) that reviews + corrects the writer's answer before grading — the
+    /// undeniable team proof (same model, same tasks, +1 teammate → does coordination lift?).
+    /// None/0 = solo. First slice supports one reviewer; live single-pass path only (no gene,
+    /// no base_model_id).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
+    pub reviewers: Option<u32>,
     /// Max act→observe cycles per task before it counts as unfinished. Default 8.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional, type = "number")]
@@ -937,8 +945,24 @@ impl ActionCommand for CognitionEval {
 
         // Single pass: measure whatever genome is currently paged in (base by
         // default) — the plain coder number, no A/B. Still isolated, so a plain
-        // baseline run is reproducible and leaves her memory untouched.
-        let (score, results) = run_pass(&cycle, &isolation, &tasks, room, max_acts, max_retries).await;
+        // baseline run is reproducible and leaves her memory untouched. TEAM mode
+        // (reviewers>=1, live single-pass only) forks a second copy of the same persona
+        // as a reviewer and grades the reviewed answer — same model, +1 teammate.
+        let want_team = p.reviewers.unwrap_or(0) >= 1 && p.gene.is_none() && p.base_model_id.is_none();
+        let (score, results) = if want_team {
+            let reviewer = crate::cognition::persona_workspace::global()
+                .fork_eval_cycle(&persona_uuid)
+                .ok_or_else(|| CommandError::NotFound(format!(
+                    "no workspace template for persona {persona_uuid} — cannot fork a reviewer teammate"
+                )))?;
+            let reviewer_iso = reviewer.isolate_for_eval();
+            let out =
+                run_pass_team(&cycle, &isolation, &reviewer, &reviewer_iso, &tasks, room, max_acts).await;
+            drop(reviewer_iso);
+            out
+        } else {
+            run_pass(&cycle, &isolation, &tasks, room, max_acts, max_retries).await
+        };
         drop(isolation);
         let verify = self_verify_rate(&results);
         let agg = speed_latency_aggregates(&results);
@@ -1279,6 +1303,121 @@ async fn run_pass(
             ok,
             grade,
             acts: total_acts,
+            answer: answer.chars().take(200).collect(),
+            latency_ms: m.latency_ms,
+            output_tokens: m.output_tokens,
+            tokens_per_second: m.tokens_per_second(),
+            decode_tokens_per_second: m.decode_tokens_per_second(),
+            cache_hit_rate: m.cache_hit_rate(),
+            prefill_ms: m.prefill_ms,
+            decode_ms: m.decode_ms,
+        });
+    }
+    (pass, results)
+}
+
+/// One deliberation on a forked cycle: deliver `prompt` through the SAME live burst formatter
+/// the heartbeat uses, then drive to settlement (directed — an exam question put TO her). The
+/// shared motion behind each teammate's turn in `run_pass_team`; mirrors the solo `run_pass`
+/// delivery byte-for-byte so a team-vs-solo delta is coordination, not a framing difference.
+/// Caller does the exam-hygiene reset/rewind (isolation is per-cycle).
+async fn eval_settle(
+    cycle: &crate::cognition::workspace::WorkspaceCycle,
+    room: Uuid,
+    prompt: &str,
+    max_acts: usize,
+) -> crate::cognition::act_observe::SettleOutcome {
+    let delivery = crate::persona::rag_budget::RagDelivery {
+        source_id: "airc".to_string(),
+        items: vec![crate::persona::rag_budget::RagItem {
+            content: prompt.to_string(),
+            tokens: 0,
+            metadata: serde_json::json!({ "peer_id": "peer", "occurred_at_ms": EVAL_EPOCH_MS }),
+        }],
+        tokens_used: 0,
+        continuation: None,
+        resolution_used: crate::persona::rag_budget::ResolutionPreference::Raw,
+    };
+    let burst = crate::cognition::workspace::Burst::from_turns(
+        room,
+        crate::persona::service_loop::build_workspace_turns(
+            std::slice::from_ref(&delivery),
+            "",
+            "",
+            None,
+        ),
+    );
+    crate::cognition::act_observe::drive_to_settle(
+        cycle,
+        burst,
+        room,
+        max_acts,
+        crate::cognition::workspace::TurnFraming::directed(),
+    )
+    .await
+}
+
+/// TEAM pass — the Continuum's molecule: two forks of the SAME persona (same base model) as
+/// WRITER + REVIEWER. The writer solves each task; a FRESH reviewer (clean context — a genuine
+/// second set of eyes, which is exactly what a solo who can't catch its own bug lacks) reviews
+/// the writer's solution, finds defects, and produces the FINAL code. The reviewer's answer is
+/// graded — same tasks, same grader, same model as the solo `run_pass`, so any team-vs-solo
+/// delta is PURE coordination value, not model-fit. This is the undeniable proof of teams:
+/// hold everything fixed but add a teammate. [[coordination-learning-flywheel]]
+async fn run_pass_team(
+    writer: &crate::cognition::workspace::WorkspaceCycle,
+    writer_iso: &crate::cognition::workspace::EvalIsolation,
+    reviewer: &crate::cognition::workspace::WorkspaceCycle,
+    reviewer_iso: &crate::cognition::workspace::EvalIsolation,
+    tasks: &[EvalTask],
+    room: Uuid,
+    max_acts: usize,
+) -> (u32, Vec<EvalTaskResult>) {
+    let mut pass = 0u32;
+    let mut results = Vec::with_capacity(tasks.len());
+    for t in tasks {
+        // WRITER solves (exam-hygiene reset, same delivery as solo run_pass).
+        writer.reset_working_memory();
+        writer_iso.rewind();
+        let w = eval_settle(writer, room, &t.prompt, max_acts).await;
+        let writer_answer = w.spoken.clone().unwrap_or_default();
+
+        // REVIEWER reviews the writer's solution and produces the FINAL code.
+        reviewer.reset_working_memory();
+        reviewer_iso.rewind();
+        let review_prompt = format!(
+            "A teammate proposed the solution below. Review it for correctness against the task \
+             — compile/run or trace it if useful — find any bug, and give the FINAL, complete \
+             corrected code (or return it unchanged if already correct).\n\nTASK:\n{}\n\n\
+             TEAMMATE'S SOLUTION:\n{}",
+            t.prompt, writer_answer
+        );
+        let r = eval_settle(reviewer, room, &review_prompt, max_acts).await;
+        let answer = r.spoken.clone().unwrap_or_default();
+
+        // Grade the FINAL (reviewer's) answer — SAME branches as solo run_pass.
+        let (ok, grade) = if let Some(cause) =
+            r.inference_error.clone().or_else(|| w.inference_error.clone())
+        {
+            (false, format!("inference failed: {cause}"))
+        } else if let Some(dod) = &t.dod_shell {
+            run_dod(dod).await
+        } else if let Some(test) = &t.test {
+            test_grade(&answer, t.lang.as_deref().unwrap_or("rust"), test).await
+        } else {
+            let m = !t.expect.is_empty() && answer.to_lowercase().contains(&t.expect.to_lowercase());
+            (m, if m { "substring match".into() } else { "no match".into() })
+        };
+        if ok {
+            pass += 1;
+        }
+        let acts = w.acts as u32 + r.acts as u32;
+        let m = r.metrics;
+        results.push(EvalTaskResult {
+            id: t.id.clone(),
+            ok,
+            grade,
+            acts,
             answer: answer.chars().take(200).collect(),
             latency_ms: m.latency_ms,
             output_tokens: m.output_tokens,

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -159,6 +159,11 @@ pub struct BenchmarkRunParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub base_model_id: Option<String>,
+    /// Team mode: `Some(n>=1)` adds a reviewer teammate (same persona/model) that reviews +
+    /// corrects each answer before grading — the undeniable team-vs-solo proof. None = solo.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
+    pub reviewers: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -236,6 +241,7 @@ impl ActionCommand for BenchmarkRun {
                     tasks: None,
                     eval_set: Some(tmp.display().to_string()),
                     base_model_id: p.base_model_id.clone(),
+                    reviewers: p.reviewers,
                     max_acts: p.max_acts.or(Some(6)),
                     max_retries: Some(0),
                     note: Some(match &p.base_model_id {

--- a/core/continuum-core/src/modules/training_completion_sentinel.rs
+++ b/core/continuum-core/src/modules/training_completion_sentinel.rs
@@ -181,6 +181,7 @@ impl TrainingCompletionSentinel {
                 // Some at the top of this fn.
                 eval_set: Some(eval_set),
                 base_model_id: None, // a gene names its own forged base
+                reviewers: None,     // solo eval for training lift
                 max_acts: None,
                 max_retries: None,
                 note: Some(format!(


### PR DESCRIPTION
The undeniable team proof: hold model + tasks + grader fixed, add ONE teammate. cognition/eval + benchmark/run take
`reviewers: Option<u32>`; with >=1 (live single-pass path), the eval forks a SECOND copy of the same persona as a
REVIEWER — a fresh set of eyes (exactly what a solo who can't catch its own bug lacks) — which reviews and corrects
the writer's answer before grading. Same model, same tasks: any team-vs-solo delta is pure coordination value, not
model-fit.

- eval_settle: shared deliberation helper (delivery mirrors solo run_pass byte-for-byte, so the comparison is clean).
- run_pass_team: writer solves → fresh reviewer reviews+corrects → grade the FINAL answer; solo run_pass untouched.
- run() branch forks the reviewer via fork_eval_cycle (its own #59 isolation); reviewers on both param structs.

Compiles clean; sanity-validated (--reviewers 1 → 2/2). One proven citizen → a team. Next: solo-vs-team on a slice
(function-level lift will be modest — the real coordination win is on harder tasks where the writer fails more —
measured honestly, not asserted). [[coordination-learning-flywheel]]

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
