### PR TITLE
feat(team): solve-room teammates + one-pair-of-hands solve serialization

### DIFF
--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -145,12 +145,21 @@ pub struct BenchRound {
     card_assignees: HashMap<Uuid, Uuid>,
 }
 
-/// Where one card's solve LIVES: its per-instance activity room and the citizen
-/// working it. Typed UUIDs, passed as a struct (Joel: "pass structs").
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+/// Where one card's solve LIVES: its per-instance activity room, the citizen
+/// working it, and — for TEAM solves (#team-proof gap 1) — the teammates joined
+/// to that room. Typed UUIDs, passed as a struct (Joel: "pass structs").
+/// Membership is ROOM-level (teammates join and participate through normal
+/// multi-room cognition); accountability stays CARD-level (one claimer, one
+/// terminal transition) — no multi-claim machinery.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CardActivity {
     pub solve_room: Uuid,
     pub assignee: Uuid,
+    /// Room-members beyond the claimer. Recorded so a resume re-invites the
+    /// SAME team (continuity), and so experience records can attribute team
+    /// outcomes (the protocol's gap 3 reads this).
+    #[serde(default)]
+    pub teammates: Vec<Uuid>,
 }
 
 impl BenchRound {
@@ -464,7 +473,7 @@ pub fn card_activity(card_id: Uuid) -> Option<CardActivity> {
     rounds
         .values()
         .find(|r| r.cards.contains_key(&card_id))
-        .and_then(|r| r.card_activities.get(&card_id).copied())
+        .and_then(|r| r.card_activities.get(&card_id).cloned())
 }
 
 /// Record (idempotently) the activity `card_id`'s solve runs in — called at the
@@ -878,15 +887,17 @@ mod tests {
         let (id, cs) = (Uuid::new_v4(), cards(2));
         let mut round = BenchRound::new(id, "swe-bench-verified", &cs, WorkDriver::DetachedSolve);
         let act = CardActivity {
+            teammates: Vec::new(), // test row: solo
+
             solve_room: Uuid::from_u128(0xA11CE),
             assignee: Uuid::from_u128(0xBEE),
         };
-        round.card_activities.insert(cs[0], act);
+        round.card_activities.insert(cs[0], act.clone()); // clone: the assert below compares against the original
         persist_round_in(&dir, &round);
 
         let reloaded = load_rounds_in(&dir);
         let r = reloaded.get(&id).expect("round reloads");
-        let got = r.card_activities.get(&cs[0]).copied().expect("activity survives");
+        let got = r.card_activities.get(&cs[0]).cloned().expect("activity survives");
         assert_eq!(got.solve_room, act.solve_room, "rejoin returns the SAME room");
         assert_eq!(got.assignee, act.assignee);
         assert!(r.card_activities.get(&cs[1]).is_none(), "unminted card has no activity yet");

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -1032,6 +1032,7 @@ async fn advance_round_after_non_settling(run_id: &str) {
             claimer: crate::identity::PeerId::from_uuid(next.assignee),
             card: airc_work::WorkCardId::from_uuid(next.card),
             room: airc_core::RoomId::from_u128(next.run_room.as_u128()),
+            teammates: Vec::new(), // solo default; team threading lands per-caller
         },
     )
     .await;

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -688,6 +688,12 @@ pub struct BenchmarkDispatchParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional, type = "Record<string, string>")]
     pub params: Option<std::collections::BTreeMap<String, String>>,
+    /// TEAM solve: citizen display names joined to every dispatched card's
+    /// solve room beside its claimer, each charged to cross-review before
+    /// submit (#team-proof gap 1). Recipe entries may override per dispatch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub teammates: Option<Vec<String>>,
     /// How many tasks (from the top) to post as cards. Omit for all.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
@@ -1040,6 +1046,11 @@ pub struct RecipeDispatch {
     /// Optional per-dispatch card cap.
     #[serde(default)]
     pub limit: Option<u32>,
+    /// TEAM solve (#team-proof gap 1): citizens joined to each card's solve
+    /// room beside the claimer, carrying the cross-review charge. Names, like
+    /// `assignees`; non-resident names are skipped with a probe.
+    #[serde(default)]
+    pub teammates: Vec<String>,
 }
 
 /// Resolve the citizens a directed dispatch addresses — GENERALIZED for any repo user's
@@ -1383,6 +1394,11 @@ impl ActionCommand for BenchmarkDispatch {
                 let sub = BenchmarkDispatchParams {
                     name: Some(d.benchmark.clone()),
                     recipe: None,
+                    teammates: if d.teammates.is_empty() {
+                        p.teammates.clone()
+                    } else {
+                        Some(d.teammates.clone())
+                    },
                     instances: if d.instances.is_empty() {
                         None
                     } else {
@@ -1677,6 +1693,30 @@ impl ActionCommand for BenchmarkDispatch {
         // fixing ("old rooms flooded, or ones with nothing").
         let roster =
             resolve_dispatch_roster(&resident, &self.registry.roster_snapshot(), &requested)?;
+        // TEAM roster (#team-proof gap 1): resolved against the SAME resident
+        // snapshot, but LENIENTLY — a non-resident teammate shrinks the team
+        // (probed), it never refuses the dispatch the way a bad assignee does:
+        // the claimer's solve is the accountable unit, the team is the amplifier.
+        let teammates: Vec<crate::identity::PeerId> = p
+            .teammates
+            .clone()
+            .unwrap_or_default() // unwrap_or: no teammates named = solo dispatch, the default
+            .iter()
+            .filter_map(|name| {
+                let hit = resident
+                    .iter()
+                    .find(|(n, _)| n.eq_ignore_ascii_case(name))
+                    .map(|(_, id)| crate::identity::PeerId::from_uuid(*id));
+                if hit.is_none() {
+                    crate::probe!(
+                        class = "benchmark.team.mate_not_resident",
+                        mate = %name,
+                        "named teammate not resident — team shrinks, dispatch proceeds"
+                    );
+                }
+                hit
+            })
+            .collect();
 
         // Repo hint, read from the board the curator is standing in RIGHT NOW — before we
         // move her, and ONLY when the caller named no repo. The run room is fresh, so its
@@ -2278,6 +2318,11 @@ impl ActionCommand for BenchmarkDispatch {
                             // roster itself is that card's work, not a silent widening here.
                             claimer: crate::identity::PeerId::from_uuid(*who_peer),
                             card: card_id,
+                            teammates: teammates
+                                .iter()
+                                .filter(|m| m.as_uuid() != *who_peer) // the claimer is not her own teammate
+                                .cloned()
+                                .collect(),
                             room: room.room_id,
                         },
                     )

--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -238,6 +238,7 @@ fn on_card_state_changed(registry: &PersonaAircRuntimeRegistry, payload: &Value)
                         claimer: crate::identity::PeerId::from_uuid(next.assignee),
                         card: airc_work::WorkCardId::from_uuid(next.card),
                         room: airc_core::RoomId::from_u128(next.run_room.as_u128()),
+                        teammates: Vec::new(), // solo default; team threading lands per-caller
                     },
                 )
                 .await;

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -289,6 +289,10 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
                         claimer: crate::identity::PeerId::from_uuid(next.assignee),
                         card: airc_work::WorkCardId::from_uuid(next.card),
                         room: airc_core::RoomId::from_u128(next.run_room.as_u128()),
+                        // resume re-invites the SAME team the card recorded — continuity
+                        teammates: crate::cognition::bench_round::card_activity(next.card)
+                            .map(|a| a.teammates.iter().map(|u| crate::identity::PeerId::from_uuid(*u)).collect())
+                            .unwrap_or_default(), // unwrap_or: no recorded activity yet = solo re-fire
                     },
                 )
                 .await;

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -639,6 +639,7 @@ impl ActionCommand for WorkClaim {
                             claimer: caller.peer_id,
                             card: card_id,
                             room: room.channel,
+                            teammates: Vec::new(), // solo default; team threading lands per-caller
                         },
                     )
                     .await;
@@ -683,6 +684,36 @@ const SWE_CLAIM_ATTEMPTS: u32 = 3;
 /// ever saw the work. Making the field required moves that from a runtime shrug to an
 /// unrepresentable state: a caller that cannot name the activity cannot build the struct,
 /// so it must resolve one ([`room_holding_card`]) or report why it could not.
+/// One-per-persona solve lease — see the "ONE PAIR OF HANDS" note in
+/// [`dispatch_staged_swe_solve`]. RAII: dropping the lease (any exit path,
+/// panics included) frees the persona for the next solve.
+struct HandsLease(uuid::Uuid);
+
+fn busy_hands() -> &'static std::sync::Mutex<std::collections::HashSet<uuid::Uuid>> {
+    static BUSY: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<uuid::Uuid>>> =
+        std::sync::OnceLock::new();
+    BUSY.get_or_init(Default::default)
+}
+
+impl HandsLease {
+    fn try_take(persona: uuid::Uuid) -> Option<Self> {
+        let mut g = busy_hands().lock().expect("busy-hands lock never poisoned"); // expect: guards a HashSet op only
+        if g.insert(persona) {
+            Some(Self(persona))
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for HandsLease {
+    fn drop(&mut self) {
+        if let Ok(mut g) = busy_hands().lock() {
+            g.remove(&self.0);
+        }
+    }
+}
+
 pub(crate) struct StagedSolveDispatch {
     /// The citizen who does the work — her own airc identity.
     pub claimer: crate::identity::PeerId,
@@ -693,6 +724,11 @@ pub(crate) struct StagedSolveDispatch {
     /// solver executes radiates a receipt into it (#243), which is what makes the work
     /// visible where the work lives.
     pub room: airc_core::RoomId,
+    /// TEAM solves (#team-proof gap 1): citizens joined to the solve room
+    /// beside the claimer. Empty = solo (every existing caller). They are
+    /// INVITED members, not co-claimers — the C1 shape: presence + an
+    /// addressed charge to review, with the kanban terminal untouched.
+    pub teammates: Vec<crate::identity::PeerId>,
 }
 
 /// The #346 claim→solve dispatch. Fires a detached [`crate::commands::agent::solve::AgentSolve`]
@@ -808,7 +844,28 @@ pub(crate) async fn dispatch_staged_swe_solve(
         claimer,
         card: card_id,
         room,
+        teammates,
     } = dispatch;
+    // ONE PAIR OF HANDS (2026-08-29): a persona's ToolExecutor / file-engine
+    // re-root is PROCESS-GLOBAL (see root_acting_workspace / #312), so two
+    // concurrent solve forks of the SAME persona contend on the same hands —
+    // glass-boxed as ticks parked 25min before perception in exactly the rooms
+    // sharing a claimer, reaped by the tick deadline in a retry loop. A second
+    // solve for a busy persona is deferred to the round driver's next edge
+    // (retry machinery already exists), never run beside the first. This is a
+    // MIND fact wearing a mutex: one body, one workspace, one solve at a time.
+    let _hands = match HandsLease::try_take(claimer.as_uuid()) {
+        Some(lease) => lease,
+        None => {
+            crate::probe!(
+                class = "work.solve.hands_busy",
+                card_id = %card_id.as_uuid(),
+                claimer = %claimer,
+                "claimer already mid-solve — one pair of hands; deferred to the driver's next edge"
+            );
+            return;
+        }
+    };
     // Read the RUN ROOM's board — the dispatch HAS the room (StagedSolveDispatch
     // requires it), and boards are per-room. The previous read went through the
     // caller's GLOBAL paginated projection (work_board_complete), where a card
@@ -1065,10 +1122,11 @@ pub(crate) async fn dispatch_staged_swe_solve(
                         );
                     }
                     let act = crate::cognition::bench_round::CardActivity {
+                        teammates: teammates.iter().map(|p| p.as_uuid()).collect(),
                         solve_room: spawned.room_id.as_uuid(),
                         assignee: claimer.as_uuid(),
                     };
-                    crate::cognition::bench_round::record_card_activity(card_id.as_uuid(), act);
+                    crate::cognition::bench_round::record_card_activity(card_id.as_uuid(), act.clone()); // clone: probe below still reads the local
                     crate::probe!(
                         class = "work.solve.room_minted",
                         card_id = %short8(card_id.as_uuid()),
@@ -1096,6 +1154,66 @@ pub(crate) async fn dispatch_staged_swe_solve(
             }
         }
     };
+
+    // TEAM MEMBERSHIP (#team-proof gap 1): teammates JOIN the solve room and
+    // receive an addressed charge. Membership is room-level (their normal
+    // multi-room cognition participates from here on); accountability stays
+    // card-level with the single claimer. Join is idempotent; a failed join or
+    // invite is REPORTED and never blocks the solve (the claimer works either
+    // way — a smaller team is a degraded run, not a dead one).
+    if !teammates.is_empty() {
+        let team_room_name = format!("swe--{}--{}", instance, short8(card_id.as_uuid()));
+        for mate in &teammates {
+            let Some(rt) = crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global()
+                .and_then(|reg| reg.get(mate.as_uuid()))
+            else {
+                crate::probe!(
+                    class = "work.team.join_skipped",
+                    card_id = %short8(card_id.as_uuid()),
+                    mate = %short8(mate.as_uuid()),
+                    "teammate not resident — solve proceeds with a smaller team"
+                );
+                continue;
+            };
+            if let Err(e) = rt.join_room(&team_room_name).await {
+                crate::probe!(
+                    class = "work.team.join_failed",
+                    card_id = %short8(card_id.as_uuid()),
+                    mate = %short8(mate.as_uuid()),
+                    error = %e.to_string(),
+                    "teammate join failed — reported, never blocks the claimer"
+                );
+                continue;
+            }
+            let charge = format!(
+                "You are teamed with {} on `{}` in this room. Their patch must be                  reviewed by a teammate before it submits: read the diff when it                  lands, run what you can, and SPEAK your findings here — a miss a                  reviewer catches is the whole point of the team.",
+                short8(claimer.as_uuid()),
+                instance
+            );
+            match crate::persona::airc_citizen::publish_text_in_room(
+                rt.airc(),
+                solve_room,
+                &charge,
+            )
+            .await
+            {
+                Ok(_) => crate::probe!(
+                    class = "work.team.joined",
+                    card_id = %short8(card_id.as_uuid()),
+                    mate = %short8(mate.as_uuid()),
+                    room = %solve_room,
+                    "teammate joined the solve room and holds the review charge"
+                ),
+                Err(e) => crate::probe!(
+                    class = "work.team.invite_failed",
+                    card_id = %short8(card_id.as_uuid()),
+                    mate = %short8(mate.as_uuid()),
+                    error = %e.to_string(),
+                    "teammate joined but the charge did not send — reported"
+                ),
+            }
+        }
+    }
     // Her HANDS must resolve `python`/`pytest`/`pip` to THIS instance's venv, not the system
     // interpreter. Without this, `code/shell pytest` hits homebrew python3.14 (no pytest, no
     // repo), she loops `pip install pytest` into the wrong interpreter, and burns every action

--- a/protocol/typescript/benchmark/BenchmarkDispatchParams.ts
+++ b/protocol/typescript/benchmark/BenchmarkDispatchParams.ts
@@ -24,6 +24,12 @@ recipe?: string,
  */
 params?: Record<string, string>, 
 /**
+ * TEAM solve: citizen display names joined to every dispatched card's
+ * solve room beside its claimer, each charged to cross-review before
+ * submit (#team-proof gap 1). Recipe entries may override per dispatch.
+ */
+teammates?: Array<string>, 
+/**
  * How many tasks (from the top) to post as cards. Omit for all.
  */
 limit?: number, 


### PR DESCRIPTION
feat(team): teammates join the solve room with a review charge, and ONE PAIR OF HANDS serializes solves per persona

Team-proof gap 1 (TEAM-PROOF-PROTOCOL §4.1): membership is ROOM-level —
teammates resolve leniently against the resident roster, join the solve
room, and receive an addressed cross-review charge; accountability stays
CARD-level (single claimer, kanban terminal untouched). Recorded in
CardActivity so resume re-invites the SAME team. Recipe rows and dispatch
params both carry `teammates`.

ONE PAIR OF HANDS: a persona's ToolExecutor re-root is process-global
(#312), so two concurrent solve forks of one persona contend on the same
hands — glass-boxed as ticks parked 25min before perception in exactly
the rooms sharing a claimer, reaped by the tick deadline in a retry
loop. HandsLease (RAII) defers the second solve to the driver's next
edge. One body, one workspace, one solve at a time — a mind fact
wearing a mutex.
