### PR TITLE
fix(cognition): re-pin agentic-surface ceiling 9600→9800 — the growth #2162 declared but never pinned

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -2818,7 +2818,19 @@ mod tests {
             // pass-cascade costs the room more than 144 tokens (the 2026-08-01 one ran
             // ~30 minutes across every peer), and this replaces matcher code that could
             // only ever be beaten by the next phrasing.
-            const AGENTIC_SURFACE_BOUND_CEILING: u32 = 9600;
+            //
+            // 9600 → 9800, and what grew, stated plainly as the ratchet demands: PR #2162
+            // grew the native payload 20 → 23 schemas (+212 tokens, 9544 → 9756) and said
+            // so in its own commit message — the #339 lifecycle write-back verbs
+            // (REACHABLE-VERIFIED: they existed and had never declared NATIVE, so a
+            // native-call citizen could claim work she could never update or close) plus
+            // `room/members` (pinned into the native-surface test after #358 proved a
+            // correct roster read). Each verb closes a measured live defect; shrinking
+            // here would undo verified fixes. What #2162 did NOT do was re-pin this
+            // ceiling, so canary sat red for a day and every branch inherited it —
+            // which is itself the ratchet working: the growth got named here instead
+            // of accruing silently.
+            const AGENTIC_SURFACE_BOUND_CEILING: u32 = 9800;
             assert!(
                 needed <= AGENTIC_SURFACE_BOUND_CEILING,
                 "the agentic surface now needs {needed} tokens (was 8040, ceiling \


### PR DESCRIPTION
Canary's Rust Tests red streak starts at fb93436b6 (#2162, Aug 8 00:48Z) — verified against the workflow run history (last green: 731999668, Aug 7 00:33Z). It predates today's #2174-#2177, which inherited it.

The tripwire fired as designed: surface needs 9756 vs ceiling 9600. #2162 grew the native payload 20→23 schemas (+212 tokens) and documented it in its own commit message (#339 lifecycle verbs + room/members — each closing a verified live defect) but never re-pinned. This PR states the growth at the ratchet site and pins 9800, keeping the same ~50-token headroom as prior pins. Shrinking instead would undo #339/#358.

Companion: #2178 (BigMama) clears the ts-rs drift guard. Together canary goes green.

Local: `tool_surface_is_a_category_index_plus_discovery_pair` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo