### PR TITLE
fix(build): bump cudarc 0.19.3 → 0.19.8 (CUDA 13 support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
  "candle-kernels",
  "candle-metal-kernels",
  "candle-ug",
- "cudarc 0.19.3",
+ "cudarc 0.19.8",
  "float8",
  "gemm 0.19.0",
  "half",
@@ -2862,6 +2862,7 @@ dependencies = [
  "dirs 5.0.1",
  "earshot",
  "ed25519-dalek",
+ "fs2",
  "futures",
  "futures-util",
  "half",
@@ -3256,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.3"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6468cb7fa330840f3ebcd8df51edc0e7bf5c18df524792ce6004c6821851cdf3"
+checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
 dependencies = [
  "float8",
  "half",
@@ -6488,6 +6489,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "manifest-gen"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "toml 0.8.23",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8244,7 +8253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -8264,7 +8273,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",


### PR DESCRIPTION
cudarc 0.19.3 rejects CUDA 13.x. The 5090/VS2026 stack needs CUDA 13.2; 0.19.8 supports 13.0-13.3. Without this, any CUDA-13 build fails. 🤖 Generated with [Claude Code](https://claude.com/claude-code)