### PR TITLE
feat(cognition): receipt proprioception archive — act history survives the ring (#414 option b)

### DIFF
--- a/core/continuum-core/src/cognition/context_budget.rs
+++ b/core/continuum-core/src/cognition/context_budget.rs
@@ -229,6 +229,37 @@ impl ContextBudget {
     pub fn echoed_arg_chars(&self) -> usize {
         self.fraction(64)
     }
+
+    /// Total char share of the PROPRIOCEPTION RECEIPT ARCHIVE — the receipts-ONLY ring in
+    /// [`WorkingMemory`](super::working_memory::WorkingMemory) that makes act history
+    /// survive the chatty shared window (#414 option b). The shared trail evicts by entry
+    /// count and receipts are RARE entries in it, so a citizen with thousands of executed
+    /// acts perceived ONE (measured 2026-08-14: Asha, 2,863 acts, one visible, "+2862
+    /// aged out" — and she read that starvation as "I have nothing to contribute"). The
+    /// archive stores each receipt's HEAD LINE only, so 1/16 of the window holds tens of
+    /// acts on a 16k lane and hundreds on a big one.
+    ///
+    /// Unknown window → the `MIN_SERVE_CTX` floor share, not "no bound": this bounds a
+    /// STORED buffer, and (per [`Self::working_memory_steps`]'s precedent) an unbounded
+    /// buffer is not an honest no-bound — it is a leak.
+    pub fn receipt_archive_chars(&self) -> usize {
+        match self.total_chars {
+            Some(_) => self.fraction(16),
+            None => {
+                Self::from_window(crate::cognition::serving_plan::MIN_SERVE_CTX).fraction(16)
+            }
+        }
+    }
+
+    /// The steps-taken LEDGER's rendered share — how much of the receipt archive the
+    /// perception fact re-injects per turn. One trail-head-equivalent (`1/64`): head
+    /// lines only, newest first to fit, so the ledger shows a citizen her recent act
+    /// HISTORY without re-creating the double-payment the #324 dedup removed. Render
+    /// bound, not storage: unknown window keeps the honest no-bound (the deliberation
+    /// guard trims downstream), same contract as [`Self::trail_head_chars`].
+    pub fn steps_ledger_chars(&self) -> usize {
+        self.fraction(TRAIL_HEAD_DENOM)
+    }
 }
 
 #[cfg(test)]

--- a/core/continuum-core/src/cognition/perception_facts.rs
+++ b/core/continuum-core/src/cognition/perception_facts.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use super::deliberation_budget::{
     inbound_restates_fact, own_repetition_fact, peer_echo_fact, template_loop_fact,
 };
-use super::working_memory::{WmKind, WorkingMemory};
+use super::working_memory::WorkingMemory;
 use super::workspace::BurstTurn;
 
 /// Everything a fact may look at when deciding whether it applies this tick.
@@ -173,27 +173,38 @@ impl PerceptionFact for StepsLedger {
         // result body — already renders once, in the working-memory TRAILING
         // channel nearest generation. This ledger's job is the session'S ACT
         // HISTORY as a fact ("what has actually executed"), so it lists each
-        // step's head line (`[action #n] name(args)`) and nothing more. Before
-        // this, both channels carried the full bodies and every receipt was
-        // paid twice on a 16k window (measured: the ledger was a byte-level
-        // duplicate of the WM tail).
-        let steps: Vec<String> = wm
-            .recent_entries()
-            .into_iter()
-            .filter(|e| matches!(e.kind, WmKind::Receipt { .. }))
-            .map(|e| e.text.lines().next().unwrap_or_default().to_string())
-            .collect();
-        // Receipts are RARE entries in a chatty capacity-bounded ring, so
-        // they age out while the session's act counter keeps counting.
-        // Three states, each honest (glass-boxed 2026-07-13: Asha's window
-        // held 3 silence Facts and zero Receipts minutes after real
-        // searches ran — the old zero-case would have DENIED her own acts,
-        // the inverse of the confabulation shelter):
-        //   receipts visible  → list them (+ how many aged out, if any)
+        // step's head line (`[action #n] name(args)`) and nothing more.
+        //
+        // Rendered from the receipts-ONLY archive, never the shared ring (#414
+        // option b). The ring evicts by entry count and receipts are its RARE
+        // kind, so filtering it here starved a 2,863-act citizen down to ONE
+        // visible act — and with her history invisible she concluded she had
+        // nothing to contribute (the withdrawal loop's deprivation mechanism,
+        // measured 2026-08-14). The archive keeps every act's head line inside
+        // a window-derived char share; the ledger shows its newest tail that
+        // fits the ledger's own share, so history depth scales with the lane.
+        let archive = wm.receipt_archive();
+        let render_budget = wm.budget().steps_ledger_chars();
+        let mut fit: Vec<&str> = Vec::new();
+        let mut used = 0usize;
+        for line in archive.iter().rev() {
+            let cost = line.chars().count() + 1;
+            if !fit.is_empty() && used + cost > render_budget {
+                break;
+            }
+            used += cost;
+            fit.push(line.as_str());
+        }
+        fit.reverse();
+        // The act counter keeps counting past what the archive holds (and
+        // survives reboots that predate the archive). Three states, each
+        // honest (glass-boxed 2026-07-13: the old zero-case would have DENIED
+        // a citizen's own acts, the inverse of the confabulation shelter):
+        //   heads render      → list them (+ how many are beyond reach)
         //   none, count == 0  → the explicit nothing-has-executed void
-        //   none, count  > 0  → acts happened; details aged out — say so
+        //   none, count  > 0  → acts happened; details are gone — say so
         let taken = wm.actions_taken();
-        Some(if steps.is_empty() {
+        Some(if fit.is_empty() {
             if taken == 0 {
                 "[steps taken this session]\n(nothing has executed yet — anything described as already run, created, tested, committed, or merged does not exist, whether in the messages you can see or before them; running a tool is what makes it real)".to_string()
             } else {
@@ -207,18 +218,20 @@ impl PerceptionFact for StepsLedger {
                 // reach for what the substrate had put out of reach: a lying
                 // receipt of the #151/#357 class, in the fact whose whole job is
                 // ground truth. State the loss plainly instead; an honest gap she
-                // can plan around beats a door that isn't there (#414).
+                // can plan around beats a door that isn't there (#414). This arm
+                // is now the PRE-ARCHIVE remnant: it renders only when the
+                // counter survived a snapshot written before the archive existed.
                 format!(
                     "[steps taken this session]\n({taken} step{} executed earlier this session — you did that work; the details aged out of working memory and cannot be retrieved, so re-check the workspace or the board rather than trusting memory of them. Nothing NEW has executed since.)",
                     if taken == 1 { "" } else { "s" }
                 )
             }
         } else {
-            let aged = taken.saturating_sub(steps.len() as u64);
-            let mut ledger = format!("[steps taken this session]\n{}", steps.join("\n"));
+            let aged = taken.saturating_sub(fit.len() as u64);
+            let mut ledger = format!("[steps taken this session]\n{}", fit.join("\n"));
             if aged > 0 {
                 ledger.push_str(&format!(
-                    "\n(+{aged} earlier step{} aged out of working memory)",
+                    "\n(+{aged} earlier step{} before what this ledger shows)",
                     if aged == 1 { "" } else { "s" }
                 ));
             }
@@ -362,28 +375,61 @@ mod tests {
         assert!(l.contains("code/shell(ls)"));
         assert!(!l.contains("nothing has executed yet"));
 
-        // State 3: chatty facts flood the tiny ring until the receipt ages
-        // out — the counter still knows one act happened. The ledger must
-        // NOT claim nothing executed.
+        // State 3: chatty facts flood the tiny ring until the receipt's ring
+        // ENTRY ages out — and the ledger still lists it, because it renders
+        // from the receipts-only archive, not the shared ring. This is the
+        // #414 fix itself: the deprivation that starved a 2,863-act citizen
+        // down to one visible act was exactly "ring churn hides receipts".
+        // what this catches: the ledger regressing to a shared-ring filter,
+        // which would make act history vanish under conversation again.
         wm.record_fact("chose silence — said nothing to the room");
         wm.record_fact("chose silence — said nothing to the room (again)");
+        assert!(
+            !wm.has_receipt(),
+            "precondition: the ring entry must have aged out for this state"
+        );
         let l = ledger(&render_facts(&cx, &FactPolicy::default()));
+        assert!(
+            l.contains("code/shell(ls)"),
+            "the archive must keep her act visible through ring churn: {l}"
+        );
         assert!(
             !l.contains("nothing has executed yet"),
             "denied her real act: {l}"
         );
-        assert!(
-            l.contains("aged out of working memory"),
-            "must explain the void: {l}"
-        );
-        assert!(l.contains("1 step executed earlier"));
-        // what this catches: the all-aged branch must never again promise that
-        // recall can retrieve the aged receipts. It is FALSE by construction —
+
+        // State 4: the pre-archive remnant — a counter restored from a
+        // snapshot written before the archive existed (taken > 0, no heads).
+        // The honest-loss arm covers it, and must never again promise that
+        // recall can retrieve the lost receipts. It is FALSE by construction —
         // acts become `EngramOrigin::Tool` engrams and `recall_candidates`
         // carries an executing assertion that a Tool-origin receipt is NEVER in
         // the semantic recall pool, through the persona's only production recall
         // caller. The old wording sent her after a door that does not exist
         // (#414); this pins the honest form so a future edit can't restore it.
+        let pre_archive = Arc::new(WorkingMemory::new(2));
+        pre_archive.restore(crate::cognition::working_memory::VolatileSnapshot {
+            entries: Vec::new(),
+            last_action: None,
+            action_fps: Vec::new(),
+            next_action_seq: 4, // 3 acts happened in the old life
+            saved_at_ms: 0,
+            interrupted_dispatches: Vec::new(),
+            build_sha: String::new(),
+            receipt_heads: Vec::new(), // written before the archive existed
+        });
+        let cx2 = FactContext {
+            turns: &turns,
+            own_speech: &own,
+            room_speech: &[],
+            working_memory: Some(&pre_archive),
+        };
+        let l = ledger(&render_facts(&cx2, &FactPolicy::default()));
+        assert!(
+            !l.contains("nothing has executed yet"),
+            "denied her real acts: {l}"
+        );
+        assert!(l.contains("3 steps executed earlier"), "{l}");
         assert!(
             !l.to_lowercase().contains("recall can retrieve"),
             "the ledger must not promise a retrieval path the substrate does not have: {l}"

--- a/core/continuum-core/src/cognition/working_memory.rs
+++ b/core/continuum-core/src/cognition/working_memory.rs
@@ -192,6 +192,24 @@ pub struct WorkingMemory {
     /// per session are naturally modest (a persona issues dozens of distinct calls,
     /// not millions), so it is left unbounded within the per-spawn lifetime.
     action_fp_counts: Mutex<HashMap<String, usize>>,
+    /// The PROPRIOCEPTION RECEIPT ARCHIVE — receipts-ONLY, head lines only (#414 option b).
+    ///
+    /// `entries` above is a SHARED ring: thoughts, facts, settlements and receipts all
+    /// compete for the same `capacity` slots, and receipts are the RARE kind, so they age
+    /// out while the act counter climbs. Measured 2026-08-14: Asha had executed 2,863
+    /// acts and her window rendered ONE (`+2862 earlier steps aged out`) — and with her
+    /// history invisible she concluded she had nothing to contribute (the withdrawal
+    /// loop's deprivation mechanism). Tool-origin engrams hold the durable copy but are
+    /// deliberately gated OUT of semantic recall (#166), so there was NO persona-facing
+    /// path back to her own acts.
+    ///
+    /// This ring is that path: every receipt's `[action #n]` FIRST LINE, in order,
+    /// bounded by CHARS ([`ContextBudget::receipt_archive_chars`] — window-derived,
+    /// never a bare count) instead of sharing the chatty ring's entry slots. The
+    /// steps-taken ledger renders from here, so act history survives conversation.
+    /// Persisted in [`VolatileSnapshot`] like the ring itself
+    /// ([[act-results-need-a-recency-channel-not-semantic-recall]]).
+    receipt_heads: Mutex<VecDeque<String>>,
     /// The lowest action `seq` whose FULL result is still "active" — i.e. the mind is
     /// still inside the act→observe loop that produced it and hasn't yet spoken. The
     /// full raw result exists to answer "what next" the moment the hands fetch it; once
@@ -273,6 +291,13 @@ pub struct VolatileSnapshot {
     /// then says nothing rather than guessing a change it cannot see (#165).
     #[serde(default)]
     pub build_sha: String,
+    /// The proprioception receipt archive (#414) — act-history head lines that must
+    /// survive a reboot exactly as the ring entries do (the counter already did; a
+    /// counter without its lines is the deprivation this field exists to end). Empty
+    /// on snapshots written before this field (serde default): restore starts the
+    /// archive fresh and the ledger's counter-only arm stays honest about the gap.
+    #[serde(default)]
+    pub receipt_heads: Vec<String>,
 }
 
 /// One typed working-memory entry: kind + the FINAL rendered line (rendered
@@ -305,6 +330,7 @@ impl WorkingMemory {
             next_action_seq: AtomicU64::new(1),
             action_fps: Mutex::new(VecDeque::new()),
             action_fp_counts: Mutex::new(HashMap::new()),
+            receipt_heads: Mutex::new(VecDeque::new()),
             active_from_seq: AtomicU64::new(0),
         }
     }
@@ -434,15 +460,43 @@ impl WorkingMemory {
         // full result and never pre-truncate. Append-only + `#seq`-stamped keeps the
         // trail's KV-cache prefix byte-stable across a settle-act.
         let head: String = a.chars().take(self.budget().trail_head_chars()).collect();
+        let text = format!("[action #{seq}] {head}");
+        // Receipts-own archive (#414): the FIRST LINE of every receipt, kept beyond the
+        // shared ring's lifetime so the steps ledger can show act HISTORY, not just the
+        // last few conversation beats. Char-bounded by the window-derived archive share.
+        self.push_receipt_head(text.lines().next().unwrap_or_default().to_string());
         let mut e = self.entries.lock();
         e.push_back(WmEntry {
             kind: WmKind::Receipt { n: seq },
-            text: format!("[action #{seq}] {head}"),
+            text,
             acts,
         });
         while e.len() > self.capacity {
             e.pop_front();
         }
+    }
+
+    /// Append one receipt head line to the proprioception archive and evict oldest-first
+    /// down to the window-derived char share. One body for the live write and the
+    /// snapshot restore, so both obey the same bound.
+    fn push_receipt_head(&self, head_line: String) {
+        let cap = self.budget().receipt_archive_chars();
+        let mut heads = self.receipt_heads.lock();
+        heads.push_back(head_line);
+        let mut total: usize = heads.iter().map(|h| h.chars().count() + 1).sum();
+        while total > cap && heads.len() > 1 {
+            if let Some(evicted) = heads.pop_front() {
+                total -= evicted.chars().count() + 1;
+            }
+        }
+    }
+
+    /// The proprioception receipt archive, oldest → newest: every act's `[action #n]`
+    /// head line that still fits the archive share. The steps-taken ledger renders its
+    /// newest tail from here — the persona-facing path back to her own act history that
+    /// semantic recall deliberately refuses to be (#166 / #414).
+    pub fn receipt_archive(&self) -> Vec<String> {
+        self.receipt_heads.lock().iter().cloned().collect()
     }
 
     /// The TYPED acts still in the recency window, oldest → newest — the parallel
@@ -507,6 +561,7 @@ impl WorkingMemory {
             entries: self.entries.lock().iter().cloned().collect(),
             last_action: self.last_action.lock().clone(),
             action_fps: self.action_fps.lock().iter().cloned().collect(),
+            receipt_heads: self.receipt_heads.lock().iter().cloned().collect(),
             next_action_seq: self.next_action_seq.load(Ordering::Relaxed),
             saved_at_ms: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -541,6 +596,14 @@ impl WorkingMemory {
             e.extend(snap.entries);
             while e.len() > self.capacity {
                 e.pop_front();
+            }
+        }
+        {
+            // Same re-clamp contract as `entries`: refill through the one bounded push so
+            // a snapshot from a bigger-window life evicts down to THIS life's share.
+            self.receipt_heads.lock().clear();
+            for head in snap.receipt_heads {
+                self.push_receipt_head(head);
             }
         }
         *self.last_action.lock() = snap.last_action;
@@ -1291,6 +1354,7 @@ mod tests {
             saved_at_ms: 0, // pre-field snapshot: no gap guessed
             interrupted_dispatches: Vec::new(),
             build_sha: String::new(), // pre-field snapshot: no rebuild guessed either
+            receipt_heads: Vec::new(), // pre-archive snapshot: ledger's counter-only arm covers it
         });
         let q = quiet.recent();
         assert_eq!(q.len(), 1);
@@ -1367,6 +1431,52 @@ mod tests {
     // the WmEntry.acts field existed — restores WITHOUT panic, the `acts` defaulting
     // to empty via `#[serde(default)]` (the same contract as saved_at_ms/build_sha).
     // A grid-sync peer or a pre-deploy snapshot must never wedge the mind on restore.
+    #[test]
+    // what this catches: the #414 deprivation regressing — receipts must survive
+    // the shared ring's churn via the receipts-only archive, the archive must stay
+    // within its window-derived CHAR share (never a bare count, never unbounded),
+    // and it must round-trip the volatile snapshot exactly as the ring does. The
+    // measured failure: a 2,863-act citizen whose window showed ONE act read her
+    // own starved history as "I have nothing to contribute".
+    #[test]
+    fn receipt_archive_survives_ring_churn_and_roundtrips_the_snapshot() {
+        let wm = WorkingMemory::new(2);
+        wm.set_served_window(16_384);
+        wm.record_receipt("I ran code/shell(ls) Result: ok");
+        for i in 0..10 {
+            wm.record_fact(&format!("chatty fact {i}"));
+        }
+        assert!(
+            !wm.has_receipt(),
+            "precondition: the ring entry must age out under churn"
+        );
+        let archive = wm.receipt_archive();
+        assert_eq!(archive.len(), 1, "the archive must survive the churn");
+        assert!(archive[0].contains("code/shell(ls)"));
+
+        // Char-bound eviction: flood with receipts; the archive keeps its
+        // NEWEST within the share and never grows unbounded.
+        for i in 0..2000 {
+            wm.record_receipt(&format!("I ran code/read(f{i}) Result: ok"));
+        }
+        let archive = wm.receipt_archive();
+        let cap = wm.budget().receipt_archive_chars();
+        let total: usize = archive.iter().map(|h| h.chars().count() + 1).sum();
+        assert!(total <= cap, "archive exceeded its share: {total} > {cap}");
+        assert!(
+            archive.last().unwrap().contains("f1999"),
+            "eviction must drop oldest, keep newest: {:?}",
+            archive.last()
+        );
+
+        // Snapshot round-trip: the archive persists like the ring.
+        let snap = wm.snapshot();
+        let fresh = WorkingMemory::new(2);
+        fresh.set_served_window(16_384);
+        fresh.restore(snap);
+        assert_eq!(fresh.receipt_archive(), archive);
+    }
+
     #[test]
     fn an_old_snapshot_without_acts_restores_without_panic() {
         // A hand-authored legacy snapshot: entries have NO `acts` key at all.


### PR DESCRIPTION
Builds the ratified fix for the withdrawal loop's deprivation mechanism: a citizen's own completed acts were invisible to her next turn (receipts age out of the capacity-bounded shared WM ring; Tool-origin engrams are deliberately gated out of semantic recall per #166). Measured: Asha, 2,863 acts executed, ONE visible — and she read that starvation as 'I have nothing to contribute'.

**The channel**: a receipts-ONLY archive inside `WorkingMemory` — every act's `[action #n]` head line, char-bounded by two new window-derived `ContextBudget` fractions (`receipt_archive_chars` 1/16, `steps_ledger_chars` 1/64 — the de-hardcode guard's contract, no bare counts, floored at MIN_SERVE_CTX for the stored buffer per the `working_memory_steps` precedent). The `StepsLedger` perception fact renders from the archive instead of filtering the ring, so act history survives conversation and depth scales with the lane. Persisted in `VolatileSnapshot` (serde-default back-compat); the pre-archive counter-only arm keeps its honest no-recall-promise wording.

**Not touched**: the #166 semantic-recall gate (its executing assertion stays green), the WM trailing channel, the full-result pin.

**Tests** (existing mods, `// what this catches:`): archive survives ring churn, char-bound eviction keeps newest, snapshot round-trip; ledger four states including the churn-survival fix itself and the pinned no-recall-promise. 33/33 targeted green; `no_new_hardcoded_context_or_prompt_size_constant_anywhere_in_the_crate` green.

Live proof owed post-deploy: a citizen's ledger showing multi-act history through conversation churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo