### PR TITLE
fix(persona): wall/pin resolves short/mistyped persona ids via id_resolve (#164)

### DIFF
--- a/core/continuum-core/src/commands/persona/wall/pin.rs
+++ b/core/continuum-core/src/commands/persona/wall/pin.rs
@@ -91,12 +91,13 @@ crate::action_command! {
     params: PersonaWallPinParams,
     output: PersonaWallPinResult,
     run(this, _ctx, p) => {
-        let persona_id = Uuid::parse_str(&p.persona_id).map_err(|e| {
-            CommandError::Invalid(format!(
-                "persona_id '{}' is not a valid uuid: {e} — call persona/instances/list",
-                p.persona_id
-            ))
-        })?;
+        // #164: resolve the short/mistyped id a caller quotes back against the
+        // personas this process knows — the ONE id_resolve primitive, same as
+        // persona/identity/get. What a surface displays (8-char short form), its
+        // verbs must accept.
+        let persona_id =
+            crate::id_resolve::resolve(&p.persona_id, &crate::persona::card::ids(), "persona")
+                .map_err(CommandError::Invalid)?;
         let supersedes = match p.supersedes.as_deref() {
             Some(s) => Some(Uuid::parse_str(s).map_err(|e| {
                 CommandError::Invalid(format!("supersedes '{s}' is not a valid post_id uuid: {e}"))


### PR DESCRIPTION
#164 (short-form uuids resolve on every id param) is **mostly already done** — the `id_resolve` primitive is wired into `persona/identity/{get,set}`, `instances/{get,despawn}`, `card`, and `work`. `persona/wall/pin` was a straggler still doing raw `Uuid::parse_str`, so a persona pinning to a persona-id it was **shown** as an 8-char short form bounced with 'not a valid uuid.'

Converted to `id_resolve::resolve(raw, &persona::card::ids(), "persona")` — same candidate source + pattern as `persona/identity/get`. The resolver's errors teach (enumerate valid short forms), subsuming the old hint. `supersedes` (a wall post_id) stays raw (different id-type, no cheap candidate source here — follow-up). Remaining stragglers: `agent/solve` (harness-fed) + `avatar` (Option helper).

id_resolve's 4 tests green; compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)