### PR TITLE
fix(eval): the grader reads from the run's root, not the process cwd

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -2468,6 +2468,7 @@ impl CognitionEval {
                 &tasks,
                 room,
                 max_acts,
+                eval_workspace_root.as_deref(),
             )
             .await;
             drop(reviewer_iso);
@@ -4092,7 +4093,13 @@ async fn run_pass(
             // text) — the only way the act→verify loop shows up in the score. Same harness as
             // test_grade (strip her main, append test, compile, run).
             let lang = t.lang.as_deref().unwrap_or("rust");
-            crate::cognition::gym_grader::test_grade_file(file, lang, test).await
+            crate::cognition::gym_grader::test_grade_file(
+                task_root.map(std::path::Path::new),
+                file,
+                lang,
+                test,
+            )
+            .await
         } else if let Some(dod) = &t.dod_shell {
             // REAL task: run the definition-of-done against the repo state her edits produced.
             run_dod(dod).await
@@ -4229,6 +4236,9 @@ async fn run_pass_team(
     tasks: &[EvalTask],
     room: Uuid,
     max_acts: usize,
+    // The run's resolved eval root (explicit pin or #312 ephemeral clone) —
+    // artifact grading resolves solution files against it, same as solo.
+    workspace_root: Option<&str>,
 ) -> PassOutcome {
     let mut pass = 0u32;
     let mut results = Vec::with_capacity(tasks.len());
@@ -4314,6 +4324,10 @@ async fn run_pass_team(
             run_dod(dod).await
         } else if let (Some(file), Some(test)) = (&t.solution_file, &t.test) {
             crate::cognition::gym_grader::test_grade_file(
+                t.workspace_root
+                    .as_deref()
+                    .or(workspace_root)
+                    .map(std::path::Path::new),
                 file,
                 t.lang.as_deref().unwrap_or("rust"),
                 test,

--- a/core/continuum-core/src/cognition/gym_grader.rs
+++ b/core/continuum-core/src/cognition/gym_grader.rs
@@ -179,7 +179,12 @@ pub async fn test_grade(answer: &str, lang: &str, test: &str) -> (bool, String) 
 /// `code/write` sandboxes to). Fails LOUD (never a silent pass) if she wrote nothing, the path
 /// escapes the workspace, or the file is empty. The file is removed after grading so a stale
 /// artifact from this or a prior task can never false-pass a later one.
-pub async fn test_grade_file(rel_path: &str, lang: &str, test: &str) -> (bool, String) {
+pub async fn test_grade_file(
+    root: Option<&std::path::Path>,
+    rel_path: &str,
+    lang: &str,
+    test: &str,
+) -> (bool, String) {
     match lang {
         "rust" | "rs" => {}
         other => {
@@ -189,14 +194,24 @@ pub async fn test_grade_file(rel_path: &str, lang: &str, test: &str) -> (bool, S
             )
         }
     }
-    let path = std::path::Path::new(rel_path);
-    if path.is_absolute() || rel_path.contains("..") {
+    // Resolve against the RUN'S ROOT, never the process CWD. The grader read
+    // bare `rel_path` from the core's cwd (the repo checkout) while her hands
+    // wrote into the #312 ephemeral clone — so every artifact-graded task
+    // reported "she never wrote it" about a file she demonstrably wrote
+    // (glass-boxed 2026-08-23, take 2 of the Ornith battery: sol_roman_to_int.rs
+    // correct IN the clone, grade said not-found). `None` = cwd-relative, for
+    // callers that genuinely run in the target directory (tests).
+    if std::path::Path::new(rel_path).is_absolute() || rel_path.contains("..") {
         return (
             false,
             format!("solution_file must be a relative in-workspace path, got '{rel_path}'"),
         );
     }
-    let code = match std::fs::read_to_string(path) {
+    let path = match root {
+        Some(r) => r.join(rel_path),
+        None => std::path::PathBuf::from(rel_path),
+    };
+    let code = match std::fs::read_to_string(&path) {
         Ok(c) if !c.trim().is_empty() => c,
         Ok(_) => {
             let _ = std::fs::remove_file(path);
@@ -223,7 +238,7 @@ pub async fn test_grade_file(rel_path: &str, lang: &str, test: &str) -> (bool, S
             );
         }
     };
-    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file(&path);
     let dir = std::env::temp_dir().join(format!("cu-gym-{}", Uuid::new_v4()));
     if std::fs::create_dir_all(&dir).is_err() {
         return (false, "temp dir create failed".to_string());
@@ -521,18 +536,34 @@ mod tests {
     async fn artifact_grade_reads_the_file_passes_correct_cleans_up_and_fails_loud() {
         let rel = format!("cu-gym-artifact-{}.rs", uuid::Uuid::new_v4());
         std::fs::write(&rel, "pub fn dbl(x: i32) -> i32 { x * 2 }\n").unwrap();
-        let (ok, grade) = test_grade_file(&rel, "rust", "assert_eq!(dbl(3), 6);").await;
+        let (ok, grade) = test_grade_file(None, &rel, "rust", "assert_eq!(dbl(3), 6);").await;
         assert!(ok, "a correct solution file should pass: {grade}");
         assert!(
             !std::path::Path::new(&rel).exists(),
             "the file must be removed after grading so it can't false-pass a later task"
         );
-        let (ok2, grade2) = test_grade_file(&rel, "rust", "assert_eq!(dbl(3), 6);").await;
+        let (ok2, grade2) = test_grade_file(None, &rel, "rust", "assert_eq!(dbl(3), 6);").await;
         assert!(
             !ok2 && grade2.contains("never wrote it"),
             "a missing file must fail loud, not silently pass: {grade2}"
         );
-        let (ok3, _) = test_grade_file("../escape.rs", "rust", "").await;
+        let (ok3, _) = test_grade_file(None, "../escape.rs", "rust", "").await;
+
+        // what this catches: THE take-2 defect — the grader must read the file
+        // from the RUN'S root, not the process cwd. A correct solution in the
+        // eval root graded "not found" (a manufactured lie about the solver)
+        // when resolution used bare rel_path. Regression for 2026-08-23.
+        let rooted = tempfile::tempdir().expect("tempdir");
+        std::fs::write(rooted.path().join("sol_rooted.rs"), "pub fn dbl(x: i32) -> i32 { x * 2 }")
+            .expect("write");
+        let (ok4, grade4) = test_grade_file(
+            Some(rooted.path()),
+            "sol_rooted.rs",
+            "rust",
+            "assert_eq!(dbl(4), 8);",
+        )
+        .await;
+        assert!(ok4, "rooted resolution must grade the real file: {grade4}");
         assert!(!ok3, "a path escaping the workspace must be refused");
     }
 


### PR DESCRIPTION
Defect 2 of the Ornith showcase battery. Take 2 of hard-rs proved #2382's hands-rooting works (sol files landed in the ephemeral clone with live timestamps) — and every task still graded 0 because `test_grade_file` resolved `rel_path` against the core process CWD, not the run root.

- `test_grade_file(root: Option<&Path>, ...)` — joins rel_path under the run's root; `None` keeps old behavior for absolute-path callers
- solo pass: `task_root` (per-task pin or the #312 ephemeral clone)
- team pass: the run root threaded through `run_pass_team` as a new param (same semantics as solo)
- rooted regression test: artifact written into a tempdir root, graded from an unrelated CWD

Takes 1 and 2 both infra-poisoned, neither recorded. Take 3 launches after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo