### PR TITLE
fix(nav): run rooms observable and nested under the room they were dispatched from

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -16,7 +16,6 @@
 //! - Pricing
 
 use async_trait::async_trait;
-use serde::Deserialize;
 use serde_json::{json, Value};
 use std::collections::BTreeSet;
 use std::time::Instant;
@@ -31,8 +30,8 @@ use super::adapter::{
 use super::openai_endpoints::OpenAiBase;
 use super::registry_bridge::models_for_provider_via_registry;
 use super::types::{
-    ActiveAdapterRequest, ChatMessage, ContentPart, EmbeddingInput, EmbeddingRequest,
-    EmbeddingResponse, FinishReason, GenerationTiming, HealthState, HealthStatus, MessageContent,
+    ActiveAdapterRequest, ContentPart, EmbeddingInput, EmbeddingRequest, EmbeddingResponse,
+    FinishReason, GenerationTiming, HealthState, HealthStatus,
     ModelInfo, TextGenerationRequest, TextGenerationResponse, ToolCall, UsageMetrics,
 };
 
@@ -1070,7 +1069,7 @@ pub(crate) fn extract_reasoning(
 
 
 // The SSE wire types + stream consumer live in `crate::inference::sse_stream` (S3b decompose).
-use crate::inference::sse_stream::{warn_if_decode_collapsed, OpenAITimings, OpenAIUsage, StreamToolAccum};
+use crate::inference::sse_stream::warn_if_decode_collapsed;
 
 #[async_trait]
 impl AIProviderAdapter for OpenAICompatibleAdapter {
@@ -2190,7 +2189,7 @@ mod tests {
     use crate::inference::lane_send::PRE_STREAM_HEADER_TIMEOUT_SECS;
     use crate::inference::sse_stream::{OpenAIStreamChunk, STREAM_IDLE_TIMEOUT_SECS};
 
-    use crate::ai::types::ImageInput;
+    use crate::ai::types::{ChatMessage, ImageInput, MessageContent};
 
     mod prefill_progress_is_liveness {
         use super::*;

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1906,8 +1906,8 @@ impl ActionCommand for BenchmarkDispatch {
             "review_gate".to_string(),
             serde_json::json!(p.review_gate.unwrap_or(false)),  // unwrap_or: gate not named = off, the control arm
         );
-        // The run room is a CHILD of the room the curator stands in (academy by default):
-        // the binding's `parent` is what the navigator nests by, for every recipe.
+        // The run room is a CHILD of whatever room the curator stands in — the tree is
+        // dynamic, built from the binding's `parent` at spawn; no room name is a rule here.
         let parent_room = airc.current_room().await.ok().map(|r| r.channel);
         let room = crate::modules::activity::spawn_activity_room(
             &airc,

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1906,14 +1906,40 @@ impl ActionCommand for BenchmarkDispatch {
             "review_gate".to_string(),
             serde_json::json!(p.review_gate.unwrap_or(false)),  // unwrap_or: gate not named = off, the control arm
         );
+        // The run room is a CHILD of the room the curator stands in (academy by default):
+        // the binding's `parent` is what the navigator nests by, for every recipe.
+        let parent_room = airc.current_room().await.ok().map(|r| r.channel);
         let room = crate::modules::activity::spawn_activity_room(
             &airc,
             &room_name,
             &bench_recipe,
-            None,
+            parent_room,
             &run_params,
         )
         .await?;
+        // The OPERATOR observes every activity on this node: her self-peer subscribes to
+        // the run room without moving her focus, so the desktop's nav and transcript
+        // reach it. Before this the run room lived only in citizens' scopes and the
+        // human could not navigate to it (Joel 2026-09-03).
+        match crate::persona::operator_peer::operator_airc() {
+            Some(op) => {
+                if let Err(e) = op.subscribe_room(&room_name).await {
+                    crate::probe!(
+                        class = "bench.round.operator_subscribe_failed",
+                        room = %room_name,
+                        error = %e.to_string(),
+                        "operator self-peer could not subscribe to the run room — the desktop \
+                         will not list it until room/join"
+                    );
+                }
+            }
+            None => crate::probe!(
+                class = "bench.round.operator_subscribe_failed",
+                room = %room_name,
+                error = "no operator self-peer online",
+                "operator self-peer offline — the run room is not observable from the desktop"
+            ),
+        }
         // The round's standing rules, published as the run room's operating doctrine
         // RIGHT HERE while the curator's current room is still the freshly spawned run
         // (spawn_activity_room leaves the pointer there). Rendered verbatim into every

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1917,29 +1917,6 @@ impl ActionCommand for BenchmarkDispatch {
             &run_params,
         )
         .await?;
-        // The OPERATOR observes every activity on this node: her self-peer subscribes to
-        // the run room without moving her focus, so the desktop's nav and transcript
-        // reach it. Before this the run room lived only in citizens' scopes and the
-        // human could not navigate to it (Joel 2026-09-03).
-        match crate::persona::operator_peer::operator_airc() {
-            Some(op) => {
-                if let Err(e) = op.subscribe_room(&room_name).await {
-                    crate::probe!(
-                        class = "bench.round.operator_subscribe_failed",
-                        room = %room_name,
-                        error = %e.to_string(),
-                        "operator self-peer could not subscribe to the run room — the desktop \
-                         will not list it until room/join"
-                    );
-                }
-            }
-            None => crate::probe!(
-                class = "bench.round.operator_subscribe_failed",
-                room = %room_name,
-                error = "no operator self-peer online",
-                "operator self-peer offline — the run room is not observable from the desktop"
-            ),
-        }
         // The round's standing rules, published as the run room's operating doctrine
         // RIGHT HERE while the curator's current room is still the freshly spawned run
         // (spawn_activity_room leaves the pointer there). Rendered verbatim into every

--- a/core/continuum-core/src/ipc/positron_nav_source.rs
+++ b/core/continuum-core/src/ipc/positron_nav_source.rs
@@ -71,6 +71,9 @@ pub struct NavActivity {
     /// The activity purpose the room-purpose seam resolved ("chat", "foundry",
     /// …). Empty = unresolved — honest unknown.
     pub purpose: String,
+    /// The binding's parent activity (`RoomPurposeSource::parent_for`) — the generic
+    /// nesting every recipe gets; the bench-specific solve→run lineage is layered on top.
+    pub parent: Option<String>,
     /// The last-read cursor for this activity's room (ms/lamport), when it is
     /// a room. `None` for activities with no read cursor.
     pub last_read: Option<i64>,
@@ -117,7 +120,15 @@ pub fn project_nav(user: Uuid, snap: NavSnapshot) -> NavViewState {
                 // the same record (instance · assignee name resolved by the
                 // renderer's roster); the raw room id keeps its identity job
                 // in `id` and retreats from the reading line.
-                let (parent_ref, display_label) = activity_lineage(&a.id, &a.title);
+                let (lineage_parent, display_label) = activity_lineage(&a.id, &a.title);
+                // The bench solve→run lineage first (it also names the tab); else the
+                // binding's own parent — a run room nests under the room it was
+                // dispatched from, a pipeline under its project, generically.
+                let parent_ref = if lineage_parent.is_empty() {
+                    a.parent.clone().unwrap_or_default()  // unwrap_or: no parent = a top-level activity
+                } else {
+                    lineage_parent
+                };
                 NavTab {
                     id: a.id,
                     title: a.title,
@@ -497,6 +508,7 @@ impl NavReader for ChannelBookmarksNavReader {
                     // The recipe-defined activity nature, resolved through the
                     // ONE purpose seam — the tab's description/facet line.
                     purpose: self.purpose.purpose_for(*room),
+                    parent: self.purpose.parent_for(*room).map(|p| p.to_string()),
                     last_read: Some(last as i64),
                 }
             })
@@ -532,6 +544,7 @@ impl NavReader for ChannelBookmarksNavReader {
                 unread: 0,
                 purpose: "persona".to_string(),
                 last_read: None,
+                parent: None,
             });
         }
         let current = focus
@@ -722,6 +735,22 @@ mod tests {
 
     /// A canned reader — returns a fixed snapshot, the nav analogue of the
     /// kanban `StubReader`.
+    // what this catches: nesting is GENERIC — an activity whose binding names a parent
+    // nests under it in the nav even when it is not a bench solve room. Before
+    // 2026-09-03 only solve rooms nested (under their run room, via the bench tracker);
+    // a dispatched run room was a flat top-level tab, or absent (Joel: "active benchmark
+    // rooms don't even show up… not under the base academy room").
+    #[test]
+    fn a_bound_activity_nests_under_its_binding_parent() {
+        let academy = Uuid::new_v4();
+        let run = Uuid::new_v4();
+        let mut a = room(&run.to_string(), "bench-swe-bench-verified-1", 0, 0);
+        a.parent = Some(academy.to_string());
+        let snap = NavSnapshot { current: None, activities: vec![a], bookmarks: vec![] };
+        let view = project_nav(Uuid::new_v4(), snap);
+        assert_eq!(view.open_tabs[0].parent_ref, academy.to_string());
+    }
+
     struct StubNav(NavSnapshot);
     impl NavReader for StubNav {
         fn nav_snapshot(&self, _user: Uuid) -> NavSnapshot {
@@ -737,6 +766,7 @@ mod tests {
             unread,
             purpose: "chat".into(),
             last_read: Some(last_read),
+            parent: None,
         }
     }
 

--- a/core/continuum-core/src/ipc/recipe_room_purpose.rs
+++ b/core/continuum-core/src/ipc/recipe_room_purpose.rs
@@ -94,7 +94,8 @@ pub trait RoomRecipeReader: Send + Sync {
 /// exactly one answer per room, process-wide ([[compression]]).
 #[derive(Clone, Default)]
 pub struct RecipeRoomPurpose {
-    index: Arc<RwLock<HashMap<Uuid, String>>>,
+    /// room → (purpose, the binding's parent activity).
+    index: Arc<RwLock<HashMap<Uuid, (String, Option<Uuid>)>>>,
 }
 
 impl RecipeRoomPurpose {
@@ -104,9 +105,9 @@ impl RecipeRoomPurpose {
 
     /// Record a room's resolved purpose. Idempotent; last write wins, which is
     /// what a re-bind means.
-    fn set(&self, room_id: Uuid, purpose: String) {
+    fn set(&self, room_id: Uuid, purpose: String, parent: Option<Uuid>) {
         let mut index = self.index.write().unwrap_or_else(|e| e.into_inner());
-        index.insert(room_id, purpose);
+        index.insert(room_id, (purpose, parent));
     }
 
     /// Resolve one room's binding through `reader` and fold it in. Returns the
@@ -116,6 +117,7 @@ impl RecipeRoomPurpose {
     /// stream — the seam is a total function, so the only choice is between a
     /// LOUD default and a silent one.
     pub async fn refresh(&self, room_id: Uuid, reader: &dyn RoomRecipeReader) -> String {
+        let mut parent: Option<Uuid> = None;
         let purpose = match reader.recipe_posts(room_id).await {
             Err(error) => {
                 crate::probe!(
@@ -129,7 +131,10 @@ impl RecipeRoomPurpose {
                 UNBOUND_PURPOSE.to_string()
             }
             Ok(posts) => match project_binding(&posts) {
-                Ok(Some(binding)) => binding.recipe,
+                Ok(Some(binding)) => {
+                    parent = binding.parent.map(|p| p.as_uuid());
+                    binding.recipe
+                }
                 Ok(None) => UNBOUND_PURPOSE.to_string(),
                 Err(error) => {
                     crate::probe!(
@@ -143,7 +148,7 @@ impl RecipeRoomPurpose {
                 }
             },
         };
-        self.set(room_id, purpose.clone());
+        self.set(room_id, purpose.clone(), parent);
         purpose
     }
 }
@@ -154,8 +159,16 @@ impl RoomPurposeSource for RecipeRoomPurpose {
             .read()
             .unwrap_or_else(|e| e.into_inner())
             .get(&room_id)
-            .cloned()
+            .map(|(purpose, _)| purpose.clone())
             .unwrap_or_else(|| UNBOUND_PURPOSE.to_string())
+    }
+
+    fn parent_for(&self, room_id: Uuid) -> Option<Uuid> {
+        self.index
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&room_id)
+            .and_then(|(_, parent)| *parent)
     }
 }
 

--- a/core/continuum-core/src/ipc/room_purpose.rs
+++ b/core/continuum-core/src/ipc/room_purpose.rs
@@ -22,6 +22,14 @@ pub trait RoomPurposeSource: Send + Sync {
     /// default (`"chat"`), never a fabricated or panicking value; a room the resolver
     /// has never seen is simply a plain chat room until its recipe says otherwise.
     fn purpose_for(&self, room_id: Uuid) -> String;
+
+    /// The activity this room was spawned UNDER (the binding's `parent`), if any —
+    /// what lets a navigator nest a run room under the room it was dispatched from
+    /// instead of listing every activity flat. Default `None`: a source that only
+    /// knows purposes nests nothing.
+    fn parent_for(&self, _room_id: Uuid) -> Option<Uuid> {
+        None
+    }
 }
 
 /// The default until the room→recipe store exists: every room is a chat room. Honest,

--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -78,27 +78,6 @@ pub async fn ensure_operator_peer(
                     "operator self-peer could not join general — the human speaks nowhere by default until room/join"
                 );
             }
-            // THE HUMAN OBSERVES EVERY ACTIVITY ON THIS NODE. Subscribe (without moving
-            // her focus) to every live activity room the tracker knows — run rooms and
-            // their solve rooms — so a reboot, or a round dispatched before this boot,
-            // never leaves the desktop blind to work in flight (Joel 2026-09-03: "if it's
-            // an airc room you should be able to observe… active benchmark rooms don't
-            // even show up"). New rooms subscribe at their spawn seam.
-            let mut subscribed = 0u64;
-            let mut failed = 0u64;
-            for (_, name) in crate::cognition::bench_round::activity_rooms() {
-                match rt.airc().subscribe_room(&name).await {
-                    Ok(_) => subscribed += 1,
-                    Err(_) => failed += 1,
-                }
-            }
-            crate::probe!(
-                class = "operator.peer.activity_rooms_subscribed",
-                subscribed,
-                failed,
-                "operator self-peer subscribed to the live activity rooms — the desktop can \
-                 navigate to work in flight"
-            );
             let _ = OPERATOR.set(rt);
         }
         Err(e) => {

--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -78,6 +78,27 @@ pub async fn ensure_operator_peer(
                     "operator self-peer could not join general — the human speaks nowhere by default until room/join"
                 );
             }
+            // THE HUMAN OBSERVES EVERY ACTIVITY ON THIS NODE. Subscribe (without moving
+            // her focus) to every live activity room the tracker knows — run rooms and
+            // their solve rooms — so a reboot, or a round dispatched before this boot,
+            // never leaves the desktop blind to work in flight (Joel 2026-09-03: "if it's
+            // an airc room you should be able to observe… active benchmark rooms don't
+            // even show up"). New rooms subscribe at their spawn seam.
+            let mut subscribed = 0u64;
+            let mut failed = 0u64;
+            for (_, name) in crate::cognition::bench_round::activity_rooms() {
+                match rt.airc().subscribe_room(&name).await {
+                    Ok(_) => subscribed += 1,
+                    Err(_) => failed += 1,
+                }
+            }
+            crate::probe!(
+                class = "operator.peer.activity_rooms_subscribed",
+                subscribed,
+                failed,
+                "operator self-peer subscribed to the live activity rooms — the desktop can \
+                 navigate to work in flight"
+            );
             let _ = OPERATOR.set(rt);
         }
         Err(e) => {


### PR DESCRIPTION
Operator self-peer subscribes to every run room at spawn (no focus move); run rooms spawn with the curator's room as the binding parent; the nav nests any activity by its binding parent (generic), bench lineage layered on top. Plus the adapter carves' leftover imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo