### PR TITLE
fix(lifecycle): reboot rebuilds the CLI wherever the image is replaceable (#422)

### DIFF
--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -28,7 +28,9 @@ use std::time::Duration;
 use continuum_client::Connection;
 use continuum_core::runtime::core_bind_guard::BindDecision;
 use continuum_core::runtime::core_ipc_transport::CoreIpcTransport;
-use continuum_core::runtime::deploy_provenance::{cli_staleness_note, deploy_verdict};
+use continuum_core::runtime::deploy_provenance::{
+    cli_self_build, cli_staleness_note, deploy_verdict, CliSelfBuild,
+};
 use serde_json::Value;
 
 /// Where `continuum start` records the detached core's PID so `continuum stop` can find it.
@@ -1324,14 +1326,23 @@ async fn launch_core(wait_for_death: &[i32], policy: LaunchSource) -> Result<u64
     for (k, v) in continuum_core::config_env::read_all() {
         cmd.env(k, v);
     }
+    // We ARE the continuum binary — may this deploy rebuild our own image?
+    //
+    // The guard below used to be unconditional, and that is the whole of #422: a
+    // Windows file-locking accommodation charged to every platform, which made the
+    // documented deploy path structurally unable to ship a fix living in the CLI.
+    // The decision now names the ONE platform it is for; everywhere else the script
+    // builds the CLI and installs it with the temp+mv swap it already performs.
+    match cli_self_build(std::env::consts::OS) {
+        CliSelfBuild::Rebuild => {}
+        CliSelfBuild::Skip { reason } => {
+            // Say it out loud. A skipped build that looks like a completed one is how
+            // stale binaries survive a "successful" deploy — #194, one tier up.
+            eprintln!("▶ {reason}");
+            cmd.env("CONTINUUM_SKIP_SELF_BUILD", "1");
+        }
+    }
     cmd.env("CONTINUUM_CORE_SOCKET", &socket)
-        // We ARE the continuum binary. On Windows a running image cannot be
-        // replaced, so letting the script `cargo build --bin continuum` fails the
-        // whole cargo invocation, skips every later build (including the CORE),
-        // and `reboot` dies after its full timeout having rebuilt nothing —
-        // measured 772s to that failure on BIGMAMA. Tell the script to leave our
-        // own image alone; it still rebuilds the core, which is reboot's contract.
-        .env("CONTINUUM_SKIP_SELF_BUILD", "1")
         .stdin(Stdio::null())
         .stdout(Stdio::from(log))
         .stderr(Stdio::from(log_err));

--- a/core/continuum-core/src/runtime/deploy_provenance.rs
+++ b/core/continuum-core/src/runtime/deploy_provenance.rs
@@ -118,6 +118,64 @@ pub fn cli_staleness_note(
     ))
 }
 
+/// Whether this deploy may rebuild the `continuum` CLI in place — see [`cli_self_build`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CliSelfBuild {
+    /// Rebuild it. Replacing the FILE of a running executable is legal here, so the
+    /// deploy loop can close itself with no operator step.
+    Rebuild,
+    /// Skip it, and print `reason`. A running image is locked on this platform, so
+    /// building over it fails the whole cargo invocation and takes the CORE build down
+    /// with it.
+    Skip { reason: String },
+}
+
+/// May `reboot` rebuild the CLI it is running from, on `target_os`
+/// ([`std::env::consts::OS`])?
+///
+/// ## The bug this fixes: a platform guard applied to every platform
+///
+/// `reboot` sets `CONTINUUM_SKIP_SELF_BUILD=1` unconditionally, and `start-server.sh`
+/// then skips the CLI build. That guard exists for exactly ONE constraint, stated in its
+/// own comment: Windows LOCKS a running image, so `cargo build --bin continuum` from
+/// inside the running `continuum` fails with `failed to remove file ...\continuum.exe`,
+/// cargo returns non-zero for the WHOLE invocation, every later build is skipped — the
+/// CORE included — and reboot dies after its full timeout having rebuilt nothing
+/// (measured 772s on BIGMAMA, 2026-08-05). Real, and worth guarding.
+///
+/// But the same comment also records that on Unix it "silently works: unlink leaves the
+/// running inode" — and the guard was applied there anyway. That is the whole of #422:
+/// a Windows accommodation charged to every operator, making the documented deploy path
+/// (`edit → reboot → exercise`) structurally unable to ship a fix that lives in the CLI.
+/// Measured on this machine 2026-08-14: `stop`'s split-brain reap (#2287) had merged and
+/// had NOT reached the installed CLI, which left a core alive and silent — while
+/// `deploy-verify` printed its green checkmark, because it only looked at the core.
+///
+/// Nothing else was missing. `start-server.sh` already installs the built CLI into
+/// `~/.local/bin` with a temp+`mv` atomic swap, and does it OUTSIDE this guard — so on a
+/// Rebuild platform the loop closes with no new verb and no new swap machinery. And the
+/// running image is normally the `~/.local/bin` COPY, not the target-dir binary cargo
+/// replaces, so even the Unix inode trick is a second line of defence rather than the
+/// first.
+///
+/// Pure, and takes the OS as a parameter rather than reading `cfg!`, so BOTH rows are
+/// tested from any host — the Windows row is the one no Mac CI job would otherwise cover.
+pub fn cli_self_build(target_os: &str) -> CliSelfBuild {
+    // Allow-list the platform whose constraint is real, rather than deny-listing the
+    // ones known safe: a future target that locks running images should inherit the
+    // SKIP, not silently inherit the breakage ([[fallbacks-are-illegal-fail-loud]]).
+    if target_os == "windows" {
+        return CliSelfBuild::Skip {
+            reason: "skipping the continuum CLI build — Windows locks a running image, and \
+                     building over it would fail the whole cargo invocation and skip the CORE \
+                     build too. The CORE is still rebuilt. A CLI-side fix is NOT deployed by \
+                     this reboot: reinstall the CLI separately (#422)."
+                .to_string(),
+        };
+    }
+    CliSelfBuild::Rebuild
+}
+
 /// Two short/long git SHAs refer to the same commit when one prefixes the other (git's
 /// `--short` abbreviation length varies over a repo's life). Both must be real hex SHAs of
 /// credible length — never matches `""` or `"unknown"`.
@@ -210,6 +268,32 @@ mod tests {
                 !note.contains("STALE CLI"),
                 "never assert staleness it cannot prove: {note}"
             );
+        }
+    }
+
+    // what this catches: #422 in both directions. The self-build guard is a WINDOWS
+    // file-locking accommodation (building over a locked image fails the whole cargo
+    // invocation and takes the CORE build with it — 772s to failure on BIGMAMA); it was
+    // applied on every platform, which is what made `reboot` structurally unable to ship
+    // a CLI-side fix anywhere. Widening the Skip row back to Unix re-opens that gap
+    // silently; narrowing it to nothing re-breaks Windows reboot outright. The skip must
+    // also SAY it did not deploy the CLI — a silent skip that reads as a completed deploy
+    // is exactly how the stale CLI survived a green deploy-verify.
+    #[test]
+    fn only_a_platform_that_locks_running_images_skips_the_cli_build() {
+        for os in ["macos", "linux", "freebsd"] {
+            assert_eq!(
+                cli_self_build(os),
+                CliSelfBuild::Rebuild,
+                "{os} can replace a running executable's file — reboot must close the loop"
+            );
+        }
+
+        let CliSelfBuild::Skip { reason } = cli_self_build("windows") else {
+            panic!("windows locks a running image — building over it kills the CORE build too");
+        };
+        for needle in ["Windows", "CORE is still rebuilt", "NOT deployed", "#422"] {
+            assert!(reason.contains(needle), "skip reason names {needle}: {reason}");
         }
     }
 

--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -91,17 +91,35 @@ source "$SCRIPT_DIR/lib/windows-build-env.sh"
 # ── Per-platform feature flags ───────────────────────────────────────
 # Mac Intel can't use Metal (task #131 — ggml_metal_device_init hangs on
 # Intel + AMD discrete). Force mac-cpu-only on Intel Mac.
+#
+# CONTINUUM_CLI_FEATURES is the GPU-FREE set for the `continuum` CLI, which is a
+# socket client and must never link a GPU runtime (see the CLI build below for why
+# that made it unlaunchable on Windows). It is platform-shaped for the same reason
+# the core's set is: a bare `--no-default-features` is NOT GPU-free-and-buildable
+# everywhere. On macOS the unconditional `llama` dependency fires
+#
+#   compile_error!("llama crate built on macOS WITHOUT `--features metal`")
+#
+# so the plain flag has NEVER produced a CLI on a Mac — every `npm start` since it
+# landed has hit the loud "⚠ GPU-free continuum build failed — retrying with the
+# full feature set … Please report this" fallback, and shipped a GPU-linked CLI
+# while reporting an anomaly nobody reported. `llama/mac-cpu-only` is that guard's
+# OWN declared opt-in for a deliberately CPU-only build, which is exactly what a
+# socket client wants.
 case "$(uname -sm)" in
   "Darwin x86_64")
     CONTINUUM_FEATURES="--no-default-features --features livekit-webrtc,llama/mac-cpu-only"
+    CONTINUUM_CLI_FEATURES="--no-default-features --features llama/mac-cpu-only"
     ;;
   "Darwin arm64")
     CONTINUUM_FEATURES="--features metal,accelerate"
+    CONTINUUM_CLI_FEATURES="--no-default-features --features llama/mac-cpu-only"
     ;;
   *)
     # Source the existing detector for Linux/Windows.
     source "$SCRIPT_DIR/shared/cargo-features.sh"
     CONTINUUM_FEATURES="$CARGO_GPU_FEATURES"
+    CONTINUUM_CLI_FEATURES="--no-default-features"
     ;;
 esac
 
@@ -330,9 +348,15 @@ cargo build --manifest-path "$CORE_MANIFEST" --bin continuum-mcp $PROFILE_FLAG $
 # is why reboot has never worked on Windows — the verb was trying to overwrite
 # itself mid-run. (On Unix it silently works: unlink leaves the running inode.)
 #
-# The caller sets CONTINUUM_SKIP_SELF_BUILD when it IS the continuum binary.
-# reboot's contract is "rebuild + relaunch the CORE"; the CLI on PATH is installed
-# by `npm start` / install.sh, which do not run from inside it. Skipping is stated
+# The caller sets CONTINUUM_SKIP_SELF_BUILD when it IS the continuum binary AND the
+# platform locks a running image — `runtime::deploy_provenance::cli_self_build` owns
+# that decision and is unit-tested on both rows. It used to be set unconditionally,
+# which charged this Windows-only constraint to every operator and made `reboot`
+# structurally unable to ship a fix living in the CLI (#422): proven on a Mac
+# 2026-08-14, when `stop`'s split-brain reap had merged and the installed CLI still
+# did not have it, leaving a core alive and silent under a green deploy-verify.
+# Where the image is replaceable the build below runs and the install further down
+# swaps it in, so the deploy loop closes with no operator step. Skipping is stated
 # out loud, never silent — a skipped build that looks like a completed one is how
 # stale binaries survive a "successful" deploy.
 if [ -n "${CONTINUUM_SKIP_SELF_BUILD:-}" ]; then
@@ -368,7 +392,7 @@ else
   # platform, the featured build still produces a working CLI on that platform,
   # and the warning names exactly what the user gets instead.
   echo "▶ building continuum (Rust CLI client — GPU-free: it is a socket client)"
-  if ! cargo build --manifest-path "$CORE_MANIFEST" --bin continuum $PROFILE_FLAG --no-default-features; then
+  if ! cargo build --manifest-path "$CORE_MANIFEST" --bin continuum $PROFILE_FLAG $CONTINUUM_CLI_FEATURES; then
     echo "⚠ GPU-free continuum build failed — retrying with the full feature set." >&2
     echo "  The CLI will then carry GPU link deps and may fail to launch on a box" >&2
     echo "  without a matching CUDA runtime on PATH. Please report this." >&2
@@ -393,7 +417,7 @@ CONTINUUM_CLI_BIN="$CARGO_TARGET_DIR/$PROFILE_LABEL/continuum"
 # disk — restore it so the copy below has real bytes. Non-fatal (matches the
 # build's own warn): a missing CLI doesn't block core boot, and the installed
 # ~/.local/bin copy from the last deploy keeps working.
-if ! ensure_unswept_bin "$CONTINUUM_CLI_BIN" continuum "$CORE_MANIFEST" $PROFILE_FLAG $CONTINUUM_FEATURES; then
+if ! ensure_unswept_bin "$CONTINUUM_CLI_BIN" continuum "$CORE_MANIFEST" $PROFILE_FLAG $CONTINUUM_CLI_FEATURES; then
   echo "⚠ continuum CLI still missing after swept-cache rebuild — CLI install skipped (core still launches)" >&2
 fi
 if [ -x "$CONTINUUM_CLI_BIN" ]; then


### PR DESCRIPTION
Closes the remaining half of #422. The visibility half (deploy-verify can *see* a stale CLI) shipped in #2292; this is the rebuild itself.

## What this was, and why it was never a design fork

I had #422's fix parked as a three-way choice (side-path build + atomic swap / a new `self-update` verb / visibility only). Reading `start-server.sh` collapsed it. Two facts settle it:

1. **The install machinery already exists and already runs on every reboot.** `start-server.sh:399-424` copies the built CLI into `~/.local/bin` with a temp+`mv` atomic swap — and it does that **outside** the self-build guard. The only thing missing was the *build* of the binary it copies.
2. **The guard encodes exactly one constraint, and it isn't universal.** From its own comment:

   > Windows LOCKS a running image … cargo returns non-zero for the WHOLE invocation. Every later build in this script is skipped, continuum-core-server is never rebuilt … **(On Unix it silently works: unlink leaves the running inode.)**

   The Windows half is real and measured (772s to failure on BIGMAMA). The Unix half was written down and then guarded anyway.

So this is a **platform-blind guard**, not a missing feature. On macOS/Linux the deploy loop closes with no new verb and no new swap machinery. Doubly so, since the running image is normally the `~/.local/bin` *copy*, not the target-dir binary cargo replaces.

## The change

`runtime::deploy_provenance::cli_self_build(target_os) -> CliSelfBuild::{Rebuild, Skip{reason}}` owns the decision and names the one platform it's for. It takes the OS as a **parameter** rather than reading `cfg!`, so both rows are unit-tested from any host — the Windows row is the one no Mac CI job would otherwise cover. Allow-list, not deny-list: a future target that locks running images inherits the Skip, not the breakage.

On Skip the CLI says out loud that a CLI-side fix is **not** deployed. A silent skip that reads as a completed deploy is how the stale CLI survived a green deploy-verify in the first place — #194 one tier up.

## Second defect, fixed here because enabling the build walks straight into it

The CLI's "GPU-free" flag was a bare `--no-default-features`. On macOS that **always** fails: `metal` is not a default feature and `llama` is an unconditional path dependency, so the llama crate's `compile_error!("built on macOS WITHOUT --features metal")` fires.

**The GPU-free CLI build has therefore never once succeeded on a Mac.** Every `npm start` since it landed hit the loud `⚠ GPU-free continuum build failed — retrying with the full feature set … Please report this` fallback, shipped a GPU-linked CLI, and reported an anomaly nobody reported. Without fixing it, this PR would fire that false alarm on every reboot.

`CONTINUUM_CLI_FEATURES` is now platform-shaped like the core's set already was, using `llama/mac-cpu-only` — that guard's own declared opt-in for a deliberately CPU-only build, which is exactly what a socket client wants. Verified locally: `cargo check --bin continuum --no-default-features --features llama/mac-cpu-only` compiles clean in 1m45s.

Also repointed the swept-cache CLI restore (the #296 path) from `CONTINUUM_FEATURES` to `CONTINUUM_CLI_FEATURES` — it was rebuilding the CLI **with** GPU deps, re-creating the exact Windows-unlaunchable bug (0 bytes of output, exit 127, on a CUDA-version mismatch) that the GPU-free build exists to prevent.

## Verification

- `cargo test -p continuum-core --lib … deploy_provenance` → **5/5 pass**, including the new `only_a_platform_that_locks_running_images_skips_the_cli_build` (both rows). Under the `--lib` gate CI actually runs.
- `cargo check --bin continuum` with the new macOS feature set → clean.
- Windows behaviour is unchanged by construction: same env var, same skip, now with a louder reason.

## Not claimed

The end-to-end live proof — reboot on this Mac, then confirm `deploy-verify` stops printing the `⚠ STALE CLI (#422)` note it currently prints — is **not** in this PR. Citizens are live and one has already objected to reboot-driven churn; I'm not cycling the box for it while a benchmark round is in flight. The note from #2292 is the instrument that will confirm it on the next legitimate reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo