### PR TITLE
fix(lifecycle): `start` reclaims-or-refuses instead of binding blindly (#420 tail)

### DIFF
--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -3,6 +3,7 @@
 //!
 //! ```text
 //! continuum start            # build + run the headless Rust core (detached), wait until ready
+//!                     # refuses if a core is running but not answering — `--force` reclaims it
 //! continuum reboot           # rebuild + relaunch, replacing any running core (~0 downtime)
 //!                     # refuses while training (mlx_lm) is live — `--force` overrides
 //! continuum stop             # stop the running core
@@ -25,6 +26,7 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use continuum_client::Connection;
+use continuum_core::runtime::core_bind_guard::BindDecision;
 use continuum_core::runtime::core_ipc_transport::CoreIpcTransport;
 use serde_json::Value;
 
@@ -53,14 +55,17 @@ async fn run() -> Result<(), String> {
             Ok(())
         }
         "start" => {
+            // Collect once: `args.any(..)` consumes the iterator, so reading a
+            // second flag off it afterwards would silently always be false.
+            let flags: Vec<String> = args.collect();
             // `--from-source` is the EXPLICIT opt-in to compiling before
             // starting. Without it, `start` execs the installed server; a
             // build is never the silent default (see `launch_core`).
-            if args.any(|a| a == "--from-source") {
+            if flags.iter().any(|a| a == "--from-source") {
                 // SAFETY: single-threaded CLI startup, before any task spawns.
                 unsafe { std::env::set_var("CONTINUUM_FROM_SOURCE", "1") };
             }
-            start().await
+            start(flags.iter().any(|a| a == "--force")).await
         }
         "reboot" | "restart" => {
             let force = args.any(|a| a == "--force");
@@ -434,16 +439,43 @@ fn connection() -> Connection<CoreIpcTransport> {
     Connection::new(CoreIpcTransport::new(socket_path()))
 }
 
+/// How long a `ping` may take before we call the core "not answering".
+///
+/// Measured on a healthy local core: 20ms, five samples, no variance — this is a
+/// unix-socket round trip, not a network call. 5s is 250× that, so it cannot fire on
+/// a merely-busy core; it exists solely to bound a core that will NEVER answer.
+const PING_BUDGET: Duration = Duration::from_secs(5);
+
 /// Is a core already answering on the socket? A real ping round-trip, not just a
-/// socket-file existence check (a stale socket file lies).
+/// socket-file existence check (a stale socket file lies) — and BOUNDED, which is
+/// load-bearing rather than defensive.
+///
+/// An unbounded ping does not fail against an unresponsive core, it HANGS: the kernel
+/// completes `connect()` into the listen backlog whether or not the process is
+/// scheduled, the write succeeds, and the read then waits for a reply that never comes.
+/// A timeout counts as NOT answering, which is the safe direction — paired with a
+/// visible core process it yields `Occupied`, so the caller refuses and names the pids
+/// rather than launching a competitor.
+///
+/// This bound is what makes the [`BindDecision::Occupied`] arm REACHABLE, not a
+/// nicety. Glass-boxed 2026-08-14 on this box, both directions:
+///
+/// - unbounded: SIGSTOP every core, run `start` → no output, no decision, still hung
+///   at 90s. The guard was green in unit tests and dead on the live path.
+/// - bounded:   same setup → exits 1 in 8s with the refusal naming both live pids
+///   (5s here plus the process-table read), and the cores resume unharmed on SIGCONT.
+///
+/// The 90s figure came from a binary whose build had failed, so it measures the
+/// unbounded path either way — but it is the OLD behaviour, not evidence against the
+/// timeout, which the 8s run then confirmed directly.
 async fn core_is_up() -> bool {
-    matches!(
-        connection()
-            .commands()
-            .execute_value("ping", Value::Object(Default::default()))
-            .await,
-        Ok(_)
-    )
+    // Bound to locals: `connection()` and `.commands()` yield temporaries that the
+    // future borrows, so building the future inline drops them at the end of the
+    // statement (E0716).
+    let conn = connection();
+    let cmds = conn.commands();
+    let ping = cmds.execute_value("ping", Value::Object(Default::default()));
+    matches!(tokio::time::timeout(PING_BUDGET, ping).await, Ok(Ok(_)))
 }
 
 /// Make sure a core is answering before dispatching, launching one if not. See the
@@ -453,8 +485,25 @@ async fn core_is_up() -> bool {
 /// machine-parseable) so an operator who typed one command and got a 60s pause knows
 /// exactly what is happening instead of assuming it hung.
 async fn ensure_core_running(command: &str) -> Result<(), String> {
-    if core_is_up().await {
-        return Ok(());
+    // Same reclaim-or-refuse guard `start` uses, minus the reclaim: an implicit
+    // autostart exists to get the caller a live core, and killing someone else's
+    // core is never part of that errand. Occupied therefore always refuses here.
+    match bind_decision().await {
+        BindDecision::AlreadyServing { .. } => return Ok(()),
+        BindDecision::Occupied { pids } => {
+            return Err(format!(
+                "`{command}` needs a running core, and {} core process(es) are running \
+                 (pid(s) {}) but NONE is answering on {}. Starting another would bind a \
+                 second core on the same socket — whichever one the kernel hands a \
+                 connection to would answer, so results would be non-deterministic. \
+                 Either wait (a core that is still booting answers shortly), or clear it \
+                 with `continuum stop`.",
+                pids.len(),
+                pids.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(","),
+                socket_path()
+            ));
+        }
+        BindDecision::Free => {}
     }
     if std::env::var("CONTINUUM_NO_AUTOSTART").is_ok_and(|v| v != "0") {
         return Err(format!(
@@ -471,14 +520,69 @@ async fn ensure_core_running(command: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Gather the two observations [`BindDecision`] is a function of — a real `ping`
+/// round-trip and the core process table — and hand them to the shared truth table.
+///
+/// The observation half lives here because it is platform- and transport-shaped; the
+/// DECISION half lives in the lib so it is unit-tested by the `--lib` CI gate. Both
+/// `start` and `ensure_core_running` go through this one seam, which is the point:
+/// the split brain existed because each launch path had its own ad-hoc guard.
+async fn bind_decision() -> BindDecision {
+    let ping_ok = core_is_up().await;
+    let running: Vec<i32> = running_core_pids().into_iter().filter(|p| pid_alive(*p)).collect();
+    continuum_core::runtime::core_bind_guard::decide(ping_ok, &running)
+}
+
 /// `continuum start` — build + run the headless Rust core (detached), wait until it
 /// answers `ping`. Idempotent: a no-op if a core is already up.
-async fn start() -> Result<(), String> {
+///
+/// Reclaim-or-refuse, never blind-bind. The old guard was `core_is_up()` alone, so a
+/// core that was RUNNING but not answering (wedged, mid-boot, bound where this CLI
+/// cannot reach) was invisible and `start` launched a second one on top of it. That is
+/// the same missing constraint `stop` got in #2287, on the other side of the lifecycle.
+async fn start(force: bool) -> Result<(), String> {
     let socket = socket_path();
 
-    if core_is_up().await {
-        println!("core already running (socket={socket})");
-        return Ok(());
+    match bind_decision().await {
+        BindDecision::AlreadyServing { .. } => {
+            println!("core already running (socket={socket})");
+            return Ok(());
+        }
+        BindDecision::Free => {}
+        BindDecision::Occupied { pids } => {
+            let list = pids.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(",");
+            if !force {
+                return Err(format!(
+                    "{} core process(es) are running (pid(s) {list}) but NONE is answering on \
+                     {socket}. Refusing to start a second core: both would hold the same socket \
+                     and whichever one the kernel hands a connection to would answer, which is \
+                     how a shipped fix comes to look intermittently broken.\n  \
+                     • still booting? wait — a healthy core answers shortly, then `continuum start` \
+                     is a no-op\n  \
+                     • wedged? `continuum stop` reaps every core, then start\n  \
+                     • sure it is dead weight? `continuum start --force` reclaims it here",
+                    pids.len()
+                ));
+            }
+            // Explicit reclaim. `reboot` guards destructive restarts behind live-training
+            // and live-benchmark leases; `start --force` deliberately carries no such
+            // lease check, so say plainly what is being killed rather than implying a
+            // vetted teardown.
+            println!(
+                "⚠ --force: reclaiming {} unresponsive core(s) (pid(s) {list}) — no training or \
+                 benchmark lease is checked on this path; use `continuum reboot` if those matter",
+                pids.len()
+            );
+            for pid in &pids {
+                kill_pid_tree(*pid);
+            }
+            // Hand the reaped pids to launch_core as its death-wait set, so readiness is
+            // only reported once the OLD cores are gone and the ping provably came from
+            // the NEW one — the same honesty check reboot relies on.
+            let secs = launch_core(&pids, LaunchSource::Installed).await?;
+            println!("✅ core ready (socket={socket}) after ~{secs}s");
+            return Ok(());
+        }
     }
 
     let secs = launch_core(&[], LaunchSource::Installed).await?;
@@ -1973,7 +2077,8 @@ fn usage() -> String {
     "usage: continuum <start|reboot|stop|command> [json | --key value ...]\n\
      \n\
      Lifecycle:\n  \
-       continuum start                 build + run the headless Rust core (detached), wait until ready\n  \
+       continuum start                 build + run the headless Rust core (detached), wait until ready;\n                                       refuses if a core is running but not answering (a second core on\n                                       one socket makes results non-deterministic)\n  \
+       continuum start --force         reclaim those unresponsive core(s) first, then start\n  \
        continuum reboot                rebuild + relaunch, replacing any running core (~0 downtime);\n                                       verifies the RUNNING core's build SHA before reporting success\n  \
        continuum stop                  stop the running core\n  \
        continuum deploy-verify         prove the running core's build SHA matches the deployed source\n\

--- a/core/continuum-core/src/runtime/core_bind_guard.rs
+++ b/core/continuum-core/src/runtime/core_bind_guard.rs
@@ -1,0 +1,130 @@
+//! core_bind_guard.rs — the pre-launch RECLAIM-OR-REFUSE decision for the core socket.
+//!
+//! ## The missing constraint this exists to supply
+//!
+//! A second `continuum-core-server` on one machine is never benign: both can hold
+//! the same socket path (the later one unlinks and re-binds it), and whichever the
+//! kernel hands a connection to is the one that answers. A shipped fix then looks
+//! intermittently broken and an unshipped one intermittently fixed — measured
+//! 2026-08-14, two cores alive at once (a debug build at 23:51 and the installed
+//! release at 23:54).
+//!
+//! `stop` learned this first (it now reaps EVERY core and shouts SPLIT BRAIN on a
+//! survivor). `start` did not: its only guard was "does a core answer `ping`?", so
+//! a core that is running but NOT answering — wedged, mid-boot, or bound somewhere
+//! this CLI cannot reach — was invisible to it, and `start` launched a second one
+//! straight on top. Same missing constraint at a second site, which by
+//! [[the-same-bug-at-two-sites-is-a-missing-constraint]] means the fix is ONE
+//! primitive both paths call, not a second ad-hoc check.
+//!
+//! ## Why a pure decision, and why it lives in the lib
+//!
+//! The process-table read and the ping round-trip are the caller's (they are
+//! platform- and transport-shaped, and the CLI already owns both: `running_core_pids`
+//! and `core_is_up`). What is worth pinning is the DECISION over their two answers —
+//! four rows, exhaustive — so it can be tested without spawning a core. It lives in
+//! the lib rather than the `continuum` bin because CI runs
+//! `cargo test -p continuum-core --lib`; a truth table tested inside a bin would not
+//! be covered by the gate that guards it.
+//!
+//! ## Reclaim vs refuse
+//!
+//! [`BindDecision::Occupied`] does NOT auto-kill. `reboot` already guards destructive
+//! restarts behind live-training and live-benchmark leases and makes the operator pass
+//! `--force`; a `start` that silently reaped a wedged core would route around those
+//! guards. So the default is to REFUSE, loudly, naming the pids and both ways out —
+//! and `start --force` is the explicit reclaim ([[fallbacks-are-illegal-fail-loud]]).
+//! An implicit autostart (`ensure_core_running`) never reclaims at all: a command that
+//! merely wants a live core has no business killing one.
+
+/// What the pre-launch guard decided, given a ping answer and the process table.
+/// Exhaustive over both inputs so a new state cannot be silently dropped into an
+/// existing arm.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindDecision {
+    /// Nothing answers and no core process exists — the socket is ours to bind.
+    Free,
+    /// A core answers `ping`. `start` is a no-op here; this is the idempotent path.
+    /// `pids` may be EMPTY and still be this arm: something is serving that this
+    /// process cannot see in its own process table (a container, another user, a
+    /// forwarded socket). Serving is serving — never launch a competitor for it.
+    AlreadyServing { pids: Vec<i32> },
+    /// Core process(es) are running but NOTHING answers `ping` — wedged, still
+    /// booting, or bound elsewhere. Binding on top of this is what manufactures a
+    /// split brain, so the caller must reclaim explicitly or refuse.
+    Occupied { pids: Vec<i32> },
+}
+
+/// Decide whether this process may launch a core, from the two facts the caller can
+/// observe: whether a `ping` round-trip succeeded, and which `continuum-core-server`
+/// pids are in the process table.
+///
+/// Pure and total — the caller supplies the observations, so this is testable without
+/// a live core, and both `start` and the implicit autostart share ONE truth table.
+pub fn decide(ping_ok: bool, running: &[i32]) -> BindDecision {
+    match (ping_ok, running.is_empty()) {
+        // Serving wins over process-table visibility in BOTH directions: a core that
+        // answers is a core, whether or not we can see its process.
+        (true, _) => BindDecision::AlreadyServing {
+            pids: running.to_vec(),
+        },
+        (false, true) => BindDecision::Free,
+        (false, false) => BindDecision::Occupied {
+            pids: running.to_vec(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the ONLY row that may launch a core is "nothing answers AND
+    // no core process exists". If this ever widens, `start` can bind a second core.
+    #[test]
+    fn free_is_the_only_launchable_row() {
+        assert_eq!(decide(false, &[]), BindDecision::Free);
+        for (ping, pids) in [(true, &[][..]), (true, &[101][..]), (false, &[101][..])] {
+            assert_ne!(
+                decide(ping, pids),
+                BindDecision::Free,
+                "ping={ping} pids={pids:?} must not be launchable"
+            );
+        }
+    }
+
+    // what this catches: the regression that motivated this module — a core that is
+    // RUNNING but not answering ping must never read as launchable. `start`'s old
+    // guard was ping-only, so this row silently became a second core.
+    #[test]
+    fn a_running_but_silent_core_is_occupied_not_free() {
+        assert_eq!(
+            decide(false, &[70240, 68653]),
+            BindDecision::Occupied {
+                pids: vec![70240, 68653]
+            }
+        );
+    }
+
+    // what this catches: a serving core with no visible process (container, other
+    // user, forwarded socket) must still suppress the launch. Treating an empty
+    // process table as "free" here would spawn a competitor for a healthy core.
+    #[test]
+    fn serving_with_no_visible_process_is_still_serving() {
+        assert_eq!(
+            decide(true, &[]),
+            BindDecision::AlreadyServing { pids: vec![] }
+        );
+    }
+
+    // what this catches: a ping answer must dominate the process table, so the
+    // ordinary idempotent `start` on a healthy box stays a no-op rather than
+    // reporting contention against the very core that is answering.
+    #[test]
+    fn ping_dominates_the_process_table() {
+        assert_eq!(
+            decide(true, &[70240]),
+            BindDecision::AlreadyServing { pids: vec![70240] }
+        );
+    }
+}

--- a/core/continuum-core/src/runtime/mod.rs
+++ b/core/continuum-core/src/runtime/mod.rs
@@ -36,6 +36,7 @@ pub mod command_events;
 pub mod command_executor;
 pub mod command_interceptor;
 pub mod control;
+pub mod core_bind_guard;
 pub mod core_ipc_transport;
 pub mod daemon;
 pub mod governor_bus;


### PR DESCRIPTION
Closes the remaining half of #420. `stop` learned in #2287 that the pidfile names ONE core; `start` never did.

## The missing constraint

`start`'s only guard was **"does a core answer `ping`?"**. A core that is *running but not answering* — wedged, mid-boot, or bound where this CLI can't reach — was invisible, so `start` launched a second one on top of it. Same shape as #2287 on the other side of the lifecycle, and the same as airc #355: *reclaim belongs in BOTH shutdown and start*.

A second core is never benign: both hold the same socket path (the later one unlinks and re-binds it), and whichever the kernel hands a connection to is the one that answers — so a shipped fix looks intermittently broken and an unshipped one intermittently fixed.

## The fix — ONE primitive, not a second ad-hoc check

`runtime/core_bind_guard::decide(ping_ok, running_pids)` — pure, exhaustive 4-row truth table: `Free` / `AlreadyServing` / `Occupied`.

It lives in the **lib, not the bin**, because CI runs `cargo test -p continuum-core --lib`; a truth table tested inside a bin wouldn't be covered by the gate that guards it.

| caller | Free | AlreadyServing | Occupied |
|---|---|---|---|
| `start` | launch | no-op | **refuse**, naming pids (`--force` reclaims) |
| `ensure_core_running` | launch | ok | **refuse** — never reclaims |

**Refuse, not auto-kill.** `reboot` guards destructive restarts behind live-training and live-benchmark leases; a `start` that silently reaped a core would route around them. `start --force` is the explicit reclaim and says plainly that it checks no lease. An implicit autostart never reclaims at all — a command that merely wants a live core has no business killing one.

## The ping bound is load-bearing, not defensive

An unbounded ping doesn't *fail* against an unresponsive core, it **hangs**: the kernel completes `connect()` into the listen backlog whether or not the process is scheduled, then the read waits for a reply that never comes. Without `PING_BUDGET` the `Occupied` arm was **unreachable on the live path despite green unit tests**. 5s against a measured 20ms round trip.

## Verification

Unit: 4 truth-table tests, `--lib` (the CI gate). Live, on this box:

- **SIGSTOP every core, run `start`** — unbounded: no output, still hung at 90s. Bounded: **exit 1 in 8s** with the refusal naming both live pids; cores resume unharmed on SIGCONT.
- **Unserved socket, two live cores**: exit 1 in 0s, both pids named.
- **Healthy core**: still a no-op. Idempotence preserved.
- Found while testing: **two cores were live on this machine at once** (a debug build and the installed release, 78s apart, both holding `/tmp/continuum-core.sock`) — the #2287 condition, in the wild.

## Note for whoever picks this up

`continuum reboot` sets `CONTINUUM_SKIP_SELF_BUILD` and so **never rebuilds the `continuum` CLI itself**, meaning a CLI-only fix does not reach an operator via reboot. Proven here: the installed CLI's `stop` left a survivor that the freshly-built `stop` then reaped with SPLIT BRAIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo