### PR TITLE
feat(eval): DoD verify loop — settle-red re-drives until green or exhausted

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -4604,12 +4604,27 @@ async fn run_pass(
         // words — ground truth, not steering) and one bounded re-drive to
         // fix. A green DoD here is also the grade (no double run below).
         let mut presettle_dod: Option<(bool, String)> = None;
+        // VERIFY LOOP, not a single retry (2026-08-24, the score-lever pass): while
+        // budget remains, a DoD task may not settle red. Each iteration re-runs the
+        // task's OWN definition-of-done and hands her its output — ground truth she
+        // could produce herself (the DoD is part of the task, so no answer-key
+        // leak; artifact-test tasks stay excluded for exactly that reason). Bounded
+        // at 2 re-drives: the third red verdict grades as the miss it is.
+        const DOD_REDRIVES: u32 = 2;
+        let mut redrive_round = 0u32;
         if let Some(dod) = &t.dod_shell {
+            loop {
             let (dod_ok, dod_out) = run_dod(task_root.map(std::path::Path::new), dod).await;
-            if !dod_ok {
+            if dod_ok || redrive_round >= DOD_REDRIVES {
+                presettle_dod = Some((dod_ok, dod_out));
+                break;
+            }
+            redrive_round += 1;
+            {
                 crate::probe!(
                     class = "eval.task.red_build_redrive",
                     task = %t.id,
+                    round = redrive_round as u64,
                     "settled on a RED DoD — handing her the verdict with a bounded re-drive"
                 );
                 let tail: String = dod_out.chars().rev().take(4000).collect::<Vec<_>>().into_iter().rev().collect();
@@ -4655,9 +4670,8 @@ Fix the workspace and finish —                              the grade reads th
                         settled = re;
                     }
                 }
-                // The re-drive's own DoD verdict is taken fresh below.
-            } else {
-                presettle_dod = Some((dod_ok, dod_out));
+                // Loop re-runs the DoD fresh; green (or exhausted rounds) exits above.
+            }
             }
         }
         let answer = settled.spoken.clone().unwrap_or_default();
@@ -4689,9 +4703,10 @@ Fix the workspace and finish —                              the grade reads th
         } else if let Some(dod) = &t.dod_shell {
             // REAL task: run the definition-of-done against the repo state her edits produced.
             match presettle_dod.take() {
-                // Pre-settle DoD already ran GREEN and nothing re-drove — that verdict IS the grade.
+                // The verify loop's LAST DoD run IS the grade — green or exhausted-red,
+                // never a double run.
                 Some(v) => v,
-                None => run_dod(task_root.map(std::path::Path::new), dod).await,
+                None => run_dod(task_root.map(std::path::Path::new), dod).await, // unreachable for dod tasks (loop always sets it); kept as the honest fallback
             }
         } else if t.test.is_some() {
             // UNREACHABLE by construction: `require_hands_for_code` gives every `test`-carrying

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -2141,6 +2141,31 @@ impl Faculty for LlmDeliberationFaculty {
         // musing or a long ambient turn. Directed calls take from the full pool. Scoped to a
         // block so every lane releases the instant generation returns — downstream
         // capture/parse/act hold nothing. [[conversational-latency-is-a-misdirection-budget]]
+        // WIRE CAPTURE (2026-08-24, the churn hunt's missing instrument): when
+        // `SERVING_WIRE_CAPTURE_DIR` is configured (config.env — same channel as
+        // SERVING_KV_CACHE_TYPE), append this request's EXACT message list to
+        // `<dir>/<persona>.wire.jsonl` before it ships. Byte-diffing consecutive
+        // rows names the precise prompt position where the KV prefix dies —
+        // today that diagnosis ran on the BID capture, which is not the wire,
+        // and misled twice. Off (unset) = zero cost, zero IO — the Noop default
+        // every capture sink owes the hot path.
+        if let Some(dir) = crate::config_env::read("SERVING_WIRE_CAPTURE_DIR") {
+            let row = serde_json::json!({
+                "ts_ms": crate::persona::trace::now_ms(),
+                "persona": self.persona_name,
+                "messages": request
+                    .messages
+                    .iter()
+                    .map(|m| serde_json::json!({"role": m.role, "text": m.content_text()}))
+                    .collect::<Vec<_>>(),
+            });
+            let path = std::path::Path::new(&dir).join(format!("{}.wire.jsonl", self.persona_name));
+            let _ = std::fs::create_dir_all(&dir);
+            use std::io::Write as _;
+            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+                let _ = writeln!(f, "{row}");
+            }
+        }
         let gen_result = {
             let _lane =
                 crate::cognition::resource_admission::acquire_serving_lane(ws.directed_at_self)

--- a/core/continuum-core/src/system_resources/disk_eviction.rs
+++ b/core/continuum-core/src/system_resources/disk_eviction.rs
@@ -670,6 +670,13 @@ mod tests {
         let owned = ["cargo-target", "genome-models", "logs", "probes"];
         let deferred = [
             ("hf-hub", "#155: hub LRU keyed on last-access — downloads are re-fetchable"),
+            (
+                "eval-captures",
+                "#155: age-based sweep — every file is a re-creatable diagnostic (kv-diag \
+                 snapshots, wire-request jsonl from SERVING_WIRE_CAPTURE_DIR); writers are \
+                 opt-in and quiet by default, so the class grows only while an operator is \
+                 actively hunting. Owner when built: a capped appender like the log pool",
+            ),
             ("citizens", "#155/#49: workspace CoW fix removes the bulk; stores are persona MEMORY, never auto-evicted"),
             // Sibling of `citizens` and inherits its rule: a LIVE mind's longterm.db and
             // working-set.json are MEMORY, never auto-evicted. What IS evictable is the

--- a/core/continuum-core/src/system_resources/disk_reporters.rs
+++ b/core/continuum-core/src/system_resources/disk_reporters.rs
@@ -223,6 +223,11 @@ pub fn standard_tracked_dirs(home: &std::path::Path) -> Vec<Arc<TrackedDir>> {
         // orphaned a full clone that no reporter could see, the silent-class shape
         // the 2026-07-13 incident was about.
         TrackedDir::new("eval-roots", std::env::temp_dir().join("continuum-eval")),
+        // Diagnostic captures: cognition kv-diag snapshots + the wire-request
+        // capture (SERVING_WIRE_CAPTURE_DIR default location). Opt-in writers,
+        // bounded by operator attention in practice — tracked so "in practice"
+        // never becomes the 2026-07-13 silent-class shape.
+        TrackedDir::new("eval-captures", home.join(".continuum/eval-captures")),
     ];
     // Present only when its real location is KNOWN (see the warn above). Kept
     // CONDITIONAL rather than defaulted: fabricating a path here is how a class


### PR DESCRIPTION
Score lever #1: the single red-build re-drive becomes a bounded loop (2 re-drives) driven by the task's own DoD output — self-runnable ground truth, no oracle leak (artifact-test tasks deliberately excluded). Converts the 'found the fix, never verified' miss class into passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo