### PR TITLE
feat(eval): workspace-root seam (#49) — deterministically root a persona's hands at a target repo before her cycle

### DIFF
--- a/benchmarks/swe/run_ours.py
+++ b/benchmarks/swe/run_ours.py
@@ -55,7 +55,10 @@ def main():
         sh(["git", "apply", p], cwd=repo_dir)
     else:
         # OURS: point a Continuum persona at the clone and run her cognition on the issue.
-        # She opens the repo herself via create-workspace (the proven hinge), reads, edits.
+        # Her file engine is rooted at the clone DETERMINISTICALLY by cognition/eval's
+        # --workspace_root seam (#49) — it invokes code/create-workspace through her own
+        # identity-bearing executor before her cycle, so we no longer rely on the MODEL
+        # choosing to call create-workspace itself (that was the 0-byte-diff failure mode).
         # Grading is EXTERNAL (the git diff → official harness), so the eval's own dod is a
         # no-op; we only need her to ACT on the working tree.
         import time
@@ -63,18 +66,18 @@ def main():
         ASHA="90e758b2-3cf3-45c1-b100-de7c4ab5a549"
         note=f"swe-{args.instance}"
         task={"id":args.instance,
-              "prompt":(f"You are fixing a real bug in a cloned git repository located at `{repo_dir}`. "
-                        f"FIRST call `code/create-workspace` with workspace_root=\"{repo_dir}\" to open it. "
-                        f"Then use code/read and code/search to find the relevant source, and code/edit or "
-                        f"code/write to fix it IN PLACE. Do not create new top-level files; edit the existing "
-                        f"source. Compile/run checks with code/shell if useful. When done, the working tree "
-                        f"should contain your fix.\n\nISSUE:\n{inst['problem_statement']}"),
+              "prompt":(f"You are fixing a real bug in a git repository. Your workspace is ALREADY rooted at "
+                        f"the repo — just use your tools on it directly. Use code/search and code/read to find "
+                        f"the relevant source, and code/edit to fix it IN PLACE (do NOT create new top-level "
+                        f"files; edit the existing source). Run checks with code/shell if useful. When done, the "
+                        f"working tree should contain your fix.\n\nISSUE:\n{inst['problem_statement']}"),
               "dod_shell":"true","lang":"rust"}
         tf=os.path.join(wd,"task.jsonl"); open(tf,"w").write(json.dumps(task)+"\n")
         led=os.path.expanduser(f"~/.continuum/progress/{ASHA}.jsonl")
         n0=sum(1 for _ in open(led)) if os.path.exists(led) else 0
-        print(f"[ours] dispatching persona on {args.instance} (detached, max_acts=25)")
-        sh([CU,"cognition/eval","--persona_id",ASHA,"--eval_set",tf,"--max_acts","25","--note",note,"--detach","true"],check=False)
+        print(f"[ours] dispatching persona on {args.instance} (workspace rooted at clone, detached, max_acts=25)")
+        sh([CU,"cognition/eval","--persona_id",ASHA,"--eval_set",tf,"--workspace_root",repo_dir,
+            "--max_acts","25","--note",note,"--detach","true"],check=False)
         # poll the ledger for this run to land (she is editing the clone in the background)
         for _ in range(40):
             time.sleep(30)

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -540,6 +540,14 @@ pub struct CognitionEvalParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub detach: Option<bool>,
+    /// Repo-work seam (#49): pin the persona's file engine at this directory (e.g. a SWE-bench
+    /// target-repo clone) BEFORE her cycle, by invoking `code/create-workspace` through HER OWN
+    /// identity-bearing executor. Deterministic rooting — no reliance on the model choosing to
+    /// call create-workspace itself. `None` → she uses the default root (core cwd) exactly as
+    /// before, so this is opt-in with zero change to every existing eval path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub workspace_root: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -902,6 +910,63 @@ impl CognitionEval {
                         .to_string(),
                 ));
             }
+        }
+
+        // WORKSPACE-ROOT SEAM (#49) — if the caller pinned a workspace_root (SWE-bench: the target
+        // repo clone), root the persona's file engine THERE before any task runs, by invoking
+        // code/create-workspace through HER OWN identity-bearing executor. create-workspace keys on
+        // the caller identity (not a spoofable param), so this reroots the eval-fork's hands at the
+        // repo — her subsequent edits land in the clone, not the core cwd. Deterministic: no reliance
+        // on the model choosing to call create-workspace itself. Fail LOUD if requested but unroutable
+        // — a silent no-root scores a false ZERO (0-byte diff) that would LIE about the solver
+        // ([[fallbacks-are-illegal-fail-loud]]).
+        if let Some(root) = &p.workspace_root {
+            let acting = cycle.acting().ok_or_else(|| {
+                CommandError::Internal(
+                    "workspace_root requested but this eval cycle has no acting body (no hands) — \
+                     cannot root a workspace for a pure-cognition persona"
+                        .to_string(),
+                )
+            })?;
+            let ws_ctx = crate::cognition::tool_executor::ToolExecutionContext {
+                persona_id: acting.persona_id,
+                persona_name: acting.persona_name.clone(),
+                session_id: Uuid::new_v4(),
+                context_id: Uuid::new_v4(),
+                caller_context: serde_json::Value::Null,
+                persona_config: crate::cognition::tool_executor::PersonaMediaConfigLite {
+                    auto_load_media: false,
+                    supported_media_types: vec![],
+                },
+            };
+            let ws_call = crate::ai::types::ToolCall {
+                id: "eval-workspace-root".to_string(),
+                name: "code/create-workspace".to_string(),
+                input: serde_json::json!({ "workspace_root": root }),
+            };
+            let ws_out = acting
+                .executor
+                .execute_native_batch(std::slice::from_ref(&ws_call), &ws_ctx, 8000)
+                .await
+                .map_err(|e| {
+                    CommandError::Internal(format!("failed to root eval workspace at '{root}': {e}"))
+                })?;
+            if let Some(r) = ws_out.results.first() {
+                if r.is_error.is_some() {
+                    return Err(CommandError::Internal(format!(
+                        "code/create-workspace rejected workspace_root '{root}': {} — refusing to \
+                         run the eval with the persona's hands rooted at the wrong directory (would \
+                         score a false zero).",
+                        r.content
+                    )));
+                }
+            }
+            crate::probe!(
+                class = "eval.workspace.rooted",
+                persona = %acting.persona_name,
+                root = %root,
+                "eval persona's file engine rooted at the target repo before her cycle"
+            );
         }
 
         let max_acts = p.max_acts.unwrap_or(DEFAULT_MAX_ACTS) as usize;

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -250,6 +250,7 @@ impl ActionCommand for BenchmarkRun {
                     detach: p.detach,
                     max_acts: p.max_acts.or(Some(6)),
                     max_retries: Some(0),
+                    workspace_root: None,
                     note: Some(match &p.base_model_id {
                         Some(m) => format!("benchmark/run {} on {m}", spec.name),
                         None => format!("benchmark/run {}", spec.name),

--- a/core/continuum-core/src/modules/training_completion_sentinel.rs
+++ b/core/continuum-core/src/modules/training_completion_sentinel.rs
@@ -185,6 +185,7 @@ impl TrainingCompletionSentinel {
                 detach: None,
                 max_acts: None,
                 max_retries: None,
+                workspace_root: None,
                 note: Some(format!(
                     "L3 auto-eval (gene={}, base={}, provider={})",
                     job.trait_kind, job.base_model, job.handle.provider_id


### PR DESCRIPTION
The last gate on the Hermes-beating SWE-bench matrix. `--solver ours` produced a 0-byte diff because the
eval-fork persona's file engine defaulted to the core cwd (std::env::current_dir()), and the "she calls
create-workspace herself" prompt didn't reliably reroot it — a false ZERO that lied about the solver.

Fix (opt-in, regression-safe): `CognitionEvalParams.workspace_root: Option<String>` (None → unchanged for every
existing path). When set, cognition/eval runs `code/create-workspace` through the persona's OWN identity-bearing
executor (cycle.acting().executor) BEFORE her cycle. create-workspace keys on caller identity, so this reroots
the fork's hands at the repo — her edits land in the clone, deterministically, with NO reliance on the model
choosing to call create-workspace itself. Fails LOUD if requested-but-unroutable (a silent no-root would score a
false zero). Mirrors load_harness's exact tool/ctx/execute_native_batch pattern.

VALIDATED live: eval with --workspace_root <clone> + a "write SEAM_PROOF.txt" task → the file landed IN THE CLONE
(content "ROOTED"), NOT the core cwd. Her hands now sit exactly where Claude-as-agent sat when solving flask-4045
by hand → RESOLVED. run_ours.py updated to pass --workspace_root (drops the model-self-call directive).

This unblocks the local-model × {ours,opencode,raw} × SWE-bench matrix — the actual "can we beat Hermes" number.
[[fallbacks-are-illegal-fail-loud]] [[eval-mutates-persona-lift-needs-isolation]]

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
