### PR TITLE
feat(media): perception substrate — non-blocking read twins + PerceptionBuffer (airc-keyed, room-as-now)

### DIFF
--- a/core/continuum-core/src/media/frame.rs
+++ b/core/continuum-core/src/media/frame.rs
@@ -132,6 +132,32 @@ impl MediaFrame {
             })
             .await
     }
+
+    /// NON-BLOCKING read of an already-warmed scaled cell — the read-side twin of
+    /// [`scaled`] (which WARMS async). Returns `Some(Arc<Result<..>>)` ONLY if the
+    /// `(crop, dest)` derivative has ALREADY resolved on `compute`; `None` if it hasn't
+    /// been computed yet. This is how live perception stays alive: a persona takes what's
+    /// ready NOW and the rest bridges in on a later tick — it NEVER awaits a cell
+    /// ([[command-async-shape-prefer-stream-never-block]]). Warm with `scaled`/`prefetch`
+    /// (fire-and-forget in a spawned task); read here.
+    pub fn scaled_if_ready(
+        &self,
+        compute: &SharedCompute,
+        crop: Option<CropRect>,
+        dest: DestSize,
+    ) -> Option<Arc<Result<Vec<u8>, String>>> {
+        compute.get::<Result<Vec<u8>, String>>(&self.content_hash, &derivative_key(crop, dest))
+    }
+
+    /// NON-BLOCKING read of the already-warmed description cell — the read-side twin of
+    /// [`description`]. `Some` only if the describe cell has resolved; `None` otherwise.
+    /// Same "take what's ready, never wait" contract as [`scaled_if_ready`].
+    pub fn description_if_ready(
+        &self,
+        compute: &SharedCompute,
+    ) -> Option<Arc<Result<String, String>>> {
+        compute.get::<Result<String, String>>(&self.content_hash, DESCRIBE_KEY)
+    }
 }
 
 /// sha256-hex of `bytes` — the content address (same hashing spill/vision use).
@@ -304,6 +330,38 @@ mod tests {
         let frame = MediaFrame::from_bytes(png(8, 8));
         let d = frame.description(&compute, &FailingDescriber, "image/png").await;
         assert_eq!(d.as_ref().as_ref().unwrap_err(), "vision model unavailable");
+    }
+
+    // what this catches: THE non-blocking-read contract — a cell reads None BEFORE it's
+    // warmed (perception takes what's ready, never waits), and after warming the _if_ready
+    // read returns the SAME cached Arc (zero-copy, no recompute). How live perception stays
+    // alive: fire the warm, read what's ready NOW, the rest bridges in later.
+    #[tokio::test]
+    async fn ready_reads_are_none_until_warmed_then_share_the_cell() {
+        let compute = SharedCompute::new();
+        let frame = MediaFrame::from_bytes(png(50, 40));
+        let dest = DestSize { width: 20, height: 16 };
+        let describer = CountingDescriber {
+            calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+
+        // Cold: nothing warmed → non-blocking reads see nothing (absent this tick).
+        assert!(frame.scaled_if_ready(&compute, None, dest).is_none(), "scaled cold → None");
+        assert!(frame.description_if_ready(&compute).is_none(), "describe cold → None");
+
+        // Warm the cells (the async fire; in the PerceptionBuffer this is a spawned task).
+        let warmed_scaled = frame.scaled(&compute, None, dest).await;
+        let warmed_desc = frame.description(&compute, &describer, "image/png").await;
+
+        // Non-blocking reads now return the SAME cached Arc — ready, zero-copy.
+        let read_scaled = frame.scaled_if_ready(&compute, None, dest).expect("scaled ready");
+        let read_desc = frame.description_if_ready(&compute).expect("describe ready");
+        assert!(Arc::ptr_eq(&read_scaled, &warmed_scaled), "ready read shares the warmed cell");
+        assert!(Arc::ptr_eq(&read_desc, &warmed_desc), "ready read shares the warmed cell");
+        // A DIFFERENT spec is still cold — reads only what was actually warmed.
+        assert!(frame
+            .scaled_if_ready(&compute, None, DestSize { width: 8, height: 8 })
+            .is_none());
     }
 
     // what this catches: two SEPARATE frame handles to the SAME content share the

--- a/core/continuum-core/src/media/mod.rs
+++ b/core/continuum-core/src/media/mod.rs
@@ -26,7 +26,9 @@
 
 pub mod frame;
 pub mod image_ops;
+pub mod perception_buffer;
 pub mod projection;
 
 pub use frame::{FrameDescriber, MediaFrame};
+pub use perception_buffer::{ParticipantId, Percept, PerceptionBuffer};
 pub use projection::{project_image, MediaResolution, ProjectedMedia};

--- a/core/continuum-core/src/media/perception_buffer.rs
+++ b/core/continuum-core/src/media/perception_buffer.rs
@@ -1,0 +1,228 @@
+//! `PerceptionBuffer` — the non-blocking, room-as-NOW hold for live-call perception.
+//!
+//! One LATEST frame per participant (coalesced — a newer frame REPLACES the old; never a
+//! backlog, [[perceive-the-room-as-it-is-now]]). Ingest FIRES the ambient cell warms async
+//! and returns immediately; reads return ONLY the cells resolved so far via the
+//! `MediaFrame::*_if_ready` twins — the persona NEVER waits, a pending cell is simply absent
+//! this tick and bridges in the next ([[command-async-shape-prefer-stream-never-block]]).
+//!
+//! Keyed by the **airc participant identity** (the room roster), NOT a parallel call-scoped
+//! id: the call IS an airc room, LiveKit is only the media plane
+//! ([[all-rooms-are-airc-rooms-no-mirrors]], [[livekit-media-plane-rides-airc-not-parallel]],
+//! [[placement-first-four-repos-then-adapters-boy-scout]]).
+//!
+//! This is the buffer under the (next) `MediaPerceptionSource: RagSource`, which delivers
+//! these percepts under the flexbox RAG budget so perception never dominates context
+//! ([[perception-feedback-must-not-blow-rag]]).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use super::frame::{FrameDescriber, MediaFrame};
+use super::image_ops::DestSize;
+use crate::runtime::SharedCompute;
+
+/// The airc participant identity (peer id) a frame belongs to. Never a parallel
+/// call/session id — the room roster is the truth.
+pub type ParticipantId = String;
+
+/// What a persona perceives of ONE participant RIGHT NOW — only the cells that have
+/// RESOLVED. Each field holds the cache's `Arc` (zero-copy); `None` = not-ready-this-tick
+/// (present the next); `Some(Err(..))` = the cell resolved to a surfaced failure, never a
+/// silent placeholder ([[fallbacks-are-illegal-fail-loud]]).
+#[derive(Clone, Debug)]
+pub struct Percept {
+    pub participant: ParticipantId,
+    pub content_hash: String,
+    /// The ambient thumbnail cell (PNG bytes), if resolved.
+    pub thumbnail: Option<Arc<Result<Vec<u8>, String>>>,
+    /// The description cell (the sensory-bridge text), if resolved.
+    pub description: Option<Arc<Result<String, String>>>,
+}
+
+impl Percept {
+    /// Whether this participant has ANY resolved cell to perceive yet (else it's a known
+    /// presence with nothing rendered this tick).
+    pub fn has_any(&self) -> bool {
+        self.thumbnail.is_some() || self.description.is_some()
+    }
+}
+
+/// Non-blocking, room-as-now perception hold. One latest frame per airc participant; cells
+/// warm async on the shared cache; reads take only what's ready.
+pub struct PerceptionBuffer {
+    latest: Mutex<HashMap<ParticipantId, MediaFrame>>,
+    /// The ambient forced-look size (~480w default) — the cheap thumbnail cell every tick
+    /// warms + reads. Full-res / bigger is the drill-in tool, not the ambient path.
+    ambient: DestSize,
+}
+
+impl PerceptionBuffer {
+    pub fn new(ambient: DestSize) -> Self {
+        Self {
+            latest: Mutex::new(HashMap::new()),
+            ambient,
+        }
+    }
+
+    /// Ingest a frame for `participant`: COALESCE to the latest (room-as-now — a newer frame
+    /// replaces the old), then FIRE the ambient cell warms (thumbnail + description) on a
+    /// spawned task and return IMMEDIATELY. Non-blocking — the ingest path never awaits the
+    /// cells. Must be called within a tokio runtime (the live LiveKit ingest path always is).
+    pub fn observe(
+        &self,
+        participant: ParticipantId,
+        frame: MediaFrame,
+        compute: Arc<SharedCompute>,
+        describer: Arc<dyn FrameDescriber>,
+        mime: &str,
+    ) {
+        // Coalesce: the latest frame per participant wins; the old one is dropped.
+        self.latest
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(participant, frame.clone());
+
+        // Fire-and-forget the ambient cells async — compute-once per content-hash, shared to
+        // every viewer; a re-observe of the same bytes is a cache hit (no recompute).
+        let ambient = self.ambient;
+        let mime = mime.to_string();
+        tokio::spawn(async move {
+            let _ = frame.scaled(&compute, None, ambient).await; // warm ~480w thumbnail
+            let _ = frame.description(&compute, describer.as_ref(), &mime).await; // warm describe
+        });
+    }
+
+    /// The perception of the room AS IT IS NOW — one `Percept` per participant, each carrying
+    /// only the cells RESOLVED so far (non-blocking reads via the `_if_ready` twins). NEVER
+    /// awaits; a still-warming cell is simply `None` this tick.
+    pub fn current_percepts(&self, compute: &SharedCompute) -> Vec<Percept> {
+        self.latest
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .map(|(pid, frame)| Percept {
+                participant: pid.clone(),
+                content_hash: frame.content_hash().to_string(),
+                thumbnail: frame.scaled_if_ready(compute, None, self.ambient),
+                description: frame.description_if_ready(compute),
+            })
+            .collect()
+    }
+
+    /// Drop a participant that left the call.
+    pub fn remove(&self, participant: &str) {
+        self.latest
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(participant);
+    }
+
+    /// Number of participants currently held (for probes/tests).
+    pub fn len(&self) -> usize {
+        self.latest.lock().unwrap_or_else(|e| e.into_inner()).len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
+    use std::io::Cursor;
+
+    fn png(w: u32, h: u32) -> Vec<u8> {
+        let img = RgbaImage::from_fn(w, h, |x, _| {
+            if x < w / 2 {
+                Rgba([255, 0, 0, 255])
+            } else {
+                Rgba([0, 0, 255, 255])
+            }
+        });
+        let mut out = Cursor::new(Vec::new());
+        DynamicImage::ImageRgba8(img)
+            .write_to(&mut out, ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    struct StubDescriber;
+    #[async_trait]
+    impl FrameDescriber for StubDescriber {
+        async fn describe(&self, source: &[u8], mime: &str) -> Result<String, String> {
+            Ok(format!("{mime} image, {} bytes", source.len()))
+        }
+    }
+
+    const AMBIENT: DestSize = DestSize { width: 32, height: 24 };
+
+    // what this catches: COALESCE — a newer frame for the same participant REPLACES the old
+    // (room-as-now, no backlog). Two observes of the same participant leave ONE percept,
+    // carrying the LATEST content hash.
+    #[tokio::test]
+    async fn observe_coalesces_to_the_latest_frame_per_participant() {
+        let buffer = PerceptionBuffer::new(AMBIENT);
+        let compute = Arc::new(SharedCompute::new());
+        let describer: Arc<dyn FrameDescriber> = Arc::new(StubDescriber);
+
+        let old = MediaFrame::from_bytes(png(40, 40));
+        let new = MediaFrame::from_bytes(png(60, 40)); // different bytes → different hash
+        buffer.observe("alice".into(), old.clone(), compute.clone(), describer.clone(), "image/png");
+        buffer.observe("alice".into(), new.clone(), compute.clone(), describer.clone(), "image/png");
+        buffer.observe("bob".into(), MediaFrame::from_bytes(png(20, 20)), compute.clone(), describer.clone(), "image/png");
+
+        assert_eq!(buffer.len(), 2, "alice coalesced, bob separate → 2 participants");
+        let percepts = buffer.current_percepts(&compute);
+        let alice = percepts.iter().find(|p| p.participant == "alice").unwrap();
+        assert_eq!(alice.content_hash, new.content_hash(), "alice holds the LATEST frame");
+    }
+
+    // what this catches: NON-BLOCKING read semantics — before a cell is warmed the percept
+    // carries None (perception takes what's ready, doesn't wait); once the same content-hash
+    // cell is resolved on the shared compute, current_percepts surfaces it as Some. Proves the
+    // buffer reads via the _if_ready twins, not a blocking recompute.
+    #[tokio::test]
+    async fn current_percepts_surface_cells_only_once_resolved() {
+        let buffer = PerceptionBuffer::new(AMBIENT);
+        let compute = Arc::new(SharedCompute::new());
+        let describer: Arc<dyn FrameDescriber> = Arc::new(StubDescriber);
+        let frame = MediaFrame::from_bytes(png(50, 40));
+
+        // Store WITHOUT warming: read the percept before any cell resolves → all None.
+        buffer.latest.lock().unwrap().insert("alice".into(), frame.clone());
+        let before = &buffer.current_percepts(&compute)[0];
+        assert!(before.thumbnail.is_none() && before.description.is_none(), "cold → nothing rendered");
+        assert!(!before.has_any());
+
+        // Resolve the cells on the SHARED compute (deterministic; in prod the observe spawn
+        // does this async). Now the non-blocking read surfaces them.
+        frame.scaled(&compute, None, AMBIENT).await;
+        frame.description(&compute, &StubDescriber, "image/png").await;
+        let after = &buffer.current_percepts(&compute)[0];
+        assert!(after.thumbnail.is_some(), "thumbnail now ready");
+        assert!(after.description.is_some(), "description now ready");
+        assert_eq!(
+            image::load_from_memory(after.thumbnail.as_ref().unwrap().as_ref().as_ref().unwrap())
+                .unwrap()
+                .width(),
+            AMBIENT.width,
+            "the ready thumbnail is the ambient size"
+        );
+    }
+
+    // what this catches: remove drops a participant who left the call.
+    #[tokio::test]
+    async fn remove_drops_a_participant() {
+        let buffer = PerceptionBuffer::new(AMBIENT);
+        let compute = Arc::new(SharedCompute::new());
+        let describer: Arc<dyn FrameDescriber> = Arc::new(StubDescriber);
+        buffer.observe("alice".into(), MediaFrame::from_bytes(png(10, 10)), compute, describer, "image/png");
+        assert_eq!(buffer.len(), 1);
+        buffer.remove("alice");
+        assert!(buffer.is_empty());
+    }
+}

--- a/core/continuum-core/src/persona/media_perception_source.rs
+++ b/core/continuum-core/src/persona/media_perception_source.rs
@@ -1,0 +1,249 @@
+//! `MediaPerceptionSource` — the live-call perception [`RagSource`].
+//!
+//! Wraps a [`PerceptionBuffer`] and delivers the room AS IT IS NOW — who is visible + a
+//! description of what they show — as budgeted [`RagItem`]s. Two disciplines, together:
+//! - **NON-BLOCKING**: reads only the cells RESOLVED so far (`current_percepts` → the
+//!   `MediaFrame::*_if_ready` twins). A still-warming participant is simply absent this
+//!   delivery, present the next — the turn NEVER waits ([[command-async-shape-prefer-stream-never-block]]).
+//! - **BUDGETED**: perception must NOT dominate. It competes for context with
+//!   engram/airc/roster through the ONE flexbox allocator, stopping when its allotment is
+//!   spent ([[perception-feedback-must-not-blow-rag]], [[budget-at-assembly-not-clamp-the-prompt]]).
+//!
+//! Delivers the TEXT percept (description grounding, available to ANY model). The
+//! thumbnail image for a native-vision persona rides the separate render seam (#190) off
+//! the SAME cached cells — one describe/scale per frame, shared. Room-as-now, not a
+//! backlog ([[perceive-the-room-as-it-is-now]]); never paginated.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::rag_budget::{
+    ContinuationCursor, RagContext, RagDelivery, RagItem, RagSource, ResolutionPreference,
+};
+use crate::cognition::token_budget::estimate_prompt_tokens as estimate_tokens;
+use crate::media::{Percept, PerceptionBuffer};
+use crate::runtime::SharedCompute;
+
+const SOURCE_ID: &str = "media-perception";
+
+/// A persona's live-call visual perception, delivered as budgeted RAG grounding.
+pub struct MediaPerceptionSource {
+    persona_id: uuid::Uuid,
+    /// The room-as-now frame hold (one latest frame per airc participant).
+    buffer: Arc<PerceptionBuffer>,
+    /// The ONE runtime shared cache the cells resolve on (read-only here).
+    compute: Arc<SharedCompute>,
+}
+
+impl MediaPerceptionSource {
+    pub fn new(
+        persona_id: uuid::Uuid,
+        buffer: Arc<PerceptionBuffer>,
+        compute: Arc<SharedCompute>,
+    ) -> Self {
+        Self {
+            persona_id,
+            buffer,
+            compute,
+        }
+    }
+
+    /// One RESOLVED percept → a grounding [`RagItem`]. `None` when nothing has resolved for
+    /// this participant yet — non-blocking: absent this delivery, present the next as its
+    /// cells land. A failed cell (`Err`) is treated as not-yet (never a fabricated line).
+    fn make_item(p: &Percept) -> Option<RagItem> {
+        let has_ok_thumbnail = matches!(p.thumbnail.as_deref(), Some(Ok(_)));
+        let content = match p.description.as_deref() {
+            Some(Ok(desc)) if !desc.trim().is_empty() => {
+                format!("[seeing {}] {desc}", short(&p.participant))
+            }
+            _ if has_ok_thumbnail => format!(
+                "[seeing {}] visible on the call — description still resolving",
+                short(&p.participant)
+            ),
+            _ => return None,
+        };
+        let tokens = estimate_tokens(&content);
+        Some(RagItem {
+            content,
+            tokens,
+            metadata: serde_json::json!({
+                "participant": p.participant,
+                "content_hash": p.content_hash,
+            }),
+        })
+    }
+}
+
+/// First 8 chars of an id for the grounding line (airc peer ids are long; the description
+/// carries the "who/what"). The full id rides in item metadata for provenance.
+fn short(id: &str) -> &str {
+    &id[..8.min(id.len())]
+}
+
+fn empty_delivery() -> RagDelivery {
+    RagDelivery {
+        source_id: SOURCE_ID.to_string(),
+        items: Vec::new(),
+        tokens_used: 0,
+        continuation: None,
+        resolution_used: ResolutionPreference::Placeholder,
+    }
+}
+
+#[async_trait]
+impl RagSource for MediaPerceptionSource {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    async fn deliver(
+        &self,
+        ctx: &RagContext,
+        budget: u32,
+        resolution: ResolutionPreference,
+    ) -> RagDelivery {
+        // Persona-scoped: a cross-persona ctx gets nothing (defense in depth, same shape as
+        // the roster/airc sources).
+        if ctx.persona_id != self.persona_id {
+            return empty_delivery();
+        }
+
+        // NON-BLOCKING read of the room as it is NOW — only cells resolved this tick.
+        let percepts = self.buffer.current_percepts(&self.compute);
+        let mut items: Vec<RagItem> = Vec::new();
+        let mut tokens_used: u32 = 0;
+        for p in &percepts {
+            let Some(item) = Self::make_item(p) else {
+                continue;
+            };
+            // BUDGET: perception must NOT dominate — stop when the allotment is spent.
+            // A truncated view is still truthful for the participants it names.
+            if tokens_used.saturating_add(item.tokens) > budget {
+                break;
+            }
+            tokens_used += item.tokens;
+            items.push(item);
+        }
+
+        RagDelivery {
+            source_id: SOURCE_ID.to_string(),
+            items,
+            tokens_used,
+            // Room-as-now, not a paginated history.
+            continuation: None,
+            resolution_used: resolution,
+        }
+    }
+
+    async fn deliver_continuation(
+        &self,
+        _ctx: &RagContext,
+        _cursor: ContinuationCursor,
+        _budget: u32,
+    ) -> Option<RagDelivery> {
+        // Live perception is the CURRENT tail, not a backlog — no pagination.
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::frame::{FrameDescriber, MediaFrame};
+    use crate::media::image_ops::DestSize;
+    use async_trait::async_trait;
+    use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
+    use std::io::Cursor;
+    use uuid::Uuid;
+
+    const AMBIENT: DestSize = DestSize { width: 32, height: 24 };
+
+    fn png(w: u32, h: u32) -> Vec<u8> {
+        let img = RgbaImage::from_fn(w, h, |x, _| {
+            if x < w / 2 {
+                Rgba([255, 0, 0, 255])
+            } else {
+                Rgba([0, 0, 255, 255])
+            }
+        });
+        let mut out = Cursor::new(Vec::new());
+        DynamicImage::ImageRgba8(img)
+            .write_to(&mut out, ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    struct StubDescriber;
+    #[async_trait]
+    impl FrameDescriber for StubDescriber {
+        async fn describe(&self, source: &[u8], mime: &str) -> Result<String, String> {
+            Ok(format!("a {mime} image of {} bytes", source.len()))
+        }
+    }
+
+    /// Store `alice` with her cells RESOLVED on `compute` (deterministic; in prod the
+    /// observe spawn warms them async). Returns (source, ctx, compute).
+    async fn source_with_resolved_alice(
+        pid: Uuid,
+    ) -> (MediaPerceptionSource, Arc<SharedCompute>) {
+        let compute = Arc::new(SharedCompute::new());
+        let buffer = Arc::new(PerceptionBuffer::new(AMBIENT));
+        let describer: Arc<dyn FrameDescriber> = Arc::new(StubDescriber);
+        let frame = MediaFrame::from_bytes(png(60, 40));
+        frame.scaled(&compute, None, AMBIENT).await;
+        frame.description(&compute, &StubDescriber, "image/png").await;
+        buffer.observe("alice-peer".into(), frame, compute.clone(), describer, "image/png");
+        (
+            MediaPerceptionSource::new(pid, buffer, compute.clone()),
+            compute,
+        )
+    }
+
+    // what this catches: a resolved percept becomes a budgeted "[seeing …] <desc>" grounding
+    // item; wrong persona gets nothing; a zero budget yields nothing (perception must not
+    // dominate). The core deliver contract.
+    #[tokio::test]
+    async fn delivers_resolved_percepts_as_budgeted_grounding() {
+        let pid = Uuid::new_v4();
+        let (src, _compute) = source_with_resolved_alice(pid).await;
+        let ctx = RagContext::for_persona(pid, 0);
+
+        let d = src.deliver(&ctx, 10_000, ResolutionPreference::Raw).await;
+        assert_eq!(d.items.len(), 1, "one resolved participant → one item");
+        assert!(d.items[0].content.contains("seeing"), "grounds who is seen: {}", d.items[0].content);
+        assert!(d.tokens_used > 0);
+        assert!(d.continuation.is_none(), "room-as-now, never paginated");
+
+        // Cross-persona → empty (defense in depth).
+        let other = RagContext::for_persona(Uuid::new_v4(), 0);
+        assert!(src.deliver(&other, 10_000, ResolutionPreference::Raw).await.items.is_empty());
+
+        // Zero budget → nothing (must NOT dominate context).
+        assert!(src.deliver(&ctx, 0, ResolutionPreference::Raw).await.items.is_empty());
+    }
+
+    // what this catches: NON-BLOCKING — a participant whose cells haven't resolved yet is
+    // simply ABSENT from the delivery (the turn never waits on them).
+    #[tokio::test]
+    async fn unresolved_participants_are_absent_not_awaited() {
+        let compute = Arc::new(SharedCompute::new());
+        let buffer = Arc::new(PerceptionBuffer::new(AMBIENT));
+        let pid = Uuid::new_v4();
+        // Store a frame WITHOUT warming its cells → nothing resolved.
+        let frame = MediaFrame::from_bytes(png(20, 20));
+        buffer.observe(
+            "bob-peer".into(),
+            frame,
+            compute.clone(),
+            Arc::new(StubDescriber),
+            "image/png",
+        );
+        // (observe spawns a warm task, but we don't await it — read immediately.)
+        let src = MediaPerceptionSource::new(pid, buffer, compute);
+        let ctx = RagContext::for_persona(pid, 0);
+        let d = src.deliver(&ctx, 10_000, ResolutionPreference::Raw).await;
+        assert!(d.items.is_empty(), "unresolved participant is absent this tick, not awaited");
+    }
+}

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -81,6 +81,7 @@ pub mod active_work_source;
 pub mod recorder;
 pub mod resource_forecast;
 pub mod response;
+pub mod media_perception_source;
 pub mod room_board_source;
 pub mod room_doctrine_source;
 pub mod room_roster_source;


### PR DESCRIPTION
First two components of the LiveKit perception substrate (plan: `docs/planning/LIVEKIT-PERCEPTION-PIPELINE.md`), built async/non-blocking from the start per the command-async-shape discipline.

**#1 — `MediaFrame::{scaled_if_ready, description_if_ready}`**: the read-side twins of the async `scaled()`/`description()` warmers. Warm async (fire), read only what's *already resolved* (`Some`) else `None` — 'take what's ready now, never block' at the substrate level.

**#2 — `PerceptionBuffer`**: one LATEST frame per participant (coalesced, room-as-now, no backlog); `observe()` stores + fires the ambient cell warms (~480w thumbnail + description) on a spawned task, returns immediately (non-blocking ingest); `current_percepts()` reads only resolved cells via the #1 twins. **Keyed by airc participant identity** (call = airc room, LiveKit = media plane only), per placement-first.

10 media tests green (non-blocking read; coalesce-to-latest; cold→None then resolved→Some; remove-on-leave).

**Next:** `MediaPerceptionSource: RagSource` (deliver percepts under the flexbox budget — must not dominate), then the STOP-zone bind into `compose_for_turn`; positron projects the glass-box UI.

Refs #192, #187, #190, #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)