### PR TITLE
fix(bench): detached agent/solve journals state:running at dispatch (runs visible from second zero)

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -287,6 +287,28 @@ impl ActionCommand for AgentSolve {
             .then(|| inner.workspace.clone());
             tokio::spawn(async move {
                 let path = agent_solve_ledger_path(&run_id);
+                // JOURNAL `state: running` NOW, before attempt 1 does anything (#2246,
+                // live 2026-08-11): the result file used to be written only when an
+                // attempt ENDED, so `benchmark/runs` — the projection whose whole job
+                // is "silence must never be ambiguous with progress" — could not list
+                // a run at all for the entire first attempt (an hour-plus on a full
+                // SWE budget). Four dispatched solves ran invisible for 17 minutes
+                // while every watcher read the empty projection as "nothing started".
+                // The marker folds as `active` with the solver named (fold_run_card
+                // reads `persona_id`); each finished attempt overwrites it with the
+                // real result, exactly as before.
+                if let Some(p) = path.as_ref() {
+                    let _ = std::fs::write(
+                        p,
+                        serde_json::json!({
+                            "state": "running",
+                            "run_id": run_id,
+                            "persona_id": inner.persona_id,
+                            "workspace": inner.workspace,
+                        })
+                        .to_string(),
+                    );
+                }
                 // HOLD THE LANE STEADY for the run's whole lifetime — the same RAII pin a
                 // living-persona eval binds ([[benchmark-is-a-governor-preemption-lease]]).
                 // Without it, the OPTIONAL grow-back re-home relaunches the lane under the

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1752,6 +1752,24 @@ mod swe_setup_tests {
             assert_eq!(card.phase, "active");
             assert!(!card.stalled);
         }
+
+        // what this catches: the dispatch-time `state: running` marker (#2246 —
+        // four live solves ran INVISIBLE to this projection for their whole
+        // first attempt because nothing was journaled until an attempt ended)
+        // must fold as a live `active` card with the solver named, never as
+        // failed/resolved, so the run is on the board from second zero.
+        #[test]
+        fn a_running_marker_folds_active_with_the_solver_named() {
+            let now: u64 = 10_000_000_000;
+            let fresh = now - 5_000;
+            let marker = json!({"state": "running", "run_id": "r5",
+                                "persona_id": "atlas-uuid", "workspace": "/w/swe/x"});
+            let card = fold_run_card("r5", Some(&marker), None, fresh, now);
+            assert_eq!(card.phase, "active");
+            assert!(!card.stalled);
+            assert_eq!(card.solver.as_deref(), Some("atlas-uuid"));
+            assert_eq!(card.resolved, None, "no grade yet — never a verdict");
+        }
     }
 }
 


### PR DESCRIPTION
## The failure (live, 2026-08-11)

The 4-project slate dispatched, three solves acquired lanes and drove — and
`benchmark/runs` listed none of them for 17+ minutes. The result ledger was only
written when an attempt **ended**, so the RunProjection (built to make silence
unambiguous) had nothing to enumerate for the whole first attempt: an hour-plus
of structural blindness on a full SWE act budget.

## The fix

The detached spawn journals `{"state":"running", run_id, persona_id, workspace}`
to the poll file before attempt 1 begins. `fold_run_card` already folds it right
— `active`, solver named, no verdict — and finished attempts overwrite the marker
with the real result exactly as before. One write, no new state machine.

run_projection tests 4/4 (new: running marker → active + solver + resolved=None).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo