### PR TITLE
fix(cognition): bounded tool await + trail-entry clip (the 70k block)

### DIFF
--- a/core/continuum-core/src/cognition/act_observe/apply.rs
+++ b/core/continuum-core/src/cognition/act_observe/apply.rs
@@ -342,11 +342,39 @@ pub async fn apply_act(
     if !fg_calls.is_empty() {
         cycle.note_acting();
     }
-    let outcome = match body
-        .executor
-        .execute_native_batch(&fg_calls, &ctx, budget.result_fold_chars())
-        .await
-    {
+    // BOUNDED (2026-08-24): this await was the last UNGUARDED hang in the act
+    // chain — inference has the stream-liveness ladder, but a wedged IPC
+    // socket or a runaway command could hold this forever with NO propagated
+    // error. Measured: bitwise ran 03:51→05:51 in silence until the 2h
+    // GLOBAL backstop fired as an infra fault. This per-act ceiling converts
+    // that into a 30-min act-level ERROR OBSERVATION she perceives and can
+    // react to. Generous by design (a real build can take many minutes; the
+    // shell window hands back handles long before this) — firing means a
+    // substrate hang, and the receipt says so.
+    const TOOL_BATCH_CEILING: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+    let batch_result = tokio::time::timeout(
+        TOOL_BATCH_CEILING,
+        body.executor
+            .execute_native_batch(&fg_calls, &ctx, budget.result_fold_chars()),
+    )
+    .await
+    .unwrap_or_else(|_| { // timeout elapsed = the hang this bound exists to convert; the closure builds the honest error
+        crate::probe!(
+            class = "persona.act.tool_batch_hung",
+            ceiling_s = TOOL_BATCH_CEILING.as_secs(),
+            tools = fg_calls.len(),
+            "tool batch exceeded the act ceiling with no result and no error —              substrate hang converted to a perceptible act error (find the              unpropagated await beneath)"
+        );
+        Err(crate::cognition::tool_executor::ToolError::ExecutionFailed {
+            tool: "batch".to_string(),
+            underlying: format!(
+                "tool batch hung past {}s with no result — the substrate lost this \
+                 act; the workspace may hold partial effects",
+                TOOL_BATCH_CEILING.as_secs()
+            ),
+        })
+    });
+    let outcome = match batch_result {
         Ok(o) => o,
         Err(e) => {
             // Fail loud-ish: the hand could not run. Abstain — do NOT synthesize a

--- a/core/continuum-core/src/cognition/working_memory.rs
+++ b/core/continuum-core/src/cognition/working_memory.rs
@@ -1185,10 +1185,25 @@ impl Faculty for WorkingMemoryFaculty {
         // scaffold-echo of the [resumed] briefing. Same bug class as the
         // second-person header this comment block's sibling above fixed
         // (#264 third finding): provenance framing must match the voice.
+        // Each entry CLIPPED to the same head bound receipts already use —
+        // measured 2026-08-24: ONE unclipped reasoning trace (a 16k-token
+        // think emission) made this block 70,086 chars (~20k tokens), the
+        // single dominant mass of an 85k prompt. The full text stays in the
+        // entry (the pinned path and recall read it); only the TRAIL RENDER
+        // is bounded, with the collapse idiom naming what was elided.
+        let head = self.memory.budget().trail_head_chars();
+        let clip = |t: &str| -> String {
+            if t.chars().count() <= head {
+                t.to_string()
+            } else {
+                let kept: String = t.chars().take(head).collect();
+                format!("{kept} …[{} more chars — my full thought, collapsed]", t.chars().count() - head)
+            }
+        };
         let recent: Vec<String> = entries
             .iter()
             .filter(|e| !matches!(e.kind, WmKind::Fact))
-            .map(|e| e.text.clone())
+            .map(|e| clip(&e.text))
             .collect();
         let notices: Vec<String> = entries
             .iter()


### PR DESCRIPTION
Two morning fixes from the night's evidence: (1) the tool-batch IPC await — the last unguarded hang — gets a 30-min ceiling converting to a named error observation (the 2h backstop firing's cure); (2) capture-measured, the [working-memory] block hit 70k chars because reasoning traces rendered unclipped — thoughts now clip to the same head bound receipts use, collapse idiom names the elision. 45+52 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo