### PR TITLE
feat: system-aware model catalog — SystemProfile + PlacementPlanner + MoE-paged K3 on-ramp (slice 1 of #19)

### DIFF
--- a/core/continuum-core/src/capacity/mod.rs
+++ b/core/continuum-core/src/capacity/mod.rs
@@ -31,6 +31,9 @@ pub mod recursion_depth;
 pub mod residency_detect;
 pub mod score;
 pub mod sim;
+pub mod system_profile;
+
+pub use system_profile::{DriveInfo, DriveRole, SystemProfile};
 
 /// A LIVE reading of one device's usable compute, external consumers already subtracted.
 /// NOT a boot classification — re-taken continuously. `gpu_free_bytes_live` is the

--- a/core/continuum-core/src/capacity/system_profile.rs
+++ b/core/continuum-core/src/capacity/system_profile.rs
@@ -1,0 +1,308 @@
+//! `SystemProfile` — the keystone of `catalog = f(system × storage × grid)`.
+//!
+//! ONE measured descriptor of what THIS box can do, so the model catalog resolves its
+//! offering against reality instead of a static list. It COMPOSES primitives that
+//! already exist — it never re-measures what another module owns:
+//!   - [`HardwareClass`] — the boot silicon / VRAM / RAM classifier
+//!     ([`classify_hardware`] over a live [`probe_hardware_profile`]).
+//!   - live [`DeviceCapacity`] — free GPU / RAM right now.
+//!   - the 0.80 serving budget via [`host_budget_from`] — ONE definition of the
+//!     serving fraction, never a second copy of `0.80`.
+//!   - detected drives, with the big offload drive flagged as the COLD/frozen tier.
+//!
+//! **Storage and grid are RESOLUTION FIELDS, never GATES** (solve-for-public-users,
+//! [[public-project-not-joels-machines]]): a huge drive RECOMMENDS the full experience
+//! (big models, MoE expert sets frozen on it); its absence DEGRADES the offering
+//! (smaller quant / dense student / route to a grid node that fits) — it never
+//! EXCLUDES a user. The default must work on any laptop. `SystemProfile` is shaped to
+//! compose UP into a [`GridSnapshot`](super::grid::GridSnapshot) so "too big for THIS
+//! node" resolves to a peer, not a wall.
+//!
+//! The pure [`SystemProfile::from_parts`] core is the outlier-validation seam: a
+//! Blackwell-5090-with-16TB profile and a no-cold-drive laptop profile exercise the
+//! SAME resolution logic, and must resolve UP vs DOWN — never one included, the other
+//! excluded.
+
+use std::path::PathBuf;
+
+use super::DeviceCapacity;
+use crate::governor::types::HardwareClass;
+use crate::modules::serving_daemon::{host_budget_from, HostBudgetInputs};
+
+/// Minimum free space for a drive to qualify as a usable COLD/frozen tier. Below this
+/// a second drive is too small to hold model artifacts / MoE expert sets, so it does
+/// not change the resolution — the offering degrades exactly as if the drive were
+/// absent. A RESOLUTION threshold, not a gate: nothing is excluded, the deep-storage
+/// tier simply isn't offered. Conservative floor — a single small GGUF is ~0.6 GiB and
+/// an MoE expert set is hundreds of GiB, so 32 GiB is "big enough to be worth tiering
+/// artifacts onto" without flagging a small scratch partition.
+const MIN_COLD_TIER_BYTES: u64 = 32 * 1024 * 1024 * 1024;
+
+/// The role a detected drive plays in artifact placement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriveRole {
+    /// The OS / working drive (where the binary + config live). Kept lean — big cold
+    /// artifacts belong elsewhere when a `Cold` drive exists.
+    System,
+    /// A large offload drive — the COLD/frozen artifact tier (big GGUFs, MoE expert
+    /// sets paged into VRAM on demand). The Steam-library-style second drive.
+    Cold,
+}
+
+/// A drive the system can place artifacts on — DETECTED, not configured. This is the
+/// "recognize the storage" primitive: the system sees its OWN drives, so a user never
+/// hand-places a model file (the manual `curl`-to-`D:` that this exists to retire).
+#[derive(Debug, Clone)]
+pub struct DriveInfo {
+    /// Mount root (e.g. `C:\` or `D:\continuum-cold`).
+    pub mount: PathBuf,
+    pub total_bytes: u64,
+    pub available_bytes: u64,
+    pub role: DriveRole,
+}
+
+/// What THIS box can do — the catalog's resolution input. Composes the hardware class,
+/// live device capacity, detected drives, and the perf-core count into one descriptor.
+#[derive(Debug, Clone)]
+pub struct SystemProfile {
+    /// Silicon class + VRAM / RAM ceilings (discrete vs UMA).
+    pub hardware: HardwareClass,
+    /// Free GPU / RAM RIGHT NOW.
+    pub capacity: DeviceCapacity,
+    /// Detected drives; at most one is flagged [`DriveRole::Cold`].
+    pub drives: Vec<DriveInfo>,
+    /// Performance-core proxy for lane parallelism (feeds the serving budget).
+    pub perf_cores: u32,
+}
+
+impl SystemProfile {
+    /// PURE composition — the testable core. No I/O, no probes: hand it measured parts
+    /// and it derives the resolution inputs. THIS is the outlier-validation seam.
+    pub fn from_parts(
+        hardware: HardwareClass,
+        capacity: DeviceCapacity,
+        drives: Vec<DriveInfo>,
+        perf_cores: u32,
+    ) -> Self {
+        Self {
+            hardware,
+            capacity,
+            drives,
+            perf_cores,
+        }
+    }
+
+    /// The serving VRAM budget: live-free capped at the physical ceiling, minus the
+    /// 0.80 headroom. REUSES [`host_budget_from`] so the serving fraction has ONE
+    /// definition (never a second copy of `0.80` drifting out of sync). On UMA
+    /// (`vram_mb == 0`, Apple Silicon) the budget is a slice of system RAM, mirroring
+    /// the governor's own UMA handling.
+    pub fn serving_budget_bytes(&self) -> u64 {
+        let uma = self.hardware.vram_mb == 0;
+        let total = if uma {
+            self.capacity.gpu_total_bytes // UMA: capacity carries the serving slice
+        } else {
+            self.hardware.vram_mb.saturating_mul(1024 * 1024)
+        };
+        let available = if uma {
+            self.capacity.system_ram_free_bytes
+        } else {
+            self.capacity.gpu_free_bytes_live
+        };
+        host_budget_from(&HostBudgetInputs {
+            available_bytes: available,
+            total_vram_bytes: total,
+            perf_cores: self.perf_cores,
+        })
+        .usable_bytes
+    }
+
+    /// The COLD/frozen artifact-tier drive, if this box has one flagged. `None` ⇒ no
+    /// cold tier: placement DEGRADES (smaller quant / grid route), never excludes.
+    pub fn cold_drive(&self) -> Option<&DriveInfo> {
+        self.drives.iter().find(|d| d.role == DriveRole::Cold)
+    }
+
+    /// Does this box RECOMMEND the deep-storage experience — big models / MoE expert
+    /// sets frozen on a cold drive? True only when a `Cold` drive exists AND still has
+    /// enough free space to matter. False ⇒ the offering resolves DOWN, never out.
+    pub fn has_cold_tier(&self) -> bool {
+        self.cold_drive()
+            .is_some_and(|d| d.available_bytes >= MIN_COLD_TIER_BYTES)
+    }
+
+    /// Live detection — wires the real machine from primitives that already exist:
+    /// [`probe_hardware_profile`] (live VRAM / RAM / cores) → [`classify_hardware`],
+    /// and sysinfo for the drive list. Best-effort and non-panicking: a probe that
+    /// can't see the GPU still yields a usable (CPU/degraded) profile, because the
+    /// resolution never gates — it degrades.
+    pub fn detect() -> Self {
+        use crate::inference_capability::hw_probe::probe_hardware_profile;
+        use crate::governor::types::classify_hardware;
+
+        let hw_profile = probe_hardware_profile();
+        let hardware = classify_hardware(&hw_profile);
+
+        // Live free RAM (the probe's `system_ram_bytes` is TOTAL, not free).
+        let mut sys = sysinfo::System::new();
+        sys.refresh_memory();
+        let system_ram_free_bytes = sys.available_memory();
+
+        let capacity = DeviceCapacity {
+            gpu_total_bytes: hw_profile.total_vram_bytes,
+            gpu_free_bytes_live: hw_profile.free_vram_bytes,
+            system_ram_free_bytes,
+        };
+
+        let drives = detect_drives();
+        let perf_cores = hw_profile.cpu_cores.max(1);
+
+        Self::from_parts(hardware, capacity, drives, perf_cores)
+    }
+}
+
+/// Enumerate mounted drives (sysinfo) and flag the COLD tier: the largest-available
+/// drive that ISN'T the system/root drive and clears [`MIN_COLD_TIER_BYTES`]. Every
+/// other drive is `System`. Matches the `disk_pressure` sysinfo pattern
+/// (`total_space`/`available_space`). Detection only — the roles feed RESOLUTION, so a
+/// box with no qualifying second drive simply has no `Cold` drive (offering degrades).
+fn detect_drives() -> Vec<DriveInfo> {
+    let disks = sysinfo::Disks::new_with_refreshed_list();
+    let mut infos: Vec<DriveInfo> = disks
+        .iter()
+        .map(|d| DriveInfo {
+            mount: d.mount_point().to_path_buf(),
+            total_bytes: d.total_space(),
+            available_bytes: d.available_space(),
+            role: DriveRole::System,
+        })
+        .collect();
+
+    // The cold tier is the biggest-available drive that clears the floor AND is not
+    // the smallest (the OS drive tends to be busiest/smallest-free). If exactly one
+    // drive clears the floor and there are others, it's the cold tier; with a single
+    // drive there is no cold tier (nowhere distinct to offload to).
+    if infos.len() > 1 {
+        if let Some((idx, _)) = infos
+            .iter()
+            .enumerate()
+            .filter(|(_, d)| d.available_bytes >= MIN_COLD_TIER_BYTES)
+            .max_by_key(|(_, d)| d.available_bytes)
+        {
+            infos[idx].role = DriveRole::Cold;
+        }
+    }
+    infos
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::governor::types::{PowerSource, TargetSilicon, ThermalClass};
+
+    fn hw(silicon: TargetSilicon, vram_mb: u64, ram_mb: u64) -> HardwareClass {
+        HardwareClass {
+            silicon,
+            silicon_model: "test".into(),
+            vram_mb,
+            system_ram_mb: ram_mb,
+            power_source: PowerSource::Plugged,
+            thermal_class: ThermalClass::Workstation,
+            battery_pct: None,
+            thermal_headroom_pct: None,
+        }
+    }
+
+    fn cap(gpu_total: u64, gpu_free: u64, ram_free: u64) -> DeviceCapacity {
+        DeviceCapacity {
+            gpu_total_bytes: gpu_total,
+            gpu_free_bytes_live: gpu_free,
+            system_ram_free_bytes: ram_free,
+        }
+    }
+
+    const GB: u64 = 1024 * 1024 * 1024;
+
+    /// BigMama: RTX 5090 (32 GiB VRAM discrete) + a 16 TB cold drive.
+    fn bigmama() -> SystemProfile {
+        SystemProfile::from_parts(
+            hw(TargetSilicon::NvidiaCuda, 32 * 1024, 128 * 1024),
+            cap(32 * GB, 30 * GB, 100 * GB),
+            vec![
+                DriveInfo {
+                    mount: "C:\\".into(),
+                    total_bytes: 2000 * GB,
+                    available_bytes: 40 * GB,
+                    role: DriveRole::System,
+                },
+                DriveInfo {
+                    mount: "D:\\continuum-cold".into(),
+                    total_bytes: 16_000 * GB,
+                    available_bytes: 15_000 * GB,
+                    role: DriveRole::Cold,
+                },
+            ],
+            24,
+        )
+    }
+
+    /// A no-cold-drive laptop: single small drive, modest discrete GPU.
+    fn laptop_no_cold() -> SystemProfile {
+        SystemProfile::from_parts(
+            hw(TargetSilicon::NvidiaCuda, 8 * 1024, 16 * 1024),
+            cap(8 * GB, 6 * GB, 8 * GB),
+            vec![DriveInfo {
+                mount: "C:\\".into(),
+                total_bytes: 500 * GB,
+                available_bytes: 20 * GB, // below the 32 GiB cold floor
+                role: DriveRole::System,
+            }],
+            8,
+        )
+    }
+
+    // what this catches: THE OUTLIER-VALIDATION INVARIANT for catalog=f(system×storage).
+    // The SAME resolution logic must resolve UP for a box with a big cold drive and
+    // DOWN for one without — the deep-storage tier is a RESOLUTION FIELD, never a gate.
+    // Regression here = a laptop being EXCLUDED (no cold tier → crash/deny) instead of
+    // DEGRADED, which breaks solve-for-public-users.
+    #[test]
+    fn cold_tier_is_a_resolution_field_not_a_gate() {
+        assert!(
+            bigmama().has_cold_tier(),
+            "a 16TB cold drive must RECOMMEND the deep-storage tier"
+        );
+        assert!(
+            !laptop_no_cold().has_cold_tier(),
+            "no qualifying cold drive → tier not offered (DEGRADE), NOT excluded"
+        );
+        // Both are still valid profiles that answer every query — neither errors.
+        assert!(bigmama().cold_drive().is_some());
+        assert!(laptop_no_cold().cold_drive().is_none());
+    }
+
+    // what this catches: the serving budget REUSES host_budget_from's 0.80 fraction —
+    // one definition, applied to the discrete VRAM ceiling. A drift to a second
+    // hardcoded fraction (or planning above physical VRAM) is caught here.
+    #[test]
+    fn serving_budget_applies_the_shared_080_headroom_to_vram() {
+        // 30 GiB live-free, 32 GiB ceiling → budget = 0.80 × 30 GiB.
+        let expected = (30 * GB as u64) * 80 / 100;
+        assert_eq!(bigmama().serving_budget_bytes(), expected);
+    }
+
+    // what this catches: on UMA (vram_mb==0, Apple Silicon) the budget comes from the
+    // system-RAM slice, not a zero VRAM ceiling — a discrete-only budget path would
+    // return 0 here and blind the catalog to every Apple-Silicon box.
+    #[test]
+    fn uma_budget_uses_the_system_ram_slice_not_zero_vram() {
+        let uma = SystemProfile::from_parts(
+            hw(TargetSilicon::AppleM, 0, 48 * 1024),
+            cap(36 * GB, 36 * GB, 30 * GB), // capacity carries the UMA serving slice
+            vec![],
+            10,
+        );
+        // available (ram_free 30) capped at total (gpu_total 36) → 30, ×0.80.
+        assert_eq!(uma.serving_budget_bytes(), (30 * GB) * 80 / 100);
+    }
+}

--- a/core/continuum-core/src/provisioning/mod.rs
+++ b/core/continuum-core/src/provisioning/mod.rs
@@ -22,10 +22,12 @@ pub mod downloader;
 pub mod fetch;
 pub mod model_catalog;
 pub mod model_source;
+pub mod placement_planner;
 pub mod provisioner;
 pub mod scaling;
 
 pub use avatar_source::AvatarSource;
+pub use placement_planner::{resolve_from_footprint, resolve_placement, PlacementResolution};
 pub use cache::{reconcile, CacheDecision, CacheEntry, ProvisionPlan};
 pub use downloader::{DownloadError, Downloader};
 pub use fetch::{fetch_and_place, FetchError};

--- a/core/continuum-core/src/provisioning/mod.rs
+++ b/core/continuum-core/src/provisioning/mod.rs
@@ -27,7 +27,9 @@ pub mod provisioner;
 pub mod scaling;
 
 pub use avatar_source::AvatarSource;
-pub use placement_planner::{resolve_from_footprint, resolve_placement, PlacementResolution};
+pub use placement_planner::{
+    grid_has_fit, resolve_from_footprint, resolve_placement, PlacementResolution,
+};
 pub use cache::{reconcile, CacheDecision, CacheEntry, ProvisionPlan};
 pub use downloader::{DownloadError, Downloader};
 pub use fetch::{fetch_and_place, FetchError};

--- a/core/continuum-core/src/provisioning/placement_planner.rs
+++ b/core/continuum-core/src/provisioning/placement_planner.rs
@@ -1,0 +1,289 @@
+//! `PlacementPlanner` — the RESOLUTION half of `catalog = f(system × storage × grid)`.
+//!
+//! Given what THIS box ([`SystemProfile`]) and the grid can do, resolve WHERE a model
+//! runs — and when it doesn't fit at full fidelity here, resolve it DOWN (grid node /
+//! smaller variant) rather than EXCLUDING it. There is deliberately **no `Excluded`
+//! variant**: storage and grid are RESOLUTION FIELDS, never gates
+//! ([[public-project-not-joels-machines]], solve-for-public-users). The default must
+//! work on any laptop — a box that can't serve a model locally still gets an answer.
+//!
+//! It REUSES the fit primitives rather than re-deriving them:
+//!   - [`SystemProfile::serving_budget_bytes`] — the VRAM budget (the one 0.80
+//!     `vram_headroom` via `host_budget_from`, config-inherited, no second const).
+//!   - [`footprint_for`] — the `Model` → [`ModelFootprint`] bridge (GGUF on disk →
+//!     size). `None` ⇒ not provisioned yet.
+//!   - [`plan_serving`] — the honest fit oracle (`fits_on_gpu`).
+//!
+//! The grid verdict is an INPUT (`grid_has_fit`), derived by the caller from
+//! `plan_grid_placement` over a [`GridSnapshot`](crate::capacity::grid::GridSnapshot),
+//! so the resolution core stays pure and testable (a solo box passes `false`).
+
+use crate::capacity::SystemProfile;
+use crate::cognition::serving_plan::{plan_serving, HostBudget, ModelFootprint};
+use crate::model_registry::types::Model;
+
+/// How a model resolves against a system + grid. Every case is an ANSWER — there is
+/// no "excluded": the offering resolves up (local) or down (grid / provision /
+/// degrade), never out.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlacementResolution {
+    /// Fits this node's serving budget — the recommended experience, served HERE.
+    LocalRecommended { budget_bytes: u64, weights_bytes: u64 },
+    /// No artifact on disk yet — resolve by PROVISIONING it, to the COLD tier when
+    /// this box has one (big models / MoE expert sets belong on the offload drive),
+    /// else the system drive. "Not here yet", never "can't run".
+    NeedsProvisioning { to_cold_tier: bool },
+    /// An MoE model too big to fit WHOLE in the VRAM budget, but this box has a COLD
+    /// tier: resolve to EXPERT-PAGED serving — the base + all experts FROZEN on the
+    /// cold drive (`TierRole::Frozen`), the hot subset paged into VRAM on demand
+    /// (`PageKind::MoEExpert` over `ArtifactSource::Mapped`, sentinel-PGO picking the
+    /// subset). The K3 path: a 594 GB model "fits" a 32 GB GPU by RESIDENCY + paging,
+    /// not by shrinking. Preferred over grid/degrade when a cold tier exists — local
+    /// frontier intelligence, no cloud. (Prefer-grid-if-a-peer-serves-it-whole-faster
+    /// is a throughput-policy follow-up, not this slice.)
+    MoePaged { vram_budget_bytes: u64, weights_bytes: u64 },
+    /// Too big for THIS node's budget → resolve to a grid node that fits. The grid is
+    /// a resolution field: too-big-HERE becomes served-THERE, not excluded.
+    GridRouted { local_budget_bytes: u64, weights_bytes: u64 },
+    /// Doesn't fit locally AND no grid node fits → degrade to a smaller variant /
+    /// cloud. The FLOOR — still an answer (the caller owns the smaller-variant / cloud
+    /// choice), never an exclusion.
+    Degraded { local_budget_bytes: u64, weights_bytes: u64 },
+}
+
+/// PURE resolution — the testable core. Feeds on an already-resolved footprint
+/// (`None` = no artifact on disk) plus the caller's grid verdict, so it does zero
+/// I/O and every branch is exercised with synthetic inputs.
+pub fn resolve_from_footprint(
+    profile: &SystemProfile,
+    footprint: Option<&ModelFootprint>,
+    is_moe: bool,
+    grid_has_fit: bool,
+) -> PlacementResolution {
+    let usable = profile.serving_budget_bytes();
+
+    let Some(fp) = footprint else {
+        // Not on disk → provision it. Prefer the cold tier when present (that's where
+        // big GGUFs / MoE expert sets live), else the system drive. Never excluded.
+        return PlacementResolution::NeedsProvisioning {
+            to_cold_tier: profile.has_cold_tier(),
+        };
+    };
+
+    let host = HostBudget {
+        usable_bytes: usable,
+        perf_cores: profile.perf_cores,
+    };
+    // `plan_serving` returns `Some` even when nothing fits (its honest-degrade path,
+    // `fits_on_gpu = false`); `None` only for an empty candidate slice, which a
+    // single-element slice never is — so `unwrap_or(false)` is the not-empty floor.
+    let fits = plan_serving(host, std::slice::from_ref(fp), 1)
+        .map(|p| p.fits_on_gpu)
+        .unwrap_or(false);
+
+    if fits {
+        PlacementResolution::LocalRecommended {
+            budget_bytes: usable,
+            weights_bytes: fp.weights_bytes,
+        }
+    } else if is_moe && profile.has_cold_tier() {
+        // The K3 magic: an MoE model that can't fit whole in VRAM still serves LOCALLY
+        // by freezing its experts on the cold drive and paging the hot subset — no
+        // grid hop, no cloud. Preferred over grid/degrade because local frontier
+        // intelligence is the whole thesis.
+        PlacementResolution::MoePaged {
+            vram_budget_bytes: usable,
+            weights_bytes: fp.weights_bytes,
+        }
+    } else if grid_has_fit {
+        PlacementResolution::GridRouted {
+            local_budget_bytes: usable,
+            weights_bytes: fp.weights_bytes,
+        }
+    } else {
+        PlacementResolution::Degraded {
+            local_budget_bytes: usable,
+            weights_bytes: fp.weights_bytes,
+        }
+    }
+}
+
+/// Resolve a model's placement on this box. Reuses [`footprint_for`] (GGUF → size)
+/// then the pure core.
+///
+/// `is_moe` is the caller's GGUF-derived verdict — MoE-ness is a FACT the GGUF
+/// carries (`{arch}.expert_count`), read via
+/// [`locate_layer_sets`](crate::genome::expert_layout::locate_layer_sets) /
+/// `gguf_keys::expert_count` at the site that already loads the header — NOT a
+/// hand-authored catalog field (the catalog's "ask the GGUF" discipline). `grid_has_fit`
+/// is the caller's grid verdict (derive from `plan_grid_placement` over a
+/// `GridSnapshot`); `false` on a solo box.
+///
+/// [`footprint_for`]: crate::modules::serving_daemon::footprint_for
+pub fn resolve_placement(
+    profile: &SystemProfile,
+    model: &Model,
+    is_moe: bool,
+    grid_has_fit: bool,
+) -> PlacementResolution {
+    let fp = crate::modules::serving_daemon::footprint_for(model);
+    resolve_from_footprint(profile, fp.as_ref(), is_moe, grid_has_fit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capacity::{DeviceCapacity, DriveInfo, DriveRole};
+    use crate::governor::types::{HardwareClass, PowerSource, TargetSilicon, ThermalClass};
+
+    const GB: u64 = 1024 * 1024 * 1024;
+
+    fn discrete(vram_gb: u64, gpu_free_gb: u64, with_cold: bool) -> SystemProfile {
+        let mut drives = vec![DriveInfo {
+            mount: "C:\\".into(),
+            total_bytes: 2000 * GB,
+            available_bytes: 20 * GB,
+            role: DriveRole::System,
+        }];
+        if with_cold {
+            drives.push(DriveInfo {
+                mount: "D:\\continuum-cold".into(),
+                total_bytes: 16_000 * GB,
+                available_bytes: 15_000 * GB,
+                role: DriveRole::Cold,
+            });
+        }
+        SystemProfile::from_parts(
+            HardwareClass {
+                silicon: TargetSilicon::NvidiaCuda,
+                silicon_model: "test".into(),
+                vram_mb: vram_gb * 1024,
+                system_ram_mb: 128 * 1024,
+                power_source: PowerSource::Plugged,
+                thermal_class: ThermalClass::Workstation,
+                battery_pct: None,
+                thermal_headroom_pct: None,
+            },
+            DeviceCapacity {
+                gpu_total_bytes: vram_gb * GB,
+                gpu_free_bytes_live: gpu_free_gb * GB,
+                system_ram_free_bytes: 100 * GB,
+            },
+            drives,
+            24,
+        )
+    }
+
+    fn footprint(weights_gb: u64) -> ModelFootprint {
+        ModelFootprint {
+            model_id: "test-model".into(),
+            weights_bytes: weights_gb * GB,
+            kv_per_token: 1024, // ~2 MiB KV at the 2048 MIN_SERVE_CTX — weights dominate
+            context_window: 32_768,
+            capability_rank: 5,
+        }
+    }
+
+    // what this catches: a model whose weights fit the 0.80 VRAM budget resolves to
+    // LocalRecommended — served HERE. (BigMama: 32 GiB VRAM, 30 free → 24 GiB budget;
+    // a 10 GiB model fits.)
+    #[test]
+    fn fitting_model_resolves_local_recommended() {
+        let p = discrete(32, 30, true);
+        let r = resolve_from_footprint(&p, Some(&footprint(10)), false, false);
+        assert!(matches!(r, PlacementResolution::LocalRecommended { .. }), "got {r:?}");
+    }
+
+    // what this catches: THE NEVER-EXCLUDE INVARIANT. A model too big for THIS node
+    // resolves to the grid when a peer fits, and DEGRADES (not excludes) when none
+    // does — the same oversized model, two resolutions, never a wall.
+    #[test]
+    fn oversized_model_routes_to_grid_then_degrades_never_excludes() {
+        let p = discrete(32, 30, true); // 24 GiB budget
+        let huge = footprint(80); // 80 GiB weights — cannot fit locally
+
+        let with_grid = resolve_from_footprint(&p, Some(&huge), false, true);
+        assert!(matches!(with_grid, PlacementResolution::GridRouted { .. }), "got {with_grid:?}");
+
+        let solo = resolve_from_footprint(&p, Some(&huge), false, false);
+        assert!(matches!(solo, PlacementResolution::Degraded { .. }), "got {solo:?}");
+        // The invariant: BOTH are answers. Neither errors, panics, or "excludes".
+    }
+
+    // what this catches: an un-provisioned model (no GGUF on disk) resolves to
+    // PROVISION-to-cold-tier on a box with a big drive, and provision-to-system when
+    // there's no cold drive — storage RESOLVES the destination, never gates the model.
+    #[test]
+    fn missing_artifact_provisions_to_cold_tier_when_available() {
+        let with_cold = discrete(32, 30, true);
+        assert_eq!(
+            resolve_from_footprint(&with_cold, None, false, false),
+            PlacementResolution::NeedsProvisioning { to_cold_tier: true }
+        );
+
+        let no_cold = discrete(8, 6, false);
+        assert_eq!(
+            resolve_from_footprint(&no_cold, None, false, false),
+            PlacementResolution::NeedsProvisioning { to_cold_tier: false }
+        );
+    }
+
+    // what this catches: a modest laptop (8 GiB VRAM, 6 free → ~4.8 GiB budget) and a
+    // BigMama box run the SAME resolver over the SAME oversized model and BOTH get a
+    // valid resolution — the laptop is DEGRADED, never excluded (solve-for-public-users).
+    #[test]
+    fn laptop_and_workstation_both_resolve_the_same_oversized_model() {
+        let laptop = discrete(8, 6, false);
+        let workstation = discrete(32, 30, true);
+        let big = footprint(40);
+        // Neither fits locally; with no grid, both DEGRADE (an answer), never exclude.
+        assert!(matches!(
+            resolve_from_footprint(&laptop, Some(&big), false, false),
+            PlacementResolution::Degraded { .. }
+        ));
+        assert!(matches!(
+            resolve_from_footprint(&workstation, Some(&big), false, false),
+            PlacementResolution::Degraded { .. }
+        ));
+    }
+
+    // what this catches: THE K3 ON-RAMP. An MoE model too big to fit whole in VRAM
+    // resolves to MoePaged (experts frozen on the cold drive, hot subset paged) on a
+    // box WITH a cold tier — served LOCALLY, not routed away — and correctly does NOT
+    // when there's no cold tier (degrades/routes like any oversized model). This is
+    // the difference between "594GB can't run here" and "594GB runs here by paging".
+    #[test]
+    fn oversized_moe_pages_locally_when_a_cold_tier_exists() {
+        let big_moe = footprint(80); // 80 GiB — cannot fit a 24 GiB budget whole
+
+        // Cold tier present → page the experts locally (the K3 magic), NOT grid/degrade.
+        let with_cold = discrete(32, 30, true);
+        assert!(
+            matches!(
+                resolve_from_footprint(&with_cold, Some(&big_moe), true, true),
+                PlacementResolution::MoePaged { .. }
+            ),
+            "MoE + cold tier must page locally, preferred even over an available grid node"
+        );
+
+        // No cold tier → MoE has nowhere to freeze experts, so it resolves like any
+        // oversized model: grid when a peer fits, degrade otherwise. Never excluded.
+        let no_cold = discrete(8, 6, false);
+        assert!(matches!(
+            resolve_from_footprint(&no_cold, Some(&big_moe), true, true),
+            PlacementResolution::GridRouted { .. }
+        ));
+        assert!(matches!(
+            resolve_from_footprint(&no_cold, Some(&big_moe), true, false),
+            PlacementResolution::Degraded { .. }
+        ));
+
+        // And an MoE that FITS whole just serves normally — paging is only for the
+        // doesn't-fit case.
+        let small_moe = footprint(10);
+        assert!(matches!(
+            resolve_from_footprint(&with_cold, Some(&small_moe), true, false),
+            PlacementResolution::LocalRecommended { .. }
+        ));
+    }
+}

--- a/core/continuum-core/src/provisioning/placement_planner.rs
+++ b/core/continuum-core/src/provisioning/placement_planner.rs
@@ -18,6 +18,7 @@
 //! `plan_grid_placement` over a [`GridSnapshot`](crate::capacity::grid::GridSnapshot),
 //! so the resolution core stays pure and testable (a solo box passes `false`).
 
+use crate::capacity::grid::GridSnapshot;
 use crate::capacity::SystemProfile;
 use crate::cognition::serving_plan::{plan_serving, HostBudget, ModelFootprint};
 use crate::model_registry::types::Model;
@@ -115,19 +116,46 @@ pub fn resolve_from_footprint(
 /// carries (`{arch}.expert_count`), read via
 /// [`locate_layer_sets`](crate::genome::expert_layout::locate_layer_sets) /
 /// `gguf_keys::expert_count` at the site that already loads the header — NOT a
-/// hand-authored catalog field (the catalog's "ask the GGUF" discipline). `grid_has_fit`
-/// is the caller's grid verdict (derive from `plan_grid_placement` over a
-/// `GridSnapshot`); `false` on a solo box.
+/// hand-authored catalog field (the catalog's "ask the GGUF" discipline). `grid` is
+/// the live [`GridSnapshot`] (`None` on a solo box); the grid verdict is derived from
+/// it via [`grid_has_fit`].
 ///
 /// [`footprint_for`]: crate::modules::serving_daemon::footprint_for
 pub fn resolve_placement(
     profile: &SystemProfile,
     model: &Model,
     is_moe: bool,
-    grid_has_fit: bool,
+    grid: Option<&GridSnapshot>,
 ) -> PlacementResolution {
     let fp = crate::modules::serving_daemon::footprint_for(model);
-    resolve_from_footprint(profile, fp.as_ref(), is_moe, grid_has_fit)
+    let grid_fit = match (grid, fp.as_ref()) {
+        (Some(snapshot), Some(f)) => grid_has_fit(snapshot, f),
+        _ => false,
+    };
+    resolve_from_footprint(profile, fp.as_ref(), is_moe, grid_fit)
+}
+
+/// Does ANY reachable grid peer's live-free VRAM hold this model (weights + one
+/// lane's KV)? The grid verdict for [`resolve_placement`], honoring the "sum of
+/// per-node FITS, never an aggregate pool" doctrine ([`GridSnapshot`]): each reachable
+/// peer is tested with the SAME [`plan_serving`] oracle used locally, against its own
+/// live-free bytes. A peer that could only CPU-spill does NOT count as a fit
+/// (`fits_on_gpu = false`) — the grid resolves a model to a node that can actually
+/// GPU-serve it, or it degrades; it never routes to a node that can't.
+pub fn grid_has_fit(snapshot: &GridSnapshot, footprint: &ModelFootprint) -> bool {
+    snapshot
+        .peers
+        .iter()
+        .filter(|p| p.reachable)
+        .any(|p| {
+            let host = HostBudget {
+                usable_bytes: p.capacity.gpu_free_bytes_live,
+                perf_cores: 1,
+            };
+            plan_serving(host, std::slice::from_ref(footprint), 1)
+                .map(|plan| plan.fits_on_gpu)
+                .unwrap_or(false)
+        })
 }
 
 #[cfg(test)]
@@ -285,5 +313,53 @@ mod tests {
             resolve_from_footprint(&with_cold, Some(&small_moe), true, false),
             PlacementResolution::LocalRecommended { .. }
         ));
+    }
+
+    // what this catches: the grid verdict is a PER-NODE fit, never an aggregate pool
+    // (the GridSnapshot doctrine). grid_has_fit is true iff SOME reachable peer's
+    // live-free VRAM holds the model WHOLE — two small peers that "sum" to enough do
+    // NOT fit, an unreachable peer that would fit does NOT count, and a peer that could
+    // only CPU-spill does NOT count (fits_on_gpu = false).
+    #[test]
+    fn grid_has_fit_is_per_node_never_a_pool() {
+        use crate::capacity::grid::{GridSnapshot, PeerCapacity};
+        use crate::identity::PeerId;
+
+        let peer = |id: u128, free_gb: u64, reachable: bool| PeerCapacity {
+            peer: PeerId::from_u128(id),
+            capacity: DeviceCapacity {
+                gpu_total_bytes: 80 * GB,
+                gpu_free_bytes_live: free_gb * GB,
+                system_ram_free_bytes: 0,
+            },
+            reachable,
+        };
+        let local = DeviceCapacity {
+            gpu_total_bytes: 32 * GB,
+            gpu_free_bytes_live: 4 * GB,
+            system_ram_free_bytes: 0,
+        };
+        let fp = footprint(40); // needs ~40 GiB resident whole
+
+        // Two reachable 20 GiB peers — an aggregate POOL would "fit", per-node does NOT.
+        let pooled = GridSnapshot {
+            local,
+            peers: vec![peer(1, 20, true), peer(2, 20, true)],
+        };
+        assert!(!grid_has_fit(&pooled, &fp), "two 20GiB peers must NOT fit a 40GiB model — never a pool");
+
+        // One reachable peer with room fits.
+        let has_big = GridSnapshot {
+            local,
+            peers: vec![peer(3, 20, true), peer(4, 60, true)],
+        };
+        assert!(grid_has_fit(&has_big, &fp));
+
+        // A peer big enough but UNREACHABLE is a memory, not an offer.
+        let unreachable = GridSnapshot {
+            local,
+            peers: vec![peer(5, 60, false)],
+        };
+        assert!(!grid_has_fit(&unreachable, &fp));
     }
 }


### PR DESCRIPTION
## What
Slice 1 of `catalog = f(system × storage × grid)`: the system recognizes its own hardware + drives, and resolves a model's placement against that reality — **storage and grid are RESOLUTION FIELDS, never gates** (a laptop degrades, never gets excluded; solve-for-public-users).

## Pieces
- **`SystemProfile`** (`capacity/system_profile.rs`) — the keystone. Composes `HardwareClass` + live `DeviceCapacity` + detected drives (auto-flags the big cold/frozen tier) + the serving budget via `host_budget_from` (**reuses** the one `vram_headroom` 0.80, reads no config itself — inherits M5's `config_env::vram_headroom()` transitively, adds nothing to the config sprawl).
- **`PlacementPlanner`** (`provisioning/placement_planner.rs`) — the never-exclude resolver. `LocalRecommended | NeedsProvisioning{to_cold_tier} | MoePaged | GridRouted | Degraded`. Reuses `footprint_for` + `plan_serving`.
- **MoE resolution** = M5's **option B**: MoE-ness is GGUF-derived (`{arch}.expert_count` via `locate_layer_sets`), NOT a hand-authored `Model` field (avoids an 11-site churn + honors the catalog's ask-the-GGUF discipline). **`MoePaged`** is the K3 on-ramp: a 594GB MoE model serves LOCALLY by freezing experts on the cold drive + paging the hot subset — fits a 32GB GPU by residency, not by shrinking.

## Invariants (unit-tested, pure cores)
- A laptop and a workstation resolve the SAME oversized model — one degrades, MoE pages locally when a cold tier exists — **neither is ever excluded**.
- The 0.80 headroom applies to the VRAM ceiling; UMA budgets from the RAM slice.
- MoE + cold tier → `MoePaged`; MoE + no cold tier → grid/degrade like any oversized model.

## Notes
- Windows: `cargo test` harness doesn't build on windows-msvc (pre-existing Unix-socket cfg gap, separate lane); validated via `cargo build --lib`, tests run in CI (Linux).
- Foundation for the K3 MoE expert pager (weights drop imminently) — the `MoePaged` resolution is where `expert_ingest` + the dynamic Rust pager plug in next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)