### PR TITLE
feat(web): Academy bench board slice 1 — purpose + renderer + real-fixture spec

### DIFF
--- a/apps/web/src/bench/renderBench.spec.ts
+++ b/apps/web/src/bench/renderBench.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * renderBench (Lit) unit spec — the bench board's render seam.
+ *
+ * Same discipline as renderChat.spec: DOM-free, flatten the template tree and
+ * assert every model fact reaches the markup. The fixture is NOT invented —
+ * every row is cut from 2026-08-08's REAL receipts (probe stream + captures),
+ * which makes this spec double as the first recorded-stream regression
+ * artifact for the universe seam ([[universes-are-positron-asset-payloads]]):
+ * a future universe renders THIS SAME body and diffs against its own snapshot.
+ *
+ * The three facts that must never regress:
+ *  1. REGRESSION leads visibly when a patch broke pass-to-pass tests
+ *     (the hidden-collateral lesson, atlas-24066-n7).
+ *  2. A run before its first generation says "no generations yet" — queued is
+ *     never dressed as work (the 50-minute ambiguity, n8/n11 launch hour).
+ *  3. A citizen-claimed run is marked on the same board as operator runs
+ *     (the invisible-contention lesson, claim-a6d6d166).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { BenchContentBody } from '@continuum/patterns';
+import { renderBench } from './renderBench';
+
+/** Flatten a Lit TemplateResult tree into its static strings + stringified
+ *  interpolations (the renderChat.spec technique — no DOM, no SSR). */
+function flatten(node: unknown, out: string[] = []): string[] {
+  if (node == null || node === false) return out;
+  if (Array.isArray(node)) {
+    for (const child of node as readonly unknown[]) flatten(child, out);
+    return out;
+  }
+  if (typeof node === 'object' && 'strings' in (node as object) && 'values' in (node as object)) {
+    // Interleave statics with their interpolations so ORDER survives —
+    // template semantics are strings[0] v[0] strings[1] v[1] … strings[n].
+    const t = node as { strings: readonly string[]; values: readonly unknown[] };
+    for (let i = 0; i < t.values.length; i++) {
+      out.push(t.strings[i] ?? '');
+      flatten(t.values[i], out);
+    }
+    out.push(t.strings[t.strings.length - 1] ?? '');
+    return out;
+  }
+  out.push(String(node));
+  return out;
+}
+
+/** 2026-08-08's real hour, as a body: Atlas's regression round terminal,
+ *  Benchy's harmless-patch round terminal, the n8 relaunch queued behind the
+ *  citizen's self-claimed flask run — under 2-serving/4-demanding pressure. */
+const REAL_HOUR: BenchContentBody = {
+  feedLive: true,
+  lanePressure: { serving: 2, demanding: 4 },
+  runs: [
+    {
+      runId: 'atlas-sympy-24066-n8',
+      instance: 'sympy__sympy-24066',
+      persona: 'Atlas',
+      selfClaimed: false,
+      attempt: 1,
+      maxAttempts: 3,
+      state: 'queued',
+      generations: 0,
+      lastGenAgeS: null,
+      editActs: 0,
+      patchBytes: null,
+    },
+    {
+      runId: 'claim-a6d6d166-a2c5-4350-94eb-7b6f420dc945',
+      instance: 'flask-4045',
+      persona: 'Casper',
+      selfClaimed: true,
+      attempt: 3,
+      maxAttempts: 3,
+      state: 'failed',
+      generations: 12,
+      lastGenAgeS: 95,
+      editActs: 2,
+      patchBytes: 0,
+      verdict: {
+        resolved: false,
+        f2pPassed: 0,
+        f2pTotal: 2,
+        p2pPassed: 30,
+        p2pTotal: 30,
+        regression: false,
+        failedTests: ['tests/test_cli.py::TestRoutes::test_host'],
+      },
+    },
+    {
+      runId: 'atlas-sympy-24066-n7',
+      instance: 'sympy__sympy-24066',
+      persona: 'Atlas',
+      selfClaimed: false,
+      attempt: 3,
+      maxAttempts: 3,
+      state: 'failed',
+      generations: 41,
+      lastGenAgeS: 3600,
+      editActs: 3,
+      patchBytes: 2003,
+      verdict: {
+        resolved: false,
+        f2pPassed: 0,
+        f2pTotal: 1,
+        p2pPassed: 0,
+        p2pTotal: 30,
+        regression: true,
+        failedTests: ['test_Quantity_definition', 'test_issue_24062'],
+      },
+    },
+  ],
+};
+
+describe('renderBench', () => {
+  it('renders every fact of the real 2026-08-08 hour, with regression leading as an alarm', () => {
+    const text = flatten(renderBench(REAL_HOUR)).join(' ');
+
+    // NOTE: flattened Lit templates separate interpolations from static strings,
+    // so adjacency is asserted whitespace-tolerantly (\s+), never as substrings.
+
+    // fact 1 — the regression alarm: count of broken p2p, alarm class, names.
+    expect(text).toContain('REGRESSION');
+    expect(text).toMatch(/30\s+broken/); // p2pTotal 30 - p2pPassed 0
+    expect(text).toContain('bench-verdict-regression');
+    expect(text).toContain('test_Quantity_definition');
+
+    // fact 2 — queued honesty: the relaunched run shows its truth, not a pulse.
+    expect(text).toContain('no generations yet');
+    expect(text).toMatch(/bench-state-\s*queued/);
+
+    // fact 3 — the self-claimed run is on the SAME board, marked.
+    expect(text).toContain('self-claimed');
+    expect(text).toContain('flask-4045');
+    expect(text).toContain('Casper');
+
+    // progress facts reach markup: gens+age, edits, patch bytes, attempts, counts.
+    expect(text).toMatch(/41\s+gens/);
+    expect(text).toMatch(/60m0s\s+ago/);
+    expect(text).toMatch(/3\s+edits/);
+    expect(text).toContain('2003');
+    expect(text).toMatch(/attempt\s+3\s*\/\s*3/);
+    expect(text).toMatch(/f2p\s+0\s*\/\s*2/);
+
+    // lane pressure — the contention that took probe archaeology to see.
+    expect(text).toMatch(/2\s+serving/);
+    expect(text).toMatch(/4\s+demanding/);
+
+    // no fabricated verdict on the queued run: exactly two verdict cells.
+    expect(text.split('bench-verdict ').length - 1).toBe(2);
+  });
+
+  it('renders the awaiting frame on an empty board and the snapshot banner off-feed', () => {
+    const empty = flatten(renderBench({ runs: [], feedLive: false })).join(' ');
+    expect(empty).toContain('No benchmark runs');
+    expect(empty).toContain('frame is the promise');
+
+    const snapshot = flatten(
+      renderBench({ ...REAL_HOUR, feedLive: false }),
+    ).join(' ');
+    expect(snapshot).toContain('snapshot — no live feed attached');
+  });
+});

--- a/apps/web/src/bench/renderBench.ts
+++ b/apps/web/src/bench/renderBench.ts
@@ -1,0 +1,85 @@
+/**
+ * `renderBench` — the web renderer for the Academy's live BENCHMARK BOARD
+ * (`purpose="bench"`, #374/#329: a benchmark IS a live room).
+ *
+ * One row per run — operator-launched and citizen-claimed on the SAME board
+ * (the 2026-08-08 contention hour, made one glance). Every cell reports
+ * PROGRESS, never bare liveness: generations + last-generation age, edit
+ * acts, patch bytes, attempt, and the graded verdict — with a pass-to-pass
+ * REGRESSION rendered as the alarm it is (the hidden-collateral lesson:
+ * buried in a count it taught "not fixed yet" when the truth was "destroyed
+ * the tree").
+ *
+ * Honesty rules (same contract as serving/arena): no runs → the awaiting
+ * frame; `feedLive` false → the "snapshot" banner; a run before its first
+ * generation renders the literal "no generations yet" — a QUEUED state is
+ * shown as queued, never dressed as work ([[honest presence]]: never look
+ * alive when you are not).
+ */
+
+import { html, nothing, type TemplateResult } from 'lit';
+import type { BenchContentBody, BenchRunVM, BenchVerdictVM } from '@continuum/patterns';
+
+/** Compact seconds → "12s" / "3m40s" — board legibility, not precision. */
+function age(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m${seconds % 60}s`;
+}
+
+function verdictCell(v: BenchVerdictVM): TemplateResult {
+  const cls = v.resolved ? 'bench-verdict-pass' : v.regression ? 'bench-verdict-regression' : 'bench-verdict-fail';
+  return html`<span class="bench-verdict ${cls}">
+    ${v.resolved ? html`<span class="bench-resolved">RESOLVED</span>` : nothing}
+    ${v.regression
+      ? html`<span class="bench-alarm" title="the patch broke previously-passing tests">
+          REGRESSION ${v.p2pTotal - v.p2pPassed} broken</span>`
+      : nothing}
+    <span class="bench-counts" title="fail-to-pass / pass-to-pass">
+      f2p ${v.f2pPassed}/${v.f2pTotal} · p2p ${v.p2pPassed}/${v.p2pTotal}</span>
+    ${v.failedTests.length > 0
+      ? html`<span class="bench-failed" title=${v.failedTests.join(', ')}>
+          ${v.failedTests[0]}${v.failedTests.length > 1 ? ` +${v.failedTests.length - 1}` : ''}</span>`
+      : nothing}
+  </span>`;
+}
+
+function runRow(run: BenchRunVM): TemplateResult {
+  const pulse =
+    run.lastGenAgeS === null
+      ? html`<span class="bench-nogen" title="attempt started; first generation not completed">no generations yet</span>`
+      : html`<span class="bench-pulse" title="generations this attempt · age of latest">
+          ${run.generations} gens · ${age(run.lastGenAgeS)} ago</span>`;
+  return html`<div class="bench-row bench-state-${run.state}">
+    <span class="bench-who">
+      <span class="bench-persona">${run.persona}</span>
+      ${run.selfClaimed ? html`<span class="bench-selfclaimed" title="claimed off the work board by the citizen herself">self-claimed</span>` : nothing}
+    </span>
+    <span class="bench-instance" title=${run.runId}>${run.instance}</span>
+    <span class="bench-attempt">attempt ${run.attempt}/${run.maxAttempts}</span>
+    <span class="bench-state">${run.state}</span>
+    ${pulse}
+    <span class="bench-acts" title="edit/write acts — a patch forming">${run.editActs} edits</span>
+    ${run.patchBytes !== null
+      ? html`<span class="bench-patch">${run.patchBytes}B patch</span>`
+      : nothing}
+    ${run.verdict ? verdictCell(run.verdict) : nothing}
+  </div>`;
+}
+
+/** The bench board content — pure fragments of the projected body. */
+export function renderBench(body: BenchContentBody): TemplateResult {
+  if (body.runs.length === 0) {
+    return html`<div class="bench-awaiting">
+      <p>No benchmark runs on this board yet.</p>
+      <p class="bench-awaiting-sub">Rows appear when a run starts — operator-launched or claimed by a citizen. The frame is the promise.</p>
+    </div>`;
+  }
+  return html`<div class="bench-board">
+    ${body.feedLive ? nothing : html`<div class="bench-snapshot-banner">snapshot — no live feed attached</div>`}
+    ${body.lanePressure
+      ? html`<div class="bench-lanes" title="serving lanes vs lanes of demand — contention at a glance">
+          lanes ${body.lanePressure.serving} serving · ${body.lanePressure.demanding} demanding</div>`
+      : nothing}
+    ${body.runs.map(runRow)}
+  </div>`;
+}

--- a/apps/web/src/content/registry.ts
+++ b/apps/web/src/content/registry.ts
@@ -11,12 +11,14 @@
 import { html, type TemplateResult } from 'lit';
 import {
   ARENA_PURPOSE,
+  BENCH_PURPOSE,
   createContentRegistry,
   LIVE_PURPOSE,
   GRID_PURPOSE,
   PERSONA_PURPOSE,
   SERVING_PURPOSE,
   type ArenaContentBody,
+  type BenchContentBody,
   type ContentRegistry,
   type GridContentBody,
   type LiveContentBody,
@@ -28,6 +30,7 @@ import { modelCell, type ForgeContentBody } from '@continuum/foundry-view';
 import { listingCell, messageRow } from '../render/parts';
 import { renderPersona } from '../persona/renderPersona';
 import { renderLive } from '../live/renderLive';
+import { renderBench } from '../bench/renderBench';
 import { renderArena } from '../arena/renderArena';
 import { renderServing } from '../serving/renderServing';
 import { renderGrid } from '../grid/renderGrid';
@@ -73,6 +76,9 @@ webContentRegistry.register<ArenaContentBody>(ARENA_PURPOSE, (body) => renderAre
 // The SERVING console — per-node control-loop panels center-stage, dispatched
 // when the room recipe's purpose is "serving" (the machine room, full view).
 webContentRegistry.register<ServingContentBody>(SERVING_PURPOSE, (body) => renderServing(body));
+// The Academy's live BENCHMARK BOARD — one progress row per run, operator and
+// citizen-claimed alike, dispatched when the room recipe's purpose is "bench".
+webContentRegistry.register<BenchContentBody>(BENCH_PURPOSE, (body) => renderBench(body));
 // The GRID view — every node's panel (resources + serving), the NODES
 // strip's full activity, dispatched when the room's purpose is "grid".
 webContentRegistry.register<GridContentBody>(GRID_PURPOSE, (body) => renderGrid(body));

--- a/packages/patterns/benchContent.ts
+++ b/packages/patterns/benchContent.ts
@@ -1,0 +1,88 @@
+/**
+ * The `bench` activity's neutral `Content` body — the Academy's live benchmark
+ * board (#374/#329: a benchmark IS a live room; the run rows ARE the panel).
+ *
+ * One row per active or recently-graded run — operator-launched AND
+ * citizen-claimed on the SAME board (2026-08-08: an autonomous claim-run
+ * contended invisibly with two operator rounds for two lanes, and only probe
+ * archaeology surfaced it; on this board that hour is one glance). Each row
+ * carries PROGRESS, never just liveness ([[a-serving-health-status-signal-
+ * that-reports-liveness-instead-of-progress]] applied to benchmarks):
+ * generations completed, age of the last one, edit acts, patch bytes, and the
+ * verdict when graded — with a pass-to-pass REGRESSION rendered as the alarm
+ * it is, never folded into a count.
+ *
+ * Shapes only: consumer-neutral, DOM-free, ANSI-free. The web/tui/desktop
+ * renderers (and later every universe skin — the SCADA face is universe A)
+ * are pure functions of this body; the recorded-fixture specs regression-test
+ * exactly that seam.
+ */
+
+/** The `Content` purpose key the bench board dispatches on. A room recipe
+ *  declaring this purpose IS a benchmark room (academy/bench/<run>). */
+export const BENCH_PURPOSE = 'bench';
+
+/** A graded attempt's verdict — the teachable facts, not just the counts. */
+export interface BenchVerdictVM {
+  readonly resolved: boolean;
+  readonly f2pPassed: number;
+  readonly f2pTotal: number;
+  readonly p2pPassed: number;
+  readonly p2pTotal: number;
+  /** True when the patch broke previously-passing tests — the board renders
+   *  this as an ALARM (the hidden-collateral lesson: a regression buried in a
+   *  count taught "not fixed yet" when the truth was "destroyed the tree"). */
+  readonly regression: boolean;
+  /** Failed test NAMES (capped upstream) — a verdict that can teach. */
+  readonly failedTests: readonly string[];
+}
+
+/** How a run's row reads RIGHT NOW. `queued` and `working` are distinct on
+ *  purpose — the 2026-08-08 contention hour was 50 minutes of ambiguity
+ *  between exactly those two states. */
+export type BenchRunState =
+  | 'queued' // attempt started, no generation completed yet
+  | 'working' // generations flowing
+  | 'grading' // attempt ended, verdict pending
+  | 'resolved' // terminal: a graded attempt passed
+  | 'failed' // terminal: final attempt graded, not resolved
+  | 'stalled'; // watchdog fired — infra fault, never a capability verdict
+
+/** One benchmark run — one board row. */
+export interface BenchRunVM {
+  readonly runId: string;
+  /** Instance under test ("sympy__sympy-24066"). */
+  readonly instance: string;
+  /** The citizen working it ("Atlas") — the board shows WHO, always. */
+  readonly persona: string;
+  /** True when a citizen claimed this off the work board herself (vs an
+   *  operator launch) — self-directed study is marked, never hidden. */
+  readonly selfClaimed: boolean;
+  readonly attempt: number;
+  readonly maxAttempts: number;
+  readonly state: BenchRunState;
+  /** Generations completed this attempt. */
+  readonly generations: number;
+  /** Seconds since the last completed generation; null before the first —
+   *  renders as the honest "no generations yet", never a fabricated pulse. */
+  readonly lastGenAgeS: number | null;
+  /** Edit/write acts so far — the leading indicator a patch is forming. */
+  readonly editActs: number;
+  /** Workspace diff size at last grading; null before any grade. */
+  readonly patchBytes: number | null;
+  /** Last graded attempt's verdict, when one exists. */
+  readonly verdict?: BenchVerdictVM;
+}
+
+/** The bench board's content body. */
+export interface BenchContentBody {
+  /** Rows, most recently active first. Empty = the awaiting frame (the frame
+   *  is the promise). */
+  readonly runs: readonly BenchRunVM[];
+  /** Lane pressure while runs contend — serving vs demanding lane counts from
+   *  the live plan; absent when no serving feed. */
+  readonly lanePressure?: { readonly serving: number; readonly demanding: number };
+  /** True only when a live probe stream is attached — a static projection
+   *  renders the honest "snapshot" banner (same contract as serving/arena). */
+  readonly feedLive: boolean;
+}

--- a/packages/patterns/index.ts
+++ b/packages/patterns/index.ts
@@ -48,6 +48,11 @@ export type { ServingContentBody, ServingNodeVM } from './servingContent';
 // strip's full activity: every node's resources + serving, SCADA-style.
 export { GRID_PURPOSE } from './gridContent';
 export type { GridContentBody, GridNodeVM } from './gridContent';
+
+// The Academy's live BENCHMARK BOARD (`purpose === BENCH_PURPOSE`) — one row
+// per run (operator + citizen-claimed), progress-not-liveness (#374/#329).
+export { BENCH_PURPOSE } from './benchContent';
+export type { BenchContentBody, BenchRunVM, BenchRunState, BenchVerdictVM } from './benchContent';
 export type {
   LiveContentBody,
   LiveParticipantVM,


### PR DESCRIPTION
BENCH_PURPOSE content body (progress-not-liveness shapes), renderBench with the honesty rules (queued never dressed as work, REGRESSION as alarm, self-claimed runs marked on the same board), registered in the one content registry. Spec fixture cut from 2026-08-08's real receipts — doubles as the first universe-seam regression artifact. 2/2 specs, tsc clean.

Next named slices: live probe-stream feed; preview fixture + cross-platform screenshots (macOS here, Windows via BigMama).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo