### PR TITLE
fix(install): win Mod-BuildCore builds `continuum`, not the renamed-away `cu` bin

### DIFF
--- a/tools/scripts/lib/win-modules.ps1
+++ b/tools/scripts/lib/win-modules.ps1
@@ -469,11 +469,13 @@ function Mod-BuildCore {
     Push-Location $core
     try {
         # Runs as the invoking user (NOT via gsudo) so the cache stays user-owned.
-        # Build BOTH the serving binary AND `cu` (the CLI the user + agents drive
-        # the core with -- `cu ping`, `cu memory/*`, etc.). An install that ships
-        # the server but not its CLI is only half a product.
+        # Build BOTH the serving binary AND `continuum` (the CLI the user + agents
+        # drive the core with -- `continuum ping`, `continuum memory/*`, etc.). An
+        # install that ships the server but not its CLI is only half a product.
+        # (The CLI bin was `cu`; renamed to `continuum` in #2010 to kill the Unix
+        # UUCP `cu` collision -- keep this arg in lockstep with the [[bin]] name.)
         $buildArgs = @('build', '-p', 'continuum-core',
-            '--bin', 'continuum-core-server', '--bin', 'cu',
+            '--bin', 'continuum-core-server', '--bin', 'continuum',
             '--release', '--features', $features)
         & cargo @buildArgs
         $code = $LASTEXITCODE


### PR DESCRIPTION
## Why
`#2010` renamed the CLI bin `cu` → `continuum` (UUCP collision) and moved the source to `src/bin/continuum.rs`. The Windows installer's `Mod-BuildCore` still passed `--bin cu`, so a **fresh `install.ps1` on Windows would fail the build** on a nonexistent target — shipping the server without its CLI, or failing outright.

## Fix
Point the build args at `--bin continuum`; add a note tying the arg to the `[[bin]]` name so the next rename catches it here too.

Manifest + `install-manifest.toml` were already clean — the stale ref was isolated to this one `Mod-BuildCore` build-args line. No `cu.exe` copy step exists, so this is the complete drift fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)