### PR TITLE
feat(airc): one page back on first attach — airc f01a3f4 + backlog_tail(32)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=816a0be#816a0be12b0e2361b37ee6e0eb793e538dce33f2"
+source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
 dependencies = [
  "airc-core",
  "airc-store",
@@ -453,7 +453,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -464,7 +464,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3697,7 +3697,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4000,7 +4000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4850,7 +4850,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5516,7 +5516,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -7004,7 +7004,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9386,7 +9386,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10106,7 +10106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10615,7 +10615,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12397,7 +12397,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,18 +152,18 @@ exclude = ["wordstats", "work-wordstats", "conway_game_of_life", "work-08ece9e8"
 # personas load their stored peer_id unchanged. This SHA is on the
 # feat/persona-peer-id-mint branch, not canary — reconcile to the canary SHA
 # when the airc PR lands. Re-validate persona attach on bump.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "816a0be" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/core/continuum-core/src/airc/inbound_attach.rs
+++ b/core/continuum-core/src/airc/inbound_attach.rs
@@ -108,20 +108,28 @@ fn persist_cursor(channel: &RoomId, cursor: &IpcCursor) {
     }
 }
 
+/// One page of recent room history on a first-ever attach (Joel, 2026-08-01:
+/// "When you join a Discord channel do you read the whole history from 10
+/// years back? No — one page"). The daemon streams the newest
+/// `FIRST_ATTACH_PAGE` backlog events at the catch-up seam and coalesces
+/// everything older into the watermark summary (airc PR #1312).
+const FIRST_ATTACH_PAGE: u32 = 32;
+
 /// Build the attach request for this consumer's cursor state (#295).
 ///
 /// A persisted watermark resumes strictly after it, streaming the gap
 /// event-by-event (those events were live while we were down — the
 /// transcript writer and perception both want them). No watermark means
 /// first-ever attach: start from the transcript head for cursor
-/// correctness, but coalesce the entire backlog into one summary frame
-/// so history never floods the bus, the personas, or the CPU.
+/// correctness, coalesce the deep backlog into one summary frame so history
+/// never floods the bus, the personas, or the CPU — but keep one page of
+/// recent tail so the room isn't a void on join.
 fn attach_request_for_cursor(channel: RoomId, cursor: Option<IpcCursor>) -> AttachRequest {
     match cursor {
         Some(cursor) => AttachRequest::new(channel, AttachStart::After(cursor)),
-        None => {
-            AttachRequest::new(channel, AttachStart::FromTranscriptStart).with_coalesced_backlog()
-        }
+        None => AttachRequest::new(channel, AttachStart::FromTranscriptStart)
+            .with_coalesced_backlog()
+            .with_backlog_tail(FIRST_ATTACH_PAGE),
     }
 }
 
@@ -498,6 +506,11 @@ mod tests {
         assert!(
             first.coalesces_backlog(),
             "first-ever attach must not replay full room history into live perception"
+        );
+        assert_eq!(
+            first.backlog_tail(),
+            Some(FIRST_ATTACH_PAGE),
+            "join shows one page back, not a void (airc PR #1312)"
         );
 
         let cursor = IpcCursor {


### PR DESCRIPTION
## Summary
Completes the #295 arc per Joel's Discord analogy: a fresh node's first attach now shows **one page of recent room history** (32 events) instead of either extreme — the old full-history storm (fixed in #2094) or #2094's zero-backlog void.

airc PR #1312 (merged, f01a3f4) added the `backlog_tail` knob: the daemon streams the newest N backlog events at the catch-up seam, coalescing older history into the watermark summary — tail delivered before the summary, so the #261 cursor discipline holds (a persisted watermark never skips an undelivered event).

## Changes
- All airc crate pins bumped together 816a0be → f01a3f4 (mixed revs = two airc-core versions = type clashes)
- `FIRST_ATTACH_PAGE = 32` on the no-cursor attach via `with_backlog_tail`
- Resumed attaches unchanged (gap replay stays uncoalesced, owed to the transcript writer)

## Testing
`inbound_attach` mod 9/9 green against the bumped rev; first-attach test now asserts the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo