### PR TITLE
fix(cognition): steps ledger heads-only — receipts were paid twice per window (#324/#211)

### DIFF
--- a/core/continuum-core/src/cognition/perception_facts.rs
+++ b/core/continuum-core/src/cognition/perception_facts.rs
@@ -169,11 +169,19 @@ impl PerceptionFact for StepsLedger {
 
     fn render(&self, cx: &FactContext) -> Option<String> {
         let wm = cx.working_memory?;
+        // HEAD LINE ONLY (#324/#211 dedup): a receipt's full text — args AND the
+        // result body — already renders once, in the working-memory TRAILING
+        // channel nearest generation. This ledger's job is the session'S ACT
+        // HISTORY as a fact ("what has actually executed"), so it lists each
+        // step's head line (`[action #n] name(args)`) and nothing more. Before
+        // this, both channels carried the full bodies and every receipt was
+        // paid twice on a 16k window (measured: the ledger was a byte-level
+        // duplicate of the WM tail).
         let steps: Vec<String> = wm
             .recent_entries()
             .into_iter()
             .filter(|e| matches!(e.kind, WmKind::Receipt { .. }))
-            .map(|e| e.text)
+            .map(|e| e.text.lines().next().unwrap_or_default().to_string())
             .collect();
         // Receipts are RARE entries in a chatty capacity-bounded ring, so
         // they age out while the session's act counter keeps counting.


### PR DESCRIPTION
The steps-ledger fact carried every receipt's full text (args + result body) while the WM trailing channel renders the same entries again — byte-level duplication on every prompt. Ledger becomes a table of contents (head lines); the full trace lives once in the trailing channel. Ledger tests 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo