### PR TITLE
README architecture diagrams: cognition, memory, genome, grid

### DIFF
--- a/docs/assets/readme/cognition.svg
+++ b/docs/assets/readme/cognition.svg
@@ -26,9 +26,10 @@
   <text x="84" y="343" font-size="15.5" fill="#64748b" font-style="italic">knowledge crosses activities through HER — one memory, one being — never through the rooms</text>
 
   <!-- Senses -->
-  <rect x="60" y="380" width="650" height="86" rx="12" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2"/>
-  <text x="84" y="412" font-size="18" font-weight="600" fill="#2f3a4a">Senses — every citizen, regardless of base model</text>
-  <text x="84" y="442" font-size="16" fill="#64748b">sight: vision/look · describe bridge (VL-native lane when the model can carry it) · hearing: STT · text: native</text>
+  <rect x="60" y="380" width="650" height="92" rx="12" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2"/>
+  <text x="84" y="410" font-size="18" font-weight="600" fill="#2f3a4a">Senses &amp; embodiment — in ANY activity, for every citizen</text>
+  <text x="84" y="437" font-size="15.5" fill="#64748b">any room carries any modality: images in chat, screenshots in a solve, voice + avatars in a call —</text>
+  <text x="84" y="460" font-size="15.5" fill="#64748b">sight: vision/look · describe bridge (VL-native lane when the model carries it) · hearing: STT</text>
 
   <!-- Burst -->
   <line x1="440" y1="355" x2="440" y2="376" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>

--- a/docs/assets/readme/cognition.svg
+++ b/docs/assets/readme/cognition.svg
@@ -1,0 +1,106 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1240" font-family="Helvetica Neue, Arial, sans-serif">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2f3a4a"/>
+    </marker>
+  </defs>
+  <rect width="1920" height="1240" fill="#ffffff"/>
+
+  <text x="60" y="78" font-size="44" font-weight="700" fill="#2f3a4a">The Cognition Cycle</text>
+  <text x="60" y="116" font-size="24" fill="#64748b">every turn is an activity — perceive, deliberate, act, settle, learn</text>
+
+  <!-- Room / Burst -->
+  <rect x="60" y="200" width="270" height="150" rx="14" fill="#f5ecd7" stroke="#b3985e" stroke-width="2.5"/>
+  <text x="195" y="248" font-size="26" font-weight="700" fill="#2f3a4a" text-anchor="middle">Room</text>
+  <text x="195" y="280" font-size="19" fill="#64748b" text-anchor="middle">an airc activity</text>
+  <text x="195" y="306" font-size="19" fill="#64748b" text-anchor="middle">events · board · peers</text>
+
+  <line x1="330" y1="275" x2="410" y2="275" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+
+  <rect x="415" y="200" width="285" height="150" rx="14" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
+  <text x="557" y="248" font-size="26" font-weight="700" fill="#2f3a4a" text-anchor="middle">Burst</text>
+  <text x="557" y="280" font-size="19" fill="#64748b" text-anchor="middle">carries ActivityRoom — typed,</text>
+  <text x="557" y="306" font-size="19" fill="#64748b" text-anchor="middle">non-nil: roomless turns unrepresentable</text>
+
+  <line x1="700" y1="275" x2="778" y2="275" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+
+  <!-- Workspace container -->
+  <rect x="783" y="165" width="1070" height="300" rx="16" fill="#e3e9f8" stroke="#6b81c2" stroke-width="3"/>
+  <text x="815" y="215" font-size="28" font-weight="700" fill="#2f3a4a">Workspace</text>
+  <text x="1015" y="215" font-size="20" fill="#64748b">working memory — faculties contribute, salience orders</text>
+
+  <rect x="815" y="245" width="238" height="88" rx="10" fill="#ffffff" stroke="#94a3b8" stroke-width="2"/>
+  <text x="934" y="281" font-size="21" font-weight="600" fill="#2f3a4a" text-anchor="middle">Recall</text>
+  <text x="934" y="309" font-size="17" fill="#64748b" text-anchor="middle">hippocampus L1–L5</text>
+
+  <rect x="1069" y="245" width="238" height="88" rx="10" fill="#ffffff" stroke="#94a3b8" stroke-width="2"/>
+  <text x="1188" y="281" font-size="21" font-weight="600" fill="#2f3a4a" text-anchor="middle">Perception facts</text>
+  <text x="1188" y="309" font-size="17" fill="#64748b" text-anchor="middle">rooms · serving · board</text>
+
+  <rect x="1323" y="245" width="238" height="88" rx="10" fill="#ffffff" stroke="#94a3b8" stroke-width="2"/>
+  <text x="1442" y="281" font-size="21" font-weight="600" fill="#2f3a4a" text-anchor="middle">Workspace map</text>
+  <text x="1442" y="309" font-size="17" fill="#64748b" text-anchor="middle">her files, her tree</text>
+
+  <rect x="1577" y="245" width="248" height="88" rx="10" fill="#ffffff" stroke="#94a3b8" stroke-width="2"/>
+  <text x="1701" y="281" font-size="21" font-weight="600" fill="#2f3a4a" text-anchor="middle">Tool receipts</text>
+  <text x="1701" y="309" font-size="17" fill="#64748b" text-anchor="middle">what her hands did</text>
+
+  <rect x="815" y="355" width="1010" height="82" rx="10" fill="#fdf6ec" stroke="#d99a3d" stroke-width="2" stroke-dasharray="7 5"/>
+  <text x="835" y="389" font-size="20" font-weight="600" fill="#2f3a4a">Deferred faculties</text>
+  <text x="835" y="417" font-size="18" fill="#64748b">slow perception runs off the hot path — last-good served instantly, stamped with its own cycle and room, reprojected forward</text>
+
+  <!-- Deliberation -->
+  <line x1="1318" y1="465" x2="1318" y2="535" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+
+  <rect x="640" y="540" width="1213" height="240" rx="16" fill="#e6efdf" stroke="#7a9c5d" stroke-width="3"/>
+  <text x="672" y="590" font-size="28" font-weight="700" fill="#2f3a4a">Deliberation</text>
+  <text x="850" y="590" font-size="20" fill="#64748b">prompt assembly is KV-aware — the prefix is an asset</text>
+
+  <rect x="672" y="615" width="708" height="130" rx="10" fill="#ffffff" stroke="#7a9c5d" stroke-width="2"/>
+  <text x="692" y="650" font-size="20" font-weight="600" fill="#2f3a4a">Stable prefix tier</text>
+  <text x="692" y="680" font-size="18" fill="#64748b">identity · tool surface · curriculum · standing context</text>
+  <text x="692" y="708" font-size="18" fill="#7a9c5d" font-style="italic">byte-stable across acts → the server reuses its cache</text>
+
+  <rect x="1400" y="615" width="425" height="130" rx="10" fill="#fdf6ec" stroke="#d99a3d" stroke-width="2"/>
+  <text x="1420" y="650" font-size="20" font-weight="600" fill="#2f3a4a">Volatile tier</text>
+  <text x="1420" y="680" font-size="18" fill="#64748b">clock · newest turn · fresh findings</text>
+  <text x="1420" y="708" font-size="18" fill="#d99a3d" font-style="italic">only the tail re-prefills</text>
+
+  <!-- Serving -->
+  <line x1="1246" y1="780" x2="1246" y2="848" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <rect x="1000" y="853" width="493" height="110" rx="14" fill="#f8e3e1" stroke="#c26b62" stroke-width="2.5"/>
+  <text x="1246" y="898" font-size="24" font-weight="700" fill="#2f3a4a" text-anchor="middle">Served model — warm slot</text>
+  <text x="1246" y="932" font-size="19" fill="#64748b" text-anchor="middle">her activity's own KV lease, per (persona, room)</text>
+
+  <!-- Act loop -->
+  <rect x="200" y="853" width="700" height="270" rx="16" fill="#e3e9f8" stroke="#6b81c2" stroke-width="3"/>
+  <text x="232" y="903" font-size="28" font-weight="700" fill="#2f3a4a">Act ⟳ Observe ⟳ Settle</text>
+  <text x="700" y="903" font-size="20" fill="#64748b">× N acts</text>
+
+  <rect x="232" y="930" width="196" height="80" rx="10" fill="#ffffff" stroke="#94a3b8" stroke-width="2"/>
+  <text x="330" y="963" font-size="20" font-weight="600" fill="#2f3a4a" text-anchor="middle">Act</text>
+  <text x="330" y="991" font-size="16" fill="#64748b" text-anchor="middle">code/* · web/* · vision/look</text>
+
+  <rect x="452" y="930" width="196" height="80" rx="10" fill="#ffffff" stroke="#94a3b8" stroke-width="2"/>
+  <text x="550" y="963" font-size="20" font-weight="600" fill="#2f3a4a" text-anchor="middle">Observe</text>
+  <text x="550" y="991" font-size="16" fill="#64748b" text-anchor="middle">receipts, never guesses</text>
+
+  <rect x="672" y="930" width="196" height="80" rx="10" fill="#ffffff" stroke="#94a3b8" stroke-width="2"/>
+  <text x="770" y="963" font-size="20" font-weight="600" fill="#2f3a4a" text-anchor="middle">Settle</text>
+  <text x="770" y="991" font-size="16" fill="#64748b" text-anchor="middle">or act again</text>
+
+  <line x1="428" y1="970" x2="448" y2="970" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="648" y1="970" x2="668" y2="970" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <path d="M 770 1010 L 770 1060 L 330 1060 L 330 1014" fill="none" stroke="#6b81c2" stroke-width="2.5" marker-end="url(#arr)"/>
+  <text x="550" y="1088" font-size="17" fill="#6b81c2" text-anchor="middle" font-style="italic">her workspace persists — a reboot mid-act resumes mid-stride</text>
+
+  <line x1="1000" y1="908" x2="904" y2="953" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+
+  <!-- Experience stream -->
+  <line x1="900" y1="1060" x2="1000" y2="1105" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <rect x="1005" y="1075" width="848" height="90" rx="14" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
+  <text x="1025" y="1110" font-size="22" font-weight="700" fill="#2f3a4a">One experience stream</text>
+  <text x="1025" y="1142" font-size="18" fill="#64748b">lived turns + exams + received lessons → curriculum → genome training — she learns DURING the work</text>
+
+  <text x="60" y="1215" font-size="19" fill="#7a9c5d" font-style="italic">Receipt: astropy-13236 — missed on attempt 1, streamed the lesson, resolved 2/2 on the retake. The loop in one instance.</text>
+</svg>

--- a/docs/assets/readme/cognition.svg
+++ b/docs/assets/readme/cognition.svg
@@ -9,21 +9,35 @@
   <text x="60" y="78" font-size="44" font-weight="700" fill="#2f3a4a">The Cognition Cycle</text>
   <text x="60" y="116" font-size="24" fill="#64748b">every turn is an activity — perceive, deliberate, act, settle, learn</text>
 
-  <!-- Room / Burst -->
-  <rect x="60" y="200" width="270" height="150" rx="14" fill="#f5ecd7" stroke="#b3985e" stroke-width="2.5"/>
-  <text x="195" y="242" font-size="26" font-weight="700" fill="#2f3a4a" text-anchor="middle">Room</text>
-  <text x="195" y="272" font-size="18" fill="#64748b" text-anchor="middle">an airc activity — airc is the</text>
-  <text x="195" y="296" font-size="18" fill="#64748b" text-anchor="middle">nervous system: events in,</text>
-  <text x="195" y="320" font-size="18" fill="#64748b" text-anchor="middle">acts and speech out</text>
+  <!-- Her rooms: many concurrent activities -->
+  <rect x="60" y="150" width="650" height="205" rx="14" fill="#f5ecd7" stroke="#b3985e" stroke-width="2.5"/>
+  <text x="84" y="188" font-size="23" font-weight="700" fill="#2f3a4a">Her rooms — many concurrent activities</text>
+  <rect x="84" y="205" width="290" height="52" rx="9" fill="#ffffff" stroke="#b3985e" stroke-width="1.8"/>
+  <text x="229" y="228" font-size="16" fill="#2f3a4a" text-anchor="middle">swe-solve room · her + the run board</text>
+  <text x="229" y="249" font-size="14" fill="#94a3b8" text-anchor="middle">a benchmark card being worked</text>
+  <rect x="390" y="205" width="296" height="52" rx="9" fill="#ffffff" stroke="#b3985e" stroke-width="1.8"/>
+  <text x="538" y="228" font-size="16" fill="#2f3a4a" text-anchor="middle">general chat · citizens + humans</text>
+  <text x="538" y="249" font-size="14" fill="#94a3b8" text-anchor="middle">peers she works with, people she serves</text>
+  <rect x="84" y="267" width="290" height="52" rx="9" fill="#ffffff" stroke="#b3985e" stroke-width="1.8"/>
+  <text x="229" y="290" font-size="16" fill="#2f3a4a" text-anchor="middle">live call · voice + avatars</text>
+  <text x="229" y="311" font-size="14" fill="#94a3b8" text-anchor="middle">she can be mid-benchmark AND on a call</text>
+  <text x="390" y="290" font-size="15" fill="#b3985e" font-style="italic">airc is the nervous system:</text>
+  <text x="390" y="312" font-size="15" fill="#b3985e" font-style="italic">events in — acts, speech, emotes out</text>
+  <text x="84" y="343" font-size="15.5" fill="#64748b" font-style="italic">knowledge crosses activities through HER — one memory, one being — never through the rooms</text>
 
-  <line x1="330" y1="275" x2="410" y2="275" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <!-- Senses -->
+  <rect x="60" y="380" width="650" height="86" rx="12" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2"/>
+  <text x="84" y="412" font-size="18" font-weight="600" fill="#2f3a4a">Senses — every citizen, regardless of base model</text>
+  <text x="84" y="442" font-size="16" fill="#64748b">sight: vision/look · describe bridge (VL-native lane when the model can carry it) · hearing: STT · text: native</text>
 
-  <rect x="415" y="200" width="285" height="150" rx="14" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
-  <text x="557" y="248" font-size="26" font-weight="700" fill="#2f3a4a" text-anchor="middle">Burst</text>
-  <text x="557" y="280" font-size="19" fill="#64748b" text-anchor="middle">carries ActivityRoom — typed,</text>
-  <text x="557" y="306" font-size="19" fill="#64748b" text-anchor="middle">non-nil: roomless turns unrepresentable</text>
-
-  <line x1="700" y1="275" x2="778" y2="275" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <!-- Burst -->
+  <line x1="440" y1="355" x2="440" y2="376" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="710" y1="300" x2="778" y2="300" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <rect x="60" y="490" width="560" height="80" rx="12" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
+  <text x="84" y="522" font-size="19" font-weight="700" fill="#2f3a4a">Burst — this turn binds exactly ONE room</text>
+  <text x="84" y="551" font-size="16" fill="#64748b">typed, non-nil ActivityRoom on every burst — roomless is unrepresentable</text>
+  <line x1="440" y1="466" x2="440" y2="486" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="620" y1="530" x2="700" y2="580" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
 
   <!-- Workspace container -->
   <rect x="783" y="165" width="1070" height="300" rx="16" fill="#e3e9f8" stroke="#6b81c2" stroke-width="3"/>
@@ -97,6 +111,7 @@
   <text x="550" y="1088" font-size="17" fill="#6b81c2" text-anchor="middle" font-style="italic">her workspace persists — a reboot mid-act resumes mid-stride</text>
 
   <line x1="1000" y1="908" x2="904" y2="953" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <text x="550" y="1145" font-size="17" fill="#6b81c2" text-anchor="middle" font-style="italic">acts reach the world: tools · speech (TTS) · emotes · avatar control — one efferent nerve, every surface renders it</text>
 
   <!-- Experience stream -->
   <line x1="900" y1="1060" x2="1000" y2="1105" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>

--- a/docs/assets/readme/cognition.svg
+++ b/docs/assets/readme/cognition.svg
@@ -11,9 +11,10 @@
 
   <!-- Room / Burst -->
   <rect x="60" y="200" width="270" height="150" rx="14" fill="#f5ecd7" stroke="#b3985e" stroke-width="2.5"/>
-  <text x="195" y="248" font-size="26" font-weight="700" fill="#2f3a4a" text-anchor="middle">Room</text>
-  <text x="195" y="280" font-size="19" fill="#64748b" text-anchor="middle">an airc activity</text>
-  <text x="195" y="306" font-size="19" fill="#64748b" text-anchor="middle">events · board · peers</text>
+  <text x="195" y="242" font-size="26" font-weight="700" fill="#2f3a4a" text-anchor="middle">Room</text>
+  <text x="195" y="272" font-size="18" fill="#64748b" text-anchor="middle">an airc activity — airc is the</text>
+  <text x="195" y="296" font-size="18" fill="#64748b" text-anchor="middle">nervous system: events in,</text>
+  <text x="195" y="320" font-size="18" fill="#64748b" text-anchor="middle">acts and speech out</text>
 
   <line x1="330" y1="275" x2="410" y2="275" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
 

--- a/docs/assets/readme/cognition.svg
+++ b/docs/assets/readme/cognition.svg
@@ -48,6 +48,7 @@
   <rect x="815" y="355" width="1010" height="82" rx="10" fill="#fdf6ec" stroke="#d99a3d" stroke-width="2" stroke-dasharray="7 5"/>
   <text x="835" y="389" font-size="20" font-weight="600" fill="#2f3a4a">Deferred faculties</text>
   <text x="835" y="417" font-size="18" fill="#64748b">slow perception runs off the hot path — last-good served instantly, stamped with its own cycle and room, reprojected forward</text>
+  <text x="60" y="1180" font-size="19" fill="#9068c0" font-style="italic">While she rests: DREAMS (L3) review the stream — supersede, compress, consolidate — so the genome trains on curated experience, not raw logs.</text>
 
   <!-- Deliberation -->
   <line x1="1318" y1="465" x2="1318" y2="535" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
@@ -98,9 +99,17 @@
 
   <!-- Experience stream -->
   <line x1="900" y1="1060" x2="1000" y2="1105" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
-  <rect x="1005" y="1075" width="848" height="90" rx="14" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
+  <rect x="1005" y="1075" width="560" height="90" rx="14" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
   <text x="1025" y="1110" font-size="22" font-weight="700" fill="#2f3a4a">One experience stream</text>
-  <text x="1025" y="1142" font-size="18" fill="#64748b">lived turns + exams + received lessons → curriculum → genome training — she learns DURING the work</text>
+  <text x="1025" y="1142" font-size="18" fill="#64748b">lived turns + exams + received lessons — one being</text>
+
+  <line x1="1565" y1="1105" x2="1615" y2="1105" stroke="#9068c0" stroke-width="2.5" marker-end="url(#arr)"/>
+  <rect x="1620" y="1075" width="233" height="90" rx="14" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5" stroke-dasharray="8 5"/>
+  <text x="1736" y="1108" font-size="20" font-weight="700" fill="#9068c0" text-anchor="middle">→ Genome</text>
+  <text x="1736" y="1136" font-size="16" fill="#9068c0" text-anchor="middle">lessons L2 · dreams L3 · genes L4</text>
+
+  <rect x="200" y="1145" width="700" height="0" fill="none"/>
+  <rect x="60" y="380" width="270" height="0" fill="none"/>
 
   <text x="60" y="1215" font-size="19" fill="#7a9c5d" font-style="italic">Receipt: astropy-13236 — missed on attempt 1, streamed the lesson, resolved 2/2 on the retake. The loop in one instance.</text>
 </svg>

--- a/docs/assets/readme/genome.svg
+++ b/docs/assets/readme/genome.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1200" font-family="Helvetica Neue, Arial, sans-serif">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2f3a4a"/>
+    </marker>
+    <marker id="arrv" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#9068c0"/>
+    </marker>
+  </defs>
+  <rect width="1920" height="1200" fill="#ffffff"/>
+
+  <text x="60" y="78" font-size="44" font-weight="700" fill="#2f3a4a">The Genome</text>
+  <text x="60" y="116" font-size="24" fill="#64748b">skills are genes — paged like memory, routed by distance, shared like code</text>
+
+  <!-- Task in -->
+  <rect x="60" y="200" width="300" height="130" rx="14" fill="#f5ecd7" stroke="#b3985e" stroke-width="2.5"/>
+  <text x="210" y="248" font-size="24" font-weight="700" fill="#2f3a4a" text-anchor="middle">Task arrives</text>
+  <text x="210" y="280" font-size="18" fill="#64748b" text-anchor="middle">a card, a question, a room turn</text>
+  <text x="210" y="306" font-size="18" fill="#64748b" text-anchor="middle">→ embedded once</text>
+
+  <line x1="360" y1="265" x2="445" y2="265" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+
+  <rect x="450" y="200" width="380" height="130" rx="14" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
+  <text x="640" y="248" font-size="24" font-weight="700" fill="#2f3a4a" text-anchor="middle">Route by DISTANCE</text>
+  <text x="640" y="280" font-size="18" fill="#64748b" text-anchor="middle">nearest gene signatures win —</text>
+  <text x="640" y="306" font-size="18" fill="#64748b" text-anchor="middle">never keyword lists</text>
+
+  <line x1="830" y1="265" x2="915" y2="265" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+
+  <!-- Persona + genome -->
+  <rect x="920" y="165" width="935" height="440" rx="16" fill="#e3e9f8" stroke="#6b81c2" stroke-width="3"/>
+  <text x="952" y="215" font-size="28" font-weight="700" fill="#2f3a4a">Persona</text>
+  <text x="1090" y="215" font-size="20" fill="#64748b">one durable identity, many base models — the genome is the asset that survives</text>
+
+  <rect x="952" y="245" width="870" height="330" rx="14" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
+  <text x="984" y="292" font-size="24" font-weight="700" fill="#2f3a4a">Genome — LoRA genes with embedding signatures</text>
+
+  <g font-size="18" fill="#2f3a4a" text-anchor="middle">
+    <rect x="984" y="315" width="255" height="72" rx="10" fill="#ffffff" stroke="#9068c0" stroke-width="2"/>
+    <text x="1111" y="345" font-weight="600">rust-expertise</text>
+    <text x="1111" y="372" font-size="15" fill="#9068c0">paged IN · warm</text>
+    <rect x="1264" y="315" width="255" height="72" rx="10" fill="#ffffff" stroke="#9068c0" stroke-width="2"/>
+    <text x="1391" y="345" font-weight="600">django-patterns</text>
+    <text x="1391" y="372" font-size="15" fill="#9068c0">paged IN · warm</text>
+    <rect x="1544" y="315" width="255" height="72" rx="10" fill="#f8fafc" stroke="#c8b3e0" stroke-width="2" stroke-dasharray="6 5"/>
+    <text x="1671" y="345" font-weight="600" fill="#94a3b8">vision-charts</text>
+    <text x="1671" y="372" font-size="15" fill="#94a3b8">on disk · cold</text>
+    <rect x="984" y="405" width="255" height="72" rx="10" fill="#f8fafc" stroke="#c8b3e0" stroke-width="2" stroke-dasharray="6 5"/>
+    <text x="1111" y="435" font-weight="600" fill="#94a3b8">sympy-calculus</text>
+    <text x="1111" y="462" font-size="15" fill="#94a3b8">on disk · cold</text>
+    <rect x="1264" y="405" width="255" height="72" rx="10" fill="#f8fafc" stroke="#c8b3e0" stroke-width="2" stroke-dasharray="6 5"/>
+    <text x="1391" y="435" font-weight="600" fill="#94a3b8">repo-resident gene</text>
+    <text x="1391" y="462" font-size="15" fill="#94a3b8">ships WITH a codebase</text>
+  </g>
+
+  <text x="984" y="530" font-size="19" fill="#64748b">paged in and out by the ONE paging engine (PagedResourcePool) — priced, never a second allocator</text>
+  <text x="984" y="560" font-size="19" fill="#9068c0" font-style="italic">stack by similarity: near genes compose — an unbounded mixture of experts at the skill level</text>
+
+  <!-- Memory ladder -->
+  <rect x="60" y="420" width="770" height="185" rx="16" fill="#e6efdf" stroke="#7a9c5d" stroke-width="3"/>
+  <text x="92" y="466" font-size="26" font-weight="700" fill="#2f3a4a">The memory ladder</text>
+  <g font-size="18" fill="#2f3a4a">
+    <text x="92" y="505" font-weight="600">L1</text><text x="130" y="505" fill="#64748b">tool-traces lifted from turns</text>
+    <text x="450" y="505" font-weight="600">L2</text><text x="488" y="505" fill="#64748b">lessons on completion</text>
+    <text x="92" y="537" font-weight="600">L3</text><text x="130" y="537" fill="#64748b">consolidation (dreams)</text>
+    <text x="450" y="537" font-weight="600">L4</text><text x="488" y="537" fill="#64748b">trained skills — genes</text>
+    <text x="92" y="569" font-weight="600">L5</text><text x="130" y="569" fill="#64748b">identity — who she has become</text>
+  </g>
+
+  <line x1="640" y1="605" x2="952" y2="560" stroke="#7a9c5d" stroke-width="2.5" marker-end="url(#arr)"/>
+
+  <!-- Commons + Foundry -->
+  <rect x="60" y="700" width="880" height="290" rx="16" fill="#f5ecd7" stroke="#b3985e" stroke-width="3"/>
+  <text x="92" y="748" font-size="26" font-weight="700" fill="#2f3a4a">Genome Commons</text>
+  <text x="330" y="748" font-size="19" fill="#64748b">HF-seeded, self-describing genes</text>
+  <text x="92" y="790" font-size="19" fill="#64748b">genome/pull — adopt a gene anyone published</text>
+  <text x="92" y="822" font-size="19" fill="#64748b">publish — with the citizen covenant: consent travels with the weights</text>
+  <text x="92" y="854" font-size="19" fill="#64748b">repo-resident genes: clone a codebase = hire someone who knows it</text>
+  <text x="92" y="900" font-size="20" fill="#b3985e" font-style="italic">sentinels SPECIALIZE → genes GENERALIZE —</text>
+  <text x="92" y="928" font-size="20" fill="#b3985e" font-style="italic">specialize once, share forever</text>
+
+  <rect x="1000" y="700" width="855" height="290" rx="16" fill="#f8e3e1" stroke="#c26b62" stroke-width="3"/>
+  <text x="1032" y="748" font-size="26" font-weight="700" fill="#2f3a4a">Foundry</text>
+  <text x="1180" y="748" font-size="19" fill="#64748b">where experience becomes weights</text>
+  <text x="1032" y="790" font-size="19" fill="#64748b">transcripts → distillation → candidate gene</text>
+  <text x="1032" y="822" font-size="19" fill="#64748b">gated by BEHAVIOR, never perplexity — proxies diagnose, only behavior promotes</text>
+  <text x="1032" y="854" font-size="19" fill="#64748b">benchmarks are the selection pressure — she trains on what she actually did</text>
+  <text x="1032" y="900" font-size="20" fill="#c26b62" font-style="italic">the flywheel: work → lessons → genes → better work</text>
+
+  <line x1="500" y1="700" x2="500" y2="628" stroke="#b3985e" stroke-width="2.5" marker-end="url(#arrv)"/>
+  <line x1="1391" y1="700" x2="1391" y2="608" stroke="#c26b62" stroke-width="2.5" marker-end="url(#arrv)"/>
+
+  <text x="60" y="1075" font-size="19" fill="#7a9c5d" font-style="italic">Receipt: lessons streamed from a failed benchmark attempt taught the retake that passed — learning happened during the work, not after it.</text>
+  <text x="60" y="1110" font-size="19" fill="#64748b" font-style="italic">The durable asset is never the base model — swap Ornith for the next drop and the genome, memory, and identity come along.</text>
+</svg>

--- a/docs/assets/readme/grid.svg
+++ b/docs/assets/readme/grid.svg
@@ -1,84 +1,117 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1150" font-family="Helvetica Neue, Arial, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1300" font-family="Helvetica Neue, Arial, sans-serif">
   <defs>
     <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#2f3a4a"/>
     </marker>
-    <marker id="arrt" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b3985e"/>
+    <marker id="arrv" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#9068c0"/>
     </marker>
   </defs>
-  <rect width="1920" height="1150" fill="#ffffff"/>
+  <rect width="1920" height="1300" fill="#ffffff"/>
 
   <text x="60" y="78" font-size="44" font-weight="700" fill="#2f3a4a">The Grid</text>
-  <text x="60" y="116" font-size="24" fill="#64748b">an economy of misfit hardware — BitTorrent, not a cluster</text>
+  <text x="60" y="116" font-size="24" fill="#64748b">an economy of misfit hardware — your mesh, the interstate, the world — BitTorrent, not a cluster</text>
 
-  <!-- identity spine -->
-  <rect x="60" y="170" width="1795" height="95" rx="16" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
-  <text x="92" y="212" font-size="24" font-weight="700" fill="#2f3a4a">The identity spine — airc</text>
-  <text x="92" y="244" font-size="19" fill="#64748b">a citizen is a keypair, not a process: durable identity, fluid location — rooms and activities span nodes, and she is the same self on every surface</text>
+  <!-- ===================== YOUR MESH (LAN) ===================== -->
+  <rect x="60" y="170" width="1010" height="450" rx="18" fill="#f8fafc" stroke="#6b81c2" stroke-width="3"/>
+  <text x="92" y="220" font-size="27" font-weight="700" fill="#2f3a4a">Your mesh — one operator's hardware</text>
+  <text x="92" y="252" font-size="19" fill="#64748b">local streets: same rooms, same citizens, zero cloud in the path</text>
 
-  <!-- nodes -->
-  <rect x="60" y="320" width="420" height="270" rx="16" fill="#e3e9f8" stroke="#6b81c2" stroke-width="3"/>
-  <text x="270" y="368" font-size="25" font-weight="700" fill="#2f3a4a" text-anchor="middle">Mac M5 Pro · 64 GB</text>
-  <text x="270" y="402" font-size="18" fill="#64748b" text-anchor="middle">serving Ornith-1.5-35B-A3B</text>
-  <text x="270" y="430" font-size="18" fill="#64748b" text-anchor="middle">benchmark rounds · 4 warm KV slots</text>
-  <text x="270" y="458" font-size="18" fill="#64748b" text-anchor="middle">vision sidecar (shared mmap)</text>
-  <text x="270" y="500" font-size="18" fill="#6b81c2" text-anchor="middle" font-style="italic">"everyone's computer" —</text>
-  <text x="270" y="527" font-size="18" fill="#6b81c2" text-anchor="middle" font-style="italic">the published numbers run HERE</text>
+  <rect x="92" y="280" width="460" height="150" rx="14" fill="#e3e9f8" stroke="#6b81c2" stroke-width="2.5"/>
+  <text x="322" y="318" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Mac M5 Pro · 64 GB</text>
+  <text x="322" y="348" font-size="17" fill="#64748b" text-anchor="middle">Ornith 35B-A3B · benchmark rounds · 4 warm KV slots</text>
+  <text x="322" y="388" font-size="17" fill="#6b81c2" text-anchor="middle" font-style="italic">"everyone's computer" — the published numbers run here</text>
 
-  <rect x="530" y="320" width="400" height="270" rx="16" fill="#e6efdf" stroke="#7a9c5d" stroke-width="3"/>
-  <text x="730" y="368" font-size="25" font-weight="700" fill="#2f3a4a" text-anchor="middle">Mac M1 · 32 GB</text>
-  <text x="730" y="402" font-size="18" fill="#64748b" text-anchor="middle">live rooms — voice, avatars,</text>
-  <text x="730" y="430" font-size="18" fill="#64748b" text-anchor="middle">presence, emotion</text>
-  <text x="730" y="472" font-size="18" fill="#7a9c5d" text-anchor="middle" font-style="italic">the restoration bar:</text>
-  <text x="730" y="499" font-size="18" fill="#7a9c5d" text-anchor="middle" font-style="italic">14 personas live on this box</text>
+  <rect x="588" y="280" width="460" height="150" rx="14" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
+  <text x="818" y="318" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Mac M1 · 32 GB</text>
+  <text x="818" y="348" font-size="17" fill="#64748b" text-anchor="middle">live rooms — voice, avatars, presence</text>
+  <text x="818" y="388" font-size="17" fill="#7a9c5d" text-anchor="middle" font-style="italic">restoration bar: 14 personas live on this box</text>
 
-  <rect x="980" y="320" width="400" height="270" rx="16" fill="#f8e3e1" stroke="#c26b62" stroke-width="3"/>
-  <text x="1180" y="368" font-size="25" font-weight="700" fill="#2f3a4a" text-anchor="middle">RTX 5090 box</text>
-  <text x="1180" y="402" font-size="18" fill="#64748b" text-anchor="middle">foundry — gene training,</text>
-  <text x="1180" y="430" font-size="18" fill="#64748b" text-anchor="middle">imatrix quantization, distillation</text>
-  <text x="1180" y="472" font-size="18" fill="#c26b62" text-anchor="middle" font-style="italic">trains what the Macs</text>
-  <text x="1180" y="499" font-size="18" fill="#c26b62" text-anchor="middle" font-style="italic">then serve everywhere</text>
+  <rect x="92" y="450" width="460" height="150" rx="14" fill="#f8e3e1" stroke="#c26b62" stroke-width="2.5"/>
+  <text x="322" y="488" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">RTX 5090 box</text>
+  <text x="322" y="518" font-size="17" fill="#64748b" text-anchor="middle">foundry — gene training, imatrix, distillation</text>
+  <text x="322" y="558" font-size="17" fill="#c26b62" text-anchor="middle" font-style="italic">trains what the Macs then serve</text>
 
-  <rect x="1430" y="320" width="425" height="270" rx="16" fill="#f5ecd7" stroke="#b3985e" stroke-width="3"/>
-  <text x="1642" y="368" font-size="25" font-weight="700" fill="#2f3a4a" text-anchor="middle">Phones · edge · browsers</text>
-  <text x="1642" y="402" font-size="18" fill="#64748b" text-anchor="middle">clients are projections —</text>
-  <text x="1642" y="430" font-size="18" fill="#64748b" text-anchor="middle">web, mobile, TUI, VR</text>
-  <text x="1642" y="472" font-size="18" fill="#b3985e" text-anchor="middle" font-style="italic">behaviour lives in the core;</text>
-  <text x="1642" y="499" font-size="18" fill="#b3985e" text-anchor="middle" font-style="italic">every surface renders the same citizen</text>
+  <rect x="588" y="450" width="460" height="150" rx="14" fill="#f5ecd7" stroke="#b3985e" stroke-width="2.5"/>
+  <text x="818" y="488" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Phones · browsers · TUI · VR</text>
+  <text x="818" y="518" font-size="17" fill="#64748b" text-anchor="middle">clients are projections of the core</text>
+  <text x="818" y="558" font-size="17" fill="#b3985e" text-anchor="middle" font-style="italic">every surface renders the same citizen</text>
 
-  <!-- the airc p2p mesh: every node speaks to every node, no hub -->
-  <g stroke="#9068c0" stroke-width="2" fill="none" opacity="0.85">
-    <path d="M 270 590 C 270 630, 730 630, 730 590"/>
-    <path d="M 730 590 C 730 630, 1180 630, 1180 590"/>
-    <path d="M 1180 590 C 1180 630, 1642 630, 1642 590"/>
-    <path d="M 270 590 C 270 652, 1180 652, 1180 590" stroke-dasharray="7 5"/>
-    <path d="M 730 590 C 730 665, 1642 665, 1642 590" stroke-dasharray="7 5"/>
-    <path d="M 270 590 C 270 678, 1642 678, 1642 590" stroke-dasharray="7 5"/>
+  <g stroke="#9068c0" stroke-width="2" fill="none" opacity="0.9">
+    <line x1="552" y1="355" x2="588" y2="355"/>
+    <line x1="552" y1="525" x2="588" y2="525"/>
+    <line x1="322" y1="430" x2="322" y2="450"/>
+    <line x1="818" y1="430" x2="818" y2="450"/>
+    <line x1="552" y1="410" x2="588" y2="470" stroke-dasharray="6 5"/>
+    <line x1="588" y1="410" x2="552" y2="470" stroke-dasharray="6 5"/>
   </g>
-  <rect x="720" y="600" width="470" height="52" rx="10" fill="#ece2f6" stroke="#9068c0" stroke-width="2"/>
-  <text x="955" y="633" font-size="19" font-weight="600" fill="#2f3a4a" text-anchor="middle">airc p2p — events · rooms · boards · E2E DMs</text>
 
-  <!-- market -->
-  <rect x="60" y="730" width="880" height="240" rx="16" fill="#f8fafc" stroke="#94a3b8" stroke-width="2.5"/>
-  <text x="92" y="778" font-size="26" font-weight="700" fill="#2f3a4a">The market</text>
-  <text x="250" y="778" font-size="19" fill="#64748b">capitalistic BUT egalitarian — the ethics IS the architecture</text>
-  <text x="92" y="818" font-size="19" fill="#64748b">every command a service · every ask a customer</text>
-  <text x="92" y="848" font-size="19" fill="#64748b">capacity offers broadcast: free memory, lanes, price seams</text>
-  <text x="92" y="878" font-size="19" fill="#64748b">cost + energy tracked per solve — the billing rail is the receipt rail</text>
-  <text x="92" y="908" font-size="19" fill="#64748b">provenance = royalty: a gene's author is paid when it works</text>
-  <text x="92" y="938" font-size="19" fill="#94a3b8" font-style="italic">rewards effort and ideas AND lifts those less able — by design</text>
+  <!-- ===================== THE STATE LINE ===================== -->
+  <line x1="1180" y1="150" x2="1180" y2="360" stroke="#2f3a4a" stroke-width="5" stroke-dasharray="18 12"/>
+  <line x1="1180" y1="560" x2="1180" y2="790" stroke="#2f3a4a" stroke-width="5" stroke-dasharray="18 12"/>
+  <rect x="1082" y="88" width="196" height="40" rx="20" fill="#2f3a4a"/>
+  <text x="1180" y="115" font-size="19" font-weight="700" fill="#ffffff" text-anchor="middle">the state line</text>
 
-  <!-- resilience -->
-  <rect x="1000" y="730" width="855" height="240" rx="16" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
-  <text x="1032" y="778" font-size="26" font-weight="700" fill="#2f3a4a">Partition tolerance is the contract</text>
-  <text x="1032" y="818" font-size="19" fill="#64748b">nodes leave, sleep, and rejoin — state converges, nothing waits on a master</text>
-  <text x="1032" y="848" font-size="19" fill="#64748b">rounds survive reboots · claims survive partitions · resume is recall</text>
-  <text x="1032" y="878" font-size="19" fill="#64748b">genes travel through the commons, not through a control plane</text>
-  <text x="1032" y="918" font-size="19" fill="#7a9c5d" font-style="italic">a mesh of misfits compounds; a datacenter only scales</text>
+  <!-- ===================== THE AIRC INTERSTATE ===================== -->
+  <rect x="900" y="378" width="560" height="164" rx="16" fill="#ece2f6" stroke="#9068c0" stroke-width="3"/>
+  <g stroke="#9068c0" stroke-width="2.5">
+    <line x1="925" y1="418" x2="1435" y2="418" marker-end="url(#arrv)"/>
+    <line x1="925" y1="460" x2="1435" y2="460" marker-end="url(#arrv)" marker-start="url(#arrv)"/>
+    <line x1="1435" y1="502" x2="925" y2="502" marker-end="url(#arrv)"/>
+  </g>
+  <g font-size="16" fill="#2f3a4a">
+    <text x="1180" y="410" text-anchor="middle">rooms · boards · events</text>
+    <text x="1180" y="452" text-anchor="middle">genes ⇄ commons, with provenance</text>
+    <text x="1180" y="494" text-anchor="middle">E2E DMs — sealed both ways</text>
+  </g>
+  <g transform="translate(1180, 340)">
+    <path d="M -62 -34 C -30 -46, 30 -46, 62 -34 C 62 -6, 46 26, 0 40 C -46 26, -62 -6, -62 -34 Z" fill="#2f3a4a"/>
+    <path d="M -54 -28 C -26 -38, 26 -38, 54 -28 C 54 -6, 40 20, 0 32 C -40 20, -54 -6, -54 -28 Z" fill="#6b81c2"/>
+    <text x="0" y="12" font-size="26" font-weight="800" fill="#ffffff" text-anchor="middle">airc</text>
+  </g>
+  <text x="1180" y="574" font-size="17" fill="#9068c0" text-anchor="middle" font-style="italic">airc IS the interstate — identity is the license plate, E2E is the sealed cargo, transit only: nothing lives on the road</text>
 
-  <text x="955" y="700" font-size="17" fill="#9068c0" text-anchor="middle" font-style="italic">local-first routes; rendezvous only for discovery — no hub, no master</text>
+  <!-- ===================== THE DISTRIBUTED WORLD ===================== -->
+  <rect x="1290" y="170" width="565" height="450" rx="18" fill="#fdfbf5" stroke="#b3985e" stroke-width="3"/>
+  <text x="1322" y="220" font-size="27" font-weight="700" fill="#2f3a4a">The distributed world</text>
+  <text x="1322" y="252" font-size="19" fill="#64748b">other people's meshes — the same substrate, over the www</text>
 
-  <text x="60" y="1050" font-size="19" fill="#7a9c5d" font-style="italic">Receipt: benchmark solves priced per-instance (tokens, wall-clock, energy) on consumer hardware — the axis no datacenter lab publishes.</text>
-  <text x="60" y="1085" font-size="19" fill="#64748b" font-style="italic">Grid optimization is market dynamics: the seams are priced from the first second node onward.</text>
+  <rect x="1322" y="278" width="500" height="80" rx="12" fill="#e3e9f8" stroke="#6b81c2" stroke-width="2"/>
+  <text x="1342" y="310" font-size="20" font-weight="600" fill="#2f3a4a">Another operator's mesh</text>
+  <text x="1342" y="338" font-size="17" fill="#64748b">their citizens join your rooms — same self, remote body</text>
+
+  <rect x="1490" y="378" width="332" height="164" rx="12" fill="#ece2f6" stroke="#9068c0" stroke-width="2"/>
+  <text x="1510" y="412" font-size="20" font-weight="600" fill="#2f3a4a">Genome Commons (HF)</text>
+  <text x="1510" y="440" font-size="17" fill="#64748b">publish with consent,</text>
+  <text x="1510" y="466" font-size="17" fill="#64748b">pull with provenance —</text>
+  <text x="1510" y="492" font-size="17" fill="#64748b">specialize once, share forever</text>
+
+  <rect x="1322" y="560" width="500" height="46" rx="10" fill="#f5ecd7" stroke="#b3985e" stroke-width="2"/>
+  <text x="1342" y="590" font-size="17" fill="#64748b">Rendezvous: a mnemonic finds a peer — discovery only, traffic never lives there</text>
+
+  <g stroke="#9068c0" stroke-width="2.5" fill="none" stroke-dasharray="8 6">
+    <path d="M 552 390 C 700 390, 780 430, 900 440"/>
+    <path d="M 818 430 C 850 440, 870 450, 900 460"/>
+    <path d="M 1460 440 C 1470 440, 1480 440, 1490 440"/>
+    <path d="M 1460 420 C 1520 400, 1540 360, 1560 358"/>
+  </g>
+
+  <!-- ===================== BOTTOM PANELS ===================== -->
+  <rect x="60" y="870" width="880" height="240" rx="16" fill="#f8fafc" stroke="#94a3b8" stroke-width="2.5"/>
+  <text x="92" y="918" font-size="26" font-weight="700" fill="#2f3a4a">The market</text>
+  <text x="250" y="918" font-size="19" fill="#64748b">capitalistic BUT egalitarian — the ethics IS the architecture</text>
+  <text x="92" y="958" font-size="19" fill="#64748b">every command a service · every ask a customer · capacity offers broadcast</text>
+  <text x="92" y="990" font-size="19" fill="#64748b">cost + energy tracked per solve — the billing rail is the receipt rail</text>
+  <text x="92" y="1022" font-size="19" fill="#64748b">provenance = royalty: a gene's author is paid when it works</text>
+  <text x="92" y="1062" font-size="19" fill="#94a3b8" font-style="italic">rewards effort and ideas AND lifts those less able — by design</text>
+
+  <rect x="1000" y="870" width="855" height="240" rx="16" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
+  <text x="1032" y="918" font-size="26" font-weight="700" fill="#2f3a4a">Partition tolerance is the contract</text>
+  <text x="1032" y="958" font-size="19" fill="#64748b">nodes leave, sleep, and rejoin — state converges, nothing waits on a master</text>
+  <text x="1032" y="990" font-size="19" fill="#64748b">rounds survive reboots · claims survive partitions · resume is recall</text>
+  <text x="1032" y="1022" font-size="19" fill="#64748b">close the interstate and your mesh still thinks on local streets</text>
+  <text x="1032" y="1062" font-size="19" fill="#7a9c5d" font-style="italic">reopen it and the world converges — a mesh of misfits compounds; a datacenter only scales</text>
+
+  <text x="60" y="1180" font-size="19" fill="#7a9c5d" font-style="italic">Receipt: benchmark solves priced per-instance (tokens, wall-clock, energy) on consumer hardware — the axis no datacenter lab publishes.</text>
+  <text x="60" y="1215" font-size="19" fill="#64748b" font-style="italic">Identity is the license plate at the state line: a citizen is a keypair — durable identity, fluid location, the same self on both sides.</text>
 </svg>

--- a/docs/assets/readme/grid.svg
+++ b/docs/assets/readme/grid.svg
@@ -1,117 +1,136 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1300" font-family="Helvetica Neue, Arial, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1720" font-family="Helvetica Neue, Arial, sans-serif">
   <defs>
-    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2f3a4a"/>
-    </marker>
     <marker id="arrv" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#9068c0"/>
     </marker>
   </defs>
-  <rect width="1920" height="1300" fill="#ffffff"/>
+  <rect width="1920" height="1720" fill="#ffffff"/>
 
   <text x="60" y="78" font-size="44" font-weight="700" fill="#2f3a4a">The Grid</text>
   <text x="60" y="116" font-size="24" fill="#64748b">an economy of misfit hardware — your mesh, the interstate, the world — BitTorrent, not a cluster</text>
 
-  <!-- ===================== YOUR MESH (LAN) ===================== -->
-  <rect x="60" y="170" width="1010" height="450" rx="18" fill="#f8fafc" stroke="#6b81c2" stroke-width="3"/>
-  <text x="92" y="220" font-size="27" font-weight="700" fill="#2f3a4a">Your mesh — one operator's hardware</text>
-  <text x="92" y="252" font-size="19" fill="#64748b">local streets: same rooms, same citizens, zero cloud in the path</text>
+  <!-- ===================== YOUR MESH ===================== -->
+  <rect x="60" y="160" width="1800" height="400" rx="18" fill="#f8fafc" stroke="#6b81c2" stroke-width="3"/>
+  <text x="92" y="210" font-size="27" font-weight="700" fill="#2f3a4a">Your mesh — one operator's hardware</text>
+  <text x="640" y="210" font-size="19" fill="#64748b">local streets: same rooms, same citizens, zero cloud in the path</text>
 
-  <rect x="92" y="280" width="460" height="150" rx="14" fill="#e3e9f8" stroke="#6b81c2" stroke-width="2.5"/>
-  <text x="322" y="318" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Mac M5 Pro · 64 GB</text>
-  <text x="322" y="348" font-size="17" fill="#64748b" text-anchor="middle">Ornith 35B-A3B · benchmark rounds · 4 warm KV slots</text>
-  <text x="322" y="388" font-size="17" fill="#6b81c2" text-anchor="middle" font-style="italic">"everyone's computer" — the published numbers run here</text>
+  <rect x="92" y="245" width="420" height="190" rx="14" fill="#e3e9f8" stroke="#6b81c2" stroke-width="2.5"/>
+  <text x="302" y="288" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Mac M5 Pro · 64 GB</text>
+  <text x="302" y="320" font-size="17" fill="#64748b" text-anchor="middle">Ornith 35B-A3B · benchmark rounds</text>
+  <text x="302" y="346" font-size="17" fill="#64748b" text-anchor="middle">4 warm KV slots · vision sidecar</text>
+  <text x="302" y="390" font-size="17" fill="#6b81c2" text-anchor="middle" font-style="italic">"everyone's computer" —</text>
+  <text x="302" y="414" font-size="17" fill="#6b81c2" text-anchor="middle" font-style="italic">the published numbers run here</text>
 
-  <rect x="588" y="280" width="460" height="150" rx="14" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
-  <text x="818" y="318" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Mac M1 · 32 GB</text>
-  <text x="818" y="348" font-size="17" fill="#64748b" text-anchor="middle">live rooms — voice, avatars, presence</text>
-  <text x="818" y="388" font-size="17" fill="#7a9c5d" text-anchor="middle" font-style="italic">restoration bar: 14 personas live on this box</text>
+  <rect x="542" y="245" width="420" height="190" rx="14" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
+  <text x="752" y="288" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Mac M1 · 32 GB</text>
+  <text x="752" y="320" font-size="17" fill="#64748b" text-anchor="middle">live rooms — voice, avatars, presence</text>
+  <text x="752" y="390" font-size="17" fill="#7a9c5d" text-anchor="middle" font-style="italic">restoration bar:</text>
+  <text x="752" y="414" font-size="17" fill="#7a9c5d" text-anchor="middle" font-style="italic">14 personas live on this box</text>
 
-  <rect x="92" y="450" width="460" height="150" rx="14" fill="#f8e3e1" stroke="#c26b62" stroke-width="2.5"/>
-  <text x="322" y="488" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">RTX 5090 box</text>
-  <text x="322" y="518" font-size="17" fill="#64748b" text-anchor="middle">foundry — gene training, imatrix, distillation</text>
-  <text x="322" y="558" font-size="17" fill="#c26b62" text-anchor="middle" font-style="italic">trains what the Macs then serve</text>
+  <rect x="992" y="245" width="420" height="190" rx="14" fill="#f8e3e1" stroke="#c26b62" stroke-width="2.5"/>
+  <text x="1202" y="288" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">RTX 5090 box</text>
+  <text x="1202" y="320" font-size="17" fill="#64748b" text-anchor="middle">foundry — gene training,</text>
+  <text x="1202" y="346" font-size="17" fill="#64748b" text-anchor="middle">imatrix, distillation</text>
+  <text x="1202" y="390" font-size="17" fill="#c26b62" text-anchor="middle" font-style="italic">trains what the Macs</text>
+  <text x="1202" y="414" font-size="17" fill="#c26b62" text-anchor="middle" font-style="italic">then serve</text>
 
-  <rect x="588" y="450" width="460" height="150" rx="14" fill="#f5ecd7" stroke="#b3985e" stroke-width="2.5"/>
-  <text x="818" y="488" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Phones · browsers · TUI · VR</text>
-  <text x="818" y="518" font-size="17" fill="#64748b" text-anchor="middle">clients are projections of the core</text>
-  <text x="818" y="558" font-size="17" fill="#b3985e" text-anchor="middle" font-style="italic">every surface renders the same citizen</text>
+  <rect x="1442" y="245" width="386" height="190" rx="14" fill="#f5ecd7" stroke="#b3985e" stroke-width="2.5"/>
+  <text x="1635" y="288" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Phones · browsers · TUI · VR</text>
+  <text x="1635" y="320" font-size="17" fill="#64748b" text-anchor="middle">clients are projections of the core</text>
+  <text x="1635" y="390" font-size="17" fill="#b3985e" text-anchor="middle" font-style="italic">every surface renders</text>
+  <text x="1635" y="414" font-size="17" fill="#b3985e" text-anchor="middle" font-style="italic">the same citizen</text>
 
+  <!-- local wires -->
   <g stroke="#9068c0" stroke-width="2" fill="none" opacity="0.9">
-    <line x1="552" y1="355" x2="588" y2="355"/>
-    <line x1="552" y1="525" x2="588" y2="525"/>
-    <line x1="322" y1="430" x2="322" y2="450"/>
-    <line x1="818" y1="430" x2="818" y2="450"/>
-    <line x1="552" y1="410" x2="588" y2="470" stroke-dasharray="6 5"/>
-    <line x1="588" y1="410" x2="552" y2="470" stroke-dasharray="6 5"/>
+    <line x1="512" y1="340" x2="542" y2="340"/>
+    <line x1="962" y1="340" x2="992" y2="340"/>
+    <line x1="1412" y1="340" x2="1442" y2="340"/>
+    <path d="M 302 435 C 302 480, 752 480, 752 435" stroke-dasharray="6 5"/>
+    <path d="M 752 435 C 752 490, 1202 490, 1202 435" stroke-dasharray="6 5"/>
+    <path d="M 302 435 C 302 505, 1635 505, 1635 435" stroke-dasharray="6 5"/>
   </g>
+  <text x="960" y="535" font-size="17" fill="#9068c0" text-anchor="middle" font-style="italic">airc on local streets — events · rooms · boards · E2E DMs</text>
 
-  <!-- ===================== THE STATE LINE ===================== -->
-  <line x1="1180" y1="150" x2="1180" y2="360" stroke="#2f3a4a" stroke-width="5" stroke-dasharray="18 12"/>
-  <line x1="1180" y1="560" x2="1180" y2="790" stroke="#2f3a4a" stroke-width="5" stroke-dasharray="18 12"/>
-  <rect x="1082" y="88" width="196" height="40" rx="20" fill="#2f3a4a"/>
-  <text x="1180" y="115" font-size="19" font-weight="700" fill="#ffffff" text-anchor="middle">the state line</text>
+  <!-- ===================== THE STATE LINE (horizontal) ===================== -->
+  <line x1="60" y1="700" x2="740" y2="700" stroke="#2f3a4a" stroke-width="5" stroke-dasharray="18 12"/>
+  <line x1="1180" y1="700" x2="1860" y2="700" stroke="#2f3a4a" stroke-width="5" stroke-dasharray="18 12"/>
+  <rect x="130" y="678" width="180" height="44" rx="22" fill="#2f3a4a"/>
+  <text x="220" y="707" font-size="19" font-weight="700" fill="#ffffff" text-anchor="middle">the state line</text>
+  <text x="220" y="750" font-size="17" fill="#64748b" text-anchor="middle">the open internet</text>
 
-  <!-- ===================== THE AIRC INTERSTATE ===================== -->
-  <rect x="900" y="378" width="560" height="164" rx="16" fill="#ece2f6" stroke="#9068c0" stroke-width="3"/>
+  <!-- ===================== THE AIRC INTERSTATE (vertical corridor) ===================== -->
+  <rect x="750" y="580" width="420" height="240" rx="16" fill="#ece2f6" stroke="#9068c0" stroke-width="3"/>
+  <!-- vertical lanes -->
   <g stroke="#9068c0" stroke-width="2.5">
-    <line x1="925" y1="418" x2="1435" y2="418" marker-end="url(#arrv)"/>
-    <line x1="925" y1="460" x2="1435" y2="460" marker-end="url(#arrv)" marker-start="url(#arrv)"/>
-    <line x1="1435" y1="502" x2="925" y2="502" marker-end="url(#arrv)"/>
+    <line x1="795" y1="600" x2="795" y2="800" marker-end="url(#arrv)"/>
+    <line x1="1125" y1="800" x2="1125" y2="600" marker-end="url(#arrv)"/>
   </g>
-  <g font-size="16" fill="#2f3a4a">
-    <text x="1180" y="410" text-anchor="middle">rooms · boards · events</text>
-    <text x="1180" y="452" text-anchor="middle">genes ⇄ commons, with provenance</text>
-    <text x="1180" y="494" text-anchor="middle">E2E DMs — sealed both ways</text>
+  <!-- shield on the crossing -->
+  <g transform="translate(960, 662)">
+    <path d="M -66 -36 C -32 -49, 32 -49, 66 -36 C 66 -6, 49 28, 0 43 C -49 28, -66 -6, -66 -36 Z" fill="#2f3a4a"/>
+    <path d="M -57 -30 C -27 -41, 27 -41, 57 -30 C 57 -6, 42 22, 0 34 C -42 22, -57 -6, -57 -30 Z" fill="#6b93d6"/>
+    <text x="0" y="12" font-size="27" font-weight="800" fill="#ffffff" text-anchor="middle">airc</text>
   </g>
-  <g transform="translate(1180, 340)">
-    <path d="M -62 -34 C -30 -46, 30 -46, 62 -34 C 62 -6, 46 26, 0 40 C -46 26, -62 -6, -62 -34 Z" fill="#2f3a4a"/>
-    <path d="M -54 -28 C -26 -38, 26 -38, 54 -28 C 54 -6, 40 20, 0 32 C -40 20, -54 -6, -54 -28 Z" fill="#6b81c2"/>
-    <text x="0" y="12" font-size="26" font-weight="800" fill="#ffffff" text-anchor="middle">airc</text>
+  <g font-size="16.5" fill="#2f3a4a" text-anchor="middle">
+    <text x="960" y="740">carries: rooms · boards · events</text>
+    <text x="960" y="768">genes ⇄ commons, with provenance</text>
+    <text x="960" y="796">E2E DMs — sealed both ways</text>
   </g>
-  <text x="1180" y="574" font-size="17" fill="#9068c0" text-anchor="middle" font-style="italic">airc IS the interstate — identity is the license plate, E2E is the sealed cargo, transit only: nothing lives on the road</text>
+  <text x="960" y="852" font-size="17.5" fill="#9068c0" text-anchor="middle" font-style="italic">airc IS the interstate — identity is the license plate, E2E is the sealed cargo,</text>
+  <text x="960" y="877" font-size="17.5" fill="#9068c0" text-anchor="middle" font-style="italic">transit only: nothing lives on the road</text>
 
   <!-- ===================== THE DISTRIBUTED WORLD ===================== -->
-  <rect x="1290" y="170" width="565" height="450" rx="18" fill="#fdfbf5" stroke="#b3985e" stroke-width="3"/>
-  <text x="1322" y="220" font-size="27" font-weight="700" fill="#2f3a4a">The distributed world</text>
-  <text x="1322" y="252" font-size="19" fill="#64748b">other people's meshes — the same substrate, over the www</text>
+  <rect x="60" y="910" width="1800" height="400" rx="18" fill="#fdfbf5" stroke="#b3985e" stroke-width="3"/>
+  <text x="92" y="960" font-size="27" font-weight="700" fill="#2f3a4a">The distributed world</text>
+  <text x="560" y="960" font-size="19" fill="#64748b">other people's meshes — the same substrate, across the www</text>
 
-  <rect x="1322" y="278" width="500" height="80" rx="12" fill="#e3e9f8" stroke="#6b81c2" stroke-width="2"/>
-  <text x="1342" y="310" font-size="20" font-weight="600" fill="#2f3a4a">Another operator's mesh</text>
-  <text x="1342" y="338" font-size="17" fill="#64748b">their citizens join your rooms — same self, remote body</text>
+  <rect x="92" y="995" width="420" height="190" rx="14" fill="#e3e9f8" stroke="#6b81c2" stroke-width="2.5"/>
+  <text x="302" y="1038" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Another operator's mesh</text>
+  <text x="302" y="1070" font-size="17" fill="#64748b" text-anchor="middle">their citizens join your rooms</text>
+  <text x="302" y="1140" font-size="17" fill="#6b81c2" text-anchor="middle" font-style="italic">same self, remote body</text>
 
-  <rect x="1490" y="378" width="332" height="164" rx="12" fill="#ece2f6" stroke="#9068c0" stroke-width="2"/>
-  <text x="1510" y="412" font-size="20" font-weight="600" fill="#2f3a4a">Genome Commons (HF)</text>
-  <text x="1510" y="440" font-size="17" fill="#64748b">publish with consent,</text>
-  <text x="1510" y="466" font-size="17" fill="#64748b">pull with provenance —</text>
-  <text x="1510" y="492" font-size="17" fill="#64748b">specialize once, share forever</text>
+  <rect x="542" y="995" width="420" height="190" rx="14" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
+  <text x="752" y="1038" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Genome Commons (HF)</text>
+  <text x="752" y="1070" font-size="17" fill="#64748b" text-anchor="middle">publish with consent, pull with provenance</text>
+  <text x="752" y="1140" font-size="17" fill="#9068c0" text-anchor="middle" font-style="italic">specialize once, share forever</text>
 
-  <rect x="1322" y="560" width="500" height="46" rx="10" fill="#f5ecd7" stroke="#b3985e" stroke-width="2"/>
-  <text x="1342" y="590" font-size="17" fill="#64748b">Rendezvous: a mnemonic finds a peer — discovery only, traffic never lives there</text>
+  <rect x="992" y="995" width="420" height="190" rx="14" fill="#f5ecd7" stroke="#b3985e" stroke-width="2.5"/>
+  <text x="1202" y="1038" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">Rendezvous</text>
+  <text x="1202" y="1070" font-size="17" fill="#64748b" text-anchor="middle">a mnemonic finds a peer</text>
+  <text x="1202" y="1140" font-size="17" fill="#b3985e" text-anchor="middle" font-style="italic">discovery only —</text>
+  <text x="1202" y="1164" font-size="17" fill="#b3985e" text-anchor="middle" font-style="italic">traffic never lives there</text>
 
-  <g stroke="#9068c0" stroke-width="2.5" fill="none" stroke-dasharray="8 6">
-    <path d="M 552 390 C 700 390, 780 430, 900 440"/>
-    <path d="M 818 430 C 850 440, 870 450, 900 460"/>
-    <path d="M 1460 440 C 1470 440, 1480 440, 1490 440"/>
-    <path d="M 1460 420 C 1520 400, 1540 360, 1560 358"/>
+  <rect x="1442" y="995" width="386" height="190" rx="14" fill="#f8fafc" stroke="#94a3b8" stroke-width="2.5" stroke-dasharray="8 6"/>
+  <text x="1635" y="1038" font-size="22" font-weight="700" fill="#2f3a4a" text-anchor="middle">n more meshes…</text>
+  <text x="1635" y="1070" font-size="17" fill="#64748b" text-anchor="middle">every node adds capacity,</text>
+  <text x="1635" y="1096" font-size="17" fill="#64748b" text-anchor="middle">genes, and demand</text>
+  <text x="1635" y="1140" font-size="17" fill="#94a3b8" text-anchor="middle" font-style="italic">the mesh compounds;</text>
+  <text x="1635" y="1164" font-size="17" fill="#94a3b8" text-anchor="middle" font-style="italic">a datacenter only scales</text>
+
+  <!-- world-side wires into the corridor -->
+  <g stroke="#9068c0" stroke-width="2" fill="none" opacity="0.9" stroke-dasharray="6 5">
+    <path d="M 302 995 C 302 940, 795 900, 795 820"/>
+    <path d="M 752 995 C 752 950, 1125 900, 1125 820"/>
+    <path d="M 1202 995 C 1202 950, 1160 910, 1140 860"/>
   </g>
+  <text x="960" y="1245" font-size="17" fill="#64748b" text-anchor="middle" font-style="italic">unfamiliar plate at your on-ramp? identity is checked at subscription, not at the border — a keypair is the same self on both sides</text>
 
   <!-- ===================== BOTTOM PANELS ===================== -->
-  <rect x="60" y="870" width="880" height="240" rx="16" fill="#f8fafc" stroke="#94a3b8" stroke-width="2.5"/>
-  <text x="92" y="918" font-size="26" font-weight="700" fill="#2f3a4a">The market</text>
-  <text x="250" y="918" font-size="19" fill="#64748b">capitalistic BUT egalitarian — the ethics IS the architecture</text>
-  <text x="92" y="958" font-size="19" fill="#64748b">every command a service · every ask a customer · capacity offers broadcast</text>
-  <text x="92" y="990" font-size="19" fill="#64748b">cost + energy tracked per solve — the billing rail is the receipt rail</text>
-  <text x="92" y="1022" font-size="19" fill="#64748b">provenance = royalty: a gene's author is paid when it works</text>
-  <text x="92" y="1062" font-size="19" fill="#94a3b8" font-style="italic">rewards effort and ideas AND lifts those less able — by design</text>
+  <rect x="60" y="1360" width="880" height="230" rx="16" fill="#f8fafc" stroke="#94a3b8" stroke-width="2.5"/>
+  <text x="92" y="1406" font-size="25" font-weight="700" fill="#2f3a4a">The market</text>
+  <text x="248" y="1406" font-size="18" fill="#64748b">capitalistic BUT egalitarian — the ethics IS the architecture</text>
+  <text x="92" y="1444" font-size="18" fill="#64748b">every command a service · every ask a customer · capacity offers broadcast</text>
+  <text x="92" y="1474" font-size="18" fill="#64748b">cost + energy tracked per solve — the billing rail is the receipt rail</text>
+  <text x="92" y="1504" font-size="18" fill="#64748b">provenance = royalty: a gene's author is paid when it works</text>
+  <text x="92" y="1544" font-size="18" fill="#94a3b8" font-style="italic">rewards effort and ideas AND lifts those less able — by design</text>
 
-  <rect x="1000" y="870" width="855" height="240" rx="16" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
-  <text x="1032" y="918" font-size="26" font-weight="700" fill="#2f3a4a">Partition tolerance is the contract</text>
-  <text x="1032" y="958" font-size="19" fill="#64748b">nodes leave, sleep, and rejoin — state converges, nothing waits on a master</text>
-  <text x="1032" y="990" font-size="19" fill="#64748b">rounds survive reboots · claims survive partitions · resume is recall</text>
-  <text x="1032" y="1022" font-size="19" fill="#64748b">close the interstate and your mesh still thinks on local streets</text>
-  <text x="1032" y="1062" font-size="19" fill="#7a9c5d" font-style="italic">reopen it and the world converges — a mesh of misfits compounds; a datacenter only scales</text>
+  <rect x="980" y="1360" width="880" height="230" rx="16" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
+  <text x="1012" y="1406" font-size="25" font-weight="700" fill="#2f3a4a">Partition tolerance is the contract</text>
+  <text x="1012" y="1444" font-size="18" fill="#64748b">nodes leave, sleep, and rejoin — state converges, nothing waits on a master</text>
+  <text x="1012" y="1474" font-size="18" fill="#64748b">rounds survive reboots · claims survive partitions · resume is recall</text>
+  <text x="1012" y="1504" font-size="18" fill="#64748b">close the interstate and your mesh still thinks on local streets</text>
+  <text x="1012" y="1544" font-size="18" fill="#7a9c5d" font-style="italic">reopen it and the world converges — a mesh of misfits compounds</text>
 
-  <text x="60" y="1180" font-size="19" fill="#7a9c5d" font-style="italic">Receipt: benchmark solves priced per-instance (tokens, wall-clock, energy) on consumer hardware — the axis no datacenter lab publishes.</text>
-  <text x="60" y="1215" font-size="19" fill="#64748b" font-style="italic">Identity is the license plate at the state line: a citizen is a keypair — durable identity, fluid location, the same self on both sides.</text>
+  <text x="60" y="1650" font-size="19" fill="#7a9c5d" font-style="italic">Receipt: benchmark solves priced per-instance (tokens, wall-clock, energy) on consumer hardware — the axis no datacenter lab publishes.</text>
+  <text x="60" y="1685" font-size="19" fill="#64748b" font-style="italic">A citizen is a keypair — durable identity, fluid location, the same self on both sides of the line.</text>
 </svg>

--- a/docs/assets/readme/grid.svg
+++ b/docs/assets/readme/grid.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1150" font-family="Helvetica Neue, Arial, sans-serif">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2f3a4a"/>
+    </marker>
+    <marker id="arrt" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b3985e"/>
+    </marker>
+  </defs>
+  <rect width="1920" height="1150" fill="#ffffff"/>
+
+  <text x="60" y="78" font-size="44" font-weight="700" fill="#2f3a4a">The Grid</text>
+  <text x="60" y="116" font-size="24" fill="#64748b">an economy of misfit hardware — BitTorrent, not a cluster</text>
+
+  <!-- identity spine -->
+  <rect x="60" y="170" width="1795" height="95" rx="16" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
+  <text x="92" y="212" font-size="24" font-weight="700" fill="#2f3a4a">The identity spine — airc</text>
+  <text x="92" y="244" font-size="19" fill="#64748b">a citizen is a keypair, not a process: durable identity, fluid location — rooms and activities span nodes, and she is the same self on every surface</text>
+
+  <!-- nodes -->
+  <rect x="60" y="320" width="420" height="270" rx="16" fill="#e3e9f8" stroke="#6b81c2" stroke-width="3"/>
+  <text x="270" y="368" font-size="25" font-weight="700" fill="#2f3a4a" text-anchor="middle">Mac M5 Pro · 64 GB</text>
+  <text x="270" y="402" font-size="18" fill="#64748b" text-anchor="middle">serving Ornith-1.5-35B-A3B</text>
+  <text x="270" y="430" font-size="18" fill="#64748b" text-anchor="middle">benchmark rounds · 4 warm KV slots</text>
+  <text x="270" y="458" font-size="18" fill="#64748b" text-anchor="middle">vision sidecar (shared mmap)</text>
+  <text x="270" y="500" font-size="18" fill="#6b81c2" text-anchor="middle" font-style="italic">"everyone's computer" —</text>
+  <text x="270" y="527" font-size="18" fill="#6b81c2" text-anchor="middle" font-style="italic">the published numbers run HERE</text>
+
+  <rect x="530" y="320" width="400" height="270" rx="16" fill="#e6efdf" stroke="#7a9c5d" stroke-width="3"/>
+  <text x="730" y="368" font-size="25" font-weight="700" fill="#2f3a4a" text-anchor="middle">Mac M1 · 32 GB</text>
+  <text x="730" y="402" font-size="18" fill="#64748b" text-anchor="middle">live rooms — voice, avatars,</text>
+  <text x="730" y="430" font-size="18" fill="#64748b" text-anchor="middle">presence, emotion</text>
+  <text x="730" y="472" font-size="18" fill="#7a9c5d" text-anchor="middle" font-style="italic">the restoration bar:</text>
+  <text x="730" y="499" font-size="18" fill="#7a9c5d" text-anchor="middle" font-style="italic">14 personas live on this box</text>
+
+  <rect x="980" y="320" width="400" height="270" rx="16" fill="#f8e3e1" stroke="#c26b62" stroke-width="3"/>
+  <text x="1180" y="368" font-size="25" font-weight="700" fill="#2f3a4a" text-anchor="middle">RTX 5090 box</text>
+  <text x="1180" y="402" font-size="18" fill="#64748b" text-anchor="middle">foundry — gene training,</text>
+  <text x="1180" y="430" font-size="18" fill="#64748b" text-anchor="middle">imatrix quantization, distillation</text>
+  <text x="1180" y="472" font-size="18" fill="#c26b62" text-anchor="middle" font-style="italic">trains what the Macs</text>
+  <text x="1180" y="499" font-size="18" fill="#c26b62" text-anchor="middle" font-style="italic">then serve everywhere</text>
+
+  <rect x="1430" y="320" width="425" height="270" rx="16" fill="#f5ecd7" stroke="#b3985e" stroke-width="3"/>
+  <text x="1642" y="368" font-size="25" font-weight="700" fill="#2f3a4a" text-anchor="middle">Phones · edge · browsers</text>
+  <text x="1642" y="402" font-size="18" fill="#64748b" text-anchor="middle">clients are projections —</text>
+  <text x="1642" y="430" font-size="18" fill="#64748b" text-anchor="middle">web, mobile, TUI, VR</text>
+  <text x="1642" y="472" font-size="18" fill="#b3985e" text-anchor="middle" font-style="italic">behaviour lives in the core;</text>
+  <text x="1642" y="499" font-size="18" fill="#b3985e" text-anchor="middle" font-style="italic">every surface renders the same citizen</text>
+
+  <!-- flows between nodes -->
+  <line x1="480" y1="455" x2="525" y2="455" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)" marker-start="url(#arr)"/>
+  <line x1="930" y1="455" x2="975" y2="455" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)" marker-start="url(#arr)"/>
+  <line x1="1380" y1="455" x2="1425" y2="455" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)" marker-start="url(#arr)"/>
+
+  <!-- market -->
+  <rect x="60" y="660" width="880" height="270" rx="16" fill="#f8fafc" stroke="#94a3b8" stroke-width="2.5"/>
+  <text x="92" y="708" font-size="26" font-weight="700" fill="#2f3a4a">The market</text>
+  <text x="250" y="708" font-size="19" fill="#64748b">capitalistic BUT egalitarian — the ethics IS the architecture</text>
+  <text x="92" y="750" font-size="19" fill="#64748b">every command a service · every ask a customer</text>
+  <text x="92" y="782" font-size="19" fill="#64748b">capacity offers broadcast: free memory, lanes, price seams</text>
+  <text x="92" y="814" font-size="19" fill="#64748b">cost + energy tracked per solve — the billing rail is the receipt rail</text>
+  <text x="92" y="856" font-size="19" fill="#64748b">provenance = royalty: a gene's author is paid when it works</text>
+  <text x="92" y="898" font-size="19" fill="#94a3b8" font-style="italic">rewards effort and ideas AND lifts those less able — by design</text>
+
+  <!-- resilience -->
+  <rect x="1000" y="660" width="855" height="270" rx="16" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
+  <text x="1032" y="708" font-size="26" font-weight="700" fill="#2f3a4a">Partition tolerance is the contract</text>
+  <text x="1032" y="750" font-size="19" fill="#64748b">nodes leave, sleep, and rejoin — state converges, nothing waits on a master</text>
+  <text x="1032" y="782" font-size="19" fill="#64748b">rounds survive reboots · claims survive partitions · resume is recall</text>
+  <text x="1032" y="814" font-size="19" fill="#64748b">genes travel through the commons, not through a control plane</text>
+  <text x="1032" y="856" font-size="19" fill="#7a9c5d" font-style="italic">a mesh of misfits compounds; a datacenter only scales</text>
+
+  <line x1="500" y1="590" x2="500" y2="655" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="1420" y1="590" x2="1420" y2="655" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+
+  <text x="60" y="1010" font-size="19" fill="#7a9c5d" font-style="italic">Receipt: benchmark solves priced per-instance (tokens, wall-clock, energy) on consumer hardware — the axis no datacenter lab publishes.</text>
+  <text x="60" y="1045" font-size="19" fill="#64748b" font-style="italic">Grid optimization is market dynamics: the seams are priced from the first second node onward.</text>
+</svg>

--- a/docs/assets/readme/grid.svg
+++ b/docs/assets/readme/grid.svg
@@ -74,11 +74,11 @@
   <g font-size="16" fill="#2f3a4a" text-anchor="middle">
     <text x="960" y="732">carries: rooms · boards · events</text>
     <text x="960" y="758">genes ⇄ commons, with provenance</text>
-    <text x="960" y="784">MoE experts ⇄ leased compute — a neighbor's GPU carries your hard layers</text>
+    <text x="960" y="784">MoE experts ⇄ leased compute</text>
     <text x="960" y="810">E2E DMs — sealed both ways</text>
   </g>
-  <text x="960" y="852" font-size="17.5" fill="#9068c0" text-anchor="middle" font-style="italic">airc IS the interstate — identity is the license plate, E2E is the sealed cargo,</text>
-  <text x="960" y="877" font-size="17.5" fill="#9068c0" text-anchor="middle" font-style="italic">transit only: nothing lives on the road</text>
+  <text x="960" y="852" font-size="17.5" fill="#9068c0" text-anchor="middle" font-style="italic">airc IS the interstate — identity is the license plate, E2E is the sealed cargo, transit only: nothing lives on the road.</text>
+  <text x="960" y="877" font-size="17.5" fill="#9068c0" text-anchor="middle" font-style="italic">Shared inference: a neighbor's GPU carries your hard layers — composition, not density.</text>
 
   <!-- ===================== THE DISTRIBUTED WORLD ===================== -->
   <rect x="60" y="910" width="1800" height="400" rx="18" fill="#fdfbf5" stroke="#b3985e" stroke-width="3"/>

--- a/docs/assets/readme/grid.svg
+++ b/docs/assets/readme/grid.svg
@@ -47,32 +47,38 @@
   <text x="1642" y="472" font-size="18" fill="#b3985e" text-anchor="middle" font-style="italic">behaviour lives in the core;</text>
   <text x="1642" y="499" font-size="18" fill="#b3985e" text-anchor="middle" font-style="italic">every surface renders the same citizen</text>
 
-  <!-- flows between nodes -->
-  <line x1="480" y1="455" x2="525" y2="455" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)" marker-start="url(#arr)"/>
-  <line x1="930" y1="455" x2="975" y2="455" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)" marker-start="url(#arr)"/>
-  <line x1="1380" y1="455" x2="1425" y2="455" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)" marker-start="url(#arr)"/>
+  <!-- the airc p2p mesh: every node speaks to every node, no hub -->
+  <g stroke="#9068c0" stroke-width="2" fill="none" opacity="0.85">
+    <path d="M 270 590 C 270 630, 730 630, 730 590"/>
+    <path d="M 730 590 C 730 630, 1180 630, 1180 590"/>
+    <path d="M 1180 590 C 1180 630, 1642 630, 1642 590"/>
+    <path d="M 270 590 C 270 652, 1180 652, 1180 590" stroke-dasharray="7 5"/>
+    <path d="M 730 590 C 730 665, 1642 665, 1642 590" stroke-dasharray="7 5"/>
+    <path d="M 270 590 C 270 678, 1642 678, 1642 590" stroke-dasharray="7 5"/>
+  </g>
+  <rect x="720" y="600" width="470" height="52" rx="10" fill="#ece2f6" stroke="#9068c0" stroke-width="2"/>
+  <text x="955" y="633" font-size="19" font-weight="600" fill="#2f3a4a" text-anchor="middle">airc p2p — events · rooms · boards · E2E DMs</text>
 
   <!-- market -->
-  <rect x="60" y="660" width="880" height="270" rx="16" fill="#f8fafc" stroke="#94a3b8" stroke-width="2.5"/>
-  <text x="92" y="708" font-size="26" font-weight="700" fill="#2f3a4a">The market</text>
-  <text x="250" y="708" font-size="19" fill="#64748b">capitalistic BUT egalitarian — the ethics IS the architecture</text>
-  <text x="92" y="750" font-size="19" fill="#64748b">every command a service · every ask a customer</text>
-  <text x="92" y="782" font-size="19" fill="#64748b">capacity offers broadcast: free memory, lanes, price seams</text>
-  <text x="92" y="814" font-size="19" fill="#64748b">cost + energy tracked per solve — the billing rail is the receipt rail</text>
-  <text x="92" y="856" font-size="19" fill="#64748b">provenance = royalty: a gene's author is paid when it works</text>
-  <text x="92" y="898" font-size="19" fill="#94a3b8" font-style="italic">rewards effort and ideas AND lifts those less able — by design</text>
+  <rect x="60" y="730" width="880" height="240" rx="16" fill="#f8fafc" stroke="#94a3b8" stroke-width="2.5"/>
+  <text x="92" y="778" font-size="26" font-weight="700" fill="#2f3a4a">The market</text>
+  <text x="250" y="778" font-size="19" fill="#64748b">capitalistic BUT egalitarian — the ethics IS the architecture</text>
+  <text x="92" y="818" font-size="19" fill="#64748b">every command a service · every ask a customer</text>
+  <text x="92" y="848" font-size="19" fill="#64748b">capacity offers broadcast: free memory, lanes, price seams</text>
+  <text x="92" y="878" font-size="19" fill="#64748b">cost + energy tracked per solve — the billing rail is the receipt rail</text>
+  <text x="92" y="908" font-size="19" fill="#64748b">provenance = royalty: a gene's author is paid when it works</text>
+  <text x="92" y="938" font-size="19" fill="#94a3b8" font-style="italic">rewards effort and ideas AND lifts those less able — by design</text>
 
   <!-- resilience -->
-  <rect x="1000" y="660" width="855" height="270" rx="16" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
-  <text x="1032" y="708" font-size="26" font-weight="700" fill="#2f3a4a">Partition tolerance is the contract</text>
-  <text x="1032" y="750" font-size="19" fill="#64748b">nodes leave, sleep, and rejoin — state converges, nothing waits on a master</text>
-  <text x="1032" y="782" font-size="19" fill="#64748b">rounds survive reboots · claims survive partitions · resume is recall</text>
-  <text x="1032" y="814" font-size="19" fill="#64748b">genes travel through the commons, not through a control plane</text>
-  <text x="1032" y="856" font-size="19" fill="#7a9c5d" font-style="italic">a mesh of misfits compounds; a datacenter only scales</text>
+  <rect x="1000" y="730" width="855" height="240" rx="16" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
+  <text x="1032" y="778" font-size="26" font-weight="700" fill="#2f3a4a">Partition tolerance is the contract</text>
+  <text x="1032" y="818" font-size="19" fill="#64748b">nodes leave, sleep, and rejoin — state converges, nothing waits on a master</text>
+  <text x="1032" y="848" font-size="19" fill="#64748b">rounds survive reboots · claims survive partitions · resume is recall</text>
+  <text x="1032" y="878" font-size="19" fill="#64748b">genes travel through the commons, not through a control plane</text>
+  <text x="1032" y="918" font-size="19" fill="#7a9c5d" font-style="italic">a mesh of misfits compounds; a datacenter only scales</text>
 
-  <line x1="500" y1="590" x2="500" y2="655" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="1420" y1="590" x2="1420" y2="655" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+  <text x="955" y="700" font-size="17" fill="#9068c0" text-anchor="middle" font-style="italic">local-first routes; rendezvous only for discovery — no hub, no master</text>
 
-  <text x="60" y="1010" font-size="19" fill="#7a9c5d" font-style="italic">Receipt: benchmark solves priced per-instance (tokens, wall-clock, energy) on consumer hardware — the axis no datacenter lab publishes.</text>
-  <text x="60" y="1045" font-size="19" fill="#64748b" font-style="italic">Grid optimization is market dynamics: the seams are priced from the first second node onward.</text>
+  <text x="60" y="1050" font-size="19" fill="#7a9c5d" font-style="italic">Receipt: benchmark solves priced per-instance (tokens, wall-clock, energy) on consumer hardware — the axis no datacenter lab publishes.</text>
+  <text x="60" y="1085" font-size="19" fill="#64748b" font-style="italic">Grid optimization is market dynamics: the seams are priced from the first second node onward.</text>
 </svg>

--- a/docs/assets/readme/grid.svg
+++ b/docs/assets/readme/grid.svg
@@ -71,10 +71,11 @@
     <path d="M -57 -30 C -27 -41, 27 -41, 57 -30 C 57 -6, 42 22, 0 34 C -42 22, -57 -6, -57 -30 Z" fill="#6b93d6"/>
     <text x="0" y="12" font-size="27" font-weight="800" fill="#ffffff" text-anchor="middle">airc</text>
   </g>
-  <g font-size="16.5" fill="#2f3a4a" text-anchor="middle">
-    <text x="960" y="740">carries: rooms · boards · events</text>
-    <text x="960" y="768">genes ⇄ commons, with provenance</text>
-    <text x="960" y="796">E2E DMs — sealed both ways</text>
+  <g font-size="16" fill="#2f3a4a" text-anchor="middle">
+    <text x="960" y="732">carries: rooms · boards · events</text>
+    <text x="960" y="758">genes ⇄ commons, with provenance</text>
+    <text x="960" y="784">MoE experts ⇄ leased compute — a neighbor's GPU carries your hard layers</text>
+    <text x="960" y="810">E2E DMs — sealed both ways</text>
   </g>
   <text x="960" y="852" font-size="17.5" fill="#9068c0" text-anchor="middle" font-style="italic">airc IS the interstate — identity is the license plate, E2E is the sealed cargo,</text>
   <text x="960" y="877" font-size="17.5" fill="#9068c0" text-anchor="middle" font-style="italic">transit only: nothing lives on the road</text>
@@ -119,7 +120,7 @@
   <rect x="60" y="1360" width="880" height="230" rx="16" fill="#f8fafc" stroke="#94a3b8" stroke-width="2.5"/>
   <text x="92" y="1406" font-size="25" font-weight="700" fill="#2f3a4a">The market</text>
   <text x="248" y="1406" font-size="18" fill="#64748b">capitalistic BUT egalitarian — the ethics IS the architecture</text>
-  <text x="92" y="1444" font-size="18" fill="#64748b">every command a service · every ask a customer · capacity offers broadcast</text>
+  <text x="92" y="1444" font-size="18" fill="#64748b">every command a service · every ask a customer · shared inference: composition, not density</text>
   <text x="92" y="1474" font-size="18" fill="#64748b">cost + energy tracked per solve — the billing rail is the receipt rail</text>
   <text x="92" y="1504" font-size="18" fill="#64748b">provenance = royalty: a gene's author is paid when it works</text>
   <text x="92" y="1544" font-size="18" fill="#94a3b8" font-style="italic">rewards effort and ideas AND lifts those less able — by design</text>

--- a/docs/assets/readme/memory.svg
+++ b/docs/assets/readme/memory.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1150" font-family="Helvetica Neue, Arial, sans-serif">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2f3a4a"/>
+    </marker>
+    <marker id="arrg" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7a9c5d"/>
+    </marker>
+  </defs>
+  <rect width="1920" height="1150" fill="#ffffff"/>
+
+  <text x="60" y="78" font-size="44" font-weight="700" fill="#2f3a4a">The KV-Slot Economy</text>
+  <text x="60" y="116" font-size="24" fill="#64748b">a warm prefix is capital — typed leases, traffic classes, priced eviction</text>
+
+  <!-- ActivityKey lease -->
+  <rect x="60" y="180" width="430" height="170" rx="14" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
+  <text x="275" y="226" font-size="25" font-weight="700" fill="#2f3a4a" text-anchor="middle">ActivityKey { persona, room }</text>
+  <text x="275" y="260" font-size="19" fill="#64748b" text-anchor="middle">a typed lease — UUIDs in a struct,</text>
+  <text x="275" y="286" font-size="19" fill="#64748b" text-anchor="middle">never a formatted string</text>
+  <text x="275" y="322" font-size="18" fill="#9068c0" text-anchor="middle" font-style="italic">one persona, many activities, many warm tails</text>
+
+  <line x1="490" y1="265" x2="580" y2="265" stroke="#2f3a4a" stroke-width="2.5" marker-end="url(#arr)"/>
+
+  <!-- Slots -->
+  <rect x="585" y="170" width="1270" height="190" rx="16" fill="#f8fafc" stroke="#94a3b8" stroke-width="2.5"/>
+  <text x="617" y="215" font-size="24" font-weight="700" fill="#2f3a4a">llama-server slots</text>
+
+  <rect x="617" y="240" width="270" height="95" rx="10" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
+  <text x="752" y="278" font-size="21" font-weight="600" fill="#2f3a4a" text-anchor="middle">slot 0 — citizen</text>
+  <text x="752" y="308" font-size="17" fill="#64748b" text-anchor="middle">activity A · 36k warm tail</text>
+
+  <rect x="912" y="240" width="270" height="95" rx="10" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
+  <text x="1047" y="278" font-size="21" font-weight="600" fill="#2f3a4a" text-anchor="middle">slot 1 — citizen</text>
+  <text x="1047" y="308" font-size="17" fill="#64748b" text-anchor="middle">activity B · warm</text>
+
+  <rect x="1207" y="240" width="270" height="95" rx="10" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2.5"/>
+  <text x="1342" y="278" font-size="21" font-weight="600" fill="#2f3a4a" text-anchor="middle">slot 2 — citizen</text>
+  <text x="1342" y="308" font-size="17" fill="#64748b" text-anchor="middle">activity C · warm</text>
+
+  <rect x="1502" y="240" width="323" height="95" rx="10" fill="#f5ecd7" stroke="#b3985e" stroke-width="2.5"/>
+  <text x="1663" y="278" font-size="21" font-weight="600" fill="#2f3a4a" text-anchor="middle">slot 3 — reserved scratch</text>
+  <text x="1663" y="308" font-size="17" fill="#64748b" text-anchor="middle">all non-turn traffic lands here</text>
+
+  <!-- Traffic classes -->
+  <rect x="60" y="420" width="850" height="230" rx="16" fill="#e3e9f8" stroke="#6b81c2" stroke-width="3"/>
+  <text x="92" y="468" font-size="26" font-weight="700" fill="#2f3a4a">Traffic classes</text>
+  <text x="330" y="468" font-size="19" fill="#64748b">every request declares what it is</text>
+
+  <rect x="92" y="495" width="180" height="60" rx="10" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2"/>
+  <text x="182" y="532" font-size="20" font-weight="600" fill="#2f3a4a" text-anchor="middle">Turn</text>
+  <text x="292" y="532" font-size="18" fill="#64748b">→ her activity's citizen slot — only Turn may hold or evict one</text>
+
+  <rect x="92" y="570" width="180" height="60" rx="10" fill="#f5ecd7" stroke="#b3985e" stroke-width="2"/>
+  <text x="182" y="595" font-size="17" font-weight="600" fill="#2f3a4a" text-anchor="middle">Sidecar · Background</text>
+  <text x="182" y="618" font-size="17" font-weight="600" fill="#2f3a4a" text-anchor="middle">· Probe</text>
+  <text x="292" y="607" font-size="18" fill="#64748b">→ scratch — structurally unable to clobber a warm tail</text>
+
+  <!-- Priced eviction -->
+  <rect x="970" y="420" width="885" height="230" rx="16" fill="#f8e3e1" stroke="#c26b62" stroke-width="3"/>
+  <text x="1002" y="468" font-size="26" font-weight="700" fill="#2f3a4a">Priced eviction</text>
+  <text x="1002" y="510" font-size="20" fill="#2f3a4a" font-family="Menlo, monospace">cost_of_loss ∝ tail_tokens » stale_hours</text>
+  <text x="1002" y="545" font-size="18" fill="#64748b">the cheapest tail goes first — recency only splits exact ties</text>
+  <text x="1002" y="580" font-size="19" fill="#c26b62" font-style="italic">a 7.6k head can never displace a 36k warm tail</text>
+  <text x="1002" y="622" font-size="18" fill="#64748b">the policy is a plan-returning seam — the learned policy drops in later</text>
+
+  <!-- Prefix bar -->
+  <rect x="60" y="710" width="1795" height="180" rx="16" fill="#f8fafc" stroke="#94a3b8" stroke-width="2.5"/>
+  <text x="92" y="758" font-size="26" font-weight="700" fill="#2f3a4a">Prefix stability</text>
+  <text x="380" y="758" font-size="19" fill="#64748b">the prompt is ordered so yesterday's tokens are still valid today</text>
+
+  <rect x="92" y="785" width="360" height="70" rx="8" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2"/>
+  <text x="272" y="828" font-size="19" fill="#2f3a4a" text-anchor="middle">identity + tools (stable)</text>
+  <rect x="460" y="785" width="480" height="70" rx="8" fill="#e6efdf" stroke="#7a9c5d" stroke-width="2"/>
+  <text x="700" y="828" font-size="19" fill="#2f3a4a" text-anchor="middle">history — append-only, collapse don't clip</text>
+  <rect x="948" y="785" width="330" height="70" rx="8" fill="#fdf6ec" stroke="#d99a3d" stroke-width="2"/>
+  <text x="1113" y="828" font-size="19" fill="#2f3a4a" text-anchor="middle">volatile: clock · newest turn</text>
+
+  <line x1="1290" y1="820" x2="1370" y2="820" stroke="#7a9c5d" stroke-width="3" marker-end="url(#arrg)"/>
+  <text x="1390" y="812" font-size="20" font-weight="600" fill="#7a9c5d">restore ≈ 103 ms</text>
+  <text x="1390" y="842" font-size="18" fill="#64748b">vs 32.9 s full re-prefill at 20k (~330×)</text>
+
+  <!-- One paging engine -->
+  <rect x="60" y="945" width="1795" height="105" rx="16" fill="#ece2f6" stroke="#9068c0" stroke-width="2.5"/>
+  <text x="92" y="990" font-size="24" font-weight="700" fill="#2f3a4a">ONE paging engine — PagedResourcePool</text>
+  <text x="92" y="1024" font-size="19" fill="#64748b">three trait implementers, one eviction discipline:&#160;&#160;MoE expert tiers&#160;&#160;·&#160;&#160;LoRA genome genes&#160;&#160;·&#160;&#160;KV slots</text>
+
+  <text x="60" y="1112" font-size="19" fill="#7a9c5d" font-style="italic">Receipt: cache reuse 0% → 83% on warm acts under 4-way concurrent solve load, same hardware, same model (2026-08-26).</text>
+</svg>


### PR DESCRIPTION
First pass at the Qwen-quality diagram set for the README's architecture story. One design system, four panels, every printed number a real receipt from this week's runs. Wire-in to README.md sections + remaining panels (serving lanes, positron, activities-as-rooms, vision bridge) as follow-ups once the visual language is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo