### PR TITLE
fix(boot): the stranger's first thirty minutes

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -2518,6 +2518,56 @@ pub fn start_server(
                     return;
                 }
             };
+        // FIRST-BOOT MODEL ACQUISITION (2026-08-24, Joel: "this repo isn't for
+        // ME — a new repo user without an agent and a totally different
+        // machine"). A fresh clone has ZERO local GGUFs: the planner finds no
+        // viable candidate, citizens boot mute, and only a log line an agent
+        // would read names the fix. Boot now owns its engine like it owns its
+        // transport: when NO catalog model resolves a local gguf, pull the
+        // modest first-boot default (our own forged 4B coder, ~small download,
+        // tool-trained) in the background — the serving reconcile adopts it on
+        // its own edge when the pull lands. Escape hatch:
+        // CONTINUUM_NO_AUTO_PULL=1 restores the old fail-loud-only behavior.
+        {
+            let none_local = crate::model_registry::catalog::models()
+                .iter()
+                .all(|m| crate::model_registry::artifacts::resolve_gguf_for_model(m).is_none());
+            let opted_out = crate::config_env::read("CONTINUUM_NO_AUTO_PULL")
+                .is_some_and(|v| v == "1");
+            if none_local && !opted_out {
+                const FIRST_BOOT_MODEL: &str = "continuum-ai/qwen3.5-4b-code-forged-GGUF";
+                crate::probe!(
+                    class = "boot.first_model_pull",
+                    model = FIRST_BOOT_MODEL,
+                    "fresh install: no local GGUF anywhere — boot pulls the first-boot                      default so citizens are never mute on a stranger's machine"
+                );
+                tracing::info!(
+                    model = FIRST_BOOT_MODEL,
+                    "🧲 first boot: no local models — downloading the default engine                      (serving adopts it automatically when the pull completes;                      CONTINUUM_NO_AUTO_PULL=1 to opt out)"
+                );
+                let exec = tool_executor.clone();
+                tokio::spawn(async move {
+                    let outcome = exec
+                        .execute(
+                            "models/pull",
+                            serde_json::json!({ "model_id": FIRST_BOOT_MODEL }),
+                        )
+                        .await;
+                    match outcome {
+                        Ok(_) => tracing::info!(
+                            model = FIRST_BOOT_MODEL,
+                            "🧲 first-boot model pull COMPLETE — serving reconcile will adopt it"
+                        ),
+                        Err(e) => tracing::error!(
+                            model = FIRST_BOOT_MODEL,
+                            error = %e,
+                            "first-boot model pull FAILED — citizens stay mute; manual fix:                              continuum models/pull --model_id {FIRST_BOOT_MODEL}"
+                        ),
+                    }
+                });
+            }
+        }
+
             use crate::persona::resume_or_mint_provider::ResumeOrMintProvider;
             // `persona_floor` (read once above) floors the provider's mint count
             // to the SAME value that sized the spawner's plan via with_population

--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -1013,8 +1013,8 @@ pub fn models() -> Vec<Model> {
                 Capability::Streaming,
             ],
             gguf_hint: Some("huggingface.co/bartowski/Qwen2-VL-7B-Instruct-GGUF"),
-            gguf_local_path: Some("~/models/qwen2-vl-7b/Qwen2-VL-7B-Instruct-Q4_K_M.gguf"),
-            mmproj_local_path: Some("~/models/qwen2-vl-7b/mmproj-Qwen2-VL-7B-Instruct-f16.gguf"),
+            gguf_local_path: Some("~/.continuum/models/Qwen2-VL-7B-Instruct-Q4_K_M.gguf"),
+            mmproj_local_path: Some("~/.continuum/models/mmproj-Qwen2-VL-7B-Instruct-f16.gguf"),
             multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
             ..ModelSpec::default()
         }),
@@ -1034,8 +1034,8 @@ pub fn models() -> Vec<Model> {
                 Capability::Streaming,
             ],
             gguf_hint: Some("huggingface.co/ggml-org/Qwen2.5-Omni-7B-GGUF"),
-            gguf_local_path: Some("~/models/qwen2.5-omni-7b/Qwen2.5-Omni-7B-Q4_K_M.gguf"),
-            mmproj_local_path: Some("~/models/qwen2.5-omni-7b/mmproj-Qwen2.5-Omni-7B-f16.gguf"),
+            gguf_local_path: Some("~/.continuum/models/Qwen2.5-Omni-7B-Q4_K_M.gguf"),
+            mmproj_local_path: Some("~/.continuum/models/mmproj-Qwen2.5-Omni-7B-f16.gguf"),
             multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
             ..ModelSpec::default()
         }),

--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -288,9 +288,28 @@ adopt_or_reap_llama_lanes
 #     one is the class of lie this whole card exists to end.
 ensure_airc_daemon() {
   if ! command -v airc >/dev/null 2>&1; then
-    echo "⚠  airc is NOT INSTALLED — the substrate has no transport." >&2
-    echo "   The core will launch, but citizens have no rooms and cannot hear each other." >&2
-    return 0
+    # BOOT ACQUIRES ITS OWN TRANSPORT (2026-08-24, Joel: "this repo isn't for
+    # ME — a new repo user without an agent"). A warn-and-carry-on here left a
+    # fresh clone with mute citizens and a runbook line only an agent would
+    # ever read. airc is OUR sibling repo; boot installs it the same way the
+    # published instructions do, then proceeds. Offline/failed install falls
+    # back to the old loud warning — degraded is honest, silent is not.
+    echo "▶ airc not installed — installing (CambrianTech/airc, the substrate's transport)" >&2
+    if bounded_run 300 sh -c 'curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash'        && command -v airc >/dev/null 2>&1; then
+      echo "✓ airc installed ($(command -v airc))" >&2
+    else
+      # PATH may not include the fresh install dir in THIS shell — try the
+      # conventional location before declaring absence.
+      if [ -x "${HOME}/.local/bin/airc" ]; then
+        export PATH="${HOME}/.local/bin:${PATH}"
+        echo "✓ airc installed (${HOME}/.local/bin/airc — added to PATH for this boot)" >&2
+      else
+        echo "⚠  airc install FAILED — the substrate has no transport." >&2
+        echo "   The core will launch, but citizens have no rooms and cannot hear each other." >&2
+        echo "   Manual fix: curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash" >&2
+        return 0
+      fi
+    fi
   fi
 
   if bounded_run 5 airc ping; then


### PR DESCRIPTION
Catalog personal paths canonicalized (they pointed at nothing anywhere); boot installs airc when absent (bounded, loud fallback); first boot pulls our forged 4B coder when zero GGUFs resolve — serving adopts on its edge. Filed en route: two env-dependent tests + a footprint-constructor drift (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo