### PR TITLE
feat(academy): live work on people surfaces — lapsed leases, PR links, roster work badges, scoreboard styling

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -997,40 +997,93 @@ export class ChatWidget extends LitElement {
       gap: 4px;
     }
     .bench-round {
+      position: relative;
       display: grid;
       grid-template-columns: auto auto auto 1fr auto;
       align-items: center;
       gap: 8px;
-      padding: 4px 8px;
-      border: 1px solid var(--border-color, #2a2a3a);
-      border-radius: 4px;
+      padding: 6px 10px 6px 12px;
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-sm);
+      background: color-mix(in srgb, var(--surface, #0b1220) 65%, transparent);
       font-size: 11px;
+      overflow: hidden;
+    }
+    /* Stage stripe: the round's lifecycle as a left edge of light —
+     * working breathes in the accent, done settles into success. */
+    .bench-round::before {
+      content: '';
+      position: absolute;
+      inset: 0 auto 0 0;
+      width: 3px;
+      background: var(--accent-primary);
+      box-shadow: 0 0 8px color-mix(in srgb, var(--accent-primary) 60%, transparent);
+      animation: bench-round-breathe 2.4s ease-in-out infinite;
+    }
+    .bench-round[data-stage='done']::before {
+      background: var(--status-success, #4caf7d);
+      box-shadow: 0 0 6px color-mix(in srgb, var(--status-success, #4caf7d) 50%, transparent);
+      animation: none;
+    }
+    @keyframes bench-round-breathe {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.45; }
     }
     .bench-round-name {
-      font-weight: 600;
+      font-weight: 700;
+      letter-spacing: 0.02em;
       white-space: nowrap;
+      color: var(--content-primary);
     }
     .bench-round-stage {
-      opacity: 0.7;
       text-transform: uppercase;
-      font-size: 9px;
-      letter-spacing: 0.06em;
+      font-size: 8.5px;
+      letter-spacing: 0.12em;
+      padding: 1px 6px;
+      border-radius: 999px;
+      border: 1px solid color-mix(in srgb, var(--accent-primary) 40%, transparent);
+      color: var(--accent-primary);
+      background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
+    }
+    .bench-round[data-stage='done'] .bench-round-stage {
+      border-color: color-mix(in srgb, var(--status-success, #4caf7d) 40%, transparent);
+      color: var(--status-success, #4caf7d);
+      background: color-mix(in srgb, var(--status-success, #4caf7d) 10%, transparent);
     }
     .bench-round-count {
       font-variant-numeric: tabular-nums;
+      font-weight: 700;
       white-space: nowrap;
+      color: var(--content-primary);
     }
     .bench-round .bench-bar {
       margin: 0;
     }
+    /* Settle bar earns a gradient + glow — progress is the row's headline. */
+    .bench-round .bench-bar-fill {
+      background: linear-gradient(
+        90deg,
+        color-mix(in srgb, var(--accent-primary) 75%, transparent),
+        var(--status-success, #4caf7d)
+      );
+      box-shadow: 0 0 6px color-mix(in srgb, var(--status-success, #4caf7d) 45%, transparent);
+    }
     .bench-round-driver {
-      font-size: 9px;
+      font-size: 8.5px;
       text-transform: uppercase;
-      letter-spacing: 0.06em;
-      opacity: 0.75;
+      letter-spacing: 0.1em;
+      padding: 1px 6px;
+      border-radius: 3px;
+      border: 1px solid var(--border-subtle);
+      color: var(--content-secondary);
     }
     .bench-round-detached {
       opacity: 0.45;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .bench-round::before {
+        animation: none;
+      }
     }
     .bench-stat {
       display: flex;
@@ -3304,6 +3357,27 @@ export class ChatWidget extends LitElement {
     }
     .claim-priority {
       color: var(--meter-par);
+    }
+    /* A lapsed LEASE is takeable, not busy (the 2026-08-06 distinction):
+     * grey the row, badge the fact, keep the holder named as who to ask. */
+    .claim[data-lapsed] .claim-title {
+      opacity: 0.55;
+    }
+    .claim-lapsed {
+      font-size: 9px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      border: 1px solid var(--border-color, #2a2a3a);
+      border-radius: 3px;
+      padding: 0 4px;
+      opacity: 0.7;
+    }
+    .claim-pr {
+      font-size: 10px;
+      text-decoration: none;
+      border: 1px solid var(--border-color, #2a2a3a);
+      border-radius: 3px;
+      padding: 0 4px;
     }
     @media (prefers-reduced-motion: reduce) {
       .p-avatar[data-online],

--- a/apps/web/src/persona/renderPersona.ts
+++ b/apps/web/src/persona/renderPersona.ts
@@ -110,11 +110,17 @@ function pathwayTile(p: PersonaPathwayVM): TemplateResult {
 /** One claims-feed row — a work-board card this persona owns. */
 function claimRow(c: PersonaClaimVM): TemplateResult {
   const ago = agoLabel(c.updatedAtMs);
-  return html`<li class="claim" data-state=${c.state}>
+  return html`<li class="claim" data-state=${c.state} data-lapsed=${c.holdLapsed ? '' : nothing}>
     <span class="claim-state">${c.state.replace('_', ' ')}</span>
     <span class="claim-title">${c.title}</span>
     <span class="claim-meta">
       <span class="claim-priority">${c.priority}</span>
+      ${c.holdLapsed
+        ? html`<span class="claim-lapsed" title="the claim's lease expired — the card is takeable; ask this persona before taking it">lease lapsed</span>`
+        : nothing}
+      ${c.prUrl
+        ? html`<a class="claim-pr" href=${c.prUrl} target="_blank" rel="noopener" title="the card's landing PR">PR</a>`
+        : nothing}
       ${ago ? html`<span class="claim-ago">${ago}</span>` : nothing}
     </span>
   </li>`;

--- a/apps/web/src/preview.ts
+++ b/apps/web/src/preview.ts
@@ -65,6 +65,19 @@ const BENCH_FIXTURE: BenchViewState = {
       pass_to_pass: '6/6', failed_tests: [],
     },
   ],
+  // In-flight ROUNDS (#371) — mirrors the real 2026-08-22 board the hour the
+  // rows landed: the DS-1000 maiden round at done (4/4, the first external
+  // round ever to complete) beside a working SWE round.
+  rounds: [
+    {
+      round_id: '2d6decb3-1beb-5ac7-9ded-ee186c7deb7f', benchmark: 'ds-1000',
+      stage: 'done', dispatched: 4, settled: 4, remaining: 0, driver: 'citizen',
+    },
+    {
+      round_id: 'bf08832d-c7e2-5bc9-a858-5447c15ccbfe', benchmark: 'swe-bench-lite',
+      stage: 'working', dispatched: 4, settled: 1, remaining: 3, driver: 'citizen',
+    },
+  ],
 };
 
 const member = (over: Partial<RosterSlotView>): RosterSlotView => ({

--- a/packages/chat-view/patternProjections.ts
+++ b/packages/chat-view/patternProjections.ts
@@ -85,13 +85,42 @@ function rosterCell(m: RosterMemberVM): ListingCell {
   return cell;
 }
 
+/** Live work summary for one member off the kanban board — the roster row's
+ *  who-is-working-what fact (peer visibility for humans; the same projection
+ *  later feeds citizen perception). Badges only when there IS work: `⚒ N`
+ *  (live-held cards), the hottest priority when any is P0/P1, and `lapsed`
+ *  when every claim's lease expired (takeable, not busy — the 2026-08-06
+ *  six-citizens-stalled distinction). */
+function workBadges(board: KanbanViewState | undefined, memberId: string): string[] {
+  if (!board) return [];
+  const mine = board.cards.filter(
+    (c) => c.assignee_id === memberId && c.state !== 'merged' && c.state !== 'closed',
+  );
+  if (mine.length === 0) return [];
+  const held = mine.filter((c) => c.hold === 'held');
+  const badges: string[] = [`⚒ ${held.length > 0 ? held.length : mine.length}`];
+  const hot = mine.some((c) => c.priority === 'p0')
+    ? 'P0'
+    : mine.some((c) => c.priority === 'p1')
+      ? 'P1'
+      : undefined;
+  if (hot) badges.push(hot);
+  if (held.length === 0) badges.push('lapsed');
+  return badges;
+}
+
 /** The chat activity's `who` panel projected as the `Listing` primitive. Same shape
- *  the rooms/DMs list and Foundry's model list use — one primitive, different data. */
-export function rosterListing(vm: ChatViewModel): ListingView {
+ *  the rooms/DMs list and Foundry's model list use — one primitive, different data.
+ *  With the board feed attached, each row also carries its live work badges. */
+export function rosterListing(vm: ChatViewModel, board?: KanbanViewState): ListingView {
   return {
     id: 'roster',
     title: 'Users & Agents',
-    cells: vm.members.map(rosterCell),
+    cells: vm.members.map((m) => {
+      const work = workBadges(board, m.id);
+      const cell = rosterCell(m);
+      return work.length > 0 ? { ...cell, badges: [...(cell.badges ?? []), ...work] } : cell;
+    }),
   };
 }
 
@@ -491,7 +520,7 @@ export function chatWorkspace(vm: ChatViewModel, live?: WorkspaceLive): Workspac
     systemPanelWidget(vm, live?.sys, live?.serving),
     ...(nodes ? [nodes] : []),
     listingWidget(rooms),
-    listingWidget(rosterListing(vm)),
+    listingWidget(rosterListing(vm, live?.board)),
   ];
   // The live benchmark board (#329) — joins the contextual rail whenever this
   // node has runs, filling the academy's dead right column.

--- a/packages/chat-view/personaProjections.ts
+++ b/packages/chat-view/personaProjections.ts
@@ -140,6 +140,15 @@ export function personaClaims(
       state: c.state,
       priority: c.priority.toUpperCase(),
       updatedAtMs: c.updated_at,
+      // A lapsed LEASE is takeable, not busy — the substrate says it, the
+      // row renders it ([[fallbacks-are-illegal-fail-loud]]; six citizens
+      // stalled a night on a board that hid this, 2026-08-06).
+      holdLapsed: c.hold === 'lapsed',
+      ...(c.pull_request
+        ? {
+            prUrl: `https://github.com/${c.pull_request.repo}/pull/${c.pull_request.number}`,
+          }
+        : {}),
     }))
     .sort((a, b) => b.updatedAtMs - a.updatedAtMs);
 }

--- a/packages/patterns/personaContent.ts
+++ b/packages/patterns/personaContent.ts
@@ -83,6 +83,13 @@ export interface PersonaClaimVM {
   readonly priority: string;
   /** Raw epoch ms of the card's last event — the renderer formats recency. */
   readonly updatedAtMs: number;
+  /** True when the claim's LEASE expired — the holder stopped and the card is
+   *  takeable. Rendering a lapsed hold like live work is the defect that
+   *  stalled six citizens for a night (2026-08-06); the substrate SAYS it,
+   *  renderers never re-derive. */
+  readonly holdLapsed: boolean;
+  /** Landing link once a PR exists for the card. */
+  readonly prUrl?: string;
 }
 
 /** One published writing of the persona (blog / wonder-work feed). The feed is


### PR DESCRIPTION
Third academy slice per Joel's targets (user list rows · persona pages · beautiful): claims rows carry the lease truth (lapsed = takeable, grey + badged) and PR link chips; roster rows show who-is-working-what (⚒ held count, hottest priority, lapsed flag) from the kanban pipe; round rows get scoreboard-grade styling (breathing stage stripe, gradient settle bar) in the existing token system. Preview fixture mirrors the real 2026-08-22 board; screenshots delivered from the live widget.

Validation: all client suites green (218 tests), typecheck 0 errors, lint 67 (one below canary's 68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo