### PR TITLE
fix(bench): infra-void attempts classified + retried, never graded (#384 — last known round-killer)

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -334,7 +334,16 @@ impl ActionCommand for AgentSolve {
                     inner.max_acts.unwrap_or(DEFAULT_MAX_ACTS).max(1) as u64
                         * PER_ACT_ALLOWANCE_SECS,
                 );
-                for attempt in 1..=max_attempts {
+                // #384: the attempt counter is MANUAL so an infra-void attempt (she
+                // never worked — zero acts, no error, empty patch: the F1 signature,
+                // where six null-decision settles during a serving transition graded
+                // as capability zeros) can retry WITHOUT burning her chances. A zero
+                // is a harness claim; the harness must not launder its own faults
+                // into her record.
+                let mut attempt = 1;
+                let mut infra_void_retries: u32 = 0;
+                const INFRA_VOID_RETRIES_MAX: u32 = 2;
+                while attempt <= max_attempts {
                     let mut this_attempt = inner.clone();
                     this_attempt.task = next_task.clone();
                     this_attempt.prev_failed_patch_sha = prev_patch_sha.clone();
@@ -397,6 +406,54 @@ impl ActionCommand for AgentSolve {
                                 }
                             }
                             tracing::info!(run_id = %run_id, acts = r.acts, attempt, "agent/solve detached run complete");
+                            // #384: ZERO acts + NO error + EMPTY patch = she never
+                            // worked at all — the serving-transition signature (F1:
+                            // decision:null ticks, ~60ms "deliberations", lane not
+                            // resident at pre-flight). That is INFRA, never a
+                            // capability verdict: retry the SAME attempt after a
+                            // settling pause, bounded; exhausted retries end the run
+                            // with a loud infra marker instead of a graded zero.
+                            if r.acts == 0 && r.infra_error.is_none() && r.patch.is_empty() {
+                                if infra_void_retries < INFRA_VOID_RETRIES_MAX {
+                                    infra_void_retries += 1;
+                                    crate::probe!(
+                                        class = "benchmark.attempt.infra_void",
+                                        run_id = %run_id,
+                                        attempt,
+                                        retry = infra_void_retries,
+                                        "attempt produced ZERO work with no error — \
+                                         infra void (serving transition); retrying the \
+                                         SAME attempt, her chances unburned (#384)"
+                                    );
+                                    tokio::time::sleep(std::time::Duration::from_secs(90))
+                                        .await;
+                                    continue;
+                                }
+                                crate::probe!(
+                                    class = "benchmark.attempt.infra_void",
+                                    run_id = %run_id,
+                                    attempt,
+                                    retry = infra_void_retries,
+                                    "infra-void retries exhausted — run ends as INFRA, \
+                                     never graded (#384)"
+                                );
+                                if let Some(path) = path.as_ref() {
+                                    let _ = std::fs::write(
+                                        path,
+                                        serde_json::json!({
+                                            "failed": true,
+                                            "infra_error": "attempt produced zero work \
+                                             with no error repeatedly — serving never \
+                                             delivered a working mind (#384); this run \
+                                             is an INFRA VOID, not a capability result",
+                                            "run_id": run_id,
+                                            "attempt": attempt,
+                                        })
+                                        .to_string(),
+                                    );
+                                }
+                                break;
+                            }
                             // The claim ran to a diff; now the diff runs to a VERDICT with
                             // no human in the loop. Same grader as `benchmark/swe-grade`
                             // (fresh clone, held-out tests) — its verdict path also writes
@@ -691,6 +748,9 @@ impl ActionCommand for AgentSolve {
                             break;
                         }
                     }
+                    // Manual increment (#384): only a GENUINE attempt outcome advances
+                    // the counter — the infra-void arm `continue`s above this line.
+                    attempt += 1;
                 }
             });
             return Ok(AgentSolveResult {


### PR DESCRIPTION
Manual attempt counter; zero-work-no-error outcomes retry bounded then end as INFRA VOID. cargo check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo