### PR TITLE
fix(reliability): citizens always hear their work — join-on-send + kickoff re-say on reload

### DIFF
--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -642,6 +642,38 @@ pub fn next_unworked_per_round() -> Vec<NextCard> {
         .collect()
 }
 
+/// Every unworked card of every Working CITIZEN-driven round — the cards whose
+/// driver is the citizens' own perception, not a detached dispatch. The boot
+/// resume RE-SAYS their kickoffs into the run room (through the assignee's own
+/// subscribed runtime), because a reload leaves the original kickoffs buried
+/// beyond every window: found live 2026-09-01, a lite round sat 'working, 4
+/// remaining' a full day while its four assignees idled beside their own
+/// unworked cards ([[bench-rounds-die-at-perception-run-rooms-are-deaf]]).
+/// One entry per card (not first-only): re-perception addresses every
+/// assignee, unlike the one-at-a-time detached dispatch.
+pub fn unworked_citizen_cards() -> Vec<NextCard> {
+    let rounds = ROUNDS.lock().expect("bench rounds mutex");
+    rounds
+        .values()
+        .filter(|r| r.stage == RoundStage::Working && r.driver == WorkDriver::Citizen)
+        .flat_map(|r| {
+            let run_room = r.round_id;
+            r.cards
+                .iter()
+                .filter(|(_, state)| state.is_none())
+                .filter_map(move |(card, _)| {
+                    r.card_assignees.get(card).map(|assignee| NextCard {
+                        card: *card,
+                        assignee: *assignee,
+                        run_room,
+                        teammates: r.team.clone(),
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
 /// Total OPEN (non-terminal) cards across every Working round — the board-side
 /// LANE DEMAND. Queued benchmark work is demand the serving plan must see:
 /// measured live 2026-08-27, the plan converged to 1 lane after a 4-way cohort

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -737,16 +737,35 @@ pub fn resume_round(round_id: Uuid) -> Option<NextCard> {
     let live = live_run_ids();
     let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
     let r = rounds.get_mut(&round_id)?;
-    if r.stage != RoundStage::Paused {
-        return None;
+    match r.stage {
+        RoundStage::Paused => {
+            r.stage = RoundStage::Working;
+            persist_round_in(&rounds_state_dir(), r);
+            crate::probe!(
+                class = "bench.round.resumed_by_operator",
+                round_id = %round_id,
+                "round resumed from pause — driver kicked"
+            );
+        }
+        // A WORKING round can still be IDLE — the zombie state a core reload
+        // leaves behind (found live 2026-09-01: a lite round reloaded
+        // 'working, 4 remaining', demand leased, and sat a full day with
+        // card_activities empty, because the settle-edge driver needs a
+        // settle that an idle round can never produce). The verb's own doc
+        // promises 'the driver is kicked immediately' — make that true here
+        // too: no stage change, just the kick. The in-flight guard
+        // (`live_run_ids` via `first_unworked`) keeps this idempotent — a
+        // round with a genuinely live run returns None and nothing double-
+        // fires ([[launch-and-pray-is-the-defect-read-the-state-pipe-before-staging-work]]).
+        RoundStage::Working => {
+            crate::probe!(
+                class = "bench.round.kicked_while_working",
+                round_id = %round_id,
+                "working round kicked by operator — firing the next unworked card if any run is not already live"
+            );
+        }
+        _ => return None,
     }
-    r.stage = RoundStage::Working;
-    persist_round_in(&rounds_state_dir(), r);
-    crate::probe!(
-        class = "bench.round.resumed_by_operator",
-        round_id = %round_id,
-        "round resumed — driver kicked"
-    );
     first_unworked(r, &live)
 }
 
@@ -1193,6 +1212,29 @@ mod tests {
             ROUNDS.lock().unwrap().get(&round_id).is_none(),
             "an empty round must not remain tracked"
         );
+    }
+
+    // what this catches: the ZOMBIE round (found live 2026-09-01) — a core
+    // reload leaves a round WORKING with no live run and no settle edge ever
+    // coming, and resume_round used to no-op on anything not Paused, so the
+    // one verb whose doc promises "the driver is kicked immediately" left the
+    // exact stalled state it exists for. A Working round with no live run must
+    // hand back its first unworked card.
+    #[test]
+    fn resume_kicks_a_working_idle_round() {
+        let ids = cards(2);
+        let round_id = Uuid::new_v4();
+        let mut r = BenchRound::new(round_id, "swe-bench-lite", &ids, WorkDriver::DetachedSolve);
+        for c in &ids {
+            r.card_assignees.insert(*c, Uuid::new_v4());
+        }
+        ROUNDS.lock().unwrap().insert(round_id, r);
+        let next = resume_round(round_id);
+        assert!(
+            next.as_ref().is_some_and(|n| ids.contains(&n.card)),
+            "a WORKING round with no live run must kick its first unworked card: {next:?}"
+        );
+        ROUNDS.lock().unwrap().remove(&round_id);
     }
 
     // what this catches: the END transition firing more than once. All-settled must yield

--- a/core/continuum-core/src/commands/chat/send.rs
+++ b/core/continuum-core/src/commands/chat/send.rs
@@ -112,13 +112,55 @@ crate::action_command! {
             });
         match runtime {
             Some(rt) => {
-                if let Err(e) = crate::persona::airc_citizen::publish_text_in_room(
+                let mut publish_err = crate::persona::airc_citizen::publish_text_in_room(
                     rt.airc(),
                     p.room_id,
                     &p.text,
                 )
                 .await
-                {
+                .err();
+                // JOIN-ON-SEND heal, SELF-PEERS ONLY (operator/agent). Their
+                // scopes lose room subscriptions across reboots (found live
+                // 2026-09-01: after ~12 restarts even `general` refused, and
+                // every CLI send stored + live-fed while citizens stayed deaf
+                // — questions into a void). For a human/agent DELIBERATELY
+                // addressing a room, sending IS the intent to be in it, so the
+                // heal subscribes (membership without moving focus) and
+                // retries once. Citizens keep the documented no-auto-join
+                // safety untouched — answering must never silently change
+                // which rooms a persona belongs to; this guard is scoped to
+                // exactly the two self-peers
+                // ([[a-design-fork-is-usually-a-guard-scoped-too-broadly]]).
+                let is_self_peer = crate::persona::operator_peer::operator_runtime()
+                    .map(|o| o.airc().peer_id().as_uuid() == sender_id)
+                    .unwrap_or(false) // unwrap_or: self-peer not up this boot = the sender simply isn't it
+                    || crate::persona::operator_peer::agent_runtime()
+                        .map(|a| a.airc().peer_id().as_uuid() == sender_id)
+                        .unwrap_or(false); // unwrap_or: same — absence of the agent peer is a fact, not an error
+                if publish_err.is_some() && is_self_peer {
+                    if let Some(name) =
+                        crate::persona::airc_citizen::room_name_by_id(p.room_id).await
+                    {
+                        if rt.airc().subscribe_room(&name).await.is_ok() {
+                            crate::probe!(
+                                class = "chat.send.join_on_send",
+                                room = %p.room_id,
+                                room_name = %name,
+                                sender = %sender_id,
+                                "self-peer subscribed on send — its scope had no membership \
+                                 for a room it deliberately addressed; retrying the say",
+                            );
+                            publish_err = crate::persona::airc_citizen::publish_text_in_room(
+                                rt.airc(),
+                                p.room_id,
+                                &p.text,
+                            )
+                            .await
+                            .err();
+                        }
+                    }
+                }
+                if let Some(e) = publish_err {
                     result.warning = Some(format!(
                         "message stored + live-fed, but the daemon-room say failed — \
                          citizens in the room did not hear it: {e}"

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -88,6 +88,10 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
         let regime_id = uuid::Uuid::from_u128(0xBE7C_11A6_2026_0827);
         let mut demand_lease: Option<(u64, u32)> = None;
         let mut attempt: u32 = 0;
+        // Cards whose citizen-round kickoff was already re-said this boot —
+        // re-perception happens once, never per watch tick (a failed or
+        // not-yet-resident attempt un-marks itself for a later tick).
+        let mut nudged: std::collections::HashSet<uuid::Uuid> = std::collections::HashSet::new();
         loop {
             let queued = crate::cognition::bench_round::total_unworked_cards() as u32;
             if queued > 0 {
@@ -179,6 +183,56 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
             // Once per task lifetime; cheap when everything is already warm.
             if attempt == 1 {
                 crate::modules::work::spawn_env_prewarm_for_working_rounds();
+            }
+            // CITIZEN-driven rounds resume by RE-PERCEPTION, not dispatch: a
+            // reload buries the original kickoffs beyond every window, and the
+            // assignees then idle beside their own unworked cards (live
+            // 2026-09-01: a lite round 'working, 4 remaining' for a full day).
+            // Re-say the kickoff through the ASSIGNEE'S OWN runtime — she is
+            // subscribed to the run room by construction, so no operator-scope
+            // membership is needed. Once per card per boot; the say is
+            // perception, and repeating it every watch tick would be the
+            // room-join flood shape.
+            for next in crate::cognition::bench_round::unworked_citizen_cards() {
+                if !nudged.insert(next.card) {
+                    continue;
+                }
+                let Some(rt) = registry.get(next.assignee) else {
+                    nudged.remove(&next.card); // not resident yet — retry a later tick
+                    continue;
+                };
+                let short = next.card.simple().to_string()[..8].to_string();
+                let text = format!(
+                    "[resume] This round survived a core restart and your kickoff predates \
+                     your window. Your card {short} is still yours and unworked: check \
+                     work/list for its title, claim it, work it in your workspace, and when \
+                     your patch is verified green say `work/state {short} done` — that is \
+                     what fires your grade; nobody fires it for you."
+                );
+                match crate::persona::airc_citizen::publish_text_in_room(
+                    rt.airc(),
+                    next.run_room,
+                    &text,
+                )
+                .await
+                {
+                    Ok(_) => crate::probe!(
+                        class = "bench.round.kickoff_resaid",
+                        card_id = %next.card,
+                        assignee = %next.assignee,
+                        room = %next.run_room,
+                        "citizen-round kickoff re-said after reload — re-perception, not dispatch"
+                    ),
+                    Err(e) => {
+                        nudged.remove(&next.card); // say failed — retry a later tick
+                        crate::probe!(
+                            class = "bench.round.kickoff_resay_failed",
+                            card_id = %next.card,
+                            error = %e,
+                            "kickoff re-say failed — will retry on a later watch tick"
+                        );
+                    }
+                }
             }
             let due = crate::cognition::bench_round::next_unworked_per_round();
             if due.is_empty() {

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -267,6 +267,34 @@ pub(crate) async fn publish_text_in_room(
     .map(|receipt| receipt.event_id)
 }
 
+/// Resolve the channel NAME for `room_id` from ANY runtime in this process
+/// that already subscribes to it — the core hosts every citizen runtime, so a
+/// room at least one citizen belongs to is always nameable, even though the
+/// channel-id → name mapping is one-way (ids are hashes of names).
+///
+/// Exists for the operator/agent JOIN-ON-SEND heal (chat/send): after the
+/// 2026-09-01 reboot marathon, the self-peers' scopes had no subscription to
+/// rooms the citizens lived in, so every CLI send stored + live-fed but the
+/// daemon say was refused — the operator asked questions into a void, and
+/// join-by-uuid is structurally impossible from outside. Failure-path only
+/// (one subscription-set read per runtime, and only after a refused publish),
+/// so it costs the hot path nothing.
+pub(crate) async fn room_name_by_id(room_id: Uuid) -> Option<String> {
+    let reg = crate::persona::PersonaAircRuntimeRegistry::try_global()?;
+    let runtimes: Vec<_> = reg.iter().collect();
+    for rt in runtimes {
+        if let Ok(set) = rt.airc().subscription_set().await {
+            if let Some(sub) = set
+                .all()
+                .find(|s| s.as_room().channel.as_uuid() == room_id)
+            {
+                return Some(sub.name.to_string());
+            }
+        }
+    }
+    None
+}
+
 /// Test fixture implementing [`AircCitizen`] without standing up the
 /// airc daemon. Holds the peer_id the test wants to project; subscribe
 /// and say resolve to errors (the service-loop tests don't drive

--- a/docs/architecture/FOLLOW-THE-SIGNAL-THE-COMPRESSION-LADDER.md
+++ b/docs/architecture/FOLLOW-THE-SIGNAL-THE-COMPRESSION-LADDER.md
@@ -98,6 +98,17 @@ becomes room for new signal; cache pressure drops; latency drops. The improvemen
 chart is "cost of being this mind, over time, falling" — measured by the same ledger
 that drives the training.
 
+And the deepest corollary closes the loop: **novelty drives learning.** After
+compression does its work, the misses that remain are not residual inefficiency —
+they are the purified learning signal: prediction error at the context tier, the
+mind's surprise measured in tokens. The live warm-hit distribution is honestly
+bimodal (0.80–0.95 on consecutive work turns, 0.45–0.49 on turns right after fresh
+peer messages), and the low band marks exactly the content worth admitting at high
+salience and worth dreaming on. The ledger's two sides are the promotion mix itself:
+high-reuse stable content promotes to weights (exploitation); low-reuse novel
+content is the curriculum's raw material (exploration). Learn where prediction
+fails — the same law a JEPA-class world model trains by.
+
 The corollary reads the other way too: **a cache miss is unconsolidated experience,
 quantified.** A segment that keeps churning is the system reporting "this hasn't been
 generalized yet." The steady state the ladder converges toward: a mind's live context


### PR DESCRIPTION
The night audit's two deepest gaps: (1) self-peer scopes lose subscriptions across reboots so CLI sends were stored-but-unheard even in general — join-on-send heals it for exactly the two self-peers, citizens keep no-auto-join safety; (2) citizen-driven rounds reload with kickoffs buried beyond every window — the resume watch re-says each unworked card's kickoff through the assignee's own runtime. The next reboot is the acceptance test: it must heal the very rounds it interrupts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo