### PR TITLE
fix(cognition): discovery saturates at half budget on workspace-deliverable turns (#390 state gate)

### DIFF
--- a/core/continuum-core/src/cognition/act_observe/mod.rs
+++ b/core/continuum-core/src/cognition/act_observe/mod.rs
@@ -564,6 +564,104 @@ mod tests {
     }
 
 
+    /// Emits a DIFFERENT read-class act every tick (fresh path per generation), so
+    /// every batch has a fresh loop signature — the exact shape the #206 identical-act
+    /// backstop can never bound. The instrument for the #390 discovery-saturation gate.
+    struct VaryingAct {
+        ticks: Mutex<usize>,
+    }
+    #[async_trait]
+    impl Faculty for VaryingAct {
+        fn id(&self) -> FacultyId {
+            FacultyId::Deliberation
+        }
+        fn reacts_to_broadcast(&self) -> bool {
+            true
+        }
+        async fn contribute(&self, _ws: &Workspace) -> Option<Contribution> {
+            let n = {
+                let mut t = self.ticks.lock().unwrap();
+                *t += 1;
+                *t
+            };
+            Some(Contribution::verdict(
+                Decision::Act {
+                    calls: vec![ToolCall {
+                        id: format!("call-{n}"),
+                        name: "code/read".into(),
+                        input: serde_json::json!({ "path": format!("src/file_{n}.rs") }),
+                    }],
+                    intent: "keep reading".into(),
+                },
+                0.9,
+                "reads forever, never writes",
+            ))
+        }
+    }
+
+    // what this catches (#390 discovery-saturation gate): a workspace-deliverable turn
+    // spending VARIED read acts — each with a fresh signature, so the #206 identical-act
+    // backstop never trips — must be stopped at HALF the act budget while nothing has
+    // mutated the workspace, so the remaining half survives for the empty-diff re-drive
+    // instead of being read away (glass-boxed live: 15 varied reads on the right file,
+    // patch_bytes 0, [no-deliverable] fact firing every act and changing nothing). The
+    // ambient control pins the scope: a turn whose deliverable is the UTTERANCE reads
+    // freely to the full budget — the gate exists only where the diff is the deliverable.
+    #[tokio::test]
+    async fn drive_to_settle_gates_discovery_at_half_budget_on_workspace_deliverable() {
+        let exec = Arc::new(RecordingExecutor {
+            seen_context: Mutex::new(None),
+            result_content: "file contents...".into(),
+        });
+        let adm = admission();
+        let cycle = WorkspaceCycle::new(
+            vec![Arc::new(VaryingAct { ticks: Mutex::new(0) })],
+            Arc::new(SalienceArbiter),
+            8,
+        )
+        .with_acting(body(exec.clone(), adm.clone()));
+
+        let outcome = drive_to_settle(
+            &cycle,
+            "fix the bug",
+            Uuid::new_v4(),
+            20,
+            TurnFraming::ambient().on_workspace(),
+        )
+        .await;
+
+        assert_eq!(
+            outcome.acts, 10,
+            "discovery saturates at half the budget (20/2) with zero mutations — \
+             the other half is preserved for the empty-diff re-drive"
+        );
+        assert!(
+            matches!(outcome.decision, Decision::Act { .. }) && outcome.spoken.is_none(),
+            "the never-write faculty returns un-driven — honest 'saturated, did not settle'"
+        );
+
+        // Ambient control: same never-writing faculty, deliverable is the utterance —
+        // discovery is not gated and the full budget is hers.
+        let exec2 = Arc::new(RecordingExecutor {
+            seen_context: Mutex::new(None),
+            result_content: "file contents...".into(),
+        });
+        let cycle2 = WorkspaceCycle::new(
+            vec![Arc::new(VaryingAct { ticks: Mutex::new(0) })],
+            Arc::new(SalienceArbiter),
+            8,
+        )
+        .with_acting(body(exec2, admission()));
+        let ambient =
+            drive_to_settle(&cycle2, "look around", Uuid::new_v4(), 20, TurnFraming::ambient())
+                .await;
+        assert_eq!(
+            ambient.acts, 20,
+            "a non-workspace turn reads to the full budget — the gate scopes to \
+             workspace-deliverable turns only"
+        );
+    }
+
     // what this catches: the grader's stopwatch. A mind that never settles is
     // bounded by the EXTERNAL `max_acts` budget and the final un-driven Act is
     // returned as unfinished — never a fabricated answer, and the budget is the

--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -90,6 +90,28 @@ pub async fn drive_to_settle(
     // rather than being trapped. Her own behavior is the budget — no counter, no constant.
     let mut acts_at_last_nudge: Option<usize> = None;
 
+    // DISCOVERY SATURATION GATE (#390) — the STATE escalation of the [no-deliverable]
+    // fact above, built on its own measured failure: the fact fires on EVERY act with
+    // no mutation receipt (see the Acted arm), and a live run still spent 15+ varied
+    // reads on the right file with a zero-byte diff — the fact was perceived and
+    // changed nothing ([[perception-facts-fire-correctly-and-change-nothing-only-
+    // state-changes-behaviour]]). Varied reads never trip the #206 identical-act
+    // backstop (each has a fresh signature), so the only bound they ever hit is
+    // `max_acts` — at which point the budget is gone and the empty-diff re-drive in
+    // `agent/solve` structurally cannot fire. The state fix: on a turn whose
+    // DELIVERABLE IS THE WORKSPACE, discovery may spend at most HALF the act budget
+    // before the first workspace mutation; past that, acts are withheld (same
+    // `may_act` lever as #206) so the drive ends with REAL remaining budget — which
+    // is exactly what the empty-diff re-drive needs to hand back with the structural
+    // fact. The first mutation lifts the gate for the rest of the turn: iteration
+    // (edit → run tests → edit) is never bounded, only pre-write wandering. Not a
+    // steer — it never says what to write, exactly like `max_acts`; it converts an
+    // unbounded read loop into a decision point while the budget can still buy the
+    // decision. Non-workspace turns (chat, research) are untouched.
+    let discovery_budget = (max_acts / 2).max(1);
+    let mut mutated_yet = false;
+    let mut saturation_probed = false;
+
     // #386: transient-deliberation retry. Glass-boxed on atlas-17139-h1
     // (2026-08-09): the per-slot wedge fails ~1 in 3 generations and the VERY
     // NEXT generation succeeds — capture tick 2 faults, tick 3 acts, tick 5
@@ -121,10 +143,27 @@ pub async fn drive_to_settle(
         } else {
             Situation::PostAction
         };
-        // may_act gates ACTING (not speaking): past the act budget OR once she is provably
-        // stuck re-emitting the identical act, a fresh Act is returned un-driven and she must
-        // settle into a Speak/Pass. Speaking is never gated.
-        let may_act = acts < max_acts && stuck < STUCK_LIMIT;
+        // may_act gates ACTING (not speaking): past the act budget, once she is provably
+        // stuck re-emitting the identical act, OR once a workspace-deliverable turn has
+        // saturated its discovery budget without a single mutation (#390 gate above), a
+        // fresh Act is returned un-driven and she must settle into a Speak/Pass.
+        // Speaking is never gated.
+        let discovery_open =
+            !framing.workspace_deliverable || mutated_yet || acts < discovery_budget;
+        if !discovery_open && acts < max_acts && stuck < STUCK_LIMIT && !saturation_probed {
+            saturation_probed = true;
+            crate::probe!(
+                class = "persona.settle.discovery_saturated",
+                room_id = %room_id,
+                acts = acts,
+                discovery_budget = discovery_budget,
+                max_acts = max_acts,
+                "workspace-deliverable turn spent its discovery budget with zero \
+                 mutations — withholding further acts so the remaining budget reaches \
+                 the empty-diff re-drive instead of being read away (#390 state gate)"
+            );
+        }
+        let may_act = acts < max_acts && stuck < STUCK_LIMIT && discovery_open;
         let (step, step_metrics) =
             settle_step(cycle, burst.clone(), room_id, may_act, framing, situation).await;
         if let Some(m) = step_metrics {
@@ -186,6 +225,15 @@ pub async fn drive_to_settle(
             SettleStep::Acted { calls, .. } => {
                 acts += 1;
                 collect_touched_paths(&mut touched, &calls);
+                // Latch the #390 discovery gate OPEN on the first workspace mutation:
+                // once she has written anything, iteration is hers for the whole
+                // remaining budget. Same receipt predicate as the [no-deliverable]
+                // fact — one truth for "did an act change a file".
+                if framing.workspace_deliverable && !mutated_yet {
+                    if let Some(body) = cycle.acting() {
+                        mutated_yet = mutated_workspace(&body.working_memory.recent_entries());
+                    }
+                }
                 // THE DELIVERABLE FACT BELONGS ON THE ACT PATH, NOT ONLY ON SETTLE.
                 //
                 // It used to live exclusively in the Spoke arm, so it could only reach a

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -1086,17 +1086,23 @@ impl AgentSolve {
         // 2026-08-08, atlas-sympy-24066-n6 attempts 2+3): on a Workspace-deliverable
         // task she settled by SPEAKING after ONE act — a generic file summary, zero
         // edits — leaving 11 of 12 acts unused, twice, near-verbatim. Working is not
-        // speaking: when the deliverable is the workspace diff, a Speak with an EMPTY
-        // diff and real remaining budget must not end the attempt. ONE bounded
+        // speaking: when the deliverable is the workspace diff, an attempt ending with
+        // an EMPTY diff and real remaining budget must not end silently. ONE bounded
         // re-drive (a retry, never a nag loop): state the structural fact, hand back
-        // the remaining budget. If she speaks to an empty diff again, THAT settles —
-        // honestly graded, with the fact on the record. Not fired on budget
-        // exhaustion (spoken=None un-driven Act) or infra failure — those already
-        // grade honestly.
+        // the remaining budget. If she ends on an empty diff again, THAT settles —
+        // honestly graded, with the fact on the record.
+        //
+        // This fires on ANY non-infra end with budget remaining — a Speak, the #206
+        // stuck backstop, or the #390 discovery-saturation gate (which deliberately
+        // ends the drive EARLY, at half budget, precisely so this re-drive still has
+        // budget to hand back; see `drive_to_settle`). It used to require
+        // `spoken.is_some()`, which structurally excluded the gated endings — the one
+        // population that most needs the redirect. TRUE budget exhaustion is still
+        // excluded by `acts + 1 < max_acts` (nothing left to hand back), and infra
+        // failures by `inference_error` — those grade honestly as before.
         if workspace_deliverable
             && patch.is_empty()
             && settled.inference_error.is_none()
-            && settled.spoken.is_some()
             && settled.acts + 1 < max_acts
         {
             let remaining = max_acts - settled.acts;
@@ -1105,8 +1111,9 @@ impl AgentSolve {
                 run_id = %run_id.as_deref().unwrap_or("-"),
                 acts_used = settled.acts,
                 acts_remaining = remaining,
-                "Speak settled a workspace-deliverable attempt with an EMPTY diff and \
-                 remaining act budget — one bounded re-drive with the structural fact"
+                "workspace-deliverable attempt ended with an EMPTY diff and remaining \
+                 act budget (Speak, stuck backstop, or #390 saturation gate) — one \
+                 bounded re-drive with the structural fact"
             );
             let fact = format!(
                 "Status check from the grading harness (a structural fact, not a person): \


### PR DESCRIPTION
## The defect (verified live)

claim-2ff4accd (Atlas, sympy-24152): 15 acts, all varied reads, RIGHT file located, `patch_bytes 0`. The `[no-deliverable]` perception fact fired on every act and changed nothing — [[perception-facts-fire-correctly-and-change-nothing-only-state-changes-behaviour]]. Varied reads have fresh signatures, so the #206 identical-act backstop never trips; the budget is read away and agent/solve's empty-diff re-drive has nothing left to hand back.

## The state gate

- `drive_to_settle`: on `workspace_deliverable` framing, discovery gets `(max_acts/2).max(1)` acts before the first workspace mutation. Past that, `may_act = false` (same defer lever as the stuck backstop) and the drive ends with **real remaining budget**. First mutation latches the gate open — iteration is never bounded, only mutation-free discovery.
- `agent/solve` EMPTY-DIFF RE-DRIVE: dropped `spoken.is_some()` — it structurally excluded exactly the gated endings. True exhaustion still excluded by `acts+1 < max_acts`, infra by `inference_error`. Identical-diff sibling untouched (needs a non-empty patch a saturation ending can't produce).

## Proof

- New regression: `VaryingAct` faculty (fresh path/tick, backstop-proof) × budget 20 on workspace framing → `acts == 10`, `spoken=None`; ambient control → full 20 (gate scopes to workspace-deliverable only).
- 37 act_observe + 11 agent::solve tests green; `cargo check --lib --tests` clean.

Live A/B = next dispatched bench run after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo