### PR TITLE
fix(deploy): rebuild a swept core binary before exec — cache eviction is a supported event (#296)

### DIFF
--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -295,6 +295,32 @@ if [ -n "$CONTINUUM_RELEASE" ]; then
   PROFILE_LABEL="release"
 fi
 
+# ── #296 swept-artifact guard ────────────────────────────────────────
+# Cache eviction is a SUPPORTED event (CLAUDE.md disk doctrine): the shared
+# cargo cache's $PROFILE_LABEL/ dir can be swept while build/ + deps/ survive,
+# and an incremental `cargo build` then prints "Finished" from a warm
+# fingerprint WITHOUT restoring the missing binary (2026-08-01 incident:
+# `continuum reboot` reported success, `exec "$CORE_BIN"` died with "No such
+# file or directory", serving stayed down — fail-loud worked, self-heal
+# didn't). This is the self-heal: if the expected artifact file is missing,
+# say so loudly and re-run the SAME build invocation the script already uses
+# for that bin (a missing output forces cargo to re-link). Returns non-zero
+# if the artifact STILL doesn't exist — the caller decides fatality; no
+# silent fallback [[fallbacks-are-illegal-fail-loud]].
+# Args: 1=expected artifact path, 2=bin name, 3=manifest path,
+#       4+=profile/feature flags (pre-split by the caller, as elsewhere).
+ensure_unswept_bin() {
+  local bin_path="$1" bin_name="$2" manifest="$3"
+  shift 3
+  if [ -f "$bin_path" ]; then
+    return 0
+  fi
+  echo "▶ $bin_name missing from cargo cache (swept?) — rebuilding --bin $bin_name" >&2
+  cargo build --manifest-path "$manifest" --bin "$bin_name" "$@" \
+    || echo "⚠ swept-cache rebuild of $bin_name failed" >&2
+  [ -f "$bin_path" ]
+}
+
 # ── Build the continuum-mcp bin ──────────────────────────────────────
 # The MCP server is a separate stdio bin that MCP clients (unsloth Studio,
 # Claude Code) SPAWN — it isn't launched by us, so it must exist on disk after
@@ -326,6 +352,13 @@ cargo build --manifest-path "$CORE_MANIFEST" --bin continuum $PROFILE_FLAG $CONT
 # PATH always points at the current build. Copy atomically (temp + mv) so a `continuum`
 # invocation concurrent with a deploy never sees a half-written binary.
 CONTINUUM_CLI_BIN="$CARGO_TARGET_DIR/$PROFILE_LABEL/continuum"
+# #296: a swept cache can leave the build above "Finished" with no binary on
+# disk — restore it so the copy below has real bytes. Non-fatal (matches the
+# build's own warn): a missing CLI doesn't block core boot, and the installed
+# ~/.local/bin copy from the last deploy keeps working.
+if ! ensure_unswept_bin "$CONTINUUM_CLI_BIN" continuum "$CORE_MANIFEST" $PROFILE_FLAG $CONTINUUM_FEATURES; then
+  echo "⚠ continuum CLI still missing after swept-cache rebuild — CLI install skipped (core still launches)" >&2
+fi
 if [ -x "$CONTINUUM_CLI_BIN" ]; then
   CONTINUUM_LINK_DIR="$HOME/.local/bin"
   mkdir -p "$CONTINUUM_LINK_DIR"
@@ -371,6 +404,12 @@ fi
 echo "▶ building forge-custodian (Rust gguf-lora export sidecar)"
 cargo build --manifest-path "$CORE_MANIFEST" --bin forge-custodian $PROFILE_FLAG $CONTINUUM_FEATURES \
   || echo "⚠ forge-custodian build failed — genome gene-conversion unavailable (core still launches)" >&2
+# #296: the core spawns this bin later as a sibling of its own exe — a swept
+# cache that survives the build above would fail loud only at first gene
+# conversion. Restore it now; non-fatal, matching the build's own warn.
+if ! ensure_unswept_bin "$CARGO_TARGET_DIR/$PROFILE_LABEL/forge-custodian" forge-custodian "$CORE_MANIFEST" $PROFILE_FLAG $CONTINUUM_FEATURES; then
+  echo "⚠ forge-custodian still missing after swept-cache rebuild — genome gene-conversion unavailable (core still launches)" >&2
+fi
 
 # Build the server binary BEFORE stopping the old core, so the running core keeps
 # serving through the (cached, fast) compile and downtime is ~0.
@@ -391,6 +430,15 @@ cargo build --manifest-path "$CORE_MANIFEST" --bin continuum-core-server $PROFIL
 # launch a lie. [[verify-the-build-actually-deployed]], [[fallbacks-are-illegal-fail-loud]].
 CORE_SRC_DIR="$(dirname "$CORE_MANIFEST")/src"
 CORE_BIN="$CARGO_TARGET_DIR/$PROFILE_LABEL/continuum-core-server"
+# #296: THE incident bin. A swept debug/ dir let the build above print
+# "Finished" with no binary on disk, and `exec "$CORE_BIN"` died at the very
+# end while the deploy read as green. Restore it HERE — before the #194
+# freshness guard, so #194 asserts against a real file — and if the rebuild
+# STILL can't produce it, fail loud now instead of at exec.
+if ! ensure_unswept_bin "$CORE_BIN" continuum-core-server "$CORE_MANIFEST" $PROFILE_FLAG $CONTINUUM_FEATURES; then
+  echo "✗ FATAL #296: continuum-core-server missing at $CORE_BIN even after a swept-cache rebuild — refusing to exec a nonexistent binary (leaving any running core untouched)" >&2
+  exit 1
+fi
 core_bin_is_stale() { [ -f "$CORE_BIN" ] && [ -n "$(find "$CORE_SRC_DIR" -name '*.rs' -type f -newer "$CORE_BIN" 2>/dev/null | head -1)" ]; }
 if core_bin_is_stale; then
   echo "⚠ #194: continuum-core-server is STALE (a source is newer than the binary) — cargo missed an edit; busting fingerprint + rebuilding" >&2
@@ -438,6 +486,12 @@ start_livekit_rail() {
     echo "▶ building livekit-bridge sidecar (release — links webrtc-sys, first build is slow)…"
     cargo build --manifest-path "$REPO_ROOT/core/livekit-bridge/Cargo.toml" --bin livekit-bridge --release \
       || { echo "⚠ livekit-bridge build failed — live avatar/voice unavailable"; return 0; }
+    # #296: a swept cache can let cargo report success without the binary on
+    # disk — verify before nohup'ing a nonexistent path (rail is non-fatal).
+    if [ ! -x "$BRIDGE_BIN" ]; then
+      echo "⚠ livekit-bridge still missing at $BRIDGE_BIN after rebuild (swept cache?) — live avatar/voice unavailable"
+      return 0
+    fi
   fi
   if ! pgrep -f "livekit-bridge .*${SOCK}" >/dev/null 2>&1; then
     echo "▶ livekit-bridge sidecar starting ($SOCK → $LK_URL)"


### PR DESCRIPTION
## Incident (2026-08-01, glass-boxed)

Disk eviction swept the shared cargo cache's `debug/` dir (`build/` + `deps/` survived). `continuum reboot` ran an incremental cargo build that printed **"Finished dev profile" without restoring `debug/continuum-core-server`**, then `tools/scripts/start-server.sh`'s `exec "$CORE_BIN"` died with "No such file or directory" and serving stayed down. Fail-loud worked; self-heal didn't. Cache eviction is a SUPPORTED event (CLAUDE.md disk doctrine) — every deploy path must tolerate a swept artifact.

## Fix

One shared guard function, `ensure_unswept_bin` (matches the script's existing function style — `stop_existing_core`, `core_bin_is_stale`, `start_livekit_rail`):

- if the expected artifact file is missing, print `▶ <bin> missing from cargo cache (swept?) — rebuilding --bin <bin>` and re-run the **same cargo build invocation the script already uses** for that bin (same manifest / `$PROFILE_FLAG` / `$CONTINUUM_FEATURES`; a missing output forces cargo to re-link) — no new build shape;
- if the artifact STILL doesn't exist, return non-zero; the caller decides fatality. No fallback.

Applied to every artifact the script builds and later exec's/copies:

| Artifact | Guard | Fatality |
|---|---|---|
| `continuum-core-server` (`$CORE_BIN`) | between its build and the **#194 freshness guard**, so #194 asserts against a real file | **FATAL** — `✗ FATAL #296 … refusing to exec a nonexistent binary`, exits before touching the running core |
| `continuum` CLI (`$CONTINUUM_CLI_BIN`) | before the `~/.local/bin` copy | non-fatal warn (matches its build's own `⚠ … core still launches`) |
| `forge-custodian` | after its build | non-fatal warn (would otherwise fail loud only at first gene conversion) |
| `livekit-bridge` | rail already rebuilt on missing; added a post-rebuild existence check before `nohup "$BRIDGE_BIN"` | non-fatal (rail is non-fatal by design) |

`continuum-mcp` is untouched: it's neither exec'd nor copied by this script.

## Validation (honest scope)

- `bash -n tools/scripts/start-server.sh` — clean.
- The guard function was exercised **in isolation**: sed-extracted verbatim from the script into a scratchpad harness with a stubbed `cargo`, covering present / missing-then-restored / missing-still-missing / cargo-nonzero cases. All four behave as designed under `set -e`, and the stub confirmed the forwarded invocation shape (`build --manifest-path … --bin … --release --features x`).
- The **live shared cargo cache was deliberately NOT touched** to simulate the sweep — the running core depends on it — so there is no end-to-end reproduction in this PR; validation is syntax check + isolated function simulation + careful dry review of variable usage.

Fixes #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo