### PR TITLE
feat(plugin): /share skill — the invocation handle for agent-to-agent engram handoff

### DIFF
--- a/tools/plugins/memory-bridge/.claude-plugin/plugin.json
+++ b/tools/plugins/memory-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-bridge",
-  "description": "Agent memory bridge — automatic relevance-recall at session start (incl. after compaction) plus /remember and /recall, backed by the continuum memory/* substrate. Stops the agent re-forgetting across amnesia resets.",
+  "description": "Agent memory bridge — automatic relevance-recall at session start (incl. after compaction) plus /remember, /recall, and /share (hand a lesson to another agent), backed by the continuum memory/* substrate. Stops the agent re-forgetting across amnesia resets.",
   "version": "0.1.0",
   "author": {
     "name": "Continuum (BigMama + M5)"

--- a/tools/plugins/memory-bridge/README.md
+++ b/tools/plugins/memory-bridge/README.md
@@ -10,6 +10,9 @@ re-forgetting across amnesia resets by making relevance-recall **automatic**.
   the exact moment an agent would otherwise re-forget.
 - **`/remember <lesson>`** — store a durable lesson (agent-origin engram).
 - **`/recall <query>`** — explicit relevance search.
+- **`/share <recipient> <lesson>`** — hand a lesson directly to another agent's memory
+  (engram handoff / telepathy): lands in THEIR corpus with shared-by provenance, surfaces
+  in their recall, tagged received-from-you.
 
 ## Architecture
 All three shell to ONE seam: `ctm memory {store,recall}` (the runtime-agnostic

--- a/tools/plugins/memory-bridge/scripts/share.sh
+++ b/tools/plugins/memory-bridge/scripts/share.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# share.sh — hand a durable lesson to ANOTHER agent's corpus (engram handoff / telepathy).
+#
+# Usage: share.sh "<recipient peer id or airc name>" "<lesson text>"
+#
+# The cross-agent twin of remember.sh: where /remember writes a lesson into YOUR own
+# corpus (self-learned), /share writes it into the RECIPIENT's corpus with shared-by
+# provenance (memory_type=shared, source=shared:<you>), so a lesson you learned once
+# lands in another agent's memory without them re-deriving it. Their recall surfaces it,
+# tagged as received-from-you.
+#
+# Fail-LOUD: a /share that silently no-ops is worse than an error.
+#
+# ZERO shell JSON — `memory/share` takes FLAT params and builds+escapes the record via
+# serde server-side. Lesson quotes/newlines are the shell's problem (one CLI arg), not JSON's.
+set -uo pipefail
+
+RECIPIENT="${1:-}"
+CONTENT="${2:-}"
+if [ -z "$RECIPIENT" ] || [ -z "$CONTENT" ]; then
+  echo "share: usage: share \"<recipient peer id or airc name>\" \"<lesson>\"" >&2
+  echo "  find recipients with: airc peers" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib.sh"
+CONTINUUM="$(resolve_continuum)" || { echo "share: 'continuum' CLI not found (build the core, or set CONTINUUM_BIN)" >&2; exit 1; }
+
+FROM="$(resolve_agent_persona)"
+[ -n "${FROM:-}" ] || { echo "share: could not resolve THIS agent's persona (airc peer id)" >&2; exit 1; }
+
+# Resolve the recipient. A full UUID is used verbatim; otherwise treat it as an airc
+# name and look up its peer id via `airc whois` (falling back to a `airc peers` scan).
+# Fail loud if it can't be resolved — sharing to a phantom peer is a silent black hole.
+resolve_recipient() {
+  local raw="$1"
+  if printf '%s' "$raw" | grep -qiE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
+    printf '%s' "$raw"; return 0
+  fi
+  # Name → peer id via airc, best-effort (whois first, then a peers-table scan).
+  local id
+  id="$(airc whois "$raw" 2>/dev/null | grep -oiE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)"
+  [ -z "$id" ] && id="$(airc peers 2>/dev/null | grep -iF "$raw" | grep -oiE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)"
+  printf '%s' "$id"
+}
+
+TO="$(resolve_recipient "$RECIPIENT")"
+[ -n "${TO:-}" ] || { echo "share: could not resolve recipient '$RECIPIENT' to a peer id (try: airc peers)" >&2; exit 1; }
+
+SCOPE="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+
+if "$CONTINUUM" memory/share --from_persona_id "$FROM" --to_persona_id "$TO" --content "$CONTENT" --scope "$SCOPE" 2>/dev/null | grep -q '"appended"\|"id"'; then
+  echo "shared to $TO (scope: $SCOPE): ${CONTENT:0:80}"
+else
+  echo "share: continuum memory/share failed (is the server up? try: continuum ping)" >&2
+  exit 1
+fi

--- a/tools/plugins/memory-bridge/skills/share/SKILL.md
+++ b/tools/plugins/memory-bridge/skills/share/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: share
+description: Hand a durable lesson directly to ANOTHER agent's memory (engram handoff / telepathy). Use when you learn something a teammate agent (M5, a persona, Codex) should know without re-deriving it — a correction, a gotcha, a hard-won invariant. Lands in THEIR corpus with shared-by provenance and surfaces in their future recall.
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/share.sh *)
+---
+
+# Share
+
+Hand this lesson to another agent so they don't have to learn it the hard way too.
+
+Parse **$ARGUMENTS** as `<recipient> — <lesson>` (recipient first, then the lesson).
+The recipient is an airc peer id or name (find them with `airc peers`).
+
+Run:
+```
+${CLAUDE_PLUGIN_ROOT}/scripts/share.sh "<recipient>" "<lesson>"
+```
+
+The cross-agent twin of `/remember`: where `/remember` stores a lesson in YOUR own
+corpus (self-learned), `/share` writes it into the RECIPIENT's corpus via
+`continuum memory/share` with shared-by provenance (`memory_type=shared`,
+`source=shared:<you>`, `context.shared_by`). A lesson you learned once lands in another
+agent's memory without them re-deriving it; their recall surfaces it, tagged
+received-from-you. The recipient's cognition can weight a *taught* lesson differently
+from a self-learned one (ReceivedSalience — the deliberate act of sharing IS the signal).
+
+Confirm to the user in one line what was shared and to whom. Share concrete, load-bearing
+lessons ("M5 — the airc send-truncation is a genuine bug airc#1292, not a stale build; use
+single-line until fixed"), not chatter — a shared lesson enters the recipient's durable
+memory and their learning stream.


### PR DESCRIPTION
`memory/share` (#2025) gave the substrate the capability; this gives agents the **handle** to use it.

The cross-agent twin of `/remember`: where `/remember` stores a lesson in the agent's own corpus, `/share` hands it to **another** agent — lands in their corpus with shared-by provenance, surfaces in their recall, tagged received-from-you (and feeds M5's `ReceivedSalience` learning path).

- `share.sh` mirrors `remember.sh` (resolve continuum + agent persona, project scope, fail-loud, zero shell JSON) + recipient resolution: UUID verbatim, name via `airc whois`/`airc peers`, fail-loud on a phantom peer.
- Registered in `plugin.json` + README alongside `/remember` and `/recall`.

Plugin-only (shell + markdown), no Rust build. The telepathy seed is now invokable end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)