### PR TITLE
27B throughput measured, and the collapse alarm can now attribute it (#440/#441)

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -1513,6 +1513,22 @@ fn warn_if_decode_collapsed(model_id: &str, decode_tokens: u32, measured_tps: f6
         f64::INFINITY,
     );
     if verdict.is_degraded() {
+        // CONCURRENCY AT THE MOMENT OF MEASUREMENT (#441). The expectation is a
+        // SINGLE-STREAM rate; this decode may have shared the box with N-1 other
+        // model calls, and a shared decode is legitimately slower with NOTHING
+        // wrong. Measured 2026-08-20 on the 27B: 6.56 t/s median against a 17.2
+        // pinned expectation — ratio 0.38, which is real contention, not a defect.
+        //
+        // ANNOTATE, DO NOT GATE. This alarm's own contract names "contended GPU"
+        // as a thing it exists to catch, so suppressing on concurrency would
+        // defeat it. Reporting the count lets a reader attribute the ratio
+        // instead of hunting a CPU fallback that isn't there — the failure mode
+        // this line previously invited by listing three suspects and no evidence.
+        //
+        // Reuses the existing gauge (`resource_admission::inflight_model_calls`,
+        // "lane-queue + prefill + decode") rather than counting again — the
+        // concurrency sibling of the window axis on `ThroughputBaseline`.
+        let inflight = crate::cognition::resource_admission::inflight_model_calls();
         tracing::warn!(
             probe_class = "serving.throughput.degraded",
             model = model_id,
@@ -1520,9 +1536,12 @@ fn warn_if_decode_collapsed(model_id: &str, decode_tokens: u32, measured_tps: f6
             expected_tps = expected,
             ratio = verdict.ratio(),
             decode_tokens = decode_tokens,
+            inflight_model_calls = inflight,
             "THROUGHPUT COLLAPSE: decode {measured_tps:.1} t/s vs expected {expected:.0} t/s \
-             — this lane is serving at a fraction of its catalog rate. Suspect CPU fallback \
-             (see serving.placement.cpu_fallback), pager thrash, or GPU contention (#441)."
+             (single-stream) with {inflight} model call(s) in flight — this lane is serving at \
+             a fraction of its catalog rate. With >1 in flight the expectation is not \
+             like-for-like and contention alone may explain it; at 1 in flight suspect CPU \
+             fallback (see serving.placement.cpu_fallback) or pager thrash (#441)."
         );
     }
 }

--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -543,6 +543,25 @@ pub fn models() -> Vec<Model> {
             // 19,712 served window with the KV cache warm (cache_n 42 of a 67-token prompt).
             // Was a conservative 10.0 estimate; the row's own instruction is "corrected by
             // live measurement, never by wish", so this is the measurement.
+            //
+            // SECOND DATAPOINT, and it does NOT replace the one above (2026-08-20, 6
+            // samples, 150 tok each): 4.74 / 5.25 / 6.55 / 6.57 / 6.66 / 6.67 tok/s,
+            // median 6.56 — at a 22,528 PER-SLOT window with `busy_slots = 2` of 4 on
+            // EVERY sample. That is a CONTENDED rate, so it is not a `ThroughputBaseline`
+            // (that type means single-sequence by its own definition) and it must not be
+            // written into `tokens_per_second`, which the #441 collapse alarm reads as the
+            // single-stream expectation. Recording 6.5 there would raise the alarm's floor
+            // to ~1.6 t/s and let a genuine collapse pass silently.
+            //
+            // Both numbers are true and they measure different machines: 17.2 pinned,
+            // ~6.5 sharing the box with two working citizens. THE GAP IS THE POINT — the
+            // sentinel currently cannot tell "contended" from "degraded" because nothing
+            // records concurrency at measurement time. That is #441's remaining half, the
+            // sibling of the window axis landed in `ThroughputBaseline` (#2339).
+            //
+            // MTP spec-decode held 83.9–84.8% draft acceptance across all six, and across
+            // three earlier samples at a different prompt — the draft head is doing its job
+            // and is NOT the variance source (acceptance is flat while t/s moves 1.4×).
             tokens_per_second: 17.2,
             capabilities: &[
                 Capability::TextGeneration,


### PR DESCRIPTION
Two halves of the same finding. **Supersedes #2340** (its commit is included here).

## Measured (#440)
Six samples on the live M5 lane: **median 6.56 tok/s**, 22,528 per-slot window, `busy_slots = 2` of 4 every time. MTP held **83.9–84.8%** draft acceptance throughout — flat while t/s moved 1.4×, so the draft head is not the variance source.

Deliberately **not** written into `tokens_per_second`: that field is the single-stream expectation the alarm reads, and 6.56 is contended. Recording it would drop the collapse floor from ~4.3 to ~1.6 t/s and let a real collapse pass silently. The pinned 17.2 stays.

## Attributable (#441)
The alarm compared that rate against the single-stream expectation and named three suspects — CPU fallback, pager thrash, GPU contention — with evidence for none. Ratio 0.38 with 2 calls in flight is **real contention**, and a reader handed only the ratio goes hunting a defect that isn't there.

Now the warning carries `inflight_model_calls`: **>1 in flight → not like-for-like; 1 in flight → the original suspects stand.**

**Annotate, not gate.** The alarm's own contract lists "contended GPU" as something it exists to catch, so suppressing on concurrency would defeat it. Firing decision untouched.

**Reuses the existing gauge** — `resource_admission::inflight_model_calls()` is already public and RAII-maintained, doc says it "reflects exactly the model-call window (lane-queue + prefill + decode)". No second counter. Concurrency sibling of the window axis in #2339.

## Correction
`-c 89280` is the **total across 4 slots**, not the live window. Per-slot is 22,528 vs the catalog's 19,712 — **1.14×, not the 4.5×** I claimed earlier. The window was never the explanation; recorded in the code comment where the next reader hits it.

cargo check 0; throughput + resource_admission + model_registry tests 0 (all by exit code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo