### PR TITLE
fix(claude): marketplace source type is 'directory', not 'local'

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "extraKnownMarketplaces": {
     "continuum-local-tools": {
       "source": {
-        "source": "local",
+        "source": "directory",
         "path": "tools/plugins"
       }
     }


### PR DESCRIPTION
`.claude/settings.json` declares `extraKnownMarketplaces.continuum-local-tools.source.source = "local"`, which is not a valid marketplace source type. Claude Code reports **Invalid input** and the `memory-bridge` plugin's marketplace does not resolve — so the plugin is configured, enabled, and dead.

`"directory"` is the type for a filesystem-path marketplace. `path` (`tools/plugins`) unchanged. Validated: the file parses and round-trips through `ConvertFrom-Json`.

**Why this is a PR and not a working-tree fix.** The file is tracked. I fixed it locally twice today and both times my own `git checkout` / `reset --hard` — rescuing #2056 into five PRs, then syncing to canary — silently reverted it, and the error came back looking fresh. A config fix that only exists in a working tree is not a fix; it is a fix with a countdown on it.

One-line change; no behavior beyond making the declared plugin actually load.