### PR TITLE
fix(bench): env pre-flight gate — a failed env blocks the scored solve

### DIFF
--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -989,6 +989,14 @@ impl ActionCommand for BenchmarkDispatch {
                 if staged_ok {
                     if let Err(e) = crate::cognition::swe_bench::ensure_env(instance, &dir).await {
                         kickoff_errors.push(format!("env {}: {e}", instance.instance_id));
+                        // A solve against an unbuildable env can ONLY void: she spends a
+                        // full attempt (24 acts, live: pytest-5413 twice on 2026-08-12)
+                        // in a workspace whose grade is a known-in-advance env fault —
+                        // no verdict, no lesson (the failure is the env's, not hers).
+                        // The card still posts (claimable once the env heals); the
+                        // SCORED solve does not fire (Joel: "why run broken code
+                        // knowing she's gonna struggle and fall").
+                        staged_ok = false;
                     }
                 }
             }


### PR DESCRIPTION
A solve against an unbuildable env can only void; dispatch now refuses to fire it (card still posts, error still named). Live cost this fixed: pytest-5413 burned two full 24-act attempts today against a known-broken venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo