### PR TITLE
fix(benchmark): the round advances the INSTANT a run ends without settling — stop waiting out the watchdog

### DIFF
--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -510,6 +510,31 @@ pub fn next_unworked_after(card_of_round: Uuid) -> Option<NextCard> {
     first_unworked(round, &live)
 }
 
+/// The NON-SETTLING edge of the same driver decision — the fourth edge.
+///
+/// A run can finish WITHOUT its card reaching a terminal state: she produced no
+/// diff, the env was absent, the cached env would not re-point. Those are honest
+/// outcomes (the card stays open for a retake) but they emit no card-settled
+/// event, so the settle edge never fires and the round would sit still until the
+/// 5-minute becalmed watchdog noticed. Measured 2026-08-28: a non-settling run at
+/// 01:58 and another at 03:30 each left the round idle behind one finished solve.
+/// A round that advances only by TIMEOUT is polling wearing an actuator's coat;
+/// it should move the instant the fact is known ([[the-whole-system-is-event-based-not-polling]]).
+///
+/// `just_finished` is EXCLUDED, and that exclusion is the loop guard: the card is
+/// still unsettled and no longer live, so the unguarded decision would hand back
+/// the very card that just failed and re-fire it forever. The watchdog remains the
+/// backstop for everything this edge cannot see (a process that died without
+/// running its close path at all).
+pub fn next_unworked_excluding(just_finished: Uuid) -> Option<NextCard> {
+    let live = live_run_ids();
+    let rounds = ROUNDS.lock().expect("bench rounds mutex");
+    let round = rounds
+        .values()
+        .find(|r| r.cards.contains_key(&just_finished))?;
+    first_unworked_excluding(round, &live, Some(just_finished))
+}
+
 /// The boot-resume edge of the SAME decision: the first unworked card of EVERY
 /// Working detached round. Called once at benchmark-module boot (after the
 /// serving + residency parks); the card-settled edge then chains the rest.
@@ -555,6 +580,14 @@ fn live_run_ids() -> std::collections::HashSet<String> {
 
 /// The one shared decision body behind both edges.
 fn first_unworked(round: &BenchRound, live: &std::collections::HashSet<String>) -> Option<NextCard> {
+    first_unworked_excluding(round, live, None)
+}
+
+fn first_unworked_excluding(
+    round: &BenchRound,
+    live: &std::collections::HashSet<String>,
+    exclude: Option<Uuid>,
+) -> Option<NextCard> {
     if round.driver != WorkDriver::DetachedSolve {
         return None;
     }
@@ -562,6 +595,7 @@ fn first_unworked(round: &BenchRound, live: &std::collections::HashSet<String>) 
         .cards
         .iter()
         .filter(|(_, state)| state.is_none())
+        .filter(|(c, _)| Some(**c) != exclude)
         .filter(|(c, _)| !live.contains(&format!("claim-{}", c)))
         .find_map(|(c, _)| {
             round.card_assignees.get(c).map(|a| NextCard {
@@ -751,6 +785,59 @@ pub fn live_rounds() -> Vec<RoundSnapshot> {
 
 #[cfg(test)]
 mod tests {
+    // what this catches: the round advancing only by TIMEOUT, and the loop the
+    // naive fix creates. Measured 2026-08-28 — a run can finish WITHOUT settling
+    // its card (no diff, env absent, cached env would not re-point). Those emit
+    // no card-settled event, so the settle edge never fires and the round sat
+    // idle behind one finished solve until the 5-minute becalmed watchdog
+    // noticed (01:58 and 03:30 both did exactly that).
+    //
+    // The exclusion IS the loop guard: after a non-settling run the card is
+    // still unsettled and no longer live, so the unguarded decision hands back
+    // the very card that just failed — forever. Both halves are pinned here.
+    #[test]
+    fn the_non_settling_edge_advances_past_the_card_that_just_failed() {
+        fn round_with(cards: &[(Uuid, Uuid)]) -> BenchRound {
+            BenchRound {
+                round_id: Uuid::new_v4(),
+                benchmark: "swe-bench-lite".into(),
+                cards: cards.iter().map(|(c, _)| (*c, None)).collect(),
+                stage: RoundStage::Working,
+                driver: WorkDriver::DetachedSolve,
+                card_activities: Default::default(),
+                card_assignees: cards.iter().copied().collect(),
+            }
+        }
+        let live = std::collections::HashSet::new();
+        let who = Uuid::new_v4();
+        let failed = Uuid::new_v4();
+        let next = Uuid::new_v4();
+
+        // THE LOOP GUARD. One card left, and it is the one that just failed:
+        // unguarded the decision hands it straight back (re-firing forever);
+        // excluded, the chain honestly ends.
+        let only = round_with(&[(failed, who)]);
+        assert_eq!(
+            first_unworked(&only, &live).map(|n| n.card),
+            Some(failed),
+            "sanity: unguarded, the just-failed card is handed back — the tight loop"
+        );
+        assert!(
+            first_unworked_excluding(&only, &live, Some(failed)).is_none(),
+            "the last card failing must end the chain, never re-fire itself"
+        );
+
+        // THE ADVANCE. Real work remains, so the round moves NOW rather than
+        // waiting out the 5-minute becalmed watchdog.
+        let two = round_with(&[(failed, who), (next, who)]);
+        assert_eq!(
+            first_unworked_excluding(&two, &live, Some(failed)).map(|n| n.card),
+            Some(next),
+            "the non-settling edge must advance PAST the card that just failed"
+        );
+    }
+
+
     use super::*;
 
     fn cards(n: usize) -> Vec<Uuid> {

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -977,6 +977,66 @@ fn classify_grade_for_close(grade: Option<&serde_json::Value>) -> CardCloseDecis
     CardCloseDecision::Close
 }
 
+
+/// Fire the round's next card the MOMENT a run ends without settling its own.
+///
+/// The settle edge (`benchmark_grade`'s follow-on) only fires on a card-state
+/// change, so an honest non-settling outcome — no diff, env absent, a cached env
+/// that would not re-point — left the round motionless until the 5-minute
+/// becalmed watchdog happened to notice. That is advancement by TIMEOUT; the
+/// fact is known right here, so act on it here.
+///
+/// The just-finished card is excluded by the decision itself
+/// (`next_unworked_excluding`), which is what keeps this from re-firing the card
+/// that just failed in a tight loop. Best-effort by design: no live citizen
+/// simply means the watchdog picks it up on its next pass, exactly as before.
+async fn advance_round_after_non_settling(run_id: &str) {
+    let Some(card) = run_id
+        .strip_prefix("claim-")
+        .and_then(|s| Uuid::parse_str(s).ok())
+    else {
+        return; // not a claim-dispatched run — it owns no card to advance from
+    };
+    let Some(next) = crate::cognition::bench_round::next_unworked_excluding(card) else {
+        return; // round finished, or every remaining card is already in flight
+    };
+    let Some(reg) = crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global()
+    else {
+        return;
+    };
+    let Some(airc) = reg
+        .get(next.assignee)
+        .or_else(|| reg.any_live_citizen())
+        .map(|rt| rt.airc().clone())
+    else {
+        crate::probe!(
+            class = "bench.round.advance_blocked",
+            card_id = %next.card,
+            "the next card is due after a non-settling run, but no live citizen can \
+             carry the dispatch — the becalmed watchdog remains the backstop"
+        );
+        return;
+    };
+    crate::probe!(
+        class = "bench.round.advanced",
+        finished = %card,
+        next_card = %next.card,
+        assignee = %next.assignee,
+        "a run ended WITHOUT settling its card — firing the round's next card now \
+         instead of waiting out the becalmed watchdog"
+    );
+    crate::modules::work::dispatch_staged_swe_solve(
+        &Default::default(),
+        &airc,
+        crate::modules::work::StagedSolveDispatch {
+            claimer: crate::identity::PeerId::from_uuid(next.assignee),
+            card: airc_work::WorkCardId::from_uuid(next.card),
+            room: airc_core::RoomId::from_u128(next.run_room.as_u128()),
+        },
+    )
+    .await;
+}
+
 /// The A3 terminal close: a claim-dispatched run (`run_id == claim-<card uuid>`)
 /// whose final attempt produced a REAL verdict closes its card, authored through
 /// the run's own persona (subscribed to the run room by dispatch). Non-claim runs
@@ -1007,6 +1067,7 @@ async fn close_claim_card_if_graded(run_id: &str) {
             reason = "no_patch",
             "she produced no diff — card stays open for a retake; not an env absence"
         );
+        advance_round_after_non_settling(run_id).await;
         return;
     }
     if cache_repoint_failed {
@@ -1019,6 +1080,7 @@ async fn close_claim_card_if_graded(run_id: &str) {
              a sibling grader on a pristine clone may already have scored it). No \
              parking brake: this run simply does not close the card"
         );
+        advance_round_after_non_settling(run_id).await;
         return;
     }
     if !verdict_is_real && !env_absent {
@@ -1028,6 +1090,7 @@ async fn close_claim_card_if_graded(run_id: &str) {
             "no verdict on disk at all (infra died before grading) — this run does \
              not close the card, so a resume re-fires it (the owed retake)"
         );
+        advance_round_after_non_settling(run_id).await;
         return;
     }
     if env_absent {
@@ -1059,6 +1122,7 @@ async fn close_claim_card_if_graded(run_id: &str) {
              fires itself on the first boot whose env pre-warm succeeds (if the \
              card is still open — a lapse sweeper may already have closed it)"
         );
+        advance_round_after_non_settling(run_id).await;
         return;
     }
     // Author through the run's persona (her runtime is subscribed to the run


### PR DESCRIPTION
A solve can finish **without** its card reaching a terminal state: she produced no diff, the env was absent, a cached env would not re-point. Those are honest outcomes and the card correctly stays open for a retake — but they emit no card-settled event, so the settle edge never fires and the round sits motionless behind one finished solve until the 5-minute becalmed watchdog notices.

Measured 2026-08-28: a non-settling run at 01:58 and another at 03:30 each left the round idle. The watchdog *does* recover it, so this was a **throughput drag, not a dead round** — but a round that advances by timeout is polling wearing an actuator's coat. The fact is known the moment the run closes; act on it there.

## The fourth edge of ONE decision

`next_unworked_excluding(just_finished)` reuses `first_unworked`, so dispatch, card-settled, boot-resume and now non-settling all make the *same* decision — never a second scheduler.

## The exclusion is the loop guard

This is why it isn't a one-liner. After a non-settling run the card is still unsettled and no longer live, so the unguarded decision hands back **the very card that just failed** — forever. The test pins both halves: with only that card left the chain ends honestly; with real work remaining it advances past it.

Written deterministically on purpose — `BenchRound.cards` is a `HashMap`, so "which card is first" is not a stable fact to assert on, and my first draft of the test was flaky for exactly that reason.

## Best-effort by design

No live citizen, or every remaining card already in flight, means the becalmed watchdog picks it up exactly as before. This makes the common case immediate; it does not become a new single point of failure.

16 bench_round + 19 solve tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo