### PR TITLE
fix(web): transcript renders, directory never blank, per-activity sessions (+ nav tree slice a)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "TZ=UTC vitest run",

--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -24,6 +24,7 @@ import {
   focusedPersonaTab,
   historyRowsFromPoll,
   type MessageRowVM,
+  type RosterMemberVM,
 } from '@continuum/chat-view';
 import type {
   KanbanViewState,
@@ -194,6 +195,15 @@ export class ChatWidget extends LitElement {
    *  tail so no gap ever opens between buffer and window. Cleared on room
    *  switch. Reassigned (not mutated) so Lit re-renders. */
   private _history: MessageRowVM[] = [];
+  /** Per-ACTIVITY session state, keyed by room UUID (tab = content = room =
+   *  activity — Joel's law). Typing streams and the history buffer belong to
+   *  the activity they happened in; switching tabs swaps the pointer, never
+   *  clobbers. A stream running in a background room accumulates in ITS
+   *  session and is intact when its tab regains focus. */
+  private _sessions = new Map<
+    string,
+    { typing: Map<string, string>; history: MessageRowVM[]; historyExhausted: boolean }
+  >();
   /** An empty page came back — the room's history is fully on screen. */
   private _historyExhausted = false;
   /** One in-flight page at a time (the scroll handler fires per frame). */
@@ -259,6 +269,12 @@ export class ChatWidget extends LitElement {
   /** The live face's caption strip toggle (CC) — on by default; the strip only
    *  draws while a real turn streams, so "on" costs nothing in silence. */
   private _captionsOn = true;
+  /** THE DIRECTORY (Joel, 2026-08-30): the who-panel shows everyone known —
+   *  online active, offline greyed — in EVERY room, never a blank. Folded
+   *  from each roster seen this session + seeded from persona/list. */
+  private _directory = new Map<string, RosterMemberVM>();
+  /** Host-injected seed: the node's residents + the viewer themself. */
+  directorySeed: readonly RosterMemberVM[] = [];
 
   /** The Settings face state + its fetched body (substrate truth; undefined
    *  while a fetch is in flight — the face shows its awaiting frame). */
@@ -487,7 +503,20 @@ export class ChatWidget extends LitElement {
    * ignored. Never touches `state` — the authoritative message still arrives there.
    */
   applyStreamDelta(delta: StreamDelta): void {
-    if (delta.roomId !== this.state?.room_id) return;
+    if (delta.roomId !== this.state?.room_id) {
+      // A stream in ANOTHER activity accumulates in THAT activity's session —
+      // never in the tab being viewed (the "(Benchy) is responding… in every
+      // tab" leak, Joel 2026-08-30). It's all there when its tab regains focus.
+      const sess = this._sessions.get(delta.roomId) ?? {
+        typing: new Map<string, string>(),
+        history: [],
+        historyExhausted: false,
+      };
+      if (delta.done) sess.typing.delete(delta.senderId);
+      else sess.typing.set(delta.senderId, (sess.typing.get(delta.senderId) ?? '') + delta.token);
+      this._sessions.set(delta.roomId, sess);
+      return;
+    }
     const next = new Map(this._typing);
     if (delta.done) {
       next.delete(delta.senderId);
@@ -769,6 +798,12 @@ export class ChatWidget extends LitElement {
     .rail-widget {
       display: block;
       border-bottom: 1px solid var(--border-subtle);
+    }
+    /* The system HUD keeps ONE height across its faces — a rail that reflows
+     * every time a face changes reads as broken chrome (Joel, 2026-08-30:
+     * "dynamically change heights all the time"). Reserve the tallest face. */
+    .rail-widget[data-widget='system'] {
+      min-height: 128px;
     }
     .rail-widget:last-child {
       border-bottom: none;
@@ -4555,6 +4590,40 @@ export class ChatWidget extends LitElement {
     // Digest tier ([[perception-resolution-contract]]): stamp the reader's expand
     // choices onto the rows the projection classified — an expanded row renders
     // its full body with a collapse affordance; everything else stays digested.
+    // Directory union: this room's live roster as-is; every other known
+    // member appended greyed. A citizens app showing zero citizens is broken
+    // by definition ([Joel, live]) — the panel is never blank again.
+    for (const m of vm.members) this._directory.set(m.id, m);
+    for (const m of this.directorySeed) if (!this._directory.has(m.id)) this._directory.set(m.id, m);
+    {
+      // Residency wins for liveness: the room's presence flag derives from
+      // lane-readiness (away=warming), which greys a citizen precisely while
+      // she's hardest at work. A resident on THIS node is online, full stop.
+      const resident = new Set(this.directorySeed.filter((m) => m.active).map((m) => m.id));
+      vm = {
+        ...vm,
+        members: vm.members.map((m) => (resident.has(m.id) && !m.active ? { ...m, active: true } : m)),
+      };
+      const present = new Set(vm.members.map((m) => m.id));
+      const offRoom = [...this._directory.values()]
+        .filter((m) => !present.has(m.id))
+        .map((m) => ({ ...m, active: false }));
+      // Working minds on top, the greyed past below — sorted by liveness then
+      // recency then name ("the ONLINE users like benchy and atlas are greyed,
+      // at the bottom and doing shit" — Joel, 2026-08-30).
+      const merged = [...vm.members, ...offRoom].sort(
+        (a, b) =>
+          Number(b.active) - Number(a.active) ||
+          b.lastSeenMs - a.lastSeenMs ||
+          a.name.localeCompare(b.name),
+      );
+      vm = {
+        ...vm,
+        members: merged,
+        memberCount: merged.length,
+        activeCount: merged.filter((m) => m.active).length,
+      };
+    }
     if (this._expanded.size > 0) {
       vm = {
         ...vm,
@@ -4596,7 +4665,12 @@ export class ChatWidget extends LitElement {
         });
       }
       if (typingRows.length > 0) {
-        vm = { ...vm, messages: [...vm.messages, ...typingRows] };
+        vm = {
+          ...vm,
+          messages: [...vm.messages, ...typingRows],
+          transcript: [...vm.transcript, ...typingRows.map((r) => ({ row: 'message' as const, ...r }))],
+          isEmpty: false,
+        };
       }
       // The tile's SPEAKING ring: overlay the live token rail onto the roster
       // vitals (`speaking: 100`) for members mid-turn — the same widget-owned
@@ -4617,7 +4691,14 @@ export class ChatWidget extends LitElement {
     if (this._history.length > 0) {
       const liveIds = new Set(vm.messages.map((m) => m.id));
       const older = this._history.filter((r) => !liveIds.has(r.id));
-      if (older.length > 0) vm = { ...vm, messages: [...older, ...vm.messages] };
+      if (older.length > 0) {
+        vm = {
+          ...vm,
+          messages: [...older, ...vm.messages],
+          transcript: [...older.map((r) => ({ row: 'message' as const, ...r })), ...vm.transcript],
+          isEmpty: false,
+        };
+      }
     }
     // Error boundary: a render throw (e.g. the Content registry hitting an
     // unregistered room purpose) must be VISIBLE here, not swallowed into a Lit
@@ -4730,8 +4811,18 @@ export class ChatWidget extends LitElement {
     if (!changed.has('state') || !this.state) return;
     const prev = changed.get('state') as ChatState | undefined;
     if (prev && prev.room_id !== this.state.room_id) {
-      this._history = [];
-      this._historyExhausted = false;
+      // Activity switch = session swap. The outgoing room's live streams and
+      // scroll-back buffer are SAVED under its UUID; the incoming room's are
+      // restored (or start fresh). Nothing leaks, nothing is lost.
+      this._sessions.set(prev.room_id, {
+        typing: this._typing,
+        history: this._history,
+        historyExhausted: this._historyExhausted,
+      });
+      const sess = this._sessions.get(this.state.room_id);
+      this._typing = sess?.typing ?? new Map();
+      this._history = sess?.history ?? [];
+      this._historyExhausted = sess?.historyExhausted ?? false;
       return;
     }
     // A settled message retires the sender's typing bubble ONLY when it is

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -51,6 +51,7 @@ import {
   canvasFromEnvelope,
   systemMetricsFromEnvelope,
   type ChatState,
+  type RosterMemberVM,
 } from '@continuum/chat-view';
 
 // Importing the module registers `<chat-widget>` as a side effect; keep the
@@ -224,6 +225,81 @@ async function main(): Promise<void> {
     );
   };
   widget.closeTabHandler = closeTabHandler;
+
+  // Seed the who-panel directory from the core's own roster + the viewer —
+  // independent of the per-room presence pipe: citizens (and YOU) visible
+  // from the first frame, in every room.
+  // Self-updating client: when a new build lands on the static server, the
+  // page swaps itself — the operator never hand-refreshes to see a fix
+  // (Joel, 2026-08-30: "i shouldnt have to refresh"). The dev server HMRs on
+  // its own; this covers the preview/dist path. The current bundle name is in
+  // the served index.html; a changed hash = a new build.
+  const bundleOf = (html: string): string | undefined =>
+    /assets\/index-[\w-]+\.js/.exec(html)?.[0];
+  void (async () => {
+    let current: string | undefined;
+    try {
+      current = bundleOf(await (await fetch('/', { cache: 'no-store' })).text());
+    } catch {
+      return; // non-static host (dev HMR) — nothing to watch
+    }
+    if (current === undefined) return;
+    setInterval(() => {
+      void (async () => {
+        try {
+          const served = bundleOf(await (await fetch('/', { cache: 'no-store' })).text());
+          if (served !== undefined && served !== current) window.location.reload();
+        } catch {
+          /* server briefly away (rebuild) — next tick retries */
+        }
+      })();
+    }, 15_000);
+  })();
+
+  // The viewer is ALWAYS in the directory, synchronously — a failed roster
+  // fetch must never render the operator themself as absent/offline.
+  widget.directorySeed = [
+    {
+      id: config.senderId,
+      name: 'you',
+      kind: 'human',
+      active: true,
+      runtime: 'interactive',
+      vitals: {},
+      lastSeenMs: Date.now(),
+    },
+  ];
+  // Liveness re-polls: right after a core reboot the roster is empty while
+  // citizens respawn — a one-shot seed would freeze that emptiness forever.
+  // NOTE: `persona/roster` is the CANONICAL name — the auth gate does not yet
+  // resolve aliases (persona/list bounces off the Owner wildcard; core fix
+  // queued), so the canonical verb is load-bearing here.
+  const seedDirectory = async (): Promise<void> => {
+    try {
+      const raw = await transport.execute(buildCommandUri('persona/roster'), '{}');
+      const parsed = JSON.parse(raw) as {
+        citizens?: readonly { agent_name?: string; peer_id?: string; resident?: boolean }[];
+      };
+      const seed: RosterMemberVM[] = (parsed.citizens ?? [])
+        .filter((c) => c.peer_id)
+        .map((c) => ({
+          id: c.peer_id as string,
+          name: c.agent_name ?? (c.peer_id as string).slice(0, 8),
+          kind: 'agent',
+          active: c.resident === true,
+          runtime: '',
+          vitals: {},
+          lastSeenMs: 0,
+        }));
+      const self = widget.directorySeed.filter((m) => m.kind === 'human');
+      widget.directorySeed = [...self, ...seed];
+      widget.requestUpdate();
+    } catch (err) {
+      console.error('directory seed failed:', err);
+    }
+  };
+  void seedDirectory();
+  setInterval(() => void seedDirectory(), 30_000);
 
   // Round pause/resume from the bench rail (composed event out of the pure
   // renderer): bind to the AiSafe verbs. Fire-and-forget — the round's stage

--- a/apps/web/src/render/SysPanel.ts
+++ b/apps/web/src/render/SysPanel.ts
@@ -55,7 +55,7 @@ export class SysPanel extends LitElement {
   /** HUD auto-cycle (the far-left corner toggle): ON rotates through the
    *  enabled faces every CYCLE_MS; picking a chip PINS. Renderer state — a
    *  lens the reader holds, never projection state. */
-  private _cycle = true;
+  private _cycle = false;
 
   private _hover = false;
 

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -504,6 +504,17 @@ pub fn card_activity(card_id: Uuid) -> Option<CardActivity> {
 /// callers that hold an activity's room but not its card (the experience
 /// stream's grade-time seam). `None` = no tracked round runs a solve there
 /// (solo work, non-bench rooms).
+/// The RUN room of the round whose solve runs in `room` — the tree edge the
+/// nav rail renders (#2632): a solve activity nests under its round. `None`
+/// = no tracked round solves there (top-level activity).
+pub fn run_room_for_solve(room: Uuid) -> Option<Uuid> {
+    let rounds = ROUNDS.lock().expect("bench rounds mutex");
+    rounds
+        .values()
+        .find(|r| r.card_activities.values().any(|a| a.solve_room == room))
+        .map(|r| r.round_id)
+}
+
 pub fn team_for_room(room: Uuid) -> Option<CardActivity> {
     let rounds = ROUNDS.lock().expect("bench rounds mutex");
     rounds

--- a/core/continuum-core/src/commands/persona_roster.rs
+++ b/core/continuum-core/src/commands/persona_roster.rs
@@ -117,9 +117,12 @@ fn staged_swe_for(peer: &uuid::Uuid) -> Vec<String> {
 #[async_trait::async_trait]
 impl ActionCommand for PersonaRoster {
     const NAME: &'static str = "persona/roster";
-    // Operator/inspection surface: it exposes peer_ids and workspace staging, the same
-    // infra a curator/dispatch sees. Not a citizen-facing verb (that is room/members).
-    const ACCESS: AccessLevel = AccessLevel::Privileged;
+    // Read-only node directory: names, peer_ids, residency, staged instance NAMES.
+    // Nothing here is privileged — room/members already serves peer_ids at ai-safe,
+    // and the web desktop's who-panel seeds from this verb (2026-08-30: Privileged
+    // left the operator's own UI showing every citizen offline while four solves ran).
+    // Mutating persona verbs (despawn, reassign-model) keep their own locks.
+    const ACCESS: AccessLevel = AccessLevel::AiSafe;
     const DESCRIPTION: &'static str =
         "List the citizens currently online on this machine (the roster benchmark/dispatch \
          targets when --assignees is omitted), each with her durable peer_id and the SWE \

--- a/core/continuum-core/src/ipc/positron_nav_source.rs
+++ b/core/continuum-core/src/ipc/positron_nav_source.rs
@@ -109,12 +109,24 @@ pub fn project_nav(user: Uuid, snap: NavSnapshot) -> NavViewState {
             if let Some(ts) = a.last_read {
                 last_read.insert(a.id.clone(), ts);
             }
-            NavTab {
-                id: a.id,
-                title: a.title,
-                kind: a.kind,
-                unread: a.unread,
-                purpose: a.purpose,
+            {
+                // The tree half of #2632: a solve room nests under its run
+                // room — the round tracker already RECORDS the lineage
+                // (CardActivity.solve_room ↔ round_id), so parenthood is a
+                // lookup, never new state. The humanized label derives from
+                // the same record (instance · assignee name resolved by the
+                // renderer's roster); the raw room id keeps its identity job
+                // in `id` and retreats from the reading line.
+                let (parent_ref, display_label) = activity_lineage(&a.id, &a.title);
+                NavTab {
+                    id: a.id,
+                    title: a.title,
+                    kind: a.kind,
+                    unread: a.unread,
+                    purpose: a.purpose,
+                    parent_ref,
+                    display_label,
+                }
             }
         })
         .collect();
@@ -660,6 +672,36 @@ impl NavProjectorRegistry {
             Arc::clone(&self.reader),
         );
     }
+}
+
+
+/// The activity's tree position + humanized reading-line label (#2632 slice a).
+///
+/// Pure lookup over records the substrate already keeps: a room that hosts a
+/// tracked solve card nests under its round's run room, labeled
+/// `<instance> · <assignee-short>`. Anything untracked stays top-level with
+/// its own title — honest flat, never an invented hierarchy.
+fn activity_lineage(room_ref: &str, title: &str) -> (String, String) {
+    let Ok(room) = uuid::Uuid::parse_str(room_ref) else {
+        return (String::new(), String::new());
+    };
+    let Some(act) = crate::cognition::bench_round::team_for_room(room) else {
+        return (String::new(), String::new());
+    };
+    let Some(run_room) = crate::cognition::bench_round::run_room_for_solve(room) else {
+        return (String::new(), String::new());
+    };
+    // `swe--<instance>--<card8>` → `<instance>`; an unconventional name keeps
+    // its title (label stays honest, never lossy).
+    let instance = title
+        .strip_prefix("swe--")
+        .and_then(|rest| rest.rsplit_once("--").map(|(i, _)| i))
+        .unwrap_or(title);
+    let assignee8 = act.assignee.to_string()[..8].to_string();
+    (
+        run_room.to_string(),
+        format!("{instance} · {assignee8}"),
+    )
 }
 
 #[cfg(test)]

--- a/core/continuum-positron/src/nav.rs
+++ b/core/continuum-positron/src/nav.rs
@@ -93,6 +93,19 @@ pub struct NavTab {
     /// tab serialized before this field folds as empty, never dropped.
     #[serde(default)]
     pub purpose: String,
+    /// The PARENT activity's ref, when this activity nests under another —
+    /// a solve room under its benchmark run room, a design review under its
+    /// project (#2632: the rail is a tree, not a list). Empty = top-level.
+    /// Renderers group children under their parent; the raw ref stays a
+    /// tooltip/copy affordance, never the reading line.
+    #[serde(default)]
+    pub parent_ref: String,
+    /// Humanized label for the reading line (`django-10914 · Atlas`) when the
+    /// raw title is a substrate identifier. Empty = use `title` as-is.
+    /// Display labels humanize; URIs address; UUIDs identify — three jobs,
+    /// never conflated (Joel, 2026-08-30).
+    #[serde(default)]
+    pub display_label: String,
 }
 
 /// A pinned quick-nav target — the citizen's bookmarks (rooms, content,


### PR DESCRIPTION
The blank-UI crisis boundary: hydrated history never reached the rendered transcript (isEmpty lied), typing/history were widget-global (Benchy haunted every tab), the who-panel was a single-room presence feed instead of a directory, residency lost to lane-readiness greying, persona/roster was locked away from the operator's own desktop, and the client couldn't self-update. All six fixed and verified by perception/observe against the live core. Carries #2632 slice a (nav tree fields) which was already on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo