### PR TITLE
feat(bench): failing-test output in retry verdicts + scale fact on destructive-edit refusals

### DIFF
--- a/core/continuum-core/src/code/file_engine.rs
+++ b/core/continuum-core/src/code/file_engine.rs
@@ -321,6 +321,27 @@ impl FileEngine {
                 path = %relative_path,
                 "edit refused — it would break the file's parse; file unchanged on disk"
             );
+            // SCALE fact (glass-boxed on sympy-22840 n7b, 2026-08-08): Benchy twice proposed
+            // replacing ~700 lines of cse_main.py with a 16-line rewrite of `cse()` that
+            // referenced helpers the file doesn't have — the gate refused (correctly), but
+            // nothing told her the SHAPE was wrong, so she tried the same wholesale rewrite
+            // again. The tool can PROVE the removal size, so state it: a bug fix is rarely
+            // a mass deletion. A fact about the edit, not a steer — same doctrine as the
+            // repair hint below.
+            let removed = old_content
+                .lines()
+                .count()
+                .saturating_sub(new_content.lines().count());
+            let scale_note = if removed >= 50 {
+                format!(
+                    "\nSCALE: this edit REMOVES ~{removed} lines of {relative_path}. Bug fixes \
+                     are usually a few lines — replace only the exact function or lines at \
+                     fault (read them first, then use a search_replace on that block), not a \
+                     large region.\n"
+                )
+            } else {
+                String::new()
+            };
             return Ok(WriteResult {
                 success: false,
                 change_id: None,
@@ -329,7 +350,8 @@ impl FileEngine {
                 error: Some(format!(
                     "EDIT REFUSED — it would have made {relative_path} unparseable. The file \
                      is UNCHANGED on disk; nothing was written and there is nothing to undo.\n\
-                     {}\n{}",
+                     {}{}\n{}",
+                    scale_note,
                     syntax_error_detail(&abs_path, &new_content).unwrap_or_default(),
                     // Don't just diagnose — AIM HER. The refusal used to say "widen the range",
                     // which is advice she has to act on blind. The same parser that proved the

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -109,6 +109,16 @@ pub struct SweVerdict {
     /// This is what the experience stream and the room verdict carry forward.
     #[serde(default)]
     pub failed_tests: Vec<String>,
+    /// The failing FAIL_TO_PASS run's OUTPUT tail (capped) — the assertion diff a
+    /// human reviewer would paste. Glass-boxed on atlas-sympy-24066-n4 (2026-08-08):
+    /// she synthesized ~90% of the gold patch and missed on one predicate
+    /// (`== Dimension(1)` vs `is_dimensionless`); the retry verdict named the
+    /// failing TEST but not what it PRINTED — the leftover
+    /// `Dimension(impedance*capacitance/time)` in the assertion output is the fact
+    /// that teaches equality isn't enough. Format-agnostic (a report TAIL, not a
+    /// parsed section) so sympy's own runner and pytest both carry it.
+    #[serde(default)]
+    pub failure_excerpt: Option<String>,
 }
 
 /// Where a detached benchmark run journals its state. One file per run, rewritten in place:
@@ -548,9 +558,9 @@ pub async fn run_tests(
     venv_py: &Path,
     ids: &[String],
     test_files: &[String],
-) -> HashMap<String, bool> {
+) -> (HashMap<String, bool>, String) {
     if test_files.is_empty() || ids.is_empty() {
-        return ids.iter().map(|i| (i.clone(), false)).collect();
+        return (ids.iter().map(|i| (i.clone(), false)).collect(), String::new());
     }
     let mut args: Vec<&str> = vec!["-m", "pytest"];
     for f in test_files {
@@ -558,7 +568,7 @@ pub async fn run_tests(
     }
     args.extend(["-v", "--no-header", "-rN", "-p", "no:cacheprovider"]);
     let Ok(out) = run(&venv_py.to_string_lossy(), &args, Some(repo_dir)).await else {
-        return ids.iter().map(|i| (i.clone(), false)).collect();
+        return (ids.iter().map(|i| (i.clone(), false)).collect(), String::new());
     };
     let report = format!(
         "{}{}",
@@ -566,9 +576,32 @@ pub async fn run_tests(
         String::from_utf8_lossy(&out.stderr)
     );
     let (by_node, by_func) = parse_pytest_report(&report);
-    ids.iter()
+    let verdicts = ids
+        .iter()
         .map(|id| (id.clone(), verdict_for(id, &by_node, &by_func).unwrap_or(false)))
-        .collect()
+        .collect();
+    // The report rides back so the grader can excerpt the FAILURE OUTPUT into the
+    // verdict — the assertion diff is the teaching half a bare test name lacks.
+    (verdicts, report)
+}
+
+/// Cap on the failure-output excerpt a verdict carries. Failures and the short
+/// summary sit at the END of a test run's output (pytest and sympy's own runner
+/// alike), so the TAIL is the format-agnostic excerpt. Bounded so a pathological
+/// run (a runaway traceback, a print loop) can't flood the retry prompt.
+const FAILURE_EXCERPT_MAX: usize = 2000;
+
+/// Tail of a test report, char-capped on a char boundary.
+fn report_tail(report: &str) -> String {
+    let trimmed = report.trim_end();
+    if trimmed.len() <= FAILURE_EXCERPT_MAX {
+        return trimmed.to_string();
+    }
+    let mut start = trimmed.len() - FAILURE_EXCERPT_MAX;
+    while !trimmed.is_char_boundary(start) {
+        start += 1;
+    }
+    format!("…{}", &trimmed[start..])
 }
 
 /// How many PASS_TO_PASS tests to sample. The full set runs to hundreds on some instances and
@@ -610,7 +643,7 @@ pub async fn grade(
         verdict.error = Some(e);
         return verdict;
     }
-    let pre = run_tests(repo_dir, &venv_py, &f2p, &test_files).await;
+    let (pre, _) = run_tests(repo_dir, &venv_py, &f2p, &test_files).await;
     let already: Vec<&String> = pre.iter().filter(|(_, ok)| **ok).map(|(id, _)| id).collect();
     verdict.gate_ok = already.is_empty();
     if !verdict.gate_ok {
@@ -634,8 +667,8 @@ pub async fn grade(
         return verdict;
     }
 
-    let f2p_res = run_tests(repo_dir, &venv_py, &f2p, &test_files).await;
-    let p2p_res = run_tests(repo_dir, &venv_py, &p2p, &test_files).await;
+    let (f2p_res, f2p_report) = run_tests(repo_dir, &venv_py, &f2p, &test_files).await;
+    let (p2p_res, _) = run_tests(repo_dir, &venv_py, &p2p, &test_files).await;
     verdict.f2p_passed = f2p_res.values().filter(|ok| **ok).count();
     verdict.p2p_passed = p2p_res.values().filter(|ok| **ok).count();
     verdict.failed_tests = f2p_res
@@ -645,6 +678,12 @@ pub async fn grade(
         .map(|(id, _)| id.clone())
         .collect();
     verdict.failed_tests.sort();
+    // Only when the target tests still fail: the run's output TAIL, where every
+    // runner puts its failures + summary. This is what turns "test_issue_24062
+    // failed" into "AssertionError: Dimension(impedance*capacitance/time) != 1".
+    if verdict.f2p_passed < verdict.f2p_total && !f2p_report.trim().is_empty() {
+        verdict.failure_excerpt = Some(report_tail(&f2p_report));
+    }
     verdict.resolved = verdict.f2p_passed == verdict.f2p_total
         && verdict.p2p_passed == verdict.p2p_total
         && verdict.f2p_total > 0;

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -423,6 +423,19 @@ impl ActionCommand for AgentSolve {
                                     } else {
                                         format!(" Failing tests: {}.", g.failed_tests.join(", "))
                                     };
+                                    // The OUTPUT half of the verdict (atlas-sympy-24066-n4,
+                                    // 2026-08-08): she rebuilt ~90% of the gold patch and
+                                    // missed on one predicate; the verdict named the failing
+                                    // test but not what it PRINTED. The assertion diff — the
+                                    // leftover `Dimension(impedance*capacitance/time)` — is
+                                    // the fact a next attempt reasons from. What a human
+                                    // reviewer would paste, so the grader pastes it.
+                                    let output = match g.failure_excerpt.as_deref() {
+                                        Some(x) if !x.trim().is_empty() => format!(
+                                            "\n\nFailing test output (what the test run printed):\n{x}\n"
+                                        ),
+                                        _ => String::new(),
+                                    };
                                     // A retry is a FRESH turn with fresh working memory, so
                                     // "the file you already identified" names knowledge the
                                     // next attempt does not have (glass-boxed 2026-08-08,
@@ -458,7 +471,7 @@ impl ActionCommand for AgentSolve {
                                              FAIL_TO_PASS {}/{}, PASS_TO_PASS {}/{}.{failing} \
                                              Your previous edits are still in this workspace.{edited}{trail} \
                                              Investigate why these tests fail — run them — then fix in place without \
-                                             breaking what passes.",
+                                             breaking what passes.{output}",
                                             g.fail_to_pass_passed,
                                             g.fail_to_pass_total,
                                             g.pass_to_pass_passed,

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1727,6 +1727,12 @@ pub struct SweGradeResult {
     /// next attempt) can actually chase.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub failed_tests: Vec<String>,
+    /// The failing FAIL_TO_PASS run's output tail (capped) — the assertion diff.
+    /// Names say WHICH test failed; this says WHAT it printed, which is the half
+    /// a next attempt (or a human reviewer) actually reasons from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub failure_excerpt: Option<String>,
 }
 
 impl From<(SweVerdict, usize)> for SweGradeResult {
@@ -1742,6 +1748,7 @@ impl From<(SweVerdict, usize)> for SweGradeResult {
             error: v.error,
             patch_bytes: patch_bytes as u32,
             failed_tests: v.failed_tests,
+            failure_excerpt: v.failure_excerpt,
         }
     }
 }

--- a/protocol/typescript/benchmark/SweGradeResult.ts
+++ b/protocol/typescript/benchmark/SweGradeResult.ts
@@ -28,4 +28,10 @@ patchBytes: number,
  * teaches nothing; a named test is what a human reviewer (or the citizen herself,
  * next attempt) can actually chase.
  */
-failedTests?: Array<string>, };
+failedTests?: Array<string>, 
+/**
+ * The failing FAIL_TO_PASS run's output tail (capped) — the assertion diff.
+ * Names say WHICH test failed; this says WHAT it printed, which is the half
+ * a next attempt (or a human reviewer) actually reasons from.
+ */
+failureExcerpt?: string, };


### PR DESCRIPTION
The two levers from today's near-misses: Atlas gets the assertion output her one-predicate miss needed; Benchy gets told a 700-line removal is the wrong shape for a bug fix. Both are facts the substrate already held, handed back at the moment of need. Tests green, binding regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo