### PR TITLE
feat(kv): the context switch — page KV to disk on eviction, restore on return

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,27 @@ But continuum goes beyond routing. **Routing picks from what exists. continuum c
 
 ---
 
+## vs. the Harness Generation — it scales its own mind
+
+A new class of local coding harnesses (omp, Hermes-style agents, codex CLI) is winning mindshare by bolting good ideas onto disposable sessions: an "advisor" model that steers, subagents spawned per task, a vision model you configure by hand. The ideas are right. The architecture underneath them can't keep what it learns — and every one of their pain points is a symptom of that.
+
+Ask the questions their own users ask:
+
+| The question their users ask | Their answer | continuum's answer |
+|---|---|---|
+| *"When it spawns subagents, does each keep full context, or pass compact summaries?"* | Pick one; both lose. Full copies eat the RAM, summaries eat the signal. | Neither. [Citizens are persistent](#one-solution-to-continual-learning) — each holds her own **warm KV slot** on the serving lane, so "context" isn't copied or summarized, it's *resident*. Teammates share state through [rooms](#collaborative-team-delegation), not paste. |
+| *"48 GB disappears when it spawns a pile of subagents"* | It does. Every subagent is a fresh context re-prefilled from zero. | The [serving planner](#the-efficiency-engine--every-token-accounted-for) derives lane count and window from **measured demand** and re-homes the server when the plan outgrows it. Minds page; the [governor](docs/architecture/CBAR-SUBSTRATE-ARCHITECTURE.md) budgets; nothing is spawned that isn't funded. |
+| *"Are you setting a vision model or letting the advisor steer?"* | You configure it. Per tool, per machine. | Every citizen has the [same senses](#every-persona-has-a-full-sensory-system) regardless of base model — a vision-capable model sees raw pixels, a blind one gets the description service, automatically. There is no vision-model checkbox because there is no blind persona. |
+| *"2–3× slower for similar quality — too many tool calls and loops"* | The loop is the product; you live with it. | The whole perceive→think→act loop is [measured end to end](#the-efficiency-engine--every-token-accounted-for) and every slow turn's thief is named by a probe. When it's slow, the ledger says *why* — and the fix ships with the receipt. That discipline is the product. |
+| *"Deep thinking on hard stuff?"* | One model, one speed. | Task-shaped [lanes](docs/architecture/INFERENCE-LANES-REALISTIC.md): low-latency chatter during a live call, the best coding model on the solve, deep thinking scheduled where the work earns it — same citizens, same memory, different gears. |
+| *"How do I configure all this?"* | Dotfiles, flags, a wiki. | **Configuration is an activity.** Model switching, serving policy, persona setup — rooms you stand in and steer, through the same [console](docs/architecture/OBSERVABILITY-AS-SUBSTRATE.md) the citizens use. Defaults just work; power users get the levers without the dotfiles. |
+
+The deeper difference: their harness is **static** — the same subagent tree, the same context policy, the same models, until a human edits a config. Continuum **scales its own mind**: serving windows grow from measured demand, specialists are [trained when missing](#genomic-intelligence), models are adopted through a [gauntlet](#the-efficiency-engine--every-token-accounted-for) when a better one drops, and what a session learns outlives the session as [genes](#genomic-intelligence). A harness session ends and its insight dies. A citizen's insight is next week's reflex.
+
+*(Honesty, per the ledger: the loop economics above are instrumented, not finished — the same probes that named this week's thieves are public, and the beta re-measures every number on this page.)*
+
+---
+
 ## The Efficiency Engine — every token accounted for
 
 Local inference lives or dies on turn economics, so continuum treats them as an engineering discipline with [receipts](docs/architecture/OBSERVABILITY-AS-SUBSTRATE.md), not folklore. Every load-bearing decision in the serving path emits a typed [probe](docs/architecture/RTOS-DEBUGGER-PROBES.md); when something is slow, the ledger names the thief, and the fix ships the same day with the receipt that proves it worked.

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -704,13 +704,13 @@ impl OpenAICompatibleAdapter {
     async fn slot_for_activity(
         &self,
         key: crate::inference::slots::ActivityKey,
-    ) -> Option<u32> {
+    ) -> Option<crate::inference::slots::SlotPaging> {
         let root = self.endpoints().root().to_string();
         let dir = crate::inference::slots::directory();
         // Fast path: this server's state already known (process-global directory —
         // every adapter instance talking to the same server shares ONE assignment).
         match dir.get(&root) {
-            Some(Some(pool)) => return pool.lease(key).await,
+            Some(Some(pool)) => return pool.lease_paged(key).await,
             Some(None) => return None, // latched unsupported
             None => {}                 // never probed — probe below
         }
@@ -790,7 +790,53 @@ impl OpenAICompatibleAdapter {
             n_slots,
             "slot affinity enabled — activities lease llama-server slots (props-discovered)"
         );
-        pool.lease(key).await
+        pool.lease_paged(key).await
+    }
+
+    /// Execute one KV page action against the server (`/slots/{id}?action=save|restore`)
+    /// — the restore economy's context switch, ordered on the slot exactly like the
+    /// inference it brackets. Measured ~0.1s at 20k tokens; the 10s cap is for a
+    /// wedged server, not a slow page. Returns success; failures probe loudly and the
+    /// turn proceeds as a plain prefill — slower, never wrong.
+    async fn kv_page_action(
+        &self,
+        slot: u32,
+        key: &crate::inference::slots::ActivityKey,
+        action: &str,
+    ) -> bool {
+        let url = format!(
+            "{}/slots/{}?action={}",
+            self.endpoints().root().trim_end_matches('/'),
+            slot,
+            action
+        );
+        let filename = crate::inference::slots::page_filename(key);
+        let started = std::time::Instant::now();
+        let resp = self
+            .client
+            .post(&url)
+            .timeout(std::time::Duration::from_secs(10))
+            .json(&json!({ "filename": filename }))
+            .send()
+            .await;
+        let ok = matches!(&resp, Ok(r) if r.status().is_success());
+        let status = resp
+            .as_ref()
+            .map(|r| r.status().as_u16())
+            .unwrap_or(0); // 0 = transport error, distinguished from any HTTP status
+        crate::probe!(
+            class = "inference.kv_page.action",
+            action = %action,
+            slot = slot as u64,
+            persona = %key.persona,
+            room = %key.room,
+            ok,
+            status = status as u64,
+            ms = started.elapsed().as_millis() as u64,
+            "KV page context switch — save pages the evictee's state out, restore pages \
+             the returner's state in (~0.1s measured; a miss means this turn re-prefills)",
+        );
+        ok
     }
 
     pub(crate) async fn probe_lora_catalog(&self) -> Result<(), String> {
@@ -2112,8 +2158,33 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                         .and_then(|(p, r)| crate::inference::slots::ActivityKey::new(p, r));
                     match key {
                         Some(k) => {
-                            let leased = self.slot_for_activity(k).await;
-                            if leased.is_some() {
+                            let paging = self.slot_for_activity(k).await;
+                            if let Some(pg) = paging {
+                                // THE CONTEXT SWITCH (restore economy): page the
+                                // evictee's registers out, page the returner's in —
+                                // both ordered on this slot exactly like the
+                                // inference they bracket, so nothing else waits.
+                                let root = self.endpoints().root().to_string();
+                                let pool = match crate::inference::slots::directory().get(&root) {
+                                    Some(Some(pool)) => Some(pool),
+                                    _ => None,
+                                };
+                                if let Some(prev) = pg.save_first {
+                                    if self.kv_page_action(pg.slot, &prev, "save").await {
+                                        if let Some(pool) = pool.as_ref() {
+                                            pool.note_saved(prev);
+                                        }
+                                    }
+                                }
+                                if pg.restore
+                                    && !self.kv_page_action(pg.slot, &k, "restore").await
+                                {
+                                    // Dead page (geometry swept, file missing): stop
+                                    // offering it; this turn re-prefills plainly.
+                                    if let Some(pool) = pool.as_ref() {
+                                        pool.note_page_lost(&k);
+                                    }
+                                }
                                 // Price basis for the eviction policy (B5): this
                                 // activity's current prompt size, the same chars/4
                                 // estimate the overshoot alarm uses — comparable
@@ -2130,14 +2201,11 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                                             .sum::<usize>()
                                     })
                                     .unwrap_or(0) as u64; // 0 = no usage block in the reply; the estimate only prices eviction, never budgets
-                                let root = self.endpoints().root().to_string();
-                                if let Some(Some(pool)) =
-                                    crate::inference::slots::directory().get(&root)
-                                {
+                                if let Some(pool) = pool.as_ref() {
                                     pool.note_tail(&k, approx_tokens);
                                 }
                             }
-                            leased
+                            paging.map(|pg| pg.slot)
                         }
                         None => None,
                     }

--- a/core/continuum-core/src/inference/lane_args.rs
+++ b/core/continuum-core/src/inference/lane_args.rs
@@ -216,6 +216,7 @@ pub fn base_invocation(
     lanes: u32,
     total_ctx: u32,
     cache_ram_mib: u32,
+    slot_save_dir: &Path,
 ) -> LaneInvocation {
     let arg = |s: &str| s.to_string();
     LaneInvocation {
@@ -264,6 +265,17 @@ pub fn base_invocation(
             // so llama.cpp's 8 GiB default can never run un-owned again (§4).
             arg("--cache-ram"),
             cache_ram_mib.to_string(),
+            // KV DISK PAGING (restore economy, the OS-context-switch design):
+            // `/slots/{id}?action=save|restore` only works when the server was
+            // LAUNCHED with a save path, so the flag is part of the
+            // unconditional spine — a lane without it silently amputates the
+            // whole paging tier and rotation on an oversubscribed server costs
+            // a full re-prefill per turn (measured 2026-09-01: hit_rate 0.0 on
+            // every act, 35-45s each; restore of the same state measured
+            // ~0.1s). The dir is GEOMETRY-KEYED by the caller (model + per-slot
+            // ctx) so a stale page can never restore into a mismatched slot.
+            arg("--slot-save-path"),
+            slot_save_dir.to_string_lossy().into_owned(),
             // PREFILL THROUGHPUT (#139). Live personas are prefill-bound: a real turn
             // re-prefills ~4k tokens of fresh RAG context at ~109 tok/s → 30-110s turns
             // (decode is tiny and fast; the mind is NOT slow, the re-read is). The
@@ -604,7 +616,24 @@ mod tests {
             lanes,
             total_ctx,
             CACHE_RAM_MIB, // the cold-start prior — these tests pin arg shape, not sizing
+            &PathBuf::from("/tmp/kv-pages/test"),
         )
+    }
+
+    // what this catches: the KV disk-paging tier silently amputated. Slot
+    // save/restore (`/slots/{id}?action=…`) only exists when the server was
+    // LAUNCHED with `--slot-save-path`; a lane missing it turns every rotation
+    // on an oversubscribed server into a full re-prefill (hit_rate 0.0 across
+    // all acts, 2026-09-01) while the code above it believes paging works.
+    #[test]
+    fn slot_save_path_is_part_of_the_unconditional_spine() {
+        let i = inv(4, 65_536);
+        assert_eq!(
+            i.value_of("--slot-save-path"),
+            Some("/tmp/kv-pages/test"),
+            "the paging tier must be launched into existence: {:?}",
+            i.args
+        );
     }
 
     // what this catches: the window-quartering regression — `--parallel` inherited

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -24,7 +24,7 @@
 //! (single-machine first), but the snapshot is the rail it slots onto.
 
 use crate::model_registry::Model;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -771,6 +771,67 @@ pub fn port_of_base_url(url: &str) -> Option<u16> {
     let after_scheme = url.split("://").nth(1).unwrap_or(url);
     let host_port = after_scheme.split('/').next()?;
     host_port.rsplit_once(':')?.1.parse().ok()
+}
+
+/// The KV disk-page dir for one serve GEOMETRY (restore economy): a page saved
+/// under one model + per-slot window must never restore into another. The
+/// geometry is IN THE PATH so mismatch is structurally impossible — a new
+/// geometry simply reads an empty dir. Rooted under `~/.continuum/cache/`
+/// (tracked in `system_resources::disk_reporters`, eviction decided in
+/// `disk_eviction` — the no-new-cache-dir-without-an-eviction-decision law).
+pub fn kv_page_dir(model_id: &str, per_slot_ctx: u32) -> PathBuf {
+    let sanitized: String = model_id
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '.' || c == '-' { c } else { '_' })
+        .collect();
+    kv_pages_root().join(format!("{sanitized}--c{per_slot_ctx}"))
+}
+
+/// The root every geometry dir lives under — the ONE path the disk reporter
+/// tracks and the spawn sweep walks.
+pub fn kv_pages_root() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(std::env::temp_dir) // JUSTIFIED unwrap_or_else: no home dir = containerized oddity; pages in tmp still work, and the lane must not fail to spawn over cache placement
+        .join(".continuum")
+        .join("cache")
+        .join("kv-pages")
+}
+
+/// Sweep sibling GENERATIONS of the current geometry dir: same model prefix,
+/// different `--c<n>` suffix. Their pages can never be restored again (the
+/// geometry is gone), so the spawn — the one place that knows the new truth —
+/// deletes them. This is the eviction story `disk_eviction` records for
+/// `cache/kv-pages`; cross-model dirs are left for their own lanes' spawns.
+pub fn sweep_stale_page_generations(current: &Path) {
+    let (Some(parent), Some(name)) = (current.parent(), current.file_name().and_then(|n| n.to_str()))
+    else {
+        return;
+    };
+    let Some((model_prefix, _)) = name.rsplit_once("--c") else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let entry_name = entry.file_name();
+        let Some(entry_name) = entry_name.to_str() else {
+            continue;
+        };
+        if entry_name != name
+            && entry_name.starts_with(model_prefix)
+            && entry_name[model_prefix.len()..].starts_with("--c")
+        {
+            let stale = entry.path();
+            let removed = std::fs::remove_dir_all(&stale).is_ok();
+            crate::probe!(
+                class = "inference.kv_page.generation_swept",
+                dir = %stale.display(),
+                removed,
+                "stale KV page generation removed — its geometry no longer exists to restore into",
+            );
+        }
+    }
 }
 
 /// Path to the `llama-server` binary — the inference engine WE OWN, built from
@@ -2797,6 +2858,25 @@ impl LlamaServerControl for LlamaServerProcess {
             target.adapters.iter().map(|a| a.path.clone()).collect();
         let expert_ot = target.expert_ot_value();
 
+        // KV disk-paging dir (restore economy): GEOMETRY-KEYED — model + the
+        // per-slot window — so a saved page can never be restored into a slot
+        // of a different size or model (llama-server would refuse or corrupt).
+        // Stale sibling generations for the SAME model are swept at spawn: a
+        // relaunch that changed geometry orphans its old pages, and the spawn
+        // is the one place that knows the new truth. Tracked + eviction-decided
+        // in system_resources (the no-new-cache-dir-without-eviction law).
+        let slot_save_dir = kv_page_dir(&target.model.id, total_ctx / lanes.max(1));
+        if let Err(e) = std::fs::create_dir_all(&slot_save_dir) {
+            tracing::warn!(
+                probe_class = "inference.kv_page.dir_failed",
+                dir = %slot_save_dir.display(),
+                error = %e,
+                "could not create the KV page dir — the lane still serves, but rotation \
+                 pays full re-prefill (the paging tier is amputated for this serve)"
+            );
+        } else {
+            sweep_stale_page_generations(&slot_save_dir);
+        }
         let mut cmd = tokio::process::Command::new(&self.bin);
         let invocation = crate::inference::lane_args::base_invocation(
             &gguf,
@@ -2806,6 +2886,7 @@ impl LlamaServerControl for LlamaServerProcess {
             lanes,
             total_ctx,
             target.host_prompt_cache_mib,
+            &slot_save_dir,
         )
         .with_options(&crate::inference::lane_args::LaneOptions {
             kv_cache_type: kv_cache_type.as_deref(),

--- a/core/continuum-core/src/inference/slots.rs
+++ b/core/continuum-core/src/inference/slots.rs
@@ -162,6 +162,41 @@ pub struct KvSlotPool {
     /// evict a citizen's warm tail. `None` on small servers (≤2 slots): there,
     /// non-Turn traffic goes unpinned with `cache_prompt: false` instead.
     scratch: Option<u32>,
+    /// slot index → the activity whose KV last WARMED that slot. This is the
+    /// paging ledger's "who is resident" half: when a lease hands a slot to a
+    /// DIFFERENT activity, the previous holder's KV is still physically in the
+    /// server slot and must be SAVED to its disk page before the new turn
+    /// overwrites it. Tiny map (n_slots entries), cold path (one pin per turn).
+    holders: Mutex<std::collections::HashMap<u32, ActivityKey>>,
+    /// Activities with a valid KV page on disk (written via
+    /// `/slots/{id}?action=save` under the lane's `--slot-save-path`). The
+    /// restore half of the ledger: a re-entering activity whose slot was
+    /// recycled restores its page (~0.1s measured at 20k tokens) instead of
+    /// re-prefilling (~35s at 22k — the 330× cliff the restore economy names).
+    saved: Mutex<std::collections::HashSet<ActivityKey>>,
+}
+
+/// What a Turn must do AROUND its request to honor the KV paging design — the
+/// OS-context-switch shape (Joel: "many threads but one at a time … they page
+/// in and out per persona"). Both actions are ordered on the slot itself, the
+/// same FIFO inference already imposes; nothing else waits on them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SlotPaging {
+    pub slot: u32,
+    /// A different activity's KV is still resident in this slot — save it to
+    /// its disk page BEFORE the new turn's prefill overwrites it.
+    pub save_first: Option<ActivityKey>,
+    /// This activity has a page on disk and the slot does not currently hold
+    /// its (fresher) KV — restore the page before the turn.
+    pub restore: bool,
+}
+
+/// The page filename for an activity — stable across processes, one file per
+/// activity, overwritten on each save. Lives under the lane's geometry-keyed
+/// `--slot-save-path` dir, so a page can never be restored into a slot with a
+/// different context size or model.
+pub fn page_filename(key: &ActivityKey) -> String {
+    format!("a-{}-{}.bin", key.persona.simple(), key.room.simple())
 }
 
 impl KvSlotPool {
@@ -216,6 +251,8 @@ impl KvSlotPool {
             free,
             n_slots,
             scratch,
+            holders: Mutex::new(std::collections::HashMap::new()),
+            saved: Mutex::new(std::collections::HashSet::new()),
         }
     }
 
@@ -297,6 +334,43 @@ impl KvSlotPool {
             }
         }
         None
+    }
+
+    /// [`Self::lease`] plus the paging ledger: who to SAVE before this turn
+    /// overwrites the slot, and whether to RESTORE this activity's own page.
+    ///
+    /// The rules, in order:
+    /// - slot still holds THIS activity (warm re-lease) → no save, no restore:
+    ///   the in-slot KV is fresher than any page on disk.
+    /// - slot last warmed a DIFFERENT activity → save THEIRS first (their KV is
+    ///   physically still in the server slot), then restore OURS if a page
+    ///   exists.
+    /// - slot holder unknown (fresh pool over a pre-existing server) → restore
+    ///   ours if a page exists; nothing known to save.
+    pub async fn lease_paged(&self, key: ActivityKey) -> Option<SlotPaging> {
+        let slot = self.lease(key).await?;
+        let prev = self.holders.lock().insert(slot, key);
+        let save_first = prev.filter(|p| *p != key);
+        let slot_holds_ours = prev == Some(key);
+        let restore = !slot_holds_ours && self.saved.lock().contains(&key);
+        Some(SlotPaging {
+            slot,
+            save_first,
+            restore,
+        })
+    }
+
+    /// Record that `key`'s page was successfully written to disk — it becomes
+    /// restorable. Called by the adapter AFTER the save HTTP call succeeds.
+    pub fn note_saved(&self, key: ActivityKey) {
+        self.saved.lock().insert(key);
+    }
+
+    /// The page turned out unusable (restore failed: file gone, geometry
+    /// mismatch) — stop offering it so the turn falls back to a plain prefill
+    /// instead of retrying a dead restore every pin.
+    pub fn note_page_lost(&self, key: &ActivityKey) {
+        self.saved.lock().remove(key);
     }
 }
 
@@ -404,6 +478,50 @@ mod tests {
         assert_ne!(c, a, "c must not steal the warm slot that was just refreshed");
         // And the evicted activity can come back (cold) on whatever frees next.
         let _ = pool.lease(key(1, 2)).await.expect("evicted activity re-leases");
+    }
+
+    // what this catches: the paging ledger around slot recycling (the restore-
+    // economy context switch). A recycled slot must (1) name the previous
+    // holder for SAVE before the new turn overwrites their KV, (2) offer
+    // RESTORE only to an activity with a written page whose KV is not already
+    // in the slot, (3) never save/restore on a warm same-holder re-lease, and
+    // (4) stop offering a page after note_page_lost. Without (1) rotation on
+    // an oversubscribed server is a full re-prefill per turn — measured live
+    // 2026-09-01 as hit_rate 0.0 across every act, 35-45s prefill each.
+    #[tokio::test]
+    async fn slot_recycling_pages_the_evictee_out_and_the_returner_in() {
+        let pool = KvSlotPool::new("test", 2); // 2 slots, no scratch
+        let a = key(1, 1);
+        let b = key(1, 2);
+        let c = key(1, 3);
+        let pa = pool.lease_paged(a).await.expect("a");
+        assert_eq!(pa.save_first, None, "fresh slot: nobody to save");
+        assert!(!pa.restore, "no page written yet");
+        // Warm re-lease: same holder, nothing to page either way.
+        let pa2 = pool.lease_paged(a).await.expect("a warm");
+        assert_eq!(pa2.slot, pa.slot);
+        assert_eq!(pa2.save_first, None, "same holder — no save");
+        assert!(!pa2.restore, "slot already holds a's fresher KV — no restore");
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        let _pb = pool.lease_paged(b).await.expect("b");
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        // c arrives on a full pool: someone (LRU = a) is evicted; the paging
+        // ledger must name the previous holder of the recycled slot for save.
+        let pc = pool.lease_paged(c).await.expect("c");
+        assert_eq!(pc.save_first, Some(a), "the evictee's KV must be saved before overwrite");
+        pool.note_saved(a); // adapter reports the save HTTP call succeeded
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        // a returns: her slot was recycled, but she has a page → restore.
+        let pa3 = pool.lease_paged(a).await.expect("a returns");
+        assert!(pa3.restore, "a has a page and the slot holds someone else's KV");
+        // A dead page stops being offered.
+        pool.note_page_lost(&a);
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        let _ = pool.lease_paged(b).await.expect("b again");
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        let pa4 = pool.lease_paged(a).await.expect("a after lost page");
+        assert!(!pa4.restore, "a lost page must not be offered again");
+        assert_eq!(page_filename(&a), format!("a-{}-{}.bin", a.persona.simple(), a.room.simple()));
     }
 
     // what this catches: the scratch reservation and the placement law. On a

--- a/core/continuum-core/src/system_resources/disk_eviction.rs
+++ b/core/continuum-core/src/system_resources/disk_eviction.rs
@@ -724,6 +724,22 @@ mod tests {
                 "#155: broker-reachable pool over cognition/eval::live_eval_roots(); \
                  sweep + RAII already own the steady state and the crash path",
             ),
+            // Steady-state owner ALREADY EXISTS at lane spawn:
+            // `inference::llama_server::sweep_stale_page_generations` deletes every
+            // sibling geometry the moment a serve's geometry changes — a page whose
+            // slot size no longer exists can never be restored, so the sweep is
+            // reference-safe by construction, and within a live geometry each
+            // activity owns ONE file that saves overwrite in place (count bounded
+            // by residents × rooms). Deferred only for the broker seam: under real
+            // disk pressure the broker cannot yet claw back the CURRENT
+            // generation's pages — that wants a pool that asks the slot pool which
+            // activities are resident (their pages are one eviction from being
+            // needed) versus departed, never a blind LRU.
+            (
+                "kv-pages",
+                "#155: broker-reachable pool keyed on slot-pool residency; the \
+                 spawn-time generation sweep already owns the stale-geometry path",
+            ),
         ];
         use super::super::disk_pressure::DiskReporter as _;
         for dir in super::super::disk_reporters::standard_tracked_dirs(Path::new("/h")) {

--- a/core/continuum-core/src/system_resources/disk_reporters.rs
+++ b/core/continuum-core/src/system_resources/disk_reporters.rs
@@ -228,6 +228,15 @@ pub fn standard_tracked_dirs(home: &std::path::Path) -> Vec<Arc<TrackedDir>> {
         // bounded by operator attention in practice — tracked so "in practice"
         // never becomes the 2026-07-13 silent-class shape.
         TrackedDir::new("eval-captures", home.join(".continuum/eval-captures")),
+        // KV disk pages (restore economy): one file per activity, overwritten on
+        // each save, under a GEOMETRY-KEYED subdir per serve (model + per-slot
+        // ctx). Bounded by residents × rooms per geometry; stale geometry
+        // generations are swept at lane spawn
+        // (`inference::llama_server::sweep_stale_page_generations` — the owner
+        // of this class's eviction decision). A page at 20-40k tokens of q8_0
+        // KV is hundreds of MB, so the class is small in COUNT but real in
+        // bytes — exactly what must never be an untracked writer.
+        TrackedDir::new("kv-pages", home.join(".continuum/cache/kv-pages")),
     ];
     // Present only when its real location is KNOWN (see the warn above). Kept
     // CONDITIONAL rather than defaulted: fabricating a path here is how a class


### PR DESCRIPTION
## The designed tier that was never wired

The restore economy's whole premise — many personas context-switching over few slots like OS threads over registers, near-instant page-in/out — hinges on llama-server's slot save/restore. That needs `--slot-save-path` at launch and explicit `/slots/{id}?action=save|restore` calls. The tree had **zero references to either**. Every rotation was a full re-prefill: last night's measured hit_rate 0.0 on every act, 35–45s prefill each, decodes starved to 2–7 t/s.

## What lands

- **`--slot-save-path`** in the unconditional lane spine, geometry-keyed dir (model + per-slot ctx) so pages can't restore into mismatched slots; stale generations swept at spawn.
- **Paging ledger** in `slots.rs`: `lease_paged()` names the evictee to save and whether the returner restores; warm re-leases do neither.
- **Adapter performs the switch** around the Turn pin — ordered on the slot, exactly the FIFO inference already imposes; nothing else waits. Probed: `inference.kv_page.action`.
- **kv-pages** tracked + eviction-decided (spawn sweep owns stale geometries; broker pool deferred under #155).

Companion to #2717 (re-home guard counts lanes). Together: plans actuate, and when residents still exceed slots, rotation costs ~0.1s instead of ~35s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo