### PR TITLE
feat(serving): vision sidecar lane — every persona gets eyes beside a text-only mind (#106)

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -1998,7 +1998,16 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         // the wrong thing to consult. Skip the guard for a lane we own.
         if self.config.single_resident_model && !self.dedicated_lane {
             let snap = crate::inference::llama_server::current_serving();
-            if !snap.ready || snap.active_model.as_deref() != Some(model) {
+            // The snapshot guarantees TWO residencies: the main lane's active
+            // model, and (when published) the verified vision endpoint's model —
+            // the #106 sidecar lane beside a text-only mind. A request for the
+            // sidecar's model is exactly as guaranteed as one for the active
+            // model (the daemon verified its `/props` before publishing), and
+            // `endpoints_for_model` routes it to `vision_base_url`.
+            let guaranteed = snap.ready
+                && (snap.active_model.as_deref() == Some(model)
+                    || (snap.vision_ready && snap.vision_model.as_deref() == Some(model)));
+            if !guaranteed {
                 return Err(format!(
                     "{}: model '{}' is not the active served model (serving: {}, ready: {}); \
                      the serving daemon owns which single model is resident — refusing to \

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -455,6 +455,30 @@ impl OpenAICompatibleAdapter {
         OpenAiBase::new(raw)
     }
 
+    /// The endpoint base for a SPECIFIC requested model. Same as [`Self::endpoints`]
+    /// except for the local serving gateway when the requested model is the
+    /// serving snapshot's VISION model but not its main-lane model: that is the
+    /// #106 vision SIDECAR (a VL lane beside a text-only mind), and the request
+    /// routes to the snapshot's verified `vision_base_url`. Driven entirely by
+    /// the ONE published snapshot (id-equality against the gateway's canonical
+    /// [`PROVIDER_ID`](crate::inference::llama_server::PROVIDER_ID) const — no
+    /// name sniffing), and the address exists only when `/props` confirmed
+    /// sight, so pixels can never be aimed at a text lane.
+    fn endpoints_for_model(&self, model: &str) -> OpenAiBase {
+        if self.config.provider_id == crate::inference::llama_server::PROVIDER_ID {
+            let snap = crate::inference::llama_server::current_serving();
+            if snap.vision_ready
+                && snap.vision_model.as_deref() == Some(model)
+                && snap.active_model.as_deref() != Some(model)
+            {
+                if let Some(url) = snap.vision_base_url.as_deref() {
+                    return OpenAiBase::new(url);
+                }
+            }
+        }
+        self.endpoints()
+    }
+
     /// Fetch the live model list from the provider's /v1/models endpoint.
     /// Used by adapters that have dynamic catalogs (DMR above all — the list
     /// changes every time the user runs `docker model pull`). Populates
@@ -1888,8 +1912,13 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
             }
         }
 
-        // Make request - use runtime base URL if set, otherwise config base URL
-        let url = self.endpoints().chat_completions();
+        // Make request — the endpoint base for THIS request's model. Normally the
+        // runtime/config base; for the local serving gateway, a request for the
+        // snapshot's VISION model (the #106 sidecar lane serving beside a
+        // text-only mind) routes to the snapshot's verified `vision_base_url`.
+        // Snapshot-driven: the daemon publishes the address only after `/props`
+        // confirmed sight, so this can never aim pixels at a text lane.
+        let url = self.endpoints_for_model(&model).chat_completions();
 
         let mut request_builder = self
             .client

--- a/core/continuum-core/src/cognition/vision_describe.rs
+++ b/core/continuum-core/src/cognition/vision_describe.rs
@@ -175,20 +175,24 @@ fn llama_server_row_ready(
     if !snap.ready || snap.active_model.is_none() {
         return Err("serving lane has no ready model".to_string());
     }
-    if snap.active_model.as_deref() != Some(model_id) {
-        return Err(format!(
-            "serving lane is occupied by {:?}, not this vision row — pin/pull it to bring \
-             vision up (`models/pull` + `serving/pin`)",
-            snap.active_model.as_deref().unwrap_or("<none>")
-        ));
-    }
+    // The node's ONE verified vision endpoint (#106): the main lane when the
+    // mind's model itself sees, or the SIDECAR lane beside a text-only mind.
+    // A row is servable iff it IS that endpoint's model — the snapshot's
+    // vision fields are projected from a single verified value, so this check
+    // covers both shapes without caring which lane answers.
     if !snap.vision_ready {
         return Err(
-            "lane serves this model but its multimodal endpoint is NOT verified \
-             (mmproj missing or /props reports no vision modality) — see the serving \
-             daemon's `serving.vision.*` probes for the reason"
+            "no verified vision endpoint on this node (main lane is text-only and no \
+             sidecar came up) — see the serving daemon's `serving.vision.*` probes for \
+             the reason (`models/pull` a *-VL-*-GGUF repo to enable the sidecar)"
                 .to_string(),
         );
+    }
+    if snap.vision_model.as_deref() != Some(model_id) {
+        return Err(format!(
+            "the verified vision endpoint serves {:?}, not this row",
+            snap.vision_model.as_deref().unwrap_or("<none>")
+        ));
     }
     Ok(())
 }
@@ -659,35 +663,41 @@ mod tests {
         assert_eq!(picked.model_id, "local-llava");
     }
 
-    // what this catches (#106): the observe path may route to the local serving lane
-    // ONLY when the lane is ready, serving THIS model, and its multimodal endpoint is
-    // VERIFIED (`vision_ready`). A regression that accepts a ready-but-unverified lane
-    // re-opens the capability lie (images POSTed to a text-only lane, silently
-    // dropped); one that accepts a different active model re-opens the pre-#106 bug
-    // where every observe act died at select() while a good lane sat elsewhere.
+    // what this catches (#106): the observe path may route to the local serving
+    // gateway ONLY when the node has a VERIFIED vision endpoint AND this row IS
+    // that endpoint's model — the main lane when the mind's model itself sees, or
+    // the vision SIDECAR beside a text-only mind. A regression that accepts an
+    // unverified node re-opens the capability lie (images POSTed to a text-only
+    // lane, silently dropped); one that accepts a row the endpoint doesn't serve
+    // aims pixels at the wrong model.
     #[test]
-    fn llama_server_row_is_servable_only_when_active_ready_and_vision_verified() {
+    fn llama_server_row_is_servable_only_when_it_is_the_verified_vision_endpoint() {
         use crate::inference::llama_server::ServingSnapshot;
         let mut snap = ServingSnapshot::empty();
 
         // Nothing serving → not servable.
         assert!(llama_server_row_ready("vl-model", &snap).is_err());
 
-        // Ready but the lane serves a DIFFERENT model → not servable, and the
-        // reason names the occupant (the operator's pin/pull hint).
+        // Ready text-only mind, no sidecar → no verified endpoint anywhere; the
+        // reason teaches the fix (pull a VL repo to enable the sidecar).
         snap.ready = true;
         snap.active_model = Some("coder-14b".into());
         snap.vision_ready = false;
         let err = llama_server_row_ready("vl-model", &snap).unwrap_err();
-        assert!(err.contains("coder-14b"), "{err}");
+        assert!(err.contains("no verified vision endpoint"), "{err}");
+        assert!(err.contains("sidecar"), "teaches the sidecar path: {err}");
 
-        // Serving this model but multimodal endpoint NOT verified → not servable.
-        snap.active_model = Some("vl-model".into());
-        let err = llama_server_row_ready("vl-model", &snap).unwrap_err();
-        assert!(err.contains("NOT verified"), "{err}");
-
-        // All three facts line up → servable.
+        // SIDECAR shape: text mind stays active, the verified endpoint is the
+        // sidecar's model → the VL row is servable, the mind's row is not.
         snap.vision_ready = true;
+        snap.vision_base_url = Some("http://127.0.0.1:58091/v1".into());
+        snap.vision_model = Some("vl-model".into());
+        assert!(llama_server_row_ready("vl-model", &snap).is_ok());
+        let err = llama_server_row_ready("coder-14b", &snap).unwrap_err();
+        assert!(err.contains("vl-model"), "names the endpoint's real model: {err}");
+
+        // MAIN-LANE shape: a VL mind — the endpoint IS the active model.
+        snap.active_model = Some("vl-model".into());
         assert!(llama_server_row_ready("vl-model", &snap).is_ok());
     }
 

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -533,6 +533,21 @@ pub struct ServingSnapshot {
     /// persisted snapshots (pre-#106) readable as not-vision-ready.
     #[serde(default)]
     pub vision_ready: bool,
+    /// The `/v1` base url of the VERIFIED vision endpoint on this node — the
+    /// address the observation path routes image bytes to. When the MAIN lane's
+    /// model itself sees, this is `base_url`; when a vision SIDECAR lane serves
+    /// beside a text-only mind (#106, `vision_sidecar`), it is the sidecar's
+    /// own url. `None` exactly when `vision_ready == false` — an address is
+    /// only ever published for an endpoint whose `/props` confirmed sight.
+    #[serde(default)]
+    #[ts(optional)]
+    pub vision_base_url: Option<String>,
+    /// The model id the verified vision endpoint serves — what the describe
+    /// path selects and stamps on its result. Same `None`-iff-not-ready
+    /// contract as `vision_base_url`.
+    #[serde(default)]
+    #[ts(optional)]
+    pub vision_model: Option<String>,
 }
 
 impl ServingSnapshot {
@@ -553,6 +568,8 @@ impl ServingSnapshot {
             degraded_reason: None,
             // Nothing served → nothing can see.
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         }
     }
 
@@ -1310,6 +1327,20 @@ impl EphemeralServingLane {
     /// the server is up but `/props` is unreadable — never a guessed window.
     pub async fn served_context_window(&self) -> Result<u32, LlamaServerError> {
         self.proc.served_context_window().await
+    }
+
+    /// The running lane's own `/props modalities` verdict — the #106 endpoint
+    /// truth, delegated to the child probe. `Ok(None)` = this llama-server
+    /// build publishes no modalities block (unverifiable ≠ working).
+    pub async fn multimodal_support(&self) -> Result<Option<MultimodalSupport>, LlamaServerError> {
+        LlamaServerControl::multimodal_support(&self.proc).await
+    }
+
+    /// The model id this lane actually serves (its `/v1/models` alias) — for
+    /// incumbent verification against the process's own report, never our spawn
+    /// memory.
+    pub async fn active_model(&self) -> Result<Option<String>, LlamaServerError> {
+        LlamaServerControl::active_model(&self.proc).await
     }
 }
 
@@ -2524,6 +2555,8 @@ mod tests {
             lanes: 0,
             degraded_reason: None,
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         });
         assert!(!pred(&rx.borrow()));
         // not-ready but has a model → unsatisfied.
@@ -2536,6 +2569,8 @@ mod tests {
             lanes: 0,
             degraded_reason: None,
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         });
         assert!(!pred(&rx.borrow()));
         // ready AND a model → satisfied, and wait_for resolves to it at once.
@@ -2548,6 +2583,8 @@ mod tests {
             lanes: 0,
             degraded_reason: None,
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         });
         let got = tokio::time::timeout(Duration::from_millis(100), rx.wait_for(pred))
             .await

--- a/core/continuum-core/src/inference/mod.rs
+++ b/core/continuum-core/src/inference/mod.rs
@@ -54,6 +54,7 @@ pub mod ort_providers;
 pub mod placement_capture;
 pub mod recipe_budget;
 pub mod throughput_expectation;
+pub mod vision_sidecar;
 pub mod vendored;
 
 // Re-export commonly used types

--- a/core/continuum-core/src/inference/vision_sidecar.rs
+++ b/core/continuum-core/src/inference/vision_sidecar.rs
@@ -1,0 +1,305 @@
+//! Vision SIDECAR lane (#106): a small VL model serving BESIDE the persona lane
+//! so every persona has eyes even when the mind's own model is text-only.
+//!
+//! The main lane serves ONE model (the residents' mind — e.g. Devstral). A
+//! text-only mind cannot receive pixels, and the sensory bridge
+//! (`VisionDescriptionService` → `cognition/vision-describe`) needs a
+//! vision-capable endpoint to turn an observe/look image into words. Before
+//! this module, a headless box with a text mind had NO local vision endpoint:
+//! `vision_ready: false`, every describe skipped all candidates, and the
+//! persona's eyes (the connected eye-node, `perception/observe`) delivered
+//! pixels nobody could interpret.
+//!
+//! The sidecar reuses [`EphemeralServingLane`] (the eval-lane primitive:
+//! Drop-kills its child, own scanned port, never touches the live lane) but
+//! holds it LONG-LIVED under the serving daemon's ownership. Placement is
+//! [`LanePlacement::Cpu`] by design, not fallback: on a single GPU two resident
+//! models OOM the Metal command buffer at decode (#59/#175 lesson), and a
+//! describe is an occasional, seconds-tolerant call — the misfit-toy CPU RAM is
+//! the right home. Promotion to a governed GPU share is the #173/#126 arc.
+//!
+//! Decision logic is PURE (unit-tested); the daemon calls [`ensure_sidecar`]
+//! from its reconcile with the decision's plan. Every "no" is a NAMED reason
+//! probed loud — a persona without eyes is a diagnosable state, never a silent
+//! one ([[fallbacks-are-illegal-fail-loud]]).
+
+use std::path::PathBuf;
+
+use crate::inference::llama_server::{
+    vision_lane_ready, EphemeralServingLane, LanePlacement, ServingTarget,
+};
+use crate::model_registry::types::Model;
+use crate::model_registry::Capability;
+
+/// Port scan base for the vision sidecar — decimal-distant from the live lane
+/// (58057) and the eval lane's scan range so a port-collision never routes a
+/// describe at the wrong model.
+pub const VISION_SIDECAR_BASE_PORT: u16 = 58091;
+
+/// The sidecar's served window. Describe prompts are ONE image + a short
+/// instruction; 8k covers the multimodal tokenization of a full-detail frame
+/// with generous margin while keeping the KV cost trivial.
+pub const SIDECAR_CTX: u32 = 8192;
+
+/// Host-RAM margin the sidecar demands beyond its weights: mmproj + KV at
+/// [`SIDECAR_CTX`] + llama.cpp compute buffers, rounded up. A gate on REAL free
+/// bytes, per the eval-lane lesson ([[eval-lane-second-24b-cannot-coexist]]):
+/// planning from a stale or optimistic figure SIGKILLs a lane mid-load.
+pub const SIDECAR_OVERHEAD_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// A vision row that can actually stand up as the sidecar: artifacts ON DISK
+/// (no network fetch inside a reconcile — `models/pull` is the operator/persona
+/// verb for that), projector included.
+#[derive(Debug, Clone)]
+pub struct SidecarCandidate {
+    pub model: Model,
+    pub gguf: PathBuf,
+    pub mmproj: PathBuf,
+    /// Weights size on disk — the dominant term of the budget gate.
+    pub weights_bytes: u64,
+}
+
+/// Why no sidecar can (or need) come up. Every variant is a teaching string in
+/// the probe — the difference between "personas are blind" and "personas are
+/// blind BECAUSE X; do Y".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SidecarVerdict {
+    /// The MAIN lane already sees (a VL mind) — no sidecar needed.
+    MainLaneSees,
+    /// Stand this candidate up.
+    Spawn,
+    /// No local vision row has its artifacts on disk. Names what was skipped.
+    NoCandidate { skipped: Vec<String> },
+    /// A candidate exists but free host memory can't hold it alongside the
+    /// live lane. Real numbers, so the operator sees the actual gap.
+    NoBudget { need_bytes: u64, free_bytes: u64 },
+}
+
+/// Pure decision: should the daemon stand up a vision sidecar this reconcile?
+///
+/// `main_vision_ready` is the reconcile's verdict on the LIVE lane;
+/// `candidate` is the best on-disk vision row (or the skip reasons);
+/// `free_host_bytes` is the LIVE available-memory read (never a cached plan
+/// figure — the eval-lane SIGKILL lesson).
+pub fn plan_sidecar(
+    main_vision_ready: bool,
+    candidate: Result<&SidecarCandidate, &[String]>,
+    free_host_bytes: u64,
+) -> SidecarVerdict {
+    if main_vision_ready {
+        return SidecarVerdict::MainLaneSees;
+    }
+    match candidate {
+        Err(skipped) => SidecarVerdict::NoCandidate {
+            skipped: skipped.to_vec(),
+        },
+        Ok(c) => {
+            let need = c.weights_bytes.saturating_add(SIDECAR_OVERHEAD_BYTES);
+            if free_host_bytes < need {
+                SidecarVerdict::NoBudget {
+                    need_bytes: need,
+                    free_bytes: free_host_bytes,
+                }
+            } else {
+                SidecarVerdict::Spawn
+            }
+        }
+    }
+}
+
+/// Find the best on-disk vision candidate among `rows`, excluding the model the
+/// MAIN lane serves (that case is `MainLaneSees` or "pin it" territory, never a
+/// duplicate second copy of the same weights). Returns the first row whose GGUF
+/// AND mmproj both resolve locally, or the named skip reasons for the probe.
+pub fn find_candidate(
+    rows: &[Model],
+    active_model: Option<&str>,
+) -> Result<SidecarCandidate, Vec<String>> {
+    let mut skipped = Vec::new();
+    for m in rows {
+        if !m.has(Capability::Vision) {
+            continue;
+        }
+        if active_model == Some(m.id.as_str()) {
+            skipped.push(format!("{}: is the main lane's model", m.id));
+            continue;
+        }
+        let Some(gguf) = crate::model_registry::artifacts::resolve_gguf_for_model(m) else {
+            skipped.push(format!("{}: no local GGUF", m.id));
+            continue;
+        };
+        let Some(mmproj) = crate::model_registry::artifacts::resolve_mmproj_for_model(m) else {
+            skipped.push(format!("{}: no mmproj projector on disk", m.id));
+            continue;
+        };
+        let weights_bytes = std::fs::metadata(&gguf).map(|md| md.len()).unwrap_or(0);
+        if weights_bytes == 0 {
+            skipped.push(format!("{}: GGUF unreadable/empty at {}", m.id, gguf.display()));
+            continue;
+        }
+        return Ok(SidecarCandidate {
+            model: m.clone(),
+            gguf,
+            mmproj,
+            weights_bytes,
+        });
+    }
+    Err(skipped)
+}
+
+/// The verified, live sidecar the snapshot publishes: the routing address and
+/// the model it serves. Existence == the multimodal endpoint ANSWERED
+/// (`/props modalities.vision`), never just "a process spawned".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SidecarLane {
+    pub base_url: String,
+    pub model_id: String,
+}
+
+/// Bring the sidecar up (or verify the existing one), long-lived in `slot`.
+///
+/// Idempotent per reconcile tick: an existing lane serving the planned model
+/// whose multimodal endpoint still answers is kept as-is (no churn); a dead,
+/// wrong-model, or sight-lost lane is dropped (child killed via `Drop`) and
+/// respawned. Any failure returns the NAMED reason and leaves `slot` empty —
+/// the snapshot then publishes `vision_ready: false` honestly.
+pub async fn ensure_sidecar(
+    slot: &mut Option<EphemeralServingLane>,
+    cand: &SidecarCandidate,
+) -> Result<SidecarLane, String> {
+    // Keep a healthy incumbent: same model + endpoint still claims sight.
+    if let Some(existing) = slot.as_ref() {
+        match existing.multimodal_support().await {
+            Ok(props) => {
+                let verified = vision_lane_ready(true, true, props).unwrap_or(false);
+                if verified && existing.active_model().await.ok().flatten().as_deref()
+                    == Some(cand.model.id.as_str())
+                {
+                    return Ok(SidecarLane {
+                        base_url: existing.v1_url(),
+                        model_id: cand.model.id.clone(),
+                    });
+                }
+            }
+            Err(_) => { /* dead lane — fall through to respawn */ }
+        }
+        // Wrong model / lost sight / unreachable: drop kills the child.
+        *slot = None;
+    }
+
+    let target = ServingTarget {
+        model: cand.model.clone(),
+        context_window: SIDECAR_CTX,
+        lanes: 1,
+        adapters: Vec::new(),
+        placement: LanePlacement::Cpu,
+        expert_placement: None,
+    };
+    let lane = EphemeralServingLane::spawn(&target, VISION_SIDECAR_BASE_PORT)
+        .await
+        .map_err(|e| format!("sidecar spawn failed: {e}"))?;
+
+    // ENDPOINT truth (#106): only the process itself can confirm the projector
+    // loaded. Unverifiable ≠ working.
+    let props = lane
+        .multimodal_support()
+        .await
+        .map_err(|e| format!("sidecar up but /props unreadable: {e}"))?;
+    match vision_lane_ready(true, true, props) {
+        Ok(true) => {
+            let out = SidecarLane {
+                base_url: lane.v1_url(),
+                model_id: cand.model.id.clone(),
+            };
+            *slot = Some(lane);
+            Ok(out)
+        }
+        Ok(false) => Err("sidecar row lost its Vision declaration mid-spawn".to_string()),
+        Err(why) => Err(format!("sidecar cannot verifiably see: {why}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_registry::types::Model;
+
+    fn vision_row(id: &str) -> Model {
+        use crate::model_registry::types::{Arch, MultiPartyChatStrategy};
+        let mut capabilities = std::collections::BTreeSet::new();
+        capabilities.insert(Capability::Vision);
+        Model {
+            id: id.to_string(),
+            name: None,
+            provider: crate::inference::llama_server::PROVIDER_ID.to_string(),
+            arch: Arch::Qwen2,
+            context_window: 32_768,
+            max_output_tokens: 4096,
+            tokens_per_second: 0.0,
+            capabilities,
+            cost_input_per_1k: 0.0,
+            cost_output_per_1k: 0.0,
+            gguf_hint: None,
+            hf_source: None,
+            gguf_local_path: None,
+            chat_template: None,
+            stop_sequences: Vec::new(),
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            mmproj_local_path: None,
+            parameter_count: 0,
+            sampling: crate::model_registry::types::ModelSampling::default(),
+            persona_serving_eligible: true,
+        }
+    }
+
+    // what this catches: the sidecar must never duplicate the main lane's model
+    // (a second copy of the same weights) and must skip rows with no on-disk
+    // artifacts WITH a named reason — the difference between diagnosable
+    // blindness and silent blindness.
+    #[test]
+    fn candidate_skips_active_model_and_names_artifact_gaps() {
+        let rows = vec![vision_row("vl-model-a"), vision_row("vl-model-b")];
+        let out = find_candidate(&rows, Some("vl-model-a"));
+        // Neither resolves artifacts in a test env; the ACTIVE one is skipped
+        // for being active, the other for missing artifacts.
+        let skipped = out.expect_err("no artifacts on disk in tests");
+        assert!(skipped.iter().any(|s| s.contains("is the main lane's model")));
+        assert!(skipped.iter().any(|s| s.contains("no local GGUF")));
+    }
+
+    // what this catches: the budget gate compares REAL free bytes against
+    // weights + overhead — an over-budget spawn is refused with both numbers
+    // (the eval-lane second-24B SIGKILL class), and a seeing main lane never
+    // spawns a redundant sidecar.
+    #[test]
+    fn plan_gates_on_budget_and_main_lane_sight() {
+        let cand = SidecarCandidate {
+            model: vision_row("vl"),
+            gguf: PathBuf::from("/x.gguf"),
+            mmproj: PathBuf::from("/x-mmproj.gguf"),
+            weights_bytes: 5 * 1024 * 1024 * 1024,
+        };
+        // Main lane sees → no sidecar regardless of budget.
+        assert_eq!(
+            plan_sidecar(true, Ok(&cand), u64::MAX),
+            SidecarVerdict::MainLaneSees
+        );
+        // Not enough free RAM → refused with the real gap.
+        let need = cand.weights_bytes + SIDECAR_OVERHEAD_BYTES;
+        assert_eq!(
+            plan_sidecar(false, Ok(&cand), need - 1),
+            SidecarVerdict::NoBudget {
+                need_bytes: need,
+                free_bytes: need - 1
+            }
+        );
+        // Enough → spawn.
+        assert_eq!(plan_sidecar(false, Ok(&cand), need), SidecarVerdict::Spawn);
+        // No candidate → the named reasons ride through.
+        let reasons = vec!["vl: no local GGUF".to_string()];
+        assert_eq!(
+            plan_sidecar(false, Err(&reasons), u64::MAX),
+            SidecarVerdict::NoCandidate { skipped: reasons }
+        );
+    }
+}

--- a/core/continuum-core/src/modules/serving_consumer.rs
+++ b/core/continuum-core/src/modules/serving_consumer.rs
@@ -348,6 +348,8 @@ mod tests {
             lanes: 4,
             degraded_reason: None,
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         });
         let (suppress_tx, _srx) = watch::channel(Arc::new(HashSet::new()));
         let (pin_tx, _prx) = watch::channel(None);
@@ -433,6 +435,8 @@ mod tests {
             lanes: 3,
             degraded_reason: None,
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         });
         let footprint_of: FootprintFn = Arc::new(move |id: &str, window: u32, lanes: u32| {
             *seen_w.lock() = Some((id.to_string(), window, lanes));
@@ -525,6 +529,8 @@ mod tests {
             lanes: 4,
             degraded_reason: None,
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         });
         let (suppress_tx, _srx) = watch::channel(Arc::new(HashSet::new()));
         let (pin_tx, pin_rx) = watch::channel(None);

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -254,6 +254,13 @@ pub struct ServingDaemonModule {
     /// that fit at pin time; budget can still shift under it, and then the plan
     /// degrades honestly (`fits_on_gpu = false`) rather than over-committing.
     pinned: watch::Sender<Option<String>>,
+    /// The long-lived vision SIDECAR lane (#106, `inference::vision_sidecar`):
+    /// a small VL model serving beside a text-only mind so every persona has
+    /// eyes. Owned here so it lives across reconciles and its child dies with
+    /// the daemon (`EphemeralServingLane` Drop-kills). A tokio Mutex because
+    /// [`vision_sidecar::ensure_sidecar`] awaits (spawn + `/props` verify)
+    /// inside the reconcile task while holding the slot.
+    vision_sidecar: Arc<tokio::sync::Mutex<Option<crate::inference::llama_server::EphemeralServingLane>>>,
 }
 
 impl ServingDaemonModule {
@@ -320,6 +327,7 @@ impl ServingDaemonModule {
                 "K3_MEASURE_FORCE_EXPERT_BUDGET_BYTES",
             )
             .and_then(|s| s.trim().parse::<u64>().ok()),
+            vision_sidecar: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 
@@ -946,6 +954,8 @@ impl ServingDaemonModule {
         let serving_tx = self.serving_tx.clone();
         let reconciling = self.reconciling.clone();
         let bus = self.bus.get().cloned();
+        let sidecar_slot = self.vision_sidecar.clone();
+        let system = self.system.clone();
         // RAII gate-clear (#214): the `reconciling` flag was set `true` at the top of this
         // reconcile and MUST clear even if the relaunch task panics or is cancelled
         // mid-await — otherwise ONE failed relaunch (an OOM spawn under a memory squeeze, a
@@ -994,13 +1004,15 @@ impl ServingDaemonModule {
                 }
                 EnsureOutcome::Degraded { .. } => 0,
             };
-            // #106 vision readiness: for a ready lane, verify the MULTIMODAL endpoint
-            // actually answers — the row's declared Vision, the resolved mmproj, and
-            // the server's own `/props modalities` must all agree before the snapshot
-            // claims sight. Any gap publishes `vision_ready: false` WITH the reason
-            // logged loud, so the observe path fails honestly instead of POSTing
-            // pixels a text-only lane would silently drop.
-            let vision_ready = match &outcome {
+            // #106 vision readiness: for a ready lane, resolve the node's VERIFIED
+            // vision endpoint. First the MAIN lane — the row's declared Vision, the
+            // resolved mmproj, and the server's own `/props modalities` must all
+            // agree. A text-only mind then gets a SIDECAR attempt (a small VL lane
+            // beside it, `inference::vision_sidecar`) so personas are not blind just
+            // because their mind's model doesn't see. Every gap publishes no
+            // endpoint WITH the reason probed loud, so the observe path fails
+            // honestly instead of POSTing pixels a text-only lane would drop.
+            let vision = match &outcome {
                 EnsureOutcome::AlreadyServing | EnsureOutcome::Spawned { .. } => {
                     let declares_vision = target
                         .model
@@ -1021,7 +1033,7 @@ impl ServingDaemonModule {
                             None
                         }
                     };
-                    match crate::inference::llama_server::vision_lane_ready(
+                    let main_sees = match crate::inference::llama_server::vision_lane_ready(
                         declares_vision,
                         mmproj_resolved,
                         props,
@@ -1036,9 +1048,88 @@ impl ServingDaemonModule {
                             );
                             false
                         }
+                    };
+                    if main_sees {
+                        // A VL mind: the main lane IS the vision endpoint. Any
+                        // sidecar from a previous plan is redundant — drop it
+                        // (its Drop kills the child, RAM freed).
+                        *sidecar_slot.lock().await = None;
+                        Some(crate::inference::vision_sidecar::SidecarLane {
+                            base_url: serving_v1_url(),
+                            model_id: desired.clone(),
+                        })
+                    } else {
+                        use crate::inference::vision_sidecar as sidecar;
+                        let rows: Vec<crate::model_registry::types::Model> =
+                            crate::model_registry::try_global()
+                                .map(|r| r.models().cloned().collect())
+                                .unwrap_or_default();
+                        let candidate = sidecar::find_candidate(&rows, Some(desired.as_str()));
+                        match &candidate {
+                            Err(skipped) => {
+                                crate::probe!(
+                                    class = "serving.vision.sidecar_no_candidate",
+                                    skipped = skipped.join("; ").as_str(),
+                                    "text-only mind and no on-disk VL row — personas \
+                                     have no local vision endpoint (models/pull a \
+                                     *-VL-*-GGUF repo to give them eyes)",
+                                );
+                                None
+                            }
+                            Ok(cand) => {
+                                // Gate on the LIVE free-memory read, never a cached
+                                // plan figure (the eval-lane second-model SIGKILL
+                                // class).
+                                let free = system.snapshot().memory.available_bytes;
+                                match sidecar::plan_sidecar(false, Ok(cand), free) {
+                                    sidecar::SidecarVerdict::Spawn => {
+                                        let mut slot = sidecar_slot.lock().await;
+                                        match sidecar::ensure_sidecar(&mut slot, cand).await {
+                                            Ok(lane) => {
+                                                crate::probe!(
+                                                    class = "serving.vision.sidecar_up",
+                                                    model = lane.model_id.as_str(),
+                                                    base_url = lane.base_url.as_str(),
+                                                    "vision sidecar verified — personas can see",
+                                                );
+                                                Some(lane)
+                                            }
+                                            Err(why) => {
+                                                crate::probe!(
+                                                    class = "serving.vision.sidecar_failed",
+                                                    model = cand.model.id.as_str(),
+                                                    why = why.as_str(),
+                                                    "vision sidecar could not come up",
+                                                );
+                                                None
+                                            }
+                                        }
+                                    }
+                                    sidecar::SidecarVerdict::NoBudget {
+                                        need_bytes,
+                                        free_bytes,
+                                    } => {
+                                        crate::probe!(
+                                            class = "serving.vision.sidecar_no_budget",
+                                            model = cand.model.id.as_str(),
+                                            need_bytes,
+                                            free_bytes,
+                                            "vision sidecar refused: not enough free host \
+                                             memory beside the live lane",
+                                        );
+                                        None
+                                    }
+                                    // plan_sidecar was called with
+                                    // main_vision_ready=false and Ok(cand), so the
+                                    // remaining variants cannot arise; publish no
+                                    // endpoint rather than assert in the reconcile.
+                                    _ => None,
+                                }
+                            }
+                        }
                     }
                 }
-                EnsureOutcome::Degraded { .. } => false,
+                EnsureOutcome::Degraded { .. } => None,
             };
             let snapshot = snapshot_from_outcome(
                 &outcome,
@@ -1046,7 +1137,7 @@ impl ServingDaemonModule {
                 &desired_adapter_paths,
                 served_window,
                 target.lanes,
-                vision_ready,
+                vision,
             );
             crate::probe!(
                 class = "serving.reconcile",
@@ -1699,7 +1790,12 @@ fn snapshot_from_outcome(
     adapters: &[String],
     served_context_window: u32,
     lanes: u32,
-    vision_ready: bool,
+    // The VERIFIED vision endpoint on this node, if any (#106): the main lane
+    // itself when its model sees, or the sidecar lane. `Some` ⇒ its `/props`
+    // confirmed sight; the snapshot's `vision_ready`/`vision_base_url`/
+    // `vision_model` are all projected from this ONE value, so an address can
+    // never be published without the verified flag (or vice versa).
+    vision: Option<crate::inference::vision_sidecar::SidecarLane>,
 ) -> ServingSnapshot {
     match outcome {
         EnsureOutcome::AlreadyServing | EnsureOutcome::Spawned { .. }
@@ -1720,11 +1816,13 @@ fn snapshot_from_outcome(
                 // KV as `lanes × kv_at(served_context_window)` (#79).
                 lanes,
                 degraded_reason: None,
-                // The reconcile's verified multimodal verdict (#106): declared
-                // Vision + resolved mmproj + `/props modalities.vision` all
-                // agreed. The observe path gates on THIS, never on the row's
-                // declaration alone.
-                vision_ready,
+                // The reconcile's verified multimodal verdict (#106): the ONE
+                // `vision` value projects all three fields, so readiness and
+                // the routing address can never disagree. The observe path
+                // gates on THIS, never on a row's declaration alone.
+                vision_ready: vision.is_some(),
+                vision_base_url: vision.as_ref().map(|v| v.base_url.clone()),
+                vision_model: vision.map(|v| v.model_id),
             }
         }
         // Ready outcome but the served window was unreadable (0) → do NOT publish
@@ -2439,7 +2537,10 @@ mod tests {
             &genes,
             11008,
             4,
-            true,
+            Some(crate::inference::vision_sidecar::SidecarLane {
+                base_url: "http://127.0.0.1:58091/v1".to_string(),
+                model_id: "vl-7b".to_string(),
+            }),
         );
         assert_eq!(up.active_model.as_deref(), Some("coder-14b"));
         assert!(up.ready);
@@ -2458,16 +2559,27 @@ mod tests {
             "the reconcile's verified multimodal verdict must survive into the snapshot \
              — the observe path gates on THIS field (#106)"
         );
+        assert_eq!(
+            up.vision_base_url.as_deref(),
+            Some("http://127.0.0.1:58091/v1"),
+            "the ONE vision value projects the routing address with the flag — an \
+             address can never publish without verified readiness"
+        );
+        assert_eq!(up.vision_model.as_deref(), Some("vl-7b"));
 
         let already =
-            snapshot_from_outcome(&EnsureOutcome::AlreadyServing, "coder-14b", &genes, 11008, 4, false);
+            snapshot_from_outcome(&EnsureOutcome::AlreadyServing, "coder-14b", &genes, 11008, 4, None);
         assert_eq!(already.active_model.as_deref(), Some("coder-14b"));
         assert!(already.ready);
         assert_eq!(already.served_context_window, 11008);
         assert_eq!(already.lanes, 4);
         assert!(
             !already.vision_ready,
-            "a text lane (verdict false) must never read as sighted"
+            "a text lane (no verified endpoint) must never read as sighted"
+        );
+        assert!(
+            already.vision_base_url.is_none() && already.vision_model.is_none(),
+            "no verified endpoint → no address, no model (None-iff-not-ready)"
         );
 
         // Ready outcome but the served window was unreadable (0) → publish the gap,
@@ -2478,7 +2590,7 @@ mod tests {
             &genes,
             0,
             4,
-            false,
+            None,
         );
         assert_eq!(windowless.active_model, None, "ready-but-no-window → nothing live");
         assert!(!windowless.ready);
@@ -2491,7 +2603,7 @@ mod tests {
             &genes,
             11008,
             4,
-            false,
+            None,
         );
         assert_eq!(degraded.active_model, None, "degraded → nothing live");
         assert!(!degraded.ready);
@@ -2570,6 +2682,8 @@ mod tests {
             lanes: 4,
             degraded_reason: None,
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         });
         let budget = HostBudget { usable_bytes: 45 * GB, perf_cores: 6 };
         let candidates = vec![footprint_from_parts("coder-14b", 9 * GB, 8192, true).unwrap()];
@@ -2590,6 +2704,8 @@ mod tests {
             lanes: 4,
             degraded_reason: None,
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         }
     }
 
@@ -2742,6 +2858,8 @@ mod tests {
             lanes: 4,
             degraded_reason: None,
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         });
         daemon
             .reconcile_to_plan()
@@ -2760,6 +2878,8 @@ mod tests {
             lanes: 4,
             degraded_reason: None,
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         });
         assert!(
             daemon.reconcile_to_plan().is_none(),
@@ -2786,6 +2906,8 @@ mod tests {
             lanes: 4,
             degraded_reason: None,
             vision_ready: false,
+            vision_base_url: None,
+            vision_model: None,
         });
         let budget = HostBudget { usable_bytes: 45 * GB, perf_cores: 6 };
         daemon.publish_plan(budget, &[]); // no candidates → plan None

--- a/shared/generated/persona/ServingSnapshot.ts
+++ b/shared/generated/persona/ServingSnapshot.ts
@@ -75,4 +75,19 @@ degraded_reason?: string,
  * ([[fallbacks-are-illegal-fail-loud]]). `serde(default)` keeps older
  * persisted snapshots (pre-#106) readable as not-vision-ready.
  */
-vision_ready: boolean, };
+vision_ready: boolean, 
+/**
+ * The `/v1` base url of the VERIFIED vision endpoint on this node — the
+ * address the observation path routes image bytes to. When the MAIN lane's
+ * model itself sees, this is `base_url`; when a vision SIDECAR lane serves
+ * beside a text-only mind (#106, `vision_sidecar`), it is the sidecar's
+ * own url. `None` exactly when `vision_ready == false` — an address is
+ * only ever published for an endpoint whose `/props` confirmed sight.
+ */
+vision_base_url?: string, 
+/**
+ * The model id the verified vision endpoint serves — what the describe
+ * path selects and stamps on its result. Same `None`-iff-not-ready
+ * contract as `vision_base_url`.
+ */
+vision_model?: string, };


### PR DESCRIPTION
## What

The residents' unanimous wall this week: `perception/look`/`observe` had no local vision endpoint — the main lane serves the text mind (Devstral), cloud rows are keyless, and vision-describe silently skipped every candidate. Personas were blind by construction on a headless box.

Three pieces:

1. **Vision sidecar lane** (`inference/vision_sidecar.rs`): the serving daemon's reconcile, on a ready lane whose model does NOT see, stands up a long-lived `EphemeralServingLane` (Drop-kills its child, port 58091, CPU placement — the documented coexisting-lane shape) holding the best ON-DISK VL row (GGUF + mmproj both resolve locally, no fetch in a reconcile). Gated on the LIVE free-memory read; verified through the existing `vision_lane_ready` endpoint truth. Pure decision fns, unit-tested.
2. **ONE-value snapshot contract**: `snapshot_from_outcome` takes `Option<SidecarLane>`; `vision_ready`/`vision_base_url`/`vision_model` are all projections of it — an address can never publish without verified readiness (None-iff-not-ready pinned in tests).
3. **Consumers**: vision-describe's servable gate is endpoint-aware (one check covers VL-mind and sidecar shapes); the llama-server adapter admits the sidecar model through the single-resident guard and routes it to `vision_base_url` via `endpoints_for_model` (snapshot-driven, no name sniffing).

## Live proof (M5, build 05a8c4129, verify-the-deploy green)

- `serving/status`: `active: Devstral-Small-2507` + `vision_ready: true, vision_model: Qwen2.5-VL-7B-Instruct-GGUF, vision_url: http://127.0.0.1:58091/v1`
- `cognition/vision-describe` on a red/blue test PNG → **"two vertical rectangles side by side, left red, right blue"** in 1468ms, via the sidecar, minds undisturbed
- eye-node (`apps/eye-node`) proven live same session: `perception/observe https://example.com` → success, 2880×1800 + DOM structure through core→provider→browser

## Tests

vision_sidecar 2/2 · serving_daemon 26/26 · serving_consumer 7/7 · llama_server 24/24 · vision_describe 18/18 · openai_adapter 27/27

Known follow-ups (not in-slice): eye-node lifecycle is still operator-run (system-owns-lifecycle wiring next); sidecar footprint not yet registered as its own ResourceConsumer row (#225 sibling); describe's all-skipped outcome still returns a silent null at the command wire (fail-loud PX fix queued).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo