### PR TITLE
chore: pin airc to 2b5bdac — NAT traversal reaches the grid (airc #1365)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=140bb01#140bb01998b3b66e59154a08a753ce5f147473ab"
+source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
 dependencies = [
  "airc-core",
  "airc-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,18 +185,18 @@ members = [
 # room is still its default under either verb. This is what continuum's
 # room/join needs (task #65, Joel: a persona is first-class and can subscribe to
 # many rooms). Also fixes `RoomJoinedBody.is_default`, previously hardcoded true.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "140bb01" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)


### PR DESCRIPTION
Picks up airc #1365: configurable ICE/STUN gathering + evidence-gated WebRTC DataChannel routing for durable data classes.

**What changes for continuum:** a peer pair that can't reach each other on the LAN now hole-punches a **direct p2p route** (free public STUN by default, `AIRC_STUN_SERVERS` / `AIRC_WEBRTC_BIND` overridable — including at a grid member's own STUN-speaking relay). The grid's self-elected relay only carries what genuinely cannot go direct. Tailscale stays one optional rung, never a requirement — which is what the many-humans grid needs, since a tailnet is account-scoped and can't host a federation of strangers pooling compute.

Transport ladder after this: LAN direct → hole-punched direct p2p → Reticulum → grid relay → (Tailscale, if you happen to run it).

`cargo check` green on continuum-client, continuum-cli, and continuum-core (metal). Build-only change — no deploy, so the in-flight benchmark round is untouched; it reaches the running core at the next natural reboot boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo