### PR TITLE
The round-killer arc: prefill watchdog, slot-affinity boot race, round durability, grade-race fix

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -406,6 +406,16 @@ fn apply_llamacpp_sampling_knobs(
     }
 }
 
+/// Does this `/props` status PROVE the endpoint does not exist — the only verdict
+/// allowed to latch [`SlotAffinity::Unsupported`] for the process's life? 404/501
+/// are the server saying "no such surface"; everything else (above all the 503 of a
+/// model still loading) is a statement about NOW, and a permanent conclusion drawn
+/// from a transient state is the [[unknown-is-not-a-quantity]] error with a cache
+/// bolted on.
+fn props_status_proves_endpoint_absent(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::NOT_IMPLEMENTED
+}
+
 impl SlotAffinity {
     /// Lease a warm slot for `persona` (see [`SlotAffinity`] doc). Reuse the slot it
     /// already holds → take a free slot → evict the least-recently-active holder.
@@ -437,6 +447,15 @@ impl SlotAffinity {
         // 2. A free slot → take it.
         if let Some(slot) = holders.iter().position(|h| h.is_none()) {
             holders[slot] = Some((persona.to_string(), now));
+            // Fires once per persona per process (plus re-pins after eviction), so
+            // the ledger can PROVE pinning is live — its silent predecessor ran
+            // latched-off for weeks with nothing to say so (2026-08-21).
+            crate::probe!(
+                class = "inference.slot_affinity.pinned",
+                persona = persona,
+                slot = slot as u64,
+                "persona pinned to a free llama-server slot — her prefix warms HERE",
+            );
             return Some(slot as u32);
         }
         // 3. All held → evict the least-recently-active holder (min tick).
@@ -445,6 +464,20 @@ impl SlotAffinity {
             .enumerate()
             .min_by_key(|(_, h)| h.as_ref().map(|(_, t)| *t).unwrap_or(0))
             .map(|(i, _)| i)?;
+        // Cross-persona eviction IS the KV-clobber event — the evicted citizen's
+        // warm tail is gone and her next turn re-prefills from zero. More personas
+        // than slots makes this legitimate; the probe is what makes it PRICED
+        // (KV-CACHE-ECONOMY: eviction must be a decision, not an accident).
+        if let Some((evicted, _)) = &holders[slot] {
+            crate::probe!(
+                class = "inference.slot_affinity.evicted",
+                persona = persona,
+                evicted = evicted.as_str(),
+                slot = slot as u64,
+                "all slots held — least-recently-active persona evicted; her warm \
+                 prefix is forfeit and her next turn re-prefills from zero",
+            );
+        }
         holders[slot] = Some((persona.to_string(), now));
         Some(slot as u32)
     }
@@ -759,13 +792,44 @@ impl OpenAICompatibleAdapter {
             }
         };
         if !resp.status().is_success() {
-            slot_tables().insert(root, SlotAffinity::Unsupported);
+            let status = resp.status();
+            // ONLY "this endpoint does not exist" may latch Unsupported. Any other
+            // status — above all the 503 a llama-server answers while the model is
+            // still LOADING — is transient, and latching on it killed slot affinity
+            // on effectively EVERY boot: personas start deliberating before the lane
+            // is warm (`inference.lane_relaunch_retry` ×93, reason=503_loading, same
+            // ledger), so the first probe raced the load window, latched Unsupported
+            // for the process's life, and prefix-similarity slot theft quietly
+            // replaced pinning — measured as `cached: 0` mid-conversation on
+            // 2026-08-21. A verdict about what a server IS must never be reached
+            // while the server is mid-transition (#442's rule, one layer down).
+            if props_status_proves_endpoint_absent(status) {
+                crate::probe!(
+                    class = "inference.slot_affinity.unsupported",
+                    status = status.as_u16() as u64,
+                    "props endpoint absent — slot affinity latched OFF for this server",
+                );
+                slot_tables().insert(root, SlotAffinity::Unsupported);
+            } else {
+                crate::probe!(
+                    class = "inference.slot_affinity.deferred",
+                    status = status.as_u16() as u64,
+                    "props not ready (transient status) — affinity deferred, NOT latched; \
+                     will re-probe on the next persona request",
+                );
+            }
             return None;
         }
         let body: serde_json::Value = match resp.json().await {
             Ok(v) => v,
             Err(_) => {
-                slot_tables().insert(root, SlotAffinity::Unsupported);
+                // A malformed body from a live server is also not proof of absence —
+                // mid-load llama-server can answer partial/HTML bodies. Defer, don't latch.
+                crate::probe!(
+                    class = "inference.slot_affinity.deferred",
+                    status = 200u64,
+                    "props answered but body did not parse — affinity deferred, NOT latched",
+                );
                 return None;
             }
         };
@@ -3696,6 +3760,36 @@ mod tests {
     // personas take distinct free slots; once full, a NEW persona evicts the
     // LEAST-recently-active holder, not a fixed round-robin victim — so the active
     // set keeps its warm slots and co-active minds never share one. This is the
+    // what this catches: the boot-race latch that killed slot affinity on effectively
+    // EVERY boot (2026-08-21). Personas start deliberating while llama-server still
+    // answers 503_loading (measured ×93 in the same ledger); the old code latched
+    // Unsupported on ANY non-success status, so one probe racing the load window
+    // disabled pinning for the process's life and prefix-similarity slot theft took
+    // over (`cached: 0` mid-conversation). Only "no such endpoint" may be permanent.
+    #[test]
+    fn a_loading_lane_must_not_latch_slot_affinity_off() {
+        use reqwest::StatusCode;
+        for transient in [
+            StatusCode::SERVICE_UNAVAILABLE, // llama-server mid-load — THE incident
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::TOO_MANY_REQUESTS,
+        ] {
+            assert!(
+                !props_status_proves_endpoint_absent(transient),
+                "{transient} is a statement about NOW, not about what the server IS — \
+                 latching Unsupported on it re-opens the boot race"
+            );
+        }
+        for absent in [StatusCode::NOT_FOUND, StatusCode::NOT_IMPLEMENTED] {
+            assert!(
+                props_status_proves_endpoint_absent(absent),
+                "{absent} genuinely proves the surface is missing — without the latch \
+                 every cloud provider would be re-probed per persona request forever"
+            );
+        }
+    }
+
     // regression guard on the old first-touch pin that let two permanent slot-mates
     // clobber each other every turn (cachedTokens≈4). Non-Table states never pin.
     #[test]

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -2557,20 +2557,23 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         let mut last_prefill_processed: u64 = 0;
         let stream_opened = Instant::now();
         let mut last_progress = stream_opened;
+        // PREFILL IS NOT DECODE (2026-08-21, the round-killer). `live_budget` is a
+        // DECODE watchdog by its own doc — "a token every few hundred ms". Selecting
+        // it the moment ANY progress arrived meant llama.cpp's 0%-ingestion signalling
+        // frame dropped us from 300s to 90s seconds into a prefill that measured ~170s
+        // for a window-sized prompt, so every big turn died and retried forever. The
+        // phase machine keeps the two regimes apart; see `inference::stream_liveness`.
+        let mut phase = crate::inference::stream_liveness::StreamPhase::Queued;
         loop {
-            // `last_progress` only ever moves when the SERVER did something for us
-            // (prefill advanced, token, tool delta, finish). So "has it moved since
-            // we opened the stream" is exactly "has the slot started our work" —
-            // no extra flag to keep in sync with the activity sites below.
-            let idle = if last_progress > stream_opened {
-                live_budget
-            } else {
-                queue_budget
-            };
+            let idle = crate::inference::stream_liveness::idle_budget(
+                phase,
+                queue_budget,
+                live_budget,
+            );
             let next = tokio::time::timeout(idle, byte_stream.next())
                 .await
                 .map_err(|_| {
-                    let started = last_progress > stream_opened;
+                    let started = phase.has_started();
                     if local_lane {
                         if started {
                             // Started-then-stopped is per-slot evidence about OUR
@@ -2681,6 +2684,12 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                     // `>` so a REPEATED frame carrying the same count (the wedge
                     // signature) cannot hold the watchdog open forever.
                     if let Some(p) = parsed.prompt_progress {
+                        // Phase advances on EVERY frame (including the 0% signalling
+                        // one), because "the slot is assigned and ingesting" is true
+                        // from the first frame — that is what picks the bulk budget.
+                        // The liveness STAMP below still requires strict advance, so a
+                        // frozen counter cannot hold the watchdog open (#385).
+                        phase = phase.on_prefill(p.processed, p.total);
                         if p.processed > last_prefill_processed {
                             last_prefill_processed = p.processed;
                             last_progress = Instant::now();
@@ -2697,6 +2706,12 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                             });
                         }
                     }
+                    // Any REAL output (token, reasoning, tool delta, finish) means
+                    // prefill is definitionally over. Detected once here, by observing
+                    // whether the sites below moved the liveness stamp, rather than
+                    // repeating a phase assignment at each of the four — one decision,
+                    // one place, and a new output kind cannot forget to declare itself.
+                    let progress_before_output = last_progress;
                     if let Some(choice) = parsed.choices.into_iter().next() {
                         if let Some(fr) = choice.finish_reason {
                             finish_reason_str = Some(fr);
@@ -2724,6 +2739,9 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                                 }
                             }
                         }
+                    }
+                    if last_progress != progress_before_output {
+                        phase = phase.on_output();
                     }
                 }
             }

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -2566,6 +2566,14 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         let mut phase = crate::inference::stream_liveness::StreamPhase::Queued;
         // One `inference.prefill.rescued` row per stream, not per frame.
         let mut prefill_rescued = false;
+        // When the FIRST prompt_progress frame arrived. llama.cpp emits the 0% frame
+        // at the moment the slot is ASSIGNED ("signal the client that the request has
+        // started processing"), so open→first-frame is QUEUE WAIT and
+        // first-frame→complete is INGEST. The first cut of these probes conflated the
+        // two into one `elapsed_ms`, and the numbers were absurd in exactly the way a
+        // conflation is: a 467-token prompt "prefilling" for 231s at 1 tok/s. It was
+        // queued 230 of those seconds. A probe that mixes two regimes measures neither.
+        let mut first_prefill_frame: Option<Instant> = None;
         loop {
             let idle = crate::inference::stream_liveness::idle_budget(
                 phase,
@@ -2693,6 +2701,7 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                         // frozen counter cannot hold the watchdog open (#385).
                         let was = phase;
                         phase = phase.on_prefill(p.processed, p.total);
+                        let first_frame = *first_prefill_frame.get_or_insert_with(Instant::now);
 
                         // PROVE THE FIX IS LOAD-BEARING. Without this the change is
                         // invisible: "no retries" is an ABSENCE, and an absence cannot
@@ -2712,6 +2721,7 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                                 class = "inference.prefill.rescued",
                                 provider = self.config.name.as_str(),
                                 elapsed_s = elapsed.as_secs(),
+                                queued_s = first_frame.duration_since(stream_opened).as_secs(),
                                 old_budget_s = live_budget.as_secs(),
                                 processed = p.processed,
                                 total = p.total,
@@ -2721,14 +2731,19 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                                  would have been killed here and retried forever",
                             );
                         }
-                        // The whole-ingest timing, emitted once at the prefill→decode
-                        // edge. This is the number the 90s constant was implicitly
-                        // guessing at, and the one the budget should eventually be
-                        // DERIVED from per model/device (#441).
+                        // Per-stream ingest receipt, emitted once at the prefill→decode
+                        // edge, with QUEUE and INGEST separated: llama.cpp's 0% frame
+                        // marks slot ASSIGNMENT, so open→first-frame is time spent
+                        // waiting for a slot and first-frame→now is real ingest work.
+                        // `ingest_tok_per_s` is the number the 90s constant was
+                        // implicitly guessing at and the one a derived budget should
+                        // come from per model+device (#441); `queued_ms` is the
+                        // admission/oversubscription signal (#234 QoS).
                         if matches!(was, crate::inference::stream_liveness::StreamPhase::Prefilling { .. })
                             && matches!(phase, crate::inference::stream_liveness::StreamPhase::Decoding)
                         {
-                            let ms = elapsed.as_millis().max(1) as u64;
+                            let queued_ms = first_frame.duration_since(stream_opened).as_millis() as u64;
+                            let ingest_ms = (first_frame.elapsed().as_millis().max(1)) as u64;
                             let fresh = p.total.saturating_sub(p.cache);
                             crate::probe!(
                                 class = "inference.prefill.complete",
@@ -2736,11 +2751,12 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                                 total = p.total,
                                 cached = p.cache,
                                 fresh = fresh,
-                                elapsed_ms = ms,
-                                tok_per_s = (fresh as f64 * 1000.0 / ms as f64) as u64,
+                                queued_ms = queued_ms,
+                                ingest_ms = ingest_ms,
+                                ingest_tok_per_s = (fresh as f64 * 1000.0 / ingest_ms as f64) as u64,
                                 would_have_died = u8::from(elapsed > live_budget) as u64,
-                                "prefill complete — ingest wall-clock and the cache's \
-                                 real contribution, per stream",
+                                "prefill complete — queue wait vs real ingest, and the \
+                                 cache's actual contribution, per stream",
                             );
                         }
                         if p.processed > last_prefill_processed {

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -2564,6 +2564,8 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         // for a window-sized prompt, so every big turn died and retried forever. The
         // phase machine keeps the two regimes apart; see `inference::stream_liveness`.
         let mut phase = crate::inference::stream_liveness::StreamPhase::Queued;
+        // One `inference.prefill.rescued` row per stream, not per frame.
+        let mut prefill_rescued = false;
         loop {
             let idle = crate::inference::stream_liveness::idle_budget(
                 phase,
@@ -2689,7 +2691,58 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                         // from the first frame — that is what picks the bulk budget.
                         // The liveness STAMP below still requires strict advance, so a
                         // frozen counter cannot hold the watchdog open (#385).
+                        let was = phase;
                         phase = phase.on_prefill(p.processed, p.total);
+
+                        // PROVE THE FIX IS LOAD-BEARING. Without this the change is
+                        // invisible: "no retries" is an ABSENCE, and an absence cannot
+                        // distinguish "prefills now survive" from "nothing is running"
+                        // — the exact ambiguity that cost a full day of diagnosis.
+                        // This fires ONCE per stream, only for a prefill that has
+                        // already outlived the OLD decode budget while still advancing.
+                        // Every row is therefore a turn that would previously have been
+                        // killed and retried forever.
+                        let elapsed = stream_opened.elapsed();
+                        if !prefill_rescued
+                            && matches!(phase, crate::inference::stream_liveness::StreamPhase::Prefilling { .. })
+                            && elapsed > live_budget
+                        {
+                            prefill_rescued = true;
+                            crate::probe!(
+                                class = "inference.prefill.rescued",
+                                provider = self.config.name.as_str(),
+                                elapsed_s = elapsed.as_secs(),
+                                old_budget_s = live_budget.as_secs(),
+                                processed = p.processed,
+                                total = p.total,
+                                cached = p.cache,
+                                "prefill outlived the OLD decode watchdog and is STILL \
+                                 advancing — under the previous flat budget this turn \
+                                 would have been killed here and retried forever",
+                            );
+                        }
+                        // The whole-ingest timing, emitted once at the prefill→decode
+                        // edge. This is the number the 90s constant was implicitly
+                        // guessing at, and the one the budget should eventually be
+                        // DERIVED from per model/device (#441).
+                        if matches!(was, crate::inference::stream_liveness::StreamPhase::Prefilling { .. })
+                            && matches!(phase, crate::inference::stream_liveness::StreamPhase::Decoding)
+                        {
+                            let ms = elapsed.as_millis().max(1) as u64;
+                            let fresh = p.total.saturating_sub(p.cache);
+                            crate::probe!(
+                                class = "inference.prefill.complete",
+                                provider = self.config.name.as_str(),
+                                total = p.total,
+                                cached = p.cache,
+                                fresh = fresh,
+                                elapsed_ms = ms,
+                                tok_per_s = (fresh as f64 * 1000.0 / ms as f64) as u64,
+                                would_have_died = u8::from(elapsed > live_budget) as u64,
+                                "prefill complete — ingest wall-clock and the cache's \
+                                 real contribution, per stream",
+                            );
+                        }
                         if p.processed > last_prefill_processed {
                             last_prefill_processed = p.processed;
                             last_progress = Instant::now();

--- a/core/continuum-core/src/cognition/activity.rs
+++ b/core/continuum-core/src/cognition/activity.rs
@@ -1,0 +1,421 @@
+//! What an activity ADAPTS — material in, verdict out.
+//!
+//! This is the one seam every activity plugs into: SWE-bench, a HumanEval-style gym, a
+//! game level, a life-drawing critique, a robot that either picked up the block or didn't.
+//! The room is the runner; an adapter only translates between the outside world's form and
+//! ours ([[benchmarks-are-adapters-not-a-runner]]).
+//!
+//! # Why this is not `BenchmarkAdapter` any more
+//!
+//! The interface it replaces was the right SHAPE and the wrong SCOPE. It already carried
+//! both directions — `dataset()`/`tasks()` bring material IN, `grade()` renders a verdict
+//! OUT — but it was named for one subsystem, and a name is load-bearing: an interface called
+//! `BenchmarkAdapter` cannot plausibly host a game level, so the second activity gets its own
+//! parallel trait, its own registry, its own runner, and the substrate now has two of
+//! everything. That is the same failure as naming a room for a subsystem and making it
+//! immortal. Named for the JOB (an activity adapting its material), gameplay is a sibling
+//! implementation instead of a fork.
+//!
+//! # Both directions are the same kind of thing
+//!
+//! - **IN** — [`ActivityAdapter::material`] declares where the outside form lives and
+//!   [`ActivityAdapter::tasks`] normalizes it into our canonical [`EvalTask`]. For a
+//!   benchmark that is "task + oracle, nothing else" — deliberately NOT the upstream
+//!   harness, which we never run.
+//! - **OUT** — [`ActivityAdapter::judge`] turns what the citizen actually produced into a
+//!   [`Verdict`].
+//!
+//! # Declaring none is normal
+//!
+//! Most activities score nothing. `chat` names no adapters and nothing judges it; there is
+//! no "the ungraded kind" branch anywhere, because an empty list is already the answer
+//! (Joel, 2026-08-21: *"always adapter(s) with none as an option … formulaic or not,
+//! anything can plug in. Just build the ones you initially need"*). Judging lives in the
+//! recipe's `params`, never on the base recipe type — an exam concept stamped onto every
+//! chat room and profile page is exactly the over-reach this seam exists to avoid.
+//!
+//! # The growable outcome, and why it is not a fixed struct
+//!
+//! [`Outcome`] carries what the citizen produced. The universal parts are named fields:
+//! every activity has a mouth (what she said) and a place she worked. Everything modality-
+//! specific goes in [`Outcome::channels`] — a typed, growable carrier, the same shape the
+//! adapter capability surface already uses in this codebase.
+//!
+//! This matters for the reason the fixed struct failed: with `patch` and `workspace` as
+//! bare fields, SWE-bench OWNS the outcome type, and a game trajectory or a robot's joint
+//! log can only be added by editing a struct that every other activity compiles against. A
+//! new modality would either widen a shared type for everyone or — far more likely, and what
+//! actually happens — grow its own parallel outcome and its own parallel judge. Channels let
+//! gameplay add [`Channel::Trajectory`] without SWE-bench recompiling a line, and let a judge
+//! ask for exactly the channel it grades and get a typed `None` when the activity did not
+//! produce one.
+//!
+//! Growing the enum is still a deliberate act: a new variant is added when a REAL activity
+//! needs it, never speculatively. What changed is the cost of being wrong — a wrong guess is
+//! now one unused variant instead of a second subsystem.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::cognition::eval::EvalTask;
+
+/// Where an activity's material comes from — declared by the adapter, fetched ON DEMAND by
+/// the room that runs it, never bundled in the repo.
+#[derive(Debug, Clone)]
+pub struct MaterialSpec {
+    /// Hugging Face repo id (`org/name`), an HTTPS URL, or a git remote — read per `kind`.
+    pub source: String,
+    /// How to fetch `source`. Enumerated so a new source kind forces the fetch match to be
+    /// revisited instead of silently skipped.
+    pub kind: MaterialKind,
+    /// Subdirectory under the shared cache where the material materializes. ONE canonical
+    /// cache, so a fetched suite is reused across runs and citizens.
+    pub cache_key: String,
+    /// Optional glob restricting what to fetch (e.g. only `*.jsonl`, skip weights).
+    pub include: Option<String>,
+}
+
+/// The fetch strategy for a [`MaterialSpec`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaterialKind {
+    /// Hugging Face dataset/model repo — snapshot-style fetch.
+    Hf,
+    /// A single HTTPS artifact the adapter parses.
+    Url,
+    /// A git repository (real-repo activities clone per-task from here).
+    Git,
+    /// Already resident — generated, seeded, or shipped in-tree. Nothing to fetch.
+    Resident,
+}
+
+/// A placement hint the grid uses to route an activity to a capable node. All fields
+/// optional: an unknown hint means "place anywhere", never a hard block.
+#[derive(Debug, Clone, Default)]
+pub struct ResourceHint {
+    /// Approx disk the material needs once materialized (bytes).
+    pub disk_bytes: Option<u64>,
+    /// True if judging needs a container runtime. A node without one is not a candidate —
+    /// surfaced as data, never a crash.
+    pub needs_container: bool,
+    /// True if tasks need outbound web access.
+    pub needs_network: bool,
+}
+
+/// A modality channel on an [`Outcome`] — what the citizen produced, beyond speech.
+///
+/// One variant per REAL modality some activity actually judges. Adding a variant is how a
+/// new kind of activity arrives; it costs every other adapter nothing, because judges match
+/// on the channel they care about and treat absence as `None`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Channel {
+    /// Unified `git diff` of everything she changed — what SWE/Terminal-style activities grade.
+    Diff,
+    /// A relative in-workspace path she was told to write her solution to (artifact grade).
+    Artifact,
+}
+
+/// The value on a [`Channel`]. Kept deliberately narrow — a channel carries either text or a
+/// path today, and a judge that needs richer structure parses it. Widening this is a
+/// deliberate act with a real activity behind it.
+#[derive(Debug, Clone)]
+pub enum ChannelValue {
+    Text(String),
+    Path(PathBuf),
+}
+
+impl ChannelValue {
+    /// The text of this value, or `None` if it is a path. Judges use this instead of
+    /// matching, so an activity that stored the wrong shape reads as absent rather than
+    /// panicking inside a judge.
+    pub fn text(&self) -> Option<&str> {
+        match self {
+            ChannelValue::Text(t) => Some(t),
+            ChannelValue::Path(_) => None,
+        }
+    }
+
+    /// The path of this value, or `None` if it is text.
+    pub fn path(&self) -> Option<&std::path::Path> {
+        match self {
+            ChannelValue::Path(p) => Some(p),
+            ChannelValue::Text(_) => None,
+        }
+    }
+}
+
+/// What one citizen actually produced in one task — the input every judge grades.
+///
+/// Universal facts are named fields. Modality-specific ones live in [`Self::channels`] so a
+/// new activity adds a modality without widening a type its siblings compile against.
+#[derive(Debug, Clone, Default)]
+pub struct Outcome {
+    /// Her final spoken answer (mouth). Some activities grade this directly.
+    pub spoken: String,
+    /// The workspace after she acted — where a judge re-runs the activity's own checks.
+    pub workspace: PathBuf,
+    /// Whether the generic harness already passed it, and why. This is the harness's OWN
+    /// verdict, not the activity's: a judge may confirm, override, or ignore it.
+    pub harness_passed: bool,
+    /// Human-readable detail from the generic harness grade.
+    pub harness_detail: String,
+    /// Modality channels, keyed by [`Channel`]. Absent = the activity produced none.
+    pub channels: BTreeMap<Channel, ChannelValue>,
+}
+
+impl Outcome {
+    /// The value on `channel`, or `None` when this activity produced nothing there.
+    pub fn channel(&self, channel: Channel) -> Option<&ChannelValue> {
+        self.channels.get(&channel)
+    }
+
+    /// Text on `channel`, or `""` when absent — the ergonomic read for judges that treat a
+    /// missing modality the same as an empty one (a diff-grading judge does).
+    pub fn channel_text(&self, channel: Channel) -> &str {
+        self.channel(channel).and_then(|v| v.text()).unwrap_or("")
+    }
+
+    /// Attach `value` to `channel`, replacing anything already there.
+    pub fn with_channel(mut self, channel: Channel, value: ChannelValue) -> Self {
+        self.channels.insert(channel, value);
+        self
+    }
+}
+
+/// One activity's verdict on one task — did it pass, how well, and WHY.
+///
+/// `reason` is not decoration: it is the receipt a citizen and a human both read, and the
+/// text the curriculum keeps when the task failed.
+#[derive(Debug, Clone)]
+pub struct Verdict {
+    pub passed: bool,
+    /// Normalized 0..1. A pass/fail judge reports 1.0/0.0; a scored one reports its scale.
+    pub score: f64,
+    pub reason: String,
+}
+
+impl Verdict {
+    /// A passing verdict with a reason.
+    pub fn pass(reason: impl Into<String>) -> Self {
+        Self { passed: true, score: 1.0, reason: reason.into() }
+    }
+
+    /// A failing verdict with a reason.
+    pub fn fail(reason: impl Into<String>) -> Self {
+        Self { passed: false, score: 0.0, reason: reason.into() }
+    }
+}
+
+/// One activity, as a plug-in: it adapts material IN and renders a verdict OUT.
+///
+/// The room runs the activity; this only translates. Implement once per activity kind —
+/// the runner, the grid placement, and the learning loop treat every adapter identically.
+#[async_trait::async_trait]
+pub trait ActivityAdapter: Send + Sync {
+    /// Stable slug, used on the CLI, in a recipe's declaration, and on the scorecard.
+    /// Must match the registry key.
+    fn name(&self) -> &str;
+
+    /// Where this activity's material comes from, or `None` when it needs none (generated,
+    /// seeded, or already resident). The room materializes this before [`Self::tasks`].
+    fn material(&self) -> Option<MaterialSpec> {
+        None
+    }
+
+    /// What kind of node can run this — for grid placement. Default: anywhere.
+    fn resources(&self) -> ResourceHint {
+        ResourceHint::default()
+    }
+
+    /// Load this activity's items into our canonical [`EvalTask`] shape from the
+    /// already-materialized root (`None` when [`Self::material`] is `None`). `limit` caps
+    /// items for a quick pulse. THE ONLY per-activity parsing — everything downstream is
+    /// generic.
+    async fn tasks(
+        &self,
+        material_root: Option<&std::path::Path>,
+        limit: Option<usize>,
+    ) -> Result<Vec<EvalTask>, String>;
+
+    /// Judge what she produced.
+    ///
+    /// The DEFAULT defers to the harness's own verdict, which is correct for activities
+    /// whose `EvalTask` already encodes the definition of done (a `dod_shell`, a `test`, an
+    /// `expect`). Activities that must inspect the world after she acted — re-run a repo's
+    /// held-out tests, read a final score, measure a trajectory — override this.
+    async fn judge(&self, _task: &EvalTask, outcome: &Outcome) -> Verdict {
+        Verdict {
+            passed: outcome.harness_passed,
+            score: if outcome.harness_passed { 1.0 } else { 0.0 },
+            reason: if outcome.harness_detail.is_empty() {
+                "harness verdict".to_string()
+            } else {
+                outcome.harness_detail.clone()
+            },
+        }
+    }
+}
+
+/// A builtin adapter that self-registers at link time via `inventory` — the same mechanism
+/// commands use, so a resident activity is discoverable with NO boot hook and NO central
+/// list to edit. Adding an activity is adding a file.
+pub struct BuiltinActivityAdapter {
+    /// Constructs the adapter. A `fn` pointer (not a value) so submission stays const-evaluable.
+    pub make: fn() -> Arc<dyn ActivityAdapter>,
+}
+
+inventory::collect!(BuiltinActivityAdapter);
+
+/// Runtime-registered adapters (tests, and any future dynamic registration). Builtins come
+/// from `inventory` and are folded in by [`get`]/[`names`].
+static RUNTIME: std::sync::LazyLock<std::sync::RwLock<BTreeMap<String, Arc<dyn ActivityAdapter>>>> =
+    std::sync::LazyLock::new(|| std::sync::RwLock::new(BTreeMap::new()));
+
+/// Register (or replace) an adapter at runtime. Idempotent by name. Builtins self-register
+/// and need NOT be passed here.
+pub fn register(adapter: Arc<dyn ActivityAdapter>) {
+    if let Ok(mut w) = RUNTIME.write() {
+        w.insert(adapter.name().to_string(), adapter);
+    }
+}
+
+/// Look up an adapter by name. Runtime registrations win over builtins so a test can shadow
+/// a builtin; otherwise the link-time set is searched.
+pub fn get(name: &str) -> Option<Arc<dyn ActivityAdapter>> {
+    if let Ok(r) = RUNTIME.read() {
+        if let Some(a) = r.get(name) {
+            return Some(a.clone());
+        }
+    }
+    inventory::iter::<BuiltinActivityAdapter>
+        .into_iter()
+        .map(|b| (b.make)())
+        .find(|a| a.name() == name)
+}
+
+/// Every known adapter name (runtime ∪ builtin), sorted and deduped — for a fail-loud
+/// "unknown activity 'X'; known: …" instead of a silent miss.
+pub fn names() -> Vec<String> {
+    let mut out: Vec<String> = inventory::iter::<BuiltinActivityAdapter>
+        .into_iter()
+        .map(|b| (b.make)().name().to_string())
+        .collect();
+    if let Ok(r) = RUNTIME.read() {
+        out.extend(r.keys().cloned());
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Resolve every adapter a recipe declared, or say EXACTLY which name is unknown.
+///
+/// This is the seam that makes "the exam was sat and nobody marked it" unrepresentable. A
+/// declared-but-unresolvable judge is an error at the moment of staging, not a run that
+/// quietly ends with no verdict — the failure mode that produced 253 of 450 unmarked runs
+/// (measured 2026-08-21) and that no amount of citizen effort could have avoided.
+///
+/// An EMPTY declaration resolves to an empty vec and is NOT an error: most activities judge
+/// nothing, and that is normal, not a missing judge.
+pub fn resolve_all(declared: &[String]) -> Result<Vec<Arc<dyn ActivityAdapter>>, String> {
+    let mut out = Vec::with_capacity(declared.len());
+    for name in declared {
+        match get(name) {
+            Some(a) => out.push(a),
+            None => {
+                return Err(format!(
+                    "unknown activity adapter '{name}' — known: {}. \
+                     A recipe that names a judge nothing can resolve must fail HERE, at \
+                     staging, not by producing a run that ends with no verdict.",
+                    names().join(", ")
+                ))
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Stub;
+
+    #[async_trait::async_trait]
+    impl ActivityAdapter for Stub {
+        fn name(&self) -> &str {
+            "stub-activity"
+        }
+        async fn tasks(
+            &self,
+            _root: Option<&std::path::Path>,
+            _limit: Option<usize>,
+        ) -> Result<Vec<EvalTask>, String> {
+            Ok(vec![])
+        }
+    }
+
+    // what this catches: the registry must round-trip a registration AND name the unknown
+    // key on a miss. A silent `None` here is how a declared judge goes missing without
+    // anyone noticing.
+    #[test]
+    fn registry_round_trips_and_names_the_unknown() {
+        register(Arc::new(Stub));
+        assert!(get("stub-activity").is_some());
+        assert!(get("no-such-activity").is_none());
+        assert!(names().iter().any(|n| n == "stub-activity"));
+    }
+
+    // what this catches: declaring NO judge is legal and yields no judges — the "none is
+    // normal" contract. If this ever errors, every chat room becomes an exam.
+    #[test]
+    fn declaring_no_judge_is_legal_and_not_an_error() {
+        let resolved = resolve_all(&[]).expect("empty declaration must resolve, not error");
+        assert!(resolved.is_empty());
+    }
+
+    // what this catches: a declared-but-unknown judge fails LOUD at resolve time and the
+    // message names both the bad key and the known set. This is the guard that makes an
+    // unmarked run impossible — regression for the 253/450 unmarked runs of 2026-08-21.
+    #[test]
+    fn an_unknown_declared_judge_fails_loud_and_names_it() {
+        register(Arc::new(Stub));
+        // Matched rather than `expect_err`: the Ok side is `Vec<Arc<dyn ActivityAdapter>>`,
+        // and a trait object is not `Debug`. Requiring `Debug` on the trait just to phrase a
+        // test would put a constraint on every future adapter to serve the test's ergonomics.
+        let err = match resolve_all(&["stub-activity".into(), "ghost-judge".into()]) {
+            Ok(_) => panic!("an unresolvable judge must be an error, never a silent skip"),
+            Err(e) => e,
+        };
+        assert!(err.contains("ghost-judge"), "must name the offending key: {err}");
+        assert!(err.contains("stub-activity"), "must list what IS known: {err}");
+    }
+
+    // what this catches: the default judge defers to the harness verdict, so an activity
+    // whose EvalTask already encodes done-ness needs no judge code at all.
+    #[tokio::test]
+    async fn default_judge_defers_to_the_harness() {
+        let task = EvalTask::default();
+        let passed = Outcome { harness_passed: true, ..Default::default() };
+        assert!(Stub.judge(&task, &passed).await.passed);
+        let failed = Outcome {
+            harness_passed: false,
+            harness_detail: "tests failed".into(),
+            ..Default::default()
+        };
+        let v = Stub.judge(&task, &failed).await;
+        assert!(!v.passed);
+        assert_eq!(v.reason, "tests failed");
+    }
+
+    // what this catches: a channel a judge asks for but the activity never produced reads as
+    // absent — NOT as an empty success. This is what lets gameplay add a modality without
+    // SWE-bench's judge changing, and what stops a judge panicking on a missing one.
+    #[test]
+    fn an_absent_channel_reads_absent_not_empty_success() {
+        let o = Outcome::default().with_channel(Channel::Diff, ChannelValue::Text("x".into()));
+        assert_eq!(o.channel_text(Channel::Diff), "x");
+        assert!(o.channel(Channel::Artifact).is_none());
+        assert_eq!(o.channel_text(Channel::Artifact), "");
+    }
+}

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -195,9 +195,26 @@ static ROUNDS: LazyLock<Mutex<HashMap<Uuid, BenchRound>>> =
 /// Where in-flight rounds persist — one JSON file per round, removed at Done. The same
 /// durable-state family as the airc attach cursor (`~/.continuum/state`): tiny, per-key,
 /// self-evicting at terminal state, so the directory only ever holds in-flight rounds.
+///
+/// Under `cfg(test)` this is a per-process temp dir, NEVER the real state dir. The first
+/// cut resolved to `$HOME` unconditionally, and the existing tests — which exercise the
+/// PUBLIC `open_round`/`add_card` — persisted their fixture rounds into the operator's
+/// real state: two `cargo test` runs minted four phantom rounds that the next live core
+/// faithfully reloaded and reported as in-flight (measured 2026-08-21, `in_flight: 5`
+/// with one real round). A durable layer's tests must be durable somewhere disposable.
 fn rounds_state_dir() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    std::path::PathBuf::from(home).join(".continuum/state/bench-rounds")
+    #[cfg(test)]
+    {
+        static TEST_DIR: LazyLock<std::path::PathBuf> = LazyLock::new(|| {
+            std::env::temp_dir().join(format!("bench-rounds-test-proc-{}", std::process::id()))
+        });
+        TEST_DIR.clone()
+    }
+    #[cfg(not(test))]
+    {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        std::path::PathBuf::from(home).join(".continuum/state/bench-rounds")
+    }
 }
 
 /// Persist one round. Failure degrades to the pre-2026-08-21 behaviour (the round

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -27,6 +27,7 @@
 //! on a different task, with nothing threaded between them.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::{LazyLock, Mutex};
 
 use serde_json::Value;
@@ -72,7 +73,8 @@ pub enum WorkDriver {
 /// posted and kickoffs sent); `Done` when every card in the round's set has reached a
 /// terminal card state. Two stages only — the smallest true lifecycle; claim/review
 /// granularity already lives on the cards themselves.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum RoundStage {
     Working,
     Done,
@@ -109,6 +111,17 @@ enum SettleOutcome {
 /// One benchmark round: the card set a single `benchmark/dispatch` posted, tracked from
 /// dispatch (Working) to all-cards-terminal (Done). Identity is the run ROOM's uuid —
 /// the id dispatch already mints per run; a round IS its room's activity.
+///
+/// Serde is DURABILITY, not wire: an in-flight round persists to
+/// [`rounds_state_dir`] on every mutation and reloads on the next boot. Until
+/// 2026-08-21 this map was process-memory only, and the cost was measured twice in
+/// one day: `benchmark/rounds` answered `rounds: []` while a staged round was live
+/// (the operator re-derived the round from probe archaeology), and — worse, silent —
+/// a reboot mid-round made [`driver_for_card`] fall back to `DetachedSolve` for a
+/// `Citizen` round's remaining cards, quietly rebuilding the parallel runner the
+/// round was configured to avoid. A round must outlive the process that opened it:
+/// "kicked off by a command, owned by events" only holds if the owner survives.
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct BenchRound {
     round_id: Uuid,
     benchmark: String,
@@ -172,8 +185,79 @@ impl BenchRound {
 /// Sync `Mutex`, never held across an await (every touch is a short pure mutation).
 /// A round is REMOVED the moment it completes, so the map only ever holds in-flight
 /// rounds — no unbounded growth, and "done fires once" is structural.
+///
+/// First touch RELOADS persisted in-flight rounds (see [`BenchRound`]'s serde note) —
+/// lazy so no boot hook is needed: the first `driver_for_card` after a reboot already
+/// answers from the reloaded round.
 static ROUNDS: LazyLock<Mutex<HashMap<Uuid, BenchRound>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+    LazyLock::new(|| Mutex::new(load_rounds_in(&rounds_state_dir())));
+
+/// Where in-flight rounds persist — one JSON file per round, removed at Done. The same
+/// durable-state family as the airc attach cursor (`~/.continuum/state`): tiny, per-key,
+/// self-evicting at terminal state, so the directory only ever holds in-flight rounds.
+fn rounds_state_dir() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    std::path::PathBuf::from(home).join(".continuum/state/bench-rounds")
+}
+
+/// Persist one round. Failure degrades to the pre-2026-08-21 behaviour (the round
+/// forgets on reboot) and WARNS — durability must never make a live dispatch fail.
+fn persist_round_in(dir: &Path, round: &BenchRound) {
+    let _ = std::fs::create_dir_all(dir);
+    let path = dir.join(format!("{}.json", round.round_id));
+    match serde_json::to_string(round) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(&path, json) {
+                tracing::warn!(round = %round.round_id, error = %e, "bench round not persisted — it will not survive a core restart");
+            }
+        }
+        Err(e) => tracing::warn!(round = %round.round_id, error = %e, "bench round not serializable — it will not survive a core restart"),
+    }
+}
+
+/// Forget a completed round's file. Best-effort: a leftover file re-loads a Done round
+/// at next boot, and [`load_rounds_in`] drops those on read.
+fn remove_round_file_in(dir: &Path, round_id: Uuid) {
+    let _ = std::fs::remove_file(dir.join(format!("{round_id}.json")));
+}
+
+/// Reload the in-flight rounds a previous core persisted. Unreadable or Done entries
+/// are dropped (Done should have been removed at settle; tolerate the crash window).
+///
+/// HONEST LIMIT, by design: cards that reached a terminal state WHILE the core was
+/// down settle here as still-working until the next real event touches the round. The
+/// reconciler that re-derives card state from the board at boot is the follow-up —
+/// this reload restores the round's EXISTENCE (driver, card set, visibility), which is
+/// what a reboot was silently destroying.
+fn load_rounds_in(dir: &Path) -> HashMap<Uuid, BenchRound> {
+    let mut out = HashMap::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let Ok(text) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        let Ok(round) = serde_json::from_str::<BenchRound>(&text) else {
+            tracing::warn!(file = %entry.path().display(), "unreadable bench-round state file skipped (left in place for inspection)");
+            continue;
+        };
+        if round.stage == RoundStage::Done {
+            let _ = std::fs::remove_file(entry.path());
+            continue;
+        }
+        crate::probe!(
+            class = "bench.round.reloaded",
+            round_id = %round.round_id,
+            benchmark = %round.benchmark,
+            remaining = round.remaining(),
+            driver = ?round.driver,
+            "in-flight benchmark round reloaded after core restart — driver and card set restored"
+        );
+        out.insert(round.round_id, round);
+    }
+    out
+}
 
 /// Open a round BEFORE its first card is posted, so the driver is readable from the
 /// instant a card can be claimed.
@@ -187,11 +271,11 @@ static ROUNDS: LazyLock<Mutex<HashMap<Uuid, BenchRound>>> =
 ///
 /// Idempotent by round id: re-opening a live round leaves it untouched.
 pub fn open_round(round_id: Uuid, benchmark: &str, driver: WorkDriver) {
-    ROUNDS
-        .lock()
-        .unwrap_or_else(|p| p.into_inner())
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let round = rounds
         .entry(round_id)
         .or_insert_with(|| BenchRound::new(round_id, benchmark, &[], driver));
+    persist_round_in(&rounds_state_dir(), round);
 }
 
 /// Add a freshly posted card to an open round. Unknown round = no-op (dispatch always
@@ -203,6 +287,7 @@ pub fn add_card(round_id: Uuid, card_id: Uuid) {
         .get_mut(&round_id)
     {
         r.cards.entry(card_id).or_insert(None);
+        persist_round_in(&rounds_state_dir(), r);
     }
 }
 
@@ -227,6 +312,7 @@ pub fn seal_round(round_id: Uuid) {
     );
     if dispatched == 0 {
         rounds.remove(&round_id);
+        remove_round_file_in(&rounds_state_dir(), round_id);
         crate::probe!(
             class = "bench.round.done",
             round_id = %round_id,
@@ -286,6 +372,7 @@ pub fn observe_card_event(payload: &Value) {
     match round.settle_card(card, state) {
         SettleOutcome::NotOurs | SettleOutcome::AlreadySettled => {}
         SettleOutcome::Settled { remaining } => {
+            persist_round_in(&rounds_state_dir(), round);
             crate::probe!(
                 class = "bench.round.card_settled",
                 round_id = %round_id,
@@ -314,6 +401,7 @@ pub fn observe_card_event(payload: &Value) {
                 "benchmark round END — every card reached a terminal state"
             );
             rounds.remove(&round_id);
+            remove_round_file_in(&rounds_state_dir(), round_id);
         }
     }
 }
@@ -411,6 +499,50 @@ mod tests {
 
     fn cards(n: usize) -> Vec<Uuid> {
         (0..n).map(|_| Uuid::new_v4()).collect()
+    }
+
+    // what this catches: the reboot amnesia measured twice on 2026-08-21 — a live
+    // round answered `rounds: []` after restart, and (silent, worse) driver_for_card
+    // fell back to DetachedSolve for a Citizen round's remaining cards, quietly
+    // rebuilding the parallel runner the round was configured to avoid. A round must
+    // round-trip its FULL deciding state: driver, card set, and which cards settled.
+    #[test]
+    fn a_round_survives_a_core_restart_with_driver_and_settles_intact() {
+        let dir = std::env::temp_dir().join(format!("bench-rounds-test-{}", Uuid::new_v4()));
+        let (id, cs) = (Uuid::new_v4(), cards(3));
+        let mut round = BenchRound::new(id, "swe-bench-lite", &cs, WorkDriver::Citizen);
+        assert!(matches!(round.settle_card(cs[0], "closed"), SettleOutcome::Settled { remaining: 2 }));
+        persist_round_in(&dir, &round);
+
+        // "reboot": reload from disk into a fresh map.
+        let reloaded = load_rounds_in(&dir);
+        let r = reloaded.get(&id).expect("in-flight round must reload");
+        assert_eq!(r.driver, WorkDriver::Citizen, "driver reverting is the silent bug");
+        assert_eq!(r.dispatched(), 3);
+        assert_eq!(r.remaining(), 2, "the settled card must stay settled across the restart");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // what this catches: the state dir growing without an eviction story (the
+    // 2026-07-13 rule). Done is terminal — its file is removed at settle, and a
+    // Done file that survives a crash window is dropped (and deleted) on reload
+    // rather than resurrected as a round no event can ever settle.
+    #[test]
+    fn done_rounds_never_reload_and_their_files_self_evict() {
+        let dir = std::env::temp_dir().join(format!("bench-rounds-test-{}", Uuid::new_v4()));
+        let (id, cs) = (Uuid::new_v4(), cards(1));
+        let mut round = BenchRound::new(id, "swe-bench-lite", &cs, WorkDriver::Citizen);
+        persist_round_in(&dir, &round);
+        assert!(matches!(round.settle_card(cs[0], "closed"), SettleOutcome::RoundDone));
+        // Crash window: the round reached Done but its file removal never ran.
+        persist_round_in(&dir, &round);
+        let reloaded = load_rounds_in(&dir);
+        assert!(reloaded.is_empty(), "a Done round must not resurrect");
+        assert!(
+            !dir.join(format!("{id}.json")).exists(),
+            "the Done file must be evicted on the reload that drops it"
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// Open a round and add its cards — the dispatch sequence, for tests that only care

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -2784,6 +2784,121 @@ mod tests {
             );
         }
 
+        // what this catches: the OTHER half of the #266 cache defect — a fixed SET of
+        // stable contributions emitting DIFFERENT bytes because salience re-ranked them.
+        //
+        // Its sibling above pins the tier split (stable before volatile). That shipped,
+        // and reuse did not follow. The sort under it read
+        // `sort_by_key(|(c, _)| u8::from(!c.stable))` with a comment calling the
+        // preserved within-tier salience order harmless. It was the bug: salience is
+        // recomputed EVERY turn, so the tier whose only job is byte-identity re-shuffled.
+        // Measured live 2026-08-21 in Atlas's flask-4045 run — consecutive prompts shared
+        // ~82% of their prefix and diverged where stable blocks traded places, costing
+        // ~306s of re-prefill per act with `cachedTokens: 0` throughout.
+        //
+        // So the tier-split assertion alone could not catch it, and this one is what
+        // makes the fix hold: SAME SET IN, SAME BYTES OUT, whatever attention ranked.
+        // If someone reverts to a salience-ordered stable tier, this fails and the
+        // sibling above still passes.
+        #[test]
+        fn stable_tier_bytes_are_identical_however_salience_ranks_them() {
+            let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
+            let faculty = LlmDeliberationFaculty::new(
+                Uuid::new_v4(),
+                "Ivar",
+                "You are Ivar.",
+                Arc::clone(&adapter),
+            );
+
+            // Same three stable blocks, built with per-turn salience + push order.
+            // These are the exact faculties that were caught trading places.
+            let render = |sal: [f32; 3], order: [usize; 3]| {
+                let bodies = [
+                    ("room-roster", "STABLE_ROSTER: alice, bob, carol present"),
+                    ("workspace-map", "STABLE_MAP: src/ tests/ docs/"),
+                    ("room-kanban", "STABLE_BOARD: you hold 9 cards here"),
+                ];
+                let mut ws = Workspace::new("teammate: what's the plan?");
+                for &i in order.iter() {
+                    ws.broadcast.push(
+                        Contribution::context(
+                            FacultyId::Custom(bodies[i].0.to_string()),
+                            bodies[i].1,
+                            sal[i],
+                            "framing",
+                        )
+                        .session_stable(),
+                    );
+                }
+                // Generous budget so all three fit — this isolates ORDER, never truncation.
+                faculty.render_assembled_context_within(&ws, 4096, (0, 0, 0, 0, 0))
+            };
+
+            let turn0 = render([0.90, 0.50, 0.30], [0, 1, 2]);
+            // Turn 1: attention completely re-ranks them, and they arrive in a new order.
+            let turn1 = render([0.30, 0.90, 0.50], [2, 0, 1]);
+            // Turn 2: a third ranking, reversed arrival.
+            let turn2 = render([0.50, 0.30, 0.90], [2, 1, 0]);
+
+            assert_eq!(
+                turn0, turn1,
+                "a re-ranked stable tier must emit IDENTICAL bytes — this is the whole \
+                 cacheable prefix (#266)\nturn0:\n{turn0}\nturn1:\n{turn1}"
+            );
+            assert_eq!(
+                turn0, turn2,
+                "third ranking must also be byte-identical\nturn0:\n{turn0}\nturn2:\n{turn2}"
+            );
+
+            // And it is CANONICAL, not merely "whatever arrived first" — an insertion-order
+            // block would satisfy the equalities above only by accident of this test's
+            // orders. Pin the actual rule so the guarantee is legible.
+            let (kanban, map, roster) = (
+                turn0.find("[room-kanban]").expect("kanban present"),
+                turn0.find("[workspace-map]").expect("map present"),
+                turn0.find("[room-roster]").expect("roster present"),
+            );
+            assert!(
+                kanban < roster && roster < map,
+                "stable tier orders canonically by faculty name (room-kanban < room-roster \
+                 < workspace-map is alphabetical; note room-roster sits between)\n{turn0}"
+            );
+
+            // The volatile tier keeps salience order ON PURPOSE (#205: most salient
+            // nearest the write point). It re-prefills by construction, so canonical
+            // ordering would buy no reuse and would cost that placement. Guard the
+            // asymmetry, so a future "make it all deterministic" pass has to read this.
+            //
+            // NOT `active-work`: it is pinned FIRST by an explicit rule ABOVE salience
+            // (the ctx_floor reservation only holds if its claimant also leads the
+            // greedy walk). Probing the asymmetry with the one salience-immune faculty
+            // reports "salience does nothing" about a tier where it does plenty —
+            // which is exactly what the first draft of this assertion did.
+            let volatile = |sal: (f32, f32)| {
+                let mut ws = Workspace::new("teammate: what's the plan?");
+                ws.broadcast.push(Contribution::context(
+                    FacultyId::Recall,
+                    "VOLATILE_RECALL: deploy was red, fixed 4pm",
+                    sal.0,
+                    "recalled",
+                ));
+                ws.broadcast.push(Contribution::context(
+                    FacultyId::Custom("affect".to_string()),
+                    "VOLATILE_AFFECT: mild time pressure",
+                    sal.1,
+                    "felt",
+                ));
+                faculty.render_assembled_context_within(&ws, 4096, (0, 0, 0, 0, 0))
+            };
+            let recall_leads = volatile((0.9, 0.2));
+            let work_leads = volatile((0.2, 0.9));
+            assert_ne!(
+                recall_leads, work_leads,
+                "the VOLATILE tier must still follow salience (#205) — if this ever \
+                 matches, canonical ordering leaked into the tier that must not have it"
+            );
+        }
+
         /// A grounding block built from a LIST of units, sized like the live work
         /// board (leads first, then one line per card).
         fn board_like(units: usize) -> Contribution {

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -1136,15 +1136,52 @@ impl LlmDeliberationFaculty {
                 );
             }
         }
-        // SERIALIZATION (by volatility): stable standing-framing FIRST (roster,
-        // doctrine, map) so it lands in the cacheable KV-prefix region adjacent to
-        // the static system prompt it resembles; volatile grounding (recall, working
-        // memory) LAST, nearest the generation point. A stable sort preserves the
-        // salience order WITHIN each tier, so attention ranking is untouched — this
-        // is a pure emit-order choice that maximizes cross-turn prefix reuse AND puts
-        // the live, actionable context closest to where the model writes. `false`
-        // (stable) sorts before `true` (volatile). See [`Contribution::stable`].
-        selected.sort_by_key(|(c, _)| u8::from(!c.stable));
+        // SERIALIZATION (by volatility, then CANONICALLY within the stable tier):
+        // stable standing-framing FIRST (roster, doctrine, map) so it lands in the
+        // cacheable KV-prefix region adjacent to the static system prompt it resembles;
+        // volatile grounding (recall, working memory) LAST, nearest the generation point.
+        //
+        // WHY THE SECOND KEY EXISTS — this tier-split alone did NOT deliver reuse.
+        // The original comment here said a stable sort "preserves the salience order
+        // WITHIN each tier, so attention ranking is untouched", and treated that as
+        // harmless. It is the remaining half of the #266 cache defect. Salience is
+        // recomputed EVERY turn, so preserving it as EMIT ORDER re-shuffles the very
+        // tier whose whole purpose is to be byte-identical across turns.
+        //
+        // Measured live 2026-08-21 in Atlas's `pallets__flask-4045` run, from her own
+        // captures: consecutive system prompts shared only ~82% of their prefix, and the
+        // divergence points were stable-tier blocks trading places —
+        // `[room-kanban]` → `[active-work]` → `[workspace-map]` at chars 8216 / 7879 /
+        // 8133. Because the system prompt is FIRST, a swap at token ~2,000 invalidates
+        // the KV for EVERYTHING after it, including a 34,000-token conversation tail.
+        // `--cache-reuse 256` was passed the whole time and every turn reported
+        // `cachedTokens: 0` — the cache was correct; we were destroying the prefix.
+        // Cost at the measured 111 tok/s prefill: ~306s of re-prefill PER ACT, growing
+        // as her conversation grows. One observed turn was 20 minutes of apparent
+        // silence that was a single 36k re-prefill.
+        //
+        // So within the stable tier, order is CANONICAL (by faculty name), not by
+        // salience. Attention ranking is genuinely untouched: salience still decides
+        // WHICH contributions are selected — that happened above, against the budget.
+        // It simply stops deciding WHERE the survivors sit, which it never needed to.
+        // Same set in, same bytes out, every turn.
+        //
+        // The volatile tier deliberately KEEPS salience order: it is re-prefilled by
+        // construction (it changes every turn), so ordering it canonically would buy no
+        // reuse and would cost the "most salient nearest the write point" placement
+        // that #205 put there on purpose.
+        //
+        // `false` (stable) sorts before `true` (volatile). See [`Contribution::stable`].
+        selected.sort_by(|(a, _), (b, _)| {
+            u8::from(!a.stable).cmp(&u8::from(!b.stable)).then_with(|| {
+                match (a.stable, b.stable) {
+                    // Stable tier: canonical, so the cacheable prefix is deterministic.
+                    (true, true) => a.faculty.as_str().cmp(b.faculty.as_str()),
+                    // Volatile tier: leave salience order alone (stable sort keeps it).
+                    _ => std::cmp::Ordering::Equal,
+                }
+            })
+        });
         let mut block = String::new();
         for (c, body) in selected {
             block.push_str("\n[");

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -2382,7 +2382,7 @@ fn metrics_from(resp: &TextGenerationResponse) -> crate::cognition::workspace::T
     // wall-clock split that lets the harness see where Metal time actually goes.
     // Absent (cloud / older endpoints) → 0, and the breakdown rows read "n/a".
     let t = resp.timing.as_ref();
-    crate::cognition::workspace::TurnMetrics {
+    let m = crate::cognition::workspace::TurnMetrics {
         input_tokens: resp.usage.input_tokens,
         output_tokens: resp.usage.output_tokens,
         latency_ms: resp.response_time_ms,
@@ -2390,7 +2390,45 @@ fn metrics_from(resp: &TextGenerationResponse) -> crate::cognition::workspace::T
         prefill_tokens: t.map(|t| t.prefill_tokens).unwrap_or(0),
         prefill_ms: t.map(|t| t.prefill_ms.round() as u64).unwrap_or(0),
         decode_ms: t.map(|t| t.decode_ms.round() as u64).unwrap_or(0),
+    };
+
+    // THE CACHE-REUSE GLASS BOX — the row whose ABSENCE cost two weeks.
+    //
+    // Every generation funnels through here, so one probe covers every turn of every
+    // citizen with no caller change. Emitted only when the lane actually reported
+    // timings (cloud/older endpoints omit them); a fabricated 0.0 hit-rate for a
+    // provider that never measured one is a lying receipt, so those stay silent.
+    //
+    // Why this did not exist and why that mattered: `delib` carried `turn.demand` and
+    // `context.render` — how big the prompt WAS — and nothing about what the lane did
+    // with it. So a prompt whose prefix we were destroying every turn looked identical
+    // in the probe stream to one served entirely from cache. The only way to see it on
+    // 2026-08-21 was hand-diffing a citizen's raw prompt captures, which is exactly the
+    // manual step a probe exists to delete.
+    //
+    // What it proves, in one row: `hit_rate` near 0 with a large `prefill_tokens` means
+    // the prefix is being invalidated upstream — measured that day at ~306s of wasted
+    // re-prefill PER ACT while `--cache-reuse 256` was set and working. After the
+    // canonical stable-tier ordering above, the same row is the verification: hit_rate
+    // should climb off the floor from the second act of a task onward, WITHOUT anyone
+    // re-reading a capture by hand.
+    if t.is_some() {
+        crate::probe!(
+            class = "delib.generate.cache",
+            cached_tokens = m.cached_tokens,
+            prefill_tokens = m.prefill_tokens,
+            // The ratio the humans and the citizens both read. 1.0 = fully warm prefix;
+            // near 0 = re-encoding the prompt every act, the inefficiency to attack.
+            hit_rate = m.cache_hit_rate(),
+            prefill_ms = m.prefill_ms,
+            decode_ms = m.decode_ms,
+            input_tokens = m.input_tokens,
+            output_tokens = m.output_tokens,
+            latency_ms = m.latency_ms,
+            "prompt cache reuse for this generation"
+        );
     }
+    m
 }
 
 #[cfg(test)]

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -34,6 +34,7 @@ pub mod bench_round;
 pub mod bench_staging;
 pub mod bench_task;
 pub mod round_readiness;
+pub mod activity;
 pub mod benchmark;
 pub mod benchmark_humaneval;
 pub mod channel_digest;

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -738,9 +738,59 @@ pub(crate) async fn run_env(
     }
 }
 
+/// One live `clone_at` per DESTINATION. Keyed by `repo_dir`, not instance — the same
+/// instance staged at two different roots is two independent jobs, while two callers
+/// aiming at ONE path are a razed tree waiting to happen (see the guard below).
+static CLONE_AT_LOCKS: std::sync::LazyLock<
+    std::sync::Mutex<
+        std::collections::HashMap<std::path::PathBuf, std::sync::Arc<tokio::sync::Mutex<()>>>,
+    >,
+> = std::sync::LazyLock::new(Default::default);
+
+fn clone_lock_for(repo_dir: &Path) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+    CLONE_AT_LOCKS
+        .lock()
+        .expect("clone-lock registry poisoned")
+        .entry(repo_dir.to_path_buf())
+        .or_default()
+        .clone()
+}
+
+/// The staging tree a fresh clone is built in before the rename commit-point.
+///
+/// Unique per INVOCATION, not per process: `cloning-{pid}` was a Node-era assumption
+/// (every clone its own process). In the headless core every clone shares ONE pid, so
+/// two concurrent stages of the same instance computed the same path and the
+/// stale-staging sweep deleted a LIVE clone mid-fetch — the 2026-08-18 grade loss
+/// (`repo.cloning-78289/.git/: No such file or directory`, sympy-18057's finished
+/// artifact voided at scoring). The per-destination lock in [`clone_at`] already
+/// serializes callers; the nonce keeps even a future unlocked path collision-free and
+/// keeps a crashed run's leftovers from ever matching a live invocation's name.
+fn staging_path_for(repo_dir: &Path) -> PathBuf {
+    static CLONE_NONCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    repo_dir.with_extension(format!(
+        "cloning-{}-{}",
+        std::process::id(),
+        CLONE_NONCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ))
+}
+
 /// Clone the repo at `base_commit`. The commit is the whole point — a clone left at HEAD is
 /// how eight runs got scored against a tree with the fix already in it.
 pub async fn clone_at(instance: &SweInstance, repo_dir: &Path) -> Result<(), String> {
+    // SERIALIZE PER DESTINATION (2026-08-21, from the 2026-08-18 grade loss). This
+    // function both REMOVES `repo_dir` at entry and razes/renames it at the commit
+    // point, and the protocol legitimately wants the same instance's tree more than
+    // once (her work tree + the pristine score tree, a lapsed-claim auto-grade racing
+    // a re-stage). Concurrent callers therefore delete each other's trees mid-use —
+    // measured: sympy-18057's FINISHED artifact died at grading with "clone from its
+    // local mirror failed: repo.cloning-78289/.git/: No such file or directory", which
+    // is caller B's stale-staging sweep removing caller A's clone WHILE git wrote into
+    // it (same pid → same staging name, see below). The tree is one resource; its
+    // builder is a critical section. tokio::Mutex (never a sync lock) because the
+    // section awaits on git subprocesses throughout.
+    let lock = clone_lock_for(repo_dir);
+    let _staged = lock.lock().await;
     // A stale tree here is not "probably fine" — it is the tree the score comes from. Removal
     // failing used to be SWALLOWED (`let _ =`), and the clone below then died on git's own
     // "destination path already exists and is not an empty directory", which reads like a
@@ -810,14 +860,20 @@ pub async fn clone_at(instance: &SweInstance, repo_dir: &Path) -> Result<(), Str
     // the receipt, from a grade voided by the harness — so close the window instead of
     // widening the diagnosis. Staging + rename also means a half-fetched tree is never
     // visible at `repo_dir`: the move is the commit point.
-    let staging = repo_dir.with_extension(format!(
-        "cloning-{}",
-        std::process::id()
-    ));
-    if staging.exists() {
-        std::fs::remove_dir_all(&staging).map_err(|e| {
-            format!("could not clear the stale staging tree {}: {e}", staging.display())
-        })?;
+    let staging = staging_path_for(repo_dir);
+    // Sweep DEAD staging trees for this destination — any `<name>.cloning-*` sibling.
+    // Under the per-destination lock nothing live matches, and a crashed run's leftovers
+    // (whose nonce-bearing names can never collide with ours) must not accumulate as
+    // unswept disk litter (the 2026-07-13 rule: no cache dir without an eviction story).
+    if let (Some(parent), Some(name)) = (repo_dir.parent(), repo_dir.file_name()) {
+        let dead_prefix = format!("{}.cloning-", name.to_string_lossy());
+        if let Ok(entries) = std::fs::read_dir(parent) {
+            for entry in entries.flatten() {
+                if entry.file_name().to_string_lossy().starts_with(&dead_prefix) {
+                    let _ = std::fs::remove_dir_all(entry.path());
+                }
+            }
+        }
     }
     let out = run(
         "git",
@@ -2816,6 +2872,49 @@ pub async fn grade(instance: &SweInstance, model_patch: Option<&str>) -> SweVerd
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the staging-collision half of the 2026-08-18 grade loss. Two
+    // concurrent stages of the same instance shared `cloning-{pid}` (one pid in the
+    // headless core), so the stale-staging sweep deleted a LIVE clone mid-fetch and
+    // sympy-18057's finished artifact died at scoring. Staging names must be unique
+    // per invocation while still carrying the sweepable `<name>.cloning-` prefix the
+    // dead-tree sweep keys on — silently changing that prefix would turn every crashed
+    // run's staging tree into permanent disk litter.
+    #[test]
+    fn staging_paths_never_collide_and_stay_sweepable() {
+        let repo = Path::new("/tmp/swe/work/sympy__sympy-18057/repo");
+        let a = staging_path_for(repo);
+        let b = staging_path_for(repo);
+        assert_ne!(a, b, "two invocations for the SAME destination must never share a tree");
+        for p in [&a, &b] {
+            let name = p.file_name().unwrap().to_string_lossy();
+            assert!(
+                name.starts_with("repo.cloning-"),
+                "staging name {name} lost the sweepable prefix — dead trees would accumulate"
+            );
+            assert_eq!(p.parent(), repo.parent(), "staging must be a sibling of its destination");
+        }
+    }
+
+    // what this catches: the serialization half of the same incident. clone_at both
+    // removes its destination at entry and razes it at the rename commit-point, so two
+    // concurrent callers for ONE destination delete each other's trees mid-use. The
+    // lock registry must hand the SAME lock to same-destination callers and different
+    // locks to different destinations (or a 300-instance sweep would serialize globally).
+    #[test]
+    fn clone_locks_are_per_destination() {
+        let a1 = clone_lock_for(Path::new("/tmp/swe/work/i-1/repo"));
+        let a2 = clone_lock_for(Path::new("/tmp/swe/work/i-1/repo"));
+        let b = clone_lock_for(Path::new("/tmp/swe/work/i-2/repo"));
+        assert!(
+            std::sync::Arc::ptr_eq(&a1, &a2),
+            "same destination must serialize on the same lock"
+        );
+        assert!(
+            !std::sync::Arc::ptr_eq(&a1, &b),
+            "different destinations must not contend"
+        );
+    }
 
     // what this catches: the path parse behind "the tests are not the solver's to touch".
     // If this under-reads, a test file the solver edited is NOT restored, and the grade either

--- a/core/continuum-core/src/inference/lane_args.rs
+++ b/core/continuum-core/src/inference/lane_args.rs
@@ -42,6 +42,44 @@
 
 use std::path::Path;
 
+/// One conversion for anything that can be a CLI argument.
+///
+/// Joel, 2026-08-21: *"Templates are underutilized by you in both cpp and rust… it
+/// reduces code size a lot sometimes."* Correct, and this is the place it pays. Without
+/// it every value is hand-converted at its call site — `total_ctx.to_string()`,
+/// `p.to_string_lossy().into_owned()`, a bare `"256".into()` — which is three different
+/// spellings of one idea and, worse, three chances to write the VALUE without its FLAG.
+/// That adjacency is exactly the class that broke serving on 2026-08-20.
+///
+/// A trait plus [`pair`] makes the flag-and-its-value a single indivisible call, so the
+/// bug becomes unrepresentable rather than merely tested for. The Rust monomorphises it
+/// the same way a C++ template would — one generic definition, zero runtime cost.
+pub trait AsArg {
+    fn as_arg(&self) -> String;
+}
+impl AsArg for &str {
+    fn as_arg(&self) -> String { (*self).to_string() }
+}
+impl AsArg for String {
+    fn as_arg(&self) -> String { self.clone() }
+}
+impl AsArg for &Path {
+    fn as_arg(&self) -> String { self.to_string_lossy().into_owned() }
+}
+impl AsArg for u16 {
+    fn as_arg(&self) -> String { self.to_string() }
+}
+impl AsArg for u32 {
+    fn as_arg(&self) -> String { self.to_string() }
+}
+
+/// Push a flag and its value together — the only way this module emits a valued flag,
+/// so a value can never be orphaned from its flag.
+fn pair<V: AsArg>(args: &mut Vec<String>, flag: &str, value: V) {
+    args.push(flag.to_string());
+    args.push(value.as_arg());
+}
+
 /// A fully-specified llama-server invocation: what to pass, and what environment to
 /// pass it in. Returned rather than applied, so it can be asserted in a test and
 /// logged on a receipt.
@@ -158,6 +196,127 @@ pub fn base_invocation(
     }
 }
 
+/// The per-lane CONDITIONAL surface — flags that depend on the model's artifacts, the
+/// governor's plan, or an operator opt-in. Slice 2 of the extraction.
+///
+/// Every field is an ALREADY-RESOLVED value, never a thing to look up. Resolution
+/// (reading `config_env`, probing the registry for an mmproj or an MTP head, deciding a
+/// placement) stays with the caller, which owns the I/O and the receipts; this module
+/// only decides what that resolution MEANS on a command line. That split is what keeps
+/// the function pure and the flags assertable — and it is the same split as
+/// `TierPolicy`: gather inputs, then compute a plan.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LaneOptions<'a> {
+    /// KV cache quantization (#232) — `Some("q8_0")` etc. `None` (or `f16` upstream)
+    /// leaves llama.cpp's f16 default, byte-identical to passing nothing.
+    pub kv_cache_type: Option<&'a str>,
+    /// Flash attention (#232), operator opt-in.
+    pub flash_attn: bool,
+    /// Multimodal projector (#106) — the model actually SEES when present.
+    pub mmproj: Option<&'a Path>,
+    /// Native MTP speculative-decode draft head (#440).
+    pub mtp_draft: Option<&'a Path>,
+    /// Device-fit resident override (#29) — an ENV var, not a flag.
+    pub resident_override: Option<&'a Path>,
+    /// CPU-pinned lane: never contend for VRAM a living lane already holds.
+    pub cpu_only: bool,
+}
+
+impl LaneInvocation {
+    /// Fold the conditional surface onto a base invocation.
+    pub fn with_options(mut self, opts: &LaneOptions<'_>) -> Self {
+        let mut push = |s: String| self.args.push(s);
+        // KV CACHE QUANTIZATION (#232, opt-in field-proven technique). f16 KV is the
+        // default; q8_0 is ~half the resident KV footprint at near-lossless quality,
+        // freeing memory the elastic window (#234) can spend on a BIGGER context or MORE
+        // warm lanes. OFF by default: not every backend/build ships Metal KV-quant
+        // kernels, so this is an operator opt-in, never a blind assumption
+        // ([[verify-real-device-numbers-not-a-clamp-premise]]). NOTE: to have the plan
+        // actually GROW the window on the freed memory (not just leave it as extra
+        // headroom), the fit math must also scale kv_per_token — that footprint coupling
+        // is the follow-up; this is the safe enablement.
+        if let Some(kv) = opts.kv_cache_type {
+            push("--cache-type-k".into());
+            push(kv.to_string());
+            push("--cache-type-v".into());
+            push(kv.to_string());
+        }
+        // FLASH ATTENTION (#232, opt-in). Fused attention is faster on BOTH prefill and
+        // decode and lowers peak memory — directly attacking prefill-bound turn latency
+        // (#139). OFF by default: Metal/backend support + quality vary by build.
+        //
+        // MUST carry an explicit VALUE. Upstream changed this from a bare boolean switch
+        // to `-fa, --flash-attn [on|off|auto]`. A bare `--flash-attn` now EATS THE NEXT
+        // ARGUMENT as its value and the server refuses to start:
+        //
+        //   error while handling argument "--flash-attn": unknown value for
+        //   --flash-attn: '--mmproj'
+        //
+        // Found 2026-08-20 the first time anyone ever set SERVING_FLASH_ATTN=1 — the flag
+        // shipped, was never exercised because it was opt-in and nobody opted in, and
+        // rotted against upstream in the meantime. The whole lane failed to spawn and
+        // serving sat at 0 lanes. An opt-in that has never once been switched on is
+        // untested code with a config-shaped trigger
+        // ([[an-absence-is-an-unfinished-measurement]]). `every_flag_that_takes_a_value_
+        // is_followed_by_one` is the regression test that class earned.
+        if opts.flash_attn {
+            push("--flash-attn".into());
+            push("on".into());
+        }
+        // MULTIMODAL PROJECTOR (#106): a vision/audio-capable model needs its mmproj GGUF
+        // so llama-server loads the encoder and can tokenize image/audio parts. Absent on
+        // a Vision-capable row the server serves TEXT only and silently ignores images,
+        // which is a capability LIE — the caller warns LOUD rather than fabricate sight
+        // ([[fallbacks-are-illegal-fail-loud]]). Safe on a generation lane (unlike
+        // `--embeddings`): the projector only adds the encoder, it does not switch the
+        // server out of causal-generation mode.
+        if let Some(p) = opts.mmproj {
+            push("--mmproj".into());
+            push(p.to_string_lossy().into_owned());
+        }
+        // NATIVE MTP SPECULATIVE DECODE (#440): an `mtp-*.gguf` draft head shipped beside
+        // the main GGUF (the ggml-org Qwen3.8 layout) loads as the spec-decode draft. MTP
+        // heads are trained WITH the model, so acceptance is high and there is no external
+        // draft model to fit: field-measured on Qwen3.8-27B (RTX 4090, 2026-08-15) decode
+        // went 40.7 → 60.1 t/s for ~0.1GB extra state. Artifact presence IS the capability
+        // signal (the mmproj pattern): no draft file → no flags → byte-identical serving.
+        // n-max 4 / p-min 0.7 are the upstream-recommended MTP operating point from that
+        // same field benchmark — per-model tuning, if ever needed, belongs on the Model
+        // row beside `sampling`, not here.
+        if let Some(d) = opts.mtp_draft {
+            push("--spec-type".into());
+            push("draft-mtp".into());
+            push("--spec-draft-model".into());
+            push(d.to_string_lossy().into_owned());
+            push("--spec-draft-n-max".into());
+            push("4".into());
+            push("--spec-draft-p-min".into());
+            push("0.7".into());
+        }
+        // Placement: CPU lanes pin every layer to RAM so they never contend for the GPU
+        // VRAM a living lane already holds (the Metal decode-time OOM that muted the
+        // eval). GPU lanes omit the flag — llama-server offloads all it can by default.
+        // [[ServingTarget::placement]] / #59 / #56.
+        if opts.cpu_only {
+            push("--n-gpu-layers".into());
+            push("0".into());
+        }
+        // Device-fit resident-override (#29): source the RESIDENT (non-expert) tensors
+        // from the precision-shrunk fit GGUF so the whole resident tier fits VRAM
+        // offloaded to GPU, while the primary GGUF streams the experts. The loader hook
+        // lazy-maps only the override's resident bytes (its experts are ignored). Set by
+        // the governor's device_fit plan when as-shipped resident overflows the VRAM
+        // budget; absent = resident fits as-shipped. [[device-fit-repeatable-primitive]].
+        //
+        // An ENV var, not a flag — which is precisely why `LaneInvocation` carries `envs`.
+        if let Some(ov) = opts.resident_override {
+            self.envs
+                .push(("LLAMA_RESIDENT_OVERRIDE".to_string(), ov.to_string_lossy().into_owned()));
+        }
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -250,5 +409,61 @@ mod tests {
     #[test]
     fn the_base_invocation_needs_no_environment() {
         assert!(inv(2, 16_384).envs.is_empty());
+    }
+
+    // what this catches: a conditional silently becoming unconditional (or vice versa).
+    // Every flag below costs memory, changes numerics, or claims a capability, so
+    // "present when it should be absent" is a real defect — the mmproj case literally
+    // decides whether a citizen can SEE.
+    #[test]
+    fn no_options_means_no_conditional_flags() {
+        let i = inv(2, 8192).with_options(&LaneOptions::default());
+        for f in ["--cache-type-k", "--flash-attn", "--mmproj", "--spec-type", "--n-gpu-layers"] {
+            assert!(!i.has(f), "{f} must be absent with default options\n{:?}", i.args);
+        }
+        assert!(i.envs.is_empty(), "no options must mean no environment");
+    }
+
+    // what this catches: THE 2026-08-20 SPAWN FAILURE, as a test instead of an outage.
+    // Upstream turned --flash-attn from a switch into one taking [on|off|auto]; the bare
+    // form ate the NEXT argument ("unknown value for --flash-attn: '--mmproj'") and the
+    // lane refused to start, so serving sat at 0 lanes. The pairing below is the exact
+    // adjacency that broke.
+    #[test]
+    fn flash_attn_carries_its_value_even_next_to_mmproj() {
+        let mm = PathBuf::from("/models/mmproj.gguf");
+        let i = inv(1, 4096).with_options(&LaneOptions {
+            flash_attn: true,
+            mmproj: Some(&mm),
+            ..Default::default()
+        });
+        assert_eq!(i.value_of("--flash-attn"), Some("on"));
+        assert_eq!(i.value_of("--mmproj"), Some("/models/mmproj.gguf"));
+    }
+
+    // what this catches: the resident override degrading into a command-line flag, or
+    // being dropped entirely. It is an ENV var read by a loader hook (#29) — the reason
+    // LaneInvocation models envs at all rather than returning a bare Vec<String>.
+    #[test]
+    fn resident_override_rides_the_environment_not_the_args() {
+        let ro = PathBuf::from("/models/fit.gguf");
+        let i = inv(1, 4096).with_options(&LaneOptions {
+            resident_override: Some(&ro),
+            ..Default::default()
+        });
+        assert_eq!(
+            i.envs,
+            vec![("LLAMA_RESIDENT_OVERRIDE".to_string(), "/models/fit.gguf".to_string())]
+        );
+        assert!(!i.args.iter().any(|a| a.contains("fit.gguf")), "must not leak into args");
+    }
+
+    // what this catches: KV quant emitting only one half of the pair. K and V are
+    // separate flags; setting one and not the other is a silent asymmetry in the cache.
+    #[test]
+    fn kv_quant_sets_both_k_and_v() {
+        let i = inv(1, 4096).with_options(&LaneOptions { kv_cache_type: Some("q8_0"), ..Default::default() });
+        assert_eq!(i.value_of("--cache-type-k"), Some("q8_0"));
+        assert_eq!(i.value_of("--cache-type-v"), Some("q8_0"));
     }
 }

--- a/core/continuum-core/src/inference/lane_args.rs
+++ b/core/continuum-core/src/inference/lane_args.rs
@@ -191,6 +191,18 @@ pub fn base_invocation(
             // surfaces the real defect: a RAG budget that overshot the served
             // window ([[fallbacks-are-illegal-fail-loud]]).
             arg("--no-context-shift"),
+            // NATIVE TOOL CALLING, unconditional. `--jinja` makes llama-server render the
+            // `tools` we send and do GRAMMAR-CONSTRAINED parsing of the model's own native
+            // tool-call format, using the model's OWN chat template — the tool-trained
+            // shape a Qwen/Hermes GGUF expects, infinitely more reliable than
+            // reverse-engineering tool calls out of prose after the fact.
+            //
+            // It is unconditional because gating it was a silent capability kill: the
+            // switch used to require a forge-written sidecar to exist, so every normally
+            // PULLED GGUF ran with tools DISABLED — the gateway ignored the `tools` param
+            // and the persona NARRATED tool calls instead of emitting them. A model with
+            // hands, holding them behind its back, because of a file that was never there.
+            arg("--jinja"),
         ],
         envs: Vec::new(),
     }
@@ -220,6 +232,18 @@ pub struct LaneOptions<'a> {
     pub resident_override: Option<&'a Path>,
     /// CPU-pinned lane: never contend for VRAM a living lane already holds.
     pub cpu_only: bool,
+    /// A forge-written `chat_template.jinja` sidecar, when one sits beside the GGUF.
+    /// OVERRIDES the embedded template — for forged GGUFs whose mlx→gguf conversion
+    /// stripped it to a thin tool-less ChatML loop (measured 2026-06-26: a 208-char
+    /// template, zero tool support, the persona's hands dead). Absent → the embedded
+    /// tool-capable template stands. Explicit override, never a silent fallback.
+    pub chat_template: Option<&'a Path>,
+    /// Trained genome layers to load into the `/lora-adapters` catalog, in index order;
+    /// the per-request `"lora":[{id,scale}]` field pages them in.
+    pub loras: &'a [std::path::PathBuf],
+    /// K3 expert paging (#278): `-ot` tensor placement for COLD layers, from the
+    /// residency planner. `None` / all-hot → no flag (llama-server rejects an empty one).
+    pub expert_ot: Option<&'a str>,
 }
 
 impl LaneInvocation {
@@ -309,6 +333,34 @@ impl LaneInvocation {
         // budget; absent = resident fits as-shipped. [[device-fit-repeatable-primitive]].
         //
         // An ENV var, not a flag — which is precisely why `LaneInvocation` carries `envs`.
+        // The sidecar template, when the forge wrote one (see `chat_template`).
+        if let Some(tpl) = opts.chat_template {
+            pair(&mut self.args, "--chat-template-file", tpl);
+        }
+        // ONE comma-separated `--lora` value. llama.cpp (b8784+) DEPRECATED repeated
+        // `--lora` flags and SILENTLY keeps only the LAST — which was collapsing every
+        // multi-layer genome stack to a single adapter. Glass-boxed 2026-07-23 in the
+        // lane's own stderr: "DEPRECATED: --lora specified multiple times... only last
+        // value will be used" x4, while a 4-layer stack was supposedly serving. The
+        // genome's whole premise is layers that STACK; this arg SHAPE is what stacks them,
+        // which is why the join lives here with the flag rather than at a call site.
+        if !opts.loras.is_empty() {
+            let joined = opts
+                .loras
+                .iter()
+                .map(|a| a.to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+                .join(",");
+            pair(&mut self.args, "--lora", joined);
+        }
+        // K3 slice-1 physical expert paging: offload COLD layers' stacked expert tensors
+        // to CPU while hot layers stay GPU-resident. Experts are stacked (one
+        // blk.N.ffn_*_exps per layer), so `-ot` — which places WHOLE tensors — pages at
+        // LAYER granularity. A change to the hot set is honored on the next relaunch (the
+        // pager decides when).
+        if let Some(ot) = opts.expert_ot {
+            pair(&mut self.args, "--override-tensor", ot);
+        }
         if let Some(ov) = opts.resident_override {
             self.envs
                 .push(("LLAMA_RESIDENT_OVERRIDE".to_string(), ov.to_string_lossy().into_owned()));

--- a/core/continuum-core/src/inference/lane_args.rs
+++ b/core/continuum-core/src/inference/lane_args.rs
@@ -1,0 +1,254 @@
+//! The llama-server INVOCATION SURFACE — the flags we hand the upstream binary.
+//!
+//! # Why this is its own module
+//!
+//! `llama_server.rs` was 4,190 lines and every concern lived in it: flag
+//! construction, readiness probing, request shaping, lifecycle, orphan reaping.
+//! This is slice 1 of the decomposition (docs/architecture/KV-CACHE-ECONOMY.md §7).
+//!
+//! Flags earn the FIRST slice because they are one of exactly two places upstream
+//! drift can reach us. We consume llama.cpp two independent ways, and only one of
+//! them touches this file:
+//!
+//! - **as a BINARY** — `llama-server` spawned as a subprocess, spoken to over HTTP.
+//!   Zero linkage. Upstream drift arrives as a changed CLI surface (here) or a
+//!   changed JSON shape (the request/readiness modules). That is this module's
+//!   whole exposure.
+//! - **as a LIBRARY** — the `llama` crate links libllama in-process for the forge
+//!   and conversion paths. That is where our fork's C++ lives (K3 KDA kernel,
+//!   AttnRes, MoE gather). It never passes through here.
+//!
+//! So a fork rebase should touch this file and the wire shapes, and nothing else.
+//! It could not, while the flags were welded into a `Command` chain inside a 4k-line
+//! file with no way to assert them without launching a real GPU process.
+//!
+//! # The invocation is DATA, not a side effect
+//!
+//! [`base_invocation`] is pure: primitives in, [`LaneInvocation`] out. No `Command`,
+//! no process, no I/O. That is what lets the arithmetic below be unit-tested on a
+//! machine with no GPU and no model — and the arithmetic is exactly where the
+//! expensive bug was (see `-c` / `--parallel`, below).
+//!
+//! It also matches the policy shape the rest of the serving stack already uses:
+//! `TierPolicy::plan` returns a plan rather than applying one, so decisions can be
+//! logged, replayed and diffed. An invocation is the same kind of object.
+//!
+//! # The comments are the incident record — they travel WITH their flag
+//!
+//! Every value here was set by a specific failure. The comment beside it is the only
+//! surviving account of that failure, so moving a flag without its comment destroys
+//! the reason and invites the reversion. They are copied verbatim from
+//! `llama_server.rs`, not paraphrased.
+
+use std::path::Path;
+
+/// A fully-specified llama-server invocation: what to pass, and what environment to
+/// pass it in. Returned rather than applied, so it can be asserted in a test and
+/// logged on a receipt.
+///
+/// `envs` exists because the invocation is genuinely not args-only —
+/// `LLAMA_RESIDENT_OVERRIDE` (device-fit, #29) is an environment variable read by a
+/// loader hook. Modelling it as "args plus a side effect someone remembers to apply"
+/// is how it would get dropped by the next caller.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LaneInvocation {
+    /// Positional CLI arguments, in order.
+    pub args: Vec<String>,
+    /// Environment variables the child must be spawned with, as `(key, value)`.
+    pub envs: Vec<(String, String)>,
+}
+
+impl LaneInvocation {
+    /// Value of the flag named `flag`, if present — i.e. the argument that follows
+    /// it. Test-facing convenience so assertions read as intent
+    /// (`inv.value_of("--parallel")`) rather than as index arithmetic, which is its
+    /// own source of wrong-but-passing tests.
+    pub fn value_of(&self, flag: &str) -> Option<&str> {
+        let at = self.args.iter().position(|a| a == flag)?;
+        self.args.get(at + 1).map(String::as_str)
+    }
+
+    /// Whether a valueless switch is present.
+    pub fn has(&self, flag: &str) -> bool {
+        self.args.iter().any(|a| a == flag)
+    }
+}
+
+/// The flags EVERY generation lane carries, regardless of model or placement.
+///
+/// Conditional flags (KV quant, flash-attn, mmproj, MTP draft, resident override,
+/// CPU placement, jinja template, LoRA set, MoE `-ot` overrides) are still assembled
+/// by the caller and are slice 2 of this extraction. They are conditional on model
+/// artifacts and operator config; this function is the unconditional spine, which is
+/// also the part carrying the arithmetic worth pinning.
+pub fn base_invocation(
+    gguf: &Path,
+    model_id: &str,
+    host: &str,
+    port: u16,
+    lanes: u32,
+    total_ctx: u32,
+) -> LaneInvocation {
+    let arg = |s: &str| s.to_string();
+    LaneInvocation {
+        args: vec![
+            arg("-m"),
+            gguf.to_string_lossy().into_owned(),
+            arg("--alias"),
+            model_id.to_string(),
+            arg("--host"),
+            host.to_string(),
+            arg("--port"),
+            port.to_string(),
+            // llama-server's `-c` is the TOTAL KV cache, split evenly across the
+            // `--parallel` slots; each request only sees `-c / n_parallel` tokens.
+            // The plan's `context_window` is PER-LANE, so the total we must request
+            // is `context_window * lanes` — then each of `lanes` slots holds exactly
+            // one planned window. We pass `--parallel` EXPLICITLY (never inherit
+            // llama.cpp's default, which is 4 and silently quartered the window in
+            // the prior bug). See `served_total_ctx` / `parallel_lanes`.
+            arg("-c"),
+            total_ctx.to_string(),
+            arg("--parallel"),
+            lanes.to_string(),
+            // KV PREFIX REUSE across a persona's turns. `cache_prompt:true` (sent
+            // per-request) only reuses a slot's prior content when the *exact*
+            // prefix still sits in that slot; with the volatile grounding tail
+            // changing every turn and embedding requests sharing these same slots,
+            // measured cross-turn reuse was ZERO (`cachedTokens: 0` over every
+            // captured live turn, forcing a full re-prefill of the static
+            // identity/doctrine/tool prefix each turn). `--cache-reuse` lets
+            // llama.cpp reuse cached chunks >= N tokens via KV shifting even when a
+            // later span differs — so the stable prefix is kept, not recomputed. 256
+            // is the llama.cpp-recommended min chunk. This is a pure optimization
+            // flag: absent it we just re-prefill (correct, slow); present it we reuse
+            // (correct, fast) — no fallback, no behavior change.
+            //
+            // 2026-08-21 POSTSCRIPT, and it matters for anyone tempted to tune this
+            // number: the flag was never the defect. It was set the whole time reuse
+            // measured 0%, because WE were mutating our own system prompt at token
+            // ~2,000 (salience re-ordering the stable tier) and invalidating the
+            // 34k-token tail behind it. Fixed by canonical ordering in
+            // `llm_deliberation_faculty`, not by touching this value.
+            arg("--cache-reuse"),
+            arg("256"),
+            // PREFILL THROUGHPUT (#139). Live personas are prefill-bound: a real turn
+            // re-prefills ~4k tokens of fresh RAG context at ~109 tok/s → 30-110s turns
+            // (decode is tiny and fast; the mind is NOT slow, the re-read is). The
+            // physical micro-batch (`--ubatch-size`, llama.cpp default 512) is how many
+            // prompt tokens Metal processes per compute pass — bigger batch = more
+            // parallel prefill = higher tok/s, traded against a larger per-slot compute
+            // buffer. 1024 doubles prefill parallelism; the compute-buffer growth is the
+            // same axis that OOMs (kIOGPUCommandBufferCallbackErrorOutOfMemory) so it is
+            // sized WITH the 2-lane headroom, not blindly. Measured knob: watch prefill
+            // tok/s in the captures and back off if the lane 500s "Compute error".
+            arg("--ubatch-size"),
+            arg("1024"),
+            // Overflow must FAIL, never silently amputate. With context shift on
+            // (the llama.cpp default), a prompt larger than the slot's window has
+            // its MIDDLE evicted and generation proceeds on the mutilated prompt —
+            // exam-corrupting amnesia no log line reports (#139: 44k-token prompts
+            // observed riding ~13.4k slots with no error anywhere). Disabled, the
+            // server 400s ("exceeds context size") and the caller's fail-loud path
+            // surfaces the real defect: a RAG budget that overshot the served
+            // window ([[fallbacks-are-illegal-fail-loud]]).
+            arg("--no-context-shift"),
+        ],
+        envs: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn inv(lanes: u32, total_ctx: u32) -> LaneInvocation {
+        base_invocation(
+            &PathBuf::from("/models/m.gguf"),
+            "qwen3-coder",
+            "127.0.0.1",
+            58057,
+            lanes,
+            total_ctx,
+        )
+    }
+
+    // what this catches: the window-quartering regression — `--parallel` inherited
+    // llama.cpp's default of 4 while `-c` was passed as a per-lane window, so every
+    // slot silently served a QUARTER of the planned context. Nothing failed; citizens
+    // were just quietly given 1/4 of their window.
+    //
+    // This is the whole reason flags became data. The arithmetic was previously
+    // welded into a `Command` chain, so asserting it meant launching a real
+    // llama-server on a real GPU with a real model — which no unit test does, which
+    // is why it went unnoticed. Now it is a pure function and this is three lines.
+    #[test]
+    fn parallel_is_explicit_and_total_ctx_is_the_per_lane_window_times_lanes() {
+        let i = inv(2, 32_768);
+        assert_eq!(
+            i.value_of("--parallel"),
+            Some("2"),
+            "--parallel must be passed EXPLICITLY — inheriting llama.cpp's default of \
+             4 is the bug that quartered every citizen's window\n{:?}",
+            i.args
+        );
+        assert_eq!(
+            i.value_of("-c"),
+            Some("32768"),
+            "-c is the TOTAL KV across slots (per-lane window x lanes), not the \
+             per-lane window\n{:?}",
+            i.args
+        );
+    }
+
+    // what this catches: a "cheap" future edit re-enabling context shift, which does
+    // not fail — it silently evicts the MIDDLE of an over-long prompt and generates
+    // from the mutilation. #139: 44k-token prompts observed riding ~13.4k slots with
+    // no error anywhere. Overflow must 400, so the caller's fail-loud path can report
+    // the real defect (a RAG budget that overshot the window).
+    #[test]
+    fn context_shift_stays_disabled_on_every_lane() {
+        assert!(
+            inv(1, 4096).has("--no-context-shift"),
+            "overflow must FAIL loudly, never amputate the prompt middle"
+        );
+    }
+
+    // what this catches: dropping --cache-reuse while "cleaning up flags", which
+    // costs a full re-prefill per turn and shows up only as latency. It was measured
+    // at ~306s per act on a 36k conversation before the #266 ordering fix.
+    #[test]
+    fn cache_reuse_is_configured_for_prefix_reuse() {
+        assert_eq!(inv(1, 4096).value_of("--cache-reuse"), Some("256"));
+    }
+
+    // what this catches: flag/value pairs drifting out of adjacency. Upstream turned
+    // `--flash-attn` from a bare switch into one taking [on|off|auto] on 2026-08-20,
+    // and the bare form then ATE THE NEXT ARGUMENT ("unknown value for --flash-attn:
+    // '--mmproj'") — the lane failed to spawn and serving sat at 0. Any invocation
+    // this module builds must be an even, well-formed sequence.
+    #[test]
+    fn every_flag_that_takes_a_value_is_followed_by_one() {
+        let i = inv(4, 65_536);
+        for flag in ["-m", "--alias", "--host", "--port", "-c", "--parallel", "--cache-reuse", "--ubatch-size"] {
+            let v = i.value_of(flag);
+            assert!(
+                v.is_some_and(|v| !v.starts_with("--")),
+                "{flag} must be followed by its VALUE, not by another flag \
+                 (upstream's --flash-attn change is how this class breaks)\n{:?}",
+                i.args
+            );
+        }
+    }
+
+    // what this catches: the base invocation quietly acquiring an env dependency.
+    // Envs are spawn-time state that a caller must remember to apply; the conditional
+    // one we DO have (LLAMA_RESIDENT_OVERRIDE, #29) is why `envs` exists on the
+    // struct at all. If a base env ever appears, it must be a deliberate edit here
+    // with its own justification, not a drive-by.
+    #[test]
+    fn the_base_invocation_needs_no_environment() {
+        assert!(inv(2, 16_384).envs.is_empty());
+    }
+}

--- a/core/continuum-core/src/inference/lane_health.rs
+++ b/core/continuum-core/src/inference/lane_health.rs
@@ -1,0 +1,240 @@
+//! Per-slot throughput verdict — the sensor that was missing on 2026-08-21.
+//!
+//! # The defect this exists for, measured live
+//!
+//! A citizen (`e5f4141d`) was working `pallets__flask-4045` in-room. Her run reported
+//! `state: running`, heartbeated every minute, and sat at `acts: 4` for twelve minutes.
+//! The lane answered `/health` `{"status":"ok"}`, `/props` 200, `/v1/models` 200, port
+//! bound, process up 3h58m. Every readiness signal in the system said healthy.
+//!
+//! The lane's own per-slot numbers said otherwise:
+//!
+//! ```text
+//! slot 1 | task 3   | n_decoded = 1092, tg = 2.65 t/s, tg_3s = 0.96 t/s
+//! slot 1 | task 3   | n_decoded = 1093, tg = 2.53 t/s, tg_3s = 0.05 t/s
+//! slot 0 | task 605 | prompt processing, progress 0.52, 105 t/s
+//! ```
+//!
+//! **Slot 1 was decoding at 0.05 tokens/second** — one token per twenty seconds — while
+//! still holding `task 3` after six hundred tasks had gone by on the neighbouring slot.
+//! Prefill was healthy (105 t/s, the expected rate). Only DECODE had collapsed, on ONE
+//! slot, and nothing in the system could see it.
+//!
+//! That is the #386 per-slot wedge, and it is the round-killer: a citizen whose
+//! generation runs at 1/600th speed burns her whole attempt deadline producing nothing,
+//! while the board renders a healthy pulse the entire time.
+//!
+//! # Why a whole-lane health check cannot catch it
+//!
+//! `/health` is lane-scoped and the LANE is fine — the other slot decodes normally, so
+//! any aggregate reads healthy. #363 already established that readiness must verify
+//! GENERATION rather than the socket; this is the next layer down: **generation must be
+//! verified PER SLOT, because a lane is healthy exactly as long as its best slot is.**
+//!
+//! # Why the floor is a PARAMETER
+//!
+//! `expected_tps` is passed in, never baked here. What counts as collapsed depends on the
+//! model and the device — a 27B on Metal and a 4B on a 5090 have different honest floors,
+//! and the catalog Model row is where that expectation lives (#441). A constant here
+//! would be a hardcoded LCD clamp of exactly the kind the substrate docs forbid, and it
+//! would either miss a real wedge on a fast box or cry wolf on a slow one.
+//!
+//! # Instrument note
+//!
+//! The numbers above were read out of llama-server's stderr BY HAND, which is the only
+//! way they were visible — and that is itself the defect Joel named the same day:
+//! *"STDERR/out is never a place for interfacing, just debug."* Reading a log to DIAGNOSE
+//! is correct; a control path may never depend on it. This module is deliberately pure
+//! and takes [`SlotObservation`] values, so it works the moment those values arrive from
+//! a structured channel (`/slots`, which currently returns HTTP 000 on our pinned build
+//! and is the follow-up). The verdict logic must not wait on the transport.
+
+/// One slot's throughput, as observed at a point in time.
+///
+/// Field names mirror what llama-server reports so the eventual `/slots` mapping is
+/// obvious, but this type is transport-agnostic ON PURPOSE — see the module note.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SlotObservation {
+    /// Slot index within the lane.
+    pub id: u32,
+    /// The task currently occupying the slot.
+    pub task_id: u64,
+    /// Tokens decoded so far for this task.
+    pub n_decoded: u64,
+    /// Average decode rate over the task's life, tokens/sec.
+    pub decode_tps: f32,
+    /// Decode rate over the last ~3 seconds, tokens/sec. The LEADING indicator: a slot
+    /// that just fell over still has a healthy lifetime average for a long while.
+    pub decode_tps_3s: f32,
+}
+
+/// What the slot is actually doing, as opposed to what the lane claims.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SlotVerdict {
+    /// Decoding at or near the expected rate.
+    Healthy,
+    /// Measurably slow but still progressing — worth a probe, not a reap. Contention and
+    /// thermal throttling live here, and both recover on their own.
+    Degraded { ratio: f32 },
+    /// Effectively stopped. Progress is nominal rather than real: the slot will not
+    /// finish this task in any useful time, so the run should be told rather than left
+    /// to burn its deadline.
+    Wedged { ratio: f32 },
+}
+
+impl SlotVerdict {
+    /// Does this verdict warrant interrupting a run? `Wedged` only — `Degraded` is a
+    /// report. Acting on `Degraded` would reap lanes that are merely busy, which is how
+    /// a health check becomes the outage (#446: starvation stamped as wedge evidence,
+    /// producing a 2-minute relaunch loop).
+    pub fn is_actionable(&self) -> bool {
+        matches!(self, SlotVerdict::Wedged { .. })
+    }
+}
+
+/// Fraction of expected throughput below which a slot is DEGRADED rather than healthy.
+/// Above this, normal variance: batching, contention, a long prompt landing.
+const DEGRADED_BELOW: f32 = 0.5;
+
+/// Fraction below which the slot is WEDGED. 5% of expected is not "slow" — at the
+/// measured 0.05 t/s against a ~30 t/s expectation (0.0017) a 500-token answer takes
+/// nearly three hours, which is longer than the attempt deadline it is spending.
+const WEDGED_BELOW: f32 = 0.05;
+
+/// Minimum decoded tokens before a rate is trusted. A slot that has just started has a
+/// meaningless average, and calling it wedged would reap every cold generation — the
+/// [[an-absence-is-an-unfinished-measurement]] error in actuator form.
+const MIN_DECODED_FOR_VERDICT: u64 = 32;
+
+/// Classify one slot against the throughput its model/device is expected to deliver.
+///
+/// Uses the 3-SECOND rate, not the lifetime average, because the lifetime average hides
+/// a collapse for a long time: the live slot read `tg = 2.53` (already bad) while
+/// `tg_3s = 0.05` (catastrophic). Averaged over a task that has been running for hours,
+/// a dead slot still looks merely slow.
+pub fn classify(obs: &SlotObservation, expected_tps: f32) -> SlotVerdict {
+    // No expectation, no verdict. A catalog row without a measured rate must not be
+    // silently assigned one — that would make the sensor fabricate its own threshold.
+    if expected_tps <= 0.0 || obs.n_decoded < MIN_DECODED_FOR_VERDICT {
+        return SlotVerdict::Healthy;
+    }
+    let ratio = obs.decode_tps_3s / expected_tps;
+    if ratio < WEDGED_BELOW {
+        SlotVerdict::Wedged { ratio }
+    } else if ratio < DEGRADED_BELOW {
+        SlotVerdict::Degraded { ratio }
+    } else {
+        SlotVerdict::Healthy
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The live slot 1 reading from 2026-08-21, verbatim.
+    fn wedged_slot_from_the_live_incident() -> SlotObservation {
+        SlotObservation {
+            id: 1,
+            task_id: 3,
+            n_decoded: 1093,
+            decode_tps: 2.53,
+            decode_tps_3s: 0.05,
+        }
+    }
+
+    // what this catches: THE ROUND-KILLER, as a test instead of a twelve-minute mystery.
+    // Measured live — citizen e5f4141d on pallets__flask-4045, lane reporting /health ok
+    // the whole time, acts frozen at 4. If this ever returns anything but Wedged, a
+    // citizen can again burn a 4.3h attempt deadline at one token per twenty seconds
+    // with every dashboard green.
+    #[test]
+    fn the_live_wedge_is_classified_wedged() {
+        let v = classify(&wedged_slot_from_the_live_incident(), 30.0);
+        assert!(
+            matches!(v, SlotVerdict::Wedged { .. }),
+            "0.05 t/s against a 30 t/s expectation must read WEDGED, got {v:?}"
+        );
+        assert!(v.is_actionable(), "a wedge must be actionable — that is the point");
+    }
+
+    // what this catches: the lifetime average masking a collapse. The SAME slot's
+    // lifetime figure (2.53 t/s) is 50x its instantaneous rate; classifying on the
+    // average would have called this merely Degraded and left her running.
+    #[test]
+    fn the_lifetime_average_would_have_missed_it() {
+        let obs = wedged_slot_from_the_live_incident();
+        let on_lifetime = classify(
+            &SlotObservation { decode_tps_3s: obs.decode_tps, ..obs },
+            30.0,
+        );
+        assert!(
+            !matches!(on_lifetime, SlotVerdict::Wedged { .. }),
+            "the lifetime average hides the collapse — which is WHY classify() reads \
+             the 3s rate. If this ever becomes Wedged the constants moved and the \
+             leading-indicator argument needs rechecking, not the assert flipping."
+        );
+    }
+
+    // what this catches: reaping a healthy-but-busy slot. #446 — starvation stamped as
+    // wedge evidence produced a 2-minute relaunch loop that WAS the outage. Slow is a
+    // report; stopped is an action.
+    #[test]
+    fn merely_slow_is_reported_not_actioned() {
+        let obs = SlotObservation {
+            id: 0,
+            task_id: 605,
+            n_decoded: 400,
+            decode_tps: 12.0,
+            decode_tps_3s: 9.0, // 30% of expected — contention, not death
+        };
+        let v = classify(&obs, 30.0);
+        assert!(matches!(v, SlotVerdict::Degraded { .. }), "got {v:?}");
+        assert!(!v.is_actionable(), "Degraded must never reap a lane");
+    }
+
+    // what this catches: killing cold generations. A slot 8 tokens into a reply has a
+    // meaningless rate; a verdict there is the absence-as-fact error wired to an
+    // actuator.
+    #[test]
+    fn a_slot_that_just_started_is_never_wedged() {
+        let obs = SlotObservation {
+            id: 2,
+            task_id: 900,
+            n_decoded: 8,
+            decode_tps: 0.4,
+            decode_tps_3s: 0.4,
+        };
+        assert_eq!(classify(&obs, 30.0), SlotVerdict::Healthy);
+    }
+
+    // what this catches: the sensor inventing its own floor. A catalog row with no
+    // measured expectation must yield NO verdict — never a fabricated threshold, and
+    // never a hardcoded LCD clamp (the substrate docs' standing prohibition).
+    #[test]
+    fn no_expectation_means_no_verdict() {
+        assert_eq!(
+            classify(&wedged_slot_from_the_live_incident(), 0.0),
+            SlotVerdict::Healthy,
+            "without a per-model expectation the sensor must abstain, not guess"
+        );
+    }
+
+    // what this catches: a fast box being judged by a slow box's standard, and vice
+    // versa. The SAME observation is healthy or wedged depending on what the device was
+    // expected to deliver — which is exactly why expected_tps is a parameter.
+    #[test]
+    fn the_verdict_follows_the_devices_own_expectation() {
+        let obs = SlotObservation {
+            id: 0,
+            task_id: 1,
+            n_decoded: 500,
+            decode_tps: 2.0,
+            decode_tps_3s: 2.0,
+        };
+        // A 2 t/s slot on a box expected to do 2.5 t/s (big model, modest hardware): fine.
+        assert_eq!(classify(&obs, 2.5), SlotVerdict::Healthy);
+        // The same 2 t/s on a 5090 expected to do 60: dead.
+        assert!(matches!(classify(&obs, 60.0), SlotVerdict::Wedged { .. }));
+    }
+}

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -2573,57 +2573,29 @@ impl LlamaServerControl for LlamaServerProcess {
         // the prior bug). See `served_total_ctx` / `parallel_lanes`.
         let lanes = target.parallel_lanes();
         let total_ctx = target.served_total_ctx();
+        // The unconditional flag spine moved to `lane_args` (decomposition slice 1,
+        // docs/architecture/KV-CACHE-ECONOMY.md §7). It lives there because it is PURE
+        // there — primitives in, an invocation out — and therefore assertable without
+        // spawning a GPU process. From HERE it never could be, which is exactly how
+        // `--parallel` silently quartered every citizen's window: the arithmetic was
+        // welded into a Command chain no unit test could reach. Every flag's incident
+        // comment moved WITH it; that comment is the only record of the failure that
+        // set the value.
         let mut cmd = tokio::process::Command::new(&self.bin);
-        cmd.arg("-m")
-            .arg(&gguf)
-            .arg("--alias")
-            .arg(&target.model.id)
-            .arg("--host")
-            .arg(host)
-            .arg("--port")
-            .arg(port.to_string())
-            // Total KV = per-lane window × lanes; split back to one full window
-            // per slot by `--parallel` below. The plan budgeted this exact total
-            // (`kv_at(context_window) * lanes`) against the host, so it fits.
-            .arg("-c")
-            .arg(total_ctx.to_string())
-            .arg("--parallel")
-            .arg(lanes.to_string())
-            // KV PREFIX REUSE across a persona's turns. `cache_prompt:true` (sent
-            // per-request) only reuses a slot's prior content when the *exact*
-            // prefix still sits in that slot; with the volatile grounding tail
-            // changing every turn and embedding requests sharing these same slots,
-            // measured cross-turn reuse was ZERO (`cachedTokens: 0` over every
-            // captured live turn, forcing a full re-prefill of the ~720-token
-            // static identity/doctrine/tool prefix each turn). `--cache-reuse`
-            // lets llama.cpp reuse cached chunks ≥ N tokens via KV shifting even
-            // when a later span differs — so the stable prefix is kept, not
-            // recomputed. 256 is the llama.cpp-recommended min chunk. This is a
-            // pure optimization flag: absent it we just re-prefill (correct, slow);
-            // present it we reuse (correct, fast) — no fallback, no behavior change.
-            .arg("--cache-reuse")
-            .arg("256")
-            // PREFILL THROUGHPUT (#139). Live personas are prefill-bound: a real turn
-            // re-prefills ~4k tokens of fresh RAG context at ~109 tok/s → 30–110s turns
-            // (decode is tiny and fast; the mind is NOT slow, the re-read is). The
-            // physical micro-batch (`--ubatch-size`, llama.cpp default 512) is how many
-            // prompt tokens Metal processes per compute pass — bigger batch = more
-            // parallel prefill = higher tok/s, traded against a larger per-slot compute
-            // buffer. 1024 doubles prefill parallelism; the compute-buffer growth is the
-            // same axis that OOMs (kIOGPUCommandBufferCallbackErrorOutOfMemory) so it is
-            // sized WITH the 2-lane headroom, not blindly. Measured knob: watch prefill
-            // tok/s in the captures and back off if the lane 500s "Compute error".
-            .arg("--ubatch-size")
-            .arg("1024")
-            // Overflow must FAIL, never silently amputate. With context shift on
-            // (the llama.cpp default), a prompt larger than the slot's window has
-            // its MIDDLE evicted and generation proceeds on the mutilated prompt —
-            // exam-corrupting amnesia no log line reports (#139: 44k-token prompts
-            // observed riding ~13.4k slots with no error anywhere). Disabled, the
-            // server 400s ("exceeds context size") and the caller's fail-loud path
-            // surfaces the real defect: a RAG budget that overshot the served
-            // window ([[fallbacks-are-illegal-fail-loud]]).
-            .arg("--no-context-shift");
+        let base = crate::inference::lane_args::base_invocation(
+            &gguf,
+            &target.model.id,
+            &host,
+            port,
+            lanes,
+            total_ctx,
+        );
+        for a in &base.args {
+            cmd.arg(a);
+        }
+        for (k, v) in &base.envs {
+            cmd.env(k, v);
+        }
         // KV CACHE QUANTIZATION (#232, opt-in field-proven technique). f16 KV is the
         // default; q8_0 is ~half the resident KV footprint at near-lossless quality,
         // freeing memory the elastic window (#234) can spend on a BIGGER context or MORE

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -2612,6 +2612,16 @@ impl LlamaServerControl for LlamaServerProcess {
         }
         let mtp_draft = crate::model_registry::artifacts::resolve_mtp_draft_for_model(&target.model);
 
+        // Slice-3 resolution, same rule as above: look things up HERE, let `lane_args`
+        // decide what they mean on a command line.
+        let chat_template = gguf
+            .parent()
+            .map(|d| d.join("chat_template.jinja"))
+            .filter(|p| p.is_file());
+        let lora_paths: Vec<std::path::PathBuf> =
+            target.adapters.iter().map(|a| a.path.clone()).collect();
+        let expert_ot = target.expert_ot_value();
+
         let mut cmd = tokio::process::Command::new(&self.bin);
         let invocation = crate::inference::lane_args::base_invocation(
             &gguf,
@@ -2628,72 +2638,15 @@ impl LlamaServerControl for LlamaServerProcess {
             mtp_draft: mtp_draft.as_deref(),
             resident_override: target.resident_override.as_deref(),
             cpu_only: target.placement == LanePlacement::Cpu,
+            chat_template: chat_template.as_deref(),
+            loras: &lora_paths,
+            expert_ot: expert_ot.as_deref(),
         });
         for a in &invocation.args {
             cmd.arg(a);
         }
         for (k, v) in &invocation.envs {
             cmd.env(k, v);
-        }
-        // Native tool-calling needs the model's TOOL-CAPABLE chat template. The
-        // mlx→gguf conversion can strip the embedded template down to a bare
-        // ChatML loop (no `<tools>`/`<tool_call>` rendering) — which silently
-        // disables native function-calling, so the gateway ignores the `tools`
-        // param and the persona's hands go dead (verified live 2026-06-26: the
-        // forged GGUF carried a 208-char template, zero tool support). When the
-        // forge writes a `chat_template.jinja` sidecar next to the GGUF, hand it
-        // to llama-server with --jinja so it renders tools and does
-        // grammar-constrained native tool calls — VALID tool-call JSON guaranteed
-        // by the sampler, not hand-escaped by a 4B model into a JSON string (the
-        // failure that made multi-line code calls unparseable). This is an
-        // explicit override file, not a silent fallback: present → it's the
-        // truth the GGUF should have carried; absent → the embedded template
-        // stands.
-        // --jinja is UNCONDITIONAL: it makes llama-server render the `tools` we send and do
-        // grammar-constrained parsing of the model's NATIVE tool-call format, using the
-        // model's OWN chat template. That is the tool-trained shape a Qwen/Hermes/etc GGUF
-        // expects — infinitely more reliable than us reverse-engineering tool calls out of
-        // prose after the fact. A normal pulled GGUF carries a tool-capable embedded template;
-        // this switch was previously gated on a forge sidecar existing, so pulled models
-        // silently ran with tools DISABLED (the gateway ignored the `tools` param → the
-        // persona narrated tool calls instead of emitting them). The sidecar, when the forge
-        // wrote one, now OVERRIDES the embedded template (for forged GGUFs that shipped a
-        // thin, tool-less 208-char template) — present → override, absent → the embedded
-        // tool-capable template stands, tools ON either way.
-        cmd.arg("--jinja");
-        if let Some(tpl) = gguf
-            .parent()
-            .map(|d| d.join("chat_template.jinja"))
-            .filter(|p| p.is_file())
-        {
-            cmd.arg("--chat-template-file").arg(tpl);
-        }
-        // Load each trained genome layer into the `/lora-adapters` catalog at
-        // index order; the per-request `"lora":[{id,scale}]` field pages them in.
-        // ONE comma-separated `--lora` value: llama.cpp (b8784+) deprecated
-        // repeated `--lora` flags and SILENTLY keeps only the last — which was
-        // collapsing every multi-layer genome stack to a single adapter
-        // (glass-boxed 2026-07-23 in the lane's own stderr: 'DEPRECATED:
-        // --lora specified multiple times... only last value will be used' ×4
-        // while a 4-layer stack served). The genome's whole premise is layers
-        // that STACK; this arg shape is what actually stacks them.
-        if !target.adapters.is_empty() {
-            let joined = target
-                .adapters
-                .iter()
-                .map(|a| a.path.to_string_lossy().into_owned())
-                .collect::<Vec<_>>()
-                .join(",");
-            cmd.arg("--lora").arg(joined);
-        }
-        // K3 slice-1 physical expert paging: if the residency planner handed us a layer
-        // placement, offload the COLD layers' stacked expert tensors to CPU via -ot, keeping
-        // the hot layers GPU-resident. Experts are stacked (one blk.N.ffn_*_exps tensor per
-        // layer), so -ot — which places whole tensors — pages at LAYER granularity. None /
-        // all-hot → no flag (an empty -ot is rejected by llama-server). A change to the hot
-        // set is honored on the next relaunch (the pager decides when).
-        if let Some(ot) = target.expert_ot_value() {
-            cmd.arg("--override-tensor").arg(ot);
         }
         // MoE glass-box env seam (#278): when expert paging is active, the DAEMON
         // hands the fork its capture + plan file locations. Previously these envs

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -2581,82 +2581,26 @@ impl LlamaServerControl for LlamaServerProcess {
         // welded into a Command chain no unit test could reach. Every flag's incident
         // comment moved WITH it; that comment is the only record of the failure that
         // set the value.
-        let mut cmd = tokio::process::Command::new(&self.bin);
-        let base = crate::inference::lane_args::base_invocation(
-            &gguf,
-            &target.model.id,
-            &host,
-            port,
-            lanes,
-            total_ctx,
-        );
-        for a in &base.args {
-            cmd.arg(a);
-        }
-        for (k, v) in &base.envs {
-            cmd.env(k, v);
-        }
-        // KV CACHE QUANTIZATION (#232, opt-in field-proven technique). f16 KV is the
-        // default; q8_0 is ~half the resident KV footprint at near-lossless quality,
-        // freeing memory the elastic window (#234) can spend on a BIGGER context or MORE
-        // warm lanes — faster for multiple personas AND more room for hard coding.
-        // OFF by default: not every backend/build ships Metal KV-quant kernels, so this
-        // is an operator opt-in, never a blind assumption ([[verify-real-device-numbers-not-a-clamp-premise]]).
-        // Set SERVING_KV_CACHE_TYPE=q8_0 (or q4_0) to enable; absent / `f16` → byte-identical
-        // f16 behavior. NOTE: to have the plan actually GROW the window on the freed memory
-        // (not just leave it as extra headroom), the fit math must also scale kv_per_token —
-        // that footprint coupling is the follow-up; this slice is the safe enablement.
-        if let Some(kv_type) = crate::config_env::read("SERVING_KV_CACHE_TYPE")
+        // Resolution stays HERE (config_env reads, registry probes, the vision receipt);
+        // `lane_args` decides only what a resolved value MEANS on a command line. That is
+        // the split that keeps the flag surface pure and assertable — gather inputs, then
+        // compute a plan, exactly as `TierPolicy` does.
+        let kv_cache_type = crate::config_env::read("SERVING_KV_CACHE_TYPE")
             .map(|s| s.trim().to_ascii_lowercase())
-            .filter(|s| !s.is_empty() && s != "f16")
-        {
-            cmd.arg("--cache-type-k")
-                .arg(&kv_type)
-                .arg("--cache-type-v")
-                .arg(&kv_type);
-        }
-        // FLASH ATTENTION (#232, opt-in field-proven technique). The fused attention kernel
-        // is faster on BOTH prefill and decode and lowers peak memory — directly attacking
-        // the prefill-bound turn latency (#139) and freeing room the elastic window (#234)
-        // can spend. OFF by default: Metal/backend flash-attn support + quality vary by build
-        // ([[verify-real-device-numbers-not-a-clamp-premise]]), so it's an operator opt-in,
-        // never a blind assumption. SERVING_FLASH_ATTN=1|on|true → enable; absent → llama.cpp
-        // default (no flag), byte-identical.
-        // MUST carry an explicit VALUE. Upstream llama.cpp changed this from a bare
-        // boolean switch to `-fa, --flash-attn [on|off|auto]`. A bare `--flash-attn`
-        // now EATS THE NEXT ARGUMENT as its value, and the server refuses to start:
-        //
-        //   error while handling argument "--flash-attn": unknown value for
-        //   --flash-attn: '--mmproj'
-        //
-        // Found 2026-08-20 the first time anyone ever set SERVING_FLASH_ATTN=1 — the
-        // flag shipped, was never exercised because it was opt-in and nobody opted in,
-        // and rotted against upstream in the meantime. The whole lane failed to spawn
-        // and serving sat at 0 lanes. An opt-in that has never once been switched on is
-        // untested code with a config-shaped trigger ([[an-absence-is-an-unfinished-measurement]]).
-        if crate::config_env::read("SERVING_FLASH_ATTN")
+            .filter(|s| !s.is_empty() && s != "f16");
+        let flash_attn = crate::config_env::read("SERVING_FLASH_ATTN")
             .map(|s| matches!(s.trim().to_ascii_lowercase().as_str(), "1" | "on" | "true" | "yes"))
-            .unwrap_or(false)
+            .unwrap_or(false);
+        let mmproj = crate::model_registry::artifacts::resolve_mmproj_for_model(&target.model);
+        if mmproj.is_none()
+            && target
+                .model
+                .capabilities
+                .contains(&crate::model_registry::Capability::Vision)
         {
-            cmd.arg("--flash-attn").arg("on");
-        }
-        // MULTIMODAL PROJECTOR (#106): a vision/audio-capable model needs its mmproj GGUF so
-        // llama-server loads the vision (or audio) encoder and can tokenize image/audio content
-        // parts. Present → the model actually SEES (the `ContentPart::Image` the persona render
-        // seam attaches gets mtmd-encoded). Absent on a Vision-capable row → the server serves
-        // TEXT only and silently ignores images, which is a capability LIE — so warn LOUD rather
-        // than fabricate sight ([[fallbacks-are-illegal-fail-loud]]). Safe on a generation lane
-        // (unlike `--embeddings` below): the projector only adds the encoder, it does not switch
-        // the server out of causal-generation mode.
-        if let Some(mmproj) =
-            crate::model_registry::artifacts::resolve_mmproj_for_model(&target.model)
-        {
-            cmd.arg("--mmproj").arg(&mmproj);
-        } else if target
-            .model
-            .capabilities
-            .contains(&crate::model_registry::Capability::Vision)
-        {
+            // A Vision row serving text-only is a capability LIE — warn loud rather than
+            // fabricate sight ([[fallbacks-are-illegal-fail-loud]]). This is a RECEIPT,
+            // not a flag, which is why it stays with resolution and not in `lane_args`.
             tracing::warn!(
                 probe_class = "serving.vision.no_mmproj",
                 model = %target.model.id,
@@ -2666,55 +2610,30 @@ impl LlamaServerControl for LlamaServerProcess {
                  mmproj_local_path) or drop the Vision capability so the row stops claiming sight."
             );
         }
-        // NATIVE MTP SPECULATIVE DECODE (#440): if the model ships an `mtp-*.gguf`
-        // draft head beside its main GGUF (the ggml-org Qwen3.8 layout), load it as
-        // the spec-decode draft. MTP heads are trained WITH the model, so acceptance
-        // is high and there is no external draft model to fit: field-measured on
-        // Qwen3.8-27B (RTX 4090, 2026-08-15) decode went 40.7 → 60.1 t/s for ~0.1GB
-        // extra state. Artifact presence IS the capability signal (the mmproj
-        // pattern): no draft file → no flags → byte-identical serving. n-max 4 /
-        // p-min 0.7 are the upstream-recommended MTP operating point from that same
-        // field benchmark — per-model tuning, if ever needed, belongs on the Model
-        // row beside `sampling`, not here.
-        if let Some(draft) =
-            crate::model_registry::artifacts::resolve_mtp_draft_for_model(&target.model)
-        {
-            cmd.arg("--spec-type")
-                .arg("draft-mtp")
-                .arg("--spec-draft-model")
-                .arg(&draft)
-                .arg("--spec-draft-n-max")
-                .arg("4")
-                .arg("--spec-draft-p-min")
-                .arg("0.7");
+        let mtp_draft = crate::model_registry::artifacts::resolve_mtp_draft_for_model(&target.model);
+
+        let mut cmd = tokio::process::Command::new(&self.bin);
+        let invocation = crate::inference::lane_args::base_invocation(
+            &gguf,
+            &target.model.id,
+            &host,
+            port,
+            lanes,
+            total_ctx,
+        )
+        .with_options(&crate::inference::lane_args::LaneOptions {
+            kv_cache_type: kv_cache_type.as_deref(),
+            flash_attn,
+            mmproj: mmproj.as_deref(),
+            mtp_draft: mtp_draft.as_deref(),
+            resident_override: target.resident_override.as_deref(),
+            cpu_only: target.placement == LanePlacement::Cpu,
+        });
+        for a in &invocation.args {
+            cmd.arg(a);
         }
-        // Device-fit resident-override (#29): source the RESIDENT (non-expert)
-        // tensors from the precision-shrunk fit GGUF so the whole resident tier fits
-        // VRAM offloaded to GPU, while this primary GGUF streams the experts. The
-        // loader hook (`LLAMA_RESIDENT_OVERRIDE`) lazy-maps only the override's
-        // resident bytes (its experts are ignored). Set by the governor's device_fit
-        // plan when as-shipped resident overflows the VRAM budget; absent = resident
-        // fits as-shipped (no override, no env). [[device-fit-repeatable-primitive]].
-        if let Some(ov) = &target.resident_override {
-            cmd.env("LLAMA_RESIDENT_OVERRIDE", ov);
-        }
-        // `--embeddings` is deliberately NOT set on this GENERATION lane. On the
-        // current llama.cpp build it puts the server in embedding (non-causal)
-        // mode, which makes generation fail with `500 "Compute error."` on EVERY
-        // request — every persona turn went dark (and OAI /v1/embeddings still
-        // 400s with "pooling type 'none'", so it wasn't even serving embeddings
-        // correctly). One server cannot serve both causal generation and
-        // non-causal embeddings. Verified 2026-07-03: the base GGUF generates
-        // cleanly the instant this flag is removed. llama-server-hosted
-        // embeddings need their OWN lane (`--embeddings --pooling mean/last` on a
-        // separate port) — a follow-up; the live embedding path today is the
-        // fastembed/ONNX provider, unaffected by this lane.
-        // Placement: CPU lanes pin every layer to RAM so they never contend for
-        // the GPU VRAM a living lane already holds (the Metal decode-time OOM that
-        // muted the eval). GPU lanes omit the flag — llama-server offloads all it
-        // can by default. [[ServingTarget::placement]] / #59 / #56.
-        if target.placement == LanePlacement::Cpu {
-            cmd.arg("--n-gpu-layers").arg("0");
+        for (k, v) in &invocation.envs {
+            cmd.env(k, v);
         }
         // Native tool-calling needs the model's TOOL-CAPABLE chat template. The
         // mlx→gguf conversion can strip the embedded template down to a bare

--- a/core/continuum-core/src/inference/mod.rs
+++ b/core/continuum-core/src/inference/mod.rs
@@ -40,6 +40,7 @@ pub mod handle_module;
 pub mod handle_store;
 pub mod kv_quant;
 pub mod lane_args;
+pub mod lane_health;
 pub mod lane;
 pub mod lane_pidfile;
 pub mod lane_process;

--- a/core/continuum-core/src/inference/mod.rs
+++ b/core/continuum-core/src/inference/mod.rs
@@ -41,6 +41,7 @@ pub mod handle_store;
 pub mod kv_quant;
 pub mod lane_args;
 pub mod lane_health;
+pub mod stream_liveness;
 pub mod lane;
 pub mod lane_pidfile;
 pub mod lane_process;

--- a/core/continuum-core/src/inference/mod.rs
+++ b/core/continuum-core/src/inference/mod.rs
@@ -39,6 +39,7 @@ pub mod footprint_registry;
 pub mod handle_module;
 pub mod handle_store;
 pub mod kv_quant;
+pub mod lane_args;
 pub mod lane;
 pub mod lane_pidfile;
 pub mod lane_process;

--- a/core/continuum-core/src/inference/stream_liveness.rs
+++ b/core/continuum-core/src/inference/stream_liveness.rs
@@ -1,0 +1,234 @@
+//! Which liveness budget a generation stream is owed, given what the lane is
+//! actually doing right now.
+//!
+//! # The defect this exists for, measured live 2026-08-21
+//!
+//! Four citizens resident on an M5, lane healthy, `persona.turn.*` = **0 across the
+//! ledger's 868 minutes**. The chain, every link measured:
+//!
+//! ```text
+//! demand           94,370 tok   against a 58,112-token served window (over_window 1.62)
+//! prefill rate        382 tok/s  (measured: 603 tok → 17.7s TTFB; 5,728 tok → 31.1s)
+//! ⇒ first byte       ~170 s      for a window-sized prompt
+//! watchdog             90 s      ← fires first, every time
+//! ```
+//!
+//! So the lane was killed mid-prefill and the turn retried — Atlas re-sent the
+//! byte-identical 94,370-token demand 21 minutes later and died the same way. 44
+//! `persona.settle.deliberation_retry` rows carry the verdict the watchdog reached:
+//! *"the slot HAD started our work and then stopped mid-stream, so the backend is
+//! stuck or dead."* The backend was neither.
+//!
+//! The downstream damage is what made it a round-killer rather than a slow turn: the
+//! ambient permit is held across that wait (`persona/service_loop.rs`), so three
+//! permits were occupied ~90s each by turns that could never finish. Measured
+//! **+4 yields/min, exactly, for 25 consecutive minutes, with zero successes** — the
+//! perfect periodicity is the tell, because real contention is bursty.
+//!
+//! # The actual mistake, which was one line and not a missing feature
+//!
+//! Both budgets already existed and both were correctly sized *for their own job*:
+//!
+//! - [`STREAM_IDLE_TIMEOUT_SECS`] (90s) — its doc calls it a per-token DECODE
+//!   watchdog, for "a slow-but-producing decode… a token every few hundred ms".
+//! - [`PRE_STREAM_HEADER_TIMEOUT_SECS`] (300s) — its doc says it is "sized for a
+//!   worst-case full-window prefill queued behind co-tenants (minutes)".
+//!
+//! The adapter switched from the second to the first the instant the FIRST
+//! `prompt_progress` frame arrived — which llama.cpp emits at 0% ingestion, before
+//! any real work. So the decode watchdog was policing the prefill, and the budget
+//! written for exactly this situation was skipped past in the first few seconds.
+//!
+//! **Prefill is not decode.** Ingesting 58k tokens behind three co-tenants is the
+//! same regime as waiting in the queue: bulk work, contended, minutes-scale. Decode
+//! is the steady drip the 90s budget was written for. This module names that
+//! distinction once so no caller has to re-derive it.
+//!
+//! # Why the wedge detector keeps its teeth
+//!
+//! This does NOT weaken #385. Liveness is keyed on the GAP BETWEEN PROGRESS EVENTS,
+//! never on elapsed total — the caller stamps `last_progress` only when `processed`
+//! strictly advances, so a slot replaying a frozen counter (the wedge signature,
+//! `n_decoded` stuck at 1 for hours on 2026-08-09) still fails, just at the prefill
+//! budget instead of the decode one. A healthy prefill emits a frame per batch
+//! iteration — `send_partial_response(slot, {}, true)` fires for every slot in
+//! `SLOT_STATE_PROCESSING_PROMPT` on every server loop pass — so a real ingest never
+//! approaches even the 90s gap. Only a slot that stopped being SCHEDULED goes quiet,
+//! and that is precisely the case worth waiting longer on.
+//!
+//! # Lanes that never report progress
+//!
+//! A provider that emits no `prompt_progress` (every cloud adapter) transitions
+//! straight `Queued → Decoding` on its first content delta, so its budgets are
+//! bit-for-bit what they were before this module existed. The change is a strict
+//! addition for lanes that DO report, never a relaxation for lanes that don't.
+
+use std::time::Duration;
+
+/// What the lane is doing for us right now.
+///
+/// Deliberately transport-agnostic: it is derived from parsed stream events, not
+/// from any particular provider's JSON, so the same phase machine serves llama.cpp
+/// (which reports prefill) and cloud providers (which do not).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamPhase {
+    /// POSTed; nothing has come back. The slot may not have been assigned yet.
+    Queued,
+    /// Prefill is advancing — bulk ingest, contended with co-tenants.
+    Prefilling { processed: u64, total: u64 },
+    /// Prefill is done (or the provider never reported it and tokens are flowing).
+    /// Output should now arrive as a steady drip.
+    Decoding,
+}
+
+impl StreamPhase {
+    /// Has the lane begun our work? Drives the diagnosis in the timeout message —
+    /// "never started" (dead backend vs oversubscribed queue) reads very differently
+    /// from "started then stopped", and #446 showed that mislabelling the first as
+    /// the second relaunches healthy busy lanes every two minutes.
+    pub fn has_started(&self) -> bool {
+        !matches!(self, StreamPhase::Queued)
+    }
+
+    /// Fold a prefill-progress report into the phase.
+    ///
+    /// A frame whose `processed` has reached `total` means ingest is done and decode
+    /// is next, so we advance to [`StreamPhase::Decoding`] rather than waiting for
+    /// the first token — otherwise a model that thinks for a while before emitting
+    /// anything visible would sit on the prefill budget with no prefill left to do.
+    ///
+    /// [`StreamPhase::Decoding`] is TERMINAL: a late or stray progress frame arriving
+    /// mid-decode must not re-open the generous budget, or the #385 wedge detector
+    /// loses its teeth for the rest of the stream.
+    pub fn on_prefill(self, processed: u64, total: u64) -> Self {
+        match self {
+            StreamPhase::Decoding => self,
+            _ if total > 0 && processed >= total => StreamPhase::Decoding,
+            _ => StreamPhase::Prefilling { processed, total },
+        }
+    }
+
+    /// Fold "real output arrived" (content / reasoning / tool delta / finish) into
+    /// the phase. Once anything is generated, prefill is definitionally over.
+    pub fn on_output(self) -> Self {
+        StreamPhase::Decoding
+    }
+}
+
+/// How long the stream may stay silent, given its phase.
+///
+/// Both budgets are passed in rather than read from constants here, so the policy is
+/// testable without a clock and the two timeout values keep exactly one definition
+/// each (they live beside the HTTP code that also uses them for the header wait).
+///
+/// The rule, in one line: **bulk work gets the bulk budget; the drip gets the drip
+/// budget.**
+pub fn idle_budget(phase: StreamPhase, bulk: Duration, drip: Duration) -> Duration {
+    match phase {
+        // Unassigned or ingesting: both are "waiting on minutes-scale work behind
+        // co-tenants", which is the case PRE_STREAM_HEADER_TIMEOUT_SECS was written for.
+        StreamPhase::Queued | StreamPhase::Prefilling { .. } => bulk,
+        // Generating: a token every few hundred ms is the contract, so silence is
+        // genuinely suspicious at the decode budget.
+        StreamPhase::Decoding => drip,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BULK: Duration = Duration::from_secs(300);
+    const DRIP: Duration = Duration::from_secs(90);
+
+    /// The live 2026-08-21 numbers: Atlas's prompt against the served window.
+    const LIVE_TOTAL: u64 = 58_112;
+    /// ~382 tok/s measured ⇒ a window-sized prefill needs ~170s of headroom.
+    const LIVE_PREFILL_SECS: u64 = 170;
+
+    // what this catches: THE ROUND-KILLER. A prompt mid-prefill must be judged
+    // against the bulk budget. If this ever returns the drip budget, a window-sized
+    // prompt is again structurally incapable of surviving its own liveness check —
+    // measured live as 44 retries, 0 completed turns in 868 minutes, and the
+    // starvation cascade behind it.
+    #[test]
+    fn a_prompt_still_prefilling_gets_the_bulk_budget() {
+        let phase = StreamPhase::Queued.on_prefill(12_288, LIVE_TOTAL);
+        let budget = idle_budget(phase, BULK, DRIP);
+        assert_eq!(budget, BULK, "prefill must not be policed by the decode watchdog");
+        assert!(
+            budget.as_secs() > LIVE_PREFILL_SECS,
+            "the budget must exceed the ~{LIVE_PREFILL_SECS}s a 58k-token prefill \
+             actually takes at the measured 382 tok/s, or the fix is cosmetic"
+        );
+    }
+
+    // what this catches: the exact off-by-one-phase that caused the outage. llama.cpp
+    // emits a 0% progress frame the moment the slot is assigned ("this is to signal
+    // the client that the request has started processing"). Treating that as "started
+    // → decode budget" is what dropped 300s to 90s in the first few seconds.
+    #[test]
+    fn the_zero_percent_frame_does_not_start_the_decode_clock() {
+        let phase = StreamPhase::Queued.on_prefill(0, LIVE_TOTAL);
+        assert_eq!(phase, StreamPhase::Prefilling { processed: 0, total: LIVE_TOTAL });
+        assert_eq!(idle_budget(phase, BULK, DRIP), BULK);
+        assert!(phase.has_started(), "the slot IS assigned — the diagnosis text depends on this");
+    }
+
+    // what this catches: leaving a finished prefill on the generous budget forever,
+    // which would blunt #385. Once ingest completes, the drip contract applies.
+    #[test]
+    fn a_completed_prefill_switches_to_the_decode_budget() {
+        let phase = StreamPhase::Queued.on_prefill(LIVE_TOTAL, LIVE_TOTAL);
+        assert_eq!(phase, StreamPhase::Decoding);
+        assert_eq!(idle_budget(phase, BULK, DRIP), DRIP);
+    }
+
+    // what this catches: a thinking model that finishes prefill and reasons privately
+    // for a while. Prefill is over, so it is decode's contract that applies — we must
+    // not park on the bulk budget just because no VISIBLE token has appeared.
+    #[test]
+    fn prefill_completion_not_first_token_ends_the_bulk_phase() {
+        let phase = StreamPhase::Prefilling { processed: 58_000, total: LIVE_TOTAL }
+            .on_prefill(LIVE_TOTAL, LIVE_TOTAL);
+        assert_eq!(idle_budget(phase, BULK, DRIP), DRIP);
+    }
+
+    // what this catches: a regression for every provider that reports no prefill at
+    // all (all cloud adapters). Their budgets must be bit-for-bit what they were
+    // before this module existed: bulk until first output, drip after.
+    #[test]
+    fn a_lane_that_never_reports_prefill_behaves_exactly_as_before() {
+        let queued = StreamPhase::Queued;
+        assert_eq!(idle_budget(queued, BULK, DRIP), BULK);
+        assert!(!queued.has_started());
+
+        let decoding = queued.on_output();
+        assert_eq!(idle_budget(decoding, BULK, DRIP), DRIP);
+        assert!(decoding.has_started());
+    }
+
+    // what this catches: a total of 0 (llama.cpp sends this on the initial signalling
+    // frame before token counts are known) being read as "0 >= 0 ⇒ complete", which
+    // would jump a just-assigned slot straight onto the decode budget — the outage
+    // again, by a different route.
+    #[test]
+    fn an_unknown_total_is_never_mistaken_for_a_finished_prefill() {
+        let phase = StreamPhase::Queued.on_prefill(0, 0);
+        assert_eq!(phase, StreamPhase::Prefilling { processed: 0, total: 0 });
+        assert_eq!(idle_budget(phase, BULK, DRIP), BULK);
+    }
+
+    // what this catches: output arriving after prefill can never demote the phase
+    // back to a laxer budget — the wedge detector's teeth depend on decode staying
+    // on the drip budget for the rest of the stream.
+    #[test]
+    fn decoding_is_terminal() {
+        let phase = StreamPhase::Decoding.on_prefill(1, LIVE_TOTAL);
+        assert_eq!(
+            idle_budget(phase, BULK, DRIP),
+            DRIP,
+            "a late/stray progress frame must not re-open the bulk budget mid-decode"
+        );
+    }
+}

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -704,11 +704,19 @@ impl PersonaAircRuntime {
                         ) {
                             if !renewal_denied {
                                 renewal_denied = true;
+                                // `idle` is None when she has NEVER thought this
+                                // process — that is a state, not a duration, and
+                                // stamping it u64::MAX printed a 584-million-year
+                                // idle into the ledger (seen live 2026-08-21).
+                                // [[unknown-is-not-a-quantity]]: the unknown gets a
+                                // word, never a sentinel number.
                                 crate::probe!(
                                     class = "persona.claim.renewal_skipped_idle",
                                     persona_id = %hb_persona,
                                     agent_name = %hb_name,
-                                    idle_ms = idle.unwrap_or(u64::MAX),
+                                    idle = %idle
+                                        .map(|ms| ms.to_string())
+                                        .unwrap_or_else(|| "never-thought".to_string()),
                                     ttl_ms = crate::modules::work::DEFAULT_CLAIM_TTL_MS,
                                     "no cognition within one lease-length — renewals \
                                      DENIED from here until she thinks again; holds \

--- a/docs/architecture/ADMISSION-IS-UNOBSERVABLE.md
+++ b/docs/architecture/ADMISSION-IS-UNOBSERVABLE.md
@@ -3,6 +3,20 @@
 **Status:** measured defect + design, 2026-08-21, M5, core `eb33af7b3`, lane
 `Qwen3.8-27B` on 4 slots, 58,112-token served window.
 
+> **RESOLUTION LOG (same day, measured on each successive build):**
+>
+> | Build | Change | Live proof |
+> |---|---|---|
+> | `9e2f95820` | `stream_liveness` phase machine — prefill gets the bulk budget | retries 44 → **0** |
+> | `312c4a9c8` | `prefill.rescued` / `prefill.complete` probes | 4 rescued rows, each `would_have_died=1` — 163–192s prefills now complete |
+> | `6dea7c435` | queue/ingest split in the receipts | `queued_ms=0` on ALL streams — §2's slot-theft-during-queue hypothesis **dead**; residual is ingest-share under continuous batching (~95–100 tok/s on big prompts) |
+> | `cfe606c55` | §"one more root": the `/props` 503 boot-race latch — **slot affinity had been silently OFF on virtually every boot since 2026-07-11** | `slot_affinity.pinned` ×3 (first pins ever observed); `prefill.complete` with `cached: 1155 / total: 1159` — **~99.7% KV reuse on a byte-stable prompt** |
+>
+> The serving governor also replanned mid-day to `lanes: 4, window: 125,184` (from
+> 58,112), so the §1 demands now FIT (`over_window` 0.70–0.78). The remaining open
+> measurement is a citizen's own second-turn reuse through her pinned slot, and a
+> completed `persona.turn.*` on the citizen-driver bench path.
+
 **The one-line version:** citizens demand 1.3–2.1× the served window, prefill of a
 window-sized prompt takes ~170s at the measured rate, our liveness watchdog gives it 90s,
 and every turn dies and retries forever. The ambient-permit starvation everyone can see is

--- a/docs/architecture/ADMISSION-IS-UNOBSERVABLE.md
+++ b/docs/architecture/ADMISSION-IS-UNOBSERVABLE.md
@@ -1,0 +1,225 @@
+# The 90s watchdog is killing live prefills, and the starvation is its shadow
+
+**Status:** measured defect + design, 2026-08-21, M5, core `eb33af7b3`, lane
+`Qwen3.8-27B` on 4 slots, 58,112-token served window.
+
+**The one-line version:** citizens demand 1.3–2.1× the served window, prefill of a
+window-sized prompt takes ~170s at the measured rate, our liveness watchdog gives it 90s,
+and every turn dies and retries forever. The ambient-permit starvation everyone can see is
+the *shadow* of that — three permits held ~90s each by turns that can never finish.
+
+**Why this doc exists in this shape (Joel, mid-investigation):** *"This should have been
+something delivered across the boundary."* Every number below I computed by hand — parsing
+a JSONL ledger, correlating classes, timing an HTTP stream with a throwaway script. The
+substrate knows all of it and delivers none of it. The design in §4 is about that, not
+about adding one more counter.
+
+---
+
+## 1. The measured chain
+
+Every row live from this box, deltas not cumulative totals.
+
+| # | Fact | Measurement |
+|---|---|---|
+| 1 | Serving is healthy | `serving/status` → `ready: true`, `lanes: 4`, window 58,112 |
+| 2 | Demand exceeds the window on most turns | `over_window` = **1.31, 1.62, 1.83, 2.12** (Kira 97,359 / Atlas 94,370 / Joaquin 88,475 tok) |
+| 3 | Prefill rate, measured directly | 603 tok → **17.7s** TTFB; 5,728 tok → **31.1s** ⇒ ~**382 tok/s** + ~16s fixed |
+| 4 | ⇒ a window-sized prompt cannot deliver first byte in 90s | 58,112 tok ⇒ ~**170s**; the watchdog fires at **90s**. Crossover ≈ **28,000 tokens** |
+| 5 | The watchdog fires, naming the lane dead | 44× `persona.settle.deliberation_retry`, *"inference lane went silent for 90s (no bytes at all) — the slot HAD started our work and then stopped mid-stream, so the backend is stuck or dead"* |
+| 6 | The retry is byte-identical | Atlas `demand_tokens: 94370` at −27.3 min **and** −6.4 min — same prompt, same outcome |
+| 7 | Permits are held across that wait | `run_self_cycle` holds the ambient permit; `service_loop.rs:559` |
+| 8 | ⇒ starvation, perfectly periodic | **+4 yields/min, exactly, for 25 consecutive minutes** (total_yields 40→84) |
+| 9 | Zero successful self-cycles in that window | last `selftick.perceive` −16 min, last `persona.act.*` −42 min |
+| 10 | Zero room turns, ever | `persona.turn.*` = **0 across the ledger's 868 minutes** — grep-confirmed, not a filter artifact |
+
+**Periodicity is the tell.** Contention is bursty; exactly +4/min for 25 minutes is four
+citizens each yielding once per beat, with **zero** winners. The pool is 3 permits
+(`lanes − 1`). Three are held continuously by turns burning 90s to fail.
+
+---
+
+## 2. What is proven, and what is not
+
+**Proven:** items 1–10. In particular #4 is now a measurement, not arithmetic from a
+remembered rate — I timed two prompt sizes against the live lane.
+
+**NOT proven — the mechanism behind #5.** The error's `started` branch means
+`last_progress` *did* advance: `prompt_progress` frames arrived, then stopped for 90s
+while prefill was still incomplete. Something suspends an in-flight prefill. The leading
+candidate is **slot theft**: `slot_prompt_similarity` defaults to 0.1 and we never pin
+`id_slot`, so a request routes to whichever free slot shares the longest prefix, and four
+citizens sharing a ~7,600-token tool head are all above that threshold. A long prefill is
+a long exposure window for reassignment. That reconciles with
+[[llama-server-already-does-slot-affinity-and-conversation-save-restore]] and makes
+**declared slot affinity the keystone**, as the KV work already concluded for independent
+reasons. It is a hypothesis. The discriminator is §4's first instrument.
+
+**Retracted during this investigation** (see §5): "the ambient pool is hardcoded to 1";
+"`set_served_lane_count` forgets to grow it"; "a lazy pool seals at the boot floor"
+(the fallback is `MAX_LANES` = 8, not 1); "citizens took zero turns because the pool is
+saturated by long *successful* turns" (nothing succeeds); "we never request
+`return_progress`" (we do — `openai_adapter.rs:1990`).
+
+---
+
+## 3. Why this is one defect and not three
+
+The KV finding from this morning and this one are the same failure at two scales:
+
+```
+KV prefix reuse = 0%   (measured: cachedTokens 0, 57,005 tok re-prefilled over 4 acts)
+   → every turn re-prefills from scratch
+   → prefill duration scales with the whole prompt, not the delta
+   → first byte lands beyond ANY fixed watchdog at window scale
+   → watchdog kills it at 90s, stamps "backend is stuck or dead"
+   → retry re-enters with the identical prompt, identical outcome
+   → permit held ~90s per attempt × 3 permits = the starvation everyone sees
+```
+
+Fixing the watchdog alone makes turns take ~170s instead of failing — better, not good.
+Fixing KV reuse alone still leaves a fixed 90s cliff for any cold prompt. **Both, and the
+ordering fix already landed (`eb33af7b3`) is the cheaper half.**
+
+---
+
+## 4. Design — deliver it across the boundary
+
+The rule this all obeys, already written as law in KV-CACHE-ECONOMY §6b: **a control path
+may never depend on a signal that only exists as text.** Three instruments, in order.
+
+### 4.0 Where the schema lives (Joel, 2026-08-21)
+
+*"Work more like Java or well defined schema across boundaries, ideally from a rust struct
+or something inside Airc envelopes and events."* Not backwards — **that architecture is
+already in the tree, and these facts simply never got defined as schema at all.** Two
+planes, and the choice between them is "who must see this":
+
+| Plane | Source of truth | Generates | Use for |
+|---|---|---|---|
+| **airc wire** | `airc-wire/src/schema/wire.fbs` (FlatBuffers via `planus`) — its own Cargo.toml calls it "the source of truth" | Rust today; C++/TS/Swift/Kotlin from the **same file**, no extra tool | facts that cross NODES |
+| **ts-rs** | the Rust struct, `#[derive(TS)]` | `protocol/typescript/**` (~500 types live) | facts a client renders in-process |
+
+**One correction to the tooling, in service of the same principle.** For C++ we should not
+reach for cbindgen here: FlatBuffers is *already* a language-neutral IDL, so a table in
+`wire.fbs` yields C++ for free. cbindgen is Rust→C ABI only, one direction, POD-friendly
+and awkward around `String`/`Vec`/`Option` — and standing it up beside the `.fbs` would
+create **a second definition of the same fact**, which is exactly what the compression
+principle forbids. Right instinct, and the better tool is already here.
+
+**So `AdmissionSnapshot` and `LaneProgress` are `.fbs` tables**, with the Rust generated
+rather than hand-written — cross-grid glass boxes (#283) need them from another node, which
+settles the plane. And note what the schema carries today: **only `Envelope` and `Header`**,
+so every payload is opaque bytes. Typed payload tables *are* #445 ("every publish declares
+its class in a HEADER; subscribers filter daemon-side before fanout/decode") — this work
+completes that card rather than sitting beside it.
+
+**Upstream schemas are not ours.** llama.cpp's `prompt_progress` / `/slots` shapes belong
+to llama.cpp; we parse them into our table at the adapter and never let their JSON shape
+leak inward. That boundary is a translation, not a generation — and it is the one place
+where hand-written types are correct.
+
+### 4a. The watchdog waits on PROGRESS, with the lane's own expectation
+
+The signal already crosses the boundary correctly — `return_progress: true` makes
+llama-server emit `prompt_progress {total, cache, processed, time_ms}` in-band on the SSE
+stream, and we request and parse it (`openai_adapter.rs:1990`, `:2683`). The machinery is
+right. **The budget is wrong**: a fixed 90s applied to a variable-size prefill.
+
+Derive it instead: `expected_prefill_ms = (total − cache) / measured_tok_per_s`, and let
+the budget be a multiple of that, floored at today's 90s. Every term is already on the
+frame — `total` and `cache` come from the server, the rate is the catalog expectation
+(#441) or the observed rate from prior frames. A slot that *stops advancing `processed`*
+still fails at the same 90s, so the #385 wedge detector keeps its teeth; a slot legitimately
+ingesting 58k tokens stops being executed for the crime of a big prompt.
+
+This is the same lesson as the readiness smoke (below): the constant encodes an assumption
+about work size that the work itself reports.
+
+### 4b. Admission state becomes a snapshot, not a yield counter
+
+To ask "why did this citizen not take a turn" you need four numbers that are all
+process-private today: `lane_count()` (private fn), `ambient_installed` / `serving_installed`
+/ `nondirected_installed` (`AtomicUsize`, **written and never read**), and live permit
+occupancy (semaphore internals; `available_permits()` is used only in tests).
+
+The one public signal, `ambient_yields()`, is a monotonic counter of *failures* at ≤1
+row/min. It told me starvation was happening and nothing about why — and its cumulative
+total across reboots is what made me misread the rate three times.
+
+```rust
+pub struct AdmissionSnapshot {
+    pub served_lanes: usize,        // 0 = serving has NEVER published (≠ one lane)
+    pub ambient_budget: usize,      // == ambient_installed, today unreadable
+    pub ambient_held: usize,        // the number that would have ended this in 5 seconds
+    pub nondirected_budget: usize,
+    pub nondirected_held: usize,
+    pub ambient_yields_total: usize,
+}
+```
+
+`ambient_held` is the whole point: 3-of-3 held with zero completions is a *stuck holder*,
+and 3-of-3 held with completions flowing is healthy contention. Nothing in the tree can
+currently tell those apart. Note the fields already exist as private atomics — this is a
+**publisher, not a schema change**.
+
+Per CONCURRENCY-STYLE-GUIDE: `watch::Sender<AdmissionSnapshot>`, published on change plus
+the governor tick, never per-yield (per-yield was correctly rejected at ~92 rows/min,
+#399). `LaneAdmission` already owns every field.
+
+### 4c. Readiness stops rediscovering thinking-ness by experiment
+
+`serving.smoke.think_retry` fired **355 times**, byte-identical every time
+(`quick_tokens: 24, reasoning_len: 97, retry_budget: 768`). On a thinking model the quick
+budget is structurally incapable of answering, so every readiness check burns two
+generations on lanes citizens are starving for. Thinking-ness is a **known property of the
+catalog Model row**, beside `tool_protocol` and `sampling` (#76, #294). Read it; keep the
+`ThinkStarved` retry only as the fallback for rows that don't say.
+
+### 4d. The acceptance test
+
+From BENCHMARKS-ARE-ADAPTERS: *can a citizen in the room perceive this through the same
+ViewState pipe the human's screen uses?* Today "why am I not getting turns" is answerable
+by neither the citizen nor the operator without a debugger and a hand-written parser.
+
+---
+
+## 5. The method failures, recorded because they were the expensive part
+
+Seven wrong reads in one session, all one shape: **I concluded about what lay outside the
+window I actually looked at.**
+
+1. `pgrep` found no solve process → "the run finished." It runs *inside* the core.
+2. `/slots` → HTTP 000 → "the lane is dead." `/health`, `/props`, `/v1/models` all 200.
+3. Ambient pool read as constant `1` → live-derived since 8/17.
+4. `set_served_lane_count` read to line 416 → the `ambient` grow is at 423.
+5. **Cumulative probe counts read as current rate** — the exact trap my own plan (Phase 0c)
+   was written to prevent. `total_yields: 84` in-process vs 258 rows accumulated across
+   reboots.
+6. **My own analysis script used `capturedAtMs`** (the CLI's normalized key) against a file
+   whose field is `captured_at_ms` — every row parsed as timestamp 0, and I nearly reported
+   "no probe activity in 60 minutes" as a finding about the *system*.
+7. "We never request `return_progress`" → we request it, parse it, and the watchdog is
+   built around it.
+
+Each was caught by one more command. #6 is the one worth generalizing: **an instrument I
+wrote myself gets the same scrutiny as the system under test** — it produced a
+system-shaped conclusion from a bug in my own five lines.
+[[an-absence-is-an-unfinished-measurement]]: *a window is not the world, and that includes
+the window your own tool opened.*
+
+---
+
+## 6. Work order
+
+| # | Work | Gate |
+|---|---|---|
+| 1 | Derive the prefill budget from `prompt_progress` (§4a) | A 58k-token prompt completes instead of failing at 90s |
+| 2 | Discriminate the mid-prefill stall (§2) — log `id_slot` per frame; does our slot change? | Slot theft confirmed or killed |
+| 3 | If confirmed: declare `id_slot` affinity per resident citizen | Prefill is not preemptible mid-flight |
+| 4 | `AdmissionSnapshot` + `watch` publisher (§4b) | One command prints `ambient_held` on a live box |
+| 5 | Catalog-driven smoke budget (§4c) | One generation per readiness check, not two |
+| 6 | Re-measure `delib.generate.cache` `hit_rate` against the pinned `684c24f8a` baseline | The KV ordering fix proven live |
+
+Step 1 is the unblock — everything else is measuring a system that can currently complete
+zero turns. Steps 2–3 are the keystone the KV work already pointed at from the other side.

--- a/docs/architecture/ADMISSION-IS-UNOBSERVABLE.md
+++ b/docs/architecture/ADMISSION-IS-UNOBSERVABLE.md
@@ -16,6 +16,22 @@
 > 58,112), so the §1 demands now FIT (`over_window` 0.70–0.78). The remaining open
 > measurement is a citizen's own second-turn reuse through her pinned slot, and a
 > completed `persona.turn.*` on the citizen-driver bench path.
+>
+> **Also observed same day:** a full citizen act→observe cycle post-fix (Kira,
+> `persona.act.think_only` → `persona.act.observed`, tools:1), and three more
+> window-scale prefills (16k–30k tokens, 163–293s) completed with `would_have_died=1`.
+>
+> **Next distinct defect, scoped but not fixed — the deaf kickoff.** The dispatch
+> chat kickoff reached no persona inbound (zero `persona.inbound.raw_event` rows for
+> the addressee). The consumer-cursor layer is EXONERATED — `inbound_attach.rs`'s
+> watermark discipline (#261) only ever persists already-delivered positions. The
+> surviving suspect is subscription COVERAGE: `run_daemon_attach` is "single-attach
+> today" (one default channel), and persona subscriptions opened at boot don't cover
+> a bench room created mid-session until their next re-open — the kickoff landed
+> exactly in that gap. Per the standing law, room events must be INTERRUPTS: a
+> `join_room` must extend the live subscription at join time, not at the next
+> stream restart. (This round survived because the citizen driver PRE-CLAIMS the
+> card through her own runtime, so the work arrived via the board pipe.)
 
 **The one-line version:** citizens demand 1.3–2.1× the served window, prefill of a
 window-sized prompt takes ~170s at the measured rate, our liveness watchdog gives it 90s,

--- a/docs/architecture/KV-CACHE-ECONOMY.md
+++ b/docs/architecture/KV-CACHE-ECONOMY.md
@@ -1,0 +1,221 @@
+# The KV Cache Economy
+
+**Status:** design, 2026-08-21. Written after the #266 prefix defect was found and
+fixed (`40075d7ea`) and instrumented (`faf8c07c9`, `delib.generate.cache`).
+
+**Scope:** what a prompt costs to *serve*, as opposed to what it costs to *fit*. The
+budget/packing question ("what goes in the window") is
+[CONTEXT-IS-A-CAPABILITY-AXIS.md](CONTEXT-IS-A-CAPABILITY-AXIS.md) and #460. This
+document is about the KV cache underneath it: which tokens we pay to encode, how often,
+and who pays twice for the same tokens.
+
+**Why it exists as a doc and not a patch:** Joel, 2026-08-21 — *"Still need to design
+docker form, or reuse between persona, for KV cache. Really need a focused effort."* The
+patch (canonical stable-tier ordering) was the emergency. This is the part that needed
+reading the serving layer first, because **most of the machinery we were about to design
+already exists in llama.cpp and is already switched on.** Building a second copy of it
+would have been the expensive mistake.
+
+---
+
+## 1. What is actually true today, read from source
+
+Every row below was read in-file on 2026-08-21, not inferred. Two of them contradict what
+I assumed before reading, and both would have sent the design the wrong way.
+
+| Fact | Where | Consequence |
+|---|---|---|
+| One llama-server slot per lane: `--parallel <lanes>`, `-c = window × lanes` | `inference/llama_server.rs:2568-2590` | Each slot holds exactly one planned window. Slots are the scarce resource, not KV bytes. |
+| `--cache-reuse 256` is passed | `llama_server.rs:2604` | Chunk reuse via KV shifting is on. It was on the entire time reuse measured 0% — the flag was never the defect. |
+| **`slot_prompt_similarity` defaults to `0.1`, and we never disable it** | `common/common.h:687`; selection at `server-context.cpp:1543-1587` | **LCP-based slot selection is ALREADY ACTIVE.** An incoming request is routed to whichever free slot shares the longest common prefix with it. Cross-persona head sharing is not a feature to build; it is a behaviour we are already getting, unmanaged. |
+| **`cache_ram_mib` defaults to `8192` (8 GiB)** and the server saves an evicted slot's state and restores the incoming one | `common/common.h:626`; `server-context.cpp:1620-1633` (`prompt_save` / `prompt_load`) | **A prompt cache already exists, in host RAM, by default.** A persona bumped off a slot does not necessarily lose its tail — it can be restored. Also: 8 GiB of host RAM that our `ResourceGovernor` has never heard of (§4). |
+| We do **not** pin `id_slot` per request | no occurrence in `inference/*.rs` | Every turn re-enters slot selection. Affinity is emergent from LCP, never declared. |
+| Context shift is **disabled** deliberately | `llama_server.rs`, the `--no-context-shift` block | Overflow 400s instead of silently amputating the prompt middle (#139). Unchanged by anything here. |
+
+The corrected mental model: **llama.cpp already implements slot affinity and conversation
+save/restore. What is missing is not mechanism — it is *policy*, and an owner for the
+resource that policy spends.**
+
+---
+
+## 2. The arithmetic, from Atlas's measured run
+
+From the `pallets__flask-4045` captures (2026-08-21):
+
+| Quantity | Measured |
+|---|---|
+| Tool schemas, native | 4,609 tok (#333) |
+| Prose tool menu (paid *again*, same surface) | ~1,000 tok (#333) |
+| Identity + standing framing | ~2,000 tok |
+| **Shared head total** | **~7,600 tok** |
+| Conversation tail, act 1 → act N | 9,847 → 36,242 tok and climbing |
+| Prefill throughput | ~111 tok/s |
+| Re-prefill cost per act at 36k | **~306 s** |
+
+Now put those two numbers against the LCP threshold, because this is where the naive
+design fails:
+
+```
+persona B arrives, its head matches persona A's slot:
+    sim  = 7,600 / 36,242  ≈ 0.21     > 0.1  →  B TAKES A's SLOT
+    f_keep = 7,600 / 36,242 ≈ 0.21    < 0.5  →  A's 36k is evicted
+```
+
+**The shared head is a big enough fraction to win slot selection, and a small enough
+fraction that winning it throws away 4.7× more than it saves.** B keeps 7,600 tokens and
+destroys 28,642 of A's. A's next turn then pays ~258 s to rebuild what B discarded.
+
+This is the finding that reverses the obvious plan. "Make the tool head identical and
+first so every persona shares it" is correct about *token cost* (#333: we pay for that
+surface twice, in schemas and again in prose) and it is correct that a shared head is a
+precondition. But as a *KV strategy it is dominated*, and if implemented naively it makes
+things worse by making cross-persona slot theft more likely.
+
+**Tail retention beats head sharing by roughly the ratio of tail to head — today ~4.7×,
+and it grows every act.** Any design that trades a tail for a head is backwards.
+
+> Not yet measured, and it decides §3's mechanism: the wall-clock cost of
+> `prompt_save`/`prompt_load` for a ~36k-token conversation on this model. It is a host-RAM
+> copy of the KV for those tokens; if it is ~1 s it makes eviction survivable and slot
+> pressure stops mattering much, and if it is ~30 s it is a second re-prefill wearing a
+> different hat. **Do not build §3.2 before measuring this.** The instrument is already in:
+> `delib.generate.cache` reports `prefill_tokens` vs `cached_tokens`, so a restore shows up
+> as high `cached_tokens` with low `prefill_ms`.
+
+---
+
+## 3. The design
+
+Three parts, in dependency order. Part 1 is done; part 2 is the keystone; part 3 is the
+one Joel named as "docker form" and it is deliberately last.
+
+### 3.1 A deterministic head — SHIPPED, and it is a precondition, not the win
+
+`40075d7ea` made the stable tier canonically ordered, so a citizen's own head is
+byte-identical turn to turn. Without that, nothing below can work: LCP selection, chunk
+reuse, and the prompt cache all key on *identical leading bytes*, and we were mutating
+ours at token ~2,000.
+
+Still open under this heading, and it is #333's actual body:
+
+- **Pay for the tool surface once.** 4,609 tok of native schemas plus ~1,000 tok of prose
+  menu describe the same tools to the same model. On a 16k window that is ~35% of
+  everything, before a single word of grounding. Deleting the duplicate is a straight win
+  independent of caching.
+- **Order the head so the SHARED part leads.** Tool schemas and common doctrine are
+  byte-identical across citizens; identity and persona-specific framing are not. Emitting
+  shared-then-personal (rather than personal-then-shared) is what makes a cross-persona
+  prefix exist at all. This is cheap and it is the precondition for §3.3 — but on its own,
+  per §2, it *increases* slot-theft risk. It must not ship before §3.2.
+
+### 3.2 Declared slot affinity — THE KEYSTONE
+
+Today affinity is emergent: whoever's prefix matches best gets the slot, with no notion of
+whose conversation is more expensive to lose. The fix is to make affinity **declared and
+priced**, which means continuum choosing the slot rather than discovering it.
+
+llama-server already accepts `id_slot` on a request, and honours it above LCP
+(`server-context.cpp:1535` — a specified slot short-circuits selection but still runs the
+cache-update logic). So the mechanism is a field we are not sending.
+
+**Policy:** a resident citizen holds a slot for the duration of a *task*, not a *turn*.
+
+- The lane registry gains a `slot_id` per hosted persona — the same registry that already
+  owns lane identity, so this is a field on an existing owner, not a new manager
+  (CONCURRENCY-STYLE-GUIDE.md forbids the parallel one).
+- Requests carry `id_slot`. A citizen returns to *her own* KV, whatever anyone else's
+  prefix looks like.
+- Eviction becomes a **decision with a cost**, not an accident of similarity: evicting a
+  36k tail to seat a 7.6k head is refused; evicting a cold or finished conversation is
+  fine.
+- When citizens outnumber slots, the choice of *whose* tail to spill is the same class of
+  decision as `PagedResourcePool::evict_at_least` and belongs behind the same seam, with
+  the same rule as every other cache class we own: **no cache class without a decided
+  eviction story** (`disk_eviction.rs`'s standing test, and the 2026-07-13 incident it
+  came from).
+
+**Acceptance:** two citizens alternating turns on a 2-slot lane both report
+`hit_rate > 0.8` from act 2 onward. Today the pair thrash and both report ~0.
+
+### 3.3 A shared, governed head — "docker form", and only after 3.2
+
+Once tails are protected, sharing the head is pure upside: the tool surface prefills once
+per box instead of once per citizen per act.
+
+This is the piece Joel called *docker form* — and the containerisation instinct is exactly
+right for the reason that matters. A shared prefix only stays shared if **every consumer
+of that lane is byte-identical in its head**, which means the head must be a function of
+*lane identity*, not of whichever citizen happens to be calling. Same model, same flags,
+same tool manifest, same version → one head. Change any of them and it is a different
+lane, with its own head, by construction. That is a container image's contract, applied to
+a prompt.
+
+Concretely, and consistent with
+[GENOME-FOUNDRY-SENTINEL.md](GENOME-FOUNDRY-SENTINEL.md)'s artifact model: the head gets
+an **identity hash** over (model id, tool manifest, doctrine version, template). Lanes
+advertise theirs. Two citizens on the same lane share a head or the hash says why not —
+and a mismatch is loud, because a silently-diverged head is exactly the failure we just
+spent two weeks not seeing.
+
+**This reconciles with
+[[kv-prefix-caching-is-the-only-form-and-repetition-between-persona-is-forbidden]]**,
+which says there is no repetition *between* personas and block-level dedup is impossible.
+Both still hold: that memory is about **conversation content**, which is genuinely unique
+per citizen. The tool schema head is not conversation. Sharing it is prefix reuse — the
+only form that works — not dedup.
+
+---
+
+## 4. The un-governed 8 GiB (found while writing this; own it or turn it off)
+
+`cache_ram_mib` defaults to **8192**, so every llama-server we spawn may hold up to 8 GiB
+of host RAM for saved conversations, and we have never passed the flag, never budgeted it,
+and never told the governor.
+
+That is a textbook violation of our own law: **any place the substrate writes unbounded
+derived data gets a tracked owner and an eviction decision** — the rule written after
+2026-07-13, when 460 GB of derived artifacts took the disk to a day of runway while
+`DiskPressureMonitor` logged `level=high [no reporters]`. Same shape, different medium:
+every component healthy, the wiring absent.
+
+It is also directly load-bearing for §3.2 — the prompt cache *is* the spill space that
+makes eviction survivable, so its size is not an incidental setting, it is the depth of
+the buffer the whole affinity policy leans on.
+
+**Action, independent of everything above:** `--cache-ram` becomes a governed lease
+derived by the daemon at spawn from real free RAM, exactly as
+`GGML_MOE_HOST_CACHE_GB` was governed (#287) rather than left as a scratchpad constant.
+`ResourceGovernor` is the one per-machine authority (#56); serving leases from it.
+
+---
+
+## 5. Order of work, and what gates each step
+
+| # | Work | Gate |
+|---|---|---|
+| 0 | ✅ Canonical stable-tier head (`40075d7ea`) + `delib.generate.cache` (`faf8c07c9`) | Live: `hit_rate` climbs off the floor from act 2. **Owed — the flask run holds the core.** |
+| 1 | Measure `prompt_save`/`prompt_load` wall-clock at ~36k tokens | A number. If restore ≈ re-prefill, §3.2's eviction policy must avoid spilling rather than lean on it. |
+| 2 | `--cache-ram` as a governed lease (§4) | Governor accounts it; no un-owned cache class. |
+| 3 | Declared slot affinity, `id_slot` per resident citizen (§3.2) | Two citizens alternating on 2 slots, both `hit_rate > 0.8`. |
+| 4 | Kill the duplicate tool surface (#333) | ~1,000 tok back on every turn; grounding budget rises. |
+| 5 | Shared head + head identity hash (§3.3) | A second citizen's *first* act on a warm lane reports nonzero `cached_tokens`. |
+
+Steps 1 and 2 are independent of the flask run and can start now. Step 3 needs step 1's
+number. Step 5 must not precede step 3 — per §2 it makes slot theft *more* likely, and
+shipping it alone would look like a regression and be read as "caching doesn't help."
+
+---
+
+## 6. What this document is not
+
+- **Not a budget/packing design.** How much grounding a citizen gets is #460 and the
+  `ContextBudget` work; the two interact (a smaller volatile tail is both cheaper to fit
+  and cheaper to re-prefill) but they are different decisions with different owners.
+- **Not a claim that caching fixes the SWE rate.** It fixes *latency*, which buys acts
+  inside a fixed deadline. A citizen who re-prefills 306 s per act spends a 4.3 h attempt
+  budget on re-reading. Whether more acts convert to more passes is an open, separate
+  question — and reading a latency fix as a capability fix is exactly the error
+  [[one-sample-of-a-live-system-is-not-a-fact-about-it]] warns about.
+- **Not measured on the grid.** Everything here is single-box. Cross-node prefix sharing
+  (a peer that already holds the head) is the natural sequel and belongs with the Grid
+  Expert Share work (#315), not here.

--- a/docs/architecture/KV-CACHE-ECONOMY.md
+++ b/docs/architecture/KV-CACHE-ECONOMY.md
@@ -200,12 +200,41 @@ emphatically not a new manager. `ResourceGovernor` remains the one per-machine a
 
 | # | Work | Gate |
 |---|---|---|
-| 0 | ✅ Canonical stable-tier head (`40075d7ea`) + `delib.generate.cache` (`faf8c07c9`) | Live: `hit_rate` climbs off the floor from act 2. **Owed — the flask run holds the core.** |
+| 0 | ✅ Canonical stable-tier head (`40075d7ea`) + `delib.generate.cache` (`faf8c07c9`) | Live: `hit_rate` climbs off the floor from act 2. **BASELINE PINNED (below); after-number owed.** |
 | 1 | Measure `prompt_save`/`prompt_load` wall-clock at ~36k tokens | A number. If restore ≈ re-prefill, §3.2's eviction policy must avoid spilling rather than lean on it. |
 | 2 | `--cache-ram` as a governed lease (§4) | Governor accounts it; no un-owned cache class. |
 | 3 | Declared slot affinity, `id_slot` per resident citizen (§3.2) | Two citizens alternating on 2 slots, both `hit_rate > 0.8`. |
 | 4 | Kill the duplicate tool surface (#333) | ~1,000 tok back on every turn; grounding budget rises. |
 | 5 | Shared head + head identity hash (§3.3) | A second citizen's *first* act on a warm lane reports nonzero `cached_tokens`. |
+
+### The pre-fix baseline, measured — so the delta is a number, not an argument
+
+Captured 2026-08-21 10:57 from a LIVE run: citizen `e5f4141d`, instance
+`pallets__flask-4045`, on the pre-fix binary (`b10196-fa7e0d8e9`), read from her own
+prompt captures.
+
+| act | cached_tokens | prefill_tokens | hit rate |
+|---|---|---|---|
+| 1 | 0 | 9,847 | 0.000 |
+| 2 | 0 | 11,172 | 0.000 |
+| 3 | 0 | 19,434 | 0.000 |
+| 4 | 0 | 16,552 | 0.000 |
+
+**57,005 tokens re-prefilled across four acts. Zero reuse on every single turn.** At the
+measured ~111 tok/s that is ~513 seconds — roughly 8.5 minutes of a 4.3h attempt budget
+spent re-reading, four acts in, with the cost per act still climbing.
+
+This is the number the ordering fix has to move, and it is now pinned to a specific
+citizen on a specific instance, so the after-measurement is a comparison rather than a
+claim. Re-run the same read (or simply query `delib.generate.cache`, which reports the
+same fields directly once the fix is deployed) on the same instance.
+
+**Method note, because it nearly went wrong:** `pgrep` for a solve process finds NOTHING
+even while a run is live — `agent/solve` executes INSIDE the core, not as a subprocess.
+Checking for the process and concluding the run had finished was a wrong-instrument read
+of the exact class this document keeps cataloguing, and it would have rebooted the box out
+from under a citizen at act 4. The authoritative signal is
+`~/.continuum/progress/agent-solve-claim-<run>.json` (`state`, `acts`, mtime).
 
 Steps 1 and 2 are independent of the flask run and can start now. Step 3 needs step 1's
 number. Step 5 must not precede step 3 — per §2 it makes slot theft *more* likely, and

--- a/docs/architecture/KV-CACHE-ECONOMY.md
+++ b/docs/architecture/KV-CACHE-ECONOMY.md
@@ -182,10 +182,17 @@ It is also directly load-bearing for §3.2 — the prompt cache *is* the spill s
 makes eviction survivable, so its size is not an incidental setting, it is the depth of
 the buffer the whole affinity policy leans on.
 
-**Action, independent of everything above:** `--cache-ram` becomes a governed lease
-derived by the daemon at spawn from real free RAM, exactly as
-`GGML_MOE_HOST_CACHE_GB` was governed (#287) rather than left as a scratchpad constant.
-`ResourceGovernor` is the one per-machine authority (#56); serving leases from it.
+**Action — and it is far smaller than it looks, because the machinery exists.**
+`capacity/host_cache_lease.rs` is already the governed host-cache lease (#287); it already
+runs **on the governor tick rather than once at spawn**, and its module doc already states
+the exact reason that matters here: *"KV grows as slots fill, so this derivation runs on
+the governor tick, never once at spawn."* It was written for the pinned expert cache after
+the 2026-08-01 overcommit (95.9 GB committed on a 63 GB box → 33 GB pagefile → fetch
+collapsed 2.5 GB/s → 205 MB/s), and it already encodes "commit can never exceed physical."
+
+So `--cache-ram` is **one more term on an existing lease** — not a new lease, and
+emphatically not a new manager. `ResourceGovernor` remains the one per-machine authority
+(#56); serving leases from it.
 
 ---
 
@@ -206,7 +213,93 @@ shipping it alone would look like a regression and be read as "caching doesn't h
 
 ---
 
-## 6. What this document is not
+## 6. Policy is an ADAPTER, never a rule (Joel, 2026-08-21)
+
+> *"It's solvable, just not too hard coded into one paradigm here — better add proper
+> adapters and break the module down into concerns. We could do a ton with plugin ML here,
+> especially RL."*
+
+Everything in §3 describes *decisions under scarcity*: which conversation keeps a slot,
+what a tail is worth, when to spill. Written as `if f_keep < 0.5 { … }` those become
+exactly the hardcoded paradigm this project keeps having to tear back out. They are a
+**policy**, and policy belongs behind a seam with at least two implementations.
+
+**And the seam already exists, with a learned implementation in it.** This is the third
+time today that reading first changed the answer:
+
+| In tree | What it is |
+|---|---|
+| `capacity/expert_tier_policy.rs` | `trait TierPolicy { fn plan(&self, inputs: &TierPolicyInputs) -> ExpertTierPlan }` — decisions returned as a **plan**, not applied inline. `ClassicTierPolicy` is the v1 heuristic (#273). |
+| `expert-pager-policy` **leaf crate** | Policy already extracted into its own crate (windows-msvc driver requirement) — the plugin boundary, already cut. |
+| `capacity/bandit_plan_controller.rs` | A **bandit controller**, re-exported from that crate. RL is not greenfield here (#276, #281). |
+| `expert_predictor.rs`, `expert_decay_policy.rs`, `expert_residency.rs`, `expert_observer.rs` | Predict / decay / residency / observe, already separate concerns. |
+
+**The generalisation is now earned, not speculative.** CLAUDE.md's rule is: identify the
+pattern at 2–3 similar implementations, then design, then validate with a maximally
+different outlier. We have **three** instances of *paged resource under scarcity with a
+learnable value function* — MoE experts (built), LoRA genome paging (built), and KV slots
+(this doc). Three is the threshold, and KV slots are the ideal outlier B precisely because
+they are *maximally different* from experts: the unit is a whole conversation rather than a
+tensor, the cost of a miss is seconds of prefill rather than bytes of fetch, and the
+population is tiny (2–8) rather than thousands. **If one seam fits both ends, it fits
+everything between.**
+
+So: KV slot residency implements the same shape rather than inventing a rival.
+
+- **Outlier A — heuristic.** `cost_of_loss = tail_tokens / prefill_rate`, in seconds. Not a
+  magic ratio: a quantity with a unit, derived from measurement, comparable across
+  candidates. Ships first, is legible, and is the baseline everything else must beat.
+- **Outlier B — learned / RL.** Slot eviction is a textbook sequential decision problem:
+  *state* = per-slot (tail length, recency, citizen, task phase) + arriving request;
+  *action* = which slot to seat it in; *reward* = **prefill seconds saved**.
+
+**And the reward signal is already instrumented — I shipped it this morning without
+noticing it was one.** `delib.generate.cache` (`faf8c07c9`) emits `cached_tokens`,
+`prefill_tokens`, `prefill_ms`, `hit_rate` on *every* generation. That is a labelled
+transition per turn, continuously, in production. The bandit needs a reward and the probe
+is already producing it — which also means the honest baseline (A vs B, same workload)
+is measurable from day one rather than argued.
+
+**Guardrails, so "plugin ML" does not become "unexplainable serving":**
+
+1. **Policies return plans, never side effects** — same as `TierPolicy::plan`. A plan can be
+   logged, replayed, diffed against the heuristic, and refused. This is what makes an RL
+   policy auditable instead of a black box wired to a GPU.
+2. **The heuristic is the floor, permanently.** A learned policy that loses to
+   `ClassicKvPolicy` on measured prefill-seconds gets switched off by the comparison, not by
+   an argument. Keep A callable forever.
+3. **Learned policy is opt-in per lane, and its identity is on the receipt.** Which policy
+   decided is part of the plan, so a latency regression can be attributed instead of
+   investigated.
+4. **Never learn on a broken substrate.** Until §3.1's deterministic head shipped, the
+   reward signal was ~0 for structural reasons; a bandit trained through that would have
+   learned that nothing helps. Order matters for learning, not just for correctness.
+
+## 7. Break the module into concerns
+
+`inference/llama_server.rs` is **4,190 lines** — eight times the decomposition law in
+CLAUDE.md ("assume a new concept or group of functions ought to be in its own file and most
+likely its own class"), and it is where every one of §3's changes would otherwise land. The
+KV work is the forcing function, not the excuse: adding slot affinity, a policy seam, and a
+cache-ram lease to a 4k-line file is how it becomes 5k.
+
+Concerns visible in the file today, each of which is a module:
+
+| Concern | What it owns |
+|---|---|
+| `spawn/args` | Flag construction — `-c`/`--parallel`/`--cache-reuse`/`--ubatch-size`/`--no-context-shift`, each with its incident comment. Pure, therefore unit-testable without a process. |
+| `readiness` | Health, generation-verified readiness (#363 — a wedged server passed `/health` while every turn died), port-holder verification. |
+| `slots` | The registry §3.2 needs: slot ↔ citizen, occupancy, `id_slot` on requests. Does not exist yet — this is where it goes, rather than a new manager. |
+| `request` | Payload construction, timing extraction (`metrics_from`), the cache probe. |
+| `lifecycle` | Spawn / reclaim / orphan sweep / teardown (#90, #452, #454). |
+| `policy` (leaf crate) | §6's seam. Sits beside `expert-pager-policy`, not inside the server. |
+
+Constraint from the concurrency guide: this is a **decomposition, not a re-architecture**.
+No new tokio task, no new watch channel, no second registry. Same behaviour, same tests,
+moved — and the flag comments travel with their flags, because those comments are the only
+record of the incidents that set each value.
+
+## 8. What this document is not
 
 - **Not a budget/packing design.** How much grounding a citizen gets is #460 and the
   `ContextBudget` work; the two interact (a smaller volatile tail is both cheaper to fit

--- a/docs/architecture/KV-CACHE-ECONOMY.md
+++ b/docs/architecture/KV-CACHE-ECONOMY.md
@@ -275,6 +275,39 @@ is measurable from day one rather than argued.
    reward signal was ~0 for structural reasons; a bandit trained through that would have
    learned that nothing helps. Order matters for learning, not just for correctness.
 
+## 6b. STDERR IS NEVER AN INTERFACE (Joel, 2026-08-21)
+
+> *"STDERR/out is never a place for interfacing, just debug."*
+
+A law, and we are currently breaking it twice. Both were written in good faith for real
+incidents, and both make llama.cpp's **debug text** load-bearing in our control plane:
+
+| Site | Parses | Drives |
+|---|---|---|
+| `inference::wedge::WedgeWatch` | stderr for an impossible slot progress (`progress = 1.10`) | raises a flag **the serving daemon reaps a lane on** |
+| `inference::placement_watch::OffloadWatch` | llama.cpp's **load banner** for layers offloaded | fires `serving.placement.cpu_fallback` — treated as a lease violation (#441) |
+
+Why it must change even though it currently works: stderr is unstructured, unversioned,
+and drifts with upstream's logging taste. The failure mode when it drifts is not an error
+— it is **silence**. The watcher stops matching, the flag stops rising, and the wedge that
+burned four hours on 2026-08-05 becomes invisible again with every component still green.
+That is the same shape as every other defect in this document: an absence that looks like
+normal operation.
+
+**The structured channels exist.** `/slots` carries per-slot state and progress; `/props`
+carries the load configuration; the per-request `timings` block already reaches us and is
+what `delib.generate.cache` reports. The sentinel work (#441) should read the same
+`prefill_tokens`/`prefill_ms` we already parse rather than scrape a banner for tok/s.
+
+**What is NOT a violation, and the line between them:** `stderr_log_tail()` on spawn
+failure — a human asking "why did it die" and getting llama.cpp's own last words. Reading
+stderr to **SHOW** is debug and correct. Parsing stderr to **DECIDE** is an interface and
+forbidden. The test is whether a control path branches on it.
+
+**Status: named, not fixed.** Rewriting both watchers onto `/slots` + `/props` needs the
+endpoint payloads verified against our pinned build first (`b10196-fa7e0d8e9`) — asserting
+a field exists because upstream documents it is the same mistake in a different channel.
+
 ## 7. Break the module into concerns
 
 `inference/llama_server.rs` is **4,190 lines** — eight times the decomposition law in


### PR DESCRIPTION
Nine commits beyond #2348, each proven live on the M5 before commit.

## The serving arc (the round-killer, closed)
- **`9e2f95820` prefill is not decode** — the 90s decode watchdog was policing prefill; a window-sized prompt needs ~170s+ to first byte, so every big turn died and retried forever (44 retries, 0 turns in 868 min). New `stream_liveness` phase machine: bulk work gets the bulk budget, the drip gets the drip. Retries 44→0; 163–626s ingests now complete. #385/#446 semantics preserved, 7 tests carry the incident numbers.
- **`312c4a9c8` + `6dea7c435` probes** — `prefill.rescued` / `prefill.complete` with queue/ingest SPLIT (the first cut conflated them and measured neither).
- **`cfe606c55` slot affinity un-latched** — pinning (built 7/11) was silently OFF on virtually every boot: a `/props` probe racing llama's `503_loading` window latched `Unsupported` for the process's life. Only 404/501 may latch now; regression test carries the incident. First `slot_affinity.pinned` rows ever observed; KV reuse measured **99.7%** byte-stable, **42% / 23%** on live citizen turns.

## The benchmark repair arc (started)
- **`b03953eb6` clone_at serialized per destination** — `cloning-{pid}` staging collided inside the one-pid core; concurrent stages deleted each other's live clones (the 8/18 grade loss that voided sympy-18057's finished artifact).
- **`33bd072f1` rounds survive core restarts** — the ROUNDS map was process-memory: reboots blanked `benchmark/rounds` and silently reverted Citizen rounds to DetachedSolve at re-claim. One JSON per in-flight round, reload on first touch, self-evicting at Done.
- **`531c6e696`** — "never thought" is a state, not a u64::MAX idle.

## Milestone observed
First end-to-end CITIZEN bench work ever: Atlas `work/state` + `code/write` (24.6KB) through her own service loop on a pre-claimed swe-bench-lite card.

Full measured chain + design: `docs/architecture/ADMISSION-IS-UNOBSERVABLE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo