### PR TITLE
fix(benchmark): astropy numpy ceiling + the coverage map GATES dispatch (validate stops being advice)

### DIFF
--- a/core/continuum-core/src/code/file_engine.rs
+++ b/core/continuum-core/src/code/file_engine.rs
@@ -86,7 +86,111 @@ impl From<std::io::Error> for FileEngineError {
     }
 }
 
+/// Directories never worth walking to suggest a path — they are enormous, they
+/// are never the file she meant, and on SOMEONE ELSE'S COMPUTER walking them is
+/// the difference between a helpful error and a stalled laptop.
+const SUGGEST_SKIP_DIRS: &[&str] = &[
+    ".git", "node_modules", "target", "__pycache__", ".venv", "venv", "build",
+    "dist", ".tox", ".mypy_cache", ".pytest_cache", ".cargo", "site-packages",
+];
+
+/// Hard ceiling on entries visited while looking for a near-miss. A suggestion
+/// is a courtesy; it must never become the expensive part of an error path.
+const SUGGEST_MAX_ENTRIES: usize = 20_000;
+const SUGGEST_MAX_DEPTH: usize = 12;
+const SUGGEST_MAX_RESULTS: usize = 3;
+
+/// Bounded hunt for what she probably MEANT, ranked best-first.
+///
+/// Why this exists (glass-boxed 2026-08-28, the five no-candidate-patch solve
+/// runs): a citizen spent 30 acts on django-15252, found the correct source file
+/// on her FIRST act, and still produced no diff — because 3 of her 8 reads were
+/// paths that do not exist (`django/db/backends/creation.py` missing the `base/`
+/// segment, `django/migration/commands/migrate.py` for `migrations`). Each miss
+/// cost a full act out of a 30-act budget and returned nothing but
+/// "File not found", so nothing pushed her back on track and she ran out of
+/// budget before writing. The substrate already does exactly this for mistyped
+/// COMMAND names ("did you mean"); a mistyped PATH deserves the same courtesy,
+/// and it is recoverable from the tree she is standing in.
+///
+/// Ranking mirrors how a person recovers: same file name somewhere else in the
+/// tree first (the `base/` case), then a near-miss on the name itself (the
+/// `migration`/`migrations` case).
+fn suggest_nearest_paths(root: &Path, wanted: &str) -> Vec<String> {
+    let wanted_name = Path::new(wanted)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_lowercase())
+        .unwrap_or_default();
+    if wanted_name.is_empty() {
+        return Vec::new();
+    }
+    let mut exact_name: Vec<String> = Vec::new();
+    let mut near_name: Vec<String> = Vec::new();
+    let mut visited = 0usize;
+    let mut stack = vec![(root.to_path_buf(), 0usize)];
+    while let Some((dir, depth)) = stack.pop() {
+        if depth > SUGGEST_MAX_DEPTH || visited >= SUGGEST_MAX_ENTRIES {
+            break;
+        }
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            visited += 1;
+            if visited >= SUGGEST_MAX_ENTRIES {
+                break;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+            if is_dir {
+                if !name.starts_with('.') && !SUGGEST_SKIP_DIRS.contains(&name.as_str()) {
+                    stack.push((entry.path(), depth + 1));
+                }
+                continue;
+            }
+            let lower = name.to_lowercase();
+            let rel = entry
+                .path()
+                .strip_prefix(root)
+                .map(|r| r.to_string_lossy().to_string())
+                .unwrap_or(name.clone());
+            if lower == wanted_name {
+                if exact_name.len() < SUGGEST_MAX_RESULTS {
+                    exact_name.push(rel);
+                }
+            } else if near_name.len() < SUGGEST_MAX_RESULTS
+                && (lower.starts_with(&wanted_name) || wanted_name.starts_with(&lower))
+            {
+                near_name.push(rel);
+            }
+        }
+        if exact_name.len() >= SUGGEST_MAX_RESULTS {
+            break;
+        }
+    }
+    exact_name.extend(near_name);
+    exact_name.truncate(SUGGEST_MAX_RESULTS);
+    exact_name
+}
+
 impl FileEngine {
+    /// A NotFound that tries to be useful — the same courtesy the executor
+    /// already extends to a mistyped COMMAND name ("did you mean"), applied to a
+    /// mistyped PATH. One constructor, used by every not-found site, so read,
+    /// edit and write all recover the same way (compression: one decision, one
+    /// place).
+    fn not_found(&self, relative_path: &str) -> FileEngineError {
+        let hits = suggest_nearest_paths(self.security.workspace_root(), relative_path);
+        if hits.is_empty() {
+            return FileEngineError::NotFound(relative_path.to_string());
+        }
+        FileEngineError::NotFound(format!(
+            "{relative_path} — no such file. Did you mean: {}? (searched this \
+             workspace; use file_tree/grep to look further)",
+            hits.join(", ")
+        ))
+    }
+
     /// Create a new FileEngine for a persona.
     pub fn new(persona_id: &str, security: PathSecurity) -> Self {
         let workspace_id = format!("workspace-{}", persona_id);
@@ -121,7 +225,7 @@ impl FileEngine {
         let abs_path = self.security.validate_read(relative_path)?;
 
         if !abs_path.exists() {
-            return Err(FileEngineError::NotFound(relative_path.to_string()));
+            return Err(self.not_found(relative_path));
         }
 
         let content = fs::read_to_string(&abs_path)?;
@@ -255,7 +359,7 @@ impl FileEngine {
         let abs_path = self.security.validate_write(relative_path)?;
 
         if !abs_path.exists() {
-            return Err(FileEngineError::NotFound(relative_path.to_string()));
+            return Err(self.not_found(relative_path));
         }
 
         let old_content = fs::read_to_string(&abs_path)?;
@@ -485,7 +589,7 @@ impl FileEngine {
         let abs_path = self.security.validate_write(relative_path)?;
 
         if !abs_path.exists() {
-            return Err(FileEngineError::NotFound(relative_path.to_string()));
+            return Err(self.not_found(relative_path));
         }
 
         let old_content = fs::read_to_string(&abs_path)?;
@@ -546,7 +650,7 @@ impl FileEngine {
         let abs_path = self.security.validate_read(relative_path)?;
 
         if !abs_path.exists() {
-            return Err(FileEngineError::NotFound(relative_path.to_string()));
+            return Err(self.not_found(relative_path));
         }
 
         let old_content = fs::read_to_string(&abs_path)?;
@@ -2002,6 +2106,62 @@ fn now_millis() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    mod path_recovery {
+        use super::super::suggest_nearest_paths;
+        use std::fs;
+
+        // what this catches: a mistyped path returning a dead end. Glass-boxed
+        // 2026-08-28 on the five no-candidate-patch solve runs — django-15252
+        // burned 30 acts, found the RIGHT file on act 1, and still wrote nothing
+        // because 3 of its 8 reads were paths that do not exist. Both real
+        // misses are pinned here: a missing directory segment
+        // (django/db/backends/creation.py -> .../base/creation.py) and a
+        // singular/plural slip (migration/ -> migrations/). Also pins the
+        // "operate on people's computers" bounds: heavy directories are never
+        // walked, so an error path can never stall someone's machine.
+        #[test]
+        fn a_mistyped_path_gets_pointed_at_the_real_one() {
+            let tmp = std::env::temp_dir().join(format!("fe-suggest-{}", uuid::Uuid::new_v4()));
+            let deep = tmp.join("django/db/backends/base");
+            fs::create_dir_all(&deep).unwrap();
+            fs::write(deep.join("creation.py"), "x").unwrap();
+            let mig = tmp.join("django/core/management/commands");
+            fs::create_dir_all(&mig).unwrap();
+            fs::write(mig.join("migrate.py"), "x").unwrap();
+
+            // The real miss: she dropped the `base/` segment.
+            let hits = suggest_nearest_paths(&tmp, "django/db/backends/creation.py");
+            assert!(
+                hits.iter().any(|h| h.ends_with("base/creation.py")),
+                "same filename elsewhere in the tree must be offered, got {hits:?}"
+            );
+
+            // The other real miss: `migration/` for `migrations/`.
+            let hits = suggest_nearest_paths(&tmp, "django/migration/commands/migrate.py");
+            assert!(
+                hits.iter().any(|h| h.ends_with("commands/migrate.py")),
+                "the correct migrate.py must be offered, got {hits:?}"
+            );
+
+            // A name nothing resembles yields nothing — never noise.
+            assert!(suggest_nearest_paths(&tmp, "totally/unrelated/zzzz.py").is_empty());
+
+            // OPERATE ON PEOPLE'S COMPUTERS: heavy dirs are not walked, so a
+            // file hiding in node_modules/.git is never even considered.
+            let heavy = tmp.join("node_modules/pkg");
+            fs::create_dir_all(&heavy).unwrap();
+            fs::write(heavy.join("recorder.py"), "x").unwrap();
+            let hits = suggest_nearest_paths(&tmp, "django/db/migrations/recorder.py");
+            assert!(
+                !hits.iter().any(|h| h.contains("node_modules")),
+                "node_modules must never be walked for suggestions, got {hits:?}"
+            );
+
+            let _ = fs::remove_dir_all(&tmp);
+        }
+    }
+
+
     use super::*;
     use std::fs;
 

--- a/core/continuum-core/src/cognition/persona_tools.rs
+++ b/core/continuum-core/src/cognition/persona_tools.rs
@@ -711,6 +711,7 @@ pub struct ToolSurfaceReport {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     // what this catches: the yield verb must be REACHABLE — offered on the same surface

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -1599,6 +1599,21 @@ fn era_sdist_build_deps_for(repo: &str, year: u32) -> &'static [&'static str] {
         // is the one the instance's own cutoff allows (the two failures above wanted >=1.10
         // and >=1.13 respectively — both far below any era cap we set), so this widens what
         // BUILDS without smuggling a modern numpy into a date-pinned subject graph.
+        // NUMPY 2 IS A HARD WALL FOR PRE-2021 ASTROPY (measured 2026-08-28, live
+        // dispatch): numpy 2.0 made `np.array(obj, copy=False)` RAISE instead of
+        // silently copying, and 2017-era astropy calls exactly that inside
+        // `Quantity._new_view` — so the env build dies with "Unable to avoid copy
+        // while creating an array as requested" before a citizen ever sees the
+        // task. A bare "numpy" here is the smuggling path this row's own comment
+        // warns about: when the dated resolve hiccups, the era-pin's loud
+        // unpinned retry lands a 2026 numpy in a 2017 subject graph.
+        //
+        // 1.21.6 is the same proven middle xarray uses above — arm64 wheels on
+        // this box, and it still carries the old C macros these eras compile
+        // against. Scoped to the OLD eras only: 2022+ astropy (12907, 13236,
+        // 14365, 14995 — all currently PASSING) resolves its own numpy fine and
+        // must not be disturbed by a ceiling it never needed.
+        "astropy/astropy" if year <= 2020 => &["jinja2", "numpy==1.21.6"],
         "astropy/astropy" => &["jinja2", "numpy"],
         // Same class, measured at prewarm 2026-08-26 (the seeded-25 round): both
         // setup.py's import numpy at metadata time under --no-build-isolation.

--- a/core/continuum-core/src/cognition/tool_executor/command_executor.rs
+++ b/core/continuum-core/src/cognition/tool_executor/command_executor.rs
@@ -174,6 +174,26 @@ fn truncate_tool_output(s: String, max: usize, spill: Option<&spill::SpillRef>) 
         return truncate_on_boundary(s, max);
     }
     let dropped = tail_start - head_end;
+    // MAKE THE FLOOD OBSERVABLE. Without this probe there is no way to answer
+    // "does her output actually flood?" — and on 2026-08-28 that question blocked
+    // a real decision: `tool/output` (the verb that reads the spilled MIDDLE) is
+    // not in the native surface, and making it native costs ~1200 tokens on EVERY
+    // prompt forever against a ceiling guard that says "do not keep bumping this".
+    // The honest answer was "no spill has ever been recorded on this box" — the
+    // demand was UNMEASURED, not proven absent. She already receives head+tail;
+    // the middle is what a spill adds. This probe is the evidence that decides it:
+    // if floods are frequent in solves the verb earns its slot; if they never
+    // happen, the surface stays lean.
+    if let Some(r) = spill {
+        crate::probe!(
+            class = "tool.output.spilled",
+            handle = %r.handle,
+            dropped_chars = %dropped,
+            "a tool result flooded and was spilled to disk — its MIDDLE is reachable \
+             only through `tool/output`, which is NOT in the native surface today \
+             (she holds the handle, not the verb)"
+        );
+    }
     let recovery = match spill {
         // The whole result is recoverable — point her at the handle, and at the
         // failure-hunting path specifically (grep for the error), per Joel: the

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -2098,12 +2098,16 @@ mod tests {
         fn the_coverage_gate_fails_open_and_only_blocks_a_locally_proven_red_class() {
             let dataset = "swe-bench-unit-test-fixture";
             let here = BenchmarkPlatformFingerprint::capture().machine_class;
-            let path = coverage_map_path(dataset, &here);
-            let _ = std::fs::remove_file(&path);
+            // A TEMPDIR, never the operator's real ~/.continuum: writing a
+            // fixture into a person's live data directory is both a lie about
+            // isolation and a way to clobber their state — and it made this very
+            // test pass alone and FAIL in the full suite.
+            let root = std::env::temp_dir().join(format!("cov-gate-{}", uuid::Uuid::new_v4()));
+            let path = coverage_map_path_in(&root, dataset, &here);
 
             // 1. No map at all — the fresh-clone case. Must dispatch.
             assert_eq!(
-                known_red_wall(dataset, "astropy/astropy", 2017),
+                known_red_wall_in(&root, dataset, "astropy/astropy", 2017),
                 None,
                 "a user who never ran validate must never be gated"
             );
@@ -2134,22 +2138,22 @@ mod tests {
                 summary: String::new(),
             };
             if let Some(d) = path.parent() {
-                let _ = std::fs::create_dir_all(d);
+                std::fs::create_dir_all(d).unwrap();
             }
             std::fs::write(&path, serde_json::to_string(&map).unwrap()).unwrap();
 
             assert_eq!(
-                known_red_wall(dataset, "astropy/astropy", 2017).as_deref(),
+                known_red_wall_in(&root, dataset, "astropy/astropy", 2017).as_deref(),
                 Some("numpy 2 rejects copy=False"),
                 "a locally-proven red class must withhold the card AND name the wall"
             );
             assert_eq!(
-                known_red_wall(dataset, "django/django", 2022),
+                known_red_wall_in(&root, dataset, "django/django", 2022),
                 None,
                 "a green class must dispatch"
             );
             assert_eq!(
-                known_red_wall(dataset, "astropy/astropy", 2023),
+                known_red_wall_in(&root, dataset, "astropy/astropy", 2023),
                 None,
                 "an era with no row is not evidence of anything — dispatch"
             );
@@ -2158,12 +2162,12 @@ mod tests {
             map.platform.machine_class = format!("not-{here}");
             std::fs::write(&path, serde_json::to_string(&map).unwrap()).unwrap();
             assert_eq!(
-                known_red_wall(dataset, "astropy/astropy", 2017),
+                known_red_wall_in(&root, dataset, "astropy/astropy", 2017),
                 None,
                 "another box's coverage claim is not evidence about this box"
             );
 
-            let _ = std::fs::remove_file(&path);
+            let _ = std::fs::remove_dir_all(&root);
         }
     }
 
@@ -4141,6 +4145,23 @@ impl ActionCommand for BenchmarkValidate {
 /// Under the governed benchmarks root, next to the verdicts it protects — one
 /// small file per dataset, rewritten in place, so it needs no eviction story.
 pub fn coverage_map_path(dataset: &str, machine_class: &str) -> std::path::PathBuf {
+    coverage_map_path_in(
+        &crate::cognition::swe_bench::swe_cache_dir(),
+        dataset,
+        machine_class,
+    )
+}
+
+/// Root-injected core of [`coverage_map_path`] — the filesystem seam, so tests
+/// run against a tempdir instead of the operator's real `~/.continuum` (the
+/// pattern `tool_executor::spill` already sets). A test that writes into a
+/// person's live data directory is both a lie about isolation and a way to
+/// clobber their state.
+pub fn coverage_map_path_in(
+    root: &std::path::Path,
+    dataset: &str,
+    machine_class: &str,
+) -> std::path::PathBuf {
     let safe: String = dataset
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
@@ -4149,9 +4170,7 @@ pub fn coverage_map_path(dataset: &str, machine_class: &str) -> std::path::PathB
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
         .collect();
-    crate::cognition::swe_bench::swe_cache_dir()
-        .join("coverage")
-        .join(format!("{safe}.{mc}.json"))
+    root.join("coverage").join(format!("{safe}.{mc}.json"))
 }
 
 fn write_coverage_map(dataset: &str, result: &BenchmarkValidateResult) -> Result<(), String> {
@@ -4169,8 +4188,23 @@ fn write_coverage_map(dataset: &str, result: &BenchmarkValidateResult) -> Result
 /// block. Fail-open is the contract: a repo user who has never run
 /// `benchmark/validate` is never slowed down by a gate that has nothing to say.
 pub fn known_red_wall(dataset: &str, repo: &str, era_year: u32) -> Option<String> {
+    known_red_wall_in(
+        &crate::cognition::swe_bench::swe_cache_dir(),
+        dataset,
+        repo,
+        era_year,
+    )
+}
+
+/// Root-injected core of [`known_red_wall`]. See [`coverage_map_path_in`].
+pub fn known_red_wall_in(
+    root: &std::path::Path,
+    dataset: &str,
+    repo: &str,
+    era_year: u32,
+) -> Option<String> {
     let machine_class = BenchmarkPlatformFingerprint::capture().machine_class;
-    let raw = std::fs::read_to_string(coverage_map_path(dataset, &machine_class)).ok()?;
+    let raw = std::fs::read_to_string(coverage_map_path_in(root, dataset, &machine_class)).ok()?;
     let map: BenchmarkValidateResult = serde_json::from_str(&raw).ok()?;
     if map.platform.machine_class != machine_class {
         return None; // another box's claim is not evidence about this one

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -794,6 +794,12 @@ pub struct BenchmarkDispatchResult {
     /// full coverage is the lie this field exists to prevent.
     #[ts(type = "number")]
     pub skipped_needs_setup: u32,
+    /// Instances withheld because THIS box already proved their (repo, era) env
+    /// class red via `benchmark/validate`. Reported, never silent — the operator
+    /// must see that the round is smaller than requested and WHY (the named wall
+    /// rides in `kickoff_errors`).
+    #[serde(default)]
+    pub skipped_known_red: u32,
     /// Tasks NOT dispatched because a LIVE card for that exact task is already on
     /// the board (same `[bench <name>] <task_id>:` key, in any non-terminal state).
     /// Dispatch is idempotent per task: re-running it tops the board up to one card
@@ -1562,6 +1568,7 @@ impl ActionCommand for BenchmarkDispatch {
         // shorts are the human/CLI handle, not the identity).
         let mut card_uuids: Vec<uuid::Uuid> = Vec::new();
         let mut skipped_needs_setup = 0u32;
+        let mut skipped_known_red = 0u32;
         let mut skipped_already_on_board = 0u32;
         let mut kickoffs = 0u32;
         let mut solves_fired = 0u32;
@@ -1717,6 +1724,36 @@ impl ActionCommand for BenchmarkDispatch {
             }
 
             let mut staged_ok = false;
+            // THE COVERAGE GATE (the cheap half of `benchmark/validate`). If THIS
+            // box has already PROVEN this instance's (repo, era) env class red,
+            // do not spend a citizen's hours and a grader's slot discovering the
+            // same wall a third time — name it and skip. Measured 2026-08-28:
+            // astropy-6938 was dispatched into the numpy-2 wall while a validate
+            // run minutes away already knew astropy/2017 was red.
+            //
+            // A DICTIONARY LOOKUP, never a build: dispatch must stay fast for a
+            // repo user who has never run validate. Fail-open by construction —
+            // no map, a green class, or a map earned on a different machine class
+            // all return None and DISPATCH (see known_red_wall). Reported like
+            // every other skip; a partial dispatch reading as full coverage is
+            // the lie these counters exist to prevent.
+            if let CardWork::Swe { instance } = &pc.work {
+                if let Some(wall) =
+                    known_red_wall(spec.name, &instance.repo, instance.year())
+                {
+                    skipped_known_red += 1;
+                    kickoff_errors.push(format!(
+                        "skipped {} — its env class ({} {}) is PROVEN RED on this box by \
+                         benchmark/validate, so a solve here would burn hours on a known \
+                         wall: {wall}",
+                        instance.instance_id,
+                        instance.repo,
+                        instance.year()
+                    ));
+                    continue;
+                }
+            }
+
             if let (CardWork::Swe { instance }, Some(home)) = (&pc.work, stage_home.as_ref()) {
                 let dir = crate::identity::citizen_peer_dir(
                     home,
@@ -2026,6 +2063,7 @@ impl ActionCommand for BenchmarkDispatch {
             dispatched: card_ids.len() as u32,
             card_ids,
             skipped_needs_setup,
+            skipped_known_red,
             skipped_already_on_board,
             pruned_duplicates,
             contended_tasks,
@@ -2044,6 +2082,92 @@ crate::register_command!(BenchmarkDispatch);
 
 #[cfg(test)]
 mod tests {
+    mod coverage_gate {
+        use super::super::*;
+
+        // what this catches: the gate turning into a BLOCKER for people who have
+        // never run benchmark/validate. Joel's constraint, 2026-08-28: "we don't
+        // slow them down, but we run checks before wasting the persona and
+        // graders time." So every ambiguous case must DISPATCH: no map on disk, a
+        // green class, or a map earned on a DIFFERENT machine class (a coverage
+        // claim is only true for the platform that earned it). Only a class this
+        // very box proved red may withhold a card — and then it must name the
+        // wall, because a silent skip is the partial-dispatch lie the counters
+        // exist to prevent.
+        #[test]
+        fn the_coverage_gate_fails_open_and_only_blocks_a_locally_proven_red_class() {
+            let dataset = "swe-bench-unit-test-fixture";
+            let here = BenchmarkPlatformFingerprint::capture().machine_class;
+            let path = coverage_map_path(dataset, &here);
+            let _ = std::fs::remove_file(&path);
+
+            // 1. No map at all — the fresh-clone case. Must dispatch.
+            assert_eq!(
+                known_red_wall(dataset, "astropy/astropy", 2017),
+                None,
+                "a user who never ran validate must never be gated"
+            );
+
+            // 2. A map from THIS box: red class blocks (with its wall), green does not.
+            let mut map = BenchmarkValidateResult {
+                platform: BenchmarkPlatformFingerprint::capture(),
+                classes: vec![
+                    BenchmarkValidateClass {
+                        repo: "astropy/astropy".into(),
+                        era: "2017".into(),
+                        representative: "astropy__astropy-6938".into(),
+                        covers: 1,
+                        green: false,
+                        wall: Some("numpy 2 rejects copy=False".into()),
+                    },
+                    BenchmarkValidateClass {
+                        repo: "django/django".into(),
+                        era: "2022".into(),
+                        representative: "django__django-15252".into(),
+                        covers: 9,
+                        green: true,
+                        wall: None,
+                    },
+                ],
+                instances_green: 9,
+                dataset_size: 10,
+                summary: String::new(),
+            };
+            if let Some(d) = path.parent() {
+                let _ = std::fs::create_dir_all(d);
+            }
+            std::fs::write(&path, serde_json::to_string(&map).unwrap()).unwrap();
+
+            assert_eq!(
+                known_red_wall(dataset, "astropy/astropy", 2017).as_deref(),
+                Some("numpy 2 rejects copy=False"),
+                "a locally-proven red class must withhold the card AND name the wall"
+            );
+            assert_eq!(
+                known_red_wall(dataset, "django/django", 2022),
+                None,
+                "a green class must dispatch"
+            );
+            assert_eq!(
+                known_red_wall(dataset, "astropy/astropy", 2023),
+                None,
+                "an era with no row is not evidence of anything — dispatch"
+            );
+
+            // 3. A map earned on ANOTHER machine class must not gate this one.
+            map.platform.machine_class = format!("not-{here}");
+            std::fs::write(&path, serde_json::to_string(&map).unwrap()).unwrap();
+            assert_eq!(
+                known_red_wall(dataset, "astropy/astropy", 2017),
+                None,
+                "another box's coverage claim is not evidence about this box"
+            );
+
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+
+
     use super::*;
 
     fn citizen(name: &str) -> (String, uuid::Uuid) {
@@ -3986,14 +4110,80 @@ impl ActionCommand for BenchmarkValidate {
             rows.iter().filter(|r| r.green).count(),
             rows.iter().filter(|r| !r.green).count()
         );
-        Ok(BenchmarkValidateResult {
+        let result = BenchmarkValidateResult {
             platform: BenchmarkPlatformFingerprint::capture(),
             classes: rows,
             instances_green,
             dataset_size,
             summary,
-        })
+        };
+        // PERSIST, so the map can GATE. A coverage map that only ever exists in
+        // one command's stdout cannot protect anything: dispatch had no way to
+        // ask "is this instance's class known-red?", so a citizen could be sent
+        // to spend hours inside an env class this box had already PROVEN cannot
+        // build (measured 2026-08-28: astropy-6938 dispatched into the numpy-2
+        // wall while a validate run sitting minutes away already knew that class
+        // was red). Written per (dataset × machine_class) because a coverage
+        // claim is only true for the platform that earned it.
+        if let Err(e) = write_coverage_map(name, &result) {
+            crate::probe!(
+                class = "benchmark.validate.map_unwritten",
+                error = %e,
+                "coverage map could not be persisted — dispatch keeps its \
+                 fail-open behaviour and gates nothing"
+            );
+        }
+        Ok(result)
     }
+}
+
+/// Where a validated coverage map lives for one (dataset, machine-class) pair.
+/// Under the governed benchmarks root, next to the verdicts it protects — one
+/// small file per dataset, rewritten in place, so it needs no eviction story.
+pub fn coverage_map_path(dataset: &str, machine_class: &str) -> std::path::PathBuf {
+    let safe: String = dataset
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
+        .collect();
+    let mc: String = machine_class
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
+        .collect();
+    crate::cognition::swe_bench::swe_cache_dir()
+        .join("coverage")
+        .join(format!("{safe}.{mc}.json"))
+}
+
+fn write_coverage_map(dataset: &str, result: &BenchmarkValidateResult) -> Result<(), String> {
+    let path = coverage_map_path(dataset, &result.platform.machine_class);
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    let json = serde_json::to_string_pretty(result).map_err(|e| e.to_string())?;
+    std::fs::write(&path, json).map_err(|e| e.to_string())
+}
+
+/// The named wall for an instance's env class, when THIS box has already proven
+/// that class red. `None` means "no map, or the class is green, or the map was
+/// earned on a different machine class" — every one of which must DISPATCH, not
+/// block. Fail-open is the contract: a repo user who has never run
+/// `benchmark/validate` is never slowed down by a gate that has nothing to say.
+pub fn known_red_wall(dataset: &str, repo: &str, era_year: u32) -> Option<String> {
+    let machine_class = BenchmarkPlatformFingerprint::capture().machine_class;
+    let raw = std::fs::read_to_string(coverage_map_path(dataset, &machine_class)).ok()?;
+    let map: BenchmarkValidateResult = serde_json::from_str(&raw).ok()?;
+    if map.platform.machine_class != machine_class {
+        return None; // another box's claim is not evidence about this one
+    }
+    let era = era_year.to_string();
+    map.classes
+        .iter()
+        .find(|c| c.repo == repo && c.era == era && !c.green)
+        .map(|c| {
+            c.wall
+                .clone()
+                .unwrap_or_else(|| "class proven red by benchmark/validate".to_string())
+        })
 }
 crate::register_stateless_command!(BenchmarkValidate);
 

--- a/core/continuum-core/src/commands/tool/output.rs
+++ b/core/continuum-core/src/commands/tool/output.rs
@@ -147,6 +147,20 @@ pub struct ToolOutput;
 #[async_trait]
 impl ActionCommand for ToolOutput {
     const NAME: &'static str = "tool/output";
+    // THE RECOVERY VERB MUST BE IN HER VOCABULARY. Measured 2026-08-28: the
+    // elision marker tells her to "jump straight to what broke" with
+    // `tool/output`, and this command declared NO aliases — so under
+    // `OfferStyle::TrainedReflex` (which offers each command's PRIMARY alias,
+    // `code/read` → `read_file`) it never landed on the menu in a name her
+    // training reaches for, and across every log on this box it had been called
+    // exactly ZERO times. The substrate was handing her a handle and naming a
+    // verb she did not hold: the tail of every flood-sized error — which is
+    // usually the actual failure — was unreadable to her.
+    //
+    // Inbound resolution accepts every style (`from_wire_name`), so adding
+    // aliases can only widen what she can say, never narrow it.
+    const ALIASES: &'static [&'static str] =
+        &["read_output", "grep_output", "tail_output", "search_output"];
     const DESCRIPTION: &'static str =
         "Page or grep a large tool result that was saved to disk because it was too big \
          to show in full. Pass the `handle` from the elision marker. EASIEST: set \

--- a/protocol/typescript/benchmark/BenchmarkDispatchResult.ts
+++ b/protocol/typescript/benchmark/BenchmarkDispatchResult.ts
@@ -27,6 +27,13 @@ card_ids: Array<string>,
  */
 skipped_needs_setup: number, 
 /**
+ * Instances withheld because THIS box already proved their (repo, era) env
+ * class red via `benchmark/validate`. Reported, never silent — the operator
+ * must see that the round is smaller than requested and WHY (the named wall
+ * rides in `kickoff_errors`).
+ */
+skipped_known_red: number, 
+/**
  * Tasks NOT dispatched because a LIVE card for that exact task is already on
  * the board (same `[bench <name>] <task_id>:` key, in any non-terminal state).
  * Dispatch is idempotent per task: re-running it tops the board up to one card


### PR DESCRIPTION
Two halves of the same problem: the harness *knew* which env classes were broken and had no way to act on it.

## 1. The wall itself — numpy 2 vs pre-2021 astropy

Caught on a live dispatch. `astropy__astropy-6938` (2017) died at env build with `ValueError: Unable to avoid copy while creating an array as requested` — numpy 2.0 made `np.array(obj, copy=False)` **raise**, and 2017-era astropy calls exactly that in `Quantity._new_view`. The instance was gone before a citizen saw it.

The row was a bare `"numpy"`, which is the smuggling path *its own comment warns about*: when the dated resolve hiccups, the era-pin's unpinned retry lands a 2026 numpy in a 2017 subject graph. Fixed with `numpy==1.21.6` for `year <= 2020` — the same middle xarray uses, **verified on this box** (`xarray-2905`/`-4966` both carry numpy 1.21.6 on the python3.9 those eras get) rather than assumed. Scoped to old eras so the passing 2022+ astropy instances are untouched.

## 2. The gate — `benchmark/validate` stops being advice

`validate` already builds one real env per (repo, era) class and names the wall for every red one. But the map lived only in that command's stdout, so **nothing could act on it**: astropy-6938 was dispatched into the numpy-2 wall while a validate run minutes away already knew `astropy/2017` was red.

- **validate persists** the map, keyed by (dataset × machine_class) — a coverage claim is only true for the platform that earned it.
- **dispatch does a dictionary lookup**, never a build, so the dispatch path stays fast for a repo user who has never run validate. It withholds only instances whose class *this box* proved red, naming the wall in `kickoff_errors` and counting them in `skipped_known_red`.

**Fail-open is the contract**, and the test pins all four ambiguous cases — no map, a green class, an era with no row, and a map earned on a different machine class **all dispatch**. Only a locally-proven red class withholds a card, and never silently.

## Live map on this box

**30 classes, 26 green, 4 red** — `astropy 2017/2018` (fixed by half 1) and `requests 2015/2016` (still open, next).

## Why it matters

Of the last 14 solve runs in the current harness era, only **3 measured the citizen at all** — 5 died on environment, 5 produced no candidate patch. This closes an env class *and* stops the remaining ones from costing solve hours to rediscover.

56 benchmark + 29 swe_bench tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo