### PR TITLE
feat(serving): retention verdict on the governed host-cache lease (#287)

### DIFF
--- a/core/continuum-core/src/capacity/host_cache_lease.rs
+++ b/core/continuum-core/src/capacity/host_cache_lease.rs
@@ -73,6 +73,38 @@ pub fn host_cache_lease_bytes(i: &HostCacheLeaseInputs) -> u64 {
     }
 }
 
+/// One token's EXPERT working set: the bytes of experts the router activates
+/// across every MoE layer for a single decode token. Uniform K3-class geometry
+/// makes the layer count cancel: per-layer expert bytes × top_k × n_moe_layers
+/// == (expert_bytes_total / n_experts_per_layer) × top_k. This is the number
+/// the lease must EXCEED for the cache to retain even one token's set — below
+/// it, every token evicts the previous token's experts before they can be
+/// reused (the resident=0 evict-everything thrash BigMama measured on K3:
+/// ~1472 experts/token vs a 2377-slot cache with zero cross-token reuse).
+pub fn per_token_expert_working_set_bytes(
+    expert_bytes_total: u64,
+    n_experts_per_layer: u32,
+    top_k: u32,
+) -> u64 {
+    if n_experts_per_layer == 0 {
+        return 0;
+    }
+    (expert_bytes_total / n_experts_per_layer as u64).saturating_mul(top_k as u64)
+}
+
+/// How many tokens' expert working sets the lease retains, ×100 (fixed-point so
+/// the probe reads "retention 0.42 tokens" without floats on the wire). The
+/// GO/NO-GO line is 100: below it the cache buys nothing — the honest verdict
+/// the operator (and later the governor's own policy) acts on, instead of a
+/// healthy-looking lease that thrashes silently. Zero working set (dense
+/// model) → 0, never a division wrap.
+pub fn retention_tokens_x100(lease_bytes: u64, per_token_ws_bytes: u64) -> u64 {
+    if per_token_ws_bytes == 0 {
+        return 0;
+    }
+    lease_bytes.saturating_mul(100) / per_token_ws_bytes
+}
+
 /// Sticky publication of the lease — the never-thrash layer. The raw
 /// derivation flutters with every KV sample; the PUBLISHED budget moves
 /// only when the change is material, and shrinks faster than it grows:
@@ -169,6 +201,28 @@ mod tests {
         i.commit_charge_bytes = None;
         i.live_kv_bytes = 200 * GB;
         assert_eq!(host_cache_lease_bytes(&i), 0, "over-full working set saturates to zero");
+    }
+
+    /// what this catches (#287 retention arithmetic): the per-token expert
+    /// working set uses the layer-cancelling identity (total/experts × top_k),
+    /// and the retention verdict is honest fixed-point — a K3-shaped serve
+    /// (16-of-896 routed, big expert total) against a lease SMALLER than one
+    /// token's set reads below 100 (the thrash verdict), and a lease that
+    /// holds two tokens' sets reads 200. Dense models (no experts) never wrap.
+    #[test]
+    fn retention_verdict_reads_tokens_of_working_set() {
+        // K3-ish: 72GB of experts, 896/layer, top-16 → one token ≈ 1.286GB.
+        let ws = per_token_expert_working_set_bytes(72 * GB, 896, 16);
+        assert_eq!(ws, (72 * GB / 896) * 16);
+        // A 16GB lease holds ~12 tokens of THIS shape (the thrash she measured
+        // was slot-count-bound, which the probe pairs with this byte verdict).
+        assert!(retention_tokens_x100(16 * GB, ws) > 100);
+        // A lease below one token's set → verdict under 100 (cache buys nothing).
+        assert!(retention_tokens_x100(ws - 1, ws) < 100);
+        assert_eq!(retention_tokens_x100(2 * ws, ws), 200, "two tokens retained");
+        // Dense model (no experts) → zero working set → zero verdict, no wrap.
+        assert_eq!(per_token_expert_working_set_bytes(0, 0, 16), 0);
+        assert_eq!(retention_tokens_x100(16 * GB, 0), 0);
     }
 
     /// what this catches (never-thrash + #214 grow-back): sub-band

--- a/core/continuum-core/src/capacity/moe_serving.rs
+++ b/core/continuum-core/src/capacity/moe_serving.rs
@@ -34,6 +34,11 @@ pub struct MoeServingContext {
     pub pager: ServingExpertPager,
     /// Experts per MoE layer (uniform K3-class geometry) — the `-ot` layer-byte unit.
     pub n_experts_per_layer: u32,
+    /// Router top-k — experts ACTIVATED per token per MoE layer (the artifact's
+    /// `expert_used_count`). With `expert_bytes_total` this yields the per-token
+    /// expert working set the governed host cache must retain to buy any
+    /// cross-token reuse (#287 retention arithmetic).
+    pub top_k: u32,
     /// TOTAL transformer block count — the `-ot` iteration ceiling the launcher needs to
     /// compute the cold (CPU) complement of the hot layers.
     pub n_layers: u32,
@@ -75,6 +80,12 @@ pub fn moe_serving_context(
     if n_experts_per_layer == 0 {
         return None;
     }
+    // Router top-k — experts activated per token per MoE layer. Required geometry
+    // for the retention arithmetic (#287): without it the governed cache cannot
+    // say whether its lease retains even ONE token's expert working set. A MoE
+    // artifact missing the key has unreadable geometry → None (same contract as
+    // the other reads here).
+    let top_k = gguf_keys::expert_used_count(&ct, &arch)?;
     // Per-expert bytes: the layer's stacked expert blob divided by its expert count. K3-class
     // geometry is uniform across MoE layers, so the first set sizes them all.
     let expert_bytes = sets[0].total_bytes() / n_experts_per_layer as u64;
@@ -93,6 +104,7 @@ pub fn moe_serving_context(
     Some(MoeServingContext {
         pager,
         n_experts_per_layer,
+        top_k,
         n_layers,
         expert_bytes_total,
         committed_placement: None,

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -714,14 +714,18 @@ impl ServingDaemonModule {
         let Some(port) = crate::inference::llama_server::port_of_base_url(&live.base_url) else {
             return;
         };
-        // Expert-tensor total for the ACTIVE model — present only for a MoE serve.
+        // Expert geometry for the ACTIVE model — present only for a MoE serve.
         // Read under the same never-across-await sync Mutex as the placement path.
-        let expert_bytes_total = {
+        // top_k + experts-per-layer feed the retention verdict below: the lease
+        // is only USEFUL when it exceeds one token's expert working set.
+        let (expert_bytes_total, n_experts_per_layer, top_k) = {
             let Ok(guard) = self.moe_serving.lock() else {
                 return;
             };
             match guard.as_ref() {
-                Some((id, ctx)) if *id == active => ctx.expert_bytes_total,
+                Some((id, ctx)) if *id == active => {
+                    (ctx.expert_bytes_total, ctx.n_experts_per_layer, ctx.top_k)
+                }
                 _ => return, // dense model (or stale context) — no governed cache to lease
             }
         };
@@ -765,6 +769,30 @@ impl ServingDaemonModule {
             MOE_PLAN_WINDOW_K,
             Vec::new(),
         );
+        // Retention verdict (#287): does the published lease retain even one
+        // token's expert working set? Below 100 (×100 fixed-point) the cache
+        // buys NOTHING — every token evicts the previous token's experts (the
+        // resident=0 thrash) — and the lease is honest about it instead of
+        // looking healthy while thrashing silently.
+        let per_token_ws = crate::capacity::host_cache_lease::per_token_expert_working_set_bytes(
+            expert_bytes_total,
+            n_experts_per_layer,
+            top_k,
+        );
+        let retention_x100 =
+            crate::capacity::host_cache_lease::retention_tokens_x100(budget_bytes, per_token_ws);
+        if retention_x100 < 100 {
+            crate::probe!(
+                class = "serving.moe_host_cache_retention",
+                model = active.as_str(),
+                budget_bytes,
+                per_token_ws_bytes = per_token_ws,
+                retention_tokens_x100 = retention_x100,
+                "lease retains LESS than one token's expert working set — the \
+                 cache thrashes (zero cross-token reuse); free host RAM or accept \
+                 streaming-only decode",
+            );
+        }
         match crate::capacity::plan_file::write_plan_file(&gb.plan, &doc) {
             Ok(()) => crate::probe!(
                 class = "serving.moe_host_cache_lease",
@@ -773,10 +801,15 @@ impl ServingDaemonModule {
                 derived_bytes = derived,
                 weights_host_bytes = inputs.weights_host_bytes,
                 live_kv_bytes = inputs.live_kv_bytes,
+                per_token_ws_bytes = per_token_ws,
+                retention_tokens_x100 = retention_x100,
                 plan = gb.plan.display().to_string().as_str(),
-                "published governed host-cache lease: {} GiB (raw {} GiB)",
+                "published governed host-cache lease: {} GiB (raw {} GiB, retains \
+                 {}.{:02} tokens' expert set)",
                 budget_bytes / (1024 * 1024 * 1024),
                 derived / (1024 * 1024 * 1024),
+                retention_x100 / 100,
+                retention_x100 % 100,
             ),
             Err(e) => crate::probe!(
                 class = "serving.moe_host_cache_lease",


### PR DESCRIPTION
The missing arithmetic behind BigMama's GPU-first K3 thrash (resident=0, evict-everything, zero cross-token reuse while the lease looked healthy): the lease law answers *how much RAM is safe to grant* but not *whether that grant buys anything*.

Two pure fns on `host_cache_lease`: per-token expert working set from the artifact's own geometry (`expert_bytes_total / experts_per_layer × top_k` — layer count cancels under uniform K3-class geometry; `top_k` now read from the GGUF's `expert_used_count` into `MoeServingContext`), and fixed-point `retention_tokens_x100` (100 = GO/NO-GO). The daemon's lease publish probes both every tick and fires a loud `serving.moe_host_cache_retention` when the budget retains less than one token's set.

Tests: capacity 108/108 (retention identity + thrash verdict + dense no-wrap pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo