### PR TITLE
fix(runtime): unbreak canary — airc room-route error echoes aircRoom target

### DIFF
--- a/core/continuum-core/src/runtime/airc_interceptor.rs
+++ b/core/continuum-core/src/runtime/airc_interceptor.rs
@@ -124,11 +124,11 @@ impl CommandInterceptor for AircInterceptor {
 
             // Room broadcast isn't a request/response inference hop. Fail loud
             // rather than pretend a single-peer RPC — only aircPeer routes today.
-            (None, Some(_room)) => Err(
-                "airc room-broadcast routing (aircRoom) isn't wired into the kernel \
-                 yet — only aircPeer (a single-peer command RPC) routes over airc today."
-                    .to_string(),
-            ),
+            // Echo the target (like the peer path) so callers can correlate logs.
+            (None, Some(room)) => Err(format!(
+                "airc room-broadcast routing (aircRoom '{room}') isn't wired into the \
+                 kernel yet — only aircPeer (a single-peer command RPC) routes over airc today."
+            )),
 
             // Explicit single-peer target: route the command over airc to that
             // peer's continuum-core and return its result — the E=mc² primitive,


### PR DESCRIPTION
**Canary is RED** (`Continuum Rust Tests: failure`): #2051 merged without this one-line fix, so `fails_loud_when_airc_room_targeted` fails on the un-echoed error. Echo `{room}` (matches the peer path). Fix the code, not the test.

Regression: the #2051 merge raced ahead of the fix commit (which lived only on the now-deleted feature branch). This lands it on canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)