### PR TITLE
feat(vision): #106 serving foundation — mmproj self-provisions + live FrameDescriber

### DIFF
--- a/core/continuum-core/src/cognition/vision_describe.rs
+++ b/core/continuum-core/src/cognition/vision_describe.rs
@@ -338,6 +338,78 @@ pub async fn describe_image(
     }))
 }
 
+/// The live [`FrameDescriber`](crate::media::FrameDescriber) — the sensory bridge that
+/// `media/` promises but cannot implement itself (the layering rule forbids `media/`
+/// from depending on `cognition/`). This is the ONE production implementor: it routes a
+/// frame's bytes through [`describe_image`] (i.e. `ai/generate` on the best available
+/// vision model) and hands back the prose a non-vision persona reads to "see"
+/// ([[perception-feedback-must-not-blow-rag]]).
+///
+/// A [`MediaFrame`](crate::media::MediaFrame) caches the result per content hash, so
+/// wrapping this describer ONCE and pointing every persona's frame at it means the same
+/// image is described a single time and shared — N personas in a call cost one describe
+/// per distinct frame, not N ([[media-is-compute-once-zero-copy-hardware-grade]]).
+pub struct VisionDescribeFramer {
+    executor: std::sync::Arc<crate::runtime::CommandExecutor>,
+    options: VisionDescribeOptions,
+}
+
+impl VisionDescribeFramer {
+    /// Bridge over the given command executor with default describe options
+    /// (concise prose, best available vision model).
+    pub fn new(executor: std::sync::Arc<crate::runtime::CommandExecutor>) -> Self {
+        Self {
+            executor,
+            options: VisionDescribeOptions::default(),
+        }
+    }
+
+    /// Bridge with caller-tuned options (e.g. `detect_objects`, a length cap, or a
+    /// pinned model) applied to every frame this describer handles.
+    pub fn with_options(
+        executor: std::sync::Arc<crate::runtime::CommandExecutor>,
+        options: VisionDescribeOptions,
+    ) -> Self {
+        Self { executor, options }
+    }
+}
+
+/// Encode + shape a frame's raw bytes into a [`VisionDescribeRequest`]. Pulled out as a
+/// pure function so the base64 + option threading is unit-testable without standing up a
+/// `CommandExecutor` or the model registry (the executor IO lives in `describe_image`).
+fn build_frame_request(
+    source: &[u8],
+    mime: &str,
+    options: VisionDescribeOptions,
+) -> VisionDescribeRequest {
+    use base64::Engine;
+    VisionDescribeRequest {
+        base64_data: base64::engine::general_purpose::STANDARD.encode(source),
+        mime_type: mime.to_string(),
+        options,
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::media::FrameDescriber for VisionDescribeFramer {
+    async fn describe(&self, source: &[u8], mime: &str) -> Result<String, String> {
+        let req = build_frame_request(source, mime, self.options.clone());
+        match describe_image(req, &self.executor).await? {
+            Some(desc) => Ok(desc.description),
+            // No vision-capable model resolved (or the model errored / returned empty).
+            // Fail loud — a describe with no real sight must never fabricate a
+            // placeholder a persona would read AS having seen the frame
+            // ([[fallbacks-are-illegal-fail-loud]]). `MediaFrame` caches this `Err` per
+            // content hash, so the gap is surfaced deterministically, not silently
+            // retried per persona.
+            None => Err(format!(
+                "no vision-capable model available to describe this {mime} frame — bring \
+                 up a VL model (or grant a vision provider) before a persona can see it"
+            )),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -346,6 +418,25 @@ mod tests {
     fn build_prompt_default_is_concise() {
         let prompt = build_prompt(&VisionDescribeOptions::default());
         assert_eq!(prompt, "Describe this image concisely.");
+    }
+
+    // what this catches: the live FrameDescriber bridge encodes a frame's raw bytes as
+    // standard base64 and threads the caller's describe options through to the
+    // ai/generate request — the wiring the compute-once description cell depends on to
+    // let a non-vision persona "see". A regression here silently corrupts every frame
+    // the perception pipeline sends for description.
+    #[test]
+    fn build_frame_request_base64_encodes_and_threads_options() {
+        let opts = VisionDescribeOptions {
+            detect_objects: true,
+            max_length: Some(120),
+            ..Default::default()
+        };
+        let req = build_frame_request(b"hello", "image/png", opts);
+        assert_eq!(req.base64_data, "aGVsbG8=", "base64('hello')");
+        assert_eq!(req.mime_type, "image/png");
+        assert!(req.options.detect_objects);
+        assert_eq!(req.options.max_length, Some(120));
     }
 
     #[test]

--- a/core/continuum-core/src/inference/llamacpp_adapter.rs
+++ b/core/continuum-core/src/inference/llamacpp_adapter.rs
@@ -498,17 +498,20 @@ impl LlamaCppAdapter {
         let active_kv = self
             .kv_quant_policy
             .for_residency(crate::inference::kv_quant::Residency::Active);
-        // Pull the multimodal projector path from the registry if this
-        // model declares one. The registry is the source of truth for
-        // per-model configuration (mmproj alongside chat_template,
-        // stop_sequences, capabilities). When set, the backend's
-        // generate_with_image route lazily loads the MtmdContext from it.
-        // When absent, generate_with_image returns a clear error rather
-        // than silently bridging to text — vision-capable callers should
-        // surface that as a config issue, not a degraded experience.
-        let mmproj_path = crate::model_registry::try_global()
-            .and_then(|reg| reg.model(&self.default_model))
-            .and_then(|m| m.mmproj_local_path.clone());
+        // Resolve the multimodal projector via the ONE registry resolver — the
+        // single source of truth for "where is this model's mmproj" (declared
+        // local path first, else the projector sitting beside the GGUF in the
+        // HF cache snapshot, existence-checked). Reading the raw
+        // `mmproj_local_path` field here would miss the self-provisioned sibling
+        // and skip the existence check; `resolve_mmproj_for_model` is what
+        // `llama-server` uses too, so both serving paths agree. When set, the
+        // backend's generate_with_image route lazily loads the MtmdContext from
+        // it; when None, generate_with_image returns a clear error rather than
+        // silently bridging to text — a config issue, not a degraded experience.
+        let mmproj_path = crate::model_registry::try_global().and_then(|reg| {
+            reg.model(&self.default_model)
+                .and_then(crate::model_registry::artifacts::resolve_mmproj_for_model)
+        });
         // CONTINUUM_TIER is set by install.sh's hardware probe (commit
         // 7b3b8e086) — when the install detects a Mac Intel + discrete
         // AMD or integrated Intel UHD host, it exports

--- a/core/continuum-core/src/model_registry/artifacts.rs
+++ b/core/continuum-core/src/model_registry/artifacts.rs
@@ -32,19 +32,51 @@ pub fn resolve_gguf_for_model_id(model_id: &str) -> Option<PathBuf> {
     resolve_gguf(model_id, None, None)
 }
 
-/// Resolve a vision/audio model's multimodal projector (mmproj) GGUF for serving —
-/// expands `~` and VERIFIES the file exists on disk. `None` when the row declares no
-/// projector, or declares one that isn't present.
+/// Resolve a vision/audio model's multimodal projector (mmproj) GGUF for serving.
+/// Two tiers, in order — an explicitly declared path first, then the SAME cache the
+/// GGUF resolves from:
 ///
-/// A VL model needs this to SEE: `llama-server --mmproj <path>` loads the vision
-/// encoder so image content parts are tokenized. Without it the server serves text
-/// but silently ignores images — so the serving spawn treats a Vision-capable row
-/// with no resolvable projector as a LOUD warning (blind, not a fabricated sight),
-/// never a silent capability lie ([[fallbacks-are-illegal-fail-loud]]).
+/// 1. **Declared local path** — the row's `mmproj_local_path`, with `~` expanded, when
+///    it's present on disk. Operator/row placement is honored first.
+/// 2. **Beside the resolved GGUF** — the projector ships in the same `*-GGUF` repo
+///    snapshot as the model (bartowski-style layout: `model-Q4_K_M.gguf` +
+///    `mmproj-model-f16.gguf` side by side). So we resolve the GGUF the normal way
+///    (local root → HF cache) and look for a `*mmproj*.gguf` sibling in its directory.
+///
+/// Tier 2 is what makes vision serving self-provisioning: pulling the model pulls its
+/// projector into the HF cache, and the mmproj resolves from there exactly like the
+/// GGUF does — no hand-placed path, no manual step. This mirrors
+/// [`resolve_gguf_for_model`]; a projector must never require a placement the GGUF
+/// doesn't ([[fallbacks-are-illegal-fail-loud]]).
+///
+/// `None` when the row declares no projector AND none sits beside the GGUF. A VL model
+/// needs this to SEE: `llama-server --mmproj <path>` loads the vision encoder so image
+/// content parts are tokenized. Without it the server serves text but silently ignores
+/// images — so the serving spawn treats a Vision-capable row with an unresolved
+/// projector as a LOUD warning (blind, not a fabricated sight), never a silent
+/// capability lie.
 pub fn resolve_mmproj_for_model(model: &Model) -> Option<PathBuf> {
-    let declared = model.mmproj_local_path.as_deref()?;
-    let expanded = expand_user_path(declared);
-    expanded.exists().then_some(expanded)
+    // Tier 1: an explicitly declared projector that's actually on disk.
+    if let Some(declared) = model.mmproj_local_path.as_deref() {
+        let expanded = expand_user_path(declared);
+        if expanded.exists() {
+            return Some(expanded);
+        }
+    }
+    // Tier 2: the projector sibling in the GGUF's resolved snapshot dir.
+    let gguf = resolve_gguf_for_model(model)?;
+    find_mmproj_beside(gguf.parent()?)
+}
+
+/// Find a multimodal projector GGUF sitting in `dir` — a `*mmproj*.gguf` sibling of
+/// the model's GGUF (the layout every `*-GGUF` vision repo snapshot uses). First match
+/// wins; a snapshot ships one projector.
+fn find_mmproj_beside(dir: &Path) -> Option<PathBuf> {
+    fs::read_dir(dir).ok()?.flatten().find_map(|entry| {
+        let path = entry.path();
+        let name = path.file_name()?.to_str()?.to_ascii_lowercase();
+        (name.contains("mmproj") && name.ends_with(".gguf")).then_some(path)
+    })
 }
 
 /// Resolve a canonical model id to the HF safetensors repo id of its
@@ -459,27 +491,69 @@ mod tests {
         }
     }
 
-    // what this catches: a vision model's projector resolves (with `~` expansion +
-    // existence check) so the serving spawn passes `--mmproj` and the model can SEE;
-    // a declared-but-absent projector, or no projector, resolves to None so a Vision
-    // row can't silently claim sight it can't deliver (the spawn's loud-warn path).
+    // what this catches: tier-1 resolution — an explicitly declared projector resolves
+    // (with `~` expansion + existence check) so the serving spawn passes `--mmproj` and
+    // the model can SEE; a declared-but-absent projector with no GGUF-sibling either,
+    // or no projector at all, resolves to None so a Vision row can't silently claim
+    // sight it can't deliver (the spawn's loud-warn path). Runs under an empty test HOME
+    // so tier-2's `resolve_gguf` finds nothing — the None cases stay deterministic and
+    // don't leak a real on-disk projector from the dev machine's HF cache (cf. #72).
     #[test]
-    fn resolves_mmproj_only_when_the_projector_file_exists() {
-        let dir = tempfile::tempdir().unwrap();
-        let mmproj = dir.path().join("mmproj-f16.gguf");
-        fs::write(&mmproj, b"\0").unwrap();
+    fn resolves_declared_mmproj_only_when_the_projector_file_exists() {
+        let home = tempfile::tempdir().unwrap();
+        with_test_home(home.path(), || {
+            let dir = tempfile::tempdir().unwrap();
+            let mmproj = dir.path().join("mmproj-f16.gguf");
+            fs::write(&mmproj, b"\0").unwrap();
 
-        let mut m = model("qwen-vl", None, None);
-        m.mmproj_local_path = Some(mmproj.clone());
-        assert_eq!(resolve_mmproj_for_model(&m).as_deref(), Some(mmproj.as_path()));
+            let mut m = model("qwen-vl", None, None);
+            m.mmproj_local_path = Some(mmproj.clone());
+            assert_eq!(resolve_mmproj_for_model(&m).as_deref(), Some(mmproj.as_path()));
 
-        // Declared but not on disk → None (serving warns TEXT-ONLY, never fakes sight).
-        m.mmproj_local_path = Some(dir.path().join("absent-mmproj.gguf"));
-        assert!(resolve_mmproj_for_model(&m).is_none());
+            // Declared but not on disk, and no GGUF resolves (empty HOME) → None
+            // (serving warns TEXT-ONLY, never fakes sight).
+            m.mmproj_local_path = Some(dir.path().join("absent-mmproj.gguf"));
+            assert!(resolve_mmproj_for_model(&m).is_none());
 
-        // No projector declared → None.
-        m.mmproj_local_path = None;
-        assert!(resolve_mmproj_for_model(&m).is_none());
+            // No projector declared, no GGUF → None.
+            m.mmproj_local_path = None;
+            assert!(resolve_mmproj_for_model(&m).is_none());
+        });
+    }
+
+    // what this catches: tier-2 self-provisioning — a VL model's mmproj auto-resolves
+    // from the SAME HF cache snapshot as its GGUF, with NO declared-local path. The
+    // projector ships beside the GGUF in `*-GGUF` repos, so pulling the model into the
+    // HF cache is enough; there is no separate hand-placement step for the projector.
+    // This is the resolution asymmetry fix: the mmproj now resolves like the GGUF
+    // (local → HF cache), so vision serving is managed, not manually wired.
+    #[test]
+    fn resolves_mmproj_from_the_gguf_hf_cache_snapshot_when_not_declared() {
+        let home = tempfile::tempdir().unwrap();
+        with_test_home(home.path(), || {
+            let snap = home.path().join(
+                ".cache/huggingface/hub/models--continuum-ai--qwen3-vl-7b-GGUF/snapshots/abc",
+            );
+            fs::create_dir_all(&snap).unwrap();
+            let gguf = snap.join("qwen3-vl-7b-Q4_K_M.gguf");
+            write_empty_gguf(&gguf);
+            let mmproj = snap.join("mmproj-qwen3-vl-7b-f16.gguf");
+            write_empty_gguf(&mmproj);
+
+            // GGUF resolves from the HF cache via the hint; the projector is NOT declared
+            // locally (declared path is stale/absent) but sits beside the GGUF.
+            let mut m = model("qwen3-vl-7b", Some("continuum-ai/qwen3-vl-7b-GGUF"), None);
+            m.mmproj_local_path = Some(PathBuf::from("~/nonexistent/mmproj.gguf"));
+            assert_eq!(
+                resolve_mmproj_for_model(&m).as_deref(),
+                Some(mmproj.as_path()),
+                "mmproj must resolve beside the GGUF in the HF cache snapshot"
+            );
+
+            // Tier 1 still wins when a declared projector is actually present.
+            m.mmproj_local_path = Some(mmproj.clone());
+            assert_eq!(resolve_mmproj_for_model(&m).as_deref(), Some(mmproj.as_path()));
+        });
     }
 
     #[test]

--- a/core/continuum-core/src/modules/ai_provider.rs
+++ b/core/continuum-core/src/modules/ai_provider.rs
@@ -543,26 +543,24 @@ impl AIProviderModule {
                 // returns a clean error when mmproj is absent — we log
                 // the gap upfront so install scripts catch it before
                 // a real user hits "model declares Vision but mmproj
-                // missing" at request time.
+                // missing" at request time. Resolve via the ONE resolver
+                // (declared path OR the projector beside the GGUF in the
+                // HF cache), so a self-provisioned sibling reads as present
+                // and we don't false-warn on a model that will serve fine.
                 let needs_mmproj = model_meta.has(crate::model_registry::types::Capability::Vision)
                     || model_meta.has(crate::model_registry::types::Capability::AudioInput);
-                if needs_mmproj {
-                    match &model_meta.mmproj_local_path {
-                        None => self.log().info(&format!(
-                            "Adapter `{}` declares Vision/AudioInput but TOML has no \
-                             mmproj_local_path — multimodal calls will hard-error. \
-                             Add `mmproj_local_path = \"...\"` to the row.",
-                            model_meta.id
-                        )),
-                        Some(p) if !p.exists() => self.log().info(&format!(
-                            "Adapter `{}` declares Vision/AudioInput but mmproj file \
-                             missing at {} — multimodal calls will hard-error. \
-                             Install must pull this artifact alongside the GGUF.",
-                            model_meta.id,
-                            p.display()
-                        )),
-                        Some(_) => {} // present + on disk, good
-                    }
+                if needs_mmproj
+                    && crate::model_registry::artifacts::resolve_mmproj_for_model(model_meta)
+                        .is_none()
+                {
+                    self.log().info(&format!(
+                        "Adapter `{}` declares Vision/AudioInput but no mmproj projector \
+                         resolves — none declared, and none sits beside the GGUF in the HF \
+                         cache. Multimodal calls will hard-error. Pull the model's `*-GGUF` \
+                         repo (its projector ships alongside the GGUF) or add \
+                         `mmproj_local_path` to the row.",
+                        model_meta.id
+                    ));
                 }
                 self.log().info(&format!(
                     "Registering in-process llama.cpp adapter for model `{}`",


### PR DESCRIPTION
Two foundational pieces so a VL persona can actually **see** — both #106, both cargo-validated.

## 1. mmproj resolves like the GGUF (declared → HF-cache sibling)

`resolve_mmproj_for_model` only honored a **declared local path** while the GGUF resolves **local → HF cache**. That asymmetry forced manual projector placement whenever a model's bytes already lived in the HF cache without a fresh `models/pull` — a managed-product violation. Now two-tier: (1) declared path, existence-checked; (2) the `*mmproj*.gguf` sibling in the GGUF's resolved snapshot dir (the layout every `*-GGUF` repo ships). Pulling the model pulls its projector; no hand-placement step.

**One resolver (compression):** `llamacpp_adapter` `generate_with_image` and the `ai_provider` boot preflight now route through it instead of reading the raw field — they see the self-provisioned sibling and get existence-checking, matching `llama-server`. `resolve_model_artifacts` stays as declared-intent (the `omni.mmproj_local_path.is_some()` contract).

## 2. Live `FrameDescriber` — the sensory bridge media/ had no impl for

`media/frame.rs` documented "the live implementor is `cognition::vision_describe`" but that bridge **never existed** — the only impls on canary were test stubs, so a persona's `MediaFrame` description cell had no production producer. Add `VisionDescribeFramer`: routes a frame's bytes through `describe_image` (`ai/generate` on the best vision model) → prose. Cached per content hash → the same image is described **once and shared** across N personas (the 4+-persona shared-KV payoff). Fail loud when no vision model resolves — never a fabricated placeholder. Layering holds: trait in `media/`, sole live impl in `cognition/`.

## Tests
43 model_registry + 17 vision_describe tests green. New: tier-2 HF-cache-sibling resolution (isolated HOME, no #72 leak); base64+options threading via a pure helper.

Refs #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo