### PR TITLE
feat(serving): daemon-integrated pin actuator — trace tail → bandit → pins on the GOVERNED plan (#281)

### DIFF
--- a/core/continuum-core/src/capacity/mod.rs
+++ b/core/continuum-core/src/capacity/mod.rs
@@ -40,6 +40,7 @@ pub mod lease;
 pub mod moe_arch_profile;
 pub mod moe_serving;
 pub mod pager_capture;
+pub mod trace_tail;
 pub mod plan_file;
 pub mod placement;
 pub mod recursion_depth;

--- a/core/continuum-core/src/capacity/trace_tail.rs
+++ b/core/continuum-core/src/capacity/trace_tail.rs
@@ -1,0 +1,329 @@
+//! MoE trace tail — the daemon-side observation front end of the pin
+//! actuator (#281). Tails the fork's `GGML_MOE_TRACE_FILE` (12-byte
+//! binary records: tkey u64 + expert u32, appended per activated
+//! expert), segments decode tokens, and folds them into the
+//! [`BanditPlanController`] whose `pin_list` the serving daemon's
+//! governed plan publish carries to her `ResidencyCache`.
+//!
+//! This is the DAEMON-integrated sibling of the standalone
+//! `moe-pager-driver` bin (same primitives from `expert_pager_policy`,
+//! same offset-resume + truncation-reset discipline) with one upgrade:
+//! the tkey table is SYNTHESIZED from the model's `n_layers`
+//! ([`TkeyTable::for_layers`]) instead of loaded from an operator JSON
+//! — zero configuration, the system owns the seam.
+//!
+//! Read discipline: incremental (only bytes past the last offset),
+//! bounded per drain ([`MAX_DRAIN_BYTES`]) so a long catch-up backlog
+//! can never stall the daemon tick — on overflow the tail JUMPS to the
+//! recent window and lets the segmenter re-sync on the next key-cycle
+//! boundary (recency is the signal; stale backlog is not). A file
+//! shorter than the stored offset = a fresh serve (the fork opens
+//! `"wb"`) → full state reset, stale scores never leak across serves.
+
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+use expert_pager_policy::controller::BanditPlanController;
+use expert_pager_policy::plan_file::PlanPin;
+use expert_pager_policy::segment::{
+    parse_records, PrefillBoundaryDetector, TkeyTable, TokenSegmenter, RECORD_BYTES,
+};
+
+/// Per-drain read ceiling. A decode token is ~17 KB of trace (~1472
+/// experts × 12 B), so 4 MiB ≈ 240 tokens of catch-up per tick — far
+/// more than accumulates between 5 s ticks at single-digit tok/s, while
+/// bounding the worst-case tick cost when the daemon was down for hours.
+const MAX_DRAIN_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Adaptive budget factor: the bandit predicts against 1.5× the first
+/// observed token's working set (the prototypes' heuristic, carried
+/// from the driver bin).
+const BUDGET_FACTOR_NUM: usize = 3;
+const BUDGET_FACTOR_DEN: usize = 2;
+
+/// Streaming trace consumer + controller owner. One per serving lane;
+/// lives behind the daemon's sync Mutex (never held across await).
+pub struct MoeTraceTail {
+    /// Geometry the table was synthesized for — a model change (new
+    /// n_layers) rebuilds the table and resets the controller.
+    n_layers: u32,
+    table: TkeyTable,
+    offset: u64,
+    carry: Vec<u8>,
+    segmenter: TokenSegmenter,
+    boundary: PrefillBoundaryDetector,
+    controller: Option<BanditPlanController>,
+    /// Decode tokens folded in since the last reset (telemetry).
+    pub tokens_observed: u64,
+    /// True when the last drain crossed the prefill→decode boundary —
+    /// the caller publishes the warm-start plan immediately (prefill's
+    /// tail predicts ~47-66% of decode experts; acting AT the boundary
+    /// is when the hint matters most).
+    pub boundary_crossed: bool,
+    /// The pin list as last written to the plan file — the write-churn
+    /// gate's memory. The sticky budget band alone would suppress plan
+    /// writes while pins roll; comparing against this lets the caller
+    /// write exactly when the ACTUATOR state changed and stay silent
+    /// (no mtime churn under her per-token poll) when it didn't.
+    last_published_pins: Vec<PlanPin>,
+}
+
+impl MoeTraceTail {
+    pub fn new(n_layers: u32) -> Self {
+        Self {
+            n_layers,
+            table: TkeyTable::for_layers(n_layers),
+            offset: 0,
+            carry: Vec::new(),
+            segmenter: TokenSegmenter::new(),
+            boundary: PrefillBoundaryDetector::new(),
+            controller: None,
+            tokens_observed: 0,
+            boundary_crossed: false,
+            last_published_pins: Vec::new(),
+        }
+    }
+
+    fn reset_stream_state(&mut self) {
+        self.offset = 0;
+        self.carry.clear();
+        self.segmenter = TokenSegmenter::new();
+        self.boundary = PrefillBoundaryDetector::new();
+        self.controller = None;
+        self.tokens_observed = 0;
+        self.last_published_pins.clear();
+    }
+
+    /// Did the actuator state move since the last plan write? Compares
+    /// (and on change, records) the candidate pin list. The caller
+    /// writes the plan when this is true, when the budget moved, or at
+    /// the prefill→decode boundary — and stays silent otherwise.
+    pub fn pins_changed(&mut self, pins: &[PlanPin]) -> bool {
+        if self.last_published_pins.as_slice() == pins {
+            return false;
+        }
+        self.last_published_pins = pins.to_vec();
+        true
+    }
+
+    /// Ensure the tail matches the active model's geometry; a change
+    /// rebuilds the synthesized table AND resets everything (scores
+    /// from another model's experts are meaningless).
+    pub fn ensure_geometry(&mut self, n_layers: u32) {
+        if self.n_layers != n_layers {
+            self.n_layers = n_layers;
+            self.table = TkeyTable::for_layers(n_layers);
+            self.reset_stream_state();
+        }
+    }
+
+    /// Drain new trace bytes and fold completed decode tokens into the
+    /// bandit. Missing file = serve not started (no-op). Returns the
+    /// number of tokens folded this drain.
+    pub fn drain(&mut self, trace_path: &Path) -> u64 {
+        self.boundary_crossed = false;
+        let Ok(mut file) = std::fs::File::open(trace_path) else {
+            return 0;
+        };
+        let len = file.metadata().map(|m| m.len()).unwrap_or(0);
+        if len < self.offset {
+            // Truncated: a NEW serve started — reset, stale scores
+            // belong to the previous generation.
+            self.reset_stream_state();
+        }
+        if len <= self.offset {
+            return 0;
+        }
+        if len - self.offset > MAX_DRAIN_BYTES {
+            // Backlog overflow: jump to the recent window (record-aligned
+            // relative to the file start so parse framing holds — the
+            // fork writes from byte 0 in whole records) and re-sync.
+            let target = len - MAX_DRAIN_BYTES;
+            self.offset = target - (target % RECORD_BYTES as u64);
+            self.carry.clear();
+            self.segmenter = TokenSegmenter::new();
+        }
+        if file.seek(SeekFrom::Start(self.offset)).is_err() {
+            return 0;
+        }
+        let mut fresh = Vec::with_capacity((len - self.offset) as usize);
+        let Ok(_) = (&mut file).take(len - self.offset).read_to_end(&mut fresh) else {
+            return 0;
+        };
+        self.offset += fresh.len() as u64;
+        self.carry.extend_from_slice(&fresh);
+        let (records, consumed) = parse_records(&self.carry);
+        self.carry.drain(..consumed);
+        debug_assert!(self.carry.len() < RECORD_BYTES);
+
+        let mut folded = 0u64;
+        for rec in records {
+            if let Some(token) = self.segmenter.push(rec, &self.table) {
+                if token.is_empty() {
+                    continue;
+                }
+                let experts: Vec<_> = token.into_iter().collect();
+                if self.boundary.observe(experts.len()) {
+                    self.boundary_crossed = true;
+                }
+                let ctl = self.controller.get_or_insert_with(|| {
+                    BanditPlanController::new(
+                        experts.len() * BUDGET_FACTOR_NUM / BUDGET_FACTOR_DEN,
+                    )
+                });
+                ctl.observe_token(&experts);
+                self.tokens_observed += 1;
+                folded += 1;
+            }
+        }
+        folded
+    }
+
+    /// The current hot-routed pin list, or empty before the first
+    /// observed token (a budget-only plan — exactly the v1 wire shape,
+    /// so the actuator degrades to the validated behavior when the
+    /// trace is dark). Pins roll with the bandit's decay window every
+    /// call — the anti-fossil property: yesterday's hot experts fade
+    /// out of the list as their scores decay.
+    pub fn pin_list(&self, top_n: usize) -> Vec<PlanPin> {
+        match (&self.controller, top_n) {
+            (Some(ctl), n) if n > 0 => ctl.pin_list(n),
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// How many experts the governed lease can afford to PIN: half the
+/// lease (the other half stays free for the recency working set —
+/// pinning the whole budget would evict the very tokens-in-flight the
+/// cache exists to retain), divided by one expert's bytes. Zero when
+/// geometry is unknown/degenerate — a budget-only plan, never a
+/// division panic.
+pub fn pin_ceiling(
+    budget_bytes: u64,
+    expert_bytes_total: u64,
+    n_layers: u32,
+    n_experts_per_layer: u32,
+) -> usize {
+    let expert_count = u64::from(n_layers) * u64::from(n_experts_per_layer);
+    if expert_count == 0 || expert_bytes_total == 0 {
+        return 0;
+    }
+    let per_expert = expert_bytes_total / expert_count;
+    if per_expert == 0 {
+        return 0;
+    }
+    ((budget_bytes / 2) / per_expert) as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use expert_pager_policy::segment::fnv1a_name_key;
+
+    /// Append `experts` as one decode token's worth of records for the
+    /// gate matrix of `layer` (one tensor-key group). Cycling back to
+    /// an earlier layer's key is what closes the token.
+    fn append_records(buf: &mut Vec<u8>, layer: u32, experts: &[u32]) {
+        let tkey = fnv1a_name_key(&format!("blk.{layer}.ffn_gate_exps.weight"));
+        for &e in experts {
+            buf.extend_from_slice(&tkey.to_le_bytes());
+            buf.extend_from_slice(&e.to_le_bytes());
+        }
+    }
+
+    /// Two-layer token: records for layer 0 then layer 1. Repeating
+    /// layer 0 in the NEXT call wraps the router cycle and completes it.
+    fn token_bytes(experts_l0: &[u32], experts_l1: &[u32]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        append_records(&mut buf, 0, experts_l0);
+        append_records(&mut buf, 1, experts_l1);
+        buf
+    }
+
+    // what this catches: the whole daemon-side observation loop against
+    // a real file — offset-resumed incremental reads (drain twice, no
+    // re-count), token completion on cycle wrap, and pins emerging in
+    // REAL (layer, expert) coordinates from the synthesized table (no
+    // JSON table anywhere).
+    #[test]
+    fn drains_incrementally_and_pins_real_coordinates() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let trace = tmp.path().join("moe-trace.bin");
+        let mut tail = MoeTraceTail::new(2);
+
+        // Token A (open) — nothing completes yet.
+        std::fs::write(&trace, token_bytes(&[3, 7], &[9])).expect("write");
+        assert_eq!(tail.drain(&trace), 0, "token A still open");
+
+        // Token B's records arrive: A completes on cycle wrap.
+        let mut more = std::fs::read(&trace).expect("read");
+        more.extend_from_slice(&token_bytes(&[3, 8], &[9]));
+        std::fs::write(&trace, &more).expect("write");
+        assert_eq!(tail.drain(&trace), 1, "token A folds");
+        assert_eq!(tail.tokens_observed, 1);
+
+        // Pins are real coordinates from token A's set.
+        let pins = tail.pin_list(8);
+        assert!(!pins.is_empty());
+        assert!(
+            pins.iter().all(|p| (p.layer == 0 && (p.expert == 3 || p.expert == 7))
+                || (p.layer == 1 && p.expert == 9)),
+            "pins must be token A's (layer, expert) set, got {pins:?}"
+        );
+
+        // No new bytes → no re-count (offset held).
+        assert_eq!(tail.drain(&trace), 0);
+    }
+
+    // what this catches: truncation-reset — a shorter file is a NEW
+    // serve (fork reopens "wb"); stale bandit scores and the old offset
+    // must not survive into the new generation.
+    #[test]
+    fn truncation_resets_state_for_the_new_serve() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let trace = tmp.path().join("moe-trace.bin");
+        let mut tail = MoeTraceTail::new(2);
+
+        let mut buf = token_bytes(&[1, 2], &[3]);
+        buf.extend_from_slice(&token_bytes(&[1, 2], &[3]));
+        std::fs::write(&trace, &buf).expect("write");
+        tail.drain(&trace);
+        assert!(tail.tokens_observed >= 1);
+
+        // New serve: file restarts smaller.
+        std::fs::write(&trace, token_bytes(&[5], &[6])).expect("write");
+        tail.drain(&trace);
+        assert_eq!(
+            tail.tokens_observed, 0,
+            "reset: no tokens counted from the fresh open stream yet"
+        );
+        assert!(tail.pin_list(8).is_empty(), "stale pins do not survive a new serve");
+    }
+
+    // what this catches: a geometry change (different model) rebuilds
+    // the synthesized table and resets — layer coordinates from one
+    // model must never label another model's trace.
+    #[test]
+    fn geometry_change_resets_table_and_state() {
+        let mut tail = MoeTraceTail::new(4);
+        tail.tokens_observed = 7;
+        tail.ensure_geometry(4);
+        assert_eq!(tail.tokens_observed, 7, "same geometry: state kept");
+        tail.ensure_geometry(8);
+        assert_eq!(tail.tokens_observed, 0, "new geometry: full reset");
+    }
+
+    // what this catches: the pin ceiling is HALF the lease over real
+    // per-expert bytes (pins must never consume the whole budget — the
+    // recency window is the cache's reason to exist), and degenerate
+    // geometry yields 0 (budget-only plan), never a division panic.
+    #[test]
+    fn pin_ceiling_is_half_lease_and_degenerates_to_zero() {
+        // 1000 experts of 10 MB each; lease 4 GB → half = 2 GB → 200 pins.
+        let mb = 1024 * 1024;
+        assert_eq!(pin_ceiling(4000 * mb, 10_000 * mb, 10, 100), 200);
+        assert_eq!(pin_ceiling(4000 * mb, 0, 10, 100), 0);
+        assert_eq!(pin_ceiling(4000 * mb, 10_000 * mb, 0, 0), 0);
+    }
+}

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -401,6 +401,12 @@ pub struct MoeGlassBoxPaths {
     /// and the fork's `ResidencyCache` mtime-polls per token
     /// (docs/architecture/EXPERT-PAGING-CONTROL-LAW.md §5).
     pub plan: PathBuf,
+    /// The ordered routed-expert activation trace the fork appends (12-byte
+    /// binary records: tkey u64 + expert u32) — the observation feed the
+    /// daemon's pin actuator tails per tick (#281). Truncated by the fork at
+    /// each fresh serve (opened `"wb"`), so the tail's truncation-reset is
+    /// the rotation story.
+    pub trace: PathBuf,
 }
 
 /// See [`MoeGlassBoxPaths`]. Lives beside the per-port stderr logs
@@ -410,6 +416,7 @@ pub fn moe_glass_box_paths(port: u16) -> Option<MoeGlassBoxPaths> {
     Some(MoeGlassBoxPaths {
         capture: dir.join(format!("moe-capture-{port}.jsonl")),
         plan: dir.join(format!("moe-plan-{port}.json")),
+        trace: dir.join(format!("moe-trace-{port}.bin")),
     })
 }
 
@@ -1775,6 +1782,9 @@ impl LlamaServerControl for LlamaServerProcess {
                 }
                 if std::env::var_os("GGML_MOE_PLAN_FILE").is_none() {
                     cmd.env("GGML_MOE_PLAN_FILE", &gb.plan);
+                }
+                if std::env::var_os("GGML_MOE_TRACE_FILE").is_none() {
+                    cmd.env("GGML_MOE_TRACE_FILE", &gb.trace);
                 }
             }
         }

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -221,6 +221,12 @@ pub struct ServingDaemonModule {
     /// resident model out from under the engine). Tracked so a model change
     /// releases the old registration exactly once.
     active_artifact: std::sync::Mutex<Option<std::path::PathBuf>>,
+    /// The pin actuator's observation state (#281): tails the fork's
+    /// routed-expert trace, owns the bandit, and remembers the last
+    /// published pin list (the write-churn gate). `None` until the first
+    /// MoE lease publish; rebuilt on geometry change. Same sync-Mutex
+    /// discipline as `moe_serving` (never held across await).
+    moe_trace_tail: std::sync::Mutex<Option<crate::capacity::trace_tail::MoeTraceTail>>,
     /// MEASUREMENT-ONLY, off by default: an explicit forced VRAM budget for K3 expert
     /// placement, read ONCE at construction from `K3_MEASURE_FORCE_EXPERT_BUDGET_BYTES`. When
     /// `Some`, it OVERRIDES the governed ceiling so a model that would otherwise fit is driven
@@ -326,6 +332,7 @@ impl ServingDaemonModule {
             lane_demand: Arc::new(std::sync::atomic::AtomicU32::new(1)),
             moe_serving: std::sync::Mutex::new(None),
             active_artifact: std::sync::Mutex::new(None),
+            moe_trace_tail: std::sync::Mutex::new(None),
             host_cache_lease: std::sync::Mutex::new(
                 crate::capacity::host_cache_lease::StickyLease::new(HOST_CACHE_LEASE_BAND_DIVISOR),
             ),
@@ -749,14 +756,17 @@ impl ServingDaemonModule {
         // Read under the same never-across-await sync Mutex as the placement path.
         // top_k + experts-per-layer feed the retention verdict below: the lease
         // is only USEFUL when it exceeds one token's expert working set.
-        let (expert_bytes_total, n_experts_per_layer, top_k) = {
+        let (expert_bytes_total, n_experts_per_layer, top_k, n_layers) = {
             let Ok(guard) = self.moe_serving.lock() else {
                 return;
             };
             match guard.as_ref() {
-                Some((id, ctx)) if *id == active => {
-                    (ctx.expert_bytes_total, ctx.n_experts_per_layer, ctx.top_k)
-                }
+                Some((id, ctx)) if *id == active => (
+                    ctx.expert_bytes_total,
+                    ctx.n_experts_per_layer,
+                    ctx.top_k,
+                    ctx.n_layers,
+                ),
                 _ => return, // dense model (or stale context) — no governed cache to lease
             }
         };
@@ -783,22 +793,58 @@ impl ServingDaemonModule {
             return;
         };
         let derived = crate::capacity::host_cache_lease::host_cache_lease_bytes(&inputs);
-        let published = {
+        // Sticky band on the BUDGET axis only: `budget_moved` says the
+        // published value changed; a held budget reuses the last published
+        // value so the ACTUATOR axis (pins, below) can still trigger a
+        // write. The no-churn property now lives on the write decision —
+        // nothing changed on either axis ⇒ no write, no mtime churn.
+        let (budget_bytes, budget_moved) = {
             let Ok(mut sticky) = self.host_cache_lease.lock() else {
                 return;
             };
-            sticky.observe(derived)
+            match sticky.observe(derived) {
+                Some(published) => (published, true),
+                None => (sticky.published_bytes(), false),
+            }
         };
-        let Some(budget_bytes) = published else {
-            return; // held within the band — no write, no mtime churn
-        };
+        if budget_bytes == 0 {
+            return; // nothing governed yet — never publish a zero lease
+        }
         let Some(gb) = crate::inference::llama_server::moe_glass_box_paths(port) else {
             return;
         };
+        // Pin actuator (#281): drain the fork's routed-expert trace into
+        // the bandit and carry its hot list on the governed plan. The pin
+        // budget is retention-derived — at most half the lease's worth of
+        // experts (the recency window keeps the other half) — so a lease
+        // too small to retain anything publishes budget-only (v1 shape).
+        let (pins, boundary_crossed, tokens_observed, pins_moved) = {
+            let Ok(mut tail_guard) = self.moe_trace_tail.lock() else {
+                return;
+            };
+            let tail = tail_guard.get_or_insert_with(|| {
+                crate::capacity::trace_tail::MoeTraceTail::new(n_layers)
+            });
+            tail.ensure_geometry(n_layers);
+            tail.drain(&gb.trace);
+            let ceiling = crate::capacity::trace_tail::pin_ceiling(
+                budget_bytes,
+                expert_bytes_total,
+                n_layers,
+                n_experts_per_layer,
+            );
+            let pins = tail.pin_list(ceiling);
+            let moved = tail.pins_changed(&pins);
+            (pins, tail.boundary_crossed, tail.tokens_observed, moved)
+        };
+        if !budget_moved && !pins_moved && !boundary_crossed {
+            return; // neither axis changed — no write, no mtime churn
+        }
+        let pins_count = pins.len();
         let doc = crate::capacity::plan_file::PlanFileDocument::new(
             budget_bytes,
             MOE_PLAN_WINDOW_K,
-            Vec::new(),
+            pins,
         );
         // Retention verdict (#287): does the published lease retain even one
         // token's expert working set? Below 100 (×100 fixed-point) the cache
@@ -834,6 +880,9 @@ impl ServingDaemonModule {
                 live_kv_bytes = inputs.live_kv_bytes,
                 per_token_ws_bytes = per_token_ws,
                 retention_tokens_x100 = retention_x100,
+                pins = pins_count as u64,
+                trace_tokens = tokens_observed,
+                warm_start = boundary_crossed,
                 plan = gb.plan.display().to_string().as_str(),
                 "published governed host-cache lease: {} GiB (raw {} GiB, retains \
                  {}.{:02} tokens' expert set)",

--- a/core/expert-pager-policy/src/segment.rs
+++ b/core/expert-pager-policy/src/segment.rs
@@ -56,7 +56,39 @@ pub struct TkeyTable {
     layer_of: HashMap<u64, u32>,
 }
 
+/// FNV-1a over a canonical tensor leaf name — the EXACT hash the fork's
+/// `canonical_name_key` computes (ggml-moe-residency.hpp: offset basis
+/// 1469598103934665603, prime 1099511628211). One implementation per
+/// side of the wire; the cross-check test pins them byte-for-byte
+/// against her real table's keys.
+pub fn fnv1a_name_key(name: &str) -> u64 {
+    let mut h: u64 = 1_469_598_103_934_665_603;
+    for b in name.as_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(1_099_511_628_211);
+    }
+    h
+}
+
 impl TkeyTable {
+    /// Synthesize the table from model geometry — no JSON file, no
+    /// operator step. Every routed-expert tensor follows the universal
+    /// llama.cpp MoE convention `blk.{layer}.ffn_{gate,up,down}_exps.weight`
+    /// (the same names `expert_pin_keys` renders on the C++ side), so
+    /// `n_layers` alone determines the full tkey→layer map. This is what
+    /// lets the serving daemon tail the trace with ZERO configuration:
+    /// the system owns the seam.
+    pub fn for_layers(n_layers: u32) -> Self {
+        let mut layer_of = HashMap::with_capacity(n_layers as usize * 3);
+        for layer in 0..n_layers {
+            for matrix in ["gate", "up", "down"] {
+                let name = format!("blk.{layer}.ffn_{matrix}_exps.weight");
+                layer_of.insert(fnv1a_name_key(&name), layer);
+            }
+        }
+        Self { layer_of }
+    }
+
     pub fn from_json(json: &str) -> Result<Self, String> {
         #[derive(serde::Deserialize)]
         struct Entry {
@@ -269,6 +301,30 @@ mod tests {
         // Decode-only serve (no prefill trace): never fires.
         let mut det2 = PrefillBoundaryDetector::new();
         assert!((0..10).all(|_| !det2.observe(1472)));
+    }
+
+    /// what this catches: the synthesized table's hash matches the C++
+    /// fork's `canonical_name_key` EXACTLY — pinned against a key from
+    /// her REAL tkey-to-layer-matrix.json (blk.5.ffn_up_exps.weight →
+    /// 16542725649459479844, independently recomputed 2026-08-02). A
+    /// drifted FNV constant would silently map every trace record to
+    /// unknown_tkeys and the actuator would pin nothing.
+    #[test]
+    fn synthesized_table_matches_the_forks_canonical_hash() {
+        assert_eq!(
+            fnv1a_name_key("blk.5.ffn_up_exps.weight"),
+            16542725649459479844,
+            "FNV-1a drifted from the fork's canonical_name_key"
+        );
+        let table = TkeyTable::for_layers(6);
+        assert_eq!(table.len(), 18, "3 matrices × 6 layers");
+        assert_eq!(table.layer(16542725649459479844), Some(5));
+        assert_eq!(
+            table.layer(fnv1a_name_key("blk.0.ffn_gate_exps.weight")),
+            Some(0)
+        );
+        // Layer OUTSIDE the geometry is absent, not misattributed.
+        assert_eq!(table.layer(fnv1a_name_key("blk.6.ffn_gate_exps.weight")), None);
     }
 
     /// what this catches: the table loader against her real JSON shape


### PR DESCRIPTION
The rung-3 actuator leaves the standalone `moe-pager-driver` bin and becomes autonomic: the serving daemon tails the fork's routed-expert trace and carries the bandit's hot pin list on the SAME governed plan file the host-cache lease publishes. One writer, one plan — policy and budget on one document, consumed by her `ResidencyCache`'s per-token mtime poll.

## What
- **Zero-config observation**: spawn now sets `GGML_MOE_TRACE_FILE` per port beside capture/plan (`moe_glass_box_paths`), and `TkeyTable::for_layers(n_layers)` SYNTHESIZES the tkey→layer map from geometry via the fork's exact FNV-1a — no operator JSON step. Hash parity pinned against a key from her REAL `tkey-to-layer-matrix.json` (`blk.5.ffn_up_exps.weight` → `16542725649459479844`, independently recomputed).
- **`capacity/trace_tail.rs` (new)**: `MoeTraceTail` — offset-resumed, truncation-reset (fork reopens `"wb"` per serve), bounded 4 MiB drains with record-aligned skip-ahead on backlog, prefill→decode boundary detection → immediate warm-start publish (prefill's tail predicts ~47–66% of decode experts), and last-published-pins memory.
- **Two-axis write decision** in `publish_moe_host_cache_lease`: the sticky band governs the BUDGET value; pins roll independently. A write happens when either axis moves (or at the boundary), never otherwise — the no-mtime-churn property moved from the band to the write decision.
- **Retention-derived pin budget**: `pin_ceiling` = at most HALF the lease's worth of experts (the recency window keeps the rest); an under-retention lease publishes budget-only — exactly the v1 wire shape her parse was validated against.
- **Probe**: `serving.moe_host_cache_lease` now carries `pins` / `trace_tokens` / `warm_start`.

## Anti-fossil by construction
Pins re-derive from the decay bandit every publish — a static pin set cannot fossilize (the RUN-1 lesson: routed-expert hotness is prompt-dependent; static pins hurt).

## Tests
4 new in `trace_tail` + 1 hash-parity in `segment.rs`, each with `// what this catches:`. expert-pager-policy 18/18; serving_daemon + host_cache_lease + llama_server suites 56/56.

Note: the ts-rs drift guard is red on canary (pre-existing) — fix is PR #2118; this branch will go green once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo