### PR TITLE
fix(media): pixel-path one-seam cures — zero-copy audit, first installment

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -3419,10 +3419,7 @@ pub fn start_server(
                 // persona's own observe/hot-edit results publish frames at the
                 // act seam; no tick, no scan. Install-only here; the act loop
                 // does the publishing when work actually happens.
-                positron_canvas_source::install(
-                    ws_substrate.clone(),
-                    global_bench_substrate(),
-                );
+                positron_canvas_source::install(ws_substrate.clone());
 
                 // Live-call glass box (#58): folds the TRANSPORT's calls against
                 // the ORCHESTRATOR's registered sessions. Their disagreement is

--- a/core/continuum-core/src/ipc/positron_canvas_source.rs
+++ b/core/continuum-core/src/ipc/positron_canvas_source.rs
@@ -20,7 +20,6 @@ use continuum_positron::{StateBuilder, Substrate};
 struct CanvasFeed {
     builder: StateBuilder,
     substrate: Substrate,
-    mind_substrate: Substrate,
     /// Monotonic per-process observation counter — the face's iterate pulse.
     revision: u32,
 }
@@ -29,12 +28,11 @@ static FEED: OnceLock<Mutex<CanvasFeed>> = OnceLock::new();
 
 /// Install the feed's render targets at boot (beside the bench emitter).
 /// Second call is a boot-sequence bug — fail loud, one feed per process.
-pub fn install(substrate: Substrate, mind_substrate: Substrate) {
+pub fn install(substrate: Substrate) {
     if FEED
         .set(Mutex::new(CanvasFeed {
             builder: StateBuilder::standalone(),
             substrate,
-            mind_substrate,
             revision: 0,
         }))
         .is_err()
@@ -52,8 +50,13 @@ pub fn publish(mut view: CanvasViewState) {
     feed.revision = feed.revision.saturating_add(1);
     view.revision = Some(feed.revision);
     let envelope = feed.builder.session(view);
-    feed.substrate.store(envelope.clone());
-    feed.mind_substrate.store(envelope);
+    // ONE store, no clone: the 2026-08-23 pixel audit found the second
+    // (mind-substrate) store had NO reader — no ViewStateRagSource<CanvasViewState>
+    // exists — so the deep clone of a screenshot-bearing envelope duplicated
+    // megabytes into a void. The mind-side binding returns WITH its reader,
+    // by handle, when the observe wire moves to filepath (the architectural
+    // rung); pixels-in-envelopes never get a second copy again.
+    feed.substrate.store(envelope);
 }
 
 /// Fold a persona's observe/hot-edit TOOL RESULT into a frame and publish it.

--- a/core/continuum-core/src/media/frame.rs
+++ b/core/continuum-core/src/media/frame.rs
@@ -18,6 +18,15 @@ use async_trait::async_trait;
 use sha2::{Digest, Sha256};
 
 use super::image_ops::{scale_crop, CropRect, DestSize};
+
+/// The tier a describe reads from — ~480w (the perception buffer's ambient
+/// class): a VL vision tower downsamples to a fixed grid, so full-res input
+/// buys no fidelity, only multi-MB base64 in the request JSON (2026-08-23
+/// pixel audit). 16:9 default; scale_crop preserves aspect via its own path.
+const DESCRIBE_TIER: DestSize = DestSize {
+    width: 480,
+    height: 270,
+};
 use crate::runtime::SharedCompute;
 
 /// Produces the text DESCRIPTION of a media frame — the sensory bridge that lets a
@@ -90,7 +99,18 @@ impl MediaFrame {
         describer: &dyn FrameDescriber,
         mime: &str,
     ) -> Arc<Result<String, String>> {
-        let source = Arc::clone(&self.source);
+        // Describe from the ~ambient THUMBNAIL, not the full source (2026-08-23
+        // pixel audit): a VL model's vision tower downsamples to a fixed grid
+        // anyway, and the warm path computes this exact scaled cell right before
+        // the describe — full-res only base64-inflated a multi-MB source into
+        // the request JSON for zero fidelity gain. Fall back to the source ONLY
+        // when scaling itself failed (a corrupt frame should still fail loudly
+        // through the describer's own error, not silently skip description).
+        let scaled = self.scaled(compute, None, DESCRIBE_TIER).await;
+        let source = match &*scaled {
+            Ok(bytes) => Arc::new(bytes.clone()), // one small thumbnail copy replaces a multi-MB inline
+            Err(_) => Arc::clone(&self.source),
+        };
         let mime = mime.to_string();
         compute
             .get_or_compute(&self.content_hash, DESCRIBE_KEY, async move {

--- a/packages/perception/domSurface.ts
+++ b/packages/perception/domSurface.ts
@@ -68,6 +68,9 @@ export interface DomSurfaceOptions {
   readonly url: string;
   readonly viewport?: { readonly width: number; readonly height: number };
   readonly headless?: boolean;
+  /** Pixel density of the capture. Default 1 — retina (2) is an opt-in for
+   *  tasks grading fine detail; it quadruples every screenshot's bytes. */
+  readonly deviceScaleFactor?: number;
   /** Force a specific Chromium binary (Opera GX / Brave / Chromium / any). Highest priority.
    *  Env fallbacks: `PERCEPTION_CHROME`, then `CHROME`. */
   readonly executablePath?: string;
@@ -150,7 +153,11 @@ export class DomSurface implements Surface<DomViewSpec, DomAction> {
     });
     const page = await browser.newPage({
       viewport: opts.viewport ?? { width: 1440, height: 900 },
-      deviceScaleFactor: 2,
+      // 1 by default (2026-08-23 pixel audit): the hardcoded 2 quadrupled every
+      // screenshot's pixels for consumers that render thumbnails — retina
+      // capture is an OPT-IN for tasks that grade fine detail, never a tax on
+      // every observation.
+      deviceScaleFactor: opts.deviceScaleFactor ?? 1,
     });
     // esbuild's `keepNames` (tsx, vite, ts-node all use it) wraps named functions with a
     // `__name(fn, 'name')` helper. When Playwright serializes our `domWalk` into the page,


### PR DESCRIPTION
Canvas dead-store+clone deleted, describes read a 480w tier instead of full-res base64, retina capture opt-in. The architectural handle seam (observe-by-filepath, video-plane Bytes, GPU publisher wiring) is the follow-up arc; full audit in the session record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo