### PR TITLE
fix(models): pull downloads to cold-storage drive, not system drive

### DIFF
--- a/core/continuum-core/src/commands/models/pull.rs
+++ b/core/continuum-core/src/commands/models/pull.rs
@@ -115,10 +115,16 @@ crate::action_command! {
         drop(snap);
 
         // 3. Ask the repo what files it actually has — the authority on quant tiers.
-        let api = ApiBuilder::new()
-            .with_token(hf_token())
-            .build()
-            .map_err(|e| CommandError::Internal(format!("hf-hub init failed: {e}")))?;
+        //    Route the download cache to the configured cold-storage drive (HF_HOME/hub)
+        //    so multi-GB GGUFs land on the big/data drive, NOT the system drive.
+        let api = {
+            let mut b = ApiBuilder::new().with_token(hf_token());
+            if let Some(hub) = crate::model_registry::artifacts::huggingface_cache_root() {
+                b = b.with_cache_dir(hub);
+            }
+            b.build()
+                .map_err(|e| CommandError::Internal(format!("hf-hub init failed: {e}")))?
+        };
         let repo = api.model(repo_id.clone());
         let info = repo.info().await.map_err(|e| {
             CommandError::Internal(format!("could not list repo '{repo_id}': {e}"))

--- a/core/continuum-core/src/model_registry/artifacts.rs
+++ b/core/continuum-core/src/model_registry/artifacts.rs
@@ -316,7 +316,7 @@ fn hf_repo_slug(hint: &str) -> Option<String> {
     ))
 }
 
-fn huggingface_cache_root() -> Option<PathBuf> {
+pub(crate) fn huggingface_cache_root() -> Option<PathBuf> {
     if let Ok(hf_home) = std::env::var("HF_HOME") {
         if !hf_home.trim().is_empty() {
             return Some(PathBuf::from(hf_home).join("hub"));


### PR DESCRIPTION
`models/pull` built its hf-hub ApiBuilder with the default cache dir, so multi-GB GGUFs landed on the system drive even with a large cold-storage drive configured. Route the download cache through `huggingface_cache_root()` (HF_HOME/hub from config.env) so model artifacts default to the big/data drive — the precondition for the genome pager's backing store.

Validated end-to-end (595857d51 on the cross-grid branch): Devstral pulled to D:, C: untouched. Re-applied cleanly onto canary here; CI compile-validates on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)