### PR TITLE
feat(serving): throughput sentinel — placement-contract readback + decode-rate floor (#441)

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -1470,6 +1470,53 @@ const PRE_STREAM_HEADER_TIMEOUT_SECS: u64 = 300;
 const LANE_RELAUNCH_CONNECT_RETRIES: u32 = 6;
 const LANE_RELAUNCH_RETRY_BASE: std::time::Duration = std::time::Duration::from_secs(1);
 
+/// Warn LOUD when a call's measured decode rate collapses far below the catalog
+/// row's expectation (#441, Joel 2026-08-15: "we need very good tok/sec or it's a
+/// failure. We need warnings when shit hits the fan").
+///
+/// The comparison is decode-only (`predicted_per_second` — undiluted by prefill,
+/// so a long prompt can't false-positive this) against the row's
+/// `tokens_per_second`. Both thresholds are deliberately coarse: this is a
+/// shit-hit-the-fan alarm for order-of-magnitude collapse (CPU-fallback lane,
+/// thrashing pager, contended GPU), not a perf regression tracker — a row whose
+/// estimate is merely 2× optimistic must stay silent.
+///
+/// - `MIN_SAMPLE_TOKENS`: a rate computed over a handful of tokens is noise, and
+///   warmup's first few decodes read slow; a real turn decodes far more.
+/// - `FLOOR_FRACTION`: below a quarter of expectation is a different MACHINE
+///   STATE, not variance.
+///
+/// Stateless by design — one warn per breaching call. During a genuinely
+/// degraded period that is one line per turn, which is the correct volume for
+/// "every consumer of this lane is currently waiting an eternity". Unknown model
+/// rows and rows without an expectation stay silent (no registry = no contract
+/// to breach — external/cloud adapters are not governed lanes).
+fn warn_if_decode_collapsed(model_id: &str, decode_tokens: u32, measured_tps: f64) {
+    const MIN_SAMPLE_TOKENS: u32 = 16;
+    const FLOOR_FRACTION: f64 = 0.25;
+    if decode_tokens < MIN_SAMPLE_TOKENS || measured_tps <= 0.0 {
+        return;
+    }
+    let Some(expected) = crate::model_registry::try_global()
+        .and_then(|r| r.model(model_id).map(|m| m.tokens_per_second as f64))
+        .filter(|e| *e > 0.0)
+    else {
+        return;
+    };
+    if measured_tps < expected * FLOOR_FRACTION {
+        tracing::warn!(
+            probe_class = "serving.throughput.degraded",
+            model = model_id,
+            measured_tps = measured_tps,
+            expected_tps = expected,
+            decode_tokens = decode_tokens,
+            "THROUGHPUT COLLAPSE: decode {measured_tps:.1} t/s vs expected {expected:.0} t/s \
+             — this lane is serving at a fraction of its catalog rate. Suspect CPU fallback \
+             (see serving.placement.cpu_fallback), pager thrash, or GPU contention (#441)."
+        );
+    }
+}
+
 /// One streamed SSE frame from an OpenAI-compatible `/v1/chat/completions` with
 /// `stream: true`. Each frame carries an incremental `delta`; `usage` arrives only
 /// on the final frame (requires `stream_options.include_usage`).
@@ -2743,6 +2790,14 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
             decode_ms: t.predicted_ms,
             decode_tokens_per_second: t.predicted_per_second,
         });
+        // THROUGHPUT FLOOR (#441): every call already carries the lane's own decode
+        // rate; the catalog row states what this model is EXPECTED to serve at. A
+        // collapse far below expectation is the eternity-class failure nobody was
+        // catching (CPU-fallback lane, thrashing pager, contended GPU) — warn on
+        // every breaching call rather than wait for a human to notice slowness.
+        if let Some(t) = &timing {
+            warn_if_decode_collapsed(model, t.decode_tokens, t.decode_tokens_per_second);
+        }
 
         Ok(TextGenerationResponse {
             text,

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -1481,10 +1481,13 @@ const LANE_RELAUNCH_RETRY_BASE: std::time::Duration = std::time::Duration::from_
 /// thrashing pager, contended GPU), not a perf regression tracker — a row whose
 /// estimate is merely 2× optimistic must stay silent.
 ///
-/// - `MIN_SAMPLE_TOKENS`: a rate computed over a handful of tokens is noise, and
-///   warmup's first few decodes read slow; a real turn decodes far more.
-/// - `FLOOR_FRACTION`: below a quarter of expectation is a different MACHINE
-///   STATE, not variance.
+/// The classification itself is delegated to the canonical
+/// [`crate::inference::throughput_expectation::classify_throughput`] — this
+/// call site only supplies policy: a sample-size gate (a rate computed over a
+/// handful of tokens is noise, and warmup's first few decodes read slow) and a
+/// collapse floor (below a quarter of expectation is a different MACHINE
+/// STATE, not variance — a row whose estimate is merely 2× optimistic must
+/// stay silent).
 ///
 /// Stateless by design — one warn per breaching call. During a genuinely
 /// degraded period that is one line per turn, which is the correct volume for
@@ -1492,9 +1495,7 @@ const LANE_RELAUNCH_RETRY_BASE: std::time::Duration = std::time::Duration::from_
 /// rows and rows without an expectation stay silent (no registry = no contract
 /// to breach — external/cloud adapters are not governed lanes).
 fn warn_if_decode_collapsed(model_id: &str, decode_tokens: u32, measured_tps: f64) {
-    const MIN_SAMPLE_TOKENS: u32 = 16;
-    const FLOOR_FRACTION: f64 = 0.25;
-    if decode_tokens < MIN_SAMPLE_TOKENS || measured_tps <= 0.0 {
+    if decode_tokens < 16 || measured_tps <= 0.0 {
         return;
     }
     let Some(expected) = crate::model_registry::try_global()
@@ -1503,12 +1504,21 @@ fn warn_if_decode_collapsed(model_id: &str, decode_tokens: u32, measured_tps: f6
     else {
         return;
     };
-    if measured_tps < expected * FLOOR_FRACTION {
+    // Collapse alarm only: floor 0.25 of catalog rate, no above-par ceiling
+    // (this seam never celebrates over-delivery — it screams on collapse).
+    let verdict = crate::inference::throughput_expectation::classify_throughput(
+        measured_tps,
+        expected,
+        0.25,
+        f64::INFINITY,
+    );
+    if verdict.is_degraded() {
         tracing::warn!(
             probe_class = "serving.throughput.degraded",
             model = model_id,
             measured_tps = measured_tps,
             expected_tps = expected,
+            ratio = verdict.ratio(),
             decode_tokens = decode_tokens,
             "THROUGHPUT COLLAPSE: decode {measured_tps:.1} t/s vs expected {expected:.0} t/s \
              — this lane is serving at a fraction of its catalog rate. Suspect CPU fallback \

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -1526,6 +1526,11 @@ pub struct LlamaServerProcess {
     /// polled by the serving daemon. Live lane only — an ephemeral lane has no daemon
     /// watching it and tears down its own process, so its watcher would report into a void.
     wedge: Option<crate::inference::wedge::WedgeFlag>,
+    /// The engine's own offload banner (`offloaded X/Y layers to GPU`), recorded by the
+    /// same stderr pump — the READBACK half of the placement contract (#441). Every lane
+    /// carries it (live and ephemeral): a CPU-fallback eval lane silently corrupts a
+    /// benchmark's wall-clock exactly like a live one starves citizens.
+    offload: crate::inference::placement_watch::OffloadReport,
 }
 
 impl LlamaServerProcess {
@@ -1545,6 +1550,7 @@ impl LlamaServerProcess {
             // pidfile. `new()`/`with_client()` are the live constructors.
             is_live_lane: true,
             wedge: Some(crate::inference::wedge::WedgeFlag::new()),
+            offload: crate::inference::placement_watch::OffloadReport::new(),
         }
     }
 
@@ -1571,6 +1577,7 @@ impl LlamaServerProcess {
             // No serving daemon watches an ephemeral lane, and its owner tears the process
             // down when the eval ends — a wedge report would have no consumer.
             wedge: None,
+            offload: crate::inference::placement_watch::OffloadReport::new(),
         }
     }
 
@@ -2455,9 +2462,18 @@ impl LlamaServerControl for LlamaServerProcess {
         // `progress = 1.10` is wedged; the decode heartbeat can't see it (the OTHER slots
         // still decode, so the lane reads healthy) — which is how one slot burned four
         // hours on 2026-08-05. The watcher only RAISES; the serving daemon reaps.
+        // The same pump also records the engine's OFFLOAD BANNER — the readback half of
+        // the placement contract (#441): the governor planned a placement, the banner is
+        // what the engine actually allocated, and serve() compares them after readiness.
+        let offload_watch = Box::new(super::placement_watch::OffloadWatch::new(
+            self.offload.clone(),
+        ));
         let watch: Box<dyn super::child_log::LineWatch> = match self.wedge.clone() {
-            Some(flag) => Box::new(super::wedge::WedgeWatch::new(flag)),
-            None => Box::new(()),
+            Some(flag) => Box::new(super::placement_watch::ChainWatch(
+                Box::new(super::wedge::WedgeWatch::new(flag)),
+                offload_watch,
+            )),
+            None => offload_watch,
         };
         match (child.stderr.take(), log_path) {
             (Some(stderr), Some(path)) => super::child_log::drain_capped(stderr, path, watch),
@@ -2533,6 +2549,45 @@ impl LlamaServerControl for LlamaServerProcess {
         *self.served_adapters.lock().unwrap() = target.adapter_paths();
 
         self.wait_ready().await?;
+        // PLACEMENT CONTRACT READBACK (#441, Joel 2026-08-15: "models that got fucked by
+        // serving and are on cpu. You never catch it and we are waiting an eternity").
+        // The governor planned a placement; the engine's own load banner says what it
+        // ACTUALLY allocated. A GPU-placement lane that offloaded ZERO layers is the
+        // whole model on CPU — it answers /health, decodes at a tenth of the planned
+        // speed, and nothing else in the system can see the difference. This is a lease
+        // violation, not a tuning note: probe LOUD so the daemon/operator respond,
+        // never wait for a human to notice the eternity. (Partial offload is legit —
+        // MoE cold-expert `-ot` splits offload a subset by design; only 0-of-N on a
+        // GPU-intent lane is unambiguous.) The watcher only REPORTS; lifecycle stays
+        // with the daemon, same doctrine as the wedge flag.
+        if target.placement != LanePlacement::Cpu {
+            match self.offload.get() {
+                Some((0, total)) => {
+                    crate::probe!(
+                        class = "serving.placement.cpu_fallback",
+                        port = port,
+                        model = target.model_id(),
+                        total_layers = total,
+                        "PLACEMENT VIOLATION: GPU-placement lane offloaded 0/{total} layers \
+                         — the model is running ON CPU. Throughput will be an order of \
+                         magnitude below plan; every consumer of this lane is degraded (#441).",
+                    );
+                }
+                Some(_) => {}
+                None => {
+                    // No banner observed is a different fact from "reported 0" — an
+                    // engine build that never prints it would otherwise read as
+                    // healthy forever, which is exactly the silent class this exists
+                    // to kill. Say so once, quietly.
+                    tracing::info!(
+                        probe_class = "serving.placement.unreported",
+                        port = port,
+                        "no offload banner observed by readiness — placement readback \
+                         unavailable for this lane (#441)"
+                    );
+                }
+            }
+        }
         // GENOME DORMANCY (glass-boxed 2026-07-23): llama.cpp loads every
         // `--lora` at scale 1.0 — ALL ACTIVE, superimposed. Four personas'
         // adapters blended at full scale produced the degenerate-decode plague

--- a/core/continuum-core/src/inference/mod.rs
+++ b/core/continuum-core/src/inference/mod.rs
@@ -55,6 +55,7 @@ pub mod ort_providers;
 pub mod placement_capture;
 pub mod recipe_budget;
 pub mod throughput_expectation;
+pub mod placement_watch;
 pub mod vendored;
 pub mod vision_sidecar;
 pub mod wedge;

--- a/core/continuum-core/src/inference/placement_watch.rs
+++ b/core/continuum-core/src/inference/placement_watch.rs
@@ -1,0 +1,156 @@
+//! Verifying that the lane's ACTUAL allocation matches the governor's placement.
+//!
+//! # The failure class (Joel, 2026-08-15)
+//!
+//! > "You ignore and miss major throughput issues including models that got fucked by
+//! > serving and are on cpu. You never catch it and we are waiting an eternity."
+//!
+//! The governor plans a placement ([`super::llama_server::LanePlacement`]) and the spawn
+//! passes flags — but llama.cpp decides the real allocation at load time, and it can land
+//! somewhere else entirely (Metal init failure, VRAM exhaustion at map time, a build
+//! without GPU kernels). When that happens the lane still answers `/health`, still
+//! decodes, still reads `ready` — at a tenth of the planned speed, silently, for hours.
+//! A lease nobody reads back is a suggestion: this module is the READBACK half of the
+//! placement contract. Plan → actuate → **verify the engine's own account of what it
+//! allocated** → mismatch is a lease violation, surfaced loud.
+//!
+//! # The signal
+//!
+//! llama.cpp's load banner states the allocation in one line:
+//!
+//! ```text
+//! load_tensors: offloaded 63/63 layers to GPU
+//! ```
+//!
+//! `offloaded 0/63` on a GPU-placement lane is not "slow" — it is the whole model on CPU,
+//! the exact eternity-class failure quoted above. The stderr pump already reads every
+//! line the engine emits ([`super::child_log`]), so the receipt costs one comparison per
+//! line: no new probe, no new tick, no second connection to the engine.
+//!
+//! # What it does NOT do
+//!
+//! It does not kill anything and it does not decide policy. It records the engine's own
+//! report into a shared cell; the spawn path (which knows the PLANNED placement) compares
+//! and raises loud. Lane lifecycle stays with exactly one owner — the same doctrine as
+//! [`super::wedge`].
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use super::child_log::LineWatch;
+
+/// The engine's own report of how many layers it offloaded to GPU: `(offloaded, total)`.
+///
+/// Packed into one `AtomicU64` (`offloaded << 32 | total`) so readers get a coherent pair
+/// without a lock — the pump thread writes once at load, everything after is reads.
+/// `None` until the load banner has been observed (a lane mid-load has no report yet,
+/// which is a different fact from "reported 0").
+#[derive(Clone, Default)]
+pub struct OffloadReport(Arc<AtomicU64>);
+
+/// Sentinel for "no banner observed yet" — a real report always has `total > 0`.
+const UNREPORTED: u64 = 0;
+
+impl OffloadReport {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The engine's `(offloaded, total)` layer counts, once its load banner has printed.
+    pub fn get(&self) -> Option<(u32, u32)> {
+        let v = self.0.load(Ordering::Relaxed);
+        if v == UNREPORTED {
+            return None;
+        }
+        Some(((v >> 32) as u32, v as u32))
+    }
+
+    fn set(&self, offloaded: u32, total: u32) {
+        self.0
+            .store(((offloaded as u64) << 32) | total as u64, Ordering::Relaxed);
+    }
+}
+
+/// The [`LineWatch`] that records the engine's offload banner into an [`OffloadReport`].
+///
+/// Cheap per line (a substring probe before any parsing) and never blocks — the pump's
+/// contract. Repeated banners (a `-ot` split prints per-buffer lines on some builds)
+/// keep the LAST parsed values; the final banner is the settled allocation.
+pub struct OffloadWatch {
+    report: OffloadReport,
+}
+
+impl OffloadWatch {
+    pub fn new(report: OffloadReport) -> Self {
+        Self { report }
+    }
+}
+
+impl LineWatch for OffloadWatch {
+    fn observe(&mut self, line: &str) {
+        if let Some((offloaded, total)) = parse_offload_banner(line) {
+            self.report.set(offloaded, total);
+        }
+    }
+}
+
+/// Chain two watches over one pump — the stderr sink asks BOTH questions (wedge +
+/// placement) of every line without a second reader. Each stays a single-question
+/// observer per the [`LineWatch`] doctrine; this is composition, not a mega-watcher.
+pub struct ChainWatch(pub Box<dyn LineWatch>, pub Box<dyn LineWatch>);
+
+impl LineWatch for ChainWatch {
+    fn observe(&mut self, line: &str) {
+        self.0.observe(line);
+        self.1.observe(line);
+    }
+}
+
+/// Parse llama.cpp's offload banner: `... offloaded X/Y layers to GPU`.
+///
+/// Pure (str in, pair out) so the shape is pinned by tests without a server. Tolerant of
+/// the prefix (`load_tensors:` vs `llm_load_tensors:` has drifted across llama.cpp
+/// versions) but strict about the phrase itself — a line mentioning "offloaded" in some
+/// other grammar parses `None` rather than guessing.
+pub fn parse_offload_banner(line: &str) -> Option<(u32, u32)> {
+    let idx = line.find("offloaded ")?;
+    let rest = &line[idx + "offloaded ".len()..];
+    let (frac, tail) = rest.split_once(' ')?;
+    if !tail.trim_start().starts_with("layers to GPU") {
+        return None;
+    }
+    let (x, y) = frac.split_once('/')?;
+    Some((x.trim().parse().ok()?, y.trim().parse().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the banner parse must match llama.cpp's real load line in both
+    // prefix spellings, reject lookalike grammar, and round-trip through the shared cell
+    // — this is the placement contract's READBACK, and a silent parse miss here means a
+    // CPU-fallback lane reads as "unreported" forever (the eternity-class failure this
+    // module exists to catch, Joel 2026-08-15).
+    #[test]
+    fn offload_banner_parses_and_reports() {
+        assert_eq!(
+            parse_offload_banner("load_tensors: offloaded 63/63 layers to GPU"),
+            Some((63, 63))
+        );
+        assert_eq!(
+            parse_offload_banner("llm_load_tensors: offloaded 0/33 layers to GPU"),
+            Some((0, 33))
+        );
+        // Lookalike grammar must not parse — no guessing.
+        assert_eq!(parse_offload_banner("offloaded all layers to GPU"), None);
+        assert_eq!(parse_offload_banner("slot update: task offloaded 3/4"), None);
+
+        let report = OffloadReport::new();
+        assert_eq!(report.get(), None, "no banner yet = no report, not (0,0)");
+        let mut watch = OffloadWatch::new(report.clone());
+        watch.observe("noise line");
+        watch.observe("load_tensors: offloaded 0/48 layers to GPU");
+        assert_eq!(report.get(), Some((0, 48)));
+    }
+}

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -563,6 +563,22 @@ impl PersonaAircRuntime {
             let handle = tokio::spawn(async move {
                 let mut ticker = tokio::time::interval(DEFAULT_HEARTBEAT_INTERVAL);
                 let mut last: Option<airc_lib::AgentAvailabilityState> = None;
+                // CLAIM RENEWAL RUNS ON ITS OWN, SLOWER CADENCE (Joel 2026-08-15:
+                // "Heartbeat needs fix. That is no good"). Presence needs the 60s
+                // pulse — roster liveness IS a fast question. A 30-minute claim
+                // lease does not: renewing it every presence tick emitted ~30× the
+                // events one lease needs, and that churn crossed the wire to EVERY
+                // subscriber on every node. Renew at TTL/3 — derived from the one
+                // lease constant, never a second magic number — which still gives a
+                // healthy citizen three renewal opportunities per lease. The stamp
+                // is only advanced on a fully-clean pass, so any roster-read or
+                // per-card failure falls back to retrying on the NEXT 60s tick
+                // (exactly the old cadence) until clean — degraded mode is the old
+                // behavior, never a wider gap.
+                let renewal_period = std::time::Duration::from_millis(
+                    crate::modules::work::DEFAULT_CLAIM_TTL_MS / 3,
+                );
+                let mut last_clean_renewal: Option<std::time::Instant> = None;
                 loop {
                     ticker.tick().await;
                     let serving = crate::inference::llama_server::current_serving();
@@ -631,6 +647,11 @@ impl PersonaAircRuntime {
                     //
                     // Renewal is per-card WARN-and-continue: a failed renewal degrades
                     // to exactly the old lapse, and never takes down presence.
+                    let renewal_due = last_clean_renewal
+                        .map_or(true, |t| t.elapsed() >= renewal_period);
+                    if !renewal_due {
+                        continue;
+                    }
                     match hb_airc
                         .work_roster_status(airc_lib::WorkRosterQuery::default())
                         .await
@@ -644,6 +665,7 @@ impl PersonaAircRuntime {
                                 .map(|r| r.active_claims)
                                 .unwrap_or_default();
                             let mut renewed = 0usize;
+                            let mut failed = 0usize;
                             for card in &mine {
                                 let Some(claim_id) = card.claim_id else {
                                     continue;
@@ -656,6 +678,7 @@ impl PersonaAircRuntime {
                                     })
                                     .await
                                 {
+                                    failed += 1;
                                     warn!(
                                         persona_id = %hb_persona,
                                         agent_name = %hb_name,
@@ -676,8 +699,13 @@ impl PersonaAircRuntime {
                                     renewed = renewed,
                                     held = mine.len(),
                                     ttl_ms = crate::modules::work::DEFAULT_CLAIM_TTL_MS,
-                                    "held work-card claims renewed on the presence pulse"
+                                    "held work-card claims renewed on the claim cadence (TTL/3)"
                                 );
+                            }
+                            // Only a fully-clean pass earns the slow cadence; any
+                            // failure retries on the next 60s presence tick.
+                            if failed == 0 {
+                                last_clean_renewal = Some(std::time::Instant::now());
                             }
                         }
                         Err(error) => {
@@ -685,7 +713,8 @@ impl PersonaAircRuntime {
                                 persona_id = %hb_persona,
                                 agent_name = %hb_name,
                                 error = %error,
-                                "claim-renewal roster read failed — holds may lapse this tick"
+                                "claim-renewal roster read failed — holds may lapse; retrying \
+                                 on the next presence tick"
                             );
                         }
                     }


### PR DESCRIPTION
## What

Joel's directive: *"we need very good tok/sec or it's a failure. We need warnings when shit hits the fan. You ignore and miss major throughput issues including models that got fucked by serving and are on cpu."*

Two detectors, both riding **existing** machinery (no new monitor task, no new tick):

1. **Placement contract readback** (`inference/placement_watch.rs`, new): the stderr pump that already feeds the log cap + wedge watch now also records the engine's own `offloaded X/Y layers to GPU` banner. After readiness, `serve()` compares it against the *planned* placement — a GPU-intent lane at **0/N layers** probes `serving.placement.cpu_fallback` as a **PLACEMENT VIOLATION** (the model is on CPU; every consumer is waiting an eternity). Partial offload stays silent (MoE `-ot` splits are by design); "no banner" is reported as its own fact, never conflated with healthy. Watcher reports, daemon owns lifecycle — the wedge doctrine.

2. **Decode-rate floor** (`ai/openai_adapter.rs`): every streamed call already parses lane timings; measured decode t/s (predicted-only, prefill can't false-positive it) is compared against the catalog row's `tokens_per_second`. Below 25% of expectation on a ≥16-token sample → `serving.throughput.degraded` naming measured vs expected + suspect causes. Coarse by design: an order-of-magnitude-collapse alarm, not a perf tracker.

## Why this shape

This is the readback half of the governor's lease: plan → actuate → **verify the engine's own account of what it allocated**. A lease nobody reads back is a suggestion — the exact bypass class Joel called out.

## Verification

- `cargo check -p continuum-core --features metal,accelerate` clean
- New regression test green: banner parse (both prefix spellings, lookalike rejection, no-banner ≠ zero)
- Live proof owed post-deploy: a real CPU-fallback (or induced one on an ephemeral lane) firing the probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo