### PR TITLE
feat(serving): daemon-owned MoE glass-box env seam — unattended paged serves light the console (#278)

### DIFF
--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -385,6 +385,34 @@ pub fn serving_v1_url() -> String {
     format!("{}/v1", serving_root())
 }
 
+/// The daemon-owned MoE glass-box file locations for the lane on `port` — ONE
+/// pure derivation shared by the spawn (which hands them to the child process
+/// as `GGML_MOE_CAPTURE_FILE` / `GGML_MOE_PLAN_FILE`) and the positron serving
+/// source (which re-derives the capture path from the snapshot's port to tail
+/// it). Deriving both sides from the port is what lights the glass box with NO
+/// operator env and no wire-type change: the system owns the seam (#278).
+/// `None` only when there is no home directory (no stable place to put them).
+pub struct MoeGlassBoxPaths {
+    /// Per-token pager telemetry JSONL the fork appends — bounded by the
+    /// fork's 32 MB default cap (`GGML_MOE_CAPTURE_MB` overrides), so this is
+    /// not a new unbounded cache class.
+    pub capture: PathBuf,
+    /// The v1 policy→mechanism plan document the controller writes atomically
+    /// and the fork's `ResidencyCache` mtime-polls per token
+    /// (docs/architecture/EXPERT-PAGING-CONTROL-LAW.md §5).
+    pub plan: PathBuf,
+}
+
+/// See [`MoeGlassBoxPaths`]. Lives beside the per-port stderr logs
+/// (`~/.continuum/logs/llama-server-{port}.log`) — same dir, same lifecycle.
+pub fn moe_glass_box_paths(port: u16) -> Option<MoeGlassBoxPaths> {
+    let dir = dirs::home_dir()?.join(".continuum").join("logs");
+    Some(MoeGlassBoxPaths {
+        capture: dir.join(format!("moe-capture-{port}.jsonl")),
+        plan: dir.join(format!("moe-plan-{port}.json")),
+    })
+}
+
 /// Path to the `llama-server` binary — the inference engine WE OWN, built from
 /// our vendored llama.cpp submodule by `tools/scripts/install-llama-server.sh`
 /// into `~/.continuum/bin`. Resolution order:
@@ -1570,6 +1598,27 @@ impl LlamaServerControl for LlamaServerProcess {
         // set is honored on the next relaunch (the pager decides when).
         if let Some(ot) = target.expert_ot_value() {
             cmd.arg("--override-tensor").arg(ot);
+        }
+        // MoE glass-box env seam (#278): when expert paging is active, the DAEMON
+        // hands the fork its capture + plan file locations. Previously these envs
+        // existed only when an operator hand-exported them before booting the
+        // core, so every unattended MoE serve ran dark — no pager telemetry for
+        // the serving console, no actuator channel for the policy controller.
+        // The paths are the pure port derivation [`moe_glass_box_paths`]; the
+        // positron serving source re-derives the same capture path from the
+        // snapshot's port, so the two sides share one truth with no wire-type
+        // change. An operator-exported env is an intentional campaign override
+        // and is inherited untouched (config over convention — the child gets
+        // the parent's env by default; we only fill the ABSENT case).
+        if target.expert_placement.is_some() {
+            if let Some(gb) = moe_glass_box_paths(port) {
+                if std::env::var_os("GGML_MOE_CAPTURE_FILE").is_none() {
+                    cmd.env("GGML_MOE_CAPTURE_FILE", &gb.capture);
+                }
+                if std::env::var_os("GGML_MOE_PLAN_FILE").is_none() {
+                    cmd.env("GGML_MOE_PLAN_FILE", &gb.plan);
+                }
+            }
         }
         // Capture the server's stderr to a per-port log file (#175). llama.cpp prints
         // its load banner AND — critically — the underlying ggml/Metal fault behind a

--- a/core/continuum-core/src/ipc/positron_serving_source.rs
+++ b/core/continuum-core/src/ipc/positron_serving_source.rs
@@ -170,6 +170,16 @@ impl PagerFold {
     }
 }
 
+/// The port embedded in a serving base URL (`http://host:port[/...]`), or
+/// `None` when the URL carries no explicit port. Feeds the capture-path
+/// derivation — a config-pinned remote URL still parses, and the derived
+/// LOCAL path simply never exists there (honest absence, not a guess).
+fn port_of(url: &str) -> Option<u16> {
+    let rest = url.split_once("://").map_or(url, |(_, r)| r);
+    let authority = rest.split('/').next()?;
+    authority.rsplit_once(':')?.1.parse().ok()
+}
+
 /// Offset-tailer for the capture JSONL: reads whole new lines, resets on
 /// truncation (a new serve) and reports the reset so the fold can card it.
 struct CaptureTail {
@@ -239,13 +249,35 @@ pub fn spawn_serving_emitter(rt: &tokio::runtime::Handle, substrate: Substrate) 
         let builder = StateBuilder::standalone();
         let mut ticker = tokio::time::interval(SAMPLE_INTERVAL);
         let mut fold = PagerFold::default();
-        // Capture feed location is serve-side config; read once — the env of
-        // a running core doesn't change. Absent = header-only widget.
-        let mut tail = std::env::var(CAPTURE_FILE_ENV)
-            .ok()
-            .map(|p| CaptureTail { path: PathBuf::from(p), offset: 0, last_len: 0 });
+        // Capture feed location: an operator-exported env is a deliberate
+        // campaign override and wins (read once — the env of a running core
+        // doesn't change). Otherwise the path is DERIVED per tick from the
+        // serving snapshot's port via the same pure helper the spawn used to
+        // hand it to the fork (`moe_glass_box_paths`, #278) — one truth, both
+        // sides, so the glass box lights on an unattended serve. A remote or
+        // non-MoE serve derives a path that never exists; the tail's failed
+        // open is the existing honest-absence branch.
+        let env_override = std::env::var(CAPTURE_FILE_ENV).ok().map(PathBuf::from);
+        let mut tail: Option<CaptureTail> = None;
         loop {
             ticker.tick().await;
+
+            let snap = crate::inference::llama_server::current_serving();
+            let desired = env_override.clone().or_else(|| {
+                port_of(&snap.base_url)
+                    .and_then(crate::inference::llama_server::moe_glass_box_paths)
+                    .map(|g| g.capture)
+            });
+            match (&mut tail, desired) {
+                // New or relocated feed → fresh tail (offset 0; the first poll
+                // of a pre-existing file replays it, which is the correct
+                // catch-up for a source that just learned where to look).
+                (t, Some(path)) if t.as_ref().map(|t| &t.path) != Some(&path) => {
+                    *t = Some(CaptureTail { path, offset: 0, last_len: 0 });
+                }
+                (t @ Some(_), None) => *t = None,
+                _ => {}
+            }
 
             if let Some(t) = tail.as_mut() {
                 let (events, reset) = t.poll();
@@ -266,7 +298,6 @@ pub fn spawn_serving_emitter(rt: &tokio::runtime::Handle, substrate: Substrate) 
                 }
             }
 
-            let snap = crate::inference::llama_server::current_serving();
             let header = ServingHeaderView {
                 model: snap.active_model.clone(),
                 ready: snap.ready,
@@ -315,6 +346,19 @@ mod tests {
         let chosen: Vec<bool> = fold.arms.iter().map(|a| a.chosen).collect();
         assert_eq!(chosen.iter().filter(|c| **c).count(), 1, "exactly one chosen arm");
         assert!(fold.arms.iter().any(|a| a.label == "0.30" && a.chosen));
+    }
+
+    // what this catches (#278): the capture-path derivation's port parse — the
+    // snapshot's base_url is the ONLY thing the reader has, and a mis-parse
+    // silently darkens the glass box (tail opens a nonexistent path forever).
+    // Pins scheme'd/bare/pathless/portless shapes.
+    #[test]
+    fn port_of_parses_serving_base_urls() {
+        assert_eq!(port_of("http://127.0.0.1:58057/v1"), Some(58057));
+        assert_eq!(port_of("http://localhost:8080"), Some(8080));
+        assert_eq!(port_of("127.0.0.1:9001/v1"), Some(9001));
+        assert_eq!(port_of("http://remote.example/v1"), None, "no explicit port");
+        assert_eq!(port_of(""), None);
     }
 
     // what this catches: the raw C++ perf-only line (no decision fields)


### PR DESCRIPTION
First wire of the #278 single-box flagship (Joel this morning: "you need to get the k3 and others moe's solid").

**The gap**: the `GGML_MOE_CAPTURE_FILE`/`GGML_MOE_PLAN_FILE` seam between the fork's ResidencyCache and our policy/console only existed when an operator hand-exported env before booting the core. Every unattended MoE serve ran dark — no pager telemetry in the serving console, no actuator channel for the controller. The M5 flagship needs the SYSTEM to own this wire.

**The fix — one pure derivation, two callers, no wire-type change**:
- `moe_glass_box_paths(port)` puts `moe-capture-{port}.jsonl` + `moe-plan-{port}.json` beside the per-port stderr logs.
- The spawn sets both envs on MoE lanes (`expert_placement` present) unless the operator exported them — explicit env is a deliberate campaign override, inherited untouched.
- `positron_serving_source` re-derives the same capture path per tick from the snapshot's `base_url` port (env override still wins), re-keying its tail on path change. Remote/non-MoE serves derive a path that never exists — the tail's failed open is the existing honest-absence branch.

**Disk discipline**: capture bounded by the fork's 32 MB default cap; both files live in the logs dir the stderr logs already use — no new unbounded cache class.

**Tests**: new `port_of` pin (scheme'd/bare/pathless/portless — a mis-parse silently darkens the glass box); existing tail/fold/llama_server suites green (28 tests). `cargo check` clean.

Next slices on this lane: in-core plan publisher tick (BanditPlanController → the plan path this PR standardizes), then the traced Kimi-Linear-48B serve datum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo