### PR TITLE
refactor(commands): native tool surface auto-derives from a per-command flag (kill the hardcoded list)

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -342,7 +342,16 @@ impl LlmDeliberationFaculty {
             .unwrap_or(0);
         let native_surface_min_ctx = full_surface_tokens.saturating_mul(SURFACE_MAX_WINDOW_SHARE);
         if self.binding.load().context_window < native_surface_min_ctx {
-            specs.truncate(2); // ["commands/list", commands/help] lead the list by contract
+            // Tight window: shrink to the DISCOVERY PAIR (commands/list, then commands/help),
+            // selected BY NAME in that order — NOT by list position. The native surface is
+            // registry-DERIVED now (sorted by name, so `commands/help` sorts before
+            // `commands/list`), so a `truncate(2)` would grab the alphabetically-first two,
+            // not the discovery pair. These two reach the long tail by name.
+            specs = ["commands/list", persona_tools::TOOL_HELP_NAME]
+                .iter()
+                .filter_map(|n| persona_tools::spec_for_command(n))
+                .map(crate::cognition::tool_dialect::to_wire_spec)
+                .collect();
         }
         self.native_specs = specs;
     }

--- a/core/continuum-core/src/cognition/persona_tools.rs
+++ b/core/continuum-core/src/cognition/persona_tools.rs
@@ -362,52 +362,24 @@ pub fn group_categories(tools: &[NativeToolSpec]) -> Vec<(&str, Vec<&str>)> {
 /// her. Only includes a spec that actually resolves in the registry (fail-closed:
 /// a missing command is omitted, never fabricated — [[fallbacks-are-illegal-fail-loud]]).
 pub fn native_tool_specs() -> Vec<NativeToolSpec> {
-    // The discovery pair (reaches the long tail by name) PLUS the core agentic-coding arc
-    // as REAL native specs. A model TRAINED to tool-call (Devstral, Qwen-Coder) emits native
-    // tool_calls — given only the discovery pair it loops forever on `commands/help{code/search}`
-    // and never acts (glass-boxed: 14/14 SWE acts were `commands/help`, 0 edits, 0 score). Offering
-    // the working set directly lets it search→read→edit→write→run→verify without the help detour,
-    // while a weak model that can't emit native tool_calls still falls back to the text menu +
-    // narrated-call recovery. Bounded (~11 schemas, ~1-2k tokens) so it never overflows the window
-    // the way a full ~150-tool dump did. Only specs that actually resolve are included (fail-closed).
+    // DERIVED, not a hand-kept list: the native surface is every command that DECLARES
+    // itself native (`CommandSpec::NATIVE = true`, in its OWN file) — so adding a command
+    // and marking it native offers it here AUTOMATICALLY, no central array to edit. This
+    // is the dynamic-discovery contract, not a switch statement (CLAUDE.md §Anti-Pattern).
+    //
+    // Why a bounded native set at all (rather than every AiSafe command): a model TRAINED
+    // to tool-call (Devstral, Qwen-Coder) emits native tool_calls, and given the FULL
+    // ~150-tool schema dump it was muted (glass-boxed: window overflow). Given ONLY the
+    // discovery pair it loops on `commands/help{code/search}` and never acts (14/14 SWE
+    // acts were `commands/help`, 0 edits). So the core agentic working set opts into
+    // NATIVE while the long tail stays reachable BY NAME through the compact catalog +
+    // `commands/help`. The `native` flag is per-command; this projection just collects it.
     // [[adaptive-tool-surface-meets-you-in-the-middle]] [[local-first-tool-call-robustness-is-the-differentiator]]
-    const NATIVE: &[&str] = &[
-        "commands/list",
-        TOOL_HELP_NAME,
-        "code/search",
-        "code/read",
-        "code/list",
-        "code/tree",
-        "code/edit",
-        "code/write",
-        "code/run",
-        "code/shell",
-        "code/git/diff",
-        // The consolidation rail (2026-07-11): status/commit/apply are how
-        // parallel workspaces converge — diff→post→apply, the loop the Conway
-        // team invented socially before the rails existed.
-        "code/git/status",
-        "code/git/commit",
-        "code/git/apply",
-        // Observation parity (Joel 2026-07-11): seeing the screen is a first-class
-        // work verb, not a special capability — "if they can observe like we do,
-        // they can build like we do." Routed to a client adapter (WireShape::
-        // Provided); fails loud when no UI adapter is connected, never fabricates.
-        "interface/screenshot",
-        // Perception Surface (#187): observe = SEE + REASON — pixels AND the
-        // structure tree to aim actions at an element, not a pixel. The enriched
-        // sibling of screenshot; also Provided (fails loud with no eye-node).
-        "perception/observe",
-        // Perception Surface (#187), live-call video sibling: look = a persona's
-        // OWN eyes on the video call it's in — pull a current image of one
-        // participant or everyone, thumbnail or full. Substrate-served off the
-        // in-process perception buffer; empties/teaches when not in a call.
-        "perception/look",
-        // The shared-board lifecycle: claiming work as yourself is core to the
-        // room workflow (rides the wire as `claim_task` via the dialect).
-        "work/claim",
-    ];
-    NATIVE.iter().filter_map(|n| spec_for_command(n)).collect()
+    command_registry()
+        .iter()
+        .filter(|d| d.native)
+        .map(descriptor_to_tool_spec)
+        .collect()
 }
 
 /// Look up one command by name and project it to a full tool spec — the on-demand
@@ -593,6 +565,52 @@ pub struct ToolSurfaceReport {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the native surface is DERIVED from each command's declared
+    // `NATIVE` flag, not a hand-kept list — a command that declares `native: true` is
+    // offered automatically, and a sibling AiSafe command that does NOT (e.g. code/glob)
+    // is excluded. This is the anti-switch-statement contract: add a command, mark it
+    // native in its OWN file, and it appears here with zero edits to this function. If
+    // someone reintroduces a hardcoded array, or the flag stops being read, this breaks.
+    #[test]
+    fn native_surface_is_derived_from_the_per_command_native_flag() {
+        let specs = native_tool_specs();
+        let names: std::collections::HashSet<&str> =
+            specs.iter().map(|s| s.name.as_str()).collect();
+
+        // The declared core agentic working set is present (each opted in at its own site).
+        for expected in [
+            "commands/list",
+            "commands/help",
+            "code/search",
+            "code/read",
+            "code/edit",
+            "code/write",
+            "code/run",
+            "code/shell",
+            "code/git/status",
+            "interface/screenshot",
+            "perception/observe",
+            "perception/look",
+            "work/claim",
+        ] {
+            assert!(names.contains(expected), "native surface must include declared-native {expected}");
+        }
+
+        // A sibling AiSafe command that did NOT opt in is EXCLUDED — proving this is a
+        // filter on the flag, not "every AiSafe command" (which would re-flood the window).
+        assert!(
+            !names.contains("code/glob"),
+            "code/glob is AiSafe but not declared native — must stay catalog-only, not native"
+        );
+
+        // And it stays BOUNDED (the muting guardrail) — nowhere near the full registry.
+        assert!(
+            names.len() < 40,
+            "native set stayed bounded ({} tools); a full dump would re-mute personas",
+            names.len()
+        );
+    }
 
     fn spec(name: &str) -> NativeToolSpec {
         NativeToolSpec {

--- a/core/continuum-core/src/commands/catalog.rs
+++ b/core/continuum-core/src/commands/catalog.rs
@@ -79,6 +79,7 @@ pub struct CommandsList;
 #[async_trait]
 impl ActionCommand for CommandsList {
     const NAME: &'static str = "commands/list";
+    const NATIVE: bool = true; // discovery pair — the persona reaches the long tail through this
     const DESCRIPTION: &'static str =
         "List the available commands (name, description, access, params type) from the live \
          registry. Optional `filter` is a case-insensitive name substring.";

--- a/core/continuum-core/src/commands/code/git/apply.rs
+++ b/core/continuum-core/src/commands/code/git/apply.rs
@@ -44,6 +44,7 @@ crate::action_command! {
     pub struct CodeGitApply { state: Arc<CodeState> }
     name: "code/git/apply",
     access: AiSafe,
+    native: true,
     params: GitApplyParams,
     output: GitApplyResult,
     run(this, ctx, p) => {

--- a/core/continuum-core/src/commands/code/git/commit.rs
+++ b/core/continuum-core/src/commands/code/git/commit.rs
@@ -31,6 +31,7 @@ crate::action_command! {
     pub struct CodeGitCommit { state: Arc<CodeState> }
     name: "code/git/commit",
     access: AiSafe,
+    native: true,
     params: GitCommitParams,
     output: GitCommitResult,
     run(this, ctx, p) => {

--- a/core/continuum-core/src/commands/code/git/diff.rs
+++ b/core/continuum-core/src/commands/code/git/diff.rs
@@ -32,6 +32,7 @@ crate::action_command! {
     pub struct CodeGitDiff { state: Arc<CodeState> }
     name: "code/git/diff",
     access: AiSafe,
+    native: true,
     params: GitDiffParams,
     output: GitDiffResult,
     run(this, ctx, p) => {

--- a/core/continuum-core/src/commands/code/git/status.rs
+++ b/core/continuum-core/src/commands/code/git/status.rs
@@ -23,6 +23,7 @@ crate::action_command! {
     pub struct CodeGitStatus { state: Arc<CodeState> }
     name: "code/git/status",
     access: AiSafe,
+    native: true,
     params: GitStatusParams,
     output: GitStatusInfo,
     run(this, ctx, _p) => {

--- a/core/continuum-core/src/commands/code/run.rs
+++ b/core/continuum-core/src/commands/code/run.rs
@@ -81,6 +81,7 @@ pub struct CodeRun;
 #[async_trait]
 impl ActionCommand for CodeRun {
     const NAME: &'static str = "code/run";
+    const NATIVE: bool = true; // core agentic working set — offered natively (auto-derived)
     const DESCRIPTION: &'static str =
         "Compile and run a complete Rust program (lang \"rust\", code must have its own \
          `fn main`) and return its stdout, stderr, exit code, and duration. A compile \

--- a/core/continuum-core/src/commands/help.rs
+++ b/core/continuum-core/src/commands/help.rs
@@ -302,6 +302,7 @@ pub struct CommandsHelp;
 #[async_trait]
 impl ActionCommand for CommandsHelp {
     const NAME: &'static str = "commands/help";
+    const NATIVE: bool = true; // discovery pair — the on-demand "how do I call this?" tool
     const ACCESS: AccessLevel = AccessLevel::AiSafe;
     const DESCRIPTION: &'static str =
         "Show how to CALL a command: the exact tool-call format to emit + its arguments. \

--- a/core/continuum-core/src/interface/mod.rs
+++ b/core/continuum-core/src/interface/mod.rs
@@ -125,6 +125,7 @@ pub struct ScreenshotCommand;
 impl crate::sdk_codegen::CommandSpec for ScreenshotCommand {
     const NAME: &'static str = "interface/screenshot";
     const ACCESS_LEVEL: crate::sdk_codegen::AccessLevel = crate::sdk_codegen::AccessLevel::AiSafe;
+    const NATIVE: bool = true; // observation parity — seeing the screen is a first-class work verb
     const DESCRIPTION: &'static str =
         "Capture a screenshot of the UI — your way to SEE the screen (or a specific \
          element via a CSS selector). Use it to visually verify what a human or a UI is \

--- a/core/continuum-core/src/modules/code_commands.rs
+++ b/core/continuum-core/src/modules/code_commands.rs
@@ -329,6 +329,7 @@ pub struct CodeReadParams {
 #[async_trait]
 impl ActionCommand for CodeRead {
     const NAME: &'static str = "code/read";
+    const NATIVE: bool = true; // core agentic working set — offered natively (auto-derived)
     const DESCRIPTION: &'static str =
         "Read a file from the workspace, optionally a line range. Returns content plus line metadata.";
     type Params = CodeReadParams;
@@ -363,6 +364,7 @@ pub struct CodeWriteParams {
 #[async_trait]
 impl ActionCommand for CodeWrite {
     const NAME: &'static str = "code/write";
+    const NATIVE: bool = true; // core agentic working set — offered natively (auto-derived)
     const DESCRIPTION: &'static str =
         "Create or overwrite a file with new content. Tracked in the change history (undoable).";
     type Params = CodeWriteParams;
@@ -537,6 +539,7 @@ fn reject_placeholder_path(file_path: &str) -> Result<(), CommandError> {
 #[async_trait]
 impl ActionCommand for CodeEdit {
     const NAME: &'static str = "code/edit";
+    const NATIVE: bool = true; // core agentic working set — offered natively (auto-derived)
     const DESCRIPTION: &'static str =
         "Edit an existing file: line-range replace, search/replace, insert-at, or append. Undoable.";
     type Params = CodeEditParams;
@@ -572,6 +575,7 @@ pub struct CodeListParams {
 #[async_trait]
 impl ActionCommand for CodeList {
     const NAME: &'static str = "code/list";
+    const NATIVE: bool = true; // core agentic working set — offered natively (auto-derived)
     const DESCRIPTION: &'static str =
         "List a directory (flat, non-recursive): names, kinds, and sizes. Use code/tree for recursion.";
     type Params = CodeListParams;
@@ -778,6 +782,7 @@ pub struct CodeTreeParams {
 #[async_trait]
 impl ActionCommand for CodeTree {
     const NAME: &'static str = "code/tree";
+    const NATIVE: bool = true; // core agentic working set — offered natively (auto-derived)
     const DESCRIPTION: &'static str =
         "Print a recursive directory tree (bounded depth) — the project's structure at a glance.";
     type Params = CodeTreeParams;
@@ -836,6 +841,7 @@ pub struct CodeSearchParams {
 #[async_trait]
 impl ActionCommand for CodeSearch {
     const NAME: &'static str = "code/search";
+    const NATIVE: bool = true; // core agentic working set — offered natively (auto-derived)
     const DESCRIPTION: &'static str =
         "Search file contents for a pattern across the workspace (grep). Returns file:line matches.";
     type Params = CodeSearchParams;
@@ -1043,6 +1049,7 @@ fn shell_response(s: &crate::code::shell_session::ExecutionState) -> ShellExecut
 #[async_trait]
 impl ActionCommand for CodeShell {
     const NAME: &'static str = "code/shell";
+    const NATIVE: bool = true; // core agentic working set — offered natively (auto-derived)
     // Privileged → Trusted tier: arbitrary execution is for high-trust local
     // citizens (a local persona / a trusted node), never a Provisional remote peer.
     const ACCESS: AccessLevel = AccessLevel::Privileged;

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -156,6 +156,7 @@ pub struct WorkClaimResult {
 #[async_trait]
 impl ActionCommand for WorkClaim {
     const NAME: &'static str = "work/claim";
+    const NATIVE: bool = true; // core room workflow — claiming shared-board work as yourself
     // AiSafe since 2026-07-10: claiming/working a card AS YOURSELF is the
     // self-scoped cooperative act the shared board exists for. It was
     // Privileged, so every persona claim all day was structurally impossible —

--- a/core/continuum-core/src/perception/look.rs
+++ b/core/continuum-core/src/perception/look.rs
@@ -204,6 +204,7 @@ pub struct LookCommand;
 #[async_trait]
 impl ActionCommand for LookCommand {
     const NAME: &'static str = "perception/look";
+    const NATIVE: bool = true; // live-call eyes — offered natively beside perception/observe
     const DESCRIPTION: &'static str =
         "Look at the live video call you are in — get a current image of the people on \
          the call. Pass `participant` (an id) to see one person, or omit it to see \

--- a/core/continuum-core/src/perception/mod.rs
+++ b/core/continuum-core/src/perception/mod.rs
@@ -203,6 +203,7 @@ pub struct ObserveCommand;
 impl crate::sdk_codegen::CommandSpec for ObserveCommand {
     const NAME: &'static str = "perception/observe";
     const ACCESS_LEVEL: crate::sdk_codegen::AccessLevel = crate::sdk_codegen::AccessLevel::AiSafe;
+    const NATIVE: bool = true; // SEE + REASON — offered natively beside interface/screenshot
     const DESCRIPTION: &'static str =
         "Observe a UI or web page — SEE it as pixels AND read its STRUCTURE (the \
          tree of elements with their names, text, and on-screen boxes). Use it to \

--- a/core/continuum-core/src/sdk_codegen/command.rs
+++ b/core/continuum-core/src/sdk_codegen/command.rs
@@ -155,6 +155,11 @@ pub trait ActionCommand: Send + Sync + Sized + 'static {
     /// Model-facing one-liner surfaced into the persona tool surface. Defaults
     /// empty (falls back to a name-based description).
     const DESCRIPTION: &'static str = "";
+    /// Whether this command joins the persona's NATIVE tool surface (the bounded set
+    /// given as full structured tool-call schemas every turn). Defaults `false`
+    /// (catalog-only); a core agentic command overrides it to `true` — and then it's
+    /// offered natively AUTOMATICALLY, no central list. See [`CommandSpec::NATIVE`].
+    const NATIVE: bool = false;
 
     /// The typed request payload (a ts-rs wire type). `JsonSchema` so its schema
     /// is derived automatically (no hand-authoring) and exposed to every SDK.
@@ -173,6 +178,7 @@ impl<T: ActionCommand> CommandSpec for T {
     const NAME: &'static str = <T as ActionCommand>::NAME;
     const ACCESS_LEVEL: AccessLevel = <T as ActionCommand>::ACCESS;
     const DESCRIPTION: &'static str = <T as ActionCommand>::DESCRIPTION;
+    const NATIVE: bool = <T as ActionCommand>::NATIVE;
     const WIRE: WireShape = WireShape::Bare;
     type Params = <T as ActionCommand>::Params;
     type Result = <T as ActionCommand>::Output;

--- a/core/continuum-core/src/sdk_codegen/mod.rs
+++ b/core/continuum-core/src/sdk_codegen/mod.rs
@@ -168,6 +168,17 @@ pub trait CommandSpec {
     /// TS emitter. Defaults to empty; the tool projection falls back to a
     /// name-based description when unset, so existing commands need no change.
     const DESCRIPTION: &'static str = "";
+    /// Whether this command joins the persona's NATIVE tool surface — the bounded set
+    /// handed to the model as first-class structured tool-call *schemas* every turn.
+    /// (Distinct from the compact catalog, which already lists EVERY authorized command
+    /// by name for on-demand `commands/help` expansion — awareness of all commands is
+    /// automatic regardless of this flag.) Declared HERE, by the command in its own
+    /// file, so a new command joins the native surface AUTOMATICALLY on registration —
+    /// never by editing a central list ([[commands-do-real-work-and-return-receipts-not-promise-slop]]).
+    /// Defaults `false` (catalog-only): the native set stays the small core agentic
+    /// working set so the schema payload never floods the window — the ~150-tool dump
+    /// muted personas (see [`native_tool_specs`](crate::cognition::persona_tools::native_tool_specs)).
+    const NATIVE: bool = false;
     /// The handler's ACTUAL wire convention — decides whether the generated
     /// surface is enveloped or bare. MUST match what the handler really does
     /// (a mismatch is a type that lies about the wire).
@@ -253,6 +264,10 @@ pub struct CommandDescriptor {
     pub description: &'static str,
     /// The handler's real wire convention (decides envelope wrapping).
     pub wire: WireShape,
+    /// Whether the command opts into the persona's native tool surface (from
+    /// [`CommandSpec::NATIVE`]). The projection [`native_tool_specs`] filters the
+    /// registry on this — so the native set is derived, never a hand-kept list.
+    pub native: bool,
     pub params: TypeRef,
     /// The params' JSON Schema (from [`CommandSpec::params_schema`]) — the
     /// canonical input contract every SDK/interface adapts from. `Null` when the
@@ -297,6 +312,7 @@ impl CommandDescriptor {
             access_level: C::ACCESS_LEVEL,
             description: C::DESCRIPTION,
             wire: C::WIRE,
+            native: C::NATIVE,
             params,
             params_schema: C::params_schema(),
             result,
@@ -611,6 +627,7 @@ macro_rules! action_command {
         $vis:vis struct $cmd:ident;
         name: $name:expr,
         access: $access:ident,
+        $(native: $native:expr,)?
         params: $params:ty,
         output: $output:ty,
         run($this:ident, $ctx:ident, $p:ident) => $body:block
@@ -618,7 +635,7 @@ macro_rules! action_command {
         $(#[doc = $doc])*
         #[derive(::std::default::Default)]
         $vis struct $cmd;
-        $crate::action_command!(@impl $cmd, $name, $access, [$($doc)*], $params, $output, $this, $ctx, $p, $body);
+        $crate::action_command!(@impl $cmd, $name, $access, [$($doc)*], [$($native)?], $params, $output, $this, $ctx, $p, $body);
         $crate::register_stateless_command!($cmd);
     };
 
@@ -629,13 +646,14 @@ macro_rules! action_command {
         $vis:vis struct $cmd:ident { $($field:ident : $fty:ty),+ $(,)? }
         name: $name:expr,
         access: $access:ident,
+        $(native: $native:expr,)?
         params: $params:ty,
         output: $output:ty,
         run($this:ident, $ctx:ident, $p:ident) => $body:block
     ) => {
         $(#[doc = $doc])*
         $vis struct $cmd { $(pub $field: $fty),+ }
-        $crate::action_command!(@impl $cmd, $name, $access, [$($doc)*], $params, $output, $this, $ctx, $p, $body);
+        $crate::action_command!(@impl $cmd, $name, $access, [$($doc)*], [$($native)?], $params, $output, $this, $ctx, $p, $body);
         // Register the DESCRIPTOR (type-only — no instance needed) so the command
         // appears in `command_registry()`, the persona tool surface, the ACL, and
         // codegen. Its RUNTIME object is constructed with deps by the owning
@@ -644,7 +662,7 @@ macro_rules! action_command {
     };
 
     // ── Internal: the shared `ActionCommand` impl both forms expand to. ──
-    (@impl $cmd:ident, $name:expr, $access:ident, [$($doc:literal)*], $params:ty, $output:ty, $this:ident, $ctx:ident, $p:ident, $body:block) => {
+    (@impl $cmd:ident, $name:expr, $access:ident, [$($doc:literal)*], [$($native:expr)?], $params:ty, $output:ty, $this:ident, $ctx:ident, $p:ident, $body:block) => {
         #[::async_trait::async_trait]
         impl $crate::sdk_codegen::ActionCommand for $cmd {
             const NAME: &'static str = $name;
@@ -652,6 +670,10 @@ macro_rules! action_command {
             // Doc comment ⟹ model-facing DESCRIPTION. Each `///` line keeps its
             // leading space, so concatenation separates lines naturally; no docs ⇒ "".
             const DESCRIPTION: &'static str = ::std::concat!($($doc),*);
+            // Optional `native: <bool>,` clause ⟹ NATIVE; absent ⇒ false (catalog-only).
+            // `false || <expr>` when present, bare `false` when absent — const-valid, no
+            // unused bindings.
+            const NATIVE: bool = false $(|| $native)?;
             type Params = $params;
             type Output = $output;
             async fn run(


### PR DESCRIPTION
## The problem

`native_tool_specs()` was a hardcoded `NATIVE: &[&str]` array. Every new native tool meant editing that central list — the switch-statement / central-registry anti-pattern the modular command architecture explicitly forbids (CLAUDE.md §Anti-Pattern Detection). Adding `perception/look` this session meant hand-editing it. That's backwards.

## The fix — automatic, declarative, decentralized

A command **declares** `native: true` in its OWN file; `native_tool_specs()` is now a projection over the registry (`filter(|d| d.native)`). Add a command, mark it native at its declaration, and it's offered natively **automatically** — zero edits to any central function.

- `CommandSpec::NATIVE` (default `false`) + `ActionCommand::NATIVE` + the `action_command!` macro's optional `native: true,` clause (threaded through the blanket impl).
- `CommandDescriptor.native` captures it from the type level.

## Why still bounded (not "every ai-safe command")

Awareness of **all** commands is *already* automatic — the compact catalog + `commands/help` make every authorized command reachable by name. The native set is the narrower subset given to the model as full structured tool-call **schemas**, and the full ~150-schema dump muted personas (glass-boxed: 14/14 SWE acts were `commands/help`, 0 edits). So the core agentic working set opts in; the long tail stays catalog-only. The flag is the opt-in; the projection is automatic.

## Migration

The existing native set now declares the flag at its own site: `commands/list`, `commands/help`, `code/{search,read,list,tree,edit,write,run,shell}`, `code/git/{diff,status,commit,apply}`, `interface/screenshot`, `perception/{observe,look}`, `work/claim`.

## Test

`native_surface_is_derived_from_the_per_command_native_flag` pins it: declared-native commands present, a sibling ai-safe command (`code/glob`) excluded, set stays bounded (<40). Existing `perception::look` / `perception::observe` native-membership tests still pass (now via the derived path). `cargo check` + targeted tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)