### PR TITLE
feat(positron): the left HUD — one graph control, cycling faces, corner pin toggle

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -1026,6 +1026,32 @@ export class ChatWidget extends LitElement {
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+    /* HUD cycle/pin toggle — the far-left corner control of the one graph
+     * control: ⟳ while auto-cycling faces, ◉ when pinned. */
+    .hud-toggle {
+      appearance: none;
+      border: 1px solid var(--border-subtle);
+      background: transparent;
+      color: var(--content-secondary);
+      border-radius: 50%;
+      width: 16px;
+      height: 16px;
+      font-size: 9px;
+      line-height: 1;
+      padding: 0;
+      cursor: pointer;
+      flex-shrink: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .hud-toggle[data-cycling] {
+      color: var(--accent-primary);
+      border-color: var(--accent-primary);
+    }
+    .hud-toggle:hover {
+      color: var(--content-primary);
+    }
     /* SERVING CONSOLE (purpose="serving") — the machine room center-stage:
      * per-node panels, headline tok/s numeral, full-width instrument, arm
      * bank, control-loop feed. Console legibility: big numerals, wide

--- a/apps/web/src/render/SysPanel.ts
+++ b/apps/web/src/render/SysPanel.ts
@@ -15,6 +15,7 @@
 import { LitElement, html, type TemplateResult } from 'lit';
 import type { GaugeView, SystemPanelView } from '@continuum/patterns';
 import { renderGaugeBody, renderMetricsRow } from './parts';
+import { renderServingBody } from './ServingPanel';
 
 /** The gauge's honest window label, derived from its own data: longest series
  *  length × sample cadence. `undefined` when either is absent/zero — no chip
@@ -30,22 +31,61 @@ export function gaugeWindowLabel(view: GaugeView | undefined): string | undefine
   return `${+(mins / 60).toFixed(1)}h`;
 }
 
-type Face = 'sys' | 'ai';
+type Face = 'sys' | 'ai' | 'srv';
+
+/** The HUD's face cadence when auto-cycling. */
+const CYCLE_MS = 6000;
 
 export class SysPanel extends LitElement {
   static override properties = {
     body: { attribute: false },
     heading: { attribute: false },
     _face: { state: true },
+    _cycle: { state: true },
   };
 
-  /** The projected two-face body ({ gauge?, stats }). */
+  /** The projected HUD body ({ gauge?, stats, serving? }). */
   body?: SystemPanelView;
 
   /** Section heading (the PanelWidget title). */
   heading = 'System';
 
   private _face: Face = 'sys';
+
+  /** HUD auto-cycle (the far-left corner toggle): ON rotates through the
+   *  enabled faces every CYCLE_MS; picking a chip PINS. Renderer state — a
+   *  lens the reader holds, never projection state. */
+  private _cycle = true;
+
+  private _hover = false;
+
+  private _timer: ReturnType<typeof setInterval> | undefined;
+
+  /** Faces with data to show, in rotation order. */
+  private enabledFaces(): Face[] {
+    const faces: Face[] = [];
+    if (this.body?.gauge) faces.push('sys');
+    faces.push('ai');
+    if (this.body?.serving) faces.push('srv');
+    return faces;
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this._timer = setInterval(() => {
+      if (!this._cycle || this._hover) return;
+      const faces = this.enabledFaces();
+      if (faces.length < 2) return;
+      const at = faces.indexOf(this._face);
+      this._face = faces[(at + 1) % faces.length] ?? this._face;
+    }, CYCLE_MS);
+  }
+
+  override disconnectedCallback(): void {
+    if (this._timer !== undefined) clearInterval(this._timer);
+    this._timer = undefined;
+    super.disconnectedCallback();
+  }
 
   protected override createRenderRoot(): HTMLElement {
     return this;
@@ -67,19 +107,43 @@ export class SysPanel extends LitElement {
       aria-selected=${face === id ? 'true' : 'false'}
       ?data-active=${face === id}
       ?disabled=${!enabled}
-      title=${enabled ? label : 'no resource feed yet'}
+      title=${enabled ? `${label} — click to pin` : 'no feed yet'}
       @click=${(): void => {
+        // Picking a face PINS it — cycling resumes via the corner toggle.
         this._face = id;
+        this._cycle = false;
       }}
     >
       ${label}
     </button>`;
     return html`
-      <section class="rail-widget" data-widget="system" data-id="system">
+      <section
+        class="rail-widget"
+        data-widget="system"
+        data-id="system"
+        @pointerenter=${(): void => {
+          this._hover = true;
+        }}
+        @pointerleave=${(): void => {
+          this._hover = false;
+        }}
+      >
         <div class="who-head">
+          <button
+            class="hud-toggle"
+            ?data-cycling=${this._cycle}
+            title=${this._cycle ? 'auto-cycling faces — click to pin' : 'pinned — click to auto-cycle'}
+            aria-label=${this._cycle ? 'pin current face' : 'auto-cycle faces'}
+            @click=${(): void => {
+              this._cycle = !this._cycle;
+            }}
+          >
+            ${this._cycle ? '⟳' : '◉'}
+          </button>
           <span class="who-title">${this.heading}</span>
-          <span class="face-chips" role="tablist" aria-label="system panel face">
+          <span class="face-chips" role="tablist" aria-label="HUD face">
             ${chip('sys', 'SYS', hasGauge)} ${chip('ai', 'AI', true)}
+            ${chip('srv', 'SRV', body.serving !== undefined)}
           </span>
           ${window
             ? html`<span class="gauge-window" title="window span — samples × cadence, from the data"
@@ -93,7 +157,13 @@ export class SysPanel extends LitElement {
             : html`<div class="gauge-awaiting" title="the system-metrics feed has not delivered yet">
                 awaiting system feed…
               </div>`
-          : renderMetricsRow(body.stats)}
+          : face === 'srv'
+            ? body.serving
+              ? renderServingBody(body.serving)
+              : html`<div class="gauge-awaiting" title="no serving feed on this node yet">
+                  awaiting serving feed…
+                </div>`
+            : renderMetricsRow(body.stats)}
       </section>
     `;
   }

--- a/packages/chat-view/patternProjections.ts
+++ b/packages/chat-view/patternProjections.ts
@@ -280,10 +280,15 @@ export function nodesWidget(sys?: SystemMetricsViewState): PanelWidget<ListingVi
 export function systemPanelWidget(
   vm: ChatViewModel,
   sys?: SystemMetricsViewState,
+  serving?: ServingViewState,
 ): PanelWidget<SystemPanelView> {
   const body: SystemPanelView = {
     ...(sys ? { gauge: systemGaugeWidget(sys).body } : {}),
     stats: metricsWidget(vm).body,
+    // The HUD's SRV face — compact summary, portal to the serving console
+    // activity (the FULL view). One graph control on the left, per the
+    // console doctrine; faces cycle or pin in the renderer.
+    ...(serving ? { serving: servingWidget(serving)?.body ?? undefined } : {}),
   };
   return { id: 'system', kind: 'system', title: 'System', body, scope: 'global' };
 }
@@ -414,13 +419,13 @@ export function chatWorkspace(vm: ChatViewModel, live?: WorkspaceLive): Workspac
   // dispatched by kind; the roster stays the participants `Listing`
   // (ROSTER_LISTING_ID) that RAG + mobile ground on.
   const nodes = nodesWidget(live?.sys);
-  // LEFT = NAVIGATION + one compact performance instrument, nothing more
-  // (Joel's console doctrine 2026-08-01: the left has little to no real
-  // estate — rooms and users must never be pushed down by telemetry; the
-  // graphical lives center-stage and in the right instrument cluster).
+  // LEFT = NAVIGATION + the ONE HUD graph control, nothing more (console
+  // doctrine: little real estate, rooms/users never pushed down; every
+  // graph is a FACE of the one HUD — cycling or pinned — and details take
+  // you to the full center-stage activity).
   const left = [
     continuonWidget(vm, live?.version),
-    systemPanelWidget(vm, live?.sys),
+    systemPanelWidget(vm, live?.sys, live?.serving),
     ...(nodes ? [nodes] : []),
     listingWidget(rooms),
     listingWidget(rosterListing(vm)),

--- a/packages/patterns/index.ts
+++ b/packages/patterns/index.ts
@@ -255,6 +255,10 @@ export interface SystemPanelView {
   readonly gauge?: GaugeView;
   /** The live team-cognition stat row — the AI face. */
   readonly stats: MetricsView;
+  /** The serving summary — the SRV face of the HUD (compact; the FULL view
+   *  is the serving console activity, which this face is the portal to).
+   *  Absent = no serving feed; the face disables, honestly. */
+  readonly serving?: ServingPanelView;
 }
 
 /** One bandit arm of the `serving` widget — the pager's learned-decay dial. */


### PR DESCRIPTION
One graph control on the left (SYS | AI | SRV faces), auto-cycling every 6s with hover-pause; the far-left ⟳/◉ corner toggle pins or resumes; picking a chip pins. SRV is the compact summary face — the serving console activity (#2079) is its full-view destination. Honest absence: faces without data disable. Preview-shot caught the rotation mid-cycle.

Click-through from the SRV face to the console tab wires when a serving-purpose room exists in nav (#274/#284).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo