### PR TITLE
docs: README Grid serving section + expert-share shipped-status (the paging arc's code truth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,46 @@ continuum-core (Rust — 46 modules, 6,400+ tests)
 - **Trust levels** — Owner/Trusted/Provisional/Blocked with ACL enforcement and audit logging
 - **Node registry** — persistent, auto-discovered, with latency tracking
 
+### Serving big minds on small machines — MoE expert paging
+
+The Grid's hardest technical bet is now mostly code: **models larger than any one
+machine's memory, served by paging their experts** — the same virtual-memory idea
+that let 1980s computers run programs bigger than RAM, applied to mixture-of-experts
+weights, and eventually spread across the mesh. A modern MoE only *activates* a few
+experts per token; keep the hot ones resident at high precision, the warm ones at
+low precision, page the cold ones from disk — or from a peer.
+
+What's built and measured (our [llama.cpp fork](https://github.com/CambrianTech/llama.cpp) + `core/continuum-core/src/capacity/`):
+
+- **Kimi-Linear-48B generating at ~57 tok/s on a Mac** (Metal, via the fork's
+  converter + serving path) — a model tier that "doesn't fit" consumer hardware, running on it
+- **Zero-copy expert gather** (`MUL_MAT_ID` consume path) — 4.0× measured on Metal A/B,
+  bit-identical CUDA kernels; consume an expert from *any* location without staging copies
+- **4 KiB-aligned streaming expert container** — fixed-size records, one bank per layer,
+  per-layer files as the grid shard unit; precision **tiers are part of expert identity**
+  (a sharp copy and a cheap copy are different bytes, never aliased)
+- **LFRU expert cache with a measured cliff law** — below one token's working set a cache
+  has *structurally zero* hit rate, so the budget refuses loudly instead of thrashing silently
+- **Tier policy + demand predictor** — all-star experts stay sharp, the tail goes cheap,
+  hotness is measured per-prompt (it is *not* static), and the learned layer trains on
+  captured paging traces
+- **Expert depot** — each node serves its resident expert banks over a local seam and
+  publishes a manifest of exactly what it holds; misses fall back cleanly, so the depot
+  can degrade serving but never break it. This is the seam grid share rides: a node that
+  holds only layers 0–30 serves them to peers that don't
+- **Governed budgets end-to-end** — one per-machine resource authority; serving, embeddings,
+  benchmarks, and training lease from the same ledger with hysteresis on every decision
+
+The allocation math is written down too: **[nested λ-pricing](docs/architecture/GRID-MARKET-CLEARING.md)** —
+the pager's Lagrange multiplier *is* the price of a byte of residency, the same scalar that
+clears work between two nodes and later N (Kelly-style network utility maximization + backpressure;
+the math behind TCP and WiFi airtime scheduling). Design docs:
+[GRID-EXPERT-SHARE](docs/serving/GRID-EXPERT-SHARE.md) ·
+[GRID-ECONOMICS-AND-AFFINITY-ROUTING](docs/architecture/GRID-ECONOMICS-AND-AFFINITY-ROUTING.md) ·
+[GRID-MARKET-CLEARING](docs/architecture/GRID-MARKET-CLEARING.md).
+**Next proofs on deck:** live learned paging on a single box end-to-end, then the two-machine
+milestone — one node generating coherent tokens from experts that exist only on its peer's disk.
+
 ### Zero-trust by construction — airc answers WHO, forge-alloy answers WHAT
 
 The Grid assumes a zero-trust world and was built for it with two purpose-made projects:

--- a/docs/architecture/GRID-ECONOMICS-AND-AFFINITY-ROUTING.md
+++ b/docs/architecture/GRID-ECONOMICS-AND-AFFINITY-ROUTING.md
@@ -1,6 +1,9 @@
 # Grid Economics & Affinity Routing — why paged genome on cheap hardware beats one massive expert
 
-**Status:** thesis + build spec. Companion to
+**Status:** thesis + build spec. The clearing MECHANISM this thesis implies is now
+designed in [GRID-MARKET-CLEARING.md](GRID-MARKET-CLEARING.md) (nested λ-pricing,
+2026-08-08) — read that for the types/slices; this doc remains the economic argument.
+Companion to
 [INFERENCE-LANES-REALISTIC.md](INFERENCE-LANES-REALISTIC.md) (#109, the realistic
 one-base-N-lanes serving floor), [GENOME-FOUNDRY-SENTINEL.md](GENOME-FOUNDRY-SENTINEL.md)
 (L1–L5 genome cache, foundry, demand-aligned recall), and

--- a/docs/serving/GRID-EXPERT-SHARE.md
+++ b/docs/serving/GRID-EXPERT-SHARE.md
@@ -51,6 +51,10 @@ The depot can DEGRADE serving; it can never break it.
 resident-expert manifest (ExpertIds + artifact hashes + tier) on airc,
 refreshed on the recency cadence. No consumer yet. Validates: manifest size,
 churn rate, airc fit. *Exit: two nodes see each other's manifests.*
+**STATUS 2026-08-08: manifest derivation SHIPPED** (`capacity/expert_depot.rs`,
+PR #2195) — resident banks ONLY (a partial-shard node advertises exactly what
+it holds), container tier table passed through verbatim; `depot.manifest`
+probe emits on derivation. The airc publication *cadence* is the open tail.
 
 **Slice 1 — depot outlier A: localhost serve.** `expert_depot` module serves
 expert bytes by key over localhost HTTP from its own artifacts (mmap/container
@@ -58,6 +62,15 @@ readers already exist). Fork gains `GridFetcher` (`GGML_MOE_DEPOT_URL`):
 `fetch` = one GET, `fetch_many` = parallel GETs. Single machine, zero network
 unknowns. *Exit: `[MOE-PAGER]` parity (hit-rate, coherence, tok/s within
 noise) vs the mmap fetcher on OLMoE — proves the seam.*
+**STATUS 2026-08-08: depot side SHIPPED** (PR #2195) — `GET /manifest` +
+`GET /expert/{layer}/{expert}?tier=N` with `x-expert-sha256` per record (the
+slice-2 verify seam, priced in from the first localhost byte); miss semantics
+locked (absent shard / out-of-range → 404 fork-falls-back; geometry/identity
+violation → 500 loud); 4 socket-level tests. The fork-side `GridFetcher`
+adapter + the `[MOE-PAGER]` parity A/B are the open tail. Pricing addendum
+(same-day design, [GRID-MARKET-CLEARING](../architecture/GRID-MARKET-CLEARING.md)):
+the manifest grows an `advertised_cost` field (λ + transport class) in market
+slice S2 so slice-4 placement clears against a real price.
 
 **Slice 2 — grid resolve outlier B: the two-machine proof.** Depot resolves
 misses from peer depots (manifest lookup → direct GET → BLAKE3/SHA-256 verify


### PR DESCRIPTION
Joel: "Should update our docs and readme for this grid work. Have most of the code and algorithms now."

- README § The Grid gains **Serving big minds on small machines — MoE expert paging**: the shipped-and-measured inventory (fork + capacity/ module), λ-pricing design pointer, and the two next proofs explicitly named as *next*, not claimed.
- GRID-EXPERT-SHARE.md slices 0–1 stamped SHIPPED (PR #2195) with open tails named.
- GRID-ECONOMICS ↔ GRID-MARKET-CLEARING reciprocal link (thesis ↔ mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo