### PR TITLE
fix(serving): lane grow-back — relaunch when the plan wants more lanes than are served (#368/#214)

### DIFF
--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -1180,16 +1180,34 @@ pub async fn ensure_model_serving<C: LlamaServerControl + ?Sized>(
                     true
                 }
             };
-            if !window_ok {
+            // LANE grow-back — the exact sibling of the window grow-back above. After a
+            // transient RAM/VRAM squeeze relaunched the lane at fewer parallel slots
+            // (n_seq_max 4→1), a later plan that wants more lanes would otherwise
+            // short-circuit to AlreadyServing on `genome_matches && window_ok` and stay
+            // FROZEN AT ONE LANE FOREVER — starving every citizen to one-at-a-time while
+            // the daemon re-decides the same plan each tick (glass-boxed 2026-08-11:
+            // ~11GB free, lanes stuck at 1, a benchmark solve infra-failed). llama.cpp
+            // cannot hot-resize n_seq_max any more than the window, so a lane increase
+            // needs a relaunch. Grow-only + discrete: served 0 = nothing to compare;
+            // target ≤ served is fine (a down-plan is the daemon's sticky choice); only
+            // target > served relaunches. `served_lanes` is the process's own truth
+            // (ServingSnapshot.lanes), never a recomputed plan value.
+            let served_lanes = current_serving().lanes;
+            let lanes_ok = served_lanes == 0 || target.lanes <= served_lanes;
+            if !window_ok || !lanes_ok {
                 crate::probe!(
-                    class = "serving.window_grow",
+                    class = "serving.grow",
                     model = target.model_id(),
                     target_window = target.context_window,
-                    "served window is below the target beyond padding tolerance — \
-                     relaunching to grow (llama.cpp has no hot-resize; a genome-set \
-                     match alone must not strand a starved lane at the boot floor)",
+                    target_lanes = target.lanes,
+                    served_lanes,
+                    window_ok,
+                    lanes_ok,
+                    "served capacity is below target (window and/or lanes) — relaunching to \
+                     grow (llama.cpp has no hot-resize; a genome-set match alone must not \
+                     strand a starved lane at the boot floor)",
                 );
-                // fall through to relaunch at the larger window.
+                // fall through to relaunch at the larger window / more lanes.
             } else {
                 // Window matches. Is the COMPUTE path alive? A child we spawned
                 // ourselves was decode-verified at `wait_ready` and is trusted


### PR DESCRIPTION
## The bug (glass-boxed 2026-08-11)

The grow-back relaunch gate (`ensure_model_serving`, at the genome-match short-circuit) checked **only the served context WINDOW**. So after a transient RAM/VRAM squeeze relaunched the lane at fewer parallel slots (`n_seq_max` 4→1), a later plan that wanted 4 lanes saw `genome_matches && window_ok` → returned `AlreadyServing` → **serving froze at ONE LANE FOREVER**, while the daemon re-decided the same plan every tick.

Live symptom: ~11GB free, `serving/status` stuck at `lanes:1` across repeated checks, and a sympy SWE-bench solve settled `INFRA_ERROR` — every citizen starved to one-at-a-time on a single warm slot.

## The fix

llama.cpp cannot hot-resize `n_seq_max` any more than the per-slot window, so a lane increase needs a relaunch — the **exact sibling** of the window grow-back the code already documents (2048→31k). Compute a grow-only `lanes_ok` from the process's own truth (`ServingSnapshot.lanes`) and fold it into the same relaunch gate:

- served `0` → nothing to compare (will serve)
- target ≤ served → fine (a down-plan is the daemon's sticky choice)
- target > served → relaunch to grow

Probe class renamed `serving.window_grow` → `serving.grow`, now carrying `target_lanes` / `served_lanes` / which axis tripped.

Addresses the lane axis of #368 / #214. The base-model rehome-on-recovery (#368 defect 2) and base-model hysteresis (defect 1) remain their own lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)