### PR TITLE
feat(core): version trio — auto-incrementing build number + sha + built-at on health surfaces

### DIFF
--- a/core/continuum-core/build.rs
+++ b/core/continuum-core/build.rs
@@ -14,6 +14,34 @@ fn main() {
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=CONTINUUM_BUILD_GIT_SHA={sha}");
+    // Auto-incrementing BUILD NUMBER (Joel, 2026-08-08: "versions must always
+    // increment and display along with sha in every repo … stale binaries ruin
+    // you"). Commit count is monotonic per branch, deterministic, and needs no
+    // state file — two builds can be ORDERED at a glance where bare SHAs
+    // cannot, which is what turns "is this node stale?" into arithmetic.
+    let build_num = std::process::Command::new("git")
+        .args(["rev-list", "--count", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "0".to_string());
+    println!("cargo:rustc-env=CONTINUUM_BUILD_NUMBER={build_num}");
+    // Third leg of the version trio: WHEN this binary was compiled. Number
+    // orders source, sha names source, built-at catches the case both miss —
+    // a binary rebuilt from OLD source after a fix landed (number and sha look
+    // plausible; the timestamp says the binary predates the fix). Refreshes
+    // when the build script reruns (HEAD moved or clean build), which is
+    // exactly the granularity a staleness question needs.
+    let built_at = std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=CONTINUUM_BUILD_AT={built_at}");
     // Relative to this crate (repo/core/continuum-core) the repo `.git` is two levels up.
     println!("cargo:rerun-if-changed=../../.git/logs/HEAD");
     println!("cargo:rerun-if-changed=../../.git/HEAD");

--- a/core/continuum-core/src/main.rs
+++ b/core/continuum-core/src/main.rs
@@ -282,7 +282,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.len() >= 2 {
         match args[1].as_str() {
             "-V" | "--version" | "version" => {
-                println!("continuum-core-server {}", env!("CARGO_PKG_VERSION"));
+                // Number + sha together, always (Joel 2026-08-08): the number
+                // orders two builds at a glance, the sha names the source.
+                println!(
+                    "continuum-core-server {} build {} ({}) built {}",
+                    env!("CARGO_PKG_VERSION"),
+                    env!("CONTINUUM_BUILD_NUMBER"),
+                    env!("CONTINUUM_BUILD_GIT_SHA"),
+                    env!("CONTINUUM_BUILD_AT"),
+                );
                 std::process::exit(0);
             }
             "-h" | "--help" | "help" => {

--- a/core/continuum-core/src/modules/health.rs
+++ b/core/continuum-core/src/modules/health.rs
@@ -40,6 +40,17 @@ pub struct PingResult {
     /// swapped the file under a still-running old core. `"unknown"` only when the
     /// server was built outside a git tree.
     pub build_sha: String,
+    /// Auto-incrementing build number: the repo's commit count at compile time
+    /// (Joel, 2026-08-08: "versions must always increment and display along with
+    /// sha … stale binaries ruin you"). Monotonic per branch, so two nodes'
+    /// builds can be ORDERED at a glance — "is this node stale?" becomes
+    /// arithmetic instead of SHA archaeology. 0 only outside a git tree.
+    #[ts(type = "number")]
+    pub build_number: u32,
+    /// UTC timestamp this binary was compiled (third leg of the version trio:
+    /// number orders SOURCE, sha names it, built-at dates the BINARY — catching
+    /// a rebuild of old source after a fix landed, which number+sha both miss).
+    pub built_at: String,
 }
 
 /// `ping` — the canonical self-routing command. As an [`ActionCommand`] it gets
@@ -63,6 +74,8 @@ impl ActionCommand for PingCommand {
             ok: true,
             round_trip_ms: 0,
             build_sha: env!("CONTINUUM_BUILD_GIT_SHA").to_string(),
+            build_number: env!("CONTINUUM_BUILD_NUMBER").parse().unwrap_or(0),
+            built_at: env!("CONTINUUM_BUILD_AT").to_string(),
         })
     }
 }

--- a/protocol/typescript/health/PingResult.ts
+++ b/protocol/typescript/health/PingResult.ts
@@ -19,4 +19,18 @@ roundTripMs: number,
  * swapped the file under a still-running old core. `"unknown"` only when the
  * server was built outside a git tree.
  */
-buildSha: string, };
+buildSha: string, 
+/**
+ * Auto-incrementing build number: the repo's commit count at compile time
+ * (Joel, 2026-08-08: "versions must always increment and display along with
+ * sha … stale binaries ruin you"). Monotonic per branch, so two nodes'
+ * builds can be ORDERED at a glance — "is this node stale?" becomes
+ * arithmetic instead of SHA archaeology. 0 only outside a git tree.
+ */
+buildNumber: number, 
+/**
+ * UTC timestamp this binary was compiled (third leg of the version trio:
+ * number orders SOURCE, sha names it, built-at dates the BINARY — catching
+ * a rebuild of old source after a fix landed, which number+sha both miss).
+ */
+builtAt: string, };


### PR DESCRIPTION
Per Joel's stale-binaries ruling: build_number (commit count — orders), build_sha (identity), built_at (dates the binary, catches rebuilt-old-source). On ping + --version; --build-sha reboot contract untouched. airc gets the same scheme via BigMama so peer numbers compare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo