### PR TITLE
fix(commands): resolve short-form persona ids in agent/solve + memory/consolidate (#164)

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -209,8 +209,16 @@ impl AgentSolve {
     /// registry), so it runs inline OR spawned detached with the same code path.
     async fn solve_body(p: AgentSolveParams) -> Result<AgentSolveResult, CommandError> {
         let run_id = p.run_id.clone();
-        let persona_uuid = Uuid::parse_str(p.persona_id.trim())
-            .map_err(|_| CommandError::Invalid(format!("persona_id '{}' is not a UUID", p.persona_id)))?;
+        // Short-form persona ids resolve too (#164): rosters/benchmark harnesses DISPLAY
+        // 8-char short ids, so accept the id a caller was shown — a clean UUID passes
+        // straight through, a short/mistyped form expands against the live persona registry
+        // (the ONE shared id_resolve primitive), instead of failing "is not a UUID".
+        let persona_uuid = crate::id_resolve::resolve(
+            p.persona_id.trim(),
+            &crate::persona::card::ids(),
+            "persona",
+        )
+        .map_err(CommandError::Invalid)?;
         let workspace = p.workspace.trim().to_string();
         if !std::path::Path::new(&workspace).is_dir() {
             return Err(CommandError::Invalid(format!(

--- a/core/continuum-core/src/commands/memory/consolidate.rs
+++ b/core/continuum-core/src/commands/memory/consolidate.rs
@@ -110,9 +110,14 @@ crate::action_command! {
     run(this, _ctx, p) => {
         let _timer = TimingGuard::new("module", "memory_consolidate");
 
-        let persona_uuid = uuid::Uuid::parse_str(&p.persona_id).map_err(|e| {
-            CommandError::Internal(format!("memory/consolidate: persona_id must be a uuid: {e}"))
-        })?;
+        // #164: accept the short-form persona id rosters display, not just a full UUID —
+        // the same id_resolve primitive persona/* and work/* already use.
+        let persona_uuid = crate::id_resolve::resolve(
+            &p.persona_id,
+            &crate::persona::card::ids(),
+            "persona",
+        )
+        .map_err(CommandError::Invalid)?;
         let persona_name = p.persona_name.clone().unwrap_or_else(|| p.persona_id.clone());
 
         let executor = this.state.executor().map_err(CommandError::Internal)?;


### PR DESCRIPTION
## #164 — short-form ids should resolve on every id param

The proven short-id resolver (`id_resolve::resolve`) already backs `work/*` (cards) and `persona/{identity,instances,wall}` (personas): a caller can pass the **8-char short id the surfaces display** and it expands against the live registry. But two persona-facing siblings still parsed a **raw UUID** and failed *"is not a UUID"* on the exact short/mistyped ids the rosters show — the ~28% `work/claim`-class miss in the live captures (#161):

- **`agent/solve`** (the headless benchmark-agent entrypoint) — `persona_id`
- **`memory/consolidate`** — `persona_id`

Both now route `persona_id` through the ONE shared `id_resolve::resolve(_, &persona::card::ids(), "persona")` primitive — clean UUID passes through, short/mistyped form resolves, a genuine miss fails **loud** naming the kind + enumerating the valid short forms (self-correcting, not a silent dead-end) — identical to the seven existing callers.

## Scope note
The remaining `Uuid::parse_str` sites in the audit are **internal** — wire-state/optional-field `.ok()` parses and `.expect()` invariants on system-supplied ids, not persona-typed tool params — so they legitimately need no resolver. The fuller "per-type resolver at the dispatch base" (resolve once, universally) stays the architectural target; this closes the concrete `persona_id` inconsistency now.

## Validation
`continuum-core` compiles clean (`--features metal,accelerate`, 0 errors); the resolver's own comprehensive tests (`normalize`/`resolve`/error-scaling in `id_resolve.rs`) already cover the behavior this wiring reuses.