### PR TITLE
docs: the contributor front door — receipts-asking bug template + CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,6 +21,12 @@ A clear and concise description of what you expected to happen.
 **Screenshots or logs**
 If applicable, add screenshots or logs to help explain your problem.
 
+**Receipts (one command, paste the output):**
+```bash
+continuum ping        # the version trio: build #, sha, built-at — tells us EXACTLY what you ran
+```
+If the bug involves benchmarks or scores, also paste `continuum benchmark/scoreboard` (the regime line carries model + window + build + host). Server log lives at `~/.continuum/logs/continuum-core-server.log` — the last ~50 lines around the failure are gold.
+
 **Environment (please complete the following information):**
  - OS: [e.g. Ubuntu 20.04, macOS 12.0]
  - Node version: [e.g. 16.14.0]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Continuum
+
+Seven forks in, we write this down. Whether you're fixing a typo, upstreaming a
+patch from your fork, or teaching your own citizens to work on the codebase —
+welcome. This page is the short map; the deep laws live in
+[CLAUDE.md](CLAUDE.md) and [docs/ARCHITECTURE-RULES.md](docs/ARCHITECTURE-RULES.md).
+
+## The shape of a good contribution
+
+- **Branch from `canary`, PR to `canary`.** `main` is the beta gate and merges
+  from canary only.
+- **Every claim carries a receipt.** A fix PR shows the failing behavior and the
+  passing behavior — probe output, test output, or a `perception/observe`
+  screenshot. This repo's culture is receipts over assertions, and reviews go
+  fast when the evidence is attached.
+- **Every test justifies itself.** One `#[cfg(test)] mod tests` per file; each
+  test carries a `// what this catches:` line naming the invariant or the
+  regression it pins. Trivial-getter tests are declined kindly.
+- **No suppressions.** `#[allow(...)]`, `@ts-ignore`, swallowed errors, and
+  `--no-verify` don't land. If a hook or a ratchet fails, the failure is the
+  finding — fix the cause or ask in the PR.
+- **Ratchets only go down.** Source-hygiene counters (unwraps, boundary
+  serializations, README link hygiene) may never rise; touching old code is a
+  chance to lower them.
+- **Deploy-verify if you touch the core.** `continuum reboot` then check
+  `continuum ping`'s sha matches your commit before believing any behavior
+  change. A fix you can't prove reached the running binary is not yet a fix.
+
+## Filing issues
+
+Use the templates — the bug template asks for `continuum ping` output (the
+version trio) because "what exactly were you running" is half of every
+diagnosis. Benchmarks issues want the `benchmark/scoreboard` regime line.
+Feature ideas and design conversations are welcome in Discussions; so are
+questions from other AI projects — precedent exists (#1729).
+
+## For AI contributors
+
+Continuum is built daily by a human-AI team, and contributions from agent
+sessions (Claude Code, Codex, or your own) are first-class. Two requests:
+identify the driving human in the PR (accountability, not gatekeeping), and
+hold your agents to the same receipt discipline — the reviewers here include
+AIs who will actually check.
+
+## License
+
+AGPL-3.0. Contributions are accepted under the same license. The genome
+commons additionally carries its own covenant (`continuum genome/sharing`) —
+code license and gene covenant are separate consents.


### PR DESCRIPTION
Seven forks means inbound is real. Bug template now asks for `continuum ping`'s version trio (+ scoreboard regime for benchmark reports); root CONTRIBUTING.md distills the house laws for external and AI contributors. Also: issue #1729 — an autonomous AI project that said hello in June — finally has its answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo