### PR TITLE
fix(tools): her measured friction — Python in code/run, teaching errors

### DIFF
--- a/core/continuum-core/src/commands/code/git/apply.rs
+++ b/core/continuum-core/src/commands/code/git/apply.rs
@@ -56,8 +56,16 @@ crate::action_command! {
     output: GitApplyResult,
     run(this, ctx, p) => {
         if p.patch.trim().is_empty() {
+            // Glass-boxed 2026-08-24: she hit this refusal THIRTEEN times in one
+            // night — the bare param name taught nothing, so the same mistake
+            // repeated. An error that costs an act must teach the call shape.
             return Err(CommandError::Invalid(
-                "code/git/apply: 'patch' is required (the unified diff text — the output of code/git/diff)".into(),
+                concat!(
+                    "code/git/apply: 'patch' is required — the unified diff TEXT itself ",
+                    "(not a path). Get one from code/git/diff and pass it verbatim as ",
+                    "patch=<that text>. To write or replace whole files, use code/write instead."
+                )
+                .into(),
             ));
         }
         let root = workspace_root_for(&this.state, ctx)?;

--- a/core/continuum-core/src/commands/code/run.rs
+++ b/core/continuum-core/src/commands/code/run.rs
@@ -99,21 +99,36 @@ impl ActionCommand for CodeRun {
     type Output = CodeRunResult;
 
     async fn run(&self, _ctx: &Ctx, params: CodeRunParams) -> Result<CodeRunResult, CommandError> {
-        // Rust only — this is a Rust organism's hand. Unknown language fails loud,
-        // never guesses a toolchain.
-        match params.lang.as_str() {
-            "rust" | "rs" => {}
-            other => return Err(CommandError::Invalid(format!(
-                "code/run: unsupported lang '{other}' (Rust only — give a complete Rust program)"
-            ))),
-        }
-
         let timeout = std::time::Duration::from_secs(
             params
                 .timeout_secs
                 .unwrap_or(DEFAULT_TIMEOUT_SECS)
                 .clamp(1, MAX_TIMEOUT_SECS),
         );
+        // Rust + Python. Glass-boxed 2026-08-24 from her own capture stream: she
+        // reached for Python TWENTY-THREE times in one night — every analysis
+        // scratch-tool she builds is Python — and the Rust-only refusal burned
+        // each of those acts before she found the bash-heredoc workaround. A
+        // hand that refuses the language its owner thinks in is harness
+        // friction, not principle; every serious harness runs both. Unknown
+        // languages still fail loud, now naming BOTH supported paths.
+        match params.lang.as_str() {
+            "rust" | "rs" => {}
+            "python" | "python3" | "py" => {
+                let dir =
+                    std::env::temp_dir().join(format!("cu-coderun-{}", uuid::Uuid::new_v4()));
+                std::fs::create_dir_all(&dir).map_err(|e| {
+                    CommandError::Internal(format!("code/run: temp dir create failed: {e}"))
+                })?;
+                let result = run_python(&dir, &params.code, timeout).await;
+                let _ = std::fs::remove_dir_all(&dir);
+                return result;
+            }
+            other => return Err(CommandError::Invalid(format!(
+                "code/run: unsupported lang '{other}' — supported: rust, python. \
+                 For anything else use code/shell (any command; long runs hand back a handle)"
+            ))),
+        }
 
         // Fresh temp dir per run, removed afterward. The code is written verbatim — no
         // fence-stripping, no wrapping: the persona hands a complete program and we run
@@ -137,6 +152,62 @@ impl ActionCommand for CodeRun {
 /// rustc's stderr), not hidden — the persona reads the compiler's errors and
 /// self-corrects exactly as she would a runtime panic. `Err` is reserved for a
 /// failure to spawn the toolchain at all (e.g. `rustc` absent).
+/// Run a complete Python program under the same wall-clock + kill_on_drop
+/// contract as the Rust path. Same ground-truth shape: a traceback is the run
+/// result (ok=false), never hidden; `Err` is reserved for a missing
+/// interpreter. python3 resolves from PATH like rustc does.
+async fn run_python(
+    dir: &std::path::Path,
+    code: &str,
+    timeout: std::time::Duration,
+) -> Result<CodeRunResult, CommandError> {
+    let src = dir.join("main.py");
+    std::fs::write(&src, code)
+        .map_err(|e| CommandError::Internal(format!("code/run: write failed: {e}")))?;
+    let mut cmd = tokio::process::Command::new("python3");
+    cmd.arg(&src)
+        .current_dir(dir)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    let child = cmd
+        .spawn()
+        .map_err(|e| CommandError::Internal(format!("code/run: python3 spawn failed: {e}")))?;
+    let started = std::time::Instant::now();
+    let waited = tokio::time::timeout(timeout, child.wait_with_output()).await;
+    let duration_ms = started.elapsed().as_millis() as u64;
+    let out = match waited {
+        Err(_) => {
+            // Same honest shape as the Rust path: a timeout is a RESULT (she
+            // reads it and adjusts), never a hidden kill.
+            return Ok(CodeRunResult {
+                ok: false,
+                stdout: String::new(),
+                stderr: format!(
+                    "killed: exceeded the {}s run timeout (raise timeout_secs up to {}s, \
+                     or use code/shell for long-running work)",
+                    timeout.as_secs(),
+                    MAX_TIMEOUT_SECS
+                ),
+                exit_code: None,
+                duration_ms,
+                timed_out: true,
+            });
+        }
+        Ok(r) => {
+            r.map_err(|e| CommandError::Internal(format!("code/run: python wait failed: {e}")))?
+        }
+    };
+    Ok(CodeRunResult {
+        ok: out.status.success(),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        exit_code: out.status.code(),
+        duration_ms,
+        timed_out: false,
+    })
+}
+
 async fn compile_and_run_rust(
     dir: &std::path::Path,
     code: &str,
@@ -380,8 +451,11 @@ mod tests {
             .run(
                 &Ctx::default(),
                 CodeRunParams {
-                    lang: "python".into(),
-                    code: "print(1)".into(),
+                    // PREMISE CHANGED 2026-08-24: python is now SUPPORTED (she
+                    // reached for it 23 times in one night and every refusal
+                    // burned an act). A genuinely unknown lang still fails loud.
+                    lang: "cobol".into(),
+                    code: "DISPLAY '1'.".into(),
                     timeout_secs: None,
                 },
             )
@@ -391,5 +465,26 @@ mod tests {
             format!("{err:?}").contains("unsupported lang"),
             "names the cause: {err:?}"
         );
+    }
+
+    // what this catches: the python path actually RUNS a program end-to-end and
+    // returns ground truth (stdout + ok) — the 2026-08-24 harness-friction fix
+    // (23 refused python acts in one night) staying real, not just an accepted
+    // lang string.
+    #[tokio::test]
+    async fn python_runs_and_returns_ground_truth() {
+        let r = CodeRun
+            .run(
+                &Ctx::default(),
+                CodeRunParams {
+                    lang: "python".into(),
+                    code: "print(2+2)".into(),
+                    timeout_secs: None,
+                },
+            )
+            .await
+            .expect("python must run");
+        assert!(r.ok, "clean exit: {r:?}");
+        assert_eq!(r.stdout.trim(), "4");
     }
 }


### PR DESCRIPTION
Glass-boxed her capture stream: 36 of ~70 generations hit a refused act — 23× Python refused by the Rust-only sandbox, 13× the same git/apply param confusion. Python now runs (same ground-truth contract); the apply error teaches the shape. 61 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo