### PR TITLE
feat(live): binary media plane — one byte discriminates, zero copies, identity binds once

### DIFF
--- a/core/continuum-core/src/live/avatar/video_pump.rs
+++ b/core/continuum-core/src/live/avatar/video_pump.rs
@@ -145,7 +145,7 @@ pub async fn spawn_avatar_video_pump(
                 .await;
 
             match manager
-                .publish_video_frame(&call_id, &identity, &frame.data, frame.width, frame.height)
+                .publish_video_frame(&call_id, &identity, frame.data, frame.width, frame.height)
                 .await
             {
                 Ok(()) => {

--- a/core/continuum-core/src/live/transport/bridge_client.rs
+++ b/core/continuum-core/src/live/transport/bridge_client.rs
@@ -64,6 +64,10 @@ pub struct LiveKitAgentManager {
     /// Media-plane queue head. Replaced on every reconnect; the old pump thread
     /// exits when its receiver disconnects.
     media_tx: Mutex<Option<std::sync::mpsc::SyncSender<MediaFrame>>>,
+    /// Outbound binary media channels: (call, user, kind) → channel, bound once
+    /// via `OpenMediaOut` — identity leaves the frame path entirely.
+    out_channels: Mutex<std::collections::HashMap<(String, String, u8), u16>>,
+    next_out_channel: AtomicU64,
     /// Frames dropped because the media queue was full (bridge stalled). Loud
     /// via rate-limited warn in [`Self::send_media`]; MUST stay 0 steady-state.
     media_dropped: Arc<AtomicU64>,
@@ -79,12 +83,51 @@ pub struct LiveKitAgentManager {
     reader_started: Mutex<bool>,
 }
 
-/// One queued media-plane frame: fully wire-encoded (envelope + payload), ready
-/// for a single `write_all`. Encoding happens on the caller's thread so the
-/// pump does nothing but move bytes to the kernel.
+/// One queued media-plane frame on the BINARY plane (2026-09-01): a fixed
+/// 8-byte header ([len][magic][kind][channel]), optional 4-byte video dims,
+/// and the payload MOVED from the producer — at 30fps HD RGBA the payload is
+/// ~3.7MB and is never copied after the pump hands it over (forward-on, no
+/// copies — the airc law). The writer emits the parts back-to-back; identity
+/// strings bound once at channel open, never per frame.
 struct MediaFrame {
-    frame: Vec<u8>,
+    header: [u8; 8],
+    dims: Option<[u8; 4]>,
+    payload: Vec<u8>,
     kind: &'static str,
+}
+
+impl MediaFrame {
+    fn new(
+        kind: continuum_bridge_protocol::MediaKind,
+        channel: u16,
+        dims: Option<(u16, u16)>,
+        payload: Vec<u8>,
+        label: &'static str,
+    ) -> Self {
+        let dim_len = if dims.is_some() { 4 } else { 0 };
+        let total = 1 + 1 + 2 + dim_len + payload.len();
+        let mut header = [0u8; 8];
+        header[0..4].copy_from_slice(&(total as u32).to_le_bytes());
+        header[4] = continuum_bridge_protocol::MEDIA_MAGIC;
+        header[5] = kind as u8;
+        header[6..8].copy_from_slice(&channel.to_le_bytes());
+        let dims = dims.map(|(w, h)| {
+            let mut d = [0u8; 4];
+            d[0..2].copy_from_slice(&w.to_le_bytes());
+            d[2..4].copy_from_slice(&h.to_le_bytes());
+            d
+        });
+        Self {
+            header,
+            dims,
+            payload,
+            kind: label,
+        }
+    }
+
+    fn wire_len(&self) -> usize {
+        8 + self.dims.map_or(0, |_| 4) + self.payload.len()
+    }
 }
 
 /// Media queue depth. Sized for burst absorption (~a second of mixed PCM chunks
@@ -120,6 +163,8 @@ impl LiveKitAgentManager {
             writer: Arc::new(Mutex::new(None)),
             pending: Arc::new(Mutex::new(HashMap::new())),
             media_tx: Mutex::new(None),
+            out_channels: Mutex::new(std::collections::HashMap::new()),
+            next_out_channel: AtomicU64::new(1),
             media_dropped: Arc::new(AtomicU64::new(0)),
             bridge_socket_path,
             livekit_url,
@@ -189,31 +234,56 @@ impl LiveKitAgentManager {
     /// Grid contract: this is the LOCAL media plane. A remote node never speaks
     /// this socket — it acquires a media handle via a command (grid calls are
     /// commands) and its bytes arrive through that handle's plane.
+    /// Bind (once) the outbound binary channel for `(call, user, kind)`. The
+    /// control round-trip happens on the FIRST frame of a stream; every frame
+    /// after rides the binary plane with no identity and no JSON.
+    fn ensure_out_channel(
+        &self,
+        call_id: &str,
+        user_id: &str,
+        kind: continuum_bridge_protocol::MediaKind,
+    ) -> Result<u16, String> {
+        let key = (call_id.to_string(), user_id.to_string(), kind as u8);
+        if let Some(ch) = self.out_channels.lock().unwrap().get(&key) {
+            return Ok(*ch);
+        }
+        let channel = self.next_out_channel.fetch_add(1, Ordering::Relaxed) as u16;
+        self.send_command(
+            BridgeCommand::OpenMediaOut {
+                channel,
+                kind,
+                call_id: call_id.to_string(),
+                user_id: user_id.to_string(),
+            },
+            None,
+        )?;
+        self.out_channels.lock().unwrap().insert(key, channel);
+        crate::probe!(
+            class = "media.pump.channel_open",
+            module = "livekit-bridge",
+            channel = channel as u64,
+            "outbound media channel bound — identity once, binary frames from here on"
+        );
+        Ok(channel)
+    }
+
     fn send_media(
         &self,
-        command: BridgeCommand,
-        binary: &[u8],
-        kind: &'static str,
+        kind: continuum_bridge_protocol::MediaKind,
+        channel: u16,
+        dims: Option<(u16, u16)>,
+        payload: Vec<u8>,
+        label: &'static str,
     ) -> Result<(), String> {
         self.ensure_connected()?;
-
-        let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
-        let mut envelope =
-            serde_json::to_value(&command).map_err(|e| format!("Serialize error: {}", e))?;
-        envelope
-            .as_object_mut()
-            .unwrap()
-            .insert("request_id".to_string(), request_id.into());
-        let json_bytes =
-            serde_json::to_vec(&envelope).map_err(|e| format!("Serialize error: {}", e))?;
-        let frame = continuum_bridge_protocol::encode_frame(&json_bytes, Some(binary));
-
         let tx_guard = self.media_tx.lock().unwrap();
         let Some(tx) = tx_guard.as_ref() else {
             return Err("Not connected".to_string());
         };
-        let frame_bytes = frame.len();
-        match tx.try_send(MediaFrame { frame, kind }) {
+        let item = MediaFrame::new(kind, channel, dims, payload, label);
+        let frame_bytes = item.wire_len();
+        let kind = label;
+        match tx.try_send(item) {
             Ok(()) => {
                 crate::probe!(
                     class = "media.pump.enqueue",
@@ -459,17 +529,20 @@ impl LiveKitAgentManager {
         // Bevy animation (stays in core)
         self.trigger_speech_animation(user_id, text, &synthesis.samples, sample_rate, duration_ms);
 
-        // Send PCM audio to bridge for LiveKit publishing — media plane,
-        // fire-and-forget: the speak turn must never block behind the bridge.
-        let pcm_bytes = pcm_le_bytes(&synthesis.samples);
-
+        // Send PCM audio to bridge for LiveKit publishing — BINARY media
+        // plane, fire-and-forget: identity bound once, payload moved (never
+        // copied), the speak turn never blocks behind the bridge.
+        let _ = num_samples;
+        let channel = self.ensure_out_channel(
+            call_id,
+            user_id,
+            continuum_bridge_protocol::MediaKind::AudioPcm,
+        )?;
         self.send_media(
-            BridgeCommand::Speak {
-                call_id: call_id.to_string(),
-                user_id: user_id.to_string(),
-                sample_count: num_samples as u32,
-            },
-            &pcm_bytes,
+            continuum_bridge_protocol::MediaKind::AudioPcm,
+            channel,
+            None,
+            pcm_le_bytes(&synthesis.samples),
             "speak-pcm",
         )?;
 
@@ -484,14 +557,16 @@ impl LiveKitAgentManager {
         user_id: &str,
         samples: Vec<i16>,
     ) -> Result<(), String> {
-        let pcm_bytes = pcm_le_bytes(&samples);
+        let channel = self.ensure_out_channel(
+            call_id,
+            user_id,
+            continuum_bridge_protocol::MediaKind::AudioPcm,
+        )?;
         self.send_media(
-            BridgeCommand::InjectAudio {
-                call_id: call_id.to_string(),
-                user_id: user_id.to_string(),
-                sample_count: samples.len() as u32,
-            },
-            &pcm_bytes,
+            continuum_bridge_protocol::MediaKind::AudioPcm,
+            channel,
+            None,
+            pcm_le_bytes(&samples),
             "inject-audio",
         )
     }
@@ -508,17 +583,22 @@ impl LiveKitAgentManager {
         &self,
         call_id: &str,
         user_id: &str,
-        rgba: &[u8],
+        rgba: Vec<u8>,
         width: u32,
         height: u32,
     ) -> Result<(), String> {
+        // BINARY plane: [w][h] ride as a 4-byte header part; the ~3.7MB RGBA
+        // payload is MOVED end-to-end — pump → queue → kernel, zero copies
+        // (30fps × N personas forbids any other answer).
+        let channel = self.ensure_out_channel(
+            call_id,
+            user_id,
+            continuum_bridge_protocol::MediaKind::VideoRgba,
+        )?;
         self.send_media(
-            BridgeCommand::PublishVideoFrame {
-                call_id: call_id.to_string(),
-                user_id: user_id.to_string(),
-                width,
-                height,
-            },
+            continuum_bridge_protocol::MediaKind::VideoRgba,
+            channel,
+            Some((width as u16, height as u16)),
             rgba,
             "video-frame",
         )
@@ -555,16 +635,21 @@ impl LiveKitAgentManager {
         handle: &str,
         samples: Vec<i16>,
     ) -> Result<(), String> {
+        // Ambient stays on the COMMAND plane: the bridge's ambient sink is a
+        // no-op ack today (server.rs dispatches InjectAmbient to `{"ack"}`),
+        // so this is not a live per-frame path. When the ambient mixer gets
+        // built bridge-side it joins the binary plane with its own MediaKind —
+        // do NOT stream a real 50fps bed through here.
         let pcm_bytes = pcm_le_bytes(&samples);
-        self.send_media(
+        self.send_command(
             BridgeCommand::InjectAmbient {
                 call_id: call_id.to_string(),
                 handle: handle.to_string(),
                 sample_count: samples.len() as u32,
             },
-            &pcm_bytes,
-            "inject-ambient",
+            Some(&pcm_bytes),
         )
+        .map(|_| ())
     }
 
     pub async fn remove_ambient_source(&self, call_id: &str, handle: &str) -> Result<(), String> {
@@ -682,7 +767,16 @@ fn media_pump_loop(
         let mut guard = writer.lock().unwrap();
         match guard.as_mut() {
             Some(stream) => {
-                if let Err(e) = stream.write_all(&item.frame) {
+                // Parts back-to-back — the payload was MOVED here, never
+                // copied into a combined frame (30fps HD forbids it).
+                let write = stream
+                    .write_all(&item.header)
+                    .and_then(|_| match &item.dims {
+                        Some(d) => stream.write_all(d),
+                        None => Ok(()),
+                    })
+                    .and_then(|_| stream.write_all(&item.payload));
+                if let Err(e) = write {
                     clog_warn!("🌉 media pump write failed ({}): {}", item.kind, e);
                     *guard = None;
                     return;
@@ -696,7 +790,7 @@ fn media_pump_loop(
                     class = "media.pump.write",
                     module = "livekit-bridge",
                     kind = item.kind,
-                    bytes = item.frame.len(),
+                    bytes = item.wire_len(),
                     write_us = start.elapsed().as_micros() as u64
                 );
             }
@@ -708,12 +802,24 @@ fn media_pump_loop(
     }
 }
 
+/// One bound INBOUND media channel: identity strings held once as `Arc<str>`
+/// so the per-frame path clones two pointers, never bytes.
+struct InMediaBinding {
+    kind: continuum_bridge_protocol::MediaKind,
+    call_id: std::sync::Arc<str>,
+    speaker_id: std::sync::Arc<str>,
+    speaker_name: std::sync::Arc<str>,
+    frames: u64,
+}
+
 fn reader_loop(mut stream: UnixStream, pending: Arc<Mutex<HashMap<u64, Arc<PendingRequest>>>>) {
     let mut buf = vec![0u8; 4 * 1024 * 1024];
     let mut data = Vec::new();
 
     // Audio processing state per speaker (call_id + speaker_id → VAD state)
     let mut audio_processors: HashMap<String, AudioProcessor> = HashMap::new();
+    // Inbound binary media channels (bound once via MediaChannelOpened).
+    let mut in_channels: HashMap<u16, InMediaBinding> = HashMap::new();
 
     loop {
         let n = match stream.read(&mut buf) {
@@ -736,6 +842,78 @@ fn reader_loop(mut stream: UnixStream, pending: Arc<Mutex<HashMap<u64, Arc<Pendi
                 break;
             }
 
+            // BINARY MEDIA plane first (2026-09-01): one byte decides, the
+            // frame is processed as a BORROW of the socket buffer — no
+            // to_vec, no JSON, no double-parse. The old shape parsed every
+            // 20ms audio frame as JSON TWICE (response-then-event) with four
+            // identity strings each; at 50fps/speaker that was the
+            // eat-the-cpu-at-the-boundary mistake the airc design forbids.
+            if let Some((kind, channel, payload)) =
+                continuum_bridge_protocol::parse_media_frame(&data[4..4 + frame_len])
+            {
+                match in_channels.get_mut(&channel) {
+                    Some(binding) if binding.kind != kind => {
+                        clog_warn!(
+                            "🌉 media frame kind {:?} ≠ bound {:?} on ch {} — dropped",
+                            kind,
+                            binding.kind,
+                            channel
+                        );
+                    }
+                    Some(binding) => match kind {
+                        continuum_bridge_protocol::MediaKind::AudioPcm => {
+                            binding.frames += 1;
+                            let samples: Vec<i16> = payload
+                                .chunks_exact(2)
+                                .map(|c| i16::from_le_bytes([c[0], c[1]]))
+                                .collect();
+                            if let Some(tx) = HUMAN_AUDIO_TX.get() {
+                                let saturated = tx
+                                    .try_send(HumanAudioChunk {
+                                        call_id: binding.call_id.clone(),
+                                        user_id: binding.speaker_id.clone(),
+                                        samples,
+                                    })
+                                    .is_err();
+                                if saturated && binding.frames % 500 == 1 {
+                                    clog_warn!(
+                                        "🎤 human-audio forwarder saturated — dropping frames from '{}' to stay current",
+                                        binding.speaker_name
+                                    );
+                                }
+                            } else if binding.frames == 1 {
+                                clog_warn!(
+                                    "🎤 no human-audio forwarder installed — speech from '{}' cannot reach STT",
+                                    binding.speaker_name
+                                );
+                            }
+                        }
+                        continuum_bridge_protocol::MediaKind::VideoJpeg => {
+                            if let Some((_w, _h, jpeg)) =
+                                continuum_bridge_protocol::parse_video_payload(payload)
+                            {
+                                crate::media::perception_ingest::try_enqueue(
+                                    crate::media::perception_ingest::IngestFrame {
+                                        call_id: binding.call_id.to_string(),
+                                        speaker_id: binding.speaker_id.to_string(),
+                                        jpeg: jpeg.to_vec(),
+                                        mime: "image/jpeg".to_string(),
+                                    },
+                                );
+                            }
+                        }
+                        continuum_bridge_protocol::MediaKind::VideoRgba => {
+                            clog_warn!("🌉 VideoRgba is outbound-only — dropped (ch {channel})");
+                        }
+                    },
+                    None => {
+                        clog_warn!("🌉 media frame on unbound in-channel {channel} — dropped");
+                    }
+                }
+                data.drain(..4 + frame_len);
+                continue;
+            }
+
             let frame_data = data[4..4 + frame_len].to_vec();
             data.drain(..4 + frame_len);
 
@@ -754,7 +932,7 @@ fn reader_loop(mut stream: UnixStream, pending: Arc<Mutex<HashMap<u64, Arc<Pendi
 
             // Try as BridgeEvent (pushed from bridge)
             if let Ok(event) = serde_json::from_slice::<BridgeEvent>(json_bytes) {
-                handle_bridge_event(event, binary, &mut audio_processors);
+                handle_bridge_event(event, binary, &mut audio_processors, &mut in_channels);
             }
         }
     }
@@ -764,8 +942,8 @@ fn reader_loop(mut stream: UnixStream, pending: Arc<Mutex<HashMap<u64, Arc<Pendi
 /// hopping from the bridge reader THREAD into async land where the CallServer
 /// lives. Bounded; a saturated channel drops frames (stay-current rule).
 pub struct HumanAudioChunk {
-    pub call_id: String,
-    pub user_id: String,
+    pub call_id: std::sync::Arc<str>,
+    pub user_id: std::sync::Arc<str>,
     pub samples: Vec<i16>,
 }
 
@@ -781,22 +959,24 @@ pub fn install_human_audio_forwarder(tx: tokio::sync::mpsc::Sender<HumanAudioChu
     let _ = HUMAN_AUDIO_TX.set(tx);
 }
 
-/// Per-speaker audio processing state (VAD frame accumulation).
+/// Per-speaker audio processing state for the LEGACY JSON AudioFrame arm
+/// (kept as wire-compat while older bridges drain; the binary plane's
+/// per-channel state lives in [`InMediaBinding`]). track_sid was dropped when
+/// the accumulate-into-VAD path moved to the CallServer — routing needs only
+/// call + speaker identity.
 struct AudioProcessor {
     call_id: String,
     speaker_id: String,
     speaker_name: String,
-    track_sid: String,
     frame_count: u64,
 }
 
 impl AudioProcessor {
-    fn new(call_id: String, speaker_id: String, speaker_name: String, track_sid: String) -> Self {
+    fn new(call_id: String, speaker_id: String, speaker_name: String) -> Self {
         Self {
             call_id,
             speaker_id,
             speaker_name,
-            track_sid,
             frame_count: 0,
         }
     }
@@ -807,13 +987,43 @@ fn handle_bridge_event(
     event: BridgeEvent,
     binary: Option<&[u8]>,
     processors: &mut HashMap<String, AudioProcessor>,
+    in_channels: &mut HashMap<u16, InMediaBinding>,
 ) {
     match event {
+        BridgeEvent::MediaChannelOpened {
+            channel,
+            kind,
+            call_id,
+            speaker_id,
+            speaker_name,
+            track_sid: _,
+        } => {
+            // Identity binds ONCE per (speaker, kind); every subsequent frame
+            // on this channel is header + payload only. The Strings arriving
+            // here are the LAST per-speaker identity allocations on this path.
+            clog_info!(
+                "🌉 media in-channel {} bound: {:?} from '{}' in call {}",
+                channel,
+                kind,
+                speaker_name,
+                &call_id[..8.min(call_id.len())]
+            );
+            in_channels.insert(
+                channel,
+                InMediaBinding {
+                    kind,
+                    call_id: call_id.into(),
+                    speaker_id: speaker_id.into(),
+                    speaker_name: speaker_name.into(),
+                    frames: 0,
+                },
+            );
+        }
         BridgeEvent::AudioFrame {
             call_id,
             speaker_id,
             speaker_name,
-            track_sid,
+            track_sid: _,
             sample_count: _,
         } => {
             // Decode PCM samples from binary payload
@@ -832,12 +1042,7 @@ fn handle_bridge_event(
                     speaker_name,
                     &call_id[..8.min(call_id.len())]
                 );
-                AudioProcessor::new(
-                    call_id.clone(),
-                    speaker_id.clone(),
-                    speaker_name.clone(),
-                    track_sid.clone(),
-                )
+                AudioProcessor::new(call_id.clone(), speaker_id.clone(), speaker_name.clone())
             });
 
             processor.frame_count += 1;
@@ -864,8 +1069,8 @@ fn handle_bridge_event(
             // rule the transcription semaphore applies downstream).
             if let Some(tx) = HUMAN_AUDIO_TX.get() {
                 let chunk = HumanAudioChunk {
-                    call_id: processor.call_id.clone(),
-                    user_id: processor.speaker_id.clone(),
+                    call_id: processor.call_id.as_str().into(),
+                    user_id: processor.speaker_id.as_str().into(),
                     samples,
                 };
                 if tx.try_send(chunk).is_err() && processor.frame_count % 500 == 1 {

--- a/core/livekit-bridge/src/agent.rs
+++ b/core/livekit-bridge/src/agent.rs
@@ -20,7 +20,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex, RwLock};
-use tracing::{info, warn, error};
+use tracing::{info, warn};
 
 /// Event with optional binary payload (e.g., PCM audio samples).
 pub struct EventWithPayload {
@@ -200,10 +200,6 @@ impl Agent {
         &self.audio_track_sid
     }
 
-    pub fn identity(&self) -> &str {
-        &self.identity
-    }
-
     pub async fn disconnect(&self) {
         info!("🔊 Agent '{}' disconnecting", self.identity);
         let _ = self.shutdown_tx.send(true);
@@ -222,20 +218,28 @@ pub struct AgentManager {
     agents: RwLock<HashMap<AgentKey, Arc<Agent>>>,
     listeners: RwLock<HashMap<String, Arc<Room>>>,
     livekit_url: String,
-    /// Channel to send audio frames from STT listeners back to core.
+    /// Channel to send CONTROL events back to core (JSON plane).
     audio_tx: mpsc::UnboundedSender<EventWithPayload>,
+    /// Channel to send continuous MEDIA frames back to core (binary plane —
+    /// identity bound once via MediaChannelOpened, then [magic][kind][ch]+payload).
+    media_tx: mpsc::UnboundedSender<(continuum_bridge_protocol::MediaKind, u16, Vec<u8>)>,
 }
+
+/// Bridge-assigned inbound channel ids (its own send-direction namespace).
+static NEXT_IN_CHANNEL: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(1);
 
 impl AgentManager {
     pub fn new(
         livekit_url: String,
         audio_tx: mpsc::UnboundedSender<EventWithPayload>,
+        media_tx: mpsc::UnboundedSender<(continuum_bridge_protocol::MediaKind, u16, Vec<u8>)>,
     ) -> Self {
         Self {
             agents: RwLock::new(HashMap::new()),
             listeners: RwLock::new(HashMap::new()),
             livekit_url,
             audio_tx,
+            media_tx,
         }
     }
 
@@ -356,6 +360,7 @@ impl AgentManager {
         });
 
         let audio_tx = self.audio_tx.clone();
+        let media_plane_tx = self.media_tx.clone();
         let call_id_owned = call_id.to_string();
 
         // Spawn event handler — subscribes to audio tracks and forwards PCM to core
@@ -383,6 +388,7 @@ impl AgentManager {
                                 info!("🎤 Subscribed to audio from '{}' ({})", speaker_name, &speaker_id[..8.min(speaker_id.len())]);
 
                                 let tx = audio_tx.clone();
+                                let mtx = media_plane_tx.clone();
                                 let cid = call_id_owned.clone();
                                 let sid = speaker_id.clone();
                                 let sname = speaker_name.clone();
@@ -392,7 +398,7 @@ impl AgentManager {
                                 // and sends raw PCM to core for VAD/STT processing
                                 tokio::spawn(async move {
                                     forward_audio_to_core(
-                                        audio_track, tx, cid, sid, sname, tsid,
+                                        audio_track, tx, mtx, cid, sid, sname, tsid,
                                     ).await;
                                 });
                             }
@@ -407,12 +413,14 @@ impl AgentManager {
                                 info!("👁 Subscribed to video from '{}' ({})", speaker_name, &speaker_id[..8.min(speaker_id.len())]);
 
                                 let tx = audio_tx.clone();
+                                let mtx = media_plane_tx.clone();
                                 let cid = call_id_owned.clone();
                                 let sid = speaker_id.clone();
                                 let sname = speaker_name.clone();
 
                                 tokio::spawn(async move {
-                                    forward_video_to_core(video_track, tx, cid, sid, sname).await;
+                                    forward_video_to_core(video_track, tx, mtx, cid, sid, sname)
+                                        .await;
                                 });
                             }
                         }
@@ -479,6 +487,7 @@ impl AgentManager {
 async fn forward_audio_to_core(
     audio_track: RemoteAudioTrack,
     tx: mpsc::UnboundedSender<EventWithPayload>,
+    media_tx: mpsc::UnboundedSender<(continuum_bridge_protocol::MediaKind, u16, Vec<u8>)>,
     call_id: String,
     speaker_id: String,
     speaker_name: String,
@@ -493,6 +502,23 @@ async fn forward_audio_to_core(
         1, // mono
     );
 
+    // BIND ONCE, THEN STREAM (binary plane, 2026-09-01): the old shape sent a
+    // JSON `AudioFrame` event — four identity strings, a serialize here and a
+    // DOUBLE parse in core — 50×/sec/speaker. Identity now binds once; every
+    // frame after is [magic][kind][channel] + raw PCM.
+    let channel = NEXT_IN_CHANNEL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let _ = tx.send(EventWithPayload {
+        event: continuum_bridge_protocol::BridgeEvent::MediaChannelOpened {
+            channel,
+            kind: continuum_bridge_protocol::MediaKind::AudioPcm,
+            call_id,
+            speaker_id,
+            speaker_name: speaker_name.clone(),
+            track_sid,
+        },
+        binary: None,
+    });
+
     let mut frame_count: u64 = 0;
     while let Some(frame) = stream.next().await {
         frame_count += 1;
@@ -500,29 +526,26 @@ async fn forward_audio_to_core(
 
         if frame_count == 1 {
             info!(
-                "🎤 First audio frame from '{}': {} samples, sr={}",
-                speaker_name, samples.len(), frame.sample_rate
+                "🎤 First audio frame from '{}': {} samples, sr={} → binary ch {}",
+                speaker_name, samples.len(), frame.sample_rate, channel
             );
         }
 
-        // Send raw PCM to core — core does VAD/STT
-        let pcm_bytes: Vec<u8> = samples.iter()
-            .flat_map(|s| s.to_le_bytes())
-            .collect();
+        // Raw PCM to core (LE bytes) — core does VAD/STT.
+        let mut pcm_bytes: Vec<u8> = Vec::with_capacity(samples.len() * 2);
+        for s in samples {
+            pcm_bytes.extend_from_slice(&s.to_le_bytes());
+        }
 
-        let payload = EventWithPayload {
-            event: continuum_bridge_protocol::BridgeEvent::AudioFrame {
-                call_id: call_id.clone(),
-                speaker_id: speaker_id.clone(),
-                speaker_name: speaker_name.clone(),
-                track_sid: track_sid.clone(),
-                sample_count: samples.len() as u32,
-            },
-            binary: Some(pcm_bytes),
-        };
-
-        if tx.send(payload).is_err() {
-            warn!("🎤 Audio channel closed for '{}'", speaker_name);
+        if media_tx
+            .send((
+                continuum_bridge_protocol::MediaKind::AudioPcm,
+                channel,
+                pcm_bytes,
+            ))
+            .is_err()
+        {
+            warn!("🎤 Media channel closed for '{}'", speaker_name);
             break;
         }
     }
@@ -537,9 +560,11 @@ async fn forward_audio_to_core(
 /// Capture video frames from a LiveKit participant, convert to JPEG,
 /// and forward to core for vision processing.
 /// Rate-limited to 1 fps — AI vision doesn't need every frame.
+#[allow(clippy::too_many_arguments)]
 async fn forward_video_to_core(
     video_track: RemoteVideoTrack,
     tx: mpsc::UnboundedSender<EventWithPayload>,
+    media_tx: mpsc::UnboundedSender<(continuum_bridge_protocol::MediaKind, u16, Vec<u8>)>,
     call_id: String,
     speaker_id: String,
     speaker_name: String,
@@ -549,6 +574,23 @@ async fn forward_video_to_core(
 
     let video_stream = NativeVideoStream::new(video_track.rtc_track());
     let mut pinned_stream = std::pin::pin!(video_stream);
+
+    // BIND ONCE, THEN STREAM (binary plane — same concept as audio): identity
+    // rides one MediaChannelOpened; every sampled JPEG after is
+    // [magic][kind][channel][w][h] + bytes. Vision cognition samples at 1fps —
+    // 30fps HD into a mind that perceives once a second is pure waste.
+    let channel = NEXT_IN_CHANNEL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let _ = tx.send(EventWithPayload {
+        event: continuum_bridge_protocol::BridgeEvent::MediaChannelOpened {
+            channel,
+            kind: continuum_bridge_protocol::MediaKind::VideoJpeg,
+            call_id: call_id.clone(),
+            speaker_id: speaker_id.clone(),
+            speaker_name: speaker_name.clone(),
+            track_sid: String::new(),
+        },
+        binary: None,
+    });
 
     let min_interval = std::time::Duration::from_secs(1); // 1 fps
     let mut last_capture = std::time::Instant::now() - min_interval;
@@ -574,10 +616,7 @@ async fn forward_video_to_core(
         }
 
         // Convert I420 → RGBA on blocking thread
-        let sid = speaker_id.clone();
-        let sname = speaker_name.clone();
-        let cid = call_id.clone();
-        let tx_clone = tx.clone();
+        let mtx_clone = media_tx.clone();
 
         let i420_data = frame.buffer.to_i420();
         let (data_y, data_u, data_v) = i420_data.data();
@@ -628,22 +667,20 @@ async fn forward_video_to_core(
                 return;
             }
 
-            // Content hash for dedup
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            jpeg[..jpeg.len().min(1024)].hash(&mut hasher);
-            let hash = format!("{:016x}", hasher.finish());
-
-            let _ = tx_clone.send(EventWithPayload {
-                event: continuum_bridge_protocol::BridgeEvent::VideoFrame {
-                    call_id: cid,
-                    speaker_id: sid,
-                    speaker_name: sname,
-                    width,
-                    height,
-                },
-                binary: Some(jpeg),
-            });
+            // Binary plane: [w][h] + jpeg on the bound channel — no JSON,
+            // no identity strings, no core-side double parse.
+            let mut payload = Vec::new();
+            continuum_bridge_protocol::encode_video_payload_into(
+                &mut payload,
+                width as u16,
+                height as u16,
+                &jpeg,
+            );
+            let _ = mtx_clone.send((
+                continuum_bridge_protocol::MediaKind::VideoJpeg,
+                channel,
+                payload,
+            ));
         });
 
         last_capture = std::time::Instant::now();

--- a/core/livekit-bridge/src/server.rs
+++ b/core/livekit-bridge/src/server.rs
@@ -7,7 +7,7 @@
 //! length-prefixed frames. Commands have `request_id`; events don't.
 
 use crate::agent::{AgentManager, EventWithPayload};
-use continuum_bridge_protocol::{BridgeCommand, BridgeEvent, BridgeResponse};
+use continuum_bridge_protocol::{BridgeCommand, BridgeResponse};
 
 use std::io::{Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
@@ -23,7 +23,17 @@ pub async fn run(socket_path: &str, livekit_url: &str) -> Result<(), Box<dyn std
 
     // Event channel — AgentManager sends events here, we forward to core
     let (event_tx, event_rx) = mpsc::unbounded_channel::<EventWithPayload>();
-    let manager = Arc::new(AgentManager::new(livekit_url.to_string(), event_tx));
+    // MEDIA plane (binary, 2026-09-01): continuous frames (PCM, video) ride
+    // their own channel into the SAME writer — identity was bound once via a
+    // MediaChannelOpened control event, so each frame is [magic][kind][ch] +
+    // payload: no JSON, no strings, no per-frame serialize.
+    let (media_tx, media_rx) =
+        mpsc::unbounded_channel::<(continuum_bridge_protocol::MediaKind, u16, Vec<u8>)>();
+    let manager = Arc::new(AgentManager::new(
+        livekit_url.to_string(),
+        event_tx,
+        media_tx,
+    ));
 
     let rt = tokio::runtime::Handle::current();
 
@@ -47,29 +57,47 @@ pub async fn run(socket_path: &str, livekit_url: &str) -> Result<(), Box<dyn std
                 let writer = Arc::new(std::sync::Mutex::new(write_stream));
                 let writer_for_events = writer.clone();
 
-                // Spawn event forwarder — pushes bridge events to core
+                // Spawn event forwarder — pushes bridge events AND binary media
+                // frames to core over one socket, two planes. One reused encode
+                // buffer: the media hot path allocates nothing once warm.
                 let mut event_rx_moved = event_rx;
+                let mut media_rx_moved = media_rx;
                 let event_handle = handle.clone();
                 std::thread::spawn(move || {
                     event_handle.block_on(async move {
-                        while let Some(payload) = event_rx_moved.recv().await {
-                            let json = match serde_json::to_vec(&payload.event) {
-                                Ok(j) => j,
-                                Err(e) => {
-                                    warn!("🌉 Event serialize error: {}", e);
-                                    continue;
+                        let mut media_buf: Vec<u8> = Vec::new();
+                        loop {
+                            tokio::select! {
+                                payload = event_rx_moved.recv() => {
+                                    let Some(payload) = payload else { break };
+                                    let json = match serde_json::to_vec(&payload.event) {
+                                        Ok(j) => j,
+                                        Err(e) => {
+                                            warn!("🌉 Event serialize error: {}", e);
+                                            continue;
+                                        }
+                                    };
+                                    let frame = continuum_bridge_protocol::encode_frame(
+                                        &json,
+                                        payload.binary.as_deref(),
+                                    );
+                                    let mut w = writer_for_events.lock().unwrap();
+                                    if let Err(e) = w.write_all(&frame) {
+                                        warn!("🌉 Event write error (core disconnected?): {}", e);
+                                        break;
+                                    }
                                 }
-                            };
-
-                            let frame = continuum_bridge_protocol::encode_frame(
-                                &json,
-                                payload.binary.as_deref(),
-                            );
-
-                            let mut w = writer_for_events.lock().unwrap();
-                            if let Err(e) = w.write_all(&frame) {
-                                warn!("🌉 Event write error (core disconnected?): {}", e);
-                                break;
+                                media = media_rx_moved.recv() => {
+                                    let Some((kind, channel, payload)) = media else { break };
+                                    continuum_bridge_protocol::encode_media_frame_into(
+                                        &mut media_buf, kind, channel, &payload,
+                                    );
+                                    let mut w = writer_for_events.lock().unwrap();
+                                    if let Err(e) = w.write_all(&media_buf) {
+                                        warn!("🌉 Media write error (core disconnected?): {}", e);
+                                        break;
+                                    }
+                                }
                             }
                         }
                     });
@@ -112,6 +140,13 @@ fn handle_client(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = vec![0u8; 4 * 1024 * 1024]; // 4MB read buffer (video frames can be large)
     let mut pending = Vec::new();
+    // Core-assigned OUTBOUND media channels (binary plane): channel →
+    // (kind, call_id, user_id), bound once by OpenMediaOut. Media frames then
+    // route here with zero JSON and zero identity strings per frame.
+    let mut out_channels: std::collections::HashMap<
+        u16,
+        (continuum_bridge_protocol::MediaKind, String, String),
+    > = std::collections::HashMap::new();
 
     loop {
         let n = match read_stream.read(&mut buf) {
@@ -135,6 +170,55 @@ fn handle_client(
                 break;
             }
 
+            // BINARY MEDIA plane first — one byte decides, and the frame is
+            // processed as a BORROW of the socket buffer: at 30fps HD RGBA
+            // (~3.7MB/frame/persona) every avoidable copy is real CPU
+            // (forward-on, no copies — the airc law, 2026-09-01). The only
+            // copy on this path is the I420 transform physics requires.
+            if let Some((kind, channel, payload)) =
+                continuum_bridge_protocol::parse_media_frame(&pending[4..4 + frame_len])
+            {
+                match out_channels.get(&channel) {
+                    Some((_, call_id, user_id)) => match kind {
+                        continuum_bridge_protocol::MediaKind::AudioPcm => {
+                            let samples: Vec<i16> = payload
+                                .chunks_exact(2)
+                                .map(|c| i16::from_le_bytes([c[0], c[1]]))
+                                .collect();
+                            if let Err(e) =
+                                rt.block_on(manager.speak(call_id, user_id, samples))
+                            {
+                                warn!("🌉 media speak failed on ch {}: {}", channel, e);
+                            }
+                        }
+                        continuum_bridge_protocol::MediaKind::VideoRgba => {
+                            if let Some((w, h, rgba)) =
+                                continuum_bridge_protocol::parse_video_payload(payload)
+                            {
+                                if let Err(e) = rt.block_on(manager.publish_video_frame(
+                                    call_id,
+                                    user_id,
+                                    rgba,
+                                    w as u32,
+                                    h as u32,
+                                )) {
+                                    warn!("🌉 media video failed on ch {}: {}", channel, e);
+                                }
+                            }
+                        }
+                        continuum_bridge_protocol::MediaKind::VideoJpeg => {
+                            warn!("🌉 VideoJpeg is an inbound-only kind — dropped");
+                        }
+                    },
+                    None => {
+                        warn!("🌉 media frame on unbound out-channel {} — dropped", channel)
+                    }
+                }
+                pending.drain(..4 + frame_len);
+                continue;
+            }
+
+            // JSON control plane (low rate): the owned copy here is fine.
             let frame_data = pending[4..4 + frame_len].to_vec();
             pending.drain(..4 + frame_len);
 
@@ -142,6 +226,38 @@ fn handle_client(
 
             match serde_json::from_slice::<CommandEnvelope>(json_bytes) {
                 Ok(envelope) => {
+                    // Channel binding is a CONTROL act, handled here where the
+                    // out-channel map lives (once per stream, never per frame).
+                    if let BridgeCommand::OpenMediaOut {
+                        channel,
+                        kind,
+                        call_id,
+                        user_id,
+                    } = envelope.command
+                    {
+                        info!(
+                            "🌉 out-channel {} bound: {:?} for {}/{}",
+                            channel,
+                            kind,
+                            &call_id[..8.min(call_id.len())],
+                            &user_id[..8.min(user_id.len())]
+                        );
+                        out_channels.insert(channel, (kind, call_id, user_id));
+                        let response = BridgeResponse {
+                            request_id: envelope.request_id,
+                            success: true,
+                            error: None,
+                            data: Some(serde_json::json!({ "opened": true })),
+                        };
+                        let resp_json = serde_json::to_vec(&response).unwrap_or_default();
+                        let resp_frame =
+                            continuum_bridge_protocol::encode_frame(&resp_json, None);
+                        let mut w = writer.lock().unwrap();
+                        if w.write_all(&resp_frame).is_err() {
+                            return Ok(());
+                        }
+                        continue;
+                    }
                     let response = rt.block_on(dispatch_command(
                         &manager,
                         envelope.request_id,
@@ -228,6 +344,11 @@ async fn dispatch_command(
         BridgeCommand::AddAmbient { .. } |
         BridgeCommand::InjectAmbient { .. } |
         BridgeCommand::RemoveAmbient { .. } => Ok(serde_json::json!({ "ack": true })),
+        // Bound inline in handle_client (where the out-channel map lives);
+        // reaching here means a caller bypassed that path — refuse loudly.
+        BridgeCommand::OpenMediaOut { channel, .. } => {
+            Err(format!("OpenMediaOut ch {channel} must bind in handle_client"))
+        }
         BridgeCommand::SnapshotRoom | BridgeCommand::SnapshotParticipant { .. } => {
             Ok(serde_json::json!({ "snapshot": "not_implemented" }))
         }

--- a/core/livekit-protocol/src/lib.rs
+++ b/core/livekit-protocol/src/lib.rs
@@ -131,6 +131,18 @@ pub enum BridgeCommand {
     SnapshotParticipant {
         identity: String,
     },
+
+    /// Bind a CORE-assigned outbound media channel (binary plane, 2026-09-01):
+    /// after this, frames for `(call_id, user_id, kind)` arrive as
+    /// [`MEDIA_MAGIC`] binary frames on `channel` — identity once, then
+    /// streaming. Replaces per-frame `Speak`/`InjectAudio`/`PublishVideoFrame`
+    /// JSON envelopes for continuous media.
+    OpenMediaOut {
+        channel: u16,
+        kind: MediaKind,
+        call_id: String,
+        user_id: String,
+    },
 }
 
 // =============================================================================
@@ -159,6 +171,20 @@ pub enum BridgeEvent {
         speaker_name: String,
         width: u32,
         height: u32,
+    },
+
+    /// Bind a BRIDGE-assigned inbound media channel (binary plane,
+    /// 2026-09-01): after this, `(call_id, speaker_id, kind)`'s media arrives
+    /// as [`MEDIA_MAGIC`] binary frames on `channel` — identity once, then
+    /// streaming. Replaces the per-frame `AudioFrame`/`VideoFrame` JSON
+    /// envelopes for continuous media.
+    MediaChannelOpened {
+        channel: u16,
+        kind: MediaKind,
+        call_id: String,
+        speaker_id: String,
+        speaker_name: String,
+        track_sid: String,
     },
 
     /// Human participant connected to the LiveKit room.
@@ -240,6 +266,99 @@ pub struct BridgeResponse {
     /// Command-specific response data.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<serde_json::Value>,
+}
+
+// =============================================================================
+// BINARY MEDIA PLANE — handle + stream, never JSON-per-frame (2026-09-01)
+// =============================================================================
+//
+// Continuous media (audio PCM, avatar/video frames — and tomorrow, 3D/game
+// state streams) must NEVER pay a JSON envelope per frame. The old shape —
+// `{type:"AudioFrame", call_id:"<uuid>", speaker_id:"<uuid>", …}` serialized
+// and DOUBLE-parsed 50×/sec/speaker, and `PublishVideoFrame` JSON wrapping
+// ~1MB of RGBA 30×/sec/persona — is the handle-less anti-pattern: identity
+// restated per frame, parse cost per frame, allocation per frame.
+//
+// The plane: identity binds ONCE on the control plane (a JSON channel-open
+// message), yielding a u16 CHANNEL handle; media then flows as tight binary
+// frames. A JSON frame always begins with `{` (0x7B); a media frame begins
+// with [`MEDIA_MAGIC`] — one byte disambiguates the planes on the same socket
+// with zero scanning.
+//
+//   [len: u32 LE] [0xB1] [kind: u8] [channel: u16 LE] [payload…]
+//     kind 1 = AUDIO_PCM:  payload = i16 LE mono PCM at the core rate (16k)
+//     kind 2 = VIDEO_RGBA: payload = [w: u16 LE][h: u16 LE][rgba bytes]
+//     kind 3 = VIDEO_JPEG: payload = [w: u16 LE][h: u16 LE][jpeg bytes]
+//
+// Channel id spaces are PER-DIRECTION (each sender assigns its own ids and
+// announces the binding), so no negotiation and no races. Receivers hold a
+// tiny channel→binding map and touch no strings on the frame path.
+
+/// First byte of a binary media frame. JSON frames start with `{` (0x7B).
+pub const MEDIA_MAGIC: u8 = 0xB1;
+
+/// Media payload kinds for the binary plane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MediaKind {
+    AudioPcm = 1,
+    VideoRgba = 2,
+    VideoJpeg = 3,
+}
+
+impl MediaKind {
+    pub fn from_u8(b: u8) -> Option<Self> {
+        match b {
+            1 => Some(Self::AudioPcm),
+            2 => Some(Self::VideoRgba),
+            3 => Some(Self::VideoJpeg),
+            _ => None,
+        }
+    }
+}
+
+/// Encode one binary media frame into `buf` (cleared first, capacity reused —
+/// the caller keeps one buffer per stream so the frame path allocates nothing
+/// once warm).
+pub fn encode_media_frame_into(buf: &mut Vec<u8>, kind: MediaKind, channel: u16, payload: &[u8]) {
+    buf.clear();
+    let total = 1 + 1 + 2 + payload.len();
+    buf.reserve(4 + total);
+    buf.extend_from_slice(&(total as u32).to_le_bytes());
+    buf.push(MEDIA_MAGIC);
+    buf.push(kind as u8);
+    buf.extend_from_slice(&channel.to_le_bytes());
+    buf.extend_from_slice(payload);
+}
+
+/// Parse a frame (length prefix already stripped) as a binary media frame.
+/// `None` = not a media frame (fall through to the JSON plane).
+pub fn parse_media_frame(frame: &[u8]) -> Option<(MediaKind, u16, &[u8])> {
+    if frame.len() < 4 || frame[0] != MEDIA_MAGIC {
+        return None;
+    }
+    let kind = MediaKind::from_u8(frame[1])?;
+    let channel = u16::from_le_bytes([frame[2], frame[3]]);
+    Some((kind, channel, &frame[4..]))
+}
+
+/// Prepend a `[w][h]` dimension header to a video payload (RGBA or JPEG).
+pub fn encode_video_payload_into(buf: &mut Vec<u8>, width: u16, height: u16, pixels: &[u8]) {
+    buf.clear();
+    buf.reserve(4 + pixels.len());
+    buf.extend_from_slice(&width.to_le_bytes());
+    buf.extend_from_slice(&height.to_le_bytes());
+    buf.extend_from_slice(pixels);
+}
+
+/// Split a video payload into `(width, height, pixels)`.
+pub fn parse_video_payload(payload: &[u8]) -> Option<(u16, u16, &[u8])> {
+    if payload.len() < 4 {
+        return None;
+    }
+    let w = u16::from_le_bytes([payload[0], payload[1]]);
+    let h = u16::from_le_bytes([payload[2], payload[3]]);
+    Some((w, h, &payload[4..]))
 }
 
 // =============================================================================
@@ -336,6 +455,34 @@ mod tests {
         let (decoded_json, decoded_bin) = decode_frame(&frame[4..4 + len]);
         assert_eq!(decoded_json, json);
         assert_eq!(decoded_bin.unwrap(), &audio[..]);
+    }
+
+    #[test]
+    fn media_frame_roundtrip_and_json_disambiguation() {
+        // what this catches: the binary media plane and the JSON plane share
+        // one socket — a media frame must round-trip losslessly AND a JSON
+        // frame must NEVER parse as media (0xB1 vs '{' is the whole contract).
+        let mut buf = Vec::new();
+        let pcm: Vec<u8> = (0u16..320).flat_map(|s| s.to_le_bytes()).collect();
+        encode_media_frame_into(&mut buf, MediaKind::AudioPcm, 7, &pcm);
+        let len = u32::from_le_bytes(buf[0..4].try_into().unwrap()) as usize;
+        let (kind, channel, payload) = parse_media_frame(&buf[4..4 + len]).unwrap();
+        assert_eq!(kind, MediaKind::AudioPcm);
+        assert_eq!(channel, 7);
+        assert_eq!(payload, &pcm[..]);
+
+        // JSON frames fall through to the JSON plane.
+        assert!(parse_media_frame(b"{\"type\":\"Speak\"}").is_none());
+        // Unknown kind byte refuses rather than mis-routing.
+        let mut bogus = buf[4..4 + len].to_vec();
+        bogus[1] = 99;
+        assert!(parse_media_frame(&bogus).is_none());
+
+        // Video payload dims survive the [w][h] header round-trip.
+        let mut vbuf = Vec::new();
+        encode_video_payload_into(&mut vbuf, 640, 360, &[9, 8, 7]);
+        let (w, h, px) = parse_video_payload(&vbuf).unwrap();
+        assert_eq!((w, h, px), (640, 360, &[9u8, 8, 7][..]));
     }
 
     #[test]


### PR DESCRIPTION
## The audit

Joel: *"In the past you made these into json packets and lots of commands or events instead of setting up a handle and streaming to and from. Make sure we didn't do this major mistake again."* — Confirmed present. Every 20ms audio frame and every video frame crossed the core↔bridge socket as a JSON command carrying four identity strings, and the receiving side parsed each frame **twice** (try-as-response, then try-as-event). At 30fps HD each way, that's the eat-all-resources-at-the-boundary failure.

## The fix

- **One-byte discriminator**: `MEDIA_MAGIC = 0xB1` (JSON frames start with `{` = 0x7B). Frame = `[len:u32][0xB1][kind:u8][channel:u16][payload]`.
- **Identity binds once**: channels open via the JSON control plane (`OpenMediaOut` out, `MediaChannelOpened` in) carrying call/speaker identity a single time. After that the frame path touches **no strings, no serde**.
- **Zero copies**: payloads are MOVED end to end — Bevy pump → queue → kernel via three back-to-back `write_all`s (header, dims, payload); the bridge reader **borrows** media frames in place from the pending buffer; receivers hold a `u16 → Arc<str>` binding map, so per-frame identity cost is two pointer bumps.
- **Kinds**: `AudioPcm` (speak, inject, human STT intake), `VideoRgba` (avatar out, `[w][h]` rides a 4-byte header part), `VideoJpeg` (human video in → perception ingest).
- `inject_ambient` stays on the command plane — the bridge sink is a no-op ack today; it gets its own kind when the mixer is built. Legacy JSON `AudioFrame`/`VideoFrame` arms remain as wire-compat while old bridges drain.

## Receipts

- `cargo check` clean (zero warnings in touched files) on continuum-core (metal,accelerate), livekit-bridge, continuum-bridge-protocol.
- Protocol round-trip + JSON-disambiguation + unknown-kind-refusal test added to the existing mod (4/4 pass).
- Post-deploy: verify `media.pump.channel_open` fires once per (speaker,kind), `media.pump.write` byte counts, and absence of per-frame JSON in the bridge log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo