### PR TITLE
chore(cognition): dead-wire + doc hygiene from the citizenship audit (#428)

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -461,11 +461,6 @@ impl ActionCommand for AgentSolve {
                                     let _ = std::fs::write(path, json);
                                 }
                             }
-                            if let Some(bus) = crate::runtime::MessageBus::global() {
-                                if let Ok(v) = serde_json::to_value(&r) {
-                                    bus.publish_async_only("agent:solve:complete", v);
-                                }
-                            }
                             tracing::info!(run_id = %run_id, acts = r.acts, attempt, "agent/solve detached run complete");
                             // #384: ZERO acts + NO error + EMPTY patch = she never
                             // worked at all — the serving-transition signature (F1:

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -702,16 +702,19 @@ async fn serve_persona_loop_inner(
         );
 
         // ===========================================================
-        // The brain services the turn through the canonical cognition
-        // pipeline — `persona::response::respond(RespondInput)`. This
-        // is the agent contract Joel and I have been building for a
-        // year: shared analysis (single-flight cache) → specialty
-        // scoring → genome activate → evaluate_response (adapter-
-        // translated, model-canonical tool calls + multi-modal) →
-        // clean_and_validate → tool_executor → audit → record_turn.
+        // The brain services the turn through the WorkspaceCycle:
+        // admit → build_workspace_turns → Burst → workspace cycle
+        // (RecallFaculty feeds the prompt, deliberation decides,
+        // act→observe drives to settle). That is the live path below.
+        //
+        // NOT `persona::response::respond(RespondInput)` — that verb
+        // only has one caller, PersonaServiceModule, which the module
+        // audit declares UNWIRED ("shadowed", runtime/registry.rs) so
+        // the respond path is dead code, kept only until the verbs it
+        // owns are dismantled or re-homed.
         //
         // See docs/architecture/PERSONA-COGNITION-PIPELINE.md for the
-        // full pipeline and the bypass this commit replaces.
+        // full pipeline.
         //
         // NOT a `will_respond + response_text` chatbot contract. NOT
         // a parallel rag_inspect bypass. The verbs in `cognition/`

--- a/docs/architecture/PERSONA-COGNITION-PIPELINE.md
+++ b/docs/architecture/PERSONA-COGNITION-PIPELINE.md
@@ -31,23 +31,31 @@ Continuum personas are **citizens**, not query handlers. The README has the full
 
 ## 2. The Brain Pipeline — the verbs that exist
 
-This is the cognition cycle PER PERSONA, PER TURN. **All verbs already exist** in `core/continuum-core/src/cognition/` and `core/continuum-core/src/persona/`. Do not re-implement. Do not parallel. Use them.
+This is the cognition cycle PER PERSONA, PER TURN. The verbs exist in `core/continuum-core/src/cognition/` and `core/continuum-core/src/persona/`. Do not re-implement. Do not parallel.
 
-| # | Verb | Location | Purpose |
-|---|------|----------|---------|
-| 1 | `admission.admit(message)` | `persona/admission_state.rs` | Memory forms — engram lands in L2, dedup + replay-protection enforced. |
-| 2 | `full_evaluate(...)` | `persona/evaluator/mod.rs` | Fast-path gates: sleep mode, undirected-persona chatter, self-message dedup, fast-path priority. Sub-1ms. Silence = first-class outcome. |
-| 3 | `cognition::analyze(AnalysisInput)` | `cognition/shared_analysis/mod.rs` | ONE inference per chat message via single-flight DashMap cache. N personas analyzing the same message coalesce into one inference. Returns `SharedAnalysis` with `suggested_angles` per specialty. **Cache is the optimization; each persona still calls.** |
-| 4 | `score_persona(slot, analysis)` | `cognition/response_orchestrator.rs` | Per-persona relevance via specialty match. Returns `ResponderDecision { is_responder, score, is_lead, reason }`. |
-| 5 | `genome_engine.activate_skill(domain, now_ms)` | `persona/genome_paging.rs` | L1-L5 LoRA paging — page in the adapter for this domain. LRU evicts under pressure. |
-| 6 | `PersonaCognition::compose_for_turn(profile, now_ms)` | `persona/unified.rs` | Brain RAG composition: `engram_source + airc_source + ...` via `FlexboxRagBudgetAdapter` (PR #8 / task #93 — no-clipping, source-owned units, full allocation telemetry). |
-| 7 | `cognition::generate_response::evaluate_response(GenerateResponseRequest)` | `cognition/generate_response.rs` | The agent inference. Takes `AIDecisionContext` (system_prompt + history + trigger). Routes through the provider registry. Typed errors (no silent fallback). |
-| 8 | `cognition::clean_and_validate(...)` | `cognition/response_validator.rs` | Output cleaning + validation. `ValidationOutcome`. |
-| 9 | `cognition::ToolExecutor` | `cognition/tool_executor/` | Executes any `ContentPart::ToolUse` in the response. Multi-modal aware: `MediaItemLite`, `ParsedToolBatch`. Threads results back; may re-call `evaluate_response`. |
-| 10 | `cognition::audit::*` | `cognition/audit.rs` | Audit trail. The substrate's forensic record of what the brain did. |
-| 11 | `cognition::check_redundancy::*` | `cognition/check_redundancy.rs` | Avoid posting echoes the room already covered. |
-| 12 | Brain state updates | `persona/unified.rs` fields | `rate_limiter.track_response`, `content_dedup.record`, `message_cache.push`, `genome_engine.record_activity`, `recall_metadata.*`. |
-| 13 | Post via `ctx.runtime.say(...)` | `persona/airc_citizen.rs` | The persona posts under HER identity (her airc citizen, her peer_id). |
+**Status column added 2026-08-14 (citizenship audit):** the LIVE turn path is the
+WorkspaceCycle in `service_loop.rs` (admit → `build_workspace_turns` → `Burst` →
+faculties → act→observe drive_to_settle). Several verbs below are today reachable
+only from diagnostic commands or from `persona::response::respond`, whose sole
+caller (`PersonaServiceModule`) the module-wiring audit declares UNWIRED/shadowed
+(`runtime/registry.rs`). "dormant" means: exists, tested, NOT on the live per-turn
+path — reuse it when the capability returns, do not write a parallel one.
+
+| # | Verb | Location | Status | Purpose |
+|---|------|----------|--------|---------|
+| 1 | `admission.admit(message)` | `persona/admission_state.rs` | **live** (service_loop) | Memory forms — engram lands in L2, dedup + replay-protection enforced. |
+| 2 | `full_evaluate(...)` | `persona/evaluator/mod.rs` | dormant (command `cognition/full-evaluate` only) | Fast-path gates: sleep mode, undirected-persona chatter, self-message dedup, fast-path priority. Sub-1ms. Silence = first-class outcome. |
+| 3 | `cognition::analyze(AnalysisInput)` | `cognition/shared_analysis/mod.rs` | dormant (respond path only) | ONE inference per chat message via single-flight DashMap cache. N personas analyzing the same message coalesce into one inference. |
+| 4 | `score_persona(slot, analysis)` | `cognition/response_orchestrator.rs` | dormant (respond path only) | Per-persona relevance via specialty match. Returns `ResponderDecision`. |
+| 5 | `genome_engine.activate_skill(domain, now_ms)` | `persona/genome_paging.rs` | dormant (command `cognition/genome-activate-skill` only) | L1-L5 LoRA paging — page in the adapter for this domain. LRU evicts under pressure. |
+| 6 | `PersonaCognition::compose_for_turn(profile, now_ms)` | `persona/unified.rs` | **live** (WorkspaceCycle RAG) | Brain RAG composition: `engram_source + airc_source + roster/doctrine/bench sources` via `FlexboxRagBudgetAdapter`. |
+| 7 | `cognition::generate_response::evaluate_response(...)` | `cognition/generate_response.rs` | dormant (command wrapper + respond path; the live turn infers via `llm_deliberation_faculty`) | Agent inference through the provider registry. Typed errors (no silent fallback). |
+| 8 | `cognition::clean_and_validate(...)` | `cognition/response_validator.rs` | dormant (test-only today) | Output cleaning + validation. `ValidationOutcome`. |
+| 9 | `cognition::ToolExecutor` | `cognition/tool_executor/` | **live** (act→observe) | Executes tool calls. Multi-modal aware. Results re-enter as working-memory receipts + engrams. |
+| 10 | `cognition::audit::*` | `cognition/audit.rs` | dormant (types used by threat_detector; no turn-cycle caller) | Audit trail. The substrate's forensic record of what the brain did. |
+| 11 | `cognition::check_redundancy::*` | `cognition/check_redundancy.rs` | dormant (`self_repeat.rs` notes it "isn't wired into the live loop"; live repetition perception is the WM repetition brick) | Avoid posting echoes the room already covered. |
+| 12 | Brain state updates | `persona/unified.rs` fields | **live** (partial: dedup/speech rings on the cycle) | `rate_limiter.track_response`, `content_dedup.record`, `message_cache.push`, `recall_metadata.*`. |
+| 13 | Post via `ctx.runtime.say(...)` | `persona/airc_citizen.rs` | **live** | The persona posts under HER identity (her airc citizen, her peer_id). |
 
 **Multi-modal is not a flag.** The input projection (the future `TurnInput` shape) carries `Vec<MediaItemRequest>`. Each item has `kind`, `mime_type`, `blob_hash`, `url`, and a pre-computed `description` from `VisionDescriptionService`. Vision-capable personas get `ContentPart::Image` in the inference request; incapable personas get the description in `ContentPart::Text`. The prompt builder picks.
 


### PR DESCRIPTION
## What

Three hygiene fixes from the 2026-08-14 citizenship audit (AXIS 3, drift items). No behavior change on any live path.

1. **Orphan event deleted**: `agent:solve:complete` (solve.rs) had zero subscribers tree-wide. The bench board reads run ledgers via `scan_run_cards` (and now reaches citizen perception via the ViewState pipe, #2298); the event was dead wire on the detached-runner path that #425 will retire.

2. **Stale comment corrected** (service_loop.rs): claimed the turn is serviced through `persona::response::respond(RespondInput)`. That verb's only caller, `PersonaServiceModule`, is declared UNWIRED/shadowed by the module-wiring audit (`runtime/registry.rs`). The comment now names the real live path — the WorkspaceCycle (admit → build_workspace_turns → Burst → faculties → act→observe).

3. **PERSONA-COGNITION-PIPELINE.md §2 gets a Status column**: the 13-verb table previously presented all verbs as the live per-turn cycle. Verified per-verb (grep for production callers): live = admit, compose_for_turn, ToolExecutor, state updates (partial), say. Dormant (diagnostic-command-only / dead respond path / test-only) = full_evaluate, analyze, score_persona, activate_skill, evaluate_response, clean_and_validate, audit, check_redundancy. "Dormant" is explicitly defined as reuse-don't-parallel.

## Why

The doc drift is how the respond bypass kept getting rebuilt under amnesia — the doc said those verbs run per-turn, so new code kept wiring against them. Task #428.

## Validation

`cargo check -p continuum-core --features metal,accelerate` clean (1m18s). The only code changes are a 5-line dead publish removal and a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo