### PR TITLE
feat(llama): sync vendored fork to today's upstream — K3-day + multi-arch readiness

### DIFF
--- a/core/llama/build.rs
+++ b/core/llama/build.rs
@@ -185,31 +185,90 @@ fn main() {
     // cmake ACTUALLY produced (Debug/Release/...), rather than trusting Cargo's
     // PROFILE which can diverge when a build.rs pins a cmake config (per M5's
     // review). No-op on single-config Unix (no such subdir exists).
-    let link_search = |rel: &str| {
-        let base = dst.join(rel);
-        println!("cargo:rustc-link-search=native={}", base.display());
-        for cfg_dir in ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"] {
-            let sub = base.join(cfg_dir);
-            if sub.is_dir() {
-                println!("cargo:rustc-link-search=native={}", sub.display());
+    // Collect every native link-search dir (base + whichever cmake config
+    // subdir actually exists) — emitted to cargo AND retained for the presence
+    // contract below. Single-config Unix drops libs directly in the base dir;
+    // multi-config (MSVC / Visual Studio) nests them under Debug/Release/etc.,
+    // so we probe the filesystem rather than trust Cargo's PROFILE (which can
+    // diverge when a build.rs pins a cmake config, per M5's review).
+    let mut search_dirs: Vec<std::path::PathBuf> = Vec::new();
+    {
+        let mut add_search = |rel: &str| {
+            let base = dst.join(rel);
+            println!("cargo:rustc-link-search=native={}", base.display());
+            search_dirs.push(base.clone());
+            for cfg_dir in ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"] {
+                let sub = base.join(cfg_dir);
+                if sub.is_dir() {
+                    println!("cargo:rustc-link-search=native={}", sub.display());
+                    search_dirs.push(sub);
+                }
             }
+        };
+        add_search("lib");
+        add_search("build/ggml/src");
+        add_search("build/src");
+        add_search("build/tools/mtmd");
+        add_search("build/common");
+    }
+
+    // NON-FRAGILE LINK CONTRACT. Before emitting a link directive for one of
+    // OUR cmake-built static libs, assert the archive actually exists in a
+    // search dir. Why this exists: link names are hardcoded target names that
+    // upstream can rename or restructure out from under us (the 2026 sync
+    // renamed `common` → `llama-common` + split off `llama-common-base`). A
+    // stale name otherwise surfaces ONLY as a cryptic `ld: library 'X' not
+    // found` at LINK time — which `cargo check` never reaches (it typechecks
+    // but does not link), so the break sails through local validation and
+    // dies in CI. A build.rs panic fires during `cargo check` too, converting
+    // a downstream link mystery into an upstream, named, actionable failure
+    // the instant the fork drifts. System libs (c++/stdc++/gomp) resolve from
+    // system paths and are NOT routed through here — only libs WE build.
+    let link_static = |name: &str, whole_archive: bool| {
+        let (prefix, ext) = if target_env == "msvc" {
+            ("", "lib")
+        } else {
+            ("lib", "a")
+        };
+        let filename = format!("{prefix}{name}.{ext}");
+        let present = search_dirs.iter().any(|d| d.join(&filename).exists());
+        assert!(
+            present,
+            "llama build.rs: expected static library `{name}` ({filename}) was not \
+             produced by the cmake build.\nSearched:\n{}\n\
+             The vendored llama.cpp most likely renamed or restructured this cmake \
+             target (the 2026 upstream sync renamed `common` → `llama-common`). \
+             Update the link names in core/llama/build.rs to match the new targets.",
+            search_dirs
+                .iter()
+                .map(|d| format!("  {}", d.display()))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+        if whole_archive {
+            println!("cargo:rustc-link-lib=static:+whole-archive={name}");
+        } else {
+            println!("cargo:rustc-link-lib=static={name}");
         }
     };
-    link_search("lib");
-    link_search("build/ggml/src");
-    link_search("build/src");
-    link_search("build/tools/mtmd");
-    link_search("build/common");
-    println!("cargo:rustc-link-lib=static=llama");
-    println!("cargo:rustc-link-lib=static=ggml");
-    println!("cargo:rustc-link-lib=static=ggml-base");
-    println!("cargo:rustc-link-lib=static=ggml-cpu");
+
+    link_static("llama", false);
+    link_static("ggml", false);
+    link_static("ggml-base", false);
+    link_static("ggml-cpu", false);
     // libmtmd: multimodal projector + image/audio encoder. Loaded via
     // mtmd_init_from_file(mmproj_path, model, params); produces image
     // tokens that get evaluated alongside text via mtmd_helper_eval_chunks.
-    // Depends on libcommon (string utils, base64 decoder).
-    println!("cargo:rustc-link-lib=static=mtmd");
-    println!("cargo:rustc-link-lib=static=common");
+    // Depends on llama-common (string utils, base64 decoder).
+    link_static("mtmd", false);
+    // Upstream (2026 sync) renamed the common utils lib `common` →
+    // `llama-common` and split off `llama-common-base` (build-info.cpp) to
+    // stop `libcommon.a` colliding with other packages' common libs.
+    // llama-common's arg/chat/sampling code calls build-info symbols in
+    // llama-common-base, so the dependent must precede the dependency for GNU
+    // ld's single-pass resolver.
+    link_static("llama-common", false);
+    link_static("llama-common-base", false);
     // GGML backends register via C++ static initializers inside the backend's
     // static archive. Without +whole-archive, ld --as-needed / dead_strip
     // drops the archive because nothing from the main llama archive directly
@@ -227,16 +286,16 @@ fn main() {
     //   Undefined symbols for architecture arm64:
     //     "_ggml_backend_blas_reg" in ggml-backend-reg.cpp.o
     if target_os == "macos" {
-        println!("cargo:rustc-link-lib=static:+whole-archive=ggml-blas");
+        link_static("ggml-blas", true);
     }
     if cfg!(feature = "metal") && target_os == "macos" {
-        println!("cargo:rustc-link-lib=static:+whole-archive=ggml-metal");
+        link_static("ggml-metal", true);
     }
     if cfg!(feature = "cuda") && target_os == "linux" {
-        println!("cargo:rustc-link-lib=static:+whole-archive=ggml-cuda");
+        link_static("ggml-cuda", true);
     }
     if cfg!(feature = "vulkan") && target_os == "linux" {
-        println!("cargo:rustc-link-lib=static:+whole-archive=ggml-vulkan");
+        link_static("ggml-vulkan", true);
     }
 
     // C++ stdlib + OpenMP (llama.cpp CPU backend uses GOMP_parallel on Linux).

--- a/core/llama/build.rs
+++ b/core/llama/build.rs
@@ -25,6 +25,11 @@ fn main() {
     cfg.define("LLAMA_BUILD_EXAMPLES", "OFF")
         .define("LLAMA_BUILD_TESTS", "OFF")
         .define("LLAMA_BUILD_SERVER", "OFF")
+        // Upstream 2026-07 added the unified `llama` app (LLAMA_BUILD_APP, default ON
+        // standalone) which links llama-server-impl — a lib that never builds when
+        // LLAMA_BUILD_SERVER=OFF, so the install target dies at link. We consume the
+        // LIBRARIES only; never build the app. (No-op on older trees: unknown -D is ignored.)
+        .define("LLAMA_BUILD_APP", "OFF")
         // We want libmtmd (multimodal projector + image/audio encoder) so
         // the in-process LlamaCppAdapter can route ContentPart::Image to
         // the model natively instead of dropping it. mtmd lives under

--- a/core/llama/src/bin/bench.rs
+++ b/core/llama/src/bin/bench.rs
@@ -8,7 +8,7 @@
 use std::path::PathBuf;
 use std::time::Instant;
 
-use llama::{Batch, Context, ContextParams, Model, ModelParams, Sampler};
+use llama::{Batch, ContextParams, Model, ModelParams, Sampler};
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/core/llama/src/mtmd.rs
+++ b/core/llama/src/mtmd.rs
@@ -166,14 +166,18 @@ impl MtmdContext {
         // Step 1: load bitmap from raw bytes — the helper auto-detects
         // image vs audio from magic bytes (per mtmd-helper.h: stb_image
         // formats for images, miniaudio formats wav/mp3/flac for audio).
-        let bitmap = unsafe {
+        // Upstream 2026-07: gained `placeholder` (false = real media bytes) and returns a
+        // wrapper { bitmap, video_ctx }. video_ctx is only populated for VIDEO inputs —
+        // unsupported here (images/audio only), where it is null; the bitmap is ours to free.
+        let wrapper = unsafe {
             sys::mtmd_helper_bitmap_init_from_buf(
                 self.ptr.as_ptr(),
                 media_bytes.as_ptr(),
                 media_bytes.len(),
+                false,
             )
         };
-        let bitmap = NonNull::new(bitmap).ok_or_else(|| {
+        let bitmap = NonNull::new(wrapper.bitmap).ok_or_else(|| {
             format!(
                 "mtmd_helper_bitmap_init_from_buf failed — bytes not a valid {} format",
                 match kind {
@@ -209,6 +213,8 @@ impl MtmdContext {
         let c_text = CString::new(text).map_err(|e| format!("invalid text (NUL byte?): {e}"))?;
         let input_text = sys::mtmd_input_text {
             text: c_text.as_ptr(),
+            // Upstream 2026-07: explicit byte length alongside the pointer (excl. NUL).
+            text_len: c_text.as_bytes().len(),
             add_special: true,
             parse_special: true,
         };

--- a/core/llama/src/safe.rs
+++ b/core/llama/src/safe.rs
@@ -316,7 +316,13 @@ impl Model {
 
         let mut ffi_params = unsafe { sys::llama_model_default_params() };
         ffi_params.n_gpu_layers = params.n_gpu_layers;
-        ffi_params.use_mmap = params.use_mmap;
+        // Upstream 2026-07 replaced `use_mmap: bool` with the load_mode enum
+        // (NONE/MMAP/MLOCK/DIRECT_IO — DIRECT_IO is the future NVMe cold-expert read path).
+        ffi_params.load_mode = if params.use_mmap {
+            sys::llama_load_mode_LLAMA_LOAD_MODE_MMAP
+        } else {
+            sys::llama_load_mode_LLAMA_LOAD_MODE_NONE
+        };
 
         let raw = unsafe { sys::llama_model_load_from_file(c_path.as_ptr(), ffi_params) };
         let ptr = NonNull::new(raw)


### PR DESCRIPTION
## The K3-day critical-path removal

Our vendored llama.cpp base was **2026-04-13 — 1360 commits behind** — and 12 new architectures landed upstream since. K3 (and the GLM/Kimi-K2.7 multi-arch validation) need fresh upstream. This bumps the submodule to `continuum/sync-2026-07-27`: **today's** upstream master + our two continuum patches cherry-picked (metal controls; the `llama_model_get_tensor` slice-2 accessor — conflict hand-resolved, coexisting with upstream's own new expert accessors).

## Drift reconciliation (4 fixes, each read from the new headers)
- `build.rs`: `LLAMA_BUILD_APP=OFF` — upstream's new unified app links a server lib we rightly don't build. No-op on older trees.
- `mtmd.rs`: new `placeholder` arg (false = real media); wrapper return `{bitmap, video_ctx}`; explicit `text_len`.
- `safe.rs`: `use_mmap` → the new `load_mode` enum (`DIRECT_IO` noted — the future NVMe cold-expert path).

## Validation state — and the merge gate
✅ llama crate compiles green (bindings verified to carry `llama_model_get_tensor`)
✅ continuum-core compiles green (zero errors)
⛔ **DO NOT merge on compile-green.** This is a 1360-commit serving-substrate jump under living personas. Merge gate: deploy this branch on the Mac → decode smoke on Devstral + the 30B MoE → `serving.k3_placement` probe re-fires correctly (A1 re-check) → then merge. I'll run that validation and report here.

Upstream gifts spotted during the sync: `LLAMA_LOAD_MODE_DIRECT_IO` (NVMe cold-expert reads) and `tensor_buft_overrides` now programmatic in `llama_model_params` (our `-ot` can go API-native when embedding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)