### PR TITLE
feat(rag): workspace-map cache wire — event invalidation, no wrap without a wire (#398 slice 2)

### DIFF
--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -586,13 +586,39 @@ fn repoint_workspace_map_if_pinned(
     let Some(root) = workspace_root else {
         return;
     };
+    // The fork's hands expose the bus where its write-completions land — the
+    // invalidation wire for the cache wrap below. Resolved once, outside the loop.
+    let bus = cfg
+        .tool_executor
+        .as_ref()
+        .and_then(|t| t.command_executor())
+        .and_then(|c| c.message_bus());
     for g in cfg.grounding_sources.iter_mut() {
         if g.source.source_id() == "workspace-map" {
-            g.source = Arc::new(
+            let pinned: Arc<dyn crate::persona::rag_budget::RagSource> = Arc::new(
                 crate::persona::workspace_map_source::WorkspaceMapSource::for_pinned_root(
                     *persona_id, root,
                 ),
             );
+            // Event-invalidated cache (#398): eval forks compose SYNCHRONOUSLY
+            // (defer_grounding=false), so without this the pinned map re-walks
+            // the repo dir on EVERY act — the measured per-act prefill churn on
+            // solve runs (#266). Serve last-good until one of the fork's own
+            // mutating commands completes. No wrap without a wire: a handless
+            // cfg keeps the raw walk. The invalidator holds only a weak handle,
+            // so it exits with the ephemeral fork instead of leaking.
+            g.source = match bus.clone() {
+                Some(bus) => {
+                    let (cached, dirty) =
+                        crate::persona::cached_source::CachedRagSource::new(pinned);
+                    crate::persona::grounding_invalidation::spawn_workspace_invalidator(
+                        bus,
+                        dirty.downgrade(),
+                    );
+                    cached
+                }
+                None => pinned,
+            };
         }
     }
 }

--- a/core/continuum-core/src/persona/cached_source.rs
+++ b/core/continuum-core/src/persona/cached_source.rs
@@ -44,6 +44,33 @@ impl DirtyHandle {
     pub fn mark(&self) {
         self.0.store(true, Ordering::SeqCst);
     }
+
+    /// A weak lever for long-lived listeners (a bus subscriber task): `mark()`
+    /// returns `false` once the wrapped source is gone, so the listener can
+    /// exit instead of parking forever on behalf of a dead cache. This is what
+    /// keeps per-fork invalidator tasks from leaking across ephemeral eval
+    /// forks — the fork's cycle drops, the weak dies, the task ends.
+    pub fn downgrade(&self) -> WeakDirtyHandle {
+        WeakDirtyHandle(Arc::downgrade(&self.0))
+    }
+}
+
+/// See [`DirtyHandle::downgrade`].
+#[derive(Clone)]
+pub struct WeakDirtyHandle(std::sync::Weak<AtomicBool>);
+
+impl WeakDirtyHandle {
+    /// Mark dirty if the cache is still alive. `false` == the owner dropped;
+    /// the caller should stop listening.
+    pub fn mark(&self) -> bool {
+        match self.0.upgrade() {
+            Some(flag) => {
+                flag.store(true, Ordering::SeqCst);
+                true
+            }
+            None => false,
+        }
+    }
 }
 
 struct CachedDelivery {

--- a/core/continuum-core/src/persona/grounding_invalidation.rs
+++ b/core/continuum-core/src/persona/grounding_invalidation.rs
@@ -1,0 +1,241 @@
+//! Grounding invalidation — the EVENT WIRES that make [`CachedRagSource`]
+//! honest (#398 slice 2).
+//!
+//! A cache with no invalidation wire is a staleness bug waiting to be
+//! measured (#346's stale board is the cautionary tale). The rule this
+//! module enforces by construction: **no wrap without a wire** — the owner
+//! that wraps a source spawns the matching invalidator here, or doesn't
+//! wrap at all.
+//!
+//! First wire (outlier A of the #398 pair): the `[workspace-map]` grounding.
+//! Its substrate is the filesystem the persona's HANDS mutate, and every
+//! hand action already emits `command:completed` on the kernel bus
+//! ([`COMMAND_COMPLETED_TOPIC`], real-time — the coalescer passes
+//! `command:*` through). So the invalidator is a pure REUSE of the
+//! async-dispatch listener's shape (`cognition/dispatch_listener.rs`):
+//! subscribe, filter, mark. No polling, no new pump — the event that
+//! changes the substrate IS the dirty signal
+//! ([[the-whole-system-is-event-based-not-polling]]).
+//!
+//! Deliberately COARSE: the completion event carries no persona
+//! attribution, so any citizen's write dirties every wrapped map. Today all
+//! personas share one workspace root (#49 pending), so that is CORRECT, and
+//! after #49 it degrades to over-invalidation — an extra refetch, never a
+//! stale projection. Staleness is the failure mode we refuse; a wasted
+//! refetch is the price we accept.
+
+use std::sync::Arc;
+
+use crate::persona::cached_source::WeakDirtyHandle;
+use crate::runtime::command_events::{CommandCompletedEvent, COMMAND_COMPLETED_TOPIC};
+use crate::runtime::message_bus::MessageBus;
+
+/// Does completing this command potentially change the filesystem a
+/// `[workspace-map]` describes?
+///
+/// DENY-list of known read-only verbs, then prefix-match the families whose
+/// verbs mutate (files, shell, git, cargo — a build materializes `target/`).
+/// Unknown verbs in those families default to "mutates": over-invalidation
+/// is safe, a missed mutation is a stale map.
+pub fn mutates_workspace(command: &str) -> bool {
+    const READ_ONLY: &[&str] = &[
+        "code/read",
+        "code/list",
+        "code/tree",
+        "code/search",
+        "code/glob",
+        "code/diff",
+        "git/status",
+        "git/log",
+        "git/diff",
+        "tool/output",
+    ];
+    if READ_ONLY.contains(&command) {
+        return false;
+    }
+    command.starts_with("code/") || command.starts_with("git/") || command.starts_with("cargo/")
+}
+
+/// Spawn the workspace-map invalidator: marks `dirty` whenever a
+/// workspace-mutating command completes on the bus.
+///
+/// Holds only a [`WeakDirtyHandle`] — when the wrapped source is gone (an
+/// ephemeral eval fork's cycle dropped), the next mark fails and the task
+/// exits instead of parking forever. Success is NOT required to mark: a
+/// failed `code/shell` may have mutated before it failed (mkdir-then-die),
+/// so failures dirty too.
+pub fn spawn_workspace_invalidator(bus: Arc<MessageBus>, dirty: WeakDirtyHandle) {
+    let mut rx = bus.receiver();
+    tokio::spawn(async move {
+        loop {
+            let event = match rx.recv().await {
+                Ok(e) => e,
+                // Lagged == we MISSED events, and one of them may have been a
+                // mutation. Mark dirty conservatively — correctness over a
+                // spare refetch — and keep listening.
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                    if !dirty.mark() {
+                        return;
+                    }
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+            };
+            if event.name != COMMAND_COMPLETED_TOPIC {
+                continue;
+            }
+            let Ok(ev) = serde_json::from_value::<CommandCompletedEvent>(event.payload) else {
+                continue;
+            };
+            if !mutates_workspace(&ev.command_name) {
+                continue;
+            }
+            if !dirty.mark() {
+                return; // cache dropped — stop listening on its behalf
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persona::cached_source::{CachedRagSource, DirtyHandle};
+    use crate::persona::rag_budget::{
+        ContinuationCursor, RagContext, RagDelivery, RagSource, ResolutionPreference,
+    };
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    struct CountingSource {
+        fetches: AtomicU32,
+    }
+
+    #[async_trait]
+    impl RagSource for CountingSource {
+        fn source_id(&self) -> &'static str {
+            "counting"
+        }
+        fn expand_command(&self) -> Option<&'static str> {
+            None
+        }
+        fn floor_tokens(&self) -> u32 {
+            1
+        }
+        async fn deliver(
+            &self,
+            _ctx: &RagContext,
+            _budget: u32,
+            _resolution: ResolutionPreference,
+        ) -> RagDelivery {
+            let n = self.fetches.fetch_add(1, Ordering::SeqCst) + 1;
+            RagDelivery {
+                source_id: "counting".to_string(),
+                items: vec![crate::persona::rag_budget::RagItem {
+                    content: format!("fetch #{n}"),
+                    tokens: 4,
+                    metadata: serde_json::json!({}),
+                }],
+                tokens_used: 4,
+                continuation: None,
+                resolution_used: ResolutionPreference::Raw,
+            }
+        }
+        async fn deliver_continuation(
+            &self,
+            _ctx: &RagContext,
+            _cursor: ContinuationCursor,
+            _budget: u32,
+        ) -> Option<RagDelivery> {
+            None
+        }
+    }
+
+    fn completed(command: &str) -> serde_json::Value {
+        serde_json::to_value(CommandCompletedEvent {
+            command_name: command.to_string(),
+            duration_ms: 1,
+            success: true,
+            error: None,
+            handle: None,
+            result: None,
+        })
+        .expect("serialize")
+    }
+
+    // what this catches: the deny-list vs prefix-family split. A read-only verb
+    // marking dirty defeats the whole cache (refetch per act again); a mutating
+    // verb NOT marking is a stale map — the #346 staleness class.
+    #[test]
+    fn mutation_predicate_splits_read_from_write() {
+        for read_only in ["code/read", "code/list", "code/tree", "code/search", "git/status"] {
+            assert!(!mutates_workspace(read_only), "{read_only} must not dirty the map");
+        }
+        for mutating in [
+            "code/write",
+            "code/edit",
+            "code/shell",
+            "code/run",
+            "code/create-workspace",
+            "git/checkout",
+            "cargo/build",
+        ] {
+            assert!(mutates_workspace(mutating), "{mutating} must dirty the map");
+        }
+        // Foreign namespaces never dirty (a chat/send is not a file mutation).
+        assert!(!mutates_workspace("chat/send"));
+        assert!(!mutates_workspace("work/claim"));
+    }
+
+    // what this catches: the end-to-end wire — a `command:completed` bus event
+    // for a mutating command reaches the cache and forces exactly the refetch
+    // the compose path needs, while read-only completions leave the cached
+    // projection served. This is the "no wrap without a wire" contract working.
+    #[tokio::test]
+    async fn bus_mutation_events_dirty_the_cache_read_only_do_not() {
+        let bus = Arc::new(MessageBus::new());
+        let inner = Arc::new(CountingSource { fetches: AtomicU32::new(0) });
+        let (cached, dirty) = CachedRagSource::new(inner.clone());
+        spawn_workspace_invalidator(bus.clone(), dirty.downgrade());
+        drop(dirty); // wiring done — cache liveness now keys the listener
+
+        let ctx = RagContext::for_persona(uuid::Uuid::new_v4(), 0);
+        let d = cached.deliver(&ctx, 100, ResolutionPreference::Raw).await;
+        assert_eq!(d.items[0].content, "fetch #1");
+
+        // Read-only completion → cache keeps serving.
+        bus.publish_async_only(COMMAND_COMPLETED_TOPIC, completed("code/read"));
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let d = cached.deliver(&ctx, 100, ResolutionPreference::Raw).await;
+        assert_eq!(d.items[0].content, "fetch #1", "read-only completion must not dirty");
+
+        // Mutating completion → next deliver refetches.
+        bus.publish_async_only(COMMAND_COMPLETED_TOPIC, completed("code/write"));
+        let mut refetched = false;
+        for _ in 0..100 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            let d = cached.deliver(&ctx, 100, ResolutionPreference::Raw).await;
+            if d.items[0].content == "fetch #2" {
+                refetched = true;
+                break;
+            }
+        }
+        assert!(refetched, "a code/write completion must dirty the wrapped map");
+        assert_eq!(inner.fetches.load(Ordering::SeqCst), 2, "exactly one refetch");
+    }
+
+    // what this catches: the weak-handle lifecycle — a dead cache must stop
+    // being markable, which is what lets per-fork invalidator tasks exit
+    // instead of leaking one parked task per ephemeral eval fork.
+    #[test]
+    fn weak_handle_dies_with_the_cache() {
+        let inner = Arc::new(CountingSource { fetches: AtomicU32::new(0) });
+        let (cached, dirty): (Arc<CachedRagSource>, DirtyHandle) = CachedRagSource::new(inner);
+        let weak = dirty.downgrade();
+        assert!(weak.mark(), "alive while the cache lives");
+        drop(dirty);
+        assert!(weak.mark(), "the cache alone keeps the flag alive");
+        drop(cached);
+        assert!(!weak.mark(), "all owners gone → mark reports dead");
+    }
+}

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -36,6 +36,7 @@ pub mod durable_history;
 pub mod allocator;
 pub mod cached_source;
 pub mod card;
+pub mod grounding_invalidation;
 pub mod card_holder;
 pub mod channel_items;
 pub mod channel_queue;

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -666,6 +666,11 @@ pub async fn materialize_adapters(
                 runtime.clone(),
             ));
 
+        // The persona's HANDS, built once here — consumed by the brain config
+        // below AND by the workspace-map cache wire (its command executor's bus
+        // is where write-completion events land).
+        let tool_executor = tool_executor_for(identity.peer_id.as_uuid());
+
         // Workspace map: grounds the persona in WHERE code lives — the real root
         // and top-level layout the code tools resolve against. NOT airc-backed
         // (reads the same cwd-rooted FileEngine as the persona's hands, so it
@@ -674,10 +679,34 @@ pub async fn materialize_adapters(
         // the layout was only ever an echoed error in recall, never standing
         // framing. Grounding, not steering — names the dirs, never which holds
         // the answer. Swaps to the airc-leased root when #49 lands.
-        let workspace_map_source: Arc<dyn crate::persona::rag_budget::RagSource> =
+        //
+        // Wrapped as an event-invalidated cache (#398): the dir re-walk ran on
+        // EVERY compose, so it serves last-good until a workspace-mutating
+        // command completes on the bus. No wrap without a wire — a speak-only
+        // persona (no hands → no bus) keeps the raw source, because her map
+        // can still be mutated by OTHERS' hands and an unwired cache would be
+        // stale forever.
+        let raw_workspace_map: Arc<dyn crate::persona::rag_budget::RagSource> =
             Arc::new(crate::persona::workspace_map_source::WorkspaceMapSource::for_peer_layer(
                 identity.peer_id.as_uuid(),
             ));
+        let workspace_map_source: Arc<dyn crate::persona::rag_budget::RagSource> =
+            match tool_executor
+                .as_ref()
+                .and_then(|t| t.command_executor())
+                .and_then(|c| c.message_bus())
+            {
+                Some(bus) => {
+                    let (cached, dirty) =
+                        crate::persona::cached_source::CachedRagSource::new(raw_workspace_map);
+                    crate::persona::grounding_invalidation::spawn_workspace_invalidator(
+                        bus,
+                        dirty.downgrade(),
+                    );
+                    cached
+                }
+                None => raw_workspace_map,
+            };
 
         // Wall source: grounds the persona in the room's LIVING SHARED
         // DOCUMENTS — the airc-pinned plan, coding instructions, agenda,
@@ -886,7 +915,7 @@ pub async fn materialize_adapters(
                 ],
                 // The persona's HANDS — built by the caller for THIS persona's
                 // identity (None → speak-only). What turns "talks" into "acts".
-                tool_executor: tool_executor_for(identity.peer_id.as_uuid()),
+                tool_executor,
                 // The window the gateway actually serves this persona (task #50:
                 // single-sourced; Local → ServingPlan.served_context_window). The
                 // deliberation faculty keeps its prompt inside it so llama-server


### PR DESCRIPTION
## What

Outlier A of the #398 invalidation pair: the `[workspace-map]` grounding becomes an event-invalidated cache, dirtied by workspace-mutating `command:completed` bus events. Builds on the `CachedRagSource` decorator from #2262.

## Why

The map re-walked the workspace dir on EVERY compose — synchronously in eval forks (`defer_grounding=false`), part of the measured per-act prefill churn on solve runs (#266). Its substrate only changes when hands mutate the filesystem, and every hand action already emits `command:completed` on the kernel bus.

## Shape

- **`grounding_invalidation.rs`** — `mutates_workspace` predicate (deny-list read-only verbs; `code/` `git/` `cargo/` families default to mutates — over-invalidation is safe, a missed mutation is a stale map) + `spawn_workspace_invalidator`: pure reuse of the `dispatch_listener` shape (subscribe → filter → mark). A lagged receiver marks dirty conservatively.
- **`DirtyHandle::downgrade()` → `WeakDirtyHandle`** — the invalidator holds only a weak lever and exits when the wrapped source drops, so ephemeral eval forks never leak parked tasks.
- **Both construction sites wired**: supervisor spawn (live) and `repoint_workspace_map_if_pinned` (eval forks — the solve-path win).
- **No wrap without a wire**: a handless cfg (no bus) keeps the raw walk. An unwired cache would be stale forever — #346's staleness class is the failure mode this rule refuses by construction.

Coarseness is deliberate: the completion event carries no persona attribution, so any citizen's write dirties every wrapped map. Correct today (shared root, #49 pending); over-invalidation after — an extra refetch, never a stale projection.

## Tests (4 green)

- Predicate split: read verbs never dirty, mutation verbs always, foreign namespaces (`chat/send`, `work/claim`) never.
- End-to-end bus wire: `code/read` completion → cached projection still served; `code/write` completion → exactly one refetch.
- Weak-handle lifecycle: cache alone keeps the flag alive; all owners gone → mark reports dead (task exit path).

Next slice (outlier B): an airc-fed source (roster/board) dirtied by the wire fold's join/part/card events — needs the airc event-taxonomy dig, done carefully against the #346 board-freshness ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo