### PR TITLE
fix(commands): a command declares BOTH halves or the core refuses to boot — activity/* was routable and invisible

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -3090,7 +3090,37 @@ mod tests {
             // to the point where more cutting would recreate #358 — a citizen who cannot
             // find the verb reaches for the wrong one and reads her own looping as having
             // nothing to contribute.
-            const AGENTIC_SURFACE_BOUND_CEILING: u32 = 10350;
+            // 10350 → 11300, stated plainly as the ratchet demands, and SHRUNK FIRST
+            // as its own first branch requires — this is the first re-pin where the
+            // shrink was MEASURED rather than eyeballed.
+            //
+            // WHAT GREW: three NATIVE activity verbs — `activity/spawn`, `activity/archive`,
+            // `activity/protect` (+1,273 gross). They are not new commands; they routed
+            // all along and had simply never shipped a DESCRIPTOR, so `activity/spawn` —
+            // the verb that mints every room, benchmark rooms included — was absent from
+            // `commands/list`, the ACL, codegen and every citizen's tool surface. Same
+            // defect class as #339, now impossible: `ModuleRegistry::register` panics on
+            // a constructor with no descriptor.
+            //
+            // WHAT SHRANK: 728 tokens, from making the schema projection stop shipping
+            // MAINTAINER RATIONALE to citizens. schemars lifts `///` verbatim, so one
+            // doc comment served two readers with opposite needs — a citizen deciding
+            // whether to spawn a room was billed for `schemars(with = "String") describes
+            // the WIRE (a uuid string, per #[serde(transparent)])…`. The projection now
+            // keeps the LEAD PARAGRAPH (see `persona_tools::lead_paragraph_descriptions`);
+            // rationale stays in the file where it belongs. Not a length cap — truncating
+            // the ANSWER is #358's shape.
+            //
+            // NET 11,972 → 11,244. Design + full measurement:
+            // docs/cognition/TOOL-DISCLOSURE-LADDER.md. That doc also retracts the
+            // "the schemas are 3-5x bloated" reading this ceiling invited: measured, the
+            // 26-verb surface is 6,935 tokens, mean 266/verb — leaner per verb than the
+            // frontier agent runtimes it was being unfavourably compared to. The surface
+            // is not obese; it is paid TWICE (#333) and it is charged against a 16k lane.
+            // The next real shrink is structural — rung 2 of the ladder becoming the
+            // TURN's working set instead of a static list — after which this ceiling
+            // guards the SPINE and stops taxing capability.
+            const AGENTIC_SURFACE_BOUND_CEILING: u32 = 11300;
             assert!(
                 needed <= AGENTIC_SURFACE_BOUND_CEILING,
                 "the agentic surface now needs {needed} tokens (was 8040, ceiling \

--- a/core/continuum-core/src/cognition/persona_tools.rs
+++ b/core/continuum-core/src/cognition/persona_tools.rs
@@ -536,7 +536,7 @@ fn tool_input_schema_from(schema: &serde_json::Value) -> ToolInputSchema {
             .to_string(),
         properties: schema
             .get("properties")
-            .cloned()
+            .map(|p| lead_paragraph_descriptions(p.clone()))
             .unwrap_or_else(|| json!({})),
         required: schema.get("required").and_then(|v| v.as_array()).map(|a| {
             a.iter()
@@ -548,7 +548,60 @@ fn tool_input_schema_from(schema: &serde_json::Value) -> ToolInputSchema {
         definitions: schema
             .get("definitions")
             .or_else(|| schema.get("$defs"))
-            .cloned(),
+            .map(|d| lead_paragraph_descriptions(d.clone())),
+    }
+}
+
+/// Keep only the LEADING PARAGRAPH of every `description` in a schema subtree.
+///
+/// # Why the schema and the source comment are not the same text
+///
+/// `schemars` lifts a field's `///` doc comment verbatim into the JSON Schema, so
+/// one piece of prose is asked to serve two readers with opposite needs. The
+/// maintainer needs the WHY — why the Rust type is what it is, what the doc used to
+/// claim, why a list is deliberately not enumerated. The caller deciding whether to
+/// invoke the verb needs only WHAT the field is and what a valid value looks like,
+/// and pays for every token of the rest on every turn it is offered.
+///
+/// Measured on the 26-verb native surface (build 4743): 550 tokens of the 6,935
+/// were maintainer rationale, 310 of them on `activity/spawn` alone — where a
+/// citizen was billed for `schemars(with = "String") describes the WIRE (a uuid
+/// string, per #[serde(transparent)]) to the tool schema while Rust keeps the type`
+/// on the way to deciding whether to spawn a room.
+///
+/// The split is CONVENTIONAL rather than declared — a blank line — because that is
+/// how these docs are already written (lead sentence, then rationale), so it needs
+/// no per-command annotation and cannot drift from a second source. A single-
+/// paragraph doc is unchanged, which is the common case: only 2 of 26 verbs carry
+/// a second paragraph today.
+///
+/// Deliberately NOT a length cap. A long first paragraph is a long ANSWER to
+/// "what is this field", and truncating that is how a verb becomes unusable —
+/// #358's shape, where a citizen who cannot find the verb reaches for the wrong one.
+/// Contentless length is the defect; length is not.
+fn lead_paragraph_descriptions(node: serde_json::Value) -> serde_json::Value {
+    use serde_json::Value;
+    match node {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(k, v)| {
+                    // Only a `description` STRING is prose. A key called
+                    // `description` whose value is a schema (a param actually named
+                    // `description`, e.g. code/edit's) recurses like any other.
+                    match (k.as_str(), &v) {
+                        ("description", Value::String(text)) => {
+                            let lead = text.split("\n\n").next().unwrap_or(text).trim_end();
+                            (k, Value::String(lead.to_string()))
+                        }
+                        _ => (k, lead_paragraph_descriptions(v)),
+                    }
+                })
+                .collect(),
+        ),
+        Value::Array(items) => {
+            Value::Array(items.into_iter().map(lead_paragraph_descriptions).collect())
+        }
+        other => other,
     }
 }
 
@@ -763,6 +816,62 @@ mod tests {
             "native set stayed bounded ({} tools); a full dump would re-mute personas",
             names.len()
         );
+    }
+
+    // what this catches: the schema is a TEACHING surface, not a copy of the source
+    // comment. schemars lifts `///` verbatim, so maintainer rationale (why the Rust
+    // type is what it is, what the doc used to say) rode into every offered tool on
+    // every turn — 550 tokens of the 26-verb native surface, measured. The lead
+    // paragraph survives intact (truncating the ANSWER is #358's shape); everything
+    // after the blank line is for whoever opens the file. Regression here = the
+    // rationale coming back, or — worse — the lead sentence getting clipped.
+    #[test]
+    fn schema_descriptions_carry_the_lead_paragraph_not_the_rationale() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "recipe": {
+                    "type": "string",
+                    "description": "Which recipe to build from — the EXACT `purpose` key.\n\nNot enumerated here on purpose: recipes are DATA, so any list in this comment is stale the moment someone authors a new one."
+                },
+                // A param literally NAMED `description` must recurse, not be treated
+                // as prose — the code/edit shape that a naive key-match would corrupt.
+                "description": {
+                    "type": "string",
+                    "description": "Optional note describing the change.\n\nRecorded in the change history."
+                }
+            },
+            "definitions": {
+                "EditMode": {
+                    "description": "How to edit.\n\nHistorical note nobody calling this needs."
+                }
+            }
+        });
+
+        let out = tool_input_schema_from(&schema);
+        let recipe = out.properties["recipe"]["description"].as_str().unwrap();
+        assert_eq!(
+            recipe, "Which recipe to build from — the EXACT `purpose` key.",
+            "lead paragraph must survive VERBATIM — clipping the answer makes the verb unusable"
+        );
+        assert!(
+            !recipe.contains("stale the moment"),
+            "maintainer rationale must not reach the offered schema: {recipe}"
+        );
+
+        // The param named `description` is a SCHEMA, so it keeps its own shape and
+        // its nested prose is trimmed like any other field's.
+        let named = &out.properties["description"];
+        assert_eq!(named["type"], "string", "a param named `description` is not prose");
+        assert_eq!(
+            named["description"].as_str().unwrap(),
+            "Optional note describing the change."
+        );
+
+        // definitions travel with the schema (llama.cpp resolves $refs against them)
+        // and get the same treatment — they are offered prose too.
+        let defs = out.definitions.expect("definitions must still ship");
+        assert_eq!(defs["EditMode"]["description"].as_str().unwrap(), "How to edit.");
     }
 
     fn spec(name: &str) -> NativeToolSpec {

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -195,12 +195,18 @@ impl ActionCommand for ActivitySpawn {
     // touching this file. Naming members here re-hardcodes what the recipe loader
     // exists to keep dynamic.
     //
-    // So this points at the live catalogue instead of enumerating it. The real
-    // fix is one layer deeper and is NOT done: spawn does not VALIDATE that the
-    // recipe resolves, so any typo still mints a chat room silently — a fallback,
-    // in a subsystem whose own loader cites [[fallbacks-are-illegal-fail-loud]].
-    // That needs the experience source threaded to this command so it can refuse
-    // with the live `purposes()` list. Tracked on #274.
+    // So this points at the live catalogue instead of enumerating it. The layer
+    // below it — VALIDATION — shipped with #431: `validate_recipe` (below) resolves
+    // the string against the live overlaid catalogue and REFUSES an unknown purpose,
+    // naming the known recipes. A typo can no longer silently mint a chat room, which
+    // is what [[fallbacks-are-illegal-fail-loud]] demands of a subsystem whose own
+    // loader cites it. #433 added the same treatment to caller-supplied params.
+    //
+    // (This paragraph said "is NOT done" for some time after it WAS done. Cost: a
+    // later reader trusted the comment over the function 40 lines below it and went
+    // looking for a gate that already existed. A comment describing absent code is a
+    // lying receipt of the #151/#357 class — it just lies to engineers instead of to
+    // citizens. If you change this behaviour, change this paragraph in the same edit.)
     const DESCRIPTION: &'static str =
         "Create a new room from a recipe. `name` is what people call this instance; \
          `recipe` is the `purpose` of an authored recipe — use the exact purpose \
@@ -561,6 +567,19 @@ impl ActionCommand for ActivityProtect {
         })
     }
 }
+
+// Descriptors for the three verbs above. Their CONSTRUCTORS come from
+// `ActivityModule::commands()` (they hold the airc registry, so they are not
+// `Default`-constructible and cannot use `register_stateless_command!`); the
+// descriptor is type-only, so it is declared here at the same site the command is.
+// Both halves are required — a constructor without a descriptor routes but is
+// INVISIBLE to `commands/list`, the persona tool surface, the ACL and codegen, which
+// is exactly how `activity/spawn` — the verb that mints every room, benchmark rooms
+// included — became undiscoverable while the catalog promised "Listed == callable".
+// `ModuleRegistry::register` now refuses to boot on the omission.
+crate::register_command!(ActivitySpawn);
+crate::register_command!(ActivityArchive);
+crate::register_command!(ActivityProtect);
 
 // ─────────────────────────── module ───────────────────────────
 

--- a/core/continuum-core/src/runtime/registry.rs
+++ b/core/continuum-core/src/runtime/registry.rs
@@ -109,6 +109,34 @@ impl ModuleRegistry {
         // sdk_codegen::command_registry's duplicate-name panic).
         for cmd in module.commands() {
             let cmd_name = cmd.name();
+            // A command is ONE thing declared in ONE file as a (descriptor, constructor)
+            // pair. `register_stateless_command!` emits both; a dep-holding command splits
+            // them — `register_command!(X)` at the declaration site for the descriptor
+            // (type-only, `CommandDescriptor::of::<Spec>()`, so deps are irrelevant to it)
+            // and this `commands()` vec for the constructor (which needs the module's
+            // deps). Splitting is fine. Shipping only ONE HALF is not, and nothing used to
+            // catch it: a constructor with no descriptor is routable but INVISIBLE — absent
+            // from `commands/list`, from the persona tool surface, from the ACL, from
+            // codegen. That is how `activity/spawn` — the verb that mints every room —
+            // became unfindable while `commands/list` was promising "Listed == callable".
+            // Six commands had shipped this way.
+            //
+            // `dispatch_orphans` audits the OTHER direction (descriptor, no route). This is
+            // its mirror, and together they make the pair total. It panics rather than logs
+            // for the same reason the duplicate-name check below does, and it is the same
+            // class of defect: the "no central list" design removes the human backstop, so
+            // the registry must catch its own wiring gaps. Boot is the right time — the
+            // fact is knowable the instant the module registers, and the alternative is a
+            // command that silently does not exist for anyone who has to discover it.
+            if !crate::sdk_codegen::descriptor_exists(cmd_name) {
+                panic!(
+                    "ModuleRegistry: command object '{cmd_name}' (module '{name}') has NO \
+                     DESCRIPTOR — it would route but stay invisible to commands/list, the \
+                     persona tool surface, the ACL and codegen. Add `crate::register_command!\
+                     (<Type>);` at its declaration site (descriptor is type-only, so it needs \
+                     none of the module's deps — see BenchmarkDispatch for the pattern)."
+                );
+            }
             if let Some(existing) = self.command_objects.insert(cmd_name, cmd) {
                 panic!(
                     "ModuleRegistry: duplicate command object '{}' — module '{}' \
@@ -316,6 +344,74 @@ mod tests {
         fn as_any(&self) -> &dyn Any {
             self
         }
+    }
+
+    /// A module contributing a command CONSTRUCTOR whose name was never declared as
+    /// a descriptor — the exact half-declared shape the boot guard exists to catch.
+    struct UndeclaredCommandModule;
+
+    struct UndeclaredCommand;
+
+    #[async_trait::async_trait]
+    impl crate::sdk_codegen::DynCommand for UndeclaredCommand {
+        fn name(&self) -> &'static str {
+            // Deliberately a name no `register_command!` anywhere claims. The guard
+            // keys on this, so the descriptor below can be any real one.
+            "test/never-declared-verb"
+        }
+        fn descriptor(&self) -> crate::sdk_codegen::CommandDescriptor {
+            crate::sdk_codegen::CommandDescriptor::of::<crate::commands::catalog::CommandsList>()
+        }
+        async fn invoke(
+            &self,
+            _params: Value,
+            _caller: Option<crate::routing::CallerIdentity>,
+        ) -> Result<CommandResult, String> {
+            Ok(CommandResult::Json(serde_json::json!({})))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ServiceModule for UndeclaredCommandModule {
+        fn config(&self) -> ModuleConfig {
+            ModuleConfig {
+                name: "undeclared",
+                priority: ModulePriority::Normal,
+                command_prefixes: &[],
+                event_subscriptions: &[],
+                needs_dedicated_thread: false,
+                max_concurrency: 0,
+                tick_interval: None,
+            }
+        }
+        async fn initialize(&self, _ctx: &ModuleContext) -> Result<(), String> {
+            Ok(())
+        }
+        async fn handle_command(&self, _c: &str, _p: Value) -> Result<CommandResult, String> {
+            Ok(CommandResult::Json(serde_json::json!({})))
+        }
+        fn commands(&self) -> Vec<Arc<dyn crate::sdk_codegen::DynCommand>> {
+            vec![Arc::new(UndeclaredCommand)]
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    // what this catches: a command shipping only HALF its declaration — a constructor
+    // in a module's `commands()` with no `register_command!` descriptor. Such a command
+    // ROUTES, so every smoke test passes, while being invisible to `commands/list`, the
+    // persona tool surface, the ACL and codegen. Three real verbs shipped that way
+    // (`activity/spawn|archive|protect`), which is why the room-minting verb could not
+    // be found by anyone — human or citizen — reading the catalog. `dispatch_orphans`
+    // covers the mirror case (descriptor, no route); this covers the one that had no
+    // check at all. It must PANIC at register(), not warn: the fact is knowable the
+    // instant the module registers, and a warning about an invisible command is read
+    // by nobody, for the same reason the command is invisible.
+    #[test]
+    #[should_panic(expected = "has NO DESCRIPTOR")]
+    fn a_command_constructor_without_a_descriptor_refuses_to_register() {
+        ModuleRegistry::new().register(Arc::new(UndeclaredCommandModule));
     }
 
     #[test]
@@ -530,6 +626,11 @@ mod tests {
         Unwired {
             module: "BarrierModule",
             why: "fixture: barrier for the command-executor concurrency test",
+        },
+        Unwired {
+            module: "UndeclaredCommandModule",
+            why: "fixture: half-declared command (constructor, no descriptor) — \
+                  the boot guard's positive control",
         },
         Unwired {
             module: "DefaultsModule",

--- a/core/continuum-core/src/sdk_codegen/mod.rs
+++ b/core/continuum-core/src/sdk_codegen/mod.rs
@@ -745,6 +745,22 @@ pub fn command_registry() -> Vec<CommandDescriptor> {
         .clone()
 }
 
+/// Is `name` declared in the descriptor registry?
+///
+/// The half of a command's declaration that codegen, the ACL, `commands/list` and the
+/// persona tool surface all read. `ModuleRegistry::register` asks this of every
+/// constructor a module contributes, so a command that declared only one half of its
+/// (descriptor, constructor) pair fails LOUD at boot instead of routing invisibly.
+///
+/// `command_registry()` sorts by name and panics on duplicates, so a binary search is
+/// exact — and it reads the SAME list every other consumer reads, which is the point:
+/// this must never become a second opinion about what commands exist.
+pub fn descriptor_exists(name: &str) -> bool {
+    command_registry()
+        .binary_search_by(|d| d.name.cmp(name))
+        .is_ok()
+}
+
 // No demo/fixture commands: the generator is validated against the REAL
 // registered commands (declared via CommandSpec at their own sites, e.g. the
 // inference module), whose Params/Result are real ts-rs types carrying the

--- a/docs/cognition/TOOL-DISCLOSURE-LADDER.md
+++ b/docs/cognition/TOOL-DISCLOSURE-LADDER.md
@@ -1,0 +1,221 @@
+# The Tool Disclosure Ladder
+
+*How a citizen's verbs reach her prompt — one ladder, three rungs, no rung repeating another.*
+
+Status: design, 2026-08-16. Measured against build 4743 (`340eb6c34`).
+Supersedes the "shrink the surface" framing on #333; feeds #163 (tool conformance
+harness) and unblocks the #2332 ratchet.
+
+---
+
+## 1. What it costs today, measured
+
+Not estimated. `describe_tool_tokens` serializes each `NativeToolSpec` with
+`serde_json` and charges `len/3 + 8`; this table replicates that projection exactly
+against the running core's own descriptors.
+
+| slice | tokens | share |
+|---|---:|---:|
+| `properties` (JSON Schema) | 3,658 | 53% |
+| `description` (prose) | 1,986 | 29% |
+| `definitions` (`$ref` targets) | 219 | 3% |
+| per-tool template margin (26 × 8) | 208 | 3% |
+| **native payload** | **6,935** | |
+| framing floor (rest of the 8,979 fixed cost) | ~2,044 | |
+
+**26 verbs, mean 266 tokens each.** Top five: `activity/spawn` 871,
+`work/list` 672, `perception/look` 561, `code/edit` 476, `code/run` 428.
+
+### The claim this retracts
+
+An earlier pass on this asserted the surface ran "3–5× over a clean design," on a
+calibration of 50–150 tokens per well-formed tool. **That calibration was fiction.**
+The tools a frontier agent runtime actually ships — a shell verb, a subagent
+launcher, a workflow orchestrator — run several hundred to well over a thousand
+tokens each, because a rich description is what teaches correct use. At 266/verb
+Continuum's native schemas are *leaner than the surface the comparison was drawn
+from*.
+
+Two more hypotheses died the same way, and are recorded so nobody re-derives them:
+
+- **`$schema` / `title` boilerplate.** Already stripped —
+  `persona_tools::tool_input_schema_from` carries only `type` / `properties` /
+  `required` / `definitions`. **0 tokens.** (The `$schema` line is visible in
+  `commands/list` output, which is a *different* surface. Reading one surface's
+  output and attributing its shape to another is the error here.)
+- **Multi-paragraph doc rationale.** Real, but **550 tokens across 2 commands** —
+  8%, not a general lever.
+
+**The schemas are not where the waste is.** What follows is therefore not a diet.
+
+---
+
+## 2. The two real defects
+
+Joel, 2026-08-16: *"So many are just devoid of knowledge or repetition."* Both are
+measurable, and both are quality defects rather than size defects.
+
+### 2.1 Devoid — a field with no description
+
+`code/edit` offers 12 properties. Eight of them — `search`, `replace`, `line`,
+`new_content`, `start_line`, `end_line`, `content`, `all` — ship as bare
+`{"default": null, "type": ["string","null"]}`. No description. They are flattened
+duplicates of the fields already inside `edit_mode`'s tagged object, present
+because the parser is deliberately forgiving about both shapes.
+
+An undescribed nullable field is **worse than an absent one**: it is a named slot
+with no stated purpose and no stated validity, which is an invitation to fill it
+with something plausible. That is #334 (*"a persona with nothing to write invents a
+`file_path`, and THAT field degenerates"*) arriving through a different door.
+
+Being forgiving at the PARSER is correct. Advertising both shapes in the SCHEMA is
+not — the schema is a teaching surface, and it should teach exactly one way in.
+
+### 2.2 Repetition — the surface is composed twice
+
+Both of these reach the prompt every turn:
+
+- 26 full `NativeToolSpec` schemas (6,935 tokens), and
+- the prose `render_tool_menu` over the authorized catalog.
+
+The menu re-states in prose what the schemas already carry in structure. This is
+#333, now confirmed by reading `compose_system` rather than asserted.
+
+Worth recording because it explains how it happened: the field doc on
+`LlmDeliberationFaculty::native_specs` still describes it as *"the DISCOVERY PAIR —
+`commands/list` + `commands/help`"*. That was true when the menu was the only
+schema-bearing surface. It stopped being true when commands began declaring
+`NATIVE` individually, and no comment marked the transition. The duplication was
+never designed; it accreted, one justified `NATIVE` flag at a time.
+
+---
+
+## 3. The design
+
+The ladder already exists — three rungs are built and working. The defect is that
+the top rung **bypasses** the ladder instead of sitting on it.
+
+```
+rung 0  SPINE       every category, every verb NAME              always
+rung 1  EXPANDED    verbs + one-line summaries, per category     situational
+rung 2  SCHEMA      full argument schema for one verb            on demand / working set
+```
+
+**Nothing is hidden at rung 0.** Every verb she has is named every turn. This is
+the "not censoring them" line: discovery never depends on guessing that a verb
+exists. What varies is how much *detail* rides along, and detail is what costs.
+
+### 3.1 The keystone: `NATIVE` becomes situational, not static
+
+Today `NATIVE` is a `const bool` on each command — a static list of 26 that only
+grows, which is precisely why the agentic-surface ratchet keeps needing to be
+re-pinned. Each addition is individually justified (#339's lifecycle write-backs,
+#358's `room/members`, the room-membership trio) and collectively unbounded.
+
+The move: **rung 2 is this turn's working set, not a fixed list.** The same
+`expanded_categories` signal that already drives rung 1 selects which verbs get
+full schemas. Consequences:
+
+- Adding a verb costs a **NAME** (a few tokens at rung 0), not a **SCHEMA** (266).
+  The ratchet stops being a tax on giving citizens new capabilities.
+- The payload becomes a function of the turn. A citizen editing code carries
+  `code/*` schemas; a citizen triaging the board carries `work/*`. Neither carries
+  both.
+- `commands/help` stays permanently at rung 2 so any named verb is one call from
+  its full schema — the escape hatch that makes selection safe.
+
+### 3.2 The safety line this must not cross
+
+`rebuild_tool_surface` carries a deleted-code warning worth honoring: the #206
+shrink cliff amputated the tool surface to fit a budget and produced a model that
+could not act at all, flipping 10/10 ↔ 0/6 on one token of window.
+
+**Situational selection is not a budget clamp.** The distinction is load-bearing:
+
+- *Situational* — chosen by what she is doing. Deterministic given the turn.
+  Degrades to "the wrong category expanded", recoverable in one `commands/help`.
+- *Budget clamp* — chosen by what fits. Non-deterministic w.r.t. the task, and
+  degrades to "no hands", unrecoverable within the turn.
+
+If a working set does not fit the served window, that is a **measured demand
+reported to the governor** (the existing `min_window_for_agentic_surface` sensor),
+never a silent amputation.
+
+### 3.3 The quality bar for a tool definition
+
+Both defects in §2 are conformance failures, and there is already a card for
+enforcing conformance by construction (#163). This design contributes the rules:
+
+1. **Every parameter carries a description.** No exceptions — an undescribed param
+   is a defect, not a terse one.
+2. **No parameter is an alternate encoding of another parameter.** If the parser
+   accepts two shapes, the schema advertises one. Forgiveness lives at the parser.
+3. **The schema describes the WIRE, for the caller.** Maintainer rationale — why
+   the Rust type is what it is, what the doc used to say, why a list is omitted —
+   belongs in the file, not in the projection. `schemars` lifts `///` verbatim, so
+   this needs a mechanical split, not discipline (see slice 1).
+4. **Descriptions teach use, not existence.** "Optional note describing the change"
+   is a label. "…recorded in the change history" is the part that tells her when to
+   bother. Length is not the enemy; contentless length is.
+
+---
+
+## 4. Build plan
+
+Sliced so each lands and is verifiable alone.
+
+**Slice 1 — the projection splits the audiences.** In `tool_input_schema_from`,
+take only the leading paragraph of each field description into the schema;
+everything after the first blank line is maintainer-facing. One place, zero
+per-command edits, and it matches how the docs are already written. Measured
+recovery: **550 tokens**, 310 of them on `activity/spawn`. *This is the "SHRUNK
+FIRST" branch the ratchet's own contract asks for, and it is what unblocks #2332
+without rationing a verb.*
+
+**Slice 2 — `code/edit` advertises one shape.** Drop the eight flattened aliases
+from the schema; keep the parser forgiving. −171 tokens, and it closes a #334-class
+invitation on the most-used editing verb.
+
+**Slice 3 — conformance test.** Every native descriptor: every param described, no
+param a duplicate encoding. Fails on a new violation. This is the #163 gate applied
+to the surface that exists today. *Do this before slice 4 — it is the regression
+net for everything after.*
+
+**Slice 4 — rung 2 becomes the working set.** `NATIVE` stops being a static const
+and becomes selection over `expanded_categories`. `commands/help` pinned always-on.
+The ratchet ceiling then guards the SPINE, which grows sub-linearly in verb count.
+
+**Slice 5 — delete the duplicate.** With rung 2 situational, decide which surface
+teaches call form and remove the other. Closes #333.
+
+---
+
+## 5. Why this is a benchmark item
+
+The surface is 6,935 tokens. On a 16k-window lane that is **43% of everything she
+has**; on a frontier window it is ~3%. The identical code is either crushing or
+invisible depending only on what the lane serves — which is why #332's
+16,384 → 26,368 moved more than any schema edit could.
+
+So the benchmark argument is not "the tools are too big." It is:
+
+- **Every token rung 2 spends on a verb she is not using is a token the TASK does
+  not get.** On a small lane that trade is the whole margin.
+- **A verb that arrives devoid of knowledge gets called wrong**, and a wrong call
+  costs a whole act out of a bounded budget — far more than the tokens the missing
+  description would have cost.
+- **The ratchet currently taxes capability.** Every new verb a citizen needs makes
+  the window arithmetic worse for every citizen, so the pressure is to withhold
+  verbs. Situational disclosure removes that pressure, which is the difference
+  between a citizen and a managed resource.
+
+---
+
+## 6. Reproducing the measurement
+
+The numbers above come from replicating `describe_tool_tokens` against the running
+core's own `commands/list` output — same projection (`tool_input_schema_from`),
+same estimator (`len/3`), same per-tool margin (8). Re-run it after any slice to
+confirm the recovery rather than assume it.
+
+Native verbs are those declaring `const NATIVE: bool = true`; 26 as of build 4743.


### PR DESCRIPTION
## The defect

`activity/spawn` — the verb that mints every room, benchmark rooms included — did not appear in `commands/list`. Neither did `activity/archive` or `activity/protect`. All three route fine, so every smoke test passed.

## Mechanism

A command is ONE thing declared as a **(descriptor, constructor)** pair:

| half | what it is | who reads it |
|---|---|---|
| descriptor | `CommandDescriptor::of::<Spec>()` — **type-only**, needs no deps | codegen, ACL, `commands/list`, persona tool surface |
| constructor | the runtime object; dep-holding ones come from the module's `commands()` | the executor |

`action_command!` emits both, in **both** its stateless and dep-holding forms. `register_stateless_command!` emits both. `BenchmarkDispatch` splits them correctly and documents why. **The generator has never gotten this wrong.**

Only the three **hand-written** `impl ActionCommand` blocks in `activity.rs` dropped a half. Nothing checked, so it shipped.

Half a declaration is worse than none: the command **routes**, so it looks healthy, while being absent from every surface through which anyone — human or citizen — discovers it exists. `commands/list` describes itself as "the discovery pair — the persona reaches the long tail through this," and was quietly lying about three AI-safe verbs.

## Fix

1. The three missing `register_command!` declarations. They now also pass the AI-usability conformance floor they'd never been held to.
2. `sdk_codegen::descriptor_exists()` — binary search over the **same sorted list** every other consumer reads, so it can't become a second opinion about what exists.
3. The guard at the seam where constructors enter: `ModuleRegistry::register` **panics** on a constructor with no descriptor, naming the remedy and the worked example. Not a warning — a warning about an invisible command is read by nobody, for exactly the reason the command is invisible. It sits beside the duplicate-name panic already there, same rationale.

`dispatch_orphans` already audited the mirror case (descriptor, no route — #361). **The pair is now total in both directions.**

Also corrects the doc comment above `ActivitySpawn::DESCRIPTION` that claimed recipe validation "is NOT done" long after #431 shipped `validate_recipe` 40 lines below it.

## Verified live (deployed, build 340eb6c34)

- `commands/list --filter=activit` → **4 matches**, all three verbs, all `ai-safe`
- catalog total **297 → 300**, exactly +3
- **the core boots** — so the guard passes against every real module; no other half-declared command exists tree-wide. Stronger than any static scan.

My first scan was by type name and produced 3 false positives (`GenerateModule`, `PersonaAllocate`, `SystemPressureBrokerState` are all registered *through* `action_command!`). Reverted before they became a fake fix. The runtime guard is the honest instrument; grep was a bad proxy for it.

`cargo check` clean · `sdk_codegen` 21/21 · `runtime::registry` 9/9 incl. a `#[should_panic]` positive control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo