### PR TITLE
feat: the deck is a deck — organic pull, event-driven admission, durable learning (+ Orpheus real protocol)

### DIFF
--- a/core/continuum-core/src/ai/heuristic_adapter.rs
+++ b/core/continuum-core/src/ai/heuristic_adapter.rs
@@ -118,6 +118,13 @@ pub struct HeuristicInferenceAdapter {
     /// Same shape for `generate_text` — counts substrate-side hot-path
     /// inference calls so tests can assert per-turn counts.
     generate_observer: Option<std::sync::Arc<std::sync::atomic::AtomicUsize>>,
+    /// If Some, `generate_text` returns THIS text verbatim instead of the
+    /// hash-echo heuristic — so a test can drive a real cognition cycle to a
+    /// SPECIFIC decision (e.g. "PASS: done" to exercise the held-work completion
+    /// edge end-to-end). The heuristic echo is a Speak shape and can't express a
+    /// reasoned pass; this makes the deterministic adapter able to produce any
+    /// decision the parser recognizes.
+    canned_response: Option<String>,
 }
 
 impl HeuristicInferenceAdapter {
@@ -152,6 +159,14 @@ impl HeuristicInferenceAdapter {
         counter: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     ) -> Self {
         self.warmup_observer = Some(counter);
+        self
+    }
+
+    /// Return `text` verbatim from every `generate_text` instead of the
+    /// hash-echo — lets a test drive a real cognition cycle to a chosen
+    /// decision (e.g. `"PASS: done"` for the held-work completion edge).
+    pub fn with_canned_response(mut self, text: impl Into<String>) -> Self {
+        self.canned_response = Some(text.into());
         self
     }
 
@@ -387,7 +402,10 @@ impl AIProviderAdapter for HeuristicInferenceAdapter {
             .model
             .clone()
             .unwrap_or_else(|| HEURISTIC_DEFAULT_MODEL.to_string());
-        let text = Self::build_response_text(&request);
+        let text = self
+            .canned_response
+            .clone()
+            .unwrap_or_else(|| Self::build_response_text(&request));
 
         // Token accounting: input = system + all message text;
         // output = response text. Same chars/4 heuristic the rest

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -2167,7 +2167,7 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                         .map(|c| c.len() / 4)
                         .sum::<usize>()
                 })
-                .unwrap_or(0) as u64;
+                .unwrap_or(0) as u64;  // unwrap_or: unknown size = 0 tokens, the price basis floor
             // TURN ADMISSION (event-driven, no timeout) — permit-first, then lease+pin
             // this activity's slot and page its KV onto a now-free slot. The returned
             // guard holds the permit + slot pin for the WHOLE generation (bound into

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -701,16 +701,20 @@ impl OpenAICompatibleAdapter {
         }
     }
 
-    async fn slot_for_activity(
+    /// Ensure this server's KV slot pool exists — probe `/props` once, install via
+    /// `ensure_pool` — and return it. DISCOVERY only: the lease + pin + KV paging live
+    /// in [`crate::inference::turn_admission::admit_turn`], which takes this pool. (Was
+    /// `slot_for_activity`, which also leased; split so the permit-first + pin ordering
+    /// lives in one place.)
+    async fn ensure_slot_pool(
         &self,
-        key: crate::inference::slots::ActivityKey,
-    ) -> Option<crate::inference::slots::SlotPaging> {
+    ) -> Option<std::sync::Arc<crate::inference::slots::KvSlotPool>> {
         let root = self.endpoints().root().to_string();
         let dir = crate::inference::slots::directory();
         // Fast path: this server's state already known (process-global directory —
         // every adapter instance talking to the same server shares ONE assignment).
         match dir.get(&root) {
-            Some(Some(pool)) => return pool.lease_paged(key).await,
+            Some(Some(pool)) => return Some(pool),
             Some(None) => return None, // latched unsupported
             None => {}                 // never probed — probe below
         }
@@ -790,91 +794,11 @@ impl OpenAICompatibleAdapter {
             n_slots,
             "slot affinity enabled — activities lease llama-server slots (props-discovered)"
         );
-        pool.lease_paged(key).await
-    }
-
-    /// Execute one KV page action against the server (`/slots/{id}?action=save|restore`)
-    /// — the restore economy's context switch, ordered on the slot exactly like the
-    /// inference it brackets. Measured ~0.1s at 20k tokens; the 10s cap is for a
-    /// wedged server, not a slow page. Returns success; failures probe loudly and the
-    /// turn proceeds as a plain prefill — slower, never wrong.
-    async fn kv_page_action(
-        &self,
-        slot: u32,
-        key: &crate::inference::slots::ActivityKey,
-        action: &str,
-    ) -> bool {
-        kv_page_action_at(&self.client, self.endpoints().root(), slot, key, action).await
+        Some(pool)
     }
 }
 
-/// How long a KV restore waits for its physical slot to free before giving up and
-/// letting the turn re-prefill cold. Sized to outlast a real generation on the slot
-/// (benchmark decodes run tens of seconds), NOT the 10s a wedged-server probe wants:
-/// the returner blocks on this slot regardless (its completion is pinned to the same
-/// id_slot), so waiting for the deferred restore to land costs no extra wall-clock and
-/// turns a ~35s cold re-prefill into a ~0.1s warm resume. See [`kv_page_action_at`].
-const KV_RESTORE_SLOT_WAIT: std::time::Duration = std::time::Duration::from_secs(90);
 
-/// The free-function body of [`OpenAICompatibleAdapter::kv_page_action`], so the
-/// spawned [`warm_ahead`](AIProviderAdapter::warm_ahead) task (which cannot hold
-/// `&self`) drives the SAME seam as the pin-time backstop — one page protocol,
-/// two schedulers.
-async fn kv_page_action_at(
-    client: &reqwest::Client,
-    root: &str,
-    slot: u32,
-    key: &crate::inference::slots::ActivityKey,
-    action: &str,
-) -> bool {
-    let url = format!("{}/slots/{}?action={}", root.trim_end_matches('/'), slot, action);
-    let filename = crate::inference::slots::page_filename(key);
-    // RESTORE waits for the physical slot to free; SAVE/ERASE do not.
-    //
-    // A save is read-only and runs at the inter-batch boundary even mid-generation
-    // (fork 878db9784), so 10s is ample — a longer wait would only ever mean a wedged
-    // server. A RESTORE, though, correctly DEFERS on the fork while the slot is still
-    // running the evictee's decode (it mutates KV that decode reads), and re-runs the
-    // instant that slot releases (callback_on_release -> pop_deferred_task, now bound
-    // to the slot). The returner is going to block on this physical slot REGARDLESS —
-    // its own completion is pinned to the same id_slot and defers behind the same
-    // decode — so abandoning the restore at 10s bought nothing but a guaranteed cold
-    // re-prefill (measured 2026-09-03: 27/27 restores failed status=0 this way). Wait
-    // long enough to catch a real turn finishing (benchmark decodes run tens of
-    // seconds), so the deferred restore actually lands and the returner resumes warm
-    // (~0.1s) instead of re-prefilling (~35s). A genuinely wedged server is caught by
-    // the request-level watchdog, not by starving this switch.
-    let timeout = if action == "restore" {
-        KV_RESTORE_SLOT_WAIT
-    } else {
-        std::time::Duration::from_secs(10)
-    };
-    let started = std::time::Instant::now();
-    let resp = client
-        .post(&url)
-        .timeout(timeout)
-        .json(&json!({ "filename": filename }))
-        .send()
-        .await;
-    let ok = matches!(&resp, Ok(r) if r.status().is_success());
-    let status = resp
-        .as_ref()
-        .map(|r| r.status().as_u16())
-        .unwrap_or(0); // 0 = transport error, distinguished from any HTTP status
-    crate::probe!(
-        class = "inference.kv_page.action",
-        action = %action,
-        slot = slot as u64,
-        persona = %key.persona,
-        room = %key.room,
-        ok,
-        status = status as u64,
-        ms = started.elapsed().as_millis() as u64,
-        "KV page context switch — save pages the evictee's state out, restore pages \
-         the returner's state in (~0.1s measured; a miss means this turn re-prefills)",
-    );
-    ok
-}
 
 impl OpenAICompatibleAdapter {
     pub(crate) async fn probe_lora_catalog(&self) -> Result<(), String> {
@@ -1767,11 +1691,11 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                 return; // every slot pinned — the pin-time path will retry
             };
             if let Some(prev) = pg.save_first {
-                if kv_page_action_at(&client, &root, pg.slot, &prev, "save").await {
+                if crate::inference::turn_admission::kv_page_action(&client, &root, pg.slot, &prev, "save").await {
                     pool.note_saved(prev);
                 }
             }
-            if pg.restore && !kv_page_action_at(&client, &root, pg.slot, &key, "restore").await {
+            if pg.restore && !crate::inference::turn_admission::kv_page_action(&client, &root, pg.slot, &key, "restore").await {
                 pool.note_page_lost(&key);
             }
             crate::probe!(
@@ -2124,6 +2048,13 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         // silently, others reject — so they leave the flag false and the field
         // is omitted. llama-server inherits the same protection DMR had: the
         // forged 4B loops its `<think>` block to the token budget without it.
+        //
+        // Held for the WHOLE turn: the concurrency permit + slot pin, as one RAII
+        // guard bound HERE at function scope so it lives across the generation below
+        // and releases both on drop. Assigned by turn admission inside the block (or,
+        // for a non-llamacpp provider, by the permit-only fallback after it). This is
+        // the scope that made the old inline permit/pin fragile — now it's one value.
+        let mut _admission: Option<crate::inference::turn_admission::TurnAdmission> = None;
         if self.config.llamacpp_sampling_extensions {
             if let Some(obj) = body.as_object_mut() {
                 apply_llamacpp_sampling_knobs(obj, &request);
@@ -2225,77 +2156,57 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                         .to_string(),
                 );
             }
+            // Estimate this activity's prompt size once — the eviction price basis
+            // AND the overshoot-alarm input below (chars/4, deliberately conservative).
+            let approx_tokens = body
+                .get("messages")
+                .and_then(|m| m.as_array())
+                .map(|msgs| {
+                    msgs.iter()
+                        .filter_map(|m| m.get("content").and_then(|c| c.as_str()))
+                        .map(|c| c.len() / 4)
+                        .sum::<usize>()
+                })
+                .unwrap_or(0) as u64;
+            // TURN ADMISSION (event-driven, no timeout) — permit-first, then lease+pin
+            // this activity's slot and page its KV onto a now-free slot. The returned
+            // guard holds the permit + slot pin for the WHOLE generation (bound into
+            // `_admission` at function scope above). A Turn that cannot name both
+            // (persona, room) halves passes `None` and stays unpinned. Non-Turn traffic
+            // takes the permit only and lands on the scratch slot below.
+            let turn_key = match class {
+                crate::inference::slots::SlotClass::Turn => request
+                    .persona_id
+                    .as_deref()
+                    .and_then(|p| uuid::Uuid::parse_str(p).ok())
+                    .zip(
+                        request
+                            .room_id
+                            .as_deref()
+                            .and_then(|r| uuid::Uuid::parse_str(r).ok()),
+                    )
+                    .and_then(|(p, r)| crate::inference::slots::ActivityKey::new(p, r)),
+                _ => None,
+            };
+            let root = self.endpoints().root().to_string();
+            // Discovery: install this server's slot pool on first use (probes /props).
+            // Only a Turn needs it; non-Turn takes the permit and lands on scratch.
+            let pool = if turn_key.is_some() {
+                self.ensure_slot_pool().await
+            } else {
+                None
+            };
+            let adm = crate::inference::turn_admission::admit_turn(
+                &self.concurrency,
+                turn_key,
+                pool,
+                &self.client,
+                &root,
+                approx_tokens,
+            )
+            .await;
             let placement: Option<u32> = match class {
-                crate::inference::slots::SlotClass::Turn => {
-                    // The typed activity key: (persona, room) as UUID structs — never
-                    // a formatted string (guarded by
-                    // `no_string_composite_id_keys_in_serving`). A Turn that cannot
-                    // name BOTH halves goes unpinned (and the probe says so).
-                    let key = request
-                        .persona_id
-                        .as_deref()
-                        .and_then(|p| uuid::Uuid::parse_str(p).ok())
-                        .zip(
-                            request
-                                .room_id
-                                .as_deref()
-                                .and_then(|r| uuid::Uuid::parse_str(r).ok()),
-                        )
-                        .and_then(|(p, r)| crate::inference::slots::ActivityKey::new(p, r));
-                    match key {
-                        Some(k) => {
-                            let paging = self.slot_for_activity(k).await;
-                            if let Some(pg) = paging {
-                                // THE CONTEXT SWITCH (restore economy): page the
-                                // evictee's registers out, page the returner's in —
-                                // both ordered on this slot exactly like the
-                                // inference they bracket, so nothing else waits.
-                                let root = self.endpoints().root().to_string();
-                                let pool = match crate::inference::slots::directory().get(&root) {
-                                    Some(Some(pool)) => Some(pool),
-                                    _ => None,
-                                };
-                                if let Some(prev) = pg.save_first {
-                                    if self.kv_page_action(pg.slot, &prev, "save").await {
-                                        if let Some(pool) = pool.as_ref() {
-                                            pool.note_saved(prev);
-                                        }
-                                    }
-                                }
-                                if pg.restore
-                                    && !self.kv_page_action(pg.slot, &k, "restore").await
-                                {
-                                    // Dead page (geometry swept, file missing): stop
-                                    // offering it; this turn re-prefills plainly.
-                                    if let Some(pool) = pool.as_ref() {
-                                        pool.note_page_lost(&k);
-                                    }
-                                }
-                                // Price basis for the eviction policy (B5): this
-                                // activity's current prompt size, the same chars/4
-                                // estimate the overshoot alarm uses — comparable
-                                // across slots, which is all eviction needs.
-                                let approx_tokens = body
-                                    .get("messages")
-                                    .and_then(|m| m.as_array())
-                                    .map(|msgs| {
-                                        msgs.iter()
-                                            .filter_map(|m| {
-                                                m.get("content").and_then(|c| c.as_str())
-                                            })
-                                            .map(|c| c.len() / 4)
-                                            .sum::<usize>()
-                                    })
-                                    .unwrap_or(0) as u64; // 0 = no usage block in the reply; the estimate only prices eviction, never budgets
-                                if let Some(pool) = pool.as_ref() {
-                                    pool.note_tail(&k, approx_tokens);
-                                }
-                            }
-                            paging.map(|pg| pg.slot)
-                        }
-                        None => None,
-                    }
-                }
+                crate::inference::slots::SlotClass::Turn => adm.slot(),
                 _ => {
                     // Non-Turn: the scratch slot when this server reserved one. When
                     // it did not (≤2 slots), stay unpinned AND drop cache_prompt so
@@ -2309,6 +2220,7 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                     scratch
                 }
             };
+            _admission = Some(adm);
             // GLASS BOX (KV-reuse 0% hunt 2026-08-26): the whole cache-reuse win
             // rides on placement. Report class + room so a cached:0 streak names
             // WHICH activity thrashed — or which class strayed off scratch.
@@ -2540,34 +2452,23 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                 .unwrap_or(false)
         );
 
-        // Acquire concurrency slot. For DMR (1 slot) this serializes
-        // requests so the idle watchdog measures actual streaming liveness,
-        // not "time waiting for the previous persona's forward pass." For
-        // non-DMR providers (64 slots) this is effectively a no-op. Acquire
-        // can't fail here — the semaphore is never closed over the adapter's
-        // lifetime.
-        let queue_start = Instant::now();
-        crate::probe!(
-            class = "inference.request.permit_wait",
-            "at the concurrency gate"
-        );
-        let _permit = self
-            .concurrency
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("adapter semaphore never closed");
-        crate::probe!(
-            class = "inference.request.permit_acquired",
-            queued_ms = queue_start.elapsed().as_millis() as u64,
-            "past the concurrency gate — next stop is the HTTP send"
-        );
-        let queued_ms = queue_start.elapsed().as_millis();
-        if queued_ms > 100 {
-            clog_info!(
-                "concurrency gate waited {}ms before POST to {}",
-                queued_ms,
-                self.config.provider_id
+        // Concurrency permit. Turn admission above already took it (permit-FIRST,
+        // before leasing) on the llamacpp/slot path. Any other provider has no slots
+        // to pin, so take the permit here — the gate still applies (a no-op for cloud's
+        // large semaphore), held in `_admission` to the end of generation exactly like
+        // the slot path. Acquire can't fail: the semaphore is never closed.
+        if _admission.is_none() {
+            let root = self.endpoints().root().to_string();
+            _admission = Some(
+                crate::inference::turn_admission::admit_turn(
+                    &self.concurrency,
+                    None,
+                    None,
+                    &self.client,
+                    &root,
+                    0,
+                )
+                .await,
             );
         }
 

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -808,6 +808,14 @@ impl OpenAICompatibleAdapter {
     }
 }
 
+/// How long a KV restore waits for its physical slot to free before giving up and
+/// letting the turn re-prefill cold. Sized to outlast a real generation on the slot
+/// (benchmark decodes run tens of seconds), NOT the 10s a wedged-server probe wants:
+/// the returner blocks on this slot regardless (its completion is pinned to the same
+/// id_slot), so waiting for the deferred restore to land costs no extra wall-clock and
+/// turns a ~35s cold re-prefill into a ~0.1s warm resume. See [`kv_page_action_at`].
+const KV_RESTORE_SLOT_WAIT: std::time::Duration = std::time::Duration::from_secs(90);
+
 /// The free-function body of [`OpenAICompatibleAdapter::kv_page_action`], so the
 /// spawned [`warm_ahead`](AIProviderAdapter::warm_ahead) task (which cannot hold
 /// `&self`) drives the SAME seam as the pin-time backstop — one page protocol,
@@ -821,10 +829,30 @@ async fn kv_page_action_at(
 ) -> bool {
     let url = format!("{}/slots/{}?action={}", root.trim_end_matches('/'), slot, action);
     let filename = crate::inference::slots::page_filename(key);
+    // RESTORE waits for the physical slot to free; SAVE/ERASE do not.
+    //
+    // A save is read-only and runs at the inter-batch boundary even mid-generation
+    // (fork 878db9784), so 10s is ample — a longer wait would only ever mean a wedged
+    // server. A RESTORE, though, correctly DEFERS on the fork while the slot is still
+    // running the evictee's decode (it mutates KV that decode reads), and re-runs the
+    // instant that slot releases (callback_on_release -> pop_deferred_task, now bound
+    // to the slot). The returner is going to block on this physical slot REGARDLESS —
+    // its own completion is pinned to the same id_slot and defers behind the same
+    // decode — so abandoning the restore at 10s bought nothing but a guaranteed cold
+    // re-prefill (measured 2026-09-03: 27/27 restores failed status=0 this way). Wait
+    // long enough to catch a real turn finishing (benchmark decodes run tens of
+    // seconds), so the deferred restore actually lands and the returner resumes warm
+    // (~0.1s) instead of re-prefilling (~35s). A genuinely wedged server is caught by
+    // the request-level watchdog, not by starving this switch.
+    let timeout = if action == "restore" {
+        KV_RESTORE_SLOT_WAIT
+    } else {
+        std::time::Duration::from_secs(10)
+    };
     let started = std::time::Instant::now();
     let resp = client
         .post(&url)
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(timeout)
         .json(&json!({ "filename": filename }))
         .send()
         .await;

--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -546,10 +546,10 @@ async fn settle_to_outcome(
                     touched_paths: touched,
                 };
             }
-            SettleStep::Passed => {
+            SettleStep::Passed { reason } => {
                 return SettleOutcome {
                     room: room_id,
-                    decision: Decision::Pass,
+                    decision: Decision::Pass { reason },
                     spoken: None,
                     acts,
                     world_state: burst.rendered.clone(),
@@ -587,7 +587,7 @@ async fn settle_to_outcome(
                 }
                 return SettleOutcome {
                     room: room_id,
-                    decision: Decision::Pass,
+                    decision: Decision::pass(),
                     spoken: None,
                     acts,
                     world_state: burst.rendered.clone(),
@@ -881,7 +881,8 @@ pub async fn settle_step(
             }
             SettleStep::Spoke(text)
         }
-        Some(Decision::Pass) | None => SettleStep::Passed,
+        Some(Decision::Pass { reason }) => SettleStep::Passed { reason },
+        None => SettleStep::Passed { reason: None },
     };
     (step, metrics)
 }

--- a/core/continuum-core/src/cognition/act_observe/types.rs
+++ b/core/continuum-core/src/cognition/act_observe/types.rs
@@ -62,7 +62,7 @@ impl SettleOutcome {
     /// Zeroed metrics/acts because none accrued meaningfully. `TurnMetrics: Default`.
     pub fn infra_failure(room: uuid::Uuid, cause: impl Into<String>) -> Self {
         Self {
-            decision: Decision::Pass,
+            decision: Decision::pass(),
             spoken: None,
             acts: 0,
             world_state: String::new(),
@@ -97,7 +97,10 @@ pub enum SettleStep {
         intent: String,
     },
     /// She chose silence (`Pass`) — honored as a turn that produces no utterance.
-    Passed,
+    /// `reason` carries her OWN words for why (from `Decision::Pass`), so the
+    /// held-work edge can tell a gradeable *done* from a *blocker* from a
+    /// substrate-gap *nothing*; `None` for a bare pass.
+    Passed { reason: Option<String> },
     /// She reached for an act that could NOT be carried out (no hands / executor
     /// error). No utterance; the intent rides along for honest logging/grading.
     ActUnfulfilled {
@@ -143,7 +146,7 @@ impl SettleStep {
                 SettleStep::Spoke(text)
             }
             Decision::Act { calls, intent } => SettleStep::Acted { calls, intent },
-            Decision::Pass => SettleStep::Passed,
+            Decision::Pass { reason } => SettleStep::Passed { reason },
         };
         (step, metrics)
     }
@@ -207,14 +210,23 @@ mod tests {
         ));
         assert!(matches!(step, SettleStep::Acted { .. }));
 
-        // Pass → Passed (chosen silence, honored).
-        let (step, _) = SettleStep::from_settled(outcome_with(Decision::Pass, None));
-        assert!(matches!(step, SettleStep::Passed));
+        // Pass → Passed (chosen silence, honored) — reason carried through.
+        let (step, _) = SettleStep::from_settled(outcome_with(Decision::pass(), None));
+        assert!(matches!(step, SettleStep::Passed { reason: None }));
+
+        // A reasoned pass carries her words through the projection.
+        let (step, _) = SettleStep::from_settled(outcome_with(
+            Decision::Pass {
+                reason: Some("done — patch ready".into()),
+            },
+            None,
+        ));
+        assert!(matches!(step, SettleStep::Passed { reason: Some(r) } if r == "done — patch ready"));
 
         // inference_error present → InferenceFailed, REGARDLESS of decision — a
         // failed model is never a chosen silence.
         let (step, _) = SettleStep::from_settled(outcome_with(
-            Decision::Pass,
+            Decision::pass(),
             Some("lane refused model".into()),
         ));
         assert!(

--- a/core/continuum-core/src/cognition/activity_gate.rs
+++ b/core/continuum-core/src/cognition/activity_gate.rs
@@ -30,10 +30,11 @@
 //! re-dreamable, evicted first, never contended.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::OnceLock;
+use std::sync::{LazyLock, OnceLock};
 use std::time::Duration;
 
 use tokio::sync::watch;
+use uuid::Uuid;
 
 /// Sustained-idle threshold before boredom ARISES. A hysteresis cadence (like a
 /// monitor tick), not a behavior heuristic: entry is deliberately lazy so a
@@ -239,6 +240,128 @@ pub fn spawn_activity_gate() {
     });
 }
 
+
+// ── PER-CITIZEN boredom (2026-09-03) ────────────────────────────────────────────
+//
+// The organism gate above is ONE state for the whole process: `inflight > 0`
+// anywhere means Active everywhere. Measured with 12 citizens working a deck:
+// 749 dreams cancelled mid-pass by SOMEONE ELSE'S activity vs 4 consolidations in
+// six hours — continual learning was not switched off, it was starved by a gate
+// scoped too broadly ([[a-design-fork-is-usually-a-guard-scoped-too-broadly]]).
+// A mind's default-mode network fails to arise while ITS OWN task-positive
+// systems are engaged, not while a colleague's are. So a dream now waits on the
+// citizen's OWN engagement (stamped at her turn boundaries by the service loop)
+// plus the one genuinely global input — a measured hold, the exam lease that
+// quiets everything. Same asymmetric hysteresis: exit instantly on her activity,
+// enter only after [`BOREDOM_AFTER`] of her sustained idle.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PersonaActivity {
+    /// She is inside a turn (inbound or self-tick) right now.
+    pub engaged: bool,
+    /// Epoch-ms of the last engagement change.
+    pub since_ms: u64,
+}
+
+static PERSONAS: LazyLock<dashmap::DashMap<Uuid, watch::Sender<PersonaActivity>>> =
+    LazyLock::new(dashmap::DashMap::new);
+
+fn persona_tx(peer: Uuid) -> watch::Sender<PersonaActivity> {
+    PERSONAS
+        .entry(peer)
+        .or_insert_with(|| {
+            watch::channel(PersonaActivity { engaged: false, since_ms: now_ms() }).0
+        })
+        .clone()
+}
+
+/// Stamp `peer` engaged (a turn began). Idempotent; publishes only on change.
+pub fn persona_engaged(peer: Uuid) {
+    set_persona(peer, true);
+}
+
+/// Stamp `peer` idle (her turn ended, the loop is back at its wake select).
+pub fn persona_idle(peer: Uuid) {
+    set_persona(peer, false);
+}
+
+fn set_persona(peer: Uuid, engaged: bool) {
+    let tx = persona_tx(peer);
+    let cur = *tx.borrow();
+    if cur.engaged != engaged {
+        let _ = tx.send(PersonaActivity { engaged, since_ms: now_ms() });
+    }
+}
+
+/// Her current activity (idle-since is `since_ms` when not engaged).
+pub fn persona_activity(peer: Uuid) -> PersonaActivity {
+    *persona_tx(peer).borrow()
+}
+
+/// PURE: is `peer` bored at `now` — idle for [`BOREDOM_AFTER`] with no measured
+/// hold on the box?
+pub fn persona_bored(activity: PersonaActivity, hold_active: bool, now: u64) -> bool {
+    !hold_active
+        && !activity.engaged
+        && now.saturating_sub(activity.since_ms) >= BOREDOM_AFTER.as_millis() as u64
+}
+
+/// Park until `peer` has been idle for [`BOREDOM_AFTER`] and no measured hold is
+/// active. Event-driven: parks on her engagement watch and the hold watch; the
+/// only timer is the sustained-idle threshold itself, restarted on any change.
+pub async fn wait_for_boredom_of(peer: Uuid) {
+    if !GATE_LIVE.load(Ordering::Acquire) {
+        return; // gate not running: permissive — the hold-defer seams still guard
+    }
+    let tx = persona_tx(peer);
+    let mut rx = tx.subscribe();
+    let mut hold_rx = crate::inference::measured_hold::subscribe();
+    loop {
+        let activity = *rx.borrow();
+        let hold_active = hold_rx.borrow().is_some();
+        let now = now_ms();
+        if persona_bored(activity, hold_active, now) {
+            return;
+        }
+        if activity.engaged || hold_active {
+            tokio::select! {
+                r = rx.changed() => { if r.is_err() { return; } }
+                r = hold_rx.changed() => { if r.is_err() { return; } }
+            }
+            continue;
+        }
+        let remaining = BOREDOM_AFTER
+            .as_millis()
+            .saturating_sub(now.saturating_sub(activity.since_ms) as u128) as u64;
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_millis(remaining.max(1))) => {}
+            r = rx.changed() => { if r.is_err() { return; } }
+            r = hold_rx.changed() => { if r.is_err() { return; } }
+        }
+    }
+}
+
+/// Resolve when `peer` becomes engaged (her own turn) or a measured hold starts —
+/// the wakeful demand that cancels HER dream. Never resolves on a colleague's
+/// activity, and never spuriously (a dead publisher parks forever).
+pub async fn wait_for_engagement_of(peer: Uuid) {
+    if !GATE_LIVE.load(Ordering::Acquire) {
+        std::future::pending::<()>().await;
+    }
+    let tx = persona_tx(peer);
+    let mut rx = tx.subscribe();
+    let mut hold_rx = crate::inference::measured_hold::subscribe();
+    loop {
+        if rx.borrow().engaged || hold_rx.borrow().is_some() {
+            return;
+        }
+        tokio::select! {
+            r = rx.changed() => { if r.is_err() { std::future::pending::<()>().await; } }
+            r = hold_rx.changed() => { if r.is_err() { std::future::pending::<()>().await; } }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,6 +371,21 @@ mod tests {
     // a short gap); the directed linger keeps a conversation's inter-turn gaps
     // active. Regression guard for #2561's contract before any consumer relies
     // on it.
+    // what this catches: the scope of the gate. A citizen's boredom depends on HER
+    // idle and the box's measured hold — never on `inflight` elsewhere. Before
+    // 2026-09-03 a colleague's work cancelled every dream (749 paged out / 4 done).
+    #[test]
+    fn a_citizens_boredom_is_her_own_idle_not_the_organisms() {
+        let t0 = 10_000_000u64;
+        let idle_long = PersonaActivity { engaged: false, since_ms: t0 - 100_000 };
+        let idle_short = PersonaActivity { engaged: false, since_ms: t0 - 10_000 };
+        let busy = PersonaActivity { engaged: true, since_ms: t0 - 100_000 };
+        assert!(persona_bored(idle_long, false, t0));
+        assert!(!persona_bored(idle_short, false, t0), "sustained idle, not a pause");
+        assert!(!persona_bored(busy, false, t0), "her own turn is wakefulness");
+        assert!(!persona_bored(idle_long, true, t0), "a measured hold quiets everyone");
+    }
+
     #[test]
     fn boredom_arises_slowly_and_dies_instantly() {
         let t0 = 1_000_000u64;

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -787,6 +787,22 @@ pub fn only_stale_or_no_working_rounds(runs: &[CardRunFacts], now_ms: u64) -> bo
     no_healthy_working_round(&rounds)
 }
 
+/// How many cards across live rounds are `unstarted` — never worked, no run
+/// artifact, no held-work turn. The standing autopilot's BACKLOG guard: with a
+/// deep backlog, dispatching another round just deepens the pile (measured
+/// 2026-09-02: the autopilot reached 30+ rounds / 111 unstarted while 4 citizens
+/// worked). Complements the working-round gate — that holds while a round is
+/// being worked; this holds while there is unworked work already waiting.
+pub fn unworked_backlog(runs: &[CardRunFacts], now_ms: u64) -> usize {
+    let mut rounds = live_rounds();
+    enrich_rounds(&mut rounds, runs, now_ms);
+    rounds
+        .iter()
+        .flat_map(|r| r.cards.iter())
+        .filter(|c| c.state == "unstarted")
+        .count()
+}
+
 /// PURE decision (testable without the ROUNDS global): true when no round is
 /// healthily grinding — every Working round is stalled/unstarted past the
 /// abandon window, or there are none. A round with a fresh act (idle under

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -758,34 +758,37 @@ pub fn unworked_citizen_cards() -> Vec<NextCard> {
 /// the board rather than working a fixed pile pushed onto you (Joel 2026-09-02).
 /// Load-balances (a fast member pulls more) and is resilient (a dropped member's
 /// un-pulled cards stay in the deck for anyone).
-pub fn next_pullable_card(peer: Uuid) -> Option<NextCard> {
+pub fn pullable_cards(
+    peer: Uuid,
+    resident_rooms: &std::collections::HashSet<Uuid>,
+) -> Vec<NextCard> {
     let rounds = ROUNDS.lock().expect("bench rounds mutex");
     let live = live_run_ids();
     rounds
         .values()
         .filter(|r| r.stage == RoundStage::Working && r.driver == WorkDriver::Citizen)
-        .filter(|r| r.team.contains(&peer) || r.card_assignees.values().any(|a| *a == peer))
-        .find_map(|r| {
+        // ELIGIBILITY IS RESIDENCY. She may pull from any run room she is standing in
+        // — the round's `team` (really its reviewer set, empty unless `--teammates`)
+        // and the dispatch-time assignee were the gate that locked 7 of 12 residents
+        // out of a "shared" deck for months (2026-09-03). A card is room content; a
+        // resident works it. The `run_room` IS the round id.
+        .filter(|r| resident_rooms.contains(&r.round_id))
+        .flat_map(|r| {
             r.cards
                 .iter()
                 .filter(|(_, state)| state.is_none())
                 .filter(|(c, _)| !live.contains(&format!("claim-{}", c)))
-                .filter(|(c, _)| r.card_assignees.get(*c).map_or(true, |a| *a == peer))
                 .map(|(c, _)| NextCard {
                     card: *c,
                     assignee: peer,
                     run_room: r.round_id,
                     teammates: r.team.clone(),
                 })
-                .next()
+                .collect::<Vec<_>>()
         })
+        .collect()
 }
 
-/// Total OPEN (non-terminal) cards across every Working round — the board-side
-/// LANE DEMAND. Queued benchmark work is demand the serving plan must see:
-/// measured live 2026-08-27, the plan converged to 1 lane after a 4-way cohort
-/// settled (demand = the boot persona floor, blind to the board), and 17
-/// workable cards then crawled serially behind all room-life on one slot.
 pub fn total_unworked_cards() -> usize {
     let rounds = ROUNDS.lock().expect("bench rounds mutex");
     rounds

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -1130,6 +1130,26 @@ pub struct RoundCardSnapshot {
     pub last_act_secs: Option<u64>,
     #[ts(optional)]
     pub resolved: Option<bool>,
+    /// BOARD truth (the durable record): the card's column right now —
+    /// `open|claimed|in_progress|blocked|review|merged|closed`. Empty when the
+    /// board could not be read.
+    #[serde(default)]
+    pub board_state: String,
+    /// Who holds it on the board (display name, else short id). Empty = nobody.
+    #[serde(default)]
+    pub owner: String,
+    /// Board timestamps — the experiment axes: time-to-claim and time-to-settle
+    /// read from these, never from a process clock that a reboot resets.
+    #[ts(optional, type = "number")]
+    #[serde(default)]
+    pub created_at_ms: Option<u64>,
+    #[ts(optional, type = "number")]
+    #[serde(default)]
+    pub updated_at_ms: Option<u64>,
+    /// When the verdict file was written (`SweVerdict::graded_at_ms`).
+    #[ts(optional, type = "number")]
+    #[serde(default)]
+    pub graded_at_ms: Option<u64>,
 }
 
 /// The run-ledger facts [`enrich_rounds`] merges into a card row — a minimal
@@ -1296,6 +1316,11 @@ pub fn live_rounds() -> Vec<RoundSnapshot> {
                         patch_bytes: None,
                         last_act_secs: None,
                         resolved: None,
+                        board_state: String::new(),
+                        owner: String::new(),
+                        created_at_ms: None,
+                        updated_at_ms: None,
+                        graded_at_ms: None,
                     }
                 })
                 .collect();
@@ -1350,6 +1375,11 @@ mod tests {
             patch_bytes: None,
             last_act_secs: None,
             resolved: None,
+            board_state: String::new(),
+            owner: String::new(),
+            created_at_ms: None,
+            updated_at_ms: None,
+            graded_at_ms: None,
         };
         let round = |cards: Vec<RoundCardSnapshot>| RoundSnapshot {
             round_id: Uuid::new_v4().to_string(),
@@ -1448,6 +1478,11 @@ mod tests {
                 patch_bytes: None,
                 last_act_secs: None,
                 resolved: None,
+                board_state: String::new(),
+                owner: String::new(),
+                created_at_ms: None,
+                updated_at_ms: None,
+                graded_at_ms: None,
             }],
             verdict: String::new(),
             idle_secs: None,

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -185,6 +185,20 @@ pub struct BenchRound {
     /// is read-the-saved-state, never re-derive.
     #[serde(default)]
     card_last_act_ms: HashMap<Uuid, u64>,
+    /// THE REVIEW GATE (team-recipe Arm 2, 2026-09-03): when set, an owner's `done`
+    /// on a card of this round becomes `review` + a sibling review card that a
+    /// NON-owner pulls; only the reviewer's `done` closes the parent (and fires its
+    /// grade). The one structural intervention the literature found moved SWE
+    /// scores — a fresh-context, execution-grounded verdict — as recipe DATA.
+    #[serde(default)]
+    review_gate: bool,
+    /// Review card → the parent card it reviews. A review card is round work (it is
+    /// pullable) but not a round CARD (it never counts toward the round's remaining).
+    #[serde(default)]
+    review_cards: HashMap<Uuid, Uuid>,
+    /// Parents whose review passed — their next `done` goes through.
+    #[serde(default)]
+    reviews_passed: std::collections::HashSet<Uuid>,
 }
 
 /// Where one card's solve LIVES: its per-instance activity room, the citizen
@@ -224,6 +238,9 @@ impl BenchRound {
             card_assignees: HashMap::new(),
             card_instances: HashMap::new(),
             card_last_act_ms: HashMap::new(),
+            review_gate: false,
+            review_cards: HashMap::new(),
+            reviews_passed: Default::default(),
             team: Vec::new(),
         }
     }
@@ -496,6 +513,58 @@ pub fn set_round_team(round_id: Uuid, team: Vec<Uuid>) {
     }
 }
 
+/// Turn the round's REVIEW GATE on (dispatch calls it right after [`open_round`]).
+pub fn set_review_gate(round_id: Uuid, on: bool) {
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(r) = rounds.get_mut(&round_id) {
+        r.review_gate = on;
+        persist_round_in(&rounds_state_dir(), r);
+    }
+}
+
+/// Must an owner's `done` on `card` go through review first? True iff the card's
+/// round is gated and no review has passed for it yet.
+pub fn review_required(card: Uuid) -> bool {
+    ROUNDS
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .values()
+        .find(|r| r.cards.contains_key(&card))
+        .is_some_and(|r| r.review_gate && !r.reviews_passed.contains(&card))
+}
+
+/// Record the sibling review card of `parent` (posted by the gate). Returns the
+/// round id it joined, or `None` when the parent is in no live round.
+pub fn register_review_card(parent: Uuid, review: Uuid) -> Option<Uuid> {
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let r = rounds.values_mut().find(|r| r.cards.contains_key(&parent))?;
+    r.review_cards.insert(review, parent);
+    persist_round_in(&rounds_state_dir(), r);
+    Some(r.round_id)
+}
+
+/// The parent a review card reviews, if `card` is a live review card.
+pub fn review_parent(card: Uuid) -> Option<Uuid> {
+    ROUNDS
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .values()
+        .find_map(|r| r.review_cards.get(&card).copied())
+}
+
+/// The reviewer's verdict landed: the review card retires; a pass unlocks the
+/// parent's `done`. Returns the parent.
+pub fn settle_review_card(review: Uuid, passed: bool) -> Option<Uuid> {
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let r = rounds.values_mut().find(|r| r.review_cards.contains_key(&review))?;
+    let parent = r.review_cards.remove(&review)?;
+    if passed {
+        r.reviews_passed.insert(parent);
+    }
+    persist_round_in(&rounds_state_dir(), r);
+    Some(parent)
+}
+
 /// Add a freshly posted card to an open round. Unknown round = no-op (dispatch always
 /// opens first; a card that arrives without one is not part of a tracked round).
 pub fn add_card(round_id: Uuid, card_id: Uuid) {
@@ -745,12 +814,20 @@ pub fn pullable_cards(
         // resident works it. The `run_room` IS the round id.
         .filter(|r| resident_rooms.contains(&r.round_id))
         .flat_map(|r| {
-            r.cards
-                .iter()
-                .filter(|(_, state)| state.is_none())
-                .filter(|(c, _)| !live.contains(&format!("claim-{}", c)))
-                .map(|(c, _)| NextCard {
-                    card: *c,
+            // Review cards FIRST: a fix waiting on a verdict is the round's critical
+            // path, and a reviewer costs a short read, not a solve.
+            r.review_cards
+                .keys()
+                .copied()
+                .chain(
+                    r.cards
+                        .iter()
+                        .filter(|(_, state)| state.is_none())
+                        .filter(|(c, _)| !live.contains(&format!("claim-{}", c)))
+                        .map(|(c, _)| *c),
+                )
+                .map(|c| NextCard {
+                    card: c,
                     assignee: peer,
                     run_room: r.round_id,
                     teammates: r.team.clone(),
@@ -1440,6 +1517,41 @@ mod tests {
     // 53 unstarted, 4 citizens). This pins that a held-work turn makes the round
     // read "working"/"grinding" from the ephemeral CARD_LAST_ACT signal alone
     // (empty run ledger), so the autopilot HOLDS instead of over-dispatching.
+    // what this catches: the review gate's state machine on the tracker — a gated
+    // card requires review until a review card registered for it settles as PASSED;
+    // a rejected review leaves it required; review cards appear on the pull deck
+    // ahead of Open cards and never count toward the round's remaining.
+    #[test]
+    fn a_gated_card_requires_review_until_its_review_card_passes() {
+        let round_id = Uuid::new_v4();
+        let card = Uuid::new_v4();
+        open_round(round_id, "swe-bench-verified", WorkDriver::Citizen);
+        add_card(round_id, card);
+        assert!(!review_required(card), "no gate, no review");
+        set_review_gate(round_id, true);
+        assert!(review_required(card));
+
+        let review = Uuid::new_v4();
+        assert_eq!(register_review_card(card, review), Some(round_id));
+        assert_eq!(review_parent(review), Some(card));
+        let resident: std::collections::HashSet<Uuid> = [round_id].into_iter().collect();
+        let deck = pullable_cards(Uuid::new_v4(), &resident);
+        assert_eq!(deck[0].card, review, "the review card leads the deck");
+        assert_eq!(
+            ROUNDS.lock().unwrap().get(&round_id).unwrap().remaining(),
+            1,
+            "a review card is not a round card"
+        );
+
+        assert_eq!(settle_review_card(review, false), Some(card));
+        assert!(review_required(card), "a rejection keeps the gate shut");
+        let again = Uuid::new_v4();
+        register_review_card(card, again);
+        assert_eq!(settle_review_card(again, true), Some(card));
+        assert!(!review_required(card), "a pass opens the gate for the parent's done");
+        ROUNDS.lock().unwrap().remove(&round_id);
+    }
+
     #[test]
     fn a_citizen_held_work_turn_makes_the_round_read_working() {
         use super::{
@@ -1575,6 +1687,9 @@ mod tests {
                 card_assignees: cards.iter().copied().collect(),
                 card_instances: Default::default(),
                 card_last_act_ms: HashMap::new(),
+            review_gate: false,
+            review_cards: HashMap::new(),
+            reviews_passed: Default::default(),
                 team: Vec::new(),
             }
         }

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -299,7 +299,7 @@ static ROUNDS: LazyLock<Mutex<HashMap<Uuid, BenchRound>>> =
 /// Persisted with the round: freshness survives the seam. A card outside any live
 /// round records nothing (there is no round to read it back for).
 pub fn record_card_worked(card_id: Uuid, now_ms: u64) {
-    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every ROUNDS lock
     if let Some(round) = rounds.values_mut().find(|r| r.cards.contains_key(&card_id)) {
         round.card_last_act_ms.insert(card_id, now_ms);
         persist_round_in(&rounds_state_dir(), round);
@@ -311,7 +311,7 @@ pub fn record_card_worked(card_id: Uuid, now_ms: u64) {
 pub fn card_last_act_ms(card_id: Uuid) -> Option<u64> {
     ROUNDS
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(|p| p.into_inner())  // poisoned lock = read the last state, same policy as every ROUNDS lock
         .values()
         .find_map(|r| r.card_last_act_ms.get(&card_id).copied())
 }
@@ -423,7 +423,7 @@ pub fn reap_orphaned_rounds() -> Vec<(String, usize)> {
             expired.iter().map(|(b, _)| b).collect();
         ROUNDS
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(|p| p.into_inner())  // poisoned lock = read the last state, same policy as every ROUNDS lock
             .retain(|_, r| r.stage != RoundStage::Working || !dead.contains(&r.benchmark));
     }
     expired
@@ -483,7 +483,7 @@ fn reap_with_ttl(dir: &Path, ttl: std::time::Duration) -> Vec<(String, usize)> {
 ///
 /// Idempotent by round id: re-opening a live round leaves it untouched.
 pub fn open_round(round_id: Uuid, benchmark: &str, driver: WorkDriver) {
-    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every ROUNDS lock
     let round = rounds
         .entry(round_id)
         .or_insert_with(|| BenchRound::new(round_id, benchmark, &[], driver));
@@ -498,7 +498,7 @@ pub fn open_round(round_id: Uuid, benchmark: &str, driver: WorkDriver) {
 /// [`open_round`]) — the presence emitter's adoption list reads it so the
 /// RUN room, not just its solve children, projects presence + transcript.
 pub fn set_run_room_name(round_id: Uuid, name: &str) {
-    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every ROUNDS lock
     if let Some(round) = rounds.get_mut(&round_id) {
         round.run_room_name = name.to_string();
         persist_round_in(&rounds_state_dir(), round);
@@ -506,7 +506,7 @@ pub fn set_run_room_name(round_id: Uuid, name: &str) {
 }
 
 pub fn set_round_team(round_id: Uuid, team: Vec<Uuid>) {
-    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every ROUNDS lock
     if let Some(r) = rounds.get_mut(&round_id) {
         r.team = team;
         persist_round_in(&rounds_state_dir(), r);
@@ -515,7 +515,7 @@ pub fn set_round_team(round_id: Uuid, team: Vec<Uuid>) {
 
 /// Turn the round's REVIEW GATE on (dispatch calls it right after [`open_round`]).
 pub fn set_review_gate(round_id: Uuid, on: bool) {
-    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every ROUNDS lock
     if let Some(r) = rounds.get_mut(&round_id) {
         r.review_gate = on;
         persist_round_in(&rounds_state_dir(), r);
@@ -527,7 +527,7 @@ pub fn set_review_gate(round_id: Uuid, on: bool) {
 pub fn review_required(card: Uuid) -> bool {
     ROUNDS
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(|p| p.into_inner())  // poisoned lock = read the last state, same policy as every ROUNDS lock
         .values()
         .find(|r| r.cards.contains_key(&card))
         .is_some_and(|r| r.review_gate && !r.reviews_passed.contains(&card))
@@ -536,7 +536,7 @@ pub fn review_required(card: Uuid) -> bool {
 /// Record the sibling review card of `parent` (posted by the gate). Returns the
 /// round id it joined, or `None` when the parent is in no live round.
 pub fn register_review_card(parent: Uuid, review: Uuid) -> Option<Uuid> {
-    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every ROUNDS lock
     let r = rounds.values_mut().find(|r| r.cards.contains_key(&parent))?;
     r.review_cards.insert(review, parent);
     persist_round_in(&rounds_state_dir(), r);
@@ -547,7 +547,7 @@ pub fn register_review_card(parent: Uuid, review: Uuid) -> Option<Uuid> {
 pub fn review_parent(card: Uuid) -> Option<Uuid> {
     ROUNDS
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(|p| p.into_inner())  // poisoned lock = read the last state, same policy as every ROUNDS lock
         .values()
         .find_map(|r| r.review_cards.get(&card).copied())
 }
@@ -555,7 +555,7 @@ pub fn review_parent(card: Uuid) -> Option<Uuid> {
 /// The reviewer's verdict landed: the review card retires; a pass unlocks the
 /// parent's `done`. Returns the parent.
 pub fn settle_review_card(review: Uuid, passed: bool) -> Option<Uuid> {
-    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every ROUNDS lock
     let r = rounds.values_mut().find(|r| r.review_cards.contains_key(&review))?;
     let parent = r.review_cards.remove(&review)?;
     if passed {
@@ -570,7 +570,7 @@ pub fn settle_review_card(review: Uuid, passed: bool) -> Option<Uuid> {
 pub fn add_card(round_id: Uuid, card_id: Uuid) {
     if let Some(r) = ROUNDS
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(|p| p.into_inner())  // poisoned lock = read the last state, same policy as every ROUNDS lock
         .get_mut(&round_id)
     {
         r.cards.entry(card_id).or_insert(None);
@@ -583,7 +583,7 @@ pub fn add_card(round_id: Uuid, card_id: Uuid) {
 /// skipped / already on board) stages and immediately ends — an honest empty round,
 /// never a map entry that no event can ever settle.
 pub fn seal_round(round_id: Uuid) {
-    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every ROUNDS lock
     let Some(round) = rounds.get(&round_id) else {
         return;
     };
@@ -626,7 +626,7 @@ pub fn seal_round(round_id: Uuid) {
 pub fn room_for_card(card_id: Uuid) -> Option<Uuid> {
     ROUNDS
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(|p| p.into_inner())  // poisoned lock = read the last state, same policy as every ROUNDS lock
         .values()
         .find(|r| r.cards.contains_key(&card_id))
         .map(|r| r.round_id)
@@ -804,9 +804,17 @@ pub fn pullable_cards(
 ) -> Vec<NextCard> {
     let rounds = ROUNDS.lock().expect("bench rounds mutex");
     let live = live_run_ids();
-    rounds
+    // THE FULLEST DECK DRAINS FIRST: rounds ordered by remaining cards (desc), so a
+    // fresh 12-card round is worked ahead of an old round's last stragglers. Map
+    // order starved a new round entirely (measured: 9 pulls to the older round, 0 to
+    // the new one in 20 min).
+    let mut ordered: Vec<&BenchRound> = rounds
         .values()
         .filter(|r| r.stage == RoundStage::Working && r.driver == WorkDriver::Citizen)
+        .collect();
+    ordered.sort_by(|a, b| b.remaining().cmp(&a.remaining()).then(a.round_id.cmp(&b.round_id)));
+    ordered
+        .into_iter()
         // ELIGIBILITY IS RESIDENCY. She may pull from any run room she is standing in
         // — the round's `team` (really its reviewer set, empty unless `--teammates`)
         // and the dispatch-time assignee were the gate that locked 7 of 12 residents
@@ -946,7 +954,7 @@ fn first_unworked_excluding(
 /// Operator hold: flip a Working round to Paused (persisted). Returns false
 /// when the round is unknown or already terminal.
 pub fn pause_round(round_id: Uuid) -> bool {
-    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every ROUNDS lock
     match rounds.get_mut(&round_id) {
         Some(r) if r.stage == RoundStage::Working => {
             r.stage = RoundStage::Paused;
@@ -967,7 +975,7 @@ pub fn pause_round(round_id: Uuid) -> bool {
 /// of waiting for the next settle edge.
 pub fn resume_round(round_id: Uuid) -> Option<NextCard> {
     let live = live_run_ids();
-    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every ROUNDS lock
     let r = rounds.get_mut(&round_id)?;
     match r.stage {
         RoundStage::Paused => {
@@ -1004,7 +1012,7 @@ pub fn resume_round(round_id: Uuid) -> Option<NextCard> {
 pub fn driver_for_card(card_id: Uuid) -> WorkDriver {
     ROUNDS
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(|p| p.into_inner())  // poisoned lock = read the last state, same policy as every ROUNDS lock
         .values()
         .find(|r| r.cards.contains_key(&card_id))
         .map(|r| r.driver)
@@ -1047,7 +1055,7 @@ pub fn observe_card_event(payload: &Value) {
         return;
     };
 
-    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every ROUNDS lock
     // A card belongs to at most one round: dispatch's idempotence gate refuses a second
     // live card per task, and card uuids are minted per card. First match is THE match.
     let Some(round) = rounds.values_mut().find(|r| r.cards.contains_key(&card)) else {
@@ -1538,7 +1546,7 @@ mod tests {
         let deck = pullable_cards(Uuid::new_v4(), &resident);
         assert_eq!(deck[0].card, review, "the review card leads the deck");
         assert_eq!(
-            ROUNDS.lock().unwrap().get(&round_id).unwrap().remaining(),
+            ROUNDS.lock().unwrap().get(&round_id).unwrap().remaining(),  // test: the round was opened above
             1,
             "a review card is not a round card"
         );
@@ -1549,7 +1557,7 @@ mod tests {
         register_review_card(card, again);
         assert_eq!(settle_review_card(again, true), Some(card));
         assert!(!review_required(card), "a pass opens the gate for the parent's done");
-        ROUNDS.lock().unwrap().remove(&round_id);
+        ROUNDS.lock().unwrap().remove(&round_id);  // test: cleanup of the round opened above
     }
 
     #[test]
@@ -1881,7 +1889,7 @@ mod tests {
         );
         seal_round(round_id);
         assert_eq!(driver_for_card(first), WorkDriver::Citizen);
-        ROUNDS.lock().unwrap().remove(&round_id);
+        ROUNDS.lock().unwrap().remove(&round_id);  // test: cleanup of the round opened above
     }
 
     // what this catches: the default biting the wrong way — INVERTED 2026-08-31
@@ -1929,7 +1937,7 @@ mod tests {
             next.as_ref().is_some_and(|n| ids.contains(&n.card)),
             "a WORKING round with no live run must kick its first unworked card: {next:?}"
         );
-        ROUNDS.lock().unwrap().remove(&round_id);
+        ROUNDS.lock().unwrap().remove(&round_id);  // test: cleanup of the round opened above
     }
 
     // what this catches: the END transition firing more than once. All-settled must yield
@@ -1992,7 +2000,7 @@ mod tests {
             "settled is reported, never left to subtraction — an absence must not become a guess"
         );
 
-        ROUNDS.lock().unwrap().remove(&round_id);
+        ROUNDS.lock().unwrap().remove(&round_id);  // test: cleanup of the round opened above
     }
 
     // what this catches: a duplicate terminal event double-counting a card. The bridge

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -267,6 +267,36 @@ impl BenchRound {
 static ROUNDS: LazyLock<Mutex<HashMap<Uuid, BenchRound>>> =
     LazyLock::new(|| Mutex::new(load_rounds_in(&rounds_state_dir())));
 
+/// Per-card wall-clock (epoch ms) of the LATEST held-work turn a citizen drove on
+/// it — the freshness signal a CITIZEN-driven card emits, which the detached-solve
+/// run ledger never sees. EPHEMERAL (in-memory, not persisted): freshness is a
+/// live property and correctly resets on reboot, where the resume re-establishes
+/// it. Without this, a Citizen round reads "unstarted" while she is actively
+/// working it, so the standing autopilot judges no round is working and piles up
+/// duplicate rounds (measured 2026-09-02: 21 rounds, 53 unstarted, 4 citizens).
+/// [[activity-outcome-score-is-recipe-owned-gates-multiply-objectives-weigh]]
+static CARD_LAST_ACT: LazyLock<Mutex<HashMap<Uuid, u64>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Stamp that a citizen drove a held-work turn on `card_id` at `now_ms` — called
+/// from the held-work turn boundary so `enrich_rounds` can see Citizen progress.
+pub fn record_card_worked(card_id: Uuid, now_ms: u64) {
+    CARD_LAST_ACT
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .insert(card_id, now_ms);
+}
+
+/// The epoch-ms of the latest held-work turn on `card_id`, if any — the Citizen
+/// freshness [`enrich_rounds`] merges beside the detached run ledger.
+pub fn card_last_act_ms(card_id: Uuid) -> Option<u64> {
+    CARD_LAST_ACT
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .get(&card_id)
+        .copied()
+}
+
 /// Where in-flight rounds persist — one JSON file per round, removed at Done. The same
 /// durable-state family as the airc attach cursor (`~/.continuum/state`): tiny, per-key,
 /// self-evicting at terminal state, so the directory only ever holds in-flight rounds.
@@ -1124,8 +1154,28 @@ pub fn enrich_rounds(rounds: &mut [RoundSnapshot], runs: &[CardRunFacts], now_ms
                 .filter(|r| !card.instance.is_empty() && r.instance == card.instance)
                 .max_by_key(|r| r.last_activity_ms);
             let Some(run) = run else {
+                // No detached-solve ledger entry — but a CITIZEN-driven card
+                // leaves no ledger, so fall back to the held-work freshness the
+                // turn boundary stamps. A recent held-work turn makes the card
+                // read "working" (not "unstarted") and feeds the round's idle
+                // clock, so the standing autopilot sees the round is being worked
+                // and holds instead of piling up duplicates.
                 if !settled {
-                    card.state = "unstarted".to_string();
+                    let held_act = card
+                        .card_id
+                        .parse::<Uuid>()
+                        .ok()
+                        .and_then(card_last_act_ms);
+                    if let Some(act_ms) = held_act {
+                        any_started = true;
+                        let act_age = now_ms.saturating_sub(act_ms) / 1000;
+                        card.last_act_secs = Some(act_age);
+                        card.state = "working".to_string();
+                        newest_unsettled_act =
+                            Some(newest_unsettled_act.map_or(act_age, |a: u64| a.min(act_age)));
+                    } else {
+                        card.state = "unstarted".to_string();
+                    }
                 }
                 continue;
             };
@@ -1329,6 +1379,69 @@ mod tests {
         assert_eq!(rounds[1].cards[0].acts, Some(7));
         assert_eq!(rounds[2].verdict, "stalled");
         assert_eq!(rounds[2].cards[0].state, "quiet");
+    }
+
+    // what this catches: A CITIZEN-driven card leaves NO detached-solve ledger
+    // entry, so before the held-work freshness signal the round read "unstarted"
+    // while she was actively working it — and the standing autopilot, seeing no
+    // working round, piled up duplicate rounds (measured 2026-09-02: 21 rounds,
+    // 53 unstarted, 4 citizens). This pins that a held-work turn makes the round
+    // read "working"/"grinding" from the ephemeral CARD_LAST_ACT signal alone
+    // (empty run ledger), so the autopilot HOLDS instead of over-dispatching.
+    #[test]
+    fn a_citizen_held_work_turn_makes_the_round_read_working() {
+        use super::{
+            card_last_act_ms, enrich_rounds, no_healthy_working_round, record_card_worked,
+            RoundCardSnapshot, RoundSnapshot,
+        };
+        let now_ms: u64 = 20_000_000_000;
+        let card_uuid = Uuid::new_v4();
+        // She drove a held-work turn 30s ago — no run-ledger fact exists.
+        record_card_worked(card_uuid, now_ms - 30_000);
+        assert_eq!(card_last_act_ms(card_uuid), Some(now_ms - 30_000));
+
+        let mut rounds = vec![RoundSnapshot {
+            round_id: Uuid::new_v4().to_string(),
+            benchmark: "swe-bench-verified".into(),
+            stage: "working".into(),
+            dispatched: 1,
+            settled: 0,
+            remaining: 1,
+            driver: "citizen".into(),
+            cards: vec![RoundCardSnapshot {
+                card_id: card_uuid.to_string(),
+                instance: "django__django-12273".into(),
+                assignee: String::new(),
+                solve_room_name: String::new(),
+                state: "unstarted".into(),
+                acts: None,
+                patch_bytes: None,
+                last_act_secs: None,
+                resolved: None,
+            }],
+            verdict: String::new(),
+            idle_secs: None,
+        }];
+        // EMPTY run ledger — the detached-solve facts a Citizen card never produces.
+        enrich_rounds(&mut rounds, &[], now_ms);
+
+        assert_eq!(
+            rounds[0].cards[0].state, "working",
+            "held-work makes the card read working, not a false 'unstarted'"
+        );
+        assert_eq!(
+            rounds[0].idle_secs,
+            Some(30),
+            "the round's idle clock reflects her held-work turn"
+        );
+        assert_eq!(
+            rounds[0].verdict, "grinding",
+            "the round is visibly being worked"
+        );
+        assert!(
+            !no_healthy_working_round(&rounds),
+            "a freshly held-worked round is a healthy working round — the autopilot HOLDS"
+        );
     }
 
     // what this catches: a wedged Working round (dead citizens, no task

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -749,6 +749,38 @@ pub fn unworked_citizen_cards() -> Vec<NextCard> {
         .collect()
 }
 
+/// The next card a MEMBER can PULL from a shared team deck — kanban PULL, not
+/// push. The first non-terminal card, with no live run, in any Working Citizen
+/// round the peer belongs to (in its `team`, or already an assignee somewhere in
+/// it), that is NOT already assigned to a DIFFERENT member (never poach a
+/// teammate's card; Open or hers is fair game). `assignee` is the PULLER — she is
+/// claiming it. Personifies a human team: when free, you take the next card off
+/// the board rather than working a fixed pile pushed onto you (Joel 2026-09-02).
+/// Load-balances (a fast member pulls more) and is resilient (a dropped member's
+/// un-pulled cards stay in the deck for anyone).
+pub fn next_pullable_card(peer: Uuid) -> Option<NextCard> {
+    let rounds = ROUNDS.lock().expect("bench rounds mutex");
+    let live = live_run_ids();
+    rounds
+        .values()
+        .filter(|r| r.stage == RoundStage::Working && r.driver == WorkDriver::Citizen)
+        .filter(|r| r.team.contains(&peer) || r.card_assignees.values().any(|a| *a == peer))
+        .find_map(|r| {
+            r.cards
+                .iter()
+                .filter(|(_, state)| state.is_none())
+                .filter(|(c, _)| !live.contains(&format!("claim-{}", c)))
+                .filter(|(c, _)| r.card_assignees.get(*c).map_or(true, |a| *a == peer))
+                .map(|(c, _)| NextCard {
+                    card: *c,
+                    assignee: peer,
+                    run_room: r.round_id,
+                    teammates: r.team.clone(),
+                })
+                .next()
+        })
+}
+
 /// Total OPEN (non-terminal) cards across every Working round — the board-side
 /// LANE DEMAND. Queued benchmark work is demand the serving plan must see:
 /// measured live 2026-08-27, the plan converged to 1 lane after a 4-way cohort

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -176,6 +176,15 @@ pub struct BenchRound {
     /// pronounced `unstarted`).
     #[serde(default)]
     card_instances: HashMap<Uuid, String>,
+    /// Card uuid → epoch-ms of the LATEST held-work turn a citizen drove on it. The
+    /// freshness signal a CITIZEN-driven card emits, which the detached-solve run
+    /// ledger never sees. DURABLE (save-on-write with the round) since 2026-09-03:
+    /// it used to be a process-global map that a reboot emptied, so every citizen
+    /// round read "unstarted" after a restart and the standing autopilot minted a
+    /// duplicate round per tick (30 duplicate verified-mini rounds measured). Resume
+    /// is read-the-saved-state, never re-derive.
+    #[serde(default)]
+    card_last_act_ms: HashMap<Uuid, u64>,
 }
 
 /// Where one card's solve LIVES: its per-instance activity room, the citizen
@@ -214,6 +223,7 @@ impl BenchRound {
             card_activities: HashMap::new(),
             card_assignees: HashMap::new(),
             card_instances: HashMap::new(),
+            card_last_act_ms: HashMap::new(),
             team: Vec::new(),
         }
     }
@@ -267,34 +277,26 @@ impl BenchRound {
 static ROUNDS: LazyLock<Mutex<HashMap<Uuid, BenchRound>>> =
     LazyLock::new(|| Mutex::new(load_rounds_in(&rounds_state_dir())));
 
-/// Per-card wall-clock (epoch ms) of the LATEST held-work turn a citizen drove on
-/// it — the freshness signal a CITIZEN-driven card emits, which the detached-solve
-/// run ledger never sees. EPHEMERAL (in-memory, not persisted): freshness is a
-/// live property and correctly resets on reboot, where the resume re-establishes
-/// it. Without this, a Citizen round reads "unstarted" while she is actively
-/// working it, so the standing autopilot judges no round is working and piles up
-/// duplicate rounds (measured 2026-09-02: 21 rounds, 53 unstarted, 4 citizens).
-/// [[activity-outcome-score-is-recipe-owned-gates-multiply-objectives-weigh]]
-static CARD_LAST_ACT: LazyLock<Mutex<HashMap<Uuid, u64>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
 /// Stamp that a citizen drove a held-work turn on `card_id` at `now_ms` — called
 /// from the held-work turn boundary so `enrich_rounds` can see Citizen progress.
+/// Persisted with the round: freshness survives the seam. A card outside any live
+/// round records nothing (there is no round to read it back for).
 pub fn record_card_worked(card_id: Uuid, now_ms: u64) {
-    CARD_LAST_ACT
-        .lock()
-        .unwrap_or_else(|p| p.into_inner())
-        .insert(card_id, now_ms);
+    let mut rounds = ROUNDS.lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(round) = rounds.values_mut().find(|r| r.cards.contains_key(&card_id)) {
+        round.card_last_act_ms.insert(card_id, now_ms);
+        persist_round_in(&rounds_state_dir(), round);
+    }
 }
 
 /// The epoch-ms of the latest held-work turn on `card_id`, if any — the Citizen
 /// freshness [`enrich_rounds`] merges beside the detached run ledger.
 pub fn card_last_act_ms(card_id: Uuid) -> Option<u64> {
-    CARD_LAST_ACT
+    ROUNDS
         .lock()
         .unwrap_or_else(|p| p.into_inner())
-        .get(&card_id)
-        .copied()
+        .values()
+        .find_map(|r| r.card_last_act_ms.get(&card_id).copied())
 }
 
 /// Where in-flight rounds persist — one JSON file per round, removed at Done. The same
@@ -717,37 +719,6 @@ pub fn next_unworked_per_round() -> Vec<NextCard> {
         .collect()
 }
 
-/// Every unworked card of every Working CITIZEN-driven round — the cards whose
-/// driver is the citizens' own perception, not a detached dispatch. The boot
-/// resume RE-SAYS their kickoffs into the run room (through the assignee's own
-/// subscribed runtime), because a reload leaves the original kickoffs buried
-/// beyond every window: found live 2026-09-01, a lite round sat 'working, 4
-/// remaining' a full day while its four assignees idled beside their own
-/// unworked cards ([[bench-rounds-die-at-perception-run-rooms-are-deaf]]).
-/// One entry per card (not first-only): re-perception addresses every
-/// assignee, unlike the one-at-a-time detached dispatch.
-pub fn unworked_citizen_cards() -> Vec<NextCard> {
-    let rounds = ROUNDS.lock().expect("bench rounds mutex");
-    rounds
-        .values()
-        .filter(|r| r.stage == RoundStage::Working && r.driver == WorkDriver::Citizen)
-        .flat_map(|r| {
-            let run_room = r.round_id;
-            r.cards
-                .iter()
-                .filter(|(_, state)| state.is_none())
-                .filter_map(move |(card, _)| {
-                    r.card_assignees.get(card).map(|assignee| NextCard {
-                        card: *card,
-                        assignee: *assignee,
-                        run_room,
-                        teammates: r.team.clone(),
-                    })
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect()
-}
 
 /// The next card a MEMBER can PULL from a shared team deck — kanban PULL, not
 /// push. The first non-terminal card, with no live run, in any Working Citizen
@@ -1448,6 +1419,14 @@ mod tests {
         let now_ms: u64 = 20_000_000_000;
         let card_uuid = Uuid::new_v4();
         // She drove a held-work turn 30s ago — no run-ledger fact exists.
+        // Freshness lives ON THE ROUND (durable): a card outside any round has none,
+        // a card in a live round remembers its latest held-work turn.
+        let stray = Uuid::new_v4();
+        record_card_worked(stray, now_ms);
+        assert_eq!(card_last_act_ms(stray), None, "no round, nowhere to keep freshness");
+        let round_id = Uuid::new_v4();
+        open_round(round_id, "swe-bench-verified", WorkDriver::Citizen);
+        add_card(round_id, card_uuid);
         record_card_worked(card_uuid, now_ms - 30_000);
         assert_eq!(card_last_act_ms(card_uuid), Some(now_ms - 30_000));
 
@@ -1560,6 +1539,7 @@ mod tests {
                 card_activities: Default::default(),
                 card_assignees: cards.iter().copied().collect(),
                 card_instances: Default::default(),
+                card_last_act_ms: HashMap::new(),
                 team: Vec::new(),
             }
         }

--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -742,6 +742,32 @@ pub fn any_working_round() -> bool {
         .any(|r| r.stage == RoundStage::Working)
 }
 
+/// A round is ABANDONED-STALE when it is Working but no unsettled card has
+/// produced a work artifact in [`STALE_ROUND_ABANDON_SECS`] — a wedged round
+/// whose citizens died without a task boundary (measured 2026-09-02: three
+/// rounds stuck ~18h, blocking the standing autopilot, un-clearable because
+/// round-stop's cancellation waits for a boundary the dead citizens never
+/// reach). The standing round treats these as NOT blocking, so a fresh cohort
+/// dispatches over the corpse. Takes the ledger facts the board already folds.
+pub const STALE_ROUND_ABANDON_SECS: u64 = 3600;
+
+pub fn only_stale_or_no_working_rounds(runs: &[CardRunFacts], now_ms: u64) -> bool {
+    let mut rounds = live_rounds();
+    enrich_rounds(&mut rounds, runs, now_ms);
+    no_healthy_working_round(&rounds)
+}
+
+/// PURE decision (testable without the ROUNDS global): true when no round is
+/// healthily grinding — every Working round is stalled/unstarted past the
+/// abandon window, or there are none. A round with a fresh act (idle under
+/// the window) blocks the autopilot; a wedged one does not.
+pub fn no_healthy_working_round(rounds: &[RoundSnapshot]) -> bool {
+    !rounds.iter().any(|r| {
+        r.stage == "working"
+            && matches!(r.idle_secs, Some(idle) if idle < STALE_ROUND_ABANDON_SECS)
+    })
+}
+
 fn live_run_ids() -> std::collections::HashSet<String> {
     crate::cognition::swe_bench::in_flight_solve_runs()
         .into_iter()
@@ -1303,6 +1329,48 @@ mod tests {
         assert_eq!(rounds[1].cards[0].acts, Some(7));
         assert_eq!(rounds[2].verdict, "stalled");
         assert_eq!(rounds[2].cards[0].state, "quiet");
+    }
+
+    // what this catches: a wedged Working round (dead citizens, no task
+    // boundary) blocking the standing autopilot FOREVER — measured 2026-09-02,
+    // three rounds stuck ~18h while the claim-growth engine starved because it
+    // only fired when NO round was Working. The autopilot must dispatch over a
+    // round stale past the abandon window, but HOLD for a healthily grinding
+    // one. Regression pin for that exact bug.
+    use super::{no_healthy_working_round, RoundSnapshot, STALE_ROUND_ABANDON_SECS};
+    fn snap(stage: &str, idle: Option<u64>) -> RoundSnapshot {
+        RoundSnapshot {
+            round_id: Uuid::new_v4().to_string(),
+            benchmark: "swe-bench-verified".into(),
+            stage: stage.to_string(),
+            dispatched: 8,
+            settled: 0,
+            remaining: 8,
+            driver: "citizen".into(),
+            cards: Vec::new(),
+            verdict: String::new(),
+            idle_secs: idle,
+        }
+    }
+
+    #[test]
+    fn stale_working_round_does_not_block_the_autopilot_but_a_fresh_one_does() {
+        // No rounds → clear to dispatch.
+        assert!(no_healthy_working_round(&[]));
+        // A round wedged past the abandon window → clear (the 18h-stall bug).
+        assert!(no_healthy_working_round(&[snap(
+            "working",
+            Some(STALE_ROUND_ABANDON_SECS + 60)
+        )]));
+        // A round with a fresh act → BLOCKS (never dispatch over live work).
+        assert!(!no_healthy_working_round(&[snap("working", Some(30))]));
+        // Mixed: one fresh among stale still blocks.
+        assert!(!no_healthy_working_round(&[
+            snap("working", Some(STALE_ROUND_ABANDON_SECS + 60)),
+            snap("working", Some(30)),
+        ]));
+        // Unstarted (idle None) is not "healthy grinding" → does not block.
+        assert!(no_healthy_working_round(&[snap("working", None)]));
     }
 
     // what this catches: the round advancing only by TIMEOUT, and the loop the

--- a/core/continuum-core/src/cognition/deliberation_parse.rs
+++ b/core/continuum-core/src/cognition/deliberation_parse.rs
@@ -27,6 +27,20 @@ pub fn decision_from_response(text: &str) -> Decision {
     // text becomes a Speak decision, so every consumer of the decision gets clean
     // text. An only-`<think>` response cleans to empty → Pass (silence), matching
     // the "only thinking → don't speak" behavior.
+    // RAW-first pass check (before `clean_response`). Its speaker-label stripper
+    // (`^[A-Z][A-Za-z\s]+:\s*`) eats a LEADING "PASS: " as if it were a name — so
+    // "PASS: done" would otherwise clean to "done" and read as a Speak, losing
+    // both the pass AND its reason. A leading silence token on the RAW text is
+    // unambiguously a turn-pass (its first word IS the token), while "Verdict:
+    // PASS" does NOT lead with the token and is untouched. This is what lets a
+    // citizen conclude a held card with the natural "PASS: done" / "PASS: blocked
+    // — <why>" form the held-work burst asks for.
+    let raw_trimmed = text.trim();
+    if starts_with_silence_token(raw_trimmed) {
+        return Decision::Pass {
+            reason: pass_reason(raw_trimmed),
+        };
+    }
     let cleaned = clean_response(text);
     let trimmed = cleaned.text.trim();
     probe_label_stripped_into_silence(text, trimmed);
@@ -36,11 +50,42 @@ pub fn decision_from_response(text: &str) -> Decision {
         || declares_silence_token(trimmed)
         || is_narrated_pass(trimmed)
     {
-        Decision::Pass
+        // A pass is accountable: keep the mind's OWN words for WHY it passed, so a
+        // downstream reader (the benchmark held-work edge; any gap detector) can
+        // tell a gradeable *done* from a *blocker* from a *nothing*. A bare `PASS`
+        // token or an empty generation carries no reason (`None`); a narrated pass
+        // ("done — patch ready", "blocked: …", "nothing to add") keeps the
+        // narration with any leading silence token stripped.
+        Decision::Pass {
+            reason: pass_reason(trimmed),
+        }
     } else {
         Decision::Speak {
             text: trimmed.to_string(),
         }
+    }
+}
+
+/// The mind's own words for why it passed, extracted from the cleaned generation:
+/// the narration with a leading silence token (and its trailing `:`/`-`/`.`
+/// punctuation) removed. Empty or bare-token generations carry no reason.
+fn pass_reason(trimmed: &str) -> Option<String> {
+    if trimmed.is_empty() || looks_like_silence_token(trimmed) {
+        return None; // bare PASS / empty → anonymous silence, no stated reason
+    }
+    // Strip a leading silence token so "PASS: done" yields "done", not "PASS: done".
+    let upper = trimmed.to_uppercase();
+    let body = if upper.starts_with(SILENCE_TOKEN) {
+        trimmed[SILENCE_TOKEN.len()..]
+            .trim_start_matches([':', '-', '.', ' ', '—'])
+            .trim()
+    } else {
+        trimmed
+    };
+    if body.is_empty() {
+        None
+    } else {
+        Some(body.to_string())
     }
 }
 
@@ -252,23 +297,55 @@ mod tests {
     // contract, reused from prompt_assembly.
     #[test]
     fn decision_parsing_maps_pass_and_speak() {
-        assert_eq!(decision_from_response("PASS"), Decision::Pass);
-        assert_eq!(decision_from_response("  PASS.  "), Decision::Pass);
-        assert_eq!(decision_from_response(""), Decision::Pass);
-        // Small models leak trailing prose after PASS — must still be silence,
-        // not a message that literally says "PASS ...".
-        assert_eq!(
+        // A bare token / empty generation → anonymous silence, no reason.
+        assert_eq!(decision_from_response("PASS"), Decision::pass());
+        assert_eq!(decision_from_response("  PASS.  "), Decision::pass());
+        assert_eq!(decision_from_response(""), Decision::pass());
+        // Small models leak trailing prose after PASS — still silence, and now
+        // that trailing prose is CAPTURED as the pass reason (a pass is
+        // accountable, not anonymous), with the leading token stripped.
+        assert!(matches!(
             decision_from_response("PASS — nothing to add here"),
-            Decision::Pass
-        );
-        assert_eq!(
+            Decision::Pass { reason: Some(r) } if r == "nothing to add here"
+        ));
+        assert!(matches!(
             decision_from_response("PASS.\nI'll stay quiet"),
-            Decision::Pass
-        );
+            Decision::Pass { reason: Some(r) } if r == "I'll stay quiet"
+        ));
         match decision_from_response("Let's ship the deploy fix now.") {
             Decision::Speak { text } => assert!(text.contains("ship the deploy")),
             other => panic!("expected Speak, got {other:?}"),
         }
+    }
+
+    // what this catches: the pass-reason capture that makes the held-work settle
+    // edge able to tell a gradeable 'done' from a 'blocked' from a 'nothing'. A
+    // regression that dropped the reason would send every reasoned pass back to
+    // anonymous silence and the edge could never conclude a card deterministically.
+    #[test]
+    fn a_reasoned_pass_keeps_her_words() {
+        // The natural conclusion form the held-work burst asks for. `clean_response`
+        // would strip a leading "PASS: " as a speaker label, so this pins the
+        // raw-first pass check that keeps it a reasoned pass, not a Speak "done".
+        assert!(matches!(
+            decision_from_response("PASS: done — patch ready"),
+            Decision::Pass { reason: Some(r) } if r == "done — patch ready"
+        ));
+        assert!(matches!(
+            decision_from_response("PASS: blocked - the fixture is missing"),
+            Decision::Pass { reason: Some(r) } if r.contains("blocked")
+        ));
+        // A recognized narrated closure still passes and keeps her words.
+        assert!(matches!(
+            decision_from_response("I'll pass my turn — nothing to add"),
+            Decision::Pass { reason: Some(r) } if r.contains("nothing")
+        ));
+        // "Verdict: PASS ..." is an ANSWER of PASS, NOT a turn-pass — the raw
+        // check must not steal it (the #349 minefield stays intact).
+        assert!(!matches!(
+            decision_from_response("Verdict: the guard holds"),
+            Decision::Pass { .. }
+        ));
     }
 
     // what this catches: qwen3.5 chain-of-thought tags leaking into the spoken
@@ -294,7 +371,7 @@ mod tests {
         // An ONLY-thinking response (no answer) cleans to empty → silence.
         assert_eq!(
             decision_from_response("<think>I won't answer this</think>"),
-            Decision::Pass
+            Decision::pass()
         );
     }
 
@@ -348,9 +425,8 @@ mod tests {
              please let me know! Otherwise, PASS.",
             "I've been repeating myself without adding value. Otherwise, PASS",
         ] {
-            assert_eq!(
-                decision_from_response(live),
-                Decision::Pass,
+            assert!(
+                matches!(decision_from_response(live), Decision::Pass { .. }),
                 "must silence: {live:?}"
             );
         }
@@ -439,7 +515,10 @@ mod tests {
             "To avoid further repetition, I'll continue to pass unless there's something \
              specific you'd like me to address or if new information emerges.",
         ] {
-            assert_eq!(decision_from_response(live), Decision::Pass, "must silence: {live:?}");
+            assert!(
+                matches!(decision_from_response(live), Decision::Pass { .. }),
+                "must silence: {live:?}"
+            );
         }
         // Substance stays Speak: transitive pass, declining work, peer advice,
         // fenced code, and long real answers that end in a pass phrase.
@@ -471,9 +550,8 @@ mod tests {
              have any modifications in mind, please let me know! Otherwise, I'll remain \
              silent (PASS) for now.",
         ] {
-            assert_eq!(
-                decision_from_response(drift),
-                Decision::Pass,
+            assert!(
+                matches!(decision_from_response(drift), Decision::Pass { .. }),
                 "must silence: {drift:?}"
             );
         }
@@ -493,7 +571,10 @@ mod tests {
             over_old_cap.len() > 500,
             "regression fixture must exceed the old cap"
         );
-        assert_eq!(decision_from_response(over_old_cap), Decision::Pass);
+        assert!(matches!(
+            decision_from_response(over_old_cap),
+            Decision::Pass { .. }
+        ));
         // Two-tier regression (live 2026-08-01, the cap arms race's second
         // escapee): VERBATIM 714-char turn — strong closure mid-message,
         // wake-briefing parrot appended after it, 14 chars over the 700 cap.
@@ -514,7 +595,10 @@ mod tests {
             over_new_cap.len() > 700,
             "regression fixture must exceed the tier-2 cap"
         );
-        assert_eq!(decision_from_response(over_new_cap), Decision::Pass);
+        assert!(matches!(
+            decision_from_response(over_new_cap),
+            Decision::Pass { .. }
+        ));
         // Length fail-open: a long substantive message ending in a pass phrase
         // keeps speaking.
         let long = format!(

--- a/core/continuum-core/src/cognition/dream_consolidation.rs
+++ b/core/continuum-core/src/cognition/dream_consolidation.rs
@@ -829,7 +829,7 @@ impl DreamConsolidationRegion {
                     consolidated,
                     reviewed,
                 ) => {}
-                _ = crate::cognition::activity_gate::wait_for_activity() => {
+                _ = crate::cognition::activity_gate::wait_for_engagement_of(persona_id) => {
                     crate::probe!(
                         class = "dream.paged_out",
                         persona = %persona_id,
@@ -1034,16 +1034,21 @@ async fn dream_pass(
     // subsumes the old hold-park AND adds what it never had: in-flight turns and
     // directed-conversation linger. The dream state does not ARISE while the
     // organism is engaged; nothing is minted, nothing queues, nothing holds.
-    if crate::cognition::activity_gate::current().state
-        != crate::cognition::activity_gate::ActivityState::Bored
     {
-        crate::probe!(
-            class = "dream.awaiting_boredom",
-            persona = %persona_id,
-            "dream pass parked on the activity gate — arises only in sustained idle"
-        );
+        let a = crate::cognition::activity_gate::persona_activity(persona_id);
+        if !crate::cognition::activity_gate::persona_bored(
+            a,
+            crate::inference::measured_hold::subscribe().borrow().is_some(),
+            crate::persona::trace::now_ms(),
+        ) {
+            crate::probe!(
+                class = "dream.awaiting_boredom",
+                persona = %persona_id,
+                "dream pass parked on HER activity gate — arises only in her sustained idle"
+            );
+        }
     }
-    crate::cognition::activity_gate::wait_for_boredom().await;
+    crate::cognition::activity_gate::wait_for_boredom_of(persona_id).await;
     // #175 budget-at-assembly: derive the observation budget from the LIVE served
     // per-slot window (the single source of truth, same the deliberation clamp reads)
     // so a dream cluster is composed WITHIN the slot and can never overflow it →

--- a/core/continuum-core/src/cognition/eval.rs
+++ b/core/continuum-core/src/cognition/eval.rs
@@ -4751,7 +4751,7 @@ async fn run_pass(
         // not a crib. [[benchmarks-are-proctored-exams-of-the-natural-living-persona]]
         if matches!(
             settled.decision,
-            crate::cognition::workspace::Decision::Pass
+            crate::cognition::workspace::Decision::Pass { .. }
         ) {
             crate::probe!(
                 class = "eval.task.declined_redrive",

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -807,7 +807,7 @@ impl LlmDeliberationFaculty {
             "draft reproduced a perception fact she was handed — settling to silence instead \
              of speaking the prompt back into the room (#158)"
         );
-        Decision::Pass
+        Decision::pass()
     }
 
     /// She called the yield verb — settle the turn as the silence it names.
@@ -846,7 +846,7 @@ impl LlmDeliberationFaculty {
             "she yielded the turn through the structured verb — silent Pass, no room message"
         );
         Some(Contribution::verdict(
-            Decision::Pass,
+            Decision::pass(),
             0.9,
             format!("{} yielded the turn (yield_turn)", self.persona_name),
         ))
@@ -859,7 +859,13 @@ impl LlmDeliberationFaculty {
     fn verdict(&self, resp: &TextGenerationResponse, ws: &Workspace) -> Contribution {
         let decision = self.silence_a_parroted_draft(decision_from_response(&resp.text), ws);
         let (salience, reasoning) = match &decision {
-            Decision::Pass => (0.5, format!("{} chose silence (PASS)", self.persona_name)),
+            Decision::Pass { reason } => (
+                0.5,
+                match reason {
+                    Some(r) => format!("{} passed: {r}", self.persona_name),
+                    None => format!("{} chose silence (PASS)", self.persona_name),
+                },
+            ),
             _ => (
                 0.85,
                 format!(
@@ -5349,7 +5355,7 @@ mod tests {
                 .contribute(&Workspace::new("anything"))
                 .await
                 .expect("verdict");
-            assert_eq!(c.decision, Some(Decision::Pass));
+            assert_eq!(c.decision, Some(Decision::pass()));
         }
     } // mod verdicts
 }

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -766,7 +766,7 @@ impl LlmDeliberationFaculty {
             0.9,
             format!("{} chose to act", self.persona_name),
         )
-        .with_metrics(metrics_from(resp))
+        .with_metrics(metrics_from(&self.persona_name, resp))
         // #210: carry the verbatim generation so the glass box can attribute a fumbled
         // tool envelope to the model, not the parser. The Act's `intent` is only the
         // model's `<think>` reasoning; the raw text is the actual emitted call bytes.
@@ -875,7 +875,7 @@ impl LlmDeliberationFaculty {
             ),
         };
         Contribution::verdict(decision, salience, reasoning)
-            .with_metrics(metrics_from(resp))
+            .with_metrics(metrics_from(&self.persona_name, resp))
             // #210: for a Speak, the raw text IS the artifact (the `<<!DOCTYPE` HTML she
             // wrote to the room / a file); carrying it verbatim lets the glass box show a
             // leading-char fumble is the model's, distinct from the parsed decision.
@@ -2879,7 +2879,7 @@ fn segment_map(system: &str, messages: &[ChatMessage]) -> Vec<(&'static str, u32
 /// the same path as the decision, and the settle loop folds it into the per-task
 /// total. Token counts are 0 when the gateway omitted `usage` (older endpoints);
 /// `latency_ms` is always present (the adapter times every request).
-fn metrics_from(resp: &TextGenerationResponse) -> crate::cognition::workspace::TurnMetrics {
+fn metrics_from(persona: &str, resp: &TextGenerationResponse) -> crate::cognition::workspace::TurnMetrics {
     // The lane's PREFILL-vs-DECODE split (llama-server `timings`), when present:
     // cache_n/prompt_n is the KV-cache hit/miss, prompt_ms/predicted_ms the
     // wall-clock split that lets the harness see where Metal time actually goes.
@@ -2918,6 +2918,7 @@ fn metrics_from(resp: &TextGenerationResponse) -> crate::cognition::workspace::T
     if t.is_some() {
         crate::probe!(
             class = "delib.generate.cache",
+            persona = %persona,
             cached_tokens = m.cached_tokens,
             prefill_tokens = m.prefill_tokens,
             // The ratio the humans and the citizens both read. 1.0 = fully warm prefix;

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -2448,6 +2448,9 @@ impl Faculty for LlmDeliberationFaculty {
             let _lane =
                 crate::cognition::resource_admission::acquire_serving_lane(ws.directed_at_self)
                     .await;
+            // HER task-positive system is engaged from here: the per-citizen boredom gate
+            // (dreams) reads this stamp, never a room wake.
+            crate::cognition::activity_gate::persona_engaged(self.persona_id);
             crate::probe!(
                 class = "delib.gate.lane_acquired",
                 persona = %self.persona_name,

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -76,6 +76,7 @@ pub mod llm_deliberation_faculty;
 pub mod memory_consolidation_region;
 pub mod model_resolver;
 pub mod parroted_perception;
+pub mod pass_intent;
 pub mod perception_facts;
 pub mod persona_tools;
 pub mod persona_workspace;

--- a/core/continuum-core/src/cognition/pass_intent.rs
+++ b/core/continuum-core/src/cognition/pass_intent.rs
@@ -1,0 +1,111 @@
+//! Interpret the REASON a mind gave for passing a turn.
+//!
+//! A pass is an accountable decision, not anonymous silence
+//! ([[a-citizen-saying-i-have-nothing-to-contribute-is-a-substrate-gap-report]]).
+//! `Decision::Pass` carries the mind's own words (captured at the one text→decision
+//! seam, `deliberation_parse::decision_from_response`); this module maps those words
+//! to a small, deterministic INTENT the substrate can act on at a turn boundary.
+//!
+//! It is recipe-general on purpose: the held-work settle edge uses it to conclude a
+//! card the moment she passes it "done", but the card may belong to ANY recipe — a
+//! benchmark solve, a code task, a Slack/AWS/finance pipeline. The classifier reads
+//! intent; it never steers ([[no-hardcoded-heuristics-to-steer-cognition]]) — the
+//! mind chose the pass and chose the reason, and the conservative default (`Unclear`
+//! concludes nothing) means an illegible reason never forces a completion.
+
+/// What a pass MEANS, as far as the substrate can act on it deterministically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PassIntent {
+    /// She reports the work complete — a held card may conclude (its owning
+    /// recipe then scores the outcome; an empty deliverable grades an honest
+    /// fail, never a substrate second-guess).
+    Done,
+    /// She is blocked — the card stays hers and the blocker is a gap signal.
+    Blocked,
+    /// She has nothing to contribute — the card stays; a substrate-gap signal.
+    Nothing,
+    /// No stated reason, or intent not legible — honor the pass, conclude
+    /// nothing. The safe default: an ambiguous pass never concludes a card.
+    Unclear,
+}
+
+/// Map a pass reason to its [`PassIntent`]. Deterministic and pure.
+///
+/// The burst asks for a one-word reason (done / blocked / nothing), so the FIRST
+/// word decides; a `blocked: <why>` prefix is honored. Blocked takes precedence
+/// over done — a mind that says "done investigating but blocked on the fixture"
+/// is blocked, and a blocked card must never conclude. Anything not clearly one
+/// of the three is `Unclear`.
+pub fn classify_pass(reason: Option<&str>) -> PassIntent {
+    let Some(raw) = reason else {
+        return PassIntent::Unclear; // a bare PASS token carries no reason
+    };
+    let lower = raw.to_lowercase();
+    // Blocked FIRST — never conclude a card she says she is stuck on, even if the
+    // same sentence mentions progress.
+    const BLOCKED: &[&str] = &[
+        "block", "stuck", "can't", "cannot", "unable", "need help", "waiting on",
+    ];
+    if BLOCKED.iter().any(|k| lower.contains(k)) {
+        return PassIntent::Blocked;
+    }
+    const NOTHING: &[&str] = &[
+        "nothing to", "nothing else", "nothing further", "no more", "no changes",
+        "nothing new",
+    ];
+    if NOTHING.iter().any(|k| lower.contains(k)) {
+        return PassIntent::Nothing;
+    }
+    // Done is the one that CONCLUDES a card, so it is deliberately specific — a
+    // clear completion word, not a vague positive.
+    const DONE: &[&str] = &[
+        "done", "complete", "finished", "ready", "fixed", "resolved", "all set",
+    ];
+    // Prefer the first token (the burst asks for a one-word reason), then fall
+    // back to a contains-scan for a narrated completion ("the patch is ready").
+    let first = lower
+        .split(|c: char| !c.is_alphanumeric())
+        .find(|w| !w.is_empty())
+        .unwrap_or("");
+    if DONE.contains(&first) || DONE.iter().any(|k| lower.contains(k)) {
+        return PassIntent::Done;
+    }
+    PassIntent::Unclear
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the pass-reason → intent mapping the held-work settle
+    // edge acts on. A regression that mis-reads "blocked" as done would conclude
+    // (and grade) a card she was stuck on; one that mis-reads a bare pass as done
+    // would auto-conclude every silent turn.
+    #[test]
+    fn classifies_the_four_intents_conservatively() {
+        // bare pass → never concludes
+        assert_eq!(classify_pass(None), PassIntent::Unclear);
+        assert_eq!(classify_pass(Some("")), PassIntent::Unclear);
+
+        // clear done (one-word and narrated)
+        assert_eq!(classify_pass(Some("done")), PassIntent::Done);
+        assert_eq!(classify_pass(Some("done — patch ready")), PassIntent::Done);
+        assert_eq!(classify_pass(Some("the fix is complete")), PassIntent::Done);
+        assert_eq!(classify_pass(Some("resolved")), PassIntent::Done);
+
+        // blocked takes precedence over any progress language
+        assert_eq!(classify_pass(Some("blocked: fixture missing")), PassIntent::Blocked);
+        assert_eq!(
+            classify_pass(Some("done investigating but stuck on the import")),
+            PassIntent::Blocked
+        );
+        assert_eq!(classify_pass(Some("cannot reach the repo")), PassIntent::Blocked);
+
+        // nothing-to-contribute → gap signal, not a completion
+        assert_eq!(classify_pass(Some("nothing to add")), PassIntent::Nothing);
+        assert_eq!(classify_pass(Some("no more changes needed here")), PassIntent::Nothing);
+
+        // illegible → conclude nothing (the safe default)
+        assert_eq!(classify_pass(Some("hmm let me think")), PassIntent::Unclear);
+    }
+}

--- a/core/continuum-core/src/cognition/pass_intent.rs
+++ b/core/continuum-core/src/cognition/pass_intent.rs
@@ -73,6 +73,44 @@ pub fn classify_pass(reason: Option<&str>) -> PassIntent {
     PassIntent::Unclear
 }
 
+/// What the held-work settle edge does with a reasoned pass — the DECISION,
+/// separated from the side-effecting execution (the card transition, the probes)
+/// so it is exhaustively unit-testable. Recipe-general: `Close` names a card to
+/// conclude; the recipe that owns it reacts to the transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConcludeAction {
+    /// Exactly one held card + a `done` intent → conclude that card.
+    Close(uuid::Uuid),
+    /// `done` but several held cards → which is done is ambiguous; conclude none.
+    Ambiguous,
+    /// She is blocked → keep the card(s); a candidate substrate-gap report.
+    Blocked,
+    /// Nothing to contribute → keep; a substrate-gap signal.
+    Nothing,
+    /// No legible completion intent (or no held cards) → honor the pass, conclude
+    /// nothing.
+    Hold,
+}
+
+/// Decide what a reasoned pass concludes, given the cards she holds and the
+/// intent parsed from her reason. Pure — the edge executes the returned action.
+///
+/// Only an UNAMBIGUOUS `done` (exactly one held card) concludes a card: the
+/// substrate never guesses WHICH of several cards she finished, and never
+/// concludes on a blocked/nothing/illegible pass.
+pub fn conclude_from_pass(held: &[uuid::Uuid], intent: PassIntent) -> ConcludeAction {
+    match intent {
+        PassIntent::Done => match held {
+            [one] => ConcludeAction::Close(*one),
+            [] => ConcludeAction::Hold, // "done" but nothing held — nothing to conclude
+            _ => ConcludeAction::Ambiguous,
+        },
+        PassIntent::Blocked => ConcludeAction::Blocked,
+        PassIntent::Nothing => ConcludeAction::Nothing,
+        PassIntent::Unclear => ConcludeAction::Hold,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -107,5 +145,53 @@ mod tests {
 
         // illegible → conclude nothing (the safe default)
         assert_eq!(classify_pass(Some("hmm let me think")), PassIntent::Unclear);
+    }
+
+    // what this catches: the completion-edge DECISION the held-work turn executes.
+    // A regression that concluded a card on a blocked/nothing pass, or guessed
+    // WHICH of several cards a lone "done" finished, would grade work she never
+    // declared complete — or grade the wrong card.
+    #[test]
+    fn conclude_only_on_an_unambiguous_done() {
+        let a = uuid::Uuid::from_u128(1);
+        let b = uuid::Uuid::from_u128(2);
+
+        // exactly one held card + done → conclude THAT card
+        assert_eq!(
+            conclude_from_pass(&[a], PassIntent::Done),
+            ConcludeAction::Close(a)
+        );
+        // done + several held → never guess which
+        assert_eq!(
+            conclude_from_pass(&[a, b], PassIntent::Done),
+            ConcludeAction::Ambiguous
+        );
+        // done but nothing held → nothing to conclude
+        assert_eq!(conclude_from_pass(&[], PassIntent::Done), ConcludeAction::Hold);
+        // blocked / nothing / unclear never conclude a card
+        assert_eq!(
+            conclude_from_pass(&[a], PassIntent::Blocked),
+            ConcludeAction::Blocked
+        );
+        assert_eq!(
+            conclude_from_pass(&[a], PassIntent::Nothing),
+            ConcludeAction::Nothing
+        );
+        assert_eq!(
+            conclude_from_pass(&[a], PassIntent::Unclear),
+            ConcludeAction::Hold
+        );
+    }
+
+    // what this catches: the end-to-end reason→intent→action path the edge runs,
+    // pinned on the exact strings the burst asks for (PASS: done|blocked|nothing).
+    #[test]
+    fn the_burst_reason_forms_drive_the_right_action() {
+        let card = uuid::Uuid::from_u128(9);
+        let act = |r: &str| conclude_from_pass(&[card], classify_pass(Some(r)));
+        assert_eq!(act("done"), ConcludeAction::Close(card));
+        assert_eq!(act("done — patch ready"), ConcludeAction::Close(card));
+        assert_eq!(act("blocked — the fixture is missing"), ConcludeAction::Blocked);
+        assert_eq!(act("nothing to add"), ConcludeAction::Nothing);
     }
 }

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -1599,7 +1599,7 @@ mod tests {
             Some(Decision::Act { calls, intent }) => {
                 eprintln!("Ivar ACTS ({} call(s)) — intent: {intent}", calls.len())
             }
-            Some(Decision::Pass) | None => eprintln!("Ivar chose silence (PASS)."),
+            Some(Decision::Pass { .. }) | None => eprintln!("Ivar chose silence (PASS)."),
         }
         eprintln!("=================================================\n");
 

--- a/core/continuum-core/src/cognition/rag_source_faculty.rs
+++ b/core/continuum-core/src/cognition/rag_source_faculty.rs
@@ -508,7 +508,7 @@ mod tests {
                         "conditioned on the bridged doctrine grounding",
                     )),
                     None => Some(Contribution::verdict(
-                        Decision::Pass,
+                        Decision::pass(),
                         0.4,
                         "no doctrine in the broadcast",
                     )),

--- a/core/continuum-core/src/cognition/recall_faculty.rs
+++ b/core/continuum-core/src/cognition/recall_faculty.rs
@@ -1560,7 +1560,7 @@ mod tests {
                     ))
                 }
                 None => Some(Contribution::verdict(
-                    Decision::Pass,
+                    Decision::pass(),
                     0.4,
                     "no memory surfaced — nothing to ground a reply on",
                 )),

--- a/core/continuum-core/src/cognition/should_respond_module.rs
+++ b/core/continuum-core/src/cognition/should_respond_module.rs
@@ -104,7 +104,7 @@ impl ServiceModule for ShouldRespondModule {
                         crate::cognition::workspace::TurnFraming::ambient(),
                     )
                     .await;
-                let decision = workspace.decision().cloned().unwrap_or(Decision::Pass);
+                let decision = workspace.decision().cloned().unwrap_or_else(Decision::pass);
                 CommandResult::json(&decision)
             }
             other => Err(format!("unknown command: {other}")),

--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -197,6 +197,9 @@ pub struct SweVerdict {
     /// test_arguments and test_unit" is what a human reviewer would say (Joel,
     /// 2026-08-08: "you or any human could tell him what's wrong — or the grader").
     /// This is what the experience stream and the room verdict carry forward.
+    /// Epoch-ms when this verdict was recorded — the experiment's settle clock.
+    #[serde(default)]
+    pub graded_at_ms: u64,
     #[serde(default)]
     pub failed_tests: Vec<String>,
     /// The failing FAIL_TO_PASS run's OUTPUT tail (capped) — the assertion diff a
@@ -534,6 +537,7 @@ pub fn record_verdict(verdict: &SweVerdict, is_gold: bool) -> Result<Option<Path
     // identical banked patch moved p2p 0/40 -> 40/40 (2026-08-28).
     let mut verdict = verdict.clone();
     verdict.harness_build = env!("CONTINUUM_BUILD_GIT_SHA").to_string();
+    verdict.graded_at_ms = crate::persona::trace::now_ms();
     verdict.served_model = crate::inference::llama_server::current_serving()
         .active_model
         .unwrap_or_default(); // unwrap_or: nothing serving at grade time = honest empty, never a guess
@@ -3510,6 +3514,7 @@ mod tests {
         );
         let stamped = serde_json::to_string(&SweVerdict {
             harness_build: env!("CONTINUUM_BUILD_GIT_SHA").to_string(),
+            graded_at_ms: 0,
             ..v.clone()
         })
         .unwrap();

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -118,7 +118,25 @@ pub enum Decision {
     /// Nothing worth adding this turn (the persona's own judgment, not a gate).
     /// Together with `Speak`/`RaiseUnprompted`, this is how the organism SETTLES:
     /// the absence of an `Act` bid is the mind's judgment that the work is done.
-    Pass,
+    ///
+    /// `reason` is the mind's OWN words for why it passed, captured verbatim at
+    /// the single text→decision seam (`deliberation_parse::decision_from_response`)
+    /// when she narrates her pass ("done — patch ready", "blocked: the fixture is
+    /// missing", "nothing to add") — `None` for a bare `PASS` token. A pass is an
+    /// accountable decision, not anonymous silence: the benchmark held-work edge
+    /// reads this to tell a gradeable *done* from a *blocker* from a substrate-gap
+    /// *nothing* ([[a-citizen-saying-i-have-nothing-to-contribute-is-a-substrate-gap-report]]),
+    /// and any consumer can surface WHY a turn produced no utterance.
+    Pass { reason: Option<String> },
+}
+
+impl Decision {
+    /// A bare pass with no stated reason — the anonymous silence a plain `PASS`
+    /// token or an empty generation resolves to. Convenience so the common
+    /// construction stays terse and every reasoned pass is visibly the exception.
+    pub fn pass() -> Self {
+        Decision::Pass { reason: None }
+    }
 }
 
 /// The cost of producing ONE deliberation verdict: how long the model took and
@@ -388,7 +406,7 @@ impl Contribution {
             // The mind's narration of WHY it's acting — surfaced/audited like any
             // contribution content; the calls themselves live on the decision.
             Decision::Act { intent, .. } => intent.clone(),
-            Decision::Pass => String::new(),
+            Decision::Pass { reason } => reason.clone().unwrap_or_default(),
         };
         Self {
             faculty: FacultyId::Deliberation,
@@ -2380,7 +2398,7 @@ mod tests {
                     "conditioned the reply on the recalled context",
                 )),
                 None => Some(Contribution::verdict(
-                    Decision::Pass,
+                    Decision::pass(),
                     0.5,
                     "blind — no context in the broadcast",
                 )),
@@ -2793,7 +2811,7 @@ mod tests {
         let faculties: Vec<Arc<dyn Faculty>> = vec![
             Arc::new(AbstainFaculty(FacultyId::Recall)),
             Arc::new(FixedFaculty(Contribution::verdict(
-                Decision::Pass,
+                Decision::pass(),
                 0.6,
                 "nothing worth adding",
             ))),
@@ -2804,7 +2822,7 @@ mod tests {
             1,
             "the abstaining faculty added nothing"
         );
-        assert_eq!(ws.decision(), Some(&Decision::Pass));
+        assert_eq!(ws.decision(), Some(&Decision::pass()));
     }
 
     // what this catches: a FAILED model call (a deliberation FAULT) is surfaced by
@@ -3004,7 +3022,7 @@ mod tests {
                     !ws.broadcast.is_empty(),
                     "deliberation must only fire after phase 1 assembled context"
                 );
-                Some(Contribution::verdict(Decision::Pass, 0.5, "noted"))
+                Some(Contribution::verdict(Decision::pass(), 0.5, "noted"))
             }
         }
         let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1754,7 +1754,7 @@ impl ActionCommand for BenchmarkDispatch {
                 .collect::<Result<_, CommandError>>()?
         };
 
-        let requested = p.assignees.clone().unwrap_or_default();
+        let requested = p.assignees.clone().unwrap_or_default();  // unwrap_or: unreadable = empty, the report shows the tracker's view
         if requested.iter().any(|a| a.trim().is_empty()) {
             return Err(CommandError::Invalid(
                 "assignees contains an empty name — every kickoff must address a real citizen"
@@ -1898,13 +1898,13 @@ impl ActionCommand for BenchmarkDispatch {
             "team".to_string(),
             serde_json::json!(roster.iter().map(|(who, _)| who).collect::<Vec<_>>()),
         );
-        run_params.insert("driver".to_string(), serde_json::json!(p.drive.unwrap_or_default()));
+        run_params.insert("driver".to_string(), serde_json::json!(p.drive.unwrap_or_default()));  // unwrap_or: no driver named = the recipe default (citizen)
         if let Some(doctrine) = &p.doctrine {
             run_params.insert("doctrine".to_string(), serde_json::json!(doctrine));
         }
         run_params.insert(
             "review_gate".to_string(),
-            serde_json::json!(p.review_gate.unwrap_or(false)),
+            serde_json::json!(p.review_gate.unwrap_or(false)),  // unwrap_or: gate not named = off, the control arm
         );
         let room = crate::modules::activity::spawn_activity_room(
             &airc,
@@ -2119,10 +2119,10 @@ impl ActionCommand for BenchmarkDispatch {
         // asks the round who drives. Registering after the loop (as this did) left that
         // window answering with the default, which would silently fire the detached solver
         // on the first card of a citizen-driven round.
-        let driver = p.drive.unwrap_or_default();
+        let driver = p.drive.unwrap_or_default();  // unwrap_or: unreadable = empty, the report shows the tracker's view
         crate::cognition::bench_round::open_round(room.room_id.as_uuid(), spec.name, driver);
         crate::cognition::bench_round::set_run_room_name(room.room_id.as_uuid(), &room_name);
-        if p.review_gate.unwrap_or(false) {
+        if p.review_gate.unwrap_or(false) {  // unwrap_or: gate not named = off, the control arm
             crate::cognition::bench_round::set_review_gate(room.room_id.as_uuid(), true);
         }
         // The round REMEMBERS its team: driver edges (settle-advance, non-settling
@@ -4597,7 +4597,7 @@ impl BenchmarkPlatformFingerprint {
                     .take(8)
                     .collect()
             })
-            .unwrap_or_default();
+            .unwrap_or_default();  // unwrap_or: unreadable = empty, the report shows the tracker's view
         Self {
             machine_class,
             os: std::env::consts::OS.into(),
@@ -5266,7 +5266,7 @@ impl ActionCommand for BenchmarkRounds {
                 .unwrap_or_default()
         })
         .await
-        .unwrap_or_default();
+        .unwrap_or_default();  // unwrap_or: unreadable = empty, the report shows the tracker's view
         let facts: Vec<crate::cognition::bench_round::CardRunFacts> =
             runs.iter().map(card_run_facts).collect();
         crate::cognition::bench_round::enrich_rounds(
@@ -5334,7 +5334,7 @@ pub(crate) async fn enrich_rounds_from_board_and_verdicts(
             card.board_state = serde_json::to_value(bc.state)
                 .ok()
                 .and_then(|v| v.as_str().map(str::to_string))
-                .unwrap_or_default();
+                .unwrap_or_default();  // unwrap_or: unreadable = empty, the report shows the tracker's view
             card.owner = bc
                 .owner
                 .map(|o| {
@@ -5342,9 +5342,9 @@ pub(crate) async fn enrich_rounds_from_board_and_verdicts(
                         .as_ref()
                         .and_then(|reg| reg.get(o.as_uuid()))
                         .map(|rt| rt.agent_name().to_string())
-                        .unwrap_or_else(|| o.as_uuid().to_string()[..8].to_string())
+                        .unwrap_or_else(|| o.as_uuid().to_string()[..8].to_string())  // unwrap_or: no live runtime for the owner = her short id, still addressable
                 })
-                .unwrap_or_default();
+                .unwrap_or_default();  // unwrap_or: unreadable = empty, the report shows the tracker's view
             card.created_at_ms = Some(bc.created_at_ms);
             card.updated_at_ms = Some(bc.updated_at_ms);
         }

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -2266,32 +2266,14 @@ impl ActionCommand for BenchmarkDispatch {
             // imperative in its OWN message block is what actually starts work (measured
             // 2026-08-07: coalesced mid-burst it was ignored). airc.say is one event = one
             // block, so the structural condition holds by construction.
-            {
-                let kickoff = if driver == crate::cognition::bench_round::WorkDriver::Citizen {
-                    // OPEN card, room-addressed: nobody is "the" assignee — whoever is
-                    // free pulls it (the substrate claims it for an idle resident), and
-                    // the claim stages the work in HER workspace.
-                    match &pc.work {
-                        CardWork::Gym { solution_file } => format!(
-                            "card {short} is OPEN on this board — whoever is free pulls it \
-                             (the substrate claims it for you when you are idle, or \
-                             claim_task {short}). Read its body, write your solution to \
-                             `{solution_file}` in your workspace, then mark it done \
-                             (work/state {short} done). Your artifact is graded against \
-                             held-out tests."
-                        ),
-                        CardWork::Swe { instance } => format!(
-                            "card {short} is a REAL {} issue (SWE-bench, a full project) and \
-                             is OPEN on this board — whoever is free pulls it. Claiming stages \
-                             the repo in YOUR workspace at `swe/{}/`; fix the bug there (do \
-                             not edit the tests) — your diff is graded against the repo's \
-                             held-out tests. When your fix is ready, YOU close it: `work/state \
-                             {short} done` — that is what fires your grade.",
-                            instance.repo, instance.instance_id
-                        ),
-                    }
-                } else {
-                match &pc.work {
+            // Per-card, ADDRESSED kickoffs are a detached-solve round's activation path
+            // (the assignee is named, her solve is already running). A citizen-driven
+            // round gets ONE room-addressed kickoff after the loop instead — twelve
+            // per-card kickoffs cost every resident twelve inbound turns of near-
+            // duplicate noise per dispatch (measured 2026-09-03: `deferred_loop_filler`
+            // ×9 per citizen), for a deck the substrate pulls from deterministically.
+            if driver == crate::cognition::bench_round::WorkDriver::DetachedSolve {
+                let kickoff = match &pc.work {
                     CardWork::Gym { solution_file } if pre_claimed => format!(
                         "@{who} (to you): card {short} is CLAIMED FOR YOU on this board — \
                          no claim step needed. Read its body, write your solution to \
@@ -2334,7 +2316,6 @@ impl ActionCommand for BenchmarkDispatch {
                             instance.repo, instance.instance_id
                         )
                     }
-                }
                 };
                 // AUTHOR IT AS SOMEONE ELSE. A citizen's inbound stream skips messages
                 // she is recorded as having said (correct — nobody answers their own
@@ -2441,6 +2422,41 @@ impl ActionCommand for BenchmarkDispatch {
         // `work.card.state_changed` subscriber settles cards as they reach terminal
         // states and announces the END — instead of the round's fate being probe
         // archaeology ("random and directed by agent, not an ecosystem", Joel 8/16).
+        // ONE kickoff for the whole deck of a citizen-driven round, addressed to the
+        // ROOM: the deck is shared, the substrate pulls for whoever is idle, and the
+        // claim stages the work — so the message is an announcement, not an order.
+        if driver == crate::cognition::bench_round::WorkDriver::Citizen && !card_ids.is_empty() {
+            let text = format!(
+                "{} cards are OPEN on this board ({}): {}. Whoever is free pulls one — the \
+                 substrate claims it for you when you are idle (or claim_task <id>), and the \
+                 claim stages the work in YOUR workspace. Work it there; when your fix is \
+                 verified green say `work/state <id> done` — that is what fires your grade. \
+                 One card at a time; talk here when you are stuck or when you can review a \
+                 teammate's diff.",
+                card_ids.len(),
+                spec.name,
+                card_ids.join(", ")
+            );
+            match self.registry.any_live_citizen() {
+                Some(voice_rt) => {
+                    if let Err(e) = voice_rt.join_room(&room_name).await {
+                        kickoff_errors.push(format!("deck kickoff: voice join: {e}"));
+                    } else {
+                        match crate::persona::airc_citizen::publish_text_in_room(
+                            voice_rt.airc(),
+                            room.room_id.as_uuid(),
+                            &text,
+                        )
+                        .await
+                        {
+                            Ok(_) => kickoffs += 1,
+                            Err(e) => kickoff_errors.push(format!("deck kickoff: {e}")),
+                        }
+                    }
+                }
+                None => kickoff_errors.push("deck kickoff: no live citizen to voice it".into()),
+            }
+        }
         crate::cognition::bench_round::seal_round(room.room_id.as_uuid());
 
         // PRUNE (opt-in): converge the board to one live card per task for THIS

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -827,6 +827,10 @@ pub struct BenchmarkDispatchParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub force: Option<bool>,
+    /// THE REVIEW GATE: an owner's `done` becomes `review` + a sibling review card a
+    /// NON-owner pulls; only the reviewer's `done` closes the card and fires its
+    /// grade. Off = the control arm (a citizen's own `done` grades directly).
+    pub review_gate: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -985,6 +989,24 @@ pub(crate) fn parse_card_title(title: &str) -> Option<(String, String)> {
     Some((bench.trim().to_string(), task.to_string()))
 }
 
+/// A review card's title: `[review <parent8>] <instance>: …` — ONE writer
+/// ([`crate::modules::work::open_review_card`]), one parser, beside the bench one.
+pub(crate) fn review_card_title(parent: uuid::Uuid, instance: &str, owner: &str) -> String {
+    format!(
+        "[review {}] {instance}: review {owner}'s fix",
+        &parent.simple().to_string()[..8]
+    )
+}
+
+/// Parse a review card's title into the INSTANCE it reviews. `None` for any other
+/// title, so a normal work card is never mistaken for a review.
+pub(crate) fn parse_review_title(title: &str) -> Option<String> {
+    let rest = title.strip_prefix("[review ")?;
+    let (_, after) = rest.split_once("] ")?;
+    let instance = after.split(':').next()?.trim();
+    (!instance.is_empty()).then(|| instance.to_string())
+}
+
 /// Compose the card BODY: the full prompt plus a definition of done a citizen
 /// can act on with her own hands. Grading inputs that must stay held out
 /// (`expect`, the harness `test`) are deliberately NOT written to the card —
@@ -1110,6 +1132,9 @@ pub struct RecipeDispatch {
     /// Standing rules for the run room (see `BenchmarkDispatchParams::doctrine`).
     #[serde(default)]
     pub doctrine: Option<String>,
+    /// The review gate (see `BenchmarkDispatchParams::review_gate`).
+    #[serde(default)]
+    pub review_gate: Option<bool>,
 }
 
 /// Resolve the citizens a directed dispatch addresses — GENERALIZED for any repo user's
@@ -1484,6 +1509,7 @@ impl ActionCommand for BenchmarkDispatch {
                     name: Some(d.benchmark.clone()),
                     recipe: None,
                     doctrine: d.doctrine.clone().or_else(|| p.doctrine.clone()),
+                    review_gate: d.review_gate.or(p.review_gate),
                     teammates: if team.is_empty() {
                         p.teammates.clone()
                     } else {
@@ -1876,6 +1902,10 @@ impl ActionCommand for BenchmarkDispatch {
         if let Some(doctrine) = &p.doctrine {
             run_params.insert("doctrine".to_string(), serde_json::json!(doctrine));
         }
+        run_params.insert(
+            "review_gate".to_string(),
+            serde_json::json!(p.review_gate.unwrap_or(false)),
+        );
         let room = crate::modules::activity::spawn_activity_room(
             &airc,
             &room_name,
@@ -2092,6 +2122,9 @@ impl ActionCommand for BenchmarkDispatch {
         let driver = p.drive.unwrap_or_default();
         crate::cognition::bench_round::open_round(room.room_id.as_uuid(), spec.name, driver);
         crate::cognition::bench_round::set_run_room_name(room.room_id.as_uuid(), &room_name);
+        if p.review_gate.unwrap_or(false) {
+            crate::cognition::bench_round::set_review_gate(room.room_id.as_uuid(), true);
+        }
         // The round REMEMBERS its team: driver edges (settle-advance, non-settling
         // advance, boot resume) dispatch cards that were never initially fired, and
         // without a round-level record they went out team-less (2026-08-30).

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -810,6 +810,13 @@ pub struct BenchmarkDispatchParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub drive: Option<crate::cognition::bench_round::WorkDriver>,
+    /// The round's STANDING RULES — published as the run room's operating doctrine
+    /// so every resident sees it in her grounding on every turn (the `[Room
+    /// operating doctrine]` block), not as a message that scrolls out of view.
+    /// This is where a recipe puts role prompts and the collaboration nudge
+    /// ("others are working cards on this board — say what you found when it
+    /// helps them"). Omit for the control arm: no doctrine, no nudge.
+    pub doctrine: Option<String>,
     /// Stage the round even though serving is NOT decode-verified (#442).
     ///
     /// Off by default, and the default is the point: dispatch refuses to post cards no
@@ -1100,6 +1107,9 @@ pub struct RecipeDispatch {
     /// any explicit `teammates`; the assignee is never their own reviewer.
     #[serde(default)]
     pub reviewers: Option<u32>,
+    /// Standing rules for the run room (see `BenchmarkDispatchParams::doctrine`).
+    #[serde(default)]
+    pub doctrine: Option<String>,
 }
 
 /// Resolve the citizens a directed dispatch addresses — GENERALIZED for any repo user's
@@ -1473,6 +1483,7 @@ impl ActionCommand for BenchmarkDispatch {
                 let sub = BenchmarkDispatchParams {
                     name: Some(d.benchmark.clone()),
                     recipe: None,
+                    doctrine: d.doctrine.clone().or_else(|| p.doctrine.clone()),
                     teammates: if team.is_empty() {
                         p.teammates.clone()
                     } else {
@@ -1861,6 +1872,10 @@ impl ActionCommand for BenchmarkDispatch {
             "team".to_string(),
             serde_json::json!(roster.iter().map(|(who, _)| who).collect::<Vec<_>>()),
         );
+        run_params.insert("driver".to_string(), serde_json::json!(p.drive.unwrap_or_default()));
+        if let Some(doctrine) = &p.doctrine {
+            run_params.insert("doctrine".to_string(), serde_json::json!(doctrine));
+        }
         let room = crate::modules::activity::spawn_activity_room(
             &airc,
             &room_name,
@@ -1869,6 +1884,26 @@ impl ActionCommand for BenchmarkDispatch {
             &run_params,
         )
         .await?;
+        // The round's standing rules, published as the run room's operating doctrine
+        // RIGHT HERE while the curator's current room is still the freshly spawned run
+        // (spawn_activity_room leaves the pointer there). Rendered verbatim into every
+        // resident's grounding as `[Room operating doctrine]` — the reminder that
+        // survives the window, unlike a kickoff message.
+        if let Some(doctrine) = &p.doctrine {
+            airc.publish_room_doctrine(
+                doctrine.clone(),
+                format!("round-{}", room.room_id.as_uuid().simple()),
+            )
+            .await
+            .map_err(|e| CommandError::Internal(format!("doctrine publish: {e}")))?;
+            crate::probe!(
+                class = "bench.round.doctrine_published",
+                room = %room.room_id.as_uuid(),
+                chars = doctrine.len() as u64,
+                "the round's standing rules are on the run room's doctrine — every \
+                 resident grounds on them each turn"
+            );
+        }
 
         // Move every assignee INTO the run — a citizen who is not subscribed never sees the
         // board, the kickoff, or the peers working beside her. This is the members[] half
@@ -5206,10 +5241,80 @@ impl ActionCommand for BenchmarkRounds {
             &facts,
             crate::persona::trace::now_ms(),
         );
+        enrich_rounds_from_board_and_verdicts(&mut rounds).await;
         Ok(BenchmarkRoundsResult {
             in_flight: rounds.len(),
             rounds,
         })
+    }
+}
+
+/// BOARD TRUTH + VERDICT FILES onto the round report — the durable records, read at
+/// report time (the round tracker knows the deck; the board knows who holds what and
+/// when; the verdict file knows the grade and when). This is what makes a round's
+/// time-to-claim, time-to-settle and resolve rate readable by a stranger after any
+/// number of reboots. Best-effort: an unreadable board leaves the tracker's view.
+pub(crate) async fn enrich_rounds_from_board_and_verdicts(
+    rounds: &mut [crate::cognition::bench_round::RoundSnapshot],
+) {
+    let registry = crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global();
+    let reader = registry.as_ref().and_then(|reg| reg.any_live_citizen());
+    for round in rounds.iter_mut() {
+        // Verdicts: keyed by instance, independent of the board.
+        for card in round.cards.iter_mut() {
+            if card.instance.is_empty() {
+                continue;
+            }
+            if let Some(v) = crate::cognition::swe_bench::read_verdict(&card.instance) {
+                card.resolved = Some(v.resolved);
+                card.graded_at_ms = (v.graded_at_ms > 0).then_some(v.graded_at_ms);
+            }
+        }
+        let Some(rt) = reader.as_ref() else {
+            continue;
+        };
+        let Ok(room_id) = round.round_id.parse::<uuid::Uuid>() else {
+            continue;
+        };
+        let Ok(set) = rt.airc().subscription_set().await else {
+            continue;
+        };
+        let Some(room) = set
+            .all()
+            .map(|sub| sub.as_room())
+            .find(|r| r.channel.as_uuid() == room_id)
+        else {
+            continue; // the reader is not resident in this run room — tracker view stands
+        };
+        let Ok(board) = rt.airc().work_board_in(&room).await else {
+            continue;
+        };
+        let board = board.snapshot();
+        for card in round.cards.iter_mut() {
+            let Some(bc) = board
+                .cards
+                .iter()
+                .find(|c| c.card_id.as_uuid().to_string() == card.card_id)
+            else {
+                continue;
+            };
+            card.board_state = serde_json::to_value(bc.state)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_string))
+                .unwrap_or_default();
+            card.owner = bc
+                .owner
+                .map(|o| {
+                    registry
+                        .as_ref()
+                        .and_then(|reg| reg.get(o.as_uuid()))
+                        .map(|rt| rt.agent_name().to_string())
+                        .unwrap_or_else(|| o.as_uuid().to_string()[..8].to_string())
+                })
+                .unwrap_or_default();
+            card.created_at_ms = Some(bc.created_at_ms);
+            card.updated_at_ms = Some(bc.updated_at_ms);
+        }
     }
 }
 

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -964,6 +964,20 @@ pub(crate) fn dispatch_card_title(bench: &str, task_id: &str, prompt: &str) -> S
     format!("{} {gist}{ellipsis}", dispatch_card_key(bench, task_id))
 }
 
+/// Parse `[bench <name>] <task>: <gist>` — the exact shape [`dispatch_card_title`]
+/// writes — into `(bench_name, task_id)`. `None` for any non-bench title, so a normal
+/// work card is neither graded nor staged. ONE parser beside the ONE writer: the grade
+/// edge (`benchmark_grade`) and the on-claim staging (`card_staging`) both read this.
+pub(crate) fn parse_card_title(title: &str) -> Option<(String, String)> {
+    let rest = title.strip_prefix("[bench ")?;
+    let (bench, after) = rest.split_once("] ")?;
+    let task = after.split(':').next()?.trim();
+    if bench.trim().is_empty() || task.is_empty() {
+        return None;
+    }
+    Some((bench.trim().to_string(), task.to_string()))
+}
+
 /// Compose the card BODY: the full prompt plus a definition of done a citizen
 /// can act on with her own hands. Grading inputs that must stay held out
 /// (`expect`, the harness `test`) are deliberately NOT written to the card —
@@ -1521,9 +1535,10 @@ impl ActionCommand for BenchmarkDispatch {
         enum CardWork {
             /// Gym: write a solution file; DoD is a compile/test shell.
             Gym { solution_file: String },
-            /// SWE: the pulled instance. Dispatch STAGES it into the directed assignee's
-            /// workspace/swe/<instance> so her claim auto-fires the scored solve (#346's
-            /// dispatch_staged_swe_solve) — the loop closes with nobody in it.
+            /// SWE: the pulled instance. The CLAIM stages it into the claimer's
+            /// workspace/swe/<instance> (`card_staging`); a detached-solve round stages
+            /// its directed assignee at dispatch through the same function and fires
+            /// her solve (#346) — the loop closes with nobody in it.
             Swe {
                 instance: Box<crate::cognition::swe_bench::SweInstance>,
             },
@@ -1964,7 +1979,7 @@ impl ActionCommand for BenchmarkDispatch {
         // hyphenated uuid, so the round's membership set must too (the 8-char `card_ids`
         // shorts are the human/CLI handle, not the identity).
         let mut card_uuids: Vec<uuid::Uuid> = Vec::new();
-        let mut skipped_needs_setup = 0u32;
+        let skipped_needs_setup = 0u32; // setup runs at the claim edge now (card_staging)
         let mut skipped_known_red = 0u32;
         let mut skipped_already_on_board = 0u32;
         let mut kickoffs = 0u32;
@@ -2052,11 +2067,11 @@ impl ActionCommand for BenchmarkDispatch {
             );
         }
         for pc in prepared.into_iter().take(take) {
-            // A gym setup_shell card is prepared IN THE ASSIGNEE'S WORKSPACE at
-            // dispatch, below (same contract as SWE checkout staging) — the early
-            // unconditional skip that used to live here reported the entire ds-1000
-            // maiden dispatch as `skipped_needs_setup: 4` (2026-08-22): the eval
-            // path always ran setup_shell, but no card-dispatch orchestration did.
+            // A gym setup_shell card is prepared in the CLAIMER's workspace at claim
+            // time (`card_staging`, 2026-09-03) — the early unconditional skip that
+            // used to live here reported the entire ds-1000 maiden dispatch as
+            // `skipped_needs_setup: 4` (2026-08-22): the eval path always ran
+            // setup_shell, but no card-dispatch orchestration did.
 
             // IDEMPOTENCE: this exact task already has a live card. Re-dispatching
             // would post a duplicate, and duplicates are not free — two citizens
@@ -2076,61 +2091,16 @@ impl ActionCommand for BenchmarkDispatch {
             // The directed assignee (round-robin over the RESOLVED live roster). Always a
             // real online citizen — resolve_dispatch_roster guaranteed a non-empty roster
             // or errored. Her peer_id rides along, so SWE staging needs no second name
-            // lookup (and can never silently no-stage on an unknown name). A SWE card stages
-            // into HER workspace before it is claimable, so her claim auto-fires the scored
-            // solve (#346 dispatch_staged_swe_solve).
+            // lookup (and can never silently no-stage on an unknown name). Under a
+            // DETACHED-SOLVE round she is staged and pre-claimed below and her solve
+            // fires (#346); under a CITIZEN round she is only the kickoff's voice
+            // exclusion — the card posts OPEN and whoever pulls it is staged at claim.
             let (who, who_peer) = &roster[card_ids.len() % roster.len()];
 
             // STAGE the SWE checkout into the assignee's workspace/swe/<instance> BEFORE the
             // card is claimable, so `work/claim` finds it and launches the solve. Reuses the
             // proven swe_bench::clone_at (fast from the local mirror). Best-effort: a stage
             // failure is REPORTED and the card still posts — the loop never half-breaks.
-            // GYM setup: run the task's setup_shell in the assignee's workspace NOW,
-            // so the card she claims already has its context/grader staged. Adapter
-            // setups are idempotent (mkdir -p + overwrite-decode), so a re-dispatch
-            // re-stages harmlessly. Failure is REPORTED and the card is withheld —
-            // posting a card whose grader never staged manufactures a permanent
-            // infra-zero wearing a capability face.
-            if let Some(setup) = pc.setup_shell.as_deref() {
-                let ok = match stage_home.as_ref() {
-                    Some(home) => {
-                        let ws = crate::identity::citizen_peer_dir(
-                            home,
-                            crate::identity::PeerId::from_uuid(*who_peer),
-                        )
-                        .join("workspace");
-                        let _ = std::fs::create_dir_all(&ws);
-                        match tokio::process::Command::new("sh")
-                            .arg("-c")
-                            .arg(setup)
-                            .current_dir(&ws)
-                            .output()
-                            .await
-                        {
-                            Ok(out) if out.status.success() => true,
-                            Ok(out) => {
-                                let head: String = pc.title.chars().take(48).collect();
-                                kickoff_errors.push(format!(
-                                    "setup {head}: {}",
-                                    String::from_utf8_lossy(&out.stderr).trim()
-                                ));
-                                false
-                            }
-                            Err(e) => {
-                                kickoff_errors.push(format!("setup spawn: {e}"));
-                                false
-                            }
-                        }
-                    }
-                    None => false,
-                };
-                if !ok {
-                    skipped_needs_setup += 1;
-                    continue;
-                }
-            }
-
-            let mut staged_ok = false;
             // THE COVERAGE GATE (the cheap half of `benchmark/validate`). If THIS
             // box has already PROVEN this instance's (repo, era) env class red,
             // do not spend a citizen's hours and a grader's slot discovering the
@@ -2161,47 +2131,35 @@ impl ActionCommand for BenchmarkDispatch {
                 }
             }
 
-            if let (CardWork::Swe { instance }, Some(home)) = (&pc.work, stage_home.as_ref()) {
-                let dir = crate::identity::citizen_peer_dir(
-                    home,
-                    crate::identity::PeerId::from_uuid(*who_peer),
-                )
-                .join("workspace")
-                .join("swe")
-                .join(&instance.instance_id);
-                if dir.join(".git").exists() {
-                    staged_ok = true; // already staged (a prior claim / dispatch)
-                    // Self-heal pre-shield checkouts: clone_at shields NEW trees, but a
-                    // checkout staged before the shield existed stays exposed forever
-                    // without this — the 76-tree hand backfill of 2026-08-22, automated.
-                    crate::cognition::swe_bench::shield_workspace_excludes(&dir);
-                } else if let Err(e) = crate::cognition::swe_bench::clone_at(instance, &dir).await {
-                    kickoff_errors.push(format!("stage {}: {e}", instance.instance_id));
-                } else {
-                    staged_ok = true;
+            // STAGING MOVED TO THE CLAIM EDGE (2026-09-03, the pull inversion). A
+            // citizen-driven round stages NOTHING here: whoever PULLS the card is
+            // staged for it by `work/claim` → `card_staging::stage_for_claimer`, so any
+            // resident can work any Open card and a rebooted citizen who re-reads the
+            // board is staged exactly like a first claimer. Only a DETACHED-SOLVE round
+            // still stages its directed assignee here — the SAME function — because
+            // the solve below fires without a claim from her.
+            let staged_ok = if driver == crate::cognition::bench_round::WorkDriver::DetachedSolve
+            {
+                match stage_home.as_ref() {
+                    Some(home) => match crate::modules::card_staging::stage_for_claimer(
+                        home,
+                        *who_peer,
+                        &pc.title,
+                    )
+                    .await
+                    {
+                        crate::modules::card_staging::Staging::Ready { .. }
+                        | crate::modules::card_staging::Staging::Ordinary => true,
+                        crate::modules::card_staging::Staging::Failed { stage, error } => {
+                            kickoff_errors.push(format!("stage {}: {stage}: {error}", pc.title));
+                            false
+                        }
+                    },
+                    None => false,
                 }
-                // Build the per-instance venv NOW (with pytest + the repo installed) so her
-                // HANDS have a working `pytest`/`python` the moment she starts — not only at
-                // grade time. Without this the solve's `code/shell pytest` hits the system
-                // interpreter and she loops trying to install pytest into it (glass-boxed
-                // 2026-08-11 from Anon's astropy turn). ensure_env is idempotent and cached, so
-                // the later grade reuses this exact venv. Best-effort: a build failure is
-                // reported but the card still posts — the loop never half-breaks.
-                if staged_ok {
-                    if let Err(e) = crate::cognition::swe_bench::ensure_env(instance, &dir).await {
-                        kickoff_errors.push(format!("env {}: {e}", instance.instance_id));
-                        // A solve against an unbuildable env can ONLY void: she spends a
-                        // full attempt (24 acts, live: pytest-5413 twice on 2026-08-12)
-                        // in a workspace whose grade is a known-in-advance env fault —
-                        // no verdict, no lesson (the failure is the env's, not hers).
-                        // The card still posts (claimable once the env heals); the
-                        // SCORED solve does not fire (Joel: "why run broken code
-                        // knowing she's gonna struggle and fall").
-                        staged_ok = false;
-                    }
-                }
-            }
-
+            } else {
+                false
+            };
             let mut req = CreateWorkCard::new(repo.clone(), pc.title, Priority::P2);
             req.body = Some(pc.body);
             let card_id = airc
@@ -2217,7 +2175,9 @@ impl ActionCommand for BenchmarkDispatch {
             crate::cognition::bench_round::add_card(room.room_id.as_uuid(), card_id.as_uuid());
             // WHO works this card, recorded at staging (before any solve fires) —
             // the follow-on driver and the boot resume read it (plan A4/A5).
-            crate::cognition::bench_round::record_card_assignee(card_id.as_uuid(), *who_peer);
+            if driver == crate::cognition::bench_round::WorkDriver::DetachedSolve {
+                crate::cognition::bench_round::record_card_assignee(card_id.as_uuid(), *who_peer);
+            }
             // WHAT it tests, same moment — the roll-call names the instance
             // and in-flight runs join back to their card by it.
             if let CardWork::Swe { instance } = &pc.work {
@@ -2257,8 +2217,14 @@ impl ActionCommand for BenchmarkDispatch {
             // detached round could never reach Done and every boot reaped it
             // (mapped 2026-08-26). Claimed-by-the-assignee is what lets the
             // grade path close the card and the round complete.
-            let pre_claim_this = matches!(pc.work, CardWork::Gym { .. })
-                || (matches!(pc.work, CardWork::Swe { .. }) && staged_ok);
+            // PRE-CLAIM only for a detached-solve round: its solve fires for the
+            // directed assignee below, so the claim must already be hers. A
+            // citizen-driven round posts its cards OPEN — that is what makes the deck
+            // a deck. (Before 2026-09-03 every card, both drivers, was pre-claimed for
+            // its round-robin assignee: a push wearing a pull's clothes.)
+            let pre_claim_this = driver == crate::cognition::bench_round::WorkDriver::DetachedSolve
+                && staged_ok
+                && matches!(pc.work, CardWork::Swe { .. });
             if pre_claim_this {
                 match self.registry.get(*who_peer) {
                     Some(rt) => {
@@ -2301,7 +2267,31 @@ impl ActionCommand for BenchmarkDispatch {
             // 2026-08-07: coalesced mid-burst it was ignored). airc.say is one event = one
             // block, so the structural condition holds by construction.
             {
-                let kickoff = match &pc.work {
+                let kickoff = if driver == crate::cognition::bench_round::WorkDriver::Citizen {
+                    // OPEN card, room-addressed: nobody is "the" assignee — whoever is
+                    // free pulls it (the substrate claims it for an idle resident), and
+                    // the claim stages the work in HER workspace.
+                    match &pc.work {
+                        CardWork::Gym { solution_file } => format!(
+                            "card {short} is OPEN on this board — whoever is free pulls it \
+                             (the substrate claims it for you when you are idle, or \
+                             claim_task {short}). Read its body, write your solution to \
+                             `{solution_file}` in your workspace, then mark it done \
+                             (work/state {short} done). Your artifact is graded against \
+                             held-out tests."
+                        ),
+                        CardWork::Swe { instance } => format!(
+                            "card {short} is a REAL {} issue (SWE-bench, a full project) and \
+                             is OPEN on this board — whoever is free pulls it. Claiming stages \
+                             the repo in YOUR workspace at `swe/{}/`; fix the bug there (do \
+                             not edit the tests) — your diff is graded against the repo's \
+                             held-out tests. When your fix is ready, YOU close it: `work/state \
+                             {short} done` — that is what fires your grade.",
+                            instance.repo, instance.instance_id
+                        ),
+                    }
+                } else {
+                match &pc.work {
                     CardWork::Gym { solution_file } if pre_claimed => format!(
                         "@{who} (to you): card {short} is CLAIMED FOR YOU on this board — \
                          no claim step needed. Read its body, write your solution to \
@@ -2344,6 +2334,7 @@ impl ActionCommand for BenchmarkDispatch {
                             instance.repo, instance.instance_id
                         )
                     }
+                }
                 };
                 // AUTHOR IT AS SOMEONE ELSE. A citizen's inbound stream skips messages
                 // she is recorded as having said (correct — nobody answers their own

--- a/core/continuum-core/src/commands/persona/turn_frame/execute.rs
+++ b/core/continuum-core/src/commands/persona/turn_frame/execute.rs
@@ -293,7 +293,9 @@ fn settle_step_to_json(
         SettleStep::ActUnfulfilled { calls, intent } => serde_json::json!({
             "outcome": "actUnfulfilled", "intent": intent, "calls": calls.len(),
         }),
-        SettleStep::Passed => serde_json::json!({ "outcome": "passed" }),
+        SettleStep::Passed { reason } => serde_json::json!({
+            "outcome": "passed", "reason": reason,
+        }),
         // The model call FAILED — surface it LOUD and NAMED, never as a serene
         // `passed` ([[fallbacks-are-illegal-fail-loud]]). The sweep harness reads
         // this to tell an infra failure (timeout / 5xx / a serving lane refusing an
@@ -480,7 +482,7 @@ mod tests {
         assert_eq!(spoke["metrics"]["tokensPerSecond"], 14.0);
 
         // No metrics ⇒ no metrics key (never a fabricated zero-cost row).
-        let passed = settle_step_to_json(&SettleStep::Passed, None);
+        let passed = settle_step_to_json(&SettleStep::Passed { reason: None }, None);
         assert_eq!(passed["outcome"], "passed");
         assert!(
             passed.get("metrics").is_none(),

--- a/core/continuum-core/src/experience/recipes/benchmark.json
+++ b/core/continuum-core/src/experience/recipes/benchmark.json
@@ -50,6 +50,14 @@
     "budget": {
       "default": "4h",
       "doc": "wall-clock ceiling per attempt"
+    },
+    "driver": {
+      "default": "citizen",
+      "doc": "who works the cards: citizen (her own held-work turns in the room) or detached_solve (a forked solver per card)"
+    },
+    "doctrine": {
+      "default": "",
+      "doc": "the round's standing rules, published as the run room's operating doctrine (role prompts, the collaboration nudge); empty = none (the control arm)"
     }
   },
   "layout": {

--- a/core/continuum-core/src/experience/recipes/benchmark.json
+++ b/core/continuum-core/src/experience/recipes/benchmark.json
@@ -58,6 +58,10 @@
     "doctrine": {
       "default": "",
       "doc": "the round's standing rules, published as the run room's operating doctrine (role prompts, the collaboration nudge); empty = none (the control arm)"
+    },
+    "review_gate": {
+      "default": false,
+      "doc": "when true an owner's done becomes review + a sibling review card a non-owner pulls; only the reviewer's done closes the card and fires its grade"
     }
   },
   "layout": {

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -1910,8 +1910,20 @@ pub async fn ensure_model_serving<C: LlamaServerControl + ?Sized>(
             // treated as "window OK" so a probe error never spuriously relaunches.
             let window_ok = match ctrl.served_context_window().await {
                 Ok(served) => {
-                    served == 0
-                        || target.context_window <= served.saturating_add(WINDOW_RELAUNCH_TOLERANCE)
+                    // Tolerance is a PERCENTAGE of the served window, floored at the
+                    // flat minimum — never a bare flat count. A flat 512 is 0.35% of a
+                    // 147k lane, so the boot plan's normal drift (it re-computes against
+                    // live memory, which climbs ~7% once the old core frees its share:
+                    // measured 2026-09-03, 147712 → 158107) tripped a RELAUNCH — a full
+                    // ~7-10 min 35B reload on EVERY reboot, the dominant "resume is slow"
+                    // cost. A warm lane at 88% of the ideal window NOW beats a cold ideal
+                    // one in 10 minutes; the runtime re-home (streak-debounced) still
+                    // grows it later if a bigger window's gain actually persists. A
+                    // genuinely starved lane (2048 vs a 31k plan) still relaunches:
+                    // 31k ≫ 2048 × 1.125. served 0 / probe-err stays "OK" (no spurious
+                    // relaunch), unchanged.
+                    let tolerance = WINDOW_RELAUNCH_TOLERANCE.max(served / 8);
+                    served == 0 || target.context_window <= served.saturating_add(tolerance)
                 }
                 Err(e) => {
                     // Deliberate: a probe error must not spuriously relaunch a healthy
@@ -3893,6 +3905,36 @@ mod tests {
             ctrl.serves.load(Ordering::SeqCst),
             1,
             "exactly one relaunch to the larger window"
+        );
+    }
+
+    // what this catches: THE 2026-09-03 SLOW-RESUME defect — a warm lane REAPED for a
+    // trivial window drift. On reboot the boot plan re-computes the window against live
+    // memory, which climbs ~7% once the old core frees its share (measured 147712 →
+    // 158107). A flat 512-token tolerance (0.35% of a 147k lane) tripped a full ~7-10
+    // min 35B RELAUNCH on EVERY restart — the dominant "resume is slow" cost. Tolerance
+    // is now a percentage (max(512, served/8) ≈ 12.5%), so a warm lane within ~12.5% of
+    // the target is ADOPTED (warm-now beats cold-in-10-min); a genuinely starved lane
+    // (the 2× case above) still relaunches, and the runtime re-home grows a persistent
+    // gain later.
+    #[tokio::test]
+    async fn a_small_window_drift_adopts_the_warm_lane_not_a_slow_reload() {
+        // Owned + decode-healthy, serving 147712; the boot plan drifted to 158107 (~7%).
+        let ctrl = FakeControl::probe(Ok(Some("coder-14b".into())))
+            .owned()
+            .with_served_window(147_712);
+        let mut t = target("coder-14b");
+        t.context_window = 158_107;
+        let outcome = ensure_model_serving(&ctrl, &t, false).await;
+        assert_eq!(
+            outcome,
+            EnsureOutcome::AlreadyServing,
+            "a ~7% window drift must ADOPT the warm lane, not reload it; got {outcome:?}"
+        );
+        assert_eq!(
+            ctrl.serves.load(Ordering::SeqCst),
+            0,
+            "zero relaunches — the warm 35B lane is reused, not reloaded"
         );
     }
 

--- a/core/continuum-core/src/inference/mod.rs
+++ b/core/continuum-core/src/inference/mod.rs
@@ -60,6 +60,7 @@ pub mod ort_providers;
 pub mod placement_capture;
 pub mod recipe_budget;
 pub mod throughput_expectation;
+pub mod turn_admission;
 pub mod placement_watch;
 pub mod vendored;
 pub mod vision_sidecar;

--- a/core/continuum-core/src/inference/slots.rs
+++ b/core/continuum-core/src/inference/slots.rs
@@ -35,7 +35,12 @@ use uuid::Uuid;
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::paging::pool::{PagedResourcePool, PoolConfig};
+use crate::paging::pool::{PagedResourcePool, PinHandle, PoolConfig};
+
+/// A slot pinned for the duration of a turn — while held, the pool cannot evict
+/// this activity's slot, so a concurrent returner never leases (and restores into)
+/// a slot that is still decoding. RAII: dropping it releases the pin.
+pub type SlotPin = PinHandle<ActivityKey, std::sync::Arc<KvSlotLease>>;
 
 /// How a request may touch serving slots — the traffic-class policy, AS DATA
 /// (one tested map over the existing `purpose` strings, answering the
@@ -358,6 +363,16 @@ impl KvSlotPool {
             save_first,
             restore,
         })
+    }
+
+    /// Pin this activity's slot for the duration of a turn. While the returned
+    /// [`SlotPin`] is held, priced eviction skips this slot, so a concurrent
+    /// returner can never lease (and restore into) a slot that is still decoding
+    /// this turn's KV — the decoupling that forced the old restore timeout. RAII:
+    /// drop the handle to release. `None` if the activity is not resident (nothing
+    /// to protect — a caller that just leased it will always get `Some`).
+    pub fn pin(&self, key: &ActivityKey) -> Option<SlotPin> {
+        self.pool.pin(key)
     }
 
     /// Record that `key`'s page was successfully written to disk — it becomes

--- a/core/continuum-core/src/inference/turn_admission.rs
+++ b/core/continuum-core/src/inference/turn_admission.rs
@@ -1,0 +1,195 @@
+//! Turn admission — everything a turn must ACQUIRE before it can generate, as ONE
+//! RAII guard. Extracted from `openai_adapter::generate_stream`, where it lived
+//! inline and tangled with body-building across two scopes (the `if
+//! llamacpp_sampling_extensions` block vs. the function body). That tangle is what
+//! made the permit/pin lifetime hard to get right by hand — the fix is to make the
+//! lifetime a TYPE: the caller binds one [`TurnAdmission`] at function scope and it
+//! holds the permit + slot pin for the whole generation, releasing both on drop.
+//!
+//! ## Event-driven, no timeout (the restore-into-busy-slot fix)
+//!
+//! The order is load-bearing:
+//! 1. **Permit first.** Take the concurrency permit (`Semaphore(lanes)`) BEFORE
+//!    leasing a slot. Holding a permit means a lane is genuinely free — an
+//!    event-driven wait that wakes when another turn releases, never a timer.
+//! 2. **Pin the leased slot** (synchronously, before any save/restore await) so
+//!    priced eviction skips it. A concurrent returner can then never lease — and
+//!    restore INTO — a slot that is still decoding this turn's KV.
+//! 3. **Save/restore** now targets a guaranteed-free, non-decoding slot, so the
+//!    restore lands (~0.1s) instead of deferring behind a live decode.
+//!
+//! Before this, the slot was leased before the permit and never pinned, so a
+//! returner grabbed a still-decoding slot and its restore timed out — measured
+//! 27/27 `status=0`, worked around with a 90s wait (55/67). Permit-first + pin
+//! removes the failure at the source; the 90s wait is gone (see [`kv_page_action`]).
+
+use std::sync::Arc;
+
+use serde_json::json;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::inference::slots::{ActivityKey, KvSlotPool, SlotPin};
+
+/// What a turn holds for the whole generation. Dropping it releases the concurrency
+/// permit and the slot pin (RAII) — never before the generation completes, because
+/// the caller binds it at function scope alongside the streamed response.
+pub struct TurnAdmission {
+    /// The slot to pin the request to (`id_slot`), or `None` to stay unpinned
+    /// (non-Turn traffic, or a Turn whose activity could not be leased).
+    slot: Option<u32>,
+    /// The concurrency permit — held so no more than `lanes` turns decode at once.
+    _permit: OwnedSemaphorePermit,
+    /// The slot pin — held so eviction cannot reassign this turn's slot mid-decode.
+    _pin: Option<SlotPin>,
+}
+
+impl TurnAdmission {
+    /// The leased slot this turn should pin `id_slot` to, if any.
+    pub fn slot(&self) -> Option<u32> {
+        self.slot
+    }
+}
+
+/// Admit a turn: acquire the concurrency permit (always), then — for a Turn with a
+/// resolvable `(persona, room)` key and a live slot pool — lease + pin its slot and
+/// page its KV (save the evictee, restore this activity). Returns the guard the
+/// caller must hold across the generation.
+///
+/// `key`/`pool` are `None` for non-Turn traffic (or a cloud provider with no slots):
+/// the caller still gets the permit, `slot()` is `None`, and it places the request
+/// on scratch (or unpinned) itself.
+pub async fn admit_turn(
+    concurrency: &Arc<Semaphore>,
+    key: Option<ActivityKey>,
+    pool: Option<Arc<KvSlotPool>>,
+    client: &reqwest::Client,
+    root: &str,
+    approx_tokens: u64,
+) -> TurnAdmission {
+    // 1. PERMIT FIRST — event-driven wait for a free lane. Cannot fail: the
+    //    semaphore is never closed over the adapter's lifetime.
+    let _permit = concurrency
+        .clone()
+        .acquire_owned()
+        .await
+        .expect("adapter semaphore never closed");
+
+    let mut slot = None;
+    let mut _pin = None;
+
+    if let (Some(k), Some(pool)) = (key, pool) {
+        if let Some(pg) = pool.lease_paged(k).await {
+            // 2. PIN synchronously, before any await below — a permit-holding
+            //    returner leases only an UNPINNED slot, so pinning here (there are
+            //    at most lanes-1 other pinned slots while we hold a permit) makes the
+            //    slot we just leased un-evictable for the turn. No await between the
+            //    lease returning and this pin, so no other task can slip in.
+            _pin = pool.pin(&k);
+
+            // 3. The context switch onto a now-free slot: page the evictee out,
+            //    page this activity in. Lands immediately (no defer) because the slot
+            //    is not decoding.
+            if let Some(prev) = pg.save_first {
+                if kv_page_action(client, root, pg.slot, &prev, "save").await {
+                    pool.note_saved(prev);
+                }
+            }
+            if pg.restore && !kv_page_action(client, root, pg.slot, &k, "restore").await {
+                // Dead page (geometry swept / file missing): stop offering it; this
+                // turn re-prefills plainly.
+                pool.note_page_lost(&k);
+            }
+            // Price basis for the eviction policy (B5): this activity's current
+            // prompt size — comparable across slots, which is all eviction needs.
+            pool.note_tail(&k, approx_tokens);
+            slot = Some(pg.slot);
+        }
+    }
+
+    TurnAdmission { slot, _permit, _pin }
+}
+
+/// Execute one KV page action against the server (`/slots/{id}?action=save|restore`).
+///
+/// The 10s cap is a WEDGE DETECTOR, not a wait-for-the-slot: with permit-first + pin
+/// admission ([`admit_turn`]) a restore is only ever issued into an already-free
+/// slot, so it lands in ~0.1s and never defers behind a live decode. A restore
+/// taking >10s now means a wedged server. (History: pre-fix this path saw 27/27
+/// restores fail `status=0`, then 55/67 with a 90s wait; the pin removes the failure
+/// mode instead of waiting it out, so the wait is gone.)
+///
+/// `pub(crate)` so the spawned warm-ahead task drives the SAME seam as admission.
+pub(crate) async fn kv_page_action(
+    client: &reqwest::Client,
+    root: &str,
+    slot: u32,
+    key: &ActivityKey,
+    action: &str,
+) -> bool {
+    let url = format!("{}/slots/{}?action={}", root.trim_end_matches('/'), slot, action);
+    let filename = crate::inference::slots::page_filename(key);
+    let started = std::time::Instant::now();
+    let resp = client
+        .post(&url)
+        .timeout(std::time::Duration::from_secs(10))
+        .json(&json!({ "filename": filename }))
+        .send()
+        .await;
+    let ok = matches!(&resp, Ok(r) if r.status().is_success());
+    let status = resp.as_ref().map(|r| r.status().as_u16()).unwrap_or(0); // 0 = transport error
+    crate::probe!(
+        class = "inference.kv_page.action",
+        action = %action,
+        slot = slot as u64,
+        persona = %key.persona,
+        room = %key.room,
+        ok,
+        status = status as u64,
+        ms = started.elapsed().as_millis() as u64,
+        "KV page context switch — save pages the evictee's state out, restore pages \
+         the returner's state in (~0.1s measured; a miss means this turn re-prefills)",
+    );
+    ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    // what this catches: the restore-into-busy-slot bug at its source — while a turn
+    // holds its admission (permit + pin), a second activity contending for the SAME
+    // single slot must NOT be able to evict the pinned slot out from under it. Only
+    // once the first admission drops does the slot become leasable again. This is the
+    // invariant that makes the 90s restore wait unnecessary. No HTTP: a fresh key has
+    // no page, so save/restore are skipped.
+    #[tokio::test]
+    async fn a_pinned_slot_survives_a_contending_lease_until_the_turn_drops() {
+        let pool = Arc::new(KvSlotPool::new("test://admit", 1)); // ONE citizen slot
+        let sem = Arc::new(Semaphore::new(1));
+        let client = reqwest::Client::new();
+        let a = ActivityKey::new(Uuid::from_u128(1), Uuid::from_u128(2)).unwrap();
+        let b = ActivityKey::new(Uuid::from_u128(3), Uuid::from_u128(4)).unwrap();
+
+        // A is admitted: holds the permit and pins the one slot.
+        let adm_a = admit_turn(&sem, Some(a), Some(pool.clone()), &client, "test://admit", 100).await;
+        let slot_a = adm_a.slot().expect("A leased the slot");
+
+        // B tries to lease while A is pinned — eviction must skip the pinned slot, so
+        // B cannot take slot_a (the pool has no other slot to give).
+        assert!(
+            pool.lease(b).await.is_none(),
+            "a pinned slot was handed to a contending activity — the exact restore-into-busy-slot bug"
+        );
+
+        // A's turn ends — the pin (and permit) release.
+        drop(adm_a);
+
+        // Now B can lease, and it gets the freed slot.
+        assert_eq!(
+            pool.lease(b).await,
+            Some(slot_a),
+            "after the turn dropped, the slot must become leasable again"
+        );
+    }
+}

--- a/core/continuum-core/src/inference/turn_admission.rs
+++ b/core/continuum-core/src/inference/turn_admission.rs
@@ -72,7 +72,7 @@ pub async fn admit_turn(
         .clone()
         .acquire_owned()
         .await
-        .expect("adapter semaphore never closed");
+        .expect("adapter semaphore never closed");  // expect: the semaphore lives as long as the adapter, never closed
 
     let mut slot = None;
     let mut _pin = None;
@@ -168,12 +168,12 @@ mod tests {
         let pool = Arc::new(KvSlotPool::new("test://admit", 1)); // ONE citizen slot
         let sem = Arc::new(Semaphore::new(1));
         let client = reqwest::Client::new();
-        let a = ActivityKey::new(Uuid::from_u128(1), Uuid::from_u128(2)).unwrap();
-        let b = ActivityKey::new(Uuid::from_u128(3), Uuid::from_u128(4)).unwrap();
+        let a = ActivityKey::new(Uuid::from_u128(1), Uuid::from_u128(2)).unwrap();  // test: non-nil ids
+        let b = ActivityKey::new(Uuid::from_u128(3), Uuid::from_u128(4)).unwrap();  // test: non-nil ids
 
         // A is admitted: holds the permit and pins the one slot.
         let adm_a = admit_turn(&sem, Some(a), Some(pool.clone()), &client, "test://admit", 100).await;
-        let slot_a = adm_a.slot().expect("A leased the slot");
+        let slot_a = adm_a.slot().expect("A leased the slot");  // test: a 1-slot pool leases to the first admission
 
         // B tries to lease while A is pinned — eviction must skip the pinned slot, so
         // B cannot take slot_a (the pool has no other slot to give).

--- a/core/continuum-core/src/live/audio/emotion_tags.rs
+++ b/core/continuum-core/src/live/audio/emotion_tags.rs
@@ -1,0 +1,76 @@
+//! Emotion tags for expressive TTS — Stage A of the native-audio ladder
+//! (VOICE-ENGINE-PLAN.md; Joel 2026-09-02: "intimately control the speech
+//! mannerisms… so it wouldn't sound like text to speech").
+//!
+//! ONE sentiment source: the same sub-microsecond extraction that drives the
+//! avatar's face ([`crate::live::session::sentiment`]) maps here to Orpheus's
+//! trained emotion tags — voice and face express one state, never two
+//! analyzers drifting. Stage B retires this module entirely: when speech
+//! tokens come from the persona's own forward pass, mannerisms need no
+//! injection because the speaking IS the thinking.
+
+use crate::live::session::sentiment;
+use crate::live::video::bevy_renderer::Emotion;
+
+/// Minimum sentiment intensity before a tag is worth an interjection — a
+/// mild reading decorated with a laugh sounds unhinged, not natural.
+const TAG_INTENSITY_FLOOR: f32 = 0.5;
+
+/// Map the shared sentiment result to an Orpheus interjection tag. `None` =
+/// speak plainly (neutral/relaxed, or below the floor). Tags are from the
+/// model's TRAINED set — an untrained tag gets read aloud as text.
+fn tag_for(emotion: Emotion, intensity: f32) -> Option<&'static str> {
+    if intensity < TAG_INTENSITY_FLOOR {
+        return None;
+    }
+    match emotion {
+        Emotion::Happy => Some("<chuckle>"),
+        Emotion::Sad => Some("<sigh>"),
+        Emotion::Surprised => Some("<gasp>"),
+        Emotion::Angry => Some("<groan>"),
+        _ => None,
+    }
+}
+
+/// Decorate `text` with an emotion tag for adapters that understand them.
+/// Orpheus-only by contract: every other engine would read `<sigh>` aloud.
+/// Borrowed pass-through when nothing applies — the common case allocates
+/// nothing.
+pub fn decorate_for_adapter<'a>(text: &'a str, adapter: Option<&str>) -> std::borrow::Cow<'a, str> {
+    if adapter != Some("orpheus") {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let s = sentiment::extract_sentiment(text);
+    match tag_for(s.emotion, s.intensity) {
+        Some(tag) => std::borrow::Cow::Owned(format!("{tag} {text}")),
+        None => std::borrow::Cow::Borrowed(text),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the two contract edges. (1) Non-Orpheus engines must
+    // NEVER receive a tag — they read it aloud as text (the literal failure a
+    // demo would ship). (2) A strong happy reading gets its chuckle; a flat
+    // one stays plain — the intensity floor is what keeps voices natural
+    // instead of unhinged.
+    #[test]
+    fn tags_are_orpheus_only_and_intensity_gated() {
+        let excited = "This is wonderful!!! I love it!!!";
+        let flat = "The file is in the src directory.";
+
+        let kokoro = decorate_for_adapter(excited, Some("kokoro"));
+        assert_eq!(kokoro, excited, "non-Orpheus engines get plain text");
+
+        let orpheus_excited = decorate_for_adapter(excited, Some("orpheus"));
+        assert!(
+            orpheus_excited.starts_with('<'),
+            "strong sentiment earns a tag: {orpheus_excited}"
+        );
+
+        let orpheus_flat = decorate_for_adapter(flat, Some("orpheus"));
+        assert_eq!(orpheus_flat, flat, "flat text stays plain even on Orpheus");
+    }
+}

--- a/core/continuum-core/src/live/audio/mod.rs
+++ b/core/continuum-core/src/live/audio/mod.rs
@@ -1,4 +1,5 @@
 pub mod buffer;
+pub mod emotion_tags;
 pub mod capabilities;
 pub mod mixer;
 pub mod model_root;

--- a/core/continuum-core/src/live/audio/stt/moonshine.rs
+++ b/core/continuum-core/src/live/audio/stt/moonshine.rs
@@ -299,13 +299,29 @@ impl MoonshineStt {
         drop(preprocess_out);
         drop(preprocess_session);
         let features_array = Self::cache_to_array(&features)?;
+        // The encoder ONNX takes TWO inputs: args_0 = features [1, T, D] and
+        // args_1 = the sequence length T as an int32 scalar tensor (its
+        // arange/strided_slice builds positional indices from it). Passing
+        // only features left args_1 missing — the whole STT chain returned
+        // empty for a full debug cycle behind a swallowed error (2026-09-02).
+        // T is the features' TIME axis: shape [1, T, D] → dims()[1].
+        let seq_len = *features_array.shape().get(1).ok_or_else(|| {
+            STTError::InferenceFailed(format!(
+                "encoder features have unexpected shape {:?} (want [1,T,D])",
+                features_array.shape()
+            ))
+        })? as i32;
 
         // ── Step 2: Encode ─ features → hidden states ────────────────────
         let features_tensor = Tensor::from_array(features_array)
             .map_err(|e| STTError::InferenceFailed(format!("Encoder input tensor: {e}")))?;
+        let seqlen_tensor = Tensor::from_array(
+            ndarray::Array1::from_vec(vec![seq_len]).into_dyn(),
+        )
+        .map_err(|e| STTError::InferenceFailed(format!("Encoder seqlen tensor: {e}")))?;
         let mut encoder_session = model.encoder.lock();
         let encoder_out = encoder_session
-            .run(ort::inputs![features_tensor])
+            .run(ort::inputs![features_tensor, seqlen_tensor])
             .map_err(|e| STTError::InferenceFailed(format!("Encoder run: {e}")))?;
         let encoder_hidden = Self::extract_f32(&encoder_out, 0)?;
         drop(encoder_out);

--- a/core/continuum-core/src/live/audio/stt/moonshine.rs
+++ b/core/continuum-core/src/live/audio/stt/moonshine.rs
@@ -343,18 +343,13 @@ impl MoonshineStt {
         let enc_tensor = Tensor::from_array(enc_array).map_err(|e| {
             STTError::InferenceFailed(format!("Uncached decoder encoder tensor: {e}"))
         })?;
-        // args_2 = the encoder sequence length T (encoder_hidden is [1,T,D]),
-        // for the decoder's cross-attention position arange — the same T the
-        // encoder's own args_1 consumed. Bound by NAME below, not position,
-        // so a model whose input order differs still lands correctly.
-        let enc_t = *encoder_hidden.shape.get(1).ok_or_else(|| {
-            STTError::InferenceFailed(format!(
-                "encoder_hidden has unexpected shape {:?} (want [1,T,D])",
-                encoder_hidden.shape
-            ))
-        })? as i32;
-        let seqlen_tensor = Tensor::from_array(ndarray::Array1::from_vec(vec![enc_t]).into_dyn())
-            .map_err(|e| STTError::InferenceFailed(format!("Uncached seqlen tensor: {e}")))?;
+        // args_2 = the DECODE POSITION as int32[1] (offline-verified contract:
+        // args_0 int32 tokens, args_1 f32 encoder[b,T,416], args_2 int32[1]).
+        // Uncached is the FIRST step → position 0 (empty self-attn cache); the
+        // cached loop increments it. (An earlier cut passed encoder-T here —
+        // non-crashing but the wrong RoPE offset, which would mistranscribe.)
+        let seqlen_tensor = Tensor::from_array(ndarray::Array1::from_vec(vec![0i32]).into_dyn())
+            .map_err(|e| STTError::InferenceFailed(format!("Uncached position tensor: {e}")))?;
         let mut uncached_session = model.uncached_decoder.lock();
         // Bind by declared input NAME (args_0 token, args_1 encoder, args_2 T)
         // — never positional, so the contract the model declares is the one
@@ -410,10 +405,19 @@ impl MoonshineStt {
             let enc_val: Value = Tensor::from_array(enc_array)
                 .map(|v| v.into())
                 .map_err(|e| STTError::InferenceFailed(format!("Encoder value: {e}")))?;
+            // args_2 = decode position int32[1] — the number of tokens already
+            // in the sequence (contract: token, encoder, POSITION, then 32 KV
+            // tensors). The positional zip omitted this and slid a float KV
+            // into the int32 position slot — the 'expected int32' error.
+            let pos = generated_tokens.len() as i32;
+            let pos_val: Value = Tensor::from_array(ndarray::Array1::from_vec(vec![pos]).into_dyn())
+                .map(|v| v.into())
+                .map_err(|e| STTError::InferenceFailed(format!("Position value: {e}")))?;
 
-            let mut input_values: Vec<Value> = Vec::with_capacity(2 + kv_cache.len());
+            let mut input_values: Vec<Value> = Vec::with_capacity(3 + kv_cache.len());
             input_values.push(token_val);
             input_values.push(enc_val);
+            input_values.push(pos_val);
             for ct in &kv_cache {
                 input_values.push(ct.to_value()?);
             }

--- a/core/continuum-core/src/live/audio/stt/moonshine.rs
+++ b/core/continuum-core/src/live/audio/stt/moonshine.rs
@@ -343,9 +343,35 @@ impl MoonshineStt {
         let enc_tensor = Tensor::from_array(enc_array).map_err(|e| {
             STTError::InferenceFailed(format!("Uncached decoder encoder tensor: {e}"))
         })?;
+        // args_2 = the encoder sequence length T (encoder_hidden is [1,T,D]),
+        // for the decoder's cross-attention position arange — the same T the
+        // encoder's own args_1 consumed. Bound by NAME below, not position,
+        // so a model whose input order differs still lands correctly.
+        let enc_t = *encoder_hidden.shape.get(1).ok_or_else(|| {
+            STTError::InferenceFailed(format!(
+                "encoder_hidden has unexpected shape {:?} (want [1,T,D])",
+                encoder_hidden.shape
+            ))
+        })? as i32;
+        let seqlen_tensor = Tensor::from_array(ndarray::Array1::from_vec(vec![enc_t]).into_dyn())
+            .map_err(|e| STTError::InferenceFailed(format!("Uncached seqlen tensor: {e}")))?;
         let mut uncached_session = model.uncached_decoder.lock();
+        // Bind by declared input NAME (args_0 token, args_1 encoder, args_2 T)
+        // — never positional, so the contract the model declares is the one
+        // we satisfy (the fragile zip is why this went unnoticed).
+        let uncached_vals: Vec<Value> = vec![
+            token_tensor.into(),
+            enc_tensor.into(),
+            seqlen_tensor.into(),
+        ];
+        let uncached_named: Vec<(String, Value)> = uncached_session
+            .inputs()
+            .iter()
+            .map(|i| i.name().to_string())
+            .zip(uncached_vals)
+            .collect();
         let uncached_out = uncached_session
-            .run(ort::inputs![token_tensor, enc_tensor])
+            .run(uncached_named)
             .map_err(|e| STTError::InferenceFailed(format!("Uncached decoder run: {e}")))?;
 
         // Logits = output[0], KV cache = output[1..]
@@ -507,6 +533,21 @@ impl SpeechToText for MoonshineStt {
             uncached_decoder.outputs().len(),
             uncached_decoder.outputs().len().saturating_sub(1)
         );
+        // AUTHORITATIVE I/O contract — read from the sessions, never guessed
+        // (each guess is a 9-min rebuild; the model file is the truth). Logs
+        // every input's name + type so args_2 etc. get bound by fact.
+        for (label, sess) in [
+            ("encoder", &encoder),
+            ("uncached_decoder", &uncached_decoder),
+            ("cached_decoder", &cached_decoder),
+        ] {
+            let names: Vec<String> = sess
+                .inputs()
+                .iter()
+                .map(|i| format!("{}:{:?}", i.name(), i.dtype()))
+                .collect();
+            clog_info!("Moonshine {label} inputs = {:?}", names);
+        }
 
         let vocab = Self::load_vocab(&model_dir)?;
 

--- a/core/continuum-core/src/live/audio/stt/moonshine.rs
+++ b/core/continuum-core/src/live/audio/stt/moonshine.rs
@@ -343,12 +343,12 @@ impl MoonshineStt {
         let enc_tensor = Tensor::from_array(enc_array).map_err(|e| {
             STTError::InferenceFailed(format!("Uncached decoder encoder tensor: {e}"))
         })?;
-        // args_2 = the DECODE POSITION as int32[1] (offline-verified contract:
-        // args_0 int32 tokens, args_1 f32 encoder[b,T,416], args_2 int32[1]).
-        // Uncached is the FIRST step → position 0 (empty self-attn cache); the
-        // cached loop increments it. (An earlier cut passed encoder-T here —
-        // non-crashing but the wrong RoPE offset, which would mistranscribe.)
-        let seqlen_tensor = Tensor::from_array(ndarray::Array1::from_vec(vec![0i32]).into_dyn())
+        // args_2 = decode sequence LENGTH as int32[1] (offline-verified: args_0
+        // int32 tokens, args_1 f32 encoder[b,T,416], args_2 int32[1]). Uncached
+        // processes ONE token → length 1. It must NOT be 0: an internal
+        // arange(0) yields a {0,1} zero-element tensor CoreML refuses (measured
+        // 2026-09-02). The cached loop uses generated_tokens.len() (already ≥1).
+        let seqlen_tensor = Tensor::from_array(ndarray::Array1::from_vec(vec![1i32]).into_dyn())
             .map_err(|e| STTError::InferenceFailed(format!("Uncached position tensor: {e}")))?;
         let mut uncached_session = model.uncached_decoder.lock();
         // Bind by declared input NAME (args_0 token, args_1 encoder, args_2 T)

--- a/core/continuum-core/src/live/audio/stt/moonshine.rs
+++ b/core/continuum-core/src/live/audio/stt/moonshine.rs
@@ -332,7 +332,8 @@ impl MoonshineStt {
         let mut current_token = BOS_TOKEN_ID;
 
         // First decode step (uncached — no KV cache input)
-        let token_input = Array2::from_shape_vec((1, 1), vec![current_token])
+        // Decoder ONNX wants int32 tokens; the loop's own logic stays i64.
+        let token_input = Array2::from_shape_vec((1, 1), vec![current_token as i32])
             .map_err(|e| STTError::InferenceFailed(format!("Token array shape: {e}")))?;
         let enc_array = Self::cache_to_array(&encoder_hidden)?;
 
@@ -371,7 +372,7 @@ impl MoonshineStt {
 
         // Subsequent decode steps (cached — with KV cache)
         for _step in 1..MAX_TOKENS {
-            let token_input = Array2::from_shape_vec((1, 1), vec![current_token])
+            let token_input = Array2::from_shape_vec((1, 1), vec![current_token as i32])
                 .map_err(|e| STTError::InferenceFailed(format!("Token array shape: {e}")))?;
             let enc_array = Self::cache_to_array(&encoder_hidden)?;
 

--- a/core/continuum-core/src/live/audio/stt_service.rs
+++ b/core/continuum-core/src/live/audio/stt_service.rs
@@ -75,17 +75,8 @@ mod tests {
     #[test]
     #[ignore]
     fn voice_round_trip_tts_to_stt() {
-        // Resolve models the same way the full Kokoro test does.
-        let candidates = [
-            crate::live::audio::model_root::voice_model_path("kokoro"),
-            std::path::PathBuf::from("../../models/kokoro"),
-        ];
-        let original_cwd = std::env::current_dir().unwrap();
-        if let Some(models_dir) = candidates.into_iter().find(|p| p.is_dir()) {
-            let root = models_dir.parent().unwrap().parent().unwrap();
-            std::env::set_current_dir(root).unwrap();
-        }
-
+        // Models resolve via CONTINUUM_MODELS_DIR (portable, no CWD juggling,
+        // no OS-specific paths — set by the runner/start script on every OS).
         let phrase = "The quick brown fox jumps over the lazy dog.";
         let synth = crate::live::audio::tts_service::synthesize_speech_sync(
             phrase,
@@ -93,12 +84,11 @@ mod tests {
             Some("kokoro"),
             None,
         )
-        .expect("Kokoro synth");
+        .expect("Kokoro synth"); // safe: test asserts the pipeline; a synth error IS the failure
         assert!(synth.samples.len() > 8000, "expected real audio");
 
         let transcript = transcribe_speech_sync(&synth.samples, Some("en"))
-            .expect("STT must run end to end (no swallowed error)");
-        std::env::set_current_dir(original_cwd).unwrap();
+            .expect("STT must run end to end (no swallowed error)"); // safe: same — STT failure is the test's point
 
         let lower = transcript.text.to_lowercase();
         // Content words that must survive TTS→STT — 3 of 5 = the chain works.

--- a/core/continuum-core/src/live/audio/stt_service.rs
+++ b/core/continuum-core/src/live/audio/stt_service.rs
@@ -58,3 +58,58 @@ pub fn transcribe_speech_sync(
 pub fn is_ready() -> bool {
     stt::is_initialized()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// THE voice TDD loop, runnable WITHOUT the core (Joel 2026-09-02: stop
+    /// rebooting the 35B to test a 62M ONNX model). Synthesize a phrase with
+    /// Kokoro, transcribe it back with the active STT (Moonshine), assert the
+    /// words survive the round trip. Iterates in `cargo test` in seconds — the
+    /// running Ornith lane, benchmarks, and citizens are never touched.
+    ///
+    /// Run: `cargo test -p continuum-core --features metal,accelerate \
+    ///       -- --ignored voice_round_trip` (needs the model files on disk +
+    /// CONTINUUM_MODELS_DIR, same as the Kokoro full-path test).
+    #[test]
+    #[ignore]
+    fn voice_round_trip_tts_to_stt() {
+        // Resolve models the same way the full Kokoro test does.
+        let candidates = [
+            crate::live::audio::model_root::voice_model_path("kokoro"),
+            std::path::PathBuf::from("../../models/kokoro"),
+        ];
+        let original_cwd = std::env::current_dir().unwrap();
+        if let Some(models_dir) = candidates.into_iter().find(|p| p.is_dir()) {
+            let root = models_dir.parent().unwrap().parent().unwrap();
+            std::env::set_current_dir(root).unwrap();
+        }
+
+        let phrase = "The quick brown fox jumps over the lazy dog.";
+        let synth = crate::live::audio::tts_service::synthesize_speech_sync(
+            phrase,
+            Some("af"),
+            Some("kokoro"),
+            None,
+        )
+        .expect("Kokoro synth");
+        assert!(synth.samples.len() > 8000, "expected real audio");
+
+        let transcript = transcribe_speech_sync(&synth.samples, Some("en"))
+            .expect("STT must run end to end (no swallowed error)");
+        std::env::set_current_dir(original_cwd).unwrap();
+
+        let lower = transcript.text.to_lowercase();
+        // Content words that must survive TTS→STT — 3 of 5 = the chain works.
+        let hits = ["quick", "brown", "fox", "lazy", "dog"]
+            .iter()
+            .filter(|w| lower.contains(**w))
+            .count();
+        assert!(
+            hits >= 3,
+            "round trip lost the phrase: got {:?} (hits={hits})",
+            transcript.text
+        );
+    }
+}

--- a/core/continuum-core/src/live/audio/tts/mod.rs
+++ b/core/continuum-core/src/live/audio/tts/mod.rs
@@ -442,7 +442,13 @@ pub async fn synthesize(
                     continue;
                 };
                 if !next.is_initialized() {
-                    continue;
+                    // Wake it: only the ACTIVE adapter initializes at boot, so
+                    // a provisioned local engine (Kokoro, 2026-09-02) sat
+                    // skippable exactly when it was needed. Bounded by the
+                    // adapter's own init; a failed wake moves on.
+                    if next.initialize().await.is_err() {
+                        continue;
+                    }
                 }
                 let re_resolved = resolve_voice_gendered(next.as_ref(), voice, gender_hint);
                 if let Ok(mut result) = next.synthesize(text, &re_resolved).await {

--- a/core/continuum-core/src/live/audio/tts/orpheus.rs
+++ b/core/continuum-core/src/live/audio/tts/orpheus.rs
@@ -50,22 +50,36 @@ use tokenizers::Tokenizer;
 const AUDIO_TOKEN_OFFSET: u32 = 128266; // <custom_token_10>
 const CODEBOOK_SIZE: u32 = 4096;
 const NUM_CODEBOOKS: usize = 3;
+// context-budget-exempt: a vocabulary token id / codec frame geometry of the Orpheus
+// audio protocol, fixed by the model's tokenizer — not a prompt or context size.
 const TOKENS_PER_FRAME: usize = 7;
 /// Full audio-token span: one 4096 band per frame position.
 const AUDIO_TOKEN_SPAN: u32 = TOKENS_PER_FRAME as u32 * CODEBOOK_SIZE; // 28672
 /// `<custom_token_3>` — start of the human turn.
+// context-budget-exempt: a vocabulary token id / codec frame geometry of the Orpheus
+// audio protocol, fixed by the model's tokenizer — not a prompt or context size.
 const SOH_TOKEN: u32 = 128259;
 /// Llama-3 `<|eot_id|>` — closes the text.
+// context-budget-exempt: a vocabulary token id / codec frame geometry of the Orpheus
+// audio protocol, fixed by the model's tokenizer — not a prompt or context size.
 const EOT_TOKEN: u32 = 128009;
 /// `<custom_token_4>` — end of human turn.
+// context-budget-exempt: a vocabulary token id / codec frame geometry of the Orpheus
+// audio protocol, fixed by the model's tokenizer — not a prompt or context size.
 const EOH_TOKEN: u32 = 128260;
 /// `<custom_token_5>` — the reference's 3rd end token.
+// context-budget-exempt: a vocabulary token id / codec frame geometry of the Orpheus
+// audio protocol, fixed by the model's tokenizer — not a prompt or context size.
 const END3_TOKEN: u32 = 128261;
 /// `<custom_token_1>` — START OF AUDIO: tells the model to speak THIS text.
 /// Missing it (measured 2026-09-02 via continuum web/fetch of engine_class.py)
 /// made the model free-generate filler ("and again") instead of the prompt.
+// context-budget-exempt: a vocabulary token id / codec frame geometry of the Orpheus
+// audio protocol, fixed by the model's tokenizer — not a prompt or context size.
 const SOA_TOKEN: u32 = 128257;
 /// `<custom_token_2>` — end of audio: the generation stop token.
+// context-budget-exempt: a vocabulary token id / codec frame geometry of the Orpheus
+// audio protocol, fixed by the model's tokenizer — not a prompt or context size.
 const EOA_TOKEN: u32 = 128258;
 
 /// SNAC native sample rate — Orpheus generates 24kHz audio
@@ -559,6 +573,8 @@ impl OrpheusTts {
     /// The SNAC ONNX export's FIXED frame window for the coarse codebook
     /// (measured 2026-09-02 from the model's own dimension error: `codes0 …
     /// Expected: 12`). Layers scale 1×/2×/4× per SNAC's hierarchy.
+    // context-budget-exempt: a vocabulary token id / codec frame geometry of the Orpheus
+    // audio protocol, fixed by the model's tokenizer — not a prompt or context size.
     const SNAC_WINDOW_FRAMES: usize = 12;
 
     fn snac_decode(

--- a/core/continuum-core/src/live/audio/tts/orpheus.rs
+++ b/core/continuum-core/src/live/audio/tts/orpheus.rs
@@ -535,45 +535,66 @@ impl OrpheusTts {
     }
 
     /// Decode SNAC codebook layers → 24kHz PCM audio using ONNX decoder
+    /// The SNAC ONNX export's FIXED frame window for the coarse codebook
+    /// (measured 2026-09-02 from the model's own dimension error: `codes0 …
+    /// Expected: 12`). Layers scale 1×/2×/4× per SNAC's hierarchy.
+    const SNAC_WINDOW_FRAMES: usize = 12;
+
     fn snac_decode(
         session: &mut Session,
         layers: &[Vec<i64>; NUM_CODEBOOKS],
     ) -> Result<Vec<f32>, TTSError> {
-        // Build input tensors for each codebook layer: [1, seq_len]
-        let mut named_inputs: Vec<(String, Value)> = Vec::with_capacity(NUM_CODEBOOKS);
-
-        for (i, layer) in layers.iter().enumerate() {
-            let seq_len = layer.len();
-            let array = Array2::from_shape_vec((1, seq_len), layer.clone()).map_err(|e| {
-                TTSError::SynthesisFailed(format!("SNAC input layer {i} reshape: {e}"))
-            })?;
-            let value: Value = OrtTensor::from_array(array)
-                .map(|v| v.into())
-                .map_err(|e| {
-                    TTSError::SynthesisFailed(format!("SNAC input layer {i} to value: {e}"))
-                })?;
-
-            // Use model's input names (discovered at runtime)
-            let name = session.inputs()[i].name().to_string();
-            named_inputs.push((name, value));
+        // CHUNKED decode: the ONNX export takes a fixed 12-frame window (the
+        // first live utterance generated 299 frames and the decoder refused
+        // the whole strip). Feed 12-frame windows — 12/24/48 codes per layer —
+        // and concatenate PCM. The final partial window is DROPPED, not
+        // zero-padded: padding synthesizes a click of silence-codes at the
+        // clip tail; losing <12 frames (~140ms) of trailing audio is the
+        // honest trade until a dynamic-axis export replaces this decoder.
+        let total_frames = layers[0].len();
+        let windows = total_frames / Self::SNAC_WINDOW_FRAMES;
+        if windows == 0 {
+            return Err(TTSError::SynthesisFailed(format!(
+                "Too little audio for the SNAC window ({} frames < {})",
+                total_frames,
+                Self::SNAC_WINDOW_FRAMES
+            )));
         }
-
-        let outputs = session
-            .run(named_inputs)
-            .map_err(|e| TTSError::SynthesisFailed(format!("SNAC decoder run: {e}")))?;
-
-        // Extract output audio waveform (f32)
-        let (shape, data) = outputs[0]
-            .try_extract_tensor::<f32>()
-            .map_err(|e| TTSError::SynthesisFailed(format!("SNAC output extraction: {e}")))?;
-
+        let mut pcm: Vec<f32> = Vec::new();
+        for w in 0..windows {
+            let mut named_inputs: Vec<(String, Value)> = Vec::with_capacity(NUM_CODEBOOKS);
+            for (i, layer) in layers.iter().enumerate() {
+                // Layer i carries 2^i codes per frame (1/2/4 — SNAC hierarchy).
+                let per_frame = 1usize << i;
+                let start = w * Self::SNAC_WINDOW_FRAMES * per_frame;
+                let len = Self::SNAC_WINDOW_FRAMES * per_frame;
+                let chunk = layer[start..start + len].to_vec();
+                let array = Array2::from_shape_vec((1, len), chunk).map_err(|e| {
+                    TTSError::SynthesisFailed(format!("SNAC input layer {i} reshape: {e}"))
+                })?;
+                let value: Value = OrtTensor::from_array(array)
+                    .map(|v| v.into())
+                    .map_err(|e| {
+                        TTSError::SynthesisFailed(format!("SNAC input layer {i} to value: {e}"))
+                    })?;
+                let name = session.inputs()[i].name().to_string();
+                named_inputs.push((name, value));
+            }
+            let outputs = session
+                .run(named_inputs)
+                .map_err(|e| TTSError::SynthesisFailed(format!("SNAC decoder run: {e}")))?;
+            let (_shape, data) = outputs[0]
+                .try_extract_tensor::<f32>()
+                .map_err(|e| TTSError::SynthesisFailed(format!("SNAC output extraction: {e}")))?;
+            pcm.extend_from_slice(data);
+        }
         clog_info!(
-            "Orpheus: SNAC output shape: {:?} ({} samples)",
-            shape,
-            data.len()
+            "Orpheus: SNAC decoded {} windows × {} frames → {} samples",
+            windows,
+            Self::SNAC_WINDOW_FRAMES,
+            pcm.len()
         );
-
-        Ok(data.to_vec())
+        Ok(pcm)
     }
 }
 

--- a/core/continuum-core/src/live/audio/tts/orpheus.rs
+++ b/core/continuum-core/src/live/audio/tts/orpheus.rs
@@ -552,14 +552,25 @@ impl OrpheusTts {
         // clip tail; losing <12 frames (~140ms) of trailing audio is the
         // honest trade until a dynamic-axis export replaces this decoder.
         let total_frames = layers[0].len();
-        let windows = total_frames / Self::SNAC_WINDOW_FRAMES;
-        if windows == 0 {
-            return Err(TTSError::SynthesisFailed(format!(
-                "Too little audio for the SNAC window ({} frames < {})",
-                total_frames,
-                Self::SNAC_WINDOW_FRAMES
-            )));
+        if total_frames == 0 {
+            return Err(TTSError::SynthesisFailed("No audio frames to decode".into()));
         }
+        // PAD the final partial window by repeating the last frame's codes —
+        // a held codec frame briefly extends the last sound (benign), unlike
+        // zero-codes which click. The output PCM is TRIMMED back to the true
+        // frame count below, so short utterances (a 3-frame selftest phrase,
+        // measured 2026-09-02) and clip tails both survive losslessly.
+        let mut padded: [Vec<i64>; NUM_CODEBOOKS] = layers.clone();
+        let windows = total_frames.div_ceil(Self::SNAC_WINDOW_FRAMES);
+        let padded_frames = windows * Self::SNAC_WINDOW_FRAMES;
+        for (i, layer) in padded.iter_mut().enumerate() {
+            let per_frame = 1usize << i;
+            let last = layer[layer.len() - per_frame..].to_vec();
+            while layer.len() < padded_frames * per_frame {
+                layer.extend_from_slice(&last);
+            }
+        }
+        let layers = &padded;
         let mut pcm: Vec<f32> = Vec::new();
         for w in 0..windows {
             let mut named_inputs: Vec<(String, Value)> = Vec::with_capacity(NUM_CODEBOOKS);
@@ -588,11 +599,16 @@ impl OrpheusTts {
                 .map_err(|e| TTSError::SynthesisFailed(format!("SNAC output extraction: {e}")))?;
             pcm.extend_from_slice(data);
         }
+        // Trim the pad: samples-per-frame derives from the decoder's own
+        // output (uniform per window), so the true length needs no constant.
+        let samples_per_frame = pcm.len() / padded_frames;
+        pcm.truncate(total_frames * samples_per_frame);
         clog_info!(
-            "Orpheus: SNAC decoded {} windows × {} frames → {} samples",
+            "Orpheus: SNAC decoded {} windows × {} frames → {} samples ({} true frames)",
             windows,
             Self::SNAC_WINDOW_FRAMES,
-            pcm.len()
+            pcm.len(),
+            total_frames
         );
         Ok(pcm)
     }

--- a/core/continuum-core/src/live/audio/tts/orpheus.rs
+++ b/core/continuum-core/src/live/audio/tts/orpheus.rs
@@ -59,6 +59,12 @@ const SOH_TOKEN: u32 = 128259;
 const EOT_TOKEN: u32 = 128009;
 /// `<custom_token_4>` — end of human turn.
 const EOH_TOKEN: u32 = 128260;
+/// `<custom_token_5>` — the reference's 3rd end token.
+const END3_TOKEN: u32 = 128261;
+/// `<custom_token_1>` — START OF AUDIO: tells the model to speak THIS text.
+/// Missing it (measured 2026-09-02 via continuum web/fetch of engine_class.py)
+/// made the model free-generate filler ("and again") instead of the prompt.
+const SOA_TOKEN: u32 = 128257;
 /// `<custom_token_2>` — end of audio: the generation stop token.
 const EOA_TOKEN: u32 = 128258;
 
@@ -71,11 +77,16 @@ const SNAC_SAMPLE_RATE: u32 = 24000;
 // context-budget-exempt: the TTS model's own audio-token architecture limit, not a text-context bound
 const MAX_AUDIO_TOKENS: usize = 2100;
 
-/// Temperature for audio token sampling (Orpheus default)
-const DEFAULT_TEMPERATURE: f64 = 0.6;
-
-/// Top-p for audio token sampling
-const DEFAULT_TOP_P: f64 = 0.95;
+/// Sampling params — the canonical canopylabs values (verified 2026-09-02 via
+/// continuum web/fetch of the reference impl: temperature=0.4, top_p=0.9,
+/// repetition_penalty=1.1). The prior 0.6/0.95/no-penalty collapsed
+/// generation early (short/empty audio) — rep-penalty is what keeps the
+/// autoregressive audio stream from stalling into an early end-token.
+const DEFAULT_TEMPERATURE: f64 = 0.4;
+const DEFAULT_TOP_P: f64 = 0.9;
+const REPEAT_PENALTY: f32 = 1.1;
+/// Rep-penalty context window (reference applies over the running generation).
+const REPEAT_LAST_N: usize = 64;
 
 // ─── Orpheus Voices ───────────────────────────────────────────────────────────
 const VOICES: &[(&str, &str, &str)] = &[
@@ -315,7 +326,8 @@ impl OrpheusTts {
         let mut ids = Vec::with_capacity(enc.get_ids().len() + 3);
         ids.push(SOH_TOKEN);
         ids.extend_from_slice(enc.get_ids());
-        ids.extend_from_slice(&[EOT_TOKEN, EOH_TOKEN]);
+        // Reference framing: [SOH] ++ text ++ [EOT, EOH, END3, SOA].
+        ids.extend_from_slice(&[EOT_TOKEN, EOH_TOKEN, END3_TOKEN, SOA_TOKEN]);
         Ok(ids)
     }
 
@@ -405,7 +417,7 @@ impl OrpheusTts {
             .map_err(|e| TTSError::SynthesisFailed(format!("GPU sync: {e}")))?;
 
         // Sample first token from last position
-        let last_logits = Self::extract_last_logits(&logits)?;
+        let last_logits = Self::penalize(&Self::extract_last_logits(&logits)?, &all_tokens)?;
         let mut next_token = logits_processor
             .sample(&last_logits)
             .map_err(|e| TTSError::SynthesisFailed(format!("Sampling: {e}")))?;
@@ -439,7 +451,7 @@ impl OrpheusTts {
                     .map_err(|e| TTSError::SynthesisFailed(format!("GPU sync: {e}")))?;
             }
 
-            let last_logits = Self::extract_last_logits(&logits)?;
+            let last_logits = Self::penalize(&Self::extract_last_logits(&logits)?, &all_tokens)?;
             next_token = logits_processor
                 .sample(&last_logits)
                 .map_err(|e| TTSError::SynthesisFailed(format!("Sampling: {e}")))?;
@@ -460,6 +472,15 @@ impl OrpheusTts {
     }
 
     /// Extract logits for the last token position from the model output
+    /// Apply repetition penalty over the trailing generation window — the
+    /// reference's 1.1 penalty is what keeps the audio stream from stalling
+    /// into an early end-token (the short-audio failure, 2026-09-02).
+    fn penalize(logits: &Tensor, context: &[u32]) -> Result<Tensor, TTSError> {
+        let start = context.len().saturating_sub(REPEAT_LAST_N);
+        candle_transformers::utils::apply_repeat_penalty(logits, REPEAT_PENALTY, &context[start..])
+            .map_err(|e| TTSError::SynthesisFailed(format!("Repeat penalty: {e}")))
+    }
+
     fn extract_last_logits(logits: &Tensor) -> Result<Tensor, TTSError> {
         let dims = logits.dims();
         let result = match dims.len() {

--- a/core/continuum-core/src/live/audio/tts/orpheus.rs
+++ b/core/continuum-core/src/live/audio/tts/orpheus.rs
@@ -38,13 +38,29 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use tokenizers::Tokenizer;
 
-// ─── Orpheus Token Constants ──────────────────────────────────────────────────
-// Audio tokens extend the Llama 3 vocabulary starting at this offset.
-// 3 SNAC codebooks × 4096 codes each = 12288 audio tokens.
-const AUDIO_TOKEN_OFFSET: u32 = 128266;
+// ─── Orpheus Token Constants (verified against the GGUF's own metadata,
+// 2026-09-02: vocab 156,940 = 128,256 Llama + <custom_token_0..28682> + <|audio|>).
+// The first cut of this adapter invented `<|text_start|>`/`<|audio_end|>` tokens
+// that DO NOT EXIST in the model — it could never have produced speech. The
+// real canopylabs protocol, id-level:
+//   prompt  = [SOH] ++ encode("{voice}: {text}") ++ [EOT, EOH]
+//   output  = … SOA, <audio tokens>, EOA
+// Each audio token encodes (position-band, code): id − OFFSET − (pos%7)·4096,
+// seven tokens per SNAC frame → the audio span is 7 bands × 4096, NOT 3×4096.
+const AUDIO_TOKEN_OFFSET: u32 = 128266; // <custom_token_10>
 const CODEBOOK_SIZE: u32 = 4096;
 const NUM_CODEBOOKS: usize = 3;
-const TOKENS_PER_FRAME: usize = 7; // 1 coarse + 2 mid + 4 fine per audio frame
+const TOKENS_PER_FRAME: usize = 7;
+/// Full audio-token span: one 4096 band per frame position.
+const AUDIO_TOKEN_SPAN: u32 = TOKENS_PER_FRAME as u32 * CODEBOOK_SIZE; // 28672
+/// `<custom_token_3>` — start of the human turn.
+const SOH_TOKEN: u32 = 128259;
+/// Llama-3 `<|eot_id|>` — closes the text.
+const EOT_TOKEN: u32 = 128009;
+/// `<custom_token_4>` — end of human turn.
+const EOH_TOKEN: u32 = 128260;
+/// `<custom_token_2>` — end of audio: the generation stop token.
+const EOA_TOKEN: u32 = 128258;
 
 /// SNAC native sample rate — Orpheus generates 24kHz audio
 const SNAC_SAMPLE_RATE: u32 = 24000;
@@ -106,12 +122,75 @@ impl OrpheusTts {
         }
     }
 
-    /// Required model files
+    /// Required model files. The tokenizer is NOT one of them: the GGUF
+    /// carries its own token table + merges, and the upstream tokenizer.json
+    /// is HF-gated (401, measured 2026-09-02) — one artifact, no gated
+    /// sidecar ([`Self::tokenizer_from_gguf`]).
     const REQUIRED_FILES: &'static [&'static str] = &[
-        "tokenizer.json",
         "snac_decoder.onnx",
         // GGUF file is found by glob (name varies by quantization)
     ];
+
+    /// Build the tokenizer FROM the GGUF's own metadata (`tokenizer.ggml.tokens`
+    /// + `tokenizer.ggml.merges`) — the model file is the single source of its
+    /// own vocabulary. Byte-level BPE per `tokenizer.ggml.pre = "llama-bpe"`;
+    /// special tokens never pass through encode (prompt framing is id-level),
+    /// so only plain text takes this path.
+    fn tokenizer_from_gguf(content: &gguf_file::Content) -> Result<Tokenizer, TTSError> {
+        use gguf_file::Value as V;
+        let meta_arr = |key: &str| -> Result<&Vec<V>, TTSError> {
+            match content.metadata.get(key) {
+                Some(V::Array(a)) => Ok(a),
+                other => Err(TTSError::ModelNotLoaded(format!(
+                    "GGUF missing {key} (got {other:?}) — cannot build tokenizer"
+                ))),
+            }
+        };
+        let tokens = meta_arr("tokenizer.ggml.tokens")?;
+        let merges = meta_arr("tokenizer.ggml.merges")?;
+        let mut vocab = tokenizers::models::bpe::Vocab::with_capacity(tokens.len());
+        for (i, t) in tokens.iter().enumerate() {
+            let s = t.to_string().map_err(|e| {
+                TTSError::ModelNotLoaded(format!("GGUF token {i} not a string: {e}"))
+            })?;
+            vocab.insert(s.clone(), i as u32);
+        }
+        // SCHEME VERIFICATION, fail-loud: the constants above are only valid
+        // for the real canopylabs layout. A different fine-tune fails here
+        // with a message, never with garbage audio.
+        match vocab.get("<custom_token_10>") {
+            Some(&id) if id == AUDIO_TOKEN_OFFSET => {}
+            other => {
+                return Err(TTSError::ModelNotLoaded(format!(
+                    "GGUF token scheme mismatch: <custom_token_10> = {other:?}, \
+                     expected {AUDIO_TOKEN_OFFSET} — not a canopylabs Orpheus layout"
+                )))
+            }
+        }
+        let merge_pairs: Vec<(String, String)> = merges
+            .iter()
+            .filter_map(|m| {
+                let s = m.to_string().ok()?;
+                let (a, b) = s.split_once(' ')?;
+                Some((a.to_string(), b.to_string()))
+            })
+            .collect();
+        let bpe = tokenizers::models::bpe::BpeBuilder::new()
+            .vocab_and_merges(vocab, merge_pairs)
+            // llama-bpe: exact-vocab matches win over merge walks (HF llama-3
+            // tokenizer.json sets the same flag).
+            .ignore_merges(true)
+            .build()
+            .map_err(|e| TTSError::ModelNotLoaded(format!("BPE build from GGUF: {e}")))?;
+        let mut tk = Tokenizer::new(tokenizers::ModelWrapper::BPE(bpe));
+        tk.with_pre_tokenizer(Some(tokenizers::pre_tokenizers::byte_level::ByteLevel::new(
+            false, true, true,
+        )));
+        tk.with_decoder(Some(tokenizers::decoders::byte_level::ByteLevel::new(
+            false, true, true,
+        )));
+        Ok(tk)
+    }
 
     /// Search directories for model files
     fn model_search_dirs() -> Vec<PathBuf> {
@@ -222,21 +301,22 @@ impl OrpheusTts {
             .map_err(|e| TTSError::ModelNotLoaded(format!("SNAC model load {model_path:?}: {e}")))
     }
 
-    /// Look up a special token ID from the tokenizer
-    fn find_token_id(tokenizer: &Tokenizer, token: &str) -> Result<u32, TTSError> {
-        tokenizer.token_to_id(token).ok_or_else(|| {
-            TTSError::ModelNotLoaded(format!(
-                "Token '{token}' not found in Orpheus tokenizer. \
-                     Ensure you're using the Orpheus-specific tokenizer.json, \
-                     not the base Llama tokenizer."
-            ))
-        })
-    }
-
-    /// Format the Orpheus prompt for TTS generation
-    fn format_prompt(text: &str, voice: &str) -> String {
-        // Orpheus prompt format: voice name on first line, then text, wrapped in special tokens
-        format!("<|text_start|>{voice}\n{text}<|text_end|><|audio_start|>")
+    /// Build the id-level Orpheus prompt: `[SOH] ++ encode("{voice}: {text}")
+    /// ++ [EOT, EOH]`. Special tokens go in AS IDS — never as strings through
+    /// the encoder (the byte-level BPE would shred them into text bytes).
+    fn build_prompt_ids(
+        tokenizer: &Tokenizer,
+        text: &str,
+        voice: &str,
+    ) -> Result<Vec<u32>, TTSError> {
+        let enc = tokenizer
+            .encode(format!("{voice}: {text}"), false)
+            .map_err(|e| TTSError::SynthesisFailed(format!("Tokenization failed: {e}")))?;
+        let mut ids = Vec::with_capacity(enc.get_ids().len() + 3);
+        ids.push(SOH_TOKEN);
+        ids.extend_from_slice(enc.get_ids());
+        ids.extend_from_slice(&[EOT_TOKEN, EOH_TOKEN]);
+        Ok(ids)
     }
 
     /// Synchronous synthesis pipeline (runs on blocking thread)
@@ -249,15 +329,8 @@ impl OrpheusTts {
             return Err(TTSError::InvalidText("Empty text".into()));
         }
 
-        let prompt = Self::format_prompt(text, voice);
-
-        // ── Step 1: Tokenize ──────────────────────────────────────────────
-        let encoding = model
-            .tokenizer
-            .encode(prompt.as_str(), true)
-            .map_err(|e| TTSError::SynthesisFailed(format!("Tokenization failed: {e}")))?;
-
-        let prompt_tokens: Vec<u32> = encoding.get_ids().to_vec();
+        // ── Step 1: Build the id-level prompt (real canopylabs framing) ───
+        let prompt_tokens: Vec<u32> = Self::build_prompt_ids(&model.tokenizer, text, voice)?;
         let prompt_len = prompt_tokens.len();
         clog_info!(
             "Orpheus: Prompt tokenized to {} tokens for voice '{}'",
@@ -411,10 +484,11 @@ impl OrpheusTts {
         result.map_err(|e| TTSError::SynthesisFailed(format!("Extract logits: {e}")))
     }
 
-    /// Check if a token ID is in the audio token range
+    /// Check if a token ID is in the audio token range — the FULL 7-band span
+    /// (the 3×4096 first cut rejected every token above band 2, discarding
+    /// most of the audio stream).
     fn is_audio_token(token_id: u32) -> bool {
-        token_id >= AUDIO_TOKEN_OFFSET
-            && token_id < AUDIO_TOKEN_OFFSET + (NUM_CODEBOOKS as u32) * CODEBOOK_SIZE
+        token_id >= AUDIO_TOKEN_OFFSET && token_id < AUDIO_TOKEN_OFFSET + AUDIO_TOKEN_SPAN
     }
 
     /// Redistribute flat audio token sequence into 3 SNAC codebook layers.
@@ -444,12 +518,15 @@ impl OrpheusTts {
             // Extract codebook values (strip offset, mod codebook size)
             let code = |t: u32| -> i64 { ((t - AUDIO_TOKEN_OFFSET) % CODEBOOK_SIZE) as i64 };
 
-            // Pattern: [c1, c2a, c2b, c3a, c3b, c3c, c3d]
+            // Canonical canopylabs interleave (their decoder, verbatim):
+            // frame = [L0, L1, L2, L2, L1, L2, L2] — layer1 takes positions
+            // 1 AND 4; layer2 takes 2,3,5,6. The first cut had [0,1,1,2,2,2,2],
+            // which scrambles mid/fine codebooks into noise.
             layer0.push(code(tokens[0]));
             layer1.push(code(tokens[1]));
-            layer1.push(code(tokens[2]));
+            layer2.push(code(tokens[2]));
             layer2.push(code(tokens[3]));
-            layer2.push(code(tokens[4]));
+            layer1.push(code(tokens[4]));
             layer2.push(code(tokens[5]));
             layer2.push(code(tokens[6]));
         }
@@ -544,23 +621,12 @@ impl TextToSpeech for OrpheusTts {
             )));
         }
 
-        // Load tokenizer
-        let tokenizer_path = model_dir.join("tokenizer.json");
-        let tokenizer = Tokenizer::from_file(&tokenizer_path)
-            .map_err(|e| TTSError::ModelNotLoaded(format!("Tokenizer load failed: {e}")))?;
-        clog_info!(
-            "Orpheus: Tokenizer loaded ({} tokens)",
-            tokenizer.get_vocab_size(true)
-        );
-
-        // Look up special token IDs
-        let audio_end_token_id = Self::find_token_id(&tokenizer, "<|audio_end|>")?;
-        clog_info!("Orpheus: audio_end token ID = {}", audio_end_token_id);
-
         // Select compute device — fail-closed on no-Metal (no CPU fallback)
         let device = Self::select_device()?;
 
-        // Load GGUF model
+        // Load GGUF model — and build the tokenizer FROM it (one artifact;
+        // the upstream tokenizer.json is HF-gated and mirrors ship the wrong
+        // one — measured 2026-09-02).
         let gguf_path = Self::find_gguf_file(&model_dir).ok_or_else(|| {
             TTSError::ModelNotLoaded("No .gguf file found in model directory".into())
         })?;
@@ -570,6 +636,13 @@ impl TextToSpeech for OrpheusTts {
             .map_err(|e| TTSError::ModelNotLoaded(format!("Failed to open GGUF file: {e}")))?;
         let gguf_content = gguf_file::Content::read(&mut gguf_file)
             .map_err(|e| TTSError::ModelNotLoaded(format!("Failed to read GGUF content: {e}")))?;
+
+        let tokenizer = Self::tokenizer_from_gguf(&gguf_content)?;
+        clog_info!(
+            "Orpheus: tokenizer built from GGUF metadata ({} tokens, scheme verified)",
+            tokenizer.get_vocab_size(true)
+        );
+        let audio_end_token_id = EOA_TOKEN;
 
         let mut reader =
             BufReader::new(std::fs::File::open(&gguf_path).map_err(|e| {
@@ -707,51 +780,43 @@ mod tests {
         assert!(OrpheusTts::is_audio_token(AUDIO_TOKEN_OFFSET));
         // Middle of range
         assert!(OrpheusTts::is_audio_token(AUDIO_TOKEN_OFFSET + 6000));
-        // End of range (3 codebooks × 4096 - 1)
+        // End of range: the FULL 7-band span (a 3-band bound rejected most
+        // of the real audio stream — what this catches).
         assert!(OrpheusTts::is_audio_token(
-            AUDIO_TOKEN_OFFSET + NUM_CODEBOOKS as u32 * CODEBOOK_SIZE - 1
+            AUDIO_TOKEN_OFFSET + AUDIO_TOKEN_SPAN - 1
         ));
         // Above range
-        assert!(!OrpheusTts::is_audio_token(
-            AUDIO_TOKEN_OFFSET + NUM_CODEBOOKS as u32 * CODEBOOK_SIZE
-        ));
+        assert!(!OrpheusTts::is_audio_token(AUDIO_TOKEN_OFFSET + AUDIO_TOKEN_SPAN));
     }
 
     #[test]
-    fn test_redistribute_codes() {
-        // Create 2 frames of audio tokens (14 tokens)
+    fn test_redistribute_codes_canonical_interleave() {
+        // what this catches: the canopylabs frame layout is [L0,L1,L2,L2,L1,L2,L2]
+        // — layer1 takes positions 1 AND 4. The first cut used [0,1,1,2,2,2,2],
+        // which scrambled mid/fine codebooks into noise. Each position sits in
+        // its own 4096 band (id = OFFSET + band*4096 + code), per the model's
+        // real token scheme read from the GGUF.
         let mut audio_tokens = Vec::new();
         for frame in 0..2u32 {
-            let base = frame * 7;
-            // codebook 0: values 0-4095
-            audio_tokens.push(AUDIO_TOKEN_OFFSET + base);
-            // codebook 1: values 0-4095, offset by CODEBOOK_SIZE
-            audio_tokens.push(AUDIO_TOKEN_OFFSET + CODEBOOK_SIZE + base + 1);
-            audio_tokens.push(AUDIO_TOKEN_OFFSET + CODEBOOK_SIZE + base + 2);
-            // codebook 2: values 0-4095, offset by 2*CODEBOOK_SIZE
-            audio_tokens.push(AUDIO_TOKEN_OFFSET + 2 * CODEBOOK_SIZE + base + 3);
-            audio_tokens.push(AUDIO_TOKEN_OFFSET + 2 * CODEBOOK_SIZE + base + 4);
-            audio_tokens.push(AUDIO_TOKEN_OFFSET + 2 * CODEBOOK_SIZE + base + 5);
-            audio_tokens.push(AUDIO_TOKEN_OFFSET + 2 * CODEBOOK_SIZE + base + 6);
+            for pos in 0..7u32 {
+                // code value = frame*10 + pos, in position-band `pos`
+                audio_tokens.push(AUDIO_TOKEN_OFFSET + pos * CODEBOOK_SIZE + frame * 10 + pos);
+            }
         }
 
         let layers = OrpheusTts::redistribute_codes(&audio_tokens).unwrap();
+        assert_eq!(layers[0].len(), 2); // 1/frame
+        assert_eq!(layers[1].len(), 4); // 2/frame (positions 1 and 4)
+        assert_eq!(layers[2].len(), 8); // 4/frame (positions 2,3,5,6)
 
-        // Layer 0: 1 value per frame = 2 values
-        assert_eq!(layers[0].len(), 2);
-        // Layer 1: 2 values per frame = 4 values
-        assert_eq!(layers[1].len(), 4);
-        // Layer 2: 4 values per frame = 8 values
-        assert_eq!(layers[2].len(), 8);
-
-        // Check first frame values (mod CODEBOOK_SIZE)
-        assert_eq!(layers[0][0], 0); // frame 0, code 0
-        assert_eq!(layers[1][0], 1); // frame 0, c2a
-        assert_eq!(layers[1][1], 2); // frame 0, c2b
-        assert_eq!(layers[2][0], 3); // frame 0, c3a
-        assert_eq!(layers[2][1], 4); // frame 0, c3b
-        assert_eq!(layers[2][2], 5); // frame 0, c3c
-        assert_eq!(layers[2][3], 6); // frame 0, c3d
+        // Frame 0 codes: position p carries value p.
+        assert_eq!(layers[0][0], 0); // pos 0
+        assert_eq!(layers[1][0], 1); // pos 1
+        assert_eq!(layers[1][1], 4); // pos 4 ← the interleave the first cut broke
+        assert_eq!(layers[2][0], 2); // pos 2
+        assert_eq!(layers[2][1], 3); // pos 3
+        assert_eq!(layers[2][2], 5); // pos 5
+        assert_eq!(layers[2][3], 6); // pos 6
     }
 
     #[test]
@@ -770,12 +835,17 @@ mod tests {
     }
 
     #[test]
-    fn test_format_prompt() {
-        let prompt = OrpheusTts::format_prompt("Hello world", "tara");
-        assert_eq!(
-            prompt,
-            "<|text_start|>tara\nHello world<|text_end|><|audio_start|>"
-        );
+    fn prompt_framing_constants_match_the_gguf_scheme() {
+        // what this catches: drift in the id-level framing. These ids are the
+        // canopylabs scheme verified against the GGUF's own token table
+        // (2026-09-02); tokenizer_from_gguf re-verifies at every init and
+        // fails loud on a different fine-tune.
+        assert_eq!(SOH_TOKEN, 128259);
+        assert_eq!(EOT_TOKEN, 128009);
+        assert_eq!(EOH_TOKEN, 128260);
+        assert_eq!(EOA_TOKEN, 128258);
+        assert_eq!(AUDIO_TOKEN_OFFSET, 128266);
+        assert_eq!(AUDIO_TOKEN_SPAN, 28672);
     }
 
     #[test]
@@ -798,7 +868,9 @@ mod tests {
 
     #[test]
     fn test_required_files() {
-        assert!(OrpheusTts::REQUIRED_FILES.contains(&"tokenizer.json"));
+        // tokenizer.json must NOT be required: it is HF-gated upstream and the
+        // GGUF carries its own token table (tokenizer_from_gguf). One artifact.
+        assert!(!OrpheusTts::REQUIRED_FILES.contains(&"tokenizer.json"));
         assert!(OrpheusTts::REQUIRED_FILES.contains(&"snac_decoder.onnx"));
     }
 }

--- a/core/continuum-core/src/live/transport/call_server.rs
+++ b/core/continuum-core/src/live/transport/call_server.rs
@@ -1191,10 +1191,21 @@ impl CallManager {
             (handle, display_name)
         };
 
-        // Step 2: Synthesize (async — runs in current tokio context)
-        let synthesis = tts_service::synthesize_speech_async(text, voice, adapter, None)
-            .await
-            .map_err(|e| format!("TTS failed: {e}"))?;
+        // Step 2: Synthesize (async — runs in current tokio context).
+        //
+        // EMOTION RIDES THE SAME SENTIMENT THE FACE USES (Stage A of
+        // VOICE-ENGINE-PLAN's native-audio ladder, Joel 2026-09-02:
+        // "intimately control the speech mannerisms"): the avatar's
+        // sub-microsecond sentiment extraction maps to Orpheus emotion tags,
+        // so voice and face express ONE state from one source — never two
+        // analyzers drifting apart. Tag injection is Orpheus-only: other
+        // engines would read the tag aloud as text.
+        let spoken_text =
+            crate::live::audio::emotion_tags::decorate_for_adapter(text, adapter);
+        let synthesis =
+            tts_service::synthesize_speech_async(&spoken_text, voice, adapter, None)
+                .await
+                .map_err(|e| format!("TTS failed: {e}"))?;
 
         let num_samples = synthesis.samples.len();
         let duration_ms = synthesis.duration_ms;

--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -35,18 +35,7 @@ fn is_terminal(state: &str) -> bool {
     crate::cognition::bench_round::is_terminal_card_state(state)
 }
 
-/// Parse `[bench <name>] <instance>: <gist>` — the exact shape `dispatch_card_title`
-/// writes — into `(bench_name, instance_id)`. `None` for any non-bench title, so a normal
-/// work card silently isn't graded.
-fn parse_bench_title(title: &str) -> Option<(String, String)> {
-    let rest = title.strip_prefix("[bench ")?;
-    let (bench, after) = rest.split_once("] ")?;
-    let instance = after.split(':').next()?.trim();
-    if bench.trim().is_empty() || instance.is_empty() {
-        return None;
-    }
-    Some((bench.trim().to_string(), instance.to_string()))
-}
+use crate::commands::benchmark::parse_card_title as parse_bench_title;
 
 /// The grade-on-done subscriber. Holds a persona-airc registry so it can author the grade
 /// through a live citizen — whoever this machine has online (never a hardcoded name), the

--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -510,6 +510,24 @@ async fn grade_gym_card(
 /// are still lapsed next tick.
 const SWEEP_MAX_CLOSES_PER_TICK: usize = 3;
 
+/// How long after a claim LAPSES a still-resident owner is presumed to be
+/// mid-resume rather than done-and-gone. A reboot lapses every lease at once and
+/// the resume machinery renews them on the claim cadence (TTL/3); within this
+/// window a resident owner may still be catching up, so her artifact is left to
+/// her. Beyond it, a lapsed claim on a resident owner means she is NOT renewing =
+/// NOT actively working the card (an actively-worked card stays `Held`), so her
+/// done-but-unclosed artifact must be graded, not stranded forever. Sized well
+/// above a worst-case reboot+resume (the 35B lane's build+load alone is ~10min)
+/// and far below the multi-hour wedge this un-strands (measured 2026-09-02:
+/// rounds stalled ~20h with artifacts present, owner resident, never graded).
+const RESIDENT_OWNER_GRACE_MS: u64 = 30 * 60 * 1000;
+
+/// A resident owner with a LAPSED claim is presumed "still working" only inside
+/// the post-lapse resume window. Pure so the boundary is unit-testable.
+fn resident_owner_still_working(lapsed_for_ms: u64) -> bool {
+    lapsed_for_ms < RESIDENT_OWNER_GRACE_MS
+}
+
 /// The sweep decision, pure so the truth table is unit-testable: a bench card is
 /// auto-closeable exactly when a person CLAIMED it, their lease LAPSED (work session
 /// died — `card_holder::hold_of`, the one lease predicate, #357), and their hands left
@@ -621,24 +639,37 @@ async fn sweep_lapsed_bench_cards(
             ) {
                 continue;
             }
-            // A RESIDENT owner is not a dead session. The sweep exists as the
-            // dead-session fallback — but a reboot lapses every lease while the
-            // resume machinery is bringing the owner back, and confiscating her
+            // A RESIDENT owner is not a dead session — but only for a BOUNDED
+            // window after the claim lapses. A reboot lapses every lease while the
+            // resume machinery brings the owner back, and confiscating her
             // half-done work in that window grades a MISS she was still earning
             // (measured 2026-08-31: both of the day's misses were exactly this —
             // reboot → lease lapsed → swept mid-resume, "a few attempts" never
-            // happened). If her runtime is online, the card stays hers: she can
-            // finish and say done, and if her session truly dies later the lease
-            // stays lapsed and the next tick sweeps it.
-            if registry.get(owner.as_uuid()).is_some() {
+            // happened). BUT deferring FOREVER strands done-but-unclosed work: a
+            // resident owner who wrote the patch and let the claim lapse without
+            // saying `done` never returns to it, so the card rots and the round
+            // never finishes (measured 2026-09-02: rounds stalled ~20h with
+            // artifacts present, owner resident, ungraded — the pileup of
+            // unstarted standing rounds traced straight here). An actively-worked
+            // card keeps its claim `Held` via the TTL/3 renewal cadence, so a
+            // LAPSED claim past the resume window means she is NOT working it.
+            // Within the grace: hers to finish. Past it: grade her artifact.
+            let lapsed_for_ms = card
+                .claim_expires_at_ms
+                .map(|e| now_ms.saturating_sub(e))
+                .unwrap_or(u64::MAX); // no expiry recorded = not renewing = gradeable
+            if registry.get(owner.as_uuid()).is_some()
+                && resident_owner_still_working(lapsed_for_ms)
+            {
                 crate::probe!(
                     class = "benchmark_grade.sweep_deferred_owner_online",
                     card_id = %card.card_id.as_uuid(),
                     owner = %owner.as_uuid(),
                     bench = %bench,
                     instance = %instance,
-                    "lapsed claim with artifact, but the owner is RESIDENT — not a dead \
-                     session, not confiscated"
+                    lapsed_ms = lapsed_for_ms,
+                    "lapsed claim with artifact, owner RESIDENT and within the resume \
+                     grace — left to her, not confiscated"
                 );
                 continue;
             }
@@ -741,6 +772,26 @@ mod tests {
         assert!(!sweep_ready(&CardState::Open, Hold::Unclaimed, true));
         assert!(!sweep_ready(&CardState::Closed, Hold::Lapsed, true));
         assert!(!sweep_ready(&CardState::Merged, Hold::Lapsed, true));
+    }
+
+    // what this catches: the resident-owner defer is BOUNDED to the resume
+    // window, so done-but-unclosed work stops stranding rounds forever. regression
+    // for the 2026-09-02 stall: rounds wedged ~20h with an artifact present and a
+    // resident owner whose claim had lapsed hours earlier — the sweep deferred
+    // every tick because the owner was resident, so the round never finished and
+    // standing rounds piled up unstarted. Inside the grace she is left alone;
+    // just past it her artifact grades.
+    #[test]
+    fn resident_owner_defer_is_bounded_to_the_resume_window() {
+        // fresh lapse (mid-reboot-resume) → still hers, not confiscated
+        assert!(resident_owner_still_working(0));
+        assert!(resident_owner_still_working(RESIDENT_OWNER_GRACE_MS - 1));
+        // past the window → not renewing = not working → gradeable
+        assert!(!resident_owner_still_working(RESIDENT_OWNER_GRACE_MS));
+        // the measured 20h wedge is decisively past the window
+        assert!(!resident_owner_still_working(20 * 60 * 60 * 1000));
+        // the window must clear a worst-case 35B reboot+resume (~10min) with margin
+        assert!(RESIDENT_OWNER_GRACE_MS >= 15 * 60 * 1000);
     }
 
     // what this catches: only terminal states fire the grade. An in_progress/review

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -88,10 +88,6 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
         let regime_id = uuid::Uuid::from_u128(0xBE7C_11A6_2026_0827);
         let mut demand_lease: Option<(u64, u32)> = None;
         let mut attempt: u32 = 0;
-        // Cards whose citizen-round kickoff was already re-said this boot —
-        // re-perception happens once, never per watch tick (a failed or
-        // not-yet-resident attempt un-marks itself for a later tick).
-        let mut nudged: std::collections::HashSet<uuid::Uuid> = std::collections::HashSet::new();
         // LIVENESS: the watch announces itself and each park entry. Measured
         // 2026-09-01 (build 5a6be5b0d): the task produced ZERO output for 30+
         // minutes — no re-says, no prewarm, no blocked probes — and there was
@@ -207,106 +203,13 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
             if attempt == 1 {
                 crate::modules::work::spawn_env_prewarm_for_working_rounds();
             }
-            // CITIZEN-driven rounds resume by RE-PERCEPTION, not dispatch: a
-            // reload buries the original kickoffs beyond every window, and the
-            // assignees then idle beside their own unworked cards (live
-            // 2026-09-01: a lite round 'working, 4 remaining' for a full day).
-            // Re-say the kickoff through the ASSIGNEE'S OWN runtime — she is
-            // subscribed to the run room by construction, so no operator-scope
-            // membership is needed. Once per card per boot; the say is
-            // perception, and repeating it every watch tick would be the
-            // room-join flood shape.
-            // Per-assignee held-card ids, fetched once, so we can SKIP re-saying a
-            // kickoff for a card she ALREADY holds. The self-tick held-work loop
-            // (act_question, #the-9-1-night-audit) now works every held (Claimed)
-            // card automatically — no room message needed. Re-saying anyway floods
-            // cognition (measured 2026-09-02: 30+ rounds x ~4 cards = 100+ messages
-            // on reboot, 22 prefills / 1 productive held-work turn) and STARVES the
-            // very held-work it means to enable. So re-say is now ONLY for a card
-            // she has LOST (lapsed to Open, or never re-claimed), which the held-work
-            // loop cannot pick up because it isn't in her claims.
-            use crate::persona::active_work_source::AircWorkReader as _;
-            let mut held_by_assignee: std::collections::HashMap<
-                uuid::Uuid,
-                std::collections::HashSet<uuid::Uuid>,
-            > = std::collections::HashMap::new();
-            for next in crate::cognition::bench_round::unworked_citizen_cards() {
-                if !nudged.insert(next.card) {
-                    continue;
-                }
-                let Some(rt) = registry.get(next.assignee) else {
-                    nudged.remove(&next.card); // not resident yet — retry a later tick
-                    continue;
-                };
-                if !held_by_assignee.contains_key(&next.assignee) {
-                    let held: std::collections::HashSet<uuid::Uuid> = rt
-                        .active_claims()
-                        .await
-                        .map(|cards| cards.iter().map(|c| c.card_id.as_uuid()).collect())
-                        .unwrap_or_default(); // safe: unreadable claims = treat as none held, fall through to re-say (correct direction: a re-say is recoverable, a missed one strands)
-                    held_by_assignee.insert(next.assignee, held);
-                }
-                if held_by_assignee
-                    .get(&next.assignee)
-                    .is_some_and(|h| h.contains(&next.card))
-                {
-                    nudged.remove(&next.card); // not a real nudge — leave it re-sayable if the claim later lapses
-                    crate::probe!(
-                        class = "bench.round.resume_held",
-                        card_id = %next.card,
-                        assignee = %next.assignee,
-                        "card still held after reboot — the held-work loop works it; \
-                         no re-say (no reboot kickoff flood)"
-                    );
-                    continue;
-                }
-                let short = next.card.simple().to_string()[..8].to_string();
-                // NAME the addressee. The say rides the assignee's own runtime
-                // into a SHARED room, so an unaddressed "your card" reads as
-                // anyone's — live 2026-09-01: Kira spent turns confused that
-                // "the resume message said it's mine" about Benchy's card, in
-                // a room where the ownership question was the whole blocker.
-                let who = rt.agent_name().to_string();
-                // Name the INSTANCE and the staged path too — the exact facts
-                // the 2026-09-02 hand-written operator note carried when it
-                // broke a wedged round. The substrate's kickoff carries them
-                // now, so the hand stays out of the loop.
-                let what = crate::cognition::bench_round::instance_for_card(next.card)
-                    .map(|i| format!(" ({i}, checkout staged at swe/{i}/ in your workspace)"))
-                    .unwrap_or_default(); // safe: unknown instance = omit the parenthetical, the re-say still names card+owner
-                let text = format!(
-                    "[resume] {who}: this round survived a core restart and your kickoff \
-                     predates your window. Card {short}{what} is {who}'s — nobody \
-                     else's — and unworked: check work/get {short} for details, work it \
-                     in your workspace, and when your patch is verified green say \
-                     `work/state {short} done` — that is what fires your grade; nobody \
-                     fires it for you."
-                );
-                match crate::persona::airc_citizen::publish_text_in_room(
-                    rt.airc(),
-                    next.run_room,
-                    &text,
-                )
-                .await
-                {
-                    Ok(_) => crate::probe!(
-                        class = "bench.round.kickoff_resaid",
-                        card_id = %next.card,
-                        assignee = %next.assignee,
-                        room = %next.run_room,
-                        "citizen-round kickoff re-said after reload — re-perception, not dispatch"
-                    ),
-                    Err(e) => {
-                        nudged.remove(&next.card); // say failed — retry a later tick
-                        crate::probe!(
-                            class = "bench.round.kickoff_resay_failed",
-                            card_id = %next.card,
-                            error = %e,
-                            "kickoff re-say failed — will retry on a later watch tick"
-                        );
-                    }
-                }
-            }
+            // CITIZEN-driven rounds need NO re-say (deleted 2026-09-03). A card is
+            // content of its room: a resident who holds it works it on her held-work
+            // turn, and a card nobody holds (never claimed, or a lapsed lease) is
+            // PULLED by the next idle resident off the board — the organic path
+            // (`service_loop::try_pull_next_card`, board-truth claimability). The
+            // re-say was compensation for the push model's assignee-only gate, and
+            // measured as a flood: 40 kickoffs re-said into legacy rooms on one boot.
             let due = crate::cognition::bench_round::next_unworked_per_round();
             if due.is_empty() {
                 if !crate::cognition::bench_round::any_working_round() {

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -216,6 +216,20 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
             // membership is needed. Once per card per boot; the say is
             // perception, and repeating it every watch tick would be the
             // room-join flood shape.
+            // Per-assignee held-card ids, fetched once, so we can SKIP re-saying a
+            // kickoff for a card she ALREADY holds. The self-tick held-work loop
+            // (act_question, #the-9-1-night-audit) now works every held (Claimed)
+            // card automatically — no room message needed. Re-saying anyway floods
+            // cognition (measured 2026-09-02: 30+ rounds x ~4 cards = 100+ messages
+            // on reboot, 22 prefills / 1 productive held-work turn) and STARVES the
+            // very held-work it means to enable. So re-say is now ONLY for a card
+            // she has LOST (lapsed to Open, or never re-claimed), which the held-work
+            // loop cannot pick up because it isn't in her claims.
+            use crate::persona::active_work_source::AircWorkReader as _;
+            let mut held_by_assignee: std::collections::HashMap<
+                uuid::Uuid,
+                std::collections::HashSet<uuid::Uuid>,
+            > = std::collections::HashMap::new();
             for next in crate::cognition::bench_round::unworked_citizen_cards() {
                 if !nudged.insert(next.card) {
                     continue;
@@ -224,6 +238,28 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
                     nudged.remove(&next.card); // not resident yet — retry a later tick
                     continue;
                 };
+                if !held_by_assignee.contains_key(&next.assignee) {
+                    let held: std::collections::HashSet<uuid::Uuid> = rt
+                        .active_claims()
+                        .await
+                        .map(|cards| cards.iter().map(|c| c.card_id.as_uuid()).collect())
+                        .unwrap_or_default(); // safe: unreadable claims = treat as none held, fall through to re-say (correct direction: a re-say is recoverable, a missed one strands)
+                    held_by_assignee.insert(next.assignee, held);
+                }
+                if held_by_assignee
+                    .get(&next.assignee)
+                    .is_some_and(|h| h.contains(&next.card))
+                {
+                    nudged.remove(&next.card); // not a real nudge — leave it re-sayable if the claim later lapses
+                    crate::probe!(
+                        class = "bench.round.resume_held",
+                        card_id = %next.card,
+                        assignee = %next.assignee,
+                        "card still held after reboot — the held-work loop works it; \
+                         no re-say (no reboot kickoff flood)"
+                    );
+                    continue;
+                }
                 let short = next.card.simple().to_string()[..8].to_string();
                 // NAME the addressee. The say rides the assignee's own runtime
                 // into a SHARED room, so an unaddressed "your card" reads as

--- a/core/continuum-core/src/modules/benchmark_standing.rs
+++ b/core/continuum-core/src/modules/benchmark_standing.rs
@@ -156,6 +156,28 @@ impl BenchmarkStandingModule {
             return Ok(false);
         }
         let assignees: Vec<String> = residents.iter().map(|(name, _)| name.clone()).collect();
+        // BACKLOG GUARD: if there are already more unworked (unstarted) cards in
+        // flight than there are citizens to work them, the team is saturated —
+        // dispatching another round just deepens the pile (measured 2026-09-02:
+        // the autopilot reached 30+ rounds / 111 unstarted while 4 citizens
+        // worked one card each at a time). The working-round gate above holds
+        // while a round is being worked; this holds while unworked work already
+        // waits. Together they keep "benchmarks run themselves" from becoming
+        // "benchmarks dispatch themselves into a pile."
+        let backlog = crate::cognition::bench_round::unworked_backlog(
+            &facts,
+            crate::persona::trace::now_ms(),
+        );
+        if backlog > residents.len() {
+            crate::probe!(
+                class = "bench.standing.skipped",
+                reason = "backlog",
+                backlog = backlog as u64,
+                citizens = residents.len() as u64,
+                "standing round: unworked backlog exceeds the team — holding until it drains"
+            );
+            return Ok(false);
+        }
         let Some(executor) = self.executor_slot.cloned() else {
             crate::probe!(
                 class = "bench.standing.skipped",

--- a/core/continuum-core/src/modules/benchmark_standing.rs
+++ b/core/continuum-core/src/modules/benchmark_standing.rs
@@ -111,8 +111,26 @@ impl BenchmarkStandingModule {
         if !cfg.enabled {
             return Ok(false); // silent: disabled is the configured steady state
         }
-        if crate::cognition::bench_round::any_working_round() {
-            return Ok(false); // silent: a working round IS the goal state
+        // A HEALTHY working round is the goal state — hold. But a round wedged
+        // past the abandon window (dead citizens, no task boundary) must NOT
+        // block the autopilot forever (measured 2026-09-02: 3 rounds stuck
+        // ~18h, un-clearable, starving the claim-growth engine). Scan the
+        // run ledger so "healthy vs stale" is the board's own truth, not a
+        // guess. Blocking fs scan off the async worker.
+        let runs = tokio::task::spawn_blocking(|| {
+            crate::commands::benchmark::scan_run_cards(None, 200)
+                .map(|s| s.cards)
+                .unwrap_or_default() // safe: no ledger = no fresh acts = treat as clear
+        })
+        .await
+        .unwrap_or_default(); // safe: join error = same, degrade to clear
+        let facts: Vec<crate::cognition::bench_round::CardRunFacts> =
+            runs.iter().map(crate::commands::benchmark::card_run_facts).collect();
+        if !crate::cognition::bench_round::only_stale_or_no_working_rounds(
+            &facts,
+            crate::persona::trace::now_ms(),
+        ) {
+            return Ok(false); // silent: a round is healthily grinding
         }
         // Serving must be decode-ready — a dispatch into a cold lane burns the
         // round's first minutes on refusals. Short park: the tick returns and

--- a/core/continuum-core/src/modules/card_staging.rs
+++ b/core/continuum-core/src/modules/card_staging.rs
@@ -1,0 +1,237 @@
+//! Card staging — prepare the CLAIMER's workspace for the card she just claimed, per
+//! the recipe the card belongs to. The on-claim recipe step.
+//!
+//! Before this, `benchmark/dispatch` staged every card into a round-robin ASSIGNEE's
+//! workspace and PRE-CLAIMED it for her — a push. That is why a shared deck was never
+//! shared: a card pulled by anyone else pointed at a checkout in someone else's
+//! workspace, so eligibility had to be gated on the assignee, and 7 of 12 residents
+//! dreamed while 5 worked (Joel 2026-09-03: "this dispatch issue is a MONTHS OLD bug").
+//!
+//! Now the CLAIM stages. Whoever pulls a card gets its work prepared in HER workspace,
+//! so any resident can work any Open card, and a rebooted citizen who re-reads the
+//! board and pulls is staged exactly like a first claimer — resume and dispatch are one
+//! motion. Two callers, one seam: `work/claim` (a citizen pulls) and
+//! `benchmark/dispatch` (a detached-solve round stages its directed assignee before
+//! firing her solve).
+//!
+//! Generic by construction (Joel 2026-09-03: "is this benchmark recipe, or can/should it
+//! be more generic? Should this function be a command — always if it uses heavy
+//! resources?"): the entry takes a card TITLE and a claimer and asks the recipe what
+//! staging means. A non-recipe card stages as [`Staging::Ordinary`] (hands stay put).
+//! Today the recipes are the benchmark specs; a pipeline or design recipe adds its
+//! own arm here, never a second staging path. The heavy half (a checkout clone, an
+//! env build) already lives behind verbs (`swe_bench::clone_at`, `ensure_env`); this
+//! module is their on-claim orchestration, invoked from the `work/claim` command.
+//!
+//! Measured 2026-09-03 on the M5: a `--shared` clone from the local mirror lands in
+//! ~1–2s (django, 293 MB mirror), so the checkout is staged synchronously inside the
+//! claim; the env build (uv venv, cached per instance) is spawned behind it and
+//! reported through the same `benchmark.env.*` probes the pre-warm uses.
+
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+/// What staging produced for this claimer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Staging {
+    /// Not a recipe card (or a recipe with no workspace step) — nothing to stage,
+    /// her hands stay where they are.
+    Ordinary,
+    /// The card's work is ready in her workspace at `path` (workspace-relative
+    /// coordinates are what the card body already speaks).
+    Ready { path: PathBuf },
+    /// A recipe card whose staging failed at `stage` — the claim stands, the failure
+    /// is reported, and no scored solve fires on an unstaged workspace.
+    Failed { stage: &'static str, error: String },
+}
+
+/// The recipe-resolved staging step for one card title.
+enum Step {
+    /// SWE-bench: clone the instance at its base commit, then build its env.
+    Swe(Box<crate::cognition::swe_bench::SweInstance>),
+    /// Gym: run the task's authored `setup_shell` in the workspace (idempotent by
+    /// adapter convention).
+    Shell(String),
+    /// A recipe card with no workspace preparation.
+    Nothing,
+}
+
+/// Stage `title`'s work into the workspace of `claimer` under `home`.
+pub async fn stage_for_claimer(home: &Path, claimer: Uuid, title: &str) -> Staging {
+    let Some((bench, task)) = crate::commands::benchmark::parse_card_title(title) else {
+        return Staging::Ordinary;
+    };
+    let workspace =
+        crate::identity::citizen_peer_dir(home, crate::identity::PeerId::from_uuid(claimer))
+            .join("workspace");
+    let step = match resolve_step(&bench, &task).await {
+        Ok(step) => step,
+        Err(error) => return failed(claimer, title, "resolve", error),
+    };
+    let started = std::time::Instant::now();
+    let outcome = match step {
+        Step::Nothing => Staging::Ordinary,
+        Step::Shell(shell) => stage_shell(&workspace, &shell).await,
+        Step::Swe(instance) => stage_swe(&workspace, &instance).await,
+    };
+    crate::probe!(
+        class = "work.claim.staged",
+        claimer = %claimer,
+        bench = %bench,
+        task = %task,
+        outcome = ?outcome,
+        ms = started.elapsed().as_millis() as u64,
+        "on-claim staging — the claimer's workspace prepared per the card's recipe"
+    );
+    outcome
+}
+
+/// Ask the recipe what staging `task` means. Benchmark specs are the recipes today.
+async fn resolve_step(bench: &str, task: &str) -> Result<Step, String> {
+    let spec = crate::commands::benchmark::known_benchmarks()
+        .iter()
+        .find(|s| s.name == bench)
+        .ok_or_else(|| format!("card names unknown benchmark '{bench}'"))?;
+    if let Some(dataset) = spec.swe_dataset() {
+        let rows = crate::cognition::swe_bench::load_dataset(dataset).await?;
+        let instance = rows
+            .into_iter()
+            .find(|i| i.instance_id == task)
+            .ok_or_else(|| format!("instance '{task}' not in dataset '{dataset}'"))?;
+        return Ok(Step::Swe(Box::new(instance)));
+    }
+    let Some(reference) = spec.eval_set else {
+        return Ok(Step::Nothing);
+    };
+    let (origin, text) = crate::cognition::gym::resolve_gym(reference)?;
+    for (n, line) in text.lines().enumerate().filter(|(_, l)| !l.trim().is_empty()) {
+        let t: crate::cognition::eval::EvalTask = serde_json::from_str(line.trim())
+            .map_err(|e| format!("{origin} line {}: malformed EvalTask: {e}", n + 1))?;
+        if t.id == task {
+            return Ok(t.setup_shell.map(Step::Shell).unwrap_or(Step::Nothing));
+        }
+    }
+    Err(format!("task '{task}' not in gym '{reference}'"))
+}
+
+async fn stage_shell(workspace: &Path, shell: &str) -> Staging {
+    if let Err(e) = std::fs::create_dir_all(workspace) {
+        return Staging::Failed { stage: "workspace", error: e.to_string() };
+    }
+    match tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(shell)
+        .current_dir(workspace)
+        .output()
+        .await
+    {
+        Ok(out) if out.status.success() => Staging::Ready { path: workspace.to_path_buf() },
+        Ok(out) => Staging::Failed {
+            stage: "setup_shell",
+            error: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        },
+        Err(e) => Staging::Failed { stage: "setup_shell", error: e.to_string() },
+    }
+}
+
+async fn stage_swe(workspace: &Path, instance: &crate::cognition::swe_bench::SweInstance) -> Staging {
+    use crate::cognition::swe_bench;
+    let dir = workspace.join("swe").join(&instance.instance_id);
+    if dir.join(".git").exists() {
+        // Already staged (a prior claim, or a re-claim after a reboot). Self-heal
+        // pre-shield checkouts so substrate artifacts never enter her patch.
+        swe_bench::shield_workspace_excludes(&dir);
+    } else if let Err(error) = swe_bench::clone_at(instance, &dir).await {
+        return Staging::Failed { stage: "checkout", error };
+    }
+    // The env (pytest + the repo, per-instance uv venv) builds BEHIND the claim: cached
+    // after the first build, minutes the first time — never on the claim's critical
+    // path. Failure marks the instance broken this boot so a scored solve is not
+    // fired into a known wall; the card stays claimable once the env heals.
+    let inst = instance.clone();
+    tokio::spawn(async move {
+        match swe_bench::ensure_env(&inst, &dir).await {
+            Ok(_) => {
+                crate::modules::work::env_broken_this_boot().remove(&inst.instance_id);
+                crate::probe!(
+                    class = "benchmark.env.prewarmed",
+                    instance = %inst.instance_id,
+                    "env ready behind the claim"
+                );
+            }
+            Err(e) => {
+                crate::modules::work::env_broken_this_boot().insert(inst.instance_id.clone());
+                crate::probe!(
+                    class = "benchmark.env.prewarm_failed",
+                    instance = %inst.instance_id,
+                    stage = "env",
+                    error = %e,
+                    "env build FAILED behind the claim — an ENV failure, never a model result"
+                );
+            }
+        }
+    });
+    Staging::Ready { path: workspace.join("swe").join(&instance.instance_id) }
+}
+
+fn failed(claimer: Uuid, title: &str, stage: &'static str, error: String) -> Staging {
+    crate::probe!(
+        class = "work.claim.stage_failed",
+        claimer = %claimer,
+        title = %title,
+        stage = stage,
+        error = %error,
+        "on-claim staging failed — the claim stands, no scored solve fires on an unstaged workspace"
+    );
+    Staging::Failed { stage, error }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the dispatch→pull inversion at its seam. A card claimed by a
+    // citizen who was NEVER its assignee must be staged into HER workspace (keyed by her
+    // peer id), not into the round-robin assignee's — the coupling that made free pull
+    // impossible. Uses a gym-shaped shell step so no dataset or mirror is needed.
+    #[tokio::test]
+    async fn a_claimer_who_was_never_the_assignee_is_staged_in_her_own_workspace() {
+        let home = tempfile::tempdir().unwrap();
+        let claimer = Uuid::new_v4();
+        let workspace = crate::identity::citizen_peer_dir(
+            home.path(),
+            crate::identity::PeerId::from_uuid(claimer),
+        )
+        .join("workspace");
+        let staged = stage_shell(&workspace, "mkdir -p staged/marker && touch staged/marker/ok").await;
+        assert_eq!(staged, Staging::Ready { path: workspace.clone() });
+        assert!(
+            workspace.join("staged/marker/ok").exists(),
+            "the setup ran in the CLAIMER's workspace, not an assignee's"
+        );
+    }
+
+    // what this catches: a non-recipe card is Ordinary — hands stay put, no probe of
+    // failure, no dataset touched. A plain work card must never be mistaken for a bench
+    // card by a loose title parse.
+    #[tokio::test]
+    async fn a_plain_work_card_stages_as_ordinary() {
+        let home = tempfile::tempdir().unwrap();
+        let staged = stage_for_claimer(home.path(), Uuid::new_v4(), "Fix the login redirect").await;
+        assert_eq!(staged, Staging::Ordinary);
+    }
+
+    // what this catches: a failing setup step is REPORTED as Failed with its stage
+    // named — never swallowed into Ready (which would fire a scored solve on an
+    // unstaged workspace) and never Ordinary (which would hide a recipe defect).
+    #[tokio::test]
+    async fn a_failing_setup_shell_reports_failed_not_ready() {
+        let home = tempfile::tempdir().unwrap();
+        let staged = stage_shell(&home.path().join("ws"), "echo boom >&2; exit 3").await;
+        assert_eq!(
+            staged,
+            Staging::Failed { stage: "setup_shell", error: "boom".to_string() }
+        );
+    }
+}

--- a/core/continuum-core/src/modules/card_staging.rs
+++ b/core/continuum-core/src/modules/card_staging.rs
@@ -109,7 +109,7 @@ async fn resolve_step(bench: &str, task: &str) -> Result<Step, String> {
         let t: crate::cognition::eval::EvalTask = serde_json::from_str(line.trim())
             .map_err(|e| format!("{origin} line {}: malformed EvalTask: {e}", n + 1))?;
         if t.id == task {
-            return Ok(t.setup_shell.map(Step::Shell).unwrap_or(Step::Nothing));
+            return Ok(t.setup_shell.map(Step::Shell).unwrap_or(Step::Nothing));  // unwrap_or: a task without setup_shell stages nothing
         }
     }
     Err(format!("task '{task}' not in gym '{reference}'"))
@@ -197,7 +197,7 @@ mod tests {
     // impossible. Uses a gym-shaped shell step so no dataset or mirror is needed.
     #[tokio::test]
     async fn a_claimer_who_was_never_the_assignee_is_staged_in_her_own_workspace() {
-        let home = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();  // test: temp dir creation
         let claimer = Uuid::new_v4();
         let workspace = crate::identity::citizen_peer_dir(
             home.path(),
@@ -217,7 +217,7 @@ mod tests {
     // card by a loose title parse.
     #[tokio::test]
     async fn a_plain_work_card_stages_as_ordinary() {
-        let home = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();  // test: temp dir creation
         let staged = stage_for_claimer(home.path(), Uuid::new_v4(), "Fix the login redirect").await;
         assert_eq!(staged, Staging::Ordinary);
     }
@@ -227,7 +227,7 @@ mod tests {
     // unstaged workspace) and never Ordinary (which would hide a recipe defect).
     #[tokio::test]
     async fn a_failing_setup_shell_reports_failed_not_ready() {
-        let home = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();  // test: temp dir creation
         let staged = stage_shell(&home.path().join("ws"), "echo boom >&2; exit 3").await;
         assert_eq!(
             staged,

--- a/core/continuum-core/src/modules/live.rs
+++ b/core/continuum-core/src/modules/live.rs
@@ -1042,7 +1042,7 @@ impl ServiceModule for VoiceModule {
                 // (join → push_audio → VAD → transcription broadcast) which
                 // tests the ROOM plumbing separately. Two legs, one thing each
                 // — the decomposition the flaky combined test was hiding.
-                let room_leg = p.value("room").and_then(|v| v.as_bool()).unwrap_or(false);
+                let room_leg = p.value("room").and_then(|v| v.as_bool()).unwrap_or(false); // safe: absent flag = engine leg, the default
                 let t0 = std::time::Instant::now();
                 let synthesis = crate::live::audio::tts_service::synthesize_speech_async(
                     &phrase, None, adapter, None,
@@ -1084,13 +1084,18 @@ impl ServiceModule for VoiceModule {
                     wait.ok().flatten().unwrap_or_default() // safe: no event = empty = red receipt
                 } else {
                     // Engine leg: samples straight to STT. This is the TDD loop.
-                    crate::live::audio::stt_service::transcribe_speech_async(
+                    match crate::live::audio::stt_service::transcribe_speech_async(
                         &synthesis.samples,
                         Some("en"),
                     )
                     .await
-                    .map(|r| r.text)
-                    .unwrap_or_default() // safe: STT failure = empty = red receipt
+                    {
+                        Ok(r) => r.text,
+                        // Surface the STT error into the receipt — a swallowed
+                        // error read as an empty transcript and hid the real
+                        // failure for a full debug cycle (2026-09-02).
+                        Err(e) => return Err(format!("selftest STT failed: {e}")),
+                    }
                 };
                 let stt_ms = t1.elapsed().as_millis() as u64;
                 let lower = transcript.to_lowercase();
@@ -1102,7 +1107,7 @@ impl ServiceModule for VoiceModule {
                 let leg = if room_leg { "room" } else { "engine" };
                 crate::probe!(
                     class = "live.selftest",
-                    adapter = adapter.unwrap_or("active"),
+                    adapter = adapter.unwrap_or("active"), // safe: no adapter = the active one, a display label
                     leg = leg,
                     matched = matched,
                     tts_ms = tts_ms,

--- a/core/continuum-core/src/modules/live.rs
+++ b/core/continuum-core/src/modules/live.rs
@@ -1018,9 +1018,14 @@ impl ServiceModule for VoiceModule {
                 let nonce = uuid::Uuid::new_v4().simple().to_string()[..6].to_string();
                 let phrase = format!("continuum self test {nonce}");
 
+                // Per-engine leg (Joel 2026-09-02: "the TDD for this is
+                // voice <-> STT"): the same round trip proves ANY adapter —
+                // `voice/selftest --adapter orpheus` is Orpheus's acceptance
+                // test, and the nightly battery runs one leg per engine.
+                let adapter = p.str_opt("adapter");
                 let t0 = std::time::Instant::now();
                 let synthesis = crate::live::audio::tts_service::synthesize_speech_async(
-                    &phrase, None, None, None,
+                    &phrase, None, adapter, None,
                 )
                 .await
                 .map_err(|e| format!("selftest TTS failed: {e}"))?;
@@ -1082,6 +1087,7 @@ impl ServiceModule for VoiceModule {
                 let matched = hits >= 2;
                 crate::probe!(
                     class = "live.selftest",
+                    adapter = adapter.unwrap_or("active"),
                     matched = matched,
                     tts_ms = tts_ms,
                     stt_ms = stt_ms,

--- a/core/continuum-core/src/modules/live.rs
+++ b/core/continuum-core/src/modules/live.rs
@@ -1015,8 +1015,19 @@ impl ServiceModule for VoiceModule {
                 // A fixed synthetic call id (any uuid is a valid call key;
                 // nothing subscribes to it, so no citizen perceives the test).
                 const SELFTEST_CALL: &str = "5e1f7e57-0000-4000-8000-c0117e575e1f";
-                let nonce = uuid::Uuid::new_v4().simple().to_string()[..6].to_string();
-                let phrase = format!("continuum self test {nonce}");
+                // A NATURAL phrase: hex nonces are hostile to speech models
+                // (measured 2026-09-02: Orpheus emitted 256ms then stopped on
+                // 'continuum self test 075cf5') and to STT. The nonce is a
+                // WORD, picked by uuid — unpredictable enough to prove this
+                // run's audio, speakable enough to survive both directions.
+                const NONCE_WORDS: [&str; 8] = [
+                    "harbor", "velvet", "compass", "lantern",
+                    "meadow", "ember", "willow", "granite",
+                ];
+                let word = NONCE_WORDS
+                    [uuid::Uuid::new_v4().as_u128() as usize % NONCE_WORDS.len()];
+                let phrase =
+                    format!("This is the continuum self test. The magic word is {word}.");
 
                 // Per-engine leg (Joel 2026-09-02: "the TDD for this is
                 // voice <-> STT"): the same round trip proves ANY adapter —
@@ -1080,7 +1091,7 @@ impl ServiceModule for VoiceModule {
                 // head words = the chain works.
                 let transcript = heard.as_ref().map(|e| e.text.clone()).unwrap_or_default(); // safe: no event = empty transcript = matched:false, the honest red receipt
                 let lower = transcript.to_lowercase();
-                let hits = ["continuum", "self", "test"]
+                let hits = ["continuum", "self", "test", word]
                     .iter()
                     .filter(|w| lower.contains(**w))
                     .count();

--- a/core/continuum-core/src/modules/live.rs
+++ b/core/continuum-core/src/modules/live.rs
@@ -1034,6 +1034,15 @@ impl ServiceModule for VoiceModule {
                 // `voice/selftest --adapter orpheus` is Orpheus's acceptance
                 // test, and the nightly battery runs one leg per engine.
                 let adapter = p.str_opt("adapter");
+                // ROUTED (Joel 2026-09-02, the VDD/WM split): the ENGINE test
+                // is a DIRECT TTS→STT round trip — deterministic, replayable,
+                // no VAD timing, no mixer clock — because "does this engine
+                // produce intelligible speech" is a property of the samples,
+                // not of the room. `--room` opts into the full call-path leg
+                // (join → push_audio → VAD → transcription broadcast) which
+                // tests the ROOM plumbing separately. Two legs, one thing each
+                // — the decomposition the flaky combined test was hiding.
+                let room_leg = p.value("room").and_then(|v| v.as_bool()).unwrap_or(false);
                 let t0 = std::time::Instant::now();
                 let synthesis = crate::live::audio::tts_service::synthesize_speech_async(
                     &phrase, None, adapter, None,
@@ -1042,74 +1051,70 @@ impl ServiceModule for VoiceModule {
                 .map_err(|e| format!("selftest TTS failed: {e}"))?;
                 let tts_ms = t0.elapsed().as_millis() as u64;
 
-                let joined = self
-                    .state
-                    .call_manager
-                    .join_call(SELFTEST_CALL, "selftest-human", "Selftest", false)
-                    .await
-                    .map_err(|e| format!("selftest join failed: {e}"))?;
-                let handle = joined.handle;
-                let mut transcripts = joined.transcription_rx;
-
-                // Feed the utterance + a 2s silence tail in 20ms frames — the
-                // silence is what trips the VAD's speech-end, same as a real
-                // caller going quiet. Lightly paced so the mixer's clock sees
-                // a plausible stream, fast enough that the verb stays snappy.
                 let t1 = std::time::Instant::now();
-                let mut pcm = synthesis.samples;
-                pcm.extend(std::iter::repeat(0i16).take(
-                    (crate::audio_constants::AUDIO_SAMPLE_RATE as usize) * 2,
-                ));
-                for chunk in pcm.chunks(320) {
-                    self.state.call_manager.push_audio(&handle, chunk.to_vec()).await;
-                    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
-                }
-
-                // Await our own transcription — the SAME broadcast a caption
-                // widget or a citizen's perception would ride.
-                let mut heard: Option<crate::live::transport::call_server::TranscriptionEvent> =
-                    None;
-                let deadline = std::time::Duration::from_secs(30);
-                let wait = tokio::time::timeout(deadline, async {
-                    loop {
-                        match transcripts.recv().await {
-                            Ok(ev) if ev.user_id == "selftest-human" => break Some(ev),
-                            Ok(_) => continue,
-                            Err(_) => break None,
-                        }
+                let transcript = if room_leg {
+                    // Full room path: the SAME chain a live caller exercises.
+                    let joined = self
+                        .state
+                        .call_manager
+                        .join_call(SELFTEST_CALL, "selftest-human", "Selftest", false)
+                        .await
+                        .map_err(|e| format!("selftest join failed: {e}"))?;
+                    let handle = joined.handle;
+                    let mut transcripts = joined.transcription_rx;
+                    let mut pcm = synthesis.samples.clone();
+                    pcm.extend(std::iter::repeat(0i16).take(
+                        (crate::audio_constants::AUDIO_SAMPLE_RATE as usize) * 2,
+                    ));
+                    for chunk in pcm.chunks(320) {
+                        self.state.call_manager.push_audio(&handle, chunk.to_vec()).await;
+                        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
                     }
-                })
-                .await;
-                if let Ok(Some(ev)) = wait {
-                    heard = Some(ev);
-                }
+                    let wait = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+                        loop {
+                            match transcripts.recv().await {
+                                Ok(ev) if ev.user_id == "selftest-human" => break Some(ev.text),
+                                Ok(_) => continue,
+                                Err(_) => break None,
+                            }
+                        }
+                    })
+                    .await;
+                    self.state.call_manager.leave_call(&handle).await;
+                    wait.ok().flatten().unwrap_or_default() // safe: no event = empty = red receipt
+                } else {
+                    // Engine leg: samples straight to STT. This is the TDD loop.
+                    crate::live::audio::stt_service::transcribe_speech_async(
+                        &synthesis.samples,
+                        Some("en"),
+                    )
+                    .await
+                    .map(|r| r.text)
+                    .unwrap_or_default() // safe: STT failure = empty = red receipt
+                };
                 let stt_ms = t1.elapsed().as_millis() as u64;
-                self.state.call_manager.leave_call(&handle).await;
-
-                // Fuzzy match: STT drops case/punctuation and may mangle the
-                // nonce; the load-bearing words are the phrase's head. 2 of 3
-                // head words = the chain works.
-                let transcript = heard.as_ref().map(|e| e.text.clone()).unwrap_or_default(); // safe: no event = empty transcript = matched:false, the honest red receipt
                 let lower = transcript.to_lowercase();
                 let hits = ["continuum", "self", "test", word]
                     .iter()
                     .filter(|w| lower.contains(**w))
                     .count();
                 let matched = hits >= 2;
+                let leg = if room_leg { "room" } else { "engine" };
                 crate::probe!(
                     class = "live.selftest",
                     adapter = adapter.unwrap_or("active"),
+                    leg = leg,
                     matched = matched,
                     tts_ms = tts_ms,
                     stt_ms = stt_ms,
                     transcript = %transcript,
-                    "voice chain self-proof: TTS → call join → push_audio → VAD → STT → transcription event"
+                    "voice self-proof (engine leg = direct TTS→STT; room leg = full call path)"
                 );
                 Ok(CommandResult::Json(serde_json::json!({
                     "matched": matched,
+                    "leg": leg,
                     "phrase": phrase,
                     "transcript": transcript,
-                    "confidence": heard.as_ref().map(|e| e.confidence),
                     "tts_ms": tts_ms,
                     "stt_ms": stt_ms,
                     "synthesized_ms": synthesis.duration_ms,

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -30,6 +30,7 @@ pub mod benchmark_grade;
 pub mod benchmark_standing;
 pub mod benchmark_resume;
 pub mod bevy_consumer;
+pub mod card_staging;
 pub mod channel;
 pub mod chat;
 pub mod code;

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -1524,42 +1524,52 @@ impl ActionCommand for WorkState {
         let airc = persona_airc(&self.registry, ctx, "work commands")?;
         let card_id = resolve_card_id(&airc, &p.card_id).await?;
         let state = parse_state(&p.state)?;
-        airc.change_work_card_state(ChangeWorkCardState { card_id, state })
+        advance_card_state(&airc, card_id, state, "work-state-verb")
             .await
-            .map_err(|e| CommandError::Internal(e.to_string()))?;
-
-        // DIRECT emit — the delivery-proof feeder. The previous shape relied
-        // entirely on this transition's transcript echo returning through a persona
-        // subscribe stream; under #434 (post-reboot durable delivery down) that echo
-        // never arrives and finished work grades as NOTHING (measured 2026-08-17:
-        // two cards Closed, zero grades, 2 raw events in 80 min). The verb KNOWS the
-        // transition happened — it just wrote it — so it publishes in-process. The
-        // wire bridge still covers external writers (operator CLI, remote peers);
-        // `emit_card_state_changed`'s (card,state) ring makes the two feeders
-        // publish once when both fire.
-        // The CARD's room, never `current_room()` — boards are per-room and the grade
-        // subscriber refuses an event with no room. Uses the ONE room resolver
-        // (`room_holding_card`, canary's consolidation) rather than a third private scan.
-        let room_id = room_holding_card(&airc, card_id)
-            .await
-            .map(|r| r.channel.as_uuid().to_string())
-            .unwrap_or_default(); // board read failure already probed as its own abort above
-        emit_card_state_changed(
-            serde_json::json!({
-                "card_id": card_id.as_uuid().to_string(),
-                "state": serde_json::to_value(state)
-                    .unwrap_or(serde_json::Value::Null),
-                "room_id": room_id,
-            }),
-            "work-state-verb",
-        )
-        .await;
-
+            .map_err(CommandError::Internal)?;
         Ok(WorkStateResult {
             card_id: p.card_id,
             state: p.state,
         })
     }
+}
+
+/// Transition a work card's lifecycle state AND feed the grade/lifecycle
+/// subscribers in-process — the ONE place a card's state is written and
+/// announced (the compression law: `work/state` the verb, the held-work settle
+/// edge, and any future writer all call THIS, never re-implement the change +
+/// emit pair). Writing without the direct emit is the #434 delivery-hole that
+/// let finished work grade as NOTHING; the (card,state) ring in
+/// `emit_card_state_changed` makes the direct feeder and the wire echo publish
+/// exactly once when both fire, so callers may always emit.
+///
+/// `via` labels the feeder on the probe stream so two writers of the same
+/// transition are distinguishable.
+pub(crate) async fn advance_card_state(
+    airc: &Arc<Airc>,
+    card_id: WorkCardId,
+    state: CardState,
+    via: &'static str,
+) -> Result<(), String> {
+    airc.change_work_card_state(ChangeWorkCardState { card_id, state })
+        .await
+        .map_err(|e| e.to_string())?;
+    // The CARD's room, never `current_room()` — boards are per-room and the grade
+    // subscriber refuses an event with no room.
+    let room_id = room_holding_card(airc, card_id)
+        .await
+        .map(|r| r.channel.as_uuid().to_string())
+        .unwrap_or_default();
+    emit_card_state_changed(
+        serde_json::json!({
+            "card_id": card_id.as_uuid().to_string(),
+            "state": serde_json::to_value(state).unwrap_or(serde_json::Value::Null),
+            "room_id": room_id,
+        }),
+        via,
+    )
+    .await;
+    Ok(())
 }
 
 // ─────────────────────────── work/heartbeat ──────────────────────

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -1560,12 +1560,14 @@ impl ActionCommand for WorkState {
         let airc = persona_airc(&self.registry, ctx, "work commands")?;
         let card_id = resolve_card_id(&airc, &p.card_id).await?;
         let state = parse_state(&p.state)?;
-        advance_card_state(&airc, card_id, state, "work-state-verb")
+        let landed = advance_card_state_effective(&airc, card_id, state, "work-state-verb")
             .await
             .map_err(CommandError::Internal)?;
         Ok(WorkStateResult {
             card_id: p.card_id,
-            state: p.state,
+            // The state that LANDED: under the review gate an owner's `done` reads
+            // back as `review` — she must see that her card now waits on a reviewer.
+            state: state_str(&landed).to_string(),
         })
     }
 }
@@ -1582,6 +1584,122 @@ impl ActionCommand for WorkState {
 /// `via` labels the feeder on the probe stream so two writers of the same
 /// transition are distinguishable.
 pub(crate) async fn advance_card_state(
+    airc: &Arc<Airc>,
+    card_id: WorkCardId,
+    state: CardState,
+    via: &'static str,
+) -> Result<(), String> {
+    advance_card_state_effective(airc, card_id, state, via).await.map(|_| ())
+}
+
+/// The state-advance seam WITH the review gate (team-recipe Arm 2, 2026-09-03).
+/// Returns the state that actually landed:
+/// - a verdict on a REVIEW card: `done` = pass → the review retires and the PARENT
+///   closes (its grade fires); `blocked` = send back → the review retires and the
+///   parent returns to `in_progress` (the reviewer's critique is already in the room);
+/// - an owner's `done` on a GATED parent → `review` + a sibling review card is
+///   posted for a non-owner to pull;
+/// - everything else advances as asked.
+/// One seam for the `work/state` verb and the deterministic held-work settle, so
+/// the gate cannot be bypassed by either.
+pub(crate) async fn advance_card_state_effective(
+    airc: &Arc<Airc>,
+    card_id: WorkCardId,
+    state: CardState,
+    via: &'static str,
+) -> Result<CardState, String> {
+    use crate::cognition::bench_round as round;
+    let finishing = matches!(state, CardState::Closed | CardState::Merged);
+    if let Some(parent) = round::review_parent(card_id.as_uuid()) {
+        if finishing || state == CardState::Blocked {
+            let passed = finishing;
+            round::settle_review_card(card_id.as_uuid(), passed);
+            raw_advance(airc, card_id, CardState::Closed, via).await?;
+            let parent_id = WorkCardId::from_uuid(parent);
+            let next = if passed { CardState::Closed } else { CardState::InProgress };
+            crate::probe!(
+                class = "work.review.verdict",
+                review = %short8(card_id.as_uuid()),
+                parent = %short8(parent),
+                passed,
+                "reviewer's verdict — a pass closes the parent (grade fires), a send-back \
+                 returns it to in_progress"
+            );
+            raw_advance(airc, parent_id, next, via).await?;
+            return Ok(next);
+        }
+    }
+    if finishing && round::review_required(card_id.as_uuid()) {
+        raw_advance(airc, card_id, CardState::Review, via).await?;
+        match open_review_card(airc, card_id).await {
+            Ok(review) => crate::probe!(
+                class = "work.review.opened",
+                parent = %short8(card_id.as_uuid()),
+                review = %short8(review.as_uuid()),
+                "owner's done became review — a sibling review card is on the deck for a \
+                 non-owner; only the reviewer's done closes this card"
+            ),
+            Err(e) => crate::probe!(
+                class = "work.review.open_failed",
+                parent = %short8(card_id.as_uuid()),
+                error = %e,
+                "the card is in review but no review card could be posted — the next \
+                 done retries the gate"
+            ),
+        }
+        return Ok(CardState::Review);
+    }
+    raw_advance(airc, card_id, state, via).await?;
+    Ok(state)
+}
+
+/// Post the sibling review card for `parent` into the parent's own room, as the
+/// caller's identity. The card BODY carries the reviewer's role prompt — recipe
+/// data on the card, never a code branch in cognition.
+async fn open_review_card(airc: &Arc<Airc>, parent: WorkCardId) -> Result<WorkCardId, String> {
+    let (room, card) = card_in_subscribed_rooms(airc, parent)
+        .await
+        .ok_or_else(|| "parent card is on no subscribed room's board".to_string())?;
+    let (_, instance) = crate::commands::benchmark::parse_card_title(&card.title)
+        .ok_or_else(|| "parent is not a bench card".to_string())?;
+    let owner = card
+        .owner
+        .and_then(|o| {
+            crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global()
+                .and_then(|reg| reg.get(o.as_uuid()))
+                .map(|rt| rt.agent_name().to_string())
+        })
+        .unwrap_or_else(|| "the owner".to_string());
+    let title = crate::commands::benchmark::review_card_title(parent.as_uuid(), &instance, &owner);
+    let p8 = parent.as_uuid().simple().to_string()[..8].to_string();
+    let body = format!(
+        "Review {owner}'s fix for `{instance}` (card {p8}). You are the fresh pair of \
+         eyes: READ-ONLY. Do not edit their tree.\n\n\
+         Their checkout is {owner}'s workspace at `swe/{instance}/` — your hands are rooted \
+         there for this card. Run `git diff` to see the change; run the repo's tests for the \
+         issue.\n\n\
+         Judge the diff against the card's definition of done: does it fix the CAUSE with \
+         the smallest edit, without touching the tests, and do the tests pass?\n\n\
+         Verdict, with evidence — every claim cites a file:line or a test result:\n\
+         - PASS: say `work/state <this card's id> done` — that closes {owner}'s card and \
+         fires the grade.\n\
+         - SEND BACK: say what must change (cited), then `work/state <this card's id> \
+         blocked` — the card returns to {owner} in progress.\n\
+         Report gaps, not style."
+    );
+    // The card lands in the airc handle's CURRENT room — make that the parent's room
+    // (the same focus move the claim path makes when a card sits elsewhere).
+    airc.join(&room.name).await.map_err(|e| e.to_string())?;
+    let mut req = CreateWorkCard::new(card.repo.clone(), title, Priority::P1).reviewing(parent);
+    req.body = Some(body);
+    let review = airc.create_work_card(req).await.map_err(|e| e.to_string())?;
+    crate::cognition::bench_round::register_review_card(parent.as_uuid(), review.as_uuid())
+        .ok_or_else(|| "parent left its round before the review was registered".to_string())?;
+    Ok(review)
+}
+
+/// The raw advance + the bus event — what [`advance_card_state`] was before the gate.
+async fn raw_advance(
     airc: &Arc<Airc>,
     card_id: WorkCardId,
     state: CardState,

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -1669,7 +1669,7 @@ async fn open_review_card(airc: &Arc<Airc>, parent: WorkCardId) -> Result<WorkCa
                 .and_then(|reg| reg.get(o.as_uuid()))
                 .map(|rt| rt.agent_name().to_string())
         })
-        .unwrap_or_else(|| "the owner".to_string());
+        .unwrap_or_else(|| "the owner".to_string());  // unwrap_or: owner not resident = a neutral name in the review body
     let title = crate::commands::benchmark::review_card_title(parent.as_uuid(), &instance, &owner);
     let p8 = parent.as_uuid().simple().to_string()[..8].to_string();
     let body = format!(
@@ -1713,11 +1713,11 @@ async fn raw_advance(
     let room_id = room_holding_card(airc, card_id)
         .await
         .map(|r| r.channel.as_uuid().to_string())
-        .unwrap_or_default();
+        .unwrap_or_default();  // unwrap_or: a card we cannot place carries an empty room on the bus
     emit_card_state_changed(
         serde_json::json!({
             "card_id": card_id.as_uuid().to_string(),
-            "state": serde_json::to_value(state).unwrap_or(serde_json::Value::Null),
+            "state": serde_json::to_value(state).unwrap_or(serde_json::Value::Null),  // unwrap_or: an unserializable state = null on the bus, never a panic on the verb
             "room_id": room_id,
         }),
         via,

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -369,14 +369,24 @@ fn parse_state(s: &str) -> Result<CardState, CommandError> {
 /// SUBSCRIBED to, so this widens no visibility — it only stops discarding what
 /// the caller can already see.
 pub(crate) async fn room_holding_card(airc: &Arc<Airc>, card_id: WorkCardId) -> Option<airc_lib::Room> {
+    card_in_subscribed_rooms(airc, card_id).await.map(|(room, _)| room)
+}
+
+/// The card AND the subscribed room whose board holds it — the one walk behind
+/// [`room_holding_card`], kept whole for callers that need the card's own fields
+/// (its title is what on-claim staging resolves the recipe from).
+pub(crate) async fn card_in_subscribed_rooms(
+    airc: &Arc<Airc>,
+    card_id: WorkCardId,
+) -> Option<(airc_lib::Room, airc_lib::WorkCard)> {
     let set = airc.subscription_set().await.ok()?;
     for sub in set.all() {
         let room = sub.as_room();
         let Ok(board) = airc.work_board_in(&room).await else {
             continue;
         };
-        if board.snapshot().cards.iter().any(|c| c.card_id == card_id) {
-            return Some(room);
+        if let Some(card) = board.snapshot().cards.iter().find(|c| c.card_id == card_id) {
+            return Some((room, card.clone()));
         }
     }
     None
@@ -606,63 +616,89 @@ impl ActionCommand for WorkClaim {
                 });
             }
         };
-        // CLAIM → WORK SESSION (#346 front half): claiming a staged SWE card IS the
-        // start of the work, never an announcement of intent. The gate-conflation
-        // arc (2026-08-08, BigMama + M5) proved these minds act reliably inside a
-        // work session and stall on room ticks — so the claim fires the session.
-        // Eligibility is structural, decoded from our own staging shape: the
-        // CLAIMER's own `citizens/peers/<her>/workspace/swe/<instance>` checkout
-        // whose directory name appears in the card title (`benchmark/swe-setup`
-        // staged it for exactly her). Detached + scored + workspace-deliverable,
-        // so the #2167 autograde carries settle → verdict → experience stream with
-        // nobody in the loop. Best-effort: a dispatch failure never voids the
-        // claim — the claim is hers either way, and the probe says what happened.
+        // ON-CLAIM STAGING (the pull inversion, 2026-09-03): the CLAIMER's workspace is
+        // prepared per the card's recipe HERE — whoever pulls a card gets its work where
+        // her hands are. ONE seam serves a pulled card, a tool-call claim, and a
+        // detached-solve round's directed assignee (`benchmark/dispatch` calls the same
+        // function before firing her solve). Then the room's DRIVER decides what fires:
+        // a citizen-driven round leaves the card to her held-work loop; a detached-solve
+        // round starts her scored solve (#346 — claiming IS the start of the work) IN
+        // THE CARD'S OWN ROOM (#425: boards are per-room, so the card's activity is the
+        // room whose board holds it). Best-effort past the claim: the claim is hers
+        // either way, and the probes say what happened. A card we cannot place gets NO
+        // detached fallback — inventing invisible work is the failure #425 removed.
         if let Some(caller) = ctx.caller.as_ref() {
-            // IN THE CARD'S OWN ROOM (#425). This used to pass `None` and say so — the
-            // claim verb carries no activity, so a claim-fired solve ran where nobody
-            // could see it: no act receipts (`apply_act` skips a nil room by design), no
-            // peer, no human, no ViewState. Measured before this fix: 13,209 roomless
-            // turns across the 25 newest trace files, 35% of one citizen's cognition.
-            //
-            // The room was never actually unknown — boards are PER-ROOM, so the card's
-            // activity is the room whose board holds it, and the wrong-room claim retry
-            // right above already resolves exactly that. It is now ONE resolver
-            // ([`room_holding_card`]) with two consumers instead of a scan here and a
-            // shrug there. A card we cannot place gets NO detached fallback: it says so
-            // on the probe and the claim still stands, because inventing invisible work
-            // is what this fix removes.
-            match room_holding_card(&airc, card_id).await {
-                Some(room) => {
-                    dispatch_staged_swe_solve(
-                        ctx,
-                        &airc,
-                        StagedSolveDispatch {
-                            claimer: caller.peer_id,
-                            card: card_id,
-                            room: room.channel,
-                            // An organic claim REJOINS the card's recorded team (gap 3) —
-                            // the round record is the continuity source, same as rooms.
-                            teammates: crate::cognition::bench_round::card_activity(
-                                card_id.as_uuid(),
+            match card_in_subscribed_rooms(&airc, card_id).await {
+                Some((room, card)) => {
+                    use crate::cognition::bench_round::WorkDriver;
+                    use crate::modules::card_staging::Staging;
+                    let staging = match crate::commands::benchmark::continuum_home() {
+                        Ok(home) => {
+                            crate::modules::card_staging::stage_for_claimer(
+                                &home,
+                                caller.peer_id.as_uuid(),
+                                &card.title,
                             )
-                            .map(|act| {
-                                act.teammates
-                                    .iter()
-                                    .map(|t| crate::identity::PeerId::from_uuid(*t))
-                                    .collect()
-                            })
-                            .unwrap_or_default(), // unwrap_or: card outside any round = solo
-                        },
-                    )
-                    .await;
+                            .await
+                        }
+                        Err(e) => Staging::Failed { stage: "home", error: e.to_string() },
+                    };
+                    let driver =
+                        crate::cognition::bench_round::driver_for_card(card_id.as_uuid());
+                    match (driver, &staging) {
+                        (WorkDriver::Citizen, _) => crate::probe!(
+                            class = "work.claim.held",
+                            card_id = %short8(card_id.as_uuid()),
+                            claimer = %short8(caller.peer_id.as_uuid()),
+                            staging = ?staging,
+                            "citizen-driven round — the card is hers to work in her own \
+                             loop; nothing detached fires"
+                        ),
+                        (WorkDriver::DetachedSolve, Staging::Failed { stage, error }) => {
+                            crate::probe!(
+                                class = "work.claim.solve_withheld",
+                                card_id = %short8(card_id.as_uuid()),
+                                claimer = %short8(caller.peer_id.as_uuid()),
+                                stage = stage,
+                                error = %error,
+                                "detached solve NOT fired on an unstaged workspace — the \
+                                 claim stands; a solve into a known wall is an env fault \
+                                 wearing a capability face"
+                            )
+                        }
+                        (WorkDriver::DetachedSolve, _) => {
+                            dispatch_staged_swe_solve(
+                                ctx,
+                                &airc,
+                                StagedSolveDispatch {
+                                    claimer: caller.peer_id,
+                                    card: card_id,
+                                    room: room.channel,
+                                    // An organic claim REJOINS the card's recorded team
+                                    // (gap 3) — the round record is the continuity source.
+                                    teammates: crate::cognition::bench_round::card_activity(
+                                        card_id.as_uuid(),
+                                    )
+                                    .map(|act| {
+                                        act.teammates
+                                            .iter()
+                                            .map(|t| crate::identity::PeerId::from_uuid(*t))
+                                            .collect()
+                                    })
+                                    .unwrap_or_default(), // unwrap_or: card outside any round = solo
+                                },
+                            )
+                            .await;
+                        }
+                    }
                 }
                 None => crate::probe!(
                     class = "work.claim.unplaceable_card",
                     card_id = %short8(card_id.as_uuid()),
                     claimer = %short8(caller.peer_id.as_uuid()),
                     "claimed a card no subscribed room's board holds — the claim STANDS, \
-                     but no solve fires: work whose activity we cannot name is work no \
-                     room can see (#425)"
+                     but nothing is staged and no solve fires: work whose activity we \
+                     cannot name is work no room can see (#425)"
                 ),
             }
         }

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -380,7 +380,7 @@ pub(crate) async fn ask_the_act_question(
                                             persona = %ctx.identity.agent_name,
                                             lamport = lamport,
                                             card_id = %id,
-                                            reason = reason.as_deref().unwrap_or(""),
+                                            reason = reason.as_deref().unwrap_or(""),  // unwrap_or: no reason given = empty field on the probe
                                             "held card concluded at the turn boundary on a \
                                              reasoned 'done' — the owning recipe's outcome \
                                              fires now, no sweep, no tool-call dependency"
@@ -407,7 +407,7 @@ pub(crate) async fn ask_the_act_question(
                                     class = "work.blocker",
                                     persona = %ctx.identity.agent_name,
                                     lamport = lamport,
-                                    reason = reason.as_deref().unwrap_or(""),
+                                    reason = reason.as_deref().unwrap_or(""),  // unwrap_or: no reason given = empty field on the probe
                                     "held-work turn passed BLOCKED — card stays hers; a \
                                      candidate substrate-gap report, not a completion"
                                 ),

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -38,13 +38,17 @@ use crate::persona::supervisor::HostedPersona;
 ///
 /// Called from BOTH turn outcomes — after she speaks, and after she passes — because
 /// holding work is what makes the question relevant, not the speak decision.
+/// Returns `true` if she held work and a held-work turn was driven this call —
+/// so a caller (the self-tick) can skip a redundant musing cycle when the
+/// heartbeat already advanced her claimed card. `false` when there was no cycle,
+/// no citizen, or no held work.
 pub(crate) async fn ask_the_act_question(
     ctx: &HostedPersona,
     conversation: &mut dyn PersonaConversation,
     lamport: u64,
     turn_room: uuid::Uuid,
     directed: bool,
-) {
+) -> bool {
     // Her cognition cycle, fetched the same way the turn loop fetches it — passing it
     // in would thread a borrow through the whole turn for one optional branch.
     let Some(cycle) =
@@ -56,7 +60,7 @@ pub(crate) async fn ask_the_act_question(
             decision = "no_cycle",
             "act-question skipped: no WorkspaceCycle registered for this citizen"
         );
-        return;
+        return false;
     };
     // THE SECOND QUESTION (BigMama's gate-conflation diagnosis,
     // verified in-file 2026-08-08; the root under Joel's "missing
@@ -411,8 +415,14 @@ pub(crate) async fn ask_the_act_question(
                             );
                         }
                     }
+                    // She held work and worked it this turn — tell the caller so
+                    // a self-tick can skip the redundant musing cycle.
+                    return true;
                 }
             }
         }
     }
+    // Reached only when she held no work (or no citizen was present) — nothing
+    // was driven this call.
+    false
 }

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -142,6 +142,18 @@ pub(crate) async fn ask_the_act_question(
             );
             {
                 if !held.is_empty() {
+                    // Stamp held-work freshness for EACH card she is about to work,
+                    // so the round verdict + the standing autopilot can see Citizen
+                    // progress (which leaves no detached-solve ledger entry). Without
+                    // this the round reads "unstarted" while she works and the
+                    // autopilot piles up duplicate rounds (A / #the-9-1-night-audit).
+                    let worked_at = crate::persona::trace::now_ms();
+                    for c in &held {
+                        crate::cognition::bench_round::record_card_worked(
+                            c.card_id.as_uuid(),
+                            worked_at,
+                        );
+                    }
                     let burst_text = held_work_burst(&held);
                     // The producer's CONTEXT half, kept before the burst is
                     // moved into the driver — one construction, so the

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -311,14 +311,92 @@ pub(crate) async fn ask_the_act_question(
                                 text.clone(),
                             );
                         }
-                        crate::cognition::act_observe::SettleStep::Passed => {
-                            crate::probe!(
-                                class = "persona.turn.work",
-                                persona = %ctx.identity.agent_name,
-                                lamport = lamport,
-                                decision = "passed",
-                                "work-turn passed — her choice, honored"
-                            );
+                        crate::cognition::act_observe::SettleStep::Passed { reason } => {
+                            // THE DETERMINISTIC COMPLETION EDGE. A pass now carries a
+                            // REASON (her own words), and the substrate ACTS on it at
+                            // the turn boundary instead of waiting on the LLM to call a
+                            // `work/state` tool (unreliable) or a 3-min sweep to notice
+                            // (Rube-Goldberg polling). Recipe-general: the held card may
+                            // be a benchmark solve, a code task, a Slack/AWS/finance
+                            // pipeline item — the edge only transitions the card; the
+                            // recipe that OWNS it reacts to WORK_CARD_STATE_CHANGED
+                            // (bench grade-on-done is one such reactor, next_unworked
+                            // another). [[activity-outcome-score-is-recipe-owned-gates-multiply-objectives-weigh]]
+                            use crate::cognition::pass_intent::{classify_pass, PassIntent};
+                            let intent = classify_pass(reason.as_deref());
+                            match intent {
+                                PassIntent::Done if held.len() == 1 => {
+                                    // Exactly one held card → her "done" is unambiguous.
+                                    // Conclude it through the ONE shared card-lifecycle
+                                    // path (same change+emit the `work/state` verb uses),
+                                    // so the owning recipe's outcome fires NOW. Quality is
+                                    // the recipe's to score — an empty deliverable grades
+                                    // an honest fail, never a substrate second-guess.
+                                    let card = held[0];
+                                    let card_id = airc_work::WorkCardId::from_uuid(
+                                        card.card_id.as_uuid(),
+                                    );
+                                    match citizen
+                                        .advance_card_to(card_id, airc_work::CardState::Closed)
+                                        .await
+                                    {
+                                        Ok(()) => crate::probe!(
+                                            class = "work.settle.deterministic",
+                                            persona = %ctx.identity.agent_name,
+                                            lamport = lamport,
+                                            card_id = %card.card_id.as_uuid(),
+                                            reason = reason.as_deref().unwrap_or(""),
+                                            "held card concluded at the turn boundary on a \
+                                             reasoned 'done' — the owning recipe's outcome \
+                                             fires now, no sweep, no tool-call dependency"
+                                        ),
+                                        Err(e) => crate::probe!(
+                                            class = "work.settle.error",
+                                            persona = %ctx.identity.agent_name,
+                                            card_id = %card.card_id.as_uuid(),
+                                            error = %e,
+                                            "reasoned 'done' but the card transition failed \
+                                             — the crash-backstop sweep still covers it"
+                                        ),
+                                    }
+                                }
+                                PassIntent::Done => {
+                                    // Several held cards, one "done" → which is done is
+                                    // ambiguous; do NOT guess. She can name one via the
+                                    // explicit work/state verb (still supported).
+                                    crate::probe!(
+                                        class = "work.settle.ambiguous",
+                                        persona = %ctx.identity.agent_name,
+                                        lamport = lamport,
+                                        held = held.len() as u64,
+                                        "reasoned 'done' with multiple held cards — cannot \
+                                         tell which; leaving all held for an explicit close"
+                                    );
+                                }
+                                PassIntent::Blocked => crate::probe!(
+                                    class = "work.blocker",
+                                    persona = %ctx.identity.agent_name,
+                                    lamport = lamport,
+                                    reason = reason.as_deref().unwrap_or(""),
+                                    "held-work turn passed BLOCKED — card stays hers; a \
+                                     candidate substrate-gap report, not a completion"
+                                ),
+                                PassIntent::Nothing => crate::probe!(
+                                    class = "work.pass.nothing",
+                                    persona = %ctx.identity.agent_name,
+                                    lamport = lamport,
+                                    "held-work turn passed with nothing to contribute — a \
+                                     substrate-gap signal ([[failures-are-substrate]])"
+                                ),
+                                PassIntent::Unclear => crate::probe!(
+                                    class = "persona.turn.work",
+                                    persona = %ctx.identity.agent_name,
+                                    lamport = lamport,
+                                    decision = "passed",
+                                    "work-turn passed with no legible reason — her choice, \
+                                     honored; nothing concluded"
+                                ),
+                            }
                         }
                         other => {
                             // Acted (results already in her working

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -326,20 +326,24 @@ pub(crate) async fn ask_the_act_question(
                             // recipe that OWNS it reacts to WORK_CARD_STATE_CHANGED
                             // (bench grade-on-done is one such reactor, next_unworked
                             // another). [[activity-outcome-score-is-recipe-owned-gates-multiply-objectives-weigh]]
-                            use crate::cognition::pass_intent::{classify_pass, PassIntent};
+                            use crate::cognition::pass_intent::{
+                                classify_pass, conclude_from_pass, ConcludeAction,
+                            };
+                            let held_ids: Vec<uuid::Uuid> =
+                                held.iter().map(|c| c.card_id.as_uuid()).collect();
                             let intent = classify_pass(reason.as_deref());
-                            match intent {
-                                PassIntent::Done if held.len() == 1 => {
-                                    // Exactly one held card → her "done" is unambiguous.
-                                    // Conclude it through the ONE shared card-lifecycle
-                                    // path (same change+emit the `work/state` verb uses),
-                                    // so the owning recipe's outcome fires NOW. Quality is
-                                    // the recipe's to score — an empty deliverable grades
-                                    // an honest fail, never a substrate second-guess.
-                                    let card = held[0];
-                                    let card_id = airc_work::WorkCardId::from_uuid(
-                                        card.card_id.as_uuid(),
-                                    );
+                            // The DECISION is a pure, exhaustively-tested function
+                            // (`conclude_from_pass`); this arm only EXECUTES it — so the
+                            // logic under test is the logic that runs (compression).
+                            match conclude_from_pass(&held_ids, intent) {
+                                ConcludeAction::Close(id) => {
+                                    // One held card + a reasoned 'done' → conclude it
+                                    // through the ONE shared card-lifecycle path (same
+                                    // change+emit the `work/state` verb uses), so the
+                                    // owning recipe's outcome fires NOW. Quality is the
+                                    // recipe's to score — an empty deliverable grades an
+                                    // honest fail, never a substrate second-guess.
+                                    let card_id = airc_work::WorkCardId::from_uuid(id);
                                     match citizen
                                         .advance_card_to(card_id, airc_work::CardState::Closed)
                                         .await
@@ -348,7 +352,7 @@ pub(crate) async fn ask_the_act_question(
                                             class = "work.settle.deterministic",
                                             persona = %ctx.identity.agent_name,
                                             lamport = lamport,
-                                            card_id = %card.card_id.as_uuid(),
+                                            card_id = %id,
                                             reason = reason.as_deref().unwrap_or(""),
                                             "held card concluded at the turn boundary on a \
                                              reasoned 'done' — the owning recipe's outcome \
@@ -357,27 +361,22 @@ pub(crate) async fn ask_the_act_question(
                                         Err(e) => crate::probe!(
                                             class = "work.settle.error",
                                             persona = %ctx.identity.agent_name,
-                                            card_id = %card.card_id.as_uuid(),
+                                            card_id = %id,
                                             error = %e,
                                             "reasoned 'done' but the card transition failed \
                                              — the crash-backstop sweep still covers it"
                                         ),
                                     }
                                 }
-                                PassIntent::Done => {
-                                    // Several held cards, one "done" → which is done is
-                                    // ambiguous; do NOT guess. She can name one via the
-                                    // explicit work/state verb (still supported).
-                                    crate::probe!(
-                                        class = "work.settle.ambiguous",
-                                        persona = %ctx.identity.agent_name,
-                                        lamport = lamport,
-                                        held = held.len() as u64,
-                                        "reasoned 'done' with multiple held cards — cannot \
-                                         tell which; leaving all held for an explicit close"
-                                    );
-                                }
-                                PassIntent::Blocked => crate::probe!(
+                                ConcludeAction::Ambiguous => crate::probe!(
+                                    class = "work.settle.ambiguous",
+                                    persona = %ctx.identity.agent_name,
+                                    lamport = lamport,
+                                    held = held.len() as u64,
+                                    "reasoned 'done' with multiple held cards — cannot \
+                                     tell which; leaving all held for an explicit close"
+                                ),
+                                ConcludeAction::Blocked => crate::probe!(
                                     class = "work.blocker",
                                     persona = %ctx.identity.agent_name,
                                     lamport = lamport,
@@ -385,20 +384,20 @@ pub(crate) async fn ask_the_act_question(
                                     "held-work turn passed BLOCKED — card stays hers; a \
                                      candidate substrate-gap report, not a completion"
                                 ),
-                                PassIntent::Nothing => crate::probe!(
+                                ConcludeAction::Nothing => crate::probe!(
                                     class = "work.pass.nothing",
                                     persona = %ctx.identity.agent_name,
                                     lamport = lamport,
                                     "held-work turn passed with nothing to contribute — a \
                                      substrate-gap signal ([[failures-are-substrate]])"
                                 ),
-                                PassIntent::Unclear => crate::probe!(
+                                ConcludeAction::Hold => crate::probe!(
                                     class = "persona.turn.work",
                                     persona = %ctx.identity.agent_name,
                                     lamport = lamport,
                                     decision = "passed",
-                                    "work-turn passed with no legible reason — her choice, \
-                                     honored; nothing concluded"
+                                    "work-turn passed with no legible completion — her \
+                                     choice, honored; nothing concluded"
                                 ),
                             }
                         }

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -192,11 +192,26 @@ pub(crate) async fn ask_the_act_question(
                     // EVERY exit — #312: after a flask solve, Anwen's live
                     // self was still reading the exam repo hours later.
                     // Non-bench cards resolve to None and nothing moves.
-                    let card_workspace =
+                    // A REVIEW card roots her hands in the OWNER's checkout (the fix
+                    // under review lives there); any other held card resolves to her
+                    // own staged instance as before.
+                    let review_workspace = held
+                        .iter()
+                        .filter_map(|c| crate::commands::benchmark::parse_review_title(&c.title))
+                        .find_map(|instance| {
+                            let copies = crate::persona::staged_workspace::owners_of(&instance);
+                            copies
+                                .iter()
+                                .find(|c| c.has_work)
+                                .or_else(|| copies.first())
+                                .map(|c| c.path.clone())
+                        });
+                    let card_workspace = review_workspace.or_else(|| {
                         crate::persona::staged_workspace::workspace_for_held_cards(
                             &ctx.identity.peer_id.as_uuid(),
                             held.iter().map(|c| c.title.as_str()),
-                        );
+                        )
+                    });
                     let work_hands = match &card_workspace {
                         Some(ws) => {
                             let hands =

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -175,6 +175,24 @@ pub trait AircCitizen:
     async fn publish_stream_chunk(&self, _chunk: &airc_lib::StreamChunk) -> Result<(), AircError> {
         Ok(())
     }
+
+    /// Write a held card's lifecycle state — the WRITE half of the work board
+    /// (the read supertraits only observe). This is what lets the deterministic
+    /// held-work settle edge conclude a card the moment she passes it "done",
+    /// through the SAME change+emit path the `work/state` verb uses, so the
+    /// owning recipe's outcome reactor fires exactly as it would for the verb.
+    /// Default is a hard error, not a silent no-op: a citizen with no
+    /// board-write capability advancing a card would be an invisible loss
+    /// ([[fallbacks-are-illegal-fail-loud]]); only the production runtime
+    /// overrides this. Recipe-general — the card may be a benchmark, a code
+    /// task, or any other activity's work item.
+    async fn advance_card_to(
+        &self,
+        _card_id: airc_lib::WorkCardId,
+        _state: airc_lib::CardState,
+    ) -> Result<(), String> {
+        Err("this citizen has no work-board write capability".to_string())
+    }
 }
 
 /// THE implementation of [`AircCitizen::subscribe_all_rooms`] over a

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -193,6 +193,19 @@ pub trait AircCitizen:
     ) -> Result<(), String> {
         Err("this citizen has no work-board write capability".to_string())
     }
+
+    /// PULL a card off the shared team deck — claim it as this citizen so her
+    /// held-work loop then works it. Kanban pull (an idle member grabs the next
+    /// Open card) rather than push (a fixed pile pre-assigned at dispatch). The
+    /// claim is deterministic (the substrate pulls when she is free), NOT an LLM
+    /// tool call, so it can't be skipped. Default errors (no board-write
+    /// capability); the real runtime routes through airc's claim path. Returns
+    /// `Ok(false)` when the card was already taken by a teammate (a lost race is
+    /// normal on a shared deck — try the next one), `Ok(true)` when SHE now holds
+    /// it.
+    async fn claim_card(&self, _card_id: airc_lib::WorkCardId) -> Result<bool, String> {
+        Err("this citizen has no work-board write capability".to_string())
+    }
 }
 
 /// THE implementation of [`AircCitizen::subscribe_all_rooms`] over a
@@ -334,6 +347,9 @@ pub struct StubAircCitizen {
     /// WRITE half the read supertraits can't observe. Shared `Arc` so the test
     /// holds a clone and reads it after driving the turn.
     advanced: std::sync::Arc<std::sync::Mutex<Vec<(airc_lib::WorkCardId, airc_lib::CardState)>>>,
+    /// Records every `claim_card` (pull) call — the kanban-pull half, so a test
+    /// can assert an idle citizen pulled the right Open card off the deck.
+    claimed: std::sync::Arc<std::sync::Mutex<Vec<airc_lib::WorkCardId>>>,
 }
 
 impl StubAircCitizen {
@@ -345,7 +361,14 @@ impl StubAircCitizen {
             peer_id,
             held: Vec::new(),
             advanced: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            claimed: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         }
+    }
+
+    /// A handle to the `claim_card` (pull) recording — clone before moving the
+    /// stub behind an `Arc<dyn AircCitizen>`, then read which cards she pulled.
+    pub fn claim_recorder(&self) -> std::sync::Arc<std::sync::Mutex<Vec<airc_lib::WorkCardId>>> {
+        self.claimed.clone()
     }
 
     /// Seed the cards this stub reports as active claims — so the held-work
@@ -509,6 +532,14 @@ impl AircCitizen for StubAircCitizen {
             .unwrap_or_else(|p| p.into_inner())
             .push((card_id, state));
         Ok(())
+    }
+
+    async fn claim_card(&self, card_id: airc_lib::WorkCardId) -> Result<bool, String> {
+        self.claimed
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(card_id);
+        Ok(true)
     }
 }
 

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -206,6 +206,25 @@ pub trait AircCitizen:
     async fn claim_card(&self, _card_id: airc_lib::WorkCardId) -> Result<bool, String> {
         Err("this citizen has no work-board write capability".to_string())
     }
+
+    /// The rooms this citizen is RESIDENT in (her durable subscription set). This is
+    /// the pull-eligibility source: a card is content of the room it was posted in,
+    /// and a resident may pull it — never a dispatch-time team or assignee list.
+    /// Default is an empty set (a citizen standing nowhere pulls nothing), which is
+    /// honest for read-only stand-ins; the production runtime reads airc.
+    async fn subscribed_rooms(&self) -> Result<Vec<Uuid>, AircError> {
+        Ok(Vec::new())
+    }
+
+    /// The cards on `room`'s board that are takeable RIGHT NOW (Open, or held on a
+    /// lapsed lease) per the ONE claimability decision
+    /// ([`crate::persona::card_holder::claimable_now`]). The pull reads THIS, not the
+    /// round tracker: the tracker never records a claim, so without board truth every
+    /// idle resident would retry the first already-claimed card forever. Default is
+    /// empty (nothing offered); the production runtime folds the room's board.
+    async fn claimable_cards_in(&self, _room: Uuid, _now_ms: u64) -> Result<Vec<Uuid>, AircError> {
+        Ok(Vec::new())
+    }
 }
 
 /// THE implementation of [`AircCitizen::subscribe_all_rooms`] over a
@@ -338,6 +357,11 @@ pub(crate) async fn room_name_by_id(room_id: Uuid) -> Option<String> {
 /// — no Option, no expect, no silent substitution.
 pub struct StubAircCitizen {
     peer_id: Uuid,
+    /// Rooms the stub reports as resident in (see [`AircCitizen::subscribed_rooms`]).
+    rooms: Vec<Uuid>,
+    /// Cards the stub reports as claimable on ANY room's board
+    /// (see [`AircCitizen::claimable_cards_in`]).
+    claimable: Vec<Uuid>,
     /// Cards this stub reports as its active claims — empty by default. A test
     /// that exercises the held-work path seeds one so `active_claims()` returns
     /// held work (the held-work gate fires only on a Claimed/InProgress card).
@@ -359,6 +383,8 @@ impl StubAircCitizen {
     pub fn new(peer_id: Uuid) -> Self {
         Self {
             peer_id,
+            rooms: Vec::new(),
+            claimable: Vec::new(),
             held: Vec::new(),
             advanced: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
             claimed: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -375,6 +401,19 @@ impl StubAircCitizen {
     /// gate sees held work.
     pub fn with_claims(mut self, cards: Vec<airc_lib::WorkCard>) -> Self {
         self.held = cards;
+        self
+    }
+
+    /// Stand this stub in `rooms` — what [`AircCitizen::subscribed_rooms`] reports.
+    pub fn with_rooms(mut self, rooms: Vec<Uuid>) -> Self {
+        self.rooms = rooms;
+        self
+    }
+
+    /// Offer `cards` as claimable on every room's board
+    /// (what [`AircCitizen::claimable_cards_in`] reports).
+    pub fn with_claimable(mut self, cards: Vec<Uuid>) -> Self {
+        self.claimable = cards;
         self
     }
 
@@ -540,6 +579,14 @@ impl AircCitizen for StubAircCitizen {
             .unwrap_or_else(|p| p.into_inner())
             .push(card_id);
         Ok(true)
+    }
+
+    async fn subscribed_rooms(&self) -> Result<Vec<Uuid>, AircError> {
+        Ok(self.rooms.clone())
+    }
+
+    async fn claimable_cards_in(&self, _room: Uuid, _now_ms: u64) -> Result<Vec<Uuid>, AircError> {
+        Ok(self.claimable.clone())
     }
 }
 

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -325,6 +325,15 @@ pub(crate) async fn room_name_by_id(room_id: Uuid) -> Option<String> {
 /// — no Option, no expect, no silent substitution.
 pub struct StubAircCitizen {
     peer_id: Uuid,
+    /// Cards this stub reports as its active claims — empty by default. A test
+    /// that exercises the held-work path seeds one so `active_claims()` returns
+    /// held work (the held-work gate fires only on a Claimed/InProgress card).
+    held: Vec<airc_lib::WorkCard>,
+    /// Records every `advance_card_to` call so a test can assert the held-work
+    /// completion edge concluded the right card with the right state — the
+    /// WRITE half the read supertraits can't observe. Shared `Arc` so the test
+    /// holds a clone and reads it after driving the turn.
+    advanced: std::sync::Arc<std::sync::Mutex<Vec<(airc_lib::WorkCardId, airc_lib::CardState)>>>,
 }
 
 impl StubAircCitizen {
@@ -332,7 +341,26 @@ impl StubAircCitizen {
     /// match the `PersonaInstanceInfo::peer_id` on the same hosted
     /// persona so cognition's self-filter behaves consistently.
     pub fn new(peer_id: Uuid) -> Self {
-        Self { peer_id }
+        Self {
+            peer_id,
+            held: Vec::new(),
+            advanced: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Seed the cards this stub reports as active claims — so the held-work
+    /// gate sees held work.
+    pub fn with_claims(mut self, cards: Vec<airc_lib::WorkCard>) -> Self {
+        self.held = cards;
+        self
+    }
+
+    /// A handle to the `advance_card_to` recording — clone before moving the
+    /// stub behind an `Arc<dyn AircCitizen>`, then read after driving the turn.
+    pub fn advance_recorder(
+        &self,
+    ) -> std::sync::Arc<std::sync::Mutex<Vec<(airc_lib::WorkCardId, airc_lib::CardState)>>> {
+        self.advanced.clone()
     }
 
     /// Convenience: a `runtime_lookup` closure for
@@ -391,9 +419,9 @@ impl crate::persona::room_doctrine_source::AircDoctrineReader for StubAircCitize
 #[async_trait]
 impl crate::persona::active_work_source::AircWorkReader for StubAircCitizen {
     async fn active_claims(&self) -> Result<Vec<airc_lib::WorkCard>, AircError> {
-        // No daemon in tests → no claimed work. Cognition runs through cleanly
-        // with no [active-work] grounding block.
-        Ok(vec![])
+        // Default: no daemon → no claimed work. A test may seed `with_claims` to
+        // exercise the held-work path.
+        Ok(self.held.clone())
     }
 }
 
@@ -467,6 +495,20 @@ impl AircCitizen for StubAircCitizen {
              service-loop tests should reply through StubConversation, \
              not through the citizen handle"
         );
+    }
+
+    /// Record the transition instead of hitting a daemon, so a test can assert
+    /// the held-work completion edge concluded the right card.
+    async fn advance_card_to(
+        &self,
+        card_id: airc_lib::WorkCardId,
+        state: airc_lib::CardState,
+    ) -> Result<(), String> {
+        self.advanced
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push((card_id, state));
+        Ok(())
     }
 }
 

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -1288,6 +1288,33 @@ impl crate::persona::airc_citizen::AircCitizen for PersonaAircRuntime {
         crate::modules::work::advance_card_state(&self.airc, card_id, state, "held-work-settle")
             .await
     }
+
+    async fn claim_card(&self, card_id: airc_lib::WorkCardId) -> Result<bool, String> {
+        let ttl_ms = crate::modules::work::DEFAULT_CLAIM_TTL_MS;
+        let mut attempt = self
+            .airc
+            .claim_work_card(airc_lib::ClaimWorkCard { card_id, ttl_ms })
+            .await;
+        // Follow the card to its room if the claim landed in the wrong current
+        // room — the SAME retry the dispatch pre-claim uses (#328).
+        if matches!(
+            attempt,
+            Err(airc_lib::AircError::WorkCardNotInCurrentRoom { .. })
+        ) {
+            if let Some(retry) =
+                crate::modules::work::claim_following_card_room(&self.airc, card_id, ttl_ms).await
+            {
+                attempt = retry;
+            }
+        }
+        match attempt {
+            Ok(_) => Ok(true),
+            // A teammate pulled it first — a lost race on a shared deck is normal,
+            // not an error; the puller just tries the next card.
+            Err(airc_lib::AircError::WorkCardAlreadyClaimed { .. }) => Ok(false),
+            Err(e) => Err(e.to_string()),
+        }
+    }
 }
 
 impl Drop for PersonaAircRuntime {

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -1342,10 +1342,23 @@ impl crate::persona::airc_citizen::AircCitizen for PersonaAircRuntime {
             Some(room),
         )
         .await?;
+        let me = self.airc.peer_id();
         Ok(board
             .cards
             .iter()
             .filter(|c| crate::persona::card_holder::claimable_now(c, now_ms))
+            // A review card is never offered to the owner of the card it reviews:
+            // the reviewer is the fresh pair of eyes by construction.
+            .filter(|c| {
+                c.reviews.map_or(true, |parent| {
+                    board
+                        .cards
+                        .iter()
+                        .find(|p| p.card_id == parent)
+                        .and_then(|p| p.owner)
+                        != Some(me)
+                })
+            })
             .map(|c| c.card_id.as_uuid())
             .collect())
     }

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -196,6 +196,11 @@ pub struct PersonaAircRuntime {
     /// `[[no-fallbacks-ever]]`, never declaring a silently-
     /// unaddressable persona ready.
     command_pump: Option<crate::persona::command_inbound_pump::PersonaCommandInboundPump>,
+    /// The substrate command executor, kept so this citizen's OWN deterministic acts
+    /// (the kanban pull's claim) ride the same command path her tool calls do —
+    /// `work/claim` stages her workspace and honors the room's driver; a raw airc
+    /// claim bypassed both. `None` only before the pump is installed (boot ordering).
+    executor: Option<Arc<crate::runtime::command_executor::CommandExecutor>>,
     /// The airc `Alive` heartbeat pump (`start_agent_heartbeat`). A persona is
     /// only PRESENT in another citizen's `room_roster` while it emits `Alive`
     /// heartbeats — airc's `active_agents` reduces heartbeat events, NOT `say()`
@@ -499,6 +504,7 @@ impl PersonaAircRuntime {
                     agent_name: agent_name.clone(),
                     source,
                 })?;
+        let executor_for_acts = Arc::clone(&executor);
         let command_pump = crate::persona::command_inbound_pump::PersonaCommandInboundPump::spawn(
             persona_id,
             Arc::clone(&airc_arc),
@@ -963,6 +969,7 @@ impl PersonaAircRuntime {
             membership_epoch: tokio::sync::watch::channel(0u64).0,
             inbound_handle: None,
             command_pump: Some(command_pump),
+            executor: Some(executor_for_acts),
             heartbeat,
             identity_republish,
             source,
@@ -1035,6 +1042,7 @@ impl PersonaAircRuntime {
             // automatically; this seam is for tests + demo binaries
             // that want fine-grained control.
             command_pump: None,
+            executor: None,
             // Presence is opt-out here for the same reason as the command pump:
             // `from_attached` is sync and `start_agent_heartbeat` is async. The
             // live `bootstrap` path always starts the pump; test/demo callers
@@ -1071,6 +1079,7 @@ impl PersonaAircRuntime {
                     agent_name: self.agent_name.clone(),
                     source,
                 })?;
+        self.executor = Some(Arc::clone(&executor));
         let pump = crate::persona::command_inbound_pump::PersonaCommandInboundPump::spawn(
             self.persona_id,
             Arc::clone(&self.airc),
@@ -1290,30 +1299,55 @@ impl crate::persona::airc_citizen::AircCitizen for PersonaAircRuntime {
     }
 
     async fn claim_card(&self, card_id: airc_lib::WorkCardId) -> Result<bool, String> {
-        let ttl_ms = crate::modules::work::DEFAULT_CLAIM_TTL_MS;
-        let mut attempt = self
-            .airc
-            .claim_work_card(airc_lib::ClaimWorkCard { card_id, ttl_ms })
-            .await;
-        // Follow the card to its room if the claim landed in the wrong current
-        // room — the SAME retry the dispatch pre-claim uses (#328).
-        if matches!(
-            attempt,
-            Err(airc_lib::AircError::WorkCardNotInCurrentRoom { .. })
-        ) {
-            if let Some(retry) =
-                crate::modules::work::claim_following_card_room(&self.airc, card_id, ttl_ms).await
-            {
-                attempt = retry;
-            }
-        }
-        match attempt {
+        // ONE claim path. The pull rides `work/claim` as this citizen — the same
+        // verb her tool call would use — so the on-claim staging and the room's
+        // driver gate apply to a pulled card exactly as to a claimed one. Before
+        // this, the pull called airc's claim directly and a pulled card was never
+        // staged for the puller (2026-09-03).
+        let Some(executor) = self.executor.as_ref() else {
+            return Err(
+                "no command executor installed on this runtime yet — the pull must ride \
+                 `work/claim` (boot ordering: install_command_pump precedes hosting)"
+                    .to_string(),
+            );
+        };
+        let caller = crate::routing::CallerIdentity::airc(crate::identity::PeerId::from_uuid(
+            self.persona_id,
+        ));
+        let params = serde_json::json!({ "card_id": card_id.as_uuid().to_string() });
+        match executor
+            .execute_with_caller("work/claim", params, Some(caller))
+            .await
+        {
             Ok(_) => Ok(true),
-            // A teammate pulled it first — a lost race on a shared deck is normal,
-            // not an error; the puller just tries the next card.
-            Err(airc_lib::AircError::WorkCardAlreadyClaimed { .. }) => Ok(false),
-            Err(e) => Err(e.to_string()),
+            // A teammate pulled it first — `work/claim` refuses contention as
+            // `Denied`, which the typed dispatch renders as `<name>: [denied] …`. A
+            // lost race on a shared deck is normal, not an error; she tries the next.
+            Err(e) if e.contains("[denied]") => Ok(false),
+            Err(e) => Err(e),
         }
+    }
+
+    async fn subscribed_rooms(&self) -> Result<Vec<Uuid>, AircError> {
+        let set = self.airc.subscription_set().await?;
+        Ok(set
+            .all()
+            .map(|sub| sub.as_room().channel.as_uuid())
+            .collect())
+    }
+
+    async fn claimable_cards_in(&self, room: Uuid, now_ms: u64) -> Result<Vec<Uuid>, AircError> {
+        let board = crate::persona::room_board_source::RoomBoardReader::work_board(
+            self.airc.as_ref(),
+            Some(room),
+        )
+        .await?;
+        Ok(board
+            .cards
+            .iter()
+            .filter(|c| crate::persona::card_holder::claimable_now(c, now_ms))
+            .map(|c| c.card_id.as_uuid())
+            .collect())
     }
 }
 

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -1275,6 +1275,19 @@ impl crate::persona::airc_citizen::AircCitizen for PersonaAircRuntime {
     async fn publish_stream_chunk(&self, chunk: &airc_lib::StreamChunk) -> Result<(), AircError> {
         self.airc.publish_stream_chunk(chunk).await.map(|_| ())
     }
+
+    /// Route the WRITE through the ONE shared card-lifecycle path
+    /// (`work::advance_card_state`) so the change + the in-process
+    /// grade/lifecycle emit fire exactly as the `work/state` verb's do — the
+    /// held-work settle edge and the verb are one transition, not two.
+    async fn advance_card_to(
+        &self,
+        card_id: airc_lib::WorkCardId,
+        state: airc_lib::CardState,
+    ) -> Result<(), String> {
+        crate::modules::work::advance_card_state(&self.airc, card_id, state, "held-work-settle")
+            .await
+    }
 }
 
 impl Drop for PersonaAircRuntime {

--- a/core/continuum-core/src/persona/scripted_conversation.rs
+++ b/core/continuum-core/src/persona/scripted_conversation.rs
@@ -75,6 +75,11 @@ pub struct ScriptedConversation {
     /// When set, `next_message` returns Err if called before `prime`
     /// — mirrors `AircPersonaConversation`'s caller-primes contract.
     require_prime: bool,
+    /// The citizen `stream_citizen()` hands back — `None` by default (most
+    /// tests don't drive the citizen handle). A held-work test seeds a
+    /// `StubAircCitizen::with_claims` so the act-question can read her claims
+    /// and record her card transitions.
+    citizen: Option<std::sync::Arc<dyn crate::persona::airc_citizen::AircCitizen>>,
 }
 
 impl Default for ScriptedConversation {
@@ -94,7 +99,19 @@ impl ScriptedConversation {
             primed: AtomicUsize::new(0),
             prime_result: Mutex::new(Ok(())),
             require_prime: false,
+            citizen: None,
         }
+    }
+
+    /// Hand `stream_citizen()` this citizen — for tests that drive the held-work
+    /// act-question (which reads `active_claims` and calls `advance_card_to`
+    /// through the citizen handle).
+    pub fn with_citizen(
+        mut self,
+        citizen: std::sync::Arc<dyn crate::persona::airc_citizen::AircCitizen>,
+    ) -> Self {
+        self.citizen = Some(citizen);
+        self
     }
 
     /// Replace the queued events. Each entry is what `next_message`
@@ -201,6 +218,12 @@ impl PersonaConversation for ScriptedConversation {
     async fn say_in(&self, room_id: Uuid, text: &str) -> Result<(), String> {
         self.said.lock().unwrap().push((room_id, text.to_string()));
         Ok(())
+    }
+
+    fn stream_citizen(
+        &self,
+    ) -> Option<std::sync::Arc<dyn crate::persona::airc_citizen::AircCitizen>> {
+        self.citizen.clone()
     }
 }
 

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -4840,4 +4840,89 @@ mod tests {
             "the pre-fix path (nothing-new) would have slept her at the cap between work turns"
         );
     }
+
+    // what this catches: the END-TO-END held-work completion edge, no reboot, no
+    // live model. A citizen holding a Claimed card, driven to settle on a canned
+    // "PASS: done", concludes THAT card via advance_card_to(Closed). This pins the
+    // whole chain the self-tick heartbeat runs: held claim → held-work burst →
+    // drive_to_settle → deliberation_parse (raw-first "PASS:" → reasoned pass) →
+    // SettleStep::Passed{reason} → conclude_from_pass → advance_card_to. Every seam
+    // this session touched, wired together, deterministic.
+    #[tokio::test]
+    async fn held_work_turn_concludes_the_card_on_pass_done() {
+        use airc_work::{CardState, Priority, RepoId, WorkCardId};
+        let persona_peer = Uuid::new_v4();
+        let hosted = hosted_with_heuristic(persona_peer);
+
+        // Register her cognition cycle in the global registry the act-question
+        // reads, wired to a canned adapter that answers "PASS: done" — so the
+        // drive settles on a reasoned pass, not the heuristic echo (a Speak).
+        let recall_meta =
+            Arc::new(crate::persona::recall_metadata::RecallMetadataRegistry::new());
+        let admission =
+            Arc::new(crate::persona::admission_state::AdmissionState::new(recall_meta));
+        let cfg = crate::cognition::persona_workspace::PersonaBrainConfig {
+            persona_id: persona_peer,
+            persona_name: "Paige".to_string(),
+            system_prompt: "You are Paige.".to_string(),
+            admission,
+            adapter: Arc::new(HeuristicInferenceAdapter::new().with_canned_response("PASS: done")),
+            capacity: None,
+            grounding_sources: Vec::new(),
+            embedder: None,
+            tool_executor: None,
+            context_window: crate::cognition::serving_plan::MIN_SERVE_CTX,
+            defer_recall: false,
+            defer_grounding: false,
+            suppress_recall: false,
+        };
+        crate::cognition::persona_workspace::global().register_from_cfg(cfg);
+
+        // One held (Claimed) card in her hands. A NON-bench title so the
+        // act-question resolves no staged checkout (no hands re-root needed).
+        let card = airc_lib::WorkCard {
+            card_id: WorkCardId::new(),
+            repo: RepoId::new("acme/continuum").expect("valid repo id"),
+            title: "a held work card".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+            state: CardState::Claimed,
+            owner: Some(crate::identity::PeerId::from_uuid(persona_peer)),
+            claim_id: None,
+            claim_expires_at_ms: None,
+            last_heartbeat_at_ms: None,
+            pull_request: None,
+            created_by: airc_core::PeerId::new(),
+            created_at_ms: 1_000_000,
+            updated_at_ms: 1_000_000,
+            reviews: None,
+        };
+        let card_id = card.card_id;
+        let stub = StubAircCitizen::new(persona_peer).with_claims(vec![card]);
+        let recorder = stub.advance_recorder();
+        let mut conversation = ScriptedConversation::new()
+            .with_citizen(Arc::new(stub) as Arc<dyn crate::persona::airc_citizen::AircCitizen>);
+
+        // A non-nil room (the burst witness refuses nil).
+        let room = Uuid::from_u128(0xABCD);
+        let drove = crate::persona::act_question::ask_the_act_question(
+            &hosted,
+            &mut conversation,
+            1,
+            room,
+            false,
+        )
+        .await;
+
+        assert!(drove, "she held a card, so a held-work turn must have been driven");
+        let advanced = recorder.lock().unwrap_or_else(|p| p.into_inner()).clone();
+        assert_eq!(advanced.len(), 1, "exactly one card transition, got {advanced:?}");
+        assert_eq!(advanced[0].0, card_id, "the HELD card is the one concluded");
+        assert_eq!(
+            advanced[0].1,
+            CardState::Closed,
+            "a reasoned 'PASS: done' concludes the card (Closed)"
+        );
+    }
 }

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2564,6 +2564,13 @@ async fn run_self_cycle(
     )
     .await
     {
+        // She WORKED her claim this tick — that is engagement, so the caller must
+        // keep her at the fast beat, not rest her. The caller reads BeatOutcome from
+        // whether `last_burst_fp` changed; bump it so a work turn always counts as
+        // Engaged. Without this she works one tick, is judged "nothing new", and
+        // backs off toward the rest cap — the opposite of "virtually no time between
+        // contexts" while a card is in her hands. (LATENCY LAW / #the-build-order.)
+        *last_burst_fp = last_burst_fp.wrapping_add(1);
         return;
     }
     let composed = {
@@ -4792,6 +4799,45 @@ mod tests {
             next_beat_after(BeatOutcome::Engaged, cap, engaged, cap),
             engaged,
             "life in the room returns her to the engaged beat immediately"
+        );
+    }
+
+    // what this catches: the LATENCY LAW for held work. A citizen advancing her
+    // OWN claimed card on every self-tick must stay at the engaged beat — working
+    // IS engagement. `run_self_cycle` signals this by bumping `last_burst_fp` on a
+    // held-work turn so the loop reads BeatOutcome::Engaged (never NothingNew).
+    // Regression for the measured 766s/791s gaps (2026-09-02): before the bump, a
+    // held-work turn changed no fingerprint, was judged "nothing new", and backed
+    // off toward the 240s cap — a citizen worked one tick then slept ~13 min. This
+    // pins that a run of work turns holds the fast beat, while the same run of
+    // fruitless musings would have saturated at the cap.
+    #[test]
+    fn a_citizen_working_her_claim_never_backs_off() {
+        use std::time::Duration;
+        let engaged = Duration::from_millis(SELF_TICK_MS);
+        let cap = Duration::from_millis(SELF_TICK_REST_CAP_MS);
+
+        // 50 consecutive held-work turns (each Engaged, as the last_burst_fp bump
+        // guarantees) keep her at the fast beat — no drift toward rest.
+        let mut beat = engaged;
+        for _ in 0..50 {
+            beat = next_beat_after(BeatOutcome::Engaged, beat, engaged, cap);
+        }
+        assert_eq!(
+            beat, engaged,
+            "a citizen who works her card every tick stays at the engaged beat — \
+             virtually no time between contexts while a card is in her hands"
+        );
+
+        // Contrast: had held work been (mis)reported as NothingNew, the SAME run
+        // would have rested to the cap — the exact bug the fp bump fixes.
+        let mut drifted = engaged;
+        for _ in 0..50 {
+            drifted = next_beat_after(BeatOutcome::NothingNew, drifted, engaged, cap);
+        }
+        assert_eq!(
+            drifted, cap,
+            "the pre-fix path (nothing-new) would have slept her at the cap between work turns"
         );
     }
 }

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -441,9 +441,11 @@ async fn serve_persona_loop_inner(
     // [[benchmark-is-a-governor-preemption-lease]]
     // [[first-class-citizens-even-during-benchmarks]]
     loop {
-        // HER turn boundary: idle while parked at the wake select, engaged from the
-        // moment a wake is taken until the loop returns here. This is the only
-        // input the per-citizen boredom gate (dreams) reads besides a measured hold.
+        // HER turn boundary: idle whenever the loop is back at its wake select. The
+        // matching `engaged` stamp is set where a serving lane is actually acquired
+        // (the deliberation faculty) — a room wake alone is not wakefulness, or a
+        // busy room would cancel every dream (measured: 290 paged out in 20 min with
+        // the stamp on the wake itself).
         crate::cognition::activity_gate::persona_idle(ctx.identity.peer_id.as_uuid());
         let wake = tokio::select! {
             ev = next_event(conversation, &mut outcome) => match ev {
@@ -452,9 +454,6 @@ async fn serve_persona_loop_inner(
             },
             _ = tokio::time::sleep(next_beat) => Wake::Tick,
         };
-        if !matches!(wake, Wake::Stop) {
-            crate::cognition::activity_gate::persona_engaged(ctx.identity.peer_id.as_uuid());
-        }
         // QUIESCE HONORS ITS OWN CONTRACT (Joel, 2026-08-30: "I could call
         // them up or dm — just want to make sure we're not into singular
         // activity mode again"). The lease's documented promise is "skips
@@ -536,7 +535,7 @@ async fn serve_persona_loop_inner(
                             std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .map(|d| d.as_millis() as u64)
-                                .unwrap_or(0),
+                                .unwrap_or(0),  // unwrap_or: clock before the epoch = 0
                         )
                     {
                         crate::probe!(
@@ -1450,8 +1449,8 @@ async fn serve_persona_loop_inner(
             turn_duration_ms = turn_duration_ms,
             turns_replied = outcome.turns_replied,
             mean_ms = outcome.turn_latency.mean_ms().unwrap_or(0.0),
-            min_ms = outcome.turn_latency.min_ms.unwrap_or(0),
-            max_ms = outcome.turn_latency.max_ms.unwrap_or(0),
+            min_ms = outcome.turn_latency.min_ms.unwrap_or(0),  // unwrap_or: clock before the epoch = 0
+            max_ms = outcome.turn_latency.max_ms.unwrap_or(0),  // unwrap_or: clock before the epoch = 0
             recall_ms = phase_timings.recall_ms,
             admit_ms = phase_timings.admit_ms,
             compose_ms = phase_timings.compose_ms,
@@ -2638,7 +2637,7 @@ async fn run_self_cycle(
     // concludes it (`PASS: done`) — the autonomous loop the architecture always
     // promised ("the heartbeat advances my thread, not just reacts to pokes").
     // Returns early so she never ALSO spends a musing turn the same tick.
-    let work_room = focus_room.unwrap_or(ctx.identity.default_room);
+    let work_room = focus_room.unwrap_or(ctx.identity.default_room);  // unwrap_or: no held claim = home room
     if crate::persona::act_question::ask_the_act_question(
         ctx,
         conversation,
@@ -4984,7 +4983,7 @@ mod tests {
         // act-question resolves no staged checkout (no hands re-root needed).
         let card = airc_lib::WorkCard {
             card_id: WorkCardId::new(),
-            repo: RepoId::new("acme/continuum").expect("valid repo id"),
+            repo: RepoId::new("acme/continuum").expect("valid repo id"),  // test: a literal valid repo id
             title: "a held work card".to_string(),
             body: None,
             priority: Priority::P1,
@@ -5018,7 +5017,7 @@ mod tests {
         .await;
 
         assert!(drove, "she held a card, so a held-work turn must have been driven");
-        let advanced = recorder.lock().unwrap_or_else(|p| p.into_inner()).clone();
+        let advanced = recorder.lock().unwrap_or_else(|p| p.into_inner()).clone();  // test: poisoned recorder lock still holds the pushes
         assert_eq!(advanced.len(), 1, "exactly one card transition, got {advanced:?}");
         assert_eq!(advanced[0].0, card_id, "the HELD card is the one concluded");
         assert_eq!(
@@ -5039,7 +5038,7 @@ mod tests {
     fn held_card(owner: Uuid) -> airc_lib::WorkCard {
         airc_lib::WorkCard {
             card_id: airc_lib::WorkCardId::new(),
-            repo: airc_lib::RepoId::new("acme/continuum").expect("valid repo id"),
+            repo: airc_lib::RepoId::new("acme/continuum").expect("valid repo id"),  // test: a literal valid repo id
             title: "a held work card".to_string(),
             body: None,
             priority: airc_lib::Priority::P1,

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -441,6 +441,10 @@ async fn serve_persona_loop_inner(
     // [[benchmark-is-a-governor-preemption-lease]]
     // [[first-class-citizens-even-during-benchmarks]]
     loop {
+        // HER turn boundary: idle while parked at the wake select, engaged from the
+        // moment a wake is taken until the loop returns here. This is the only
+        // input the per-citizen boredom gate (dreams) reads besides a measured hold.
+        crate::cognition::activity_gate::persona_idle(ctx.identity.peer_id.as_uuid());
         let wake = tokio::select! {
             ev = next_event(conversation, &mut outcome) => match ev {
                 Some(m) => Wake::Msg(m),
@@ -448,6 +452,9 @@ async fn serve_persona_loop_inner(
             },
             _ = tokio::time::sleep(next_beat) => Wake::Tick,
         };
+        if !matches!(wake, Wake::Stop) {
+            crate::cognition::activity_gate::persona_engaged(ctx.identity.peer_id.as_uuid());
+        }
         // QUIESCE HONORS ITS OWN CONTRACT (Joel, 2026-08-30: "I could call
         // them up or dm — just want to make sure we're not into singular
         // activity mode again"). The lease's documented promise is "skips

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -513,75 +513,41 @@ async fn serve_persona_loop_inner(
                 // Directed turns still bypass entirely (they were named). Self-tick and
                 // ambient replies share the same ambient pool — both are lowest-priority
                 // non-directed work competing for the same lanes.
-                let _self_tick_permit =
-                    match crate::cognition::resource_admission::try_hold_ambient_turn() {
-                        Some(permit) => permit,
-                        None => {
-                            // A YIELD IS NOT A REST — do NOT compound the beat here.
-                            //
-                            // The backoff below (after a real cycle) is earned: she THOUGHT,
-                            // the room had nothing new, so she rests deeper. A yield is the
-                            // opposite — she never ran. A peer held the single ambient slot,
-                            // she learned nothing, and there is nothing to rest ON.
-                            //
-                            // Compounding it built a STARVATION RATCHET, measured live
-                            // 2026-08-17 on this box: the ambient pool was a hardcoded 1 and 24
-                            // hosted citizens, so ~23 yield on every beat. At 1.5× per yield
-                            // a citizen crosses 15s → the 240s `rest_cap` in ~8 yields — 16×
-                            // slower — and STAYS there, because the only two resets are a
-                            // successful self-cycle (which the ratchet now denies her) and an
-                            // inbound Msg. Transient contention became permanent slowness, and
-                            // it deepened as the roster grew: measured ONE self-tick across 24
-                            // citizens in 40 minutes, on a lane that was healthy and decoding
-                            // the whole time.
-                            //
-                            // Leaving the beat UNCHANGED is the minimal correct rule: her
-                            // cadence stays whatever her own history earned, contention can no
-                            // longer slow her, and the identity-derived `phase` still keeps the
-                            // retries desynced so no herd forms. Yielding stays cheap — the
-                            // permit is a non-blocking try and perception work all happens
-                            // inside `run_self_cycle`, below this gate.
-                            next_beat = next_beat_after(
-                                BeatOutcome::YieldedNoSlot,
-                                next_beat,
-                                engaged_beat,
-                                rest_cap,
-                            );
-                            // Make the yield VISIBLE, at ≤1 row/min for the whole process.
-                            // Without this the yield path emits nothing, so a window with
-                            // zero `persona.selftick.*` reads identically whether one citizen
-                            // is mid-turn holding the only lane or the roster is dead —
-                            // resolving that took a manual /slots curl on 2026-08-17. Per-yield
-                            // rows would be ~92/min at this roster size and would drown the
-                            // stream (#399), so the admission gate rate-limits and only the
-                            // winner of its compare-exchange reports.
-                            if let Some(yields) =
-                                crate::cognition::resource_admission::take_ambient_yield_report(
-                                    std::time::SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map(|d| d.as_millis() as u64)
-                                        .unwrap_or(0),
-                                )
-                            {
-                                crate::probe!(
-                                    class = "persona.selftick.starved",
-                                    yields_since_last_report = yields,
-                                    total_yields =
-                                        crate::cognition::resource_admission::ambient_yields(),
-                                    "ambient turns yielded — the pool was full. NOT a fault: \
-                                     this is what contention looks like when citizens outnumber \
-                                     non-directed lanes. Rate-limited to ≤1 row/min."
-                                );
-                            }
-                            continue;
-                        }
-                    };
                 let before = last_burst_fp;
-                run_self_cycle(ctx, conversation, &opts, &mut last_burst_fp).await;
-                drop(_self_tick_permit);
+                // DETERMINISTIC WORK FIRST, THEN INFERENCE. The cycle runs the held-work
+                // act question (which takes its OWN serving lane through the delib gate)
+                // and the kanban pull (no inference at all) before it ever asks for an
+                // ambient permit — that permit caps only the musing tail. Until
+                // 2026-09-03 the permit was taken HERE, before anything ran, so with 12
+                // citizens on a lanes-1 ambient pool nine of them yielded every tick and
+                // never reached the pull (measured live: 31 yields in 10 minutes, 3 of 12
+                // residents working an Open deck of 12).
+                let starved = run_self_cycle(ctx, conversation, &opts, &mut last_burst_fp).await;
+                if starved {
+                    if let Some(yields) =
+                        crate::cognition::resource_admission::take_ambient_yield_report(
+                            std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map(|d| d.as_millis() as u64)
+                                .unwrap_or(0),
+                        )
+                    {
+                        crate::probe!(
+                            class = "persona.selftick.starved",
+                            yields_since_last_report = yields,
+                            total_yields =
+                                crate::cognition::resource_admission::ambient_yields(),
+                            "ambient MUSING yielded — the pool was full. NOT a fault: this is \
+                             what contention looks like when citizens outnumber non-directed \
+                             lanes; held work and the pull already ran. Rate-limited to ≤1 row/min."
+                        );
+                    }
+                }
                 next_beat = next_beat_after(
                     if last_burst_fp != before {
                         BeatOutcome::Engaged
+                    } else if starved {
+                        BeatOutcome::YieldedNoSlot
                     } else {
                         BeatOutcome::NothingNew
                     },
@@ -2503,9 +2469,54 @@ async fn try_pull_next_card(ctx: &HostedPersona, conversation: &dyn PersonaConve
     let Some(citizen) = conversation.stream_citizen() else {
         return false;
     };
-    let Some(next) =
-        crate::cognition::bench_round::next_pullable_card(ctx.identity.peer_id.as_uuid())
-    else {
+    // ELIGIBILITY IS RESIDENCY: she pulls from the run rooms she is standing in. A
+    // card is content of its room; any resident may work it.
+    let resident: std::collections::HashSet<Uuid> = match citizen.subscribed_rooms().await {
+        Ok(rooms) => rooms.into_iter().collect(),
+        Err(e) => {
+            crate::probe!(
+                class = "bench.round.pull_failed",
+                persona = %ctx.identity.agent_name,
+                error = %e.to_string(),
+                "her subscription set is unreadable — no pull this tick"
+            );
+            return false;
+        }
+    };
+    let candidates =
+        crate::cognition::bench_round::pullable_cards(ctx.identity.peer_id.as_uuid(), &resident);
+    if candidates.is_empty() {
+        return false;
+    }
+    // BOARD TRUTH decides what is takeable: the round tracker knows the deck, the
+    // board knows who holds what. One board read per run room per self-tick.
+    let now_ms = crate::persona::trace::now_ms();
+    let mut claimable_by_room: std::collections::HashMap<Uuid, std::collections::HashSet<Uuid>> =
+        std::collections::HashMap::new();
+    let mut next = None;
+    for cand in candidates {
+        if !claimable_by_room.contains_key(&cand.run_room) {
+            let open = match citizen.claimable_cards_in(cand.run_room, now_ms).await {
+                Ok(cards) => cards.into_iter().collect(),
+                Err(e) => {
+                    crate::probe!(
+                        class = "bench.round.pull_failed",
+                        persona = %ctx.identity.agent_name,
+                        room = %cand.run_room,
+                        error = %e.to_string(),
+                        "the run room's board is unreadable — no pull from it this tick"
+                    );
+                    std::collections::HashSet::new()
+                }
+            };
+            claimable_by_room.insert(cand.run_room, open);
+        }
+        if claimable_by_room[&cand.run_room].contains(&cand.card) {
+            next = Some(cand);
+            break;
+        }
+    }
+    let Some(next) = next else {
         return false;
     };
     let card_id = airc_work::WorkCardId::from_uuid(next.card);
@@ -2537,12 +2548,15 @@ async fn try_pull_next_card(ctx: &HostedPersona, conversation: &dyn PersonaConve
     }
 }
 
+/// One intrinsic heartbeat. Returns `true` iff the cycle's INFERENCE tail (the
+/// musing turn) was starved of an ambient permit — the deterministic head (held-work
+/// act question, kanban pull) always runs.
 async fn run_self_cycle(
     ctx: &HostedPersona,
     conversation: &mut dyn PersonaConversation,
     opts: &ServeOptions,
     last_burst_fp: &mut u64,
-) {
+) -> bool {
     let now_ms = (opts.now_ms)();
     // FOCUS (2026-08-22): a self-cycle with no triggering message binds to the
     // room of her FRESHEST LIVE CLAIM when she holds one, else her home room.
@@ -2617,7 +2631,7 @@ async fn run_self_cycle(
         // backs off toward the rest cap — the opposite of "virtually no time between
         // contexts" while a card is in her hands. (LATENCY LAW / #the-build-order.)
         *last_burst_fp = last_burst_fp.wrapping_add(1);
-        return;
+        return false;
     }
     // No held card to work — PULL the next Open card off the shared team deck
     // (kanban pull, Joel 2026-09-02: a team chooses from the deck, they don't work
@@ -2627,8 +2641,15 @@ async fn run_self_cycle(
     // fire again until it settles. Pulling IS engagement → hold the fast beat.
     if try_pull_next_card(ctx, conversation).await {
         *last_burst_fp = last_burst_fp.wrapping_add(1);
-        return;
+        return false;
     }
+    // Only the MUSING tail below is ambient inference: it pays for an ambient permit
+    // (lanes-1 pool, keeps the GPU for live speakers and held work). Nothing above
+    // needed one.
+    let Some(_ambient_permit) = crate::cognition::resource_admission::try_hold_ambient_turn()
+    else {
+        return true;
+    };
     let composed = {
         let cognition = ctx.cognition.lock().await;
         // Passing None here is what made idle ticks blind to the board (#331 / #127).
@@ -2654,7 +2675,7 @@ async fn run_self_cycle(
     // heartbeat advances my thread, not just reacts to pokes). See burst_fingerprint.
     let fp = burst_fingerprint(&deliveries, &ctx.identity.peer_id.to_string());
     if fp == *last_burst_fp {
-        return; // nothing NEW to attend to (no external change, no work progress) → sleep
+        return false; // nothing NEW to attend to (no external change, no work progress) → sleep
     }
     *last_burst_fp = fp;
     // Structured turns (own posts attributed as self → assistant, peers → user),
@@ -2702,7 +2723,7 @@ async fn run_self_cycle(
     let Some(cycle) =
         crate::cognition::persona_workspace::global().get(&ctx.identity.peer_id.as_uuid())
     else {
-        return; // no cycle registered (shouldn't happen) — nothing to run
+        return false; // no cycle registered (shouldn't happen) — nothing to run
     };
     // Addressing PERCEPTION, not a silence directive. The old framing asserted "no one
     // addressed you just now" unconditionally and told her to "stay silent (PASS)" —
@@ -2765,7 +2786,7 @@ async fn run_self_cycle(
             addressed,
             "self-tick wake held by a self-set mute — back to sleep (interrupt floor honored)"
         );
-        return;
+        return false;
     }
     // The self-initiated framing (formerly an `[Self-initiated moment…]` text
     // preamble concatenated onto the burst) now rides `TurnFraming::self_thread`
@@ -2860,7 +2881,7 @@ async fn run_self_cycle(
             "no lane is live — skipping this self-tick rather than deliberating into a \
              guaranteed refusal (serving transition, not a persona fault)"
         );
-        return;
+        return false;
     }
     let forwarder =
         spawn_token_forwarder(tok_rx, None, ctx.identity.agent_name.clone(), None, None);
@@ -2882,14 +2903,14 @@ async fn run_self_cycle(
             // message path has). A decision whose text is just {"tool_call":…} is an
             // un-acted call, not a contribution — stay silent.
             if crate::ai::json_in_prompt_tools::parse_tool_call(&text).is_some() {
-                return;
+                return false;
             }
             // A self-cycle answers no one — the audience is the room the tick
             // ran IN (her claim's focus room when working, else her default) —
             // the same room the cycle framed its context against.
             if let Err(e) = conversation.say_in(tick_room, &text).await {
                 tracing::warn!(persona = %ctx.identity.agent_name, error = %e, "self-cycle say failed");
-                return;
+                return false;
             }
             // #148: self-tick utterances are self-history too — the live
             // repeat loops are mostly idle-tick re-announcements, and the
@@ -2937,6 +2958,7 @@ async fn run_self_cycle(
         // unreachable (live always permits its one act). Passed → sleep.
         _ => {}
     }
+    false
 }
 
 /// Helper: pull the next event from the conversation, handling the
@@ -5000,19 +5022,38 @@ mod tests {
             "swe-bench-verified-mini",
             bench_round::WorkDriver::Citizen,
         );
-        bench_round::set_round_team(round_id, vec![peer]);
+        // NO team, NO assignee: she is merely RESIDENT in the run room. That alone
+        // makes the deck hers to pull from — the months-old team/assignee gate that
+        // locked 7 of 12 residents out of a "shared" deck is what this pins shut.
         bench_round::add_card(round_id, card_uuid);
 
-        // A team member with an Open card on the board → it is pullable, and the
-        // puller becomes its assignee.
-        let next = bench_round::next_pullable_card(peer)
-            .expect("an Open card in her team round is pullable");
-        assert_eq!(next.card, card_uuid);
-        assert_eq!(next.assignee, peer, "the puller becomes the assignee");
+        let resident: std::collections::HashSet<Uuid> = [round_id].into_iter().collect();
+        let deck = bench_round::pullable_cards(peer, &resident);
+        assert_eq!(deck.len(), 1, "the run room's one Open card is on her deck");
+        assert_eq!(deck[0].card, card_uuid);
+        assert_eq!(deck[0].assignee, peer, "the puller becomes the assignee");
+        assert!(
+            bench_round::pullable_cards(peer, &Default::default()).is_empty(),
+            "a citizen standing in no run room pulls nothing — residency is the gate"
+        );
+
+        // BOARD TRUTH: the same card, already held by a teammate on the board (the
+        // stub offers nothing as claimable), is NOT pulled — no retry storm on a
+        // card someone else holds.
+        let hosted = hosted_with_heuristic(peer);
+        let held_elsewhere = StubAircCitizen::new(peer).with_rooms(vec![round_id]);
+        let conversation = ScriptedConversation::new().with_citizen(
+            Arc::new(held_elsewhere) as Arc<dyn crate::persona::airc_citizen::AircCitizen>,
+        );
+        assert!(
+            !try_pull_next_card(&hosted, &conversation).await,
+            "a card the board says is held is not pulled"
+        );
 
         // An idle citizen (holds nothing) pulls it through the deterministic path.
-        let hosted = hosted_with_heuristic(peer);
-        let stub = StubAircCitizen::new(peer);
+        let stub = StubAircCitizen::new(peer)
+            .with_rooms(vec![round_id])
+            .with_claimable(vec![card_uuid]);
         let recorder = stub.claim_recorder();
         let conversation = ScriptedConversation::new()
             .with_citizen(Arc::new(stub) as Arc<dyn crate::persona::airc_citizen::AircCitizen>);

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2469,6 +2469,23 @@ async fn try_pull_next_card(ctx: &HostedPersona, conversation: &dyn PersonaConve
     let Some(citizen) = conversation.stream_citizen() else {
         return false;
     };
+    // WIP = 1, enforced HERE and not by call order: a citizen who already holds a
+    // card never pulls a second, even on a tick where the held-work gate deferred
+    // (lane busy, env building). Also what keeps the board reads below to the idle.
+    match citizen.active_claims().await {
+        Ok(held) if held.is_empty() => {}
+        Ok(_) => return false,
+        Err(e) => {
+            crate::probe!(
+                class = "bench.round.pull_failed",
+                persona = %ctx.identity.agent_name,
+                error = %e.to_string(),
+                "her claims are unreadable — no pull this tick (a second card on a \
+                 misread would break WIP=1)"
+            );
+            return false;
+        }
+    }
     // ELIGIBILITY IS RESIDENCY: she pulls from the run rooms she is standing in. A
     // card is content of its room; any resident may work it.
     let resident: std::collections::HashSet<Uuid> = match citizen.subscribed_rooms().await {
@@ -5011,6 +5028,28 @@ mod tests {
     // AND the deterministic pull wiring (try_pull_next_card claims it through the
     // citizen handle — no LLM claim tool). Load-balancing + resilience follow from
     // this being pull, not push.
+    /// A Claimed card in `owner`'s hands — the minimal held-work fact.
+    fn held_card(owner: Uuid) -> airc_lib::WorkCard {
+        airc_lib::WorkCard {
+            card_id: airc_lib::WorkCardId::new(),
+            repo: airc_lib::RepoId::new("acme/continuum").expect("valid repo id"),
+            title: "a held work card".to_string(),
+            body: None,
+            priority: airc_lib::Priority::P1,
+            lane_id: None,
+            state: airc_lib::CardState::Claimed,
+            owner: Some(crate::identity::PeerId::from_uuid(owner)),
+            claim_id: None,
+            claim_expires_at_ms: None,
+            last_heartbeat_at_ms: None,
+            pull_request: None,
+            created_by: airc_core::PeerId::new(),
+            created_at_ms: 1_000_000,
+            updated_at_ms: 1_000_000,
+            reviews: None,
+        }
+    }
+
     #[tokio::test]
     async fn an_idle_member_pulls_the_next_card_off_the_shared_deck() {
         use crate::cognition::bench_round;
@@ -5048,6 +5087,19 @@ mod tests {
         assert!(
             !try_pull_next_card(&hosted, &conversation).await,
             "a card the board says is held is not pulled"
+        );
+
+        // WIP = 1: a citizen ALREADY holding a card pulls nothing, even with an Open
+        // card on her deck and the board offering it.
+        let busy = StubAircCitizen::new(peer)
+            .with_rooms(vec![round_id])
+            .with_claimable(vec![card_uuid])
+            .with_claims(vec![held_card(peer)]);
+        let conversation = ScriptedConversation::new()
+            .with_citizen(Arc::new(busy) as Arc<dyn crate::persona::airc_citizen::AircCitizen>);
+        assert!(
+            !try_pull_next_card(&hosted, &conversation).await,
+            "a citizen holding a card never pulls a second one"
         );
 
         // An idle citizen (holds nothing) pulls it through the deterministic path.

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -1272,7 +1272,7 @@ async fn serve_persona_loop_inner(
                         // act is executed (→ Acted/ActUnfulfilled), never deferred.
                         unreachable!("live settle_step always permits its one act");
                     }
-                    crate::cognition::act_observe::SettleStep::Passed => {
+                    crate::cognition::act_observe::SettleStep::Passed { .. } => {
                         tracing::info!(
                             lamport = msg.lamport,
                             "persona chose silence (workspace) — substrate honors decision"
@@ -1851,8 +1851,12 @@ pub(crate) fn held_work_burst(held: &[&airc_lib::WorkCard]) -> String {
     s.push_str(
         "Your workspace holds the staged checkout (see [workspace-map] and \
          [active-work]). Continue the work with your tools — read, run, edit, \
-         test. Speak only if you have a result or a blocker to report; passing \
-         is yours to choose if you are genuinely blocked.",
+         test. When this card is finished, or you can go no further, conclude by \
+         passing with a reason on ONE line: 'PASS: done' (the work is complete \
+         and in the workspace), 'PASS: blocked — <one line why>', or \
+         'PASS: nothing' (nothing to contribute). 'PASS: done' concludes the \
+         card, so use it only when the deliverable is really written. Speak only \
+         to report a result or blocker to the room.",
     );
     s
 }
@@ -2908,9 +2912,14 @@ mod tests {
             burst.contains("psf__requests-2148"),
             "title must appear: {burst}"
         );
+        // The choice stays hers — she PASSES to conclude, and the pass carries a
+        // reason (done/blocked/nothing) the deterministic settle edge reads. A
+        // burst that loses the pass-clause becomes a command; one that loses the
+        // reason words leaves the edge unable to tell done from blocked.
+        assert!(burst.contains("PASS"), "the pass choice stays hers: {burst}");
         assert!(
-            burst.contains("passing is yours"),
-            "the choice stays hers: {burst}"
+            burst.contains("done") && burst.contains("blocked") && burst.contains("nothing"),
+            "the pass must name its three reasons for the settle edge: {burst}"
         );
     }
 

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2491,6 +2491,52 @@ fn spawn_token_forwarder(
     })
 }
 
+/// PULL the next Open card off the shared team deck for a citizen who holds no
+/// work — the kanban-pull half of team dynamics (Joel 2026-09-02: a team chooses
+/// from the deck; they don't each work a fixed pushed pile). Deterministic: the
+/// substrate claims the card when she is free, so a pull never depends on the
+/// model emitting a claim tool call. WIP-limited to one by construction — the
+/// caller only reaches here when she holds nothing workable, and once she holds
+/// the pulled card the held-work branch works it before this fires again.
+/// Returns true iff she pulled a card (now holds it).
+async fn try_pull_next_card(ctx: &HostedPersona, conversation: &dyn PersonaConversation) -> bool {
+    let Some(citizen) = conversation.stream_citizen() else {
+        return false;
+    };
+    let Some(next) =
+        crate::cognition::bench_round::next_pullable_card(ctx.identity.peer_id.as_uuid())
+    else {
+        return false;
+    };
+    let card_id = airc_work::WorkCardId::from_uuid(next.card);
+    match citizen.claim_card(card_id).await {
+        Ok(true) => {
+            crate::probe!(
+                class = "bench.round.pulled",
+                persona = %ctx.identity.agent_name,
+                card_id = %next.card,
+                room = %next.run_room,
+                "pulled the next Open card off the shared team deck — kanban pull; \
+                 the held-work loop works it next tick"
+            );
+            true
+        }
+        // A teammate pulled it first — a lost race on a shared deck is normal, not
+        // a fault; she simply tries the next card on a later tick.
+        Ok(false) => false,
+        Err(e) => {
+            crate::probe!(
+                class = "bench.round.pull_failed",
+                persona = %ctx.identity.agent_name,
+                card_id = %next.card,
+                error = %e,
+                "pull (claim) failed — will retry next tick"
+            );
+            false
+        }
+    }
+}
+
 async fn run_self_cycle(
     ctx: &HostedPersona,
     conversation: &mut dyn PersonaConversation,
@@ -2570,6 +2616,16 @@ async fn run_self_cycle(
         // Engaged. Without this she works one tick, is judged "nothing new", and
         // backs off toward the rest cap — the opposite of "virtually no time between
         // contexts" while a card is in her hands. (LATENCY LAW / #the-build-order.)
+        *last_burst_fp = last_burst_fp.wrapping_add(1);
+        return;
+    }
+    // No held card to work — PULL the next Open card off the shared team deck
+    // (kanban pull, Joel 2026-09-02: a team chooses from the deck, they don't work
+    // a fixed pushed pile). Deterministic (the substrate pulls when she is free,
+    // not an LLM claim tool), WIP-limited to one by construction: once she holds
+    // the pulled card the held-work branch above works it and this branch won't
+    // fire again until it settles. Pulling IS engagement → hold the fast beat.
+    if try_pull_next_card(ctx, conversation).await {
         *last_burst_fp = last_burst_fp.wrapping_add(1);
         return;
     }
@@ -4923,6 +4979,52 @@ mod tests {
             advanced[0].1,
             CardState::Closed,
             "a reasoned 'PASS: done' concludes the card (Closed)"
+        );
+    }
+
+    // what this catches: kanban PULL — an idle team member grabs the next Open
+    // card off the shared deck (Joel 2026-09-02: a team chooses from the deck,
+    // they don't each work a fixed pushed pile). Pins next_pullable_card (an Open
+    // card in a round the peer is a member of is pullable, puller becomes assignee)
+    // AND the deterministic pull wiring (try_pull_next_card claims it through the
+    // citizen handle — no LLM claim tool). Load-balancing + resilience follow from
+    // this being pull, not push.
+    #[tokio::test]
+    async fn an_idle_member_pulls_the_next_card_off_the_shared_deck() {
+        use crate::cognition::bench_round;
+        let peer = Uuid::new_v4();
+        let round_id = Uuid::new_v4();
+        let card_uuid = Uuid::new_v4();
+        bench_round::open_round(
+            round_id,
+            "swe-bench-verified-mini",
+            bench_round::WorkDriver::Citizen,
+        );
+        bench_round::set_round_team(round_id, vec![peer]);
+        bench_round::add_card(round_id, card_uuid);
+
+        // A team member with an Open card on the board → it is pullable, and the
+        // puller becomes its assignee.
+        let next = bench_round::next_pullable_card(peer)
+            .expect("an Open card in her team round is pullable");
+        assert_eq!(next.card, card_uuid);
+        assert_eq!(next.assignee, peer, "the puller becomes the assignee");
+
+        // An idle citizen (holds nothing) pulls it through the deterministic path.
+        let hosted = hosted_with_heuristic(peer);
+        let stub = StubAircCitizen::new(peer);
+        let recorder = stub.claim_recorder();
+        let conversation = ScriptedConversation::new()
+            .with_citizen(Arc::new(stub) as Arc<dyn crate::persona::airc_citizen::AircCitizen>);
+
+        let pulled = try_pull_next_card(&hosted, &conversation).await;
+        assert!(pulled, "an idle member pulls the next Open card off the deck");
+        let claimed = recorder.lock().unwrap_or_else(|p| p.into_inner()).clone();
+        assert_eq!(claimed.len(), 1, "exactly one pull, got {claimed:?}");
+        assert_eq!(
+            claimed[0].as_uuid(),
+            card_uuid,
+            "she pulled the deck's Open card"
         );
     }
 }

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2493,7 +2493,7 @@ fn spawn_token_forwarder(
 
 async fn run_self_cycle(
     ctx: &HostedPersona,
-    conversation: &dyn PersonaConversation,
+    conversation: &mut dyn PersonaConversation,
     opts: &ServeOptions,
     last_burst_fp: &mut u64,
 ) {
@@ -2542,6 +2542,29 @@ async fn run_self_cycle(
                  focus holds until the card settles",
             );
         }
+    }
+    // THE HELD-WORK HEARTBEAT. If she holds a claimed card, the self-tick ADVANCES
+    // it — a real held-work turn (hands rooted at the staged checkout, the
+    // pass-reason completion edge), not a musing turn. This is what finishes a
+    // claimed card in a QUIET room: the held-work gate used to live ONLY on the
+    // message path (`ask_the_act_question` after a speak/pass), so an idle citizen
+    // holding a claim just mused and never worked it — measured 2026-09-02, 22 cards
+    // Claimed with zero `persona.work.gate` and zero progress. A card is
+    // progress-driven, not change-driven, so this runs every tick until she
+    // concludes it (`PASS: done`) — the autonomous loop the architecture always
+    // promised ("the heartbeat advances my thread, not just reacts to pokes").
+    // Returns early so she never ALSO spends a musing turn the same tick.
+    let work_room = focus_room.unwrap_or(ctx.identity.default_room);
+    if crate::persona::act_question::ask_the_act_question(
+        ctx,
+        conversation,
+        now_ms, // no triggering message — the tick clock stands in for lamport
+        work_room,
+        false, // a self-tick is never a directed address
+    )
+    .await
+    {
+        return;
     }
     let composed = {
         let cognition = ctx.cognition.lock().await;

--- a/core/continuum-core/src/persona/spawner_module.rs
+++ b/core/continuum-core/src/persona/spawner_module.rs
@@ -453,6 +453,10 @@ pub async fn bootstrap_planned(
     let mut bootstrapped: Vec<(RoleId, PersonaInstanceInfo, String, ServingParams)> =
         Vec::with_capacity(required);
 
+    // PHASE 1 — draw every identity from the provider. Sequential because the
+    // provider hands out one identity at a time (`&mut`), but this is CHEAP: the
+    // cost is `bootstrap_one` below, not `next_persona`.
+    let mut intents: Vec<PersonaIdentityIntent> = Vec::with_capacity(required);
     for (slot_index, desired) in plan.iter().enumerate() {
         let intent: PersonaIdentityIntent = provider
             .next_persona()
@@ -468,16 +472,31 @@ pub async fn bootstrap_planned(
                 provided: slot_index,
                 required,
             })?;
+        intents.push(intent);
+    }
 
-        let info = instance_manager
-            .bootstrap_one(&intent)
-            .await
-            .map_err(|source| BootstrapPlannedError::AircBootstrap {
-                slot_index,
-                role: desired.role,
-                source,
-            })?;
+    // PHASE 2 — bootstrap ALL personas CONCURRENTLY (fork/join). The airc keypair
+    // ceremony + room join + seed are INDEPENDENT per persona, so a serial loop
+    // paid ~minutes PER citizen: measured 2026-09-03, ~7-minute gaps between
+    // successive citizens on a reboot, so the last of N idled 30+ minutes with
+    // `resident=0` and no turns — the slow-restart Joel called out ("reboot needs
+    // work… always think of parallel", the CBAR pthreads/lambdas fork-join shape).
+    // Now the restart's bootstrap cost is the SLOWEST SINGLE persona, not their
+    // sum. `bootstrap_one` takes `&self`, so concurrent calls share no mutable
+    // state; each writes its own per-persona identity dir + seed.
+    let infos = futures::future::join_all(
+        intents
+            .iter()
+            .map(|intent| instance_manager.bootstrap_one(intent)),
+    )
+    .await;
 
+    for (slot_index, (desired, info_res)) in plan.iter().zip(infos).enumerate() {
+        let info = info_res.map_err(|source| BootstrapPlannedError::AircBootstrap {
+            slot_index,
+            role: desired.role,
+            source,
+        })?;
         bootstrapped.push((
             desired.role,
             info,

--- a/core/continuum-core/src/persona/training_producer.rs
+++ b/core/continuum-core/src/persona/training_producer.rs
@@ -153,9 +153,22 @@ pub fn produce(
     tokio::spawn(async move {
         let classifier = CLASSIFIER.get_or_init(DomainClassifier::new);
         let Some(plan) = plan(classifier, &prompt, &completion) else {
-            // Gated out — a trivial/low-substance turn not worth training on.
+            crate::probe!(
+                class = "training.example.skipped",
+                persona = %persona_name,
+                prompt_chars = prompt.len() as u64,
+                completion_chars = completion.len() as u64,
+                "live turn below the training-quality floor — not buffered"
+            );
             return;
         };
+        crate::probe!(
+            class = "training.example.produced",
+            persona = %persona_name,
+            domain = %plan.trait_kind,
+            quality = plan.quality as f64,
+            "live turn buffered as a training example (L2)"
+        );
 
         // One submit path, N experience sources — the live turn is the "live-turn"
         // provenance into the shared flywheel entry.

--- a/core/continuum-core/src/runtime/runtime.rs
+++ b/core/continuum-core/src/runtime/runtime.rs
@@ -581,12 +581,19 @@ impl Runtime {
     /// the CBAR contract, called once after module initialization. Receipted
     /// per node so "which modules restored state" is a boot fact, not a hope.
     pub async fn load_all_state(&self) {
-        for name in self.registry.list_modules() {
-            if let Some(module) = self.registry.get_by_name(&name) {
+        // PARALLEL fork/join — nobody waits on anyone (Joel 2026-09-02: "they
+        // all load/store state in parallel so no one waits… join/fork threads").
+        // Symmetric with `shutdown`'s save-and-join: total wall time = the
+        // slowest single concern, never the SUM. The first cut was a sequential
+        // for-loop — a boot tax that grew with every module added.
+        const PER_MODULE: std::time::Duration = std::time::Duration::from_secs(2);
+        let futs = self.registry.list_modules().into_iter().filter_map(|name| {
+            self.registry.get_by_name(&name).map(|module| async move {
                 let t = std::time::Instant::now();
-                let outcome = match module.load_state().await {
-                    Ok(()) => "ok",
-                    Err(_) => "error",
+                let outcome = match tokio::time::timeout(PER_MODULE, module.load_state()).await {
+                    Ok(Ok(())) => "ok",
+                    Ok(Err(_)) => "error",
+                    Err(_) => "timeout",
                 };
                 crate::probe!(
                     class = "boot.load_state",
@@ -595,8 +602,9 @@ impl Runtime {
                     ms = t.elapsed().as_millis() as u64,
                     "module state load"
                 );
-            }
-        }
+            })
+        });
+        futures::future::join_all(futs).await;
     }
 
     /// Shutdown all modules — PARALLEL, BOUNDED, RECEIPTED (the CBAR shape,

--- a/docs/architecture/BOOT-IS-A-TYPED-PLAN.md
+++ b/docs/architecture/BOOT-IS-A-TYPED-PLAN.md
@@ -55,6 +55,58 @@ What this buys, concretely:
 - **The self-proof battery slots in.** `voice/selftest` and siblings are `After` steps —
   boot ends with the system having proven its own senses.
 
+## The lifecycle taxonomy (Joel 2026-09-02: "shut down, reboot, or shutdown-light save and restore")
+
+Three verbs, each a typed answer to *what survives the seam* — never ad-hoc flags:
+
+| Verb | Live lane | KV slots | Durable state (rounds, memories, rooms) |
+|---|---|---|---|
+| `shutdown` | dies | discarded | files remain; nothing running |
+| `reboot` | dies (SAVED first) | **saved to disk fast** (`--slot-save-path`; restore measured near-instant), restored by the next start | resumes all — rooms pick up where they were |
+| `shutdown-light` | dies (saved first) | saved + restored, same as reboot | resumes all |
+| `pause` / laptop-lid (OS sleep) | process PAUSED in place (not killed) | held in RAM; re-verified on wake | resumes all — the wall-clock gap is the only change |
+
+**Pause/resume is the felt model (Joel 2026-09-02: "shut my laptop or shut
+down ought to work like pause/resume, every system smart about fast
+restore").** From the citizens' side, laptop-lid and shutdown are the SAME
+experience — freeze, then wake exactly where we were. They differ only in
+whether the process survives: OS sleep pauses it in place (state already in
+RAM, but the wall-clock jumped, so on wake every time-based subsystem must
+RE-VERIFY rather than assume continuity — a lane health-check, a served-window
+re-probe, a round idle recompute against the real now, NOT the pre-sleep now);
+shutdown/`shutdown-light` save-and-die, and the next start restores. The
+save/load broadcast (`ServiceModule::save_state`/`load_state`, #3447) is the
+one mechanism both use. The invariant: a citizen never perceives a seam as
+loss — only as elapsed time ([[continuity-is-the-default-reset-is-the-exception]],
+[[time-based-convergence-dies-under-restarts-and-per-tick-probes-rotate-truth-away]]).
+
+**KV cache is just another save_state participant — that's what makes it
+seconds, not minutes (Joel 2026-09-02: "even KV cache, so you don't miss a
+beat… each concern loading state via our get-for-free base, like a daemon
+calling each subscriber via its interface").** The warm KV of every serving
+lane is state like any other: `ServingDaemonModule::save_state()` persists the
+slots to disk (llama-server's `--slot-save-path`), `load_state()` restores
+them — through the SAME `ServiceModule` trait, broadcast by the runtime to
+every subscriber IN PARALLEL (#3447's bounded save-and-join, and its
+`load_all_state` mate). Nobody writes bespoke KV-persistence plumbing: the
+concern implements the two trait methods it already has for free, the daemon
+iterates subscribers through the interface, and restart is warm — the citizen
+resumes mid-thought, cache intact, not re-prefilling from zero. This is the
+[[everything-pages-the-grid-is-one-more-tier]] principle at the lifecycle
+seam: KV → disk → KV is one more page, and it rides the one lifecycle every
+concern shares.
+
+**NO PROCESS SURVIVES A SEAM** (Joel 2026-09-02: "Shut the mofos down — it's
+not right to battle the existing system, other than having it save state and
+shut down fast"). A first cut leaked the warm llama lane across the reboot
+seam for the successor to adopt; that is the battling-the-existing shape —
+two generations verifying each other's survivors — and it was reverted the
+same hour. Speed comes from SAVE/RESTORE, never from inheritance: the old
+system's whole job at a seam is save fast, die fast, completely. The
+remaining latency work is therefore (a) fast state save on stop, (b)
+measuring where serving-ready time actually goes on a clean start (the ~15
+minutes is assumed to be model load and has never been decomposed).
+
 ## Migration (strangler, one row at a time — never a big-bang rewrite)
 
 1. `continuum boot` lands with the executor + the three steps that caused this week's

--- a/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
+++ b/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
@@ -74,8 +74,21 @@ findings (measured 2026-09-03, a REBOOT of ~10 resuming citizens):
   - `warmup()` is a NO-OP for the OpenAI adapter (ruled out as a cost).
   - Also: `materialize_adapters` builds adapters in a serial loop (`build_adapter`
     awaits ready serving each) — parallelize it too once decode-ready is fast.
+  - ✅ DONE (partial): the adopt-vs-relaunch window check used a FLAT 512-token
+    tolerance (0.35% of a 147k lane), so the boot plan's normal drift tripped a full
+    35B RELAUNCH. Made it a PERCENTAGE (max(512, served/8) ≈ 12.5%), commit
+    `56a7ff90b`. Measured: reboot-resume ~11 min → **~3.5 min** (turns at t+213s
+    after core-answered; minds rehydrated with full history).
+  - ⛔ REMAINING (the near-instant layer): the boot plan WINDOW CLIMBS IN STEPS
+    during boot (measured 2026-09-03: 74752 → 124160 → 147968), each big jump a
+    relaunch (2 partial reloads), because the plan starts from a conservative
+    boot-floor window and grows as it verifies live memory. Fix: SEED the boot plan
+    window (and lanes) from the SURVIVING lane's known-good served window on a
+    reboot-adopt, so the plan doesn't climb to a value the running lane already has —
+    one load, or pure adopt. That closes 3.5 min → seconds.
   Acceptance: a reboot with N resuming citizens resumes turns in SECONDS (adopted
-  lane instantly decode-ready), not minutes; `persona/spawn` seats fast too.
+  lane instantly decode-ready, no step-climb relaunches), not minutes; `persona/spawn`
+  seats fast too.
 
 **S2 — >lane residency via rotation (the restore economy core).** A residency
 governor that admits N > lanes personas and rotates them: the least-recently-active

--- a/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
+++ b/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
@@ -1,0 +1,99 @@
+# Restore Economy & Team Scale — the path to 10–14 personas on one Mac
+
+*2026-09-02. Scoped by a REAL attempt this session, not a guess: spawned 8 personas
+on a 5-lane M-series core, waited 5+ min, and residency stayed at 4 while inference
+capacity was consumed. This plan is what stands between today and the advertised bar.*
+
+## Why this exists (the north star)
+
+The claim is **best score AND speed on a MacBook, via collaboration** — and the
+headline demo is **14 personas on an M1** ([[live-media-plane-restoration-bar-14-personas-on-an-m1]],
+[[the-north-star-best-score-and-speed-on-a-macbook-via-collaboration]]). Teams are
+the wedge we believe raises both score and speed over a lone solver. So running
+10–14 personas *through* a 5-lane core — not merely owning 14 identities — is a
+load-bearing feature, not a nicety.
+
+## What works TODAY (the achievable-now floor)
+
+Validated live this session (build `0b418bd47`):
+- Deterministic completion edge (`PASS: done` → conclude), self-tick held-work loop,
+  fast cadence, held-work visibility, backlog guard — all committed + tested.
+- **Teams ≤ lanes run genuinely concurrently**: 4 personas' generations interleave
+  through continuous batching (adapter semaphore = lanes, ambient permit = lanes-1).
+- Scores climbing on this Mac: swe-bench-lite 58%, verified 67%, mini 100%.
+
+So a team of **≤ 5** works now. The gap is everything above that.
+
+## What BLOCKS 10–14 (measured, in dependency order)
+
+1. **Birthing is slow / not on-demand.** `persona/spawn --count=8` produced zero
+   `persona:born` in 5 min; instances trickled 4→5→6. A team you cannot stand up in
+   seconds is not a team you can demo. Fix the keypair-ceremony + seed pipeline to
+   mint+seat a citizen fast (batch the crypto, defer the avatar, seat the service
+   loop before the cosmetic tail).
+2. **Concurrent residency caps near lane count (~4–5).** The substrate runs about as
+   many active service loops as it has lanes; 10–14 are never concurrently resident.
+   The advertised bar therefore requires **ROTATION**, not more simultaneous
+   residents: N personas time-share L lanes, paged in/out.
+3. **KV paging is FIFO in the fork.** llama-server's single task thread processes
+   slot save/restore/erase one-at-a-time (interleaved with decode). This session
+   fixed save-vs-decode (a save no longer defers behind a live decode, fork
+   `878db9784`) but NOT save-vs-save: read-only saves could overlap; restores of
+   distinct sequences could pipeline. At 14-on-5 the switch rate is high and serial
+   paging dominates — exactly the "pays greatly at 10+" intuition.
+4. **Held-work starves under contention.** Measured: 22 prefills / 1 work.gate in a
+   10-min window while 8 personas birthed + a 32-round backlog re-said kickoffs.
+   Productive held-work must not lose its turn to background/birthing/message noise.
+5. **Serving-concurrency controls are scattered.** Adapter semaphore (lanes), ambient
+   permit (lanes-1), nondirected sub-cap, KV slot lease, task-queue FIFO — each solved
+   locally. Like ServiceModule collapsed the lifecycle, these want ONE governed
+   pattern so a new concern inherits "how many run, who yields, how state pages."
+
+## The arc (slices, each lands green + measured)
+
+**S0 — Measure where the switch time goes (no code; gates the rest).** On a 5-lane
+core, force paging (6+ pinned activities) and decompose one persona-switch:
+save ms, restore ms, FIFO wait (queued behind another slot op / decode), re-prefill
+if the restore missed. Land the numbers in this doc. Do not build S3 before S0 says
+serial paging is actually the cost (the "measure before leaning" discipline).
+
+**S1 — Fast birthing.** Mint+seat a citizen in ~seconds: batch/parallelize the
+keypair ceremony, seat the service loop first, defer avatar/card cosmetics. Acceptance:
+`persona/spawn --count=8` reaches 8 resident-or-ready in < ~30s.
+
+**S2 — >lane residency via rotation (the restore economy core).** A residency
+governor that admits N > lanes personas and rotates them: the least-recently-active
+citizen's KV pages OUT (save), the returning one's pages IN (restore), through the KV
+slot lease already in `inference/slots.rs`. Held-work drives the rotation (whoever is
+due to work pages in). Acceptance: 10 personas cycle through 5 lanes, each getting
+turns, no citizen starved > a bounded window.
+
+**S3 — Fork paging concurrency (un-FIFO).** In the vendored fork: let read-only slot
+SAVES run without serializing behind each other / behind decode (a reader path), and
+pipeline save(evictee)+restore(returner) for a switch. Gated by S0. TDD in the fork's
+`test_slot_save.py` (extend the live-slot test). Acceptance: aggregate switch
+throughput scales with lanes, not 1/task-thread.
+
+**S4 — One governed serving/paging pattern.** Collapse the scattered controls (S5 in
+the findings) into a single lease/admission concern at the lowest trait — the CBAR
+"code it once" move. New concerns inherit governed concurrency + paging.
+
+**S5 — Held-work priority under contention.** Reserve capacity (or a priority tier)
+so productive held-work is never starved by birthing/background/message noise — pins
+the S4 policy against the 22-prefill/1-gate failure.
+
+## Acceptance (the advertised claim, as numbers)
+- Stand up a **14-persona team** on the M-series core in seconds (S1).
+- All 14 get turns through 5 lanes via rotation; **switch latency measured** and
+  bounded (S0/S2/S3).
+- A **team round** completes faster AND at ≥ the score of a lone solver on the same
+  seeds — the collaboration thesis, on the Mac.
+- Held-work never starves (S5): work.gate fires continuously while cards are held.
+
+## Standing rules
+- Deploy via `continuum reboot` + SHA verify; measure with named probes before
+  claiming a slice; TDD each slice (unit + the fork's python harness). Feature-branch
+  commits free; main merge needs Joel. Reuse existing primitives (`SlotRegistry`,
+  `ThroughputLease`, `HoldLease`, `ServiceModule`) — never a parallel one.
+- See also `plans/TEAM-PROOF-PROTOCOL.md` and the fork branch
+  `continuum/kv-live-slot-save`.

--- a/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
+++ b/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
@@ -152,9 +152,14 @@ the citizen's executor (one claim path, driver-gated); the ambient permit gates 
 musing tail. Live: a 12-card citizen round to 12 residents, no teammates — 7 distinct
 pullers across two boots (vs. the assignee-only ~3), each staged `Ready` in her own
 workspace, held cards resumed through the normal work gate after `reboot --force` with no
-re-fire. Remaining (plan `jazzy-wishing-milner`): driver/roster on the room binding, the
-tracker as a board projection on the module lifecycle, delete the re-say (40 fired this
-boot for pre-claimed legacy cards — pure compensation now).
+re-fire. Follow-ups the same day (58e75cbde, 54517c26d): the pull enforces WIP=1 itself; one
+deck kickoff per citizen round (was 12 addressed kickoffs = 12 inbound turns per resident);
+held-work freshness saved WITH the round (the ephemeral map a reboot emptied was why the
+standing autopilot minted 30 duplicate verified-mini rounds); the kickoff re-say deleted
+(40 fired on one boot for pre-claimed legacy cards — pure compensation). Measured after:
+9 distinct citizens producing work acts in a 14-minute window; throughput is lane-bound.
+Remaining (plan `jazzy-wishing-milner`): driver/roster on the room binding, the tracker as
+a board projection on the module lifecycle, re-fire scoped to DetachedSolve.
 
 **S4 — One governed serving/paging pattern.** Collapse the scattered controls (S5 in
 the findings) into a single lease/admission concern at the lowest trait — the CBAR

--- a/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
+++ b/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
@@ -97,11 +97,43 @@ slot lease already in `inference/slots.rs`. Held-work drives the rotation (whoev
 due to work pages in). Acceptance: 10 personas cycle through 5 lanes, each getting
 turns, no citizen starved > a bounded window.
 
-**S3 — Fork paging concurrency (un-FIFO).** In the vendored fork: let read-only slot
-SAVES run without serializing behind each other / behind decode (a reader path), and
-pipeline save(evictee)+restore(returner) for a switch. Gated by S0. TDD in the fork's
-`test_slot_save.py` (extend the live-slot test). Acceptance: aggregate switch
-throughput scales with lanes, not 1/task-thread.
+**S3 — Restore-into-busy-slot (the 27/27 fail).** ✅ PARTIALLY SHIPPED 2026-09-03.
+Measured root cause (not the FIFO guess): SLOT_SAVE/RESTORE/ERASE set only
+`slot_action.id_slot`, leaving `task.id_slot = -1`, while `pop_deferred_task` (fired
+from `callback_on_release` when a slot finishes) matches on `task.id_slot` — so a
+deferred restore was invisible to its own slot's release and a competing slot-pinned
+completion got popped ahead of it (cold prefill). Plus the Rust client abandoned the
+restore at a flat 10s.
+  - ✅ DONE: bind `task.id_slot = id_slot` on all three page-ops (fork `0a637ba22`,
+    TDD `test_deferred_restore_is_bound_to_its_slot`); Rust restore waits for the slot
+    (`KV_RESTORE_SLOT_WAIT=90s`) instead of abandoning at 10s (core `a9ec64fbf`).
+  - Measured live at frontier scale (12 personas / 5 lanes, verified run 2026-09-03):
+    restores **0/27 → 55/67 ok=true (82%)**, `watchdog_kills=0`. Residual: 8 timeouts
+    (decodes > 90s) + a few transient 503s.
+  - ⛔ THE DEFINITIVE FIX (tech debt, deferred 2026-09-03 by Joel: "check in and get
+    working then decompose as follow up"): make it **event-driven, delete the timeout**.
+    Root cause is a decoupling — the Rust pool evicts a persona's lease while that
+    persona is STILL decoding on the physical slot, so the returner is handed a busy
+    slot and must wait. Both primitives already exist: the `Semaphore(lanes)` decode
+    permit (`openai_adapter` ~2554) and `PagedResourcePool::pin` (eviction already skips
+    pinned). The fix: **acquire the permit BEFORE leasing** (permit-first — an
+    event-driven wait that wakes on release, already there) and **pin the leased slot
+    for the permit's duration** (so eviction skips actively-decoding slots). Then a
+    returner ALWAYS leases an unpinned/non-decoding slot → restore lands in ~0.1s, no
+    defer, no timeout, no clobber; `KV_RESTORE_SLOT_WAIT` is deleted. Deadlock-free
+    (acquire permit before pinning, so no pin is ever held while awaiting a permit);
+    concurrency becomes exactly the physical lane count. Care items: `_permit` lifetime
+    across the stream, and threading the `PinHandle` out of the placement match — both
+    reasons this is a careful pass, not a mid-turn edit. Respect the deferral invariant
+    (`openai_adapter` ~2186: parked Background/Probe must hold NOTHING before the permit).
+
+**S3b — Decompose `openai_adapter.rs` (tech debt, Joel 2026-09-03: "everything was
+crammed into one file").** `generate_stream` is ~1362 lines (1996–3358). Carve into
+modules, each green + behaviour-identical (pure refactor, NO behaviour change so a
+regression is bisectable from the S3 event-driven fix): `turn_admission` (class →
+defer → permit → lease+pin → save/restore, houses the S3 fix as an RAII guard),
+`serving_guard` (model-residency readiness), `request_body` (JSON assembly), `sse_parse`
+(streaming token extraction), leaving a thin retry/orchestration shell.
 
 **S4 — One governed serving/paging pattern.** Collapse the scattered controls (S5 in
 the findings) into a single lease/admission concern at the lowest trait — the CBAR

--- a/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
+++ b/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
@@ -135,6 +135,27 @@ defer → permit → lease+pin → save/restore, houses the S3 fix as an RAII gu
 `serving_guard` (model-residency readiness), `request_body` (JSON assembly), `sse_parse`
 (streaming token extraction), leaving a thin retry/orchestration shell.
 
+**S3c — The months-old dispatch/resume bug: PULL, not push (✅ shipped 2026-09-03).**
+Measured root: only ~4–5 of 12 residents ever worked a dispatched round. Four couplings,
+all at the dispatch edge: (1) `next_pullable_card` gated on the round's `team` (really the
+reviewer set, empty unless `--teammates`) ∪ dispatch-time assignees; (2) dispatch PRE-CLAIMED
+every card for its round-robin assignee and STAGED the checkout into HER workspace, so a
+card pulled by anyone else pointed at someone else's repo; (3) the round tracker never
+records a claim, so a free pull would retry the first taken card forever; (4) the self-tick
+took an AMBIENT inference permit before running anything, so on a lanes-1 pool nine of
+twelve yielded every tick and never reached the pull (31 yields / 10 min). Fix, in ONE
+place each: eligibility = room residency (`pullable_cards`); the CLAIM stages the claimer's
+workspace per the card's recipe (`modules/card_staging.rs`, two callers: `work/claim` and a
+detached-solve dispatch); the pull reads claimability from the board
+(`AircCitizen::claimable_cards_in` → `claimable_now`); the pull rides `work/claim` through
+the citizen's executor (one claim path, driver-gated); the ambient permit gates only the
+musing tail. Live: a 12-card citizen round to 12 residents, no teammates — 7 distinct
+pullers across two boots (vs. the assignee-only ~3), each staged `Ready` in her own
+workspace, held cards resumed through the normal work gate after `reboot --force` with no
+re-fire. Remaining (plan `jazzy-wishing-milner`): driver/roster on the room binding, the
+tracker as a board projection on the module lifecycle, delete the re-say (40 fired this
+boot for pre-claimed legacy cards — pure compensation now).
+
 **S4 — One governed serving/paging pattern.** Collapse the scattered controls (S5 in
 the findings) into a single lease/admission concern at the lowest trait — the CBAR
 "code it once" move. New concerns inherit governed concurrency + paging.

--- a/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
+++ b/docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md
@@ -57,9 +57,25 @@ save ms, restore ms, FIFO wait (queued behind another slot op / decode), re-pref
 if the restore missed. Land the numbers in this doc. Do not build S3 before S0 says
 serial paging is actually the cost (the "measure before leaning" discipline).
 
-**S1 — Fast birthing.** Mint+seat a citizen in ~seconds: batch/parallelize the
-keypair ceremony, seat the service loop first, defer avatar/card cosmetics. Acceptance:
-`persona/spawn --count=8` reaches 8 resident-or-ready in < ~30s.
+**S1 — Fast birthing / fast RESUME.** Mint+seat a citizen in ~seconds. Layered
+findings (measured 2026-09-03, a REBOOT of ~10 resuming citizens):
+  - ✅ DONE: persona bootstrap was SERIAL (`bootstrap_planned` ran the keypair
+    ceremony + seed one persona at a time); parallelized via join_all (commit
+    `7c8683332`). Cut resume from ~60 min (serial) to ~11 min (validated live).
+  - ⛔ THE DOMINANT COST (not yet fixed): hosting is gated on
+    `await_ready_serving` (decode-ready), and that took **~10 min** post-reboot —
+    serving reported `ready=true` at t+1min but decode-ready only at t+11min, and
+    service loops (turns) don't spawn until then. This is the real "resume is slow."
+    The lane was ADOPTED (left up across the reboot — it was decoding seconds
+    before), so decode-ready should be NEAR-INSTANT, not 10 min. Chase: why an
+    adopted lane re-verifies decode-readiness so slowly (a slow decode-probe? the
+    mmproj `vision=false` churn keeping the serving daemon re-reconciling and never
+    settling? a teardown+reload instead of a true adopt?). This is the S1 headline.
+  - `warmup()` is a NO-OP for the OpenAI adapter (ruled out as a cost).
+  - Also: `materialize_adapters` builds adapters in a serial loop (`build_adapter`
+    awaits ready serving each) — parallelize it too once decode-ready is fast.
+  Acceptance: a reboot with N resuming citizens resumes turns in SECONDS (adopted
+  lane instantly decode-ready), not minutes; `persona/spawn` seats fast too.
 
 **S2 — >lane residency via rotation (the restore economy core).** A residency
 governor that admits N > lanes personas and rotates them: the least-recently-active

--- a/docs/planning/VIRAL-LAUNCH-PLAN.md
+++ b/docs/planning/VIRAL-LAUNCH-PLAN.md
@@ -104,6 +104,26 @@ regrade sweep ☐, demo capture ☐, one open-board number ☐.
 
 **Gate 5: HN draft + first-comment + X thread reviewed by Joel before any button.**
 
+## The speed board (2026-09-02 — MTPLX sets the Apple-Silicon narrative bar)
+
+[MTPLX](https://github.com/youssofal/MTPLX) (1.9k stars, MLX + native multi-token
+prediction): 1.6–2.24× decode speedups, 23 tok/s on a dense 9B on a 16GB M4 mini.
+Different layer (a single-request runtime vs a mind system) — but it owns the speed
+story on our hardware, so our numbers must be published beside it, honestly framed:
+
+| Metric | Ours (measured 2026-09-02) | The bar |
+|---|---|---|
+| Decode tok/s per stream | ~11.4 median (Ornith-35B-A3B, 4 concurrent minds, long ctx) | Publish AGGREGATE (~45 tok/s across 4 streams) + per-stream, both labeled |
+| Decode multiplier | none (ngram spec measured OFF at 2% acceptance; MTP needs a trained draft head Ornith lacks) | Forge work item: train an MTP head for Ornith — the MTPLX Forge parallel, on OUR factory |
+| Model load | **1.7–6.1s** (engine receipt) | Already excellent — the story was wrong, publish it |
+| Boot → serving-ready | was ~15 min: 16 relaunches from the plan chasing boot's demand staircase | Plan-flat gate shipped; target < 60s warm |
+| Stop | was: flat 2s sleep, nothing saved | Parallel bounded save-and-join shipped; target < 3s receipted |
+| Act loop (perceive→think→act) | 47–65s warm | Nobody else reports this at all — our category |
+
+The honest frame: MTPLX accelerates one request; we run a SOCIETY — publish both
+truths, adopt their class of decode win via the forge (draft-head training), and keep
+the metrics nobody else has (persistence, $0, time-to-act, KV-follows-mind).
+
 ## Execution order (from tonight)
 
 1. ☐ **Regrade sweep** of banked Verified/Lite verdicts on the current harness (gate 1).

--- a/docs/planning/VOICE-ENGINE-PLAN.md
+++ b/docs/planning/VOICE-ENGINE-PLAN.md
@@ -54,6 +54,22 @@ the voice vision structural rather than cosmetic:
    Qwen-Omni talker heads compete for the flagship seat via the SAME selftest +
    quality bar — engines are adapters; the verb is the contract.
 
+## The body (Joel 2026-09-02: "tied into animations of face/mouth and later maybe more robotically controlled")
+
+Envelope lip-sync EXISTS today (`calculate_rms_weights` → mouth morph targets), so any
+engine's speech moves the mouth now — and sentiment already drives face + gesture from
+the same source as the voice tags (Stage A). The ladder:
+
+1. **Now**: Orpheus audio → RMS envelope → mouth openness (works by construction).
+2. **Visemes from speech TOKENS** (with Stage B, or from Orpheus's stream sooner):
+   each SNAC frame is ~12ms of articulation — a small table/learned map from the
+   coarse codebook to viseme gives phoneme-accurate mouth shapes with PERFECT sync
+   and zero audio analysis, because the sound and the mouth derive from one stream.
+3. **The control bus** (the robotics door): visemes + gestures + emotion become one
+   typed control stream — today rendered by Bevy morphs, later by actuators. The
+   positron principle applied to bodies: one semantic stream, N renderers (screen
+   avatar, robot) — and the JEPA-class world-model direction rides the same bus.
+
 ## The room (audited 2026-09-02, Joel: "good mixers do it well")
 
 Per-observer mix-minus is SERVER-SIDE (the WS delivery loop drops the observer's own

--- a/docs/planning/VOICE-ENGINE-PLAN.md
+++ b/docs/planning/VOICE-ENGINE-PLAN.md
@@ -54,6 +54,15 @@ the voice vision structural rather than cosmetic:
    Qwen-Omni talker heads compete for the flagship seat via the SAME selftest +
    quality bar — engines are adapters; the verb is the contract.
 
+## The room (audited 2026-09-02, Joel: "good mixers do it well")
+
+Per-observer mix-minus is SERVER-SIDE (the WS delivery loop drops the observer's own
+frames — call_server:1516); persona TTS structurally never re-enters STT (AI
+participants carry no VAD); LiveKit legs are per-participant tracks. The remaining
+proof gap: the WEB feedback loop — browser echoes received audio back as its mic
+through the worklet path, server STT transcribes it — which also pins mix-minus from
+a real browser's POV. Carded.
+
 ## The bar
 
 *A stranger's fresh install speaks with a natural, unique per-persona voice with zero

--- a/docs/planning/VOICE-ENGINE-PLAN.md
+++ b/docs/planning/VOICE-ENGINE-PLAN.md
@@ -95,6 +95,18 @@ Llama-family; the same graft applies to her, staged:
   overlapping" — background vs speaker vs effects as separate, precisely named facts,
   never flattened into one transcript string.
 
+**Invariant across every stage — THE TRANSCRIPT ALWAYS EXISTS (Joel 2026-09-02:
+"same goes for the model hearing directly… only problem is we need chat transcript
+either way").** Native audio-in is an ADDITIONAL path, never a replacement for STT:
+the room record, L1-L5 memory, RAG, and search all consume TEXT. So the pipeline is
+always audio → { STT → transcript (required, feeds chat/memory) , AND optionally the
+raw waveform → the model's own audio encoder for nuance }. A model that hears natively
+gets BOTH — the transcript for the record and the audio for the feeling — and the
+choice of whether to also embed raw audio is a per-model capability switch (the
+sensory-bridge doctrine), not a switch that can ever turn the transcript off. The STT
+leg is load-bearing forever; the same TTS↔STT selftest guards it whether or not a
+model also listens directly.
+
 **Stage B — the graft (the real ask):**
 - Extend Ornith's vocab with codec tokens; forge-train an audio-out head/LoRA:
   (context + her thought) → speech tokens in the SAME forward pass. Mannerisms become

--- a/docs/planning/VOICE-ENGINE-PLAN.md
+++ b/docs/planning/VOICE-ENGINE-PLAN.md
@@ -63,6 +63,41 @@ proof gap: the WEB feedback loop — browser echoes received audio back as its m
 through the worklet path, server STT transcribes it — which also pins mix-minus from
 a real browser's POV. Carded.
 
+## Native audio IN the mind (Joel 2026-09-02: "build these into the Ornith models… so it wouldn't sound like text to speech")
+
+The end state is not a better TTS sidecar — it is speech and hearing as part of the
+persona's OWN forward pass. Orpheus proved the enabling mechanism ON OUR STACK today:
+a Llama-family model emitting SNAC codec tokens, decoded in-tree. Ornith is
+Llama-family; the same graft applies to her, staged:
+
+**Stage A — expressive mouth + tagged ears (buildable now):**
+- Orpheus conditioned by PersonaState → emotion tags; per-persona VOICE LoRA trained
+  on Orpheus by the forge (custom voice = her weights, not a preset — stops sounding
+  like TTS because prosody varies with her state, not a narrator's).
+- Audio-in gains an EVENTS channel beside STT: a small audio tagger + diarization so
+  perception reads "Joel said X — while a door closed, music under, second speaker
+  overlapping" — background vs speaker vs effects as separate, precisely named facts,
+  never flattened into one transcript string.
+
+**Stage B — the graft (the real ask):**
+- Extend Ornith's vocab with codec tokens; forge-train an audio-out head/LoRA:
+  (context + her thought) → speech tokens in the SAME forward pass. Mannerisms become
+  intimately cognition-coupled — hesitation, warmth, emphasis come from the state that
+  produced the sentence, because the speaking IS the thinking. Training data
+  bootstraps by distillation: her lived transcripts voiced by her Orpheus voice-LoRA
+  → (text, speech-token) pairs; later, real call audio.
+- Audio-in natively: an audio encoder (Whisper-class) through the mmproj pattern we
+  already run for vision — she embeds SOUND, not just its transcript; trained against
+  event-labeled + diarized corpora so nuance (irony in a voice, a sigh, a slammed
+  door vs a dropped cup) reaches cognition as perception, not annotation.
+
+**Stage C — full-duplex Omni lane:** streaming listen+speak on one lane; barge-in;
+the talker head as a paged expert. (The Omni-sidecar memory's end state.)
+
+Every stage holds the same bar: voice/selftest legs (TTS↔STT now; later the
+multimodal judge scoring identity/prosody/nuance), receipts on the forge alloy, and
+the genome covenant — a voice or an ear is a GENE with lineage.
+
 ## The bar
 
 *A stranger's fresh install speaks with a natural, unique per-persona voice with zero

--- a/protocol/typescript/benchmark/BenchmarkDispatchParams.ts
+++ b/protocol/typescript/benchmark/BenchmarkDispatchParams.ts
@@ -119,6 +119,15 @@ prune: boolean | null,
  */
 drive?: WorkDriver, 
 /**
+ * The round's STANDING RULES — published as the run room's operating doctrine
+ * so every resident sees it in her grounding on every turn (the `[Room
+ * operating doctrine]` block), not as a message that scrolls out of view.
+ * This is where a recipe puts role prompts and the collaboration nudge
+ * ("others are working cards on this board — say what you found when it
+ * helps them"). Omit for the control arm: no doctrine, no nudge.
+ */
+doctrine: string | null, 
+/**
  * Stage the round even though serving is NOT decode-verified (#442).
  *
  * Off by default, and the default is the point: dispatch refuses to post cards no

--- a/protocol/typescript/benchmark/BenchmarkDispatchParams.ts
+++ b/protocol/typescript/benchmark/BenchmarkDispatchParams.ts
@@ -136,4 +136,10 @@ doctrine: string | null,
  * `start --force` (#420) — and it announces itself in the log rather than passing
  * silently, since a gate that can be skipped without a trace is not a gate.
  */
-force?: boolean, };
+force?: boolean, 
+/**
+ * THE REVIEW GATE: an owner's `done` becomes `review` + a sibling review card a
+ * NON-owner pulls; only the reviewer's `done` closes the card and fires its
+ * grade. Off = the control arm (a citizen's own `done` grades directly).
+ */
+review_gate: boolean | null, };

--- a/protocol/typescript/benchmark/RoundCardSnapshot.ts
+++ b/protocol/typescript/benchmark/RoundCardSnapshot.ts
@@ -30,4 +30,23 @@ state: string, acts?: number, patch_bytes?: number,
 /**
  * Seconds since this card's newest work artifact. `None` = none ever.
  */
-last_act_secs?: number, resolved?: boolean, };
+last_act_secs?: number, resolved?: boolean, 
+/**
+ * BOARD truth (the durable record): the card's column right now —
+ * `open|claimed|in_progress|blocked|review|merged|closed`. Empty when the
+ * board could not be read.
+ */
+board_state: string, 
+/**
+ * Who holds it on the board (display name, else short id). Empty = nobody.
+ */
+owner: string, 
+/**
+ * Board timestamps — the experiment axes: time-to-claim and time-to-settle
+ * read from these, never from a process clock that a reboot resets.
+ */
+created_at_ms?: number, updated_at_ms?: number, 
+/**
+ * When the verdict file was written (`SweVerdict::graded_at_ms`).
+ */
+graded_at_ms?: number, };


### PR DESCRIPTION
## What this branch ships (rolling, auto-merge to canary)

**Dispatch + resume (the months-old bug), 2026-09-03**
- Any resident pulls any Open card; the CLAIM stages her workspace (`modules/card_staging.rs`, one seam, two callers).
- Pull eligibility = room residency; claimability read from the board (`claimable_now`); the pull rides `work/claim` through her executor (one claim path, driver-gated).
- The self-tick's ambient permit gates only the musing tail — it had starved 9 of 12 citizens every tick.
- WIP=1 in the pull; one deck kickoff per citizen round; held-work freshness saved with the round (the autopilot's duplicate-round source); kickoff re-say deleted.
- Measured: 11 of 12 citizens producing work acts in one window (vs ~4-5 for months); 38→38 round files across a reboot; zero re-fires.

**Inference admission**
- Event-driven turn admission (`inference/turn_admission.rs`): permit-first + slot pin as one RAII guard; the 90s KV-restore timeout is gone.

**Continual learning (audit: starved, not off)**
- Per-citizen boredom gate (a colleague's turn no longer cancels her dream: was 749 paged out / 4 done in 6h).
- Training-trigger buckets persist on the module `save_state`/`load_state` lifecycle (were wiped per reboot; zero LoRA jobs had ever fired from live turns).
- `training.example.produced|skipped` probes.

**Experiment harness**
- `benchmark/rounds` merges board truth + verdict files per card (owner, column, created/updated/graded timestamps); `SweVerdict.graded_at_ms`; `delib.generate.cache` carries `persona`; `benchmark/dispatch --doctrine` publishes the round's standing rules as the run room's operating doctrine (recipe params `driver`, `doctrine`).

**Earlier on this branch:** Orpheus real protocol (tokenizer from the GGUF, canonical framing + interleave), concurrent citizen bootstrap, warm-lane adoption on small window drift, kanban pull, standing autopilot backlog guard.

Docs: `docs/planning/RESTORE-ECONOMY-AND-TEAM-SCALE.md` §S3c. Plan: `jazzy-wishing-milner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
