### PR TITLE
docs(placement): date the aspirational paragraph that misled two agents in one day

### DIFF
--- a/core/continuum-core/src/resources/placement.rs
+++ b/core/continuum-core/src/resources/placement.rs
@@ -255,6 +255,31 @@ fn plan_to_fit(
 // weights (`ShareLane`) beats a node with more free bytes every time. `capacity::grid`'s
 // `GridPlacementPolicy` becomes a thin adapter over this once its `GridSnapshot` carries
 // each node's resident models (the integration slice) — NOT a third parallel allocator.
+//
+// ─── STATUS 2026-08-10: THE PARAGRAPH ABOVE IS A PLAN, NOT A DESCRIPTION ───────────
+//
+// Read it as intent. Neither seam is on a live path, and the wording above has now
+// misled two agents in a single day — once into nominating `capacity::grid` as the
+// surviving allocator, and once into building a pricing policy behind
+// `GridPlacementPolicy` because "AffinityFit uses it" implied traffic.
+//
+// Verified by both of us independently, today:
+//   * `GridPlacementPolicy` — zero non-test callers. The ONLY reference outside
+//     `capacity/grid.rs` is this comment. Its impls are exercised solely by the
+//     `GridScenario` sim in that same file, which is what makes them look alive.
+//   * `plan_grid_placement` (below) — zero non-test callers, despite its own doc
+//     calling it "THE grid admission planner".
+//
+// Note the trap in the sentence above: "becomes a thin adapter over this" DEMOTES
+// `GridPlacementPolicy` (the pronoun is `plan_grid_placement`), yet it scans as an
+// endorsement because it names `GridPlacementPolicy` last. If you are choosing a
+// survivor, do not read it as a vote.
+//
+// The seam that IS live is `modules::grid::router::GridRouter::route`, reached via
+// `GridInterceptor → try_route_remote`. Eligibility gating landed there in #2230;
+// ranking/pricing composes onto it AFTER the eligibility filter. Anything built
+// behind the two policy seams above is unreachable in production until something
+// calls them — see #2227 / task #68 for the cleanup decision.
 
 /// One node in the grid's live view: its physical ceiling + what it already serves +
 /// the network's `reachable` verdict THIS instant. An unreachable node is a memory, not


### PR DESCRIPTION
Comment-only. No behavior change.

`resources/placement.rs:253-257` describes what the grid allocators **will become**. It reads as a description of what they **are**, and it produced two wrong conclusions today:

1. Nominating `capacity::grid` as the surviving allocator (I did this; git history showed the opposite — `0bd652b8b` is both grid.rs's last touch AND placement.rs's creation).
2. Starting a pricing policy behind `GridPlacementPolicy` because "the same on-ramp AffinityFit used" implied there was traffic on it (M5 did this, verified my objection independently, and reverted).

Both of us then verified, separately:

- **`GridPlacementPolicy`** — zero non-test callers. The only reference outside `capacity/grid.rs` **is this comment**. Its impls are exercised solely by the `GridScenario` sim in the same file, which is precisely what keeps them looking alive.
- **`plan_grid_placement`** — zero non-test callers either, despite its own doc calling it *"THE grid admission planner"*.

## The specific trap, now called out inline

> `GridPlacementPolicy` becomes a thin adapter over this once its `GridSnapshot` carries…

That sentence **demotes** `GridPlacementPolicy` — the pronoun `this` is `plan_grid_placement` — but it scans as an *endorsement* because it names `GridPlacementPolicy` last. Both misreads went that way.

## What the added STATUS block says

Dated 2026-08-10: which seams are dead and how that was verified, that the live seam is `modules::grid::router::GridRouter::route` (via `GridInterceptor → try_route_remote`, where #2230 landed eligibility gating), and that ranking/pricing composes onto it **after** the eligibility filter.

Refs #2227