### PR TITLE
feat(code): handed-back shell completions PUSH into perception

### DIFF
--- a/core/continuum-core/src/code/shell_session.rs
+++ b/core/continuum-core/src/code/shell_session.rs
@@ -57,6 +57,13 @@ pub struct ExecutionState {
     pub pid: Option<u32>,
     pub started_at: u64,
     pub finished_at: Option<u64>,
+    /// True once code/shell's inline window elapsed and the HANDLE was handed
+    /// back to the caller (2026-08-24): completion must then be PUSHED — the
+    /// exit fold publishes a command:completed event the dispatch listener
+    /// folds into her working memory, so a finished build reaches her
+    /// perception without her remembering to poll. False for in-window
+    /// completions (the caller already holds the result).
+    pub handed_back: bool,
     /// Cursor: index of next stdout line to return on poll/watch.
     stdout_cursor: usize,
     /// Cursor: index of next stderr line to return on poll/watch.
@@ -172,6 +179,19 @@ impl CompiledSentinel {
 ///
 /// Maintains working directory and environment across command executions.
 /// Each command runs in its own isolated process (bash -c "...").
+/// Process-global bus handle for pushed shell completions — set once at boot
+/// (ipc wiring), read by the detached exit-fold task which holds no self. Same
+/// shape as the lane-demand / roster globals; None (tests, early boot) = the
+/// old poll-only behavior, never an error.
+static SHELL_COMPLETION_BUS: std::sync::OnceLock<
+    std::sync::Arc<crate::runtime::message_bus::MessageBus>,
+> = std::sync::OnceLock::new();
+
+/// Wire the completion bus (boot, once). Idempotent; later calls are no-ops.
+pub fn set_shell_completion_bus(bus: std::sync::Arc<crate::runtime::message_bus::MessageBus>) {
+    let _ = SHELL_COMPLETION_BUS.set(bus);
+}
+
 pub struct ShellSession {
     id: String,
     persona_id: String,
@@ -323,6 +343,7 @@ impl ShellSession {
             pid: None,
             started_at: now_ms,
             finished_at: None,
+            handed_back: false,
             stdout_cursor: 0,
             stderr_cursor: 0,
             output_notify: notify,
@@ -952,13 +973,52 @@ async fn run_shell_command(
                 s.finished_at = Some(now());
                 // Wake any blocked watch() calls to deliver final status
                 s.output_notify.notify_one();
+                // PUSHED COMPLETION (2026-08-24): a handed-back execution's
+                // finish previously reached her only if she remembered to
+                // poll. Publish the same command:completed shape tracked
+                // dispatches use; the dispatch listener folds it into her
+                // working memory IF the handle was registered (apply.rs does,
+                // on handback).
+                if s.handed_back {
+                    if let (Some(bus), Ok(handle)) =
+                        (SHELL_COMPLETION_BUS.get(), uuid::Uuid::parse_str(&s.id))
+                    {
+                        let mut lines: Vec<&String> =
+                            s.stdout_lines.iter().chain(s.stderr_lines.iter()).collect();
+                        let cut = lines.len().saturating_sub(20);
+                        let tail: String = lines
+                            .split_off(cut)
+                            .into_iter()
+                            .map(String::as_str)
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        let ev = crate::runtime::command_events::CommandCompletedEvent {
+                            command_name: "code/shell".to_string(),
+                            duration_ms: s.finished_at.unwrap_or(0).saturating_sub(s.started_at), // set 3 lines up; 0 → saturates to 0ms, display only
+                            success: s.exit_code == Some(0),
+                            error: (s.exit_code != Some(0))
+                                .then(|| format!("exit {}", s.exit_code.map_or(-1, |c| c))),
+                            handle: Some(handle),
+                            result: Some(serde_json::json!({
+                                "exitCode": s.exit_code,
+                                "tail": tail,
+                            })),
+                        };
+                        if let Ok(payload) = serde_json::to_value(&ev) { // bus fan-out boundary — the same encode tracked dispatches pay
+                            bus.publish_async_only(
+                                crate::runtime::command_events::COMMAND_COMPLETED_TOPIC,
+                                payload,
+                            );
+                        }
+                    }
+                }
 
                 log_info!(
                     "code",
                     "shell",
                     "Execution {} finished: exit={} cmd={}",
                     &s.id[..8],
-                    s.exit_code.unwrap_or(-1),
+                    s.exit_code.unwrap_or(-1), // killed/no-status path reads as conventional -1 in the error line
                     &s.command
                 );
             }

--- a/core/continuum-core/src/cognition/act_observe/apply.rs
+++ b/core/continuum-core/src/cognition/act_observe/apply.rs
@@ -42,7 +42,11 @@ const PROPRIOCEPTION_RECALL_SALIENCE: f32 = 0.25;
 fn is_long_running(command: &str) -> bool {
     matches!(
         command,
-        "code/cargo/check" | "code/cargo/test" | "cognition/full-evaluate" | "forge/train"
+        "code/cargo/check"
+            | "code/cargo/test"
+            | "code/cargo/build"
+            | "cognition/full-evaluate"
+            | "forge/train"
     )
 }
 
@@ -436,6 +440,36 @@ pub async fn apply_act(
                 is_error: None,
                 spill_handle: None,
             });
+        // PUSHED SHELL COMPLETION, receive side (2026-08-24): a `code/shell` whose
+        // inline window elapsed hands back a RUNNING handle. Register that handle as a
+        // dispatch NOW so the exit fold's command:completed event (shell_session.rs)
+        // has a label to fold against — dispatch_listener drops completions for
+        // unregistered handles. Without this she must remember to poll; with it the
+        // finished build lands in her working memory like any dispatched background job.
+        if call.name.replace('_', "/") == "code/shell" && typed_result.is_error != Some(true) {
+            if let Ok(resp) = serde_json::from_str::<crate::code::shell_types::ShellExecuteResponse>(
+                &typed_result.content,
+            ) {
+                if resp.status == crate::code::shell_types::ShellExecutionStatus::Running {
+                    if let Ok(handle) = uuid::Uuid::parse_str(&resp.execution_id) {
+                        let label: String = call
+                            .input
+                            .get("command")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("code/shell") // label only — the handle is the key
+                            .chars()
+                            .take(80)
+                            .collect();
+                        body.working_memory.record_dispatch_event(
+                            handle,
+                            &format!("code/shell: {label}"),
+                            "handle handed back — still running",
+                            crate::cognition::working_memory::DispatchStatus::Running,
+                        );
+                    }
+                }
+            }
+        }
         let obs = Observation {
             call: call.clone(),
             output: ToolOutput {

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1847,6 +1847,9 @@ pub fn start_server(
     // Phase 3: CodeModule (wraps file engines and shell sessions per-persona)
     let file_engines: Arc<DashMap<String, FileEngine>> = Arc::new(DashMap::new());
     let shell_sessions: Arc<DashMap<String, ShellSession>> = Arc::new(DashMap::new());
+    // Pushed shell completions (2026-08-24): the exit fold publishes
+    // command:completed for handed-back executions; wire it the bus once.
+    crate::code::shell_session::set_shell_completion_bus(runtime.bus_arc());
     let code_state = Arc::new(CodeState::new(
         file_engines.clone(),
         shell_sessions.clone(),

--- a/core/continuum-core/src/modules/code_commands.rs
+++ b/core/continuum-core/src/modules/code_commands.rs
@@ -1160,9 +1160,13 @@ impl ActionCommand for CodeShell {
             };
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
-                let s = state_arc
+                let mut s = state_arc
                     .lock()
                     .map_err(|e| CommandError::Internal(format!("execution lock poisoned: {e}")))?;
+                // Mark the handback so the exit fold PUSHES completion (the
+                // dispatch listener folds it into her working memory) instead
+                // of waiting silently to be polled.
+                s.handed_back = true;
                 return Ok(shell_response(&s)); // still running → hand back the handle
             }
             // Wake on new output or when the inline window closes, then re-check.


### PR DESCRIPTION
A code/shell that outlives its inline window hands back a RUNNING handle — and until now its completion was silent: she had to remember to poll. This makes the exit fold publish the same command:completed event tracked dispatches use, and the handback site registers the handle as a dispatch label, so the finished build folds into her working memory automatically.

Purely additive: nothing kills the running process; the handle contract is unchanged. `is_long_running` gains `code/cargo/build`.

Battery: shell_session + code_commands + dispatch_listener + apply + mod-singularity + unwrap/serialization ratchets — 66 passed, exit code checked explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo