### PR TITLE
feat(positron): the SERVING CONSOLE — the machine room center-stage (purpose=serving, #284)

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -1026,6 +1026,177 @@ export class ChatWidget extends LitElement {
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+    /* SERVING CONSOLE (purpose="serving") — the machine room center-stage:
+     * per-node panels, headline tok/s numeral, full-width instrument, arm
+     * bank, control-loop feed. Console legibility: big numerals, wide
+     * instruments, generous rhythm. */
+    .srv-console {
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing-lg);
+      padding: var(--spacing-lg);
+      overflow-y: auto;
+      height: 100%;
+    }
+    .srv-snapshot {
+      align-self: flex-start;
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      padding: 2px 8px;
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-sm);
+      color: var(--content-secondary);
+    }
+    .srv-node {
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md, 8px);
+      background: var(--widget-surface, rgba(255, 255, 255, 0.02));
+      padding: var(--spacing-md) var(--spacing-lg) var(--spacing-lg);
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing-md);
+    }
+    .srv-banner {
+      display: flex;
+      align-items: baseline;
+      gap: var(--spacing-md);
+      min-width: 0;
+    }
+    .srv-node-name {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--content-secondary);
+      flex-shrink: 0;
+    }
+    .srv-node-name[data-local] {
+      color: var(--content-primary);
+    }
+    .srv-local-chip {
+      font-size: 8px;
+      letter-spacing: 0.1em;
+      padding: 1px 5px;
+      border-radius: var(--radius-sm);
+      background: var(--accent-primary);
+      color: var(--surface, #0a0e14);
+      text-transform: uppercase;
+    }
+    .srv-model {
+      font-family: var(--font-mono);
+      font-size: 16px;
+      font-weight: 700;
+      color: var(--content-primary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
+    .srv-pulse {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--status-warning, #e0a458);
+      flex-shrink: 0;
+      align-self: center;
+    }
+    .srv-pulse[data-ready='true'] {
+      background: var(--status-success, #4caf7d);
+      box-shadow: 0 0 6px var(--status-success, #4caf7d);
+    }
+    .srv-lanes {
+      font-size: 11px;
+      color: var(--content-secondary);
+      font-variant-numeric: tabular-nums;
+      flex-shrink: 0;
+    }
+    .srv-degraded {
+      font-size: 11px;
+      color: var(--status-warning, #e0a458);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .srv-headline {
+      margin-left: auto;
+      display: inline-flex;
+      align-items: baseline;
+      gap: 6px;
+      flex-shrink: 0;
+    }
+    .srv-headline-num {
+      font-family: var(--font-mono);
+      font-size: 34px;
+      font-weight: 700;
+      line-height: 1;
+      color: var(--accent-primary);
+      font-variant-numeric: tabular-nums;
+    }
+    .srv-headline-unit {
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--content-secondary);
+    }
+    .srv-instrument .gauge {
+      padding: 0;
+    }
+    .srv-instrument .gauge svg {
+      height: 120px;
+    }
+    .srv-section-label {
+      display: block;
+      font-size: 9px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--content-secondary);
+      margin-bottom: 4px;
+    }
+    .srv-bank-arms {
+      padding: 0;
+      gap: 6px;
+    }
+    .srv-bank .serving-arm {
+      padding: 5px 0 7px;
+    }
+    .srv-bank .arm-label {
+      font-size: 11px;
+    }
+    .arm-reward {
+      display: block;
+      font-family: var(--font-mono);
+      font-size: 9px;
+      color: var(--content-secondary);
+      font-variant-numeric: tabular-nums;
+    }
+    .srv-bank .arm-bar {
+      height: 3px;
+    }
+    .srv-feed-events {
+      padding: 0;
+      gap: 4px;
+    }
+    .srv-feed .serving-event {
+      font-size: 11px;
+      padding: 4px 8px;
+    }
+    .srv-awaiting {
+      margin: auto;
+      text-align: center;
+      color: var(--content-secondary);
+    }
+    .srv-awaiting-title {
+      font-size: 14px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      margin-bottom: 6px;
+    }
+    .srv-awaiting-line {
+      font-size: 11px;
+    }
     /* NODES strip — the factory sidebar's "1/1 nodes online": pulse dot + host
      * name + role chip per attested node. */
     .nodes-online {

--- a/apps/web/src/content/registry.ts
+++ b/apps/web/src/content/registry.ts
@@ -14,10 +14,12 @@ import {
   createContentRegistry,
   LIVE_PURPOSE,
   PERSONA_PURPOSE,
+  SERVING_PURPOSE,
   type ArenaContentBody,
   type ContentRegistry,
   type LiveContentBody,
   type PersonaContentBody,
+  type ServingContentBody,
 } from '@continuum/patterns';
 import type { ChatContentBody } from '@continuum/chat-view';
 import { modelCell, type ForgeContentBody } from '@continuum/foundry-view';
@@ -25,6 +27,7 @@ import { listingCell, messageRow } from '../render/parts';
 import { renderPersona } from '../persona/renderPersona';
 import { renderLive } from '../live/renderLive';
 import { renderArena } from '../arena/renderArena';
+import { renderServing } from '../serving/renderServing';
 
 /** The chat activity's center: the conversation (or an honest empty state). */
 function chatContent(body: ChatContentBody): TemplateResult {
@@ -64,3 +67,6 @@ webContentRegistry.register<LiveContentBody>(LIVE_PURPOSE, (body) => renderLive(
 // The benchmark ARENA — ranked leaderboards + live-run strip from real eval
 // ledger rows, dispatched when the room recipe's purpose is "arena".
 webContentRegistry.register<ArenaContentBody>(ARENA_PURPOSE, (body) => renderArena(body));
+// The SERVING console — per-node control-loop panels center-stage, dispatched
+// when the room recipe's purpose is "serving" (the machine room, full view).
+webContentRegistry.register<ServingContentBody>(SERVING_PURPOSE, (body) => renderServing(body));

--- a/apps/web/src/preview.ts
+++ b/apps/web/src/preview.ts
@@ -306,6 +306,18 @@ function main(): void {
     widget.nav = NAV_FIXTURES.rooms;
     widget.sys = SYS_FIXTURE;
   }
+  // `?fixture=console` — the SERVING CONSOLE center-stage (purpose="serving"):
+  // the machine room as the focused activity, fed the campaign's measured
+  // numbers. The design's reference input for the full-view face.
+  if (name === 'console') {
+    const base = FIXTURES.roster;
+    if (base) {
+      widget.state = { ...base, room_name: 'serving', purpose: 'serving' };
+    }
+    widget.nav = NAV_FIXTURES.rooms;
+    widget.sys = SYS_FIXTURE;
+    widget.serving = SERVING_FIXTURE;
+  }
   // `?fixture=serving` — the full rail PLUS the serving glass box carrying the
   // beat-WASTE campaign's measured numbers (#141 slice 1's reference input).
   if (name === 'serving') {

--- a/apps/web/src/serving/renderServing.ts
+++ b/apps/web/src/serving/renderServing.ts
@@ -1,0 +1,116 @@
+/**
+ * `renderServing` — the web renderer for the SERVING console (`purpose="serving"`).
+ *
+ * The machine room, center-stage (console doctrine, Joel 2026-08-01: the
+ * graphical FULL VIEW lives here — futuristic-console legibility, state
+ * readable at a distance — never crammed into rails). One panel per grid
+ * node, local first: a banner (node · model · ready pulse · lanes×ctx) with
+ * the HEADLINE tok/s numeral large on the right, the full-width control-loop
+ * instrument (hit/tok-s/fetch), the bandit's arm bank, and the pager event
+ * feed. Registered for `SERVING_PURPOSE` in the ONE content registry — the
+ * ops sibling of chat/foundry/arena/live. Pure fragments of the projected
+ * `ServingContentBody`.
+ *
+ * Honesty rules: no nodes → the awaiting frame (the frame is the promise);
+ * `feedLive` false → the "snapshot" banner; a node without pager capture
+ * renders its banner + an honest no-telemetry line, never a fabricated gauge.
+ */
+
+import { html, nothing, type TemplateResult } from 'lit';
+import type { ServingContentBody, ServingNodeVM, ServingPanelView } from '@continuum/patterns';
+import { renderGaugeBody } from '../render/parts';
+
+/** The banner's headline stat — the current tok/s reading, extracted from the
+ *  projection's own series (source-formatted; no client unit math). */
+function headline(view: ServingPanelView): TemplateResult | typeof nothing {
+  const tok = view.gauge?.series.find((s) => s.label.toLowerCase().includes('tok'));
+  if (!tok) return nothing;
+  return html`<span class="srv-headline" title="current decode rate">
+    <span class="srv-headline-num">${tok.current}</span>
+    <span class="srv-headline-unit">tok/s</span>
+  </span>`;
+}
+
+function banner(n: ServingNodeVM): TemplateResult {
+  const h = n.view.header;
+  return html`<div class="srv-banner">
+    <span class="srv-node-name" ?data-local=${n.local} title=${n.local ? 'this node' : 'grid peer'}>
+      ${n.node}${n.local ? html`<span class="srv-local-chip">local</span>` : nothing}
+    </span>
+    ${h?.model
+      ? html`<span class="srv-model" title=${h.model}>${h.model}</span>
+          <span class="srv-pulse" data-ready=${h.ready ? 'true' : 'false'}></span>
+          <span class="srv-lanes">${h.ready ? 'ready' : 'warming'} · ${h.lanes}×${h.contextWindow}</span>`
+      : h?.degradedReason
+        ? html`<span class="srv-degraded" title=${h.degradedReason}>⚠ ${h.degradedReason}</span>`
+        : html`<span class="srv-lanes">no model serving</span>`}
+    ${headline(n.view)}
+  </div>`;
+}
+
+function armBank(view: ServingPanelView): TemplateResult | typeof nothing {
+  if (view.arms.length === 0) return nothing;
+  return html`<div class="srv-bank" title="bandit decay arms — reward belief per arm">
+    <span class="srv-section-label">decay arms</span>
+    <div class="serving-arms srv-bank-arms">
+      ${view.arms.map(
+        (a) => html`<span
+          class="serving-arm"
+          ?data-chosen=${a.chosen}
+          title="decay ${a.label} · reward ${a.reward.toFixed(3)}${a.chosen ? ' · serving' : ''}"
+        >
+          <span class="arm-label">${a.label}</span>
+          <span class="arm-reward">${a.reward.toFixed(2)}</span>
+          <span class="arm-bar" style="width:${Math.round(Math.min(1, Math.max(0, a.reward)) * 100)}%"></span>
+        </span>`,
+      )}
+    </div>
+  </div>`;
+}
+
+function eventFeed(view: ServingPanelView): TemplateResult | typeof nothing {
+  if (view.events.length === 0) return nothing;
+  const newestFirst = [...view.events].reverse();
+  return html`<div class="srv-feed">
+    <span class="srv-section-label">control loop</span>
+    <ul class="serving-events srv-feed-events">
+      ${newestFirst.map(
+        (e) => html`<li class="serving-event" data-kind=${e.kind}>
+          <span class="event-token">t${e.atToken}</span>
+          <span class="event-detail">${e.detail}</span>
+        </li>`,
+      )}
+    </ul>
+  </div>`;
+}
+
+function nodePanel(n: ServingNodeVM): TemplateResult {
+  return html`<section class="srv-node" data-node=${n.node}>
+    ${banner(n)}
+    <div class="srv-instrument">
+      ${n.view.gauge
+        ? renderGaugeBody(n.view.gauge)
+        : html`<div class="gauge-awaiting" title="no pager capture feed on this serve">
+            no pager telemetry on this serve
+          </div>`}
+    </div>
+    ${armBank(n.view)} ${eventFeed(n.view)}
+  </section>`;
+}
+
+/** The serving console — the full center view. */
+export function renderServing(body: ServingContentBody): TemplateResult {
+  return html`<div class="srv-console">
+    ${body.feedLive
+      ? nothing
+      : html`<div class="srv-snapshot" title="no live serving stream attached">snapshot — not live</div>`}
+    ${body.nodes.length > 0
+      ? body.nodes.map(nodePanel)
+      : html`<div class="srv-awaiting">
+          <div class="srv-awaiting-title">no serving feed</div>
+          <div class="srv-awaiting-line">
+            panels appear when a node's serving daemon publishes — the frame is the promise
+          </div>
+        </div>`}
+  </div>`;
+}

--- a/packages/chat-view/patternProjections.ts
+++ b/packages/chat-view/patternProjections.ts
@@ -29,7 +29,7 @@ import type {
   SystemMetricsViewState,
 } from '@continuum/sdk-typescript';
 import type { ChatViewModel, MemberKind, MessageRowVM, RosterMemberVM } from './chatViewModel';
-import { ARENA_PURPOSE, LIVE_PURPOSE, PERSONA_PURPOSE, type ArenaContentBody as ArenaContentBodyT } from '@continuum/patterns';
+import { ARENA_PURPOSE, LIVE_PURPOSE, PERSONA_PURPOSE, SERVING_PURPOSE, type ArenaContentBody as ArenaContentBodyT, type ServingContentBody, type ServingNodeVM } from '@continuum/patterns';
 import type { LiveContentBody, PersonaContentBody } from '@continuum/patterns';
 import {
   focusedPersonaTab,
@@ -233,6 +233,27 @@ export function servingWidget(serving?: ServingViewState): PanelWidget<ServingPa
   return { id: 'serving', kind: 'serving', title: 'Serving', body, scope: 'global' };
 }
 
+/** The serving CONSOLE content body — per-node panels for the center-stage
+ *  ops face (`purpose === SERVING_PURPOSE`). Today: the local node (named
+ *  from the metrics feed's host name); grid peers join as the cross-grid
+ *  serving feed lands (#283) with zero shape change. `feedLive` is true only
+ *  when the serving subscription has actually delivered. */
+export function servingContentBody(
+  serving?: ServingViewState,
+  node?: string,
+): ServingContentBody {
+  const nodes: ServingNodeVM[] = serving
+    ? [
+        {
+          node: node ?? 'this node',
+          local: true,
+          view: servingWidget(serving)?.body ?? { arms: [], events: [] },
+        },
+      ]
+    : [];
+  return { nodes, feedLive: serving !== undefined };
+}
+
 /** The NODES strip (the factory sidebar's "1/1 nodes online"): every grid node
  *  this surface can honestly attest, as a `status` widget whose body is the one
  *  `Listing` primitive. Today that is exactly THIS node — attested by its live
@@ -358,20 +379,30 @@ export function chatWorkspace(vm: ChatViewModel, live?: WorkspaceLive): Workspac
     !personaBody && !liveBody && vm.purpose === ARENA_PURPOSE
       ? arenaContentBody(live?.arena ?? { rows: [] }, live?.arena !== undefined)
       : undefined;
+  // The SERVING console face: a serving-purpose room renders the full
+  // center-stage ops console (console doctrine — the graphical full view
+  // lives HERE, never crammed into rails).
+  const servingBody =
+    !personaBody && !liveBody && !arenaBody && vm.purpose === SERVING_PURPOSE
+      ? servingContentBody(live?.serving, live?.sys?.node ?? undefined)
+      : undefined;
   const content:
     | ContentView<ChatContentBody>
     | ContentView<PersonaContentBody>
     | ContentView<LiveContentBody>
-    | ContentView<ArenaContentBodyT> = personaBody
+    | ContentView<ArenaContentBodyT>
+    | ContentView<ServingContentBody> = personaBody
     ? { purpose: PERSONA_PURPOSE, body: personaBody }
     : liveBody
       ? { purpose: LIVE_PURPOSE, body: liveBody }
       : arenaBody
         ? { purpose: ARENA_PURPOSE, body: arenaBody }
-        : {
-            purpose: vm.purpose,
-            body: { messages: vm.messages, isEmpty: vm.isEmpty },
-          };
+        : servingBody
+          ? { purpose: SERVING_PURPOSE, body: servingBody }
+          : {
+              purpose: vm.purpose,
+              body: { messages: vm.messages, isEmpty: vm.isEmpty },
+            };
   // The ACTIVE nav cell follows the citizen's current tab: the persona tab
   // when a persona home is focused, else the chat room on screen.
   const rooms = live?.nav

--- a/packages/patterns/index.ts
+++ b/packages/patterns/index.ts
@@ -38,6 +38,11 @@ export type {
   ArenaBoardVM,
   ArenaLiveRunVM,
 } from './arenaContent';
+
+// The serving-ops CONSOLE's neutral Content body (`purpose === SERVING_PURPOSE`)
+// — per-node control-loop panels, center-stage full view (console doctrine).
+export { SERVING_PURPOSE } from './servingContent';
+export type { ServingContentBody, ServingNodeVM } from './servingContent';
 export type {
   LiveContentBody,
   LiveParticipantVM,

--- a/packages/patterns/servingContent.ts
+++ b/packages/patterns/servingContent.ts
@@ -1,0 +1,46 @@
+/**
+ * The `serving` activity's neutral `Content` body — the node-ops CONSOLE face.
+ *
+ * The serving stack is the machine room ([[north-star-metrics]]: persona-tok/s
+ * × quality ÷ cost): this face renders it center-stage as a full console —
+ * per-node panels carrying the live control loop (model banner, the headline
+ * tok/s numeral, hit/fetch sparklines, the bandit's arm bank, the pager event
+ * feed). It is a room PURPOSE (`SERVING_PURPOSE`), reached by the same nav
+ * semantics as any activity and rendered by a purpose-registered `Content`
+ * renderer — the ops sibling of `'arena'` / `'foundry'` / `'live'`. Shapes
+ * only: consumer-neutral, DOM-free, ANSI-free.
+ *
+ * Console doctrine (Joel 2026-08-01): left rail = navigation + one condensed
+ * performance instrument; the graphical FULL VIEW lives HERE, center-stage
+ * with all the scroll room, futuristic-console legibility — state readable at
+ * a distance. Multi-node from day one: the grid renders every node's panel
+ * (local first), so BigMama's 5090 works beside the M5 the moment the
+ * cross-grid feed carries her view. Honest absence: a node with no pager
+ * capture renders its banner + an awaiting line, never a fabricated gauge.
+ */
+
+import type { ServingPanelView } from './index';
+
+/** The `Content` purpose key the serving console dispatches on. A room recipe
+ *  that declares this purpose IS a serving-ops room. */
+export const SERVING_PURPOSE = 'serving';
+
+/** One node's console panel — identity + its live serving view. */
+export interface ServingNodeVM {
+  /** Host name ("bigmama.local", "m5.local"). */
+  readonly node: string;
+  /** True for the node this surface runs on (renders first, marked). */
+  readonly local: boolean;
+  /** The node's live serving view — same shape the rail widget folds. */
+  readonly view: ServingPanelView;
+}
+
+/** The serving console's content body. */
+export interface ServingContentBody {
+  /** Per-node panels, local node first. Empty = no serving feed anywhere —
+   *  the awaiting frame renders (the frame is the promise). */
+  readonly nodes: readonly ServingNodeVM[];
+  /** True only when a live envelope stream is attached — a static projection
+   *  renders the honest "snapshot" banner (same contract as the arena). */
+  readonly feedLive: boolean;
+}


### PR DESCRIPTION
The full view, done right: serving renders as a purpose-dispatched center-stage face (arena's exact spine) — per-node panels with the model banner, a headline tok/s numeral readable across the room, the full-width control-loop instrument, the decay-arm bank, and the pager event feed. Left rail stays pure navigation. Multi-node shape from day one (#283 grid peers drop in with zero shape change). Honest absence at every level. Preview-shot verified via `?fixture=console` with the campaign's measured numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo