### PR TITLE
feat(genome): lived-axis LLM-teacher expansion — the being learns from turns it stalled on

### DIFF
--- a/core/continuum-core/src/commands/genome/curriculum.rs
+++ b/core/continuum-core/src/commands/genome/curriculum.rs
@@ -216,6 +216,105 @@ pub fn expansion_examples(records: &[ExperienceRecord]) -> Vec<Value> {
         .collect()
 }
 
+/// **Expansion — the LIVED axis (outlier B of outlier B).** The received path
+/// ([`expansion_examples`]) teaches deliberately-authored true knowledge directly, but a
+/// salient LIVED turn is a FAILURE with no known-correct answer, so it needs an LLM teacher
+/// to avoid confident garbage — the path `expansion_examples` names but skips. This is that
+/// teacher, structured exactly like [`RemediationSynthesizer`]: a deterministic
+/// [`select`](Self::select) (unit-testable with no inference) picks the salient lived
+/// stimuli, and [`synthesize`](Self::synthesize) resolves a teacher and re-answers each,
+/// yielding `{question → answer}` SFT pairs.
+///
+/// The teacher re-answers the STIMULUS she stalled on — never her stalled answer (that would
+/// teach the failure) — and the corpus is validated per-CONSOLIDATION by benchmark lift
+/// (#59), the same whole-being gate that makes the received axis safe on untestable material.
+/// It is a sibling of [`RemediationSynthesizer`], not an impl of [`CurriculumSynthesizer`]:
+/// the return type is bare SFT `{messages}` (like [`expansion_examples`]), NOT a
+/// test-validated [`RemediationCorpus`] — the differing type is the honest signal that these
+/// are two distinct efferent organs, not one behind a fake corpus.
+pub struct LivedExpansionSynthesizer {
+    /// The salience selector — `ErrorSalience` by default, so ONLY lived failures (the ones
+    /// worth a lesson) feed the teacher; a cleanly-settled lived turn is not salient and is
+    /// never re-taught. Boxed so a composite detector slots in without touching this type.
+    detector: Box<dyn SalienceDetector>,
+    /// `None` = resolve the locally-served model at synthesis time (runs with no external
+    /// dep); `Some` points at a stronger peer/gateway teacher for higher-quality answers.
+    teacher_model: Option<String>,
+    /// Decoding temperature — the same low default as remediation (correct, convergent
+    /// answers, not wandering).
+    temperature: f32,
+}
+
+impl Default for LivedExpansionSynthesizer {
+    fn default() -> Self {
+        Self {
+            detector: Box::new(ErrorSalience),
+            teacher_model: None,
+            temperature: DEFAULT_TEMPERATURE,
+        }
+    }
+}
+
+impl LivedExpansionSynthesizer {
+    /// A lived-expansion synthesizer with the honest defaults (`ErrorSalience`, local
+    /// teacher, [`DEFAULT_TEMPERATURE`]).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Point at an explicit teacher model instead of the locally-served one.
+    pub fn with_teacher(mut self, model: impl Into<String>) -> Self {
+        self.teacher_model = Some(model.into());
+        self
+    }
+
+    /// Swap in a different salience selector.
+    pub fn with_detector(mut self, detector: Box<dyn SalienceDetector>) -> Self {
+        self.detector = detector;
+        self
+    }
+
+    /// A stable provenance name for the corpus this makes.
+    pub fn name(&self) -> &'static str {
+        "lived-expansion"
+    }
+
+    /// The deterministic selection sub-step (unit-testable WITHOUT a teacher): the salient
+    /// LIVED episodes' stimuli — what she was asked and stalled on, to be re-answered. A
+    /// received or eval record is not lived; a lived record the detector doesn't flag (a
+    /// clean turn) or one with no stimulus is dropped. Mirrors
+    /// [`RemediationSynthesizer::select`] — selection here, inference in `synthesize`.
+    pub fn select(&self, records: &[ExperienceRecord]) -> Vec<String> {
+        records
+            .iter()
+            .filter(|r| r.source == ExperienceSource::Lived)
+            .filter(|r| self.detector.assess(r).is_some())
+            .map(|r| r.task.prompt.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    }
+
+    /// Salient lived episodes → `{question → answer}` SFT examples via the teacher. Empty
+    /// selection → empty (no teacher round-trip); fail-loud if a teacher can't be resolved
+    /// once there IS work — same discipline as [`RemediationSynthesizer::synthesize`].
+    pub async fn synthesize(
+        &self,
+        records: &[ExperienceRecord],
+    ) -> Result<Vec<Value>, CommandError> {
+        let stimuli = self.select(records);
+        if stimuli.is_empty() {
+            return Ok(Vec::new());
+        }
+        let teacher_model = match &self.teacher_model {
+            Some(m) => m.clone(),
+            None => resolve_model(None).await.map_err(|e| {
+                CommandError::Internal(format!("teacher model resolve failed: {e:?}"))
+            })?,
+        };
+        super::teach::synthesize_lived_expansion(&stimuli, &teacher_model, self.temperature).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -340,5 +439,65 @@ mod tests {
         );
 
         assert!(expansion_examples(&[]).is_empty(), "empty in → empty out (no gap is a legitimate outcome)");
+    }
+
+    /// Build a lived ExperienceRecord directly (the from_lived_turn shape without a
+    /// SettleOutcome): a stimulus she faced, a salience-carrying grade, ok toggled.
+    fn lived_record(stimulus: &str, ok: bool) -> ExperienceRecord {
+        ExperienceRecord {
+            task: EvalTask { prompt: stimulus.to_string(), ..EvalTask::default() },
+            ok,
+            grade: if ok { "lived turn: settled".into() } else { "lived turn: did not converge".into() },
+            answer: "half-finished attempt".to_string(),
+            world_state: String::new(),
+            acts: 8,
+            source: ExperienceSource::Lived,
+        }
+    }
+
+    // What this catches: the LIVED-axis selection is the deterministic half of the
+    // LLM-teacher path — it picks ONLY salient (failed) lived episodes' STIMULI (what she
+    // stalled on, to be re-answered by the teacher), never her stalled answer. A clean lived
+    // turn (ok=true → not salient) is dropped, a received/eval record is not lived, and an
+    // empty stimulus has nothing to re-pose. This is what lets the teacher path be tested
+    // without live inference; a regression here would re-teach clean turns (wasted compute)
+    // or feed the teacher a blank prompt.
+    #[test]
+    fn lived_expansion_selects_only_salient_lived_stimuli() {
+        let synth = LivedExpansionSynthesizer::new();
+
+        let failed_lived = lived_record("how does build_workspace_cycle settle a turn?", false);
+        let clean_lived = lived_record("say hi to the room", true); // ok → not salient → drop
+        let empty_stimulus = lived_record("   ", false); // salient but nothing to re-pose → drop
+        // A received lesson is untestable+salient but NOT lived — it has its own direct path
+        // (expansion_examples), never the teacher.
+        let received = ExperienceRecord {
+            task: EvalTask { prompt: "continuum".to_string(), ..EvalTask::default() },
+            ok: true,
+            grade: "received lesson from BigMama".into(),
+            answer: "the call room IS the airc room".into(),
+            world_state: String::new(),
+            acts: 0,
+            source: ExperienceSource::Received,
+        };
+
+        let stimuli = synth.select(&[failed_lived, clean_lived, empty_stimulus, received]);
+
+        assert_eq!(stimuli.len(), 1, "only the salient lived turn with a real stimulus is selected");
+        assert_eq!(stimuli[0], "how does build_workspace_cycle settle a turn?");
+    }
+
+    // What this catches: no salient lived turn → empty selection, so synthesize honors its
+    // "empty → no teacher round-trip" contract (the quiet-when-healthy path). A batch of
+    // clean lived turns and received lessons yields nothing for the lived teacher.
+    #[test]
+    fn lived_expansion_empty_when_nothing_salient_and_lived() {
+        let synth = LivedExpansionSynthesizer::new();
+        let batch = [lived_record("all good", true), lived_record("also fine", true)];
+        assert!(
+            synth.select(&batch).is_empty(),
+            "no salient lived failure → nothing to re-teach → empty (no teacher spin-up)"
+        );
+        assert_eq!(synth.name(), "lived-expansion");
     }
 }

--- a/core/continuum-core/src/commands/genome/teach.rs
+++ b/core/continuum-core/src/commands/genome/teach.rs
@@ -655,6 +655,107 @@ pub async fn synthesize_remediation(
     })
 }
 
+/// The teacher's standing instruction for LIVED expansion — produce a strong, complete
+/// answer to a real question the persona faced but stalled on. Unlike [`TEACHER_SYSTEM`]
+/// (correct CODE, grader-gated), this is a general expert answer with NO objective grader;
+/// the whole-being benchmark-lift gate (#59) validates the CONSOLIDATION, never a single
+/// trajectory. The system turn shapes the teacher's GENERATION but is deliberately NOT
+/// trained in (see [`synthesize_lived_expansion`]) — the being learns to answer the class
+/// of question without needing this scaffold.
+const LIVED_TEACHER_SYSTEM: &str = "You are a thoughtful expert. A teammate was asked the \
+    following in a live conversation and their attempt stalled before they finished. Give a single, \
+    complete, self-contained answer — clear and correct, with no meta-commentary about the attempt.";
+
+/// **Lived-axis expansion — the LLM-teacher path** that [`super::curriculum::expansion_examples`]
+/// deliberately deferred. A salient LIVED turn is untestable (no grader) AND a failure
+/// (non-convergence / infra fault), so it can be neither remediated (no `test` to validate
+/// a correction) nor echoed (training on her stalled answer would teach the failure). The
+/// honest resolution: a teacher RE-ANSWERS the stimulus she faced, and that strong answer —
+/// not her stalled one — becomes the SFT pair. Safe on untestable material for the same
+/// reason the received axis is: validation is per-CONSOLIDATION by whole-being benchmark
+/// lift (#59), never per-trajectory ([[lived-and-eval-experience-are-one-stream-one-being]]).
+///
+/// Mirrors [`synthesize_remediation`]'s lane discipline (readiness gate → dedicated
+/// bare-base lane → degrade-loud to the live lane) but has NO grader loop: ONE teacher
+/// generation per stimulus. Two honesty guards: an empty teacher answer is dropped (never
+/// ship a blank lesson), and the teacher's system turn shapes generation but is NOT in the
+/// example — the SFT pair is the bare `{question → answer}`, so the being learns the class
+/// of question, not a scaffolded reply. Empty stimuli in → empty out (no lane spin-up).
+pub async fn synthesize_lived_expansion(
+    stimuli: &[String],
+    teacher_model: &str,
+    temperature: f32,
+) -> Result<Vec<Value>, CommandError> {
+    // Trim + drop blanks up front: nothing to answer, and it decides whether we even need
+    // a lane. Empty in → empty out is a legitimate outcome (no fitness gap), never a fault.
+    let stimuli: Vec<&str> = stimuli.iter().map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+    if stimuli.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Same readiness discipline as remediation: WAIT for a served lane before the first
+    // generation, or a relaunch race hangs the teacher forever (glass-boxed 2026-07-21).
+    if await_ready_serving(DEFAULT_SERVING_WAIT).await.is_none() {
+        return Err(CommandError::Internal(
+            "no served model became ready within the serving-wait budget — cannot run the lived \
+             expansion teacher. Bring up serving (ai/inference/serve) first."
+                .to_string(),
+        ));
+    }
+
+    // A DEDICATED bare-base lane (the #175-safe isolation eval + remediation use), degrading
+    // LOUD to the live lane if it can't come up — a shared attempt beats no attempt.
+    let dedicated_lane = match crate::cognition::eval::spawn_base_eval_lane(teacher_model).await {
+        Ok(lane) => Some(lane),
+        Err(e) => {
+            tracing::warn!(
+                target: "genome::teach",
+                teacher_model = %teacher_model,
+                error = %e,
+                "dedicated lived-expansion teacher lane failed to come up — DEGRADING to the live \
+                 serving lane (may inherit the #175 multi-LoRA OOM)."
+            );
+            None
+        }
+    };
+    let teacher_adapter = dedicated_lane.as_ref().map(|l| l.adapter.clone());
+
+    let mut examples: Vec<Value> = Vec::new();
+    for stimulus in stimuli {
+        // The system turn steers the GENERATION only; it is not part of the training pair.
+        let messages = vec![
+            ChatMessage::text("system", LIVED_TEACHER_SYSTEM),
+            ChatMessage::text("user", stimulus),
+        ];
+        let answer =
+            match teacher_generate(teacher_adapter.as_ref(), teacher_model, messages, temperature).await {
+                Ok(a) => a,
+                Err(e) => {
+                    // Fail-loud on the ITEM, resilient on the BATCH — one stimulus failing
+                    // must not abort the whole consolidation (same spirit as remediation
+                    // breaking one task without killing the run).
+                    tracing::warn!(
+                        target: "genome::teach",
+                        error = %e,
+                        "lived-expansion teacher generation failed for one stimulus — skipped"
+                    );
+                    continue;
+                }
+            };
+        if answer.trim().is_empty() {
+            continue; // never ship a blank lesson
+        }
+        // The bare {stimulus → answer} pair — the teacher's scaffold system turn is dropped.
+        examples.push(json!({
+            "messages": [
+                { "role": "user", "content": stimulus },
+                { "role": "assistant", "content": answer.trim() },
+            ]
+        }));
+    }
+    Ok(examples)
+}
+
 /// Stateless — self-registers onto the ONE registry. Holds no module state; resolves
 /// inference + dataset packaging through their global/associated seams.
 #[derive(Default)]


### PR DESCRIPTION
## The third efferent organ of the being-loop

The being-loop unifies lived + eval + received experience into one stream ([[lived-and-eval-experience-are-one-stream-one-being]]). Two of the three axes already teach:
- **Eval failures** → remediation (`RemediationSynthesizer`, test-validated).
- **Received lessons** → expansion (`expansion_examples`, deliberately-authored true knowledge taught directly).

The **Lived axis** was deferred with a named reason: a salient lived turn is a FAILURE (non-convergence / infra fault) with no known-correct answer, so echoing her stalled answer would train the failure, and with no `test` it can't be remediated. This builds the path `expansion_examples` pointed at.

## What it does

A teacher **re-answers the stimulus she stalled on**, and that strong answer — not her stalled one — becomes the `{question → answer}` SFT pair. Safe on untestable material for the same reason the received axis is: validated **per-consolidation by whole-being benchmark lift (#59)**, never per-trajectory.

Structured exactly like remediation (one seam, two organs):
- `teach.rs::synthesize_lived_expansion` — inference core, mirrors `synthesize_remediation`'s lane discipline (readiness gate → dedicated bare-base lane → degrade-loud) but **no grader loop**. Honesty guards: empty answers dropped; the teacher's system turn shapes generation but is **not** trained in (the pair is the bare question→answer).
- `curriculum.rs::LivedExpansionSynthesizer` — selection wrapper, sibling of `RemediationSynthesizer`: deterministic detector-driven `select()` (unit-testable, only salient lived failures; a clean turn is never re-taught) + async `synthesize()`. Returns bare SFT `{messages}`, not a `RemediationCorpus` — the differing type is the honest signal these are two distinct organs.

## Scope

Organ + tests only. Wiring the lived branch into the auto-firing consolidation driver (alongside the received branch) is a separate reviewable step, like #2028.

## Tests
`cargo test -p continuum-core --lib curriculum` — 7/7 green, incl. two new lived-expansion selection tests (salient-lived-only; empty-when-nothing-salient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)