### PR TITLE
feat(serving): device-side expert-slot budget on the governed plan — free-VRAM-after-fit (#305)

### DIFF
--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -215,6 +215,15 @@ pub struct ServingDaemonModule {
     /// never republishes; a material shrink publishes NOW; grow-back publishes past
     /// the band (#214). Same sync-Mutex discipline as `moe_serving` (never across await).
     host_cache_lease: std::sync::Mutex<crate::capacity::host_cache_lease::StickyLease>,
+    /// Sticky publisher state for the DEVICE-side expert-slot budget (#305;
+    /// BigMama's measured ask): free-VRAM-after-device-fit, from the live
+    /// resource board (the serve's own residency is already a registered
+    /// consumer per #79, so the board's available IS post-fit), less the
+    /// placement margin. Same band + same never-thrash discipline as the
+    /// host lease — raw VRAM flutters every tick; the published budget
+    /// moves only on material change. Warm coverage scales directly with
+    /// this (measured 2026-08-02: 13.8% @ 1.9 GiB → 65.7% @ 30 GiB).
+    device_budget_lease: std::sync::Mutex<crate::capacity::host_cache_lease::StickyLease>,
     /// The artifact path currently registered in the process-wide
     /// [`serving_active_artifacts`](crate::system_resources::serving_active_artifacts)
     /// set (#302 invariant 1: the NvmeServingTierPool must never migrate the
@@ -334,6 +343,9 @@ impl ServingDaemonModule {
             active_artifact: std::sync::Mutex::new(None),
             moe_trace_tail: std::sync::Mutex::new(None),
             host_cache_lease: std::sync::Mutex::new(
+                crate::capacity::host_cache_lease::StickyLease::new(HOST_CACHE_LEASE_BAND_DIVISOR),
+            ),
+            device_budget_lease: std::sync::Mutex::new(
                 crate::capacity::host_cache_lease::StickyLease::new(HOST_CACHE_LEASE_BAND_DIVISOR),
             ),
             // Read ONCE here (single config entry point, no per-tick I/O). Off by default.
@@ -810,6 +822,25 @@ impl ServingDaemonModule {
         if budget_bytes == 0 {
             return; // nothing governed yet — never publish a zero lease
         }
+        // DEVICE axis (#305, BigMama's measured ask): the copy-stream's
+        // expert-slot budget = live free-VRAM-after-fit less the placement
+        // margin. The board's `available(Vram)` is already net of the
+        // resident serve (#79 registers it as a consumer), so this is
+        // exactly "size to the free VRAM AFTER device-fit, not a fixed
+        // number". Sticky like the host axis; a zero publishes as ABSENT
+        // (the mechanism keeps its own sizing), never as a zero budget.
+        let device_derived = governed_vram_ceiling(&self.resource_daemon)
+            .unwrap_or(0)
+            .saturating_sub(EXPERT_PLACEMENT_MARGIN_BYTES);
+        let (device_budget_bytes, device_moved) = {
+            let Ok(mut sticky) = self.device_budget_lease.lock() else {
+                return;
+            };
+            match sticky.observe(device_derived) {
+                Some(published) => (published, true),
+                None => (sticky.published_bytes(), false),
+            }
+        };
         let Some(gb) = crate::inference::llama_server::moe_glass_box_paths(port) else {
             return;
         };
@@ -853,15 +884,18 @@ impl ServingDaemonModule {
                 tail.schedulable_coverage_x100(),
             )
         };
-        if !budget_moved && !pins_moved && !boundary_crossed {
-            return; // neither axis changed — no write, no mtime churn
+        if !budget_moved && !pins_moved && !boundary_crossed && !device_moved {
+            return; // no axis changed — no write, no mtime churn
         }
         let pins_count = pins.len();
-        let doc = crate::capacity::plan_file::PlanFileDocument::new(
+        let mut doc = crate::capacity::plan_file::PlanFileDocument::new(
             budget_bytes,
             MOE_PLAN_WINDOW_K,
             pins,
         );
+        if device_budget_bytes > 0 {
+            doc = doc.with_device_budget(device_budget_bytes);
+        }
         // Retention verdict (#287): does the published lease retain even one
         // token's expert working set? Below 100 (×100 fixed-point) the cache
         // buys NOTHING — every token evicts the previous token's experts (the
@@ -891,6 +925,8 @@ impl ServingDaemonModule {
                 class = "serving.moe_host_cache_lease",
                 model = active.as_str(),
                 budget_bytes,
+                device_budget_bytes,
+                device_derived_bytes = device_derived,
                 derived_bytes = derived,
                 weights_host_bytes = inputs.weights_host_bytes,
                 live_kv_bytes = inputs.live_kv_bytes,

--- a/core/expert-pager-policy/src/plan_file.rs
+++ b/core/expert-pager-policy/src/plan_file.rs
@@ -95,6 +95,17 @@ pub struct PlanFileDocument {
     /// byte-identical to the v1 wire.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_tier: Option<u32>,
+    /// DEVICE-side expert-slot byte budget for the copy-stream fetcher
+    /// (#305; BigMama's measured ask, 2026-08-02): how much VRAM the
+    /// `DeviceUploadFetcher` may fill with resident expert slots, derived
+    /// LIVE from free-VRAM-after-device-fit — never a constant. Warm
+    /// coverage scales directly with this (measured on run2.trace:
+    /// 13.8% @ 1.9 GiB → 51.3% @ 15 GiB → 65.7% @ 30 GiB, one slot ≈ one
+    /// 8.09 MB expert record), so the mechanism sizes `slots =
+    /// device_budget_bytes / record_bytes`. `None` = the mechanism keeps
+    /// its own sizing (pre-#305 wire, byte-identical on serialize).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub device_budget_bytes: Option<u64>,
 }
 
 impl PlanFileDocument {
@@ -105,12 +116,19 @@ impl PlanFileDocument {
             window_k,
             pin_list,
             default_tier: None,
+            device_budget_bytes: None,
         }
     }
 
     /// Set the ladder index unpinned experts fetch from.
     pub fn with_default_tier(mut self, tier: u32) -> Self {
         self.default_tier = Some(tier);
+        self
+    }
+
+    /// Set the device-side expert-slot budget (free-VRAM-after-fit derived).
+    pub fn with_device_budget(mut self, bytes: u64) -> Self {
+        self.device_budget_bytes = Some(bytes);
         self
     }
 }
@@ -208,6 +226,36 @@ mod tests {
         }
         let back: PlanFileDocument = serde_json::from_str(&json).expect("round trip");
         assert_eq!(back, doc);
+    }
+
+    /// what this catches (#305 device-budget extension): a document with
+    /// no device budget serializes byte-identical to the pre-#305 wire
+    /// her deployed consumer parses (no `device_budget_bytes` key at
+    /// all); a budget-carrying document pins the literal field name her
+    /// fetcher binds to; and a pre-#305 document still parses (None).
+    /// Additive-optional or lockstep — this enforces additive.
+    #[test]
+    fn device_budget_is_optional_on_the_wire_and_prior_documents_still_parse() {
+        let plain = PlanFileDocument::new(1_000, 8, vec![]);
+        let json = serde_json::to_string(&plain).expect("serialize");
+        assert!(
+            !json.contains("device_budget_bytes"),
+            "absent budget must not serialize: {json}"
+        );
+
+        let with = PlanFileDocument::new(1_000, 8, vec![]).with_device_budget(16_106_127_360);
+        let json = serde_json::to_string(&with).expect("serialize");
+        assert!(
+            json.contains("\"device_budget_bytes\":16106127360"),
+            "literal field name pinned: {json}"
+        );
+        let back: PlanFileDocument = serde_json::from_str(&json).expect("round trip");
+        assert_eq!(back.device_budget_bytes, Some(16_106_127_360));
+
+        // Pre-#305 document (no key) parses with None.
+        let old = r#"{"version":1,"budget_bytes":1000,"window_k":8,"pin_list":[]}"#;
+        let back: PlanFileDocument = serde_json::from_str(old).expect("old wire parses");
+        assert_eq!(back.device_budget_bytes, None);
     }
 
     /// what this catches (precision-hint extension, 2026-08-01): a


### PR DESCRIPTION
BigMama's measured ask off the run2.trace coverage sweep: warm coverage scales directly with expert-slot VRAM (13.8% @ 1.9GiB → 51.3% @ 15GiB → 65.7% @ 30GiB, slot ≈ 8.09MB), bandit beats naive recency +7–9pts at matched VRAM. The copy-stream budget must therefore track LIVE free-VRAM-after-device-fit — never a constant.

- **Wire** (expert-pager-policy): additive-optional `device_budget_bytes` on `PlanFileDocument` + `with_device_budget`; absent field = byte-identical pre-#305 wire (goldens untouched, new test pins the literal field name + old-document parse).
- **Daemon**: the resource board's `available(Vram)` is already net of the resident serve (#79), so device budget = governed ceiling − placement margin, published through its own `StickyLease` (same 1/8 band as the host axis) as a third axis on the no-churn write gate. Probe carries both derived and published values.

19 leaf-crate + 26 serving_daemon tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo