### PR TITLE
feat(desktop): the display manager — the core serves its own UI; uu desktop opens it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5413,6 +5413,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11355,14 +11361,24 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/core/continuum-core/Cargo.toml
+++ b/core/continuum-core/Cargo.toml
@@ -117,7 +117,7 @@ chrono.workspace = true
 # Claude Code sends POST /v1/messages — we serve it from Candle
 axum = "0.8"
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "fs"] }
 parking_lot.workspace = true
 tokio-stream.workspace = true
 

--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -75,6 +75,33 @@ async fn run() -> Result<(), String> {
             reboot(force).await
         }
         "stop" => stop().await,
+        // The display-manager door: the core serves the built desktop itself
+        // (http::desktop, always-current, browsers attach/detach freely) —
+        // this verb just verifies the greeter answers and opens the browser.
+        "desktop" | "ui" => {
+            let port = std::env::var("CONTINUUM_UI_PORT")
+                .ok()
+                .and_then(|v| v.parse::<u16>().ok())
+                .unwrap_or(8975); // unwrap_or: the display manager's documented default
+            let url = format!("http://127.0.0.1:{port}/");
+            let up = tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok();
+            if !up {
+                eprintln!(
+                    "✗ the desktop display manager is not answering on :{port}.\n                       Is the core running? `continuum ping` — and `continuum start` \n                       builds the web client and serves it automatically. \n                       (Probe classes desktop.dm.* in the server log say why it stayed off.)"
+                );
+                std::process::exit(1);
+            }
+            println!("🖥  {url}");
+            #[cfg(target_os = "macos")]
+            {
+                let _ = std::process::Command::new("open").arg(&url).status();
+            }
+            #[cfg(target_os = "linux")]
+            {
+                let _ = std::process::Command::new("xdg-open").arg(&url).status();
+            }
+            Ok(())
+        }
         // Dry-run of the reap `reboot`/`stop` perform. Answers "what is this
         // install still holding that nothing is using?" WITHOUT killing it —
         // the safe way to inspect a suspected leak, and the way to confirm a

--- a/core/continuum-core/src/http/desktop.rs
+++ b/core/continuum-core/src/http/desktop.rs
@@ -1,0 +1,86 @@
+//! The desktop display manager — the core serves its own UI, always current.
+//!
+//! Joel, 2026-08-30, after a stale preview server rendered a broken sidebar:
+//! "this should have worked. Should work like a Display Manager (such as GDM,
+//! LightDM, or SDDM)." The session layer must be ALWAYS THERE, always serving
+//! the current build, with browsers attaching and detaching freely — never a
+//! hand-run script racing a hand-run server.
+//!
+//! So the core serves the built web desktop statically:
+//! - `CONTINUUM_UI_DIST` names the dist directory (the start script builds it
+//!   and exports the path); absent/missing = the display manager stays off
+//!   with a probe naming the fix — an honestly-disabled projection, never a
+//!   broken one.
+//! - `CONTINUUM_UI_PORT` (default 8975) on 127.0.0.1 — beside the WS ingress
+//!   (8974) and the call plane (8790). One `continuum start` brings up all
+//!   three; `continuum desktop` opens the door.
+//! - The zero-config client needs no query params: it defaults to the core's
+//!   own WS port and mints its identity.
+//!
+//! SPA fallback: unknown paths serve index.html (client-side routing), real
+//! files serve as themselves. Served from disk per request — a redeploy that
+//! rewrites dist is picked up on the next load, no server restart, and the
+//! stale-index race dies because index.html and its hashed bundles come from
+//! the same generation of the directory on every full reload.
+
+use std::path::PathBuf;
+
+use axum::Router;
+use tower_http::services::{ServeDir, ServeFile};
+
+/// Spawn the display manager if a dist directory is configured and present.
+/// Detached; failures probe loudly and never block boot.
+pub fn spawn_if_configured(rt: &tokio::runtime::Handle) {
+    let Some(dist) = crate::config_env::read("CONTINUUM_UI_DIST").map(PathBuf::from) else {
+        crate::probe!(
+            class = "desktop.dm.unconfigured",
+            "no CONTINUUM_UI_DIST — the core serves no desktop this boot \
+             (continuum start sets it after building the web client)"
+        );
+        return;
+    };
+    if !dist.join("index.html").is_file() {
+        crate::probe!(
+            class = "desktop.dm.dist_missing",
+            dist = %dist.display(),
+            "CONTINUUM_UI_DIST has no index.html — build the web client \
+             (npm run build -w @continuum/web) or re-run continuum start"
+        );
+        return;
+    }
+    let port: u16 = crate::config_env::read("CONTINUUM_UI_PORT")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8975); // unwrap_or: the documented default port, beside WS 8974
+    let index = dist.join("index.html");
+    rt.spawn(async move {
+        let app = Router::new().fallback_service(
+            ServeDir::new(&dist).fallback(ServeFile::new(index)),
+        );
+        let bind = format!("127.0.0.1:{port}");
+        let listener = match tokio::net::TcpListener::bind(&bind).await {
+            Ok(l) => l,
+            Err(e) => {
+                crate::probe!(
+                    class = "desktop.dm.bind_failed",
+                    bind = %bind,
+                    error = %e,
+                    "desktop display manager could not bind — another server holds the port"
+                );
+                return;
+            }
+        };
+        crate::probe!(
+            class = "desktop.dm.online",
+            url = %format!("http://{bind}/"),
+            dist = %dist.display(),
+            "desktop display manager online — the core serves its own UI (continuum desktop opens it)"
+        );
+        if let Err(e) = axum::serve(listener, app).await {
+            crate::probe!(
+                class = "desktop.dm.exited",
+                error = %e,
+                "desktop display manager exited"
+            );
+        }
+    });
+}

--- a/core/continuum-core/src/http/mod.rs
+++ b/core/continuum-core/src/http/mod.rs
@@ -30,6 +30,8 @@
 //! - Runs as tokio task, shared across all sentinels
 //! - Port stored in SERVER_PORT for IPC query
 
+pub mod desktop;
+
 pub mod anthropic_compat;
 
 use anthropic_compat::{

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -3174,6 +3174,10 @@ pub fn start_server(
     // #249: the durable-transcript reader behind persona wake hydration shares
     // the same substrate executor (one dispatch chain, no parallel query stack).
     crate::persona::durable_history::install_executor(Arc::clone(&executor));
+    // The desktop display manager (Joel: 'should work like a Display Manager'):
+    // the core serves its own built UI, always current — browsers attach and
+    // detach freely; continuum desktop opens the door.
+    crate::http::desktop::spawn_if_configured(&rt_handle);
     // #27 CLOSED: the operator self-peer boots beside the citizens — the
     // human's in-core airc identity, so room-scoped verbs invoked from the
     // operator seat READ AND SPEAK instead of denying. Spawned (not awaited):

--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -831,4 +831,19 @@ fi
 # which re-runs cargo's build logic at launch and could second-guess (or re-stale)
 # what we already verified. We built it, we checked it reflects source, we run it.
 # Unambiguous: the process image is the verified $CORE_BIN. [[verify-the-build-actually-deployed]]
+# ── The desktop display manager's dist (Joel: 'should work like a Display
+# Manager'). Build the web client so the core can serve it — ALWAYS current
+# by construction: this runs on every start/reboot, so the greeter and the
+# core deploy as one generation. Non-fatal: a failed UI build boots a
+# headless core (desktop.dm.dist_missing probes the fix) rather than no core.
+if [ -f "$REPO_ROOT/apps/web/package.json" ] && command -v npm >/dev/null 2>&1; then
+  echo "→ building the desktop (served by the core at :\${CONTINUUM_UI_PORT:-8975})…"
+  if (cd "$REPO_ROOT" && npm run build -w @continuum/web >/dev/null 2>&1); then
+    export CONTINUUM_UI_DIST="$REPO_ROOT/apps/web/dist"
+    echo "  desktop built — continuum desktop opens it"
+  else
+    echo "  ⚠ desktop build failed — core boots headless (npm run build -w @continuum/web to diagnose)" >&2
+  fi
+fi
+
 exec "$CORE_BIN" "$CONTINUUM_SOCKET"


### PR DESCRIPTION
GDM-model per Joel: an axum static server inside the core (SPA fallback, dist from disk per request — greeter and core deploy as one generation, stale-index race structurally dead); start builds the web client every boot; `continuum desktop` verifies and opens. Probes: desktop.dm.*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo