### PR TITLE
27B contended throughput, recorded as contended (#440/#441)

### DIFF
--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -543,6 +543,25 @@ pub fn models() -> Vec<Model> {
             // 19,712 served window with the KV cache warm (cache_n 42 of a 67-token prompt).
             // Was a conservative 10.0 estimate; the row's own instruction is "corrected by
             // live measurement, never by wish", so this is the measurement.
+            //
+            // SECOND DATAPOINT, and it does NOT replace the one above (2026-08-20, 6
+            // samples, 150 tok each): 4.74 / 5.25 / 6.55 / 6.57 / 6.66 / 6.67 tok/s,
+            // median 6.56 — at a 22,528 PER-SLOT window with `busy_slots = 2` of 4 on
+            // EVERY sample. That is a CONTENDED rate, so it is not a `ThroughputBaseline`
+            // (that type means single-sequence by its own definition) and it must not be
+            // written into `tokens_per_second`, which the #441 collapse alarm reads as the
+            // single-stream expectation. Recording 6.5 there would raise the alarm's floor
+            // to ~1.6 t/s and let a genuine collapse pass silently.
+            //
+            // Both numbers are true and they measure different machines: 17.2 pinned,
+            // ~6.5 sharing the box with two working citizens. THE GAP IS THE POINT — the
+            // sentinel currently cannot tell "contended" from "degraded" because nothing
+            // records concurrency at measurement time. That is #441's remaining half, the
+            // sibling of the window axis landed in `ThroughputBaseline` (#2339).
+            //
+            // MTP spec-decode held 83.9–84.8% draft acceptance across all six, and across
+            // three earlier samples at a different prompt — the draft head is doing its job
+            // and is NOT the variance source (acceptance is flat while t/s moves 1.4×).
             tokens_per_second: 17.2,
             capabilities: &[
                 Capability::TextGeneration,


### PR DESCRIPTION
6 samples on the live M5 lane: median **6.56 tok/s** at a 22,528 per-slot window with `busy_slots = 2` of 4 every time. MTP held **83.9–84.8%** draft acceptance throughout — flat while t/s moved 1.4×, so the draft head is not the variance source.

**Deliberately NOT written into `tokens_per_second`.** That field is #441's single-stream expectation; 6.56 is contended. Recording it would drop the collapse floor from ~4.3 to ~1.6 tok/s and let a real collapse pass silently. The pinned 17.2 stays.

Both numbers are true and measure different machines. The gap is the finding: **the sentinel can't distinguish contended from degraded**, because nothing records concurrency at measurement time — the sibling of the window axis landed in #2339, and #441's remaining half.

Also corrects my own earlier claim: `-c 89280` is the total across 4 slots, not the live window. Per-slot is 22,528 vs the catalog's 19,712 — 1.14×, not 4.5×.

Comment-only change to one file. cargo check 0, model_registry tests 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo