### PR TITLE
fix(team): first-team-round fix pack — pre-claim room race, self-voiced charge, reviewers quiesced

### DIFF
--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -497,11 +497,15 @@ pub fn record_card_assignee(card_id: Uuid, assignee: Uuid) {
 }
 
 /// The next card the round owes a solve — passed as a struct (typed UUIDs).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct NextCard {
     pub card: Uuid,
     pub assignee: Uuid,
     pub run_room: Uuid,
+    /// The card's recorded team (empty = solo). Carried so every driver edge
+    /// re-fires the solve WITH its team — a re-dispatch that drops teammates
+    /// silently converts a team round into a solo round mid-flight.
+    pub teammates: Vec<Uuid>,
 }
 
 /// ONE driver decision, three edges (dispatch, card-settled, boot resume): given
@@ -611,6 +615,11 @@ fn first_unworked_excluding(
                 card: *c,
                 assignee: *a,
                 run_room: round.round_id,
+                teammates: round
+                    .card_activities
+                    .get(c)
+                    .map(|act| act.teammates.clone())
+                    .unwrap_or_default(), // unwrap_or: no recorded activity yet = solo card
             })
         })
 }

--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -178,6 +178,15 @@ pub struct AgentSolveParams {
     #[ts(optional)]
     #[ts(optional, type = "number")]
     pub attempts: Option<u32>,
+    /// Teammates on this solve (team-proof gap 3, 2026-08-30): peers who joined the
+    /// solve room to review. The measured-work quiesce lease excepts them alongside
+    /// the solver — the first team round proved a reviewer quiesced for the solve's
+    /// whole duration is structurally unable to review (Kira: 28 min, zero turns).
+    /// The lease's lane-demand override counts them too, so serving budgets a warm
+    /// slot per PARTICIPANT, not per resident.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[ts(optional, type = "Array<string>")]
+    pub teammates: Vec<Uuid>,
 }
 
 
@@ -1032,7 +1041,13 @@ async fn advance_round_after_non_settling(run_id: &str) {
             claimer: crate::identity::PeerId::from_uuid(next.assignee),
             card: airc_work::WorkCardId::from_uuid(next.card),
             room: airc_core::RoomId::from_u128(next.run_room.as_u128()),
-            teammates: Vec::new(), // solo default; team threading lands per-caller
+            // The card's RECORDED team rides every driver edge — dropping it here
+            // silently converted a team round into a solo round on re-dispatch.
+            teammates: next
+                .teammates
+                .iter()
+                .map(|t| crate::identity::PeerId::from_uuid(*t))
+                .collect(),
         },
     )
     .await;
@@ -1340,16 +1355,25 @@ impl AgentSolve {
             persona_uuid,
             run_id.as_deref().unwrap_or("agent-solve"),
         );
+        // PARTICIPANTS stay awake, not just the solver (team-proof gap 3): a
+        // teammate holding the review charge must be able to take turns DURING
+        // the solve — the first team round (2026-08-30) quiesced the reviewers
+        // and made review structurally impossible. The lease's demand override
+        // counts the whole except-set, so serving budgets one warm slot per
+        // participant.
+        let mut participants = vec![persona_uuid];
+        participants.extend(p.teammates.iter().copied());
         let _quiesce_lease =
             crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global().map(
                 |reg| {
-                    let lease = reg.quiesce_others(persona_uuid);
+                    let lease = reg.quiesce_others_than(&participants);
                     crate::probe!(
                         class = "benchmark.solve.phase",
                         run_id = %run_id.as_deref().unwrap_or("-"), // unwrap_or: probe label only, "-" marks an unnamed run
                         phase = "quiesce_others",
                         quiesced_peers = lease.count() as u64,
-                        "measured solve holds an exclusive warm slot — idle citizens quiesced so the KV prefix survives turn-to-turn"
+                        awake_participants = participants.len() as u64,
+                        "measured solve holds an exclusive warm slot — non-participants quiesced so the KV prefix survives turn-to-turn"
                     );
                     lease
                 },

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -2179,14 +2179,31 @@ impl ActionCommand for BenchmarkDispatch {
             if pre_claim_this {
                 match self.registry.get(*who_peer) {
                     Some(rt) => {
-                        match rt
+                        let ttl_ms = crate::modules::work::DEFAULT_CLAIM_TTL_MS;
+                        let mut attempt = rt
                             .airc()
-                            .claim_work_card(airc_lib::ClaimWorkCard {
+                            .claim_work_card(airc_lib::ClaimWorkCard { card_id, ttl_ms })
+                            .await;
+                        // Follow the card to its room, same as work/claim (#328).
+                        // Sequential dispatch mints a solve room per card, so the
+                        // assignee's current-room pointer trails one card behind and
+                        // every pre-claim after the first bounced on wrong-room
+                        // (observed on the first team round, 2026-08-30: 3 of 8).
+                        if matches!(
+                            attempt,
+                            Err(airc_lib::AircError::WorkCardNotInCurrentRoom { .. })
+                        ) {
+                            if let Some(retry) = crate::modules::work::claim_following_card_room(
+                                rt.airc(),
                                 card_id,
-                                ttl_ms: crate::modules::work::DEFAULT_CLAIM_TTL_MS,
-                            })
+                                ttl_ms,
+                            )
                             .await
-                        {
+                            {
+                                attempt = retry;
+                            }
+                        }
+                        match attempt {
                             Ok(_) => pre_claimed = true,
                             Err(e) => kickoff_errors.push(format!("pre-claim {short}: {e}")),
                         }

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1051,6 +1051,13 @@ pub struct RecipeDispatch {
     /// `assignees`; non-resident names are skipped with a probe.
     #[serde(default)]
     pub teammates: Vec<String>,
+    /// ROLE-shaped team (recipe = content-type + RULES, #371): how many live
+    /// residents to enroll as reviewers per card, resolved against the roster
+    /// AT DISPATCH — a recipe that names citizens is brittle across machines;
+    /// a recipe that names ROLES ships anywhere. Resolved reviewers merge with
+    /// any explicit `teammates`; the assignee is never their own reviewer.
+    #[serde(default)]
+    pub reviewers: Option<u32>,
 }
 
 /// Resolve the citizens a directed dispatch addresses — GENERALIZED for any repo user's
@@ -1391,13 +1398,43 @@ impl ActionCommand for BenchmarkDispatch {
             self.ensure_recipe_model(&recipe).await?;
             let mut agg: Option<BenchmarkDispatchResult> = None;
             for d in &recipe.dispatches {
+                // ROLE → NAMES, at dispatch (recipe = content-type + RULES, #371):
+                // `reviewers: N` resolves against the LIVE resident roster here, so
+                // the recipe ships without citizen names. Merged with any explicit
+                // `teammates`; a reviewer who lands as a card's assignee is skipped
+                // per-card downstream (never their own reviewer). Short rosters
+                // degrade loudly, never silently.
+                let mut team: Vec<String> = d.teammates.clone();
+                if let Some(n) = d.reviewers.filter(|n| *n > 0) {
+                    let picked: Vec<String> = match crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global() {
+                        Some(reg) => reg
+                            .resident_snapshot()
+                            .await
+                            .into_iter()
+                            .map(|(name, _)| name)
+                            .filter(|name| !team.contains(name))
+                            .take(n as usize)
+                            .collect(),
+                        None => Vec::new(),
+                    };
+                    if (picked.len() as u32) < n {
+                        crate::probe!(
+                            class = "recipe.reviewers.short",
+                            benchmark = %d.benchmark,
+                            wanted = n as u64,
+                            resolved = picked.len() as u64,
+                            "recipe asked for more reviewers than the roster holds — team degrades, loudly"
+                        );
+                    }
+                    team.extend(picked);
+                }
                 let sub = BenchmarkDispatchParams {
                     name: Some(d.benchmark.clone()),
                     recipe: None,
-                    teammates: if d.teammates.is_empty() {
+                    teammates: if team.is_empty() {
                         p.teammates.clone()
                     } else {
-                        Some(d.teammates.clone())
+                        Some(team)
                     },
                     instances: if d.instances.is_empty() {
                         None

--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -238,7 +238,12 @@ fn on_card_state_changed(registry: &PersonaAircRuntimeRegistry, payload: &Value)
                         claimer: crate::identity::PeerId::from_uuid(next.assignee),
                         card: airc_work::WorkCardId::from_uuid(next.card),
                         room: airc_core::RoomId::from_u128(next.run_room.as_u128()),
-                        teammates: Vec::new(), // solo default; team threading lands per-caller
+                        // The card's RECORDED team rides every driver edge (gap 3).
+                        teammates: next
+                            .teammates
+                            .iter()
+                            .map(|t| crate::identity::PeerId::from_uuid(*t))
+                            .collect(),
                     },
                 )
                 .await;

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -389,7 +389,7 @@ pub(crate) async fn room_holding_card(airc: &Arc<Airc>, card_id: WorkCardId) -> 
 /// both cases the original wrong-room refusal stands, verbatim. `Some(result)`
 /// means a room-switched claim was attempted and that result REPLACES the refusal,
 /// so a genuine contention in the card's room still reports as contention.
-async fn claim_following_card_room(
+pub(crate) async fn claim_following_card_room(
     airc: &Arc<Airc>,
     card_id: WorkCardId,
     ttl_ms: u64,

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -639,7 +639,18 @@ impl ActionCommand for WorkClaim {
                             claimer: caller.peer_id,
                             card: card_id,
                             room: room.channel,
-                            teammates: Vec::new(), // solo default; team threading lands per-caller
+                            // An organic claim REJOINS the card's recorded team (gap 3) —
+                            // the round record is the continuity source, same as rooms.
+                            teammates: crate::cognition::bench_round::card_activity(
+                                card_id.as_uuid(),
+                            )
+                            .map(|act| {
+                                act.teammates
+                                    .iter()
+                                    .map(|t| crate::identity::PeerId::from_uuid(*t))
+                                    .collect()
+                            })
+                            .unwrap_or_default(), // unwrap_or: card outside any round = solo
                         },
                     )
                     .await;
@@ -1175,6 +1186,10 @@ pub(crate) async fn dispatch_staged_swe_solve(
                 );
                 continue;
             };
+            if mate.as_uuid() == claimer.as_uuid() {
+                // Teamed with yourself is a roster accident, not a team.
+                continue;
+            }
             if let Err(e) = rt.join_room(&team_room_name).await {
                 crate::probe!(
                     class = "work.team.join_failed",
@@ -1185,13 +1200,63 @@ pub(crate) async fn dispatch_staged_swe_solve(
                 );
                 continue;
             }
+            // AUTHOR THE CHARGE AS SOMEONE ELSE — the same law the kickoff path
+            // learned (#417, benchmark.rs "AUTHOR IT AS SOMEONE ELSE"): a citizen's
+            // inbound stream skips messages she is recorded as having said, so a
+            // charge published through the MATE'S OWN airc is dropped by her
+            // self-filter and never wakes her. Measured on the first team round
+            // (2026-08-30): Kira held the review charge in five rooms and produced
+            // zero turns in 28 minutes — the charge was her own voice. The natural
+            // author is the CLAIMER (it is their patch being reviewed); fall back
+            // to any other live citizen, and skip loudly rather than send a
+            // message that cannot be heard.
+            let registry =
+                crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global();
+            let voice_rt = registry
+                .as_ref()
+                .and_then(|reg| reg.get(claimer.as_uuid()))
+                .or_else(|| {
+                    registry
+                        .as_ref()
+                        .and_then(|reg| reg.any_live_citizen_other_than(Some(mate.as_uuid())))
+                });
+            let Some(voice_rt) = voice_rt else {
+                crate::probe!(
+                    class = "work.team.charge_unvoiced",
+                    card_id = %short8(card_id.as_uuid()),
+                    mate = %short8(mate.as_uuid()),
+                    "no live citizen other than the mate can voice the charge — \
+                     skipped loudly; a self-authored charge would be self-filtered"
+                );
+                continue;
+            };
+            // Membership is what makes the room deliverable for the voice too
+            // (idempotent; same rule as the kickoff's voice-join).
+            if let Err(e) = voice_rt.join_room(&team_room_name).await {
+                crate::probe!(
+                    class = "work.team.voice_join_failed",
+                    card_id = %short8(card_id.as_uuid()),
+                    mate = %short8(mate.as_uuid()),
+                    error = %e.to_string(),
+                    "charge voice could not join the solve room — charge skipped"
+                );
+                continue;
+            }
+            let claimer_name = registry
+                .as_ref()
+                .and_then(|reg| reg.get(claimer.as_uuid()))
+                .map(|c| c.agent_name().to_string())
+                .unwrap_or_else(|| short8(claimer.as_uuid()));
             let charge = format!(
-                "You are teamed with {} on `{}` in this room. Their patch must be                  reviewed by a teammate before it submits: read the diff when it                  lands, run what you can, and SPEAK your findings here — a miss a                  reviewer catches is the whole point of the team.",
-                short8(claimer.as_uuid()),
-                instance
+                "@{mate_name} (to you): you are teamed with {claimer_name} on \
+                 `{instance}` in this room. Their patch must be reviewed by a \
+                 teammate before it submits: read the diff when it lands, run what \
+                 you can, and SPEAK your findings here — a miss a reviewer catches \
+                 is the whole point of the team.",
+                mate_name = rt.agent_name(),
             );
             match crate::persona::airc_citizen::publish_text_in_room(
-                rt.airc(),
+                voice_rt.airc(),
                 solve_room,
                 &charge,
             )
@@ -1265,6 +1330,9 @@ pub(crate) async fn dispatch_staged_swe_solve(
         // own failure is part of the exam. Three chances: first attempt, one informed
         // retry, one consolidation — beyond that the failures repeat, not teach.
         attempts: Some(SWE_CLAIM_ATTEMPTS),
+        // Participants stay awake through the measured-work quiesce (gap 3) —
+        // the reviewers this dispatch just joined into the solve room.
+        teammates: teammates.iter().map(|m| m.as_uuid()).collect(),
     };
     match crate::commands::agent::solve::AgentSolve
         .run(ctx, params)

--- a/core/continuum-core/src/persona/airc_runtime_registry.rs
+++ b/core/continuum-core/src/persona/airc_runtime_registry.rs
@@ -337,7 +337,7 @@ impl PersonaAircRuntimeRegistry {
     #[must_use = "bind the lease to a named `_lease` for the eval's duration; \
                   binding to `_` drops it immediately and resumes the fleet at once"]
     pub fn quiesce_all(&self) -> QuiesceLease {
-        Self::quiesce_lease_over(self.quiesce_pairs(), None)
+        Self::quiesce_lease_over(self.quiesce_pairs(), &[])
     }
 
     /// Snapshot of every live persona's `(id, quiesce-flag)` — the input both quiesce
@@ -359,12 +359,12 @@ impl PersonaAircRuntimeRegistry {
     /// verbs; the only difference is whether `except` is `Some`.
     fn quiesce_lease_over(
         pairs: Vec<(Uuid, Arc<AtomicBool>)>,
-        except: Option<Uuid>,
+        except: &[Uuid],
     ) -> QuiesceLease {
         let total = pairs.len();
         let flags: Vec<Arc<AtomicBool>> = pairs
             .into_iter()
-            .filter(|(id, _)| except != Some(*id))
+            .filter(|(id, _)| !except.contains(id))
             .map(|(_, flag)| flag)
             .collect();
         for f in &flags {
@@ -401,7 +401,16 @@ impl PersonaAircRuntimeRegistry {
     #[must_use = "bind the lease to a named `_lease` for the solve's duration; \
                   binding to `_` drops it immediately and resumes the fleet at once"]
     pub fn quiesce_others(&self, except: Uuid) -> QuiesceLease {
-        Self::quiesce_lease_over(self.quiesce_pairs(), Some(except))
+        Self::quiesce_lease_over(self.quiesce_pairs(), &[except])
+    }
+
+    /// [`quiesce_others`] generalized to a PARTICIPANT SET — the solver plus her
+    /// teammates. A measured team solve needs every participant awake (a quiesced
+    /// reviewer cannot review — first team round, 2026-08-30); the lane-demand
+    /// override inside the lease counts the whole except-set, so serving budgets
+    /// a warm slot per participant.
+    pub fn quiesce_others_than(&self, except: &[Uuid]) -> QuiesceLease {
+        Self::quiesce_lease_over(self.quiesce_pairs(), except)
     }
 
     /// Attach a service-loop `JoinHandle` to the persona's slot. The
@@ -707,7 +716,7 @@ mod tests {
             (other_c, fc.clone()),
         ];
 
-        let lease = PersonaAircRuntimeRegistry::quiesce_lease_over(pairs, Some(solver));
+        let lease = PersonaAircRuntimeRegistry::quiesce_lease_over(pairs, &[solver]);
         assert!(fa.load(Ordering::Relaxed), "other citizen A suspended");
         assert!(
             !fs.load(Ordering::Relaxed),
@@ -733,7 +742,7 @@ mod tests {
         let fb = Arc::new(AtomicBool::new(false));
         let pairs = vec![(Uuid::new_v4(), fa.clone()), (Uuid::new_v4(), fb.clone())];
 
-        let lease = PersonaAircRuntimeRegistry::quiesce_lease_over(pairs, None);
+        let lease = PersonaAircRuntimeRegistry::quiesce_lease_over(pairs, &[]);
         assert!(
             fa.load(Ordering::Relaxed) && fb.load(Ordering::Relaxed),
             "None → the whole fleet is suspended"

--- a/protocol/typescript/agent/AgentSolveParams.ts
+++ b/protocol/typescript/agent/AgentSolveParams.ts
@@ -130,4 +130,13 @@ path_prepend?: Array<string>,
  * fault ends the run early. Default 1 (one shot, exactly the old behavior) — the
  * per-benchmark adapter that dispatches the run owns its N, not this abstraction.
  */
-attempts?: number, };
+attempts?: number, 
+/**
+ * Teammates on this solve (team-proof gap 3, 2026-08-30): peers who joined the
+ * solve room to review. The measured-work quiesce lease excepts them alongside
+ * the solver — the first team round proved a reviewer quiesced for the solve's
+ * whole duration is structurally unable to review (Kira: 28 min, zero turns).
+ * The lease's lane-demand override counts them too, so serving budgets a warm
+ * slot per PARTICIPANT, not per resident.
+ */
+teammates?: Array<string>, };


### PR DESCRIPTION
The first team round (2026-08-30, challenge recipe + teammates) ran as solo work in a team costume. Glass-boxing found three independent walls; this PR removes them.

## The receipts that found it
Kira held the review charge in five solve rooms and produced **zero turns in 28 minutes** (Atlas 258 log lines, Joaquin 174, Benchy 65, Kira 0). Three of eight pre-claims bounced. No teammate ever perceived anyone else.

## The three walls

1. **Pre-claim raced its own room pointer** (`work.rs`, `benchmark.rs`): sequential dispatch mints a solve room per card; the assignee's current-room pointer trails one card behind; 3/8 pre-claims bounced with "not in current room". `work/claim` learned accept-or-redirect in #328 — the dispatch pre-claim bypassed the verb and never inherited it. The follow helper is now `pub(crate)` and both sites share it.

2. **The review charge was self-voiced** (`work.rs`): published through the mate's own airc handle, so her self-filter dropped the only message that could wake her. The kickoff path documents this exact trap (#417 "AUTHOR IT AS SOMEONE ELSE"); the team block reflex-coded it anyway. Now voiced by the claimer (fallback: any other live citizen), addressed `@mate`, loud skip when unvoiceable.

3. **Reviewers were quiesced for the solve's whole duration** (`solve.rs`, `airc_runtime_registry.rs`): the measured-work lease parked every non-solver — correct law pre-teams, scoped too broadly now. `quiesce_others` → `quiesce_others_than(participants)`: solver + teammates stay awake; the lease's lane-demand override counts the participant set (serving budgets a warm slot per participant — matches the 3-lane layout). Teammates thread dispatch → `AgentSolveParams` → lease, and ride every driver edge (`NextCard`/`card_activity`), so re-dispatch can't silently de-team a round.

Wall 4 (presence facts in perception) is deliberately deferred: with walls 2+3 down, awareness bootstraps through real speech (the charge is a real message from a real other author); a dedicated presence fact should be designed from what the next team round actually shows.

Validation: `cargo check` clean, `bench_round` (16) + `quiesce` (3) + `export_bindings` (1256) green, ts-rs binding regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo