### PR TITLE
chore(deps): bump airc pin to 816a0be — delivery receipts chain (airc#1307/#1308)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=dc02c7f#dc02c7f9d808854e9d3b20fb78fa2b9296a95e07"
+source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
 dependencies = [
  "airc-core",
  "airc-store",
@@ -453,7 +453,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -464,7 +464,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3695,7 +3695,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3998,7 +3998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4839,7 +4839,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5505,7 +5505,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6993,7 +6993,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8254,7 +8254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -8274,7 +8274,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -9375,7 +9375,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10095,7 +10095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10604,7 +10604,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12386,7 +12386,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,18 +151,18 @@ exclude = ["wordstats", "work-wordstats", "conway_game_of_life", "work-08ece9e8"
 # personas load their stored peer_id unchanged. This SHA is on the
 # feat/persona-peer-id-mint branch, not canary — reconcile to the canary SHA
 # when the airc PR lands. Re-validate persona attach on bump.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "dc02c7f" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)


### PR DESCRIPTION
Keeps continuum's vendored airc crates at canary tip, picking up the delivery-truth work that closed today's "airc is broken" fundamental:

- **airc#1307**: `DeliveryLedger` — per-peer ack accounting feeds route health (measured rtt/success_ppm) and the suspect purge (≥2 flushed-but-unacked frames ⇒ force-drop + re-dial the half-open session same refresh pass).
- **airc#1308**: `DeliveryStats` IPC + `airc doctor --health` per-peer "last confirmed delivery to X: N ago" lines.

Verified live between M5 and BigMama before this bump — first message through the new stack registered `last confirmed delivery 50s ago, rtt ~86ms (1 of 1 acked)`.

`cargo check -p continuum-core --features metal,accelerate` clean against the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo