### PR TITLE
feat(eval): lived sampling default — greedy becomes the opt-in

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1618,6 +1618,16 @@ pub struct CognitionEvalParams {
     #[ts(optional)]
     #[ts(optional, type = "number")]
     pub max_retries: Option<u32>,
+    /// Decoding temperature pin for the WHOLE run. **Omitted → her LIVED
+    /// sampling** (the engineerable form — Joel 2026-08-23: "the old form is
+    /// useless"): greedy 0.0 measured pathological on long-context agentic
+    /// work (16k-token think spirals hitting the reply ceiling exactly, 4+min
+    /// decodes) while every serious agentic harness samples. Pass
+    /// `Some(0.0)` to opt INTO the old byte-reproducible greedy pin. A run's
+    /// number is only comparable to runs at the same pin either way.
+    #[serde(default)]
+    #[ts(optional)]
+    pub temperature: Option<f32>,
     /// Free-text label for THIS run, written to the progress ledger so a trend
     /// line is readable: "baseline", "taught show-output", "genome v2", etc.
     /// The ledger is how you "mark improvement as you go" — every eval leaves a
@@ -2474,7 +2484,9 @@ impl CognitionEval {
         // A/B fairness, not protection of her durable memory — that protection now
         // comes from measuring a copy at all. See
         // [[eval-mutates-persona-lift-needs-isolation]].
-        let isolation = cycle.isolate_for_eval();
+        // Omitted → None → her lived temperature rides (see the param doc);
+        // an explicit value pins the whole run (0.0 = the legacy greedy form).
+        let isolation = cycle.isolate_for_eval_at(p.temperature);
 
         // A/B mode: a gene was given → measure base vs gene over the SAME tasks
         // through the SAME live mind, reporting the lift. Page the gene OUT first

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -1802,10 +1802,22 @@ impl WorkspaceCycle {
     /// admitted) yields a no-op guard. See
     /// [[eval-mutates-persona-lift-needs-isolation]].
     pub fn isolate_for_eval(&self) -> EvalIsolation {
+        self.isolate_for_eval_at(Some(0.0))
+    }
+
+    /// [`Self::isolate_for_eval`] with an explicit decoding pin — the
+    /// temperature A/B seam (2026-08-23). Greedy (0.0) buys byte-reproducible
+    /// rewards but measured pathological on long-context agentic work: think
+    /// emissions spiraled 6.9k → 16,384 tokens (the reply ceiling, hit
+    /// exactly) at 4+ min decode per act, while every SOTA agentic harness
+    /// samples ~0.6-0.8 for exactly this reason. `None` = her lived
+    /// temperature. Behavior-before-perplexity applied to our own harness:
+    /// the pin is a MEASURED choice per run, not an axiom.
+    pub fn isolate_for_eval_at(&self, decoding: Option<f32>) -> EvalIsolation {
         // Force greedy decoding for the WHOLE eval window — before the no-hands
         // early return, because a reproducible metric needs deterministic
         // generation even for a pure-speak (no-tools) eval. Restored on drop.
-        self.decoding.store(Arc::new(Some(0.0)));
+        self.decoding.store(Arc::new(decoding));
         let decoding = Some(Arc::clone(&self.decoding));
 
         let Some(acting) = &self.acting else {

--- a/core/continuum-core/src/modules/training_completion_sentinel.rs
+++ b/core/continuum-core/src/modules/training_completion_sentinel.rs
@@ -169,6 +169,7 @@ impl TrainingCompletionSentinel {
             };
 
             let params = CognitionEvalParams {
+            temperature: None, // sentinel measures her as she LIVES — lived sampling
                 run_id: None,
                 persona_id: crate::identity::PersonaRef::new(job.persona_id.to_string()),
                 gene: Some(EvalGene {


### PR DESCRIPTION
Greedy temp-0.0 measured pathological on long-context agentic work (16k think spirals hitting the ceiling exactly, 4-11min acts). `temperature` param: omitted → lived sampling; `0.0` → legacy byte-repro pin. 58 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo