### PR TITLE
feat(eval): capture_dir glass-box — wrap the eval-fork in JsonlWorkspaceCaptureSink so a MEASURED run is readable

### DIFF
--- a/benchmarks/swe/run_ours.py
+++ b/benchmarks/swe/run_ours.py
@@ -75,9 +75,10 @@ def main():
         tf=os.path.join(wd,"task.jsonl"); open(tf,"w").write(json.dumps(task)+"\n")
         led=os.path.expanduser(f"~/.continuum/progress/{ASHA}.jsonl")
         n0=sum(1 for _ in open(led)) if os.path.exists(led) else 0
-        print(f"[ours] dispatching persona on {args.instance} (workspace rooted at clone, detached, max_acts=25)")
+        cap=os.path.join(wd,"capture")  # glass-box: her per-tick bids+DECISION land in <cap>/<persona>.jsonl
+        print(f"[ours] dispatching persona on {args.instance} (workspace rooted at clone, capture→{cap}, detached, max_acts=25)")
         sh([CU,"cognition/eval","--persona_id",ASHA,"--eval_set",tf,"--workspace_root",repo_dir,
-            "--max_acts","25","--note",note,"--detach","true"],check=False)
+            "--capture_dir",cap,"--max_acts","25","--note",note,"--detach","true"],check=False)
         # poll the ledger for this run to land (she is editing the clone in the background)
         for _ in range(40):
             time.sleep(30)

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -548,6 +548,14 @@ pub struct CognitionEvalParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub workspace_root: Option<String>,
+    /// Glass-box seam (task #14): if set, wrap the eval-fork's cognition in the JSONL
+    /// [`JsonlWorkspaceCaptureSink`] so every tick's bids + DECISION + timings land in
+    /// `<capture_dir>/<persona_id>.jsonl` — makes a MEASURED run inspectable (did she Act or
+    /// Respond? which tool? why 0 edits?) without touching her live mind. `None` → Noop capture
+    /// exactly as before. Opt-in: zero change to every existing eval path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub capture_dir: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -852,6 +860,24 @@ impl CognitionEval {
                 .ok_or_else(|| CommandError::NotFound(format!(
                     "no workspace template for persona {persona_uuid} — its mind was not assembled at spawn (register_from_cfg), so eval cannot fork a measurement copy without measuring her live mind"
                 )))?,
+        };
+
+        // GLASS-BOX (task #14): if a capture_dir is pinned, wrap the fork's cognition in the
+        // JSONL capture sink so every tick's bids + DECISION + timings append to
+        // <dir>/<persona>.jsonl. This is what makes a MEASURED run inspectable — reading the
+        // `decision` field tells us whether she chose Act (and which tool) or Respond, which is
+        // exactly the fork needed to diagnose a 0-edit. Fork-only, never her live mind. Opt-in.
+        let cycle = match &p.capture_dir {
+            Some(dir) => cycle.with_capture(std::sync::Arc::new(
+                crate::cognition::workspace_capture::JsonlWorkspaceCaptureSink::open(
+                    std::path::Path::new(dir),
+                    persona_uuid,
+                )
+                .map_err(|e| {
+                    CommandError::Internal(format!("failed to open eval capture_dir '{dir}': {e}"))
+                })?,
+            )),
+            None => cycle,
         };
 
         // WARM-GATE — never measure a COLD model. A just-loaded or just-swapped lane 500s

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -251,6 +251,7 @@ impl ActionCommand for BenchmarkRun {
                     max_acts: p.max_acts.or(Some(6)),
                     max_retries: Some(0),
                     workspace_root: None,
+                    capture_dir: None,
                     note: Some(match &p.base_model_id {
                         Some(m) => format!("benchmark/run {} on {m}", spec.name),
                         None => format!("benchmark/run {}", spec.name),

--- a/core/continuum-core/src/modules/training_completion_sentinel.rs
+++ b/core/continuum-core/src/modules/training_completion_sentinel.rs
@@ -186,6 +186,7 @@ impl TrainingCompletionSentinel {
                 max_acts: None,
                 max_retries: None,
                 workspace_root: None,
+                capture_dir: None,
                 note: Some(format!(
                     "L3 auto-eval (gene={}, base={}, provider={})",
                     job.trait_kind, job.base_model, job.handle.provider_id


### PR DESCRIPTION
Opt-in `CognitionEvalParams.capture_dir: Option<String>` (None → Noop, zero change to existing paths). When set,
cognition/eval wraps the fork's cognition via `cycle.with_capture(JsonlWorkspaceCaptureSink::open(dir, persona))`
BEFORE the run, so every tick's bids + DECISION + timings append to <dir>/<persona>.jsonl. This is task #14's own
primitive, wired into the measurement path — you can now read WHY a persona scored what she did (did she Act or
Respond? which tool? did deliberation fail?), not just the final number.

VALIDATED live + immediately earned its keep: pointed at a flask SWE run, it revealed the real cause of the
persona's 0-byte diff — ALL 15 deliberation ticks failed with the local llama-server returning 500 "Compute error"
(confirmed by a direct `say hi` probe → HTTP 500). Not exam-framing, not tools, not the model — a broken local
inference lane. The 0-edit read itself off the trace in one line. run_ours.py now passes --capture_dir.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
