### PR TITLE
fix(bench): solve prelude quiesces FIRST + event-gated plan resettle — kills the 400-token keyhole

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -858,6 +858,76 @@ impl AgentSolve {
             available_slots = solve_admission().available_permits() as u64,
             "solve admitted — holding one serving-lane solve slot for the drive"
         );
+        // 1a) Quiesce BEFORE the lane, and let the plan RESETTLE before anything
+        //     pins it (glass-boxed 2026-08-11, Atlas on sympy-24152). The old order
+        //     was lane-then-quiesce, which built a catch-22: the lease's lowered
+        //     lane demand (#2238/#2239) would let the planner collapse a crowded
+        //     4-lane × 16k layout into one big-window lane — but by then the solve
+        //     already held the lane, and the reconcile (correctly) refuses to
+        //     relaunch under a live measurement ("eval holds the lane steady"). The
+        //     solve froze the cramped layout under itself, and the persona worked a
+        //     SWE repo through a ~400-token keyhole: 13.1k of her 16.4k window was
+        //     fixed overhead (tools 6300 + framing 2741 + completion reserve 4096),
+        //     over-window on every single compose. Quiesce-first + an EVENT-GATED
+        //     settle (the daemon's own snapshot watch — never a sleep-poll) means
+        //     the lane below is acquired against the settled big-window plan, and
+        //     `lane.served_ctx` carries it into her fork with no further plumbing.
+        //     Bounded loudly: a planner that keeps the layout is a legitimate
+        //     outcome, so `Unchanged` proceeds — it can never park the solve.
+        let _quiesce_lease =
+            crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global().map(
+                |reg| {
+                    let lease = reg.quiesce_others(persona_uuid);
+                    crate::probe!(
+                        class = "benchmark.solve.phase",
+                        run_id = %run_id.as_deref().unwrap_or("-"),
+                        phase = "quiesce_others",
+                        quiesced_peers = lease.count() as u64,
+                        "measured solve holds an exclusive warm slot — idle citizens quiesced so the KV prefix survives turn-to-turn"
+                    );
+                    lease
+                },
+            );
+        if let Some(rx) = crate::inference::llama_server::serving_state_receiver() {
+            let pre = crate::inference::llama_server::current_serving();
+            // Wide enough for one planner tick + a resident-model relaunch (weights
+            // already on disk); a settle that needs longer is a serving fault the
+            // lane-acquire timeout below will name, not something to wait out here.
+            const SERVING_RESETTLE_BOUND: Duration = Duration::from_secs(180);
+            let outcome = crate::inference::llama_server::await_snapshot_resettle(
+                rx,
+                pre.lanes,
+                pre.served_context_window,
+                SERVING_RESETTLE_BOUND,
+            )
+            .await;
+            match outcome {
+                crate::inference::llama_server::SnapshotSettle::Resettled { lanes, window } => {
+                    crate::probe!(
+                        class = "benchmark.solve.phase",
+                        run_id = %run_id.as_deref().unwrap_or("-"),
+                        phase = "serving_resettled",
+                        pre_lanes = pre.lanes as u64,
+                        pre_window = pre.served_context_window as u64,
+                        lanes = lanes as u64,
+                        window = window as u64,
+                        "quiesce lowered demand and the plan RESETTLED — the solve \
+                         drives on the settled layout instead of freezing the crowded one"
+                    );
+                }
+                crate::inference::llama_server::SnapshotSettle::Unchanged => {
+                    crate::probe!(
+                        class = "benchmark.solve.phase",
+                        run_id = %run_id.as_deref().unwrap_or("-"),
+                        phase = "serving_unchanged",
+                        lanes = pre.lanes as u64,
+                        window = pre.served_context_window as u64,
+                        "plan held its layout under lowered demand — proceeding on the \
+                         current lanes/window (legitimate: it may already be optimal)"
+                    );
+                }
+            }
+        }
         crate::probe!(
             class = "benchmark.solve.phase",
             run_id = %run_id.as_deref().unwrap_or("-"),
@@ -898,35 +968,11 @@ impl AgentSolve {
             "solve prelude: lane acquired"
         );
 
-        // 1b) Give this persona an EXCLUSIVE warm slot for the solve's duration by quiescing the
-        //      OTHER resident citizens. On a single-warm-slot box (glass-boxed 2026-08-09,
-        //      serving.plan "warm-slot-oversubscribed": 4 residents, 1 warm slot) the idle
-        //      citizens' autonomic turns rotate through the shared llama.cpp KV slots and EVICT
-        //      this solver's prefilled prefix — so every act re-prefills the FULL prompt cold
-        //      (measured ~85s for ~12k tokens at 139 tok/s, O(n²) degrading) instead of reusing
-        //      cache and prefilling only the ~50-token delta. Quiescing the others lets the prefix
-        //      survive turn-to-turn. This is the SAME discipline cognition/eval uses (`quiesce_all`
-        //      at eval.rs) for a measured snapshot — swe-solve/agent-solve simply never invoked it.
-        //      The lease is panic-safe RAII: the fleet resumes on drop, early-return, OR unwind, so
-        //      a stalled or panicking solve can never leave the citizens frozen. SHE is never
-        //      suspended — only the idle contenders step back, and they still answer DIRECTED
-        //      messages (quiesced gates only the autonomic self-tick). `None` in unit tests / tools
-        //      that never stood up a live roster — a solve with no fleet has nothing to quiesce.
-        //      [[benchmark-is-a-governor-preemption-lease]] [[first-class-citizens-even-during-benchmarks]]
-        let _quiesce_lease =
-            crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global().map(
-                |reg| {
-                    let lease = reg.quiesce_others(persona_uuid);
-                    crate::probe!(
-                        class = "benchmark.solve.phase",
-                        run_id = %run_id.as_deref().unwrap_or("-"),
-                        phase = "quiesce_others",
-                        quiesced_peers = lease.count() as u64,
-                        "measured solve holds an exclusive warm slot — idle citizens quiesced so the KV prefix survives turn-to-turn"
-                    );
-                    lease
-                },
-            );
+        // (The exclusive-warm-slot quiesce lease — KV-prefix protection, panic-safe
+        // RAII, she is never suspended, only idle contenders' autonomic ticks —
+        // is acquired in step 1a ABOVE the lane, so its lowered demand shapes the
+        // plan the lane is acquired against. [[benchmark-is-a-governor-preemption-lease]]
+        // [[first-class-citizens-even-during-benchmarks]])
 
         // 2) Fork her WHOLE cognition onto that lane, rooted at the workspace: tools ON, recall ON.
         //    A brief wait covers the post-spawn template race (same as the eval fork-waiter).

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -864,6 +864,76 @@ pub fn serving_state_receiver() -> Option<watch::Receiver<ServingSnapshot>> {
     SERVING_STATE.get().cloned()
 }
 
+/// Outcome of [`await_snapshot_resettle`] — did the serving layout change?
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotSettle {
+    /// A READY snapshot arrived whose (lanes, window) differ from the
+    /// pre-change layout — the planner acted on the demand change.
+    Resettled { lanes: u32, window: u32 },
+    /// The bound expired with the layout unchanged. A demand change the
+    /// planner decides not to act on is a legitimate outcome (the current
+    /// layout may already be optimal), never an error.
+    Unchanged,
+}
+
+/// Await the serving plan RESETTLING after a demand change — event-gated on
+/// the daemon's own `watch` (each wake is a real snapshot publish), never a
+/// condition-scanning poll ([[the-whole-system-is-event-based-not-polling]]).
+///
+/// The consumer this exists for (glass-boxed 2026-08-11, Atlas on
+/// sympy-24152): a measured solve's quiesce lease lowers lane demand so the
+/// planner can collapse a crowded 4-lane × 16k layout into one big-window
+/// lane — but the old prelude drove IMMEDIATELY, and the reconcile then
+/// refused to relaunch under a live measurement ("eval holds the lane
+/// steady"). The solve froze the cramped layout under itself and the persona
+/// worked a SWE repo through a ~400-token keyhole (13.1k of her 16.4k window
+/// was fixed overhead). Awaiting the resettle BEFORE the lane is acquired
+/// breaks that deadlock with ordering alone.
+///
+/// Resolves on the first READY snapshot whose (lanes, served window) differ
+/// from `pre_*`, or when `bound` expires — bounded loudly by the caller, so a
+/// planner that (correctly) keeps the layout can never park the solve.
+pub async fn await_snapshot_resettle(
+    mut rx: watch::Receiver<ServingSnapshot>,
+    pre_lanes: u32,
+    pre_window: u32,
+    bound: std::time::Duration,
+) -> SnapshotSettle {
+    let deadline = tokio::time::Instant::now() + bound;
+    // The daemon publishes once per reconcile tick. TWO ready publishes with the
+    // layout still unchanged means the planner has RUN under the new demand and
+    // decided to hold — return early instead of taxing every no-change solve
+    // with the full bound (the bound remains the backstop for a daemon that
+    // stops publishing entirely).
+    let mut unchanged_ready_publishes = 0u8;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return SnapshotSettle::Unchanged;
+        }
+        match tokio::time::timeout(remaining, rx.changed()).await {
+            // Sender dropped — the daemon is gone; nothing further will arrive.
+            Ok(Err(_)) => return SnapshotSettle::Unchanged,
+            Ok(Ok(())) => {
+                let (ready, lanes, window) = {
+                    let snap = rx.borrow();
+                    (snap.ready, snap.lanes, snap.served_context_window)
+                };
+                if ready && (lanes != pre_lanes || window != pre_window) {
+                    return SnapshotSettle::Resettled { lanes, window };
+                }
+                if ready {
+                    unchanged_ready_publishes += 1;
+                    if unchanged_ready_publishes >= 2 {
+                        return SnapshotSettle::Unchanged;
+                    }
+                }
+            }
+            Err(_) => return SnapshotSettle::Unchanged,
+        }
+    }
+}
+
 /// The model currently served on this node, per the daemon's last reconcile.
 /// Returns [`ServingSnapshot::empty`] before the daemon installs its state
 /// (boot) or when nothing is live. No HTTP, no probe — a `watch` borrow.
@@ -2500,6 +2570,62 @@ fn split_host_port(root: &str) -> (String, u16) {
 
 #[cfg(test)]
 mod tests {
+
+    /// what this catches (2026-08-11, the solve-prelude keyhole): the settle wait
+    /// must resolve on the FIRST ready snapshot whose layout differs from the
+    /// pre-quiesce one (event-gated on the watch, no polling), and a planner that
+    /// keeps its layout must end as `Unchanged` at the bound — a legitimate
+    /// outcome that proceeds, never a park. A non-ready layout change must NOT
+    /// resolve it (mid-relaunch snapshots are transient, not a settled plan).
+    #[tokio::test]
+    async fn await_snapshot_resettle_resolves_on_ready_layout_change_and_bounds_out_otherwise() {
+        use super::{await_snapshot_resettle, ServingSnapshot, SnapshotSettle};
+        use std::time::Duration;
+
+        // Resettle: a ready snapshot with a NEW layout resolves the wait.
+        let (tx, rx) = tokio::sync::watch::channel(ServingSnapshot::empty());
+        let waiter = tokio::spawn(await_snapshot_resettle(rx, 4, 16384, Duration::from_secs(5)));
+        // Transient mid-relaunch publish (not ready) must be ignored…
+        let mut transitional = ServingSnapshot::empty();
+        transitional.lanes = 1;
+        transitional.served_context_window = 32768;
+        transitional.ready = false;
+        tx.send(transitional.clone()).unwrap();
+        // …and the settled ready layout resolves it.
+        transitional.ready = true;
+        tx.send(transitional).unwrap();
+        assert_eq!(
+            waiter.await.unwrap(),
+            SnapshotSettle::Resettled {
+                lanes: 1,
+                window: 32768
+            }
+        );
+
+        // Unchanged, EARLY: two ready publishes with the same layout mean the
+        // planner ran and held — resolves well before the (long) bound, so a
+        // no-change solve pays reconcile-tick latency, never the full backstop.
+        let (tx2, rx2) = tokio::sync::watch::channel(ServingSnapshot::empty());
+        let waiter2 = tokio::spawn(await_snapshot_resettle(rx2, 4, 16384, Duration::from_secs(30)));
+        let mut same = ServingSnapshot::empty();
+        same.lanes = 4;
+        same.served_context_window = 16384;
+        same.ready = true;
+        tx2.send(same.clone()).unwrap();
+        tokio::task::yield_now().await;
+        tx2.send(same).unwrap();
+        let early = tokio::time::timeout(Duration::from_secs(2), waiter2)
+            .await
+            .expect("two unchanged ready publishes must resolve early, not ride the bound")
+            .unwrap();
+        assert_eq!(early, SnapshotSettle::Unchanged);
+
+        // Unchanged, BACKSTOP: a daemon that stops publishing ends at the bound.
+        let (_tx3, rx3) = tokio::sync::watch::channel(ServingSnapshot::empty());
+        let waiter3 =
+            tokio::spawn(await_snapshot_resettle(rx3, 4, 16384, Duration::from_millis(80)));
+        assert_eq!(waiter3.await.unwrap(), SnapshotSettle::Unchanged);
+    }
 
     /// what this catches (#350): the two states an EMPTY serving snapshot can mean
     /// collapsing back into one. `ServingSnapshot::empty()` is published from process


### PR DESCRIPTION
## The catch-22 (glass-boxed live, Atlas on sympy-24152)

Old order: lane → quiesce. The lease's lowered demand (#2238/#2239) would let the planner collapse 4×16k into one big-window lane — but the solve already held the lane, and reconcile correctly refuses to relaunch under a live measurement. Result: the solve froze the cramped layout under itself and the persona worked a SWE repo through a **~400-token keyhole** (13.1k of 16.4k fixed overhead, `over_window` on every compose).

## The fix — ordering + one event-gated helper

- Quiesce lease moves **above** lane acquisition (one lease, one place; the old post-lane block deleted).
- `llama_server::await_snapshot_resettle`: awaits the daemon's own `ServingSnapshot` watch (the Trinity — subscribe to the happening, never poll). Resolves on the first READY snapshot with a new (lanes, window); **two** ready publishes with the layout held = the planner ran and decided — early `Unchanged`, so a no-change solve pays one reconcile tick, never the 180s backstop. Not-ready mid-relaunch publishes ignored.
- Both outcomes probed (`serving_resettled` / `serving_unchanged`); neither can park the solve.

## Proof

Regression test pins resettle-on-change, early-unchanged-on-hold, and bound-on-silence. 11 agent::solve tests green, check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo