### PR TITLE
fix(benchmark): round idempotence from dispatch time — first-grade window minted duplicates

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1906,6 +1906,25 @@ pub struct CognitionEvalResult {
 /// The gym command. Stateless: it reaches the persona's live cognition through the
 /// global [`WorkspaceCycle`](super::persona_workspace) registry, so it needs no host
 /// module state.
+/// Detached evals in flight, registered at DISPATCH time — not at first grade.
+/// The idempotence gap this closes (measured live, 2026-08-24, runs 4ae8e14c +
+/// 912de04f): a round's first task can grade 30+ minutes after dispatch, and until
+/// then the run has no ledger rows and no RunMeta scope — so `benchmark/round`
+/// re-invoked in that window happily minted a DUPLICATE fresh run. Entries are
+/// (run_id, persona, eval_set reference); removed when the detached body returns
+/// (either arm), so a crashed core clears it by process death — never a stale file.
+static DETACHED_IN_FLIGHT: std::sync::Mutex<Vec<(String, String, String)>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// Snapshot of the detached evals dispatched and not yet finished. For
+/// `benchmark/round`'s idempotence gate.
+pub(crate) fn detached_evals_in_flight() -> Vec<(String, String, String)> {
+    DETACHED_IN_FLIGHT
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or_default() // poisoned lock = a panicked writer; empty = gate opens, worst case a duplicate run (the pre-fix behavior), never a wedge
+}
+
 #[derive(Default)]
 pub struct CognitionEval;
 
@@ -1946,8 +1965,22 @@ impl ActionCommand for CognitionEval {
             // for the ack's return value below (they're `String`, not `Copy`).
             let ledger_persona = persona_id.clone();
             let ledger_run = run_id.clone();
+            if let Ok(mut g) = DETACHED_IN_FLIGHT.lock() {
+                g.push((
+                    run_id.clone(),
+                    persona_id.as_str().to_string(),
+                    inner
+                        .eval_set
+                        .clone()
+                        .unwrap_or_else(|| DEFAULT_EVAL_SET.to_string()), // same default the task-source block resolves — one identity
+                ));
+            }
             tokio::spawn(async move {
-                match CognitionEval::run_eval_restoring(inner).await {
+                let outcome = CognitionEval::run_eval_restoring(inner).await;
+                if let Ok(mut g) = DETACHED_IN_FLIGHT.lock() {
+                    g.retain(|(rid, _, _)| rid != &ledger_run);
+                }
+                match outcome {
                     Ok(r) => tracing::info!(
                         note = %note,
                         score = r.score,

--- a/core/continuum-core/src/commands/benchmark_round.rs
+++ b/core/continuum-core/src/commands/benchmark_round.rs
@@ -19,8 +19,8 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use crate::cognition::eval::{
-    graded_task_ids_from, live_eval_run_id, progress_ledger_dir, CognitionEval,
-    CognitionEvalParams, EvalTask,
+    detached_evals_in_flight, graded_task_ids_from, live_eval_run_id, progress_ledger_dir,
+    CognitionEval, CognitionEvalParams, EvalTask,
 };
 use crate::cognition::learning_policy::LearningPolicy;
 use crate::sdk_codegen::command::ActionCommand;
@@ -84,6 +84,27 @@ pub struct BenchmarkRoundResult {
     pub remaining: u32,
     /// Human-readable one-liner of what the verb decided and why.
     pub note: String,
+}
+
+/// The dispatch-time idempotence gate, pure for tests: given the detached evals in
+/// flight, decide whether the verb may dispatch. `Some(Ok(run_id))` = THIS
+/// benchmark's round is already in flight (report it, dispatch nothing);
+/// `Some(Err(msg))` = a DIFFERENT round holds the arena (evals serialize — a second
+/// dispatch would silently queue behind it for hours, so refuse loudly instead);
+/// `None` = free to dispatch. Closes the measured gap where a round's first task
+/// grades ~30min after dispatch and the ledger-based resume scan sees nothing.
+fn gate_on_in_flight(
+    in_flight: &[(String, String, String)],
+    benchmark: &str,
+) -> Option<Result<String, String>> {
+    if let Some((rid, _, _)) = in_flight.iter().find(|(_, _, set)| set == benchmark) {
+        return Some(Ok(rid.clone()));
+    }
+    in_flight.first().map(|(rid, persona, set)| {
+        Err(format!(
+            "another round is already grading (run {rid}, persona {persona}, gym {set}) — evals              serialize on the exam lease, so dispatching now would silently queue for hours.              Wait for it (cognition/eval-status --run-id {rid}) or reboot to clear it."
+        ))
+    })
 }
 
 /// The newest streamed task row's runId for `(persona ledger, benchmark ref)` —
@@ -155,6 +176,50 @@ impl ActionCommand for BenchmarkRound {
                 "gym '{}' resolved ({origin}) but holds zero tasks — nothing to round on",
                 p.benchmark
             )));
+        }
+
+        // 1.5. Idempotence at DISPATCH scope: a detached round in flight for this
+        //      benchmark is THE round — report it, never mint a sibling (live-measured
+        //      hole: two fresh runs from two invocations 90s apart). A different
+        //      benchmark's round holding the arena refuses loudly.
+        match gate_on_in_flight(&detached_evals_in_flight(), &p.benchmark) {
+            Some(Ok(rid)) => {
+                let ledger_probe = progress_ledger_dir()
+                    .map(|d| {
+                        d.read_dir()
+                            .ok()
+                            .map(|entries| {
+                                entries
+                                    .flatten()
+                                    .filter(|e| {
+                                        e.path().extension().and_then(|x| x.to_str())
+                                            == Some("jsonl")
+                                    })
+                                    .filter_map(|e| std::fs::read_to_string(e.path()).ok())
+                                    .collect::<Vec<_>>()
+                                    .join("\n")
+                            })
+                            .unwrap_or_default() // unreadable ledger dir = 0 graded shown; the run handle is still correct
+                    })
+                    .unwrap_or_default(); // no HOME = no ledger = 0 graded shown, handle still correct
+                let graded = graded_task_ids_from(&ledger_probe, &rid).len() as u32;
+                return Ok(BenchmarkRoundResult {
+                    run_id: rid,
+                    resumed: false,
+                    complete: false,
+                    already_running: true,
+                    benchmark: p.benchmark,
+                    eval_set: origin,
+                    total: all_tasks.len() as u32,
+                    graded,
+                    remaining: all_tasks.len() as u32 - graded,
+                    note: "this round is already in flight — nothing dispatched; poll \
+                           cognition/eval-status"
+                        .into(),
+                });
+            }
+            Some(Err(msg)) => return Err(CommandError::Invalid(msg)),
+            None => {}
         }
 
         // 2. Persona: named, or the sole online citizen. Zero/several online →
@@ -364,5 +429,37 @@ mod tests {
         );
         // Unknown gym → nothing to resume.
         assert_eq!(latest_round_run_id(&text, "nope.jsonl"), None);
+    }
+
+    // what this catches (live, 2026-08-24, runs 4ae8e14c + 912de04f): a round's first
+    // task grades ~30min after dispatch; until then the ledger has no rows and the
+    // resume scan sees nothing, so a re-invoked verb minted a DUPLICATE fresh run.
+    // The gate must answer from DISPATCH-time state: same benchmark in flight →
+    // report that run; a different one → refuse loudly (evals serialize, a second
+    // dispatch silently queues for hours); nothing in flight → dispatch.
+    #[test]
+    fn gate_reports_same_benchmark_refuses_other_dispatches_when_free() {
+        let in_flight = vec![(
+            "run-live".to_string(),
+            "atlas".to_string(),
+            "mirrorcode.jsonl".to_string(),
+        )];
+        assert_eq!(
+            gate_on_in_flight(&in_flight, "mirrorcode.jsonl"),
+            Some(Ok("run-live".to_string())),
+            "same benchmark in flight = THE round — never a sibling"
+        );
+        match gate_on_in_flight(&in_flight, "ds-1000.jsonl") {
+            Some(Err(msg)) => assert!(
+                msg.contains("run-live"),
+                "refusal must name the holding run: {msg}"
+            ),
+            other => panic!("a different round holding the arena must refuse, got {other:?}"),
+        }
+        assert_eq!(
+            gate_on_in_flight(&[], "mirrorcode.jsonl"),
+            None,
+            "nothing in flight = free to dispatch"
+        );
     }
 }


### PR DESCRIPTION
Live-caught 90s after v1 shipped: re-invoking `benchmark/round` before the round's first task graded minted a duplicate fresh run (no ledger rows + no RunMeta scope yet = invisible). Detached evals now register in-memory at dispatch; the verb gates on that registry first — same benchmark → already_running, different benchmark → loud refusal naming the holder, free → dispatch. Pure gate fn + regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo