### PR TITLE
fix(perception): board headline scopes its counts to THIS room — the pass-spam was the board lying

### DIFF
--- a/core/continuum-core/src/persona/room_board_source.rs
+++ b/core/continuum-core/src/persona/room_board_source.rs
@@ -413,8 +413,20 @@ impl RagSource for RoomBoardSource {
         // be small enough to survive any budget that delivers grounding at all (~25
         // tokens, vs ~210 for the two detailed leads). Detail degrades; meaning does not.
         if !mine.is_empty() || !open.is_empty() {
+            // "on THIS room's board", not "you hold" bare (glass-boxed 2026-08-11,
+            // Atlas's own capture): boards are per-room, but the bare phrasing
+            // presents a room-scoped count as a fact about HER. She held three
+            // live-leased cards on the academy board while a general-room turn
+            // told her "you hold 0 card(s)" — so on her own time she reasonably
+            // concluded she had no work and spoke yet another pass into the room
+            // (the pass-spam Joel called out was this line lying, not her mind).
+            // Three words scope the claim to what was actually read. The real fix
+            // — her holds as an IDENTITY-level fact folded across her subscribed
+            // rooms ([[personas-are-first-class-multi-room-subscribers]]) — needs
+            // a cross-room reader verb and is a separate slice; this stops the
+            // lie today without new reads.
             let headline = format!(
-                "[board] you hold {held} card(s); {avail} claimable.",
+                "[board] this room only: you hold {held} card(s) here; {avail} claimable here.",
                 held = mine.len(),
                 avail = open.len(),
             );


### PR DESCRIPTION
## Glass-boxed from Atlas's own capture (2026-08-11)

Boards are per-room; the headline wasn't. `[board] you hold 0 card(s); 50 claimable.` rendered on her **general**-room wakes while she held **three live-leased cards on the academy board** (renewals pulsing every minute). Told she held nothing on her own time, passing was the rational move — the recurring "I will PASS and continue monitoring" spam Joel called out was this line gaslighting her, not her mind failing.

## Fix

`[board] this room only: you hold N card(s) here; M claimable here.` — scope rides in the sentence, stays under the 32-token headline-survival cap (guard test green, 12/12 board tests).

## The real fix, named for the follow-up slice

Her holds are an **identity**-level fact: a my-work source folded across her subscribed rooms (`RoomBoardReader` needs a cross-room verb — `work_board(None)` means current-room, not all-rooms). Doctrine: turn reads by TURN room, self-relevance by SUBSCRIBED SET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo