### PR TITLE
fix(persona): runtime room joins reach the LIVE perception stream — deaf run rooms (P0 20b44763)

### DIFF
--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1142,7 +1142,12 @@ impl ActionCommand for BenchmarkDispatch {
         for (who, peer) in &roster {
             match self.registry.get(*peer) {
                 Some(rt) => {
-                    if let Err(e) = rt.airc().join(&room_name).await {
+                    // join_room, not airc().join: it bumps the membership epoch so
+                    // her LIVE perception stream re-opens with the new room in its
+                    // channel snapshot. A bare join grants durable membership to a
+                    // room she structurally cannot hear (P0 20b44763 — three rounds
+                    // of kickoffs into deaf run rooms, zero turns).
+                    if let Err(e) = rt.join_room(&room_name).await {
                         room_join_errors.push(format!("{who}: {e}"));
                     }
                 }

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -117,6 +117,27 @@ pub trait AircCitizen:
     /// to drive the service loop.
     async fn subscribe_all_rooms(&self) -> Result<FilteredEventStream, AircError>;
 
+    /// Watch receiver whose value increments whenever this citizen's room
+    /// membership GROWS at runtime (a join after spawn) — the perception
+    /// stream's rebuild cue (P0 20b44763). airc-lib's
+    /// `subscribe_subscribed_filtered` snapshots the subscribed-channel
+    /// list ONCE at subscribe time, so a room joined later (benchmark
+    /// dispatch moving assignees into a fresh run room) never enters an
+    /// existing stream — the run room is born deaf. Consumers select on
+    /// this beside the stream and re-open it (via
+    /// [`subscribe_all_rooms`](Self::subscribe_all_rooms)) when the epoch
+    /// moves. The sibling of the 2026-08-08 narrowing bug documented on
+    /// `subscribe_all_rooms` above: that one snapshotted the WRONG SET,
+    /// this one snapshots the right set at the WRONG TIME.
+    ///
+    /// Default: a receiver whose sender is already dropped — membership
+    /// never changes for stubs/fixtures. Consumers MUST treat a closed
+    /// channel as "never fires" (park on `pending()`), never as an event,
+    /// or a stub conversation would busy-loop on `changed() == Err`.
+    fn membership_epoch(&self) -> tokio::sync::watch::Receiver<u64> {
+        tokio::sync::watch::channel(0u64).1
+    }
+
     /// Publish a text message under the citizen's identity INTO A
     /// SPECIFIC ROOM — normally the room the turn being answered
     /// arrived in ([`IncomingMessage::room_id`](super::service_loop::IncomingMessage),
@@ -388,6 +409,23 @@ mod tests {
     // degradation path (sources stay uncached, logged loud). What must never happen is
     // an Ok(empty stream): that would look like a live subscription that silently never
     // invalidates — the actual fallback.
+    // what this catches: the default `membership_epoch` contract (P0 20b44763) —
+    // a CLOSED receiver (sender already dropped). The conversation's select loop
+    // parks on `pending()` when `changed()` errs; if a future default swapped to
+    // a live-but-never-moving channel (or a consumer treated Err as an event),
+    // stub-driven conversations would either deadlock waiting on a phantom
+    // membership change or busy-loop resubscribing. Closed = "membership never
+    // changes", and this pins that both ways.
+    #[tokio::test]
+    async fn default_membership_epoch_is_a_closed_channel() {
+        let stub: Arc<dyn AircCitizen> = Arc::new(StubAircCitizen::new(Uuid::new_v4()));
+        let mut rx = stub.membership_epoch();
+        assert!(
+            rx.changed().await.is_err(),
+            "default epoch sender must be dropped — consumers park, never poll"
+        );
+    }
+
     #[tokio::test]
     async fn stub_subscribe_refuses_rather_than_faking_a_stream() {
         let stub: Arc<dyn AircCitizen> = Arc::new(StubAircCitizen::new(Uuid::new_v4()));

--- a/core/continuum-core/src/persona/airc_persona_conversation.rs
+++ b/core/continuum-core/src/persona/airc_persona_conversation.rs
@@ -78,6 +78,16 @@ pub struct AircPersonaConversation {
     /// wire-schema fault it surfaces loud, card 807193ab), which we
     /// re-surface rather than mask.
     stream: Option<FilteredEventStream>,
+    /// Membership-change cue (P0 20b44763): when the citizen joins a room at
+    /// RUNTIME (benchmark dispatch moving her into a fresh run room), this
+    /// epoch moves and `next_message` re-opens the stream so the new room's
+    /// events reach her. Without it the stream keeps the spawn-time channel
+    /// snapshot forever and every later-joined room is born deaf — measured
+    /// live 2026-08-15: three bench rounds, 12 addressed kickoffs each, zero
+    /// turns. NOT the forbidden auto-resubscribe fallback documented on the
+    /// terminal-`None` arm below: that masks a wire fault; this answers a
+    /// REAL membership event, the system-law event-driven shape.
+    membership_epoch: tokio::sync::watch::Receiver<u64>,
 }
 
 impl AircPersonaConversation {
@@ -85,10 +95,12 @@ impl AircPersonaConversation {
     /// is built on first `next_message`; until then this is free.
     pub fn new(runtime: Arc<dyn AircCitizen>) -> Self {
         let own_peer_id = runtime.peer_id();
+        let membership_epoch = runtime.membership_epoch();
         Self {
             runtime,
             own_peer_id,
             stream: None,
+            membership_epoch,
         }
     }
 
@@ -161,12 +173,14 @@ impl PersonaConversation for AircPersonaConversation {
         // visibly — never silently lazy-subscribes (PR #1514 reviewer
         // fix: the soft-language lazy fallback was a silent-degradation
         // shape we refuse).
-        let stream = self.stream.as_mut().ok_or_else(|| {
-            "AircPersonaConversation::next_message called before prime() — caller must \
-             invoke prime() before iterating (serve_persona_loop does this automatically \
-             at boot)"
-                .to_string()
-        })?;
+        if self.stream.is_none() {
+            return Err(
+                "AircPersonaConversation::next_message called before prime() — caller must \
+                 invoke prime() before iterating (serve_persona_loop does this automatically \
+                 at boot)"
+                    .to_string(),
+            );
+        }
 
         // Skip self / non-text inline — they're not "next messages"
         // from the loop's perspective. Yielding them with the loop
@@ -174,7 +188,45 @@ impl PersonaConversation for AircPersonaConversation {
         // over-counts skips for events the conversation already
         // knows aren't relevant.
         loop {
-            match stream.next().await {
+            // Wait on EITHER the next event OR a membership-epoch move. The
+            // epoch branch is the P0 20b44763 fix: a room joined at runtime
+            // (benchmark dispatch) never enters the existing stream's channel
+            // snapshot, so on a membership change we re-open the stream with
+            // the enlarged set. A closed epoch channel (stub citizens whose
+            // default `membership_epoch` drops its sender) parks on
+            // `pending()` — closed means "membership never changes", never
+            // an event, or stubs would busy-loop on `changed() == Err`.
+            let polled = {
+                let stream = self
+                    .stream
+                    .as_mut()
+                    .expect("stream checked Some at next_message entry");
+                let epoch = &mut self.membership_epoch;
+                tokio::select! {
+                    ev = stream.next() => Some(ev),
+                    _ = async {
+                        if epoch.changed().await.is_err() {
+                            std::future::pending::<()>().await;
+                        }
+                    } => None,
+                }
+            };
+            let Some(polled) = polled else {
+                tracing::info!(
+                    persona = %self.own_peer_id,
+                    probe_class = "persona.inbound.resubscribed",
+                    "room membership changed at runtime — re-opening the subscribe \
+                     stream with the enlarged channel snapshot (P0 20b44763)"
+                );
+                let stream = self
+                    .runtime
+                    .subscribe_all_rooms()
+                    .await
+                    .map_err(|e| format!("resubscribe after membership change failed: {e}"))?;
+                self.stream = Some(stream);
+                continue;
+            };
+            match polled {
                 None => {
                     // Transient transport loss (daemon restart, socket
                     // drop) is NOT seen here — airc-lib's `subscribe()`

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -176,6 +176,14 @@ pub struct PersonaAircRuntime {
     home: PathBuf,
     airc: Arc<Airc>,
     default_room: RoomId,
+    /// Bumped by [`Self::join_room`] whenever this citizen's room membership
+    /// GROWS at runtime. The perception stream's rebuild cue (P0 20b44763):
+    /// airc-lib's `subscribe_subscribed_filtered` snapshots the subscribed
+    /// channel list ONCE at subscribe time, so a room joined after `prime()`
+    /// (benchmark dispatch moving assignees into a fresh run room) never
+    /// enters an existing stream — the run room is born deaf. Watchers of
+    /// [`AircCitizen::membership_epoch`] re-open their stream when this moves.
+    membership_epoch: tokio::sync::watch::Sender<u64>,
     inbound_handle: Option<JoinHandle<()>>,
     /// Per-persona command inbound pump (task #222). When `Some`,
     /// this persona's airc handle is wired to receive cross-grid
@@ -837,12 +845,28 @@ impl PersonaAircRuntime {
             // state above) — before #298 this stored the passed-in operator
             // room, which could even diverge from the joined channel.
             default_room: RoomId::from_uuid(room.channel.as_uuid()),
+            membership_epoch: tokio::sync::watch::channel(0u64).0,
             inbound_handle: None,
             command_pump: Some(command_pump),
             heartbeat,
             identity_republish,
             source,
         })
+    }
+
+    /// Join a room UNDER THIS CITIZEN'S IDENTITY at runtime and bump the
+    /// membership epoch so her live perception stream re-opens with the
+    /// enlarged channel snapshot (P0 20b44763). This — not `airc().join`
+    /// directly — is the ONE runtime-join path for a living persona:
+    /// airc-lib's `subscribe_subscribed_filtered` collects the channel list
+    /// once at subscribe time, so a bare join grants durable membership to a
+    /// room whose events her existing stream will never carry (measured
+    /// 2026-08-15: three benchmark rounds, 12 addressed kickoffs each, zero
+    /// turns — every per-run room was born deaf).
+    pub async fn join_room(&self, name: &str) -> Result<(), AircError> {
+        self.airc.join(name).await?;
+        self.membership_epoch.send_modify(|e| *e += 1);
+        Ok(())
     }
 
     /// Wrap an already-attached + already-joined `Arc<Airc>` into a
@@ -887,6 +911,7 @@ impl PersonaAircRuntime {
             home,
             airc,
             default_room,
+            membership_epoch: tokio::sync::watch::channel(0u64).0,
             inbound_handle: None,
             // from_attached is sync + the pump install is async, so
             // we don't install at construction. Callers that want the
@@ -1109,6 +1134,10 @@ impl crate::persona::airc_citizen::AircCitizen for PersonaAircRuntime {
 
     async fn subscribe_all_rooms(&self) -> Result<airc_lib::FilteredEventStream, AircError> {
         crate::persona::airc_citizen::subscribe_every_room(&self.airc).await
+    }
+
+    fn membership_epoch(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.membership_epoch.subscribe()
     }
 
     async fn say_in(&self, room_id: Uuid, text: &str) -> Result<EventId, AircError> {


### PR DESCRIPTION
## The bug that killed every benchmark round

MEASURED 2026-08-15: three dispatch rounds, 12 addressed kickoffs each into per-run activity rooms, **zero citizen turns** — while the same citizens turn instantly on an academy message. No round has ever reached a claim, a write, or the grader: the chain dies at **perception**, not grading.

Root cause, both ends read in-file: airc-lib's `subscribe_subscribed_filtered` snapshots the subscribed-channel list ONCE at subscribe time (`messaging.rs:302`), and the persona's perception stream opens once at `prime()`. Dispatch's `rt.airc().join(run_room)` grants durable membership to a channel her existing stream structurally cannot carry — **every per-run room is born deaf**.

## The wire (event-driven, not a fallback)

- `PersonaAircRuntime.membership_epoch` (watch) + `join_room()` — THE runtime-join path; bumps the epoch after `airc.join`.
- `AircCitizen::membership_epoch()` default = closed receiver (stubs never change membership; consumers park on closed, never busy-loop — contract pinned by test).
- `AircPersonaConversation::next_message` selects on the stream OR an epoch move; on a move it re-opens via `subscribe_all_rooms` with the enlarged snapshot (`persona.inbound.resubscribed` probe). Distinct from the terminal-`None` no-auto-resubscribe doctrine: that masks wire faults; this answers a real membership event.
- Benchmark dispatch joins assignees via `join_room`.

Sibling of the 2026-08-08 narrowing bug on the same trait: that snapshotted the WRONG SET; this snapshotted the right set at the WRONG TIME.

## Validation

- `cargo check` clean; airc_citizen + airc_persona_conversation mods: 11 passed.
- New test: `default_membership_epoch_is_a_closed_channel` (park-vs-busy-loop contract).
- **Live acceptance owed after deploy**: dispatch a round → citizen turn fires on the kickoff IN the run room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo