### PR TITLE
fix(work): add WorkList + WorkGet to the module dispatch list (#309 final layer)

### DIFF
--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -626,6 +626,8 @@ impl ServiceModule for WorkModule {
 
     fn commands(&self) -> Vec<Arc<dyn DynCommand>> {
         vec![
+            Arc::new(WorkList { registry: self.registry.clone() }),
+            Arc::new(WorkGet { registry: self.registry.clone() }),
             Arc::new(WorkClaim { registry: self.registry.clone() }),
             Arc::new(WorkCreate { registry: self.registry.clone() }),
             Arc::new(WorkRelease { registry: self.registry.clone() }),


### PR DESCRIPTION
The last layer of the registered-but-invisible onion, found live: `register_command!` feeds the descriptor registry (help/suggestions/offer) while the module's `commands()` vec is what dispatches — the two new read verbs were never added, so Benchy's first-ever live native `list_tasks` call was refused with a did-you-mean listing `work/list` itself. Two lines. Deployed and live-verified: receipt #1489 returned real board cards and Benchy posted a summary of 17 open cards to the room — the first persona board read.

Follow-up card: registry-parity guard (every NATIVE/AiSafe descriptor must be dispatchable) to kill this class at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo