### PR TITLE
perf: the act-speed triple — KV layer-3, ngram spec decode, reserve ceiling

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -564,9 +564,24 @@ impl LlmDeliberationFaculty {
         // that overshoots and gets trimmed. That regime is not reachable in production
         // (`window_for` floors at MIN_SERVE_CTX) but the ordering should not depend on it.
         share
+            .min(Self::COMPLETION_CEILING_TOKENS)
             .min(context_window.saturating_sub(mandatory))
             .max(Self::COMPLETION_FLOOR_TOKENS)
     }
+
+    /// Absolute ceiling on the reply reserve. A bare RATIO scales its waste
+    /// with the window: at the 166k lane the /2 share reserved 83,200 tokens
+    /// for replies that measure 0.2-2.5k, squeezing the PROMPT to 73k and
+    /// forcing the packer to amputate accumulated working memory mid-task
+    /// (measured 2026-08-23: demand 112-118k against the squeezed budget,
+    /// context trimmed at act 27 of a 32-act task). Derived, not declared:
+    /// 8× the smallest servable window ≈ 16k — nine minutes of decode at the
+    /// measured ~30 tok/s, far above any observed turn (a thinking model's
+    /// longest measured emission this round was ~2.5k). The honest endgame is
+    /// output-p95 measurement riding the working-set registry pattern; until
+    /// that lands this ceiling stops the ratio's unbounded growth without
+    /// ever clipping a real reply.
+    const COMPLETION_CEILING_TOKENS: u32 = crate::cognition::serving_plan::MIN_SERVE_CTX * 8;
 
     /// The reply's share of the served window, as a DENOMINATOR: reply gets `window/N`.
     ///
@@ -1736,7 +1751,7 @@ impl LlmDeliberationFaculty {
             // behind it: measured 20-22% cached on 34-42k prefills, the old
             // ceiling wearing a new hat. Order in the tail IS the fix: history
             // (stable head) → churning grounding → pinned newest result.
-            if let Some(block) = wm.recent_results_block() {
+            for block in wm.recent_results_messages() {
                 messages.push(ChatMessage::text("user", block));
             }
         }

--- a/core/continuum-core/src/cognition/working_memory.rs
+++ b/core/continuum-core/src/cognition/working_memory.rs
@@ -893,6 +893,32 @@ impl WorkingMemory {
     /// running). Deliberately NOT gated on settlement: the tails are small and
     /// append-only, so the KV prefix stays stable and the #139 full-dump prefill
     /// objection does not apply. `None` before any act.
+    /// The recent-results channel as ONE MESSAGE PER RESULT — the KV layer-3
+    /// shape (2026-08-23). As a single block, any eviction (pop_front under the
+    /// char cap — every act once results are large) mutated the block's HEAD
+    /// in place, re-prefilling everything after the burst: measured 75%→22%
+    /// cache decay within one task, ~6.4k tokens of reuse against 29k prompts.
+    /// As separate messages, eviction DROPS THE OLDEST MESSAGE whole and
+    /// llama's --cache-reuse chunk-shifting re-aligns the surviving suffix
+    /// instead of re-ingesting it. First message carries the banner so the
+    /// semantics of the ledger stay stated.
+    pub fn recent_results_messages(&self) -> Vec<String> {
+        let rr = self.recent_results.lock();
+        if rr.is_empty() {
+            return Vec::new();
+        }
+        // Banner as its OWN byte-stable message (never an rr entry, so eviction
+        // can never take it — gluing it to entry #1 would delete the ledger's
+        // semantics on the first pop_front).
+        let mut out = Vec::with_capacity(rr.len() + 1);
+        out.push(
+            "Recent results of your own actions (oldest first; #n matches the action ledger):"
+                .to_string(),
+        );
+        out.extend(rr.iter().map(|(seq, _, tail)| format!("[result #{seq}] {tail}")));
+        out
+    }
+
     pub fn recent_results_block(&self) -> Option<String> {
         let rr = self.recent_results.lock();
         if rr.is_empty() {

--- a/core/continuum-core/src/inference/lane_args.rs
+++ b/core/continuum-core/src/inference/lane_args.rs
@@ -236,6 +236,12 @@ pub struct LaneOptions<'a> {
     pub mmproj: Option<&'a Path>,
     /// Native MTP speculative-decode draft head (#440).
     pub mtp_draft: Option<&'a Path>,
+    /// Ngram speculative decoding (2026-08-23) — drafts from the prompt's own
+    /// n-grams: zero extra tensors, no draft model, no VRAM. Code/tool output
+    /// is maximally ngram-friendly (identifiers, syntax, paths repeat), and
+    /// acts measured ~80s of decode at ~30 tok/s writing one file. Composes
+    /// with `mtp_draft` into one `--spec-type` list when both are on.
+    pub ngram_spec: bool,
     /// Device-fit resident override (#29) — an ENV var, not a flag.
     pub resident_override: Option<&'a Path>,
     /// CPU-pinned lane: never contend for VRAM a living lane already holds.
@@ -315,9 +321,20 @@ impl LaneInvocation {
         // n-max 4 / p-min 0.7 are the upstream-recommended MTP operating point from that
         // same field benchmark — per-model tuning, if ever needed, belongs on the Model
         // row beside `sampling`, not here.
-        if let Some(d) = opts.mtp_draft {
+        // `--spec-type` is ONE comma-list flag; MTP and ngram compose here so a
+        // second push can never shadow the first.
+        let mut spec_types: Vec<&str> = Vec::new();
+        if opts.mtp_draft.is_some() {
+            spec_types.push("draft-mtp");
+        }
+        if opts.ngram_spec {
+            spec_types.push("ngram-simple");
+        }
+        if !spec_types.is_empty() {
             push("--spec-type".into());
-            push("draft-mtp".into());
+            push(spec_types.join(","));
+        }
+        if let Some(d) = opts.mtp_draft {
             push("--spec-draft-model".into());
             push(d.to_string_lossy().into_owned());
             push("--spec-draft-n-max".into());

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -2728,6 +2728,9 @@ impl LlamaServerControl for LlamaServerProcess {
             flash_attn,
             mmproj: mmproj.as_deref(),
             mtp_draft: mtp_draft.as_deref(),
+            // Ngram spec is free (no tensors, no VRAM) and decode is half of
+            // act latency — on for every GPU serving lane.
+            ngram_spec: true,
             resident_override: target.resident_override.as_deref(),
             cpu_only: target.placement == LanePlacement::Cpu,
             chat_template: chat_template.as_deref(),


### PR DESCRIPTION
Acts were 60-150s: re-prefill (only 6.4k KV survived) + 30 tok/s decode + an 83k reply reserve squeezing the prompt. (1) Per-result messages so eviction drops whole messages and cache-reuse chunk-shifts; (2) `ngram-simple` speculative decode as a proper LaneOptions conditional composing with draft-mtp; (3) reserve ceiling `min(share, MIN_SERVE_CTX*8)`. Target: 26s-class acts as the norm. 135+46 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo