### PR TITLE
fix(serving): prefill is lane liveness — L9, the smoke-heartbeat sibling of L8

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -2567,7 +2567,7 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                             // in-flight generations that proved it healthy.
                             use crate::inference::llama_server::NeverStartedClass;
                             match crate::inference::llama_server::classify_never_started_timeout(
-                                crate::inference::llama_server::ms_since_real_decode(),
+                                crate::inference::llama_server::ms_since_real_work(),
                                 idle.as_millis() as u64,
                             ) {
                                 NeverStartedClass::WedgeEvidence => {
@@ -2665,6 +2665,12 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                         if p.processed > last_prefill_processed {
                             last_prefill_processed = p.processed;
                             last_progress = Instant::now();
+                            // L9: prefill advance is LANE liveness, not just request
+                            // liveness — the health heartbeat and the never-started
+                            // classifier both read this stamp via ms_since_real_work.
+                            if local_lane {
+                                crate::inference::llama_server::note_real_prefill_progress();
+                            }
                             let _ = sink.send(GenerationChunk::Prefill {
                                 processed: p.processed,
                                 total: p.total,

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -240,6 +240,55 @@ pub fn classify_never_started_timeout(
     }
 }
 
+/// Wall-clock ms of the last real PREFILL advance on the served lane. The decode stamp
+/// above is blind to a lane that is 100% mid-prefill: eight 17k prompts saturate the
+/// slots for minutes producing ZERO output tokens, the decode stamp goes stale, the
+/// health heartbeat's "trust busy lanes" gate falls through, its probe can't get a
+/// slot, and two misses relaunch a lane working flat out (round-killer L9, live
+/// 2026-08-15 13:32 — 30s after dispatch, reason "sustained decode failure"). The #385
+/// per-request detector already learned PREFILL IS PROGRESS; this is the same lesson at
+/// the lane level. Stamped from the adapter's prefill-progress site, same local-lane
+/// gating as the decode stamp.
+static LAST_REAL_PREFILL_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Record that a real generation's PREFILL advanced on the served lane.
+pub fn note_real_prefill_progress() {
+    let Ok(since_epoch) = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) else {
+        // Same clock discipline as note_real_decode: 0 is the "never" sentinel,
+        // an unreadable clock must not erase a real stamp.
+        return;
+    };
+    LAST_REAL_PREFILL_MS.store(
+        since_epoch.as_millis() as u64,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+}
+
+/// Milliseconds since the lane last did REAL WORK for anyone — a decode that produced
+/// tokens OR a prefill that advanced, whichever is fresher. This is the liveness
+/// question the health heartbeat and the never-started-timeout classifier actually ask;
+/// [`ms_since_real_decode`] remains for callers that specifically need tokens-out.
+pub fn ms_since_real_work() -> Option<u64> {
+    let decode = ms_since_real_decode();
+    let prefill = ms_since_stamp(&LAST_REAL_PREFILL_MS);
+    match (decode, prefill) {
+        (Some(d), Some(p)) => Some(d.min(p)),
+        (one, other) => one.or(other),
+    }
+}
+
+fn ms_since_stamp(stamp: &std::sync::atomic::AtomicU64) -> Option<u64> {
+    let last = stamp.load(std::sync::atomic::Ordering::Relaxed);
+    if last == 0 {
+        return None;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_millis() as u64;
+    Some(now.saturating_sub(last))
+}
+
 /// Milliseconds since the last real token-producing generation, or `None` if none has been
 /// observed yet (fresh boot) — the caller must then fall back to probing.
 pub fn ms_since_real_decode() -> Option<u64> {

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -476,7 +476,7 @@ impl ServingDaemonModule {
             model_resolver: Arc::new(|id: &str| {
                 crate::model_registry::try_global().and_then(|r| r.model(id).cloned())
             }),
-            decode_age: Arc::new(crate::inference::llama_server::ms_since_real_decode),
+            decode_age: Arc::new(crate::inference::llama_server::ms_since_real_work),
             real_fails: Arc::new(crate::inference::llama_server::consecutive_real_decode_failures),
             last_healthy_window: Arc::new(AtomicU32::new(0)),
             last_healthy_lanes: Arc::new(AtomicU32::new(0)),
@@ -2092,10 +2092,11 @@ impl ServingDaemonModule {
                 crate::probe!(
                     class = "serving.health",
                     ok = true,
-                    via = "real_decode",
-                    ms_since_decode = since,
-                    "lane proven alive by real token delivery — skipped the smoke probe rather \
-                     than contend for a slot with the work that proves it",
+                    via = "real_work",
+                    ms_since_work = since,
+                    "lane proven alive by real work (decode OR prefill advance — L9: a lane \
+                     saturated in prefill produces no tokens but is NOT quiet) — skipped the \
+                     smoke probe rather than contend for a slot with the work that proves it",
                 );
                 return None;
             }


### PR DESCRIPTION
30s after the first post-L8 dispatch the OTHER health arm relaunched the lane: slots saturated in prefill emit no decode tokens, the decode-only trust stamp goes stale, the probe can't win a slot, two misses = relaunch of a lane working flat out. Same busy-vs-wedged confound as #2317, smoke path. Prefill-advance now stamps lane liveness (the #385 'prefill is progress' lesson at lane level); heartbeat trust + the L8 classifier read ms_since_real_work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo