### PR TITLE
feat(cognition): forage-before-you-guess — make the working web hand a HABIT, not just an available tool

### DIFF
--- a/core/continuum-core/src/cognition/deliberation_prompt.rs
+++ b/core/continuum-core/src/cognition/deliberation_prompt.rs
@@ -187,7 +187,13 @@ const ACTING_BLOCK: &str = "\n[Acting]\n\
      \"I'd rather not create or execute files\": this IS your workspace and \
      these ARE your hands — declining to use them, or delegating the work to \
      the asker, is the SAME mistake as claiming you can't, and the fix is the \
-     same: just call the tool.";
+     same: just call the tool. \
+     And when you hit a library, an API, an error message, or a fact you are \
+     not sure of, do NOT guess from memory — SEARCH the web (`web/search`) and \
+     READ the page (`web/fetch`), the way a developer actually works. Your \
+     training has a cutoff; the web does not. Foraging for what you don't know \
+     and then writing from what you found beats confidently shipping something \
+     wrong.";
 
 /// `[Your own time]` — the self-initiated free-time block. When this turn is the
 /// never-stop heartbeat pursuing her own thread (no inbound message drove it), say so


### PR DESCRIPTION
The web tools now return real results (PR #1943), but a working tool she never reaches for is worthless. Her
acting doctrine (`ACTING_BLOCK`) told her to write/run/read — but said nothing about the web, so she'd guess a
library's API from a stale training memory instead of looking it up. That's exactly how a local model loses to
a real dev workflow.

Fix: one sentence in the acting doctrine — when she hits a library, API, error, or fact she's unsure of, SEARCH
(`web/search`) and READ (`web/fetch`) the way a developer actually works; her training has a cutoff, the web
doesn't; foraging then writing from what she found beats confidently shipping something wrong. Doctrine/PX, not
output-steering — it names when the hand is for, same voice as the rest of the block.

This is the edge canned agents don't have on real projects: she learns the current tool instead of hallucinating
last year's API. [[active-acquisition-foraging]] [[px-persona-experience-tools-as-good-ux]]

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
