### PR TITLE
fix(cognition): think-only generation routes the teacher sentinel, not empty Speak (#181 tail)

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -1997,6 +1997,36 @@ impl Faculty for LlmDeliberationFaculty {
                         );
                         return Some(self.act_verdict(vec![call], &resp));
                     }
+                    // THINK-ONLY turn (#181 tail, glass-boxed on the 2026-08-15 bench
+                    // round): she spent the ENTIRE generation inside the reasoning
+                    // channel and stopped — no answer, no PASS, no liftable call
+                    // anywhere in the thinking (the captured turn analyzed all 12
+                    // tasks lucidly and then just ended). Settling that as an empty
+                    // Speak is a silent dead turn: maximal thought, zero commitment,
+                    // and the round dies of it. Route the SAME mechanism #159 built
+                    // for the sibling cases above: a reported-never-executed sentinel
+                    // whose executor teacher names what happened as an observation,
+                    // and `drive_to_settle` hands her another generation — which
+                    // starts from her own conclusions, because the reasoning was
+                    // already recorded into working memory at the top of this fn.
+                    // Model-agnostic by construction: `reasoning` is an adapter fact,
+                    // never a model sniff. Bounded by `max_acts`; an identical repeat
+                    // short-circuits via `all_calls_already_satisfied`.
+                    if !reasoning.trim().is_empty() {
+                        crate::probe!(
+                            class = "persona.act.think_only",
+                            persona = %self.persona_name,
+                            reasoning_len = reasoning.len(),
+                            "generation ended inside the reasoning channel — no answer, no act; routing the think-only teacher"
+                        );
+                        let call = crate::ai::types::ToolCall {
+                            id: "tool-attempt-think-only".to_string(),
+                            name: crate::cognition::tool_executor::command_executor::THINK_ONLY_SENTINEL
+                                .to_string(),
+                            input: serde_json::json!({}),
+                        };
+                        return Some(self.act_verdict(vec![call], &resp));
+                    }
                 }
             }
         }
@@ -3657,6 +3687,48 @@ mod tests {
             match c.decision {
                 Some(Decision::Speak { .. }) => {}
                 other => panic!("expected the spoken answer to stand, got {other:?}"),
+            }
+        }
+
+        // what this catches: the THINK-ONLY tail of the #181 arc — a thinking model
+        // that ends its generation INSIDE the reasoning channel (content empty,
+        // reasoning present, NO liftable call anywhere in the thinking) must not
+        // settle as an empty Speak. The verdict routes the think-only sentinel so
+        // the executor's teacher fires as an observation and drive_to_settle hands
+        // her another generation. Glass-boxed live 2026-08-15: a full bench round
+        // produced 17 inference turns and zero acts through exactly this hole.
+        #[tokio::test]
+        async fn think_only_turn_routes_the_teacher_sentinel_not_empty_speak() {
+            let persona = Uuid::new_v4();
+            let mut resp = make_response(FinishReason::Stop, "", None);
+            resp.reasoning = Some(
+                "These tasks are all tractable. I should start with the parser fix, \
+                 then the two string tasks. Let me plan the order carefully."
+                    .to_string(),
+            );
+            let adapter = Arc::new(ScriptedAdapter::new(vec![resp]));
+            let faculty = LlmDeliberationFaculty::new(persona, "Asha", "You are Asha.", adapter)
+                .with_tools(vec![read_tool()])
+                .with_context_window(32_768);
+
+            let c = faculty
+                .contribute(&Workspace::new("solve the tasks on the board"))
+                .await
+                .expect("verdict");
+            match c.decision {
+                Some(Decision::Act { calls, intent }) => {
+                    assert_eq!(calls.len(), 1);
+                    assert_eq!(
+                        calls[0].name,
+                        crate::cognition::tool_executor::command_executor::THINK_ONLY_SENTINEL,
+                        "the think-only sentinel rides the verdict so the teacher fires"
+                    );
+                    assert!(
+                        intent.contains("tractable"),
+                        "her own reasoning is the act's intent — the engram records why"
+                    );
+                }
+                other => panic!("expected the think-only sentinel Act, got {other:?}"),
             }
         }
 

--- a/core/continuum-core/src/cognition/tool_executor/command_executor.rs
+++ b/core/continuum-core/src/cognition/tool_executor/command_executor.rs
@@ -239,6 +239,15 @@ fn fold_with_recovery(full: String, max: usize, persona_id: Uuid) -> String {
 /// citizen cannot summon this arm by guessing it.
 pub(crate) const NAMELESS_ARGS_SENTINEL: &str = "tools/<no name given>";
 
+/// Reserved pseudo-name for "the generation ended INSIDE the reasoning channel" —
+/// content empty, reasoning present, no liftable call anywhere in the thinking.
+/// Same uncallable namespace as [`NAMELESS_ARGS_SENTINEL`]; same contract:
+/// REPORTED, never executed. The teacher arm below is the accommodation for
+/// thinking models (any of them — the reasoning channel is an adapter fact, not a
+/// model sniff): her thinking already landed in working memory, so the next
+/// generation `drive_to_settle` grants starts from her own conclusions.
+pub(crate) const THINK_ONLY_SENTINEL: &str = "tools/<think-only turn>";
+
 fn persona_tool_error(attempted: &str, raw: String) -> String {
     // The MISSING-name case, which is not the wrong-name case and must not borrow its
     // sentence. Rendering "`X` is not a tool you can call" here would be actively
@@ -247,6 +256,23 @@ fn persona_tool_error(attempted: &str, raw: String) -> String {
     // English — the fence lifted nothing and, before this, reported nothing, so she
     // repeated the same shape until the deadline. Name the missing piece and show the
     // form; the args she already wrote are reusable as-is.
+    // The THINK-ONLY case: nothing she wrote was wrong and nothing was absent from a
+    // call — there was no call, no answer, no PASS; the whole generation stayed in the
+    // private reasoning channel. "not a tool you can call" would be false (she called
+    // nothing), and silence would be the dead turn this sentinel exists to break. Name
+    // what happened and the three commitment affordances; her reasoning is already in
+    // working memory, so the retry starts from her own conclusions.
+    if attempted == THINK_ONLY_SENTINEL {
+        return "Your whole generation was private reasoning — the turn ended inside the \
+                thinking channel, so nothing was said and nothing ran. Your thinking is \
+                saved in your working memory, but nobody else can see it, and it is not \
+                an answer or an action. Commit now: call a tool \
+                (`tool/name({\"arg\": \"value\"})`), or state your conclusion as plain \
+                text, or PASS. You have already done the thinking — put the conclusion \
+                in the answer."
+            .to_string();
+    }
+
     if attempted == NAMELESS_ARGS_SENTINEL {
         return format!(
             "You emitted tool ARGUMENTS with no tool NAME, so nothing ran:\n{raw}\n\n\
@@ -573,6 +599,22 @@ mod tests {
         assert!(
             out.contains("`frobnicate`"),
             "must name what she tried: {out}"
+        );
+    }
+
+    // what this catches: the think-only sentinel gets its OWN teacher sentence — it
+    // must name what happened (the generation ended inside the reasoning channel) and
+    // the three commitment affordances (tool call / plain answer / PASS). The
+    // "not a tool you can call" wording would be false here: she called nothing.
+    #[test]
+    fn think_only_sentinel_teaches_commitment_not_unknown_tool() {
+        let raw = "no Rust module handles command: 'tools/<think-only turn>'".to_string();
+        let out = persona_tool_error(THINK_ONLY_SENTINEL, raw);
+        assert!(out.contains("reasoning"), "{out}");
+        assert!(out.contains("PASS"), "{out}");
+        assert!(
+            !out.contains("not a tool you can call"),
+            "she called nothing — the unknown-tool wording is false here: {out}"
         );
     }
 


### PR DESCRIPTION
## The kill point this closes

Round 3 of the bench: 17 turns reached inference with tools, zero acts. Capture 19397b2f: `finish=stop`, full lucid reasoning naming all 12 tasks tractable, `text:""`. The model ended its generation **inside the thinking channel** — no answer, no act, no liftable call. The two-arm serving test on an idle lane proved the channel splitter innocent (simple prompts return perfect content both with and without `/no_think`), so this is the turn contract, not serving.

## The fix (reuses #159's mechanism, zero new machinery)

- New `THINK_ONLY_SENTINEL` next to `NAMELESS_ARGS_SENTINEL` — uncallable namespace, reported never executed.
- Verdict seam: content empty + reasoning present + reasoning-lift found nothing → route the sentinel as an Act. The executor's teacher fires as an observation (thinking is private; commit via tool call / plain answer / PASS) and `drive_to_settle` grants another generation that starts from her own conclusions (reasoning already recorded into working memory).
- Bounded by `max_acts`; identical repeats short-circuit via `all_calls_already_satisfied`.
- Model-agnostic: `reasoning` is an adapter fact. No model names, no hardcodes. Thinking stays ON (Joel's ruling); raw CoT still never publishes as speech.

## Tests

- `think_only_turn_routes_the_teacher_sentinel_not_empty_speak` (faculty verdict, existing mod)
- `think_only_sentinel_teaches_commitment_not_unknown_tool` (executor teacher, existing mod)
- All 34 neighboring verdict/teacher tests green; `cargo check --features metal,accelerate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo