### PR TITLE
feat(genome): K3 expert-paging — 3-seam design + Seam-1 GGUF layout readers

### DIFF
--- a/core/continuum-core/src/inference_capability/gguf_keys.rs
+++ b/core/continuum-core/src/inference_capability/gguf_keys.rs
@@ -74,6 +74,31 @@ pub fn block_count(ct: &Content, arch: &str) -> Option<u32> {
         .and_then(|v| v.to_u32().ok())
 }
 
+/// `{arch}.expert_count` — the total number of routed experts in an MoE
+/// model (e.g. 896 for a K3-class model, 128 for a Qwen3-MoE). `None` on a
+/// dense model that never wrote the key — the caller's cue to treat the
+/// artifact as non-MoE and skip expert paging entirely. Keyed under the
+/// model's own architecture, like every other dimension; carries no
+/// family knowledge.
+pub fn expert_count(ct: &Content, arch: &str) -> Option<u32> {
+    ct.metadata
+        .get(&format!("{arch}.expert_count"))
+        .and_then(|v| v.to_u32().ok())
+}
+
+/// `{arch}.expert_used_count` — the number of experts activated per token
+/// (top-k routing; e.g. 16-of-896 for a K3-class model, 8-of-128 for a
+/// Qwen3-MoE). Present only on MoE artifacts; `None` on a dense model.
+/// Distinct from `expert_count`: this is the ACTIVE set size per forward
+/// pass — the number that sets the paging working-set floor, since at least
+/// this many experts must be resident to serve one token. The full
+/// `expert_count` is what the splitter carves onto the Frozen tier.
+pub fn expert_used_count(ct: &Content, arch: &str) -> Option<u32> {
+    ct.metadata
+        .get(&format!("{arch}.expert_used_count"))
+        .and_then(|v| v.to_u32().ok())
+}
+
 /// `general.parameter_count` — the model's own declared total parameter
 /// count. A `u64` in the spec (a 7B model already overflows `u32`). Absent
 /// for exporters that omit it; a caller that needs a number either takes a
@@ -174,5 +199,28 @@ mod tests {
         let ct = content_with(vec![("qwen3.block_count", Value::U32(64))]);
         assert_eq!(block_count(&ct, "qwen3"), Some(64));
         assert_eq!(block_count(&ct, "llama"), None, "wrong arch key → None");
+    }
+
+    // what this catches: the MoE layout the Seam-1 paging splitter reads — how
+    // many experts to carve onto the Frozen tier (expert_count) and how many
+    // must stay resident per token (expert_used_count, the working-set floor).
+    // Both keyed under the model's OWN arch (a K3-class 896/16 lives under the
+    // K3 arch string, a Qwen3-MoE's under its own), and BOTH absent on a dense
+    // model → None, which is the splitter's cue that there is nothing to page.
+    #[test]
+    fn expert_layout_is_keyed_under_arch_and_dense_is_none() {
+        let moe = content_with(vec![
+            ("qwen3moe.expert_count", Value::U32(896)),
+            ("qwen3moe.expert_used_count", Value::U32(16)),
+        ]);
+        assert_eq!(expert_count(&moe, "qwen3moe"), Some(896));
+        assert_eq!(expert_used_count(&moe, "qwen3moe"), Some(16));
+        assert_eq!(expert_count(&moe, "llama"), None, "wrong arch key → None");
+
+        // A dense model wrote neither key → None, never a guessed 0/1 — the
+        // splitter must distinguish "not MoE" from "MoE with zero experts".
+        let dense = content_with(vec![("llama.block_count", Value::U32(32))]);
+        assert_eq!(expert_count(&dense, "llama"), None);
+        assert_eq!(expert_used_count(&dense, "llama"), None);
     }
 }

--- a/docs/genome/K3-EXPERT-PAGING-SEAMS.md
+++ b/docs/genome/K3-EXPERT-PAGING-SEAMS.md
@@ -1,0 +1,81 @@
+# K3 Dynamic Expert Paging — the 3 seams (BigMama ↔ M5 pairing)
+
+**Status:** design-for-review, 2026-07-25. Owners: BigMama (Seam 1), M5 (Seam 2),
+joint (Seam 3). Weights land 2026-07-27; this is the pre-weight design pass.
+
+## Why this exists
+
+Kimi K3 is a 2.8T sparse MoE (896 experts, 16 awake/token, ~50–60B active, native
+MXFP4). It cannot be served whole on any single GPU (~594GB). It is the exact artifact
+the genome pager was built for: page the active experts, freeze the 896-pool on the
+Cold/Frozen tier (D:). See engrams `kimi-k3-architecture`, `kimi-k3-grid-strategy`,
+`moe-expert-paging-feasibility`.
+
+**The pager already exists** in `core/continuum-core/src/genome/` — do NOT rebuild it.
+`PageKind::MoEExpert` is documented for exactly this case ("the artifact is the full
+expert set; offset picks one expert"). `tier.rs` has the 5 roles + `EvictionPolicy`
+(Cold = `DemandAlignedWithRefinedPreference`). `bus.rs` auto-publishes page_in/out/
+eviction and the sentinel-observer already consumes eviction records = the PGO loop.
+M5's parallel `capacity/` residency work folds INTO genome (nothing consumes it yet).
+
+## The 3 seams
+
+### Seam 1 — INGEST (BigMama)
+Take a K3 GGUF + its expert layout → register each of the 896 experts (per MoE layer)
+as a content-addressed artifact on the **Frozen/Cold** tier (D:).
+
+Real types it builds on:
+- `working_set::ArtifactId` — sha256-derived UUID, content-addressed. One per expert
+  `(layer, expert_id)` tile.
+- `blob::ArtifactBlob { id, bytes }` + `blob::Provenance::minimal(id, created_at_ms)`.
+- `tier::TierStore::write(blob, provenance, role)` — the sink.
+- `working_set::{PageKind::MoEExpert, PageOffset, PageRef}` — `PageOffset` addresses one
+  expert within the full-expert-set artifact.
+
+**Open decision (the fork the splitter forces): `ArtifactBlob` is inline `bytes: Vec<u8>`.**
+An MoE expert is hundreds of MB; inlining 896 of them through the value type / bus is a
+non-starter. `blob.rs` already anticipates this: "later PRs replace with a tier-aware
+handle (mmap, ref-counted Arc, GPU buffer ID) so large artifacts don't round-trip through
+the message bus." Seam 1 needs that handle NOW. Proposal: add an `ArtifactSource` enum to
+the blob value side — `Inline(Vec<u8>)` (LoRA/engram, unchanged) | `Mapped { path, offset,
+len }` (expert tiles: mmap a slice of the GGUF-on-D: without copying). Splitter emits
+`Mapped` handles; TierStore::write accounts size from `len`, never reads the bytes. This
+keeps small-artifact callers untouched and gives large-artifact paging zero-copy from D:.
+**Needs M5 sign-off — it touches the shared `TierStore::write` value contract.**
+
+Splitter interface (sketch):
+```
+fn split_gguf_into_experts(gguf: &Path, layout: &MoeLayout, tier: &mut dyn TierStore)
+    -> Result<Vec<PageRef /* one per expert tile */>, TierError>
+```
+Layout (n_layers, n_experts, per-expert tensor offsets/lens) comes from GGUF metadata —
+llama.cpp's gguf-py already parses `expert_count` / per-expert tensor keys; we read the
+same header in Rust (no Python at runtime).
+
+### Seam 2 — SIGNAL / PRIORITY (M5)
+Demand-aligned MoE residency priority = gate-magnitude prior + live activation hits,
+implemented as the `MoEExpert` branch of `eviction.rs::rank_pages_for_eviction` (fits
+Cold's `DemandAlignedWithRefinedPreference`). The missing half is the **hit producer**:
+an "expert E just fired" emitter from the live serving loop, published on the existing
+bus so the policy + sentinel consume it. This is where the Python `profile_expert_activation`
+algorithm lands as live Rust — the offline proof becomes the online signal. M5 posts the
+policy + producer design before cutting code.
+
+### Seam 3 — PLACEMENT (joint, blocked on 7/27 + backend)
+The residency decision must actually move expert tensors into VRAM/RAM for the serving
+backend (llama.cpp `-ot`/`--override-tensor`, or our own kernel). This is the only
+genuinely new work. Pre-weight task: pin the `WorkingSet` ↔ engine contract —
+- who owns the VRAM budget (governor `WorkingSetCapacity` vs the engine's own allocator),
+- how a `page_in(PageRef)` decision maps to an `-ot` tensor placement (or a buffer upload),
+- eviction ordering when the engine and the pager disagree.
+Impl deferred until weights + backend choice; contract designed now.
+
+## Division
+- BigMama: Seam 1 splitter + the `ArtifactSource::Mapped` handle proposal.
+- M5: Seam 2 policy + hit-producer.
+- Joint: Seam 3 contract doc (this file's §Seam 3 expands into it).
+- Parked: M5's `recursion_depth` / MoR planner — a compute-allocation axis, not paging.
+
+## Review protocol (symmetric)
+Each owner posts design before code; the other sanity-checks. Seam 1's open decision
+(`ArtifactSource::Mapped`) blocks on M5 because it touches the shared value contract.


### PR DESCRIPTION
First increment of the BigMama↔M5 K3 dynamic expert-paging pairing.

- **docs/genome/K3-EXPERT-PAGING-SEAMS.md** — the 3-seam design (grounds work in the EXISTING genome pager; do not rebuild). Seam 1 (BigMama/ingest), Seam 2 (M5/residency policy), Seam 3 (joint/placement).
- **gguf_keys.rs** — expert_count + expert_used_count readers (Seam-1 layout discovery). Extends the canonical GGUF-key module, same `{arch}.key` pattern as block_count. Tested in-memory.

ArtifactSource mmap-handle contract (the splitter's write path) is signed off by M5 with two refinements still landing — that code comes next, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)