### PR TITLE
fix(serving): smoke miss on an advancing lane is contention, not wedge evidence (L11) — the 23-min boot kill-loop

### DIFF
--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -240,6 +240,75 @@ pub fn classify_never_started_timeout(
     }
 }
 
+/// How a missed decode SMOKE PROBE should be read, judged by the server's own
+/// `/slots` activity between two consecutive misses (L11) — the exact sibling of
+/// [`classify_never_started_timeout`], one layer up: that one classifies a REQUEST
+/// timeout by the lane's delivery record; this one classifies a PROBE miss by the
+/// lane's slot-state record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SmokeMissVerdict {
+    /// `/slots` changed between the two misses: the serve loop is advancing (for
+    /// whoever's work — including clients this core never knew about), so the probe
+    /// missed because real work held the slots. Contention, never wedge evidence.
+    AliveViaSlotProgress,
+    /// No proof of progress: first miss (nothing to compare), fingerprint frozen
+    /// (the wedge signature), or `/slots` unreadable (no exoneration on a fetch
+    /// error). Counts toward the relaunch threshold exactly as before L11.
+    CountMiss,
+}
+
+/// Judge a smoke-probe miss by comparing `/slots` fingerprints across misses. Pure so
+/// the busy-lane / frozen-lane / first-miss / no-endpoint rows are table-testable.
+pub fn judge_smoke_miss(prev_fp: Option<u64>, cur_fp: Option<u64>) -> SmokeMissVerdict {
+    match (prev_fp, cur_fp) {
+        (Some(prev), Some(cur)) if prev != cur => SmokeMissVerdict::AliveViaSlotProgress,
+        _ => SmokeMissVerdict::CountMiss,
+    }
+}
+
+/// Fingerprint of the server's own `/slots` activity state — the lane-level work
+/// evidence that survives every blind spot the adapter-side stamps have (L11).
+///
+/// The adapter stamps ([`note_real_decode`] / [`note_real_prefill_progress`]) only see
+/// work done for OUR open streams. Two measured cases where that goes blind while the
+/// lane works flat out:
+///   1. GHOST WORK after a core restart: the predecessor's in-flight turns keep
+///      decoding inside llama-server for clients that no longer exist — no stream on
+///      this side, no stamps (2026-08-16 boot: 3 wedge declarations + kill-loop,
+///      10:13→10:36, on a lane llama's own log showed grinding the whole time).
+///   2. A fresh core's atomics start at 0 (`None`), so the L9 "trust busy lanes" gate
+///      falls through until the first adapter stream observes progress.
+/// `/slots` is the server's OWN account: per slot `id_task` (task turnover),
+/// `is_processing`, `n_prompt_tokens_processed` (prefill advance), and the decode
+/// counter when the build exposes it. If ANY of that changed between two looks, the
+/// serve loop is provably advancing — for whoever's work — and a missed smoke probe
+/// is queue contention, not death. A truly wedged backend is FROZEN: same fingerprint
+/// every look (the 2026-08-05 4-hour wedge held one task at one impossible progress).
+///
+/// FOR WHOEVER EXTENDS THIS: hash only fields that change WITH WORK. Never hash
+/// timing/params blobs — they'd churn the fingerprint on every poll and exonerate a
+/// dead lane forever. `None` (no array) means "cannot say", which the caller must
+/// treat as no exoneration, never as evidence of progress.
+pub fn slots_activity_fingerprint_of(slots: &serde_json::Value) -> Option<u64> {
+    use std::hash::{Hash, Hasher};
+    let arr = slots.as_array()?;
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    arr.len().hash(&mut h);
+    for slot in arr {
+        slot.get("id").and_then(|v| v.as_u64()).hash(&mut h);
+        slot.get("id_task").and_then(|v| v.as_i64()).hash(&mut h);
+        slot.get("is_processing").and_then(|v| v.as_bool()).hash(&mut h);
+        slot.get("n_prompt_tokens_processed")
+            .and_then(|v| v.as_u64())
+            .hash(&mut h);
+        slot.get("next_token")
+            .and_then(|nt| nt.get("n_decoded"))
+            .and_then(|v| v.as_u64())
+            .hash(&mut h);
+    }
+    Some(h.finish())
+}
+
 /// Wall-clock ms of the last real PREFILL advance on the served lane. The decode stamp
 /// above is blind to a lane that is 100% mid-prefill: eight 17k prompts saturate the
 /// slots for minutes producing ZERO output tokens, the decode stamp goes stale, the
@@ -1424,6 +1493,17 @@ pub trait LlamaServerControl: Send + Sync {
         false
     }
 
+    /// Fingerprint of the server's `/slots` activity state (see
+    /// [`slots_activity_fingerprint_of`]). The health heartbeat compares the value
+    /// across two consecutive smoke-probe MISSES: changed → the serve loop is
+    /// advancing (ghost work, other clients' turns — work the adapter stamps can't
+    /// see) and the miss is queue contention; frozen → the miss counts as wedge
+    /// evidence exactly as before. `None` = "cannot say" (no endpoint, fake/remote
+    /// control) — never exoneration. Default `None` keeps fakes honest.
+    async fn slots_activity_fingerprint(&self) -> Option<u64> {
+        None
+    }
+
     /// The flag this control's stderr watcher raises when the running lane proves itself
     /// WEDGED — a slot reporting arithmetically impossible progress (see
     /// [`crate::inference::wedge`]). The serving daemon polls it on its tick and owns the
@@ -1693,9 +1773,21 @@ pub async fn ensure_model_serving<C: LlamaServerControl + ?Sized>(
     }
 
     match ctrl.serve(target).await {
-        Ok(()) => EnsureOutcome::Spawned {
-            model: target.model_id().to_string(),
-        },
+        Ok(()) => {
+            // A fresh lane starts with a CLEAN failure record. `serve` kills the old
+            // child, which murders its in-flight turns; their deaths stamp
+            // `note_real_decode_failure` DURING the load window — after the reset
+            // `declare_lane_wedged` did — so without this the corpses of the turns OUR
+            // kill created condemn the replacement on its first heartbeat and the
+            // relaunch loops (measured 2026-08-16: wedge 10:19:04 → kill → 4 stamped
+            // fails by 10:19:49 → wedged again; 23 min of self-fighting). The reset
+            // comment on `reset_real_decode_failures` always promised "the freshly
+            // relaunched lane starts clean" — this is the site that makes it true.
+            reset_real_decode_failures();
+            EnsureOutcome::Spawned {
+                model: target.model_id().to_string(),
+            }
+        }
         Err(reason) => EnsureOutcome::Degraded {
             reason: reason.to_string(),
         },
@@ -2242,6 +2334,24 @@ impl LlamaServerControl for LlamaServerProcess {
                 }
             }
         }
+    }
+
+    async fn slots_activity_fingerprint(&self) -> Option<u64> {
+        // Control-plane read (`/slots` is on the HTTP thread, answers while compute
+        // is saturated). Any failure → None: the caller must not read a fetch error
+        // as either progress or freeze.
+        let url = format!("{}/slots", self.root);
+        let body: serde_json::Value = self
+            .client
+            .get(&url)
+            .timeout(PROBE_TIMEOUT)
+            .send()
+            .await
+            .ok()?
+            .json()
+            .await
+            .ok()?;
+        slots_activity_fingerprint_of(&body)
     }
 
     fn owns_child(&self) -> bool {
@@ -2883,6 +2993,66 @@ mod tests {
         assert_eq!(
             classify_never_started_timeout(Some(120_000), 120_000),
             NeverStartedClass::WedgeEvidence
+        );
+    }
+
+    // what this catches (2026-08-16, the 23-minute boot kill-loop): a smoke miss on
+    // a lane doing GHOST WORK (a dead core's in-flight turns, no adapter stream →
+    // no L9 stamps) counted as wedge evidence, so 2 misses killed a lane llama's
+    // own log showed grinding flat out — three times in one boot. The verdict must
+    // exonerate a miss when the server's own /slots state ADVANCED between misses,
+    // keep a FROZEN fingerprint counting (the 2026-08-05 wedge signature holds one
+    // task at one impossible progress forever), never exonerate on a first miss
+    // (nothing to compare), and never exonerate on a fetch error.
+    #[test]
+    fn smoke_miss_on_an_advancing_lane_is_contention_not_wedge_evidence() {
+        use super::{judge_smoke_miss, SmokeMissVerdict};
+        // Slots advanced between the two misses: real work held the probe out.
+        assert_eq!(
+            judge_smoke_miss(Some(1), Some(2)),
+            SmokeMissVerdict::AliveViaSlotProgress
+        );
+        // Frozen fingerprint: the wedge signature — count it.
+        assert_eq!(judge_smoke_miss(Some(7), Some(7)), SmokeMissVerdict::CountMiss);
+        // First miss: nothing to compare — count it (threshold ≥ 2 keeps the
+        // detection latency identical to pre-L11).
+        assert_eq!(judge_smoke_miss(None, Some(7)), SmokeMissVerdict::CountMiss);
+        // /slots unreadable: a fetch error is never exoneration.
+        assert_eq!(judge_smoke_miss(Some(7), None), SmokeMissVerdict::CountMiss);
+        assert_eq!(judge_smoke_miss(None, None), SmokeMissVerdict::CountMiss);
+    }
+
+    // what this catches: the fingerprint must move with WORK (prefill advance, task
+    // turnover, decode count) and must NOT move with volatile per-request params —
+    // hashing the params blob would churn every poll and exonerate a dead lane
+    // forever. JSON shape pinned from a live /slots response (2026-08-16, :58057).
+    #[test]
+    fn slots_fingerprint_moves_with_work_and_ignores_params() {
+        use super::slots_activity_fingerprint_of;
+        let slot = |processed: u64, temp: f64| {
+            serde_json::json!([{
+                "id": 0, "n_ctx": 32512, "is_processing": true, "id_task": 55395,
+                "n_prompt_tokens": 143, "n_prompt_tokens_processed": processed,
+                "params": { "temperature": temp, "top_k": 20 }
+            }])
+        };
+        let base = slots_activity_fingerprint_of(&slot(4, 0.0)).expect("array parses");
+        // Prefill advanced → fingerprint moves.
+        assert_ne!(
+            base,
+            slots_activity_fingerprint_of(&slot(90, 0.0)).unwrap(),
+            "prefill advance must change the fingerprint"
+        );
+        // Only volatile params changed → fingerprint stable.
+        assert_eq!(
+            base,
+            slots_activity_fingerprint_of(&slot(4, 0.9)).unwrap(),
+            "params churn must NOT change the fingerprint"
+        );
+        // Non-array body (error page, wrong endpoint) → None, never a fake hash.
+        assert_eq!(
+            slots_activity_fingerprint_of(&serde_json::json!({"error": "nope"})),
+            None
         );
     }
 

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -282,6 +282,14 @@ pub struct ServingDaemonModule {
     /// Where the liveness heartbeat gets "how long since a real decode" from. Defaults to
     /// the llama-server process-global; tests own it ([`Self::set_decode_age_source`]).
     decode_age: DecodeAgeSource,
+    /// The `/slots` activity fingerprint observed at the LAST missed smoke probe (L11).
+    /// A changed fingerprint at the next miss proves the serve loop advanced between the
+    /// two looks — work the adapter stamps can't see (ghost turns from a dead core's
+    /// clients, a fresh boot's un-stamped atomics) — so the miss is queue contention,
+    /// not wedge evidence. Cleared on every smoke success so a stale value can never
+    /// exonerate a later freeze. `std::sync::Mutex` — held only for a copy, never
+    /// across an await.
+    last_miss_slots_fp: Arc<std::sync::Mutex<Option<u64>>>,
     /// Where the heartbeat reads the real-turn failure streak (#363). Sustained real
     /// failure is wedge evidence that OUTRANKS a passing smoke probe — the undersized-slot
     /// wedge class rejects the fleet's real prompts while a tiny probe still succeeds.
@@ -541,6 +549,7 @@ impl ServingDaemonModule {
                 crate::model_registry::try_global().and_then(|r| r.model(id).cloned())
             }),
             decode_age: Arc::new(crate::inference::llama_server::ms_since_real_work),
+            last_miss_slots_fp: Arc::new(std::sync::Mutex::new(None)),
             real_fails: Arc::new(crate::inference::llama_server::consecutive_real_decode_failures),
             last_healthy_window: Arc::new(AtomicU32::new(0)),
             last_healthy_lanes: Arc::new(AtomicU32::new(0)),
@@ -2138,7 +2147,9 @@ impl ServingDaemonModule {
         }))
     }
 
-    /// The liveness HEARTBEAT (#175 self-heal). On a cadence far slower than [`TICK`],
+    /// The liveness HEARTBEAT (#175 self-heal) — see also [`judge_smoke_miss`] (L11),
+    /// which decides whether a missed probe is contention or wedge evidence.
+    /// On a cadence far slower than [`TICK`],
     /// decode-probe the LIVE lane the daemon currently believes is `ready`. The reconcile
     /// fast-path trusts that published `ready` and never re-probes a child it owns, so a
     /// Metal-GPU-OOM-POISONED backend — which answers every control-plane read (`/health`,
@@ -2240,6 +2251,7 @@ impl ServingDaemonModule {
         let health_fails = self.health_fails.clone();
         let health_probing = self.health_probing.clone();
         let force_relaunch = self.force_relaunch.clone();
+        let last_miss_fp = self.last_miss_slots_fp.clone();
         let bus = self.bus.get().cloned();
         Some(tokio::spawn(async move {
             // A real one-token generation through the live slots — the ONLY probe that
@@ -2249,6 +2261,38 @@ impl ServingDaemonModule {
             let ok = server.decode_smoke_ok().await;
             if ok {
                 health_fails.store(0, Ordering::Relaxed);
+                // A success invalidates the miss-time fingerprint — a stale one must
+                // never exonerate a LATER freeze.
+                *last_miss_fp.lock().unwrap() = None;
+                health_probing.store(false, Ordering::Release);
+                return;
+            }
+            // L11: before counting the miss, ask the server's OWN /slots whether the
+            // serve loop advanced since the LAST miss. The adapter stamps (L9) are
+            // blind to work done for clients that no longer exist — measured
+            // 2026-08-16 boot: an adopted lane grinding through a dead core's ghost
+            // turns ate 2 smoke misses and got killed, three times, 23 minutes. A
+            // changed fingerprint = queue contention (probe couldn't get a slot
+            // because real work held them); frozen = wedge evidence, same threshold
+            // and latency as before.
+            let cur_fp = server.slots_activity_fingerprint().await;
+            let prev_fp = {
+                let mut guard = last_miss_fp.lock().unwrap();
+                std::mem::replace(&mut *guard, cur_fp)
+            };
+            if matches!(
+                crate::inference::llama_server::judge_smoke_miss(prev_fp, cur_fp),
+                crate::inference::llama_server::SmokeMissVerdict::AliveViaSlotProgress
+            ) {
+                health_fails.store(0, Ordering::Relaxed);
+                crate::probe!(
+                    class = "serving.health",
+                    ok = true,
+                    via = "slot_progress",
+                    "smoke probe missed but /slots advanced between misses — the serve \
+                     loop is doing real work the adapter stamps can't see (ghost turns, \
+                     other clients); contention, not a wedge (L11)",
+                );
                 health_probing.store(false, Ordering::Release);
                 return;
             }
@@ -3912,6 +3956,10 @@ mod tests {
         /// The stderr watcher's report channel, as the real `LlamaServerProcess` exposes it.
         /// A test raises this to stand in for a slot printing impossible progress.
         wedge: crate::inference::wedge::WedgeFlag,
+        /// Drives [`LlamaServerControl::slots_activity_fingerprint`] (L11). 0 = the
+        /// endpoint is unreadable (`None`); any other value is the fingerprint. A test
+        /// bumps it to stand in for the serve loop advancing between smoke misses.
+        slots_fp: Arc<AtomicU64>,
     }
 
     impl FakeServer {
@@ -3922,6 +3970,7 @@ mod tests {
                 ok,
                 smoke_ok: Arc::new(AtomicBool::new(true)),
                 wedge: Default::default(),
+                slots_fp: Default::default(),
             }
         }
     }
@@ -3957,6 +4006,12 @@ mod tests {
             // liveness-heartbeat tests) independently of the control plane; defaults
             // true (a healthy fake decodes).
             self.smoke_ok.load(Ordering::Relaxed)
+        }
+        async fn slots_activity_fingerprint(&self) -> Option<u64> {
+            match self.slots_fp.load(Ordering::Relaxed) {
+                0 => None,
+                v => Some(v),
+            }
         }
     }
 
@@ -4736,6 +4791,7 @@ mod tests {
             ok: true,
             smoke_ok: smoke.clone(),
             wedge: Default::default(),
+                slots_fp: Default::default(),
         }));
         let _ = daemon.serving_tx.send_replace(ready_snapshot());
 
@@ -4776,6 +4832,7 @@ mod tests {
             ok: true,
             smoke_ok: smoke.clone(),
             wedge: Default::default(),
+                slots_fp: Default::default(),
         }));
         let _ = daemon.serving_tx.send_replace(ready_snapshot());
 
@@ -4818,6 +4875,7 @@ mod tests {
             ok: true,
             smoke_ok: smoke.clone(),
             wedge: Default::default(),
+                slots_fp: Default::default(),
         }));
         let _ = daemon.serving_tx.send_replace(ready_snapshot());
 
@@ -4861,6 +4919,7 @@ mod tests {
             ok: true,
             smoke_ok: Arc::new(AtomicBool::new(false)),
             wedge: Default::default(),
+                slots_fp: Default::default(),
         }));
         busy.set_decode_age_source(Arc::new(move || Some(window_ms / 2)));
         let _ = busy.serving_tx.send_replace(ready_snapshot());
@@ -4878,6 +4937,7 @@ mod tests {
             ok: true,
             smoke_ok: Arc::new(AtomicBool::new(true)),
             wedge: Default::default(),
+                slots_fp: Default::default(),
         }));
         quiet.set_decode_age_source(Arc::new(move || Some(window_ms + 1)));
         let _ = quiet.serving_tx.send_replace(ready_snapshot());
@@ -4909,6 +4969,7 @@ mod tests {
             // chance to vouch for a lane the real workload proves broken.
             smoke_ok: Arc::new(AtomicBool::new(true)),
             wedge: Default::default(),
+                slots_fp: Default::default(),
         }));
         // Fresh decode trust too (a partial stream can stamp it) — must ALSO be outranked.
         let window_ms = TICK.as_millis() as u64 * HEALTH_PROBE_EVERY_TICKS;
@@ -4929,6 +4990,75 @@ mod tests {
             d.force_relaunch.load(Ordering::Acquire),
             "the reconcile must be forced to re-prove the lane, not re-adopt it"
         );
+    }
+
+    // what this catches (L11 — the 2026-08-16 23-minute boot kill-loop): after a
+    // reboot, the adopted lane ground through the dead core's GHOST turns — real
+    // work no adapter stream observes, so decode-age trust (L9) was blind, two
+    // smoke misses counted as wedge evidence, and a healthy lane was killed three
+    // times. The heartbeat must consult the server's OWN /slots between misses:
+    // an ADVANCING fingerprint exonerates the miss (streak resets, lane stays
+    // ready); a FROZEN fingerprint keeps counting and wedges at the same
+    // threshold/latency as before.
+    #[tokio::test]
+    async fn a_smoke_miss_on_a_lane_with_advancing_slots_is_not_wedge_evidence() {
+        let serves = Arc::new(AtomicUsize::new(0));
+        let slots_fp = Arc::new(AtomicU64::new(1));
+        let mut d = daemon_with(Arc::new(FakeServer {
+            serves,
+            ok: true,
+            // Every smoke probe MISSES — the ghost work holds the slots.
+            smoke_ok: Arc::new(AtomicBool::new(false)),
+            wedge: Default::default(),
+            slots_fp: slots_fp.clone(),
+        }));
+        // Pin both process-global evidence sources to inert test values — the
+        // globals are stamped by unrelated tests under full-suite parallelism
+        // (the #7 isolation class), which would silently skip the probe path.
+        d.set_decode_age_source(Arc::new(|| None));
+        d.set_real_fails_source(Arc::new(|| 0));
+        let _ = d.serving_tx.send_replace(ready_snapshot());
+
+        // Drive a heartbeat probe to completion (the cadence gate only fires
+        // every Nth call; bounded by that cadence).
+        let probe_once = |d: &ServingDaemonModule| {
+            let mut h = None;
+            for _ in 0..(HEALTH_PROBE_EVERY_TICKS as usize + 1) {
+                if let Some(handle) = d.spawn_health_heartbeat_if_due() {
+                    h = Some(handle);
+                    break;
+                }
+            }
+            h.expect("a heartbeat probe must fire within one cadence window")
+        };
+
+        // Miss #1: first miss has nothing to compare — it counts (streak = 1).
+        probe_once(&d).await.unwrap();
+        assert_eq!(d.health_fails.load(Ordering::Relaxed), 1);
+        // The serve loop ADVANCES between misses (ghost work / other clients).
+        slots_fp.store(2, Ordering::Relaxed);
+        // Miss #2: fingerprint moved → exonerated, streak resets, still ready.
+        probe_once(&d).await.unwrap();
+        assert_eq!(
+            d.health_fails.load(Ordering::Relaxed),
+            0,
+            "slot progress between misses proves the serve loop alive — the miss \
+             must reset the streak, not feed the relaunch threshold"
+        );
+        assert!(d.serving_tx.borrow().ready, "lane must stay ready");
+        assert!(!d.force_relaunch.load(Ordering::Acquire));
+
+        // Now FREEZE the fingerprint (the 2026-08-05 wedge signature): two more
+        // misses with no slot movement must wedge exactly as before L11.
+        probe_once(&d).await.unwrap();
+        assert_eq!(d.health_fails.load(Ordering::Relaxed), 1);
+        probe_once(&d).await.unwrap();
+        assert!(
+            !d.serving_tx.borrow().ready,
+            "a frozen /slots across the miss window is the real wedge — detection \
+             latency must be unchanged"
+        );
+        assert!(d.force_relaunch.load(Ordering::Acquire));
     }
 
     // what this catches: a lane whose per-slot window froze at ≤ HALF the


### PR DESCRIPTION
## The measured failure (2026-08-16 boot, probe ledger)

Adoption at boot **worked** — lane ready 3 seconds after the first reconcile. Then the health machinery killed the healthy lane **three times** (wedge declarations 10:19:04, 10:19:49, 10:34:52; adopt_rejected 10:21:09 and 10:36:12) before a respawn finally stuck at 10:36. Twenty-three minutes of the system fighting itself per reboot, and citizens citing "the ongoing rebuilds and interruptions" in their withdrawal messages.

The lane was never wedged. It was grinding through the dead core's **ghost turns** — in-flight work whose clients died with the old core. No adapter stream observes that work, so every existing liveness shield (L9 decode-age, prefill stamps, #2317's delivery record) was blind, and two smoke misses read as death.

## Two fixes

1. **L11 — slot-progress exoneration.** On a smoke miss, fingerprint the server's own `/slots` (`id_task`, `is_processing`, `n_prompt_tokens_processed`, `n_decoded` — enabled by default, answers on the HTTP thread while compute is saturated). Fingerprint moved since the last miss → the serve loop is provably advancing *for someone* → contention, streak resets. Frozen fingerprint → counts exactly as before (the 2026-08-05 four-hour wedge held one task at one impossible progress forever), so real-wedge detection latency is **unchanged**. Pure verdict `judge_smoke_miss` lives beside its sibling `classify_never_started_timeout` — one classifier family, one place.

2. **Fresh lanes start with a clean failure record.** `serve()` kills the old child, which murders its in-flight turns; their deaths stamped 4 real-turn failures onto the *replacement* lane's account and re-wedged it 45 seconds after birth (10:19:49) — each kill manufactured the evidence for the next. `reset_real_decode_failures` always promised "the freshly relaunched lane starts clean"; the reset at `serve() Ok` is the site that makes it true.

## Tests
- Pure verdict table (advance/frozen/first-miss/fetch-error rows)
- Fingerprint moves with work, ignores volatile params, `None` on non-array (JSON shape pinned from the live `/slots` on :58057)
- Daemon-level: drives miss→advance→exonerate then miss→frozen→wedge through the real `spawn_health_heartbeat_if_due` path; pre-existing L9/#363 heartbeat tests unregressed

Part of #452 (boot owns the process tree) / #446 (starvation-stamped-as-wedge family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo