### PR TITLE
feat(activity): a recipe declares its BASE; the spawn seam roots the activity there

### DIFF
--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1906,14 +1906,14 @@ impl ActionCommand for BenchmarkDispatch {
             "review_gate".to_string(),
             serde_json::json!(p.review_gate.unwrap_or(false)),  // unwrap_or: gate not named = off, the control arm
         );
-        // The run room is a CHILD of whatever room the curator stands in — the tree is
-        // dynamic, built from the binding's `parent` at spawn; no room name is a rule here.
-        let parent_room = airc.current_room().await.ok().map(|r| r.channel);
+        // WHERE THE ROUND ROOTS is the spawn seam's decision, for every recipe: the
+        // benchmark recipe declares `base: academy` (a round is learning, by what it is),
+        // so no parent is named here.
         let room = crate::modules::activity::spawn_activity_room(
             &airc,
             &room_name,
             &bench_recipe,
-            parent_room,
+            None,
             &run_params,
         )
         .await?;

--- a/core/continuum-core/src/experience/recipe.rs
+++ b/core/continuum-core/src/experience/recipe.rs
@@ -140,6 +140,17 @@ pub struct ExperienceRecipe {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub layout: Option<Layout>,
+    /// The default top-level BASE this recipe's activities root under, by what the
+    /// activity IS (Joel 2026-09-03: "The academy. Think of what the word means. It's for
+    /// learning. Now for other stuff: not inside academy."). The shipped bases are
+    /// `academy` (learning by purpose: benchmark rounds, training, exams, curricula),
+    /// `projects`, `commons`, `personal`; any room may technically root from any base
+    /// path — the defaults are the ship, not a rule in code. `None` = the activity roots
+    /// wherever it was spawned from. A SUB-activity's parent is always the activity
+    /// that spawned it, never the base.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub base: Option<String>,
 }
 
 /// One declared recipe parameter (#433). The DEFAULT is also the TYPE

--- a/core/continuum-core/src/experience/recipes/benchmark.json
+++ b/core/continuum-core/src/experience/recipes/benchmark.json
@@ -2,6 +2,7 @@
   "id": "fed332c3-383c-45bb-a205-b54b02c43916",
   "version": 1,
   "purpose": "benchmark/hard-rs",
+  "base": "academy",
   "regions": [
     {
       "name": "scoreboard",

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -506,6 +506,30 @@ pub async fn spawn_activity_room(
         ),
     )?;
     let resolved_params = resolve_params(&recipe_def, params)?;
+    // WHERE IT ROOTS: an explicit parent wins (a sub-activity nests under the activity
+    // that spawned it); else the recipe's declared BASE (a benchmark round is learning →
+    // `academy`, by what it is); else nowhere in particular (the spawner's context). The
+    // base room is resolved by name WITHOUT moving the spawner's focus (airc's Keep join).
+    let parent = match parent {
+        Some(p) => Some(p),
+        None => match recipe_def.base.as_deref() {
+            Some(base) => match airc.subscribe_room(base).await {
+                Ok(room) => Some(room.channel),
+                Err(source) => {
+                    crate::probe!(
+                        class = "activity.base_unresolved",
+                        recipe = %recipe,
+                        base = %base,
+                        error = %source.to_string(),
+                        "the recipe's base room could not be resolved — the activity roots \
+                         top-level this time"
+                    );
+                    None
+                }
+            },
+            None => None,
+        },
+    };
     {
         // `join` IS room creation in airc: it derives the channel from the name,
         // subscribes this peer, and publishes presence. Reusing it keeps ONE room
@@ -938,6 +962,18 @@ mod tests {
         use super::*;
         use crate::experience::recipe::ExperienceRecipe;
         use std::collections::BTreeMap;
+
+        // what this catches: the shipped benchmark recipe declares `academy` as its base —
+        // a round is LEARNING and roots there by what it is, not by where the curator
+        // stood. Losing this line would drop every round to a flat top-level room again.
+        #[test]
+        fn the_benchmark_recipe_roots_in_the_academy() {
+            let recipe = crate::experience::recipe::ExperienceRecipe::from_json(
+                include_str!("../experience/recipes/benchmark.json"),
+            )
+            .expect("shipped recipe parses");  // test: the embedded recipe is authored JSON
+            assert_eq!(recipe.base.as_deref(), Some("academy"));
+        }
 
         fn recipe_with_params() -> ExperienceRecipe {
             ExperienceRecipe::from_json(

--- a/protocol/typescript/experience/ExperienceRecipe.ts
+++ b/protocol/typescript/experience/ExperienceRecipe.ts
@@ -71,4 +71,15 @@ citizens: Array<CitizenRecipe>,
 /**
  * Optional explicit composition (level-3 layout). Omitted → organic placement.
  */
-layout?: Layout, };
+layout?: Layout, 
+/**
+ * The default top-level BASE this recipe's activities root under, by what the
+ * activity IS (Joel 2026-09-03: "The academy. Think of what the word means. It's for
+ * learning. Now for other stuff: not inside academy."). The shipped bases are
+ * `academy` (learning by purpose: benchmark rounds, training, exams, curricula),
+ * `projects`, `commons`, `personal`; any room may technically root from any base
+ * path — the defaults are the ship, not a rule in code. `None` = the activity roots
+ * wherever it was spawned from. A SUB-activity's parent is always the activity
+ * that spawned it, never the base.
+ */
+base?: string, };


### PR DESCRIPTION
Joel 9/3: academy is for learning; other things are not inside academy. The recipe declares `base` (benchmark: `academy`); `spawn_activity_room` resolves the base room by name without moving the spawner's focus and writes it as the binding's parent, unless an explicit parent was given (a sub-activity nests under what spawned it). Dispatch no longer guesses from the curator's room. Shipped bases: academy / projects / commons / personal — the ship, not a rule in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo