### PR TITLE
feat(cognition): act-budget receipts — probes + a test pin the stopwatch reaching her mind

### DIFF
--- a/core/continuum-core/src/cognition/act_observe/mod.rs
+++ b/core/continuum-core/src/cognition/act_observe/mod.rs
@@ -797,6 +797,79 @@ mod tests {
         );
     }
 
+    // what this catches: the act-budget stopwatch actually reaching her MIND —
+    // regression for the 2026-08-23 framing gap where the facts were written
+    // (#2411) but eval framed every task as directed-speech, so they never
+    // fired for the DoD tasks they were built for. Pins: on a workspace-
+    // deliverable turn the [act-budget] contract fact lands in working memory;
+    // on an ordinary turn it does not (speech turns owe no stopwatch).
+    #[tokio::test]
+    async fn act_budget_facts_reach_working_memory_on_workspace_turns_only() {
+        let exec = Arc::new(RecordingExecutor {
+            seen_context: Mutex::new(None),
+            result_content: "file contents...".into(),
+        });
+        let adm = admission();
+        let the_body = body(exec.clone(), adm.clone());
+        let wm = the_body.working_memory.clone();
+        let cycle = WorkspaceCycle::new(
+            vec![Arc::new(VaryingAct {
+                ticks: Mutex::new(0),
+            })],
+            Arc::new(SalienceArbiter),
+            8,
+        )
+        .with_acting(the_body);
+        drive_to_settle(
+            &cycle,
+            "fix the bug",
+            Uuid::new_v4(),
+            6,
+            TurnFraming::ambient().on_workspace(),
+        )
+        .await;
+        let entries = wm.recent_entries();
+        let budget_facts: Vec<_> = entries
+            .iter()
+            .filter(|e| e.text.contains("[act-budget]"))
+            .collect();
+        // The turn-start contract fact fires at act 0 and is legitimately
+        // EVICTED by the WM ring as acts accumulate (observed in this very
+        // test: 6 acts on a capacity-8 ring pushed it out) — which is exactly
+        // why the midpoint/two-remaining milestones RE-STATE the budget. The
+        // guarantee worth pinning is therefore: at settle, working memory
+        // holds at least one [act-budget] fact naming the REAL budget number.
+        assert!(
+            budget_facts.iter().any(|e| e.text.contains("my 6 acts")),
+            "a budget fact naming the real budget must survive to settle; got: {:?}",
+            budget_facts.iter().map(|e| &e.text).collect::<Vec<_>>()
+        );
+
+        // Control: an ordinary (speech-deliverable) turn records no stopwatch.
+        let exec2 = Arc::new(RecordingExecutor {
+            seen_context: Mutex::new(None),
+            result_content: "file contents...".into(),
+        });
+        let body2 = body(exec2, admission());
+        let wm2 = body2.working_memory.clone();
+        let cycle2 = WorkspaceCycle::new(
+            vec![Arc::new(VaryingAct {
+                ticks: Mutex::new(0),
+            })],
+            Arc::new(SalienceArbiter),
+            8,
+        )
+        .with_acting(body2);
+        drive_to_settle(&cycle2, "look around", Uuid::new_v4(), 6, TurnFraming::ambient()).await;
+        assert!(
+            !wm2
+                .recent_entries()
+                .iter()
+                .any(|e| e.text.contains("[act-budget]")),
+            "speech turns owe no stopwatch — the fact is scoped to workspace-deliverable turns"
+        );
+    }
+
     // what this catches: the grader's stopwatch. A mind that never settles is
     // bounded by the EXTERNAL `max_acts` budget and the final un-driven Act is
     // returned as unfinished — never a fabricated answer, and the budget is the

--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -213,8 +213,23 @@ async fn settle_to_outcome(
         // [[no-hardcoded-heuristics-to-steer-cognition]]
         if framing.workspace_deliverable && budget_fact_at != Some(acts) {
             if let Some(body) = cycle.acting() {
+                // The probe is the RECEIPT that the fact reached her working
+                // memory — record_fact leaves no structured trace, and "the
+                // stopwatch is visible to her" was unprovable from the live
+                // stream the day it shipped ([[observability-as-substrate]]).
+                let probe_budget_fact = |milestone: &str| {
+                    crate::probe!(
+                        class = "persona.act_budget.fact",
+                        persona = body.persona_name.as_str(),
+                        milestone = milestone,
+                        acts = acts,
+                        max_acts = max_acts,
+                        "act-budget proprioception fact recorded in working memory"
+                    );
+                };
                 if acts == 0 {
                     budget_fact_at = Some(acts);
+                    probe_budget_fact("turn_start");
                     body.working_memory.record_fact(&format!(
                         "[act-budget] This turn grants me {max_acts} act→observe \
                          cycles before I must settle. The task is graded on the state of \
@@ -223,11 +238,13 @@ async fn settle_to_outcome(
                     ));
                 } else if acts == max_acts / 2 {
                     budget_fact_at = Some(acts);
+                    probe_budget_fact("midpoint");
                     body.working_memory.record_fact(&format!(
                         "[act-budget] I have spent {acts} of my {max_acts} acts this turn."
                     ));
                 } else if max_acts.saturating_sub(acts) == 2 {
                     budget_fact_at = Some(acts);
+                    probe_budget_fact("two_remaining");
                     body.working_memory.record_fact(&format!(
                         "[act-budget] {acts} of {max_acts} acts spent — 2 remain before I \
                          must settle."

--- a/docs/architecture/HIDDEN-CONSTANTS-LEDGER.md
+++ b/docs/architecture/HIDDEN-CONSTANTS-LEDGER.md
@@ -1,0 +1,73 @@
+# Hidden Constants Ledger — every number that silently shapes cognition
+
+**Born 2026-08-23.** `DEFAULT_MAX_ACTS = 8` sat unnamed in eval.rs and graded a
+citizen 0-pass with an empty `src/` after 8 competent analysis acts — the cap
+measured our patience, not the model, and nothing in her perception ever said
+the floor existed. Joel: *"more of your damn hidden constants."* This ledger is
+the standing sweep of that class.
+
+## The law
+
+A numeric constant that shapes what a citizen can perceive, recall, hold, or do
+must be ONE of:
+
+1. **Window-derived** — expressed as a fraction of the served context
+   (`ContextBudget` denominators). Scales with the hardware; no LCD clamp.
+2. **Recipe/data-owned** — carried by the task row, activity recipe, or persona
+   config (`EvalTask::max_acts` is the model). The gym sizes patience to the
+   task class; the code carries only the inherit default.
+3. **A justified bound** — a backstop against runaways (never the working
+   ceiling), documented at the site with the incident or invariant it guards.
+   The test: honest work must never hit it.
+
+A bare capability cap — a number that decides how much mind a citizen gets,
+living in code, invisible to her, unscaled by hardware — is the forbidden
+shape. It is exactly how 8 acts, a 2,816-token window, and the two-tool
+discovery pair each muted capable models.
+
+## Classification (swept 2026-08-23, cognition/ + persona/)
+
+### Fixed this sweep
+
+| Constant | Was | Now |
+|---|---|---|
+| `eval::DEFAULT_MAX_ACTS` | 8, silent | 32, per-task `max_acts` override, and the act-budget proprioception facts make the stopwatch VISIBLE to her |
+
+### Capability caps needing principled fixes (worst first)
+
+| Constant | Value | Why it's suspect |
+|---|---|---|
+| `persona_workspace::DEFAULT_WORKSPACE_CAPACITY` | 6 | SIX global-workspace slots for every citizen on every hardware tier. Should scale with window (a 160k lane can hold more mind than a 4k lane) or be persona-config. |
+| `recall_faculty::DEFAULT_RECALL_LIMIT` | 16 | Recall breadth capped identically for a 3B and a 35B. Window-derived candidate (`RECALL_DENOM` exists in context_budget — route through it). |
+| `channel_digest::DEFAULT_GROUNDING` / `FIRST_READ_PAGE` | 5 / 20 | How much of a room she perceives on entry. Data-owned candidate (room recipe). |
+| `response_orchestrator::DEFAULT_RELEVANCE_THRESHOLD` | 0.30 | Speaks/silence gate. Should be persona-learned or config, not universal. |
+| `check_redundancy::REDUNDANCY_CONVERSATION_WINDOW` | 10 | Redundancy horizon fixed at 10 turns regardless of window. |
+| `recall_faculty::RECALL_RELEVANCE_FLOOR` | 0.15 | Universal relevance floor; interacts with embedding model choice. |
+
+### Justified bounds (audited, keep — each documents its incident)
+
+- `settle::STUCK_LIMIT = 3` — byte-identical act loop breaker (#206); genuine
+  iteration has a different signature and never trips it.
+- `eval::PER_TASK_HANG_BACKSTOP = 2h` — firing is a bug report, not a policy.
+- `service_loop::LIVE_MAX_ACTS = usize::MAX` — the CORRECT shape: no cap, she
+  settles when done.
+- `discovery_budget = max_acts / 2` (#390) — derived from the act budget, lifts
+  on first mutation, only bounds pre-write wandering.
+- Spill/truncation caps (`tool_executor`) — context safety with full recovery
+  on disk (`tool/output`); nothing is lost.
+- `context_budget` denominators — the sanctioned window-derived shape itself.
+
+### Infrastructure tuning (not cognition-shaping; ordinary review)
+
+Cache sizes (`EMBEDDING_CACHE_MAX`, `CHANNEL_ELEMENT_CACHE_MAX`), schema
+versions, fetch paging (`MAX_ROWS`), display truncation for ledgers.
+
+## Enforcement
+
+The de-hardcode guard (`no_new_hardcoded_context_or_prompt_size_constant…`)
+already refuses new `WINDOW|CTX|TOKEN|PROMPT|CHARS`-named literals. This ledger
+is the review-time companion for the names that guard cannot match: when a PR
+adds a `const` that decides how much a citizen perceives, recalls, holds, or
+acts — demand shape 1, 2, or 3, in that order of preference. When one of the
+"needing principled fixes" rows lands its fix, move it to the fixed table with
+the PR number.


### PR DESCRIPTION
Joel: 'prove it.' Two receipts for #2411's stopwatch:

1. **`persona.act_budget.fact` probe** at all three emission sites — the live stream now proves the fact reached working memory.
2. **Regression test** pinning that a budget fact naming the real number survives to settle on workspace turns (and that speech turns owe no stopwatch). Writing it surfaced a real behavior: the turn-start fact is legitimately evicted by the WM ring as acts accumulate — exactly why the milestone re-statements exist; the test pins the honest guarantee.

Plus **HIDDEN-CONSTANTS-LEDGER.md** — the standing sweep of every number that silently shapes cognition, with the law (window-derived / recipe-owned / justified-bound) and the capability-cap fix queue (WORKSPACE_CAPACITY=6, RECALL_LIMIT=16, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo