### PR TITLE
feat(bench): hash-anchored attempt-patch receipts (#379)

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -392,6 +392,41 @@ impl ActionCommand for AgentSolve {
                                 .file_name()
                                 .map(|s| s.to_string_lossy().to_string())
                                 .unwrap_or_default();
+                            // #379: the attempt's PATCH is a receipt, not a transient.
+                            // Read the exact candidate the grader is about to read (same
+                            // helper — one definition of "her diff"), persist it beside
+                            // the run's captures, and put its sha256 on the wire. Round D
+                            // (2026-08-08) needed "is att3 byte-identical to att2?" and
+                            // NO artifact could answer: probes carried size only. Hash
+                            // custody per the transcript standard (#377); the persisted
+                            // patch is what a verdict-as-state lever will compare against.
+                            let patch_sha256 =
+                                match crate::commands::benchmark::workspace_candidate_diff(&ws) {
+                                    Ok(diff) => {
+                                        use sha2::{Digest, Sha256};
+                                        let sha =
+                                            format!("{:x}", Sha256::digest(diff.as_bytes()));
+                                        if let Some(dir) = inner.capture_dir.as_ref() {
+                                            let _ = std::fs::create_dir_all(dir);
+                                            let _ = std::fs::write(
+                                                std::path::Path::new(dir)
+                                                    .join(format!("attempt-{attempt}.patch")),
+                                                &diff,
+                                            );
+                                        }
+                                        sha
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            run_id = %run_id,
+                                            attempt,
+                                            error = %e,
+                                            "attempt patch receipt could not be read — \
+                                             verdict proceeds, custody hole logged"
+                                        );
+                                        String::new()
+                                    }
+                                };
                             let grade = crate::commands::benchmark::grade_swe(
                                 crate::commands::benchmark::SweGradeParams {
                                     instance: instance.clone(),
@@ -423,6 +458,7 @@ impl ActionCommand for AgentSolve {
                                         p2p_passed = g.pass_to_pass_passed,
                                         p2p_total = g.pass_to_pass_total,
                                         patch_bytes = g.patch_bytes,
+                                        patch_sha256 = %patch_sha256,
                                         failed_tests = %g.failed_tests.join(","),
                                         "solve attempt graded — the verdict, on the wire"
                                     );

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1780,6 +1780,23 @@ impl ActionCommand for BenchmarkSweGrade {
     }
 }
 
+/// The candidate diff of a solver workspace — the ONE reading of "her work"
+/// (grade_swe's candidate arm and agent/solve's attempt-patch receipt both
+/// call this; a second inline `git diff` would drift on the exclude rules).
+/// `diff HEAD` (not bare `diff`) so STAGED edits count as her work too, and
+/// `:(exclude).airc` because the substrate stages its own coordination files
+/// into her workspace (card b34f7eb5): Atlas's first grade carried 91KB of
+/// staged `.airc` blobs, and the fresh clone refused the WHOLE candidate —
+/// a real fix voided by files no solver wrote.
+pub(crate) fn workspace_candidate_diff(ws: &str) -> Result<String, CommandError> {
+    let out = std::process::Command::new("git")
+        .args(["diff", "HEAD", "--", ".", ":(exclude).airc"])
+        .current_dir(ws)
+        .output()
+        .map_err(|e| CommandError::Internal(format!("could not read {ws}'s diff: {e}")))?;
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
 /// The `benchmark/swe-grade` body, callable without a command context — the
 /// hands-free autograde on `agent/solve` completion invokes the SAME grader
 /// (fresh clone at base_commit, held-out tests, experience-stream write) as
@@ -1804,17 +1821,7 @@ pub(crate) async fn grade_swe(p: SweGradeParams) -> Result<SweGradeResult, Comma
         let candidate: Option<String> = if p.gold.unwrap_or(false) {
             Some(instance.patch.clone())
         } else if let Some(ws) = p.workspace.as_ref() {
-            // `diff HEAD` (not bare `diff`) so STAGED edits count as her work too, and
-            // `:(exclude).airc` because the substrate stages its own coordination files
-            // into her workspace (card b34f7eb5): Atlas's first grade carried 91KB of
-            // staged `.airc` blobs, and the fresh clone refused the WHOLE candidate —
-            // a real fix voided by files no solver wrote.
-            let out = std::process::Command::new("git")
-                .args(["diff", "HEAD", "--", ".", ":(exclude).airc"])
-                .current_dir(ws)
-                .output()
-                .map_err(|e| CommandError::Internal(format!("could not read {ws}'s diff: {e}")))?;
-            Some(String::from_utf8_lossy(&out.stdout).to_string())
+            Some(workspace_candidate_diff(ws)?)
         } else {
             p.patch.clone()
         };


### PR DESCRIPTION
patch_sha256 on benchmark.attempt.end + attempt-N.patch persisted beside run captures; diff-read compressed to one helper shared with the grader. cargo check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo