### PR TITLE
feat(inference): prefill probe carries persona + purpose

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -2627,6 +2627,15 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         // frame dropped us from 300s to 90s seconds into a prefill that measured ~170s
         // for a window-sized prompt, so every big turn died and retried forever. The
         // phase machine keeps the two regimes apart; see `inference::stream_liveness`.
+        // Stream attribution for the prefill probe: without it every cached%
+        // sample is anonymous, and the 2026-08-23 KV iteration spent a round
+        // unable to tell Atlas's task acts from Benchy's ambient turns. One
+        // clone per stream open — cold path.
+        let probe_persona: String = request
+            .persona_id
+            .clone()
+            .unwrap_or_else(|| "non-persona".into());
+        let probe_purpose: String = request.purpose.clone().unwrap_or_default();
         let mut phase = crate::inference::stream_liveness::StreamPhase::Queued;
         // One `inference.prefill.rescued` row per stream, not per frame.
         let mut prefill_rescued = false;
@@ -2812,6 +2821,8 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                             crate::probe!(
                                 class = "inference.prefill.complete",
                                 provider = self.config.name.as_str(),
+                                persona = probe_persona.as_str(),
+                                purpose = probe_purpose.as_str(),
                                 total = p.total,
                                 cached = p.cache,
                                 fresh = fresh,

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -2634,8 +2634,8 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         let probe_persona: String = request
             .persona_id
             .clone()
-            .unwrap_or_else(|| "non-persona".into());
-        let probe_purpose: String = request.purpose.clone().unwrap_or_default();
+            .unwrap_or_else(|| "non-persona".into()); // non-persona callers (CLI, probes) are a real class, labeled honestly
+        let probe_purpose: String = request.purpose.clone().unwrap_or_default(); // absent purpose renders empty — a label, never a quantity
         let mut phase = crate::inference::stream_liveness::StreamPhase::Queued;
         // One `inference.prefill.rescued` row per stream, not per frame.
         let mut prefill_rescued = false;


### PR DESCRIPTION
Attributed evidence for the KV iteration: cached% samples were anonymous, making Atlas-task vs Benchy-ambient streams indistinguishable. One clone per stream open; two probe fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo