### PR TITLE
fix(test): align canary's tool-surface test with its own de-amputated code (CI red, card 0e62aca2)

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -1752,7 +1752,13 @@ mod tests {
             // A tool set whose FULL schemas would dwarf the window — the live shape
             // (whole authorized set ≫ whole slot), scaled down. With progressive
             // disclosure it no longer matters: only names+summaries ride the prompt.
-            let window: u32 = 4096;
+            // 8192 = tight-but-SERVABLE: the un-amputated native surface (~4.1k
+            // tokens of specs) must fit beside a real prompt + reserve. 4096 was
+            // the old cliff-era fixture — below what the full surface can ever
+            // serve in, i.e. a window the plan would never hand a tool-using
+            // persona. The budget trims VOLATILE context to fit; specs are
+            // reserved up front, never amputated.
+            let window: u32 = 8192;
             let tools: Vec<NativeToolSpec> = (0..60)
                 .map(|i| NativeToolSpec {
                     name: format!("cat/command_{i}"),
@@ -1782,9 +1788,15 @@ mod tests {
             .with_context_window(window)
             .with_tools(tools);
 
-            // The native surface is WINDOW-ADAPTIVE. On this TIGHT window (4096) it shrinks
-            // to the DISCOVERY PAIR — the full coding-arc schemas (~2.7k tokens) would crowd
-            // out the prompt itself. The long tail stays reachable by name.
+            // The native surface is NEVER window-amputated. The old tight-window
+            // "discovery pair only" cliff was a clamp (glass-boxed #206): a
+            // native-tool-call model can only emit calls for offered specs, so the
+            // amputated surface stranded it in a commands/help loop with 0 edits —
+            // and the threshold sat on the served window's knife-edge, flipping
+            // 10/10 ↔ 0/6 on a token. The budget (`prompt_view_within`) owns the
+            // fit now: it reserves these specs' tokens up front and trims VOLATILE
+            // context, protecting the hands. This test USED to pin the cliff; now
+            // it pins its absence.
             let native: Vec<&str> = faculty
                 .native_specs
                 .iter()
@@ -1792,16 +1804,12 @@ mod tests {
                 .collect();
             // Names on the wire ride the DIALECT (tool_dialect): the conventional,
             // charset-legal aliases tool-trained models actually saw in training.
-            assert_eq!(
-                native,
-                vec!["list_commands", "help"],
-                "tight window ⇒ discovery pair only (wire dialect)"
-            );
-            assert!(
-                faculty.describe_tool_tokens() < 512,
-                "the discovery-pair surface must be tiny ({} tokens)",
-                faculty.describe_tool_tokens()
-            );
+            for must in ["list_commands", "help", "edit_file", "bash", "grep"] {
+                assert!(
+                    native.contains(&must),
+                    "tight window must NOT amputate the native surface — {must} missing: {native:?}"
+                );
+            }
             // On a ROOMY window the CORE CODING ARC rides natively too — so a
             // tool-call-trained model acts directly instead of looping on
             // `commands/help{code/search}` (glass-boxed: 14/14 SWE acts were help-loops,

--- a/core/continuum-core/src/cognition/resource_admission.rs
+++ b/core/continuum-core/src/cognition/resource_admission.rs
@@ -493,7 +493,24 @@ mod tests {
     fn inflight_gauge_counts_releases_and_saturates_at_serving_concurrency() {
         let _serial = TEST_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
         let max = crate::cognition::serving_plan::MAX_LANES as usize;
-        assert_eq!(inflight_model_calls(), 0, "gauge starts clean");
+        // The gauge is PROCESS-global and TEST_SERIAL only serializes THIS
+        // module's tests — a test elsewhere in the crate that walks the
+        // admission path holds an InflightModelCall guard for a moment, and CI's
+        // scheduling (unlike local) can overlap it with our baseline read (the
+        // deterministic-local/flaky-CI split, canary red 2026-07-25). Bounded
+        // drain-wait: transient cross-module guards drop in microseconds; a
+        // LEAK still fails loudly below with the real count named.
+        for _ in 0..200 {
+            if inflight_model_calls() == 0 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(
+            inflight_model_calls(),
+            0,
+            "gauge did not drain to zero — a cross-module InflightModelCall guard leaked"
+        );
         assert!(!shared_model_saturated(), "idle model is not saturated");
 
         let mut guards: Vec<InflightModelCall> = Vec::new();


### PR DESCRIPTION
Canary CI has been deterministically red since #1976: the squash brought the #206 amputation-removal CODE but not the TEST update, so the test asserts a cliff the code no longer has. Test-only fix; both failing-in-CI cognition tests green on this base (tool_surface + inflight_gauge). Proven pre-existing on parent d15e46ad0 during #1980 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo