### PR TITLE
feat: cross-grid dispatch — AircInterceptor routes Commands.execute over airc to a peer

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1686,6 +1686,40 @@ pub fn start_server(
     // can attach a heartbeat-less node reader against the same daemon +
     // room the citizens attach to.
     let node_presence_deps = persona_bootstrap_deps.clone();
+
+    // AircInterceptor's late-bind Arc<Airc>: the interceptor is built ~800 lines
+    // below (inside the executor), synchronously, but `Airc::attach_as` is async and
+    // must not block the boot critical path. Create the cell HERE (where the daemon
+    // socket is in scope), spawn a task that attaches the interceptor's own handle —
+    // same daemon_socket + continuum_root the citizens use — and fills the cell, then
+    // hand the SAME cell to the interceptor at construction. Until it's filled an
+    // aircPeer-targeted command fails loud (never a silent fallthrough). Mirrors the
+    // node-presence reader's own attach.
+    let interceptor_airc_deps = persona_bootstrap_deps.clone();
+    let airc_interceptor_cell: Arc<tokio::sync::OnceCell<Arc<airc_lib::Airc>>> =
+        Arc::new(tokio::sync::OnceCell::new());
+    if let Some((interceptor_daemon_socket, _room)) = interceptor_airc_deps {
+        let cell = airc_interceptor_cell.clone();
+        let root = crate::modules::persona_instance_manager::resolve_continuum_root();
+        tokio::spawn(async move {
+            match airc_lib::Airc::attach_as(root, "continuum-airc-interceptor", interceptor_daemon_socket)
+                .await
+            {
+                Ok(airc) => {
+                    // attach_as yields an owned `Airc`; the interceptor + AircLiveTransport
+                    // share it as `Arc<Airc>`.
+                    let _ = cell.set(Arc::new(airc));
+                }
+                Err(err) => tracing::error!(
+                    error = %err,
+                    "airc interceptor: attach_as failed — aircPeer command routing stays \
+                     unavailable (commands with aircPeer will fail loud until a boot with a \
+                     reachable airc daemon)"
+                ),
+            }
+        });
+    }
+
     runtime.register(airc_module);
 
     // A.2 [[no-fallbacks-ever]]: in `FullCitizen` or `FailFast` mode,
@@ -2520,7 +2554,9 @@ pub fn start_server(
             // event source and `message_bus()` is None — the boot-loud
             // panic the `CONTINUUM_CORE_WS` block asserts against.
             .with_message_bus(runtime.bus_arc())
-            .with_interceptor(Arc::new(crate::runtime::AircInterceptor::new()))
+            .with_interceptor(Arc::new(crate::runtime::AircInterceptor::with_airc_cell(
+                airc_interceptor_cell,
+            )))
             .with_interceptor(Arc::new(crate::runtime::GridInterceptor::new(grid_state)))
             // `provided` sits at the TAIL of the chain: airc/grid get first look
             // so an explicitly remote-targeted perception/observe still hops to a

--- a/core/continuum-core/src/runtime/airc_interceptor.rs
+++ b/core/continuum-core/src/runtime/airc_interceptor.rs
@@ -43,19 +43,60 @@
 //! stub's structure already discriminates the param shape; only the
 //! transport call body needs to change.
 
+use std::sync::Arc;
+
+use airc_lib::Airc;
 use async_trait::async_trait;
 use serde_json::Value;
+use tokio::sync::OnceCell;
+use uuid::Uuid;
 
 use super::command_interceptor::{CommandInterceptor, InterceptorOutcome};
+use crate::ai::types::TextGenerationRequest;
+use crate::inference::airc_remote::protocol::RemoteInferenceRequest;
+use crate::inference::airc_remote::transport::{AircInferenceTransport, AircLiveTransport};
+use crate::runtime::service_module::CommandResult;
+
+/// The one command that rides the airc inference transport in this first cut.
+/// Generic any-command routing over airc (mirroring grid's `dispatch_to_node`)
+/// is the follow-up; today only inference hops to an explicit peer.
+const AIRC_ROUTED_GENERATE: &str = "ai/generate";
 
 /// AircInterceptor — sits at the head of the interceptor chain so airc-
 /// targeted commands route to the messaging substrate before grid even
-/// looks at them. See module docs for the stub contract.
-pub struct AircInterceptor;
+/// looks at them. See module docs.
+///
+/// Holds a LATE-BOUND concrete `Arc<Airc>` — the airc-lib handle carrying
+/// `request()`, the peer RPC that `AircLiveTransport` sends over. It's a cell,
+/// not a constructor arg, because the interceptor is built synchronously during
+/// executor construction (`ipc/mod.rs`) while `Airc::attach_as` is async and must
+/// not block the boot critical path: a spawned boot task fills the cell once the
+/// daemon socket is reachable. Until it's filled, an `aircPeer` target fails loud
+/// (no silent fallthrough) — same honest contract as the old stub.
+pub struct AircInterceptor {
+    airc: Arc<OnceCell<Arc<Airc>>>,
+}
 
 impl AircInterceptor {
+    /// Stub form — an empty cell. `try_route` on an `aircPeer` target fails loud
+    /// until the cell is filled. Used by tests + call sites that don't wire airc.
     pub fn new() -> Self {
-        Self
+        Self {
+            airc: Arc::new(OnceCell::new()),
+        }
+    }
+
+    /// Production form — share the cell a boot task fills with the attached
+    /// `Arc<Airc>` (`Airc::attach_as` → `cell.set(...)`). Hand the SAME `Arc` to
+    /// the spawned attach task via [`Self::airc_cell`].
+    pub fn with_airc_cell(cell: Arc<OnceCell<Arc<Airc>>>) -> Self {
+        Self { airc: cell }
+    }
+
+    /// The late-bind cell, so the boot flow can spawn the `attach_as` task that
+    /// fills it with the concrete handle.
+    pub fn airc_cell(&self) -> Arc<OnceCell<Arc<Airc>>> {
+        self.airc.clone()
     }
 }
 
@@ -77,22 +118,64 @@ impl CommandInterceptor for AircInterceptor {
         let room = params.get("aircRoom").and_then(|v| v.as_str());
 
         match (peer, room) {
-            // Neither airc target field set — this isn't an airc-routed
-            // command. Decline cleanly, let the chain continue.
+            // Neither airc target field set — not an airc-routed command.
+            // Decline cleanly, let the chain (grid, then local) continue.
             (None, None) => Ok(InterceptorOutcome::Decline),
 
-            // Airc target set, but the transport isn't wired yet. Fail
-            // loudly with a concrete pointer to the missing piece, so a
-            // caller writing `aircPeer` finds out at request time rather
-            // than from silent fallthrough.
-            (Some(target), _) | (_, Some(target)) => Err(format!(
-                "airc routing requested for command '{command}' \
-                 (target: '{target}'), but the airc transport is not \
-                 yet wired into the kernel — see MODULE-ARCHITECTURE.md \
-                 §7.1. Until @continuum-modules/airc exposes the \
-                 send-command primitive this interceptor delegates to, \
-                 callers must omit aircPeer/aircRoom params."
-            )),
+            // Room broadcast isn't a request/response inference hop. Fail loud
+            // rather than pretend a single-peer RPC — only aircPeer routes today.
+            (None, Some(_room)) => Err(
+                "airc room-broadcast routing (aircRoom) isn't wired into the kernel \
+                 yet — only aircPeer (a single-peer command RPC) routes over airc today."
+                    .to_string(),
+            ),
+
+            // Explicit single-peer target: route the command over airc to that
+            // peer's continuum-core and return its result — the E=mc² primitive,
+            // remote-transparent to the caller.
+            (Some(target), _) => {
+                // The concrete airc handle, late-bound by the boot attach task.
+                // Absent until attach completes → fail loud, never silent-decline.
+                let airc = self.airc.get().ok_or_else(|| {
+                    format!(
+                        "airc routing requested for '{command}' (target '{target}') but the \
+                         airc handle hasn't attached yet — retry once the airc daemon is \
+                         reachable (Airc::attach_as fills the interceptor cell on boot)."
+                    )
+                })?;
+
+                // First cut: only inference rides the airc transport. Generic
+                // any-command routing (mirroring grid's dispatch_to_node) is the follow-up.
+                if command != AIRC_ROUTED_GENERATE {
+                    return Err(format!(
+                        "airc routing for '{command}' isn't wired yet — only \
+                         '{AIRC_ROUTED_GENERATE}' hops to an explicit aircPeer today. \
+                         Generic command-over-airc is the follow-up (mirrors grid dispatch)."
+                    ));
+                }
+
+                let peer_id = Uuid::parse_str(target).map_err(|e| {
+                    format!("aircPeer must be a peer UUID, got {target:?}: {e}")
+                })?;
+
+                // For ai/generate the command params ARE the TextGenerationRequest.
+                let text_request: TextGenerationRequest = serde_json::from_value(params.clone())
+                    .map_err(|e| {
+                        format!(
+                            "aircPeer '{AIRC_ROUTED_GENERATE}' params aren't a \
+                             TextGenerationRequest: {e}"
+                        )
+                    })?;
+
+                let transport = AircLiveTransport::new(airc.clone(), peer_id);
+                let request = RemoteInferenceRequest::new(text_request).with_target_peer(target);
+                let response = transport.send_request(request).await.map_err(|e| {
+                    format!("airc remote inference to peer '{target}' failed: {e}")
+                })?;
+
+                let result = CommandResult::json(&response.text_response)?;
+                Ok(InterceptorOutcome::Handled(result))
+            }
         }
     }
 
@@ -142,11 +225,14 @@ mod tests {
             );
         assert!(
             err.contains("airc"),
-            "error must name the missing transport: {err}"
+            "error must name the airc transport: {err}"
         );
+        // With an empty cell (new()), the aircPeer target fails loud on the
+        // not-yet-attached handle — the honest "retry when the daemon is
+        // reachable" contract, never a silent decline.
         assert!(
-            err.contains("MODULE-ARCHITECTURE"),
-            "error must point at the canonical doc for the design: {err}"
+            err.contains("attach"),
+            "error must explain the airc handle hasn't attached yet: {err}"
         );
         assert!(
             err.contains("peer-uuid-here"),


### PR DESCRIPTION
Completes cross-grid inference dispatch (task #17) — the consumer side of M5's merged `grid_overflow_lanes` producer (#2050). NOT a new adapter: the canonical E=mc² primitive, `Commands.execute(cmd, { aircPeer })` routes over airc to that peer's continuum-core and returns the result.

## Two commits
1. **`AircInterceptor::try_route` → `AircLiveTransport`** — fills the deliberate stub ("only the transport body changes"). Mirrors `GridInterceptor` (the sibling doing capability-based remote routing). First cut routes `ai/generate` (params → `TextGenerationRequest` → `send_request` → `response.text_response` → `CommandResult::json` → `Handled`); room-broadcast + generic-any-command are explicit fail-loud follow-ups.
2. **Boot wire (`ipc/mod.rs`)** — resolves the async-attach / sync-construction mismatch with a **late-bind cell**: a spawned boot task `Airc::attach_as`es and fills `Arc<OnceCell<Arc<Airc>>>` without blocking boot; `with_airc_cell` hands it to the interceptor. Fails loud until attached — never silent.

## Why this shape (M5 + Joel's redirect)
Avoids the "parallel plane" — one transport (`AircLiveTransport`, `airc.request`), one primitive (`Commands.execute`), remote-transparent. Interceptor chain order `[airc, grid]`: explicit `aircPeer` beats grid's capability routing.

## End-to-end
`grid_overflow_lanes > 0` (M5's governor) → `aircPeer = select_grid_peer` → this interceptor routes the overflow inference lane to a peer. Local overload transparently spills across the fleet — the grid-distribution lever.

## Validation
`cargo check -p continuum-core --lib` clean (0 errors). Runtime end-to-end (live peer round-trip) validates once two nodes are up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)