### PR TITLE
feat(ui): pause/resume controls on the bench rail

### DIFF
--- a/apps/web/src/bench/renderBench.ts
+++ b/apps/web/src/bench/renderBench.ts
@@ -37,7 +37,35 @@ function roundRow(round: BenchRoundVM): TemplateResult {
     ${round.driver === 'citizen'
       ? html`<span class="bench-round-driver" title="worked in the room — turns feed the curriculum">citizens</span>`
       : html`<span class="bench-round-driver bench-round-detached" title="detached solve — produces no room turns">detached</span>`}
+    ${round.stage === 'working'
+      ? html`<button
+          class="bench-round-ctl"
+          title="hold this round — in-flight solves finish, no new card fires until resume"
+          @click=${(e: Event) => emitRoundControl(e, 'pause', round.roundId)}
+        >⏸</button>`
+      : round.stage === 'paused'
+        ? html`<button
+            class="bench-round-ctl bench-round-ctl-resume"
+            title="lift the hold — the driver fires the next card immediately"
+            @click=${(e: Event) => emitRoundControl(e, 'resume', round.roundId)}
+          >▶</button>`
+        : nothing}
   </div>`;
+}
+
+/** Round pause/resume, as a composed event — the renderer stays pure; the
+ *  host (which owns the transport) binds `bench-round-control` to
+ *  `benchmark/pause` / `benchmark/resume`. Same seam discipline as
+ *  historyHandler: rendering never talks to the wire directly. */
+function emitRoundControl(e: Event, action: 'pause' | 'resume', roundId: string): void {
+  e.stopPropagation();
+  (e.currentTarget as HTMLElement).dispatchEvent(
+    new CustomEvent('bench-round-control', {
+      detail: { action, roundId },
+      bubbles: true,
+      composed: true,
+    }),
+  );
 }
 
 /** Compact seconds → "12s" / "3m" / "2h" — board legibility, not precision. */

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -225,6 +225,18 @@ async function main(): Promise<void> {
   };
   widget.closeTabHandler = closeTabHandler;
 
+  // Round pause/resume from the bench rail (composed event out of the pure
+  // renderer): bind to the AiSafe verbs. Fire-and-forget — the round's stage
+  // flips in the next bench projection, so the UI's truth stays the feed,
+  // never an optimistic local toggle.
+  widget.addEventListener('bench-round-control', (e: Event) => {
+    const { action, roundId } = (e as CustomEvent<{ action: string; roundId: string }>).detail;
+    const verb = action === 'pause' ? 'benchmark/pause' : 'benchmark/resume';
+    void transport
+      .execute(buildCommandUri(verb), JSON.stringify({ roundId }))
+      .catch((err: unknown) => console.error(`${verb} failed:`, err));
+  });
+
   // Visible connection diagnostics — a stuck "Connecting…" with no on-screen
   // reason is undebuggable. Surface the WS lifecycle so a blank/stuck tab tells
   // you WHY (socket closed / connected-but-no-snapshot / connect failed).

--- a/core/continuum-core/src/commands/benchmark_pause.rs
+++ b/core/continuum-core/src/commands/benchmark_pause.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, TS, JsonSchema)]
 #[ts(export, export_to = "../../../protocol/typescript/benchmark/BenchmarkPauseParams.ts")]
+#[serde(rename_all = "camelCase")]
 pub struct BenchmarkPauseParams {
     /// The round's id (= its run room id, shown by `benchmark/rounds`).
     pub round_id: String,
@@ -28,6 +29,7 @@ pub struct BenchmarkPauseParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS, JsonSchema)]
 #[ts(export, export_to = "../../../protocol/typescript/benchmark/BenchmarkPauseResult.ts")]
+#[serde(rename_all = "camelCase")]
 pub struct BenchmarkPauseResult {
     /// The round's stage after the verb ("working" | "paused" | "done").
     pub stage: String,

--- a/protocol/typescript/benchmark/BenchmarkPauseParams.ts
+++ b/protocol/typescript/benchmark/BenchmarkPauseParams.ts
@@ -4,4 +4,4 @@ export type BenchmarkPauseParams = {
 /**
  * The round's id (= its run room id, shown by `benchmark/rounds`).
  */
-round_id: string, };
+roundId: string, };

--- a/protocol/typescript/benchmark/BenchmarkPauseResult.ts
+++ b/protocol/typescript/benchmark/BenchmarkPauseResult.ts
@@ -12,4 +12,4 @@ changed: boolean,
 /**
  * On resume: the card the driver was kicked with, if any work remained.
  */
-kicked_card?: string, };
+kickedCard?: string, };


### PR DESCRIPTION
⏸/▶ per round row, composed-event out of the pure renderer, host-bound to the AiSafe verbs; feed-as-truth (no optimistic toggle). Wire fix: pause params camelCase. Built against live rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo