### PR TITLE
feat(identity): the operator self-peer — #27 closed, the human can read the rooms

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -2012,6 +2012,8 @@ pub fn start_server(
     // that genuinely ride it: GridCapacityModule (gossip channel) and the
     // node-level presence emitter.
     let persona_bootstrap_deps = airc_module.daemon_socket().map(|p| p.to_path_buf());
+    // #27: held for the operator self-peer boot after the executor is live.
+    let operator_peer_socket = persona_bootstrap_deps.clone();
     let discovered_default_room = airc_module.default_room();
     let persona_bootstrap_room_name = airc_module.default_room_name().map(|s| s.to_string());
     // The node-level presence emitter (WS seam below) needs BOTH the daemon
@@ -3172,6 +3174,17 @@ pub fn start_server(
     // #249: the durable-transcript reader behind persona wake hydration shares
     // the same substrate executor (one dispatch chain, no parallel query stack).
     crate::persona::durable_history::install_executor(Arc::clone(&executor));
+    // #27 CLOSED: the operator self-peer boots beside the citizens — the
+    // human's in-core airc identity, so room-scoped verbs invoked from the
+    // operator seat READ AND SPEAK instead of denying. Spawned (not awaited):
+    // identity ceremony does disk + daemon I/O, and boot must not block on it.
+    if let Some(sock) = operator_peer_socket {
+        let exec = Arc::clone(&executor);
+        let root = crate::modules::persona_instance_manager::resolve_continuum_root();
+        rt_handle.spawn(async move {
+            crate::persona::operator_peer::ensure_operator_peer(&root, sock, exec).await;
+        });
+    }
     // Autonomic dream consolidation: the dream region dispatches `memory/consolidate`
     // through the SAME wired executor, so a persona consolidates the lessons other agents
     // taught her into her genome WHILE IDLE — the being-loop's received axis going

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -207,19 +207,20 @@ pub(crate) fn persona_airc(
     // A refusal that misnames the thing you called teaches the wrong lesson.
     family: &str,
 ) -> Result<Arc<Airc>, CommandError> {
-    let peer = ctx
-        .caller
-        .as_ref()
-        .map(|c| c.peer_id.as_uuid())
-        .ok_or_else(|| {
+    // A persona acting through her toolbelt acts as HERSELF; the caller-less
+    // operator acts as the OPERATOR SELF-PEER (#27, closed 2026-08-30) — the
+    // human's in-core identity, booted beside the citizens. The deny below
+    // survives only for the boot window before the self-peer is online.
+    let Some(peer) = ctx.caller.as_ref().map(|c| c.peer_id.as_uuid()) else {
+        return crate::persona::operator_peer::operator_airc().ok_or_else(|| {
             CommandError::Denied(format!(
-                "{family} acts as the caller's own airc identity, and the \
-                     substrate-local operator has none in-core (yet — the self-peer gap, \
-                     task #27). Personas calling through their toolbelt act as themselves \
-                     and need nothing special; for operator-identity board writes use \
-                     `airc work <verb> ...`."
+                "{family} acts as the caller's own airc identity, and the operator \
+                 self-peer is not online yet this boot (it starts beside the \
+                 citizens — retry shortly, or check the operator.peer.boot_failed \
+                 probe)."
             ))
-        })?;
+        });
+    };
     let rt = registry.get(peer).ok_or_else(|| {
         CommandError::NotFound(format!("no live airc runtime for persona {peer}"))
     })?;

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -312,13 +312,39 @@ impl PersonaAircRuntime {
         source: crate::persona::identity_provider::PersonaIdentitySource,
         executor: Arc<crate::runtime::command_executor::CommandExecutor>,
     ) -> Result<Self, PersonaAircRuntimeError> {
+        Self::bootstrap_as(
+            crate::identity::IdentityKind::Persona,
+            persona_id,
+            agent_name,
+            continuum_root,
+            daemon_socket,
+            source,
+            executor,
+        )
+        .await
+    }
+
+    /// [`Self::bootstrap`] generalized over the citizen KIND — the operator
+    /// self-peer (#27) boots the SAME runtime as a persona (identity keypair,
+    /// daemon attach, transcript/roster readers) homed under its own kind dir
+    /// (`citizens/humans/<label>/airc/`), so it can never be mistaken for a
+    /// citizen by the persona resumer or the roster.
+    pub async fn bootstrap_as(
+        kind: crate::identity::IdentityKind,
+        persona_id: Uuid,
+        agent_name: impl Into<String>,
+        continuum_root: &Path,
+        daemon_socket: PathBuf,
+        source: crate::persona::identity_provider::PersonaIdentitySource,
+        executor: Arc<crate::runtime::command_executor::CommandExecutor>,
+    ) -> Result<Self, PersonaAircRuntimeError> {
         let agent_name = agent_name.into();
         // Slice 4 of #142: symmetric citizens/<kind>/<label>/airc/
         // layout. Use the shared helper so every actor kind shares
         // the same path schema.
         let home = crate::context::citizen_home_path(
             continuum_root,
-            crate::identity::IdentityKind::Persona,
+            kind,
             None,
             &agent_name,
         );
@@ -327,7 +353,7 @@ impl PersonaAircRuntime {
         // with the exact `mv` command per [[no-fallbacks-ever]].
         if let Some(legacy) = crate::context::legacy_home_path(
             continuum_root,
-            crate::identity::IdentityKind::Persona,
+            kind,
             &agent_name,
         ) {
             if tokio::fs::try_exists(&legacy).await.unwrap_or(false) {

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -18,6 +18,7 @@ pub mod airc_admission;
 pub mod airc_citizen;
 pub mod airc_persona_conversation;
 pub mod airc_runtime;
+pub mod operator_peer;
 pub mod command_inbound_pump;
 // `scripted_*` are SYSTEM-level test/replay primitives per
 // [[test-fixtures-are-system-primitives]] — ubiquitous across every

--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -1,0 +1,90 @@
+//! The operator's self-peer (#27) — the human's in-core airc presence.
+//!
+//! Until this existed, every room-scoped verb invoked without a persona
+//! caller was DENIED ("the substrate-local operator has none in-core") — the
+//! operator could dispatch work but could not read the rooms it ran in.
+//! Diagnosing a comatose citizen took an hour of log archaeology because the
+//! transcript she should have been reachable through was unreadable from the
+//! operator seat (glass-boxed 2026-08-30; Joel: "Operator room issue is a
+//! major bug").
+//!
+//! Shape: ONE durable identity per machine, kind [`IdentityKind::Human`],
+//! labeled by the OS user, homed at `citizens/humans/<label>/airc/` — the
+//! same runtime a persona boots (keypair, daemon attach, transcript/roster
+//! readers) with NO service loop and NO registry row, so it can never be
+//! picked by `any_live_citizen`, the reviewer resolver, the resumer, or any
+//! other citizens-only path. Identity durability comes from the keypair on
+//! disk: re-bootstrapping the same home resumes the same peer.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+use crate::persona::airc_runtime::PersonaAircRuntime;
+
+static OPERATOR: OnceLock<Arc<PersonaAircRuntime>> = OnceLock::new();
+
+/// The operator's label — the OS user, falling back to "operator" only when
+/// the environment carries no user at all (containers).
+fn operator_label() -> String {
+    std::env::var("USER")
+        .ok()
+        .filter(|u| !u.trim().is_empty())
+        .unwrap_or_else(|| "operator".to_string()) // unwrap_or: no $USER (container) = the neutral label, still durable per home dir
+}
+
+/// Boot (or resume) the operator self-peer. Idempotent; first success wins.
+/// Called from the persona instance manager's start path — after the daemon
+/// socket exists and the executor is installed, alongside citizen births.
+pub async fn ensure_operator_peer(
+    continuum_root: &Path,
+    daemon_socket: PathBuf,
+    executor: Arc<crate::runtime::command_executor::CommandExecutor>,
+) {
+    if OPERATOR.get().is_some() {
+        return;
+    }
+    let label = operator_label();
+    match PersonaAircRuntime::bootstrap_as(
+        crate::identity::IdentityKind::Human,
+        uuid::Uuid::new_v4(), // pre-mint id; the durable identity is the home keypair (post-collapse peer id wins)
+        &label,
+        continuum_root,
+        daemon_socket,
+        crate::persona::identity_provider::PersonaIdentitySource::ResumedFromDisk,
+        executor,
+    )
+    .await
+    {
+        Ok(rt) => {
+            let rt = Arc::new(rt);
+            crate::probe!(
+                class = "operator.peer.online",
+                label = %label,
+                peer_id = %rt.airc().peer_id(),
+                "operator self-peer online — room-scoped verbs now act as the human, not a denial (#27)"
+            );
+            let _ = OPERATOR.set(rt);
+        }
+        Err(e) => {
+            // Loud, not fatal: the substrate runs without an operator peer the
+            // way it always has — verbs deny with the #27 message — but the
+            // failure is a named probe, never silence.
+            crate::probe!(
+                class = "operator.peer.boot_failed",
+                label = %label,
+                error = %e.to_string(),
+                "operator self-peer failed to boot — room verbs stay denied (#27 still open on this boot)"
+            );
+        }
+    }
+}
+
+/// The operator's airc handle, when the self-peer is online.
+pub fn operator_airc() -> Option<Arc<airc_lib::Airc>> {
+    OPERATOR.get().map(|rt| rt.airc().clone())
+}
+
+/// The operator's runtime (transcript/roster readers), when online.
+pub fn operator_runtime() -> Option<Arc<PersonaAircRuntime>> {
+    OPERATOR.get().cloned()
+}


### PR DESCRIPTION
"Operator room issue is a major bug you need to fix." The substrate-local operator had no in-core airc identity: every room-scoped verb from the operator seat denied, so the operator could dispatch work but never read the rooms it ran in. Measured cost this morning: an hour of log archaeology to diagnose a comatose citizen whose room transcript was unreadable from the operator seat.

The fix: one durable self-peer per machine — `IdentityKind::Human`, labeled by the OS user, homed at `citizens/humans/<label>/airc/`. Same runtime a persona boots (`bootstrap_as`, the kind-generalized bootstrap), with **no service loop and no registry row** — it can never be picked by `any_live_citizen`, the reviewer resolver, or the persona resumer. Boots beside the citizens (spawned, non-blocking, loud probe on failure); identity durability is the home keypair. `persona_airc`'s caller-less arm resolves to it, so `room/list`, `room/members`, `chat` reads, and transcript replay act as the human; the deny survives only for the pre-boot window.

Probes: `operator.peer.online` / `operator.peer.boot_failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo