### PR TITLE
feat(serving): wire the derived prompt cache to the spawn path — one derivation, two consumers (restore-economy 1.b)

### DIFF
--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -734,6 +734,9 @@ async fn spawn_gene_eval_lane(gene: &EvalGene) -> Result<EvalLane, CommandError>
     //    the per-request `lora` field decides per turn whether it actually pages in,
     //    which is exactly the base-vs-gene A/B below).
     let target = ServingTarget {
+        // Single-purpose lane: no citizen population to derive from — the
+        // declared cold-start prior is the honest value (restore-economy 1.b).
+        host_prompt_cache_mib: crate::inference::lane_args::CACHE_RAM_MIB,
         model: base.clone(),
         context_window: lane_ctx,
         lanes: 1,
@@ -867,6 +870,9 @@ async fn build_base_eval_lane_inner(base_id: &str) -> Result<EvalLaneInner, Comm
     let (placement_evidence, vram_lease) =
         decide_eval_lane_placement(&base, lane_ctx, &format!("eval-lane base:{base_id}"));
     let target = ServingTarget {
+        // Single-purpose lane: no citizen population to derive from — the
+        // declared cold-start prior is the honest value (restore-economy 1.b).
+        host_prompt_cache_mib: crate::inference::lane_args::CACHE_RAM_MIB,
         model: base.clone(),
         context_window: lane_ctx,
         lanes: 1,

--- a/core/continuum-core/src/inference/lane_args.rs
+++ b/core/continuum-core/src/inference/lane_args.rs
@@ -125,6 +125,13 @@ impl LaneInvocation {
 /// geometry, and the governor accounts this exact number as a term of the
 /// host-cache lease (`serving_daemon::moe_host_cache_lease_inputs`), so the
 /// expert cache can never be sized as if this RAM were free.
+/// COLD-START PRIOR only (restore-economy 1.b): the value a lane gets when no
+/// citizen demand has ever been measured (fresh install, or a single-purpose
+/// eval/vision lane). Every steady-state serve derives the real number via
+/// [`host_prompt_cache_mib`] from per-citizen measured demand — this constant
+/// is a declared prior with provenance, the same pattern as
+/// `ServingDemand`'s bootstrap ("cold start is a real state, not a missing
+/// measurement"), never the sizing decision itself.
 pub const CACHE_RAM_MIB: u32 = 4096;
 
 /// The absolute floor in MiB — not a sizing decision, just a refusal to pass
@@ -208,6 +215,7 @@ pub fn base_invocation(
     port: u16,
     lanes: u32,
     total_ctx: u32,
+    cache_ram_mib: u32,
 ) -> LaneInvocation {
     let arg = |s: &str| s.to_string();
     LaneInvocation {
@@ -255,7 +263,7 @@ pub fn base_invocation(
             // The governed host-RAM prompt cache — see [`CACHE_RAM_MIB`]. Explicit
             // so llama.cpp's 8 GiB default can never run un-owned again (§4).
             arg("--cache-ram"),
-            CACHE_RAM_MIB.to_string(),
+            cache_ram_mib.to_string(),
             // PREFILL THROUGHPUT (#139). Live personas are prefill-bound: a real turn
             // re-prefills ~4k tokens of fresh RAG context at ~109 tok/s → 30-110s turns
             // (decode is tiny and fast; the mind is NOT slow, the re-read is). The
@@ -551,6 +559,7 @@ mod tests {
             58057,
             lanes,
             total_ctx,
+            CACHE_RAM_MIB, // the cold-start prior — these tests pin arg shape, not sizing
         )
     }
 

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -478,6 +478,14 @@ const THINKING_SMOKE_BUDGET: u64 = 768;
 pub struct ServingTarget {
     /// The chosen base model — the grouped model info, resolved once.
     pub model: Model,
+    /// The host-RAM prompt cache (`--cache-ram`, MiB) DERIVED for this serve —
+    /// per-citizen measured demand × the model's own kv/token, clamped by what
+    /// the host affords after the resident working set (restore-economy 1.b).
+    /// Computed ONCE at target construction; the governor's host-cache lease
+    /// reads the SAME number, so the expert cache can never be sized as if
+    /// this RAM were free. Single-purpose lanes (eval, vision sidecar) pass
+    /// the declared cold-start prior.
+    pub host_prompt_cache_mib: u32,
     /// The host-fit served window the planner computed for this host — the
     /// PER-LANE window. Sized to fit the working set (tool schemas + framing +
     /// room burst + recalled memory + completion reserve) within the budget,
@@ -2797,6 +2805,7 @@ impl LlamaServerControl for LlamaServerProcess {
             port,
             lanes,
             total_ctx,
+            target.host_prompt_cache_mib,
         )
         .with_options(&crate::inference::lane_args::LaneOptions {
             kv_cache_type: kv_cache_type.as_deref(),
@@ -3664,6 +3673,7 @@ mod tests {
     fn target(id: &str) -> ServingTarget {
         use crate::model_registry::types::{Arch, MultiPartyChatStrategy};
         ServingTarget {
+            host_prompt_cache_mib: crate::inference::lane_args::CACHE_RAM_MIB,
             model: Model {
                 weights_bytes: None,
                 mmproj_bytes: None,

--- a/core/continuum-core/src/inference/vision_sidecar.rs
+++ b/core/continuum-core/src/inference/vision_sidecar.rs
@@ -239,6 +239,9 @@ pub async fn ensure_sidecar(
     }
 
     let target = ServingTarget {
+        // Single-purpose lane: no citizen population to derive from — the
+        // declared cold-start prior is the honest value (restore-economy 1.b).
+        host_prompt_cache_mib: crate::inference::lane_args::CACHE_RAM_MIB,
         model: cand.model.clone(),
         context_window: SIDECAR_CTX,
         lanes: 1,

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -419,6 +419,10 @@ pub struct ServingDaemonModule {
     /// for which tier the RUNNING serve actually loaded. Division rewards credit this
     /// tier, never the bandit's latest (unlaunched) choice — two-speed honesty.
     served_resident: std::sync::Mutex<Option<std::path::PathBuf>>,
+    /// The prompt-cache MiB the CURRENT serve derived and passed to its lane —
+    /// stashed so the governor-tick host-cache lease accounts the SAME number
+    /// (one derivation, two consumers; the compression contract of 1.b).
+    served_prompt_cache_mib: std::sync::Mutex<u32>,
     /// MEASUREMENT-ONLY, off by default: an explicit forced VRAM budget for K3 expert
     /// placement, read ONCE at construction from `K3_MEASURE_FORCE_EXPERT_BUDGET_BYTES`. When
     /// `Some`, it OVERRIDES the governed ceiling so a model that would otherwise fit is driven
@@ -629,6 +633,9 @@ impl ServingDaemonModule {
             moe_trace_tail: std::sync::Mutex::new(None),
             division: std::sync::Mutex::new(None),
             served_resident: std::sync::Mutex::new(None),
+            served_prompt_cache_mib: std::sync::Mutex::new(
+                crate::inference::lane_args::CACHE_RAM_MIB,
+            ),
             host_cache_lease: std::sync::Mutex::new(
                 crate::capacity::host_cache_lease::StickyLease::new(HOST_CACHE_LEASE_BAND_DIVISOR),
             ),
@@ -1364,6 +1371,10 @@ impl ServingDaemonModule {
             live.lanes,
             physical,
             system_commit_charge_bytes(),
+            self.served_prompt_cache_mib
+                .lock()
+                .map(|g| *g)
+                .unwrap_or(crate::inference::lane_args::CACHE_RAM_MIB),
         ) else {
             return;
         };
@@ -2038,7 +2049,25 @@ impl ServingDaemonModule {
         // touches it — the NvmeServingTierPool must never migrate the GGUF the
         // engine is loading or serving. Model change swaps the registration.
         self.set_active_artifact(model.gguf_local_path.clone());
+        // RESTORE-ECONOMY 1.b: derive the host prompt cache HERE, where footprint,
+        // physical memory and the citizen population are all in hand — computed
+        // once per serve, carried on the target so the lane's `--cache-ram` and
+        // the governor's host-cache lease read the SAME number (never the old
+        // constant the lease had to work around). Spawn-time snapshot only:
+        // the value changes at relaunch boundaries, never mid-serve, so there
+        // is zero flap surface (Law 2 — capacity follows measurement, structure
+        // does not).
+        let host_prompt_cache_mib = derived_prompt_cache_mib(
+            footprint_for(&model).as_ref(),
+            served_ctx,
+            lanes,
+            self.system.memory().total_bytes,
+        );
+        if let Ok(mut g) = self.served_prompt_cache_mib.lock() {
+            *g = host_prompt_cache_mib;
+        }
         let target = ServingTarget {
+            host_prompt_cache_mib,
             model,
             context_window: served_ctx,
             lanes,
@@ -3264,6 +3293,52 @@ fn serving_footprint_fn(catalog: Arc<ModelCatalog>) -> FootprintFn {
 /// derive from measured non-serving usage once mmap attribution is solved — the
 /// free-memory monitor can't be used here because mmap'd weight pages report
 /// "available" while load-bearing (see host_cache_lease module doc).
+/// The derived `--cache-ram` for a persona-population serve (restore-economy
+/// 1.b): per-citizen MEASURED demand (WorkingSetRegistry, persisted across
+/// restarts) × the model's own kv/token, clamped by what the host affords
+/// after the serve's peak resident working set and the OS floor.
+///
+/// Cold start (no demand ever measured — fresh install) and a missing
+/// footprint both return the declared prior [`lane_args::CACHE_RAM_MIB`]:
+/// "cold start is a real state, not a missing measurement". The clamp means
+/// this can only ever hand the lane RAM the resident plan was not using —
+/// never RAM the weights, live KV or OS needed.
+fn derived_prompt_cache_mib(
+    fp: Option<&crate::cognition::serving_plan::ModelFootprint>,
+    served_ctx: u32,
+    lanes: u32,
+    physical_bytes: u64,
+) -> u32 {
+    let Some(fp) = fp else {
+        return crate::inference::lane_args::CACHE_RAM_MIB;
+    };
+    let demands: Vec<u32> = crate::cognition::working_set::global()
+        .all()
+        .into_iter()
+        .map(|(_, d)| d.peak_tokens)
+        .collect();
+    if demands.is_empty() || physical_bytes == 0 {
+        return crate::inference::lane_args::CACHE_RAM_MIB;
+    }
+    let afford = physical_bytes
+        .saturating_sub(fp.peak_resident_bytes(served_ctx, lanes))
+        .saturating_sub(host_os_floor_bytes(physical_bytes));
+    let derived = crate::inference::lane_args::host_prompt_cache_mib(
+        &demands,
+        fp.kv_per_token,
+        afford,
+    );
+    crate::probe!(
+        class = "serving.prompt_cache.derived",
+        citizens = demands.len() as u64,
+        derived_mib = derived as u64,
+        afford_mib = (afford / (1024 * 1024)) as u64,
+        "host prompt cache sized from per-citizen measured demand — the lane and \
+         the host-cache lease read this SAME number"
+    );
+    derived
+}
+
 fn host_os_floor_bytes(physical_bytes: u64) -> u64 {
     (physical_bytes / 8).max(2 * 1024 * 1024 * 1024)
 }
@@ -3323,6 +3398,7 @@ fn moe_host_cache_lease_inputs(
     lanes: u32,
     physical_bytes: u64,
     commit_charge_bytes: Option<u64>,
+    prompt_cache_mib: u32,
 ) -> Option<crate::capacity::host_cache_lease::HostCacheLeaseInputs> {
     let weights_host_bytes = file_weights_bytes.saturating_sub(expert_bytes_total);
     let fp = footprint_from_parts(model_id, weights_host_bytes, model_context_window, false)?;
@@ -3336,9 +3412,10 @@ fn moe_host_cache_lease_inputs(
         // expert-cache lease can never be derived as if that RAM were free.
         compute_buffer_bytes: fp
             .prefill_compute_reserve(served_window, lanes)
-            .saturating_add(
-                (crate::inference::lane_args::CACHE_RAM_MIB as u64) * 1024 * 1024,
-            ),
+            // The DERIVED prompt cache of the current serve — the same number the
+            // lane's --cache-ram carries (restore-economy 1.b), never a constant
+            // the lease has to work around.
+            .saturating_add((prompt_cache_mib as u64) * 1024 * 1024),
         os_floor_bytes: host_os_floor_bytes(physical_bytes),
         commit_charge_bytes,
     })
@@ -3905,7 +3982,7 @@ mod tests {
         let experts = 640 * GB;
         let physical = 63 * GB;
         let inputs =
-            moe_host_cache_lease_inputs("k3", file, experts, 262_144, 4096, 2, physical, None)
+            moe_host_cache_lease_inputs("k3", file, experts, 262_144, 4096, 2, physical, None, 4096)
                 .expect("host share is real");
         assert_eq!(
             inputs.weights_host_bytes,
@@ -3932,7 +4009,7 @@ mod tests {
         // lease saturates to zero and the cache is permanently off. The subtraction
         // is load-bearing, not cosmetic.
         let blind =
-            moe_host_cache_lease_inputs("k3", file, 0, 262_144, 4096, 2, physical, None).unwrap();
+            moe_host_cache_lease_inputs("k3", file, 0, 262_144, 4096, 2, physical, None, 4096).unwrap();
         assert_eq!(
             crate::capacity::host_cache_lease::host_cache_lease_bytes(&blind),
             0,
@@ -3941,7 +4018,7 @@ mod tests {
 
         // Degenerate all-expert read → no honest host footprint → publish nothing.
         assert!(
-            moe_host_cache_lease_inputs("k3", file, file, 262_144, 4096, 2, physical, None)
+            moe_host_cache_lease_inputs("k3", file, file, 262_144, 4096, 2, physical, None, 4096)
                 .is_none()
         );
     }


### PR DESCRIPTION
Restore-economy **Phase 1.b** — the derivation from #2542, wired to the spawn path. With #2544 (measured hold) already merged, this completes Phase 1's code; what remains is the boundary deploy and the receipt.

## One derivation, two consumers

The daemon computes `host_prompt_cache_mib` **once** at target construction — where footprint, physical memory, and the citizen population are all in hand — and the value flows to both readers:

- the lane's `--cache-ram` (`base_invocation` gains the primitive param and stays pure), and
- the governor's host-cache lease, whose constant term is replaced by the stashed served value — so the expert cache can never again be sized as if this RAM were free.

## Flap-safety (Law 2)

Spawn-time snapshot only: the value changes at relaunch boundaries, never mid-serve. Capacity follows measurement; structure never couples to a moving signal.

## Cold start, honestly

No demand ever measured (fresh install) or a missing footprint returns `CACHE_RAM_MIB` — retitled as the **declared cold-start prior** it always actually was, never the sizing decision. Single-purpose lanes (eval, vision sidecar) pass the prior explicitly: there is no citizen population to derive from. The clamp can only hand the lane RAM the resident plan wasn't using: `afford = physical − peak_resident(window, lanes) − os_floor`.

## VDD receipt (at the boundary deploy)

- `serving.prompt_cache.derived` probe: citizens, derived_mib, afford_mib
- the spawned invocation's `--cache-ram` ≈ Σ(citizen demand × kv/token)
- 4-citizen interleave `delib.generate.cache` hit rate vs the **0.29 baseline** (banked from 2026-08-28 logs)

Then the Thrash Gauntlet (plan: `restore-economy-fourteen-personas-one-core.md`) is the phase's proof: aggregate tokens/sec across 4 minds ≥ 80% of solo.

375 inference + 43 serving_daemon tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
