### PR TITLE
fix(grid): transport adopts its OS-assigned port — kills the free_port TOCTOU race

### DIFF
--- a/core/continuum-core/src/modules/grid/tests.rs
+++ b/core/continuum-core/src/modules/grid/tests.rs
@@ -17,16 +17,21 @@ mod tailscale_transport_integration {
     use std::sync::Arc;
 
     /// Find a free port by binding to port 0.
-    async fn free_port() -> u16 {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        listener.local_addr().unwrap().port()
+    /// Bind-to-0 then ask the transport what the OS assigned — the probe-then-
+    /// rebind `free_port()` this replaces was a TOCTOU race: a port measured free
+    /// can be taken before the transport re-binds it (CI 2026-08-23, `Address
+    /// already in use` on a busy runner). regression for PR #2389's flake.
+    async fn started_server() -> (Arc<TailscaleTransport>, u16) {
+        let server = Arc::new(TailscaleTransport::new(0));
+        server.start_with_ip("127.0.0.1").await.unwrap();
+        let port = server.bound_port();
+        assert_ne!(port, 0, "bind must adopt the OS-assigned port");
+        (server, port)
     }
 
     #[tokio::test]
     async fn test_tcp_connect_and_send_frame() {
-        let port = free_port().await;
-        let server = Arc::new(TailscaleTransport::new(port));
-        server.start_with_ip("127.0.0.1").await.unwrap();
+        let (server, port) = started_server().await;
 
         // Spawn server accept loop
         let server_clone = server.clone();
@@ -89,9 +94,7 @@ mod tailscale_transport_integration {
 
     #[tokio::test]
     async fn test_multiple_frames_on_same_connection() {
-        let port = free_port().await;
-        let server = Arc::new(TailscaleTransport::new(port));
-        server.start_with_ip("127.0.0.1").await.unwrap();
+        let (server, port) = started_server().await;
 
         let server_clone = server.clone();
         let server_task = tokio::spawn(async move {
@@ -140,9 +143,7 @@ mod tailscale_transport_integration {
 
     #[tokio::test]
     async fn test_large_frame_payload() {
-        let port = free_port().await;
-        let server = Arc::new(TailscaleTransport::new(port));
-        server.start_with_ip("127.0.0.1").await.unwrap();
+        let (server, port) = started_server().await;
 
         let server_clone = server.clone();
         let server_task = tokio::spawn(async move {
@@ -187,9 +188,7 @@ mod tailscale_transport_integration {
 
     #[tokio::test]
     async fn test_event_frame_roundtrip() {
-        let port = free_port().await;
-        let server = Arc::new(TailscaleTransport::new(port));
-        server.start_with_ip("127.0.0.1").await.unwrap();
+        let (server, port) = started_server().await;
 
         let server_clone = server.clone();
         let server_task = tokio::spawn(async move {
@@ -259,9 +258,7 @@ mod tailscale_transport_integration {
 
     #[tokio::test]
     async fn test_multiple_clients_to_same_server() {
-        let port = free_port().await;
-        let server = Arc::new(TailscaleTransport::new(port));
-        server.start_with_ip("127.0.0.1").await.unwrap();
+        let (server, port) = started_server().await;
 
         // Spawn server that accepts 3 connections
         let server_clone = server.clone();

--- a/core/continuum-core/src/modules/grid/transports/tailscale.rs
+++ b/core/continuum-core/src/modules/grid/transports/tailscale.rs
@@ -108,8 +108,12 @@ impl TailscaleConnection {
 /// Uses TCP connections over Tailscale WireGuard mesh.
 /// Discovery via `tailscale status --json` CLI.
 pub struct TailscaleTransport {
-    /// Port to listen on / connect to.
-    port: u16,
+    /// Port to listen on / connect to. `0` = OS-assigned: the REAL port is
+    /// stored back here after bind, so `local_address()`/`bound_port()` always
+    /// report the truth. This is what kills the probe-then-rebind TOCTOU race
+    /// (a "free" port can be taken between probe and bind — CI, 2026-08-23:
+    /// `Failed to bind 0.0.0.0:46243: Address already in use`).
+    port: std::sync::atomic::AtomicU16,
     /// TCP listener (set after start()).
     listener: Mutex<Option<Arc<TcpListener>>>,
     /// Our Tailscale IP (discovered at start time).
@@ -119,10 +123,15 @@ pub struct TailscaleTransport {
 impl TailscaleTransport {
     pub fn new(port: u16) -> Self {
         Self {
-            port,
+            port: std::sync::atomic::AtomicU16::new(port),
             listener: Mutex::new(None),
             local_ip: Mutex::new(None),
         }
+    }
+
+    /// The port actually bound (differs from the constructor arg when it was 0).
+    pub fn bound_port(&self) -> u16 {
+        self.port.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn with_default_port() -> Self {
@@ -134,10 +143,14 @@ impl TailscaleTransport {
     pub async fn start_with_ip(&self, ip: &str) -> Result<(), TransportError> {
         *self.local_ip.lock().await = Some(ip.to_string());
 
-        let bind_addr = format!("0.0.0.0:{}", self.port);
+        let bind_addr = format!("0.0.0.0:{}", self.port.load(std::sync::atomic::Ordering::Relaxed));
         let listener = TcpListener::bind(&bind_addr).await.map_err(|e| {
             TransportError::ConnectionFailed(format!("Failed to bind {bind_addr}: {e}"))
         })?;
+        if let Ok(addr) = listener.local_addr() {
+            // Adopt the OS-assigned port so every later report speaks the truth.
+            self.port.store(addr.port(), std::sync::atomic::Ordering::Relaxed);
+        }
 
         *self.listener.lock().await = Some(Arc::new(listener));
         Ok(())
@@ -156,7 +169,7 @@ impl GridTransport for TailscaleTransport {
         let ip = self.local_ip.try_lock().ok()?.clone()?;
         Some(TransportAddress::Tailscale {
             ip,
-            port: self.port,
+            port: self.port.load(std::sync::atomic::Ordering::Relaxed),
             machine_name: None,
         })
     }
@@ -179,10 +192,14 @@ impl GridTransport for TailscaleTransport {
         *self.local_ip.lock().await = Some(self_ip.clone());
 
         // Bind TCP listener on all interfaces (Tailscale handles routing)
-        let bind_addr = format!("0.0.0.0:{}", self.port);
+        let bind_addr = format!("0.0.0.0:{}", self.port.load(std::sync::atomic::Ordering::Relaxed));
         let listener = TcpListener::bind(&bind_addr).await.map_err(|e| {
             TransportError::ConnectionFailed(format!("Failed to bind {bind_addr}: {e}"))
         })?;
+        if let Ok(addr) = listener.local_addr() {
+            // Adopt the OS-assigned port so every later report speaks the truth.
+            self.port.store(addr.port(), std::sync::atomic::Ordering::Relaxed);
+        }
 
         *self.listener.lock().await = Some(Arc::new(listener));
 
@@ -261,7 +278,7 @@ impl GridTransport for TailscaleTransport {
                 DiscoveredNode {
                     address: TransportAddress::Tailscale {
                         ip,
-                        port: self.port,
+                        port: self.port.load(std::sync::atomic::Ordering::Relaxed),
                         machine_name: Some(peer.host_name.clone()),
                     },
                     capabilities: vec![], // We don't know capabilities until we connect


### PR DESCRIPTION
PR #2389's CI red: probe-then-rebind port race shared by five grid tests. The transport now learns its bound port (atomic, stored after bind), tests bind 0 and ask via `bound_port()`. Production gains honest port-0 semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo