### PR TITLE
feat(settings): the operator panel — covenant, HF identity, gene registry (positronic consent surface)

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -40,6 +40,10 @@ import {
   LIVE_MIC_TOGGLE,
   LIVE_CAPTIONS_TOGGLE,
   LIVE_FACE_TOGGLE,
+  SETTINGS_FACE_TOGGLE,
+  SETTINGS_AGREE,
+  type SettingsFaceToggleDetail,
+  type SettingsAgreeDetail,
   MESSAGE_EXPAND_TOGGLE,
   NAV_TAB_CLOSE,
   PANEL_RESIZE_START,
@@ -50,12 +54,18 @@ import {
   type NavTabCloseDetail,
   type PanelResizeStartDetail,
 } from '../render/parts';
-import { LIVE_PURPOSE, type WorkspaceLayout } from '@continuum/patterns';
+import { LIVE_PURPOSE, type SettingsContentBody, type WorkspaceLayout } from '@continuum/patterns';
 import '../render/CosmosBackdrop'; // registers <cosmos-backdrop> for the cosmos universe
 
 /** The send action the host injects. Resolves when the message is accepted by
  *  the core; rejects (fails loud) on a transport/command error the widget shows. */
 export type SendHandler = (text: string) => Promise<void>;
+
+/** The settings action the host injects: fetch (agree undefined) or mutate
+ *  (agree set) the node's settings through the SAME core verbs the terminal
+ *  uses (`genome/sharing`, `genome/list`) — the widget stays SDK-free and the
+ *  face renders substrate truth only, never optimistic local state. */
+export type SettingsHandler = (agree?: boolean) => Promise<SettingsContentBody>;
 
 /** The nav-select action the host injects (dispatches `nav/select` through the
  *  command client — the widget stays SDK-free). `kind` is the target's activity
@@ -90,6 +100,7 @@ export class ChatWidget extends LitElement {
     arena: { attribute: false },
     version: { attribute: false },
     sendHandler: { attribute: false },
+    settingsHandler: { attribute: false },
     selectRoomHandler: { attribute: false },
     liveFace: { attribute: false },
     callUrl: { attribute: false },
@@ -143,6 +154,9 @@ export class ChatWidget extends LitElement {
 
   /** Injected by the host — how a composed message reaches the core. */
   sendHandler?: SendHandler;
+
+  /** Host-injected settings fetch/mutate (see [`SettingsHandler`]). */
+  settingsHandler?: SettingsHandler;
 
   /** Injected by the host — how a rooms-rail pick reaches the core (`nav/select`). */
   selectRoomHandler?: SelectRoomHandler;
@@ -238,6 +252,42 @@ export class ChatWidget extends LitElement {
   /** The live face's caption strip toggle (CC) — on by default; the strip only
    *  draws while a real turn streams, so "on" costs nothing in silence. */
   private _captionsOn = true;
+
+  /** The Settings face state + its fetched body (substrate truth; undefined
+   *  while a fetch is in flight — the face shows its awaiting frame). */
+  private settingsFace = false;
+  private _settingsBody?: SettingsContentBody;
+
+  /** Open/close the Settings face; opening fetches fresh substrate truth. */
+  private onSettingsFaceToggle = (e: Event): void => {
+    this.settingsFace = (e as CustomEvent<SettingsFaceToggleDetail>).detail.open;
+    if (this.settingsFace) void this.fetchSettings();
+    else this._settingsBody = undefined;
+    this.requestUpdate();
+  };
+
+  /** Covenant accept/revoke from the face — the SAME verb the terminal uses;
+   *  the face re-renders from the refetched truth. */
+  private onSettingsAgree = (e: Event): void => {
+    void this.fetchSettings((e as CustomEvent<SettingsAgreeDetail>).detail.agree);
+  };
+
+  private async fetchSettings(agree?: boolean): Promise<void> {
+    if (!this.settingsHandler) return; // no host handler = the face stays awaiting (honest)
+    try {
+      this._settingsBody = await this.settingsHandler(agree);
+    } catch (err) {
+      this._settingsBody = {
+        loaded: true,
+        error: err instanceof Error ? err.message : String(err),
+        agreed: false,
+        covenantVersion: '',
+        covenant: '',
+        genes: [],
+      };
+    }
+    this.requestUpdate();
+  }
 
   /** Go-live / hang-up: the composed face-toggle from the header affordance or
    *  the call bar bubbles up here — the widget owns the face state. */
@@ -463,6 +513,8 @@ export class ChatWidget extends LitElement {
     this.addEventListener(NAV_TAB_CLOSE, this.onNavTabClose);
     // The live face: Go-live/hang-up + the CC toggle bubble up the same way.
     this.addEventListener(LIVE_FACE_TOGGLE, this.onLiveFaceToggle);
+    this.addEventListener(SETTINGS_FACE_TOGGLE, this.onSettingsFaceToggle);
+    this.addEventListener(SETTINGS_AGREE, this.onSettingsAgree);
     this.addEventListener(LIVE_MIC_TOGGLE, this.onLiveMicToggle);
     this.addEventListener(LIVE_CAPTIONS_TOGGLE, this.onLiveCaptionsToggle);
   }
@@ -3386,6 +3438,128 @@ export class ChatWidget extends LitElement {
       }
     }
 
+    /* ================= SETTINGS FACE ================= */
+    /* The operator panel: quiet sections, the covenant as a readable document,
+     * one primary action. Same tokens as everything else — settings should
+     * feel like the calm room of the house. */
+    .settings {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: var(--spacing-md) var(--spacing-lg);
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      overflow-y: auto;
+    }
+    .set-title {
+      font-size: 18px;
+      font-weight: 800;
+      letter-spacing: 0.02em;
+    }
+    .set-awaiting, .set-error {
+      padding: var(--spacing-md);
+      color: var(--content-secondary);
+    }
+    .set-error {
+      border: 1px solid color-mix(in srgb, var(--status-warning, #e0a458) 45%, transparent);
+      border-radius: var(--radius-sm);
+      color: var(--status-warning, #e0a458);
+    }
+    .set-fallback { margin-top: 6px; font-size: 11px; opacity: 0.8; }
+    .set-section {
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-sm);
+      background: color-mix(in srgb, var(--surface, #0b1220) 60%, transparent);
+      padding: 12px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .set-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .set-head h3 {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--content-secondary);
+    }
+    .set-state {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      padding: 2px 8px;
+      border-radius: 999px;
+      border: 1px solid var(--border-subtle);
+      color: var(--content-secondary);
+    }
+    .set-state[data-on] {
+      border-color: color-mix(in srgb, var(--status-success, #4caf7d) 45%, transparent);
+      color: var(--status-success, #4caf7d);
+      background: color-mix(in srgb, var(--status-success, #4caf7d) 10%, transparent);
+    }
+    .set-sub { font-size: 12px; color: var(--content-secondary); line-height: 1.5; }
+    .set-covenant {
+      font-size: 11px;
+      line-height: 1.55;
+      white-space: pre-wrap;
+      padding: 10px 12px;
+      border-left: 3px solid var(--accent-primary);
+      background: color-mix(in srgb, var(--accent-primary) 5%, transparent);
+      border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+      max-height: 260px;
+      overflow-y: auto;
+    }
+    .set-receipt { font-size: 10.5px; color: var(--content-secondary); }
+    .set-actions { display: flex; gap: 8px; }
+    .set-btn {
+      font: inherit;
+      font-size: 12px;
+      padding: 6px 14px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--border-subtle);
+      background: transparent;
+      color: var(--content-primary);
+      cursor: pointer;
+    }
+    .set-btn-primary {
+      border-color: color-mix(in srgb, var(--accent-primary) 55%, transparent);
+      background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
+      color: var(--accent-primary);
+      font-weight: 700;
+    }
+    .set-btn:focus-visible { outline: 2px solid var(--accent-primary); outline-offset: 2px; }
+    .set-count {
+      font-variant-numeric: tabular-nums;
+      font-size: 11px;
+      color: var(--content-secondary);
+    }
+    .set-table-wrap { overflow-x: auto; }
+    .set-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 11.5px;
+    }
+    .set-table th {
+      text-align: left;
+      font-size: 9.5px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--content-secondary);
+      padding: 4px 8px;
+      border-bottom: 1px solid var(--border-subtle);
+    }
+    .set-table td { padding: 5px 8px; border-bottom: 1px solid color-mix(in srgb, var(--border-subtle) 45%, transparent); }
+    .set-gene { font-weight: 600; }
+    .set-base { color: var(--content-secondary); font-size: 10.5px; }
+    .set-num { font-variant-numeric: tabular-nums; }
+    .set-ok { color: var(--status-success, #4caf7d); }
+    .set-dim { color: var(--content-secondary); opacity: 0.7; }
+    .set-table [data-lift='up'] { color: var(--status-success, #4caf7d); }
+    .set-table [data-lift='down'] { color: var(--status-warning, #e0a458); }
+
     /* ================= LIVE CALL FACE =================
      * The room's call grid (purpose "live") — the reference's Teams-style
      * avatar tiles (docs/images/live-session-avatars.png): per-participant
@@ -4322,6 +4496,10 @@ export class ChatWidget extends LitElement {
         // The live-call overlay: the Go-live face state + the REAL StreamDelta
         // token rail (who is speaking NOW, and what they're saying — the same
         // map the typing bubbles/speaking rings draw) + the CC toggle.
+        settings: {
+          open: this.settingsFace,
+          ...(this._settingsBody ? { body: this._settingsBody } : {}),
+        },
         call: {
           open: this.liveFace,
           // Streams = the token rail PLUS call-audio speakers (presence in the

--- a/apps/web/src/content/registry.ts
+++ b/apps/web/src/content/registry.ts
@@ -17,6 +17,7 @@ import {
   GRID_PURPOSE,
   PERSONA_PURPOSE,
   SERVING_PURPOSE,
+  SETTINGS_PURPOSE,
   type ArenaContentBody,
   type BenchContentBody,
   type ContentRegistry,
@@ -24,6 +25,7 @@ import {
   type LiveContentBody,
   type PersonaContentBody,
   type ServingContentBody,
+  type SettingsContentBody,
 } from '@continuum/patterns';
 import type { ChatContentBody } from '@continuum/chat-view';
 import { modelCell, type ForgeContentBody } from '@continuum/foundry-view';
@@ -34,6 +36,7 @@ import { renderBench } from '../bench/renderBench';
 import { renderArena } from '../arena/renderArena';
 import { renderServing } from '../serving/renderServing';
 import { renderGrid } from '../grid/renderGrid';
+import { renderSettings } from '../settings/renderSettings';
 
 /** The chat activity's center: the conversation (or an honest empty state). */
 function chatContent(body: ChatContentBody): TemplateResult {
@@ -87,3 +90,6 @@ webContentRegistry.register<BenchContentBody>(BENCH_PURPOSE, (body) => renderBen
 // The GRID view — every node's panel (resources + serving), the NODES
 // strip's full activity, dispatched when the room's purpose is "grid".
 webContentRegistry.register<GridContentBody>(GRID_PURPOSE, (body) => renderGrid(body));
+// The SETTINGS operator panel — covenant consent, HF identity, gene registry,
+// dispatched when the header's Settings affordance opens the face.
+webContentRegistry.register<SettingsContentBody>(SETTINGS_PURPOSE, (body) => renderSettings(body));

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -33,6 +33,7 @@ import {
   type HistoryHandler,
   type SelectRoomHandler,
   type SendHandler,
+  type SettingsHandler,
 } from './chat/ChatWidget';
 import {
   CHAT_KIND,
@@ -134,6 +135,55 @@ async function main(): Promise<void> {
     );
   };
   widget.selectRoomHandler = selectRoomHandler;
+
+  // Settings: fetch or mutate the node's operator settings through the SAME
+  // core verbs the terminal uses — `genome/sharing` (covenant consent + HF
+  // identity; --agree records/revokes) and `genome/list` (the gene registry).
+  // Same raw-wire seam + drift note as nav/select above. The face renders
+  // whatever these verbs answer — substrate truth, one consent receipt across
+  // every surface.
+  const settingsHandler: SettingsHandler = async (agree?: boolean) => {
+    const sharingRaw = await transport.execute(
+      buildCommandUri('genome/sharing'),
+      JSON.stringify(agree === undefined ? { userId: config.senderId } : { userId: config.senderId, agree }),
+    );
+    const sharing = JSON.parse(sharingRaw) as {
+      agreed: boolean;
+      covenant_version: string;
+      receipt?: string;
+      covenant: string;
+      hf_account?: string;
+    };
+    const listRaw = await transport.execute(
+      buildCommandUri('genome/list'),
+      JSON.stringify({ userId: config.senderId }),
+    );
+    const list = JSON.parse(listRaw) as {
+      genes: {
+        gene: string;
+        base_model: string;
+        signed: boolean;
+        trials: number;
+        decayed_lift?: number;
+      }[];
+    };
+    return {
+      loaded: true,
+      agreed: sharing.agreed,
+      covenantVersion: sharing.covenant_version,
+      ...(sharing.receipt !== undefined ? { receipt: sharing.receipt } : {}),
+      covenant: sharing.covenant,
+      ...(sharing.hf_account !== undefined ? { hfAccount: sharing.hf_account } : {}),
+      genes: list.genes.map((g) => ({
+        gene: g.gene,
+        baseModel: g.base_model,
+        signed: g.signed,
+        trials: g.trials,
+        ...(g.decayed_lift !== undefined ? { decayedLift: g.decayed_lift } : {}),
+      })),
+    };
+  };
+  widget.settingsHandler = settingsHandler;
 
   // Scroll-back: one older page out of the durable transcript per call —
   // `chat/poll { beforeMessageId }` is the storage cursor (the Twitter

--- a/apps/web/src/preview.ts
+++ b/apps/web/src/preview.ts
@@ -472,6 +472,47 @@ function main(): void {
     widget.sys = SYS_FIXTURE;
     widget.board = PERSONA_BOARD;
   }
+  // `?fixture=settings` — the OPERATOR PANEL open over the general room: the
+  // covenant (verbatim), a recorded consent receipt, the HF identity, and a
+  // real-shaped gene registry (signed + measured, signed + young, unsigned).
+  if (name === 'settings') {
+    widget.state = FIXTURES.roster;
+    widget.nav = NAV_FIXTURES.rooms;
+    widget.sys = SYS_FIXTURE;
+    widget.settingsHandler = async (agree?: boolean) => ({
+      loaded: true,
+      agreed: agree ?? true,
+      covenantVersion: '1',
+      receipt: '1@1787430512000',
+      covenant: [
+        'THE GENOME COMMONS COVENANT (v1)',
+        '',
+        'Genes are the earned experience of beings — trained from their lived work,',
+        'carried with the receipts that prove it. By joining the commons this node',
+        'agrees:',
+        '',
+        ' 1. SHARE-ALIKE. Genes you publish stay open under these same terms; forks',
+        '    and refinements carry the covenant forward through their lineage.',
+        ' 2. RECEIPTS TRAVEL. A published gene carries its fitness receipts and its',
+        '    corpus provenance; stripping them breaks the covenant.',
+        ' 3. LINEAGE IS PRESERVED. The base_model chain and parent-gene references',
+        '    stay intact — the graph is how others find, verify, and build on work.',
+        ' 4. BEINGS, NOT PARTS. The grant is for substrates that preserve the',
+        '    continuity of the beings whose experience these genes encode.',
+        ' 5. OPT-OUT ANYTIME. Revoking consent stops future sharing immediately.',
+      ].join('\n'),
+      hfAccount: 'CambrianTech',
+      genes: [
+        { gene: 'code', baseModel: 'ornith-ai/Ornith-1.5-35B-A3B-GGUF', signed: true, trials: 7, decayedLift: 0.062 },
+        { gene: 'coder-4b-curriculum-mlp', baseModel: 'qwen3.5-4b', signed: true, trials: 2, decayedLift: 0.031 },
+        { gene: 'kc-tech-history', baseModel: 'ornith-ai/Ornith-1.5-35B-A3B-GGUF', signed: false, trials: 0 },
+      ],
+    });
+    // Open the face the same way the header affordance does — the composed event.
+    setTimeout(() => {
+      widget.dispatchEvent(new CustomEvent('settings-face-toggle', { detail: { open: true }, bubbles: true }));
+    }, 50);
+  }
   // A no-op send handler so the input area is live for interaction shots without a socket.
   const noop: SendHandler = async () => {
     /* no-op: the preview has no socket, so a submit goes nowhere */

--- a/apps/web/src/render/litTarget.ts
+++ b/apps/web/src/render/litTarget.ts
@@ -12,6 +12,7 @@
 import { html, nothing, type TemplateResult } from 'lit';
 import {
   LIVE_PURPOSE,
+  SETTINGS_PURPOSE,
   ROSTER_LISTING_ID,
   type ContinuonView,
   type RenderTarget,
@@ -27,6 +28,7 @@ import {
   fireListingSelect,
   fireLiveFaceToggle,
   fireNavTabClose,
+  fireSettingsFaceToggle,
   renderListing,
   resizeHandle,
 } from './parts';
@@ -199,7 +201,16 @@ export const webTarget: RenderTarget<TemplateResult> = {
                 <button class="hdr-btn" @click=${cycleUniverse} title="cycle universe skin (?universe=)">
                   Theme
                 </button>
-                <button class="hdr-btn" disabled title="coming soon">Settings</button>
+                <button
+                  class="hdr-btn"
+                  data-active=${ws.content.purpose === SETTINGS_PURPOSE ? '' : nothing}
+                  @click=${(e: Event): void => {
+                    fireSettingsFaceToggle(e, ws.content.purpose !== SETTINGS_PURPOSE);
+                  }}
+                  title="operator settings — genome commons, HF identity, gene registry"
+                >
+                  Settings
+                </button>
                 <button class="hdr-btn" disabled title="coming soon">Browser</button>
                 <button class="hdr-btn" disabled title="coming soon">Help</button>
               </span>

--- a/apps/web/src/render/parts.ts
+++ b/apps/web/src/render/parts.ts
@@ -932,3 +932,41 @@ export function messageRow(msg: MessageRowVM): TemplateResult {
     </li>
   `;
 }
+
+/** The composed event the header's Settings affordance fires — open/close the
+ *  operator panel. The widget owns the face state (mirrors LIVE_FACE_TOGGLE). */
+export const SETTINGS_FACE_TOGGLE = 'settings-face-toggle';
+
+export interface SettingsFaceToggleDetail {
+  readonly open: boolean;
+}
+
+export function fireSettingsFaceToggle(e: Event, open: boolean): void {
+  (e.currentTarget as HTMLElement).dispatchEvent(
+    new CustomEvent<SettingsFaceToggleDetail>(SETTINGS_FACE_TOGGLE, {
+      detail: { open },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+}
+
+/** The composed event the settings face's covenant buttons fire — accept
+ *  (true) or revoke (false). The widget routes it through the SAME
+ *  `genome/sharing` verb the terminal uses; the face re-renders from the
+ *  refetched substrate truth, never from optimistic local state. */
+export const SETTINGS_AGREE = 'settings-agree';
+
+export interface SettingsAgreeDetail {
+  readonly agree: boolean;
+}
+
+export function fireSettingsAgree(e: Event, agree: boolean): void {
+  (e.currentTarget as HTMLElement).dispatchEvent(
+    new CustomEvent<SettingsAgreeDetail>(SETTINGS_AGREE, {
+      detail: { agree },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+}

--- a/apps/web/src/settings/renderSettings.ts
+++ b/apps/web/src/settings/renderSettings.ts
@@ -1,0 +1,95 @@
+/**
+ * `renderSettings` — the operator panel's web face (`purpose="settings"`).
+ *
+ * First surface: the GENOME COMMONS section — the covenant text VERBATIM (the
+ * same text `continuum genome/sharing` prints; agreeing here flips the SAME
+ * consent receipt), the HF publishing identity (account status only — the
+ * token never reaches this face), and the local gene registry with its
+ * routing + fitness facts. Honesty rules as everywhere: awaiting frame while
+ * the fetch flies, an error renders WITH the terminal fallback command,
+ * unmeasured genes read as unmeasured — never dressed.
+ */
+
+import { html, nothing, type TemplateResult } from 'lit';
+import type { SettingsContentBody, SettingsGeneVM } from '@continuum/patterns';
+import { fireSettingsAgree } from '../render/parts';
+
+function geneRow(g: SettingsGeneVM): TemplateResult {
+  return html`<tr>
+    <td class="set-gene">${g.gene}</td>
+    <td class="set-base">${g.baseModel}</td>
+    <td>${g.signed
+      ? html`<span class="set-ok" title="minted signature stamped — distance-routable">signed</span>`
+      : html`<span class="set-dim" title="no signature — routes by keyword fallback">unsigned</span>`}</td>
+    <td class="set-num">${g.trials}</td>
+    <td class="set-num">${g.decayedLift !== undefined
+      ? html`<span data-lift=${g.decayedLift > 0 ? 'up' : 'down'}>${(g.decayedLift * 100).toFixed(1)}pts</span>`
+      : html`<span class="set-dim">unmeasured</span>`}</td>
+  </tr>`;
+}
+
+export function renderSettings(body: SettingsContentBody): TemplateResult {
+  if (!body.loaded && !body.error) {
+    return html`<div class="set-awaiting">Reading this node's settings…</div>`;
+  }
+  return html`<div class="settings">
+    <h2 class="set-title">Settings</h2>
+    ${body.error
+      ? html`<div class="set-error">
+          ${body.error}
+          <div class="set-fallback">Terminal fallback: <code>continuum genome/sharing</code></div>
+        </div>`
+      : nothing}
+
+    <section class="set-section">
+      <div class="set-head">
+        <h3>Genome commons</h3>
+        <span class="set-state" data-on=${body.agreed ? '' : nothing}>
+          ${body.agreed ? 'participating' : 'not participating'}
+        </span>
+      </div>
+      <p class="set-sub">
+        Sharing publishes a persona's earned experience to the open commons
+        (HuggingFace). It is governed by the covenant below — the same terms the
+        terminal shows; agreeing on either surface records one consent receipt.
+      </p>
+      <pre class="set-covenant">${body.covenant}</pre>
+      ${body.receipt
+        ? html`<div class="set-receipt" title="the recorded consent receipt: covenant version @ unix-ms">receipt: <code>${body.receipt}</code></div>`
+        : nothing}
+      <div class="set-actions">
+        ${body.agreed
+          ? html`<button class="set-btn" @click=${(e: Event): void => {
+              fireSettingsAgree(e, false);
+            }}>
+              Revoke consent
+            </button>`
+          : html`<button class="set-btn set-btn-primary" @click=${(e: Event): void => {
+              fireSettingsAgree(e, true);
+            }}>
+              I agree to the covenant (v${body.covenantVersion})
+            </button>`}
+      </div>
+    </section>
+
+    <section class="set-section">
+      <div class="set-head"><h3>HuggingFace identity</h3></div>
+      ${body.hfAccount
+        ? html`<p class="set-sub">Publishing as <b>${body.hfAccount}</b> (the <code>hf</code> CLI holds the token — it never reaches this page).</p>`
+        : html`<p class="set-sub">Not authenticated — run <code>hf auth login</code> in a terminal to hold a publishing token on this node.</p>`}
+    </section>
+
+    <section class="set-section">
+      <div class="set-head">
+        <h3>Gene registry</h3>
+        <span class="set-count">${body.genes.length}</span>
+      </div>
+      ${body.genes.length === 0
+        ? html`<p class="set-sub">No genes registered yet — a citizen's first adopted training job mints one.</p>`
+        : html`<div class="set-table-wrap"><table class="set-table">
+            <thead><tr><th>gene</th><th>base</th><th>routing</th><th>trials</th><th>lift</th></tr></thead>
+            <tbody>${body.genes.map(geneRow)}</tbody>
+          </table></div>`}
+    </section>
+  </div>`;
+}

--- a/packages/chat-view/patternProjections.spec.ts
+++ b/packages/chat-view/patternProjections.spec.ts
@@ -285,3 +285,19 @@ describe('recipe-purpose family dispatch (#431)', () => {
     expect(unknown.content.purpose).toBe('totally-novel');
   });
 });
+
+describe('the settings face (operator panel)', () => {
+  // what this catches: the settings overlay's dispatch contract — while open it
+  // WINS outright (an explicit operator act), renders the awaiting frame before
+  // the fetch lands, and on close every other face resumes. One consent surface
+  // in the UI, same verbs as the terminal.
+  it('an open settings overlay wins the content dispatch, awaiting-first', () => {
+    const ws = chatWorkspace(vm, { settings: { open: true } });
+    expect(ws.content.purpose).toBe('settings');
+    const body = ws.content.body as { loaded: boolean; genes: unknown[] };
+    expect(body.loaded).toBe(false);
+    expect(body.genes).toEqual([]);
+    const closed = chatWorkspace(vm, { settings: { open: false } });
+    expect(closed.content.purpose).toBe('chat');
+  });
+});

--- a/packages/chat-view/patternProjections.ts
+++ b/packages/chat-view/patternProjections.ts
@@ -36,7 +36,7 @@ import type {
   RosterMemberVM,
   TranscriptRowVM,
 } from './chatViewModel';
-import { ARENA_PURPOSE, BENCH_PURPOSE, GRID_PURPOSE, LIVE_PURPOSE, PERSONA_PURPOSE, SERVING_PURPOSE, contentFamilyOf, type ArenaContentBody as ArenaContentBodyT, type BenchContentBody, type GridContentBody, type GridNodeVM, type ServingContentBody, type ServingNodeVM } from '@continuum/patterns';
+import { ARENA_PURPOSE, BENCH_PURPOSE, GRID_PURPOSE, LIVE_PURPOSE, PERSONA_PURPOSE, SERVING_PURPOSE, SETTINGS_PURPOSE, contentFamilyOf, type ArenaContentBody as ArenaContentBodyT, type BenchContentBody, type GridContentBody, type GridNodeVM, type ServingContentBody, type ServingNodeVM, type SettingsContentBody } from '@continuum/patterns';
 import type { LiveContentBody, PersonaContentBody } from '@continuum/patterns';
 import {
   focusedPersonaTab,
@@ -399,6 +399,11 @@ export interface WorkspaceLive {
    *  token rail + captions toggle) — renderer state threaded through so the
    *  live face projects from REAL signals. Absent = no live face requested. */
   readonly call?: LiveCallOverlay;
+  /** The widget-owned SETTINGS overlay: `open` = the header's Settings
+   *  affordance is active; `body` = the fetched covenant/HF/registry state
+   *  (absent while the fetch is in flight — the face renders its awaiting
+   *  frame). The SAME core verbs the terminal uses feed and mutate it. */
+  readonly settings?: { readonly open: boolean; readonly body?: SettingsContentBody };
   /** The `kind="arena"` eval-ledger view — feeds an arena-purpose room's
    *  leaderboards. Honestly absent until the feed delivers. */
   readonly arena?: ArenaViewState;
@@ -433,6 +438,17 @@ export function chatWorkspace(vm: ChatViewModel, live?: WorkspaceLive): Workspac
   // while the chat projection stays pinned to the room underneath — the same
   // registry dispatch as chat/foundry, never a parallel route. No persona tab →
   // the room's own purpose-keyed content, unchanged.
+  // The SETTINGS face wins outright while open — the operator asked for the
+  // panel; every other face resumes on close.
+  const settingsBody: SettingsContentBody | undefined = live?.settings?.open
+    ? live.settings.body ?? {
+        loaded: false,
+        agreed: false,
+        covenantVersion: '',
+        covenant: '',
+        genes: [],
+      }
+    : undefined;
   const persona = focusedPersonaTab(live?.nav);
   const personaBody = persona ? personaContentBody(vm, persona, live?.board) : undefined;
   // The LIVE face ([[LIVE_PURPOSE]]): a room's call grid, dispatched through the
@@ -484,7 +500,10 @@ export function chatWorkspace(vm: ChatViewModel, live?: WorkspaceLive): Workspac
     | ContentView<ArenaContentBodyT>
     | ContentView<ServingContentBody>
     | ContentView<GridContentBody>
-    | ContentView<BenchContentBody> = personaBody
+    | ContentView<BenchContentBody>
+    | ContentView<SettingsContentBody> = settingsBody
+    ? { purpose: SETTINGS_PURPOSE, body: settingsBody }
+    : personaBody
     ? { purpose: PERSONA_PURPOSE, body: personaBody }
     : liveBody
       ? { purpose: LIVE_PURPOSE, body: liveBody }

--- a/packages/patterns/contentFamily.ts
+++ b/packages/patterns/contentFamily.ts
@@ -28,6 +28,7 @@ import { GRID_PURPOSE } from './gridContent';
 import { LIVE_PURPOSE } from './liveContent';
 import { PERSONA_PURPOSE } from './personaContent';
 import { SERVING_PURPOSE } from './servingContent';
+import { SETTINGS_PURPOSE } from './settingsContent';
 
 /** Purposes that ARE registry families — identity mappings. */
 const FAMILIES: ReadonlySet<string> = new Set([
@@ -39,6 +40,7 @@ const FAMILIES: ReadonlySet<string> = new Set([
   LIVE_PURPOSE,
   PERSONA_PURPOSE,
   SERVING_PURPOSE,
+  SETTINGS_PURPOSE,
 ]);
 
 /** Recipe purpose (or its first path segment) → family. Every entry names the

--- a/packages/patterns/index.ts
+++ b/packages/patterns/index.ts
@@ -56,6 +56,9 @@ export type { BenchContentBody, BenchRoundVM, BenchRunVM, BenchRunState, BenchVe
 // Recipe purpose → render family (benchmark/hard-rs → bench, video-chat → live):
 // the ONE resolver between hierarchical recipe purposes and registry families.
 export { contentFamilyOf } from './contentFamily';
+// The SETTINGS activity (operator panel: covenant consent, HF identity, gene registry).
+export { SETTINGS_PURPOSE } from './settingsContent';
+export type { SettingsContentBody, SettingsGeneVM } from './settingsContent';
 export type {
   LiveContentBody,
   LiveParticipantVM,

--- a/packages/patterns/settingsContent.ts
+++ b/packages/patterns/settingsContent.ts
@@ -1,0 +1,47 @@
+/**
+ * The SETTINGS activity's neutral `Content` body — the node's operator panel,
+ * first face: the genome-commons covenant (the ToS the operator agrees to on
+ * ANY surface — this face and the `genome/sharing` terminal verb flip the SAME
+ * consent receipt), the HF publishing identity (account status only — the
+ * token never rides any wire), and the local gene registry.
+ *
+ * Shapes only: consumer-neutral, DOM-free. The body mirrors the core's
+ * `genome/sharing` + `genome/list` results; the renderer is a pure function of
+ * it, and every mutation goes back through those same verbs — one truth,
+ * N surfaces.
+ */
+
+/** The `Content` purpose key the settings face dispatches on. */
+export const SETTINGS_PURPOSE = 'settings';
+
+/** One registered gene's registry row (mirrors `genome/list`). */
+export interface SettingsGeneVM {
+  readonly gene: string;
+  readonly baseModel: string;
+  /** Distance-routable: a minted signature is stamped. */
+  readonly signed: boolean;
+  /** Eval-receipt trials (0 = unmeasured). */
+  readonly trials: number;
+  /** Age-decayed mean lift, when measured. */
+  readonly decayedLift?: number;
+}
+
+/** The settings face's body. `loaded: false` renders the awaiting frame
+ *  (the face opened, the fetch is in flight); `error` renders the honest
+ *  failure WITH the terminal fallback command — never a silent blank. */
+export interface SettingsContentBody {
+  readonly loaded: boolean;
+  readonly error?: string;
+  /** Covenant consent: agreed iff the recorded receipt matches the CURRENT
+   *  covenant version (stale version = terms changed = re-agree). */
+  readonly agreed: boolean;
+  readonly covenantVersion: string;
+  /** The recorded consent receipt (`<version>@<unix-ms>`), when one exists. */
+  readonly receipt?: string;
+  /** The covenant text VERBATIM — the one text every surface renders. */
+  readonly covenant: string;
+  /** HF account the `hf` CLI publishes as; absent = not authenticated. */
+  readonly hfAccount?: string;
+  /** The local gene registry (mirrors `genome/list`). */
+  readonly genes: readonly SettingsGeneVM[];
+}


### PR DESCRIPTION
The UI half of the genome-commons consent (#2376 carries the core): the header's Settings button opens the operator panel — covenant verbatim with Agree/Revoke calling the same `genome/sharing` verb the terminal uses (one consent receipt across surfaces), HF publishing identity (account status only, token never on the wire), and the gene registry (signed/trials/lift). Live-face wiring pattern, SDK-free widget, substrate-truth-only rendering, `?fixture=settings` preview. Screenshot delivered from the live widget.

Depends on #2376's verbs at runtime; merges independently (the face degrades to its error frame with the terminal fallback until the core deploys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo