### PR TITLE
fix(security): gitignore guards for the #424 credential-debris class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,17 @@ benchmarks/swe/.venv/
 /core/wordstats*
 /core/sample.txt
 /core/reverse*
+
+# Agent/persona scratch workspaces at the REPO ROOT (`work-<card>/`,
+# `work-team-<name>/`) — same debris class as /core/work-*/ above, minted by
+# agent sessions whose shell CWD was the checkout. The 2026-08-14 audit found
+# one carrying a live `.airc/identity.key` (card #424); the dirs were
+# quarantined and the key destroyed. Persona hands now root at the citizen
+# layer (`ensure_engine` — never the checkout), so anything matching this at
+# root is escaped debris, never repo content.
+/work-*/
+# A nested airc scope's credential must NEVER be trackable, anywhere in the
+# tree. The root `.airc/*` rule above is anchored and does not cover scopes
+# minted inside subdirectories (that is exactly how the #424 key nearly
+# became repo content).
+**/.airc/identity.key


### PR DESCRIPTION
Closes the guard gap behind the 2026-08-14 credential-workspace leak (audit card #424): an escaped agent workspace at repo root (`work-team-wordstats/`) carried a live `.airc/identity.key` and required manual quarantine because git offered no protection.

Two rules, both positive-controlled with `git check-ignore`:
- `/work-*/` — root-level agent/persona scratch dirs can never be tracked (mirrors the existing `/core/work-*/`)
- `**/.airc/identity.key` — a nested airc scope's credential is untrackable anywhere in the tree (the root-anchored `.airc/*` rule never covered nested scopes)

Root `.airc` whitelist (POLICY.md, manifest.json) verified unaffected. Substrate half already fixed in-tree (`ensure_engine` citizen-layer rooting + `ensure_shell` follows the engine root). Quarantine deleted and key destroyed per owner authorization; the enrolled peers are tier=untrusted, so no live trust referenced the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo