### PR TITLE
fix(memory): per-bullet length cap in recall-hook (length-bound anti-flood, pairs with compact-source count-bound)

### DIFF
--- a/core/continuum-core/src/commands/memory/recall_hook.rs
+++ b/core/continuum-core/src/commands/memory/recall_hook.rs
@@ -35,6 +35,24 @@ fn default_header() -> String {
     "## Relevant memories".to_string()
 }
 
+fn default_max_chars_per_memory() -> usize {
+    400
+}
+
+/// Cap one recalled memory's rendered text to `max_chars` (0 = no cap), truncating on a
+/// char boundary and appending `…`. The per-bullet complement to the caller's total budget:
+/// a low `max_results` still floods if each memory is a verbose multi-KB body, so bound the
+/// length too — critical for the `compact` source, where re-injection must not refill the
+/// context compaction just freed.
+fn cap_memory_text(text: &str, max_chars: usize) -> String {
+    let text = text.trim();
+    if max_chars == 0 || text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let truncated: String = text.chars().take(max_chars).collect();
+    format!("{}…", truncated.trim_end())
+}
+
 /// Params for `memory/recall-hook`. Mirror of `memory/multi-layer-recall`'s recall inputs
 /// (so the projection is 1:1) plus the markdown `header` for the injected block.
 #[derive(Debug, Clone, Serialize, Deserialize, TS, JsonSchema)]
@@ -58,6 +76,11 @@ pub struct MemoryRecallHookParams {
     /// Markdown header for the injected block.
     #[serde(default = "default_header")]
     pub header: String,
+    /// Cap on each recalled memory's rendered length (chars; 0 = uncapped). Bounds a
+    /// verbose memory so a low `max_results` still can't flood — the per-bullet complement
+    /// to the caller's total-char budget. Default 400.
+    #[serde(default = "default_max_chars_per_memory")]
+    pub max_chars_per_memory: usize,
 }
 
 /// The Claude Code SessionStart hook output envelope. Field names are the CC contract
@@ -132,7 +155,7 @@ crate::action_command! {
             let mut ctx = p.header.clone();
             for m in &resp.memories {
                 ctx.push_str("\n- ");
-                ctx.push_str(m.content.trim());
+                ctx.push_str(&cap_memory_text(&m.content, p.max_chars_per_memory));
             }
             ctx
         };
@@ -179,5 +202,24 @@ mod tests {
         // Round-trips back to the same struct.
         let back: SessionStartHookOutput = serde_json::from_str(&json).unwrap();
         assert_eq!(back.hook_specific_output.hook_event_name, "SessionStart");
+    }
+
+    // what this catches: a verbose memory is bounded to the per-bullet cap (on a char
+    // boundary, ellipsized) so low max_results × long content can't flood a post-compact
+    // re-injection; a short memory and cap=0 pass through untouched. Multi-byte safe.
+    #[test]
+    fn cap_memory_text_bounds_verbose_and_passes_short() {
+        let long = "x".repeat(1000);
+        let capped = cap_memory_text(&long, 400);
+        assert_eq!(capped.chars().count(), 401, "400 chars + the … ellipsis");
+        assert!(capped.ends_with('…'));
+        // short memory: untouched (just trimmed), no ellipsis
+        assert_eq!(cap_memory_text("  brief lesson  ", 400), "brief lesson");
+        // cap = 0 ⇒ uncapped
+        assert_eq!(cap_memory_text(&long, 0), long);
+        // multi-byte content truncates on a char boundary without panicking
+        let emoji = "🧠".repeat(10);
+        let c = cap_memory_text(&emoji, 4);
+        assert!(c.starts_with("🧠🧠🧠🧠") && c.ends_with('…'));
     }
 }

--- a/protocol/typescript/memory/MemoryRecallHookParams.ts
+++ b/protocol/typescript/memory/MemoryRecallHookParams.ts
@@ -25,4 +25,10 @@ max_results: number,
 /**
  * Markdown header for the injected block.
  */
-header: string, };
+header: string, 
+/**
+ * Cap on each recalled memory's rendered length (chars; 0 = uncapped). Bounds a
+ * verbose memory so a low `max_results` still can't flood — the per-bullet complement
+ * to the caller's total-char budget. Default 400.
+ */
+max_chars_per_memory: number, };


### PR DESCRIPTION
Pairs with the merged compact-source count-bound tuning. Caps each recalled memory's rendered length (`max_chars_per_memory`, default 400, char-boundary + ellipsis) so a verbose corpus can't flood a post-compact re-injection even at low `max_results`. Found by dogfooding a real 372-memory corpus (44K-char injection). Unit-tested + binding regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)