### PR TITLE
refactor(cognition): ToolCall::loop_fingerprint() — one typed source for the repeat/loop key

### DIFF
--- a/core/continuum-core/src/ai/types.rs
+++ b/core/continuum-core/src/ai/types.rs
@@ -163,6 +163,24 @@ pub struct ToolCall {
     pub input: Value, // Tool parameters as JSON
 }
 
+impl ToolCall {
+    /// Stable identity of THIS call for loop / repeat detection: `name|json(input)`.
+    ///
+    /// The random per-call `id` is deliberately excluded — two calls with the same name
+    /// and arguments ARE the same action regardless of their generated ids. This is the
+    /// SINGLE source of the fingerprint that both the settle loop's stuck-batch signature
+    /// (`act_observe::settle::drive_to_settle`) and `apply_act`'s repeat guard key on;
+    /// two hand-inlined copies of this format drifting apart would silently break loop
+    /// detection, so they share this one method.
+    pub fn loop_fingerprint(&self) -> String {
+        format!(
+            "{}|{}",
+            self.name,
+            serde_json::to_string(&self.input).unwrap_or_default()
+        )
+    }
+}
+
 /// Tool result to send back to AI after execution
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "../../../protocol/typescript/ai/ToolResult.ts")]

--- a/core/continuum-core/src/cognition/act_observe/apply.rs
+++ b/core/continuum-core/src/cognition/act_observe/apply.rs
@@ -86,11 +86,7 @@ pub async fn apply_act(
         calls
             .iter()
             .map(|c| {
-                let fp = format!(
-                    "{}|{}",
-                    c.name,
-                    serde_json::to_string(&c.input).unwrap_or_default()
-                );
+                let fp = c.loop_fingerprint();
                 body.working_memory.note_action_fingerprint(&fp)
             })
             .max()

--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -58,7 +58,7 @@ pub async fn drive_to_settle(
     fn calls_signature(calls: &[ToolCall]) -> String {
         let mut parts: Vec<String> = calls
             .iter()
-            .map(|c| format!("{}|{}", c.name, serde_json::to_string(&c.input).unwrap_or_default()))
+            .map(|c| c.loop_fingerprint())
             .collect();
         parts.sort();
         parts.join(",")


### PR DESCRIPTION
Boy-scout cleanup on the act→observe path, prompted by Joel's critique that the cognition code re-derives stringly-typed values everywhere instead of passing well-defined types.

**The rot:** the loop/repeat fingerprint `format!("{}|{}", name, json(input))` was hand-inlined **byte-for-byte in two files** — `act_observe::settle::drive_to_settle::calls_signature` (stuck-batch signature) and `act_observe::apply::apply_act`'s `bump_repeat` (repeat guard). A load-bearing format duplicated across the hot path: if one copy drifts, stuck-loop detection silently mismatches and the #206-class loop backstops break.

**The fix:** one typed method `ToolCall::loop_fingerprint()` on the type it belongs to (`ai::types`); both callers delegate. The per-call `id` stays excluded (same-name+args = same action). Behavior-identical.

**Verified:** `cargo check -p continuum-core --lib --features metal,accelerate` → Finished, no errors. (Also cleared a stale partial `webrtc-sys` prebuilt that was walling local checks — same blocker as #2223.)

First cut of the larger "stop format-and-reparse" cleanup; the typed `Observation { call, args, output, status }` thread through act→observe follows (that's the real benchmark-zeros fix — see the machine-level diagnosis: her tool result never threads back into the next prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)