### PR TITLE
fix(kv): canonical stable-tier order + the cache probe that proves it (#266) — and the ActivityAdapter seam

### DIFF
--- a/core/continuum-core/src/cognition/activity.rs
+++ b/core/continuum-core/src/cognition/activity.rs
@@ -1,0 +1,421 @@
+//! What an activity ADAPTS — material in, verdict out.
+//!
+//! This is the one seam every activity plugs into: SWE-bench, a HumanEval-style gym, a
+//! game level, a life-drawing critique, a robot that either picked up the block or didn't.
+//! The room is the runner; an adapter only translates between the outside world's form and
+//! ours ([[benchmarks-are-adapters-not-a-runner]]).
+//!
+//! # Why this is not `BenchmarkAdapter` any more
+//!
+//! The interface it replaces was the right SHAPE and the wrong SCOPE. It already carried
+//! both directions — `dataset()`/`tasks()` bring material IN, `grade()` renders a verdict
+//! OUT — but it was named for one subsystem, and a name is load-bearing: an interface called
+//! `BenchmarkAdapter` cannot plausibly host a game level, so the second activity gets its own
+//! parallel trait, its own registry, its own runner, and the substrate now has two of
+//! everything. That is the same failure as naming a room for a subsystem and making it
+//! immortal. Named for the JOB (an activity adapting its material), gameplay is a sibling
+//! implementation instead of a fork.
+//!
+//! # Both directions are the same kind of thing
+//!
+//! - **IN** — [`ActivityAdapter::material`] declares where the outside form lives and
+//!   [`ActivityAdapter::tasks`] normalizes it into our canonical [`EvalTask`]. For a
+//!   benchmark that is "task + oracle, nothing else" — deliberately NOT the upstream
+//!   harness, which we never run.
+//! - **OUT** — [`ActivityAdapter::judge`] turns what the citizen actually produced into a
+//!   [`Verdict`].
+//!
+//! # Declaring none is normal
+//!
+//! Most activities score nothing. `chat` names no adapters and nothing judges it; there is
+//! no "the ungraded kind" branch anywhere, because an empty list is already the answer
+//! (Joel, 2026-08-21: *"always adapter(s) with none as an option … formulaic or not,
+//! anything can plug in. Just build the ones you initially need"*). Judging lives in the
+//! recipe's `params`, never on the base recipe type — an exam concept stamped onto every
+//! chat room and profile page is exactly the over-reach this seam exists to avoid.
+//!
+//! # The growable outcome, and why it is not a fixed struct
+//!
+//! [`Outcome`] carries what the citizen produced. The universal parts are named fields:
+//! every activity has a mouth (what she said) and a place she worked. Everything modality-
+//! specific goes in [`Outcome::channels`] — a typed, growable carrier, the same shape the
+//! adapter capability surface already uses in this codebase.
+//!
+//! This matters for the reason the fixed struct failed: with `patch` and `workspace` as
+//! bare fields, SWE-bench OWNS the outcome type, and a game trajectory or a robot's joint
+//! log can only be added by editing a struct that every other activity compiles against. A
+//! new modality would either widen a shared type for everyone or — far more likely, and what
+//! actually happens — grow its own parallel outcome and its own parallel judge. Channels let
+//! gameplay add [`Channel::Trajectory`] without SWE-bench recompiling a line, and let a judge
+//! ask for exactly the channel it grades and get a typed `None` when the activity did not
+//! produce one.
+//!
+//! Growing the enum is still a deliberate act: a new variant is added when a REAL activity
+//! needs it, never speculatively. What changed is the cost of being wrong — a wrong guess is
+//! now one unused variant instead of a second subsystem.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::cognition::eval::EvalTask;
+
+/// Where an activity's material comes from — declared by the adapter, fetched ON DEMAND by
+/// the room that runs it, never bundled in the repo.
+#[derive(Debug, Clone)]
+pub struct MaterialSpec {
+    /// Hugging Face repo id (`org/name`), an HTTPS URL, or a git remote — read per `kind`.
+    pub source: String,
+    /// How to fetch `source`. Enumerated so a new source kind forces the fetch match to be
+    /// revisited instead of silently skipped.
+    pub kind: MaterialKind,
+    /// Subdirectory under the shared cache where the material materializes. ONE canonical
+    /// cache, so a fetched suite is reused across runs and citizens.
+    pub cache_key: String,
+    /// Optional glob restricting what to fetch (e.g. only `*.jsonl`, skip weights).
+    pub include: Option<String>,
+}
+
+/// The fetch strategy for a [`MaterialSpec`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaterialKind {
+    /// Hugging Face dataset/model repo — snapshot-style fetch.
+    Hf,
+    /// A single HTTPS artifact the adapter parses.
+    Url,
+    /// A git repository (real-repo activities clone per-task from here).
+    Git,
+    /// Already resident — generated, seeded, or shipped in-tree. Nothing to fetch.
+    Resident,
+}
+
+/// A placement hint the grid uses to route an activity to a capable node. All fields
+/// optional: an unknown hint means "place anywhere", never a hard block.
+#[derive(Debug, Clone, Default)]
+pub struct ResourceHint {
+    /// Approx disk the material needs once materialized (bytes).
+    pub disk_bytes: Option<u64>,
+    /// True if judging needs a container runtime. A node without one is not a candidate —
+    /// surfaced as data, never a crash.
+    pub needs_container: bool,
+    /// True if tasks need outbound web access.
+    pub needs_network: bool,
+}
+
+/// A modality channel on an [`Outcome`] — what the citizen produced, beyond speech.
+///
+/// One variant per REAL modality some activity actually judges. Adding a variant is how a
+/// new kind of activity arrives; it costs every other adapter nothing, because judges match
+/// on the channel they care about and treat absence as `None`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Channel {
+    /// Unified `git diff` of everything she changed — what SWE/Terminal-style activities grade.
+    Diff,
+    /// A relative in-workspace path she was told to write her solution to (artifact grade).
+    Artifact,
+}
+
+/// The value on a [`Channel`]. Kept deliberately narrow — a channel carries either text or a
+/// path today, and a judge that needs richer structure parses it. Widening this is a
+/// deliberate act with a real activity behind it.
+#[derive(Debug, Clone)]
+pub enum ChannelValue {
+    Text(String),
+    Path(PathBuf),
+}
+
+impl ChannelValue {
+    /// The text of this value, or `None` if it is a path. Judges use this instead of
+    /// matching, so an activity that stored the wrong shape reads as absent rather than
+    /// panicking inside a judge.
+    pub fn text(&self) -> Option<&str> {
+        match self {
+            ChannelValue::Text(t) => Some(t),
+            ChannelValue::Path(_) => None,
+        }
+    }
+
+    /// The path of this value, or `None` if it is text.
+    pub fn path(&self) -> Option<&std::path::Path> {
+        match self {
+            ChannelValue::Path(p) => Some(p),
+            ChannelValue::Text(_) => None,
+        }
+    }
+}
+
+/// What one citizen actually produced in one task — the input every judge grades.
+///
+/// Universal facts are named fields. Modality-specific ones live in [`Self::channels`] so a
+/// new activity adds a modality without widening a type its siblings compile against.
+#[derive(Debug, Clone, Default)]
+pub struct Outcome {
+    /// Her final spoken answer (mouth). Some activities grade this directly.
+    pub spoken: String,
+    /// The workspace after she acted — where a judge re-runs the activity's own checks.
+    pub workspace: PathBuf,
+    /// Whether the generic harness already passed it, and why. This is the harness's OWN
+    /// verdict, not the activity's: a judge may confirm, override, or ignore it.
+    pub harness_passed: bool,
+    /// Human-readable detail from the generic harness grade.
+    pub harness_detail: String,
+    /// Modality channels, keyed by [`Channel`]. Absent = the activity produced none.
+    pub channels: BTreeMap<Channel, ChannelValue>,
+}
+
+impl Outcome {
+    /// The value on `channel`, or `None` when this activity produced nothing there.
+    pub fn channel(&self, channel: Channel) -> Option<&ChannelValue> {
+        self.channels.get(&channel)
+    }
+
+    /// Text on `channel`, or `""` when absent — the ergonomic read for judges that treat a
+    /// missing modality the same as an empty one (a diff-grading judge does).
+    pub fn channel_text(&self, channel: Channel) -> &str {
+        self.channel(channel).and_then(|v| v.text()).unwrap_or("")
+    }
+
+    /// Attach `value` to `channel`, replacing anything already there.
+    pub fn with_channel(mut self, channel: Channel, value: ChannelValue) -> Self {
+        self.channels.insert(channel, value);
+        self
+    }
+}
+
+/// One activity's verdict on one task — did it pass, how well, and WHY.
+///
+/// `reason` is not decoration: it is the receipt a citizen and a human both read, and the
+/// text the curriculum keeps when the task failed.
+#[derive(Debug, Clone)]
+pub struct Verdict {
+    pub passed: bool,
+    /// Normalized 0..1. A pass/fail judge reports 1.0/0.0; a scored one reports its scale.
+    pub score: f64,
+    pub reason: String,
+}
+
+impl Verdict {
+    /// A passing verdict with a reason.
+    pub fn pass(reason: impl Into<String>) -> Self {
+        Self { passed: true, score: 1.0, reason: reason.into() }
+    }
+
+    /// A failing verdict with a reason.
+    pub fn fail(reason: impl Into<String>) -> Self {
+        Self { passed: false, score: 0.0, reason: reason.into() }
+    }
+}
+
+/// One activity, as a plug-in: it adapts material IN and renders a verdict OUT.
+///
+/// The room runs the activity; this only translates. Implement once per activity kind —
+/// the runner, the grid placement, and the learning loop treat every adapter identically.
+#[async_trait::async_trait]
+pub trait ActivityAdapter: Send + Sync {
+    /// Stable slug, used on the CLI, in a recipe's declaration, and on the scorecard.
+    /// Must match the registry key.
+    fn name(&self) -> &str;
+
+    /// Where this activity's material comes from, or `None` when it needs none (generated,
+    /// seeded, or already resident). The room materializes this before [`Self::tasks`].
+    fn material(&self) -> Option<MaterialSpec> {
+        None
+    }
+
+    /// What kind of node can run this — for grid placement. Default: anywhere.
+    fn resources(&self) -> ResourceHint {
+        ResourceHint::default()
+    }
+
+    /// Load this activity's items into our canonical [`EvalTask`] shape from the
+    /// already-materialized root (`None` when [`Self::material`] is `None`). `limit` caps
+    /// items for a quick pulse. THE ONLY per-activity parsing — everything downstream is
+    /// generic.
+    async fn tasks(
+        &self,
+        material_root: Option<&std::path::Path>,
+        limit: Option<usize>,
+    ) -> Result<Vec<EvalTask>, String>;
+
+    /// Judge what she produced.
+    ///
+    /// The DEFAULT defers to the harness's own verdict, which is correct for activities
+    /// whose `EvalTask` already encodes the definition of done (a `dod_shell`, a `test`, an
+    /// `expect`). Activities that must inspect the world after she acted — re-run a repo's
+    /// held-out tests, read a final score, measure a trajectory — override this.
+    async fn judge(&self, _task: &EvalTask, outcome: &Outcome) -> Verdict {
+        Verdict {
+            passed: outcome.harness_passed,
+            score: if outcome.harness_passed { 1.0 } else { 0.0 },
+            reason: if outcome.harness_detail.is_empty() {
+                "harness verdict".to_string()
+            } else {
+                outcome.harness_detail.clone()
+            },
+        }
+    }
+}
+
+/// A builtin adapter that self-registers at link time via `inventory` — the same mechanism
+/// commands use, so a resident activity is discoverable with NO boot hook and NO central
+/// list to edit. Adding an activity is adding a file.
+pub struct BuiltinActivityAdapter {
+    /// Constructs the adapter. A `fn` pointer (not a value) so submission stays const-evaluable.
+    pub make: fn() -> Arc<dyn ActivityAdapter>,
+}
+
+inventory::collect!(BuiltinActivityAdapter);
+
+/// Runtime-registered adapters (tests, and any future dynamic registration). Builtins come
+/// from `inventory` and are folded in by [`get`]/[`names`].
+static RUNTIME: std::sync::LazyLock<std::sync::RwLock<BTreeMap<String, Arc<dyn ActivityAdapter>>>> =
+    std::sync::LazyLock::new(|| std::sync::RwLock::new(BTreeMap::new()));
+
+/// Register (or replace) an adapter at runtime. Idempotent by name. Builtins self-register
+/// and need NOT be passed here.
+pub fn register(adapter: Arc<dyn ActivityAdapter>) {
+    if let Ok(mut w) = RUNTIME.write() {
+        w.insert(adapter.name().to_string(), adapter);
+    }
+}
+
+/// Look up an adapter by name. Runtime registrations win over builtins so a test can shadow
+/// a builtin; otherwise the link-time set is searched.
+pub fn get(name: &str) -> Option<Arc<dyn ActivityAdapter>> {
+    if let Ok(r) = RUNTIME.read() {
+        if let Some(a) = r.get(name) {
+            return Some(a.clone());
+        }
+    }
+    inventory::iter::<BuiltinActivityAdapter>
+        .into_iter()
+        .map(|b| (b.make)())
+        .find(|a| a.name() == name)
+}
+
+/// Every known adapter name (runtime ∪ builtin), sorted and deduped — for a fail-loud
+/// "unknown activity 'X'; known: …" instead of a silent miss.
+pub fn names() -> Vec<String> {
+    let mut out: Vec<String> = inventory::iter::<BuiltinActivityAdapter>
+        .into_iter()
+        .map(|b| (b.make)().name().to_string())
+        .collect();
+    if let Ok(r) = RUNTIME.read() {
+        out.extend(r.keys().cloned());
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Resolve every adapter a recipe declared, or say EXACTLY which name is unknown.
+///
+/// This is the seam that makes "the exam was sat and nobody marked it" unrepresentable. A
+/// declared-but-unresolvable judge is an error at the moment of staging, not a run that
+/// quietly ends with no verdict — the failure mode that produced 253 of 450 unmarked runs
+/// (measured 2026-08-21) and that no amount of citizen effort could have avoided.
+///
+/// An EMPTY declaration resolves to an empty vec and is NOT an error: most activities judge
+/// nothing, and that is normal, not a missing judge.
+pub fn resolve_all(declared: &[String]) -> Result<Vec<Arc<dyn ActivityAdapter>>, String> {
+    let mut out = Vec::with_capacity(declared.len());
+    for name in declared {
+        match get(name) {
+            Some(a) => out.push(a),
+            None => {
+                return Err(format!(
+                    "unknown activity adapter '{name}' — known: {}. \
+                     A recipe that names a judge nothing can resolve must fail HERE, at \
+                     staging, not by producing a run that ends with no verdict.",
+                    names().join(", ")
+                ))
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Stub;
+
+    #[async_trait::async_trait]
+    impl ActivityAdapter for Stub {
+        fn name(&self) -> &str {
+            "stub-activity"
+        }
+        async fn tasks(
+            &self,
+            _root: Option<&std::path::Path>,
+            _limit: Option<usize>,
+        ) -> Result<Vec<EvalTask>, String> {
+            Ok(vec![])
+        }
+    }
+
+    // what this catches: the registry must round-trip a registration AND name the unknown
+    // key on a miss. A silent `None` here is how a declared judge goes missing without
+    // anyone noticing.
+    #[test]
+    fn registry_round_trips_and_names_the_unknown() {
+        register(Arc::new(Stub));
+        assert!(get("stub-activity").is_some());
+        assert!(get("no-such-activity").is_none());
+        assert!(names().iter().any(|n| n == "stub-activity"));
+    }
+
+    // what this catches: declaring NO judge is legal and yields no judges — the "none is
+    // normal" contract. If this ever errors, every chat room becomes an exam.
+    #[test]
+    fn declaring_no_judge_is_legal_and_not_an_error() {
+        let resolved = resolve_all(&[]).expect("empty declaration must resolve, not error");
+        assert!(resolved.is_empty());
+    }
+
+    // what this catches: a declared-but-unknown judge fails LOUD at resolve time and the
+    // message names both the bad key and the known set. This is the guard that makes an
+    // unmarked run impossible — regression for the 253/450 unmarked runs of 2026-08-21.
+    #[test]
+    fn an_unknown_declared_judge_fails_loud_and_names_it() {
+        register(Arc::new(Stub));
+        // Matched rather than `expect_err`: the Ok side is `Vec<Arc<dyn ActivityAdapter>>`,
+        // and a trait object is not `Debug`. Requiring `Debug` on the trait just to phrase a
+        // test would put a constraint on every future adapter to serve the test's ergonomics.
+        let err = match resolve_all(&["stub-activity".into(), "ghost-judge".into()]) {
+            Ok(_) => panic!("an unresolvable judge must be an error, never a silent skip"),
+            Err(e) => e,
+        };
+        assert!(err.contains("ghost-judge"), "must name the offending key: {err}");
+        assert!(err.contains("stub-activity"), "must list what IS known: {err}");
+    }
+
+    // what this catches: the default judge defers to the harness verdict, so an activity
+    // whose EvalTask already encodes done-ness needs no judge code at all.
+    #[tokio::test]
+    async fn default_judge_defers_to_the_harness() {
+        let task = EvalTask::default();
+        let passed = Outcome { harness_passed: true, ..Default::default() };
+        assert!(Stub.judge(&task, &passed).await.passed);
+        let failed = Outcome {
+            harness_passed: false,
+            harness_detail: "tests failed".into(),
+            ..Default::default()
+        };
+        let v = Stub.judge(&task, &failed).await;
+        assert!(!v.passed);
+        assert_eq!(v.reason, "tests failed");
+    }
+
+    // what this catches: a channel a judge asks for but the activity never produced reads as
+    // absent — NOT as an empty success. This is what lets gameplay add a modality without
+    // SWE-bench's judge changing, and what stops a judge panicking on a missing one.
+    #[test]
+    fn an_absent_channel_reads_absent_not_empty_success() {
+        let o = Outcome::default().with_channel(Channel::Diff, ChannelValue::Text("x".into()));
+        assert_eq!(o.channel_text(Channel::Diff), "x");
+        assert!(o.channel(Channel::Artifact).is_none());
+        assert_eq!(o.channel_text(Channel::Artifact), "");
+    }
+}

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -1136,15 +1136,52 @@ impl LlmDeliberationFaculty {
                 );
             }
         }
-        // SERIALIZATION (by volatility): stable standing-framing FIRST (roster,
-        // doctrine, map) so it lands in the cacheable KV-prefix region adjacent to
-        // the static system prompt it resembles; volatile grounding (recall, working
-        // memory) LAST, nearest the generation point. A stable sort preserves the
-        // salience order WITHIN each tier, so attention ranking is untouched — this
-        // is a pure emit-order choice that maximizes cross-turn prefix reuse AND puts
-        // the live, actionable context closest to where the model writes. `false`
-        // (stable) sorts before `true` (volatile). See [`Contribution::stable`].
-        selected.sort_by_key(|(c, _)| u8::from(!c.stable));
+        // SERIALIZATION (by volatility, then CANONICALLY within the stable tier):
+        // stable standing-framing FIRST (roster, doctrine, map) so it lands in the
+        // cacheable KV-prefix region adjacent to the static system prompt it resembles;
+        // volatile grounding (recall, working memory) LAST, nearest the generation point.
+        //
+        // WHY THE SECOND KEY EXISTS — this tier-split alone did NOT deliver reuse.
+        // The original comment here said a stable sort "preserves the salience order
+        // WITHIN each tier, so attention ranking is untouched", and treated that as
+        // harmless. It is the remaining half of the #266 cache defect. Salience is
+        // recomputed EVERY turn, so preserving it as EMIT ORDER re-shuffles the very
+        // tier whose whole purpose is to be byte-identical across turns.
+        //
+        // Measured live 2026-08-21 in Atlas's `pallets__flask-4045` run, from her own
+        // captures: consecutive system prompts shared only ~82% of their prefix, and the
+        // divergence points were stable-tier blocks trading places —
+        // `[room-kanban]` → `[active-work]` → `[workspace-map]` at chars 8216 / 7879 /
+        // 8133. Because the system prompt is FIRST, a swap at token ~2,000 invalidates
+        // the KV for EVERYTHING after it, including a 34,000-token conversation tail.
+        // `--cache-reuse 256` was passed the whole time and every turn reported
+        // `cachedTokens: 0` — the cache was correct; we were destroying the prefix.
+        // Cost at the measured 111 tok/s prefill: ~306s of re-prefill PER ACT, growing
+        // as her conversation grows. One observed turn was 20 minutes of apparent
+        // silence that was a single 36k re-prefill.
+        //
+        // So within the stable tier, order is CANONICAL (by faculty name), not by
+        // salience. Attention ranking is genuinely untouched: salience still decides
+        // WHICH contributions are selected — that happened above, against the budget.
+        // It simply stops deciding WHERE the survivors sit, which it never needed to.
+        // Same set in, same bytes out, every turn.
+        //
+        // The volatile tier deliberately KEEPS salience order: it is re-prefilled by
+        // construction (it changes every turn), so ordering it canonically would buy no
+        // reuse and would cost the "most salient nearest the write point" placement
+        // that #205 put there on purpose.
+        //
+        // `false` (stable) sorts before `true` (volatile). See [`Contribution::stable`].
+        selected.sort_by(|(a, _), (b, _)| {
+            u8::from(!a.stable).cmp(&u8::from(!b.stable)).then_with(|| {
+                match (a.stable, b.stable) {
+                    // Stable tier: canonical, so the cacheable prefix is deterministic.
+                    (true, true) => a.faculty.as_str().cmp(b.faculty.as_str()),
+                    // Volatile tier: leave salience order alone (stable sort keeps it).
+                    _ => std::cmp::Ordering::Equal,
+                }
+            })
+        });
         let mut block = String::new();
         for (c, body) in selected {
             block.push_str("\n[");

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -2382,7 +2382,7 @@ fn metrics_from(resp: &TextGenerationResponse) -> crate::cognition::workspace::T
     // wall-clock split that lets the harness see where Metal time actually goes.
     // Absent (cloud / older endpoints) → 0, and the breakdown rows read "n/a".
     let t = resp.timing.as_ref();
-    crate::cognition::workspace::TurnMetrics {
+    let m = crate::cognition::workspace::TurnMetrics {
         input_tokens: resp.usage.input_tokens,
         output_tokens: resp.usage.output_tokens,
         latency_ms: resp.response_time_ms,
@@ -2390,7 +2390,45 @@ fn metrics_from(resp: &TextGenerationResponse) -> crate::cognition::workspace::T
         prefill_tokens: t.map(|t| t.prefill_tokens).unwrap_or(0),
         prefill_ms: t.map(|t| t.prefill_ms.round() as u64).unwrap_or(0),
         decode_ms: t.map(|t| t.decode_ms.round() as u64).unwrap_or(0),
+    };
+
+    // THE CACHE-REUSE GLASS BOX — the row whose ABSENCE cost two weeks.
+    //
+    // Every generation funnels through here, so one probe covers every turn of every
+    // citizen with no caller change. Emitted only when the lane actually reported
+    // timings (cloud/older endpoints omit them); a fabricated 0.0 hit-rate for a
+    // provider that never measured one is a lying receipt, so those stay silent.
+    //
+    // Why this did not exist and why that mattered: `delib` carried `turn.demand` and
+    // `context.render` — how big the prompt WAS — and nothing about what the lane did
+    // with it. So a prompt whose prefix we were destroying every turn looked identical
+    // in the probe stream to one served entirely from cache. The only way to see it on
+    // 2026-08-21 was hand-diffing a citizen's raw prompt captures, which is exactly the
+    // manual step a probe exists to delete.
+    //
+    // What it proves, in one row: `hit_rate` near 0 with a large `prefill_tokens` means
+    // the prefix is being invalidated upstream — measured that day at ~306s of wasted
+    // re-prefill PER ACT while `--cache-reuse 256` was set and working. After the
+    // canonical stable-tier ordering above, the same row is the verification: hit_rate
+    // should climb off the floor from the second act of a task onward, WITHOUT anyone
+    // re-reading a capture by hand.
+    if t.is_some() {
+        crate::probe!(
+            class = "delib.generate.cache",
+            cached_tokens = m.cached_tokens,
+            prefill_tokens = m.prefill_tokens,
+            // The ratio the humans and the citizens both read. 1.0 = fully warm prefix;
+            // near 0 = re-encoding the prompt every act, the inefficiency to attack.
+            hit_rate = m.cache_hit_rate(),
+            prefill_ms = m.prefill_ms,
+            decode_ms = m.decode_ms,
+            input_tokens = m.input_tokens,
+            output_tokens = m.output_tokens,
+            latency_ms = m.latency_ms,
+            "prompt cache reuse for this generation"
+        );
     }
+    m
 }
 
 #[cfg(test)]

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -34,6 +34,7 @@ pub mod bench_round;
 pub mod bench_staging;
 pub mod bench_task;
 pub mod round_readiness;
+pub mod activity;
 pub mod benchmark;
 pub mod benchmark_humaneval;
 pub mod channel_digest;


### PR DESCRIPTION
Three commits. The first is the KV fix Joel has been waiting on; the second is the
instrument that makes it self-proving; the third is the seam the judge wiring needs.

## 1. `40075d7ea` — canonical order inside the STABLE tier (the other half of #266)

The tier-split shipped for #266 (stable framing first, volatile grounding last) did not
deliver reuse, and the comment at the sort said why without noticing:

> *"A stable sort preserves the salience order WITHIN each tier, so attention ranking is untouched."*

That was treated as harmless. It is the remaining half of the defect. **Salience is
recomputed every turn**, so preserving it as EMIT ORDER re-shuffles the very tier whose
only purpose is to be byte-identical across turns.

Measured live inside Atlas's `pallets__flask-4045` run, from her own prompt captures:

| turns | common prefix | diverges into |
|---|---|---|
| 0→1 | 8,216 / 9,906 chars | `[now …]` |
| 1→2 | 7,879 | `[active-work]` |
| 2→3 | 8,133 | `[workspace-map]` |

~82% shared prefix, and the divergence points are stable-tier blocks **trading places**.
Because the system prompt is FIRST, a swap at token ~2,000 invalidates KV for everything
after it — including a 34,000-token conversation tail. `--cache-reuse 256` was passed the
whole time and every turn reported `cachedTokens: 0`. The cache was correct; we were
destroying the prefix ourselves.

Cost at the measured 111 tok/s prefill: **~306 seconds of re-prefill per act**, growing as
her conversation grows (9,847 → 36,242 tokens). One observed turn was 20 minutes of
apparent silence that was a single 36k re-prefill — with the run reporting `active` the
whole time, because the pulse is a timer.

**The fix:** within the stable tier, order canonically by faculty name. Attention ranking
is genuinely untouched — salience still decides WHICH contributions survive the budget. It
simply stops deciding WHERE the survivors sit, which it never needed to. The volatile tier
deliberately keeps salience order: it re-prefills by construction, so canonical ordering
would buy nothing and would cost the "most salient nearest the write point" placement #205
put there on purpose.

## 2. `faf8c07c9` — `delib.generate.cache`

Joel: *"hopefully it will prove itself via probes."* It could not have. `delib` carried
`turn.demand` and `context.render` — how big the prompt WAS — and **nothing about what the
lane did with it**. A prompt whose prefix we destroyed every turn looked identical in the
probe stream to one served entirely from cache. That absence is why this survived from
#266 until today, and why the only way to see it was hand-diffing raw captures.

One row in `metrics_from`, the funnel every generation already passes through, so it covers
every turn of every citizen with no caller change. `hit_rate` is the existing
`TurnMetrics::cache_hit_rate()`, which had no way out of the process. Emitted **only** when
the lane actually reported timings — a fabricated 0.0 for a provider that never measured
one is a lying receipt of the #151/#357 class.

## 3. `e404dcecd` — `ActivityAdapter`: material in, verdict out

Slice 1 of the judge wiring, per
`docs/architecture/BENCHMARKS-ARE-ADAPTERS-NOT-A-RUNNER.md`. Generic over benchmarks /
gameplay / whatever comes next, per Joel's ask — not a benchmark-shaped special case.
Growable `Outcome` with `Channel`/`ChannelValue`; `resolve_all` fails loud naming the bad
key and the known set; an empty declaration is legal. 5 tests.

**Not yet consumed** — the hardcoded `swe_bench::grade` branch is still the live path.
Deleting it is a subtraction across four call sites and is the next commit, deliberately
not smuggled in here.

## Verification

- 181 prompt tests green, including `framing_flip_never_perturbs_the_cacheable_prefix` —
  the #266 invariant is intact; this extends it to the case it did not cover (fixed
  framing, re-ranked context).
- `cargo check -p continuum-core --features metal,accelerate` clean.

## Owed, and not claimed as done

- **Live proof.** The running core still holds the flask run, so deploy is correctly
  blocked. The proof is a `delib.generate.cache` query showing `hit_rate` climbing off the
  floor from act 2 — which is now a probe query rather than a capture diff, which was the
  point.
- **A regression test** pinning "same set, different salience → identical bytes". Without
  it this regresses the same way #266's half did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo