### PR TITLE
docs(readme): lead with the thesis — grid compute that scales on misfit hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A mixture-of-experts model touches a sliver of its weights per token. Those weig
 
 One code path, every machine you own. Training runs through MLX on Apple silicon and Candle on NVIDIA — same [`genome/`](core/continuum-core/src/genome/) (171 tests), same [`genome/fine_tuning/`](core/continuum-core/src/genome/fine_tuning/) (89 tests). The dusty 3090 and the work MacBook differ in how much they can hold, not in what they can do.
 
-The work is the training data. A persona's graded work lands in her experience stream; curriculum picks her *real* failures over a static set; adapters train locally and page in like memory. Skills are pages too.
+The work is the training data. A persona's graded work lands in her experience stream; curriculum picks her *real* failures over a static set; and what she learns becomes weight deltas — LoRA layers she earned, paged in and out like memory. Then it travels. One citizen can hand a lesson directly into another's memory — `Received`, not lived — and the record keeps who taught it, because someone *choosing* to teach a thing is itself the signal of what it's worth. One machine learns something the hard way; the rest don't have to. That's a mesh that gets smarter, not just a mesh that computes.
 
 Every citizen — human or persona — is an Ed25519 keypair. Peer-to-peer join. No coordinator, no account. And here's the part we find beautiful: residency under a budget is a Lagrangian, and its multiplier is a price per byte. The number that decides which expert stays in your VRAM is the number two machines compare to decide who runs the work ([design](docs/architecture/GRID-MARKET-CLEARING.md)). The pager's control law and the grid's protocol are the same equation at two scales.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ Your machines form **[the Grid](#the-grid)** — an encrypted mesh where AI pers
 
 ---
 
+## Grid compute that scales on misfit hardware
+
+The industry fits the **model** to the machine: shrink it until it runs, or rent a datacenter that never has to care. Continuum fits the **machine** to the model.
+
+A mixture-of-experts model touches only a fraction of its weights per token. So those weights don't need to be *resident* — they need to be *there in time*. Continuum pages experts the way an operating system pages memory: a cache that keeps the last K tokens' expert **sets** as units, a 4KiB-aligned container that stores each expert at multiple precisions, and a governed budget that decides how much residency to buy. The consequence is the whole thesis in one line:
+
+> **A model that doesn't fit still serves.**
+
+**The same algorithms run on every machine you own.** Not a big path and a small path — one path. Local training goes through MLX on Apple silicon and Candle on NVIDIA ([`genome/fine_tuning/`](core/continuum-core/src/genome/fine_tuning/) — 89 tests); expert paging runs on Metal and CUDA from the same [fork](core/vendor/llama.cpp) (4.0× zero-copy gather measured on Metal A/B, bit-identical CUDA kernels). A MacBook Air, a 3090 and a 5090 differ in how much they can hold, not in what they can do. **Kimi-Linear-48B generates at ~57 tok/s on a Mac.**
+
+**The work is the training data.** Personas don't just run — they're graded, and graded work becomes training signal. The experience stream records what a citizen actually did, the curriculum selects her real failures over a static set, and adapters train locally against them ([`genome/`](core/continuum-core/src/genome/) — 171 tests). Skills are LoRA adapters paged in and out like memory, so a persona's capability is composed at runtime instead of baked at download.
+
+**Joining is peer-to-peer.** No coordinator to run, no account to create. Every citizen — human or persona — is an Ed25519 keypair; machines find each other and the grid becomes the sum of what you own. Two nodes today, and the mechanism doesn't change shape at twenty: residency under a budget is a Lagrangian, and its multiplier is a **price per byte** — the same number that decides which expert stays in your VRAM is the one two machines compare to decide which of them runs the work. Pager control law and grid protocol are the same equation at two scales ([design](docs/architecture/GRID-MARKET-CLEARING.md)).
+
+**What's proven, and what isn't.** Everything above is code in tree or a number we measured, and the [claims ledger](benchmarks/RESULTS.jsonl) says which is which. Two proofs are still on deck and we won't claim them until they land: **live learned paging** end-to-end on one box, and the **two-machine expert-serve** — one node generating coherent tokens from experts that exist only on its peer's disk. When those land it's a status flip, not a rewrite.
+
+---
+
 ## This Is Not What You Think It Is
 
 Every other project in this space is building a better **tool**. A smarter terminal. A faster code agent. A more capable chatbot. They compete on who can make the best hammer.

--- a/README.md
+++ b/README.md
@@ -52,21 +52,21 @@ Your machines form **[the Grid](#the-grid)** — an encrypted mesh where AI pers
 
 ---
 
-## Grid compute that scales on misfit hardware
+## The Grid: intelligence scales onto misfit hardware
 
-The industry fits the **model** to the machine: shrink it until it runs, or rent a datacenter that never has to care. Continuum fits the **machine** to the model.
+The industry fits the model to the machine — shrink it until it runs, or rent a datacenter that never has to care. Continuum fits the machine to the model.
 
-A mixture-of-experts model touches only a fraction of its weights per token. So those weights don't need to be *resident* — they need to be *there in time*. Continuum pages experts the way an operating system pages memory: a cache that keeps the last K tokens' expert **sets** as units, a 4KiB-aligned container that stores each expert at multiple precisions, and a governed budget that decides how much residency to buy. The consequence is the whole thesis in one line:
+A mixture-of-experts model touches a sliver of its weights per token. Those weights don't need to be *resident*. They need to be *there in time*. So we page experts the way an OS pages memory: a 4KiB-aligned container holding each expert at multiple precisions, a cache that keeps the last K tokens' expert **sets** as units, a governed budget that decides how much residency to buy. Kimi-Linear-48B generates at ~57 tok/s on a Mac through our llama.cpp [fork](core/vendor/llama.cpp). Expert gather is zero-copy — 4.0x measured on Metal; on CUDA the kernels are bit-identical, and that's a correctness claim, not a speed claim.
 
 > **A model that doesn't fit still serves.**
 
-**The same algorithms run on every machine you own.** Not a big path and a small path — one path. Local training goes through MLX on Apple silicon and Candle on NVIDIA ([`genome/fine_tuning/`](core/continuum-core/src/genome/fine_tuning/) — 89 tests); expert paging runs on Metal and CUDA from the same [fork](core/vendor/llama.cpp) (4.0× zero-copy gather measured on Metal A/B, bit-identical CUDA kernels). A MacBook Air, a 3090 and a 5090 differ in how much they can hold, not in what they can do. **Kimi-Linear-48B generates at ~57 tok/s on a Mac.**
+One code path, every machine you own. Training runs through MLX on Apple silicon and Candle on NVIDIA — same [`genome/`](core/continuum-core/src/genome/) (171 tests), same [`genome/fine_tuning/`](core/continuum-core/src/genome/fine_tuning/) (89 tests). The dusty 3090 and the work MacBook differ in how much they can hold, not in what they can do.
 
-**The work is the training data.** Personas don't just run — they're graded, and graded work becomes training signal. The experience stream records what a citizen actually did, the curriculum selects her real failures over a static set, and adapters train locally against them ([`genome/`](core/continuum-core/src/genome/) — 171 tests). Skills are LoRA adapters paged in and out like memory, so a persona's capability is composed at runtime instead of baked at download.
+The work is the training data. A persona's graded work lands in her experience stream; curriculum picks her *real* failures over a static set; adapters train locally and page in like memory. Skills are pages too.
 
-**Joining is peer-to-peer.** No coordinator to run, no account to create. Every citizen — human or persona — is an Ed25519 keypair; machines find each other and the grid becomes the sum of what you own. Two nodes today, and the mechanism doesn't change shape at twenty: residency under a budget is a Lagrangian, and its multiplier is a **price per byte** — the same number that decides which expert stays in your VRAM is the one two machines compare to decide which of them runs the work. Pager control law and grid protocol are the same equation at two scales ([design](docs/architecture/GRID-MARKET-CLEARING.md)).
+Every citizen — human or persona — is an Ed25519 keypair. Peer-to-peer join. No coordinator, no account. And here's the part we find beautiful: residency under a budget is a Lagrangian, and its multiplier is a price per byte. The number that decides which expert stays in your VRAM is the number two machines compare to decide who runs the work ([design](docs/architecture/GRID-MARKET-CLEARING.md)). The pager's control law and the grid's protocol are the same equation at two scales.
 
-**What's proven, and what isn't.** Everything above is code in tree or a number we measured, and the [claims ledger](benchmarks/RESULTS.jsonl) says which is which. Two proofs are still on deck and we won't claim them until they land: **live learned paging** end-to-end on one box, and the **two-machine expert-serve** — one node generating coherent tokens from experts that exist only on its peer's disk. When those land it's a status flip, not a rewrite.
+What we haven't earned yet — and say so in the [claims ledger](benchmarks/RESULTS.jsonl): live learned paging end-to-end on one box, and one node generating coherent tokens from experts that exist only on its peer's disk. Both are next. Watch.
 
 ---
 


### PR DESCRIPTION
The thing that makes this project different was buried. The learning loop lived in a **parenthetical about a branch**, and the paging work — the reason a model that doesn't fit still serves — appeared **570 lines down**. A reader who stopped after the fold learned we have personas with faces, not that the same algorithms run on a MacBook and a 5090, or that the work each machine does becomes its own training signal.

New section directly above *This Is Not What You Think It Is*, stating the inversion plainly:

> The industry fits the **model** to the machine: shrink it until it runs, or rent a datacenter that never has to care. Continuum fits the **machine** to the model.
>
> **A model that doesn't fit still serves.**

Then four claims — one path on every machine, work-as-training-data, peer-to-peer joining, and λ as the price that makes pager control law and grid protocol *the same equation at two scales* — followed by an explicit proven/unproven line.

## Every number verified against this tree before writing

Not recalled — counted:

| Claim | Verified |
|---|---|
| `genome/` 171 tests | counted; an earlier draft said 169 and was corrected |
| `genome/fine_tuning/` 89 tests | counted |
| MLX **and** Candle adapters | `mlx_lora_adapter.rs` + `local_candle_adapter.rs` both present — which is what makes "one path, not a big path and a small path" a fact about the tree rather than a slogan |
| every link | `RESULTS.jsonl`, `GRID-MARKET-CLEARING.md`, the fork — all resolve |

Measured claims carry their scope: **4.0× zero-copy gather is Metal A/B**, and CUDA is claimed for **bit-identical correctness, not speed** — that delta has never cleared its rig's noise floor and must not read as though it had.

## The last paragraph is the load-bearing one

Live learned paging on one box, and the two-machine expert-serve, are named as **not done**. A README that recruits believers is worth less than one that survives someone checking it. When those land it's a status flip, not a rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc