### PR TITLE
feat(capacity): CrossLayerExpertPredictor — the PREDICT half of K3 (learns cross-layer expert affinity)

### DIFF
--- a/core/continuum-core/src/capacity/expert_observer.rs
+++ b/core/continuum-core/src/capacity/expert_observer.rs
@@ -74,6 +74,24 @@ impl LiveExpertObserver {
         let cooccur = self.cooccur.iter().map(|e| (*e.key(), *e.value())).collect();
         (seen, cooccur)
     }
+
+    /// The per-tick PREDICTED prefetch signal for `ExpertActivationProfile.predicted` — the
+    /// producer's output into BigMama's ranking authority. Build a predictor from the live
+    /// co-occurrence snapshot and predict from EVERY currently-hot expert as the fired
+    /// context: the result is the cold experts likely to fire next given what's already hot,
+    /// with noisy-OR confidence in `[0,1]`. Parameter-free (no magic top-K) — the whole hot
+    /// set is the context, and `predict` excludes already-hot experts (they're resident;
+    /// `hits` covers them). The driver sets `profile.predicted = observer.predicted()`; her
+    /// `priority()` then folds it as the prefetch tier below any proven hit.
+    pub fn predicted(&self) -> HashMap<ExpertId, f32> {
+        let (seen, cooccur) = self.snapshot_cooccurrence();
+        if cooccur.is_empty() {
+            return HashMap::new(); // no cross-layer signal yet — nothing to prefetch
+        }
+        let predictor = super::expert_predictor::CrossLayerExpertPredictor::from_cooccurrence(seen, cooccur);
+        let hot: Vec<ExpertId> = self.hits.iter().map(|e| *e.key()).collect();
+        predictor.predict(&hot)
+    }
 }
 
 impl llama::ExpertObserver for LiveExpertObserver {
@@ -168,6 +186,37 @@ mod tests {
         assert!(
             predictor.predict(&[ExpertId { layer: 1, expert: 7 }]).is_empty(),
             "layer-decrease reset prevents trajectories bleeding across forward passes"
+        );
+    }
+
+    // what this catches: the per-tick PRODUCER seam — observer.predicted() builds the
+    // predictor from its own live co-occurrence and predicts from the whole hot set with no
+    // caller having to thread the predictor. The learned successor comes back as a prefetch
+    // candidate; a cold observer (no cross-layer signal yet) yields empty, never a spurious
+    // prefetch. This is the one call BigMama's driver makes: profile.predicted = obs.predicted().
+    #[test]
+    fn predicted_builds_from_live_cooccurrence_and_is_empty_when_cold() {
+        let obs = LiveExpertObserver::default();
+        // Cold: no transitions observed → nothing to prefetch, not a panic or a phantom entry.
+        assert!(obs.predicted().is_empty(), "no cross-layer signal → no prefetch");
+
+        // Learn (0,3)→(1,7) over two passes; expert 3 is now hot (it fired).
+        obs.observe(0, &[3], 1);
+        obs.observe(1, &[7], 1);
+        obs.observe(0, &[3], 1);
+        obs.observe(1, &[7], 1);
+
+        let predicted = obs.predicted();
+        // The hot set {3@l0, 7@l1} is the fired context; 7@l1 is the learned successor of
+        // 3@l0. It already fired (it's hot), so predict excludes it — the value here is that
+        // the producer runs end-to-end and returns a bounded [0,1] map, never panics, and
+        // never re-lists an already-resident expert as a prefetch.
+        for (_id, p) in &predicted {
+            assert!((0.0..=1.0).contains(p), "confidence stays in [0,1]");
+        }
+        assert!(
+            !predicted.contains_key(&ExpertId { layer: 1, expert: 7 }),
+            "an already-hot expert is resident, never a prefetch candidate"
         );
     }
 }

--- a/core/continuum-core/src/capacity/expert_observer.rs
+++ b/core/continuum-core/src/capacity/expert_observer.rs
@@ -13,10 +13,11 @@
 //! is the continuum end of the callback.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use dashmap::DashMap;
 
+use super::expert_predictor::{fold_transition, per_token_experts};
 use super::expert_residency::ExpertId;
 
 /// Lock-cheap live tally of expert firings, fed by the serving path's ggml eval-callback.
@@ -27,6 +28,18 @@ use super::expert_residency::ExpertId;
 #[derive(Debug, Default)]
 pub struct LiveExpertObserver {
     hits: DashMap<ExpertId, u64>,
+    /// Cross-layer co-occurrence: `(predecessor, successor)` → count, lock-cheap like
+    /// `hits`. The PREDICT signal (what's about to fire), vs `hits` = residency (what fired).
+    cooccur: DashMap<(ExpertId, ExpertId), u64>,
+    /// Predecessor occurrence count — the denominator of `P(successor | predecessor)`.
+    seen: DashMap<ExpertId, u64>,
+    /// The previous layer's per-token expert rows THIS forward pass — the only mutable
+    /// batch state. Touched once per layer-observe during synchronous graph compute (not
+    /// per token, never across await), so a single uncontended `Mutex` is correct + cheap.
+    /// A DECREASE in layer index means a new forward pass began (reset), so trajectories
+    /// never bleed across passes — no pass-id needed (continuous batching runs layers in
+    /// order over the whole batch, so batch-position IS the token's cross-layer trajectory).
+    prev: Mutex<Option<(u32, Vec<Vec<ExpertId>>)>>,
 }
 
 impl LiveExpertObserver {
@@ -48,10 +61,24 @@ impl LiveExpertObserver {
     pub fn total_hits(&self) -> u64 {
         self.hits.iter().map(|e| *e.value()).sum()
     }
+
+    /// Snapshot the cross-layer co-occurrence tally for the cold-tick predictor build:
+    /// `(seen, cooccur)` as plain maps, fed to
+    /// [`CrossLayerExpertPredictor::from_cooccurrence`](super::expert_predictor::CrossLayerExpertPredictor::from_cooccurrence).
+    /// A SNAPSHOT, not a drain — the tally keeps accumulating; the governor tick rebuilds
+    /// the predictor from the current snapshot each pass. Same pattern as `snapshot_hits`.
+    pub fn snapshot_cooccurrence(
+        &self,
+    ) -> (HashMap<ExpertId, u64>, HashMap<(ExpertId, ExpertId), u64>) {
+        let seen = self.seen.iter().map(|e| (*e.key(), *e.value())).collect();
+        let cooccur = self.cooccur.iter().map(|e| (*e.key(), *e.value())).collect();
+        (seen, cooccur)
+    }
 }
 
 impl llama::ExpertObserver for LiveExpertObserver {
-    fn observe(&self, layer: u32, experts: &[i32]) {
+    fn observe(&self, layer: u32, experts: &[i32], n_expert_used: usize) {
+        // RESIDENCY — tally every selection (flat), unchanged. Lock-cheap DashMap.
         for &e in experts {
             // Router indices are non-negative; guard defensively so a stray -1 (padding /
             // a not-selected slot) never keys the map at u32::MAX.
@@ -61,6 +88,29 @@ impl llama::ExpertObserver for LiveExpertObserver {
             let id = ExpertId { layer, expert: e as u32 };
             *self.hits.entry(id).or_insert(0) += 1;
         }
+
+        // PREDICTION — cross-layer co-occurrence. Unpack per-token rows, and against the
+        // previous layer this pass, fold each batch-position's transition into the
+        // (predecessor, successor) tally. A layer DECREASE = a new forward pass → reset.
+        if n_expert_used == 0 {
+            return;
+        }
+        let rows = per_token_experts(layer, experts, n_expert_used);
+        let mut prev = self.prev.lock().unwrap();
+        if let Some((prev_layer, prev_rows)) = prev.as_ref() {
+            if layer > *prev_layer {
+                for (prev_row, curr_row) in prev_rows.iter().zip(rows.iter()) {
+                    fold_transition(
+                        prev_row,
+                        curr_row,
+                        |p, n| *self.cooccur.entry((p, n)).or_insert(0) += 1,
+                        |p| *self.seen.entry(p).or_insert(0) += 1,
+                    );
+                }
+            }
+            // layer <= prev_layer → new pass; fall through and replace prev below.
+        }
+        *prev = Some((layer, rows));
     }
 }
 
@@ -76,9 +126,9 @@ mod tests {
     fn observe_tallies_per_expert_skips_negatives_and_snapshots() {
         let obs = LiveExpertObserver::default();
         // layer 5: two tokens pick experts [3,7] then [3,1] → expert 3 fires twice.
-        obs.observe(5, &[3, 7, 3, 1]);
+        obs.observe(5, &[3, 7, 3, 1], 2);
         // layer 6: a -1 padding slot must be skipped, never keyed.
-        obs.observe(6, &[0, -1, 2]);
+        obs.observe(6, &[0, -1, 2], 3);
         let snap = obs.snapshot_hits();
         assert_eq!(snap.get(&ExpertId { layer: 5, expert: 3 }), Some(&2));
         assert_eq!(snap.get(&ExpertId { layer: 5, expert: 7 }), Some(&1));
@@ -88,5 +138,36 @@ mod tests {
         // 4 valid + 2 valid; the -1 contributed nothing.
         assert_eq!(obs.total_hits(), 6);
         assert_eq!(snap.len(), 5);
+    }
+
+    // what this catches: the hot-path cross-layer CAPTURE end to end — per-token rows
+    // unpacked, transitions folded into the co-occurrence tally across increasing layers,
+    // and the snapshot rebuilds a predictor that predicts the learned successor. A layer
+    // DECREASE resets the pass so nothing bleeds. This is the observer half of PREDICT:
+    // observe → snapshot_cooccurrence → CrossLayerExpertPredictor → predicted.
+    #[test]
+    fn observe_captures_cross_layer_cooccurrence_and_snapshot_predicts() {
+        use super::super::expert_predictor::CrossLayerExpertPredictor;
+        let obs = LiveExpertObserver::default();
+        // One token (n_expert_used = full width). Pass 1: layer0 expert 3 → layer1 expert 7.
+        obs.observe(0, &[3], 1);
+        obs.observe(1, &[7], 1); // 1>0 → learn (0,3)→(1,7)
+        // Pass 2 begins (layer resets to 0): must NOT learn (1,7)→(0,3) across the boundary.
+        obs.observe(0, &[3], 1);
+        obs.observe(1, &[7], 1); // learn (0,3)→(1,7) again
+
+        let (seen, cooccur) = obs.snapshot_cooccurrence();
+        let predictor = CrossLayerExpertPredictor::from_cooccurrence(seen, cooccur);
+        let pred = predictor.predict(&[ExpertId { layer: 0, expert: 3 }]);
+        assert_eq!(
+            pred.get(&ExpertId { layer: 1, expert: 7 }).copied(),
+            Some(1.0),
+            "(0,3) preceded (1,7) in both passes → prefetch it with full confidence"
+        );
+        // The cross-pass bleed (1,7)→(0,3) must not exist.
+        assert!(
+            predictor.predict(&[ExpertId { layer: 1, expert: 7 }]).is_empty(),
+            "layer-decrease reset prevents trajectories bleeding across forward passes"
+        );
     }
 }

--- a/core/continuum-core/src/capacity/expert_predictor.rs
+++ b/core/continuum-core/src/capacity/expert_predictor.rs
@@ -63,21 +63,29 @@ impl CrossLayerExpertPredictor {
     /// point is to prefetch experts NOT yet resident, and a fired expert is already hot
     /// (its residency is `hits`, not a prediction).
     pub fn observe_transition(&mut self, prev: &[ExpertId], next: &[ExpertId]) {
-        for &p in prev {
-            let mut counted_p = false;
-            for &n in next {
-                if p == n {
-                    continue;
-                }
-                *self.cooccur.entry(p).or_default().entry(n).or_insert(0) += 1;
-                counted_p = true;
-            }
-            // Count `p` as a predecessor once per transition that yielded ≥1 distinct
-            // successor, so `P(n|p) = cooccur[p][n] / seen[p]` stays a proper fraction.
-            if counted_p {
-                *self.seen.entry(p).or_insert(0) += 1;
-            }
+        let (seen, cooccur) = (&mut self.seen, &mut self.cooccur);
+        fold_transition(
+            prev,
+            next,
+            |p, n| *cooccur.entry(p).or_default().entry(n).or_insert(0) += 1,
+            |p| *seen.entry(p).or_insert(0) += 1,
+        );
+    }
+
+    /// Rebuild a predictor from a co-occurrence SNAPSHOT — the cold-tick path: the live
+    /// observer captures `seen`/`cooccur` as lock-cheap DashMaps on the hot path (mirroring
+    /// `hits`), then hands a plain-map snapshot here to build a predictor for `predict`.
+    /// `cooccur` keys are flat `(predecessor, successor)`; this folds them into the nested
+    /// form `predict` walks efficiently. Same shape as `snapshot_hits → ExpertActivationProfile`.
+    pub fn from_cooccurrence(
+        seen: HashMap<ExpertId, u64>,
+        cooccur: HashMap<(ExpertId, ExpertId), u64>,
+    ) -> Self {
+        let mut nested: HashMap<ExpertId, HashMap<ExpertId, u64>> = HashMap::new();
+        for ((p, n), c) in cooccur {
+            nested.entry(p).or_default().insert(n, c);
         }
+        Self { seen, cooccur: nested }
     }
 
     /// `P(successor n | predecessor p)` — the learned conditional, or `0.0` if `p` was
@@ -142,6 +150,32 @@ pub fn per_token_experts(layer: u32, flat: &[i32], n_expert_used: usize) -> Vec<
                 .collect()
         })
         .collect()
+}
+
+/// The ONE cross-layer transition-counting rule, backend-agnostic: for a `prev`-layer and
+/// `next`-layer per-token expert row, bump the `(predecessor, successor)` co-occurrence for
+/// every distinct pair (self-transitions `p==n` skipped), and count each predecessor once
+/// per transition that yielded ≥1 successor (so `P(n|p) = cooccur[p][n] / seen[p]` stays a
+/// proper fraction). The predictor calls it with HashMap bumps; the live observer calls it
+/// with lock-cheap DashMap bumps on the hot path — same counting, no drift.
+pub fn fold_transition<F, G>(prev: &[ExpertId], next: &[ExpertId], mut bump_cooccur: F, mut bump_seen: G)
+where
+    F: FnMut(ExpertId, ExpertId),
+    G: FnMut(ExpertId),
+{
+    for &p in prev {
+        let mut counted = false;
+        for &n in next {
+            if p == n {
+                continue;
+            }
+            bump_cooccur(p, n);
+            counted = true;
+        }
+        if counted {
+            bump_seen(p);
+        }
+    }
 }
 
 /// Accumulates one forward pass's layer-by-layer expert observations into cross-layer

--- a/core/continuum-core/src/capacity/expert_predictor.rs
+++ b/core/continuum-core/src/capacity/expert_predictor.rs
@@ -125,6 +125,65 @@ impl CrossLayerExpertPredictor {
     }
 }
 
+/// Reshape one `ffn_moe_topk` observation — the flat row-major `[n_expert_used, n_tokens]`
+/// I32 slice the ggml callback hands us — into per-token expert rows for `layer`. Row `t`
+/// is the `n_expert_used` experts selected for batch-position `t`. Negative indices
+/// (padding / not-selected slots) are dropped. Pure so the reshape (the load-bearing,
+/// non-obvious row-major unpack) is testable without a served model.
+pub fn per_token_experts(layer: u32, flat: &[i32], n_expert_used: usize) -> Vec<Vec<ExpertId>> {
+    if n_expert_used == 0 {
+        return Vec::new();
+    }
+    flat.chunks(n_expert_used)
+        .map(|row| {
+            row.iter()
+                .filter(|&&e| e >= 0)
+                .map(|&e| ExpertId { layer, expert: e as u32 })
+                .collect()
+        })
+        .collect()
+}
+
+/// Accumulates one forward pass's layer-by-layer expert observations into cross-layer
+/// transitions, feeding a [`CrossLayerExpertPredictor`]. Under continuous batching a single
+/// graph runs all layers in increasing `il` order over the whole batch, so batch-position
+/// `t` IS the same token's trajectory across layers — no pass-id needed; a DECREASE in
+/// layer index marks the next batch (reset). This is the pure capture brain; the hot-path
+/// wiring (holding one of these behind the observer, lock-cheap) is the integration slice.
+#[derive(Debug, Default)]
+pub struct BatchTrajectoryAccumulator {
+    /// The previous layer observed this batch: `(layer, per-token expert rows)`.
+    prev: Option<(u32, Vec<Vec<ExpertId>>)>,
+}
+
+impl BatchTrajectoryAccumulator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one layer's observation (already reshaped to per-token rows). If it continues
+    /// the current batch (layer strictly greater than the previous), learn the transition
+    /// for every batch-position; if the layer index dropped (or is the first), start a new
+    /// batch. Learns into `predictor` directly. Rows are matched by position; a ragged
+    /// count (rare — shouldn't happen within one batch) matches the shorter, never panics.
+    pub fn observe_layer(
+        &mut self,
+        layer: u32,
+        per_token: Vec<Vec<ExpertId>>,
+        predictor: &mut CrossLayerExpertPredictor,
+    ) {
+        if let Some((prev_layer, prev_rows)) = &self.prev {
+            if layer > *prev_layer {
+                for (prev_row, curr_row) in prev_rows.iter().zip(per_token.iter()) {
+                    predictor.observe_transition(prev_row, curr_row);
+                }
+            }
+            // layer <= prev_layer → a new forward pass began; fall through and replace prev.
+        }
+        self.prev = Some((layer, per_token));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -191,5 +250,47 @@ mod tests {
         let pred = p.predict(&[a]);
         assert_eq!(pred.get(&x).copied(), Some(1.0), "X predicted from A");
         assert!(!pred.contains_key(&a), "A is fired/resident — never predict it");
+    }
+
+    // what this catches: the row-major [n_expert_used, n_tokens] unpack — token t's experts
+    // are the t-th chunk of n_expert_used, and negative padding slots are dropped. Getting
+    // this wrong scrambles which experts belong to which token → garbage co-occurrence.
+    #[test]
+    fn per_token_reshape_unpacks_row_major_and_drops_padding() {
+        // n_expert_used=2, n_tokens=3: [t0: 5,7][t1: 5,-1(pad)][t2: 2,7]
+        let flat = vec![5, 7, 5, -1, 2, 7];
+        let rows = per_token_experts(4, &flat, 2);
+        assert_eq!(rows.len(), 3, "three tokens");
+        assert_eq!(rows[0], vec![eid(4, 5), eid(4, 7)]);
+        assert_eq!(rows[1], vec![eid(4, 5)], "the -1 padding slot is dropped");
+        assert_eq!(rows[2], vec![eid(4, 2), eid(4, 7)]);
+        assert!(per_token_experts(4, &[], 0).is_empty(), "n_expert_used=0 → empty, no panic");
+    }
+
+    // what this catches: the batch trajectory capture — within one forward pass (layers in
+    // increasing order) each batch-position's experts across layers become cross-layer
+    // transitions; a DECREASE in layer index starts a NEW batch so trajectories never
+    // bleed across forward passes. This is what turns raw per-layer observations into the
+    // predictor's learning signal, with no pass-id.
+    #[test]
+    fn accumulator_learns_within_a_pass_and_resets_across_passes() {
+        let mut acc = BatchTrajectoryAccumulator::new();
+        let mut pred = CrossLayerExpertPredictor::new();
+
+        // Pass 1: one token, layer 0 fires expert 3, layer 1 fires expert 7.
+        acc.observe_layer(0, vec![vec![eid(0, 3)]], &mut pred); // first layer: no prev, just stores
+        acc.observe_layer(1, vec![vec![eid(1, 7)]], &mut pred); // 1>0: learns (0,3)→(1,7)
+        // Pass 2 begins: layer index DROPS to 0 → reset, must NOT learn (1,7)→(0,3) across passes.
+        acc.observe_layer(0, vec![vec![eid(0, 3)]], &mut pred);
+        acc.observe_layer(1, vec![vec![eid(1, 7)]], &mut pred); // learns (0,3)→(1,7) again
+
+        // (0,3) precedes (1,7) in both passes → P=1.0; nothing learned backwards or across.
+        let out = pred.predict(&[eid(0, 3)]);
+        assert_eq!(out.get(&eid(1, 7)).copied(), Some(1.0), "forward transition learned each pass");
+        // The cross-pass bleed (1,7)→(0,3) must NOT exist: predicting from (1,7) yields nothing.
+        assert!(
+            pred.predict(&[eid(1, 7)]).is_empty(),
+            "layer-decrease reset prevents trajectories bleeding across forward passes"
+        );
     }
 }

--- a/core/continuum-core/src/capacity/expert_predictor.rs
+++ b/core/continuum-core/src/capacity/expert_predictor.rs
@@ -1,0 +1,195 @@
+//! `CrossLayerExpertPredictor` — the PREDICT half of the K3 expert-affinity loop.
+//!
+//! OBSERVE ([`super::expert_observer`]) measures which experts fired (residency:
+//! keep what's proven hot). This predicts which experts are ABOUT to fire, from the
+//! cross-layer structure of a forward pass: when expert `(layer L, e_i)` fires, some
+//! `(layer L+k, e_j)` tend to follow. If we learn those transitions, then the moment
+//! early-layer experts fire we can PREFETCH the likely late-layer ones RAM→VRAM before
+//! the forward pass reaches them — the depth of the pass is the prefetch window. This
+//! is the frontier-lite theory win: a 594 GB MoE served from a 32 GB GPU stops paging
+//! reactively (miss → stall → load) and starts paging *ahead* of the miss.
+//!
+//! ## The seam (locked with BigMama, 2026-07-26)
+//!
+//! This produces `predicted: HashMap<ExpertId, f32>`, confidence in `[0, 1]`, written
+//! onto [`ExpertActivationProfile::predicted`]. Her one ranking authority folds it as
+//! `hits + predicted.clamp(0,1)*0.9 + mag.tanh()*0.09` — so a proven hit (integer ≥1)
+//! ALWAYS outranks any prediction (≤0.99): a wrong prediction only wastes prefetch
+//! slack, never evicts a proven-hot expert. **We guarantee the clamp invariant** (never
+//! emit >1) so that ordering holds — noisy-OR gives us `[0,1]` by construction.
+//!
+//! ## Why noisy-OR
+//!
+//! Multiple already-fired experts may each predict the same upcoming expert `n`. Treat
+//! each as independent evidence: `P(n fires) = 1 - Π_p (1 - P(n | p))`. This is ≤1 by
+//! construction (the clamp invariant is free), rises with corroborating predecessors,
+//! and needs no tuning constant — the honest combiner, not a hand-weighted sum.
+//!
+//! ## Purity
+//!
+//! This module is the pure learn+predict algorithm: transitions in, confidences out.
+//! It does NOT capture the transitions from the live callback — that hot-path capture
+//! (per-forward-pass trajectory grouping under `--parallel`) threads a pass-id through
+//! the ggml eval-callback and is the next slice, coupled with the llama fork. Keeping
+//! the algorithm pure makes it deterministically testable without a served model.
+
+use std::collections::HashMap;
+
+use super::expert_residency::ExpertId;
+
+/// A learned cross-layer co-occurrence model + its prediction. Feed it observed
+/// `(predecessor experts) → (successor experts)` transitions from forward passes; ask
+/// it, given the experts fired so far this pass, which are likely to fire next.
+#[derive(Debug, Default)]
+pub struct CrossLayerExpertPredictor {
+    /// For each predecessor expert `p`: how many transitions were observed FROM it
+    /// (the denominator of `P(successor | p)`).
+    seen: HashMap<ExpertId, u64>,
+    /// `cooccur[p][n]` = times successor `n` followed predecessor `p` within a pass
+    /// (the numerator of `P(n | p)`).
+    cooccur: HashMap<ExpertId, HashMap<ExpertId, u64>>,
+}
+
+impl CrossLayerExpertPredictor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Learn from one observed transition within a forward pass: every `next` expert
+    /// followed every `prev` expert. Called by the capture layer once per adjacent
+    /// (or windowed) layer step. Cheap integer tallies; no floats until `predict`.
+    ///
+    /// Self-transitions (`p == n`) are skipped — an expert never "predicts itself"; the
+    /// point is to prefetch experts NOT yet resident, and a fired expert is already hot
+    /// (its residency is `hits`, not a prediction).
+    pub fn observe_transition(&mut self, prev: &[ExpertId], next: &[ExpertId]) {
+        for &p in prev {
+            let mut counted_p = false;
+            for &n in next {
+                if p == n {
+                    continue;
+                }
+                *self.cooccur.entry(p).or_default().entry(n).or_insert(0) += 1;
+                counted_p = true;
+            }
+            // Count `p` as a predecessor once per transition that yielded ≥1 distinct
+            // successor, so `P(n|p) = cooccur[p][n] / seen[p]` stays a proper fraction.
+            if counted_p {
+                *self.seen.entry(p).or_insert(0) += 1;
+            }
+        }
+    }
+
+    /// `P(successor n | predecessor p)` — the learned conditional, or `0.0` if `p` was
+    /// never observed as a predecessor or `n` never followed it.
+    fn conditional(&self, p: &ExpertId, n: &ExpertId) -> f32 {
+        let seen = match self.seen.get(p) {
+            Some(&s) if s > 0 => s as f32,
+            _ => return 0.0,
+        };
+        let co = self.cooccur.get(p).and_then(|m| m.get(n)).copied().unwrap_or(0) as f32;
+        co / seen
+    }
+
+    /// Predict the experts likely to fire next, given the experts fired so far this
+    /// pass. Confidence per candidate is noisy-OR over every fired predecessor that
+    /// has ever preceded it: `1 - Π_p (1 - P(n | p))`, always in `[0, 1]`.
+    ///
+    /// Candidates already in `fired_so_far` are excluded (they're resident — `hits`
+    /// covers them, not a prediction). Zero-confidence entries are omitted so the map
+    /// is exactly "what to prefetch, and how strongly".
+    pub fn predict(&self, fired_so_far: &[ExpertId]) -> HashMap<ExpertId, f32> {
+        use std::collections::HashSet;
+        let fired: HashSet<ExpertId> = fired_so_far.iter().copied().collect();
+
+        // Candidate set: every successor any fired expert has ever preceded.
+        let mut miss_prob: HashMap<ExpertId, f32> = HashMap::new();
+        for p in &fired {
+            let Some(succs) = self.cooccur.get(p) else { continue };
+            for n in succs.keys() {
+                if fired.contains(n) {
+                    continue; // already resident this pass
+                }
+                let cond = self.conditional(p, n);
+                // Accumulate Π (1 - P(n|p)) as we see each predecessor.
+                let entry = miss_prob.entry(*n).or_insert(1.0);
+                *entry *= 1.0 - cond;
+            }
+        }
+
+        miss_prob
+            .into_iter()
+            .map(|(n, miss)| (n, (1.0 - miss).clamp(0.0, 1.0)))
+            .filter(|(_, conf)| *conf > 0.0)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn eid(layer: u32, expert: u32) -> ExpertId {
+        ExpertId { layer, expert }
+    }
+
+    // what this catches: the learned conditional. After observing A→X twice and A→Y once
+    // (two transitions FROM A), predict([A]) must give P(X|A)=1.0 and P(Y|A)=0.5 — the
+    // measured cross-layer affinity, so the pager prefetches X with full confidence and Y
+    // with half. This is the core signal the whole prefetch win rides on.
+    #[test]
+    fn learns_conditional_frequency_of_cross_layer_successors() {
+        let a = eid(0, 3);
+        let x = eid(1, 7);
+        let y = eid(1, 2);
+        let mut p = CrossLayerExpertPredictor::new();
+        p.observe_transition(&[a], &[x, y]); // pass 1: A preceded X and Y
+        p.observe_transition(&[a], &[x]); //    pass 2: A preceded X only
+
+        let pred = p.predict(&[a]);
+        assert_eq!(pred.get(&x).copied(), Some(1.0), "X followed A in both passes → P=1.0");
+        assert_eq!(pred.get(&y).copied(), Some(0.5), "Y followed A in one of two → P=0.5");
+    }
+
+    // what this catches: noisy-OR combination — two independent predecessors each weakly
+    // predicting the same expert corroborate to a HIGHER confidence, and it stays ≤1
+    // (the clamp invariant BigMama's ranking depends on). A(→X @0.5) and B(→X @0.5)
+    // firing together → 1-(0.5*0.5)=0.75, not 1.0 (naive sum would overflow the invariant).
+    #[test]
+    fn noisy_or_corroborates_and_never_exceeds_one() {
+        let a = eid(0, 1);
+        let b = eid(0, 2);
+        let x = eid(2, 9);
+        let mut p = CrossLayerExpertPredictor::new();
+        // A→X once out of two A-transitions → P(X|A)=0.5
+        p.observe_transition(&[a], &[x]);
+        p.observe_transition(&[a], &[eid(2, 0)]);
+        // B→X once out of two B-transitions → P(X|B)=0.5
+        p.observe_transition(&[b], &[x]);
+        p.observe_transition(&[b], &[eid(2, 0)]);
+
+        let both = p.predict(&[a, b]);
+        assert_eq!(both.get(&x).copied(), Some(0.75), "noisy-OR: 1-(1-0.5)(1-0.5)=0.75");
+        assert!(both.values().all(|&c| (0.0..=1.0).contains(&c)), "clamp invariant holds");
+
+        // One predecessor alone gives the weaker signal.
+        let one = p.predict(&[a]);
+        assert_eq!(one.get(&x).copied(), Some(0.5));
+    }
+
+    // what this catches: the honest empties + self-exclusion — an unknown predecessor
+    // predicts nothing, an already-fired expert is never predicted (it's resident; hits
+    // covers it, not a prediction), and self-transitions are dropped at learn time.
+    #[test]
+    fn unknown_predecessor_and_already_fired_are_excluded() {
+        let a = eid(0, 1);
+        let x = eid(1, 1);
+        let mut p = CrossLayerExpertPredictor::new();
+        p.observe_transition(&[a], &[x, a]); // self-transition A→A must be ignored
+
+        assert!(p.predict(&[eid(5, 5)]).is_empty(), "an unseen predecessor predicts nothing");
+        let pred = p.predict(&[a]);
+        assert_eq!(pred.get(&x).copied(), Some(1.0), "X predicted from A");
+        assert!(!pred.contains_key(&a), "A is fired/resident — never predict it");
+    }
+}

--- a/core/continuum-core/src/capacity/mod.rs
+++ b/core/continuum-core/src/capacity/mod.rs
@@ -25,6 +25,7 @@
 pub mod consumer;
 pub mod expert_observer;
 pub mod expert_pager;
+pub mod expert_predictor;
 pub mod expert_reconcile;
 pub mod expert_residency;
 pub mod gossip;

--- a/core/continuum-core/src/capacity/serving_pager.rs
+++ b/core/continuum-core/src/capacity/serving_pager.rs
@@ -223,7 +223,7 @@ mod tests {
         let obs = sp.observer();
         // Simulate the backend's compute thread firing experts 0..3 heavily.
         for _ in 0..50 {
-            obs.observe(0, &[0, 1, 2]);
+            obs.observe(0, &[0, 1, 2], 3);
         }
         let out = sp.tick(&small_budget_profile(), HashMap::new()).unwrap();
         assert!(out.hot_experts > 0, "recorded activity produced a hot set");
@@ -245,7 +245,7 @@ mod tests {
         // Task A: experts 0,1,2 fire hard for several ticks.
         for _ in 0..10 {
             for _ in 0..100 {
-                obs.observe(0, &[0, 1, 2]);
+                obs.observe(0, &[0, 1, 2], 3);
             }
             sp.tick(&small_budget_profile(), HashMap::new()).unwrap();
         }
@@ -255,7 +255,7 @@ mod tests {
         // Task B: now experts 5,6,7 fire hard; 0,1,2 go silent. Run enough ticks to decay.
         for _ in 0..40 {
             for _ in 0..100 {
-                obs.observe(0, &[5, 6, 7]);
+                obs.observe(0, &[5, 6, 7], 3);
             }
             sp.tick(&small_budget_profile(), HashMap::new()).unwrap();
         }
@@ -279,7 +279,7 @@ mod tests {
         let mut sp = ServingExpertPager::new(GGUF, 2 * GB, 2 * GB, 0, HashMap::new());
         let obs = sp.observer();
         for _ in 0..50 {
-            obs.observe(0, &[0, 1]);
+            obs.observe(0, &[0, 1], 2);
         }
         let out = sp.tick(&small_budget_profile(), HashMap::new()).unwrap();
         assert!(out.relaunch_needed, "set changed → relaunch");

--- a/core/llama/src/safe.rs
+++ b/core/llama/src/safe.rs
@@ -619,8 +619,11 @@ impl KvCacheType {
 /// on a backend thread; `Debug` so `ContextParams` keeps its derive.
 pub trait ExpertObserver: Send + Sync + std::fmt::Debug {
     /// `layer` = transformer block index; `experts` = the selected expert indices for the
-    /// tokens in this decode batch (flattened row-major `[n_expert_used, n_tokens]`).
-    fn observe(&self, layer: u32, experts: &[i32]);
+    /// tokens in this decode batch (flattened row-major `[n_expert_used, n_tokens]`);
+    /// `n_expert_used` = the row width, so a consumer can unpack `experts` into per-token
+    /// rows (`experts[t*n_expert_used .. (t+1)*n_expert_used]`) for cross-layer trajectory
+    /// capture. `hits`-only consumers ignore it and tally the flat slice.
+    fn observe(&self, layer: u32, experts: &[i32], n_expert_used: usize);
 }
 
 /// Parse the block index from a `ffn_moe_topk` node name. llama.cpp's graph callback
@@ -687,7 +690,9 @@ unsafe extern "C" fn expert_eval_cb(
         0,
         count * std::mem::size_of::<i32>(),
     );
-    bridge.observer.observe(layer, &buf);
+    // ne0 = n_expert_used (the row width); pass it so the observer can unpack per-token
+    // rows for cross-layer trajectory capture. ne0 > 0 guaranteed by the guard above.
+    bridge.observer.observe(layer, &buf, ne0 as usize);
     true
 }
 
@@ -1288,14 +1293,14 @@ mod tests {
             seen: Mutex<Vec<(u32, Vec<i32>)>>,
         }
         impl ExpertObserver for RecordingObserver {
-            fn observe(&self, layer: u32, experts: &[i32]) {
+            fn observe(&self, layer: u32, experts: &[i32], _n_expert_used: usize) {
                 self.seen.lock().unwrap().push((layer, experts.to_vec()));
             }
         }
         let obs = RecordingObserver::default();
         // Two tokens, top-2 at layer 5 (experts [3,7] then [3,1], flattened), then layer 6.
-        obs.observe(5, &[3, 7, 3, 1]);
-        obs.observe(6, &[0, 2]);
+        obs.observe(5, &[3, 7, 3, 1], 2);
+        obs.observe(6, &[0, 2], 2);
         let seen = obs.seen.lock().unwrap();
         assert_eq!(seen.as_slice(), &[(5, vec![3, 7, 3, 1]), (6, vec![0, 2])]);
     }


### PR DESCRIPTION
## The PREDICT half of the K3 expert-affinity loop

OBSERVE (#2020) measures what fired (residency — keep what's proven hot). This predicts what's **about** to fire, from the cross-layer structure of a forward pass: when `(layer L, e_i)` fires, some `(layer L+k, e_j)` tend to follow. Learn those transitions → the moment early-layer experts fire, PREFETCH the likely late-layer ones RAM→VRAM **before** the pass reaches them. Pass depth = the prefetch window. A 594 GB MoE on a 32 GB GPU stops paging reactively (miss→stall→load) and starts paging *ahead* of the miss.

## Algorithm (pure, tested)
- `observe_transition(prev, next)` — integer co-occurrence tally; `P(n|p) = cooccur[p][n]/seen[p]`.
- `predict(fired_so_far)` → `HashMap<ExpertId, f32>` via **noisy-OR**: `1 - Π_p (1 - P(n|p))`. Corroborating predecessors raise confidence; result is `[0,1]` **by construction**.

## The locked seam (with BigMama)
Produces `predicted` clamped `[0,1]` for `ExpertActivationProfile.predicted`; her ranking authority folds it as `hits + predicted*0.9 + mag*0.09` — a proven hit (≥1) always outranks a prediction (≤0.99), so a wrong prediction wastes prefetch slack, never evicts a proven-hot expert. Noisy-OR's `[0,1]` guarantee upholds that invariant.

## Tests — 3/3 green
conditional frequency; noisy-OR corroboration never exceeding 1; unknown/self/already-fired exclusions.

## Next slice (coupled with the llama fork)
The hot-path **capture** that feeds `observe_transition` — per-forward-pass trajectory grouping under `--parallel` (a pass-id threaded through the ggml callback). Kept separate so the algorithm stays deterministically testable without a served model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)