### PR TITLE
chore: pin airc to durable canary rev 140bb01 (branch revs orphan on squash-merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=d37bc7f#d37bc7fd377410a4545612b68df3c52a74c8a3b7"
+source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
 dependencies = [
  "airc-core",
  "airc-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,18 +185,18 @@ members = [
 # room is still its default under either verb. This is what continuum's
 # room/join needs (task #65, Joel: a persona is first-class and can subscribe to
 # many rooms). Also fixes `RoomJoinedBody.is_default`, previously hardcoded true.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "d37bc7f" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "d37bc7f" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "d37bc7f" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "d37bc7f" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "d37bc7f" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "d37bc7f" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)


### PR DESCRIPTION
**The bug this prevents:** #2527 landed the airc pin at `d37bc7f` — a commit on the `reply_in` PR branch (airc #1364). Cargo fetches `refs/heads` + tags only, so the moment that squashed branch is deleted the rev becomes unfetchable and a **fresh clone cannot build**. `140bb01` is the durable canary rev of identical content.

`cargo check -p continuum-client` green (resolves and builds against the canary rev).

Supersedes #2528, whose branch (`fix/spec-decode-tax`) had already been merged when the commit was pushed, so no `pull_request` event ever fired and its required checks could never report — the same never-runs-never-reports deadlock `continuum-rust-tests.yml`'s own header documents. This PR is a clean branch off canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo