### PR TITLE
fix(persona): a stub citizen has no transport and says so — unblocks canary's --lib gate

### DIFF
--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -347,18 +347,38 @@ impl AircCitizen for StubAircCitizen {
     }
 
     async fn subscribe_all_rooms(&self) -> Result<FilteredEventStream, AircError> {
-        // No service-loop test drives the stub's subscribe — the
-        // service loop receives messages through StubConversation
-        // directly, never through the citizen's stream. If a future
-        // test ever wires the stub into the conversation, this panics
-        // visibly per [[no-fallbacks-ever]] rather than silently
-        // returning an empty stream or fabricating an AircError
-        // variant that doesn't fit ("Transport"/"Route"/etc).
-        unreachable!(
-            "StubAircCitizen::subscribe_all_rooms must not be called — \
-             service-loop tests should drive the loop through \
-             StubConversation directly, not through the citizen handle"
-        );
+        // A stub citizen HAS no transport, and says so.
+        //
+        // This was `unreachable!()`, on the stated premise that "no
+        // service-loop test drives the stub's subscribe". That premise was
+        // true when written and stopped being true when the supervisor grew
+        // its doctrine/wall cache: `supervisor.rs` now subscribes to wire a
+        // publish-invalidator, so five supervisor tests — which are about
+        // adapter materialization and warmup, and care nothing about event
+        // streams — reached this line and aborted. `cargo test -p
+        // continuum-core --lib` has been red on every canary push since,
+        // which is what makes "canary is green" mean nothing to everyone
+        // else in the repo.
+        //
+        // The guard was right to refuse an EMPTY STREAM: that would hand the
+        // supervisor a wire that never fires, so the cache would go stale
+        // silently and the tests would pass while proving nothing. That is
+        // the masking the original comment correctly rejected, and this does
+        // not do it.
+        //
+        // Returning `Transport` is not the "variant that doesn't fit" the
+        // old comment feared. It is a free-form transport-side variant and
+        // "this citizen has no transport" is a transport-side fact. The call
+        // site already has the matching branch: on `Err` the supervisor
+        // serves raw doctrine/wall sources and logs `cache UNWIRED … slow but
+        // never stale`. So the absence stays LOUD and correct — it travels
+        // the path designed for it instead of killing the process.
+        Err(AircError::Transport(
+            "StubAircCitizen has no transport — nothing subscribes, nothing publishes. \
+             Drive service-loop tests through StubConversation; callers that need a live \
+             stream must use a real citizen."
+                .to_string(),
+        ))
     }
 
     async fn say_in(&self, _room_id: Uuid, _text: &str) -> Result<EventId, AircError> {
@@ -384,11 +404,31 @@ mod tests {
         assert!(events.is_empty());
     }
 
+    /// what this catches: the stub handing back a wire it does not have.
+    ///
+    /// This asserted a PANIC until 2026-08-13, on the premise that nothing
+    /// would ever call subscribe on a stub. The supervisor's doctrine/wall
+    /// cache then did exactly that, and five supervisor tests — about adapter
+    /// materialization, not events — died on it, keeping `cargo test -p
+    /// continuum-core --lib` red on every canary push.
+    ///
+    /// The invariant that actually matters survives, and is what this now
+    /// pins: the stub must report an ERROR, never `Ok` with an empty stream.
+    /// An empty stream is a wire that never fires, so the supervisor's cache
+    /// would go stale in silence and this test would pass while proving
+    /// nothing. Err travels the branch built for it — raw sources, loud warn.
     #[tokio::test]
-    #[should_panic(expected = "service-loop tests should drive the loop")]
-    async fn stub_subscribe_panics_loudly() {
+    async fn stub_subscribe_reports_no_transport_rather_than_faking_a_wire() {
         let stub: Arc<dyn AircCitizen> = Arc::new(StubAircCitizen::new(Uuid::new_v4()));
-        let _ = stub.subscribe_all_rooms().await;
+        let error = stub
+            .subscribe_all_rooms()
+            .await
+            .err()
+            .expect("stub must REFUSE to subscribe — an Ok here is an empty stream nobody fires");
+        assert!(
+            matches!(error, AircError::Transport(_)),
+            "the refusal must name the missing transport, got: {error}"
+        );
     }
 
     // what this catches: a reply addressed to the room that asked, rather than


### PR DESCRIPTION
## The standing red gate

`cargo test -p continuum-core --lib` has failed on **every canary push for days** — verified across the last 6 canary runs. Six tests fail; five share one cause: `StubAircCitizen::subscribe_all_rooms` was `unreachable!()`.

The premise was stated right in the code — *"no service-loop test drives the stub's subscribe."* True when written. It stopped being true when the supervisor grew its doctrine/wall cache: `supervisor.rs:745` now subscribes to wire a publish-invalidator, so five supervisor tests — about adapter materialization and warmup, caring nothing about event streams — reached that line and aborted.

**A guard whose premise the codebase has outgrown doesn't fail like a guard. It fails like a broken build, and takes the whole gate with it.** With `--lib` red on every push, "canary is green" means nothing to anyone else in the repo — which is exactly how it survived days of everyone reading around it.

## What's kept

The guard was **right** to refuse an empty stream. That would hand the supervisor a wire that never fires: the cache goes stale in silence and the tests pass while proving nothing. This does not do that.

It returns `AircError::Transport` — not the "variant that doesn't fit" the old comment feared, but a free-form transport-side variant, and *"this citizen has no transport"* is a transport-side fact. The call site already has the matching branch: on `Err` the supervisor serves raw doctrine/wall sources and logs `cache UNWIRED … slow but never stale`.

The absence stays loud. It just travels the path designed for it instead of killing the process.

The stub's own test flips from asserting a panic to pinning the invariant that actually matters: **report an error, never `Ok` with an empty stream.**

## Scope

This fixes 5 of the 6 failures. The 6th, `tool_parsing::tests::parse_time_is_measured`, is a timing assertion and a separate question — I'm not bundling an unrelated fix into a gate unblock.

## Not validated locally, and I won't pretend otherwise

This Windows box cannot build `core/llama` — its bundled cmake doesn't know the `Visual Studio 18 2026` generator, so `cargo check -p continuum-core` dies in the build script before reaching this code. Standalone Kitware CMake is the fix and it's the `Mod-CMake` item in the install plan, not this PR.

**CI is the validation here:** `cargo test -p continuum-core --lib` and `cargo check windows-msvc (lib + tests)`.

## One correction for the record

The Windows job was reported as the failing one, breaking on `tests/memory_recall_accuracy.rs` with 12 type mismatches. Checked across 6 canary runs: **`cargo check windows-msvc (lib + tests)` passes every time.** The consistently red job is `cargo test -p continuum-core --lib`. Same conclusion — the gate is meaningless — but a different job and a different cause, which matters for whoever fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc