### PR TITLE
close-cards never BUILT the airc CLI it invokes (#356)

### DIFF
--- a/.github/workflows/auto-close-queue-cards.yml
+++ b/.github/workflows/auto-close-queue-cards.yml
@@ -25,6 +25,13 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
+    env:
+      # ONE name for the built CLI. Every step below refers to this and nothing
+      # else, so the path cannot drift between the verify step and the callers —
+      # which is exactly how the old `.airc-src/airc` outlived the layout it
+      # described.
+      AIRC_BIN: .airc-src/target/release/airc
+
     permissions:
       issues: write
       pull-requests: read
@@ -41,6 +48,25 @@ jobs:
           ref: canary
           path: .airc-src
 
+      # BUILD IT. This step did not exist, and its absence is why this workflow
+      # has failed on every merge since ~2026-08-05: the checkout above fetches
+      # airc SOURCE (a Rust workspace, no committed binary, and the repo publishes
+      # no releases), then `test -x .airc-src/airc` asserted an executable that
+      # nothing had ever produced. The job died in Verify environment and never
+      # reached `queue close-merged`, so merged PRs silently stopped closing their
+      # queue cards and the board drifted from reality on every merge.
+      # Cache keyed on airc's OWN lockfile, so a Continuum-side merge does not
+      # rebuild airc unless airc itself moved. MUST precede the build it serves.
+      - name: Cache AIRC build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: .airc-src
+
+      - name: Build AIRC CLI
+        run: |
+          set -euo pipefail
+          cargo build --release --manifest-path .airc-src/Cargo.toml -p airc-cli
+
       - name: Verify environment
         run: |
           set -euo pipefail
@@ -48,14 +74,21 @@ jobs:
           gh --version | head -1
           python3 --version
           bash --version | head -1
-          test -x .airc-src/airc
+          # Fail LOUD and say which artifact is missing — the old form asserted a
+          # path with no explanation, so the failure read as "environment broken".
+          if [ ! -x "$AIRC_BIN" ]; then
+            echo "::error::airc CLI not built at $AIRC_BIN — the Build AIRC CLI step did not produce it"
+            ls -la .airc-src/target/release/ 2>/dev/null | head -20 || true
+            exit 1
+          fi
+          "$AIRC_BIN" --version || true
 
       - name: Run airc queue close-merged
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          .airc-src/airc queue close-merged \
+          "$AIRC_BIN" queue close-merged \
             "${{ github.event.pull_request.html_url }}" \
             --merge-sha "${{ github.event.pull_request.merge_commit_sha }}" \
             --actor "github-actions[continuum#1142]"
@@ -93,11 +126,11 @@ jobs:
           # per-author personalization. Personalization comes back in
           # a follow-up PR once --owner is guaranteed across all
           # consumer airc builds.
-          if ! .airc-src/airc queue next --help >/dev/null 2>&1; then
+          if ! "$AIRC_BIN" queue next --help >/dev/null 2>&1; then
             echo "::notice::airc queue next not available in this airc build; skipping post-merge nudge"
             exit 0
           fi
-          NEXT_OUT=$(.airc-src/airc queue next CambrianTech/continuum --limit 5 2>&1) || {
+          NEXT_OUT=$("$AIRC_BIN" queue next CambrianTech/continuum --limit 5 2>&1) || {
             echo "::warning::queue next failed; skipping nudge"
             echo "$NEXT_OUT" | head -20
             exit 0

--- a/.github/workflows/continuum-rust-tests.yml
+++ b/.github/workflows/continuum-rust-tests.yml
@@ -29,7 +29,19 @@ on:
       # ts-rs export root: the binding-drift gate below diffs it, so an edit
       # to a generated .ts alone must still run this job.
       - 'protocol/typescript/**'
-      - '.github/workflows/continuum-rust-tests.yml'
+      # ANY workflow change runs this gate — not just edits to this file.
+      #
+      # Found 2026-08-20 via PR #2343, which touched only
+      # auto-close-queue-cards.yml: this filter matched nothing, so all three
+      # REQUIRED checks stayed "expected" forever, GitHub reported "3 expected,
+      # 2 successful", and auto-merge waited on checks that could never report.
+      # A required check behind a narrow path filter makes every PR outside
+      # those paths permanently unmergeable — the gate stops being a gate and
+      # becomes a deadlock.
+      #
+      # CI config changes SHOULD run CI. Cheap, and it keeps the required
+      # contexts always reported.
+      - '.github/workflows/**'
   push:
     branches: [canary, main]
 


### PR DESCRIPTION
**Dead since ~2026-08-05.** Every merged PR since has silently failed to close its queue card — the board drifts from reality on every merge.

## Root cause, from the log not a guess
The job dies at `Verify environment` on `test -x .airc-src/airc`. `gh`/`python3`/`bash` all resolve. The step above checks out `CambrianTech/airc` — a Rust **workspace** (`crates/airc-cli`), no committed binary, **no releases** — then asserts an executable nothing produced. **There was no build step.** This never worked; it isn't a regression from a moved path.

## It corrects my own card
#356 said *"a binary path and a CLI verb that no longer exist."* Path: confirmed. **Verb: unverified, and stays that way** — the job never reaches `queue close-merged`. The first green run is what tests it.

## Fix
- `cargo build --release -p airc-cli` + `rust-cache` scoped to airc's workspace (no rebuild unless airc moved)
- **one** `AIRC_BIN` at job scope — the old form spelled the path at 4 sites, which is how a path outlives its layout
- verify step fails loud, names the missing artifact, lists the target dir. `test -x` gave no explanation, so a build failure read as "environment broken"

## Honest limit
**Not validated locally and cannot be** — this fires only on `pull_request.merged`. YAML parses, step order checked. The first merge after this lands is the proof; if the verb is also broken, the new error says so instead of dying two steps early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo