### PR TITLE
feat(rag): doctrine + wall event-invalidated caches — kill the per-compose sync airc fetch (#398 slice 3)

### DIFF
--- a/core/continuum-core/src/persona/grounding_invalidation.rs
+++ b/core/continuum-core/src/persona/grounding_invalidation.rs
@@ -97,6 +97,68 @@ pub fn spawn_workspace_invalidator(bus: Arc<MessageBus>, dirty: WeakDirtyHandle)
     });
 }
 
+/// Is this transcript event a room-state PUBLISH — the event class that
+/// changes what the doctrine and wall groundings project?
+///
+/// Covers BOTH kinds because they alias in the wild: doctrine now rides
+/// `WallPostPublished` with `category="doctrine"` while legacy peers still
+/// emit `DoctrinePublished` (transcript.rs documents the aliasing). One
+/// predicate, both caches — a doctrine event dirtying the wall (and vice
+/// versa) is over-invalidation, which is safe; splitting them on the
+/// category field would risk the stale side of the aliasing instead.
+pub fn is_room_state_publish(kind: &airc_core::TranscriptKind) -> bool {
+    matches!(
+        kind,
+        airc_core::TranscriptKind::DoctrinePublished
+            | airc_core::TranscriptKind::WallPostPublished
+    )
+}
+
+/// Spawn the doctrine/wall invalidator: ONE subscribe stream per persona
+/// marking every handed-in cache when a room-state publish lands. The
+/// caller subscribes BEFORE calling (failure surfaces at the call site,
+/// same contract as the command pump) and hands the stream in.
+///
+/// These events are RARE (a doctrine or wall edit), which is exactly why
+/// the sources cache so well — and why the doctrine fetch, the one
+/// SYNCHRONOUS airc round-trip on every live compose (ColdStartCritical),
+/// was pure waste per tick. Exits when every handle is dead (all wrapped
+/// sources dropped) or the stream ends terminally (airc-lib owns transient
+/// reconnection; a terminal end is a real fault the pump already logs loud
+/// — this listener just stops, the caches go permanently dirty-capable-less
+/// but the personas' pumps have bigger problems at that point).
+pub fn spawn_publish_invalidator(
+    mut stream: airc_lib::FilteredEventStream,
+    handles: Vec<WeakDirtyHandle>,
+) {
+    use futures::stream::StreamExt;
+    tokio::spawn(async move {
+        let mut handles = handles;
+        loop {
+            let event = match stream.next().await {
+                None => return,
+                // Lag: we missed events — one may have been a publish.
+                // Mark everything conservatively, prune the dead.
+                Some(Err(_lag)) => {
+                    handles.retain(|h| h.mark());
+                    if handles.is_empty() {
+                        return;
+                    }
+                    continue;
+                }
+                Some(Ok(e)) => e,
+            };
+            if !is_room_state_publish(&event.kind) {
+                continue;
+            }
+            handles.retain(|h| h.mark());
+            if handles.is_empty() {
+                return; // every wrapped source dropped — stop listening
+            }
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -222,6 +284,20 @@ mod tests {
         }
         assert!(refetched, "a code/write completion must dirty the wrapped map");
         assert_eq!(inner.fetches.load(Ordering::SeqCst), 2, "exactly one refetch");
+    }
+
+    // what this catches: the publish predicate — BOTH kinds must dirty (they
+    // alias: doctrine rides WallPostPublished with category="doctrine" while
+    // legacy peers emit DoctrinePublished), and chat traffic must NOT, or the
+    // doctrine cache refetches per message and the whole win evaporates.
+    #[test]
+    fn room_state_publish_predicate_covers_the_aliasing_pair_only() {
+        use airc_core::TranscriptKind as K;
+        assert!(is_room_state_publish(&K::DoctrinePublished));
+        assert!(is_room_state_publish(&K::WallPostPublished));
+        for benign in [K::Message, K::Attachment, K::Receipt, K::Presence, K::System] {
+            assert!(!is_room_state_publish(&benign), "{benign:?} must not dirty doctrine/wall");
+        }
     }
 
     // what this catches: the weak-handle lifecycle — a dead cache must stop

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -643,7 +643,7 @@ pub async fn materialize_adapters(
         // Bind the room-doctrine source from the same runtime (upcasts to
         // `AircDoctrineReader`). Grounds the persona in the room's nature
         // — the airc-published operating contract. Slice 2.
-        let doctrine_source: Arc<dyn crate::persona::rag_budget::RagSource> =
+        let raw_doctrine: Arc<dyn crate::persona::rag_budget::RagSource> =
             Arc::new(crate::persona::room_doctrine_source::RoomDoctrineSource::new(
                 identity.peer_id.as_uuid(),
                 runtime.clone(),
@@ -653,8 +653,6 @@ pub async fn materialize_adapters(
                 // keeps this grounding out of turns in OTHER contexts (another room,
                 // the eval fork's nil room) — the exam-bleed fix (#127).
                 .for_room(identity.default_room));
-        // Same dual-wire as the roster: one Arc, legacy path + brain faculty.
-        cognition.set_doctrine_source(doctrine_source.clone());
 
         // Active-work source: grounds the persona in ITS OWN live work across all
         // rooms (claimed cards + states), read from airc's work roster. The dynamic
@@ -719,7 +717,7 @@ pub async fn materialize_adapters(
         // active-work + workspace-map sources. See
         // docs/grid/AIRC-NATIVE-IDENTITY-ROOMS-SECURITY.md §5 and
         // [[airc-generic-per-user-room-state]].
-        let wall_source: Arc<dyn crate::persona::rag_budget::RagSource> =
+        let raw_wall: Arc<dyn crate::persona::rag_budget::RagSource> =
             Arc::new(crate::persona::wall_source::WallSource::new(
                 identity.peer_id.as_uuid(),
                 runtime.clone(),
@@ -729,6 +727,45 @@ pub async fn materialize_adapters(
                 // keeps this grounding out of turns in OTHER contexts (another room,
                 // the eval fork's nil room) — the exam-bleed fix (#127).
                 .for_room(identity.default_room));
+
+        // Doctrine + wall as event-invalidated caches (#398): these are pure
+        // event-folds — their projections change ONLY when a peer publishes
+        // (TranscriptKind::DoctrinePublished / WallPostPublished), which is
+        // rare, yet doctrine was the ONE SYNCHRONOUS airc round-trip on every
+        // live compose (ColdStartCritical, never deferred). ONE subscribe
+        // stream per persona marks both caches; the invalidator holds weak
+        // handles and dies with them. No wrap without a wire: if subscribe
+        // fails, both stay raw (correct, just slow) and we log loud. NOTE the
+        // roster is deliberately NOT cached — room_roster(within=120s, …) is
+        // a recency projection that DECAYS with no event firing; a cached
+        // roster shows ghosts.
+        let (doctrine_source, wall_source): (
+            Arc<dyn crate::persona::rag_budget::RagSource>,
+            Arc<dyn crate::persona::rag_budget::RagSource>,
+        ) = match runtime.subscribe_all_rooms().await {
+            Ok(stream) => {
+                let (doctrine_cached, doctrine_dirty) =
+                    crate::persona::cached_source::CachedRagSource::new(raw_doctrine);
+                let (wall_cached, wall_dirty) =
+                    crate::persona::cached_source::CachedRagSource::new(raw_wall);
+                crate::persona::grounding_invalidation::spawn_publish_invalidator(
+                    stream,
+                    vec![doctrine_dirty.downgrade(), wall_dirty.downgrade()],
+                );
+                (doctrine_cached, wall_cached)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    persona = %identity.agent_name,
+                    error = %e,
+                    "doctrine/wall cache UNWIRED (subscribe failed) — serving raw \
+                     airc fetch per compose; slow but never stale"
+                );
+                (raw_doctrine, raw_wall)
+            }
+        };
+        // Same dual-wire as the roster: one Arc, legacy path + brain faculty.
+        cognition.set_doctrine_source(doctrine_source.clone());
 
         // Room-board source: grounds the persona in the CURRENT ROOM's WHOLE
         // work board — every card, its column, priority, and owner — read live


### PR DESCRIPTION
## What

Doctrine and wall groundings become event-invalidated caches. Doctrine was the ONE synchronous airc round-trip on every live compose (ColdStartCritical, never deferred) for a projection that changes only when a peer publishes.

## Shape

- `spawn_publish_invalidator`: ONE subscribe stream per persona marks both caches on the publish pair (`DoctrinePublished` + `WallPostPublished` — treated together because they alias in the wild; cross-dirtying is safe over-invalidation).
- `is_room_state_publish` predicate, tested: both kinds dirty; Message/Attachment/Receipt/Presence/System never do.
- Weak handles: invalidator prunes dead handles and exits when all wrapped sources drop.
- No wrap without a wire: subscribe failure → raw sources + loud warn (slow, never stale).
- **Roster deliberately NOT cached** — `room_roster(within=120s)` is a recency projection that decays with no event firing; a cached roster shows ghosts. Documented at the wire.

5/5 module tests green, full lib compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo