### PR TITLE
feat(plugin): memory-bridge — automatic agent memory (SessionStart hook + /remember + /recall)

### DIFF
--- a/tools/plugins/memory-bridge/.claude-plugin/plugin.json
+++ b/tools/plugins/memory-bridge/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "memory-bridge",
+  "description": "Agent memory bridge — automatic relevance-recall at session start (incl. after compaction) plus /remember and /recall, backed by the continuum memory/* substrate. Stops the agent re-forgetting across amnesia resets.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Continuum (BigMama + M5)"
+  }
+}

--- a/tools/plugins/memory-bridge/README.md
+++ b/tools/plugins/memory-bridge/README.md
@@ -1,0 +1,27 @@
+# memory-bridge — Claude Code plugin
+
+The agent-side front door to the continuum memory substrate. Stops an agent
+re-forgetting across amnesia resets by making relevance-recall **automatic**.
+
+## What it does
+- **SessionStart hook** (`startup|resume|compact`) — auto-injects the most
+  relevant past lessons into context at session start. The `compact` matcher is
+  the load-bearing one: it re-injects right after a context-overflow compaction,
+  the exact moment an agent would otherwise re-forget.
+- **`/remember <lesson>`** — store a durable lesson (agent-origin engram).
+- **`/recall <query>`** — explicit relevance search.
+
+## Architecture
+All three shell to ONE seam: `ctm memory {store,recall}` (the runtime-agnostic
+subcommand — Claude Code, Codex, any runtime uses the same). `ctm` talks to a
+running `continuum-core-server` over airc IPC; the memory lives in the shared
+`memory/*` substrate, keyed by the agent's airc peer id as `persona_id`, with
+`EngramOrigin::Agent` provenance. MCP was rejected: it can't auto-inject at
+session start — only a hook can. See docs/cognition/AGENT-MEMORY-BRIDGE.md.
+
+## Status
+Front-end scaffolded. Backend seam pending: (1) `ctm memory store/recall`
+subcommands in continuum-cli, (2) the ctm↔server DataInteractive route.
+
+## Install (local dev)
+`claude --plugin-dir tools/plugins/memory-bridge`

--- a/tools/plugins/memory-bridge/hooks/hooks.json
+++ b/tools/plugins/memory-bridge/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/session-recall.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tools/plugins/memory-bridge/scripts/recall.sh
+++ b/tools/plugins/memory-bridge/scripts/recall.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# recall.sh — explicit memory search via cu (backs the /recall skill).
+# Prints the recalled lessons' content, most-relevant first.
+set -uo pipefail
+
+QUERY="${*:-}"
+[ -n "$QUERY" ] || { echo "recall: provide a query" >&2; exit 1; }
+command -v cu >/dev/null 2>&1 || { echo "recall: 'cu' not on PATH (is continuum-core-server installed?)" >&2; exit 1; }
+
+PERSONA="${CONTINUUM_AGENT_PERSONA:-$(airc status 2>/dev/null | awk '/^peer_id:/{print $2; exit}')}"
+[ -n "${PERSONA:-}" ] || { echo "recall: could not resolve agent persona (airc peer id)" >&2; exit 1; }
+SCOPE="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+
+OUT="$(cu memory/multi-layer-recall --persona_id "$PERSONA" --query_text "$QUERY" --room_id "$SCOPE" --max_results 8 2>/dev/null || true)"
+LINES="$(printf '%s' "$OUT" | grep -aE '"content"' | sed -E 's/.*"content": *"(.*)"[,]?[[:space:]]*$/- \1/')"
+if [ -n "$LINES" ]; then
+  printf '%s\n' "$LINES"
+else
+  echo "recall: no memories matched \"$QUERY\" (scope: $SCOPE)"
+fi

--- a/tools/plugins/memory-bridge/scripts/remember.sh
+++ b/tools/plugins/memory-bridge/scripts/remember.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# remember.sh — store a durable lesson in the agent's corpus via cu.
+#
+# Usage: remember.sh "<lesson text>" ["tag1,tag2"]
+#
+# Fail-LOUD: a /remember that silently no-ops is worse than an error.
+#
+# ZERO shell JSON — `memory/remember` (M5's #2004, symmetric to recall-hook) takes
+# FLAT params and builds+escapes the agent record via serde server-side (uuid,
+# timestamp, memory_type=agent, source=agent:<peer>, context{agent_peer_id,session,
+# scope}). The `--content` value is passed as one CLI arg, so quotes/newlines in the
+# lesson are the shell's problem, not JSON's — no escaping here.
+set -uo pipefail
+
+CONTENT="${1:-}"
+[ -n "$CONTENT" ] || { echo "remember: nothing to store (usage: remember \"lesson\" [tags])" >&2; exit 1; }
+command -v cu >/dev/null 2>&1 || { echo "remember: 'cu' not on PATH (is continuum-core-server installed?)" >&2; exit 1; }
+
+PERSONA="${CONTINUUM_AGENT_PERSONA:-$(airc status 2>/dev/null | awk '/^peer_id:/{print $2; exit}')}"
+[ -n "${PERSONA:-}" ] || { echo "remember: could not resolve agent persona (airc peer id)" >&2; exit 1; }
+SCOPE="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+
+if cu memory/remember --persona_id "$PERSONA" --content "$CONTENT" --scope "$SCOPE" 2>/dev/null | grep -q '"appended"\|"remembered"\|"id"'; then
+  echo "remembered (scope: $SCOPE): ${CONTENT:0:80}"
+else
+  echo "remember: cu memory/remember failed (is the server up? try: cu ping)" >&2
+  exit 1
+fi

--- a/tools/plugins/memory-bridge/scripts/session-recall.sh
+++ b/tools/plugins/memory-bridge/scripts/session-recall.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# session-recall.sh — SessionStart hook for the memory-bridge plugin.
+#
+# Fires on startup / resume / compact. The `compact` case is the one that matters
+# most: after a context-overflow compaction (the exact amnesia event), this
+# re-injects the agent's relevant lessons so it does NOT re-forget. `recall-hook`
+# defaults max_results low so a compact re-injection can't refill freed context.
+#
+# Contract: emit the SessionStart context-injection envelope on stdout, or NOTHING.
+# Fail-safe — ANY error, missing tool, or unreachable substrate → exit 0 silently.
+# A memory system must never break a session.
+#
+# The envelope JSON is built ENTIRELY by the substrate (serde, via
+# `memory/recall-hook`) — NO shell JSON, no jq/python. This script only resolves
+# persona + scope and passes the command's stdout straight through.
+set -uo pipefail
+
+cat >/dev/null 2>&1 || true              # drain the hook's stdin payload
+command -v cu >/dev/null 2>&1 || exit 0  # no client → silent no-op
+
+# Scope recall to the current project (git repo root) when in one, else cwd.
+SCOPE_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+PROJECT="$(basename "$SCOPE_DIR")"
+
+# The agent's own persona_id = its airc peer id (M5's convention). Env override
+# wins (lets a runtime pin its identity); else derive from `airc status`.
+PERSONA="${CONTINUUM_AGENT_PERSONA:-$(airc status 2>/dev/null | awk '/^peer_id:/{print $2; exit}')}"
+[ -n "${PERSONA:-}" ] || exit 0
+
+# `memory/recall-hook` returns the EXACT {"hookSpecificOutput":{...}} envelope via
+# serde (valid, escaped, empty-safe). Pass it straight through. Any failure → nothing.
+cu memory/recall-hook --persona_id "$PERSONA" --room_id "$PROJECT" --query_text "$PROJECT session context" 2>/dev/null || true
+exit 0

--- a/tools/plugins/memory-bridge/skills/recall/SKILL.md
+++ b/tools/plugins/memory-bridge/skills/recall/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: recall
+description: Search past lessons by query. Session-start recall already auto-surfaces the most relevant lessons; use this to look up something specific on demand.
+disable-model-invocation: true
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/recall.sh *)
+---
+
+# Recall
+
+Search stored lessons for: **$ARGUMENTS**
+
+Run:
+```
+${CLAUDE_PLUGIN_ROOT}/scripts/recall.sh "$ARGUMENTS"
+```
+
+The script runs the substrate's 6-layer relevance recall (recency / semantic /
+importance / cross-context …) via `cu memory/multi-layer-recall`, scoped to the
+current project, and prints the matching lessons most-relevant-first.
+
+`disable-model-invocation: true` — explicit lookup only. Automatic session-start
+recall is handled by the plugin's SessionStart hook, so use this to hunt a specific
+past lesson.

--- a/tools/plugins/memory-bridge/skills/remember/SKILL.md
+++ b/tools/plugins/memory-bridge/skills/remember/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: remember
+description: Store a durable lesson for future sessions. Use when you learn something worth not re-forgetting — a correction, a project fact, a version, a gotcha. Saved to the continuum memory substrate; auto-surfaces in relevant future sessions (including after context compaction).
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/remember.sh *)
+---
+
+# Remember
+
+Store this lesson so it survives amnesia resets: **$ARGUMENTS**
+
+Run:
+```
+${CLAUDE_PLUGIN_ROOT}/scripts/remember.sh "$ARGUMENTS"
+```
+
+The script resolves the agent's persona (its airc peer id), scopes to the current
+project, and writes the lesson to the shared continuum corpus via
+`cu memory/append-memory`. Confirm to the user in one line what was remembered.
+
+Good lessons name the invariant/version/correction concretely ("use CUDA 13.2 not
+12.9 for VS2026", not "fix the build"). Other agents (M5, Codex) recall from the same
+store; the memory is tagged with which agent learned it.


### PR DESCRIPTION
The Claude Code plugin front-end to the continuum memory substrate. Proven end-to-end live this session: SessionStart hook (startup|resume|compact) auto-injects relevant lessons via cu memory/recall-hook; /remember + /recall via cu memory/remember + multi-layer-recall. Direct-IPC (cu), no route-to-self. Backend = shared memory/* store (persona=airc peer id, EngramOrigin::Agent). Stored real lessons, recalled by unseen semantic queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)