### PR TITLE
feat(genome): GeneSignature — minted at job-create, stamped at adoption (resolver slice 1)

### DIFF
--- a/core/continuum-core/src/commands/genome/job_create.rs
+++ b/core/continuum-core/src/commands/genome/job_create.rs
@@ -174,6 +174,48 @@ crate::action_command! {
         let watched_base_model = p.request.base_model.clone();
         let watched_trait_kind = p.request.trait_kind.clone();
         let watched_eval_set = p.request.eval_set.clone();
+        // MINT the gene's embedding-space signature NOW — the training corpus is
+        // in hand at exactly this moment and never again (the audited 2026-08-22
+        // break: an adopted gene's corpus was unreferenceable). Best-effort: a
+        // failed mint warns and trains anyway — the gene routes by the fallback
+        // path; it never blocks the training the persona is owed.
+        let watched_signature = {
+            let texts: Vec<String> = p
+                .request
+                .dataset
+                .examples
+                .iter()
+                .map(|ex| format!("{}\n{}", ex.prompt, ex.completion))
+                .collect();
+            let joined = texts.join("\n");
+            let corpus = crate::forge::recipe::CorpusRef {
+                name: p
+                    .dataset_name
+                    .clone()
+                    .unwrap_or_else(|| format!("inline:{}", p.request.trait_kind)), // inline datasets have no on-disk name; the trait names the mint
+                content_hash: crate::persona::inbox_admission::content_hash_sha256(&joined),
+                size_bytes: joined.len() as u64,
+                source_url: None,
+            };
+            let embedder = crate::cognition::embedding::resolve_recall_embedder_local().await;
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0); // pre-epoch clock: mint stamps 0 rather than refusing the gene its training
+            match crate::genome::signature::GeneSignature::mint(&texts, corpus, &embedder, now_ms)
+                .await
+            {
+                Ok(sig) => Some(sig),
+                Err(e) => {
+                    tracing::warn!(
+                        trait_kind = %p.request.trait_kind,
+                        error = %e,
+                        "gene signature mint failed — training proceeds, gene will route by fallback"
+                    );
+                    None
+                }
+            }
+        };
 
         // 2. Adapter creates the job. FineTuningError carries a stable errorKind
         //    slug callers branch on for retry-vs-surface.
@@ -196,6 +238,7 @@ crate::action_command! {
                         base_model: watched_base_model,
                         trait_kind: watched_trait_kind,
                         eval_set: watched_eval_set,
+                        signature: watched_signature,
                     },
                 );
                 Ok(JobCreateOutcome {

--- a/core/continuum-core/src/forge/recipe.rs
+++ b/core/continuum-core/src/forge/recipe.rs
@@ -104,7 +104,7 @@ pub struct PriorBaseline {
 /// (consensus position #8 from the design review). Cross-domain
 /// consistency: any two subsystems comparing hashes can do
 /// string-equality without normalization.
-#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "../../../protocol/typescript/forge/CorpusRef.ts")]
 pub struct CorpusRef {
     /// Human-readable corpus name (e.g., "wikitext-103-v1").

--- a/core/continuum-core/src/genome/candidate_source_store.rs
+++ b/core/continuum-core/src/genome/candidate_source_store.rs
@@ -35,12 +35,19 @@ use crate::cognition::embedding::{cosine_similarity, EmbeddingProvider};
 pub struct LocalGenomeLayer {
     /// Content-hash identity (the market's tag/line).
     pub artifact_id: ArtifactId,
-    /// The layer's card/domain/keyword text — embedded for the cosine match.
+    /// The layer's card/domain/keyword text — embedded for the cosine match
+    /// WHEN no minted signature exists (the fallback path).
     pub match_text: String,
     /// Epoch-ms of last use (recency factor).
     pub last_used_ms: u64,
     /// Provenance trust (local, refined layers score high).
     pub trust_factor: f32,
+    /// The gene's MINTED embedding-space identity, when the adoption chain
+    /// stamped one ([`crate::genome::signature`]). Preferred over `match_text`:
+    /// computed from the actual training corpus (centroid + subspaces, so
+    /// tangential reach survives), and it kills the per-call re-embed of every
+    /// layer that the fallback path pays.
+    pub signature: Option<crate::genome::signature::GeneSignature>,
 }
 
 /// A [`CandidateSource`] over the local genome store. Holds the persona's layers
@@ -94,6 +101,38 @@ impl GenomeStoreCandidateSource {
                 // Local, persona-owned layers are trusted; a refined layer scores
                 // higher still once the sentinel-attribution slice lands.
                 trust_factor: 0.9,
+                // The paging-engine view carries no path to join the sidecar on;
+                // signatures arrive via `from_manifest` (the manifest IS keyed by
+                // path). This constructor stays the signature-less fallback.
+                signature: None,
+            })
+            .collect();
+        Self::new(layers, embedder)
+    }
+
+    /// Build the source from the durable adapter MANIFEST joined with the
+    /// signature sidecar — the store the adoption chain stamps
+    /// ([`crate::genome::signature::SignatureStore`]). Every registered gene
+    /// becomes a candidate; the ones the sentinel adopted since the signature
+    /// slice landed carry their minted identity and rank by it.
+    pub fn from_manifest(
+        manifest: &[crate::forge::adapter_manifest::TrainedAdapter],
+        signatures: &crate::genome::signature::SignatureStore,
+        embedder: Arc<dyn EmbeddingProvider>,
+    ) -> Self {
+        let layers = manifest
+            .iter()
+            .map(|a| LocalGenomeLayer {
+                artifact_id: stable_local_id(&a.alias),
+                match_text: a.alias.clone(),
+                // The manifest carries no recency; 0 = "never used" and the
+                // recency term decays it honestly rather than inventing warmth.
+                last_used_ms: 0,
+                trust_factor: 0.9,
+                signature: signatures
+                    .by_path
+                    .get(&a.path.display().to_string())
+                    .cloned(),
             })
             .collect();
         Self::new(layers, embedder)
@@ -125,8 +164,21 @@ impl CandidateSource for GenomeStoreCandidateSource {
         let q_emb = self.embedder.embed(&Self::query_text(query)).await;
         let mut out = Vec::with_capacity(self.layers.len());
         for layer in &self.layers {
-            let l_emb = self.embedder.embed(&layer.match_text).await;
-            let semantic_factor = cosine_similarity(&q_emb, &l_emb).clamp(0.0, 1.0);
+            // A minted signature answers first: corpus-derived centroid+subspaces
+            // (max over both, so tangential reach counts), zero per-layer embeds.
+            // Space mismatch (different embedder/dim) returns None and the layer
+            // falls back to its match_text — honest degrade, never a lying 0.0.
+            let semantic_factor = match layer
+                .signature
+                .as_ref()
+                .and_then(|s| s.similarity_in(self.embedder.id(), &q_emb))
+            {
+                Some(sim) => sim.clamp(0.0, 1.0),
+                None => {
+                    let l_emb = self.embedder.embed(&layer.match_text).await;
+                    cosine_similarity(&q_emb, &l_emb).clamp(0.0, 1.0)
+                }
+            };
             out.push(CandidateArtifact {
                 kind: PageKind::LoRALayer,
                 artifact_id: layer.artifact_id,
@@ -161,7 +213,64 @@ mod tests {
             match_text: text.to_string(),
             last_used_ms: 1000,
             trust_factor: 0.9,
+            signature: None,
         }
+    }
+
+    // what this catches: the signature-first contract. A layer with a minted
+    // signature ranks by IT (corpus-derived, subspace-max) — its match_text is
+    // deliberately misleading here and must not matter; a layer whose signature
+    // is from another SPACE falls back to match_text instead of scoring a lying
+    // 0.0 (which would demote every signed gene after an embedder upgrade).
+    #[tokio::test]
+    async fn a_minted_signature_outranks_match_text_and_wrong_space_falls_back() {
+        let embedder: Arc<dyn EmbeddingProvider> = Arc::new(LexicalEmbedder::default());
+        let corpus: Vec<String> =
+            vec!["parse tokens into an ast".into(), "lex the source stream".into()];
+        let corpus_ref = crate::forge::recipe::CorpusRef {
+            name: "parser-corpus".into(),
+            content_hash: "sha256:00".into(),
+            size_bytes: 1,
+            source_url: None,
+        };
+        let sig = crate::genome::signature::GeneSignature::mint(
+            &corpus,
+            corpus_ref,
+            &embedder,
+            0,
+        )
+        .await
+        .expect("mint");
+
+        // Signed layer: match_text is unrelated noise — the signature must carry it.
+        let mut signed = layer("completely unrelated cooking recipes");
+        signed.signature = Some(sig.clone());
+        // Wrong-space layer: same signature but claiming another embedder — must
+        // fall back to its (relevant) match_text, not die at 0.
+        let mut wrong_space = layer("parse tokens into an ast");
+        wrong_space.signature = Some(crate::genome::signature::GeneSignature {
+            embedder: "some-other-space".into(),
+            ..sig
+        });
+
+        let source = GenomeStoreCandidateSource::new(vec![signed, wrong_space], embedder);
+        let got = source
+            .fetch(
+                &query_for("parse tokens into an ast"),
+                &RecallContext::cold_start(crate::identity::PeerId::from_uuid(Uuid::nil())),
+            )
+            .await;
+        assert_eq!(got.len(), 2);
+        assert!(
+            got[0].semantic_factor > 0.5,
+            "signature carries the signed layer despite misleading match_text: {}",
+            got[0].semantic_factor
+        );
+        assert!(
+            got[1].semantic_factor > 0.5,
+            "wrong-space signature falls back to match_text: {}",
+            got[1].semantic_factor
+        );
     }
 
     fn query_for(domain: &str) -> CapabilityQuery {

--- a/core/continuum-core/src/genome/fine_tuning/job_board.rs
+++ b/core/continuum-core/src/genome/fine_tuning/job_board.rs
@@ -90,6 +90,13 @@ pub struct WatchedJob {
     /// gene is unmeasurable and the sentinel refuses to adopt it (never falls back to
     /// a default gym — [[fallbacks-are-illegal-fail-loud]]).
     pub eval_set: Option<String>,
+    /// The gene's embedding-space identity, MINTED at `genome/job-create` — the
+    /// one moment the training corpus is in hand (before this field the chain
+    /// broke there: an adopted gene's corpus was unreferenceable, audited
+    /// 2026-08-22). Carried here so the sentinel can stamp it into the
+    /// signature sidecar at adoption. `None` = mint failed or predates the
+    /// field; the gene still adopts, it just routes by the fallback path.
+    pub signature: Option<crate::genome::signature::GeneSignature>,
 }
 
 /// Process-global registry of in-flight training jobs. DashMap-backed so the L2
@@ -294,6 +301,7 @@ mod tests {
             base_model: "qwen3-coder".to_string(),
             trait_kind: "code".to_string(),
             eval_set: Some("docs/genome/coder-eval.jsonl".to_string()),
+            signature: None,
         }
     }
 

--- a/core/continuum-core/src/genome/mod.rs
+++ b/core/continuum-core/src/genome/mod.rs
@@ -69,6 +69,7 @@ pub mod fine_tuning;
 pub mod fitness;
 pub mod gate_magnitude;
 pub mod local_manager;
+pub mod signature;
 pub mod manager;
 pub mod recall;
 pub mod recall_trait;

--- a/core/continuum-core/src/genome/signature.rs
+++ b/core/continuum-core/src/genome/signature.rs
@@ -1,0 +1,321 @@
+//! `GeneSignature` — a gene's identity in embedding space, COMPUTED at mint,
+//! never authored ([[gene-routing-is-distance-not-keywords]]).
+//!
+//! The routing question "which gene helps this task?" is nearest-neighbor in
+//! the SAME embedding space engram recall uses — gene recall and memory recall
+//! are one problem, so this module reuses the one embedding lane
+//! ([`crate::cognition::embedding`]) and the one clustering kernel
+//! ([`crate::modules::embedding::detect_clusters`]), never a parallel space.
+//!
+//! # Where signatures come from and where they live
+//!
+//! The training corpus is in hand exactly once: at `genome/job-create`, before
+//! the dataset is consumed by the trainer. The chain used to BREAK there — by
+//! the time the L3 sentinel adopted a gene, the corpus that produced it was no
+//! longer referenceable (audited 2026-08-22: `WatchedJob` carried `eval_set`
+//! but no corpus pointer). So: **mint at job-create**, carry on the
+//! [`WatchedJob`](crate::genome::fine_tuning::WatchedJob), and the sentinel
+//! **stamps** the adopted gene's signature into the [`SignatureStore`] sidecar
+//! beside the adapter manifest — a sidecar, not a `TrainedAdapter` field,
+//! because the manifest struct derives `Eq` (a `Vec<f32>` would forfeit it)
+//! and because old manifests must keep loading byte-identically.
+//!
+//! # The shape
+//!
+//! - `centroid` — L2-normalized mean of the corpus embeddings: the gene's
+//!   center of mass.
+//! - `subspaces` — cluster centroids over the same embeddings: a gene is near
+//!   SEVERAL domains (an FP gene is near Scheme AND near parsers), and
+//!   similarity takes the max over centroid+subspaces so tangential reach
+//!   survives averaging.
+//! - `embedder` + `dim` — the embedding-SPACE identity. Similarity across
+//!   mismatched spaces is meaningless, so [`GeneSignature::similarity_in`]
+//!   returns `None` on mismatch (honest absence, never a lying 0.0) and the
+//!   caller falls back to its non-signature path.
+//! - `corpus` — the [`CorpusRef`] (name + `sha256:` hash + size): the
+//!   falsifiable mint provenance a gene card publishes.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::cognition::embedding::{cosine_similarity, EmbeddingProvider};
+use crate::forge::recipe::CorpusRef;
+
+/// Cluster admission floor for subspace detection. The recall space is
+/// anisotropic (unrelated pairs sit ~0.25–0.30, see `recall_faculty`'s war
+/// story), so this must clear the unrelated band by a wide margin — 0.55 keeps
+/// only genuinely themed neighborhoods.
+const SUBSPACE_MIN_SIMILARITY: f32 = 0.55;
+
+/// A subspace must be a THEME, not an outlier pair.
+const SUBSPACE_MIN_CLUSTER_SIZE: usize = 3;
+
+/// Routing needs coarse domains, not a topic model — and the signature rides
+/// wire/cards, so its size is bounded. Largest clusters win the seats.
+const MAX_SUBSPACES: usize = 4;
+
+/// A gene's computed identity in embedding space. See the module docs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeneSignature {
+    /// Embedding-space identity — the provider's `id()` at mint time.
+    pub embedder: String,
+    /// Vector dimensionality of that space.
+    pub dim: usize,
+    /// L2-normalized mean of the corpus embeddings.
+    pub centroid: Vec<f32>,
+    /// Cluster centroids (each L2-normalized), largest clusters first,
+    /// at most [`MAX_SUBSPACES`]. May be empty (a corpus with one theme).
+    pub subspaces: Vec<Vec<f32>>,
+    /// Falsifiable mint provenance: which corpus, hashed, how big.
+    pub corpus: CorpusRef,
+    /// Unix-ms mint time (receipt-age axis for later fitness decay).
+    pub minted_at_ms: u64,
+}
+
+/// L2-normalize in place; a zero vector stays zero (and can never win a max).
+fn normalize(v: &mut [f32]) {
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > f32::EPSILON {
+        for x in v.iter_mut() {
+            *x /= norm;
+        }
+    }
+}
+
+impl GeneSignature {
+    /// Mint a signature from the training corpus. Embeds every text through
+    /// the ONE embedding lane (the content-addressed cache absorbs repeats),
+    /// takes the normalized mean as centroid, and cluster centroids as
+    /// subspaces. An empty corpus fails loud — a signature minted from
+    /// nothing would route by noise.
+    pub async fn mint(
+        corpus_texts: &[String],
+        corpus: CorpusRef,
+        embedder: &Arc<dyn EmbeddingProvider>,
+        now_ms: u64,
+    ) -> Result<Self, String> {
+        if corpus_texts.is_empty() {
+            return Err("gene signature mint refused: empty corpus (routing by noise)".into());
+        }
+        let dim = embedder.dim();
+        let mut embeddings: Vec<Vec<f32>> = Vec::with_capacity(corpus_texts.len());
+        for text in corpus_texts {
+            let e = embedder.embed(text).await;
+            if e.len() != dim {
+                return Err(format!(
+                    "embedder '{}' returned {} dims (declared {dim}) — refusing a corrupt signature",
+                    embedder.id(),
+                    e.len()
+                ));
+            }
+            embeddings.push(e);
+        }
+        // Centroid: mean of (already-normalized) embeddings, re-normalized.
+        let mut centroid = vec![0.0f32; dim];
+        for e in &embeddings {
+            for (c, x) in centroid.iter_mut().zip(e) {
+                *c += x;
+            }
+        }
+        let n = embeddings.len() as f32;
+        for c in centroid.iter_mut() {
+            *c /= n;
+        }
+        normalize(&mut centroid);
+
+        // Subspaces: the shared clustering kernel, largest themes first.
+        let mut clusters = crate::modules::embedding::detect_clusters(
+            &embeddings,
+            SUBSPACE_MIN_SIMILARITY,
+            SUBSPACE_MIN_CLUSTER_SIZE,
+        );
+        clusters.sort_by_key(|c| std::cmp::Reverse(c.indices.len()));
+        let subspaces = clusters
+            .into_iter()
+            .take(MAX_SUBSPACES)
+            .map(|c| {
+                let mut mean = vec![0.0f32; dim];
+                for &i in &c.indices {
+                    for (m, x) in mean.iter_mut().zip(&embeddings[i]) {
+                        *m += x;
+                    }
+                }
+                let k = c.indices.len() as f32;
+                for m in mean.iter_mut() {
+                    *m /= k;
+                }
+                normalize(&mut mean);
+                mean
+            })
+            .collect();
+
+        Ok(Self {
+            embedder: embedder.id().to_string(),
+            dim,
+            centroid,
+            subspaces,
+            corpus,
+            minted_at_ms: now_ms,
+        })
+    }
+
+    /// Similarity of a query embedding to this gene, in the named space.
+    /// `None` when the spaces don't match (different embedder or dim) —
+    /// honest absence; the caller falls back to its non-signature path
+    /// rather than comparing apples to oranges as 0.0.
+    pub fn similarity_in(&self, embedder_id: &str, query: &[f32]) -> Option<f32> {
+        if embedder_id != self.embedder || query.len() != self.dim {
+            return None;
+        }
+        let mut best = cosine_similarity(query, &self.centroid);
+        for s in &self.subspaces {
+            best = best.max(cosine_similarity(query, s));
+        }
+        Some(best)
+    }
+}
+
+/// The sidecar store: gene path → signature, persisted beside the adapter
+/// manifest (so a `CONTINUUM_ADAPTER_MANIFEST` override relocates both).
+/// Keyed by the gene's on-disk PATH string — the same identity the manifest
+/// dedups on. One writer (the L3 sentinel at adoption); readers are the
+/// resolver's candidate sources.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct SignatureStore {
+    /// gene path (as recorded on its `TrainedAdapter`) → signature.
+    pub by_path: BTreeMap<String, GeneSignature>,
+}
+
+/// Where the sidecar lives: next to the manifest, same override semantics.
+pub fn signature_store_path() -> Result<PathBuf, String> {
+    Ok(crate::forge::adapter_manifest::manifest_path()?.with_file_name("signatures.json"))
+}
+
+impl SignatureStore {
+    /// Load the store at `path`. Missing file = empty store (the legitimate
+    /// pre-first-adoption state); present-but-unparsable fails loud — a
+    /// half-read store would silently unroute every signed gene.
+    pub fn load_at(path: &std::path::Path) -> Result<Self, String> {
+        match std::fs::read_to_string(path) {
+            Ok(text) => serde_json::from_str(&text)
+                .map_err(|e| format!("signature store {} unparsable: {e}", path.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(format!("signature store {} unreadable: {e}", path.display())),
+        }
+    }
+
+    /// Stamp (insert or replace) one gene's signature and persist atomically
+    /// (tmp + rename — a crash never leaves a torn store).
+    pub fn stamp_at(
+        path: &std::path::Path,
+        gene_path: &str,
+        signature: GeneSignature,
+    ) -> Result<(), String> {
+        let mut store = Self::load_at(path)?;
+        store.by_path.insert(gene_path.to_string(), signature);
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+        }
+        let tmp = path.with_extension("json.tmp");
+        let text = serde_json::to_string_pretty(&store).map_err(|e| format!("serialize: {e}"))?;
+        std::fs::write(&tmp, text).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+        std::fs::rename(&tmp, path).map_err(|e| format!("rename {}: {e}", path.display()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cognition::embedding::LexicalEmbedder;
+
+    fn corpus_ref() -> CorpusRef {
+        CorpusRef {
+            name: "test-corpus".into(),
+            content_hash: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                .into(),
+            size_bytes: 42,
+            source_url: None,
+        }
+    }
+
+    // what this catches: the mint contract — a signature is COMPUTED, normalized,
+    // space-stamped, and refuses an empty corpus. LexicalEmbedder is deterministic,
+    // so the same corpus always mints the same signature (the property that makes a
+    // published signature falsifiable: anyone can re-mint and compare).
+    #[tokio::test]
+    async fn mint_is_deterministic_normalized_and_refuses_an_empty_corpus() {
+        let embedder: Arc<dyn EmbeddingProvider> = Arc::new(LexicalEmbedder::default());
+        let texts: Vec<String> = ["fold the list", "map the vector", "recursion base case"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let a = GeneSignature::mint(&texts, corpus_ref(), &embedder, 1_000)
+            .await
+            .expect("mint");
+        let b = GeneSignature::mint(&texts, corpus_ref(), &embedder, 1_000)
+            .await
+            .expect("mint");
+        assert_eq!(a.centroid, b.centroid, "same corpus, same signature — falsifiable");
+        assert_eq!(a.embedder, embedder.id());
+        assert_eq!(a.dim, embedder.dim());
+        let norm: f32 = a.centroid.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-4, "centroid is unit-length, got {norm}");
+
+        let err = GeneSignature::mint(&[], corpus_ref(), &embedder, 1_000)
+            .await
+            .expect_err("empty corpus must refuse");
+        assert!(err.contains("empty corpus"), "{err}");
+    }
+
+    // what this catches: cross-SPACE comparison silently passing. A similarity
+    // between vectors from different embedders (or dims) is meaningless; returning
+    // 0.0 would quietly demote every signed gene instead of falling back — the
+    // honest answer is None, and same-space queries answer with a real cosine.
+    #[tokio::test]
+    async fn similarity_answers_in_its_own_space_and_refuses_others() {
+        let embedder: Arc<dyn EmbeddingProvider> = Arc::new(LexicalEmbedder::default());
+        let texts: Vec<String> = vec!["parse the tokens".into(), "lex the source".into()];
+        let sig = GeneSignature::mint(&texts, corpus_ref(), &embedder, 0)
+            .await
+            .expect("mint");
+
+        let near = embedder.embed("parse the tokens").await;
+        let sim = sig
+            .similarity_in(embedder.id(), &near)
+            .expect("same space answers");
+        assert!(sim > 0.0, "a corpus member scores positive, got {sim}");
+
+        assert!(sig.similarity_in("some-other-embedder", &near).is_none());
+        assert!(sig.similarity_in(embedder.id(), &near[..near.len() - 1]).is_none());
+    }
+
+    // what this catches: the sidecar's load/stamp contract — missing file is the
+    // legitimate empty state, a stamp round-trips, and re-stamping the same path
+    // REPLACES (a retrained gene's new signature must win, never duplicate).
+    #[tokio::test]
+    async fn the_sidecar_store_round_trips_and_restamp_replaces() {
+        let embedder: Arc<dyn EmbeddingProvider> = Arc::new(LexicalEmbedder::default());
+        let sig = GeneSignature::mint(&["alpha".to_string()], corpus_ref(), &embedder, 7)
+            .await
+            .expect("mint");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("signatures.json");
+
+        assert!(SignatureStore::load_at(&path).expect("missing = empty").by_path.is_empty());
+
+        SignatureStore::stamp_at(&path, "/genes/fp.gguf", sig.clone()).expect("stamp");
+        let loaded = SignatureStore::load_at(&path).expect("load");
+        assert_eq!(loaded.by_path.len(), 1);
+        assert_eq!(loaded.by_path["/genes/fp.gguf"].minted_at_ms, 7);
+
+        let mut newer = sig;
+        newer.minted_at_ms = 9;
+        SignatureStore::stamp_at(&path, "/genes/fp.gguf", newer).expect("restamp");
+        let reloaded = SignatureStore::load_at(&path).expect("reload");
+        assert_eq!(reloaded.by_path.len(), 1, "replace, never duplicate");
+        assert_eq!(reloaded.by_path["/genes/fp.gguf"].minted_at_ms, 9);
+    }
+}

--- a/core/continuum-core/src/genome/signature.rs
+++ b/core/continuum-core/src/genome/signature.rs
@@ -58,7 +58,8 @@ const SUBSPACE_MIN_CLUSTER_SIZE: usize = 3;
 const MAX_SUBSPACES: usize = 4;
 
 /// A gene's computed identity in embedding space. See the module docs.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// `PartialEq` (never `Eq`: f32) so layer structs comparing themselves can hold one.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GeneSignature {
     /// Embedding-space identity — the provider's `id()` at mint time.
     pub embedder: String,

--- a/core/continuum-core/src/modules/training_completion_sentinel.rs
+++ b/core/continuum-core/src/modules/training_completion_sentinel.rs
@@ -272,10 +272,31 @@ impl TrainingCompletionSentinel {
 
             cycle.page_in(vec![ActiveAdapterRequest {
                 name: job.trait_kind.clone(),
-                path: path_str,
+                path: path_str.clone(),
                 domain: job.trait_kind.clone(),
                 scale: 1.0,
             }]);
+
+            // STAMP the signature into the sidecar at the same moment the gene
+            // becomes live — adoption is the one event where the gene's path,
+            // its minted signature, and its measured worth are all in hand.
+            // Best-effort: a failed stamp warns; the gene serves either way and
+            // routes by fallback until the next adoption re-stamps.
+            if let Some(sig) = job.signature.clone() {
+                match crate::genome::signature::signature_store_path() {
+                    Ok(store) => {
+                        if let Err(e) = crate::genome::signature::SignatureStore::stamp_at(
+                            &store, &path_str, sig,
+                        ) {
+                            tracing::warn!(gene = %path_str, error = %e,
+                                "adopted gene's signature failed to stamp — routes by fallback");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "signature store path unresolvable — signature not stamped");
+                    }
+                }
+            }
 
             tracing::info!(
                 persona = %job.persona_id,


### PR DESCRIPTION
First build slice of the genome resolver arc (Joel: "Let's build it"), grounded in the full substrate inventory: the DemandAlignedRecall engine already exists unwired in genome/ — what was genuinely missing was the signature and its threading.

- `genome/signature.rs`: GeneSignature (embedder-space identity, normalized centroid, ≤4 subspace cluster centroids via the shared `detect_clusters` kernel, CorpusRef provenance) + `similarity_in` (None on space mismatch — honest absence) + SignatureStore sidecar (atomic stamp, missing-file = legit empty, replace-on-restamp).
- Threading: minted at `genome/job-create` (corpus in hand exactly once), carried on `WatchedJob`, stamped by the training-completion sentinel at adoption (lift > 0) keyed by the gene's manifest path.
- Best-effort discipline: mint/stamp failures warn loudly and never block training or adoption; unsigned genes route by the existing fallback.

Validation: 351 tests green (genome tree + job board + sentinel + signature's 3 new regression tests + both hygiene ratchets); cargo check clean (metal,accelerate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo