### PR TITLE
feat(resources): embed lane reserves a standing VRAM floor; serving budgets around it (#225)

### DIFF
--- a/core/continuum-core/src/cognition/embedding.rs
+++ b/core/continuum-core/src/cognition/embedding.rs
@@ -677,6 +677,29 @@ async fn try_neural_embedder(
         null_std = std,
         "measured unrelated-cosine null for the embedding space"
     );
+    // This node embeds — claim the embed lane's standing FLOOR on the resource
+    // board (#225, Joel 2026-08-08: "the budgeter just has all its parts figure
+    // it out"). The floor makes the ledger's `available_for` math hold the lane's
+    // working VRAM against every OTHER consumer, so the serving plan can no
+    // longer grow its window into the slice cognition needs every turn (measured
+    // the day this landed: 604 MiB governed-available vs the 1792 MiB need —
+    // embedding fully dead, every recall degraded to no-relevance). Reserved
+    // HERE, at successful resolve, so a node with no embed model wastes nothing.
+    // Idempotent: re-resolve re-states the same floor.
+    if let Some(daemon) = crate::resources::ResourceDaemon::global() {
+        use crate::inference::llamacpp_adapter::{EMBED_LANE_CONSUMER_ID, EMBED_LANE_VRAM_BYTES};
+        daemon.reserve(
+            EMBED_LANE_CONSUMER_ID,
+            crate::resources::ResourceKind::Vram,
+            EMBED_LANE_VRAM_BYTES,
+        );
+        crate::probe!(
+            class = "embed.vram.reserved",
+            consumer = EMBED_LANE_CONSUMER_ID,
+            bytes = EMBED_LANE_VRAM_BYTES,
+            "embed lane reserved its standing VRAM floor — serving's budget now plans around it"
+        );
+    }
     Some(Arc::new(CachingEmbeddingProvider::new(Arc::new(neural))) as Arc<dyn EmbeddingProvider>)
 }
 

--- a/core/continuum-core/src/inference/llamacpp_adapter.rs
+++ b/core/continuum-core/src/inference/llamacpp_adapter.rs
@@ -56,6 +56,18 @@ use std::time::Instant;
 /// "local" → device-filtered local-GPU selection logic).
 pub const LLAMACPP_PROVIDER_ID: &str = "llamacpp-local";
 
+/// The embed lane's identity on the resource board — the `consumer_id` on both
+/// its per-call VRAM leases and its standing reservation floor.
+pub const EMBED_LANE_CONSUMER_ID: &str = "embed";
+
+/// The embed lane's working VRAM: the bounded Metal embedding context (~1.2 GiB
+/// compute buffer + ~224 MiB KV) plus headroom. ONE constant, two uses: the
+/// per-call lease in [`create_embedding`], and the standing FLOOR the embedder
+/// reserves on the board at resolve so serving's plan can never grow into it
+/// (#225 — measured 2026-08-08: the grown window left 604 MiB governed-available
+/// against this 1792 MiB need, and embedding went fully dead on the box).
+pub const EMBED_LANE_VRAM_BYTES: u64 = 1792 * 1024 * 1024;
+
 /// Overlay live runtime metadata (throughput) on top of the registry's
 /// declared ModelInfo. Context-window still flows from `backend.n_ctx_train()`
 /// because that's the GGUF's ground truth — the catalog value is the intent,
@@ -1207,11 +1219,11 @@ impl AIProviderAdapter for LlamaCppAdapter {
         // "no signal", never a zero vector.
         //
         // Const, not env-tunable — substrate policy lives in code (concurrency guide).
-        // Only the per-call CONTEXT is leased here; registering the embed model's
-        // resident WEIGHTS (~600 MiB) as a ResourceConsumer (mirroring ServingConsumer)
-        // is the residency-accounting follow-up, not this admission-control slice.
-        const EMBED_LANE_CONSUMER_ID: &str = "embed";
-        const EMBED_LANE_VRAM_BYTES: u64 = 1792 * 1024 * 1024; // ~1.75 GiB (ctx + headroom)
+        // Only the per-call CONTEXT is leased here; the embed lane's standing FLOOR on
+        // the board (so serving can never grow into this slice — Joel 2026-08-08: "the
+        // budgeter just has all its parts figure it out") is claimed at embedder
+        // resolve via [`crate::resources::ResourceDaemon::reserve`], from the same
+        // module-level constants below.
         const EMBED_LANE_LEASE_TTL_MS: u64 = 60_000; // SIGKILL backstop; the RAII guard frees on drop
         let _vram_lease = {
             use crate::resources::{
@@ -1228,35 +1240,58 @@ impl AIProviderAdapter for LlamaCppAdapter {
                         ttl_ms: EMBED_LANE_LEASE_TTL_MS,
                         reclaim_policy: ReclaimPolicy::Pinned,
                     };
-                    match daemon.acquire_guarded(&req) {
-                        Ok(guard) => {
-                            crate::probe!(
-                                class = "embed.vram.leased",
-                                consumer = EMBED_LANE_CONSUMER_ID,
-                                bytes = EMBED_LANE_VRAM_BYTES,
-                                texts = texts.len(),
-                                "embedding lane acquired a governed VRAM lease"
-                            );
-                            Some(guard)
+                    // ONE bounded retry on a capacity refusal (never a loop —
+                    // [[brittleness-is-the-highest-priority-work-there-is]]): with
+                    // the standing floor reserved at resolve, a refusal here means
+                    // a TRANSIENT over-commit (a lane mid-relaunch, a burst), and
+                    // relief lands within a governor tick. The second refusal is
+                    // the honest failure.
+                    let mut refused: Option<u64> = None;
+                    let mut granted = None;
+                    for attempt in 0..2u8 {
+                        match daemon.acquire_guarded(&req) {
+                            Ok(guard) => {
+                                crate::probe!(
+                                    class = "embed.vram.leased",
+                                    consumer = EMBED_LANE_CONSUMER_ID,
+                                    bytes = EMBED_LANE_VRAM_BYTES,
+                                    texts = texts.len(),
+                                    retried = (attempt > 0),
+                                    "embedding lane acquired a governed VRAM lease"
+                                );
+                                granted = Some(guard);
+                                break;
+                            }
+                            Err(LeaseError::InsufficientCapacity { available, .. }) => {
+                                crate::probe!(
+                                    class = "embed.vram.refused",
+                                    requested = EMBED_LANE_VRAM_BYTES,
+                                    available = available,
+                                    attempt = attempt,
+                                    "embedding VRAM lease refused — failing loud, NOT emitting degenerate zeros"
+                                );
+                                refused = Some(available);
+                                if attempt == 0 {
+                                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                                }
+                            }
+                            Err(e) => {
+                                return Err(format!(
+                                    "embed: VRAM lease error ({e:?}) — refusing to embed ungoverned"
+                                ));
+                            }
                         }
-                        Err(LeaseError::InsufficientCapacity { available, .. }) => {
-                            crate::probe!(
-                                class = "embed.vram.refused",
-                                requested = EMBED_LANE_VRAM_BYTES,
-                                available = available,
-                                "embedding VRAM lease refused — failing loud, NOT emitting degenerate zeros"
-                            );
+                    }
+                    match granted {
+                        Some(guard) => Some(guard),
+                        None => {
+                            let available = refused.unwrap_or(0);
                             return Err(format!(
-                                "embed: VRAM lease refused — {} MiB requested, {} MiB governed-available. \
+                                "embed: VRAM lease refused twice — {} MiB requested, {} MiB governed-available. \
                                  Refusing to allocate an OOM-doomed embedding context (it would decode to \
                                  degenerate zeros). Free VRAM (tier down serving) and retry.",
                                 EMBED_LANE_VRAM_BYTES / (1024 * 1024),
                                 available / (1024 * 1024),
-                            ));
-                        }
-                        Err(e) => {
-                            return Err(format!(
-                                "embed: VRAM lease error ({e:?}) — refusing to embed ungoverned"
                             ));
                         }
                     }

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -2288,12 +2288,21 @@ pub fn governed_host_budget(resource_daemon: &ResourceDaemon) -> HostBudget {
 /// serving refuses rather than over-committing blind). A lock-free `watch`
 /// snapshot read, never the governor's accounting lock — safe on the hot tick.
 fn governed_vram_ceiling(resource_daemon: &ResourceDaemon) -> Option<u64> {
+    // Serving budgets from ITS OWN view of the board — global available minus
+    // every OTHER consumer's unmet reservation floor (`available_for`, the same
+    // math `acquire` enforces) — never the reservation-blind global number.
+    // #225 (Joel 2026-08-08: "the budgeter just has all its parts figure it
+    // out"): budgeting from the global figure let the serving window grow over
+    // the embed lane's 1792 MiB floor, leaving 604 MiB governed-available for a
+    // faculty cognition needs every turn — embedding fully dead while serving
+    // sat comfortable. The board row's existence still gates None ("governor
+    // hasn't reported" stays distinct from "zero bytes free").
     resource_daemon
         .board()
         .kinds
         .iter()
         .find(|k| k.kind == ResourceKind::Vram)
-        .map(|k| k.available_bytes)
+        .map(|_| resource_daemon.available_for(SERVING_CONSUMER_ID, ResourceKind::Vram))
 }
 
 /// The governed VRAM ceiling for a planner that has no way to represent "unknown",
@@ -4543,5 +4552,45 @@ mod tests {
             downshift_gate(&plan_for("qwen-0.5b"), None, &both),
             DownshiftVerdict::NotADownshift,
         );
+    }
+
+    // what this catches (#225, Joel 2026-08-08 "the budgeter just has all its
+    // parts figure it out"): serving's plan budget (`governed_vram_ceiling`)
+    // reads serving's OWN view of the board — global available minus every
+    // OTHER consumer's unmet reservation floor — so the plan can no longer size
+    // the window into the embed lane's slice and starve a faculty cognition
+    // needs every turn. Regression: reading the reservation-blind global
+    // `available_bytes` again would make this budget ignore the floor.
+    #[tokio::test]
+    async fn serving_budget_plans_around_other_consumers_floors() {
+        use crate::resources::{
+            DaemonConfig, GovernorConfig, MockCapacitySource, ResourceDaemon,
+        };
+        let src = Arc::new(MockCapacitySource::new(
+            crate::resources::ResourceKind::Vram,
+            10_000,
+        ));
+        let daemon = ResourceDaemon::start(
+            vec![src],
+            vec![],
+            DaemonConfig {
+                tick_interval: std::time::Duration::from_millis(20),
+                min_reclaim_budget: std::time::Duration::from_millis(100),
+                governor: GovernorConfig {
+                    min_dwell_ms: 0,
+                    graceful_grace_ms: 50,
+                },
+            },
+        );
+        // No floors → serving sees the whole board.
+        assert_eq!(governed_vram_ceiling(&daemon), Some(10_000));
+        // The embed lane claims its standing floor → serving's plannable view
+        // shrinks by exactly that slice; the board's Vram row still exists so
+        // the None ("governor hasn't reported") semantics are untouched.
+        daemon.reserve("embed", crate::resources::ResourceKind::Vram, 1_800);
+        assert_eq!(governed_vram_ceiling(&daemon), Some(8_200));
+        // Serving's own hypothetical floor would NOT count against itself.
+        daemon.reserve(SERVING_CONSUMER_ID, crate::resources::ResourceKind::Vram, 3_000);
+        assert_eq!(governed_vram_ceiling(&daemon), Some(8_200));
     }
 }

--- a/core/continuum-core/src/resources/daemon.rs
+++ b/core/continuum-core/src/resources/daemon.rs
@@ -298,6 +298,14 @@ impl ResourceDaemon {
         g.reserve(consumer_id, kind, min_bytes);
     }
 
+    /// This consumer's plannable headroom: global available minus every OTHER
+    /// consumer's unmet reservation floor — the same math `acquire` enforces,
+    /// exposed for BUDGETING so a planner sizes itself only into bytes it could
+    /// actually be granted (#225). A short governor-lock read, non-blocking.
+    pub fn available_for(&self, consumer_id: &str, kind: ResourceKind) -> u64 {
+        self.governor.lock().available_for(consumer_id, kind)
+    }
+
     /// Register a leaseholder after startup — no restart (the directive's
     /// "never restart a daemon to manage resources").
     pub fn add_consumer(&self, consumer: Arc<dyn ResourceConsumer>) {

--- a/core/continuum-core/src/resources/governor.rs
+++ b/core/continuum-core/src/resources/governor.rs
@@ -175,6 +175,17 @@ impl ResourceGovernor {
         self.ledger.reserve(consumer_id, kind, min_bytes);
     }
 
+    /// Headroom THIS consumer may plan against — the ledger's
+    /// [`available_for`](super::ledger::LeaseLedger::available_for): global
+    /// available minus every OTHER consumer's unmet reservation floor. The
+    /// budget-side twin of the guard `acquire` already enforces: a consumer that
+    /// PLANS from this number never sizes itself into bytes it would then be
+    /// refused (#225 — serving planned from reservation-blind `available`, grew
+    /// its window over the embed lane's floor, and embedding went dead).
+    pub fn available_for(&self, consumer_id: &str, kind: ResourceKind) -> u64 {
+        self.ledger.available_for(consumer_id, kind)
+    }
+
     // ---- the tick ----------------------------------------------------------
 
     /// The per-tick decision. For each kind, compute how many bytes must come


### PR DESCRIPTION
Per Joel's ruling ('the budgeter just has all its parts figure it out'): the reservation-floor machinery existed with zero production callers. Now: embedder resolve claims its 1792MiB floor → serving's plan budget reads `available_for("serving")` (net of others' floors, same math acquire enforces) → one bounded retry bridges transients. Regression test included; resources 137/137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo