### PR TITLE
feat(eval): the HELP ARM — peer help as a declared, receipted exam condition

### DIFF
--- a/core/continuum-core/src/airc/inbound_attach.rs
+++ b/core/continuum-core/src/airc/inbound_attach.rs
@@ -276,6 +276,7 @@ pub async fn publish_transcript_event(
                 // never depends on any persona's workspace budget.
                 crate::cognition::deliberation_budget::record_room_speech(
                     event.room_id.as_uuid(),
+                    Some(event.peer_id.as_uuid()),
                     payload["content"].as_str().unwrap_or_default(),
                 );
                 bus.publish_async_only(name, payload);
@@ -334,6 +335,7 @@ pub async fn publish_transcript_event(
         // #264: room-speech ring — same single-seam record as the plain arm.
         crate::cognition::deliberation_budget::record_room_speech(
             event.room_id.as_uuid(),
+            Some(event.peer_id.as_uuid()),
             payload["content"].as_str().unwrap_or_default(),
         );
         bus.publish_async_only(name, payload);

--- a/core/continuum-core/src/cognition/deliberation_budget.rs
+++ b/core/continuum-core/src/cognition/deliberation_budget.rs
@@ -232,12 +232,47 @@ fn room_speech_rings() -> &'static std::sync::Mutex<
     RINGS.get_or_init(Default::default)
 }
 
+/// One live room utterance, as the fan-out channel carries it (help-arm /
+/// team-exam perception — the rung-one wire of room collaboration).
+#[derive(Debug, Clone)]
+pub struct RoomSpeech {
+    pub room: uuid::Uuid,
+    /// Who spoke — `None` for legacy call sites that predate sender plumbing.
+    pub sender: Option<uuid::Uuid>,
+    pub content: String,
+}
+
+/// Live fan-out beside the ring (2026-08-24, the help arm): every room message
+/// already crosses THIS one seam, so a subscriber here perceives room speech
+/// without a module registration — the exam fork's help-channel listener is the
+/// first consumer; team exams and cross-activity coordination ride the same
+/// wire. Bounded lossy broadcast: a slow subscriber drops oldest (Lagged), the
+/// seam never blocks.
+static ROOM_SPEECH_TX: std::sync::OnceLock<tokio::sync::broadcast::Sender<RoomSpeech>> =
+    std::sync::OnceLock::new();
+
+fn room_speech_tx() -> &'static tokio::sync::broadcast::Sender<RoomSpeech> {
+    ROOM_SPEECH_TX.get_or_init(|| tokio::sync::broadcast::channel(256).0)
+}
+
+/// Subscribe to live room speech (all rooms; filter by `room` at the receiver).
+pub fn subscribe_room_speech() -> tokio::sync::broadcast::Receiver<RoomSpeech> {
+    room_speech_tx().subscribe()
+}
+
 /// Record one room message (call at the inbound-attach projection seam —
-/// once per message, never per receiving persona).
-pub fn record_room_speech(room: uuid::Uuid, content: &str) {
+/// once per message, never per receiving persona). `sender` rides into the
+/// live fan-out so a listener knows WHO spoke (a voice without a speaker
+/// cannot become a relationship); the restatement ring stays content-only.
+pub fn record_room_speech(room: uuid::Uuid, sender: Option<uuid::Uuid>, content: &str) {
     if content.trim().is_empty() {
         return;
     }
+    let _ = room_speech_tx().send(RoomSpeech {
+        room,
+        sender,
+        content: content.to_string(),
+    }); // no receivers = no listeners right now; the ring below is the durable half
     let mut rings = room_speech_rings().lock().unwrap();
     let ring = rings.entry(room).or_default();
     ring.push_back(content.to_string());

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -1695,6 +1695,15 @@ pub struct CognitionEvalParams {
     )]
     #[ts(optional)]
     pub suppress_recall: Option<bool>,
+    /// HELP ARM (rung one of room collaboration, 2026-08-24): when true and the
+    /// eval is room-scoped, the exam condition DECLARES that asking peers is
+    /// legal — the task prompts say so, and a listener folds live room speech
+    /// from OTHERS into the fork's working memory so she perceives replies
+    /// between acts. Exchanges are receipts in the transcript; score under this
+    /// arm is reported as OURS+help, never conflated with solo. Default off.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub help: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -2192,6 +2201,18 @@ impl CognitionEval {
         // load paths converge, so an inline task from a command payload obeys the same rule as a
         // committed gym line. There is no loader path to a mouth-graded code task.
         for t in tasks.iter_mut() {
+            if p.help.unwrap_or(false) { // omitted = solo arm; the condition text only appears when declared
+                // The arm's condition is DECLARED to the examinee — help is a rule
+                // of this exam, not a secret channel. [[exams-are-taken-with-full-
+                // grid-backed-capacity-disclosed]]
+                t.prompt.push_str(
+                    "\n\n[Exam condition — help arm] Asking for help is LEGAL in this exam \
+                     and counts in your favor when used well: post a question to your room \
+                     (chat tools) stating what you tried, what you expected, and what \
+                     happened. Replies from peers appear in your working memory as \
+                     `voice:` entries. All exchanges are recorded receipts.",
+                );
+            }
             t.require_hands_for_code();
         }
 
@@ -2730,6 +2751,49 @@ impl CognitionEval {
             drop(reviewer_iso);
             out
         } else {
+            // HELP ARM: subscribe the fork's perception to live room speech for the
+            // exam's duration. Peers' words land in her working memory as labeled
+            // voices (perception through a channel, never a memory write from
+            // outside); her own posts are skipped. Guard aborts with the pass.
+            let _help_guard = if p.help.unwrap_or(false) && room != Uuid::nil() { // omitted arm flag = solo, the default
+                let wm = cycle.acting().map(|b| std::sync::Arc::clone(&b.working_memory));
+                wm.map(|wm| {
+                    let mut rx = crate::cognition::deliberation_budget::subscribe_room_speech();
+                    let me = persona_uuid;
+                    let handle = tokio::spawn(async move {
+                        loop {
+                            match rx.recv().await {
+                                Ok(sp) => {
+                                    if sp.room != room || sp.sender == Some(me) {
+                                        continue;
+                                    }
+                                    let who = sp
+                                        .sender
+                                        .map(|u| u.to_string()[..8].to_string())
+                                        .unwrap_or_else(|| "peer".into()); // legacy senderless call site: an anonymous voice, labeled as such
+                                    wm.record_dispatch_event(
+                                        Uuid::new_v4(),
+                                        &format!("voice:{who}"),
+                                        &sp.content,
+                                        crate::cognition::working_memory::DispatchStatus::Done,
+                                    );
+                                    crate::probe!(
+                                        class = "eval.help.voice_folded",
+                                        room = %room,
+                                        sender = %who,
+                                        "help arm: a peer's words reached the examinee's perception"
+                                    );
+                                }
+                                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                                Err(_) => break,
+                            }
+                        }
+                    });
+                    scopeguard_abort(handle)
+                })
+            } else {
+                None
+            };
             run_pass(
                 &cycle,
                 &isolation,
@@ -3969,6 +4033,18 @@ fn eval_progress_tx() -> &'static tokio::sync::watch::Sender<Option<EvalPassProg
 /// Subscribe to live eval progress — the watch every reader shares.
 pub fn subscribe_eval_progress() -> tokio::sync::watch::Receiver<Option<EvalPassProgress>> {
     eval_progress_tx().subscribe()
+}
+
+/// RAII abort for a spawned helper task — dropped with the pass, so the help
+/// listener can never outlive the exam it serves.
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+fn scopeguard_abort(h: tokio::task::JoinHandle<()>) -> AbortOnDrop {
+    AbortOnDrop(h)
 }
 
 /// The idle-backstop verdict: an infra outcome whose probe is a SUBSTRATE BUG

--- a/core/continuum-core/src/commands/benchmark_round.rs
+++ b/core/continuum-core/src/commands/benchmark_round.rs
@@ -52,6 +52,12 @@ pub struct BenchmarkRoundParams {
     #[ts(optional)]
     #[ts(optional, type = "number")]
     pub limit: Option<u32>,
+    /// HELP ARM: declare peer help legal for this round (see
+    /// `CognitionEvalParams::help`). Scores report as OURS+help; solo stays the
+    /// default arm.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub help: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -375,6 +381,7 @@ impl ActionCommand for BenchmarkRound {
             capture_dir: None,
             learn: LearningPolicy::LearnFromThisWork,
             suppress_recall: None,
+            help: p.help, // arm rides the round declaration through to the eval
         };
         let ctx = Ctx {
             handle: None,

--- a/core/continuum-core/src/modules/chat/mod.rs
+++ b/core/continuum-core/src/modules/chat/mod.rs
@@ -548,7 +548,11 @@ impl ChatModule {
             let (Some(room), Some(text)) = (room, text) else {
                 continue;
             };
-            crate::cognition::deliberation_budget::record_room_speech(room, text);
+            let speech_sender = msg
+                .get("senderId")
+                .and_then(Value::as_str)
+                .and_then(|s| uuid::Uuid::parse_str(s).ok());
+            crate::cognition::deliberation_budget::record_room_speech(room, speech_sender, text);
             if let Some(sender) = msg
                 .get("senderId")
                 .and_then(Value::as_str)

--- a/core/continuum-core/src/modules/training_completion_sentinel.rs
+++ b/core/continuum-core/src/modules/training_completion_sentinel.rs
@@ -195,6 +195,7 @@ impl TrainingCompletionSentinel {
                 // #207: L3 auto-eval measures LIFT (base vs gene in one fork), which is
                 // reproducible regardless of recall; keep memories intact (default).
                 suppress_recall: None,
+            help: None, // solo arm — help is a declared per-round condition, never a default
                 note: Some(format!(
                     "L3 auto-eval (gene={}, base={}, provider={})",
                     job.trait_kind, job.base_model, job.handle.provider_id

--- a/protocol/typescript/benchmark/BenchmarkRoundParams.ts
+++ b/protocol/typescript/benchmark/BenchmarkRoundParams.ts
@@ -20,4 +20,10 @@ fresh?: boolean,
  * Cap the task count of a FRESH run (smoke rounds). Ignored on resume — a
  * resumed round finishes the set it started.
  */
-limit?: number, };
+limit?: number, 
+/**
+ * HELP ARM: declare peer help legal for this round (see
+ * `CognitionEvalParams::help`). Scores report as OURS+help; solo stays the
+ * default arm.
+ */
+help?: boolean, };


### PR DESCRIPTION
Rung one of room collaboration: a sender-carrying room-speech broadcast at the one seam every message crosses; an eval arm that declares help legal in the task prompts and folds peers' live words into the examinee's perception as voice: entries; round-level pass-through reporting as OURS+help. Retention is graded by the next solo round — the remembering pipeline already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo