### PR TITLE
fix(bench): live-board accuracy — names not uuids, failed ≠ stalled

### DIFF
--- a/apps/web/src/bench/renderBench.spec.ts
+++ b/apps/web/src/bench/renderBench.spec.ts
@@ -140,10 +140,13 @@ describe('renderBench', () => {
     expect(text).toMatch(/3\s*<i>\s*\/\s*<\/i>\s*3/); // attempt 3/3 chip
     expect(text).toMatch(/f2p\s+<b>\s*0\s*\/\s*2/);
 
-    // the SCOREBOARD header: 0 resolved / 0 working / 2 stalled (failed counts as stalled).
+    // the SCOREBOARD header: 0 resolved / 1 working (queued counts — an attempt
+    // in flight) / 2 FAILED. Terminal failures are history with their own stat,
+    // never dressed as a live stall; no runs are quiet → no alarm banner.
     expect(text).toContain('bench-score');
     expect(text).toMatch(/bench-stat-resolved[\s\S]*?0/);
-    expect(text).toMatch(/bench-stat-stalled[\s\S]*?2/);
+    expect(text).toMatch(/bench-stat-failed[\s\S]*?2/);
+    expect(text).not.toContain('bench-stall-banner');
 
     // the acts progress bar: the busiest run (41 gens) fills to 100%.
     expect(text).toContain('bench-bar-fill');
@@ -155,6 +158,21 @@ describe('renderBench', () => {
 
     // no fabricated verdict on the queued run: exactly two verdict cells.
     expect(text.split('class="bench-verdict"').length - 1).toBe(2);
+  });
+
+  it('raises the stall ALARM banner only for live-but-silent runs, never for terminal failures', () => {
+    // what this catches: 17 ancient failed runs reading as "17 stalled" (the
+    // live-feed first-render defect, 2026-08-12) — failed is history, stalled alarms.
+    const withStall = flatten(
+      renderBench({
+        feedLive: true,
+        runs: [
+          { ...REAL_HOUR.runs[2]!, runId: 'stall-1', state: 'stalled', verdict: undefined },
+        ],
+      }),
+    ).join(' ');
+    expect(withStall).toContain('bench-stall-banner');
+    expect(withStall).toMatch(/1\s+run\s+gone quiet/);
   });
 
   it('renders the awaiting frame on an empty board and the snapshot banner off-feed', () => {

--- a/apps/web/src/bench/renderBench.ts
+++ b/apps/web/src/bench/renderBench.ts
@@ -82,8 +82,15 @@ export function renderBench(body: BenchContentBody): TemplateResult {
     </div>`;
   }
   const resolved = body.runs.filter((r) => r.state === 'resolved').length;
-  const working = body.runs.filter((r) => r.state === 'working' || r.state === 'grading').length;
-  const stalled = body.runs.filter((r) => r.state === 'stalled' || r.state === 'failed').length;
+  const working = body.runs.filter(
+    (r) => r.state === 'working' || r.state === 'grading' || r.state === 'queued',
+  ).length;
+  // Terminal failures are HISTORY, not an alarm — they get their own stat.
+  // `stalled` (live-but-silent) is the true alarm and renders as a banner
+  // only when it exists; 17 ancient failed runs must never read as "17
+  // currently stalled" (the live-feed first-render lesson, 2026-08-12).
+  const failed = body.runs.filter((r) => r.state === 'failed').length;
+  const stalled = body.runs.filter((r) => r.state === 'stalled').length;
   const maxGens = Math.max(...body.runs.map((r) => r.generations));
   return html`<div class="bench-board">
     ${body.feedLive ? nothing : html`<div class="bench-snapshot-banner">snapshot — no live feed attached</div>`}
@@ -94,10 +101,14 @@ export function renderBench(body: BenchContentBody): TemplateResult {
       <div class="bench-stat bench-stat-working">
         <span class="bench-stat-n">${working}</span><span class="bench-stat-l">working</span>
       </div>
-      <div class="bench-stat bench-stat-stalled">
-        <span class="bench-stat-n">${stalled}</span><span class="bench-stat-l">stalled</span>
+      <div class="bench-stat bench-stat-failed">
+        <span class="bench-stat-n">${failed}</span><span class="bench-stat-l">failed</span>
       </div>
     </div>
+    ${stalled > 0
+      ? html`<div class="bench-stall-banner" role="alert">
+          ⚠ ${stalled} run${stalled === 1 ? '' : 's'} gone quiet — live but no artifact activity</div>`
+      : nothing}
     ${body.lanePressure
       ? html`<div class="bench-lanes" title="serving lanes vs lanes of demand — contention at a glance">
           lanes ${body.lanePressure.serving} serving · ${body.lanePressure.demanding} demanding</div>`

--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -1013,7 +1013,16 @@ export class ChatWidget extends LitElement {
     }
     .bench-stat-resolved .bench-stat-n { color: var(--status-success, #4caf7d); }
     .bench-stat-working .bench-stat-n { color: var(--accent-primary); }
-    .bench-stat-stalled .bench-stat-n { color: var(--status-warning, #e0a458); }
+    .bench-stat-failed .bench-stat-n { color: var(--content-secondary); }
+    .bench-stall-banner {
+      padding: 5px 8px;
+      border: 1px solid color-mix(in srgb, var(--status-warning, #e0a458) 45%, transparent);
+      border-radius: var(--radius-sm);
+      background: color-mix(in srgb, var(--status-warning, #e0a458) 12%, transparent);
+      color: var(--status-warning, #e0a458);
+      font-size: 9.5px;
+      font-weight: 600;
+    }
     .bench-card {
       display: flex;
       flex-direction: column;

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -2072,6 +2072,24 @@ pub(crate) fn scan_run_cards(
     }
     cards.sort_by(|a, b| b.last_activity_ms.cmp(&a.last_activity_ms));
     cards.truncate(limit);
+    // The ledger stores the solver as her PERSONA UUID; the board speaks NAMES.
+    // Resolve against the live workspace roster here — the ONE scan — so every
+    // consumer (command + positron emitter) gets the same display identity. A
+    // uuid not in the roster (despawned persona, operator-fired run) stays as-is;
+    // the client compacts unresolved ids to short form (#161 vocabulary).
+    let names: std::collections::HashMap<String, String> =
+        crate::cognition::persona_workspace::global()
+            .roster()
+            .into_iter()
+            .filter_map(|(id, name)| name.map(|n| (id.to_string(), n)))
+            .collect();
+    for card in &mut cards {
+        if let Some(solver) = &card.solver {
+            if let Some(name) = names.get(solver) {
+                card.solver = Some(name.clone());
+            }
+        }
+    }
     Ok(cards)
 }
 

--- a/packages/chat-view/benchProjections.spec.ts
+++ b/packages/chat-view/benchProjections.spec.ts
@@ -60,6 +60,23 @@ describe('benchContentBody', () => {
     expect(body.runs[1]!.state).toBe('stalled');
   });
 
+  it('compacts uuid-shaped ids to short form — a board row never spends 36 hex chars', () => {
+    // what this catches: the live-feed first-render defect (2026-08-12) — the
+    // ledger's persona_id uuid and claim-<uuid> run ids rendered raw. The core
+    // resolves LIVE personas to names; anything still uuid-shaped compacts to
+    // the system's 8-char short-id vocabulary (#161). Real names pass through.
+    const body = benchContentBody(
+      view([
+        row({
+          run_id: 'claim-c995488a-bb84-4c31-9f10-6a2b3c4d5e6f',
+          solver: '90e758b2-3cf3-45c1-b100-de7c4ab5a549',
+        }),
+      ]),
+    );
+    expect(body.runs[0]!.instance).toBe('claim-c995488a');
+    expect(body.runs[0]!.persona).toBe('90e758b2');
+  });
+
   it('undelivered feed is the honest snapshot frame', () => {
     const body = benchContentBody(undefined);
     expect(body.feedLive).toBe(false);

--- a/packages/chat-view/benchProjections.ts
+++ b/packages/chat-view/benchProjections.ts
@@ -62,14 +62,23 @@ function verdictOf(row: BenchRunRow): BenchVerdictVM | undefined {
   };
 }
 
+/** A raw UUID (or uuid-suffixed run id) is an ID, not a NAME — the core resolves
+ *  live personas to display names; anything still uuid-shaped here compacts to
+ *  its 8-char short form (the same short-id vocabulary the rest of the system
+ *  speaks, #161) so the board never spends a row-width on 36 hex chars. */
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+function compactId(s: string): string {
+  return s.replace(UUID_RE, (u) => u.slice(0, 8));
+}
+
 function runVM(row: BenchRunRow): BenchRunVM {
   const acts = row.acts ?? 0;
   return {
     runId: row.run_id,
     // The board names WHAT when the ledger carries it; a non-SWE run is
     // honestly identified by its run id, never a guessed instance.
-    instance: row.instance ?? row.run_id,
-    persona: row.solver ?? 'unclaimed',
+    instance: compactId(row.instance ?? row.run_id),
+    persona: compactId(row.solver ?? 'unclaimed'),
     // The wire doesn't yet distinguish self-claimed from operator-launched;
     // unmarked until it does (mark only what is KNOWN).
     selfClaimed: false,


### PR DESCRIPTION
The feed-proof's first live render exposed two honesty defects on the bench board:

1. **Personas rendered as raw UUIDs** — the ledger's `persona_id` reached the row unresolved. `scan_run_cards` (the ONE scan behind `benchmark/runs` and the positron emitter) now resolves solver uuids against the live workspace roster; the client compacts anything still uuid-shaped to the 8-char short-id vocabulary (#161).
2. **Scoreboard read '17 stalled' from ancient terminal runs** — `failed` is history and gets its own stat; `stalled` (live-but-silent, the true alarm) is now a warning banner shown only when it exists; queued counts as working.

cargo check + vitest (3+5) + tsc green. Specs pin compaction, the failed/stalled split, and a stall-banner positive control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo