### PR TITLE
fix(tests): memory_recall_accuracy compiles again — 16 tests that ran NOWHERE for days (#407)

### DIFF
--- a/core/continuum-core/tests/memory_recall_accuracy.rs
+++ b/core/continuum-core/tests/memory_recall_accuracy.rs
@@ -10,6 +10,7 @@
 //! Test dataset: A persona's thought chain about learning Rust,
 //! with explicit tags forming an associative graph.
 
+use continuum_core::identity::PersonaRef;
 use continuum_core::memory::recall::{
     AssociativeRecallLayer, CoreRecallLayer, CrossContextLayer, DecayResurfaceLayer, RecallLayer,
     RecallQuery, SemanticRecallLayer, TemporalRecallLayer,
@@ -23,6 +24,21 @@ use std::sync::Arc;
 // ─── Test Harness ─────────────────────────────────────────────────────────────
 
 const PERSONA_ID: &str = "test-persona-recall";
+
+/// The fixture persona as the TYPED ref the memory API takes.
+///
+/// `load_corpus` / `multi_layer_recall` / `consciousness_context` moved from `&str`
+/// to `&PersonaRef` — an identity is a type, not loose text. This file kept handing
+/// them the bare literal and stopped compiling, which is only visible to a build that
+/// includes `--tests`: the macOS job runs `--lib`, so the red lived exclusively in the
+/// Windows column and read like a platform problem for days. It was neither Windows-
+/// specific nor a test failure — the test binary never compiled anywhere.
+///
+/// One constructor so the id itself still lives in exactly one place; the string is
+/// still `PERSONA_ID` for the struct fields that legitimately want a `String`.
+fn persona() -> PersonaRef {
+    PersonaRef(PERSONA_ID.to_string())
+}
 
 /// Create a test manager with deterministic embeddings.
 fn test_manager() -> PersonaMemoryManager {
@@ -187,7 +203,7 @@ fn load_standard_corpus(
     memories: Vec<CorpusMemory>,
     events: Vec<CorpusTimelineEvent>,
 ) {
-    manager.load_corpus(PERSONA_ID, memories, events);
+    manager.load_corpus(&persona(), memories, events);
 }
 
 /// Build a raw MemoryCorpus directly (for individual layer tests).
@@ -210,7 +226,7 @@ async fn test_roundtrip_corpus_load_and_recall() {
         max_results: 10,
         layers: None,
     };
-    let resp = manager.multi_layer_recall(PERSONA_ID, &req).await.unwrap();
+    let resp = manager.multi_layer_recall(&persona(), &req).await.unwrap();
 
     // Should find memories (core layer alone finds 3 with importance >= 0.8)
     assert!(
@@ -497,7 +513,7 @@ async fn test_multi_layer_convergence_boost() {
         layers: None,
     };
 
-    let resp = manager.multi_layer_recall(PERSONA_ID, &req).await.unwrap();
+    let resp = manager.multi_layer_recall(&persona(), &req).await.unwrap();
 
     assert!(
         !resp.memories.is_empty(),
@@ -558,7 +574,7 @@ async fn test_thought_chain_association() {
         layers: None,
     };
 
-    let resp = manager.multi_layer_recall(PERSONA_ID, &req).await.unwrap();
+    let resp = manager.multi_layer_recall(&persona(), &req).await.unwrap();
 
     // Top result should be about Rust memory/ownership/borrow concepts.
     let top_content = resp.memories[0].content.to_lowercase();
@@ -600,7 +616,7 @@ async fn test_unrelated_query_finds_correct_domain() {
         layers: None,
     };
 
-    let resp = manager.multi_layer_recall(PERSONA_ID, &req).await.unwrap();
+    let resp = manager.multi_layer_recall(&persona(), &req).await.unwrap();
 
     // Cooking memory should appear somewhere in results
     let has_pasta = resp.memories.iter().any(|m| m.content.contains("pasta"));
@@ -674,7 +690,7 @@ async fn test_recall_performance_with_many_memories() {
         max_results: 10,
         layers: None,
     };
-    let resp = manager.multi_layer_recall(PERSONA_ID, &req).await.unwrap();
+    let resp = manager.multi_layer_recall(&persona(), &req).await.unwrap();
     let elapsed = start.elapsed();
 
     assert!(
@@ -713,7 +729,7 @@ async fn test_corpus_load_response_counts() {
     let memories = build_thought_chain().await; // 6 memories, all with embeddings
     let events = build_timeline_events().await; // 2 events, both with embeddings
 
-    let resp = manager.load_corpus(PERSONA_ID, memories, events);
+    let resp = manager.load_corpus(&persona(), memories, events);
 
     assert_eq!(resp.memory_count, 6);
     assert_eq!(resp.embedded_memory_count, 6);
@@ -736,7 +752,7 @@ async fn test_recall_without_corpus_returns_error() {
     };
 
     let result = manager
-        .multi_layer_recall("nonexistent-persona", &req)
+        .multi_layer_recall(&PersonaRef("nonexistent-persona".to_string()), &req)
         .await;
     assert!(result.is_err(), "Recall without loaded corpus should error");
 }
@@ -758,7 +774,7 @@ async fn test_consciousness_context_with_cross_context_events() {
         skip_semantic_search: false,
     };
 
-    let resp = manager.consciousness_context(PERSONA_ID, &req).unwrap();
+    let resp = manager.consciousness_context(&persona(), &req).unwrap();
 
     // Should have cross-context events (from room-academy and room-kitchen)
     assert!(
@@ -801,7 +817,7 @@ async fn test_corpus_replacement_clears_old_data() {
                 .await,
         ),
     }];
-    manager.load_corpus(PERSONA_ID, initial, vec![]);
+    manager.load_corpus(&persona(), initial, vec![]);
 
     // Replace with new corpus
     let replacement = vec![CorpusMemory {
@@ -825,7 +841,7 @@ async fn test_corpus_replacement_clears_old_data() {
         },
         embedding: Some(provider.embed("This is the new replacement memory").await),
     }];
-    manager.load_corpus(PERSONA_ID, replacement, vec![]);
+    manager.load_corpus(&persona(), replacement, vec![]);
 
     // Recall should find new memory, not old
     let req = MultiLayerRecallRequest {
@@ -834,7 +850,7 @@ async fn test_corpus_replacement_clears_old_data() {
         max_results: 10,
         layers: None,
     };
-    let resp = manager.multi_layer_recall(PERSONA_ID, &req).await.unwrap();
+    let resp = manager.multi_layer_recall(&persona(), &req).await.unwrap();
 
     assert!(
         resp.memories.iter().all(|m| m.id != "old-memory"),


### PR DESCRIPTION
## What was actually broken

The memory API moved from `&str` to `&PersonaRef` — `load_corpus`, `multi_layer_recall` and `consciousness_context` all take the typed ref now. This test file kept handing them the bare `PERSONA_ID` literal, so the **test binary stopped compiling**: 12 × `E0308` across 12 call sites.

## Why it looked like a Windows problem and wasn't

| job | command | builds test binaries? |
|---|---|---|
| macOS | `cargo test -p continuum-core --lib` | **no** |
| Windows | `cargo check -p continuum-core --lib --tests` | **yes** |

Only the second builds `--tests`. So only Windows went red — for days, on every canary push — and the tracking card (#407) reads *"Continuum Windows CI has been RED."*

It was never Windows-specific, and it was never a failing test. The binary did not compile **on any platform**; `cargo check -p continuum-core --tests` reproduces all 12 errors on macOS in one command.

The part that matters: all 16 of these tests — semantic recall, associative recall by tags, cross-context, decay-resurface, multi-layer convergence, corpus replacement, recall performance — **had not executed anywhere**. A red Windows column reads as a platform quirk. What it actually meant was that a whole recall-accuracy suite was dark.

## The fix

One `persona()` constructor beside `PERSONA_ID`; the 12 sites pass `&persona()`. The id string still lives in exactly one place, and the six struct fields that legitimately want a `String` still use `PERSONA_ID.into()` — untouched. The one call that deliberately passes an unknown persona to assert an error keeps doing exactly that, now typed.

## Verified

```
cargo check -p continuum-core --tests          # clean (was 12 errors)
cargo test -p continuum-core --test memory_recall_accuracy
    16 passed; 0 failed
```

Compiling was not the bar — they pass.

## Scope

Only `core/continuum-core/tests/memory_recall_accuracy.rs`. Note for anyone reproducing: `cargo fmt -p continuum-core` reformats ~15 unrelated files on current canary, so the crate is not rustfmt-clean; that churn was reverted and is **not** in this diff.

Unblocks the Windows column for every open PR — it is the only failure on #2286, #2287 and #2288, none of which touch this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo