### PR TITLE
fix(swe): grade resets remove created files (false env-void) + Round A manifest

### DIFF
--- a/benchmarks/swe/round-A-20260811.json
+++ b/benchmarks/swe/round-A-20260811.json
@@ -1,0 +1,93 @@
+{
+  "round": "A",
+  "date": "2026-08-11",
+  "suite": "princeton-nlp/SWE-bench_Lite",
+  "claim_shape": "resolved X of N dispatched, every non-resolve classified capability-vs-infra; this is a FIRST FORMAL ROUND on the natural kanban loop, not a leaderboard submission",
+  "config_disclosure": {
+    "harness": "continuum benchmark/dispatch -> kanban card -> citizen agent/solve (whole cognition: genome, memory, tools) -> autograde vs held-out oracle",
+    "base_model": "unsloth/Devstral-Small-2507-GGUF (llama-server, M5 Metal)",
+    "attempts_per_instance": 3,
+    "grader": "fresh clone @ base_commit, apply patch + test_patch, FAIL_TO_PASS and PASS_TO_PASS must all pass; gold gate voids trees where f2p already passes pristine",
+    "oracle": "held out from the solver; verdict feedback names failing tests only",
+    "concurrency": "4 serving lanes, one exclusive warm slot per solve (quiesce_others), waves of 4"
+  },
+  "exclusions": {
+    "django/django (114)": "needs its own test runner (#383) — 114/300 of Lite ungradeable on this grader today",
+    "astropy/astropy (6)": "env build fails (#383)",
+    "psf/requests (6)": "era test suites hit live httpbin.org; gold gate voids them (measured 2026-08-11 on requests-1963)",
+    "matplotlib, scikit-learn, xarray, seaborn (55)": "C-extension/heavy env classes not yet gold-gated on this box — future round"
+  },
+  "instances": {
+    "carried_from_2026-08-11_rounds_1_2_3": [
+      {"id": "sympy__sympy-24152", "citizen": "Anwen", "note": "organic claim path"},
+      {"id": "pallets__flask-4045", "citizen": "Anwen"},
+      {"id": "sympy__sympy-24066", "citizen": "Atlas"},
+      {"id": "pallets__flask-4992", "citizen": "Asha"},
+      {"id": "pytest-dev__pytest-5103", "citizen": "Anon", "note": "first gradeable pytest run — deleted-history env heal (#2245)"},
+      {"id": "sympy__sympy-22714", "citizen": "Anwen"},
+      {"id": "pallets__flask-5063", "citizen": "Anwen"}
+    ],
+    "waves_of_4": [
+      ["sympy__sympy-13480", "sympy__sympy-13647", "sympy__sympy-16988", "sympy__sympy-21055"],
+      ["sympy__sympy-21379", "sympy__sympy-22005", "sympy__sympy-22840", "sympy__sympy-18057"],
+      ["pytest-dev__pytest-11143", "pytest-dev__pytest-11148", "pytest-dev__pytest-5221", "pytest-dev__pytest-5227"],
+      ["pylint-dev__pylint-5859", "pylint-dev__pylint-6506", "pylint-dev__pylint-7080", "pylint-dev__pylint-7114"],
+      ["pylint-dev__pylint-7228", "pylint-dev__pylint-7993", "sphinx-doc__sphinx-10325", "sphinx-doc__sphinx-10451"],
+      ["pytest-dev__pytest-5413", "pytest-dev__pytest-5495", "sphinx-doc__sphinx-11445", "sphinx-doc__sphinx-7686"]
+    ]
+  },
+  "denominator": 31,
+  "projects": ["sympy/sympy", "pallets/flask", "pytest-dev/pytest", "pylint-dev/pylint", "sphinx-doc/sphinx"],
+  "results": {
+    "note": "filled from grade ledgers as verdicts land; every row carries resolved|not_resolved|infra_void with the receipt path",
+    "rows": [
+      {"id": "sympy__sympy-24152", "verdict": "RESOLVED", "f2p": "1/1", "p2p": "6/6", "patch_bytes": 974, "citizen": "Anwen"},
+      {"id": "pallets__flask-4045", "verdict": "not_resolved", "f2p": "0/2", "p2p": "40/40", "patch_bytes": 1299, "citizen": "Anwen", "note": "real partial fix, no regressions"},
+      {"id": "sympy__sympy-24066", "verdict": "not_resolved", "f2p": "0/1", "p2p": "30/30", "patch_bytes": 0, "citizen": "Atlas", "note": "no patch produced; p2p held"},
+      {"id": "pytest-dev__pytest-5103", "verdict": "env_suspect", "f2p": "0/1", "p2p": "0/40", "patch_bytes": 0, "citizen": "Anon", "note": "p2p 0/40 on baseline = suite does not run in this env; #2251 gate (merged, deploys next reboot) voids this shape — re-run owed"},
+      {"id": "pallets__flask-5063", "verdict": "env_suspect", "f2p": "0/2", "p2p": "0/40", "patch_bytes": 0, "citizen": "Anwen", "note": "same p2p-0/N baseline shape as pytest-5103 — re-run owed post-#2251"},
+      {"id": "pallets__flask-4992", "verdict": "infra", "f2p": "-", "p2p": "-", "patch_bytes": 1192, "citizen": "Asha", "note": "test_patch failed to apply on her tree — she likely edited files the held-out tests touch; her 1192-byte patch persisted for review"},
+      {"id": "sympy__sympy-22714", "verdict": "not_resolved", "f2p": "1/1 best", "p2p": "6/11", "patch_bytes": 2021, "citizen": "Anwen", "note": "best attempt fixed the target test but broke 5 regressions; earlier attempt held p2p 11/11 with no patch"},
+      {"id": "sympy__sympy-13480", "verdict": "RESOLVED", "f2p": "1/1", "p2p": "40/40", "patch_bytes": 592, "citizen": "Atlas", "note": "second citizen resolve of the round — wave 1"},
+      {"id": "sympy__sympy-13647", "verdict": "not_resolved", "f2p": "0/1", "p2p": "40/40", "patch_bytes": 0, "citizen": "Asha"},
+      {"id": "sympy__sympy-16988", "verdict": "not_resolved", "f2p": "0/2", "p2p": "40/40", "patch_bytes": 0, "citizen": "Anon"},
+      {"id": "sympy__sympy-21055", "verdict": "not_resolved", "f2p": "0/1", "p2p": "13/13", "patch_bytes": 0, "citizen": "Anwen"},
+      {"id": "sympy__sympy-21379", "verdict": "not_resolved", "f2p": "0/1", "p2p": "40/40", "patch_bytes": 914, "citizen": "Atlas", "note": "real attempt, no regressions"},
+      {"id": "sympy__sympy-22005", "verdict": "not_resolved", "f2p": "0/1", "p2p": "2/2", "patch_bytes": 489, "citizen": "Asha", "note": "real attempt, no regressions"},
+      {"id": "sympy__sympy-22840", "verdict": "not_resolved", "f2p": "0/2", "p2p": "40/40", "patch_bytes": 0, "citizen": "Anon"},
+      {"id": "sympy__sympy-18057", "verdict": "not_resolved", "f2p": "0/1", "p2p": "40/40", "patch_bytes": 0, "citizen": "Anwen", "note": "the #392 actuator instance; p2p held, no patch committed"},
+      {"id": "pylint-dev__pylint-5859", "verdict": "not_resolved", "f2p": "0/1", "p2p": "10/10", "patch_bytes": 174, "citizen": "Anwen", "note": "first-ever gradeable pylint verdict — #2253 era heal proven end-to-end"},
+      {"id": "pylint-dev__pylint-6506", "verdict": "not_resolved", "f2p": "0/2", "p2p": "6/6", "patch_bytes": 596, "citizen": "Asha", "note": "healthy baseline; targeted config_initialization.py correctly, fix incomplete"},
+      {"id": "pylint-dev__pylint-7080", "verdict": "env_void", "f2p": "0/1", "p2p": "0/40 pristine", "patch_bytes": 0, "citizen": "Anon", "note": "FIRST LIVE FIRING of the #2251 p2p-pristine gate: suite does not run in this env, honestly voided instead of a fake capability zero"},
+      {"id": "sphinx-doc__sphinx-10451", "verdict": "infra", "f2p": "-", "p2p": "-", "patch_bytes": 0, "citizen": "Asha", "note": "test_patch failed to apply — tree mismatch class (#383 family)"},
+      {"id": "sphinx-doc__sphinx-10325", "verdict": "not_resolved", "f2p": "0/1", "p2p": "5/5", "patch_bytes": 0, "citizen": "Atlas", "note": "first gradeable sphinx class — env built first-try"},
+      {"id": "sphinx-doc__sphinx-11445", "verdict": "not_resolved", "f2p": "0/2", "p2p": "8/8", "patch_bytes": 0, "citizen": "Anon"},
+      {"id": "pytest-dev__pytest-11143", "verdict": "not_resolved", "f2p": "0/1", "p2p": "40/40", "patch_bytes": 0, "citizen": "Atlas", "note": "modern pytest era: healthy baseline first try"},
+      {"id": "pytest-dev__pytest-11148", "verdict": "not_resolved", "f2p": "0/2", "p2p": "40/40", "patch_bytes": 0, "citizen": "Asha"},
+      {"id": "pytest-dev__pytest-5221", "verdict": "env_void", "f2p": "0/2", "p2p": "0/40 pristine", "patch_bytes": 0, "citizen": "Anon", "note": "#2251 gate: 2019-pytest era suite does not run in this env — same class as pytest-5103; expect 5413/5495/5227 to void the same way until the era env is fixed"},
+      {"id": "pytest-dev__pytest-5413", "verdict": "env_void", "f2p": "0/1", "p2p": "0/40 pristine", "patch_bytes": 0, "citizen": "Anon", "note": "#2251 gate: 2019-pytest era class, as predicted from 5221"},
+      {"id": "pylint-dev__pylint-7993", "verdict": "env_void", "f2p": "0/1", "p2p": "0/10", "patch_bytes": 0, "citizen": "Asha", "note": "venv install fail — #2254 setuptools class; re-run owed post-deploy (her claim was organic)"},
+      {"id": "pylint-dev__pylint-7228", "verdict": "env_void", "f2p": "0/2", "p2p": "0/10", "patch_bytes": 0, "citizen": "Atlas", "note": "venv install fail — #2254 setuptools class; re-run owed post-deploy"},
+      {"id": "pytest-dev__pytest-5227", "verdict": "env_void", "f2p": "0/3", "p2p": "0/34 pristine", "patch_bytes": 0, "citizen": "Anwen", "note": "#2251 gate: 2019-pytest era class (4th confirmation: 5103/5221/5413/5227)"},
+      {"id": "pytest-dev__pytest-5495", "verdict": "env_void", "f2p": "0/2", "p2p": "0/40 pristine", "patch_bytes": 0, "citizen": "Anwen", "note": "#2251 gate: 2019-pytest era class"},
+      {"id": "sphinx-doc__sphinx-7686", "verdict": "not_resolved", "f2p": "0/2", "p2p": "15/15", "patch_bytes": 0, "citizen": "Anwen"},
+      {"id": "pylint-dev__pylint-7114", "verdict": "env_void", "f2p": "-", "p2p": "-", "patch_bytes": 0, "citizen": "-", "note": "never got a gradeable run this round: 4 env-build failures (#2254 setuptools class); re-run owed post-deploy"}
+    ]
+  },
+  "first_pass_tally_2026-08-12_05:51": {
+    "resolved": 2,
+    "denominator": 31,
+    "claim": "resolved 2 of 31 dispatched (SWE-bench Lite, Devstral-Small-2507 local, whole-cognition kanban loop, held-out oracle)",
+    "resolved_ids": ["sympy__sympy-24152 (Anwen, 974B)", "sympy__sympy-13480 (Atlas, 592B)"],
+    "not_resolved_gradeable": 17,
+    "infra_test_patch_apply": 2,
+    "env_void": 8,
+    "env_suspect_rerun_owed": 2,
+    "notes": [
+      "19 of 31 produced honest capability verdicts on healthy baselines; 12 of 31 are env/infra classes, each named and receipted — none recorded as fake capability zeros (the #2251 gate fired live 6 times)",
+      "env classes remaining: 2019-pytest era (5103/5221/5413/5227/5495), #2254 setuptools clobber (7114/7228/7993 — fix merged, deploys next reboot), test_patch tree mismatch (flask-4992, sphinx-10451, #383 family)",
+      "dominant capability failure shape: patch_bytes=0 with p2p fully held — write-avoidance (#390), the training target; every non-zero patch this round held regressions except sympy-22714 attempt 2 and sphinx-11445 attempt 3"
+    ],
+    "re_runs_owed_post_reboot": ["pylint-7114", "pylint-7228", "pylint-7993", "pytest-5103 (needs 2019-pytest env fix — NOT covered by any merged PR)", "flask-5063 (env rebuild)"]
+  }
+}

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -783,6 +783,16 @@ pub fn verdict_for(
 
 /// Run the instance's test files once and resolve every required id against that report.
 /// A test absent from the report counts as failed — but the absence is knowable, not silent.
+/// Restore a grade worktree to its checked-out state: revert tracked edits AND remove
+/// files a candidate patch CREATED (checkout alone leaves those untracked in place, and a
+/// leftover broken module poisons later runs — live: pytest-11143 attempt 3 misread a real
+/// capability regression as an env void, 2026-08-12). No `-x`: gitignored editable-install
+/// artifacts (*.egg-info) must survive.
+pub async fn reset_worktree(repo_dir: &Path) {
+    let _ = run("git", &["checkout", "--quiet", "."], Some(repo_dir)).await;
+    let _ = run("git", &["clean", "-fdq"], Some(repo_dir)).await;
+}
+
 pub async fn run_tests(
     repo_dir: &Path,
     venv_py: &Path,
@@ -935,7 +945,7 @@ pub async fn grade(
     }
 
     // Reset, then run the real protocol: model patch first, tests second.
-    let _ = run("git", &["checkout", "--quiet", "."], Some(repo_dir)).await;
+    reset_worktree(repo_dir).await;
     if let Some(patch) = model_patch {
         if let Err(e) = apply_patch(repo_dir, patch, "model").await {
             verdict.error = Some(format!("candidate patch did not apply: {e}"));
@@ -963,7 +973,7 @@ pub async fn grade(
     // ALSO passes zero → the env is broken, void the tree; pristine passes any → the
     // candidate patch genuinely broke the suite and the graded numbers stand.
     if verdict.p2p_total > 0 && verdict.p2p_passed == 0 {
-        let _ = run("git", &["checkout", "--quiet", "."], Some(repo_dir)).await;
+        reset_worktree(repo_dir).await;
         if let Err(e) = apply_patch(repo_dir, &instance.test_patch, "p2p-gate").await {
             verdict.error = Some(e);
             return verdict;
@@ -1009,6 +1019,39 @@ pub async fn grade(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the false-env-void misgrade (pytest-11143 attempt 3, live
+    // 2026-08-12) — a candidate patch that CREATED a file survived `git checkout .`, the
+    // leftover module broke the "pristine" p2p re-run, and a REAL capability regression was
+    // voided as an env fault. reset_worktree must revert tracked edits AND remove untracked
+    // files, while leaving gitignored artifacts (editable-install *.egg-info) untouched.
+    #[tokio::test]
+    async fn reset_worktree_removes_created_files_but_keeps_ignored_artifacts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo = dir.path();
+        for args in [
+            vec!["init", "-q"],
+            vec!["config", "user.email", "t@t"],
+            vec!["config", "user.name", "t"],
+        ] {
+            assert!(run("git", &args, Some(repo)).await.unwrap().status.success());
+        }
+        std::fs::write(repo.join("tracked.py"), "original").unwrap();
+        std::fs::write(repo.join(".gitignore"), "*.egg-info\n").unwrap();
+        run("git", &["add", "."], Some(repo)).await.unwrap();
+        run("git", &["commit", "-qm", "base"], Some(repo)).await.unwrap();
+
+        // The three states a candidate patch leaves behind:
+        std::fs::write(repo.join("tracked.py"), "edited").unwrap(); // tracked edit
+        std::fs::write(repo.join("conftest.py"), "boom").unwrap(); // CREATED file
+        std::fs::write(repo.join("pkg.egg-info"), "install artifact").unwrap(); // ignored
+
+        reset_worktree(repo).await;
+
+        assert_eq!(std::fs::read_to_string(repo.join("tracked.py")).unwrap(), "original");
+        assert!(!repo.join("conftest.py").exists(), "created file must not survive the reset");
+        assert!(repo.join("pkg.egg-info").exists(), "ignored install artifacts must survive");
+    }
 
     // what this catches: the deleted-history env-build failure (pytest-dev__pytest-5103,
     // live 2026-08-11) — `atomicwrites`' pre-2022 uploads were deleted from PyPI, so the


### PR DESCRIPTION
Two commits from the overnight Round A campaign:

1. **bench(swe): Round A first-pass manifest** — resolved 2/31 (Anwen sympy-24152, Atlas sympy-13480), every non-resolve classified capability-vs-env-vs-infra with receipts. The #2251 gate fired live 6 times.

2. **fix(swe): grade resets must remove files the candidate patch CREATED.** `git checkout .` only reverts tracked files; a patch that created a module left it untracked, the leftover poisoned the #2251 pristine p2p re-run, and a REAL capability regression graded as env void (live: pytest-11143 attempt 3). Fix: one `reset_worktree` helper (checkout + `git clean -fdq`, no `-x` so gitignored *.egg-info survives) at both reset sites, with a test pinning tracked-reverted / created-removed / ignored-kept. swe_bench mod 10/10 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo