### PR TITLE
cognition KV-cache stability (#266) + typed Observation & 18057 actuator (#392) + coordinator-free ResourcePolicy (#395 slice 1)

### DIFF
--- a/core/continuum-core/src/cognition/deliberation_prompt.rs
+++ b/core/continuum-core/src/cognition/deliberation_prompt.rs
@@ -125,15 +125,40 @@ fn stable_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow<'
         Some(Cow::Owned(taking_your_turn_block(p.persona_name))),
         // Tools + acting — only when the persona has tools.
         tools_block(p.tools, p.expanded).map(Cow::Owned),
+        // Assembled context — the standing grounding (roster/doctrine/workspace-map)
+        // FIRST (stable-sorted inside the block), then whatever volatile tail survived the
+        // fit. It stays in the cacheable system prefix by design: its stable head IS the
+        // reusable KV, and the truly per-turn material (recall / working-memory traces) is
+        // already separated out as its own `.trailing()` conversation turns upstream
+        // (#205), so it never lands here. Keeping context in `stable` preserves the
+        // "standing framing reaches the system message" contract
+        // (`trailing_proprioception_renders_in_the_tail_not_the_system_prefix`).
+        working_context_block(p.context).map(Cow::Owned),
+        // Her NOW — a one-line clock (minute granularity), LAST in the stable prefix and
+        // nearest the framing that follows: freshest temporal grounding at the write point.
+        // Per-minute churn costs at most one re-prefill per minute (turns are seconds
+        // apart), versus the per-TURN flip the framing below would cause if it stayed here.
+        // Eval passes its pinned epoch; tests pass None.
+        p.now_ms
+            .and_then(|ms| chrono::DateTime::from_timestamp_millis(ms as i64))
+            .map(|dt| {
+                Cow::Owned(format!(
+                    "\n\n[now {}]",
+                    dt.with_timezone(&chrono::Local).format("%Y-%m-%d %H:%M %A")
+                ))
+            }),
     ]
     .into_iter()
     .flatten()
 }
 
-/// The PER-TURN situational blocks — own-time/presence framing, assembled context, clock.
-/// Each flips or grows turn-to-turn, so they MUST NOT sit in the cacheable system prefix;
-/// the message builder renders them as the newest trailing turn (same text, same order,
-/// nearest generation — the #205 trailing-proprioception placement).
+/// The PER-TURN situational FRAMING — the own-time affordance and the conversational-
+/// presence block, whose variant (DIRECTED / WORKING / SILENCE) flips hard every turn.
+/// This is the block the raw prompt-captures caught breaking the KV prefix at char ~7607
+/// (#266): it sat BEFORE the context, so every turn's flip re-prefilled the whole tail.
+/// It MUST NOT sit in the cacheable system prefix; the message builder renders it as the
+/// newest trailing turn — same text, nearest generation (the #205 trailing placement),
+/// where its volatility no longer invalidates the cached identity + tools + context prefix.
 fn volatile_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow<'a, str>> {
     [
         // Self-directed free time — only on a self-initiated heartbeat turn.
@@ -155,21 +180,6 @@ fn volatile_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow
         } else {
             SILENCE_AFFORDANCE_BLOCK
         })),
-        // Assembled context — the standing grounding (roster/doctrine/workspace-map)
-        // FIRST (stable-sorted inside the block by render_assembled_context_within), then
-        // the volatile tail (recall, working memory).
-        working_context_block(p.context).map(Cow::Owned),
-        // Her NOW — a one-line clock (minute granularity), LAST, nearest the generation
-        // point: freshest temporal grounding at the write point. Eval passes its pinned
-        // epoch; tests pass None.
-        p.now_ms
-            .and_then(|ms| chrono::DateTime::from_timestamp_millis(ms as i64))
-            .map(|dt| {
-                Cow::Owned(format!(
-                    "\n\n[now {}]",
-                    dt.with_timezone(&chrono::Local).format("%Y-%m-%d %H:%M %A")
-                ))
-            }),
     ]
     .into_iter()
     .flatten()
@@ -373,14 +383,21 @@ pub(super) const WORKING_CONTEXT_HEADER: &str = "\n\n[What you are working with 
 mod tests {
     use super::*;
 
-    // what this catches (#266 KV-cache reuse): the STABLE prefix — identity + [Taking your
-    // turn] + tools — is a pure function of the PERSONA, byte-identical across EVERY turn
-    // shape (directed / undirected / self-initiated / holds-work / clock on-or-off / any
-    // context). If a per-turn block ever leaks back into the stable prefix, the whole ~6k
-    // system prompt re-prefills every act (0% KV reuse — the ~13min SWE solves this fix
-    // targets). The per-turn framing must ride `trailing` instead, asserted below.
+    // what this catches (#266 KV-cache reuse): the block that HARD-FLIPS every turn — the
+    // own-time / conversational-presence framing (DIRECTED vs WORKING vs SILENCE) — must
+    // NOT sit in the cacheable system prefix. The raw prompt-captures caught exactly this:
+    // consecutive prompts shared only 7,607 of ~14,706 chars because the presence framing
+    // sat at char ~7607, BEFORE the context, and flipped every act → the whole tail
+    // re-prefilled (0% KV reuse, the ~13min SWE solves this targets). The fix rides that
+    // framing on `trailing` instead. The persona-and-context prefix (identity + [Taking
+    // your turn] + tools + assembled grounding + clock) stays in `stable`: its head is the
+    // reusable KV, and the truly per-turn material (recall / working-memory) is already
+    // separated as its own `.trailing()` conversation turns upstream (#205), so it never
+    // reaches this `context` string. The invariant: for a FIXED context, flipping the
+    // per-turn framing dimensions (directed / self-initiated / holds-work) must not perturb
+    // the stable prefix — that flip is what used to poison the cache.
     #[test]
-    fn stable_prefix_is_byte_identical_across_turn_shapes() {
+    fn framing_flip_never_perturbs_the_cacheable_prefix() {
         let expanded = BTreeSet::new();
         let parts = |directed, self_initiated, holds_live_work, now_ms, context| {
             SystemPromptParts {
@@ -396,36 +413,36 @@ mod tests {
             }
         };
         let stable = |p: &SystemPromptParts| compose_split(p).stable;
-        let baseline = stable(&parts(false, false, false, None, "CTX-A"));
-        // Every per-turn shape yields the SAME cacheable prefix.
+        // Context held CONSTANT — only the per-turn FRAMING dimensions flip.
+        let baseline = stable(&parts(false, false, false, None, "CTX"));
         assert_eq!(
-            stable(&parts(true, false, false, None, "CTX-B")),
+            stable(&parts(true, false, false, None, "CTX")),
             baseline,
-            "directed must not change the stable prefix"
+            "directed must not change the stable prefix (framing rides trailing)"
         );
         assert_eq!(
-            stable(&parts(false, true, false, None, "CTX-C")),
+            stable(&parts(false, true, false, None, "CTX")),
             baseline,
-            "self-initiated must not change the stable prefix"
+            "self-initiated must not change the stable prefix (own-time rides trailing)"
         );
         assert_eq!(
-            stable(&parts(false, false, true, None, "CTX-D")),
+            stable(&parts(false, false, true, None, "CTX")),
             baseline,
-            "holds-work must not change the stable prefix"
+            "holds-work must not change the stable prefix (working-presence rides trailing)"
         );
-        assert_eq!(
-            stable(&parts(false, false, false, Some(1_700_000_000_000), "CTX-E")),
-            baseline,
-            "the minute clock must not change the stable prefix"
-        );
-        // The stable prefix carries NONE of the volatile framing…
+        // The hard-flipping framing carries NONE of its markers in the cacheable prefix…
         assert!(
-            !baseline.contains("[Conversational Presence]")
-                && !baseline.contains("[Your own time]")
-                && !baseline.contains("[What you are working with"),
-            "no per-turn framing/context may sit in the cacheable prefix: {baseline}"
+            !baseline.contains("[Conversational Presence]") && !baseline.contains("[Your own time]"),
+            "the per-turn framing must not sit in the cacheable prefix: {baseline}"
         );
-        // …and that framing DOES ride the trailing bundle (same content, relocated).
+        // …the STANDING grounding, by contrast, DOES stay in the cacheable prefix (its head
+        // is the reusable KV; keeping it here preserves the "framing reaches the system
+        // message" contract that trailing_proprioception_renders_in_the_tail asserts).
+        assert!(
+            stable(&parts(false, false, false, None, "ROSTER: alice")).contains("ROSTER: alice"),
+            "standing grounding stays in the cacheable prefix, not trailing"
+        );
+        // …and the framing DOES ride the trailing bundle (same content, relocated).
         assert!(
             compose_split(&parts(false, true, false, None, "CTX"))
                 .trailing

--- a/core/continuum-core/src/cognition/deliberation_prompt.rs
+++ b/core/continuum-core/src/cognition/deliberation_prompt.rs
@@ -72,27 +72,70 @@ pub(super) struct SystemPromptParts<'a> {
     pub holds_live_work: bool,
 }
 
-/// Assemble the system prompt: fold the present blocks, in order, into one string.
-pub(super) fn compose(p: &SystemPromptParts<'_>) -> String {
-    let mut s = String::with_capacity(p.system_prompt.len() + p.context.len() + 768);
-    for block in ordered_blocks(p) {
-        s.push_str(&block);
+/// The system prompt split at the KV-cache boundary (#266/#205). `stable` is a pure
+/// function of the PERSONA (identity + turn-framing + tools) — byte-identical across all
+/// of her turns, so it lands in the cacheable prefix llama-server reuses. `trailing` is the
+/// PER-TURN situational framing (own-time/presence, assembled context, clock): same content,
+/// same order as before, but delivered as the newest turn instead of baked into the system
+/// message, so a per-turn flip (addressed↔self-initiated, a new context tail) can no longer
+/// invalidate the whole prefix. Before the split every act re-prefilled ~6k tokens because
+/// the presence block flipped at ~char 7.6k of the system prompt (0% KV reuse — the ~13min
+/// SWE solves). See [`compose`] for the byte-identical concatenation.
+pub(super) struct ComposedSystemPrompt {
+    /// Persona-invariant prefix — safe to place in the cacheable system message.
+    pub stable: String,
+    /// Per-turn situational framing — the message builder appends it as the newest turn.
+    pub trailing: String,
+}
+
+/// Assemble the system prompt split into its cacheable [`stable`](ComposedSystemPrompt::stable)
+/// prefix and its per-turn [`trailing`](ComposedSystemPrompt::trailing) tail. The single
+/// place the block set + order + gating lives, now partitioned by cache-stability.
+pub(super) fn compose_split(p: &SystemPromptParts<'_>) -> ComposedSystemPrompt {
+    let mut stable = String::with_capacity(p.system_prompt.len() + 768);
+    for block in stable_blocks(p) {
+        stable.push_str(&block);
     }
+    let mut trailing = String::with_capacity(p.context.len() + 512);
+    for block in volatile_blocks(p) {
+        trailing.push_str(&block);
+    }
+    ComposedSystemPrompt { stable, trailing }
+}
+
+/// Assemble the WHOLE system prompt as one string — `stable ++ trailing`, byte-identical
+/// to the pre-split output. Kept so callers/tests that want the composed whole are
+/// unchanged; the live message builder uses [`compose_split`] to place `stable` in the
+/// cacheable system message and `trailing` on the newest turn (the #266 KV-reuse fix).
+pub(super) fn compose(p: &SystemPromptParts<'_>) -> String {
+    let c = compose_split(p);
+    let mut s = c.stable;
+    s.push_str(&c.trailing);
     s
 }
 
-/// The system prompt AS DATA: an ordered list of present blocks. Each entry pairs a
-/// block builder with its gate — a block that doesn't apply this turn yields `None`
-/// and drops out of the fold. This is the one place the block set + their order +
-/// their gating lives; add a block by inserting an entry, nothing else changes.
-fn ordered_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow<'a, str>> {
+/// The BYTE-STABLE prefix blocks: identity + `[Taking your turn]` + tools/`[Acting]`.
+/// A pure function of the persona (system prompt, name, authorized tool set) — invariant
+/// across her turns, so it is the cacheable KV prefix. NOTHING situational belongs here.
+fn stable_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow<'a, str>> {
     [
         // Identity — always; the byte-stable head of the cacheable prefix.
         Some(Cow::Borrowed(p.system_prompt)),
-        // Take a TURN in this activity — always.
+        // Take a TURN in this activity — always; pure function of her name.
         Some(Cow::Owned(taking_your_turn_block(p.persona_name))),
         // Tools + acting — only when the persona has tools.
         tools_block(p.tools, p.expanded).map(Cow::Owned),
+    ]
+    .into_iter()
+    .flatten()
+}
+
+/// The PER-TURN situational blocks — own-time/presence framing, assembled context, clock.
+/// Each flips or grows turn-to-turn, so they MUST NOT sit in the cacheable system prefix;
+/// the message builder renders them as the newest trailing turn (same text, same order,
+/// nearest generation — the #205 trailing-proprioception placement).
+fn volatile_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow<'a, str>> {
+    [
         // Self-directed free time — only on a self-initiated heartbeat turn.
         p.self_initiated.then_some(Cow::Borrowed(OWN_TIME_BLOCK)),
         // Conversational presence — the AMBIENT block on undirected turns; the DIRECTED
@@ -114,15 +157,11 @@ fn ordered_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow<
         })),
         // Assembled context — the standing grounding (roster/doctrine/workspace-map)
         // FIRST (stable-sorted inside the block by render_assembled_context_within), then
-        // the volatile tail (recall, working memory). Placed BEFORE [now] so its stable
-        // prefix lands in the cacheable KV region adjacent to the static system prompt.
+        // the volatile tail (recall, working memory).
         working_context_block(p.context).map(Cow::Owned),
         // Her NOW — a one-line clock (minute granularity), LAST, nearest the generation
-        // point: freshest temporal grounding at the write point, and — being
-        // minute-volatile — kept OUT in front of nothing, so it can NEVER break the
-        // cacheable prefix. (Was position-6, ahead of the context block, which pinned the
-        // KV-cache boundary at ~2k tokens and re-prefilled the whole stable grounding
-        // every turn — #139 context-split.) Eval passes its pinned epoch; tests pass None.
+        // point: freshest temporal grounding at the write point. Eval passes its pinned
+        // epoch; tests pass None.
         p.now_ms
             .and_then(|ms| chrono::DateTime::from_timestamp_millis(ms as i64))
             .map(|dt| {
@@ -333,6 +372,73 @@ pub(super) const WORKING_CONTEXT_HEADER: &str = "\n\n[What you are working with 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches (#266 KV-cache reuse): the STABLE prefix — identity + [Taking your
+    // turn] + tools — is a pure function of the PERSONA, byte-identical across EVERY turn
+    // shape (directed / undirected / self-initiated / holds-work / clock on-or-off / any
+    // context). If a per-turn block ever leaks back into the stable prefix, the whole ~6k
+    // system prompt re-prefills every act (0% KV reuse — the ~13min SWE solves this fix
+    // targets). The per-turn framing must ride `trailing` instead, asserted below.
+    #[test]
+    fn stable_prefix_is_byte_identical_across_turn_shapes() {
+        let expanded = BTreeSet::new();
+        let parts = |directed, self_initiated, holds_live_work, now_ms, context| {
+            SystemPromptParts {
+                system_prompt: "IDENTITY-PROMPT",
+                persona_name: "Asha",
+                tools: &[],
+                expanded: &expanded,
+                context,
+                directed,
+                self_initiated,
+                now_ms,
+                holds_live_work,
+            }
+        };
+        let stable = |p: &SystemPromptParts| compose_split(p).stable;
+        let baseline = stable(&parts(false, false, false, None, "CTX-A"));
+        // Every per-turn shape yields the SAME cacheable prefix.
+        assert_eq!(
+            stable(&parts(true, false, false, None, "CTX-B")),
+            baseline,
+            "directed must not change the stable prefix"
+        );
+        assert_eq!(
+            stable(&parts(false, true, false, None, "CTX-C")),
+            baseline,
+            "self-initiated must not change the stable prefix"
+        );
+        assert_eq!(
+            stable(&parts(false, false, true, None, "CTX-D")),
+            baseline,
+            "holds-work must not change the stable prefix"
+        );
+        assert_eq!(
+            stable(&parts(false, false, false, Some(1_700_000_000_000), "CTX-E")),
+            baseline,
+            "the minute clock must not change the stable prefix"
+        );
+        // The stable prefix carries NONE of the volatile framing…
+        assert!(
+            !baseline.contains("[Conversational Presence]")
+                && !baseline.contains("[Your own time]")
+                && !baseline.contains("[What you are working with"),
+            "no per-turn framing/context may sit in the cacheable prefix: {baseline}"
+        );
+        // …and that framing DOES ride the trailing bundle (same content, relocated).
+        assert!(
+            compose_split(&parts(false, true, false, None, "CTX"))
+                .trailing
+                .contains("[Your own time]"),
+            "own-time framing rides trailing, not the stable prefix"
+        );
+        assert!(
+            compose_split(&parts(true, false, false, None, "CTX"))
+                .trailing
+                .contains("This message names you"),
+            "directed framing rides trailing, not the stable prefix"
+        );
+    }
 
     // what this catches: the procedural assembler must honor each block's gate AND
     // preserve block ORDER — identity first, the volatile context last. A regression

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -1018,7 +1018,35 @@ impl LlmDeliberationFaculty {
         now_ms: Option<u64>,
         holds_live_work: bool,
     ) -> String {
-        deliberation_prompt::compose(&deliberation_prompt::SystemPromptParts {
+        // Whole-string form (stable ++ trailing), byte-identical to the pre-split output.
+        // Kept for the many framing-shape tests that assert against the composed whole; the
+        // LIVE prompt path calls `compose_system_split` and places the two parts separately.
+        let c =
+            self.compose_system_split(context, expanded, directed, self_initiated, now_ms, holds_live_work);
+        let mut s = c.stable;
+        s.push_str(&c.trailing);
+        s
+    }
+
+    /// The system prompt split at the KV-cache boundary (#266): a persona-invariant
+    /// [`stable`](deliberation_prompt::ComposedSystemPrompt::stable) prefix
+    /// (identity + `[Taking your turn]` + tools) that belongs in the cacheable system
+    /// message, and the per-turn
+    /// [`trailing`](deliberation_prompt::ComposedSystemPrompt::trailing) framing +
+    /// assembled context + clock that the live path rides on the newest turn so it never
+    /// invalidates the cached prefix. The whole-string [`compose_system_holding`] is
+    /// `stable ++ trailing` of exactly this.
+    #[allow(clippy::too_many_arguments)]
+    fn compose_system_split(
+        &self,
+        context: &str,
+        expanded: &BTreeSet<String>,
+        directed: bool,
+        self_initiated: bool,
+        now_ms: Option<u64>,
+        holds_live_work: bool,
+    ) -> deliberation_prompt::ComposedSystemPrompt {
+        deliberation_prompt::compose_split(&deliberation_prompt::SystemPromptParts {
             system_prompt: &self.system_prompt,
             persona_name: &self.persona_name,
             tools: &self.tools,
@@ -1254,6 +1282,16 @@ impl LlmDeliberationFaculty {
             ),
         );
 
+        // #266 KV-cache fix lives in the block ORDER (see `deliberation_prompt::compose`):
+        // the per-turn presence/own-time framing now renders LAST in the system message,
+        // AFTER the standing grounding context, instead of before it. The raw
+        // prompt-captures caught the framing sitting at char ~7607, ahead of the context,
+        // so every directed/silence flip shortened the reusable KV prefix to ~7.6k chars
+        // and re-prefilled the whole tail. With the framing last, the served slot's reused
+        // prefix now extends through identity + tools + the stable head of the grounding —
+        // the framing flip falls past it and costs only its own short re-prefill. The ask
+        // stays the last CONVERSATION turn (framing is system-role instruction, not a
+        // conversation message), so nothing pulls the model off the freshest peer turn.
         DeliberationPromptView {
             system: self.compose_system_holding(
                 &context,
@@ -2649,6 +2687,71 @@ mod tests {
             assert!(
                 in_tail(&v2, "Then I read it back to verify"),
                 "the new act must append to the trailing turn"
+            );
+        }
+
+        // what this catches: #266 KV-cache reuse at the CALLER. The per-turn presence
+        // framing (DIRECTED vs SILENCE) flips hard every turn; the raw prompt-captures
+        // caught it sitting in the system message at char ~7607, BEFORE the grounding
+        // context, so every flip shortened the reusable KV prefix to ~7.6k chars and
+        // re-prefilled the whole tail (0% KV reuse — the ~13min SWE solves). The fix moves
+        // the framing to render LAST in the system message, after the context, so the
+        // reusable prefix now extends THROUGH the grounding and the flip falls past it.
+        // This asserts the property at the live boundary: the two systems (directed vs
+        // undirected) share a common prefix that reaches into the grounding context, and
+        // each carries its own presence variant only in the diverging tail. Before the
+        // reorder this was RED — the systems diverged at the framing, char ~7607, ahead of
+        // the context. regression for #266
+        #[test]
+        fn directedness_flip_keeps_the_grounding_inside_the_reusable_prefix() {
+            let persona = Uuid::new_v4();
+            let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
+            let faculty = LlmDeliberationFaculty::new(persona, "Ivar", "You are Ivar.", adapter)
+                // Ample window so budget pressure never perturbs what renders — this
+                // isolates the framing POSITION, not truncation.
+                .with_context_window(8192);
+
+            // Same room content + the same standing grounding (a session-stable roster
+            // contribution renders the [What you are working with] block); only the
+            // directedness dimension flips.
+            let with_grounding = |directed: bool| {
+                let mut ws = Workspace::new("the team is chatting about the plan");
+                ws.broadcast.push(
+                    Contribution::context(
+                        FacultyId::Custom("room-roster".to_string()),
+                        "ROSTER: alice, bob present",
+                        0.5,
+                        "framing",
+                    )
+                    .session_stable(),
+                );
+                ws.directed_at_self = directed;
+                ws
+            };
+            let undirected = faculty.prompt_view(&with_grounding(false));
+            let directed = faculty.prompt_view(&with_grounding(true));
+
+            // The longest shared leading run of the two system messages IS the KV prefix
+            // the served slot reuses across the flip.
+            let common_len = directed
+                .system
+                .bytes()
+                .zip(undirected.system.bytes())
+                .take_while(|(a, b)| a == b)
+                .count();
+            let reusable_prefix = &directed.system[..common_len];
+            assert!(
+                reusable_prefix.contains("[What you are working with"),
+                "the reusable KV prefix must extend THROUGH the grounding context — the \
+                 framing flip falls after it (#266). prefix ended at byte {common_len}:\n{reusable_prefix}"
+            );
+            // The presence variants diverge only in the tail past that prefix, and stay in
+            // the system message (framing is system-role instruction, not a conversation
+            // turn — so the ask remains the last conversation message).
+            assert!(
+                directed.system.contains("This message names you")
+                    && !undirected.system.contains("This message names you"),
+                "the directed presence variant renders in the system tail, past the reusable prefix"
             );
         }
 

--- a/core/continuum-core/src/resources/mod.rs
+++ b/core/continuum-core/src/resources/mod.rs
@@ -174,6 +174,7 @@ pub mod daemon;
 pub mod governor;
 pub mod ledger;
 pub mod lease;
+pub mod mode_policy;
 pub mod placement;
 
 pub use crate::cognition::{
@@ -196,3 +197,4 @@ pub use consumer::{
 };
 pub use ledger::{KindLedger, LeaseBoard, ResourceLeaseLedger};
 pub use lease::{LeaseError, LeaseRequest, ReclaimPolicy, ResourceKind, ResourceLease};
+pub use mode_policy::{ConsumerDemand, ConsumerRole, GovernorMode, PolicyFloor, Price};

--- a/core/continuum-core/src/resources/mode_policy.rs
+++ b/core/continuum-core/src/resources/mode_policy.rs
@@ -1,0 +1,255 @@
+//! `mode_policy` — operating MODES as pure lease policy (#395).
+//!
+//! An operating mode ("maximize benchmark capacity", "dev sim", "balanced") is NOT
+//! new plumbing on top of the [`ResourceGovernor`](crate::resources::ResourceGovernor).
+//! It is a CONFIGURATION of the lease primitives that already exist: per-consumer
+//! reservation floors ([`ResourceDaemon::reserve`](crate::resources::ResourceDaemon::reserve)),
+//! `serving_fraction`, and [`ReclaimPolicy`](crate::resources::ReclaimPolicy). This module
+//! is the pure decision function that turns a mode + a LOCAL view of the resident
+//! consumers into the floors the governor should hold. Nothing here touches the daemon,
+//! the board, or any I/O — the caller applies the result via `reserve(...)`.
+//!
+//! # Coordinator-free by construction (the box → grid → P2P constraint)
+//!
+//! [`GovernorMode::floors`] is `fn(&[ConsumerDemand]) -> Vec<PolicyFloor>` — a pure
+//! function of a LOCAL view. It never reads a global authority, so the SAME object runs
+//! per-node on one box today, composes into the grid market next, and drops into the P2P
+//! "wireless" arbiter (radios sharing a finite medium, no central controller) with no
+//! rewrite. A local peer that decides from what it can see is exactly what a coordinator-
+//! free protocol needs. Do NOT introduce a "the governor knows everything" dependency
+//! here — that is the thing that would force a rewrite at the grid/P2P boundary.
+//!
+//! # Cost is always present, even when donated
+//!
+//! Every [`PolicyFloor`] carries a [`Price`]. Compute has a real cost basis (energy, wear,
+//! opportunity) and every allocation is, in principle, an exchange. "Free" / "donated" is
+//! NOT the absence of cost — it is a transaction at [`Price::FREE`] where the owner bears
+//! (gifts) the cost. So the cost term exists from day one (the market / alt-coin settlement
+//! layer slots in later as a pricing policy, no rewrite); the initial modes just price at
+//! zero among trusted peers, and a [`ConsumerDemand::gift`] is always free regardless of
+//! mode. You can always answer "what did this cost, and who paid" — a gift answers "the
+//! owner". This is honest accounting, not the economy.
+//!
+//! # Roles, not id string-matching
+//!
+//! Policy switches on a consumer's [`ConsumerRole`], never on its id string (the `#70`
+//! smell). A new consumer joins by declaring its role; the modes keep working with no edit.
+
+use crate::resources::ResourceKind;
+
+/// What KIND of consumer this is, for policy purposes — the axis a mode reasons over.
+/// Distinct from the consumer's string id (which is identity, not policy).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ConsumerRole {
+    /// The base-model serving lane(s) — the persona brain AND the benchmark lane share
+    /// this role on the VRAM axis (they are one VRAM consumer; benchmark-vs-persona is
+    /// differentiated by the throughput-lease layer, not by VRAM floors).
+    Serving,
+    /// The recall embedding lane — cognition needs it every turn.
+    Embedding,
+    /// A vision / VL lane (image understanding). Optional for text-only workloads.
+    Vision,
+    /// A realtime media consumer — a live call, an avatar render (latency-critical).
+    Realtime,
+    /// Anything else that leases (a game, a batch render) — squeezed first under pressure.
+    Other,
+}
+
+/// The price the arbiter attaches to an allocation. Always present; `FREE` means the
+/// owner gifted the cost (the transaction is still real, its price is just zero).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Price {
+    /// Units of account per byte-second (or whatever the settlement layer later fixes).
+    /// `0.0` = free / donated. The market / alt-coin layer changes only THIS number.
+    pub per_unit: f64,
+}
+
+impl Price {
+    /// A gifted / donated allocation — the cost is borne by the owner, the price is zero.
+    pub const FREE: Price = Price { per_unit: 0.0 };
+}
+
+/// A LOCAL view of one resident consumer, as this node sees it right now — the input the
+/// policy decides from. Deliberately carries no handle to any global authority.
+#[derive(Debug, Clone)]
+pub struct ConsumerDemand {
+    /// The consumer's stable id (`"serving"`, `"embed"`, a VL lane id, …) — used only to
+    /// key the resulting floor back onto `reserve(...)`, never to decide policy.
+    pub id: String,
+    /// The policy axis this consumer sits on.
+    pub role: ConsumerRole,
+    /// The resource this demand is for (VRAM today; the same policy generalizes to RAM/disk).
+    pub kind: ResourceKind,
+    /// Its measured resident footprint in bytes — the floor a mode grants when it protects
+    /// this consumer. Measured, never a magic constant (that is the honest-accounting rule).
+    pub footprint_bytes: u64,
+    /// This consumer's capacity is donated: its owner bears the cost, so its price is always
+    /// [`Price::FREE`] regardless of mode.
+    pub gift: bool,
+}
+
+/// The policy's decision for one consumer: the VRAM floor the governor should hold for it
+/// under the active mode, plus the price. Maps 1:1 onto
+/// `ResourceDaemon::reserve(consumer_id, kind, floor_bytes)`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PolicyFloor {
+    pub consumer_id: String,
+    pub kind: ResourceKind,
+    /// The reservation floor to hold. `0` means "protect nothing — this consumer's bytes
+    /// are reclaimable for whoever the mode favors" (its `Graceful` lease can be evicted).
+    pub floor_bytes: u64,
+    pub price: Price,
+}
+
+/// The operating mode — a named lease policy. This is the dial a human, a `PowerMode`, or
+/// (later) a learned/market policy turns; the governor cannot tell them apart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GovernorMode {
+    /// Everyone keeps their measured footprint — no consumer is starved. The friendly
+    /// default: the box serves its whole population fairly.
+    #[default]
+    Balanced,
+    /// Maximize benchmark capacity: protect the serving lane's full footprint, drop every
+    /// OTHER consumer's floor to zero so their `Graceful` leases reclaim and the GPU frees
+    /// for the run. Vision + embedding + media all yield to the benchmark.
+    BenchmarkMax,
+    /// Development simulation: protect serving AND embedding (recall is load-bearing for a
+    /// coding persona's cognition every turn), but yield vision + realtime + other.
+    DevSim,
+}
+
+impl GovernorMode {
+    /// The pure decision. Given a LOCAL view of the resident consumers, return the floor +
+    /// price the governor should hold for each under this mode. Order-preserving; total
+    /// (every input gets exactly one output). No global state, no I/O.
+    pub fn floors(self, demands: &[ConsumerDemand]) -> Vec<PolicyFloor> {
+        demands
+            .iter()
+            .map(|d| PolicyFloor {
+                consumer_id: d.id.clone(),
+                kind: d.kind,
+                floor_bytes: if self.protects(d.role) { d.footprint_bytes } else { 0 },
+                // Cost is always present; a gifted consumer is free regardless of mode, and
+                // the initial modes price everything at zero (free among trusted peers).
+                // The market / alt-coin settlement layer replaces ONLY this value.
+                price: if d.gift { Price::FREE } else { self.price_for(d.role) },
+            })
+            .collect()
+    }
+
+    /// Does this mode PROTECT (hold the full footprint of) a consumer with this role, or
+    /// yield it (floor 0, reclaimable)?
+    fn protects(self, role: ConsumerRole) -> bool {
+        match self {
+            // Everyone protected — nobody starved.
+            GovernorMode::Balanced => true,
+            // Only the serving lane; everything else yields to the benchmark.
+            GovernorMode::BenchmarkMax => role == ConsumerRole::Serving,
+            // Serving + recall embedding; vision / realtime / other yield.
+            GovernorMode::DevSim => matches!(role, ConsumerRole::Serving | ConsumerRole::Embedding),
+        }
+    }
+
+    /// The price this mode attaches to a (non-gifted) consumer's allocation. All current
+    /// modes are FREE — the cost term is present and honest, but nothing charges yet; the
+    /// market / alt-coin layer is a later pricing policy that changes only this.
+    fn price_for(self, _role: ConsumerRole) -> Price {
+        Price::FREE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn demand(id: &str, role: ConsumerRole, bytes: u64, gift: bool) -> ConsumerDemand {
+        ConsumerDemand { id: id.into(), role, kind: ResourceKind::Vram, footprint_bytes: bytes, gift }
+    }
+
+    /// A representative LAN-party box: a serving lane, the recall embed lane, a VL vision
+    /// lane, and a game — the exact co-residency that wedged Devstral live (#385/#395).
+    fn box_demands() -> Vec<ConsumerDemand> {
+        vec![
+            demand("serving", ConsumerRole::Serving, 22_000, false),
+            demand("embed", ConsumerRole::Embedding, 1_800, false),
+            demand("vl", ConsumerRole::Vision, 2_800, false),
+            demand("game", ConsumerRole::Other, 4_000, false),
+        ]
+    }
+
+    fn floor_of<'a>(fs: &'a [PolicyFloor], id: &str) -> &'a PolicyFloor {
+        fs.iter().find(|f| f.consumer_id == id).expect("consumer present in output")
+    }
+
+    // what this catches (#395): benchmark-max must protect ONLY the serving lane and drop
+    // every other consumer's floor to 0 so their Graceful leases reclaim — that is how the
+    // mode frees the GPU for the run. A regression that kept VL/embed/game floors would
+    // leave the run oversubscribed (the live wedge this targets).
+    #[test]
+    fn benchmark_max_protects_only_serving_and_yields_the_rest() {
+        let fs = GovernorMode::BenchmarkMax.floors(&box_demands());
+        assert_eq!(floor_of(&fs, "serving").floor_bytes, 22_000, "serving keeps its full footprint");
+        assert_eq!(floor_of(&fs, "embed").floor_bytes, 0, "embed yields to the benchmark");
+        assert_eq!(floor_of(&fs, "vl").floor_bytes, 0, "vision yields to the benchmark");
+        assert_eq!(floor_of(&fs, "game").floor_bytes, 0, "the game yields to the benchmark");
+    }
+
+    // what this catches: dev-sim protects serving AND recall embedding (a coding persona
+    // needs recall every turn) but still yields vision + other — the distinction from
+    // benchmark-max lives in which NON-serving consumers survive.
+    #[test]
+    fn dev_sim_protects_serving_and_embedding_but_yields_vision_and_other() {
+        let fs = GovernorMode::DevSim.floors(&box_demands());
+        assert_eq!(floor_of(&fs, "serving").floor_bytes, 22_000);
+        assert_eq!(floor_of(&fs, "embed").floor_bytes, 1_800, "recall survives in dev-sim");
+        assert_eq!(floor_of(&fs, "vl").floor_bytes, 0, "no vision in a coding sim");
+        assert_eq!(floor_of(&fs, "game").floor_bytes, 0);
+    }
+
+    // what this catches: the default mode starves nobody — every consumer keeps its
+    // measured footprint (the friendly whole-population default).
+    #[test]
+    fn balanced_protects_every_consumers_full_footprint() {
+        let fs = GovernorMode::default().floors(&box_demands());
+        assert_eq!(GovernorMode::default(), GovernorMode::Balanced);
+        for d in box_demands() {
+            assert_eq!(floor_of(&fs, &d.id).floor_bytes, d.footprint_bytes, "{} kept whole", d.id);
+        }
+    }
+
+    // what this catches: the floor is exactly the MEASURED footprint, never a magic
+    // constant — protect a consumer and its floor equals what it actually holds (honest
+    // accounting; the thing that would drift if someone hardcoded a number).
+    #[test]
+    fn protected_floor_equals_measured_footprint_not_a_constant() {
+        let one = vec![demand("serving", ConsumerRole::Serving, 13_579, false)];
+        assert_eq!(GovernorMode::Balanced.floors(&one)[0].floor_bytes, 13_579);
+    }
+
+    // what this catches (cost-is-always-present, even donated): every floor carries a
+    // Price; the current modes price at FREE; and a GIFTED consumer is FREE regardless of
+    // mode — the exchange is real, its price is just zero and the owner bears the cost.
+    #[test]
+    fn cost_is_present_and_a_gift_is_free_regardless_of_mode() {
+        let donated = vec![
+            demand("serving", ConsumerRole::Serving, 22_000, false),
+            demand("friends-gpu", ConsumerRole::Serving, 8_000, true), // a friend lent their box
+        ];
+        for mode in [GovernorMode::Balanced, GovernorMode::BenchmarkMax, GovernorMode::DevSim] {
+            let fs = mode.floors(&donated);
+            assert_eq!(floor_of(&fs, "friends-gpu").price, Price::FREE, "a gift is always free ({mode:?})");
+            assert_eq!(floor_of(&fs, "serving").price, Price::FREE, "current modes price free ({mode:?})");
+        }
+    }
+
+    // what this catches (coordinator-free, box→grid→P2P): the decision is a pure function
+    // of the LOCAL view — same input always yields the same output, no hidden global
+    // state. A regression that reached for a global authority would make this
+    // non-deterministic across processes and break the P2P wireless-arbiter reuse.
+    #[test]
+    fn decision_is_a_pure_function_of_the_local_view() {
+        let d = box_demands();
+        assert_eq!(GovernorMode::BenchmarkMax.floors(&d), GovernorMode::BenchmarkMax.floors(&d));
+        assert_eq!(GovernorMode::BenchmarkMax.floors(&[]), Vec::<PolicyFloor>::new());
+    }
+}


### PR DESCRIPTION
Clean linear stack on canary (10 commits, no conflicts, FF-able). Three related cognition/resources concerns, each unit-green; reviewable commit-by-commit.

## #266 — KV-cache prompt-instability fix (framing renders LAST)
- `cdfa4f2b9` split the system prompt at the KV-cache boundary (scaffolding + invariant gate)
- `93be9dbd1` render per-turn framing LAST so the served slot's reusable KV prefix caches **through** the grounding
- Root cause (from raw prompt-captures): the presence/own-time framing block sat at char ~7607 **before** the assembled context and hard-flips every turn (DIRECTED/WORKING/SILENCE), cutting the reusable prefix to that point and re-prefilling the tail. Fix is pure block **order** — framing now rides the trailing segment.
- Decision that matters (don't undo): framing stays SYSTEM-role, just reordered after grounding — NOT pushed onto a trailing user turn (that broke ask-last + biased undirected turns toward the #264 idle-PASS affordance).
- **STILL OWED:** live before/after cache-reuse A/B on a healthy lane (deploy-gated).

## #392 — typed Observation refactor + 18057 actuator
- `583b07f3e`..`a4412cbd1` typed Observation steps 0–6 (new `observation.rs` types + renderers → `apply_act` returns `ActOutcome` → WorkingMemory stores typed acts → seam-5 predicates off receipt prose → render_recency/render_recall as sole producers → typed-thread acceptance assertion)
- `3dafcb3ea` pin the just-executed act's result so attention can't evict it (the real result-drop fix)
- **STILL OWED:** live 18057 re-run on a healthy lane.

## #395 slice 1 — coordinator-free ResourcePolicy
- `b23e6cb7b` operating modes as **pure lease policy** — `GovernorMode{Balanced/BenchmarkMax/DevSim}::floors(&[ConsumerDemand]) -> Vec<PolicyFloor>`, a pure function of the LOCAL view (role-based, not id string-matching), cost first-class (`Price`, gift = FREE regardless of mode). Maps 1:1 onto `ResourceDaemon::reserve`. Coordinator-free so the same object scales box → grid → P2P. 6/6 tests pin every invariant.
- Slice 2 (VL-as-consumer) spec'd on #395, deferred (spawn-path integration).

## Test status
Cognition suite green (947); `mode_policy` 6/6 green. ts-rs bindings regenerated (Observation/ActOutcome/ActStatus/ToolOutput/ToolVerb + mode_policy exports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)