### PR TITLE
scikit OpenMP repair encoded: CC-embedded libomp flags, gated prereqs, honest pre-0.22 limit

### DIFF
--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -1495,6 +1495,26 @@ fn clear_setuptools_build_debris(repo_dir: &Path) {
     }
 }
 
+/// Per-repo build ENV additions that must ride EVERY editable install of the
+/// repo — fresh build AND cached-env re-point (the re-point rebuilds the same
+/// extensions; matplotlib's vendored-freetype `make` died there twice because
+/// the fix rode only the fresh path). Returns owned pairs; empty for most repos.
+fn repo_build_env(instance: &SweInstance, env_dir: &Path) -> Result<Vec<(String, String)>, String> {
+    if instance.repo == "matplotlib/matplotlib" {
+        // System freetype via MPLSETUPCFG (vendored 2.6.1 predates Apple Silicon).
+        let cfg = env_dir.join("mplsetup.cfg");
+        std::fs::create_dir_all(env_dir)
+            .map_err(|e| format!("could not create {}: {e}", env_dir.display()))?;
+        std::fs::write(&cfg, "[libs]\nsystem_freetype = true\n")
+            .map_err(|e| format!("could not write {}: {e}", cfg.display()))?;
+        return Ok(vec![(
+            "MPLSETUPCFG".to_string(),
+            cfg.to_string_lossy().into_owned(),
+        )]);
+    }
+    Ok(Vec::new())
+}
+
 /// Re-assert the PEP-660 harness floor: setuptools in [64, 70) — the only
 /// window with BOTH `build_editable` (>=64) and `dep_util` (<70). Setuptools is
 /// HARNESS, never subject ([[…]] doctrine at the build_requires site): an
@@ -1545,6 +1565,9 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
             // The cached env may hold an era-swept setuptools (34.x has no
             // build_meta) — floor it before asking for an editable rebuild.
             assert_harness_floor(&uv, &py_s).await?;
+            let repo_env = repo_build_env(instance, &env_dir)?;
+            let mut env_pairs: Vec<(&str, &str)> = ERA_BUILD_ENV.to_vec();
+            env_pairs.extend(repo_env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
             let out = run_env(
                 &uv,
                 &[
@@ -1559,7 +1582,7 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
                     ".",
                 ],
                 Some(repo_dir),
-                ERA_BUILD_ENV,
+                &env_pairs,
             )
             .await?;
             if !out.status.success() {
@@ -1780,7 +1803,8 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
     // era interpreter). Fail-loud when the host lacks it: the message names
     // the exact install command, because "build backend error" is not a fix.
     let mut build_env: Vec<(&str, &str)> = ERA_BUILD_ENV.to_vec();
-    let mpl_cfg_path;
+    // Host-prereq gate for matplotlib's system-freetype build — fail LOUD with
+    // the remedy; "build backend error" is not a fix.
     if instance.repo == "matplotlib/matplotlib" {
         let freetype_ok = match which("pkg-config") {
             Some(pc) => run(&pc, &["--exists", "freetype2"], None)
@@ -1798,12 +1822,9 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
                 instance.instance_id
             ));
         }
-        let cfg = env_dir.join("mplsetup.cfg");
-        std::fs::write(&cfg, "[libs]\nsystem_freetype = true\n")
-            .map_err(|e| format!("could not write {}: {e}", cfg.display()))?;
-        mpl_cfg_path = cfg.to_string_lossy().into_owned();
-        build_env.push(("MPLSETUPCFG", mpl_cfg_path.as_str()));
     }
+    let repo_env = repo_build_env(instance, &env_dir)?;
+    build_env.extend(repo_env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
     let out = era_pinned_uv_install(
         &uv,
         &py_s,

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -1523,9 +1523,26 @@ fn repo_build_env(instance: &SweInstance, env_dir: &Path) -> Result<Vec<(String,
 /// editable rebuild. Idempotent and seconds-cheap; call it after ANY step that
 /// can move setuptools.
 async fn assert_harness_floor(uv: &str, py: &str) -> Result<(), String> {
+    // The floor is a COHERENT TRIO, not setuptools alone (sympy-12481/12489
+    // regressed twice before this was learned): wheel 0.44+ delegates
+    // bdist_wheel to setuptools.command.bdist_wheel, which only exists in
+    // setuptools >=70.1 — above our <70 dep_util ceiling — so wheel must stay
+    // <0.44 (self-contained bdist_wheel). And an era-swept packaging (2017's
+    // 16.8) lacks packaging.tags, which wheel imports. All three are HARNESS:
+    // pure metadata machinery no subject imports, safe at modern-in-window
+    // versions inside any era graph.
     let _ = run(
         uv,
-        &["pip", "install", "-q", "--python", py, "setuptools>=64,<70"],
+        &[
+            "pip",
+            "install",
+            "-q",
+            "--python",
+            py,
+            "setuptools>=64,<70",
+            "wheel>=0.40,<0.44",
+            "packaging>=21",
+        ],
         None,
     )
     .await?;

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -1500,6 +1500,48 @@ fn clear_setuptools_build_debris(repo_dir: &Path) {
 /// extensions; matplotlib's vendored-freetype `make` died there twice because
 /// the fix rode only the fresh path). Returns owned pairs; empty for most repos.
 fn repo_build_env(instance: &SweInstance, env_dir: &Path) -> Result<Vec<(String, String)>, String> {
+    if instance.repo == "scikit-learn/scikit-learn" {
+        // OpenMP on Apple silicon (glass-boxed 2026-08-27, full ladder): Apple
+        // clang rejects bare -fopenmp; numpy.distutils ignores env
+        // CFLAGS/CPPFLAGS entirely, so the ONLY reliable carrier is flags
+        // EMBEDDED IN $CC/$LDSHARED (verified: the exact failing clang line
+        // gained the flags and the C build completed). Needs brew's libomp —
+        // the ensure_env gate below names the remedy when absent.
+        //
+        // KNOWN STRUCTURAL LIMIT, honestly held: sklearn < 0.22 (pre-2019-12)
+        // vendors a cloudpickle that cannot IMPORT on python >= 3.8
+        // (types.CodeType signature), and no 3.7 exists for this platform
+        // (uv ships none for macOS; CPython 3.7 predates Apple silicon). Those
+        // instances stay env-absent natively; the parity path is the official
+        // harness's era containers (docker fallback, tracked on the roadmap).
+        let libomp = std::path::Path::new("/opt/homebrew/opt/libomp");
+        if libomp.join("include/omp.h").exists() {
+            let inc = libomp.join("include").to_string_lossy().into_owned();
+            let lib = libomp.join("lib").to_string_lossy().into_owned();
+            return Ok(vec![
+                (
+                    "CC".into(),
+                    format!(
+                        "clang -Xpreprocessor -fopenmp -I{inc} \
+                         -Wno-error=implicit-function-declaration -Wno-error=int-conversion"
+                    ),
+                ),
+                (
+                    "LDSHARED".into(),
+                    format!("clang -bundle -undefined dynamic_lookup -L{lib} -lomp"),
+                ),
+                // sklearn's darwin branch suppresses bare -fopenmp only when
+                // "openmp" appears in CPPFLAGS — a valid no-op define carries it.
+                ("CPPFLAGS".into(), "-Dopenmp_via_libomp=1".into()),
+            ]);
+        }
+        return Err(format!(
+            "scikit-learn needs OpenMP and this host has no libomp: install it with \
+             `brew install libomp` and re-run — an ENV prerequisite, not a model \
+             result ({})",
+            instance.instance_id
+        ));
+    }
     if instance.repo == "matplotlib/matplotlib" {
         // System freetype via MPLSETUPCFG (vendored 2.6.1 predates Apple Silicon).
         let cfg = env_dir.join("mplsetup.cfg");

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -1495,6 +1495,23 @@ fn clear_setuptools_build_debris(repo_dir: &Path) {
     }
 }
 
+/// Re-assert the PEP-660 harness floor: setuptools in [64, 70) — the only
+/// window with BOTH `build_editable` (>=64) and `dep_util` (<70). Setuptools is
+/// HARNESS, never subject ([[…]] doctrine at the build_requires site): an
+/// era-pinned resolve that sweeps it to a dated version (sympy-12481's 2017 pin
+/// left 34.3.3 — no `setuptools.build_meta` AT ALL) breaks every later
+/// editable rebuild. Idempotent and seconds-cheap; call it after ANY step that
+/// can move setuptools.
+async fn assert_harness_floor(uv: &str, py: &str) -> Result<(), String> {
+    let _ = run(
+        uv,
+        &["pip", "install", "-q", "--python", py, "setuptools>=64,<70"],
+        None,
+    )
+    .await?;
+    Ok(())
+}
+
 pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathBuf, String> {
     // PER-INSTANCE SERIALIZATION — this function used to rely on "solve/grade
     // run serially per instance"; the dispatch-time env PRE-WARM broke that
@@ -1525,6 +1542,9 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
         // instance so there is no cross-tree race.
         if let Some(uv) = which("uv") {
             let py_s = py.to_string_lossy().to_string();
+            // The cached env may hold an era-swept setuptools (34.x has no
+            // build_meta) — floor it before asking for an editable rebuild.
+            assert_harness_floor(&uv, &py_s).await?;
             let out = run_env(
                 &uv,
                 &[
@@ -1819,6 +1839,11 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
             tail(&stdout)
         ));
     }
+
+    // The era-pinned `-e .` resolve can sweep setuptools into the dated subject
+    // graph (sympy-12481: 2017 pin → setuptools 34.3.3, no build_meta) — every
+    // later re-point then dies. Floor it back: harness, never subject.
+    assert_harness_floor(&uv, &py_s).await?;
 
     // PYTEST IS SUBJECT, NOT HARNESS, for date-pinned instances (#380, glass-boxed
     // 2026-08-12): era test suites import pytest INTERNALS — flask 2.2's test_cli.py does

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -1433,6 +1433,15 @@ fn era_sdist_build_deps(repo: &str) -> &'static [&'static str] {
         // and >=1.13 respectively — both far below any era cap we set), so this widens what
         // BUILDS without smuggling a modern numpy into a date-pinned subject graph.
         "astropy/astropy" => &["jinja2", "numpy"],
+        // Same class, measured at prewarm 2026-08-26 (the seeded-25 round): both
+        // setup.py's import numpy at metadata time under --no-build-isolation.
+        // scikit-learn additionally builds .pyx sources, so cython is a build
+        // dep of the repo itself; matplotlib declares numpy via
+        // `oldest-supported-numpy`, which routinely fails to resolve on a
+        // modern interpreter (the build_requires step warns and proceeds) — a
+        // plain era-pinned numpy here is what actually lands.
+        "scikit-learn/scikit-learn" => &["numpy", "cython"],
+        "matplotlib/matplotlib" => &["numpy", "setuptools_scm", "certifi"],
         _ => &[],
     }
 }
@@ -1527,11 +1536,16 @@ pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathB
             )
             .await?;
             if !out.status.success() {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let tail: String = {
+                    let t = stderr.trim();
+                    t.chars().skip(t.chars().count().saturating_sub(1500)).collect()
+                };
                 return Err(format!(
                     "could not re-point {}'s cached env at {}: {}",
                     instance.instance_id,
                     repo_dir.display(),
-                    String::from_utf8_lossy(&out.stderr).trim()
+                    tail
                 ));
             }
             // An env cached BEFORE the test extra existed is silently ungradeable (its

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -1440,8 +1440,15 @@ fn era_sdist_build_deps(repo: &str) -> &'static [&'static str] {
         // `oldest-supported-numpy`, which routinely fails to resolve on a
         // modern interpreter (the build_requires step warns and proceeds) — a
         // plain era-pinned numpy here is what actually lands.
-        "scikit-learn/scikit-learn" => &["numpy", "cython"],
-        "matplotlib/matplotlib" => &["numpy", "setuptools_scm", "certifi"],
+        // cython<3 is load-bearing: Cython 3 REJECTS 2019-era .pyx (CompileError
+        // on sklearn's own ball_tree.pyx, walk 4 of the seeded-25 prewarm) — and
+        // the era-pin's loud unpinned retry is exactly the path that smuggles
+        // modern cython in when the dated resolve hiccups. The ceiling holds
+        // through BOTH paths; 0.29.x compiles every sklearn era we can meet.
+        "scikit-learn/scikit-learn" => &["numpy", "cython>=0.28,<3"],
+        // cppy: kiwisolver 1.3's sdist imports it at build (walk 4 — the
+        // dependency-sdist class this table exists for, same as astropy→pyerfa→jinja2).
+        "matplotlib/matplotlib" => &["numpy", "setuptools_scm", "certifi", "cppy"],
         _ => &[],
     }
 }

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -931,17 +931,40 @@ async fn close_claim_card_if_graded(run_id: &str) {
         return;
     };
     let grade_path = ledger.with_extension("grade.json");
-    let verdict_is_real = std::fs::read_to_string(&grade_path)
+    let grade = std::fs::read_to_string(&grade_path)
         .ok()
-        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok()) // disk boundary: reading the grade.json verdict file the grader wrote
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok()); // disk boundary: reading the grade.json verdict file the grader wrote
+    let env_absent = grade
+        .as_ref()
+        .is_some_and(|g| g.get("error").is_some_and(|e| !e.is_null()));
+    let verdict_is_real = grade
+        .as_ref()
         .is_some_and(|g| g.get("error").map_or(true, |e| e.is_null()));
-    if !verdict_is_real {
+    if !verdict_is_real && !env_absent {
         crate::probe!(
             class = "benchmark.card.close_skipped",
             run_id = %run_id,
-            "no real verdict on disk (infra/ungradeable) — card stays open so a              resume re-fires it (the owed retake)"
+            "no verdict on disk at all (infra died before grading) — card stays open \
+             so a resume re-fires it (the owed retake)"
         );
         return;
+    }
+    if env_absent {
+        // The harness MEASURED the environment and it is absent (error set in
+        // the verdict) — that is a terminal fact for THIS round, not a retake
+        // loop: an open env-absent card would be re-fired by the watchdog
+        // forever and the round could never reach Done (2026-08-27, the
+        // seeded-25's scikit/sphinx tail). Close it; the error-verdict keeps
+        // it OUT of the resolved tally and IN the scoreboard's env_absences,
+        // and re-running later is one dispatch with `--instances` once the
+        // env class is repaired.
+        crate::probe!(
+            class = "benchmark.card.closed_env_absent",
+            run_id = %run_id,
+            "env-absent verdict — closing the card so the round completes; \
+             the absence stays labeled and the instance re-opens with one \
+             dispatch after the env repair"
+        );
     }
     // Author through the run's persona (her runtime is subscribed to the run
     // room); fall back to any live citizen — same authoring rule as the lapse

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -950,21 +950,21 @@ async fn close_claim_card_if_graded(run_id: &str) {
         return;
     }
     if env_absent {
-        // The harness MEASURED the environment and it is absent (error set in
-        // the verdict) — that is a terminal fact for THIS round, not a retake
-        // loop: an open env-absent card would be re-fired by the watchdog
-        // forever and the round could never reach Done (2026-08-27, the
-        // seeded-25's scikit/sphinx tail). Close it; the error-verdict keeps
-        // it OUT of the resolved tally and IN the scoreboard's env_absences,
-        // and re-running later is one dispatch with `--instances` once the
-        // env class is repaired.
+        // The harness measured the environment and it is ABSENT — the card
+        // stays OPEN so the retake is AUTOMATIC the boot the env heals (Joel
+        // 2026-08-27: "you'd want to get it possible to run the broken ones
+        // after a restart"). The infinite-loop hazard this used to carry is
+        // killed at the dispatch seam instead: dispatch skips instances whose
+        // env failed THIS boot's prewarm, so a still-broken card idles quietly
+        // and a healed one re-fires with zero operator action.
         crate::probe!(
-            class = "benchmark.card.closed_env_absent",
+            class = "benchmark.card.close_skipped",
             run_id = %run_id,
-            "env-absent verdict — closing the card so the round completes; \
-             the absence stays labeled and the instance re-opens with one \
-             dispatch after the env repair"
+            reason = "env_absent",
+            "env-absent verdict — card stays open; the retake fires itself on \
+             the first boot whose env pre-warm succeeds"
         );
+        return;
     }
     // Author through the run's persona (her runtime is subscribed to the run
     // room); fall back to any live citizen — same authoring rule as the lapse

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -934,12 +934,21 @@ async fn close_claim_card_if_graded(run_id: &str) {
     let grade = std::fs::read_to_string(&grade_path)
         .ok()
         .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok()); // disk boundary: reading the grade.json verdict file the grader wrote
-    let env_absent = grade
+    // A failed GATE is env-class too: the fail-to-pass tests already passed on
+    // the pristine tree, so the control is broken and nothing was measured —
+    // the durable layer already refuses such verdicts (record_verdict), and
+    // the card must stay open for the retake the same as any env absence.
+    let gate_failed = grade
         .as_ref()
-        .is_some_and(|g| g.get("error").is_some_and(|e| !e.is_null()));
-    let verdict_is_real = grade
-        .as_ref()
-        .is_some_and(|g| g.get("error").map_or(true, |e| e.is_null()));
+        .is_some_and(|g| g.get("gate_ok").is_some_and(|k| k == false));
+    let env_absent = gate_failed
+        || grade
+            .as_ref()
+            .is_some_and(|g| g.get("error").is_some_and(|e| !e.is_null()));
+    let verdict_is_real = !env_absent
+        && grade
+            .as_ref()
+            .is_some_and(|g| g.get("error").map_or(true, |e| e.is_null()));
     if !verdict_is_real && !env_absent {
         crate::probe!(
             class = "benchmark.card.close_skipped",

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -3674,10 +3674,13 @@ impl ActionCommand for BenchmarkScoreboard {
                 if !ids.contains(id.as_str()) {
                     continue;
                 }
-                if v.error.is_some() {
+                if v.error.is_some() || !v.gate_ok {
                     // Absence, never a tallied attempt — but never invisible
                     // either: an env failure the user can't see reads as a
-                    // model miss in every retelling.
+                    // model miss in every retelling. A failed GATE is the same
+                    // class: the control was broken, nothing was measured
+                    // (belt-and-suspenders — record_verdict already refuses
+                    // gate-failed verdicts, so this arm should never fire).
                     env_absent_instances.push(id.clone());
                     continue;
                 }

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -116,6 +116,17 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
                 continue;
             }
             if !fast {
+                // TRULY becalmed means NO solve is running anywhere — the fast
+                // window may legitimately fan out boot re-fires, but the slow
+                // watch reviving one more card per tick while solves are LIVE
+                // is drift into parallel solving nobody decided (B7 is a
+                // deliberate, measured decision — never a watchdog side
+                // effect; caught live 2026-08-27, one extra solve per 5min).
+                let live = crate::cognition::swe_bench::in_flight_solve_runs();
+                if !live.is_empty() {
+                    tokio::time::sleep(SLOW_WATCH).await;
+                    continue;
+                }
                 crate::probe!(
                     class = "bench.round.becalmed",
                     unworked = due.len() as u64,

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -105,6 +105,14 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
                 }
                 continue;
             }
+            // Resumed rounds deserve the same env pre-warm dispatch gives fresh
+            // ones — without this, a reboot mid-round re-discovers its env
+            // walls one burned solve attempt at a time (2026-08-27: the
+            // operator hand-worked around it with idempotent re-dispatches).
+            // Once per task lifetime; cheap when everything is already warm.
+            if attempt == 1 {
+                crate::modules::work::spawn_env_prewarm_for_working_rounds();
+            }
             let due = crate::cognition::bench_round::next_unworked_per_round();
             if due.is_empty() {
                 if !crate::cognition::bench_round::any_working_round() {

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -710,6 +710,80 @@ pub(crate) struct StagedSolveDispatch {
 /// 2026-08-11: cards staged + assigned, zero claims, zero solves). The solve is her WHOLE
 /// cognition with an exclusive warm slot (`quiesce_others`), so nothing about "she does the
 /// work herself" changes — only the trigger moves off the chat turn.
+/// Pre-warm envs for every instance a WORKING round has staged — the resume-side
+/// twin of dispatch's pre-warm (a reboot mid-round otherwise re-discovers env
+/// walls one burned solve attempt at a time). The staged workspace dirs
+/// (`peers/<assignee>/workspace/swe/<instance>`) are the reliable card→instance
+/// map; instances resolve through the SAME dataset loader the grader uses.
+pub fn spawn_env_prewarm_for_working_rounds() {
+    tokio::spawn(async move {
+        let peers_root = match crate::commands::benchmark::continuum_home() {
+            Ok(h) => h.join("citizens").join("peers"),
+            Err(_) => return, // no home = nothing staged anywhere
+        };
+        let mut names: std::collections::BTreeSet<String> = Default::default();
+        if let Ok(peers) = std::fs::read_dir(&peers_root) {
+            for peer in peers.flatten() {
+                let swe = peer.path().join("workspace").join("swe");
+                if let Ok(instances) = std::fs::read_dir(&swe) {
+                    for inst in instances.flatten() {
+                        if inst.path().is_dir() {
+                            names.insert(inst.file_name().to_string_lossy().into_owned());
+                        }
+                    }
+                }
+            }
+        }
+        if names.is_empty() {
+            return;
+        }
+        // Resolve each staged name against every SWE dataset in the catalog —
+        // the same search the grade path performs (first dataset holding the
+        // instance wins), so this can never disagree with grading.
+        for name in names {
+            let mut resolved = None;
+            for spec in crate::commands::benchmark::known_benchmarks() {
+                let Some(dataset) = spec.swe_dataset() else { continue };
+                if let Ok(instances) = crate::cognition::swe_bench::load_dataset(dataset).await {
+                    if let Some(i) = instances.into_iter().find(|i| i.instance_id == name) {
+                        resolved = Some(i);
+                        break;
+                    }
+                }
+            }
+            let Some(inst) = resolved else { continue };
+            let checkout = match crate::cognition::swe_bench::ensure_grade_checkout(&inst).await {
+                Ok(dir) => dir,
+                Err(e) => {
+                    crate::probe!(
+                        class = "benchmark.env.prewarm_failed",
+                        instance = %inst.instance_id,
+                        stage = "checkout",
+                        error = %e,
+                        "resume-side env pre-warm could not stage a checkout — an ENV \
+                         failure, not a model result"
+                    );
+                    continue;
+                }
+            };
+            match crate::cognition::swe_bench::ensure_env(&inst, &checkout).await {
+                Ok(_) => crate::probe!(
+                    class = "benchmark.env.prewarmed",
+                    instance = %inst.instance_id,
+                    "resume-side env pre-warm: ready ahead of the driver"
+                ),
+                Err(e) => crate::probe!(
+                    class = "benchmark.env.prewarm_failed",
+                    instance = %inst.instance_id,
+                    stage = "env",
+                    error = %e,
+                    "resume-side env pre-warm FAILED — an ENV failure, never a model result"
+                ),
+            }
+        }
+    });
+}
+
 pub(crate) async fn dispatch_staged_swe_solve(
     ctx: &Ctx,
     airc: &std::sync::Arc<airc_lib::Airc>,

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -715,6 +715,14 @@ pub(crate) struct StagedSolveDispatch {
 /// walls one burned solve attempt at a time). The staged workspace dirs
 /// (`peers/<assignee>/workspace/swe/<instance>`) are the reliable card→instance
 /// map; instances resolve through the SAME dataset loader the grader uses.
+/// Instances whose env FAILED this boot's pre-warm — the dispatch gate reads
+/// this so a still-broken card idles (no attempt-burning loop) while a healed
+/// one re-fires automatically. Per-boot by construction: a restart re-walks.
+pub fn env_broken_this_boot() -> &'static dashmap::DashSet<String> {
+    static SET: std::sync::OnceLock<dashmap::DashSet<String>> = std::sync::OnceLock::new();
+    SET.get_or_init(dashmap::DashSet::new)
+}
+
 pub fn spawn_env_prewarm_for_working_rounds() {
     tokio::spawn(async move {
         let peers_root = match crate::commands::benchmark::continuum_home() {
@@ -767,18 +775,25 @@ pub fn spawn_env_prewarm_for_working_rounds() {
                 }
             };
             match crate::cognition::swe_bench::ensure_env(&inst, &checkout).await {
-                Ok(_) => crate::probe!(
-                    class = "benchmark.env.prewarmed",
-                    instance = %inst.instance_id,
-                    "resume-side env pre-warm: ready ahead of the driver"
-                ),
-                Err(e) => crate::probe!(
-                    class = "benchmark.env.prewarm_failed",
-                    instance = %inst.instance_id,
-                    stage = "env",
-                    error = %e,
-                    "resume-side env pre-warm FAILED — an ENV failure, never a model result"
-                ),
+                Ok(_) => {
+                    let healed = env_broken_this_boot().remove(&inst.instance_id).is_some();
+                    crate::probe!(
+                        class = "benchmark.env.prewarmed",
+                        instance = %inst.instance_id,
+                        healed,
+                        "resume-side env pre-warm: ready ahead of the driver"
+                    );
+                }
+                Err(e) => {
+                    env_broken_this_boot().insert(inst.instance_id.clone());
+                    crate::probe!(
+                        class = "benchmark.env.prewarm_failed",
+                        instance = %inst.instance_id,
+                        stage = "env",
+                        error = %e,
+                        "resume-side env pre-warm FAILED — an ENV failure, never a model result"
+                    );
+                }
             }
         }
     });
@@ -857,12 +872,28 @@ pub(crate) async fn dispatch_staged_swe_solve(
     // so a change to staging can never leave the two disagreeing about which repo a card
     // is about (they did disagree in kind already: this walk accepted any directory, that
     // one requires a `.git`, so an interrupted clone read as a staged instance here).
+    // ENV GATE: an instance whose env failed THIS boot's pre-warm cannot grade —
+    // firing a solve would burn an attempt on a wall we already measured. Skip
+    // with a named abort; the card stays open and re-fires on the first boot
+    // whose pre-warm heals it (the automatic retake).
+    let env_gate = |inst: &str| crate::modules::work::env_broken_this_boot().contains(inst);
     let (instance, workspace) = match crate::persona::staged_workspace::resolve_for_titles(
         // typed PeerId (canary's #425 struct) → the resolver's raw Uuid
         &claimer.as_uuid(),
         [card.title.as_str()],
     ) {
         crate::persona::staged_workspace::CardWorkspace::One { instance, path } => {
+            if env_gate(&instance) {
+                crate::probe!(
+                    class = "benchmark.dispatch",
+                    card_id = %card_id.as_uuid(),
+                    instance = %instance,
+                    "dispatch deferred: this instance's env failed THIS boot's \
+                     pre-warm — an attempt now would burn on a measured wall; the \
+                     open card re-fires the first boot the env heals"
+                );
+                return;
+            }
             (instance, path.to_string_lossy().to_string())
         }
         // No staged checkout for her matching this card — an ordinary (non-SWE) claim.

--- a/docs/benchmarks/RUNNING-A-ROUND.md
+++ b/docs/benchmarks/RUNNING-A-ROUND.md
@@ -40,6 +40,15 @@ continuum start           # build + boot the headless core, wait until ready
 continuum ping            # the version trio (build #, sha, built-at) — deploys are PROVEN, never assumed
 ```
 
+**Host build prerequisites** (macOS; each is gated with a fail-loud message
+naming its remedy when missing): `brew install freetype pkg-config libomp` —
+freetype/pkg-config for matplotlib-era builds (the vendored freetype predates
+Apple silicon), libomp for scikit-learn-era OpenMP builds. Known structural
+absence, honestly labeled: scikit-learn < 0.22 instances cannot run natively on
+Apple silicon (their vendored cloudpickle needs python ≤ 3.7, which does not
+exist for this platform) — they grade as ENV absences, never model misses; the
+parity path is the official era containers (docker fallback, tracked).
+
 Identity/airc: every citizen's identity (keypair, peer_id, rooms) lives IN the
 core — no separate airc install is needed to run a round.
 


### PR DESCRIPTION
The full ladder table-encoded (repo_build_env row + libomp gate + runbook prereqs section). sklearn <0.22 documented as structurally env-absent on Apple silicon (vendored cloudpickle needs py≤3.7, which doesn't exist for this platform); parity path is official era containers via docker, tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo