### PR TITLE
feat(perception): live-call video ingest → cognition (#192 see path)

### DIFF
--- a/core/continuum-core/src/live/session/orchestrator.rs
+++ b/core/continuum-core/src/live/session/orchestrator.rs
@@ -137,6 +137,31 @@ impl VoiceOrchestrator {
 
         ai_participants.iter().map(|p| p.user_id).collect()
     }
+
+    /// Every AI participant in the session — the video VIEWERS (who should SEE the
+    /// call's frames). Unlike [`on_utterance`](Self::on_utterance)'s audio broadcast,
+    /// this is NOT gated on `is_audio_native`: hearing is bridged per audio-capability,
+    /// but VISION is universal — every persona sees, and the system bridges the pixels
+    /// to a description for a non-vision model (the sensory-architecture contract). The
+    /// speaker-skip (a persona not seeing its OWN frame) is applied downstream by the
+    /// ingest fan-out, keyed on identity — here we return the full AI roster. Humans are
+    /// excluded (they see through their own client, not a PerceptionBuffer). Empty for an
+    /// unknown session.
+    pub fn video_viewers(&self, session_id: Uuid) -> Vec<Uuid> {
+        self.session_participants
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&session_id)
+            .map(|ps| {
+                ps.iter()
+                    .filter(|p| {
+                        matches!(p.participant_type, SpeakerType::Persona | SpeakerType::Agent)
+                    })
+                    .map(|p| p.user_id)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
 }
 
 #[cfg(test)]
@@ -212,6 +237,61 @@ mod old_tests {
         assert!(responders.contains(&text_ai_id));
         // Audio-native AI excluded (hears via mixer stream)
         assert!(!responders.contains(&audio_native_ai_id));
+    }
+
+    // what this catches: video_viewers returns EVERY AI persona/agent — including
+    // audio-native ones (vision is universal, unlike the audio broadcast which excludes
+    // them) — and EXCLUDES humans (they see through their own client). The speaker-skip
+    // is applied downstream by the ingest fan-out, so a speaker in the roster is still
+    // returned here. If this drifts, personas go blind on a call or a human's video is
+    // wrongly routed into a PerceptionBuffer.
+    #[test]
+    fn video_viewers_are_every_ai_including_audio_native_never_humans() {
+        let orchestrator = VoiceOrchestrator::new();
+        let session_id = Uuid::new_v4();
+        let text_ai = Uuid::new_v4();
+        let audio_native_ai = Uuid::new_v4();
+        let human = Uuid::new_v4();
+
+        orchestrator.register_session(
+            session_id,
+            Uuid::new_v4(),
+            vec![
+                VoiceParticipant {
+                    user_id: text_ai,
+                    display_name: "Helper".into(),
+                    participant_type: SpeakerType::Persona,
+                    expertise: vec![],
+                    is_audio_native: false,
+                },
+                VoiceParticipant {
+                    user_id: audio_native_ai,
+                    display_name: "Gemini".into(),
+                    participant_type: SpeakerType::Persona,
+                    expertise: vec![],
+                    is_audio_native: true,
+                },
+                VoiceParticipant {
+                    user_id: human,
+                    display_name: "Joel".into(),
+                    participant_type: SpeakerType::Human,
+                    expertise: vec![],
+                    is_audio_native: false,
+                },
+            ],
+        );
+
+        let viewers = orchestrator.video_viewers(session_id);
+        assert_eq!(viewers.len(), 2, "both AIs see; the human does not");
+        assert!(viewers.contains(&text_ai));
+        assert!(
+            viewers.contains(&audio_native_ai),
+            "audio-native AIs still SEE — vision is not gated on audio capability"
+        );
+        assert!(!viewers.contains(&human), "humans see via their own client, not a buffer");
+
+        // Unknown session → empty (a frame for a call we don't track goes nowhere).
+        assert!(orchestrator.video_viewers(Uuid::new_v4()).is_empty());
     }
 
     #[test]

--- a/core/continuum-core/src/live/session/voice_service.rs
+++ b/core/continuum-core/src/live/session/voice_service.rs
@@ -54,6 +54,20 @@ impl VoiceService {
 
         Ok(orchestrator.on_utterance(event))
     }
+
+    /// The AI persona viewers for a live call — who should SEE its video frames.
+    /// Parses the `call_id` string (the airc session id) and returns the session's AI
+    /// roster; empty for a malformed id, an unknown session, or a poisoned lock (a frame
+    /// for a call we don't track simply goes nowhere — never a fabricated viewer).
+    pub fn video_viewers(&self, call_id: &str) -> Vec<Uuid> {
+        let Ok(session_id) = Uuid::parse_str(call_id) else {
+            return Vec::new();
+        };
+        match self.orchestrator.lock() {
+            Ok(orchestrator) => orchestrator.video_viewers(session_id),
+            Err(_) => Vec::new(),
+        }
+    }
 }
 
 impl Default for VoiceService {

--- a/core/continuum-core/src/live/transport/bridge_client.rs
+++ b/core/continuum-core/src/live/transport/bridge_client.rs
@@ -729,27 +729,23 @@ fn handle_bridge_event(
             processors.retain(|k, _| !k.starts_with(&format!("{}:", call_id)));
         }
         BridgeEvent::VideoFrame {
-            call_id: _,
-            speaker_id: _,
+            call_id,
+            speaker_id,
             speaker_name,
             width,
             height,
         } => {
             if let Some(jpeg) = binary {
-                // Store in the VideoFrameCapture singleton (same store the vision system queries).
-                // This replaces the direct LiveKit NativeVideoStream capture that used to
-                // happen inside the monolithic binary.
                 #[cfg(feature = "livekit-webrtc")]
                 {
                     // When livekit-webrtc is enabled, VideoFrameCapture uses LiveKit directly.
                     // The bridge path is for when livekit-webrtc is disabled. Mark the
                     // bridge-path bindings as used so this cfg doesn't emit unused-variable
                     // warnings (which also trip a rustc 1.94 annotate-snippets render ICE here).
-                    let _ = (&speaker_name, &width, &height, &jpeg);
+                    let _ = (&call_id, &speaker_id, &speaker_name, &width, &height, &jpeg);
                 }
                 #[cfg(not(feature = "livekit-webrtc"))]
                 {
-                    // Store snapshot for vision system access
                     static FRAME_COUNT: std::sync::atomic::AtomicU64 =
                         std::sync::atomic::AtomicU64::new(0);
                     let count = FRAME_COUNT.fetch_add(1, Ordering::Relaxed);
@@ -763,9 +759,21 @@ fn handle_bridge_event(
                             jpeg.len() / 1024
                         );
                     }
-                    // TODO: Store in a shared snapshot cache that vision commands can query.
-                    // The VideoFrameCapture singleton currently requires livekit types.
-                    // Refactor to use bridge-protocol-only snapshot storage.
+                    // #192: hand the already-encoded frame to perception ingest — a
+                    // NON-BLOCKING post from this reader thread (no reactor here) onto
+                    // the drain's mpsc; a tokio task fans it out to each persona-viewer's
+                    // PerceptionBuffer. Drops silently until the drain is installed. This
+                    // is a COPY the bridge already made — the human display plane (the
+                    // LiveKit video track) is never touched, and perception samples it at
+                    // ~2 Hz regardless of the frame rate ([[perceive-the-room-as-it-is-now]]).
+                    crate::media::perception_ingest::try_enqueue(
+                        crate::media::perception_ingest::IngestFrame {
+                            call_id,
+                            speaker_id,
+                            jpeg: jpeg.to_vec(),
+                            mime: "image/jpeg".to_string(),
+                        },
+                    );
                 }
             }
         }

--- a/core/continuum-core/src/media/mod.rs
+++ b/core/continuum-core/src/media/mod.rs
@@ -27,6 +27,7 @@
 pub mod frame;
 pub mod image_ops;
 pub mod perception_buffer;
+pub mod perception_ingest;
 pub mod perception_registry;
 pub mod projection;
 

--- a/core/continuum-core/src/media/perception_ingest.rs
+++ b/core/continuum-core/src/media/perception_ingest.rs
@@ -1,0 +1,186 @@
+//! `perception_ingest` — fan ONE decoded call frame out into every viewer's perception.
+//!
+//! The WRITE side of live-call perception (#192): a video frame arrives from the
+//! LiveKit bridge for one speaker, and each AI persona in the call must SEE it —
+//! i.e. it must land in each persona's [`PerceptionBuffer`](super::PerceptionBuffer),
+//! keyed by the speaker's airc identity. This module is the pure fan-out that does
+//! that, decoupled from the transport so it is testable without a live call.
+//!
+//! # Compute-once/share-many holds across the fan-out
+//!
+//! The frame's expensive derivatives (scale, describe, luma signature) are keyed by
+//! CONTENT HASH on the ONE [`shared_compute::global`] cache, so even though
+//! [`observe`](super::PerceptionBuffer::observe) is called once per viewer, the
+//! describe/scale run ONCE for that frame and every viewer shares the result — the
+//! multi-persona vision moat ([[vision-replication-is-the-multipersona-moat-vs-cloud]],
+//! [[media-is-compute-once-zero-copy-hardware-grade]]). The per-viewer cost is a
+//! bounded ring push (an `Arc` handle) plus a gated warm that dedups on the cache.
+//!
+//! # A persona never watches its own outbound avatar
+//!
+//! The speaker is identified by its LiveKit identity string, which for a persona IS
+//! `persona_id.to_string()` (the avatar publish path sets `identity = persona_id`).
+//! So the fan-out SKIPS the viewer whose id equals the speaker — a persona doesn't
+//! perceive the frames it is itself publishing. Every other viewer (and every human
+//! speaker, whose identity matches no persona id) is seen by all.
+//!
+//! # Not a manager
+//!
+//! This holds no call state and tracks no rosters — the live-call lifecycle already
+//! owns "who is in the call" ([[all-rooms-are-airc-rooms-no-mirrors]]). The caller
+//! passes the viewer roster in; this is a stateless projection, not a parallel
+//! coordinator (CONCURRENCY-STYLE-GUIDE forbidden move #6). It must be invoked from
+//! within a tokio runtime — `observe` spawns the warm — which the live drain task is.
+
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use super::frame::{FrameDescriber, MediaFrame};
+
+/// The stateless fan-out. Holds ONLY the shared describer (one per call — the
+/// sensory-bridge inference that N viewers share), never any call/roster state.
+#[derive(Clone)]
+pub struct FrameIngest {
+    /// The one describer the whole call shares — `observe` hands it to each viewer's
+    /// warm, but compute-once on the content hash means it runs at most once per frame.
+    describer: Arc<dyn FrameDescriber>,
+}
+
+impl FrameIngest {
+    pub fn new(describer: Arc<dyn FrameDescriber>) -> Self {
+        Self { describer }
+    }
+
+    /// Ingest one decoded frame from `speaker` into every `viewer` persona's
+    /// perception buffer — EXCEPT the speaker's own (a persona doesn't watch its own
+    /// avatar). `jpeg` is the already-encoded frame bytes (the bridge encodes I420 →
+    /// JPEG upstream), `mime` its encoding (`image/jpeg`), `now_ms` the caller's
+    /// monotonic clock (the substrate passes time in). Non-blocking: each `observe`
+    /// coalesces the frame and fires an async warm, returning immediately.
+    ///
+    /// Builds the [`MediaFrame`] ONCE and clones the cheap `Arc`-backed handle per
+    /// viewer, so the content hash — and therefore every shared derivative — is
+    /// identical across viewers (the compute-once seam).
+    pub fn fan_out(&self, speaker: &str, viewers: &[Uuid], jpeg: Vec<u8>, mime: &str, now_ms: u64) {
+        if viewers.is_empty() {
+            return;
+        }
+        let frame = MediaFrame::from_bytes(jpeg);
+        let compute = crate::runtime::shared_compute::global();
+        for &viewer in viewers {
+            // A persona never observes its OWN outbound avatar frame. The persona's
+            // LiveKit identity is its uuid string, so equality on that is the self-skip.
+            if viewer.to_string() == speaker {
+                continue;
+            }
+            let buffer = crate::media::perception_registry().handle(viewer);
+            buffer.observe(
+                speaker.to_string(),
+                frame.clone(),
+                compute.clone(),
+                self.describer.clone(),
+                mime,
+                now_ms,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::perception_registry;
+    use async_trait::async_trait;
+    use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
+    use std::io::Cursor;
+
+    fn jpeg(w: u32, h: u32) -> Vec<u8> {
+        let img = RgbaImage::from_fn(w, h, |x, _| {
+            if x < w / 2 {
+                Rgba([200, 40, 40, 255])
+            } else {
+                Rgba([40, 40, 200, 255])
+            }
+        });
+        let mut out = Cursor::new(Vec::new());
+        // JPEG has no alpha — go through rgb8, exactly like the bridge encoder.
+        DynamicImage::ImageRgba8(img)
+            .to_rgb8()
+            .write_to(&mut out, ImageFormat::Jpeg)
+            .unwrap();
+        out.into_inner()
+    }
+
+    struct StubDescriber;
+    #[async_trait]
+    impl FrameDescriber for StubDescriber {
+        async fn describe(&self, source: &[u8], mime: &str) -> Result<String, String> {
+            Ok(format!("{mime} frame, {} bytes", source.len()))
+        }
+    }
+
+    fn ingest() -> FrameIngest {
+        FrameIngest::new(Arc::new(StubDescriber))
+    }
+
+    // what this catches: THE fan-out — a human speaker's frame lands in EVERY viewer
+    // persona's buffer, each keyed by the speaker's identity, with the SAME content
+    // hash (compute-once seam: one MediaFrame cloned across viewers). The ring push is
+    // synchronous, so residency is observable immediately after fan_out returns.
+    #[tokio::test]
+    async fn fan_out_lands_a_speaker_frame_in_every_viewer_buffer() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let human = "human-speaker-not-a-persona";
+
+        ingest().fan_out(human, &[a, b], jpeg(80, 60), "image/jpeg", 0);
+
+        let compute = crate::runtime::shared_compute::global();
+        let mut hashes = Vec::new();
+        for viewer in [a, b] {
+            let buf = perception_registry().get(&viewer).expect("viewer got a buffer");
+            let percepts = buf.current_percepts(&compute);
+            assert_eq!(percepts.len(), 1, "each viewer sees the one speaker");
+            assert_eq!(percepts[0].participant, human, "keyed by the speaker identity");
+            hashes.push(percepts[0].content_hash.clone());
+            perception_registry().remove(&viewer);
+        }
+        assert_eq!(hashes[0], hashes[1], "same frame content hash across viewers (compute-once)");
+    }
+
+    // what this catches: a persona NEVER observes its own outbound avatar frame — when
+    // the speaker id equals a viewer's id, that viewer is skipped while the others still
+    // see it. Prevents a persona perceiving the video it is itself publishing.
+    #[tokio::test]
+    async fn a_persona_does_not_observe_its_own_frame() {
+        let speaker = Uuid::new_v4();
+        let other = Uuid::new_v4();
+
+        // The speaker is one of the viewers (it's a persona in the call).
+        ingest().fan_out(&speaker.to_string(), &[speaker, other], jpeg(50, 40), "image/jpeg", 0);
+
+        assert!(
+            perception_registry().get(&speaker).is_none(),
+            "the speaker persona did not observe (and never resolved) its own buffer"
+        );
+        let compute = crate::runtime::shared_compute::global();
+        let other_buf = perception_registry().get(&other).expect("the other viewer saw it");
+        assert_eq!(other_buf.current_percepts(&compute).len(), 1, "the other viewer sees the speaker");
+        assert_eq!(
+            other_buf.current_percepts(&compute)[0].participant,
+            speaker.to_string(),
+            "keyed by the speaker persona id"
+        );
+        perception_registry().remove(&other);
+    }
+
+    // what this catches: an empty viewer roster is a no-op (no buffers created, no
+    // panic) — a frame arriving before any persona has joined simply goes nowhere.
+    #[tokio::test]
+    async fn fan_out_to_no_viewers_is_a_noop() {
+        ingest().fan_out("someone", &[], jpeg(20, 20), "image/jpeg", 0);
+        // Nothing to assert beyond "did not panic / created nothing" — a fresh id has no buffer.
+        assert!(perception_registry().get(&Uuid::new_v4()).is_none());
+    }
+}

--- a/core/continuum-core/src/media/perception_ingest.rs
+++ b/core/continuum-core/src/media/perception_ingest.rs
@@ -32,8 +32,9 @@
 //! coordinator (CONCURRENCY-STYLE-GUIDE forbidden move #6). It must be invoked from
 //! within a tokio runtime — `observe` spawns the warm — which the live drain task is.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use uuid::Uuid;
 
 use super::frame::{FrameDescriber, MediaFrame};
@@ -84,6 +85,52 @@ impl FrameIngest {
                 now_ms,
             );
         }
+    }
+}
+
+/// One decoded call frame awaiting fan-out — the unit of work crossing the bridge
+/// reader THREAD → tokio DRAIN boundary. The bridge (a blocking `std::thread` with no
+/// reactor) can't call [`FrameIngest::fan_out`] directly (`observe` spawns), so it
+/// hands the already-encoded JPEG across this channel to the drain, which runs on the
+/// runtime. `call_id` is the airc session/room id string; `speaker_id` the airc
+/// identity of whoever the frame is of.
+pub struct IngestFrame {
+    pub call_id: String,
+    pub speaker_id: String,
+    /// The encoded frame bytes (the bridge encodes I420 → JPEG upstream at ~1 fps).
+    pub jpeg: Vec<u8>,
+    /// The encoding of `jpeg` (`image/jpeg`).
+    pub mime: String,
+}
+
+/// The process-global send endpoint of the ingest channel — installed ONCE by the
+/// live module when it spawns the drain. Same `OnceLock` shape as
+/// [`perception_registry`](super::perception_registry) / `shared_compute::global`:
+/// it is a channel handle, not a manager (CONCURRENCY-STYLE-GUIDE: the mpsc "here is
+/// work" primitive). `None` until the drain is up — a frame before then is simply not
+/// perceived, and the human display plane (the LiveKit track) is unaffected regardless.
+static INGEST_SINK: OnceLock<UnboundedSender<IngestFrame>> = OnceLock::new();
+
+/// Create the ingest channel and install its sender globally, returning the receiver
+/// for the drain to own. The live module calls this once at init and spawns a task on
+/// the returned receiver. A second call returns `None` (only one drain owns the stream).
+pub fn install_channel() -> Option<UnboundedReceiver<IngestFrame>> {
+    let (tx, rx) = unbounded_channel();
+    if INGEST_SINK.set(tx).is_ok() {
+        Some(rx)
+    } else {
+        None
+    }
+}
+
+/// Post a decoded frame to the drain — NON-BLOCKING, callable from the bridge reader
+/// thread (which has no tokio runtime): an unbounded `send` neither blocks nor awaits.
+/// Drops silently if no drain is installed yet (boot-only) or the drain has shut down.
+/// This is the ONLY thing the hot bridge thread does with the frame beyond its own
+/// logging — it never scales, describes, or touches the display track.
+pub fn try_enqueue(frame: IngestFrame) {
+    if let Some(tx) = INGEST_SINK.get() {
+        let _ = tx.send(frame);
     }
 }
 

--- a/core/continuum-core/src/modules/live.rs
+++ b/core/continuum-core/src/modules/live.rs
@@ -18,7 +18,10 @@ use crate::live::session::voice_service::VoiceService;
 use crate::live::transport::bridge_client::LiveKitAgentManager;
 use crate::live::{UtteranceEvent, VoiceParticipant};
 use crate::logging::TimingGuard;
-use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
+use crate::runtime::{
+    CommandExecutor, CommandResult, LateBound, ModuleConfig, ModuleContext, ModulePriority,
+    ServiceModule,
+};
 use crate::utils::params::Params;
 use crate::{log_error, log_info};
 use async_trait::async_trait;
@@ -39,6 +42,10 @@ pub struct VoiceState {
     /// Track active session IDs to make register-session idempotent.
     /// Prevents duplicate agent spawns on browser refresh / re-navigate.
     active_sessions: std::sync::Mutex<HashSet<String>>,
+    /// Late-bound command executor for the vision describer the perception-ingest
+    /// drain builds. Installed post-boot by the runtime (the #224 late-bind slot),
+    /// read lazily on the first live-call frame — never present at `initialize`.
+    executor: LateBound<CommandExecutor>,
 }
 
 impl VoiceState {
@@ -54,6 +61,7 @@ impl VoiceState {
             audio_pool,
             resource_lifecycle,
             active_sessions: std::sync::Mutex::new(HashSet::new()),
+            executor: LateBound::new("live::perception_ingest::executor"),
         }
     }
 }
@@ -65,6 +73,65 @@ pub struct VoiceModule {
 impl VoiceModule {
     pub fn new(state: Arc<VoiceState>) -> Self {
         Self { state }
+    }
+}
+
+/// Drains the live-call perception-ingest channel (#192): each decoded frame is fanned
+/// out to every persona-viewer of its call. The vision DESCRIBER is built lazily on the
+/// first frame after the executor is installed (boot-once) and reused, so N viewers of
+/// one frame share ONE describe on the content-addressed cache — the multi-persona
+/// vision moat. Non-blocking per frame: `fan_out` coalesces + gates the warm, so the
+/// ~1 fps ingest never becomes a describe storm and the human video plane is untouched.
+async fn perception_ingest_drain(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<crate::media::perception_ingest::IngestFrame>,
+    state: Arc<VoiceState>,
+) {
+    use crate::media::perception_ingest::FrameIngest;
+
+    let mut ingest: Option<FrameIngest> = None;
+    let mut fanned: u64 = 0;
+
+    while let Some(frame) = rx.recv().await {
+        // Build the fan-out (with its vision describer) once the executor is installed.
+        // Until then — boot only, well before any call joins — drop the frame.
+        if ingest.is_none() {
+            match state.executor.cloned() {
+                Some(executor) => {
+                    let describer = Arc::new(
+                        crate::cognition::vision_describe::VisionDescribeFramer::new(executor),
+                    );
+                    ingest = Some(FrameIngest::new(describer));
+                }
+                None => continue,
+            }
+        }
+
+        let viewers = state.voice_service.video_viewers(&frame.call_id);
+        if viewers.is_empty() {
+            continue;
+        }
+
+        // Fan out: each viewer's PerceptionBuffer coalesces the frame + fires a gated
+        // async warm; compute-once/share-many means one describe across all viewers.
+        ingest.as_ref().expect("ingest built above").fan_out(
+            &frame.speaker_id,
+            &viewers,
+            frame.jpeg,
+            &frame.mime,
+            crate::persona::recall_metadata::now_ms(),
+        );
+
+        fanned += 1;
+        if fanned == 1 || fanned % 120 == 0 {
+            log_info!(
+                "module",
+                "perception_ingest",
+                "fanned {} live-call frames into perception (latest: speaker {} → {} viewers)",
+                fanned,
+                &frame.speaker_id[..8.min(frame.speaker_id.len())],
+                viewers.len()
+            );
+        }
     }
 }
 
@@ -82,11 +149,25 @@ impl ServiceModule for VoiceModule {
         }
     }
 
+    /// Receive the wired command executor at boot (the #224 late-bind slot). The
+    /// perception-ingest drain reads it lazily to build the vision describer.
+    fn install_executor(&self, executor: Arc<CommandExecutor>) {
+        self.state.executor.install(executor);
+    }
+
     async fn initialize(&self, _ctx: &ModuleContext) -> Result<(), String> {
         // Spawn idle watcher here (inside tokio runtime), not in VoiceState::new()
         self.state.resource_lifecycle.spawn_idle_watcher();
         // Safety net: detect orphaned sessions (browser crash, lost WebSocket, deploy)
         self.state.resource_lifecycle.spawn_orphan_watchdog();
+
+        // #192: spawn the live-call perception-ingest drain. The bridge reader thread
+        // posts decoded frames onto a process-global mpsc (perception_ingest); this
+        // drain, on the runtime, fans each frame out to every persona-viewer's
+        // PerceptionBuffer. Installed once — a second module init would get None.
+        if let Some(rx) = crate::media::perception_ingest::install_channel() {
+            tokio::spawn(perception_ingest_drain(rx, self.state.clone()));
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## What

Wires the **live-call video ingest** into perception (#192): a speaker's decoded frame now lands in every AI-persona-viewer's `PerceptionBuffer` on a live call. This is the **see** half of the headless two-persona-call proof. Read side was already wired (supervisor → `MediaPerceptionSource`); this closes the write side.

## Path (guide-compliant — no new thread, no parallel manager)

```
bridge reader thread  (BridgeEvent::VideoFrame — already JPEG @ ~1fps)
  → perception_ingest::try_enqueue   non-blocking post onto a process-global mpsc
                                      (the CONCURRENCY-STYLE-GUIDE "here is work"
                                      boundary; drops silently until drain is up)
  → drain task  (spawned in VoiceModule::initialize, on the runtime)
  → VoiceService::video_viewers(call_id)   all AI Persona|Agent in the session
                                           (NOT gated on is_audio_native — vision
                                           is universal; humans excluded)
  → FrameIngest::fan_out   compute-once/share-many; a persona never sees its own frame
```

## Commits

1. **FrameIngest core** — pure fan-out, decoupled from LiveKit, 3 unit tests (fan-out lands in every viewer, self-skip, empty-roster no-op).
2. **Transport wiring** — `IngestFrame` + mpsc `OnceLock` boundary; the `bridge_client.rs:731` `VideoFrame` TODO-drop becomes a `try_enqueue`; `video_viewers` roster query; `VoiceState` gains a `LateBound<CommandExecutor>` (the #224 slot) filled by `install_executor`, and `initialize()` spawns the drain. The vision describer builds lazily once the executor is installed, then is reused — so **N viewers of one frame share ONE describe**.

## Human frame rate is protected by construction

The point you flagged. The ingest never touches the human display plane:
- It reads a **JPEG copy the bridge already made** — the LiveKit video track is untouched.
- The bridge already caps upstream at **~1 fps**; the mpsc post is **non-blocking** (unbounded send from the reader thread — the audio path in the same loop is never blocked).
- `PerceptionBuffer` **coalesces-to-latest** and **gates warms to ~2 Hz per participant**, so 1fps in never becomes a describe storm.
- `describe` runs on the served VL model's lane; compute-once means one inference per distinct frame regardless of viewer count.

## Tests

51 green (fan-out ×3, `video_viewers` policy ×1, existing orchestrator + `perception::look` suites). `cargo check` clean.

## Acceptance = live validation (the see path)

Deploy + a two-persona (or human+persona) video call. Confirm: (1) human video stays smooth, (2) audio unaffected, (3) each persona's perception surfaces the *other's* frames (buffer populated, describe warms) — watch `perception_ingest` fanned-N logs + the persona cognition log. #193 (call_id==room_id unify) is adjacent, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)