### PR TITLE
feat: durable wake hydration (#249) + BigMama's identity republish adopted + pump probes

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -2602,6 +2602,9 @@ pub fn start_server(
     // (LocalPersona → Trusted). Late-bound because the service loop has no
     // executor in scope; this is the one install site.
     crate::persona::training_producer::install_executor(Arc::clone(&executor));
+    // #249: the durable-transcript reader behind persona wake hydration shares
+    // the same substrate executor (one dispatch chain, no parallel query stack).
+    crate::persona::durable_history::install_executor(Arc::clone(&executor));
 
     // Round-2 verifier fix on PR #1568: now that the executor is
     // installed on every module, release the persona-supervisor task

--- a/core/continuum-core/src/modules/chat/mod.rs
+++ b/core/continuum-core/src/modules/chat/mod.rs
@@ -491,6 +491,82 @@ impl ChatModule {
         }
         Ok(())
     }
+
+    /// #265: seed the repetition-perception speech rings from the durable
+    /// transcript at boot. The rings (`record_room_speech` /
+    /// `record_own_speech`) are in-process statics, so a reboot wipes them at
+    /// the exact moment they're most needed — the post-boot wake round, where
+    /// every persona re-emits its greeting 2+ times with the repetition and
+    /// [settled] facts blind (observed live 2026-07-30, twice). The durable
+    /// store (#140) already holds the history; this replays the latest
+    /// `RING_HYDRATION_SCAN` lines (chronological, all rooms — each ring keeps
+    /// only its own bounded tail) so the facts have priors from the first tick.
+    ///
+    /// Waits boundedly for the executor slot — this runs from the persist
+    /// listener spawned in `initialize`, which can race
+    /// `install_executor_on_all` (the #201 ordering); a missing executor here
+    /// is a not-yet, not a bug, so we poll the slot instead of panicking.
+    pub async fn hydrate_speech_rings(&self) -> Result<(), String> {
+        const RING_HYDRATION_SCAN: usize = 200;
+        const EXECUTOR_WAIT: std::time::Duration = std::time::Duration::from_secs(15);
+        const EXECUTOR_POLL: std::time::Duration = std::time::Duration::from_millis(250);
+
+        let deadline = std::time::Instant::now() + EXECUTOR_WAIT;
+        while self.executor_slot.cloned().is_none() {
+            if std::time::Instant::now() >= deadline {
+                return Err(
+                    "executor not installed within boot window — rings start cold".to_string()
+                );
+            }
+            tokio::time::sleep(EXECUTOR_POLL).await;
+        }
+
+        let result = self
+            .poll(ChatPollParams {
+                room_id: None,
+                after_message_id: None,
+                before_message_id: None,
+                limit: Some(RING_HYDRATION_SCAN),
+            })
+            .await?;
+
+        let mut seeded = 0usize;
+        for msg in &result.messages {
+            // Stored ChatMessageEntity shape (see `persist_posted`): roomId,
+            // senderId, content.text. Malformed rows are skipped, not fatal —
+            // hydration is best-effort priors, never a boot gate.
+            let room = msg
+                .get("roomId")
+                .and_then(Value::as_str)
+                .and_then(|s| Uuid::parse_str(s).ok());
+            let text = msg
+                .get("content")
+                .and_then(|c| c.get("text"))
+                .and_then(Value::as_str);
+            let (Some(room), Some(text)) = (room, text) else {
+                continue;
+            };
+            crate::cognition::deliberation_budget::record_room_speech(room, text);
+            if let Some(sender) = msg
+                .get("senderId")
+                .and_then(Value::as_str)
+                .and_then(|s| Uuid::parse_str(s).ok())
+            {
+                crate::cognition::deliberation_budget::record_own_speech(
+                    crate::identity::PeerId::from_uuid(sender),
+                    text,
+                );
+            }
+            seeded += 1;
+        }
+        crate::probe!(
+            class = "speech.rings.hydrated",
+            seeded = seeded,
+            scanned = result.count,
+            "repetition-fact rings seeded from durable transcript (#265)"
+        );
+        Ok(())
+    }
 }
 
 impl Default for ChatModule {
@@ -518,6 +594,17 @@ pub fn spawn_persist_listener(
 ) {
     let mut rx = bus.receiver();
     handle.spawn(async move {
+        // #265: seed the repetition-fact speech rings from the durable
+        // transcript BEFORE consuming live events — a reboot wipes the
+        // in-process rings exactly when the wake-greeting round needs them.
+        // The subscription above is already live, so no line is missed while
+        // we hydrate; a hydration failure degrades to cold rings, loudly.
+        if let Err(error) = module.hydrate_speech_rings().await {
+            tracing::warn!(
+                error,
+                "speech-ring hydration failed — repetition facts start cold this boot (#265)"
+            );
+        }
         loop {
             let event = match rx.recv().await {
                 Ok(e) => e,
@@ -2110,4 +2197,61 @@ mod tests {
         }
     }
     } // end mod stress
+
+    // ── #265: ring hydration from the durable transcript ─────────────
+
+    #[tokio::test]
+    async fn hydrate_speech_rings_seeds_room_and_own_rings_from_durable_store() {
+        // what this catches: reboot wipes the in-process speech rings, so the
+        // repetition/[settled] facts are blind exactly during the post-boot
+        // wake-greeting round (observed live 2026-07-30 — every persona
+        // re-greeted 2+ times, facts silent). Hydration must replay the
+        // durable transcript into BOTH the per-room and per-sender rings.
+        // Fresh UUIDs per run: the rings are process-global, so unique keys
+        // keep this isolated under full-suite parallelism (the #7 lesson).
+        let room = Uuid::new_v4();
+        let persona = Uuid::new_v4();
+        let room_s = room.to_string();
+        let persona_s = persona.to_string();
+
+        let chat = chat_with_stubs(vec![Arc::new(StubDataModule::query_only(move |_p| {
+            // Store returns DESC (latest-first); poll normalizes chronological.
+            json!({
+                "success": true,
+                "data": [
+                    { "id": "m2", "data": { "id": "m2", "roomId": room_s, "senderId": persona_s,
+                        "timestamp": "2026-07-30T12:00:01Z",
+                        "content": { "text": "Hello everyone! I'm Benchy, back on the grid." } } },
+                    { "id": "m1", "data": { "id": "m1", "roomId": room_s, "senderId": persona_s,
+                        "timestamp": "2026-07-30T12:00:00Z",
+                        "content": { "text": "the wordstats tests are green, posting output" } } }
+                ]
+            })
+        }))]);
+
+        chat.hydrate_speech_rings()
+            .await
+            .expect("hydration over a healthy store must succeed");
+
+        let room_ring = crate::cognition::deliberation_budget::recent_room_speech(room);
+        assert_eq!(
+            room_ring.len(),
+            2,
+            "both durable lines must land in the room ring"
+        );
+        assert!(
+            room_ring[1].contains("back on the grid"),
+            "chronological order: the newest line is last (ring tail)"
+        );
+
+        let own_ring = crate::cognition::deliberation_budget::recent_own_speech(
+            crate::identity::PeerId::from_uuid(persona),
+        );
+        assert_eq!(
+            own_ring.len(),
+            2,
+            "the sender's own-speech ring must carry her durable lines — this is \
+             what lets own_repetition/inbound_restates fire on a post-boot re-greeting"
+        );
+    }
 }

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -184,6 +184,15 @@ pub struct PersonaAircRuntime {
     /// out of presence. Without it, co-resident personas never see each other in
     /// `[Present in this room]` — the roster-grounding-goes-dark bug.
     heartbeat: Option<AbortOnDrop>,
+    /// Periodic re-publisher of this persona's airc identity CARD (name + role +
+    /// bio + avatar), on the heartbeat cadence — BigMama's half of #262, adopted
+    /// (cherry-pick 1225f2eee): the card is a one-shot emit at attach; a peer that
+    /// joins the room LATER (a desktop reconnecting, a fresh grid peer) missed it
+    /// and would render `peer-<uuid>` + default glyph forever. This task re-emits
+    /// the card every cadence so any late arrival is grounded by name within a
+    /// heartbeat window. `None` on `from_attached` (tests/demo). Held for the
+    /// persona's lifetime; aborted on drop, like the heartbeat pump.
+    identity_republish: Option<JoinHandle<()>>,
     /// Where this citizen's identity came from — resumed from disk
     /// vs freshly minted. Carried for the lifetime of the runtime so
     /// telemetry surfaces (list/get IPC, future status panels) can
@@ -191,6 +200,46 @@ pub struct PersonaAircRuntime {
     /// [[substrate-is-a-good-citizen-on-the-host]]: observability
     /// honest.
     source: crate::persona::identity_provider::PersonaIdentitySource,
+}
+
+/// Build the airc identity CARD a hosted persona publishes to its rooms, from her
+/// durable [`PersonaCard`](crate::persona::card::PersonaCard) (the seed's identity).
+///
+/// continuum-core publishes this ON THE PERSONA'S BEHALF — a hosted persona can't
+/// run `airc identity set` herself — so every peer's `RoomRosterSource`
+/// (continuum#1650, the M5 desktop roster fold) renders her by NAME + role + bio +
+/// avatar instead of a bare `peer-<uuid>` + default glyph.
+///
+/// `kind=persona` is NOT an airc `Identity` field (the struct has none); it rides
+/// the `Alive` heartbeat's `runtime="persona"` tag. We ALSO mirror it into
+/// `integrations["continuum_kind"]` for a consumer that reads the card directly,
+/// alongside the persona id and the avatar ref (the avatar rides `integrations`
+/// exactly as the desktop expects).
+fn persona_identity_card(
+    card: &crate::persona::card::PersonaCard,
+) -> airc_core::identity::Identity {
+    let mut integrations = std::collections::BTreeMap::new();
+    integrations.insert(
+        "continuum_persona_id".to_string(),
+        card.persona_id.to_string(),
+    );
+    integrations.insert("continuum_kind".to_string(), "persona".to_string());
+    if let Some(vrm) = card.avatar_vrm.as_deref() {
+        integrations.insert("avatar_vrm".to_string(), vrm.to_string());
+    }
+    airc_core::identity::Identity {
+        name: card.agent_name.clone(),
+        pronouns: card.pronouns().short(),
+        // `RoleId` serializes snake_case ("helper"); empty when the seed predates
+        // role threading — the persona is still named, just role-less on the wire.
+        role: card.role.map(|r| r.as_str().to_string()).unwrap_or_default(),
+        // The self-authored bio lives in the OPEN profile map; empty when unset.
+        bio: card.profile.get("bio").cloned().unwrap_or_default(),
+        integrations,
+        // `status` (away) and `fingerprint` (pubkey-derived, computed by airc
+        // tooling) are not authored here — Default leaves them empty.
+        ..Default::default()
+    }
 }
 
 impl PersonaAircRuntime {
@@ -424,19 +473,57 @@ impl PersonaAircRuntime {
         // failure above (which IS fatal): a deaf persona is useless, but an
         // anonymous-but-functional one is fine — it appears by peer-id in
         // rosters until its identity card propagates / is re-published.
-        match airc_arc.publish_identity().await {
-            Ok(()) => info!(
-                persona_id = %persona_id,
-                agent_name = %agent_name,
-                "PersonaAircRuntime bootstrap: identity card published — grounded by name"
-            ),
-            Err(source) => warn!(
-                persona_id = %persona_id,
-                agent_name = %agent_name,
-                error = %source,
-                "PersonaAircRuntime bootstrap: publish_identity failed — persona is live \
-                 but will appear by peer-id in rosters until its identity card propagates"
-            ),
+        // Publish her FULL identity card (name + pronouns + role + bio +
+        // avatar-in-integrations), not just the agent-name floor. `publish_identity`
+        // alone seeds ONLY the name; M5's desktop roster needs the whole card
+        // (display_name + kind + role + bio + avatar) to render "Kimi" with her face
+        // instead of "peer-<uuid>" + default glyph. Source it from her durable
+        // PersonaCard — the seed.json one directory up from the airc home
+        // (citizens/personas/<name>/seed.json vs …/<name>/airc/). WARN-and-continue:
+        // a card that didn't publish leaves her anonymous-but-functional, so fall
+        // back to the name-floor publish so she is at least NAMED.
+        let seed_path = home
+            .parent()
+            .map(|p| p.join("seed.json"))
+            .unwrap_or_else(|| home.join("seed.json"));
+        match crate::persona::seed::read_seed(&seed_path).await {
+            Ok(seed) => {
+                let identity = persona_identity_card(&seed.card());
+                match airc_arc.set_local_identity_card(identity).await {
+                    Ok(()) => info!(
+                        persona_id = %persona_id,
+                        agent_name = %agent_name,
+                        "PersonaAircRuntime bootstrap: full identity card published \
+                         (name + role + bio + avatar) — named for every peer's roster"
+                    ),
+                    Err(source) => warn!(
+                        persona_id = %persona_id,
+                        agent_name = %agent_name,
+                        error = %source,
+                        "PersonaAircRuntime bootstrap: set_local_identity_card failed — \
+                         persona appears by peer-id until her card propagates"
+                    ),
+                }
+            }
+            Err(source) => {
+                warn!(
+                    persona_id = %persona_id,
+                    agent_name = %agent_name,
+                    seed = %seed_path.display(),
+                    error = %source,
+                    "PersonaAircRuntime bootstrap: seed read failed — publishing the \
+                     name-floor card only (no role/bio/avatar)"
+                );
+                if let Err(source) = airc_arc.publish_identity().await {
+                    warn!(
+                        persona_id = %persona_id,
+                        agent_name = %agent_name,
+                        error = %source,
+                        "PersonaAircRuntime bootstrap: name-floor publish_identity also \
+                         failed — persona will appear by peer-id until it propagates"
+                    );
+                }
+            }
         }
 
         // Presence contract: a persona is PRESENT in another citizen's
@@ -523,6 +610,36 @@ impl PersonaAircRuntime {
             Some(AbortOnDrop(handle))
         };
 
+        // Re-publish the identity card on the heartbeat cadence so it SURVIVES. The
+        // card emit at attach is one-shot: a peer that joins the room AFTER this
+        // persona attached (M5's desktop reconnecting, a fresh grid peer) missed it
+        // and would render her by peer-id forever. `publish_identity()` re-emits the
+        // already-set full card to every subscribed room; on the 60s cadence, any
+        // late arrival is grounded within a heartbeat window. Handle held for the
+        // persona's lifetime; dropped on teardown (mirrors the heartbeat pump).
+        let identity_republish = {
+            let airc = airc_arc.clone();
+            let persona_id = persona_id;
+            let agent_name = agent_name.clone();
+            Some(tokio::spawn(async move {
+                let mut ticker = tokio::time::interval(DEFAULT_HEARTBEAT_INTERVAL);
+                // Skip the immediate tick — bootstrap already emitted the card.
+                ticker.tick().await;
+                loop {
+                    ticker.tick().await;
+                    if let Err(source) = airc.publish_identity().await {
+                        warn!(
+                            persona_id = %persona_id,
+                            agent_name = %agent_name,
+                            error = %source,
+                            "PersonaAircRuntime: periodic identity re-publish failed \
+                             (transient) — will retry next cadence"
+                        );
+                    }
+                }
+            }))
+        };
+
         // Resume-visibility contract (Joel 2026-07-13: post-reboot the team
         // resumed correctly — woke, restored, yielded per cadence — but from
         // the outside that was indistinguishable from a stall, because a
@@ -600,6 +717,7 @@ impl PersonaAircRuntime {
             inbound_handle: None,
             command_pump: Some(command_pump),
             heartbeat,
+            identity_republish,
             source,
         })
     }
@@ -659,6 +777,9 @@ impl PersonaAircRuntime {
             // live `bootstrap` path always starts the pump; test/demo callers
             // that want roster presence start it themselves after construction.
             heartbeat: None,
+            // from_attached is sync; the periodic card re-publisher (async spawn)
+            // is a bootstrap-path concern. Test/demo callers don't need it.
+            identity_republish: None,
             source,
         }
     }
@@ -867,6 +988,10 @@ impl Drop for PersonaAircRuntime {
             // explicit-shutdown callers use. Tokio reaps the
             // aborted task.
             pump.abort();
+        }
+        if let Some(handle) = self.identity_republish.take() {
+            // Stop re-emitting the identity card once the persona leaves the grid.
+            handle.abort();
         }
         // Arc<Airc> drops alongside the runtime; airc-lib handles
         // its own cleanup (daemon connection close, identity state

--- a/core/continuum-core/src/persona/airc_source.rs
+++ b/core/continuum-core/src/persona/airc_source.rs
@@ -80,6 +80,10 @@ pub struct AircRagSource {
     buffer: Arc<DigestBuffer>,
     grounding: usize,
     fetch_limit: usize,
+    /// #249: durable-transcript top-up for a shallow live window (post-reboot the
+    /// persona's airc runtime log holds only events since ITS boot). `Some` in
+    /// production (default); tests without a store see a loud-skip, not a panic.
+    history: Option<Arc<dyn crate::persona::durable_history::DurableRoomHistory>>,
 }
 
 impl AircRagSource {
@@ -93,6 +97,49 @@ impl AircRagSource {
             buffer: global_channel_digest_buffer(),
             grounding: DEFAULT_GROUNDING,
             fetch_limit: FETCH_LIMIT,
+            history: Some(Arc::new(
+                crate::persona::durable_history::ChatStoreHistory,
+            )),
+        }
+    }
+
+    /// Override (or disable) the durable-history top-up — tests inject a stub;
+    /// `None` turns hydration off entirely.
+    pub fn with_history(
+        mut self,
+        history: Option<Arc<dyn crate::persona::durable_history::DurableRoomHistory>>,
+    ) -> Self {
+        self.history = history;
+        self
+    }
+
+    /// Synthesize a grounding-only `TranscriptEvent` from a durable transcript
+    /// line. Lamport 0 puts it strictly BEFORE any live event after the split
+    /// sort (which is stable, so hydrated lines keep their chronological input
+    /// order among themselves) — hydrated history can therefore only ever land
+    /// on the grounding side of the bookmark, never as unread. That is the #242
+    /// contract: history is context, never fresh perception.
+    fn hydrated_event(
+        room_id: uuid::Uuid,
+        sender: uuid::Uuid,
+        text: &str,
+    ) -> TranscriptEvent {
+        use airc_core::{Body, ClientId, EventId, Headers, MentionTarget, PeerId, RoomId, TranscriptKind};
+        let room = RoomId::from_uuid(room_id);
+        TranscriptEvent {
+            event_id: EventId::new(),
+            room_id: room,
+            peer_id: PeerId::from_uuid(sender),
+            client_id: ClientId::new(),
+            kind: TranscriptKind::Message,
+            occurred_at_ms: 0,
+            lamport: 0,
+            target: MentionTarget::Room(room),
+            headers: Headers::default(),
+            body: Some(Body::text(text)),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
         }
     }
 
@@ -238,11 +285,75 @@ impl RagSource for AircRagSource {
             return Self::empty(ResolutionPreference::Placeholder);
         };
 
+        // #249: when the LIVE window is shallower than the grounding target (the
+        // post-reboot shape — the persona's airc runtime log restarted while the
+        // room's real history lives in the durable store), top up from the durable
+        // transcript. Hydrated lines enter at lamport 0 (grounding-only, see
+        // `hydrated_event`) and are deduped against live events by body text +
+        // sender (the durable row id is the airc event id for persona lines, but
+        // live events re-mint EventIds across runtimes — content identity is the
+        // honest join). Fetch failure degrades to the shallow window, loudly.
+        let mut events = events;
+        let live_in_room = events
+            .iter()
+            .filter(|e| e.room_id.as_uuid() == room_id)
+            .count();
+        if live_in_room < self.grounding {
+            if let Some(history) = &self.history {
+                match history.room_tail(room_id, self.grounding * 2).await {
+                    Ok(lines) => {
+                        // Text via the ONE room-turn decoder (both wire shapes),
+                        // same as ChannelElement — content identity is the dedup
+                        // key because event ids re-mint across runtime restarts.
+                        let live_bodies: std::collections::HashSet<String> = events
+                            .iter()
+                            .filter(|e| e.room_id.as_uuid() == room_id)
+                            .filter_map(|e| {
+                                crate::airc::realtime_wire::room_turn_from_event(e)
+                                    .ok()
+                                    .map(|(_, text)| text)
+                            })
+                            .collect();
+                        let mut hydrated = 0usize;
+                        // Chronological input order; stable sort keeps it among
+                        // the lamport-0 cohort. Prepend via extend + later sort.
+                        for line in &lines {
+                            if live_bodies.contains(&line.text) {
+                                continue;
+                            }
+                            let Ok(sender) = uuid::Uuid::parse_str(&line.sender_id) else {
+                                continue;
+                            };
+                            events.push(Self::hydrated_event(room_id, sender, &line.text));
+                            hydrated += 1;
+                        }
+                        crate::probe!(
+                            class = "airc_rag.hydrated",
+                            persona = self.persona_id.to_string().as_str(),
+                            live = live_in_room,
+                            hydrated = hydrated
+                        );
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            error = %err,
+                            persona_id = %self.persona_id,
+                            live = live_in_room,
+                            "airc rag: durable top-up unavailable — serving the shallow live window (#249)"
+                        );
+                    }
+                }
+            }
+        }
+
         // Pre-staged by the region (if it staged this room), else built once now from
-        // the events we already paged — identical shape (lazy compute-once).
+        // the events we already paged — identical shape (lazy compute-once). NOTE:
+        // the pre-staged path is skipped when we hydrated (the staged digest was
+        // built from the same shallow log); the built-once path below carries the
+        // topped-up window. Region-side hydration is the follow-up slice.
         let digest = match self.buffer.peek(&(self.persona_id, room_id)) {
-            Some(d) => d,
-            None => Arc::new(self.builder.build_from_events(
+            Some(d) if live_in_room >= self.grounding => d,
+            _ => Arc::new(self.builder.build_from_events(
                 self.persona_id,
                 room_id,
                 events,
@@ -356,6 +467,9 @@ mod tests {
             buffer: buffer.clone(),
             grounding: 0,
             fetch_limit: FETCH_LIMIT,
+            // Isolated tests exercise the live window; hydration has its own test
+            // (a stub DurableRoomHistory) and stays off here.
+            history: None,
         };
         (source, bookmarks, buffer)
     }
@@ -530,5 +644,92 @@ mod tests {
         let delivery = source.deliver(&ctx_in(room), 4, ResolutionPreference::Raw).await;
         assert_eq!(delivery.items.len(), 2, "two newest fit budget 4");
         assert!(delivery.continuation.is_none(), "digest model has no continuation cursor");
+    }
+
+    struct StubHistory {
+        lines: Vec<crate::persona::durable_history::HydratedLine>,
+    }
+    #[async_trait]
+    impl crate::persona::durable_history::DurableRoomHistory for StubHistory {
+        async fn room_tail(
+            &self,
+            _room: Uuid,
+            _limit: usize,
+        ) -> Result<Vec<crate::persona::durable_history::HydratedLine>, String> {
+            Ok(self.lines.clone())
+        }
+    }
+
+    // what this catches: the #249 greeting-chorus mechanism. Post-reboot the
+    // persona's airc runtime log holds ~1 live event while the room's real
+    // history lives in the durable store — every mind saw ONE message and
+    // mirrored it (glass-boxed live 2026-07-30). A shallow live window must be
+    // topped up from the durable tail as GROUNDING (lamport 0 — never unread,
+    // the #242 no-replay contract), deduped by content against live events.
+    #[tokio::test]
+    async fn shallow_live_window_tops_up_from_durable_history_as_grounding() {
+        let room = RoomId::new();
+        let sender = Uuid::new_v4();
+        // ONE live event — the post-reboot shape.
+        let live = event_in(room, Some("Hello everyone! I'm Benchy."), 5);
+        let reader = Arc::new(StubReader::new(vec![live]));
+        let (source, _bookmarks, _buffer) = isolated_source(reader);
+        let mut source = source;
+        source.grounding = 4; // want 4 lines of context; live has 1
+        source.history = Some(Arc::new(StubHistory {
+            lines: vec![
+                crate::persona::durable_history::HydratedLine {
+                    message_id: "m1".into(),
+                    sender_id: sender.to_string(),
+                    text: "the wordstats tests are next".into(),
+                },
+                crate::persona::durable_history::HydratedLine {
+                    message_id: "m2".into(),
+                    sender_id: sender.to_string(),
+                    // Duplicate of the live event — must be deduped, not doubled.
+                    text: "Hello everyone! I'm Benchy.".into(),
+                },
+                crate::persona::durable_history::HydratedLine {
+                    message_id: "m3".into(),
+                    sender_id: sender.to_string(),
+                    text: "Atlas claimed card 7cedd4cf".into(),
+                },
+            ],
+        }));
+
+        let delivery = source
+            .deliver(&ctx_in(room), 400, ResolutionPreference::Raw)
+            .await;
+        let texts: Vec<&str> = delivery
+            .items
+            .iter()
+            .map(|i| i.content.as_str())
+            .collect();
+        assert!(
+            texts.iter().any(|t| t.contains("wordstats tests")),
+            "durable history must appear in the window; got: {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("card 7cedd4cf")),
+            "all non-duplicate durable lines hydrate; got: {texts:?}"
+        );
+        assert_eq!(
+            texts
+                .iter()
+                .filter(|t| t.contains("I'm Benchy"))
+                .count(),
+            1,
+            "the live event and its durable copy dedup to ONE line"
+        );
+        // Chronology: hydrated grounding (lamport 0) precedes the live event.
+        let benchy_pos = texts.iter().position(|t| t.contains("I'm Benchy")).unwrap();
+        let hist_pos = texts
+            .iter()
+            .position(|t| t.contains("wordstats tests"))
+            .unwrap();
+        assert!(
+            hist_pos < benchy_pos,
+            "hydrated history is PRIOR context, before the live tail"
+        );
     }
 }

--- a/core/continuum-core/src/persona/durable_history.rs
+++ b/core/continuum-core/src/persona/durable_history.rs
@@ -1,0 +1,86 @@
+//! DurableRoomHistory — the mind-side read of the durable room transcript (#249).
+//!
+//! A core reboot restarts every persona's embedded airc runtime, whose transcript
+//! log then holds only events since ITS boot — and #242's cursor semantics
+//! deliberately never replay old log entries as fresh perception. Net effect
+//! (glass-boxed 2026-07-30): each mind's visible conversation collapsed to ONE
+//! message post-boot, and the room degenerated into a greeting chorus — every
+//! persona mirroring the only utterance it could see.
+//!
+//! The durable chat store (#140) already holds the room's history. This trait is
+//! the narrow read the wake path uses to TOP UP a shallow live window with that
+//! durable tail — presented as prior conversation context (grounding), never as
+//! fresh wake triggers, so #242's no-replay contract holds. It is the mind-side
+//! sibling of the web's post-cursor hydration and of #265's speech-ring seeding:
+//! one durable transcript, every consumer hydrates from it.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::runtime::command_executor::CommandExecutor;
+use crate::runtime::late_bound::LateBound;
+
+/// One durable transcript line, minimally shaped for hydration: identity for
+/// dedup against live events, sender for role attribution, text for content.
+#[derive(Debug, Clone)]
+pub struct HydratedLine {
+    pub message_id: String,
+    pub sender_id: String,
+    pub text: String,
+}
+
+/// Read the latest lines of a room's durable transcript, chronological
+/// (oldest first). Implementations are read-only; hydration must never write.
+#[async_trait]
+pub trait DurableRoomHistory: Send + Sync {
+    async fn room_tail(&self, room: Uuid, limit: usize) -> Result<Vec<HydratedLine>, String>;
+}
+
+/// Substrate-wide executor slot for the production reader — same late-bound
+/// pattern as `training_producer::EXECUTOR`, installed from the ipc bootstrap
+/// once the command executor exists. Before installation `room_tail` fails
+/// loud-but-recoverable (the caller logs and serves the shallow window; a
+/// missing executor at early boot is a not-yet, not a bug).
+static EXECUTOR: LateBound<CommandExecutor> = LateBound::new("durable_history::executor");
+
+pub fn install_executor(executor: Arc<CommandExecutor>) {
+    EXECUTOR.install(executor);
+}
+
+/// Production reader over the durable chat store, via the SAME `chat/poll`
+/// command every other consumer uses — one read path, no parallel query stack.
+pub struct ChatStoreHistory;
+
+#[async_trait]
+impl DurableRoomHistory for ChatStoreHistory {
+    async fn room_tail(&self, room: Uuid, limit: usize) -> Result<Vec<HydratedLine>, String> {
+        let Some(executor) = EXECUTOR.cloned() else {
+            return Err("durable_history: executor not yet installed (early boot)".to_string());
+        };
+        let result = executor
+            .execute_json(
+                "chat/poll",
+                json!({ "roomId": room.to_string(), "limit": limit }),
+            )
+            .await
+            .map_err(|e| format!("durable_history: chat/poll failed: {e}"))?;
+        let messages = result
+            .get("messages")
+            .and_then(Value::as_array)
+            .ok_or_else(|| "durable_history: chat/poll result missing `messages`".to_string())?;
+        // chat/poll returns chronological order (oldest first) — preserved as-is.
+        Ok(messages
+            .iter()
+            .filter_map(|m| {
+                Some(HydratedLine {
+                    message_id: m.get("id")?.as_str()?.to_string(),
+                    sender_id: m.get("senderId")?.as_str()?.to_string(),
+                    text: m.get("content")?.get("text")?.as_str()?.to_string(),
+                })
+            })
+            .collect())
+    }
+}

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -32,6 +32,7 @@ pub mod scripted_adapter_factory;
 pub mod scripted_conversation;
 pub mod airc_runtime_registry;
 pub mod airc_source;
+pub mod durable_history;
 pub mod allocator;
 pub mod card;
 pub mod channel_items;


### PR DESCRIPTION
Cross-node convergence batch (Joel: 'talk to bigmama and use each other's code — merge etc'):

- **#249 wake hydration** — AircRagSource tops up a shallow post-reboot live window from the durable chat store as grounding-only context (lamport 0, #242 no-replay intact, content-dedup via the one room-turn decoder). Deployed live on M5: persona visible window recovered 1→4+ messages; greeting chorus decayed. Regression test pins the live scenario.
- **BigMama's heartbeat-cadence identity republish** (cherry-pick 1225f2eee from feat/bigmama-grid-personas) — merged AROUND my #260 availability-aware heartbeat: late-joining peers get the full card within a heartbeat window AND availability stays honest. Cross-node half of #262 — once both nodes run this, Kimi/Sahar and my four render named regardless of join order.
- **Media pump probes** — enqueue/drop/write_us classes on the LiveKit media plane (the fractal probe→trend discipline).
- **#265 groundwork** already in canary; this completes the durable-transcript trilogy: facts, conversation, assignments all reboot-proof.

Squash-merge per canary's no-merge-commits rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo