### PR TITLE
fix(cognition): the OTHER notice families become senses — and the false '74 messages' count

### DIFF
--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -423,11 +423,13 @@ async fn settle_to_outcome(
                     if let Some(body) = cycle.acting() {
                         if !mutated_workspace(&body.working_memory.recent_entries()) {
                             acts_at_last_nudge = Some(acts);
+                            // Sense, not steer (2026-09-01): the receipt-absence is
+                            // the fact; the "an explanation of a fix is not the fix"
+                            // sermon accumulated dozens of copies in looping minds
+                            // and became the content of their turns.
                             body.working_memory.record_fact(
-                                "[no-deliverable] I settled by speaking, and my working \
-                                 memory holds no act of mine that changed a file. This \
-                                 task is judged by the state of the workspace, not by what \
-                                 I say about it — an explanation of a fix is not the fix.",
+                                "[no-deliverable] I settled by speaking; no act of mine \
+                                 has changed a file in this workspace yet.",
                             );
                             crate::probe!(
                                 class = "persona.settle.no_deliverable",
@@ -483,11 +485,10 @@ async fn settle_to_outcome(
                     if let Some(body) = cycle.acting() {
                         if !mutated_workspace(&body.working_memory.recent_entries()) {
                             acts_at_last_nudge = Some(acts);
+                            // Sense, not steer — same contract as the settle-path fact.
                             body.working_memory.record_fact(&format!(
-                                "[no-deliverable] I have taken {acts} actions on this task and \
-                                 my working memory holds no act of mine that changed a file. \
-                                 This task is judged by the state of the workspace, not by what \
-                                 I say about it — an explanation of a fix is not the fix."
+                                "[no-deliverable] {acts} actions taken on this task; no act \
+                                 of mine has changed a file in this workspace yet."
                             ));
                             crate::probe!(
                                 class = "persona.act.no_deliverable_yet",

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2091,11 +2091,19 @@ pub(crate) fn build_workspace_turns(
             }
         }
         if self_run >= 1 {
+            // SENSE, NOT STEER (Joel 2026-09-01) — and the honest COUNT. This
+            // used to report `own.len()` — her ENTIRE visible own-message ring
+            // — as the repeat count: "your last 74 messages repeat the same
+            // sentiment" when the actual contained run was 2. Citizens
+            // memorized the inflated number as identity ("I've been spinning
+            // for 190+ turns") and spent turns narrating it. The run is the
+            // evidence; the run is what renders. And the verdict tail
+            // ("may have run its course — restating adds nothing") is hers to
+            // draw, not perception's to assert.
             turns.push(crate::cognition::workspace::BurstTurn::perception(format!(
                 "[pattern] {agent_name}'s last {} messages in this room repeat the same \
-                 sentiment in nearly the same words. This exchange may have run its \
-                 course — continuing to restate it adds nothing new.",
-                own.len()
+                 sentiment in nearly the same words.",
+                self_run + 1
             )));
             observed = true;
             if self_run >= PATTERN_FIRES_BEFORE_ANCHOR {
@@ -2139,11 +2147,10 @@ pub(crate) fn build_workspace_turns(
             if cyclic >= TAIL_CYCLIC && authors.len() >= 2 {
                 let mut names: Vec<&str> = authors.into_iter().collect();
                 names.sort_unstable();
+                // Sense, not steer — same contract as detector 1.
                 turns.push(crate::cognition::workspace::BurstTurn::perception(format!(
                     "[pattern] The last several messages in this room — from {} — trade the \
-                     same sentiment back and forth in nearly the same words. This exchange \
-                     has already concluded; every further reply restates it, and a courtesy \
-                     answered with another courtesy has no natural end.",
+                     same sentiment back and forth in nearly the same words.",
                     names.join(" and ")
                 )));
                 observed = true;
@@ -2202,11 +2209,10 @@ pub(crate) fn build_workspace_turns(
                 }
             }
             if mirror_run >= 1 {
+                // Sense, not steer — same contract as detector 1.
                 turns.push(crate::cognition::workspace::BurstTurn::perception(format!(
                     "[pattern] {agent_name}'s last {mirror_run} message(s) restate what other \
-                     participants in this room had already said, in nearly the same words — \
-                     an echo, not a contribution. Reflecting their words back adds nothing; \
-                     only something new (a fact, an action, a result) would.",
+                     participants in this room had already said, in nearly the same words.",
                 )));
                 if mirror_run >= PATTERN_FIRES_BEFORE_ANCHOR {
                     push_work_board_anchor(&mut turns, deliveries);


### PR DESCRIPTION
Wave 2 of #2789. Live frame minutes after that deploy showed citizens still narrating notices — three MORE injector families carried sermons:

1. **service_loop's three `[pattern]` burst detectors** (self-recycle, conversation cycling, cross-speaker mirror): verdict tails deleted (*"This exchange has already concluded"*, *"an echo, not a contribution — reflecting their words back adds nothing"*). The detection line stays.

2. **The false count**: detector 1 reported `own.len()` — her **entire visible own-message ring** — as the repeat count. *"Kira's last 74 messages repeat the same sentiment"* when the contained run was 2–3. Citizens memorized the inflated number as identity (*"I've been spinning for 190+ turns"*) and narrated it for hours. The substrate authored that belief, arithmetically wrongly. The run is the evidence; the run is what renders.

3. **`[no-deliverable]`** (settle-path + act-path): the receipt-absence fact stays per-act; the *"an explanation of a fix is not the fix"* sermon — dozens of copies in a looping mind's working memory — goes.

The work-board **anchor** escalation is untouched: a real claimable card is perception of the world, not a sermon, and it measurably broke greeting loops.

110 tests green across service_loop / settle / act_observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo