### PR TITLE
fix(deploy): #194 freshness guard — trustworthy 'core ready' + airc-room mirror glass-box (#193)

### DIFF
--- a/core/continuum-core/src/modules/live.rs
+++ b/core/continuum-core/src/modules/live.rs
@@ -100,6 +100,24 @@ impl ServiceModule for VoiceModule {
                 let room_id = p.str("room_id")?;
                 let participants: Vec<VoiceParticipant> = p.json_or("participants");
 
+                // GLASS-BOX the mirror-room stink (#193): a voice session/call must BE the airc
+                // room. Today the LiveKit call is keyed by a client-minted `session_id`
+                // (`call_id = session_id` below), a room authority PARALLEL to airc. Surface any
+                // divergence LOUD so the collapse — the client passing `session_id == room_id` so
+                // the call IS the airc room — is observable by this warning going SILENT. Zero
+                // behaviour change; a pure diagnostic until the client-coordinated cutover lands
+                // ([[all-rooms-are-airc-rooms-no-mirrors]], [[livekit-media-plane-rides-airc-not-parallel]]).
+                if session_id != room_id {
+                    tracing::warn!(
+                        probe_class = "airc.room.mirror.voice_session_diverges",
+                        session_id = %session_id,
+                        room_id = %room_id,
+                        "MIRROR ROOM: voice session/call id != airc room id — the LiveKit call is \
+                         keyed by a client-minted session_id, not the airc room_id. Collapse (#193): \
+                         the client must pass session_id == room_id so the call IS the airc room."
+                    );
+                }
+
                 // Idempotency: skip if this session is already registered.
                 // Browser refresh triggers a re-join which calls register-session again.
                 // Without this guard, we spawn duplicate STT listeners and agent batches,

--- a/core/continuum-core/src/modules/live.rs
+++ b/core/continuum-core/src/modules/live.rs
@@ -108,13 +108,14 @@ impl ServiceModule for VoiceModule {
                 // behaviour change; a pure diagnostic until the client-coordinated cutover lands
                 // ([[all-rooms-are-airc-rooms-no-mirrors]], [[livekit-media-plane-rides-airc-not-parallel]]).
                 if session_id != room_id {
-                    tracing::warn!(
-                        probe_class = "airc.room.mirror.voice_session_diverges",
-                        session_id = %session_id,
-                        room_id = %room_id,
-                        "MIRROR ROOM: voice session/call id != airc room id — the LiveKit call is \
-                         keyed by a client-minted session_id, not the airc room_id. Collapse (#193): \
-                         the client must pass session_id == room_id so the call IS the airc room."
+                    crate::log_warn!(
+                        "module",
+                        "voice_register_session",
+                        "MIRROR ROOM (#193): voice session/call id {} != airc room id {} — the LiveKit \
+                         call is keyed by a client-minted session_id, not the airc room_id. Collapse: \
+                         the client must pass session_id == room_id so the call IS the airc room.",
+                        session_id,
+                        room_id
                     );
                 }
 

--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -256,6 +256,32 @@ echo "▶ building continuum-core-server"
 cargo build --manifest-path "$CORE_MANIFEST" --bin continuum-core-server $PROFILE_FLAG $CONTINUUM_FEATURES \
   || { echo "✗ FATAL: continuum-core-server build failed — leaving the running core untouched" >&2; exit 1; }
 
+# ── #194 FRESHNESS GUARD: never launch (or report "ready" on) a STALE binary ──
+# cargo's incremental fingerprint can MISS a source edit (mtime granularity, an
+# editor writing a non-advancing mtime, or a prior `cargo check` updating the
+# fingerprint without codegen) and emit a no-op "Finished" that leaves the OLD
+# continuum-core-server on disk. The deploy then reports "core ready" while stale
+# code runs — the verify-the-build-actually-deployed trap (observed 2026-07-18:
+# a committed one-line change never shipped; every headless live validation lied).
+# Assert the invariant DIRECTLY: the built binary must be at least as new as every
+# tracked source. If a source is newer, cargo missed it — bust the fingerprint by
+# touching the crate src and rebuild ONCE; if STILL stale, FAIL LOUD rather than
+# launch a lie. [[verify-the-build-actually-deployed]], [[fallbacks-are-illegal-fail-loud]].
+CORE_SRC_DIR="$(dirname "$CORE_MANIFEST")/src"
+CORE_BIN="$CARGO_TARGET_DIR/$PROFILE_LABEL/continuum-core-server"
+core_bin_is_stale() { [ -f "$CORE_BIN" ] && [ -n "$(find "$CORE_SRC_DIR" -name '*.rs' -type f -newer "$CORE_BIN" 2>/dev/null | head -1)" ]; }
+if core_bin_is_stale; then
+  echo "⚠ #194: continuum-core-server is STALE (a source is newer than the binary) — cargo missed an edit; busting fingerprint + rebuilding" >&2
+  find "$CORE_SRC_DIR" -name '*.rs' -type f -exec touch {} +
+  cargo build --manifest-path "$CORE_MANIFEST" --bin continuum-core-server $PROFILE_FLAG $CONTINUUM_FEATURES \
+    || { echo "✗ FATAL #194: forced rebuild failed — leaving the running core untouched" >&2; exit 1; }
+  if core_bin_is_stale; then
+    echo "✗ FATAL #194: continuum-core-server STILL stale after a forced rebuild — refusing to launch old code (verify-the-build-actually-deployed)" >&2
+    exit 1
+  fi
+  echo "✓ #194: forced a fresh continuum-core-server rebuild — binary now reflects source"
+fi
+
 # Now the new binary is ready: stop the old core (if any) and take the socket.
 stop_existing_core
 
@@ -266,4 +292,8 @@ echo "  socket:   $CONTINUUM_SOCKET"
 echo "  airc:     room=${AIRC_DEFAULT_ROOM_NAME:-?} channel=${AIRC_DEFAULT_CHANNEL:-?}"
 echo ""
 
-exec cargo run --manifest-path "$CORE_MANIFEST" --bin continuum-core-server $PROFILE_FLAG $CONTINUUM_FEATURES -- "$CONTINUUM_SOCKET"
+# Run the EXACT binary the freshness guard (#194) just verified — NOT `cargo run`,
+# which re-runs cargo's build logic at launch and could second-guess (or re-stale)
+# what we already verified. We built it, we checked it reflects source, we run it.
+# Unambiguous: the process image is the verified $CORE_BIN. [[verify-the-build-actually-deployed]]
+exec "$CORE_BIN" "$CONTINUUM_SOCKET"


### PR DESCRIPTION
## The headline fix: #194 — deploy could ship stale code and report success

Observed live 2026-07-18: a committed one-line change **never shipped** across multiple `cu reboot`s. `cargo`'s incremental fingerprint missed the edit (mtime granularity / a prior `cargo check` updating the fingerprint without codegen), emitted a no-op `Finished in 0.36s`, and `start-server.sh` launched the **old binary** while reporting `✅ core ready`. Every headless live validation then lied — the verify-the-build-actually-deployed trap.

**Two fragility removals in `tools/scripts/start-server.sh`:**
1. **Freshness guard** after the core-server build — asserts the built binary is at least as new as every tracked `.rs` source (`find -newer`, checked directly, not trusted from cargo's `Finished`). If a source is newer, cargo missed it → touch the crate src to bust the fingerprint + rebuild once → re-verify → **FAIL LOUD** rather than launch stale. Detection validated (fires on the exact bug condition; passes when fresh); recovery proven manually.
2. **Launch the exact verified binary** (`exec "$CORE_BIN"`) instead of `exec cargo run`, which re-runs cargo's build logic at launch and could second-guess / re-stale what we just verified. We built it, checked it, run it.

This makes `core ready` mean the running code **is** the source — the precondition for *any* trustworthy headless live validation (#192/#193/#190).

## Groundwork: #193 airc-room mirror glass-box (diagnostic, WIP)

The audit found the voice/call stack is a room authority **parallel** to airc (`call_server`/`VoiceOrchestrator` key by a client-minted `session_id`, discarding the airc `room_id`). Live-confirmed on the running core: `orchestrator: Registered session <session_id>` while `room_id` was discarded on divergent registrations. This PR adds a `voice/register-session` divergence warn (`session_id != room_id`) as the instrument for the eventual collapse — **honest status: the warn's own live-fire is not yet confirmed** (log-category routing detail); the mirror itself is confirmed independently by the orchestrator's existing logs. The actual collapse (`session_id == call_id == room_id`) is the follow-up arc.

Refs #194, #193. `[[verify-the-build-actually-deployed]]`, `[[all-rooms-are-airc-rooms-no-mirrors]]`, `[[fallbacks-are-illegal-fail-loud]]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)