### PR TITLE
Env walls layer 2: cython<3 ceiling (sklearn), cppy (kiwisolver sdist)

### DIFF
--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -1495,6 +1495,26 @@ fn clear_setuptools_build_debris(repo_dir: &Path) {
     }
 }
 
+/// Per-repo build ENV additions that must ride EVERY editable install of the
+/// repo — fresh build AND cached-env re-point (the re-point rebuilds the same
+/// extensions; matplotlib's vendored-freetype `make` died there twice because
+/// the fix rode only the fresh path). Returns owned pairs; empty for most repos.
+fn repo_build_env(instance: &SweInstance, env_dir: &Path) -> Result<Vec<(String, String)>, String> {
+    if instance.repo == "matplotlib/matplotlib" {
+        // System freetype via MPLSETUPCFG (vendored 2.6.1 predates Apple Silicon).
+        let cfg = env_dir.join("mplsetup.cfg");
+        std::fs::create_dir_all(env_dir)
+            .map_err(|e| format!("could not create {}: {e}", env_dir.display()))?;
+        std::fs::write(&cfg, "[libs]\nsystem_freetype = true\n")
+            .map_err(|e| format!("could not write {}: {e}", cfg.display()))?;
+        return Ok(vec![(
+            "MPLSETUPCFG".to_string(),
+            cfg.to_string_lossy().into_owned(),
+        )]);
+    }
+    Ok(Vec::new())
+}
+
 /// Re-assert the PEP-660 harness floor: setuptools in [64, 70) — the only
 /// window with BOTH `build_editable` (>=64) and `dep_util` (<70). Setuptools is
 /// HARNESS, never subject ([[…]] doctrine at the build_requires site): an
@@ -1545,6 +1565,9 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
             // The cached env may hold an era-swept setuptools (34.x has no
             // build_meta) — floor it before asking for an editable rebuild.
             assert_harness_floor(&uv, &py_s).await?;
+            let repo_env = repo_build_env(instance, &env_dir)?;
+            let mut env_pairs: Vec<(&str, &str)> = ERA_BUILD_ENV.to_vec();
+            env_pairs.extend(repo_env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
             let out = run_env(
                 &uv,
                 &[
@@ -1559,7 +1582,7 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
                     ".",
                 ],
                 Some(repo_dir),
-                ERA_BUILD_ENV,
+                &env_pairs,
             )
             .await?;
             if !out.status.success() {
@@ -1780,7 +1803,8 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
     // era interpreter). Fail-loud when the host lacks it: the message names
     // the exact install command, because "build backend error" is not a fix.
     let mut build_env: Vec<(&str, &str)> = ERA_BUILD_ENV.to_vec();
-    let mpl_cfg_path;
+    // Host-prereq gate for matplotlib's system-freetype build — fail LOUD with
+    // the remedy; "build backend error" is not a fix.
     if instance.repo == "matplotlib/matplotlib" {
         let freetype_ok = match which("pkg-config") {
             Some(pc) => run(&pc, &["--exists", "freetype2"], None)
@@ -1798,12 +1822,9 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
                 instance.instance_id
             ));
         }
-        let cfg = env_dir.join("mplsetup.cfg");
-        std::fs::write(&cfg, "[libs]\nsystem_freetype = true\n")
-            .map_err(|e| format!("could not write {}: {e}", cfg.display()))?;
-        mpl_cfg_path = cfg.to_string_lossy().into_owned();
-        build_env.push(("MPLSETUPCFG", mpl_cfg_path.as_str()));
     }
+    let repo_env = repo_build_env(instance, &env_dir)?;
+    build_env.extend(repo_env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
     let out = era_pinned_uv_install(
         &uv,
         &py_s,

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -1495,6 +1495,23 @@ fn clear_setuptools_build_debris(repo_dir: &Path) {
     }
 }
 
+/// Re-assert the PEP-660 harness floor: setuptools in [64, 70) — the only
+/// window with BOTH `build_editable` (>=64) and `dep_util` (<70). Setuptools is
+/// HARNESS, never subject ([[…]] doctrine at the build_requires site): an
+/// era-pinned resolve that sweeps it to a dated version (sympy-12481's 2017 pin
+/// left 34.3.3 — no `setuptools.build_meta` AT ALL) breaks every later
+/// editable rebuild. Idempotent and seconds-cheap; call it after ANY step that
+/// can move setuptools.
+async fn assert_harness_floor(uv: &str, py: &str) -> Result<(), String> {
+    let _ = run(
+        uv,
+        &["pip", "install", "-q", "--python", py, "setuptools>=64,<70"],
+        None,
+    )
+    .await?;
+    Ok(())
+}
+
 pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathBuf, String> {
     // PER-INSTANCE SERIALIZATION — this function used to rely on "solve/grade
     // run serially per instance"; the dispatch-time env PRE-WARM broke that
@@ -1525,6 +1542,9 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
         // instance so there is no cross-tree race.
         if let Some(uv) = which("uv") {
             let py_s = py.to_string_lossy().to_string();
+            // The cached env may hold an era-swept setuptools (34.x has no
+            // build_meta) — floor it before asking for an editable rebuild.
+            assert_harness_floor(&uv, &py_s).await?;
             let out = run_env(
                 &uv,
                 &[
@@ -1819,6 +1839,11 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
             tail(&stdout)
         ));
     }
+
+    // The era-pinned `-e .` resolve can sweep setuptools into the dated subject
+    // graph (sympy-12481: 2017 pin → setuptools 34.3.3, no build_meta) — every
+    // later re-point then dies. Floor it back: harness, never subject.
+    assert_harness_floor(&uv, &py_s).await?;
 
     // PYTEST IS SUBJECT, NOT HARNESS, for date-pinned instances (#380, glass-boxed
     // 2026-08-12): era test suites import pytest INTERNALS — flask 2.2's test_cli.py does

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -1433,6 +1433,15 @@ fn era_sdist_build_deps(repo: &str) -> &'static [&'static str] {
         // and >=1.13 respectively — both far below any era cap we set), so this widens what
         // BUILDS without smuggling a modern numpy into a date-pinned subject graph.
         "astropy/astropy" => &["jinja2", "numpy"],
+        // Same class, measured at prewarm 2026-08-26 (the seeded-25 round): both
+        // setup.py's import numpy at metadata time under --no-build-isolation.
+        // scikit-learn additionally builds .pyx sources, so cython is a build
+        // dep of the repo itself; matplotlib declares numpy via
+        // `oldest-supported-numpy`, which routinely fails to resolve on a
+        // modern interpreter (the build_requires step warns and proceeds) — a
+        // plain era-pinned numpy here is what actually lands.
+        "scikit-learn/scikit-learn" => &["numpy", "cython"],
+        "matplotlib/matplotlib" => &["numpy", "setuptools_scm", "certifi"],
         _ => &[],
     }
 }
@@ -1527,11 +1536,16 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
             )
             .await?;
             if !out.status.success() {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let tail: String = {
+                    let t = stderr.trim();
+                    t.chars().skip(t.chars().count().saturating_sub(1500)).collect()
+                };
                 return Err(format!(
                     "could not re-point {}'s cached env at {}: {}",
                     instance.instance_id,
                     repo_dir.display(),
-                    String::from_utf8_lossy(&out.stderr).trim()
+                    tail
                 ));
             }
             // An env cached BEFORE the test extra existed is silently ungradeable (its

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -1440,8 +1440,15 @@ fn era_sdist_build_deps(repo: &str) -> &'static [&'static str] {
         // `oldest-supported-numpy`, which routinely fails to resolve on a
         // modern interpreter (the build_requires step warns and proceeds) — a
         // plain era-pinned numpy here is what actually lands.
-        "scikit-learn/scikit-learn" => &["numpy", "cython"],
-        "matplotlib/matplotlib" => &["numpy", "setuptools_scm", "certifi"],
+        // cython<3 is load-bearing: Cython 3 REJECTS 2019-era .pyx (CompileError
+        // on sklearn's own ball_tree.pyx, walk 4 of the seeded-25 prewarm) — and
+        // the era-pin's loud unpinned retry is exactly the path that smuggles
+        // modern cython in when the dated resolve hiccups. The ceiling holds
+        // through BOTH paths; 0.29.x compiles every sklearn era we can meet.
+        "scikit-learn/scikit-learn" => &["numpy", "cython>=0.28,<3"],
+        // cppy: kiwisolver 1.3's sdist imports it at build (walk 4 — the
+        // dependency-sdist class this table exists for, same as astropy→pyerfa→jinja2).
+        "matplotlib/matplotlib" => &["numpy", "setuptools_scm", "certifi", "cppy"],
         _ => &[],
     }
 }

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -116,6 +116,17 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
                 continue;
             }
             if !fast {
+                // TRULY becalmed means NO solve is running anywhere — the fast
+                // window may legitimately fan out boot re-fires, but the slow
+                // watch reviving one more card per tick while solves are LIVE
+                // is drift into parallel solving nobody decided (B7 is a
+                // deliberate, measured decision — never a watchdog side
+                // effect; caught live 2026-08-27, one extra solve per 5min).
+                let live = crate::cognition::swe_bench::in_flight_solve_runs();
+                if !live.is_empty() {
+                    tokio::time::sleep(SLOW_WATCH).await;
+                    continue;
+                }
                 crate::probe!(
                     class = "bench.round.becalmed",
                     unworked = due.len() as u64,

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -105,6 +105,14 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
                 }
                 continue;
             }
