### PR TITLE
fix(cognition): byte-stable conversation front — quantized trimming + suppression-style dup collapse

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -1909,36 +1909,62 @@ impl LlmDeliberationFaculty {
             .sum()
     }
 
-    /// Fit an already-built conversation to `budget_tokens`.
+    /// The window-start advance QUANTUM divisor: when the conversation outgrows
+    /// its budget, the front is dropped in chunks of `budget/8` (floored at 512
+    /// tokens) rather than message-by-message. See [`Self::fit_messages`].
+    // context-budget-exempt: a stability/latency trade ratio, not a token budget — the actual chunk derives from the live budget at the call
+    const FRONT_DROP_QUANTUM_DIVISOR: usize = 8;
+
+    /// Fit an already-built conversation to `budget_tokens` — with a
+    /// QUANTIZED, whole-message front drop, because the fit's cut point is the
+    /// byte-stability of the entire conversation prefix.
+    ///
+    /// The old shape walked NEWEST-first, spending the budget backward: correct
+    /// per-act, and a KV catastrophe across acts — every act appends new tokens
+    /// at the tail, so the exact-fit cut point advanced the window START by a
+    /// few messages per act, and the straddling message was tail-trimmed to a
+    /// different byte offset each time. Measured 2026-09-01 (wire-capture
+    /// diffs): consecutive prompts diverging at ~1% depth on exactly this seam,
+    /// re-prefilling the other 99%.
+    ///
+    /// Now the drop is quantized: the minimum front mass that must go is
+    /// rounded UP to a chunk (`budget/8`, ≥512 tokens), whole messages only, so
+    /// the window start stays BYTE-IDENTICAL for ~a chunk's worth of new
+    /// conversation and then advances once, in one jump. The cost is a window
+    /// that runs up to one chunk under-full — a deliberate stability/capacity
+    /// trade, same law as the scratch slot: reuse of a 20-80k prefix is worth
+    /// vastly more than the last few k of oldest history
+    /// ([[collapse-dont-clip-condense-the-past-never-erode-it]] — and when the
+    /// jump does land, it drops whole turns, never a mid-message shear).
     fn fit_messages(&self, messages: Vec<ChatMessage>, budget_tokens: usize) -> Vec<ChatMessage> {
-        // Fit to the served window, NEWEST-first: walk the thread from the most
-        // recent message backward, giving each the remaining budget. A whole message
-        // that fits is kept intact; the one that straddles the budget boundary is
-        // head-trimmed (keeping its TAIL — the latest lines) via `tail_to_tokens`;
-        // anything older is dropped. This is the turn-granular successor to the old
-        // flat head-trim: the latest activity always survives (it is what the turn is
-        // about), and for the opaque single-turn (eval/test/replay) path it reduces
-        // EXACTLY to the previous `tail_to_tokens(world_state, budget)` behavior.
         // Per-message template overhead: `Self::PER_MESSAGE_TEMPLATE_TOKENS`, shared
         // with `messages_cost` so measurement and fitting charge identically.
         let per_message_template_tokens = Self::PER_MESSAGE_TEMPLATE_TOKENS;
+        let costs: Vec<usize> = messages
+            .iter()
+            .map(|m| est_tokens(&m.content_text()) + per_message_template_tokens)
+            .collect();
+        let total: usize = costs.iter().sum();
         let mut fitted: Vec<ChatMessage> = Vec::new();
-        let mut remaining = budget_tokens;
-        for msg in messages.iter().rev() {
-            let body = msg.content_text();
-            let cost = est_tokens(&body) + per_message_template_tokens;
-            if cost <= remaining {
-                remaining -= cost;
-                fitted.push(msg.clone());
-            } else {
-                // The straddling message: keep as much of its TAIL as still fits.
-                let trimmed =
-                    tail_to_tokens(&body, remaining.saturating_sub(per_message_template_tokens));
-                if !trimmed.is_empty() {
-                    fitted.push(ChatMessage::text(msg.role.clone(), trimmed));
-                }
-                break;
+        if total <= budget_tokens {
+            fitted = messages.clone();
+        } else if messages.len() > 1 {
+            let min_drop = total - budget_tokens;
+            let quantum = (budget_tokens / Self::FRONT_DROP_QUANTUM_DIVISOR).max(512);
+            let drop_q = min_drop.div_ceil(quantum).saturating_mul(quantum);
+            let mut dropped = 0usize;
+            let mut start = 0usize;
+            // Whole messages only, and never the newest — it is what the turn
+            // is about (the pre-existing guarantee, preserved).
+            while start + 1 < messages.len() && dropped < drop_q {
+                dropped += costs[start];
+                start += 1;
             }
+            if total - dropped <= budget_tokens {
+                fitted = messages[start..].to_vec();
+            }
+            // else: the surviving suffix alone still exceeds the budget (a
+            // giant newest message) — fall through to the tail-trim guarantee.
         }
         // The newest message alone can exceed the whole budget (a giant single burst
         // at a tiny window). Keep its trimmed tail regardless — a turn must reach the
@@ -1969,7 +1995,6 @@ impl LlmDeliberationFaculty {
                 return vec![ChatMessage::text(last.role.clone(), body)];
             }
         }
-        fitted.reverse();
         fitted
     }
 
@@ -4246,6 +4271,62 @@ mod tests {
                     .content_text()
                     .starts_with("Operator: "),
                 "the ask (last peer turn) stays LAST, after the grounding facts"
+            );
+        }
+
+        // what this catches: the fit's cut point IS the byte-stability of the
+        // whole conversation prefix (2026-09-01, wire-diffed: consecutive
+        // prompts diverging at ~1% depth because the exact-fit window start
+        // advanced every act). The front must stay byte-identical across small
+        // growth (a quantum of headroom), then advance in ONE whole-message
+        // jump — and the fitted suffix must always fit the budget.
+        #[test]
+        fn fit_front_advances_in_quanta_not_per_act() {
+            let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
+            let faculty =
+                LlmDeliberationFaculty::new(Uuid::new_v4(), "T", "You are T.", adapter);
+            let msgs: Vec<ChatMessage> = (0..40)
+                .map(|i| ChatMessage::text("user", format!("m{i} {}", "word ".repeat(95))))
+                .collect();
+            let budget = 2000;
+            // Simulate 20 consecutive acts, each appending one ~160-token
+            // message. Old behavior: the exact-fit start advanced EVERY act
+            // (20 moves). Quantized: total growth ≈ 3.2k tokens ÷ the 512
+            // quantum ⇒ at most ~7 boundary crossings, so most acts keep a
+            // byte-identical front. (Counted, not position-pinned, so the
+            // assertion cannot land on a quantum edge as token estimates
+            // drift.)
+            let mut moves = 0usize;
+            let mut prev_first: Option<String> = None;
+            let mut last_fit: Vec<ChatMessage> = Vec::new();
+            for n in 20..=40 {
+                let fit = faculty.fit_messages(msgs[..n].to_vec(), budget);
+                assert!(!fit.is_empty());
+                let first = fit.first().map(|m| m.content_text());
+                if prev_first.is_some() && first != prev_first {
+                    moves += 1;
+                }
+                prev_first = first;
+                last_fit = fit;
+            }
+            assert!(
+                (1..=8).contains(&moves),
+                "front moved {moves} times across 20 acts — it must advance in \
+                 QUANTA (a handful of jumps), never per act, and must still \
+                 advance eventually (bounded memory)"
+            );
+            // Whole messages only at the front: the first fitted message is one
+            // of the originals, never a mid-message shear.
+            let first = last_fit.first().unwrap().content_text();
+            assert!(
+                msgs.iter().any(|m| m.content_text() == first),
+                "front message must be a whole original message"
+            );
+            // The fitted suffix honors the budget.
+            assert!(
+                LlmDeliberationFaculty::messages_cost(&last_fit) <= budget,
+                "fitted cost {} exceeds budget {budget}",
+                LlmDeliberationFaculty::messages_cost(&last_fit)
             );
         }
 

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -1651,43 +1651,50 @@ pub(crate) fn project_room_roster(
     }
 }
 
-/// Collapse near-identical substantial turns to their NEWEST copy, annotating
-/// the surviving turn's author with "(×N near-identical)". Same-`is_self` only
-/// (role attribution stays intact), authorless opaque turns pass through
-/// untouched, and the geometry is [`near_identical_substantial`]'s — one
-/// definition of "nearly identical" shared with the perception facts. See the
-/// call site in [`build_workspace_turns`] for the why (repetition ≈ bad RAG).
+/// Collapse near-identical substantial turns by SUPPRESSING later copies —
+/// the OLDEST copy stays, byte-untouched, at its original position. Same-
+/// `is_self` only (role attribution stays intact), authorless opaque turns
+/// pass through untouched, and the geometry is [`near_identical_substantial`]'s
+/// — one definition of "nearly identical" shared with the perception facts.
+/// See the call site in [`build_workspace_turns`] for the why (repetition ≈
+/// bad RAG).
+///
+/// ## Why oldest-survivor, unannotated (2026-09-01, the KV-prefix churn)
+///
+/// The first cut kept the NEWEST copy and stamped the survivor's author with
+/// "(×N near-identical)". Both choices rewrite EARLY bytes of the rendered
+/// conversation whenever a fresh duplicate arrives — the representative
+/// relocates and the count increments — and a mutation at 1% depth of an 80k
+/// prompt invalidates the entire KV tail behind it (measured live: Benchy's
+/// consecutive prompts diverging at char ~660 on exactly this annotation,
+/// hit_rate 0.0 while his peers cached 0.38–0.50). Suppression is prefix-
+/// stable by construction: a new duplicate simply never renders, so the bytes
+/// already prefilled stay bytes. The repetition EVIDENCE still reaches her —
+/// the `[pattern]`/`[repetition]` perception facts detect on the RAW turns
+/// and render in the volatile facts phase, where flicker belongs.
+///
+/// The LAST turn is never suppressed: it is the burst's trigger/ask, and the
+/// reply anchor must always see it even when it near-duplicates history.
 pub(crate) fn collapse_near_duplicate_turns(
     turns: Vec<crate::cognition::workspace::BurstTurn>,
 ) -> Vec<crate::cognition::workspace::BurstTurn> {
     use crate::cognition::deliberation_budget::near_identical_substantial;
+    let last_idx = turns.len().saturating_sub(1);
     let mut kept: Vec<crate::cognition::workspace::BurstTurn> = Vec::with_capacity(turns.len());
-    let mut counts: Vec<usize> = Vec::new();
-    // Newest-first so the surviving representative is the freshest copy (the
-    // one the trigger anchor and reply context care about).
-    for t in turns.into_iter().rev() {
-        if t.author.trim().is_empty() {
+    for (i, t) in turns.into_iter().enumerate() {
+        if t.author.trim().is_empty() || i == last_idx {
             kept.push(t);
-            counts.push(1);
             continue;
         }
-        if let Some(i) = kept.iter().position(|k| {
+        let already_represented = kept.iter().any(|k| {
             !k.author.trim().is_empty()
                 && k.is_self == t.is_self
                 && near_identical_substantial(&k.content, &t.content)
-        }) {
-            counts[i] += 1;
-        } else {
+        });
+        if !already_represented {
             kept.push(t);
-            counts.push(1);
         }
     }
-    for (k, c) in kept.iter_mut().zip(counts.iter()) {
-        if *c > 1 {
-            k.author = format!("{} (×{c} near-identical)", k.author);
-        }
-    }
-    kept.reverse();
     kept
 }
 
@@ -3006,13 +3013,17 @@ mod tests {
     }
 
     // what this catches: the RAG-side mirror-hall cure (Joel 2026-07-12,
-    // "repetition almost always bad RAG"). Near-identical substantial turns
-    // collapse to their NEWEST copy with an "(×N near-identical)" author
-    // annotation; distinct turns, short acks (token floor), and opaque
-    // observation turns pass through untouched. Specimens are the live
-    // grep/file_tree loop that fed each mind 4-8 copies of one message.
+    // "repetition almost always bad RAG") in its KV-STABLE form (2026-09-01):
+    // near-identical substantial turns are SUPPRESSED — the OLDEST copy stays
+    // at its position, byte-untouched (no relocating representative, no
+    // mutating "(×N)" author annotation; both rewrote early prompt bytes and
+    // killed the whole KV tail — Benchy's consecutive prompts diverged at
+    // char ~660 on exactly the annotation). The LAST turn (the trigger/ask)
+    // is never suppressed even when it near-duplicates history. Distinct
+    // turns, short acks (token floor), and opaque observation turns pass
+    // through untouched.
     #[test]
-    fn near_dup_turns_collapse_to_annotated_newest_copy() {
+    fn near_dup_turns_suppress_later_copies_and_never_the_trigger() {
         use crate::cognition::workspace::BurstTurn;
         let loop_msg = "I see that we're all trying to find Rust files in the workspace. \
                         Let me use file_tree with a deeper recursion limit to explore the \
@@ -3031,26 +3042,30 @@ mod tests {
             ),
         ];
         let out = collapse_near_duplicate_turns(turns);
-        // 3 loop copies → 1 (the NEWEST, Atlas's variant); 2 short acks kept
-        // (token floor); opaque observation kept.
+        // Asha's mid-window copy suppressed; Anwen's OLDEST copy survives
+        // untouched; Atlas's trigger variant survives because the LAST turn is
+        // sacred; acks + opaque pass through.
         assert_eq!(
             out.len(),
-            4,
+            5,
             "{:?}",
             out.iter().map(|t| &t.author).collect::<Vec<_>>()
         );
         let survivor = out
             .iter()
             .find(|t| t.content.contains("find Rust files"))
-            .expect("one representative survives");
-        assert!(
-            survivor.author.contains("Atlas") && survivor.author.contains("(×3 near-identical)"),
-            "newest copy, annotated: {}",
-            survivor.author
+            .expect("the oldest representative survives");
+        assert_eq!(
+            survivor.author, "Anwen",
+            "oldest copy survives with its author BYTE-UNTOUCHED (no ×N annotation)"
         );
         assert!(
-            survivor.content.contains("aren't being returned"),
-            "newest copy is the representative"
+            !out.iter().any(|t| t.author.contains("Asha")),
+            "the interior duplicate is suppressed entirely"
+        );
+        assert!(
+            out.last().unwrap().content.contains("aren't being returned"),
+            "the trigger (last turn) is never suppressed, near-dup or not"
         );
         assert_eq!(out.iter().filter(|t| t.content == "thanks!").count(), 2);
         assert!(out.iter().any(|t| t.content.starts_with("[pattern]")));


### PR DESCRIPTION
Layer 5 and 6 of the KV arc. With the system head fixed (hit 0.38–0.50, cached mass = exactly the stable head), wire diffs showed the conversation itself churning at ~1% depth on two seams: the exact-fit window start advancing every act, and the `(×N near-identical)` collapse annotation rewriting early authors as counts grew.

- **Quantized front-drop** in `fit_messages`: whole-message drops rounded up to `budget/8` chunks — byte-stable start for ~a quantum of growth, then one jump. Deliberate capacity trade, same law as the scratch slot.
- **Suppression-style collapse**: oldest copy survives byte-untouched, later dups vanish, the trigger is sacred; repetition evidence rides the `[pattern]` facts where flicker belongs.

Expected effect: cached mass extends past the head into the conversation body — the 0.5 → 0.8 move. Receipts to follow from live measurement post-deploy.

cognition:: 1086/1086, service_loop 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo