### PR TITLE
feat(ipc): #85 abort in-flight handlers when the client disconnects — kill zombie commands

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -309,6 +309,13 @@ fn handle_client<S: IpcStream>(
         }
     });
 
+    // #85: track in-flight command tasks for THIS connection so we can abort them if the
+    // client disconnects mid-flight — a blocking handler with no one left to answer would
+    // otherwise run to completion writing into a dead socket (a zombie). Detached #86 jobs
+    // spawn on their OWN task inside the handler, so the command task tracked here has already
+    // returned for them — fire-and-poll is never aborted, only abandoned blocking requests are.
+    let mut inflight: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+
     // Reader loop — parse requests and dispatch to tokio for concurrent processing.
     // No longer blocks waiting for handle_request() to complete before reading next request.
     for line in reader.lines() {
@@ -352,7 +359,9 @@ fn handle_client<S: IpcStream>(
         let tx = tx.clone();
         let caller = caller.clone();
         let rt_handle = state.rt_handle.clone();
-        rt_handle.spawn(async move {
+        // Reap already-finished handles so this Vec stays bounded to what's actually in flight.
+        inflight.retain(|h| !h.is_finished());
+        let inflight_handle = rt_handle.spawn(async move {
             let handle_result = if let Some(ref cmd) = command {
                 // Boundary gate for a REMOTE (TCP) caller: the route_command path is
                 // owner-by-locality (ungated) for the local Unix socket, so a remote
@@ -454,6 +463,23 @@ fn handle_client<S: IpcStream>(
             };
             let _ = tx.send((request_id, handle_result));
         });
+        inflight.push(inflight_handle);
+    }
+
+    // #85: the reader hit EOF — the client is gone. Abort any handler still running for this
+    // connection (aborting an already-finished task is a harmless no-op). Fire-and-poll (#86)
+    // jobs are untouched: their command task already returned the handle, so nothing here holds
+    // them — only an abandoned BLOCKING request is cancelled, freeing its lane and CPU.
+    let aborted = inflight.iter().filter(|h| !h.is_finished()).count();
+    for h in &inflight {
+        h.abort();
+    }
+    if aborted > 0 {
+        log_debug!(
+            "ipc",
+            "server",
+            "aborted {aborted} in-flight handler(s) for disconnected client: {peer_addr}"
+        );
     }
 
     // Drop sender to signal writer thread to exit, then wait for it


### PR DESCRIPTION
Each IPC request is `rt_handle.spawn`'d detached and its JoinHandle dropped, so when the client disconnects
mid-flight the handler kept running to completion — writing its answer into a dead socket. A long blocking
command (a 60s ai/generate, a data scan) with no one left to answer is a zombie holding a lane + CPU.

Fix: the per-connection reader now tracks its spawned command handles (reaping finished ones so the Vec stays
bounded to what's actually in flight) and, on reader EOF (client gone), aborts any still-running handler —
aborting an already-finished task is a harmless no-op.

Composes with #86 by construction: a detached fire-and-poll job runs on its OWN `tokio::spawn` INSIDE the
handler, so the command task tracked here has already returned the job handle — there is nothing to abort for it.
Only abandoned BLOCKING requests are cancelled; long-running detached jobs survive the client leaving. Together
#85+#86 make a multi-hour acting eval both survivable (detach) and non-zombie-ing (abort the abandoned blocking case).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
