### PR TITLE
feat(capacity): PlacementRequest + layer-granular residency — slice-1 buft-override seam

### DIFF
--- a/core/continuum-core/src/capacity/expert_residency.rs
+++ b/core/continuum-core/src/capacity/expert_residency.rs
@@ -263,6 +263,61 @@ pub fn plan_tiered_residency(
     TieredResidencyPlan { tiers: out, cold }
 }
 
+/// LAYER-granular residency for the SLICE-1 buft-override relaunch.
+///
+/// llama.cpp's `-ot`/`--override-tensor` places WHOLE stacked tensors, and a MoE layer's
+/// experts are ONE tensor (`blk.N.ffn_*_exps` = `{n_embd, n_ff, n_expert}` — all of layer
+/// N's experts in a single blob). So a load-time relaunch can pin whole LAYERS to VRAM, not
+/// individual experts. This aggregates the per-expert priority ([`plan_expert_residency`]'s
+/// ranking) to a per-LAYER score (sum over the layer's known experts) and greedily fits
+/// whole layers by `layer_bytes` within the serving VRAM budget. The returned layer indices
+/// (ascending) are the ones whose expert blob should be GPU-resident; every other MoE layer
+/// is `-ot`'d to CPU (RAM-faulted per token).
+///
+/// Per-EXPERT residency ([`plan_expert_residency`]) is the SLICE-2 granularity — usable only
+/// once the vendored-llama upload fork can place a single expert into a loaded model. Until
+/// then this is the honest, coarser residency the load-time `-ot` mechanism actually supports.
+///
+/// Degenerate-safe: unsized experts / zero experts-per-layer place NOTHING (every layer
+/// CPU-faulted — never a false VRAM claim). `budget_bytes` is the caller's serving budget
+/// (`SystemProfile::serving_budget_bytes`, already the 0.80-of-live figure), `margin_bytes`
+/// the headroom held below it.
+pub fn plan_layer_residency(
+    profile: &ExpertActivationProfile,
+    n_experts_per_layer: u32,
+    expert_bytes: u64,
+    budget_bytes: u64,
+    margin_bytes: u64,
+) -> Vec<u32> {
+    if n_experts_per_layer == 0 || expert_bytes == 0 {
+        return Vec::new();
+    }
+    let layer_bytes = expert_bytes.saturating_mul(n_experts_per_layer as u64);
+    // Aggregate per-expert priority to a per-layer score (the SAME priority the per-expert
+    // planner ranks by — one ranking authority, layer score is its sum over the layer).
+    let mut layer_score: std::collections::BTreeMap<u32, f64> = std::collections::BTreeMap::new();
+    for e in profile.known_experts() {
+        *layer_score.entry(e.layer).or_insert(0.0) += profile.priority(&e);
+    }
+    let mut ranked: Vec<(u32, f64)> = layer_score.into_iter().collect();
+    ranked.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.0.cmp(&b.0)) // stable, deterministic tiebreak by layer index
+    });
+    let usable = budget_bytes.saturating_sub(margin_bytes);
+    let mut used = 0u64;
+    let mut hot: Vec<u32> = Vec::new();
+    for (layer, _) in ranked {
+        if used.saturating_add(layer_bytes) <= usable {
+            used += layer_bytes;
+            hot.push(layer);
+        }
+    }
+    hot.sort_unstable();
+    hot
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -456,5 +511,33 @@ mod tests {
         assert!(plan.tiers[0].1.is_empty(), "zero-fit VRAM tier skipped");
         assert_eq!(plan.tiers[1].1, vec![e(0, 0), e(0, 1)], "RAM tier takes the hot pair");
         assert_eq!(plan.cold, vec![e(0, 2)]);
+    }
+
+    // what this catches: the SLICE-1 layer-granular fit (the buft-override seam with M5's
+    // -ot arg builder). -ot places whole stacked expert tensors, so the relaunch pins whole
+    // LAYERS. This must (a) rank layers by their AGGREGATE expert priority — a layer whose
+    // experts fire hard beats a quiet one — and (b) fit whole layers within the VRAM budget
+    // by layer_bytes, never overflowing. If the aggregation or the layer-byte fit drifts, the
+    // relaunch would pin the wrong layers (cold-fault the hot ones) or overflow VRAM.
+    #[test]
+    fn layer_residency_fits_hottest_layers_by_layer_bytes() {
+        let mut p = ExpertActivationProfile::default();
+        // 3 MoE layers, 4 experts each. Layer 2 is hammered, layer 5 medium, layer 8 quiet.
+        for x in 0..4 {
+            p.hits.insert(e(2, x), 100);
+            p.hits.insert(e(5, x), 10);
+            p.hits.insert(e(8, x), 1);
+        }
+        // 1 GiB/expert × 4 experts = 4 GiB/layer. Budget 10 GiB, 2 GiB margin → 8 GiB usable
+        // → exactly 2 layers fit. The two hottest (2, 5) are placed; layer 8 stays CPU.
+        let hot = plan_layer_residency(&p, 4, GB, 10 * GB, 2 * GB);
+        assert_eq!(hot, vec![2, 5], "two hottest layers fit, ascending real blk.N indices");
+        assert!(!hot.contains(&8), "the quiet layer is -ot'd to CPU");
+
+        // Unsized experts → place nothing (never a false VRAM claim; all CPU-faulted).
+        assert!(
+            plan_layer_residency(&p, 4, 0, 10 * GB, 2 * GB).is_empty(),
+            "unsized places no layer hot"
+        );
     }
 }

--- a/core/continuum-core/src/capacity/mod.rs
+++ b/core/continuum-core/src/capacity/mod.rs
@@ -31,6 +31,7 @@ pub mod expert_residency;
 pub mod gossip;
 pub mod grid;
 pub mod lease;
+pub mod placement;
 pub mod recursion_depth;
 pub mod residency_detect;
 pub mod score;

--- a/core/continuum-core/src/capacity/placement.rs
+++ b/core/continuum-core/src/capacity/placement.rs
@@ -1,0 +1,37 @@
+//! `PlacementRequest` — the SLICE-1 buft-override seam between the K3 pager (which owns the
+//! VRAM fit) and the llama-server launcher (which owns the `-ot` args).
+//!
+//! Why layer-granular: llama.cpp's `-ot`/`--override-tensor` places WHOLE stacked tensors,
+//! and a MoE layer's experts are ONE tensor (`blk.N.ffn_*_exps` = `{n_embd, n_ff, n_expert}`,
+//! all of layer N's experts in a single blob). So a load-time relaunch pins whole LAYERS to
+//! VRAM, not individual experts. The pager decides which layers fit
+//! ([`plan_layer_residency`](super::expert_residency::plan_layer_residency)); the launcher
+//! turns the complement into one `-ot` regex (`blk\.(c1|c2|…)\.ffn_.*_exps=CPU`).
+//!
+//! Per-EXPERT placement is the slice-2 granularity (the vendored-llama upload fork); it rides
+//! a different path and is deliberately NOT in this struct.
+
+/// One serving lane's expert-layer placement for a (re)launch. Produced by the pager,
+/// consumed by `llama_server.rs` when it builds the llama-server command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlacementRequest {
+    /// The model these layers belong to — matches the served lane's GGUF.
+    pub gguf_id: String,
+    /// TOTAL transformer block count (the `-ot` iteration ceiling). The launcher computes the
+    /// cold set as `(0..n_layers)` MINUS `hot_layers`.
+    pub n_layers: u32,
+    /// The real `blk.N` indices whose full expert blob should be GPU-resident, ascending.
+    /// Every other block's expert tensor is `-ot`'d to CPU (RAM-faulted per token). Sized by
+    /// the pager to fit the serving VRAM budget, so the launcher never overflows.
+    pub hot_layers: Vec<u32>,
+}
+
+/// The result of one layer-placement pass: the request to (re)launch with, and whether the
+/// hot-layer set changed enough vs what's currently served to justify the (expensive) process
+/// respawn. The serving loop relaunches only when `needs_relaunch`, then calls
+/// [`mark_layer_relaunched`](super::serving_pager::ServingExpertPager::mark_layer_relaunched).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LayerPlacementOutcome {
+    pub request: PlacementRequest,
+    pub needs_relaunch: bool,
+}

--- a/core/continuum-core/src/capacity/serving_pager.rs
+++ b/core/continuum-core/src/capacity/serving_pager.rs
@@ -35,7 +35,8 @@ use std::sync::Arc;
 
 use super::expert_observer::LiveExpertObserver;
 use super::expert_reconcile::{expert_pager_step, PagerError, PagerStepOutcome, RelaunchPager};
-use super::expert_residency::{ExpertActivationProfile, ExpertId};
+use super::expert_residency::{plan_layer_residency, ExpertActivationProfile, ExpertId};
+use super::placement::{LayerPlacementOutcome, PlacementRequest};
 use super::system_profile::SystemProfile;
 use crate::genome::working_set::PageRef;
 
@@ -72,6 +73,10 @@ pub struct ServingExpertPager {
     last_raw: HashMap<ExpertId, u64>,
     /// Retention factor (see [`DEFAULT_DECAY_ALPHA`]).
     alpha: f64,
+    /// The hot LAYER set the currently-served process was (re)launched with (slice-1
+    /// buft-override). A layer-placement pass compares against this to decide whether the
+    /// churn justifies the (expensive) process respawn. Empty until the first launch.
+    last_hot_layers: Vec<u32>,
 }
 
 impl ServingExpertPager {
@@ -95,6 +100,7 @@ impl ServingExpertPager {
             decayed: HashMap::new(),
             last_raw: HashMap::new(),
             alpha: DEFAULT_DECAY_ALPHA,
+            last_hot_layers: Vec::new(),
         }
     }
 
@@ -118,11 +124,7 @@ impl ServingExpertPager {
     /// arg to thread: the observer produces `predicted()` from the same activations it tallies
     /// hits from, so the one owned Arc is the whole signal source.
     pub fn tick(&mut self, profile: &SystemProfile) -> Result<PagerStepOutcome, PagerError> {
-        let activation = ExpertActivationProfile {
-            gate_magnitude: self.gate_magnitude.clone(),
-            hits: self.decay_and_snapshot_hits(),
-            predicted: self.observer.predicted(),
-        };
+        let activation = self.current_activation();
         expert_pager_step(
             profile,
             &activation,
@@ -132,6 +134,66 @@ impl ServingExpertPager {
             &mut self.pager,
             self.relaunch_threshold,
         )
+    }
+
+    /// One LAYER-placement pass — the SLICE-1 buft-override path. Aggregates the current
+    /// (decayed hits + predicted + gate) activation to per-layer scores and fits whole layers
+    /// within the serving VRAM budget ([`plan_layer_residency`]), then decides whether the
+    /// hot-layer set changed enough vs what's currently served to justify the (expensive)
+    /// llama-server process respawn. The serving loop relaunches with `request` only when
+    /// `needs_relaunch`, then calls [`mark_layer_relaunched`](Self::mark_layer_relaunched).
+    ///
+    /// `n_experts_per_layer` + `n_layers` come from the GGUF layout (the launcher's `-ot`
+    /// keys on the real `blk.N`; `n_layers` is the total block count). This and [`tick`] are
+    /// the two granularities — layer now (`-ot` load placement), per-expert later (the
+    /// upload fork). A serving loop calls ONE of them per tick, not both (each decays once).
+    pub fn tick_layer_placement(
+        &mut self,
+        profile: &SystemProfile,
+        n_experts_per_layer: u32,
+        n_layers: u32,
+    ) -> LayerPlacementOutcome {
+        let activation = self.current_activation();
+        let hot_layers = plan_layer_residency(
+            &activation,
+            n_experts_per_layer,
+            self.expert_bytes,
+            profile.serving_budget_bytes(),
+            self.margin_bytes,
+        );
+        // Symmetric-difference churn vs the served set — a process respawn reloads every
+        // weight, so only a change beyond `relaunch_threshold` layers earns it. First pass
+        // (served set empty) relaunches to place any non-empty set.
+        let served: std::collections::BTreeSet<u32> = self.last_hot_layers.iter().copied().collect();
+        let want: std::collections::BTreeSet<u32> = hot_layers.iter().copied().collect();
+        let churn = served.symmetric_difference(&want).count();
+        let needs_relaunch = churn > self.relaunch_threshold;
+        LayerPlacementOutcome {
+            request: PlacementRequest {
+                gguf_id: self.gguf_id.clone(),
+                n_layers,
+                hot_layers,
+            },
+            needs_relaunch,
+        }
+    }
+
+    /// Record that the served process was (re)launched with `placed` as its hot-layer set;
+    /// subsequent [`tick_layer_placement`](Self::tick_layer_placement) calls are quiet until
+    /// the set churns past the threshold again.
+    pub fn mark_layer_relaunched(&mut self, placed: &[u32]) {
+        self.last_hot_layers = placed.to_vec();
+    }
+
+    /// Build the per-tick activation profile from the owned observer: decayed live hits
+    /// (RESIDENCY), the predictor's prefetch confidence (PREFETCH), and the static gate seed.
+    /// Advances the hit EWMA exactly once — call it once per serving tick.
+    fn current_activation(&mut self) -> ExpertActivationProfile {
+        ExpertActivationProfile {
+            gate_magnitude: self.gate_magnitude.clone(),
+            hits: self.decay_and_snapshot_hits(),
+            predicted: self.observer.predicted(),
+        }
     }
 
     /// Record that the backend relaunched the served context with the current residency set;
@@ -288,6 +350,38 @@ mod tests {
         assert!(
             !out2.relaunch_needed,
             "no churn after mark_relaunched → no relaunch"
+        );
+    }
+
+    // what this catches: the SLICE-1 layer-placement path end to end (the buft-override seam).
+    // Real expert activity on specific layers must produce a PlacementRequest whose hot_layers
+    // are those layers (the ones -ot keeps on GPU), carry the total n_layers, ask for a
+    // relaunch on the first placement (served set empty), and go QUIET after mark_layer_relaunched
+    // when nothing churns — else the serving loop respawns the llama-server every tick.
+    #[test]
+    fn layer_placement_produces_hot_layers_and_relaunch_signal_clears() {
+        // 1 GiB/expert; 24 GiB serving budget fits several 4-expert (4 GiB) layers.
+        let mut sp = ServingExpertPager::new(GGUF, GB, 2 * GB, 0, HashMap::new());
+        let obs = sp.observer();
+        // Fire layers 2 and 5 hard (4 experts each), layer 8 barely.
+        for _ in 0..50 {
+            obs.observe(2, &[0, 1, 2, 3], 4);
+            obs.observe(5, &[0, 1, 2, 3], 4);
+        }
+        obs.observe(8, &[0], 4);
+        let out = sp.tick_layer_placement(&small_budget_profile(), 4, 12);
+        assert!(out.request.hot_layers.contains(&2), "hot layer 2 placed on GPU");
+        assert!(out.request.hot_layers.contains(&5), "hot layer 5 placed on GPU");
+        assert_eq!(out.request.n_layers, 12, "carries the total block count for -ot");
+        assert_eq!(out.request.gguf_id, GGUF);
+        assert!(out.needs_relaunch, "first placement needs a relaunch (served set empty)");
+
+        sp.mark_layer_relaunched(&out.request.hot_layers);
+        // No new activity → the hot-layer set is stable → no second respawn.
+        let out2 = sp.tick_layer_placement(&small_budget_profile(), 4, 12);
+        assert!(
+            !out2.needs_relaunch,
+            "stable hot-layer set after mark_layer_relaunched → no relaunch"
         );
     }
 }


### PR DESCRIPTION
## What

The pager's half of the slice-1 buft-override seam with M5's `-ot` builder (#2036). `-ot` places **whole stacked tensors** (`blk.N.ffn_*_exps` = all of layer N's experts), so slice-1 placement is **layer-granular** (per-expert is slice-2's upload fork).

- **`plan_layer_residency`** — aggregates the per-expert priority (the one ranking authority) to a per-layer score, fits whole layers by `layer_bytes` within the 0.80 serving VRAM budget. Real `blk.N` indices, ascending. The pager owns the fit, so the launcher never overflows.
- **`PlacementRequest { gguf_id, n_layers, hot_layers }`** — the shared seam type `llama_server.rs` consumes: `hot_layers` = GPU-resident `blk.N`, complement `-ot`'d to CPU.
- **`ServingExpertPager::tick_layer_placement` + `mark_layer_relaunched`** — the slice-1 driver pass: builds the decayed+predicted activation (shared with the per-expert `tick` via `current_activation`), plans hot layers, decides relaunch on hot-layer churn beyond the threshold (a respawn reloads every weight — a 1-layer flap must not thrash it).

## Seam

Locked with M5 on airc: **I own the VRAM fit, she owns the `-ot` args + `ServingTarget.expert_placement` relaunch diff.** Her `cold_expert_offload_ot(hot_layers, n_layers)` (#2036) plugs straight into `PlacementRequest.hot_layers`.

## Tests

Two new: the layer fit (hottest layers by aggregate priority, fit by layer_bytes) and the driver relaunch-signal (first placement relaunches, stable set goes quiet). `cargo check --lib --tests` clean on the 5090 for the capacity files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)