### PR TITLE
feat(nav): seed room set from airc's durable membership registry (#241) + pin airc to dc02c7f

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -267,6 +267,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-rustls",
+ "uuid",
  "webrtc",
  "x509-parser 0.18.1",
 ]
@@ -274,7 +275,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -285,7 +286,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -299,7 +300,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -312,7 +313,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=3655e3c#3655e3c6589f1aa94f148e142c1382e137e7cf07"
+source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
 dependencies = [
  "airc-core",
  "airc-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,18 +151,18 @@ exclude = ["wordstats", "work-wordstats", "conway_game_of_life", "work-08ece9e8"
 # personas load their stored peer_id unchanged. This SHA is on the
 # feat/persona-peer-id-mint branch, not canary — reconcile to the canary SHA
 # when the airc PR lands. Re-validate persona attach on bump.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "3655e3c" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "3655e3c" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "3655e3c" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "3655e3c" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "3655e3c" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "3655e3c" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -2847,6 +2847,9 @@ pub fn start_server(
                     &state.rt_handle,
                     projection_bus.clone(),
                     nav_seed,
+                    // #241: the durable membership registry — every subscribed
+                    // room lands in nav at boot, not on first traffic.
+                    node_presence_deps.clone().map(|(socket, _room)| socket),
                 );
                 // Member-name fold (the room fold's identity sibling): resolves a
                 // persona-kind tab's title from the same presence stream.

--- a/core/continuum-core/src/ipc/positron_nav_source.rs
+++ b/core/continuum-core/src/ipc/positron_nav_source.rs
@@ -239,15 +239,48 @@ struct ChatPostedRoom {
 /// airc's registry stays the truth; this cell is the node's honest "rooms I
 /// have seen" cache, exactly like the chat accumulator ([[compression]]: one
 /// fold, every citizen's nav reader borrows the same receiver).
+///
+/// #241: when `registry_socket` is given, the owner task's FIRST act is to
+/// ask the airc daemon for the DURABLE subscribed-room registry
+/// (`DaemonClient::list_rooms`, airc #1303) and fold every membership row in
+/// — so a member's rooms exist in the nav before their first event, and a
+/// rebooted interface never collapses to just the rooms that happened to
+/// speak (the one-visible-room symptom, live-found 2026-07-31). The fetch
+/// runs inside the spawned task: boot never blocks on the daemon, and an
+/// unreachable daemon degrades to the traffic-observed behavior with a loud
+/// probe, never a wedge.
 pub fn spawn_room_set_fold(
     rt: &tokio::runtime::Handle,
     bus: Arc<MessageBus>,
     seed: Vec<(Uuid, String)>,
+    registry_socket: Option<std::path::PathBuf>,
 ) -> watch::Receiver<RoomSet> {
     let initial: RoomSet = seed.into_iter().collect();
     let (tx, rx) = watch::channel(initial);
     let mut events = bus.receiver();
     rt.spawn(async move {
+        if let Some(socket) = registry_socket {
+            match airc_ipc::DaemonClient::new(socket).list_rooms().await {
+                Ok(response) => {
+                    tx.send_if_modified(|set| {
+                        let mut changed = false;
+                        for room in response.rooms {
+                            changed |=
+                                fold_observed_room(set, room.room_id.as_uuid(), Some(room.name));
+                        }
+                        changed
+                    });
+                }
+                Err(error) => {
+                    crate::probe!(
+                        class = "nav.room_registry_seed_failed",
+                        error = format!("{error}"),
+                        "durable room-registry seed unavailable — nav degrades to \
+                         traffic-observed rooms until the daemon answers (#241)"
+                    );
+                }
+            }
+        }
         loop {
             match events.recv().await {
                 Ok(event) => {


### PR DESCRIPTION
The one-visible-room fix, continuum side, following airc #1303 (ListRooms) + #1304 (mint reland). spawn_room_set_fold's owner task asks the daemon for the durable subscribed-room registry before folding traffic — every membership room exists in nav at boot. Unreachable daemon degrades loudly to traffic-observed behavior. Pin dc02c7f is the first airc canary rev with BOTH the mint and ListRooms — closes the unmerged-branch rot for good. nav 9/9, airc_runtime 8/8 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo