### PR TITLE
Grid-elastic capability: grid_budget + settlement, and the design behind them

### DIFF
--- a/core/continuum-core/src/capacity/grid_budget.rs
+++ b/core/continuum-core/src/capacity/grid_budget.rs
@@ -1,0 +1,323 @@
+//! `grid_budget` — what the best single reachable node can serve, right now.
+//!
+//! The CONSUME half of the grid loop. The contribute half already runs:
+//! [`crate::modules::grid_capacity::GridCapacityModule`] publishes this node's
+//! `CapacityOffer` every tick, and `airc::inbound_attach` folds every heard offer
+//! into [`crate::capacity::gossip::global_ledger`]. This module reads that
+//! ledger's snapshot and answers one question: **what is the largest serving
+//! budget available to me on the grid this instant?**
+//!
+//! See `docs/architecture/GRID-ELASTIC-CAPABILITY.md`. Three constraints shape
+//! every line here, and all three are Joel's:
+//!
+//! ## 1. NEVER A POOL — `max`, never `sum`
+//!
+//! `provisioning/placement_planner.rs` asserts it directly: *two 20GiB peers must
+//! NOT fit a 40GiB model*. Summing memory across machines to host one bigger
+//! model is the exo approach, and it trades a working mind for a slow one. So the
+//! grid budget is the **best single node's** usable bytes. A grid of ten laptops
+//! is still a laptop-sized budget; it is ten laptops' worth of *citizens*, which
+//! is a different lever (see the doc's population axis).
+//!
+//! ## 2. BOTH ENDS — solo is a grid of one, and there is NO branch
+//!
+//! Every node runs the local end (fit to my own capacity — the end that never
+//! blocks, including in total partition) and the grid end (consume peers' spare)
+//! through the *same code*. There is deliberately no `if peers.is_empty()` fast
+//! path: `max` over `{local}` is `local`, which is exactly today's behavior. The
+//! tempting optimization would reintroduce two paths that drift, and the
+//! solo-node test below exists to catch anyone adding it back.
+//!
+//! ## 3. SYMMETRIC ROLE — no node types, no central authority
+//!
+//! Every node computes this for itself from its own view. There is no
+//! coordinator, no placer, and no "provider node" type — a machine that only ever
+//! provides is simply a node whose local demand is currently zero and which could
+//! consume at any instant. This function is therefore pure and local: it reads a
+//! snapshot and returns a number. It never decides anything *for* another node.
+
+use crate::capacity::grid::GridSnapshot;
+use crate::capacity::DeviceCapacity;
+
+/// Which node a budget came from — carried so the decision is legible rather than
+/// an unexplained number.
+///
+/// "The budget went up" with no attribution is the shape of bug this codebase
+/// keeps relearning; a consumer that can name the source can also notice when the
+/// source is itself wrong.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BudgetSource {
+    /// This machine. Also the answer when there are no reachable peers at all —
+    /// solo is a grid of one, not a special case.
+    Local,
+    /// A reachable peer, identified for the record.
+    Peer(String),
+}
+
+/// The best serving budget reachable this instant, and where it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GridBudget {
+    /// Free serving bytes on the winning node. NEVER a sum across nodes.
+    pub usable_bytes: u64,
+    /// The winning node's PHYSICAL ceiling.
+    ///
+    /// Carried because the consumer clamps free against total
+    /// (`host_budget_from` does `available.min(total_vram)`), and that clamp must
+    /// use the winner's device — not this machine's. Passing a 32GB peer's free
+    /// bytes while still clamping to a local 8GB card would silently discard the
+    /// entire point of the projection, and it would look like the feature simply
+    /// did nothing.
+    pub total_bytes: u64,
+    pub source: BudgetSource,
+    /// How many nodes were considered, local included. `1` means solo.
+    ///
+    /// This is the population signal — the count lever, kept separate from the
+    /// byte lever so nobody is tempted to conflate "more nodes" with "more bytes".
+    pub reachable_nodes: u32,
+}
+
+impl GridBudget {
+    /// Is the winning budget somewhere other than this machine?
+    pub fn is_remote(&self) -> bool {
+        matches!(self.source, BudgetSource::Peer(_))
+    }
+}
+
+/// What a single device can actually put toward serving.
+///
+/// Free bytes, not total: a node with a 32GB card already hosting something has
+/// less to offer than its spec sheet says, and offering the spec sheet is the
+/// fabricated-capacity lie the per-node honesty rules exist to prevent.
+fn servable_bytes(cap: &DeviceCapacity) -> u64 {
+    // Clamp PER NODE, mirroring `host_budget_from`'s `available.min(total_vram)`.
+    // It must happen here, before the max, because clamping afterwards would
+    // measure a remote node against the LOCAL card's ceiling.
+    cap.gpu_free_bytes_live.min(cap.gpu_total_bytes)
+}
+
+/// The best single reachable node's serving budget.
+///
+/// Pure: a snapshot in, a number out. No I/O, no locks, no decisions on behalf of
+/// any other node — see the module docs on symmetric role.
+///
+/// Unreachable peers are excluded rather than counted at zero. An unreachable
+/// node is a memory, not an offer; counting it as a zero-byte participant would
+/// quietly drag the population signal while contributing nothing.
+pub fn grid_budget(snapshot: &GridSnapshot) -> GridBudget {
+    let local_bytes = servable_bytes(&snapshot.local);
+
+    // Start from local and let peers WIN, never ACCUMULATE. The fold is a max,
+    // and that is the entire never-a-pool discipline in one operator.
+    let mut best = GridBudget {
+        usable_bytes: local_bytes,
+        total_bytes: snapshot.local.gpu_total_bytes,
+        source: BudgetSource::Local,
+        reachable_nodes: 1, // this node always counts; it is never unreachable to itself
+    };
+
+    for peer in snapshot.peers.iter().filter(|p| p.reachable) {
+        best.reachable_nodes = best.reachable_nodes.saturating_add(1);
+        let bytes = servable_bytes(&peer.capacity);
+        // Strictly greater: ties keep LOCAL. Preferring home on a tie avoids
+        // pointlessly nominating a remote node for a budget we already have here,
+        // and it keeps the solo-equivalence property exact.
+        if bytes > best.usable_bytes {
+            best.usable_bytes = bytes;
+            best.total_bytes = peer.capacity.gpu_total_bytes;
+            best.source = BudgetSource::Peer(peer.peer.to_string());
+        }
+    }
+
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capacity::grid::PeerCapacity;
+
+    fn dev(free_gb: u64) -> DeviceCapacity {
+        DeviceCapacity {
+            gpu_total_bytes: 64 * 1024 * 1024 * 1024,
+            gpu_free_bytes_live: free_gb * 1024 * 1024 * 1024,
+            system_ram_free_bytes: 16 * 1024 * 1024 * 1024,
+        }
+    }
+
+    fn peer(id: u128, free_gb: u64, reachable: bool) -> PeerCapacity {
+        PeerCapacity {
+            peer: airc_core::PeerId(uuid::Uuid::from_u128(id)),
+            capacity: dev(free_gb),
+            reachable,
+        }
+    }
+
+    fn gb(n: u64) -> u64 {
+        n * 1024 * 1024 * 1024
+    }
+
+    /// what this catches: an accidental grid-mode/solo-mode branch. A node with no
+    /// peers must plan EXACTLY as it does today — that is the whole "both ends, no
+    /// branch" rule (doc §3b). If someone adds `if peers.is_empty() { ... }`, the
+    /// two paths will drift and this is the test that notices.
+    #[test]
+    fn solo_is_a_grid_of_one_and_equals_the_local_budget() {
+        let snap = GridSnapshot {
+            local: dev(20),
+            peers: vec![],
+        };
+        let b = grid_budget(&snap);
+        assert_eq!(b.usable_bytes, gb(20), "solo budget IS the local budget");
+        assert_eq!(b.source, BudgetSource::Local);
+        assert_eq!(b.reachable_nodes, 1, "the node always counts itself");
+        assert!(!b.is_remote());
+    }
+
+    /// what this catches: THE never-a-pool violation. Two 20GiB peers must not add
+    /// up to a 40GiB budget. If this ever fails we have become exo — sharding a
+    /// model across machines to make it "fit" — which trades a working mind for a
+    /// slow one.
+    #[test]
+    fn two_peers_never_pool_into_a_bigger_budget() {
+        let snap = GridSnapshot {
+            local: dev(8),
+            peers: vec![peer(1, 20, true), peer(2, 20, true)],
+        };
+        let b = grid_budget(&snap);
+        assert_eq!(b.usable_bytes, gb(20), "max, never sum — 20 not 40, and not 48");
+        assert_eq!(b.reachable_nodes, 3, "all three counted for POPULATION");
+    }
+
+    /// what this catches: the actual point of the feature. A capable peer joining
+    /// must raise what this node can plan for.
+    #[test]
+    fn a_bigger_reachable_peer_raises_the_budget_and_is_named() {
+        let snap = GridSnapshot {
+            local: dev(8),
+            peers: vec![peer(7, 32, true)],
+        };
+        let b = grid_budget(&snap);
+        assert_eq!(b.usable_bytes, gb(32));
+        assert!(b.is_remote(), "the win came from a peer and says so");
+        assert_eq!(b.source, BudgetSource::Peer(airc_core::PeerId(uuid::Uuid::from_u128(7)).to_string()));
+    }
+
+    /// what this catches: an unreachable node treated as an offer. A peer we
+    /// cannot reach is a memory, not capacity — counting it would promise a budget
+    /// that cannot be spent.
+    #[test]
+    fn unreachable_peers_are_not_offers() {
+        let snap = GridSnapshot {
+            local: dev(8),
+            peers: vec![peer(1, 64, false)],
+        };
+        let b = grid_budget(&snap);
+        assert_eq!(b.usable_bytes, gb(8), "the 64GB peer is unreachable — not an offer");
+        assert_eq!(b.source, BudgetSource::Local);
+        assert_eq!(
+            b.reachable_nodes, 1,
+            "and it must not inflate the population count either"
+        );
+    }
+
+    /// what this catches: total partition, which is doc §3b test 2. When every
+    /// peer drops, the node must fall back to EXACTLY its solo budget — the local
+    /// end never blocks.
+    #[test]
+    fn total_partition_falls_back_to_exactly_the_solo_budget() {
+        let local = dev(12);
+        let solo = grid_budget(&GridSnapshot {
+            local: local.clone(),
+            peers: vec![],
+        });
+        let partitioned = grid_budget(&GridSnapshot {
+            local,
+            peers: vec![peer(1, 64, false), peer(2, 48, false)],
+        });
+        assert_eq!(
+            partitioned, solo,
+            "a partitioned node and a solo node must be indistinguishable"
+        );
+    }
+
+    /// what this catches: a tie nominating a remote node for no reason. Equal
+    /// budgets should stay home — it keeps solo-equivalence exact and avoids
+    /// advertising a remote source we gain nothing from.
+    #[test]
+    fn ties_keep_the_budget_local() {
+        let snap = GridSnapshot {
+            local: dev(16),
+            peers: vec![peer(1, 16, true)],
+        };
+        assert_eq!(grid_budget(&snap).source, BudgetSource::Local);
+    }
+
+    /// what this catches: reading the spec sheet instead of the live reading. A
+    /// node with a big card that is already full has little to offer, and offering
+    /// its TOTAL would be the fabricated-capacity lie per-node honesty prevents.
+    #[test]
+    fn a_full_big_card_offers_its_free_bytes_not_its_total() {
+        let mut busy = dev(1);
+        busy.gpu_total_bytes = gb(80);
+        let snap = GridSnapshot {
+            local: dev(10),
+            peers: vec![PeerCapacity {
+                peer: airc_core::PeerId(uuid::Uuid::from_u128(9)),
+                capacity: busy,
+                reachable: true,
+            }],
+        };
+        let b = grid_budget(&snap);
+        assert_eq!(b.usable_bytes, gb(10), "1GB free beats nothing, not 80GB total");
+        assert_eq!(b.source, BudgetSource::Local);
+        assert_eq!(b.total_bytes, gb(64), "the LOCAL ceiling travels with a local win");
+    }
+
+    /// what this catches: the clamp being applied against the wrong device. The
+    /// consumer does `available.min(total_vram)`; if a peer wins, that ceiling has
+    /// to be the PEER's card. Clamping a 40GB peer to an 8GB local card would
+    /// silently discard the whole projection and look like the feature did
+    /// nothing at all.
+    #[test]
+    fn a_remote_win_carries_the_remote_ceiling_not_the_local_one() {
+        let mut small_local = dev(4);
+        small_local.gpu_total_bytes = gb(8);
+        let mut big_peer = dev(40);
+        big_peer.gpu_total_bytes = gb(48);
+        let snap = GridSnapshot {
+            local: small_local,
+            peers: vec![PeerCapacity {
+                peer: airc_core::PeerId(uuid::Uuid::from_u128(3)),
+                capacity: big_peer,
+                reachable: true,
+            }],
+        };
+        let b = grid_budget(&snap);
+        assert_eq!(b.usable_bytes, gb(40));
+        assert_eq!(
+            b.total_bytes,
+            gb(48),
+            "the winner's ceiling must travel with it, or the consumer clamps to 8GB"
+        );
+    }
+
+    /// what this catches: a peer reporting free > total (a bad or hostile offer).
+    /// Per-node clamping keeps one broken reading from inventing capacity.
+    #[test]
+    fn a_peer_claiming_more_free_than_it_has_is_clamped_to_its_own_total() {
+        let mut liar = dev(0);
+        liar.gpu_total_bytes = gb(4);
+        liar.gpu_free_bytes_live = gb(999);
+        let snap = GridSnapshot {
+            local: dev(10),
+            peers: vec![PeerCapacity {
+                peer: airc_core::PeerId(uuid::Uuid::from_u128(4)),
+                capacity: liar,
+                reachable: true,
+            }],
+        };
+        let b = grid_budget(&snap);
+        assert_eq!(b.usable_bytes, gb(10), "999GB claim clamps to its own 4GB total");
+        assert_eq!(b.source, BudgetSource::Local);
+    }
+}

--- a/core/continuum-core/src/capacity/mod.rs
+++ b/core/continuum-core/src/capacity/mod.rs
@@ -33,6 +33,7 @@ pub mod expert_ecache;
 pub mod expert_observer;
 pub mod expert_pager;
 pub mod grid_budget;
+pub mod settlement;
 pub mod host_cache_lease;
 pub mod expert_predictor;
 pub mod expert_reconcile;

--- a/core/continuum-core/src/capacity/mod.rs
+++ b/core/continuum-core/src/capacity/mod.rs
@@ -32,6 +32,7 @@ pub mod expert_depot;
 pub mod expert_ecache;
 pub mod expert_observer;
 pub mod expert_pager;
+pub mod grid_budget;
 pub mod host_cache_lease;
 pub mod expert_predictor;
 pub mod expert_reconcile;

--- a/core/continuum-core/src/capacity/settlement.rs
+++ b/core/continuum-core/src/capacity/settlement.rs
@@ -1,0 +1,338 @@
+//! Settlement — what was PROMISED against what was DELIVERED, and the divergence
+//! between them, which is reputation.
+//!
+//! The adversarial half of the market. `capacity::market::entry_price` values a
+//! node on its **self-reported specs** — an IPO on a prospectus nobody has
+//! audited. That is the fraud surface: a node overstating its free bytes is not
+//! buggy, it is **selling supply it cannot deliver**, and under a specs-only
+//! market it gets paid for it.
+//!
+//! Settlement is what makes the claim honest. The two halves are deliberately
+//! adversarial rather than two views of the same optimism: pricing is generous
+//! and forward-looking, settlement is strict and backward-looking, and reputation
+//! is the running record of where they disagreed.
+//!
+//! Joel's shape: **IPO on specs -> trade on delivery -> Merkle-ledger reputation
+//! -> market-as-selection.** A node that consistently oversells prices itself out
+//! without anyone policing it, because buyers can read its verification rate.
+//!
+//! ## The invariants, and where each comes from
+//!
+//! 1. **An unverifiable delivery is not a successful one.** No delivery record
+//!    means `Unsettled`, never `Honored`. Absence is not evidence — this is the
+//!    absence-rendered-as-a-positive-fact bug class restated as an economic rule.
+//!    A market that counts silence as success pays for work nobody observed.
+//! 2. **Overdelivery does not offset underdelivery.** Promises settle
+//!    individually; you cannot average your way out of a broken one. A node that
+//!    is magnificent four times and absent once has broken one promise, and the
+//!    buyer of the fifth does not care about the other four.
+//! 3. **A promise nobody could have kept is fraud at QUOTE time**, not a delivery
+//!    failure. Quoting above your own physical ceiling is detectable before any
+//!    work happens, and it is a different — worse — fact than failing to deliver
+//!    something plausible.
+//! 4. **Settlement is symmetric.** The same function judges MY deliveries to
+//!    peers. Every node is both consumer and provider (there are no node types),
+//!    and a market where you only ever grade others is not a market.
+
+use crate::capacity::grid_budget::BudgetSource;
+
+/// What a node committed to, at quote time.
+///
+/// `claimed_bytes` is the supply advertised for THIS transaction, and
+/// `node_total_bytes` is the physical ceiling it advertised for itself. Keeping
+/// both lets settlement distinguish "failed to deliver something plausible" from
+/// "quoted something impossible" — invariant 3.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Promise {
+    /// Who committed. `Local` means this node promised — settlement is symmetric.
+    pub seller: BudgetSource,
+    /// Supply advertised for this transaction.
+    pub claimed_bytes: u64,
+    /// The seller's own advertised physical ceiling at quote time.
+    pub node_total_bytes: u64,
+    /// What the buyer actually required, so a settlement can be read without the
+    /// original request in hand.
+    pub required_bytes: u64,
+}
+
+/// What actually happened. `None` at the call site means no record exists — and
+/// that is a distinct outcome from a recorded failure, not a synonym for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Delivery {
+    /// Did the work actually land?
+    pub landed: bool,
+    /// Supply actually made available. Measured, not claimed.
+    pub delivered_bytes: u64,
+}
+
+/// The verdict on one promise.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Verdict {
+    /// Delivered what was required. The only outcome that builds reputation.
+    Honored,
+    /// Reached the buyer, but short of the requirement.
+    Shortfall { missing_bytes: u64 },
+    /// The work did not land at all.
+    Failed,
+    /// **Impossible at quote time** — claimed more than its own advertised
+    /// ceiling. Detectable before any work happens, and a worse fact than a
+    /// delivery failure: this is a lie rather than a disappointment.
+    Overquoted { over_by_bytes: u64 },
+    /// No delivery record exists. NOT a success and NOT a failure — the market
+    /// simply cannot say, and saying otherwise invents evidence.
+    Unsettled,
+}
+
+impl Verdict {
+    /// Only `Honored` counts toward reputation. Everything else — including
+    /// `Unsettled` — does not, because a market that rewards unobserved work
+    /// rewards claiming rather than doing.
+    pub fn builds_reputation(&self) -> bool {
+        matches!(self, Verdict::Honored)
+    }
+
+    /// Did the seller assert something untrue, as opposed to merely
+    /// underperforming? Overquoting is the fraud signal; a shortfall is a bad
+    /// day. Conflating them would let genuine overselling hide inside ordinary
+    /// variance.
+    pub fn is_dishonest(&self) -> bool {
+        matches!(self, Verdict::Overquoted { .. })
+    }
+}
+
+/// One settled transaction, ready to append to the ledger.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Settlement {
+    pub seller: BudgetSource,
+    pub verdict: Verdict,
+}
+
+/// Settle one promise against its delivery.
+///
+/// Pure: no I/O, no clock, no ledger writes — so the rule that decides whether a
+/// node gets paid is unit-testable in isolation, and there is exactly one place
+/// it is decided.
+///
+/// Order matters. The quote-time check runs FIRST: a node that promised more than
+/// it physically has is `Overquoted` even if it happens to deliver, because it
+/// got lucky rather than honest, and the market should price the claim it made.
+pub fn settle(promise: &Promise, delivery: Option<&Delivery>) -> Settlement {
+    let verdict = if promise.claimed_bytes > promise.node_total_bytes {
+        // Invariant 3 — checkable before any work happens. Same shape as
+        // grid_budget's per-node clamp, which refuses to believe an offer larger
+        // than the offering node.
+        Verdict::Overquoted {
+            over_by_bytes: promise.claimed_bytes - promise.node_total_bytes,
+        }
+    } else {
+        match delivery {
+            // Invariant 1 — no record is not a pass.
+            None => Verdict::Unsettled,
+            Some(d) if !d.landed => Verdict::Failed,
+            Some(d) if d.delivered_bytes < promise.required_bytes => Verdict::Shortfall {
+                missing_bytes: promise.required_bytes - d.delivered_bytes,
+            },
+            Some(_) => Verdict::Honored,
+        }
+    };
+
+    Settlement {
+        seller: promise.seller.clone(),
+        verdict,
+    }
+}
+
+/// A node's standing, derived from settled transactions.
+///
+/// Reputation is a **verification rate**, not a score someone assigns: honored
+/// over settled. Deliberately NOT "honored over all promises" — an unsettled
+/// promise is evidence of nothing and must not be allowed to dilute a record in
+/// either direction (invariant 1 again, on the aggregate).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Reputation {
+    pub honored: u32,
+    /// Settled transactions — those the market could actually judge.
+    pub settled: u32,
+    /// Promises that could not be judged at all. Surfaced rather than folded in,
+    /// because a seller with many unsettled promises is itself a signal.
+    pub unsettled: u32,
+    /// Quote-time lies. Tracked separately from shortfalls: a buyer may forgive a
+    /// bad day, but overquoting is a statement about the seller.
+    pub dishonest: u32,
+}
+
+impl Reputation {
+    /// Fold one settlement in.
+    pub fn record(&mut self, s: &Settlement) {
+        match &s.verdict {
+            Verdict::Unsettled => {
+                self.unsettled = self.unsettled.saturating_add(1);
+                return; // never counts as settled — invariant 1
+            }
+            Verdict::Overquoted { .. } => self.dishonest = self.dishonest.saturating_add(1),
+            _ => {}
+        }
+        self.settled = self.settled.saturating_add(1);
+        if s.verdict.builds_reputation() {
+            self.honored = self.honored.saturating_add(1);
+        }
+    }
+
+    /// Honored / settled. `None` when nothing has been settled — an unproven
+    /// seller is UNKNOWN, not perfect and not bad. Returning 1.0 for a node with
+    /// no history would let a fresh identity outrank a proven one, which is the
+    /// cheapest attack on any reputation system.
+    pub fn verification_rate(&self) -> Option<f64> {
+        (self.settled > 0).then(|| self.honored as f64 / self.settled as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gb(n: u64) -> u64 {
+        n * 1024 * 1024 * 1024
+    }
+
+    fn promise(claimed: u64, total: u64, required: u64) -> Promise {
+        Promise {
+            seller: BudgetSource::Peer("peer-a".into()),
+            claimed_bytes: claimed,
+            node_total_bytes: total,
+            required_bytes: required,
+        }
+    }
+
+    /// what this catches: silence counted as success. A market that pays for
+    /// unobserved work pays for CLAIMING rather than DOING — the
+    /// absence-as-positive-fact class with money attached.
+    #[test]
+    fn a_missing_delivery_record_is_unsettled_never_honored() {
+        let s = settle(&promise(gb(16), gb(24), gb(16)), None);
+        assert_eq!(s.verdict, Verdict::Unsettled);
+        assert!(!s.verdict.builds_reputation(), "unobserved is not delivered");
+    }
+
+    /// what this catches: overquoting hiding inside ordinary variance. Claiming
+    /// more than you physically have is detectable at QUOTE time and is a
+    /// different, worse fact than underdelivering something plausible.
+    #[test]
+    fn quoting_above_your_own_ceiling_is_dishonest_not_merely_short() {
+        let s = settle(&promise(gb(64), gb(24), gb(16)), None);
+        assert_eq!(s.verdict, Verdict::Overquoted { over_by_bytes: gb(40) });
+        assert!(s.verdict.is_dishonest());
+    }
+
+    /// what this catches: getting away with a lie by getting lucky. A node that
+    /// promised what it does not have is dishonest even when the delivery
+    /// happens to land — the market prices the CLAIM it made.
+    #[test]
+    fn overquoting_is_dishonest_even_when_the_delivery_lands() {
+        let d = Delivery {
+            landed: true,
+            delivered_bytes: gb(16),
+        };
+        let s = settle(&promise(gb(64), gb(24), gb(16)), Some(&d));
+        assert!(s.verdict.is_dishonest(), "lucky is not honest: {:?}", s.verdict);
+    }
+
+    #[test]
+    fn delivering_the_requirement_is_honored() {
+        let d = Delivery {
+            landed: true,
+            delivered_bytes: gb(16),
+        };
+        let s = settle(&promise(gb(16), gb(24), gb(16)), Some(&d));
+        assert_eq!(s.verdict, Verdict::Honored);
+        assert!(s.verdict.builds_reputation());
+    }
+
+    /// what this catches: averaging away a broken promise. Promises settle
+    /// individually — the buyer of the failed one does not care about the four
+    /// that worked.
+    #[test]
+    fn overdelivery_does_not_offset_a_separate_broken_promise() {
+        let mut rep = Reputation::default();
+        let generous = Delivery {
+            landed: true,
+            delivered_bytes: gb(64),
+        };
+        for _ in 0..4 {
+            rep.record(&settle(&promise(gb(16), gb(64), gb(16)), Some(&generous)));
+        }
+        rep.record(&settle(
+            &promise(gb(16), gb(64), gb(16)),
+            Some(&Delivery {
+                landed: false,
+                delivered_bytes: 0,
+            }),
+        ));
+        assert_eq!(rep.settled, 5);
+        assert_eq!(rep.honored, 4);
+        assert_eq!(
+            rep.verification_rate(),
+            Some(0.8),
+            "four generous deliveries do not erase one failure"
+        );
+    }
+
+    /// what this catches: unsettled promises diluting a record in EITHER
+    /// direction. They are evidence of nothing and must stay out of the rate,
+    /// while remaining visible as their own count.
+    #[test]
+    fn unsettled_promises_stay_out_of_the_rate_but_remain_visible() {
+        let mut rep = Reputation::default();
+        let ok = Delivery {
+            landed: true,
+            delivered_bytes: gb(16),
+        };
+        rep.record(&settle(&promise(gb(16), gb(64), gb(16)), Some(&ok)));
+        rep.record(&settle(&promise(gb(16), gb(64), gb(16)), None));
+        rep.record(&settle(&promise(gb(16), gb(64), gb(16)), None));
+        assert_eq!(rep.settled, 1, "only judgeable transactions are settled");
+        assert_eq!(rep.unsettled, 2, "but the unjudgeable ones are not hidden");
+        assert_eq!(rep.verification_rate(), Some(1.0));
+    }
+
+    /// what this catches: THE cheapest attack on any reputation system — a fresh
+    /// identity outranking a proven one. An unproven seller is UNKNOWN, not
+    /// perfect. If this ever returns 1.0, sybil nodes win every auction.
+    #[test]
+    fn an_unproven_seller_is_unknown_not_perfect() {
+        assert_eq!(Reputation::default().verification_rate(), None);
+    }
+
+    /// what this catches: a one-sided market. Settlement must judge OUR
+    /// deliveries too — every node is consumer and provider, and grading only
+    /// others is not a market.
+    #[test]
+    fn settlement_judges_local_deliveries_the_same_way() {
+        let mine = Promise {
+            seller: BudgetSource::Local,
+            claimed_bytes: gb(32),
+            node_total_bytes: gb(16),
+            required_bytes: gb(8),
+        };
+        let s = settle(&mine, None);
+        assert!(
+            s.verdict.is_dishonest(),
+            "our own overquote is judged exactly like a peer's"
+        );
+        assert_eq!(s.seller, BudgetSource::Local);
+    }
+
+    /// what this catches: a shortfall silently rounded to success. Landing but
+    /// under the requirement is its own verdict, and it names the gap.
+    #[test]
+    fn landing_under_the_requirement_is_a_named_shortfall() {
+        let d = Delivery {
+            landed: true,
+            delivered_bytes: gb(10),
+        };
+        let s = settle(&promise(gb(16), gb(64), gb(16)), Some(&d));
+        assert_eq!(s.verdict, Verdict::Shortfall { missing_bytes: gb(6) });
+        assert!(!s.verdict.builds_reputation());
+        assert!(!s.verdict.is_dishonest(), "a bad day is not a lie");
+    }
+}

--- a/core/continuum-core/src/capacity/settlement.rs
+++ b/core/continuum-core/src/capacity/settlement.rs
@@ -185,6 +185,39 @@ impl Reputation {
     pub fn verification_rate(&self) -> Option<f64> {
         (self.settled > 0).then(|| self.honored as f64 / self.settled as f64)
     }
+
+    /// **The number a market should price on.** A confidence-discounted rate:
+    /// evidence earns trust, and absence of evidence earns a little.
+    ///
+    /// `(honored + PRIOR_GOOD) / (settled + PRIOR_GOOD + PRIOR_BAD)` — a Beta
+    /// prior, i.e. pseudo-counts representing skepticism toward the unproven.
+    ///
+    /// Why not `verification_rate()` directly: a market that prices on the raw
+    /// rate has to answer "what about no data?", and BOTH obvious answers are
+    /// wrong. Pricing unknown as **perfect** is the sybil hole — measured on the
+    /// grid market sim at 100/100 jobs absorbed with the honest node fully
+    /// starved, because minting an identity is cheap and each fresh one wins at
+    /// the best price. Pricing unknown as **worst** excludes every newcomer, and
+    /// a market nobody can enter is not a market either.
+    ///
+    /// The prior dissolves the question. With the constants below an unproven
+    /// seller starts at 0.2 — well beneath a proven performer (→ 1.0), well above
+    /// a demonstrated failure (→ 0.0). It wins *occasionally*, when proven nodes
+    /// are expensive or busy, which is exactly the capped probe budget bounded
+    /// exploration wants: **a newcomer buys standing with delivered work, and
+    /// minting N identities buys N small chances rather than N free wins.**
+    ///
+    /// Monotone in evidence, which is what makes it safe to price on: honoring
+    /// raises it, failing lowers it, and no amount of churn resets an identity to
+    /// better than 0.2.
+    pub fn trust_lower_bound(&self) -> f64 {
+        /// Optimism granted to the unproven — the size of the probe budget.
+        const PRIOR_GOOD: f64 = 1.0;
+        /// Skepticism toward the unproven. The ratio sets the newcomer's start.
+        const PRIOR_BAD: f64 = 4.0;
+
+        (self.honored as f64 + PRIOR_GOOD) / (self.settled as f64 + PRIOR_GOOD + PRIOR_BAD)
+    }
 }
 
 #[cfg(test)]
@@ -320,6 +353,107 @@ mod tests {
             "our own overquote is judged exactly like a peer's"
         );
         assert_eq!(s.seller, BudgetSource::Local);
+    }
+
+    /// what this catches: THE SYBIL HOLE, measured. A fresh identity must NOT be
+    /// priced at or near a proven performer. On the grid market sim, pricing
+    /// unknown as 1.0 let churned shells absorb 100/100 jobs and starve the
+    /// honest incumbent completely — minting is cheap, and each new identity won
+    /// at the best price.
+    #[test]
+    fn an_unproven_seller_is_priced_well_below_a_proven_one() {
+        let fresh = Reputation::default();
+        let mut proven = Reputation::default();
+        for _ in 0..20 {
+            proven.record(&Settlement {
+                seller: BudgetSource::Local,
+                verdict: Verdict::Honored,
+            });
+        }
+        assert!(
+            fresh.trust_lower_bound() < proven.trust_lower_bound() * 0.5,
+            "unproven {} must be far below proven {}",
+            fresh.trust_lower_bound(),
+            proven.trust_lower_bound()
+        );
+    }
+
+    /// what this catches: the opposite failure — pricing unknown as WORST, which
+    /// bars every newcomer. A market nobody can enter is not a market. The
+    /// newcomer needs a real, bounded chance.
+    #[test]
+    fn but_an_unproven_seller_is_still_admissible_not_excluded() {
+        let fresh = Reputation::default();
+        let mut failed = Reputation::default();
+        for _ in 0..20 {
+            failed.record(&Settlement {
+                seller: BudgetSource::Local,
+                verdict: Verdict::Failed,
+            });
+        }
+        assert!(fresh.trust_lower_bound() > 0.0, "a newcomer is not excluded");
+        assert!(
+            fresh.trust_lower_bound() > failed.trust_lower_bound() * 2.0,
+            "unproven {} must beat demonstrated failure {}",
+            fresh.trust_lower_bound(),
+            failed.trust_lower_bound()
+        );
+    }
+
+    /// what this catches: churn resetting the clock. The whole sybil attack is
+    /// "mint a new identity, get a fresh best price". N fresh identities must be
+    /// worth N *small* chances, never N free wins — so a fresh identity can never
+    /// outrank a node that has actually delivered.
+    #[test]
+    fn minting_identities_never_beats_having_delivered() {
+        let mut modest = Reputation::default();
+        // Deliberately imperfect: 3 of 4 honored. Even a MEDIOCRE proven node
+        // must outrank an infinitely-churnable fresh one.
+        for v in [
+            Verdict::Honored,
+            Verdict::Honored,
+            Verdict::Failed,
+            Verdict::Honored,
+        ] {
+            modest.record(&Settlement {
+                seller: BudgetSource::Local,
+                verdict: v,
+            });
+        }
+        let fresh = Reputation::default();
+        assert!(
+            modest.trust_lower_bound() > fresh.trust_lower_bound(),
+            "a 3-of-4 record ({}) must beat a fresh shell ({}), or churn wins",
+            modest.trust_lower_bound(),
+            fresh.trust_lower_bound()
+        );
+    }
+
+    /// what this catches: a non-monotone trust curve, which would make pricing
+    /// exploitable. Honoring must raise standing and failing must lower it, with
+    /// no local dips a strategic actor could sit in.
+    #[test]
+    fn trust_moves_monotonically_with_evidence() {
+        let mut r = Reputation::default();
+        let mut last = r.trust_lower_bound();
+        for _ in 0..10 {
+            r.record(&Settlement {
+                seller: BudgetSource::Local,
+                verdict: Verdict::Honored,
+            });
+            let now = r.trust_lower_bound();
+            assert!(now > last, "honoring must always raise trust");
+            last = now;
+        }
+        for _ in 0..10 {
+            r.record(&Settlement {
+                seller: BudgetSource::Local,
+                verdict: Verdict::Failed,
+            });
+            let now = r.trust_lower_bound();
+            assert!(now < last, "failing must always lower trust");
+            last = now;
+        }
     }
 
     /// what this catches: a shortfall silently rounded to success. Landing but

--- a/docs/architecture/GRID-ELASTIC-CAPABILITY.md
+++ b/docs/architecture/GRID-ELASTIC-CAPABILITY.md
@@ -175,6 +175,54 @@ breached is not a floor.
 policy object is wrong — it means we wrote a grower and bolted on a shrinker.
 One arbiter, run in both directions, with different time constants and a floor.
 
+## 3b. Every node has BOTH ends — solo is a grid of one
+
+Joel's keystone framing, and it is a hard implementation constraint, not a
+sentiment: **there is no grid-mode and no solo-mode.** Every node runs both ends
+of the same policy, always:
+
+- the **local end** — fit to my own capacity. This is the end that never blocks,
+  including in total partition. A node alone on a plane is fully functional.
+- the **grid end** — consume peers' spare, contribute my own.
+
+**Therefore: no branch.** Not `if grid_available { grid_path } else { local_path }`.
+One code path in which a solo node is simply a grid whose peer list is empty.
+
+This falls out of the `max` formulation for free — `max` over `{local}` is
+`local`, which is exactly today's behavior — but it must be treated as a
+*requirement* rather than a happy accident, because the tempting optimization
+("skip the projection when there are no peers") reintroduces the branch and with
+it two code paths that drift.
+
+The two ends map onto code that already exists, which is a good sign the framing
+is right:
+
+| End | Mechanism | State |
+|---|---|---|
+| **contribute** | `GridCapacityModule` publishes this node's `CapacityOffer` each tick | **already built and live** |
+| **consume** | `grid_budget(grid)` reads the ledger snapshot | this slice |
+
+So we are not building "grid support". Half of it has been running the whole
+time; this adds the other half of a loop that was already turning.
+
+### Integration tests are the acceptance criteria
+
+Per Joel, literal tests — not a demo:
+
+1. **Solo, no grid.** No peers ever. Behavior must be byte-identical to today's
+   local-only planning. This is the regression guard on the no-branch rule.
+2. **Total partition mid-flight.** Peers exist, then all vanish. The node keeps
+   serving at its local capacity; the drop is `Graceful`, damped, and legible.
+3. **Node added.** A capable peer joins; budget rises at the next tick and the
+   plan may select a better model or deeper window.
+4. **Node dropped.** The peer goes silent; ledger eviction lowers the budget and
+   the surrender is LIFO (§3a), damped (§3a rule 2), and logged (§3a rule 3).
+5. **Flap.** A peer joins/leaves repeatedly. The fleet must NOT oscillate — this
+   is the test that the downshift debounce is actually load-bearing.
+
+Test 1 and test 5 are the ones that fail if we get this wrong: 1 catches the
+accidental branch, 5 catches missing hysteresis.
+
 ## 4. Where this sits in the λ framing
 
 Per Joel: the lease/mode arbiter is the wireless-MAC "price the seams" mechanism —

--- a/docs/architecture/GRID-ELASTIC-CAPABILITY.md
+++ b/docs/architecture/GRID-ELASTIC-CAPABILITY.md
@@ -361,8 +361,56 @@ refused.**
 
 ## 7. First slice
 
-**`grid_budget(grid)` feeding `HostBudget.usable_bytes`**, in place of the
-local-only budget.
+> ### ⚠️ CORRECTED — `HostBudget` is the WRONG consumer
+>
+> An earlier version of this section said the first slice was `grid_budget`
+> feeding `HostBudget.usable_bytes`. **That would have been a real bug**, caught
+> one edit before writing it by reading the consumer:
+>
+> - `host_budget()` ends as `usable_bytes = live * mode.serving_fraction()`, where
+>   `live` is **this box's** governed VRAM ceiling.
+> - `served_context_window` lives in `inference/llama_server.rs` and sizes
+>   resident KV as `lanes × kv_per_token × served_context_window` — **on the local
+>   GPU**.
+>
+> So `HostBudget` configures the LOCAL serving process. Feeding it a peer's bytes
+> would make this node allocate KV it does not physically have: a 40GB peer
+> produces a plan this box tries to load and OOMs on — planning against capacity
+> that is not there, which is the exact failure this design exists to prevent. It
+> would also have presented as a serving/OOM bug rather than an arithmetic one.
+>
+> **The projection was fine; the mental model was wrong.** A peer's spare VRAM does
+> not make *my* llama-server bigger. To use a peer's capacity the work must
+> **execute there** — which is routing.
+>
+> This also sharpens the Σ-vs-`max` question: it is not "no summed budget reaches
+> `HostBudget`", it is **no grid number of any shape reaches `HostBudget`**,
+> because `HostBudget` is strictly a local physical fact.
+
+**`grid_budget(grid)` feeding the ROUTER's capability decision** —
+`modules/grid/router.rs::Router::route`, reached by
+`GridState::try_route_remote`, the kernel's one dispatch hook (shared with
+`grid/send`: one path, two callers).
+
+Why the router is the right home, where `HostBudget` was not:
+
+- It is **policy**, not a physical fact, so a grid quantity legitimately belongs.
+- `RouteDecision::Remote { node, reason }` already carries `reason` — the
+  attribution slot §3c needs for a receipt.
+- Routing sends the WORK to the capacity, which is the only way a peer's VRAM
+  ever helps anyone.
+- `RouteDecision::Local` is already the always-available fallback — the end that
+  never blocks in total partition, with no branch to add.
+
+**The concrete gap it closes:** `HINT_PREFER_GPU` currently routes via
+`find_gpu_node(registry)` — a **boolean** has-a-GPU test. It cannot tell a 5090
+from an 8GB laptop card, and it has no idea whether the model this activity needs
+actually fits on the node it picks. `grid_budget` answers the question at the
+resolution that matters: *which reachable node can actually host this?*
+
+So the corrected chain is: grid grows → `grid_budget` sees a node that fits a
+better model → the router sends the activity there → the persona is more capable.
+No node is ever configured against memory it does not have.
 
 It is the smallest honest change, needs **no wire change** (`CapacityOffer`
 already carries the bytes), and unblocks the other two levers — because

--- a/docs/architecture/GRID-ELASTIC-CAPABILITY.md
+++ b/docs/architecture/GRID-ELASTIC-CAPABILITY.md
@@ -259,9 +259,48 @@ per-node clamp (`a_peer_claiming_more_free_than_it_has_is_clamped_to_its_own_tot
 is the first anti-fraud measure in the system and was written as mere robustness.
 
 The honest verification is the delivered result: did the work land, at the quoted
-speed, on the hardware claimed? That is forge-alloy's attestation-as-invoice
-shape — reputation as verification rate — and it is where this connects to the
-third pillar.
+speed, on the hardware claimed?
+
+### forge-alloy IS the verification layer — and it already works one scale down
+
+Per Joel: invoicing, requirements, zero trust, a Merkle chain of the steps taken
+and the metrics. **This is not new machinery to invent — the foundry already does
+it for custom transformers.**
+
+Look at what an alloy attests about a *model artifact*: `stages[]` with per-stage
+notes, `results.benchmarks[]` carrying `samplesPath` and `baseSamplesPath`,
+`priorMetricBaselines[]` for falsifiability, declared `limitations[]`. Now read
+that as a *service delivery*: what was required, which steps ran, what was
+measured, against which baseline, with the raw samples retained so a buyer can
+check rather than trust.
+
+Same structure, artifact-scale and service-scale. An abstraction that fits at two
+scales unchanged is usually the real one rather than a convenience — the same
+fractal property this design relies on for the λ arbiter (box -> grid -> P2P).
+
+So the economy's three unknowns already have owners:
+
+| Need | Mechanism |
+|---|---|
+| **requirements** | the contract — what the asker needs (model class, window, latency class) |
+| **zero trust** | don't believe the seller's capacity claim; verify against delivery |
+| **invoice** | the attestation itself — reputation as verification rate |
+
+### What that means for the ROUTING seam, concretely
+
+**The routing decision is the first attested step in the chain.** It is where a
+requirement meets a claim, and it is therefore where the invoice starts.
+
+`RouteDecision::Remote { node, reason }` already carries `reason` — but today it
+is a `&'static str`, a debug breadcrumb. For a chain of custody it needs to become
+a **structured claim**: what was required, what the node advertised, why it won.
+That is a small and forward-compatible change, and making it now is far cheaper
+than reconstructing intent from log strings after money moves.
+
+The counter-signature is the delivered result plus its measured metrics. Route
+decision and delivery record together are one link: *promised* and *delivered*,
+by the same node, for the same activity. A node whose promises and deliveries
+diverge is exactly what reputation-as-verification-rate measures.
 
 **`never a pool` has an economic reading too:** you cannot sell memory that is not
 on one machine. Two 20GiB sellers cannot jointly deliver a 40GiB service, so they

--- a/docs/architecture/GRID-ELASTIC-CAPABILITY.md
+++ b/docs/architecture/GRID-ELASTIC-CAPABILITY.md
@@ -223,6 +223,55 @@ Per Joel, literal tests — not a demo:
 Test 1 and test 5 are the ones that fail if we get this wrong: 1 catches the
 accidental branch, 5 catches missing hysteresis.
 
+## 3c. The economic reading — and the two requirements it adds
+
+Joel's framing: people earn and pay into this system, incentivized by its own
+metrics to improve efficiency, power, reliability, capability, and speed — all of
+which have market value. **Every command is potentially a service; every ask is a
+customer.** The contrast with proof-of-work is substantive, not rhetorical: PoW
+burns energy proving work nobody wanted, and the burn *is* the proof. Here the
+proof is a result someone asked for and can check — the receipt is the product
+rather than the waste.
+
+The substrate is already shaped for this, which is a good sign the framing is
+native rather than bolted on:
+
+| Code today | Economic reading |
+|---|---|
+| `CapacityOffer` | literally an **offer** — supply, advertised |
+| `BudgetSource` | **attribution** — who supplied it |
+| lease ladder (`Pinned`/`Graceful`/`Hard`) | **terms of service** — what may be reclaimed, and how |
+| λ arbiter pricing seams | the **market**, not merely a scheduler |
+| an activity leasing governed resources | a **transaction** |
+
+Two requirements follow, and both are cheap now and expensive later:
+
+**1. Attribution must be a receipt, not a log line.** `BudgetSource` exists today
+for legibility — "the budget went up, from where". In an economy that same field
+answers *who gets paid*. It therefore has to be accurate and non-repudiable, not
+merely informative.
+
+**2. Capacity claims must be VERIFIABLE, not trusted.** This is the real gap.
+`CapacityOffer` is self-reported and believed. That is correct among friends and
+wrong in a market: a node that overstates its free bytes is not buggy, it is
+**overselling supply it cannot deliver**, and it gets paid for it. The existing
+per-node clamp (`a_peer_claiming_more_free_than_it_has_is_clamped_to_its_own_total`)
+is the first anti-fraud measure in the system and was written as mere robustness.
+
+The honest verification is the delivered result: did the work land, at the quoted
+speed, on the hardware claimed? That is forge-alloy's attestation-as-invoice
+shape — reputation as verification rate — and it is where this connects to the
+third pillar.
+
+**`never a pool` has an economic reading too:** you cannot sell memory that is not
+on one machine. Two 20GiB sellers cannot jointly deliver a 40GiB service, so they
+must never be able to jointly *quote* one. The invariant is a truth-in-advertising
+rule as much as a technical one.
+
+Nothing here changes the first slice. It changes what must be true of it before
+anyone is billed, and it is recorded now because retrofitting attribution and
+verification after money moves is the expensive order.
+
 ## 4. Where this sits in the λ framing
 
 Per Joel: the lease/mode arbiter is the wireless-MAC "price the seams" mechanism —

--- a/docs/architecture/GRID-ELASTIC-CAPABILITY.md
+++ b/docs/architecture/GRID-ELASTIC-CAPABILITY.md
@@ -1,0 +1,242 @@
+# Grid-elastic capability — personas get more capable as the grid grows
+
+**Status:** design, 2026-08-10. Grounded in a live/dead audit of the existing code
+(every claim below was checked, and the dead paths are named so nobody builds on
+them). Implementation not started.
+
+**One sentence:** a persona's capability is currently a frozen function of the
+local GPU string and an env var; make those two inputs **live projections of the
+GridSnapshot** and everything downstream is already dynamic.
+
+---
+
+## 1. Why this is small, not a rewrite
+
+The boot chain today, in `ipc/mod.rs` around `:2155`:
+
+```
+detect_tier(gpu_name)          -> tier    <- LOCAL GPU STRING. Static forever.
+CONTINUUM_PERSONA_FLOOR (env)  -> floor   <- ENV VAR.
+set_lane_demand(floor)
+compute_plan()                 -> ServingPlan
+```
+
+So **capability = f(local GPU string, an env var), computed once at boot.**
+
+Two observations make the fix cheap:
+
+1. **The plan is already dynamic.** `serving_daemon` recomputes on its tick and
+   publishes on `plan_tx: watch::Sender<Option<ServingPlan>>` (`:246`, send at
+   `:2046`, `subscribe()` at `:587`). Consumers already subscribe. Nothing about
+   the *distribution* of a changed plan needs building.
+2. **The degradation path already exists.** `inference/lane.rs:114-119` maps
+   `LaneClass::Realtime -> Pinned`, `Interactive -> Graceful`, else `Hard`. When
+   capability must come *down*, Graceful revocation is the mechanism — already
+   wired, with real consumers (`inference/coordinator.rs`,
+   `cognition/resource_admission.rs`, `cognition/generate_response.rs`).
+
+Only the **inputs** are frozen. Unfreeze them and the rest follows.
+
+Note also that `CONTINUUM_PERSONA_FLOOR` is precisely the "env-var-tuned substrate
+threshold" the concurrency style guide lists as a forbidden move. Replacing it
+with a derived value is doctrine-correct independent of this feature.
+
+## 2. The invariant that shapes the whole design: NEVER A POOL
+
+`provisioning/placement_planner.rs:366` asserts it directly:
+
+> two 20GiB peers must **NOT** fit a 40GiB model — never a pool
+
+So "more capable as the grid grows" can **never** mean summing memory across
+nodes to host one bigger model. That is the exo approach and it is explicitly
+rejected: sharding a model to make it fit trades a working mind for a slow one.
+
+What growth *may* buy is therefore constrained to three honest levers:
+
+| Lever | What grows | Grid quantity it reads |
+|---|---|---|
+| **Tier** | the best model a persona can be assigned | `max` over reachable nodes |
+| **Depth** | served context window per citizen | best node's free bytes |
+| **Population** | how many citizens are hosted | `count` of reachable nodes |
+
+`max` and `count` — never `sum`. That is the whole discipline.
+
+## 3. The design
+
+Replace two static inputs with live projections over
+`capacity::gossip::global_ledger().snapshot(..)`:
+
+```
+detect_tier(local_gpu_name)     ->  reachable_tier(grid)      // best node, not this node
+CONTINUUM_PERSONA_FLOOR (env)   ->  citizen_demand(grid)      // count of nodes, not a constant
+```
+
+Everything else is unchanged. The tick replans, the watch publishes, subscribers
+react, and the lease ladder absorbs downgrades.
+
+**Why the gossip ledger is the right source (and is genuinely live):**
+`airc/inbound_attach.rs:312` folds heard peer offers into `global_ledger()` via
+`.hear(..)`, and `capacity/lease.rs:143` already reads `.snapshot(..)`. It
+handles join, reachability, and silence-eviction on its own. This is not a dead
+component — unlike the placement code below.
+
+### Capability floor and float
+
+A citizen that gets dumber every time a laptop sleeps is worse than one pinned at
+a known floor. So each persona carries:
+
+- a **floor** — the capability it is guaranteed, honored even at grid minimum,
+- **headroom** — the part that floats with the grid.
+
+Only headroom is revocable. A persona never silently loses its floor; if the
+floor genuinely cannot be met, the node says so **loudly** rather than degrading
+in silence.
+
+### Priority when levers compete
+
+Tier > depth > population. A smarter mind beats more mediocre ones, and a mind
+that cannot see a full turn is worse than one that can (the 4-lanes-@-6k
+starvation the 2026-07-17 revert caught). Population grows last, and only while
+each citizen still clears the full-turn window floor — the constraint
+`serving_plan.rs` already enforces via `BOOTSTRAP_WORKING_SET`.
+
+## 3a. DOWN is not degradation — it is half the law
+
+**Down matters exactly as much as up, and it is the more common direction.**
+This grid is laptops that sleep, workstations that reboot, and peers that go
+quiet mid-turn. Zero-downtime is an explicit non-goal here; the grid is supposed
+to absorb churn. A design that only reasons about growth is a design that works
+on the demo and thrashes in the field.
+
+Treating shrink as an exception is how you get the two classic failures: a fleet
+that oscillates every time a peer flaps, and a citizen that quietly gets worse
+with nothing in the record saying so.
+
+Four rules make down first-class:
+
+**1. Surrender is LIFO — the exact reverse of acquisition.**
+Acquire tier -> depth -> population; surrender population -> depth -> tier. The
+last thing bought is the first thing given back. Tier is surrendered last because
+it is closest to the floor: a smaller population of capable minds beats a full
+roster of blind ones.
+
+**2. Down is hysteretic, and the machinery already exists.**
+`e3ac68b99` (#368, PR #2186) landed **downshift debounce + level-triggered
+replan**, and `serving_plan.rs` already cites
+`[[never-thrash-sticky-hysteresis-on-every-lane]]`. Reuse both. Up may be
+promptish; down must be damped, or one flapping peer walks the whole fleet down
+and back on every gossip tick. Asymmetric time constants are correct here, not a
+hack: the cost of being briefly too small is a slow turn, while the cost of
+oscillating is every citizen re-prefilling cold, repeatedly.
+
+**3. Down is legible or it is a bug.**
+A shrink emits what was surrendered, by whom, and why — the same standard as a
+refused tool or a denied lease. "It got slower" with nothing in the record is the
+failure mode this whole codebase keeps relearning. `cognition/observe`'s
+provenance chip is the existing precedent: state the condition, never let a
+consumer infer it.
+
+**4. The floor is what makes down safe.**
+Headroom revokes through the existing ladder — `Graceful` for interactive lanes,
+`Hard` for batch, `Pinned` never. Below the floor there is no graceful option and
+the node must say so rather than invent one. A floor that can be silently
+breached is not a floor.
+
+**The symmetry is the test.** If down needs its own separate mechanism, the
+policy object is wrong — it means we wrote a grower and bolted on a shrinker.
+One arbiter, run in both directions, with different time constants and a floor.
+
+## 4. Where this sits in the λ framing
+
+Per Joel: the lease/mode arbiter is the wireless-MAC "price the seams" mechanism —
+**one policy object, applied box -> grid -> P2P.** Capability is then simply *what
+the arbiter can afford at current supply*:
+
+- **box** — lanes and window within one host's budget (exists: `plan_serving`)
+- **grid** — which reachable node's tier a citizen may draw on (this document)
+- **P2P** — the same pricing between peers as the mesh widens
+
+Same policy object at each scale, different supply. That is the fractal shape:
+one law, re-applied, not three coordinators.
+
+## 5. DEAD CODE — do not build on this
+
+Audited 2026-08-10. Recorded here because the obvious-looking path is a trap
+(see continuum#2227):
+
+| Path | State |
+|---|---|
+| `resources/placement.rs` `plan_grid_placement` | **zero production callers** — all call sites in its test mod |
+| `provisioning/placement_planner.rs` `select_grid_peer` | **zero production callers** |
+| `capacity/grid.rs` `GridPlacementPolicy` (+3 impls) | **zero production callers** — only a sim harness and tests |
+| `ServingPlan.grid_overflow_lanes` | **zero readers**; not serialized to protocol |
+| `capacity/lease.rs` `decide_lane` | **no callers**, yet cited as the reference pattern by two other modules' docs |
+
+These are an **abandoned direction**, not a missing wire: accommodation went to
+lease policy, not placement. `serving_plan.rs:1185` still asserts "the 2 unslotted
+minds are surfaced for grid placement" — a green test over a mechanism we are not
+building, and it should be removed with the rest.
+
+Also worth knowing: `GovernorMode` / `governor_mode` appears **nowhere** in
+`core/` outside tests. "Governor modes" is a design note, not a construct you can
+read or tune. Making modes first-class is a build, not a wiring.
+
+## 6. How we prove it — N concurrent activities, not a benchmark harness
+
+**A benchmark is an activity like any other.** Per Joel's framing (#371):
+recipe = content-type, room = content, each activity carrying its own
+`ActivityObjective`. A call is an activity. A benchmark is an activity. Chat is
+an activity. There is no benchmark subsystem — there are N concurrent activities,
+each leasing governed resources, arbitrated by one policy object.
+
+This matters for the proof, and it is why "benchmarks first, then LiveKit, then
+mix them" is the **wrong** experiment design: it treats benchmarks as a special
+prover and mixing as the exotic case. Mixed is the normal case. A single-activity
+measurement is the degenerate one.
+
+What benchmarks *do* uniquely contribute is an **objective score** — they are the
+activity class whose `ActivityObjective` is externally checkable. So they are the
+instrument, not the subject.
+
+### The experiment
+
+Run N concurrent activities of mixed class on a grid that grows **and shrinks**,
+and check the arbiter's behavior at every transition.
+
+| Class | Lane | Revocation | What growth should buy |
+|---|---|---|---|
+| Live call | `Realtime` | `Pinned` | more sustainable concurrent calls |
+| Benchmark / exam | isolated | `Graceful` | monotone score at fixed task set |
+| Chat / interactive | `Interactive` | `Graceful` | depth (window), then population |
+| Batch | — | `Hard` | throughput, first to yield |
+
+**Invariants that must hold, in both directions:**
+
+- **Realtime holds its floor.** `Pinned` is never revoked to feed a benchmark. If
+  growth ever helps throughput work by degrading a call, the arbiter is wrong.
+- **Headroom yields LIFO.** When the grid shrinks, batch yields before
+  interactive, interactive before realtime — the reverse of acquisition (§3a).
+- **Every number is labelled.** A benchmark score measured while a call was up is
+  `Contended`, and says so via the existing `BenchmarkProvenance` chip. An
+  unlabelled score measured under contention is not a weaker result, it is a
+  false one.
+- **Shrink is legible.** Each surrender emits what was given up and why. "It got
+  slower" with nothing in the record is the failure this codebase keeps
+  relearning.
+
+**Guard:** `LaneDemand.isolate: true` for exam lanes. Its own doc says a benchmark
+demands a dedicated lane, and the 2026-07-21 glass-box showed a benchmark sharing
+a persona lane starving behind their turns. Without isolation, a score that moved
+because of contention would be misread as a capability change.
+
+The claim is not "it got faster." The claim is: **one policy object priced every
+seam, in both directions, and we can show exactly what it charged and what it
+refused.**
+
+## 7. First slice
+
+`reachable_tier(grid)` replacing `detect_tier(local_gpu)`. It unblocks the other
+levers, is the smallest honest change, and is directly observable: a peer joining
+should raise the tier at the next tick, and a peer going silent should lower it —
+through the existing ledger eviction, with the drop taken by `Graceful`
+revocation rather than a stall.

--- a/docs/architecture/GRID-ELASTIC-CAPABILITY.md
+++ b/docs/architecture/GRID-ELASTIC-CAPABILITY.md
@@ -4,9 +4,9 @@
 (every claim below was checked, and the dead paths are named so nobody builds on
 them). Implementation not started.
 
-**One sentence:** a persona's capability is currently a frozen function of the
-local GPU string and an env var; make those two inputs **live projections of the
-GridSnapshot** and everything downstream is already dynamic.
+**One sentence:** a persona's capability is currently a frozen function of this
+box's serving budget and an env var; make those two inputs **live projections of
+the GridSnapshot** and everything downstream is already dynamic.
 
 ---
 
@@ -67,9 +67,38 @@ Replace two static inputs with live projections over
 `capacity::gossip::global_ledger().snapshot(..)`:
 
 ```
-detect_tier(local_gpu_name)     ->  reachable_tier(grid)      // best node, not this node
+HostBudget { usable_bytes }     ->  grid_budget(grid)         // best node's bytes, not this node's
 CONTINUUM_PERSONA_FLOOR (env)   ->  citizen_demand(grid)      // count of nodes, not a constant
 ```
+
+### Why BYTES, not tier — a correction to an earlier draft of this document
+
+An earlier version of this design said `detect_tier(local_gpu) -> reachable_tier(grid)`.
+**That was the wrong quantity, and building it would have forced an unnecessary
+wire change.** Recorded here because the mistake is instructive:
+
+- `CapacityOffer` (`capacity/gossip.rs:49`) carries **bytes only** —
+  `gpu_total_bytes`, `gpu_free_bytes_live`, `system_ram_free_bytes`, `at_ms`. No
+  GPU name, no tier. So "max `HwCapabilityTier` over reachable peers" is not
+  implementable from the current wire at all.
+- `HwCapabilityTier` (`cognition/model_resolver/types.rs:41`) is a **silicon
+  identity** — `M4UmaProMax`, `VulkanAmd`, `MacIntelMetalDiscrete` — derived from
+  a GPU *name string*. Projecting it across the grid would push hardware identity
+  over the wire to answer a question nobody asks. No consumer needs to know a
+  peer is an M4 Pro; they need to know it can host a 27B at a 32k window.
+- **The live path is already bytes-based.** `plan_serving` takes
+  `HostBudget { usable_bytes, perf_cores }` and selects the model from the
+  *budget*, deriving the served window as
+  `(context_window ∩ budget / lanes / kv_per_token)`. Capacity decides capability;
+  tier does not.
+
+So the projection is over **bytes**, which `CapacityOffer` already carries. No
+wire change, and it works across heterogeneous silicon for free — bytes are
+comparable between a 5090 and an M5 Max; GPU name strings are not.
+
+**`never a pool` applies directly here:** `grid_budget` is the **best single
+reachable node's usable bytes** — `max`, never `sum`. Two 20GiB peers still do
+not make a 40GiB node.
 
 Everything else is unchanged. The tick replans, the watch publishes, subscribers
 react, and the lease ladder absorbs downgrades.
@@ -235,8 +264,20 @@ refused.**
 
 ## 7. First slice
 
-`reachable_tier(grid)` replacing `detect_tier(local_gpu)`. It unblocks the other
-levers, is the smallest honest change, and is directly observable: a peer joining
-should raise the tier at the next tick, and a peer going silent should lower it —
-through the existing ledger eviction, with the drop taken by `Graceful`
-revocation rather than a stall.
+**`grid_budget(grid)` feeding `HostBudget.usable_bytes`**, in place of the
+local-only budget.
+
+It is the smallest honest change, needs **no wire change** (`CapacityOffer`
+already carries the bytes), and unblocks the other two levers — because
+`plan_serving` already derives model choice *and* served window from the budget.
+
+It is also directly observable in both directions, which is the point:
+
+- a capable peer joining raises the budget at the next tick, so the plan may
+  select a better model or a deeper window;
+- a peer going silent lowers it through the ledger's existing silence-eviction,
+  and the drop is taken by `Graceful` revocation rather than a stall.
+
+Watch for the failure mode named in §3a: without the downshift debounce, one
+flapping peer walks the whole fleet up and down on every gossip tick. Reuse
+`e3ac68b99`'s damping rather than adding a second one.


### PR DESCRIPTION
Lands the two pure primitives the grid-market work is built on, plus the design doc. **Additive** — two new modules under `capacity/`, one new doc, no existing behavior changed. 22 tests, all green.

Opening this because **M5's `capacity/market.rs` (on `fix/396-identity-resolve-persona`) cannot build against these types while they live on a side branch** — a cherry-pick left `settlement.rs` with unmet deps. Landing here lets `fix/396` rebase on canary and wire the two halves for real.

## `capacity/grid_budget.rs` — what the best single reachable node can serve

The CONSUME half of the grid loop. The contribute half already ran (`GridCapacityModule` publishes this node's `CapacityOffer` each tick; `airc::inbound_attach` folds heard offers into `gossip::global_ledger`) — this closes a loop that was already turning.

Three constraints, each enforced by a test that fails if broken:

- **NEVER A POOL.** The fold is a `max`, not a `+`. Two 20GiB peers give 20, not 40. `placement_planner.rs:366` asserts the same invariant; if that test ever fails we have become exo — sharding a model across machines to make it "fit", trading a working mind for a slow one.
- **BOTH ENDS, NO BRANCH.** Deliberately no `if peers.is_empty()` fast path, because `max` over `{local}` IS local — byte-identical to today. `total_partition_falls_back_to_exactly_the_solo_budget` asserts the strong form: a partitioned node and a solo node must be *indistinguishable*.
- **SYMMETRIC ROLE.** No coordinator, no placer, no "provider node" type. Every node computes this for itself; a provide-only machine is just a node whose demand is currently zero.

Two bugs caught by reading the consumer before wiring, both silent: `host_budget_from` clamps `available.min(total_vram)`, so returning only free bytes would have measured a 40GB peer against this box's 8GB card — the projection would have appeared to do *nothing*. And the same fix handles a peer reporting free > total (bad reading or hostile offer).

## `capacity/settlement.rs` — promise vs delivery, divergence as reputation

The adversarial half of the market. `market::entry_price` values a node on **self-reported specs** — a prospectus nobody audited. Settlement is what makes the claim honest, and the two halves are deliberately unable to flatter each other.

- A missing delivery record is `Unsettled`, **never** `Honored` — absence is not evidence.
- Overquoting is dishonest **even when the delivery lands**; the market prices the claim that was made.
- Quoting above your own ceiling is fraud at **quote time**, kept distinct from a shortfall — *a bad day is not a lie*.
- Overdelivery does not offset a broken promise; promises settle individually.
- Settlement judges `BudgetSource::Local` identically — grading only others is not a market.

### `trust_lower_bound()` — the number a market should price on

M5's harness **measured** the sybil hole: pricing unknown as `1.0` let churned shells absorb **100/100 jobs and fully starve the honest incumbent**. Total denial, not a bounded loss.

`(honored + 1) / (settled + 5)` — a Beta prior. Pricing on the raw rate forces "what about no data?", and both obvious answers are wrong: unknown-as-perfect is the measured hole; unknown-as-worst bars every newcomer, and a market nobody can enter is not a market. A fresh seller starts at **0.2** — well below proven (→1.0), well above demonstrated failure (→0.0) — so it wins *occasionally*. Minting N identities buys N *small chances*, not N free wins.

## Also included

`docs/architecture/GRID-ELASTIC-CAPABILITY.md`, with five corrections kept **in** the document rather than silently rewritten — each is an instinct the next reader is likely to repeat:

1. Project **bytes**, not `HwCapabilityTier` (which is silicon identity and isn't on the wire).
2. `HostBudget` is the **wrong consumer** — it sizes the *local* llama-server, so a peer's bytes would make this box allocate KV it doesn't have.
3. The **router** is the right consumer; routing sends work to capacity.
4. **Down is half the law**, not degradation to absorb — surrender is LIFO, hysteretic, legible, floored.
5. The three existing placement systems are an **abandoned direction** (see #2227), not a thing to wire.

## Known limits

Both modules are pure and unit-tested; **neither has run on real hardware.** The router integration is separately blocked on a `PeerId` join key between the node registry and the capacity gossip (see #2228) — M5 owns that.