### PR TITLE
Framing by importance, volatile by content: active-work + room-board leave the stable head

### DIFF
--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -185,6 +185,17 @@ pub struct GroundingSource {
     /// A perception surface must never describe affordances that don't exist
     /// this cycle. `false` (default) = capability-neutral grounding.
     pub requires_hands: bool,
+    /// FRAMING BY IMPORTANCE, VOLATILE BY CONTENT (2026-08-22). `StandingFraming`
+    /// conflated two axes: selection priority (the attention floor — correct for
+    /// these sources) and PLACEMENT in the cacheable stable tier (correct only for
+    /// byte-stable content). `debug/prompt-reuse` convicted active-work and
+    /// room-board on live captures: their content flaps every turn ("card X
+    /// [Claimed]" ↔ "[work] Your claim on card X…") at ~char 7,900 of 90–185k-char
+    /// prompts — a mutating span parked at the TOP of the prompt, invalidating the
+    /// KV of everything behind it (worst pairs: 4% predicted reuse). `true` keeps
+    /// the salience floor but serializes the content in the volatile tail, nearest
+    /// generation, where mutation costs only itself.
+    pub volatile_content: bool,
 }
 
 impl GroundingSource {
@@ -197,6 +208,7 @@ impl GroundingSource {
             policy: SaliencePolicy::StandingFraming,
             deferrability: Deferrability::ColdStartCritical,
             requires_hands: false,
+            volatile_content: false,
         }
     }
 
@@ -214,6 +226,7 @@ impl GroundingSource {
             policy: SaliencePolicy::Retrieved,
             deferrability: Deferrability::ColdStartCritical,
             requires_hands: false,
+            volatile_content: false,
         }
     }
 
@@ -224,6 +237,13 @@ impl GroundingSource {
     /// participation gate).
     pub fn defer_tolerant(mut self) -> Self {
         self.deferrability = Deferrability::DeferTolerant;
+        self
+    }
+
+    /// Framing whose CONTENT mutates per turn (see field doc): keeps the
+    /// attention floor, loses the stable-tier placement.
+    pub fn volatile_content(mut self) -> Self {
+        self.volatile_content = true;
         self
     }
 }
@@ -424,7 +444,9 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     let grounding_budget = super::rag_source_faculty::grounding_budget_for(cfg.context_window);
     for g in cfg.grounding_sources {
         let faculty =
-            RagSourceFaculty::new(cfg.persona_id, g.source, g.policy).with_budget(grounding_budget);
+            RagSourceFaculty::new(cfg.persona_id, g.source, g.policy)
+            .with_budget(grounding_budget)
+            .with_volatile_content(g.volatile_content);
         match g.deferrability {
             Deferrability::DeferTolerant if cfg.defer_grounding => {
                 faculties.push(Arc::new(DeferredFaculty::spawn(Arc::new(faculty))));

--- a/core/continuum-core/src/cognition/rag_source_faculty.rs
+++ b/core/continuum-core/src/cognition/rag_source_faculty.rs
@@ -174,7 +174,11 @@ impl RagSourceFaculty {
             source,
             faculty_id,
             salience: policy.salience(),
-            // Standing framing is session-stable; retrieved grounding is volatile.
+            // Standing framing is session-stable by default; retrieved grounding
+            // is volatile. `with_volatile_content` overrides for framing whose
+            // BYTES mutate per turn (active-work, room-board — convicted by
+            // debug/prompt-reuse 2026-08-22): importance keeps the floor,
+            // placement follows content stability.
             stable: matches!(policy, SaliencePolicy::StandingFraming),
             // Floor default (derived from the substrate serving floor, not a magic
             // number). Production overrides via `with_budget(grounding_budget_for(
@@ -194,6 +198,15 @@ impl RagSourceFaculty {
     /// Override the per-tick token budget handed to the source.
     pub fn with_budget(mut self, budget: u32) -> Self {
         self.budget = budget;
+        self
+    }
+
+    /// Framing whose content mutates per turn: demote OUT of the stable tier
+    /// while keeping the StandingFraming salience floor (see `stable` field doc).
+    pub fn with_volatile_content(mut self, volatile: bool) -> Self {
+        if volatile {
+            self.stable = false;
+        }
         self
     }
 

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -915,7 +915,10 @@ pub async fn materialize_adapters(
                     crate::cognition::persona_workspace::GroundingSource::framing(
                         active_work_source,
                     )
-                    .defer_tolerant(),
+                    .defer_tolerant()
+                    // Claim states flap per turn — floor stays, stable-tier
+                    // placement goes (debug/prompt-reuse conviction, 2026-08-22).
+                    .volatile_content(),
                     // WHERE code lives — the real workspace layout as framing, so a
                     // reasoner can avoid blind globs like `src/**/*.rs` from the
                     // prompt alone. ColdStartCritical (synchronous, NOT deferred):
@@ -949,7 +952,9 @@ pub async fn materialize_adapters(
                     crate::cognition::persona_workspace::GroundingSource::framing(
                         room_board_source,
                     )
-                    .defer_tolerant(),
+                    .defer_tolerant()
+                    // Card/column states churn with the round — same conviction.
+                    .volatile_content(),
                     // Live-call perception (#187/#192): WHO is visible on the call +
                     // what they show, as enriching framing. Defer-tolerant: a
                     // first-tick miss costs one under-grounded turn, not a wrong one —


### PR DESCRIPTION
Replay scorer convicted both on live captures (worst pairs 4-10% reuse, divergence at ~char 7,900 of 90-185k prompts). New GroundingSource::volatile_content decouples the attention floor from stable-tier placement. Receipt to watch: cached% climbing on consecutive same-room turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo