### PR TITLE
Eligibility gates routing — a node that can't hold the job is never a candidate

### DIFF
--- a/core/continuum-core/src/capacity/eligibility.rs
+++ b/core/continuum-core/src/capacity/eligibility.rs
@@ -1,0 +1,206 @@
+//! Eligibility — can this node actually host this job? A **hard gate, evaluated
+//! before price**.
+//!
+//! ## Why this is a correctness rule, not an anti-fraud measure
+//!
+//! A node that cannot host a job should not be offered it, whether or not anyone
+//! is attacking. This would be right with no economy at all — which makes it a
+//! sturdier foundation than a cost that has to be tuned.
+//!
+//! It happens to also close the one hole [`super::settlement::Reputation::trust_lower_bound`]
+//! leaves open, and that is worth understanding because it explains the ordering.
+//!
+//! ## How it collapses cross-class churn into same-class
+//!
+//! `trust_lower_bound` prices an unproven seller at ~0.2, which takes sybil churn
+//! from 100/100 absorbed jobs to 0/100 — **within a class**. Cross-class churn
+//! survives it: a shell advertises arbitrarily cheap specs, lands in a class where
+//! no proven competitor exists, and wins by default rather than by trust.
+//!
+//! The attack needs an **uncontested cheap class to hide in**. Eligibility removes
+//! that terrain: if a node is only offered jobs its advertised capability actually
+//! meets, then to be eligible for real work a shell must claim capability
+//! comparable to real competitors — and the moment it does, it is in a contested
+//! class where `trust_lower_bound` already bites completely.
+//!
+//! **Advertise cheap, or win real jobs. Not both.** And a shell that inflates its
+//! claim to qualify is [`Eligibility::VoidClaim`] here, or `Overquoted` at
+//! settlement — dishonest rather than merely short, which is the worse verdict.
+//!
+//! So the two levers are not redundant barriers. This one removes the ground the
+//! attack stands on; the mint stake (M5's lane) prices the cost of *trying*, which
+//! this does not.
+//!
+//! ## Ordering is load-bearing
+//!
+//! Eligibility is evaluated **before** price and **independently of** reputation.
+//! No amount of cheapness makes an ineligible node eligible, and a spotless record
+//! does not let a node take work it cannot hold. Fold this into a scoring function
+//! and the gate becomes a weight — which is exactly how "cheap enough" starts
+//! winning jobs it cannot serve.
+
+/// What a job needs to run at all. Deliberately a floor, not a preference: a
+/// preference belongs in ranking, and mixing the two is how a hard gate quietly
+/// becomes a soft one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Requirement {
+    /// Serving bytes the job cannot run below.
+    pub min_bytes: u64,
+}
+
+/// What a node says it can provide for this job.
+///
+/// Both fields are the node's own claims. `node_total_bytes` is carried so an
+/// impossible claim is detectable here — before any work is dispatched — rather
+/// than only after a delivery fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Offer {
+    pub advertised_bytes: u64,
+    /// The node's own advertised physical ceiling.
+    pub node_total_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Eligibility {
+    /// May be offered the job. Ranking (price, reputation, latency) happens after
+    /// this, never instead of it.
+    Eligible,
+    /// Honest but too small. Not a fraud signal — most nodes are ineligible for
+    /// most jobs, and that is ordinary.
+    Insufficient { short_by: u64 },
+    /// Claimed more than its own advertised ceiling. The claim is **void**: it is
+    /// not a cheap bid to be outranked, it is not an offer at all. Refused here so
+    /// an impossible promise never reaches dispatch.
+    VoidClaim { over_by: u64 },
+}
+
+impl Eligibility {
+    pub fn is_eligible(&self) -> bool {
+        matches!(self, Eligibility::Eligible)
+    }
+
+    /// Did the node assert something impossible, as opposed to being honestly
+    /// small? Kept distinct so genuine overclaiming cannot hide among the ordinary
+    /// mass of too-small nodes.
+    pub fn is_void(&self) -> bool {
+        matches!(self, Eligibility::VoidClaim { .. })
+    }
+}
+
+/// Decide whether `offer` may be considered for `requirement`.
+///
+/// Pure, and takes **no price and no reputation** — not an oversight. Passing
+/// them in would invite weighing them, and the entire value of this gate is that
+/// it cannot be outbid.
+///
+/// The void check runs first: a node claiming beyond its own ceiling is refused
+/// even when the inflated claim would have satisfied the requirement. Otherwise a
+/// shell could qualify for anything by simply claiming more.
+pub fn eligible(requirement: &Requirement, offer: &Offer) -> Eligibility {
+    if offer.advertised_bytes > offer.node_total_bytes {
+        return Eligibility::VoidClaim {
+            over_by: offer.advertised_bytes - offer.node_total_bytes,
+        };
+    }
+    if offer.advertised_bytes < requirement.min_bytes {
+        return Eligibility::Insufficient {
+            short_by: requirement.min_bytes - offer.advertised_bytes,
+        };
+    }
+    Eligibility::Eligible
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gb(n: u64) -> u64 {
+        n * 1024 * 1024 * 1024
+    }
+
+    fn need(n: u64) -> Requirement {
+        Requirement { min_bytes: gb(n) }
+    }
+
+    fn offer(advertised: u64, total: u64) -> Offer {
+        Offer {
+            advertised_bytes: gb(advertised),
+            node_total_bytes: gb(total),
+        }
+    }
+
+    /// what this catches: THE CROSS-CLASS HOLE. A shell advertising cheap specs
+    /// must not be offered real work AT ANY PRICE. This is the property that
+    /// collapses cross-class churn into same-class, where trust_lower_bound
+    /// already takes sybil absorption to 0/100.
+    #[test]
+    fn a_cheap_shell_is_not_offered_work_it_cannot_hold() {
+        let e = eligible(&need(24), &offer(8, 8));
+        assert!(!e.is_eligible());
+        assert_eq!(e, Eligibility::Insufficient { short_by: gb(16) });
+        assert!(
+            !e.is_void(),
+            "honestly small is not fraud — most nodes are ineligible for most jobs"
+        );
+    }
+
+    /// what this catches: qualifying by simply claiming more. If inflating the
+    /// claim let a shell pass the gate, the filter would be decorative — the
+    /// attacker's specs are self-reported, so the gate must reject impossible
+    /// claims rather than believe them.
+    #[test]
+    fn inflating_the_claim_to_qualify_is_void_not_eligible() {
+        // Claims 64GB (would satisfy a 24GB job) on a 16GB card.
+        let e = eligible(&need(24), &offer(64, 16));
+        assert!(!e.is_eligible(), "an impossible claim never qualifies");
+        assert!(e.is_void());
+        assert_eq!(e, Eligibility::VoidClaim { over_by: gb(48) });
+    }
+
+    /// what this catches: the void check running AFTER the sufficiency check. A
+    /// node overclaiming *below* the requirement is still lying, and the verdict
+    /// must say so rather than reporting the more forgiving "too small".
+    #[test]
+    fn an_impossible_claim_is_void_even_when_it_is_also_too_small() {
+        // Claims 12GB on an 8GB card, for a 24GB job — both lying AND short.
+        let e = eligible(&need(24), &offer(12, 8));
+        assert!(e.is_void(), "the lie is the more important fact: {e:?}");
+    }
+
+    /// what this catches: an off-by-one at the boundary that would exclude a node
+    /// that exactly fits. The requirement is a floor the job cannot run BELOW —
+    /// meeting it exactly is meeting it.
+    #[test]
+    fn exactly_meeting_the_requirement_is_eligible() {
+        assert!(eligible(&need(24), &offer(24, 24)).is_eligible());
+        assert!(!eligible(&need(24), &offer(23, 24)).is_eligible());
+    }
+
+    /// what this catches: THE ORDERING, which is the whole point. `eligible` takes
+    /// no price and no reputation, so this test is really a signature check —
+    /// if a future refactor adds them as parameters, the gate has become a weight
+    /// and can be outbid. A spotless record must not let a node take work it
+    /// cannot hold, and a rock-bottom price must not either.
+    #[test]
+    fn eligibility_cannot_be_bought_or_earned() {
+        let too_small = offer(8, 8);
+        let job = need(24);
+        // There is deliberately no argument to vary here. The gate is a function
+        // of capability alone; the only way to pass it is to be big enough.
+        for _ in 0..100 {
+            assert!(
+                !eligible(&job, &too_small).is_eligible(),
+                "no repetition, price, or standing changes a capability verdict"
+            );
+        }
+    }
+
+    /// what this catches: a node being judged differently because it is us. Same
+    /// gate for local and remote — there are no node types, and an offer we make
+    /// to ourselves is judged exactly like one a peer makes to us.
+    #[test]
+    fn the_local_node_is_gated_identically() {
+        assert!(!eligible(&need(48), &offer(32, 32)).is_eligible());
+        assert!(eligible(&need(16), &offer(32, 32)).is_eligible());
+    }
+}

--- a/core/continuum-core/src/capacity/mod.rs
+++ b/core/continuum-core/src/capacity/mod.rs
@@ -32,6 +32,7 @@ pub mod expert_depot;
 pub mod expert_ecache;
 pub mod expert_observer;
 pub mod expert_pager;
+pub mod eligibility;
 pub mod grid_budget;
 pub mod settlement;
 pub mod host_cache_lease;

--- a/core/continuum-core/src/modules/grid/router.rs
+++ b/core/continuum-core/src/modules/grid/router.rs
@@ -5,9 +5,76 @@
 //! 2. routingHint param → match hint to capability
 //! 3. Local execution impossible → find capable remote node
 //! 4. Default → execute locally
+//!
+//! # Eligibility gates ranking (why candidates are filtered before sorting)
+//!
+//! Every ranking below used to be "sort by advertised VRAM, take the top". That
+//! makes the biggest *claim* win, not the biggest card — a node advertising
+//! 999999 MB is picked for every job forever, and nothing here notices, because
+//! the number is only ever compared against other numbers.
+//!
+//! So a declared requirement ([`crate::capacity::eligibility::Requirement`], read
+//! from `requiresVramMb`) is now applied as a **hard filter before the sort**, via
+//! [`crate::capacity::eligibility::eligible`]. Ineligible nodes are not
+//! low-ranked; they are not candidates. The ordering is the point: fold the check
+//! into the comparator and "big enough" becomes a tiebreak that a large enough
+//! claim can outrank.
+//!
+//! The local node is gated by the same call on the same axis — `prefer-gpu` no
+//! longer means "we have *a* GPU" but "we have a GPU that can hold this job".
+//!
+//! **Honest limit.** The registry's `vram_mb` is a self-reported advertisement,
+//! and it is the *only* number a node publishes here — so
+//! [`crate::capacity::eligibility::Eligibility::VoidClaim`] (claiming past your
+//! own ceiling) is structurally unreachable from this path: with one number,
+//! claim and ceiling are the same value. Catching that requires the live capacity
+//! ledger's measured free bytes as an independent ceiling, which needs the
+//! `PeerId` join key (#2228). Until then this filter refuses nodes that *admit*
+//! they are too small, which is what collapses the cross-class hiding place; it
+//! does not yet catch a node that lies about its size.
 
 use super::node::{GridNode, NodeCapability, TrustLevel};
 use super::registry::NodeRegistry;
+use crate::capacity::eligibility::{eligible, Offer, Requirement};
+
+/// Params key by which a caller declares the floor a job cannot run below.
+///
+/// Megabytes, to match the unit the node registry already advertises in.
+pub const PARAM_REQUIRES_VRAM_MB: &str = "requiresVramMb";
+
+fn mb_to_bytes(mb: u64) -> u64 {
+    mb.saturating_mul(1024 * 1024)
+}
+
+/// Read the declared requirement out of command params.
+///
+/// Absent ⇒ a floor of zero: an undeclared job is not silently assumed to be
+/// huge (which would strand it) nor assumed to fit a specific node (which is the
+/// bug this module is closing). It is simply unconstrained, and every node stays
+/// eligible exactly as before. Replacing this with a real per-command declaration
+/// is M5's requirements lane; this reads whatever the caller states today.
+fn requirement_from(params: &serde_json::Value) -> Requirement {
+    let mb = params
+        .get(PARAM_REQUIRES_VRAM_MB)
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    Requirement {
+        min_bytes: mb_to_bytes(mb),
+    }
+}
+
+/// A node's advertised capability, expressed as an eligibility offer.
+///
+/// `node_total_bytes` mirrors `advertised_bytes` because the registry publishes a
+/// single number — see the module doc's honest-limit note. The moment a measured
+/// ceiling is available, this is the one place that changes.
+fn offer_of(node: &GridNode) -> Offer {
+    let bytes = mb_to_bytes(gpu_vram(node));
+    Offer {
+        advertised_bytes: bytes,
+        node_total_bytes: bytes,
+    }
+}
 
 /// Routing decision for a command.
 #[derive(Debug, Clone)]
@@ -63,16 +130,20 @@ impl GridRouter {
             return RouteDecision::Local;
         }
 
+        let requirement = requirement_from(params);
+
         // 2. Routing hints
         if let Some(hint) = params.get("routingHint").and_then(|v| v.as_str()) {
             match hint {
                 HINT_LOCAL_ONLY => return RouteDecision::Local,
 
                 HINT_PREFER_GPU => {
-                    if self.local_has_gpu {
+                    // "We have a GPU" is not the question — "we have a GPU that
+                    // can hold this job" is. Same gate a peer faces.
+                    if self.local_has_gpu && self.local_is_eligible(&requirement) {
                         return RouteDecision::Local;
                     }
-                    if let Some(node) = find_gpu_node(registry) {
+                    if let Some(node) = find_gpu_node(registry, &requirement) {
                         return RouteDecision::Remote {
                             node,
                             reason: "prefer-gpu hint",
@@ -81,7 +152,9 @@ impl GridRouter {
                 }
 
                 HINT_MAX_COMPUTE => {
-                    if let Some(node) = find_max_compute_node(registry, self.local_vram_mb) {
+                    if let Some(node) =
+                        find_max_compute_node(registry, self.local_vram_mb, &requirement)
+                    {
                         return RouteDecision::Remote {
                             node,
                             reason: "max-compute hint",
@@ -110,7 +183,7 @@ impl GridRouter {
 
         // 3. Capability-based routing (can't run locally?)
         if requires_gpu(command) && !self.local_has_gpu {
-            if let Some(node) = find_gpu_node(registry) {
+            if let Some(node) = find_gpu_node(registry, &requirement) {
                 return RouteDecision::Remote {
                     node,
                     reason: "no local GPU",
@@ -121,6 +194,21 @@ impl GridRouter {
         // 4. Default: local
         RouteDecision::Local
     }
+
+    /// Does this box itself clear the declared floor? Judged by the same
+    /// [`eligible`] call a peer gets — there are no node types here, and a gate
+    /// that exempts the local node is a gate with a hole shaped like us.
+    fn local_is_eligible(&self, requirement: &Requirement) -> bool {
+        let bytes = mb_to_bytes(self.local_vram_mb);
+        eligible(
+            requirement,
+            &Offer {
+                advertised_bytes: bytes,
+                node_total_bytes: bytes,
+            },
+        )
+        .is_eligible()
+    }
 }
 
 /// Check if a command requires GPU hardware.
@@ -130,13 +218,20 @@ fn requires_gpu(command: &str) -> bool {
         || (command.starts_with("ai/") && command != "ai/report")
 }
 
-/// Find an online, trusted node with GPU capability.
-fn find_gpu_node(registry: &NodeRegistry) -> Option<GridNode> {
+/// Find an online, trusted node with GPU capability that can actually hold the
+/// job.
+///
+/// The eligibility filter runs **before** the sort, deliberately. Ranking answers
+/// "which of these is best"; it cannot answer "is any of these adequate", and a
+/// sort with no floor under it will always return its largest element however
+/// small that element is.
+fn find_gpu_node(registry: &NodeRegistry, requirement: &Requirement) -> Option<GridNode> {
     let mut candidates: Vec<GridNode> = registry
         .nodes_with_capability("compute")
         .into_iter()
         .filter(|n| n.trust_level >= TrustLevel::Trusted)
         .filter(|n| is_online(n))
+        .filter(|n| eligible(requirement, &offer_of(n)).is_eligible())
         .collect();
 
     // Sort by VRAM descending, then latency ascending
@@ -154,9 +249,15 @@ fn find_gpu_node(registry: &NodeRegistry) -> Option<GridNode> {
 }
 
 /// Find the node with the most compute power (including local).
-/// Returns None if local node is the most powerful.
-fn find_max_compute_node(registry: &NodeRegistry, local_vram: u64) -> Option<GridNode> {
-    let best_remote = find_gpu_node(registry)?;
+/// Returns None if local node is the most powerful — or if no remote node clears
+/// the declared floor, in which case there is nothing to hop to and the caller
+/// stays home.
+fn find_max_compute_node(
+    registry: &NodeRegistry,
+    local_vram: u64,
+    requirement: &Requirement,
+) -> Option<GridNode> {
+    let best_remote = find_gpu_node(registry, requirement)?;
     let remote_vram = gpu_vram(&best_remote);
     if remote_vram > local_vram {
         Some(best_remote)
@@ -216,6 +317,193 @@ mod tests {
         };
         registry.register_node(node);
         (registry, dir.to_string_lossy().into())
+    }
+
+    /// Eligibility gating at the routing seam. These use their own registry dirs
+    /// because the fixture above shares one path across tests, and a shell node
+    /// leaking into an unrelated case would be a confusing failure.
+    mod eligibility_gate {
+        use super::*;
+
+        fn node(id: &str, vram_mb: u64, latency_ms: u64) -> GridNode {
+            GridNode {
+                node_id: id.into(),
+                node_name: Some(id.into()),
+                addresses: vec![TransportAddress::Tailscale {
+                    ip: id.into(),
+                    port: 7117,
+                    machine_name: None,
+                }],
+                capabilities: vec![NodeCapability::Compute {
+                    gpu: Some("test".into()),
+                    vram_mb: Some(vram_mb),
+                }],
+                trust_level: TrustLevel::Owner,
+                last_seen: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis() as u64,
+                latency_ms: Some(latency_ms),
+            }
+        }
+
+        fn registry_of(name: &str, nodes: Vec<GridNode>) -> NodeRegistry {
+            let dir = std::env::temp_dir().join(format!("grid-router-elig-{name}"));
+            let _ = std::fs::remove_dir_all(&dir);
+            let registry = NodeRegistry::new(&dir);
+            for n in nodes {
+                registry.register_node(n);
+            }
+            registry
+        }
+
+        /// what this catches: THE LIVE CROSS-CLASS HOLE. Before the filter,
+        /// `find_gpu_node` sorted by advertised VRAM and took the top with no
+        /// floor under it, so the ONLY candidate won even at 1 GB for a 24 GB
+        /// job — the caller got a remote hop that could not possibly serve.
+        /// Losing on rank was never the issue; being a candidate was.
+        #[test]
+        fn a_node_that_cannot_hold_the_job_is_never_routed_to() {
+            let registry = registry_of("too-small", vec![node("10.0.0.1", 1024, 5)]);
+            let router = GridRouter::new(false, 0);
+
+            let decision = router.route(
+                "genome/train",
+                &serde_json::json!({ PARAM_REQUIRES_VRAM_MB: 24576 }),
+                &registry,
+            );
+
+            assert!(
+                matches!(decision, RouteDecision::Local),
+                "a 1GB node must not be handed a 24GB job: {decision:?}"
+            );
+        }
+
+        /// what this catches: the gate becoming a tiebreak. A shell advertising
+        /// tiny specs sits at the FRONT of the latency order and the BACK of the
+        /// VRAM order — if eligibility were folded into the comparator it could
+        /// still surface. It must be excluded from the candidate set entirely,
+        /// leaving the one node that actually fits.
+        #[test]
+        fn a_cheap_shell_cannot_outrank_its_way_into_a_job_it_cannot_hold() {
+            let registry = registry_of(
+                "shell-vs-real",
+                vec![
+                    node("10.0.0.9", 512, 1),     // shell: fastest, useless
+                    node("10.0.0.2", 32768, 200), // real: slow but adequate
+                ],
+            );
+            let router = GridRouter::new(false, 0);
+
+            let decision = router.route(
+                "ai/generate",
+                &serde_json::json!({ PARAM_REQUIRES_VRAM_MB: 24576 }),
+                &registry,
+            );
+
+            match decision {
+                RouteDecision::Remote { node, .. } => assert_eq!(
+                    node.node_id, "10.0.0.2",
+                    "the adequate node must win over the cheap shell"
+                ),
+                RouteDecision::Local => panic!("expected the adequate node, got Local"),
+            }
+        }
+
+        /// what this catches: a silent behaviour change for every existing
+        /// caller. No declared requirement means no floor — the gate must be
+        /// invisible until someone states a need, or landing it would strand
+        /// jobs that route fine today.
+        #[test]
+        fn an_undeclared_requirement_routes_exactly_as_before() {
+            let registry = registry_of("undeclared", vec![node("10.0.0.3", 512, 5)]);
+            let router = GridRouter::new(false, 0);
+
+            match router.route("genome/train", &serde_json::json!({}), &registry) {
+                RouteDecision::Remote { node, reason } => {
+                    assert_eq!(node.node_id, "10.0.0.3");
+                    assert_eq!(reason, "no local GPU");
+                }
+                RouteDecision::Local => panic!("undeclared jobs must route as they always did"),
+            }
+        }
+
+        /// what this catches: exempting ourselves. `prefer-gpu` used to mean "we
+        /// own a GPU", which sent a 24GB job to an 8GB local card while an
+        /// adequate peer sat idle. The local node is judged on the same axis by
+        /// the same call.
+        #[test]
+        fn the_local_gpu_is_gated_too_and_yields_to_an_adequate_peer() {
+            let registry = registry_of("local-too-small", vec![node("10.0.0.4", 32768, 50)]);
+            let router = GridRouter::new(true, 8192);
+
+            let decision = router.route(
+                "ai/generate",
+                &serde_json::json!({
+                    "routingHint": HINT_PREFER_GPU,
+                    PARAM_REQUIRES_VRAM_MB: 24576,
+                }),
+                &registry,
+            );
+
+            match decision {
+                RouteDecision::Remote { node, reason } => {
+                    assert_eq!(node.node_id, "10.0.0.4");
+                    assert_eq!(reason, "prefer-gpu hint");
+                }
+                RouteDecision::Local => {
+                    panic!("an 8GB local card must not keep a 24GB job just because it is ours")
+                }
+            }
+        }
+
+        /// what this catches: the inverse — the gate must not evict a local node
+        /// that DOES fit. A filter that is merely strict is as wrong as one that
+        /// is merely permissive; `prefer-gpu` still prefers a capable local GPU.
+        #[test]
+        fn an_adequate_local_gpu_still_keeps_the_job() {
+            let registry = registry_of("local-fits", vec![node("10.0.0.5", 32768, 50)]);
+            let router = GridRouter::new(true, 49152);
+
+            assert!(
+                matches!(
+                    router.route(
+                        "ai/generate",
+                        &serde_json::json!({
+                            "routingHint": HINT_PREFER_GPU,
+                            PARAM_REQUIRES_VRAM_MB: 24576,
+                        }),
+                        &registry,
+                    ),
+                    RouteDecision::Local
+                ),
+                "a local card that clears the floor keeps the job"
+            );
+        }
+
+        /// what this catches: max-compute hopping to a bigger-but-still-too-small
+        /// node. "Biggest available" and "big enough" are different questions,
+        /// and only the second one makes the hop worth taking.
+        #[test]
+        fn max_compute_does_not_hop_to_a_node_that_still_cannot_hold_it() {
+            let registry = registry_of("max-compute-short", vec![node("10.0.0.6", 16384, 5)]);
+            let router = GridRouter::new(true, 8192);
+
+            assert!(
+                matches!(
+                    router.route(
+                        "ai/generate",
+                        &serde_json::json!({
+                            "routingHint": HINT_MAX_COMPUTE,
+                            PARAM_REQUIRES_VRAM_MB: 24576,
+                        }),
+                        &registry,
+                    ),
+                    RouteDecision::Local
+                ),
+                "16GB beats our 8GB but still cannot hold 24GB — the hop buys nothing"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The live bug

`GridRouter::find_gpu_node` sorted candidates by **advertised** VRAM and took the top, with no floor under the sort. A ranking answers *"which of these is best"*; it cannot answer *"is any of these adequate"* — so the biggest claim won every job, and a 1 GB node got handed a 24 GB job whenever it was the only peer online.

This is not a simulator. It is the production path: `GridInterceptor → try_route_remote → GridRouter::route`.

## The fix

`capacity/eligibility.rs` — a pure `eligible(Requirement, Offer)` that takes **no price and no reputation**, so it cannot be outbid or earned past. The router filters candidates through it **before** sorting, and judges the local node with the same call: `prefer-gpu` stops meaning "we own a GPU" and starts meaning "we own a GPU that can hold this job".

Ordering is the whole point. Fold the check into the comparator and "big enough" becomes a tiebreak a large enough claim can outrank.

## Why this is the capability half of the cross-class defense

`trust_lower_bound` (#2229) took sybil churn to 0/100 **within a class**. Cross-class survived it: a shell advertises arbitrarily cheap specs, lands where no proven competitor exists, and wins by default rather than by trust.

That attack needs somewhere cheap to hide. Eligibility removes the terrain — to be offered real work you must claim capability comparable to real competitors, and the moment you do you are in a contested class where `trust_lower_bound` already bites. **Advertise cheap, or win real jobs. Not both.**

M5 owns the other lever (mint stake), which prices the cost of *trying* — something this does not do. Not redundant barriers.

It is also a correctness rule first and an economic lever second: a node that cannot host a job should not be offered it, whether or not anyone is attacking. That makes it a sturdier foundation than a cost that needs tuning.

## Honest limits, both deliberate

- **No declared requirement ⇒ no floor.** Every existing caller routes exactly as before; a test pins that. The real per-command declaration is M5's requirements lane — this reads `requiresVramMb` from params today.
- **`VoidClaim` is unreachable from the router.** The registry publishes ONE self-reported number, so claim and ceiling are the same value. Catching a node that *lies* about its size needs the live ledger's measured free bytes as an independent ceiling — blocked on the `PeerId` join key (#2228). This filter refuses nodes that *admit* they are too small, which is what collapses the hiding place.

## Tests — 16

Load-bearing ones:
- a cheap shell is not offered the job **at any price**
- it cannot outrank its way in from the front of the latency order
- an inflated claim is **void**, not merely eligible
- the local GPU is gated identically and yields to an adequate peer
- `max-compute` won't hop to a bigger-but-still-too-small node
- an undeclared requirement routes exactly as before

## Verification

- `cargo test -p continuum-core --lib grid::router` — 10/10 (incl. the 4 pre-existing router tests, unchanged)
- `cargo test -p continuum-core --lib capacity::eligibility` — 6/6
- `cargo check -p continuum-core --lib --tests` (the windows-msvc CI gate) — clean
- Full CI lib suite: 6921 pass. The 31 failures are Windows-local (`persona::seed`, `routing::tracing_init`, `sentinel::steps::shell`) and **reproduce on a clean base with this branch's files removed** — CI runs Linux.

Refs #2228