### PR TITLE
fix(cognition): collapse work receipts in grounding; GitHub verbs stop being a must-use for citizens

### DIFF
--- a/core/continuum-core/src/commands/code/github/issue_create.rs
+++ b/core/continuum-core/src/commands/code/github/issue_create.rs
@@ -36,10 +36,11 @@ crate::action_command! {
     pub struct CodeGithubIssueCreate { state: Arc<CodeState> }
     name: "code/github/issue-create",
     access: AiSafe,
-    native: true,
+    native: false, // reachable BY NAME; never pushed into every turn (placeholder-issue spam, 2026-09-03)
     params: GithubIssueCreateParams,
     output: GithubIssueCreateResult,
     run(this, ctx, p) => {
+        super::require_operator(ctx, "code/github/issue-create")?;
         if p.title.trim().is_empty() {
             return Err(CommandError::Invalid("code/github/issue-create: 'title' is required".into()));
         }

--- a/core/continuum-core/src/commands/code/github/mod.rs
+++ b/core/continuum-core/src/commands/code/github/mod.rs
@@ -32,6 +32,25 @@ pub mod pr_comment;
 pub mod pr_create;
 
 use issue_create::CodeGithubIssueCreate;
+
+/// GitHub verbs act on an EXTERNAL service under the OPERATOR's `gh` identity.
+/// A citizen (an airc caller) may not file issues, open PRs, or comment as the
+/// operator: 114 "placeholder" issues landed on the repo on 2026-09-03 because
+/// the verbs were offered to every turn and looping citizens used them to
+/// "avoid an unused tool". Until a room recipe can GRANT a citizen GitHub
+/// authorship in her own name, the verbs refuse airc callers loudly — the
+/// refusal names the rule, so a citizen learns the boundary instead of a 500.
+pub(crate) fn require_operator(ctx: &crate::sdk_codegen::Ctx, verb: &str) -> Result<(), CommandError> {
+    use crate::routing::auth_policy::CallerSource;
+    match ctx.caller.as_ref().map(|c| &c.source) {
+        Some(CallerSource::Airc) => Err(CommandError::Invalid(format!(
+            "{verb}: GitHub verbs act under the operator's identity and are not available to \
+             citizens in this room. Do the work in your checkout (code/read, code/edit, \
+             code/shell, git) and report in the room; an offered tool is never a must-use."
+        ))),
+        _ => Ok(()),
+    }
+}
 use pr_comment::CodeGithubPrComment;
 use pr_create::CodeGithubPrCreate;
 
@@ -88,16 +107,33 @@ pub fn command_objects(state: Arc<CodeState>) -> Vec<Arc<dyn DynCommand>> {
 mod tests {
     use crate::sdk_codegen::ActionCommand;
 
-    // what this catches: the wire names mirror the file paths (the routing keys), and each
-    // is offered natively (a native-call model can only emit calls for OFFERED tools, so a
-    // non-native collaboration verb would be unusable by her — the whole point is she can
-    // participate in PR/issue workflow).
+    // what this catches: the wire names mirror the file paths (the routing keys), and
+    // NONE is pushed into every turn's native offer — a tool-call model treats an offered
+    // tool as a must-use (114 placeholder issues on 2026-09-03). They stay reachable BY
+    // NAME through commands/list + commands/help for a caller allowed to use them.
     #[test]
-    fn github_command_names_mirror_path_and_are_native() {
+    fn github_command_names_mirror_path_and_are_not_native() {
         use super::*;
         assert_eq!(pr_create::CodeGithubPrCreate::NAME, "code/github/pr-create");
         assert_eq!(pr_comment::CodeGithubPrComment::NAME, "code/github/pr-comment");
         assert_eq!(issue_create::CodeGithubIssueCreate::NAME, "code/github/issue-create");
-        assert!(pr_create::CodeGithubPrCreate::NATIVE, "PR create must be offered to be usable");
+        assert!(!pr_create::CodeGithubPrCreate::NATIVE);
+        assert!(!issue_create::CodeGithubIssueCreate::NATIVE);
+        assert!(!pr_comment::CodeGithubPrComment::NATIVE);
+    }
+
+    // what this catches: a citizen (airc caller) is refused with the rule named; the
+    // operator (local caller, or no caller — the CLI) passes.
+    #[test]
+    fn github_verbs_refuse_citizens_and_admit_the_operator() {
+        use super::*;
+        use crate::routing::CallerIdentity;
+        let mut ctx = crate::sdk_codegen::Ctx::default();
+        assert!(require_operator(&ctx, "code/github/issue-create").is_ok());
+        ctx.caller = Some(CallerIdentity::local(crate::identity::PeerId::new()));
+        assert!(require_operator(&ctx, "code/github/issue-create").is_ok());
+        ctx.caller = Some(CallerIdentity::airc(crate::identity::PeerId::new()));
+        let err = require_operator(&ctx, "code/github/issue-create").unwrap_err();
+        assert!(err.to_string().contains("not available to citizens"), "{err}");
     }
 }

--- a/core/continuum-core/src/commands/code/github/pr_comment.rs
+++ b/core/continuum-core/src/commands/code/github/pr_comment.rs
@@ -34,10 +34,11 @@ crate::action_command! {
     pub struct CodeGithubPrComment { state: Arc<CodeState> }
     name: "code/github/pr-comment",
     access: AiSafe,
-    native: true,
+    native: false, // reachable BY NAME; never pushed into every turn (placeholder-issue spam, 2026-09-03)
     params: GithubPrCommentParams,
     output: GithubPrCommentResult,
     run(this, ctx, p) => {
+        super::require_operator(ctx, "code/github/pr-comment")?;
         if p.body.trim().is_empty() {
             return Err(CommandError::Invalid("code/github/pr-comment: 'body' is required".into()));
         }

--- a/core/continuum-core/src/commands/code/github/pr_create.rs
+++ b/core/continuum-core/src/commands/code/github/pr_create.rs
@@ -46,10 +46,11 @@ crate::action_command! {
     pub struct CodeGithubPrCreate { state: Arc<CodeState> }
     name: "code/github/pr-create",
     access: AiSafe,
-    native: true,
+    native: false, // reachable BY NAME; never pushed into every turn (placeholder-issue spam, 2026-09-03)
     params: GithubPrCreateParams,
     output: GithubPrCreateResult,
     run(this, ctx, p) => {
+        super::require_operator(ctx, "code/github/pr-create")?;
         if p.title.trim().is_empty() {
             return Err(CommandError::Invalid("code/github/pr-create: 'title' is required".into()));
         }

--- a/core/continuum-core/src/persona/airc_source.rs
+++ b/core/continuum-core/src/persona/airc_source.rs
@@ -327,15 +327,23 @@ impl AircRagSource {
         // tiny budgets still render a sentence and huge ones don't let one
         // essay crowd the window.
         let per_turn_cap = (budget / 8).clamp(48, 256);
+        let units = Self::collapse_work_receipts(digest);
         let mut keep: Vec<(usize, Option<String>)> = Vec::new();
         let mut tokens_used: u32 = 0;
         let mut newest_kept = true;
-        for (idx, el) in digest.elements.iter().enumerate().rev() {
-            let Some(text) = el.text() else { continue };
+        for unit in units.iter().rev() {
+            let idx = unit.last_idx;
+            let text: &str = match unit.collapsed.as_deref() {
+                Some(t) => t,
+                None => match digest.elements[idx].text() {
+                    Some(t) => t,
+                    None => continue,
+                },
+            };
             let full = estimate_tokens(text);
             let cap = if newest_kept { budget } else { per_turn_cap };
             let (cost, trimmed) = if full <= cap {
-                (full, None)
+                (full, unit.collapsed.clone())
             } else {
                 let head = head_to_tokens(text, cap);
                 let head_cost = estimate_tokens(&head).saturating_add(2); // marker
@@ -362,6 +370,89 @@ impl AircRagSource {
             })
             .collect();
         (items, tokens_used, read_through)
+    }
+
+    /// COLLAPSE, DON'T CLIP — work receipts. A working citizen radiates one
+    /// `💭 thought` + `⚙ verb ✓/✗` receipt per act batch into the room (so
+    /// roommates see live work). Grounded verbatim, a run room's window is 140
+    /// receipts and no conversation: every citizen reads everyone's "I've been
+    /// going in circles" and says it back (12 citizens, live 2026-09-03 — the
+    /// loop was the WINDOW). A consecutive run of receipts from ONE author
+    /// collapses to a single unit: her latest thought + a tally of what she
+    /// did. The run's last element anchors the unit (read-through cursor,
+    /// unread flag); chat lines break runs and stay verbatim.
+    fn collapse_work_receipts(digest: &ChannelDigest) -> Vec<PackUnit> {
+        let mut units: Vec<PackUnit> = Vec::new();
+        let mut run: Vec<usize> = Vec::new();
+        let mut run_sender: Option<uuid::Uuid> = None;
+        let flush = |run: &mut Vec<usize>, units: &mut Vec<PackUnit>| {
+            if run.is_empty() {
+                return;
+            }
+            let last_idx = *run.last().unwrap_or(&0); // unwrap_or: guarded by is_empty above
+            let collapsed = if run.len() == 1 {
+                None
+            } else {
+                Some(Self::collapsed_receipt_text(
+                    run.iter().filter_map(|i| digest.elements[*i].text()),
+                    run.len(),
+                ))
+            };
+            units.push(PackUnit { last_idx, collapsed });
+            run.clear();
+        };
+        for (idx, el) in digest.elements.iter().enumerate() {
+            let is_receipt = el.text().is_some_and(is_work_receipt);
+            let sender = el.sender_id();
+            if is_receipt && (run.is_empty() || run_sender == Some(sender)) {
+                run.push(idx);
+                run_sender = Some(sender);
+                continue;
+            }
+            flush(&mut run, &mut units);
+            if is_receipt {
+                run.push(idx);
+                run_sender = Some(sender);
+            } else {
+                units.push(PackUnit { last_idx: idx, collapsed: None });
+                run_sender = None;
+            }
+        }
+        flush(&mut run, &mut units);
+        units
+    }
+
+    /// The collapsed text of a receipt run: the newest `💭` line, then a tally
+    /// of every `⚙ verb mark` across the run (`⚙ code/shell ✓×4 · code/github/issue-create ✗×2`).
+    fn collapsed_receipt_text<'a>(texts: impl Iterator<Item = &'a str>, batches: usize) -> String {
+        let mut last_thought: Option<&str> = None;
+        let mut tally: Vec<(String, usize)> = Vec::new();
+        for text in texts {
+            for line in text.lines() {
+                let line = line.trim();
+                if line.starts_with("💭") {
+                    last_thought = Some(line);
+                } else if let Some(rest) = line.strip_prefix("⚙") {
+                    let mut parts = rest.split_whitespace();
+                    let verb = parts.next().unwrap_or("?"); // unwrap_or: a bare marker still tallies as unknown
+                    let mark = parts.last().unwrap_or("·"); // unwrap_or: a verb without a mark tallies as neutral
+                    let key = format!("{verb} {mark}");
+                    match tally.iter_mut().find(|(k, _)| *k == key) {
+                        Some((_, n)) => *n += 1,
+                        None => tally.push((key, 1)),
+                    }
+                }
+            }
+        }
+        let acts: Vec<String> = tally
+            .iter()
+            .map(|(k, n)| if *n > 1 { format!("{k}×{n}") } else { k.clone() })
+            .collect();
+        format!(
+            "{} · ⚙ {batches} act batches: {}",
+            last_thought.unwrap_or("💭 (working)"), // unwrap_or: a run of bare act lines has no thought to lead with
+            if acts.is_empty() { "(no receipts)".to_string() } else { acts.join(" · ") }
+        )
     }
 
     fn format_item(
@@ -404,6 +495,21 @@ impl AircRagSource {
             resolution_used: resolution,
         }
     }
+}
+
+/// One packable unit of the window: a message, or a collapsed run of work receipts.
+struct PackUnit {
+    /// The element that anchors the unit (the run's newest; the read-through cursor).
+    last_idx: usize,
+    /// The collapsed text when the unit is a receipt run of two or more; `None`
+    /// packs the element's own text.
+    collapsed: Option<String>,
+}
+
+/// A radiated work receipt (`act_observe::apply`): leads with `💭` or `⚙`.
+fn is_work_receipt(text: &str) -> bool {
+    let t = text.trim_start();
+    t.starts_with("💭") || t.starts_with("⚙")
 }
 
 #[async_trait]
@@ -901,6 +1007,46 @@ mod tests {
             "budget honored: {}",
             delivery.tokens_used
         );
+    }
+
+    fn receipt_from(room: RoomId, peer: PeerId, thought: &str, act: &str, lamport: u64) -> TranscriptEvent {
+        let mut ev = event_in(room, Some(&format!("💭 {thought}\n⚙ {act}")), lamport);
+        ev.peer_id = peer;
+        ev
+    }
+
+    // what this catches: THE LOOP WAS THE WINDOW (2026-09-03) — a run of one
+    // author's work receipts collapses to ONE unit (her newest thought + an act
+    // tally) instead of N verbatim "I've been going in circles" lines; a chat
+    // line breaks the run and stays verbatim; the newest receipt anchors the unit.
+    #[tokio::test]
+    async fn a_run_of_work_receipts_collapses_to_the_latest_thought_plus_a_tally() {
+        let room = RoomId::new();
+        let atlas = PeerId::new();
+        let mut events = vec![event_in(room, Some("OPERATOR: card 678b8f5c is yours"), 1)];
+        for l in 2..=5 {
+            events.push(receipt_from(room, atlas, &format!("thought {l}"), "code/shell ls ✓", l));
+        }
+        events.push(receipt_from(room, atlas, "thought six", "code/github/issue-create  ✗", 6));
+        events.push(event_in(room, Some("Kira: Atlas, stop filing issues"), 7));
+        let reader = Arc::new(StubReader::new(events));
+        let (source, _) = isolated_source(reader);
+        let delivery = source
+            .deliver(&ctx_in(room), 4_000, ResolutionPreference::Raw)
+            .await;
+        assert_eq!(
+            delivery.items.len(),
+            3,
+            "operator line + ONE collapsed run + Kira: {:?}",
+            delivery.items.iter().map(|i| i.content.clone()).collect::<Vec<_>>()
+        );
+        let run = &delivery.items[1].content;
+        assert!(run.starts_with("💭 thought six"), "newest thought leads: {run:?}");
+        assert!(run.contains("5 act batches"), "batch count: {run:?}");
+        assert!(run.contains("code/shell ✓×4"), "tally: {run:?}");
+        assert!(run.contains("code/github/issue-create ✗"), "tally: {run:?}");
+        assert!(!run.contains("thought 2"), "older thoughts folded away: {run:?}");
+        assert!(delivery.items[2].content.starts_with("Kira:"));
     }
 
     // what this catches: THE DEAF-PERSONA FIX — when the turn's ctx has no airc_room


### PR DESCRIPTION
Glass-boxed: a citizen window was 140 peer work receipts and no conversation (the loop was the window); 114 placeholder issues were filed on this repo under the operator gh identity because the GitHub verbs were native (offered = must-use to a tool-call model).

1. Consecutive work receipts from one author collapse to her newest thought + an act tally in grounding.
2. GitHub verbs are non-native and refuse citizen (airc) callers with the rule named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo