### PR TITLE
Causal memory slice B + grader-hears-the-store bridge (#447, #450)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=574ce235#574ce2352181591584ea52e913a80b202bd0c011"
+source = "git+https://github.com/CambrianTech/airc?rev=103fd898#103fd898c24d88b01ccbfe9a37bf47e27da7579e"
 dependencies = [
  "airc-core",
  "airc-store",
@@ -453,7 +453,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -464,7 +464,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3710,7 +3710,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4013,7 +4013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4863,7 +4863,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5529,7 +5529,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -7093,7 +7093,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9474,7 +9474,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10251,7 +10251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10760,7 +10760,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12625,7 +12625,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,18 +185,18 @@ members = [
 # room is still its default under either verb. This is what continuum's
 # room/join needs (task #65, Joel: a persona is first-class and can subscribe to
 # many rooms). Also fixes `RoomJoinedBody.is_default`, previously hardcoded true.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "574ce235" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "574ce235" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "574ce235" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "574ce235" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "574ce235" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "103fd898" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "103fd898" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "103fd898" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "103fd898" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "103fd898" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "574ce235" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "103fd898" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/core/continuum-core/src/cognition/act_observe/apply.rs
+++ b/core/continuum-core/src/cognition/act_observe/apply.rs
@@ -629,7 +629,7 @@ pub async fn apply_act(
     // by field instead of re-parsing this prose (run-18057-f1). `observation` is the
     // one-time recency rendering; `acts` are the id-correlated typed observations.
     body.working_memory
-        .record_receipt_typed(&acts, &observation);
+        .record_receipt_typed(&acts, &observation, Some(room_id));
     if let Some(f) = &tally_fact {
         body.working_memory.record_fact(f);
     }

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -1439,6 +1439,7 @@ impl LlmDeliberationFaculty {
             own_speech: &spoken,
             room_speech: &room_speech,
             working_memory: self.working_memory.as_ref(),
+            room_id: Some(ws.room_id),
         };
         let facts = super::perception_facts::render_facts(
             &fact_cx,

--- a/core/continuum-core/src/cognition/perception_facts.rs
+++ b/core/continuum-core/src/cognition/perception_facts.rs
@@ -23,6 +23,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
+use uuid::Uuid;
 
 use super::deliberation_budget::{
     inbound_restates_fact, own_repetition_fact, peer_echo_fact, template_loop_fact,
@@ -47,6 +48,11 @@ pub struct FactContext<'a> {
     /// Typed working memory when the persona has one (live spawns); eval
     /// forks and replays may run without it — ledger-class facts skip.
     pub working_memory: Option<&'a Arc<WorkingMemory>>,
+    /// The room THIS turn is happening in — the activity scope. The steps
+    /// ledger renders this-room acts first and folds other rooms into one
+    /// honest count (CAUSAL-MEMORY-GRAPH.md slice B). `None` (roomless
+    /// replays/tests) renders the unpartitioned ledger exactly as before.
+    pub room_id: Option<Uuid>,
 }
 
 /// One structural fact about the persona's present. `render` returns the
@@ -185,9 +191,26 @@ impl PerceptionFact for StepsLedger {
         // fits the ledger's own share, so history depth scales with the lane.
         let archive = wm.receipt_archive();
         let render_budget = wm.budget().steps_ledger_chars();
+        // SCOPE-FIRST (slice B): the room is the activity boundary, so the
+        // ledger's budget goes to THIS room's acts; acts PROVEN elsewhere fold
+        // into one honest count below. UNSCOPED heads (pre-upgrade snapshots,
+        // roomless paths) render in the local list: filing a citizen's own
+        // history as "other rooms" on the upgrade boundary would repeat the
+        // exact deprivation this arc exists to kill — only a head that names a
+        // DIFFERENT room is excluded, because that exclusion we can prove.
+        let mut elsewhere = 0usize;
         let mut fit: Vec<&str> = Vec::new();
         let mut used = 0usize;
-        for line in archive.iter().rev() {
+        for (head_room, line) in archive.iter().rev() {
+            let in_scope = match (cx.room_id, head_room) {
+                (None, _) => true,          // no scope to partition by — render all
+                (Some(_), None) => true,    // unscoped head — never hidden
+                (Some(r), Some(h)) => *h == r,
+            };
+            if !in_scope {
+                elsewhere += 1;
+                continue;
+            }
             let cost = line.chars().count() + 1;
             if !fit.is_empty() && used + cost > render_budget {
                 break;
@@ -204,9 +227,33 @@ impl PerceptionFact for StepsLedger {
         //   none, count == 0  → the explicit nothing-has-executed void
         //   none, count  > 0  → acts happened; details are gone — say so
         let taken = wm.actions_taken();
+        // GLASS BOX (Joel 2026-08-15: "you'll have to glass box this… we need to
+        // really understand the rag as it evolves"): the ledger's full accounting
+        // on every render, so archive starvation / scope partition / eviction
+        // pressure are diagnosable from the probe stream — today's diagnosis
+        // needed capture-scraping precisely because these numbers were invisible.
+        crate::probe!(
+            class = "perception.steps_ledger",
+            room = %cx.room_id.map(|r| r.to_string()).unwrap_or_else(|| "unscoped".into()),
+            shown = fit.len(),
+            elsewhere = elsewhere,
+            taken = taken,
+            archive_len = archive.len(),
+            budget_chars = render_budget,
+            "steps ledger accounting for this render"
+        );
         Some(if fit.is_empty() {
             if taken == 0 {
                 "[steps taken this session]\n(nothing has executed yet — anything described as already run, created, tested, committed, or merged does not exist, whether in the messages you can see or before them; running a tool is what makes it real)".to_string()
+            } else if elsewhere > 0 {
+                // Scoped ledger, nothing local: her acts are real but happened
+                // in OTHER rooms. Saying "nothing has executed" here would deny
+                // her own work (the inverse confabulation-shelter); saying
+                // "aged out" would misname where it went. Say what is true.
+                format!(
+                    "[steps taken this session]\n(no acts in this room yet this session; {elsewhere} act{} in other rooms — each room's ledger tracks its own activity)",
+                    if elsewhere == 1 { "" } else { "s" }
+                )
             } else {
                 // NO RECALL PROMISE HERE. This line used to end "recall can
                 // retrieve them" — provably false: every act becomes an
@@ -227,8 +274,22 @@ impl PerceptionFact for StepsLedger {
                 )
             }
         } else {
-            let aged = taken.saturating_sub(fit.len() as u64);
+            // Split the not-shown count honestly: acts archived under OTHER
+            // rooms vs acts genuinely gone (evicted/pre-archive). Lumping both
+            // into "earlier steps" would misname other-room work as lost.
+            let aged = taken
+                .saturating_sub(fit.len() as u64)
+                .saturating_sub(elsewhere as u64);
+            // ONE stable title: scoping shows in the fold line below, never by
+            // renaming the section (a shifting header breaks every consumer
+            // that anchors on it — including her own learned reading of it).
             let mut ledger = format!("[steps taken this session]\n{}", fit.join("\n"));
+            if elsewhere > 0 {
+                ledger.push_str(&format!(
+                    "\n(+{elsewhere} act{} in other rooms this session)",
+                    if elsewhere == 1 { "" } else { "s" }
+                ));
+            }
             if aged > 0 {
                 ledger.push_str(&format!(
                     "\n(+{aged} earlier step{} before what this ledger shows)",
@@ -314,6 +375,7 @@ mod tests {
             own_speech: &own,
             room_speech: &[],
             working_memory: None,
+            room_id: None,
         };
         let facts = render_facts(&cx, &FactPolicy::default());
         assert_eq!(facts.len(), 1, "quiet room: only the bounds fact renders");
@@ -332,6 +394,7 @@ mod tests {
             own_speech: &own,
             room_speech: &[],
             working_memory: None,
+            room_id: None,
         };
         let mut policy = FactPolicy::default();
         policy.disable("context_bounds");
@@ -356,6 +419,7 @@ mod tests {
             own_speech: &own,
             room_speech: &[],
             working_memory: Some(&wm),
+            room_id: None,
         };
         let ledger = |facts: &[String]| {
             facts
@@ -416,13 +480,15 @@ mod tests {
             saved_at_ms: 0,
             interrupted_dispatches: Vec::new(),
             build_sha: String::new(),
-            receipt_heads: Vec::new(), // written before the archive existed
+            receipt_heads: Vec::new(),
+            receipt_head_rooms: Vec::new(), // written before the archive existed
         });
         let cx2 = FactContext {
             turns: &turns,
             own_speech: &own,
             room_speech: &[],
             working_memory: Some(&pre_archive),
+            room_id: None,
         };
         let l = ledger(&render_facts(&cx2, &FactPolicy::default()));
         assert!(

--- a/core/continuum-core/src/cognition/working_memory.rs
+++ b/core/continuum-core/src/cognition/working_memory.rs
@@ -209,7 +209,10 @@ pub struct WorkingMemory {
     /// steps-taken ledger renders from here, so act history survives conversation.
     /// Persisted in [`VolatileSnapshot`] like the ring itself
     /// ([[act-results-need-a-recency-channel-not-semantic-recall]]).
-    receipt_heads: Mutex<VecDeque<String>>,
+    /// Each head carries the room the act was FOR (`None` for legacy/unscoped
+    /// receipts) so the steps ledger can render this-room acts first — scope
+    /// is the activity boundary (CAUSAL-MEMORY-GRAPH.md slice B).
+    receipt_heads: Mutex<VecDeque<(Option<Uuid>, String)>>,
     /// The lowest action `seq` whose FULL result is still "active" — i.e. the mind is
     /// still inside the act→observe loop that produced it and hasn't yet spoken. The
     /// full raw result exists to answer "what next" the moment the hands fetch it; once
@@ -298,6 +301,12 @@ pub struct VolatileSnapshot {
     /// archive fresh and the ledger's counter-only arm stays honest about the gap.
     #[serde(default)]
     pub receipt_heads: Vec<String>,
+    /// Room tags parallel to `receipt_heads`, index-aligned (slice B). A
+    /// SEPARATE defaulted field — not a tuple — so snapshots written before
+    /// scoping still deserialize; restore pads missing tags with `None`
+    /// (honest "unscoped", never a guessed room).
+    #[serde(default)]
+    pub receipt_head_rooms: Vec<Option<Uuid>>,
 }
 
 /// One typed working-memory entry: kind + the FINAL rendered line (rendered
@@ -426,7 +435,7 @@ impl WorkingMemory {
     /// changes the perception window (see `next_action_seq`). Oldest ages out past
     /// capacity, same rolling scratchpad as reasoning.
     pub fn record_receipt(&self, result: &str) {
-        self.record_receipt_inner(result, Vec::new());
+        self.record_receipt_inner(result, Vec::new(), None);
     }
 
     /// TYPED sibling of [`record_receipt`](Self::record_receipt): store the same
@@ -436,8 +445,11 @@ impl WorkingMemory {
     /// string produced ONCE at the act seam (`render_recency`) — this method does NOT
     /// re-render from `acts` (that would break the #205 KV byte-stability invariant:
     /// `text` is the stable source of truth, `acts` the parallel typed channel).
-    pub fn record_receipt_typed(&self, acts: &[Observation], rendered: &str) {
-        self.record_receipt_inner(rendered, acts.to_vec());
+    /// `room` scopes the archived head to the room the act was FOR (the act
+    /// path passes it; legacy text callers don't have it) — the steps ledger
+    /// renders this-room acts first (CAUSAL-MEMORY-GRAPH.md slice B).
+    pub fn record_receipt_typed(&self, acts: &[Observation], rendered: &str, room: Option<Uuid>) {
+        self.record_receipt_inner(rendered, acts.to_vec(), room);
     }
 
     /// Shared body: mint the monotonic `#seq`, keep the FULL latest result, and push
@@ -445,7 +457,7 @@ impl WorkingMemory {
     /// plus the (possibly empty) typed acts. One entry per batch so `recent()` stays
     /// byte-stable (a multi-call batch renders as one receipt exactly as before);
     /// `acts` carries every call's typed observation for the typed consumers.
-    fn record_receipt_inner(&self, result: &str, acts: Vec<Observation>) {
+    fn record_receipt_inner(&self, result: &str, acts: Vec<Observation>, room: Option<Uuid>) {
         let a = result.trim();
         if a.is_empty() {
             return;
@@ -461,10 +473,31 @@ impl WorkingMemory {
         // trail's KV-cache prefix byte-stable across a settle-act.
         let head: String = a.chars().take(self.budget().trail_head_chars()).collect();
         let text = format!("[action #{seq}] {head}");
-        // Receipts-own archive (#414): the FIRST LINE of every receipt, kept beyond the
-        // shared ring's lifetime so the steps ledger can show act HISTORY, not just the
-        // last few conversation beats. Char-bounded by the window-derived archive share.
-        self.push_receipt_head(text.lines().next().unwrap_or_default().to_string());
+        // Receipts-own archive (#414): every act's head line, kept beyond the shared
+        // ring's lifetime so the steps ledger can show act HISTORY, not just the last
+        // few conversation beats. Char-bounded by the window-derived archive share.
+        //
+        // COMPACT head from the TYPED channel when we have it (CAUSAL-MEMORY-GRAPH.md
+        // slice B): `name(args)` per call, never the receipt's first line — that line
+        // drags the full `because <reasoning>` clause (~250 chars), which starved a
+        // 1,808-act citizen down to 1-2 visible acts (measured live 2026-08-15). The
+        // reasoning is not lost: it lives in the act's engram content, reachable
+        // through the CausedBy edge. Legacy text callers (no typed acts) keep the
+        // first-line head unchanged.
+        let archive_head = if acts.is_empty() {
+            text.lines().next().unwrap_or_default().to_string()
+        } else {
+            let calls: Vec<String> = acts
+                .iter()
+                .map(|o| {
+                    let args = o.call.input.to_string();
+                    let args: String = args.chars().take(48).collect();
+                    format!("{}({args})", o.call.name)
+                })
+                .collect();
+            format!("[action #{seq}] {}", calls.join("; "))
+        };
+        self.push_receipt_head(room, archive_head);
         let mut e = self.entries.lock();
         e.push_back(WmEntry {
             kind: WmKind::Receipt { n: seq },
@@ -479,13 +512,13 @@ impl WorkingMemory {
     /// Append one receipt head line to the proprioception archive and evict oldest-first
     /// down to the window-derived char share. One body for the live write and the
     /// snapshot restore, so both obey the same bound.
-    fn push_receipt_head(&self, head_line: String) {
+    fn push_receipt_head(&self, room: Option<Uuid>, head_line: String) {
         let cap = self.budget().receipt_archive_chars();
         let mut heads = self.receipt_heads.lock();
-        heads.push_back(head_line);
-        let mut total: usize = heads.iter().map(|h| h.chars().count() + 1).sum();
+        heads.push_back((room, head_line));
+        let mut total: usize = heads.iter().map(|(_, h)| h.chars().count() + 1).sum();
         while total > cap && heads.len() > 1 {
-            if let Some(evicted) = heads.pop_front() {
+            if let Some((_, evicted)) = heads.pop_front() {
                 total -= evicted.chars().count() + 1;
             }
         }
@@ -495,7 +528,7 @@ impl WorkingMemory {
     /// head line that still fits the archive share. The steps-taken ledger renders its
     /// newest tail from here — the persona-facing path back to her own act history that
     /// semantic recall deliberately refuses to be (#166 / #414).
-    pub fn receipt_archive(&self) -> Vec<String> {
+    pub fn receipt_archive(&self) -> Vec<(Option<Uuid>, String)> {
         self.receipt_heads.lock().iter().cloned().collect()
     }
 
@@ -557,11 +590,24 @@ impl WorkingMemory {
     /// the same serialization grid-sync will ship (one format, one seam —
     /// [[persona-mind-persists-across-shutdowns]]).
     pub fn snapshot(&self) -> VolatileSnapshot {
+        // ONE lock for both parallel arrays. Two `.lock()` calls inside the same
+        // struct literal self-deadlock: literal temporaries (the first guard) live
+        // until the whole expression ends, so the second lock waits on ourselves
+        // forever. Found as a 100%-reproducible test hang, 2026-08-15 — every
+        // snapshot save (i.e. every deploy pause) would have wedged the same way.
+        let (receipt_heads, receipt_head_rooms) = {
+            let archive = self.receipt_heads.lock();
+            (
+                archive.iter().map(|(_, h)| h.clone()).collect(),
+                archive.iter().map(|(r, _)| *r).collect(),
+            )
+        };
         VolatileSnapshot {
             entries: self.entries.lock().iter().cloned().collect(),
             last_action: self.last_action.lock().clone(),
             action_fps: self.action_fps.lock().iter().cloned().collect(),
-            receipt_heads: self.receipt_heads.lock().iter().cloned().collect(),
+            receipt_heads,
+            receipt_head_rooms,
             next_action_seq: self.next_action_seq.load(Ordering::Relaxed),
             saved_at_ms: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -602,8 +648,11 @@ impl WorkingMemory {
             // Same re-clamp contract as `entries`: refill through the one bounded push so
             // a snapshot from a bigger-window life evicts down to THIS life's share.
             self.receipt_heads.lock().clear();
+            // Zip with the (possibly shorter/absent on legacy snapshots) room
+            // tags; missing tags restore as None — honest "unscoped".
+            let mut rooms = snap.receipt_head_rooms.into_iter();
             for head in snap.receipt_heads {
-                self.push_receipt_head(head);
+                self.push_receipt_head(rooms.next().flatten(), head);
             }
         }
         *self.last_action.lock() = snap.last_action;
@@ -1354,7 +1403,8 @@ mod tests {
             saved_at_ms: 0, // pre-field snapshot: no gap guessed
             interrupted_dispatches: Vec::new(),
             build_sha: String::new(), // pre-field snapshot: no rebuild guessed either
-            receipt_heads: Vec::new(), // pre-archive snapshot: ledger's counter-only arm covers it
+            receipt_heads: Vec::new(),
+            receipt_head_rooms: Vec::new(), // pre-archive snapshot: ledger's counter-only arm covers it
         });
         let q = quiet.recent();
         assert_eq!(q.len(), 1);
@@ -1396,7 +1446,7 @@ mod tests {
         let rendered = "code/search({\"query\":\"needle\"})\nResult:\nmatch at foo.rs:42\n\n";
 
         let typed = WorkingMemory::new(8);
-        typed.record_receipt_typed(std::slice::from_ref(&obs), rendered);
+        typed.record_receipt_typed(std::slice::from_ref(&obs), rendered, None);
         let legacy = WorkingMemory::new(8);
         legacy.record_receipt(rendered);
         assert_eq!(
@@ -1452,7 +1502,7 @@ mod tests {
         );
         let archive = wm.receipt_archive();
         assert_eq!(archive.len(), 1, "the archive must survive the churn");
-        assert!(archive[0].contains("code/shell(ls)"));
+        assert!(archive[0].1.contains("code/shell(ls)"));
 
         // Char-bound eviction: flood with receipts; the archive keeps its
         // NEWEST within the share and never grows unbounded.
@@ -1461,10 +1511,10 @@ mod tests {
         }
         let archive = wm.receipt_archive();
         let cap = wm.budget().receipt_archive_chars();
-        let total: usize = archive.iter().map(|h| h.chars().count() + 1).sum();
+        let total: usize = archive.iter().map(|(_, h)| h.chars().count() + 1).sum();
         assert!(total <= cap, "archive exceeded its share: {total} > {cap}");
         assert!(
-            archive.last().unwrap().contains("f1999"),
+            archive.last().unwrap().1.contains("f1999"),
             "eviction must drop oldest, keep newest: {:?}",
             archive.last()
         );

--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -535,25 +535,47 @@ async fn sweep_lapsed_bench_cards(
                 instance = %instance,
                 "lapsed claim with a written artifact — auto-closing so the grade can run"
             );
-            // Provenance first, then the close: the room sees WHY the card moved before
-            // the verdict lands, and the verdict is attributable to the sweep, not to a
-            // citizen `done` that never happened.
-            let note = format!(
-                "⏱️ [bench {bench}] {instance} — the claim lapsed with a written artifact \
-                 and no `done`; auto-closing so the grade can run. (A live claim is never \
-                 preempted.)"
-            );
-            let _ = crate::persona::airc_citizen::publish_text_in_room(&airc, room_id, &note)
-                .await;
-            if airc
+            // Close FIRST, provenance note only on success: a persistently-failing close
+            // must not post a note into the room every tick (the first live tick failed
+            // ALL 21 closes silently — 21 probes in 0.6s straight past the 3-close cap,
+            // which only counts successes; without an error probe the whole failure mode
+            // was invisible). The note still lands before the verdict — grading takes
+            // seconds, the note posts immediately after the close.
+            match airc
                 .change_work_card_state(airc_lib::ChangeWorkCardState {
                     card_id: card.card_id,
                     state: CardState::Closed,
                 })
                 .await
-                .is_ok()
             {
-                closed += 1;
+                Ok(_) => {
+                    closed += 1;
+                    let note = format!(
+                        "⏱️ [bench {bench}] {instance} — the claim lapsed with a written \
+                         artifact and no `done`; auto-closed so the grade can run. (A live \
+                         claim is never preempted.)"
+                    );
+                    if let Err(e) =
+                        crate::persona::airc_citizen::publish_text_in_room(&airc, room_id, &note)
+                            .await
+                    {
+                        crate::probe!(
+                            class = "benchmark_grade.sweep_note_failed",
+                            card_id = %card.card_id.as_uuid(),
+                            error = %e,
+                            "card closed but the provenance note did not post"
+                        );
+                    }
+                }
+                Err(e) => {
+                    crate::probe!(
+                        class = "benchmark_grade.sweep_close_failed",
+                        card_id = %card.card_id.as_uuid(),
+                        room_id = %room_id,
+                        error = %e,
+                        "auto-close refused — card stays as-is, retried next tick"
+                    );
+                }
             }
         }
     }

--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -19,6 +19,8 @@ use std::any::Any;
 use async_trait::async_trait;
 use serde_json::Value;
 
+use airc_lib::CardState;
+
 use crate::commands::benchmark::{grade_swe, known_benchmarks, SweGradeParams};
 use crate::modules::work::WORK_CARD_STATE_CHANGED;
 use crate::persona::PersonaAircRuntimeRegistry;
@@ -67,12 +69,22 @@ impl ServiceModule for BenchmarkGradeModule {
             name: "benchmark_grade",
             priority: ModulePriority::Normal,
             command_prefixes: &[],
-            // EVENT-DRIVEN: react to the card-transition event. No tick, no board poll.
+            // EVENT-DRIVEN for the grade itself: react to the card-transition event.
             event_subscriptions: &[WORK_CARD_STATE_CHANGED],
             needs_dedicated_thread: false,
             max_concurrency: 0,
-            tick_interval: None,
+            // The one periodic ACTUATOR (doctrine: actuators may tick; condition-polls
+            // may not): lease expiry is a TIME fact with no wire event, so a bench card
+            // whose owner wrote the artifact but whose work session died before `done`
+            // would rot as Claimed forever. The sweep detects exactly that state and
+            // CLOSES the card — the close's wire echo then drives the normal
+            // bridge→grade tail. One grade path; the sweeper is only a detector.
+            tick_interval: Some(std::time::Duration::from_secs(180)),
         }
+    }
+
+    async fn tick(&self) -> Result<(), String> {
+        sweep_lapsed_bench_cards(&self.registry).await
     }
 
     async fn initialize(&self, ctx: &ModuleContext) -> Result<(), String> {
@@ -398,6 +410,156 @@ async fn grade_gym_card(
     Ok(())
 }
 
+/// Most closes a single sweep will perform. A burst of lapsed cards (e.g. a whole round's
+/// worth after a long outage) grades a few per tick instead of storming the room; the rest
+/// are still lapsed next tick.
+const SWEEP_MAX_CLOSES_PER_TICK: usize = 3;
+
+/// The sweep decision, pure so the truth table is unit-testable: a bench card is
+/// auto-closeable exactly when a person CLAIMED it, their lease LAPSED (work session
+/// died — `card_holder::hold_of`, the one lease predicate, #357), and their hands left
+/// a real artifact behind. A LIVE claim is never preempted; an unclaimed card was never
+/// worked; no artifact means there is nothing to grade — dispatch re-offer (#419) is
+/// that card's path, not a grade.
+fn sweep_ready(
+    state: &CardState,
+    hold: crate::persona::card_holder::Hold,
+    artifact_present: bool,
+) -> bool {
+    matches!(state, CardState::Claimed | CardState::InProgress)
+        && matches!(hold, crate::persona::card_holder::Hold::Lapsed)
+        && artifact_present
+}
+
+/// Did the owner's hands leave something gradeable? Mirrors the grade arms' own path
+/// derivations exactly — gym: the task's `solution_file` exists non-empty under her
+/// workspace root; SWE: the staged checkout exists AND the tree is dirty (an untouched
+/// clone graded would burn a fake capability-zero for a dead session, the #384 class).
+fn bench_artifact_present(bench: &str, instance: &str, owner: &str) -> bool {
+    let Some(spec) = known_benchmarks().iter().find(|b| b.name == bench) else {
+        return false;
+    };
+    let Ok(home) = crate::commands::benchmark::continuum_home() else {
+        return false;
+    };
+    let workspace = home
+        .join("citizens")
+        .join("peers")
+        .join(owner)
+        .join("workspace");
+    if spec.swe_dataset().is_some() {
+        let tree = workspace.join("swe").join(instance);
+        if !tree.is_dir() {
+            return false;
+        }
+        return std::process::Command::new("git")
+            .arg("-C")
+            .arg(&tree)
+            .args(["status", "--porcelain"])
+            .output()
+            .map(|o| o.status.success() && !o.stdout.is_empty())
+            .unwrap_or(false);
+    }
+    let Some(reference) = spec.eval_set else {
+        return false;
+    };
+    let Ok(task) = normalized_gym_task(reference, instance) else {
+        return false;
+    };
+    if task.test.is_none() {
+        return false; // expect-graded knowledge task — nothing file-shaped to sweep
+    }
+    let solution_file = task
+        .solution_file
+        .clone()
+        .unwrap_or_else(|| format!("{}.rs", task.id));
+    std::fs::read_to_string(workspace.join(solution_file))
+        .map(|code| !code.trim().is_empty())
+        .unwrap_or(false)
+}
+
+/// The algorithm of the operator's manual flip (2026-08-15, the first graded pass):
+/// a citizen writes the artifact but her work session dies before she says `done`,
+/// so the card rots as a lapsed claim and the grade never runs. The sweep detects
+/// exactly that state and CLOSES the card as her would-have-been `done` — the close's
+/// wire echo then drives the normal bridge→grade tail. ONE grade path; this is only
+/// a detector. A citizen who says `done` herself beats the sweeper (card goes
+/// terminal, sweep skips it); a citizen still working is never preempted (Held).
+async fn sweep_lapsed_bench_cards(
+    registry: &PersonaAircRuntimeRegistry,
+) -> Result<(), String> {
+    // Boot / no citizens online yet: quietly nothing to do — same posture as grade_card,
+    // but a tick must not error every 3 minutes of a citizen-less core.
+    let Some(rt) = registry.any_live_citizen() else {
+        return Ok(());
+    };
+    let airc = rt.airc().clone();
+    let set = airc
+        .subscription_set()
+        .await
+        .map_err(|e| format!("subscription set: {e}"))?;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| e.to_string())?
+        .as_millis() as u64;
+
+    let mut closed = 0usize;
+    for room in set.all().map(|sub| sub.as_room()) {
+        // Rooms without a board (or with a transiently unreadable one) are not sweep
+        // targets this tick; the board is durable, next tick sees it.
+        let Ok(board) = airc.work_board_in(&room).await else {
+            continue;
+        };
+        for card in &board.snapshot().cards {
+            if closed >= SWEEP_MAX_CLOSES_PER_TICK {
+                return Ok(());
+            }
+            let Some((bench, instance)) = parse_bench_title(&card.title) else {
+                continue; // normal work cards are NEVER the sweeper's business
+            };
+            let Some(owner) = card.owner else { continue };
+            let hold = crate::persona::card_holder::hold_of(card, now_ms);
+            if !sweep_ready(
+                &card.state,
+                hold,
+                bench_artifact_present(&bench, &instance, &owner.to_string()),
+            ) {
+                continue;
+            }
+            let room_id = room.channel.as_uuid();
+            crate::probe!(
+                class = "benchmark_grade.sweep_close",
+                card_id = %card.card_id.as_uuid(),
+                room_id = %room_id,
+                bench = %bench,
+                instance = %instance,
+                "lapsed claim with a written artifact — auto-closing so the grade can run"
+            );
+            // Provenance first, then the close: the room sees WHY the card moved before
+            // the verdict lands, and the verdict is attributable to the sweep, not to a
+            // citizen `done` that never happened.
+            let note = format!(
+                "⏱️ [bench {bench}] {instance} — the claim lapsed with a written artifact \
+                 and no `done`; auto-closing so the grade can run. (A live claim is never \
+                 preempted.)"
+            );
+            let _ = crate::persona::airc_citizen::publish_text_in_room(&airc, room_id, &note)
+                .await;
+            if airc
+                .change_work_card_state(airc_lib::ChangeWorkCardState {
+                    card_id: card.card_id,
+                    state: CardState::Closed,
+                })
+                .await
+                .is_ok()
+            {
+                closed += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -413,6 +575,27 @@ mod tests {
         assert_eq!(i, "sympy__sympy-24152");
         assert!(parse_bench_title("a normal work card").is_none());
         assert!(parse_bench_title("[bench frontier-rs] task-1: gist").is_some());
+    }
+
+    // what this catches: the sweep's whole safety envelope in one truth table — a LIVE
+    // claim is never preempted, an unclaimed/terminal card is never touched, a lapsed
+    // claim without an artifact is dispatch's re-offer problem (#419) not a grade, and
+    // ONLY lapsed+claimed+artifact auto-closes. Drift here either preempts working
+    // citizens or resurrects the manual operator flip.
+    #[test]
+    fn sweep_ready_truth_table() {
+        use crate::persona::card_holder::Hold;
+        // the one auto-close case (and its InProgress sibling)
+        assert!(sweep_ready(&CardState::Claimed, Hold::Lapsed, true));
+        assert!(sweep_ready(&CardState::InProgress, Hold::Lapsed, true));
+        // a live claim is NEVER preempted
+        assert!(!sweep_ready(&CardState::Claimed, Hold::Held, true));
+        // no artifact → nothing to grade → not the sweeper's business
+        assert!(!sweep_ready(&CardState::Claimed, Hold::Lapsed, false));
+        // never-claimed and terminal cards are untouchable regardless
+        assert!(!sweep_ready(&CardState::Open, Hold::Unclaimed, true));
+        assert!(!sweep_ready(&CardState::Closed, Hold::Lapsed, true));
+        assert!(!sweep_ready(&CardState::Merged, Hold::Lapsed, true));
     }
 
     // what this catches: only terminal states fire the grade. An in_progress/review

--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -75,7 +75,33 @@ impl ServiceModule for BenchmarkGradeModule {
         }
     }
 
-    async fn initialize(&self, _ctx: &ModuleContext) -> Result<(), String> {
+    async fn initialize(&self, ctx: &ModuleContext) -> Result<(), String> {
+        // THE live wiring. `config().event_subscriptions` installs a SYNCHRONOUS-tier
+        // subscription the registry marks `synchronous: false` — which `publish()`
+        // filters OUT, and runtime.rs:99 says so out loud: "event_subscriptions are
+        // dispatched only by the (currently unused) synchronous publish path — if
+        // this module expects live bus events, spawn a bus-receiver task from
+        // initialize() instead". Grade-on-done shipped on the dead tier and NEVER
+        // fired in production (proven live 2026-08-15: two bridged publishes, zero
+        // handle_event probes). This is the prescribed receiver task, same shape as
+        // chat::spawn_persist_listener.
+        let mut rx = ctx.bus.receiver();
+        let registry = self.registry.clone();
+        ctx.runtime.spawn(async move {
+            loop {
+                let event = match rx.recv().await {
+                    Ok(e) => e,
+                    // Lagged (slow consumer): a missed transition re-fires on the
+                    // next state change; the board is the durable truth, not the bus.
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+                };
+                if event.name != WORK_CARD_STATE_CHANGED {
+                    continue;
+                }
+                on_card_state_changed(&registry, &event.payload);
+            }
+        });
         Ok(())
     }
 
@@ -84,59 +110,65 @@ impl ServiceModule for BenchmarkGradeModule {
     }
 
     async fn handle_event(&self, event_name: &str, payload: Value) -> Result<(), String> {
-        if event_name != WORK_CARD_STATE_CHANGED {
-            return Ok(());
+        // Kept for the synchronous tier should it ever dispatch — the LIVE path is
+        // the bus-receiver task spawned in `initialize` (see the comment there).
+        if event_name == WORK_CARD_STATE_CHANGED {
+            on_card_state_changed(&self.registry, &payload);
         }
-        let state = payload
-            .get("state")
-            .and_then(Value::as_str)
-            .unwrap_or_default();
-        if !is_terminal(state) {
-            return Ok(());
-        }
-        let card_id = payload
-            .get("card_id")
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string();
-        if card_id.is_empty() {
-            return Ok(());
-        }
-        // The card's room, from the wire event (bridge payload contract). Boards are
-        // per-room: without this the grade read whatever room the grading citizen
-        // happened to be in — the #345 wrong-room trap, hit live 2026-08-15.
-        let room_id = payload
-            .get("room_id")
-            .and_then(Value::as_str)
-            .and_then(|s| s.parse::<uuid::Uuid>().ok());
-
-        // Grading is minutes long (clone + venv + pytest). The bus calls handle_event
-        // INLINE during publish, so blocking here would hang the citizen's work/state
-        // verb. Spawn it — fire-and-observe, never block-on-client (the long-jobs rule).
-        let registry = self.registry.clone();
-        tokio::spawn(async move {
-            crate::probe!(
-                class = "benchmark_grade.start",
-                card_id = %card_id,
-                room_id = %room_id.map(|r| r.to_string()).unwrap_or_default(),
-                "grade-on-done fired — reading the card's own room board"
-            );
-            if let Err(e) = grade_card(&registry, &card_id, room_id).await {
-                crate::probe!(
-                    class = "benchmark_grade.error",
-                    card_id = %card_id,
-                    error = %e,
-                    "grade could not run"
-                );
-                tracing::warn!(card = %card_id, "benchmark_grade: {e}");
-            }
-        });
         Ok(())
     }
 
     fn as_any(&self) -> &dyn Any {
         self
     }
+}
+
+/// React to one card-state transition: terminal state → spawn the grade against the
+/// card's OWN room. Non-terminal / malformed payloads are silently not-ours. Spawns
+/// because grading is minutes long (clone + venv + pytest) and the caller is a bus
+/// consumer loop that must keep draining.
+fn on_card_state_changed(registry: &PersonaAircRuntimeRegistry, payload: &Value) {
+    let state = payload
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if !is_terminal(state) {
+        return;
+    }
+    let card_id = payload
+        .get("card_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    if card_id.is_empty() {
+        return;
+    }
+    // The card's room, from the wire event (bridge payload contract). Boards are
+    // per-room: without this the grade read whatever room the grading citizen
+    // happened to be in — the #345 wrong-room trap, hit live 2026-08-15.
+    let room_id = payload
+        .get("room_id")
+        .and_then(Value::as_str)
+        .and_then(|s| s.parse::<uuid::Uuid>().ok());
+
+    let registry = registry.clone();
+    tokio::spawn(async move {
+        crate::probe!(
+            class = "benchmark_grade.start",
+            card_id = %card_id,
+            room_id = %room_id.map(|r| r.to_string()).unwrap_or_default(),
+            "grade-on-done fired — reading the card's own room board"
+        );
+        if let Err(e) = grade_card(&registry, &card_id, room_id).await {
+            crate::probe!(
+                class = "benchmark_grade.error",
+                card_id = %card_id,
+                error = %e,
+                "grade could not run"
+            );
+            tracing::warn!(card = %card_id, "benchmark_grade: {e}");
+        }
+    });
 }
 
 /// Read the card, and — if it is a bench SWE card — grade her workspace against the

--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -102,13 +102,32 @@ impl ServiceModule for BenchmarkGradeModule {
         if card_id.is_empty() {
             return Ok(());
         }
+        // The card's room, from the wire event (bridge payload contract). Boards are
+        // per-room: without this the grade read whatever room the grading citizen
+        // happened to be in — the #345 wrong-room trap, hit live 2026-08-15.
+        let room_id = payload
+            .get("room_id")
+            .and_then(Value::as_str)
+            .and_then(|s| s.parse::<uuid::Uuid>().ok());
 
         // Grading is minutes long (clone + venv + pytest). The bus calls handle_event
         // INLINE during publish, so blocking here would hang the citizen's work/state
         // verb. Spawn it — fire-and-observe, never block-on-client (the long-jobs rule).
         let registry = self.registry.clone();
         tokio::spawn(async move {
-            if let Err(e) = grade_card(&registry, &card_id).await {
+            crate::probe!(
+                class = "benchmark_grade.start",
+                card_id = %card_id,
+                room_id = %room_id.map(|r| r.to_string()).unwrap_or_default(),
+                "grade-on-done fired — reading the card's own room board"
+            );
+            if let Err(e) = grade_card(&registry, &card_id, room_id).await {
+                crate::probe!(
+                    class = "benchmark_grade.error",
+                    card_id = %card_id,
+                    error = %e,
+                    "grade could not run"
+                );
                 tracing::warn!(card = %card_id, "benchmark_grade: {e}");
             }
         });
@@ -122,7 +141,17 @@ impl ServiceModule for BenchmarkGradeModule {
 
 /// Read the card, and — if it is a bench SWE card — grade her workspace against the
 /// held-out oracle and post the verdict into the room.
-async fn grade_card(registry: &PersonaAircRuntimeRegistry, card_id: &str) -> Result<(), String> {
+///
+/// `room_id` is the card's OWN room from the wire event. Boards are per-room, so the
+/// read scopes there and the verdict posts there — never to `current_room()`, which
+/// is whichever room the grading citizen happens to sit in (#345's wrong-room trap,
+/// hit live 2026-08-15: the grader read academy's board, never found the bench card,
+/// and parked forever with no receipt).
+async fn grade_card(
+    registry: &PersonaAircRuntimeRegistry,
+    card_id: &str,
+    room_id: Option<uuid::Uuid>,
+) -> Result<(), String> {
     // Author/read through a live citizen — whoever this machine has online (never a
     // hardcoded name), the same deterministic pick curator_airc uses.
     let rt = registry
@@ -130,8 +159,25 @@ async fn grade_card(registry: &PersonaAircRuntimeRegistry, card_id: &str) -> Res
         .ok_or("no live citizen to author the grade through")?;
     let airc = rt.airc().clone();
 
+    // Resolve the card's room from the citizen's subscription set (same pattern as
+    // work.rs::claim_following_card_room). A room we can't resolve is a LOUD error —
+    // grading against a guessed board is exactly the silent-wrong-room failure this
+    // parameter exists to kill.
+    let room_id = room_id.ok_or("event carried no room_id — cannot scope the board read")?;
+    let set = airc
+        .subscription_set()
+        .await
+        .map_err(|e| format!("subscription set: {e}"))?;
+    let room = set
+        .all()
+        .map(|sub| sub.as_room())
+        .find(|r| r.channel.as_uuid() == room_id)
+        .ok_or_else(|| {
+            format!("grading citizen is not subscribed to the card's room {room_id}")
+        })?;
+
     let board = airc
-        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .work_board_in(&room)
         .await
         .map_err(|e| format!("board read: {e}"))?
         .snapshot();
@@ -160,7 +206,7 @@ async fn grade_card(registry: &PersonaAircRuntimeRegistry, card_id: &str) -> Res
     let spec = known_benchmarks().iter().find(|b| b.name == bench);
     let Some(dataset) = spec.and_then(|s| s.swe_dataset()) else {
         if let Some(spec) = spec.filter(|s| s.eval_set.is_some()) {
-            return grade_gym_card(&airc, spec, &instance, owner, &bench).await;
+            return grade_gym_card(&airc, spec, &instance, owner, &bench, room_id).await;
         }
         return Ok(()); // catalogued-but-not-runnable, or a bench name we don't know
     };
@@ -211,9 +257,16 @@ async fn grade_card(registry: &PersonaAircRuntimeRegistry, card_id: &str) -> Res
         )
     };
 
-    // Post the verdict into the room as a participant (slice 2 posts to the authoring
-    // citizen's room; per-run bench-room targeting is #329/#346 slice 3).
-    airc.say(&msg)
+    // Post the verdict into the CARD'S room as a participant — the run room the
+    // citizens are standing in, not the grading citizen's current room.
+    crate::probe!(
+        class = "benchmark_grade.verdict",
+        card_id = %card_id,
+        room_id = %room_id,
+        resolved = verdict.resolved,
+        "SWE grade complete — posting verdict into the card's room"
+    );
+    crate::persona::airc_citizen::publish_text_in_room(&airc, room_id, &msg)
         .await
         .map_err(|e| format!("post verdict: {e}"))?;
     Ok(())
@@ -251,6 +304,7 @@ async fn grade_gym_card(
     task_id: &str,
     owner: Option<impl std::fmt::Display>,
     bench: &str,
+    room_id: uuid::Uuid,
 ) -> Result<(), String> {
     let owner = owner
         .ok_or_else(|| format!("bench card {task_id} has no owner — nobody worked it"))?
@@ -299,7 +353,14 @@ async fn grade_gym_card(
              The card is graded on the file her hands write (code/write); it was never written."
         ),
     };
-    airc.say(&msg)
+    crate::probe!(
+        class = "benchmark_grade.verdict",
+        card_id = %task_id,
+        room_id = %room_id,
+        resolved = msg.starts_with('✅'),
+        "gym grade complete — posting verdict into the card's room"
+    );
+    crate::persona::airc_citizen::publish_text_in_room(airc, room_id, &msg)
         .await
         .map_err(|e| format!("post verdict: {e}"))?;
     Ok(())

--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -541,11 +541,18 @@ async fn sweep_lapsed_bench_cards(
             // which only counts successes; without an error probe the whole failure mode
             // was invisible). The note still lands before the verdict — grading takes
             // seconds, the note posts immediately after the close.
+            // Room-SCOPED mutate (airc #1363): the close targets the room the card
+            // actually lives in. The current-room verb refused all 21 of the first
+            // tick's closes — every target card was in a room the authoring citizen
+            // wasn't standing in (the WRITE half of the #345 class).
             match airc
-                .change_work_card_state(airc_lib::ChangeWorkCardState {
-                    card_id: card.card_id,
-                    state: CardState::Closed,
-                })
+                .change_work_card_state_in(
+                    &room,
+                    airc_lib::ChangeWorkCardState {
+                        card_id: card.card_id,
+                        state: CardState::Closed,
+                    },
+                )
                 .await
             {
                 Ok(_) => {

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -40,18 +40,94 @@ use crate::runtime::{
 };
 use crate::sdk_codegen::{AccessLevel, ActionCommand, CommandError, Ctx, DynCommand};
 
-/// The bus event `work/state` publishes the moment a card transitions. Subscribers
+/// The bus event published the moment a card transitions — by [`bridge_wire_work_event`]
+/// from the transition's own wire echo, so EVERY writer fires it: a citizen's
+/// `work/state`, the operator's `airc work state`, a remote peer. Subscribers
 /// glob-match this to REACT (e.g. the SWE grade-on-done handler, board freshness,
 /// auto-close) — the system is event-based, never polling
 /// ([[the-whole-system-is-event-based-not-polling]]). Payload: `{card_id, state}`.
 pub const WORK_CARD_STATE_CHANGED: &str = "work.card.state_changed";
 
-/// Process-global handle to the bus + registry so `work/state` (a command, which holds
-/// no `ModuleContext`) can publish the transition event. Set once by `WorkModule::
-/// initialize`; the bus and registry ARE process-global (one core), same granularity as
-/// the gossip ledger and the admission gates — so a process-global is the honest shape,
-/// not a field threaded through every command constructor.
+/// Process-global handle to the bus + registry so [`bridge_wire_work_event`] (called
+/// from persona inbound streams, which hold no `ModuleContext`) can publish the
+/// transition event. Set once by `WorkModule::initialize`; the bus and registry ARE
+/// process-global (one core), same granularity as the gossip ledger and the admission
+/// gates — so a process-global is the honest shape, not a field threaded through every
+/// command constructor.
 static WORK_EVENT_BUS: OnceLock<(Arc<MessageBus>, Arc<ModuleRegistry>)> = OnceLock::new();
+
+/// Decode a wire transcript event into the `work.card.state_changed` payload — or
+/// `None` if it isn't a card-state transition. Pure over the event so the contract
+/// is unit-testable against the real producer (`airc_work::encode_work_event`).
+///
+/// Payload contract: `{card_id, state}` with `card_id` the FULL hyphenated UUID and
+/// `state` the snake_case `CardState` serde form ("closed"/"merged"/…) — the exact
+/// vocabulary `benchmark_grade::is_terminal` and `parse_state` already speak.
+fn wire_card_state_payload(event: &airc_core::TranscriptEvent) -> Option<Value> {
+    if !airc_work::transcript_is_work_event(event) {
+        return None;
+    }
+    let item = airc_work::decode_transcript_work_event(event).ok()?;
+    let airc_work::WorkEvent::CardStateChanged(changed) = item.event else {
+        return None;
+    };
+    let state = serde_json::to_value(changed.state).ok()?;
+    Some(serde_json::json!({
+        "card_id": changed.card_id.as_uuid().to_string(),
+        "state": state,
+    }))
+}
+
+/// Once-per-process sighting of a wire event id. Every resident persona's subscribe
+/// stream yields the SAME room event once, so the bridge below would otherwise
+/// publish N copies for N residents; first sighting wins. Bounded ring — old ids
+/// age out, which is safe because duplicate deliveries arrive within the same
+/// fan-out instant, not hours apart.
+fn first_sighting(event_id: Uuid) -> bool {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+    const SEEN_CAP: usize = 256;
+    static SEEN: OnceLock<Mutex<VecDeque<Uuid>>> = OnceLock::new();
+    let seen = SEEN.get_or_init(|| Mutex::new(VecDeque::with_capacity(SEEN_CAP)));
+    let mut seen = seen.lock().unwrap_or_else(|p| p.into_inner());
+    if seen.contains(&event_id) {
+        return false;
+    }
+    if seen.len() >= SEEN_CAP {
+        seen.pop_front();
+    }
+    seen.push_back(event_id);
+    true
+}
+
+/// THE one emitter of [`WORK_CARD_STATE_CHANGED`] — bridge a card-state transition
+/// heard on the WIRE onto the internal bus. The state change in the airc store is
+/// the single source of truth, and its transcript echo is the single event source:
+/// a citizen's own `work/state` (her echo arrives on her own subscribe stream), the
+/// operator's `airc work state`, and a remote peer's transition all fire subscribers
+/// (the grade-on-done handler) identically. Before this bridge, only the continuum
+/// `work/state` VERB emitted — a card closed by any other writer changed the board
+/// and graded nothing (found live 2026-08-15: Asha's real rle_roundtrip artifact,
+/// operator close, zero grade).
+pub async fn bridge_wire_work_event(event: &airc_core::TranscriptEvent) {
+    let Some(payload) = wire_card_state_payload(event) else {
+        return;
+    };
+    if !first_sighting(event.event_id.as_uuid()) {
+        return;
+    }
+    crate::probe!(
+        class = "work.card.state_changed.bridged",
+        event_id = %event.event_id.as_uuid(),
+        room_id = %event.room_id.as_uuid(),
+        card_id = %payload["card_id"],
+        state = %payload["state"],
+        "wire card-state transition bridged onto the internal bus"
+    );
+    if let Some((bus, registry)) = WORK_EVENT_BUS.get() {
+        bus.publish(WORK_CARD_STATE_CHANGED, payload, registry).await;
+    }
+}
 
 /// Default claim lease (ms) — 30 min — when the caller doesn't set one. The claim
 /// is heartbeat-extendable; this is just the initial TTL.
@@ -775,19 +851,12 @@ impl ActionCommand for WorkState {
             .await
             .map_err(|e| CommandError::Internal(e.to_string()))?;
 
-        // Emit the transition as a bus EVENT — the moment a citizen moves a card, any
-        // subscriber REACTS (the SWE grade-on-done handler, board freshness, auto-close).
-        // Nothing scans the board on a clock; this is the event-based system law
-        // ([[the-whole-system-is-event-based-not-polling]]). Best-effort: the state
-        // change already succeeded, so a bus that isn't wired yet must never fail the verb.
-        if let Some((bus, registry)) = WORK_EVENT_BUS.get() {
-            bus.publish(
-                WORK_CARD_STATE_CHANGED,
-                serde_json::json!({ "card_id": p.card_id.clone(), "state": p.state.clone() }),
-                registry,
-            )
-            .await;
-        }
+        // NO bus emit here — the transition's transcript echo comes back on this
+        // persona's own subscribe stream and `bridge_wire_work_event` publishes
+        // [`WORK_CARD_STATE_CHANGED`] exactly once. One fact, one emitter: emitting
+        // from the verb too would double-fire every subscriber, and verb-side-only
+        // (the old shape) left cards closed by the airc CLI or a remote peer
+        // changing the board while grading nothing.
 
         Ok(WorkStateResult {
             card_id: p.card_id,
@@ -1357,13 +1426,113 @@ mod tests {
     use super::*;
 
     // what this catches: the card-transition event NAME is the contract between the
-    // emitter (`work/state`) and every subscriber (SWE grade-on-done, board freshness,
-    // auto-close). A silent rename here would unsubscribe every reactor — the event
-    // would fire into the void, undetectably. Pin the string. (Event-based system law:
-    // the grade REACTS to this, it never polls the board.)
+    // emitter (`bridge_wire_work_event`) and every subscriber (SWE grade-on-done, board
+    // freshness, auto-close). A silent rename here would unsubscribe every reactor — the
+    // event would fire into the void, undetectably. Pin the string. (Event-based system
+    // law: the grade REACTS to this, it never polls the board.)
     #[test]
     fn card_state_changed_event_name_is_the_stable_emitter_subscriber_contract() {
         assert_eq!(WORK_CARD_STATE_CHANGED, "work.card.state_changed");
+    }
+
+    /// Build a wire transcript event through the REAL producer (`encode_work_event`),
+    /// so a header/codec contract drift fails these tests instead of shipping.
+    fn wire_work_event(event: airc_work::WorkEvent, event_id: u128) -> airc_core::TranscriptEvent {
+        let (headers, body) =
+            airc_work::encode_work_event(&event).expect("work event encodes for the fixture");
+        airc_core::TranscriptEvent {
+            event_id: airc_core::EventId::from_u128(event_id),
+            room_id: airc_core::RoomId::from_u128(2),
+            peer_id: airc_core::PeerId::from_u128(3),
+            client_id: airc_core::ClientId::from_u128(4),
+            kind: airc_core::TranscriptKind::System,
+            occurred_at_ms: 100,
+            lamport: 1,
+            target: airc_core::MentionTarget::All,
+            headers,
+            body: Some(body),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    // what this catches: the grade-on-done tail was DEAF to every writer except the
+    // continuum `work/state` verb — a card closed via `airc work state` (operator) or a
+    // remote peer changed the board and graded NOTHING (live 2026-08-15: Asha's real
+    // rle_roundtrip artifact, operator close, zero grade). The bridge decodes the wire
+    // echo into the exact payload contract the grader speaks: full hyphenated card UUID
+    // + snake_case state that `is_terminal`/`parse_state` accept.
+    #[test]
+    fn wire_card_state_change_decodes_to_the_grader_payload_contract() {
+        let card_id = airc_work::WorkCardId::new();
+        let event = wire_work_event(
+            airc_work::WorkEvent::CardStateChanged(airc_work::CardStateChanged {
+                card_id,
+                state: airc_work::CardState::Closed,
+                changed_by: airc_core::PeerId::from_u128(3),
+                changed_at_ms: 100,
+            }),
+            0xA1,
+        );
+        let payload = wire_card_state_payload(&event).expect("card-state event must decode");
+        assert_eq!(
+            payload["card_id"].as_str().unwrap(),
+            card_id.as_uuid().to_string(),
+            "card_id must be the FULL hyphenated UUID (the grader prefix-matches it)"
+        );
+        assert_eq!(
+            payload["state"].as_str().unwrap(),
+            "closed",
+            "state must be the snake_case CardState serde form — the is_terminal vocabulary"
+        );
+        // parse_state round-trip: the bridged state string is valid work/state input.
+        assert_eq!(parse_state("closed").unwrap(), CardState::Closed);
+    }
+
+    // what this catches: a NON-state work event (a claim) or a non-work event must
+    // never fabricate a state-change publish — a claim firing the grader would grade
+    // half-finished work the moment it was picked up.
+    #[test]
+    fn non_state_work_events_and_non_work_events_do_not_bridge() {
+        let claim = wire_work_event(
+            airc_work::WorkEvent::CardClaimed(airc_work::WorkCardClaimed {
+                card_id: airc_work::WorkCardId::new(),
+                claim_id: airc_work::ClaimId::from_uuid(uuid::Uuid::new_v4()),
+                owner: airc_core::PeerId::from_u128(3),
+                ttl_ms: 200,
+                claimed_at_ms: 100,
+            }),
+            0xA2,
+        );
+        assert!(wire_card_state_payload(&claim).is_none());
+
+        let mut chat = wire_work_event(
+            airc_work::WorkEvent::CardStateChanged(airc_work::CardStateChanged {
+                card_id: airc_work::WorkCardId::new(),
+                state: airc_work::CardState::Closed,
+                changed_by: airc_core::PeerId::from_u128(3),
+                changed_at_ms: 100,
+            }),
+            0xA3,
+        );
+        chat.headers = airc_core::Headers::default(); // strip the work body-hint
+        assert!(
+            wire_card_state_payload(&chat).is_none(),
+            "without the work body-hint header the event must not decode as work"
+        );
+    }
+
+    // what this catches: every resident persona's subscribe stream yields the SAME
+    // room event once — without first-sighting dedup the bridge would publish N
+    // copies for N residents and the grader would grade (and post verdicts) N times.
+    // Fresh uuids per call keep this parallel-safe against the process-global ring.
+    #[test]
+    fn first_sighting_admits_once_per_event_id() {
+        let id = Uuid::new_v4();
+        assert!(first_sighting(id), "first delivery must win");
+        assert!(!first_sighting(id), "the second resident's echo must dedup");
+        assert!(first_sighting(Uuid::new_v4()), "a different event is fresh");
     }
 
     /// what this catches (#357): `work/claim` inventing a holder out of a stale

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -75,6 +75,12 @@ fn wire_card_state_payload(event: &airc_core::TranscriptEvent) -> Option<Value> 
     Some(serde_json::json!({
         "card_id": changed.card_id.as_uuid().to_string(),
         "state": state,
+        // The card's OWN room — boards are per-room, so a subscriber that reads
+        // the board or posts a verdict must scope to THIS room, never to whatever
+        // current_room() happens to be (the documented #345 wrong-room trap;
+        // found live 2026-08-15 when the grader read the grading citizen's
+        // academy board and never found the bench card).
+        "room_id": event.room_id.as_uuid().to_string(),
     }))
 }
 
@@ -1485,6 +1491,12 @@ mod tests {
             payload["state"].as_str().unwrap(),
             "closed",
             "state must be the snake_case CardState serde form — the is_terminal vocabulary"
+        );
+        assert_eq!(
+            payload["room_id"].as_str().unwrap(),
+            airc_core::RoomId::from_u128(2).as_uuid().to_string(),
+            "room_id must be the card's OWN room — the grader scopes its board read and \
+             verdict post to it (#345 wrong-room trap, hit live 2026-08-15)"
         );
         // parse_state round-trip: the bridged state string is valid work/state input.
         assert_eq!(parse_state("closed").unwrap(), CardState::Closed);

--- a/core/continuum-core/src/persona/airc_persona_conversation.rs
+++ b/core/continuum-core/src/persona/airc_persona_conversation.rs
@@ -300,6 +300,14 @@ impl PersonaConversation for AircPersonaConversation {
                         probe_class = "persona.inbound.raw_event",
                         "persona subscribe stream yielded a raw event (#146)"
                     );
+                    // Card-state transitions bridge onto the internal bus HERE —
+                    // the persona subscribe streams are the only channel-complete
+                    // receiver this core has (the daemon attach covers ONE room),
+                    // and this runs BEFORE the perceptual filter and the self-skip
+                    // so a citizen's own `work/state` echo counts. Once per wire
+                    // event process-wide (the bridge dedups by event id); this is
+                    // the single emitter the grade-on-done subscriber hears.
+                    crate::modules::work::bridge_wire_work_event(&event).await;
                     // Recover a perceptual room turn. Two on-wire shapes
                     // reach a persona's subscribe stream and both are
                     // messages it must hear: a peer's plain-text `say()`


### PR DESCRIPTION
## Two slices, one funnel

**Slice B (#447)**: receipt heads store the compact call form (~5x more act history per char budget), room-scoped archive with scope-first StepsLedger rendering, snapshot round-trip of room tags. Also fixes a 100%-reproducible self-deadlock: snapshot() locked receipt_heads twice inside one struct literal — every deploy-pause snapshot would have wedged (caught as a permanent test hang).

**Grader bridge (#450)**: benchmark_grade subscribed to a bus event only continuum's work/state verb emitted — a card closed by the airc CLI or a remote peer changed the board and graded nothing (found live with Asha's real rle_roundtrip artifact). bridge_wire_work_event is now THE single emitter of work.card.state_changed: decode the store's own wire echo via airc-work's codec, once-per-event-id dedup, publish through WORK_EVENT_BUS. Called from the persona inbound loop before the perceptual filter and self-skip. Verb-side emit deleted.

Tests: 16/16 work+benchmark_grade (decode contract vs the real encoder, non-state refusal, dedup), 66/66 working_memory+perception_facts+act_observe. Deployed to the M5 (deploy-verified e3e44f118); bridge live proof rides the next dispatch round (citizens spawned into the run room).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo