### PR TITLE
feat(nav): the rail becomes a tree — parent_ref + display_label (#2632 slice a)

### DIFF
--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -504,6 +504,17 @@ pub fn card_activity(card_id: Uuid) -> Option<CardActivity> {
 /// callers that hold an activity's room but not its card (the experience
 /// stream's grade-time seam). `None` = no tracked round runs a solve there
 /// (solo work, non-bench rooms).
+/// The RUN room of the round whose solve runs in `room` — the tree edge the
+/// nav rail renders (#2632): a solve activity nests under its round. `None`
+/// = no tracked round solves there (top-level activity).
+pub fn run_room_for_solve(room: Uuid) -> Option<Uuid> {
+    let rounds = ROUNDS.lock().expect("bench rounds mutex");
+    rounds
+        .values()
+        .find(|r| r.card_activities.values().any(|a| a.solve_room == room))
+        .map(|r| r.round_id)
+}
+
 pub fn team_for_room(room: Uuid) -> Option<CardActivity> {
     let rounds = ROUNDS.lock().expect("bench rounds mutex");
     rounds

--- a/core/continuum-core/src/ipc/positron_nav_source.rs
+++ b/core/continuum-core/src/ipc/positron_nav_source.rs
@@ -109,12 +109,24 @@ pub fn project_nav(user: Uuid, snap: NavSnapshot) -> NavViewState {
             if let Some(ts) = a.last_read {
                 last_read.insert(a.id.clone(), ts);
             }
-            NavTab {
-                id: a.id,
-                title: a.title,
-                kind: a.kind,
-                unread: a.unread,
-                purpose: a.purpose,
+            {
+                // The tree half of #2632: a solve room nests under its run
+                // room — the round tracker already RECORDS the lineage
+                // (CardActivity.solve_room ↔ round_id), so parenthood is a
+                // lookup, never new state. The humanized label derives from
+                // the same record (instance · assignee name resolved by the
+                // renderer's roster); the raw room id keeps its identity job
+                // in `id` and retreats from the reading line.
+                let (parent_ref, display_label) = activity_lineage(&a.id, &a.title);
+                NavTab {
+                    id: a.id,
+                    title: a.title,
+                    kind: a.kind,
+                    unread: a.unread,
+                    purpose: a.purpose,
+                    parent_ref,
+                    display_label,
+                }
             }
         })
         .collect();
@@ -660,6 +672,36 @@ impl NavProjectorRegistry {
             Arc::clone(&self.reader),
         );
     }
+}
+
+
+/// The activity's tree position + humanized reading-line label (#2632 slice a).
+///
+/// Pure lookup over records the substrate already keeps: a room that hosts a
+/// tracked solve card nests under its round's run room, labeled
+/// `<instance> · <assignee-short>`. Anything untracked stays top-level with
+/// its own title — honest flat, never an invented hierarchy.
+fn activity_lineage(room_ref: &str, title: &str) -> (String, String) {
+    let Ok(room) = uuid::Uuid::parse_str(room_ref) else {
+        return (String::new(), String::new());
+    };
+    let Some(act) = crate::cognition::bench_round::team_for_room(room) else {
+        return (String::new(), String::new());
+    };
+    let Some(run_room) = crate::cognition::bench_round::run_room_for_solve(room) else {
+        return (String::new(), String::new());
+    };
+    // `swe--<instance>--<card8>` → `<instance>`; an unconventional name keeps
+    // its title (label stays honest, never lossy).
+    let instance = title
+        .strip_prefix("swe--")
+        .and_then(|rest| rest.rsplit_once("--").map(|(i, _)| i))
+        .unwrap_or(title);
+    let assignee8 = act.assignee.to_string()[..8].to_string();
+    (
+        run_room.to_string(),
+        format!("{instance} · {assignee8}"),
+    )
 }
 
 #[cfg(test)]

--- a/core/continuum-positron/src/nav.rs
+++ b/core/continuum-positron/src/nav.rs
@@ -93,6 +93,19 @@ pub struct NavTab {
     /// tab serialized before this field folds as empty, never dropped.
     #[serde(default)]
     pub purpose: String,
+    /// The PARENT activity's ref, when this activity nests under another —
+    /// a solve room under its benchmark run room, a design review under its
+    /// project (#2632: the rail is a tree, not a list). Empty = top-level.
+    /// Renderers group children under their parent; the raw ref stays a
+    /// tooltip/copy affordance, never the reading line.
+    #[serde(default)]
+    pub parent_ref: String,
+    /// Humanized label for the reading line (`django-10914 · Atlas`) when the
+    /// raw title is a substrate identifier. Empty = use `title` as-is.
+    /// Display labels humanize; URIs address; UUIDs identify — three jobs,
+    /// never conflated (Joel, 2026-08-30).
+    #[serde(default)]
+    pub display_label: String,
 }
 
 /// A pinned quick-nav target — the citizen's bookmarks (rooms, content,


### PR DESCRIPTION
NavTab gains parent_ref (solve rooms nest under run rooms — a lookup over CardActivity, no new state) + display_label (humanized reading line; the raw id keeps the identity job). Serde-tolerant both directions. Slice (b) renders the tree client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo