### PR TITLE
fix(kv): the MIND's roster block renders in stable order — presence rotation was Benchy's real 0.0

### DIFF
--- a/core/continuum-core/src/persona/viewstate_rag.rs
+++ b/core/continuum-core/src/persona/viewstate_rag.rs
@@ -321,8 +321,22 @@ impl RagRenderable for continuum_positron::RosterViewState {
     }
 
     fn units(&self) -> Vec<String> {
-        self.roster
-            .iter()
+        // STABLE ORDER for the mind (2026-09-01, Benchy hit_rate=0.0): this
+        // block renders at ~0.4% prompt depth, and "presence order" rotates
+        // as heartbeats land — his consecutive prompts diverged at char ~226
+        // on exactly this rotation, re-prefilling the whole ~50k tail every
+        // turn while peers cached 0.4-0.8. The browser may sort presence-first
+        // for human eyes; the MIND's copy sorts by name so the same people are
+        // the same bytes. Set parity with the screen is unchanged — only the
+        // line order is pinned ([[a-mutating-system-prompt-destroys-kv-reuse]]).
+        let mut ordered: Vec<_> = self.roster.iter().collect();
+        ordered.sort_by(|a, b| {
+            a.display_name
+                .cmp(&b.display_name)
+                .then_with(|| a.member_id.cmp(&b.member_id))
+        });
+        ordered
+            .into_iter()
             .map(|slot| {
                 // Kind and role are what make a name actionable ("who can I ask?"),
                 // so they ride the SAME unit as the name rather than a second block


### PR DESCRIPTION
The first roster sort (#2819) fixed `room_roster_source` — but Benchy's prompt block comes from **`ViewStateRagSource<RosterViewState>`** (source id `'roster'`), which deliberately rendered *"presence order so the citizen and the browser list the room the same way."* Presence order rotates as heartbeats land; post-deploy captures on build 2509cce2e still diverged at **char ~226** on exactly this rotation, re-prefilling his whole ~50k tail every turn (hit_rate 0.0) while peers cached 0.4–0.8.

The mind's copy now sorts by (display_name, member_id): same people as the screen, same **bytes** across turns. The browser keeps whatever order suits human eyes — set parity unchanged, only line order pinned.

Receipt owed post-deploy: Benchy's `delib.generate.cache` hit_rate off 0.0 from his second act.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo