### PR TITLE
feat(benchmark): shipped recipe declares targeting params + dispatch threads real targeting (#433 dispatch slice)

### DIFF
--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1102,16 +1102,26 @@ impl ActionCommand for BenchmarkDispatch {
                     .into(),
             )
         })?;
-        // Empty params = the recipe's declared defaults (#433). Threading the
-        // run's REAL targeting (suite/instances/team/budget) through here is
-        // the remaining #433 slice for dispatch — until then the binding
-        // carries the defaults honestly rather than nothing.
+        // The run's REAL targeting rides the binding (#433): suite is the
+        // resolved spec's name, instances the caller's explicit selection,
+        // team the resolved roster. Anything not set here (budget) stays at
+        // the recipe's declared default — the binding is the room's honest
+        // self-description, readable through the same pipe as everything else.
+        let mut run_params = std::collections::BTreeMap::new();
+        run_params.insert("suite".to_string(), serde_json::json!(spec.name));
+        if let Some(instances) = &p.instances {
+            run_params.insert("instances".to_string(), serde_json::json!(instances));
+        }
+        run_params.insert(
+            "team".to_string(),
+            serde_json::json!(roster.iter().map(|(who, _)| who).collect::<Vec<_>>()),
+        );
         let room = crate::modules::activity::spawn_activity_room(
             &airc,
             &room_name,
             &bench_recipe,
             None,
-            &Default::default(),
+            &run_params,
         )
         .await?;
 

--- a/core/continuum-core/src/experience/recipes/benchmark.json
+++ b/core/continuum-core/src/experience/recipes/benchmark.json
@@ -34,6 +34,24 @@
       "command": "cognition/observe"
     }
   ],
+  "params": {
+    "suite": {
+      "default": "hard-rs",
+      "doc": "which task manifest to import (task + oracle only, see benchmark/list)"
+    },
+    "instances": {
+      "default": [],
+      "doc": "explicit instance ids to run, in order; empty = suite order"
+    },
+    "team": {
+      "default": [],
+      "doc": "assignee display names; empty = the whole live roster, resolved at dispatch"
+    },
+    "budget": {
+      "default": "4h",
+      "doc": "wall-clock ceiling per attempt"
+    }
+  },
   "layout": {
     "container": "row",
     "children": [

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -845,5 +845,42 @@ mod tests {
                 resolved.params.keys().collect::<Vec<_>>()
             );
         }
+
+        // what this catches (#433): the SHIPPED benchmark recipe's declared
+        // param types drifting from what benchmark dispatch actually sends
+        // (suite: string, instances: array, team: array). Dispatch builds
+        // this exact map shape at benchmark.rs — if a decl's default changed
+        // JSON type, every run-room spawn would refuse at the type gate and
+        // no unit test on either side alone would say why.
+        #[test]
+        fn shipped_benchmark_recipe_accepts_dispatchs_targeting_map() {
+            let empty_overlay = tempfile::tempdir().expect("tempdir");
+            let recipe = resolve_recipe("benchmark/hard-rs", empty_overlay.path())
+                .expect("shipped benchmark recipe resolves");
+            for declared in ["suite", "instances", "team", "budget"] {
+                assert!(
+                    recipe.params.contains_key(declared),
+                    "shipped benchmark recipe must declare {declared:?} (the catalog's \
+                     targeting set), got: {:?}",
+                    recipe.params.keys().collect::<Vec<_>>()
+                );
+            }
+            let dispatch_shaped = std::collections::BTreeMap::from([
+                ("suite".to_string(), serde_json::json!("swe-bench-lite")),
+                (
+                    "instances".to_string(),
+                    serde_json::json!(["sympy__sympy-24152"]),
+                ),
+                ("team".to_string(), serde_json::json!(["Asha", "Anwen"])),
+            ]);
+            let resolved = resolve_params(&recipe, &dispatch_shaped)
+                .expect("dispatch's targeting map must type-check against the decls");
+            assert_eq!(resolved["suite"], serde_json::json!("swe-bench-lite"));
+            assert_eq!(
+                resolved["budget"],
+                serde_json::json!("4h"),
+                "unset budget rides the declared default onto the binding"
+            );
+        }
     }
 }


### PR DESCRIPTION
## What

The **last #433 slice** — closes the gap #2306 left open ("threading the run's REAL targeting through dispatch is the remaining slice").

- **`benchmark.json`** (shipped recipe) declares the catalog's targeting set as param data: `suite` (default `"hard-rs"`, the recipe's namesake), `instances` (`[]` = suite order), `team` (`[]` = whole live roster), `budget` (`"4h"`).
- **Dispatch** (`commands/benchmark.rs`) stops passing an empty map: the run room's binding now carries `suite` = the resolved spec's name, `instances` = the caller's explicit selection (omitted when none so the declared default rides), `team` = the resolved roster names. `budget` stays at the declared default until a caller-facing knob exists.
- Every run room is now **self-describing through the wall binding** — a citizen, renderer, or grader reads what this run targets from the same pipe as everything else (BENCHMARKS-ARE-ADAPTERS law).

## Test

One test pinning the cross-file seam neither side's unit tests could see alone: the shipped recipe declares all four catalog params, and dispatch's exact map shape (`string`/`array`/`array`) type-checks against the decls — with unset `budget` riding its default onto the binding. If a decl's default ever changed JSON type, every run-room spawn would refuse at the #2306 type gate; this test says why before it ships.

## Validation

- `cargo check -p continuum-core --features metal,accelerate` clean
- targeted `cargo test --lib` (activity + experience + benchmark): 102 passed
- no ts-rs changes (data + call-site only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo