### PR TITLE
feat(cognition): causal memory graph slice A — acts join the engram edge substrate (#447)

### DIFF
--- a/core/continuum-core/src/cognition/act_observe/apply.rs
+++ b/core/continuum-core/src/cognition/act_observe/apply.rs
@@ -71,11 +71,39 @@ fn short_circuit_acts(calls: &[ToolCall], nudge: &str, status: ActStatus) -> Vec
         .collect()
 }
 
+/// One settle chain's causal thread — owned by the DRIVER of the chain
+/// (`drive_to_settle`, or one turn-frame), passed by reference through
+/// `settle_step` into `apply_act`. Holds the engram id of the most recently
+/// ADMITTED act observation so the next act in the same chain can carry a
+/// `CausedBy` edge to it (CAUSAL-MEMORY-GRAPH.md §3a). One concern, one
+/// chain; the driver drops it when the turn settles, so an edge can never
+/// cross turns or rooms by construction — the wire is the scope, never an
+/// inference over timestamps.
+#[derive(Default)]
+pub struct ActChain(std::sync::Mutex<Option<Uuid>>);
+
+impl ActChain {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The chain's latest admitted act engram — the CAUSE of whatever act
+    /// comes next in this chain. `None` until the first admission.
+    pub fn prior(&self) -> Option<Uuid> {
+        *self.0.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    fn advance(&self, id: Uuid) {
+        *self.0.lock().unwrap_or_else(|p| p.into_inner()) = Some(id);
+    }
+}
+
 pub async fn apply_act(
     cycle: &WorkspaceCycle,
     calls: &[ToolCall],
     intent: &str,
     room_id: Uuid,
+    chain: &ActChain,
 ) -> ActOutcome {
     // no hands → cannot act (and tools were never offered)
     let Some(body) = cycle.acting() else {
@@ -550,6 +578,27 @@ pub async fn apply_act(
             // durable knowledge.
             body.admission
                 .set_recall_salience(engram.id, PROPRIOCEPTION_RECALL_SALIENCE);
+            // The causal spine (CAUSAL-MEMORY-GRAPH.md): this act was decided by
+            // a deliberation that perceived the chain's previous act result, so
+            // wire the CausedBy edge HERE, where the relation is known — the
+            // `because` clause as structure. A fact about what happened, never
+            // a rail on what she does next.
+            if let Some(prior) = chain.prior() {
+                body.admission.link_engrams(
+                    engram.id,
+                    prior,
+                    crate::persona::engram_graph::EdgeKind::CausedBy,
+                );
+                crate::probe!(
+                    class = "engram.edge.caused_by",
+                    persona = %body.persona_name,
+                    room_id = %room_id,
+                    from = %engram.id,
+                    to = %prior,
+                    "act chained to its predecessor in the causal memory graph"
+                );
+            }
+            chain.advance(engram.id);
         }
         Ok(_) => {} // Drop (dedup) — nothing admitted to weight.
         Err(e) => {

--- a/core/continuum-core/src/cognition/act_observe/mod.rs
+++ b/core/continuum-core/src/cognition/act_observe/mod.rs
@@ -38,7 +38,7 @@ mod types;
 pub use types::{SettleOutcome, SettleStep};
 
 mod apply;
-pub use apply::apply_act;
+pub use apply::{apply_act, ActChain};
 
 mod settle;
 pub use settle::{drive_to_settle, settle_step};
@@ -312,6 +312,60 @@ mod tests {
         }
     }
 
+    // what this catches: the causal spine's first production wiring (task #447,
+    // CAUSAL-MEMORY-GRAPH.md slice A). Two acts driven through ONE chain must
+    // leave a `CausedBy` edge from the second act's engram to the first's —
+    // recorded at the write site, queryable through the admission store's graph.
+    // A fresh chain (a new turn) must NOT link back to the previous turn's acts.
+    // Regression guard for the zero-production-callers state EngramGraph shipped
+    // in: this pins that acts now populate the graph.
+    #[tokio::test]
+    async fn a_settle_chain_links_each_act_caused_by_its_predecessor() {
+        let exec = Arc::new(RecordingExecutor {
+            seen_context: Mutex::new(None),
+            result_content: "ok\n".into(),
+        });
+        let adm = admission();
+        let cycle = WorkspaceCycle::new(Vec::new(), Arc::new(SalienceArbiter), 8)
+            .with_acting(body(exec.clone(), adm.clone()));
+        let room = Uuid::new_v4();
+        let chain = ActChain::new();
+
+        // Act 1 — starts the chain: no predecessor, so no edge.
+        acts_of(apply_act(&cycle, &[tool_call()], "start", room, &chain).await);
+        let first = chain.prior().expect("first act admitted onto the chain");
+        assert!(
+            adm.engram_neighbors(&first).is_empty(),
+            "the chain's first act has no predecessor to point at"
+        );
+
+        // Act 2 — a DIFFERENT call (the repeat guard short-circuits identical
+        // batches; a chain is made of distinct steps).
+        let second_call = ToolCall {
+            id: "call-2".into(),
+            name: "code/read".into(),
+            input: serde_json::json!({ "file_path": "src/main.rs" }),
+        };
+        acts_of(apply_act(&cycle, &[second_call], "inspect", room, &chain).await);
+        let second = chain.prior().expect("second act admitted onto the chain");
+        assert_ne!(first, second, "two acts, two engrams");
+
+        let edges = adm.engram_neighbors(&second);
+        assert!(
+            edges.iter().any(|e| e.target == first
+                && e.kind == crate::persona::engram_graph::EdgeKind::CausedBy),
+            "the second act must carry a CausedBy edge to its predecessor — \
+             the `because` clause as structure, not prose; got {edges:?}"
+        );
+
+        // A NEW chain (next turn) must not reach back across the boundary.
+        let next_turn = ActChain::new();
+        assert!(
+            next_turn.prior().is_none(),
+            "a fresh chain starts empty — edges can never cross turns by construction"
+        );
+    }
+
     /// Unwrap the typed acts of an `Acted` outcome (panics on NoHands/ExecutorError) —
     /// the typed sibling of the old `.expect("acted")` on the `Option<String>`.
     fn acts_of(outcome: ActOutcome) -> Vec<Observation> {
@@ -365,7 +419,7 @@ mod tests {
             .with_acting(body(exec.clone(), adm.clone()));
 
         let room = Uuid::new_v4();
-        let acts = match apply_act(&cycle, &[tool_call()], "check the math", room).await {
+        let acts = match apply_act(&cycle, &[tool_call()], "check the math", room, &ActChain::new()).await {
             ActOutcome::Acted { acts } => acts,
             other => panic!("expected Acted, got {other:?}"),
         };
@@ -417,7 +471,7 @@ mod tests {
         let cycle = WorkspaceCycle::new(Vec::new(), Arc::new(SalienceArbiter), 8);
         assert!(
             matches!(
-                apply_act(&cycle, &[tool_call()], "try", Uuid::new_v4()).await,
+                apply_act(&cycle, &[tool_call()], "try", Uuid::new_v4(), &ActChain::new()).await,
                 ActOutcome::NoHands
             ),
             "no hands → NoHands, never a fabricated success"
@@ -434,7 +488,7 @@ mod tests {
             .with_acting(body(Arc::new(FailingExecutor), adm.clone()));
         assert!(
             matches!(
-                apply_act(&cycle, &[tool_call()], "run", Uuid::new_v4()).await,
+                apply_act(&cycle, &[tool_call()], "run", Uuid::new_v4(), &ActChain::new()).await,
                 ActOutcome::ExecutorError { .. }
             ),
             "a batch-level failure surfaces as ExecutorError, distinct from NoHands"
@@ -764,6 +818,7 @@ mod tests {
             false,
             TurnFraming::ambient(),
             Situation::FreshContext,
+            &ActChain::new(),
         )
         .await;
         assert!(
@@ -782,6 +837,7 @@ mod tests {
             true,
             TurnFraming::ambient(),
             Situation::FreshContext,
+            &ActChain::new(),
         )
         .await;
         assert!(
@@ -1042,7 +1098,7 @@ mod tests {
         let room = Uuid::new_v4();
 
         // First act genuinely runs; its result lands in working memory.
-        let first = acts_of(apply_act(&cycle, &[tool_call()], "check the math", room).await);
+        let first = acts_of(apply_act(&cycle, &[tool_call()], "check the math", room, &ActChain::new()).await);
         assert_eq!(
             first[0].call.name, "code/run",
             "first act names the tool it ran"
@@ -1059,7 +1115,7 @@ mod tests {
 
         // Second, byte-identical act: already satisfied → short-circuit, no re-run.
         // The typed act's OUTPUT carries the nudge and the STATUS names the demotion.
-        let second = acts_of(apply_act(&cycle, &[tool_call()], "check the math", room).await);
+        let second = acts_of(apply_act(&cycle, &[tool_call()], "check the math", room, &ActChain::new()).await);
         assert!(
             matches!(second[0].status, ActStatus::AlreadySatisfied { .. }),
             "the second identical act is typed AlreadySatisfied, not Executed"
@@ -1079,7 +1135,7 @@ mod tests {
         // than the second — the proprioception climbs rather than repeating byte-identical
         // text. Without this, static-nudge spam evicts the useful receipt from the bounded
         // recency window and a greedy (temp-0) model re-emits the identical call forever.
-        let third = acts_of(apply_act(&cycle, &[tool_call()], "check the math", room).await);
+        let third = acts_of(apply_act(&cycle, &[tool_call()], "check the math", room, &ActChain::new()).await);
         let third_nudge = third[0].output.result.content.clone();
         assert_ne!(
             second_nudge, third_nudge,
@@ -1251,7 +1307,7 @@ mod tests {
         };
 
         // First orientation genuinely runs; its receipt lands in working memory.
-        acts_of(apply_act(&cycle, &[list], "orient", room).await);
+        acts_of(apply_act(&cycle, &[list], "orient", room, &ActChain::new()).await);
         assert_eq!(
             exec.results.lock().unwrap().len(),
             1,
@@ -1259,7 +1315,7 @@ mod tests {
         );
 
         // Second, DIFFERENT-args orientation this concern → demoted, no re-run.
-        let second = acts_of(apply_act(&cycle, &[help], "orient again", room).await);
+        let second = acts_of(apply_act(&cycle, &[help], "orient again", room, &ActChain::new()).await);
         assert!(
             matches!(second[0].status, ActStatus::RedundantOrientation { .. }),
             "the demoted orientation is typed RedundantOrientation, not Executed"
@@ -1391,6 +1447,7 @@ mod tests {
             true,
             TurnFraming::ambient(),
             Situation::FreshContext,
+            &ActChain::new(),
         )
         .await;
         assert!(matches!(step, SettleStep::Spoke(_)));
@@ -1414,6 +1471,7 @@ mod tests {
             true,
             TurnFraming::ambient(),
             Situation::FreshContext,
+            &ActChain::new(),
         )
         .await;
         assert!(matches!(step2, SettleStep::Spoke(_)));
@@ -1459,6 +1517,7 @@ mod tests {
             true,
             TurnFraming::ambient(),
             Situation::FreshContext,
+            &ActChain::new(),
         )
         .await;
         assert!(matches!(step, SettleStep::Spoke(_)));
@@ -1488,6 +1547,7 @@ mod tests {
             true,
             TurnFraming::ambient(),
             Situation::FreshContext,
+            &ActChain::new(),
         )
         .await;
         assert!(matches!(step2, SettleStep::Spoke(_)));

--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -43,6 +43,10 @@ pub async fn drive_to_settle(
 ) -> SettleOutcome {
     let burst: Burst = burst.into();
     let mut acts = 0usize;
+    // This turn's causal thread: each admitted act observation becomes the
+    // CausedBy target of the next act in the SAME chain — the driver owns the
+    // chain, so an edge can never cross turns or rooms (CAUSAL-MEMORY-GRAPH.md).
+    let chain = super::apply::ActChain::new();
     // The turn's investigation trail (see `SettleOutcome::touched_paths`).
     let mut touched: Vec<String> = Vec::new();
     // Fold each tick's deliberation cost in, so the settled outcome reports the
@@ -158,8 +162,16 @@ pub async fn drive_to_settle(
             );
         }
         let may_act = acts < max_acts && stuck < STUCK_LIMIT && discovery_open;
-        let (step, step_metrics) =
-            settle_step(cycle, burst.clone(), room_id, may_act, framing, situation).await;
+        let (step, step_metrics) = settle_step(
+            cycle,
+            burst.clone(),
+            room_id,
+            may_act,
+            framing,
+            situation,
+            &chain,
+        )
+        .await;
         if let Some(m) = step_metrics {
             metrics.accumulate(m);
         }
@@ -388,6 +400,7 @@ pub async fn settle_step(
     may_act: bool,
     framing: TurnFraming,
     situation: Situation,
+    chain: &super::apply::ActChain,
 ) -> (SettleStep, Option<TurnMetrics>) {
     let burst: Burst = burst.into();
     // Snapshot the burst's PEER turns before the workspace consumes it — the
@@ -428,7 +441,7 @@ pub async fn settle_step(
                 // re-perceive next step; `NoHands`/`ExecutorError` → unfulfilled. Behavior
                 // identical to the old `Some`/`None`, but `ExecutorError` is now
                 // distinguishable for a future backstop.
-                if apply_act(cycle, &calls, &intent, room_id)
+                if apply_act(cycle, &calls, &intent, room_id, chain)
                     .await
                     .produced_an_act()
                 {

--- a/core/continuum-core/src/commands/persona/turn_frame/execute.rs
+++ b/core/continuum-core/src/commands/persona/turn_frame/execute.rs
@@ -242,6 +242,11 @@ crate::action_command! {
         // command-seeded message is put TO the persona, so we withhold the silent-PASS
         // hatch — the same exam-is-directed measurement control the eval driver documents
         // (a structural harness fact fed to the mind, never a filter on her output).
+        // Per-frame causal thread: this surface executes ONE settle step per
+        // invocation, so the chain starts fresh each frame. Cross-frame
+        // CausedBy linking (frame N+1's act → frame N's) needs the chain to
+        // live with the frame session — CAUSAL-MEMORY-GRAPH.md follow-on.
+        let chain = crate::cognition::act_observe::ActChain::new();
         let (step, metrics) = crate::cognition::act_observe::settle_step(
             &cycle,
             burst,
@@ -250,6 +255,7 @@ crate::action_command! {
             crate::cognition::workspace::TurnFraming::message(true),
             // One-shot directed tick: a fresh ask, so fuller grounding.
             crate::cognition::workspace::Situation::FreshContext,
+            &chain,
         )
         .await;
 

--- a/core/continuum-core/src/persona/admission_state.rs
+++ b/core/continuum-core/src/persona/admission_state.rs
@@ -164,6 +164,13 @@ pub struct AdmissionState {
     /// per-token), so the cost is nil. See
     /// [[eval-mutates-persona-lift-needs-isolation]].
     persistence: RwLock<Arc<dyn crate::persona::admission_persistence::AdmissionPersistenceSink>>,
+    /// The engram edge graph — causal + associative structure over the
+    /// engrams this store admits (docs/cognition/CAUSAL-MEMORY-GRAPH.md,
+    /// docs/cognition/BELIEF-JUSTIFICATION-GRAPH.md). Edges are FACTS about
+    /// what happened, recorded at the write site; the graph never decides —
+    /// retrieval surfaces walk it, cognition judges. In-memory (DashMap);
+    /// sidecar durability is a follow-on slice.
+    graph: crate::persona::engram_graph::EngramGraph,
     /// The persona this store BELONGS to (its own user id). Set once at spawn via
     /// [`set_owner_id`](Self::set_owner_id); `None` for bare/test states. Used to
     /// recognize the persona's OWN authored chat engrams (`Chat` origin whose
@@ -221,6 +228,7 @@ impl AdmissionState {
             recall_metadata,
             persistence: RwLock::new(persistence),
             owner_id: RwLock::new(None),
+            graph: crate::persona::engram_graph::EngramGraph::new(),
         }
     }
 
@@ -265,6 +273,10 @@ impl AdmissionState {
             recall_metadata,
             persistence: RwLock::new(persistence),
             owner_id: RwLock::new(None),
+            // Edges are not yet durable — a rehydrated store starts with an
+            // empty graph and re-accumulates from live acts. Sidecar
+            // persistence is the next slice (CAUSAL-MEMORY-GRAPH.md §4).
+            graph: crate::persona::engram_graph::EngramGraph::new(),
         }
     }
 
@@ -273,6 +285,31 @@ impl AdmissionState {
     /// observe the same DashMap admission writes into.
     pub fn recall_metadata(&self) -> &Arc<crate::persona::recall_metadata::RecallMetadataRegistry> {
         &self.recall_metadata
+    }
+
+    /// Record one directed edge between two admitted engrams — a FACT about
+    /// how they relate (CausedBy, Produced, derived_from, …), written at the
+    /// site that KNOWS the relation, never inferred later. The graph never
+    /// decides anything; retrieval surfaces walk it and cognition judges
+    /// (CAUSAL-MEMORY-GRAPH.md §3c, BELIEF-JUSTIFICATION-GRAPH.md §5).
+    /// Weight 1.0: a wired structural edge is a certainty, unlike the
+    /// tuned associative kinds.
+    pub fn link_engrams(
+        &self,
+        from: Uuid,
+        to: Uuid,
+        kind: crate::persona::engram_graph::EdgeKind,
+    ) {
+        self.graph.add_edge(from, to, kind, 1.0);
+    }
+
+    /// Outbound edges of one engram — the traversal read the ledger,
+    /// thread retrieval, and the confabulation check walk.
+    pub fn engram_neighbors(
+        &self,
+        id: &Uuid,
+    ) -> Vec<crate::persona::engram_graph::EngramEdge> {
+        self.graph.neighbors(id)
     }
 
     /// Bind this store to the persona that owns it (its own user id). Called once

--- a/core/continuum-core/src/persona/engram_graph.rs
+++ b/core/continuum-core/src/persona/engram_graph.rs
@@ -84,6 +84,19 @@ pub enum EdgeKind {
     /// produced. Used by the outcome-linked salience boost in
     /// algorithm 4.
     TaskOutcome,
+
+    /// Act-engram → the engram of what directly triggered it: the
+    /// predecessor act in the same settle chain, the inbound message,
+    /// or the work-card kickoff. The causal spine of the memory graph
+    /// (docs/cognition/CAUSAL-MEMORY-GRAPH.md) — the `because` clause
+    /// as structure instead of archived prose. Wired at the act write
+    /// site, never inferred after the fact.
+    CausedBy,
+
+    /// Act-engram → engram/handle of what the act created: an artifact
+    /// write, a posted message, a card state change. The forward half
+    /// of the causal spine; TaskOutcome remains the start→done pairing.
+    Produced,
 }
 
 // ─── EngramEdge ─────────────────────────────────────────────────────
@@ -426,6 +439,8 @@ mod tests {
             EdgeKind::RecallCoOccurrence,
             EdgeKind::ConversationalReply,
             EdgeKind::TaskOutcome,
+            EdgeKind::CausedBy,
+            EdgeKind::Produced,
         ] {
             let json = serde_json::to_string(&kind).expect("serialize");
             let decoded: EdgeKind = serde_json::from_str(&json).expect("deserialize");

--- a/docs/cognition/CAUSAL-MEMORY-GRAPH.md
+++ b/docs/cognition/CAUSAL-MEMORY-GRAPH.md
@@ -1,0 +1,101 @@
+# The Causal Memory Graph — acts join the engram edge substrate
+
+**Status:** design (Joel, 2026-08-15: act memory is "completely broken… fundamental to
+every activity and room" — overhaul it in general cognition, never in benchmark
+rigging). Companion to [BELIEF-JUSTIFICATION-GRAPH.md](BELIEF-JUSTIFICATION-GRAPH.md)
+(the epistemic level of the same graph), [ACTING-ORGANISM.md](ACTING-ORGANISM.md)
+(the act→observe circuit these edges make traversable), and
+`docs/architecture/COGNITION-ALGORITHMS.md` (the spreading-activation traversal that
+walks them). Read `docs/architecture/PERSONA-COGNITION-PIPELINE.md` first.
+
+## 1. The live evidence (round bench-hard-rs-1786823331, 2026-08-15)
+
+A citizen with 1,808 lifetime acts sees **one** of them. The steps ledger renders from
+a char-budgeted receipt archive whose every head line drags its full `because
+<reasoning>` clause (~250 chars each), so the archive holds 1–2 lines before evicting;
+the ledger then honestly reports `(+1808 earlier steps before what this ledger
+shows)`. Downstream, measured across 4,482 captured turns: citizens execute thousands
+of acts, cannot see them, conclude they have nothing to contribute, and withdraw — the
+deprivation mechanism (#390/#414). Semantic recall is *forbidden* from returning
+Tool-origin receipts by an executing assertion (#166 — correct, and staying).
+
+The diagnosis is not budget tuning. **The `because` clause is a causal edge serialized
+as English.** We are paying graph-edge information as flat prose in the one place a
+citizen thinks from.
+
+## 2. What every mature system converges on
+
+Two pointers per node: *which thread am I part of* and *what directly caused me*.
+Distributed tracing (`trace_id` + `parent_span_id`), event sourcing (`correlation_id`
++ `causation_id`), W3C PROV (`wasInformedBy`/`used`/`wasGeneratedBy`), git (commit
+parents). Cognitive architectures split retrieval the same way we did with #166: Soar's
+episodic memory replays by temporal/contextual adjacency, deliberately separate from
+semantic cue-matching.
+
+Continuum already has the first pointer — `Engram.context_id` (the scope, durable,
+indexed; the scope IS the learning unit per SCOPE-BASED-RECIPES.md). It has the second
+pointer **only for beliefs** (BJG `derived_from`) and **only latently for acts**
+(`EdgeKind::TaskOutcome`, `ConversationalReply` — declared, but the act write path
+adds no edges at all).
+
+## 3. The design: one graph, two levels, one new wiring
+
+No new store, no new subsystem, no benchmark-specific anything. The existing
+`persona/engram_graph.rs` (`EngramGraph`, `EdgeKind`, DashMap, alg-3 traversal) is the
+substrate; BJG's sidecar persistence is the durability plan. Acts join it:
+
+### 3a. Edge kinds (extend `EdgeKind`)
+
+- **`CausedBy`** — act-engram → the engram of what triggered it: the inbound message,
+  the work card's kickoff, or the parent act in a settle chain. Asymmetric. This is
+  the `because` clause as structure.
+- **`Produced`** — act-engram → engram/handle of what it created (artifact write,
+  posted message, card state change). The inverse story of TaskOutcome's start→done.
+
+Both are **wired at the write site, never inferred**: `act_observe/apply.rs` stands
+next to the cause when it writes the Tool engram (the directed dispatch carries the
+triggering engram id; a settle chain knows its predecessor). Zero hot-path inference,
+one DashMap insert + one sidecar row per edge.
+
+### 3b. Views become queries (delete the parallel structures)
+
+| Today (parallel, broken) | Becomes (graph view) |
+|---|---|
+| Receipt-head archive (char-starved prose ring) | **Ledger query**: Tool engrams in THIS `context_id`, recent-first; heads render as compact call forms (`[action #n] name(args)`) because reasoning/cause is an edge + engram content, not archived prose |
+| "cannot be retrieved" (honest today, a dead end) | **Thread retrieval**: recency + `CausedBy` walk within scope — proprioception, distinct from semantic recall; the #166 assertion is untouched |
+| Confabulation fact (phrase heuristics) | "No path in the graph to that claimed result" — a structural fact |
+| L1 training lift (flat lines) | Cause → act → result chains — the scope flywheel gets causal training data |
+
+The steps ledger renders **scope-first**: this room's acts at real depth (compressed
+heads ≈ 5× more history in the same budget), cross-room remainder as one honest line.
+
+### 3c. Freedom doctrine (non-negotiable, inherited from BJG §5)
+
+- **The graph never decides.** Edges are recorded facts about what happened; retrieval
+  is an affordance she invokes; perception renders honest summaries of the graph's
+  shape. Nothing gates or steers cognition — a fact, never an instruction.
+- **History is sacred.** Act engrams and their edges are append-only provenance;
+  plasticity eats inference, never experience.
+- **Zero hot-path cost.** Edge writes ride the existing act persistence; traversal
+  runs at recall/perception time under the same budgets as today.
+
+## 4. Build order
+
+1. **Slice A — edges at the act write site.** `EdgeKind::{CausedBy, Produced}` +
+   `apply.rs` wiring (trigger engram id threaded through the directed-dispatch path;
+   settle chains link predecessor). Pure capture, no behavior change. Tests: a
+   directed act carries a `CausedBy` edge to its trigger; a settle chain is walkable.
+2. **Slice B — compact heads + scope-first ledger.** Receipt heads store the call form
+   only (reasoning stays in engram content, reachable by edge); StepsLedger renders
+   this-scope acts first. Tests: depth ≥ N acts in a busy scope on the same budget;
+   cross-scope line honest.
+3. **Slice C — thread retrieval.** The proprioception query (recency + CausedBy walk,
+   scope-filtered, result bodies included) surfaced as a persona affordance; the
+   ledger's aged line names the real door. #166's semantic gate untouched — new path,
+   different keying.
+4. **Slice D — confab + L1 consume the graph** (follow-on; each independently
+   valuable).
+
+Every slice is general cognition: chat reply chains, wall edits, bench solves, and
+dreams get the same causal spine. Benchmarks touch none of this — they are adapters
+into rooms, and rooms get this for free.

--- a/docs/cognition/CAUSAL-MEMORY-GRAPH.md
+++ b/docs/cognition/CAUSAL-MEMORY-GRAPH.md
@@ -95,6 +95,19 @@ heads ≈ 5× more history in the same budget), cross-room remainder as one hone
    different keying.
 4. **Slice D — confab + L1 consume the graph** (follow-on; each independently
    valuable).
+5. **Slice E — `GraphViewState` (positron)** (Joel, 2026-08-15: "so cool to see
+   visually how engrams are linked … dynamically via events and introspection").
+   The standard projection contract, nothing bespoke: one truth in Rust, keyed
+   on `(room_id, kind)` per #408, N renderers (web canvas, persona tile #184,
+   console #284). Event-driven, never polled — every edge write already fires
+   at the moment it happens (`engram.edge.caused_by` probe today, a typed wire
+   class under #445), so the graph GROWS on screen as she works: a solve draws
+   itself as a causal chain. Introspection is the same traversal twice — her
+   slice-C thread query IS the walk the human watches, one graph, one query,
+   two observers (diegetic doctrine). BJG §6's "watch her change her mind"
+   click-through is the epistemic sibling; this adds click-an-artifact → walk
+   the acts that built it. Diagnosis for free: a spiraling citizen is a graph
+   that visibly stopped growing.
 
 Every slice is general cognition: chat reply chains, wall edits, bench solves, and
 dreams get the same causal spine. Benchmarks touch none of this — they are adapters

--- a/protocol/typescript/persona/EdgeKind.ts
+++ b/protocol/typescript/persona/EdgeKind.ts
@@ -12,4 +12,4 @@
  * empirically by algorithm 7 in L0-4c; this enum just declares the
  * variants the substrate supports.
  */
-export type EdgeKind = "shared-entity" | "shared-topic" | "cited-in" | "recall-co-occurrence" | "conversational-reply" | "task-outcome";
+export type EdgeKind = "shared-entity" | "shared-topic" | "cited-in" | "recall-co-occurrence" | "conversational-reply" | "task-outcome" | "caused-by" | "produced";


### PR DESCRIPTION
## The overhaul (Joel, 2026-08-15: act memory is 'completely broken… fundamental to every activity and room')

A citizen with 1,808 lifetime acts sees 1–2 of them, concludes she has nothing to contribute, and withdraws — measured live in round v4's first captures. The diagnosis is a design gap, not a budget bug: **the receipt's `because` clause is a causal edge serialized as prose**, starving the char-budgeted archive. And `EngramGraph` — the substrate built for exactly this — had **zero production callers**.

## What this slice does (general cognition, zero benchmark rigging)

- `EdgeKind::{CausedBy, Produced}` — the causal/motor level of the ONE engram graph, joining BJG's epistemic kinds. No parallel store.
- `AdmissionState` owns the graph: `link_engrams()` / `engram_neighbors()`, written at the site that KNOWS the relation, never inferred.
- `ActChain`: the settle driver owns the turn's causal thread; `apply_act` links each admitted act `CausedBy` its predecessor. The chain dies with the turn — edges cannot cross turns or rooms by construction.
- `probe!` `engram.edge.caused_by` at the link site.
- Design doc: `docs/cognition/CAUSAL-MEMORY-GRAPH.md` — the two-pointer convergence (trace/span, correlation/causation, PROV, git parents), views-as-queries (slices B–D: compact scope-first ledger, thread retrieval affordance, confab + L1 consumers), and the freedom doctrine inherited from BJG §5: edges are facts, the graph never decides.

## Tests

`a_settle_chain_links_each_act_caused_by_its_predecessor` (two acts, one chain → CausedBy edge; fresh chain starts empty) + serde round-trip rows for the new kinds. Suites: act_observe 38/38, engram_graph 16/16, admission_state 41/41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo