### PR TITLE
perf(cognition,logging): serialization small cures — memoized tool-surface tokens, pre-format log gates

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -168,6 +168,11 @@ pub struct LlmDeliberationFaculty {
     /// schemas instead of the whole ~150-tool registry. Computed in
     /// [`Self::rebuild_tool_surface`].
     native_specs: Vec<NativeToolSpec>,
+    /// Token cost of serializing `native_specs` into the request — memoized at
+    /// [`Self::rebuild_tool_surface`] time because the specs are static between
+    /// rebuilds while [`Self::describe_tool_tokens`] is consulted on EVERY
+    /// prompt assembly (per-turn serde of ~a dozen schemas, pure waste).
+    tool_surface_tokens: usize,
     /// Where this faculty records its chain-of-thought after a verdict, so the
     /// persona can resume its train of thought next turn (the
     /// [`WorkingMemory`](crate::cognition::working_memory::WorkingMemory)
@@ -230,6 +235,7 @@ impl LlmDeliberationFaculty {
             temperature: DEFAULT_TEMPERATURE,
             tools: Vec::new(),
             native_specs: Vec::new(),
+            tool_surface_tokens: 0,
             working_memory: None,
             prompt_capture: None,
             genome: empty_genome(),
@@ -336,6 +342,7 @@ impl LlmDeliberationFaculty {
     fn rebuild_tool_surface(&mut self) {
         if self.tools.is_empty() {
             self.native_specs.clear();
+            self.tool_surface_tokens = 0;
             return;
         }
         // Offer the working set in the WIRE DIALECT, charset-legal per the OpenAI
@@ -372,6 +379,21 @@ impl LlmDeliberationFaculty {
             .into_iter()
             .map(|s| crate::cognition::tool_dialect::to_wire_spec_with(s, style))
             .collect();
+        self.tool_surface_tokens = Self::tool_surface_tokens_of(&self.native_specs);
+    }
+
+    /// Serde-and-count the tool surface ONCE per rebuild — the only place the
+    /// per-spec serialization cost is ever paid.
+    fn tool_surface_tokens_of(specs: &[NativeToolSpec]) -> usize {
+        // context-budget-exempt: fixed per-tool schema overhead in the template — same reason as PER_MESSAGE_TEMPLATE_TOKENS
+        const PER_TOOL_TEMPLATE_MARGIN_TOKENS: usize = 8;
+        specs
+            .iter()
+            .map(|spec| {
+                let serialized = serde_json::to_string(spec).unwrap_or_default();
+                est_tokens(&serialized) + PER_TOOL_TEMPLATE_MARGIN_TOKENS
+            })
+            .sum()
     }
 
     /// Set the effective served context window (tokens) this faculty must keep its
@@ -1845,15 +1867,7 @@ impl LlmDeliberationFaculty {
     /// set — the amputated surface is the #206 cliff and measured 14/14 SWE acts as
     /// `commands/help` with 0 edits.
     fn describe_tool_tokens(&self) -> usize {
-        // context-budget-exempt: fixed per-tool schema overhead in the template — same reason as PER_MESSAGE_TEMPLATE_TOKENS
-        const PER_TOOL_TEMPLATE_MARGIN_TOKENS: usize = 8;
-        self.native_specs
-            .iter()
-            .map(|spec| {
-                let serialized = serde_json::to_string(spec).unwrap_or_default();
-                est_tokens(&serialized) + PER_TOOL_TEMPLATE_MARGIN_TOKENS
-            })
-            .sum()
+        self.tool_surface_tokens
     }
 }
 

--- a/core/continuum-core/src/logging/mod.rs
+++ b/core/continuum-core/src/logging/mod.rs
@@ -98,7 +98,9 @@ macro_rules! log_debug {
             // `else`, all 615 `log_*` call sites evaporated there. Falls through to
             // the SAME sink `clog_*` already writes to, so there is one file-logging
             // truth rather than a third path.
-            $crate::logging::write_log_direct($category, "DEBUG", $component, &format!($($arg)*));
+            if $crate::modules::logger::log_sink_ready() {
+                $crate::logging::write_log_direct($category, "DEBUG", $component, &format!($($arg)*));
+            }
         }
     };
 }
@@ -121,7 +123,9 @@ macro_rules! log_info {
             // `else`, all 615 `log_*` call sites evaporated there. Falls through to
             // the SAME sink `clog_*` already writes to, so there is one file-logging
             // truth rather than a third path.
-            $crate::logging::write_log_direct($category, "INFO", $component, &format!($($arg)*));
+            if $crate::modules::logger::log_sink_ready() {
+                $crate::logging::write_log_direct($category, "INFO", $component, &format!($($arg)*));
+            }
         }
     };
 }
@@ -144,7 +148,9 @@ macro_rules! log_warn {
             // `else`, all 615 `log_*` call sites evaporated there. Falls through to
             // the SAME sink `clog_*` already writes to, so there is one file-logging
             // truth rather than a third path.
-            $crate::logging::write_log_direct($category, "WARN", $component, &format!($($arg)*));
+            if $crate::modules::logger::log_sink_ready() {
+                $crate::logging::write_log_direct($category, "WARN", $component, &format!($($arg)*));
+            }
         }
     };
 }
@@ -167,7 +173,9 @@ macro_rules! log_error {
             // `else`, all 615 `log_*` call sites evaporated there. Falls through to
             // the SAME sink `clog_*` already writes to, so there is one file-logging
             // truth rather than a third path.
-            $crate::logging::write_log_direct($category, "ERROR", $component, &format!($($arg)*));
+            if $crate::modules::logger::log_sink_ready() {
+                $crate::logging::write_log_direct($category, "ERROR", $component, &format!($($arg)*));
+            }
         }
     };
 }
@@ -288,10 +296,12 @@ pub fn write_log_direct(category: &str, level: &str, component: &str, message: &
 #[macro_export]
 macro_rules! clog_info {
     ($($arg:tt)*) => {{
-        let category = $crate::logging::module_path_to_category(module_path!());
-        let component = $crate::logging::extract_component(module_path!());
-        let message = format!($($arg)*);
-        $crate::logging::write_log_direct(category, "INFO", component, &message);
+        if $crate::modules::logger::log_sink_ready() {
+            let category = $crate::logging::module_path_to_category(module_path!());
+            let component = $crate::logging::extract_component(module_path!());
+            let message = format!($($arg)*);
+            $crate::logging::write_log_direct(category, "INFO", component, &message);
+        }
     }};
 }
 
@@ -299,10 +309,12 @@ macro_rules! clog_info {
 #[macro_export]
 macro_rules! clog_warn {
     ($($arg:tt)*) => {{
-        let category = $crate::logging::module_path_to_category(module_path!());
-        let component = $crate::logging::extract_component(module_path!());
-        let message = format!($($arg)*);
-        $crate::logging::write_log_direct(category, "WARN", component, &message);
+        if $crate::modules::logger::log_sink_ready() {
+            let category = $crate::logging::module_path_to_category(module_path!());
+            let component = $crate::logging::extract_component(module_path!());
+            let message = format!($($arg)*);
+            $crate::logging::write_log_direct(category, "WARN", component, &message);
+        }
     }};
 }
 
@@ -310,10 +322,12 @@ macro_rules! clog_warn {
 #[macro_export]
 macro_rules! clog_error {
     ($($arg:tt)*) => {{
-        let category = $crate::logging::module_path_to_category(module_path!());
-        let component = $crate::logging::extract_component(module_path!());
-        let message = format!($($arg)*);
-        $crate::logging::write_log_direct(category, "ERROR", component, &message);
+        if $crate::modules::logger::log_sink_ready() {
+            let category = $crate::logging::module_path_to_category(module_path!());
+            let component = $crate::logging::extract_component(module_path!());
+            let message = format!($($arg)*);
+            $crate::logging::write_log_direct(category, "ERROR", component, &message);
+        }
     }};
 }
 
@@ -321,10 +335,12 @@ macro_rules! clog_error {
 #[macro_export]
 macro_rules! clog_debug {
     ($($arg:tt)*) => {{
-        let category = $crate::logging::module_path_to_category(module_path!());
-        let component = $crate::logging::extract_component(module_path!());
-        let message = format!($($arg)*);
-        $crate::logging::write_log_direct(category, "DEBUG", component, &message);
+        if $crate::modules::logger::log_sink_ready() {
+            let category = $crate::logging::module_path_to_category(module_path!());
+            let component = $crate::logging::extract_component(module_path!());
+            let message = format!($($arg)*);
+            $crate::logging::write_log_direct(category, "DEBUG", component, &message);
+        }
     }};
 }
 
@@ -332,24 +348,32 @@ macro_rules! clog_debug {
 #[macro_export]
 macro_rules! clog_to {
     ($category:expr, info, $($arg:tt)*) => {{
-        let component = $crate::logging::extract_component(module_path!());
-        let message = format!($($arg)*);
-        $crate::logging::write_log_direct($category, "INFO", component, &message);
+        if $crate::modules::logger::log_sink_ready() {
+            let component = $crate::logging::extract_component(module_path!());
+            let message = format!($($arg)*);
+            $crate::logging::write_log_direct($category, "INFO", component, &message);
+        }
     }};
     ($category:expr, warn, $($arg:tt)*) => {{
-        let component = $crate::logging::extract_component(module_path!());
-        let message = format!($($arg)*);
-        $crate::logging::write_log_direct($category, "WARN", component, &message);
+        if $crate::modules::logger::log_sink_ready() {
+            let component = $crate::logging::extract_component(module_path!());
+            let message = format!($($arg)*);
+            $crate::logging::write_log_direct($category, "WARN", component, &message);
+        }
     }};
     ($category:expr, error, $($arg:tt)*) => {{
-        let component = $crate::logging::extract_component(module_path!());
-        let message = format!($($arg)*);
-        $crate::logging::write_log_direct($category, "ERROR", component, &message);
+        if $crate::modules::logger::log_sink_ready() {
+            let component = $crate::logging::extract_component(module_path!());
+            let message = format!($($arg)*);
+            $crate::logging::write_log_direct($category, "ERROR", component, &message);
+        }
     }};
     ($category:expr, debug, $($arg:tt)*) => {{
-        let component = $crate::logging::extract_component(module_path!());
-        let message = format!($($arg)*);
-        $crate::logging::write_log_direct($category, "DEBUG", component, &message);
+        if $crate::modules::logger::log_sink_ready() {
+            let component = $crate::logging::extract_component(module_path!());
+            let message = format!($($arg)*);
+            $crate::logging::write_log_direct($category, "DEBUG", component, &message);
+        }
     }};
 }
 

--- a/core/continuum-core/src/modules/logger.rs
+++ b/core/continuum-core/src/modules/logger.rs
@@ -48,6 +48,17 @@ static GLOBAL_LOG_SENDER: OnceLock<mpsc::SyncSender<WriteLogPayload>> = OnceLock
 /// Channel capacity - if full, new messages dropped (NEVER blocks)
 const CLOG_CHANNEL_CAPACITY: usize = 4096;
 
+/// Is the in-process file-log sink up? The clog_*/log_* macros consult this
+/// BEFORE paying `format!` + category/component derivation — pre-gate, every
+/// call site built its whole payload only for `queue_log` to drop it when the
+/// LoggerModule wasn't initialized (and on the native server the fallback arm
+/// is the ONLY arm, so early-boot call sites paid full formatting for nothing).
+/// Same drop semantics, zero formatting cost.
+#[inline]
+pub fn log_sink_ready() -> bool {
+    GLOBAL_LOG_SENDER.get().is_some()
+}
+
 /// Queue a log entry for async writing (called by clog_* macros).
 /// GUARANTEED NON-BLOCKING: Uses try_send(), drops if channel full.
 /// If LoggerModule not yet initialized, message is dropped.


### PR DESCRIPTION
Second installment of the 8/23 serialization audit's fix ladder (follows #2407).

1. **`describe_tool_tokens` memo** — re-serialized every native tool schema per prompt assembly to count static tokens. Now counted once at `rebuild_tool_surface` (the only assignment site); the per-turn call is a field read.
2. **Log macros gate before formatting** — all twelve `clog_*`/`log_*` macro arms consult a new `log_sink_ready()` before paying `format!` + module-path derivation; `queue_log` previously dropped the fully-built payload silently when the sink wasn't up. Same drop semantics, zero cost on the dropped path.

Validation: `cargo check` clean; 80-test battery (deliberation, logging, logger, unwrap ratchet, test-mod singularity) green. Producer-side only — rides the next natural deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo