### PR TITLE
fix(eval): harden both grading environments — orphan-swept exam worlds, garbage-ceiling grade timeouts

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1089,13 +1089,15 @@ async fn build_external_eval_lane_inner(
 fn provision_ephemeral_eval_root(tag: &str) -> Result<std::path::PathBuf, String> {
     let base = std::env::current_dir().map_err(|e| format!("cwd: {e}"))?;
     let root = std::env::temp_dir().join("continuum-eval").join(tag);
+    let parent = root
+        .parent()
+        .ok_or_else(|| "eval root has no parent".to_string())?
+        .to_path_buf();
+    sweep_orphan_eval_roots(&parent, &root);
     if root.is_dir() {
         return Ok(root); // resume of the same run reuses its world
     }
-    let parent = root
-        .parent()
-        .ok_or_else(|| "eval root has no parent".to_string())?;
-    std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+    std::fs::create_dir_all(&parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
     let mut clone = std::process::Command::new("cp");
     if cfg!(target_os = "macos") {
         clone.arg("-cR");
@@ -1124,13 +1126,80 @@ fn provision_ephemeral_eval_root(tag: &str) -> Result<std::path::PathBuf, String
     Ok(root)
 }
 
+/// Eval worlds LIVE in this process. `Drop` covers every in-process return path,
+/// but not a killed process: `continuum reboot` SIGTERMs the core, `Drop` never
+/// runs, and the run's world outlives it (measured 2026-08-23 — a reboot mid-run
+/// left a 31 GB clone under `$TMPDIR/continuum-eval`, found by hand during the
+/// Ornith battery). The sweep below deletes those orphans at the next provision;
+/// this set is what stops it deleting a CONCURRENT run's live world.
+static LIVE_EVAL_ROOTS: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashSet<std::path::PathBuf>>,
+> = std::sync::OnceLock::new();
+
+fn live_eval_roots() -> &'static std::sync::Mutex<std::collections::HashSet<std::path::PathBuf>> {
+    LIVE_EVAL_ROOTS.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
+/// Remove sibling eval worlds that belong to no live run in this process. An
+/// eval run cannot survive its process (the mind fork, the lane lease, and the
+/// progress reporter all die with it), so any world under `continuum-eval/`
+/// that is neither the run being provisioned nor in [`live_eval_roots`] is an
+/// orphan from a killed process — re-creatable debris by construction (#312:
+/// the world is a CoW clone of the checkout; nothing in it is the only copy).
+/// Event-driven at the point of use — no boot hook, no background tick.
+fn sweep_orphan_eval_roots(parent: &std::path::Path, keep: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return; // parent not created yet — nothing to sweep
+    };
+    // Snapshot the live set and release the lock BEFORE deleting: a multi-GB
+    // clone takes seconds to remove, and a concurrent provision must not queue
+    // behind filesystem work.
+    let live = match live_eval_roots().lock() {
+        Ok(guard) => guard.clone(),
+        Err(_) => return, // poisoned registry: skip the sweep, never guess at liveness
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() || path == keep || live.contains(&path) {
+            continue;
+        }
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => crate::probe!(
+                class = "eval.workspace.orphan_swept",
+                root = path.display().to_string().as_str(),
+                "orphaned exam world from a killed process removed — Drop cannot run \
+                 through SIGTERM, so provision-time sweep is the crash-path owner"
+            ),
+            Err(e) => tracing::warn!(
+                root = %path.display(),
+                error = %e,
+                "orphaned eval world could not be removed — temp-dir debris persists"
+            ),
+        }
+    }
+}
+
 /// RAII holder for the run's disposable world — `Drop` removes it on EVERY return
 /// path (score, infra-abort, error), so a crashed exam never leaks fixtures into
-/// the temp dir long-term and NEVER touches the shared checkout at all.
+/// the temp dir long-term and NEVER touches the shared checkout at all. The
+/// crash path Drop cannot cover (SIGKILL/SIGTERM) is owned by
+/// [`sweep_orphan_eval_roots`] at the next provision.
 struct EphemeralEvalRoot(std::path::PathBuf);
+
+impl EphemeralEvalRoot {
+    fn new(root: std::path::PathBuf) -> Self {
+        if let Ok(mut live) = live_eval_roots().lock() {
+            live.insert(root.clone());
+        }
+        Self(root)
+    }
+}
 
 impl Drop for EphemeralEvalRoot {
     fn drop(&mut self) {
+        if let Ok(mut live) = live_eval_roots().lock() {
+            live.remove(&self.0);
+        }
         if let Err(e) = std::fs::remove_dir_all(&self.0) {
             tracing::warn!(
                 root = %self.0.display(),
@@ -1989,7 +2058,7 @@ impl CognitionEval {
                 .clone()
                 .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
             match provision_ephemeral_eval_root(&tag) {
-                Ok(root) => Some(EphemeralEvalRoot(root)),
+                Ok(root) => Some(EphemeralEvalRoot::new(root)),
                 Err(e) => {
                     // Fail LOUD and refuse to contaminate — no silent fallback to cwd.
                     return Err(CommandError::Internal(format!(
@@ -4396,6 +4465,31 @@ crate::register_stateless_command!(CognitionEval);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the orphan sweep deleting a CONCURRENT run's live world —
+    // the one direction that turns crash-path hygiene into data loss mid-exam.
+    // regression for the 2026-08-23 finding (a SIGTERM'd reboot orphaned a 31 GB
+    // eval clone that Drop could never reap; the sweep is the crash-path owner,
+    // and live_eval_roots() is what scopes it to true orphans).
+    #[test]
+    fn orphan_sweep_removes_dead_worlds_and_never_live_ones() {
+        let parent = tempfile::tempdir().expect("tempdir");
+        let live = parent.path().join("live-run");
+        let orphan = parent.path().join("orphan-run");
+        std::fs::create_dir_all(&live).expect("mkdir live");
+        std::fs::create_dir_all(&orphan).expect("mkdir orphan");
+        let keep = parent.path().join("being-provisioned");
+        std::fs::create_dir_all(&keep).expect("mkdir keep");
+
+        let holder = EphemeralEvalRoot::new(live.clone());
+        sweep_orphan_eval_roots(parent.path(), &keep);
+
+        assert!(live.is_dir(), "a registered live world must survive the sweep");
+        assert!(keep.is_dir(), "the world being provisioned must survive the sweep");
+        assert!(!orphan.is_dir(), "an unregistered world is an orphan and must be removed");
+        drop(holder); // Drop removes the live world AND its registry entry
+        assert!(!live.is_dir(), "Drop still owns the in-process cleanup path");
+    }
 
     // what this catches: #310 — the /v1/models context_length contract for gateway-routed
     // eval lanes. The ds4 sidecar serves 8192 while its catalog row states the model's 1M

--- a/core/continuum-core/src/cognition/gym_grader.rs
+++ b/core/continuum-core/src/cognition/gym_grader.rs
@@ -10,8 +10,17 @@
 
 use uuid::Uuid;
 
-/// Per-step grade timeout. A compile or run that overruns is SIGKILLed on drop.
-const TEST_GRADE_TIMEOUT_SECS: u64 = 10;
+/// Per-step grade timeouts. A step that overruns is SIGKILLed on drop.
+///
+/// These are GARBAGE CEILINGS, not performance targets (stopwatch-test doctrine):
+/// grading shares the machine with a 35B decode, so a flat tight budget converts
+/// scheduler contention into a false FAIL against the candidate — the one verdict
+/// the grader must never invent. Compile gets minutes because `rustc` on a busy
+/// box is legitimately slow and a compile CANNOT hang forever on its own; the run
+/// step stays an order of magnitude tighter because it is the infinite-loop guard
+/// — gym tests assert in microseconds, so anything near this ceiling IS a hang.
+const COMPILE_TIMEOUT_SECS: u64 = 120;
+const RUN_TIMEOUT_SECS: u64 = 30;
 
 /// Extract the model's code from a response for test-grading.
 ///
@@ -141,8 +150,8 @@ fn matching_brace(bytes: &[u8], open: usize) -> Option<usize> {
 /// failure the message carries the first failing step's compiler/panic output so
 /// the failure is diagnosable — and so a teacher can read the REAL error and fix.
 ///
-/// SAFETY: compiles and runs model-generated code in a temp dir, each step under a
-/// 10s timeout with `kill_on_drop` so a runaway is reaped, never orphaned. That is
+/// SAFETY: compiles and runs model-generated code in a temp dir, each step under
+/// its garbage-ceiling timeout with `kill_on_drop` so a runaway is reaped, never orphaned. That is
 /// the pragmatic floor for an OWNER's local dev machine (what coding agents do); it
 /// is NOT a sandbox. Before public/untrusted tasks, this MUST run in a real sandbox
 /// (container/seccomp). Slice 1 = prove the grading mechanism; sandbox is a P1 req.
@@ -290,13 +299,13 @@ async fn grade_rust(dir: &std::path::Path, code: &str, test: &str) -> Result<(),
         .arg("-o")
         .arg(&bin)
         .arg(&src);
-    let compiled = run_capped(&mut rustc, "compile").await?;
+    let compiled = run_capped(&mut rustc, "compile", COMPILE_TIMEOUT_SECS).await?;
     if !compiled.status.success() {
         return Err(format!("compile error: {}", trunc_stderr(&compiled.stderr)));
     }
 
     let mut run = tokio::process::Command::new(&bin);
-    let ran = run_capped(&mut run, "run").await?;
+    let ran = run_capped(&mut run, "run", RUN_TIMEOUT_SECS).await?;
     if ran.status.success() {
         Ok(())
     } else {
@@ -309,17 +318,13 @@ async fn grade_rust(dir: &std::path::Path, code: &str, test: &str) -> Result<(),
 async fn run_capped(
     cmd: &mut tokio::process::Command,
     label: &str,
+    timeout_secs: u64,
 ) -> Result<std::process::Output, String> {
     cmd.kill_on_drop(true);
-    match tokio::time::timeout(
-        std::time::Duration::from_secs(TEST_GRADE_TIMEOUT_SECS),
-        cmd.output(),
-    )
-    .await
-    {
+    match tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), cmd.output()).await {
         Ok(Ok(out)) => Ok(out),
         Ok(Err(e)) => Err(format!("{label} spawn failed: {e}")),
-        Err(_) => Err(format!("{label} timeout ({TEST_GRADE_TIMEOUT_SECS}s)")),
+        Err(_) => Err(format!("{label} timeout ({timeout_secs}s)")),
     }
 }
 

--- a/core/continuum-core/src/system_resources/disk_eviction.rs
+++ b/core/continuum-core/src/system_resources/disk_eviction.rs
@@ -704,6 +704,19 @@ mod tests {
                  this entry read \"everything under it is re-creatable\", which the 25 \
                  patches already sitting there had falsified since before it was written",
             ),
+            // Steady-state owner ALREADY EXISTS in-file: RAII drop on every in-process
+            // return path + the provision-time orphan sweep for worlds a killed process
+            // leaves behind (an eval run cannot survive its process, so any non-live
+            // sibling is debris; everything inside is a CoW clone of the checkout —
+            // re-creatable by construction). Deferred only for the broker seam: under
+            // real disk pressure the broker cannot yet claw these bytes back BETWEEN
+            // provisions — that wants a pool that consults `live_eval_roots()`, never
+            // a blind LRU that could delete a mid-exam world.
+            (
+                "eval-roots",
+                "#155: broker-reachable pool over cognition/eval::live_eval_roots(); \
+                 sweep + RAII already own the steady state and the crash path",
+            ),
         ];
         use super::super::disk_pressure::DiskReporter as _;
         for dir in super::super::disk_reporters::standard_tracked_dirs(Path::new("/h")) {

--- a/core/continuum-core/src/system_resources/disk_reporters.rs
+++ b/core/continuum-core/src/system_resources/disk_reporters.rs
@@ -215,6 +215,14 @@ pub fn standard_tracked_dirs(home: &std::path::Path) -> Vec<Arc<TrackedDir>> {
         // `super::rotation_log_pool`.
         TrackedDir::new("logs", home.join(".continuum/logs")),
         TrackedDir::new("probes", home.join(".continuum/probes")),
+        // #312 ephemeral exam worlds: one CoW clone of the checkout per eval run
+        // (~31 GB logical each). RAII drop removes them on every in-process return
+        // path, and the provision-time orphan sweep (`cognition/eval.rs::
+        // sweep_orphan_eval_roots`) owns the crash path a SIGTERM'd reboot leaves
+        // behind — registered 2026-08-23 after exactly that: a mid-run reboot
+        // orphaned a full clone that no reporter could see, the silent-class shape
+        // the 2026-07-13 incident was about.
+        TrackedDir::new("eval-roots", std::env::temp_dir().join("continuum-eval")),
     ];
     // Present only when its real location is KNOWN (see the warn above). Kept
     // CONDITIONAL rather than defaulted: fabricating a path here is how a class


### PR DESCRIPTION
Environment audit of the eval seam, both sides, prompted mid-Ornith-battery ("make sure their environments aren't screwed up, persona and grader").

**Persona side: sound.** ShellSession roots at the canonicalized eval clone, inherits the shared cargo cache — no fix needed, verified live (Atlas's sol files land in the clone).

**Grader side: two defects fixed.**

1. **Orphaned exam worlds** — #312's RAII drop can't run through SIGTERM, so `continuum reboot` mid-run leaks the whole CoW clone (Take 2's 31 GB logical root, found by hand today; the 2026-07-13 silent-class shape). Fix: `LIVE_EVAL_ROOTS` registry + provision-time orphan sweep (event-driven, no boot hook, no tick) + the disk law's two receipts: `eval-roots` TrackedDir row and an eviction-decision entry (broker pool deferred to #155, live-set requirement named).
2. **Flat 10s grade timeout** — grading shares the box with a 35B decode; contention became a false FAIL. Split into garbage ceilings: compile 120s, run 30s (the infinite-loop guard).

Regression test: sweep removes an unregistered world, never a live or in-provision one; Drop still owns the in-process path.

Deploy note: **not before Take 3 completes** — a reboot would kill the run (that's how defect 1 was found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo