### PR TITLE
fix(cognition): embedding-cache eviction self-deadlock — a full cache silenced the whole citizenry

### DIFF
--- a/core/continuum-core/src/cognition/embedding.rs
+++ b/core/continuum-core/src/cognition/embedding.rs
@@ -438,10 +438,7 @@ impl CachingEmbeddingProvider {
     /// Wrap `inner`, sharing the process-global cache — what makes the
     /// compute-once-across-personas property hold in production.
     pub fn new(inner: Arc<dyn EmbeddingProvider>) -> Self {
-        Self {
-            inner,
-            cache: global_embedding_cache(),
-        }
+        Self::with_cache(inner, global_embedding_cache())
     }
 
     /// Wrap `inner` against a specific cache (tests / isolated benches).
@@ -484,8 +481,22 @@ impl EmbeddingProvider for CachingEmbeddingProvider {
         }
         // Bound memory: evict one arbitrary entry on overflow before inserting a
         // genuinely new key. Hot/recent content re-populates on its next miss.
+        //
+        // LOCK DISCIPLINE (#368-family stall, 2026-08-08): the victim key MUST be
+        // bound by its own `let` so the `iter()` guard (a shard READ lock) is
+        // dropped at that statement's end. The previous form put the iterator
+        // temporary inside an `if let` scrutinee, where it lives for the WHOLE
+        // block — so `remove` waited forever on the same shard's WRITE lock.
+        // Self-deadlock, reachable only when the cache is FULL, which is why it
+        // slept until the cache first hit EMBEDDING_CACHE_MAX in production:
+        // from then on every novel embed parked its task permanently, and since
+        // recall embeds inside every turn, the entire citizenry went silent one
+        // turn at a time (sampled live: 100% parked in lock_exclusive_slow under
+        // DashMap::remove). dashmap's own docs: never call `remove` while
+        // holding any reference into the map.
         if !self.cache.map.contains_key(&key) && self.cache.map.len() >= EMBEDDING_CACHE_MAX {
-            if let Some(victim) = self.cache.map.iter().next().map(|e| *e.key()) {
+            let victim = self.cache.map.iter().next().map(|e| *e.key());
+            if let Some(victim) = victim {
                 self.cache.map.remove(&victim);
             }
         }
@@ -1351,6 +1362,50 @@ mod tests {
             "three back-to-back failed resolves must not attempt more than one load \
              (got {} new attempts)",
             attempts_after - attempts_before
+        );
+    }
+
+    // what this catches (regression for the 2026-08-08 civilization-wide stall):
+    // CachingEmbeddingProvider's overflow eviction self-deadlocked — the
+    // `iter()` shard READ guard lived for the whole `if let` block (scrutinee
+    // temporary lifetime), so `remove` parked forever on the same shard's WRITE
+    // lock. Reachable ONLY when the cache is at EMBEDDING_CACHE_MAX, so it
+    // slept until production filled 20k entries — then every novel embed hung
+    // its task, recall embeds inside every turn, and all four citizens went
+    // silent (sampled live: 100% parked in lock_exclusive_slow). This test
+    // fills a PRIVATE cache to the cap and embeds one novel text under a
+    // timeout: pre-fix it deadlocks (timeout fires), post-fix it evicts and
+    // returns in microseconds.
+    #[tokio::test]
+    async fn full_cache_eviction_does_not_self_deadlock() {
+        struct Tiny;
+        #[async_trait::async_trait]
+        impl EmbeddingProvider for Tiny {
+            fn id(&self) -> &str {
+                "tiny-test-embedder"
+            }
+            fn dim(&self) -> usize {
+                2
+            }
+            async fn embed(&self, _text: &str) -> Vec<f32> {
+                vec![0.5, -0.5]
+            }
+        }
+        let cache = Arc::new(EmbeddingCache::new());
+        for i in 0..EMBEDDING_CACHE_MAX {
+            cache.map.insert(i as u64, vec![0.0, 0.0]);
+        }
+        let provider = CachingEmbeddingProvider::with_cache(Arc::new(Tiny), cache.clone());
+        let v = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            provider.embed("a text the full cache has never seen"),
+        )
+        .await
+        .expect("full-cache embed must not deadlock on its own eviction");
+        assert_eq!(v, vec![0.5, -0.5]);
+        assert!(
+            cache.map.len() <= EMBEDDING_CACHE_MAX,
+            "eviction kept the cache bounded"
         );
     }
 }


### PR DESCRIPTION
The `if let` scrutinee's `iter()` guard held the shard READ lock while `remove` waited on the WRITE lock — self-deadlock, reachable only at EMBEDDING_CACHE_MAX, live-sampled as the cause of both solver stalls and citizen silence. Fix: bind the victim key first so the guard drops. Regression test on a private cache under timeout. VRAM-lease starvation of the embedder found on the same trail is #225, separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo