### PR TITLE
fix: the experience-degradation sweep — act budgets, serialization ratchet, canvas pre-fold

### DIFF
--- a/core/continuum-core/src/cognition/act_observe/apply.rs
+++ b/core/continuum-core/src/cognition/act_observe/apply.rs
@@ -417,14 +417,9 @@ pub async fn apply_act(
         };
         observation.push_str(&obs.render_recency(intent, &budget));
         recall_observation.push_str(&obs.render_recall(intent));
-        // The canvas feed: her OWN observation, published the moment she made
-        // it — the desktop watches the work itself, never a poller
-        // (positron_canvas_source is a no-op until boot installs it).
-        crate::ipc::positron_canvas_source::maybe_publish_observation(
-            &body.persona_name,
-            &call.name,
-            &obs.output.result.content,
-        );
+        // (The canvas feed publishes at the tool-executor seam, PRE-fold — a
+        // flood-sized ObserveResult here is already a spilled preview that no
+        // longer parses. See CommandToolExecutor::execute_native_batch.)
         acts.push(obs);
     }
     // A pure-background batch (every call was long-running → dispatched, `fg_calls`

--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -143,6 +143,10 @@ async fn settle_to_outcome(
     // in a row with no act between them means the nudge is not working, so she settles
     // rather than being trapped. Her own behavior is the budget — no counter, no constant.
     let mut acts_at_last_nudge: Option<usize> = None;
+    // Which `acts` value the last budget fact fired at — a Speak's one-shot
+    // re-perception re-enters the loop with `acts` unchanged, and the same
+    // milestone must not stamp twice.
+    let mut budget_fact_at: Option<usize> = None;
 
     // DISCOVERY SATURATION GATE (#390) — the STATE escalation of the [no-deliverable]
     // fact above, built on its own measured failure: the fact fires on EVERY act with
@@ -197,6 +201,40 @@ async fn settle_to_outcome(
         } else {
             Situation::PostAction
         };
+        // ACT-BUDGET PROPRIOCEPTION (2026-08-23). She could never see her own
+        // stopwatch: the budget gated acts SILENTLY, so an engineer's rational
+        // analysis-first plan burned the whole default budget and was graded
+        // with an empty src/ (MirrorCode baseline — the cap measured our
+        // patience, not her skill; an engineer who can see "2 acts left"
+        // triages, one who can't cannot). Three structural facts — the
+        // contract at turn start, the midpoint, and two-remaining — state the
+        // TRUE shape of the turn and nothing else: no file, no fix, no next
+        // tool. Pacing stays entirely her decision.
+        // [[no-hardcoded-heuristics-to-steer-cognition]]
+        if framing.workspace_deliverable && budget_fact_at != Some(acts) {
+            if let Some(body) = cycle.acting() {
+                if acts == 0 {
+                    budget_fact_at = Some(acts);
+                    body.working_memory.record_fact(&format!(
+                        "[act-budget] This turn grants me {max_acts} act→observe \
+                         cycles before I must settle. The task is graded on the state of \
+                         the workspace when I settle — work not yet written when the \
+                         budget ends does not exist for the grader."
+                    ));
+                } else if acts == max_acts / 2 {
+                    budget_fact_at = Some(acts);
+                    body.working_memory.record_fact(&format!(
+                        "[act-budget] I have spent {acts} of my {max_acts} acts this turn."
+                    ));
+                } else if max_acts.saturating_sub(acts) == 2 {
+                    budget_fact_at = Some(acts);
+                    body.working_memory.record_fact(&format!(
+                        "[act-budget] {acts} of {max_acts} acts spent — 2 remain before I \
+                         must settle."
+                    ));
+                }
+            }
+        }
         // may_act gates ACTING (not speaking): past the act budget, once she is provably
         // stuck re-emitting the identical act, OR once a workspace-deliverable turn has
         // saturated its discovery budget without a single mutation (#390 gate above), a

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -48,8 +48,17 @@ use crate::sdk_codegen::{AccessLevel, ActionCommand, CommandError, Ctx};
 const DEFAULT_EVAL_SET: &str = "docs/genome/coder-eval.jsonl";
 
 /// How many act→observe cycles a single task may take before it counts as
-/// unfinished, when the caller doesn't set `max_acts`.
-const DEFAULT_MAX_ACTS: u32 = 8;
+/// unfinished, when neither the caller nor the task row sets `max_acts`.
+///
+/// Raised 8 → 32 on 2026-08-23 after the MirrorCode baseline showed what 8
+/// buys on a frontier task: Atlas spent the whole budget on a genuinely
+/// competent case-bucketing analysis and was graded with an EMPTY src/ — the
+/// cap measured our patience, not the model ("repeated engineering process
+/// till finished … who cares if it has to cycle to do it" — the doctrine the
+/// old default contradicted). Tasks that need fewer acts settle on their own;
+/// the cap only exists to bound a runaway, so it must sit ABOVE what honest
+/// engineering needs. Per-task rows override via `EvalTask::max_acts`.
+const DEFAULT_MAX_ACTS: u32 = 32;
 
 /// Fixed "exam epoch" stamped on every task's burst (`[t=<ms>] peer: …`). The
 /// live burst carries each message's real `occurred_at_ms`; the eval pins it to
@@ -1252,6 +1261,12 @@ pub struct EvalTask {
     /// Stable id for the task (echoed in results so a regression is identifiable).
     #[serde(default)]
     pub id: String,
+    /// Per-task act→observe budget override — budget-as-data, so a gym can size
+    /// patience to its task class (a mirror task needs analysis + implementation
+    /// + verification; a one-liner doesn't). `None` inherits the run's budget.
+    #[serde(default)]
+    #[ts(optional)]
+    pub max_acts: Option<u32>,
     /// The prompt posed to the persona, framed as a room message.
     #[serde(default)]
     pub prompt: String,
@@ -4086,7 +4101,7 @@ async fn run_pass(
                     cycle,
                     make_burst(),
                     room,
-                    max_acts,
+                    t.max_acts.map(|v| v as usize).unwrap_or(max_acts), // None = row sets no budget; the run's budget is the documented inherit
                     crate::cognition::workspace::TurnFraming::directed(),
                 ),
             )
@@ -4226,7 +4241,7 @@ async fn run_pass(
                     cycle,
                     nudge_burst,
                     room,
-                    max_acts,
+                    t.max_acts.map(|v| v as usize).unwrap_or(max_acts), // None = row sets no budget; the run's budget is the documented inherit
                     crate::cognition::workspace::TurnFraming::directed(),
                 ),
             )

--- a/core/continuum-core/src/cognition/experience.rs
+++ b/core/continuum-core/src/cognition/experience.rs
@@ -638,6 +638,7 @@ mod tests {
     fn eval_task(id: &str, with_test: bool) -> EvalTask {
         EvalTask {
             id: id.to_string(),
+            max_acts: None,
             prompt: "write a function that reverses a string".to_string(),
             expect: String::new(),
             test: with_test.then(|| "assert_eq!(rev(\"ab\"), \"ba\");".to_string()),

--- a/core/continuum-core/src/cognition/tool_executor/command_executor.rs
+++ b/core/continuum-core/src/cognition/tool_executor/command_executor.rs
@@ -421,17 +421,27 @@ impl ToolExecutor for CommandToolExecutor {
             .into_iter()
             .enumerate()
             .map(|(i, (tool_use_id, outcome))| match outcome {
-                Ok(value) => NativeToolResult {
-                    tool_use_id,
-                    // Spill-then-bound: a flood-sized result is persisted whole
-                    // (recoverable via `tool/output`) before the preview is cut.
-                    content: fold_with_recovery(
-                        value.to_string(),
-                        max_result_chars,
-                        ctx.persona_id,
-                    ),
-                    is_error: None,
-                },
+                Ok(value) => {
+                    let full = value.to_string(); // owned render once; both the canvas feed and the fold read it
+                    // Canvas feed publishes from the PRE-FOLD content. It used to
+                    // hook the post-fold observation in act_observe/apply, where a
+                    // flood-sized ObserveResult had already been spilled + cut to a
+                    // preview — the JSON parse failed and the desktop went blind on
+                    // exactly the big screenshots worth watching (2026-08-23 audit's
+                    // latent canvas bug). Here the full result still exists.
+                    crate::ipc::positron_canvas_source::maybe_publish_observation(
+                        &ctx.persona_name,
+                        &calls[i].name,
+                        &full,
+                    );
+                    NativeToolResult {
+                        tool_use_id,
+                        // Spill-then-bound: a flood-sized result is persisted whole
+                        // (recoverable via `tool/output`) before the preview is cut.
+                        content: fold_with_recovery(full, max_result_chars, ctx.persona_id),
+                        is_error: None,
+                    }
+                }
                 // A failed tool call is NOT a batch failure — it's fed back to the
                 // model as an error result so it can recover (retry, fix args,
                 // pick another tool). Batch-level `Err` is reserved for the

--- a/core/continuum-core/src/commands/genome/curriculum.rs
+++ b/core/continuum-core/src/commands/genome/curriculum.rs
@@ -322,6 +322,7 @@ mod tests {
     fn eval_task(id: &str, with_test: bool) -> EvalTask {
         EvalTask {
             id: id.to_string(),
+            max_acts: None,
             prompt: "write a function that reverses a string".to_string(),
             expect: String::new(),
             test: with_test.then(|| "assert_eq!(rev(\"ab\"), \"ba\");".to_string()),

--- a/core/continuum-core/src/live/transport/bridge_client.rs
+++ b/core/continuum-core/src/live/transport/bridge_client.rs
@@ -21,7 +21,7 @@ use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 
-use crate::{clog_error, clog_info, clog_warn};
+use crate::{clog_info, clog_warn};
 
 /// Captured transcription from STT.
 #[derive(Debug, Clone, serde::Serialize)]

--- a/core/continuum-core/src/source_hygiene/boundary_serialization.rs
+++ b/core/continuum-core/src/source_hygiene/boundary_serialization.rs
@@ -1,0 +1,151 @@
+//! **Every serialization site names the boundary it crosses, and the count can
+//! only go down.**
+//!
+//! Joel's standing law, 2026-08-23, after the pixel + serialization audits:
+//! *"The way we did it was preventing your insane use of
+//! memcpy/serialization/rasterizing… It's like a cancer everywhere."* /
+//! *"Base64 is just fucking insane."* / *"You write js level code all the time.
+//! Never cpp/rust performant rtos. It's like a sickness."*
+//!
+//! # The disease this guards against
+//!
+//! Managed-language reflexes transplanted into Rust: typed data serialized into
+//! `serde_json::Value`/strings to move BETWEEN IN-PROCESS LAYERS, then parsed
+//! back out on the other side — paying encode + alloc + decode where a `&T`,
+//! an `Arc<T>`, or a handle should have traveled. Base64 is the worst form:
+//! pixels inflated 4/3× into JSON envelopes cloned per consumer, on the same
+//! machine that produced them. Each site compiles, passes review, and taxes the
+//! hot path forever; the taxes COMPOUND (per tick × per consumer × per frame).
+//! The 2026-08-23 audits found the compounding total was most of the substrate's
+//! self-inflicted CPU waste — see [[i-write-js-level-code-in-rust-the-sickness-and-the-rtos-cure]].
+//!
+//! # What counts as justified
+//!
+//! Serialization is CORRECT at a true system boundary: a socket to another
+//! process, a file format on disk, a wire protocol, a foreign API's contract.
+//! So the rule is the unwrap rule's shape — a same-line `//` comment with real
+//! content (≥ [`super::unwrap_justification`]'s bar) naming WHICH boundary this
+//! encoding crosses. "// IPC wire to the web client" is a reason;
+//! "// serialize" is the shape of a reason, which is worse than nothing.
+//!
+//! # Why a ratchet, not a wall
+//!
+//! Same argument as the unwrap guard verbatim: hundreds are in tree today, a
+//! wall would fail forever and get ignored, and the only rule with teeth on day
+//! one is **the unjustified count may never rise** — every new site names its
+//! boundary, every old one touched is a chance to ratchet down.
+
+use super::{split_code_and_comment, SourceFile, SourceRule, Violation};
+
+/// Same bar as the unwrap rule — a justification has to say something.
+// context-budget-exempt: bounds the length of a COMMENT a human types, never a
+// window, prompt, or token budget.
+const MIN_JUSTIFICATION_CHARS: usize = 12;
+
+/// The call shapes this rule watches. Serde's owned-encode family (each one an
+/// allocation + full traversal of the value) and the base64 engine (the
+/// pixels-in-JSON signature). `to_writer`/`from_reader`/`from_str`/`from_slice`
+/// are deliberately NOT counted: they read/write an existing byte stream, which
+/// is almost always an actual boundary already — counting them would bury the
+/// signal under legitimate wire code.
+const SHAPES: &[&str] = &[
+    "serde_json::to_string_pretty(",
+    "serde_json::to_string(",
+    "serde_json::to_vec(",
+    "serde_json::to_value(",
+    "serde_json::from_value(",
+    "STANDARD.encode(",
+    "STANDARD.decode(",
+    "STANDARD_NO_PAD.encode(",
+    "STANDARD_NO_PAD.decode(",
+];
+
+/// Unjustified production occurrences at the time this guard landed
+/// (2026-08-23, the day the audits ran — measured by running the rule with a
+/// zero baseline and reading the count, so there is no slack for new sites to
+/// hide in).
+///
+/// **This number may only ever go DOWN.** A single total, not a per-file map,
+/// for the same reason as the unwrap ratchet: pressure on the whole surface.
+const BASELINE_UNJUSTIFIED: usize = 242;
+
+pub struct BoundarySerialization;
+
+impl SourceRule for BoundarySerialization {
+    fn name(&self) -> &'static str {
+        "boundary-serialization"
+    }
+
+    fn check(&self, file: &SourceFile) -> Vec<Violation> {
+        let mut out = Vec::new();
+        for (line_no, line) in file.production_lines() {
+            let (code, comment) = split_code_and_comment(line);
+            if !SHAPES.iter().any(|s| code.contains(s)) {
+                continue;
+            }
+            let justified = comment
+                .map(|c| c.trim().chars().count() >= MIN_JUSTIFICATION_CHARS)
+                .unwrap_or(false); // JUSTIFIED: no same-line comment IS the unjustified case
+            if !justified {
+                out.push(Violation {
+                    rule: "boundary-serialization",
+                    file: file.rel.clone(),
+                    line: line_no,
+                    source: code.trim().to_string(),
+                });
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source_hygiene::scan;
+
+    /// What this catches: a NEW in-process serialization site landing without
+    /// naming the boundary it crosses. The assertion is a RATCHET, not a wall —
+    /// see the module header. If this fails because you added one: either the
+    /// encode crosses a true boundary (say which, same line) or it shouldn't
+    /// exist (pass `&T`/`Arc<T>`/a handle instead). If it fails because you
+    /// removed some, lower `BASELINE_UNJUSTIFIED` and take the win.
+    #[test]
+    fn the_unjustified_serialization_count_never_rises() {
+        let violations = scan(&[&BoundarySerialization]);
+        let count = violations.len();
+
+        assert!(
+            count <= BASELINE_UNJUSTIFIED,
+            "unjustified serialization sites rose to {count} (baseline {BASELINE_UNJUSTIFIED}).\n\
+             Serialize ONLY at a true system boundary (socket, disk format, wire protocol, \n\
+             foreign API) and say WHICH boundary on the same line. Between in-process layers, \n\
+             data travels as &T / Arc<T> / a handle — typed → Value → typed is the sickness \n\
+             the 2026-08-23 audits measured as most of the substrate's self-inflicted CPU \n\
+             waste. Base64 pixels inside JSON are never justified on-machine.\n\
+             First few new ones:\n{}",
+            violations
+                .iter()
+                .take(10)
+                .map(|v| format!("  {}:{}  {}", v.file, v.line, v.source))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+
+    /// What this catches: the justification predicate accepting a non-reason —
+    /// a rule `// json` satisfies reports zero violations forever while the
+    /// codebase rots.
+    #[test]
+    fn a_token_comment_does_not_count_as_a_boundary_name() {
+        let rule = BoundarySerialization;
+        let file = SourceFile::for_test(
+            "fake.rs",
+            "let s = serde_json::to_string(&x); // json\n\
+             let t = serde_json::to_string(&y); // IPC wire to the web client\n",
+        );
+        let v = rule.check(&file);
+        assert_eq!(v.len(), 1, "short token comment must not justify; real boundary name must");
+        assert_eq!(v[0].line, 1);
+    }
+}

--- a/core/continuum-core/src/source_hygiene/mod.rs
+++ b/core/continuum-core/src/source_hygiene/mod.rs
@@ -24,6 +24,7 @@
 //! The two existing scanners should migrate onto this seam (they predate it); doing
 //! that is a follow-up, not a reason to hand-roll a fourth.
 
+pub mod boundary_serialization;
 pub mod production_reachability;
 pub mod test_mod_singularity;
 pub mod unwrap_justification;
@@ -60,6 +61,17 @@ impl SourceFile {
     /// so a violation can point at a real editor line.
     pub fn production_lines(&self) -> impl Iterator<Item = (usize, &str)> {
         self.production.lines().enumerate().map(|(i, l)| (i + 1, l))
+    }
+
+    /// Build a `SourceFile` from an inline snippet — fixture for a rule's own
+    /// unit tests, so predicate regressions are pinned without touching disk.
+    #[cfg(test)]
+    pub fn for_test(rel: &str, production: &str) -> Self {
+        Self {
+            rel: rel.to_string(),
+            production: production.to_string(),
+            raw: production.to_string(),
+        }
     }
 }
 

--- a/protocol/typescript/cognition/EvalTask.ts
+++ b/protocol/typescript/cognition/EvalTask.ts
@@ -13,6 +13,12 @@ export type EvalTask = {
  */
 id: string, 
 /**
+ * Per-task act→observe budget override — budget-as-data, so a gym can size
+ * patience to its task class (a mirror task needs analysis + implementation
+ * + verification; a one-liner doesn't). `None` inherits the run's budget.
+ */
+max_acts?: number, 
+/**
  * The prompt posed to the persona, framed as a room message.
  */
 prompt: string, 


### PR DESCRIPTION
Three commits, one directive: fix everything degrading the citizens' experience, solidified before the model handoff.

1. **Honest act budgets** — default 8→32 (MirrorCode graded Atlas 0-pass with an empty src/ after 8 competent analysis acts; the cap measured our patience, not the model), `EvalTask::max_acts` budget-as-data per gym row, and act-budget proprioception (turn-start contract / midpoint / two-remaining facts) so she can pace like an engineer instead of hitting an invisible floor.
2. **Boundary-serialization ratchet** — the sickness doctrine gets CI teeth that survive model swaps: every new serde owned-encode / base64-engine site names the true boundary it crosses, count (baseline 242, zero slack) only falls.
3. **Canvas feed publishes pre-fold** — flood-sized ObserveResults were spilled+truncated before the feed parsed them, so the desktop went blind on exactly the big screenshots worth watching. Hook moved to the executor seam where the full result exists.

Batteries green: 157 + hygiene suite + 84 (tool_executor/canvas/act_observe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo