### PR TITLE
feat(spawn): host EVERY resumed citizen + recipe overlay in prod + drop vestigial default_room gate (#432)

### DIFF
--- a/core/continuum-core/src/experience/source.rs
+++ b/core/continuum-core/src/experience/source.rs
@@ -178,14 +178,39 @@ impl RecipeExperienceSource {
         Self::new(purpose, Self::embedded())
     }
 
-    /// Every purpose the SHIPPED recipe set declares — the validation list
-    /// `activity/spawn` refuses against (#431). Derived from the SAME
-    /// [`Self::embedded`] iterator the registry is built from, so the
-    /// validation set and the resolution set cannot drift. When the disk
-    /// overlay is wired into production (#432), this must grow the overlay
-    /// too — they are the same set by definition.
+    /// Every purpose the SHIPPED recipe set declares. Derived from the SAME
+    /// [`Self::embedded`] iterator the registry is built from, so this list
+    /// and the embedded resolution set cannot drift. Production validation
+    /// goes through [`Self::known_purposes`], which is this PLUS the disk
+    /// overlay — the same union [`Self::builtins_with_overlay`] resolves.
     pub fn shipped_purposes() -> Vec<String> {
         Self::embedded().map(|r| r.purpose).collect()
+    }
+
+    /// The ONE directory production overlays recipes from:
+    /// `<continuum_root>/recipes`. Named here so the resolution side
+    /// ([`Self::builtins_with_overlay`] in the positron projection) and the
+    /// validation side (`activity/spawn`'s `validate_recipe`) derive the same
+    /// path from the same root — two hand-built joins would drift, and a
+    /// drifted pair means an authored recipe that RESOLVES gets REFUSED at
+    /// spawn (or the reverse, the #431 silent-chat downgrade).
+    pub fn overlay_dir(continuum_root: &std::path::Path) -> std::path::PathBuf {
+        continuum_root.join("recipes")
+    }
+
+    /// Every purpose the FULL recipe set declares — embedded floor plus the
+    /// disk overlay under `dir` (#432). This is the validation list
+    /// `activity/spawn` refuses against, and it is the same union
+    /// [`Self::builtins_with_overlay`] builds its registry from, so an
+    /// authored on-disk recipe is spawnable the moment the file exists. A
+    /// malformed overlay recipe is an ERROR naming the file, not a silent
+    /// skip — the author believes it is live.
+    pub fn known_purposes(dir: &std::path::Path) -> Result<Vec<String>, RecipeLoadError> {
+        let overlay = Self::load_dir(dir)?;
+        Ok(Self::embedded()
+            .map(|r| r.purpose)
+            .chain(overlay.into_iter().map(|r| r.purpose))
+            .collect())
     }
 
     /// The declared purpose of a shipped recipe, by its [`shipped`] handle.

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1914,17 +1914,20 @@ pub fn start_server(
         boot_status("airc", kind, &detail);
     }
     let airc_module = Arc::new(AircModule::from_discovery(&discovery));
-    let persona_bootstrap_deps = airc_module
-        .daemon_socket()
-        .map(|p| p.to_path_buf())
-        .zip(airc_module.default_room());
+    // #432 (was the vestigial gate): persona hosting needs the DAEMON SOCKET
+    // only — #298 removed the operator room from birth deps, but the zip here
+    // still required a discovered default room, so "no default room ⇒ no
+    // citizens, for no reason". The room stays a dep ONLY for the consumers
+    // that genuinely ride it: GridCapacityModule (gossip channel) and the
+    // node-level presence emitter.
+    let persona_bootstrap_deps = airc_module.daemon_socket().map(|p| p.to_path_buf());
+    let discovered_default_room = airc_module.default_room();
     let persona_bootstrap_room_name = airc_module.default_room_name().map(|s| s.to_string());
-    // The node-level presence emitter (WS seam below) needs the same
-    // (daemon_socket, default_room) the persona block consumes. Clone the
-    // deps here BEFORE that `if let Some(...)` moves them, so the emitter
-    // can attach a heartbeat-less node reader against the same daemon +
-    // room the citizens attach to.
-    let node_presence_deps = persona_bootstrap_deps.clone();
+    // The node-level presence emitter (WS seam below) needs BOTH the daemon
+    // socket and the default room. Build its pair here, BEFORE the persona
+    // block moves the socket, so the emitter can attach a heartbeat-less node
+    // reader against the same daemon + room the citizens attach to.
+    let node_presence_deps = persona_bootstrap_deps.clone().zip(discovered_default_room);
 
     // AircInterceptor's late-bind Arc<Airc>: the interceptor is built ~800 lines
     // below (inside the executor), synchronously, but `Airc::attach_as` is async and
@@ -1937,7 +1940,7 @@ pub fn start_server(
     let interceptor_airc_deps = persona_bootstrap_deps.clone();
     let airc_interceptor_cell: Arc<tokio::sync::OnceCell<Arc<airc_lib::Airc>>> =
         Arc::new(tokio::sync::OnceCell::new());
-    if let Some((interceptor_daemon_socket, _room)) = interceptor_airc_deps {
+    if let Some(interceptor_daemon_socket) = interceptor_airc_deps {
         let cell = airc_interceptor_cell.clone();
         let root = crate::modules::persona_instance_manager::resolve_continuum_root();
         // `rt_handle.spawn`, NOT bare `tokio::spawn` — this runs in the SYNCHRONOUS boot
@@ -2023,17 +2026,29 @@ pub fn start_server(
         tokio::sync::oneshot::Sender<Arc<crate::runtime::CommandExecutor>>,
     > = None;
 
-    if let Some((daemon_socket, default_room)) = persona_bootstrap_deps {
+    if let Some(daemon_socket) = persona_bootstrap_deps {
         // Grid capacity gossip (#56 step 4): this node offers its live capacity to
         // the grid on the module tick and hears every peer's offers (its own echo
         // included — the loopback proof) via inbound_attach → gossip::global_ledger.
-        // Rides the DISCOVERED default room, same dep the citizens attach to.
-        runtime.register(Arc::new(
-            crate::modules::grid_capacity::GridCapacityModule::new(
-                resource_daemon.clone(),
-                default_room,
-            ),
-        ));
+        // Rides the DISCOVERED default room — the ONE consumer in this block that
+        // genuinely needs it (#432: the room is a gossip channel, not a birth dep;
+        // citizens must come online whether or not a default room was discovered).
+        match discovered_default_room {
+            Some(default_room) => {
+                runtime.register(Arc::new(
+                    crate::modules::grid_capacity::GridCapacityModule::new(
+                        resource_daemon.clone(),
+                        default_room,
+                    ),
+                ));
+            }
+            None => {
+                tracing::warn!(
+                    "no default room discovered — grid capacity gossip is NOT \
+                     registered this run; citizens still boot (#432)"
+                );
+            }
+        }
         let continuum_root = crate::modules::persona_instance_manager::resolve_continuum_root();
         let daemon_socket_for_rag_inspect = daemon_socket.clone();
         let registry = crate::persona::PersonaAircRuntimeRegistry::new();
@@ -2406,6 +2421,25 @@ pub fn start_server(
                         return;
                     }
                 };
+            // #432: size the roster plan to what the provider WILL yield —
+            // every resumed citizen, floored by the mint floor. Before this,
+            // plan slots == floor while the provider held all resumed seeds,
+            // so with 5 citizens on disk and floor=1 only the alphabetically
+            // first came online; the other four sat unhosted forever. The
+            // floor remains a MINT floor only ([[benchmarks-use-our-citizens-never-spawn-disposable-solvers]]:
+            // the durable population is the asset — leaving members unhosted
+            // on disk breaks the contract).
+            let mut supervisor = supervisor;
+            let population = provider.identities_available();
+            if population > persona_floor {
+                tracing::info!(
+                    resumed_plus_floor = population,
+                    persona_floor,
+                    "resumed citizens exceed the mint floor — plan re-sized so \
+                     EVERY citizen on disk comes online (#432)"
+                );
+            }
+            supervisor.set_population(population);
             // Event-driven spawn: the persona host reacts to the serving
             // daemon's published plan (its watch channel) instead of probing
             // the gateway once at boot. The serving daemon ticks every 5s; the

--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -611,11 +611,28 @@ impl ChatProjection {
     }
 
     /// As [`Self::with_purpose`], plus the per-room stores every per-room envelope
-    /// is mirrored into (#408).
+    /// is mirrored into (#408). Experiences resolve from the EMBEDDED recipe set
+    /// only — the right floor for tests and headless fixtures. Production goes
+    /// through [`Self::with_experience`] so on-disk authored recipes resolve too
+    /// (#432).
     fn with_rooms(
         substrate: Substrate,
         purpose_source: crate::ipc::room_purpose::SharedRoomPurpose,
         rooms: Option<std::sync::Arc<continuum_positron::scoping::PerRoomSubstrates>>,
+    ) -> Self {
+        let experience_source = RecipeExperienceSource::builtins(purpose_source.clone());
+        Self::with_experience(substrate, purpose_source, rooms, experience_source)
+    }
+
+    /// As [`Self::with_rooms`], with the experience source INJECTED (#432).
+    /// `spawn` builds it via `builtins_with_overlay` so a recipe authored on
+    /// disk projects without recompiling — the module's own "new experience is
+    /// a new recipe entry, zero code" promise, finally true in production.
+    fn with_experience(
+        substrate: Substrate,
+        purpose_source: crate::ipc::room_purpose::SharedRoomPurpose,
+        rooms: Option<std::sync::Arc<continuum_positron::scoping::PerRoomSubstrates>>,
+        experience_source: RecipeExperienceSource,
     ) -> Self {
         Self {
             rooms,
@@ -633,7 +650,7 @@ impl ChatProjection {
             vitals: HashMap::new(),
             loadout: HashMap::new(),
             genes: HashMap::new(),
-            experience_source: RecipeExperienceSource::builtins(purpose_source.clone()),
+            experience_source,
             experience_builder: StateBuilder::standalone(),
             last_experience: std::cell::RefCell::new(None),
             roster_builder: StateBuilder::standalone(),
@@ -1081,8 +1098,35 @@ pub fn spawn(
     // roster-empty view until presence next changes. `rx` is subscribed
     // above, so the emitter's re-publish lands in our buffer.
     crate::ipc::positron_presence::request_presence_resync(&bus);
+    // #432: production resolves experiences from the embedded floor PLUS the
+    // on-disk overlay (`<continuum_root>/recipes`) — authoring an activity is a
+    // JSON file, zero code, the module's own promise. A malformed overlay file
+    // is REFUSED loudly here, and the projection keeps the embedded floor so
+    // chat itself never goes dark over one bad recipe; the author gets the
+    // second, harder surface at `activity/spawn`, whose validation reads the
+    // SAME directory and returns the parse error naming the file.
+    let overlay_dir = RecipeExperienceSource::overlay_dir(
+        &crate::modules::persona_instance_manager::resolve_continuum_root(),
+    );
+    let experience_source = match RecipeExperienceSource::builtins_with_overlay(
+        purpose.clone(),
+        &overlay_dir,
+    ) {
+        Ok(source) => source,
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                dir = %overlay_dir.display(),
+                "recipe overlay REFUSED — an authored recipe failed to load; \
+                 serving EMBEDDED recipes only until the named file is fixed \
+                 or removed (#432)"
+            );
+            RecipeExperienceSource::builtins(purpose.clone())
+        }
+    };
     rt.spawn(async move {
-        let mut projection = ChatProjection::with_rooms(substrate, purpose, rooms);
+        let mut projection =
+            ChatProjection::with_experience(substrate, purpose, rooms, experience_source);
         if let Some((executor, room)) = seed {
             for payload in fetch_seed_messages(&executor, room).await {
                 if let Some(ProjectionInput::Message(m)) = classify(CHAT_POSTED, &payload) {

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -188,8 +188,20 @@ impl ActionCommand for ActivitySpawn {
 /// rendered as chat for a full campaign: dispatch bound `"benchmark"` while the
 /// shipped recipe's purpose is `"benchmark/hard-rs"`. The refusal names the
 /// actionable set, per the registry's own `ids()`/`purposes()` design note.
-pub fn validate_recipe(recipe: &str) -> Result<(), CommandError> {
-    let known = crate::experience::source::RecipeExperienceSource::shipped_purposes();
+/// `overlay_dir` is the SAME directory the positron projection resolves from
+/// (`RecipeExperienceSource::overlay_dir`), so an authored on-disk recipe is
+/// spawnable the moment the file exists (#432) — validation and resolution
+/// stay one set by construction. A malformed overlay file surfaces HERE as the
+/// parse error naming the file: the author's loudest, most actionable surface.
+pub fn validate_recipe(recipe: &str, overlay_dir: &std::path::Path) -> Result<(), CommandError> {
+    let known = crate::experience::source::RecipeExperienceSource::known_purposes(overlay_dir)
+        .map_err(|e| {
+            CommandError::Invalid(format!(
+                "recipe overlay under {} failed to load — fix or remove the named \
+                 file, then retry: {e}",
+                overlay_dir.display()
+            ))
+        })?;
     if known.iter().any(|k| k == recipe) {
         return Ok(());
     }
@@ -217,7 +229,12 @@ pub async fn spawn_activity_room(
     recipe: &str,
     parent: Option<RoomId>,
 ) -> Result<ActivitySpawnResult, CommandError> {
-    validate_recipe(recipe)?;
+    validate_recipe(
+        recipe,
+        &crate::experience::source::RecipeExperienceSource::overlay_dir(
+            &crate::modules::persona_instance_manager::resolve_continuum_root(),
+        ),
+    )?;
     {
         // `join` IS room creation in airc: it derives the channel from the name,
         // subscribes this peer, and publishes presence. Reusing it keeps ONE room
@@ -499,17 +516,49 @@ mod tests {
     // regression for #431 / commit at benchmark.rs:1091
     #[test]
     fn validate_recipe_refuses_unknown_and_passes_every_shipped_purpose() {
+        let empty_overlay = tempfile::tempdir().expect("tempdir");
         for purpose in crate::experience::source::RecipeExperienceSource::shipped_purposes() {
             assert!(
-                validate_recipe(&purpose).is_ok(),
+                validate_recipe(&purpose, empty_overlay.path()).is_ok(),
                 "shipped purpose {purpose:?} must validate"
             );
         }
-        let err = validate_recipe("benchmark").expect_err("the old dispatch literal must refuse");
+        let err = validate_recipe("benchmark", empty_overlay.path())
+            .expect_err("the old dispatch literal must refuse");
         let msg = format!("{err}");
         assert!(
             msg.contains("benchmark/hard-rs"),
             "refusal must name the actionable set, got: {msg}"
+        );
+    }
+
+    // what this catches (#432): validation and resolution staying ONE set once
+    // the disk overlay is live. An authored on-disk recipe must be spawnable
+    // the moment the file exists — if validate_recipe only consulted the
+    // embedded set, every authored recipe would be refused at activity/spawn
+    // while the projection happily resolved it (or vice versa). Also pins the
+    // fail-loud arm: a malformed overlay file refuses NAMING the file, never a
+    // silent skip.
+    #[test]
+    fn validate_recipe_accepts_overlay_authored_purpose_and_refuses_malformed_overlay() {
+        let overlay = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            overlay.path().join("wordstats.json"),
+            r#"{ "purpose": "bench/wordstats", "regions": [], "affordances": [] }"#,
+        )
+        .expect("write authored recipe");
+        match validate_recipe("bench/wordstats", overlay.path()) {
+            Ok(()) => {}
+            Err(e) => panic!("authored overlay purpose must validate, got: {e}"),
+        }
+
+        std::fs::write(overlay.path().join("broken.json"), "{ not json")
+            .expect("write malformed recipe");
+        let err = validate_recipe("bench/wordstats", overlay.path())
+            .expect_err("a malformed overlay file must refuse loudly");
+        assert!(
+            format!("{err}").contains("broken.json"),
+            "refusal must name the malformed file, got: {err}"
         );
     }
 

--- a/core/continuum-core/src/persona/host.rs
+++ b/core/continuum-core/src/persona/host.rs
@@ -240,6 +240,15 @@ impl PersonaSpawnSupervisor {
         }
     }
 
+    /// Re-size the roster plan to the identity provider's REAL yield (#432).
+    /// Called by the boot task after constructing `ResumeOrMintProvider`,
+    /// whose `identities_available()` counts every resumed citizen on disk —
+    /// the plan must have a slot for each of them, or resumed citizens beyond
+    /// the mint floor sit on disk unhosted forever.
+    pub fn set_population(&mut self, population: usize) {
+        self.spawner.set_population(population);
+    }
+
     /// Run the full boot pipeline:
     ///
     /// 1. `bootstrap_planned`: provider intents → airc-bootstrapped

--- a/core/continuum-core/src/persona/resume_or_mint_provider.rs
+++ b/core/continuum-core/src/persona/resume_or_mint_provider.rs
@@ -110,6 +110,18 @@ impl ResumeOrMintProvider {
             minted_count: 0,
         })
     }
+
+    /// How many identities this provider WILL yield: every resumed citizen on
+    /// disk, floored by the mint floor. The spawner's plan must be sized to
+    /// THIS number, not to the floor alone — before #432, `plan.len()` came
+    /// from `CONTINUUM_PERSONA_FLOOR` while the provider held every resumed
+    /// seed, so with 5 seeds and floor=1 only the alphabetically-first citizen
+    /// came online and the rest sat on disk, silently unhosted. The floor
+    /// stays a MINT floor (how many to create when the disk is emptier than
+    /// it); it must never CAP how many existing citizens resume.
+    pub fn identities_available(&self) -> usize {
+        self.resumed.len().max(self.min_personas)
+    }
 }
 
 #[async_trait]
@@ -297,6 +309,46 @@ mod tests {
         // min_personas=1 satisfied by the resumed one → no extra mint.
         let exhausted = provider.next_persona().await.unwrap();
         assert!(exhausted.is_none());
+    }
+
+    // what this catches (#432): the floor ORPHANING resumed citizens. The
+    // spawner's plan must be sized to identities_available() — every resumed
+    // seed on disk, floored by the mint floor — not to the floor alone. Before
+    // this, 5 seeds + floor=1 meant one hosted citizen and four sitting on
+    // disk, silently unhosted forever.
+    #[tokio::test]
+    async fn identities_available_counts_every_resumed_seed_above_the_floor() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // Empty disk: the mint floor is the whole population.
+        let empty = ResumeOrMintProvider::new(temp.path(), 2)
+            .await
+            .expect("provider");
+        assert_eq!(empty.identities_available(), 2);
+
+        // Three seeds on disk with floor=1: every resumed citizen gets a slot.
+        // Same production layout + writer helper as the other resume tests.
+        let dir =
+            crate::context::citizens_kind_dir(temp.path(), crate::identity::IdentityKind::Persona);
+        for i in 0..3u32 {
+            let name = format!("Citizen{i}");
+            let seed = PersonaSeedFile::V1 {
+                persona_id: Uuid::from_u128(0x432_0000 + u128::from(i)),
+                agent_name: name.clone(),
+                created_at_ms: 1_717_200_000_000,
+                avatar_vrm: None,
+            };
+            write_seed_atomic(&dir.join(&name).join("seed.json"), &seed)
+                .await
+                .expect("write seed");
+        }
+        let provider = ResumeOrMintProvider::new(temp.path(), 1)
+            .await
+            .expect("provider");
+        assert_eq!(
+            provider.identities_available(),
+            3,
+            "floor must MINT, never CAP: all resumed citizens count"
+        );
     }
 
     #[tokio::test]

--- a/core/continuum-core/src/persona/spawner_module.rs
+++ b/core/continuum-core/src/persona/spawner_module.rs
@@ -213,6 +213,15 @@ impl PersonaSpawnerModule {
         self
     }
 
+    /// Mutating sibling of [`Self::with_population`], for the boot task that
+    /// only learns the REAL population after constructing the identity
+    /// provider (#432: the plan must be sized to what the provider will
+    /// yield — every resumed citizen — not to the mint floor alone). Same
+    /// ≥1 clamp; same homogeneous-replication safety as the builder form.
+    pub fn set_population(&mut self, population: usize) {
+        self.population = population.max(1);
+    }
+
     /// Apply the serving daemon's [`ServingPlan`](crate::cognition::serving_plan::ServingPlan):
     /// every desired role runs the plan's base model, lane count, and host-fit
     /// served context window. The daemon makes the honest per-host decision
@@ -479,6 +488,22 @@ pub async fn bootstrap_planned(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches (#432): the boot task re-sizing the plan to the
+    // identity provider's real yield. set_population must grow plan() the same
+    // way with_population does (with the same ≥1 clamp) — if it silently
+    // no-opped, every resumed citizen beyond the mint floor would stay
+    // unhosted on disk again.
+    #[test]
+    fn set_population_resizes_the_plan() {
+        let mut spawner =
+            PersonaSpawnerModule::new(HwCapabilityTier::CpuOnly, HwTierCategory::Compat);
+        assert_eq!(spawner.plan().len(), 1);
+        spawner.set_population(3);
+        assert_eq!(spawner.plan().len(), 3);
+        spawner.set_population(0);
+        assert_eq!(spawner.plan().len(), 1, "clamped to >=1, same as the builder");
+    }
 
     /// Compat tier produces the LCD roster: Helper + Coder both on
     /// Qwen2.5-0.5B. The canonical Intel-Mac startup state #133


### PR DESCRIPTION
Spawn-gate slices 4+5 (#432), completing the survey's remaining structural fixes:

**Floor orphans resumed citizens (5a).** The spawner's plan was sized to `CONTINUUM_PERSONA_FLOOR` while `ResumeOrMintProvider` held every resumed seed on disk — 5 seeds + floor=1 meant one citizen hosted and four orphaned, silently, forever. The boot task now re-sizes the plan to `provider.identities_available()` (= `resumed.max(floor)`): the floor mints, it never caps a resume.

**Vestigial default_room gate (5b).** Persona bootstrap gated on `daemon_socket.zip(default_room)` — no discovered default room meant no citizens, for no reason (#298 removed the operator-room birth dep; the zip outlived it). The persona block now gates on the socket alone. The room remains a dep only for its genuine consumers: `GridCapacityModule` (registered when present, loud warn when absent) and the node-presence emitter (pair rebuilt explicitly).

**Recipe disk overlay wired in prod (4).** `builtins_with_overlay` had zero production callers, so "a new experience is a new recipe entry, zero code" was false in the running system. The chat projection now resolves embedded + `<continuum_root>/recipes` via one canonical `overlay_dir` helper, and #431's `validate_recipe` validates against the SAME union (`known_purposes(overlay_dir)`) — validation and resolution cannot drift, so an authored on-disk recipe is spawnable the moment the file exists. Malformed overlay files refuse loudly, naming the file, at both boot and `activity/spawn`.

Tests: floor/resume matrix on `identities_available`; `set_population` plan resize + clamp; overlay-authored purpose validates; malformed overlay refuses naming the file; all existing recipe/activity/projection tests green. `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo