### PR TITLE
fix(live): speech reaches minds — both STT dead links closed

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1842,8 +1842,74 @@ pub fn start_server(
                 }
             },
         ));
+        // SPEECH → PERCEPTION (the second STT dead link, closed 2026-09-01):
+        // a transcribed human utterance posts as a ROOM MESSAGE from the human
+        // (the call id IS the airc RoomId), through the full chat/send
+        // composition — store + live feed + daemon say — so citizens perceive
+        // speech exactly like text and the whole reply pipeline (directedness,
+        // turns, voice-out) fires. Subtitles alone reached screens, no minds.
+        {
+            let exec_slot = live_registrar_executor.clone();
+            mgr.set_transcript_sink(std::sync::Arc::new(
+                move |call_id: &str, user_id: &str, _display_name: &str, text: &str| {
+                    let Some(exec) = exec_slot.cloned() else { return };
+                    let (room, speaker, said) =
+                        (call_id.to_string(), user_id.to_string(), text.to_string());
+                    tokio::spawn(async move {
+                        match exec
+                            .execute_json(
+                                "chat/send",
+                                serde_json::json!({
+                                    "roomId": room,
+                                    "senderId": speaker,
+                                    "text": said,
+                                }),
+                            )
+                            .await
+                        {
+                            Ok(_) => crate::probe!(
+                                class = "live.stt.utterance_to_room",
+                                room = %room,
+                                speaker = %speaker,
+                                chars = said.len(),
+                                "spoken words landed as a room message — citizens can now \
+                                 answer speech"
+                            ),
+                            Err(e) => tracing::warn!(
+                                room = %room,
+                                error = %e,
+                                probe_class = "live.stt.utterance_to_room_failed",
+                                "transcription could not post to the room — subtitles only \
+                                 for this utterance"
+                            ),
+                        }
+                    });
+                },
+            ));
+        }
         std::sync::Arc::new(mgr)
     };
+    {
+        // STT WIRE (closed 2026-09-01): bridge-heard human audio → the
+        // CallServer's existing VAD → speech-end → transcription pipeline.
+        // The bridge reader is a plain thread; this bounded channel + task is
+        // its one hop into async land. Capacity ~2s of 20ms frames: a stalled
+        // consumer drops frames (stay current) instead of building a backlog
+        // of stale speech.
+        let (tx, mut rx) =
+            tokio::sync::mpsc::channel::<crate::live::transport::bridge_client::HumanAudioChunk>(
+                128,
+            );
+        crate::live::transport::bridge_client::install_human_audio_forwarder(tx);
+        let manager = call_manager.clone();
+        rt_handle.spawn(async move {
+            while let Some(chunk) = rx.recv().await {
+                manager
+                    .push_remote_human_audio(&chunk.call_id, &chunk.user_id, chunk.samples)
+                    .await;
+            }
+        });
+    }
     {
         let port = crate::config_env::read("CONTINUUM_CALL_WS")
             .and_then(|s| s.trim().parse::<u16>().ok())

--- a/core/continuum-core/src/live/transport/bridge_client.rs
+++ b/core/continuum-core/src/live/transport/bridge_client.rs
@@ -760,14 +760,33 @@ fn reader_loop(mut stream: UnixStream, pending: Arc<Mutex<HashMap<u64, Arc<Pendi
     }
 }
 
+/// One human speaker's PCM chunk (16k mono i16, the core-wide audio contract),
+/// hopping from the bridge reader THREAD into async land where the CallServer
+/// lives. Bounded; a saturated channel drops frames (stay-current rule).
+pub struct HumanAudioChunk {
+    pub call_id: String,
+    pub user_id: String,
+    pub samples: Vec<i16>,
+}
+
+/// The installed forwarder for bridge-heard human audio. Filled once at IPC
+/// startup (beside the CallManager's construction) by
+/// [`install_human_audio_forwarder`]; absent = the reader warns on a speaker's
+/// first frame instead of silently eating speech.
+static HUMAN_AUDIO_TX: std::sync::OnceLock<tokio::sync::mpsc::Sender<HumanAudioChunk>> =
+    std::sync::OnceLock::new();
+
+/// Install the channel the bridge reader forwards human audio through.
+pub fn install_human_audio_forwarder(tx: tokio::sync::mpsc::Sender<HumanAudioChunk>) {
+    let _ = HUMAN_AUDIO_TX.set(tx);
+}
+
 /// Per-speaker audio processing state (VAD frame accumulation).
 struct AudioProcessor {
     call_id: String,
     speaker_id: String,
     speaker_name: String,
     track_sid: String,
-    /// Accumulation buffer for VAD (needs 512 samples = 32ms at 16kHz).
-    accum_buf: Vec<i16>,
     frame_count: u64,
 }
 
@@ -778,7 +797,6 @@ impl AudioProcessor {
             speaker_id,
             speaker_name,
             track_sid,
-            accum_buf: Vec::with_capacity(crate::audio_constants::AUDIO_FRAME_SIZE),
             frame_count: 0,
         }
     }
@@ -834,20 +852,33 @@ fn handle_bridge_event(
                 );
             }
 
-            // Accumulate into VAD-sized chunks and process
-            processor.accum_buf.extend_from_slice(&samples);
-            let vad_frame_size = crate::audio_constants::AUDIO_FRAME_SIZE;
-
-            while processor.accum_buf.len() >= vad_frame_size {
-                let vad_frame: Vec<i16> = processor.accum_buf.drain(..vad_frame_size).collect();
-
-                // TODO: Feed vad_frame into ProductionVAD → STT pipeline.
-                // This requires initializing VAD per-speaker (spawn_blocking for ORT)
-                // and routing completed transcriptions to the TS server.
-                // For now, the frame accumulation is correct and ready for wiring.
-                // The VAD/STT integration is the next step after verifying the
-                // bridge audio transport works end-to-end.
-                let _ = vad_frame; // Silence unused warning
+            // THE WIRE THAT WAS NEVER RUN (closed 2026-09-01): these frames
+            // used to accumulate into perfect VAD-sized chunks and die in a
+            // TODO — the bridge heard the first audio frame and citizens never
+            // answered speech, because the pipeline simply STOPPED here. Now
+            // each frame forwards to the CallServer's existing VAD →
+            // speech-end → transcription path (the human's handle + VAD were
+            // minted by her WS-control join all along). This loop is a plain
+            // thread, so the hop to async land is one bounded channel; a full
+            // channel drops the frame (stay current, never backlog — the same
+            // rule the transcription semaphore applies downstream).
+            if let Some(tx) = HUMAN_AUDIO_TX.get() {
+                let chunk = HumanAudioChunk {
+                    call_id: processor.call_id.clone(),
+                    user_id: processor.speaker_id.clone(),
+                    samples,
+                };
+                if tx.try_send(chunk).is_err() && processor.frame_count % 500 == 1 {
+                    clog_warn!(
+                        "🎤 human-audio forwarder saturated — dropping frames from '{}' to stay current",
+                        processor.speaker_name
+                    );
+                }
+            } else if processor.frame_count == 1 {
+                clog_warn!(
+                    "🎤 no human-audio forwarder installed — speech from '{}' cannot reach STT",
+                    processor.speaker_name
+                );
             }
         }
         BridgeEvent::ParticipantJoined {

--- a/core/continuum-core/src/live/transport/call_server.rs
+++ b/core/continuum-core/src/live/transport/call_server.rs
@@ -353,7 +353,20 @@ pub struct CallManager {
     /// installs it; a call still works without it, it is just not registered — which
     /// is precisely the state the live-call view now renders instead of hiding.
     session_registrar: Option<SessionRegistrar>,
+    /// Where a HUMAN's transcribed utterance goes so the CITIZENS can perceive
+    /// it (closed 2026-09-01 — the second STT dead link: transcriptions
+    /// forwarded to WebSocket SUBTITLES only, so even a heard human was never
+    /// answered; the words reached screens and no minds). The call id IS the
+    /// airc RoomId, so the sink posts the utterance as a ROOM MESSAGE from the
+    /// human — and the whole existing pipeline (perception, directedness,
+    /// turns, voice-out) fires as if she had typed it. Same callback shape and
+    /// reason as [`SessionRegistrar`]: transport announces a fact, never
+    /// learns what cognition does with it.
+    transcript_sink: Option<TranscriptSink>,
 }
+
+/// `(call_id/room, speaker user_id, speaker display name, transcribed text)`.
+pub type TranscriptSink = Arc<dyn Fn(&str, &str, &str, &str) + Send + Sync>;
 
 /// Told when a participant joins a live call, so the CORE can register the session
 /// itself (#58).
@@ -376,6 +389,12 @@ impl CallManager {
     /// and the call manager both exist; absent in tests, where a call needs no session.
     pub fn set_session_registrar(&mut self, registrar: SessionRegistrar) {
         self.session_registrar = Some(registrar);
+    }
+
+    /// Install the transcript→room sink. Called once at boot beside the
+    /// registrar; absent in tests, where subtitles alone are the contract.
+    pub fn set_transcript_sink(&mut self, sink: TranscriptSink) {
+        self.transcript_sink = Some(sink);
     }
 
     /// Every LIVE call and how many participants are in it — the read side the live-call
@@ -412,6 +431,7 @@ impl CallManager {
             capability_registry: Arc::new(ModelCapabilityRegistry::new()),
             persona_audio_handles: RwLock::new(HashMap::new()),
             session_registrar: None,
+            transcript_sink: None,
         }
     }
 
@@ -829,15 +849,23 @@ impl CallManager {
                         let semaphore = TRANSCRIPTION_SEMAPHORE.clone();
                         match semaphore.clone().try_acquire_owned() {
                             Ok(permit) => {
-                                // Spawn transcription task with permit
+                                // Spawn transcription task with permit. The sink
+                                // (when installed) turns the utterance into a ROOM
+                                // message so citizens PERCEIVE speech — subtitles
+                                // alone reached screens and no minds (2026-09-01).
+                                let sink = self.transcript_sink.clone();
+                                let room = call_id.clone();
                                 tokio::spawn(async move {
-                                    Self::transcribe_and_broadcast(
+                                    let text = Self::transcribe_and_broadcast(
                                         transcription_tx,
-                                        user_id,
-                                        display_name,
+                                        user_id.clone(),
+                                        display_name.clone(),
                                         speech_samples,
                                     )
                                     .await;
+                                    if let (Some(sink), Some(text)) = (sink, text) {
+                                        sink(&room, &user_id, &display_name, &text);
+                                    }
                                     // Permit automatically released when dropped
                                     drop(permit);
                                 });
@@ -981,6 +1009,45 @@ impl CallManager {
         let _ = call.push_audio(&handle, samples);
     }
 
+    /// Bridge-fed HUMAN audio (the LiveKit media lane): route a remote
+    /// participant's 16k PCM into the SAME VAD → speech-end → transcription
+    /// pipeline the WS lane has always used.
+    ///
+    /// This closes the STT dead leg (found live 2026-09-01: the bridge heard
+    /// the first audio frame and nothing followed — `bridge_client`'s frame
+    /// loop accumulated perfect VAD-sized chunks into a `TODO` and dropped
+    /// them, so citizens never answered speech). The human's handle + VAD
+    /// already exist from her WS-control `join_call`; media frames just never
+    /// reached them. One lookup, then the existing `push_audio` does speech-end
+    /// detection and spawns transcription exactly as before — no second
+    /// pipeline ([[the-same-bug-at-two-sites-is-a-missing-constraint-not-two-bugs]]).
+    pub async fn push_remote_human_audio(
+        &self,
+        call_id: &str,
+        user_id: &str,
+        samples: Vec<i16>,
+    ) {
+        let call = {
+            let calls = self.calls.read().await;
+            calls.get(call_id).cloned()
+        };
+        let Some(call) = call else {
+            return; // no native Call — nobody has this call open on this node
+        };
+        let handle = {
+            let call = call.read().await;
+            call.mixer.find_handle_by_user_id(user_id)
+        };
+        let Some(handle) = handle else {
+            // Media arrived before (or without) the WS-control join that mints
+            // her handle + VAD — a real ordering that self-heals when the join
+            // lands; frames until then are honestly droppable (they predate
+            // her being a participant here).
+            return;
+        };
+        self.push_audio(&handle, samples).await;
+    }
+
     /// Broadcast a CallMessage to all participants in a call (avatar updates, etc.)
     pub async fn broadcast_message(&self, call_id: &str, msg: CallMessage) {
         let call = {
@@ -997,16 +1064,19 @@ impl CallManager {
     }
 
     /// Transcribe speech samples and broadcast to all participants
+    /// Returns the transcribed text (when non-empty) so the caller can also
+    /// deliver it to cognition via the [`TranscriptSink`] — the broadcast here
+    /// reaches SCREENS (subtitles); the sink reaches MINDS.
     async fn transcribe_and_broadcast(
         transcription_tx: broadcast::Sender<TranscriptionEvent>,
         user_id: String,
         display_name: String,
         samples: Vec<i16>,
-    ) {
+    ) -> Option<String> {
         // Check if STT is initialized
         if !stt::is_initialized() {
             clog_warn!("STT adapter not initialized - skipping transcription");
-            return;
+            return None;
         }
 
         clog_info!(
@@ -1057,12 +1127,15 @@ impl CallManager {
 
                         // Critical issue already logged via tracing::error above
                     }
+                    Some(text.to_string())
                 } else {
                     clog_info!("📝 Empty transcription result from {}", display_name);
+                    None
                 }
             }
             Err(e) => {
                 clog_error!("Transcription failed for {}: {}", display_name, e);
+                None
             }
         }
     }


### PR DESCRIPTION
Two dead links in series: (1) the bridge accumulated human audio into VAD-sized chunks and dropped them in a TODO; (2) transcriptions went to WebSocket subtitles only — screens, not minds. Both closed at existing seams: one bounded thread→async hop into the existing VAD/speech-end/transcription path, and a TranscriptSink that posts the utterance as a room message from the human (call id = RoomId) so the entire reply pipeline fires. Acceptance: speak in a call → a citizen answers what you said, out loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo