### PR TITLE
fix(serving): quiesce lease lowers warm-slot demand to active count — kill solo-solve plan thrash

### DIFF
--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -503,8 +503,45 @@ impl ServingDaemonModule {
     /// persona floor). The boot wiring calls this before the first
     /// [`Self::compute_plan`]; the next tick replans if it changes.
     pub fn set_lane_demand(&self, demand: u32) {
+        // Register the demand cell process-globally the first time boot sets it, so a
+        // measurement preemption lease (quiesce_all / quiesce_others) can drop the
+        // warm-slot demand to the ACTIVE (non-quiesced) count for its duration and
+        // restore on drop — without threading a ServingDaemon handle into the persona
+        // registry. Idempotent: `set` after the first call is a no-op.
+        let _ = LANE_DEMAND_CELL.set(self.lane_demand.clone());
         self.lane_demand.store(demand.max(1), Ordering::Relaxed);
     }
+}
+
+/// Process-global handle to the live lane-demand cell (registered by the first
+/// [`ServingDaemonModule::set_lane_demand`] at boot). Lets a measurement preemption lease
+/// override serving's warm-slot demand to the number of minds that ACTUALLY need a
+/// warm slot right now — 1 during a solo measured solve — and restore it on drop, so
+/// the plan is feasible for the measurement instead of thrashing to warm-host every
+/// resident persona ([[measured-work-gets-an-exclusive-warm-slot-quiesce-others]]).
+/// `None` before boot (unit tests / tools that never stood a daemon) → every override
+/// is a no-op, so the quiesce lease stays pure and daemon-free-testable.
+static LANE_DEMAND_CELL: std::sync::OnceLock<Arc<std::sync::atomic::AtomicU32>> =
+    std::sync::OnceLock::new();
+
+/// Override the lane demand to `active` (minds that need a warm slot now; floored at
+/// 1 — a measurement still needs one lane), returning the PREVIOUS value for restore.
+/// No-op returning `None` before the daemon has booted.
+pub fn quiesce_lane_demand(active: u32) -> Option<u32> {
+    LANE_DEMAND_CELL
+        .get()
+        .map(|cell| cell.swap(active.max(1), Ordering::Relaxed))
+}
+
+/// Restore the lane demand to `prev` — the value [`quiesce_lane_demand`] returned when
+/// the lease was acquired. No-op if the daemon never booted.
+pub fn restore_lane_demand(prev: u32) {
+    if let Some(cell) = LANE_DEMAND_CELL.get() {
+        cell.store(prev.max(1), Ordering::Relaxed);
+    }
+}
+
+impl ServingDaemonModule {
 
     /// The current lane demand (≥ 1).
     /// Register serving's autonomic PLANNER to run on the memory authority's tick

--- a/core/continuum-core/src/persona/airc_runtime_registry.rs
+++ b/core/continuum-core/src/persona/airc_runtime_registry.rs
@@ -112,6 +112,10 @@ pub struct PersonaAircRuntimeRegistry {
 /// [[benchmark-is-a-governor-preemption-lease]] [[first-class-citizens-even-during-benchmarks]]
 pub struct QuiesceLease {
     flags: Vec<Arc<AtomicBool>>,
+    /// The serving lane-demand value in effect BEFORE this lease dropped it to the
+    /// active (non-quiesced) count — restored on drop. `None` when no serving daemon
+    /// was booted to override (unit tests / tools), keeping the lease pure there.
+    prev_demand: Option<u32>,
 }
 
 impl QuiesceLease {
@@ -126,6 +130,10 @@ impl Drop for QuiesceLease {
     fn drop(&mut self) {
         for f in &self.flags {
             f.store(false, Ordering::Relaxed);
+        }
+        // Restore the fleet's warm-slot demand the measurement borrowed down.
+        if let Some(prev) = self.prev_demand {
+            crate::modules::serving_daemon::restore_lane_demand(prev);
         }
     }
 }
@@ -313,6 +321,7 @@ impl PersonaAircRuntimeRegistry {
         pairs: Vec<(Uuid, Arc<AtomicBool>)>,
         except: Option<Uuid>,
     ) -> QuiesceLease {
+        let total = pairs.len();
         let flags: Vec<Arc<AtomicBool>> = pairs
             .into_iter()
             .filter(|(id, _)| except != Some(*id))
@@ -321,7 +330,17 @@ impl PersonaAircRuntimeRegistry {
         for f in &flags {
             f.store(true, Ordering::Relaxed);
         }
-        QuiesceLease { flags }
+        // Drop serving's warm-slot demand to the minds that ACTUALLY need a warm slot
+        // for the measurement's duration — the non-quiesced remainder (`total - flags`,
+        // = 1 for quiesce_others(solver), 0 → floored to 1 for quiesce_all). Without
+        // this the plan keeps budgeting a warm slot for EVERY resident persona and
+        // thrashes recompute→relaunch trying to warm-host a fleet that is deliberately
+        // idle — the exact 4→0→2 oscillation glass-boxed under a dispatched solve
+        // ([[measured-work-gets-an-exclusive-warm-slot-quiesce-others]]). Restored on
+        // drop. A no-op (`None`) before the serving daemon booted — pure in unit tests.
+        let active = (total - flags.len()) as u32;
+        let prev_demand = crate::modules::serving_daemon::quiesce_lane_demand(active);
+        QuiesceLease { flags, prev_demand }
     }
 
     /// Acquire the same exclusive-measurement lease as [`quiesce_all`] but leave ONE


### PR DESCRIPTION
Glass-boxed live under a dispatched SWE solve: serving oscillated 4→0→2, `serving.plan warm-slot-oversubscribed` every recompute. Root cause: `set_lane_demand(persona_floor)` is a static constant; `agent/solve`'s `quiesce_others` suspends idle citizens' self-tick but never lowered that demand, so the plan kept warm-budgeting every resident and thrashed. Fix: the QuiesceLease drops serving lane demand to the active (non-quiesced) count for its duration, RAII-restored on drop. cargo check --lib green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)