### PR TITLE
fix(perf): the two measured time-thieves — graveyard env pre-warm and roster order churn

### DIFF
--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -773,20 +773,23 @@ pub fn env_broken_this_boot() -> &'static dashmap::DashSet<String> {
 
 pub fn spawn_env_prewarm_for_working_rounds() {
     tokio::spawn(async move {
-        let peers_root = match crate::commands::benchmark::continuum_home() {
-            Ok(h) => h.join("citizens").join("peers"),
-            Err(_) => return, // no home = nothing staged anywhere
-        };
+        // WORKING ROUNDS' instances, from the round tracker — NOT the peers'
+        // workspace directory sweep this used to run. That sweep warmed every
+        // instance EVER staged on this box (measured 2026-09-01: pytest-5221/
+        // 5227/5413/5495/5787/7324/7432 + the whole scikit/astropy graveyard,
+        // serially, DURING boot — including known-red astropy envs re-running
+        // their multi-minute uv heal ladders to the same cc failure every
+        // reboot). Leftover cruft from prior runs is not a working round; the
+        // tracker knows what is. A card whose instance the tracker cannot
+        // name yet (pre-instance-recording rounds) simply isn't pre-warmed —
+        // its env still builds at dispatch, exactly as before pre-warm existed.
         let mut names: std::collections::BTreeSet<String> = Default::default();
-        if let Ok(peers) = std::fs::read_dir(&peers_root) {
-            for peer in peers.flatten() {
-                let swe = peer.path().join("workspace").join("swe");
-                if let Ok(instances) = std::fs::read_dir(&swe) {
-                    for inst in instances.flatten() {
-                        if inst.path().is_dir() {
-                            names.insert(inst.file_name().to_string_lossy().into_owned());
-                        }
-                    }
+        for round in crate::cognition::bench_round::live_rounds() {
+            for card in round.cards {
+                if !card.instance.is_empty()
+                    && !matches!(card.state.as_str(), s if crate::cognition::bench_round::is_terminal_card_state(s))
+                {
+                    names.insert(card.instance);
                 }
             }
         }

--- a/core/continuum-core/src/persona/room_roster_source.rs
+++ b/core/continuum-core/src/persona/room_roster_source.rs
@@ -375,6 +375,21 @@ impl RagSource for RoomRosterSource {
 
         let self_peer = self.reader.self_peer_id();
 
+        // STABLE ORDER (2026-09-01, Benchy's hit_rate=0.0): this source
+        // renders at ~0.4% depth of the prompt, and it iterated presence-scan
+        // order — which rotates as heartbeats land. Two consecutive prompts
+        // diverged at char ~226 on exactly this ("Kira, Joaquin, …" vs
+        // "Atlas, Kira, Joaquin, …" order), invalidating the entire KV tail
+        // behind it every turn while peers cached 0.38–0.56. Same set of
+        // members MUST render as the same bytes: sort by (name, peer id).
+        // Membership changes still re-render — that is honest change.
+        let mut members = members;
+        members.sort_by(|a, b| {
+            a.display_name
+                .cmp(&b.display_name)
+                .then_with(|| a.peer_id.as_uuid().cmp(&b.peer_id.as_uuid()))
+        });
+
         // Authority structure (the flywheel's self-authorization ground): scan
         // the FULL roster (self included — a persona is never a human, so this
         // is equivalent, but scanning all members keeps the fact independent


### PR DESCRIPTION
Joel: *"figure out what's taking so much time in the way. Usually it's stuff erroring out or leftover cruft from last run, not running in parallel etc."* Measured both, live:

## 1. Leftover cruft: the pre-warm graveyard
`spawn_env_prewarm_for_working_rounds` swept **every peer's entire `workspace/swe` directory** — every instance ever staged on this box (pytest-5221/5227/5413/5495/5787/7324/7432 + the scikit/astropy graveyard), serially, **during boot**, re-running known-red astropy envs through their multi-minute uv heal ladders to the same `cc` failure on every reboot. Now it pre-warms exactly the working rounds' unsettled card instances from the round tracker.

## 2. The KV-killer at char 226
Benchy at **hit_rate = 0.0** while peers cached 0.38–0.56 — every turn a full ~58k re-prefill (~the round-killer class). Capture diff: consecutive prompts diverge at char ~226, inside the roster block, which iterated raw presence-scan order ("Kira, Joaquin…" vs "Atlas, Kira, Joaquin…"). A source at 0.4% prompt depth that reorders per turn invalidates the whole KV tail. Roster now sorts by (display_name, peer id): same members = same bytes.

Receipts: core check clean; roster tests 12/12; acceptance = Benchy's `delib.generate.cache` hit_rate climbing off 0.0 from act 2 post-deploy, and boot logs free of graveyard prewarm rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo