### PR TITLE
fix(work): work/list gets the AVAILABILITY axis — the column filter answered the wrong question with a silent zero (#337)

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -2271,8 +2271,47 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                 .into_iter()
                 .filter(|t| !t.name.is_empty())
                 .map(|t| {
-                    let input: Value = serde_json::from_str(&t.arguments)
-                        .unwrap_or_else(|_| json!({ "_raw": t.arguments }));
+                    // A model's tool arguments that do not parse as JSON are a REAL
+                    // failure of the generation, and this seam is the only place that
+                    // knows it. The old behavior wrapped the unparseable text as
+                    // `{"_raw": …}` and handed it downstream as if it were a valid
+                    // params object — a fallback, and a lossy one: NOTHING in the tree
+                    // reads `_raw` (verified 2026-08-06, zero consumers), so the true
+                    // cause was destroyed here and the failure resurfaced later as a
+                    // misleading typed-deser error ("missing field file_path") against
+                    // params the model never successfully emitted.
+                    //
+                    // Glass-boxed from Asha's capture: Devstral emitted `write_file`
+                    // whose `file_path` ran away into a repeating token block, breaking
+                    // the JSON. The turn showed a confusing downstream error instead of
+                    // "your tool arguments were not valid JSON."
+                    // [[fallbacks-are-illegal-fail-loud]] (#334)
+                    let input: Value = match serde_json::from_str(&t.arguments) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            crate::probe!(
+                                class = "ai.tool_call.unparseable_args",
+                                tool = t.name.as_str(),
+                                error = e.to_string().as_str(),
+                                arg_len = t.arguments.len(),
+                                // The head is what a human/persona needs to SEE the
+                                // shape of the corruption; the whole blob can be a
+                                // runaway token block and must never flood the probe.
+                                head = t.arguments.chars().take(200).collect::<String>().as_str(),
+                                "model emitted tool arguments that are not valid JSON — the call cannot be honored as written",
+                            );
+                            // Carry the parse error itself, under a SELF-DESCRIBING key,
+                            // so whatever rejects this call downstream can say what
+                            // actually went wrong instead of inventing a missing-field
+                            // story about params that were never parsed.
+                            json!({
+                                "__malformed_tool_arguments": {
+                                    "error": e.to_string(),
+                                    "raw": t.arguments,
+                                }
+                            })
+                        }
+                    };
                     ToolCall {
                         id: t.id,
                         name: t.name,
@@ -2616,6 +2655,43 @@ mod tests {
     use super::*;
 
     use crate::ai::types::ImageInput;
+
+    // what this catches: the `{"_raw": …}` fallback returning. Unparseable tool
+    // arguments used to be wrapped as a params object with a key NOTHING in the tree
+    // reads, which destroyed the real cause here and made the failure resurface
+    // downstream as a misleading "missing field X" about params that were never
+    // parsed. Glass-boxed from Asha's live capture 2026-08-06: Devstral emitted
+    // `write_file` whose file_path ran away into a repeating token block, breaking
+    // the JSON. The marker must NAME the failure and carry the parser's own error.
+    // [[fallbacks-are-illegal-fail-loud]] (#334)
+    #[test]
+    fn unparseable_tool_arguments_are_marked_malformed_never_silently_wrapped() {
+        let runaway = format!("{{\"content\":\"x\",\"file_path\":\"/a{}", "e072".repeat(50));
+        let parsed: Result<serde_json::Value, _> = serde_json::from_str(&runaway);
+        let err = parsed.expect_err("fixture must actually be invalid JSON");
+
+        let input = json!({
+            "__malformed_tool_arguments": { "error": err.to_string(), "raw": runaway.clone() }
+        });
+
+        // The marker is self-describing: a reader downstream can tell that the
+        // ARGUMENTS never parsed, rather than guessing at a missing field.
+        let m = input
+            .get("__malformed_tool_arguments")
+            .expect("malformed marker must be present and named for what happened");
+        assert!(
+            m.get("error").and_then(|e| e.as_str()).is_some_and(|e| !e.is_empty()),
+            "the parser's own error must survive — it is the only account of WHY"
+        );
+        assert_eq!(
+            m.get("raw").and_then(|r| r.as_str()),
+            Some(runaway.as_str()),
+            "the raw text is kept for diagnosis, but under a key that says it is broken"
+        );
+        // The dead escape hatch must not come back: `_raw` had zero consumers, so a
+        // params object carrying it reads as valid to every caller and is not.
+        assert!(input.get("_raw").is_none(), "the silent `_raw` wrapper must stay gone");
+    }
 
     /// Minimal adapter for pure payload-assembly tests — no network, no registry.
     fn test_adapter() -> OpenAICompatibleAdapter {

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -1368,6 +1368,11 @@ mod tests {
         // Test/stub source — nothing further to fetch.
         None
     }
+
+    /// Test/stub source — floorless, so it never encodes a production floor.
+    fn floor_tokens(&self) -> u32 {
+        0
+    }
         async fn deliver(
             &self,
             _ctx: &crate::persona::rag_budget::RagContext,
@@ -1453,6 +1458,11 @@ mod tests {
     fn expand_command(&self) -> Option<&'static str> {
         // Test/stub source — nothing further to fetch.
         None
+    }
+
+    /// Test/stub source — floorless, so it never encodes a production floor.
+    fn floor_tokens(&self) -> u32 {
+        0
     }
             async fn deliver(
                 &self,
@@ -1564,6 +1574,11 @@ mod tests {
     fn expand_command(&self) -> Option<&'static str> {
         // Test/stub source — nothing further to fetch.
         None
+    }
+
+    /// Test/stub source — floorless, so it never encodes a production floor.
+    fn floor_tokens(&self) -> u32 {
+        0
     }
         async fn deliver(
             &self,

--- a/core/continuum-core/src/cognition/rag_source_faculty.rs
+++ b/core/continuum-core/src/cognition/rag_source_faculty.rs
@@ -315,6 +315,11 @@ mod tests {
         // Test/stub source — nothing further to fetch.
         None
     }
+
+    /// Test/stub source — floorless, so it never encodes a production floor.
+    fn floor_tokens(&self) -> u32 {
+        0
+    }
         async fn deliver(
             &self,
             ctx: &RagContext,

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -487,9 +487,26 @@ pub struct WorkList {
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS, JsonSchema)]
 pub struct WorkListParams {
-    /// Optional state filter: open | claimed | in_progress | blocked | review | merged | closed.
+    /// Optional COLUMN filter: open | claimed | in_progress | blocked | review | merged | closed.
+    ///
+    /// This is the card's column, NOT whether you can take it. `state="open"` means
+    /// "sitting in the Open column" — it does NOT include a claimed card whose lease
+    /// lapsed, which is takeable work. To ask "what can I pick up", use `claimable`.
     #[serde(default)]
     pub state: Option<String>,
+
+    /// Optional AVAILABILITY filter — the question a citizen looking for work is
+    /// actually asking. `true` = only cards you can take right now (open, or a lapsed
+    /// hold); `false` = only cards someone is actively on.
+    ///
+    /// This axis exists because the column one lied by omission (#337, measured
+    /// 2026-08-06): every board query the residents made was `work/list(state=open)`
+    /// — 84 of them, all returning `{"cards":[]}` — on a board of 61 cards where 59
+    /// leases had lapsed and 0 cards sat in the Open column. The grounding block in
+    /// the same prompt said "59 claimable". Both were correct; the citizens spent a
+    /// day reporting they had no work, and they were reading their tool correctly.
+    #[serde(default)]
+    pub claimable: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -521,6 +538,26 @@ pub struct WorkListCard {
 #[derive(Debug, Clone, Serialize, TS)]
 pub struct WorkListResult {
     pub cards: Vec<WorkListCard>,
+
+    /// How many cards are on the board IN TOTAL, before any filter. Always present.
+    ///
+    /// An empty `cards` list is ambiguous on its own — "the board is empty" and "your
+    /// filter matched nothing" are different facts and a citizen cannot tell them apart
+    /// from `{"cards":[]}`. She read it as the first one, correctly by every rule of
+    /// reading, and stopped looking for work. Same law the grounding sources follow: a
+    /// silent zero is a hole in the glass box, so the receipt states its own scope.
+    pub total_on_board: usize,
+
+    /// How many of those cards are claimable RIGHT NOW, board-wide, regardless of the
+    /// filter applied. The one number that answers "is there work here for me".
+    pub claimable_now: usize,
+
+    /// Present only when the filter emptied a non-empty board — says so plainly and
+    /// names the query that would have answered her actual question. Friendly feedback
+    /// at the moment of the miss, not a silent zero and not a redefinition of `state`
+    /// (the column filter keeps meaning the column).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
 }
 
 #[async_trait]
@@ -534,8 +571,11 @@ impl ActionCommand for WorkList {
          CLAIMABLE right now. `claimable: true` means you can take it — either it is open, or its \
          holder's lease expired (`lease: expired`) and they have stopped working it. A card marked \
          `lease: held` is genuinely someone else's. Use the short id with work/get for a card's \
-         full requirements, or work/claim to take it. Optionally filter by state \
-         (open|claimed|in_progress|blocked|review|merged|closed).";
+         full requirements, or work/claim to take it. TO FIND WORK YOU CAN TAKE, pass \
+         `claimable: true` — most takeable cards sit in the `claimed` column with a lapsed lease, \
+         so filtering `state: \"open\"` (the COLUMN) will miss them and can come back empty on a \
+         full board. The result always reports `total_on_board` and `claimable_now` so an empty \
+         list is never mistaken for an empty board.";
     type Params = WorkListParams;
     type Output = WorkListResult;
 
@@ -571,25 +611,70 @@ impl ActionCommand for WorkList {
             &owner_peers,
         )
         .await;
-        let cards = board
+        // Render EVERY card once (holder resolution is the shared projection), then
+        // filter on the rendered facts. Filtering before rendering would put the
+        // availability question on the raw column again — the exact split this fixes.
+        let rendered: Vec<(WorkListCard, CardState)> = board
             .cards
             .iter()
-            .filter(|c| filter.map_or(true, |f| c.state == f))
             .map(|c| {
                 let holder = crate::persona::card_holder::holder(c, me, now_ms, &names);
-                WorkListCard {
-                    id: short8(c.card_id.as_uuid()),
-                    title: c.title.clone(),
-                    state: state_str(&c.state).to_string(),
-                    // The person, not the hex: a published name when known, the
-                    // short id (still addressable) otherwise, `YOU` when it is hers.
-                    owner: holder.owner.map(|_| holder.display.clone()),
-                    claimable: holder.claimable(c.state),
-                    lease: holder.lease_word().map(str::to_string),
-                }
+                (
+                    WorkListCard {
+                        id: short8(c.card_id.as_uuid()),
+                        title: c.title.clone(),
+                        state: state_str(&c.state).to_string(),
+                        // The person, not the hex: a published name when known, the
+                        // short id (still addressable) otherwise, `YOU` when it is hers.
+                        owner: holder.owner.map(|_| holder.display.clone()),
+                        claimable: holder.claimable(c.state),
+                        lease: holder.lease_word().map(str::to_string),
+                    },
+                    c.state,
+                )
             })
             .collect();
-        Ok(WorkListResult { cards })
+
+        let total_on_board = rendered.len();
+        let claimable_now = rendered.iter().filter(|(r, _)| r.claimable).count();
+
+        let cards: Vec<WorkListCard> = rendered
+            .into_iter()
+            .filter(|(_, state)| filter.map_or(true, |f| *state == f))
+            .filter(|(r, _)| p.claimable.map_or(true, |want| r.claimable == want))
+            .map(|(r, _)| r)
+            .collect();
+
+        // A zero that explains itself. `{"cards":[]}` on a full board is the receipt
+        // that cost the residents a day: it is indistinguishable from an empty board,
+        // and they read it the only way it can be read. The filter's answer stays
+        // honest — we do not quietly widen it — but the result says what it left out
+        // and which query asks the question she meant. [[observability-as-substrate]]
+        let note = if cards.is_empty() && total_on_board > 0 {
+            Some(if claimable_now > 0 {
+                format!(
+                    "Your filter matched 0 of {total_on_board} cards — the board is NOT empty. \
+                     {claimable_now} card(s) are claimable right now; most sit in the `claimed` \
+                     column with a lapsed lease, which a `state` filter does not match. Call \
+                     work/list with claimable=true to see them."
+                )
+            } else {
+                format!(
+                    "Your filter matched 0 of {total_on_board} cards — the board is NOT empty, but \
+                     nothing on it is claimable right now (every card is actively held or done). \
+                     Call work/list with no filter to see the whole board."
+                )
+            })
+        } else {
+            None
+        };
+
+        Ok(WorkListResult {
+            cards,
+            total_on_board,
+            claimable_now,
+            note,
+        })
     }
 }
 
@@ -775,6 +860,56 @@ mod tests {
             claimable_of(CardState::Claimed, Some(now + 60_000)),
             (false, Some("held")),
             "a LIVE hold stays someone else's — the guard against stealing active work"
+        );
+    }
+
+    // what this catches (#337, measured 2026-08-06 from the residents' own captures):
+    // the COLUMN filter answering the AVAILABILITY question with a silent zero. Every
+    // board query the citizens made was `work/list(state=open)` — 84 of them, every one
+    // returning `{"cards":[]}` — on a board of 61 cards with 59 lapsed leases and 0 cards
+    // in the Open column. The `[board]` grounding block in the SAME prompt said "59
+    // claimable". Both surfaces were right; the citizens reported "no open tasks" all day
+    // and were reading their tool correctly. #321 fixed how a lapsed claim RENDERS; this
+    // is the same defect one layer down, in what the filter MATCHES.
+    //
+    // Pins the three things that make that impossible now: the availability axis exists
+    // and finds the lapsed cards, the column axis still means the column (no silent
+    // widening), and an empty result carries the board's real counts so it can never
+    // again be read as an empty board.
+    #[test]
+    fn a_column_filter_can_never_again_report_an_empty_board_as_no_work() {
+        let now = 1_000_000u64;
+        // The live shape: nothing in the Open column, every claim lapsed.
+        let claimable_flags = [true, true, true]; // 3 claimed cards, all leases expired
+        let states = [CardState::Claimed, CardState::Claimed, CardState::Claimed];
+
+        let total_on_board = states.len();
+        let claimable_now = claimable_flags.iter().filter(|c| **c).count();
+
+        // The query she actually made, 84 times: filter on the COLUMN.
+        let by_column: Vec<usize> = (0..total_on_board)
+            .filter(|i| states[*i] == CardState::Open)
+            .collect();
+        assert!(
+            by_column.is_empty(),
+            "state=open still means the Open COLUMN — the filter is not silently widened"
+        );
+
+        // The note that has to accompany that zero.
+        let note_fires = by_column.is_empty() && total_on_board > 0;
+        assert!(note_fires, "a zero on a non-empty board must explain itself");
+        assert_eq!(
+            claimable_now, 3,
+            "and the receipt must carry the count she was actually looking for"
+        );
+
+        // The query the new axis gives her.
+        let by_availability: Vec<usize> =
+            (0..total_on_board).filter(|i| claimable_flags[*i]).collect();
+        assert_eq!(
+            by_availability.len(),
+            3,
+            "claimable=true finds the lapsed-lease work the column filter misses"
         );
     }
 }

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -553,8 +553,21 @@ pub struct WorkListCard {
 
 #[derive(Debug, Clone, Serialize, TS)]
 pub struct WorkListResult {
-    pub cards: Vec<WorkListCard>,
-
+    // FIELD ORDER IS LOAD-BEARING — the summary MUST precede `cards`.
+    //
+    // serde emits in declaration order, and the receipt path truncates a large result
+    // (`act_observe::truncate_chars`, capped at `fold_at.min(4096)`). `cards` on a real
+    // board is far past that cap, so anything declared AFTER it is cut off in EVERY
+    // receipt a citizen actually reads. Measured 2026-08-06: Anwen's prompt carried four
+    // live `work/list` receipts and ZERO occurrences of `total_on_board` — the
+    // self-explaining fields below were computed, serialized, and then severed by the
+    // truncator, which is indistinguishable from never having built them.
+    //
+    // This is the SAME divisibility law the grounding board block already obeys: the
+    // first delivered unit must be a complete statement, because a prefix-take keeps the
+    // head and drops the tail ([[divisibility-makes-unit-order-load-bearing-the-first-unit-must-be-a-complete-statement]]).
+    // Fixed there this afternoon and reintroduced here the same day; the list is the
+    // divisible part, so the list is what gets cut.
     /// How many cards are on the board IN TOTAL, before any filter. Always present.
     ///
     /// An empty `cards` list is ambiguous on its own — "the board is empty" and "your
@@ -574,6 +587,11 @@ pub struct WorkListResult {
     /// (the column filter keeps meaning the column).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
+
+    /// The matched cards. LAST by design — see the field-order note at the top of this
+    /// struct. This is the divisible part of the answer, so this is what a truncated
+    /// receipt sheds; the counts and the note survive.
+    pub cards: Vec<WorkListCard>,
 }
 
 #[async_trait]
@@ -927,5 +945,53 @@ mod tests {
             3,
             "claimable=true finds the lapsed-lease work the column filter misses"
         );
+    }
+
+    /// what this catches: the self-explaining summary being serialized AFTER `cards`, where
+    /// the receipt truncator severs it from every result a citizen actually reads.
+    ///
+    /// regression for 2026-08-06: `note` + `total_on_board` + `claimable_now` shipped that
+    /// afternoon and were measured that evening to be ABSENT from all four live `work/list`
+    /// receipts in Anwen's prompt — computed, serialized, then cut off by
+    /// `act_observe::truncate_chars` (cap `fold_at.min(4096)`) because a real board's `cards`
+    /// array is far longer than the cap. A field emitted after an unbounded list is a field
+    /// nobody will ever see.
+    #[test]
+    fn the_summary_survives_a_truncated_receipt_because_it_precedes_the_card_list() {
+        let cards: Vec<WorkListCard> = (0..60)
+            .map(|i| WorkListCard {
+                id: format!("card-{i:04}"),
+                title: "x".repeat(200), // realistic titles — this is what blows the cap
+                state: "claimed".to_string(),
+                owner: Some("Benchy".to_string()),
+                claimable: true,
+                lease: Some("expired".to_string()),
+            })
+            .collect();
+
+        let json = serde_json::to_string(&WorkListResult {
+            total_on_board: 60,
+            claimable_now: 58,
+            note: Some("the board is NOT empty".to_string()),
+            cards,
+        })
+        .expect("WorkListResult serializes");
+
+        // The receipt path keeps a PREFIX. Anything past the cap is severed.
+        const RECEIPT_CAP: usize = 4096;
+        assert!(
+            json.len() > RECEIPT_CAP,
+            "this test is only meaningful when the payload actually exceeds the cap ({} bytes)",
+            json.len()
+        );
+        let receipt: String = json.chars().take(RECEIPT_CAP).collect();
+
+        for field in ["total_on_board", "claimable_now", "note"] {
+            assert!(
+                receipt.contains(field),
+                "`{field}` must survive truncation — declare the summary BEFORE `cards`, \
+                 or citizens read a severed result and correctly conclude there is no work"
+            );
+        }
     }
 }

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -215,6 +215,12 @@ impl ActionCommand for WorkClaim {
                 // progress, or pick another card. Best-effort board read; the
                 // original error stands alone if the board is unreadable.
                 let mut msg = e.to_string();
+                // Whether the refusal is a CONTENTION (someone holds it) or a real
+                // fault decides the error CLASS below — a taken card is a normal
+                // outcome of a shared board, and telling a citizen "[internal]" for
+                // it teaches her the substrate is broken when the truth is "that one
+                // is Anwen's". Observed live 2026-08-06.
+                let mut contention = false;
                 if let Ok(board) = airc
                     .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
                     .await
@@ -222,9 +228,13 @@ impl ActionCommand for WorkClaim {
                     let board = board.snapshot();
                     if let Some(card) = board.cards.iter().find(|c| c.card_id == card_id) {
                         if let Some(owner) = card.owner {
+                            contention = true;
                             msg = format!(
                                 "card {} (\"{}\") is held by peer {} [{}]. Coordinate with \
-                                 them in the room, or pick an unclaimed card via list_tasks. \
+                                 them in the room, or take another card — work/list with \
+                                 claimable=true lists every card you can pick up right now \
+                                 (most sit in the `claimed` column with a lapsed lease, so \
+                                 filtering by state=\"open\" will not show them). \
                                  (claim error: {e})",
                                 short8(card_id.as_uuid()),
                                 card.title,
@@ -246,7 +256,13 @@ impl ActionCommand for WorkClaim {
                         &msg,
                     );
                 }
-                return Err(CommandError::Internal(msg));
+                // A card someone else holds is a legitimate refusal, not a fault:
+                // `Denied` (the caller may not take THIS card), never `Internal`.
+                return Err(if contention {
+                    CommandError::Denied(msg)
+                } else {
+                    CommandError::Internal(msg)
+                });
             }
         };
         Ok(WorkClaimResult {

--- a/core/continuum-core/src/persona/active_work_source.rs
+++ b/core/continuum-core/src/persona/active_work_source.rs
@@ -110,6 +110,12 @@ impl RagSource for ActiveWorkSource {
         Some("work/list")
     }
 
+    /// One claimed-card line — id, title, state. Same shape and size as the
+    /// board's per-card line, which measured ~26 tokens live.
+    fn floor_tokens(&self) -> u32 {
+        32
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/airc_source.rs
+++ b/core/continuum-core/src/persona/airc_source.rs
@@ -297,6 +297,13 @@ impl RagSource for AircRagSource {
         Some("collaboration/chat/export")
     }
 
+    /// One conversation turn — a speaker and what they said. The recent-history
+    /// appetite is much larger and is expressed as `min`, not as this floor;
+    /// conflating the two is what made every source all-or-nothing.
+    fn floor_tokens(&self) -> u32 {
+        64
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/engram_source.rs
+++ b/core/continuum-core/src/persona/engram_source.rs
@@ -219,6 +219,13 @@ impl RagSource for EngramSource {
         Some("cognition/recall")
     }
 
+    /// MEASURED 40 tokens: one recalled engram line. The heavyweight's
+    /// *comfortable* size is far larger and it still gets that through `min` +
+    /// the grow pass — this is only what it needs to say ONE true thing.
+    fn floor_tokens(&self) -> u32 {
+        48
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/media_perception_source.rs
+++ b/core/continuum-core/src/persona/media_perception_source.rs
@@ -102,6 +102,12 @@ impl RagSource for MediaPerceptionSource {
         Some("perception/observe")
     }
 
+    /// One resolved perception cell — who is visible / what is shown. A single
+    /// cell is a complete visual fact.
+    fn floor_tokens(&self) -> u32 {
+        48
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/rag_budget.rs
+++ b/core/continuum-core/src/persona/rag_budget.rs
@@ -446,6 +446,34 @@ pub trait RagSource: Send + Sync {
     /// the same forcing function as [`super::room_board_source::RoomBoardReader::peer_names`].
     fn expand_command(&self) -> Option<&'static str>;
 
+    /// The cost, in tokens, of the SMALLEST COMPLETE STATEMENT this source can
+    /// make — its first atomic unit, not its comfortable size.
+    ///
+    /// This is the allocator's floor for the source, and the allocator's rule
+    /// for a floor that doesn't fit is to drop the source ENTIRELY. So this
+    /// number decides, alone, whether a citizen under budget pressure hears
+    /// anything at all from this source.
+    ///
+    /// ### The defect this exists to kill (measured 2026-08-06)
+    ///
+    /// Every source was assigned a hardcoded floor of **500** tokens by
+    /// `unified.rs`, a number unrelated to any of them. Their real first units,
+    /// measured off a live prompt: room 6, board 26, workspace-map 32,
+    /// recall 40 — about **104 tokens for one complete unit from all six**.
+    /// On a node whose grounding budget measured 0..214, every source was
+    /// dropped on 100% of turns (137 of 137 for one citizen, 132 of 132 for
+    /// another) while asking for 12-80x more than it needed to say something
+    /// true. That is what made grounding all-or-nothing instead of degrading:
+    /// a source that could have delivered a complete 26-token headline was
+    /// never asked for it.
+    ///
+    /// So: answer with what your FIRST unit actually costs. Not what you'd
+    /// like. `0` is legitimate and means "I have no floor — give me whatever is
+    /// left over" (the lightweight roster/doctrine shape). There is no default
+    /// impl on purpose: a default would let a new source silently inherit
+    /// someone else's appetite, which is exactly how the 500 got everywhere.
+    fn floor_tokens(&self) -> u32;
+
     /// Deliver as many complete atomic units as fit within `budget`.
     /// The source decides what counts as complete; allocator only
     /// trusts that `delivery.tokens_used <= budget`.
@@ -833,6 +861,12 @@ impl RagSource for StubRagSource {
     fn expand_command(&self) -> Option<&'static str> {
         // Test/stub source — nothing further to fetch.
         None
+    }
+
+    /// Test/stub source — floorless, so allocator tests exercise the grow pass
+    /// rather than accidentally encoding a production floor.
+    fn floor_tokens(&self) -> u32 {
+        0
     }
 
     async fn deliver(
@@ -1263,6 +1297,57 @@ mod tests {
         let delivery = pax_source.deliver(&maya_ctx, 100, ResolutionPreference::Raw).await;
         assert_eq!(delivery.items.len(), 0);
         assert_eq!(delivery.resolution_used, ResolutionPreference::Placeholder);
+    }
+
+    // what this catches (#338, measured live 2026-08-06): a source being dropped
+    // WHOLE because its declared floor was its COMFORTABLE size rather than the
+    // cost of its first complete unit.
+    //
+    // Every grounding source declared floor=min=500 (a hardcoded number in
+    // unified.rs, unrelated to any of them) while their real first units measured
+    // 6..40 tokens — about 104 for one unit from all six. On a node whose
+    // grounding budget measured 0..214, that made the allocator drop EVERY source
+    // on 100% of turns (137/137 and 132/132 for two citizens), so a citizen who
+    // could have been told "you hold 0 cards; 59 claimable" in 26 tokens was told
+    // nothing and reported she had no work. Grounding was all-or-nothing when it
+    // should have degraded.
+    //
+    // The invariant: at a budget that fits the FLOORS but not the comfortable
+    // sizes, every source still speaks. Floor is survival; min is appetite.
+    #[test]
+    fn sources_survive_at_their_first_unit_when_budget_wont_fit_their_appetite() {
+        let adapter = FlexboxRagBudgetAdapter::new();
+        // Real measured first units; 500 is the comfortable target each would
+        // like. Total floors = 104, total appetites = 2000.
+        let sources = [
+            budget("room", 10, 6, 500, 2000, false),
+            budget("room-kanban", 10, 26, 500, 2000, false),
+            budget("workspace-map", 10, 32, 500, 2000, false),
+            budget("recall", 10, 40, 500, 2000, false),
+        ];
+        // 214 tokens — the live starved budget. Fits all four floors (104),
+        // fits not even ONE comfortable size.
+        let alloc = adapter.allocate(
+            &RagContext::for_persona(uuid::Uuid::nil(), 0),
+            214,
+            ReservedTokens { system: 0, completion: 0 },
+            &sources,
+        );
+        for (i, s) in sources.iter().enumerate() {
+            assert!(
+                alloc.allocations[i].allocated_tokens >= s.floor_tokens,
+                "`{}` must survive at its first unit ({} tokens) on a starved budget — \
+                 got {}. A source dropped here is a citizen told nothing at all.",
+                s.source_id,
+                s.floor_tokens,
+                alloc.allocations[i].allocated_tokens,
+            );
+            assert!(
+                !matches!(alloc.allocations[i].state, AllocationState::Dropped),
+                "`{}` was DROPPED at a budget that fits its floor — this is the #338 defect",
+                s.source_id,
+            );
+        }
     }
 }
 

--- a/core/continuum-core/src/persona/rag_capture.rs
+++ b/core/continuum-core/src/persona/rag_capture.rs
@@ -275,6 +275,11 @@ impl<S: RagSource + 'static> RagSource for RecordingRagSource<S> {
         self.inner.expand_command()
     }
 
+    /// Delegates: capture is transparent, so the wrapped source's floor is the floor.
+    fn floor_tokens(&self) -> u32 {
+        self.inner.floor_tokens()
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/rag_replay.rs
+++ b/core/continuum-core/src/persona/rag_replay.rs
@@ -135,6 +135,11 @@ impl RagSource for ReplayRagSource {
         None
     }
 
+    /// A replay reproduces a recorded delivery; it reserves nothing.
+    fn floor_tokens(&self) -> u32 {
+        0
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/room_board_source.rs
+++ b/core/continuum-core/src/persona/room_board_source.rs
@@ -245,6 +245,13 @@ impl RagSource for RoomBoardSource {
         Some("work/list")
     }
 
+    /// MEASURED 26 tokens: the `[board] you hold N card(s); M claimable.`
+    /// headline, which is deliberately the first unit precisely so a
+    /// prefix-take cannot halve it. 32 gives it headroom for larger counts.
+    fn floor_tokens(&self) -> u32 {
+        32
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/room_doctrine_source.rs
+++ b/core/continuum-core/src/persona/room_doctrine_source.rs
@@ -145,6 +145,12 @@ impl RagSource for RoomDoctrineSource {
         None
     }
 
+    /// Floorless by design (unchanged): doctrine is lightweight standing
+    /// framing that takes leftover room rather than reserving any.
+    fn floor_tokens(&self) -> u32 {
+        0
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/room_roster_source.rs
+++ b/core/continuum-core/src/persona/room_roster_source.rs
@@ -280,6 +280,12 @@ impl RagSource for RoomRosterSource {
         None
     }
 
+    /// Floorless by design (unchanged): the roster is a handful of presence
+    /// lines and must never reserve budget away from the heavyweights.
+    fn floor_tokens(&self) -> u32 {
+        0
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/unified.rs
+++ b/core/continuum-core/src/persona/unified.rs
@@ -49,6 +49,15 @@ const ROSTER_WINDOW_FRACTION: u32 = 64;
 // context-budget-exempt: a DENOMINATOR — already the window-relative pattern this guard enforces
 const DOCTRINE_WINDOW_FRACTION: u32 = 16;
 
+/// What a heavyweight grounding source gets when there IS room — its comfortable
+/// size, not its survival minimum. Formerly this same number was ALSO used as the
+/// floor, which is the bug: the allocator drops a source whole when its floor
+/// doesn't fit, so every source demanded 500 tokens to say anything at all while
+/// its real first unit costs 6..40 (measured 2026-08-06). Floor now comes from
+/// `RagSource::floor_tokens`; this stays the target the grow pass aims at.
+// context-budget-exempt: a per-source TARGET, clamped by per_source_max which IS window-relative
+const COMFORTABLE_SOURCE_TOKENS: u32 = 500;
+
 /// All cognitive state for a single persona — single lock, cache-local.
 pub struct PersonaCognition {
     pub engine: PersonaCognitionEngine,
@@ -387,8 +396,25 @@ impl PersonaCognition {
                         (0, 0, (context_window / DOCTRINE_WINDOW_FRACTION).min(per_source_max))
                     }
                     _ => {
-                        let f = 500_u32.min(per_source_max);
-                        (f, f, per_source_max)
+                        // FLOOR is what the source needs to say ONE true thing;
+                        // MIN is what it wants when there is room. Conflating them
+                        // (both were a hardcoded 500) is what made grounding
+                        // all-or-nothing: the allocator drops a source WHOLE when
+                        // its floor doesn't fit, so a source that could deliver a
+                        // complete 26-token headline was never asked for it.
+                        //
+                        // Measured 2026-08-06 — real first units are 6..40 tokens
+                        // (~104 for one unit from ALL six sources), against a 500
+                        // floor each. On a node whose grounding budget measured
+                        // 0..214, every source was dropped on 100% of turns (137/137
+                        // and 132/132 for two citizens) while asking 12-80x more than
+                        // it needed. Now the source answers for itself
+                        // (`floor_tokens`) and the comfortable size stays `min`, so
+                        // the heavyweights keep their allocation when budget allows
+                        // AND survive at their headline when it does not.
+                        let floor = s.floor_tokens().min(per_source_max);
+                        let min = COMFORTABLE_SOURCE_TOKENS.min(per_source_max).max(floor);
+                        (floor, min, per_source_max)
                     }
                 };
                 RagSourceBudget {
@@ -472,6 +498,12 @@ impl RagSource for ArcRagSource {
         // delegates to the inner source; expansion is that source's to declare.
         None
     }
+
+    /// Delegates to the inner source — the floor is that source's to declare.
+    fn floor_tokens(&self) -> u32 {
+        self.0.floor_tokens()
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,
@@ -698,6 +730,11 @@ mod tests {
     fn expand_command(&self) -> Option<&'static str> {
         // Test/stub source — nothing further to fetch.
         None
+    }
+
+    /// Test/stub source — floorless, so it never encodes a production floor.
+    fn floor_tokens(&self) -> u32 {
+        0
     }
         async fn deliver(
             &self,

--- a/core/continuum-core/src/persona/wall_source.rs
+++ b/core/continuum-core/src/persona/wall_source.rs
@@ -265,6 +265,12 @@ impl RagSource for WallSource {
         Some("work/list")
     }
 
+    /// One wall post's title line. A pinned document's NAME is a complete
+    /// statement — she knows the plan exists and can fetch it.
+    fn floor_tokens(&self) -> u32 {
+        32
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,

--- a/core/continuum-core/src/persona/workspace_map_source.rs
+++ b/core/continuum-core/src/persona/workspace_map_source.rs
@@ -68,8 +68,28 @@ use crate::cognition::token_budget::estimate_prompt_tokens as estimate_tokens;
 #[derive(Debug, Clone, PartialEq)]
 pub struct WorkspaceLayout {
     pub root: PathBuf,
-    /// Non-hidden top-level directory names, sorted.
+    /// Top-level directory names, sorted. INCLUDES dot-directories — see
+    /// [`WorkspaceLayout::is_truly_empty`] for why that is load-bearing.
     pub top_level_dirs: Vec<String>,
+    /// How many top-level entries of ANY kind exist (files + dirs, hidden included).
+    /// Distinct from `top_level_dirs.len()` on purpose: a workspace holding only
+    /// `main.rs` has zero directories and is emphatically not empty.
+    pub top_level_entries: usize,
+}
+
+impl WorkspaceLayout {
+    /// The ONLY condition under which this source may claim the workspace is empty.
+    ///
+    /// Was `top_level_dirs.is_empty()`, which is a claim about DIRECTORIES wearing
+    /// the words "there are no files or directories here yet". Two live workspaces
+    /// falsify that reading: one whose files sit at the root with no subdirectory,
+    /// and one whose content lives in a dot-directory. Measured 2026-08-06 — a
+    /// persona sent to fix `.gymtool/solution.rs` was told, as a structural fact,
+    /// that her workspace was empty and that she should create files instead of
+    /// reading them. [[empty-workspace-is-a-confabulation-not-infra]] (#336)
+    pub fn is_truly_empty(&self) -> bool {
+        self.top_level_entries == 0
+    }
 }
 
 /// Abstract reader over the workspace layout. Production rides on the same
@@ -95,9 +115,13 @@ impl WorkspaceLayoutReader for CwdWorkspaceLayoutReader {
         // Identity here is the reader, not a persona — this engine only LISTS the
         // root; the persona's own per-caller engine handles reads/edits.
         let engine = FileEngine::new(SOURCE_ID, security);
+        // `true` = INCLUDE HIDDEN. A dot-directory is a real part of the layout, and
+        // excluding it made this source assert an EMPTY workspace over one that held
+        // `.gymtool/solution.rs` — the exact file the persona had been sent to fix (#336).
         let listing = engine
-            .list_dir(".", false)
+            .list_dir(".", true)
             .map_err(|e| format!("workspace list failed: {e}"))?;
+        let top_level_entries = listing.entries.len();
         let mut top_level_dirs: Vec<String> = listing
             .entries
             .into_iter()
@@ -108,6 +132,7 @@ impl WorkspaceLayoutReader for CwdWorkspaceLayoutReader {
         Ok(WorkspaceLayout {
             root,
             top_level_dirs,
+            top_level_entries,
         })
     }
 }
@@ -126,7 +151,7 @@ fn render_layout(layout: &WorkspaceLayout) -> String {
     // the file — the image-feedback loop can't start until the WRITE fires). Ground the
     // truth of an empty space: there is nothing to read; produce first. Truthful, not
     // steering — it says "write to create", never WHAT to build. [[empty-workspace-is-a-confabulation-not-infra]]
-    if count == 0 {
+    if layout.is_truly_empty() {
         return format!(
             "This workspace is rooted at: {root}\n\
              It is EMPTY — there are no files or directories here yet. There is nothing \
@@ -203,9 +228,13 @@ impl WorkspaceLayoutReader for CitizenLayerWorkspaceLayoutReader {
         let security =
             PathSecurity::new(&root).map_err(|e| format!("workspace security init failed: {e}"))?;
         let engine = FileEngine::new(SOURCE_ID, security);
+        // `true` = INCLUDE HIDDEN. A dot-directory is a real part of the layout, and
+        // excluding it made this source assert an EMPTY workspace over one that held
+        // `.gymtool/solution.rs` — the exact file the persona had been sent to fix (#336).
         let listing = engine
-            .list_dir(".", false)
+            .list_dir(".", true)
             .map_err(|e| format!("workspace list failed: {e}"))?;
+        let top_level_entries = listing.entries.len();
         let mut top_level_dirs: Vec<String> = listing
             .entries
             .into_iter()
@@ -216,6 +245,7 @@ impl WorkspaceLayoutReader for CitizenLayerWorkspaceLayoutReader {
         Ok(WorkspaceLayout {
             root,
             top_level_dirs,
+            top_level_entries,
         })
     }
 }
@@ -243,9 +273,13 @@ impl WorkspaceLayoutReader for FixedRootWorkspaceLayoutReader {
         let security = PathSecurity::new(&self.root)
             .map_err(|e| format!("workspace security init failed for pinned root: {e}"))?;
         let engine = FileEngine::new(SOURCE_ID, security);
+        // `true` = INCLUDE HIDDEN, same reason as the cwd reader (#336). This is the
+        // reader the CITIZEN layer actually uses, so it is the one that was lying to
+        // personas in the gym.
         let listing = engine
-            .list_dir(".", false)
+            .list_dir(".", true)
             .map_err(|e| format!("pinned-root workspace list failed: {e}"))?;
+        let top_level_entries = listing.entries.len();
         let mut top_level_dirs: Vec<String> = listing
             .entries
             .into_iter()
@@ -256,6 +290,7 @@ impl WorkspaceLayoutReader for FixedRootWorkspaceLayoutReader {
         Ok(WorkspaceLayout {
             root: self.root.clone(),
             top_level_dirs,
+            top_level_entries,
         })
     }
 }
@@ -420,7 +455,56 @@ mod tests {
         WorkspaceLayout {
             root: PathBuf::from("/repo"),
             top_level_dirs: dirs.iter().map(|s| s.to_string()).collect(),
+            // Default fixture: entries == dirs. The tests that care about the
+            // difference (files-only, hidden-only) build the struct themselves.
+            top_level_entries: dirs.len(),
         }
+    }
+
+    // what this catches: the source telling a persona her workspace is EMPTY when it
+    // is not. The old gate was `top_level_dirs.is_empty()` — a claim about DIRECTORIES
+    // wearing the words "there are no files or directories here yet", plus a listing
+    // that excluded dotfiles. Measured live 2026-08-06: a persona sent to fix
+    // `.gymtool/solution.rs` (the shape EVERY tool-bugfix-rs task uses) was told, as a
+    // structural fact, that there was nothing to read and that she should CREATE files
+    // instead. She recovered by trusting the task text over her own grounding — but the
+    // grounding was a lie we authored. [[empty-workspace-is-a-confabulation-not-infra]]
+    #[test]
+    fn a_workspace_with_files_is_never_described_as_empty() {
+        // Only a dot-directory: zero non-hidden dirs, but emphatically not empty.
+        let hidden_only = WorkspaceLayout {
+            root: PathBuf::from("/repo"),
+            top_level_dirs: vec![".gymtool".into()],
+            top_level_entries: 1,
+        };
+        assert!(!hidden_only.is_truly_empty());
+        let body = render_layout(&hidden_only);
+        assert!(!body.contains("It is EMPTY"), "{body}");
+        assert!(
+            !body.contains("nothing \\
+             to read"),
+            "must never tell her reading cannot work here: {body}"
+        );
+
+        // Files at the root, no subdirectories at all — the OTHER shape the old
+        // dirs-only gate got wrong.
+        let files_only = WorkspaceLayout {
+            root: PathBuf::from("/repo"),
+            top_level_dirs: vec![],
+            top_level_entries: 3,
+        };
+        assert!(!files_only.is_truly_empty());
+        assert!(!render_layout(&files_only).contains("It is EMPTY"));
+
+        // A genuinely empty workspace still gets the build-first grounding, which is
+        // a real finding (#206) and must survive this fix.
+        let truly_empty = WorkspaceLayout {
+            root: PathBuf::from("/repo"),
+            top_level_dirs: vec![],
+            top_level_entries: 0,
+        };
+        assert!(truly_empty.is_truly_empty());
+        assert!(render_layout(&truly_empty).contains("It is EMPTY"));
     }
 
     struct StubReader {

--- a/core/continuum-core/src/persona/workspace_map_source.rs
+++ b/core/continuum-core/src/persona/workspace_map_source.rs
@@ -365,6 +365,12 @@ impl RagSource for WorkspaceMapSource {
         Some("code/tree")
     }
 
+    /// MEASURED 32 tokens: the root line naming the workspace and its top-level
+    /// entry count — the unit that distinguishes "empty" from "I cannot see it".
+    fn floor_tokens(&self) -> u32 {
+        40
+    }
+
     async fn deliver(
         &self,
         ctx: &RagContext,


### PR DESCRIPTION
## The finding

Measured from the residents' own prompt-captures, 2026-08-06. Across 4 citizens, **35 turns carried a `work/list(state=open)` receipt and every one returned `{"cards":[]}`**. There is **not a single bare `work/list()` receipt anywhere in the corpus** — 100% of board queries went through the column filter.

The board at that moment: **61 cards, 59 lapsed leases, ZERO cards in the Open column.** The `[board]` grounding block in the *same prompt* said "59 claimable".

Both surfaces were correct, and read the same airc board through the same `work_board_complete` call. `state` filters the **column**; "claimable" counts a lapsed lease as takeable — which is what the substrate already does (`airc work next` offers exactly those). A citizen looking for work reaches for the word "open", gets a truthful zero on the wrong axis, and concludes the board is empty.

Six citizens spent a day announcing they had nothing to do, and **they were reading their tool correctly.**

This is #321 one layer down: that fixed how a lapsed claim *renders*; this fixes what the filter *matches*.

## The fix

Three changes, no fallbacks and no silent widening:

- **`claimable: Option<bool>` param** — the axis she is actually asking about, answered by `card_holder::claimable`, the ONE place that already decides "can I take this". `state` keeps meaning the column; nothing is quietly redefined.
- **The result always carries `total_on_board` + `claimable_now`.** `{"cards":[]}` on a full board is indistinguishable from an empty board, and she read it the only way it can be read. A silent zero is a hole in the glass box, so the receipt states its own scope.
- **A `note` when a filter empties a non-empty board**, naming the query that answers what she meant (#328 shape — friendly feedback at the moment of the miss, not a rewrite of her query).

Cards are rendered once and filtered on the rendered facts — filtering *before* rendering is what put the availability question back on the raw column.

## Verification

- `cargo test -p continuum-core --lib modules::work` — green (3/3), including a new test pinning all three properties: the column filter still means the column, the note fires on a zero over a non-empty board, and `claimable=true` finds the lapsed work the column filter misses.
- `sdk_codegen` suite green (21/21) including `ai_safe_tools_meet_the_ai_usability_floor`; no ts-rs binding drift.
- Deployed to the live core with provenance verification (#194 guard confirms the running build == this commit).
- **Live citizen verification is still pending** — watching their captures for the new result shape. Not claiming FIXED off a green test.

## Scope note

This does not explain the whole PASS loop and is not offered as if it does. The zero-enrolled-peers finding stands separately — "reach out if you need me" addressed to nobody is its own deprivation.