### PR TITLE
feat(registry): ModelServingPrefs — lane behavior is model truth, not blanket policy

### DIFF
--- a/core/continuum-core/src/cognition/model_resolver/mod.rs
+++ b/core/continuum-core/src/cognition/model_resolver/mod.rs
@@ -294,6 +294,7 @@ mod tests {
             parameter_count: 0,
             sampling: crate::model_registry::types::ModelSampling::default(),
             persona_serving_eligible: true,
+            serving: Default::default(), // test/fixture literal: substrate defaults (text-only main lane, unverified kv-shift)
         }
     }
 

--- a/core/continuum-core/src/cognition/working_memory.rs
+++ b/core/continuum-core/src/cognition/working_memory.rs
@@ -519,30 +519,16 @@ impl WorkingMemory {
             let handle = acts.iter().find_map(|o| o.output.result.spill_handle.clone());
             let mut rr = self.recent_results.lock();
             rr.push_back((seq, room, tail, label, handle));
-            let mut total: usize = rr.iter().map(|(_, _, t, _, _)| t.chars().count() + 1).sum();
-            while total > cap && rr.len() > 1 {
-                if let Some((eseq, _, evicted, elabel, ehandle)) = rr.pop_front() {
-                    total -= evicted.chars().count() + 1;
-                    // COLLAPSE, never delete: the evicted result leaves a
-                    // queryable one-line pointer (its spill handle when the
-                    // full body is on disk via tool/output; else its identity
-                    // so she can re-run deliberately instead of forgetting it
-                    // ever happened).
-                    let mut ptrs = self.evicted_pointers.lock();
-                    ptrs.push_back(match &ehandle {
-                        Some(h) => format!(
-                            "[result #{eseq} ({elabel}) — collapsed; full output: tool/output {h}]"
-                        ),
-                        None => format!(
-                            "[result #{eseq} ({elabel}, {} chars) — collapsed from view; re-run if needed]",
-                            evicted.chars().count()
-                        ),
-                    });
-                    while ptrs.len() > 12 {
-                        ptrs.pop_front();
-                    }
-                }
-            }
+            // NO mid-settle eviction (2026-08-24, the third head-rotation): evicting
+            // here pop_fronted the ring on every act past ~3, and on a model whose KV
+            // cannot shift (`ModelServingPrefs::kv_shiftable = Some(false)` — llama:
+            // "cache_reuse is not supported by this context") every byte after the
+            // rotation re-prefilled, pinning reuse at the system head for the whole
+            // act loop. Within one settle the ring only APPENDS — the served window
+            // (via fit_messages) is the real mid-settle bound, and the eval budget
+            // dwarfs any task's ring. The cap is enforced at SETTLEMENT
+            // ([`Self::record_settlement`] → `collapse_results_over_cap`), the
+            // boundary where the prompt re-prefills anyway.
         }
         // Head into the rolling recency trail: proprioception ("I did #n X") + the
         // repeat-break signal. Truncation lives HERE now (one place), so callers pass the
@@ -1056,7 +1042,42 @@ impl WorkingMemory {
     /// (identical call re-issued WITHIN one settling, before any answer) from a
     /// legitimate re-use of the same tool for a genuinely NEW concern after an answer.
     /// Blank is ignored. Oldest ages out past capacity, same rolling scratchpad.
+    /// Enforce the recent-results char cap by COLLAPSING oldest entries to
+    /// queryable pointers (spill handle when the body is on disk; identity
+    /// otherwise). Called at SETTLEMENT — never mid-settle, where a pop_front
+    /// rotates the prompt head and re-prefills everything after it on a
+    /// non-KV-shiftable model (the 2026-08-24 reuse collapse).
+    fn collapse_results_over_cap(&self) {
+        let cap = self.budget().recent_results_chars();
+        let mut rr = self.recent_results.lock();
+        let mut total: usize = rr.iter().map(|(_, _, t, _, _)| t.chars().count() + 1).sum();
+        while total > cap && rr.len() > 1 {
+            if let Some((eseq, _, evicted, elabel, ehandle)) = rr.pop_front() {
+                total -= evicted.chars().count() + 1;
+                // COLLAPSE, never delete: the evicted result leaves a queryable
+                // one-line pointer so she can expand or re-run deliberately
+                // instead of forgetting it ever happened.
+                let mut ptrs = self.evicted_pointers.lock();
+                ptrs.push_back(match &ehandle {
+                    Some(h) => format!(
+                        "[result #{eseq} ({elabel}) — collapsed; full output: tool/output {h}]"
+                    ),
+                    None => format!(
+                        "[result #{eseq} ({elabel}, {} chars) — collapsed from view; re-run if needed]",
+                        evicted.chars().count()
+                    ),
+                });
+                while ptrs.len() > 12 {
+                    ptrs.pop_front();
+                }
+            }
+        }
+    }
+
     pub fn record_settlement(&self, answer_head: &str) {
+        // Deferred ring hygiene: the settle just closed, the next prompt
+        // re-prefills regardless — collapse over-cap results NOW, never mid-settle.
+        self.collapse_results_over_cap();
         let a = answer_head.trim();
         let mut e = self.entries.lock();
         e.push_back(WmEntry {
@@ -1395,19 +1416,29 @@ mod tests {
             block.contains("E0601"),
             "the compile error must survive later trivial acts: {block}"
         );
-        // Bound: flooding with huge results evicts oldest, never grows unbounded.
+        // PREMISE CHANGED (2026-08-24, the third head-rotation): mid-settle the
+        // ring only APPENDS — per-act eviction pop_fronted the prompt's head and
+        // re-prefilled everything after it on a non-KV-shiftable model. The bound
+        // is enforced at SETTLEMENT (the boundary where the prompt re-prefills
+        // anyway). So: flooding mid-settle keeps everything visible…
         let cap = wm.budget().recent_results_chars();
         for _ in 0..8 {
             wm.record_receipt(&"x".repeat(cap));
         }
+        assert!(
+            wm.recent_results_block().unwrap_or_default().contains("E0601"),
+            "mid-settle the ring is append-only — no head rotation before settlement"
+        );
+        // …and SETTLEMENT collapses over-cap tails to pointers, restoring the bound.
+        wm.record_settlement("done");
         let total: usize = wm.recent_results_block().unwrap_or_default().chars().count();
         assert!(
             total <= cap + 256,
-            "buffer must respect its window-derived bound: {total} > {cap}"
+            "settlement must restore the window-derived bound: {total} > {cap}"
         );
         assert!(
             !wm.recent_results_block().unwrap_or_default().contains("E0601"),
-            "oldest tails evict when the bound is hit — bounded, not immortal"
+            "oldest tails collapse to pointers at settlement — bounded, not immortal"
         );
     }
 

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -2719,15 +2719,26 @@ impl LlamaServerControl for LlamaServerProcess {
         // description bridge take over — the exact flow every text-only mind
         // already uses. One sight path, not two. The mmproj artifact stays
         // resolved/fetched for the sidecar's use.
-        let mmproj: Option<std::path::PathBuf> = None;
-        if crate::model_registry::artifacts::resolve_mmproj_for_model(&target.model).is_some() {
+        // MODEL TRUTH, not blanket policy (Joel 2026-08-24: "we are not designing
+        // around one model but many"): the row's `serving.mmproj_on_main_lane`
+        // decides. Default FALSE (text-only main lane, cache_reuse alive); a
+        // VL-first deployment opts in per model and pays the reuse cost knowingly.
+        let resolved_mmproj =
+            crate::model_registry::artifacts::resolve_mmproj_for_model(&target.model);
+        let mmproj: Option<std::path::PathBuf> = if target.model.serving.mmproj_on_main_lane {
+            resolved_mmproj.clone()
+        } else {
+            None
+        };
+        if mmproj.is_none() && resolved_mmproj.is_some() {
             crate::probe!(
                 class = "serving.vision.mmproj_withheld",
                 model = %target.model.id,
-                "mmproj resolved but WITHHELD from the main lane (multimodal disables \
-                 cache_reuse); sight routes via the vision sidecar + description bridge"
+                "mmproj resolved but WITHHELD from the main lane (model row: \
+                 mmproj_on_main_lane=false — multimodal disables cache_reuse); sight \
+                 routes via the vision sidecar + description bridge"
             );
-        } else if target
+        } else if resolved_mmproj.is_none() && target
             .model
             .capabilities
             .contains(&crate::model_registry::Capability::Vision)
@@ -3647,6 +3658,7 @@ mod tests {
                 parameter_count: 0,
                 sampling: crate::model_registry::types::ModelSampling::default(),
                 persona_serving_eligible: true,
+                serving: Default::default(), // test/fixture literal: substrate defaults (text-only main lane, unverified kv-shift)
             },
             context_window: 32768,
             lanes: 1,

--- a/core/continuum-core/src/inference/llamacpp_adapter.rs
+++ b/core/continuum-core/src/inference/llamacpp_adapter.rs
@@ -1548,6 +1548,7 @@ mod tests {
             parameter_count: 0,
             sampling: crate::model_registry::types::ModelSampling::default(),
             persona_serving_eligible: true,
+            serving: Default::default(), // test/fixture literal: substrate defaults (text-only main lane, unverified kv-shift)
         }
     }
 

--- a/core/continuum-core/src/inference/vision_sidecar.rs
+++ b/core/continuum-core/src/inference/vision_sidecar.rs
@@ -281,6 +281,7 @@ mod tests {
             parameter_count: 0,
             sampling: crate::model_registry::types::ModelSampling::default(),
             persona_serving_eligible: true,
+            serving: Default::default(), // test/fixture literal: substrate defaults (text-only main lane, unverified kv-shift)
         }
     }
 

--- a/core/continuum-core/src/ipc/positron_foundry_source.rs
+++ b/core/continuum-core/src/ipc/positron_foundry_source.rs
@@ -90,6 +90,7 @@ mod tests {
                 parameter_count: params,
                 sampling: crate::model_registry::types::ModelSampling::default(),
                 persona_serving_eligible: true,
+                serving: Default::default(), // test/fixture literal: substrate defaults (text-only main lane, unverified kv-shift)
             },
             status: ModelStatus {
                 availability: Availability::Ready,

--- a/core/continuum-core/src/model_registry/artifacts.rs
+++ b/core/continuum-core/src/model_registry/artifacts.rs
@@ -645,6 +645,7 @@ mod tests {
             parameter_count: 0,
             sampling: crate::model_registry::types::ModelSampling::default(),
             persona_serving_eligible: true,
+            serving: Default::default(), // test/fixture literal: substrate defaults (text-only main lane, unverified kv-shift)
         }
     }
 

--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -6,7 +6,7 @@
 
 use super::registry::{Registry, RegistryError};
 use super::types::{
-    Arch, AuthKind, Capability, Model, ModelSampling, MultiPartyChatStrategy, Provider,
+    Arch, AuthKind, Capability, Model, ModelSampling, ModelServingPrefs, MultiPartyChatStrategy, Provider,
     ProviderCapabilities, ProviderKind, ToolProtocol,
 };
 use std::collections::BTreeSet;
@@ -629,6 +629,15 @@ pub fn models() -> Vec<Model> {
             chat_template: None,
             multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
             stop_sequences: &["<|im_end|>"],
+            // MEASURED 2026-08-24 (llama-server load log, this M5): cache_reuse is
+            // disabled BOTH ways for this model — "not supported by multimodal"
+            // (mmproj) and "not supported by this context" (hybrid attention can't
+            // KV-shift). Main lane stays text-only (the default) and prompt shaping
+            // must treat this row's prefix as extend-only.
+            serving: ModelServingPrefs {
+                mmproj_on_main_lane: false,
+                kv_shiftable: Some(false),
+            },
             ..ModelSpec::default()
         }),
         // Hermes-3-Llama-3.1-8B — the OPPONENT, made first-class. A general (non-coder) model we
@@ -1371,6 +1380,9 @@ struct ModelSpec {
     /// opponents / campaign-roster rows opt OUT so the autonomic planner can
     /// never conscript them as the citizens' model.
     persona_serving_eligible: bool,
+    /// Per-model serving truths ([`ModelServingPrefs`]) — defaults via
+    /// `..Default::default()`; only a model we've MEASURED overrides.
+    serving: ModelServingPrefs,
 }
 
 impl Default for ModelSpec {
@@ -1395,6 +1407,7 @@ impl Default for ModelSpec {
             stop_sequences: &[],
             sampling: ModelSampling::default(),
             persona_serving_eligible: true,
+            serving: ModelServingPrefs::default(),
         }
     }
 }
@@ -1425,6 +1438,7 @@ fn model(spec: ModelSpec) -> Model {
         multi_party_strategy: spec.multi_party_strategy,
         stop_sequences: spec.stop_sequences.iter().map(|s| s.to_string()).collect(),
         sampling: spec.sampling,
+        serving: spec.serving,
         // Not a hand-authored fact: the size comes from the artifact's own
         // `general.parameter_count` header, hydrated once at registry load
         // ([`super::hydrate`]). The `ModelSpec` deliberately omits it so no

--- a/core/continuum-core/src/model_registry/hydrate.rs
+++ b/core/continuum-core/src/model_registry/hydrate.rs
@@ -271,6 +271,7 @@ mod tests {
             parameter_count: 0,
             sampling: crate::model_registry::types::ModelSampling::default(),
             persona_serving_eligible: true,
+            serving: Default::default(), // test/fixture literal: substrate defaults (text-only main lane, unverified kv-shift)
         }
     }
 

--- a/core/continuum-core/src/model_registry/types.rs
+++ b/core/continuum-core/src/model_registry/types.rs
@@ -344,6 +344,39 @@ pub struct ModelSampling {
     pub frequency_penalty: f32,
 }
 
+/// Per-model SERVING truths (2026-08-24) — how this model behaves on a llama
+/// lane, stamped where measured. The substrate serves MANY models; anything a
+/// lane decision branches on lives HERE as model truth, never as a blanket
+/// policy that bakes one model's quirk into the architecture (Joel: "we are not
+/// designing around one model but many").
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelServingPrefs {
+    /// Load the vision projector on the MAIN persona lane. Default FALSE:
+    /// llama-server hard-disables `--cache-reuse` on a multimodal lane
+    /// ("cache_reuse is not supported by multimodal"), and chunk reuse is worth
+    /// ~60-90s of re-prefill per act to every persona. Sight then routes through
+    /// the vision sidecar + description bridge — the same path every text-only
+    /// mind uses. A VL-first deployment (live-call heavy, KV economy secondary)
+    /// opts IN per model.
+    pub mmproj_on_main_lane: bool,
+    /// Can this model's KV cache shift (llama context-shift / cache_reuse
+    /// realignment)? `None` = unverified. `Some(false)` = measured incapable
+    /// (hybrid/SWA attention — llama logs "cache_reuse is not supported by this
+    /// context"): prompt shaping must then treat the prefix as EXTEND-ONLY,
+    /// because any interior mutation re-prefills everything after it.
+    pub kv_shiftable: Option<bool>,
+}
+
+impl Default for ModelServingPrefs {
+    fn default() -> Self {
+        Self {
+            mmproj_on_main_lane: false,
+            kv_shiftable: None,
+        }
+    }
+}
+
 impl Default for ModelSampling {
     /// The substrate floor — conservative chat defaults + the #181 anti-loop
     /// pair. The ONE place these numbers live; `SamplingProfile::chat_defaults`
@@ -496,6 +529,11 @@ pub struct Model {
     /// row that doesn't tune sampling is byte-identical to the pre-#76 default.
     #[serde(default)]
     pub sampling: ModelSampling,
+    /// Per-model serving truths (see [`ModelServingPrefs`]) — lane decisions
+    /// branch on the ROW, never on a hardcoded model name. Omitted rows get the
+    /// defaults (text-only main lane, unverified kv-shift) via serde.
+    #[serde(default)]
+    pub serving: ModelServingPrefs,
     /// Whether the autonomic serving planner may pick this row to host the
     /// PERSONAS. Benchmark opponents and campaign-roster rows carry real Ready
     /// GGUFs (so the matrix can serve them on demand) but must NEVER be

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -4392,6 +4392,7 @@ mod tests {
             parameter_count: 0,
             sampling: crate::model_registry::types::ModelSampling::default(),
             persona_serving_eligible: true,
+            serving: Default::default(), // test/fixture literal: substrate defaults (text-only main lane, unverified kv-shift)
         }
     }
 

--- a/core/continuum-core/src/persona/profile_builder.rs
+++ b/core/continuum-core/src/persona/profile_builder.rs
@@ -301,6 +301,7 @@ mod tests {
             parameter_count: 0,
             sampling,
             persona_serving_eligible: true,
+            serving: Default::default(), // test/fixture literal: substrate defaults (text-only main lane, unverified kv-shift)
         };
         Arc::new(
             Registry::from_catalog(vec![model], vec![llamacpp_provider]).expect("build registry"),

--- a/core/continuum-core/src/persona/spawner.rs
+++ b/core/continuum-core/src/persona/spawner.rs
@@ -174,6 +174,7 @@ mod tests {
             parameter_count: 0,
             sampling: crate::model_registry::types::ModelSampling::default(),
             persona_serving_eligible: true,
+            serving: Default::default(), // test/fixture literal: substrate defaults (text-only main lane, unverified kv-shift)
         };
         Arc::new(
             Registry::from_catalog(vec![qwen25_05b], vec![llamacpp_provider])

--- a/core/continuum-core/src/sensory/mod.rs
+++ b/core/continuum-core/src/sensory/mod.rs
@@ -167,6 +167,7 @@ mod tests {
             parameter_count: 0,
             sampling: crate::model_registry::types::ModelSampling::default(),
             persona_serving_eligible: true,
+            serving: Default::default(), // test/fixture literal: substrate defaults (text-only main lane, unverified kv-shift)
         };
         m.capabilities.extend(caps.iter().copied());
         m


### PR DESCRIPTION
Follow-up to #2444 per Joel: the text-only-main-lane rule becomes a per-model row (`mmproj_on_main_lane`, default false) plus `kv_shiftable` (measured context-shift capability — Ornith stamps `Some(false)` from its own load log). The spawn reads the row; prompt shaping gains the truth it needs to go extend-only per model. ModelSampling pattern throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo