### PR TITLE
feat(persona): fresh citizens land in #academy — the citizen commons (daa01102 slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=490dc76#490dc7601a2f406a93ff954ec943b18a1f84d387"
+source = "git+https://github.com/CambrianTech/airc?rev=dd34f68#dd34f687283aa5a2b9443c028b9ff37878f3aaea"
 dependencies = [
  "airc-core",
  "airc-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,18 +166,18 @@ members = [
 # personas load their stored peer_id unchanged. This SHA is on the
 # feat/persona-peer-id-mint branch, not canary — reconcile to the canary SHA
 # when the airc PR lands. Re-validate persona attach on bump.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "490dc76" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "490dc76" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "490dc76" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "490dc76" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "490dc76" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "dd34f68" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "dd34f68" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "dd34f68" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "dd34f68" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "dd34f68" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "490dc76" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "dd34f68" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -56,6 +56,16 @@ use std::sync::Arc;
 use airc_core::{EventId, PeerId, RoomId};
 use airc_lib::{Airc, AircError, DEFAULT_HEARTBEAT_INTERVAL};
 
+/// The room a FRESH citizen scope lands in (room-consolidation master
+/// card daa01102, Joel: academy is THE default room — training,
+/// benchmarks, and the commons all root there; `#general` was airc's
+/// generic lobby, and citizens landing in it is the "disorganized
+/// non-academy room stuff" the consolidation kills). Passed to
+/// `Airc::current_room_landing_in` at bootstrap; an ESTABLISHED
+/// persona's durable membership always wins, so changing this never
+/// migrates a living citizen.
+pub const CITIZEN_COMMONS_ROOM: &str = "academy";
+
 /// Abort-on-drop guard for the continuum-owned heartbeat pump (#260): keeps
 /// the airc `HeartbeatTask` teardown contract — dropping the runtime aborts
 /// the pump so a torn-down persona ages out of the roster within the
@@ -112,8 +122,8 @@ pub enum PersonaAircRuntimeError {
     #[error(
         "failed to resolve persona {agent_name:?}'s home room from her durable \
          subscription state: {source} — a persona's rooms come from HER OWN airc \
-         home (fresh scopes land in #general), never from the operator's current \
-         room (#298)"
+         home (fresh scopes land in the citizen commons, #academy — daa01102), \
+         never from the operator's current room (#298)"
     )]
     HomeRoom {
         agent_name: String,
@@ -261,11 +271,13 @@ impl PersonaAircRuntime {
     ///    (generate or load Ed25519 keypair, write `identity.key`,
     ///    record the local_identity row) and attaches a daemon
     ///    client for live publish + subscribe. No shelling out.
-    /// 3. Resolve her HOME room via `Airc::current_room()` — her OWN
-    ///    durable subscription default; a fresh scope lands in
-    ///    `#general` per airc's canonical fresh-scope semantics. This
-    ///    makes the persona appear on `airc peers` as an enrolled
-    ///    participant of HER room — never the operator's (#298).
+    /// 3. Resolve her HOME room via
+    ///    `Airc::current_room_landing_in(CITIZEN_COMMONS_ROOM)` — her
+    ///    OWN durable subscription default; a fresh scope lands in the
+    ///    citizen commons `#academy` (daa01102) instead of airc's
+    ///    generic `#general` lobby. This makes the persona appear on
+    ///    `airc peers` as an enrolled participant of HER room — never
+    ///    the operator's (#298).
     /// 4. Install the per-persona command inbound pump
     ///    ([`PersonaCommandInboundPump`](crate::persona::command_inbound_pump))
     ///    so this persona's airc handle starts receiving cross-grid
@@ -400,20 +412,22 @@ impl PersonaAircRuntime {
         // parking citizens in one whose activity ended is how a fleet
         // ends up with nothing to do and no way to say why.)
         // A persona is her own airc peer with her own home dir;
-        // `current_room()` loads HER durable subscription set (the same
-        // state `Airc::join` writes), returns her established default,
-        // and on a FRESH scope applies airc's canonical landing-room
-        // semantics: subscribe to `#general`, set it default, publish
-        // presence + identity card. Resumed personas keep their real
-        // membership; new minds land in the commons. The operator's
-        // current-room pointer no longer exists on this path.
-        let room =
-            airc.current_room()
-                .await
-                .map_err(|source| PersonaAircRuntimeError::HomeRoom {
-                    agent_name: agent_name.clone(),
-                    source,
-                })?;
+        // `current_room_landing_in` loads HER durable subscription set
+        // (the same state `Airc::join` writes), returns her established
+        // default, and on a FRESH scope lands her in the citizen
+        // commons `#academy` (CITIZEN_COMMONS_ROOM, card daa01102 —
+        // airc's own `current_room` lobby stays `#general`; continuum's
+        // citizens root in the academy tree): subscribe, set default,
+        // publish presence + identity card. Resumed personas keep their
+        // real membership; only new minds land in the commons. The
+        // operator's current-room pointer no longer exists on this path.
+        let room = airc
+            .current_room_landing_in(CITIZEN_COMMONS_ROOM)
+            .await
+            .map_err(|source| PersonaAircRuntimeError::HomeRoom {
+                agent_name: agent_name.clone(),
+                source,
+            })?;
 
         info!(
             persona_id = %persona_id,


### PR DESCRIPTION
Continuum half of the landing-room pair (airc half merged as CambrianTech/airc#1329, canary `dd34f687`).

**Why now (live-measured tonight):** both resident citizens' durable subscription sets are `general`-only while the operator scope holds cambriantech+academy+general — so operator messages to academy were structurally invisible. BigMama root-caused the perception half (single-channel `subscribe()` narrowing, her lane); this PR is the landing half: fresh minds root in `#academy` per Joel's room-consolidation directive (master card daa01102, which gates positron).

- `CITIZEN_COMMONS_ROOM = "academy"` — one constant, persona-bootstrap policy.
- `Airc::current_room_landing_in(CITIZEN_COMMONS_ROOM)` at bootstrap; an established persona's durable default always wins — no living citizen is migrated by this change.
- airc pins 490dc76 → dd34f68 (canary lineage; `cargo check` + airc_runtime tests green, airc-lib landing tests 3/3).
- Follow-up (with BigMama's plural-subscribe fix): membership migration for existing general-only citizens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo