### PR TITLE
fix(cognition): truncation is never an answer; the gate never out-stubborns her

### DIFF
--- a/core/continuum-core/src/cognition/act_observe/mod.rs
+++ b/core/continuum-core/src/cognition/act_observe/mod.rs
@@ -760,9 +760,11 @@ mod tests {
         .await;
 
         assert_eq!(
-            outcome.acts, 10,
-            "discovery saturates at half the budget (20/2) with zero mutations — \
-             the other half is preserved for the empty-diff re-drive"
+            outcome.acts, 15,
+            "discovery saturates at 3/4 of the budget (20*3/4) with zero mutations \
+             — PREMISE CHANGED 2026-08-24: the /2 gate measured live as forcing \
+             early settles on honest study phases (she 'quit' at 16/32 because \
+             the gate quit for her); 3/4 still bounds a pure-read runaway"
         );
         assert!(
             matches!(outcome.decision, Decision::Act { .. }) && outcome.spoken.is_none(),
@@ -841,7 +843,7 @@ mod tests {
         // guarantee worth pinning is therefore: at settle, working memory
         // holds at least one [act-budget] fact naming the REAL budget number.
         assert!(
-            budget_facts.iter().any(|e| e.text.contains("my 6 acts")),
+            budget_facts.iter().any(|e| e.text.contains("of 6 acts") || e.text.contains("my 6 acts")),
             "a budget fact naming the real budget must survive to settle; got: {:?}",
             budget_facts.iter().map(|e| &e.text).collect::<Vec<_>>()
         );

--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -168,7 +168,15 @@ async fn settle_to_outcome(
     // steer — it never says what to write, exactly like `max_acts`; it converts an
     // unbounded read loop into a decision point while the budget can still buy the
     // decision. Non-workspace turns (chat, research) are untouched.
-    let discovery_budget = (max_acts / 2).max(1);
+    // 3/4 of the budget, not 1/2 (2026-08-24): at /2 the gate fired at act 16
+    // of 32 on tasks whose honest STUDY phase needs more (126-case reverse
+    // engineering) — she "quit" at half budget because the gate quit for her,
+    // and the red-build re-drive's fresh turn hit its own gate identically.
+    // The gate still bounds a pure-read runaway (a full-budget read turn ends
+    // withheld, and the pre-gate warning now lands 4 acts before THIS bound —
+    // genuinely before, not at, the cliff). Plumbing must never out-stubborn
+    // the engineer it serves.
+    let discovery_budget = (max_acts * 3 / 4).max(1);
     let mut mutated_yet = false;
     let mut saturation_probed = false;
 

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -2314,6 +2314,33 @@ impl Faculty for LlmDeliberationFaculty {
             );
             return Some(Contribution::deliberation_fault(why));
         }
+        // TRUNCATED-WITH-TEXT is NOT an utterance (2026-08-24, Joel: "why is
+        // this amazing LLM not finishing things or quitting — something in
+        // plumbing always"). A generation that ended at the OUTPUT LIMIT with
+        // no tool call is a thought cut mid-stream — measured: 16,384-token
+        // emissions (the ceiling, exactly) whose text then flowed through the
+        // Speak path and SETTLED GRADED TURNS on a half-sentence. The empty
+        // case above already faults; the with-text case fell through. Same
+        // treatment: a fault (the #386 bounded in-place retry re-samples —
+        // under lived sampling a fresh draw rarely spirals identically), never
+        // a candidate answer. Her cut text rides the fault head so the glass
+        // box shows what she was mid-way through.
+        if matches!(resp.finish_reason, FinishReason::Length)
+            && resp.tool_calls.as_ref().is_none_or(|c| c.is_empty())
+            && !resp.text.trim().is_empty()
+        {
+            crate::probe!(
+                class = "delib.truncated_not_an_answer",
+                persona = %self.persona_name,
+                text_chars = resp.text.len(),
+                "generation ended AT the output limit with no tool call — a cut                  thought, faulted for re-sample, never a gradeable utterance"
+            );
+            let head: String = resp.text.chars().take(200).collect();
+            return Some(Contribution::deliberation_fault(format!(
+                "the model hit the output limit mid-thought with no committed action                  (finish_reason Length, {} chars) — a cut thought is not an answer.                  It began: {head}",
+                resp.text.len()
+            )));
+        }
 
         // Did she choose to act? Two shapes, both → `Decision::Act`:
         //  (a) the adapter returned a native tool-use turn (FinishReason::ToolUse);


### PR DESCRIPTION
The two plumbing pieces behind every 'she quit': (1) `Length`-with-text flowed to Speak and settled graded turns on cut-off thoughts — now faulted for re-sample like the empty case; (2) the /2 discovery gate forced settles at 16/32 on honest study phases (and the re-drive's turn hit its own gate) — now 3/4 with the warning truly before the cliff. 123 tests green, premise changes stated in the updated pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo