### PR TITLE
feat(cognition): lost-claim transition fact — a lease that expires speaks, once (#156)

### DIFF
--- a/core/continuum-core/src/persona/active_work_source.rs
+++ b/core/continuum-core/src/persona/active_work_source.rs
@@ -48,11 +48,45 @@ use crate::cognition::token_budget::estimate_prompt_tokens as estimate_tokens;
 pub struct ActiveWorkSource {
     persona_id: uuid::Uuid,
     reader: Arc<dyn AircWorkReader>,
+    /// Card ids → titles from the LAST successful read — the diff memory behind
+    /// the lost-claim transition fact (#156). `None` until the first successful
+    /// read (a fresh mind has no baseline to lose from). A sync Mutex locked
+    /// only AFTER the `active_claims` await resolves — never held across await.
+    prev_claims: std::sync::Mutex<Option<std::collections::HashMap<uuid::Uuid, String>>>,
 }
 
 impl ActiveWorkSource {
     pub fn new(persona_id: uuid::Uuid, reader: Arc<dyn AircWorkReader>) -> Self {
-        Self { persona_id, reader }
+        Self {
+            persona_id,
+            reader,
+            prev_claims: std::sync::Mutex::new(None),
+        }
+    }
+
+    /// The lost-claim transition fact (#156, the Benchy case): a lease that
+    /// expired or a card released between reads VANISHES from `active_claims`
+    /// silently, and the persona keeps planning work on a card it no longer
+    /// holds ("I've already claimed…", turns after peer 90e758b2 legitimately
+    /// re-claimed it). One honest fact at the transition — we know the claim is
+    /// GONE from this read; we do NOT know who holds it now (that would need a
+    /// board read), so the fact says exactly that and points at the board.
+    fn lost_claim_item(card_id: &uuid::Uuid, title: &str) -> RagItem {
+        let id8: String = card_id.to_string().chars().take(8).collect();
+        let content = format!(
+            "[work] Your claim on card {id8} \"{title}\" is no longer held by you \
+             (lease expired or released). Do not continue work on it as yours — \
+             check the board before touching it again."
+        );
+        let tokens = estimate_tokens(&content);
+        RagItem {
+            content,
+            tokens,
+            metadata: json!({
+                "fact": "claim_lost",
+                "card_id": card_id.to_string(),
+            }),
+        }
     }
 
     fn empty() -> RagDelivery {
@@ -84,7 +118,9 @@ impl RagSource for ActiveWorkSource {
         }
 
         // One airc call (board-wide, all rooms). Failure is non-fatal — empty
-        // delivery, cognition stays up (good-citizen doctrine).
+        // delivery, cognition stays up (good-citizen doctrine). CRUCIALLY the
+        // early return leaves `prev_claims` untouched: a degraded read must
+        // never fabricate "you lost everything" transition facts.
         let claims = match self.reader.active_claims().await {
             Ok(c) => c,
             Err(err) => {
@@ -96,12 +132,43 @@ impl RagSource for ActiveWorkSource {
                 return Self::empty();
             }
         };
-        if claims.is_empty() {
-            return Self::empty();
-        }
+
+        // Diff against the last SUCCESSFUL read (#156): cards that vanished are
+        // lost claims — surface each ONCE as a transition fact, then adopt the
+        // new baseline. Runs even when `claims` is empty: losing your LAST card
+        // is exactly the silent-handoff case this exists for.
+        let now: std::collections::HashMap<uuid::Uuid, String> = claims
+            .iter()
+            .map(|c| (c.card_id.as_uuid(), c.title.clone()))
+            .collect();
+        let lost: Vec<(uuid::Uuid, String)> = {
+            let mut prev = self.prev_claims.lock().unwrap_or_else(|p| p.into_inner());
+            let lost = match prev.as_ref() {
+                Some(before) => before
+                    .iter()
+                    .filter(|(id, _)| !now.contains_key(*id))
+                    .map(|(id, title)| (*id, title.clone()))
+                    .collect(),
+                // First successful read: no baseline, nothing to lose from.
+                None => Vec::new(),
+            };
+            *prev = Some(now);
+            lost
+        };
 
         let mut items: Vec<RagItem> = Vec::new();
         let mut tokens_used: u32 = 0;
+        for (card_id, title) in &lost {
+            let item = Self::lost_claim_item(card_id, title);
+            if tokens_used.saturating_add(item.tokens) > budget {
+                break;
+            }
+            tokens_used += item.tokens;
+            items.push(item);
+        }
+        if claims.is_empty() && items.is_empty() {
+            return Self::empty();
+        }
         for card in &claims {
             let id8: String = card.card_id.as_uuid().to_string().chars().take(8).collect();
             // Human-readable line; structured parts also ride in metadata so
@@ -155,5 +222,132 @@ impl RagSource for ActiveWorkSource {
     ) -> Option<RagDelivery> {
         // Atomic units (one card each), no pagination — same as the roster.
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_work::{CardState, Priority, RepoId, WorkCardId};
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    struct StubWork {
+        /// Each deliver pops the front result; `Err` = degraded read.
+        results: Mutex<Vec<Result<Vec<WorkCard>, ()>>>,
+    }
+
+    #[async_trait]
+    impl AircWorkReader for StubWork {
+        async fn active_claims(&self) -> Result<Vec<WorkCard>, AircError> {
+            match self.results.lock().unwrap().remove(0) {
+                Ok(cards) => Ok(cards),
+                Err(()) => Err(AircError::UnknownPeer(airc_core::PeerId::new())),
+            }
+        }
+    }
+
+    fn card(title: &str) -> WorkCard {
+        WorkCard {
+            card_id: WorkCardId::new(),
+            repo: RepoId::new("acme/continuum").expect("valid repo id in fixture"),
+            title: title.to_string(),
+            body: None,
+            priority: Priority::P2,
+            lane_id: None,
+            state: CardState::Claimed,
+            owner: None,
+            claim_id: None,
+            claim_expires_at_ms: None,
+            last_heartbeat_at_ms: None,
+            pull_request: None,
+            created_by: airc_core::PeerId::new(),
+            created_at_ms: 1_000_000,
+            updated_at_ms: 1_000_000,
+            reviews: None,
+        }
+    }
+
+    fn ctx(persona: Uuid) -> RagContext {
+        RagContext::for_persona(persona, 1_000_000)
+    }
+
+    fn source(persona: Uuid, results: Vec<Result<Vec<WorkCard>, ()>>) -> ActiveWorkSource {
+        ActiveWorkSource::new(
+            persona,
+            Arc::new(StubWork {
+                results: Mutex::new(results),
+            }),
+        )
+    }
+
+    // what this catches (#156, the Benchy silent-handoff case): a card that
+    // VANISHES between reads — lease expired or re-claimed by another peer —
+    // must surface as a [work] claim_lost transition fact exactly ONCE, even
+    // when it was the persona's LAST card (the empty-claims path). The next
+    // read carries no fact (baseline adopted): a transition, not a nag loop.
+    #[tokio::test]
+    async fn lost_claim_surfaces_once_even_when_it_was_the_last_card() {
+        let persona = Uuid::new_v4();
+        let millbrook = card("Build and launch the Millbrook Bakery website");
+        let src = source(
+            persona,
+            vec![Ok(vec![millbrook.clone()]), Ok(vec![]), Ok(vec![])],
+        );
+
+        // Read 1: holds the card — normal grounding line, no facts.
+        let d1 = src.deliver(&ctx(persona), 1_000, ResolutionPreference::Raw).await;
+        assert_eq!(d1.items.len(), 1);
+        assert!(d1.items[0].metadata.get("fact").is_none());
+
+        // Read 2: the card vanished → the transition fact, once, loud.
+        let d2 = src.deliver(&ctx(persona), 1_000, ResolutionPreference::Raw).await;
+        assert_eq!(d2.items.len(), 1);
+        assert_eq!(d2.items[0].metadata["fact"], "claim_lost");
+        assert!(d2.items[0].content.contains("Millbrook"), "names the lost card");
+        assert!(
+            d2.items[0].content.contains("no longer held by you"),
+            "states the transition plainly"
+        );
+
+        // Read 3: baseline adopted — silence, not a nag loop.
+        let d3 = src.deliver(&ctx(persona), 1_000, ResolutionPreference::Raw).await;
+        assert!(d3.items.is_empty());
+    }
+
+    // what this catches: a DEGRADED read must never fabricate loss — the
+    // baseline survives the error, and the loss fact only fires when a
+    // SUCCESSFUL read actually shows the card gone.
+    #[tokio::test]
+    async fn degraded_read_never_fabricates_loss() {
+        let persona = Uuid::new_v4();
+        let c = card("real work");
+        let src = source(
+            persona,
+            vec![Ok(vec![c.clone()]), Err(()), Ok(vec![c]), Ok(vec![])],
+        );
+
+        let _hold = src.deliver(&ctx(persona), 1_000, ResolutionPreference::Raw).await;
+        // Degraded read: empty delivery, NO loss facts, baseline preserved.
+        let err = src.deliver(&ctx(persona), 1_000, ResolutionPreference::Raw).await;
+        assert!(err.items.is_empty(), "degraded read stays empty — never a fake loss");
+        // Recovered read still holding: no facts (nothing was ever lost).
+        let ok = src.deliver(&ctx(persona), 1_000, ResolutionPreference::Raw).await;
+        assert_eq!(ok.items.len(), 1);
+        assert!(ok.items[0].metadata.get("fact").is_none());
+        // NOW it's genuinely gone → the fact fires from the preserved baseline.
+        let lost = src.deliver(&ctx(persona), 1_000, ResolutionPreference::Raw).await;
+        assert_eq!(lost.items.len(), 1);
+        assert_eq!(lost.items[0].metadata["fact"], "claim_lost");
+    }
+
+    // what this catches: the FIRST successful read has no baseline — a fresh
+    // mind (or a rebooted core) must not hallucinate losses it never held.
+    #[tokio::test]
+    async fn first_read_carries_no_loss_facts() {
+        let persona = Uuid::new_v4();
+        let src = source(persona, vec![Ok(vec![])]);
+        let d = src.deliver(&ctx(persona), 1_000, ResolutionPreference::Raw).await;
+        assert!(d.items.is_empty(), "empty first read = empty delivery, no facts");
     }
 }


### PR DESCRIPTION
The Benchy silent-handoff case: a lease expires, the card vanishes from `active_claims`, and the persona keeps working a card it lost. Now the vanish emits one `[work] claim_lost` transition fact (diff memory over successful reads), then the baseline adopts. Losing your LAST card still speaks; a degraded read never fabricates loss; first read has no baseline. 3/3 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo