### PR TITLE
feat(benchmarks): SWE-rebench + SWE-bench Pro adapters — the frontier-hard tier

### DIFF
--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -63,10 +63,42 @@ pub struct SweInstance {
     pub problem_statement: String,
     #[serde(default)]
     pub created_at: String,
-    #[serde(rename = "FAIL_TO_PASS", default)]
+    #[serde(
+        rename = "FAIL_TO_PASS",
+        alias = "fail_to_pass",
+        default,
+        deserialize_with = "test_list_string"
+    )]
     pub fail_to_pass: String,
-    #[serde(rename = "PASS_TO_PASS", default)]
+    #[serde(
+        rename = "PASS_TO_PASS",
+        alias = "pass_to_pass",
+        default,
+        deserialize_with = "test_list_string"
+    )]
     pub pass_to_pass: String,
+}
+
+/// The SWE-instance family speaks THREE dialects for the same two fields
+/// (2026-08-23 landscape import): SWE-bench serves `FAIL_TO_PASS` as a
+/// JSON-ENCODED STRING, SWE-rebench serves it as a REAL LIST, and SWE-bench
+/// Pro lowercases the name (string-encoded). One tolerant deserializer
+/// normalizes all three to the JSON-encoded-string form `f2p()`/`p2p()`
+/// already parse — the constraint fix, so no second instance struct ever
+/// exists per dialect ([[fix-the-constraint-not-the-instance-interfaces-first]]).
+fn test_list_string<'de, D>(d: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = serde_json::Value::deserialize(d)?;
+    match v {
+        serde_json::Value::String(s) => Ok(s),
+        serde_json::Value::Array(_) => Ok(v.to_string()),
+        serde_json::Value::Null => Ok(String::new()),
+        other => Err(serde::de::Error::custom(format!(
+            "FAIL_TO_PASS/PASS_TO_PASS must be a JSON-encoded string or a list, got {other}"
+        ))),
+    }
 }
 
 impl SweInstance {
@@ -463,7 +495,11 @@ pub async fn fetch_hf_rows(
 /// list. A suite larger than this needs the bound RAISED deliberately, with its size named —
 /// never silently truncated, which would publish a partial denominator as if it were the whole
 /// suite.
-const MAX_ROWS: usize = 5_000;
+// Raised 5_000 → 25_000 on 2026-08-23 for SWE-rebench, whose full `test`
+// split is 21,336 rows (the real suite size, per the HF size endpoint) — the
+// refusal below demands the bound be raised DELIBERATELY, naming the suite,
+// rather than publishing a rate over a truncated list.
+const MAX_ROWS: usize = 25_000;
 
 /// Where a suite's rows are cached. JSONL — one row per line — specifically so it can be read
 /// back INCREMENTALLY. A single JSON array cannot be: `from_slice` must materialize the whole
@@ -2916,6 +2952,44 @@ pub async fn grade(instance: &SweInstance, model_patch: Option<&str>) -> SweVerd
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the three wire dialects of one instance family
+    // (2026-08-23 import): SWE-bench string-encoded F2P, SWE-rebench REAL-LIST
+    // F2P, SWE-bench Pro lowercase names — all must decode into ONE SweInstance
+    // whose f2p()/p2p() yield the same ids, or a schema-kin suite silently
+    // "fetches 21k rows but NONE decoded" (load_dataset's own failure text).
+    #[test]
+    fn one_swe_instance_decodes_all_three_wire_dialects() {
+        let base = serde_json::json!({
+            "instance_id": "x__x-1", "repo": "x/x", "base_commit": "abc",
+            "patch": "p", "test_patch": "t", "problem_statement": "s",
+        });
+        let mut swebench = base.clone();
+        swebench["FAIL_TO_PASS"] = serde_json::json!("[\"tests/a.py::t1\"]");
+        swebench["PASS_TO_PASS"] = serde_json::json!("[\"tests/a.py::t2\"]");
+        let mut rebench = base.clone();
+        rebench["FAIL_TO_PASS"] = serde_json::json!(["tests/a.py::t1"]);
+        rebench["PASS_TO_PASS"] = serde_json::json!(["tests/a.py::t2"]);
+        rebench["created_at"] = serde_json::json!("2026-05-12 13:21:50");
+        let mut pro = base.clone();
+        pro["fail_to_pass"] = serde_json::json!("[\"tests/a.py::t1\"]");
+        pro["pass_to_pass"] = serde_json::json!("[\"tests/a.py::t2\"]");
+        for (dialect, v) in [("swe-bench", swebench), ("swe-rebench", rebench), ("pro", pro)] {
+            let inst: SweInstance = serde_json::from_value(v)
+                .unwrap_or_else(|e| panic!("{dialect} dialect failed to decode: {e}"));
+            assert_eq!(inst.f2p(), vec!["tests/a.py::t1"], "{dialect} f2p");
+            assert_eq!(inst.p2p(), vec!["tests/a.py::t2"], "{dialect} p2p");
+        }
+        // rebench's space-separated created_at still yields the era year.
+        let inst: SweInstance = serde_json::from_value(serde_json::json!({
+            "instance_id": "y", "repo": "y/y", "base_commit": "c", "patch": "p",
+            "test_patch": "t", "problem_statement": "s",
+            "created_at": "2026-05-12 13:21:50",
+            "FAIL_TO_PASS": [], "PASS_TO_PASS": []
+        }))
+        .expect("decodes");
+        assert_eq!(inst.year(), 2026);
+    }
 
     // what this catches: the exclude shield's MERGE contract. It runs on every
     // dispatch over already-staged checkouts (self-heal for pre-shield trees), so

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -236,13 +236,46 @@ pub fn known_benchmarks() -> &'static [BenchmarkSpec] {
         },
         BenchmarkSpec {
             name: "swe-bench-verified",
-            description: "SWE-bench Verified — the 500 human-validated instances (OpenAI). The current \
-                          agentic headline the frontier labs report; solution = a repo patch that passes \
-                          the real test suite. Official swebench Docker scorer.",
+            description: "SWE-bench Verified — the 500 human-validated instances (OpenAI). SATURATED \
+                          as a frontier signal (Opus 5 at 97.0%, seven models ≥95%, vals.ai 2026-08-19) \
+                          — keep as a floor/sanity check, never a headline. Solution = a repo patch \
+                          that passes the real test suite.",
             grader: Grader::Python,
             tasks: 500,
             eval_set: None,
             source_url: Some("https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified"),
+        },
+        BenchmarkSpec {
+            name: "swe-rebench",
+            description: "SWE-rebench (Nebius) — continuously-mined real GitHub issue→PR tasks, \
+                          CONTAMINATION-PROOF BY CONSTRUCTION: rolling time-windows mean only \
+                          instances newer than a model's cutoff count. Frontier mid-2026: Fable 5 \
+                          64.5%, Opus 5 63.4% on the May–Jul window. Same instance schema as \
+                          SWE-bench (list-shaped F2P/P2P normalized by the tolerant mapper); full \
+                          test split 21,336 instances — an HONEST run selects a window newer than \
+                          the model's training cutoff via each instance's created_at and says so \
+                          in the receipt. Tier-1 pick of the 2026-08-23 frontier-landscape sweep \
+                          (docs/planning/FRONTIER-BENCHMARK-LANDSCAPE-2026-08.md).",
+            grader: Grader::Python,
+            tasks: 21336,
+            eval_set: None,
+            source_url: Some("https://huggingface.co/datasets/nebius/SWE-rebench"),
+        },
+        BenchmarkSpec {
+            name: "swe-bench-pro",
+            description: "SWE-bench Pro (Scale AI) — the Verified successor: 731 public instances \
+                          (of 1,865) across 41 professional repos, long-horizon multi-file issues, \
+                          copyleft/held-out contamination barrier. Frontier mid-2026: 46–61% \
+                          (Gemini 3.1 Pro 46.1%, Opus 4.6 51.9%, GPT-5.4 59.1%) — frontier-HARD. \
+                          MULTI-LANGUAGE repos (js/go/py — `repo_language` per row): python \
+                          instances grade through the existing era-venv runners today; other \
+                          languages need their runner seam before their rows grade (#383's \
+                          repo→runner map is the extension point, expressed as data). Tier-1 pick \
+                          of the 2026-08-23 landscape sweep.",
+            grader: Grader::Python,
+            tasks: 731,
+            eval_set: None,
+            source_url: Some("https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro"),
         },
         BenchmarkSpec {
             name: "bigcodebench",

--- a/docs/planning/FRONTIER-BENCHMARK-LANDSCAPE-2026-08.md
+++ b/docs/planning/FRONTIER-BENCHMARK-LANDSCAPE-2026-08.md
@@ -1,0 +1,68 @@
+# Frontier Benchmark Landscape — researched 2026-08-23
+
+Web-researched (direct fetches of leaderboards, model cards, repos, tracker
+sites, all dated 2026-08-23) after Joel's standing rule landed: **no toys, no
+contaminated sets** ([[humaneval-is-prohibited-contaminated-benchmarks-carry-no-signal]]).
+The question answered: *what are the standards frontier labs are actually
+measured on mid-2026, which of them are frontier-HARD (frontier models < ~60%),
+execution-graded, and importable under our adapter doctrine (task + oracle only,
+the ROOM is the runner)?*
+
+## The headline
+
+**SWE-bench Verified is dead as a frontier signal** — Claude Opus 5 scores
+97.0%, seven models ≥95% (vals.ai, 2026-08-19). LiveCodeBench classic is
+saturating (Fable 5 89.8%). Anything our showcase records on those reads as a
+solved-problem row. The frontier moved to the suites below.
+
+## The ranked shortlist (frontier-hard × execution-graded × importable × prestige)
+
+| # | Benchmark | Frontier ceiling (8/2026) | Oracle | Import path |
+|---|---|---|---|---|
+| 1 | **SWE-bench Pro** (Scale AI) — 731 public of 1,865 tasks, 41 pro repos | Muse Spark 1.1 61.5%, GPT-5.4 59.1%, Opus 4.6 51.9%, Gemini 3.1 Pro 46.1% | execution: F2P/P2P suites, per-instance Docker (`jefzda/sweap-images`) | HF `ScaleAI/SWE-bench_Pro`, MIT eval code, standalone |
+| 2 | **Terminal-Bench 3.0 / Frontier Bench** (Stanford × Laude) — 74 tasks, 7 domains | GPT-5.6 Sol 34.4%, Fable 5 33.8%, Opus 4.8 21.1% — hardest widely-cited suite | execution: separate agent + verifier containers, artifacts re-gradeable | public registry `terminal-bench-core` (tbench.ai); task = container + verifier script |
+| 3 | **SWE-rebench** (Nebius) — rolling window (111 problems May–Jul window), 21k+ corpus | Fable 5 64.5%, Grok 4.5 63.8%, Opus 5 63.4% | execution: F2P/P2P in per-instance Docker (7,500 prebuilt images) | HF `nebius/SWE-rebench` CC-BY-4.0 — **identical schema to SWE-bench** = our cheapest import; rolling window kills the contamination objection |
+| 4 | **MirrorCode** (Epoch × METR) — reimplement whole programs from behavior, 30 task-configs | Fable 5 64%, GPT-5.6 Sol **20%** | execution: exact-match visible + ~34% held-out tests, 100% required | MIT, github.com/epoch-research; declare a smaller token budget honestly (official is 10B tok/attempt) |
+| 5 | **DeepSWE** (Datacurve) — 113 from-scratch long-horizon tasks, contamination-free by construction | Opus 5 74%, GPT-5.6 Sol 73%, Fable 5 70% | execution: hand-written per-task program verifiers, sandboxed | public subset 49/62 configs — verify coverage first |
+| 6 | **MLE-bench** (OpenAI) — 75 Kaggle comps; the **High split (~42% any-medal)** is the hard part | best agents ~60% overall; High ~42% | execution: `mlebench grade-sample` vs held-out keys — cleanest standalone grader on the list | github.com/openai/mle-bench; heavy (158GB Lite, GPU-hours) |
+| 7 | **SWE-Lancer IC-Diamond** (OpenAI) — 198 real-dollar Expensify freelance tasks | no maintained 2026 leaderboard (aging) | execution: **full-app Playwright e2e user-flow tests** — the only prestige suite whose oracle is "the feature works in the app" | github.com/openai/preparedness; per-task Docker ~14GB |
+| 8 | **ProgramBench** — 200 from-scratch rebuilds | Opus 5 82.3% raw but **6/200 fully resolved** | execution: hidden behavioral tests | verify the hidden test sets actually ship before committing |
+
+## Excluded, with reasons
+
+SWE-bench Verified (saturated — floor/sanity check only) · LiveCodeBench
+(saturating; contest ≠ project) · Vibe Code Bench (exactly the one-shot-app
+category but proprietary AND near-saturated: Fable 5 90.35%) · FrontierCode
+(rubric-judged — fails the execution bar) · CursorBench (closed) · WebDev Arena
+(human-pref Elo) · Design2Code (judge-scored, inactive) · Aider Polyglot (stale,
+drifting toy) · AppWorld (great oracle, but API-orchestration not SWE; optional
+breadth add) · Commit0 (superseded by MirrorCode/ProgramBench) · OSWorld 2.0
+(computer-use, out of scope) · METR time-horizons (methodology, not a task set —
+cite, don't import).
+
+## What this means for the showcase (the adapter queue)
+
+1. **SWE-rebench first** — same schema as the SWE-bench adapters we already
+   have, so it's the fastest path from "toy rows" to "frontier-hard rows with a
+   public leaderboard that already includes open models for direct comparison."
+   The rolling window is the honest answer to "your local model trained on it."
+2. **SWE-bench Pro public second** — the prestige successor; identical task
+   shape, prebuilt per-instance images, frontier at 46-61%.
+3. **Terminal-Bench 2.1 + 3.0 third** — terminal-native fits our citizens'
+   shell-first hands exactly; 3.0's separate-verifier-container design matches
+   our glass-box doctrine. 2.1 is the mid-rung (frontier 74-84%), 3.0 the
+   summit (frontier ~34%).
+4. **MirrorCode public** as the from-scratch tier (exact-match oracle, MIT,
+   tiny import) — declare our token budget on the row.
+5. MLE-bench High / SWE-Lancer Diamond as the long-horizon e2e tier when the
+   disk + hours budget allows.
+
+Env note: the per-instance Docker images are x86-first; on Apple Silicon we
+rebuild envs our own way (the SWE-bench era-venv precedent) — adapter doctrine
+imports task + oracle, never the maintainer's harness, so this is the designed
+path, not a workaround.
+
+One-shot app challenges (the viral fluid-sim shape) have a formal home:
+Vibe Code Bench — proprietary for now. Our in-house import of the circulating
+prompt (docs/genome/design/fluid-sim-task.md, §6b of the design-bench doc) is
+the right stand-in until it opens.


### PR DESCRIPTION
First two adapters from the frontier-landscape sweep (doc in-repo). One tolerant SweInstance deserializer absorbs all three wire dialects (string-encoded, real-list, lowercase) — no parallel structs. Catalog rows carry the contamination/saturation honesty. Fetch bound raised deliberately, naming the real suite size.

Terminal-Bench and MirrorCode converters are building in parallel worktrees and follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo