### PR TITLE
fix(serving): #216 — don't re-plan while a relaunch is in flight (kills the VRAM-scan thrash)

### DIFF
--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -534,6 +534,22 @@ impl ServingDaemonModule {
     /// Recompute the plan from the live host snapshot + on-disk models, publish
     /// it, and log the decision. Idempotent — safe to call on init and tick.
     fn recompute(&self) {
+        // Don't re-plan while a relaunch of the serving lane is IN FLIGHT (#216). During the
+        // kill→respawn, the GPU scan (`physical_used`) transiently drops as the old lane exits
+        // and rises as the new one loads, so `host_budget()` — which reads the board's
+        // `available = capacity − max(granted, physical_used)` — sees a PHANTOM free-VRAM
+        // spike/dip. A plan recomputed off that transient flaps the window and triggers ANOTHER
+        // relaunch: the thrash loop (glass-boxed 2026-07-20 — board available swung 12.9↔41GB,
+        // window 44800↔7680, back-to-back relaunches). Serving's own in-flight churn must not
+        // feed back into its own plan. Hold the last plan until the reconcile settles; the gate
+        // clears via RAII (#214) the instant the relaunch finishes OR fails, so re-planning
+        // resumes promptly against the STABLE post-relaunch budget — no thrash, no stall. (The
+        // deeper fix — serving holding an explicit board lease so `granted` pins its residency
+        // and the scan transient never reaches `available` at all — is the #56 consumers-LEASE
+        // residual; this breaks the feedback loop cleanly in the meantime.)
+        if self.reconciling.load(Ordering::Acquire) {
+            return;
+        }
         let budget = self.host_budget();
         self.publish_plan(budget, &self.live_candidates());
     }


### PR DESCRIPTION
After #214 un-froze grow-back, serving **thrashed** on a churned box: window flapped **44800↔7680** while the board's `available` swung **12.9↔41 GB** in 30 s.

Root: serving is scan-accounted (`available = capacity − max(granted, physical_used)`, granted=0 with no lease), so `available` tracks the raw GPU scan. During serving's **own** relaunch (kill→respawn) the scan dips then rises — a phantom free-VRAM spike/dip. The planner reads it, flaps the window, and the flapped plan triggers **another** relaunch: a feedback loop where serving's own churn re-plans its own lane off a transient budget.

Fix: `recompute()` early-returns while a relaunch is in flight (`reconciling` true). Composes with #214 — the RAII gate clears the instant the relaunch finishes *or* fails, so re-planning resumes promptly against the **stable post-relaunch budget**. No thrash, no stall. (Deeper fix — serving holding an explicit board lease so the scan transient never reaches `available` — is the #56 consumers-LEASE residual.)

22/22 serving_daemon tests green. Live thrash-gone validation on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)