### PR TITLE
fix(lifecycle): `stop` reaps EVERY running core, not just the one the pidfile names

### DIFF
--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -1360,36 +1360,74 @@ async fn stop() -> Result<(), String> {
     let socket = socket_path();
     let pidfile = pidfile_for(&socket);
 
-    let mut stopped = false;
+    let mut pidfile_core: Option<i32> = None;
     if let Ok(contents) = std::fs::read_to_string(&pidfile) {
         if let Ok(pid) = contents.trim().parse::<i32>() {
             kill_pid_tree(pid);
-            stopped = true;
+            pidfile_core = Some(pid);
             println!("stopping core (pid {pid})");
         }
         let _ = std::fs::remove_file(&pidfile);
     }
+    let stopped = pidfile_core.is_some();
 
-    if !stopped {
-        // No pidfile (started another way). This fallback WAS `pkill -f
-        // continuum-core-server`, which does not exist on Windows: the spawn
-        // failed, `.unwrap_or(false)` swallowed it, and stop printed "no
-        // running core found" while the core was running — the identical bug,
-        // in the identical shape, to the `pgrep` one documented on
-        // `processes_named` a few hundred lines up. That fix ported the finder
-        // to sysinfo and missed this sibling call site, so a repaired function
-        // sat directly above an unrepaired twin. Same enumerator now, one
-        // implementation, both platforms.
-        let cores = running_core_pids();
-        if cores.is_empty() {
+    // The pidfile names ONE core. It is not evidence that only one is running.
+    //
+    // This sweep used to be gated behind `if !stopped` — a pidfile present meant
+    // "handled, nothing else to look for". Measured 2026-08-14: two cores were
+    // alive at once, both with /tmp/continuum-core.sock open (a debug build at
+    // 23:51 and the installed release at 23:54, the second having unlinked and
+    // re-bound the path). `stop` printed "stopping core (pid 70240)" — singular —
+    // reaped that one, and left the other serving. The `reap_owned_orphans` sweep
+    // below could not catch it either: ownership there is keyed on
+    // `~/.continuum/bin`, and a core built into the project's mandated
+    // CARGO_TARGET_DIR is not under that root, so a dev-built core is invisible to
+    // it by construction.
+    //
+    // A second core on this machine is never benign — whichever one the kernel
+    // hands a connection to is the one that answers, so a shipped fix can look
+    // intermittently broken and an unshipped one intermittently fixed. `stop`
+    // must therefore always enumerate, and must be LOUD about a survivor: an
+    // extra core is evidence of a lifecycle bug, exactly as an orphan is.
+    //
+    // (The enumerator itself was `pkill -f continuum-core-server`, which does not
+    // exist on Windows: the spawn failed, `.unwrap_or(false)` swallowed it, and
+    // stop printed "no running core found" while the core was running — the same
+    // shape as the `pgrep` bug documented on `processes_named` above. That fix
+    // ported the finder to sysinfo and missed this sibling call site.)
+    // Exclude the pidfile core: SIGTERM is asynchronous, so it is very likely
+    // still in the process table on the next line. Counting it here would report
+    // a SPLIT BRAIN on every ordinary stop — a false alarm on a message whose
+    // whole value is that it only fires when something is genuinely wrong.
+    let survivors: Vec<i32> = running_core_pids()
+        .into_iter()
+        .filter(|pid| Some(*pid) != pidfile_core)
+        .filter(|pid| pid_alive(*pid))
+        .collect();
+    if survivors.is_empty() {
+        if !stopped {
             println!("no running core found");
-        } else {
-            for pid in &cores {
-                kill_pid_tree(*pid);
-            }
+        }
+    } else {
+        if stopped {
+            println!(
+                "  SPLIT BRAIN: {} core(s) still running after the pidfile core was stopped \
+                 — reaping (pid(s) {})",
+                survivors.len(),
+                survivors
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+        }
+        for pid in &survivors {
+            kill_pid_tree(*pid);
+        }
+        if !stopped {
             println!(
                 "stopped continuum-core-server (pid(s) {})",
-                cores
+                survivors
                     .iter()
                     .map(|p| p.to_string())
                     .collect::<Vec<_>>()


### PR DESCRIPTION
## What was measured

Two `continuum-core-server` processes were alive at once, **both with `/tmp/continuum-core.sock` open**:

| pid | image | started |
|---|---|---|
| 68653 | `~/.continuum/cache/cargo-target/debug/continuum-core-server` | 23:51:35 |
| 70240 | `~/.continuum/bin/continuum-core-server` | 23:54:36 |

`continuum stop` printed `stopping core (pid 70240)` — **singular** — reaped that one, and left the other serving.

`deploy-verify` had already been reporting `pid(s) 70240,68653` — plural — but as a footnote inside a stale-binary message, so a split brain read as a version mismatch.

## Why the survivor was invisible to both sweeps

1. **The multi-core sweep was gated behind `if !stopped`.** A pidfile present meant "handled, stop looking". But the pidfile names ONE core; it is not evidence that only one is running.
2. **`reap_owned_orphans` keys ownership on `~/.continuum/bin`** (`owned_engine_orphans:994`). A core built into the project's own mandated `CARGO_TARGET_DIR` is not under that root, so **every dev-built core is un-reapable by construction** — which is exactly what the survivor was.

## Why a second core is never benign

Whichever core the kernel hands a connection to is the one that answers. A shipped fix can look intermittently broken and an unshipped one intermittently fixed — the worst possible debugging surface. Observed symptoms: two sets of personas heartbeating the same claims, a board row reading `Claimed` with `owner=- claim=- lease=-`, and duplicate Qwen2.5-VL lanes on 58091/58092 spawned ten seconds apart.

## The fix

After the pidfile core is killed, always enumerate `running_core_pids()` (name-based, already platform-correct) and reap anything left. The pidfile pid is excluded from that set because SIGTERM is asynchronous and would otherwise report a split brain on every ordinary stop — a false alarm on a message whose entire value is that it only fires when something is genuinely wrong.

## Live positive control

On a real split brain that reproduced on its own during this session (a core respawned between two stops):

```
stopping core (pid 29747)
  SPLIT BRAIN: 1 core(s) still running after the pidfile core was stopped — reaping (pid(s) 68653)
```

Both arms proven: the previously-dead pidfile-present path fired, and the false-positive guard held (29747, freshly SIGTERMed, was correctly not counted as a survivor). Verified afterwards that zero cores remained.

## Remaining half (tracked separately, not in this PR)

`start` still binds blindly. Every dispatched command auto-starts a core when nothing answers the socket (`dispatch` → `ensure_core_running`), so a core alive on an *orphaned inode* looks like "no core" and a fresh one is spawned — the loop that manufactured this state:

1. Core A holds the socket → 2. something rebinds the path, Core B gets a fresh inode → 3. pidfile names only B → 4. `stop` kills B, leaves A → 5. next command sees nothing answering, auto-starts C → **two cores again**.

This PR breaks the loop at step 4. Step 2 needs `start` to reclaim-or-refuse — the same shape #90 already uses for orphaned llama-server lanes, and the same missing constraint as airc #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo