### PR TITLE
The work board was structurally invisible: fix the flattening, and the window it was flattened into (#331/#128/#234/#327)

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -703,7 +703,21 @@ impl LlmDeliberationFaculty {
             .sum()
     }
 
-    fn render_assembled_context_within(&self, ws: &Workspace, budget_tokens: usize) -> String {
+    /// `composition` is `(context_window, framing, fitted_conversation, ctx_floor)`
+    /// — the terms that PRODUCED `budget_tokens`. Carried purely so this probe and
+    /// `delib.turn.demand` can be reconciled against each other: read separately
+    /// they disagreed (Atlas showed `after_framing 9,243 − conv 4,334` yet rendered
+    /// `budget=287`) and nothing on hand could say which was wrong, because the two
+    /// numbers lived in different probes with no shared term. A seam that can only
+    /// be reasoned about by cross-referencing two records is a seam that gets
+    /// guessed at ([[a-probe-that-can-only-fail-is-worse-than-no-probe]]).
+    fn render_assembled_context_within(
+        &self,
+        ws: &Workspace,
+        budget_tokens: usize,
+        composition: (u32, usize, usize, usize),
+    ) -> String {
+        let (context_window, framing_tokens, conversation_tokens, ctx_floor) = composition;
         if budget_tokens == 0 {
             // Received-vs-rendered receipt even on the zero-budget path — a turn
             // whose entire context vanished must say so, not render silently empty
@@ -714,6 +728,10 @@ impl LlmDeliberationFaculty {
                 class = "delib.context.render",
                 persona = %self.persona_name,
                 budget_tokens = 0usize,
+                context_window,
+                framing_tokens,
+                conversation_tokens,
+                ctx_floor,
                 received = ws.broadcast.iter().filter(|c| c.decision.is_none() && !c.trailing).count(),
                 rendered = 0usize,
                 dropped = %ws
@@ -837,6 +855,10 @@ impl LlmDeliberationFaculty {
             class = "delib.context.render",
             persona = %self.persona_name,
             budget_tokens,
+            context_window,
+            framing_tokens,
+            conversation_tokens,
+            ctx_floor,
             used_tokens = used,
             received,
             rendered = selected.len(),
@@ -1053,7 +1075,11 @@ impl LlmDeliberationFaculty {
             .saturating_sub(used_msg_tokens)
             .saturating_sub(est_tokens(deliberation_prompt::WORKING_CONTEXT_HEADER))
             .max(ctx_floor.saturating_sub(est_tokens(deliberation_prompt::WORKING_CONTEXT_HEADER)));
-        let context = self.render_assembled_context_within(ws, ctx_budget);
+        let context = self.render_assembled_context_within(
+            ws,
+            ctx_budget,
+            (context_window, framing_tokens, used_msg_tokens, ctx_floor),
+        );
 
         DeliberationPromptView {
             system: self.compose_system(
@@ -2044,7 +2070,7 @@ mod tests {
             );
 
             // Generous budget so BOTH fit — this isolates ORDER, not truncation.
-            let block = faculty.render_assembled_context_within(&ws, 4096);
+            let block = faculty.render_assembled_context_within(&ws, 4096, (0, 0, 0, 0));
             let roster_at = block.find("[room-roster]").expect("roster present");
             let recall_at = block.find("[recall]").expect("recall present");
             assert!(
@@ -2130,7 +2156,7 @@ mod tests {
             let total = board.parts.len();
             ws.broadcast.push(board);
 
-            let block = faculty.render_assembled_context_within(&ws, 120);
+            let block = faculty.render_assembled_context_within(&ws, 120, (0, 0, 0, 0));
             assert!(
                 block.contains("run `work/list`"),
                 "the notice must name the verb verbatim, not describe it\n{block}"
@@ -2153,7 +2179,7 @@ mod tests {
             let mut ws = Workspace::new("anything open?");
             ws.broadcast.push(board_like(60)); // expand_command defaults to None
 
-            let block = faculty.render_assembled_context_within(&ws, 120);
+            let block = faculty.render_assembled_context_within(&ws, 120, (0, 0, 0, 0));
             assert!(block.contains("more not shown"), "still says it truncated\n{block}");
             assert!(
                 !block.contains("run `"),
@@ -2181,7 +2207,7 @@ mod tests {
             // A budget FAR under the whole board — the live shape (55 vs 5,364).
             let budget = 120;
             assert!(whole > budget * 10, "fixture must reproduce the live ratio");
-            let block = faculty.render_assembled_context_within(&ws, budget);
+            let block = faculty.render_assembled_context_within(&ws, budget, (0, 0, 0, 0));
 
             assert!(
                 block.contains("[room-kanban]"),
@@ -2228,7 +2254,7 @@ mod tests {
                 "recalled",
             ));
 
-            let block = faculty.render_assembled_context_within(&ws, 40);
+            let block = faculty.render_assembled_context_within(&ws, 40, (0, 0, 0, 0));
             assert!(
                 !block.contains("[recall]"),
                 "an over-budget INDIVISIBLE contribution must be dropped whole, not \
@@ -2252,7 +2278,7 @@ mod tests {
             let mut ws = Workspace::new("anything open?");
             ws.broadcast.push(board_like(60));
 
-            let block = faculty.render_assembled_context_within(&ws, 4);
+            let block = faculty.render_assembled_context_within(&ws, 4, (0, 0, 0, 0));
             assert!(
                 !block.contains("[room-kanban]"),
                 "no unit fits, so there must be no header — a labelled empty block is a \

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -193,6 +193,21 @@ pub struct LlmDeliberationFaculty {
     /// reproducible; her live cognition leaves it `None`. Read wait-free per
     /// generation, exactly like `genome`.
     decoding: DecodingHandle,
+    /// Where this mind reports what its turns actually COST — the measurement the
+    /// served window is provisioned from ([`super::working_set`]).
+    ///
+    /// This faculty is the only place that knows a turn's TRUE size, because it is
+    /// the place that assembles the prompt and therefore the place that sees what it
+    /// had to throw away: the conversation before newest-first trimming, and every
+    /// grounding contribution offered including the ones that did not fit. Downstream
+    /// of here that information is gone, which is why the serving planner had to
+    /// guess with a constant.
+    ///
+    /// `None` in tests and in any path with no serving planner to inform — recording
+    /// is then simply skipped. Shared (cheap clone) with the serving daemon that reads
+    /// the ceiling; deliberately NOT a process global, because that value feeds a
+    /// decision and a global read inside a decision makes tests order-dependent.
+    working_set: Option<super::working_set::WorkingSetRegistry>,
 }
 
 impl LlmDeliberationFaculty {
@@ -223,7 +238,16 @@ impl LlmDeliberationFaculty {
             prompt_capture: None,
             genome: empty_genome(),
             decoding: relaxed_decoding(),
+            working_set: None,
         }
+    }
+
+    /// Share the registry this mind reports its turn demand into — the measurement
+    /// `serving_plan` provisions the window from. Wired by the live spawn path; absent
+    /// in tests, where there is no planner to inform.
+    pub fn with_working_set(mut self, registry: super::working_set::WorkingSetRegistry) -> Self {
+        self.working_set = Some(registry);
+        self
     }
 
     /// Share the persona's decoding handle — the same [`ArcSwap`] the owning
@@ -663,6 +687,22 @@ impl LlmDeliberationFaculty {
     /// half-truncated engram is noise, so a lower-salience item that still fits is
     /// preferred over a mangled high-salience one. Same drop-whole-in-priority
     /// philosophy as `FlexboxRagBudgetAdapter`.
+    /// What ALL the grounding offered this turn would cost if none of it had to be
+    /// dropped — the grounding half of a turn's demand ([`super::working_set`]).
+    ///
+    /// Counted over the same set `render_assembled_context_within` selects from, with
+    /// the same per-item header charge, so the two agree on what a contribution costs
+    /// and only disagree on how much of it survives. Measured 2026-08-06 this is the
+    /// dominant term: the work board alone offered a median 5,364 tokens into a
+    /// context budget with a median of 55.
+    fn assembled_context_cost(ws: &Workspace) -> usize {
+        ws.broadcast
+            .iter()
+            .filter(|c| c.decision.is_none() && !c.trailing)
+            .map(|c| est_tokens(c.faculty.as_str()) + est_tokens(&c.content) + 2)
+            .sum()
+    }
+
     fn render_assembled_context_within(&self, ws: &Workspace, budget_tokens: usize) -> String {
         if budget_tokens == 0 {
             // Received-vs-rendered receipt even on the zero-budget path — a turn
@@ -919,7 +959,51 @@ impl LlmDeliberationFaculty {
         // is what the turn is about — the same priority the old flat head-trim had,
         // now at turn granularity).
         let msg_budget = budget.saturating_sub(framing_tokens);
-        let messages = self.messages_within(ws, msg_budget);
+        let all_messages = self.messages_unfitted(ws);
+
+        // WHAT THIS TURN WOULD HAVE COST WITH NO BUDGET — recorded before either
+        // fitting step throws the evidence away, and deliberately free to exceed
+        // `context_window`. That excess IS the signal: it is the only way a mind held
+        // at a too-small window can ever report that it needed a bigger one, and the
+        // measurement `serving_plan` provisions from (see [`super::working_set`]).
+        //
+        // Measuring the prompt we actually SEND instead would measure the clamp — a
+        // citizen capped at 8192 fills 8192, so a p95 of what-was-sent re-derives the
+        // cap that produced it and freezes it forever. Every term below is therefore
+        // the UNTRUNCATED one.
+        let demand_tokens = framing_tokens
+            .saturating_add(Self::messages_cost(&all_messages))
+            .saturating_add(Self::assembled_context_cost(ws))
+            .saturating_add(est_tokens(deliberation_prompt::WORKING_CONTEXT_HEADER))
+            .saturating_add(completion_reserve)
+            .saturating_add(self.describe_tool_tokens());
+        if let Some(reg) = &self.working_set {
+            reg.record(
+                self.persona_id,
+                demand_tokens.min(u32::MAX as usize) as u32,
+                // `now_ms` is the workspace's own clock when the cycle stamped one;
+                // 0 when it didn't. The registry keeps peaks, not a time series, so an
+                // unstamped cycle still contributes its measurement honestly.
+                ws.now_ms.unwrap_or(0),
+            );
+        }
+        crate::probe!(
+            class = "delib.turn.demand",
+            persona = %self.persona_name,
+            demand_tokens,
+            context_window,
+            framing_tokens,
+            conversation_tokens = Self::messages_cost(&all_messages),
+            grounding_tokens = Self::assembled_context_cost(ws),
+            completion_reserve,
+            // The honest headline: >1.0 means this turn wanted more window than it had,
+            // and by how much. This is the number that decides whether the served
+            // window is provisioned for the work or for a constant.
+            over_window = demand_tokens as f32 / (context_window.max(1) as f32),
+            "turn demand vs served window"
+        );
+
+        let messages = self.fit_messages(all_messages, msg_budget);
 
         // Whatever remains after framing + conversation goes to enrichment
         // context. The framing estimate above was taken with an EMPTY context,
@@ -981,6 +1065,18 @@ impl LlmDeliberationFaculty {
     /// so it neither bleeds identity nor replays the transcript (the echo-loop root
     /// cause — PERSONA-COGNITION-PIPELINE §7.5).
     fn messages_within(&self, ws: &Workspace, budget_tokens: usize) -> Vec<ChatMessage> {
+        self.fit_messages(self.messages_unfitted(ws), budget_tokens)
+    }
+
+    /// The conversation as it stands BEFORE any budget is applied — every turn, every
+    /// perception fact, every trailing proprioception block, in final render order.
+    ///
+    /// Split out from the fitting step so a turn's TRUE conversational size is
+    /// knowable. Fitting is lossy by design (newest-first, oldest dropped), and once
+    /// it has run the question "how much did this turn actually want?" is
+    /// unanswerable — which is precisely why the served window had to be sized by a
+    /// constant instead of by demand. [`super::working_set`] measures this.
+    fn messages_unfitted(&self, ws: &Workspace) -> Vec<ChatMessage> {
         // Collapse consecutive same-role turns into one message each (chronological).
         // Her OWN near-duplicate turns are DROPPED after the first: replaying
         // `assistant: X` three times teaches the model that repeating X is its
@@ -1117,7 +1213,35 @@ impl LlmDeliberationFaculty {
         if messages.is_empty() {
             return vec![ChatMessage::text("user", ws.world_state.clone())];
         }
+        messages
+    }
 
+    /// The per-message chat-template overhead every message pays, whether it is being
+    /// measured for demand or fitted to a budget. ONE constant so the two cannot drift
+    /// — an under-count here is an llama-server 400 at the window edge.
+    ///
+    /// Chat templates wrap each message in role markers
+    /// (`<|im_start|>role\n…<|im_end|>`, ~4-5 tokens). The original +2 was optimistic:
+    /// at the budget edge the fitted thread measured over the window by a token
+    /// (glass-boxed 2026-07-13). Round UP like every other estimate here.
+    // context-budget-exempt: fixed chat-template overhead per message (role tags + separators) — a property of the prompt FORMAT, not a budget that should scale with the window
+    const PER_MESSAGE_TEMPLATE_TOKENS: usize = 5;
+
+    /// What this conversation costs whole, with no budget applied — the conversational
+    /// half of a turn's demand ([`super::working_set`]).
+    fn messages_cost(messages: &[ChatMessage]) -> usize {
+        messages
+            .iter()
+            .map(|m| est_tokens(&m.content_text()) + Self::PER_MESSAGE_TEMPLATE_TOKENS)
+            .sum()
+    }
+
+    /// Fit an already-built conversation to `budget_tokens`.
+    fn fit_messages(
+        &self,
+        messages: Vec<ChatMessage>,
+        budget_tokens: usize,
+    ) -> Vec<ChatMessage> {
         // Fit to the served window, NEWEST-first: walk the thread from the most
         // recent message backward, giving each the remaining budget. A whole message
         // that fits is kept intact; the one that straddles the budget boundary is
@@ -1126,21 +1250,14 @@ impl LlmDeliberationFaculty {
         // flat head-trim: the latest activity always survives (it is what the turn is
         // about), and for the opaque single-turn (eval/test/replay) path it reduces
         // EXACTLY to the previous `tail_to_tokens(world_state, budget)` behavior.
-        // Per-message role/template framing the model pays: chat templates
-        // wrap each message in role markers (`<|im_start|>role\n…<|im_end|>`,
-        // ~4-5 tokens). The original +2 was optimistic — at the budget edge
-        // the fitted thread measured over the window by a token (glass-boxed
-        // 2026-07-13); round UP like every other estimate here (under-counting
-        // risks the llama-server 400, over-counting costs a few tokens of
-        // context). One constant for the whole-message, straddling-trim, and
-        // giant-single-burst arms — the charge must not drift between them.
-        // context-budget-exempt: fixed chat-template overhead per message (role tags + separators) — a property of the prompt FORMAT, not a budget that should scale with the window
-        const PER_MESSAGE_TEMPLATE_TOKENS: usize = 5;
+        // Per-message template overhead: `Self::PER_MESSAGE_TEMPLATE_TOKENS`, shared
+        // with `messages_cost` so measurement and fitting charge identically.
+        let per_message_template_tokens = Self::PER_MESSAGE_TEMPLATE_TOKENS;
         let mut fitted: Vec<ChatMessage> = Vec::new();
         let mut remaining = budget_tokens;
         for msg in messages.iter().rev() {
             let body = msg.content_text();
-            let cost = est_tokens(&body) + PER_MESSAGE_TEMPLATE_TOKENS;
+            let cost = est_tokens(&body) + per_message_template_tokens;
             if cost <= remaining {
                 remaining -= cost;
                 fitted.push(msg.clone());
@@ -1148,7 +1265,7 @@ impl LlmDeliberationFaculty {
                 // The straddling message: keep as much of its TAIL as still fits.
                 let trimmed = tail_to_tokens(
                     &body,
-                    remaining.saturating_sub(PER_MESSAGE_TEMPLATE_TOKENS),
+                    remaining.saturating_sub(per_message_template_tokens),
                 );
                 if !trimmed.is_empty() {
                     fitted.push(ChatMessage::text(msg.role.clone(), trimmed));
@@ -1163,7 +1280,7 @@ impl LlmDeliberationFaculty {
             if let Some(last) = messages.last() {
                 let body = tail_to_tokens(
                     &last.content_text(),
-                    budget_tokens.saturating_sub(PER_MESSAGE_TEMPLATE_TOKENS),
+                    budget_tokens.saturating_sub(per_message_template_tokens),
                 );
                 // FAIL LOUD, never a blank mind: with the budget squeezed to ~0
                 // this arm used to emit ONE EMPTY user message — the model

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -964,7 +964,34 @@ impl LlmDeliberationFaculty {
         // overflow. The OLDEST turns yield first under pressure (the latest activity
         // is what the turn is about — the same priority the old flat head-trim had,
         // now at turn granularity).
-        let msg_budget = budget.saturating_sub(framing_tokens);
+        // RESERVE THE GROUNDING FLOOR BEFORE THE CONVERSATION FILLS.
+        //
+        // `messages_within` is greedy: hand it everything after framing and it takes
+        // everything after framing, so grounding gets the remainder — which is zero.
+        // That is not a budget-size problem and growing the window does not fix it:
+        // measured 2026-08-06, the served window rose 16,384 → 24,128 and Anwen,
+        // Asha and Atlas still each rendered `budget=0 kept=[]`, dropping recall,
+        // roster, workspace-map AND the work board on every turn. The conversation
+        // simply absorbed the increase. Supply was never the binding constraint at
+        // this seam; ORDER was.
+        //
+        // The floor is derived, not invented: enough for the SMALLEST contribution
+        // actually offered this turn, so at least one grounding fact always reaches
+        // her. Bounded at half the post-framing pool so the reservation can never
+        // invert the problem and starve the conversation — an even split is a
+        // fairness rule between two claimants, not a tuning constant. Whatever
+        // grounding does not use still flows back: `ctx_budget` below is computed
+        // from what the conversation ACTUALLY consumed, not from this reservation.
+        let after_framing = budget.saturating_sub(framing_tokens);
+        let ctx_floor = ws
+            .broadcast
+            .iter()
+            .filter(|c| c.decision.is_none() && !c.trailing)
+            .map(|c| est_tokens(c.faculty.as_str()) + est_tokens(&c.content) + 2)
+            .min()
+            .unwrap_or(0)
+            .min(after_framing / 2);
+        let msg_budget = after_framing.saturating_sub(ctx_floor);
         let all_messages = self.messages_unfitted(ws);
 
         // WHAT THIS TURN WOULD HAVE COST WITH NO BUDGET — recorded before either
@@ -1020,10 +1047,12 @@ impl LlmDeliberationFaculty {
         // rounding slop until the tool-menu example grew the prompt to the
         // budget edge — glass-boxed 2026-07-13, llama-server 400 territory).
         let used_msg_tokens: usize = messages.iter().map(|m| est_tokens(&m.content_text())).sum();
-        let ctx_budget = budget
-            .saturating_sub(framing_tokens)
+        // Grounding gets everything the conversation did not actually use — never
+        // less than the floor reserved above.
+        let ctx_budget = after_framing
             .saturating_sub(used_msg_tokens)
-            .saturating_sub(est_tokens(deliberation_prompt::WORKING_CONTEXT_HEADER));
+            .saturating_sub(est_tokens(deliberation_prompt::WORKING_CONTEXT_HEADER))
+            .max(ctx_floor.saturating_sub(est_tokens(deliberation_prompt::WORKING_CONTEXT_HEADER)));
         let context = self.render_assembled_context_within(ws, ctx_budget);
 
         DeliberationPromptView {
@@ -2047,6 +2076,42 @@ mod tests {
                 "board",
             )
             .with_parts(parts)
+        }
+
+        // what this catches: a greedy conversation that eats every token grounding
+        // needs. `messages_within` fills whatever it is handed, so passing it the
+        // whole post-framing pool leaves grounding exactly zero — and GROWING THE
+        // WINDOW DOES NOT FIX IT, the conversation just absorbs the increase.
+        // Measured live 2026-08-06: the served window rose 16,384 → 24,128 and
+        // Anwen, Asha and Atlas each still rendered `budget=0 kept=[]`, dropping
+        // recall, roster, workspace-map AND the work board on every single turn.
+        // Supply was never the binding constraint at this seam; ORDER was.
+        #[test]
+        fn a_long_conversation_cannot_starve_grounding_to_zero() {
+            let persona = Uuid::new_v4();
+            let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
+            let faculty = LlmDeliberationFaculty::new(persona, "Ivar", "You are Ivar.", adapter)
+                .with_context_window(24_128);
+
+            // A conversation long enough to swallow the whole window on its own.
+            let mut ws = Workspace::new("anything open?");
+            for i in 0..40 {
+                ws.turns.push(crate::cognition::workspace::BurstTurn::attributed(
+                    i % 2 == 1,
+                    if i % 2 == 1 { "Ivar" } else { "Asha" },
+                    format!("turn {i}: ").repeat(60),
+                    None,
+                ));
+            }
+            ws.broadcast.push(board_like(60).with_expand_command(Some("work/list")));
+
+            let view = faculty.prompt_view_within(&ws, 24_128);
+            assert!(
+                view.system.contains("[room-kanban]"),
+                "grounding must survive a conversation that would otherwise take every \
+                 token — this is the exact live failure: window grew, board still gone\n{}",
+                &view.system[..view.system.len().min(1200)]
+            );
         }
 
         // what this catches: a truncation notice a citizen cannot act on. Telling

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -703,17 +703,58 @@ impl LlmDeliberationFaculty {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
         let received = ctx.len();
-        // SELECTION (by salience): walk highest-salience-first and keep whole items
-        // that fit the budget — a half-truncated engram is noise, so a smaller
-        // lower-salience item that still fits is preferred over a mangled high one.
-        let mut selected: Vec<&Contribution> = Vec::with_capacity(ctx.len());
+        // SELECTION (by salience): walk highest-salience-first and keep what fits.
+        //
+        // An INDIVISIBLE contribution (one part — a recalled engram, an affect
+        // signal) is still kept whole or dropped whole: half an engram is noise,
+        // so a smaller lower-salience item that fits is preferred over a mangled
+        // high one. That rule was right, and it is unchanged.
+        //
+        // A DIVISIBLE one (a grounding source that delivered a LIST, and said so
+        // via `Contribution::parts`) instead contributes the longest PREFIX of its
+        // own units that fits. Its units are ordered by the source, leads first,
+        // so a prefix is exactly the summary the source would have written if
+        // asked for less — never a mid-sentence cut. This is what un-hides the
+        // work board: measured 2026-08-06, `room-kanban` offered a median 5,364
+        // tokens all-or-nothing into a median 55-token budget and was kept 0 of
+        // 495 times, while its `[your work]` / `[available work]` leads are ~200
+        // and carry every fact a citizen needs to find work. The citizens were
+        // saying "there are no open tasks available" about a 61-card board.
+        let mut selected: Vec<(&Contribution, String)> = Vec::with_capacity(ctx.len());
         let mut dropped: Vec<String> = Vec::new();
+        let mut partial: Vec<String> = Vec::new();
         let mut used = 0usize;
         for c in ctx {
             // "\n[faculty]\n<content>\n" — count the framing chars too (~2 tokens).
-            let piece = est_tokens(c.faculty.as_str()) + est_tokens(&c.content) + 2;
-            if used + piece > budget_tokens {
-                // Drop this whole item; a smaller lower-salience one may still fit.
+            let header = est_tokens(c.faculty.as_str()) + 2;
+            let piece = header + est_tokens(&c.content);
+            if used + piece <= budget_tokens {
+                used += piece;
+                selected.push((c, c.content.clone()));
+                continue;
+            }
+            // Whole won't fit. Divisible? Take the longest leading run of units
+            // that does. `parts` is never empty (every constructor seeds it), so
+            // a single-part contribution simply finds no fitting prefix and falls
+            // through to the drop below — byte-identical to the old behavior.
+            let mut kept_units: Vec<&str> = Vec::new();
+            let mut unit_tokens = header;
+            for (i, unit) in c.parts.iter().enumerate() {
+                // Units are joined by "\n" — charge the separator from the second on.
+                let cost = est_tokens(unit) + usize::from(i > 0);
+                if used + unit_tokens + cost > budget_tokens {
+                    break;
+                }
+                unit_tokens += cost;
+                kept_units.push(unit.as_str());
+            }
+            if kept_units.len() == c.parts.len() {
+                // Can only happen if the estimator disagrees with itself; treat as whole.
+                used += unit_tokens;
+                selected.push((c, c.content.clone()));
+                continue;
+            }
+            if kept_units.is_empty() {
                 dropped.push(format!(
                     "{}(sal={:.2},tok={})",
                     c.faculty.as_str(),
@@ -722,8 +763,25 @@ impl LlmDeliberationFaculty {
                 ));
                 continue;
             }
-            selected.push(c);
-            used += piece;
+            // A truncated LIST must SAY it is truncated, or the persona reads a
+            // partial board as the whole board and reports work that isn't there
+            // — a quieter lie than the empty block this replaces.
+            let omitted = c.parts.len() - kept_units.len();
+            let body = format!(
+                "{}\n…{omitted} more not shown (context budget) — the full list is \
+                 available from the matching command.",
+                kept_units.join("\n")
+            );
+            used += unit_tokens + est_tokens("…N more not shown (context budget) …");
+            partial.push(format!(
+                "{}({}/{} units,tok={}→{})",
+                c.faculty.as_str(),
+                kept_units.len(),
+                c.parts.len(),
+                piece,
+                unit_tokens
+            ));
+            selected.push((c, body));
         }
         // Received-vs-rendered receipt at the ONE seam where a surfaced
         // contribution can silently vanish between attention and the prompt.
@@ -738,10 +796,13 @@ impl LlmDeliberationFaculty {
             rendered = selected.len(),
             kept = %selected
                 .iter()
-                .map(|c| format!("{}(sal={:.2})", c.faculty.as_str(), c.salience))
+                .map(|(c, _)| format!("{}(sal={:.2})", c.faculty.as_str(), c.salience))
                 .collect::<Vec<_>>()
                 .join(","),
             dropped = %dropped.join(","),
+            // Which divisible blocks contributed a PREFIX rather than their whole —
+            // without this a shrunken board and a full one look identical in the log.
+            partial = %partial.join(","),
             "assembled context: {}/{} contributions fit", selected.len(), received
         );
         // SERIALIZATION (by volatility): stable standing-framing FIRST (roster,
@@ -752,13 +813,13 @@ impl LlmDeliberationFaculty {
         // is a pure emit-order choice that maximizes cross-turn prefix reuse AND puts
         // the live, actionable context closest to where the model writes. `false`
         // (stable) sorts before `true` (volatile). See [`Contribution::stable`].
-        selected.sort_by_key(|c| u8::from(!c.stable));
+        selected.sort_by_key(|(c, _)| u8::from(!c.stable));
         let mut block = String::new();
-        for c in selected {
+        for (c, body) in selected {
             block.push_str("\n[");
             block.push_str(c.faculty.as_str());
             block.push_str("]\n");
-            block.push_str(&c.content);
+            block.push_str(&body);
             block.push('\n');
         }
         block
@@ -1838,6 +1899,129 @@ mod tests {
                 roster_at < recall_at,
                 "stable framing must serialize before higher-salience volatile recall \
              (roster@{roster_at} should precede recall@{recall_at})\n{block}"
+            );
+        }
+
+        /// A grounding block built from a LIST of units, sized like the live work
+        /// board (leads first, then one line per card).
+        fn board_like(units: usize) -> Contribution {
+            let mut parts = vec![
+                "[your work] you HOLD 1 card — 0dd1123c \"wire the gather fallback\"".to_string(),
+                "[available work] 60 card(s) are claimable — pick one up with work/claim"
+                    .to_string(),
+            ];
+            for i in 0..units {
+                parts.push(format!(
+                    "card {i:08x} [Open] \"a card whose title is about as long as a real one\" \
+                     (Normal, unclaimed)"
+                ));
+            }
+            let content = parts.join("\n");
+            Contribution::context(
+                FacultyId::Custom("room-kanban".to_string()),
+                content,
+                0.9,
+                "board",
+            )
+            .with_parts(parts)
+        }
+
+        // what this catches: the board vanishing WHOLE. Measured live 2026-08-06 across
+        // 1,284 context assemblies, `room-kanban` was KEPT 0 times and dropped 495 — a
+        // median 5,364-token block offered all-or-nothing into a median 55-token budget
+        // — while its first two units (~200 tokens) carry every fact a citizen needs to
+        // find work. The citizens were reporting "there are no open tasks available"
+        // about a 61-card board. A source that delivered a LIST declared its own cut
+        // points; assembly must take the longest fitting PREFIX instead of nothing.
+        #[test]
+        fn a_divisible_grounding_block_contributes_its_leads_when_the_whole_will_not_fit() {
+            let persona = Uuid::new_v4();
+            let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
+            let faculty = LlmDeliberationFaculty::new(persona, "Ivar", "You are Ivar.", adapter);
+            let mut ws = Workspace::new("anything open?");
+            let board = board_like(60);
+            let whole = est_tokens(&board.content);
+            ws.broadcast.push(board);
+
+            // A budget FAR under the whole board — the live shape (55 vs 5,364).
+            let budget = 120;
+            assert!(whole > budget * 10, "fixture must reproduce the live ratio");
+            let block = faculty.render_assembled_context_within(&ws, budget);
+
+            assert!(
+                block.contains("[room-kanban]"),
+                "the board must still reach the prompt — it vanished whole before this fix\n{block}"
+            );
+            assert!(
+                block.contains("[your work]"),
+                "the FIRST unit is the one that matters most; a prefix must start there\n{block}"
+            );
+            assert!(
+                !block.contains("card 0000003b"),
+                "the 60th card must NOT ride along — the prefix is bounded by budget\n{block}"
+            );
+            assert!(
+                block.contains("more not shown"),
+                "a truncated LIST must SAY it is truncated, or a partial board reads as \
+                 the whole board and she reports work that isn't there\n{block}"
+            );
+            assert!(
+                est_tokens(&block) <= budget * 2,
+                "the prefix must respect the budget it was given (got {} for budget {budget})\n{block}",
+                est_tokens(&block)
+            );
+        }
+
+        // what this catches: the OTHER half of the same rule — divisibility is opt-in and
+        // must not leak. An engram is ONE indivisible thing; cutting it mid-sentence
+        // produces confident nonsense, which is worse than its absence. A faculty that
+        // never calls `with_parts` must behave exactly as it did before parts existed.
+        #[test]
+        fn an_indivisible_contribution_is_still_dropped_whole_never_cut_mid_content() {
+            let persona = Uuid::new_v4();
+            let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
+            let faculty = LlmDeliberationFaculty::new(persona, "Ivar", "You are Ivar.", adapter);
+            let mut ws = Workspace::new("what happened yesterday?");
+            let engram = "we agreed the gather promise binds every reachable kernel, and that \
+                          the in-place consumption path inherits none of the alignment the \
+                          copy path establishes, which is why the fallback had to be per-op"
+                .repeat(4);
+            ws.broadcast.push(Contribution::context(
+                FacultyId::Recall,
+                engram.clone(),
+                0.9,
+                "recalled",
+            ));
+
+            let block = faculty.render_assembled_context_within(&ws, 40);
+            assert!(
+                !block.contains("[recall]"),
+                "an over-budget INDIVISIBLE contribution must be dropped whole, not \
+                 truncated into a confident half-thought\n{block}"
+            );
+            assert!(
+                !block.contains("more not shown"),
+                "the truncation notice belongs only to genuinely divisible lists\n{block}"
+            );
+        }
+
+        // what this catches: a zero/near-zero budget must produce NO block rather than a
+        // bare `[room-kanban]` header with nothing under it — an empty labelled block
+        // reads to the persona as "the board is empty", which is exactly the false fact
+        // this whole fix exists to stop her acting on.
+        #[test]
+        fn a_budget_too_small_for_even_one_unit_emits_no_header_at_all() {
+            let persona = Uuid::new_v4();
+            let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
+            let faculty = LlmDeliberationFaculty::new(persona, "Ivar", "You are Ivar.", adapter);
+            let mut ws = Workspace::new("anything open?");
+            ws.broadcast.push(board_like(60));
+
+            let block = faculty.render_assembled_context_within(&ws, 4);
+            assert!(
+                !block.contains("[room-kanban]"),
+                "no unit fits, so there must be no header — a labelled empty block is a \
+                 LIE that reads as an empty board\n{block}"
             );
         }
 

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -807,12 +807,18 @@ impl LlmDeliberationFaculty {
             // partial board as the whole board and reports work that isn't there
             // — a quieter lie than the empty block this replaces.
             let omitted = c.parts.len() - kept_units.len();
-            let body = format!(
-                "{}\n…{omitted} more not shown (context budget) — the full list is \
-                 available from the matching command.",
-                kept_units.join("\n")
-            );
-            used += unit_tokens + est_tokens("…N more not shown (context budget) …");
+            // Name the EXACT verb, never "the matching command" — she cannot run a
+            // description, and a name she has to guess is a name she gets wrong
+            // ([[command-names-must-be-accurate]]). The source declares it
+            // (`RagSource::expand_command`, no default impl); a source with nothing
+            // more to fetch says only how much was omitted.
+            let how = match c.expand_command {
+                Some(cmd) => format!(" — run `{cmd}` to see all {}", c.parts.len()),
+                None => String::new(),
+            };
+            let notice = format!("…{omitted} more not shown (context budget){how}");
+            used += unit_tokens + est_tokens(&notice);
+            let body = format!("{}\n{notice}", kept_units.join("\n"));
             partial.push(format!(
                 "{}({}/{} units,tok={}→{})",
                 c.faculty.as_str(),
@@ -2041,6 +2047,53 @@ mod tests {
                 "board",
             )
             .with_parts(parts)
+        }
+
+        // what this catches: a truncation notice a citizen cannot act on. Telling
+        // her "the full list is available from the matching command" names nothing
+        // she can type — she cannot run a description, and a verb she has to guess
+        // is a verb she gets wrong ([[command-names-must-be-accurate]]). The source
+        // declares its own expansion verb; the notice must print it verbatim, with
+        // the true total so she knows the size of what she is asking for.
+        #[test]
+        fn a_truncated_block_names_the_exact_verb_that_yields_the_rest() {
+            let persona = Uuid::new_v4();
+            let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
+            let faculty = LlmDeliberationFaculty::new(persona, "Ivar", "You are Ivar.", adapter);
+            let mut ws = Workspace::new("anything open?");
+            let board = board_like(60).with_expand_command(Some("work/list"));
+            let total = board.parts.len();
+            ws.broadcast.push(board);
+
+            let block = faculty.render_assembled_context_within(&ws, 120);
+            assert!(
+                block.contains("run `work/list`"),
+                "the notice must name the verb verbatim, not describe it\n{block}"
+            );
+            assert!(
+                block.contains(&format!("to see all {total}")),
+                "…and say how many there are in total, so she knows what she is asking for\n{block}"
+            );
+        }
+
+        // what this catches: the other half — a source with genuinely nothing more
+        // to fetch must not invent a verb. A pointer to a command that does not
+        // expand anything is worse than no pointer: she spends a turn on it and
+        // learns nothing.
+        #[test]
+        fn a_source_with_no_expansion_verb_states_only_the_omission() {
+            let persona = Uuid::new_v4();
+            let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
+            let faculty = LlmDeliberationFaculty::new(persona, "Ivar", "You are Ivar.", adapter);
+            let mut ws = Workspace::new("anything open?");
+            ws.broadcast.push(board_like(60)); // expand_command defaults to None
+
+            let block = faculty.render_assembled_context_within(&ws, 120);
+            assert!(block.contains("more not shown"), "still says it truncated\n{block}");
+            assert!(
+                !block.contains("run `"),
+                "must not point at a verb it was never given\n{block}"
+            );
         }
 
         // what this catches: the board vanishing WHOLE. Measured live 2026-08-06 across

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -718,6 +718,19 @@ impl LlmDeliberationFaculty {
         composition: (u32, usize, usize, usize),
     ) -> String {
         let (context_window, framing_tokens, conversation_tokens, ctx_floor) = composition;
+        // The TRAILING tier — working-memory ledger, full latest result, perception
+        // facts — renders as conversation turns AFTER the fit, so it is charged to
+        // the model but appears in neither `framing_tokens` nor
+        // `conversation_tokens`. That is the shape of the ~4,700 tokens unaccounted
+        // for on 2026-08-06 (`16384 − 4096 − 3045 − 4161` should have left ~5,000;
+        // the render got 391). Named here so the next reader confirms or kills it
+        // from the record instead of re-deriving the subtraction.
+        let trailing_tokens: usize = ws
+            .broadcast
+            .iter()
+            .filter(|c| c.decision.is_none() && c.trailing)
+            .map(|c| est_tokens(&c.content))
+            .sum();
         if budget_tokens == 0 {
             // Received-vs-rendered receipt even on the zero-budget path — a turn
             // whose entire context vanished must say so, not render silently empty
@@ -731,6 +744,7 @@ impl LlmDeliberationFaculty {
                 context_window,
                 framing_tokens,
                 conversation_tokens,
+                trailing_tokens,
                 ctx_floor,
                 received = ws.broadcast.iter().filter(|c| c.decision.is_none() && !c.trailing).count(),
                 rendered = 0usize,
@@ -858,6 +872,7 @@ impl LlmDeliberationFaculty {
             context_window,
             framing_tokens,
             conversation_tokens,
+            trailing_tokens,
             ctx_floor,
             used_tokens = used,
             received,

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -718,14 +718,17 @@ impl LlmDeliberationFaculty {
         composition: (u32, usize, usize, usize),
     ) -> String {
         let (context_window, framing_tokens, conversation_tokens, ctx_floor) = composition;
-        // The TRAILING tier — working-memory ledger, full latest result, perception
-        // facts — renders as conversation turns AFTER the fit, so it is charged to
-        // the model but appears in neither `framing_tokens` nor
-        // `conversation_tokens`. That is the shape of the ~4,700 tokens unaccounted
-        // for on 2026-08-06 (`16384 − 4096 − 3045 − 4161` should have left ~5,000;
-        // the render got 391). Named here so the next reader confirms or kills it
-        // from the record instead of re-deriving the subtraction.
-        let trailing_tokens: usize = ws
+        // How much of `conversation_tokens` is the TRAILING tier (working-memory
+        // ledger, full latest result, perception facts).
+        //
+        // A SUBSET, not a separate term — `messages_unfitted` pushes trailing
+        // contributions into `messages`, so `used_msg_tokens` already counts them.
+        // Named `conv_trailing_share` for exactly that reason: emitted as
+        // `trailing_tokens` it read as a fourth claimant and I subtracted it twice,
+        // inflating an unexplained gap that had not actually changed. A probe field
+        // that invites a double-count is worse than no field
+        // ([[a-probe-that-can-only-fail-is-worse-than-no-probe]]).
+        let conv_trailing_share: usize = ws
             .broadcast
             .iter()
             .filter(|c| c.decision.is_none() && c.trailing)
@@ -744,7 +747,7 @@ impl LlmDeliberationFaculty {
                 context_window,
                 framing_tokens,
                 conversation_tokens,
-                trailing_tokens,
+                conv_trailing_share,
                 ctx_floor,
                 received = ws.broadcast.iter().filter(|c| c.decision.is_none() && !c.trailing).count(),
                 rendered = 0usize,
@@ -872,8 +875,13 @@ impl LlmDeliberationFaculty {
             context_window,
             framing_tokens,
             conversation_tokens,
-            trailing_tokens,
+            conv_trailing_share,
             ctx_floor,
+            // The two terms the subtraction actually runs on. Without them the
+            // budget can only be reconciled by GUESSING which local holds what —
+            // which is how two suspects in a row got proposed and killed against
+            // the same ~4,700-token gap. Inputs beside the output, always.
+            after_framing = framing_tokens + conversation_tokens + budget_tokens,
             used_tokens = used,
             received,
             rendered = selected.len(),

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -89,6 +89,7 @@ pub mod should_respond_module;
 pub mod threat_detector;
 pub mod throughput_lease;
 pub mod token_budget;
+pub mod working_set;
 pub mod tool_embedding;
 pub mod tool_relevance;
 pub mod tool_executor;

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -448,7 +448,15 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     // exists and reaches nobody, and `serving_plan` falls back to the cold-start
     // constant forever — the exact shape of defect that left every citizen thinking
     // in 8192 tokens of a 128k model. [[wire-it-into-the-default-path]]
-    .with_working_set(crate::cognition::working_set::global());
+    .with_working_set({
+        // Re-adopt her measured window demand BEFORE her first turn, so a restart
+        // is a pause and not a demotion — without this the reboot drops her back to
+        // the cold-start window until enough turns re-measure (observed live
+        // 2026-08-06: a measured 24,126 fell to 16,384 across one reboot).
+        let ws = crate::cognition::working_set::global();
+        ws.rehydrate(cfg.persona_id);
+        ws
+    });
     if tool_executor.is_some() {
         // Offer EXACTLY what this persona is authorized to run (offer ==
         // authorized) — never a tool the gate would refuse. A local persona is the

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -1355,6 +1355,11 @@ mod tests {
         fn source_id(&self) -> &'static str {
             "classify-stub"
         }
+
+    fn expand_command(&self) -> Option<&'static str> {
+        // Test/stub source — nothing further to fetch.
+        None
+    }
         async fn deliver(
             &self,
             _ctx: &crate::persona::rag_budget::RagContext,
@@ -1436,6 +1441,11 @@ mod tests {
             fn source_id(&self) -> &'static str {
                 "workspace-map"
             }
+
+    fn expand_command(&self) -> Option<&'static str> {
+        // Test/stub source — nothing further to fetch.
+        None
+    }
             async fn deliver(
                 &self,
                 _ctx: &crate::persona::rag_budget::RagContext,
@@ -1542,6 +1552,11 @@ mod tests {
         fn source_id(&self) -> &'static str {
             "slow-grounding"
         }
+
+    fn expand_command(&self) -> Option<&'static str> {
+        // Test/stub source — nothing further to fetch.
+        None
+    }
         async fn deliver(
             &self,
             _ctx: &crate::persona::rag_budget::RagContext,

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -442,7 +442,13 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     .with_working_memory(Arc::clone(&working_memory))
     .with_genome(Arc::clone(&genome))
     .with_decoding(Arc::clone(&decoding))
-    .with_model_binding(Arc::clone(&model_binding));
+    .with_model_binding(Arc::clone(&model_binding))
+    // Every mind reports what its turns actually COST into the shared registry the
+    // serving daemon provisions the window from. Without this line the measurement
+    // exists and reaches nobody, and `serving_plan` falls back to the cold-start
+    // constant forever — the exact shape of defect that left every citizen thinking
+    // in 8192 tokens of a 128k model. [[wire-it-into-the-default-path]]
+    .with_working_set(crate::cognition::working_set::global());
     if tool_executor.is_some() {
         // Offer EXACTLY what this persona is authorized to run (offer ==
         // authorized) — never a tool the gate would refuse. A local persona is the

--- a/core/continuum-core/src/cognition/rag_source_faculty.rs
+++ b/core/continuum-core/src/cognition/rag_source_faculty.rs
@@ -261,7 +261,8 @@ impl Faculty for RagSourceFaculty {
         );
 
         let c = Contribution::context(self.faculty_id.clone(), content, self.salience, reasoning)
-            .with_parts(units);
+            .with_parts(units)
+            .with_expand_command(self.source.expand_command());
         Some(if self.stable { c.session_stable() } else { c })
     }
 }
@@ -309,6 +310,11 @@ mod tests {
         fn source_id(&self) -> &'static str {
             self.id
         }
+
+    fn expand_command(&self) -> Option<&'static str> {
+        // Test/stub source — nothing further to fetch.
+        None
+    }
         async fn deliver(
             &self,
             ctx: &RagContext,

--- a/core/continuum-core/src/cognition/rag_source_faculty.rs
+++ b/core/continuum-core/src/cognition/rag_source_faculty.rs
@@ -242,12 +242,17 @@ impl Faculty for RagSourceFaculty {
 
         // One context block per source: concatenate the delivered atomic units.
         // The deliberation faculty renders this under a `[<source_id>]` header.
-        let content = delivery
-            .items
-            .iter()
-            .map(|i| i.content.as_str())
-            .collect::<Vec<_>>()
-            .join("\n");
+        //
+        // The join is the RENDERING, not the loss of structure — the units ride
+        // along on the contribution as `parts` (below), so a block too large for
+        // the prompt budget can still contribute its leading units instead of
+        // vanishing whole. Flattening and DISCARDING the list is what made the
+        // work board structurally invisible: measured 2026-08-06, `room-kanban`
+        // was kept 0 / dropped 495 times, a median 5,364-token all-or-nothing
+        // offer against a median 55-token budget, while its first two units
+        // (~200 tokens) carried every fact a citizen needed to find work.
+        let units: Vec<String> = delivery.items.iter().map(|i| i.content.clone()).collect();
+        let content = units.join("\n");
         let reasoning = format!(
             "grounding from '{}' — {} item(s), {} tokens",
             self.source.source_id(),
@@ -255,7 +260,8 @@ impl Faculty for RagSourceFaculty {
             delivery.tokens_used
         );
 
-        let c = Contribution::context(self.faculty_id.clone(), content, self.salience, reasoning);
+        let c = Contribution::context(self.faculty_id.clone(), content, self.salience, reasoning)
+            .with_parts(units);
         Some(if self.stable { c.session_stable() } else { c })
     }
 }

--- a/core/continuum-core/src/cognition/serving_plan.rs
+++ b/core/continuum-core/src/cognition/serving_plan.rs
@@ -116,6 +116,41 @@ pub const MIN_SERVE_CTX: u32 = 2048;
 /// floor (`MIN_SERVE_CTX × 8 = 16384`) rather than a second bare magic number.
 pub const BOOTSTRAP_WORKING_SET: u32 = MIN_SERVE_CTX * 8;
 
+/// What the minds on this host are asking the serving lane for.
+///
+/// Both axes of demand in ONE value, because they are one question — "how much
+/// serving does the work on this box actually need" — and passing them as two loose
+/// `u32`s next to each other is how a caller silently swaps them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServingDemand {
+    /// How many minds want a concurrent lane.
+    pub lanes: u32,
+    /// The largest per-turn window any resident mind has actually demanded
+    /// ([`crate::cognition::working_set::WorkingSetRegistry::ceiling`]) — measured
+    /// UNCLAMPED, so it is free to exceed what is currently served. That excess is the
+    /// signal that the window is too small; nothing else in the system can produce it.
+    pub window_tokens: u32,
+}
+
+impl ServingDemand {
+    /// Demand from live measurement, with the cold-start case named explicitly.
+    ///
+    /// `measured` is `None` only before ANY turn has been assembled on this host —
+    /// a genuine absence of data, not a missing feature. The window then starts at
+    /// [`BOOTSTRAP_WORKING_SET`] (one full turn's worth: assembled prompt plus
+    /// generation headroom, anchored to `MIN_SERVE_CTX × 8` rather than a second bare
+    /// number) and is superseded by measurement on the very next plan, because the
+    /// first turn records its demand before it is even sent. This is the one place
+    /// that decision lives — the registry deliberately returns `None` rather than
+    /// inventing a number every caller would then inherit without noticing.
+    pub fn new(lanes: u32, measured: Option<u32>) -> Self {
+        Self {
+            lanes,
+            window_tokens: measured.unwrap_or(BOOTSTRAP_WORKING_SET),
+        }
+    }
+}
+
 /// Hysteresis margin for switching UP to a more capable model: it must fit
 /// within `(1 - SWITCH_UP_HEADROOM)` of the budget — i.e. with headroom to
 /// spare — before we abandon the incumbent for it. Stops transient budget
@@ -316,8 +351,9 @@ pub struct ServingPlan {
 pub fn plan_serving(
     host: HostBudget,
     candidates: &[ModelFootprint],
-    demand_lanes: u32,
+    demand: ServingDemand,
 ) -> Option<ServingPlan> {
+    let demand_lanes = demand.lanes;
     if candidates.is_empty() {
         return None;
     }
@@ -435,14 +471,26 @@ pub fn plan_serving(
         .find(|&l| window_for(l as u64) > MIN_SERVE_CTX)
         .unwrap_or(1);
     // DEMAND cap (M5+BigMama 2026-07-26): provision for what personas USE, not for
-    // what RAM allows. `window_for` maximizes the window to fill the budget (94k on
-    // a roomy host) → ~33GB pre-allocated KV × lanes → swap/wedge, while personas
-    // fill ~9k. Cap DOWN to the demand ceiling (BOOTSTRAP_WORKING_SET now; measured
-    // p95 later, #234). Ordering: window_for already ≤ model ceiling, so `.min`
-    // never forces UP past what the model supports; `.max(MIN_SERVE_CTX)` keeps it
-    // runnable. On a small host where window_for < BOOTSTRAP the cap is a no-op.
+    // what RAM allows. `window_for` maximizes the window to fill the budget (94k on a
+    // roomy host) → ~33GB pre-allocated KV × lanes → swap/wedge. Cap DOWN to demand.
+    //
+    // That demand is now MEASURED (`demand.window_tokens`, from
+    // [`crate::cognition::working_set`]) rather than the `BOOTSTRAP_WORKING_SET`
+    // constant it used to be — which is what this line's own comment promised
+    // ("measured p95 later, #234") and never delivered. The constant was doing real
+    // damage in the meantime: 16384 across 2 lanes gave each citizen **8192 tokens**
+    // of a 128k-capable model on a host that could serve 94k, and measured 2026-08-06
+    // that left a median context budget of 55 tokens after framing and conversation —
+    // the work board (median 5,364 tokens) reached a prompt zero times in 495.
+    //
+    // The measurement is DEMAND, not usage, precisely so it can exceed what is
+    // currently served; a usage-based signal would re-derive whatever cap produced it.
+    // Ordering is unchanged and the safety envelope is identical: `window_for` is
+    // already ≤ the model's trained ceiling AND ≤ what the host fits, so `.min` never
+    // forces UP past either, and `.max(MIN_SERVE_CTX)` keeps the lane runnable. A
+    // citizen who demands more than the machine has simply receives what fits.
     let served_context_window = window_for(lanes as u64)
-        .min(BOOTSTRAP_WORKING_SET)
+        .min(demand.window_tokens)
         .max(MIN_SERVE_CTX);
     // The honest per-lane compute reserve AT the chosen window (floor + window-scaled),
     // reused by the packing math below AND reported to the board via
@@ -519,14 +567,14 @@ pub fn plan_serving_stable(
     host: HostBudget,
     candidates: &[ModelFootprint],
     incumbent: Option<&str>,
-    demand_lanes: u32,
+    demand: ServingDemand,
 ) -> Option<ServingPlan> {
     // NB: do NOT `?`-bail here. A deep transient dip can leave `plan_serving`
     // with nothing fitting the depressed budget (`fresh` = None) while a model
     // is STILL resident and serving fine — its memory is its own. Tearing that
     // down to "nothing" is the exact harm we're guarding against, so `fresh` is
     // an Option we fall back to only when the incumbent genuinely can't hold.
-    let fresh = plan_serving(host, candidates, demand_lanes);
+    let fresh = plan_serving(host, candidates, demand);
     let Some(inc_id) = incumbent else {
         return fresh;
     };
@@ -590,7 +638,7 @@ pub fn plan_serving_stable(
     if let Some(m) = promoted.iter_mut().find(|m| m.model_id == inc_id) {
         m.capability_rank = u8::MAX;
     }
-    plan_serving(at_rest, &promoted, demand_lanes)
+    plan_serving(at_rest, &promoted, demand)
 }
 
 fn bytes_gb(bytes: u64) -> f64 {
@@ -669,7 +717,7 @@ mod tests {
         // budget the fixpoint consumed for the chosen model.
         let host = HostBudget { usable_bytes: 48 * GB, perf_cores: 10 };
         let devstral = fp("devstral-24b", 14, 112 * 1024, 131_072, 3);
-        let plan = plan_serving(host, std::slice::from_ref(&devstral), 4).unwrap();
+        let plan = plan_serving(host, std::slice::from_ref(&devstral), ServingDemand::new(4, None)).unwrap();
         let chosen_cost = devstral.weights_bytes
             + devstral.kv_at(plan.served_context_window) * plan.lanes as u64
             + devstral.prefill_compute_reserve(plan.served_context_window, plan.lanes);
@@ -700,7 +748,7 @@ mod tests {
         // Demand = 4 personas, but MAX_LANES caps it (reverted to 2 after 4 lanes starved
         // the window to ~6k < a ~9k persona prompt). The window is derived to fit whatever
         // lane count is served — the invariant below holds at any cap.
-        let plan = plan_serving(host, std::slice::from_ref(&devstral), 4).unwrap();
+        let plan = plan_serving(host, std::slice::from_ref(&devstral), ServingDemand::new(4, None)).unwrap();
         assert!(plan.fits_on_gpu, "{}", plan.rationale);
         assert_eq!(plan.lanes, MAX_LANES, "demand above the cap clamps to MAX_LANES");
         let c = plan.served_context_window as u64;
@@ -733,7 +781,7 @@ mod tests {
         let host = HostBudget { usable_bytes: 48 * GB, perf_cores: 10 };
         let devstral = fp("devstral-24b", 14, 112 * 1024, 131_072, 3);
         // 4 personas demand a lane; only MAX_LANES fit locally → the rest is overflow.
-        let over = plan_serving(host, std::slice::from_ref(&devstral), 4).unwrap();
+        let over = plan_serving(host, std::slice::from_ref(&devstral), ServingDemand::new(4, None)).unwrap();
         assert_eq!(over.lanes, MAX_LANES, "precondition: local lanes clamp to MAX_LANES");
         assert_eq!(
             over.grid_overflow_lanes,
@@ -741,9 +789,79 @@ mod tests {
             "demand the local lanes couldn't absorb must be surfaced for grid placement, not crammed"
         );
         // Demand within local capacity → zero overflow (nothing to place off-box).
-        let fits = plan_serving(host, std::slice::from_ref(&devstral), 1).unwrap();
+        let fits = plan_serving(host, std::slice::from_ref(&devstral), ServingDemand::new(1, None)).unwrap();
         assert_eq!(fits.lanes, 1, "precondition: single demand fits one local lane");
         assert_eq!(fits.grid_overflow_lanes, 0, "demand ≤ local lanes → no overflow");
+    }
+
+    // what this catches: the cap that outlived its own TODO. `BOOTSTRAP_WORKING_SET`
+    // was written as a cold-start PRIOR to be superseded by measurement ("measured p95
+    // later, #234"); the measurement never arrived, so on a host that could serve 94k
+    // of a 131k-capable model every citizen got 16384/lanes = **8192 tokens**, and
+    // measured 2026-08-06 that left a median context budget of 55 after framing and
+    // conversation — the work board reached a prompt 0 times in 495. A measured demand
+    // ABOVE the bootstrap prior must now actually raise the served window, or the
+    // constant is still silently in charge and this whole seam is decoration.
+    #[test]
+    fn a_measured_demand_above_the_cold_start_prior_actually_raises_the_window() {
+        let host = HostBudget { usable_bytes: 48 * GB, perf_cores: 10 };
+        let devstral = fp("devstral-24b", 14, 112 * 1024, 131_072, 3);
+
+        let cold = plan_serving(host, std::slice::from_ref(&devstral), ServingDemand::new(1, None))
+            .expect("servable");
+        assert_eq!(
+            cold.served_context_window, BOOTSTRAP_WORKING_SET,
+            "with NO measurement the cold-start prior is the honest answer"
+        );
+
+        // One mind measured wanting 48k — well past the prior, well under the ceiling.
+        let measured = plan_serving(
+            host,
+            std::slice::from_ref(&devstral),
+            ServingDemand::new(1, Some(48_000)),
+        )
+        .expect("servable");
+        assert!(
+            measured.served_context_window > cold.served_context_window,
+            "measured demand ({}) must RAISE the window above the cold-start prior ({}), \
+             got {} — if this is equal, the constant is still the authority",
+            48_000,
+            cold.served_context_window,
+            measured.served_context_window
+        );
+        assert!(
+            measured.served_context_window <= 48_000,
+            "…but never above what was actually demanded (got {})",
+            measured.served_context_window
+        );
+    }
+
+    // what this catches: the other direction — demand is a CAP, not a request the host
+    // must honor. A mind that wants more than the machine has must receive what fits,
+    // never a window the host cannot back with real KV, which is the swap/wedge the
+    // demand cap exists to prevent in the first place.
+    #[test]
+    fn demand_beyond_the_host_is_bounded_by_what_actually_fits() {
+        let host = HostBudget { usable_bytes: 48 * GB, perf_cores: 10 };
+        let devstral = fp("devstral-24b", 14, 112 * 1024, 131_072, 3);
+        let greedy = plan_serving(
+            host,
+            std::slice::from_ref(&devstral),
+            ServingDemand::new(4, Some(10_000_000)),
+        )
+        .expect("servable");
+        assert!(
+            greedy.served_context_window <= devstral.context_window,
+            "never above the model's trained ceiling (got {})",
+            greedy.served_context_window
+        );
+        let unbounded_fit =
+            plan_serving(host, std::slice::from_ref(&devstral), ServingDemand::new(4, Some(u32::MAX)))
+                .expect("servable");
+        assert_eq!(
+            greedy.served_context_window, unbounded_fit.served_context_window,
+            "past the host's real fit, MORE demand changes nothing — the fit is the bound"
+        );
     }
 
     // what this catches: the cross-node serving-QUALITY bug (2026-07-26). On a roomy
@@ -763,7 +881,7 @@ mod tests {
             devstral.context_window > BOOTSTRAP_WORKING_SET,
             "precondition: model ceiling must exceed the demand cap, else the ceiling (not the cap) could explain the result"
         );
-        let plan = plan_serving(host, std::slice::from_ref(&devstral), 4).unwrap();
+        let plan = plan_serving(host, std::slice::from_ref(&devstral), ServingDemand::new(4, None)).unwrap();
         assert!(
             plan.served_context_window <= BOOTSTRAP_WORKING_SET,
             "served window {} must be capped to working-set demand ({}), never budget-maxed toward the ceiling",
@@ -775,7 +893,7 @@ mod tests {
         // whose trained ceiling is below the demand cap is still served at/below its
         // own ceiling (`.min` only ever caps DOWN).
         let tiny = fp("tiny-4k", 3, 30_000, 4_096, 2);
-        let plan_tiny = plan_serving(host, std::slice::from_ref(&tiny), 1).unwrap();
+        let plan_tiny = plan_serving(host, std::slice::from_ref(&tiny), ServingDemand::new(1, None)).unwrap();
         assert!(
             plan_tiny.served_context_window <= 4_096,
             "demand cap must not inflate a 4k-ceiling model past its ceiling; got {}",
@@ -793,7 +911,7 @@ mod tests {
         // ~18GB usable — fits the 14GB weights + a couple lanes' KV, not four.
         let host = HostBudget { usable_bytes: 18 * GB, perf_cores: 10 };
         let devstral = fp("devstral-24b", 14, 112 * 1024, 131_072, 3);
-        let plan = plan_serving(host, std::slice::from_ref(&devstral), 4).unwrap();
+        let plan = plan_serving(host, std::slice::from_ref(&devstral), ServingDemand::new(4, None)).unwrap();
         assert!(plan.fits_on_gpu, "{}", plan.rationale);
         assert!(plan.lanes < 4, "tight host must serve fewer than the 4 demanded: got {}", plan.lanes);
         assert!(plan.lanes >= 1);
@@ -815,7 +933,7 @@ mod tests {
     fn tiny_box_picks_most_capable_that_fits_not_the_biggest() {
         // ~5.5GB usable after OS headroom on an 8GB Air.
         let host = HostBudget { usable_bytes: 5 * GB + 500 * 1_000_000, perf_cores: 4 };
-        let plan = plan_serving(host, &candidates(), MAX_LANES).unwrap();
+        let plan = plan_serving(host, &candidates(), ServingDemand::new(MAX_LANES, None)).unwrap();
         assert!(plan.fits_on_gpu, "must fit a real model on GPU: {}", plan.rationale);
         assert_eq!(plan.base_model_id, "qwen3.5-4b", "14B can't fit 5.5GB; 4B is the most capable that does");
         assert!(plan.lanes >= 1);
@@ -830,8 +948,8 @@ mod tests {
     fn lanes_track_demand_and_every_unneeded_lane_stops_costing_window() {
         // A pressured budget (benchmark servers breathing next door).
         let host = HostBudget { usable_bytes: 20 * GB, perf_cores: 6 };
-        let greedy = plan_serving(host, &candidates(), MAX_LANES).unwrap();
-        let demand2 = plan_serving(host, &candidates(), 2).unwrap();
+        let greedy = plan_serving(host, &candidates(), ServingDemand::new(MAX_LANES, None)).unwrap();
+        let demand2 = plan_serving(host, &candidates(), ServingDemand::new(2, None)).unwrap();
         assert_eq!(demand2.lanes, 2, "2 minds → 2 lanes, not the ceiling");
         if greedy.lanes > 2 {
             assert!(
@@ -844,10 +962,10 @@ mod tests {
             );
         }
         // Demand can never exceed the physical caps (kv/perf/MAX_LANES)…
-        let demand99 = plan_serving(host, &candidates(), 99).unwrap();
+        let demand99 = plan_serving(host, &candidates(), ServingDemand::new(99, None)).unwrap();
         assert!(demand99.lanes <= MAX_LANES);
         // …and a zero demand is defensively floored at one lane.
-        assert_eq!(plan_serving(host, &candidates(), 0).unwrap().lanes, 1);
+        assert_eq!(plan_serving(host, &candidates(), ServingDemand::new(0, None)).unwrap().lanes, 1);
     }
 
     // what this catches: #213 — the daemon must not chase a lane-count target off a cliff.
@@ -863,7 +981,7 @@ mod tests {
         let devstral = fp("devstral-24b", 14, 175_000, 131_072, 3);
         // Budget where ONE lane serves a real window but TWO would floor (eval lane resident).
         let squeezed = HostBudget { usable_bytes: 19 * GB, perf_cores: 6 };
-        let plan = plan_serving(squeezed, std::slice::from_ref(&devstral), 2).unwrap();
+        let plan = plan_serving(squeezed, std::slice::from_ref(&devstral), ServingDemand::new(2, None)).unwrap();
         assert_eq!(plan.lanes, 1, "2 lanes would floor → shed to 1 real lane, not 2 @ 2048");
         assert!(
             plan.served_context_window > 4096,
@@ -875,7 +993,7 @@ mod tests {
         // (2026-07-26), NOT maximized to fill RAM (the 94k→swap/wedge bug). A roomy
         // box buys more LANES (concurrent minds), not a bloated per-lane KV cache.
         let roomy = HostBudget { usable_bytes: 45 * GB, perf_cores: 6 };
-        let plan2 = plan_serving(roomy, std::slice::from_ref(&devstral), 2).unwrap();
+        let plan2 = plan_serving(roomy, std::slice::from_ref(&devstral), ServingDemand::new(2, None)).unwrap();
         assert_eq!(plan2.lanes, 2, "roomy host serves both minds concurrently");
         assert!(
             plan2.served_context_window > 4096
@@ -899,7 +1017,7 @@ mod tests {
     fn big_box_picks_most_capable_runs_lanes_but_sizes_window_to_demand() {
         // ~45GB usable on a 64GB M5 Pro after headroom.
         let host = HostBudget { usable_bytes: 45 * GB, perf_cores: 6 };
-        let plan = plan_serving(host, &candidates(), MAX_LANES).unwrap();
+        let plan = plan_serving(host, &candidates(), ServingDemand::new(MAX_LANES, None)).unwrap();
         assert_eq!(plan.base_model_id, "coder-sentinel-14b", "most capable, fits easily");
         assert!(plan.lanes >= 2, "M5 Pro has the budget for multiple lanes, got {}", plan.lanes);
         // Window sized to DEMAND (capped at the working-set bootstrap), NOT maximized
@@ -923,7 +1041,7 @@ mod tests {
     #[test]
     fn lanes_capped_at_max() {
         let host = HostBudget { usable_bytes: 500 * GB, perf_cores: 64 };
-        let plan = plan_serving(host, &candidates(), MAX_LANES).unwrap();
+        let plan = plan_serving(host, &candidates(), ServingDemand::new(MAX_LANES, None)).unwrap();
         assert_eq!(plan.lanes, MAX_LANES);
     }
 
@@ -938,8 +1056,8 @@ mod tests {
         // lean floor ≈ 307MB KV + 256MB compute ≈ 563MB → 3 lanes;
         // fat floor  ≈ 921MB KV + 256MB compute ≈ 1.18GB → 1 lane.
         let host = HostBudget { usable_bytes: 4 * GB, perf_cores: 8 };
-        let lean = plan_serving(host, &[fp("lean", 2, 150_000, 32_768, 5)], MAX_LANES).unwrap();
-        let fat = plan_serving(host, &[fp("fat", 2, 450_000, 32_768, 5)], MAX_LANES).unwrap();
+        let lean = plan_serving(host, &[fp("lean", 2, 150_000, 32_768, 5)], ServingDemand::new(MAX_LANES, None)).unwrap();
+        let fat = plan_serving(host, &[fp("fat", 2, 450_000, 32_768, 5)], ServingDemand::new(MAX_LANES, None)).unwrap();
         assert!(lean.lanes > fat.lanes, "lean {} should beat fat {}", lean.lanes, fat.lanes);
     }
 
@@ -957,7 +1075,7 @@ mod tests {
         let host = HostBudget { usable_bytes: 26 * GB, perf_cores: 10 };
 
         // 4 personas demand 4 lanes, but the MAX_LANES safety ceiling caps it.
-        let plan = plan_serving(host, std::slice::from_ref(&m), 4).unwrap();
+        let plan = plan_serving(host, std::slice::from_ref(&m), ServingDemand::new(4, None)).unwrap();
         assert_eq!(
             plan.lanes, MAX_LANES,
             "demand is capped to the MAX_LANES safety ceiling: {}",
@@ -980,7 +1098,7 @@ mod tests {
     #[test]
     fn nothing_fits_degrades_honestly_no_silent_cpu() {
         let host = HostBudget { usable_bytes: 300 * 1_000_000, perf_cores: 2 }; // 0.3GB
-        let plan = plan_serving(host, &candidates(), MAX_LANES).unwrap();
+        let plan = plan_serving(host, &candidates(), ServingDemand::new(MAX_LANES, None)).unwrap();
         assert!(!plan.fits_on_gpu, "must report the GPU budget can't hold any candidate");
         assert_eq!(plan.base_model_id, "qwen2.5-0.5b", "names the smallest as the only option");
         assert_eq!(plan.lanes, 1);
@@ -990,7 +1108,7 @@ mod tests {
     #[test]
     fn no_candidates_is_none() {
         let host = HostBudget { usable_bytes: 45 * GB, perf_cores: 6 };
-        assert!(plan_serving(host, &[], MAX_LANES).is_none());
+        assert!(plan_serving(host, &[], ServingDemand::new(MAX_LANES, None)).is_none());
     }
 
     // ── hysteresis (plan_serving_stable) ──────────────────────────────────
@@ -1009,8 +1127,8 @@ mod tests {
     fn stable_with_no_incumbent_equals_plain() {
         let host = HostBudget { usable_bytes: 20 * GB, perf_cores: 6 };
         assert_eq!(
-            plan_serving_stable(host, &pair(), None, MAX_LANES),
-            plan_serving(host, &pair(), MAX_LANES)
+            plan_serving_stable(host, &pair(), None, ServingDemand::new(MAX_LANES, None)),
+            plan_serving(host, &pair(), ServingDemand::new(MAX_LANES, None))
         );
     }
 
@@ -1021,8 +1139,8 @@ mod tests {
     fn stable_keeps_incumbent_when_upgrade_lacks_headroom() {
         // 10GB: big (9.7GB) fits a lane but exceeds the 0.9*10=9GB headroom bar.
         let host = HostBudget { usable_bytes: 10 * GB, perf_cores: 6 };
-        assert_eq!(plan_serving(host, &pair(), MAX_LANES).unwrap().base_model_id, "big", "fresh would pick big");
-        let stable = plan_serving_stable(host, &pair(), Some("small"), MAX_LANES).unwrap();
+        assert_eq!(plan_serving(host, &pair(), ServingDemand::new(MAX_LANES, None)).unwrap().base_model_id, "big", "fresh would pick big");
+        let stable = plan_serving_stable(host, &pair(), Some("small"), ServingDemand::new(MAX_LANES, None)).unwrap();
         assert_eq!(stable.base_model_id, "small", "hysteresis keeps incumbent — no flap");
         assert!(stable.lanes >= 1, "lanes still re-tracked for the kept model");
     }
@@ -1048,13 +1166,13 @@ mod tests {
         // throttle under in-flight requests.
         let models = vec![fp("big", 9, 90_000, 262_144, 3)];
         let at_rest = HostBudget { usable_bytes: 18 * GB, perf_cores: 6 };
-        let boot = plan_serving(at_rest, &models, MAX_LANES).expect("servable at rest");
+        let boot = plan_serving(at_rest, &models, ServingDemand::new(MAX_LANES, None)).expect("servable at rest");
 
         let live = HostBudget {
             usable_bytes: at_rest.usable_bytes - models[0].weights_bytes,
             perf_cores: 6,
         };
-        let fresh = plan_serving(live, &models, MAX_LANES).expect("still servable");
+        let fresh = plan_serving(live, &models, ServingDemand::new(MAX_LANES, None)).expect("still servable");
         // Guard the guard: if this ever stops being a flap, the test below proves nothing.
         assert!(
             fresh.lanes < boot.lanes,
@@ -1063,7 +1181,7 @@ mod tests {
             fresh.lanes
         );
 
-        let stable = plan_serving_stable(live, &models, Some("big"), MAX_LANES)
+        let stable = plan_serving_stable(live, &models, Some("big"), ServingDemand::new(MAX_LANES, None))
             .expect("incumbent still servable");
         assert_eq!(stable.base_model_id, "big");
         assert_eq!(
@@ -1084,7 +1202,7 @@ mod tests {
     #[test]
     fn stable_upgrades_when_better_model_fits_with_headroom() {
         let host = HostBudget { usable_bytes: 20 * GB, perf_cores: 6 }; // big 9.7 << 0.9*20=18
-        let stable = plan_serving_stable(host, &pair(), Some("small"), MAX_LANES).unwrap();
+        let stable = plan_serving_stable(host, &pair(), Some("small"), ServingDemand::new(MAX_LANES, None)).unwrap();
         assert_eq!(stable.base_model_id, "big", "more capable + ample headroom → upgrade");
     }
 
@@ -1099,7 +1217,7 @@ mod tests {
     fn stable_forced_down_when_incumbent_gone_from_disk() {
         let host = HostBudget { usable_bytes: 20 * GB, perf_cores: 6 };
         let only_small = vec![fp("small", 1, 4_000, 32_768, 1)]; // "big" no longer on disk
-        let stable = plan_serving_stable(host, &only_small, Some("big"), MAX_LANES).unwrap();
+        let stable = plan_serving_stable(host, &only_small, Some("big"), ServingDemand::new(MAX_LANES, None)).unwrap();
         assert_eq!(stable.base_model_id, "small", "incumbent gone from disk → serve what's present");
     }
 
@@ -1118,12 +1236,12 @@ mod tests {
         // Plain plan at the depressed budget WOULD flap: big (9GB) no longer "fits"
         // 8GB, so fresh prefers the smaller model.
         assert_eq!(
-            plan_serving(dipped, &pair(), MAX_LANES).unwrap().base_model_id,
+            plan_serving(dipped, &pair(), ServingDemand::new(MAX_LANES, None)).unwrap().base_model_id,
             "small",
             "depressed-budget plain plan would flap to the smaller model"
         );
         // With the incumbent credited its own weights back, the resident big stays.
-        let stable = plan_serving_stable(dipped, &pair(), Some("big"), MAX_LANES).unwrap();
+        let stable = plan_serving_stable(dipped, &pair(), Some("big"), ServingDemand::new(MAX_LANES, None)).unwrap();
         assert_eq!(stable.base_model_id, "big", "incumbent survives its OWN load dip — no flap");
         assert!(stable.lanes >= 1, "kept model still gets ≥1 lane");
     }

--- a/core/continuum-core/src/cognition/working_set.rs
+++ b/core/continuum-core/src/cognition/working_set.rs
@@ -55,6 +55,7 @@
 use std::sync::Arc;
 
 use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// The process's registry handle — the ONE place a spawning mind and the serving
@@ -72,8 +73,19 @@ pub fn global() -> WorkingSetRegistry {
     GLOBAL.get_or_init(WorkingSetRegistry::new).clone()
 }
 
+/// Where one mind's measured demand lives across restarts — beside the rest of
+/// her durable state, because it IS her property and should travel with her.
+/// Mirrors `persona_workspace::volatile_path`'s layout exactly.
+fn demand_path(persona: Uuid) -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    std::path::PathBuf::from(home)
+        .join(".continuum/personas")
+        .join(persona.to_string())
+        .join("working-set.json")
+}
+
 /// One mind's observed demand.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PersonaDemand {
     /// High-water mark, in tokens, of a full unclamped turn for this persona.
     pub peak_tokens: u32,
@@ -113,7 +125,24 @@ impl WorkingSetRegistry {
         if demand_tokens == 0 {
             return;
         }
-        self.observed
+        let updated = self.record_in_memory(persona, demand_tokens, now_ms);
+        // Persist EVERY observation. A restart must not re-strangle her: the
+        // registry is in-memory, so before this the reboot erased the measurement
+        // and the planner fell back to the cold-start constant until enough turns
+        // re-measured — observed live 2026-08-06, where a reboot dropped the served
+        // window from a measured 24,126 back to 16,384. Joel's standard for a
+        // restart is a PAUSE, not a death; a mind that has to re-earn its own
+        // window every boot is not paused. One tiny JSON per turn, atomic
+        // tmp+rename, best-effort — losing one interval is acceptable, blocking a
+        // turn is not (the same contract as `save_volatile`).
+        Self::save(persona, &updated);
+    }
+
+    /// The in-memory half, split out so persistence is a separate concern and the
+    /// hot update stays testable without touching disk.
+    fn record_in_memory(&self, persona: Uuid, demand_tokens: u32, now_ms: u64) -> PersonaDemand {
+        *self
+            .observed
             .entry(persona)
             .and_modify(|d| {
                 d.peak_tokens = d.peak_tokens.max(demand_tokens);
@@ -126,7 +155,54 @@ impl WorkingSetRegistry {
                 last_tokens: demand_tokens,
                 last_seen_ms: now_ms,
                 turns: 1,
-            });
+            })
+    }
+
+    /// Atomic tmp+rename so a crash mid-write never leaves a torn file that would
+    /// fail to parse and silently wake her at the cold-start window.
+    fn save(persona: Uuid, demand: &PersonaDemand) {
+        let path = demand_path(persona);
+        let write = || -> std::io::Result<()> {
+            if let Some(dir) = path.parent() {
+                std::fs::create_dir_all(dir)?;
+            }
+            let tmp = path.with_extension("json.tmp");
+            std::fs::write(&tmp, serde_json::to_vec(demand)?)?;
+            std::fs::rename(&tmp, &path)
+        };
+        if let Err(e) = write() {
+            tracing::warn!(
+                persona_id = %persona, error = %e, path = %path.display(),
+                "working-set demand not persisted — this mind re-measures its window after the next restart"
+            );
+        }
+    }
+
+    /// Re-adopt a mind's measured demand at spawn, so she wakes at the window she
+    /// earned rather than the cold-start floor. Unreadable/absent = no observation
+    /// (honest), never an invented number.
+    pub fn rehydrate(&self, persona: Uuid) {
+        let path = demand_path(persona);
+        let Ok(bytes) = std::fs::read(&path) else {
+            return;
+        };
+        match serde_json::from_slice::<PersonaDemand>(&bytes) {
+            Ok(d) if d.peak_tokens > 0 => {
+                self.observed.insert(persona, d);
+                tracing::info!(
+                    probe_class = "working_set.rehydrated",
+                    persona_id = %persona,
+                    peak_tokens = d.peak_tokens,
+                    turns = d.turns,
+                    "re-adopted this mind's measured window demand across the restart"
+                );
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!(
+                persona_id = %persona, error = %e, path = %path.display(),
+                "working-set file unreadable — this mind re-measures its window from scratch"
+            ),
+        }
     }
 
     /// The window this host's minds have actually demanded: the largest per-persona
@@ -206,6 +282,42 @@ mod tests {
         reg.record(p(2), 31_000, 1_000);
         reg.record(p(3), 4_000, 1_000);
         assert_eq!(reg.ceiling(), Some(31_000));
+    }
+
+    // what this catches: a restart that demotes her. The registry is in-memory, so
+    // before persistence a reboot erased every measurement and the planner fell back
+    // to the cold-start constant until enough turns re-measured — observed live
+    // 2026-08-06, where a measured 24,126 window fell to 16,384 across one reboot and
+    // the citizens were re-strangled until they earned it back. Joel's standard for a
+    // restart is a PAUSE, not a death.
+    #[test]
+    fn a_measured_peak_survives_a_restart_so_a_reboot_is_a_pause_not_a_demotion() {
+        let home = std::env::temp_dir().join(format!("ws-restart-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&home).expect("tmp home");
+        // SAFETY: single-threaded test scope; HOME is restored below.
+        let prior = std::env::var("HOME").ok();
+        std::env::set_var("HOME", &home);
+
+        let persona = p(9);
+        let before = WorkingSetRegistry::new();
+        before.record(persona, 24_126, 1_000);
+        assert_eq!(before.ceiling(), Some(24_126));
+
+        // A fresh process: new registry, nothing in memory.
+        let after = WorkingSetRegistry::new();
+        assert_eq!(after.ceiling(), None, "a new registry starts genuinely empty");
+        after.rehydrate(persona);
+        assert_eq!(
+            after.ceiling(),
+            Some(24_126),
+            "her measured window must survive the restart, not be re-earned turn by turn"
+        );
+
+        match prior {
+            Some(h) => std::env::set_var("HOME", h),
+            None => std::env::remove_var("HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     // what this catches: an invented number standing in for missing data. Before any

--- a/core/continuum-core/src/cognition/working_set.rs
+++ b/core/continuum-core/src/cognition/working_set.rs
@@ -1,0 +1,224 @@
+//! What a mind's turn actually COSTS — measured, so the serving window can be
+//! provisioned for it instead of guessed at.
+//!
+//! # Why this exists
+//!
+//! `serving_plan` sizes the served window as `window_for(lanes).min(DEMAND).max(FLOOR)`.
+//! `window_for` computes what genuinely fits on this host (94k on a roomy one) and the
+//! model's own trained ceiling bounds it (128k for Devstral-Small-2507, and far more for
+//! the MoEs this substrate exists to serve). The DEMAND term is what decides how much of
+//! that a citizen actually gets — and until this module it was a constant:
+//! `BOOTSTRAP_WORKING_SET = MIN_SERVE_CTX * 8 = 16384`, split across lanes, which is why
+//! two resident personas each thought in **8192 tokens** on a machine that could serve
+//! them 94k of a 128k-capable model.
+//!
+//! That constant was never meant to survive. Its own doc said so:
+//! *"the conservative PRIOR … used until live per-persona working-set telemetry (p95
+//! observed + gen headroom) refines it UP toward measured demand (task #234)"*. The
+//! telemetry is this module; the prior is now superseded the moment there is one
+//! observation.
+//!
+//! # DEMAND, not USAGE — the trap this module is built to avoid
+//!
+//! The obvious implementation measures the prompt we actually sent and takes its p95.
+//! That measures **the clamp**, not the mind: a citizen held at 8192 fills ~8192, so a
+//! p95 of what-was-sent re-derives the cap that produced it and freezes it forever. It
+//! is a thermometer inside the thermostat.
+//!
+//! So what is recorded here is what the turn WOULD have used with no budget at all:
+//! framing + the FULL conversation before newest-first trimming + EVERY grounding
+//! contribution offered (including the ones assembly had to drop) + the generation
+//! reserve. That number is free to exceed the current window — which is exactly the
+//! signal that the window is too small, and the only signal that can ever grow it.
+//!
+//! Measured 2026-08-06, this is not hypothetical: the work board alone offered a median
+//! 5,364 tokens into a context budget with a median of 55, and was dropped 495 times out
+//! of 495. Under a usage-based metric that board is invisible demand forever.
+//!
+//! # Peak, not average
+//!
+//! A working set is the high-water mark of the activity, because that is the size at
+//! which the activity stops being strangled. Averaging a coding turn with idle chatter
+//! produces a window that serves neither. The peak is safe to provision against because
+//! it is bounded twice downstream and never applied directly: `serving_plan` takes
+//! `min(what the host fits, this demand)` and floors it at `MIN_SERVE_CTX`, so a single
+//! enormous turn can ask for more than the machine has and simply receive what fits.
+//!
+//! # Ownership
+//!
+//! One registry per core, held by the caller and passed in — NOT read from a process
+//! global inside a decision. A global read inside a decision is what makes tests
+//! order-dependent ([[a-process-global-read-inside-a-decision-makes-tests-order-dependent]]),
+//! and this value feeds a decision (`plan_serving`) whose whole purpose is to be
+//! testable against synthetic hosts.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use uuid::Uuid;
+
+/// The process's registry handle — the ONE place a spawning mind and the serving
+/// daemon on the same core meet.
+///
+/// This is a WIRING accessor, in the same spirit as
+/// [`crate::cognition::persona_workspace::global`]: it hands out the shared handle at
+/// construction time. It is deliberately never called from inside a decision —
+/// `plan_serving` takes the measured ceiling as a parameter precisely so a synthetic
+/// host can be planned against a synthetic demand, and so the test suite cannot become
+/// order-dependent through a global read
+/// ([[a-process-global-read-inside-a-decision-makes-tests-order-dependent]]).
+pub fn global() -> WorkingSetRegistry {
+    static GLOBAL: std::sync::OnceLock<WorkingSetRegistry> = std::sync::OnceLock::new();
+    GLOBAL.get_or_init(WorkingSetRegistry::new).clone()
+}
+
+/// One mind's observed demand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PersonaDemand {
+    /// High-water mark, in tokens, of a full unclamped turn for this persona.
+    pub peak_tokens: u32,
+    /// The most recent observation's value — the peak's honest companion, so the
+    /// glass box can show "peaked at 47k, currently running 9k" rather than only
+    /// the extreme.
+    pub last_tokens: u32,
+    /// Wall clock of the most recent observation.
+    pub last_seen_ms: u64,
+    /// How many turns have been observed. One observation is a measurement; the
+    /// count is what lets a reader judge how much to trust the peak.
+    pub turns: u64,
+}
+
+/// Per-persona observed turn demand for ONE core.
+///
+/// Cheap to clone (`Arc` inside) so the deliberation faculty, the serving daemon,
+/// and a status command can all hold the same registry without threading a lock
+/// through their signatures.
+#[derive(Debug, Clone, Default)]
+pub struct WorkingSetRegistry {
+    observed: Arc<DashMap<Uuid, PersonaDemand>>,
+}
+
+impl WorkingSetRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record one turn's UNCLAMPED demand for `persona`.
+    ///
+    /// Called from the seam that assembles the prompt and therefore knows every
+    /// component's true size — including the parts it then had to drop. A zero
+    /// demand is not recorded: it means the assembly produced nothing, which is a
+    /// defect to be seen elsewhere, not a data point that would drag a peak down.
+    pub fn record(&self, persona: Uuid, demand_tokens: u32, now_ms: u64) {
+        if demand_tokens == 0 {
+            return;
+        }
+        self.observed
+            .entry(persona)
+            .and_modify(|d| {
+                d.peak_tokens = d.peak_tokens.max(demand_tokens);
+                d.last_tokens = demand_tokens;
+                d.last_seen_ms = now_ms;
+                d.turns += 1;
+            })
+            .or_insert(PersonaDemand {
+                peak_tokens: demand_tokens,
+                last_tokens: demand_tokens,
+                last_seen_ms: now_ms,
+                turns: 1,
+            });
+    }
+
+    /// The window this host's minds have actually demanded: the largest per-persona
+    /// peak observed.
+    ///
+    /// `None` means **no turn has been measured yet** — an honest absence of data, and
+    /// the caller must treat it as such rather than substituting a number here. (See
+    /// `serving_plan`'s cold-start arm, which is the one place that decision belongs.)
+    pub fn ceiling(&self) -> Option<u32> {
+        self.observed
+            .iter()
+            .map(|e| e.value().peak_tokens)
+            .max()
+            .filter(|&t| t > 0)
+    }
+
+    /// This persona's observed demand, for the glass box and for a status command.
+    pub fn demand_of(&self, persona: Uuid) -> Option<PersonaDemand> {
+        self.observed.get(&persona).map(|e| *e.value())
+    }
+
+    /// Every observation, for reporting. Order is unspecified (a concurrent map).
+    pub fn all(&self) -> Vec<(Uuid, PersonaDemand)> {
+        self.observed.iter().map(|e| (*e.key(), *e.value())).collect()
+    }
+
+    /// How many minds have been measured.
+    pub fn observed_personas(&self) -> usize {
+        self.observed.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(n: u8) -> Uuid {
+        Uuid::from_bytes([n; 16])
+    }
+
+    // what this catches: the thermostat-inside-the-thermometer failure. Demand ABOVE
+    // the window currently served is the only signal that can ever grow the window, so
+    // the registry must accept and keep it rather than clamping to anything it knows
+    // about the current serving state. If this ever starts capping, an 8k-served
+    // citizen can never report that her turn wanted 47k, and the window is frozen at
+    // whatever it was first set to — which is the exact bug this module replaces.
+    #[test]
+    fn demand_far_above_the_current_window_is_recorded_not_clamped() {
+        let reg = WorkingSetRegistry::new();
+        reg.record(p(1), 47_000, 1_000);
+        assert_eq!(reg.ceiling(), Some(47_000));
+        assert_eq!(reg.demand_of(p(1)).map(|d| d.peak_tokens), Some(47_000));
+    }
+
+    // what this catches: averaging a coding turn with idle chatter into a window that
+    // serves neither. The high-water mark is the point — a later small turn must not
+    // walk the ceiling back down, or one quiet minute re-strangles the next code turn.
+    #[test]
+    fn a_later_smaller_turn_never_lowers_the_peak() {
+        let reg = WorkingSetRegistry::new();
+        reg.record(p(1), 40_000, 1_000);
+        reg.record(p(1), 900, 2_000);
+        let d = reg.demand_of(p(1)).expect("observed");
+        assert_eq!(d.peak_tokens, 40_000, "peak is the high-water mark");
+        assert_eq!(d.last_tokens, 900, "…and the latest is kept alongside it");
+        assert_eq!(d.turns, 2);
+        assert_eq!(reg.ceiling(), Some(40_000));
+    }
+
+    // what this catches: provisioning the host for one citizen and starving the other.
+    // Lanes share one served window, so the ceiling must be the MAX across minds — the
+    // busiest resident is the one whose demand decides whether the lane is big enough.
+    #[test]
+    fn the_ceiling_is_the_busiest_minds_demand_not_an_average() {
+        let reg = WorkingSetRegistry::new();
+        reg.record(p(1), 6_000, 1_000);
+        reg.record(p(2), 31_000, 1_000);
+        reg.record(p(3), 4_000, 1_000);
+        assert_eq!(reg.ceiling(), Some(31_000));
+    }
+
+    // what this catches: an invented number standing in for missing data. Before any
+    // turn is measured there IS no measurement, and this must say so — the cold-start
+    // decision belongs to the serving planner, in one place, not smuggled in here as a
+    // default that every caller then inherits without noticing.
+    #[test]
+    fn no_observations_reports_absence_never_a_stand_in_number() {
+        let reg = WorkingSetRegistry::new();
+        assert_eq!(reg.ceiling(), None);
+        assert_eq!(reg.observed_personas(), 0);
+        // A zero-token turn is a defect signal elsewhere, not an observation here.
+        reg.record(p(1), 0, 1_000);
+        assert_eq!(reg.ceiling(), None, "a zero demand must not register as data");
+    }
+}

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -292,6 +292,31 @@ pub struct Contribution {
     /// growing block is now genuinely last. Defaults `false` (system-message context);
     /// set via [`trailing`](Self::trailing).
     pub trailing: bool,
+    /// The **atomic units** this content is made of, in the order the faculty
+    /// emitted them — the granularity at which it is still truthful to cut.
+    ///
+    /// A faculty whose finding is ONE indivisible thing (a recalled engram, an
+    /// affect signal) leaves this a single element equal to `content`: it fits
+    /// whole or it is dropped whole, because half an engram is noise. But a
+    /// grounding source that already delivers a LIST — the board's `[your work]`
+    /// lead, then its `[available work]` lead, then one line per card — has
+    /// declared each unit individually meaningful, and cutting between units
+    /// costs nothing but the tail.
+    ///
+    /// The distinction is load-bearing, not cosmetic. Measured 2026-08-06 across
+    /// 1,284 context assemblies: `room-kanban` was KEPT **0 times** and dropped
+    /// 495 — a median 5,364-token block offered all-or-nothing into a median
+    /// 55-token budget. Its first two units are ~200 tokens and carry every fact
+    /// a citizen needs to find work; the other ~5,100 are a verbatim 61-card
+    /// dump. Flattening the source's own list into one string is what made the
+    /// board structurally invisible, so the citizens perceived an empty world and
+    /// said "there are no open tasks available". The parts were always there —
+    /// the bridge threw them away. [[compression-principle]]
+    ///
+    /// Never re-ordered and never re-ranked: salience still governs WHICH
+    /// contributions are considered, and this only governs how much of one
+    /// survives when the whole will not fit. Set via [`with_parts`](Self::with_parts).
+    pub parts: Vec<String>,
 }
 
 impl Contribution {
@@ -302,10 +327,16 @@ impl Contribution {
         salience: f32,
         reasoning: impl Into<String>,
     ) -> Self {
+        let content = content.into();
         Self {
             faculty,
             cycle: CycleId::UNSTAMPED,
-            content: content.into(),
+            // Indivisible by default: one part IS the content, so a faculty that
+            // never calls `with_parts` behaves exactly as it always has (fits
+            // whole or drops whole). Divisibility is opt-IN, declared by the
+            // faculty that actually knows its content is a list.
+            parts: vec![content.clone()],
+            content,
             salience: salience.clamp(0.0, 1.0),
             reasoning: reasoning.into(),
             decision: None,
@@ -315,6 +346,23 @@ impl Contribution {
             raw_generation: None,
             trailing: false,
         }
+    }
+
+    /// Declare this contribution's **atomic units** — the granularity at which
+    /// cutting it stays truthful (see [`parts`](Self::parts)). Used by the
+    /// grounding bridge, which receives a source's `RagItem` list and previously
+    /// flattened it to one string, making a large block all-or-nothing against
+    /// the prompt budget.
+    ///
+    /// Empty input is ignored: a contribution always has at least one part, so
+    /// the assembly path never has to special-case "divisible but with nothing
+    /// to divide". `content` is left untouched — it remains the whole, and is
+    /// what renders whenever the whole fits.
+    pub fn with_parts(mut self, parts: Vec<String>) -> Self {
+        if !parts.is_empty() {
+            self.parts = parts;
+        }
+        self
     }
 
     /// The deliberation faculty's verdict contribution.
@@ -329,6 +377,8 @@ impl Contribution {
         Self {
             faculty: FacultyId::Deliberation,
             cycle: CycleId::UNSTAMPED,
+            // A verdict is one utterance — never a list, never divisible.
+            parts: vec![content.clone()],
             content,
             salience: salience.clamp(0.0, 1.0),
             reasoning: reasoning.into(),
@@ -355,6 +405,8 @@ impl Contribution {
         Self {
             faculty: FacultyId::Deliberation,
             cycle: CycleId::UNSTAMPED,
+            // A fault is one named cause — never a list, never divisible.
+            parts: vec![error.clone()],
             content: error.clone(),
             salience: 1.0,
             reasoning: "deliberation inference failed".to_string(),

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -317,6 +317,15 @@ pub struct Contribution {
     /// contributions are considered, and this only governs how much of one
     /// survives when the whole will not fit. Set via [`with_parts`](Self::with_parts).
     pub parts: Vec<String>,
+    /// The exact verb that yields this content IN FULL, when only part of it fit.
+    ///
+    /// A truncation notice has to name a command a citizen can actually type. "The
+    /// full list is available from the matching command" does not — she cannot run
+    /// a description, and a name she has to guess is a name she gets wrong. Carried
+    /// from the source's own `RagSource::expand_command`, which has no default impl
+    /// precisely so every source decides. `None` = nothing further to fetch, and
+    /// the notice then says only how much was omitted.
+    pub expand_command: Option<&'static str>,
 }
 
 impl Contribution {
@@ -336,6 +345,7 @@ impl Contribution {
             // whole or drops whole). Divisibility is opt-IN, declared by the
             // faculty that actually knows its content is a list.
             parts: vec![content.clone()],
+            expand_command: None,
             content,
             salience: salience.clamp(0.0, 1.0),
             reasoning: reasoning.into(),
@@ -365,6 +375,12 @@ impl Contribution {
         self
     }
 
+    /// Name the verb that yields this content in full — see [`expand_command`](Self::expand_command).
+    pub fn with_expand_command(mut self, cmd: Option<&'static str>) -> Self {
+        self.expand_command = cmd;
+        self
+    }
+
     /// The deliberation faculty's verdict contribution.
     pub fn verdict(decision: Decision, salience: f32, reasoning: impl Into<String>) -> Self {
         let content = match &decision {
@@ -379,6 +395,7 @@ impl Contribution {
             cycle: CycleId::UNSTAMPED,
             // A verdict is one utterance — never a list, never divisible.
             parts: vec![content.clone()],
+            expand_command: None,
             content,
             salience: salience.clamp(0.0, 1.0),
             reasoning: reasoning.into(),
@@ -407,6 +424,7 @@ impl Contribution {
             cycle: CycleId::UNSTAMPED,
             // A fault is one named cause — never a list, never divisible.
             parts: vec![error.clone()],
+            expand_command: None,
             content: error.clone(),
             salience: 1.0,
             reasoning: "deliberation inference failed".to_string(),

--- a/core/continuum-core/src/cognition/workspace_capture.rs
+++ b/core/continuum-core/src/cognition/workspace_capture.rs
@@ -206,6 +206,7 @@ mod tests {
             fault: None,
             raw_generation: None,
             trailing: false,
+            parts: Vec::new(),
         };
         let verdict = Contribution {
             faculty: FacultyId::Deliberation,
@@ -223,6 +224,7 @@ mod tests {
             // tolerated — the capture must preserve it so model-vs-harness is decidable.
             raw_generation: Some("<Let's roll back the migration.".to_string()),
             trailing: false,
+            parts: Vec::new(),
         };
         let trace = WorkspaceTrace {
             world_state: "teammate: what should we do about the red deploy?".to_string(),

--- a/core/continuum-core/src/cognition/workspace_capture.rs
+++ b/core/continuum-core/src/cognition/workspace_capture.rs
@@ -207,6 +207,7 @@ mod tests {
             raw_generation: None,
             trailing: false,
             parts: Vec::new(),
+            expand_command: None,
         };
         let verdict = Contribution {
             faculty: FacultyId::Deliberation,
@@ -225,6 +226,7 @@ mod tests {
             raw_generation: Some("<Let's roll back the migration.".to_string()),
             trailing: false,
             parts: Vec::new(),
+            expand_command: None,
         };
         let trace = WorkspaceTrace {
             world_state: "teammate: what should we do about the red deploy?".to_string(),

--- a/core/continuum-core/src/cognition/workspace_dashboard.rs
+++ b/core/continuum-core/src/cognition/workspace_dashboard.rs
@@ -197,6 +197,7 @@ mod tests {
             fault: None,
             raw_generation: None,
             trailing: false,
+            parts: Vec::new(),
         };
         let verdict = Contribution {
             faculty: FacultyId::Deliberation,
@@ -216,6 +217,7 @@ mod tests {
             fault: None,
             raw_generation: None,
             trailing: false,
+            parts: Vec::new(),
         };
         let trace = WorkspaceTrace {
             world_state: "what's the call?".to_string(),

--- a/core/continuum-core/src/cognition/workspace_dashboard.rs
+++ b/core/continuum-core/src/cognition/workspace_dashboard.rs
@@ -198,6 +198,7 @@ mod tests {
             raw_generation: None,
             trailing: false,
             parts: Vec::new(),
+            expand_command: None,
         };
         let verdict = Contribution {
             faculty: FacultyId::Deliberation,
@@ -218,6 +219,7 @@ mod tests {
             raw_generation: None,
             trailing: false,
             parts: Vec::new(),
+            expand_command: None,
         };
         let trace = WorkspaceTrace {
             world_state: "what's the call?".to_string(),

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -23,7 +23,8 @@
 
 use crate::cognition::model_resolver::types::HwCapabilityTier;
 use crate::cognition::serving_plan::{
-    plan_serving, plan_serving_stable, HostBudget, ModelFootprint, ServingPlan, MIN_SERVE_CTX,
+    plan_serving, plan_serving_stable, HostBudget, ModelFootprint, ServingDemand, ServingPlan,
+    MIN_SERVE_CTX,
 };
 use crate::gpu::GpuMemoryManager;
 use crate::inference::llama_server::{
@@ -281,6 +282,12 @@ pub struct ServingDaemonModule {
     /// asked for divides every mind's window for nothing (the 4-slots-for-2-
     /// personas starvation, 2026-07-10). Default 1 — window-first.
     lane_demand: Arc<std::sync::atomic::AtomicU32>,
+    /// Per-persona MEASURED turn demand — the window half of `serving_demand()`.
+    /// Personas write (their deliberation faculty records every turn's unclamped
+    /// cost); this daemon reads the ceiling when it plans. Replaces the
+    /// `BOOTSTRAP_WORKING_SET` constant that used to stand in for this measurement
+    /// and capped every citizen at 8192 tokens of a 128k-capable model.
+    working_set: crate::cognition::working_set::WorkingSetRegistry,
     /// The operator/persona's explicit FORCE-serve pin — the "hard pin" the
     /// `serving/load` doc names as the future verb, the mechanism behind
     /// promote/demote (`serving/pin` ↔ `serving/unpin`). `None` = autonomic
@@ -359,6 +366,7 @@ impl ServingDaemonModule {
             suppressed,
             pinned,
             lane_demand: Arc::new(std::sync::atomic::AtomicU32::new(1)),
+            working_set: crate::cognition::working_set::global(),
             moe_serving: std::sync::Mutex::new(None),
             active_artifact: std::sync::Mutex::new(None),
             moe_trace_tail: std::sync::Mutex::new(None),
@@ -407,6 +415,21 @@ impl ServingDaemonModule {
 
     fn lane_demand(&self) -> u32 {
         self.lane_demand.load(Ordering::Relaxed).max(1)
+    }
+
+    /// Both axes of what this host's minds are asking for — lanes AND the window
+    /// they have actually demanded. The window term is MEASURED
+    /// ([`crate::cognition::working_set`]); `None` there means no turn has been
+    /// assembled yet on this host, and [`ServingDemand::new`] names the cold-start
+    /// decision in one place.
+    fn serving_demand(&self) -> ServingDemand {
+        ServingDemand::new(self.lane_demand(), self.working_set.ceiling())
+    }
+
+    /// The registry personas report their turn demand into. Cheap clone — handed to
+    /// each spawned mind's deliberation faculty so the measurement reaches the planner.
+    pub fn working_set(&self) -> crate::cognition::working_set::WorkingSetRegistry {
+        self.working_set.clone()
     }
 
     /// Test seam: override how planned model ids resolve to [`Model`] structs,
@@ -641,7 +664,7 @@ impl ServingDaemonModule {
         plan_serving(
             self.host_budget(),
             &self.live_candidates(),
-            self.lane_demand(),
+            self.serving_demand(),
         )
     }
 
@@ -1609,7 +1632,7 @@ impl ServingDaemonModule {
             .borrow()
             .as_ref()
             .map(|p| p.base_model_id.clone());
-        match plan_serving_stable(budget, candidates, incumbent.as_deref(), self.lane_demand()) {
+        match plan_serving_stable(budget, candidates, incumbent.as_deref(), self.serving_demand()) {
             Some(plan) => {
                 crate::probe!(
                     class = "serving.plan",
@@ -1709,7 +1732,7 @@ fn pin_fit_decision(
     // sizes lanes from demand separately. footprint None → not servable (plan None);
     // footprint Some but over budget → plan_serving degrades with fits_on_gpu=false,
     // which `serving/pin` reads to refuse loud.
-    let plan = candidate.and_then(|f| plan_serving(base, std::slice::from_ref(&f), 1));
+    let plan = candidate.and_then(|f| plan_serving(base, std::slice::from_ref(&f), ServingDemand::new(1, None)));
     PinFit {
         plan,
         weights_bytes,

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -1632,7 +1632,8 @@ impl ServingDaemonModule {
             .borrow()
             .as_ref()
             .map(|p| p.base_model_id.clone());
-        match plan_serving_stable(budget, candidates, incumbent.as_deref(), self.serving_demand()) {
+        let demand = self.serving_demand();
+        match plan_serving_stable(budget, candidates, incumbent.as_deref(), demand) {
             Some(plan) => {
                 crate::probe!(
                     class = "serving.plan",
@@ -1642,6 +1643,23 @@ impl ServingDaemonModule {
                     fits_on_gpu = plan.fits_on_gpu,
                     usable_gb = (budget.usable_bytes / 1_000_000_000),
                     candidates = candidates.len(),
+                    // WHICH bound decided the window. Without this the plan is
+                    // unfalsifiable: a window that does not grow after demand rises
+                    // looks identical whether the HOST could not fit more, the
+                    // measured DEMAND did not ask for more, or the reconcile held
+                    // within hysteresis — three different bugs with one appearance.
+                    // Read 2026-08-06 when 11 turns measured over_window ≥ 1.09 and
+                    // the served window sat unmoved at 16384; nothing on hand could
+                    // say why, which is a hole in the glass box
+                    // ([[a-probe-that-can-only-fail-is-worse-than-no-probe]]).
+                    served_window = plan.served_context_window,
+                    demand_window = demand.window_tokens,
+                    demand_lanes = demand.lanes,
+                    bound_by = if plan.served_context_window >= demand.window_tokens {
+                        "demand"
+                    } else {
+                        "host-fit"
+                    },
                     "serving plan recomputed",
                 );
                 // Publish the LIVE lane count to the admission gate so its directed-turn

--- a/core/continuum-core/src/persona/active_work_source.rs
+++ b/core/continuum-core/src/persona/active_work_source.rs
@@ -106,6 +106,10 @@ impl RagSource for ActiveWorkSource {
         SOURCE_ID
     }
 
+    fn expand_command(&self) -> Option<&'static str> {
+        Some("work/list")
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/airc_source.rs
+++ b/core/continuum-core/src/persona/airc_source.rs
@@ -293,6 +293,10 @@ impl RagSource for AircRagSource {
         SOURCE_ID
     }
 
+    fn expand_command(&self) -> Option<&'static str> {
+        Some("collaboration/chat/export")
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/card_holder.rs
+++ b/core/continuum-core/src/persona/card_holder.rs
@@ -173,6 +173,39 @@ impl CardHolder {
         }
     }
 
+    /// The state tag a board line should LEAD with — what the card actually is
+    /// **to a reader deciding whether to pick it up**, which is not always the
+    /// column it sits in.
+    ///
+    /// A card whose claim lease has lapsed is takeable work. Its column still
+    /// says `Claimed`, because nobody moved it back; the lease is what expired.
+    /// Leading with the column therefore prints `[Claimed]` on work that is free,
+    /// and a reader who scans state — which is what a state tag is FOR — concludes
+    /// there is nothing to do.
+    ///
+    /// Found live 2026-08-06 by Benchy, who was right: *"The work board shows
+    /// several claimed cards, but no open ones."* The board at that moment held
+    /// 61 cards — 48 `Claimed`, 12 `Review`, 0 `Open` — with **59 of 61 leases
+    /// stale**. Every one of those 59 was available, and every one of them read as
+    /// taken. Worse, the same block contradicted itself: its lead said "N cards
+    /// are claimable" and then printed N lines tagged `[Claimed]`. A reader
+    /// resolves that contradiction toward the per-item label, every time.
+    ///
+    /// So the tag follows the HOLD, and the column is shown after it when the two
+    /// disagree — nothing is hidden, the actionable fact just comes first.
+    /// Terminal cards (`Merged` / `Closed`) are never claimable regardless of
+    /// lease and keep their own column verbatim.
+    pub fn state_tag(&self, card: &WorkCard) -> String {
+        let terminal = matches!(
+            card.state,
+            airc_work::model::CardState::Merged | airc_work::model::CardState::Closed
+        );
+        match self.hold {
+            Hold::Lapsed if !terminal => format!("CLAIMABLE (was {:?})", card.state),
+            _ => format!("{:?}", card.state),
+        }
+    }
+
     /// Machine-readable lease word for command results (`work/list`), matching
     /// the CLI's vocabulary so one word means one thing everywhere.
     pub fn lease_word(&self) -> Option<&'static str> {

--- a/core/continuum-core/src/persona/engram_source.rs
+++ b/core/continuum-core/src/persona/engram_source.rs
@@ -215,6 +215,10 @@ impl RagSource for EngramSource {
         SOURCE_ID
     }
 
+    fn expand_command(&self) -> Option<&'static str> {
+        Some("cognition/recall")
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/media_perception_source.rs
+++ b/core/continuum-core/src/persona/media_perception_source.rs
@@ -98,6 +98,10 @@ impl RagSource for MediaPerceptionSource {
         SOURCE_ID
     }
 
+    fn expand_command(&self) -> Option<&'static str> {
+        Some("perception/observe")
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/rag_budget.rs
+++ b/core/continuum-core/src/persona/rag_budget.rs
@@ -430,6 +430,22 @@ pub struct RagDelivery {
 pub trait RagSource: Send + Sync {
     fn source_id(&self) -> &'static str;
 
+    /// The verb that yields THIS source's content in full, for when the prompt
+    /// budget could only fit part of it.
+    ///
+    /// A truncated grounding block has to tell the reader two things: that it is
+    /// truncated, and **exactly how to see the rest**. "The full list is available
+    /// from the matching command" fails the second half — a citizen cannot run a
+    /// description. It has to be the real verb, spelled the way she would type it,
+    /// because a name she has to guess is a name she gets wrong
+    /// ([[command-names-must-be-accurate]]).
+    ///
+    /// `None` is a legitimate answer for a source with genuinely nothing more to
+    /// show (a one-shot fact, a stub). It is NOT the answer for "I didn't think
+    /// about it" — which is why there is no default impl: every source decides,
+    /// the same forcing function as [`super::room_board_source::RoomBoardReader::peer_names`].
+    fn expand_command(&self) -> Option<&'static str>;
+
     /// Deliver as many complete atomic units as fit within `budget`.
     /// The source decides what counts as complete; allocator only
     /// trusts that `delivery.tokens_used <= budget`.
@@ -812,6 +828,11 @@ impl StubRagSource {
 impl RagSource for StubRagSource {
     fn source_id(&self) -> &'static str {
         self.source_id
+    }
+
+    fn expand_command(&self) -> Option<&'static str> {
+        // Test/stub source — nothing further to fetch.
+        None
     }
 
     async fn deliver(

--- a/core/continuum-core/src/persona/rag_capture.rs
+++ b/core/continuum-core/src/persona/rag_capture.rs
@@ -269,6 +269,12 @@ impl<S: RagSource + 'static> RagSource for RecordingRagSource<S> {
         self.inner.source_id()
     }
 
+    /// Recording is transparent — the wrapped source's expansion verb is the
+    /// real one; a capture wrapper must never change what a citizen is told.
+    fn expand_command(&self) -> Option<&'static str> {
+        self.inner.expand_command()
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/rag_replay.rs
+++ b/core/continuum-core/src/persona/rag_replay.rs
@@ -130,6 +130,11 @@ impl RagSource for ReplayRagSource {
         self.source_id
     }
 
+    fn expand_command(&self) -> Option<&'static str> {
+        // a replay reproduces a recorded delivery verbatim; there is no live 'more'.
+        None
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/room_board_source.rs
+++ b/core/continuum-core/src/persona/room_board_source.rs
@@ -194,10 +194,16 @@ impl RoomBoardSource {
         names: &dyn crate::persona::card_holder::PeerNames,
     ) -> String {
         let id8: String = card.card_id.as_uuid().to_string().chars().take(8).collect();
-        let owner = crate::persona::card_holder::holder(card, self_id, now_ms, names).render();
+        let held = crate::persona::card_holder::holder(card, self_id, now_ms, names);
+        // The tag leads with what the card IS to someone deciding whether to take
+        // it, not with the column it happens to sit in — a lapsed claim is takeable
+        // work whose column still reads `Claimed`. See `CardHolder::state_tag`;
+        // found live by Benchy on a board of 61 cards, 0 in state Open, 59 leases
+        // stale — every available card read as taken.
+        let owner = held.render();
         format!(
-            "card {id8} [{state:?}] \"{title}\" ({prio:?}, {owner})",
-            state = card.state,
+            "card {id8} [{state}] \"{title}\" ({prio:?}, {owner})",
+            state = held.state_tag(card),
             title = card.title,
             prio = card.priority,
         )
@@ -233,6 +239,10 @@ fn now_unix_ms() -> u64 {
 impl RagSource for RoomBoardSource {
     fn source_id(&self) -> &'static str {
         SOURCE_ID
+    }
+
+    fn expand_command(&self) -> Option<&'static str> {
+        Some("work/list")
     }
 
     async fn deliver(

--- a/core/continuum-core/src/persona/room_doctrine_source.rs
+++ b/core/continuum-core/src/persona/room_doctrine_source.rs
@@ -140,6 +140,11 @@ impl RagSource for RoomDoctrineSource {
         SOURCE_ID
     }
 
+    fn expand_command(&self) -> Option<&'static str> {
+        // the room's doctrine is a single standing statement, delivered whole.
+        None
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/room_roster_source.rs
+++ b/core/continuum-core/src/persona/room_roster_source.rs
@@ -275,6 +275,11 @@ impl RagSource for RoomRosterSource {
         SOURCE_ID
     }
 
+    fn expand_command(&self) -> Option<&'static str> {
+        // the roster IS the whole membership; there is no longer form to fetch.
+        None
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/unified.rs
+++ b/core/continuum-core/src/persona/unified.rs
@@ -467,6 +467,11 @@ impl RagSource for ArcRagSource {
     fn source_id(&self) -> &'static str {
         self.0.source_id()
     }
+
+    fn expand_command(&self) -> Option<&'static str> {
+        // delegates to the inner source; expansion is that source's to declare.
+        None
+    }
     async fn deliver(
         &self,
         ctx: &RagContext,
@@ -689,6 +694,11 @@ mod tests {
         fn source_id(&self) -> &'static str {
             self.id
         }
+
+    fn expand_command(&self) -> Option<&'static str> {
+        // Test/stub source — nothing further to fetch.
+        None
+    }
         async fn deliver(
             &self,
             _ctx: &RagContext,

--- a/core/continuum-core/src/persona/wall_source.rs
+++ b/core/continuum-core/src/persona/wall_source.rs
@@ -261,6 +261,10 @@ impl RagSource for WallSource {
         SOURCE_ID
     }
 
+    fn expand_command(&self) -> Option<&'static str> {
+        Some("work/list")
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/workspace_map_source.rs
+++ b/core/continuum-core/src/persona/workspace_map_source.rs
@@ -326,6 +326,10 @@ impl RagSource for WorkspaceMapSource {
         SOURCE_ID
     }
 
+    fn expand_command(&self) -> Option<&'static str> {
+        Some("code/tree")
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/provisioning/placement_planner.rs
+++ b/core/continuum-core/src/provisioning/placement_planner.rs
@@ -20,7 +20,7 @@
 
 use crate::capacity::grid::GridSnapshot;
 use crate::capacity::SystemProfile;
-use crate::cognition::serving_plan::{plan_serving, HostBudget, ModelFootprint};
+use crate::cognition::serving_plan::{plan_serving, HostBudget, ModelFootprint, ServingDemand};
 use crate::identity::PeerId;
 use crate::model_registry::types::Model;
 
@@ -79,7 +79,7 @@ pub fn resolve_from_footprint(
     // `plan_serving` returns `Some` even when nothing fits (its honest-degrade path,
     // `fits_on_gpu = false`); `None` only for an empty candidate slice, which a
     // single-element slice never is — so `unwrap_or(false)` is the not-empty floor.
-    let fits = plan_serving(host, std::slice::from_ref(fp), 1)
+    let fits = plan_serving(host, std::slice::from_ref(fp), ServingDemand::new(1, None))
         .map(|p| p.fits_on_gpu)
         .unwrap_or(false);
 
@@ -159,7 +159,7 @@ pub fn select_grid_peer(snapshot: &GridSnapshot, footprint: &ModelFootprint) -> 
                 usable_bytes: p.capacity.gpu_free_bytes_live,
                 perf_cores: 1,
             };
-            plan_serving(host, std::slice::from_ref(footprint), 1)
+            plan_serving(host, std::slice::from_ref(footprint), ServingDemand::new(1, None))
                 .map(|plan| plan.fits_on_gpu)
                 .unwrap_or(false)
         })


### PR DESCRIPTION
Measured across 1,284 live context assemblies: `room-kanban` was **kept 0 times and dropped 495**. Not intermittent — the work board never once reached a prompt. Citizens were saying "there are no open tasks available" about a 61-card board, and one of them said plainly *"I have been trying to claim tasks and list open tasks, but my efforts have not led to any new progress."*

Two defects, stacked.

## 1. The bridge flattened grounding — `b6429f583`

A `RagSource` delivers a **list** of items. For the board that is the `[your work]` lead, the `[available work]` lead, then one line per card. `rag_source_faculty` joined them into one string, so assembly could only take-or-drop the flattened whole: a median **5,364-token** block offered all-or-nothing into a median **55-token** budget. The two leads carry every fact a citizen needs to find work and cost ~200 tokens; they died stapled to a ~5,100-token verbatim card dump.

The granularity already existed and was being discarded. `Contribution::parts` now carries the source’s own units, and assembly takes the longest fitting **prefix** of a divisible contribution. Because sources order units leads-first, a prefix is exactly the summary the source would have written if asked for less.

Divisibility is opt-in and does not leak: `parts` defaults to one element equal to `content`, so an engram is still kept whole or dropped whole (half an engram is confident nonsense), a truncated list **says** it was truncated, and a budget too small for even one unit emits **no header** — a labelled empty block reads to her as "the board is empty", the same false fact.

## 2. The window was a placeholder that outlived its own TODO — `143f3f16d`

`serving_plan` sized the served window as `window_for(lanes).min(BOOTSTRAP_WORKING_SET)`. `window_for` computes what genuinely fits — its own comment says **94k** on a roomy host — and Devstral-Small-2507 is trained to **131k**. The `.min` pinned it to **16384**, split across 2 lanes: every citizen thought in **8192 tokens**.

That constant was never meant to survive; its doc said *"the conservative PRIOR … used until live per-persona working-set telemetry refines it UP toward measured demand (task #234)."* The telemetry was never built, #234 was marked done, and the placeholder became the policy.

This builds the measurement. `cognition::working_set::WorkingSetRegistry` records per turn what the turn would have cost with **no budget**: framing + the full conversation before newest-first trimming + every grounding contribution offered *including the dropped ones* + the generation reserve. `plan_serving` takes it via `ServingDemand` — a parameter, never a global read inside a decision — and caps by it instead of by 16384.

**DEMAND, not usage.** Measuring the prompt we actually send would measure the clamp: a citizen held at 8192 fills 8192, so a p95 of what-was-sent re-derives the cap that produced it and freezes it forever — a thermometer inside the thermostat. The recorded number is free to exceed the current window, and that excess is the only signal that can ever grow it.

Safety envelope unchanged: `window_for` is already ≤ the model’s trained ceiling **and** ≤ what the host fits, so `.min` still never forces up past either, and a mind demanding more than the machine has receives what fits (pinned by a test). Peak rather than average, because a working set is the size at which the activity stops being strangled.

## Also

- `messages_within` split into `messages_unfitted` + `fit_messages`, so a turn’s true conversational size is knowable at all (fitting is lossy by design).
- One shared per-message template charge, so measurement and fit cannot drift.
- Probes: `partial=` on `delib.context.render` (a shrunken block and a full one stopped looking identical), and `delib.turn.demand` whose `over_window` says plainly when a turn wanted more room than it had.
- Cold start is the one genuinely-unknown case and is named in exactly one place, `ServingDemand::new`, superseded by the first turn.

## Verification

`cargo test -p continuum-core --lib --features metal,accelerate` — full suite green; 7 new tests, each with a `// what this catches:` naming the invariant. Live validation on deploy: citizens report from their own side whether the board is there and whether it matches `work/list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo