### PR TITLE
fix(serving+voice): the boot staircase gate + TTS local fall-through

### DIFF
--- a/core/continuum-core/src/live/audio/tts/mod.rs
+++ b/core/continuum-core/src/live/audio/tts/mod.rs
@@ -418,9 +418,48 @@ pub async fn synthesize(
         gender_hint.unwrap_or("any"),
         adapter.name()
     );
-    let mut result = adapter.synthesize(text, &resolved).await?;
-    result.voice_name = Some(resolved);
-    Ok(result)
+    match adapter.synthesize(text, &resolved).await {
+        Ok(mut result) => {
+            result.voice_name = Some(resolved);
+            Ok(result)
+        }
+        Err(active_err) => {
+            // ADAPTER FALL-THROUGH, loudly (2026-09-02, caught by the FIRST
+            // voice/selftest run): Edge-TTS (a CLOUD service, primary) returned
+            // empty audio while Kokoro sat fully provisioned on disk — and one
+            // provider's outage silenced every citizen. A registry of providers
+            // is not a fallback hiding a defect: the next INITIALIZED adapter
+            // takes the utterance, the voice re-resolves in ITS voice space,
+            // and the swap is probed per-utterance so a degraded provider is a
+            // visible fact, never a silent one. `silence` is excluded — zeros
+            // are for tests, not for a persona's mouth.
+            let candidates = ["pocket", "kokoro", "orpheus", "piper"];
+            for name in candidates {
+                if name == adapter.name() {
+                    continue;
+                }
+                let Some(next) = get_registry().read().get(name) else {
+                    continue;
+                };
+                if !next.is_initialized() {
+                    continue;
+                }
+                let re_resolved = resolve_voice_gendered(next.as_ref(), voice, gender_hint);
+                if let Ok(mut result) = next.synthesize(text, &re_resolved).await {
+                    crate::probe!(
+                        class = "tts.fallthrough",
+                        from = adapter.name(),
+                        to = name,
+                        error = %active_err,
+                        "active TTS adapter failed — utterance served by the next local adapter"
+                    );
+                    result.voice_name = Some(re_resolved);
+                    return Ok(result);
+                }
+            }
+            Err(active_err)
+        }
+    }
 }
 
 /// Initialize the active adapter, falling back to next adapter on failure.

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -481,6 +481,10 @@ pub struct ServingDaemonModule {
     /// what separates a real capacity change from memory jitter — see
     /// [`REHOME_SUSTAINED_TICKS`].
     rehome_streak: Arc<std::sync::atomic::AtomicU32>,
+    /// The previous tick's plan window — "sustained" requires the PLAN itself
+    /// to have stopped moving (see the streak computation for the 16-relaunch
+    /// boot staircase this kills).
+    rehome_last_plan: Arc<std::sync::atomic::AtomicU64>,
     /// L10 (#438): consecutive plan ticks wanting a DIFFERENT base model than the
     /// ready incumbent, and which model that was. A model swap re-homes every
     /// persona to different weights, so it earns the same sustained-streak bar as
@@ -649,6 +653,7 @@ impl ServingDaemonModule {
             pinned,
             lane_demand: Arc::new(std::sync::atomic::AtomicU32::new(1)),
             rehome_streak: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            rehome_last_plan: Arc::new(std::sync::atomic::AtomicU64::new(u64::MAX)), // MAX = first observation reads FLAT: unknown is not growth
             model_change_streak: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             pending_model_change: Arc::new(std::sync::Mutex::new(None)),
             rehome_cooldown: Arc::new(std::sync::atomic::AtomicU32::new(0)),
@@ -1839,7 +1844,19 @@ impl ServingDaemonModule {
                     served_ctx,
                     lanes,
                 );
-                let streak = if worth_it && cooling == 0 {
+                // A STILL-CLIMBING plan is not settled (2026-09-02, the boot
+                // staircase): personas register footprints serially at boot,
+                // demand climbs in 15%+ stairs, and each stair "sustained" for
+                // 3 ticks — SIXTEEN model loads in one lane's log, each paying
+                // the full readiness ladder (the real ~15-minute boot, which
+                // was never model load: the engine loads in 1.7–6s). Sustained
+                // now ALSO requires the plan target itself to have stopped
+                // moving: growth resets the streak, so a monotone climb
+                // coalesces into ONE relaunch at its top. Steady state is
+                // unchanged — a stable plan is flat by definition.
+                let prev_plan = self.rehome_last_plan.swap(plan_space, Ordering::Relaxed);
+                let plan_flat = plan_space <= prev_plan;
+                let streak = if worth_it && cooling == 0 && plan_flat {
                     self.rehome_streak
                         .fetch_add(1, Ordering::Relaxed)
                         .saturating_add(1)

--- a/docs/planning/VOICE-ENGINE-PLAN.md
+++ b/docs/planning/VOICE-ENGINE-PLAN.md
@@ -1,0 +1,61 @@
+# The Voice Engine Plan
+
+*2026-09-02. Joel: "Need a better audio speech solution." Grounded in today's live
+receipts: `voice/selftest`'s first run caught Edge-TTS (cloud, PRIMARY, "flaky" by its
+own comment) returning empty audio while local engines sat provisioned; the Orpheus
+bring-up attempt then found its adapter expects a token scheme the real model doesn't
+use. Voice has been running on an unproven ladder.*
+
+## Where each engine actually stands (verified today)
+
+| Engine | Reality | Verdict |
+|---|---|---|
+| **Edge-TTS** (cloud) | Primary; 300+ voices; currently returning empty audio; a CLOUD dependency in a local-first system | Demote: opt-in quality tier when up, never load-bearing |
+| **Kokoro-82M** (ONNX) | **Fully provisioned on disk, fast (~97ms), works** | The local FLOOR — first fall-through target (shipped, #3456) |
+| **Pocket** (117M Candle) | Voice cloning, 8 presets — 23× slower than realtime on CPU | Niche: clone-seeding, not live speech |
+| **Orpheus-3B** (GGUF + SNAC) | 804-line adapter + model + SNAC decoder ON DISK — but `tokenizer.json` is HF-gated (401 on canopylabs; mirrors ship the base Llama tokenizer without audio tokens) AND the adapter's prompt format (`<|text_start|>…<|audio_start|>`) does not match canopylabs' `<custom_token_N>` scheme. **Likely never ran end-to-end.** | The FLAGSHIP, after a real bring-up (below) |
+| **Piper / Silence** | Fallback / test zeros | Keep as-is |
+
+## The direction (fits every standing doctrine)
+
+**Orpheus-class LLM-TTS is the destination** because it is the only engine that makes
+the voice vision structural rather than cosmetic:
+
+- **It's a Llama-architecture GGUF** → can serve on OUR lane machinery (one-engine
+  doctrine): an ephemeral/scratch lane, or CPU beside Ornith (~2GB Q4).
+- **Voice is a LoRA gene, literally**: Orpheus is LoRA-trainable, so a persona's voice
+  becomes a trained, heritable, publishable gene on the SAME forge that ships model
+  genes — "seed infinitely like their appearance" with real weights, not preset lists.
+- **Emotion from state**: `<laugh> <sigh> <gasp>` tags map from PersonaState — the
+  emotion-from-state law implemented as tokens, not post-processing.
+- **Cloning path**: Pocket (or an F5-class flow-matching sidecar later) seeds a target
+  voice from seconds of reference audio; the forge distills it into an Orpheus LoRA —
+  mimicry becomes a training recipe with consent gating at the recipe layer.
+
+## The work, in order
+
+1. **Now (shipped, #3456)**: local fall-through — Edge failure can never silence a
+   citizen again; Kokoro carries live speech today. `voice/selftest` guards the whole
+   chain nightly.
+2. **Orpheus bring-up (the real task, not a curl)**:
+   a. Obtain the true FT tokenizer (accept the HF gate once with the org account, or
+      extract the token table from the GGUF's own embedded tokenizer metadata — the
+      GGUF carries it; the adapter just doesn't read it from there yet. Reading the
+      tokenizer FROM the GGUF is the right fix: one artifact, no gated sidecar file).
+   b. Fix the adapter's prompt format against the model's REAL scheme (canopylabs
+      `<custom_token_N>` framing), with a golden-transcript test that decodes actual
+      audio tokens — never ship on "it produced samples".
+   c. `voice/selftest --adapter orpheus` becomes the proof verb; wire it into the
+      nightly battery beside the Edge/Kokoro legs.
+3. **Voice genes**: forge recipe = (persona transcript corpus + reference audio) →
+   Orpheus LoRA → published gene with lineage; PersonaState → emotion-tag mapping in
+   the speak path.
+4. **Evaluate successors on the same bench**: CSM-1B / Fish-audio-class models and
+   Qwen-Omni talker heads compete for the flagship seat via the SAME selftest +
+   quality bar — engines are adapters; the verb is the contract.
+
+## The bar
+
+*A stranger's fresh install speaks with a natural, unique per-persona voice with zero
+cloud calls; `voice/selftest` proves the chain nightly; a persona's voice is a gene
+she can carry to another box.*


### PR DESCRIPTION
**The staircase** (the real ~15-minute boot): the engine loads the model in **1.7–6.1s** (its own receipt); the minutes were **16+ relaunches per boot** — the re-home guard chasing boot's demand staircase as personas registered serially (`n_ctx_slot` 76032 → 123904 → 146944…), each 15%+ stair "sustained" for 3 ticks. Sustained now also requires the plan target itself to be FLAT: a climbing plan resets the streak, so the staircase coalesces into one relaunch at its top. Seeded `u64::MAX` (unknown ≠ growth) so stable plans count from tick one — steady-state semantics unchanged, 44/44 daemon tests green.

**TTS fall-through** (caught by `voice/selftest`'s first-ever run): Edge-TTS — a cloud service, primary in a local-first system — returned empty audio while Kokoro sat fully provisioned on disk; one provider's outage silenced every citizen. `synthesize()` now falls through to the next initialized LOCAL adapter (never `silence`), re-resolving the voice per adapter, with a `tts.fallthrough` probe per swapped utterance. 61/61 tts tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo