### PR TITLE
fix(bench): queued-behind-hands is not a stall

### DIFF
--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -4015,7 +4015,9 @@ pub struct BenchRunCard {
     pub solver: Option<String>,
     /// `resolved` | `failed` (loud infra marker, incl. #2180 stalls the
     /// deadline caught) | `active` (artifact activity within the stall
-    /// window) | `quiet` (non-terminal AND silent past the window — the
+    /// window) | `queued` (silent past the window BUT the solver is actively
+    /// working another run — one pair of hands; waiting a turn is not a
+    /// stall) | `quiet` (non-terminal AND silent past the window — the
     /// shape the projection exists to make visible) | `ungraded` (a staged
     /// workspace holds a real diff that no grade has ever seen — durable
     /// work awaiting a verdict, NOT a stall; see
@@ -5000,6 +5002,30 @@ pub(crate) fn scan_run_cards(
             last_activity_ms,
             now_ms,
         ));
+    }
+    // QUEUED-BEHIND-HANDS, not stalled (glass-boxed 2026-08-30): a persona
+    // runs ONE solve at a time (HandsLease), so her other claim-dispatched
+    // runs sit legitimately idle while she works — and the per-card silence
+    // window read them as "quiet", inflating the console's gone-quiet alarm
+    // with runs that are just WAITING THEIR TURN (4 of the banner's 8, live).
+    // Cross-card rule: a quiet card whose solver has an ACTIVE card is
+    // re-phased `queued`. Same-solver-and-active is the whole test — honest
+    // quiet (solver has nothing active anywhere) still alarms.
+    let active_solvers: std::collections::HashSet<String> = cards
+        .iter()
+        .filter(|c| c.phase == "active")
+        .filter_map(|c| c.solver.clone())
+        .collect();
+    for card in cards.iter_mut() {
+        if card.phase == "quiet"
+            && card
+                .solver
+                .as_ref()
+                .is_some_and(|s| active_solvers.contains(s))
+        {
+            card.phase = "queued".to_string();
+            card.stalled = false;
+        }
     }
     // Second source: staged trees holding work no grade has seen. Only when the caller is
     // asking for the BOARD — a run-id query is asking about one run's ledger, and a workspace

--- a/packages/chat-view/benchProjections.ts
+++ b/packages/chat-view/benchProjections.ts
@@ -41,6 +41,10 @@ function stateOf(row: BenchRunRow): BenchRunState {
       return 'failed';
     case 'quiet':
       return 'stalled';
+    case 'queued':
+      // The core's cross-card verdict: silent, but the solver's hands are
+      // busy on another run — waiting a turn, never an alarm.
+      return 'queued';
     default:
       return (row.acts ?? 0) > 0 ? 'working' : 'queued';
   }

--- a/protocol/typescript/benchmark/BenchRunCard.ts
+++ b/protocol/typescript/benchmark/BenchRunCard.ts
@@ -24,7 +24,9 @@ solver?: string,
 /**
  * `resolved` | `failed` (loud infra marker, incl. #2180 stalls the
  * deadline caught) | `active` (artifact activity within the stall
- * window) | `quiet` (non-terminal AND silent past the window — the
+ * window) | `queued` (silent past the window BUT the solver is actively
+ * working another run — one pair of hands; waiting a turn is not a
+ * stall) | `quiet` (non-terminal AND silent past the window — the
  * shape the projection exists to make visible) | `ungraded` (a staged
  * workspace holds a real diff that no grade has ever seen — durable
  * work awaiting a verdict, NOT a stall; see


### PR DESCRIPTION
The gone-quiet banner counted runs waiting their turn behind the one-solve-per-persona hands rule (4 of 8, live). Cross-card rule at the board fold: quiet + solver-active-elsewhere → queued. Honest quiet still alarms. An alarm that cries wolf trains operators to ignore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo