### PR TITLE
chore(plugin): add marketplace description — clear the validate warning

### DIFF
--- a/tools/plugins/.claude-plugin/marketplace.json
+++ b/tools/plugins/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "continuum-local-tools",
+  "description": "Continuum's local Claude Code plugins — agent-facing bridges into the continuum substrate (memory recall/remember, and more as they land).",
   "owner": {
     "name": "Continuum"
   },


### PR DESCRIPTION
Clears the `claude plugin validate` warning so the continuum-local-tools marketplace manifest validates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)