### PR TITLE
fix(bench): benchmark/runs — grade ledgers are siblings, not phantom runs

### DIFF
--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -3164,8 +3164,14 @@ impl ActionCommand for BenchmarkRuns {
                 .strip_prefix("agent-solve-")
                 .and_then(|r| r.strip_suffix(".json"))
             else {
-                continue; // grade files are read as siblings, not enumerated
+                continue;
             };
+            // Grade files are read as SIBLINGS of their run below, never
+            // enumerated as runs (live first use showed `X.grade` phantoms:
+            // `agent-solve-X.grade.json` survives the prefix/suffix strip).
+            if run_id.ends_with(".grade") {
+                continue;
+            }
             if let Some(want) = p.run_id.as_deref() {
                 if want != run_id {
                     continue;


### PR DESCRIPTION
First live use showed every run doubled by an `X.grade` phantom (the grade file survives the filename strip). One guard; siblings stay siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo