### PR TITLE
feat(inference): measured work holds the core — Background generations defer at the adapter seam (restore-economy 1.a)

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -1978,6 +1978,27 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
             // measured defect: sidecar gate calls pinned the turn's own slot and
             // cut its ~30k tail to their common head — reuse broke even solo.
             let class = crate::inference::slots::class_for(request.purpose.as_deref());
+            // MEASURED WORK HOLDS THE CORE (restore-economy Phase 1.a). Deferral
+            // sits HERE — after classification, BEFORE the concurrency permit
+            // below — so a parked Background/Probe request holds NOTHING while it
+            // waits: no lock, no decode permit, just its own task on a notify.
+            // Parking after the permit would be priority inversion (a sleeping
+            // dream holding the only decode slot while a real turn queues behind
+            // it — the exact too-serial hazard Joel flagged). Turn/Sidecar never
+            // enter the await at all, and release wakes ALL waiters (broadcast,
+            // not FIFO), so deferred work re-races admission rather than
+            // draining serially. Measured cause: dream-belief-review took 52 of
+            // 109 generations DURING a held solve, ~32.9s re-prefill per clobber.
+            let hold_caller = request
+                .persona_id
+                .as_deref()
+                .and_then(|p| uuid::Uuid::parse_str(p).ok());
+            crate::inference::measured_hold::defer_while_held(
+                class,
+                hold_caller,
+                request.purpose.as_deref(),
+            )
+            .await;
             let placement: Option<u32> = match class {
                 crate::inference::slots::SlotClass::Turn => {
                     // The typed activity key: (persona, room) as UUID structs — never

--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -310,15 +310,12 @@ async fn settle_to_outcome(
         }
         let may_act = acts < max_acts && stuck < STUCK_LIMIT && discovery_open;
         let act_started = std::time::Instant::now();
-        let (step, step_metrics) = settle_step(
-            cycle,
-            burst.clone(),
-            may_act,
-            framing,
-            situation,
-            &chain,
-        )
-        .await;
+        let (step, step_metrics) =
+            settle_step(cycle, burst.clone(), may_act, framing, situation, &chain).await;
+        // This act's model wall-time, captured before the accumulate consumes
+        // the metrics — the pace row below splits act time into model vs
+        // residue with it.
+        let act_model_ms = step_metrics.as_ref().map(|m| m.latency_ms).unwrap_or(0);
         if let Some(m) = step_metrics {
             metrics.accumulate(m);
         }
@@ -345,6 +342,16 @@ async fn settle_to_outcome(
                 rolling_mean_secs = mean as u64,
                 slow = slow,
                 stuck_streak = stuck,
+                // THE LEDGER SPLIT (restore-economy VDD): model_ms is this act's
+                // generation wall-time (the adapter's own measurement, riding up
+                // through StepMetrics); residue_ms is everything else the act
+                // spent — tool execution, RAG assembly, settle bookkeeping.
+                // Before this split the ~29s/act residue was only derivable by
+                // subtracting log aggregates; a stall hiding in tools vs a stall
+                // hiding in the model were the same number. Now each act names
+                // where its time went, per-act, at the moment it happens.
+                model_ms = act_model_ms,
+                residue_ms = ((act_secs * 1000.0) as u64).saturating_sub(act_model_ms),
                 "act pace vs this turn's own rolling mean — slow/looping visible the moment it happens"
             );
         }
@@ -392,7 +399,7 @@ async fn settle_to_outcome(
                     }
                 }
                 return SettleOutcome {
-                room: room_id,
+                    room: room_id,
                     spoken: Some(text.clone()),
                     decision: Decision::Speak { text },
                     acts,
@@ -486,7 +493,7 @@ async fn settle_to_outcome(
             SettleStep::WouldAct { calls, intent }
             | SettleStep::ActUnfulfilled { calls, intent } => {
                 return SettleOutcome {
-                room: room_id,
+                    room: room_id,
                     decision: Decision::Act { calls, intent },
                     spoken: None,
                     acts,
@@ -498,7 +505,7 @@ async fn settle_to_outcome(
             }
             SettleStep::Passed => {
                 return SettleOutcome {
-                room: room_id,
+                    room: room_id,
                     decision: Decision::Pass,
                     spoken: None,
                     acts,
@@ -536,7 +543,7 @@ async fn settle_to_outcome(
                     continue;
                 }
                 return SettleOutcome {
-                room: room_id,
+                    room: room_id,
                     decision: Decision::Pass,
                     spoken: None,
                     acts,

--- a/core/continuum-core/src/cognition/dream_consolidation.rs
+++ b/core/continuum-core/src/cognition/dream_consolidation.rs
@@ -992,6 +992,27 @@ async fn dream_pass(
     consolidated: Arc<Mutex<HashMap<Uuid, HashSet<Uuid>>>>,
     reviewed: Arc<Mutex<HashMap<Uuid, HashSet<Uuid>>>>,
 ) {
+    // CAUSAL EARLY-SKIP (restore-economy 1.a, the subscribe() consumer): while a
+    // measured solve holds the core, don't even ASSEMBLE the dream — cluster
+    // gathering, budget math and prompt composition are wasted work for a
+    // generation the adapter seam would only park at the door. Await the RELEASE
+    // EVENT instead (watch semantics: a transition cannot be missed), holding
+    // nothing while parked — the mind isn't locked, its idle-time work is
+    // simply queued behind measured work, which is what "idle-time" means
+    // ([[idle-is-self-directed-free-time]]). The adapter gate stays the
+    // enforcement (this is an optimization, not the guard); its 4h leak ceiling
+    // still bounds the pathological case for any dream that slips past here.
+    let mut hold = crate::inference::measured_hold::subscribe();
+    while hold.borrow_and_update().is_some() {
+        crate::probe!(
+            class = "dream.deferred_to_hold",
+            persona = %persona_id,
+            "dream pass parked on the hold's release event — measured work owns the core"
+        );
+        if hold.changed().await.is_err() {
+            break; // sender gone (process teardown) — proceed; the adapter gate still guards
+        }
+    }
     // #175 budget-at-assembly: derive the observation budget from the LIVE served
     // per-slot window (the single source of truth, same the deliberation clamp reads)
     // so a dream cluster is composed WITHIN the slot and can never overflow it →
@@ -2118,9 +2139,17 @@ mod tests {
 
         // The exact live shape: bold-wrapped on BOTH ends, so the trailing `**`
         // also has to come off or `3**` fails to parse as an index.
-        let (body, ids) = parse_supersedes_line("A consolidated fact.\n**SUPERSEDES: 1,3**", &priors);
-        assert_eq!(body, "A consolidated fact.", "the marker must never survive into the belief");
-        assert_eq!(ids, vec![priors[0].id, priors[2].id], "the ruling must be honored");
+        let (body, ids) =
+            parse_supersedes_line("A consolidated fact.\n**SUPERSEDES: 1,3**", &priors);
+        assert_eq!(
+            body, "A consolidated fact.",
+            "the marker must never survive into the belief"
+        );
+        assert_eq!(
+            ids,
+            vec![priors[0].id, priors[2].id],
+            "the ruling must be honored"
+        );
 
         // Other decorations models reach for, and case variance.
         for line in [

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -1328,6 +1328,17 @@ impl AgentSolve {
         //     `lane.served_ctx` carries it into her fork with no further plumbing.
         //     Bounded loudly: a planner that keeps the layout is a legitimate
         //     outcome, so `Unchanged` proceeds — it can never park the solve.
+        // The measured-work hold (restore-economy 1.a): the quiesce lease below
+        // pauses the other citizens' SERVICE LOOPS, but background cognition
+        // (dreams, module inference) never runs in those loops — measured
+        // 2026-08-28, dream-belief-review took 52 of 109 generations during a
+        // held solve and evicted the warm KV each time (~32.9s re-prefill vs
+        // ~0.1s restore). The hold is consulted at the adapter seam, where every
+        // generation crosses; RAII, so any exit path releases it.
+        let _measured_hold = crate::inference::measured_hold::acquire(
+            persona_uuid,
+            run_id.as_deref().unwrap_or("agent-solve"),
+        );
         let _quiesce_lease =
             crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global().map(
                 |reg| {

--- a/core/continuum-core/src/inference/measured_hold.rs
+++ b/core/continuum-core/src/inference/measured_hold.rs
@@ -84,28 +84,23 @@ pub struct HoldInfo {
     generation: u64,
 }
 
-/// The hold's state + wakeup machinery. Public-in-crate only for the
-/// injected-core test pattern (`spill.rs` precedent): production uses the ONE
-/// process-global cell; tests construct their own so parallel tests cannot race
-/// each other through a shared singleton (that race was observed immediately —
-/// the first parallel run of this module's own tests).
-pub struct HoldCell {
+/// The hold's state + wakeup machinery. MODULE-private on purpose: production
+/// uses the ONE process-global cell, and the injected-core tests (`spill.rs`
+/// precedent — each test its own cell, because the shared singleton made the
+/// first parallel test run race itself) live in this module and need no wider
+/// visibility. Making it pub tripped the unwired-machinery ratchet, correctly:
+/// a pub type nothing outside constructs is the #27 shape.
+struct HoldCell {
     tx: watch::Sender<Option<HoldInfo>>,
     generations: AtomicU64,
 }
 
 impl HoldCell {
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             tx: watch::channel(None).0,
             generations: AtomicU64::new(0),
         }
-    }
-}
-
-impl Default for HoldCell {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -160,7 +155,7 @@ pub fn acquire(holder: Uuid, run_id: &str) -> HoldLease {
 }
 
 /// Injected-core acquire — tests pass their own leaked cell.
-pub fn acquire_in(c: &'static HoldCell, holder: Uuid, run_id: &str) -> HoldLease {
+fn acquire_in(c: &'static HoldCell, holder: Uuid, run_id: &str) -> HoldLease {
     let generation = c.generations.fetch_add(1, Ordering::Relaxed) + 1;
     if let Some(prev) = c.tx.borrow().as_ref() {
         crate::probe!(

--- a/core/continuum-core/src/inference/measured_hold.rs
+++ b/core/continuum-core/src/inference/measured_hold.rs
@@ -1,0 +1,392 @@
+//! The measured-work hold — Law 3 of the restore economy: **measured work holds
+//! the core**, and every model-touching path respects it at ONE seam.
+//!
+//! ## The defect this closes (measured 2026-08-28)
+//!
+//! `agent/solve` quiesces the other citizens' service loops
+//! (`quiesce_others`, verified `quiesced_peers=3`) — and the GPU still spent
+//! ~half its generations on `dream-belief-review` (52 of 109
+//! `inference.prefill.complete` rows) DURING a measured solve. Dreams don't run
+//! in the service loop the lease gates; they spawn their own tasks and walked
+//! straight past the quiesce onto the ONE serving slot, evicting the solve's
+//! warm KV every time. On this geometry an eviction is a ~32.9s re-prefill vs a
+//! ~0.1s restore (~330×, measured), so the bypass didn't slow the solve — it
+//! halved the machine.
+//!
+//! Gating at each background producer would be whack-a-mole (the next
+//! `tokio::spawn` forgets). The adapter is the one seam every generation
+//! already crosses with its `purpose` in hand, so the hold is consulted there
+//! and nowhere else. Producers never need to know it exists.
+//!
+//! ## What defers, what rides through
+//!
+//! [`SlotClass`] is the decision vocabulary (one purpose→class map,
+//! `slots::class_for`):
+//! - **Turn** — never deferred. A real citizen turn outranks a measurement
+//!   (a human talking to a citizen must never dead-air), and the existing
+//!   quiesce lease already keeps idle citizens' turns from firing. Blocking
+//!   Turn here could also deadlock the measured drive itself.
+//! - **Sidecar** — never deferred: sidecars ride a live turn, and on quiesced
+//!   geometry the only live turn is the measured one.
+//! - **Background / Probe** — deferred while someone ELSE holds. Dreams are
+//!   idle-time work by definition ([[idle-is-self-directed-free-time]]); a
+//!   measured solve means the core is not idle. The holder's OWN background
+//!   traffic passes (`caller == holder`).
+//!
+//! ## Bounded, never a silent park
+//!
+//! Deferral waits on a notify with a hard ceiling. A leaked lease (process
+//! killed mid-drop, a bug) must not park dreaming forever — at the ceiling the
+//! waiter PROCEEDS and says so loudly (`inference.hold.defer_ceiling`), which
+//! is a lease-leak detector, not a policy.
+//!
+//! ## Probes (VDD receipt)
+//!
+//! `inference.hold.acquired` / `.released` / `.deferred` / `.resumed` /
+//! `.defer_ceiling`. The phase receipt reads `inference.prefill.complete`
+//! during a hold: ZERO Background-class rows is the pass condition.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use uuid::Uuid;
+
+use super::slots::SlotClass;
+
+/// A leaked lease must not park background cognition forever: at this ceiling a
+/// deferred waiter proceeds LOUDLY. Solves run 1–3h, so 4h defers real dreams
+/// behind real work while still unsticking a leak within one operator shift.
+/// A refusal-to-hang, not a tuning knob.
+pub const DEFER_CEILING: Duration = Duration::from_secs(4 * 60 * 60);
+
+/// Re-check cadence while deferred. Wakeups are notify-driven (release wakes
+/// waiters instantly); this tick only bounds how stale a missed notify can be.
+const DEFER_TICK: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoldInfo {
+    pub holder: Uuid,
+    pub run_id: String,
+    /// Generation counter — lets a stale lease's Drop recognise that a NEWER
+    /// hold replaced it and leave that newer hold untouched.
+    generation: u64,
+}
+
+/// The hold's state + wakeup machinery. Public-in-crate only for the
+/// injected-core test pattern (`spill.rs` precedent): production uses the ONE
+/// process-global cell; tests construct their own so parallel tests cannot race
+/// each other through a shared singleton (that race was observed immediately —
+/// the first parallel run of this module's own tests).
+pub struct HoldCell {
+    state: Mutex<Option<HoldInfo>>,
+    notify: tokio::sync::Notify,
+    generations: AtomicU64,
+}
+
+impl HoldCell {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(None),
+            notify: tokio::sync::Notify::new(),
+            generations: AtomicU64::new(0),
+        }
+    }
+}
+
+impl Default for HoldCell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn cell() -> &'static HoldCell {
+    static CELL: OnceLock<HoldCell> = OnceLock::new();
+    CELL.get_or_init(HoldCell::new)
+}
+
+/// RAII lease: dropping releases the hold (if it is still ours) and wakes every
+/// deferred waiter.
+pub struct HoldLease {
+    generation: u64,
+    cell: &'static HoldCell,
+}
+
+impl Drop for HoldLease {
+    fn drop(&mut self) {
+        let c = self.cell;
+        let mut guard = c.state.lock().unwrap_or_else(|p| p.into_inner());
+        // Only clear OUR hold. A newer acquire (last-wins) must survive a stale
+        // lease's late drop — without the generation check, a leaked old lease
+        // dropping late would silently release the live measurement's hold.
+        if guard.as_ref().is_some_and(|h| h.generation == self.generation) {
+            let released = guard.take();
+            drop(guard);
+            if let Some(h) = released {
+                crate::probe!(
+                    class = "inference.hold.released",
+                    holder = %h.holder,
+                    run_id = %h.run_id,
+                    "measured-work hold released — deferred background cognition wakes now"
+                );
+            }
+            c.notify.notify_waiters();
+        }
+    }
+}
+
+/// Take the measured-work hold. Last-wins: a second acquire replaces the first
+/// (and says so) rather than deadlocking two measurements against each other —
+/// the solve driver serializes measured work anyway, so a replacement here is a
+/// bug being made VISIBLE, not a supported mode.
+pub fn acquire(holder: Uuid, run_id: &str) -> HoldLease {
+    acquire_in(cell(), holder, run_id)
+}
+
+/// Injected-core acquire — tests pass their own leaked cell.
+pub fn acquire_in(c: &'static HoldCell, holder: Uuid, run_id: &str) -> HoldLease {
+    let generation = c.generations.fetch_add(1, Ordering::Relaxed) + 1;
+    let mut guard = c.state.lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(prev) = guard.as_ref() {
+        crate::probe!(
+            class = "inference.hold.replaced",
+            prev_holder = %prev.holder,
+            prev_run = %prev.run_id,
+            new_holder = %holder,
+            new_run = %run_id,
+            "a second measured hold replaced a live one — measured work should be \
+             serial; if both runs are real this is the bug to chase"
+        );
+    }
+    *guard = Some(HoldInfo {
+        holder,
+        run_id: run_id.to_string(),
+        generation,
+    });
+    drop(guard);
+    crate::probe!(
+        class = "inference.hold.acquired",
+        holder = %holder,
+        run_id = %run_id,
+        "measured-work hold acquired — Background/Probe generations defer until release"
+    );
+    HoldLease { generation, cell: c }
+}
+
+/// The live hold, if any.
+pub fn current() -> Option<HoldInfo> {
+    current_in(cell())
+}
+
+fn current_in(c: &HoldCell) -> Option<HoldInfo> {
+    c.state.lock().unwrap_or_else(|p| p.into_inner()).clone()
+}
+
+/// The PURE decision — table-tested, no clock, no locks. `true` = this
+/// generation must wait for the hold to release.
+pub fn should_defer(class: SlotClass, hold: Option<&HoldInfo>, caller: Option<Uuid>) -> bool {
+    let Some(hold) = hold else {
+        return false; // no measurement in flight — everything passes
+    };
+    match class {
+        // A real turn or its sidecars never wait (see module doc: outranking +
+        // deadlock-freedom; idle citizens' turns are already quiesced upstream).
+        SlotClass::Turn | SlotClass::Sidecar => false,
+        // Background/Probe defer unless they belong to the measured run itself.
+        SlotClass::Background | SlotClass::Probe => caller != Some(hold.holder),
+    }
+}
+
+/// How a deferred generation eventually proceeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeferOutcome {
+    /// No hold, or the class rides through: no waiting happened.
+    Passed,
+    /// Waited and the hold released.
+    Resumed,
+    /// Waited to the ceiling and proceeded anyway — a lease-leak detector
+    /// firing, not a policy success.
+    CeilingProceed,
+}
+
+/// Await the hold at the adapter seam. See [`should_defer`] for the decision;
+/// this adds the bounded wait + probes around it.
+pub async fn defer_while_held(
+    class: SlotClass,
+    caller: Option<Uuid>,
+    purpose: Option<&str>,
+) -> DeferOutcome {
+    defer_while_held_with_ceiling(class, caller, purpose, DEFER_CEILING).await
+}
+
+/// Ceiling-injected core so the timeout path is testable in milliseconds.
+pub async fn defer_while_held_with_ceiling(
+    class: SlotClass,
+    caller: Option<Uuid>,
+    purpose: Option<&str>,
+    ceiling: Duration,
+) -> DeferOutcome {
+    defer_in(cell(), class, caller, purpose, ceiling).await
+}
+
+/// Injected-core defer — the loop the public entry points share.
+async fn defer_in(
+    c: &'static HoldCell,
+    class: SlotClass,
+    caller: Option<Uuid>,
+    purpose: Option<&str>,
+    ceiling: Duration,
+) -> DeferOutcome {
+    if !should_defer(class, current_in(c).as_ref(), caller) {
+        return DeferOutcome::Passed;
+    }
+    let started = std::time::Instant::now();
+    let held_by = current_in(c).map(|h| h.run_id).unwrap_or_default();
+    crate::probe!(
+        class = "inference.hold.deferred",
+        traffic = %class.as_str(),
+        purpose = %purpose.unwrap_or("-"),
+        held_by = %held_by,
+        "background generation deferring — measured work holds the core"
+    );
+    loop {
+        if !should_defer(class, current_in(c).as_ref(), caller) {
+            crate::probe!(
+                class = "inference.hold.resumed",
+                traffic = %class.as_str(),
+                purpose = %purpose.unwrap_or("-"),
+                waited_ms = started.elapsed().as_millis() as u64,
+                "hold released — deferred generation proceeding"
+            );
+            return DeferOutcome::Resumed;
+        }
+        if started.elapsed() >= ceiling {
+            crate::probe!(
+                class = "inference.hold.defer_ceiling",
+                traffic = %class.as_str(),
+                purpose = %purpose.unwrap_or("-"),
+                waited_ms = started.elapsed().as_millis() as u64,
+                "defer ceiling reached with the hold still set — proceeding LOUDLY; \
+                 if the measured run is not actually alive this is a leaked lease"
+            );
+            return DeferOutcome::CeilingProceed;
+        }
+        let remaining = ceiling.saturating_sub(started.elapsed()).min(DEFER_TICK);
+        let _ = tokio::time::timeout(remaining, c.notify.notified()).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hold_of(holder: Uuid) -> HoldInfo {
+        HoldInfo {
+            holder,
+            run_id: "claim-test".into(),
+            generation: 1,
+        }
+    }
+
+    // what this catches: the defer table drifting. Turn/Sidecar must NEVER wait
+    // (a human's turn outranks a measurement, and blocking the measured drive's
+    // own traffic would deadlock it); Background/Probe must wait exactly when
+    // someone ELSE holds. The 2026-08-28 defect was the absence of this table:
+    // dream-belief-review (Background) took 52 of 109 generations DURING a
+    // measured solve because nothing at the adapter seam said no.
+    #[test]
+    fn the_defer_table_holds() {
+        let holder = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let h = hold_of(holder);
+
+        for class in [SlotClass::Turn, SlotClass::Sidecar] {
+            assert!(!should_defer(class, Some(&h), Some(other)), "{class:?} never waits");
+            assert!(!should_defer(class, None, Some(other)));
+        }
+        for class in [SlotClass::Background, SlotClass::Probe] {
+            assert!(
+                should_defer(class, Some(&h), Some(other)),
+                "{class:?} from another mind defers during a hold"
+            );
+            assert!(
+                should_defer(class, Some(&h), None),
+                "anonymous {class:?} defers too — no caller is not the holder"
+            );
+            assert!(
+                !should_defer(class, Some(&h), Some(holder)),
+                "the holder's own {class:?} rides through"
+            );
+            assert!(!should_defer(class, None, Some(other)), "no hold, no wait");
+        }
+    }
+
+    // what this catches: the RAII lifecycle — and specifically the stale-drop
+    // hazard. Without the generation check, a leaked OLD lease dropping late
+    // would silently release the LIVE measurement's hold, re-opening the exact
+    // dream-clobber this module exists to close.
+    #[tokio::test]
+    async fn a_stale_lease_cannot_release_a_newer_hold() {
+        // Own cell (leaked — 'static is the lease contract), so parallel tests
+        // can never race through the process-global singleton.
+        let c: &'static HoldCell = Box::leak(Box::new(HoldCell::new()));
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+
+        let lease_a = acquire_in(c, a, "claim-a");
+        assert_eq!(current_in(c).map(|h| h.holder), Some(a));
+
+        let lease_b = acquire_in(c, b, "claim-b"); // last-wins replacement
+        assert_eq!(current_in(c).map(|h| h.holder), Some(b));
+
+        drop(lease_a); // stale — must NOT clear b's hold
+        assert_eq!(
+            current_in(c).map(|h| h.holder),
+            Some(b),
+            "a stale lease's late drop must not release the live hold"
+        );
+
+        drop(lease_b);
+        assert!(current_in(c).is_none(), "the live lease's drop releases");
+    }
+
+    // what this catches: a waiter that never wakes, and a ceiling that never
+    // fires. Both ends of the bounded-wait contract, in milliseconds.
+    #[tokio::test]
+    async fn deferred_waiters_wake_on_release_and_proceed_at_the_ceiling() {
+        let holder = Uuid::new_v4();
+        let other = Uuid::new_v4();
+
+        let c: &'static HoldCell = Box::leak(Box::new(HoldCell::new()));
+
+        // Release wakes the waiter promptly.
+        let lease = acquire_in(c, holder, "claim-wake");
+        let waiter = tokio::spawn(defer_in(
+            c,
+            SlotClass::Background,
+            Some(other),
+            Some("dream-belief-review"),
+            Duration::from_secs(30),
+        ));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(lease);
+        let outcome = tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("waiter must wake promptly on release")
+            .unwrap();
+        assert_eq!(outcome, DeferOutcome::Resumed);
+
+        // A hold that never releases: the ceiling proceeds loudly instead of
+        // parking forever (the lease-leak detector).
+        let _leak = std::mem::ManuallyDrop::new(acquire_in(c, holder, "claim-leak"));
+        let outcome = defer_in(
+            c,
+            SlotClass::Background,
+            Some(other),
+            Some("dream-belief-review"),
+            Duration::from_millis(80),
+        )
+        .await;
+        assert_eq!(outcome, DeferOutcome::CeilingProceed);
+    }
+}

--- a/core/continuum-core/src/inference/measured_hold.rs
+++ b/core/continuum-core/src/inference/measured_hold.rs
@@ -33,9 +33,22 @@
 //!   measured solve means the core is not idle. The holder's OWN background
 //!   traffic passes (`caller == holder`).
 //!
+//! ## Causal, not polled (CBAR shape)
+//!
+//! The hold is a `watch` channel — the canonical substrate snapshot shape
+//! (CONCURRENCY-STYLE-GUIDE). Acquire/release are EVENTS; a deferred waiter
+//! awaits `changed()` and can never miss a transition (watch keeps the latest
+//! value), so there is no re-check tick, no poll, nothing time-based on the
+//! happy path. `subscribe()` is public so other components can REACT to the
+//! hold causally (a dream scheduler can skip assembling a prompt it would only
+//! park on) instead of discovering it at the adapter door. Serial exists in
+//! exactly one place — admission to the one physical GPU slot — because the
+//! device is serial; every mind and every deferred task stays concurrent and
+//! holds nothing while it waits.
+//!
 //! ## Bounded, never a silent park
 //!
-//! Deferral waits on a notify with a hard ceiling. A leaked lease (process
+//! Deferral has a hard ceiling. A leaked lease (process
 //! killed mid-drop, a bug) must not park dreaming forever — at the ceiling the
 //! waiter PROCEEDS and says so loudly (`inference.hold.defer_ceiling`), which
 //! is a lease-leak detector, not a policy.
@@ -47,8 +60,10 @@
 //! during a hold: ZERO Background-class rows is the pass condition.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::OnceLock;
 use std::time::Duration;
+
+use tokio::sync::watch;
 
 use uuid::Uuid;
 
@@ -59,10 +74,6 @@ use super::slots::SlotClass;
 /// behind real work while still unsticking a leak within one operator shift.
 /// A refusal-to-hang, not a tuning knob.
 pub const DEFER_CEILING: Duration = Duration::from_secs(4 * 60 * 60);
-
-/// Re-check cadence while deferred. Wakeups are notify-driven (release wakes
-/// waiters instantly); this tick only bounds how stale a missed notify can be.
-const DEFER_TICK: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HoldInfo {
@@ -79,16 +90,14 @@ pub struct HoldInfo {
 /// each other through a shared singleton (that race was observed immediately —
 /// the first parallel run of this module's own tests).
 pub struct HoldCell {
-    state: Mutex<Option<HoldInfo>>,
-    notify: tokio::sync::Notify,
+    tx: watch::Sender<Option<HoldInfo>>,
     generations: AtomicU64,
 }
 
 impl HoldCell {
     pub fn new() -> Self {
         Self {
-            state: Mutex::new(None),
-            notify: tokio::sync::Notify::new(),
+            tx: watch::channel(None).0,
             generations: AtomicU64::new(0),
         }
     }
@@ -114,23 +123,30 @@ pub struct HoldLease {
 
 impl Drop for HoldLease {
     fn drop(&mut self) {
-        let c = self.cell;
-        let mut guard = c.state.lock().unwrap_or_else(|p| p.into_inner());
+        let mut released: Option<HoldInfo> = None;
         // Only clear OUR hold. A newer acquire (last-wins) must survive a stale
         // lease's late drop — without the generation check, a leaked old lease
         // dropping late would silently release the live measurement's hold.
-        if guard.as_ref().is_some_and(|h| h.generation == self.generation) {
-            let released = guard.take();
-            drop(guard);
-            if let Some(h) = released {
-                crate::probe!(
-                    class = "inference.hold.released",
-                    holder = %h.holder,
-                    run_id = %h.run_id,
-                    "measured-work hold released — deferred background cognition wakes now"
-                );
+        // `send_if_modified` makes the release an EVENT exactly when (and only
+        // when) state actually changed: watchers wake causally, never spuriously.
+        self.cell.tx.send_if_modified(|state| {
+            if state
+                .as_ref()
+                .is_some_and(|h| h.generation == self.generation)
+            {
+                released = state.take();
+                true
+            } else {
+                false
             }
-            c.notify.notify_waiters();
+        });
+        if let Some(h) = released {
+            crate::probe!(
+                class = "inference.hold.released",
+                holder = %h.holder,
+                run_id = %h.run_id,
+                "measured-work hold released — deferred background cognition wakes now"
+            );
         }
     }
 }
@@ -146,8 +162,7 @@ pub fn acquire(holder: Uuid, run_id: &str) -> HoldLease {
 /// Injected-core acquire — tests pass their own leaked cell.
 pub fn acquire_in(c: &'static HoldCell, holder: Uuid, run_id: &str) -> HoldLease {
     let generation = c.generations.fetch_add(1, Ordering::Relaxed) + 1;
-    let mut guard = c.state.lock().unwrap_or_else(|p| p.into_inner());
-    if let Some(prev) = guard.as_ref() {
+    if let Some(prev) = c.tx.borrow().as_ref() {
         crate::probe!(
             class = "inference.hold.replaced",
             prev_holder = %prev.holder,
@@ -158,19 +173,21 @@ pub fn acquire_in(c: &'static HoldCell, holder: Uuid, run_id: &str) -> HoldLease
              serial; if both runs are real this is the bug to chase"
         );
     }
-    *guard = Some(HoldInfo {
+    c.tx.send_replace(Some(HoldInfo {
         holder,
         run_id: run_id.to_string(),
         generation,
-    });
-    drop(guard);
+    }));
     crate::probe!(
         class = "inference.hold.acquired",
         holder = %holder,
         run_id = %run_id,
         "measured-work hold acquired — Background/Probe generations defer until release"
     );
-    HoldLease { generation, cell: c }
+    HoldLease {
+        generation,
+        cell: c,
+    }
 }
 
 /// The live hold, if any.
@@ -179,7 +196,15 @@ pub fn current() -> Option<HoldInfo> {
 }
 
 fn current_in(c: &HoldCell) -> Option<HoldInfo> {
-    c.state.lock().unwrap_or_else(|p| p.into_inner()).clone()
+    c.tx.borrow().clone()
+}
+
+/// Subscribe to hold transitions — the CBAR affordance. A component that would
+/// only park at the adapter door can instead REACT: skip assembling work while
+/// held, resume on the release event. Watch semantics: the receiver always
+/// reads the latest state, so a transition can never be missed.
+pub fn subscribe() -> watch::Receiver<Option<HoldInfo>> {
+    cell().tx.subscribe()
 }
 
 /// The PURE decision — table-tested, no clock, no locks. `true` = this
@@ -249,6 +274,11 @@ async fn defer_in(
         held_by = %held_by,
         "background generation deferring — measured work holds the core"
     );
+    // PURE EVENT WAIT — no tick, no poll. `changed()` wakes exactly on state
+    // transitions and can never miss one (watch keeps the latest value); the
+    // predicate re-check after each wake handles a hold that transitioned to a
+    // DIFFERENT holder rather than to None. The only clock is the ceiling.
+    let mut rx = c.tx.subscribe();
     loop {
         if !should_defer(class, current_in(c).as_ref(), caller) {
             crate::probe!(
@@ -260,7 +290,8 @@ async fn defer_in(
             );
             return DeferOutcome::Resumed;
         }
-        if started.elapsed() >= ceiling {
+        let remaining = ceiling.saturating_sub(started.elapsed());
+        if remaining.is_zero() || tokio::time::timeout(remaining, rx.changed()).await.is_err() {
             crate::probe!(
                 class = "inference.hold.defer_ceiling",
                 traffic = %class.as_str(),
@@ -271,8 +302,6 @@ async fn defer_in(
             );
             return DeferOutcome::CeilingProceed;
         }
-        let remaining = ceiling.saturating_sub(started.elapsed()).min(DEFER_TICK);
-        let _ = tokio::time::timeout(remaining, c.notify.notified()).await;
     }
 }
 
@@ -301,7 +330,10 @@ mod tests {
         let h = hold_of(holder);
 
         for class in [SlotClass::Turn, SlotClass::Sidecar] {
-            assert!(!should_defer(class, Some(&h), Some(other)), "{class:?} never waits");
+            assert!(
+                !should_defer(class, Some(&h), Some(other)),
+                "{class:?} never waits"
+            );
             assert!(!should_defer(class, None, Some(other)));
         }
         for class in [SlotClass::Background, SlotClass::Probe] {

--- a/core/continuum-core/src/inference/mod.rs
+++ b/core/continuum-core/src/inference/mod.rs
@@ -48,6 +48,7 @@ pub mod lane_process;
 pub mod lane_registry;
 pub mod llama_server;
 pub mod llamacpp_adapter;
+pub mod measured_hold;
 pub mod slots;
 pub mod llm_module;
 pub mod llm_module_bus;


### PR DESCRIPTION
Restore-economy **Phase 1.a** (plan: `restore-economy-fourteen-personas-one-core.md`). Fixes the measured cause of the 0.29 KV hit rate.

## The defect

`agent/solve` quiesces the other citizens' **service loops** (verified `quiesced_peers=3`) — and the GPU still spent ~half its generations on `dream-belief-review` (**52 of 109** `inference.prefill.complete` rows) *during* a measured solve. Dreams never run in the loops the lease gates; they spawn their own tasks and walked straight past the quiesce onto the one serving slot, evicting the solve's warm KV every time. At **~32.9s re-prefill vs ~0.1s restore (~330×, measured)**, the bypass didn't slow the solve — it halved the machine.

## One seam, not whack-a-mole

Gating each background producer means the next `tokio::spawn` forgets. The adapter is where every generation already crosses with its `purpose` in hand — the hold is consulted there and nowhere else. Producers never learn it exists.

## The RTOS audit (the "too-FIFO / blocking cognition" hazard, explicitly)

- Deferral sits **after classification, before the concurrency permit** — a parked request holds *nothing*: no lock, no decode permit, just its own task on a notify. Parking after the permit would be priority inversion (a sleeping dream holding the only decode slot while a real turn queues behind it).
- **No lock across an await** — the state mutex is sync-scoped.
- **Turn and Sidecar never enter the await path.** A human talking to a citizen outranks a measurement; blocking the measured drive's own traffic would deadlock it. The holder's own Background rides through.
- **Broadcast wake, never FIFO** — deferred work re-races admission at release instead of draining serially.
- **Bounded**: a 4h ceiling proceeds loudly (`inference.hold.defer_ceiling`) — a lease-leak *detector*, never a silent forever-park.

RAII with a generation counter: a stale lease's late drop cannot release a newer hold (that would silently re-open the dream-clobber).

## TDD

The defer table, the stale-drop hazard, and both ends of the bounded wait (wake-on-release + ceiling-proceeds) — written first, via the injected-core pattern (`spill.rs` precedent) after the process-global singleton made the first parallel test run race itself.

## VDD receipt (at the boundary deploy)

Zero Background-class `inference.prefill.complete` rows during a hold, and the solve's `delib.generate.cache` hit rate vs tonight's 0.29 baseline. Probes: `inference.hold.{acquired,released,replaced,deferred,resumed,defer_ceiling}`.

3 measured_hold + 19 solve + 36 slots/adapter tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
