### PR TITLE
fix(cognition): prove grounding-deferral by control flow, not by a stopwatch

### DIFF
--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -1258,6 +1258,12 @@ fn load_volatile(persona_id: Uuid) -> Option<PersistedVolatile> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::time::Duration;
+
+    use tokio::sync::{watch, Notify};
+    use tokio::time::timeout;
+
     use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
     use crate::cognition::workspace::Decision;
     use crate::persona::engram::{ChatMessageRef, Engram, EngramKind, EngramOrigin, TrustState};
@@ -1710,7 +1716,10 @@ mod tests {
         let mut cfg = cfg_for(persona);
         cfg.grounding_sources = vec![
             GroundingSource::framing(Arc::new(HandsMap)).requires_hands(),
-            GroundingSource::framing(Arc::new(SlowGrounding { delay_ms: 0 })),
+            // A second, hands-agnostic source so the assertion below is about the
+            // hands-describing one being stripped, not about grounding being empty.
+            // Its gate starts open, so it delivers straight through here.
+            GroundingSource::framing(Arc::new(GatedGrounding::new())),
         ];
         registry.register_from_cfg(cfg);
 
@@ -1774,17 +1783,62 @@ mod tests {
         );
     }
 
-    /// A grounding RagSource whose deliver is deliberately slow — models the real
-    /// I/O cost (roster query / workspace-map scan) the slice moves off the hot
-    /// path. Exercised through the LIVE grounding path (GroundingSource →
-    /// RagSourceFaculty → DeferredFaculty), not a hand-built faculty.
-    struct SlowGrounding {
-        delay_ms: u64,
+    /// A grounding RagSource whose `deliver()` the TEST holds the door on: it
+    /// cannot return until the gate is opened. Models the real I/O cost (roster
+    /// query / workspace-map scan) the slice moves off the hot path — but as a
+    /// *control-flow* hold rather than a `sleep`, so "is this deliver on the
+    /// critical path?" is answered by whether the tick completes, never by a
+    /// wall-clock threshold a loaded CI runner can forge. Exercised through the
+    /// LIVE grounding path (GroundingSource → RagSourceFaculty → DeferredFaculty),
+    /// not a hand-built faculty.
+    struct GatedGrounding {
+        /// `false` = held shut. Every `deliver()` parks here until it flips true.
+        gate: watch::Sender<bool>,
+        /// Bumped on ENTRY to `deliver()`, before parking — so the test can wait
+        /// for "the tick reached the source" without polling a clock.
+        entries: AtomicUsize,
+        /// Fires on each entry, so that wait is event-driven (system law: no
+        /// condition-polling).
+        entered: Notify,
     }
+
+    impl GatedGrounding {
+        /// Starts OPEN — the cold tick must be able to complete.
+        fn new() -> Self {
+            let (gate, _rx) = watch::channel(true);
+            Self {
+                gate,
+                entries: AtomicUsize::new(0),
+                entered: Notify::new(),
+            }
+        }
+        /// `send_replace`, not `send`: with no receiver parked at this instant
+        /// `send` fails and silently leaves the value UNCHANGED, which quietly
+        /// turns the whole gate into a no-op. Same reason `DashboardCaptureSink`
+        /// publishes with `send_replace`.
+        fn open_gate(&self) {
+            self.gate.send_replace(true);
+        }
+        fn shut_gate(&self) {
+            self.gate.send_replace(false);
+        }
+        fn deliver_entries(&self) -> usize {
+            self.entries.load(AtomicOrdering::SeqCst)
+        }
+        /// Resolves once `deliver()` has been ENTERED beyond `baseline`. Loops on
+        /// the counter because a stale `notify_one` permit from an earlier entry
+        /// may wake us spuriously.
+        async fn entered_beyond(&self, baseline: usize) {
+            while self.deliver_entries() == baseline {
+                self.entered.notified().await;
+            }
+        }
+    }
+
     #[async_trait::async_trait]
-    impl RagSource for SlowGrounding {
+    impl RagSource for GatedGrounding {
         fn source_id(&self) -> &'static str {
-            "slow-grounding"
+            "gated-grounding"
         }
 
         fn expand_command(&self) -> Option<&'static str> {
@@ -1802,9 +1856,13 @@ mod tests {
             _budget: u32,
             resolution: crate::persona::rag_budget::ResolutionPreference,
         ) -> crate::persona::rag_budget::RagDelivery {
-            tokio::time::sleep(std::time::Duration::from_millis(self.delay_ms)).await;
+            self.entries.fetch_add(1, AtomicOrdering::SeqCst);
+            self.entered.notify_one();
+            // Park until the test opens the gate. `wait_for` returns immediately
+            // when it is already open, so an open gate costs nothing.
+            let _ = self.gate.subscribe().wait_for(|open| *open).await;
             crate::persona::rag_budget::RagDelivery {
-                source_id: "slow-grounding".to_string(),
+                source_id: "gated-grounding".to_string(),
                 items: vec![crate::persona::rag_budget::RagItem {
                     content: "roster: Ivar [persona], win-claude [claude]".to_string(),
                     tokens: 12,
@@ -1825,85 +1883,101 @@ mod tests {
         }
     }
 
-    // what this catches: the SPEED the grounding-deferral slice buys, measured on
-    // the live critical path. Model LOCKED (same HeuristicInferenceAdapter both
-    // forks), ONE variable changed (defer_grounding) — the glass-box controlled
-    // experiment. A slow grounding source (60ms deliver, modeling roster/
-    // workspace-map I/O) sits ON the perception barrier when synchronous; when
-    // deferred it runs in the bg and the WARM tick serves reprojected last-good,
-    // so it LEAVES the barrier. critical_path_us = max(perception)+max(delib);
-    // the model (delib) is identical across forks, so the delta isolates exactly
-    // the grounding cost removed from the loop. If a regression puts the deferred
-    // source back on the barrier, the delta collapses and this fails.
+    // what this catches: that deferring grounding takes the slow source OFF the
+    // perception barrier — the structural claim, proven by control flow instead of
+    // by a stopwatch. Model LOCKED (same HeuristicInferenceAdapter both forks), ONE
+    // variable changed (defer_grounding). With the source's deliver held SHUT:
+    //   * the DEFERRED fork's warm tick still completes — it can only do that by
+    //     serving reprojected last-good, i.e. never awaiting deliver; and
+    //   * the SYNCHRONOUS fork's warm tick runs INTO deliver and parks there —
+    //     the control that proves the hold is real and the completion above means
+    //     something.
+    // A future parked on a shut gate cannot complete no matter how loaded the
+    // machine is, so neither assertion has a timing tolerance to blow. The COST
+    // this buys (that removing it from the barrier removes exactly its deliver
+    // from the turn's wait) is the arithmetic half, table-tested clock-free in
+    // `workspace_dashboard::tests`.
+    //
+    // This replaces a version that asserted `deferred_critical_path < 30ms` on the
+    // live cycle. It measured wall clock through `cargo test`'s parallelism, so on
+    // a loaded CI runner (a 60s CPU-hog test running alongside it) the deferred
+    // fork clocked 99,798µs against the synchronous fork's 62,427µs — the fork
+    // that pays NO grounding cost measuring higher than the one that pays 60ms.
+    // The number was scheduler stall, not grounding; the invariant was never
+    // temporal. Never re-express it as a duration.
     #[tokio::test]
-    async fn deferring_grounding_removes_its_deliver_cost_from_the_critical_path() {
-        use crate::cognition::workspace_dashboard::DashboardCaptureSink;
-        const DELAY_MS: u64 = 60;
+    async fn deferring_grounding_takes_the_slow_source_off_the_perception_barrier() {
+        // A LIVENESS bound, never a performance threshold: every assertion here is
+        // about control flow, so this only fires if a tick genuinely hangs.
+        const LIVENESS: Duration = Duration::from_secs(30);
+        const WARM_BURST: &str = "teammate: and the rollback plan?";
 
-        // Build a cycle with ONE slow grounding source, run a cold tick + a warm
-        // tick in the same room, and return the WARM tick's critical path.
-        async fn warm_critical_path(defer_grounding: bool) -> u128 {
+        // Build a cycle with ONE gated grounding source and run the COLD tick with
+        // the gate OPEN, so the deferred lane publishes its last-good finding and
+        // both forks reach the steady state a live persona actually runs at.
+        async fn warmed(defer_grounding: bool) -> (WorkspaceCycle, Arc<GatedGrounding>, Uuid) {
             let persona = Uuid::new_v4();
             let room = Uuid::new_v4();
-            let slow: Arc<dyn RagSource> = Arc::new(SlowGrounding { delay_ms: DELAY_MS });
+            let gate = Arc::new(GatedGrounding::new());
+            let source: Arc<dyn RagSource> = Arc::clone(&gate) as Arc<dyn RagSource>;
             let mut cfg = cfg_for(persona);
-            cfg.grounding_sources = vec![GroundingSource::framing(slow).defer_tolerant()];
+            cfg.grounding_sources = vec![GroundingSource::framing(source).defer_tolerant()];
             cfg.defer_grounding = defer_grounding;
 
-            let sink = Arc::new(DashboardCaptureSink::new(persona));
-            let rx = sink.subscribe();
-            let cycle = build_workspace_cycle(cfg).with_capture(sink.clone());
-
-            // Tick 1: cold-start for the deferred fork (kicks the bg worker, serves
-            // None); the sync fork pays the full deliver here too.
-            let _ = cycle
-                .run_in_room("teammate: where are we on the deploy?", room)
-                .await;
-            // Let the bg worker land its finding so the warm tick serves last-good.
-            tokio::time::sleep(std::time::Duration::from_millis(DELAY_MS * 2)).await;
-            // Tick 2 (warm): the steady-state the live persona actually runs at.
-            let _ = cycle
-                .run_in_room("teammate: and the rollback plan?", room)
-                .await;
-            // record() ran synchronously inside run_in_room → the watch holds tick 2.
-            let cp = rx.borrow().critical_path_us;
-            cp
+            let cycle = build_workspace_cycle(cfg);
+            timeout(
+                LIVENESS,
+                cycle.run_in_room("teammate: where are we on the deploy?", room),
+            )
+            .await
+            .expect("cold tick completes with the grounding gate open");
+            (cycle, gate, room)
         }
 
-        let sync_cp = warm_critical_path(false).await;
-        let deferred_cp = warm_critical_path(true).await;
+        // DEFERRED fork: with deliver held shut, the warm tick must STILL complete.
+        let (cycle, gate, room) = warmed(true).await;
+        gate.shut_gate();
+        timeout(LIVENESS, cycle.run_in_room(WARM_BURST, room))
+            .await
+            .expect(
+                "deferred fork's warm tick never completed with the grounding deliver held \
+                 shut — the deferred source is back ON the perception barrier",
+            );
+        // Release the background worker (parked on the gate) before teardown.
+        gate.open_gate();
+        drop(cycle);
 
-        eprintln!("\n=== grounding-deferral speed delta (model locked) ===");
-        eprintln!("defer_grounding=false  critical_path = {sync_cp} µs");
-        eprintln!("defer_grounding=true   critical_path = {deferred_cp} µs");
-        eprintln!(
-            "removed from the loop  = {} µs (~{} ms)",
-            sync_cp.saturating_sub(deferred_cp),
-            sync_cp.saturating_sub(deferred_cp) / 1000
-        );
-        eprintln!("====================================================\n");
-
-        let delay_us = (DELAY_MS as u128) * 1000;
-        assert!(
-            sync_cp >= delay_us - 10_000,
-            "sync fork must pay ~the deliver cost on the barrier: {sync_cp}µs < {}µs",
-            delay_us - 10_000
-        );
-        assert!(
-            deferred_cp < delay_us / 2,
-            "deferred fork's warm tick must NOT pay the deliver cost: {deferred_cp}µs"
-        );
-        assert!(
-            sync_cp.saturating_sub(deferred_cp) >= 40_000,
-            "deferral must remove ~the grounding deliver from the critical path; \
-             delta was only {}µs",
-            sync_cp.saturating_sub(deferred_cp)
-        );
+        // SYNCHRONOUS fork — the control. Same gate, same hold: this tick must run
+        // INTO deliver rather than complete, which is what makes the deferred
+        // fork's completion above evidence of anything.
+        let (cycle, gate, room) = warmed(false).await;
+        gate.shut_gate();
+        let before = gate.deliver_entries();
+        let mut tick = std::pin::pin!(cycle.run_in_room(WARM_BURST, room));
+        tokio::select! {
+            _ = tick.as_mut() => panic!(
+                "synchronous fork's warm tick completed while the grounding deliver was held \
+                 shut — the source is not on the perception barrier at all, so this test can \
+                 no longer tell deferral apart from nothing happening"
+            ),
+            reached = timeout(LIVENESS, gate.entered_beyond(before)) => {
+                reached.expect(
+                    "synchronous fork's warm tick never reached the grounding deliver — the \
+                     source is not being delivered on the barrier"
+                );
+            }
+        }
+        // …and it finishes the moment the door opens, proving the hold — not a
+        // deadlock elsewhere — is what kept it parked.
+        gate.open_gate();
+        timeout(LIVENESS, tick)
+            .await
+            .expect("synchronous fork's warm tick finishes once the gate opens");
     }
 
     mod hands_isolation {
         use super::*;
-        use crate::cognition::tool_executor::{CommandToolExecutor, ToolExecutor};
+        use crate::cognition::tool_executor::CommandToolExecutor;
         use crate::modules::code::{CodeModule, CodeState};
         use crate::routing::CallerIdentity;
         use crate::runtime::{CommandExecutor, InProcessTransport, ModuleRegistry};

--- a/core/continuum-core/src/cognition/workspace_dashboard.rs
+++ b/core/continuum-core/src/cognition/workspace_dashboard.rs
@@ -27,7 +27,31 @@ use serde::Serialize;
 use tokio::sync::watch;
 use uuid::Uuid;
 
-use super::workspace::{Decision, WorkspaceCaptureSink, WorkspaceTrace};
+use super::workspace::{Decision, FacultyTiming, WorkspaceCaptureSink, WorkspaceTrace};
+
+/// The two concurrent barriers, as arithmetic: the turn waits on the SLOWEST
+/// faculty of each phase, not the sum — `max(perception) + max(deliberation)`.
+///
+/// Pure, and lifted out of [`DashboardCaptureSink::record`] on purpose. The COST
+/// claim of the grounding-deferral slice — *"taking a slow source off the
+/// perception barrier removes exactly its deliver from the turn's wait"* — is
+/// arithmetic over per-faculty timings, so it is provable with the timings as
+/// PARAMETERS. Proving it instead with a stopwatch around a live cycle is what
+/// made the old `deferring_grounding_..._critical_path` test flaky: on a loaded
+/// CI runner a scheduler stall forged a 99,798µs "grounding cost" in the fork
+/// that pays no grounding cost at all. Same shape as the pure verdict fns in
+/// `inference/llama_server.rs` — decide from parameters, leave the clock outside.
+pub(crate) fn critical_path_us(timings: &[FacultyTiming]) -> u128 {
+    let slowest_of = |deliberation: bool| {
+        timings
+            .iter()
+            .filter(|t| t.deliberation == deliberation)
+            .map(|t| t.elapsed_us)
+            .max()
+            .unwrap_or(0)
+    };
+    slowest_of(false) + slowest_of(true)
+}
 
 /// One faculty's wall-clock this tick, projected to a serializable shape. Same
 /// pattern as the JSONL sink's `TimingRecord`: each sink owns its wire format so
@@ -105,22 +129,6 @@ impl WorkspaceCaptureSink for DashboardCaptureSink {
     fn record(&self, trace: &WorkspaceTrace) {
         let tick = self.tick.fetch_add(1, Ordering::Relaxed) + 1;
 
-        // The two concurrent barriers: the turn waits on the slowest of each
-        // phase, not the sum. critical_path = max(perception) + max(deliberation).
-        let max_perception = trace
-            .timings
-            .iter()
-            .filter(|t| !t.deliberation)
-            .map(|t| t.elapsed_us)
-            .max()
-            .unwrap_or(0);
-        let max_deliberation = trace
-            .timings
-            .iter()
-            .filter(|t| t.deliberation)
-            .map(|t| t.elapsed_us)
-            .max()
-            .unwrap_or(0);
         let total_faculty_us: u128 = trace.timings.iter().map(|t| t.elapsed_us).sum();
 
         let context_chars: usize = trace
@@ -152,7 +160,7 @@ impl WorkspaceCaptureSink for DashboardCaptureSink {
                     bid: t.bid,
                 })
                 .collect(),
-            critical_path_us: max_perception + max_deliberation,
+            critical_path_us: critical_path_us(&trace.timings),
             total_faculty_us,
             context_bids: trace.context_broadcast.len(),
             context_chars,
@@ -277,5 +285,83 @@ mod tests {
         assert_eq!(frame.output_tokens, 40);
         // The decision rides along, kebab-tagged.
         assert!(matches!(frame.decision, Some(Decision::Speak { .. })));
+    }
+
+    // what this catches: the COST half of the grounding-deferral claim — that
+    // moving a slow grounding source OFF the perception barrier removes exactly
+    // its deliver from the turn's wait — as arithmetic over the timings instead
+    // of a stopwatch around a live cycle. The structural half (that the deferred
+    // tick genuinely never awaits `deliver()`) is proven clock-free in
+    // `persona_workspace.rs`. Together they replace the wall-clock test that CI
+    // load could forge either way.
+    #[test]
+    fn taking_the_slow_grounding_faculty_off_the_barrier_removes_exactly_its_cost() {
+        let deliberation = FacultyTiming {
+            faculty: FacultyId::Deliberation,
+            elapsed_us: 5_000,
+            deliberation: true,
+            bid: true,
+        };
+        let fast_perception = FacultyTiming {
+            faculty: FacultyId::Recall,
+            elapsed_us: 200,
+            deliberation: false,
+            bid: true,
+        };
+        let grounding = |elapsed_us| FacultyTiming {
+            faculty: FacultyId::Custom("grounding".to_string()),
+            elapsed_us,
+            deliberation: false,
+            bid: true,
+        };
+
+        // Synchronous: the 60ms deliver IS the perception max, so the turn waits on it.
+        let on_barrier = critical_path_us(&[
+            fast_perception.clone(),
+            grounding(60_000),
+            deliberation.clone(),
+        ]);
+        assert_eq!(on_barrier, 60_000 + 5_000);
+
+        // Deferred: the tick serves reprojected last-good, so the grounding faculty
+        // reads ~0 and the perception max collapses back to the fast faculty.
+        let off_barrier = critical_path_us(&[
+            fast_perception.clone(),
+            grounding(3),
+            deliberation.clone(),
+        ]);
+        assert_eq!(off_barrier, 200 + 5_000);
+        assert_eq!(
+            on_barrier - off_barrier,
+            59_800,
+            "deferral must remove the grounding deliver, and nothing else, from the wait"
+        );
+
+        // The barrier is a MAX, not a sum: a second slow perception faculty means
+        // deferring grounding buys nothing, and the arithmetic must say so rather
+        // than crediting the slice with a win it didn't earn.
+        let two_slow = critical_path_us(&[
+            FacultyTiming {
+                elapsed_us: 60_000,
+                ..fast_perception.clone()
+            },
+            grounding(60_000),
+            deliberation.clone(),
+        ]);
+        let one_deferred = critical_path_us(&[
+            FacultyTiming {
+                elapsed_us: 60_000,
+                ..fast_perception.clone()
+            },
+            grounding(3),
+            deliberation.clone(),
+        ]);
+        assert_eq!(two_slow, one_deferred, "the barrier waits on the slowest");
+
+        // An all-perception tick has no deliberation term, and vice versa — the
+        // `unwrap_or(0)` legs, so a half-populated trace can't underflow the frame.
+        assert_eq!(critical_path_us(&[grounding(700)]), 700);
+        assert_eq!(critical_path_us(&[deliberation]), 5_000);
+        assert_eq!(critical_path_us(&[]), 0);
     }
 }


### PR DESCRIPTION
## The failure

PR #2329 was CI-red on exactly one test — `cognition::persona_workspace::tests::deferring_grounding_removes_its_deliver_cost_from_the_critical_path` — despite that PR's only changed file being `cognition/swe_bench.rs`, which does not touch this module.

## Root cause: the assertion was unfalsifiable, not the code

The test asserted `deferred_critical_path < 30ms` on a **live cognition cycle**. `critical_path_us` is built from `FacultyTiming.elapsed_us`, which is real wall clock and by its own doc *"includes scheduling waits, which is honest: it's the latency the barrier actually saw"*. Under `cargo test`'s parallelism that number measures the runner, not grounding.

The CI numbers prove it rather than merely suggesting it:

| fork | measured critical path |
|---|---|
| `defer_grounding=false` (pays a 60ms deliver) | 62,427µs |
| `defer_grounding=true` (pays none) | **99,798µs** |

The fork that pays *no* grounding cost measured **higher** than the one that pays 60ms. That is impossible for a grounding measurement — it can only be scheduler stall, and the same run has `capacity::trace_tail::tests::k3_fixture_measured_schedulable_coverage` logging *"has been running for over 60 seconds"* concurrently. Solo on this machine the same fork reads **784µs**, ~127× under the CI value.

So: class (a) — non-deterministic by construction. The production path is correct; `DeferredFaculty::contribute` returns reprojected last-good and never awaits the inner faculty on a warm ambient tick (`deferred_faculty.rs`, the `return served` branch). The invariant is **control flow**, and it was being probed with a stopwatch.

## The fix — split into its two honest halves, both clock-free

**Structural** (`persona_workspace.rs`): `SlowGrounding`'s `sleep` becomes `GatedGrounding`, whose `deliver()` parks until the *test* opens a gate. With the gate held shut:

- the **deferred** fork's warm tick must still **complete** — it can only do that by serving last-good, i.e. never awaiting `deliver()`;
- the **synchronous** fork's warm tick must run **into** `deliver()` and park there — the control that makes the completion above evidence of anything.

A future parked on a shut gate cannot complete no matter how loaded the machine is, so neither assertion has a timing tolerance to blow. The two remaining `timeout`s are 30s **liveness** bounds that only fire on a genuine hang — never perf thresholds. (One real bug found while building this: `watch::Sender::send` silently leaves the value unchanged when no receiver is parked, which made the gate a no-op; `send_replace` is the repo idiom, as `DashboardCaptureSink` already documents.)

**Cost** (`workspace_dashboard.rs`): the `max(perception) + max(deliberation)` barrier arithmetic is lifted out of `record()` into a pure `critical_path_us(&[FacultyTiming])` and table-tested with the timings as **parameters** — including that the barrier is a MAX, so a second slow perception faculty means deferral is correctly credited *nothing*. Same shape as the pure verdict fns in `inference/llama_server.rs`.

## Verification

- **Positive control**: mutating the deferred fork back onto the barrier fails with the intended diagnostic (*"the deferred source is back ON the perception barrier"*) — the test has teeth.
- New tests: **5/5 green** repeated.
- Full lib suite `cargo test -p continuum-core --lib --features metal,accelerate`: **7194 passed, 0 failed — twice**.
- `cargo check --all-targets` clean; no new warnings (one pre-existing unused `ToolExecutor` import removed, boy-scout).
- Test wall time drops 450ms → ~10ms: the sleeps existed only to feed the stopwatch.

No `#[ignore]`, no loosened threshold, no retry, no new test mod (both tests extend the existing `mod tests` in their file).

Unblocks #2329 (django runner seam + astropy sdist build deps + era pins), which is the #1 scoreboard blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo