### PR TITLE
fix(build): scraper is cross-platform — unblock Linux/Docker continuum-core build

### DIFF
--- a/core/continuum-core/Cargo.toml
+++ b/core/continuum-core/Cargo.toml
@@ -231,6 +231,18 @@ similar = "2.6"                  # Unified diff computation
 ignore = "0.4"                   # .gitignore-aware file walking (from ripgrep)
 regex = "1"                      # Regex search for code search
 
+# Static-HTML eye: parse a persona's rendered artifact (index.html) into the
+# perception ProbeNode tree so the headless eval core can grade structural
+# ui_checks (tags/roles/text/counts) WITHOUT a browser eye-node connected.
+# html5ever-backed → parses malformed model output the way a browser would.
+# CROSS-PLATFORM: `perception::static_html` (perception/mod.rs, unconditional
+# `pub mod`) uses this on every target and the eval core runs on the Linux/
+# Docker grid, so this MUST live in the plain dependency table — it was
+# previously mis-placed under the macOS-only target block, which broke the
+# Linux continuum-core build (grid Docker images) while native macOS + a stale
+# Windows incremental cache masked it.
+scraper = "0.21"
+
 # ORM module — database-agnostic storage with adapter traits
 rusqlite = { version = "0.32", features = ["bundled"] }  # SQLite adapter
 deadpool-postgres.workspace = true                        # Postgres connection pool
@@ -248,12 +260,6 @@ objc = "0.2"    # Objective-C runtime — for Metal APIs not wrapped by metal cr
 # compilation, which the Command Line Tools don't include).
 #
 # mlx-rs = { version = "0.25", optional = true }  # phase B
-
-# Static-HTML eye: parse a persona's rendered artifact (index.html) into the
-# perception ProbeNode tree so the headless eval core can grade structural
-# ui_checks (tags/roles/text/counts) WITHOUT a browser eye-node connected.
-# html5ever-backed → parses malformed model output the way a browser would.
-scraper = "0.21"
 
 [features]
 # `metal` is NOT default — earlier comment claimed it was harmless on


### PR DESCRIPTION
## What
`scraper = "0.21"` was declared under `[target.'cfg(target_os = "macos")'.dependencies]`, but `perception::static_html` (unconditional `pub mod`, used by the headless eval core's `grade_ui`) calls `scraper::{Html, Selector, ElementRef}` on **every** target.

## Impact
**continuum-core does not compile on Linux** — 4× `E0433 "unlinked crate scraper"` — which **breaks the CUDA/CPU grid Docker images**. Native macOS (dep present) and a stale Windows incremental cache masked it, so it slipped onto canary.

## Fix
Move `scraper` to the plain `[dependencies]` table. It's html5ever-backed and pure-Rust — cross-platform by nature; the macOS-only placement was a mistake (appended next to the `metal`/`objc`/`mlx` Apple deps).

## Verification
`continuum-core --lib --no-default-features` now compiles and its tests pass in a Linux/CUDA container (`nvidia/cuda:12.8.0-devel`, `--gpus all`, RTX 5090). Fixes the same wall for every Linux/Docker build of the core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)