### PR TITLE
fix(activity): validate recipe strings + fix live benchmark-room purpose mismatch (#431)

### DIFF
--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1087,8 +1087,23 @@ impl ActionCommand for BenchmarkDispatch {
             Some(r) => r.trim().to_string(),
             None => default_run_room_name(spec.name, epoch_secs()),
         };
+        // The room binds to the SHIPPED benchmark recipe's declared purpose,
+        // resolved from its constant — never a re-typed string. The old literal
+        // here was "benchmark" while the recipe declares "benchmark/hard-rs",
+        // so every run room resolved to no manifest and rendered as plain chat
+        // (#431 — the scoreboard region was the whole point of the recipe).
+        let bench_recipe = crate::experience::source::RecipeExperienceSource::shipped_purpose(
+            crate::experience::source::shipped::BENCHMARK_HARD_RS,
+        )
+        .ok_or_else(|| {
+            CommandError::Internal(
+                "shipped benchmark recipe missing from the embedded set — \
+                 build-time authoring bug"
+                    .into(),
+            )
+        })?;
         let room = crate::modules::activity::spawn_activity_room(
-            &airc, &room_name, "benchmark", None,
+            &airc, &room_name, &bench_recipe, None,
         )
         .await?;
 

--- a/core/continuum-core/src/experience/source.rs
+++ b/core/continuum-core/src/experience/source.rs
@@ -178,6 +178,25 @@ impl RecipeExperienceSource {
         Self::new(purpose, Self::embedded())
     }
 
+    /// Every purpose the SHIPPED recipe set declares — the validation list
+    /// `activity/spawn` refuses against (#431). Derived from the SAME
+    /// [`Self::embedded`] iterator the registry is built from, so the
+    /// validation set and the resolution set cannot drift. When the disk
+    /// overlay is wired into production (#432), this must grow the overlay
+    /// too — they are the same set by definition.
+    pub fn shipped_purposes() -> Vec<String> {
+        Self::embedded().map(|r| r.purpose).collect()
+    }
+
+    /// The declared purpose of a shipped recipe, by its [`shipped`] handle.
+    /// Lets core call sites bind rooms by CONSTANT (`shipped::BENCHMARK_HARD_RS`)
+    /// while the purpose string stays authored in exactly one place — the
+    /// recipe JSON. `None` only if the handle names no embedded recipe, which
+    /// is a build-time authoring bug the shipped-constants test pins.
+    pub fn shipped_purpose(id: RecipeId) -> Option<String> {
+        Self::embedded().find(|r| r.id == id).map(|r| r.purpose)
+    }
+
     /// The embedded seed set. These ship IN the binary so a fresh clone has working
     /// experiences with zero files on disk — the same self-provisioning contract the
     /// rest of the substrate holds. They are a FLOOR, not the catalogue: anything on

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -179,6 +179,27 @@ impl ActionCommand for ActivitySpawn {
     }
 }
 
+/// Refuse a recipe string that names no known recipe purpose (#431).
+///
+/// A recipe string is a reference into the recipe REGISTRY, not free text.
+/// Before this gate, an unknown one "worked" — the room got made, the binding
+/// published — and then resolved to no manifest, so every client projected the
+/// room as plain chat. That silent downgrade is how every benchmark run room
+/// rendered as chat for a full campaign: dispatch bound `"benchmark"` while the
+/// shipped recipe's purpose is `"benchmark/hard-rs"`. The refusal names the
+/// actionable set, per the registry's own `ids()`/`purposes()` design note.
+pub fn validate_recipe(recipe: &str) -> Result<(), CommandError> {
+    let known = crate::experience::source::RecipeExperienceSource::shipped_purposes();
+    if known.iter().any(|k| k == recipe) {
+        return Ok(());
+    }
+    Err(CommandError::Invalid(format!(
+        "unknown recipe {recipe:?} — no recipe declares that purpose, so the room \
+         would project as plain chat. Known recipes: {}",
+        known.join(", ")
+    )))
+}
+
 /// Birth a room from a recipe on an ALREADY-RESOLVED airc handle.
 ///
 /// This is the whole of `activity/spawn` minus the caller-identity lookup, split
@@ -196,6 +217,7 @@ pub async fn spawn_activity_room(
     recipe: &str,
     parent: Option<RoomId>,
 ) -> Result<ActivitySpawnResult, CommandError> {
+    validate_recipe(recipe)?;
     {
         // `join` IS room creation in airc: it derives the channel from the name,
         // subscribes this peer, and publishes presence. Reusing it keeps ONE room
@@ -468,6 +490,43 @@ impl ServiceModule for ActivityModule {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the exact live bug that made EVERY benchmark run room
+    // render as plain chat — dispatch bound the recipe string "benchmark" while
+    // the shipped recipe declares purpose "benchmark/hard-rs", and nothing
+    // validated the string against the registry. The gate must refuse the bad
+    // string LOUDLY (naming the actionable set) and pass every shipped purpose.
+    // regression for #431 / commit at benchmark.rs:1091
+    #[test]
+    fn validate_recipe_refuses_unknown_and_passes_every_shipped_purpose() {
+        for purpose in crate::experience::source::RecipeExperienceSource::shipped_purposes() {
+            assert!(
+                validate_recipe(&purpose).is_ok(),
+                "shipped purpose {purpose:?} must validate"
+            );
+        }
+        let err = validate_recipe("benchmark").expect_err("the old dispatch literal must refuse");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("benchmark/hard-rs"),
+            "refusal must name the actionable set, got: {msg}"
+        );
+    }
+
+    // what this catches: core call sites bind rooms by shipped CONSTANT; the
+    // purpose string must come from the recipe JSON, resolved through
+    // shipped_purpose — if the mapping breaks, dispatch would silently bind a
+    // wrong (or no) purpose again.
+    #[test]
+    fn shipped_benchmark_constant_resolves_to_its_declared_purpose() {
+        assert_eq!(
+            crate::experience::source::RecipeExperienceSource::shipped_purpose(
+                crate::experience::source::shipped::BENCHMARK_HARD_RS
+            )
+            .as_deref(),
+            Some("benchmark/hard-rs")
+        );
+    }
 
     // what this catches: the recipe binding riding a category every reader agrees
     // on. If this constant drifts from what the purpose resolver filters for, a


### PR DESCRIPTION
## What

SPAWN GATE slice 3 (task #431). Two halves:

1. **Recipe validation at the one birth path.** `spawn_activity_room` now refuses a recipe string that names no known recipe purpose, with the actionable set in the error. New `shipped_purposes()`/`shipped_purpose(id)` on `RecipeExperienceSource`, derived from the same `embedded()` iterator the registry itself is built from — the validation set and the resolution set cannot drift (both must grow the disk overlay when #432 wires it; noted in-doc).

2. **The live bug fixed:** `benchmark/dispatch` bound `"benchmark"` while the shipped recipe declares `"benchmark/hard-rs"` — every benchmark run room resolved to no manifest and rendered as plain chat. The call site now resolves the purpose from `shipped::BENCHMARK_HARD_RS`, keeping the string authored in exactly one place (the recipe JSON).

## Why

The classroom must look like a classroom: a benchmark room whose scoreboard never renders is the parallel-system failure in UI form. The registry's own `ids()` doc named this exact validation as its purpose — it was designed and never wired (spawn survey, 2026-08-14).

## Validation

`modules::activity` + `experience::source` suites: **15 passed, 0 failed**, including the regression pinning the exact old literal (`"benchmark"` refuses, every shipped purpose passes, constant→purpose mapping pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo