### PR TITLE
feat(perception): live-call perception into cognition — rings, à la carte look, change-monitor, governed

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1492,6 +1492,17 @@ pub fn start_server(
         voice_state.resource_lifecycle.clone(),
         gpu_manager.clone(),
     )));
+    // Live-call perception joins as a peer consumer (#56): it holds RAM — the per-source
+    // frame rings every persona perceives from — read live from the process-global
+    // PerceptionRegistry. Under pressure it evicts oldest ring frames, always keeping each
+    // source's head so a live perceiver is never blinded (room-as-now survives a reclaim).
+    // The vision-describe it triggers is SERVING's VRAM, not perception's; this accounts
+    // only what perception owns.
+    resource_daemon.add_consumer(Arc::new(
+        crate::modules::perception_consumer::PerceptionConsumer::new(
+            crate::media::perception_registry(),
+        ),
+    ));
     runtime.register(Arc::new(VoiceModule::new(voice_state)));
 
     // Phase 3: CodeModule (wraps file engines and shell sessions per-persona)

--- a/core/continuum-core/src/media/frame.rs
+++ b/core/continuum-core/src/media/frame.rs
@@ -158,6 +158,29 @@ impl MediaFrame {
     ) -> Option<Arc<Result<String, String>>> {
         compute.get::<Result<String, String>>(&self.content_hash, DESCRIBE_KEY)
     }
+
+    /// The perceptual-change SIGNATURE cell — a tiny luma fingerprint, computed ONCE per
+    /// content hash and shared. Diffing two frames' signatures is the change monitor that
+    /// gates the expensive describe (universal, any view). Cheap enough to warm alongside
+    /// the thumbnail; the diff itself is inline ([`image_ops::luma_mean_abs_delta`]).
+    pub async fn signature(&self, compute: &SharedCompute) -> Arc<Result<Vec<u8>, String>> {
+        let source = Arc::clone(&self.source);
+        compute
+            .get_or_compute(&self.content_hash, SIGNATURE_KEY, async move {
+                super::image_ops::luma_signature(&source, super::image_ops::SIGNATURE_SIZE)
+            })
+            .await
+    }
+
+    /// NON-BLOCKING read of the already-warmed signature cell — the read-side twin of
+    /// [`signature`]. `Some` only if it has resolved; the change monitor reads this so it
+    /// never awaits on the hot path (a cold signature simply means "can't tell yet").
+    pub fn signature_if_ready(
+        &self,
+        compute: &SharedCompute,
+    ) -> Option<Arc<Result<Vec<u8>, String>>> {
+        compute.get::<Result<Vec<u8>, String>>(&self.content_hash, SIGNATURE_KEY)
+    }
 }
 
 /// sha256-hex of `bytes` — the content address (same hashing spill/vision use).
@@ -177,6 +200,10 @@ fn sha256_hex(bytes: &[u8]) -> String {
 /// description per content hash — the describer/mime don't fork the key because the
 /// bytes fully determine the derivative (the compute-once contract).
 const DESCRIBE_KEY: &str = "describe";
+
+/// The SharedCompute key for the perceptual-change signature cell within a frame's scope.
+/// One fingerprint per content hash — shared by every watcher of the same frame.
+const SIGNATURE_KEY: &str = "signature";
 
 /// The SharedCompute key for one scaled derivative within a frame's scope —
 /// stable and unique per `(crop, dest)` so identical requests share a cell.

--- a/core/continuum-core/src/media/image_ops.rs
+++ b/core/continuum-core/src/media/image_ops.rs
@@ -84,11 +84,75 @@ pub fn scale_crop(src: &[u8], crop: Option<CropRect>, dest: DestSize) -> Result<
     Ok(out.into_inner())
 }
 
