### PR TITLE
docs(design-bench): fluid-sim showcase task imported from the wild

### DIFF
--- a/docs/architecture/DESIGN-BENCH-VISUAL-CRAFT.md
+++ b/docs/architecture/DESIGN-BENCH-VISUAL-CRAFT.md
@@ -134,7 +134,27 @@ the same seam the 3D universe payloads ride ([[universes-are-positron-asset-payl
 5. **V3 judge panel + peer-review acts** — objectives, falsifiability rails.
 6. **Design2Code adapter** — external comparability, fingerprinted like ds-1000.
 
-## 7. What this is deliberately NOT
+### 6b. First imported-from-the-wild showcase task: `fluid-sim`
+
+Circulating 2026-08-22 (@scaling01): a fully-specified one-shot prompt — a
+self-contained single-file WebGL 2D fluid simulation (advection, pressure,
+vorticity, dye transport, interaction, control panel, visualization modes,
+perf overlay) — with published baselines: Qwen3.8-27B thought 40k tokens for
+an hour and shipped a black screen; Opus 4.5 one-shotted it in a minute. The
+prompt's own closing paragraph enumerates grading criteria (correctness,
+stability, fluid-like behavior, responsiveness, interaction, visual quality,
+performance) that map near 1:1 onto this bench's V1/V2/perception axes.
+
+Import it VERBATIM as a design-bench task, graded on the RUNNING artifact
+through the eye-node (does dye advect? does drag inject momentum? is the FPS
+overlay live?), citizen iterating in the loop. The claim it showcases is the
+bench's whole thesis: one-shot-from-cold rewards whatever a model memorized
+about fluid solvers — a blind 27B loses by construction. A smaller model
+with eyes and hands (render → observe → hot-edit → re-grade) does not have
+to one-shot Navier-Stokes from memory; she has to CONVERGE on it. A local
+A3B converging to a working sim, act trail as the receipt, beats a bigger
+blind model's black screen — and the wild baselines above are the free
+comparison column.
 
 - **Not pixel-matching.** Reference-screenshot similarity punishes creativity and
   breaks on fonts/AA; craft facts are measured, likeness is not required.

--- a/docs/genome/design/fluid-sim-task.md
+++ b/docs/genome/design/fluid-sim-task.md
@@ -1,0 +1,68 @@
+# fluid-sim — imported-from-the-wild design-bench task (verbatim prompt)
+
+Provenance: circulating on X 2026-08-22 via @scaling01, prompt authored by
+GPT-5.6-Sol per the post. Published wild baselines at import time: Qwen3.8-27B —
+40k thinking tokens, ~1 hour, black screen (fail); Opus 4.5 — one-shot,
+~1 minute, working (pass); "Ox Alpha" — one-shot, 1000-line file, working.
+Grading here is NOT one-shot: the citizen iterates (render → observe →
+hot-edit → re-grade) and is scored on the running artifact through the
+eye-node. See docs/architecture/DESIGN-BENCH-VISUAL-CRAFT.md §6b.
+
+## Prompt (verbatim — do not edit)
+
+Create a polished, interactive real-time 2D fluid simulation that runs entirely
+inside a single self-contained `index.html` file, with all HTML, CSS,
+JavaScript, shaders, controls, and visual assets embedded directly in that file
+and with no build process, server, external libraries, frameworks, imports, or
+network dependencies.
+
+The simulation must behave like a continuous fluid rather than a simple
+particle animation, supporting visible velocity flow, advection, diffusion or
+viscosity, pressure, incompressibility, vorticity or swirling motion,
+dissipation, and the transport and mixing of colored dye through the simulated
+fluid field.
+
+Allow the user to interact directly with the fluid using the mouse or pointer
+by dragging through the simulation to inject momentum and dye, with the
+direction and speed of the drag influencing the resulting force and with
+interaction remaining smooth during rapid or continuous movement.
+
+Provide a compact real-time control interface containing at least pause/resume,
+reset, clear dye, simulation resolution, timestep or simulation speed,
+viscosity, pressure strength or pressure iterations, vorticity, velocity
+dissipation, dye dissipation, interaction force, interaction radius, and dye
+color controls, while giving the implementation freedom to choose suitable
+ranges, defaults, widgets, and presentation.
+
+Include multiple selectable visualization modes that expose meaningful aspects
+of the simulation, such as rendered dye, velocity magnitude or direction,
+pressure, divergence, vorticity, or another useful diagnostic representation,
+and make switching between modes possible without restarting the simulation.
+
+The application must automatically adapt its rendering surface and simulation
+to browser-window resizing, support high-DPI displays appropriately, provide
+usable mouse and touch or pointer input, and remain visually coherent across
+common desktop viewport sizes.
+
+Display a small performance and simulation-status overlay containing useful
+live information such as frames per second, simulation dimensions, current
+visualization mode, pause state, and any other metrics the implementation
+considers valuable for evaluating performance.
+
+Design the interface and fluid rendering to look intentional and
+demonstration-ready, including a full-screen or near-full-screen simulation
+area, readable controls, clear interaction feedback, visually rich dye mixing,
+and sensible defaults that produce interesting fluid motion immediately without
+requiring configuration.
+
+The implementation may choose WebGL, WebGL2, Canvas, CPU techniques, GPU
+shaders, numerical method details, data structures, rendering style,
+optimization strategies, control layout, color treatment, and additional
+features freely, but every required feature must work from the delivered HTML
+file alone when opened in a modern browser.
+
+Return only the complete working HTML document, and treat correctness,
+stability, fluid-like behavior, responsiveness, interaction quality, visual
+quality, performance, code organization, graceful handling of unsupported
+capabilities, and completeness of the required feature set as benchmark
+criteria.


### PR DESCRIPTION
Adds §6b to DESIGN-BENCH-VISUAL-CRAFT.md and pins the verbatim prompt at docs/genome/design/fluid-sim-task.md with provenance + published wild baselines (Qwen3.8-27B black-screen fail, Opus 4.5 one-minute pass). Graded our way: running artifact through the eye-node, citizen iterating.

Docs-only — also a live exercise of #2383's CI relevance gate: the cargo jobs should skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo