### PR TITLE
fix(kv): the remaining layers — header-true KV rate, recall to the tail, the split applied for real

### DIFF
--- a/core/continuum-core/src/cognition/deliberation_prompt.rs
+++ b/core/continuum-core/src/cognition/deliberation_prompt.rs
@@ -96,11 +96,27 @@ pub(super) fn compose_split(p: &SystemPromptParts<'_>) -> ComposedSystemPrompt {
     for block in stable_blocks(p) {
         stable.push_str(&block);
     }
-    let mut trailing = String::with_capacity(p.context.len() + 512);
-    for block in volatile_blocks(p) {
+    ComposedSystemPrompt {
+        stable,
+        trailing: compose_trailing(p.now_ms, p.self_initiated, p.directed, p.holds_live_work),
+    }
+}
+
+/// The volatile framing alone — clock + own-time/presence — composable WITHOUT
+/// the assembled context, because none of its blocks read it. This is what lets
+/// the live prompt path render the framing as a conversation turn (facts-phase,
+/// before the ask) while the stable half still waits for the fitted context.
+pub(super) fn compose_trailing(
+    now_ms: Option<u64>,
+    self_initiated: bool,
+    directed: bool,
+    holds_live_work: bool,
+) -> String {
+    let mut trailing = String::with_capacity(512);
+    for block in volatile_blocks(now_ms, self_initiated, directed, holds_live_work) {
         trailing.push_str(&block);
     }
-    ComposedSystemPrompt { stable, trailing }
+    trailing
 }
 
 /// Assemble the WHOLE system prompt as one string — `stable ++ trailing`, byte-identical
@@ -152,7 +168,12 @@ fn stable_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow<'
 /// It MUST NOT sit in the cacheable system prefix; the message builder renders it as the
 /// newest trailing turn — same text, nearest generation (the #205 trailing placement),
 /// where its volatility no longer invalidates the cached identity + tools + context prefix.
-fn volatile_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow<'a, str>> {
+fn volatile_blocks(
+    now_ms: Option<u64>,
+    self_initiated: bool,
+    directed: bool,
+    holds_live_work: bool,
+) -> impl Iterator<Item = Cow<'static, str>> {
     [
         // Her NOW — a one-line clock (minute granularity). MOVED out of the stable
         // prefix (plan B4): it sat LAST in the stable blocks, priced as "at most one
@@ -164,7 +185,7 @@ fn volatile_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow
         // a clock is the cheapest thing to keep OUT of it. Here it rides the volatile
         // framing that renders as the newest trailing turn: same temporal grounding,
         // nearest generation, zero prefix invalidation. Eval passes its pinned epoch.
-        p.now_ms
+        now_ms
             .and_then(|ms| chrono::DateTime::from_timestamp_millis(ms as i64))
             .map(|dt| {
                 Cow::Owned(format!(
@@ -173,7 +194,7 @@ fn volatile_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow
                 ))
             }),
         // Self-directed free time — only on a self-initiated heartbeat turn.
-        p.self_initiated.then_some(Cow::Borrowed(OWN_TIME_BLOCK)),
+        self_initiated.then_some(Cow::Borrowed(OWN_TIME_BLOCK)),
         // Conversational presence — the AMBIENT block on undirected turns; the DIRECTED
         // variant when a message names her. Directed no longer strips her choice entirely:
         // never ghost a QUESTION (explicit in the block), but a pure appreciation/closing
@@ -184,9 +205,9 @@ fn volatile_blocks<'a>(p: &'a SystemPromptParts<'a>) -> impl Iterator<Item = Cow
         // 2026-08-07: four citizens with perfect windows yielded every ambient turn
         // under the conversational contract while acting fine under the eval
         // harness's work framing — the contract was the variable, not the model).
-        Some(Cow::Borrowed(if p.directed {
+        Some(Cow::Borrowed(if directed {
             crate::persona::prompt_assembly::DIRECTED_PRESENCE_BLOCK
-        } else if p.holds_live_work {
+        } else if holds_live_work {
             crate::persona::prompt_assembly::WORKING_PRESENCE_BLOCK
         } else {
             SILENCE_AFFORDANCE_BLOCK

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -1492,7 +1492,19 @@ impl LlmDeliberationFaculty {
             .unwrap_or(0)
             .min(after_framing / 2);
         let msg_budget = after_framing.saturating_sub(ctx_floor);
-        let all_messages = self.messages_unfitted(ws);
+        // The volatile framing (clock + own-time/presence) rides the FACTS phase
+        // of the conversation — flicker-class content, before the ask — never the
+        // system message it invalidated on every act (see the split note below).
+        let trailing_framing = deliberation_prompt::compose_trailing(
+            ws.now_ms,
+            ws.self_initiated,
+            ws.directed_at_self,
+            holds_live_work,
+        );
+        let all_messages = self.messages_unfitted(
+            ws,
+            (!trailing_framing.is_empty()).then_some(trailing_framing.as_str()),
+        );
 
         // WHAT THIS TURN WOULD HAVE COST WITH NO BUDGET — recorded before either
         // fitting step throws the evidence away, and deliberately free to exceed
@@ -1565,26 +1577,36 @@ impl LlmDeliberationFaculty {
             ),
         );
 
-        // #266 KV-cache fix lives in the block ORDER (see `deliberation_prompt::stable_blocks`
-        // and `volatile_blocks`, assembled by `compose_split`):
-        // the per-turn presence/own-time framing now renders LAST in the system message,
-        // AFTER the standing grounding context, instead of before it. The raw
-        // prompt-captures caught the framing sitting at char ~7607, ahead of the context,
-        // so every directed/silence flip shortened the reusable KV prefix to ~7.6k chars
-        // and re-prefilled the whole tail. With the framing last, the served slot's reused
-        // prefix now extends through identity + tools + the stable head of the grounding —
-        // the framing flip falls past it and costs only its own short re-prefill. The ask
-        // stays the last CONVERSATION turn (framing is system-role instruction, not a
-        // conversation message), so nothing pulls the model off the freshest peer turn.
+        // #266 KV-cache fix, THE SPLIT ACTUALLY APPLIED. The split composer
+        // existed and its own docs called it "the live path" — but this view
+        // was still built with `compose_system_holding` (stable ++ trailing in
+        // ONE system message), so the [now] minute clock and the presence/
+        // own-time flip kept churning the system prefix at char ~8.4k. Wire-
+        // capture diff 2026-09-01: consecutive turns diverged exactly at
+        // `[now …]` / `[Conversational Presence]`→`[Your own time]`, with the
+        // server's reuse proven perfect the same hour (same prompt ×2 on one
+        // slot → cache_n 397/401). A prefix that mutates every act caches
+        // nothing; hit_rate was 0.0 fleet-wide with every persona on her OWN
+        // slot ([[a-mutating-system-prompt-destroys-kv-reuse-for-everything-after-it]]).
+        //
+        // Now: `stable` (identity + tools + grounding context) IS the system
+        // message; `trailing` (clock + presence framing) rides as the NEWEST
+        // user turn — same text, nearest generation, zero prefix invalidation.
+        // Same delivery the `.trailing()` contributions already use and test.
+        // The trailing half was already rendered into the FACTS phase of the
+        // conversation by `messages_unfitted` (before the ask, parrot order
+        // preserved); only the byte-stable half may touch the system message.
         DeliberationPromptView {
-            system: self.compose_system_holding(
-                &context,
-                &expanded,
-                ws.directed_at_self,
-                ws.self_initiated,
-                ws.now_ms,
-                holds_live_work,
-            ),
+            system: self
+                .compose_system_split(
+                    &context,
+                    &expanded,
+                    ws.directed_at_self,
+                    ws.self_initiated,
+                    ws.now_ms,
+                    holds_live_work,
+                )
+                .stable,
             messages,
         }
     }
@@ -1622,7 +1644,7 @@ impl LlmDeliberationFaculty {
     /// so it neither bleeds identity nor replays the transcript (the echo-loop root
     /// cause — PERSONA-COGNITION-PIPELINE §7.5).
     fn messages_within(&self, ws: &Workspace, budget_tokens: usize) -> Vec<ChatMessage> {
-        self.fit_messages(self.messages_unfitted(ws), budget_tokens)
+        self.fit_messages(self.messages_unfitted(ws, None), budget_tokens)
     }
 
     /// The conversation as it stands BEFORE any budget is applied — every turn, every
@@ -1633,7 +1655,11 @@ impl LlmDeliberationFaculty {
     /// it has run the question "how much did this turn actually want?" is
     /// unanswerable — which is precisely why the served window had to be sized by a
     /// constant instead of by demand. [`super::working_set`] measures this.
-    fn messages_unfitted(&self, ws: &Workspace) -> Vec<ChatMessage> {
+    fn messages_unfitted(
+        &self,
+        ws: &Workspace,
+        trailing_framing: Option<&str>,
+    ) -> Vec<ChatMessage> {
         // Collapse consecutive same-role turns into one message each (chronological).
         // Her OWN near-duplicate turns are DROPPED after the first: replaying
         // `assistant: X` three times teaches the model that repeating X is its
@@ -1828,6 +1854,16 @@ impl LlmDeliberationFaculty {
         // immediately before the ask (parrot-fix order preserved).
         for fact in facts {
             messages.push(ChatMessage::text("user", fact));
+        }
+        // The volatile framing (clock + own-time/presence flip) — same flicker
+        // class as the facts, so it rides HERE: before the ask (the parrot-fix
+        // order), after everything stable. It lived at the tail of the system
+        // message until 2026-09-01, where its per-act mutation (the [now]
+        // minute tick, DIRECTED↔SILENCE) invalidated the KV prefix behind it
+        // on nearly every act — hit_rate 0.0 with per-resident slots and a
+        // server whose reuse measured perfect the same hour.
+        if let Some(framing) = trailing_framing {
+            messages.push(ChatMessage::text("user", framing.to_string()));
         }
         if let Some(ask) = ask {
             messages.push(ask);
@@ -3655,27 +3691,29 @@ mod tests {
             let undirected = faculty.prompt_view(&with_grounding(false));
             let directed = faculty.prompt_view(&with_grounding(true));
 
-            // The longest shared leading run of the two system messages IS the KV prefix
-            // the served slot reuses across the flip.
-            let common_len = directed
-                .system
-                .bytes()
-                .zip(undirected.system.bytes())
-                .take_while(|(a, b)| a == b)
-                .count();
-            let reusable_prefix = &directed.system[..common_len];
-            assert!(
-                reusable_prefix.contains("[What you are working with"),
-                "the reusable KV prefix must extend THROUGH the grounding context — the \
-                 framing flip falls after it (#266). prefix ended at byte {common_len}:\n{reusable_prefix}"
+            // 2026-09-01, the full fix: the system message is now the STABLE half
+            // only, so the directedness flip cannot touch it AT ALL — the two
+            // system messages are byte-identical, and the entire system prefix
+            // (identity + tools + grounding) is reusable KV across the flip.
+            assert_eq!(
+                directed.system, undirected.system,
+                "the system message is the stable half — a presence flip must not move a byte of it"
             );
-            // The presence variants diverge only in the tail past that prefix, and stay in
-            // the system message (framing is system-role instruction, not a conversation
-            // turn — so the ask remains the last conversation message).
             assert!(
-                directed.system.contains("This message names you")
-                    && !undirected.system.contains("This message names you"),
-                "the directed presence variant renders in the system tail, past the reusable prefix"
+                directed.system.contains("[What you are working with"),
+                "grounding context stays in the (fully reusable) system prefix"
+            );
+            // The presence variants ride the conversation tail (facts phase,
+            // before the ask) — directed carries its marker, undirected does not.
+            let tail_has = |v: &DeliberationPromptView, needle: &str| {
+                v.messages.iter().any(
+                    |m| matches!(&m.content, crate::ai::types::MessageContent::Text(t) if t.contains(needle)),
+                )
+            };
+            assert!(
+                tail_has(&directed, "This message names you")
+                    && !tail_has(&undirected, "This message names you"),
+                "the directed presence variant renders as a conversation turn, never in the system prefix"
             );
         }
 
@@ -4166,9 +4204,11 @@ mod tests {
             // WorkingMemory (this harness faculty has none), so no ledger
             // message here — the ledger-specific behavior is pinned in
             // steps_ledger_renders_receipts_and_explicit_zero_case below.
+            // …plus the volatile presence-framing turn (2026-09-01: it rides the
+            // facts phase instead of churning the system prefix), still ask-last.
             assert_eq!(
                 roles,
-                vec!["user", "assistant", "user", "user"],
+                vec!["user", "assistant", "user", "user", "user"],
                 "view: {view:?}"
             );
             assert!(
@@ -4821,35 +4861,48 @@ mod tests {
         // output is never filtered.
         #[test]
         fn directed_turn_withholds_the_silence_escape() {
+            use crate::ai::types::MessageContent;
             let adapter = Arc::new(ScriptedAdapter::new(vec![]));
             let faculty =
                 LlmDeliberationFaculty::new(Uuid::new_v4(), "Asha", "You are Asha.", adapter);
+            // 2026-09-01: presence framing rides the conversation tail (the KV
+            // split applied for real), so these assertions read the WHOLE
+            // delivered prompt — system + turns — not the system string alone.
+            let whole = |v: &DeliberationPromptView| {
+                let mut s = v.system.clone();
+                for m in &v.messages {
+                    if let MessageContent::Text(t) = &m.content {
+                        s.push('\n');
+                        s.push_str(t);
+                    }
+                }
+                s
+            };
 
-            let ambient = faculty.prompt_view(&Workspace::new("just some room chatter"));
+            let ambient = whole(&faculty.prompt_view(&Workspace::new("just some room chatter")));
             assert!(
-                ambient.system.contains("[Conversational Presence]"),
+                ambient.contains("[Conversational Presence]"),
                 "an ambient turn carries the presence/PASS affordance block"
             );
             assert!(
-                !ambient.system.contains("stay silent"),
+                !ambient.contains("stay silent"),
                 "the turn-taking block is posture-neutral — no 'stay silent' nudge"
             );
 
-            let directed =
-                faculty.prompt_view(&Workspace::new("answer me: what is 2+2?").directed(true));
+            let directed = whole(
+                &faculty.prompt_view(&Workspace::new("answer me: what is 2+2?").directed(true)),
+            );
             assert!(
-                directed.system.contains("This message names you"),
+                directed.contains("This message names you"),
                 "a directed turn carries the DIRECTED presence variant (never ghost a \
                  question; a pure pleasantry may rest — the natural spiral-break)"
             );
             assert!(
-                !directed
-                    .system
-                    .contains("do not need to be addressed by name"),
+                !directed.contains("do not need to be addressed by name"),
                 "a directed turn never carries the ambient block"
             );
             assert!(
-                !directed.system.contains("stay silent"),
+                !directed.contains("stay silent"),
                 "and carries no 'stay silent' nudge on a directed turn either"
             );
         }

--- a/core/continuum-core/src/cognition/recall_faculty.rs
+++ b/core/continuum-core/src/cognition/recall_faculty.rs
@@ -673,12 +673,21 @@ impl Faculty for RecallFaculty {
             }
         );
 
-        Some(Contribution::context(
-            FacultyId::Recall,
-            content,
-            top_salience,
-            reasoning,
-        ))
+        Some(
+            Contribution::context(FacultyId::Recall, content, top_salience, reasoning)
+                // TRAILING, not stable: recall is re-scored EVERY turn (salience ×
+                // recency, new engrams admitted between turns), so its block churns
+                // mid-list — measured 2026-09-01 as the system prompt mutating at
+                // char ~8.5k between consecutive turns (an insert + a re-fit that
+                // shrank the head 12.3k→10.7k), which invalidated the entire KV
+                // prefix behind it: hit_rate 0.0 with every persona on her OWN
+                // slot and the server's reuse proven perfect the same hour (test
+                // prompt ×2 → cache_n 397/401). The stable_blocks doc already
+                // promises "recall … is separated out as its own .trailing()
+                // turns (#205)"; this makes that promise true for FacultyId::
+                // Recall ([[a-mutating-system-prompt-destroys-kv-reuse-for-everything-after-it]]).
+                .trailing(),
+        )
     }
 }
 
@@ -945,6 +954,10 @@ mod tests {
             .expect("recall should bid when the store is non-empty");
         assert_eq!(c.faculty, FacultyId::Recall);
         assert!(c.decision.is_none(), "recall is context, never a verdict");
+        // Regression for the 2026-09-01 KV-prefix churn: recall is re-scored
+        // every turn, so it must render TRAILING (nearest generation), never in
+        // the cacheable system prefix it would invalidate on every mutation.
+        assert!(c.trailing, "recall must ride the volatile tail, not the stable head");
         // The most salient engram (highest index in the fixture) leads.
         assert!(
             c.content.contains("memory body number 4"),

--- a/core/continuum-core/src/inference_capability/gguf_keys.rs
+++ b/core/continuum-core/src/inference_capability/gguf_keys.rs
@@ -92,6 +92,87 @@ pub fn attention_head_count_kv_per_layer(ct: &Content, arch: &str) -> Option<Vec
     }
 }
 
+/// `{arch}.attention.head_count_kv` in its SCALAR form — uniform models.
+/// `None` for the per-layer array form (see
+/// [`attention_head_count_kv_per_layer`]) or a missing key.
+pub fn attention_head_count_kv_scalar(ct: &Content, arch: &str) -> Option<u32> {
+    match ct
+        .metadata
+        .get(&format!("{arch}.attention.head_count_kv"))?
+    {
+        Value::Array(_) => None,
+        v => v.to_u32().ok(),
+    }
+}
+
+/// `{arch}.attention.head_count` — the query-head count. Needed only as the
+/// divisor when deriving head_dim from `embedding_length` (exporters that
+/// omit `attention.key_length`).
+pub fn attention_head_count(ct: &Content, arch: &str) -> Option<u32> {
+    ct.metadata
+        .get(&format!("{arch}.attention.head_count"))
+        .and_then(|v| v.to_u32().ok())
+}
+
+/// `{arch}.attention.key_length` — the per-head key dimension, written by
+/// exporters whose head_dim ≠ embedding/heads (GQA with widened heads, MLA).
+pub fn attention_key_length(ct: &Content, arch: &str) -> Option<u32> {
+    ct.metadata
+        .get(&format!("{arch}.attention.key_length"))
+        .and_then(|v| v.to_u32().ok())
+}
+
+/// `{arch}.attention.value_length` — per-head value dimension; absent means
+/// "same as key_length" for every exporter observed.
+pub fn attention_value_length(ct: &Content, arch: &str) -> Option<u32> {
+    ct.metadata
+        .get(&format!("{arch}.attention.value_length"))
+        .and_then(|v| v.to_u32().ok())
+}
+
+/// `{arch}.embedding_length` — the model width; head_dim fallback divisor.
+pub fn embedding_length(ct: &Content, arch: &str) -> Option<u32> {
+    ct.metadata
+        .get(&format!("{arch}.embedding_length"))
+        .and_then(|v| v.to_u32().ok())
+}
+
+/// The artifact's OWN f16 KV bytes/token — Σ over layers of
+/// `kv_heads × (key_len + value_len) × 2 bytes` — from the header's declared
+/// geometry, no family knowledge, no size heuristic.
+///
+/// Why this exists (measured 2026-09-01): the planner's `weights/80_000`
+/// KV-rate heuristic read a 35B fine-grained MoE at ~244 KB/token where the
+/// artifact's real geometry is ~61 KB f16 (~30 KB served at q8_0, confirmed
+/// against llama-server's own prompt-cache entry sizes). Expert weights add
+/// ZERO KV, so any weights-scaled guess over-charges MoE models ~4×; the
+/// inflation starved the host prompt cache to one mind's worth (686 MiB) AND
+/// capped the lane grant below resident demand — one wrong constant, both
+/// symptoms. The header knows; ask the header.
+///
+/// Per-layer `head_count_kv` arrays (hybrid recurrent models) are summed with
+/// zeros counting zero — recurrent layers hold no per-token KV, which is
+/// exactly what their zero declares.
+pub fn kv_bytes_per_token_f16(ct: &Content, arch: &str) -> Option<u64> {
+    let key_len = attention_key_length(ct, arch)
+        .or_else(|| {
+            let width = embedding_length(ct, arch)?;
+            let heads = attention_head_count(ct, arch)?;
+            (heads > 0).then(|| width / heads)
+        })? as u64;
+    let value_len = attention_value_length(ct, arch).map(|v| v as u64).unwrap_or(key_len); // unwrap_or: absent value_length means symmetric heads — every observed exporter's convention, not a guess over a present-but-unreadable key
+    let per_head = (key_len + value_len).saturating_mul(2); // f16 = 2 bytes/element
+    let total_kv_heads: u64 = match attention_head_count_kv_per_layer(ct, arch) {
+        Some(per_layer) => per_layer.into_iter().map(|h| h as u64).sum(),
+        None => {
+            let uniform = attention_head_count_kv_scalar(ct, arch)? as u64;
+            uniform.saturating_mul(block_count(ct, arch)? as u64)
+        }
+    };
+    let rate = total_kv_heads.saturating_mul(per_head);
+    (rate > 0).then_some(rate)
+}
+
 /// `{arch}.expert_count` — the total number of routed experts in an MoE
 /// model (e.g. 896 for a K3-class model, 128 for a Qwen3-MoE). `None` on a
 /// dense model that never wrote the key — the caller's cue to treat the
@@ -191,6 +272,60 @@ mod tests {
 
         let empty = content_with(vec![]);
         assert_eq!(architecture(&empty), None);
+    }
+
+    // what this catches: the KV rate comes from the artifact's DECLARED
+    // geometry, never a weights-scaled guess (2026-09-01: the guess read a
+    // 35B MoE at ~4× its real rate — experts add weights, zero KV — which
+    // starved --cache-ram to one mind and under-granted lanes). Three shapes:
+    // uniform scalar GQA, per-layer array with recurrent zeros (each zero
+    // contributes zero KV), and the key_length-absent fallback (head_dim =
+    // embedding/heads). Missing geometry = None, never a fabricated rate.
+    #[test]
+    fn kv_rate_reads_declared_geometry_for_all_three_header_shapes() {
+        // Uniform GQA: 48 layers × 4 kv-heads × (128+128) dims × 2 bytes.
+        let uniform = content_with(vec![
+            ("qwen3.block_count", Value::U32(48)),
+            ("qwen3.attention.head_count_kv", Value::U32(4)),
+            ("qwen3.attention.key_length", Value::U32(128)),
+        ]);
+        assert_eq!(
+            kv_bytes_per_token_f16(&uniform, "qwen3"),
+            Some(48 * 4 * (128 + 128) * 2)
+        );
+        // Per-layer array with recurrent zeros: only the 2 attention layers
+        // (8 heads each) hold KV; the zeros are SSM layers and count nothing.
+        let hybrid = content_with(vec![
+            ("kimi.block_count", Value::U32(4)),
+            (
+                "kimi.attention.head_count_kv",
+                Value::Array(vec![
+                    Value::U32(0),
+                    Value::U32(8),
+                    Value::U32(0),
+                    Value::U32(8),
+                ]),
+            ),
+            ("kimi.attention.key_length", Value::U32(64)),
+        ]);
+        assert_eq!(
+            kv_bytes_per_token_f16(&hybrid, "kimi"),
+            Some(16 * (64 + 64) * 2)
+        );
+        // key_length absent → head_dim = embedding / head_count.
+        let derived = content_with(vec![
+            ("llama.block_count", Value::U32(2)),
+            ("llama.attention.head_count_kv", Value::U32(2)),
+            ("llama.attention.head_count", Value::U32(32)),
+            ("llama.embedding_length", Value::U32(4096)),
+        ]);
+        assert_eq!(
+            kv_bytes_per_token_f16(&derived, "llama"),
+            Some(2 * 2 * (128 + 128) * 2)
+        );
+        // No geometry at all → None (the weights heuristic stands upstream).
+        let bare = content_with(vec![("x.block_count", Value::U32(10))]);
+        assert_eq!(kv_bytes_per_token_f16(&bare, "x"), None);
     }
 
     // what this catches: THE reason this module exists — the context_length

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -3534,7 +3534,49 @@ pub fn footprint_for(model: &Model) -> Option<ModelFootprint> {
         ctx_ceiling,
         model.has(Capability::ToolUse),
     )?;
+    // THE ARTIFACT'S OWN KV GEOMETRY beats the weights-scaled guess. Measured
+    // 2026-09-01: the heuristic read a 35B fine-grained MoE at ~244 KB/token
+    // (experts add weights, zero KV) where the header declares ~61 KB f16 —
+    // and the 4× inflation starved --cache-ram to ONE mind's worth (686 MiB,
+    // every restore a miss, hit_rate 0.0 fleet-wide) AND under-granted lanes
+    // vs resident demand. Header read is memoized per path: this runs on the
+    // governor's accounting tick and a GGUF header parse is real I/O.
+    if let Some(path) = crate::model_registry::artifacts::resolve_gguf_for_model(model) {
+        if let Some(rate) = kv_rate_from_header_cached(&path) {
+            fp.kv_per_token = rate;
+        }
+    }
     Some(apply_kv_quantization(fp))
+}
+
+/// Memoized `gguf_keys::kv_bytes_per_token_f16` per artifact path. `None` is
+/// cached too (header unreadable / geometry keys absent → the heuristic
+/// stands), so a broken artifact costs one parse, not one per tick.
+fn kv_rate_from_header_cached(path: &std::path::Path) -> Option<u64> {
+    static CACHE: std::sync::OnceLock<
+        dashmap::DashMap<std::path::PathBuf, Option<u64>>,
+    > = std::sync::OnceLock::new();
+    let cache = CACHE.get_or_init(dashmap::DashMap::new);
+    if let Some(hit) = cache.get(path) {
+        return *hit;
+    }
+    let rate = (|| {
+        let mut file = std::fs::File::open(path).ok()?;
+        let content =
+            candle_core::quantized::gguf_file::Content::read(&mut file).ok()?;
+        let arch = crate::inference_capability::gguf_keys::architecture(&content)?;
+        crate::inference_capability::gguf_keys::kv_bytes_per_token_f16(&content, &arch)
+    })();
+    crate::probe!(
+        class = "serving.kv_rate.header",
+        path = %path.display(),
+        rate_f16 = rate.unwrap_or(0), // 0 = header did not answer; the weights heuristic stands (the probe's absence-vs-zero reading rides `answered`)
+        answered = rate.is_some(),
+        "KV bytes/token from the artifact's own declared geometry — replaces the \
+         weights-scaled guess that over-charged MoE models ~4x",
+    );
+    cache.insert(path.to_path_buf(), rate);
+    rate
 }
 
 /// KV CACHE QUANTIZATION (#232): a lane running quantized KV holds proportionally


### PR DESCRIPTION
Three commits pushed to #2719's branch after its squash-merge closed it — the layers that took hit_rate from 0.0 to a measured 0.38–0.50 with warm act latency halved (58s vs 138s):

1. **KV bytes/token from the GGUF header** — the `weights/80k` guess over-charged a 35B MoE ~4× (experts add weights, zero KV), starving `--cache-ram` to one mind and under-granting lanes. Header-true rate unlocked 5 lanes = one warm slot per resident.
2. **Recall rides `.trailing()`** — it re-scores every turn and was churning the stable system head.
3. **The KV split applied on the live path** — the view builder still glued `stable ++ trailing` into one system message, so the `[now]` clock + presence flips invalidated the prefix every act. System message is now byte-identical across presence flips (pinned by test).

Receipts in-session: consecutive warm turns cached 9,661–9,669 tokens (the stable head), hit 0.38–0.50, first nonzero reuse of the night. gguf_keys 6/6, serving_daemon 43/43, recall 20/20, llm_deliberation_faculty 38/38, cognition:: 1085/1085.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo