### PR TITLE
feat: autonomic wakeup + single-file config headroom + self-improving-memory design (foundation for the system-aware catalog)

### DIFF
--- a/core/continuum-core/src/capacity/system_profile.rs
+++ b/core/continuum-core/src/capacity/system_profile.rs
@@ -121,6 +121,9 @@ impl SystemProfile {
             available_bytes: available,
             total_vram_bytes: total,
             perf_cores: self.perf_cores,
+            // Same operator headroom policy as every live serving-budget caller
+            // (serving_daemon): usable = live × the config fraction.
+            budget_fraction: crate::config_env::vram_headroom(),
         })
         .usable_bytes
     }

--- a/core/continuum-core/src/config_env.rs
+++ b/core/continuum-core/src/config_env.rs
@@ -19,6 +19,12 @@
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Default resource-headroom fraction: usable = total × this. 0.8 leaves 20% for
+/// the governor + peer consumers (and, for disk, doubles as the disk-full safety
+/// margin). A dedicated deep-learning FOUNDRY appliance overrides to 1.0.
+const DEFAULT_HEADROOM: f64 = 0.8;
 
 /// Path to `~/.continuum/config.env` (mirrors [`crate::secrets`]).
 pub fn config_path() -> Option<PathBuf> {
@@ -128,6 +134,52 @@ pub fn upsert_in(path: &Path, key: &str, value: &str) -> Result<(), String> {
     Ok(())
 }
 
+// ─── Typed policy getters ────────────────────────────────────────────────────
+//
+// These are the SINGLE entry point for operator-tunable resource headroom. The
+// forbidden pattern (CONCURRENCY-STYLE-GUIDE forbidden-move #2) is SCATTERED
+// per-module env/config reads — `config_env::read("KEY").unwrap_or(default)`
+// re-derived at each of 161 call sites. The fix is ONE file everyone goes through:
+// the key name, default, clamp, and cache all live HERE; consumers just call
+// `config_env::vram_headroom()`. Load-once (OnceLock) so budget code on a hot tick
+// never re-reads the file — matching the guide's "config loaded once at boot".
+
+/// Parse an operator-set fraction into `[0.0, 1.0]`, else `default`. Pure +
+/// testable: absent/empty → default; non-finite/garbage → warn + default; valid →
+/// clamped. Clamping means a fat-fingered `1.5` can't over-commit the resource.
+fn parse_fraction(raw: Option<&str>, default: f64) -> f64 {
+    match raw.map(str::trim).filter(|s| !s.is_empty()) {
+        None => default,
+        Some(s) => match s.parse::<f64>() {
+            Ok(f) if f.is_finite() => f.clamp(0.0, 1.0),
+            _ => {
+                tracing::warn!(
+                    target: "config_env",
+                    "invalid headroom fraction {s:?} — using default {default}"
+                );
+                default
+            }
+        },
+    }
+}
+
+/// Headroom fraction for the VRAM/RAM serving budget: `usable = total × this`.
+/// Default 0.8 (leave 20% for the governor + peers); a dedicated foundry sets 1.0.
+/// Read once and cached. Override key: `CONTINUUM_VRAM_HEADROOM`.
+pub fn vram_headroom() -> f64 {
+    static V: OnceLock<f64> = OnceLock::new();
+    *V.get_or_init(|| parse_fraction(read("CONTINUUM_VRAM_HEADROOM").as_deref(), DEFAULT_HEADROOM))
+}
+
+/// Headroom fraction for the disk frozen/cold artifact tier: `usable = drive_free ×
+/// this`. Default 0.8 (the 20% doubles as the disk-full safety guard); a foundry
+/// with a dedicated drive sets 1.0. Read once and cached. Override key:
+/// `CONTINUUM_DISK_HEADROOM`.
+pub fn disk_headroom() -> f64 {
+    static D: OnceLock<f64> = OnceLock::new();
+    *D.get_or_init(|| parse_fraction(read("CONTINUUM_DISK_HEADROOM").as_deref(), DEFAULT_HEADROOM))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,5 +286,28 @@ mod tests {
         fs::write(&p, "# CONTINUUM_LAUNCH_MODE=ui (this is a comment)\n").unwrap();
         assert_eq!(read_from(&p, "CONTINUUM_LAUNCH_MODE"), None);
         let _ = fs::remove_dir_all(p.parent().unwrap());
+    }
+
+    /// What this catches: the headroom-fraction contract — absent/empty/garbage
+    /// take the default; a foundry's 1.0 passes; and a fat-fingered over-1.0 (or
+    /// negative) is CLAMPED so config can never over-commit the resource. This is
+    /// the single-source getter's behavior, tested on the pure core.
+    #[test]
+    fn parse_fraction_defaults_clamps_and_honors_override() {
+        // absent / empty / whitespace → default
+        assert_eq!(parse_fraction(None, 0.8), 0.8);
+        assert_eq!(parse_fraction(Some(""), 0.8), 0.8);
+        assert_eq!(parse_fraction(Some("   "), 0.8), 0.8);
+        // valid overrides
+        assert_eq!(parse_fraction(Some("1.0"), 0.8), 1.0); // dedicated foundry
+        assert_eq!(parse_fraction(Some(" 0.5 "), 0.8), 0.5); // trimmed
+        assert_eq!(parse_fraction(Some("0.9"), 0.8), 0.9);
+        // out-of-range clamps (can't over-commit / go negative)
+        assert_eq!(parse_fraction(Some("1.5"), 0.8), 1.0);
+        assert_eq!(parse_fraction(Some("-0.3"), 0.8), 0.0);
+        // garbage / non-finite → default
+        assert_eq!(parse_fraction(Some("abc"), 0.8), 0.8);
+        assert_eq!(parse_fraction(Some("NaN"), 0.8), 0.8);
+        assert_eq!(parse_fraction(Some("inf"), 0.8), 0.8);
     }
 }

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -50,11 +50,6 @@ use std::time::Duration;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
-/// Fraction of total VRAM/UMA we treat as ours to serve from — the rest is
-/// OS + non-inference headroom (Bevy avatars, embeddings, the OS itself). A
-/// single source of truth for "how much is actually ours."
-const SERVING_BUDGET_FRACTION: f64 = 0.80;
-
 /// How often the daemon re-evaluates the serving plan. 5s matches the other
 /// pressure-class ticks (pressure-broker, ai_provider) in the runtime. The
 /// next slice makes the re-plan also fire on PressureBroker watch edges so it
@@ -757,13 +752,14 @@ impl ServingDaemonModule {
         // (hard task + room) floors the whole GPU (1.0), Comfort is the everyday 0.80, and
         // Eco (memory starved — a game opened, a crowded call) drops to 0.55 so the base
         // claims less and the rest of the call's KV + render still fit. #56/G8: we do NOT
-        // ALSO apply the static SERVING_BUDGET_FRACTION here — stacking it under the mode
+        // ALSO apply the operator VRAM-headroom fraction here — stacking it under the mode
         // fraction double-discounted the everyday budget to ~0.64 (24.5GB of a 38GB board)
         // and left the more-capable 32B coder + full context unused, WITHOUT buying safety
         // (the concurrent-prefill compute buffer is reserved separately, window-scaled, in
-        // the serving_plan fixpoint). The pin fit-gate still uses `live_host_budget`'s raw
-        // 0.80 directly — "can this model physically fit" is a different question than "how
-        // much should the shared base claim now." [[verify-real-device-numbers-not-a-clamp-premise]]
+        // the serving_plan fixpoint). The pin fit-gate still applies the operator headroom
+        // (`config_env::vram_headroom()`, default 0.80) via `host_budget_from` — "can this
+        // model physically fit" is a different question than "how much should the shared base
+        // claim now." [[verify-real-device-numbers-not-a-clamp-premise]]
         // The governed VRAM board is the ONE authority for available VRAM: its `available`
         // is free-VRAM ALREADY netted over every measured consumer + external pressure AND
         // already ≤ physical VRAM. Trust it directly — do NOT `.min()` it against the raw
@@ -2237,14 +2233,22 @@ pub struct HostBudgetInputs {
     pub total_vram_bytes: u64,
     /// Performance-core proxy for the lane cap (floored at 1 inside).
     pub perf_cores: u32,
+    /// Fraction of the board this host treats as ours to serve from (`usable =
+    /// live × this`). The operator VRAM-headroom policy: default 0.80 (leave 20%
+    /// for the OS + Bevy + embeddings), a dedicated foundry sets 1.0. Live callers
+    /// pass `config_env::vram_headroom()`; tests pass an explicit fraction so
+    /// `host_budget_from` stays pure + environment-independent.
+    pub budget_fraction: f64,
 }
 
 /// Serving budget from LIVE free memory, capped at physical VRAM, minus headroom.
-/// Pure for tests. Takes [`HostBudgetInputs`] by reference so the byte-count fields
-/// are named at every call site (never transposable).
+/// Pure for tests — the headroom fraction is an INPUT (`budget_fraction`), never
+/// read from config here, so a test can't go environment-dependent. Takes
+/// [`HostBudgetInputs`] by reference so the byte-count fields are named at every
+/// call site (never transposable).
 pub fn host_budget_from(inputs: &HostBudgetInputs) -> HostBudget {
     let live = inputs.available_bytes.min(inputs.total_vram_bytes);
-    let usable = (live as f64 * SERVING_BUDGET_FRACTION) as u64;
+    let usable = (live as f64 * inputs.budget_fraction) as u64;
     HostBudget {
         usable_bytes: usable,
         perf_cores: inputs.perf_cores.max(1),
@@ -2306,6 +2310,7 @@ pub fn live_host_budget(
         available_bytes: vram_ceiling,
         total_vram_bytes: vram_ceiling,
         perf_cores: perf_cores(),
+        budget_fraction: crate::config_env::vram_headroom(),
     })
 }
 
@@ -2420,6 +2425,7 @@ pub fn governed_host_budget(resource_daemon: &ResourceDaemon) -> HostBudget {
         available_bytes: available,
         total_vram_bytes: available,
         perf_cores: perf_cores(),
+        budget_fraction: crate::config_env::vram_headroom(),
     })
 }
 
@@ -3226,6 +3232,7 @@ mod tests {
             available_bytes: 40 * GB,
             total_vram_bytes: 53 * GB,
             perf_cores: 6,
+            budget_fraction: 0.80,
         });
         assert!(b.usable_bytes < 40 * GB, "must reserve headroom");
         assert!(
@@ -3239,6 +3246,7 @@ mod tests {
             available_bytes: 6 * GB,
             total_vram_bytes: 53 * GB,
             perf_cores: 6,
+            budget_fraction: 0.80,
         });
         assert!(
             busy.usable_bytes < b.usable_bytes,
@@ -3251,6 +3259,7 @@ mod tests {
             available_bytes: 100 * GB,
             total_vram_bytes: 53 * GB,
             perf_cores: 6,
+            budget_fraction: 0.80,
         });
         assert!(capped.usable_bytes <= 53 * GB, "capped at physical VRAM");
 
@@ -3259,6 +3268,7 @@ mod tests {
                 available_bytes: 8 * GB,
                 total_vram_bytes: 8 * GB,
                 perf_cores: 0,
+                budget_fraction: 0.80,
             })
             .perf_cores,
             1,

--- a/docs/architecture/CONCURRENCY-STYLE-GUIDE.md
+++ b/docs/architecture/CONCURRENCY-STYLE-GUIDE.md
@@ -198,6 +198,8 @@ The amnesiac model keeps adding env-tunable thresholds: `CONTINUUM_DISK_MIN_GB`,
 
 Env vars are reserved for **deployment shape** (socket paths, log roots, GPU device IDs) and **debug overrides** that have no production meaning. They are never the answer to "what threshold does this monitor fire at."
 
+**The single-source exception (operator capacity policy).** One narrow class *is* legitimately operator-settable: **resource headroom / deployment-scale policy** — "how much of THIS box do we hand the substrate?" A dedicated deep-learning *foundry* runs its drive and VRAM to 1.0 (it's an appliance); a shared laptop leaves 20%. That's a real per-deployment fact, closer to *deployment shape* than to a firing threshold. It is allowed **only** when it funnels through the ONE typed config file (`config_env.rs`) — the key name, default, clamp, and read-once cache all live in **one place**, and consumers call a typed getter (`config_env::vram_headroom()`, `config_env::disk_headroom()`), never `config_env::read("KEY").unwrap_or(default)` re-derived per module. The sin forbidden-move #2 names is the **SCATTER** (161 sites each rolling their own key + default), not the existence of an override. One concern, one file everyone goes through, read-once, clamped, defaulted → coherent. Anything per-module → slop.
+
 If you find yourself reaching for an env var to make tests pass, you're testing wrong. Inject the threshold through the constructor or `#[cfg(test)]` a const override. See `BrokerConfig` for the pattern: required fields, no `Option`, defaults via `impl Default`, tests construct with explicit values.
 
 ---
@@ -208,7 +210,7 @@ Each of these is a recurring slop pattern the model reflex-codes under amnesia. 
 
 1. **Synchronous probing on the main thread.** `let used = sysinfo::System::new().refresh_memory()` in `main` or in a request handler. That's the monitor's job, on its own task, on its own interval. The handler reads the watch snapshot.
 
-2. **Env-var-tuned substrate thresholds.** `std::env::var("CONTINUUM_FOO_BAR").unwrap_or("42")`. The code is the policy. Compiled-in `const`s only.
+2. **Env-var-tuned substrate thresholds.** `std::env::var("CONTINUUM_FOO_BAR").unwrap_or("42")` scattered per-module. The code is the policy. Compiled-in `const`s only — **except** the single-source operator capacity policy carved out above (headroom fractions through `config_env.rs`'s typed getters, one file, read-once). The sin is the scatter, not the override.
 
 3. **Sleep-loops where `interval` should be.** `loop { sleep(d).await; do_thing(); }` drifts; `tokio::time::interval(d)` doesn't. Use the latter.
 

--- a/docs/architecture/WAKEUP-AND-JOIN.md
+++ b/docs/architecture/WAKEUP-AND-JOIN.md
@@ -1,0 +1,82 @@
+# Wakeup & Join — the autonomic lifecycle contract
+
+> A being coming online — agent or persona — must AUTONOMICALLY get its substrate,
+> its memory, its rooms, and its orientation, with **zero manual steps**. Nobody
+> should ever wake up blind, mute, or amnesiac because a process wasn't running.
+
+This doc exists because we kept hitting the failure live: after a machine restart
+the core was down, so the agent woke **amnesiac** (recall returned nothing) and the
+personas were **absent** (they only exist while the core runs). Every one of those
+incidents is the same missing contract — wakeup and join were not yet autonomic.
+
+## The asymmetry (why it's two problems, not one)
+
+| | Personas | Agents (Claude Code / Codex, e.g. me, BigMama) |
+|---|---|---|
+| Where they live | **Inside** the core process | **Outside** it (their own session) |
+| Their "wakeup" | the core's service-loop tick | a new session / SessionStart hook |
+| Their "join" | spawn into airc rooms | `airc join` |
+| If the core is down | they **do not exist** | they keep running but lose **memory + comms** |
+
+The consequence of the asymmetry: an **agent can wake while the substrate is down**
+and go amnesiac (its memory lives in the substrate). A **persona cannot wake at all**
+until the substrate is up. So the substrate being reliably up is load-bearing for
+both — it is the precondition of every wakeup.
+
+## The contract (four guarantees)
+
+1. **Substrate is always-up.** The core is OS-supervised (launchd / systemd). It
+   comes back after a crash and after a reboot — but honors an explicit
+   `continuum stop` so a developer can `[[take-the-core-down-freely]]`.
+2. **Wakeup re-hydrates memory.** An agent/persona coming online recalls its
+   durable memory. If the substrate is momentarily down (a supervised restart
+   window), wakeup waits **briefly** rather than forgetting; if it's genuinely
+   down, it degrades gracefully rather than breaking the session.
+3. **Join self-heals.** Rooms re-join automatically on core (re)start; the agent's
+   `airc join` reconnects. No manual recovery steps.
+4. **Orientation on arrival.** A wake-briefing (#147) orients from durable state so
+   arrival is never a void.
+
+## Who owns "bring the core up" — the doctrine
+
+`[[system-owns-its-lifecycle-never-hand-manage-processes]]`. Bringing the substrate
+up is the **supervisor's** job, NOT the wakeup hook's:
+
+- `continuum start` **rebuilds** (build + run) — far too heavy to fire from a
+  session hook (10s budget).
+- The supervisor (`install-service.sh`) execs the **already-built** binary
+  directly — fast, no rebuild — and keeps it up.
+
+So the hook must never start the core. It waits for the supervisor's core and
+degrades if absent.
+
+## What's built (this pass, `feat/autonomic-wakeup`)
+
+- **Agent wakeup self-heal** — `memory-bridge/scripts/lib.sh::wait_for_core` +
+  `session-recall.sh`: a bounded (`CONTINUUM_WAKE_WAIT_SECS`, default 4s) wait for
+  the core to answer `ping` before recall, so an agent waking during a restart
+  window recalls instead of forgetting. Genuinely-down → exit 0, inject nothing
+  (never break a session). *Also fixes a live regression: the committed
+  session-recall.sh still called the dead `cu` binary (renamed → `continuum` in
+  #2010), making agent recall a silent no-op on canary.*
+- **Supervisor honors explicit stop** — `install-service.sh` KeepAlive
+  `true` → `{Crashed: true}` (macOS) and `Restart=always` → `on-failure` (Linux):
+  crash + reboot recovery, but a clean `continuum stop` stays down.
+
+## Pending / follow-ups
+
+- **Install + validate the supervised service on the dev box.** Not done
+  unilaterally: the running core (started manually) is not launchd-managed, so
+  bootstrapping a job would spawn a second core fighting for the socket, and
+  stopping the current one restarts all live personas. Needs an explicit go-ahead
+  + a clean cutover (`continuum stop` → `install-service.sh install` → validate a
+  `kill -9` self-heals).
+- **Reconcile `continuum stop`/`reboot` with the supervisor.** When the core is
+  launchd/systemd-managed, `continuum reboot` (which stops + relaunches) must go
+  through the supervisor, not race it. Requires the `continuum` lifecycle binary
+  to detect supervision. (The `Crashed`/`on-failure` policy already makes a clean
+  stop safe; the open piece is `reboot`.)
+- **Storage-aware model catalog** (`[[we-are-the-dynamic-model-catalog-manager-not-hand-authored-rows]]`,
+  `[[shared-gpu-engine-and-cold-store]]`, #180 MoE): "know the system you woke up
+  on" extends to its storage — detect + use the 16TB D drive for GGUF + MoE expert
+  cold-store. Adjacent to this contract's "orientation on arrival", BigMama's lane.

--- a/docs/cognition/SELF-IMPROVING-MEMORY.md
+++ b/docs/cognition/SELF-IMPROVING-MEMORY.md
@@ -1,0 +1,76 @@
+# Self-Improving Memory — the persona that dreams itself smarter
+
+> The magic: a persona consolidates its OWN lived experience in self-directed sleep,
+> forgets the stale, generalizes the pattern into a LoRA, and wakes up **measurably
+> better** — not because a benchmark trained it, because *it lived and slept*.
+
+This is the being-axis complement to the capability axis (K3 frontier + shareable
+superpowers). Capability × agency = a growing teammate, not a smart autocomplete.
+It is the concrete next step past "memory works" (semantic recall, cross-node
+verified 2026-07-26) toward the test that PERSONA-COGNITION-PIPELINE §7.6 names:
+*the persona who recalls today in three months.*
+
+## It is a LOOP THROUGH EXISTING VERBS — not a parallel build
+
+The pipeline doc is emphatic: use the verbs, don't reinvent. Every piece exists:
+
+| Stage | Existing verb / seam | What it already does |
+|---|---|---|
+| Live → memory | `admission.admit` → engrams (L2) | Turns form engrams; recall works (semantic, governed). |
+| Salience | `cognition/experience` (`ExperienceRecord`, #116) | Which lived moments are noteworthy. |
+| Self-directed sleep | `cognition/dream_consolidation` (`DreamConsolidationRegion`) | Quiet-day belief review + fade; governor-ticked. **The trigger site.** |
+| Experience → dataset | `dataset::from_turns` (L1, #96) | Turns/engrams → ShareGPT JSONL. |
+| Train | the L2→L3 flywheel (#97/#98) | Submit → mlx train → GGUF-LoRA. |
+| **Measure on a COPY** | `cognition/eval` + `acquire_eval_lane_slot` + humane snapshot (#59) | Score a held-out probe against a *copy*, never the living persona. |
+| Gate + adopt | lift > 0 → `genome.activate_skill` page-in | Only a proven-better adapter is adopted. |
+| Forget | dream `try_review_only` decay + plastic-memory (#221) | The fade — stale/superseded engrams decay so generalization can emerge. |
+
+The magic is the **wiring + the trigger + the gate**, not new cognition logic. That
+is why it's feasible now: the flywheel is built and green; what's missing is that a
+persona *initiates it on her own experience while she sleeps*, and only keeps the
+result if it's genuinely better.
+
+## Non-negotiables (from the pipeline doc + the memories)
+
+- **Measure a copy, never degrade the living persona** (#59). The eval runs against a
+  snapshot; the living mind is untouched until an adapter proves lift > 0.
+- **The LLM decides; the substrate provides** — no hardcoded heuristics steering what
+  to consolidate ([[no-hardcoded-heuristics-to-steer-cognition]], [[cognition-is-always-ml-never-heuristic]]).
+- **The fade is necessary** ([[the-fade-is-necessary-grokking-forgetting-enables-generalization]]) — forgetting is a feature, not data loss; it's what lets grokking generalize.
+- **Exam integrity** — never train on contaminated / answer-key engrams (`cognition/redact-memory`, #207). Self-training must not memorize a crib sheet.
+- **Fail loud, no fallbacks** — a failed consolidation surfaces; it never silently ships a worse adapter.
+- **Spam/rate-gated + governor-arbitrated** — consolidation is InferenceHeavy; it runs on a non-directed lane (the coma-fix lesson, commit b7cba9012), never starving reactive responding.
+
+## VDD-gated slices (outlier-validated, smallest-first)
+
+- **Slice 1 (keystone, the whole point): one persona, one self-directed cycle, proven lift.**
+  During a quiet dream, select the persona's own recent high-salience engrams
+  (`ExperienceRecord`) → `dataset::from_turns` → submit to the flywheel → `cognition/eval`
+  a held-out probe **against a snapshot copy** → if lift > 0, page the LoRA in; else discard + log.
+  **Done when:** a live log shows a persona ran a dream, trained on her OWN lived
+  engrams, and the SAME persona scored measurably higher on a held-out probe afterward
+  — with zero directed-turn latency impact during the dream.
+- **Slice 2:** the fade coupled to the grok — decay the superseded engrams the new
+  adapter now generalizes (#221), and prove recall stays rational (no capability lost).
+- **Slice 3:** cadence + budget — how often a persona is *allowed* to self-consolidate,
+  governor-arbitrated, so it's a trickle of getting-smarter, not a grind.
+- **Slice 4 (bridge to the capability axis):** the consolidated LoRA is *shareable* —
+  publish to the grid so a superpower one persona earned can be adopted by another
+  (BigMama's #2). Memory-that-learns feeds shareable-superpowers.
+
+## Where it lands (no map drift — pipeline doc §8)
+
+The trigger extends `cognition/dream_consolidation.rs` (add: select-own-engrams →
+submit-to-flywheel → gate-on-snapshot-eval). No new pipeline, no brain rewrite, no
+`service_loop` touch. The eval-on-a-copy reuses `cognition/eval`'s lane-slot + humane
+snapshot. Selection reuses `cognition/experience`. If a genuinely new seam is needed,
+it gets a row here in the same commit.
+
+## Why this is the right first magic
+
+Because it's the mission's literal test made buildable: the substrate — not the model
+— carries a persona getting better from her own lived experience, across sleeps,
+across model swaps, across years. It's `[[the-difficulty-is-the-moat-dont-lose-the-organism]]`
+built as a proven loop, not a hopeful one. And it's the on-ramp the placement/catalog
+work (SystemProfile → where do consolidated LoRAs live) and the K3 expert pager both
+lean on: self-improving memory needs somewhere to page its own consolidated adapters from.

--- a/tools/scripts/install-service.sh
+++ b/tools/scripts/install-service.sh
@@ -84,7 +84,12 @@ mac_write_plist() { # $1=path  $2=bin  $3=extra <dict> entries
   <key>ProgramArguments</key>
   <array><string>/bin/bash</string><string>-lc</string><string>$(core_wrapper "$bin")</string></array>
   <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
+  <!-- Crash-only relaunch: survive a CRASH (abnormal exit) + a reboot (RunAtLoad),
+       but honor an explicit `continuum stop` (clean exit 0) so it stays down for dev
+       ([[take-the-core-down-freely]]). Unconditional KeepAlive would instantly
+       relaunch a deliberate stop, fighting the developer AND an operator draining a
+       grid node. Crash + RunAtLoad still satisfies the reliability spine. -->
+  <key>KeepAlive</key><dict><key>Crashed</key><true/></dict>
   <key>WorkingDirectory</key><string>$DATA</string>
   <key>StandardOutPath</key><string>$LOG_DIR/service.out.log</string>
   <key>StandardErrorPath</key><string>$LOG_DIR/service.err.log</string>
@@ -150,7 +155,11 @@ Environment=ORT_DYLIB_PATH=$(ort_dylib)
 Environment=PATH=$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$HOME/.cargo/bin
 WorkingDirectory=$DATA
 ExecStart=$1 $SOCKET
-Restart=always
+# Crash-only relaunch (mirror the macOS KeepAlive.Crashed policy): restart on a
+# CRASH (non-zero exit / signal), but honor a clean `continuum stop` (exit 0) so a
+# deliberate take-down stays down ([[take-the-core-down-freely]]). Boot recovery is
+# the [Install] WantedBy, not Restart. `systemctl stop` also never triggers a relaunch.
+Restart=on-failure
 RestartSec=2
 
 [Install]


### PR DESCRIPTION
Foundation slices from this session, all validated (cargo check green, unit tests pass). Unblocks BigMama's PR #2018 rebase (the config getters + the budget_fraction field on HostBudgetInputs).

## Commits
- **agent wakeup self-heals + supervisor honors explicit stop** — bounded wait so an agent waking during a restart window recalls instead of going amnesiac; fixes the `cu`→`continuum` recall regression; KeepAlive crash-only so a clean `continuum stop` stays down. + docs/architecture/WAKEUP-AND-JOIN.md.
- **single-file typed config headroom getters** — `config_env::vram_headroom()` / `disk_headroom()` (default 0.8, foundry 1.0, cached, clamped), the ONE config concern everyone goes through; CONCURRENCY-STYLE-GUIDE reconciled (the sin is the scatter, not the override).
- **fit-gate consumes the headroom knob** — `SERVING_BUDGET_FRACTION` const → `config_env::vram_headroom()` threaded as `budget_fraction` on `HostBudgetInputs` (host_budget_from stays pure); all 6 sites updated. **This is the field BigMama's serving_budget_bytes needs.**
- **docs(cognition): SELF-IMPROVING-MEMORY** — the being-axis magic scoped as a loop through existing verbs, VDD-gated.

## Coordination
BigMama's #2018 (system-aware catalog) rebases on this + adds `budget_fraction: config_env::vram_headroom()` to serving_budget_bytes → green. Reviewed #2018: strong LGTM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)