+            // Resumed rounds deserve the same env pre-warm dispatch gives fresh
+            // ones — without this, a reboot mid-round re-discovers its env
+            // walls one burned solve attempt at a time (2026-08-27: the
+            // operator hand-worked around it with idempotent re-dispatches).
+            // Once per task lifetime; cheap when everything is already warm.
+            if attempt == 1 {
+                crate::modules::work::spawn_env_prewarm_for_working_rounds();
+            }
             let due = crate::cognition::bench_round::next_unworked_per_round();
             if due.is_empty() {
                 if !crate::cognition::bench_round::any_working_round() {

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -710,6 +710,80 @@ pub(crate) struct StagedSolveDispatch {
 /// 2026-08-11: cards staged + assigned, zero claims, zero solves). The solve is her WHOLE
 /// cognition with an exclusive warm slot (`quiesce_others`), so nothing about "she does the
 /// work herself" changes — only the trigger moves off the chat turn.
+/// Pre-warm envs for every instance a WORKING round has staged — the resume-side
+/// twin of dispatch's pre-warm (a reboot mid-round otherwise re-discovers env
+/// walls one burned solve attempt at a time). The staged workspace dirs
+/// (`peers/<assignee>/workspace/swe/<instance>`) are the reliable card→instance
+/// map; instances resolve through the SAME dataset loader the grader uses.
+pub fn spawn_env_prewarm_for_working_rounds() {
+    tokio::spawn(async move {
+        let peers_root = match crate::commands::benchmark::continuum_home() {
+            Ok(h) => h.join("citizens").join("peers"),
+            Err(_) => return, // no home = nothing staged anywhere
+        };
+        let mut names: std::collections::BTreeSet<String> = Default::default();
+        if let Ok(peers) = std::fs::read_dir(&peers_root) {
+            for peer in peers.flatten() {
+                let swe = peer.path().join("workspace").join("swe");
+                if let Ok(instances) = std::fs::read_dir(&swe) {
+                    for inst in instances.flatten() {
+                        if inst.path().is_dir() {
+                            names.insert(inst.file_name().to_string_lossy().into_owned());
+                        }
+                    }
+                }
+            }
+        }
+        if names.is_empty() {
+            return;
+        }
+        // Resolve each staged name against every SWE dataset in the catalog —
+        // the same search the grade path performs (first dataset holding the
+        // instance wins), so this can never disagree with grading.
+        for name in names {
+            let mut resolved = None;
+            for spec in crate::commands::benchmark::known_benchmarks() {
+                let Some(dataset) = spec.swe_dataset() else { continue };
+                if let Ok(instances) = crate::cognition::swe_bench::load_dataset(dataset).await {
+                    if let Some(i) = instances.into_iter().find(|i| i.instance_id == name) {
+                        resolved = Some(i);
+                        break;
+                    }
+                }
+            }
+            let Some(inst) = resolved else { continue };
+            let checkout = match crate::cognition::swe_bench::ensure_grade_checkout(&inst).await {
+                Ok(dir) => dir,
+                Err(e) => {
+                    crate::probe!(
+                        class = "benchmark.env.prewarm_failed",
+                        instance = %inst.instance_id,
+                        stage = "checkout",
+                        error = %e,
+                        "resume-side env pre-warm could not stage a checkout — an ENV \
+                         failure, not a model result"
+                    );
+                    continue;
+                }
+            };
+            match crate::cognition::swe_bench::ensure_env(&inst, &checkout).await {
+                Ok(_) => crate::probe!(
+                    class = "benchmark.env.prewarmed",
+                    instance = %inst.instance_id,
+                    "resume-side env pre-warm: ready ahead of the driver"
+                ),
+                Err(e) => crate::probe!(
+                    class = "benchmark.env.prewarm_failed",
+                    instance = %inst.instance_id,
+                    stage = "env",
+                    error = %e,
+                    "resume-side env pre-warm FAILED — an ENV failure, never a model result"
+                ),
+            }
+        }
+    });
+}
+
 pub(crate) async fn dispatch_staged_swe_solve(
     ctx: &Ctx,
     airc: &std::sync::Arc<airc_lib::Airc>,


### PR DESCRIPTION
Walk-4 receipts: numpy rows worked, both classes progressed to their next real walls — sklearn's cythonize dies under Cython 3 on era .pyx (ceiling <3 holds through the unpinned-retry path too), matplotlib cleared freetype and hit kiwisolver's sdist importing cppy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo