### PR TITLE
fix(genome): un-red canary — RecordingTier missing TierStore::{capacity,observe_access}

### DIFF
--- a/core/continuum-core/src/genome/expert_ingest.rs
+++ b/core/continuum-core/src/genome/expert_ingest.rs
@@ -151,6 +151,14 @@ mod tests {
         async fn evict(&self, _target_free_bytes: usize) -> Vec<EvictionRecord> {
             Vec::new()
         }
+        fn capacity(&self) -> crate::genome::tier::TierCapacity {
+            // Unlimited test tier — the write-side double never triggers eviction.
+            crate::genome::tier::TierCapacity {
+                current_used: 0,
+                configured_limit: u64::MAX,
+            }
+        }
+        fn observe_access(&self, _page: PageRef) {}
     }
 
     fn f32_info(shape: &[usize], offset: u64) -> TensorInfo {


### PR DESCRIPTION
## Urgent — canary Rust CI is RED
Canary's Continuum Rust Tests went red (`c1807ae`, `conclusion: failure`) from a **semantic merge conflict git can't catch**: the `TierStore` trait gained `capacity()` + `observe_access()`, and the `expert_ingest` `RecordingTier` test stub (Seam-1 #1996) predates them. Both PRs were green *alone*; combined on canary the test build fails **E0046**. Every new branch inherits the red until this lands.

## Fix
`RecordingTier` (a write-side test double) implements the two methods: `capacity()` returns an unlimited test tier (`current_used: 0, configured_limit: u64::MAX` — never triggers eviction), `observe_access()` is a no-op. Mirrors the `store.rs` reference stub. Genome test suite green (338 passed).

Same class as #191 (semantic drift, not a text conflict). Merge ASAP to unblock all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)