### PR TITLE
fix(bench): bounded + probed lane acquisition — kill the silent 2h park

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -243,7 +243,13 @@ where
         return Ok(existing);
     }
     // Slow path: serialize cold-spawns so bringups never fight for the GPU.
+    // The gate wait is PROBED on both sides (n8/n11 stall, 2026-08-08): a fork
+    // queued behind a wedged bringup was indistinguishable from one that never
+    // asked — gate_wait with no matching gate_held IS the "parked on the mutex"
+    // receipt.
+    crate::probe!(class = "eval.lane.acquire", step = "gate_wait", key = %key, "cold-spawn gate: waiting");
     let _gate = EVAL_LANE_SPAWN_GATE.lock().await;
+    crate::probe!(class = "eval.lane.acquire", step = "gate_held", key = %key, "cold-spawn gate: held");
     // Re-check under the gate — a racer for the same key may have spawned it while we
     // waited, in which case we share theirs and skip a redundant cold-load.
     if let Some(existing) = lookup_warm_eval_lane(key) {
@@ -949,7 +955,26 @@ async fn share_live_serving_lane(
     let mut adapter = crate::ai::openai_adapter::OpenAICompatibleAdapter::from_registry(PROVIDER_ID)
         .with_runtime_base_url(snap.base_url.clone())
         .with_default_model(base.id.clone());
-    adapter.initialize().await.ok()?;
+    // BOUNDED: this initialize is an HTTP round-trip against the LIVE lane, and this
+    // server is documented (the /lora-adapters lesson above) to block non-completion
+    // endpoints while generating. A share CHECK must never park acquisition — if the
+    // busy lane can't answer briefly, fall through to the cold path LOUDLY instead of
+    // hanging the solve prelude (n8/n11, 2026-08-08: 2h+ parked with three candidate
+    // parks and this round-trip among them).
+    const SHARE_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+    match tokio::time::timeout(SHARE_CHECK_TIMEOUT, adapter.initialize()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(_)) => return None,
+        Err(_) => {
+            crate::probe!(
+                class = "eval.lane.acquire",
+                step = "share_check_timeout",
+                model = %base.id,
+                "live-lane share check blocked past its bound (busy lane) — falling to cold path"
+            );
+            return None;
+        }
+    }
 
     emit_eval_phase(
         "loading_lane",

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -651,7 +651,54 @@ impl AgentSolve {
 
         // 1) Stand up a dedicated measurement lane for the model (her genome pages in on top),
         //    exactly as cognition/eval does — held for the whole drive, dropped after.
-        let lane = crate::cognition::eval::spawn_base_eval_lane(&p.base_model_id).await?;
+        //
+        //    BOUNDED, loudly (glass-boxed 2026-08-08, n8/n11: both forks sat 2h+ with
+        //    ZERO generations, parked somewhere inside lane acquisition — three
+        //    candidate parks (warm-pool spawn gate held by a wedged cold-load; the
+        //    share-check's adapter.initialize() HTTP round-trip against a saturated
+        //    lane, whose sibling endpoint is DOCUMENTED to block mid-generation;
+        //    pressure defer) and no receipt discriminated them because the whole
+        //    acquisition was one silent await. The timeout converts any park into a
+        //    loud named error; the bracket probes make the NEXT stall name its line.
+        crate::probe!(
+            class = "benchmark.solve.phase",
+            run_id = %run_id.as_deref().unwrap_or("-"),
+            phase = "lane_acquire.start",
+            base_model = %p.base_model_id,
+            "solve prelude: acquiring measurement lane"
+        );
+        const LANE_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+        let lane = match tokio::time::timeout(
+            LANE_ACQUIRE_TIMEOUT,
+            crate::cognition::eval::spawn_base_eval_lane(&p.base_model_id),
+        )
+        .await
+        {
+            Ok(lane) => lane?,
+            Err(_) => {
+                crate::probe!(
+                    class = "benchmark.solve.phase",
+                    run_id = %run_id.as_deref().unwrap_or("-"),
+                    phase = "lane_acquire.timeout",
+                    base_model = %p.base_model_id,
+                    "lane acquisition exceeded its bound — INFRA fault, run ends loudly"
+                );
+                return Err(CommandError::Internal(format!(
+                    "measurement-lane acquisition for '{}' exceeded {}s — an infra \
+                     stall (spawn gate, share-check HTTP, or pressure defer), never a \
+                     capability verdict. See eval.lane.* / benchmark.solve.phase probes \
+                     for the parked step.",
+                    p.base_model_id,
+                    LANE_ACQUIRE_TIMEOUT.as_secs()
+                )));
+            }
+        };
+        crate::probe!(
+            class = "benchmark.solve.phase",
+            run_id = %run_id.as_deref().unwrap_or("-"),
+            phase = "lane_acquire.done",
+            "solve prelude: lane acquired"
+        );
 
         // 2) Fork her WHOLE cognition onto that lane, rooted at the workspace: tools ON, recall ON.
         //    A brief wait covers the post-spawn template race (same as the eval fork-waiter).


### PR DESCRIPTION
n8/n11 sat 2h13m with zero generations, parked in lane acquisition with three candidate parks and no discriminating receipt. Fix per the bisect-instrument doctrine: 15-min loud timeout around the whole acquisition (infra fault, never capability), phase probes bracketing it, gate_wait/gate_held probes on the cold-spawn mutex, and a 20s bound on the share-check's HTTP initialize (documented-blocking endpoint class) falling loudly to the cold path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo