### PR TITLE
feat(voice): client keys the call by roomId — session_id == room_id (#193 slice B)

### DIFF
--- a/legacy/src/system/voice/server/VoiceOrchestratorRustBridge.ts
+++ b/legacy/src/system/voice/server/VoiceOrchestratorRustBridge.ts
@@ -20,6 +20,14 @@ export class VoiceOrchestratorRustBridge {
 	private static _instance: VoiceOrchestratorRustBridge | null = null;
 	private client: RustCoreIPCClient;
 	private connected = false;
+	// #193 slice B: the call IS its airc room, so every call-scoped wire verb is
+	// keyed by roomId — the server's canonical call id (slice A, PR #2095). The
+	// browser-tab sessionId is a WHO/WHERE-from axis, not a call identity; verbs
+	// that only receive it (onUtterance, endSession) translate through this map.
+	// The server's legacy-alias layer would also resolve untranslated ids, but a
+	// client that sends the canonical id is the cutover — the server's MIRROR
+	// ROOM probe going silent is slice B's done-signal.
+	private callRoomBySession = new Map<string, string>();
 
 	private constructor() {
 		this.client = new RustCoreIPCClient(getContinuumCoreSocketPath());
@@ -84,16 +92,22 @@ export class VoiceOrchestratorRustBridge {
 		});
 
 		const aiCount = rustParticipants.filter(p => p.participant_type !== 'human').length;
-		await this.client.voiceRegisterSession(sessionId, roomId, rustParticipants);
+		// The call is registered under roomId on BOTH wire fields (#193 slice B):
+		// session_id == room_id means the LiveKit call IS the airc room, no
+		// parallel identity. sessionId is remembered only to translate later
+		// verbs that still carry it.
+		this.callRoomBySession.set(sessionId, roomId);
+		await this.client.voiceRegisterSession(roomId, roomId, rustParticipants);
 
 		// Register AI participants with AIAudioBridge so speak() works when
 		// persona:response:generated fires. Without this, isInCall() returns false
-		// and AI responses are silently dropped.
+		// and AI responses are silently dropped. Keyed by roomId — the same
+		// canonical call id the Rust side serves speak-in-call under.
 		const bridge = getAIAudioBridge();
 		for (const p of rustParticipants) {
 			if (p.participant_type !== 'human') {
 				const user = userMap.get(p.user_id);
-				await bridge.joinCall(sessionId, p.user_id as UUID, user?.displayName || p.display_name);
+				await bridge.joinCall(roomId, p.user_id as UUID, user?.displayName || p.display_name);
 			}
 		}
 
@@ -108,7 +122,10 @@ export class VoiceOrchestratorRustBridge {
 		}
 
 		const rustEvent = {
-			session_id: event.sessionId,
+			// Translate the tab session to the canonical call id (== roomId,
+			// #193 slice B); an unknown session passes through untranslated and
+			// the server's legacy-alias layer resolves it.
+			session_id: this.callRoomBySession.get(event.sessionId) ?? event.sessionId,
 			speaker_id: event.speakerId,
 			speaker_name: event.speakerName,
 			speaker_type: event.speakerType,
@@ -130,10 +147,12 @@ export class VoiceOrchestratorRustBridge {
 			return;
 		}
 
+		const callId = this.callRoomBySession.get(sessionId) ?? sessionId;
+		this.callRoomBySession.delete(sessionId);
 		try {
-			await this.client.voiceEndSession(sessionId);
+			await this.client.voiceEndSession(callId);
 		} catch (err) {
-			console.error(`[VoiceOrchestratorRustBridge] Failed to end session ${sessionId}:`, err);
+			console.error(`[VoiceOrchestratorRustBridge] Failed to end session ${callId}:`, err);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
The legacy voice bridge now sends `roomId` as the call identity on every call-scoped wire verb: register uses `session_id == room_id` (the LiveKit call IS the airc room), AI audio joins key by the same canonical id, and a session→room map translates `onUtterance`/`endSession` which still receive the browser-tab session. The slice-A server alias layer (#2095) backstops unknown ids; the server's MIRROR ROOM probe going silent on the next live call is the done-signal.

## Notes
- Continues PR #2005's CallManager-keyed-by-RoomId direction; slice C (typed RoomId through the call plane + alias deletion) remains.
- Takes effect on the next legacy-shell restart (not the core deploy path).
- Legacy tree has 549 pre-existing tsc errors (#83 path-drift debt); this change adds none — the file's only diagnostic is its pre-existing line-9 import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo