### PR TITLE
fix(cognition): remove the roster's timeout-fallback and the imposter's budget arm

### DIFF
--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -898,11 +898,19 @@ pub async fn materialize_adapters(
                 // #1650/#1651 grounding silently falls out of the live path —
                 // the persona forgets who is present / what the room is for.
                 grounding_sources: vec![
-                    // Roster — WHO is present. Enriching framing: a first-tick miss
-                    // costs one under-grounded turn, not a wrong one. Defer-tolerant
-                    // (runs off the hot path, served reprojected) once warm.
-                    crate::cognition::persona_workspace::GroundingSource::framing(roster_source)
-                        .defer_tolerant(),
+                    // Roster — WHO is present. SYNCHRONOUS (ColdStartCritical),
+                    // like workspace-map and for the same reason: the deferral
+                    // was earned by the OLD airc-fetch reader this source
+                    // replaced; the ViewState roster is a watch-channel borrow
+                    // (microseconds), and keeping the fallback meant slow turns
+                    // "timed out" into `reproject_to_now` serving a CACHED
+                    // roster from a different presence moment — Benchy's prompt
+                    // flapped between fresh and stale byte layouts at 0.4%
+                    // depth, hit_rate 0.0, and slower turns caused MORE
+                    // reprojections (measured 2026-09-01: both his captures
+                    // carried "[reprojected … held]"). A source this cheap
+                    // never gets a fallback ([[fallbacks-are-illegal-fail-loud]]).
+                    crate::cognition::persona_workspace::GroundingSource::framing(roster_source),
                     // Doctrine — WHAT the room is for: the PARTICIPATION GATE. This
                     // one stays SYNCHRONOUS (ColdStartCritical): a cold-start `None`
                     // would let the persona speak in a room it shouldn't on turn one,

--- a/core/continuum-core/src/persona/unified.rs
+++ b/core/continuum-core/src/persona/unified.rs
@@ -411,7 +411,14 @@ impl PersonaCognition {
                 // they never starve airc's recent_history or compete for
                 // grow headroom with the heavyweight engram/airc sources.
                 let (floor, min, max) = match s.source_id() {
-                    "room-roster" => (
+                    // "roster" is the LIVE id (ViewStateRagSource<RosterViewState>,
+                    // supervisor.rs); "room-roster" was the replaced airc-fetch
+                    // reader's id — kept matched so a replay of an old capture
+                    // still budgets it lightweight. Without the live arm the
+                    // roster fell to the heavyweight `_` arm and could claim up
+                    // to 60% of the window (found 2026-09-01 during the
+                    // imposter sweep).
+                    "roster" | "room-roster" => (
                         0,
                         0,
                         (context_window / ROSTER_WINDOW_FRACTION).min(per_source_max),


### PR DESCRIPTION
Joel: *"Find the imposter and figure out all the violations, fix it, remove the fallbacks — sometimes these timeout into fallbacks."* The sweep found the chain behind Benchy's persistent hit_rate=0.0:

## 1. The fallback
The roster grounding source kept `.defer_tolerant()` — a deferral **earned by the old airc-fetch `RoomRosterSource` it replaced**. The ViewState roster is a watch-channel borrow (microseconds), but the kept fallback meant a slow turn "timed out" into `reproject_to_now` serving a **cached roster from a different presence moment**. His prompt flapped between fresh and stale byte layouts at 0.4% depth; slower turns caused more reprojections — a self-feeding loop (both his captures carried `[reprojected … held]`). Roster is now synchronous (ColdStartCritical), the same conversion workspace-map earned for the same reason. A source this cheap never gets a fallback ([[fallbacks-are-illegal-fail-loud]]).

## 2. The imposter's budget arm
`unified.rs` budgeted source id `'room-roster'` — the replaced reader's id, which nothing delivers — so the live `'roster'` source fell to the heavyweight arm and could claim **up to 60% of the window**. The live id now budgets lightweight; the old id stays matched for replays.

Together with #2834 (stable order) this closes every roster-side KV violation found: one reader, one order, no stale serves, right budget. Receipt owed post-deploy: Benchy's hit_rate off 0.0 from act 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo