### PR TITLE
feat(observability): lease lifecycle + attempt-verdict events — nothing load-bearing stays silent

### DIFF
--- a/core/continuum-core/src/cognition/exam_serving.rs
+++ b/core/continuum-core/src/cognition/exam_serving.rs
@@ -154,7 +154,7 @@ impl ExamServingContext {
             settled = settled.is_some(),
             "exam lane grown to Ludicrous (Performance) and settled before pinning"
         );
-        let steady = ServingSteadyHold::acquire();
+        let steady = ServingSteadyHold::acquire("eval");
         ExamHold {
             _ludicrous: ludicrous,
             _steady: steady,

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -277,7 +277,8 @@ impl ActionCommand for AgentSolve {
                 // error" when the post-boot window grow bounced the lane). A scored run is
                 // exactly the demand the hold exists for; a real pressure emergency still
                 // preempts (the hold only suppresses the optional grow, never a shrink).
-                let _steady = crate::modules::serving_daemon::ServingSteadyHold::acquire();
+                let _steady =
+                    crate::modules::serving_daemon::ServingSteadyHold::acquire(run_id.clone());
                 // N CHANCES: attempts loop. Each attempt is a full solve; a non-resolved
                 // auto-grade re-enters the SAME workspace with the verdict appended to the
                 // task (named failing tests — the teachable half of the grade). The loop
@@ -391,6 +392,28 @@ impl ActionCommand for AgentSolve {
                             .await;
                             match grade {
                                 Ok(g) => {
+                                    // attempt.end — the FULL verdict on the wire, the
+                                    // bookend of benchmark.attempt.start (Joel 2026-08-08:
+                                    // "emit events for everything — need to know"). Grades
+                                    // were file-only; every wire consumer (probe router →
+                                    // rooms, exam-room widgets, the pulse monitors) had to
+                                    // scrape the ledger to learn an attempt's outcome.
+                                    crate::probe!(
+                                        class = "benchmark.attempt.end",
+                                        run_id = %run_id,
+                                        instance = %instance,
+                                        attempt,
+                                        max_attempts,
+                                        resolved = g.resolved,
+                                        gate_ok = g.gate_ok,
+                                        f2p_passed = g.fail_to_pass_passed,
+                                        f2p_total = g.fail_to_pass_total,
+                                        p2p_passed = g.pass_to_pass_passed,
+                                        p2p_total = g.pass_to_pass_total,
+                                        patch_bytes = g.patch_bytes,
+                                        failed_tests = %g.failed_tests.join(","),
+                                        "solve attempt graded — the verdict, on the wire"
+                                    );
                                     crate::probe!(
                                         class = "benchmark.autograde",
                                         run_id = %run_id,

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -2213,18 +2213,40 @@ static SERVING_STEADY_HOLDS: AtomicUsize = AtomicUsize::new(0);
 /// "pin the lane for the demand's duration" clause ([[benchmark-is-a-governor-preemption-lease]],
 /// the co-tenant/steady case: no second weight copy, just don't bounce the lane).
 #[must_use = "the hold releases the instant this guard drops — bind it for the eval's lifetime"]
-pub struct ServingSteadyHold(());
+pub struct ServingSteadyHold {
+    /// WHO pinned the lane — a run id, "eval", etc. Carried so the acquire and
+    /// release EVENTS name the holder (Joel 2026-08-08: "emit events for
+    /// everything — need to know"): a suppressed relaunch with no event is
+    /// indistinguishable from a planner that never wanted one, and a leaked
+    /// hold with no holder name is unattributable.
+    holder: String,
+}
 
 impl ServingSteadyHold {
-    pub fn acquire() -> Self {
-        SERVING_STEADY_HOLDS.fetch_add(1, Ordering::AcqRel);
-        Self(())
+    pub fn acquire(holder: impl Into<String>) -> Self {
+        let holder = holder.into();
+        let holds = SERVING_STEADY_HOLDS.fetch_add(1, Ordering::AcqRel) + 1;
+        crate::probe!(
+            class = "serving.lane.hold",
+            action = "acquired",
+            holder = %holder,
+            holds,
+            "serving lane pinned STEADY (optional grow-back re-home suppressed while held)"
+        );
+        Self { holder }
     }
 }
 
 impl Drop for ServingSteadyHold {
     fn drop(&mut self) {
-        SERVING_STEADY_HOLDS.fetch_sub(1, Ordering::AcqRel);
+        let holds = SERVING_STEADY_HOLDS.fetch_sub(1, Ordering::AcqRel) - 1;
+        crate::probe!(
+            class = "serving.lane.hold",
+            action = "released",
+            holder = %self.holder,
+            holds,
+            "serving lane steady-hold released"
+        );
     }
 }
 
@@ -2971,10 +2993,10 @@ mod tests {
     fn serving_steady_hold_is_refcounted_and_raii() {
         assert!(!serving_held_steady(), "no hold at rest");
         {
-            let _h1 = ServingSteadyHold::acquire();
+            let _h1 = ServingSteadyHold::acquire("test");
             assert!(serving_held_steady(), "one hold ⇒ steady");
             {
-                let _h2 = ServingSteadyHold::acquire();
+                let _h2 = ServingSteadyHold::acquire("test");
                 assert!(serving_held_steady(), "two holds ⇒ still steady");
             }
             assert!(


### PR DESCRIPTION
Per Joel: emit events for everything. serving.lane.hold (acquired/released, named holder, live count) + benchmark.attempt.end (full verdict on the wire, bookending attempt.start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo