### PR TITLE
fix(solve): [mission] standing framing — #390 write-avoidance root cause (anchor loss)

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1987,7 +1987,7 @@ impl CognitionEval {
                 let served_ctx = el.served_ctx;
                 let cycle = fork_eval_cycle_waiting(&persona_uuid, || {
                     crate::cognition::persona_workspace::global()
-                        .fork_eval_cycle_with_adapter(&persona_uuid, adapter.clone(), served_ctx, needs_tools, eval_workspace_root.as_deref(), suppress_recall)
+                        .fork_eval_cycle_with_adapter(&persona_uuid, adapter.clone(), served_ctx, needs_tools, eval_workspace_root.as_deref(), suppress_recall, Vec::new())
                 })
                 .await
                 .ok_or_else(|| CommandError::NotFound(format!(
@@ -2006,7 +2006,7 @@ impl CognitionEval {
                 let served_ctx = el.served_ctx;
                 let cycle = fork_eval_cycle_waiting(&persona_uuid, || {
                     crate::cognition::persona_workspace::global()
-                        .fork_eval_cycle_with_adapter(&persona_uuid, adapter.clone(), served_ctx, needs_tools, eval_workspace_root.as_deref(), suppress_recall)
+                        .fork_eval_cycle_with_adapter(&persona_uuid, adapter.clone(), served_ctx, needs_tools, eval_workspace_root.as_deref(), suppress_recall, Vec::new())
                 })
                 .await
                 .ok_or_else(|| CommandError::NotFound(format!(
@@ -2090,7 +2090,7 @@ impl CognitionEval {
                         let served_ctx = el.served_ctx;
                         let cycle = fork_eval_cycle_waiting(&persona_uuid, || {
                             crate::cognition::persona_workspace::global()
-                                .fork_eval_cycle_with_adapter(&persona_uuid, adapter.clone(), served_ctx, needs_tools, eval_workspace_root.as_deref(), suppress_recall)
+                                .fork_eval_cycle_with_adapter(&persona_uuid, adapter.clone(), served_ctx, needs_tools, eval_workspace_root.as_deref(), suppress_recall, Vec::new())
                         })
                         .await
                         .ok_or_else(|| CommandError::NotFound(format!(

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -984,6 +984,11 @@ impl PersonaWorkspaceRegistry {
     /// deliberation faculty budgets its prompt against what THIS lane serves —
     /// otherwise a fork carrying the 14B's larger window could build a prompt the
     /// ephemeral 4B lane can't hold and overflow it (the Asha-mute failure class).
+    /// `extra_grounding` joins the persona's own grounding sources for THIS fork only —
+    /// the seam a measurement drive uses to pin its task brief as `[mission]` standing
+    /// framing (#390: the brief delivered once as a burst was evicted by act ~6 on a
+    /// 24-act solve, and the persona literally asked what the issue was; a
+    /// StandingFraming source cannot be evicted). Empty for plain evals.
     pub fn fork_eval_cycle_with_adapter(
         &self,
         persona_id: &Uuid,
@@ -992,12 +997,14 @@ impl PersonaWorkspaceRegistry {
         with_tools: bool,
         workspace_root: Option<&str>,
         suppress_recall: bool,
+        extra_grounding: Vec<GroundingSource>,
     ) -> Option<WorkspaceCycle> {
         let mut cfg = self.templates.lock().get(persona_id)?.clone();
         cfg.admission = Arc::new(cfg.admission.fork_detached());
         cfg.adapter = adapter;
         cfg.context_window = context_window;
         cfg.suppress_recall = suppress_recall;
+        cfg.grounding_sources.extend(extra_grounding);
         repoint_workspace_map_if_pinned(&mut cfg, persona_id, workspace_root);
         // Synchronous perception on the eval copy (see `fork_eval_cycle`).
         cfg.defer_recall = false;

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -999,6 +999,22 @@ impl AgentSolve {
         // 2) Fork her WHOLE cognition onto that lane, rooted at the workspace: tools ON, recall ON.
         //    A brief wait covers the post-spawn template race (same as the eval fork-waiter).
         let registry = crate::cognition::persona_workspace::global();
+        // The MISSION rides as standing framing, not as the opening burst alone (#390,
+        // glass-boxed 2026-08-12 on pytest-5221): the task text delivered once was evicted
+        // from every captured prompt after act ~6 of a 24-act solve, and the persona
+        // literally asked "could you describe the symptoms of the issue?" — anchor loss,
+        // the dominant patch-0 shape. A `[mission]` StandingFraming block survives every
+        // compose of the drive, exactly like the pinned board (#347). The burst below
+        // still fires — it is the directed TRIGGER; this is the PERSISTENCE.
+        let mission = std::sync::Arc::new(crate::persona::mission_source::MissionSource::new(
+            persona_uuid,
+            format!(
+                "YOUR ONE JOB this whole session (re-read this every step):\n{}\n\nWork in \
+                 `{workspace}` — that directory IS the task's repo. The deliverable is the \
+                 edit your tools leave there; a session that only reads has failed.",
+                p.task.trim()
+            ),
+        ));
         let mut cycle = None;
         for attempt in 0..FORK_WAIT_TRIES {
             cycle = registry.fork_eval_cycle_with_adapter(
@@ -1008,6 +1024,9 @@ impl AgentSolve {
                 true,             // with_tools — her hands are ON
                 Some(&workspace), // roots the ToolExecutor at the sandbox cwd
                 p.suppress_recall.unwrap_or(false), // memory/RAG ON by default; the diagnostic knob
+                vec![crate::cognition::persona_workspace::GroundingSource::framing(
+                    mission.clone(),
+                )],
             );
             if cycle.is_some() {
                 break;

--- a/core/continuum-core/src/persona/mission_source.rs
+++ b/core/continuum-core/src/persona/mission_source.rs
@@ -1,0 +1,131 @@
+//! MissionSource — a measurement drive's task brief as STANDING FRAMING.
+//!
+//! ### The defect this kills (#390 write-avoidance, glass-boxed 2026-08-12)
+//!
+//! `agent/solve` delivered the task ONCE, as the drive's opening burst. Every
+//! later iteration rebuilt the window from accumulating tool receipts, and the
+//! brief aged out: on pytest-5221 (Asha, 24 acts, patch 0), the issue text was
+//! present at act 0 and ABSENT from every captured prompt from act ~6 on. Her
+//! late-run turn asked, verbatim, "Could you please provide additional details
+//! or describe the symptoms of the issue?" — a mind whose exam question was
+//! evicted. With no live anchor for WHAT to change, reading is the only
+//! rational act, and the run settles patchless. That anchor loss — not tool
+//! reluctance — is the dominant capability-zero shape.
+//!
+//! The fix is the same shape as #347 (the board pinned as standing framing):
+//! the mission rides as a `[mission]` grounding block with a
+//! `SaliencePolicy::StandingFraming` floor, so attention pressure can never
+//! evict the one thing the whole drive exists to do.
+//!
+//! Fixed text, no I/O, all-or-nothing: a truncated mission is a different
+//! (wrong) mission, so `floor_tokens == full size` and an under-budget call
+//! delivers nothing — which the allocator surfaces as a dropped source rather
+//! than silently grading against half a task.
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::cognition::token_budget::estimate_prompt_tokens;
+use crate::persona::rag_budget::{
+    ContinuationCursor, RagContext, RagDelivery, RagItem, RagSource, ResolutionPreference,
+};
+
+/// Source identifier — renders as the `[mission]` grounding block via the
+/// generic `[<source_id>]` projection.
+const SOURCE_ID: &str = "mission";
+
+pub struct MissionSource {
+    persona_id: Uuid,
+    text: String,
+    tokens: u32,
+}
+
+impl MissionSource {
+    pub fn new(persona_id: Uuid, text: impl Into<String>) -> Self {
+        let text = text.into();
+        let tokens = estimate_prompt_tokens(&text);
+        Self { persona_id, text, tokens }
+    }
+}
+
+#[async_trait]
+impl RagSource for MissionSource {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    /// Nothing more to show — the mission IS its full content.
+    fn expand_command(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// All-or-nothing: half a mission is a wrong mission.
+    fn floor_tokens(&self) -> u32 {
+        self.tokens
+    }
+
+    async fn deliver(
+        &self,
+        ctx: &RagContext,
+        budget: u32,
+        _resolution: ResolutionPreference,
+    ) -> RagDelivery {
+        let empty = RagDelivery {
+            source_id: SOURCE_ID.to_string(),
+            items: Vec::new(),
+            tokens_used: 0,
+            continuation: None,
+            resolution_used: ResolutionPreference::Raw,
+        };
+        // Persona-scoped like the sibling sources (defense in depth).
+        if ctx.persona_id != self.persona_id || budget < self.tokens {
+            return empty;
+        }
+        RagDelivery {
+            source_id: SOURCE_ID.to_string(),
+            items: vec![RagItem {
+                content: self.text.clone(),
+                tokens: self.tokens,
+                metadata: serde_json::json!({}),
+            }],
+            tokens_used: self.tokens,
+            continuation: None,
+            resolution_used: ResolutionPreference::Raw,
+        }
+    }
+
+    async fn deliver_continuation(
+        &self,
+        _ctx: &RagContext,
+        _cursor: ContinuationCursor,
+        _budget: u32,
+    ) -> Option<RagDelivery> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the #390 anchor-loss regression — the mission must deliver
+    // its FULL text when budgeted, refuse a partial render (a truncated mission is a
+    // wrong mission), and stay persona-scoped like every sibling source.
+    #[tokio::test]
+    async fn mission_is_all_or_nothing_and_persona_scoped() {
+        let me = Uuid::new_v4();
+        let src = MissionSource::new(me, "Fix the bug in swe/x. Deliver an edit.");
+        let ctx = RagContext::for_persona(me, 0);
+
+        let full = src.deliver(&ctx, u32::MAX, ResolutionPreference::Raw).await;
+        assert_eq!(full.items.len(), 1);
+        assert!(full.items[0].content.contains("Deliver an edit"));
+
+        let starved = src.deliver(&ctx, src.floor_tokens() - 1, ResolutionPreference::Raw).await;
+        assert!(starved.items.is_empty(), "under-budget must deliver NOTHING, never a truncation");
+
+        let other = RagContext::for_persona(Uuid::new_v4(), 0);
+        let cross = src.deliver(&other, u32::MAX, ResolutionPreference::Raw).await;
+        assert!(cross.items.is_empty(), "a mission never leaks across personas");
+    }
+}

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -87,6 +87,7 @@ pub mod resource_forecast;
 pub mod response;
 pub mod media_perception_source;
 pub mod room_board_source;
+pub mod mission_source;
 pub mod room_doctrine_source;
 pub mod room_roster_source;
 pub mod resume_or_mint_provider;


### PR DESCRIPTION
Glass-boxed from Asha's live pytest-5221 prompts: the task brief was evicted after act ~6 of 24 (delivered once as a burst, then receipt accumulation pushed it out) — she literally asked what the issue was, then settled patchless. New `MissionSource` pins the brief as an evict-proof `[mission]` StandingFraming block via a new `extra_grounding` seam on the fork. mission_source + persona_workspace tests green.

Follow-up card: exam-scoped working memory (her room-life receipts — astropy listings — rode into the pytest solve via the forked admission tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo