### PR TITLE
fix(serving): measured solve holds an exclusive warm slot — quiesce idle residents (#266/#386)

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -864,6 +864,36 @@ impl AgentSolve {
             "solve prelude: lane acquired"
         );
 
+        // 1b) Give this persona an EXCLUSIVE warm slot for the solve's duration by quiescing the
+        //      OTHER resident citizens. On a single-warm-slot box (glass-boxed 2026-08-09,
+        //      serving.plan "warm-slot-oversubscribed": 4 residents, 1 warm slot) the idle
+        //      citizens' autonomic turns rotate through the shared llama.cpp KV slots and EVICT
+        //      this solver's prefilled prefix — so every act re-prefills the FULL prompt cold
+        //      (measured ~85s for ~12k tokens at 139 tok/s, O(n²) degrading) instead of reusing
+        //      cache and prefilling only the ~50-token delta. Quiescing the others lets the prefix
+        //      survive turn-to-turn. This is the SAME discipline cognition/eval uses (`quiesce_all`
+        //      at eval.rs) for a measured snapshot — swe-solve/agent-solve simply never invoked it.
+        //      The lease is panic-safe RAII: the fleet resumes on drop, early-return, OR unwind, so
+        //      a stalled or panicking solve can never leave the citizens frozen. SHE is never
+        //      suspended — only the idle contenders step back, and they still answer DIRECTED
+        //      messages (quiesced gates only the autonomic self-tick). `None` in unit tests / tools
+        //      that never stood up a live roster — a solve with no fleet has nothing to quiesce.
+        //      [[benchmark-is-a-governor-preemption-lease]] [[first-class-citizens-even-during-benchmarks]]
+        let _quiesce_lease =
+            crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global().map(
+                |reg| {
+                    let lease = reg.quiesce_others(persona_uuid);
+                    crate::probe!(
+                        class = "benchmark.solve.phase",
+                        run_id = %run_id.as_deref().unwrap_or("-"),
+                        phase = "quiesce_others",
+                        quiesced_peers = lease.count() as u64,
+                        "measured solve holds an exclusive warm slot — idle citizens quiesced so the KV prefix survives turn-to-turn"
+                    );
+                    lease
+                },
+            );
+
         // 2) Fork her WHOLE cognition onto that lane, rooted at the workspace: tools ON, recall ON.
         //    A brief wait covers the post-spawn template race (same as the eval fork-waiter).
         let registry = crate::cognition::persona_workspace::global();

--- a/core/continuum-core/src/persona/airc_runtime_registry.rs
+++ b/core/continuum-core/src/persona/airc_runtime_registry.rs
@@ -249,12 +249,57 @@ impl PersonaAircRuntimeRegistry {
     #[must_use = "bind the lease to a named `_lease` for the eval's duration; \
                   binding to `_` drops it immediately and resumes the fleet at once"]
     pub fn quiesce_all(&self) -> QuiesceLease {
-        let flags: Vec<Arc<AtomicBool>> =
-            self.inner.iter().map(|e| e.quiesced.clone()).collect();
+        Self::quiesce_lease_over(self.quiesce_pairs(), None)
+    }
+
+    /// Snapshot of every live persona's `(id, quiesce-flag)` — the input both quiesce
+    /// verbs share. O(N), N = tens; taken once so the selector below is a pure function
+    /// over a plain Vec (no DashMap guard held across the store loop).
+    fn quiesce_pairs(&self) -> Vec<(Uuid, Arc<AtomicBool>)> {
+        self.inner
+            .iter()
+            .map(|e| (*e.key(), e.quiesced.clone()))
+            .collect()
+    }
+
+    /// Suspend the self-tick of every persona in `pairs` EXCEPT `except` (`None` = the
+    /// whole fleet), returning the RAII lease. Pulled out of `quiesce_all` /
+    /// `quiesce_others` as a PURE function so the exclusion invariant — a
+    /// `quiesce_others(solver)` must NEVER suspend the solver, or her measured drive
+    /// would deadlock waiting on a warm slot she is forbidden to take — is unit-testable
+    /// without a live airc daemon (a real `PersonaSlot` needs one). One truth for both
+    /// verbs; the only difference is whether `except` is `Some`.
+    fn quiesce_lease_over(
+        pairs: Vec<(Uuid, Arc<AtomicBool>)>,
+        except: Option<Uuid>,
+    ) -> QuiesceLease {
+        let flags: Vec<Arc<AtomicBool>> = pairs
+            .into_iter()
+            .filter(|(id, _)| except != Some(*id))
+            .map(|(_, flag)| flag)
+            .collect();
         for f in &flags {
             f.store(true, Ordering::Relaxed);
         }
         QuiesceLease { flags }
+    }
+
+    /// Acquire the same exclusive-measurement lease as [`quiesce_all`] but leave ONE
+    /// persona running — the citizen who is actively doing the measured work. Every
+    /// OTHER online persona's autonomic self-tick suspends now and RESTORES on drop
+    /// (panic-safe, same as `quiesce_all`). This is the seam a headless solve needs:
+    /// on a single-warm-slot box the idle citizens' autonomic turns rotate through
+    /// the shared llama.cpp KV slots and EVICT the solver's prefilled prefix, so
+    /// every act re-prefills the full prompt cold (measured: ~85s for a ~12k-token
+    /// prompt) instead of reusing cache and prefilling only the new delta. Quiescing
+    /// the others lets the solver hold its warm slot turn-to-turn. The solver is
+    /// still a first-class citizen — nothing suspends HER; only the idle contenders
+    /// step back for the duration. [[benchmark-is-a-governor-preemption-lease]]
+    /// [[first-class-citizens-even-during-benchmarks]]
+    #[must_use = "bind the lease to a named `_lease` for the solve's duration; \
+                  binding to `_` drops it immediately and resumes the fleet at once"]
+    pub fn quiesce_others(&self, except: Uuid) -> QuiesceLease {
+        Self::quiesce_lease_over(self.quiesce_pairs(), Some(except))
     }
 
     /// Attach a service-loop `JoinHandle` to the persona's slot. The
@@ -458,6 +503,57 @@ mod tests {
             flags.iter().all(|f| !f.load(Ordering::Relaxed)),
             "fleet resumed despite the panic — restore rode the unwind"
         );
+    }
+
+    #[test]
+    fn quiesce_others_never_suspends_the_solver() {
+        // what this catches: quiesce_others(solver) MUST leave the solver's OWN flag
+        // untouched. If it suspended her too, her measured drive would wait forever on a
+        // warm slot she is forbidden to take — a deadlocked solve — which is the exact
+        // opposite of the exclusive-warm-slot fix's intent (#266/#386 prefill contention).
+        let solver = Uuid::new_v4();
+        let (other_a, other_c) = (Uuid::new_v4(), Uuid::new_v4());
+        let fa = Arc::new(AtomicBool::new(false));
+        let fs = Arc::new(AtomicBool::new(false));
+        let fc = Arc::new(AtomicBool::new(false));
+        let pairs = vec![
+            (other_a, fa.clone()),
+            (solver, fs.clone()),
+            (other_c, fc.clone()),
+        ];
+
+        let lease = PersonaAircRuntimeRegistry::quiesce_lease_over(pairs, Some(solver));
+        assert!(fa.load(Ordering::Relaxed), "other citizen A suspended");
+        assert!(
+            !fs.load(Ordering::Relaxed),
+            "the SOLVER is never suspended — she must keep generating"
+        );
+        assert!(fc.load(Ordering::Relaxed), "other citizen C suspended");
+        assert_eq!(lease.count(), 2, "exactly the two non-solvers were leased");
+
+        drop(lease);
+        assert!(
+            !fa.load(Ordering::Relaxed) && !fc.load(Ordering::Relaxed),
+            "the quiesced others resume on drop"
+        );
+    }
+
+    #[test]
+    fn quiesce_all_selector_suspends_everyone() {
+        // what this catches: the `None` arm of the shared selector must suspend ALL flags —
+        // quiesce_all's whole-fleet-measurement contract must survive the compression of the
+        // two verbs onto quiesce_lease_over (a `filter` bug that leaked the None case would
+        // silently under-quiesce a snapshot eval).
+        let fa = Arc::new(AtomicBool::new(false));
+        let fb = Arc::new(AtomicBool::new(false));
+        let pairs = vec![(Uuid::new_v4(), fa.clone()), (Uuid::new_v4(), fb.clone())];
+
+        let lease = PersonaAircRuntimeRegistry::quiesce_lease_over(pairs, None);
+        assert!(
+            fa.load(Ordering::Relaxed) && fb.load(Ordering::Relaxed),
+            "None → the whole fleet is suspended"
+        );
+        assert_eq!(lease.count(), 2);
     }
 
     /// `attach_service_loop` fails fast when the slot doesn't exist


### PR DESCRIPTION
## What
A measured `agent/solve` / `benchmark/swe-solve` drive now quiesces the OTHER resident citizens for its duration, so the solving persona holds a stable warm slot and its prefilled KV prefix survives turn-to-turn.

## Why (glass-boxed 2026-08-09, M5, Devstral-24B)
Each solve act spent **~85s in prompt prefill** (139 tok/s, O(n²) degrading) and the llama.cpp prompt cache was evicted every turn (`srv alloc: making room for prompt cache entry, removing oldest entry`). `serving.plan` emitted `warm-slot-oversubscribed` (4 residents, **1** warm slot). The 3 idle citizens woke on their autonomic cadence, rotated through the shared KV slots, and evicted the solver's prefix → every act re-prefilled the full ~12–20k-token prompt **cold** instead of reusing cache and prefilling only the ~50-token delta. This is the #266 prefill-waste class biting the benchmark, and part of the #386 round-killer surface.

## Fix (reuse, don't invent)
`cognition/eval` **already** quiesces the fleet for a measured snapshot (`quiesce_all`). `agent/solve` — the shared headless measured-drive loop — never did. Added `quiesce_others(except)` beside it (panic-safe RAII, same lease), invoked in `solve_body` right after lane acquisition. The solver is never suspended; idle contenders step back and still answer **directed** messages (quiesced gates only the autonomic self-tick).

Compressed `quiesce_all` + `quiesce_others` onto one pure selector (`quiesce_lease_over`) so the exclusion invariant — *never suspend the solver, or the drive deadlocks* — is unit-testable without a live daemon. **2 tests added, all green.**

[[benchmark-is-a-governor-preemption-lease]] [[first-class-citizens-even-during-benchmarks]]

🤖 Generated with [Claude Code](https://claude.com/claude-code)