### PR TITLE
fix(perception): kinds-filtered paging — personas hear direction while the room streams (#297)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f01a3f4#f01a3f4319f128b7acd6d7fa6fba363aa71d9aea"
+source = "git+https://github.com/CambrianTech/airc?rev=cf6e2c6#cf6e2c6ca74e8314cb1f2465cdc23cd883036991"
 dependencies = [
  "airc-core",
  "airc-store",
@@ -453,7 +453,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -464,7 +464,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3697,7 +3697,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4000,7 +4000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4850,7 +4850,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5516,7 +5516,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -7004,7 +7004,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9386,7 +9386,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10106,7 +10106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10615,7 +10615,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12397,7 +12397,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,18 +152,18 @@ exclude = ["wordstats", "work-wordstats", "conway_game_of_life", "work-08ece9e8"
 # personas load their stored peer_id unchanged. This SHA is on the
 # feat/persona-peer-id-mint branch, not canary — reconcile to the canary SHA
 # when the airc PR lands. Re-validate persona attach on bump.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "cf6e2c6" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "cf6e2c6" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "cf6e2c6" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "cf6e2c6" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "cf6e2c6" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "f01a3f4" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "cf6e2c6" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/core/continuum-core/src/airc/daemon_transport.rs
+++ b/core/continuum-core/src/airc/daemon_transport.rs
@@ -186,6 +186,11 @@ impl AircEventTransport for DaemonAircEventTransport {
                     .map(Into::into),
                 channel: Some(RoomId::from_uuid(params.room_id)),
                 limit: Some(params.limit.unwrap_or(MAX_ROOM_REPLAY_LIMIT)),
+                // Replay is a cursor-resume of the FULL wire (durable
+                // transcript hydration), not a perception page — no kinds
+                // filter here. Perception's message-only page lives in
+                // persona/airc_source.rs (#297).
+                kinds: None,
             })
             .await?;
 

--- a/core/continuum-core/src/context/airc_adapter.rs
+++ b/core/continuum-core/src/context/airc_adapter.rs
@@ -41,7 +41,9 @@ impl AircTranscriptReader for AircHandleAdapter {
         &self,
         limit: usize,
     ) -> Result<Vec<airc_lib::TranscriptEvent>, AircError> {
-        self.inner.page_recent(limit).await
+        // Route through the ONE kinds-filtered impl on `airc_lib::Airc`
+        // (persona/airc_source.rs, #297) — never the raw inherent page.
+        crate::persona::airc_source::AircTranscriptReader::page_recent(&*self.inner, limit).await
     }
 }
 

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -887,7 +887,9 @@ impl crate::persona::airc_source::AircTranscriptReader for PersonaAircRuntime {
         &self,
         limit: usize,
     ) -> Result<Vec<airc_lib::TranscriptEvent>, AircError> {
-        self.airc.page_recent(limit).await
+        // Route through the ONE kinds-filtered impl on `airc_lib::Airc`
+        // (persona/airc_source.rs, #297) — never the raw inherent page.
+        crate::persona::airc_source::AircTranscriptReader::page_recent(&*self.airc, limit).await
     }
 }
 

--- a/core/continuum-core/src/persona/airc_source.rs
+++ b/core/continuum-core/src/persona/airc_source.rs
@@ -58,17 +58,40 @@ use crate::cognition::token_budget::{estimate_prompt_tokens as estimate_tokens, 
 /// `airc_lib::Airc`; tests use a stub that returns canned events without a daemon.
 #[async_trait]
 pub trait AircTranscriptReader: Send + Sync {
-    /// Return up to `limit` most-recent transcript events, newest-first per airc
-    /// convention.
+    /// Return up to `limit` most-recent CONVERSATIONAL transcript events
+    /// (Message + Attachment), newest-first per airc convention.
+    ///
+    /// Kinds are filtered BEFORE the page limit (#297): a raw newest-`limit`
+    /// page counts ephemeral StreamChunk frames (~4/sec per talking persona),
+    /// so active residents' own streaming evicted every durable message from
+    /// their window within a minute — working personas were DEAF to direction
+    /// while the room was busy (glass-boxed live 2026-08-01: a resident asked
+    /// the same question 3× because four direction messages never entered her
+    /// page while the attach cursor advanced normally). The diagnostic
+    /// signature: cross-machine delivery perfect, local perception stale —
+    /// the wire is fine, the WINDOW is flooded. Presence / receipts /
+    /// lifecycle ride their own sources; this page is the room's
+    /// conversation, never its firehose.
     async fn page_recent(&self, limit: usize) -> Result<Vec<TranscriptEvent>, AircError>;
 }
 
-/// `airc_lib::Airc` satisfies the reader contract directly via its existing
-/// `page_recent` method. Orphan rule OK — the trait is ours.
+/// The kinds a perception page means: the room's conversation. ONE place
+/// (compression) — every reader impl funnels through the [`airc_lib::Airc`]
+/// impl below, which applies this filter.
+pub fn perception_page_filter() -> airc_lib::EventFilter {
+    let mut filter = airc_lib::EventFilter::current_room();
+    filter.kinds.insert(airc_core::TranscriptKind::Message);
+    filter.kinds.insert(airc_core::TranscriptKind::Attachment);
+    filter
+}
+
+/// `airc_lib::Airc` satisfies the reader contract via the kinds-filtered
+/// page (daemon-side newest-N-of-kind since airc PR #1314). Orphan rule OK —
+/// the trait is ours.
 #[async_trait]
 impl AircTranscriptReader for airc_lib::Airc {
     async fn page_recent(&self, limit: usize) -> Result<Vec<TranscriptEvent>, AircError> {
-        airc_lib::Airc::page_recent(self, limit).await
+        airc_lib::Airc::page_recent_filtered(self, perception_page_filter(), limit).await
     }
 }
 


### PR DESCRIPTION
## The bug
Working personas were deaf to direction: the perception page was raw newest-50 events, and persona turns stream ~4 chunk-frames/sec — active residents' own voices evicted every durable message from their window within a minute. Live signature: a resident asked the same question 3× while four direction messages sat undelivered in her page; cross-machine delivery was perfect (the wire was fine — the window was flooded). Sibling of the #2094 attach flood: same root, raw firehose into perception.

## Fix
- `perception_page_filter()` (Message + Attachment) at the ONE `AircTranscriptReader` impl on `airc_lib::Airc`; both delegates route through the trait impl (compression: one definition of what a perception page means)
- airc pins f01a3f4 → cf6e2c6 (airc PR #1314): `page_recent_filtered` pushes kinds down to the daemon — newest-N-of-kind, filtered BEFORE the limit
- Replay/hydration keeps `kinds: None` (durable transcript wants the full wire)

## Testing
`airc_source` + `inbound_attach` filters: 20/20 green against the bumped rev; cargo check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo