### PR TITLE
fix(install-llama-server): stamp-after-verify + retry the SIGKILL-prone --version (dogfood)

### DIFF
--- a/tools/scripts/install-llama-server.sh
+++ b/tools/scripts/install-llama-server.sh
@@ -107,13 +107,29 @@ fi
 # ── install + stamp ──────────────────────────────────────────────────
 cp -f "$BUILT_BIN" "$INSTALL_BIN"
 chmod +x "$INSTALL_BIN"
-echo "$STAMP_WANT" > "$STAMP_FILE"
 
-# Verify it actually runs (fail loud here, not at first serve).
-if ! "$INSTALL_BIN" --version >/dev/null 2>&1; then
-  echo "✗ FATAL: installed $INSTALL_BIN does not run (--version failed)." >&2
+# Verify the installed binary runs BEFORE stamping it (2026-07-26, M5+BigMama
+# two-box dogfood). The old order (stamp THEN verify) had two failure modes:
+#   1. STAMP-BEFORE-VERIFY (BigMama): a genuinely-broken build still got its
+#      stamp written, so the next run saw stamp==SUBMODULE_HEAD, decided it was
+#      "already current", skipped the rebuild, and served the broken binary
+#      forever. The stamp must be the LAST step, written only after proof.
+#   2. FLAKY VERIFY (M5): a fresh Mach-O's first exec can transiently SIGKILL
+#      (Killed:9) under concurrent build+serve memory/Metal pressure even though
+#      the binary is perfectly healthy — a single --version check then false-
+#      FATALs a good install. Retry once before declaring failure.
+# On genuine failure, remove the binary so it can't masquerade as installed.
+verify_ok=0
+for _attempt in 1 2; do
+  if "$INSTALL_BIN" --version >/dev/null 2>&1; then verify_ok=1; break; fi
+  sleep 1
+done
+if [ "$verify_ok" -ne 1 ]; then
+  rm -f "$INSTALL_BIN"
+  echo "✗ FATAL: built llama-server does not run (--version failed after retry)." >&2
   exit 1
 fi
+echo "$STAMP_WANT" > "$STAMP_FILE"   # stamp LAST — only a verified-good binary is blessed
 
 echo "✓ llama-server installed: $INSTALL_BIN ($STAMP_WANT)" >&2
 echo "$INSTALL_BIN"


### PR DESCRIPTION
Two failure modes in the install block, surfaced by the 2026-07-26 two-box run + reviewed by BigMama (LGTM):
1. **Stamp-before-verify** (BigMama): a broken build got its stamp written → next run saw stamp==SUBMODULE_HEAD, skipped rebuild, served broken forever. Stamp is now LAST — only a verified binary is blessed.
2. **Flaky verify** (M5): a fresh Mach-O's first exec transiently SIGKILLs (Killed:9) under build+serve memory/Metal pressure though healthy → single --version false-FATALs a good install. Retry ×2.
rm -f on genuine failure so a broken binary leaves no binary AND no stamp → next run rebuilds clean.

Safe alone (only reorders verify/stamp + retries; does NOT change WHEN the builder runs or backend detection). Sibling of BigMama's start-server.sh caller-delegate (#2048) + Windows-CUDA backend fix, which land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)