### PR TITLE
fix(bench): infra_error settles retry, never grade (#386)

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -413,7 +413,15 @@ impl ActionCommand for AgentSolve {
                             // capability verdict: retry the SAME attempt after a
                             // settling pause, bounded; exhausted retries end the run
                             // with a loud infra marker instead of a graded zero.
-                            if r.acts == 0 && r.infra_error.is_none() && r.patch.is_empty() {
+                            // #386 extension: an attempt whose settle carries ANY
+                            // infra_error died to INFRASTRUCTURE by definition (the
+                            // inference path failed her — round G: wedge-killed
+                            // attempts with 'no TOKEN progress' still graded and
+                            // burned). Same arm, same bound; her partial work stays
+                            // in the workspace and the retry resumes from it.
+                            if r.infra_error.is_some()
+                                || (r.acts == 0 && r.patch.is_empty())
+                            {
                                 if infra_void_retries < INFRA_VOID_RETRIES_MAX {
                                     infra_void_retries += 1;
                                     crate::probe!(


### PR DESCRIPTION
Extends #384's arm to any infra_error settle. cargo check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo