### PR TITLE
fix(lifecycle): config.env reaches the core on EVERY launch path — the glass box was off by default on installed nodes

### DIFF
--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -1237,6 +1237,26 @@ async fn launch_core(wait_for_death: &[i32], policy: LaunchSource) -> Result<u64
             });
         }
     };
+    // ~/.continuum/config.env reaches the core on EVERY launch path, not just the
+    // scripted one.
+    //
+    // start-server.sh `source`s this file under `set -a`, so a core launched through
+    // the script inherits every key. The direct-exec path set none of them — the child
+    // simply inherited the calling CLI's environment. Measured 2026-08-14: a core
+    // auto-started by a dispatched command was running with the agent session's env
+    // (CLAUDECODE=1, CLAUDE_CODE_SESSION_ID=…) and NO `CONTINUUM_PROBE_DIR`, while
+    // config.env sets it on line 24 — so the glass box was OFF, silently, on an
+    // installed node. `ping`, `serving/status` and `deploy-verify` all read healthy;
+    // only `debug/probes/query` said otherwise, and only when asked.
+    //
+    // Applied BEFORE the explicit `.env()` calls below so per-launch facts (the socket
+    // this invocation is binding, the self-build guard) still win over the file, and in
+    // file order so duplicate assignments resolve last-wins exactly as `source` would.
+    // On the Script path the script re-sources the same file afterwards — same values,
+    // so this is idempotent there rather than a second source of truth.
+    for (k, v) in continuum_core::config_env::read_all() {
+        cmd.env(k, v);
+    }
     cmd.env("CONTINUUM_CORE_SOCKET", &socket)
         // We ARE the continuum binary. On Windows a running image cannot be
         // replaced, so letting the script `cargo build --bin continuum` fails the

--- a/core/continuum-core/src/config_env.rs
+++ b/core/continuum-core/src/config_env.rs
@@ -68,22 +68,53 @@ fn unquote(v: &str) -> String {
     v.to_string()
 }
 
-/// Path-taking core of [`read`] — testable without touching `$HOME`.
-pub fn read_from(path: &Path, key: &str) -> Option<String> {
-    let content = fs::read_to_string(path).ok()?;
-    let mut found = None;
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-        if let Some((k, v)) = trimmed.split_once('=') {
-            if k.trim() == key {
-                found = Some(unquote(v.trim()));
+/// Every assignment in the file, in file order, duplicates included.
+///
+/// Exists because the file has to reach a CHILD PROCESS, not just answer a
+/// single-key question. `tools/scripts/start-server.sh` gets that for free —
+/// it `source`s config.env under `set -a`, so a core launched through the
+/// script inherits every key. A core launched by exec'ing the installed binary
+/// got NONE of them, and instead inherited whatever environment the calling CLI
+/// happened to have. Measured 2026-08-14: a core auto-started from an agent
+/// session was running with that session's env and no `CONTINUUM_PROBE_DIR`,
+/// so the glass box was silently OFF on a node whose config.env sets it.
+///
+/// Order is preserved and duplicates are kept so the caller can apply them
+/// left-to-right and get shell `source` semantics (last assignment wins) from
+/// the application itself, rather than this function having to pick.
+pub fn read_all() -> Vec<(String, String)> {
+    config_path().map(|p| read_all_from(&p)).unwrap_or_default()
+}
+
+/// Path-taking core of [`read_all`] — testable without touching `$HOME`.
+/// THE parser for this format; [`read_from`] is a projection of it, so a fix to
+/// comment/quote handling can never apply to one reader and miss the other.
+pub fn read_all_from(path: &Path) -> Vec<(String, String)> {
+    let Ok(content) = fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return None;
             }
-        }
-    }
-    found
+            let (k, v) = trimmed.split_once('=')?;
+            Some((k.trim().to_string(), unquote(v.trim())))
+        })
+        .collect()
+}
+
+/// Path-taking core of [`read`] — testable without touching `$HOME`.
+/// Last assignment wins, matching the shell `source` semantics the bootstrap
+/// relies on.
+pub fn read_from(path: &Path, key: &str) -> Option<String> {
+    read_all_from(path)
+        .into_iter()
+        .filter(|(k, _)| k == key)
+        .next_back()
+        .map(|(_, v)| v)
 }
 
 /// Path-taking core of [`upsert`] — testable without touching `$HOME`. Writes
@@ -192,6 +223,54 @@ mod tests {
         static N: AtomicU64 = AtomicU64::new(0);
         let n = N.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!("continuum-config-env-test-{n}/config.env"))
+    }
+
+    /// What this catches: the file has to reach a CHILD PROCESS, not just answer one key. A core
+    /// launched by exec'ing the installed binary gets its environment from `read_all`; a core
+    /// launched via start-server.sh gets it from bash `source` under `set -a`. Those two must
+    /// agree, or the same node behaves differently depending on which verb started it — measured
+    /// 2026-08-14, when the exec path produced a core with NO `CONTINUUM_PROBE_DIR` (glass box
+    /// silently OFF) on a machine whose config.env sets it.
+    ///
+    /// Pins the three things a `source` consumer depends on: comments and blanks are skipped,
+    /// quotes are stripped the same way single-key reads strip them, and duplicate assignments
+    /// are KEPT IN ORDER so applying them left-to-right reproduces shell last-wins. Returning a
+    /// deduped map instead would silently pick a winner here and could disagree with `read_from`.
+    #[test]
+    fn read_all_reproduces_source_semantics_for_a_child_process() {
+        let p = tmp_config();
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(
+            &p,
+            "# comment\n\nA=1\nB='two'\nA=3\n  C=\"three\"  \n",
+        )
+        .unwrap();
+
+        let all = read_all_from(&p);
+        assert_eq!(
+            all,
+            vec![
+                ("A".to_string(), "1".to_string()),
+                ("B".to_string(), "two".to_string()),
+                ("A".to_string(), "3".to_string()),
+                ("C".to_string(), "three".to_string()),
+            ],
+            "file order preserved, duplicates kept, comments/blanks dropped, quotes stripped"
+        );
+
+        // The projection must agree with the parser it is built from: applying `all` in order
+        // leaves A=3, and that is exactly what a single-key read reports.
+        assert_eq!(read_from(&p, "A").as_deref(), Some("3"), "last assignment wins");
+        assert_eq!(read_from(&p, "B").as_deref(), Some("two"));
+        assert_eq!(read_from(&p, "missing"), None);
+    }
+
+    /// What this catches: a missing config.env must read as "no keys", never panic — a fresh
+    /// clone has no such file and still has to be able to launch a core (#291).
+    #[test]
+    fn read_all_on_a_missing_file_is_empty_not_a_panic() {
+        let p = tmp_config();
+        assert!(read_all_from(&p).is_empty());
     }
 
     /// What this catches: a Windows path written by the installer must survive being read back,


### PR DESCRIPTION
## The split

`launch_core` has two plans, and they were configuring two different systems:

| plan | how it starts the core | config.env |
|---|---|---|
| `LaunchPlan::Script` | `bash start-server.sh` | **sourced** under `set -a` — core inherits every key |
| `LaunchPlan::Installed` | `Command::new(server_bin)` | **never read** — child inherits only the calling CLI's env |

Both `start()` and `ensure_core_running()` — the auto-start every dispatched command passes through — use `Installed`. So on an installed node (the fresh-clone target of #291) the core comes up without config.env, and nothing says so.

## Measured

`~/.continuum/config.env:24` sets `CONTINUUM_PROBE_DIR`. The running core, started by that path, had **no `CONTINUUM_PROBE_*` at all**. `ps -Eww` showed it holding the environment of the agent session whose command auto-started it:

```
CLAUDECODE=1
CLAUDE_CODE_SESSION_ID=eeaaf632-3524-4ecb-bb1a-3ca88a22f414
```

(Instrument positive-controlled first — `ps -Eww` returns 39 `KEY=VAL` tokens for that pid, so the absence is real, not a blind reader.)

The probe ledger sat **byte-identical for five minutes** while serving was fully up — Devstral ready, window 26112, two lanes, `degraded_reason: null`. `serving.plan` alone re-emits at 1Hz (#399), so ~300 lines were missing.

`ping`, `serving/status` and `deploy-verify` all read healthy the whole time. The only surface that told the truth:

> *"the probe ledger is not being written: `CONTINUUM_PROBE_DIR` is unset, so the glass box is OFF and there is no history to search. This is a configuration state, NOT an empty result."*

That message is why this was findable at all, and it's the fail-loud doctrine working (contrast #348: `ok (6 checks clean)` while delivery was 100% down). But it fires on one debug verb, so a node can be blind for as long as nobody thinks to ask.

## The fix

Apply config.env to the child on **both** paths, through the existing Rust reader rather than a second parser.

`config_env::read_all` becomes THE parser for the format and `read_from` a projection of it — so a fix to comment or quote handling can't land on one reader and miss the other. Order preserved, duplicates kept, so applying left-to-right reproduces shell last-wins from the *application* rather than this function picking a winner that might disagree with a single-key read.

Applied **before** the explicit per-launch `.env()` calls, so the socket this invocation is binding and the self-build guard still win over the file. On the Script path the script re-sources the same file afterwards with the same values — idempotent there, not a competing source of truth.

## Tests

Two, in the existing `config_env` mod (never a second mod):
- source semantics for a child process — file order, kept duplicates, dropped comments, stripped quotes, and agreement between `read_all` and `read_from`
- a missing config.env reads as no keys rather than panicking (a fresh clone has no such file and still has to launch)

`cargo test -p continuum-core --lib config_env` → 9 passed.

## Deliberately not here (on #421 for a decision)

- The core arguably should not inherit **ambient caller environment at all** — a core auto-started from an agent session carrying `CLAUDE_CODE_*` is its own hazard. That's a design call, not a mechanical fix.
- Readiness surfaces should carry a `glass_box: on|off` fact so blindness is visible where people already look, instead of only on `debug/probes/query`.

Related: #291, #34 (config.env single-owner), #235, #420 (same file, same launch path, found in the same sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo