### PR TITLE
FOCUS: self-ticks bind to the held claim's room

### DIFF
--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -347,6 +347,21 @@ pub fn seal_round(round_id: Uuid) {
 /// A card belonging to no live round answers [`WorkDriver::DetachedSolve`]: that covers
 /// a human-claimed card, an undirected board card, and a leftover claimed after its
 /// round ended. All three are the proven path, so the default is the conservative one.
+/// The round ROOM a card belongs to — which IS the round id (a round is its
+/// room's activity). `None` for a card outside every tracked round (human-created
+/// boards, ended rounds). The FOCUS rule reads this: a citizen's self-tick binds
+/// to the room of her freshest live claim, so she stops alternating rooms —
+/// measured 2026-08-22: two live claims in two rooms swapped her pinned slot's
+/// room-scoped context every tick, `cached: 0` by her own hand.
+pub fn room_for_card(card_id: Uuid) -> Option<Uuid> {
+    ROUNDS
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .values()
+        .find(|r| r.cards.contains_key(&card_id))
+        .map(|r| r.round_id)
+}
+
 pub fn driver_for_card(card_id: Uuid) -> WorkDriver {
     ROUNDS
         .lock()

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -1654,6 +1654,7 @@ impl LlmDeliberationFaculty {
             room_speech: &room_speech,
             working_memory: self.working_memory.as_ref(),
             room_id: Some(ws.room_id),
+            persona_id: Some(self.persona_id),
         };
         let facts = super::perception_facts::render_facts(
             &fact_cx,

--- a/core/continuum-core/src/cognition/perception_facts.rs
+++ b/core/continuum-core/src/cognition/perception_facts.rs
@@ -53,6 +53,12 @@ pub struct FactContext<'a> {
     /// honest count (CAUSAL-MEMORY-GRAPH.md slice B). `None` (roomless
     /// replays/tests) renders the unpartitioned ledger exactly as before.
     pub room_id: Option<Uuid>,
+    /// WHOSE facts these are — so ledger-class probes can name their persona.
+    /// The duplicate-cycle signature is two wm instances under ONE persona;
+    /// without this key the 2026-08-22 read (three wm ids in one room) was
+    /// unconvictable — three personas legitimately shared the round room.
+    /// `None` (replays/tests) renders exactly as before.
+    pub persona_id: Option<Uuid>,
 }
 
 /// One structural fact about the persona's present. `render` returns the
@@ -242,6 +248,11 @@ impl PerceptionFact for StepsLedger {
             // anonymous rows by counter arithmetic. A ledger row that cannot say
             // whose ledger it is cannot witness a duplicate.
             wm_instance = wm.instance_id(),
+            // The instance id alone could not convict a duplicate (2026-08-22:
+            // three wm ids in one ROOM read as a split-brain until it turned out
+            // to be three personas legitimately sharing the round room). The
+            // duplicate-cycle signature is two instance ids under ONE persona.
+            persona = %cx.persona_id.map(|p| p.to_string()).unwrap_or_else(|| "unscoped".into()),
             shown = fit.len(),
             elsewhere = elsewhere,
             taken = taken,
@@ -383,6 +394,7 @@ mod tests {
             room_speech: &[],
             working_memory: None,
             room_id: None,
+            persona_id: None,
         };
         let facts = render_facts(&cx, &FactPolicy::default());
         assert_eq!(facts.len(), 1, "quiet room: only the bounds fact renders");
@@ -402,6 +414,7 @@ mod tests {
             room_speech: &[],
             working_memory: None,
             room_id: None,
+            persona_id: None,
         };
         let mut policy = FactPolicy::default();
         policy.disable("context_bounds");
@@ -427,6 +440,7 @@ mod tests {
             room_speech: &[],
             working_memory: Some(&wm),
             room_id: None,
+            persona_id: None,
         };
         let ledger = |facts: &[String]| {
             facts
@@ -497,6 +511,7 @@ mod tests {
             room_speech: &[],
             working_memory: Some(&pre_archive),
             room_id: None,
+            persona_id: None,
         };
         let l = ledger(&render_facts(&cx2, &FactPolicy::default()));
         assert!(

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2484,7 +2484,7 @@ async fn run_self_cycle(
                         let room = crate::cognition::bench_round::room_for_card(
                             c.card_id.as_uuid(),
                         )?;
-                        Some((c.claim_expires_at_ms.unwrap_or(0), room))
+                        Some((c.claim_expires_at_ms.unwrap_or(0), room)) // unknown expiry sorts LEAST-fresh: it can never win focus over a known-live lease, and a lone expiry-less claim still focuses (better than home)
                     })
                     .collect();
                 live.sort_by_key(|(exp, _)| *exp);

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2458,13 +2458,60 @@ async fn run_self_cycle(
     last_burst_fp: &mut u64,
 ) {
     let now_ms = (opts.now_ms)();
+    // FOCUS (2026-08-22): a self-cycle with no triggering message binds to the
+    // room of her FRESHEST LIVE CLAIM when she holds one, else her home room.
+    // Home-room-always was the self-clobber engine measured tonight: a citizen
+    // holding a claim in a run room alternated home-room self-ticks with
+    // work-room turns, and every swap re-rendered the room-scoped context
+    // (kanban, steps-ledger, room speech) through her ONE pinned slot —
+    // `cached: 0` by her own hand, plus attention spent re-orienting in a room
+    // her work is not in. The institution's version: you sit at your desk
+    // until the job is done; the break room is for between jobs.
+    //
+    // Claim → room resolves through the bench-round registry (a round IS its
+    // room). A claim on an untracked card (human boards) resolves None and
+    // falls back home — never a guess. Freshest = max claim_expires_at_ms,
+    // i.e. the claim most recently taken or heartbeated.
+    let focus_room = match conversation.stream_citizen() {
+        Some(citizen) => citizen
+            .active_claims()
+            .await
+            .ok()
+            .and_then(|cards| {
+                let mut live: Vec<_> = cards
+                    .iter()
+                    .filter_map(|c| {
+                        let room = crate::cognition::bench_round::room_for_card(
+                            c.card_id.as_uuid(),
+                        )?;
+                        Some((c.claim_expires_at_ms.unwrap_or(0), room))
+                    })
+                    .collect();
+                live.sort_by_key(|(exp, _)| *exp);
+                live.pop().map(|(_, room)| room)
+            }),
+        None => None,
+    };
+    if let Some(room) = focus_room {
+        if room != ctx.identity.default_room {
+            crate::probe!(
+                class = "persona.selftick.focused",
+                persona = %ctx.identity.agent_name,
+                room = %room,
+                "self-tick bound to the held claim's room instead of home — \
+                 focus holds until the card settles",
+            );
+        }
+    }
     let composed = {
         let cognition = ctx.cognition.lock().await;
-        // A self-cycle has no triggering message, so the WHERE axis is her HOME
-        // room — the durable membership her sources are bound to. Passing None
-        // here is what made idle ticks blind to the board (#331 / #127).
+        // Passing None here is what made idle ticks blind to the board (#331 / #127).
         cognition
-            .compose_for_turn(&ctx.profile, now_ms, Some(ctx.identity.default_room))
+            .compose_for_turn(
+                &ctx.profile,
+                now_ms,
+                Some(focus_room.unwrap_or(ctx.identity.default_room)),
+            )
             .await
     };
     // Collapse loop-filler BEFORE anything reasons over the burst (task #16). Two idle


### PR DESCRIPTION
A citizen with a live claim stops alternating rooms on self-ticks — the measured self-clobber of her own pinned slot (cached:0 by her own hand). Claim→room via the bench-round registry (interim; durable answer is airc-side since the kanban IS a room's projection). Plus persona key on the steps-ledger probe so duplicate cycles are convictable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo