### PR TITLE
perf(runtime): the serialization first-commit — BusEvent Arc, probe gates, shared positron stores

### DIFF
--- a/core/continuum-core/src/airc/inbound_attach.rs
+++ b/core/continuum-core/src/airc/inbound_attach.rs
@@ -302,7 +302,7 @@ pub async fn publish_transcript_event(
     //    on ONE `chat:posted`, two wire shapes, mirroring the receive-side
     //    `perceptual_from_event`. Anything else is not ours here → skip.
     if let Some(bus_event) = bus_event_from_envelope(&envelope) {
-        bus.publish_async_only(&bus_event.name, bus_event.payload);
+        bus.publish_async_only(&bus_event.name, (*bus_event.payload).clone()); // crossing OUT of the bus type; one owned copy at the boundary
     } else if let Some(offer) = capacity_offer_from_envelope(&envelope) {
         // Grid capacity gossip (#56 step 4): fold the heard offer into the
         // process-global ledger, keyed on the WIRE's peer id (airc's authenticated

--- a/core/continuum-core/src/airc/realtime_wire.rs
+++ b/core/continuum-core/src/airc/realtime_wire.rs
@@ -103,7 +103,7 @@ pub fn bus_event_from_envelope(envelope: &AircRealtimeEnvelope) -> Option<BusEve
 
     Some(BusEvent {
         name: event_name.to_string(),
-        payload: inline.clone(),
+        payload: std::sync::Arc::new(inline.clone()),
     })
 }
 

--- a/core/continuum-core/src/cognition/dispatch_listener.rs
+++ b/core/continuum-core/src/cognition/dispatch_listener.rs
@@ -87,7 +87,7 @@ pub fn spawn(bus: Arc<MessageBus>, working_memory: Arc<WorkingMemory>) {
             if event.name != COMMAND_COMPLETED_TOPIC {
                 continue;
             }
-            let Ok(ev) = serde_json::from_value::<CommandCompletedEvent>(event.payload) else {
+            let Ok(ev) = serde_json::from_value::<CommandCompletedEvent>((*event.payload).clone()) else { // typed decode needs owned; one copy at THIS consumer, not per receiver
                 continue;
             };
             fold_completion(&working_memory, ev);

--- a/core/continuum-core/src/ipc/positron_bench_source.rs
+++ b/core/continuum-core/src/ipc/positron_bench_source.rs
@@ -194,9 +194,11 @@ pub fn spawn_bench_emitter(
                 continue;
             }
             last = Some(view.clone());
-            let envelope = builder.session(view);
-            substrate.store(envelope.clone());
-            mind_substrate.store(envelope);
+            let envelope = std::sync::Arc::new(builder.session(view));
+            // One allocation, two sinks (2026-08-23 audit): the by-value clone
+            // deep-copied the whole board per publish for the second target.
+            substrate.store_shared(std::sync::Arc::clone(&envelope));
+            mind_substrate.store_shared(envelope);
         }
     });
 }

--- a/core/continuum-core/src/ipc/positron_kanban_source.rs
+++ b/core/continuum-core/src/ipc/positron_kanban_source.rs
@@ -983,7 +983,7 @@ mod tests {
         let other = Uuid::from_u128(0xdead);
         let foreign = BusEvent {
             name: KANBAN_CHANGED.to_string(),
-            payload: json!({ "roomId": other }),
+            payload: std::sync::Arc::new(json!({ "roomId": other })),
         };
         reader.board.lock().unwrap().cards.clear();
         let step = fold_recv(&mut p, room.as_uuid(), Ok(foreign)).await;

--- a/core/continuum-core/src/ipc/positron_nav_source.rs
+++ b/core/continuum-core/src/ipc/positron_nav_source.rs
@@ -294,11 +294,11 @@ pub fn spawn_room_set_fold(
                 Ok(event) => {
                     let observed: Option<(Uuid, Option<String>)> = if event.name == PRESENCE_UPDATED
                     {
-                        serde_json::from_value::<AircPresenceUpdate>(event.payload.clone())
+                        AircPresenceUpdate::deserialize(&*event.payload)
                             .ok()
                             .map(|p| (p.room_id, Some(p.room_name)))
                     } else if event.name == CHAT_POSTED {
-                        serde_json::from_value::<ChatPostedRoom>(event.payload.clone())
+                        ChatPostedRoom::deserialize(&*event.payload)
                             .ok()
                             .map(|p| (p.room_id, None))
                     } else {
@@ -369,7 +369,7 @@ pub fn spawn_member_set_fold(
                         continue;
                     }
                     if let Ok(update) =
-                        serde_json::from_value::<AircPresenceUpdate>(event.payload.clone())
+                        AircPresenceUpdate::deserialize(&*event.payload)
                     {
                         tx.send_if_modified(|set| {
                             let mut changed = false;

--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -584,6 +584,11 @@ struct ChatProjection {
     /// Last-published roster, for emit-on-change (roster shifts on presence, not per
     /// message) — same discipline as `last_experience`.
     last_roster: std::cell::RefCell<Option<Vec<RosterSlotView>>>,
+    /// Emit-on-change for the CHAT kind itself — the largest payload this
+    /// projection publishes (2026-08-23 audit: five ungated call sites,
+    /// vitals ticks re-serializing the full 100-message transcript ~2×/s).
+    /// Same discipline as `last_experience`, twelve lines above it.
+    last_chat: std::cell::RefCell<Option<ChatViewState>>,
 }
 
 impl ChatProjection {
@@ -655,6 +660,7 @@ impl ChatProjection {
             last_experience: std::cell::RefCell::new(None),
             roster_builder: StateBuilder::standalone(),
             last_roster: std::cell::RefCell::new(None),
+            last_chat: std::cell::RefCell::new(None),
             purpose_source,
         }
     }
@@ -924,7 +930,13 @@ impl ChatProjection {
             acts: self.acts.iter().cloned().collect(),
             roster,
         };
-        self.store_room_scoped(room_id, self.builder.session(view));
+        // Emit-on-change: a vitals/presence tick that moved nothing in the
+        // chat view must not re-serialize and re-broadcast 100 messages.
+        if self.last_chat.borrow().as_ref() == Some(&view) {
+            return;
+        }
+        self.store_room_scoped(room_id, self.builder.session(view.clone()));
+        *self.last_chat.borrow_mut() = Some(view);
     }
 
     /// Store one per-room envelope to BOTH sinks: the node substrate (what the
@@ -934,10 +946,14 @@ impl ChatProjection {
     /// ONE place decides the dual-sink rule, so a future kind cannot be added to one
     /// sink and forgotten in the other — the compression law applied to a write path.
     fn store_room_scoped(&self, room_id: Uuid, envelope: continuum_positron::StateEnvelope) {
+        // One allocation, both sinks (2026-08-23 audit): the by-value clone
+        // deep-copied the full ~100-message chat payload tree per store for
+        // the second sink — the largest single producer-side copy in the core.
+        let envelope = std::sync::Arc::new(envelope);
         if let Some(rooms) = &self.rooms {
-            rooms.for_room(room_id).store(envelope.clone());
+            rooms.for_room(room_id).store_shared(std::sync::Arc::clone(&envelope));
         }
-        self.substrate.store(envelope);
+        self.substrate.store_shared(envelope);
     }
 
     /// Assemble this room's [`Experience`] manifest: recipe (by the room's purpose)

--- a/core/continuum-core/src/ipc/positron_wall_source.rs
+++ b/core/continuum-core/src/ipc/positron_wall_source.rs
@@ -663,7 +663,7 @@ mod tests {
         let other = Uuid::from_u128(0xdead);
         let foreign = BusEvent {
             name: WALL_CHANGED.to_string(),
-            payload: json!({ "roomId": other }),
+            payload: std::sync::Arc::new(json!({ "roomId": other })),
         };
         // Even if the board content changed underneath, a foreign event must
         // not fold it in.

--- a/core/continuum-core/src/modules/chat/mod.rs
+++ b/core/continuum-core/src/modules/chat/mod.rs
@@ -619,7 +619,7 @@ pub fn spawn_persist_listener(
             if event.name != crate::ipc::positron_source::CHAT_POSTED {
                 continue;
             }
-            if let Err(error) = module.persist_posted(event.payload).await {
+            if let Err(error) = module.persist_posted((*event.payload).clone()).await { // persist consumes an owned Value; one copy at the boundary
                 // Loud but non-fatal: one malformed payload must not kill the
                 // transcript writer for the rest of the process lifetime.
                 tracing::warn!(error, "chat:posted persist failed (#140)");

--- a/core/continuum-core/src/modules/nav.rs
+++ b/core/continuum-core/src/modules/nav.rs
@@ -625,7 +625,7 @@ mod tests {
         while let Ok(event) = rx.try_recv() {
             if event.name == CHAT_FOCUSED {
                 let payload: AircChatFocused =
-                    serde_json::from_value(event.payload.clone()).expect("real wire struct");
+                    serde_json::from_value((*event.payload).clone()).expect("real wire struct");
                 assert_eq!(payload.room_id, room);
                 saw_focus = true;
             }

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -5678,7 +5678,7 @@ mod tests {
         let event = bus
             .find_recent_event(SERVING_SNAPSHOT_EVENT)
             .expect("serving.snapshot must be emitted on the bus");
-        let snap: ServingSnapshot = serde_json::from_value(event.payload).unwrap();
+        let snap: ServingSnapshot = serde_json::from_value((*event.payload).clone()).unwrap(); // test-only decode of the shared bus payload
         assert_eq!(snap.active_model.as_deref(), Some("coder-14b"));
         assert!(snap.ready, "emitted snapshot reflects the live model");
     }

--- a/core/continuum-core/src/persona/grounding_invalidation.rs
+++ b/core/continuum-core/src/persona/grounding_invalidation.rs
@@ -84,7 +84,7 @@ pub fn spawn_workspace_invalidator(bus: Arc<MessageBus>, dirty: WeakDirtyHandle)
             if event.name != COMMAND_COMPLETED_TOPIC {
                 continue;
             }
-            let Ok(ev) = serde_json::from_value::<CommandCompletedEvent>(event.payload) else {
+            let Ok(ev) = serde_json::from_value::<CommandCompletedEvent>((*event.payload).clone()) else { // typed decode needs owned; one copy at THIS consumer, not per receiver
                 continue;
             };
             if !mutates_workspace(&ev.command_name) {

--- a/core/continuum-core/src/routing/probe_file_sink.rs
+++ b/core/continuum-core/src/routing/probe_file_sink.rs
@@ -328,6 +328,15 @@ where
     S: Subscriber + for<'lookup> LookupSpan<'lookup>,
 {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        // ZERO-COST GATE (2026-08-23 serialization audit): callsite field sets
+        // are static metadata — asking whether `probe_class` exists allocates
+        // nothing. Without this, EVERY tracing event in the process and its
+        // dependency crates paid a full visitor walk (a String per field into a
+        // HashMap) in this layer, then discarded it. The span path got exactly
+        // this fix in PR #1541 R2; the event path never did.
+        if event.metadata().fields().field("probe_class").is_none() {
+            return;
+        }
         // Same visit pattern as ProbeRouterLayer: pull probe_class +
         // message + every other field off the tracing event. The
         // visitor is private here (not exported from probe_router)

--- a/core/continuum-core/src/routing/probe_router.rs
+++ b/core/continuum-core/src/routing/probe_router.rs
@@ -197,6 +197,15 @@ where
     S: Subscriber + for<'lookup> LookupSpan<'lookup>,
 {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        // ZERO-COST GATE (2026-08-23 serialization audit): callsite field sets
+        // are static metadata — asking whether `probe_class` exists allocates
+        // nothing. Without this, EVERY tracing event in the process and its
+        // dependency crates paid a full visitor walk (a String per field into a
+        // HashMap) in this layer, then discarded it. The span path got exactly
+        // this fix in PR #1541 R2; the event path never did.
+        if event.metadata().fields().field("probe_class").is_none() {
+            return;
+        }
         let mut visitor = ProbeEventVisitor::default();
         event.record(&mut visitor);
 

--- a/core/continuum-core/src/runtime/command_executor.rs
+++ b/core/continuum-core/src/runtime/command_executor.rs
@@ -1132,7 +1132,7 @@ mod tests {
         })
         .await
         .expect("expected a command:completed event within 2s");
-        serde_json::from_value(recv.payload).expect("event payload must parse")
+        serde_json::from_value((*recv.payload).clone()).expect("event payload must parse")
     }
 
     #[tokio::test]
@@ -1322,7 +1322,7 @@ mod tests {
             match tokio::time::timeout(remaining, rx.recv()).await {
                 Ok(Ok(event)) if event.name == COMMAND_COMPLETED_TOPIC => {
                     let parsed: CommandCompletedEvent =
-                        serde_json::from_value(event.payload).expect("payload parses");
+                        serde_json::from_value((*event.payload).clone()).expect("payload parses");
                     events.push(parsed);
                 }
                 Ok(Ok(_)) => continue, // unrelated event topic — skip

--- a/core/continuum-core/src/runtime/message_bus.rs
+++ b/core/continuum-core/src/runtime/message_bus.rs
@@ -44,10 +44,16 @@ struct ArtifactSubscription {
 }
 
 /// Event payload sent through the bus.
+///
+/// `payload` is `Arc`-shared (2026-08-23 serialization audit): tokio's
+/// broadcast clones the event into EVERY receiver — ~19 production holders —
+/// plus the recent-events archive, so a by-value `Value` paid ~20 full tree
+/// copies per publish (a 100 KB tool-result event cost ~2 MB of copying).
+/// With the Arc, every clone is a refcount bump; consumers read `&*payload`.
 #[derive(Debug, Clone)]
 pub struct BusEvent {
     pub name: String,
-    pub payload: serde_json::Value,
+    pub payload: std::sync::Arc<serde_json::Value>,
 }
 
 /// Timestamped event for the recent event buffer.
@@ -315,7 +321,7 @@ impl MessageBus {
         // Deferred tier: broadcast for async consumers
         let event = BusEvent {
             name: event_name.to_string(),
-            payload,
+            payload: std::sync::Arc::new(payload),
         };
         self.record_recent(&event);
         // Ignore send error (no receivers is fine)
@@ -353,7 +359,7 @@ impl MessageBus {
 
         let event = BusEvent {
             name: event_name.to_string(),
-            payload,
+            payload: std::sync::Arc::new(payload),
         };
         self.record_recent(&event);
         let _ = self.sender.send(event);

--- a/core/continuum-positron/src/substrate.rs
+++ b/core/continuum-positron/src/substrate.rs
@@ -57,7 +57,17 @@ impl Substrate {
     /// `Arc<StateEnvelope>` allocation per `[[shared-decode-per-
     /// persona-perspective]]`.
     pub fn store(&self, envelope: StateEnvelope) {
-        let arc = Arc::new(envelope);
+        self.store_shared(Arc::new(envelope));
+    }
+
+    /// Store an ALREADY-SHARED envelope — the dual-sink seam (2026-08-23
+    /// serialization audit): a producer publishing the same envelope to two
+    /// substrates (websocket + mind) was deep-cloning the entire payload tree
+    /// to satisfy `store(StateEnvelope)`'s by-value signature. Build the Arc
+    /// once, hand it to every sink; the clone becomes a refcount bump. This is
+    /// the module header's own promise ("every consumer reads the same bytes")
+    /// finally honored on the producer side.
+    pub fn store_shared(&self, arc: Arc<StateEnvelope>) {
         self.cache.store_arc(Arc::clone(&arc));
         self.broadcast.send(arc);
     }


### PR DESCRIPTION
The 2026-08-23 serialization audit's recommended first commit — the four low-risk items estimated at 60–80% of the compounded hot-path serialization waste.

## What changes

1. **`BusEvent.payload: Value → Arc<Value>`** — the bus fans one event to N subscribers; each previously received its own deep clone of the payload. One allocation now travels. Consumers that genuinely need an owned `Value` (two typed decodes, one persist) take one justified copy at their own boundary — no longer one per receiver. `positron_nav_source` now deserializes from the borrow with zero copies.
2. **Probe layers gate at line 1** — `probe_file_sink` and `probe_router` `on_event` check `probe_class` field presence before any visitor construction. Every non-probe tracing event previously paid full field-walking before being dropped.
3. **`Substrate::store_shared(Arc<StateEnvelope>)`** — dual-sink positron emitters (bench, room-scoped chat) share one envelope between substrates instead of cloning the ViewState per sink.
4. **Chat store-on-change gate** — `last_chat` compare in `positron_source` skips re-serializing an unchanged `ChatViewState` every tick.

## Why

Joel's zero-copy directive (the "sickness" arc): content travels by handle, hot paths allocate zero, clones on hot paths carry same-line justification — which every copy in this diff does.

## Validation

- `cargo check -p continuum-core --features metal,accelerate` clean
- 80-test battery green: `message_bus`, positron sources, unwrap ratchet, test-mod singularity
- `cargo test -p continuum-positron --lib`: 129 green

Producer-side savings only — no deploy urgency; rides the next natural deploy alongside #2406 so the running MirrorCode baseline finishes undisturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo