### PR TITLE
test(cognition): prompt_assembly e2e expects the authority fact first (CI red from #2113)

### DIFF
--- a/core/continuum-core/src/persona/prompt_assembly.rs
+++ b/core/continuum-core/src/persona/prompt_assembly.rs
@@ -1049,9 +1049,18 @@ mod tests {
         // 2. Real loop fold: delivery → grounding consumers (the converged line +
         //    the bare name), via the exact fn the heartbeat loop calls.
         let proj = project_room_roster(std::slice::from_ref(&delivery));
+        // Agent-only roster ⇒ the no-human authority fact (#2113) rides FIRST in
+        // the grounding lines — it reaches the prompt through the same block —
+        // while other_persona_names stays peer-only (the fact has no
+        // display_name, so it can NEVER become a phantom "peer" name).
+        assert_eq!(proj.room_roster.len(), 2);
+        assert!(
+            proj.room_roster[0].contains("No human is present"),
+            "authority fact first: {}",
+            proj.room_roster[0]
+        );
         assert_eq!(
-            proj.room_roster,
-            vec!["win-claude [claude] — busy".to_string()],
+            proj.room_roster[1], "win-claude [claude] — busy",
             "converged line (availability = airc's neutral 'busy', not Debug 'Busy')"
         );
         assert_eq!(proj.other_persona_names, vec!["win-claude".to_string()]);


### PR DESCRIPTION
The roster→prompt e2e asserted one grounding line; #2113's no-human authority fact now rides first on agent-only rosters (designed). Test pins the fact-first contract + phantom-name immunity. 17/17 locally; unblocks canary Rust Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo