### PR TITLE
fix(bench): N-chances retry carries the investigation trail — fresh attempts no longer start amnesiac

### DIFF
--- a/core/continuum-core/src/cognition/act_observe.rs
+++ b/core/continuum-core/src/cognition/act_observe.rs
@@ -65,6 +65,15 @@ pub struct SettleOutcome {
     /// corrupts the accuracy metric ([[self-improvement-is-a-control-loop]]: the
     /// reward is only as trustworthy as the metric). `None` on every settled turn.
     pub inference_error: Option<String>,
+    /// File paths her acts NAMED (any `file_path`/`path` string arg on an executed
+    /// call), in first-touch order, deduped. This is the turn's investigation trail
+    /// as STATE — distinct from `files_changed` (what git saw): a failed edit or a
+    /// read appears here and nowhere else. Exists because an N-chances retry is a
+    /// FRESH turn with fresh working memory (glass-boxed 2026-08-08,
+    /// benchy-sympy-22840-n4 attempt 2: the verdict said "the file you already
+    /// identified" and she had no memory of identifying it — 10 acts re-deriving
+    /// cse_main.py). The retry caller threads these into the next attempt's task.
+    pub touched_paths: Vec<String>,
 }
 
 impl SettleOutcome {
@@ -82,6 +91,23 @@ impl SettleOutcome {
             world_state: String::new(),
             metrics: TurnMetrics::default(),
             inference_error: Some(cause.into()),
+            touched_paths: Vec::new(),
+        }
+    }
+}
+
+/// Collect the file paths a tool batch NAMES: any string under a `file_path` or
+/// `path` key in a call's input, appended to `touched` in first-touch order,
+/// deduped. Mechanical extraction from HER OWN calls — never inferred, never a
+/// steer; this is the investigation-trail STATE an N-chances retry hands back.
+fn collect_touched_paths(touched: &mut Vec<String>, calls: &[ToolCall]) {
+    for call in calls {
+        for key in ["file_path", "path"] {
+            if let Some(p) = call.input.get(key).and_then(|v| v.as_str()) {
+                if !touched.iter().any(|t| t == p) {
+                    touched.push(p.to_string());
+                }
+            }
         }
     }
 }
@@ -896,6 +922,8 @@ pub async fn drive_to_settle(
 ) -> SettleOutcome {
     let burst: Burst = burst.into();
     let mut acts = 0usize;
+    // The turn's investigation trail (see `SettleOutcome::touched_paths`).
+    let mut touched: Vec<String> = Vec::new();
     // Fold each tick's deliberation cost in, so the settled outcome reports the
     // task's TOTAL speed/latency (a multi-act task pays for every generation).
     let mut metrics = TurnMetrics::default();
@@ -1015,10 +1043,12 @@ pub async fn drive_to_settle(
                     world_state: burst.rendered.clone(),
                     metrics,
                     inference_error: None,
+                    touched_paths: touched,
                 };
             }
             SettleStep::Acted { calls, .. } => {
                 acts += 1;
+                collect_touched_paths(&mut touched, &calls);
                 // THE DELIVERABLE FACT BELONGS ON THE ACT PATH, NOT ONLY ON SETTLE.
                 //
                 // It used to live exclusively in the Spoke arm, so it could only reach a
@@ -1096,6 +1126,7 @@ pub async fn drive_to_settle(
                     world_state: burst.rendered.clone(),
                     metrics,
                     inference_error: None,
+                    touched_paths: touched,
                 };
             }
             SettleStep::Passed => {
@@ -1106,6 +1137,7 @@ pub async fn drive_to_settle(
                     world_state: burst.rendered.clone(),
                     metrics,
                     inference_error: None,
+                    touched_paths: touched,
                 };
             }
             // The model call FAILED — no verdict this task. Return LOUD: carry the
@@ -1121,6 +1153,7 @@ pub async fn drive_to_settle(
                     world_state: burst.rendered.clone(),
                     metrics,
                     inference_error: Some(error),
+                    touched_paths: touched,
                 };
             }
         }
@@ -2874,6 +2907,7 @@ mod tests {
             world_state: String::new(),
             metrics: TurnMetrics::default(),
             inference_error,
+            touched_paths: Vec::new(),
         }
     }
 

--- a/core/continuum-core/src/cognition/experience.rs
+++ b/core/continuum-core/src/cognition/experience.rs
@@ -547,6 +547,7 @@ mod tests {
             world_state: world_state.to_string(),
             metrics: TurnMetrics::default(),
             inference_error: None,
+            touched_paths: Vec::new(),
         }
     }
 
@@ -746,6 +747,7 @@ mod tests {
             world_state: "budget exhausted after 8 acts".into(),
             metrics: TurnMetrics::default(),
             inference_error: None,
+            touched_paths: Vec::new(),
         };
         let lived_stuck = ExperienceRecord::from_lived_turn("fix the build", &unconverged);
         assert!(
@@ -943,6 +945,7 @@ mod tests {
             world_state: String::new(),
             metrics: TurnMetrics::default(),
             inference_error: None,
+            touched_paths: Vec::new(),
         };
         let lived = ExperienceRecord::from_lived_turn("a hard live question", &stuck);
         let received = ExperienceRecord::from_shared_lesson(&shared_lesson(

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -170,6 +170,15 @@ pub struct AgentSolveResult {
     pub patch: String,
     /// Paths she touched (from `git diff --name-only`).
     pub files_changed: Vec<String>,
+    /// Paths her acts NAMED (reads, searches, edit attempts — any `file_path`/`path`
+    /// arg on an executed call), first-touch order. The investigation trail as STATE:
+    /// a failed edit or a read appears here and nowhere else. The N-chances retry
+    /// threads these into the next attempt's task, because a retry is a FRESH turn
+    /// with fresh working memory — without this, "the file you already identified"
+    /// names knowledge the next attempt does not have (glass-boxed 2026-08-08,
+    /// benchy-sympy-22840-n4 attempt 2: 10 of 12 acts re-deriving cse_main.py).
+    #[serde(default)]
+    pub files_examined: Vec<String>,
     /// True when this is the immediate ACK of a detached run (`acts`/`patch` empty — poll the
     /// result file `agent-solve-<run_id>.json` for the real outcome).
     pub detached: bool,
@@ -353,21 +362,42 @@ impl ActionCommand for AgentSolve {
                                     } else {
                                         format!(" Failing tests: {}.", g.failed_tests.join(", "))
                                     };
+                                    // A retry is a FRESH turn with fresh working memory, so
+                                    // "the file you already identified" names knowledge the
+                                    // next attempt does not have (glass-boxed 2026-08-08,
+                                    // 22840-n4 attempt 2: her recall carried only a generic
+                                    // "I worked a coding task" reflection, and she spent 10
+                                    // of 12 acts re-deriving cse_main.py). The trail is
+                                    // STATE the substrate holds — hand it back explicitly.
+                                    let trail = if r.files_examined.is_empty() {
+                                        String::new()
+                                    } else {
+                                        format!(
+                                            " Files your previous attempt examined (in order): {}.",
+                                            r.files_examined.join(", ")
+                                        )
+                                    };
                                     next_task = if g.patch_bytes == 0 {
                                         format!(
                                             "{base_task}\n\n[grader verdict — attempt {attempt} of {max_attempts} produced NO EDIT] \
-                                             You changed no files, so the grader had nothing to run.{failing} \
+                                             You changed no files, so the grader had nothing to run.{failing}{trail} \
                                              Reading and searching cannot score; only an edit can. This attempt, go \
                                              straight to the file you already identified and apply your best-guess fix \
                                              with code/edit — a wrong edit earns failing-test feedback to iterate on; \
                                              no edit earns nothing. Do not re-read what you have already read.",
                                         )
                                     } else {
+                                        let edited = if r.files_changed.is_empty() {
+                                            String::new()
+                                        } else {
+                                            format!(" Your edits are in: {}.", r.files_changed.join(", "))
+                                        };
                                         format!(
                                             "{base_task}\n\n[grader verdict — attempt {attempt} of {max_attempts} did not resolve] \
                                              FAIL_TO_PASS {}/{}, PASS_TO_PASS {}/{}.{failing} \
-                                             Your previous edits are still in this workspace. Investigate why these \
-                                             tests fail — run them — then fix in place without breaking what passes.",
+                                             Your previous edits are still in this workspace.{edited}{trail} \
+                                             Investigate why these tests fail — run them — then fix in place without \
+                                             breaking what passes.",
                                             g.fail_to_pass_passed,
                                             g.fail_to_pass_total,
                                             g.pass_to_pass_passed,
@@ -413,6 +443,7 @@ impl ActionCommand for AgentSolve {
                 spoken: String::new(),
                 patch: String::new(),
                 files_changed: Vec::new(),
+                files_examined: Vec::new(),
                 detached: true,
                 run_id: Some(run_id_ack),
                 infra_error: None,
@@ -650,6 +681,7 @@ impl AgentSolve {
             spoken: settled.spoken.unwrap_or_default(),
             patch,
             files_changed,
+            files_examined: settled.touched_paths.clone(),
             detached: false,
             run_id,
             infra_error: settled.inference_error,

--- a/protocol/typescript/agent/AgentSolveResult.ts
+++ b/protocol/typescript/agent/AgentSolveResult.ts
@@ -20,6 +20,16 @@ patch: string,
  */
 files_changed: Array<string>, 
 /**
+ * Paths her acts NAMED (reads, searches, edit attempts — any `file_path`/`path`
+ * arg on an executed call), first-touch order. The investigation trail as STATE:
+ * a failed edit or a read appears here and nowhere else. The N-chances retry
+ * threads these into the next attempt's task, because a retry is a FRESH turn
+ * with fresh working memory — without this, "the file you already identified"
+ * names knowledge the next attempt does not have (glass-boxed 2026-08-08,
+ * benchy-sympy-22840-n4 attempt 2: 10 of 12 acts re-deriving cse_main.py).
+ */
+files_examined: Array<string>, 
+/**
  * True when this is the immediate ACK of a detached run (`acts`/`patch` empty — poll the
  * result file `agent-solve-<run_id>.json` for the real outcome).
  */


### PR DESCRIPTION
## The live failure

benchy-sympy-22840-n4 attempt 2: the #2174 zero-diff verdict reached her window (positive-control verified — all three contract phrases present) and told her to "go straight to the file you already identified." She couldn't: a retry is a fresh turn with fresh working memory, her recall carried only a generic reflection, and she burned 10 of 12 acts re-deriving cse_main.py — which attempt 1 had already found. The verdict referenced state the substrate held but never handed over.

## The fix

`drive_to_settle` collects `touched_paths` (file_path/path args on executed calls, first-touch order) onto `SettleOutcome`; `AgentSolveResult` surfaces it as `files_examined`; both retry-verdict arms name the trail (and the edits-exist arm additionally names `files_changed`). Mechanical extraction from her own calls — state handed back, never a steer.

## Verification

cargo check green; act_observe 28/28; experience 48/48; ts-rs bindings regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo