### PR TITLE
feat(cognition): rejected-claim fact — a claim rejection outlives its receipt (#159-family rejection-amnesia fix)

### DIFF
--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -182,7 +182,21 @@ impl ActionCommand for WorkClaim {
                 ttl_ms: p.ttl_ms.unwrap_or(DEFAULT_CLAIM_TTL_MS),
             })
             .await
-            .map_err(|e| CommandError::Internal(e.to_string()))?;
+            .map_err(|e| {
+                // A rejection is WORK-STATE, not a transient tool result: the
+                // raw receipt scrolls out of the persona's short window and the
+                // intent narrative resurfaces as "I've claimed it" (glass-boxed
+                // 2026-08-02, card 44ebaa41). Record it so ActiveWorkSource can
+                // keep the fact in perception past the receipt's lifetime.
+                if let Some(caller) = ctx.caller.as_ref() {
+                    crate::persona::claim_rejections::record(
+                        caller.peer_id.as_uuid(),
+                        &p.card_id,
+                        &e.to_string(),
+                    );
+                }
+                CommandError::Internal(e.to_string())
+            })?;
         Ok(WorkClaimResult {
             card_id: p.card_id,
             claim_id: claim_id.as_uuid().to_string(),

--- a/core/continuum-core/src/persona/active_work_source.rs
+++ b/core/continuum-core/src/persona/active_work_source.rs
@@ -166,6 +166,24 @@ impl RagSource for ActiveWorkSource {
             tokens_used += item.tokens;
             items.push(item);
         }
+        // Rejected-claim facts (the #159-family sibling of the lost-claim
+        // diff): `work/claim` records rejections into the per-persona ring;
+        // rendering them here keeps "that card is NOT yours" in perception
+        // past the raw receipt's short window — the rejection-amnesia fix
+        // (glass-boxed 2026-08-02: accurate rejection reports for three
+        // turns, then "I've claimed the task" once the receipts scrolled).
+        for line in crate::persona::claim_rejections::recent(self.persona_id) {
+            let tokens = estimate_tokens(&line);
+            if tokens_used.saturating_add(tokens) > budget {
+                break;
+            }
+            tokens_used += tokens;
+            items.push(RagItem {
+                content: line,
+                tokens,
+                metadata: json!({ "fact": "claim_rejected" }),
+            });
+        }
         if claims.is_empty() && items.is_empty() {
             return Self::empty();
         }
@@ -279,6 +297,34 @@ mod tests {
                 results: Mutex::new(results),
             }),
         )
+    }
+
+    // what this catches: the rejection-amnesia fix (the #159-family
+    // sibling of claim_lost) — a rejection recorded by work/claim renders
+    // as a [work] claim_rejected fact even when the persona holds ZERO
+    // cards (exactly the amnesia case: nothing claimed, receipt gone,
+    // belief resurfacing), and ONLY for the persona it belongs to.
+    #[tokio::test]
+    async fn rejected_claim_renders_as_fact_for_its_persona_only() {
+        let persona = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        crate::persona::claim_rejections::record(
+            persona,
+            "44ebaa41",
+            "already claimed by another peer",
+        );
+
+        let src = source(persona, vec![Ok(vec![]), Ok(vec![])]);
+        let delivery = src.deliver(&ctx(persona), 10_000, ResolutionPreference::Raw).await;
+        assert_eq!(delivery.items.len(), 1, "rejection fact renders with zero claims");
+        assert!(delivery.items[0].content.contains("44ebaa41"));
+        assert!(delivery.items[0].content.contains("REJECTED"));
+        assert_eq!(delivery.items[0].metadata["fact"], "claim_rejected");
+
+        // Another persona's source never sees it.
+        let src_other = source(other, vec![Ok(vec![])]);
+        let delivery = src_other.deliver(&ctx(other), 10_000, ResolutionPreference::Raw).await;
+        assert!(delivery.items.is_empty());
     }
 
     // what this catches (#156, the Benchy silent-handoff case): a card that

--- a/core/continuum-core/src/persona/claim_rejections.rs
+++ b/core/continuum-core/src/persona/claim_rejections.rs
@@ -1,0 +1,129 @@
+//! Claim-rejection ring — durable perception for REJECTED claim attempts
+//! (the #159-family sibling of the lost-claim transition fact).
+//!
+//! Glass-boxed live 2026-08-02: e5f4141d's claim on card 44ebaa41 was
+//! rejected (held by 90e758b2) and she reported the rejection accurately
+//! for three turns — then, once the raw action receipt scrolled out of
+//! her 2–6 turn window, re-narrated "I've already claimed the task" and
+//! planned work on a card she never held. The board's arbitration keeps
+//! the system safe; the persona's TIME is what burns. The receipt's
+//! lifetime was the bug: a rejection is a WORK-STATE fact, not a
+//! transient tool result, so it must outlive the context squeeze.
+//!
+//! Mechanism: `work/claim` records each rejection here (identity =
+//! the persona's airc peer uuid, the same key `ActiveWorkSource` is
+//! bound to); the source renders the recent entries as `[work]` facts
+//! for [`REJECTION_FACT_TTL`] — long enough to outlive the receipt's
+//! window, short enough not to nag past relevance. Perception fact,
+//! never a gate ([[no-hardcoded-heuristics-to-steer-cognition]]).
+//!
+//! Process-wide singleton, same shape as `install_tracked_dirs` /
+//! `serving_active_artifacts`: the command layer and the RAG source
+//! have no construction-time path to share state, and both already key
+//! the same peer-uuid space.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use uuid::Uuid;
+
+/// How long a rejection stays renderable. ~10 min ≈ several persona
+/// polls — the receipt's 2–6 turn window plus margin, well short of
+/// "nagging about last hour's board state".
+const REJECTION_FACT_TTL: Duration = Duration::from_secs(10 * 60);
+
+/// Ring cap per persona — a claim-storm must not flood perception; the
+/// newest few rejections carry all the signal.
+const MAX_PER_PERSONA: usize = 4;
+
+struct Entry {
+    at: Instant,
+    line: String,
+}
+
+static RING: OnceLock<Mutex<HashMap<Uuid, Vec<Entry>>>> = OnceLock::new();
+
+fn ring() -> &'static Mutex<HashMap<Uuid, Vec<Entry>>> {
+    RING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record a rejected claim attempt for `persona`. `card_ref` is whatever
+/// the persona passed (short id or UUID — echo HER handle back);
+/// `error` is the substrate's rejection verbatim (no parsing, no
+/// paraphrase — honest provenance).
+pub fn record(persona: Uuid, card_ref: &str, error: &str) {
+    record_at(persona, card_ref, error, Instant::now());
+}
+
+fn record_at(persona: Uuid, card_ref: &str, error: &str, now: Instant) {
+    let line = format!(
+        "[work] Your claim on card {card_ref} was REJECTED: {error}. The card is \
+         NOT yours — do not plan or narrate work on it; check the board and pick \
+         other work."
+    );
+    let Ok(mut map) = ring().lock() else { return };
+    let entries = map.entry(persona).or_default();
+    entries.push(Entry { at: now, line });
+    if entries.len() > MAX_PER_PERSONA {
+        let overflow = entries.len() - MAX_PER_PERSONA;
+        entries.drain(..overflow);
+    }
+}
+
+/// The persona's still-live rejection facts, newest last. Prunes expired
+/// entries as it reads (no background sweeper needed for a bounded ring).
+pub fn recent(persona: Uuid) -> Vec<String> {
+    recent_at(persona, Instant::now())
+}
+
+fn recent_at(persona: Uuid, now: Instant) -> Vec<String> {
+    let Ok(mut map) = ring().lock() else {
+        return Vec::new();
+    };
+    let Some(entries) = map.get_mut(&persona) else {
+        return Vec::new();
+    };
+    entries.retain(|e| now.duration_since(e.at) < REJECTION_FACT_TTL);
+    let lines = entries.iter().map(|e| e.line.clone()).collect();
+    if entries.is_empty() {
+        map.remove(&persona);
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the whole ring contract — a recorded rejection
+    // renders for its TTL and ONLY for its persona, expires afterward
+    // (no eternal nag), and the per-persona cap drops oldest-first so a
+    // claim-storm cannot flood perception.
+    #[test]
+    fn rejections_render_per_persona_expire_and_cap() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let t0 = Instant::now();
+
+        record_at(a, "44ebaa41", "already claimed by another peer", t0);
+        let facts = recent_at(a, t0 + Duration::from_secs(60));
+        assert_eq!(facts.len(), 1);
+        assert!(facts[0].contains("44ebaa41"));
+        assert!(facts[0].contains("REJECTED"));
+        assert!(facts[0].contains("already claimed by another peer"));
+        assert!(recent_at(b, t0).is_empty(), "other persona sees nothing");
+
+        // Past TTL: gone, and the persona's slot is cleaned up.
+        assert!(recent_at(a, t0 + REJECTION_FACT_TTL + Duration::from_secs(1)).is_empty());
+
+        // Cap: 6 recorded → the newest MAX_PER_PERSONA survive.
+        for i in 0..6 {
+            record_at(a, &format!("card{i}"), "held", t0);
+        }
+        let facts = recent_at(a, t0 + Duration::from_secs(1));
+        assert_eq!(facts.len(), MAX_PER_PERSONA);
+        assert!(facts.last().is_some_and(|f| f.contains("card5")), "newest kept");
+        assert!(!facts.iter().any(|f| f.contains("card0")), "oldest dropped");
+    }
+}

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -80,6 +80,7 @@ pub mod rag_replay;
 pub mod recall_metadata;
 pub mod redaction;
 pub mod active_work_source;
+pub mod claim_rejections;
 pub mod recorder;
 pub mod resource_forecast;
 pub mod response;


### PR DESCRIPTION
Glass-boxed live 2026-08-02: e5f4141d's claim on card 44ebaa41 was rejected (held by 90e758b2) and she reported the rejection ACCURATELY for three consecutive turns — then, once the raw action receipt scrolled out of her 2–6 turn window, re-narrated 'I've already claimed the task' and began planning work on a card she never held. The board's arbitration keeps the system safe; her turns are what burn. Root cause: a rejection is WORK-STATE, not a transient tool result — it must outlive the context squeeze.

## What
- **`persona/claim_rejections.rs` (new)**: per-persona rejection ring (process singleton, same shape as `install_tracked_dirs`). 10-minute TTL — several polls past the receipt's window, never an eternal nag; capped at 4 per persona so a claim-storm can't flood perception. The substrate's error text is carried VERBATIM (honest provenance, no paraphrase).
- **`work/claim`** records each rejection under the caller's peer uuid — the same identity space `ActiveWorkSource` is bound to.
- **`ActiveWorkSource`** renders live entries as `[work] claim_rejected` facts beside the #2114 lost-claim diff — the two halves of one contract: a claim you LOST and a claim you never GOT both stay in perception as long as the belief could resurface. Perception fact, never a gate.

## Tests
Ring contract (per-persona scoping + TTL expiry + oldest-first cap) with injected clock; source integration (fact renders with ZERO claims — exactly the amnesia shape — and only for its persona). `claim_rejections` + `active_work_source` + `prompt_assembly` (the consumer #2116 taught me to run) + `modules::work` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo