### PR TITLE
feat(pager): default_tier + tiered plan write — the beat-WASTE bytes knob (#281)

### DIFF
--- a/core/expert-pager-policy/src/bin/moe-pager-driver.rs
+++ b/core/expert-pager-policy/src/bin/moe-pager-driver.rs
@@ -16,7 +16,13 @@
 //!                    --table <tkey-to-layer-matrix.json> \
 //!                    --plan <GGML_MOE_PLAN_FILE> \
 //!                    --budget-bytes <N> --window-k <N> \
-//!                    [--pin-top 256] [--rewrite-every 8] [--poll-ms 50]
+//!                    [--pin-top 256] [--rewrite-every 8] [--poll-ms 50] \
+//!                    [--pin-tier N] [--default-tier N]
+//!
+//! `--pin-tier` / `--default-tier` enable the rate-distortion split
+//! (the beat-WASTE knobs): hot pins served from ladder bank
+//! `--pin-tier`, the entire unpinned cold tail fetched from
+//! `--default-tier`. Omit both for the plain v1 residency plan.
 
 use std::io::{Read, Seek, SeekFrom};
 use std::path::PathBuf;
@@ -33,6 +39,12 @@ struct Args {
     pin_top: usize,
     rewrite_every: u64,
     poll_ms: u64,
+    /// Precision-ladder index the hot pins are served from (the
+    /// high-fidelity bank). None = container default.
+    pin_tier: Option<u32>,
+    /// Precision-ladder index the unpinned cold tail fetches from (the
+    /// small-quant bank — the beat-WASTE knob). None = container default.
+    default_tier: Option<u32>,
 }
 
 fn parse_args() -> Result<Args, String> {
@@ -44,6 +56,8 @@ fn parse_args() -> Result<Args, String> {
     let mut pin_top = 256usize;
     let mut rewrite_every = 8u64;
     let mut poll_ms = 50u64;
+    let mut pin_tier = None;
+    let mut default_tier = None;
     let argv: Vec<String> = std::env::args().skip(1).collect();
     let mut i = 0;
     while i < argv.len() {
@@ -64,6 +78,12 @@ fn parse_args() -> Result<Args, String> {
                 rewrite_every = value.parse().map_err(|e| format!("--rewrite-every: {e}"))?
             }
             "--poll-ms" => poll_ms = value.parse().map_err(|e| format!("--poll-ms: {e}"))?,
+            "--pin-tier" => {
+                pin_tier = Some(value.parse().map_err(|e| format!("--pin-tier: {e}"))?)
+            }
+            "--default-tier" => {
+                default_tier = Some(value.parse().map_err(|e| format!("--default-tier: {e}"))?)
+            }
             other => return Err(format!("unknown flag {other}")),
         }
         i += 2;
@@ -77,6 +97,8 @@ fn parse_args() -> Result<Args, String> {
         pin_top,
         rewrite_every,
         poll_ms,
+        pin_tier,
+        default_tier,
     })
 }
 
@@ -182,11 +204,13 @@ fn main() {
                                 segmenter.unknown_tkeys,
                             );
                             if token_idx.is_multiple_of(args.rewrite_every) {
-                                match ctl.write_plan(
+                                match ctl.write_tiered_plan(
                                     &args.plan,
                                     args.budget_bytes,
                                     args.window_k,
                                     args.pin_top,
+                                    args.pin_tier,
+                                    args.default_tier,
                                 ) {
                                     Ok(()) => println!(
                                         "# plan rewritten @tok {token_idx} (top {} pins)",

--- a/core/expert-pager-policy/src/controller.rs
+++ b/core/expert-pager-policy/src/controller.rs
@@ -105,6 +105,32 @@ impl BanditPlanController {
         let doc = PlanFileDocument::new(budget_bytes, window_k, self.pin_list(top_n));
         write_plan_file(path, &doc)
     }
+
+    /// Publish the plan with the rate-distortion split (the beat-WASTE
+    /// write): the hot top-N pins carry `pin_tier` (high-fidelity bank)
+    /// and the entire unpinned cold tail fetches from `default_tier`
+    /// (small-quant bank). Either may be `None` to leave that side at
+    /// the container default — `(None, None)` degenerates to
+    /// [`Self::write_plan`] exactly.
+    pub fn write_tiered_plan(
+        &self,
+        path: &Path,
+        budget_bytes: u64,
+        window_k: u32,
+        top_n: usize,
+        pin_tier: Option<u32>,
+        default_tier: Option<u32>,
+    ) -> std::io::Result<()> {
+        let mut pins = self.pin_list(top_n);
+        if let Some(t) = pin_tier {
+            for p in &mut pins {
+                p.tier = Some(t);
+            }
+        }
+        let mut doc = PlanFileDocument::new(budget_bytes, window_k, pins);
+        doc.default_tier = default_tier;
+        write_plan_file(path, &doc)
+    }
 }
 
 #[cfg(test)]
@@ -193,5 +219,42 @@ mod tests {
         ] {
             assert!(doc.pin_list.contains(&pin), "missing {pin:?}");
         }
+    }
+
+    /// what this catches (the beat-WASTE write): write_tiered_plan must
+    /// stamp EVERY hot pin with `pin_tier` and carry `default_tier` for
+    /// the unpinned cold tail — the on-disk rate-distortion split her
+    /// consumer enacts. And the (None, None) degenerate case must stay
+    /// byte-identical to write_plan (no accidental tier keys).
+    #[test]
+    fn tiered_write_splits_hot_fidelity_from_cold_default() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().join("moe-plan.json");
+        let mut ctl = BanditPlanController::new(16);
+        for _ in 0..6 {
+            ctl.observe_token(&[e(1, 10), e(2, 20)]);
+        }
+
+        ctl.write_tiered_plan(&path, 1_000, 8, 2, Some(0), Some(2))
+            .expect("tiered write");
+        let doc: PlanFileDocument =
+            serde_json::from_slice(&std::fs::read(&path).expect("read")).expect("parse");
+        assert_eq!(doc.default_tier, Some(2), "cold tail must carry default_tier");
+        assert_eq!(doc.pin_list.len(), 2);
+        for p in &doc.pin_list {
+            assert_eq!(p.tier, Some(0), "every hot pin must carry pin_tier: {p:?}");
+        }
+
+        // Degenerate (None, None) == plain write_plan, byte for byte.
+        let tiered_off = dir.path().join("off.json");
+        let plain = dir.path().join("plain.json");
+        ctl.write_tiered_plan(&tiered_off, 1_000, 8, 2, None, None)
+            .expect("write");
+        ctl.write_plan(&plain, 1_000, 8, 2).expect("write");
+        assert_eq!(
+            std::fs::read(&tiered_off).expect("read"),
+            std::fs::read(&plain).expect("read"),
+            "(None, None) must degenerate to the plain v1 document"
+        );
     }
 }

--- a/core/expert-pager-policy/src/plan_file.rs
+++ b/core/expert-pager-policy/src/plan_file.rs
@@ -84,6 +84,17 @@ pub struct PlanFileDocument {
     /// Experts to keep resident ALWAYS (the guaranteed-hit tier — the
     /// 184 shared experts first).
     pub pin_list: Vec<PlanPin>,
+    /// Precision ladder index for every expert NOT in `pin_list` — the
+    /// beat-WASTE knob. Misses are unpinned by definition, so this is
+    /// where the fetch bytes actually are: `default_tier` pointed at a
+    /// small-quant bank shrinks bytes-per-miss for the whole cold tail
+    /// while per-pin `tier` keeps the hot set high-fidelity — the
+    /// rate-distortion split a uniform-quant streamer structurally
+    /// cannot make. `None` = the container's own default bank (the v1
+    /// behavior); serde omits it, so documents without it stay
+    /// byte-identical to the v1 wire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_tier: Option<u32>,
 }
 
 impl PlanFileDocument {
@@ -93,7 +104,14 @@ impl PlanFileDocument {
             budget_bytes,
             window_k,
             pin_list,
+            default_tier: None,
         }
+    }
+
+    /// Set the ladder index unpinned experts fetch from.
+    pub fn with_default_tier(mut self, tier: u32) -> Self {
+        self.default_tier = Some(tier);
+        self
     }
 }
 
@@ -176,6 +194,33 @@ mod tests {
         let parsed: PlanFileDocument = serde_json::from_str(v1).expect("v1 parse");
         assert_eq!(parsed.pin_list, vec![PlanPin::residency(3, 44)]);
         assert_eq!(parsed.pin_list[0].tier, None);
+        assert_eq!(parsed.default_tier, None);
+    }
+
+    /// what this catches (beat-WASTE knob): `default_tier` — the ladder
+    /// index for the entire UNPINNED cold tail — must appear literally
+    /// on the wire when set and vanish entirely when not, and a
+    /// document carrying it must round-trip. Same no-lockstep contract
+    /// as the per-pin tier: absent = byte-identical v1.
+    #[test]
+    fn default_tier_is_optional_on_the_wire() {
+        let plain = PlanFileDocument::new(500, 4, vec![PlanPin::residency(0, 1)]);
+        let plain_json = serde_json::to_string(&plain).expect("serialize");
+        assert!(
+            !plain_json.contains("default_tier"),
+            "unset default_tier must be omitted: {plain_json}"
+        );
+
+        let tiered =
+            PlanFileDocument::new(500, 4, vec![PlanPin::tiered(0, 1, 0)]).with_default_tier(2);
+        let json = serde_json::to_string(&tiered).expect("serialize");
+        assert!(
+            json.contains("\"default_tier\":2"),
+            "set default_tier must be a literal wire key: {json}"
+        );
+        let back: PlanFileDocument = serde_json::from_str(&json).expect("round trip");
+        assert_eq!(back, tiered);
+        assert_eq!(back.default_tier, Some(2));
     }
 
     /// what this catches: the atomic publish — the target path always


### PR DESCRIPTION
Joel's directive: decisively beat WASTE. The lever is precision-on-fetch — and the bytes are in the COLD TAIL (misses are unpinned by definition), so the wire needs a doc-level knob, not just per-pin tiers.

## What
- `PlanFileDocument.default_tier` (optional): the precision-ladder bank every **unpinned** expert fetches from. With per-pin `tier` on the hot set, one plan doc expresses the full rate-distortion split: hot = high fidelity, cold misses = small-quant (~0.45× bytes at IQ1) — the split WASTE's uniform-quant streaming structurally can't make.
- `write_tiered_plan(pin_tier, default_tier)` on the controller; `(None, None)` degenerates **byte-for-byte** to the plain v1 write (pinned by test).
- `moe-pager-driver --pin-tier N --default-tier N` flags.

## Compatibility
Same contract as #2072: serde-skipped when unset ⇒ byte-identical v1 wire, no consumer lockstep. 15/15 tests, clippy clean.

## The physics (BigMama's numbers, this run regime)
Warm decode ~4.1 GB/tok at 62% hit, 2.8 GB/s ⇒ ~1.5 s of a ~3 s token is fetch. Cold misses at IQ1 (~0.45×) ⇒ fetch ~0.7 s ⇒ ~0.5–0.6 tok/s ≈ 2× WASTE's 0.32. Her uniform-IQ1 ceiling run measures the scaling now; this wire makes the quality-preserving version drop in on the same seam.

Part of #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo