### PR TITLE
perf(cognition): volatile grounding rides trailing turns — the KV run-rate fix

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -1710,7 +1710,17 @@ impl LlmDeliberationFaculty {
             .filter(|c| c.decision.is_none() && c.trailing)
         {
             if !c.content.trim().is_empty() {
-                messages.push(ChatMessage::text("user", c.content.clone()));
+                // Same `[faculty]` banner the system block gives its sections —
+                // grounding that moved here for KV reuse (volatile-content
+                // sources, 2026-08-23) must stay as legible as it was in the
+                // system prefix. One sized allocation, no intermediate format!.
+                let mut body =
+                    String::with_capacity(c.faculty.as_str().len() + c.content.len() + 4);
+                body.push('[');
+                body.push_str(c.faculty.as_str());
+                body.push_str("]\n");
+                body.push_str(&c.content);
+                messages.push(ChatMessage::text("user", body));
             }
         }
 

--- a/core/continuum-core/src/cognition/rag_source_faculty.rs
+++ b/core/continuum-core/src/cognition/rag_source_faculty.rs
@@ -276,7 +276,21 @@ impl Faculty for RagSourceFaculty {
         let c = Contribution::context(self.faculty_id.clone(), content, self.salience, reasoning)
             .with_parts(units)
             .with_expand_command(self.source.expand_command());
-        Some(if self.stable { c.session_stable() } else { c })
+        // Volatile-content grounding rides the TRAILING-turn mechanism (#205),
+        // never the system message. The volatile tier of the system context
+        // block was a half-measure: demoted out of the cacheable stable head,
+        // but still rendered BEFORE the entire conversation — so a kanban
+        // claim-flap or a workspace-map change (her own write!) re-prefilled
+        // every conversation token after it. Measured 2026-08-23 from her own
+        // captures on the MirrorCode round: workspace-map content changed
+        // act-over-act and live KV reuse pinned at 18-33% while acts paid
+        // ~35-45k re-prefill (~2 min) each. As a trailing turn the same churn
+        // costs exactly its own tokens.
+        Some(if self.stable {
+            c.session_stable()
+        } else {
+            c.trailing()
+        })
     }
 }
 
@@ -390,6 +404,46 @@ mod tests {
         assert!(c.content.contains("Aria [persona]"));
         assert!(c.content.contains("win-claude [claude] — Busy"));
         assert!(c.salience > 0.0);
+    }
+
+    // what this catches: the KV routing contract (2026-08-23). A session-stable
+    // source's bid lands in the cacheable system prefix (stable, not trailing);
+    // a volatile-content source's bid rides as a TRAILING conversation turn —
+    // never the system message, where its churn (kanban claim-flaps, her own
+    // writes mutating the workspace map) re-prefilled every conversation token
+    // after it (live KV reuse pinned at 18-33% on the MirrorCode round).
+    #[tokio::test]
+    async fn volatile_content_grounding_is_trailing_and_stable_grounding_is_not() {
+        let stable = RagSourceFaculty::new(
+            persona(),
+            Arc::new(StubSource::new("room-roster", &["Aria [persona]"])),
+            SaliencePolicy::StandingFraming,
+        )
+        .with_clock(Arc::new(|| 1_000));
+        let c = stable
+            .contribute(&Workspace::new("hi"))
+            .await
+            .expect("non-empty source bids");
+        assert!(c.stable, "standing framing stays in the cacheable prefix");
+        assert!(!c.trailing, "stable grounding must not double as trailing");
+
+        let volatile = RagSourceFaculty::new(
+            persona(),
+            Arc::new(StubSource::new("workspace-map", &["src/ lib/ tests/"])),
+            SaliencePolicy::StandingFraming,
+        )
+        .with_volatile_content(true)
+        .with_clock(Arc::new(|| 1_000));
+        let c = volatile
+            .contribute(&Workspace::new("hi"))
+            .await
+            .expect("non-empty source bids");
+        assert!(!c.stable, "volatile content leaves the stable tier");
+        assert!(
+            c.trailing,
+            "volatile grounding rides a trailing turn — churn costs its own tokens, \
+             never the conversation's"
+        );
     }
 
     // what this catches: an empty delivery → abstain (None), not an empty bid.

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -935,7 +935,11 @@ pub async fn materialize_adapters(
                     crate::cognition::persona_workspace::GroundingSource::framing(
                         workspace_map_source,
                     )
-                    .requires_hands(),
+                    .requires_hands()
+                    // Her OWN writes mutate the map — every productive act. It sat
+                    // in the stable tier breaking the KV prefix at ~8k chars of a
+                    // 40k prompt (measured 2026-08-23, turn-over-turn capture diff).
+                    .volatile_content(),
                     // The room's pinned shared documents (airc wall) as
                     // enriching framing — the plan/instructions/recipe that
                     // shape HOW the persona works here, read from the exact


### PR DESCRIPTION
**The wall-clock lever.** Diagnosed from her own captures (turn-over-turn contribution diff on the live MirrorCode round): `workspace-map` content churns act-over-act (her own writes) while sitting in the system message's stable tier; kanban/active-work were volatile-flagged but the volatile tier still renders **inside the system message**, ahead of every conversation token. Divergence at ~8k chars of a 40k prompt → live KV reuse pinned at 18–33%, ~2min/act, 96% of compute in prefill.

Fix at the constraint using #205's existing trailing-turn mechanism: volatile-content grounding bids are `.trailing()` (renders after the conversation; churn costs its own tokens), workspace-map is flagged volatile, and the trailing render keeps its `[faculty]` banner. Expected: prefix reuse = byte-stable system + full conversation; target ≥70% cached on intra-task acts. A/B verdict rides the next round's `inference.prefill.complete` probes.

Pinned by a routing-contract test; 93+11 batteries green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo