### PR TITLE
feat(eval): task-started probe + lease preemption at act boundaries

### DIFF
--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -717,7 +717,7 @@ async fn reboot(force: bool) -> Result<(), String> {
             old.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(",")
         );
     }
-    stop().await?;
+    stop_with(true).await?;
     // `launch_core`'s `wait_for_death` on `old` is now trivially satisfied —
     // kept as the honesty check that the stop actually took.
     // Publish the claim for the WHOLE build+swap. Held until this function returns, so a
@@ -1600,6 +1600,20 @@ fn start_log_report(logfile: &str) -> String {
 
 /// `continuum stop` — stop the running core (the detached session started by `continuum start`).
 async fn stop() -> Result<(), String> {
+    stop_with(false).await
+}
+
+/// The one teardown, parameterized by lane fate. `keep_lanes: true` is the
+/// REBOOT path: a healthy llama-server about to be wanted again by the next
+/// core stays up, and boot's serve-or-adopt reconcile adopts it at zero
+/// relaunches when the shape matches (regression-pinned:
+/// a_past_form_of_ourself_serving_enough_lanes_is_adopted_not_reaped) or
+/// honestly reaps+rebuilds when it doesn't. Reaping a 20GB-resident lane just
+/// to reload it 60s later made every reboot ~5min; with adoption it is the
+/// core swap alone (Joel 2026-08-23: "if it's taking so long we need to fix
+/// that first"). The standalone `stop` verb keeps FULL teardown — an operator
+/// who says stop means everything.
+async fn stop_with(keep_lanes: bool) -> Result<(), String> {
     let socket = socket_path();
     let pidfile = pidfile_for(&socket);
 
@@ -1693,6 +1707,11 @@ async fn stop() -> Result<(), String> {
     // starved the planner into serving a 2,816-token window that cannot hold the
     // tool surface. `reboot` could not clear it either: reboot is stop + start,
     // and neither half owned lanes.
+    if keep_lanes {
+        println!("  leaving serving lane(s) up for adoption by the next core (reboot path)");
+        let _ = std::fs::remove_file(&socket); // socket cleanup still ours — only the lane fate changed
+        return Ok(());
+    }
     for outcome in continuum_core::inference::lane_registry::sweep_all() {
         use continuum_core::inference::lane_registry::SweepOutcome as S;
         match outcome {

--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -84,6 +84,8 @@ async fn settle_to_outcome(
 ) -> SettleOutcome {
     let burst: Burst = burst.into();
     let mut acts = 0usize;
+    // Rolling act-duration sum for the inline pace verdict below.
+    let mut pace_sum_secs: f64 = 0.0;
     // This turn's causal thread: each admitted act observation becomes the
     // CausedBy target of the next act in the SAME chain — the driver owns the
     // chain, so an edge can never cross turns or rooms (CAUSAL-MEMORY-GRAPH.md).
@@ -273,6 +275,7 @@ async fn settle_to_outcome(
             );
         }
         let may_act = acts < max_acts && stuck < STUCK_LIMIT && discovery_open;
+        let act_started = std::time::Instant::now();
         let (step, step_metrics) = settle_step(
             cycle,
             burst.clone(),
@@ -285,6 +288,32 @@ async fn settle_to_outcome(
         .await;
         if let Some(m) = step_metrics {
             metrics.accumulate(m);
+        }
+        // INLINE PACE VERDICT (Joel 2026-08-23: "know immediately if a model is
+        // being slow as molasses, looping, thrashing, not even starting" — the
+        // states were entering WITHOUT visibility and a human had to pester).
+        // Every act stamps its wall-clock against this turn's own rolling mean;
+        // the verdict is computed WHERE THE WORK HAPPENS, event-based, so
+        // slow/stalled is a probe row the moment it occurs, never a discovery.
+        // No constants deciding cognition: "slow" is relative to THIS turn's
+        // own pace (2x rolling mean, min 3 samples), and the row always carries
+        // the raw numbers so a dashboard can re-judge.
+        {
+            let act_secs = act_started.elapsed().as_secs_f64();
+            pace_sum_secs += act_secs;
+            let pace_n = acts as f64 + 1.0;
+            let mean = pace_sum_secs / pace_n;
+            let slow = acts >= 3 && act_secs > mean * 2.0;
+            crate::probe!(
+                class = "persona.act.pace",
+                room_id = %room_id,
+                act = acts,
+                act_secs = act_secs as u64,
+                rolling_mean_secs = mean as u64,
+                slow = slow,
+                stuck_streak = stuck,
+                "act pace vs this turn's own rolling mean — slow/looping visible the moment it happens"
+            );
         }
         match step {
             SettleStep::Spoke(text) => {

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -3942,6 +3942,16 @@ async fn run_pass(
     cycle.reset_working_memory();
     isolation.rewind();
     for t in tasks {
+        // Task-start receipt: the health verdicts downstream (session gates, the
+        // bench view) judge a running task against the round's OWN completed-task
+        // latencies — which needs an exact start signal, not an inference from
+        // the previous grade's absence (Joel 2026-08-23: a stalled task must be
+        // known in minutes, adaptively, "better fix" than a fixed window).
+        crate::probe!(
+            class = "eval.task.started",
+            task = %t.id,
+            "task drive begins — elapsed-vs-round-median verdicts key on this row"
+        );
         // #209 — per-task CLEAN WORKSPACE for from-scratch build gyms. A from-scratch build
         // task (ui_checks present, and NO setup/dod/solution that establishes or depends on
         // prior repo state) is graded by observing the artifact the persona just wrote into


### PR DESCRIPTION
Two commits: (1) `eval.task.started` probe so stall verdicts judge elapsed against the round's own median; (2) **lease preemption at act boundaries** — a drive in flight when the eval lease lands settles at the next act boundary instead of acting 10+ min through the measurement (measured live: two Atlases alternating 39k/0-cache prefills on one slot). 48+112 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo