### PR TITLE
fix(observability): the room-gate abstain is a PROBE, not a tracing line masquerading as one

### DIFF
--- a/core/continuum-core/src/persona/rag_budget.rs
+++ b/core/continuum-core/src/persona/rag_budget.rs
@@ -184,13 +184,21 @@ impl RagContext {
 /// (`None`, legacy/test construction) and an unstamped ctx (`airc_room: None`,
 /// background consolidation) both keep pre-gate behavior. One logical decision,
 /// one place (the compression law); every abstain emits a probe naming both
-/// rooms so a mis-binding is diagnosable from the log, never a silent blank
-/// grounding block. [[identity-context-session-three-axes]]
+/// rooms so a mis-binding is diagnosable from the PROBE STREAM, never a silent
+/// blank grounding block. [[identity-context-session-three-axes]]
+///
+/// `probe!`, not `tracing::info!(probe_class = …)`. Glass-boxed 2026-08-14
+/// chasing the anchor_silent cascade (#346/#353/#264): this abstain WAS a bare
+/// `tracing::info!` carrying a `probe_class` field, which is the "tracing
+/// masquerading as a probe" move the concurrency guide forbids — it never
+/// reaches `~/.continuum/probes/`, so querying the probe stream for it returned
+/// a confident zero that meant nothing at all. An absence is only evidence when
+/// the instrument can produce a presence; this one couldn't.
 pub fn room_scope_allows(bound: Option<uuid::Uuid>, ctx: &RagContext, source_id: &str) -> bool {
     match (bound, ctx.airc_room.as_ref()) {
         (Some(b), Some(t)) if t.as_uuid() != b => {
-            tracing::info!(
-                probe_class = "rag.room_gate.abstain",
+            crate::probe!(
+                class = "rag.room_gate.abstain",
                 source = %source_id,
                 bound_room = %b,
                 turn_room = %t.as_uuid(),


### PR DESCRIPTION
## What

`room_scope_allows` — the ONE gate every room-scoped `RagSource` shares — emitted its abstain as `tracing::info!(probe_class = "rag.room_gate.abstain", …)`. A bare tracing line wearing a probe's field name. It never reached `~/.continuum/probes/`.

Now it goes through `probe!`, with both rooms named, and the doc comment records why it must stay one.

## Why this is worth a PR on its own

Found while glass-boxing the idle cascade (#346 / #353 / #264): two citizens announced they had nothing to contribute and went silent **while holding 9 and 11 live work claims**, leases renewed within the minute, on a board with 136 cards.

The board source never delivered (`anchor_silent` 7/7). The obvious hypothesis was a room mis-binding — the source is bound to `default_room` at bootstrap. Querying the probe stream for `room_gate` returned a clean zero.

That zero felt like evidence and was worth nothing: the emitter physically cannot write to the probe stream. The hypothesis was only genuinely disproven after positive-controlling a *different* instrument — 5,145 `probe_class` lines do reach the core log, and the abstain has 0 hits there, so the gate really never fired.

**An absence is evidence only when the instrument can produce a presence.** This one couldn't, so it manufactured a confident zero on the first question any debugger asks. That's the exact failure mode `CONCURRENCY-STYLE-GUIDE.md` lists as forbidden (`tracing::info!(target=…)` masquerading as a probe), sitting on the shared gate for every room-scoped source.

## Scope

Instrument only. Same predicate, same `false`, same fields — only the sink changes. The underlying cascade defect is **not** fixed here; it's narrowed on #346 to a wiring gap (the `room-kanban` source is never invoked on the compose path that ran, #162 brain-vs-legacy split) and left for a decision, since it touches a `🛑 STOP` file.

## Verified

`cargo check -p continuum-core --features metal,accelerate` clean — 144 pre-existing warnings, no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo