### PR TITLE
feat(persona): PersonaSeedFile::V2 — durable coherent card, migration-safe (#199 Slice 1)

### DIFF
--- a/core/continuum-core/src/live/avatar/selection.rs
+++ b/core/continuum-core/src/live/avatar/selection.rs
@@ -113,24 +113,24 @@ pub fn select_avatar_by_identity(identity: &str) -> &'static AvatarModel {
 static AVATAR_ALLOCATION: std::sync::Mutex<Option<HashMap<String, usize>>> =
     std::sync::Mutex::new(None);
 
-/// Identity → the persona's coherent gender, derived from its NAME at the one
-/// moment name + identity co-occur (voice-session registration).
+/// Identity → a REMOTE/live participant's gender, derived from their display NAME at
+/// the one moment name + identity co-occur (voice-session join).
 ///
-/// [[procedural-persona-genesis]] coherence anchor. A persona's name is the stable,
-/// persisted, user-visible truth; its live `peer_id` is a random tag airc mints
-/// independently (`PeerId::new()`), so the two need not agree in gender. The
-/// stateless selection paths (profile snapshot, live video pump) only ever hold the
-/// peer_id — so left alone they'd fall back to an id-hash gender that can mismatch
-/// the name (a feminine "Asha" on a masculine VRM). By capturing the NAME-derived
-/// gender ONCE, keyed by identity, every later selection (snapshot, pump, voice)
-/// resolves the SAME gender by id — coherent with each other AND with the name.
+/// Scope note (#199): for a LOCAL persona, her gender now comes from her durable
+/// [`PersonaCard`](crate::persona::card), which `registered_gender` consults FIRST —
+/// so this map is no longer our own personas' anchor. It survives for participants we
+/// DON'T host (a peer joining a call from another grid): we have no card for them, so
+/// their display name is the only presentation signal, captured here. A unisex/custom
+/// name (`gender_from_name` → `None`) records nothing → id-hash fallback.
 static PERSONA_GENDER: std::sync::Mutex<Option<HashMap<String, AvatarGender>>> =
     std::sync::Mutex::new(None);
 
-/// Capture a persona's name-anchored gender, keyed by its live identity. Call this
-/// when a persona's identity + display name are both in hand (voice-session
-/// registration). A unisex/custom name (`gender_from_name` → `None`) records
-/// nothing, so those fall back to the id-hash gender.
+/// Capture a REMOTE/live participant's name-anchored gender, keyed by their live
+/// identity. Call this when a participant's identity + display name co-occur (voice-
+/// session join) and no local card exists for them. A unisex/custom name
+/// (`gender_from_name` → `None`) records nothing, so those fall back to the id-hash
+/// gender. (Local personas register a durable [`PersonaCard`](crate::persona::card) at
+/// spawn instead — this is not their path.)
 pub fn register_persona_gender(identity: &str, name: &str) {
     if let Some(gender) = crate::persona::name_generator::gender_from_name(name) {
         clog_info!(
@@ -146,9 +146,23 @@ pub fn register_persona_gender(identity: &str, name: &str) {
     }
 }
 
-/// The name-anchored gender for an identity, if one was registered. This is the
-/// coherence source every avatar/voice selection consults FIRST.
+/// The authoritative gender for an identity, if known. The coherence source every
+/// avatar/voice selection consults FIRST, layered by population:
+///
+/// 1. **Local persona** → her durable [`PersonaCard`](crate::persona::card) (persisted
+///    on disk, registered at spawn). This is the "one identity, one card" truth — it
+///    replaced the per-spawn name re-derivation for our OWN personas.
+/// 2. **Remote/live participant** → the name-anchored gender captured at voice-session
+///    join ([`register_persona_gender`]). No local card exists for a peer in a call,
+///    so their display name is the only presentation signal we have.
+///
+/// Callers fall back to `gender_from_identity` when both miss.
 pub fn registered_gender(identity: &str) -> Option<AvatarGender> {
+    // (1) Local persona's durable card wins.
+    if let Some(gender) = crate::persona::card::gender_of(identity) {
+        return Some(gender);
+    }
+    // (2) Remote/live participant name-anchor.
     PERSONA_GENDER
         .lock()
         .unwrap()

--- a/core/continuum-core/src/modules/persona_instance_manager.rs
+++ b/core/continuum-core/src/modules/persona_instance_manager.rs
@@ -305,16 +305,25 @@ impl PersonaInstanceManagerModule {
             );
         }
 
-        // Register the persona's NAME-anchored gender at SPAWN, keyed by its identity
-        // (persona_id == peer_id, the same string the live avatar/voice sites key on).
-        // This makes the profile snapshot + every avatar/voice selection coherent with
-        // the visible name from BIRTH — not only once the persona joins a voice session
-        // ([[procedural-persona-genesis]] coherence anchor; the profile pic is shown in
-        // rosters/tiles with no call in play).
-        crate::live::avatar::selection::register_persona_gender(
-            &runtime.persona_id().to_string(),
-            runtime.agent_name(),
-        );
+        // Register the persona's durable CARD in the live card registry, keyed by its
+        // identity (persona_id == peer_id, the string every avatar/voice seam keys on).
+        // This is the authoritative gender/presentation source — `registered_gender`
+        // consults it FIRST — so the profile snapshot + every avatar/voice selection
+        // cohere with her persisted identity from BIRTH, not a per-boot re-derivation
+        // from her name ([[persona-is-the-airc-user-one-identity-one-card]]). Registered
+        // BEFORE the avatar pin below so the pin resolves THIS card's gender.
+        // (`register_persona_gender` survives only for REMOTE live participants — a peer
+        // in a call, resolved from their display name, for whom no local card exists.)
+        match crate::persona::seed::read_seed(&seed_path).await {
+            Ok(seed) => crate::persona::card::register(seed.card()),
+            Err(e) => tracing::warn!(
+                error = %e,
+                persona_id = %runtime.persona_id(),
+                agent_name = %runtime.agent_name(),
+                "failed to read seed for card registration — avatar/voice gender may \
+                 fall back to the id-hash this boot"
+            ),
+        }
 
         // Resolve + PIN her avatar VRM ONCE, now that the gender is registered (warm)
         // so the selection is correct (#174). STICKY: only when unset — a live pin is
@@ -336,6 +345,9 @@ impl PersonaInstanceManagerModule {
                         "failed to pin avatar_vrm — her face may re-derive on a cold render"
                     );
                 } else {
+                    // Re-register the card so the live registry reflects the freshly
+                    // pinned face (the earlier registration saw avatar_vrm = None).
+                    crate::persona::card::register(seed.card());
                     tracing::info!(
                         persona_id = %runtime.persona_id(),
                         agent_name = %runtime.agent_name(),

--- a/core/continuum-core/src/persona/card.rs
+++ b/core/continuum-core/src/persona/card.rs
@@ -1,0 +1,220 @@
+//! `PersonaCard` — the durable, coherent identity a persona presents.
+//!
+//! A persona IS its airc user; this card is the application-layer projection of
+//! that one identity — the "card" / social presence Joel names in
+//! [[persona-is-the-airc-user-one-identity-one-card]]: name, gender, pronouns,
+//! avatar, voice, role. Every facet COHERES because they all derive from (and are
+//! persisted alongside) the one `persona_id` (== the airc peer_id post-collapse).
+//!
+//! ### Genesis vs. persistence vs. the live registry — one card, three lives
+//!
+//! - **Genesis** ([`PersonaCard::genesis`], and the pure [`super::projection::project_persona`]):
+//!   derive the coherent card from an identity. Pure + deterministic.
+//! - **Persistence** ([`super::seed::PersonaSeedFile::V2`]): the card written to
+//!   `seed.json`, so it is STABLE across reboots + catalog drift and becomes an
+//!   editable surface (the airc identity card) rather than a per-boot re-derivation.
+//! - **Live registry** (this module's [`register`] / [`get`] / [`gender_of`]): the
+//!   in-memory lookup the hot avatar/voice seams read — they can't touch disk. A
+//!   LOCAL persona registers her persisted card at spawn; the seams resolve her
+//!   gender/presentation from it.
+//!
+//! ### Why this replaces the name-anchor hack for LOCAL personas
+//!
+//! Historically a persona's gender was RE-DERIVED from her NAME string every spawn
+//! (`selection::register_persona_gender` → `gender_from_name`), held in a process-
+//! global map. That worked, but the truth lived in a transient re-derivation, not a
+//! durable record — so it couldn't be edited or trusted as identity. Now the durable
+//! CARD is the truth: a local persona registers her card here, and
+//! `selection::registered_gender` consults this registry FIRST. The name-anchored
+//! map survives only for REMOTE/live participants (a peer in a call, resolved from
+//! their display name — no local card exists for them), which is a genuinely
+//! different function, not the hack.
+//!
+//! ### Coherence during the throwaway-name era (Slice 1)
+//!
+//! [`genesis`](PersonaCard::genesis) draws gender from the NAME first
+//! (`gender_from_name`), falling back to the id-hash — which is EXACTLY the effective
+//! gender the live seams computed before this slice, so migrating the existing
+//! personas shifts nobody. When the fresh-mint name later derives from the peer_id
+//! (the airc keypair-first change, Slice 1b), `gender_from_name(name)` will equal
+//! `gender_from_identity(id)` and genesis collapses to pure `project_persona(id)`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use uuid::Uuid;
+
+use crate::live::avatar::gender::{gender_from_identity, pronouns_for_gender, PronounSet};
+use crate::live::avatar::types::AvatarGender;
+use crate::persona::name_generator::gender_from_name;
+use crate::persona::role_template::RoleId;
+
+/// The coherent identity card. Every field agrees with `gender`, the presentation
+/// spine (avatar, voice, and pronouns all follow from it). Owned + serializable via
+/// [`super::seed::PersonaSeedFile::V2`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersonaCard {
+    /// The one durable identity (== the airc peer_id post-collapse).
+    pub persona_id: Uuid,
+    /// The persona's name — user-visible, the airc display name, and the home-dir label.
+    pub agent_name: String,
+    /// Birth time (ms since epoch). Stable across reboots.
+    pub created_at_ms: u64,
+    /// The presentation spine. Avatar, voice, and pronouns all cohere with this.
+    pub gender: AvatarGender,
+    /// The PINNED avatar VRM filename (sticky, resolve-once — #174). `None` until her
+    /// face is pinned at first spawn.
+    pub avatar_vrm: Option<String>,
+    /// The seed the speak path uses to pick a stable, gender-matched voice. Today it
+    /// is the identity string; a distinct field so a persona can later choose a voice
+    /// independent of her id without a schema change (the editable-card model).
+    pub voice_seed: String,
+    /// The substrate role, when known. `None` on a card minted before role threading
+    /// (that lands in a later #199 slice); the persona still functions.
+    pub role: Option<RoleId>,
+}
+
+impl PersonaCard {
+    /// Pronouns, derived from `gender`. NOT a stored field: pronouns are a pure
+    /// function of the spine today (compression — one logical decision, one place).
+    /// They EARN a stored slot the moment they become independently overridable
+    /// (`airc identity set --pronouns`, a later slice); until then, deriving keeps
+    /// them from drifting away from the gender they must agree with.
+    pub fn pronouns(&self) -> PronounSet {
+        pronouns_for_gender(self.gender)
+    }
+
+    /// Derive the coherent card from an identity + its visible name.
+    ///
+    /// Gender coheres with the NAME first (`gender_from_name`), falling back to the
+    /// id-hash for a unisex/custom name — which is exactly the effective gender the
+    /// live seams computed pre-Slice-1, so persisting it shifts nobody. `voice_seed`
+    /// is the identity string (matching [`super::projection::project_persona`]);
+    /// `role` is unknown at genesis. `avatar_vrm` is threaded in (a resumed persona's
+    /// pinned face is preserved; a fresh mint passes `None` and pins later).
+    pub fn genesis(
+        persona_id: Uuid,
+        agent_name: impl Into<String>,
+        created_at_ms: u64,
+        avatar_vrm: Option<String>,
+    ) -> Self {
+        let agent_name = agent_name.into();
+        let id_str = persona_id.to_string();
+        let gender =
+            gender_from_name(&agent_name).unwrap_or_else(|| gender_from_identity(&id_str));
+        Self {
+            persona_id,
+            agent_name,
+            created_at_ms,
+            gender,
+            avatar_vrm,
+            voice_seed: id_str,
+            role: None,
+        }
+    }
+}
+
+/// The live card registry — identity string (`persona_id.to_string()`) → the LOCAL
+/// persona's durable card. Populated at spawn from the persisted seed; read by the
+/// hot avatar/voice seams via [`crate::live::avatar::selection::registered_gender`],
+/// which consults it FIRST. Same process-global shape as the substrate's other
+/// stateless lookups (`perception_registry`, `shared_compute::global`): a lookup
+/// table, not a manager.
+static CARD_REGISTRY: Mutex<Option<HashMap<String, PersonaCard>>> = Mutex::new(None);
+
+/// Register (or refresh) a local persona's durable card, keyed by her identity. The
+/// authoritative gender/presentation source for every avatar/voice selection — this
+/// is what replaces the name-re-derivation for our OWN personas.
+pub fn register(card: PersonaCard) {
+    let key = card.persona_id.to_string();
+    CARD_REGISTRY
+        .lock()
+        .unwrap()
+        .get_or_insert_with(HashMap::new)
+        .insert(key, card);
+}
+
+/// The full card for an identity, if a local persona registered one.
+pub fn get(identity: &str) -> Option<PersonaCard> {
+    CARD_REGISTRY
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|m| m.get(identity).cloned())
+}
+
+/// The registered card's gender for an identity, if present. The seam
+/// `registered_gender` calls before falling back to the remote-participant
+/// name-anchor and finally the id-hash.
+pub fn gender_of(identity: &str) -> Option<AvatarGender> {
+    CARD_REGISTRY
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|m| m.get(identity).map(|c| c.gender))
+}
+
+/// Drop a persona's card from the live registry (test isolation + despawn).
+#[cfg(test)]
+pub fn remove(identity: &str) {
+    if let Some(m) = CARD_REGISTRY.lock().unwrap().as_mut() {
+        m.remove(identity);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the coherence contract of the card — gender is the spine,
+    // pronouns derive from it, voice_seed is the identity, and a female/male NAME
+    // drives the gender (so the card agrees with the visible name). This is the
+    // invariant the whole "one identity, one coherent card" model rests on.
+    #[test]
+    fn genesis_card_is_coherent_with_the_name() {
+        // A name unambiguously in the FEMALE pool.
+        let female_name = "Asha";
+        assert_eq!(gender_from_name(female_name), Some(AvatarGender::Female));
+        let id = Uuid::new_v4();
+        let card = PersonaCard::genesis(id, female_name, 1000, None);
+        assert_eq!(card.gender, AvatarGender::Female, "gender agrees with the name");
+        assert_eq!(card.pronouns().subject, "she", "pronouns cohere with gender");
+        assert_eq!(card.voice_seed, id.to_string(), "voice seeds on the identity");
+        assert_eq!(card.persona_id, id);
+        assert_eq!(card.created_at_ms, 1000);
+        assert!(card.role.is_none(), "role unknown at genesis");
+    }
+
+    // what this catches: a unisex/custom name (not in either gendered pool) falls
+    // back to the id-hash gender — never panics, always coheres with SOMETHING. This
+    // is the fallback the pre-Slice-1 seams used, so it must be preserved to avoid a
+    // migration shift.
+    #[test]
+    fn genesis_falls_back_to_id_hash_for_a_custom_name() {
+        let custom = "Zzyzx-not-in-any-pool";
+        assert_eq!(gender_from_name(custom), None);
+        let id = Uuid::new_v4();
+        let card = PersonaCard::genesis(id, custom, 0, None);
+        assert_eq!(
+            card.gender,
+            gender_from_identity(&id.to_string()),
+            "custom name → id-hash gender (the effective pre-Slice-1 behavior)"
+        );
+    }
+
+    // what this catches: the live registry round-trips a card and answers gender_of
+    // — the exact lookup the avatar/voice seams depend on. A missing id returns None
+    // (so the seam falls through to the name-anchor / id-hash), never a wrong gender.
+    #[test]
+    fn registry_round_trips_and_gender_of_resolves() {
+        let id = Uuid::new_v4();
+        let card = PersonaCard::genesis(id, "Niko", 0, None); // Niko ∈ MALE_NAMES
+        let key = id.to_string();
+        register(card.clone());
+        assert_eq!(get(&key), Some(card));
+        assert_eq!(gender_of(&key), Some(AvatarGender::Male));
+        assert_eq!(gender_of(&Uuid::new_v4().to_string()), None, "unknown id → None");
+        remove(&key);
+        assert_eq!(get(&key), None, "removed card is gone");
+    }
+}

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -33,6 +33,7 @@ pub mod scripted_conversation;
 pub mod airc_runtime_registry;
 pub mod airc_source;
 pub mod allocator;
+pub mod card;
 pub mod channel_items;
 pub mod channel_queue;
 pub mod channel_registry;

--- a/core/continuum-core/src/persona/seed.rs
+++ b/core/continuum-core/src/persona/seed.rs
@@ -48,12 +48,23 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::live::avatar::types::AvatarGender;
+use crate::persona::card::PersonaCard;
+use crate::persona::role_template::RoleId;
+
 /// The on-disk seed record. Schema-versioned so we can evolve
 /// fields without breaking older installs.
+///
+/// v2 promotes the seed from a bare identity mapping to the persona's full,
+/// durable, coherent [`PersonaCard`] — the "one identity, one card" record
+/// ([[persona-is-the-airc-user-one-identity-one-card]]). A v1 row deserializes fine
+/// (serde `tag = "version"`) and is UPGRADED to v2 on the next write
+/// ([`ensure_seed`]), backfilling the card from the persona's current effective
+/// values so nobody shifts.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "version")]
 pub enum PersonaSeedFile {
-    /// v1 schema — persona_id + agent_name + created_at.
+    /// v1 schema — persona_id + agent_name + created_at (+ pinned avatar).
     #[serde(rename = "1")]
     V1 {
         /// Stable continuum-side identifier. Drives name + avatar +
@@ -80,31 +91,102 @@ pub enum PersonaSeedFile {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         avatar_vrm: Option<String>,
     },
+    /// v2 schema — the full coherent [`PersonaCard`]. Adds the presentation spine
+    /// (`gender`), the `voice_seed`, and the substrate `role` on top of v1. Pronouns
+    /// are NOT stored — they derive from `gender` (compression; see
+    /// [`PersonaCard::pronouns`]).
+    #[serde(rename = "2")]
+    V2 {
+        persona_id: Uuid,
+        agent_name: String,
+        created_at_ms: u64,
+        /// The presentation spine — avatar, voice, and pronouns all cohere with it.
+        gender: AvatarGender,
+        /// The pinned avatar VRM (sticky, resolve-once — #174). `None` until pinned.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        avatar_vrm: Option<String>,
+        /// The seed the speak path picks a stable, gender-matched voice from (today
+        /// the identity string; a field so voice can later be chosen independently).
+        voice_seed: String,
+        /// The substrate role, when known. `None` before role threading (later slice).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        role: Option<RoleId>,
+    },
 }
 
 impl PersonaSeedFile {
+    /// Build a v2 seed from a persona's durable [`PersonaCard`].
+    pub fn from_card(card: &PersonaCard) -> Self {
+        Self::V2 {
+            persona_id: card.persona_id,
+            agent_name: card.agent_name.clone(),
+            created_at_ms: card.created_at_ms,
+            gender: card.gender,
+            avatar_vrm: card.avatar_vrm.clone(),
+            voice_seed: card.voice_seed.clone(),
+            role: card.role,
+        }
+    }
+
+    /// The persona's full coherent card. A v2 seed returns its stored card verbatim
+    /// (the durable, editable truth). A v1 seed DERIVES the card via
+    /// [`PersonaCard::genesis`] — which reproduces the exact effective gender the live
+    /// seams computed pre-v2, so reading an un-upgraded v1 shifts nobody.
+    pub fn card(&self) -> PersonaCard {
+        match self {
+            Self::V2 {
+                persona_id,
+                agent_name,
+                created_at_ms,
+                gender,
+                avatar_vrm,
+                voice_seed,
+                role,
+            } => PersonaCard {
+                persona_id: *persona_id,
+                agent_name: agent_name.clone(),
+                created_at_ms: *created_at_ms,
+                gender: *gender,
+                avatar_vrm: avatar_vrm.clone(),
+                voice_seed: voice_seed.clone(),
+                role: *role,
+            },
+            Self::V1 {
+                persona_id,
+                agent_name,
+                created_at_ms,
+                avatar_vrm,
+            } => PersonaCard::genesis(
+                *persona_id,
+                agent_name.clone(),
+                *created_at_ms,
+                avatar_vrm.clone(),
+            ),
+        }
+    }
+
     pub fn persona_id(&self) -> Uuid {
         match self {
-            Self::V1 { persona_id, .. } => *persona_id,
+            Self::V1 { persona_id, .. } | Self::V2 { persona_id, .. } => *persona_id,
         }
     }
 
     pub fn agent_name(&self) -> &str {
         match self {
-            Self::V1 { agent_name, .. } => agent_name,
+            Self::V1 { agent_name, .. } | Self::V2 { agent_name, .. } => agent_name,
         }
     }
 
     pub fn created_at_ms(&self) -> u64 {
         match self {
-            Self::V1 { created_at_ms, .. } => *created_at_ms,
+            Self::V1 { created_at_ms, .. } | Self::V2 { created_at_ms, .. } => *created_at_ms,
         }
     }
 
     /// The pinned avatar VRM filename, if this persona's face has been resolved yet.
     pub fn avatar_vrm(&self) -> Option<&str> {
         match self {
-            Self::V1 { avatar_vrm, .. } => avatar_vrm.as_deref(),
+            Self::V1 { avatar_vrm, .. } | Self::V2 { avatar_vrm, .. } => avatar_vrm.as_deref(),
         }
     }
 
@@ -113,7 +195,7 @@ impl PersonaSeedFile {
     /// thrashes once chosen.
     pub fn set_avatar_vrm(&mut self, vrm: String) {
         match self {
-            Self::V1 { avatar_vrm, .. } => *avatar_vrm = Some(vrm),
+            Self::V1 { avatar_vrm, .. } | Self::V2 { avatar_vrm, .. } => *avatar_vrm = Some(vrm),
         }
     }
 }
@@ -297,22 +379,34 @@ pub async fn ensure_seed(
     agent_name: &str,
     fallback_created_at_ms: u64,
 ) -> Result<(), PersonaSeedError> {
-    // Carry forward BOTH the birth time and the pinned avatar (#174): ensure_seed
-    // rewrites the seed every spawn, so it must preserve a resolved avatar_vrm or the
-    // sticky pin would be wiped each boot — the exact thrash we're killing.
-    let (created_at_ms, avatar_vrm) = match read_seed(seed_path).await {
-        Ok(existing) => (existing.created_at_ms(), existing.avatar_vrm().map(String::from)),
-        // Missing or corrupt → treat fallback as the birth time. (A corrupt seed is
-        // being healed; we can't trust its timestamp, so the live boot stands in.)
-        Err(_) => (fallback_created_at_ms, None),
+    // Resolve the card to persist, self-healing across all three prior states:
+    //
+    // - **existing v2** → the durable card is AUTHORITATIVE + editable. Preserve its
+    //   card fields (gender, voice_seed, role, avatar_vrm, birth time) and drift-heal
+    //   only the live identity + name. Re-deriving gender here would wipe a future
+    //   user override every boot — the same clobber class as the avatar pin (#174).
+    // - **existing v1** → UPGRADE to v2: derive the coherent card via
+    //   `PersonaCard::genesis` from the LIVE identity + name, which reproduces the
+    //   exact effective gender the seams used pre-v2 (no shift), preserving the birth
+    //   time + pinned avatar the v1 row already carried.
+    // - **missing / corrupt** → genesis with the fallback birth time (a corrupt
+    //   seed's timestamp is untrusted, so the live boot stands in).
+    let card = match read_seed(seed_path).await {
+        Ok(existing @ PersonaSeedFile::V2 { .. }) => {
+            let mut card = existing.card();
+            card.persona_id = persona_id;
+            card.agent_name = agent_name.to_string();
+            card
+        }
+        Ok(existing @ PersonaSeedFile::V1 { .. }) => PersonaCard::genesis(
+            persona_id,
+            agent_name,
+            existing.created_at_ms(),
+            existing.avatar_vrm().map(String::from),
+        ),
+        Err(_) => PersonaCard::genesis(persona_id, agent_name, fallback_created_at_ms, None),
     };
-    let seed = PersonaSeedFile::V1 {
-        persona_id,
-        agent_name: agent_name.to_string(),
-        created_at_ms,
-        avatar_vrm,
-    };
-    write_seed_atomic(seed_path, &seed).await
+    write_seed_atomic(seed_path, &PersonaSeedFile::from_card(&card)).await
 }
 
 #[cfg(test)]
@@ -421,6 +515,88 @@ mod tests {
         let read = read_seed(&path).await.unwrap();
         assert_eq!(read.persona_id(), id);
         assert_eq!(read.created_at_ms(), 5555, "corrupt seed's timestamp is untrusted → fallback");
+    }
+
+    // what this catches (#199 migration a): a v1 seed UPGRADES to v2 on the next
+    // ensure_seed WITHOUT shifting the persona — her v2 gender equals the effective
+    // gender the live seams derived from her NAME pre-v2, and her birth time survives.
+    // This is the load-bearing "the existing 8 stabilize, nobody reshuffles" guard.
+    #[tokio::test]
+    async fn ensure_seed_upgrades_v1_to_v2_without_shifting() {
+        use crate::live::avatar::types::AvatarGender;
+        use crate::persona::name_generator::gender_from_name;
+
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("seed.json");
+        let pid = Uuid::new_v4();
+        // "Asha" is unambiguously in the FEMALE pool — the effective pre-v2 gender.
+        assert_eq!(gender_from_name("Asha"), Some(AvatarGender::Female));
+        let v1 = PersonaSeedFile::V1 {
+            persona_id: pid,
+            agent_name: "Asha".to_string(),
+            created_at_ms: 1_717_200_000_000,
+            avatar_vrm: Some("asha.vrm".to_string()),
+        };
+        write_seed_atomic(&path, &v1).await.unwrap();
+
+        ensure_seed(&path, pid, "Asha", 9_999_999_999_999).await.unwrap();
+        let after = read_seed(&path).await.unwrap();
+        assert!(matches!(after, PersonaSeedFile::V2 { .. }), "v1 must upgrade to v2");
+        let card = after.card();
+        assert_eq!(card.gender, AvatarGender::Female, "gender must NOT shift on upgrade");
+        assert_eq!(card.created_at_ms, 1_717_200_000_000, "birth time preserved");
+        assert_eq!(card.avatar_vrm.as_deref(), Some("asha.vrm"), "pinned face preserved");
+        assert_eq!(card.voice_seed, pid.to_string(), "voice seeds on identity");
+    }
+
+    // what this catches: a v2 card is AUTHORITATIVE + editable — ensure_seed must NOT
+    // re-derive its gender from the name each boot (a future `airc identity set
+    // --gender/--pronouns` override would be wiped otherwise, the same clobber class
+    // as the avatar pin #174). We store a gender that GENESIS would NOT produce and
+    // prove it survives a respawn.
+    #[tokio::test]
+    async fn ensure_seed_preserves_a_v2_card_gender_across_respawn() {
+        use crate::live::avatar::types::AvatarGender;
+        use crate::persona::name_generator::gender_from_name;
+
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("seed.json");
+        let pid = Uuid::new_v4();
+        // "Niko" is a MALE-pool name, so genesis would derive Male. We deliberately
+        // pin Female (a hypothetical override) and require it to stick.
+        assert_eq!(gender_from_name("Niko"), Some(AvatarGender::Male));
+        let v2 = PersonaSeedFile::V2 {
+            persona_id: pid,
+            agent_name: "Niko".to_string(),
+            created_at_ms: 500,
+            gender: AvatarGender::Female,
+            avatar_vrm: None,
+            voice_seed: pid.to_string(),
+            role: None,
+        };
+        write_seed_atomic(&path, &v2).await.unwrap();
+
+        ensure_seed(&path, pid, "Niko", 9_999).await.unwrap();
+        let after = read_seed(&path).await.unwrap();
+        assert_eq!(
+            after.card().gender,
+            AvatarGender::Female,
+            "a stored v2 gender must be preserved, not re-derived from the name"
+        );
+        assert_eq!(after.created_at_ms(), 500, "birth time preserved on v2 respawn");
+    }
+
+    // what this catches: from_card → write → read → card() is a lossless round-trip,
+    // so the durable card survives a reboot exactly (the whole point of persisting it).
+    #[tokio::test]
+    async fn from_card_round_trips_through_disk() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("seed.json");
+        let pid = Uuid::new_v4();
+        let card = PersonaCard::genesis(pid, "Maya", 4242, Some("maya.vrm".to_string()));
+        write_seed_atomic(&path, &PersonaSeedFile::from_card(&card)).await.unwrap();
+        let read = read_seed(&path).await.unwrap();
+        assert_eq!(read.card(), card, "card must survive the disk round-trip intact");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What & why (#199 Slice 1 — keystone)

The persona **is** its airc user. This makes her identity **card** (name, gender, pronouns, avatar, voice, role) a **durable, coherent record** instead of a per-boot re-derivation from her name held in a process-global `Mutex`. First step toward "one identity, one card" ([[persona-is-the-airc-user-one-identity-one-card]]).

Sequencing (approved by Joel 2026-07-18): **V2-persist first, keypair-first next.** The name can't derive from `peer_id` without an airc-lib change (peer_id is minted *after* the home/name is chosen in `bootstrap → attach_as`; airc-lib is a pinned git dep). The card is already internally coherent via the name-anchor; the only impurity is a fresh mint's name seeding from the throwaway uuid. So this slice makes the card **durable + kills the local name-anchor** (no airc change, migration-safe for the 8 living personas); Slice 1b does the keypair-first move.

## Changes
- **`persona/card.rs` (new)** — `PersonaCard` (gender = spine; pronouns **derived**, not stored, per compression) + a live registry keyed by identity. `genesis()` = `gender_from_name(name).or(gender_from_identity(id))` = today's effective gender → **zero shift**.
- **`persona/seed.rs`** — `PersonaSeedFile::V2` carrying the full card. `ensure_seed` is card-aware: a **V2 card is authoritative + editable** (preserved across respawn, never re-derived — the #174 clobber class); a **V1 row upgrades to V2 coherently**; missing/corrupt → genesis heal. `from_card` + `card()` round-trip.
- **`persona_instance_manager::bootstrap_one`** — registers the durable card at spawn (before the avatar pin, so the pin resolves the card's gender), replacing `register_persona_gender` for our own personas.
- **`live/avatar/selection::registered_gender`** — consults the card registry **first**, so every avatar/voice seam is card-first with **zero call-site churn**. The name-anchor survives only for **remote live participants** (a peer in a call, no local card) — documented, not deleted.

## Validation
- **Unit**: 41 targeted tests green — card (3), seed +3 (V1→V2 **no-shift**, V2-gender preserved across respawn, card disk round-trip), projection/selection/name_generator/instance-mgr/resume-mint regression-green. Lib compiles clean.
- **Live** (`cu reboot`): the 4 personas that bootstrapped upgraded V1→V2 with **name-coherent gender** (Anwen/Asha → female, Atlas/Casper → male), **avatars + names + birth times preserved** — zero reshuffle. Remaining 4 migrate lazily on their next spawn (read fine as V1 meanwhile). Caught + fixed a `cargo check`-poisoned-fingerprint stale deploy (#194 variant) during validation — captured in memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)