### PR TITLE
Lane lease sold the window: cap at 1 + honest no-patch class (planner window-floor filed)

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -941,14 +941,34 @@ async fn close_claim_card_if_graded(run_id: &str) {
     let gate_failed = grade
         .as_ref()
         .is_some_and(|g| g.get("gate_ok").is_some_and(|k| k == false));
-    let env_absent = gate_failed
-        || grade
-            .as_ref()
-            .is_some_and(|g| g.get("error").is_some_and(|e| !e.is_null()));
+    // "No candidate patch" is NOT an env absence — the env was fine and she
+    // simply produced no diff (measured 2026-08-27: the env label sent these
+    // through the env-retake path with a message promising "fires when the env
+    // heals", which was false and confusing in the log). Same card-stays-open
+    // outcome, honest reason.
+    let no_patch = grade.as_ref().is_some_and(|g| {
+        g.get("error")
+            .and_then(|e| e.as_str())
+            .is_some_and(|e| e.contains("no candidate patch"))
+    });
+    let env_absent = !no_patch
+        && (gate_failed
+            || grade
+                .as_ref()
+                .is_some_and(|g| g.get("error").is_some_and(|e| !e.is_null())));
     let verdict_is_real = !env_absent
         && grade
             .as_ref()
             .is_some_and(|g| g.get("error").map_or(true, |e| e.is_null()));
+    if no_patch {
+        crate::probe!(
+            class = "benchmark.card.close_skipped",
+            run_id = %run_id,
+            reason = "no_patch",
+            "she produced no diff — card stays open for a retake; not an env absence"
+        );
+        return;
+    }
     if !verdict_is_real && !env_absent {
         crate::probe!(
             class = "benchmark.card.close_skipped",

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -62,7 +62,15 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
         // and 17 queued cards crawled on ONE slot (2026-08-27). Resized as the
         // queue drains, released when the watch ends — the same max-of-overrides
         // lease the quiesce path uses, pulling the other direction.
-        const LANE_CAP: u32 = 4;
+        // MEASURED 2026-08-27, minutes after the lease shipped: raising lanes
+        // to 4 made the planner SELL THE WINDOW to pay for them — 60942 total
+        // context split ~20k/slot against a measured 166k demand window, and
+        // every solve collapsed at act 3 on the #390 saturation gate with an
+        // empty diff (four starved lanes are strictly worse than one working
+        // lane). Until the planner can hold a PER-LANE WINDOW FLOOR for
+        // solve-class demand (the real fix, filed), the lease asks for ONE
+        // lane: the proven solve config — serial but completing.
+        const LANE_CAP: u32 = 1;
         let mut demand_lease: Option<(u64, u32)> = None;
         let mut attempt: u32 = 0;
         loop {


### PR DESCRIPTION
lanes=4 → ~20k/slot vs 166k demand → act-3 saturation collapses + 5-min churn loop via the mislabeled env-absent path. Cap the lease at 1 (proven serial config), label no-patch honestly. Real fix (per-lane window floor in the lanes-vs-window trade) filed as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo