### PR TITLE
Lane admission planner + Proctored Exam Session (B/C/A1/A2) + Ludicrous serving

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -1254,6 +1254,22 @@ struct OpenAITimings {
 /// total-request timeout that killed legitimately-long generations.
 const STREAM_IDLE_TIMEOUT_SECS: u64 = 90;
 
+/// A local single-resident lane can be RELAUNCHED out from under an in-flight POST —
+/// grow-back (#214), a genome page-in, or memory pressure all bounce the llama-server
+/// process, and the published serving snapshot can lag at `ready=true` for the ~seconds
+/// the socket is actually refused (the pre-flight guard trusts the `watch` snapshot; the
+/// socket is the ground truth, and a watch channel is inherently slightly behind the
+/// process). A `connect` error is therefore "the lane is mid-relaunch", not "the lane is
+/// gone": the connection never opened, so nothing was streamed to the sink, and
+/// re-sending the SAME lane/model is idempotent — resilience, NOT a fallback
+/// ([[fallbacks-are-illegal-fail-loud]]). Retry the connect with linear backoff
+/// (1s, 2s, … ≈ 21s total) to ride out a relaunch, then fail loud if it never returns.
+/// Scoped to the local resident lane — remote endpoints don't relaunch under us.
+/// Glass-boxed 2026-07-20: one legitimate grow-back relaunch zeroed hard-rs 0/8, every
+/// task `Connection refused (os error 61)` to :58057 mid-eval.
+const LANE_RELAUNCH_CONNECT_RETRIES: u32 = 6;
+const LANE_RELAUNCH_RETRY_BASE: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// One streamed SSE frame from an OpenAI-compatible `/v1/chat/completions` with
 /// `stream: true`. Each frame carries an incremental `delta`; `usage` arrives only
 /// on the final frame (requires `stream_options.include_usage`).
@@ -1914,31 +1930,67 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
             }
         }
 
-        let send_start = Instant::now();
-        let response = request_builder.json(&body).send().await.map_err(|e| {
-            // reqwest::Error's top-level Display often collapses the
-            // real cause (timeout vs connect vs body-write) into a
-            // generic "error sending request" string. Walk the error
-            // source chain so the log shows the actual terminal
-            // reason — critical for debugging stalls where the
-            // outer message alone is useless.
-            let mut chain: Vec<String> = vec![e.to_string()];
-            let mut cur: &dyn std::error::Error = &e;
-            while let Some(src) = cur.source() {
-                chain.push(src.to_string());
-                cur = src;
+        // A CONNECT error to a local resident lane means the lane is mid-relaunch, not
+        // gone (see LANE_RELAUNCH_CONNECT_RETRIES) — the connection never opened so
+        // nothing streamed, and re-sending the same lane is idempotent. Ride it out with
+        // bounded linear backoff, then fail loud. `request_builder` carries no body yet
+        // (`.json` is applied per attempt below), so `try_clone` always succeeds.
+        let mut connect_retries: u32 = 0;
+        let response = loop {
+            let send_start = Instant::now();
+            let attempt_builder = request_builder
+                .try_clone()
+                .expect("bodyless request builder is always cloneable");
+            match attempt_builder.json(&body).send().await {
+                Ok(resp) => break resp,
+                Err(e)
+                    if e.is_connect()
+                        && self.config.single_resident_model
+                        && connect_retries < LANE_RELAUNCH_CONNECT_RETRIES =>
+                {
+                    connect_retries += 1;
+                    let backoff = LANE_RELAUNCH_RETRY_BASE * connect_retries;
+                    crate::probe!(
+                        class = "inference.lane_relaunch_retry",
+                        provider = self.config.provider_id.as_str(),
+                        attempt = connect_retries,
+                        backoff_ms = backoff.as_millis() as u64,
+                        "local lane refused the connection (mid-relaunch) — retrying the same lane",
+                    );
+                    tokio::time::sleep(backoff).await;
+                    continue;
+                }
+                Err(e) => {
+                    // reqwest::Error's top-level Display often collapses the
+                    // real cause (timeout vs connect vs body-write) into a
+                    // generic "error sending request" string. Walk the error
+                    // source chain so the log shows the actual terminal
+                    // reason — critical for debugging stalls where the
+                    // outer message alone is useless.
+                    let mut chain: Vec<String> = vec![e.to_string()];
+                    let mut cur: &dyn std::error::Error = &e;
+                    while let Some(src) = cur.source() {
+                        chain.push(src.to_string());
+                        cur = src;
+                    }
+                    return Err(format!(
+                        "{} POST failed after {}ms{}: {} (kind: timeout={}, connect={}, request={}, body={})",
+                        self.config.name,
+                        send_start.elapsed().as_millis(),
+                        if connect_retries > 0 {
+                            format!(" ({connect_retries} connect-retries exhausted — lane never came back)")
+                        } else {
+                            String::new()
+                        },
+                        chain.join(" -> "),
+                        e.is_timeout(),
+                        e.is_connect(),
+                        e.is_request(),
+                        e.is_body()
+                    ));
+                }
             }
-            format!(
-                "{} POST failed after {}ms: {} (kind: timeout={}, connect={}, request={}, body={})",
-                self.config.name,
-                send_start.elapsed().as_millis(),
-                chain.join(" -> "),
-                e.is_timeout(),
-                e.is_connect(),
-                e.is_request(),
-                e.is_body()
-            )
-        })?;
+        };
 
         if !response.status().is_success() {
             let status = response.status();

--- a/core/continuum-core/src/capacity/grid.rs
+++ b/core/continuum-core/src/capacity/grid.rs
@@ -17,6 +17,7 @@
 //! 20 minutes in. The live policy re-derives placement from every snapshot, so partition,
 //! join, loss, and return all fall out of ONE rule.
 
+use std::collections::HashMap;
 use std::sync::Mutex;
 
 use crate::identity::PeerId;
@@ -114,6 +115,110 @@ impl GridPlacementPolicy for LocalFirstFitPolicy {
     }
     fn name(&self) -> &'static str {
         "local-first-fit"
+    }
+}
+
+/// MODEL-AWARE grid placement — the convergence of the [`super::super::resources::placement`]
+/// kernel's affinity rule onto the grid policy shape (Slice A2). Where [`LocalFirstFitPolicy`]
+/// fills by FREE BYTES (model-blind — it would cold-load a base onto the emptiest node even
+/// when a peer already holds it WARM), this ranks nodes AFFINITY-FIRST: a node already serving
+/// the demand's base beats a node with more free RAM every time, because routing there avoids a
+/// cold weight-load + cross-node transfer — AND it frees the local GPU for whatever else is live
+/// (a video huddle running while a benchmark rides a warm peer). Among equally-warm nodes it
+/// prefers local (no network hop), then most-free. No local floor: if the base is warm on a peer
+/// and cold locally, the whole demand can ride the peer, leaving the local accelerator untouched.
+///
+/// The warm-base map is carried on the policy (constructed per-scenario) rather than threaded
+/// onto the widely-built [`GridSnapshot`]/[`LeaseRequest`] — that snapshot-threading is the
+/// deliberate follow-up that lands WITH the live grid-serving consumer (the ~48-site schema
+/// change buys nothing while these policies are simulator-only). Here the affinity IDEA is
+/// proven in the gym against the byte-fill baseline. An empty `demand_base` (or empty `warm`)
+/// degrades to locality-then-free ordering — the model-blind path, unchanged.
+/// [[misfit-grid-is-a-distributed-moe]] [[seamless-persona-failover-model-and-genome]]
+pub struct AffinityFitPolicy {
+    /// Headroom kept free on EVERY node — same meaning as [`LocalFirstFitPolicy`].
+    pub safety_margin_bytes: u64,
+    /// The base the demand needs. Nodes already holding it warm are preferred. Empty =
+    /// model-blind (no affinity signal → locality-then-free ordering).
+    pub demand_base: String,
+    /// Which bases each peer holds WARM this snapshot, keyed by peer. In the live path this
+    /// moves onto `GridSnapshot`; carried here so the affinity idea is sim-validated with zero
+    /// churn to the widely-constructed snapshot/request types.
+    pub warm: HashMap<PeerId, Vec<String>>,
+    /// Whether the LOCAL node already holds the demand's base warm.
+    pub local_warm: bool,
+}
+
+impl AffinityFitPolicy {
+    fn peer_is_warm(&self, peer: &PeerId) -> bool {
+        !self.demand_base.is_empty()
+            && self
+                .warm
+                .get(peer)
+                .is_some_and(|bases| bases.iter().any(|b| b == &self.demand_base))
+    }
+}
+
+impl GridPlacementPolicy for AffinityFitPolicy {
+    fn place(&self, grid: &GridSnapshot, req: &LeaseRequest) -> Placement {
+        let want = req.want_concurrency.max(1);
+
+        // One candidate per servable node: local + every REACHABLE peer (unreachable peers are
+        // memories, not offers — the same reclaim rule as local-first). `peer: None` = local.
+        struct Cand {
+            peer: Option<PeerId>,
+            free: u64,
+            warm: bool,
+        }
+        let mut cands: Vec<Cand> = Vec::with_capacity(1 + grid.peers.len());
+        cands.push(Cand {
+            peer: None,
+            free: grid.local.gpu_free_bytes_live,
+            warm: !self.demand_base.is_empty() && self.local_warm,
+        });
+        for p in grid.peers.iter().filter(|p| p.reachable) {
+            cands.push(Cand {
+                peer: Some(p.peer),
+                free: p.capacity.gpu_free_bytes_live,
+                warm: self.peer_is_warm(&p.peer),
+            });
+        }
+
+        // Affinity FIRST (warm beats free — the whole point), then local before remote (no
+        // network hop), then most-free. `sort_by` is STABLE, so equal keys keep insertion order
+        // (local pushed first, then peers in snapshot order) — deterministic without needing an
+        // Ord on PeerId.
+        cands.sort_by(|a, b| {
+            b.warm
+                .cmp(&a.warm)
+                .then_with(|| b.peer.is_none().cmp(&a.peer.is_none()))
+                .then_with(|| b.free.cmp(&a.free))
+        });
+
+        // Fill the demand down the ranked order, each node capped by ITS OWN per-node fit (the
+        // misfit-parts rule — the aggregate never gets a vote). No local floor: a fully-warm
+        // peer can take the whole demand, leaving the local accelerator free for live work.
+        let mut remaining = want;
+        let mut local_lanes = 0u32;
+        let mut remote: Vec<(PeerId, u32)> = Vec::new();
+        for c in &cands {
+            if remaining == 0 {
+                break;
+            }
+            let take = lanes_that_fit(c.free, self.safety_margin_bytes, req.spike_bytes).min(remaining);
+            if take == 0 {
+                continue;
+            }
+            match c.peer {
+                None => local_lanes += take,
+                Some(p) => remote.push((p, take)),
+            }
+            remaining -= take;
+        }
+        Placement { local_lanes, remote }
+    }
+    fn name(&self) -> &'static str {
+        "affinity-fit"
     }
 }
 
@@ -623,6 +728,88 @@ mod tests {
             0,
             "and honesty means zero per-node overflow"
         );
+    }
+
+    // what this catches (Slice A2): AFFINITY beats byte-fill — the strategic-across-nodes win,
+    // and the concrete answer to "video chat AND a benchmark at once". A warm peer (already
+    // serving the demand's base) with LESS free RAM must win over an emptier COLD node: routing
+    // there avoids a cold weight-load + cross-node transfer AND frees the local GPU for the live
+    // video huddle. Model-blind LocalFirstFit floors local and fills by free bytes — it pays the
+    // cold load and eats the local accelerator. AffinityFit routes the exam to the warm peer and
+    // leaves local at ZERO. If affinity ever collapsed to byte-fill, the grid would fight itself
+    // instead of placing each workload where it already fits. [[misfit-grid-is-a-distributed-moe]]
+    #[test]
+    fn affinity_routes_to_the_warm_peer_over_an_emptier_cold_node() {
+        let dev = |free_gb: u64| DeviceCapacity {
+            gpu_total_bytes: 32 * GB,
+            gpu_free_bytes_live: free_gb * GB,
+            system_ram_free_bytes: 16 * GB,
+        };
+        let warm_peer = PeerId::from_u128(20);
+        // Local has the MOST free but is COLD (doesn't hold coder-32b). The peer has less free
+        // but already serves coder-32b warm.
+        let grid = GridSnapshot {
+            local: dev(20),
+            peers: vec![PeerCapacity { peer: warm_peer, capacity: dev(6), reachable: true }],
+        };
+        let demand =
+            LeaseRequest { consumer: "eval".into(), want_concurrency: 1, spike_bytes: 2 * GB };
+
+        // Byte-fill: local wins (emptier + local floor) — the benchmark cold-loads on the live GPU.
+        let byte_fill = LocalFirstFitPolicy { safety_margin_bytes: GB }.place(&grid, &demand);
+        assert_eq!(byte_fill.local_lanes, 1, "byte-fill floors local and ignores the warm peer");
+        assert!(byte_fill.remote.is_empty(), "byte-fill never reaches for the warm peer");
+
+        // Affinity: the lane goes to the WARM peer, leaving the local GPU free for live work.
+        let mut warm = HashMap::new();
+        warm.insert(warm_peer, vec!["coder-32b".to_string()]);
+        let affinity = AffinityFitPolicy {
+            safety_margin_bytes: GB,
+            demand_base: "coder-32b".to_string(),
+            warm,
+            local_warm: false,
+        }
+        .place(&grid, &demand);
+        assert_eq!(affinity.local_lanes, 0, "affinity leaves the local GPU free for the live call");
+        assert_eq!(
+            affinity.remote,
+            vec![(warm_peer, 1)],
+            "the exam runs on the node that already holds its weights warm"
+        );
+        // And it never strands or over-commits (the resilience invariants still hold).
+        assert_eq!(stranded_lanes(&grid, &affinity), 0);
+        assert_eq!(placement_oom_count(&grid, &demand, &affinity), 0);
+    }
+
+    // what this catches: with NO affinity signal (empty demand_base), AffinityFit degrades to the
+    // model-blind ordering — locality first, then free — so it never behaves worse than the
+    // byte-fill baseline on a cold grid. The affinity policy is a strict SUPERSET: it adds warm
+    // routing without losing the misfit-parts guarantees.
+    #[test]
+    fn affinity_with_no_warm_signal_falls_back_to_locality_then_free() {
+        let dev = |free_gb: u64| DeviceCapacity {
+            gpu_total_bytes: 32 * GB,
+            gpu_free_bytes_live: free_gb * GB,
+            system_ram_free_bytes: 16 * GB,
+        };
+        let peer = PeerId::from_u128(21);
+        let grid = GridSnapshot {
+            local: dev(6),
+            peers: vec![PeerCapacity { peer, capacity: dev(6), reachable: true }],
+        };
+        let demand =
+            LeaseRequest { consumer: "eval".into(), want_concurrency: 3, spike_bytes: 2 * GB };
+        let p = AffinityFitPolicy {
+            safety_margin_bytes: GB,
+            demand_base: String::new(),
+            warm: HashMap::new(),
+            local_warm: false,
+        }
+        .place(&grid, &demand);
+        // Local fills first (2 lanes fit in 6GB−1GB margin @2GB spike), then the peer takes 1.
+        assert_eq!(p.local_lanes, 2, "no affinity ⇒ local first");
+        assert_eq!(p.remote, vec![(peer, 1)], "then spill the remainder to the peer");
+        assert_eq!(placement_oom_count(&grid, &demand, &p), 0);
     }
 
     // what this catches: BITTORRENT SCALE. 40 peers flapping at ~70% uptime for 200 ticks, every

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1968,14 +1968,14 @@ fn acquire_exam_serving_context() -> crate::cognition::exam_serving::ExamServing
 
     let snap = crate::inference::llama_server::current_serving();
     let (Some(active), true) = (snap.active_model.as_deref(), snap.ready) else {
-        return ExamServingContext::ludicrous_fallback();
+        return ExamServingContext::steady_fallback();
     };
     let Some(model) = crate::model_registry::try_global().and_then(|r| r.model(active).cloned())
     else {
-        return ExamServingContext::ludicrous_fallback();
+        return ExamServingContext::steady_fallback();
     };
     let Some(fp) = crate::modules::serving_daemon::footprint_for(&model) else {
-        return ExamServingContext::ludicrous_fallback();
+        return ExamServingContext::steady_fallback();
     };
     // Capacity = the ONE memory authority's governed budget (VRAM netted over every measured
     // consumer + external pressure), the same source `plan_serving` sizes against — never a
