### PR TITLE
feat(catalog): Flash-Next registered with its measured serving contract

### DIFF
--- a/core/continuum-core/src/inference/lane_args.rs
+++ b/core/continuum-core/src/inference/lane_args.rs
@@ -352,6 +352,18 @@ pub struct LaneOptions<'a> {
     /// K3 expert paging (#278): `-ot` tensor placement for COLD layers, from the
     /// residency planner. `None` / all-hot → no flag (llama-server rejects an empty one).
     pub expert_ot: Option<&'a str>,
+    /// Catalog-declared host-pinned tensors (`ModelServingPrefs::host_pinned_tensors`)
+    /// — designed disk/host-resident lookup tables (Flash-Next's n-gram table).
+    /// Merged with `expert_ot` into ONE `--override-tensor` value: repeated flags
+    /// risk the same silent last-wins that collapsed `--lora` stacks above.
+    pub host_pinned_tensors: &'a [&'static str],
+    /// `-fit off` (`ModelServingPrefs::fit_off`) — default false = fit auto-sizing runs.
+    pub fit_off: bool,
+    /// `--no-warmup` (`ModelServingPrefs::no_warmup`) — default false = warmup runs.
+    pub no_warmup: bool,
+    /// Per-model `--ubatch-size` ceiling (`ModelServingPrefs::max_ubatch`) — only ever
+    /// LOWERS the base invocation's value, never raises it past the lane-sized default.
+    pub max_ubatch: Option<u32>,
 }
 
 impl LaneInvocation {
@@ -476,9 +488,34 @@ impl LaneInvocation {
         // to CPU while hot layers stay GPU-resident. Experts are stacked (one
         // blk.N.ffn_*_exps per layer), so `-ot` — which places WHOLE tensors — pages at
         // LAYER granularity. A change to the hot set is honored on the next relaunch (the
-        // pager decides when).
+        // pager decides when). Catalog host-pins (designed disk-resident lookup tables)
+        // join the SAME value — one flag, because repeated `--override-tensor` risks the
+        // silent last-wins that collapsed `--lora` stacks.
+        let mut ot_parts: Vec<String> = Vec::new();
         if let Some(ot) = opts.expert_ot {
-            pair(&mut self.args, "--override-tensor", ot);
+            ot_parts.push(ot.to_string());
+        }
+        for pat in opts.host_pinned_tensors {
+            ot_parts.push(format!("{pat}=CPU"));
+        }
+        if !ot_parts.is_empty() {
+            pair(&mut self.args, "--override-tensor", ot_parts.join(","));
+        }
+        // Per-model serving prefs (catalog-declared, measured — see ModelServingPrefs).
+        if opts.fit_off {
+            pair(&mut self.args, "-fit", "off");
+        }
+        if opts.no_warmup {
+            self.args.push("--no-warmup".to_string());
+        }
+        if let Some(cap) = opts.max_ubatch {
+            if let Some(i) = self.args.iter().position(|a| a == "--ubatch-size") {
+                if let Some(v) = self.args.get(i + 1).and_then(|s| s.parse::<u32>().ok()) {
+                    if cap < v {
+                        self.args[i + 1] = cap.to_string();
+                    }
+                }
+            }
         }
         if let Some(ov) = opts.resident_override {
             self.envs
@@ -695,5 +732,39 @@ mod tests {
         let i = inv(1, 4096).with_options(&LaneOptions { kv_cache_type: Some("q8_0"), ..Default::default() });
         assert_eq!(i.value_of("--cache-type-k"), Some("q8_0"));
         assert_eq!(i.value_of("--cache-type-v"), Some("q8_0"));
+    }
+
+    // what this catches: the Flash-Next serving contract (measured 2026-08-28, the
+    // first local serve). Three failure shapes, each hit live that night: (1) host
+    // pins emitted as a SECOND --override-tensor beside the expert pager's — llama's
+    // repeated-flag parsing risks last-wins (the --lora collapse shape), so both
+    // MUST merge into one comma-joined value; (2) fit/warmup flags silently absent →
+    // instant Metal OOM (fit counts the 35.8 GB pinned table as loadable) / a 36 GB
+    // warmup fault-in; (3) max_ubatch RAISING the lane default instead of only
+    // capping it (the default is sized to the resident lane's compute headroom).
+    #[test]
+    fn host_pins_merge_into_one_override_and_prefs_flags_land() {
+        let i = inv(1, 4096).with_options(&LaneOptions {
+            expert_ot: Some(r"blk\.(3|7)\.ffn.*_exps=CPU"),
+            host_pinned_tensors: &["per_layer_token_embd.*"],
+            fit_off: true,
+            no_warmup: true,
+            max_ubatch: Some(512),
+            ..Default::default()
+        });
+        // ONE --override-tensor, comma-joined, pager first then pins.
+        assert_eq!(i.args.iter().filter(|a| *a == "--override-tensor").count(), 1);
+        assert_eq!(
+            i.value_of("--override-tensor"),
+            Some(r"blk\.(3|7)\.ffn.*_exps=CPU,per_layer_token_embd.*=CPU")
+        );
+        assert_eq!(i.value_of("-fit"), Some("off"));
+        assert!(i.args.iter().any(|a| a == "--no-warmup"));
+        assert_eq!(i.value_of("--ubatch-size"), Some("512"));
+
+        // The cap only lowers: a ceiling above the lane default leaves it alone.
+        let j = inv(1, 4096)
+            .with_options(&LaneOptions { max_ubatch: Some(1 << 20), ..Default::default() });
+        assert_eq!(j.value_of("--ubatch-size"), Some("2048"));
     }
 }

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -2826,6 +2826,10 @@ impl LlamaServerControl for LlamaServerProcess {
             chat_template: chat_template.as_deref(),
             loras: &lora_paths,
             expert_ot: expert_ot.as_deref(),
+            host_pinned_tensors: target.model.serving.host_pinned_tensors,
+            fit_off: target.model.serving.fit_off,
+            no_warmup: target.model.serving.no_warmup,
+            max_ubatch: target.model.serving.max_ubatch,
         });
         for a in &invocation.args {
             cmd.arg(a);

--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -637,6 +637,60 @@ pub fn models() -> Vec<Model> {
             serving: ModelServingPrefs {
                 mmproj_on_main_lane: false,
                 kv_shiftable: Some(false),
+                ..ModelServingPrefs::default()
+            },
+            ..ModelSpec::default()
+        }),
+        // Qwen3.8-Flash-Next — the M64 disk-resident-n-gram drop (qwen4exp arch,
+        // GDN+QSA hybrid, 512-expert MoE, 6B active). EXCLUSIVE/EXPERIMENTAL brain,
+        // NOT the citizen lane: the pre-registered comparison protocol's depth bar
+        // failed decisively (docs/planning/FLASHNEXT-VS-ORNITH-COMPARISON-PROTOCOL.md
+        // rule 2 — measured 2026-08-28 on the union engine 920eef087, idle box:
+        // decode 16.6-17.5 t/s @31k depth vs Ornith 40.1-40.3; prefill 160 vs 510).
+        // Serving REQUIRES the prefs below, each measured the hard way the same night:
+        // the 35.8 GB `per_layer_token_embd` n-gram table (shard 00002, ONE tensor)
+        // host-pinned or Metal OOMs instantly; warmup skipped or load faults the
+        // whole table into RAM; fit off (its heuristics count the pinned table);
+        // ubatch 512 verified. Re-measure when the expert-pager arc deepens the
+        // hierarchy — the verdict is the hierarchy's, not the model's
+        // [[everything-pages-the-grid-is-one-more-tier]].
+        model(ModelSpec {
+            id: "AtomicChat/Qwen3.8-Flash-Next-GGUF",
+            name: "Qwen3.8-Flash-Next (experimental: disk-resident n-gram MoE)",
+            provider: "llama-server",
+            // ChatML family (Qwen lineage) for template/stop semantics; the true
+            // qwen4exp arch lives in the GGUF and the engine, not this hint.
+            arch: Arch::Qwen35,
+            // VERIFIED serving geometry 2026-08-28 (c=32768, zero OOMs). The model
+            // advertises more; raise only with a measured load at the larger window.
+            context_window: 32_768,
+            max_output_tokens: 8_192,
+            // Short-prompt decode, warm, idle box, union engine (23.2/23.8 t/s runs).
+            // Depth is worse (16.6-17.5 @31k) — see the protocol doc before quoting.
+            tokens_per_second: 23.5,
+            capabilities: &[
+                Capability::TextGeneration,
+                Capability::Chat,
+                Capability::Streaming,
+                // ToolUse deliberately ABSENT: the tool-shape parse receipt
+                // (protocol Phase-0 §2.2) has not run. Claims are receipts.
+            ],
+            gguf_hint: Some("huggingface.co/AtomicChat/Qwen3.8-Flash-Next-GGUF"),
+            gguf_local_path: Some(
+                "~/.continuum/models/qwen38-flash-next/Qwen3.8-Flash-Next-AD-3.84bpw-IQ4_XS-M64/Qwen3.8-Flash-Next-AD-3.84bpw-IQ4_XS-M64-00001-of-00028.gguf",
+            ),
+            hf_source: Some("AtomicChat/Qwen3.8-Flash-Next"),
+            chat_template: None,
+            multi_party_strategy: MultiPartyChatStrategy::ProperChatMlSingleParty,
+            stop_sequences: &["<|im_end|>"],
+            serving: ModelServingPrefs {
+                mmproj_on_main_lane: false,
+                // Hybrid GDN/QSA attention — shift capability unverified on this arch.
+                kv_shiftable: None,
+                host_pinned_tensors: &["per_layer_token_embd.*"],
+                fit_off: true,
+                no_warmup: true,
+                max_ubatch: Some(512),
             },
             ..ModelSpec::default()
         }),

--- a/core/continuum-core/src/model_registry/types.rs
+++ b/core/continuum-core/src/model_registry/types.rs
@@ -366,6 +366,32 @@ pub struct ModelServingPrefs {
     /// context"): prompt shaping must then treat the prefix as EXTEND-ONLY,
     /// because any interior mutation re-prefills everything after it.
     pub kv_shiftable: Option<bool>,
+    /// Tensor-name patterns pinned to HOST memory (`--override-tensor "<pat>=CPU"`),
+    /// for models whose lookup tables are DESIGNED disk/host-resident. Embedding
+    /// gathers are memory reads, not matmul — inference stays GPU-only while the
+    /// table pages from SSD via mmap. (Flash-Next: `per_layer_token_embd`, a
+    /// single 35.8 GB n-gram table that CANNOT be Metal-resident beside 43 GB of
+    /// compute weights on a 64 GB machine — measured 2026-08-28, zero OOMs with
+    /// the pin vs instant kIOGPUCommandBufferCallbackErrorOutOfMemory without.)
+    /// Serde-skipped: consumed in-process at spawn from the catalog row; the
+    /// wire echo of prefs never drives a spawn.
+    #[serde(skip)]
+    pub host_pinned_tensors: &'static [&'static str],
+    /// Disable llama-server's `-fit` auto-sizing (default false = fit runs).
+    /// Models with host-pinned tensors opt OUT: fit's device-memory heuristics
+    /// count the pinned table as loadable and mis-size everything downstream.
+    #[serde(default)]
+    pub fit_off: bool,
+    /// Skip the load-time warmup pass (default false = warmup runs). True for
+    /// models whose warmup would fault a designed-cold tensor set fully into
+    /// RAM (Flash-Next: warmup walks the 35.8 GB table the pin exists to keep cold).
+    #[serde(default)]
+    pub no_warmup: bool,
+    /// Per-model ceiling on `--ubatch-size` (`None` = the lane default stands).
+    /// The lane default is sized for the resident coder lane's compute buffer;
+    /// a bigger-geometry model can need less (Flash-Next verified at 512).
+    #[serde(default)]
+    pub max_ubatch: Option<u32>,
 }
 
 impl Default for ModelServingPrefs {
@@ -373,6 +399,10 @@ impl Default for ModelServingPrefs {
         Self {
             mmproj_on_main_lane: false,
             kv_shiftable: None,
+            host_pinned_tensors: &[],
+            fit_off: false,
+            no_warmup: false,
+            max_ubatch: None,
         }
     }
 }


### PR DESCRIPTION
feat(catalog): register Qwen3.8-Flash-Next with its measured serving contract — per-model prefs, not blanket policy

Flash-Next served locally for the first time 2026-08-28 (union engine
920eef087). This encodes what that session measured as CATALOG TRUTH so a
lane can spawn it on demand:

- ModelServingPrefs gains host_pinned_tensors / fit_off / no_warmup /
  max_ubatch — typed prefs on the existing seam, per the standing rule
  ("anything a lane decision branches on lives as model truth, never a
  blanket policy").
- Host pins merge with the K3 expert-pager's -ot into ONE
  --override-tensor value (repeated flags risk the --lora last-wins
  collapse). max_ubatch only lowers the lane default, never raises.
- Flash-Next row: 35.8 GB per_layer_token_embd pinned to host (designed
  disk-resident; instant Metal OOM without), fit off, no warmup, ubatch
  512, context 32768 as VERIFIED geometry, ToolUse deliberately absent
  until the parse receipt runs (claims are receipts). Marked
  experimental/exclusive per the pre-registered comparison protocol's
  depth verdict (17 vs 40 t/s at 31k).

Test: host_pins_merge_into_one_override_and_prefs_flags_land (the three
live failure shapes from the first-serve night).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo