### PR TITLE
feat(eval): eval.task probe rows carry run_id

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -3957,9 +3957,19 @@ fn report_task_graded(
             bus.publish_async_only("eval:progress", v);
         }
     }
+    // run_id ON the row (2026-08-24, "not good to be so dumb about what's graded"):
+    // an unscoped consumer counting eval.task matches summed every round, sentinel
+    // A/B, and smoke eval ever run — "51 graded" while the live round had zero. The
+    // row itself must carry which round it belongs to.
+    let run_id = CURRENT_RUN_META
+        .lock()
+        .ok()
+        .and_then(|g| g.as_ref().and_then(|m| m.run_id.clone()))
+        .unwrap_or_default(); // sync/handleless run: empty = "no round", honest for a probe field
     crate::probe!(
         class = "eval.task",
         task = task_id,
+        run_id = %run_id,
         ok = ok,
         acts = acts,
         done = done,


### PR DESCRIPTION
Follow-up to the '51 graded' monitor lie: the probe row itself now names its round, so no consumer can count grades unscoped. Pairs with the per-task ledger rows from #2439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo