### PR TITLE
feat(web): tool acts render in the transcript as collapsed receipts — #243 client half

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -2097,6 +2097,65 @@ export class ChatWidget extends LitElement {
       gap: var(--spacing-sm);
       padding: 6px 0;
     }
+    /* Tool-act receipt rows (#243) — the collapsed "Read 2 files, ran a command ›"
+       line between speech, expanding IN PLACE via native <details>. Quiet by
+       design: the work is one gesture away, never shouting over the words. */
+    .messages .act-group {
+      list-style: none;
+      padding: 1px 0;
+      margin-left: calc(28px + var(--spacing-sm));
+      font-size: 11px;
+      color: var(--content-secondary);
+    }
+    .act-group summary {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
+      user-select: none;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--border-subtle);
+      background: color-mix(in srgb, var(--surface, #0b1220) 40%, transparent);
+    }
+    .act-group summary::-webkit-details-marker { display: none; }
+    .act-group summary::after { content: '›'; opacity: 0.6; transition: transform 0.15s; }
+    .act-group details[open] summary::after { transform: rotate(90deg); }
+    .act-gear { opacity: 0.75; }
+    .act-gear.act-failed { color: var(--status-warning, #e0a458); }
+    .act-actor { font-weight: 600; color: var(--content-primary); }
+    .act-count {
+      font-size: 9px;
+      padding: 0 5px;
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--content-secondary) 18%, transparent);
+      font-variant-numeric: tabular-nums;
+    }
+    .act-list {
+      list-style: none;
+      margin: 4px 0 2px;
+      padding: 0 0 0 14px;
+      border-left: 1px solid var(--border-subtle);
+    }
+    .act-item {
+      display: flex;
+      align-items: baseline;
+      gap: 7px;
+      padding: 1.5px 0;
+      font-family: var(--font-mono, ui-monospace, monospace);
+      font-size: 10.5px;
+    }
+    .act-item .act-mark { color: var(--status-success, #4caf7d); }
+    .act-item.act-failed .act-mark { color: var(--status-error, #e05858); }
+    .act-tool { color: var(--accent-primary); }
+    .act-obj {
+      color: var(--content-secondary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: 420px;
+    }
+    .act-time { margin-left: auto; opacity: 0.5; font-size: 9px; }
     /* Continuation rows (same sender, grouped upstream): tuck the body into the
        sender's column — tight runs, the classic chat grouping. */
     .messages .msg.continues {

--- a/apps/web/src/chat/renderChat.spec.ts
+++ b/apps/web/src/chat/renderChat.spec.ts
@@ -72,8 +72,13 @@ const message = (over: Partial<ChatMessageView> = {}): ChatMessageView => ({
 
 /** Project a `ChatViewState` payload through the exact pipe apps/web's index.ts
  *  runs, so the renderer is fed what the seam actually produces. */
-const project = (payload: ChatViewState): ChatViewModel => {
-  const env: StateEnvelope = { kind: CHAT_KIND, revision: 1, layer: 'ephemeral', payload };
+const project = (payload: Omit<ChatViewState, 'acts'> & { acts?: ChatViewState['acts'] }): ChatViewModel => {
+  const env: StateEnvelope = {
+    kind: CHAT_KIND,
+    revision: 1,
+    layer: 'ephemeral',
+    payload: { acts: [], ...payload },
+  };
   return chatViewModel(chatStateFromEnvelope(env));
 };
 

--- a/apps/web/src/content/registry.ts
+++ b/apps/web/src/content/registry.ts
@@ -27,7 +27,7 @@ import {
 } from '@continuum/patterns';
 import type { ChatContentBody } from '@continuum/chat-view';
 import { modelCell, type ForgeContentBody } from '@continuum/foundry-view';
-import { listingCell, messageRow } from '../render/parts';
+import { actGroupRow, listingCell, messageRow } from '../render/parts';
 import { renderPersona } from '../persona/renderPersona';
 import { renderLive } from '../live/renderLive';
 import { renderBench } from '../bench/renderBench';
@@ -37,10 +37,15 @@ import { renderGrid } from '../grid/renderGrid';
 
 /** The chat activity's center: the conversation (or an honest empty state). */
 function chatContent(body: ChatContentBody): TemplateResult {
+  // The FULL transcript (#243): speech rows interleaved with collapsed tool-act
+  // receipts, in timestamp order — the room shows the WORK, not just the words.
+  // An older wire without acts folds to a messages-only transcript upstream.
   return body.isEmpty
     ? html`<div class="empty">No messages yet — say hello.</div>`
     : html`<ul class="messages">
-        ${body.messages.map(messageRow)}
+        ${body.transcript.map((row) =>
+          row.row === 'acts' ? actGroupRow(row) : messageRow(row),
+        )}
       </ul>`;
 }
 

--- a/apps/web/src/experience/experienceSource.ts
+++ b/apps/web/src/experience/experienceSource.ts
@@ -66,7 +66,7 @@ export function makeExperienceSource(on: OnKind): AppSource<ExperienceState> {
         // Project the chat payload through the shared seam → the content body the
         // "chat" content renderer draws (identical to the standalone chat widget).
         const vm = chatViewModel(chatStateFromEnvelope(env));
-        contentBody = { messages: vm.messages, isEmpty: vm.isEmpty };
+        contentBody = { messages: vm.messages, transcript: vm.transcript, isEmpty: vm.isEmpty };
         emit();
       }),
     ];

--- a/apps/web/src/preview.ts
+++ b/apps/web/src/preview.ts
@@ -163,10 +163,23 @@ const FIXTURES: Record<string, ChatState> = {
       message({ id: 'm2', sender_id: 'solenne', sender_name: 'Solenne', provenance: { runtime: 'qwen' },
         content: 'I can take the projection side once the wire type lands.', timestamp: 1_700_000_060_000 }),
     ],
+    // Tool-act receipts (#243) between the two turns — the shapes a live solve
+    // radiates: reads collapse with the shell run into ONE "Read 2 files, ran a
+    // command ›" group (Asha), Solenne's edit stands alone after her message.
+    acts: [
+      { id: 'a1', room_id: 'general', actor_id: 'asha', actor_name: 'Asha',
+        tool: 'code/read', summary: 'sympy/core/mul.py', ok: true, timestamp: 1_700_000_010_000 },
+      { id: 'a2', room_id: 'general', actor_id: 'asha', actor_name: 'Asha',
+        tool: 'code/read', summary: 'sympy/core/tests/test_mul.py', ok: true, timestamp: 1_700_000_020_000 },
+      { id: 'a3', room_id: 'general', actor_id: 'asha', actor_name: 'Asha',
+        tool: 'code/shell', summary: 'pytest sympy/core/tests/test_mul.py -x', ok: false, timestamp: 1_700_000_030_000 },
+      { id: 'a4', room_id: 'general', actor_id: 'solenne', actor_name: 'Solenne',
+        tool: 'code/edit', summary: 'packages/chat-view/patternProjections.ts', ok: true, timestamp: 1_700_000_070_000 },
+    ],
   },
   empty: {
     kind: 'chat', revision: 1, room_id: 'general', room_name: 'general', purpose: 'chat',
-    roster, messages: [],
+    roster, messages: [], acts: [],
   },
   // The digest-tier reference input ([[perception-resolution-contract]]): the live
   // incident's shape — a degenerate repetition wall (hundreds of "ae0e-" lines)
@@ -176,6 +189,7 @@ const FIXTURES: Record<string, ChatState> = {
   flood: {
     kind: 'chat', revision: 1, room_id: 'general', room_name: 'general', purpose: 'chat',
     roster,
+    acts: [],
     messages: [
       message({ id: 'f1', content: 'Deploying the lane planner now — trace incoming.' }),
       message({
@@ -396,6 +410,7 @@ function main(): void {
       kind: 'chat', revision: 1, room_id: 'general', room_name: 'general', purpose: 'chat',
       roster: liveRoster,
       messages: FIXTURES.roster?.messages ?? [],
+      acts: [],
     };
     widget.nav = NAV_FIXTURES.rooms;
     widget.sys = SYS_FIXTURE;
@@ -417,7 +432,7 @@ function main(): void {
     widget.state = {
       kind: 'chat', revision: 1, room_id: 'arena', room_name: 'arena', purpose: 'arena',
       roster: FIXTURES.roster?.roster ?? [],
-      messages: [],
+      messages: [], acts: [],
     };
     widget.nav = NAV_FIXTURES.rooms;
     widget.sys = SYS_FIXTURE;

--- a/apps/web/src/render/parts.ts
+++ b/apps/web/src/render/parts.ts
@@ -12,7 +12,13 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import hljs from 'highlight.js/lib/common';
 import { ROSTER_LISTING_ID } from '@continuum/patterns';
 import type { GaugeView, ListingCell, ListingView, MetricsView } from '@continuum/patterns';
-import type { LoadoutVM, MemberKind, MessageRowVM, RosterMemberVM } from '@continuum/chat-view';
+import type {
+  ActGroupVM,
+  LoadoutVM,
+  MemberKind,
+  MessageRowVM,
+  RosterMemberVM,
+} from '@continuum/chat-view';
 
 /** Per-series hues for the SYS gauge — the old sidebar's legend palette (CPU
  *  red · MEM green · GPU purple), keyed by label with a cyan fallback for any
@@ -841,6 +847,37 @@ function messageBody(msg: MessageRowVM): TemplateResult {
       class="digest-tail" title="collapsed — mechanical summary of the hidden remainder">${digest.tailSummary}${digest.histogram
         ? html` <span class="digest-histogram">· ${digest.histogram}</span>`
         : nothing}</div><button class="digest-toggle" @click=${toggle}>show full message</button></div>`;
+}
+
+/** A collapsed run of tool acts — the transcript's RECEIPT row (#243, the
+ *  Claude-iOS pattern). Renders as a native `<details>` disclosure: the
+ *  collapsed line reads "⚙ Asha · Read 2 files, ran a command ›" and expands
+ *  IN PLACE (Joel's law: web expands inline; mobile opens a sheet) to one
+ *  line per act — status mark, tool name, object. No JS state — the browser
+ *  owns the open/closed bit, so a re-render never fights the reader. */
+export function actGroupRow(group: ActGroupVM): TemplateResult {
+  return html`
+    <li class="act-group" data-actor=${group.actorId} title=${group.time}>
+      <details>
+        <summary>
+          <span class="act-gear${group.anyFailed ? ' act-failed' : ''}">⚙</span>
+          <span class="act-actor">${group.actorName}</span>
+          <span class="act-line">${group.summaryLine}</span>
+          <span class="act-count">${group.receipts.length}</span>
+        </summary>
+        <ul class="act-list">
+          ${group.receipts.map(
+            (r) => html`<li class="act-item${r.ok ? '' : ' act-failed'}">
+              <span class="act-mark">${r.ok ? '✓' : '✗'}</span>
+              <span class="act-tool">${r.tool}</span>
+              ${r.summary ? html`<span class="act-obj">${r.summary}</span>` : nothing}
+              <span class="act-time">${r.time}</span>
+            </li>`,
+          )}
+        </ul>
+      </details>
+    </li>
+  `;
 }
 
 /** One conversation row — WHAT was said. */

--- a/packages/chat-view/chatApp.spec.ts
+++ b/packages/chat-view/chatApp.spec.ts
@@ -59,6 +59,7 @@ const chatState = (over: Partial<ChatState> = {}): ChatState => ({
   purpose: 'chat',
   messages: [],
   roster: [],
+  acts: [],
   ...over,
 });
 

--- a/packages/chat-view/chatViewModel.spec.ts
+++ b/packages/chat-view/chatViewModel.spec.ts
@@ -54,10 +54,53 @@ const state = (over: Partial<ChatState> = {}): ChatState => ({
   purpose: 'chat',
   messages: [],
   roster: [],
+  acts: [],
   ...over,
 });
 
 describe('chatViewModel', () => {
+  it('interleaves act receipts into the transcript, collapsing consecutive same-actor acts (#243)', () => {
+    // what this catches: the transcript contract — acts land BETWEEN the
+    // messages they chronologically belong to; consecutive same-actor acts
+    // collapse into ONE group with a composed summary line; a failure inside
+    // the group marks it; a different actor breaks the group. An acts-less
+    // wire (older core) folds to a messages-only transcript.
+    const vm = chatViewModel(
+      state({
+        messages: [
+          message({ id: 'm1', timestamp: 1_000 }),
+          message({ id: 'm2', timestamp: 60_000 }),
+        ],
+        acts: [
+          { id: 'a1', room_id: 'room-1', actor_id: 'asha', actor_name: 'Asha',
+            tool: 'code/read', summary: 'mul.py', ok: true, timestamp: 10_000 },
+          { id: 'a2', room_id: 'room-1', actor_id: 'asha', actor_name: 'Asha',
+            tool: 'code/read', summary: 'test_mul.py', ok: true, timestamp: 20_000 },
+          { id: 'a3', room_id: 'room-1', actor_id: 'asha', actor_name: 'Asha',
+            tool: 'code/shell', summary: 'pytest -x', ok: false, timestamp: 30_000 },
+          { id: 'a4', room_id: 'room-1', actor_id: 'solenne', actor_name: 'Solenne',
+            tool: 'code/edit', summary: 'proj.ts', ok: true, timestamp: 40_000 },
+        ],
+      }),
+    );
+    const rows = vm.transcript;
+    expect(rows.map((r) => r.row)).toEqual(['message', 'acts', 'acts', 'message']);
+    const group = rows[1];
+    if (group?.row !== 'acts') throw new Error('expected act group');
+    expect(group.actorName).toBe('Asha');
+    expect(group.receipts).toHaveLength(3);
+    expect(group.summaryLine).toBe('Read 2 files, ran a command');
+    expect(group.anyFailed).toBe(true); // the pytest -x failure marks the group
+    const solo = rows[2];
+    if (solo?.row !== 'acts') throw new Error('expected second act group');
+    expect(solo.actorName).toBe('Solenne');
+    expect(solo.summaryLine).toBe('Edited a file');
+    // acts-less wire: transcript degenerates to exactly the messages.
+    const bare = chatViewModel(state({ messages: [message({ id: 'm1' })] }));
+    expect(bare.transcript.map((r) => r.row)).toEqual(['message']);
+  });
+
+
   // what this catches: the three panels must project from one snapshot —
   // room→header (where), roster→members (who), messages→rows (what). A
   // regression that dropped a facet would blank a whole panel.

--- a/packages/chat-view/chatViewModel.ts
+++ b/packages/chat-view/chatViewModel.ts
@@ -21,7 +21,12 @@
  */
 
 import type { ChatState } from './ChatState';
-import type { ChatMessageView, RosterSlotView, SenderKind } from '@continuum/sdk-typescript';
+import type {
+  ActReceiptView,
+  ChatMessageView,
+  RosterSlotView,
+  SenderKind,
+} from '@continuum/sdk-typescript';
 import { messageDigest, type MessageDigestVM } from './messageDigest';
 
 /** The neutral author/member kind discriminant (`'human' | 'agent' | 'system'`). */
@@ -107,6 +112,40 @@ export interface MessageRowVM {
   readonly continues?: boolean;
 }
 
+/** One tool act inside a receipt group — the expanded row (#243). */
+export interface ActReceiptVM {
+  readonly id: string;
+  /** Opaque tool name as executed ("code/read"). */
+  readonly tool: string;
+  /** One-line human object ("sympy/core/mul.py"). Empty = verb-only. */
+  readonly summary: string;
+  readonly ok: boolean;
+  readonly time: string;
+}
+
+/** A COLLAPSED run of consecutive tool acts by one actor — the transcript's
+ *  receipt row (the Claude-iOS pattern: "Ran 3 commands ›" between speech;
+ *  web expands in place, mobile opens a sheet). Grouping lives HERE, in the
+ *  one projection, so web/tui/mobile all collapse identically. */
+export interface ActGroupVM {
+  readonly row: 'acts';
+  /** First receipt's id — the group's stable render key. */
+  readonly id: string;
+  readonly actorId: string;
+  readonly actorName: string;
+  /** The iOS-style collapsed line: "Read 2 files, ran a command". */
+  readonly summaryLine: string;
+  /** Wall-clock of the group's LAST act (the freshest fact). */
+  readonly time: string;
+  /** True when ANY receipt in the group failed — the collapsed line warns. */
+  readonly anyFailed: boolean;
+  readonly receipts: readonly ActReceiptVM[];
+}
+
+/** One transcript row: a spoken message or a collapsed act group, discriminated
+ *  on `row` (`kind` is taken — it's the author kind on message rows). */
+export type TranscriptRowVM = ({ readonly row: 'message' } & MessageRowVM) | ActGroupVM;
+
 /** The full render-ready projection of a chat snapshot. */
 export interface ChatViewModel {
   readonly roomName: string;
@@ -119,6 +158,11 @@ export interface ChatViewModel {
   readonly activeCount: number;
   readonly members: readonly RosterMemberVM[];
   readonly messages: readonly MessageRowVM[];
+  /** The FULL transcript: messages and collapsed act-receipt groups interleaved
+   *  by timestamp (#243 — the room is the activity's full event stream; speech-
+   *  only transcripts hide the work). Renderers draw THIS; `messages` remains
+   *  the speech-only view other consumers (ticker, digests) keep reading. */
+  readonly transcript: readonly TranscriptRowVM[];
   /** No messages yet — the surface renders an honest empty state, not an error. */
   readonly isEmpty: boolean;
   readonly revision?: number;
@@ -209,6 +253,101 @@ function messageVM(msg: ChatMessageView): MessageRowVM {
  *  grouping that turns bubble-per-line sprawl into readable runs. */
 const GROUP_WINDOW_MS = 5 * 60 * 1000;
 
+/** Classify a tool name into the collapsed line's verb bucket. Read verbs are
+ *  the same deny-list vocabulary the workspace invalidator speaks; everything
+ *  unknown reads as generic "used a tool" — honest, never a guessed verb. */
+function actVerb(tool: string): 'read' | 'searched' | 'edited' | 'ran' | 'used' {
+  if (/^code\/(read|list|tree|glob)$/.test(tool)) return 'read';
+  if (/^code\/search$/.test(tool)) return 'searched';
+  if (/^code\/(write|edit)$/.test(tool)) return 'edited';
+  if (/^(code\/(shell|run)|cargo\/|git\/)/.test(tool)) return 'ran';
+  return 'used';
+}
+
+/** The iOS-style collapsed line: verb buckets with counts, in first-occurrence
+ *  order — "Read 2 files, ran a command", "Edited a file, ran 3 commands". */
+export function actSummaryLine(tools: readonly string[]): string {
+  const nouns: Record<ReturnType<typeof actVerb>, [string, string]> = {
+    read: ['a file', 'files'],
+    searched: ['once', 'times'],
+    edited: ['a file', 'files'],
+    ran: ['a command', 'commands'],
+    used: ['a tool', 'tools'],
+  };
+  const order: ReturnType<typeof actVerb>[] = [];
+  const counts = new Map<ReturnType<typeof actVerb>, number>();
+  for (const t of tools) {
+    const v = actVerb(t);
+    if (!counts.has(v)) order.push(v);
+    counts.set(v, (counts.get(v) ?? 0) + 1);
+  }
+  const parts = order.map((v) => {
+    const n = counts.get(v) ?? 0;
+    const [one, many] = nouns[v];
+    return n === 1 ? `${v} ${one}` : `${v} ${n} ${many}`;
+  });
+  const line = parts.join(', ');
+  return line.charAt(0).toUpperCase() + line.slice(1);
+}
+
+/** Interleave messages and act receipts by timestamp into the transcript,
+ *  collapsing consecutive same-actor acts (nothing between them) into one
+ *  group row. Pure over the two wire arrays — the one place every client's
+ *  collapse behavior comes from. */
+function buildTranscript(
+  messages: readonly MessageRowVM[],
+  wireMessages: readonly ChatMessageView[],
+  acts: readonly ActReceiptView[],
+): TranscriptRowVM[] {
+  type Ev =
+    | { ts: number; msg: MessageRowVM }
+    | { ts: number; act: ActReceiptView };
+  const events: Ev[] = [
+    ...messages.map((m, i) => ({ ts: wireMessages[i]?.timestamp ?? 0, msg: m })),
+    ...acts.map((a) => ({ ts: a.timestamp, act: a })),
+  ].sort((x, y) => x.ts - y.ts);
+
+  const out: TranscriptRowVM[] = [];
+  for (const ev of events) {
+    if ('msg' in ev) {
+      out.push({ row: 'message', ...ev.msg });
+      continue;
+    }
+    const a = ev.act;
+    const receipt: ActReceiptVM = {
+      id: a.id,
+      tool: a.tool,
+      summary: a.summary,
+      ok: a.ok,
+      time: formatTimeOfDay(a.timestamp),
+    };
+    const last = out[out.length - 1];
+    if (last && last.row === 'acts' && last.actorId === a.actor_id) {
+      // Extend the open group: rebuild the immutable row with the new receipt.
+      const receipts = [...last.receipts, receipt];
+      out[out.length - 1] = {
+        ...last,
+        receipts,
+        summaryLine: actSummaryLine(receipts.map((r) => r.tool)),
+        time: receipt.time,
+        anyFailed: last.anyFailed || !a.ok,
+      };
+    } else {
+      out.push({
+        row: 'acts',
+        id: a.id,
+        actorId: a.actor_id,
+        actorName: a.actor_name,
+        summaryLine: actSummaryLine([a.tool]),
+        time: receipt.time,
+        anyFailed: !a.ok,
+        receipts: [receipt],
+      });
+    }
+  }
+  return out;
+}
+
 /** Project a `ChatState` snapshot into the flat view model the panels render. */
 export function chatViewModel(state: ChatState): ChatViewModel {
   const members = state.roster.map(memberVM);
@@ -243,6 +382,10 @@ export function chatViewModel(state: ChatState): ChatViewModel {
     activeCount: members.filter((m) => m.active).length,
     members,
     messages,
+    // Additive wire field (#243): an older core omits `acts` → the transcript
+    // is just the messages, exactly the pre-receipt surface.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    transcript: buildTranscript(messages, state.messages, state.acts ?? []),
     isEmpty: state.messages.length === 0,
     revision: state.revision,
   };

--- a/packages/chat-view/crossConsumer.spec.ts
+++ b/packages/chat-view/crossConsumer.spec.ts
@@ -73,11 +73,14 @@ const message = (over: Partial<ChatMessageView> = {}): ChatMessageView => ({
 /** A `chat` state frame exactly as `StateConnection` hands to a `CHAT_KIND` sink:
  *  the payload is a bare `ChatViewState` (no kind/revision — those ride the
  *  envelope), and the merge is what grafts them on. */
-const chatEnvelope = (revision: number, payload: ChatViewState): StateEnvelope => ({
+const chatEnvelope = (
+  revision: number,
+  payload: Omit<ChatViewState, 'acts'> & { acts?: ChatViewState['acts'] },
+): StateEnvelope => ({
   kind: CHAT_KIND,
   revision,
   layer: 'ephemeral',
-  payload,
+  payload: { acts: [], ...payload },
 });
 
 /**

--- a/packages/chat-view/index.ts
+++ b/packages/chat-view/index.ts
@@ -30,7 +30,11 @@ export type {
   RosterMemberVM,
   LoadoutVM,
   MessageRowVM,
+  ActReceiptVM,
+  ActGroupVM,
+  TranscriptRowVM,
 } from './chatViewModel';
+export { actSummaryLine } from './chatViewModel';
 
 // The transcript's digest tier ([[perception-resolution-contract]]): mechanical
 // head + tail-summary + repetition-histogram classification of over-threshold

--- a/packages/chat-view/liveProjections.spec.ts
+++ b/packages/chat-view/liveProjections.spec.ts
@@ -28,6 +28,7 @@ const vm: ChatViewModel = {
   roomName: 'general',
   roomId: 'room-1',
   purpose: 'chat',
+  transcript: [],
   memberCount: 3,
   activeCount: 2,
   members: [

--- a/packages/chat-view/messageDigest.spec.ts
+++ b/packages/chat-view/messageDigest.spec.ts
@@ -146,6 +146,7 @@ describe('chatViewModel digest projection', () => {
     room_name: 'general',
     purpose: 'chat',
     roster: [],
+    acts: [],
     messages: [
       {
         id: 'msg-1',

--- a/packages/chat-view/mobileScreen.spec.ts
+++ b/packages/chat-view/mobileScreen.spec.ts
@@ -30,7 +30,7 @@ const message = (over: Partial<ChatMessageView> = {}): ChatMessageView => ({
 });
 const chatState = (over: Partial<ChatState> = {}): ChatState => ({
   kind: 'chat', revision: 3, room_id: 'room-1', room_name: 'general',
-  purpose: 'chat', messages: [], roster: [], ...over,
+  purpose: 'chat', messages: [], roster: [], acts: [], ...over,
 });
 
 describe('toMobileScreen — the mobile adaptation rule', () => {

--- a/packages/chat-view/patternProjections.spec.ts
+++ b/packages/chat-view/patternProjections.spec.ts
@@ -26,6 +26,7 @@ const vm: ChatViewModel = {
   roomName: 'general',
   roomId: 'room-1',
   purpose: 'chat',
+  transcript: [],
   memberCount: 2,
   activeCount: 1,
   members: [

--- a/packages/chat-view/patternProjections.ts
+++ b/packages/chat-view/patternProjections.ts
@@ -29,7 +29,13 @@ import type {
   ServingViewState,
   SystemMetricsViewState,
 } from '@continuum/sdk-typescript';
-import type { ChatViewModel, MemberKind, MessageRowVM, RosterMemberVM } from './chatViewModel';
+import type {
+  ChatViewModel,
+  MemberKind,
+  MessageRowVM,
+  RosterMemberVM,
+  TranscriptRowVM,
+} from './chatViewModel';
 import { ARENA_PURPOSE, GRID_PURPOSE, LIVE_PURPOSE, PERSONA_PURPOSE, SERVING_PURPOSE, type ArenaContentBody as ArenaContentBodyT, type GridContentBody, type GridNodeVM, type ServingContentBody, type ServingNodeVM } from '@continuum/patterns';
 import type { LiveContentBody, PersonaContentBody } from '@continuum/patterns';
 import {
@@ -377,6 +383,9 @@ export interface WorkspaceLive {
  *  renderer draws these rows; a foundry room would carry a different purpose + body. */
 export interface ChatContentBody {
   readonly messages: readonly MessageRowVM[];
+  /** The full interleaved transcript (speech + collapsed act receipts, #243) —
+   *  what the center pane draws. `messages` stays for speech-only consumers. */
+  readonly transcript: readonly TranscriptRowVM[];
   readonly isEmpty: boolean;
 }
 
@@ -442,7 +451,7 @@ export function chatWorkspace(vm: ChatViewModel, live?: WorkspaceLive): Workspac
             ? { purpose: GRID_PURPOSE, body: gridBody }
             : {
                 purpose: vm.purpose,
-                body: { messages: vm.messages, isEmpty: vm.isEmpty },
+                body: { messages: vm.messages, transcript: vm.transcript, isEmpty: vm.isEmpty },
               };
   // The ACTIVE nav cell follows the citizen's current tab: the persona tab
   // when a persona home is focused, else the chat room on screen.

--- a/packages/chat-view/personaProjections.spec.ts
+++ b/packages/chat-view/personaProjections.spec.ts
@@ -27,6 +27,7 @@ const vm: ChatViewModel = {
   roomName: 'general',
   roomId: 'room-1',
   purpose: 'chat',
+  transcript: [],
   memberCount: 2,
   activeCount: 1,
   members: [

--- a/packages/chat-view/ragTarget.spec.ts
+++ b/packages/chat-view/ragTarget.spec.ts
@@ -26,7 +26,7 @@ const message = (over: Partial<ChatMessageView> = {}): ChatMessageView => ({
 });
 const chatState = (over: Partial<ChatState> = {}): ChatState => ({
   kind: 'chat', revision: 3, room_id: 'room-1', room_name: 'general',
-  purpose: 'chat', messages: [], roster: [], ...over,
+  purpose: 'chat', messages: [], roster: [], acts: [], ...over,
 });
 
 describe('createRagTarget — the RAG rule derives concise grounding automatically', () => {


### PR DESCRIPTION
The Claude-iOS pattern Joel referenced: a collapsed receipt line between speech (**'Asha · Read 2 files, ran a command ›'**) expanding IN PLACE to one row per act (✓/✗ · tool · object · time). Consumes the `persona:act` wire PR #2273 deployed — real receipts are flowing from the live benchmark round as of this boot.

- **chatViewModel**: `transcript` = messages + act receipts merge-sorted by timestamp; consecutive same-actor acts collapse into one `ActGroupVM` with a composed summary line (verb buckets) + `anyFailed` mark. Grouping lives in the ONE projection — web/tui/mobile collapse identically. Acts-less wire (older core) degenerates to a messages-only transcript.
- **render**: `chatContent` draws the transcript; `actGroupRow` uses native `<details>` (browser owns the open bit — re-renders never fight the reader). Mobile's bottom-sheet variant is the remaining #243 slice.
- **fixture**: the default chat preview carries real-shaped receipts; render-proof shot delivered (expanded + collapsed states in one frame).

Spec pins interleave order, collapse count, summary-line composition, failure marking, acts-less degeneration. chat-view 68 + web 24 vitest green, tsc green both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo