### PR TITLE
fix(benchmarks): SWE-Verified adapter uses absolute workspace path

### DIFF
--- a/benchmarks/swe/make_verified_gym.py
+++ b/benchmarks/swe/make_verified_gym.py
@@ -40,8 +40,13 @@ with open(out_path, "w") as out:
                 f"git -C {wdir} checkout --quiet {base}"
             ),
             "dod_shell": (
-                f"continuum benchmark/swe-grade --dataset princeton-nlp/SWE-bench_Verified "
-                f"--instance {iid} --workspace {wdir} | grep -q '\"resolved\": true'"
+                # ABSOLUTE workspace (2026-08-25): swe-grade runs IN THE CORE, so a
+                # relative --workspace resolves against the core cwd, not her eval
+                # workspace (#49 dual-root — astropy-13236 false-failed 'no such file'
+                # with real work in her tree). $PWD in the DoD shell is her workspace
+                # root, so $PWD/<wdir> is the absolute path the core-side git diff reads.
+                f'continuum benchmark/swe-grade --dataset princeton-nlp/SWE-bench_Verified '
+                f'--instance {iid} --workspace "$PWD/{wdir}" | grep -q \'"resolved": true\''
             ),
             "prompt": (
                 f"[SWE-bench Verified · {iid}] A real GitHub issue in {repo}. The repo is "


### PR DESCRIPTION
The first Verified grade (astropy-13236 ok=False) was a HARNESS zero, not a model zero: swe-grade runs in the core process so the relative --workspace resolved against core cwd, not her eval tree. $PWD makes it absolute. Prior round grades invalid; re-running on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo