### PR TITLE
fix: probe storm, pre-derivation hold gate, reboot sees eval runs, eval turns framed on_workspace

### DIFF
--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -648,6 +648,30 @@ async fn reboot(force: bool) -> Result<(), String> {
                 .join(", ")
         ));
     }
+    // Eval-run guard — the third lease, same shape. cognition/eval runs had NO
+    // on-disk in-flight signal until 2026-08-23 (the marker in each eval world),
+    // so this guard named zero runs while a MirrorCode battery was mid-task and
+    // a reboot killed it unasked. pid-checked here: a marker whose core died is
+    // debris for the next provision's sweep, not an in-flight run.
+    let evals: Vec<String> = continuum_core::cognition::eval::in_flight_eval_runs()
+        .into_iter()
+        .filter(|(_, pid)| pid_alive(*pid as i32))
+        .map(|(run, _)| run)
+        .collect();
+    if !evals.is_empty() && !force {
+        return Err(format!(
+            "eval run(s) in flight ({}) — a reboot would kill them mid-exam. Wait for them, \
+             or rerun with `continuum reboot --force` if losing the runs is acceptable.",
+            evals.join(", ")
+        ));
+    }
+    if !evals.is_empty() {
+        println!(
+            "⚠ --force: rebooting over {} live eval run(s) — they die here; their worlds are \
+             swept at the next provision",
+            evals.len()
+        );
+    }
     if !benches.is_empty() {
         println!(
             "⚠ --force: rebooting over {} live benchmark run(s) — they die here and the \

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1438,6 +1438,21 @@ pub struct EvalTask {
 }
 
 impl EvalTask {
+    /// Is this task GRADED ON THE WORKSPACE (a DoD shell reads files, a
+    /// solution file is collected, UI checks screenshot artifacts) rather than
+    /// on her spoken answer? Decides the turn's [`TurnFraming::on_workspace`]
+    /// contract — which in turn arms the discovery-saturation gate, the
+    /// no-deliverable nudge, and the act-budget proprioception. Before this
+    /// predicate the eval framed EVERY task as directed-speech, so none of
+    /// those protections ever applied to the tasks they were built for
+    /// (glass-boxed 2026-08-23: MirrorCode graded an empty src/ after a
+    /// discovery-only turn the saturation gate should have interrupted).
+    pub fn workspace_deliverable(&self) -> bool {
+        self.dod_shell.is_some() || self.solution_file.is_some() || !self.ui_checks.is_empty()
+    }
+}
+
+impl EvalTask {
     /// Whether answering THIS task requires the persona's hands. An explicit
     /// [`needs_tools`](Self::needs_tools) declaration wins; otherwise it's derived from the
     /// GRADING modality — a grade that reads a written file / DoD / rendered UI needs hands.
@@ -4161,7 +4176,11 @@ async fn run_pass(
                     make_burst(),
                     room,
                     t.max_acts.map(|v| v as usize).unwrap_or(max_acts), // None = row sets no budget; the run's budget is the documented inherit
-                    crate::cognition::workspace::TurnFraming::directed(),
+                    if t.workspace_deliverable() {
+                        crate::cognition::workspace::TurnFraming::directed().on_workspace()
+                    } else {
+                        crate::cognition::workspace::TurnFraming::directed()
+                    },
                 ),
             )
             .await
@@ -4301,7 +4320,11 @@ async fn run_pass(
                     nudge_burst,
                     room,
                     t.max_acts.map(|v| v as usize).unwrap_or(max_acts), // None = row sets no budget; the run's budget is the documented inherit
-                    crate::cognition::workspace::TurnFraming::directed(),
+                    if t.workspace_deliverable() {
+                        crate::cognition::workspace::TurnFraming::directed().on_workspace()
+                    } else {
+                        crate::cognition::workspace::TurnFraming::directed()
+                    },
                 ),
             )
             .await

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1104,6 +1104,7 @@ fn provision_ephemeral_eval_root(tag: &str) -> Result<std::path::PathBuf, String
         .to_path_buf();
     sweep_orphan_eval_roots(&parent, &root);
     if root.is_dir() {
+        write_eval_run_marker(&root, tag); // resume re-stamps the owner pid (a new core owns it now)
         return Ok(root); // resume of the same run reuses its world
     }
     std::fs::create_dir_all(&parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
@@ -1132,7 +1133,64 @@ fn provision_ephemeral_eval_root(tag: &str) -> Result<std::path::PathBuf, String
         root = root.display().to_string().as_str(),
         "exam world provisioned — CoW clone of the shared checkout, removed when the run ends"
     );
+    write_eval_run_marker(&root, tag);
     Ok(root)
+}
+
+/// Marker filename inside each eval world naming the run and its owning core
+/// pid — the cross-process evidence `continuum reboot`'s guard reads. Solve
+/// runs got this day one (the grade-ledger `state: running` rows); eval runs
+/// had NO on-disk in-flight signal, so a reboot killed them without ever being
+/// asked (measured 2026-08-23: the guard named zero runs while a MirrorCode
+/// battery was mid-task). The world dir dies with the run (Drop) and orphans
+/// are swept at next provision, so marker lifetime is exactly run lifetime;
+/// the guard pid-checks to ignore debris from a killed core.
+pub const EVAL_RUN_MARKER: &str = "eval-run.json";
+
+fn write_eval_run_marker(root: &std::path::Path, run_id: &str) {
+    let marker = serde_json::json!({
+        "runId": run_id,
+        "corePid": std::process::id(),
+        "startedAtMs": crate::persona::trace::now_ms(),
+    });
+    // Marker write is best-effort: the run must not die because its guard
+    // breadcrumb could not be written; the reboot guard just loses this run.
+    if let Err(e) = std::fs::write(
+        root.join(EVAL_RUN_MARKER),
+        marker.to_string(), // disk marker read by the CLI process — a true process boundary
+    ) {
+        tracing::warn!(error = %e, "eval run marker not written — reboot guard cannot see this run");
+    }
+}
+
+/// Every eval run some world dir claims is IN FLIGHT: `(run_id, core_pid)`.
+/// The CALLER owns pid-liveness (the CLI has its own pid_alive; this crate-side
+/// scan stays pure file reading) — a marker whose core died is debris the next
+/// provision sweeps, not an in-flight run.
+pub fn in_flight_eval_runs() -> Vec<(String, u32)> {
+    let base = std::env::temp_dir().join("continuum-eval");
+    let Ok(entries) = std::fs::read_dir(&base) else {
+        return Vec::new();
+    };
+    let mut live = Vec::new();
+    for entry in entries.flatten() {
+        let marker = entry.path().join(EVAL_RUN_MARKER);
+        let Ok(text) = std::fs::read_to_string(&marker) else {
+            continue;
+        };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) else {
+            continue;
+        };
+        let (Some(run), Some(pid)) = (
+            v.get("runId").and_then(|r| r.as_str()),
+            v.get("corePid").and_then(|p| p.as_u64()),
+        ) else {
+            continue;
+        };
+        live.push((run.to_string(), pid as u32));
+    }
+    live.sort();
+    live
 }
 
 /// Eval worlds LIVE in this process. `Drop` covers every in-process return path,
@@ -1530,7 +1588,8 @@ pub struct CognitionEvalParams {
     #[ts(optional)]
     #[ts(optional, type = "number")]
     pub reviewers: Option<u32>,
-    /// Max act→observe cycles per task before it counts as unfinished. Default 8.
+    /// Max act→observe cycles per task before it counts as unfinished. Default 32
+    /// (see DEFAULT_MAX_ACTS); a task row's own max_acts overrides per task.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     #[ts(optional, type = "number")]

--- a/core/continuum-core/src/persona/host.rs
+++ b/core/continuum-core/src/persona/host.rs
@@ -368,19 +368,38 @@ impl PersonaSpawnSupervisor {
                     let name = p.instance.agent_name.as_str();
                     let allowed = hold.allows(name);
                     if !allowed {
-                        crate::probe!(
-                            class = "persona.host.held_out",
-                            agent = name,
-                            reason = hold.reason.as_str(),
-                            until_ms = hold.until_ms,
-                            "roster hold active — reconciler skipping this citizen \
-                             until the hold lapses or is cleared",
-                        );
+                        Self::probe_held_out_once(name, &hold);
                     }
                     allowed
                 })
                 .collect(),
             None => plans,
+        }
+    }
+
+    /// Emit the `persona.host.held_out` probe ONCE per (agent, hold window).
+    /// The reconciler re-fires on every serving-plan republish (~1/s), and an
+    /// un-deduped probe here wrote a pair of identical rows per second for the
+    /// entire life of a hold (measured 2026-08-23, minutes of pure probe spam
+    /// within the first hour). The skip itself stays per-pass — only the PROBE
+    /// is edge-triggered, keyed by `until_ms` so a renewed hold announces
+    /// itself afresh.
+    fn probe_held_out_once(agent: &str, hold: &crate::persona::roster_hold::RosterHold) {
+        static PROBED: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<(String, u64)>>> =
+            std::sync::OnceLock::new();
+        let set = PROBED.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+        let Ok(mut guard) = set.lock() else {
+            return; // poisoned = a prior panic mid-insert; skip the probe, never the filter
+        };
+        if guard.insert((agent.to_string(), hold.until_ms)) {
+            crate::probe!(
+                class = "persona.host.held_out",
+                agent = agent,
+                reason = hold.reason.as_str(),
+                until_ms = hold.until_ms,
+                "roster hold active — reconciler skipping this citizen \
+                 until the hold lapses or is cleared",
+            );
         }
     }
 
@@ -423,6 +442,24 @@ impl PersonaSpawnSupervisor {
         }
         if unattended.is_empty() {
             return summary;
+        }
+
+        // Hold gate BEFORE plan derivation (not only on the materialized plans):
+        // during a hold, held-out citizens are unattended on EVERY serving-plan
+        // republish (~1/s), and deriving a full spawn plan each pass just to
+        // throw it away was a per-second churn loop for the life of the hold.
+        // Same gate, earlier — the probe inside is deduped per hold window.
+        if let Some(hold) = crate::persona::roster_hold::active() {
+            unattended.retain(|rt| {
+                let allowed = hold.allows(rt.agent_name());
+                if !allowed {
+                    Self::probe_held_out_once(rt.agent_name(), &hold);
+                }
+                allowed
+            });
+            if unattended.is_empty() {
+                return summary;
+            }
         }
 
         let plan_rows = self.spawner.plan();


### PR DESCRIPTION
Live-fire fixes from the restage attempt, one deploy:

1. **Probe storm** — reconciler treated every serving-plan *republish* (1/s) as an edge; `held_out` wrote ~2 identical rows/second for the life of a hold (1,278 rows before the fix). Probe dedups per (agent, hold-window); the skip stays per-pass.
2. **Churn** — `host_unattended` derived full spawn plans for held-out citizens every second just to discard them. Hold now gates by name before derivation. (A reconciler-loop plan-change gate was written and deliberately reverted — it would break #429 newborn hosting.)
3. **Reboot blind spot** — eval runs had no on-disk in-flight marker; `reboot` killed a mid-task battery unasked. Each eval world now carries `eval-run.json` (runId + core pid); the guard pid-checks and refuses without `--force`.
4. **Eval turns framed `on_workspace()`** — the eval framed every task as directed-speech, so the discovery-saturation gate, the no-deliverable nudge, AND #2411's act-budget stopwatch never applied to DoD-graded tasks — the exact tasks they were built for. `EvalTask::workspace_deliverable()` is the one predicate. This is the fix that generalizes: same contract any activity project rides.

Named follow-up: the live room path frames held kanban work without claim-state — needs the claim plumbed to framing.

Batteries green (34 + 69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo