### PR TITLE
feat(vision): #106 slice 1 — VL serving with verified mmproj readiness, honest observe routing, native image parts

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -964,8 +964,25 @@ impl OpenAICompatibleAdapter {
         })
     }
 
-    /// Convert ChatMessage to OpenAI format
-    fn format_messages(&self, messages: &[ChatMessage], system_prompt: Option<&str>) -> Vec<Value> {
+    /// Convert ChatMessage to OpenAI format.
+    ///
+    /// `vision_native` is the TARGET MODEL's verdict (the row's
+    /// `Capability::Vision` via `sensory::route`, resolved by the caller): when
+    /// true, `ContentPart::Image` becomes a proper OpenAI multimodal
+    /// `image_url` content part (base64 data-URI or URL) so a vision model —
+    /// cloud or the multimodal llama-server lane — receives RAW PIXELS
+    /// natively. When false, image parts are DROPPED here (with a loud log):
+    /// a non-vision model reads the VisionDescriptionService bridge text that
+    /// the sensory layer already put in the message, and POSTing `image_url`
+    /// parts at a text-only endpoint is at best an API error and at worst a
+    /// silent drop the persona would mistake for having seen
+    /// ([[fallbacks-are-illegal-fail-loud]], CLAUDE.md "Sensory Architecture").
+    fn format_messages(
+        &self,
+        messages: &[ChatMessage],
+        system_prompt: Option<&str>,
+        vision_native: bool,
+    ) -> Vec<Value> {
         // Pre-size: one wire message per input message + the optional system
         // prompt. The common text path lands exactly; tool-result turns push a
         // few extra and realloc once. Runs on every inference call — no
@@ -1054,7 +1071,21 @@ impl OpenAICompatibleAdapter {
                                     "text": text
                                 })),
                                 ContentPart::Image { image } => {
-                                    if let Some(url) = &image.url {
+                                    if !vision_native {
+                                        // Target model can't see: the sensory bridge's
+                                        // text description (already a Text part /
+                                        // upstream) is what it reads. Never ship
+                                        // image_url at a text-only endpoint.
+                                        tracing::warn!(
+                                            target: "openai_adapter",
+                                            provider = %self.config.provider_id,
+                                            "dropping image content part for a non-vision \
+                                             model — the description bridge is its sight; \
+                                             if this model CAN see, its catalog row must \
+                                             declare Capability::Vision"
+                                        );
+                                        None
+                                    } else if let Some(url) = &image.url {
                                         Some(json!({
                                             "type": "image_url",
                                             "image_url": { "url": url }
@@ -1582,8 +1613,30 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         };
         let model: &str = &resolved_model;
 
+        // Native vision is a MODEL fact, not a provider fact: gate image content
+        // parts on the TARGET model row's Capability::Vision (the same
+        // `sensory::route` verdict that drives the bridge-vs-native table in
+        // CLAUDE.md "Sensory Architecture"). Row present → its capability set is
+        // the truth (a vision-capable llama-server lane / gpt-4o gets raw
+        // pixels; a text row gets its images dropped and reads the description
+        // bridge). Row absent (dynamic catalogs like DMR resolve ids the
+        // registry never saw) → the provider-level scan ("any row under this
+        // provider declares Vision", already folded into `config.capabilities`)
+        // is the best available truth — same source `capabilities()` advertises.
+        let vision_native = crate::model_registry::try_global()
+            .and_then(|reg| {
+                reg.model(raw_model).map(|row| {
+                    crate::sensory::route(row, crate::sensory::Modality::ImageIn).is_native()
+                })
+            })
+            .unwrap_or_else(|| self.config.capabilities.contains(&Capability::Vision));
+
         // Build request body
-        let mut messages = self.format_messages(&request.messages, request.system_prompt.as_deref());
+        let mut messages = self.format_messages(
+            &request.messages,
+            request.system_prompt.as_deref(),
+            vision_native,
+        );
 
         // JsonInPrompt tool offering: for gateways/models that ignore the OpenAI
         // `tools` param (unsloth+GGUF), describe the tools IN the prompt and ask
@@ -2507,6 +2560,89 @@ fn parse_embedding_usage(body: &Value) -> UsageMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::ai::types::ImageInput;
+
+    /// Minimal adapter for pure payload-assembly tests — no network, no registry.
+    fn test_adapter() -> OpenAICompatibleAdapter {
+        OpenAICompatibleAdapter::new(OpenAICompatibleConfig {
+            provider_id: "test-gateway".into(),
+            name: "Test Gateway".into(),
+            base_url: "http://127.0.0.1:0".into(),
+            api_key_env: None,
+            default_model: "test-model".into(),
+            capabilities: std::collections::BTreeSet::new(),
+            models: Vec::new(),
+            model_prefixes: Vec::new(),
+            requires_auth: false,
+            tool_protocol: crate::model_registry::ToolProtocol::NativeFunctionCalling,
+            thinking: ThinkingMode::Default,
+            single_resident_model: false,
+            dynamic_model_catalog: false,
+            llamacpp_sampling_extensions: false,
+        })
+    }
+
+    fn image_message() -> Vec<ChatMessage> {
+        vec![ChatMessage {
+            role: "user".into(),
+            content: MessageContent::Parts(vec![
+                ContentPart::Text {
+                    text: "what do you see?".into(),
+                },
+                ContentPart::Image {
+                    image: ImageInput {
+                        url: None,
+                        base64: Some("QUJD".into()),
+                        mime_type: Some("image/png".into()),
+                    },
+                },
+            ]),
+            name: None,
+        }]
+    }
+
+    // what this catches (#106 native-vision branch): a VISION-capable target model must
+    // receive the RAW image as a proper OpenAI multimodal content part — `image_url`
+    // with a base64 data-URI — in the /v1 chat payload (this is exactly what the
+    // multimodal llama-server lane's mtmd tokenizer consumes). A regression that drops
+    // or re-texts the image blinds every natively-sighted model while all the plumbing
+    // upstream still reports success.
+    #[test]
+    fn vision_capable_model_gets_raw_image_content_parts() {
+        let wire = test_adapter().format_messages(&image_message(), None, true);
+        assert_eq!(wire.len(), 1);
+        let content = wire[0]["content"].as_array().expect("multimodal array");
+        assert_eq!(content.len(), 2, "text part + image part");
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[1]["type"], "image_url");
+        assert_eq!(
+            content[1]["image_url"]["url"], "data:image/png;base64,QUJD",
+            "raw pixels ride as a base64 data-URI — native sight, not a description"
+        );
+    }
+
+    // what this catches (#106 bridge branch): a NON-vision target model must NOT be
+    // sent `image_url` parts — its sight is the VisionDescriptionService bridge text
+    // (unchanged behavior); shipping pixels at a text-only endpoint is an API error or
+    // a silent drop the persona would mistake for having seen. The text parts (which
+    // carry the bridge's description) must survive untouched.
+    #[test]
+    fn non_vision_model_has_image_parts_dropped_and_keeps_bridge_text() {
+        let wire = test_adapter().format_messages(&image_message(), None, false);
+        assert_eq!(wire.len(), 1);
+        let content = wire[0]["content"].as_array().expect("content array");
+        assert_eq!(
+            content.len(),
+            1,
+            "image part dropped for a model that cannot see; bridge text remains"
+        );
+        assert_eq!(content[0]["type"], "text");
+        assert!(
+            !serde_json::to_string(&wire).unwrap().contains("image_url"),
+            "no image_url may reach a non-vision model's payload"
+        );
+    }
 
     // what this catches (#181): the anti-loop knobs reach the llama.cpp wire body.
     // The reasoning-channel repetition loop (Devstral-24B looped an identical wrong

--- a/core/continuum-core/src/cognition/vision_describe.rs
+++ b/core/continuum-core/src/cognition/vision_describe.rs
@@ -157,11 +157,91 @@ fn pick_vision_candidate<'a>(
     candidates.first()
 }
 
+/// Is a `llama-server`-provider vision row actually SERVABLE right now, per the
+/// serving daemon's live snapshot? Pure — the snapshot IO lives in the caller.
+///
+/// The lane serves exactly ONE model, so a vision row is a real candidate only
+/// when it IS the active model, the lane is decode-ready, AND the daemon's
+/// verified multimodal verdict (`vision_ready`: declared Vision + resolved
+/// mmproj + `/props modalities.vision`, #106) came back true. Anything less and
+/// routing an image here would either hard-error at `select()` (model not
+/// served) or be silently dropped by a text-only lane — the capability lie the
+/// observe path must fail HONESTLY on instead
+/// ([[fallbacks-are-illegal-fail-loud]]).
+fn llama_server_row_ready(
+    model_id: &str,
+    snap: &crate::inference::llama_server::ServingSnapshot,
+) -> Result<(), String> {
+    if !snap.ready || snap.active_model.is_none() {
+        return Err("serving lane has no ready model".to_string());
+    }
+    if snap.active_model.as_deref() != Some(model_id) {
+        return Err(format!(
+            "serving lane is occupied by {:?}, not this vision row — pin/pull it to bring \
+             vision up (`models/pull` + `serving/pin`)",
+            snap.active_model.as_deref().unwrap_or("<none>")
+        ));
+    }
+    if !snap.vision_ready {
+        return Err(
+            "lane serves this model but its multimodal endpoint is NOT verified \
+             (mmproj missing or /props reports no vision modality) — see the serving \
+             daemon's `serving.vision.*` probes for the reason"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Is this vision candidate SERVABLE right now? Registry rows *declare*
+/// capability; this checks the lane behind them actually answers, so the
+/// picker never selects a model whose `ai/generate` would hard-error at
+/// `select()` (the pre-#106 failure: prefer-local picked a VL row with no
+/// artifacts on disk and EVERY observe act died "no adapter", even while a
+/// perfectly good cloud vision lane sat registered).
+fn candidate_servable(m: &crate::model_registry::types::Model) -> Result<(), String> {
+    let registry = model_registry::try_global().ok_or("model registry not initialized")?;
+    let provider = registry
+        .provider(&m.provider)
+        .ok_or_else(|| format!("provider {:?} not in registry", m.provider))?;
+
+    if m.provider == crate::inference::llama_server::PROVIDER_ID {
+        // The local serving lane: gate on the daemon's LIVE snapshot.
+        return llama_server_row_ready(&m.id, &crate::inference::llama_server::current_serving());
+    }
+    if m.provider == crate::inference::LLAMACPP_PROVIDER_ID {
+        // The retiring in-process path is OPT-IN ONLY (CONTINUUM_LOCAL_LLAMA=1,
+        // see AIProviderModule) — without the opt-in no adapter registers for
+        // these rows, so they are never servable candidates.
+        if crate::config_env::read("CONTINUUM_LOCAL_LLAMA").as_deref() != Some("1") {
+            return Err("in-process llama.cpp is not opted in (CONTINUUM_LOCAL_LLAMA=1)".into());
+        }
+        if crate::model_registry::artifacts::resolve_gguf_for_model(m).is_none() {
+            return Err("no local GGUF resolves for this row".into());
+        }
+        if crate::model_registry::artifacts::resolve_mmproj_for_model(m).is_none() {
+            return Err("no mmproj projector resolves for this row".into());
+        }
+        return Ok(());
+    }
+    // Cloud (and other keyless local gateways): the adapter registers iff the
+    // provider's API key secret is present — mirror that gate here so a keyless
+    // boot never picks a cloud vision model whose `select()` would refuse.
+    match provider.api_key_env.as_deref() {
+        None => Ok(()),
+        Some(env_key) if crate::secrets::get_secret(env_key).is_some() => Ok(()),
+        Some(env_key) => Err(format!("no {env_key} secret — provider not registered")),
+    }
+}
+
 /// Pick the best vision-capable model from the global model registry.
 ///
-/// Returns `(model_id, provider_id)` or `None` if no vision-capable
-/// model is registered. Wraps `pick_vision_candidate` with the registry
-/// IO; the priority logic itself lives in the pure helper for tests.
+/// Returns `(model_id, provider_id)` or `None` if no vision-capable model is
+/// SERVABLE (declared capability alone is not enough — see
+/// [`candidate_servable`]). Wraps `pick_vision_candidate` with the registry +
+/// serving-snapshot IO; the priority logic itself lives in the pure helper for
+/// tests. Skipped candidates are logged with their reason so an all-skipped
+/// outcome (the honest "no eyes available" failure) is diagnosable, not mute.
 fn select_vision_model(opts: &VisionDescribeOptions) -> Option<(String, String)> {
     let registry = model_registry::try_global()?;
 
@@ -170,6 +250,13 @@ fn select_vision_model(opts: &VisionDescribeOptions) -> Option<(String, String)>
         .filter(|m| m.has(Capability::Vision))
         .filter_map(|m| {
             let provider = registry.provider(&m.provider)?;
+            if let Err(why) = candidate_servable(m) {
+                runtime::logger("cognition").info(&format!(
+                    "vision-describe: skipping {:?} — {why}",
+                    m.id
+                ));
+                return None;
+            }
             Some(VisionCandidate {
                 model_id: m.id.clone(),
                 provider_id: m.provider.clone(),
@@ -570,6 +657,38 @@ mod tests {
         let picked = pick_vision_candidate(&candidates, &opts).unwrap();
         assert!(picked.is_local);
         assert_eq!(picked.model_id, "local-llava");
+    }
+
+    // what this catches (#106): the observe path may route to the local serving lane
+    // ONLY when the lane is ready, serving THIS model, and its multimodal endpoint is
+    // VERIFIED (`vision_ready`). A regression that accepts a ready-but-unverified lane
+    // re-opens the capability lie (images POSTed to a text-only lane, silently
+    // dropped); one that accepts a different active model re-opens the pre-#106 bug
+    // where every observe act died at select() while a good lane sat elsewhere.
+    #[test]
+    fn llama_server_row_is_servable_only_when_active_ready_and_vision_verified() {
+        use crate::inference::llama_server::ServingSnapshot;
+        let mut snap = ServingSnapshot::empty();
+
+        // Nothing serving → not servable.
+        assert!(llama_server_row_ready("vl-model", &snap).is_err());
+
+        // Ready but the lane serves a DIFFERENT model → not servable, and the
+        // reason names the occupant (the operator's pin/pull hint).
+        snap.ready = true;
+        snap.active_model = Some("coder-14b".into());
+        snap.vision_ready = false;
+        let err = llama_server_row_ready("vl-model", &snap).unwrap_err();
+        assert!(err.contains("coder-14b"), "{err}");
+
+        // Serving this model but multimodal endpoint NOT verified → not servable.
+        snap.active_model = Some("vl-model".into());
+        let err = llama_server_row_ready("vl-model", &snap).unwrap_err();
+        assert!(err.contains("NOT verified"), "{err}");
+
+        // All three facts line up → servable.
+        snap.vision_ready = true;
+        assert!(llama_server_row_ready("vl-model", &snap).is_ok());
     }
 
     #[test]

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -521,6 +521,18 @@ pub struct ServingSnapshot {
     #[serde(default)]
     #[ts(optional)]
     pub degraded_reason: Option<String>,
+    /// True iff the active model declares [`Capability::Vision`] AND the lane
+    /// VERIFIED its multimodal endpoint actually answers: an mmproj projector
+    /// resolved at spawn (`--mmproj` was passed) and the running server's own
+    /// `/props` reports `modalities.vision == true` (#106). This is the gate the
+    /// observation path (`cognition/vision-describe` → the persona's eyes) reads
+    /// before routing image bytes to this lane — a text-only lane, or a vision
+    /// row whose projector failed to load, reads `false` and the observe act
+    /// fails HONESTLY instead of POSTing pixels a server would silently drop
+    /// ([[fallbacks-are-illegal-fail-loud]]). `serde(default)` keeps older
+    /// persisted snapshots (pre-#106) readable as not-vision-ready.
+    #[serde(default)]
+    pub vision_ready: bool,
 }
 
 impl ServingSnapshot {
@@ -539,6 +551,8 @@ impl ServingSnapshot {
             // real `--parallel` count; 0 is the "no lanes" sentinel.
             lanes: 0,
             degraded_reason: None,
+            // Nothing served → nothing can see.
+            vision_ready: false,
         }
     }
 
@@ -551,6 +565,66 @@ impl ServingSnapshot {
             degraded_reason: Some(reason),
             ..Self::empty()
         }
+    }
+}
+
+/// What the running llama-server's own `/props` says it can perceive — the
+/// `modalities` block llama.cpp publishes once an mmproj projector loads. This
+/// is the ENDPOINT truth (#106): the catalog row *declares* Vision, the mmproj
+/// file *exists*, but only the process itself can confirm the projector loaded
+/// and the multimodal tokenize path answers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MultimodalSupport {
+    /// `/props` `modalities.vision` — the server accepts image content parts.
+    pub vision: bool,
+    /// `/props` `modalities.audio` — the server accepts audio content parts.
+    pub audio: bool,
+}
+
+/// Pure readiness verdict for the VISION side of a lane (#106): given what the
+/// catalog row declares, whether an mmproj projector resolved at spawn, and what
+/// the running server's `/props` reports, decide whether this lane may claim
+/// sight. Split from the daemon IO so every branch is unit-testable.
+///
+/// - `Ok(false)` — a text lane: the row never declared Vision. Not an error.
+/// - `Ok(true)`  — declared Vision, `--mmproj` was passed, AND the server's own
+///   `/props` confirms `modalities.vision`. The lane may claim sight.
+/// - `Err(why)`  — the row declares Vision but the lane CANNOT verifiably see:
+///   no projector resolved, the server reports no vision modality (projector
+///   failed to load / wrong file), or the server build doesn't report
+///   modalities at all (unverifiable ≠ working). The daemon logs the reason
+///   loud and publishes `vision_ready: false` — the capability lie is surfaced,
+///   never served ([[fallbacks-are-illegal-fail-loud]]).
+pub fn vision_lane_ready(
+    declares_vision: bool,
+    mmproj_resolved: bool,
+    props: Option<MultimodalSupport>,
+) -> Result<bool, String> {
+    if !declares_vision {
+        return Ok(false);
+    }
+    if !mmproj_resolved {
+        return Err(
+            "model row declares Vision but no mmproj projector resolved at spawn — \
+             the lane serves TEXT ONLY; pull the model's `*-GGUF` repo (projector ships \
+             alongside) or set `mmproj_local_path` on the row"
+                .to_string(),
+        );
+    }
+    match props {
+        Some(m) if m.vision => Ok(true),
+        Some(_) => Err(
+            "--mmproj was passed but the running server's /props reports \
+             modalities.vision=false — the projector failed to load or is the wrong \
+             modality (an audio-only mmproj?); the lane cannot see"
+                .to_string(),
+        ),
+        None => Err(
+            "--mmproj was passed but the running server's /props carries no `modalities` \
+             block — this llama-server build cannot VERIFY multimodal readiness, and an \
+             unverified claim of sight is a fabrication; upgrade the serving binary"
+                .to_string(),
+        ),
     }
 }
 
@@ -756,6 +830,18 @@ pub trait LlamaServerControl: Send + Sync {
     /// answering (pre-spawn), or a ready server whose `/props` shape is missing
     /// `n_ctx` (a loud invariant violation — never a guessed window).
     async fn served_context_window(&self) -> Result<u32, LlamaServerError>;
+
+    /// The multimodal capabilities the running server ITSELF reports in `/props`
+    /// (`modalities.vision` / `modalities.audio`) — the endpoint-side truth of
+    /// whether the `--mmproj` projector actually loaded (#106). `Ok(None)` means
+    /// the server answered but its `/props` carries no `modalities` block (an
+    /// older llama-server build, or a fake control that doesn't probe) — the
+    /// caller must treat that as UNVERIFIED, never as "vision works". Default
+    /// impl returns `Ok(None)` so fakes/remote controls stay honest by
+    /// construction.
+    async fn multimodal_support(&self) -> Result<Option<MultimodalSupport>, LlamaServerError> {
+        Ok(None)
+    }
 
     /// Prove the GPU DECODE path works, not just that the HTTP server is up. A
     /// llama-server can answer `/health`, `/v1/models` and `/props` with 200
@@ -1306,6 +1392,36 @@ impl LlamaServerControl for LlamaServerProcess {
                         .to_string(),
                 )
             })
+    }
+
+    async fn multimodal_support(&self) -> Result<Option<MultimodalSupport>, LlamaServerError> {
+        // Same root-level `/props` as the served window. llama.cpp publishes a
+        // `modalities: { vision: bool, audio: bool }` block once an mtmd
+        // projector loads (and `vision:false` when launched text-only). An
+        // ABSENT block is `Ok(None)` — "this build can't say", which the pure
+        // verdict (`vision_lane_ready`) refuses to treat as sight.
+        let url = format!("{}/props", self.root);
+        let resp = self
+            .client
+            .get(&url)
+            .timeout(PROBE_TIMEOUT)
+            .send()
+            .await
+            .map_err(|e| LlamaServerError::Unreachable(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(LlamaServerError::Unreachable(format!(
+                "status {}",
+                resp.status()
+            )));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| LlamaServerError::Unreachable(e.to_string()))?;
+        Ok(body.get("modalities").map(|m| MultimodalSupport {
+            vision: m.get("vision").and_then(|v| v.as_bool()).unwrap_or(false),
+            audio: m.get("audio").and_then(|v| v.as_bool()).unwrap_or(false),
+        }))
     }
 
     async fn decode_smoke_ok(&self) -> bool {
@@ -2407,6 +2523,7 @@ mod tests {
             served_context_window: 0,
             lanes: 0,
             degraded_reason: None,
+            vision_ready: false,
         });
         assert!(!pred(&rx.borrow()));
         // not-ready but has a model → unsatisfied.
@@ -2418,6 +2535,7 @@ mod tests {
             served_context_window: 0,
             lanes: 0,
             degraded_reason: None,
+            vision_ready: false,
         });
         assert!(!pred(&rx.borrow()));
         // ready AND a model → satisfied, and wait_for resolves to it at once.
@@ -2429,12 +2547,45 @@ mod tests {
             served_context_window: 0,
             lanes: 0,
             degraded_reason: None,
+            vision_ready: false,
         });
         let got = tokio::time::timeout(Duration::from_millis(100), rx.wait_for(pred))
             .await
             .expect("should not time out")
             .expect("sender live");
         assert_eq!(got.active_model.as_deref(), Some("coder"));
+    }
+
+    // what this catches: the #106 vision-readiness verdict must only claim sight when
+    // ALL THREE facts line up — the row declares Vision, an mmproj resolved at spawn,
+    // AND the running server's own /props confirms modalities.vision. A regression that
+    // returns Ok(true) from a weaker combination publishes `vision_ready: true` for a
+    // lane that silently drops image parts — the exact capability lie the observe path
+    // gates on ([[fallbacks-are-illegal-fail-loud]]).
+    #[test]
+    fn vision_lane_ready_requires_declaration_projector_and_props_confirmation() {
+        let sees = MultimodalSupport {
+            vision: true,
+            audio: false,
+        };
+        let blind = MultimodalSupport {
+            vision: false,
+            audio: true,
+        };
+        // Text lane: never declared Vision → not vision-ready, and NOT an error.
+        assert_eq!(vision_lane_ready(false, false, None), Ok(false));
+        assert_eq!(vision_lane_ready(false, true, Some(sees)), Ok(false));
+        // Declared Vision but no projector resolved → loud error naming the gap.
+        let err = vision_lane_ready(true, false, None).unwrap_err();
+        assert!(err.contains("no mmproj projector resolved"), "{err}");
+        // Projector passed, server confirms vision → the ONLY Ok(true) path.
+        assert_eq!(vision_lane_ready(true, true, Some(sees)), Ok(true));
+        // Projector passed but the server says it can't see (wrong/failed mmproj).
+        let err = vision_lane_ready(true, true, Some(blind)).unwrap_err();
+        assert!(err.contains("modalities.vision=false"), "{err}");
+        // Server build reports no modalities block: UNVERIFIED must not read as sight.
+        let err = vision_lane_ready(true, true, None).unwrap_err();
+        assert!(err.contains("cannot VERIFY"), "{err}");
     }
 
     // what this catches: a WEDGED server (port held open, never answers HTTP — a

--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -477,6 +477,47 @@ pub fn models() -> Vec<Model> {
             sampling: ModelSampling::default(),
             ..ModelSpec::default()
         }),
+        // QWEN2.5-VL-7B — the VISION lane's model (#106): personas' eyes for live mode.
+        // The FIRST llama-server-provider row with Capability::Vision, which makes it the
+        // first VL model the serving daemon can actually bring up (`--mmproj` spawn path +
+        // the /props `modalities.vision` readiness gate). Why THIS model:
+        //   - ggml-org repo = maintained by the llama.cpp org itself; ships the GGUF AND its
+        //     `mmproj-*-f16.gguf` projector in ONE repo, so `models/pull` acquires both in a
+        //     single command (its Vision-capability mmproj-sibling logic) and
+        //     `find_mmproj_beside` resolves the projector with zero per-machine path edits.
+        //   - Qwen2.5-VL-7B is the small end of the current VL frontier that still carries
+        //     real tool use — a live-mode citizen must SEE *and* ACT, so the vision lane's
+        //     model keeps ToolUse rather than being a caption-only 2-3B.
+        //   - ~4.7 GB Q4_K_M + ~1.4 GB f16 projector: fits an M-series lane comfortably.
+        // capability_rank (GB + tool bonus) leaves the 14B coder the autonomic pick, so this
+        // row never hijacks the live lane by surprise — the operator brings vision up with
+        // `models/pull` + `serving/pin` (or it wins on hosts where it IS the best fit).
+        model(ModelSpec {
+            id: "ggml-org/Qwen2.5-VL-7B-Instruct-GGUF",
+            name: "Qwen2.5-VL-7B-Instruct (vision — the persona eye lane)",
+            provider: "llama-server",
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 8192,
+            tokens_per_second: 20.0,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::ToolUse,
+                Capability::Vision,
+                Capability::Streaming,
+            ],
+            gguf_hint: Some("huggingface.co/ggml-org/Qwen2.5-VL-7B-Instruct-GGUF"),
+            // Trainable HF base for the genome forge (vision LoRA is future work,
+            // but the row follows the Devstral pattern so it's ready when it lands).
+            hf_source: Some("Qwen/Qwen2.5-VL-7B-Instruct"),
+            // Embedded template + --jinja (same pattern as Devstral/Hermes): the
+            // ggml-org GGUF carries Qwen2.5-VL's own ChatML-with-vision template.
+            chat_template: None,
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            stop_sequences: &["<|im_end|>"],
+            ..ModelSpec::default()
+        }),
         // Hermes-3-Llama-3.1-8B — the OPPONENT, made first-class. A general (non-coder) model we
         // benchmark AGAINST; giving it a real catalog row lets it flow through OURS (base_model_id)
         // and opencode like any other model, so the head-to-head is model-through-harness fair, not

--- a/core/continuum-core/src/modules/serving_consumer.rs
+++ b/core/continuum-core/src/modules/serving_consumer.rs
@@ -347,6 +347,7 @@ mod tests {
             served_context_window: 11008,
             lanes: 4,
             degraded_reason: None,
+            vision_ready: false,
         });
         let (suppress_tx, _srx) = watch::channel(Arc::new(HashSet::new()));
         let (pin_tx, _prx) = watch::channel(None);
@@ -431,6 +432,7 @@ mod tests {
             served_context_window: 11008,
             lanes: 3,
             degraded_reason: None,
+            vision_ready: false,
         });
         let footprint_of: FootprintFn = Arc::new(move |id: &str, window: u32, lanes: u32| {
             *seen_w.lock() = Some((id.to_string(), window, lanes));
@@ -522,6 +524,7 @@ mod tests {
             served_context_window: 11008,
             lanes: 4,
             degraded_reason: None,
+            vision_ready: false,
         });
         let (suppress_tx, _srx) = watch::channel(Arc::new(HashSet::new()));
         let (pin_tx, pin_rx) = watch::channel(None);

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -994,12 +994,59 @@ impl ServingDaemonModule {
                 }
                 EnsureOutcome::Degraded { .. } => 0,
             };
+            // #106 vision readiness: for a ready lane, verify the MULTIMODAL endpoint
+            // actually answers — the row's declared Vision, the resolved mmproj, and
+            // the server's own `/props modalities` must all agree before the snapshot
+            // claims sight. Any gap publishes `vision_ready: false` WITH the reason
+            // logged loud, so the observe path fails honestly instead of POSTing
+            // pixels a text-only lane would silently drop.
+            let vision_ready = match &outcome {
+                EnsureOutcome::AlreadyServing | EnsureOutcome::Spawned { .. } => {
+                    let declares_vision = target
+                        .model
+                        .has(crate::model_registry::Capability::Vision);
+                    let mmproj_resolved =
+                        crate::model_registry::artifacts::resolve_mmproj_for_model(&target.model)
+                            .is_some();
+                    let props = match server.multimodal_support().await {
+                        Ok(p) => p,
+                        Err(e) => {
+                            crate::probe!(
+                                class = "serving.vision.props_unreadable",
+                                desired = desired.as_str(),
+                                error = %e,
+                                "ready lane but /props modalities unreadable — \
+                                 publishing vision_ready=false (unverified ≠ sight)",
+                            );
+                            None
+                        }
+                    };
+                    match crate::inference::llama_server::vision_lane_ready(
+                        declares_vision,
+                        mmproj_resolved,
+                        props,
+                    ) {
+                        Ok(ready) => ready,
+                        Err(why) => {
+                            crate::probe!(
+                                class = "serving.vision.not_ready",
+                                desired = desired.as_str(),
+                                why = why.as_str(),
+                                "vision-capable row is serving without verified sight",
+                            );
+                            false
+                        }
+                    }
+                }
+                EnsureOutcome::Degraded { .. } => false,
+            };
             let snapshot = snapshot_from_outcome(
                 &outcome,
                 &desired,
                 &desired_adapter_paths,
                 served_window,
                 target.lanes,
+                vision_ready,
             );
             crate::probe!(
                 class = "serving.reconcile",
@@ -1652,6 +1699,7 @@ fn snapshot_from_outcome(
     adapters: &[String],
     served_context_window: u32,
     lanes: u32,
+    vision_ready: bool,
 ) -> ServingSnapshot {
     match outcome {
         EnsureOutcome::AlreadyServing | EnsureOutcome::Spawned { .. }
@@ -1672,6 +1720,11 @@ fn snapshot_from_outcome(
                 // KV as `lanes × kv_at(served_context_window)` (#79).
                 lanes,
                 degraded_reason: None,
+                // The reconcile's verified multimodal verdict (#106): declared
+                // Vision + resolved mmproj + `/props modalities.vision` all
+                // agreed. The observe path gates on THIS, never on the row's
+                // declaration alone.
+                vision_ready,
             }
         }
         // Ready outcome but the served window was unreadable (0) → do NOT publish
@@ -2386,6 +2439,7 @@ mod tests {
             &genes,
             11008,
             4,
+            true,
         );
         assert_eq!(up.active_model.as_deref(), Some("coder-14b"));
         assert!(up.ready);
@@ -2399,13 +2453,22 @@ mod tests {
             up.lanes, 4,
             "ready snapshot carries the --parallel lane count for total-KV accounting"
         );
+        assert!(
+            up.vision_ready,
+            "the reconcile's verified multimodal verdict must survive into the snapshot \
+             — the observe path gates on THIS field (#106)"
+        );
 
         let already =
-            snapshot_from_outcome(&EnsureOutcome::AlreadyServing, "coder-14b", &genes, 11008, 4);
+            snapshot_from_outcome(&EnsureOutcome::AlreadyServing, "coder-14b", &genes, 11008, 4, false);
         assert_eq!(already.active_model.as_deref(), Some("coder-14b"));
         assert!(already.ready);
         assert_eq!(already.served_context_window, 11008);
         assert_eq!(already.lanes, 4);
+        assert!(
+            !already.vision_ready,
+            "a text lane (verdict false) must never read as sighted"
+        );
 
         // Ready outcome but the served window was unreadable (0) → publish the gap,
         // NOT a ready snapshot with a zero window a persona would budget against.
@@ -2415,6 +2478,7 @@ mod tests {
             &genes,
             0,
             4,
+            false,
         );
         assert_eq!(windowless.active_model, None, "ready-but-no-window → nothing live");
         assert!(!windowless.ready);
@@ -2427,6 +2491,7 @@ mod tests {
             &genes,
             11008,
             4,
+            false,
         );
         assert_eq!(degraded.active_model, None, "degraded → nothing live");
         assert!(!degraded.ready);
@@ -2504,6 +2569,7 @@ mod tests {
             served_context_window: 11008,
             lanes: 4,
             degraded_reason: None,
+            vision_ready: false,
         });
         let budget = HostBudget { usable_bytes: 45 * GB, perf_cores: 6 };
         let candidates = vec![footprint_from_parts("coder-14b", 9 * GB, 8192, true).unwrap()];
@@ -2523,6 +2589,7 @@ mod tests {
             served_context_window: 11008,
             lanes: 4,
             degraded_reason: None,
+            vision_ready: false,
         }
     }
 
@@ -2674,6 +2741,7 @@ mod tests {
             served_context_window: plan_window / 4,
             lanes: 4,
             degraded_reason: None,
+            vision_ready: false,
         });
         daemon
             .reconcile_to_plan()
@@ -2691,6 +2759,7 @@ mod tests {
             served_context_window: plan_window / 2 + 256,
             lanes: 4,
             degraded_reason: None,
+            vision_ready: false,
         });
         assert!(
             daemon.reconcile_to_plan().is_none(),
@@ -2716,6 +2785,7 @@ mod tests {
             served_context_window: 11008,
             lanes: 4,
             degraded_reason: None,
+            vision_ready: false,
         });
         let budget = HostBudget { usable_bytes: 45 * GB, perf_cores: 6 };
         daemon.publish_plan(budget, &[]); // no candidates → plan None

--- a/shared/generated/persona/ServingSnapshot.ts
+++ b/shared/generated/persona/ServingSnapshot.ts
@@ -62,4 +62,17 @@ lanes: number,
  * `active_model=null ready=false` — the reason was dropped on the floor,
  * an operator-facing silent failure ([[fallbacks-are-illegal-fail-loud]]).
  */
-degraded_reason?: string, };
+degraded_reason?: string, 
+/**
+ * True iff the active model declares [`Capability::Vision`] AND the lane
+ * VERIFIED its multimodal endpoint actually answers: an mmproj projector
+ * resolved at spawn (`--mmproj` was passed) and the running server's own
+ * `/props` reports `modalities.vision == true` (#106). This is the gate the
+ * observation path (`cognition/vision-describe` → the persona's eyes) reads
+ * before routing image bytes to this lane — a text-only lane, or a vision
+ * row whose projector failed to load, reads `false` and the observe act
+ * fails HONESTLY instead of POSTing pixels a server would silently drop
+ * ([[fallbacks-are-illegal-fail-loud]]). `serde(default)` keeps older
+ * persisted snapshots (pre-#106) readable as not-vision-ready.
+ */
+vision_ready: boolean, };


### PR DESCRIPTION
## What

Task **#106 slice 1 (vision-serving, P0)** — personas' vision gates live mode. Three coherent units:

### 1. Verified vision readiness on the serving lane
The `--mmproj` spawn path existed; nothing verified the multimodal endpoint actually **answers**. Now:
- `LlamaServerControl::multimodal_support()` reads the running server's own `/props` `modalities` block.
- `vision_lane_ready()` (pure): declared Vision + resolved mmproj + `/props modalities.vision` must ALL agree — every gap is a named, loud error; an unverified claim of sight is refused by construction.
- `ServingSnapshot.vision_ready` publishes the reconcile's verified verdict (serde-default back-compat; ts-rs regenerated).

### 2. A VL model the serving daemon can actually bring up + honest observe routing
- Catalog row `ggml-org/Qwen2.5-VL-7B-Instruct-GGUF` (llama-server provider, Vision + ToolUse, ~4.7 GB Q4_K_M + ~1.4 GB f16 mmproj in ONE repo → `models/pull` acquires both, `find_mmproj_beside` resolves — zero per-machine paths). Its capability_rank stays below the 14B coder, so it never hijacks the live lane by surprise; `serving/pin` brings it up deliberately.
- `cognition/vision-describe` (the engine behind persona look/observe acts and the live `FrameDescriber`) now selects only models whose lane **answers**: llama-server rows gate on the live snapshot (`ready` + active + `vision_ready`); llamacpp-local rows gate on the opt-in + artifacts; cloud rows gate on key presence. Kills the pre-#106 shape where prefer-local picked an artifact-less VL row and **every** observe act died at `select()` ("adapter not connected") while a good vision lane sat registered. All-skipped stays the honest no-eyes failure — never a fabricated description — with per-candidate skip reasons logged.

### 3. Native raw images for vision-capable models (Joel's scope addition)
`OpenAICompatibleAdapter` now gates image content parts per the **target model row's** `Capability::Vision` via `sensory::route`: vision-capable → proper `image_url` base64 data-URI parts in the `/v1` payload (what the multimodal llama-server lane consumes natively); non-vision → the VisionDescriptionService text bridge unchanged, and image parts are dropped loudly instead of POSTed at a text-only endpoint. Previously `image_url` was emitted unconditionally.

## Tests (all with `// what this catches:`)
- `vision_lane_ready_requires_declaration_projector_and_props_confirmation`
- `snapshot_mapping_is_honest` (extended: verdict survives into the snapshot)
- `llama_server_row_is_servable_only_when_active_ready_and_vision_verified`
- `vision_capable_model_gets_raw_image_content_parts`
- `non_vision_model_has_image_parts_dropped_and_keeps_bridge_text`

`cargo check` clean; targeted `cargo test -p continuum-core --lib --features metal,accelerate` for every touched mod: 89 + 44 + 31 pass.

## Operator steps post-merge (to run the acceptance test — Atlas's observe succeeding)
1. `continuum models/pull --model_id ggml-org/Qwen2.5-VL-7B-Instruct-GGUF` (~6.1 GB: GGUF + mmproj, lands in the HF cache).
2. `serving/pin ggml-org/Qwen2.5-VL-7B-Instruct-GGUF` (or let the planner pick it where it's the best fit) — the reconcile verifies `/props modalities.vision` and publishes `vision_ready: true`.
3. Atlas's observation act needs a connected eye-node client for the pixel capture (`perception/observe` is `Provided`); with the lane vision-ready, the describe/native-image path behind it stops failing "adapter not connected".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo