### PR TITLE
fix(pager): re-land prefill→decode boundary warm-start — orphaned by #2074's early auto-merge

### DIFF
--- a/core/expert-pager-policy/src/bin/moe-pager-driver.rs
+++ b/core/expert-pager-policy/src/bin/moe-pager-driver.rs
@@ -27,7 +27,9 @@
 use std::io::{Read, Seek, SeekFrom};
 use std::path::PathBuf;
 
-use expert_pager_policy::segment::{parse_records, TkeyTable, TokenSegmenter, RECORD_BYTES};
+use expert_pager_policy::segment::{
+    parse_records, PrefillBoundaryDetector, TkeyTable, TokenSegmenter, RECORD_BYTES,
+};
 use expert_pager_policy::BanditPlanController;
 
 struct Args {
@@ -142,6 +144,7 @@ fn main() {
     // from the first observed token (×1.5, the prototypes' heuristic).
     let mut controller: Option<BanditPlanController> = None;
     let mut segmenter = TokenSegmenter::new();
+    let mut boundary = PrefillBoundaryDetector::new();
     let mut offset: u64 = 0;
     let mut carry: Vec<u8> = Vec::new();
     let mut token_idx: u64 = 0;
@@ -163,6 +166,7 @@ fn main() {
             offset = 0;
             carry.clear();
             segmenter = TokenSegmenter::new();
+            boundary = PrefillBoundaryDetector::new();
             controller = None;
             token_idx = 0;
         }
@@ -181,6 +185,33 @@ fn main() {
                                 continue;
                             }
                             let experts: Vec<_> = token.into_iter().collect();
+                            // Prefill→decode boundary: the bandit is already
+                            // seeded by the prefill batches — publish the
+                            // warm-start plan NOW instead of waiting
+                            // rewrite_every decode tokens (prefill's tail
+                            // predicts ~47-66% of decode experts; the big
+                            // prefill batches churn the cache, so the
+                            // boundary is when the hint matters most).
+                            if boundary.observe(experts.len()) {
+                                if let Some(ctl) = controller.as_ref() {
+                                    match ctl.write_tiered_plan(
+                                        &args.plan,
+                                        args.budget_bytes,
+                                        args.window_k,
+                                        args.pin_top,
+                                        args.pin_tier,
+                                        args.default_tier,
+                                    ) {
+                                        Ok(()) => println!(
+                                            "# prefill->decode boundary — warm-start plan published (top {} prefill-seeded pins)",
+                                            args.pin_top
+                                        ),
+                                        Err(e) => eprintln!(
+                                            "moe-pager-driver: BOUNDARY PLAN WRITE FAILED: {e}"
+                                        ),
+                                    }
+                                }
+                            }
                             let ctl = controller.get_or_insert_with(|| {
                                 let budget = experts.len() * 3 / 2;
                                 println!(

--- a/core/expert-pager-policy/src/segment.rs
+++ b/core/expert-pager-policy/src/segment.rs
@@ -129,6 +129,42 @@ impl TokenSegmenter {
     }
 }
 
+/// Detects the prefill→decode boundary from segment sizes alone
+/// (measured on the RUN-1 fixture: prefill batches 2662/8637/3854
+/// experts, decode tokens ~1472). Prefill routes prompt tokens in
+/// LARGE variable batches; decode settles to the near-constant
+/// per-token working set. The first segment markedly SMALLER than
+/// everything seen so far is the first decode token — the moment the
+/// warm-start window opens (prefill's tail predicts ~47-66% of decode
+/// experts on the fixture; the 8637-batch churns the cache, so acting
+/// AT the boundary is what preserves the signal).
+#[derive(Debug, Default)]
+pub struct PrefillBoundaryDetector {
+    min_seen: Option<usize>,
+    fired: bool,
+}
+
+impl PrefillBoundaryDetector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one completed segment's expert count. Returns `true`
+    /// exactly once: on the first segment classified as decode (size
+    /// < 0.8 × the smallest segment seen before it).
+    pub fn observe(&mut self, size: usize) -> bool {
+        let is_boundary = match self.min_seen {
+            Some(min) if !self.fired && size * 10 < min * 8 => {
+                self.fired = true;
+                true
+            }
+            _ => false,
+        };
+        self.min_seen = Some(self.min_seen.map_or(size, |m| m.min(size)));
+        is_boundary
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -212,6 +248,27 @@ mod tests {
         let mut seg = TokenSegmenter::new();
         seg.push(rec(999, 1), &table);
         assert_eq!(seg.unknown_tkeys, 1);
+    }
+
+    /// what this catches: the prefill→decode boundary rule against the
+    /// RUN-1 fixture's exact segment sizes — must fire ONCE, at the
+    /// first 1472 (the first decode token), not on prefill batch
+    /// variation (8637 after 2662, 3854 after 8637) and never again on
+    /// decode-size jitter (the trailing 1069 partial).
+    #[test]
+    fn boundary_detector_fires_once_at_first_decode_token() {
+        let fixture_sizes = [2662usize, 8637, 3854, 1472, 1472, 1472, 1069];
+        let mut det = PrefillBoundaryDetector::new();
+        let fired: Vec<bool> = fixture_sizes.iter().map(|&s| det.observe(s)).collect();
+        assert_eq!(
+            fired,
+            [false, false, false, true, false, false, false],
+            "must fire exactly at the first decode-sized segment"
+        );
+
+        // Decode-only serve (no prefill trace): never fires.
+        let mut det2 = PrefillBoundaryDetector::new();
+        assert!((0..10).all(|_| !det2.observe(1472)));
     }
 
     /// what this catches: the table loader against her real JSON shape


### PR DESCRIPTION
PR #2074 auto-merged after its FIRST commit; the second commit (dd001fac6 — PrefillBoundaryDetector + driver boundary warm-start publish) was pushed to the branch moments later and got orphaned by the squash. Canary compiled and tested green without it (the two commits were independent), so nothing broke — but the warm-start extractor announced on #general was not actually on canary. This cherry-picks it cleanly.

Content identical to dd001fac6 (fixture-validated: boundary fires between the 3854-expert prefill tail and the first 1472 decode token; warm-start plan publishes with tier-0 pins + default_tier). 16/16 crate tests green.

Process note: when pushing follow-up commits to a PR that has auto-merge armed, verify the PR is still OPEN first — auto-merge races the push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo