### PR TITLE
feat(positron): the GRID view — the NODES strip's full activity (purpose=grid)

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -1223,6 +1223,23 @@ export class ChatWidget extends LitElement {
     .srv-awaiting-line {
       font-size: 11px;
     }
+    /* GRID view — the node panel's sections (resources / serving) and the
+     * node name sized as the panel's identity when no model banner leads. */
+    .grid-node-name {
+      font-size: 14px;
+      letter-spacing: 0.1em;
+    }
+    .grid-section {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .grid-section .gauge {
+      padding: 0;
+    }
+    .grid-section .gauge svg {
+      height: 88px;
+    }
     /* NODES strip — the factory sidebar's "1/1 nodes online": pulse dot + host
      * name + role chip per attested node. */
     .nodes-online {

--- a/apps/web/src/content/registry.ts
+++ b/apps/web/src/content/registry.ts
@@ -13,10 +13,12 @@ import {
   ARENA_PURPOSE,
   createContentRegistry,
   LIVE_PURPOSE,
+  GRID_PURPOSE,
   PERSONA_PURPOSE,
   SERVING_PURPOSE,
   type ArenaContentBody,
   type ContentRegistry,
+  type GridContentBody,
   type LiveContentBody,
   type PersonaContentBody,
   type ServingContentBody,
@@ -28,6 +30,7 @@ import { renderPersona } from '../persona/renderPersona';
 import { renderLive } from '../live/renderLive';
 import { renderArena } from '../arena/renderArena';
 import { renderServing } from '../serving/renderServing';
+import { renderGrid } from '../grid/renderGrid';
 
 /** The chat activity's center: the conversation (or an honest empty state). */
 function chatContent(body: ChatContentBody): TemplateResult {
@@ -70,3 +73,6 @@ webContentRegistry.register<ArenaContentBody>(ARENA_PURPOSE, (body) => renderAre
 // The SERVING console — per-node control-loop panels center-stage, dispatched
 // when the room recipe's purpose is "serving" (the machine room, full view).
 webContentRegistry.register<ServingContentBody>(SERVING_PURPOSE, (body) => renderServing(body));
+// The GRID view — every node's panel (resources + serving), the NODES
+// strip's full activity, dispatched when the room's purpose is "grid".
+webContentRegistry.register<GridContentBody>(GRID_PURPOSE, (body) => renderGrid(body));

--- a/apps/web/src/grid/renderGrid.ts
+++ b/apps/web/src/grid/renderGrid.ts
@@ -1,0 +1,70 @@
+/**
+ * `renderGrid` — the web renderer for the GRID view (`purpose="grid"`).
+ *
+ * The NODES strip's full activity, center-stage: one rich panel per node —
+ * node banner (name, LOCAL mark, serving model + ready pulse when live),
+ * the RESOURCES window (CPU/MEM/GPU), and the SERVING control loop — the
+ * whole grid legible at a distance. Registered for `GRID_PURPOSE` in the
+ * ONE content registry. Route health and resident citizens join the panel
+ * as their feeds land (#257 attestation, delivery-truth ledger); grid
+ * peers appear as rows the moment cross-grid feeds carry them (#283).
+ *
+ * Honesty: a panel renders exactly the sections its node's feeds deliver;
+ * an empty grid renders the awaiting frame.
+ */
+
+import { html, nothing, type TemplateResult } from 'lit';
+import type { GridContentBody, GridNodeVM } from '@continuum/patterns';
+import { renderGaugeBody } from '../render/parts';
+import { renderServingBody } from '../render/ServingPanel';
+
+function banner(n: GridNodeVM): TemplateResult {
+  const h = n.serving?.header;
+  return html`<div class="srv-banner">
+    <span class="srv-node-name grid-node-name" ?data-local=${n.local} title=${n.local ? 'this node' : 'grid peer'}>
+      ${n.node}${n.local ? html`<span class="srv-local-chip">local</span>` : nothing}
+    </span>
+    ${h?.model
+      ? html`<span class="srv-model" title=${h.model}>${h.model}</span>
+          <span class="srv-pulse" data-ready=${h.ready ? 'true' : 'false'}></span>`
+      : nothing}
+  </div>`;
+}
+
+function nodePanel(n: GridNodeVM): TemplateResult {
+  return html`<section class="srv-node" data-node=${n.node}>
+    ${banner(n)}
+    ${n.resources
+      ? html`<div class="grid-section">
+          <span class="srv-section-label">resources</span>
+          ${renderGaugeBody(n.resources)}
+        </div>`
+      : nothing}
+    ${n.serving
+      ? html`<div class="grid-section">
+          <span class="srv-section-label">serving</span>
+          ${renderServingBody(n.serving)}
+        </div>`
+      : nothing}
+    ${!n.resources && !n.serving
+      ? html`<div class="gauge-awaiting" title="no feeds from this node yet">awaiting node feeds…</div>`
+      : nothing}
+  </section>`;
+}
+
+/** The grid view — every node's panel, local first. */
+export function renderGrid(body: GridContentBody): TemplateResult {
+  return html`<div class="srv-console">
+    ${body.feedLive
+      ? nothing
+      : html`<div class="srv-snapshot" title="no live node streams attached">snapshot — not live</div>`}
+    ${body.nodes.length > 0
+      ? body.nodes.map(nodePanel)
+      : html`<div class="srv-awaiting">
+          <div class="srv-awaiting-title">no node feeds</div>
+          <div class="srv-awaiting-line">
+            panels appear as nodes publish their state — the frame is the promise
+          </div>
+        </div>`}
+  </div>`;
+}

--- a/apps/web/src/preview.ts
+++ b/apps/web/src/preview.ts
@@ -306,6 +306,17 @@ function main(): void {
     widget.nav = NAV_FIXTURES.rooms;
     widget.sys = SYS_FIXTURE;
   }
+  // `?fixture=grid` — the GRID view center-stage (purpose="grid"): every
+  // node's panel (resources + serving), the NODES strip's full activity.
+  if (name === 'grid') {
+    const base = FIXTURES.roster;
+    if (base) {
+      widget.state = { ...base, room_name: 'grid', purpose: 'grid' };
+    }
+    widget.nav = NAV_FIXTURES.rooms;
+    widget.sys = SYS_FIXTURE;
+    widget.serving = SERVING_FIXTURE;
+  }
   // `?fixture=console` — the SERVING CONSOLE center-stage (purpose="serving"):
   // the machine room as the focused activity, fed the campaign's measured
   // numbers. The design's reference input for the full-view face.

--- a/packages/chat-view/patternProjections.ts
+++ b/packages/chat-view/patternProjections.ts
@@ -29,7 +29,7 @@ import type {
   SystemMetricsViewState,
 } from '@continuum/sdk-typescript';
 import type { ChatViewModel, MemberKind, MessageRowVM, RosterMemberVM } from './chatViewModel';
-import { ARENA_PURPOSE, LIVE_PURPOSE, PERSONA_PURPOSE, SERVING_PURPOSE, type ArenaContentBody as ArenaContentBodyT, type ServingContentBody, type ServingNodeVM } from '@continuum/patterns';
+import { ARENA_PURPOSE, GRID_PURPOSE, LIVE_PURPOSE, PERSONA_PURPOSE, SERVING_PURPOSE, type ArenaContentBody as ArenaContentBodyT, type GridContentBody, type GridNodeVM, type ServingContentBody, type ServingNodeVM } from '@continuum/patterns';
 import type { LiveContentBody, PersonaContentBody } from '@continuum/patterns';
 import {
   focusedPersonaTab,
@@ -254,6 +254,29 @@ export function servingContentBody(
   return { nodes, feedLive: serving !== undefined };
 }
 
+/** The GRID content body — every node's full panel for the center-stage
+ *  SCADA view (`purpose === GRID_PURPOSE`; the NODES strip is its portal).
+ *  Today: the local node with its resource window + serving loop; grid
+ *  peers join as attestation/cross-grid feeds land (#257/#283) with zero
+ *  shape change. */
+export function gridContentBody(
+  sys?: SystemMetricsViewState,
+  serving?: ServingViewState,
+): GridContentBody {
+  const any = sys !== undefined || serving !== undefined;
+  const nodes: GridNodeVM[] = any
+    ? [
+        {
+          node: sys?.node ?? 'this node',
+          local: true,
+          ...(sys ? { resources: systemGaugeWidget(sys).body } : {}),
+          ...(serving ? { serving: servingWidget(serving)?.body ?? undefined } : {}),
+        },
+      ]
+    : [];
+  return { nodes, feedLive: any };
+}
+
 /** The NODES strip (the factory sidebar's "1/1 nodes online"): every grid node
  *  this surface can honestly attest, as a `status` widget whose body is the one
  *  `Listing` primitive. Today that is exactly THIS node — attested by its live
@@ -391,12 +414,18 @@ export function chatWorkspace(vm: ChatViewModel, live?: WorkspaceLive): Workspac
     !personaBody && !liveBody && !arenaBody && vm.purpose === SERVING_PURPOSE
       ? servingContentBody(live?.serving, live?.sys?.node ?? undefined)
       : undefined;
+  // The GRID face: the NODES strip's full activity — every node's panel.
+  const gridBody =
+    !personaBody && !liveBody && !arenaBody && !servingBody && vm.purpose === GRID_PURPOSE
+      ? gridContentBody(live?.sys, live?.serving)
+      : undefined;
   const content:
     | ContentView<ChatContentBody>
     | ContentView<PersonaContentBody>
     | ContentView<LiveContentBody>
     | ContentView<ArenaContentBodyT>
-    | ContentView<ServingContentBody> = personaBody
+    | ContentView<ServingContentBody>
+    | ContentView<GridContentBody> = personaBody
     ? { purpose: PERSONA_PURPOSE, body: personaBody }
     : liveBody
       ? { purpose: LIVE_PURPOSE, body: liveBody }
@@ -404,10 +433,12 @@ export function chatWorkspace(vm: ChatViewModel, live?: WorkspaceLive): Workspac
         ? { purpose: ARENA_PURPOSE, body: arenaBody }
         : servingBody
           ? { purpose: SERVING_PURPOSE, body: servingBody }
-          : {
-              purpose: vm.purpose,
-              body: { messages: vm.messages, isEmpty: vm.isEmpty },
-            };
+          : gridBody
+            ? { purpose: GRID_PURPOSE, body: gridBody }
+            : {
+                purpose: vm.purpose,
+                body: { messages: vm.messages, isEmpty: vm.isEmpty },
+              };
   // The ACTIVE nav cell follows the citizen's current tab: the persona tab
   // when a persona home is focused, else the chat room on screen.
   const rooms = live?.nav

--- a/packages/patterns/gridContent.ts
+++ b/packages/patterns/gridContent.ts
@@ -1,0 +1,43 @@
+/**
+ * The `grid` activity's neutral `Content` body — the GRID's SCADA view.
+ *
+ * The left NODES strip is the grid's condensed state (the portal); THIS is
+ * its full center-stage activity (console doctrine): one rich panel per
+ * node — identity, the resource window, the serving control loop — with
+ * route health and resident citizens joining as their feeds land (#257
+ * peer attestation, #283 cross-grid serving, delivery-truth from the airc
+ * ledger). A room PURPOSE (`GRID_PURPOSE`), same nav semantics as any
+ * activity, rendered by a purpose-registered `Content` renderer. Shapes
+ * only: consumer-neutral, DOM-free, ANSI-free.
+ *
+ * Honest absence: a node panel renders exactly the sections its feeds
+ * deliver — no fabricated gauges, no invented peers; an empty grid renders
+ * the awaiting frame (the frame is the promise).
+ */
+
+import type { GaugeView, ServingPanelView } from './index';
+
+/** The `Content` purpose key the grid view dispatches on. */
+export const GRID_PURPOSE = 'grid';
+
+/** One node's grid panel — identity plus whichever live views its feeds carry. */
+export interface GridNodeVM {
+  /** Host name ("m5.local", "bigmama.local"). */
+  readonly node: string;
+  /** True for the node this surface runs on (renders first, marked). */
+  readonly local: boolean;
+  /** The node's resource window (CPU/MEM/GPU) — absent until its metrics
+   *  feed delivers. */
+  readonly resources?: GaugeView;
+  /** The node's serving control loop — absent until its serving feed
+   *  delivers. */
+  readonly serving?: ServingPanelView;
+}
+
+/** The grid view's content body. */
+export interface GridContentBody {
+  /** Per-node panels, local node first. Empty = no node feeds anywhere. */
+  readonly nodes: readonly GridNodeVM[];
+  /** True only when live envelope streams are attached. */
+  readonly feedLive: boolean;
+}

--- a/packages/patterns/index.ts
+++ b/packages/patterns/index.ts
@@ -43,6 +43,11 @@ export type {
 // — per-node control-loop panels, center-stage full view (console doctrine).
 export { SERVING_PURPOSE } from './servingContent';
 export type { ServingContentBody, ServingNodeVM } from './servingContent';
+
+// The GRID's neutral Content body (`purpose === GRID_PURPOSE`) — the NODES
+// strip's full activity: every node's resources + serving, SCADA-style.
+export { GRID_PURPOSE } from './gridContent';
+export type { GridContentBody, GridNodeVM } from './gridContent';
 export type {
   LiveContentBody,
   LiveParticipantVM,


### PR DESCRIPTION
NODES (left, condensed) portals to the GRID activity (center, full SCADA): one panel per node — banner with LOCAL mark + serving model + ready pulse, RESOURCES window, SERVING control loop. Multi-node body from day one (#283 peers drop in; #257 attestation/route-health joins the panel). Same purpose-registry spine; honest absence throughout. Preview-shot verified (`?fixture=grid`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo