### PR TITLE
feat(work): claim_id accepts the short id the board SHOWS (#164 slice: release + heartbeat)

### DIFF
--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -109,10 +109,33 @@ async fn resolve_card_id(
         .map_err(CommandError::Invalid)
 }
 
-fn parse_claim_id(s: &str) -> Result<ClaimId, CommandError> {
-    Uuid::parse_str(s)
+/// Resolve a claim id the same way [`resolve_card_id`] resolves cards (#164:
+/// short-form ids must resolve on EVERY id param, not just card_id). The board
+/// projection and the [work] grounding facts render claim ids in short form, so
+/// the lifecycle verbs (release/heartbeat) must accept the handle the persona
+/// was SHOWN. Candidates are the live board's claim ids; the prefix/near-miss
+/// decision is the shared `id_resolve` primitive — one resolution behavior for
+/// every id kind, no second copy of the rules.
+async fn resolve_claim_id(
+    airc: &std::sync::Arc<airc_lib::Airc>,
+    s: &str,
+) -> Result<ClaimId, CommandError> {
+    if let crate::id_resolve::IdMatch::Full(id) = crate::id_resolve::normalize(s) {
+        return Ok(ClaimId::from_uuid(id));
+    }
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .map_err(|e| CommandError::Internal(format!("board read for claim resolution: {e}")))?
+        .snapshot();
+    let candidates: Vec<Uuid> = board
+        .cards
+        .iter()
+        .filter_map(|c| c.claim_id.map(|id| id.as_uuid()))
+        .collect();
+    crate::id_resolve::resolve(s, &candidates, "claim")
         .map(ClaimId::from_uuid)
-        .map_err(|e| CommandError::Invalid(format!("invalid claim_id '{s}': {e}")))
+        .map_err(CommandError::Invalid)
 }
 
 fn parse_state(s: &str) -> Result<CardState, CommandError> {
@@ -285,17 +308,15 @@ impl ActionCommand for WorkRelease {
     const NAME: &'static str = "work/release";
     const ACCESS: AccessLevel = AccessLevel::AiSafe;
     const DESCRIPTION: &'static str =
-        "Release your claim on a work card (pass card_id + the claim_id from work/claim).";
+        "Release your claim on a work card (pass card_id + the claim_id from work/claim; \
+         short 8-char ids from the board are accepted for both).";
     type Params = WorkReleaseParams;
     type Output = WorkReleaseResult;
 
     async fn run(&self, ctx: &Ctx, p: WorkReleaseParams) -> Result<WorkReleaseResult, CommandError> {
         let airc = persona_airc(&self.registry, ctx)?;
         let card_id = resolve_card_id(&airc, &p.card_id).await?;
-        let claim_id = ClaimId::from_uuid(
-            Uuid::parse_str(&p.claim_id)
-                .map_err(|e| CommandError::Invalid(format!("invalid claim_id: {e}")))?,
-        );
+        let claim_id = resolve_claim_id(&airc, &p.claim_id).await?;
         airc.release_work_claim(ReleaseWorkClaim {
             card_id,
             claim_id,
@@ -380,14 +401,15 @@ impl ActionCommand for WorkHeartbeat {
     const NAME: &'static str = "work/heartbeat";
     const ACCESS: AccessLevel = AccessLevel::AiSafe;
     const DESCRIPTION: &'static str =
-        "Extend your claim lease on a card so it doesn't go stale during long work (pass card_id + claim_id).";
+        "Extend your claim lease on a card so it doesn't go stale during long work (pass card_id + \
+         claim_id; short 8-char ids from the board are accepted for both).";
     type Params = WorkHeartbeatParams;
     type Output = WorkHeartbeatResult;
 
     async fn run(&self, ctx: &Ctx, p: WorkHeartbeatParams) -> Result<WorkHeartbeatResult, CommandError> {
         let airc = persona_airc(&self.registry, ctx)?;
         let card_id = resolve_card_id(&airc, &p.card_id).await?;
-        let claim_id = parse_claim_id(&p.claim_id)?;
+        let claim_id = resolve_claim_id(&airc, &p.claim_id).await?;
         airc.heartbeat_work_claim(HeartbeatWorkClaim {
             card_id,
             claim_id,


### PR DESCRIPTION
The #161 fix taught `card_id` to accept the projection's 8-char handles via the shared `id_resolve` primitive — but the lifecycle verbs' `claim_id` params still demanded full 32-char UUIDs: the exact positron-consistency break that bounced Anwen and Asha on cards, one param over.

`resolve_claim_id` mirrors `resolve_card_id`: full-UUID fast path, else prefix resolution against the live board's claim ids (near-miss messages name the available ids). Both `work/release` and `work/heartbeat` converge on it; the UUID-only `parse_claim_id` and release's inline duplicate parse are deleted — one resolution behavior per id kind. Command descriptions teach the short form.

Remaining #164 scope: the generic per-type resolver at the dispatch base — this is its second proven consumer (outlier B in the pattern's own terms).

`cargo check` clean; `modules::work` + `id_resolve` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo