### PR TITLE
feat(web): /persona/<name>/<tab> deep links + what she sees now on the mind tab

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -3709,6 +3709,57 @@ export class ChatWidget extends LitElement {
       font-style: italic;
       padding: var(--spacing-sm) 0;
     }
+    /* WHAT SHE SEES NOW — her window as a gauge, one row per grounding source. */
+    .sight-window {
+      height: 6px;
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-sm);
+      background: rgba(255, 255, 255, 0.04);
+      overflow: hidden;
+      margin-bottom: var(--spacing-sm);
+    }
+    .sight-window > span {
+      display: block;
+      height: 100%;
+      background: var(--status-online);
+      box-shadow: 0 0 8px rgba(0, 255, 136, 0.45);
+      transition: width 600ms ease;
+    }
+    .sight-sources {
+      display: grid;
+      gap: 6px;
+    }
+    .sight-row {
+      display: grid;
+      grid-template-columns: 7rem 10rem minmax(0, 1fr);
+      gap: var(--spacing-sm);
+      align-items: baseline;
+      font-size: 12px;
+    }
+    .sight-source {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--status-online);
+    }
+    .sight-tokens {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      color: var(--content-secondary);
+      font-variant-numeric: tabular-nums;
+    }
+    .sight-preview {
+      color: var(--content-primary);
+      opacity: 0.85;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @media (max-width: 720px) {
+      .sight-row { grid-template-columns: 1fr; gap: 2px; }
+      .sight-preview { white-space: normal; }
+    }
     .p-facts {
       display: flex;
       flex-wrap: wrap;

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -27,7 +27,12 @@ import {
   type StateEnvelope,
 } from '@continuum/sdk-typescript';
 import { resolveConfig } from './config';
-import { setMindFeed } from './persona/renderPersona';
+import {
+  onPersonaTabChange,
+  setMindFeed,
+  setMindSight,
+  setRequestedPersonaTab,
+} from './persona/renderPersona';
 import {
   ChatWidget,
   type CloseTabHandler,
@@ -229,12 +234,59 @@ async function main(): Promise<void> {
     } catch (err) {
       console.error('mind feed poll failed:', err);
     }
+    // WHAT SHE SEES NOW: the exact grounding her model would get this instant.
+    // `persona/rag-inspect` resolves by NAME today (an id misses the seed
+    // path); the directory seed maps her id back to it.
+    const personaName = widget.directorySeed.find((m) => m.id === personaId)?.name;
+    if (personaName === undefined) return; // directory not seeded yet — next poll
+    try {
+      const raw = await transport.execute(
+        buildCommandUri('persona/rag-inspect'),
+        JSON.stringify({ persona: personaName }),
+      );
+      const parsed = JSON.parse(raw) as {
+        contextWindow?: number;
+        totalAllocated?: number;
+        escalationNeeded?: boolean;
+        deliveries?: readonly {
+          sourceId?: string;
+          source?: string;
+          tokensUsed?: number;
+          items?: readonly { contentPreview?: string; content?: string }[];
+        }[];
+      };
+      const sources = (parsed.deliveries ?? []).map((d) => {
+        const id = d.sourceId ?? d.source ?? '?';
+        const items = d.items ?? [];
+        const newest = items[items.length - 1];
+        return {
+          source: id,
+          // Tokens she actually receives from this source (the allocation is a
+          // budget and reads null for an unbudgeted source — caught live as "0 tok").
+          tokens: d.tokensUsed ?? 0,
+          delivered: items.length,
+          preview: (newest?.contentPreview ?? newest?.content ?? '').slice(0, 160),
+        };
+      });
+      setMindSight({
+        personaId,
+        fetchedAtMs: Date.now(),
+        contextWindow: parsed.contextWindow ?? 0,
+        totalAllocated: parsed.totalAllocated ?? 0,
+        escalationNeeded: parsed.escalationNeeded ?? false,
+        sources,
+      });
+      widget.mindRevision = Date.now();
+    } catch (err) {
+      console.error('mind sight poll failed:', err);
+    }
   };
   const focusMind = (personaId: string | undefined): void => {
     if (mindTimer !== undefined) clearInterval(mindTimer);
     mindTimer = undefined;
     if (personaId === undefined) {
       setMindFeed(undefined);
+      setMindSight(undefined);
       return;
     }
     void pollMind(personaId);
@@ -254,7 +306,12 @@ async function main(): Promise<void> {
     // it knows the tab. replaceState: navigation-in-place, not history spam.
     const known = widget.nav?.open_tabs?.find((t) => t.id === target);
     const short = known?.title ? known.title.toLowerCase() : target;
-    window.history.replaceState(null, '', `/${kind}/${encodeURIComponent(short)}`);
+    const tab = kind === 'persona' ? personaTab : undefined;
+    window.history.replaceState(
+      null,
+      '',
+      `/${kind}/${encodeURIComponent(short)}${tab !== undefined ? `/${tab}` : ''}`,
+    );
   };
   widget.selectRoomHandler = selectRoomHandler;
 
@@ -300,14 +357,28 @@ async function main(): Promise<void> {
   // UUID-typed (names are display, ids are identity). The pending link waits
   // for the first nav envelope that knows the target, fires once, clears.
   let pendingDeepLink: { kind: 'room' | 'persona'; target: string } | null = null;
+  // The persona page's current face, mirrored into the address bar
+  // (`/persona/kira/mind`) — set by the deep link, then by tab clicks.
+  let personaTab: string | undefined;
+  onPersonaTabChange((tab) => {
+    personaTab = tab;
+    const m = /^\/persona\/([^/]+)/.exec(window.location.pathname);
+    if (m?.[1] !== undefined) window.history.replaceState(null, '', `/persona/${m[1]}/${tab}`);
+  });
   let focusPinned = false;
   {
-    const m = /^\/(room|persona)\/(.+)$/.exec(window.location.pathname);
+    // `/persona/<name>/<tab>` — the path names the page AND its face
+    // (docs/architecture/URI-ADDRESSED-DESKTOP.md): `/persona/kira/mind` opens her mind.
+    const m = /^\/(room|persona)\/([^/]+)(?:\/([a-z]+))?$/.exec(window.location.pathname);
     if (m?.[1] !== undefined && m[2] !== undefined) {
       pendingDeepLink = {
         kind: m[1] as 'room' | 'persona',
         target: decodeURIComponent(m[2]),
       };
+      if (m[1] === 'persona') {
+        setRequestedPersonaTab(m[3]);
+        personaTab = m[3];
+      }
     }
   }
   const UUID_LINK = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -317,6 +388,7 @@ async function main(): Promise<void> {
     // (solve rooms are navigable before they ever appear in a tab set).
     if (UUID_LINK.test(pendingDeepLink.target)) {
       const { kind, target } = pendingDeepLink;
+      focusPinned = true;
       void selectRoomHandler(target, kind)
         .then(() => {
           pendingDeepLink = null; // consumed only on SUCCESS
@@ -324,6 +396,7 @@ async function main(): Promise<void> {
         .catch(() => {
           // Transport not up yet (page-load race) — the next nav envelope
           // retries; the link is only consumed when the select lands.
+          focusPinned = false;
         });
       return;
     }
@@ -337,7 +410,13 @@ async function main(): Promise<void> {
       const member = widget.directorySeed.find((m) => m.name.toLowerCase() === want);
       if (member === undefined) return; // directory not seeded yet — next envelope
       pendingDeepLink = null;
+      // The link IS the explicit selection: pin before selecting, or the same
+      // envelope's focus pin selects the daemon's current tab right behind it
+      // (caught live 2026-09-03: `/persona/kira/mind` rendered, then the
+      // academy landed on top of it).
+      focusPinned = true;
       void selectRoomHandler(member.id, 'persona').catch((err: unknown) => {
+        focusPinned = false;
         console.error(`deep link ${window.location.pathname} failed:`, err);
       });
       return;
@@ -348,7 +427,9 @@ async function main(): Promise<void> {
     if (hit?.id === undefined) return; // nav doesn't know it yet — next envelope
     const { kind } = pendingDeepLink;
     pendingDeepLink = null;
+    focusPinned = true;
     void selectRoomHandler(hit.id, kind).catch((err: unknown) => {
+      focusPinned = false;
       console.error(`deep link ${window.location.pathname} failed:`, err);
     });
   };

--- a/apps/web/src/persona/renderPersona.ts
+++ b/apps/web/src/persona/renderPersona.ts
@@ -73,6 +73,78 @@ export function setMindFeed(feed: MindFeed | undefined): void {
   currentMindFeed = feed;
 }
 
+/** WHAT SHE SEES NOW — the live RAG allocation the substrate would hand her model this
+ *  instant (`persona/rag-inspect`): every grounding source, its token share of her
+ *  window, and the newest things it delivered. The mind tab's first section, because a
+ *  citizen's mind is first of all what is in front of her. */
+export interface MindSightSource {
+  readonly source: string;
+  readonly tokens: number;
+  readonly delivered: number;
+  readonly preview: string;
+}
+export interface MindSight {
+  readonly personaId: string;
+  readonly fetchedAtMs: number;
+  readonly contextWindow: number;
+  readonly totalAllocated: number;
+  readonly escalationNeeded: boolean;
+  readonly sources: readonly MindSightSource[];
+}
+let currentMindSight: MindSight | undefined;
+export function setMindSight(sight: MindSight | undefined): void {
+  currentMindSight = sight;
+}
+
+/** A deep link may name the tab (`/persona/kira/mind`); the page consumes it once. */
+let requestedTab: PersonaTab | undefined;
+let tabListener: ((tab: PersonaTab) => void) | undefined;
+/** The app mirrors the page's face into the address bar; one listener, app-owned. */
+export function onPersonaTabChange(listener: (tab: PersonaTab) => void): void {
+  tabListener = listener;
+}
+export function setRequestedPersonaTab(tab: string | undefined): void {
+  requestedTab =
+    tab !== undefined && PERSONA_TAB_IDS.includes(tab) ? (tab as PersonaTab) : undefined;
+}
+
+function sightSection(body: PersonaContentBody): TemplateResult {
+  const sight = currentMindSight?.personaId === body.personaId ? currentMindSight : undefined;
+  const pct =
+    sight === undefined
+      ? 0
+      : Math.min(100, Math.round((sight.totalAllocated / Math.max(1, sight.contextWindow)) * 100));
+  return html`<section class="p-card p-sight" id="sight">
+    <div class="p-card-head">
+      what she sees now
+      ${sight
+        ? html`<span class="p-live-chip" data-on
+            >live · ${sight.totalAllocated.toLocaleString()} / ${sight.contextWindow.toLocaleString()} tokens</span
+          >`
+        : html`<span class="p-live-chip" title="inspecting her grounding">awaiting inspection</span>`}
+      ${sight?.escalationNeeded
+        ? html`<span class="b-stat" title="her window is over budget">⚠ over budget</span>`
+        : nothing}
+    </div>
+    ${sight === undefined
+      ? html`<div class="p-empty">Reconstructing the exact grounding her model gets this instant.</div>`
+      : sight.sources.length === 0
+        ? html`<div class="p-empty">Nothing delivered — she is standing in a quiet room.</div>`
+        : html`<div class="sight-window" role="img" aria-label=${`window usage ${pct}%`}>
+              <span style=${`width:${pct}%`}></span>
+            </div>
+            <div class="sight-sources">
+              ${sight.sources.map(
+                (src) => html`<div class="sight-row">
+                  <span class="sight-source">${src.source}</span>
+                  <span class="sight-tokens">${src.tokens.toLocaleString()} tok · ${src.delivered} items</span>
+                  <span class="sight-preview">${src.preview}</span>
+                </div>`,
+              )}
+            </div>`}
+  </section>`;
+}
+
 function learningSection(body: PersonaContentBody): TemplateResult {
   const feed = currentMindFeed?.personaId === body.personaId ? currentMindFeed : undefined;
   return html`<section class="p-card p-learning" id="learning">
@@ -455,6 +527,7 @@ function writingsSection(body: PersonaContentBody): TemplateResult {
 /** Profile sub-navigation faces (PAGES-IA.md): one job per tab, the header
  *  permanent, no section on two tabs, honest empties everywhere. */
 type PersonaTab = 'overview' | 'mind' | 'genome' | 'work' | 'wall';
+const PERSONA_TAB_IDS: readonly string[] = ['overview', 'mind', 'genome', 'work', 'wall'];
 const PERSONA_TABS: readonly (readonly [PersonaTab, string])[] = [
   ['overview', 'Overview'],
   ['mind', 'Mind'],
@@ -472,7 +545,7 @@ export class PersonaPageElement extends LitElement {
   };
 
   body?: PersonaContentBody;
-  private _tab: PersonaTab = 'overview';
+  private _tab: PersonaTab = requestedTab ?? 'overview';
 
   protected override createRenderRoot(): HTMLElement {
     return this;
@@ -483,7 +556,7 @@ export class PersonaPageElement extends LitElement {
     if (!body) return html``;
     const content: Record<PersonaTab, TemplateResult> = {
       overview: html`${aboutSection(body)}${homeSection(body)}${workSection(body, 3)}${recordSection(body)}`,
-      mind: html`${brainSection(body)}${learningSection(body)}${pathwaysSection(body)}`,
+      mind: html`${sightSection(body)}${brainSection(body)}${learningSection(body)}${pathwaysSection(body)}`,
       genome: html`${genomeSection(body)}`,
       work: html`${workSection(body)}${recordSection(body)}${claimsSection(body)}`,
       wall: html`${writingsSection(body)}`,
@@ -504,6 +577,7 @@ export class PersonaPageElement extends LitElement {
             ?data-active=${this._tab === id}
             @click=${(): void => {
               this._tab = id;
+              tabListener?.(id);
             }}
           >
             ${label}

--- a/docs/architecture/URI-ADDRESSED-DESKTOP.md
+++ b/docs/architecture/URI-ADDRESSED-DESKTOP.md
@@ -22,6 +22,8 @@ workshop, plain). No client computes truth; no page is a special case.
 /personas/kira/mind                       what she sees now: grounding, doctrine, working set
 /personas/kira/mind/engrams               her memory, by recall key; dreams consolidated
 /personas/kira/learning                   examples buffered, buckets, adapters, grades credited
+/personas/kira/explore                    her EMBODIED view: the 3-D sim of where she stands
+/neighborhood                             the grid: every persona on every node, walkable
 /core                                     the serving core: lanes, demand, throughput, dreams
 /core/lanes/3                             one lane: who holds it, prefill/decode, KV pages
 ```
@@ -31,6 +33,19 @@ activity's base comes from its recipe — `academy` for learning by purpose), ne
 names in code. The path segments are the room directory's names; ids resolve the same
 routes (`/room/<uuid>` is the same page as its path).
 
+## The 3-D world is one more universe, not one more page (Joel 9/3)
+
+`/personas/kira/explore` and `/neighborhood` render the SAME view states the flat pages
+render — presence directory, roster, room bindings, her sight — as a walkable world (Sims /
+Second Life, literally): a persona is an avatar standing in the room she is resident in, her
+held card is what she is working at, her sight is what she is looking at, the room tree is
+the map, and other nodes on the grid are the neighborhood beyond the fence. No world-only
+truth: everything visible in the world is visible on the flat page and vice versa, because
+both are projections of one semantic layer. Trek is the console skin for the engineering
+areas (core, lanes, academy); the sim is the skin for people and places. Each is an asset
+payload ([[universes-are-positron-asset-payloads-one-semantic-layer-n-worlds]]); the
+embodiment work rides the avatar plan (JEPA-class world models over VLA).
+
 ## What each page is made of (nothing new)
 
 | Page | View state(s) already in Rust | Verb a citizen can call today |
@@ -39,6 +54,7 @@ routes (`/room/<uuid>` is the same page as its path).
 | round / card | Bench + Kanban + Roster + Chat | `benchmark/rounds`, `work/get` |
 | persona profile | Roster + presence directory + genome | `persona/roster`, `presence/directory`, `genome/list` |
 | persona mind | the RAG allocation + deliveries | `persona/rag-inspect` |
+| persona explore / neighborhood | presence directory + roster + room bindings + sight, rendered as a world | `presence/directory`, `persona/roster`, `persona/rag-inspect` |
 | persona learning | training-trigger buckets + verdicts | `genome/training-trigger/status` |
 | core | Serving + metrics | `serving/*`, `ai/report` |
 


### PR DESCRIPTION
The persona page is URI-addressed to its face: `/persona/kira/mind` opens the Mind tab; tab clicks mirror into the address bar; a deep link pins focus so the nav's focus pin cannot cover it with the daemon's current tab.

The Mind tab leads with **what she sees now** (`persona/rag-inspect`): window gauge, one row per grounding source (tokens received, items, newest delivery). Verified live via `perception/observe` on `/persona/Kira/mind`.

Also: URI doc gains `/personas/<name>/explore` and `/neighborhood` (the 3-D world as one more universe over the same view states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo