### PR TITLE
feat(bench): N chances — failed grades re-enter the workspace with the verdict as feedback

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -128,6 +128,17 @@ pub struct AgentSolveParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub path_prepend: Option<Vec<String>>,
+    /// N CHANCES (Joel, 2026-08-08: "they too need to learn how to investigate and fix
+    /// their code"): how many graded attempts this detached run may take. After a
+    /// non-resolved auto-grade, the NEXT attempt re-enters the SAME workspace (her
+    /// previous edits intact) with the grader's verdict — named failing tests — appended
+    /// to the task, so investigating her own failure IS the work. Only meaningful on a
+    /// detached, auto-graded run; a resolved grade, an ungradeable tree, or a harness
+    /// fault ends the run early. Default 1 (one shot, exactly the old behavior) — the
+    /// per-benchmark adapter that dispatches the run owns its N, not this abstraction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
+    pub attempts: Option<u32>,
 }
 
 /// What the caller grades when the solve returns. Two genuinely different contracts,
@@ -222,26 +233,42 @@ impl ActionCommand for AgentSolve {
             .then(|| inner.workspace.clone());
             tokio::spawn(async move {
                 let path = agent_solve_ledger_path(&run_id);
-                match AgentSolve::solve_body(inner).await {
-                    Ok(r) => {
-                        if let (Some(path), Ok(json)) =
-                            (path.as_ref(), serde_json::to_string_pretty(&r))
-                        {
-                            let _ = std::fs::write(path, json);
-                        }
-                        if let Some(bus) = crate::runtime::MessageBus::global() {
-                            if let Ok(v) = serde_json::to_value(&r) {
-                                bus.publish_async_only("agent:solve:complete", v);
+                // N CHANCES: attempts loop. Each attempt is a full solve; a non-resolved
+                // auto-grade re-enters the SAME workspace with the verdict appended to the
+                // task (named failing tests — the teachable half of the grade). The loop
+                // ends on: resolved, attempts exhausted, an ungradeable tree (gate/error —
+                // a harness fault must never burn her chances), a non-graded run (nothing
+                // to iterate against), or a solve failure. Result/grade files are OVERWRITTEN
+                // per attempt — the poll surface shows the LATEST state; history lives on
+                // the `benchmark.autograde` probe (attempt field) and the capture sink.
+                let max_attempts = inner.attempts.unwrap_or(1).max(1);
+                let base_task = inner.task.clone();
+                let mut next_task = base_task.clone();
+                for attempt in 1..=max_attempts {
+                    let mut this_attempt = inner.clone();
+                    this_attempt.task = next_task.clone();
+                    match AgentSolve::solve_body(this_attempt).await {
+                        Ok(r) => {
+                            if let (Some(path), Ok(json)) =
+                                (path.as_ref(), serde_json::to_string_pretty(&r))
+                            {
+                                let _ = std::fs::write(path, json);
                             }
-                        }
-                        tracing::info!(run_id = %run_id, acts = r.acts, "agent/solve detached run complete");
-                        // The claim ran to a diff; now the diff runs to a VERDICT with
-                        // no human in the loop. Same grader as `benchmark/swe-grade`
-                        // (fresh clone, held-out tests) — its verdict path also writes
-                        // the citizen's experience stream, so solve→grade→lesson is one
-                        // unbroken chain. The verdict lands on the poll surface beside
-                        // the result (`...<run_id>.grade.json`) + the probe stream.
-                        if let Some(ws) = autograde_workspace {
+                            if let Some(bus) = crate::runtime::MessageBus::global() {
+                                if let Ok(v) = serde_json::to_value(&r) {
+                                    bus.publish_async_only("agent:solve:complete", v);
+                                }
+                            }
+                            tracing::info!(run_id = %run_id, acts = r.acts, attempt, "agent/solve detached run complete");
+                            // The claim ran to a diff; now the diff runs to a VERDICT with
+                            // no human in the loop. Same grader as `benchmark/swe-grade`
+                            // (fresh clone, held-out tests) — its verdict path also writes
+                            // the citizen's experience stream, so solve→grade→lesson is one
+                            // unbroken chain. The verdict lands on the poll surface beside
+                            // the result (`...<run_id>.grade.json`) + the probe stream.
+                            let Some(ws) = autograde_workspace.clone() else {
+                                break; // ungraded run — nothing to iterate against
+                            };
                             let instance = std::path::Path::new(&ws)
                                 .file_name()
                                 .map(|s| s.to_string_lossy().to_string())
@@ -264,6 +291,8 @@ impl ActionCommand for AgentSolve {
                                         instance = %instance,
                                         resolved = g.resolved,
                                         gate_ok = g.gate_ok,
+                                        attempt,
+                                        max_attempts,
                                         "solve completion auto-graded"
                                     );
                                     if let Some(p) = agent_solve_ledger_path(&run_id) {
@@ -272,6 +301,30 @@ impl ActionCommand for AgentSolve {
                                             let _ = std::fs::write(gp, j);
                                         }
                                     }
+                                    if g.resolved || !g.gate_ok || g.error.is_some() {
+                                        break;
+                                    }
+                                    if attempt == max_attempts {
+                                        break;
+                                    }
+                                    // The next chance carries the verdict — what a human
+                                    // reviewer would hand back. Built from the BASE task
+                                    // each round so feedback never stacks into a scroll.
+                                    let failing = if g.failed_tests.is_empty() {
+                                        String::new()
+                                    } else {
+                                        format!(" Failing tests: {}.", g.failed_tests.join(", "))
+                                    };
+                                    next_task = format!(
+                                        "{base_task}\n\n[grader verdict — attempt {attempt} of {max_attempts} did not resolve] \
+                                         FAIL_TO_PASS {}/{}, PASS_TO_PASS {}/{}.{failing} \
+                                         Your previous edits are still in this workspace. Investigate why these \
+                                         tests fail — run them — then fix in place without breaking what passes.",
+                                        g.fail_to_pass_passed,
+                                        g.fail_to_pass_total,
+                                        g.pass_to_pass_passed,
+                                        g.pass_to_pass_total,
+                                    );
                                 }
                                 Err(e) => {
                                     // A failed GRADE is not a failed solve — surface it
@@ -281,23 +334,26 @@ impl ActionCommand for AgentSolve {
                                         run_id = %run_id,
                                         instance = %instance,
                                         error = %e.to_string(),
+                                        attempt,
                                         "auto-grade FAILED — solve result stands, verdict missing"
                                     );
+                                    break;
                                 }
                             }
                         }
-                    }
-                    Err(e) => {
-                        // Fail LOUD on the poll surface too — a detached run that dies must leave a
-                        // diagnosable marker, never an empty file forever.
-                        if let Some(path) = path {
-                            let _ = std::fs::write(
-                                &path,
-                                serde_json::json!({"failed": true, "run_id": run_id, "error": e.to_string()})
-                                    .to_string(),
-                            );
+                        Err(e) => {
+                            // Fail LOUD on the poll surface too — a detached run that dies must leave a
+                            // diagnosable marker, never an empty file forever.
+                            if let Some(path) = path.as_ref() {
+                                let _ = std::fs::write(
+                                    path,
+                                    serde_json::json!({"failed": true, "run_id": run_id, "error": e.to_string()})
+                                        .to_string(),
+                                );
+                            }
+                            tracing::error!(run_id = %run_id, error = %e, attempt, "agent/solve detached run failed");
+                            break;
                         }
-                        tracing::error!(run_id = %run_id, error = %e, "agent/solve detached run failed");
                     }
                 }
             });

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -2122,6 +2122,10 @@ impl BenchmarkSweSolve {
                 max_acts: p.max_acts.or(Some(30)),
                 detach: Some(false),
                 run_id: None,
+                // This inline arm IS the grader loop's inner body (swe-solve grades right
+                // below) — retries here would nest N chances inside N chances. The
+                // claim-dispatch adapter owns its own N (`SWE_CLAIM_ATTEMPTS`).
+                attempts: None,
                 // learn=FALSE on a SCORED, HELD-OUT instance (#312). `agent/solve` defaults
                 // learn ON and that default is right — a being learns from her work. But this
                 // command's input is a held-out benchmark dataset, and what learn mode admits

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -319,6 +319,10 @@ impl ActionCommand for WorkClaim {
     }
 }
 
+/// How many graded chances a claim-dispatched SWE run gets (`AgentSolveParams::attempts`).
+/// This is the SWE adapter's N, not a global — each benchmark adapter owns its own.
+const SWE_CLAIM_ATTEMPTS: u32 = 3;
+
 /// The #346 claim→solve dispatch. Fires a detached [`crate::commands::agent::solve::AgentSolve`]
 /// for the claimer when the claimed card matches a checkout `benchmark/swe-setup` staged
 /// into HER workspace: one staged instance directory whose name appears in the card
@@ -398,6 +402,11 @@ async fn dispatch_staged_swe_solve(
         max_acts: None,
         path_prepend: None,
         suppress_recall: None,
+        // The SWE claim adapter's N (Joel, 2026-08-08): a failed grade re-enters the
+        // same workspace with the named failing tests — learning to investigate your
+        // own failure is part of the exam. Three chances: first attempt, one informed
+        // retry, one consolidation — beyond that the failures repeat, not teach.
+        attempts: Some(SWE_CLAIM_ATTEMPTS),
     };
     match crate::commands::agent::solve::AgentSolve
         .run(ctx, params)

--- a/protocol/typescript/agent/AgentSolveParams.ts
+++ b/protocol/typescript/agent/AgentSolveParams.ts
@@ -104,4 +104,15 @@ scored?: boolean,
  * on sympy-21379: a correct reproduction script met `bash: python: command not
  * found`, and the run scored as a capability failure.
  */
-path_prepend?: Array<string>, };
+path_prepend?: Array<string>, 
+/**
+ * N CHANCES (Joel, 2026-08-08: "they too need to learn how to investigate and fix
+ * their code"): how many graded attempts this detached run may take. After a
+ * non-resolved auto-grade, the NEXT attempt re-enters the SAME workspace (her
+ * previous edits intact) with the grader's verdict — named failing tests — appended
+ * to the task, so investigating her own failure IS the work. Only meaningful on a
+ * detached, auto-graded run; a resolved grade, an ungradeable tree, or a harness
+ * fault ends the run early. Default 1 (one shot, exactly the old behavior) — the
+ * per-benchmark adapter that dispatches the run owns its N, not this abstraction.
+ */
+attempts?: number, };


### PR DESCRIPTION
Joel's ruling: citizens must learn to investigate and fix their own code, with N chances via the benchmark abstraction/adapter.

`AgentSolveParams.attempts` (default 1 = old behavior) makes the detached solve an attempt loop: a non-resolved auto-grade re-dispatches into the same workspace with the verdict — counts and **named failing tests** — appended to the task. Ends on resolved / exhausted / ungradeable / grade fault / solve failure. Poll files show latest attempt; history on the `benchmark.autograde` probe. SWE claim adapter sets N=3 (`SWE_CLAIM_ATTEMPTS`); `swe-solve`'s inline arm keeps `attempts: None` to avoid nesting inside its own grader loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo