### PR TITLE
chore(cli): rename the `cu` CLI binary to `continuum` — kill the Unix UUCP collision

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -20,7 +20,7 @@ model through the full Continuum cognition loop), and the competitor's own agent
 (**opencode**) — across a ladder of progressively harder gyms (`humaneval-rs` → `hard-rs` →
 `frontier-rs`), appends every cell to the append-only ledger `RESULTS.jsonl`, and re-renders
 the evidence board. Requirements are checked up front and named if missing (`rustc`, `python3`
-+ `huggingface_hub`, `llama-server`; a Continuum core — `cu start` — only for the OURS column).
++ `huggingface_hub`, `llama-server`; a Continuum core — `continuum start` — only for the OURS column).
 
 **Repeatable by design:** fix a cognition bug, run it again, read the delta. **Reproducible by
 design:** a stranger who cloned the repo runs the identical command and gets the identical
@@ -43,7 +43,7 @@ accept it explicitly:
 
 ```bash
 # on a Continuum box, quiet the citizens first (a humane, auto-waking nap):
-cu cognition/set-sleep-mode --persona-id <UUID> --mode sleeping --duration-minutes 90 \
+continuum cognition/set-sleep-mode --persona-id <UUID> --mode sleeping --duration-minutes 90 \
     --reason "clean benchmark — auto-waking"
 ./benchmarks/kick.sh --gyms hard-rs --limit 8         # preflight now reports CLEAN
 
@@ -68,8 +68,8 @@ mirroring the model catalog. `benchmark/run` is a thin wrapper over `cognition/e
 grader, never reimplemented.
 
 ```bash
-cu benchmark/list                                              # the catalog (name, grader, tasks, runnable)
-cu benchmark/run --persona_id <UUID> --name humaneval-rs --limit 40
+continuum benchmark/list                                              # the catalog (name, grader, tasks, runnable)
+continuum benchmark/run --persona_id <UUID> --name humaneval-rs --limit 40
 ```
 
 Add a respected collection (SWE-bench, LiveCodeBench, MBPP, …) = one `BenchmarkSpec` row in

--- a/benchmarks/kick.sh
+++ b/benchmarks/kick.sh
@@ -23,12 +23,12 @@
 # Requirements (checked below; a stranger sees exactly what's missing):
 #   rustc            — the grader compiles+runs each answer (pass = exit 0)
 #   python3 + huggingface_hub — opponent download + harness glue
-#   a Continuum core — serves the OURS lane (`cu start`); RAW/opponent arms don't need it
+#   a Continuum core — serves the OURS lane (`continuum start`); RAW/opponent arms don't need it
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 CODER="$HERE/coder"
-CU="${CU:-$HOME/.continuum/cache/cargo-target/debug/cu}"
+CU="${CU:-$HOME/.continuum/cache/cargo-target/debug/continuum}"
 
 # Easy → unsaturated. Frontier is where OURS pulls decisively ahead of RAW and the
 # competitor: the harder the task, the more the cognition loop (act→observe→act,
@@ -62,7 +62,7 @@ if "$CU" ping >/dev/null 2>&1; then
   echo "  core: up (OURS lane available)"
   OURS_OK=1
 else
-  echo "  core: DOWN — RAW + opponent arms will still run; the OURS column needs 'cu start'."
+  echo "  core: DOWN — RAW + opponent arms will still run; the OURS column needs 'continuum start'."
   OURS_OK=0
 fi
 echo "  rustc: $(rustc --version)"
@@ -73,7 +73,7 @@ echo "  rustc: $(rustc --version)"
 # corrupts them silently. Refuse a contended run unless the operator accepts it.
 GATE_FLAG=""; [ "$ALLOW_CONTENDED" = 1 ] && GATE_FLAG="--allow-contended"
 if [ -f "$CODER/preflight_gpu.py" ]; then
-  if ! python3 "$CODER/preflight_gpu.py" --cu "$CU" $GATE_FLAG; then
+  if ! python3 "$CODER/preflight_gpu.py" --continuum "$CU" $GATE_FLAG; then
     die "GPU is CONTENDED — numbers taken now are not clean. Quiet the box (the OURS
        eval auto-quiesces personas; stop any other GPU job), then re-run — or pass
        --allow-contended to measure anyway and stamp the cells CONTENDED."
@@ -90,7 +90,7 @@ for gym in "${GYMS[@]}"; do
   say "KICK: $gym  (serve → RAW + OURS + opencode → grade → teardown, per model)"
   # sweep_all serves each opponent on its scratch port, runs matrix (which appends
   # every cell to RESULTS.jsonl), and tears the server down before the next model.
-  python3 "$CODER/sweep_all.py" --models "$FLEET_RESOLVED" --benchmark "$gym" --limit "$LIMIT" --cu "$CU" \
+  python3 "$CODER/sweep_all.py" --models "$FLEET_RESOLVED" --benchmark "$gym" --limit "$LIMIT" --continuum "$CU" \
     || echo "  [gym $gym] sweep returned nonzero — cells that DID land are in the ledger; continuing"
 done
 
@@ -100,5 +100,5 @@ python3 "$HERE/render_results.py" || echo "  (render skipped — inspect benchma
 say "done"
 echo "  ledger:  benchmarks/RESULTS.jsonl   (append-only source of truth)"
 echo "  board:   benchmarks/coder/MATRIX.md + benchmarks/charts/*.svg"
-[ "$OURS_OK" = 0 ] && echo "  NOTE: OURS column is blank — start a core ('cu start') and re-run to fill it."
+[ "$OURS_OK" = 0 ] && echo "  NOTE: OURS column is blank — start a core ('continuum start') and re-run to fill it."
 rm -f "$FLEET_RESOLVED"

--- a/core/continuum-core/Cargo.toml
+++ b/core/continuum-core/Cargo.toml
@@ -12,10 +12,10 @@ name = "continuum-core-server"
 path = "src/main.rs"
 
 # `cu` — the pure-Rust CLI client (replaces the legacy Node `./jtag`). Talks to a
-# running core over its IPC socket via the uniform Connection. See src/bin/cu.rs.
+# running core over its IPC socket via the uniform Connection. See src/bin/continuum.rs.
 [[bin]]
-name = "cu"
-path = "src/bin/cu.rs"
+name = "continuum"
+path = "src/bin/continuum.rs"
 
 [[bin]]
 name = "dequantize-gguf"

--- a/core/continuum-core/build.rs
+++ b/core/continuum-core/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     // Deploy-verification (#194). Embed the git commit this binary was built from as
     // `CONTINUUM_BUILD_GIT_SHA`, so the running service can PROVE which source it is and
-    // `cu reboot` can fail loud when a build silently ran stale (a reboot that reports
+    // `continuum reboot` can fail loud when a build silently ran stale (a reboot that reports
     // success while running an old binary is a lie that turns every test into a ghost hunt).
     // Watch `.git/logs/HEAD` (the reflog — updated on every commit/checkout) so the SHA
     // refreshes exactly when HEAD moves, without forcing a rebuild on every `cargo build`.

--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -1,14 +1,14 @@
-//! `cu` — the pure-Rust Continuum CLI: the ONE surface for both lifecycle and
+//! `continuum` — the pure-Rust Continuum CLI: the ONE surface for both lifecycle and
 //! commands. Replaces the legacy Node `./jtag` and the bare start scripts.
 //!
 //! ```text
-//! cu start            # build + run the headless Rust core (detached), wait until ready
-//! cu reboot           # rebuild + relaunch, replacing any running core (~0 downtime)
+//! continuum start            # build + run the headless Rust core (detached), wait until ready
+//! continuum reboot           # rebuild + relaunch, replacing any running core (~0 downtime)
 //!                     # refuses while training (mlx_lm) is live — `--force` overrides
-//! cu stop             # stop the running core
-//! cu ping             # dispatch a command to the running core
-//! cu ping '{"message":"hi"}'
-//! cu data/list '{"collection":"users"}'
+//! continuum stop             # stop the running core
+//! continuum ping             # dispatch a command to the running core
+//! continuum ping '{"message":"hi"}'
+//! continuum data/list '{"collection":"users"}'
 //! ```
 //!
 //! Lifecycle (`start`/`stop`) wraps the pure-Rust `tools/scripts/start-server.sh`
@@ -29,7 +29,7 @@ use continuum_core::runtime::core_ipc_transport::CoreIpcTransport;
 use serde_json::Value;
 
 const DEFAULT_CORE_SOCKET: &str = "/tmp/continuum-core.sock";
-/// Where `cu start` records the detached core's PID so `cu stop` can find it.
+/// Where `continuum start` records the detached core's PID so `continuum stop` can find it.
 fn pidfile_for(socket: &str) -> String {
     format!("{socket}.pid")
 }
@@ -40,7 +40,7 @@ fn start_logfile() -> String {
 #[tokio::main]
 async fn main() {
     if let Err(e) = run().await {
-        eprintln!("cu: {e}");
+        eprintln!("continuum: {e}");
         std::process::exit(1);
     }
 }
@@ -66,7 +66,7 @@ async fn run() -> Result<(), String> {
         // CLI's paradigm (bash flags), adapted from the SAME schema the AI gets as
         // a tool spec. Otherwise dispatch, params adapted procedurally.
         command => {
-            // Meet the operator's dialect: `cu read_file ...` / `cu code_read ...`
+            // Meet the operator's dialect: `continuum read_file ...` / `continuum code_read ...`
             // resolve to the canonical `code/read` through the SAME tool_dialect
             // section personas and the socket route use — so the CLI accepts the
             // same vocabulary, and help + param-adaptation below key off the real
@@ -82,7 +82,7 @@ async fn run() -> Result<(), String> {
     }
 }
 
-/// `cu <command> --help` — the CLI adapter for the command's manual: query the
+/// `continuum <command> --help` — the CLI adapter for the command's manual: query the
 /// live registry (`commands/list`) for the command's description + params schema,
 /// then render it as bash usage. Same single source the AI tool adapter reads;
 /// only the rendering differs by paradigm ("the manual matches the paradigm").
@@ -99,7 +99,7 @@ async fn help_for(command: &str) -> Result<(), String> {
             cmds.iter()
                 .find(|c| c.get("name").and_then(|n| n.as_str()) == Some(command))
         })
-        .ok_or_else(|| format!("unknown command `{command}` (try: cu commands/list)"))?;
+        .ok_or_else(|| format!("unknown command `{command}` (try: continuum commands/list)"))?;
     println!("{}", render_cli_help(command, info));
     Ok(())
 }
@@ -113,7 +113,7 @@ fn render_cli_help(command: &str, info: &Value) -> String {
         .unwrap_or("");
     let mut out = format!("{command} — {desc}\n\n");
     out.push_str(&format!(
-        "Usage: cu {command} [--flag value ...]   (or a single JSON object)\n"
+        "Usage: continuum {command} [--flag value ...]   (or a single JSON object)\n"
     ));
 
     let schema = info.get("paramsSchema");
@@ -176,7 +176,7 @@ fn schema_type_str(spec: &Value) -> String {
     }
 }
 
-/// camelCase → kebab-case for display (`roundTripMs` → `round-trip-ms`). cu's
+/// camelCase → kebab-case for display (`roundTripMs` → `round-trip-ms`). continuum's
 /// adapter accepts either form, so the displayed flag is also a valid one.
 fn camel_to_kebab(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 4);
@@ -231,7 +231,7 @@ async fn dispatch(command: &str, args: Vec<String>) -> Result<(), String> {
 /// schema). A user flag is matched against them separator/case-insensitively, so
 /// `--persona_id`, `--persona-id`, `--personaId` all map to the schema's real
 /// `persona_id`. This is what makes snake_case Rust-native commands invokable by
-/// flag (regression: cu used to blanket-camelCase every key, turning `--persona_id`
+/// flag (regression: continuum used to blanket-camelCase every key, turning `--persona_id`
 /// into `personaId`, which the server rejected as `missing field persona_id`).
 /// Flags NOT in the schema — base `CommandParams` like userId, or commands that
 /// expose no schema (`canonical` empty) — fall back to the generic camelCase
@@ -372,7 +372,7 @@ async fn core_is_up() -> bool {
     )
 }
 
-/// `cu start` — build + run the headless Rust core (detached), wait until it
+/// `continuum start` — build + run the headless Rust core (detached), wait until it
 /// answers `ping`. Idempotent: a no-op if a core is already up.
 async fn start() -> Result<(), String> {
     let socket = socket_path();
@@ -385,8 +385,8 @@ async fn start() -> Result<(), String> {
     launch_core(&[]).await
 }
 
-/// `cu reboot` — rebuild + relaunch the core, replacing any running instance.
-/// Unlike `cu start` this never no-ops on an up core: start-server.sh builds the
+/// `continuum reboot` — rebuild + relaunch the core, replacing any running instance.
+/// Unlike `continuum start` this never no-ops on an up core: start-server.sh builds the
 /// fresh binary first (old core keeps serving), then stops the old core and
 /// execs the new one (~0 downtime). This is the canonical operator
 /// rebuild-after-edit verb — one command, no manual kill dance
@@ -403,7 +403,7 @@ async fn reboot(force: bool) -> Result<(), String> {
         return Err(format!(
             "training in flight (mlx_lm pid(s) {}) — a reboot would kill it and the \
              run would be journaled killed-by-reboot. Wait for it to finish, or rerun \
-             with `cu reboot --force` if losing the run is acceptable.",
+             with `continuum reboot --force` if losing the run is acceptable.",
             trainers
                 .iter()
                 .map(|p| p.to_string())
@@ -443,7 +443,7 @@ async fn reboot(force: bool) -> Result<(), String> {
 
 /// Prove the running core is built from the current git HEAD — the honest half of "reboot
 /// succeeded". Resolves the ACTUALLY-RUNNING core from its live pid (not a same-dir sibling of
-/// cu, which can be a stale different-profile leftover — see `running_core_binary`) and asks
+/// continuum, which can be a stale different-profile leftover — see `running_core_binary`) and asks
 /// THAT binary for its embedded build SHA, comparing it to HEAD. A mismatch means the build did
 /// NOT pick up your latest commit (a cache no-op or a failed compile that left a stale binary) —
 /// exactly the #194 trap that turned a whole session into ghost-hunting. Skips (with a warning)
@@ -505,12 +505,12 @@ fn git_head_short_sha() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-/// The `continuum-core-server` binary sitting next to this `cu` in the target dir — the one
+/// The `continuum-core-server` binary sitting next to this `continuum` in the target dir — the one
 /// start-server.sh builds and launches. `None` if it can't be resolved.
 /// Path to the executable image of the ACTUALLY-RUNNING core, resolved from its live
-/// pid — NOT "the server binary next to cu". cu and the core can be different build
+/// pid — NOT "the server binary next to continuum". continuum and the core can be different build
 /// profiles: the deploy defaults to `debug` (fast-iterate) while a stale, hand-invoked
-/// `release/cu` would otherwise verify a stale `release/continuum-core-server` LEFTOVER
+/// `release/continuum` would otherwise verify a stale `release/continuum-core-server` LEFTOVER
 /// that is not the running process at all (observed 2026-07-25 — the guard cried
 /// "mismatch 9e7947b4" about an 11:00 release leftover with zero memory/* symbols while
 /// the running `debug` core was current HEAD). Verifying a binary that isn't running is
@@ -581,12 +581,12 @@ fn pid_alive(pid: i32) -> bool {
 }
 
 /// Spawn the pure-Rust start script detached and wait until the core answers
-/// `ping`. Shared by `cu start` (after an up-check) and `cu reboot` (always).
+/// `ping`. Shared by `continuum start` (after an up-check) and `continuum reboot` (always).
 ///
 /// `wait_for_death` is the set of core PIDs that must EXIT before we trust the
-/// ping. Without it, `cu reboot` would see the OLD core still answering on the
+/// ping. Without it, `continuum reboot` would see the OLD core still answering on the
 /// same socket and falsely report "ready" before the swap happened — a fail-loud
-/// violation that would also hide a failed rebuild. `cu start` passes `&[]`.
+/// violation that would also hide a failed rebuild. `continuum start` passes `&[]`.
 async fn launch_core(wait_for_death: &[i32]) -> Result<(), String> {
     let socket = socket_path();
     let script = locate_start_script()?;
@@ -600,7 +600,7 @@ async fn launch_core(wait_for_death: &[i32]) -> Result<(), String> {
     println!("▶ starting core via {} (log: {logfile})", script.display());
 
     // Spawn the pure-Rust start script in its OWN session (setsid) so it survives
-    // `cu` exiting — a detached daemon, not a child tied to this process.
+    // `continuum` exiting — a detached daemon, not a child tied to this process.
     let mut cmd = std::process::Command::new("bash");
     cmd.arg(&script)
         .env("CONTINUUM_CORE_SOCKET", &socket)
@@ -608,7 +608,7 @@ async fn launch_core(wait_for_death: &[i32]) -> Result<(), String> {
         .stdout(Stdio::from(log))
         .stderr(Stdio::from(log_err));
     // Detach so the core outlives this CLI invocation. Unix: setsid() in the
-    // forked child before exec, off cu's session/controlling terminal. Windows:
+    // forked child before exec, off continuum's session/controlling terminal. Windows:
     // a new process group + detached process (no console tie).
     #[cfg(unix)]
     unsafe {
@@ -629,7 +629,7 @@ async fn launch_core(wait_for_death: &[i32]) -> Result<(), String> {
         .spawn()
         .map_err(|e| format!("failed to spawn {}: {e}", script.display()))?;
 
-    // Record the PID so `cu stop` can find the detached process group.
+    // Record the PID so `continuum stop` can find the detached process group.
     let pidfile = pidfile_for(&socket);
     let _ = std::fs::write(&pidfile, child.id().to_string());
 
@@ -651,7 +651,7 @@ async fn launch_core(wait_for_death: &[i32]) -> Result<(), String> {
     ))
 }
 
-/// `cu stop` — stop the running core (the detached session started by `cu start`).
+/// `continuum stop` — stop the running core (the detached session started by `continuum start`).
 async fn stop() -> Result<(), String> {
     let socket = socket_path();
     let pidfile = pidfile_for(&socket);
@@ -718,7 +718,7 @@ fn locate_start_script() -> Result<PathBuf, String> {
         if !dir.pop() {
             return Err(
                 "could not find tools/scripts/start-server.sh by walking up from the \
-                 cwd. Run `cu start` from inside the repo, or set CONTINUUM_START_SCRIPT."
+                 cwd. Run `continuum start` from inside the repo, or set CONTINUUM_START_SCRIPT."
                     .to_string(),
             );
         }
@@ -801,12 +801,12 @@ mod tests {
     }
 
     // what this catches: snake_case Rust-native command fields (e.g. cognition/eval's
-    // `persona_id`) must be invokable by flag. cu used to blanket-camelCase every key,
+    // `persona_id`) must be invokable by flag. continuum used to blanket-camelCase every key,
     // so `--persona_id` became `personaId` and the server rejected it with
     // `missing field persona_id`. With the command's schema known, any spelling of a
     // schema field canonicalizes to the exact field name; flags NOT in the schema
     // (base fields, schemaless commands) keep the legacy camelCase normalization.
-    // regression for the 2026-06-25 cu flag bug.
+    // regression for the 2026-06-25 continuum flag bug.
     #[test]
     fn flags_canonicalize_to_schema_field_names() {
         let canonical = vec!["persona_id".to_string(), "eval_set".to_string()];
@@ -878,19 +878,19 @@ mod tests {
 }
 
 fn usage() -> String {
-    "usage: cu <start|reboot|stop|command> [json | --key value ...]\n\
+    "usage: continuum <start|reboot|stop|command> [json | --key value ...]\n\
      \n\
      Lifecycle:\n  \
-       cu start                 build + run the headless Rust core (detached), wait until ready\n  \
-       cu reboot                rebuild + relaunch, replacing any running core (~0 downtime)\n  \
-       cu stop                  stop the running core\n\
+       continuum start                 build + run the headless Rust core (detached), wait until ready\n  \
+       continuum reboot                rebuild + relaunch, replacing any running core (~0 downtime)\n  \
+       continuum stop                  stop the running core\n\
      \n\
      Commands (dispatch to the running core):\n  \
-       cu ping\n  \
-       cu ping --message hi                 # --key value, coerced + camelCased automatically\n  \
-       cu ping '{\"message\":\"hi\"}'           # or a single JSON object (AI / power-user path)\n  \
-       cu commands/list                     # discover commands dynamically (single source)\n  \
-       cu commands/list --filter data/\n\
+       continuum ping\n  \
+       continuum ping --message hi                 # --key value, coerced + camelCased automatically\n  \
+       continuum ping '{\"message\":\"hi\"}'           # or a single JSON object (AI / power-user path)\n  \
+       continuum commands/list                     # discover commands dynamically (single source)\n  \
+       continuum commands/list --filter data/\n\
      \n\
      Env: CONTINUUM_CORE_SOCKET (default /tmp/continuum-core.sock)\n     \
           CONTINUUM_START_SCRIPT (override the start script path)"

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -397,7 +397,7 @@ fn refuse_eval_lane_under_memory_pressure() -> Result<(), CommandError> {
 
 /// How long a lane bringup will WAIT for a transient pressure spike to clear
 /// before failing loud. Sized for the real spikes observed live (2026-07-22): a
-/// `cu reboot` cargo build or a sibling model cold-load pushes used/total past
+/// `continuum reboot` cargo build or a sibling model cold-load pushes used/total past
 /// 0.90 for a couple of minutes, then the machine returns to Normal. Deferring
 /// briefly turns "battery wiped out by a build" into "battery ran 3 minutes
 /// later"; a SUSTAINED squeeze still fails loud at the deadline.
@@ -2375,7 +2375,7 @@ const WORKSPACE_TEMPLATE_WAIT_TRIES: u32 = 10;
 /// fired seconds after boot can race ahead of it and see `None`. This race is NOT specific
 /// to one lane — it hits the live-lane, base-model-lane, AND gene-lane forks identically —
 /// so ALL of them retry through here (previously only the live-lane branch did, and a
-/// tool-using eval on a base_model_id fired right after `cu reboot` failed loud instead of
+/// tool-using eval on a base_model_id fired right after `continuum reboot` failed loud instead of
 /// waiting). `fork` is the per-lane fork call; retried up to
 /// [`WORKSPACE_TEMPLATE_WAIT_TRIES`] times, 1s apart, then `None` (caller fails loud).
 async fn fork_eval_cycle_waiting(

--- a/core/continuum-core/src/commands/help.rs
+++ b/core/continuum-core/src/commands/help.rs
@@ -1,7 +1,7 @@
 //! `commands/help` — the AI-paradigm manual: how to CALL a command, in the exact
 //! tool-call format the caller is expected to emit.
 //!
-//! Symmetry with the CLI: `cu <command> --help` renders the SAME single schema as
+//! Symmetry with the CLI: `continuum <command> --help` renders the SAME single schema as
 //! bash flags ("the manual matches the paradigm"); this renders it as the canonical
 //! tool-call envelope a persona emits. One source (`command_registry()` + the
 //! command's `params_schema`), two paradigms. So when a persona is unsure HOW to
@@ -256,7 +256,7 @@ mod param_shape_tests {
 
     // what this catches: an externally-tagged enum param (code/edit's EditMode) is EXPANDED
     // into its variants + a concrete example instead of collapsing to a useless "any" — the
-    // invisible-contract bug I hit firsthand taking the SWE-bench test through cu (a model
+    // invisible-contract bug I hit firsthand taking the SWE-bench test through continuum (a model
     // literally could not tell what edit_mode wanted). Fixture mirrors schemars output
     // ($ref → definitions with a oneOf of {Variant:{fields}}).
     #[test]

--- a/core/continuum-core/src/commands/keys/mod.rs
+++ b/core/continuum-core/src/commands/keys/mod.rs
@@ -176,7 +176,7 @@ impl ActionCommand for KeysSet {
         Ok(KeysSetResult {
             name,
             provider: provider.clone(),
-            effective: "next core start (cu reboot)".to_string(),
+            effective: "next core start (continuum reboot)".to_string(),
         })
     }
 }

--- a/core/continuum-core/src/commands/memory/recall_hook.rs
+++ b/core/continuum-core/src/commands/memory/recall_hook.rs
@@ -6,9 +6,9 @@
 //! script hand-building `{"hookSpecificOutput":{...}}` in shell needs `jq`/`python` to
 //! escape newlines + quotes in the recalled text — fragile, and it violates the no-python
 //! / no-hand-built-wire-format rules. The ROBUST answer is the substrate emitting the
-//! envelope through serde, where escaping is correct by construction. `cu` prints a
-//! command's raw result JSON (`cu.rs`: `to_string_pretty(&result)`), so
-//! `cu memory/recall-hook` writes exactly this envelope to stdout and the hook pipes it
+//! envelope through serde, where escaping is correct by construction. `continuum` prints a
+//! command's raw result JSON (`continuum.rs`: `to_string_pretty(&result)`), so
+//! `continuum memory/recall-hook` writes exactly this envelope to stdout and the hook pipes it
 //! straight through.
 //!
 //! A thin PROJECTION over [`super::multi_layer_recall`] — it reuses
@@ -164,7 +164,7 @@ mod tests {
         let out = SessionStartHookOutput {
             hook_specific_output: HookSpecificOutput {
                 hook_event_name: "SessionStart".to_string(),
-                additional_context: "## Relevant memories\n- use cu, not ctm\n- a \"quoted\" bit"
+                additional_context: "## Relevant memories\n- use continuum, not ctm\n- a \"quoted\" bit"
                     .to_string(),
             },
         };
@@ -174,7 +174,7 @@ mod tests {
         assert!(json.contains("\"additionalContext\""), "context key: {json}");
         // The literal newline + quote are escaped by serde, not left raw — the fragility a
         // shell here-string / jq hand-build would have to get exactly right.
-        assert!(json.contains("\\n- use cu"), "newline escaped by serde: {json}");
+        assert!(json.contains("\\n- use continuum"), "newline escaped by serde: {json}");
         assert!(json.contains("\\\"quoted\\\""), "inner quotes escaped by serde: {json}");
         // Round-trips back to the same struct.
         let back: SessionStartHookOutput = serde_json::from_str(&json).unwrap();

--- a/core/continuum-core/src/commands/memory/remember.rs
+++ b/core/continuum-core/src/commands/memory/remember.rs
@@ -9,7 +9,7 @@
 //! BUILDS the record via serde: `id` (uuid) and `timestamp` are filled server-side, the
 //! agent provenance (`source`, `memory_type`, `context`, `tags`) is set consistently, and
 //! serde escapes everything by construction. `remember.sh` becomes:
-//! `cu memory/remember --persona-id <peer> --content "$1" --scope <proj>`.
+//! `continuum memory/remember --persona-id <peer> --content "$1" --scope <proj>`.
 //!
 //! Provenance mirrors the corpus half of the bridge (per [[agent-memory-bridge-agents-use-the-engram-substrate]]):
 //! `memory_type = "agent"`, `source = "agent:<peer>"`, `context = {agent_peer_id, session,
@@ -159,7 +159,7 @@ mod tests {
     fn agent_record_carries_the_bridge_provenance() {
         let r = build_agent_record(
             "peer-abc",
-            "use cu for same-machine, not ctm".to_string(),
+            "use continuum for same-machine, not ctm".to_string(),
             "continuum",
             Some("sess-1".to_string()),
             0.6,

--- a/core/continuum-core/src/commands/system.rs
+++ b/core/continuum-core/src/commands/system.rs
@@ -5,7 +5,7 @@
 //!
 //! `system/info` is the zero-ceremony stateless example (after `commands/list`): one
 //! file, one `run` body, `register_stateless_command!`, instantly callable via
-//! `cu system/info`, the persona's tools, and every SDK — derived param schema + ACL
+//! `continuum system/info`, the persona's tools, and every SDK — derived param schema + ACL
 //! gating, no wiring anywhere else. The resource reads are the dep-holding shape: they
 //! capture the module's [`SystemResourceService`] and are assembled by
 //! [`command_objects`].
@@ -78,7 +78,7 @@ pub struct SystemInfoParams {}
 pub struct SystemInfoResult {
     /// The continuum-core crate version (`CARGO_PKG_VERSION`).
     pub version: String,
-    /// OS process id of the running core — handy for ops (`cu stop` targets it).
+    /// OS process id of the running core — handy for ops (`continuum stop` targets it).
     pub pid: u32,
 }
 

--- a/core/continuum-core/src/main.rs
+++ b/core/continuum-core/src/main.rs
@@ -194,7 +194,7 @@ fn boot_mode_description(mode: continuum_core::runtime::BootMode) -> &'static st
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Deploy-verification (#194). `continuum-core-server --build-sha` prints the git commit
     // THIS binary was built from and exits immediately (before any tracing/socket/side-effect),
-    // so `cu reboot` can prove the running core is the freshly-built one — not a stale cached
+    // so `continuum reboot` can prove the running core is the freshly-built one — not a stale cached
     // binary that answered on the same socket and reported success. A reboot that silently runs
     // old code is a lie; this makes it impossible.
     if std::env::args().nth(1).as_deref() == Some("--build-sha") {

--- a/core/continuum-core/src/runtime/substrate_governor.rs
+++ b/core/continuum-core/src/runtime/substrate_governor.rs
@@ -608,7 +608,7 @@ fn pressure_budget(level: PressureLevel, total_due: usize) -> Option<usize> {
 // ─────────────────────────── governor/status ─────────────────────
 
 /// Observe the governor's last scheduling pass. The read half of the daemon's
-/// command surface — a citizen (or human/cu) asks the deterministic governor what
+/// command surface — a citizen (or human/continuum) asks the deterministic governor what
 /// it's doing. `AiSafe`: read-only telemetry.
 pub struct GovernorStatusCommand {
     snapshot: watch::Receiver<GovernorSnapshot>,

--- a/docs/CONTAINER-PATH-LINUX-VALIDATION.md
+++ b/docs/CONTAINER-PATH-LINUX-VALIDATION.md
@@ -42,7 +42,7 @@ machine.
 ## 5. `install.sh` on a fresh Ubuntu / WSL2 — ~2–3h, iterate
 Run the 9-step installer end-to-end on a clean box: system deps → node → rust → python ML → (postgres
 opt-in) → livekit → native engine note (now: llama-server + mlx, no Unsloth) → (tailscale opt-in). Confirm
-the final `npm start` + `cu ping` actually work (the message this PR fixed). WSL2 additionally exercises the
+the final `npm start` + `continuum ping` actually work (the message this PR fixed). WSL2 additionally exercises the
 `install.ps1` → `bootstrap.sh` handoff.
 
 ## 6. postgres profile — ~1h

--- a/docs/architecture/BUILD-AND-PACKAGING.md
+++ b/docs/architecture/BUILD-AND-PACKAGING.md
@@ -27,13 +27,13 @@ The bottom of the stack — **install → start → personas on airc** — must 
 ## 2. Strict principles (non-negotiable)
 
 1. **Design first.** A new startup path, test layer, or deployable unit gets designed here before it gets code. No second start orchestrator, no parallel test framework, no bespoke Dockerfile that duplicates an existing one.
-2. **One reliable startup, pure Rust.** The headless core starts via **`cu start`** → `tools/scripts/start-server.sh` → `cargo run` the `continuum-core-server`. No Node in the core start/build/test path. The legacy Node orchestrator is quarantined (`legacy/`), out of every build/CI/Docker path. (`[[validate-via-pure-rust-not-npm-jtag]]`, `[[rust-is-the-core-node-is-the-shell]]`.)
-3. **The core is headless; clients are equal consumers.** Desktop/web/mobile/CLI/task-trays all ride the uniform `continuum_client` `Connection` over a transport; none is privileged (`[[headless-core-many-clients]]`, `[[client-sdk-platform-architecture]]`). `cu` is the reference CLI client *and* the lifecycle surface.
+2. **One reliable startup, pure Rust.** The headless core starts via **`continuum start`** → `tools/scripts/start-server.sh` → `cargo run` the `continuum-core-server`. No Node in the core start/build/test path. The legacy Node orchestrator is quarantined (`legacy/`), out of every build/CI/Docker path. (`[[validate-via-pure-rust-not-npm-jtag]]`, `[[rust-is-the-core-node-is-the-shell]]`.)
+3. **The core is headless; clients are equal consumers.** Desktop/web/mobile/CLI/task-trays all ride the uniform `continuum_client` `Connection` over a transport; none is privileged (`[[headless-core-many-clients]]`, `[[client-sdk-platform-architecture]]`). `continuum` is the reference CLI client *and* the lifecycle surface.
 4. **Modular units = build units = containers.** Each deployable is a workspace member → a binary → (optionally) a container. The unit boundary is the same at every layer; you don't re-slice the system per packaging target.
-5. **Testing is a first-class deliverable, layered and deterministic.** Unit + integration tests are pure `cargo test` with **zero live deps** (no airc, no unsloth, no models, no network). Live behavior is proven by an explicit, opt-in smoke path (`cu start` + `cu ping` + a persona turn), never baked into CI's default gate. (Reinforces the test doctrine in CLAUDE.md: one test mod per file, stress behind `stress-tests`, fixtures behind `test-fixtures`, every test names the invariant it guards.)
+5. **Testing is a first-class deliverable, layered and deterministic.** Unit + integration tests are pure `cargo test` with **zero live deps** (no airc, no unsloth, no models, no network). Live behavior is proven by an explicit, opt-in smoke path (`continuum start` + `continuum ping` + a persona turn), never baked into CI's default gate. (Reinforces the test doctrine in CLAUDE.md: one test mod per file, stress behind `stress-tests`, fixtures behind `test-fixtures`, every test names the invariant it guards.)
 6. **No Node in the foundation.** Node exists only to *build the web client SDK/app* — a leaf consumer. It is never a dependency of core build, core start, core test, or the grid. If a foundation step reaches for `npm`/`tsx`, that's the bug.
 7. **Move-first to excise legacy.** Retiring something means moving it to `legacy/` and letting the build/refs break to map the coupling, then fixing to the pure replacement — never patching the old thing in place (`[[move-first-let-compiler-find-the-smell]]`).
-8. **Single dynamic command surface — no duplicated lists, ever.** Every command is callable through `cu <command> [json]` because `cu` forwards the command *string* to the core and the core routes it through the ONE registry (`command_registry` + the `DynCommand` object map). `cu` enumerates nothing; the persona tool surface, the ACL, and codegen all read the *same* registry. A command is declared in exactly ONE file (its `CommandSpec`/`ActionCommand` + `register_command!`); removing or renaming it updates that one place and everything follows. **No central command list, no switch-on-name, no per-caller catalog** — if removing a command means editing 20 strings or `match` arms, that's the bug (the anti-pattern CLAUDE.md forbids). Command *discovery* is dynamic too: `commands/list` returns the live registry, so clients/trays never hardcode a catalog.
+8. **Single dynamic command surface — no duplicated lists, ever.** Every command is callable through `continuum <command> [json]` because `continuum` forwards the command *string* to the core and the core routes it through the ONE registry (`command_registry` + the `DynCommand` object map). `continuum` enumerates nothing; the persona tool surface, the ACL, and codegen all read the *same* registry. A command is declared in exactly ONE file (its `CommandSpec`/`ActionCommand` + `register_command!`); removing or renaming it updates that one place and everything follows. **No central command list, no switch-on-name, no per-caller catalog** — if removing a command means editing 20 strings or `match` arms, that's the bug (the anti-pattern CLAUDE.md forbids). Command *discovery* is dynamic too: `commands/list` returns the live registry, so clients/trays never hardcode a catalog.
 
 ---
 
@@ -45,13 +45,13 @@ The Cargo workspace (root `Cargo.toml`) is the single source of build units. The
 |---|---|---|---|---|
 | **Core** | `core/continuum-core` | `continuum-core-server` | `docker/continuum-core.Dockerfile` (+`-cuda`, `-vulkan`) | The headless substrate: commands, events, persona hosting. The foundation. |
 | **MCP sidecar** | `core/continuum-core` | `continuum-mcp` | (co-located w/ core) | Rust MCP server over stdio → core IPC socket. What MCP clients (Studio, Claude Code) spawn. |
-| **CLI / lifecycle** | `core/continuum-core` (bin) → **should migrate to `apps/cli`** | `cu` | n/a (or thin) | `cu start`/`stop` (lifecycle) + `cu <command>` (uniform client). Replaces Node `./jtag`. |
+| **CLI / lifecycle** | `core/continuum-core` (bin) → **should migrate to `apps/cli`** | `continuum` | n/a (or thin) | `continuum start`/`stop` (lifecycle) + `continuum <command>` (uniform client). Replaces Node `./jtag`. |
 | **Inference** | `core/inference-grpc` | `inference-grpc` | (per topology) | GPU inference lane host. |
 | **LiveKit bridge** | `core/livekit-bridge` | `livekit-bridge` | `docker/livekit-bridge.Dockerfile` | Realtime media bridge. |
 | **unsloth gateway** | *external* | — | external service | Universal model gateway (`/v1` chat+embeddings, `/api`). Not ours to build; a service we address. (`[[unsloth-universal-model-gateway]]`) |
 | **Clients (new)** | `client/*`, `apps/*` | web / mobile / desktop / task-trays | `docker/node-server.Dockerfile`, `docker/widget-server.Dockerfile` | Built ON TOP, on the uniform client SDK. Node only here. |
 
-**Principle 4 in practice:** `cu`'s correct long-term home is `apps/cli` (it's a client, not core). It currently lives as a `continuum-core` bin for fast iteration (precedent: `continuum-mcp`); migrating it to `apps/cli` is tracked, not blocking.
+**Principle 4 in practice:** `continuum`'s correct long-term home is `apps/cli` (it's a client, not core). It currently lives as a `continuum-core` bin for fast iteration (precedent: `continuum-mcp`); migrating it to `apps/cli` is tracked, not blocking.
 
 ---
 
@@ -60,13 +60,13 @@ The Cargo workspace (root `Cargo.toml`) is the single source of build units. The
 **The one path:**
 
 ```bash
-cu start      # build (cargo, per-platform GPU features) + run the core detached, wait until it answers ping
-cu ping       # confirm
-cu stop       # stop the detached core (process-group SIGTERM)
+continuum start      # build (cargo, per-platform GPU features) + run the core detached, wait until it answers ping
+continuum ping       # confirm
+continuum stop       # stop the detached core (process-group SIGTERM)
 ```
 
-- `cu start` locates `tools/scripts/start-server.sh` (env `CONTINUUM_START_SCRIPT` override, else walk up from cwd), spawns it in its own session (`setsid`) so the core outlives the CLI, logs to `/tmp/continuum-core-start.log`, writes a pidfile, and polls `ping` until ready (or fails loud with the log tail). Idempotent.
-- `start-server.sh` is the **implementation detail**: pure-Rust `cargo run` with per-platform features (Darwin arm64 → `metal,accelerate`; Intel Mac → cpu-only; Linux/Windows → detected), airc context auto-discovered, builds core + mcp + cu. **No Node.**
+- `continuum start` locates `tools/scripts/start-server.sh` (env `CONTINUUM_START_SCRIPT` override, else walk up from cwd), spawns it in its own session (`setsid`) so the core outlives the CLI, logs to `/tmp/continuum-core-start.log`, writes a pidfile, and polls `ping` until ready (or fails loud with the log tail). Idempotent.
+- `start-server.sh` is the **implementation detail**: pure-Rust `cargo run` with per-platform features (Darwin arm64 → `metal,accelerate`; Intel Mac → cpu-only; Linux/Windows → detected), airc context auto-discovered, builds core + mcp + continuum. **No Node.**
 - `npm start` (root and `src/`) just calls `start-server.sh` — kept only as muscle-memory alias; it is not a Node orchestrator.
 
 **Forbidden:** a second start script; reintroducing `parallel-start.sh` (quarantined in `legacy/node-startup/`); any start step that blocks on a flaky external (model download, scene-gen) — those are separate, optional, and must degrade, never gate the core coming up.
@@ -83,7 +83,7 @@ Three layers, strictly separated by their dependency surface:
 |---|---|---|---|
 | **Unit + integration** | `cargo test -p continuum-core` | NONE (no airc/unsloth/models/network) | CI default — must be green |
 | **Stress / concurrency** | `cargo test --features stress-tests … stress` | in-process only | opt-in; sign-off + perf curves |
-| **Live smoke** | `cu start && cu ping && <persona turn>` | airc + a model | manual / scheduled; never the CI default |
+| **Live smoke** | `continuum start && continuum ping && <persona turn>` | airc + a model | manual / scheduled; never the CI default |
 
 Rules (extend, don't reinvent — these are the CLAUDE.md test rules, restated as foundation policy):
 - **Deterministic by default.** Anything depending on airc/unsloth/models/network is a *live smoke*, not a unit test. The persona→command path is proven deterministically (`cognition::tool_executor::…::persona_executes_ping_via_typed_object_path`) with no live deps — that is the pattern.
@@ -91,7 +91,7 @@ Rules (extend, don't reinvent — these are the CLAUDE.md test rules, restated a
 - **Every test names the invariant it guards** (`// what this catches:`), and regressions link the issue/commit.
 - **Shared cargo target.** Always `export CARGO_TARGET_DIR="$HOME/.continuum/cache/cargo-target"` for hand-run cargo so artifacts land in the one cache, not ghost `target/` dirs.
 
-The integration-smoke gap (`#22`: boot core + continuum-mcp smoke) is the next test investment: a scripted `cu start` → assert socket + `cu ping` + one persona turn, run on demand, so "did the wiring actually come up" is a one-command answer.
+The integration-smoke gap (`#22`: boot core + continuum-mcp smoke) is the next test investment: a scripted `continuum start` → assert socket + `continuum ping` + one persona turn, run on demand, so "did the wiring actually come up" is a one-command answer.
 
 ---
 
@@ -103,31 +103,31 @@ The Docker surface already exists and is the rollout unit:
 - **Per-unit Dockerfiles:** `docker/continuum-core.Dockerfile` (+`-cuda`, `-vulkan` for GPU backends), `docker/livekit-bridge.Dockerfile`, `docker/model-init.Dockerfile`, plus client images (`node-server`, `widget-server`).
 - **Build/push:** `scripts/ensure-docker.sh`, `scripts/push-current-arch.sh`, `scripts/push-image.sh` (`npm run docker:push*`).
 
-**Target shape (design, not all built):** each modular unit (§3) is one container image; a **continuum node** = `{ continuum-core + continuum-mcp + cu }` co-located, addressing the local core over its IPC socket, joining the grid over airc. A node is the **kubernetes rollout unit** — replicate nodes across the grid, each a citizen-host (`[[docker-personas-as-grid-peers]]`). unsloth is a sibling service addressed over `/v1`, scaled independently. Clients (task trays/web/mobile) are separate deployments consuming the grid through the SDK.
+**Target shape (design, not all built):** each modular unit (§3) is one container image; a **continuum node** = `{ continuum-core + continuum-mcp + continuum }` co-located, addressing the local core over its IPC socket, joining the grid over airc. A node is the **kubernetes rollout unit** — replicate nodes across the grid, each a citizen-host (`[[docker-personas-as-grid-peers]]`). unsloth is a sibling service addressed over `/v1`, scaled independently. Clients (task trays/web/mobile) are separate deployments consuming the grid through the SDK.
 
 **Addressing per topology** (`#23`, `#27`): in-node = IPC socket; cross-node = airc peer URI; the command/route layer already abstracts both (`COMMAND-ORGANIZATION.md` §"agnostic of machine and environment"). k8s service discovery maps onto airc peer discovery, not a parallel mechanism.
 
-**Open before this is real:** a single `node` compose profile that bundles core+mcp+cu cleanly; a k8s manifest/Helm chart per node; image addressing that doesn't assume localhost. These are the deliberate next steps, designed here before coded.
+**Open before this is real:** a single `node` compose profile that bundles core+mcp+continuum cleanly; a k8s manifest/Helm chart per node; image addressing that doesn't assume localhost. These are the deliberate next steps, designed here before coded.
 
 ---
 
 ## 7. The Node boundary (where it legitimately lives)
 
-Node/TS is **only** for building the web client SDK and the web/desktop apps that consume it (`client/`-and-`apps/`-level, leaf consumers, rebuilt anew on the uniform SDK per `[[old-web-client-is-reinvented-not-resurrected]]`). It is **never** in: core build, core start, core test, MCP, `cu`, the grid, or any Dockerfile for a foundation unit. The legacy `src/` Node tree and its `package.json` orchestration are being retired into clients-built-anew; until then, treat anything there as legacy, not the path.
+Node/TS is **only** for building the web client SDK and the web/desktop apps that consume it (`client/`-and-`apps/`-level, leaf consumers, rebuilt anew on the uniform SDK per `[[old-web-client-is-reinvented-not-resurrected]]`). It is **never** in: core build, core start, core test, MCP, `continuum`, the grid, or any Dockerfile for a foundation unit. The legacy `src/` Node tree and its `package.json` orchestration are being retired into clients-built-anew; until then, treat anything there as legacy, not the path.
 
 ---
 
 ## 8. Status & next slices
 
 **Done / live (this foundation pass):**
-- Pure-Rust startup via `cu start`/`stop`; legacy `parallel-start.sh` quarantined to `legacy/`; `.gitignore` corrected for the moved model path.
-- `cu` CLI = lifecycle + uniform client; `cu ping` green.
+- Pure-Rust startup via `continuum start`/`stop`; legacy `parallel-start.sh` quarantined to `legacy/`; `.gitignore` corrected for the moved model path.
+- `continuum` CLI = lifecycle + uniform client; `continuum ping` green.
 - Self-routing command infra (`DynCommand` + `ActionCommand`), persona executes through it (deterministic test **and** live: Asha reasons/recalls/replies on the clean build).
 
 **Next (design-first, in order):**
-1. **Live-smoke harness** (`#22`): scripted `cu start → ping → persona turn` assertion.
+1. **Live-smoke harness** (`#22`): scripted `continuum start → ping → persona turn` assertion.
 2. **unsloth `/v1/embeddings`** (`#40`): neural recall instead of lexical fallback.
-3. **`cu` → `apps/cli`** migration (unit boundary hygiene, §3).
+3. **`continuum` → `apps/cli`** migration (unit boundary hygiene, §3).
 4. **`node` compose profile + k8s manifest** (§6): the rollout unit, bundled and addressable.
 5. **Clients anew** (`#29`): task trays / web / mobile on the uniform SDK, as containers.
 

--- a/docs/architecture/HARNESS-RUNBOOK.md
+++ b/docs/architecture/HARNESS-RUNBOOK.md
@@ -37,11 +37,11 @@ tools/scripts/harness/cognition-cycle.sh --persona Asha --note "what I changed t
 That script (read its header — it is the authoritative procedure) does, idempotently,
 failing loud at the first missing precondition:
 
-1. resolves the `cu` client (prints the build command if absent),
+1. resolves the `continuum` client (prints the build command if absent),
 2. confirms the core answers `ping` on its IPC socket,
 3. resolves the persona by name or UUID (`cognition/personas`),
 4. snapshots every glass-box stream's length,
-5. runs `cu cognition/eval` (single-pass, or A/B with `--gene`),
+5. runs `continuum cognition/eval` (single-pass, or A/B with `--gene`),
 6. deltas the streams and collects *this run's* new capture lines,
 7. writes a timestamped report dir and prints the headline record.
 
@@ -55,11 +55,11 @@ spending any inference.
 export CARGO_TARGET_DIR="$HOME/.continuum/cache/cargo-target"   # the ONE shared cache
 # 1. build + run the headless core (pure Rust — never npm/jtag):
 bash tools/scripts/start-server.sh                              # binds /tmp/continuum-core.sock
-# 2. build the cu client once:
-cargo build --manifest-path core/continuum-core/Cargo.toml --bin cu --features metal,accelerate
+# 2. build the continuum client once:
+cargo build --manifest-path core/continuum-core/Cargo.toml --bin continuum --features metal,accelerate
 # 3. confirm a persona is online (they resume from disk at boot):
-$CARGO_TARGET_DIR/debug/cu cognition/personas
-#    none online? spawn one:  cu persona/instances/bootstrap
+$CARGO_TARGET_DIR/debug/continuum cognition/personas
+#    none online? spawn one:  continuum persona/instances/bootstrap
 ```
 
 ## The iteration loop (what "iterate here till it's pretty good" means)
@@ -151,7 +151,7 @@ glass box tells you *what*.** Always open the capture stream before theorizing.
 3. Read the most recent `~/.continuum/harness-runs/*/report.md`.
 4. Pick the top unaddressed lever above, change ONE variable, run the cycle, compare.
 5. The standing constraints (no fallbacks/fail-loud, no heuristics steering cognition,
-   Rust-only, validate via `cu` never npm/jtag) are in `CLAUDE.md` and the memory index.
+   Rust-only, validate via `continuum` never npm/jtag) are in `CLAUDE.md` and the memory index.
 
 ## Cross-references
 

--- a/docs/genome/DEV-TASK-LOOP-CLOSURE-PLAN.md
+++ b/docs/genome/DEV-TASK-LOOP-CLOSURE-PLAN.md
@@ -20,13 +20,13 @@ Keystone = end of L3: a real `lift > 0` produced by the persona's **own** dev wo
 
 Two senses, both used:
 - **Subject:** the persona does dev tasks; its measured `lift` on the `coder-eval.jsonl` gym (`gym_grader`, rustc exit-0 — no prose-matching) is the loop's integration test.
-- **QA agent:** for each new verb (`forge/publish`, `web/fetch`, `genome/recall`) ask the persona over airc/`cu` to use it and report confusing errors → fix error/help text before commit (CLAUDE.md AI-QA doctrine).
+- **QA agent:** for each new verb (`forge/publish`, `web/fetch`, `genome/recall`) ask the persona over airc/`continuum` to use it and report confusing errors → fix error/help text before commit (CLAUDE.md AI-QA doctrine).
 
-Glass box: `~/.continuum/fixtures/prompt-captures/<persona>.jsonl` (per-iteration tool decisions), `~/.continuum/progress/<persona>.jsonl` (lift trend), recorder fixtures. One variable at a time. Validate via pure Rust + `cu` only — never `npm start`/`./jtag`.
+Glass box: `~/.continuum/fixtures/prompt-captures/<persona>.jsonl` (per-iteration tool decisions), `~/.continuum/progress/<persona>.jsonl` (lift trend), recorder fixtures. One variable at a time. Validate via pure Rust + `continuum` only — never `npm start`/`./jtag`.
 
 ## Phase 0 — Persona ground-truth (QA baseline, before any build)
 
-Boot the headless Rust core with **`cu start`** (it owns the per-platform build flags via `start-server.sh` — the operator never types `--features …`), one llama-server lane, single core process. Run Asha on the embedded `coder-eval.jsonl` gym via `cu cognition/eval --persona_id <id> --note baseline`. Capture: pass rate; **what tools she is offered**; **whether she calls `code/run`/`cargo` to self-verify (`acts` count)**. Resolves the contradiction between the hands audit (`code/run` is a registered AiSafe ActionCommand → a Trusted local persona should be offered it) and the baseline note (`acts=0` on 29/30). If offered-but-unused → operational-genome gap the loop fixes. If not-offered → registry consolidation (#62) jumps the queue.
+Boot the headless Rust core with **`continuum start`** (it owns the per-platform build flags via `start-server.sh` — the operator never types `--features …`), one llama-server lane, single core process. Run Asha on the embedded `coder-eval.jsonl` gym via `continuum cognition/eval --persona_id <id> --note baseline`. Capture: pass rate; **what tools she is offered**; **whether she calls `code/run`/`cargo` to self-verify (`acts` count)**. Resolves the contradiction between the hands audit (`code/run` is a registered AiSafe ActionCommand → a Trusted local persona should be offered it) and the baseline note (`acts=0` on 29/30). If offered-but-unused → operational-genome gap the loop fixes. If not-offered → registry consolidation (#62) jumps the queue.
 **Gate:** committed baseline row (pass rate, offered-tool list, acts).
 
 **RESULT (2026-06-30, persona `0d3209a1`, committed to `~/.continuum/progress/0d3209a1….jsonl`):**
@@ -85,4 +85,4 @@ L1→L2→L3 = single-machine automatic loop (core of #35/#36). L4→L5 = shared
 
 ## Discipline
 
-Pure-Rust + `cu` validation (never npm/jtag); `export CARGO_TARGET_DIR=…` then `df -h /` after each cargo cycle; prefer `cargo check`; fail-loud at every gate (negative lift never silently adopts); one `#[cfg(test)] mod tests` per file with `// what this catches:`; sentinels follow CONCURRENCY-STYLE-GUIDE; feature-branch commit per validated layer; merge to main only on Joel's approval.
+Pure-Rust + `continuum` validation (never npm/jtag); `export CARGO_TARGET_DIR=…` then `df -h /` after each cargo cycle; prefer `cargo check`; fail-loud at every gate (negative lift never silently adopts); one `#[cfg(test)] mod tests` per file with `// what this catches:`; sentinels follow CONCURRENCY-STYLE-GUIDE; feature-branch commit per validated layer; merge to main only on Joel's approval.

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -22,5 +22,5 @@ nothing to do with the substrate.
 **Replacement:** `tools/scripts/start-server.sh` — the pure-Rust headless start
 (`cargo run` the `continuum-core-server` directly, per-platform GPU features, no
 Node). Both root and `src/` `package.json` `start` now point at it. Talk to the
-running core with the Rust **`cu`** client (`cu ping`, …) — the replacement for
+running core with the Rust **`continuum`** client (`continuum ping`, …) — the replacement for
 the Node `./jtag`.

--- a/protocol/typescript/system/SystemInfoResult.ts
+++ b/protocol/typescript/system/SystemInfoResult.ts
@@ -10,6 +10,6 @@ export type SystemInfoResult = {
  */
 version: string, 
 /**
- * OS process id of the running core — handy for ops (`cu stop` targets it).
+ * OS process id of the running core — handy for ops (`continuum stop` targets it).
  */
 pid: number, };

--- a/scripts/dev/measure-persona.sh
+++ b/scripts/dev/measure-persona.sh
@@ -24,7 +24,7 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-CU="$HOME/.continuum/cache/cargo-target/debug/cu"
+CU="$HOME/.continuum/cache/cargo-target/debug/continuum"
 WORK="$HOME/.continuum/measure"
 BASELINE="$REPO/scripts/dev/measure-baseline.json"
 MODEL="${MODEL:-continuum-ai/qwen2.5-coder-14b-instruct-GGUF}"
@@ -42,7 +42,7 @@ for arg in "$@"; do
 done
 
 die() { echo "FAIL: $*" >&2; exit 1; }
-[ -x "$CU" ] || die "cu not built at $CU (run: cu start)"
+[ -x "$CU" ] || die "continuum not built at $CU (run: continuum start)"
 
 # --- (1) self-clean: wipe our own workspace at the start of every run ---
 rm -rf "$WORK"; mkdir -p "$WORK"
@@ -50,15 +50,15 @@ echo "workspace: $WORK (wiped clean)"
 
 # --- (2) build + boot exactly ONE fresh server ---
 if [ "$DO_REBOOT" = 1 ]; then
-  echo "rebuilding + rebooting core (cu reboot)…"
-  "$CU" reboot >"$WORK/reboot.log" 2>&1 || { tail -30 "$WORK/reboot.log" >&2; die "cu reboot failed"; }
+  echo "rebuilding + rebooting core (continuum reboot)…"
+  "$CU" reboot >"$WORK/reboot.log" 2>&1 || { tail -30 "$WORK/reboot.log" >&2; die "continuum reboot failed"; }
 fi
 # BSD pgrep has no -c; count with wc. One core is required; >1 means a stale
 # server is racing this measurement — fail loud rather than measure a coin flip.
 CORES=$(pgrep -f 'continuum-core' | wc -l | tr -d ' ')
 LLAMAS=$(pgrep -f 'llama-server' | wc -l | tr -d ' ')
 echo "processes: core=${CORES} llama-server=${LLAMAS}"
-[ "$CORES" -ge 1 ] || die "no continuum-core process running (run: cu start)"
+[ "$CORES" -ge 1 ] || die "no continuum-core process running (run: continuum start)"
 [ "$CORES" -le 1 ] || die "$CORES continuum-core processes running — kill the stragglers; the harness measures ONE"
 "$CU" ping >/dev/null 2>&1 || die "core not responding to ping after boot"
 

--- a/scripts/dev/replay-turn.sh
+++ b/scripts/dev/replay-turn.sh
@@ -27,7 +27,7 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-CU="$HOME/.continuum/cache/cargo-target/debug/cu"
+CU="$HOME/.continuum/cache/cargo-target/debug/continuum"
 CAPDIR="$HOME/.continuum/fixtures/prompt-captures"
 WORK="$HOME/.continuum/replay"
 MODEL="${MODEL:-continuum-ai/qwen2.5-coder-14b-instruct-GGUF}"
@@ -48,14 +48,14 @@ while [ $# -gt 0 ]; do
 done
 
 die() { echo "FAIL: $*" >&2; exit 1; }
-[ -x "$CU" ] || die "cu not built at $CU (run: cu start)"
+[ -x "$CU" ] || die "continuum not built at $CU (run: continuum start)"
 
 # --- self-clean workspace ---
 rm -rf "$WORK"; mkdir -p "$WORK"
 
 # --- process guard: measure exactly ONE core (no coin-flip readings) ---
 CORES=$(pgrep -f 'continuum-core' | wc -l | tr -d ' ')
-[ "$CORES" -eq 1 ] || die "$CORES continuum-core processes — need exactly 1 (run: cu start / kill stragglers)"
+[ "$CORES" -eq 1 ] || die "$CORES continuum-core processes — need exactly 1 (run: continuum start / kill stragglers)"
 "$CU" ping >/dev/null 2>&1 || die "core not responding to ping"
 
 # --- pick the capture file ---

--- a/skills/memory/SKILL.md
+++ b/skills/memory/SKILL.md
@@ -18,13 +18,13 @@ cross-context, …). This skill is hands; the cognition is the core's.
 
 ## Prerequisite: the core is running
 
-`cu` dispatches to the running `continuum-core-server`. Verify once:
+`continuum` dispatches to the running `continuum-core-server`. Verify once:
 
 ```bash
-cu ping >/dev/null 2>&1 || { echo "continuum-core not running — start it (install.ps1 / npm start), then retry"; }
+continuum ping >/dev/null 2>&1 || { echo "continuum-core not running — start it (install.ps1 / npm start), then retry"; }
 ```
 
-If `cu` isn't found, Continuum isn't installed on this machine — that's the install lane, not this skill.
+If `continuum` isn't found, Continuum isn't installed on this machine — that's the install lane, not this skill.
 
 ## Identity: your real citizen id (never anonymous)
 
@@ -63,14 +63,14 @@ worth surviving amnesia. Content convention (mirrors the file-memory discipline)
 <the fact>. Why: <why it's load-bearing>. How to apply: <what to do with it>.
 ```
 
-Write it (append is **Privileged** — see ACL below; authorized here because `cu` is the
+Write it (append is **Privileged** — see ACL below; authorized here because `continuum` is the
 local core IPC on the owner's machine):
 
 ```bash
 now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 id="mem-$(date +%s)-$RANDOM"
 proj="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
-cu memory/append-memory --persona_id "$PID" --memory "$(cat <<JSON
+continuum memory/append-memory --persona_id "$PID" --memory "$(cat <<JSON
 {"record":{"id":"$id","persona_id":"$PID","memory_type":"agent-insight",
 "content":"CRT on windows-msvc must match libwebrtc's /MT. Why: livekit ships a prebuilt /MT webrtc.lib; a /MD object is a hard LNK2038. How to apply: set +crt-static + CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded.",
 "context":{},"timestamp":"$now","importance":0.8,"access_count":0,
@@ -91,7 +91,7 @@ Guidance for a GOOD memory:
 Query at the START of work on a topic (before re-deriving what you already learned):
 
 ```bash
-cu memory/multi-layer-recall --persona_id "$PID" --query_text "windows cuda build crt" \
+continuum memory/multi-layer-recall --persona_id "$PID" --query_text "windows cuda build crt" \
   --room_id "agent-memory" --max_results 8
 ```
 
@@ -109,7 +109,7 @@ carries `content`, `source`, `timestamp`, `importance`, and (semantic hits) `rel
 
 `memory/append-memory` is **`Privileged`** (writes to a citizen's corpus), while
 `memory/multi-layer-recall` is `AiSafe` (read). The authorized route for the write:
-`cu` dispatches over the **local core IPC** as the machine owner, which carries the
+`continuum` dispatches over the **local core IPC** as the machine owner, which carries the
 Privileged ceiling. A remote/unauthenticated TCP caller is stamped non-Owner and would
 be refused — so this skill's writes only succeed from a local agent on the owner's box.
 Do not attempt to write another citizen's `persona_id`; scope to your own (`$PID`).

--- a/tools/plugins/.claude-plugin/marketplace.json
+++ b/tools/plugins/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "continuum-local-tools",
+  "owner": {
+    "name": "Continuum"
+  },
+  "plugins": [
+    {
+      "name": "memory-bridge",
+      "source": "./memory-bridge",
+      "description": "Agent memory bridge — semantic relevance-recall at session start (incl. after compaction) plus /remember and /recall, backed by the continuum memory/* substrate. Stops the agent re-forgetting across amnesia resets."
+    }
+  ]
+}

--- a/tools/plugins/memory-bridge/scripts/lib.sh
+++ b/tools/plugins/memory-bridge/scripts/lib.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# lib.sh — shared helpers for the memory-bridge hooks/skills. Sourced, not run.
+#
+# ONE place to resolve the continuum CLI (compression principle): the binary is
+# named `continuum` (NOT `cu` — that collides with the Unix UUCP tool on every
+# mac/linux box, which silently shadowed it and made the whole bridge a no-op).
+# It also may not be on PATH — the dev deploy builds into the shared cargo target
+# under ~/.continuum, and install may not have symlinked it. Resolution order:
+#   1. $CONTINUUM_BIN override (a runtime can pin the exact binary)
+#   2. `continuum` on PATH (once install symlinks it, this wins)
+#   3. known cargo-target build dirs — release first, then debug (the dev default)
+# Prints the resolved path on stdout and returns 0, or returns 1 if not found.
+
+resolve_continuum() {
+  if [ -n "${CONTINUUM_BIN:-}" ] && [ -x "${CONTINUUM_BIN}" ]; then
+    printf '%s' "${CONTINUUM_BIN}"
+    return 0
+  fi
+  if command -v continuum >/dev/null 2>&1; then
+    command -v continuum
+    return 0
+  fi
+  local target="${CARGO_TARGET_DIR:-$HOME/.continuum/cache/cargo-target}"
+  local candidate
+  for candidate in "$target/release/continuum" "$target/debug/continuum"; do
+    if [ -x "$candidate" ]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Resolve the agent's persona id (its airc peer id). $CONTINUUM_AGENT_PERSONA wins
+# (lets a runtime pin identity); else derive from `airc status`. Prints it or nothing.
+resolve_agent_persona() {
+  if [ -n "${CONTINUUM_AGENT_PERSONA:-}" ]; then
+    printf '%s' "${CONTINUUM_AGENT_PERSONA}"
+    return 0
+  fi
+  airc status 2>/dev/null | awk '/^peer_id:/{print $2; exit}'
+}

--- a/tools/plugins/memory-bridge/scripts/recall.sh
+++ b/tools/plugins/memory-bridge/scripts/recall.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
-# recall.sh — explicit memory search via cu (backs the /recall skill).
+# recall.sh — explicit memory search via the continuum CLI (backs the /recall skill).
 # Prints the recalled lessons' content, most-relevant first.
 set -uo pipefail
 
 QUERY="${*:-}"
 [ -n "$QUERY" ] || { echo "recall: provide a query" >&2; exit 1; }
-command -v cu >/dev/null 2>&1 || { echo "recall: 'cu' not on PATH (is continuum-core-server installed?)" >&2; exit 1; }
 
-PERSONA="${CONTINUUM_AGENT_PERSONA:-$(airc status 2>/dev/null | awk '/^peer_id:/{print $2; exit}')}"
+# Resolve the continuum CLI robustly (NOT bare `cu` — collides with Unix UUCP).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib.sh"
+CONTINUUM="$(resolve_continuum)" || { echo "recall: 'continuum' CLI not found (build the core, or set CONTINUUM_BIN)" >&2; exit 1; }
+
+PERSONA="$(resolve_agent_persona)"
 [ -n "${PERSONA:-}" ] || { echo "recall: could not resolve agent persona (airc peer id)" >&2; exit 1; }
 SCOPE="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
 
-OUT="$(cu memory/multi-layer-recall --persona_id "$PERSONA" --query_text "$QUERY" --room_id "$SCOPE" --max_results 8 2>/dev/null || true)"
+OUT="$("$CONTINUUM" memory/multi-layer-recall --persona_id "$PERSONA" --query_text "$QUERY" --room_id "$SCOPE" --max_results 8 2>/dev/null || true)"
 LINES="$(printf '%s' "$OUT" | grep -aE '"content"' | sed -E 's/.*"content": *"(.*)"[,]?[[:space:]]*$/- \1/')"
 if [ -n "$LINES" ]; then
   printf '%s\n' "$LINES"

--- a/tools/plugins/memory-bridge/scripts/remember.sh
+++ b/tools/plugins/memory-bridge/scripts/remember.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# remember.sh — store a durable lesson in the agent's corpus via cu.
+# remember.sh — store a durable lesson in the agent's corpus via the continuum CLI.
 #
 # Usage: remember.sh "<lesson text>" ["tag1,tag2"]
 #
@@ -14,15 +14,20 @@ set -uo pipefail
 
 CONTENT="${1:-}"
 [ -n "$CONTENT" ] || { echo "remember: nothing to store (usage: remember \"lesson\" [tags])" >&2; exit 1; }
-command -v cu >/dev/null 2>&1 || { echo "remember: 'cu' not on PATH (is continuum-core-server installed?)" >&2; exit 1; }
 
-PERSONA="${CONTINUUM_AGENT_PERSONA:-$(airc status 2>/dev/null | awk '/^peer_id:/{print $2; exit}')}"
+# Resolve the continuum CLI robustly (NOT bare `cu` — collides with Unix UUCP).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib.sh"
+CONTINUUM="$(resolve_continuum)" || { echo "remember: 'continuum' CLI not found (build the core, or set CONTINUUM_BIN)" >&2; exit 1; }
+
+PERSONA="$(resolve_agent_persona)"
 [ -n "${PERSONA:-}" ] || { echo "remember: could not resolve agent persona (airc peer id)" >&2; exit 1; }
 SCOPE="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
 
-if cu memory/remember --persona_id "$PERSONA" --content "$CONTENT" --scope "$SCOPE" 2>/dev/null | grep -q '"appended"\|"remembered"\|"id"'; then
+if "$CONTINUUM" memory/remember --persona_id "$PERSONA" --content "$CONTENT" --scope "$SCOPE" 2>/dev/null | grep -q '"appended"\|"remembered"\|"id"'; then
   echo "remembered (scope: $SCOPE): ${CONTENT:0:80}"
 else
-  echo "remember: cu memory/remember failed (is the server up? try: cu ping)" >&2
+  echo "remember: continuum memory/remember failed (is the server up? try: continuum ping)" >&2
   exit 1
 fi

--- a/tools/plugins/memory-bridge/scripts/session-recall.sh
+++ b/tools/plugins/memory-bridge/scripts/session-recall.sh
@@ -12,22 +12,26 @@
 #
 # The envelope JSON is built ENTIRELY by the substrate (serde, via
 # `memory/recall-hook`) — NO shell JSON, no jq/python. This script only resolves
-# persona + scope and passes the command's stdout straight through.
+# the continuum binary + persona + scope and passes the command's stdout through.
 set -uo pipefail
 
 cat >/dev/null 2>&1 || true              # drain the hook's stdin payload
-command -v cu >/dev/null 2>&1 || exit 0  # no client → silent no-op
+
+# Resolve the continuum CLI robustly (NOT bare `cu` — that is the Unix UUCP tool,
+# which shadowed us on PATH and silently no-op'd the whole bridge).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib.sh"
+CONTINUUM="$(resolve_continuum)" || exit 0   # no continuum binary → silent no-op
 
 # Scope recall to the current project (git repo root) when in one, else cwd.
 SCOPE_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 PROJECT="$(basename "$SCOPE_DIR")"
 
-# The agent's own persona_id = its airc peer id (M5's convention). Env override
-# wins (lets a runtime pin its identity); else derive from `airc status`.
-PERSONA="${CONTINUUM_AGENT_PERSONA:-$(airc status 2>/dev/null | awk '/^peer_id:/{print $2; exit}')}"
+PERSONA="$(resolve_agent_persona)"
 [ -n "${PERSONA:-}" ] || exit 0
 
 # `memory/recall-hook` returns the EXACT {"hookSpecificOutput":{...}} envelope via
 # serde (valid, escaped, empty-safe). Pass it straight through. Any failure → nothing.
-cu memory/recall-hook --persona_id "$PERSONA" --room_id "$PROJECT" --query_text "$PROJECT session context" 2>/dev/null || true
+"$CONTINUUM" memory/recall-hook --persona_id "$PERSONA" --room_id "$PROJECT" --query_text "$PROJECT session context" 2>/dev/null || true
 exit 0

--- a/tools/plugins/memory-bridge/skills/recall/SKILL.md
+++ b/tools/plugins/memory-bridge/skills/recall/SKILL.md
@@ -15,7 +15,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/recall.sh "$ARGUMENTS"
 ```
 
 The script runs the substrate's 6-layer relevance recall (recency / semantic /
-importance / cross-context …) via `cu memory/multi-layer-recall`, scoped to the
+importance / cross-context …) via `continuum memory/multi-layer-recall`, scoped to the
 current project, and prints the matching lessons most-relevant-first.
 
 `disable-model-invocation: true` — explicit lookup only. Automatic session-start

--- a/tools/plugins/memory-bridge/skills/remember/SKILL.md
+++ b/tools/plugins/memory-bridge/skills/remember/SKILL.md
@@ -15,7 +15,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/remember.sh "$ARGUMENTS"
 
 The script resolves the agent's persona (its airc peer id), scopes to the current
 project, and writes the lesson to the shared continuum corpus via
-`cu memory/append-memory`. Confirm to the user in one line what was remembered.
+`continuum memory/append-memory`. Confirm to the user in one line what was remembered.
 
 Good lessons name the invariant/version/correction concretely ("use CUDA 13.2 not
 12.9 for VS2026", not "fix the build"). Other agents (M5, Codex) recall from the same

--- a/tools/scripts/harness/cognition-cycle.sh
+++ b/tools/scripts/harness/cognition-cycle.sh
@@ -8,11 +8,11 @@
 # read the runbook, then run THIS. It does, in order, idempotently and failing
 # loud at the first missing precondition:
 #
-#   1. resolve the `cu` client (build hint if absent)
-#   2. confirm the headless core is up on its IPC socket   (cu ping)
+#   1. resolve the `continuum` client (build hint if absent)
+#   2. confirm the headless core is up on its IPC socket   (continuum ping)
 #   3. resolve the target persona (by name or uuid)        (cognition/personas)
 #   4. snapshot every glass-box capture stream's length BEFORE the run
-#   5. run `cu cognition/eval` (single-pass, or A/B with --gene)
+#   5. run `continuum cognition/eval` (single-pass, or A/B with --gene)
 #   6. delta the capture streams; collect THIS run's new lines
 #   7. write a timestamped report dir + print the headline VDD-shaped record
 #
@@ -20,8 +20,8 @@
 # degrades the living citizen. Safe to run against a live, working core.
 #
 # Doctrine honored: no fallbacks — every missing precondition fails loud naming the
-# cause + the fix (`cu` returns rc=0 even on substrate refusal, so we parse output,
-# never trust $?). Pure-Rust core + cu only; never npm/jtag.
+# cause + the fix (`continuum` returns rc=0 even on substrate refusal, so we parse output,
+# never trust $?). Pure-Rust core + continuum only; never npm/jtag.
 #
 # Usage:
 #   cognition-cycle.sh [--persona NAME|UUID] [--eval-set PATH] [--note LABEL]
@@ -74,16 +74,16 @@ need() { command -v "$1" >/dev/null || die "missing '$1' on PATH — $2"; }
 
 need jq "install with: brew install jq"
 
-# ---- 1. resolve cu -----------------------------------------------------------
-CU="$TARGET_DIR/debug/cu"
-[[ -x "$CU" ]] || CU="$TARGET_DIR/release/cu"
-[[ -x "$CU" ]] || die "cu client not built. Build it:
+# ---- 1. resolve continuum -----------------------------------------------------------
+CU="$TARGET_DIR/debug/continuum"
+[[ -x "$CU" ]] || CU="$TARGET_DIR/release/continuum"
+[[ -x "$CU" ]] || die "continuum client not built. Build it:
     export CARGO_TARGET_DIR=\"$TARGET_DIR\"
-    cargo build --manifest-path core/continuum-core/Cargo.toml --bin cu --features metal,accelerate"
+    cargo build --manifest-path core/continuum-core/Cargo.toml --bin continuum --features metal,accelerate"
 export CONTINUUM_CORE_SOCKET="$SOCKET"
 
-# cu_json CMD [ARGS...] — run a cu command, return stdout. Fail loud if the
-# substrate refused (cu prints to stderr + still exits 0, so we sniff the text).
+# cu_json CMD [ARGS...] — run a continuum command, return stdout. Fail loud if the
+# substrate refused (continuum prints to stderr + still exits 0, so we sniff the text).
 # A genuine result is always valid JSON; a refusal is plain stderr text. So the
 # refusal sniff runs ONLY when the output does not parse as JSON — otherwise a
 # legitimate eval payload whose answer text happens to contain "FAIL"/"error:"
@@ -93,7 +93,7 @@ cu_json() {
   out="$("$CU" "$@" 2>&1)" || true
   if ! jq -e . >/dev/null 2>&1 <<<"$out"; then
     if grep -qiE "substrate refused|Unknown command|FAIL|error:" <<<"$out"; then
-      die "cu $* refused:
+      die "continuum $* refused:
 $out"
     fi
   fi

--- a/tools/scripts/install.sh
+++ b/tools/scripts/install.sh
@@ -741,7 +741,7 @@ if command -v tailscale &>/dev/null; then
 fi
 echo ""
 echo -e "  ${YELLOW}Start:${NC}  npm start"
-echo -e "  ${YELLOW}Test:${NC}   cu ping"
+echo -e "  ${YELLOW}Test:${NC}   continuum ping"
 echo -e "  ${YELLOW}Config:${NC} $CONFIG_FILE"
 echo ""
 

--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -52,7 +52,7 @@ fi
 
 # ── Single-owner build target ────────────────────────────────────────
 # This script is the ONE start path ([[validate-via-pure-rust-not-npm-jtag]]).
-# It must therefore own CARGO_TARGET_DIR so every `cu start` — no matter which
+# It must therefore own CARGO_TARGET_DIR so every `continuum start` — no matter which
 # shell or background task invokes it — builds into and runs from the SAME
 # binary. Without this, a shell that lacks the export builds a 396MB ghost into
 # the repo's ./target while another shell ran from ~/.continuum/cache, leaving
@@ -242,13 +242,13 @@ echo "▶ building continuum-mcp (Rust MCP server bin)"
 cargo build --manifest-path "$CORE_MANIFEST" --bin continuum-mcp $PROFILE_FLAG $CONTINUUM_FEATURES \
   || echo "⚠ continuum-mcp build failed — MCP server unavailable (core still launches)" >&2
 
-# ── Build the cu CLI client ──────────────────────────────────────────
-# `cu` is the pure-Rust CLI client (replaces the Node `./jtag`): `cu ping`,
-# `cu <command> [json]` over the core IPC socket via the uniform Connection.
+# ── Build the continuum CLI client ──────────────────────────────────────────
+# `continuum` is the pure-Rust CLI client (replaces the Node `./jtag`): `continuum ping`,
+# `continuum <command> [json]` over the core IPC socket via the uniform Connection.
 # Built here so the headless start produces the client on disk too.
-echo "▶ building cu (Rust CLI client)"
-cargo build --manifest-path "$CORE_MANIFEST" --bin cu $PROFILE_FLAG $CONTINUUM_FEATURES \
-  || echo "⚠ cu build failed — CLI client unavailable (core still launches)" >&2
+echo "▶ building continuum (Rust CLI client)"
+cargo build --manifest-path "$CORE_MANIFEST" --bin continuum $PROFILE_FLAG $CONTINUUM_FEATURES \
+  || echo "⚠ continuum build failed — CLI client unavailable (core still launches)" >&2
 
 # ── Build the forge-custodian sidecar ────────────────────────────────
 # Like continuum-mcp, this bin is SPAWNED by the core (not launched by us): the


### PR DESCRIPTION
## Why
`cu` is `/usr/bin/cu` — the 40-year-old Unix **UUCP** serial tool, present on every mac/linux box. Continuum's `cu` was never installed onto PATH, so bare `cu` resolved to UUCP, which **silently shadowed** us. The memory-bridge plugin calls the CLI by name; against UUCP it no-ops silently — a memory system that installs green and recalls nothing (the exact *"reliability is it-works, not that it reports failure well"* trap). Fix: stop colliding — name the binary `continuum`, consistent with `continuum-core-server` / `continuum-mcp`.

## Changes
- Cargo.toml `[[bin]]` `cu` → `continuum`; `git mv src/bin/cu.rs → continuum.rs`.
- Binary self-refs (usage/help/comments) + all `cu <cmd>` docs/scripts swept to `continuum` (word-boundary safe — `cuda`/`cu128`/`cu-gym` untouched).
- `start-server.sh` builds `--bin continuum`.
- memory-bridge plugin: new shared `scripts/lib.sh` → `resolve_continuum()` (via `$CONTINUUM_BIN` → PATH `continuum` → known cargo-target build dirs, **never** bare `cu`). Fixes the not-on-PATH gap too (dev deploy builds into `~/.continuum`, not a PATH dir).
- Added `tools/plugins/.claude-plugin/marketplace.json` so the plugin is installable.

## Validated
- `continuum deploy-verify` runs (correctly reports the running core is behind this branch — the #2009 fix working).
- `recall.sh` resolves `continuum` and runs the full recall pipeline with **zero collision** (empty result = corpus not yet migrated, not an error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)