+/// The perceptual-change SIGNATURE grid — a tiny luma (grayscale) downscale. 16×12 ≈
+/// 192 bytes: enough to catch a scene/motion change, cheap enough to diff inline at
+/// frame rate. The change MONITOR's fingerprint — computed once per content hash and
+/// shared, then diffed against the previous frame's signature to decide whether the
+/// expensive describe is worth spending (universal, any view).
+pub const SIGNATURE_SIZE: DestSize = DestSize { width: 16, height: 12 };
+
+/// Decode `src` and reduce it to raw GRAYSCALE (luma) bytes at `size` — a compact
+/// perceptual fingerprint for change detection. No PNG re-encode (unlike [`scale_crop`]):
+/// the raw luma is what a diff compares directly. Pure + deterministic; the caching on
+/// the content hash wraps this, so it runs once per frame and is shared.
+pub fn luma_signature(src: &[u8], size: DestSize) -> Result<Vec<u8>, String> {
+    if size.width == 0 || size.height == 0 {
+        return Err(format!(
+            "luma_signature: size must be non-zero, got {}x{}",
+            size.width, size.height
+        ));
+    }
+    let img = image::load_from_memory(src)
+        .map_err(|e| format!("luma_signature: could not decode source image: {e}"))?;
+    // Triangle (bilinear) is plenty for a fingerprint and cheaper than Lanczos3.
+    let small = img.resize_exact(size.width, size.height, image::imageops::FilterType::Triangle);
+    Ok(small.to_luma8().into_raw())
+}
+
+/// Mean absolute per-pixel difference between two equal-length luma signatures (0..=255)
+/// — a cheap scalar "how much changed"; the caller thresholds it. Mismatched lengths (or
+/// empty) → `u8::MAX`: a resolution / source swap IS a maximal change, never silently
+/// treated as "no change".
+pub fn luma_mean_abs_delta(a: &[u8], b: &[u8]) -> u8 {
+    if a.is_empty() || a.len() != b.len() {
+        return u8::MAX;
+    }
+    let sum: u64 = a.iter().zip(b).map(|(x, y)| x.abs_diff(*y) as u64).sum();
+    (sum / a.len() as u64) as u8
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use image::{DynamicImage, GenericImageView, ImageFormat, Rgba, RgbaImage};
     use std::io::Cursor;
+
+    // what this catches: the signature is a fixed-size raw luma grid, and the delta
+    // reads ~0 for identical content but large for a very different image — the core of
+    // the change monitor. Also: mismatched lengths are treated as maximally different.
+    #[test]
+    fn luma_signature_and_delta_detect_change() {
+        let a = two_tone_png(80, 60);
+        let a2 = two_tone_png(120, 90); // same red|blue pattern, different dimensions
+        let solid = {
+            let img = RgbaImage::from_pixel(40, 40, Rgba([0, 0, 0, 255]));
+            let mut out = Cursor::new(Vec::new());
+            DynamicImage::ImageRgba8(img).write_to(&mut out, ImageFormat::Png).unwrap();
+            out.into_inner()
+        };
+
+        let sig_a = luma_signature(&a, SIGNATURE_SIZE).unwrap();
+        let sig_a2 = luma_signature(&a2, SIGNATURE_SIZE).unwrap();
+        let sig_solid = luma_signature(&solid, SIGNATURE_SIZE).unwrap();
+        assert_eq!(sig_a.len(), (SIGNATURE_SIZE.width * SIGNATURE_SIZE.height) as usize);
+
+        // Same visual content (just rescaled) → near-zero delta.
+        assert!(luma_mean_abs_delta(&sig_a, &sig_a2) < 8, "same pattern → small delta");
+        // Half-bright pattern vs solid black → large delta.
+        assert!(luma_mean_abs_delta(&sig_a, &sig_solid) > 32, "different scene → large delta");
+        // Length mismatch → maximal.
+        assert_eq!(luma_mean_abs_delta(&sig_a, &[]), u8::MAX);
+    }
 
     /// A `w`x`h` PNG whose left half is red and right half is blue — enough to
     /// prove crop selects a region and scale changes dimensions.

--- a/core/continuum-core/src/media/mod.rs
+++ b/core/continuum-core/src/media/mod.rs
@@ -31,6 +31,8 @@ pub mod perception_registry;
 pub mod projection;
 
 pub use frame::{FrameDescriber, MediaFrame};
-pub use perception_buffer::{ParticipantId, Percept, PerceptionBuffer};
+pub use perception_buffer::{
+    LookFidelity, LookImage, LookScope, ParticipantId, Percept, PerceptionBuffer,
+};
 pub use perception_registry::{registry as perception_registry, AMBIENT_PERCEPTION_SIZE};
 pub use projection::{project_image, MediaResolution, ProjectedMedia};

--- a/core/continuum-core/src/media/mod.rs
+++ b/core/continuum-core/src/media/mod.rs
@@ -27,8 +27,10 @@
 pub mod frame;
 pub mod image_ops;
 pub mod perception_buffer;
+pub mod perception_registry;
 pub mod projection;
 
 pub use frame::{FrameDescriber, MediaFrame};
 pub use perception_buffer::{ParticipantId, Percept, PerceptionBuffer};
+pub use perception_registry::{registry as perception_registry, AMBIENT_PERCEPTION_SIZE};
 pub use projection::{project_image, MediaResolution, ProjectedMedia};

--- a/core/continuum-core/src/media/perception_buffer.rs
+++ b/core/continuum-core/src/media/perception_buffer.rs
@@ -15,7 +15,7 @@
 //! these percepts under the flexbox RAG budget so perception never dominates context
 //! ([[perception-feedback-must-not-blow-rag]]).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -46,6 +46,59 @@ pub const AMBIENT_WARM_MIN_INTERVAL_MS: u64 = 500;
 /// this floor, never to infinity. Attention priority (speaker/actor) shrinks both
 /// bounds later (#173).
 pub const AMBIENT_WARM_BASELINE_INTERVAL_MS: u64 = 5_000;
+
+/// Depth of each source's sliding-window frame ring — how many recent frames are held
+/// per participant. The HEAD is the most-current frame ("latest"); the window (front K)
+/// is what the sliding-window read + change comparison see. Bounded so a 30fps source
+/// costs a fixed handful of `Arc` frame handles, never an unbounded backlog. A field on
+/// the buffer (defaulted from here) so the governor can deepen it for a source under
+/// scrutiny (#173).
+pub const AMBIENT_RING_CAPACITY: usize = 8;
+
+/// A bounded, per-source sliding window of recent frames — the shared "pre-warmed image
+/// cache" for ONE participant. Newest at the FRONT (the head = "latest"); the oldest is
+/// evicted past capacity. Frames are `Arc`-backed handles and their derivatives dedup by
+/// content-hash on the shared cache, so a ring of K frames is cheap and never duplicates
+/// a derivative across viewers. The window is what change-detection (compare consecutive
+/// heads) and "what did I miss" read; the head is the room-as-now view.
+struct FrameRing {
+    /// front = newest, back = oldest.
+    frames: VecDeque<MediaFrame>,
+    capacity: usize,
+}
+
+impl FrameRing {
+    fn with_capacity(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            frames: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    /// Push the newest frame to the front. COALESCE: a re-send of the SAME content as the
+    /// current head (identical hash) is a no-op — the head already IS this frame. Evict the
+    /// oldest past capacity (room-as-now, bounded).
+    fn push(&mut self, frame: MediaFrame) {
+        if self.frames.front().map(|f| f.content_hash()) == Some(frame.content_hash()) {
+            return;
+        }
+        self.frames.push_front(frame);
+        while self.frames.len() > self.capacity {
+            self.frames.pop_back();
+        }
+    }
+
+    /// The most-current frame (room-as-now "latest").
+    fn head(&self) -> Option<&MediaFrame> {
+        self.frames.front()
+    }
+
+    /// The last `k` frames, newest first — the sliding-window read.
+    fn window(&self, k: usize) -> impl Iterator<Item = &MediaFrame> {
+        self.frames.iter().take(k)
+    }
+}
 
 /// Per-participant warm-cadence gate. Coalescing the latest frame is unconditional
 /// and O(1); only the EXPENSIVE warm (scale + describe) passes through this gate, so
@@ -87,10 +140,15 @@ impl Percept {
 /// Non-blocking, room-as-now perception hold. One latest frame per airc participant; cells
 /// warm async on the shared cache; reads take only what's ready.
 pub struct PerceptionBuffer {
-    latest: Mutex<HashMap<ParticipantId, MediaFrame>>,
+    /// One bounded sliding-window ring per participant — the shared pre-warmed store.
+    /// The head is the room-as-now frame; the window is the recent history.
+    rings: Mutex<HashMap<ParticipantId, FrameRing>>,
     /// The ambient forced-look size (~480w default) — the cheap thumbnail cell every tick
     /// warms + reads. Full-res / bigger is the drill-in tool, not the ambient path.
     ambient: DestSize,
+    /// Depth of each participant's ring (defaulted from [`AMBIENT_RING_CAPACITY`]) — a field
+    /// so the governor can deepen a source's window under scrutiny (#173).
+    ring_capacity: usize,
     /// Per-participant warm-cadence gates — the seam that keeps the expensive cells off
     /// the media frame rate. See [`WarmGate`] and [`AMBIENT_WARM_MIN_INTERVAL_MS`].
     warm_gates: Mutex<HashMap<ParticipantId, WarmGate>>,
@@ -106,8 +164,9 @@ pub struct PerceptionBuffer {
 impl PerceptionBuffer {
     pub fn new(ambient: DestSize) -> Self {
         Self {
-            latest: Mutex::new(HashMap::new()),
+            rings: Mutex::new(HashMap::new()),
             ambient,
+            ring_capacity: AMBIENT_RING_CAPACITY,
             warm_gates: Mutex::new(HashMap::new()),
             min_warm_interval_ms: AMBIENT_WARM_MIN_INTERVAL_MS,
             baseline_warm_interval_ms: AMBIENT_WARM_BASELINE_INTERVAL_MS,
@@ -169,12 +228,16 @@ impl PerceptionBuffer {
         mime: &str,
         now_ms: u64,
     ) {
-        // Coalesce ALWAYS: the latest frame per participant wins; the old one is dropped.
-        // Cheap enough for the 30fps media plane — perception samples it, doesn't mirror it.
-        self.latest
+        // Push onto the participant's ring ALWAYS — cheap (an Arc handle + a bounded pop),
+        // safe at the 30fps media plane. The head becomes the room-as-now frame; the ring
+        // retains the recent window (coalescing an identical re-send). Perception samples
+        // this store; it doesn't mirror the frame rate.
+        self.rings
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .insert(participant.clone(), frame.clone());
+            .entry(participant.clone())
+            .or_insert_with(|| FrameRing::with_capacity(self.ring_capacity))
+            .push(frame.clone());
 
         // Gate the EXPENSIVE warm. A gated tick simply returns — its frame is already the
         // coalesced latest and will warm on the next open tick (room-as-now). compute-once
@@ -199,26 +262,51 @@ impl PerceptionBuffer {
         });
     }
 
-    /// The perception of the room AS IT IS NOW — one `Percept` per participant, each carrying
-    /// only the cells RESOLVED so far (non-blocking reads via the `_if_ready` twins). NEVER
-    /// awaits; a still-warming cell is simply `None` this tick.
+    /// Non-blocking projection of one frame into a `Percept` — reads ONLY the cells resolved
+    /// so far on the shared cache (the `_if_ready` twins), never awaits, never recomputes.
+    /// The single place a frame becomes a percept, shared by the room-as-now read and the
+    /// windowed read (compression: one projection).
+    fn percept_of(&self, participant: &str, frame: &MediaFrame, compute: &SharedCompute) -> Percept {
+        Percept {
+            participant: participant.to_string(),
+            content_hash: frame.content_hash().to_string(),
+            thumbnail: frame.scaled_if_ready(compute, None, self.ambient),
+            description: frame.description_if_ready(compute),
+        }
+    }
+
+    /// The perception of the room AS IT IS NOW — one `Percept` per participant from each
+    /// ring's HEAD, carrying only cells RESOLVED so far. NEVER awaits; a still-warming cell
+    /// is simply `None` this tick. This is the GROUPED "everyone at a glance" read (the
+    /// human-widget gallery): every source's most-current warm look, shared, zero-copy.
     pub fn current_percepts(&self, compute: &SharedCompute) -> Vec<Percept> {
-        self.latest
+        self.rings
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .iter()
-            .map(|(pid, frame)| Percept {
-                participant: pid.clone(),
-                content_hash: frame.content_hash().to_string(),
-                thumbnail: frame.scaled_if_ready(compute, None, self.ambient),
-                description: frame.description_if_ready(compute),
-            })
+            .filter_map(|(pid, ring)| ring.head().map(|f| self.percept_of(pid, f, compute)))
             .collect()
+    }
+
+    /// The SLIDING-WINDOW read for ONE participant — the last `k` frames as percepts, newest
+    /// first (only resolved cells). This is "what changed / what did I miss" over a source's
+    /// recent history, off the same shared warm store. Empty if the participant is unknown.
+    pub fn window_percepts(&self, participant: &str, k: usize, compute: &SharedCompute) -> Vec<Percept> {
+        self.rings
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(participant)
+            .map(|ring| {
+                ring.window(k)
+                    .map(|f| self.percept_of(participant, f, compute))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Drop a participant that left the call.
     pub fn remove(&self, participant: &str) {
-        self.latest
+        self.rings
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(participant);
@@ -226,7 +314,7 @@ impl PerceptionBuffer {
 
     /// Number of participants currently held (for probes/tests).
     pub fn len(&self) -> usize {
-        self.latest.lock().unwrap_or_else(|e| e.into_inner()).len()
+        self.rings.lock().unwrap_or_else(|e| e.into_inner()).len()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -295,11 +383,17 @@ mod tests {
     async fn current_percepts_surface_cells_only_once_resolved() {
         let buffer = PerceptionBuffer::new(AMBIENT);
         let compute = Arc::new(SharedCompute::new());
-        let describer: Arc<dyn FrameDescriber> = Arc::new(StubDescriber);
         let frame = MediaFrame::from_bytes(png(50, 40));
 
-        // Store WITHOUT warming: read the percept before any cell resolves → all None.
-        buffer.latest.lock().unwrap().insert("alice".into(), frame.clone());
+        // Push onto the ring WITHOUT warming (bypass observe's spawn): read the percept from
+        // the head before any cell resolves → all None.
+        buffer
+            .rings
+            .lock()
+            .unwrap()
+            .entry("alice".into())
+            .or_insert_with(|| FrameRing::with_capacity(AMBIENT_RING_CAPACITY))
+            .push(frame.clone());
         let before = &buffer.current_percepts(&compute)[0];
         assert!(before.thumbnail.is_none() && before.description.is_none(), "cold → nothing rendered");
         assert!(!before.has_any());
@@ -318,6 +412,78 @@ mod tests {
             AMBIENT.width,
             "the ready thumbnail is the ambient size"
         );
+    }
+
+    // what this catches: the ring is a bounded sliding window — newest-first, an identical
+    // re-send of the head coalesces (no dup), and past capacity the oldest is evicted. This is
+    // the "pre-warmed sliding-window cache" the grouped + windowed reads sit on.
+    #[test]
+    fn frame_ring_windows_newest_first_coalesces_head_and_bounds_capacity() {
+        let mut ring = FrameRing::with_capacity(3);
+        assert!(ring.head().is_none(), "empty ring has no head");
+
+        let a = MediaFrame::from_bytes(png(11, 11));
+        let b = MediaFrame::from_bytes(png(12, 12));
+        let c = MediaFrame::from_bytes(png(13, 13));
+        let d = MediaFrame::from_bytes(png(14, 14));
+
+        ring.push(a.clone());
+        ring.push(a.clone()); // identical head → coalesced no-op
+        assert_eq!(ring.window(9).count(), 1, "re-send of the same head coalesces");
+
+        ring.push(b.clone());
+        ring.push(c.clone());
+        ring.push(d.clone()); // capacity 3 → 'a' evicted
+
+        let hashes: Vec<_> = ring.window(9).map(|f| f.content_hash().to_string()).collect();
+        assert_eq!(
+            hashes,
+            vec![
+                d.content_hash().to_string(),
+                c.content_hash().to_string(),
+                b.content_hash().to_string()
+            ],
+            "newest-first, capacity-bounded, oldest ('a') evicted"
+        );
+        assert_eq!(ring.head().unwrap().content_hash(), d.content_hash(), "head = most current");
+        assert_eq!(ring.window(2).count(), 2, "window respects k");
+    }
+
+    // what this catches: the two serving shapes off the ONE shared store — GROUPED (all ring
+    // heads = the human-widget gallery, everyone at a glance) and WINDOWED (one source's recent
+    // history, newest-first). An unknown participant windows to empty.
+    #[tokio::test]
+    async fn grouped_read_is_all_heads_windowed_read_is_one_sources_history() {
+        let buffer = PerceptionBuffer::new(AMBIENT);
+        let compute = Arc::new(SharedCompute::new());
+
+        // alice gets a short history (3 distinct frames), bob one — pushed WITHOUT warming so
+        // the read exercises structure (heads/window), not cell resolution.
+        {
+            let mut rings = buffer.rings.lock().unwrap();
+            let alice = rings
+                .entry("alice".into())
+                .or_insert_with(|| FrameRing::with_capacity(AMBIENT_RING_CAPACITY));
+            for (w, h) in [(11, 11), (12, 12), (13, 13)] {
+                alice.push(MediaFrame::from_bytes(png(w, h)));
+            }
+            rings
+                .entry("bob".into())
+                .or_insert_with(|| FrameRing::with_capacity(AMBIENT_RING_CAPACITY))
+                .push(MediaFrame::from_bytes(png(20, 20)));
+        }
+
+        // GROUPED: one head per source — the gallery of everyone at a glance.
+        let grouped = buffer.current_percepts(&compute);
+        assert_eq!(grouped.len(), 2, "gallery = one head per participant");
+
+        // WINDOWED: the last k of ONE source, newest-first.
+        let win = buffer.window_percepts("alice", 2, &compute);
+        assert_eq!(win.len(), 2, "windowed read = last k of one source");
+        assert!(win.iter().all(|p| p.participant == "alice"), "windowed read is source-scoped");
+
+        // Unknown participant → empty (never a fabricated look).
+        assert!(buffer.window_percepts("nobody", 5, &compute).is_empty());
     }
 
     // what this catches: remove drops a participant who left the call.

--- a/core/continuum-core/src/media/perception_buffer.rs
+++ b/core/continuum-core/src/media/perception_buffer.rs
@@ -47,6 +47,12 @@ pub const AMBIENT_WARM_MIN_INTERVAL_MS: u64 = 500;
 /// bounds later (#173).
 pub const AMBIENT_WARM_BASELINE_INTERVAL_MS: u64 = 5_000;
 
+/// Mean-luma-delta threshold (0..=255) above which two consecutive frames of a source
+/// count as a CHANGE. ~8/255 ≈ 3% average pixel shift — past camera noise, catches real
+/// motion / scene / slide changes. The trigger that escalates the warm band; below it the
+/// scene is "static" and decays to the baseline floor.
+pub const CHANGE_THRESHOLD: u8 = 8;
+
 /// Depth of each source's sliding-window frame ring — how many recent frames are held
 /// per participant. The HEAD is the most-current frame ("latest"); the window (front K)
 /// is what the sliding-window read + change comparison see. Bounded so a 30fps source
@@ -208,6 +214,34 @@ impl PerceptionBuffer {
         }
     }
 
+    /// Is this source's scene RECENTLY CHANGING? — the real change signal that drives the
+    /// warm band (replacing the old `changed = true` placeholder). Compares the two most
+    /// recent frames whose luma SIGNATURE has already warmed (the change monitor reads only
+    /// ready cells, never awaits): mean-abs delta over [`CHANGE_THRESHOLD`] = changed. Fewer
+    /// than two ready signatures (cold start, or signatures still warming) → `true`: assume
+    /// changed and ride the MIN ceiling until we can actually tell — safe, never starves.
+    /// Cheap: a bounded ring scan + a ~192-byte diff, fine to call per ingest.
+    fn scene_recently_changed(&self, source: &str, compute: &SharedCompute) -> bool {
+        let rings = self.rings.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(ring) = rings.get(source) else {
+            return true;
+        };
+        // Newest-first: collect the two most recent READY, OK signatures.
+        let mut ready = ring.window(usize::MAX).filter_map(|f| {
+            f.signature_if_ready(compute).and_then(|sig| match &*sig {
+                Ok(bytes) => Some(bytes.clone()),
+                Err(_) => None,
+            })
+        });
+        match (ready.next(), ready.next()) {
+            (Some(newest), Some(prev)) => {
+                super::image_ops::luma_mean_abs_delta(&newest, &prev) > CHANGE_THRESHOLD
+            }
+            // Can't tell yet → assume changed (ride the ceiling until a signature warms).
+            _ => true,
+        }
+    }
+
     /// The warm-cadence DECISION (pure + testable): should this observe launch a cell
     /// warm for `participant` at `now_ms`? Returns the in-flight flag to hold for the
     /// warm's duration when YES; `None` when GATED. The cadence is a BAND, not a switch
@@ -278,11 +312,11 @@ impl PerceptionBuffer {
         // coalesced latest and will warm on the next open tick (room-as-now). compute-once
         // per content-hash still applies on top: re-warming identical bytes is a cache hit.
         //
-        // INTERIM: no change detector wired yet (#192), so treat every coalesced frame as
-        // potentially changed → cadence rides the MIN ceiling. When the cheap
-        // motion/scene-change/YOLO detector lands, its signal replaces this `true`, and a
-        // static scene decays to the BASELINE floor.
-        let changed = true;
+        // The change monitor (cheap luma-signature diff of the two most recent warmed
+        // frames) drives the band: a static scene decays to the BASELINE floor, a real
+        // change escalates to the MIN ceiling. Cold start / signatures still warming →
+        // `true` (ride the ceiling until we can tell).
+        let changed = self.scene_recently_changed(&participant, &compute);
         let Some(in_flight) = self.should_warm(&participant, now_ms, changed) else {
             return;
         };
@@ -290,6 +324,9 @@ impl PerceptionBuffer {
         let ambient = self.ambient;
         let mime = mime.to_string();
         tokio::spawn(async move {
+            // Warm the cheap signature FIRST — it's the change monitor's fingerprint that
+            // gates future describes; then the thumbnail; then the expensive describe.
+            let _ = frame.signature(&compute).await;
             let _ = frame.scaled(&compute, None, ambient).await; // warm ~480w thumbnail
             let _ = frame.description(&compute, describer.as_ref(), &mime).await; // warm describe
             // Release the gate so the next due tick can warm the then-latest frame.
@@ -612,6 +649,55 @@ mod tests {
 
         // Unknown source → empty (never a fabricated look).
         assert!(buffer.look(LookScope::Source("nobody".into()), LookFidelity::Thumbnail, &compute).await.is_empty());
+    }
+
+    // what this catches: the change MONITOR — `scene_recently_changed` diffs the two most
+    // recent WARMED luma signatures. Same scene (same pattern, different frame) → NOT changed
+    // (decays to the floor); a visually different frame → changed (escalates). Unknown source
+    // or unwarmed signatures → true (assume changed, ride the ceiling until we can tell).
+    #[tokio::test]
+    async fn scene_recently_changed_reads_warmed_signatures() {
+        fn solid_png(w: u32, h: u32) -> Vec<u8> {
+            let img = RgbaImage::from_pixel(w, h, Rgba([0, 0, 0, 255]));
+            let mut out = Cursor::new(Vec::new());
+            DynamicImage::ImageRgba8(img).write_to(&mut out, ImageFormat::Png).unwrap();
+            out.into_inner()
+        }
+
+        let buffer = PerceptionBuffer::new(AMBIENT);
+        let compute = Arc::new(SharedCompute::new());
+        let src = "alice";
+
+        // Unknown source → assume changed.
+        assert!(buffer.scene_recently_changed(src, &compute));
+
+        // Two visually-IDENTICAL frames (same red|blue pattern, different dims → different
+        // content hash, so both are kept in the ring). Warm their signatures.
+        let f1 = MediaFrame::from_bytes(png(80, 60));
+        let f2 = MediaFrame::from_bytes(png(120, 90));
+        f1.signature(&compute).await;
+        f2.signature(&compute).await;
+        {
+            let mut rings = buffer.rings.lock().unwrap();
+            let r = rings
+                .entry(src.into())
+                .or_insert_with(|| FrameRing::with_capacity(AMBIENT_RING_CAPACITY));
+            r.push(f1.clone());
+            r.push(f2.clone());
+        }
+        assert!(
+            !buffer.scene_recently_changed(src, &compute),
+            "same scene across frames → not changed → decays to the slow floor"
+        );
+
+        // A visually DIFFERENT frame on top → changed.
+        let solid = MediaFrame::from_bytes(solid_png(50, 50));
+        solid.signature(&compute).await;
+        buffer.rings.lock().unwrap().get_mut(src).unwrap().push(solid.clone());
+        assert!(
+            buffer.scene_recently_changed(src, &compute),
+            "a different scene → changed → escalate to the ceiling"
+        );
     }
 
     // what this catches: remove drops a participant who left the call.

--- a/core/continuum-core/src/media/perception_buffer.rs
+++ b/core/continuum-core/src/media/perception_buffer.rs
@@ -38,6 +38,15 @@ pub type ParticipantId = String;
 /// persona looks more often, an idle one less.
 pub const AMBIENT_WARM_MIN_INTERVAL_MS: u64 = 500;
 
+/// The MAXIMUM staleness — the slow BASELINE floor a participant is re-looked-at even
+/// with a dead-static scene and no change signal. "Slow cadence, not NO cadence": an
+/// idle observer still refreshes a still participant every few seconds so room-as-now
+/// stays true, just coarse. The warm cadence is a BAND — a relevant change (motion /
+/// scene-change / YOLO, #192) escalates toward the MIN ceiling; its absence decays to
+/// this floor, never to infinity. Attention priority (speaker/actor) shrinks both
+/// bounds later (#173).
+pub const AMBIENT_WARM_BASELINE_INTERVAL_MS: u64 = 5_000;
+
 /// Per-participant warm-cadence gate. Coalescing the latest frame is unconditional
 /// and O(1); only the EXPENSIVE warm (scale + describe) passes through this gate, so
 /// a 30fps ingest coalesces 30 frames/sec into one latest but triggers at most
@@ -85,9 +94,13 @@ pub struct PerceptionBuffer {
     /// Per-participant warm-cadence gates — the seam that keeps the expensive cells off
     /// the media frame rate. See [`WarmGate`] and [`AMBIENT_WARM_MIN_INTERVAL_MS`].
     warm_gates: Mutex<HashMap<ParticipantId, WarmGate>>,
-    /// Minimum ms between warms per participant (the perception sample rate). Field, not
-    /// hardcoded at the call site, so the governor can retune it per persona later (#173).
+    /// The warm cadence BAND, per participant — fields (not call-site constants) so the
+    /// governor retunes them per persona as an attention-priced resolution field (#173):
+    /// `min` = the ceiling (fastest, under change), `baseline` = the floor / max-staleness
+    /// (slowest, static scene). A relevant change escalates toward min; its absence decays
+    /// to baseline, never to infinity.
     min_warm_interval_ms: u64,
+    baseline_warm_interval_ms: u64,
 }
 
 impl PerceptionBuffer {
@@ -97,25 +110,40 @@ impl PerceptionBuffer {
             ambient,
             warm_gates: Mutex::new(HashMap::new()),
             min_warm_interval_ms: AMBIENT_WARM_MIN_INTERVAL_MS,
+            baseline_warm_interval_ms: AMBIENT_WARM_BASELINE_INTERVAL_MS,
         }
     }
 
     /// The warm-cadence DECISION (pure + testable): should this observe launch a cell
     /// warm for `participant` at `now_ms`? Returns the in-flight flag to hold for the
-    /// warm's duration when YES; `None` when the warm is GATED — either one is already
-    /// in flight (never stack), or we warmed within `min_warm_interval_ms` (the frame
-    /// rate outruns the perception sample rate). The 30fps-safety guarantee lives here,
-    /// separated from the spawn so it can be asserted without timing or a runtime.
-    fn should_warm(&self, participant: &str, now_ms: u64) -> Option<Arc<AtomicBool>> {
+    /// warm's duration when YES; `None` when GATED. The cadence is a BAND, not a switch
+    /// ("slow cadence, not NO cadence"):
+    /// - Never while one is already in flight (never stack a slow describe under a fast
+    ///   stream).
+    /// - `changed` (a relevant motion/scene-change/YOLO signal, #192) ESCALATES: warm as
+    ///   soon as the MIN ceiling allows.
+    /// - Absent change, still warm on the slow BASELINE floor — an idle observer refreshes
+    ///   a static participant every few seconds, never zero.
+    ///
+    /// The 30fps-safety guarantee lives here, separated from the spawn so both branches
+    /// (changed→fast, static→slow-floor) are asserted without timing or a runtime.
+    fn should_warm(
+        &self,
+        participant: &str,
+        now_ms: u64,
+        changed: bool,
+    ) -> Option<Arc<AtomicBool>> {
         let mut gates = self.warm_gates.lock().unwrap_or_else(|e| e.into_inner());
         let g = gates.entry(participant.to_string()).or_default();
-        // Never stack a warm on an unfinished one — protects against a describe slower
-        // than the interval under a fast stream.
         if g.in_flight.load(Ordering::Acquire) {
             return None;
         }
+        let elapsed = now_ms.saturating_sub(g.last_warm_ms);
+        // First look always; a relevant change escalates to the MIN ceiling; otherwise
+        // decay to the slow BASELINE floor (never off).
         let due = !g.warmed_once
-            || now_ms.saturating_sub(g.last_warm_ms) >= self.min_warm_interval_ms;
+            || (changed && elapsed >= self.min_warm_interval_ms)
+            || elapsed >= self.baseline_warm_interval_ms;
         if !due {
             return None;
         }
@@ -148,11 +176,16 @@ impl PerceptionBuffer {
             .unwrap_or_else(|e| e.into_inner())
             .insert(participant.clone(), frame.clone());
 
-        // Gate the EXPENSIVE warm to the perception sample rate. A gated tick simply
-        // returns — its frame is already the coalesced latest and will warm on the next
-        // open tick (room-as-now). compute-once per content-hash still applies on top:
-        // re-warming identical bytes is a cache hit.
-        let Some(in_flight) = self.should_warm(&participant, now_ms) else {
+        // Gate the EXPENSIVE warm. A gated tick simply returns — its frame is already the
+        // coalesced latest and will warm on the next open tick (room-as-now). compute-once
+        // per content-hash still applies on top: re-warming identical bytes is a cache hit.
+        //
+        // INTERIM: no change detector wired yet (#192), so treat every coalesced frame as
+        // potentially changed → cadence rides the MIN ceiling. When the cheap
+        // motion/scene-change/YOLO detector lands, its signal replaces this `true`, and a
+        // static scene decays to the BASELINE floor.
+        let changed = true;
+        let Some(in_flight) = self.should_warm(&participant, now_ms, changed) else {
             return;
         };
 
@@ -310,25 +343,59 @@ mod tests {
         let p = "alice";
 
         // First ever frame → warms immediately; holds the in-flight flag.
-        let flag = buffer.should_warm(p, 0).expect("first frame warms");
+        let flag = buffer.should_warm(p, 0, true).expect("first frame warms");
         // Simulate the warm completing so the in-flight guard is not what's under test.
         flag.store(false, Ordering::Release);
 
-        // A distinct frame 10ms later (30fps ≈ 33ms apart) → GATED by cadence.
+        // A CHANGED frame 10ms later (30fps ≈ 33ms apart) → GATED by the MIN ceiling.
         assert!(
-            buffer.should_warm(p, 10).is_none(),
-            "a frame within the interval is gated — perception samples, not mirrors, 30fps"
+            buffer.should_warm(p, 10, true).is_none(),
+            "a changed frame within the min ceiling is gated — perception samples, not mirrors, 30fps"
         );
         assert!(
-            buffer.should_warm(p, AMBIENT_WARM_MIN_INTERVAL_MS - 1).is_none(),
-            "still within the interval → still gated"
+            buffer.should_warm(p, AMBIENT_WARM_MIN_INTERVAL_MS - 1, true).is_none(),
+            "still within the min ceiling → still gated"
         );
 
-        // Once the interval elapses, the next warm is due again.
+        // Once the min ceiling elapses, a changed frame warms again.
         let flag2 = buffer
-            .should_warm(p, AMBIENT_WARM_MIN_INTERVAL_MS)
-            .expect("interval elapsed → warm is due");
+            .should_warm(p, AMBIENT_WARM_MIN_INTERVAL_MS, true)
+            .expect("min ceiling elapsed + changed → warm is due");
         flag2.store(false, Ordering::Release);
+    }
+
+    // what this catches: the BAND — "slow cadence, not NO cadence". Absent a change signal a
+    // participant is NOT starved: it decays to the slow BASELINE floor (still warms every few
+    // seconds), while a relevant change escalates it to the fast MIN ceiling.
+    #[test]
+    fn warm_cadence_is_a_band_change_escalates_static_decays_to_floor() {
+        let buffer = PerceptionBuffer::new(AMBIENT);
+        let p = "carol";
+
+        // First look happens regardless.
+        buffer.should_warm(p, 0, false).expect("first look").store(false, Ordering::Release);
+
+        // STATIC (changed=false): gated until the SLOW baseline floor — but NOT forever.
+        assert!(
+            buffer.should_warm(p, AMBIENT_WARM_MIN_INTERVAL_MS, false).is_none(),
+            "static past the min ceiling is still gated — no change, don't spend a describe"
+        );
+        assert!(
+            buffer.should_warm(p, AMBIENT_WARM_BASELINE_INTERVAL_MS - 1, false).is_none(),
+            "static within the baseline floor → still gated"
+        );
+        buffer
+            .should_warm(p, AMBIENT_WARM_BASELINE_INTERVAL_MS, false)
+            .expect("static past the baseline floor → STILL warms (slow cadence, not none)")
+            .store(false, Ordering::Release);
+
+        // CHANGE escalates: a relevant change warms as soon as the MIN ceiling allows,
+        // long before the baseline floor.
+        let t = AMBIENT_WARM_BASELINE_INTERVAL_MS + AMBIENT_WARM_MIN_INTERVAL_MS;
+        buffer
+            .should_warm(p, t, true)
+            .expect("change past the min ceiling → escalates, no need to wait for the floor")
+            .store(false, Ordering::Release);
     }
 
     // what this catches: never STACK a warm — while one is in flight, later observes are
@@ -340,18 +407,18 @@ mod tests {
         let p = "bob";
 
         // Launch a warm and DON'T release it (simulates a describe still running).
-        let _held = buffer.should_warm(p, 0).expect("first warms");
+        let _held = buffer.should_warm(p, 0, true).expect("first warms");
 
         // Even far past the interval, a second warm is refused while one is in flight.
         assert!(
-            buffer.should_warm(p, AMBIENT_WARM_MIN_INTERVAL_MS * 100).is_none(),
+            buffer.should_warm(p, AMBIENT_WARM_BASELINE_INTERVAL_MS * 100, true).is_none(),
             "in-flight guard blocks stacking regardless of elapsed time"
         );
 
         // Once it completes, the next due tick warms again.
         _held.store(false, Ordering::Release);
         assert!(
-            buffer.should_warm(p, AMBIENT_WARM_MIN_INTERVAL_MS * 100).is_some(),
+            buffer.should_warm(p, AMBIENT_WARM_BASELINE_INTERVAL_MS * 100, true).is_some(),
             "warm reopens after the in-flight one finishes"
         );
     }

--- a/core/continuum-core/src/media/perception_buffer.rs
+++ b/core/continuum-core/src/media/perception_buffer.rs
@@ -104,6 +104,24 @@ impl FrameRing {
     fn window(&self, k: usize) -> impl Iterator<Item = &MediaFrame> {
         self.frames.iter().take(k)
     }
+
+    /// RAM held by this ring: the sum of frame source bytes (Arc-shared, but this ring is
+    /// the owner that can drop them). The honest footprint perception can reclaim.
+    fn resident_bytes(&self) -> u64 {
+        self.frames.iter().map(|f| f.source().len() as u64).sum()
+    }
+
+    /// Evict oldest frames (from the back) to free ~`want_bytes`, but ALWAYS keep the head
+    /// (the room-as-now frame — never blind the persona). Returns bytes actually freed.
+    fn evict_oldest(&mut self, want_bytes: u64) -> u64 {
+        let mut freed = 0u64;
+        while self.frames.len() > 1 && freed < want_bytes {
+            if let Some(f) = self.frames.pop_back() {
+                freed += f.source().len() as u64;
+            }
+        }
+        freed
+    }
 }
 
 /// Per-participant warm-cadence gate. Coalescing the latest frame is unconditional
@@ -424,6 +442,44 @@ impl PerceptionBuffer {
             });
         }
         out
+    }
+
+    /// Total RAM held by this buffer's rings (frame source bytes) — the honest footprint
+    /// perception owns and can reclaim. Derivatives (thumbnails/descriptions/signatures)
+    /// live in the SHARED compute cache, not here, so they are not double-counted.
+    pub fn resident_bytes(&self) -> u64 {
+        self.rings
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .map(|r| r.resident_bytes())
+            .sum()
+    }
+
+    /// Evict oldest ring frames across sources to free ~`want_bytes` (keeping each source's
+    /// head — room-as-now). Returns bytes ACTUALLY freed (honest, never over-reports).
+    pub fn evict_at_least(&self, want_bytes: u64) -> u64 {
+        let mut rings = self.rings.lock().unwrap_or_else(|e| e.into_inner());
+        let mut freed = 0u64;
+        for ring in rings.values_mut() {
+            if freed >= want_bytes {
+                break;
+            }
+            freed += ring.evict_oldest(want_bytes - freed);
+        }
+        freed
+    }
+
+    /// Test-only: push a frame directly onto a source's ring without spawning warms — lets
+    /// sibling-module tests (e.g. `modules::perception_consumer`) seed known residency.
+    #[cfg(test)]
+    pub(crate) fn seed_frame_for_test(&self, source: &str, frame: MediaFrame) {
+        self.rings
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .entry(source.to_string())
+            .or_insert_with(|| FrameRing::with_capacity(self.ring_capacity))
+            .push(frame);
     }
 
     /// Drop a participant that left the call.

--- a/core/continuum-core/src/media/perception_buffer.rs
+++ b/core/continuum-core/src/media/perception_buffer.rs
@@ -16,6 +16,7 @@
 //! ([[perception-feedback-must-not-blow-rag]]).
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use super::frame::{FrameDescriber, MediaFrame};
@@ -25,6 +26,32 @@ use crate::runtime::SharedCompute;
 /// The airc participant identity (peer id) a frame belongs to. Never a parallel
 /// call/session id — the room roster is the truth.
 pub type ParticipantId = String;
+
+/// The MINIMUM spacing between expensive cell-warms (scale + LLM describe) per
+/// participant — the perception plane's sample rate, DECOUPLED from the media frame
+/// rate. A live call runs 30fps for smooth human video + avatars (the display plane);
+/// a persona does NOT need a fresh vision-encode/description 30×/sec. At ~2 Hz the
+/// ambient "look" stays current while the LLM-describe cost stays bounded regardless
+/// of frame rate ([[multimodal-live-mode-is-a-latency-obsession-cbar-doctrine]],
+/// [[avatar-render-is-a-resolution-field-attention-priced]]). Birth default; the
+/// governor makes this an attention-priced resolution field later (#173) — a focused
+/// persona looks more often, an idle one less.
+pub const AMBIENT_WARM_MIN_INTERVAL_MS: u64 = 500;
+
+/// Per-participant warm-cadence gate. Coalescing the latest frame is unconditional
+/// and O(1); only the EXPENSIVE warm (scale + describe) passes through this gate, so
+/// a 30fps ingest coalesces 30 frames/sec into one latest but triggers at most
+/// ~2 describes/sec, and never stacks a second warm on an unfinished one.
+#[derive(Default)]
+struct WarmGate {
+    /// Monotonic ms of the last warm we launched for this participant.
+    last_warm_ms: u64,
+    /// False until the first warm — so a participant's first frame warms immediately.
+    warmed_once: bool,
+    /// Held `true` for the duration of an in-flight warm task; a concurrent observe
+    /// that sees it set skips (no stacking a slow describe under a fast stream).
+    in_flight: Arc<AtomicBool>,
+}
 
 /// What a persona perceives of ONE participant RIGHT NOW — only the cells that have
 /// RESOLVED. Each field holds the cache's `Arc` (zero-copy); `None` = not-ready-this-tick
@@ -55,6 +82,12 @@ pub struct PerceptionBuffer {
     /// The ambient forced-look size (~480w default) — the cheap thumbnail cell every tick
     /// warms + reads. Full-res / bigger is the drill-in tool, not the ambient path.
     ambient: DestSize,
+    /// Per-participant warm-cadence gates — the seam that keeps the expensive cells off
+    /// the media frame rate. See [`WarmGate`] and [`AMBIENT_WARM_MIN_INTERVAL_MS`].
+    warm_gates: Mutex<HashMap<ParticipantId, WarmGate>>,
+    /// Minimum ms between warms per participant (the perception sample rate). Field, not
+    /// hardcoded at the call site, so the governor can retune it per persona later (#173).
+    min_warm_interval_ms: u64,
 }
 
 impl PerceptionBuffer {
@@ -62,13 +95,43 @@ impl PerceptionBuffer {
         Self {
             latest: Mutex::new(HashMap::new()),
             ambient,
+            warm_gates: Mutex::new(HashMap::new()),
+            min_warm_interval_ms: AMBIENT_WARM_MIN_INTERVAL_MS,
         }
     }
 
+    /// The warm-cadence DECISION (pure + testable): should this observe launch a cell
+    /// warm for `participant` at `now_ms`? Returns the in-flight flag to hold for the
+    /// warm's duration when YES; `None` when the warm is GATED — either one is already
+    /// in flight (never stack), or we warmed within `min_warm_interval_ms` (the frame
+    /// rate outruns the perception sample rate). The 30fps-safety guarantee lives here,
+    /// separated from the spawn so it can be asserted without timing or a runtime.
+    fn should_warm(&self, participant: &str, now_ms: u64) -> Option<Arc<AtomicBool>> {
+        let mut gates = self.warm_gates.lock().unwrap_or_else(|e| e.into_inner());
+        let g = gates.entry(participant.to_string()).or_default();
+        // Never stack a warm on an unfinished one — protects against a describe slower
+        // than the interval under a fast stream.
+        if g.in_flight.load(Ordering::Acquire) {
+            return None;
+        }
+        let due = !g.warmed_once
+            || now_ms.saturating_sub(g.last_warm_ms) >= self.min_warm_interval_ms;
+        if !due {
+            return None;
+        }
+        g.warmed_once = true;
+        g.last_warm_ms = now_ms;
+        g.in_flight.store(true, Ordering::Release);
+        Some(g.in_flight.clone())
+    }
+
     /// Ingest a frame for `participant`: COALESCE to the latest (room-as-now — a newer frame
-    /// replaces the old), then FIRE the ambient cell warms (thumbnail + description) on a
-    /// spawned task and return IMMEDIATELY. Non-blocking — the ingest path never awaits the
-    /// cells. Must be called within a tokio runtime (the live LiveKit ingest path always is).
+    /// replaces the old) UNCONDITIONALLY (an O(1) mutex insert, safe to call at 30fps — the
+    /// media/display plane), then FIRE the ambient cell warms (thumbnail + description) on a
+    /// spawned task ONLY when the cadence gate opens ([`should_warm`](Self::should_warm)) and
+    /// return IMMEDIATELY. Non-blocking — the ingest path never awaits the cells. `now_ms` is
+    /// the caller's monotonic clock (substrate passes time in; no `Instant::now` in the media
+    /// core). Must be called within a tokio runtime (the live LiveKit ingest path always is).
     pub fn observe(
         &self,
         participant: ParticipantId,
@@ -76,20 +139,30 @@ impl PerceptionBuffer {
         compute: Arc<SharedCompute>,
         describer: Arc<dyn FrameDescriber>,
         mime: &str,
+        now_ms: u64,
     ) {
-        // Coalesce: the latest frame per participant wins; the old one is dropped.
+        // Coalesce ALWAYS: the latest frame per participant wins; the old one is dropped.
+        // Cheap enough for the 30fps media plane — perception samples it, doesn't mirror it.
         self.latest
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .insert(participant, frame.clone());
+            .insert(participant.clone(), frame.clone());
 
-        // Fire-and-forget the ambient cells async — compute-once per content-hash, shared to
-        // every viewer; a re-observe of the same bytes is a cache hit (no recompute).
+        // Gate the EXPENSIVE warm to the perception sample rate. A gated tick simply
+        // returns — its frame is already the coalesced latest and will warm on the next
+        // open tick (room-as-now). compute-once per content-hash still applies on top:
+        // re-warming identical bytes is a cache hit.
+        let Some(in_flight) = self.should_warm(&participant, now_ms) else {
+            return;
+        };
+
         let ambient = self.ambient;
         let mime = mime.to_string();
         tokio::spawn(async move {
             let _ = frame.scaled(&compute, None, ambient).await; // warm ~480w thumbnail
             let _ = frame.description(&compute, describer.as_ref(), &mime).await; // warm describe
+            // Release the gate so the next due tick can warm the then-latest frame.
+            in_flight.store(false, Ordering::Release);
         });
     }
 
@@ -171,9 +244,9 @@ mod tests {
 
         let old = MediaFrame::from_bytes(png(40, 40));
         let new = MediaFrame::from_bytes(png(60, 40)); // different bytes → different hash
-        buffer.observe("alice".into(), old.clone(), compute.clone(), describer.clone(), "image/png");
-        buffer.observe("alice".into(), new.clone(), compute.clone(), describer.clone(), "image/png");
-        buffer.observe("bob".into(), MediaFrame::from_bytes(png(20, 20)), compute.clone(), describer.clone(), "image/png");
+        buffer.observe("alice".into(), old.clone(), compute.clone(), describer.clone(), "image/png", 0);
+        buffer.observe("alice".into(), new.clone(), compute.clone(), describer.clone(), "image/png", 1);
+        buffer.observe("bob".into(), MediaFrame::from_bytes(png(20, 20)), compute.clone(), describer.clone(), "image/png", 2);
 
         assert_eq!(buffer.len(), 2, "alice coalesced, bob separate → 2 participants");
         let percepts = buffer.current_percepts(&compute);
@@ -220,9 +293,66 @@ mod tests {
         let buffer = PerceptionBuffer::new(AMBIENT);
         let compute = Arc::new(SharedCompute::new());
         let describer: Arc<dyn FrameDescriber> = Arc::new(StubDescriber);
-        buffer.observe("alice".into(), MediaFrame::from_bytes(png(10, 10)), compute, describer, "image/png");
+        buffer.observe("alice".into(), MediaFrame::from_bytes(png(10, 10)), compute, describer, "image/png", 0);
         assert_eq!(buffer.len(), 1);
         buffer.remove("alice");
         assert!(buffer.is_empty());
+    }
+
+    // what this catches: the 30fps SAFETY guarantee, as a pure decision (no timing/spawn).
+    // The first frame warms; further frames WITHIN the interval are gated even though they
+    // are distinct content (the frame rate outruns the perception sample rate); once the
+    // interval elapses the next warm is due again. This is what keeps a 30fps stream from
+    // triggering 30 LLM describes/sec.
+    #[test]
+    fn warm_cadence_gates_within_the_interval_and_reopens_after() {
+        let buffer = PerceptionBuffer::new(AMBIENT);
+        let p = "alice";
+
+        // First ever frame → warms immediately; holds the in-flight flag.
+        let flag = buffer.should_warm(p, 0).expect("first frame warms");
+        // Simulate the warm completing so the in-flight guard is not what's under test.
+        flag.store(false, Ordering::Release);
+
+        // A distinct frame 10ms later (30fps ≈ 33ms apart) → GATED by cadence.
+        assert!(
+            buffer.should_warm(p, 10).is_none(),
+            "a frame within the interval is gated — perception samples, not mirrors, 30fps"
+        );
+        assert!(
+            buffer.should_warm(p, AMBIENT_WARM_MIN_INTERVAL_MS - 1).is_none(),
+            "still within the interval → still gated"
+        );
+
+        // Once the interval elapses, the next warm is due again.
+        let flag2 = buffer
+            .should_warm(p, AMBIENT_WARM_MIN_INTERVAL_MS)
+            .expect("interval elapsed → warm is due");
+        flag2.store(false, Ordering::Release);
+    }
+
+    // what this catches: never STACK a warm — while one is in flight, later observes are
+    // gated even if the interval has elapsed, so a describe slower than the interval under
+    // a fast stream cannot pile up concurrent inferences.
+    #[test]
+    fn warm_gate_never_stacks_an_in_flight_warm() {
+        let buffer = PerceptionBuffer::new(AMBIENT);
+        let p = "bob";
+
+        // Launch a warm and DON'T release it (simulates a describe still running).
+        let _held = buffer.should_warm(p, 0).expect("first warms");
+
+        // Even far past the interval, a second warm is refused while one is in flight.
+        assert!(
+            buffer.should_warm(p, AMBIENT_WARM_MIN_INTERVAL_MS * 100).is_none(),
+            "in-flight guard blocks stacking regardless of elapsed time"
+        );
+
+        // Once it completes, the next due tick warms again.
+        _held.store(false, Ordering::Release);
+        assert!(
+            buffer.should_warm(p, AMBIENT_WARM_MIN_INTERVAL_MS * 100).is_some(),
+            "warm reopens after the in-flight one finishes"
+        );
     }
 }

--- a/core/continuum-core/src/media/perception_buffer.rs
+++ b/core/continuum-core/src/media/perception_buffer.rs
@@ -137,6 +137,41 @@ impl Percept {
     }
 }
 
+/// An à la carte look request — WHICH sources a persona wants to see right now. The PULL
+/// side of perception (the persona's explicit ask), distinct from the ambient PUSH (the
+/// warm band). "Into their vision à la carte" — the persona composes its own view.
+#[derive(Clone, Debug)]
+pub enum LookScope {
+    /// One participant's most-current frame.
+    Source(ParticipantId),
+    /// Every participant's most-current frame — the contact-sheet / gallery.
+    Everyone,
+}
+
+/// The image fidelity of a look. Higher-res is just a different SIZE on the same content
+/// hash, so it's compute-once/shared exactly like the thumbnail (a higher-res look another
+/// persona already asked for is a cache hit here). `Full` is the raw frame bytes.
+#[derive(Clone, Copy, Debug)]
+pub enum LookFidelity {
+    /// The ambient thumbnail (~480w) — the cheap default.
+    Thumbnail,
+    /// A specific resolution (higher OR lower than ambient).
+    Res(DestSize),
+    /// The raw source frame, unscaled.
+    Full,
+}
+
+/// One satisfied look — the image bytes for a source at the requested fidelity, shared
+/// (`Arc`, zero-copy for the scaled path). `Err` surfaces a real failure, never a
+/// fabricated image ([[fallbacks-are-illegal-fail-loud]]).
+#[derive(Clone)]
+pub struct LookImage {
+    pub participant: ParticipantId,
+    pub content_hash: String,
+    pub fidelity: LookFidelity,
+    pub image: Arc<Result<Vec<u8>, String>>,
+}
+
 /// Non-blocking, room-as-now perception hold. One latest frame per airc participant; cells
 /// warm async on the shared cache; reads take only what's ready.
 pub struct PerceptionBuffer {
@@ -302,6 +337,56 @@ impl PerceptionBuffer {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    /// à la carte PULL: satisfy a persona's EXPLICIT request for image(s) — of one source or
+    /// the whole group, at a chosen fidelity — ASAP. A warm cell returns instant; a cold one
+    /// is warmed NOW (compute-once/shared on the content hash, so a higher-res look another
+    /// persona already pulled is a cache hit). This is the ONE place perception AWAITS: a
+    /// deliberate ask, not the ambient hot path — and it implicitly JUMPS the warm cadence
+    /// band (it never consults the ambient gate, it computes-or-hits directly). Unknown source
+    /// → empty (never a fabricated look).
+    pub async fn look(
+        &self,
+        scope: LookScope,
+        fidelity: LookFidelity,
+        compute: &SharedCompute,
+    ) -> Vec<LookImage> {
+        // Snapshot the target heads UNDER the lock (cheap Arc-backed clones), then await
+        // compute OUTSIDE it — never hold a Mutex across an await.
+        let targets: Vec<(ParticipantId, MediaFrame)> = {
+            let rings = self.rings.lock().unwrap_or_else(|e| e.into_inner());
+            match scope {
+                LookScope::Source(id) => rings
+                    .get(&id)
+                    .and_then(|r| r.head().cloned())
+                    .map(|f| (id, f))
+                    .into_iter()
+                    .collect(),
+                LookScope::Everyone => rings
+                    .iter()
+                    .filter_map(|(id, r)| r.head().cloned().map(|f| (id.clone(), f)))
+                    .collect(),
+            }
+        };
+
+        let mut out = Vec::with_capacity(targets.len());
+        for (participant, frame) in targets {
+            let image = match fidelity {
+                LookFidelity::Thumbnail => frame.scaled(compute, None, self.ambient).await,
+                LookFidelity::Res(dest) => frame.scaled(compute, None, dest).await,
+                // Deliberate full-res pull: hand back the raw bytes (a copy — the rare,
+                // explicit expensive path; the scaled paths stay zero-copy/shared).
+                LookFidelity::Full => Arc::new(Ok(frame.source().to_vec())),
+            };
+            out.push(LookImage {
+                participant,
+                content_hash: frame.content_hash().to_string(),
+                fidelity,
+                image,
+            });
+        }
+        out
     }
 
     /// Drop a participant that left the call.
@@ -484,6 +569,49 @@ mod tests {
 
         // Unknown participant → empty (never a fabricated look).
         assert!(buffer.window_percepts("nobody", 5, &compute).is_empty());
+    }
+
+    // what this catches: the à la carte PULL — a persona requests images of a SOURCE or the
+    // GROUP, at THUMBNAIL / higher-RES / FULL, satisfied ASAP. Higher-res is a distinct cache
+    // key on the same content-hash; a repeat pull is compute-once/shared (same Arc); FULL is
+    // the raw bytes; an unknown source pulls empty.
+    #[tokio::test]
+    async fn look_serves_source_or_group_at_requested_fidelity_asap_and_shared() {
+        let buffer = PerceptionBuffer::new(AMBIENT);
+        let compute = Arc::new(SharedCompute::new());
+        let describer: Arc<dyn FrameDescriber> = Arc::new(StubDescriber);
+
+        // Two sources present (via the ingest path — the head is what a look reads).
+        buffer.observe("alice".into(), MediaFrame::from_bytes(png(120, 90)), compute.clone(), describer.clone(), "image/png", 0);
+        buffer.observe("bob".into(), MediaFrame::from_bytes(png(64, 64)), compute.clone(), describer.clone(), "image/png", 0);
+
+        // SOURCE + THUMBNAIL: one image, at the ambient size, satisfied ASAP (awaited).
+        let a = buffer.look(LookScope::Source("alice".into()), LookFidelity::Thumbnail, &compute).await;
+        assert_eq!(a.len(), 1, "source scope → just that source");
+        assert_eq!(a[0].participant, "alice");
+        let bytes = a[0].image.as_ref().as_ref().expect("thumbnail resolved");
+        assert_eq!(image::load_from_memory(bytes).unwrap().width(), AMBIENT.width, "ambient thumbnail size");
+
+        // PREFER-WARM / compute-once: a second identical pull returns the SAME shared Arc.
+        let a2 = buffer.look(LookScope::Source("alice".into()), LookFidelity::Thumbnail, &compute).await;
+        assert!(Arc::ptr_eq(&a[0].image, &a2[0].image), "repeat pull is compute-once/shared, not recomputed");
+
+        // Higher-RES: a distinct size → a distinct derivative (bigger than the thumbnail).
+        let hi = DestSize { width: 96, height: 72 };
+        let r = buffer.look(LookScope::Source("alice".into()), LookFidelity::Res(hi), &compute).await;
+        assert_eq!(image::load_from_memory(r[0].image.as_ref().as_ref().unwrap()).unwrap().width(), hi.width, "higher-res honored");
+        assert!(!Arc::ptr_eq(&a[0].image, &r[0].image), "different fidelity → different cell");
+
+        // FULL: the raw source bytes (original 120×90).
+        let f = buffer.look(LookScope::Source("alice".into()), LookFidelity::Full, &compute).await;
+        assert_eq!(image::load_from_memory(f[0].image.as_ref().as_ref().unwrap()).unwrap().width(), 120, "full = raw frame");
+
+        // GROUP (Everyone) + THUMBNAIL: the contact-sheet — one image per source.
+        let group = buffer.look(LookScope::Everyone, LookFidelity::Thumbnail, &compute).await;
+        assert_eq!(group.len(), 2, "group scope → every source's current frame (the gallery)");
+
+        // Unknown source → empty (never a fabricated look).
+        assert!(buffer.look(LookScope::Source("nobody".into()), LookFidelity::Thumbnail, &compute).await.is_empty());
     }
 
     // what this catches: remove drops a participant who left the call.

--- a/core/continuum-core/src/media/perception_registry.rs
+++ b/core/continuum-core/src/media/perception_registry.rs
@@ -82,6 +82,39 @@ impl PerceptionRegistry {
             .expect("perception registry mutex poisoned by a prior panic")
             .remove(persona_id);
     }
+
+    /// Total RAM held across every persona's perception rings — the perception subsystem's
+    /// footprint reported to the resource governor (see `modules::perception_consumer`).
+    pub fn total_resident_bytes(&self) -> u64 {
+        self.buffers
+            .lock()
+            .expect("perception registry mutex poisoned by a prior panic")
+            .values()
+            .map(|b| b.resident_bytes())
+            .sum()
+    }
+
+    /// Evict oldest ring frames across every persona to free ~`want_bytes` (each source keeps
+    /// its head). Returns bytes actually freed — the governor's reclaim honored honestly.
+    pub fn evict_at_least(&self, want_bytes: u64) -> u64 {
+        // Clone the Arcs out so we don't hold the registry lock while each buffer locks its
+        // own rings (no nested lock, no lock across the per-buffer work).
+        let buffers: Vec<Arc<PerceptionBuffer>> = self
+            .buffers
+            .lock()
+            .expect("perception registry mutex poisoned by a prior panic")
+            .values()
+            .cloned()
+            .collect();
+        let mut freed = 0u64;
+        for b in buffers {
+            if freed >= want_bytes {
+                break;
+            }
+            freed += b.evict_at_least(want_bytes - freed);
+        }
+        freed
+    }
 }
 
 /// Process-global perception registry. Same `OnceLock` shape as

--- a/core/continuum-core/src/media/perception_registry.rs
+++ b/core/continuum-core/src/media/perception_registry.rs
@@ -1,0 +1,143 @@
+//! `PerceptionRegistry` — the process-global home for per-persona
+//! [`PerceptionBuffer`](super::perception_buffer::PerceptionBuffer)s.
+//!
+//! A persona's live-call perception buffer has TWO reachers that never hold each
+//! other: the LiveKit media INGEST path warms it (`observe()` a decoded frame — the
+//! WRITE side, #192/#193), and the persona's `MediaPerceptionSource` reads it under
+//! the RAG budget (the READ side, wired at supervisor boot). Both resolve the SAME
+//! buffer by `persona_id`, so a frame warmed by ingest is exactly what the source
+//! delivers. This registry is that single seam — one `Arc<PerceptionBuffer>` per
+//! persona, resolved by id from both sides. It is NOT a parallel copy of any state;
+//! it is the single home for a persona's perception hold, the same "one home, two
+//! reachers by id" shape as [`persona::focus::registry()`](crate::persona::focus)
+//! and [`persona_workspace::global()`](crate::cognition::persona_workspace).
+//!
+//! The cells inside each buffer resolve on the ONE runtime
+//! [`SharedCompute`](crate::runtime::SharedCompute) (`shared_compute::global()`),
+//! so the compute-once/share-many payoff spans personas: four personas seeing the
+//! same participant's frame describe/scale it ONCE
+//! ([[vision-replication-is-the-multipersona-moat-vs-cloud]]).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use uuid::Uuid;
+
+use super::image_ops::DestSize;
+use super::perception_buffer::PerceptionBuffer;
+
+/// The ambient forced-look size every perception tick warms + reads — the cheap
+/// thumbnail cell, ~480w per the room-as-now doctrine. Full-res / bigger is the
+/// drill-in tool (#190), never the ambient path. 16:9 keeps a video frame's aspect
+/// without a crop. One policy constant, one place (the compression principle) —
+/// every persona's buffer is born with it.
+pub const AMBIENT_PERCEPTION_SIZE: DestSize = DestSize {
+    width: 480,
+    height: 270,
+};
+
+/// Per-persona perception-buffer home. One `Arc<PerceptionBuffer>` per persona,
+/// resolved by id from both the ingest (write) and source (read) sides.
+#[derive(Default)]
+pub struct PerceptionRegistry {
+    buffers: Mutex<HashMap<Uuid, Arc<PerceptionBuffer>>>,
+}
+
+impl PerceptionRegistry {
+    pub fn new() -> Self {
+        Self {
+            buffers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Resolve (get-or-create) the persona's perception buffer. Idempotent: the
+    /// first caller installs a buffer sized to [`AMBIENT_PERCEPTION_SIZE`] (the
+    /// correct birth posture, not a fallback over a missing precondition); every
+    /// later caller — the ingest path, the source — gets the SAME `Arc`, so what
+    /// ingest warms is exactly what the source reads. A poisoned lock is a prior
+    /// panic mid-mutation and is propagated (fail loud), never swallowed.
+    pub fn handle(&self, persona_id: Uuid) -> Arc<PerceptionBuffer> {
+        self.buffers
+            .lock()
+            .expect("perception registry mutex poisoned by a prior panic")
+            .entry(persona_id)
+            .or_insert_with(|| Arc::new(PerceptionBuffer::new(AMBIENT_PERCEPTION_SIZE)))
+            .clone()
+    }
+
+    /// Peek the buffer without creating one — `None` if this persona has never had
+    /// a perception buffer resolved (never joined a live call).
+    pub fn get(&self, persona_id: &Uuid) -> Option<Arc<PerceptionBuffer>> {
+        self.buffers
+            .lock()
+            .expect("perception registry mutex poisoned by a prior panic")
+            .get(persona_id)
+            .cloned()
+    }
+
+    /// Drop a persona's buffer when it despawns (frees the held frames). Idempotent.
+    pub fn remove(&self, persona_id: &Uuid) {
+        self.buffers
+            .lock()
+            .expect("perception registry mutex poisoned by a prior panic")
+            .remove(persona_id);
+    }
+}
+
+/// Process-global perception registry. Same `OnceLock` shape as
+/// `persona::focus::registry()` — the single seam between the media ingest that
+/// warms a persona's perception and the source that reads it.
+pub fn registry() -> Arc<PerceptionRegistry> {
+    static GLOBAL: OnceLock<Arc<PerceptionRegistry>> = OnceLock::new();
+    GLOBAL
+        .get_or_init(|| Arc::new(PerceptionRegistry::new()))
+        .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: get-or-create is idempotent — the SAME persona resolves to
+    // the SAME buffer Arc from both reachers (ingest warms exactly what the source
+    // reads); distinct personas get distinct buffers; the ambient size is applied.
+    #[test]
+    fn handle_resolves_one_buffer_per_persona_shared_across_reachers() {
+        let reg = PerceptionRegistry::new();
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+
+        let first = reg.handle(a);
+        let second = reg.handle(a); // second reacher (e.g. the source after ingest)
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "same persona → the SAME buffer Arc, so ingest and source never diverge"
+        );
+
+        let other = reg.handle(b);
+        assert!(
+            !Arc::ptr_eq(&first, &other),
+            "distinct personas → distinct buffers"
+        );
+    }
+
+    // what this catches: peek does not create, and remove frees the buffer.
+    #[test]
+    fn get_peeks_without_creating_and_remove_drops() {
+        let reg = PerceptionRegistry::new();
+        let p = Uuid::new_v4();
+
+        assert!(reg.get(&p).is_none(), "peek before touch → None (no create)");
+        let _ = reg.handle(p);
+        assert!(reg.get(&p).is_some(), "resolved → peekable");
+        reg.remove(&p);
+        assert!(reg.get(&p).is_none(), "removed → gone");
+    }
+
+    // what this catches: the process-global is a stable singleton (both callers get
+    // the same registry), so a persona's buffer is truly one home across the process.
+    #[test]
+    fn global_registry_is_a_stable_singleton() {
+        assert!(Arc::ptr_eq(&registry(), &registry()));
+    }
+}

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -58,6 +58,7 @@ pub mod mcp_transport;
 pub mod memory;
 pub mod nav;
 pub mod models;
+pub mod perception_consumer;
 pub mod persona_allocator;
 pub mod persona_instance_manager;
 pub mod persona_rag_inspect;

--- a/core/continuum-core/src/modules/perception_consumer.rs
+++ b/core/continuum-core/src/modules/perception_consumer.rs
@@ -1,0 +1,174 @@
+//! `PerceptionConsumer` — perception's seat at the resource-governor table.
+//!
+//! Live-call perception holds RAM: one bounded [`FrameRing`](crate::media::PerceptionBuffer)
+//! per source per persona, each a handful of decoded frame blobs. That is real, reclaimable
+//! residency, so — exactly like [`ServingConsumer`](super::serving_consumer) (VRAM),
+//! [`BevyConsumer`](super::bevy_consumer) (render VRAM), and
+//! [`VoiceConsumer`](super::live_session_consumer) (TTS) — perception registers as a peer
+//! [`ResourceConsumer`] and LEASES rather than growing unaccounted
+//! ([[resource-authority-is-a-system-concern]], #56). It reports its footprint and, when the
+//! authority asks for bytes back under pressure, evicts oldest ring frames — always keeping
+//! each source's HEAD so the persona is never blinded (room-as-now survives a reclaim).
+//!
+//! Perception does NOT hold VRAM: the vision-describe it triggers runs on the SERVED VL model,
+//! whose VRAM is [`ServingConsumer`]'s footprint — perception is a *demander* of that lane, not
+//! a holder of its bytes. The shared derivative cache (thumbnails/descriptions/signatures on
+//! `SharedCompute`) is likewise not double-counted here; this consumer accounts only the frame
+//! rings perception owns.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::media::perception_registry::PerceptionRegistry;
+use crate::resources::{
+    ConsumerFootprint, ReclaimOutcome, ReclaimRequest, ReclaimStatus, ResourceConsumer,
+    ResourceKind,
+};
+
+/// Stable id matching this consumer's leases in the governor ledger.
+pub const PERCEPTION_CONSUMER_ID: &str = "perception";
+
+/// Accounts + reclaims the RAM held by every persona's perception frame rings, read live
+/// from the process-global [`PerceptionRegistry`].
+pub struct PerceptionConsumer {
+    registry: Arc<PerceptionRegistry>,
+}
+
+impl PerceptionConsumer {
+    pub fn new(registry: Arc<PerceptionRegistry>) -> Self {
+        Self { registry }
+    }
+}
+
+#[async_trait]
+impl ResourceConsumer for PerceptionConsumer {
+    fn consumer_id(&self) -> &str {
+        PERCEPTION_CONSUMER_ID
+    }
+
+    fn footprint(&self) -> Vec<ConsumerFootprint> {
+        let bytes = self.registry.total_resident_bytes();
+        // Idle (no live call / no frames) → report nothing, like the sibling consumers do
+        // when not running: no zero-byte noise for the daemon to reconcile.
+        if bytes == 0 {
+            return Vec::new();
+        }
+        vec![ConsumerFootprint {
+            kind: ResourceKind::Ram,
+            bytes,
+            detail: "live-call perception frame rings".to_string(),
+        }]
+    }
+
+    async fn reclaim(&self, request: ReclaimRequest) -> ReclaimOutcome {
+        // Perception holds only RAM. An ask for any other kind is honestly refused (named,
+        // never a silent freed=0) so the authority does not misread it.
+        if request.kind != ResourceKind::Ram {
+            return ReclaimOutcome::refused(format!(
+                "perception holds no {:?}, only Ram (frame rings)",
+                request.kind
+            ));
+        }
+
+        let freed = self.registry.evict_at_least(request.target_bytes);
+        if freed >= request.target_bytes {
+            ReclaimOutcome::released(freed)
+        } else {
+            // We kept each source's head (room-as-now) — freeing more would blind a live
+            // perceiver. Honest Partial: the authority keeps the lease and may re-ask.
+            ReclaimOutcome {
+                freed_bytes: freed,
+                status: ReclaimStatus::Partial,
+                detail: Some("kept each source's current frame (room-as-now)".to_string()),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::image_ops::DestSize;
+    use crate::media::{MediaFrame, PerceptionBuffer};
+    use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
+    use std::io::Cursor;
+    use uuid::Uuid;
+
+    const AMBIENT: DestSize = DestSize { width: 32, height: 24 };
+
+    fn png(w: u32, h: u32) -> Vec<u8> {
+        let img = RgbaImage::from_pixel(w, h, Rgba([(w % 256) as u8, 0, 0, 255]));
+        let mut out = Cursor::new(Vec::new());
+        DynamicImage::ImageRgba8(img).write_to(&mut out, ImageFormat::Png).unwrap();
+        out.into_inner()
+    }
+
+    /// A registry with one persona whose ring holds three DISTINCT frames (seeded directly,
+    /// no async warm). Returns the registry + the known resident-byte total.
+    fn registry_with_three_frames() -> (Arc<PerceptionRegistry>, u64) {
+        let registry = Arc::new(PerceptionRegistry::new());
+        let buffer: Arc<PerceptionBuffer> = registry.handle(Uuid::new_v4());
+        let frames = [png(40, 40), png(41, 41), png(42, 42)];
+        let total: u64 = frames.iter().map(|b| b.len() as u64).sum();
+        for bytes in &frames {
+            buffer.seed_frame_for_test("s", MediaFrame::from_bytes(bytes.clone()));
+        }
+        (registry, total)
+    }
+
+    // what this catches: footprint reports the RAM the rings hold (sum of frame bytes) as
+    // Ram, and is EMPTY when idle — the governor accounts perception like serving/bevy/voice.
+    #[tokio::test]
+    async fn footprint_reports_ring_ram_and_is_empty_when_idle() {
+        let idle = PerceptionConsumer::new(Arc::new(PerceptionRegistry::new()));
+        assert!(idle.footprint().is_empty(), "no frames → no footprint");
+
+        let (registry, total) = registry_with_three_frames();
+        let consumer = PerceptionConsumer::new(registry);
+        let fp = consumer.footprint();
+        assert_eq!(fp.len(), 1);
+        assert_eq!(fp[0].kind, ResourceKind::Ram);
+        assert_eq!(fp[0].bytes, total, "footprint == sum of ring frame bytes");
+    }
+
+    // what this catches: reclaim(Ram) evicts oldest frames toward the target but KEEPS each
+    // source's head → a target it can't fully hit returns honest Partial with what it freed;
+    // a non-Ram ask is refused (named, not silent).
+    #[tokio::test]
+    async fn reclaim_evicts_oldest_keeps_head_and_refuses_wrong_kind() {
+        let (registry, total) = registry_with_three_frames();
+        let consumer = PerceptionConsumer::new(registry.clone());
+
+        // Wrong kind → refused, freed nothing.
+        let refused = consumer
+            .reclaim(ReclaimRequest {
+                kind: ResourceKind::Vram,
+                target_bytes: 1,
+                deadline_ms: 10,
+                reason: crate::resources::ReclaimReason::Pressure,
+            })
+            .await;
+        assert_eq!(refused.status, ReclaimStatus::Refused);
+        assert_eq!(refused.freed_bytes, 0);
+
+        // Ask for MORE than is evictable (everything, including the head): we free the two
+        // oldest but keep the head → Partial, freed < total, head's bytes remain.
+        let outcome = consumer
+            .reclaim(ReclaimRequest {
+                kind: ResourceKind::Ram,
+                target_bytes: total,
+                deadline_ms: 10,
+                reason: crate::resources::ReclaimReason::Pressure,
+            })
+            .await;
+        assert_eq!(outcome.status, ReclaimStatus::Partial, "kept the head → partial");
+        assert!(outcome.freed_bytes > 0 && outcome.freed_bytes < total, "freed the old, kept the head");
+        assert_eq!(
+            registry.total_resident_bytes(),
+            total - outcome.freed_bytes,
+            "residency dropped by exactly what was freed (honest)"
+        );
+        assert!(registry.total_resident_bytes() > 0, "the head frame survives — never blind");
+    }
+}

--- a/core/continuum-core/src/persona/media_perception_source.rs
+++ b/core/continuum-core/src/persona/media_perception_source.rs
@@ -194,7 +194,7 @@ mod tests {
         let frame = MediaFrame::from_bytes(png(60, 40));
         frame.scaled(&compute, None, AMBIENT).await;
         frame.description(&compute, &StubDescriber, "image/png").await;
-        buffer.observe("alice-peer".into(), frame, compute.clone(), describer, "image/png");
+        buffer.observe("alice-peer".into(), frame, compute.clone(), describer, "image/png", 0);
         (
             MediaPerceptionSource::new(pid, buffer, compute.clone()),
             compute,
@@ -239,6 +239,7 @@ mod tests {
             compute.clone(),
             Arc::new(StubDescriber),
             "image/png",
+            0,
         );
         // (observe spawns a warm task, but we don't await it — read immediately.)
         let src = MediaPerceptionSource::new(pid, buffer, compute);

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -723,6 +723,31 @@ pub async fn materialize_adapters(
                 // the eval fork's nil room) — the exam-bleed fix (#127).
                 .for_room(identity.default_room));
 
+        // Live-call perception: the persona's room-as-NOW visual grounding — WHO is
+        // visible on the call + a description of what they show, read NON-BLOCKING from
+        // the persona's PerceptionBuffer (only cells resolved this tick; the turn never
+        // waits) and BUDGETED through the same flexbox allocator so perception can never
+        // dominate context ([[perception-feedback-must-not-blow-rag]]).
+        //
+        // The buffer is the ADDRESSABLE home in `media::perception_registry` — the ONE
+        // seam the LiveKit media ingest (#192/#193) warms via `observe()` and this source
+        // reads, resolved by persona_id from BOTH sides (the "one home, two reachers"
+        // shape of `focus::registry()`). Its cells resolve on the runtime's ONE
+        // `SharedCompute` (`shared_compute::global()`, which the Runtime adopts), so a
+        // frame warmed once by ingest is a cache hit for EVERY viewing persona:
+        // compute-once / share-many, the multi-persona vision moat
+        // ([[vision-replication-is-the-multipersona-moat-vs-cloud]]). Empty until frames
+        // arrive — this wires the READ path into cognition; the video_rx → observe ingest
+        // is #192.
+        let perception_buffer =
+            crate::media::perception_registry().handle(identity.peer_id.as_uuid());
+        let media_perception_source: Arc<dyn crate::persona::rag_budget::RagSource> =
+            Arc::new(crate::persona::media_perception_source::MediaPerceptionSource::new(
+                identity.peer_id.as_uuid(),
+                perception_buffer,
+                crate::runtime::shared_compute::global(),
+            ));
+
         // Disk-backed, per-persona memory: open <home>/engrams.sqlite and
         // rehydrate prior engrams + recall metadata, so memory SURVIVES restart.
         // Without this, admission is in-memory only (NoopSink) and the persona is
@@ -844,6 +869,18 @@ pub async fn materialize_adapters(
                     // under-grounded turn, not a wrong one. Task #117 O6.
                     crate::cognition::persona_workspace::GroundingSource::framing(
                         room_board_source,
+                    )
+                    .defer_tolerant(),
+                    // Live-call perception (#187/#192): WHO is visible on the call +
+                    // what they show, as enriching framing. Defer-tolerant: a
+                    // first-tick miss costs one under-grounded turn, not a wrong one —
+                    // and perception is non-blocking by construction (absent cells are
+                    // simply not present this tick, never awaited). NOT requires_hands:
+                    // seeing is a SENSE, not a tool, so it stays present in a
+                    // tool-stripped (spoken-exam) cycle. Reads only ready cells (O(participants)
+                    // string assembly, no inference) — off the 30fps media plane entirely.
+                    crate::cognition::persona_workspace::GroundingSource::framing(
+                        media_perception_source,
                     )
                     .defer_tolerant(),
                 ],

--- a/core/continuum-core/src/runtime/runtime.rs
+++ b/core/continuum-core/src/runtime/runtime.rs
@@ -53,7 +53,14 @@ impl Runtime {
         Self {
             registry: Arc::new(ModuleRegistry::new()),
             bus: Arc::new(MessageBus::new()),
-            compute: Arc::new(SharedCompute::new()),
+            // Adopt the ONE process-global compute-once/share-many cache (not a
+            // private instance) so a module reaching it via `ModuleContext.compute`
+            // and a persona's `MediaPerceptionSource` reaching it via
+            // `shared_compute::global()` share the SAME derivatives — the media
+            // ingest that warms a frame and the perception source that reads it
+            // cannot diverge. Content-addressed + pure, so one shared cache is
+            // correct ([[media-is-compute-once-zero-copy-hardware-grade]]).
+            compute: super::shared_compute::global(),
             concurrency_limits: Arc::new(DashMap::new()),
             provider_registry: Arc::new(super::ProviderRegistry::new()),
         }

--- a/core/continuum-core/src/runtime/shared_compute.rs
+++ b/core/continuum-core/src/runtime/shared_compute.rs
@@ -18,7 +18,7 @@
 
 use dashmap::DashMap;
 use std::any::Any;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tokio::sync::OnceCell;
 
 /// A lazy-computed value. Computed once, shared via Arc.
@@ -133,6 +133,30 @@ impl SharedCompute {
     pub fn key_count(&self, scope: &str) -> usize {
         self.cache.get(scope).map(|m| m.len()).unwrap_or(0)
     }
+}
+
+/// The ONE process-global compute-once/share-many cache.
+///
+/// Media derivatives (a frame's scaled thumbnails, its text description, its
+/// vision-encode KV) are keyed by content hash, so two personas looking at the
+/// same frame must share ALL of its derivatives — the compute-once/share-many
+/// property that IS the multi-persona vision moat. A *parallel* cache would
+/// silently double every describe/scale, so the substrate keeps exactly one
+/// instance ([[media-is-compute-once-zero-copy-hardware-grade]],
+/// [[vision-replication-is-the-multipersona-moat-vs-cloud]]).
+///
+/// [`Runtime::new`](crate::runtime::Runtime::new) ADOPTS this instance for its own
+/// `compute` handle, so a module reaching it via `ModuleContext.compute` and a
+/// persona reaching it via this accessor see the SAME cache — the LiveKit media
+/// ingest that warms a frame's cells and the `MediaPerceptionSource` that reads
+/// them cannot diverge. Lazily created; the cache is content-addressed and pure,
+/// so sharing across every consumer (including the substrate `Runtime`) is
+/// correct by construction.
+pub fn global() -> Arc<SharedCompute> {
+    static GLOBAL: OnceLock<Arc<SharedCompute>> = OnceLock::new();
+    GLOBAL
+        .get_or_init(|| Arc::new(SharedCompute::new()))
+        .clone()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Wires live-call **perception into the persona's cognition** and builds the shared, governed, universal perception substrate underneath it. 7 validated commits; the whole media suite is green.

The mental model (fully captured in memory): **one shared pre-warmed ring per source; personas hold cursors/views; serving is a query** — grouped (gallery) or windowed (history) or à la carte pull — and it's all the persona's *own* self-directed view. The system is the humble RTOS-like daemon that is everyone's eyes.

## Commits

1. **read-path into cognition + single-source `SharedCompute`** — `MediaPerceptionSource` lifted into each persona's Workspace grounding (task-#12 bridge); `Runtime` adopts the ONE global compute so cross-persona cost is **O(distinct frames), not O(personas)** (the multi-persona vision moat).
2. **ingest cadence gate** — `observe()` coalesces at 30fps (O(1)) but gates the expensive warm; 30fps-safe by construction.
3. **warm band** — slow baseline floor (never off) + change escalation to the min ceiling; governor-tunable per persona (#173).
4. **`FrameRing` store** — bounded sliding window = the pre-warmed cache in one object; grouped (`current_percepts`) + windowed (`window_percepts`) reads.
5. **`look()` à la carte** — pull a source or the group at thumbnail / higher-res / full, satisfied ASAP (warm hit instant, cold warmed now, jumps the band); higher-res is a size-key on the same content hash, so compute-once/shared.
6. **change-monitor cell** — real 16×12 luma-signature diff drives the band (static → floor, change → ceiling); shared fingerprint, works for any view (call/game/page/movie).
7. **`PerceptionConsumer`** — perception joins the resource governor (#56) as a peer beside Serving/Bevy/Voice: reports **RAM** (ring frame bytes), reclaim evicts oldest frames but always keeps each source's head (never blinds a live perceiver).

## Scope / honesty

- Perception holds **RAM** (the rings), not VRAM — the vision-describe runs on the served VL model (that's `ServingConsumer`'s footprint). No double-counting the shared derivative cache.
- `unified.rs` (the brain) is **untouched** — perception is a NEW source wired only to the target Workspace path, not the legacy compose path mid-cutover.

## Validation status

- ✅ Unit: full `media::*` + `PerceptionConsumer` + `shared_compute` suites green; `should_warm`/band logic pure-tested; runtime isolation confirmed after the global-compute adoption.
- ⏳ **Not yet live-validated end-to-end.** The read path delivers **empty until frames arrive** — the `video_rx → observe` LiveKit ingest is #192. This PR is the substrate; it needs careful live validation with real personas once ingest is wired.

## Follow-ons (designed, captured)

Persona-facing `look()` **command** (eyes usable from a turn) · room warm-loop + tiled grouped-describe (grouped serve = grouped compute) · `video_rx → observe` ingest (#192) · durable governed **record** + its disk consumer (`ResourceKind::Disk`).

Refs #187 #106 #192 #173 #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)