### PR TITLE
feat(persona): supervisor stays resident and HOSTS what persona/spawn births (#429)

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -2423,6 +2423,16 @@ pub fn start_server(
             // follow-on; we break once a citizen is hosted to avoid
             // re-bootstrapping a live persona's airc identity.)
             let mut attempt = 0u32;
+            // #429: once boot composition succeeds, this task does NOT end —
+            // it becomes the standing HOSTING RECONCILER. `persona/spawn`
+            // births end at `registry.register` (identity only); hosting
+            // (adapter + cognition loop) is the supervisor's job, and before
+            // this flag existed it ran exactly once, so a command-born
+            // citizen was on airc, carded — and MUTE. Post-boot, each
+            // serving-plan edge drives `host_unattended`: registered
+            // citizens with no service loop get the same materialize +
+            // attach pipeline boot slots got.
+            let mut booted = false;
             loop {
                 let plan_ready = serving_plan_rx
                     .borrow()
@@ -2463,7 +2473,7 @@ pub fn start_server(
                              personas onto a lane that cannot generate; retrying on the \
                              next serving edge."
                         );
-                    } else {
+                    } else if !booted {
                         attempt += 1;
                         let summary = supervisor
                             .spawn_all(&mut provider, Some(tool_executor.clone()))
@@ -2474,26 +2484,62 @@ pub fn start_server(
                                 failed = summary.failed(),
                                 attempts = attempt,
                                 "🌐 Substrate boot composition complete (slice 13.5) — \
-                                 citizen(s) hosted, event-driven on serving-plan readiness"
+                                 citizen(s) hosted; supervisor stays resident as the \
+                                 hosting reconciler (#429)"
                             );
-                            break;
+                            booted = true;
+                        } else {
+                            tracing::warn!(
+                                failed = summary.failed(),
+                                attempt,
+                                "persona spawn found a decode-ready serving lane but no citizen \
+                                 materialized — will retry on the next serving-plan edge"
+                            );
                         }
-                        tracing::warn!(
-                            failed = summary.failed(),
-                            attempt,
-                            "persona spawn found a decode-ready serving lane but no citizen \
-                             materialized — will retry on the next serving-plan edge"
-                        );
+                    } else {
+                        // Post-boot reconcile (#429): a `persona/spawn` birth ends at
+                        // `registry.register`; the hosting half (adapter + cognition
+                        // loop) is ours. Each serving-plan edge, host any registered
+                        // citizen with no attached service loop — never re-running
+                        // `spawn_all` (which would re-bootstrap live airc identities).
+                        let summary = supervisor
+                            .host_unattended(Some(tool_executor.clone()))
+                            .await;
+                        if summary.hosted > 0 {
+                            tracing::info!(
+                                hosted = summary.hosted,
+                                failed = summary.failed(),
+                                "🌐 hosting reconciler: {} newborn citizen(s) hosted \
+                                 (persona/spawn → live mind)",
+                                summary.hosted
+                            );
+                        }
+                        for failure in &summary.failures {
+                            tracing::warn!(
+                                persona_id = ?failure.persona_id,
+                                reason = %failure.reason,
+                                "hosting reconciler: slot failed — will retry on the \
+                                 next serving-plan edge"
+                            );
+                        }
                     }
                 }
                 // Park until the serving daemon republishes (every tick, or
                 // sooner on a pressure edge). `changed()` errs only if the
                 // daemon is gone — then there is nothing left to react to.
                 if serving_plan_rx.changed().await.is_err() {
-                    tracing::warn!(
-                        "serving-daemon watch closed before any persona materialized \
-                         — no citizens online this run"
-                    );
+                    if booted {
+                        tracing::warn!(
+                            "serving-daemon watch closed — hosting reconciler exiting; \
+                             citizens already hosted stay live, but later persona/spawn \
+                             births will not be hosted this run (#429)"
+                        );
+                    } else {
+                        tracing::warn!(
+                            "serving-daemon watch closed before any persona materialized \
+                             — no citizens online this run"
+                        );
+                    }
                     break;
                 }
             }

--- a/core/continuum-core/src/persona/host.rs
+++ b/core/continuum-core/src/persona/host.rs
@@ -298,6 +298,124 @@ impl PersonaSpawnSupervisor {
             }
         };
 
+        let mut summary = BootSummary::default();
+        self.host_plans(plans, tool_command_executor, &mut summary)
+            .await;
+
+        tracing::info!(
+            hosted = summary.hosted,
+            failed = summary.failed(),
+            "🌐 PersonaSpawnSupervisor: boot composition complete — \
+             {} citizen(s) hosted, {} failed",
+            summary.hosted,
+            summary.failed(),
+        );
+
+        summary
+    }
+
+    /// Host every REGISTERED citizen whose slot has never had a
+    /// service loop attached (#429 — the mute-citizen re-entry).
+    ///
+    /// `persona/spawn` births share `birth_one` with boot, but birth
+    /// ends at `registry.register` — hosting (adapter + cognition
+    /// loop) only ran from boot's [`Self::spawn_all`]. A command-born
+    /// citizen was on airc, in the commons, carded — and MUTE. This
+    /// is the standing reconciler's verb: scan the registry, derive
+    /// the SAME single-slot plans boot uses (the spawner's roster row
+    /// is the config authority until #430 makes it recipe data), and
+    /// run the shared hosting tail.
+    ///
+    /// Attached slots — running OR finished — are skipped: a finished
+    /// loop is respawn-on-death territory (slice-14), deliberately
+    /// not this verb's concern. Idempotent: calling with nothing
+    /// unattended returns an empty summary.
+    pub async fn host_unattended(
+        &self,
+        tool_command_executor: Option<Arc<crate::runtime::CommandExecutor>>,
+    ) -> BootSummary {
+        let mut summary = BootSummary::default();
+        let mut unattended = Vec::new();
+        for persona_id in self.registry.ids() {
+            // None = no service loop was ever attached. Some(_) — running
+            // (false) or finished (true) — means a host decision was already
+            // made for this slot; not ours to redo here.
+            if self
+                .registry
+                .is_service_loop_finished(persona_id)
+                .await
+                .is_none()
+            {
+                if let Some(rt) = self.registry.get(persona_id) {
+                    unattended.push(rt);
+                }
+            }
+        }
+        if unattended.is_empty() {
+            return summary;
+        }
+
+        let plan_rows = self.spawner.plan();
+        let Some(desired) = plan_rows.first() else {
+            // An empty roster plan with live unhosted citizens is a
+            // configuration hole, not a skippable state — say so loudly
+            // per [[no-fallbacks-ever]]; no synthetic role is invented.
+            tracing::error!(
+                unattended = unattended.len(),
+                "host_unattended: spawner plan is EMPTY — {} registered \
+                 citizen(s) cannot be hosted (no role/model row to derive \
+                 an inference profile from)",
+                unattended.len()
+            );
+            return summary;
+        };
+
+        let roster: Vec<crate::persona::spawner::RosterEntry> = unattended
+            .iter()
+            .map(|rt| crate::persona::spawner::RosterEntry {
+                role: desired.role,
+                persona_id: rt.persona_id(),
+                persona_name: rt.agent_name().to_string(),
+                model_id: desired.model_id.clone(),
+                serving: crate::persona::profile_builder::ServingParams {
+                    lanes: desired.lanes,
+                    served_context_window: desired.served_context_window,
+                },
+            })
+            .collect();
+        let profiles = crate::persona::spawner::derive_spawn_plan(
+            &roster,
+            &self.tier_id,
+            self.spawner.tier_category(),
+            self.model_registry,
+        );
+        let plans: Vec<crate::persona::spawner_module::MaterializedPersonaPlan> = unattended
+            .iter()
+            .zip(profiles)
+            .map(|(rt, profile)| crate::persona::spawner_module::MaterializedPersonaPlan {
+                role: desired.role,
+                instance:
+                    crate::modules::persona_instance_manager::PersonaInstanceInfo::from_runtime(rt),
+                profile,
+            })
+            .collect();
+
+        self.host_plans(plans, tool_command_executor, &mut summary)
+            .await;
+        summary
+    }
+
+    /// Materialize adapters for a batch of plans and attach each
+    /// resulting context's service loop — the shared hosting tail of
+    /// [`Self::spawn_all`] (boot) and [`Self::host_unattended`]
+    /// (post-boot reconcile). One definition: "hosting" IS this
+    /// sequence, whichever verb asks for it.
+    async fn host_plans(
+        &self,
+        plans: Vec<crate::persona::spawner_module::MaterializedPersonaPlan>,
+        tool_command_executor: Option<Arc<crate::runtime::CommandExecutor>>,
+        summary: &mut BootSummary,
+    ) {
         let registry_for_lookup = self.registry.clone();
         // `registry.get` returns `Option<Arc<PersonaAircRuntime>>` —
         // the closure upcoerces to `Option<Arc<dyn AircCitizen>>` so
@@ -309,7 +427,7 @@ impl PersonaSpawnSupervisor {
         // scoped to the persona's identity (so the ACL gates it). Cheap — each is
         // an Arc bump on the shared executor + connection. `None` executor →
         // every persona is speak-only.
-        let tool_exec_source = tool_command_executor.clone();
+        let tool_exec_source = tool_command_executor;
         let hosted_results = materialize_adapters(
             plans,
             &*self.factory,
@@ -328,10 +446,9 @@ impl PersonaSpawnSupervisor {
         )
         .await;
 
-        let mut summary = BootSummary::default();
         for (slot_idx, result) in hosted_results.into_iter().enumerate() {
             match result {
-                Ok(ctx) => self.spawn_and_attach(slot_idx, ctx, &mut summary).await,
+                Ok(ctx) => self.spawn_and_attach(slot_idx, ctx, summary).await,
                 Err(err) => {
                     let (slot_index, role) = supervisor_error_facts(&err);
                     summary.failures.push(BootSlotFailure {
@@ -349,17 +466,6 @@ impl PersonaSpawnSupervisor {
                 }
             }
         }
-
-        tracing::info!(
-            hosted = summary.hosted,
-            failed = summary.failed(),
-            "🌐 PersonaSpawnSupervisor: boot composition complete — \
-             {} citizen(s) hosted, {} failed",
-            summary.hosted,
-            summary.failed(),
-        );
-
-        summary
     }
 
     /// Spawn one persona's service loop and attach to the registry.
@@ -484,6 +590,62 @@ fn supervisor_error_facts(err: &SupervisorError) -> (Option<usize>, RoleId) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the hosting reconciler (#429) runs host_unattended on
+    // EVERY serving-plan edge for the life of the process. With nothing
+    // unattended it must be a QUIET no-op — empty summary, zero failure rows
+    // (a spurious row here would warn-log every ~5s forever), and the adapter
+    // factory must never be consulted (a factory call on an empty scan would
+    // probe /v1 each tick for nothing). Hosting an actual newborn end-to-end
+    // needs a live airc daemon (same limit the registry's own tests document
+    // in clone_shares_roster); the scan + early-return contract is the
+    // unit-pinnable half.
+    #[tokio::test]
+    async fn host_unattended_with_nothing_unattended_is_a_quiet_noop() {
+        struct NeverConsultedFactory;
+        #[async_trait::async_trait]
+        impl PersonaAdapterFactory for NeverConsultedFactory {
+            async fn build_adapter(
+                &self,
+                _profile: &crate::persona::inference_profile::PersonaInferenceProfile,
+            ) -> Result<Arc<dyn crate::ai::adapter::AIProviderAdapter>, String> {
+                panic!("factory must not be consulted when the registry has no unattended citizens");
+            }
+        }
+
+        let registry = crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::new();
+        let tmp = std::env::temp_dir().join("host-unattended-noop-test");
+        let instance_manager = Arc::new(
+            crate::modules::persona_instance_manager::PersonaInstanceManagerModule::new(
+                registry,
+                tmp.join("daemon.sock"),
+                tmp,
+            ),
+        );
+        // Idempotent — safe under full-suite parallelism (the singleton's own
+        // doc: "subsequent init_global calls are no-ops").
+        let model_registry =
+            crate::model_registry::init_global().expect("model registry init for test");
+        let supervisor = PersonaSpawnSupervisor::new(
+            PersonaSpawnerModule::new(
+                crate::cognition::model_resolver::types::HwCapabilityTier::CpuOnly,
+                crate::persona::hw_tier_descriptor::HwTierCategory::Compat,
+            ),
+            instance_manager,
+            Arc::new(NeverConsultedFactory),
+            "test-tier",
+            model_registry,
+            tokio::runtime::Handle::current(),
+        );
+
+        let summary = supervisor.host_unattended(None).await;
+        assert_eq!(summary.hosted, 0, "nothing to host → nothing hosted");
+        assert!(
+            summary.failures.is_empty(),
+            "an empty scan must not synthesize failure rows: {:?}",
+            summary.failures
+        );
+    }
 
     #[test]
     fn boot_summary_attempted_sums_hosted_and_failures() {


### PR DESCRIPTION
## What

SPAWN GATE slice 1 (task #429), toward Joel's persona-health gate: "healthy persona in rooms, spawned from recipe registries cleanly."

**The bug (mute-citizen re-entry):** `persona/spawn` shares `birth_one` with boot, but birth ends at `registry.register`. Hosting — adapter materialization + `spawn_persona_service` + `attach_service_loop` — only ran from boot's `spawn_all`. A command-born citizen was on airc, in the commons, carded — and **mute**: no inference adapter, no cognition loop. `persona:born` fired with zero subscribers tree-wide. This is the pre-slice-13 mute-citizens failure re-entered through the front door, and one of the three flail-source finds from the spawn survey.

**The fix, event-driven on the signal the boot task already watches:**

1. `PersonaSpawnSupervisor::host_unattended` — scan the registry for citizens whose slot never had a service loop attached; derive the SAME single-slot plans boot uses (spawner roster row + ServingPlan + `derive_spawn_plan`; the config authority until #430 makes the roster recipe data); run the shared hosting tail. Attached slots — running or finished — are skipped (respawn-on-death remains the slice-14 follow-on).
2. `host_plans` — the `materialize_adapters` + `spawn_and_attach` tail extracted from `spawn_all`; boot and reconcile share ONE hosting definition.
3. The ipc boot task no longer ends after boot composition — it stays resident as the **hosting reconciler**, calling `host_unattended` on each serving-plan edge behind the same decode-ready gate (#363). `spawn_all` is never re-run (it would re-bootstrap live airc identities).

## Validation

- `cargo check` clean.
- `persona::host` + `persona::supervisor` + `persona::spawner` suites: **22 passed, 0 failed**.
- New regression test `host_unattended_with_nothing_unattended_is_a_quiet_noop`: pins the empty-scan contract — no synthesized failure rows (a spurious row would warn-log every ~5s forever) and the adapter factory is provably never consulted (panicking stub). Hosting a real newborn end-to-end needs a live airc daemon (the same limit the registry's own tests document); the live proof is owed on next deploy: `persona/spawn` → "hosting reconciler: 1 newborn citizen(s) hosted" within one serving edge, and the newborn SPEAKS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo