### PR TITLE
feat(web): browser-driven search is the auto priority — natural content, no pay-to-play

### DIFF
--- a/core/continuum-core/src/commands/web/mod.rs
+++ b/core/continuum-core/src/commands/web/mod.rs
@@ -107,9 +107,18 @@ const MAX_COUNT: u32 = 20;
 /// floor last). The single source of truth for "which backends exist" — add a
 /// provider here and it is selectable by id and eligible for auto-selection.
 fn all_providers() -> Vec<Box<dyn WebSearchProvider>> {
+    // ORDER IS THE AUTO-PRIORITY (2026-08-25, Joel: 'utilize our own browser as a
+    // possibility, priority'). The browser-driven keyless provider is FIRST, so
+    // auto-selection prefers it: it drives our REAL Chromium (JS-rendered, a
+    // believable UA, Cloudflare/bot-block-resistant) and returns exactly the
+    // natural content a human sees — no meter, no pay-to-play, no key. The paid
+    // Brave API is a deliberate OPT-IN (`adapter: "brave"`) for callers who want
+    // its structured results and hold a key; it no longer silently wins auto just
+    // because a key happens to exist. Same lesson as the operator running out of a
+    // metered search budget: owned-browser natural content beats rented API access.
     vec![
-        Box::new(brave::BraveSearchProvider),
         Box::new(duckduckgo::DuckDuckGoProvider),
+        Box::new(brave::BraveSearchProvider),
     ]
 }
 


### PR DESCRIPTION
Auto-selection now prefers the keyless browser-driven provider (our real Chromium, JS-rendered, Cloudflare-resistant) over the paid Brave API. Dogfood-verified returning the exact astropy pages for the live issue. Brave becomes explicit opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo