### PR TITLE
fix(bench): failing-test excerpt in the zero-diff retry arm too

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -490,7 +490,7 @@ impl ActionCommand for AgentSolve {
                                              Reading and searching cannot score; only an edit can. This attempt, go \
                                              straight to the file you already identified and apply your best-guess fix \
                                              with code/edit — a wrong edit earns failing-test feedback to iterate on; \
-                                             no edit earns nothing. Do not re-read what you have already read.",
+                                             no edit earns nothing. Do not re-read what you have already read.{output}",
                                         )
                                     } else {
                                         let edited = if r.files_changed.is_empty() {


### PR DESCRIPTION
Found on the lever's first live firing: the excerpt only rode the edits-exist arm; the zero-diff arm — where it makes the FIRST edit correct — lacked it. One format arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo