### PR TITLE
feat(positron): serving glass-box styles + preview fixture (#141 polish)

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -923,6 +923,109 @@ export class ChatWidget extends LitElement {
       font-weight: 700;
       color: var(--content-primary);
     }
+    /* SERVING glass box (#141 slice 1) — header line, bandit arm chips with
+     * reward bars, and the pager's event cards. Sparklines reuse .gauge. */
+    .serving-line {
+      display: flex;
+      align-items: baseline;
+      gap: var(--spacing-sm);
+      padding: 0 var(--spacing-md) var(--spacing-xs);
+      font-size: 11px;
+      min-width: 0;
+    }
+    .serving-model {
+      font-family: var(--font-mono);
+      font-weight: 700;
+      color: var(--content-primary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
+    .serving-meta {
+      flex-shrink: 0;
+      font-size: 9.5px;
+      letter-spacing: 0.05em;
+      color: var(--content-secondary);
+      font-variant-numeric: tabular-nums;
+    }
+    .serving-degraded {
+      color: var(--status-warning, #e0a458);
+    }
+    .serving-arms {
+      display: flex;
+      gap: 4px;
+      padding: var(--spacing-xs) var(--spacing-md) 0;
+    }
+    .serving-arm {
+      position: relative;
+      flex: 1;
+      min-width: 0;
+      padding: 2px 0 4px;
+      text-align: center;
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-sm);
+      overflow: hidden;
+    }
+    .serving-arm[data-chosen] {
+      border-color: var(--accent-primary);
+    }
+    .serving-arm[data-chosen] .arm-label {
+      color: var(--accent-primary);
+      font-weight: 700;
+    }
+    .arm-label {
+      font-family: var(--font-mono);
+      font-size: 8.5px;
+      color: var(--content-secondary);
+      font-variant-numeric: tabular-nums;
+    }
+    .arm-bar {
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      height: 2px;
+      background: var(--accent-primary);
+      opacity: 0.85;
+      border-radius: 1px;
+    }
+    ul.serving-events {
+      list-style: none;
+      margin: 0;
+      padding: var(--spacing-xs) var(--spacing-md) var(--spacing-sm);
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+    }
+    .serving-event {
+      display: flex;
+      align-items: baseline;
+      gap: 6px;
+      font-size: 9.5px;
+      padding: 2px 6px;
+      border-left: 2px solid var(--border-subtle);
+      background: var(--widget-surface, rgba(255, 255, 255, 0.03));
+      border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+      color: var(--content-secondary);
+    }
+    .serving-event[data-kind='decay-switch'] {
+      border-left-color: var(--accent-primary);
+    }
+    .serving-event[data-kind='serve-start'] {
+      border-left-color: var(--status-success, #4caf7d);
+    }
+    .event-token {
+      flex-shrink: 0;
+      font-family: var(--font-mono);
+      font-size: 8.5px;
+      color: var(--content-tertiary, var(--content-secondary));
+      font-variant-numeric: tabular-nums;
+    }
+    .event-detail {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
     /* NODES strip — the factory sidebar's "1/1 nodes online": pulse dot + host
      * name + role chip per attested node. */
     .nodes-online {

--- a/apps/web/src/preview.ts
+++ b/apps/web/src/preview.ts
@@ -237,6 +237,58 @@ const SYS_FIXTURE: SystemMetricsViewState = {
   node: 'bigmama.local',
 };
 
+/** The serving glass-box fixture (`?fixture=serving`) — the beat-WASTE
+ *  campaign's REAL measured numbers (2026-08-01, K3 on the 5090): hit rate
+ *  warming from the prefill boundary toward 62%, tok/s stepping 0.33 → 0.53
+ *  at the top-8 switch, fetch settling as bytes/tok halve, the bandit's six
+ *  decay arms with 0.30 serving, and the control loop's event cards. */
+const SERVING_FIXTURE: ServingViewState = {
+  header: {
+    model: 'kimi-k3-moec-tiered',
+    ready: true,
+    lanes: 1,
+    context_window: 8192,
+  },
+  series: [
+    {
+      label: 'hit',
+      points: Array.from({ length: 90 }, (_, i) =>
+        Math.min(66, 8 + i * 1.1 + 4 * Math.sin(i / 5)),
+      ),
+      current: '62%',
+    },
+    {
+      label: 'tok/s',
+      points: Array.from({ length: 90 }, (_, i) =>
+        i < 55 ? 58 + 4 * Math.sin(i / 4) : Math.min(100, 62 + (i - 55) * 1.3),
+      ),
+      current: '0.53',
+    },
+    {
+      label: 'fetch',
+      points: Array.from({ length: 90 }, (_, i) =>
+        i < 55 ? 92 - 6 * Math.sin(i / 7) : Math.max(30, 90 - (i - 55) * 1.6),
+      ),
+      current: '2458MB/s',
+    },
+  ],
+  arms: [
+    { label: '0.00', reward: 0.41, chosen: false },
+    { label: '0.30', reward: 0.69, chosen: true },
+    { label: '0.60', reward: 0.55, chosen: false },
+    { label: '0.85', reward: 0.48, chosen: false },
+    { label: '0.95', reward: 0.37, chosen: false },
+    { label: '0.99', reward: 0.23, chosen: false },
+  ],
+  events: [
+    { at_token: 0, kind: 'serve-start', detail: 'capture reset — new serve' },
+    { at_token: 4, kind: 'residency-shift', detail: 'resident experts 8037 → 4416' },
+    { at_token: 24, kind: 'decay-switch', detail: 'bandit switched decay 0.99 → 0.30' },
+    { at_token: 61, kind: 'residency-shift', detail: 'resident experts 4416 → 2208' },
+  ],
+  sample_interval_ms: 2000,
+};
+
 function main(): void {
   const name = new URLSearchParams(location.search).get('fixture') ?? 'rooms';
   const state = FIXTURES[name] ?? FIXTURES.roster;
@@ -252,6 +304,14 @@ function main(): void {
     widget.state = FIXTURES.roster;
     widget.nav = NAV_FIXTURES.rooms;
     widget.sys = SYS_FIXTURE;
+  }
+  // `?fixture=serving` — the full rail PLUS the serving glass box carrying the
+  // beat-WASTE campaign's measured numbers (#141 slice 1's reference input).
+  if (name === 'serving') {
+    widget.state = FIXTURES.roster;
+    widget.nav = NAV_FIXTURES.rooms;
+    widget.sys = SYS_FIXTURE;
+    widget.serving = SERVING_FIXTURE;
   }
   // `?fixture=live` — the room's LIVE call face open (the Go-live affordance's
   // state), 7 tiles incl. real avatar files, Asha mid-turn on the token rail:


### PR DESCRIPTION
Styles for the arms row + event cards (first preview-shot caught them unstyled — classes existed only in the panel, not the shadow stylesheet) and a `?fixture=serving` preview fixture carrying the campaign's real measured numbers. Verified via `npm run preview:shot out.png "fixture=serving"` through the real app pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo