### PR TITLE
fix(swe): importlib clash heal must UPGRADE the installed package — a lifted cutoff never touches an already-satisfied venv

### DIFF
--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -667,6 +667,25 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
                     "date-pinned resolution hit an unresolvable era package — retrying with \
                      a per-package cutoff derived from uv's own error"
                 );
+                // The setuptools/importlib clash needs MORE than a lifted cutoff: the
+                // broken importlib-metadata 0.x is ALREADY INSTALLED in the venv (2019
+                // pluggy pulled it in the requirements step), and `-e .` won't touch an
+                // already-satisfied package — so the cutoff pin alone retries into the
+                // exact same crash (live: pytest-5413/5495 kickoff, 2026-08-12, the
+                // first run after this arm shipped). Apply the banner's own remedy
+                // directly: upgrade the installed copy, then retry the editable build.
+                if pin.starts_with("importlib-metadata=") {
+                    let up = run(
+                        &uv,
+                        &["pip", "install", "-q", "--python", &py_s, "--upgrade", "importlib-metadata"],
+                        None,
+                    )
+                    .await?;
+                    if !up.status.success() {
+                        // The heal itself failed — no point looping on the same wall.
+                        break out;
+                    }
+                }
                 overrides.push(pin);
             }
             _ => break out,


### PR DESCRIPTION
Live (pytest-5413/5495 kickoff, 2026-08-12, first run after the arm
shipped): the clash arm matched setuptools' banner and pinned
importlib-metadata's cutoff — but the broken 0.x copy was ALREADY
INSTALLED (2019 pluggy pulled it in the requirements step), and the
`-e .` retry doesn't reinstall satisfied packages, so it crashed
byte-identically, the loop saw the same pin twice, and gave up. The
env gate (#2261) correctly blocked both solves; the heal just never
healed.

Fix: when the clash arm fires, apply the banner's own remedy directly
— `uv pip install --upgrade importlib-metadata` into the venv — then
retry the editable build with the cutoff pin. If the upgrade itself
fails, break instead of looping on the same wall.

swe_bench mod 11/11 green. Live proof owed: restage 5413/5495 on the
next deploy (deferred — 4 measured solves are in flight on the current
binary and must not be killed for a staging fix).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
