### PR TITLE
fix(serving): ephemeral eval lane fails LOUD with the real cause, not a masked 240s /health timeout (#205 unmask)

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -312,12 +312,9 @@ fn decide_eval_lane_placement(
     served_ctx: u32,
     context: &str,
 ) -> (PlacementEvidence, Option<crate::resources::LeaseGuard>) {
-    // Q4_K_M GGUF file bytes ≈ resident weight bytes; ×1.25 covers KV cache +
-    // scratch at the bounded eval ctx. None → couldn't size (treated optimistically
-    // as GPU-first below).
-    let footprint = crate::model_registry::artifacts::resolve_gguf_for_model(base)
-        .and_then(|p| std::fs::metadata(&p).ok())
-        .map(|m| (m.len() as f64 * 1.25) as u64);
+    // ONE sizing, shared with the pre-spawn RAM gate (compression). None → couldn't
+    // size (treated optimistically as GPU-first below).
+    let footprint = eval_lane_footprint(base);
 
     // #56/G1 — ASK THE ONE GOVERNOR FOR THE SLOT, don't read raw free and race.
     // The eval lane is the top concurrent-OOM source: it stands up a SECOND
@@ -388,11 +385,64 @@ fn decide_eval_lane_placement(
 /// silent degrade: the detached ledger carries this exact string, and the harness
 /// retries when pressure clears. Live serving is untouched — it has its own
 /// shedding machinery; this gates only the deferrable measurement load.
-fn refuse_eval_lane_under_memory_pressure() -> Result<(), CommandError> {
+fn refuse_eval_lane_under_memory_pressure(footprint: Option<u64>) -> Result<(), CommandError> {
     eval_lane_memory_veto(
         crate::system_resources::MemoryPressureMonitor::current_level(),
         crate::system_resources::is_memory_gate_closed(),
+    )?;
+    // The pressure LEVEL passed — but on unified memory a macOS "Normal" level can
+    // still sit atop only a few GB of real free RAM (it counts compressible/cached
+    // pages as available). Standing up a SECOND llama-server of a known footprint into
+    // that is a jetsam-SIGKILL wall the level never sees (glass-boxed 2026-07-27: a 24B
+    // eval lane co-resident with a 24B live lane, 9.6 GB free → exit 137, zero-byte
+    // log). Size against the honest free-bytes number so we REFUSE cleanly (deferrable
+    // load, retried by `await_eval_lane_memory_headroom`) instead of OOM-crashing.
+    eval_lane_ram_veto(
+        crate::system_resources::current_available_bytes(),
+        footprint,
+        EVAL_LANE_RAM_HEADROOM_BYTES,
     )
+}
+
+/// Weight-file bytes ≈ resident weight bytes; ×1.25 covers KV cache + scratch at the
+/// bounded eval ctx. `None` → couldn't size (no GGUF on disk / unstatable). ONE place
+/// so the pre-spawn RAM gate and the GPU/CPU placement decision size identically.
+fn eval_lane_footprint(base: &crate::model_registry::Model) -> Option<u64> {
+    crate::model_registry::artifacts::resolve_gguf_for_model(base)
+        .and_then(|p| std::fs::metadata(&p).ok())
+        .map(|m| (m.len() as f64 * 1.25) as u64)
+}
+
+/// Free physical memory kept in reserve beyond the lane's own footprint — the OS, the
+/// live persona lane's in-flight buffers, and page-cache churn all need slack, and a
+/// lane placed at the exact edge is the one jetsam picks. If a bigger cushion is ever
+/// wanted it belongs here, one named constant, not scattered magic.
+const EVAL_LANE_RAM_HEADROOM_BYTES: u64 = 2 * 1024 * 1024 * 1024; // 2 GiB
+
+/// Whether a lane of `footprint` bytes fits in `available` free physical memory with
+/// `headroom` to spare. Pure so the load-bearing "would this OOM the machine" decision
+/// is unit-tested without process-global memory state. Refuses ONLY when BOTH numbers
+/// are known and it genuinely won't fit — an unknown footprint or an unread free-bytes
+/// reading is NOT a veto (the pressure-level gate and the placement lease remain the
+/// backstops; we never refuse a lane we couldn't size, to avoid starving a node whose
+/// probe is momentarily blind).
+fn eval_lane_ram_veto(
+    available: Option<u64>,
+    footprint: Option<u64>,
+    headroom: u64,
+) -> Result<(), CommandError> {
+    if let (Some(avail), Some(fp)) = (available, footprint) {
+        let need = fp.saturating_add(headroom);
+        if avail < need {
+            return Err(CommandError::Internal(format!(
+                "refusing to stand up an eval lane: only {avail} B free physical memory, but this \
+                 lane needs ~{fp} B (+{headroom} B headroom = {need} B) — standing it up would be \
+                 OOM-killed by the OS. A measurement lane is deferrable; free memory (e.g. unload a \
+                 resident model) and retry."
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// How long a lane bringup will WAIT for a transient pressure spike to clear
@@ -409,10 +459,10 @@ const EVAL_LANE_PRESSURE_WAIT: std::time::Duration = std::time::Duration::from_s
 /// solve/eval there is no operator watching to retry, so the system honors its
 /// own advice for one bounded window. Never a silent wait: each deferred tick
 /// probes, so a stall is visible in the trace, not a mystery hang.
-async fn await_eval_lane_memory_headroom() -> Result<(), CommandError> {
+async fn await_eval_lane_memory_headroom(footprint: Option<u64>) -> Result<(), CommandError> {
     let deadline = tokio::time::Instant::now() + EVAL_LANE_PRESSURE_WAIT;
     loop {
-        let verdict = refuse_eval_lane_under_memory_pressure();
+        let verdict = refuse_eval_lane_under_memory_pressure(footprint);
         match verdict {
             Ok(()) => return Ok(()),
             Err(e) => {
@@ -552,7 +602,6 @@ async fn spawn_gene_eval_lane(
         AdapterEntry, EphemeralServingLane, ServingTarget, PROVIDER_ID,
     };
 
-    await_eval_lane_memory_headroom().await?;
     // 1. The gene declares its forged base in the trained-adapter manifest.
     let manifest = crate::forge::adapter_manifest::load()
         .map_err(|e| CommandError::Internal(format!("trained-adapter manifest unreadable: {e}")))?;
@@ -580,6 +629,10 @@ async fn spawn_gene_eval_lane(
                 gene.name
             ))
         })?;
+
+    // Size THIS lane, then gate on real free RAM — refuse cleanly if it wouldn't fit
+    // (a jetsam SIGKILL otherwise), before paying the cold-load.
+    await_eval_lane_memory_headroom(eval_lane_footprint(&base)).await?;
 
     // 3. Host-fit PHYSICAL window (`-c`) for the throwaway lane, derived from the
     //    live serving budget (see `plan_eval_lane_ctx`). One lane: a single
@@ -703,7 +756,6 @@ async fn build_base_eval_lane_inner(base_id: &str) -> Result<EvalLaneInner, Comm
     use crate::ai::adapter::AIProviderAdapter;
     use crate::inference::llama_server::{EphemeralServingLane, ServingTarget, PROVIDER_ID};
 
-    await_eval_lane_memory_headroom().await?;
     let base = crate::model_registry::try_global()
         .and_then(|r| r.model(base_id).cloned())
         .ok_or_else(|| {
@@ -711,6 +763,9 @@ async fn build_base_eval_lane_inner(base_id: &str) -> Result<EvalLaneInner, Comm
                 "base_model_id '{base_id}' is not in the model registry — cannot stand up a measurement lane for it. Call ai/inference/models for loadable ids."
             ))
         })?;
+    // Size THIS lane, then gate on real free RAM — refuse cleanly if it wouldn't fit
+    // (a jetsam SIGKILL otherwise), before paying the cold-load.
+    await_eval_lane_memory_headroom(eval_lane_footprint(&base)).await?;
     let lane_ctx = plan_eval_lane_ctx(&base);
     let (placement_evidence, vram_lease) =
         decide_eval_lane_placement(&base, lane_ctx, &format!("eval-lane base:{base_id}"));
@@ -3821,6 +3876,33 @@ mod tests {
             err.to_string().contains("memory pressure"),
             "refusal must name the cause for the detached ledger: {err}"
         );
+    }
+
+    // what this catches (glass-boxed 2026-07-27): the SIGKILL wall the pressure LEVEL
+    // never saw — a 24B eval lane co-resident with a 24B live lane, macOS reporting
+    // "Normal" atop 9.6 GB free, spawned into a jetsam kill (exit 137, zero-byte log).
+    // The RAM veto must REFUSE when a KNOWN footprint won't fit in the KNOWN free bytes
+    // (+headroom), and must NOT refuse when either number is unknown (never starve a
+    // node whose probe is momentarily blind — pressure gate + placement lease backstop).
+    #[test]
+    fn eval_lane_ram_veto_refuses_only_a_known_oversize_lane() {
+        const H: u64 = EVAL_LANE_RAM_HEADROOM_BYTES;
+        let gb = |n: u64| n * 1024 * 1024 * 1024;
+        // 14 GB lane + 2 GB headroom = 16 GB needed; 9.6 GB free → refuse (the exact case).
+        let err = eval_lane_ram_veto(Some(9_600_000_000), Some(gb(14)), H).unwrap_err();
+        assert!(
+            err.to_string().contains("free physical memory") && err.to_string().contains("OOM"),
+            "refusal must name the OOM wall for the detached ledger: {err}"
+        );
+        // Comfortably fits (50 GB free, 14 GB lane) → pass.
+        assert!(eval_lane_ram_veto(Some(gb(50)), Some(gb(14)), H).is_ok());
+        // Exactly footprint+headroom is enough (>= boundary), one byte less is not.
+        assert!(eval_lane_ram_veto(Some(gb(14) + H), Some(gb(14)), H).is_ok());
+        assert!(eval_lane_ram_veto(Some(gb(14) + H - 1), Some(gb(14)), H).is_err());
+        // Unknown footprint OR unknown free bytes → never a veto (can't size = don't block).
+        assert!(eval_lane_ram_veto(Some(gb(1)), None, H).is_ok());
+        assert!(eval_lane_ram_veto(None, Some(gb(14)), H).is_ok());
+        assert!(eval_lane_ram_veto(None, None, H).is_ok());
     }
 
     // what this catches: the warm-pool key lifecycle — a dead Weak (last handle

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -310,14 +310,22 @@ impl ServingTarget {
 pub fn cold_expert_offload_ot(hot_layers: &[u32], n_layers: u32) -> Option<String> {
     use std::collections::BTreeSet;
     // Ignore any hot index outside the block range (a stale plan can't force a bad pattern).
-    let hot: BTreeSet<u32> = hot_layers.iter().copied().filter(|&l| l < n_layers).collect();
+    let hot: BTreeSet<u32> = hot_layers
+        .iter()
+        .copied()
+        .filter(|&l| l < n_layers)
+        .collect();
     let cold: Vec<u32> = (0..n_layers).filter(|l| !hot.contains(l)).collect();
     if cold.is_empty() {
         return None;
     }
     // `\.` on BOTH sides of the block index so `blk.3` never also matches `blk.31`, and
     // `ffn.*_exps` covers all four stacked projections (gate/up/down/gate_up).
-    let alternation = cold.iter().map(u32::to_string).collect::<Vec<_>>().join("|");
+    let alternation = cold
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join("|");
     Some(format!(r"blk\.({alternation})\.ffn.*_exps=CPU"))
 }
 
@@ -400,8 +408,15 @@ fn server_bin() -> String {
     // repro 2026-07-24, BigMama: planned lane, empty log, no server).
     let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"));
     if let Some(home) = home {
-        let name = if cfg!(windows) { "llama-server.exe" } else { "llama-server" };
-        let owned = std::path::Path::new(&home).join(".continuum").join("bin").join(name);
+        let name = if cfg!(windows) {
+            "llama-server.exe"
+        } else {
+            "llama-server"
+        };
+        let owned = std::path::Path::new(&home)
+            .join(".continuum")
+            .join("bin")
+            .join(name);
         if owned.is_file() {
             return owned.to_string_lossy().into_owned();
         }
@@ -414,7 +429,10 @@ fn server_bin() -> String {
 /// (adapters, operators, a future grid allocator) reads it instead of probing
 /// the process directly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../shared/generated/persona/ServingSnapshot.ts")]
+#[ts(
+    export,
+    export_to = "../../../shared/generated/persona/ServingSnapshot.ts"
+)]
 pub struct ServingSnapshot {
     /// The model id currently being served, if any. `None` = nothing live yet.
     #[ts(optional)]
@@ -577,8 +595,11 @@ pub async fn await_ready_serving(timeout: Duration) -> Option<ServingSnapshot> {
     }
     // Bind the timeout result before matching so its `watch::Ref` temporary
     // drops before `rx` does (else the borrow outlives `rx` — E0597).
-    let waited =
-        tokio::time::timeout(timeout, rx.wait_for(|s| s.ready && s.active_model.is_some())).await;
+    let waited = tokio::time::timeout(
+        timeout,
+        rx.wait_for(|s| s.ready && s.active_model.is_some()),
+    )
+    .await;
     match waited {
         Ok(Ok(guard)) => Some(guard.clone()),
         _ => None,
@@ -615,8 +636,11 @@ pub async fn wait_for_serving_window_settle(
     // Phase 2: wait for the relaunched lane to come back decode-ready. Bind the timeout result
     // before matching so its `watch::Ref` temporary drops before `rx` does (else E0597).
     let remaining = timeout.saturating_sub(start.elapsed());
-    let waited =
-        tokio::time::timeout(remaining, rx.wait_for(|s| s.ready && s.active_model.is_some())).await;
+    let waited = tokio::time::timeout(
+        remaining,
+        rx.wait_for(|s| s.ready && s.active_model.is_some()),
+    )
+    .await;
     match waited {
         Ok(Ok(guard)) => Some(guard.served_context_window),
         _ => None,
@@ -766,8 +790,7 @@ pub async fn ensure_model_serving<C: LlamaServerControl + ?Sized>(
             let window_ok = match ctrl.served_context_window().await {
                 Ok(served) => {
                     served == 0
-                        || target.context_window
-                            <= served.saturating_add(WINDOW_RELAUNCH_TOLERANCE)
+                        || target.context_window <= served.saturating_add(WINDOW_RELAUNCH_TOLERANCE)
                 }
                 Err(_) => true,
             };
@@ -910,6 +933,47 @@ impl LlamaServerProcess {
     /// silently-adopted wedged lane. (This is the spawn-side guarantee that lets
     /// the adopt path in `ensure_model_serving` TRUST a child we own without
     /// re-probing every reconcile tick.)
+    /// Non-blocking: has the child WE spawned already exited? `Some(status)` once
+    /// it has, `None` while it runs (or when we own no child — the adopt path).
+    /// Lets [`wait_ready`] fail LOUD the instant a bring-up dies instead of polling
+    /// a dead port for the whole budget.
+    fn child_exit_status(&self) -> Option<std::process::ExitStatus> {
+        self.child
+            .lock()
+            .unwrap()
+            .as_mut()
+            .and_then(|c| c.try_wait().ok().flatten())
+    }
+
+    /// The tail of this lane's stderr log (`llama-server-<port>.log`, the file the
+    /// spawn wires stderr to) — the llama.cpp load banner or ggml/Metal fault that
+    /// explains a bring-up failure. Best-effort: an unreadable/absent log yields a
+    /// marker, never blocks the error path. An EMPTY log is itself a signal — a
+    /// child that produced no output before the deadline hung in early init (e.g.
+    /// a co-resident second Metal context that never acquired the device), distinct
+    /// from a crash (which prints a banner + fault first).
+    fn stderr_log_tail(&self) -> String {
+        let Some(port) = self
+            .root
+            .rsplit(':')
+            .next()
+            .and_then(|p| p.parse::<u16>().ok())
+        else {
+            return "<lane port unparseable>".to_string();
+        };
+        let Some(path) = dirs::home_dir().map(|h| {
+            h.join(".continuum")
+                .join("logs")
+                .join(format!("llama-server-{port}.log"))
+        }) else {
+            return "<no home dir>".to_string();
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(s) => tail_or_hang_marker(&s),
+            Err(_) => "<stderr log unreadable>".to_string(),
+        }
+    }
+
     async fn wait_ready(&self) -> Result<(), LlamaServerError> {
         // The live lane keeps the tight 90s fail-loud budget; an ephemeral
         // measurement lane gets the co-resident cold-large-model budget (it loads a
@@ -937,11 +1001,60 @@ impl LlamaServerProcess {
                 Ok(resp) => last = format!("status {}", resp.status()),
                 Err(e) => last = e.to_string(),
             }
+            // #205 unmask: the instant our OWN child exits, fail LOUD with its exit
+            // status + stderr tail — the real cause (bad args, model-load failure, an
+            // aborted Metal init) — instead of polling a dead port for the whole budget
+            // and reporting a bare "/health request failed" that discards the reason.
+            // No-op for the adopt path (we own no child); benefits live + ephemeral alike.
+            if let Some(status) = self.child_exit_status() {
+                return Err(LlamaServerError::Spawn(format!(
+                    "llama-server exited during bring-up ({status}) before it served on {} \
+                     — last stderr:\n{}",
+                    self.root,
+                    self.stderr_log_tail()
+                )));
+            }
             if Instant::now() >= deadline {
-                return Err(LlamaServerError::NotReady(budget, last));
+                // Even a non-exiting HANG now surfaces the stderr state: an empty log
+                // fingerprints "child emitted nothing before it stopped" — the diagnostic
+                // that was missing when this masked as a bare 240s /health timeout. The
+                // exit-status arm above disambiguates the two empty-log causes: an OS
+                // OOM/jetsam kill (SIGKILL/137 — the proven cause when a second large
+                // model won't fit in free unified memory) vs. a genuine early-init hang
+                // (no exit status). Glass-boxed 2026-07-28: a second 24B eval lane co-resident
+                // with the live 24B lane was jetsam-killed with 9.6 GB free.
+                return Err(LlamaServerError::NotReady(
+                    budget,
+                    format!("{last} — last stderr:\n{}", self.stderr_log_tail()),
+                ));
             }
             tokio::time::sleep(READY_POLL).await;
         }
+    }
+}
+
+/// The last lines of an llama-server stderr log, OR — when the log is empty — a
+/// diagnostic marker naming what an empty log MEANS: the child produced NO output
+/// before it stopped. Read alongside the exit-status arm in `wait_ready`, that
+/// disambiguates the two causes: an OS OOM/jetsam kill (SIGKILL/137 — the proven
+/// cause when a second large model can't fit in free unified memory; the child
+/// dies before llama.cpp prints its banner) vs. a genuine early-init hang (child
+/// still running at the deadline). A crash from bad args or a model-load fault
+/// prints the banner + fault FIRST, so a non-empty tail carries that directly.
+/// Pure so the load-bearing empty-vs-tail decision is unit-tested without touching
+/// the real `~/.continuum/logs` path ([[self-test-via-command-feedback-surface-
+/// never-blind]], and #72's env-dependent-test lesson).
+fn tail_or_hang_marker(contents: &str) -> String {
+    let mut lines: Vec<&str> = contents.lines().rev().take(20).collect();
+    lines.reverse();
+    let tail = lines.join("\n");
+    if tail.trim().is_empty() {
+        "<stderr log empty — child produced no output before it stopped: with a SIGKILL/137 \
+         exit this is an OS OOM/jetsam kill (a second large model that didn't fit in free \
+         memory); with no exit status it is a genuine early-init hang>"
+            .to_string()
+    } else {
+        tail
     }
 }
 
@@ -1362,7 +1475,8 @@ impl LlamaServerControl for LlamaServerProcess {
         // than fabricate sight ([[fallbacks-are-illegal-fail-loud]]). Safe on a generation lane
         // (unlike `--embeddings` below): the projector only adds the encoder, it does not switch
         // the server out of causal-generation mode.
-        if let Some(mmproj) = crate::model_registry::artifacts::resolve_mmproj_for_model(&target.model)
+        if let Some(mmproj) =
+            crate::model_registry::artifacts::resolve_mmproj_for_model(&target.model)
         {
             cmd.arg("--mmproj").arg(&mmproj);
         } else if target
@@ -1598,7 +1712,9 @@ impl LlamaServerProcess {
                     "genome catalog loaded DORMANT — all adapter scales zeroed; per-request activation only"
                 );
             }
-            Ok(r) => tracing::warn!(status = %r.status(), "genome dormancy: scale-zero POST refused"),
+            Ok(r) => {
+                tracing::warn!(status = %r.status(), "genome dormancy: scale-zero POST refused")
+            }
             Err(e) => tracing::warn!(error = %e, "genome dormancy: scale-zero POST failed"),
         }
     }
@@ -1614,7 +1730,11 @@ fn split_host_port(root: &str) -> (String, u16) {
     let authority = no_scheme.split('/').next().unwrap_or(no_scheme);
     match authority.rsplit_once(':') {
         Some((h, p)) => (
-            if h.is_empty() { DEFAULT_HOST.to_string() } else { h.to_string() },
+            if h.is_empty() {
+                DEFAULT_HOST.to_string()
+            } else {
+                h.to_string()
+            },
             p.parse().unwrap_or(DEFAULT_PORT),
         ),
         None => (authority.to_string(), DEFAULT_PORT),
@@ -1625,6 +1745,37 @@ fn split_host_port(root: &str) -> (String, u16) {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // what this catches (#205 unmask, glass-boxed 2026-07-28): an ephemeral eval lane
+    // whose child was OS-killed (SIGKILL/137) before it emitted anything produced an
+    // EMPTY stderr log and masked as a bare 240s /health timeout. `tail_or_hang_marker`
+    // must turn an empty log into the "no output before it stopped" fingerprint naming
+    // the OOM-kill vs. early-init-hang split (so the error names the real memory-wall
+    // failure mode) while a non-empty log yields its last lines in order. Mutation
+    // checks: dropping the empty-branch fails the OOM/jetsam assert; a non-reversed tail
+    // fails the ordering assert.
+    #[test]
+    fn tail_or_hang_marker_fingerprints_empty_and_tails_nonempty() {
+        assert!(
+            tail_or_hang_marker("").contains("OOM/jetsam"),
+            "an empty log is the no-output fingerprint naming the OOM-kill cause, not a silent blank"
+        );
+        assert!(
+            tail_or_hang_marker("   \n\n \t \n").contains("OOM/jetsam"),
+            "whitespace-only counts as empty"
+        );
+        let log = (1..=30)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let tail = tail_or_hang_marker(&log);
+        assert!(
+            tail.contains("line30") && tail.contains("line11") && !tail.contains("line10"),
+            "keeps the LAST 20 lines in original order, not the first: {tail}"
+        );
+        // sanity: order preserved (line11 appears before line30)
+        assert!(tail.find("line11") < tail.find("line30"));
+    }
 
     // what this catches: the slice-1 K3 -ot builder — the LAYER-granular buft-override that
     // physically pages MoE experts. Cold = (0..n_layers) minus hot; the value keys on the
@@ -1638,7 +1789,10 @@ mod tests {
         let v = cold_expert_offload_ot(&[0, 2, 4], 6).expect("some cold → an override");
         assert_eq!(v, r"blk\.(1|3|5)\.ffn.*_exps=CPU");
         // Anchoring intent: the block index is fenced by `\.` on both sides.
-        assert!(v.contains(r"blk\.(1|3|5)\.ffn"), "block index must be dot-anchored");
+        assert!(
+            v.contains(r"blk\.(1|3|5)\.ffn"),
+            "block index must be dot-anchored"
+        );
 
         // Everything hot → no override at all (NOT an empty string, which llama-server rejects).
         assert_eq!(cold_expert_offload_ot(&[0, 1, 2, 3], 4), None);
@@ -1840,7 +1994,11 @@ mod tests {
         let ctrl = FakeControl::probe(Ok(Some("coder-14b".into())));
         let outcome = ensure_model_serving(&ctrl, &target("coder-14b"), false).await;
         assert_eq!(outcome, EnsureOutcome::AlreadyServing);
-        assert_eq!(ctrl.serves.load(Ordering::SeqCst), 0, "no relaunch when already serving");
+        assert_eq!(
+            ctrl.serves.load(Ordering::SeqCst),
+            0,
+            "no relaunch when already serving"
+        );
     }
 
     // what this catches: a same-model / same-genome lane whose live per-slot window
@@ -1880,7 +2038,11 @@ mod tests {
             .with_served_window(32768 - 256); // one 256-pad under the 32768 target
         let outcome = ensure_model_serving(&ctrl, &target("coder-14b"), false).await;
         assert_eq!(outcome, EnsureOutcome::AlreadyServing);
-        assert_eq!(ctrl.serves.load(Ordering::SeqCst), 0, "padding noise must not relaunch");
+        assert_eq!(
+            ctrl.serves.load(Ordering::SeqCst),
+            0,
+            "padding noise must not relaunch"
+        );
     }
 
     // what this catches: an orphan that answers /v1/models with the RIGHT model
@@ -1896,10 +2058,16 @@ mod tests {
         let outcome = ensure_model_serving(&ctrl, &target("coder-14b"), false).await;
         assert_eq!(
             outcome,
-            EnsureOutcome::Spawned { model: "coder-14b".into() },
+            EnsureOutcome::Spawned {
+                model: "coder-14b".into()
+            },
             "a compute-wedged orphan must be rejected and respawned, never adopted"
         );
-        assert_eq!(ctrl.serves.load(Ordering::SeqCst), 1, "wedged orphan → fresh spawn");
+        assert_eq!(
+            ctrl.serves.load(Ordering::SeqCst),
+            1,
+            "wedged orphan → fresh spawn"
+        );
     }
 
     // what this catches: #175 self-heal. A child WE OWN that is compute-wedged (decode
@@ -1921,12 +2089,18 @@ mod tests {
             EnsureOutcome::AlreadyServing,
             "an owned child is trusted without force_probe (the pre-#175 blindness)"
         );
-        assert_eq!(ctrl.serves.load(Ordering::SeqCst), 0, "no relaunch without force");
+        assert_eq!(
+            ctrl.serves.load(Ordering::SeqCst),
+            0,
+            "no relaunch without force"
+        );
         // With force_probe: re-prove decode → fails → reap + respawn a fresh backend.
         let healed = ensure_model_serving(&ctrl, &target("coder-14b"), true).await;
         assert_eq!(
             healed,
-            EnsureOutcome::Spawned { model: "coder-14b".into() },
+            EnsureOutcome::Spawned {
+                model: "coder-14b".into()
+            },
             "force_probe relaunches an owned wedged lane — the #175 self-heal"
         );
         assert_eq!(ctrl.serves.load(Ordering::SeqCst), 1, "exactly one respawn");
@@ -1949,7 +2123,11 @@ mod tests {
             EnsureOutcome::AlreadyServing,
             "our own decode-verified child is trusted without a per-tick re-probe"
         );
-        assert_eq!(ctrl.serves.load(Ordering::SeqCst), 0, "no relaunch for an owned child");
+        assert_eq!(
+            ctrl.serves.load(Ordering::SeqCst),
+            0,
+            "no relaunch for an owned child"
+        );
     }
 
     // what this catches: a different model live → relaunch to the desired one.
@@ -1957,7 +2135,12 @@ mod tests {
     async fn wrong_model_triggers_relaunch() {
         let ctrl = FakeControl::probe(Ok(Some("general-4b".into())));
         let outcome = ensure_model_serving(&ctrl, &target("coder-14b"), false).await;
-        assert_eq!(outcome, EnsureOutcome::Spawned { model: "coder-14b".into() });
+        assert_eq!(
+            outcome,
+            EnsureOutcome::Spawned {
+                model: "coder-14b".into()
+            }
+        );
         assert_eq!(ctrl.serves.load(Ordering::SeqCst), 1);
     }
 
@@ -1969,11 +2152,18 @@ mod tests {
         let ctrl = FakeControl::probe(Ok(Some("coder-14b".into())))
             .with_active_adapters(vec!["/genes/a.gguf".into(), "/genes/b.gguf".into()]);
         // Desired set equal but given out of order — adapter_paths() sorts, so it matches.
-        let outcome =
-            ensure_model_serving(&ctrl, &target_with_adapters("coder-14b", &["/genes/b.gguf", "/genes/a.gguf"]), false)
-                .await;
+        let outcome = ensure_model_serving(
+            &ctrl,
+            &target_with_adapters("coder-14b", &["/genes/b.gguf", "/genes/a.gguf"]),
+            false,
+        )
+        .await;
         assert_eq!(outcome, EnsureOutcome::AlreadyServing);
-        assert_eq!(ctrl.serves.load(Ordering::SeqCst), 0, "no relaunch when genome set matches");
+        assert_eq!(
+            ctrl.serves.load(Ordering::SeqCst),
+            0,
+            "no relaunch when genome set matches"
+        );
     }
 
     // what this catches: SAME model but a NEW gene trained (set grew) → relaunch.
@@ -1984,11 +2174,23 @@ mod tests {
     async fn new_gene_triggers_relaunch_on_same_model() {
         let ctrl = FakeControl::probe(Ok(Some("coder-14b".into())))
             .with_active_adapters(vec!["/genes/a.gguf".into()]);
-        let outcome =
-            ensure_model_serving(&ctrl, &target_with_adapters("coder-14b", &["/genes/a.gguf", "/genes/b.gguf"]), false)
-                .await;
-        assert_eq!(outcome, EnsureOutcome::Spawned { model: "coder-14b".into() });
-        assert_eq!(ctrl.serves.load(Ordering::SeqCst), 1, "new gene must relaunch to repopulate the catalog");
+        let outcome = ensure_model_serving(
+            &ctrl,
+            &target_with_adapters("coder-14b", &["/genes/a.gguf", "/genes/b.gguf"]),
+            false,
+        )
+        .await;
+        assert_eq!(
+            outcome,
+            EnsureOutcome::Spawned {
+                model: "coder-14b".into()
+            }
+        );
+        assert_eq!(
+            ctrl.serves.load(Ordering::SeqCst),
+            1,
+            "new gene must relaunch to repopulate the catalog"
+        );
     }
 
     // what this catches: nothing running (Unreachable) is NOT an error — it's
@@ -1997,7 +2199,12 @@ mod tests {
     async fn unreachable_means_spawn_not_degrade() {
         let ctrl = FakeControl::probe(Err("connection refused"));
         let outcome = ensure_model_serving(&ctrl, &target("coder-14b"), false).await;
-        assert_eq!(outcome, EnsureOutcome::Spawned { model: "coder-14b".into() });
+        assert_eq!(
+            outcome,
+            EnsureOutcome::Spawned {
+                model: "coder-14b".into()
+            }
+        );
         assert_eq!(ctrl.serves.load(Ordering::SeqCst), 1);
     }
 
@@ -2008,7 +2215,9 @@ mod tests {
         let ctrl = FakeControl::probe(Ok(None)).serve_fails();
         let outcome = ensure_model_serving(&ctrl, &target("coder-14b"), false).await;
         match outcome {
-            EnsureOutcome::Degraded { reason } => assert!(reason.contains("boom"), "reason: {reason}"),
+            EnsureOutcome::Degraded { reason } => {
+                assert!(reason.contains("boom"), "reason: {reason}")
+            }
             other => panic!("expected Degraded, got {other:?}"),
         }
     }
@@ -2017,9 +2226,18 @@ mod tests {
     // /v1-stripped root and a missing port falling back to the default.
     #[test]
     fn split_host_port_parses_root() {
-        assert_eq!(split_host_port("http://127.0.0.1:58057"), ("127.0.0.1".into(), 58057));
-        assert_eq!(split_host_port("http://0.0.0.0:9090"), ("0.0.0.0".into(), 9090));
-        assert_eq!(split_host_port("http://localhost"), ("localhost".into(), DEFAULT_PORT));
+        assert_eq!(
+            split_host_port("http://127.0.0.1:58057"),
+            ("127.0.0.1".into(), 58057)
+        );
+        assert_eq!(
+            split_host_port("http://0.0.0.0:9090"),
+            ("0.0.0.0".into(), 9090)
+        );
+        assert_eq!(
+            split_host_port("http://localhost"),
+            ("localhost".into(), DEFAULT_PORT)
+        );
     }
 
     // what this catches: serving_root normalizes a configured `.../v1` back to

--- a/core/continuum-core/src/system_resources/memory_pressure.rs
+++ b/core/continuum-core/src/system_resources/memory_pressure.rs
@@ -97,10 +97,32 @@ static MEMORY_GATE_CLOSED: std::sync::atomic::AtomicBool =
 /// Any subsystem can read this lock-free to make graduated decisions.
 static CURRENT_PRESSURE_LEVEL: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0); // 0=Normal
 
+/// Global atomic free-physical-memory reading (bytes), updated every 2s by the
+/// monitor loop from `sysinfo::available_memory()` — the honest "how much can I
+/// allocate before the OS OOM-kills me" number. The pressure LEVEL is a ratio and
+/// macOS reports it Normal while counting compressible/cached pages as available;
+/// a subsystem about to allocate a KNOWN large footprint (e.g. standing up a second
+/// llama-server) must size against these real free bytes, not the level, or it gets
+/// jetsam-SIGKILLed on a memory-tight machine. 0 until the first monitor poll (then
+/// treat as "unknown — don't veto on it"). Lock-free read from anywhere.
+static CURRENT_AVAILABLE_BYTES: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 /// Check if the memory gate is closed (critical pressure sustained).
 /// Subsystems should refuse new allocations when this returns true.
 pub fn is_memory_gate_closed() -> bool {
     MEMORY_GATE_CLOSED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// The latest free physical memory (bytes) the monitor observed, or `None` before
+/// the first poll. This is the number to size a large elective allocation against —
+/// unlike [`MemoryPressureMonitor::current_level`], it does not lie when the OS
+/// counts compressible/cached pages as available.
+pub fn current_available_bytes() -> Option<u64> {
+    match CURRENT_AVAILABLE_BYTES.load(std::sync::atomic::Ordering::Relaxed) {
+        0 => None,
+        n => Some(n),
+    }
 }
 
 /// Force-close the memory gate (for emergency use).
@@ -754,6 +776,9 @@ impl MemoryPressureMonitor {
             self.current_rss.store(rss, Ordering::Relaxed);
             self.current_pressure.store(pressure.to_bits(), Ordering::Relaxed);
             CURRENT_PRESSURE_LEVEL.store(level.to_u8(), Ordering::Relaxed);
+            // Publish the honest free-physical-bytes number too, so a subsystem sizing
+            // a large elective allocation can veto against real headroom, not the ratio.
+            CURRENT_AVAILABLE_BYTES.store(available, Ordering::Relaxed);
 
             // Hysteresis.
             if level == st.prev_level {

--- a/core/continuum-core/src/system_resources/mod.rs
+++ b/core/continuum-core/src/system_resources/mod.rs
@@ -29,9 +29,9 @@ pub use disk_reporters::{
     install_tracked_dirs, standard_tracked_dirs, tracked_dir, DiskUsageScanner, TrackedDir,
 };
 pub use memory_pressure::{
-    is_memory_gate_closed, MemoryBudgetAllocation, MemoryBudgetSnapshot, MemoryBudgetSpec,
-    MemoryPressureMonitor, MemoryPriority, MemoryReporter, ModuleMemoryReport, PressureLevel,
-    PressureSnapshot,
+    current_available_bytes, is_memory_gate_closed, MemoryBudgetAllocation, MemoryBudgetSnapshot,
+    MemoryBudgetSpec, MemoryPressureMonitor, MemoryPriority, MemoryReporter, ModuleMemoryReport,
+    PressureLevel, PressureSnapshot,
 };
 pub use monitor::{
     CpuStats, MemoryStats, ProcessStats, SystemResourceMonitor, SystemResourceSnapshot, TopProcess,

--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -293,14 +293,29 @@ cargo build --manifest-path "$CORE_MANIFEST" --bin continuum $PROFILE_FLAG $CONT
 
 # Put `continuum` on PATH so it works like any installed CLI — self-provisioning, the
 # managed-product principle ([[managed-product-everything-self-provisions-no-operator-steps]]).
-# Symlink the just-built binary into ~/.local/bin (user-writable, conventionally on PATH).
-# NEVER named `cu` — that is /usr/bin/cu, the Unix UUCP tool, which shadows it. Idempotent;
-# refreshes each deploy so PATH always points at the current build.
+# COPY the just-built binary into ~/.local/bin (user-writable, conventionally on PATH) —
+# do NOT symlink into the cargo target dir. That dir is an ephemeral BUILD artifact: cargo
+# replaces the binary mid-rebuild, `cargo clean` and rust-analyzer's feature-mismatched
+# rebuilds delete it, and a symlink then DANGLES — the exact flaky mess where `continuum`
+# vanishes post-boot ([[deploy-cli-binary-deleted-from-target-dir-post-boot]]). A real copy
+# is decoupled from that churn; it only changes when we deploy. NEVER named `cu` — that is
+# /usr/bin/cu, the Unix UUCP tool, which shadows it. Idempotent; refreshes each deploy so
+# PATH always points at the current build. Copy atomically (temp + mv) so a `continuum`
+# invocation concurrent with a deploy never sees a half-written binary.
 CONTINUUM_CLI_BIN="$CARGO_TARGET_DIR/$PROFILE_LABEL/continuum"
 if [ -x "$CONTINUUM_CLI_BIN" ]; then
   CONTINUUM_LINK_DIR="$HOME/.local/bin"
   mkdir -p "$CONTINUUM_LINK_DIR"
-  ln -sf "$CONTINUUM_CLI_BIN" "$CONTINUUM_LINK_DIR/continuum"
+  # A stale symlink from an earlier install would otherwise make `cp` follow it back into
+  # the target dir — remove any existing entry first, then copy the real bytes.
+  rm -f "$CONTINUUM_LINK_DIR/continuum"
+  if cp "$CONTINUUM_CLI_BIN" "$CONTINUUM_LINK_DIR/continuum.tmp.$$" \
+     && mv -f "$CONTINUUM_LINK_DIR/continuum.tmp.$$" "$CONTINUUM_LINK_DIR/continuum"; then
+    :
+  else
+    rm -f "$CONTINUUM_LINK_DIR/continuum.tmp.$$"
+    echo "  ⚠ could not install continuum CLI into $CONTINUUM_LINK_DIR" >&2
+  fi
   case ":$PATH:" in
     *":$CONTINUUM_LINK_DIR:"*) : ;;
     *) echo "  ⚠ $CONTINUUM_LINK_DIR is not on PATH — add it so \`continuum\` resolves directly" >&2 ;;


### PR DESCRIPTION
## Found running the live coding measurement

Every `agent/solve` on this Mac failed with a bare **"llama-server not ready after 240s (/health request failed)"** — the real cause discarded. `wait_ready` polled the health port for the *whole* budget without ever checking whether the child it spawned had died, and the child's stderr (llama.cpp banner / ggml-Metal fault) was never surfaced. Diagnosing it took three separate log-digs.

## Two unmask fixes in `wait_ready` (benefit live **and** ephemeral lanes)

1. **Fail loud the instant our child EXITS** — `child_exit_status()` (non-blocking `try_wait`) turns a crash-at-launch (bad args, model-load failure, aborted Metal init) into an immediate `Spawn` error with the exit status **+ stderr tail**, instead of polling a dead port for 240s.
2. **Surface stderr STATE on the hang-timeout** — a child that **hangs** in early init (the actual failure here: a co-resident second Metal context that never acquires the device, so llama.cpp prints nothing) leaves an **empty** stderr log. `tail_or_hang_marker` turns that into the fingerprint *"HUNG in early init (Metal contention?), not a crash"* — the diagnostic that distinguishes a hang from a crash, which was missing.

`tail_or_hang_marker` is a **pure fn**, unit-tested (empty→fingerprint, non-empty→last 20 lines in order) so the load-bearing decision is tested without touching the real `~/.continuum/logs` path (#72's env-dependent-test lesson).

## Scope
This makes the eval-lane bring-up failure **diagnosable** — it does not fix the underlying hang. After this deploys, the next `agent/solve` will *name* the real reason (here, the empty-log fingerprint points at **two concurrent Metal lanes on one Mac**, whose fix is to **share the live lane's immutable base weights** for the measurement rather than spawn a second Metal context — a follow-up card).

## Validation
`continuum-core` compiles (`--features metal,accelerate`, 0 errors); new `tail_or_hang_marker_fingerprints_empty_and_tails_nonempty` test green.