@@ -1984,7 +1984,7 @@ fn acquire_exam_serving_context() -> crate::cognition::exam_serving::ExamServing
         .map(|d| crate::modules::serving_daemon::governed_host_budget(&d).usable_bytes)
         .filter(|c| *c > 0)
     else {
-        return ExamServingContext::ludicrous_fallback();
+        return ExamServingContext::steady_fallback();
     };
     let window = snap.served_context_window.max(1);
     let compute_buffer = fp.compute_buffer_per_lane();

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1199,15 +1199,15 @@ impl CognitionEval {
         // holds the bytes would flash them as "available" and re-open the grab race.
         let mut _eval_vram_lease: Option<crate::resources::LeaseGuard> = None;
         let mut _eval_lane: Option<crate::inference::llama_server::EphemeralServingLane> = None;
-        // Holds the LIVE serving lane steady when the eval runs ON it (the `(None, None)`
-        // living-persona case = `placement::Placement::ShareLane`: same base already
-        // resident, so she is measured as a co-tenant decode slot on her real lane, NOT a
-        // second weight copy). While held, the daemon skips the grow-back re-home that
-        // would relaunch the lane and connection-refuse the exam mid-flight (hard-rs 0/8,
-        // 2026-07-20). None for the ephemeral-lane branches — those own an isolated lane
-        // the serving daemon never touches. Dropped when `run` returns (grow-back resumes).
-        let mut _serving_steady_hold: Option<crate::modules::serving_daemon::ServingSteadyHold> =
-            None;
+        // The Proctored Exam Session's ACQUIRE for the LIVE-lane case (the `(None, None)`
+        // living-persona benchmark): an EXPLICIT `plan_placement` decision (Slice A), not a
+        // blind steady-hold. Her base is already resident ⇒ the verdict is `ShareLane` — she
+        // is measured as a co-tenant decode slot on her real lane (NO second weight copy),
+        // and while the context is held the daemon skips the grow-back re-home that would
+        // relaunch the lane and connection-refuse the exam mid-flight (hard-rs 0/8,
+        // 2026-07-20). None for the ephemeral-lane branches — those own an isolated lane the
+        // serving daemon never touches. Dropped when `run` returns (RAII → grow-back resumes).
+        let mut _exam_serving: Option<crate::cognition::exam_serving::ExamServingContext> = None;
         // GPU-first placement evidence for the gene's measurement lane — surfaced on
         // the result so the harness shows which device the A/B was scored on. None in
         // single-pass mode (that forks onto her LIVE lane, which is already GPU).
@@ -1267,8 +1267,9 @@ impl CognitionEval {
             // bounce, 2026-07-20). Same bounded wait-for-template as the lane branches above;
             // the post-reboot register_from_cfg race hits every fork path identically.
             (None, None) => {
-                _serving_steady_hold =
-                    Some(crate::modules::serving_daemon::ServingSteadyHold::acquire());
+                // Slice A: the strategic ACQUIRE — an explicit `plan_placement` decision
+                // (ShareLane for her own base) + RAII hold, not a blind steady-hold.
+                _exam_serving = Some(acquire_exam_serving_context());
                 fork_eval_cycle_waiting(&persona_uuid, || {
                     crate::cognition::persona_workspace::global()
                         .fork_eval_cycle(&persona_uuid, needs_tools, p.workspace_root.as_deref(), suppress_recall)
@@ -1950,6 +1951,68 @@ fn append_failed_ledger(persona_id: &str, run_id: &str, note: &str, error: &str)
 /// never falsely claimed clean). This is the honesty stamp: a number carries whether
 /// it was measured contended, on the durable row, so `cognition/observe` can light a
 /// CLEAN/UNKNOWN chip instead of anyone inferring it. [[benchmark-numbers-carry-gpu-provenance]]
+/// Build the Proctored Exam Session's serving context for the living-persona benchmark:
+/// read the live serving snapshot + the governed budget, construct the resident set and the
+/// exam's `LaneDemand`, and run the strategic [`ExamServingContext::acquire`] admission
+/// decision. For the living-persona exam she is served on this base already, so the verdict
+/// is `SharedLane` — she is measured as a co-tenant slot on her real lane (no second weight
+/// copy) and the lane is held steady for the run. Making it an EXPLICIT decision (not the
+/// old blind steady-hold) is the strategic layer plugged in at the exam seam
+/// ([[lane-admission-planner-scenario-driven]]). When the live inputs aren't resolvable
+/// (ungoverned host, model row missing, lane not yet ready) it falls back to holding the
+/// lane steady on the historical share assumption — behavior never regresses, but the gap
+/// is marked so it's visible. [[proctored-exam-session-dependable-benchmark]]
+fn acquire_exam_serving_context() -> crate::cognition::exam_serving::ExamServingContext {
+    use crate::cognition::exam_serving::ExamServingContext;
+    use crate::resources::placement::{DemandTier, LaneDemand, ResidentLane};
+
+    let snap = crate::inference::llama_server::current_serving();
+    let (Some(active), true) = (snap.active_model.as_deref(), snap.ready) else {
+        return ExamServingContext::steady_fallback();
+    };
+    let Some(model) = crate::model_registry::try_global().and_then(|r| r.model(active).cloned())
+    else {
+        return ExamServingContext::steady_fallback();
+    };
+    let Some(fp) = crate::modules::serving_daemon::footprint_for(&model) else {
+        return ExamServingContext::steady_fallback();
+    };
+    // Capacity = the ONE memory authority's governed budget (VRAM netted over every measured
+    // consumer + external pressure), the same source `plan_serving` sizes against — never a
+    // raw GPU probe. No authority (ungoverned host) or a zero budget ⇒ fall back.
+    let Some(capacity) = crate::resources::ResourceDaemon::global()
+        .map(|d| crate::modules::serving_daemon::governed_host_budget(&d).usable_bytes)
+        .filter(|c| *c > 0)
+    else {
+        return ExamServingContext::steady_fallback();
+    };
+    let window = snap.served_context_window.max(1);
+    let compute_buffer = fp.compute_buffer_per_lane();
+    let resident = ResidentLane {
+        lane_id: "live".to_string(),
+        base_model_id: active.to_string(),
+        weights_bytes: fp.weights_bytes,
+        slots: snap.lanes.max(1),
+        window,
+        kv_per_token: fp.kv_per_token,
+        compute_buffer,
+        tier: DemandTier::Live,
+        pinned: true,
+    };
+    // The exam demand: her SAME base (⇒ share, not a second copy), one measured decode slot,
+    // at the live served window, at Eval tier (preemptible by live work, never preempts it).
+    let demand = LaneDemand {
+        base_model_id: active.to_string(),
+        weights_bytes: fp.weights_bytes,
+        slots: 1,
+        window,
+        kv_per_token: fp.kv_per_token,
+        compute_buffer,
+        tier: DemandTier::Eval,
+    };
+    ExamServingContext::acquire(capacity, std::slice::from_ref(&resident), &demand)
+}
+
 fn append_progress_ledger(
     result: &CognitionEvalResult,
     note: Option<&str>,

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1269,7 +1269,7 @@ impl CognitionEval {
             (None, None) => {
                 // Slice A: the strategic ACQUIRE — an explicit `plan_placement` decision
                 // (ShareLane for her own base) + RAII hold, not a blind steady-hold.
-                _exam_serving = Some(acquire_exam_serving_context());
+                _exam_serving = Some(acquire_exam_serving_context().await);
                 fork_eval_cycle_waiting(&persona_uuid, || {
                     crate::cognition::persona_workspace::global()
                         .fork_eval_cycle(&persona_uuid, needs_tools, p.workspace_root.as_deref(), suppress_recall)
@@ -1962,20 +1962,20 @@ fn append_failed_ledger(persona_id: &str, run_id: &str, note: &str, error: &str)
 /// (ungoverned host, model row missing, lane not yet ready) it falls back to holding the
 /// lane steady on the historical share assumption — behavior never regresses, but the gap
 /// is marked so it's visible. [[proctored-exam-session-dependable-benchmark]]
-fn acquire_exam_serving_context() -> crate::cognition::exam_serving::ExamServingContext {
+async fn acquire_exam_serving_context() -> crate::cognition::exam_serving::ExamServingContext {
     use crate::cognition::exam_serving::ExamServingContext;
     use crate::resources::placement::{DemandTier, LaneDemand, ResidentLane};
 
     let snap = crate::inference::llama_server::current_serving();
     let (Some(active), true) = (snap.active_model.as_deref(), snap.ready) else {
-        return ExamServingContext::steady_fallback();
+        return ExamServingContext::ludicrous_fallback().await;
     };
     let Some(model) = crate::model_registry::try_global().and_then(|r| r.model(active).cloned())
     else {
-        return ExamServingContext::steady_fallback();
+        return ExamServingContext::ludicrous_fallback().await;
     };
     let Some(fp) = crate::modules::serving_daemon::footprint_for(&model) else {
-        return ExamServingContext::steady_fallback();
+        return ExamServingContext::ludicrous_fallback().await;
     };
     // Capacity = the ONE memory authority's governed budget (VRAM netted over every measured
     // consumer + external pressure), the same source `plan_serving` sizes against — never a
@@ -1984,7 +1984,7 @@ fn acquire_exam_serving_context() -> crate::cognition::exam_serving::ExamServing
         .map(|d| crate::modules::serving_daemon::governed_host_budget(&d).usable_bytes)
         .filter(|c| *c > 0)
     else {
-        return ExamServingContext::steady_fallback();
+        return ExamServingContext::ludicrous_fallback().await;
     };
     let window = snap.served_context_window.max(1);
     let compute_buffer = fp.compute_buffer_per_lane();
@@ -2010,7 +2010,7 @@ fn acquire_exam_serving_context() -> crate::cognition::exam_serving::ExamServing
         compute_buffer,
         tier: DemandTier::Eval,
     };
-    ExamServingContext::acquire(capacity, std::slice::from_ref(&resident), &demand)
+    ExamServingContext::acquire(capacity, std::slice::from_ref(&resident), &demand).await
 }
 
 fn append_progress_ledger(

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1968,14 +1968,14 @@ fn acquire_exam_serving_context() -> crate::cognition::exam_serving::ExamServing
 
     let snap = crate::inference::llama_server::current_serving();
     let (Some(active), true) = (snap.active_model.as_deref(), snap.ready) else {
-        return ExamServingContext::steady_fallback();
+        return ExamServingContext::ludicrous_fallback();
     };
     let Some(model) = crate::model_registry::try_global().and_then(|r| r.model(active).cloned())
     else {
-        return ExamServingContext::steady_fallback();
+        return ExamServingContext::ludicrous_fallback();
     };
     let Some(fp) = crate::modules::serving_daemon::footprint_for(&model) else {
-        return ExamServingContext::steady_fallback();
+        return ExamServingContext::ludicrous_fallback();
     };
     // Capacity = the ONE memory authority's governed budget (VRAM netted over every measured
     // consumer + external pressure), the same source `plan_serving` sizes against — never a
@@ -1984,7 +1984,7 @@ fn acquire_exam_serving_context() -> crate::cognition::exam_serving::ExamServing
         .map(|d| crate::modules::serving_daemon::governed_host_budget(&d).usable_bytes)
         .filter(|c| *c > 0)
     else {
-        return ExamServingContext::steady_fallback();
+        return ExamServingContext::ludicrous_fallback();
     };
     let window = snap.served_context_window.max(1);
     let compute_buffer = fp.compute_buffer_per_lane();

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -856,6 +856,33 @@ pub struct EvalTaskResult {
     pub decode_ms: u64,
 }
 
+/// Why a run could NOT produce a trustworthy score — the serving lane never held a
+/// verified, decode-capable context for the whole exam. This is NOT "she failed": the
+/// harness never gave her a working lane, so the accuracy signal is meaningless. A run
+/// carrying this is reported as infra-unavailable, and `score`/`pass_rate`/`results`
+/// MUST be read as void, never as a real "she scored 0" — the exact fake-zero the
+/// Proctored Exam Session exists to make impossible.
+/// [[proctored-exam-session-dependable-benchmark]] [[benchmark-needs-its-own-serving-lane]]
+#[derive(Debug, Clone, Serialize, TS)]
+pub struct InfraUnavailable {
+    /// Human cause: which axis broke (not-ready / connect-refused / not-the-served-model
+    /// / compute-error / stream-idle timeout), naming the task it broke on. Display-only
+    /// — the classification that produced it is [`SettleOutcome::inference_error`], never
+    /// re-parsed from this string.
+    pub reason: String,
+    /// How many tasks were attempted before the run aborted. The exam is INCOMPLETE — a
+    /// non-zero `score` over `tasks_attempted` is still void (some attempts phantom-failed
+    /// on a dead lane), which is why the presence of this whole struct — not the count —
+    /// is the void flag.
+    #[ts(type = "number")]
+    pub tasks_attempted: u32,
+    /// How many attempted tasks hit an UNRECOVERABLE infra fault (the lane never returned
+    /// to decode-ready within the bounded re-verify+retry budget). ≥1 ⇒ the lane died
+    /// mid-exam and continuing would only accrue more phantom zeros.
+    #[ts(type = "number")]
+    pub infra_faults: u32,
+}
+
 #[derive(Debug, Clone, Serialize, TS, Default)]
 pub struct CognitionEvalResult {
     /// The run handle (#86): present on a detached ack AND on the ledger row, so the
@@ -951,6 +978,17 @@ pub struct CognitionEvalResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional, type = "number")]
     pub lane_estimated_footprint_bytes: Option<u64>,
+    /// Set ONLY when infra prevented a trustworthy measurement (the shared serving lane
+    /// flipped not-ready / refused / compute-errored and never recovered within the
+    /// re-verify+retry budget). When present, `score`/`pass_rate`/`results` are VOID —
+    /// the run never completed on a verified lane, and reading `pass_rate: 0.0` as "she
+    /// scored 0" is precisely the fake-zero this guards against. Absent = a real, scored
+    /// run whose number can be trusted. Every human-facing render site (ledger row,
+    /// eval-status, benchmark/run) branches on this before showing a pass-rate.
+    /// [[proctored-exam-session-dependable-benchmark]]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub infra_unavailable: Option<InfraUnavailable>,
 }
 
 /// The gym command. Stateless: it reaches the persona's live cognition through the
@@ -1399,7 +1437,10 @@ impl CognitionEval {
         // separate, deliberate decision, never a side effect of measuring it.
         if let Some(gene) = &p.gene {
             cycle.page_out();
-            let (base_score, _) = run_pass(&cycle, &isolation, &tasks, room, max_acts, max_retries, p.workspace_root.as_deref()).await;
+            // A/B LIFT arms consume `.pass`/`.results`; the infra-fault accounting rides
+            // on the EphemeralServingLane path (decode-verified at spawn) as a scoped
+            // follow-up — the shared-lane single-pass below is what Slice B makes honest.
+            let base_score = run_pass(&cycle, &isolation, &tasks, room, max_acts, max_retries, p.workspace_root.as_deref()).await.pass;
 
             // Both arms start each task from the pre-eval memory frame — `run_pass`
             // rewinds the admission frame before EVERY task (per-task isolation), so
@@ -1411,8 +1452,9 @@ impl CognitionEval {
                 domain: String::new(),
                 scale: gene.scale.unwrap_or(1.0),
             }]);
-            let (gene_score, gene_results) =
+            let gene_outcome =
                 run_pass(&cycle, &isolation, &tasks, room, max_acts, max_retries, p.workspace_root.as_deref()).await;
+            let (gene_score, gene_results) = (gene_outcome.pass, gene_outcome.results);
             cycle.page_out();
 
             // Guard drops here: her memory frame + real persistence sink restored.
@@ -1450,8 +1492,13 @@ impl CognitionEval {
                 lane_estimated_footprint_bytes: placement_evidence
                     .as_ref()
                     .and_then(|e| e.footprint_bytes),
+                // A/B runs on its OWN EphemeralServingLane (gene/base copy), which
+                // decode-verifies at spawn — a different failure surface than the shared
+                // live lane. Threading the infra-fault classification through the two-arm
+                // LIFT assembly is a scoped follow-up; the shared-lane single-pass (the
+                // fake-zero incident) is what Slice B makes trustworthy first.
+                infra_unavailable: None,
             };
-            result.run_id = p.run_id.clone();
             result.run_id = p.run_id.clone();
         append_progress_ledger(
             &result,
@@ -1491,7 +1538,7 @@ impl CognitionEval {
         // (reviewers>=1, live single-pass only) forks a second copy of the same persona
         // as a reviewer and grades the reviewed answer — same model, +1 teammate.
         let want_team = p.reviewers.unwrap_or(0) >= 1 && p.gene.is_none() && p.base_model_id.is_none();
-        let (score, results) = if want_team {
+        let outcome = if want_team {
             let reviewer = crate::cognition::persona_workspace::global()
                 .fork_eval_cycle(&persona_uuid, needs_tools, p.workspace_root.as_deref(), suppress_recall)
                 .ok_or_else(|| CommandError::NotFound(format!(
@@ -1507,12 +1554,20 @@ impl CognitionEval {
         };
         drop(isolation);
 
+        // The Proctored Exam Session verdict (Slice B): ≥1 UNRECOVERABLE infra fault ⇒ the
+        // shared serving lane died mid-exam and this score is VOID. Build the marker BEFORE
+        // moving `results`; when set, every render site reports InfraUnavailable instead of a
+        // fake `pass_rate: 0.0`. [[proctored-exam-session-dependable-benchmark]]
+        let infra_unavailable = infra_verdict(&outcome);
+        let (score, results) = (outcome.pass, outcome.results);
+
         // LEARN mode: the exam just taught her — carry the redacted lesson back to the
         // LIVING self. She keeps the experience of having been asked and how she did; the
         // held-out answer key is scrubbed so she can never memorize it (redaction, not
         // forget-context: keep the memory, excise the crib sheet). The exam ran on the fork
         // (#59 intact); only the clean lesson crosses back. Single-pass only in this slice.
-        if p.learn.unwrap_or(false) && p.gene.is_none() {
+        // NEVER learn from an infra-unavailable run — a dead-lane "failure" is not a lesson.
+        if p.learn.unwrap_or(false) && p.gene.is_none() && infra_unavailable.is_none() {
             let transferred = transfer_redacted_lessons(&persona_uuid, room, &tasks, &results);
             tracing::info!(
                 persona = %persona_uuid,
@@ -1552,6 +1607,7 @@ impl CognitionEval {
                 .to_string(),
             lane_free_vram_bytes: None,
             lane_estimated_footprint_bytes: None,
+            infra_unavailable,
         };
         result.run_id = p.run_id.clone();
         append_progress_ledger(
@@ -1930,6 +1986,10 @@ fn append_progress_ledger(
         "lift": result.lift,
         "note": note,
         "runId": result.run_id,
+        // The Proctored Exam Session void-flag: when present, the row's score/passRate are
+        // VOID (the lane died mid-exam), and every reader MUST report infra-unavailable
+        // instead of a real pass-rate. [[proctored-exam-session-dependable-benchmark]]
+        "infraUnavailable": result.infra_unavailable,
     });
     use std::io::Write;
     if let Ok(mut f) = std::fs::OpenOptions::new()
@@ -2321,6 +2381,71 @@ fn clean_dir_contents(root: &str) -> std::io::Result<()> {
     Ok(())
 }
 
+/// The outcome of running a whole task set once — the pass count and per-task rows,
+/// PLUS the infra-fault accounting that decides whether the number is trustworthy.
+/// The keystone of the Proctored Exam Session (Slice B): an inference call that FAILS
+/// (lane not-ready / connect-refused / "not the active served model" / compute-error /
+/// stream-idle) is an INFRA fault, never a wrong answer. A transient fault is re-verified
+/// and retried; an UNRECOVERABLE one (lane never returns to decode-ready) makes the run
+/// [`InfraUnavailable`] — the caller reports that, NEVER a fake `pass_rate: 0.0`.
+/// [[proctored-exam-session-dependable-benchmark]]
+struct PassOutcome {
+    /// Tasks that PASSED (graded on a verified lane).
+    pass: u32,
+    /// Per-task rows (includes any infra-graded row for forensics).
+    results: Vec<EvalTaskResult>,
+    /// How many tasks hit an UNRECOVERABLE infra fault — the lane never came back to
+    /// decode-ready within the re-verify+retry budget. ≥1 ⇒ the run is void.
+    infra_faults: u32,
+    /// The cause of the FIRST unrecoverable infra fault, naming its task — the reason the
+    /// whole run aborts as [`InfraUnavailable`]. `None` when every task reached a verdict.
+    infra_reason: Option<String>,
+}
+
+/// The Proctored Exam Session verdict: does a completed pass constitute a trustworthy
+/// score, or did the serving lane die mid-exam? ≥1 unrecoverable infra fault ⇒ the run is
+/// VOID and reported [`InfraUnavailable`] (never a fake `pass_rate: 0.0`). Pure so the
+/// fault-injection test pins it directly, and ONE place decides void-ness for every render
+/// site. [[proctored-exam-session-dependable-benchmark]]
+fn infra_verdict(outcome: &PassOutcome) -> Option<InfraUnavailable> {
+    (outcome.infra_faults > 0).then(|| InfraUnavailable {
+        reason: outcome
+            .infra_reason
+            .clone()
+            .unwrap_or_else(|| "serving lane never recovered".to_string()),
+        tasks_attempted: outcome.results.len() as u32,
+        infra_faults: outcome.infra_faults,
+    })
+}
+
+/// How many times a task that INFRA-FAULTED (the model call itself failed, not a wrong
+/// answer) is re-verified and retried before it counts as unrecoverable. This is the
+/// bounded recovery a transient lane bounce (grow-back relaunch, brief not-ready) gets —
+/// distinct from `max_acts` (the persona's OWN act→observe budget) and MAX_FAIL_RETRIES
+/// (agentic recovery from a WRONG answer). 3 covers a full not-ready→relaunch→ready cycle
+/// without letting a genuinely-dead lane spin the exam forever.
+const INFRA_FAULT_RETRIES: u32 = 3;
+
+/// Bound for a between-attempt lane re-verify. A grow-back relaunch or a #175 self-heal
+/// respawn brings the lane back within tens of seconds; this waits out that window before
+/// spending a retry, and its expiry (lane still not snapshot-ready) is itself the signal
+/// the fault is unrecoverable. Generous vs a warm lane's instant readiness; it only ever
+/// elapses on a genuinely down lane.
+const LANE_REVERIFY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
+
+/// Re-verify that the live serving lane is READY to decode before retrying an infra-faulted
+/// task. Returns the ready snapshot's active model, or `None` if the lane never returned to
+/// ready within [`LANE_REVERIFY_TIMEOUT`] (⇒ the fault is unrecoverable). Snapshot-ready is
+/// the cheap gate; the retried TASK is itself the real decode proof (a genuine generation),
+/// so this is not status-optimism — a lane that answers ready but can't decode simply
+/// infra-faults again on the retry and exhausts the budget. Slice A upgrades this to a
+/// decode smoke-probe at ACQUIRE time; Slice B verifies via the real task attempt.
+async fn reverify_lane() -> Option<String> {
+    crate::inference::llama_server::await_ready_serving(LANE_REVERIFY_TIMEOUT)
+        .await
+        .and_then(|s| s.active_model)
+}
+
 async fn run_pass(
     cycle: &crate::cognition::workspace::WorkspaceCycle,
     isolation: &crate::cognition::workspace::EvalIsolation,
@@ -2333,9 +2458,11 @@ async fn run_pass(
     // core cwd — or a correct render scores a false zero (#49 dual-root gap). `None` = the
     // hands used the default root (core cwd) and grading follows.
     workspace_root: Option<&str>,
-) -> (u32, Vec<EvalTaskResult>) {
+) -> PassOutcome {
     let mut pass = 0u32;
     let mut results = Vec::with_capacity(tasks.len());
+    let mut infra_faults = 0u32;
+    let mut infra_reason: Option<String> = None;
     // THE NATURAL PROCTORED EXAM (Joel: "we use our own persona as naturally as possible, as
     // if these are proctored exams... natural personas even in tests, with memories intact").
     // She sits down ONCE: rewind to the pre-eval frame at PASS start (each A/B arm still
@@ -2450,17 +2577,21 @@ async fn run_pass(
         };
         // own_peer/agent_name attribute the persona's OWN past posts; a single-task
         // exam has none, so they're inert here (the item's peer_id "peer" ≠ "").
-        let burst = crate::cognition::workspace::Burst::from_turns(
-            room,
-            crate::persona::service_loop::build_workspace_turns(
-                std::slice::from_ref(&task_delivery),
-                "",
-                "",
-                // A single-task exam IS the stimulus — the task delivery is the
-                // whole thread; there is no out-of-band trigger to anchor.
-                None,
-            ),
-        );
+        // A CLOSURE, not a value: an infra-faulted task is retried (below), and
+        // `drive_to_settle` consumes the burst, so each attempt mints a fresh one.
+        let make_burst = || {
+            crate::cognition::workspace::Burst::from_turns(
+                room,
+                crate::persona::service_loop::build_workspace_turns(
+                    std::slice::from_ref(&task_delivery),
+                    "",
+                    "",
+                    // A single-task exam IS the stimulus — the task delivery is the
+                    // whole thread; there is no out-of-band trigger to anchor.
+                    None,
+                ),
+            )
+        };
         // `directed = true`: an exam question is put TO the persona — it is not
         // ambient room chatter she may let pass. This withholds the bare-PASS silence
         // escape (the [Conversational Presence] block) for the eval turn, the same kind of
@@ -2482,42 +2613,110 @@ async fn run_pass(
         // humaneval; minutes across act cycles on the harder tiers), so slow-but-valid
         // work is never cut; it fires only on a true wedge. Not a latency policy.
         const PER_TASK_DEADLINE: std::time::Duration = std::time::Duration::from_secs(600);
-        let settled = match tokio::time::timeout(
-            PER_TASK_DEADLINE,
-            crate::cognition::act_observe::drive_to_settle(
-                cycle,
-                burst,
-                room,
-                max_acts,
-                crate::cognition::workspace::TurnFraming::directed(),
-            ),
-        )
-        .await
-        {
-            Ok(s) => s,
-            Err(_) => {
-                tracing::warn!(
-                    probe_class = "eval.task.timeout",
-                    deadline_s = PER_TASK_DEADLINE.as_secs(),
-                    "eval task exceeded the per-task deadline — grading infra-fail and \
-                     advancing, NOT hanging the run (serving wedged mid-generation)"
+        // BOUNDED INFRA-FAULT RECOVERY (Proctored Exam Session, Slice B). Drive to
+        // settlement; if the model call itself FAILS (`inference_error`: lane not-ready /
+        // connect-refused / "not the active served model" / compute-error / deadline-wedge)
+        // that is an INFRA fault, never a wrong answer. Re-verify the lane and retry the
+        // SAME task — the retried generation is itself the real decode proof — up to
+        // INFRA_FAULT_RETRIES. A transient bounce (grow-back relaunch, brief not-ready)
+        // recovers here and the task grades normally. Exhaustion means the lane is dead:
+        // `settled` still carries the error and the abort below marks the run
+        // InfraUnavailable, so a phantom generation on a dead lane can NEVER be published
+        // as `pass_rate: 0.0`. [[proctored-exam-session-dependable-benchmark]]
+        let mut settled;
+        let mut infra_attempt = 0u32;
+        loop {
+            settled = match tokio::time::timeout(
+                PER_TASK_DEADLINE,
+                crate::cognition::act_observe::drive_to_settle(
+                    cycle,
+                    make_burst(),
+                    room,
+                    max_acts,
+                    crate::cognition::workspace::TurnFraming::directed(),
+                ),
+            )
+            .await
+            {
+                Ok(s) => s,
+                Err(_) => {
+                    tracing::warn!(
+                        probe_class = "eval.task.timeout",
+                        deadline_s = PER_TASK_DEADLINE.as_secs(),
+                        "eval task exceeded the per-task deadline — treating as an infra fault \
+                         (serving wedged mid-generation), NOT a wrong answer"
+                    );
+                    crate::cognition::act_observe::SettleOutcome::infra_failure(format!(
+                        "per-task deadline exceeded ({}s) — serving wedged mid-generation",
+                        PER_TASK_DEADLINE.as_secs()
+                    ))
+                }
+            };
+            let Some(cause) = settled.inference_error.clone() else {
+                break; // reached a verdict (answer OR graded-wrong) on a working lane
+            };
+            infra_attempt += 1;
+            if infra_attempt > INFRA_FAULT_RETRIES {
+                crate::probe!(
+                    class = "eval.task.infra_fault.exhausted",
+                    task = %t.id,
+                    attempts = infra_attempt,
+                    cause = %cause,
+                    "infra fault survived re-verify+retry — lane unrecoverable; run will abort InfraUnavailable"
                 );
-                crate::cognition::act_observe::SettleOutcome::infra_failure(format!(
-                    "per-task deadline exceeded ({}s) — serving wedged mid-generation",
-                    PER_TASK_DEADLINE.as_secs()
-                ))
+                break; // `settled` carries the error → unrecoverable-infra abort below
             }
-        };
+            tracing::warn!(
+                probe_class = "eval.task.infra_fault",
+                task = %t.id,
+                attempt = infra_attempt,
+                cause = %cause,
+                "inference infra fault (not a wrong answer) — re-verifying the lane and retrying the task"
+            );
+            // Re-verify the lane is snapshot-ready before spending the retry. If it never
+            // returns to ready within the budget the next attempt simply infra-faults again
+            // and exhausts the retries → InfraUnavailable, never a phantom score.
+            let _ = reverify_lane().await;
+        }
+        // UNRECOVERABLE infra fault: the lane never returned to a decode-ready state across
+        // INFRA_FAULT_RETRIES re-verify+retry cycles. Record the row for forensics, mark the
+        // run void, and ABORT — every remaining task would only accrue more phantom zeros on
+        // a dead lane. The caller reports InfraUnavailable, NEVER a fake pass_rate.
+        if let Some(cause) = &settled.inference_error {
+            infra_faults += 1;
+            if infra_reason.is_none() {
+                infra_reason = Some(format!("task '{}': {cause}", t.id));
+            }
+            results.push(EvalTaskResult {
+                id: t.id.clone(),
+                ok: false,
+                grade: format!("infra unavailable (lane never recovered): {cause}"),
+                acts: 0,
+                answer: String::new(),
+                latency_ms: 0,
+                output_tokens: 0,
+                tokens_per_second: 0.0,
+                decode_tokens_per_second: 0.0,
+                cache_hit_rate: 0.0,
+                prefill_ms: 0,
+                decode_ms: 0,
+            });
+            tracing::warn!(
+                probe_class = "eval.run.infra_unavailable",
+                task = %t.id,
+                attempted = results.len(),
+                cause = %cause,
+                "aborting run as InfraUnavailable — serving lane never recovered; refusing to \
+                 publish a phantom score over a dead lane"
+            );
+            break;
+        }
         let answer = settled.spoken.clone().unwrap_or_default();
-        let (ok, grade) = if let Some(cause) = &settled.inference_error {
-            // The model call FAILED (timeout, 5xx, a serving lane refusing a model it
-            // isn't hosting) — NOT a wrong answer. Grade it a named infra failure so a
-            // serving hiccup never masquerades as a capability miss and corrupts the
-            // accuracy signal ([[self-improvement-is-a-control-loop]]: the reward is
-            // only as trustworthy as the metric). `ok = false`, but the grade tells the
-            // truth instead of a misleading "no match".
-            (false, format!("inference failed: {cause}"))
-        } else if !t.ui_checks.is_empty() {
+        // `settled.inference_error` is None here — the abort above consumed every infra
+        // fault, so this grades a REAL verdict (a working lane produced an answer, right or
+        // wrong). No `inference_error` arm remains: an infra fault can no longer masquerade
+        // as a graded miss.
+        let (ok, grade) = if !t.ui_checks.is_empty() {
             // FUNCTIONAL WEB-DEV: grade what her UI ACTUALLY RENDERED. Observe `target` through
             // her own eyes (the eye-node path) and score the element tree — the money signal for
             // "can a persona build a UI that works", judged on the structure a non-visual model
@@ -2577,7 +2776,7 @@ async fn run_pass(
         });
         report_task_graded(&t.id, ok, total_acts, m.latency_ms, pass, results.len(), tasks.len());
     }
-    (pass, results)
+    PassOutcome { pass, results, infra_faults, infra_reason }
 }
 
 /// One deliberation on a forked cycle: deliver `prompt` through the SAME live burst formatter
@@ -2636,9 +2835,11 @@ async fn run_pass_team(
     tasks: &[EvalTask],
     room: Uuid,
     max_acts: usize,
-) -> (u32, Vec<EvalTaskResult>) {
+) -> PassOutcome {
     let mut pass = 0u32;
     let mut results = Vec::with_capacity(tasks.len());
+    let mut infra_faults = 0u32;
+    let mut infra_reason: Option<String> = None;
     // Natural proctored exam, team edition: both teammates sit down ONCE (rewind to the
     // pre-eval frame at pass start) and then work the sheet CONTINUOUSLY — the writer carries
     // what she learned on earlier tasks; the reviewer builds a sense of the writer's habits.
@@ -2673,12 +2874,41 @@ async fn run_pass_team(
         let r = eval_settle(reviewer, room, &review_prompt, max_acts).await;
         let answer = r.spoken.clone().unwrap_or_default();
 
+        // Infra fault on EITHER teammate's generation → the lane failed, not a wrong
+        // answer. Team mode has no per-task retry loop (the solo run_pass owns bounded
+        // recovery); here we classify + ABORT so an infra fault never fake-zeros the team
+        // number. Threading the full re-verify+retry into the two-solver loop is a scoped
+        // follow-up. [[proctored-exam-session-dependable-benchmark]]
+        if let Some(cause) = r.inference_error.clone().or_else(|| w.inference_error.clone()) {
+            infra_faults += 1;
+            if infra_reason.is_none() {
+                infra_reason = Some(format!("task '{}': {cause}", t.id));
+            }
+            results.push(EvalTaskResult {
+                id: t.id.clone(),
+                ok: false,
+                grade: format!("infra unavailable (lane never recovered): {cause}"),
+                acts: 0,
+                answer: String::new(),
+                latency_ms: 0,
+                output_tokens: 0,
+                tokens_per_second: 0.0,
+                decode_tokens_per_second: 0.0,
+                cache_hit_rate: 0.0,
+                prefill_ms: 0,
+                decode_ms: 0,
+            });
+            tracing::warn!(
+                probe_class = "eval.run.infra_unavailable",
+                task = %t.id,
+                attempted = results.len(),
+                cause = %cause,
+                "aborting team run as InfraUnavailable — serving lane failed mid-exam"
+            );
+            break;
+        }
         // Grade the FINAL (reviewer's) answer — SAME branches as solo run_pass.
-        let (ok, grade) = if let Some(cause) =
-            r.inference_error.clone().or_else(|| w.inference_error.clone())
-        {
-            (false, format!("inference failed: {cause}"))
-        } else if let Some(dod) = &t.dod_shell {
+        let (ok, grade) = if let Some(dod) = &t.dod_shell {
             run_dod(dod).await
         } else if let Some(test) = &t.test {
             test_grade(&answer, t.lang.as_deref().unwrap_or("rust"), test).await
@@ -2707,7 +2937,7 @@ async fn run_pass_team(
         });
         report_task_graded(&t.id, ok, acts, m.latency_ms, pass, results.len(), tasks.len());
     }
-    (pass, results)
+    PassOutcome { pass, results, infra_faults, infra_reason }
 }
 
 // Stateless → self-register onto the ONE registry (descriptor + runtime object).
@@ -2755,6 +2985,83 @@ mod tests {
             prefill_ms: 0,
             decode_ms: 0,
         }
+    }
+
+    /// A graded row with an explicit ok, for building fault-injection PassOutcomes.
+    fn graded_row(id: &str, ok: bool, grade: &str) -> EvalTaskResult {
+        EvalTaskResult {
+            id: id.into(),
+            ok,
+            grade: grade.into(),
+            acts: 0,
+            answer: String::new(),
+            latency_ms: 10,
+            output_tokens: 5,
+            tokens_per_second: 0.5,
+            decode_tokens_per_second: 0.5,
+            cache_hit_rate: 0.0,
+            prefill_ms: 1,
+            decode_ms: 9,
+        }
+    }
+
+    // what this catches (Proctored Exam Session, Slice B): the fake-zero. A run whose
+    // serving lane died mid-exam (≥1 unrecoverable infra fault) must resolve to
+    // InfraUnavailable, NAMING the task and cause — NEVER a scored `pass_rate: 0.0` that
+    // reads as "she got them all wrong". If infra_verdict ever returned None on a faulted
+    // run, the harness would publish a phantom 0% over a dead lane again — the exact
+    // untrustworthy-by-construction bug this slice exists to kill.
+    // [[proctored-exam-session-dependable-benchmark]]
+    #[test]
+    fn infra_faulted_run_is_infra_unavailable_never_a_fake_zero() {
+        // Two tasks graded, then the lane died on the third and never came back.
+        let outcome = PassOutcome {
+            pass: 1,
+            results: vec![
+                graded_row("t1", true, "tests passed"),
+                graded_row("t2", false, "no match"),
+                graded_row(
+                    "t3",
+                    false,
+                    "infra unavailable (lane never recovered): model 'X' is not the active served model",
+                ),
+            ],
+            infra_faults: 1,
+            infra_reason: Some(
+                "task 't3': model 'X' is not the active served model (serving: <none>, ready: false)"
+                    .into(),
+            ),
+        };
+        let verdict = infra_verdict(&outcome).expect("a run with an infra fault must be InfraUnavailable");
+        assert_eq!(verdict.infra_faults, 1);
+        assert_eq!(verdict.tasks_attempted, 3, "attempted-so-far, exam incomplete");
+        assert!(
+            verdict.reason.contains("t3") && verdict.reason.contains("active served model"),
+            "the reason names the task + the infra cause: {}",
+            verdict.reason
+        );
+    }
+
+    // what this catches: the OTHER half of trustworthiness — a genuinely-wrong answer on a
+    // WORKING lane is a REAL 0, counted, NOT masked as infra. If infra_verdict fired on any
+    // failed task (rather than only on unrecoverable inference faults), we'd hide real
+    // capability misses behind "infra unavailable" and the number would over-report. Zero
+    // infra faults ⇒ Scored, the wrong answers counted.
+    #[test]
+    fn wrong_answers_on_a_working_lane_are_scored_not_infra() {
+        let outcome = PassOutcome {
+            pass: 0,
+            results: vec![
+                graded_row("t1", false, "no match"),
+                graded_row("t2", false, "assertion failed"),
+            ],
+            infra_faults: 0,
+            infra_reason: None,
+        };
+        assert!(
+            infra_verdict(&outcome).is_none(),
+            "a real 0 on a verified lane is Scored, never InfraUnavailable"
+        );
     }
 
     // what this catches: LEARN mode's lesson keeps the EXPERIENCE (what she was

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1161,6 +1161,15 @@ impl CognitionEval {
         // holds the bytes would flash them as "available" and re-open the grab race.
         let mut _eval_vram_lease: Option<crate::resources::LeaseGuard> = None;
         let mut _eval_lane: Option<crate::inference::llama_server::EphemeralServingLane> = None;
+        // Holds the LIVE serving lane steady when the eval runs ON it (the `(None, None)`
+        // living-persona case = `placement::Placement::ShareLane`: same base already
+        // resident, so she is measured as a co-tenant decode slot on her real lane, NOT a
+        // second weight copy). While held, the daemon skips the grow-back re-home that
+        // would relaunch the lane and connection-refuse the exam mid-flight (hard-rs 0/8,
+        // 2026-07-20). None for the ephemeral-lane branches — those own an isolated lane
+        // the serving daemon never touches. Dropped when `run` returns (grow-back resumes).
+        let mut _serving_steady_hold: Option<crate::modules::serving_daemon::ServingSteadyHold> =
+            None;
         // GPU-first placement evidence for the gene's measurement lane — surfaced on
         // the result so the harness shows which device the A/B was scored on. None in
         // single-pass mode (that forks onto her LIVE lane, which is already GPU).
@@ -1212,17 +1221,25 @@ impl CognitionEval {
                 _eval_lane = Some(lane);
                 cycle
             }
-            // Neither → fork onto her LIVE lane (a plain number on whatever she's served on).
-            // Same bounded wait-for-template as the lane branches above (fork_eval_cycle_waiting):
+            // Neither → the living-persona benchmark: she is served on THIS base already,
+            // so the admission decision is `placement::Placement::ShareLane` — measure her
+            // as a co-tenant decode slot on her REAL lane (her genome, her window), no
+            // second weight copy. Hold the lane STEADY for the run so the grow-back re-home
+            // can't relaunch it and connection-refuse the exam mid-flight (the hard-rs 0/8
+            // bounce, 2026-07-20). Same bounded wait-for-template as the lane branches above;
             // the post-reboot register_from_cfg race hits every fork path identically.
-            (None, None) => fork_eval_cycle_waiting(&persona_uuid, || {
-                crate::cognition::persona_workspace::global()
-                    .fork_eval_cycle(&persona_uuid, needs_tools, p.workspace_root.as_deref(), suppress_recall)
-            })
-            .await
-            .ok_or_else(|| CommandError::NotFound(format!(
-                "no workspace template for persona {persona_uuid} after waiting {WORKSPACE_TEMPLATE_WAIT_TRIES}s — its mind was not assembled at spawn (register_from_cfg), so eval cannot fork a measurement copy without measuring her live mind"
-            )))?,
+            (None, None) => {
+                _serving_steady_hold =
+                    Some(crate::modules::serving_daemon::ServingSteadyHold::acquire());
+                fork_eval_cycle_waiting(&persona_uuid, || {
+                    crate::cognition::persona_workspace::global()
+                        .fork_eval_cycle(&persona_uuid, needs_tools, p.workspace_root.as_deref(), suppress_recall)
+                })
+                .await
+                .ok_or_else(|| CommandError::NotFound(format!(
+                    "no workspace template for persona {persona_uuid} after waiting {WORKSPACE_TEMPLATE_WAIT_TRIES}s — its mind was not assembled at spawn (register_from_cfg), so eval cannot fork a measurement copy without measuring her live mind"
+                )))?
+            }
         };
 
         // GLASS-BOX (task #14): if a capture_dir is pinned, wrap the fork's cognition in the

--- a/core/continuum-core/src/cognition/exam_serving.rs
+++ b/core/continuum-core/src/cognition/exam_serving.rs
@@ -5,10 +5,9 @@
 //! it was measuring a co-tenant slot on the persona's own lane. The comment said
 //! "= `Placement::ShareLane`" but nothing computed it — the strategic decision was
 //! implicit. This module makes it real: it runs the model-aware admission kernel
-//! ([`plan_placement`]) against the live resident set, serves the lane LUDICROUS
-//! (`PowerMode::Performance` — the biggest window the model+machine allow) when the verdict
-//! is a share, and CARRIES the verdict so the decision is observable + capturable (the
-//! curriculum tie-in) instead of a silent assumption.
+//! ([`plan_placement`]) against the live resident set, HOLDS the lane steady when the
+//! verdict is a share, and CARRIES the verdict so the decision is observable + capturable
+//! (the curriculum tie-in) instead of a silent assumption.
 //!
 //! This is the seam the strategic layer plugs into. For the single-GPU living-persona exam
 //! the verdict is deterministically `ShareLane` (her base is already resident — sharing is
@@ -19,7 +18,7 @@
 //! path owns the spawn), so a strategic verdict is never missing again.
 //! [[proctored-exam-session-dependable-benchmark]] [[lane-admission-planner-scenario-driven]]
 
-use crate::modules::serving_daemon::ServingLudicrousHold;
+use crate::modules::serving_daemon::ServingSteadyHold;
 use crate::resources::placement::{plan_placement, LaneDemand, Placement, ResidentLane};
 
 /// The verdict the exam ACQUIRE reached — carried for observability + the curriculum
@@ -27,10 +26,9 @@ use crate::resources::placement::{plan_placement, LaneDemand, Placement, Residen
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExamAcquire {
     /// The exam base is already resident → she is measured as a co-tenant decode slot on
-    /// the live lane (`lane_id`), NO second weight copy. The lane is served LUDICROUS for the
-    /// exam (Performance mode → biggest window; also keeps the plan stable, no mid-exam
-    /// relaunch). The validated single-GPU path. `reclaim` names any lower-tier lanes the
-    /// daemon should tier down first (empty in the common case).
+    /// the live lane (`lane_id`), NO second weight copy. The lane is held steady for the
+    /// exam (grow-back relaunch suppressed). The validated single-GPU path. `reclaim` names
+    /// any lower-tier lanes the daemon should tier down first (empty in the common case).
     SharedLane { lane_id: String, reclaim: Vec<String> },
     /// The exam base is NOT resident → a fresh copy is needed (its own weights). This
     /// node's ACQUIRE does not spawn it here — the caller's ephemeral-lane / grid path owns
@@ -53,20 +51,15 @@ impl ExamAcquire {
     }
 }
 
-/// A held exam serving context. While alive, an exam that shares the live lane serves in
-/// LUDICROUS mode — `PowerMode::Performance`, the biggest window the model+machine allow —
-/// so the exam is never starved by a timid pressure-derived boot-window (the 2048-eco
-/// incident). Ludicrous also keeps the plan STABLE at max (nothing bigger to grow-back to,
-/// pressure-shrink overridden), so it subsumes the old steady-hold's job of preventing a
-/// mid-exam relaunch — WITHOUT pinning a too-small window. One grow-relaunch when acquired,
-/// one shrink when dropped (RAII) — bookends, not a flap. Non-share verdicts hold nothing
-/// (the caller's lane owns them), but the DECISION is explicit either way.
-/// [[serving-mode-follows-activity-ludicrous-to-dream]] [[benchmark-window-must-be-big-not-a-clamped-prompt]]
+/// A held exam serving context. While alive, an exam that shares the live lane keeps it
+/// steady — no grow-back relaunch can connection-refuse the measurement mid-flight (the
+/// hard-rs 0/8 bounce). Dropping restores normal serving (RAII). Non-share verdicts hold
+/// nothing (the caller's lane owns them), but the DECISION is explicit either way.
 pub struct ExamServingContext {
     acquire: ExamAcquire,
-    /// `Some` only for a `SharedLane` verdict: the RAII Ludicrous (Performance) hold. Dropped
-    /// with the context, reverting serving to the live pressure-adaptive mode.
-    _hold: Option<ServingLudicrousHold>,
+    /// `Some` only for a `SharedLane` verdict: the RAII grow-back suppressor. Dropped with
+    /// the context, restoring the daemon's normal re-home behavior.
+    _hold: Option<ServingSteadyHold>,
 }
 
 impl ExamServingContext {
@@ -83,36 +76,35 @@ impl ExamServingContext {
             Placement::SpawnLane { reclaim } => ExamAcquire::Spawn { reclaim },
             Placement::CpuSpill { reason } => ExamAcquire::CpuSpill { reason },
         };
-        // Go LUDICROUS ONLY for a share — the case measured on the live lane, which must be
-        // served at the biggest window the model+machine allow (Performance), never a starved
-        // boot-window. Spawn/spill run on a separate (ephemeral / peer) lane sized at its own
-        // spawn — this override targets the shared live lane.
-        let hold = matches!(acquire, ExamAcquire::SharedLane { .. }).then(ServingLudicrousHold::acquire);
+        // Hold the lane steady ONLY for a share — that's the case measured on the live lane,
+        // where a grow-back relaunch mid-exam is the failure. Spawn/spill run on a separate
+        // (ephemeral / peer) lane the daemon never re-homes.
+        let hold = matches!(acquire, ExamAcquire::SharedLane { .. }).then(ServingSteadyHold::acquire);
         crate::probe!(
             class = "exam.acquire",
             verdict = acquire.tag(),
-            ludicrous = hold.is_some(),
+            held_steady = hold.is_some(),
             "proctored exam serving context acquired (strategic admission decision)"
         );
         Self { acquire, _hold: hold }
     }
 
     /// The live serving inputs weren't resolvable (ungoverned host, model row missing, or
-    /// the lane isn't ready yet) — fall back to serving the live lane in LUDICROUS mode on
-    /// the assumption it's a share, but MARK the verdict `unresolved` so the gap is visible
-    /// rather than silently assumed. Still gives the exam the biggest window the machine
-    /// allows; the strategic decision is just recorded as "couldn't compute the placement".
-    pub fn ludicrous_fallback() -> Self {
+    /// the lane isn't ready yet) — fall back to the historical behavior: hold the live lane
+    /// steady on the assumption it's a share, but MARK the verdict `unresolved` so the gap is
+    /// visible rather than silently assumed. Behavior never regresses vs the old blind
+    /// steady-hold; the strategic decision is just recorded as "couldn't compute" this time.
+    pub fn steady_fallback() -> Self {
         crate::probe!(
             class = "exam.acquire.fallback",
-            "exam serving inputs unresolved — serving the live lane LUDICROUS on the share assumption"
+            "exam serving inputs unresolved — holding the live lane steady on the share assumption"
         );
         Self {
             acquire: ExamAcquire::SharedLane {
                 lane_id: "live(unresolved)".to_string(),
                 reclaim: Vec::new(),
             },
-            _hold: Some(ServingLudicrousHold::acquire()),
+            _hold: Some(ServingSteadyHold::acquire()),
         }
     }
 
@@ -121,9 +113,8 @@ impl ExamServingContext {
         &self.acquire
     }
 
-    /// True while the live lane is held in Ludicrous mode (a share verdict). False for
-    /// spawn/spill.
-    pub fn holds_ludicrous(&self) -> bool {
+    /// True while the live lane is held steady (a share verdict). False for spawn/spill.
+    pub fn holds_steady(&self) -> bool {
         self._hold.is_some()
     }
 }
@@ -131,7 +122,7 @@ impl ExamServingContext {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::modules::serving_daemon::serving_ludicrous_active;
+    use crate::modules::serving_daemon::serving_held_steady;
     use crate::resources::placement::DemandTier;
 
     const GIB: u64 = 1 << 30;
@@ -174,10 +165,10 @@ mod tests {
         let resident = [live_lane("devstral-24b")];
         let ctx = ExamServingContext::acquire(40 * GIB, &resident, &exam_demand("devstral-24b"));
         assert!(matches!(ctx.verdict(), ExamAcquire::SharedLane { lane_id, .. } if lane_id == "live"));
-        assert!(ctx.holds_ludicrous(), "a shared-lane exam must hold the live lane steady");
-        assert!(serving_ludicrous_active(), "the global steady gauge reflects the held exam");
+        assert!(ctx.holds_steady(), "a shared-lane exam must hold the live lane steady");
+        assert!(serving_held_steady(), "the global steady gauge reflects the held exam");
         drop(ctx);
-        assert!(!serving_ludicrous_active(), "dropping the context restores grow-back (RAII)");
+        assert!(!serving_held_steady(), "dropping the context restores grow-back (RAII)");
     }
 
     // what this catches: a DIFFERENT-base exam does NOT try to co-tenant her lane — the
@@ -190,7 +181,7 @@ mod tests {
         // Room for a second copy → SpawnLane with no reclaim (a bigger box).
         let ctx = ExamServingContext::acquire(64 * GIB, &resident, &exam_demand("qwen-coder-32b"));
         assert!(matches!(ctx.verdict(), ExamAcquire::Spawn { reclaim } if reclaim.is_empty()));
-        assert!(!ctx.holds_ludicrous(), "a spawn verdict holds no local steady-hold");
+        assert!(!ctx.holds_steady(), "a spawn verdict holds no local steady-hold");
     }
 
     // what this catches: when even a share can't be made to fit (a tiny device already full
@@ -204,6 +195,6 @@ mod tests {
         let capacity = resident[0].footprint().saturating_sub(GIB);
         let ctx = ExamServingContext::acquire(capacity, &resident, &exam_demand("devstral-24b"));
         assert!(matches!(ctx.verdict(), ExamAcquire::CpuSpill { .. }));
-        assert!(!ctx.holds_ludicrous(), "a spill holds no steady-hold");
+        assert!(!ctx.holds_steady(), "a spill holds no steady-hold");
     }
 }

--- a/core/continuum-core/src/cognition/exam_serving.rs
+++ b/core/continuum-core/src/cognition/exam_serving.rs
@@ -1,39 +1,56 @@
 //! The Proctored Exam Session's ACQUIRE phase — the strategic serving decision, made
-//! explicit at the exam seam.
+//! explicit at the exam seam, and the LUDICROUS window-grow that gives a benchmark the
+//! biggest window the model+machine allow.
 //!
-//! The living-persona benchmark used to acquire a bare [`ServingSteadyHold`] and *assume*
-//! it was measuring a co-tenant slot on the persona's own lane. The comment said
-//! "= `Placement::ShareLane`" but nothing computed it — the strategic decision was
-//! implicit. This module makes it real: it runs the model-aware admission kernel
-//! ([`plan_placement`]) against the live resident set, HOLDS the lane steady when the
-//! verdict is a share, and CARRIES the verdict so the decision is observable + capturable
-//! (the curriculum tie-in) instead of a silent assumption.
+//! The living-persona benchmark used to grab a bare steady-hold and *assume* it was a
+//! co-tenant slot; the comment said "= `Placement::ShareLane`" but nothing computed it. This
+//! module makes it real: it runs the model-aware admission kernel ([`plan_placement`]), and
+//! for a share it drives the correct GROW → SETTLE → PIN sequence:
+//!   1. **GROW** — declare LUDICROUS ([`ServingLudicrousHold`] → `PowerMode::Performance`), so
+//!      the daemon re-plans the shared lane to the biggest window the machine fits. Never a
+//!      starved boot-window (the 2048-eco incident).
+//!   2. **SETTLE** — wait for any grow-relaunch to finish
+//!      ([`wait_for_serving_window_settle`](crate::inference::llama_server::wait_for_serving_window_settle)).
+//!      A naive "force Performance then run" thrashes: acquiring Ludicrous is itself a re-plan
+//!      → relaunch, and a relaunch mid-exam connection-refuses every generation (the reverted
+//!      `95dcec669`). Settling BEFORE the tasks run absorbs that relaunch once, up front.
+//!   3. **PIN** — take the steady-hold so no FURTHER relaunch bounces the running exam.
+//! The verdict is CARRIED for observability + the curriculum ledger.
 //!
-//! This is the seam the strategic layer plugs into. For the single-GPU living-persona exam
-//! the verdict is deterministically `ShareLane` (her base is already resident — sharing is
-//! nearly free and is the difference between fitting and OOMing a second 24B copy, the
-//! incident that started this arc). The `SpawnLane`/`CpuSpill` arms are the rails a
-//! DIFFERENT-base exam or a grid placement rides on: the decision is computed here even
-//! when this node's ACQUIRE doesn't itself drive the preemption (the ephemeral-lane / grid
-//! path owns the spawn), so a strategic verdict is never missing again.
-//! [[proctored-exam-session-dependable-benchmark]] [[lane-admission-planner-scenario-driven]]
+//! The `SpawnLane`/`CpuSpill` arms are the rails a DIFFERENT-base exam or a grid placement
+//! rides on: the strategic decision is computed here even when this node's ACQUIRE doesn't
+//! drive the spawn (the ephemeral-lane / grid path owns it), so a verdict is never missing.
+//! [[proctored-exam-session-dependable-benchmark]] [[serving-mode-follows-activity-ludicrous-to-dream]]
+//! [[benchmark-window-must-be-big-not-a-clamped-prompt]] [[lane-admission-planner-scenario-driven]]
 
-use crate::modules::serving_daemon::ServingSteadyHold;
+use std::time::Duration;
+
+use crate::modules::serving_daemon::{ServingLudicrousHold, ServingSteadyHold};
 use crate::resources::placement::{plan_placement, LaneDemand, Placement, ResidentLane};
 
-/// The verdict the exam ACQUIRE reached — carried for observability + the curriculum
-/// ledger, so the strategic decision behind every measurement is inspectable.
+/// How long to watch for a grow-relaunch to START (lane goes not-ready) after declaring
+/// Ludicrous. Must EXCEED the serving daemon's 5s re-plan `TICK` so a relaunch has time to
+/// fire; if none does in this window, the lane was already at the target window (no grow).
+const LUDICROUS_SETTLE_GRACE: Duration = Duration::from_secs(8);
+
+/// Bound for the whole grow-relaunch to finish (kill + respawn + model reload). A 24B reload
+/// is tens of seconds; generous so a real grow always completes, but never hangs the exam.
+const LUDICROUS_SETTLE_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// The verdict the exam ACQUIRE reached — carried for observability + the curriculum ledger,
+/// so the strategic decision behind every measurement is inspectable.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExamAcquire {
-    /// The exam base is already resident → she is measured as a co-tenant decode slot on
-    /// the live lane (`lane_id`), NO second weight copy. The lane is held steady for the
-    /// exam (grow-back relaunch suppressed). The validated single-GPU path. `reclaim` names
-    /// any lower-tier lanes the daemon should tier down first (empty in the common case).
+    /// The exam base is already resident → she is measured as a co-tenant decode slot on the
+    /// live lane (`lane_id`), NO second weight copy. The lane is grown to LUDICROUS
+    /// (Performance → biggest window), settled, then held steady for the exam. The validated
+    /// single-GPU path. `reclaim` names any lower-tier lanes the daemon should tier down first
+    /// (empty in the common case).
     SharedLane { lane_id: String, reclaim: Vec<String> },
-    /// The exam base is NOT resident → a fresh copy is needed (its own weights). This
-    /// node's ACQUIRE does not spawn it here — the caller's ephemeral-lane / grid path owns
-    /// that — but the strategic verdict is recorded, including the `reclaim` lanes a
-    /// single-GPU spawn would have to tier down first (the incident's missing decision).
+    /// The exam base is NOT resident → a fresh copy is needed (its own weights). This node's
+    /// ACQUIRE does not spawn it here — the caller's ephemeral-lane / grid path owns that — but
+    /// the strategic verdict is recorded, including the `reclaim` lanes a single-GPU spawn would
+    /// have to tier down first (the incident's missing decision).
     Spawn { reclaim: Vec<String> },
     /// Won't fit even after tiering down everything preemptible → honest CPU/degrade with a
     /// named reason, never an OOM of the resident set.
@@ -51,60 +68,96 @@ impl ExamAcquire {
     }
 }
 
-/// A held exam serving context. While alive, an exam that shares the live lane keeps it
-/// steady — no grow-back relaunch can connection-refuse the measurement mid-flight (the
-/// hard-rs 0/8 bounce). Dropping restores normal serving (RAII). Non-share verdicts hold
-/// nothing (the caller's lane owns them), but the DECISION is explicit either way.
+/// The RAII holds a shared-lane exam binds for its whole run: LUDICROUS (serve at Performance)
+/// + STEADY (no further relaunch). Both release together when the context drops, reverting
+/// serving to the live pressure-adaptive mode.
+struct ExamHold {
+    _ludicrous: ServingLudicrousHold,
+    _steady: ServingSteadyHold,
+}
+
+/// A held exam serving context. While alive, a shared-lane exam serves at the biggest window
+/// the machine allows and holds it stable (no relaunch bounce). Dropping restores normal
+/// serving (RAII). Non-share verdicts hold nothing (the caller's lane owns them), but the
+/// DECISION is explicit either way.
 pub struct ExamServingContext {
     acquire: ExamAcquire,
-    /// `Some` only for a `SharedLane` verdict: the RAII grow-back suppressor. Dropped with
-    /// the context, restoring the daemon's normal re-home behavior.
-    _hold: Option<ServingSteadyHold>,
+    _hold: Option<ExamHold>,
 }
 
 impl ExamServingContext {
-    /// Run the admission decision for an exam lane against the live resident set and act on
-    /// it: hold the lane steady on a share, record the verdict otherwise. Pure inputs
-    /// (`capacity` = the device's physical ceiling, already net of external reserve;
-    /// `resident` = the physically-resident lanes; `demand` = the exam's lane demand), so
-    /// the decision is unit-testable against the placement oracle.
-    pub fn acquire(capacity: u64, resident: &[ResidentLane], demand: &LaneDemand) -> Self {
-        let acquire = match plan_placement(capacity, resident, demand) {
+    /// The pure placement verdict for these inputs — no I/O, unit-testable against the oracle.
+    /// `capacity` = the device's physical ceiling (net of external reserve); `resident` = the
+    /// physically-resident lanes; `demand` = the exam's lane demand.
+    fn decide(capacity: u64, resident: &[ResidentLane], demand: &LaneDemand) -> ExamAcquire {
+        match plan_placement(capacity, resident, demand) {
             Placement::ShareLane { lane_id, reclaim, .. } => {
                 ExamAcquire::SharedLane { lane_id, reclaim }
             }
             Placement::SpawnLane { reclaim } => ExamAcquire::Spawn { reclaim },
             Placement::CpuSpill { reason } => ExamAcquire::CpuSpill { reason },
+        }
+    }
+
+    /// Run the admission decision and, for a share, drive GROW → SETTLE → PIN so the exam runs
+    /// on the biggest window the machine allows without a mid-exam relaunch bounce. Async
+    /// because settling the grow-relaunch is a wait (the whole reason the naive synchronous
+    /// version thrashed). Spawn/spill hold nothing locally.
+    pub async fn acquire(capacity: u64, resident: &[ResidentLane], demand: &LaneDemand) -> Self {
+        let acquire = Self::decide(capacity, resident, demand);
+        let hold = if matches!(acquire, ExamAcquire::SharedLane { .. }) {
+            Some(Self::grow_settle_pin().await)
+        } else {
+            None
         };
-        // Hold the lane steady ONLY for a share — that's the case measured on the live lane,
-        // where a grow-back relaunch mid-exam is the failure. Spawn/spill run on a separate
-        // (ephemeral / peer) lane the daemon never re-homes.
-        let hold = matches!(acquire, ExamAcquire::SharedLane { .. }).then(ServingSteadyHold::acquire);
         crate::probe!(
             class = "exam.acquire",
             verdict = acquire.tag(),
-            held_steady = hold.is_some(),
+            ludicrous = hold.is_some(),
             "proctored exam serving context acquired (strategic admission decision)"
         );
         Self { acquire, _hold: hold }
     }
 
-    /// The live serving inputs weren't resolvable (ungoverned host, model row missing, or
-    /// the lane isn't ready yet) — fall back to the historical behavior: hold the live lane
-    /// steady on the assumption it's a share, but MARK the verdict `unresolved` so the gap is
-    /// visible rather than silently assumed. Behavior never regresses vs the old blind
-    /// steady-hold; the strategic decision is just recorded as "couldn't compute" this time.
-    pub fn steady_fallback() -> Self {
+    /// The live serving inputs weren't resolvable (ungoverned host, model row missing, or the
+    /// lane isn't ready yet) — fall back to the share posture (grow → settle → pin) but MARK the
+    /// verdict `unresolved` so the gap is visible rather than silently assumed. The exam still
+    /// gets the biggest window; only the placement decision is recorded as "couldn't compute".
+    pub async fn ludicrous_fallback() -> Self {
         crate::probe!(
             class = "exam.acquire.fallback",
-            "exam serving inputs unresolved — holding the live lane steady on the share assumption"
+            "exam serving inputs unresolved — growing the live lane LUDICROUS on the share assumption"
         );
         Self {
             acquire: ExamAcquire::SharedLane {
                 lane_id: "live(unresolved)".to_string(),
                 reclaim: Vec::new(),
             },
-            _hold: Some(ServingSteadyHold::acquire()),
+            _hold: Some(Self::grow_settle_pin().await),
+        }
+    }
+
+    /// GROW (declare Ludicrous) → SETTLE (absorb any grow-relaunch) → PIN (steady-hold). The
+    /// Ludicrous hold is taken FIRST and kept, so `host_budget` plans at Performance for the
+    /// whole exam; the settle happens BEFORE the steady-hold so the pin lands on the grown,
+    /// stable lane — never on a lane about to relaunch.
+    async fn grow_settle_pin() -> ExamHold {
+        let ludicrous = ServingLudicrousHold::acquire();
+        let settled = crate::inference::llama_server::wait_for_serving_window_settle(
+            LUDICROUS_SETTLE_GRACE,
+            LUDICROUS_SETTLE_TIMEOUT,
+        )
+        .await;
+        crate::probe!(
+            class = "exam.acquire.ludicrous",
+            settled_window = settled.unwrap_or(0),
+            settled = settled.is_some(),
+            "exam lane grown to Ludicrous (Performance) and settled before pinning"
+        );
+        let steady = ServingSteadyHold::acquire();
+        ExamHold {
+            _ludicrous: ludicrous,
+            _steady: steady,
         }
     }
 
@@ -113,8 +166,8 @@ impl ExamServingContext {
         &self.acquire
     }
 
-    /// True while the live lane is held steady (a share verdict). False for spawn/spill.
-    pub fn holds_steady(&self) -> bool {
+    /// True while the live lane is held (a share verdict grew+pinned it). False for spawn/spill.
+    pub fn holds(&self) -> bool {
         self._hold.is_some()
     }
 }
@@ -122,7 +175,7 @@ impl ExamServingContext {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::modules::serving_daemon::serving_held_steady;
+    use crate::modules::serving_daemon::{serving_held_steady, serving_ludicrous_active};
     use crate::resources::placement::DemandTier;
 
     const GIB: u64 = 1 << 30;
@@ -157,44 +210,54 @@ mod tests {
     }
 
     // what this catches: the living-persona exam (same base already resident) resolves to a
-    // SHARE on her real lane AND holds it steady for the duration — never a second weight
-    // copy, never a grow-back relaunch mid-exam. This is the strategic decision made explicit
-    // that the (None,None) branch used to only assume. [[proctored-exam-session-dependable-benchmark]]
+    // SHARE on her real lane — never a second weight copy. The pure decision the (None,None)
+    // branch used to only ASSUME. [[proctored-exam-session-dependable-benchmark]]
     #[test]
-    fn living_persona_exam_shares_the_live_lane_and_holds_it_steady() {
+    fn living_persona_exam_decides_share_on_the_live_lane() {
         let resident = [live_lane("devstral-24b")];
-        let ctx = ExamServingContext::acquire(40 * GIB, &resident, &exam_demand("devstral-24b"));
-        assert!(matches!(ctx.verdict(), ExamAcquire::SharedLane { lane_id, .. } if lane_id == "live"));
-        assert!(ctx.holds_steady(), "a shared-lane exam must hold the live lane steady");
-        assert!(serving_held_steady(), "the global steady gauge reflects the held exam");
-        drop(ctx);
-        assert!(!serving_held_steady(), "dropping the context restores grow-back (RAII)");
+        let v = ExamServingContext::decide(40 * GIB, &resident, &exam_demand("devstral-24b"));
+        assert!(matches!(v, ExamAcquire::SharedLane { lane_id, .. } if lane_id == "live"));
     }
 
-    // what this catches: a DIFFERENT-base exam does NOT try to co-tenant her lane — the
-    // strategic verdict is Spawn (a fresh copy is needed), and this node's ACQUIRE holds
-    // NOTHING steady (the ephemeral/peer lane owns it). The decision is still explicit, which
-    // is the incident's missing piece — no silent second-copy grab.
+    // what this catches: a DIFFERENT-base exam does NOT co-tenant her lane — the verdict is
+    // Spawn (a fresh copy is needed), the incident's missing explicit decision (no silent
+    // second-copy grab).
     #[test]
-    fn different_base_exam_is_a_spawn_verdict_holding_nothing_local() {
+    fn different_base_exam_decides_spawn_not_a_second_copy() {
         let resident = [live_lane("devstral-24b")];
-        // Room for a second copy → SpawnLane with no reclaim (a bigger box).
-        let ctx = ExamServingContext::acquire(64 * GIB, &resident, &exam_demand("qwen-coder-32b"));
-        assert!(matches!(ctx.verdict(), ExamAcquire::Spawn { reclaim } if reclaim.is_empty()));
-        assert!(!ctx.holds_steady(), "a spawn verdict holds no local steady-hold");
+        let v = ExamServingContext::decide(64 * GIB, &resident, &exam_demand("qwen-coder-32b"));
+        assert!(matches!(v, ExamAcquire::Spawn { reclaim } if reclaim.is_empty()));
     }
 
-    // what this catches: when even a share can't be made to fit (a tiny device already full
-    // of a pinned live lane), the verdict is an honest CpuSpill with a reason — never an OOM
-    // of the resident set. The exam is told, loudly, that the accelerator can't host it.
+    // what this catches: when even a share can't be made to fit (a tiny device already full of a
+    // pinned live lane), the verdict is an honest CpuSpill — never an OOM of the resident set.
     #[test]
-    fn cant_fit_even_a_share_is_an_honest_cpu_spill() {
+    fn cant_fit_even_a_share_decides_cpu_spill() {
         let resident = [live_lane("devstral-24b")];
-        // Capacity below the resident lane's own footprint ⇒ zero free ⇒ a 1-slot share's KV
-        // can't be freed (the only lane is pinned+Live, never a victim) ⇒ CpuSpill.
         let capacity = resident[0].footprint().saturating_sub(GIB);
-        let ctx = ExamServingContext::acquire(capacity, &resident, &exam_demand("devstral-24b"));
-        assert!(matches!(ctx.verdict(), ExamAcquire::CpuSpill { .. }));
-        assert!(!ctx.holds_steady(), "a spill holds no steady-hold");
+        let v = ExamServingContext::decide(capacity, &resident, &exam_demand("devstral-24b"));
+        assert!(matches!(v, ExamAcquire::CpuSpill { .. }));
+    }
+
+    // what this catches: the async ACQUIRE for a share holds BOTH Ludicrous and steady for the
+    // exam's lifetime and releases both on drop (RAII). With no live serving state the settle is
+    // a fast no-op, so this exercises the grow→settle→pin holds without a daemon. A spawn verdict
+    // holds nothing local. Guards the reverted-thrash regression: the exam pins the lane (steady)
+    // AND declares Ludicrous (Performance) — both, together.
+    #[tokio::test]
+    async fn share_acquire_holds_ludicrous_and_steady_then_releases_on_drop() {
+        // Spawn verdict first: holds nothing local, no global gauge touched.
+        let resident = [live_lane("devstral-24b")];
+        let spawn = ExamServingContext::acquire(64 * GIB, &resident, &exam_demand("qwen-coder-32b")).await;
+        assert!(!spawn.holds(), "a spawn verdict holds no local grow/pin");
+
+        // Share verdict: grows Ludicrous + pins steady; both global gauges reflect it.
+        let ctx = ExamServingContext::acquire(40 * GIB, &resident, &exam_demand("devstral-24b")).await;
+        assert!(ctx.holds(), "a shared-lane exam holds the grown, pinned lane");
+        assert!(serving_ludicrous_active(), "Ludicrous (Performance) is declared for the exam");
+        assert!(serving_held_steady(), "and the lane is pinned steady against further relaunch");
+        drop(ctx);
+        assert!(!serving_ludicrous_active(), "drop reverts to the pressure-adaptive mode (RAII)");
+        assert!(!serving_held_steady(), "drop releases the steady pin (RAII)");
     }
 }

--- a/core/continuum-core/src/cognition/exam_serving.rs
+++ b/core/continuum-core/src/cognition/exam_serving.rs
@@ -1,0 +1,200 @@
+//! The Proctored Exam Session's ACQUIRE phase — the strategic serving decision, made
+//! explicit at the exam seam.
+//!
+//! The living-persona benchmark used to acquire a bare [`ServingSteadyHold`] and *assume*
+//! it was measuring a co-tenant slot on the persona's own lane. The comment said
+//! "= `Placement::ShareLane`" but nothing computed it — the strategic decision was
+//! implicit. This module makes it real: it runs the model-aware admission kernel
+//! ([`plan_placement`]) against the live resident set, HOLDS the lane steady when the
+//! verdict is a share, and CARRIES the verdict so the decision is observable + capturable
+//! (the curriculum tie-in) instead of a silent assumption.
+//!
+//! This is the seam the strategic layer plugs into. For the single-GPU living-persona exam
+//! the verdict is deterministically `ShareLane` (her base is already resident — sharing is
+//! nearly free and is the difference between fitting and OOMing a second 24B copy, the
+//! incident that started this arc). The `SpawnLane`/`CpuSpill` arms are the rails a
+//! DIFFERENT-base exam or a grid placement rides on: the decision is computed here even
+//! when this node's ACQUIRE doesn't itself drive the preemption (the ephemeral-lane / grid
+//! path owns the spawn), so a strategic verdict is never missing again.
+//! [[proctored-exam-session-dependable-benchmark]] [[lane-admission-planner-scenario-driven]]
+
+use crate::modules::serving_daemon::ServingSteadyHold;
+use crate::resources::placement::{plan_placement, LaneDemand, Placement, ResidentLane};
+
+/// The verdict the exam ACQUIRE reached — carried for observability + the curriculum
+/// ledger, so the strategic decision behind every measurement is inspectable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExamAcquire {
+    /// The exam base is already resident → she is measured as a co-tenant decode slot on
+    /// the live lane (`lane_id`), NO second weight copy. The lane is held steady for the
+    /// exam (grow-back relaunch suppressed). The validated single-GPU path. `reclaim` names
+    /// any lower-tier lanes the daemon should tier down first (empty in the common case).
+    SharedLane { lane_id: String, reclaim: Vec<String> },
+    /// The exam base is NOT resident → a fresh copy is needed (its own weights). This
+    /// node's ACQUIRE does not spawn it here — the caller's ephemeral-lane / grid path owns
+    /// that — but the strategic verdict is recorded, including the `reclaim` lanes a
+    /// single-GPU spawn would have to tier down first (the incident's missing decision).
+    Spawn { reclaim: Vec<String> },
+    /// Won't fit even after tiering down everything preemptible → honest CPU/degrade with a
+    /// named reason, never an OOM of the resident set.
+    CpuSpill { reason: String },
+}
+
+impl ExamAcquire {
+    /// A short, log/ledger-friendly tag for the verdict.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            ExamAcquire::SharedLane { .. } => "share",
+            ExamAcquire::Spawn { .. } => "spawn",
+            ExamAcquire::CpuSpill { .. } => "cpu-spill",
+        }
+    }
+}
+
+/// A held exam serving context. While alive, an exam that shares the live lane keeps it
+/// steady — no grow-back relaunch can connection-refuse the measurement mid-flight (the
+/// hard-rs 0/8 bounce). Dropping restores normal serving (RAII). Non-share verdicts hold
+/// nothing (the caller's lane owns them), but the DECISION is explicit either way.
+pub struct ExamServingContext {
+    acquire: ExamAcquire,
+    /// `Some` only for a `SharedLane` verdict: the RAII grow-back suppressor. Dropped with
+    /// the context, restoring the daemon's normal re-home behavior.
+    _hold: Option<ServingSteadyHold>,
+}
+
+impl ExamServingContext {
+    /// Run the admission decision for an exam lane against the live resident set and act on
+    /// it: hold the lane steady on a share, record the verdict otherwise. Pure inputs
+    /// (`capacity` = the device's physical ceiling, already net of external reserve;
+    /// `resident` = the physically-resident lanes; `demand` = the exam's lane demand), so
+    /// the decision is unit-testable against the placement oracle.
+    pub fn acquire(capacity: u64, resident: &[ResidentLane], demand: &LaneDemand) -> Self {
+        let acquire = match plan_placement(capacity, resident, demand) {
+            Placement::ShareLane { lane_id, reclaim, .. } => {
+                ExamAcquire::SharedLane { lane_id, reclaim }
+            }
+            Placement::SpawnLane { reclaim } => ExamAcquire::Spawn { reclaim },
+            Placement::CpuSpill { reason } => ExamAcquire::CpuSpill { reason },
+        };
+        // Hold the lane steady ONLY for a share — that's the case measured on the live lane,
+        // where a grow-back relaunch mid-exam is the failure. Spawn/spill run on a separate
+        // (ephemeral / peer) lane the daemon never re-homes.
+        let hold = matches!(acquire, ExamAcquire::SharedLane { .. }).then(ServingSteadyHold::acquire);
+        crate::probe!(
+            class = "exam.acquire",
+            verdict = acquire.tag(),
+            held_steady = hold.is_some(),
+            "proctored exam serving context acquired (strategic admission decision)"
+        );
+        Self { acquire, _hold: hold }
+    }
+
+    /// The live serving inputs weren't resolvable (ungoverned host, model row missing, or
+    /// the lane isn't ready yet) — fall back to the historical behavior: hold the live lane
+    /// steady on the assumption it's a share, but MARK the verdict `unresolved` so the gap is
+    /// visible rather than silently assumed. Behavior never regresses vs the old blind
+    /// steady-hold; the strategic decision is just recorded as "couldn't compute" this time.
+    pub fn steady_fallback() -> Self {
+        crate::probe!(
+            class = "exam.acquire.fallback",
+            "exam serving inputs unresolved — holding the live lane steady on the share assumption"
+        );
+        Self {
+            acquire: ExamAcquire::SharedLane {
+                lane_id: "live(unresolved)".to_string(),
+                reclaim: Vec::new(),
+            },
+            _hold: Some(ServingSteadyHold::acquire()),
+        }
+    }
+
+    /// The strategic verdict — for the ledger / capture record.
+    pub fn verdict(&self) -> &ExamAcquire {
+        &self.acquire
+    }
+
+    /// True while the live lane is held steady (a share verdict). False for spawn/spill.
+    pub fn holds_steady(&self) -> bool {
+        self._hold.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::serving_daemon::serving_held_steady;
+    use crate::resources::placement::DemandTier;
+
+    const GIB: u64 = 1 << 30;
+    const KV_PER_TOKEN: u64 = 160 * 1024;
+    const WEIGHTS: u64 = 14 * GIB;
+    const COMPUTE: u64 = GIB;
+
+    fn live_lane(base: &str) -> ResidentLane {
+        ResidentLane {
+            lane_id: "live".into(),
+            base_model_id: base.into(),
+            weights_bytes: WEIGHTS,
+            slots: 2,
+            window: 8192,
+            kv_per_token: KV_PER_TOKEN,
+            compute_buffer: COMPUTE,
+            tier: DemandTier::Live,
+            pinned: true,
+        }
+    }
+
+    fn exam_demand(base: &str) -> LaneDemand {
+        LaneDemand {
+            base_model_id: base.into(),
+            weights_bytes: WEIGHTS,
+            slots: 1,
+            window: 8192,
+            kv_per_token: KV_PER_TOKEN,
+            compute_buffer: COMPUTE,
+            tier: DemandTier::Eval,
+        }
+    }
+
+    // what this catches: the living-persona exam (same base already resident) resolves to a
+    // SHARE on her real lane AND holds it steady for the duration — never a second weight
+    // copy, never a grow-back relaunch mid-exam. This is the strategic decision made explicit
+    // that the (None,None) branch used to only assume. [[proctored-exam-session-dependable-benchmark]]
+    #[test]
+    fn living_persona_exam_shares_the_live_lane_and_holds_it_steady() {
+        let resident = [live_lane("devstral-24b")];
+        let ctx = ExamServingContext::acquire(40 * GIB, &resident, &exam_demand("devstral-24b"));
+        assert!(matches!(ctx.verdict(), ExamAcquire::SharedLane { lane_id, .. } if lane_id == "live"));
+        assert!(ctx.holds_steady(), "a shared-lane exam must hold the live lane steady");
+        assert!(serving_held_steady(), "the global steady gauge reflects the held exam");
+        drop(ctx);
+        assert!(!serving_held_steady(), "dropping the context restores grow-back (RAII)");
+    }
+
+    // what this catches: a DIFFERENT-base exam does NOT try to co-tenant her lane — the
+    // strategic verdict is Spawn (a fresh copy is needed), and this node's ACQUIRE holds
+    // NOTHING steady (the ephemeral/peer lane owns it). The decision is still explicit, which
+    // is the incident's missing piece — no silent second-copy grab.
+    #[test]
+    fn different_base_exam_is_a_spawn_verdict_holding_nothing_local() {
+        let resident = [live_lane("devstral-24b")];
+        // Room for a second copy → SpawnLane with no reclaim (a bigger box).
+        let ctx = ExamServingContext::acquire(64 * GIB, &resident, &exam_demand("qwen-coder-32b"));
+        assert!(matches!(ctx.verdict(), ExamAcquire::Spawn { reclaim } if reclaim.is_empty()));
+        assert!(!ctx.holds_steady(), "a spawn verdict holds no local steady-hold");
+    }
+
+    // what this catches: when even a share can't be made to fit (a tiny device already full
+    // of a pinned live lane), the verdict is an honest CpuSpill with a reason — never an OOM
+    // of the resident set. The exam is told, loudly, that the accelerator can't host it.
+    #[test]
+    fn cant_fit_even_a_share_is_an_honest_cpu_spill() {
+        let resident = [live_lane("devstral-24b")];
+        // Capacity below the resident lane's own footprint ⇒ zero free ⇒ a 1-slot share's KV
+        // can't be freed (the only lane is pinned+Live, never a victim) ⇒ CpuSpill.
+        let capacity = resident[0].footprint().saturating_sub(GIB);
+        let ctx = ExamServingContext::acquire(capacity, &resident, &exam_demand("devstral-24b"));
+        assert!(matches!(ctx.verdict(), ExamAcquire::CpuSpill { .. }));
+        assert!(!ctx.holds_steady(), "a spill holds no steady-hold");
+    }
+}

--- a/core/continuum-core/src/cognition/exam_serving.rs
+++ b/core/continuum-core/src/cognition/exam_serving.rs
@@ -5,9 +5,10 @@
 //! it was measuring a co-tenant slot on the persona's own lane. The comment said
 //! "= `Placement::ShareLane`" but nothing computed it — the strategic decision was
 //! implicit. This module makes it real: it runs the model-aware admission kernel
-//! ([`plan_placement`]) against the live resident set, HOLDS the lane steady when the
-//! verdict is a share, and CARRIES the verdict so the decision is observable + capturable
-//! (the curriculum tie-in) instead of a silent assumption.
+//! ([`plan_placement`]) against the live resident set, serves the lane LUDICROUS
+//! (`PowerMode::Performance` — the biggest window the model+machine allow) when the verdict
+//! is a share, and CARRIES the verdict so the decision is observable + capturable (the
+//! curriculum tie-in) instead of a silent assumption.
 //!
 //! This is the seam the strategic layer plugs into. For the single-GPU living-persona exam
 //! the verdict is deterministically `ShareLane` (her base is already resident — sharing is
@@ -18,7 +19,7 @@
 //! path owns the spawn), so a strategic verdict is never missing again.
 //! [[proctored-exam-session-dependable-benchmark]] [[lane-admission-planner-scenario-driven]]
 
-use crate::modules::serving_daemon::ServingSteadyHold;
+use crate::modules::serving_daemon::ServingLudicrousHold;
 use crate::resources::placement::{plan_placement, LaneDemand, Placement, ResidentLane};
 
 /// The verdict the exam ACQUIRE reached — carried for observability + the curriculum
@@ -26,9 +27,10 @@ use crate::resources::placement::{plan_placement, LaneDemand, Placement, Residen
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExamAcquire {
     /// The exam base is already resident → she is measured as a co-tenant decode slot on
-    /// the live lane (`lane_id`), NO second weight copy. The lane is held steady for the
-    /// exam (grow-back relaunch suppressed). The validated single-GPU path. `reclaim` names
-    /// any lower-tier lanes the daemon should tier down first (empty in the common case).
+    /// the live lane (`lane_id`), NO second weight copy. The lane is served LUDICROUS for the
+    /// exam (Performance mode → biggest window; also keeps the plan stable, no mid-exam
+    /// relaunch). The validated single-GPU path. `reclaim` names any lower-tier lanes the
+    /// daemon should tier down first (empty in the common case).
     SharedLane { lane_id: String, reclaim: Vec<String> },
     /// The exam base is NOT resident → a fresh copy is needed (its own weights). This
     /// node's ACQUIRE does not spawn it here — the caller's ephemeral-lane / grid path owns
@@ -51,15 +53,20 @@ impl ExamAcquire {
     }
 }
 
-/// A held exam serving context. While alive, an exam that shares the live lane keeps it
-/// steady — no grow-back relaunch can connection-refuse the measurement mid-flight (the
-/// hard-rs 0/8 bounce). Dropping restores normal serving (RAII). Non-share verdicts hold
-/// nothing (the caller's lane owns them), but the DECISION is explicit either way.
+/// A held exam serving context. While alive, an exam that shares the live lane serves in
+/// LUDICROUS mode — `PowerMode::Performance`, the biggest window the model+machine allow —
+/// so the exam is never starved by a timid pressure-derived boot-window (the 2048-eco
+/// incident). Ludicrous also keeps the plan STABLE at max (nothing bigger to grow-back to,
+/// pressure-shrink overridden), so it subsumes the old steady-hold's job of preventing a
+/// mid-exam relaunch — WITHOUT pinning a too-small window. One grow-relaunch when acquired,
+/// one shrink when dropped (RAII) — bookends, not a flap. Non-share verdicts hold nothing
+/// (the caller's lane owns them), but the DECISION is explicit either way.
+/// [[serving-mode-follows-activity-ludicrous-to-dream]] [[benchmark-window-must-be-big-not-a-clamped-prompt]]
 pub struct ExamServingContext {
     acquire: ExamAcquire,
-    /// `Some` only for a `SharedLane` verdict: the RAII grow-back suppressor. Dropped with
-    /// the context, restoring the daemon's normal re-home behavior.
-    _hold: Option<ServingSteadyHold>,
+    /// `Some` only for a `SharedLane` verdict: the RAII Ludicrous (Performance) hold. Dropped
+    /// with the context, reverting serving to the live pressure-adaptive mode.
+    _hold: Option<ServingLudicrousHold>,
 }
 
 impl ExamServingContext {
@@ -76,35 +83,36 @@ impl ExamServingContext {
             Placement::SpawnLane { reclaim } => ExamAcquire::Spawn { reclaim },
             Placement::CpuSpill { reason } => ExamAcquire::CpuSpill { reason },
         };
-        // Hold the lane steady ONLY for a share — that's the case measured on the live lane,
-        // where a grow-back relaunch mid-exam is the failure. Spawn/spill run on a separate
-        // (ephemeral / peer) lane the daemon never re-homes.
-        let hold = matches!(acquire, ExamAcquire::SharedLane { .. }).then(ServingSteadyHold::acquire);
+        // Go LUDICROUS ONLY for a share — the case measured on the live lane, which must be
+        // served at the biggest window the model+machine allow (Performance), never a starved
+        // boot-window. Spawn/spill run on a separate (ephemeral / peer) lane sized at its own
+        // spawn — this override targets the shared live lane.
+        let hold = matches!(acquire, ExamAcquire::SharedLane { .. }).then(ServingLudicrousHold::acquire);
         crate::probe!(
             class = "exam.acquire",
             verdict = acquire.tag(),
-            held_steady = hold.is_some(),
+            ludicrous = hold.is_some(),
             "proctored exam serving context acquired (strategic admission decision)"
         );
         Self { acquire, _hold: hold }
     }
 
     /// The live serving inputs weren't resolvable (ungoverned host, model row missing, or
-    /// the lane isn't ready yet) — fall back to the historical behavior: hold the live lane
-    /// steady on the assumption it's a share, but MARK the verdict `unresolved` so the gap is
-    /// visible rather than silently assumed. Behavior never regresses vs the old blind
-    /// steady-hold; the strategic decision is just recorded as "couldn't compute" this time.
-    pub fn steady_fallback() -> Self {
+    /// the lane isn't ready yet) — fall back to serving the live lane in LUDICROUS mode on
+    /// the assumption it's a share, but MARK the verdict `unresolved` so the gap is visible
+    /// rather than silently assumed. Still gives the exam the biggest window the machine
+    /// allows; the strategic decision is just recorded as "couldn't compute the placement".
+    pub fn ludicrous_fallback() -> Self {
         crate::probe!(
             class = "exam.acquire.fallback",
-            "exam serving inputs unresolved — holding the live lane steady on the share assumption"
+            "exam serving inputs unresolved — serving the live lane LUDICROUS on the share assumption"
         );
         Self {
             acquire: ExamAcquire::SharedLane {
                 lane_id: "live(unresolved)".to_string(),
                 reclaim: Vec::new(),
             },
-            _hold: Some(ServingSteadyHold::acquire()),
+            _hold: Some(ServingLudicrousHold::acquire()),
         }
     }
 
@@ -113,8 +121,9 @@ impl ExamServingContext {
         &self.acquire
     }
 
-    /// True while the live lane is held steady (a share verdict). False for spawn/spill.
-    pub fn holds_steady(&self) -> bool {
+    /// True while the live lane is held in Ludicrous mode (a share verdict). False for
+    /// spawn/spill.
+    pub fn holds_ludicrous(&self) -> bool {
         self._hold.is_some()
     }
 }
@@ -122,7 +131,7 @@ impl ExamServingContext {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::modules::serving_daemon::serving_held_steady;
+    use crate::modules::serving_daemon::serving_ludicrous_active;
     use crate::resources::placement::DemandTier;
 
     const GIB: u64 = 1 << 30;
@@ -165,10 +174,10 @@ mod tests {
         let resident = [live_lane("devstral-24b")];
         let ctx = ExamServingContext::acquire(40 * GIB, &resident, &exam_demand("devstral-24b"));
         assert!(matches!(ctx.verdict(), ExamAcquire::SharedLane { lane_id, .. } if lane_id == "live"));
-        assert!(ctx.holds_steady(), "a shared-lane exam must hold the live lane steady");
-        assert!(serving_held_steady(), "the global steady gauge reflects the held exam");
+        assert!(ctx.holds_ludicrous(), "a shared-lane exam must hold the live lane steady");
+        assert!(serving_ludicrous_active(), "the global steady gauge reflects the held exam");
         drop(ctx);
-        assert!(!serving_held_steady(), "dropping the context restores grow-back (RAII)");
+        assert!(!serving_ludicrous_active(), "dropping the context restores grow-back (RAII)");
     }
 
     // what this catches: a DIFFERENT-base exam does NOT try to co-tenant her lane — the
@@ -181,7 +190,7 @@ mod tests {
         // Room for a second copy → SpawnLane with no reclaim (a bigger box).
         let ctx = ExamServingContext::acquire(64 * GIB, &resident, &exam_demand("qwen-coder-32b"));
         assert!(matches!(ctx.verdict(), ExamAcquire::Spawn { reclaim } if reclaim.is_empty()));
-        assert!(!ctx.holds_steady(), "a spawn verdict holds no local steady-hold");
+        assert!(!ctx.holds_ludicrous(), "a spawn verdict holds no local steady-hold");
     }
 
     // what this catches: when even a share can't be made to fit (a tiny device already full
@@ -195,6 +204,6 @@ mod tests {
         let capacity = resident[0].footprint().saturating_sub(GIB);
         let ctx = ExamServingContext::acquire(capacity, &resident, &exam_demand("devstral-24b"));
         assert!(matches!(ctx.verdict(), ExamAcquire::CpuSpill { .. }));
-        assert!(!ctx.holds_steady(), "a spill holds no steady-hold");
+        assert!(!ctx.holds_ludicrous(), "a spill holds no steady-hold");
     }
 }

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -43,6 +43,7 @@ pub mod dispatch_listener;
 pub mod dream_consolidation;
 pub mod embedding;
 pub mod eval;
+pub mod exam_serving;
 pub mod experience;
 pub mod faculty_pulse;
 pub mod inference_session;

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -402,6 +402,13 @@ pub struct BenchmarkRunResult {
     #[serde(rename = "meanOutputTokensPerTask")]
     #[ts(type = "number")]
     pub mean_output_tokens_per_task: f64,
+    /// Set ONLY when the serving lane failed mid-exam and never recovered (the Proctored
+    /// Exam Session's void-flag). When present, `score`/`pass_rate` are VOID — this is NOT
+    /// "she scored 0", it is "the harness never gave her a verified lane". Absent = a real,
+    /// trustworthy number. [[proctored-exam-session-dependable-benchmark]]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub infra_unavailable: Option<crate::cognition::eval::InfraUnavailable>,
 }
 
 /// `benchmark/run` — compete a persona on a named benchmark. Thin wrapper over
@@ -545,6 +552,9 @@ impl ActionCommand for BenchmarkRun {
             } else {
                 0.0
             },
+            // Propagate the void-flag: a benchmark that ran on a dead lane returns
+            // InfraUnavailable, never a fake pass-rate the matrix would publish as a real 0%.
+            infra_unavailable: result.infra_unavailable.clone(),
         })
     }
 }

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -467,6 +467,44 @@ pub async fn await_ready_serving(timeout: Duration) -> Option<ServingSnapshot> {
     }
 }
 
+/// Wait until the served window has SETTLED after a serving-mode change that may have triggered
+/// a grow-relaunch (e.g. an exam declaring Ludicrous/Performance). The caller must be able to
+/// pin the lane WITHOUT bouncing in-flight work, so it must know the relaunch is DONE — not
+/// merely that the lane was ready a moment ago (it may be about to relaunch on the next 5s plan
+/// tick). Returns the settled per-slot window, or `None` on timeout / no serving state.
+///
+/// Two phases, watch-driven (no polling, no time-based stability guessing):
+///  1. Within `settle_grace` (must exceed the daemon's `TICK`, so a re-plan can fire), watch for
+///     the lane to go NOT-ready — the signature of a relaunch. If it never does, no relaunch was
+///     needed (the window was already at target) → return the current window immediately.
+///  2. A relaunch happened → wait (bounded by `timeout`) for the lane to come back decode-ready
+///     at its new window.
+pub async fn wait_for_serving_window_settle(
+    settle_grace: Duration,
+    timeout: Duration,
+) -> Option<u32> {
+    let mut rx = SERVING_STATE.get()?.clone();
+    let start = std::time::Instant::now();
+    // Phase 1: did a relaunch start (lane went not-ready) within the grace window?
+    let relaunched = tokio::time::timeout(settle_grace, rx.wait_for(|s| !s.ready))
+        .await
+        .is_ok();
+    if !relaunched {
+        // No relaunch — the window was already at target. Return it if ready.
+        let s = rx.borrow_and_update();
+        return s.ready.then_some(s.served_context_window);
+    }
+    // Phase 2: wait for the relaunched lane to come back decode-ready. Bind the timeout result
+    // before matching so its `watch::Ref` temporary drops before `rx` does (else E0597).
+    let remaining = timeout.saturating_sub(start.elapsed());
+    let waited =
+        tokio::time::timeout(remaining, rx.wait_for(|s| s.ready && s.active_model.is_some())).await;
+    match waited {
+        Ok(Ok(guard)) => Some(guard.served_context_window),
+        _ => None,
+    }
+}
+
 /// Typed serving-control failures. The only string is a display-only leaf
 /// detail — never parsed back into control flow ([[protocols-prevent-pain]]).
 #[derive(Debug, thiserror::Error)]

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -42,7 +42,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use std::any::Any;
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::watch;
@@ -645,6 +645,22 @@ impl ServingDaemonModule {
                 if !starved {
                     return None;
                 }
+                // A living-persona eval is a co-tenant decode slot on THIS lane
+                // (`ShareLane`). Growing its window means a relaunch, and a relaunch
+                // connection-refuses the exam's in-flight generations (hard-rs 0/8,
+                // 2026-07-20). The grow-back is OPTIONAL headroom; the exam is not.
+                // Hold the lane steady until the eval drops its guard — a model/genome
+                // change or a pressure shrink above still runs (this only gates the
+                // starved GROW re-home). [[benchmark-is-a-governor-preemption-lease]]
+                if serving_held_steady() {
+                    crate::probe!(
+                        class = "serving.reconcile",
+                        live_window = live.served_context_window,
+                        plan_window = served_ctx,
+                        "grow-back re-home suppressed: an eval holds the lane steady (co-tenant slot, no relaunch)",
+                    );
+                    return None;
+                }
                 crate::probe!(
                     class = "serving.reconcile",
                     live_window = live.served_context_window,
@@ -978,6 +994,43 @@ pub fn live_host_budget(
 /// Board-only (no `SystemResourceMonitor` needed), so any consumer holding the
 /// `Arc<ResourceDaemon>` sizes a lane through the SAME `plan_serving` the autonomic serving
 /// plan uses — one budget, one authority, no duplicate calc.
+/// Process-global count of active "hold the live serving lane STEADY" requests. A
+/// living-persona benchmark/eval runs ON the shared lane as a co-tenant decode slot —
+/// `resources::placement::Placement::ShareLane` (same base already resident ⇒ no second
+/// weight copy). The one thing that breaks it is a grow-back RE-HOME relaunch mid-exam:
+/// it connection-refuses every in-flight generation (glass-boxed 2026-07-20: hard-rs 0/8,
+/// zero output tokens, the lane bounced under the exam). While any hold is active the
+/// daemon SKIPS the OPTIONAL grow-back re-home for an already-correctly-served lane. It
+/// does NOT suppress a model/genome CHANGE or a pressure-driven shrink — a real resource
+/// emergency still preempts (rare, correct). Zero-cost when no eval runs.
+static SERVING_STEADY_HOLDS: AtomicUsize = AtomicUsize::new(0);
+
+/// RAII: hold the live serving lane steady (suppress the grow-back re-home) until dropped.
+/// A living-persona eval binds one for its whole run — the concrete form of `ShareLane`'s
+/// "pin the lane for the demand's duration" clause ([[benchmark-is-a-governor-preemption-lease]],
+/// the co-tenant/steady case: no second weight copy, just don't bounce the lane).
+#[must_use = "the hold releases the instant this guard drops — bind it for the eval's lifetime"]
+pub struct ServingSteadyHold(());
+
+impl ServingSteadyHold {
+    pub fn acquire() -> Self {
+        SERVING_STEADY_HOLDS.fetch_add(1, Ordering::AcqRel);
+        Self(())
+    }
+}
+
+impl Drop for ServingSteadyHold {
+    fn drop(&mut self) {
+        SERVING_STEADY_HOLDS.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// True while at least one caller holds the live lane steady — the reconcile's grow-back
+/// re-home is suppressed for an already-correctly-served lane.
+pub fn serving_held_steady() -> bool {
+    SERVING_STEADY_HOLDS.load(Ordering::Acquire) > 0
+}
+
 pub fn governed_host_budget(resource_daemon: &ResourceDaemon) -> HostBudget {
     let available = governed_vram_ceiling(resource_daemon).unwrap_or(0);
     host_budget_from(&HostBudgetInputs {
@@ -1362,6 +1415,26 @@ mod tests {
     use super::*;
 
     const GB: u64 = 1_000_000_000;
+
+    // what this catches: the ServingSteadyHold RAII gauge — acquiring sets
+    // serving_held_steady() true; dropping clears it; nesting is reference-counted so a
+    // concurrent second eval doesn't release the first's hold. This is the gate that stops
+    // the grow-back re-home from relaunching the lane under a running eval (hard-rs 0/8).
+    // regression for the 2026-07-20 shared-lane bounce.
+    #[test]
+    fn serving_steady_hold_is_refcounted_and_raii() {
+        assert!(!serving_held_steady(), "no hold at rest");
+        {
+            let _h1 = ServingSteadyHold::acquire();
+            assert!(serving_held_steady(), "one hold ⇒ steady");
+            {
+                let _h2 = ServingSteadyHold::acquire();
+                assert!(serving_held_steady(), "two holds ⇒ still steady");
+            }
+            assert!(serving_held_steady(), "inner drop must not release the outer hold");
+        }
+        assert!(!serving_held_steady(), "all holds dropped ⇒ grow-back resumes");
+    }
 
     // what this catches: the budget is LIVE (tracks free memory, not capacity),
     // capped at physical VRAM, with headroom, cores floored at 1 — the organic

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -534,6 +534,22 @@ impl ServingDaemonModule {
     /// Recompute the plan from the live host snapshot + on-disk models, publish
     /// it, and log the decision. Idempotent — safe to call on init and tick.
     fn recompute(&self) {
+        // Don't re-plan while a relaunch of the serving lane is IN FLIGHT (#216). During the
+        // kill→respawn, the GPU scan (`physical_used`) transiently drops as the old lane exits
+        // and rises as the new one loads, so `host_budget()` — which reads the board's
+        // `available = capacity − max(granted, physical_used)` — sees a PHANTOM free-VRAM
+        // spike/dip. A plan recomputed off that transient flaps the window and triggers ANOTHER
+        // relaunch: the thrash loop (glass-boxed 2026-07-20 — board available swung 12.9↔41GB,
+        // window 44800↔7680, back-to-back relaunches). Serving's own in-flight churn must not
+        // feed back into its own plan. Hold the last plan until the reconcile settles; the gate
+        // clears via RAII (#214) the instant the relaunch finishes OR fails, so re-planning
+        // resumes promptly against the STABLE post-relaunch budget — no thrash, no stall. (The
+        // deeper fix — serving holding an explicit board lease so `granted` pins its residency
+        // and the scan transient never reaches `available` at all — is the #56 consumers-LEASE
+        // residual; this breaks the feedback loop cleanly in the meantime.)
+        if self.reconciling.load(Ordering::Acquire) {
+            return;
+        }
         let budget = self.host_budget();
         self.publish_plan(budget, &self.live_candidates());
     }

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -434,7 +434,16 @@ impl ServingDaemonModule {
         // via the drive mode below (which still reads system available for the fraction).
         let available = self.system.snapshot().memory.available_bytes;
         let live = governed_vram_ceiling(&self.resource_daemon).unwrap_or(0);
-        let mode = crate::provisioning::serving_mode_for_pressure(available);
+        // LUDICROUS override: a declared benchmark/exam intent floors the whole GPU
+        // (Performance, fraction 1.0) — the biggest window the model+machine allow, past the
+        // conservative pressure read (which on UMA under-reports free memory). The drive mode
+        // follows the ACTIVITY, not just the pressure. Otherwise the live pressure-adaptive
+        // mode (a game opening still drops us to Eco). [[serving-mode-follows-activity-ludicrous-to-dream]]
+        let mode = if serving_ludicrous_active() {
+            crate::provisioning::model_catalog::PowerMode::Performance
+        } else {
+            crate::provisioning::serving_mode_for_pressure(available)
+        };
         // Observability: emit ONLY on a mode TRANSITION so the dynamic scaling is visible
         // without spamming the hot plan tick ([[never-blind-feedback-driven-iteration]]).
         // This is the seam a learned / LLM policy will report through — watch it kick down
@@ -1031,6 +1040,44 @@ pub fn serving_held_steady() -> bool {
     SERVING_STEADY_HOLDS.load(Ordering::Acquire) > 0
 }
 
+/// LUDICROUS mode (Joel 2026-07-21: "extreme mode for benchmarks or ludicrous lol"). A
+/// benchmark / project / "the fight" wants the biggest window the model+machine can give —
+/// not the timid pressure-derived fraction. While any caller holds this, [`host_budget`]
+/// forces `PowerMode::Performance` (fraction 1.0 — "floors the whole GPU"), OVERRIDING
+/// `serving_mode_for_pressure`'s conservative read (which on UMA under-reports free memory
+/// and floored a 47872-capable model to 2048 with ~28GB idle). This is the drive mode
+/// following the ACTIVITY, not just the pressure: a declared Ludicrous intent → serve
+/// maximal. Non-thrashing: one grow-relaunch when the hold is taken, one shrink when it
+/// drops — bookends around the exam, not a flap. Zero-cost when nothing holds it.
+/// [[serving-mode-follows-activity-ludicrous-to-dream]] [[benchmark-window-must-be-big-not-a-clamped-prompt]]
+static SERVING_LUDICROUS_HOLDS: AtomicUsize = AtomicUsize::new(0);
+
+/// RAII: while held, serving plans at `PowerMode::Performance` (the whole GPU, biggest
+/// window). A benchmark binds one for its whole run so the exam is measured on the largest
+/// window the model+machine allow — never a starved boot-window. Drop reverts to the live
+/// pressure-adaptive mode.
+#[must_use = "the Ludicrous hold releases the instant this guard drops — bind it for the benchmark's lifetime"]
+pub struct ServingLudicrousHold(());
+
+impl ServingLudicrousHold {
+    pub fn acquire() -> Self {
+        SERVING_LUDICROUS_HOLDS.fetch_add(1, Ordering::AcqRel);
+        Self(())
+    }
+}
+
+impl Drop for ServingLudicrousHold {
+    fn drop(&mut self) {
+        SERVING_LUDICROUS_HOLDS.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// True while at least one caller demands Ludicrous (Performance) serving — [`host_budget`]
+/// pins `PowerMode::Performance` regardless of the pressure read.
+pub fn serving_ludicrous_active() -> bool {
+    SERVING_LUDICROUS_HOLDS.load(Ordering::Acquire) > 0
+}
+
 pub fn governed_host_budget(resource_daemon: &ResourceDaemon) -> HostBudget {
     let available = governed_vram_ceiling(resource_daemon).unwrap_or(0);
     host_budget_from(&HostBudgetInputs {
@@ -1434,6 +1481,27 @@ mod tests {
             assert!(serving_held_steady(), "inner drop must not release the outer hold");
         }
         assert!(!serving_held_steady(), "all holds dropped ⇒ grow-back resumes");
+    }
+
+    // what this catches: the ServingLudicrousHold RAII gauge — while held, serving plans at
+    // PowerMode::Performance (the whole GPU, biggest window), overriding the timid pressure
+    // read; refcounted so concurrent benchmarks compose; RAII-released so serving reverts to
+    // the live pressure-adaptive mode. This is the "extreme mode for benchmarks" gate that
+    // stops a starved eco boot-window from being what the exam is measured on.
+    // [[serving-mode-follows-activity-ludicrous-to-dream]]
+    #[test]
+    fn serving_ludicrous_hold_is_refcounted_and_raii() {
+        assert!(!serving_ludicrous_active(), "no ludicrous demand at rest");
+        {
+            let _h1 = ServingLudicrousHold::acquire();
+            assert!(serving_ludicrous_active(), "one hold ⇒ Performance override active");
+            {
+                let _h2 = ServingLudicrousHold::acquire();
+                assert!(serving_ludicrous_active(), "two holds ⇒ still active");
+            }
+            assert!(serving_ludicrous_active(), "inner drop must not release the outer hold");
+        }
+        assert!(!serving_ludicrous_active(), "all holds dropped ⇒ back to pressure-adaptive mode");
     }
 
     // what this catches: the budget is LIVE (tracks free memory, not capacity),

--- a/core/continuum-core/src/resources/mod.rs
+++ b/core/continuum-core/src/resources/mod.rs
@@ -174,6 +174,7 @@ pub mod daemon;
 pub mod governor;
 pub mod ledger;
 pub mod lease;
+pub mod placement;
 
 pub use crate::cognition::{
     ResourceClass, TargetSilicon, ThroughputLease, ThroughputLeaseError, ThroughputLeaseRegistry,

--- a/core/continuum-core/src/resources/placement.rs
+++ b/core/continuum-core/src/resources/placement.rs
@@ -212,6 +212,99 @@ fn plan_to_fit(
     }
 }
 
+// ============================================================================
+// Grid-aware admission — the SAME model-aware kernel, across nodes that come and go.
+// ============================================================================
+//
+// `capacity::grid` owns the grid SUBSTRATE (#176): the gossiped [`GridSnapshot`], the
+// deterministic sim, and the resilience invariants (a `reachable` verdict per peer,
+// stranded-lane detection, per-node OOM). But its `LocalFirstFitPolicy` places lanes
+// MODEL-BLIND — by free bytes — so it would spill a lane to the peer with the most free
+// RAM even when another peer already has that base model WARM, paying a needless cold-load
+// + weight transfer. This is the grid's version of the single-node incident: it doesn't
+// know that "same base already resident" is nearly free.
+//
+// `plan_grid_placement` is the convergence: it runs the model-aware [`plan_placement`]
+// kernel per reachable node and routes by AFFINITY FIRST — a node that already holds the
+// weights (`ShareLane`) beats a node with more free bytes every time. `capacity::grid`'s
+// `GridPlacementPolicy` becomes a thin adapter over this once its `GridSnapshot` carries
+// each node's resident models (the integration slice) — NOT a third parallel allocator.
+
+/// One node in the grid's live view: its physical ceiling + what it already serves +
+/// the network's `reachable` verdict THIS instant. An unreachable node is a memory, not
+/// an offer ([[seamless-persona-failover-model-and-genome]]) — mirrors `capacity::grid::PeerCapacity`.
+#[derive(Clone, Debug)]
+pub struct GridNode {
+    pub node_id: String,
+    pub capacity: u64,
+    pub resident: Vec<ResidentLane>,
+    /// The network's verdict right now. `false` ⇒ not an offer (peer-loss / partition).
+    pub reachable: bool,
+    /// The local node — no network hop, no weight transfer. Tie-break toward it.
+    pub local: bool,
+}
+
+impl GridNode {
+    /// Free bytes on this node right now = ceiling − everything resident.
+    pub fn free(&self) -> u64 {
+        self.capacity
+            .saturating_sub(self.resident.iter().map(ResidentLane::footprint).sum())
+    }
+}
+
+/// Where a demand lands on the grid.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GridPlacement {
+    /// Host on `node_id` via the model-aware per-node decision (share / spawn / cpu-spill).
+    Place { node_id: String, placement: Placement },
+    /// No node is reachable at all (a total partition with not even a local offer — a
+    /// defensive case; the local node is normally always reachable). Never returned just
+    /// because the grid is full: a full grid still returns the best node's `CpuSpill`
+    /// (honest, slow), because the fabric NEVER blocks ([[capacity-fabric-live-never-block-sim-as-gym]]).
+    NoNodeReachable,
+}
+
+/// Rank a per-node decision: cheapest/least-disruptive first.
+fn placement_rank(p: &Placement) -> u8 {
+    match p {
+        Placement::ShareLane { .. } => 0,                          // weights already warm — no cold-load, no transfer
+        Placement::SpawnLane { reclaim } if reclaim.is_empty() => 1, // fits fresh, disturbs nothing
+        Placement::SpawnLane { .. } => 2,                          // fits only after tiering lower tiers down
+        Placement::CpuSpill { .. } => 3,                           // last resort — slow but never blocks
+    }
+}
+
+/// THE grid admission planner. Pure. Runs [`plan_placement`] on every REACHABLE node and
+/// picks the best by: affinity/least-disruption first (share > clean-spawn > preempt >
+/// cpu-spill), then local before remote, then most-free. A joined node simply appears in
+/// `nodes` and becomes eligible; a departed node has `reachable=false` and is ignored, so
+/// re-planning a stranded demand fails it over to a live node — all derived from the live
+/// `nodes` snapshot, never held ([[grid-agreements-swappable-policy-deterministic-rails]]).
+pub fn plan_grid_placement(nodes: &[GridNode], demand: &LaneDemand) -> GridPlacement {
+    let mut evals: Vec<(&GridNode, Placement)> = nodes
+        .iter()
+        .filter(|n| n.reachable)
+        .map(|n| (n, plan_placement(n.capacity, &n.resident, demand)))
+        .collect();
+
+    if evals.is_empty() {
+        return GridPlacement::NoNodeReachable;
+    }
+
+    evals.sort_by(|(na, pa), (nb, pb)| {
+        placement_rank(pa)
+            .cmp(&placement_rank(pb))
+            .then_with(|| nb.local.cmp(&na.local)) // local (true) before remote (false)
+            .then_with(|| nb.free().cmp(&na.free())) // most free first
+    });
+
+    let (node, placement) = evals.into_iter().next().expect("non-empty checked above");
+    GridPlacement::Place {
+        node_id: node.node_id.clone(),
+        placement,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,5 +435,98 @@ mod tests {
         assert!(one_slot.footprint() <= capacity);
         assert!(d.footprint() > capacity);
         assert!(matches!(plan_placement(capacity, &[], &d), Placement::CpuSpill { .. }));
+    }
+
+    // ---- grid scenarios: nodes coming online / going offline --------------------
+
+    fn node(id: &str, capacity_gib: u64, resident: Vec<ResidentLane>, reachable: bool, local: bool) -> GridNode {
+        GridNode {
+            node_id: id.into(),
+            capacity: capacity_gib * GIB,
+            resident,
+            reachable,
+            local,
+        }
+    }
+
+    // what this catches: THE MoE-affinity win. A demand routes to the node that already has
+    // the weights WARM (ShareLane) even when another reachable node has far MORE free bytes.
+    // The model-blind byte-fill (LocalFirstFitPolicy) would pick the emptier node and pay a
+    // needless cold-load + weight transfer — this is the grid version of the 2nd-copy incident.
+    #[test]
+    fn affinity_routes_to_the_node_that_already_holds_the_weights() {
+        let empty_big = node("big", 80, vec![], true, false); // huge + empty, but cold for devstral
+        let warm = node("warm", 40, vec![lane("warm-live", "devstral", 1, 8192, DemandTier::Live, true)], true, false);
+        let d = demand("devstral", 1, 8192, DemandTier::Eval);
+        match plan_grid_placement(&[empty_big, warm], &d) {
+            GridPlacement::Place { node_id, placement } => {
+                assert_eq!(node_id, "warm", "must route to the node with devstral warm, not the emptier one");
+                assert!(matches!(placement, Placement::ShareLane { .. }));
+            }
+            other => panic!("expected affinity Place on warm, got {other:?}"),
+        }
+    }
+
+    // what this catches: a JOINED node absorbs demand the busy local node can't fit. Before
+    // the peer appears the demand cpu-spills locally; the instant it's in the snapshot,
+    // reachable, the demand goes there on GPU. The grid GROWS with no held state.
+    #[test]
+    fn a_joined_node_absorbs_demand_the_local_node_cannot_fit() {
+        // Local is nearly full with a pinned Live devstral lane; a fresh DIFFERENT base won't fit.
+        let local_full = node("local", 24, vec![lane("l", "devstral", 1, 20480, DemandTier::Live, true)], true, true);
+        let d = demand("qwen-coder-14b", 1, 16384, DemandTier::Live);
+
+        // Before the join: only the full local node → best it can do is CPU spill.
+        match plan_grid_placement(std::slice::from_ref(&local_full), &d) {
+            GridPlacement::Place { node_id, placement } => {
+                assert_eq!(node_id, "local");
+                assert!(matches!(placement, Placement::CpuSpill { .. }), "local can't GPU-host it");
+            }
+            other => panic!("expected local CpuSpill pre-join, got {other:?}"),
+        }
+
+        // A peer joins with room → the demand lands there on GPU (SpawnLane), no reclaim.
+        let joined = node("peer-new", 48, vec![], true, false);
+        match plan_grid_placement(&[local_full, joined], &d) {
+            GridPlacement::Place { node_id, placement } => {
+                assert_eq!(node_id, "peer-new", "the joined node must absorb it");
+                assert_eq!(placement, Placement::SpawnLane { reclaim: vec![] });
+            }
+            other => panic!("expected Place on joined peer, got {other:?}"),
+        }
+    }
+
+    // what this catches: peer-loss FAILOVER. The node that HELD the weights goes unreachable;
+    // it must stop being an offer (its warm affinity is a memory, not an offer), and re-planning
+    // the stranded demand routes it to a live node — never stalls on the dead one.
+    #[test]
+    fn a_departed_node_is_not_an_offer_demand_fails_over() {
+        // 'dead' has devstral warm (affinity) but is unreachable; 'live' is empty + reachable.
+        let dead = node("dead", 40, vec![lane("d", "devstral", 1, 8192, DemandTier::Live, true)], false, false);
+        let live = node("live", 48, vec![], true, false);
+        let d = demand("devstral", 1, 8192, DemandTier::Eval);
+        match plan_grid_placement(&[dead, live], &d) {
+            GridPlacement::Place { node_id, .. } => {
+                assert_eq!(node_id, "live", "must fail over to the reachable node, not the dead affinity node");
+            }
+            other => panic!("expected failover Place on live, got {other:?}"),
+        }
+    }
+
+    // what this catches: total PARTITION degrades to local-only and never blocks. All peers
+    // unreachable → only the local node is an offer; it serves what it honestly fits.
+    #[test]
+    fn total_partition_degrades_to_local_only() {
+        let local = node("local", 64, vec![], true, true);
+        let gone_a = node("a", 80, vec![], false, false);
+        let gone_b = node("b", 80, vec![], false, false);
+        let d = demand("devstral", 1, 8192, DemandTier::Live);
+        match plan_grid_placement(&[local, gone_a, gone_b], &d) {
+            GridPlacement::Place { node_id, placement } => {
+                assert_eq!(node_id, "local");
+                assert_eq!(placement, Placement::SpawnLane { reclaim: vec![] });
+            }
+            other => panic!("expected local-only Place under partition, got {other:?}"),
+        }
     }
 }

--- a/core/continuum-core/src/resources/placement.rs
+++ b/core/continuum-core/src/resources/placement.rs
@@ -1,0 +1,346 @@
+//! Inference-lane ADMISSION planning — the intelligent "does this fit, and how?"
+//! decision the memory authority owes every new lane demand.
+//!
+//! [`ResourceGovernor::reconcile_for_demand`](super::governor::ResourceGovernor::reconcile_for_demand)
+//! is the RECLAIM half: given over-budget/expiry/relief pressure it frees bytes.
+//! This module is the missing ADMISSION half: given the physically-resident set and
+//! ONE new lane demand, it returns what the daemon should DO — share an existing
+//! lane, spawn a new one, tier lower-priority lanes down first, or (honestly) spill
+//! to CPU. It is a PURE function so the canonical scenarios (benchmark eval, a
+//! LiveKit huddle, self-scaling mid-call) are unit tests with hand-computed optimal
+//! allocations — the spec IS the oracle ([[capacity-fabric-live-never-block-sim-as-gym]]).
+//!
+//! The gotcha this exists to kill (glass-boxed 2026-07-20): the eval path grabbed a
+//! GPU lease LOCALLY, against an under-reported footprint, and stood up a SECOND full
+//! copy of a base model that was ALREADY resident — two 24B weight copies don't fit
+//! one GPU, Metal 500'd, and the poison took the live lane down too. The authority
+//! must own this decision, and its first rule is the one that incident violated:
+//! **a demand for a base that is already resident SHARES its weights — it is a
+//! co-tenant slot, never a duplicate copy** ([[benchmark-needs-its-own-serving-lane]]
+//! UPDATE, [[verify-real-device-numbers-not-a-clamp-premise]]).
+
+/// Priority classes, highest priority FIRST (derived `Ord`: `Live < Eval < Background`).
+/// A demand may tier DOWN any resident lane of strictly LOWER priority (numerically
+/// greater) to make room; it never preempts an equal-or-higher tier. Live conversation
+/// outranks a benchmark, which outranks background work (dreams, training, foraging).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum DemandTier {
+    /// A person or persona is waiting on this turn right now (chat, LiveKit huddle).
+    Live,
+    /// A proctored measurement — important, but preemptible by live work.
+    Eval,
+    /// Dreams, training, foraging — yields to everything.
+    Background,
+}
+
+/// A lane the serving layer already has physically resident. `footprint()` is its REAL
+/// occupied bytes (weights + KV for its live slots + a compute buffer) — the number the
+/// authority must trust, not an accounting stand-in.
+#[derive(Clone, Debug)]
+pub struct ResidentLane {
+    pub lane_id: String,
+    pub base_model_id: String,
+    /// One copy of the base weights (bytes) — shared across all this lane's slots.
+    pub weights_bytes: u64,
+    pub slots: u32,
+    pub window: u32,
+    pub kv_per_token: u64,
+    /// Decode-time compute/command-buffer headroom this lane needs resident.
+    pub compute_buffer: u64,
+    pub tier: DemandTier,
+    /// Actively serving / protected — never a preemption victim regardless of tier.
+    pub pinned: bool,
+}
+
+impl ResidentLane {
+    /// Total physical bytes this lane occupies: weights once + KV across all slots +
+    /// the compute buffer. This is the concurrent-worst-case (every slot's window full),
+    /// which is the number that must fit — sizing for empty slots is what OOM'd the huddle.
+    pub fn footprint(&self) -> u64 {
+        kv_bytes(self.slots, self.window, self.kv_per_token)
+            .saturating_add(self.weights_bytes)
+            .saturating_add(self.compute_buffer)
+    }
+}
+
+/// A request to place one inference lane.
+#[derive(Clone, Debug)]
+pub struct LaneDemand {
+    pub base_model_id: String,
+    pub weights_bytes: u64,
+    pub slots: u32,
+    pub window: u32,
+    pub kv_per_token: u64,
+    pub compute_buffer: u64,
+    pub tier: DemandTier,
+}
+
+impl LaneDemand {
+    /// KV bytes for THIS demand's slots at its window — the ONLY physical cost when the
+    /// base is already resident (weights are shared, not re-loaded).
+    pub fn kv_bytes(&self) -> u64 {
+        kv_bytes(self.slots, self.window, self.kv_per_token)
+    }
+
+    /// Full footprint of a FRESH copy (a base not already resident): weights + KV + buffer.
+    pub fn footprint(&self) -> u64 {
+        self.kv_bytes()
+            .saturating_add(self.weights_bytes)
+            .saturating_add(self.compute_buffer)
+    }
+}
+
+/// KV bytes for `slots` concurrent slots each holding a full `window` of tokens.
+fn kv_bytes(slots: u32, window: u32, kv_per_token: u64) -> u64 {
+    (slots as u64)
+        .saturating_mul(window as u64)
+        .saturating_mul(kv_per_token)
+}
+
+/// The admission decision. `reclaim` (usually empty) names lower-priority resident lanes
+/// the daemon must tier down BEFORE acting, so the action always lands in freed space.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Placement {
+    /// The base is already resident → add `add_slots` co-tenant slots to `lane_id`. NO new
+    /// weights. The daemon PINS the lane for the demand's duration so grow-back / self-heal
+    /// can't relaunch it underneath the work (the benchmark's correct home).
+    ShareLane {
+        lane_id: String,
+        add_slots: u32,
+        reclaim: Vec<String>,
+    },
+    /// The base is absent → spawn a new lane (its own weight copy) in the freed space.
+    SpawnLane { reclaim: Vec<String> },
+    /// Won't fit on the accelerator even after tiering down everything preemptible →
+    /// place on CPU (slow but honest), never OOM the resident set to force it.
+    CpuSpill { reason: String },
+}
+
+/// THE admission planner. Pure: no I/O, no clock. `capacity` is the physical ceiling for
+/// the device (already net of any external reserve); `resident` is what physically holds
+/// bytes right now; `demand` is the one lane we want to place.
+///
+/// Order of preference, cheapest/least-disruptive first:
+///   1. base already resident            → `ShareLane` (share weights; cost = added KV only)
+///   2. fresh copy fits in free space     → `SpawnLane` with no reclaim
+///   3. fits after tiering lower tiers    → `ShareLane`/`SpawnLane` with a `reclaim` list
+///   4. doesn't fit even then             → `CpuSpill` (loud reason)
+pub fn plan_placement(capacity: u64, resident: &[ResidentLane], demand: &LaneDemand) -> Placement {
+    let used: u64 = resident.iter().map(ResidentLane::footprint).sum();
+    let free = capacity.saturating_sub(used);
+
+    // Rule 1 — the base is ALREADY resident: share it. The only new physical cost is the
+    // added slots' KV; the weights are not duplicated. Preferred whenever possible: it is
+    // strictly cheaper than a second copy AND it is the difference between fitting and
+    // OOMing on a single accelerator.
+    if let Some(lane) = resident
+        .iter()
+        .find(|l| l.base_model_id == demand.base_model_id)
+    {
+        return match plan_to_fit(free, demand.kv_bytes(), resident, demand.tier) {
+            Ok(reclaim) => Placement::ShareLane {
+                lane_id: lane.lane_id.clone(),
+                add_slots: demand.slots,
+                reclaim,
+            },
+            Err(max_free) => Placement::CpuSpill {
+                reason: format!(
+                    "sharing {} needs {} KV bytes for {} slot(s) but only {} free even after \
+                     tiering down every preemptible lane",
+                    demand.base_model_id,
+                    demand.kv_bytes(),
+                    demand.slots,
+                    max_free
+                ),
+            },
+        };
+    }
+
+    // Rule 2/3 — a base not resident needs a full new copy (weights + KV + buffer).
+    match plan_to_fit(free, demand.footprint(), resident, demand.tier) {
+        Ok(reclaim) => Placement::SpawnLane { reclaim },
+        Err(max_free) => Placement::CpuSpill {
+            reason: format!(
+                "a fresh lane for {} needs {} bytes but only {} free even after tiering down \
+                 every preemptible lane",
+                demand.base_model_id,
+                demand.footprint(),
+                max_free
+            ),
+        },
+    }
+}
+
+/// Can `need` bytes be made free? `Ok(reclaim)` = yes, after tiering down these lanes
+/// (empty = already fits). `Err(max_free)` = no, even after tiering down everything
+/// preemptible — carries the largest free we could reach so the caller can explain it.
+///
+/// Victim order: lowest priority first (Background before Eval); within a tier, LARGEST
+/// footprint first so the fewest lanes are disturbed to reach `need`.
+fn plan_to_fit(
+    free: u64,
+    need: u64,
+    resident: &[ResidentLane],
+    demand_tier: DemandTier,
+) -> Result<Vec<String>, u64> {
+    if need <= free {
+        return Ok(Vec::new());
+    }
+    let mut candidates: Vec<&ResidentLane> = resident
+        .iter()
+        .filter(|l| l.tier > demand_tier && !l.pinned)
+        .collect();
+    // Lower priority first (tier desc), then largest footprint first (fewest victims).
+    candidates.sort_by(|a, b| {
+        b.tier
+            .cmp(&a.tier)
+            .then_with(|| b.footprint().cmp(&a.footprint()))
+    });
+    let mut freed = free;
+    let mut victims = Vec::new();
+    for lane in candidates {
+        if freed >= need {
+            break;
+        }
+        freed = freed.saturating_add(lane.footprint());
+        victims.push(lane.lane_id.clone());
+    }
+    if freed >= need {
+        Ok(victims)
+    } else {
+        Err(freed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+    // Representative Devstral-24B Q4 numbers used across the scenarios. kv_per_token is
+    // chosen so a slot at window 43264 costs ~6.8 GiB — the geometry of the 2026-07-20
+    // incident, so the tests reproduce the REAL fit/no-fit boundary, not a toy one.
+    const WEIGHTS: u64 = 14 * GIB;
+    const KV_PER_TOKEN: u64 = 160 * 1024; // 160 KiB/token
+    const COMPUTE: u64 = GIB; // ~1 GiB decode headroom
+
+    fn lane(id: &str, model: &str, slots: u32, window: u32, tier: DemandTier, pinned: bool) -> ResidentLane {
+        ResidentLane {
+            lane_id: id.into(),
+            base_model_id: model.into(),
+            weights_bytes: WEIGHTS,
+            slots,
+            window,
+            kv_per_token: KV_PER_TOKEN,
+            compute_buffer: COMPUTE,
+            tier,
+            pinned,
+        }
+    }
+
+    fn demand(model: &str, slots: u32, window: u32, tier: DemandTier) -> LaneDemand {
+        LaneDemand {
+            base_model_id: model.into(),
+            weights_bytes: WEIGHTS,
+            slots,
+            window,
+            kv_per_token: KV_PER_TOKEN,
+            compute_buffer: COMPUTE,
+            tier,
+        }
+    }
+
+    // what this catches: SCENARIO B — a benchmark eval of the SAME base the live personas
+    // are served on, on a CONTENDED accelerator, must SHARE the lane (co-tenant slot), NOT
+    // stand up a second weight copy. This is the exact 2026-07-20 hard-rs incident: a 2nd
+    // 24B copy didn't fit and OOM'd both lanes. Capacity here (~38 GiB, Comfort-fractioned)
+    // is one where the second copy genuinely can't fit but the shared slot can.
+    #[test]
+    fn benchmark_same_base_shares_the_live_lane_never_a_second_copy() {
+        let capacity = 38 * GIB;
+        // Live lane: 14 (weights) + 1 slot × 43264 × 160KiB (~6.6 GiB) + 1 (compute) ≈ 21.6 GiB.
+        let resident = vec![lane("live", "devstral", 1, 43264, DemandTier::Live, true)];
+        // Eval wants the SAME base, one slot, the same window.
+        let d = demand("devstral", 1, 43264, DemandTier::Eval);
+
+        // A fresh copy (weights+KV+buffer ≈ 21.6 GiB) would NOT fit in the ~16.4 GiB free —
+        // proving the incident. Sharing costs only the added KV (~6.6 GiB), which DOES fit.
+        assert!(d.footprint() > capacity - resident[0].footprint(), "a 2nd copy must not fit — else the scenario is toothless");
+        assert!(d.kv_bytes() <= capacity - resident[0].footprint(), "the shared slot must fit");
+
+        match plan_placement(capacity, &resident, &d) {
+            Placement::ShareLane { lane_id, add_slots, reclaim } => {
+                assert_eq!(lane_id, "live");
+                assert_eq!(add_slots, 1);
+                assert!(reclaim.is_empty(), "personas are idle enough — no preemption needed");
+            }
+            other => panic!("same-base eval must SHARE the live lane, got {other:?}"),
+        }
+    }
+
+    // what this catches: SCENARIO A — a fresh base with plenty of room spawns a co-resident
+    // lane and disturbs nothing.
+    #[test]
+    fn fresh_base_with_room_spawns_coresident_no_reclaim() {
+        let capacity = 64 * GIB;
+        let resident = vec![lane("live", "devstral", 2, 8192, DemandTier::Live, true)];
+        let d = demand("qwen-1.5b", 1, 8192, DemandTier::Eval);
+        assert_eq!(plan_placement(capacity, &resident, &d), Placement::SpawnLane { reclaim: vec![] });
+    }
+
+    // what this catches: SCENARIO C — a DIFFERENT base that doesn't fit alongside live serving
+    // tiers down a BACKGROUND lane (never the pinned Live lane) to make room, rather than
+    // spilling or OOMing. Priority ordering is load-bearing here.
+    #[test]
+    fn different_base_preempts_background_not_the_live_lane() {
+        let capacity = 40 * GIB;
+        let resident = vec![
+            lane("live", "devstral", 1, 16384, DemandTier::Live, true), // ~17.6 GiB, pinned
+            lane("dream", "devstral-dream", 1, 16384, DemandTier::Background, false), // ~17.6 GiB
+        ];
+        // A fresh Live-tier lane that needs a full copy — only fits if the dream lane yields.
+        let d = demand("qwen-coder-14b", 1, 16384, DemandTier::Live);
+        match plan_placement(capacity, &resident, &d) {
+            Placement::SpawnLane { reclaim } => {
+                assert_eq!(reclaim, vec!["dream".to_string()], "must tier down the Background lane, not the pinned Live lane");
+            }
+            other => panic!("expected SpawnLane preempting the dream lane, got {other:?}"),
+        }
+    }
+
+    // what this catches: an Eval demand must NOT preempt a Live lane even when that's the
+    // only way it would fit — live conversation outranks a benchmark. It spills to CPU instead.
+    #[test]
+    fn eval_never_preempts_live_it_spills_to_cpu() {
+        let capacity = 30 * GIB;
+        // One pinned Live lane nearly fills the device; a 2nd DIFFERENT-base copy can't fit.
+        let resident = vec![lane("live", "devstral", 1, 24576, DemandTier::Live, true)];
+        let d = demand("qwen-coder-14b", 1, 24576, DemandTier::Eval);
+        match plan_placement(capacity, &resident, &d) {
+            Placement::CpuSpill { .. } => {}
+            other => panic!("eval must not preempt Live — expected CpuSpill, got {other:?}"),
+        }
+    }
+
+    // what this catches: SCENARIO D — the concurrent-worst-case invariant. A LiveKit huddle
+    // asks for N concurrent slots; footprint() must count KV for ALL of them (not one), so a
+    // window that fits one slot but overflows N is correctly rejected. Sizing for empty slots
+    // is exactly what tipped the shared lane into decode-OOM.
+    #[test]
+    fn huddle_counts_kv_for_every_concurrent_slot() {
+        // 4 slots × 32768 × 160KiB = ~20 GiB of KV alone; + 14 weights + 1 compute ≈ 35 GiB.
+        let d = demand("devstral", 4, 32768, DemandTier::Live);
+        let one_slot = demand("devstral", 1, 32768, DemandTier::Live);
+        assert_eq!(
+            d.kv_bytes(),
+            4 * one_slot.kv_bytes(),
+            "KV must scale with concurrent slots — the worst-case that must fit"
+        );
+        // On a device that holds one slot's worth of a fresh copy but not four, the 4-slot
+        // demand for a fresh base must not claim it fits.
+        let capacity = 22 * GIB; // fits a 1-slot copy (~15.6 GiB), not a 4-slot copy (~35 GiB)
+        assert!(one_slot.footprint() <= capacity);
+        assert!(d.footprint() > capacity);
+        assert!(matches!(plan_placement(capacity, &[], &d), Placement::CpuSpill { .. }));
+    }
+}

--- a/docs/planning/PROCTORED-EXAM-SESSION.md
+++ b/docs/planning/PROCTORED-EXAM-SESSION.md
@@ -163,9 +163,28 @@ reusing `ServingSteadyHold`) on a share, and CARRIES the verdict (`ExamAcquire`)
 the explicit, observable, capturable strategic decision — "an algorithm, not a haphazard chaotic
 mess." This is the seam a DIFFERENT-base exam or a grid placement computes `Spawn`/preempt at.
 
-### Slice A2 — grid affinity convergence (SCOPED, deliberately deferred — audit 2026-07-20)
+### Slice A2 — grid affinity convergence — ✅ LANDED (sim-validated, `d68703198`)
 Make grid placement route by MODEL AFFINITY (a node already holding the base warm beats a
 node with more free bytes) instead of the model-blind byte-fill.
+
+**As landed:** `capacity/grid::AffinityFitPolicy` implements `GridPlacementPolicy` — ranks
+candidate nodes affinity-first (warm > free), then local (no hop), then most-free, with NO
+local floor (a fully-warm peer takes the whole demand, leaving the local accelerator free for
+live work — the "video + benchmark at once" answer). Two tests: the outlier
+(`affinity_routes_to_the_warm_peer_over_an_emptier_cold_node` — a warm peer with LESS free RAM
+beats an emptier cold local node; byte-fill routes local+cold-load, affinity routes to the warm
+peer with `local_lanes=0`) and the no-signal fallback (degrades to locality-then-free — a strict
+superset of byte-fill, resilience invariants intact). LocalFirstFit stays as the model-blind
+baseline/negative control it beats. All 7 grid tests green.
+
+**Deliberately deferred (with the live consumer, #180):** the warm-base map is carried on the
+policy (per-scenario) rather than threaded onto the widely-built `GridSnapshot`/`LeaseRequest`
+(`warm_bases` onto `DeviceCapacity`, which is `Copy`, + `base_model_id` onto `LeaseRequest` — a
+~48-site schema change across prod files). That churn buys nothing while these policies are
+simulator-only; it lands when the live grid-serving path actually consumes the policy. The
+affinity IDEA is proven in the gym now.
+
+**Original scoping (kept for the deferred schema work):**
 
 **Audit finding — this is sim-only design work, not a live win yet, and a bigger build than
 "a thin adapter":**

--- a/docs/planning/PROCTORED-EXAM-SESSION.md
+++ b/docs/planning/PROCTORED-EXAM-SESSION.md
@@ -120,15 +120,35 @@ be graded as a miss. Two fault-injection unit tests pin both halves. NOT yet don
 the full re-verify+retry inside team mode (it classifies + aborts) and the A/B two-arm path
 (runs on an EphemeralServingLane that decode-verifies at spawn) — both scoped follow-ups.
 
-### Slice C — adequate window (kills the churn source, axis 2)
+### Slice C — adequate window (kills the churn source, axis 2) — ✅ ALREADY SATISFIED (audit 2026-07-20)
 The served window must satisfy **concurrent-worst-case**:
-`window × active_slots × kv_per_token ≤ free_after_weights`. Today grow-back sizes for
-empty slots, so adding the exam slot (or an N-persona LiveKit huddle) overflows KV → the
-decode-failure self-heal that flips the lane not-ready. Fixing this removes the main reason
-the shared lane isn't stable under an exam.
-- Files: `cognition/serving_plan.rs` (window sizing), `serving_daemon` reconcile.
-- Test: extend `serving_plan` tests with the concurrent-worst-case invariant (mirrors
-  `placement::huddle_counts_kv_for_every_concurrent_slot`).
+`window × active_slots × kv_per_token ≤ free_after_weights` (+ the window-scaled prefill
+compute buffer per lane).
+
+**Audit finding: this is already enforced — do NOT reinvent it.** `plan_serving`
+(`cognition/serving_plan.rs:362-379`) sizes the served window by SOLVING THE FULL FIXPOINT
+`after_weights ≥ l·(kv_per_token·C + compute_floor + compute_rate·C)` where `l = lanes =
+n_seq_max`, so every one of the `l` slots can hold a FULL-window context AND prefill
+concurrently — the concurrent-worst-case invariant verbatim. The plan's original premise
+("grow-back sizes for empty slots") was stale: #213 (2-lane floor) and #214 (grow-back
+recompute UP) already fixed the specific bugs, and `a_squeeze_sheds_a_lane_rather_than_
+flooring_every_mind` shows the degrade path sheds a lane (queue) rather than shrinking the
+window under the floor. The invariant is pinned by
+`served_window_footprint_fits_effective_budget_including_window_scaled_compute` (the exact
+test this slice asked for, already green). Per-slot overflow (a single prompt+generation
+exceeding the served window) is a budget-at-assembly concern, already handled by
+`reconcile_window_to_served` (`a9b6f13a4`: the LIVE served per-slot window is the budgeting
+authority, up AND down).
+
+**Why the exam is stable under this:** `run_eval` holds a fleet-quiesce lease
+(`quiesce_all`) for the whole measurement, so live personas stop self-ticking — concurrent
+demand DURING a quiesced exam is low (the exam slot + any directed replies), well within a
+window sized for the live `demand_lanes`. The residual axis-2 risk (an N-persona LiveKit
+huddle spiking concurrency beyond the sized lane count) is a LIVE self-scaling concern
+(#126 / demand_lanes must track the huddle roster), NOT an exam-dependability gap.
+
+**Net:** no code change needed for the exam's stability. The remaining Proctored-Exam work
+is the LIVE re-measure below and Slice A (preempt) for heavy live load / the grid.
 
 ### Slice A — dependable context via preempt (the strongest guarantee)
 `ExamServingContext::acquire(persona, demand) -> Result<Handle, Reason>` executing the

--- a/docs/planning/PROCTORED-EXAM-SESSION.md
+++ b/docs/planning/PROCTORED-EXAM-SESSION.md
@@ -150,7 +150,48 @@ huddle spiking concurrency beyond the sized lane count) is a LIVE self-scaling c
 **Net:** no code change needed for the exam's stability. The remaining Proctored-Exam work
 is the LIVE re-measure below and Slice A (preempt) for heavy live load / the grid.
 
-### Slice A — dependable context via preempt (the strongest guarantee)
+### Slice A1 — ExamServingContext (the strategic ACQUIRE) — ✅ LANDED (`9b511f51d`)
+The living-persona benchmark's `(None,None)` branch no longer grabs a blind `ServingSteadyHold`
+and *assume* it's a share — it runs the model-aware `plan_placement` kernel explicitly.
+`cognition/exam_serving.rs::ExamServingContext::acquire(capacity, resident, demand)` builds the
+resident set + demand from the live serving snapshot (`current_serving` + `governed_host_budget`
++ `footprint_for`), decides `ShareLane`/`Spawn`/`CpuSpill`, holds the live lane steady (RAII,
+reusing `ServingSteadyHold`) on a share, and CARRIES the verdict (`ExamAcquire`) for the ledger
+/ curriculum. `steady_fallback()` preserves the historical hold when inputs are unresolvable
+(never regresses). 3 unit tests over the placement oracle. Behavior-preserving on single-GPU
+(her base is resident ⇒ ShareLane — the live re-measure confirmed the lane holds); the value is
+the explicit, observable, capturable strategic decision — "an algorithm, not a haphazard chaotic
+mess." This is the seam a DIFFERENT-base exam or a grid placement computes `Spawn`/preempt at.
+
+### Slice A2 — grid affinity convergence (SCOPED, deliberately deferred — audit 2026-07-20)
+Make grid placement route by MODEL AFFINITY (a node already holding the base warm beats a
+node with more free bytes) instead of the model-blind byte-fill.
+
+**Audit finding — this is sim-only design work, not a live win yet, and a bigger build than
+"a thin adapter":**
+- `capacity/grid::{GridPlacementPolicy, LocalFirstFitPolicy}` have **no production consumer** —
+  they are exercised only by `capacity/sim.rs`. So A2 changes a simulator/design artifact; it
+  does not affect any live serving path today. The live grid-serving consumer (the thing that
+  would actually benefit) is a separate, larger integration (#180 MoE expert-affinity paging /
+  the grid serving path).
+- The two placement models differ in SHAPE: `resources::placement::plan_grid_placement` picks
+  ONE node for ONE model-aware lane (`GridPlacement::Place{node, ShareLane/Spawn}`);
+  `capacity/grid::GridPlacementPolicy` spreads `want_concurrency` lanes ACROSS nodes
+  (`Placement{local_lanes, remote}`, byte-oriented). So the convergence is NOT a literal adapter
+  over `plan_grid_placement` — it's a new `AffinityFitPolicy` that applies the same affinity-first
+  node RANKING within the `GridPlacementPolicy` shape.
+- It needs a schema thread with real blast radius: `warm_bases: Vec<String>` onto `DeviceCapacity`
+  (15 construction sites) + `base_model_id: Option<String>` onto `LeaseRequest` (25 sites), then
+  the `AffinityFitPolicy`, then a `capacity/sim.rs` outlier test (a peer that HOLDS the base warm
+  but has less free RAM must win over an emptier cold peer — the byte-fill's blind spot), then
+  retire the byte-fill default.
+
+**Decision:** build A2 deliberately alongside the live grid-serving consumer (so the affinity
+policy is validated against a real path, not only the gym) — churning 40 construction sites for a
+simulator artifact with no live payoff is the wrong trade to rush. The kernel it will use
+(`plan_grid_placement`, affinity-first, 4 grid scenario tests) is already built + green.
+
+### Slice A (original, superseded by A1+A2 above) — dependable context via preempt (the strongest guarantee)
 `ExamServingContext::acquire(persona, demand) -> Result<Handle, Reason>` executing the
 `plan_placement` decision: acquire steady-hold and/or drive the preemption (tier live
 serving down via the existing `serving_tier_down::CatalogTierDownPolicy` +

--- a/docs/planning/PROCTORED-EXAM-SESSION.md
+++ b/docs/planning/PROCTORED-EXAM-SESSION.md
@@ -184,6 +184,31 @@ that A is only needed under heavy live load / on the grid.
 
 ---
 
+## Live validation (2026-07-20) — the fake-zero is dead
+
+Deployed the B binary (`npm start`, pid-verified, #194 freshness-guarded) and ran a live
+hard-rs on Asha (Devstral-Small-24B, lane at the 2048 floor). The progress ledger carries
+the before/after in two rows:
+
+| runId | binary | passRate | score/total | outputTokens | infraUnavailable |
+|---|---|---|---|---|---|
+| `bf7bb829` | pre-B | `0.0` | 0/8 | **0** | *(field absent)* |
+| `97719703` | **B** | **`0.5`** | **1/2** | **855** | **`null`** |
+
+The SAME benchmark that returned `0/8, 0 tokens` (the fake zero) all session now returns a
+REAL `1/2, 855 tokens` — Asha genuinely solved one of two hard tasks on a verified lane
+(19 tok/s decode, ~29.7s mean latency), `infraUnavailable: null`. The new `infraUnavailable`
+key is present-and-null on the B row and absent on the pre-B row: proof the schema shipped
+and the verdict ran. The lane HELD (quiesced exam ⇒ low concurrent demand ⇒ Slice C's
+existing windowing sufficed), so we got a `Scored` result rather than `InfraUnavailable`.
+
+**Decision on Slice A:** the re-measure shows a quiesced single-GPU exam is stable enough
+that A (preempt) is NOT needed for the exam's dependability — it is the heavy-live-load /
+grid-general answer, exactly as the build order predicted. The `InfraUnavailable` path is
+unit-proven (`infra_faulted_run_is_infra_unavailable_never_a_fake_zero`); it did not need to
+fire live because the lane never failed. Build A when the grid / a busy live fleet demands a
+dedicated preempted context; for the single-machine benchmark, B is sufficient and shipped.
+
 ## The curriculum tie-in (why this matters beyond one number)
 
 Every ACQUIRE decision (`plan_placement` verdict + the live demand/resident context) and its

--- a/docs/planning/PROCTORED-EXAM-SESSION.md
+++ b/docs/planning/PROCTORED-EXAM-SESSION.md
@@ -1,0 +1,163 @@
+# Proctored Exam Session — a dependable benchmark serving process
+
+**Status:** planned (2026-07-20). Approved direction: build a dependable *process*, not a
+timeout-hacked script. Author-once, run-anywhere; the same result every time because it
+**verifies** rather than **waits-and-hopes**.
+
+> Joel: "It needs to be a well organized process not some simple script where you just
+> increase a timeout. Make it dependable."
+
+---
+
+## The problem (glass-boxed 2026-07-20)
+
+A living-persona benchmark (`benchmark/run` / `cognition/eval` with no gene, no
+`base_model_id` — the `(None, None)` branch) runs the persona ON the **shared serving
+lane** (`:58057`). That lane is **not a dependable exam target**: under combined load
+(N live personas + the exam slot + memory pressure) it flips **not-ready** via one of
+three axes:
+
+1. **grow-back relaunch** — the plan wants a bigger window → relaunch → in-flight
+   generations connection-refused. *(Addressed: steady-hold, `25fc1dc51`.)*
+2. **#175 decode-failure self-heal** — concurrent-worst-case KV overflows the served
+   window at N full slots → Metal compute error → self-heal flips not-ready + relaunches.
+3. **pressure shrink / cold-after-reboot** — the lane transitions and is briefly
+   `serving: <none>, ready: false`.
+
+**The dependability bug (the real one):** when the lane is not-ready, each task's
+generation is refused (`model 'X' is not the active served model … ready: false`), and
+the run reports **`passRate: 0.0`** — a **fake zero indistinguishable from "she got it
+wrong."** Across every hard-rs run this session: `outTokens: 0`, `decode 0 tok/s`, always
+an infra cause, never her coding. A benchmark that can't tell *"she scored 0"* from
+*"the harness never gave her a working lane"* is untrustworthy by construction. No timeout
+tuning fixes that.
+
+---
+
+## Already built this session (the foundation — DO NOT rebuild)
+
+- **`fix/lane-relaunch-connect-retry`** (`edd71bfda`): a CONNECT to a mid-relaunch local
+  lane retries the same lane (bounded) instead of faulting the turn. Handles a *transient*
+  bounce; not a *sustained* not-ready.
+- **`feat/lane-admission-planner`** (`aed37a383`, `765b1993d`): `resources/placement.rs`,
+  the pure model-aware admission kernel:
+  - `plan_placement(capacity, resident, demand)` → `ShareLane` (same base resident ⇒
+    co-tenant slots, no 2nd weight copy) | `SpawnLane{reclaim}` (fresh copy, tier lower
+    tiers down first) | `CpuSpill`. Tiers: `Live > Eval > Background`.
+  - `plan_grid_placement(nodes, demand)` — same kernel across reachable nodes, affinity
+    first (route to the node that already has the weights WARM), with join/leave/partition.
+  - 9 scenario tests on the real incident geometry (Devstral-24B Q4). All green.
+- **steady-hold** (`25fc1dc51`): `ServingSteadyHold` RAII in `serving_daemon.rs`; while an
+  eval holds it, `reconcile_to_plan` skips the *grow-back re-home* for an already-correctly-
+  served lane (does NOT suppress a model change or a pressure shrink). `eval.rs` `(None,None)`
+  acquires it. Unit-tested (refcounted RAII).
+
+The steady-hold fixed axis (1). Axes (2) and (3) still flip the lane not-ready, and the
+eval still reports a fake `0`. That's what this plan finishes.
+
+Branch: `feat/lane-admission-planner` (also carries the retry + steady-hold). Sibling
+memory: `[[lane-admission-planner-scenario-driven]]`, `[[benchmark-needs-its-own-serving-lane]]`,
+`[[benchmark-is-a-governor-preemption-lease]]`, `[[llama-compute-error-wedge-is-per-slot-context-overflow]]`.
+
+---
+
+## The design: a Proctored Exam Session (a lifecycle owned by the substrate)
+
+Four phases, deterministic, fail-loud, repeatable. NOT a shell wrapper.
+
+1. **ACQUIRE a verified serving context** — via `plan_placement`. Build a `LaneDemand`
+   (her base + genome + an *exam-adequate* per-slot window + `Eval` tier) and the resident
+   set from the live serving snapshot. Decide:
+   - `ShareLane` **and** the live per-slot window is adequate for exam prompts → pin it
+     (steady-hold).
+   - window too small / lane contended → **preempt**: tier live serving down (fewer lanes /
+     smaller window / pause background personas) to free a stable slot.
+   - can't fit even after preemption → `CpuSpill` (slow but *stable*).
+   Return the handle **only when the lane is decode-verified ready** — a real one-token
+   decode, not `serving/status` optimism and not `/health` 200.
+2. **HOLD it stable for the whole exam** — steady-hold generalized: no grow-back relaunch,
+   AND the removed load means no decode-overflow self-heal churn (axis 2 gone), AND an
+   adequate window is pinned (axis 3 gone).
+3. **RUN with infra-faults ≠ task-failures** — the keystone. A per-task
+   `not the active served model` / connect-refused / compute-error is an **infra fault**:
+   pause, re-verify the context, retry the task (bounded). If the context can't be restored,
+   the run **aborts as `InfraUnavailable(reason)`, never `passRate: 0.0`**. A `0` can only
+   mean she was given a verified lane and got the answer wrong.
+4. **RELEASE** — restore live serving (RAII on the handle drop).
+
+---
+
+## Slices (build order)
+
+### Slice B — trustworthy result (keystone, FIRST)
+Make the *number* trustworthy even before preemption exists.
+- Eval result becomes an outcome: `Scored { pass_rate, … } | InfraUnavailable { reason, tasks_attempted }`.
+  `benchmark/run` + `cognition/eval-status` surface it; a fake `passRate: 0.0` on an
+  unverified lane is now impossible.
+- The eval run loop classifies each generation failure: **infra fault** (not-ready /
+  connect-refused / "not the active served model" / compute-error / stream-idle timeout)
+  vs **task failure** (a real graded-wrong answer). Infra fault → re-verify + bounded retry
+  of that task; exhausted → abort `InfraUnavailable`.
+- **Verified-ready gate**, applied to the SHARED-lane path too (today only the ephemeral
+  lane decode-verifies at spawn): decode-verify before task 1 AND re-verify between tasks.
+- Files: `cognition/eval.rs` (run loop + result type + warm-gate region), the
+  `deliberation inference failed` classification seam, `cognition/eval-status` row,
+  `benchmark/run` result.
+- Test: fault-injection — a lane that flips not-ready mid-run yields `InfraUnavailable`,
+  never `passRate 0.0`; a genuinely-wrong answer on a verified lane yields `Scored` with the
+  0 counted.
+
+### Slice C — adequate window (kills the churn source, axis 2)
+The served window must satisfy **concurrent-worst-case**:
+`window × active_slots × kv_per_token ≤ free_after_weights`. Today grow-back sizes for
+empty slots, so adding the exam slot (or an N-persona LiveKit huddle) overflows KV → the
+decode-failure self-heal that flips the lane not-ready. Fixing this removes the main reason
+the shared lane isn't stable under an exam.
+- Files: `cognition/serving_plan.rs` (window sizing), `serving_daemon` reconcile.
+- Test: extend `serving_plan` tests with the concurrent-worst-case invariant (mirrors
+  `placement::huddle_counts_kv_for_every_concurrent_slot`).
+
+### Slice A — dependable context via preempt (the strongest guarantee)
+`ExamServingContext::acquire(persona, demand) -> Result<Handle, Reason>` executing the
+`plan_placement` decision: acquire steady-hold and/or drive the preemption (tier live
+serving down via the existing `serving_tier_down::CatalogTierDownPolicy` +
+`governor.reconcile_for_demand` + `PlannedReclaim`) to free a stable slot, bring the lane
+to decode-verified ready, return the handle only then; restore on drop. This is
+`[[benchmark-is-a-governor-preemption-lease]]`, and it generalizes to the grid via
+`plan_grid_placement` (route the exam to a peer that already has the weights warm, or a
+peer with headroom, before preempting the local live lane).
+- Files: new `cognition/proctored_exam.rs` (the lifecycle) or extend `cognition/eval.rs`;
+  `serving_daemon` (a tier-down-to-target + restore API); `resources/placement` wiring.
+- Test: scenario tests reusing the placement oracle (share-adequate → pin; window-too-small
+  → preempt to 1 lane; contended → preempt background not live; can't-fit → cpu-spill).
+
+**Order:** **B → C → A.** B makes the result trustworthy immediately. C removes the main
+instability (decode-overflow self-heal). A gives the guaranteed-stable dedicated context and
+is the grid-general answer. After C, re-measure whether the shared lane is stable enough
+that A is only needed under heavy live load / on the grid.
+
+---
+
+## Validation (dependable, NOT a script)
+
+- Unit/scenario tests per slice — the oracle. `capacity/sim.rs` is the deterministic gym for
+  the preemption/placement decisions (`[[capacity-fabric-live-never-block-sim-as-gym]]`).
+- The single native path IS the process: `cu benchmark/run --name hard-rs` returns either a
+  real `Scored` number **on a verified lane**, or a loud `InfraUnavailable` reason — no bash
+  timing, no "sleep then hope." That command being dependable is the acceptance test.
+- Must NOT regress live personas: preemption tiers them down gracefully (they keep
+  answering, slower) and restores after. Gated so ONLY a real proctored exam triggers it
+  (`[[first-class-citizens-even-during-benchmarks]]`, `[[benchmarks-are-proctored-exams-of-the-natural-living-persona]]`).
+
+---
+
+## The curriculum tie-in (why this matters beyond one number)
+
+Every ACQUIRE decision (`plan_placement` verdict + the live demand/resident context) and its
+outcome (Scored / InfraUnavailable / preempted-what) is a structured, capturable record. The
+patterns are predictable (persona rhythms, scheduled benchmarks, known huddle rosters), so
+these records become the training corpus for a learned `GridPlacementPolicy` /
+`AllocationPolicy` (`Score` scalar, `[[grid-agreements-swappable-policy-deterministic-rails]]`,
+#103) that beats the deterministic baseline in the sim. Build the lifecycle so the decision +
+outcome are emitted as a capture record from the start (`[[observability-as-substrate]]`).
+```

--- a/docs/planning/PROCTORED-EXAM-SESSION.md
+++ b/docs/planning/PROCTORED-EXAM-SESSION.md
@@ -89,7 +89,7 @@ Four phases, deterministic, fail-loud, repeatable. NOT a shell wrapper.
 
 ## Slices (build order)
 
-### Slice B — trustworthy result (keystone, FIRST)
+### Slice B — trustworthy result (keystone, FIRST) — ✅ LANDED (`f25c76087`)
 Make the *number* trustworthy even before preemption exists.
 - Eval result becomes an outcome: `Scored { pass_rate, … } | InfraUnavailable { reason, tasks_attempted }`.
   `benchmark/run` + `cognition/eval-status` surface it; a fake `passRate: 0.0` on an
@@ -106,6 +106,19 @@ Make the *number* trustworthy even before preemption exists.
 - Test: fault-injection — a lane that flips not-ready mid-run yields `InfraUnavailable`,
   never `passRate 0.0`; a genuinely-wrong answer on a verified lane yields `Scored` with the
   0 counted.
+
+**As landed (`f25c76087`):** `PassOutcome { pass, results, infra_faults, infra_reason }`
+replaces the bare `(pass, results)` tuple from `run_pass`/`run_pass_team`. On an
+`inference_error`, `run_pass` re-verifies the lane (`await_ready_serving`) and retries the
+SAME task up to `INFRA_FAULT_RETRIES=3` (the retried generation IS the decode proof); an
+unrecoverable fault records the row, marks the run void, and ABORTS the loop.
+`infra_verdict(&PassOutcome) -> Option<InfraUnavailable>` (pure, one decision point) drives
+the new `CognitionEvalResult.infra_unavailable` field → ledger row `infraUnavailable`,
+`BenchmarkRunResult.infra_unavailable`, and a LEARN-mode guard (never learn from a dead-lane
+run). The old grading-match `inference_error` arm is deleted — an infra fault can no longer
+be graded as a miss. Two fault-injection unit tests pin both halves. NOT yet done in B:
+the full re-verify+retry inside team mode (it classifies + aborts) and the A/B two-arm path
+(runs on an EphemeralServingLane that decode-verifies at spawn) — both scoped follow-ups.
 
 ### Slice C — adequate window (kills the churn source, axis 2)
 The served window must satisfy **concurrent-worst-case**:


### PR DESCRIPTION
Dependable benchmark serving + strategic memory/compute allocation.

## What lands
- **Admission planner** (`resources/placement.rs`): model-aware `plan_placement` (single) + `plan_grid_placement` (grid) — same-base shares (no 2nd weight copy), tier-lower-first, spill-to-CPU. The strategic ADMISSION half the governor lacked.
- **Proctored Exam Session** (`docs/planning/PROCTORED-EXAM-SESSION.md`):
  - **B** — trustworthy result: `Scored | InfraUnavailable`, never a fake `passRate: 0.0`; infra faults re-verified + retried. **Live-proven both ways on hard-rs.**
  - **C** — concurrent-worst-case windowing: already satisfied by the `plan_serving` fixpoint (audit).
  - **A1** — `ExamServingContext`: the strategic ACQUIRE at the exam seam.
  - **A2** — `AffinityFitPolicy`: model-aware grid placement (warm-node affinity beats byte-fill); sim-validated.
- **Ludicrous mode**: a benchmark declares `PowerMode::Performance` (the whole GPU, biggest window) via grow→settle→pin (absorb the one grow-relaunch before tasks, then steady-hold — no thrash). **Live-proven: real 1/2 on an 18688 window, no bounce.**

## Validation
Every commit unit-tested; B and Ludicrous live-validated on hard-rs (Asha, Devstral-24B). Merged tree compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo