### PR TITLE
bench(swe): SWE-bench runner — spine validated (gold RESOLVED, hermetic filter); workspace-root seam is the one open bug

### DIFF
--- a/benchmarks/swe/run_ours.py
+++ b/benchmarks/swe/run_ours.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+run_ours.py — the Continuum SWE-bench runner (EDGE benchmark harness; scoring rides the
+official `swebench` Docker harness, the persona side rides `cu` into the Rust core).
+
+Per instance: clone repo @ base_commit → the SOLVER edits the working tree → `git diff` is the
+model_patch → write predictions.jsonl → score with the official harness (the industry yardstick).
+
+Solvers (apples-to-apples, same instances, same scorer):
+  --solver gold     apply the dataset's gold patch (SPINE CHECK — must resolve; validates our
+                    clone→edit→diff→predictions path before we trust any real solver's number)
+  --solver ours     point a Continuum persona's hands at the clone (create-workspace) and run
+                    her cognition on the problem_statement  [wired next]
+"""
+import argparse, json, os, subprocess, sys, tempfile, urllib.request
+
+def hf_instance(dataset, iid):
+    # scan the dataset in pages for the instance (datasets-server caps length=100)
+    for off in range(0, 400, 100):
+        url = (f"https://datasets-server.huggingface.co/rows?dataset={urllib.parse.quote(dataset,safe='')}"
+               f"&config=default&split=test&offset={off}&length=100")
+        rows = json.load(urllib.request.urlopen(url, timeout=30)).get("rows", [])
+        for r in rows:
+            if r["row"]["instance_id"] == iid:
+                return r["row"]
+    raise SystemExit(f"instance {iid} not found in {dataset}")
+
+def sh(cmd, cwd=None, check=True):
+    r = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if check and r.returncode != 0:
+        raise SystemExit(f"cmd failed: {' '.join(cmd)}\n{r.stdout}\n{r.stderr}")
+    return r
+
+def clone_at(repo, base_commit, dest):
+    sh(["git", "clone", f"https://github.com/{repo}.git", dest])
+    sh(["git", "checkout", "-q", base_commit], cwd=dest)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", default="princeton-nlp/SWE-bench_Lite")
+    ap.add_argument("--instance", required=True)
+    ap.add_argument("--solver", choices=["gold", "ours"], default="gold")
+    ap.add_argument("--workdir", default=None)
+    args = ap.parse_args()
+
+    inst = hf_instance(args.dataset, args.instance)
+    wd = args.workdir or tempfile.mkdtemp(prefix="swe-ours-")
+    repo_dir = os.path.join(wd, "repo")
+    print(f"[clone] {inst['repo']} @ {inst['base_commit'][:10]} -> {repo_dir}")
+    clone_at(inst["repo"], inst["base_commit"], repo_dir)
+
+    if args.solver == "gold":
+        # simulate a CORRECT solver edit by applying the gold patch to the working tree
+        p = os.path.join(wd, "gold.patch"); open(p, "w").write(inst["patch"])
+        sh(["git", "apply", p], cwd=repo_dir)
+    else:
+        # OURS: point a Continuum persona at the clone and run her cognition on the issue.
+        # She opens the repo herself via create-workspace (the proven hinge), reads, edits.
+        # Grading is EXTERNAL (the git diff → official harness), so the eval's own dod is a
+        # no-op; we only need her to ACT on the working tree.
+        import time
+        CU=os.path.expanduser("~/.continuum/cache/cargo-target/debug/cu")
+        ASHA="90e758b2-3cf3-45c1-b100-de7c4ab5a549"
+        note=f"swe-{args.instance}"
+        task={"id":args.instance,
+              "prompt":(f"You are fixing a real bug in a cloned git repository located at `{repo_dir}`. "
+                        f"FIRST call `code/create-workspace` with workspace_root=\"{repo_dir}\" to open it. "
+                        f"Then use code/read and code/search to find the relevant source, and code/edit or "
+                        f"code/write to fix it IN PLACE. Do not create new top-level files; edit the existing "
+                        f"source. Compile/run checks with code/shell if useful. When done, the working tree "
+                        f"should contain your fix.\n\nISSUE:\n{inst['problem_statement']}"),
+              "dod_shell":"true","lang":"rust"}
+        tf=os.path.join(wd,"task.jsonl"); open(tf,"w").write(json.dumps(task)+"\n")
+        led=os.path.expanduser(f"~/.continuum/progress/{ASHA}.jsonl")
+        n0=sum(1 for _ in open(led)) if os.path.exists(led) else 0
+        print(f"[ours] dispatching persona on {args.instance} (detached, max_acts=25)")
+        sh([CU,"cognition/eval","--persona_id",ASHA,"--eval_set",tf,"--max_acts","25","--note",note,"--detach","true"],check=False)
+        # poll the ledger for this run to land (she is editing the clone in the background)
+        for _ in range(40):
+            time.sleep(30)
+            if os.path.exists(led):
+                rows=[json.loads(l) for l in open(led) if l.strip()]
+                if any(r.get("note")==note for r in rows[n0:]): print("[ours] persona run landed"); break
+        else:
+            print("[ours] WARN: run did not land in ledger window (may still be editing)")
+
+    # the model_patch is whatever the solver changed in the working tree
+    diff = sh(["git", "diff"], cwd=repo_dir).stdout
+    print(f"[diff] {len(diff)} bytes changed")
+    preds = os.path.join(wd, "preds.jsonl")
+    open(preds, "w").write(json.dumps({
+        "instance_id": args.instance,
+        "model_patch": diff,
+        "model_name_or_path": f"continuum-{args.solver}",
+    }) + "\n")
+    print(f"[preds] {preds}")
+    print(f"NEXT: score with the official harness:\n  python -m swebench.harness.run_evaluation "
+          f"--dataset_name {args.dataset} --predictions_path {preds} --max_workers 1 "
+          f"--run_id ours-{args.solver} --instance_ids {args.instance}")
+    print(preds)  # last line = preds path for the caller
+
+if __name__ == "__main__":
+    import urllib.parse
+    main()


### PR DESCRIPTION
The Continuum SWE-bench runner: per instance clone @ base_commit → solver edits the working tree → git diff is
the model_patch → score with the OFFICIAL swebench Docker harness (the industry yardstick, proven on this Mac).

VALIDATED (green, stacked):
- scorer: official harness runs locally; gold control RESOLVED (astropy-12907, flask-4045).
- spine: our clone→edit→diff→predictions path scores gold RESOLVED on a hermetic instance (flask-4045).
- hermetic filter: the requests-2317 detour taught it — that instance's tests hit httpbin.org over the network,
  so even the GOLD patch scores 0 in a sandboxed container. Fix = only benchmark instances where gold resolves
  locally, so every downstream 0 is a REAL solver miss, not an environment artifact. (Glass-box, not guess.)

OPEN BUG (the one thing between here and our first real number): `--solver ours` dispatches the persona but she
produced a 0-byte diff — glass-boxed to the workspace root: her file engine defaults to the core cwd (the
continuum repo), NOT the clone, and the "she calls create-workspace herself" prompt didn't reliably re-root the
eval-fork's engine. Confirmed the mechanism exists (`code/create-workspace` OVERWRITES the caller's engine, keyed
by her peer-id). FIX = a deterministic `workspace_root` on the solve path that roots her engine at the target repo
before her cycle (the #49 seam; also needed for a persona to work on a user's real project). Then git diff is real.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
