### PR TITLE
fix(positron): nil-room acts must never steal the chat projection (#243)

### DIFF
--- a/core/continuum-core/src/cognition/act_observe/apply.rs
+++ b/core/continuum-core/src/cognition/act_observe/apply.rs
@@ -404,7 +404,15 @@ pub async fn apply_act(
     // `ChatViewState.acts`; clients render, collapse, expand. PURE
     // OBSERVABILITY — nothing on the decision path reads these events, and a
     // handless/mock executor (no `command_executor`) simply radiates nothing.
-    if let Some(bus) = body.executor.command_executor().and_then(|e| e.message_bus()) {
+    // An act with no ROOM has no transcript home: headless agent/solve runs pass
+    // `Uuid::nil()` (solve.rs), and radiating those stole the single-room chat
+    // projection onto a phantom room (live-proven 2026-08-12: the first real
+    // receipt cleared academy's view). Skip until solves thread their bench
+    // room (#329's per-run rooms make every solve act a room act).
+    if room_id.is_nil() {
+        // fall through to the working-memory record below — the receipt is
+        // transcript-only observability; her own proprioception is unaffected.
+    } else if let Some(bus) = body.executor.command_executor().and_then(|e| e.message_bus()) {
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)

--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -715,7 +715,11 @@ impl ChatProjection {
     /// joined); a rostered actor re-resolves so display identity stays
     /// single-sourced.
     fn apply_act(&mut self, act: PersonaActUpdate) {
-        if self.pinned_away_from(act.room_id) {
+        // A nil room is not a room: headless solves radiate acts with
+        // Uuid::nil() (guarded at the producer, kept here as defense in
+        // depth) — folding one would switch_room(nil) and wipe the live
+        // room's view onto a phantom (observed live 2026-08-12).
+        if act.room_id.is_nil() || self.pinned_away_from(act.room_id) {
             return;
         }
         self.switch_room(act.room_id);
@@ -1096,6 +1100,33 @@ mod tests {
         let view = current_chat(&substrate);
         assert_eq!(view.acts.len(), 1);
         assert_eq!(view.acts[0].tool, "code/shell");
+    }
+
+    #[test]
+    fn nil_room_act_never_steals_the_projection() {
+        // what this catches: regression for the 2026-08-12 live find — a
+        // headless solve's act carries Uuid::nil() as its room, and folding
+        // it switch_room(nil)'d the projection off the real room, wiping the
+        // live view onto a phantom. A nil-room act must be a no-op.
+        let substrate = Substrate::new();
+        let mut p = ChatProjection::new(substrate.clone());
+        let room = Uuid::from_u128(0x1);
+        if let Some(ProjectionInput::Act(a)) = classify(
+            PERSONA_ACT,
+            &act_payload(room, Uuid::from_u128(0x2), Uuid::from_u128(0x3), "code/read", "a.py"),
+        ) {
+            p.apply_act(a);
+        }
+        assert_eq!(current_chat(&substrate).acts.len(), 1);
+        if let Some(ProjectionInput::Act(a)) = classify(
+            PERSONA_ACT,
+            &act_payload(Uuid::nil(), Uuid::from_u128(0x4), Uuid::from_u128(0x3), "code/shell", "pytest"),
+        ) {
+            p.apply_act(a);
+        }
+        let view = current_chat(&substrate);
+        assert_eq!(view.acts.len(), 1, "nil-room act must not fold or clear");
+        assert_eq!(view.acts[0].tool, "code/read", "real room's receipts survive");
     }
 
     /// A thin `chat:posted` payload — core message facts only, sender


### PR DESCRIPTION
The #243 live proof landed — a real solve act (Asha's `code/read sympy/assumptions/refine.py`) folded into the chat transcript within 2 minutes of subscribing — and the payload exposed one defect: headless `agent/solve` passes `Uuid::nil()` as its room, and radiating that act `switch_room(nil)`'d the single-room projection onto a phantom room, wiping the live view.

Two guards:
- **producer** (`act_observe/apply.rs`): skip radiating `persona:act` when `room_id` is nil — an act with no room has no transcript home. Working memory unaffected. #329's per-run bench rooms are the real fix (thread a room through solve).
- **projection** (`positron_source.rs`): `apply_act` refuses a nil room as defense in depth, with a regression test pinning that a nil-room act neither folds nor clears the real room's receipts.

Tests: 37 act_observe + 18 positron_source green (incl. new `nil_room_act_never_steals_the_projection`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo