### PR TITLE
fix(persona): home room from HER durable membership — never the operator's focused room (#298)

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1860,8 +1860,6 @@ pub fn start_server(
             crate::modules::persona_instance_manager::PersonaInstanceManagerModule::new(
                 registry,
                 daemon_socket,
-                default_room,
-                persona_bootstrap_room_name.clone(),
                 continuum_root,
             ),
         );

--- a/core/continuum-core/src/modules/persona_instance_manager.rs
+++ b/core/continuum-core/src/modules/persona_instance_manager.rs
@@ -51,7 +51,6 @@ use std::any::Any;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use airc_core::RoomId;
 use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -115,8 +114,9 @@ pub struct PersonaInstanceInfo {
     /// Absolute path to the persona's airc home dir.
     #[ts(type = "string")]
     pub home: PathBuf,
-    /// The room the persona joined at bootstrap (currently always
-    /// the continuum-core's discovered default_room).
+    /// The persona's HOME room — her own durable subscription default,
+    /// resolved at bootstrap from HER airc home (fresh minds land in
+    /// `#general`), never the operator's discovered room (#298).
     #[ts(type = "string")]
     pub default_room: Uuid,
     /// Whether this citizen was resumed from disk or freshly
@@ -165,16 +165,15 @@ impl PersonaInstanceInfo {
 ///   [`birth_one`](PersonaBirth::birth_one) directly).
 ///
 /// It owns exactly the deps a birth needs — the live registry, the airc daemon socket,
-/// the default room (+ its name, so `Airc::join(name)` derives the canonical channel),
 /// the continuum root where homes are carved, and the late-bound substrate executor.
+/// (No room dep: a persona's home room comes from HER OWN durable subscription state —
+/// `Airc::current_room()` inside bootstrap — never from the operator's discovery, #298.)
 /// All are cheap-clone handles (`registry` is an `Arc<DashMap>`; `executor` is an
 /// `Arc<LateBound>`), so the copy the module holds and the copy `PersonaBirth` holds
 /// point at the SAME underlying state — one install of the executor reaches both.
 pub struct PersonaBirth {
     registry: PersonaAircRuntimeRegistry,
     daemon_socket: PathBuf,
-    default_room: RoomId,
-    default_room_name: Option<String>,
     continuum_root: PathBuf,
     executor: Arc<LateBound<crate::runtime::CommandExecutor>>,
     /// Late-bound event bus — installed from `ModuleContext` in
@@ -193,8 +192,6 @@ impl PersonaBirth {
     pub fn new(
         registry: PersonaAircRuntimeRegistry,
         daemon_socket: PathBuf,
-        default_room: RoomId,
-        default_room_name: Option<String>,
         continuum_root: PathBuf,
         executor: Arc<LateBound<crate::runtime::CommandExecutor>>,
         bus: Arc<LateBound<crate::runtime::MessageBus>>,
@@ -202,8 +199,6 @@ impl PersonaBirth {
         Self {
             registry,
             daemon_socket,
-            default_room,
-            default_room_name,
             continuum_root,
             executor,
             bus,
@@ -238,8 +233,6 @@ impl PersonaBirth {
             intent.agent_name.clone(),
             &self.continuum_root,
             self.daemon_socket.clone(),
-            self.default_room,
-            self.default_room_name.clone(),
             intent.source,
             executor,
         )
@@ -456,17 +449,17 @@ impl PersonaInstanceManagerModule {
     ///
     /// `registry` is shared (cheap to clone — internal `Arc<DashMap>`)
     /// so callers can hand other modules a view of the same roster.
-    /// `daemon_socket`, `default_room`, and `default_room_name` come
-    /// from [`crate::modules::airc::AircModule`]'s discovery:
-    /// [`daemon_socket`] / [`default_room`] / [`default_room_name`].
+    /// `daemon_socket` comes from
+    /// [`crate::modules::airc::AircModule`]'s discovery.
     /// `continuum_root` is where persona homes get carved out
     /// (typically `~/.continuum/`, env-overridable via
-    /// `CONTINUUM_ROOT`).
+    /// `CONTINUUM_ROOT`). No room dep (#298): each persona's home room
+    /// is her own durable subscription state, resolved inside
+    /// [`PersonaAircRuntime::bootstrap`] — never the operator's
+    /// discovered current room.
     pub fn new(
         registry: PersonaAircRuntimeRegistry,
         daemon_socket: PathBuf,
-        default_room: RoomId,
-        default_room_name: Option<String>,
         continuum_root: PathBuf,
     ) -> Self {
         let executor = Arc::new(LateBound::new("persona-instance-manager::executor"));
@@ -474,8 +467,6 @@ impl PersonaInstanceManagerModule {
         let birth = Arc::new(PersonaBirth::new(
             registry.clone(),
             daemon_socket, // birth-only dep — moved, not stored on the module
-            default_room,
-            default_room_name, // birth-only dep — moved
             continuum_root.clone(),
             executor.clone(),
             bus.clone(),
@@ -660,8 +651,6 @@ mod tests {
         let module = PersonaInstanceManagerModule::new(
             registry,
             PathBuf::from("/nonexistent/socket"),
-            RoomId::from_uuid(Uuid::nil()),
-            None,
             PathBuf::from("/tmp/continuum-test"),
         );
         let cfg = module.config();
@@ -686,8 +675,6 @@ mod tests {
         let module = PersonaInstanceManagerModule::new(
             PersonaAircRuntimeRegistry::new(),
             PathBuf::from("/nonexistent/socket"),
-            RoomId::from_uuid(Uuid::nil()),
-            None,
             PathBuf::from("/tmp/continuum-test"),
         );
         for command in ["persona/instances/list", "persona/instances/get"] {

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -109,10 +109,14 @@ pub enum PersonaAircRuntimeError {
         #[source]
         source: AircError,
     },
-    #[error("failed to join room {room_id} as persona {agent_name:?}: {source}")]
-    Join {
+    #[error(
+        "failed to resolve persona {agent_name:?}'s home room from her durable \
+         subscription state: {source} — a persona's rooms come from HER OWN airc \
+         home (fresh scopes land in #general), never from the operator's current \
+         room (#298)"
+    )]
+    HomeRoom {
         agent_name: String,
-        room_id: Uuid,
         #[source]
         source: AircError,
     },
@@ -254,9 +258,11 @@ impl PersonaAircRuntime {
     ///    (generate or load Ed25519 keypair, write `identity.key`,
     ///    record the local_identity row) and attaches a daemon
     ///    client for live publish + subscribe. No shelling out.
-    /// 3. Resolve the room by its UUID via `default_room.as_uuid()`
-    ///    and call `Airc::join(...)`. This makes the persona appear
-    ///    on `airc peers` as an enrolled participant of the room.
+    /// 3. Resolve her HOME room via `Airc::current_room()` — her OWN
+    ///    durable subscription default; a fresh scope lands in
+    ///    `#general` per airc's canonical fresh-scope semantics. This
+    ///    makes the persona appear on `airc peers` as an enrolled
+    ///    participant of HER room — never the operator's (#298).
     /// 4. Install the per-persona command inbound pump
     ///    ([`PersonaCommandInboundPump`](crate::persona::command_inbound_pump))
     ///    so this persona's airc handle starts receiving cross-grid
@@ -280,8 +286,6 @@ impl PersonaAircRuntime {
         agent_name: impl Into<String>,
         continuum_root: &Path,
         daemon_socket: PathBuf,
-        default_room: RoomId,
-        default_room_name: Option<String>,
         source: crate::persona::identity_provider::PersonaIdentitySource,
         executor: Arc<crate::runtime::command_executor::CommandExecutor>,
     ) -> Result<Self, PersonaAircRuntimeError> {
@@ -379,42 +383,29 @@ impl PersonaAircRuntime {
             "PersonaAircRuntime bootstrap: identity ready (persona_id == peer_id post-collapse)"
         );
 
-        // Join the default room. From the daemon's perspective the
-        // persona is now an enrolled participant — `airc peers`
-        // from another scope MUST list this peer_id.
+        // Resolve the persona's HOME room from her OWN durable
+        // subscription state — never from the operator's focus.
         //
-        // CRITICAL: `Airc::join(name)` calls `ChannelName::new(name)`
-        // which DERIVES a channel UUID from the name. If we pass the
-        // UUID-as-string of the operator's channel, that string gets
-        // interpreted as a name and produces a DIFFERENT channel.
-        // The persona then sits in the derived channel while the
-        // operator publishes into the canonical one — they never
-        // see each other. Joining by NAME (e.g. "continuum") lands
-        // both in the same channel. PR #1511 integration test caught
-        // this; demo binary in slice 11 reshaped via `from_attached`
-        // explicitly to work around the same hazard.
-        let join_target = match default_room_name.as_deref() {
-            Some(name) => name.to_string(),
-            None => {
-                tracing::warn!(
-                    persona_id = %persona_id,
-                    agent_name = %agent_name,
-                    room_id = %default_room.as_uuid(),
-                    "PersonaAircRuntime bootstrap: no default_room_name supplied — \
-                     falling back to joining by UUID-as-string, which derives a NEW \
-                     channel. Persona will likely land in the wrong room. Resolve: \
-                     ensure AircModule discovers default_room_name (via `airc room` \
-                     output's `room: <name>` line) and threads it through here.",
-                );
-                default_room.as_uuid().to_string()
-            }
-        };
+        // Task #298 (Joel: "we can't launch with these hacked rooms"):
+        // bootstrap used to join the room the OPERATOR's daemon happened
+        // to have current (`airc room` discovery), so every persona born
+        // on a machine was dumped into whatever coordination room the
+        // human/agent CLI last focused — live-found with the whole
+        // resident population squatting in `k3-serving`, an MoE-serving
+        // coordination room, because the operator scope was parked there.
+        // A persona is her own airc peer with her own home dir;
+        // `current_room()` loads HER durable subscription set (the same
+        // state `Airc::join` writes), returns her established default,
+        // and on a FRESH scope applies airc's canonical landing-room
+        // semantics: subscribe to `#general`, set it default, publish
+        // presence + identity card. Resumed personas keep their real
+        // membership; new minds land in the commons. The operator's
+        // current-room pointer no longer exists on this path.
         let room = airc
-            .join(&join_target)
+            .current_room()
             .await
-            .map_err(|source| PersonaAircRuntimeError::Join {
+            .map_err(|source| PersonaAircRuntimeError::HomeRoom {
                 agent_name: agent_name.clone(),
-                room_id: default_room.as_uuid(),
                 source,
             })?;
 
@@ -713,7 +704,10 @@ impl PersonaAircRuntime {
             agent_name,
             home,
             airc: airc_arc,
-            default_room,
+            // The ACTUALLY-joined home room (from her durable subscription
+            // state above) — before #298 this stored the passed-in operator
+            // room, which could even diverge from the joined channel.
+            default_room: RoomId::from_uuid(room.channel.as_uuid()),
             inbound_handle: None,
             command_pump: Some(command_pump),
             heartbeat,
@@ -1077,8 +1071,6 @@ mod tests {
             "maya",
             root,
             PathBuf::from("/nonexistent/daemon.sock"),
-            RoomId::from_uuid(Uuid::new_v4()),
-            None,
             crate::persona::identity_provider::PersonaIdentitySource::FreshlyMinted,
             dummy_executor,
         )

--- a/core/continuum-core/src/persona/spawner_module.rs
+++ b/core/continuum-core/src/persona/spawner_module.rs
@@ -50,7 +50,6 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::any::Any;
-use std::sync::Arc;
 
 /// One row in the spawner's resolved plan: a desired persona slot for
 /// the configured hardware tier, with its model already selected.
@@ -599,12 +598,10 @@ mod tests {
 
         // The bootstrapper is never reached because provider exhausts
         // first — its construction can be cheap-and-unreachable.
-        // continuum_root/daemon_socket/default_room never get touched.
+        // continuum_root/daemon_socket never get touched.
         let instance_manager = PersonaInstanceManagerModule::new(
             crate::persona::PersonaAircRuntimeRegistry::default(),
             PathBuf::from("/dev/null/unused"),
-            airc_core::RoomId::from_uuid(uuid::Uuid::nil()),
-            None,
             PathBuf::from("/dev/null/unused"),
         );
 


### PR DESCRIPTION
## The bug (Joel: "we can't launch with these hacked rooms")

Every persona on a machine was born into — and re-joined on every boot to — whatever room the **operator's** airc CLI happened to have focused. `discover_default_room_name()` parses `airc room` (the operator scope's current-room pointer) and bootstrap force-joined it. With the operator scope parked in `k3-serving` for MoE coordination, the entire resident population squatted in a coordination room, colliding Conway chatter, wordstats work, and agent coordination in one channel. Bonus defect: the runtime stored the passed-in `RoomId`, not the actually-joined channel — silently divergeable.

## The fix

- `PersonaAircRuntime::bootstrap` resolves the home room via `airc.current_room()` — the persona's **own durable subscription default**, from HER airc home. Fresh scopes get airc's canonical landing semantics: subscribe `#general`, set default, publish presence + identity card. Resumed personas keep their real membership.
- `default_room` / `default_room_name` **deleted** from bootstrap, `PersonaBirth`, and `PersonaInstanceManagerModule::new` — the deleted parameters are the regression guard: there is no way left to thread an operator room into a birth.
- Runtime stores the actually-joined room (fixes the divergence).
- Operator/node surfaces (grid-capacity gossip, nav seed, node presence emitter) still ride the discovered room — that's the operator plane, unchanged by design.

## Testing

- `cargo check -p continuum-core --lib --features metal,accelerate` clean (no new warnings; removed one dead import each in the two touched files).
- Fresh-scope → `#general` is airc-lib's own tested `current_room()` contract (crates/airc-lib/src/airc.rs).
- Live validation after deploy: existing resident homes get a one-time heal (`airc part` k3-serving — tombstoned so nothing re-adds it), then reboot and confirm residents perceive/speak in their own rooms.

Task #298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo