### PR TITLE
guard(registry): dispatch-parity audit + outbound tool-surface wire probe

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -1912,6 +1912,22 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
             }
         }
 
+        // Wire truth for the tool surface (glass-box, 2026-08-03): live residents
+        // narrated for hours with zero tool calls while every offline replay of the
+        // same context+tools+sampling called instantly — the ONLY remaining unknown
+        // was what this body actually carried. This probe states it per request so
+        // "tools offered" is never inferred from a capture again.
+        crate::probe!(
+            class = "ai.request.tool_surface",
+            model = %model,
+            tools_n = body.get("tools").and_then(|t| t.as_array()).map_or(0, |a| a.len()),
+            tool_choice = body.get("tool_choice").is_some(),
+            stops_n = body.get("stop").and_then(|s| s.as_array()).map_or(0, |a| a.len()),
+            msgs_n = body.get("messages").and_then(|m| m.as_array()).map_or(0, |a| a.len()),
+            temperature = body.get("temperature").and_then(|t| t.as_f64()).unwrap_or(-1.0),
+            "outbound chat request tool surface"
+        );
+
         // Make request — the endpoint base for THIS request's model. Normally the
         // runtime/config base; for the local serving gateway, a request for the
         // snapshot's VISION model (the #106 sidecar lane serving beside a

--- a/core/continuum-core/src/runtime/registry.rs
+++ b/core/continuum-core/src/runtime/registry.rs
@@ -126,6 +126,27 @@ impl ModuleRegistry {
         self.type_routes.insert(type_id, name);
     }
 
+    /// Dispatch-parity audit — the structural kill for the registered-but-
+    /// undispatchable class (#309's final layer, found live 2026-08-03): every
+    /// command DESCRIPTOR (what `commands/help`, did-you-mean suggestions, and the
+    /// persona tool offer all advertise) must be DISPATCHABLE — either a typed
+    /// command object, or a module prefix route. `register_command!` (descriptors)
+    /// and `commands()` (dispatch) are two per-module lists a human must keep in
+    /// sync; `work/list` shipped advertised-but-unroutable for a night because
+    /// nothing checked. Benchy's first-ever live native tool call was refused with
+    /// a did-you-mean listing the refused name ITSELF — the two registries
+    /// disagreeing in one sentence. Returns the orphan names; the boot path logs
+    /// them as ERRORs so the gap is loud on the very first startup that ships it.
+    pub fn dispatch_orphans(&self) -> Vec<&'static str> {
+        crate::sdk_codegen::command_registry()
+            .into_iter()
+            .map(|d| d.name)
+            .filter(|name| {
+                !self.command_objects.contains_key(name) && self.route_command(name).is_none()
+            })
+            .collect()
+    }
+
     /// Route a command to the correct module.
     /// Returns (module, full_command) — the module receives the full command string.
     /// Replaces the 55-arm match statement.
@@ -360,5 +381,46 @@ mod tests {
         // Can find by type
         let found = registry.module_of_type::<TestModule>();
         assert!(found.is_some());
+    }
+
+    // what this catches: the registered-but-undispatchable class (#309 final layer —
+    // work/list shipped advertised in help/suggestions/the tool offer while dispatch
+    // refused it, live 2026-08-03). dispatch_orphans must read BOTH sides: with no
+    // module registered, every dep-holding descriptor is an orphan (proves it reads
+    // the descriptor registry, and that stateless self-registering commands are
+    // exempt by construction); registering the work module clears ALL SEVEN work
+    // verbs (proves objects clear orphans — and pins that commands() carries every
+    // verb the descriptors advertise, the exact two-line gap that shipped).
+    #[test]
+    fn dispatch_orphans_reads_descriptors_and_clears_on_module_registration() {
+        let registry = ModuleRegistry::new();
+        let before = registry.dispatch_orphans();
+        let work_names = [
+            "work/list",
+            "work/get",
+            "work/claim",
+            "work/create",
+            "work/release",
+            "work/state",
+            "work/heartbeat",
+        ];
+        for name in work_names {
+            assert!(
+                before.contains(&name),
+                "{name} must be an orphan before its module registers"
+            );
+        }
+
+        registry.register(std::sync::Arc::new(crate::modules::work::WorkModule::new(
+            crate::persona::PersonaAircRuntimeRegistry::new(),
+        )));
+        let after = registry.dispatch_orphans();
+        for name in work_names {
+            assert!(
+                !after.contains(&name),
+                "{name} still orphaned after WorkModule registered — a verb is \
+                 missing from commands() (the #309 two-line gap)"
+            );
+        }
     }
 }

--- a/core/continuum-core/src/runtime/runtime.rs
+++ b/core/continuum-core/src/runtime/runtime.rs
@@ -159,6 +159,23 @@ impl Runtime {
         let modules = self.registry.list_modules();
         info!("Initializing {} modules...", modules.len());
 
+        // Dispatch-parity audit (see [`ModuleRegistry::dispatch_orphans`]): every
+        // advertised command must be routable NOW, before any client can be told
+        // it exists. ERROR (not panic) so a drift is loud on the first boot that
+        // ships it without bricking the substrate; promote to a boot refusal once
+        // the count holds at zero across the fleet.
+        let orphans = self.registry.dispatch_orphans();
+        if !orphans.is_empty() {
+            tracing::error!(
+                probe_class = "registry.dispatch_parity",
+                orphans = ?orphans,
+                count = orphans.len(),
+                "ADVERTISED-BUT-UNDISPATCHABLE commands: these appear in help, \
+                 suggestions, and the persona tool offer but cannot route — add each \
+                 to its module's commands() vec (the work/list class, #309)"
+            );
+        }
+
         // Per-module init deadline. A module's `initialize()` is meant to be fast
         // (in-memory wiring; heavy work is detached / tick-driven), so 60s is a
         // wedged-init backstop, NOT a normal budget — it bounds the airc-120s-hang


### PR DESCRIPTION
Two fixes from tonight's live hunt, per 'fix bugs as you find em':

1. **Dispatch-parity audit** — `dispatch_orphans()` verifies at boot that every advertised command descriptor is actually routable (typed object or prefix route), logging each orphan as an ERROR probe before any client can be told it exists. The structural kill for the `work/list` registered-but-undispatchable class; the new test **failed on the pre-fix tree** and passes post-merge — it catches the exact bug that shipped.

2. **Wire-truth probe** (`ai.request.tool_surface`, already live-deployed) — tools_n/stops_n/msgs_n/temperature per outbound chat request, so the tool offer is never inferred from a capture again. This probe exonerated the model and the transport in ~10 minutes tonight after hours of layer-peeling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo