### PR TITLE
feat/bench board facts

### DIFF
--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -667,6 +667,25 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
                     "date-pinned resolution hit an unresolvable era package — retrying with \
                      a per-package cutoff derived from uv's own error"
                 );
+                // The setuptools/importlib clash needs MORE than a lifted cutoff: the
+                // broken importlib-metadata 0.x is ALREADY INSTALLED in the venv (2019
+                // pluggy pulled it in the requirements step), and `-e .` won't touch an
+                // already-satisfied package — so the cutoff pin alone retries into the
+                // exact same crash (live: pytest-5413/5495 kickoff, 2026-08-12, the
+                // first run after this arm shipped). Apply the banner's own remedy
+                // directly: upgrade the installed copy, then retry the editable build.
+                if pin.starts_with("importlib-metadata=") {
+                    let up = run(
+                        &uv,
+                        &["pip", "install", "-q", "--python", &py_s, "--upgrade", "importlib-metadata"],
+                        None,
+                    )
+                    .await?;
+                    if !up.status.success() {
+                        // The heal itself failed — no point looping on the same wall.
+                        break out;
+                    }
+                }
                 overrides.push(pin);
             }
             _ => break out,

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -297,6 +297,19 @@ impl ActionCommand for AgentSolve {
                 // The marker folds as `active` with the solver named (fold_run_card
                 // reads `persona_id`); each finished attempt overwrites it with the
                 // real result, exactly as before.
+                // The instance under test — the staged checkout's own dir name (the
+                // shape benchmark/swe-setup stages). Carried on EVERY ledger write so
+                // the board (#329) names WHAT is being worked from second zero, not
+                // just who; None outside a staged SWE checkout (a plain agent run).
+                let instance: Option<String> = inner
+                    .workspace
+                    .contains("/workspace/swe/")
+                    .then(|| {
+                        std::path::Path::new(&inner.workspace)
+                            .file_name()
+                            .map(|s| s.to_string_lossy().to_string())
+                    })
+                    .flatten();
                 if let Some(p) = path.as_ref() {
                     let _ = std::fs::write(
                         p,
@@ -305,6 +318,7 @@ impl ActionCommand for AgentSolve {
                             "run_id": run_id,
                             "persona_id": inner.persona_id,
                             "workspace": inner.workspace,
+                            "instance": instance,
                         })
                         .to_string(),
                     );
@@ -417,10 +431,23 @@ impl ActionCommand for AgentSolve {
                     };
                     match body {
                         Ok(r) => {
-                            if let (Some(path), Ok(json)) =
-                                (path.as_ref(), serde_json::to_string_pretty(&r))
+                            // Ledger write carries the board facts the result struct
+                            // doesn't: WHICH instance, attempt N of M (#329) — injected
+                            // as JSON rather than widening AgentSolveResult, whose wire
+                            // shape non-benchmark callers also consume.
+                            if let (Some(path), Ok(mut v)) =
+                                (path.as_ref(), serde_json::to_value(&r))
                             {
-                                let _ = std::fs::write(path, json);
+                                if let Some(obj) = v.as_object_mut() {
+                                    obj.insert("attempt".into(), attempt.into());
+                                    obj.insert("max_attempts".into(), max_attempts.into());
+                                    if let Some(inst) = instance.clone() {
+                                        obj.insert("instance".into(), inst.into());
+                                    }
+                                }
+                                if let Ok(json) = serde_json::to_string_pretty(&v) {
+                                    let _ = std::fs::write(path, json);
+                                }
                             }
                             if let Some(bus) = crate::runtime::MessageBus::global() {
                                 if let Ok(v) = serde_json::to_value(&r) {

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1778,6 +1778,31 @@ mod swe_setup_tests {
             assert_eq!(card.solver.as_deref(), Some("atlas-uuid"));
             assert_eq!(card.resolved, None, "no grade yet — never a verdict");
         }
+
+        // what this catches: the board facts (#329) — instance + attempt N/M
+        // projected from the result ledger, and patch_bytes derived LIVE from
+        // the result's own diff before any grade exists (the "patch is
+        // forming" leading indicator), while a real grade's byte count stays
+        // authoritative the moment one lands.
+        #[test]
+        fn board_facts_project_and_live_patch_yields_to_the_grade() {
+            let now: u64 = 10_000_000_000;
+            let fresh = now - 5_000;
+            let result = json!({"persona_id": "anon-uuid", "acts": 7,
+                                "instance": "sympy__sympy-21055",
+                                "attempt": 2, "max_attempts": 3,
+                                "patch": "diff --git a/x b/x\n+fix\n"});
+            // Pre-grade: live patch length from the result's own diff.
+            let card = fold_run_card("r6", Some(&result), None, fresh, now);
+            assert_eq!(card.instance.as_deref(), Some("sympy__sympy-21055"));
+            assert_eq!(card.attempt, Some(2));
+            assert_eq!(card.max_attempts, Some(3));
+            assert_eq!(card.patch_bytes, Some(24), "live diff length pre-grade");
+            // Graded: the grade's byte count wins over the live derivation.
+            let grade = json!({"resolved": false, "patchBytes": 1299});
+            let card = fold_run_card("r6", Some(&result), Some(&grade), fresh, now);
+            assert_eq!(card.patch_bytes, Some(1299), "grade is authoritative");
+        }
     }
 }
 
@@ -1815,6 +1840,18 @@ pub struct BenchmarkRunsParams {
 #[ts(export, export_to = "../../../protocol/typescript/benchmark/BenchRunCard.ts")]
 pub struct BenchRunCard {
     pub run_id: String,
+    /// Instance under test ("sympy__sympy-24066") — from the result ledger's
+    /// staged-checkout name (#329: the board names WHAT, not just who).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub instance: Option<String>,
+    /// Attempt N of `max_attempts` — the N-chances counter, live per ledger write.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
+    pub attempt: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
+    pub max_attempts: Option<u32>,
     /// Solver persona (from the result ledger; absent while attempt 1 is
     /// still in flight and nothing has been written yet).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1908,6 +1945,9 @@ fn fold_run_card(
     };
     BenchRunCard {
         run_id: run_id.to_string(),
+        instance: s(result, "instance"),
+        attempt: n(result, "attempt"),
+        max_attempts: n(result, "max_attempts"),
         solver: s(result, "persona_id"),
         stalled: phase == "quiet",
         phase: phase.to_string(),
@@ -1919,7 +1959,15 @@ fn fold_run_card(
         resolved,
         fail_to_pass: ratio(grade, "failToPassPassed", "failToPassTotal"),
         pass_to_pass: ratio(grade, "passToPassPassed", "passToPassTotal"),
-        patch_bytes: n(grade, "patchBytes"),
+        // Graded diff size when a grade exists; before any grade, the RESULT's
+        // own patch length — the live "a patch is forming" leading indicator
+        // (#329). One field, grade-authoritative, never both shown.
+        patch_bytes: n(grade, "patchBytes").or_else(|| {
+            result
+                .and_then(|r| r.get("patch"))
+                .and_then(|p| p.as_str())
+                .map(|p| p.len() as u32)
+        }),
         failed_tests: arr(grade, "failedTests"),
         infra_error,
     }

--- a/protocol/typescript/benchmark/BenchRunCard.ts
+++ b/protocol/typescript/benchmark/BenchRunCard.ts
@@ -8,6 +8,15 @@
  */
 export type BenchRunCard = { run_id: string, 
 /**
+ * Instance under test ("sympy__sympy-24066") — from the result ledger's
+ * staged-checkout name (#329: the board names WHAT, not just who).
+ */
+instance?: string, 
+/**
+ * Attempt N of `max_attempts` — the N-chances counter, live per ledger write.
+ */
+attempt?: number, max_attempts?: number, 
+/**
  * Solver persona (from the result ledger; absent while attempt 1 is
  * still in flight and nothing has been written yet).
  */


### PR DESCRIPTION
- **fix(swe): importlib clash heal must UPGRADE the installed package — a lifted cutoff never touches an already-satisfied venv**
- **feat(bench): board facts on BenchRunCard — instance, attempt N/M, live patch-forming bytes (#329 slice 1)**
