### PR TITLE
fix(cognition): a tool result carries a one-line clipped intent, not the monologue

### DIFF
--- a/core/continuum-core/src/cognition/act_observe/observation.rs
+++ b/core/continuum-core/src/cognition/act_observe/observation.rs
@@ -214,12 +214,22 @@ impl Observation {
     /// call, shared by every act in the batch), so it is passed rather than
     /// stored per-`Observation`.
     pub fn render_recency(&self, intent: &str, budget: &ContextBudget) -> String {
+        Self::render_recency_impl(self, intent, budget)
+    }
+
+    fn render_recency_impl(&self, intent: &str, budget: &ContextBudget) -> String {
         let fold = Some(budget.echoed_arg_chars());
         let args = summarize_args_for_recency(&self.call.input, fold);
+        // The intent rides the result as a ONE-LINE reason, clipped to the same
+        // window-relative echo budget the args get — never the whole monologue.
+        // Measured 2026-09-04: one result header carried 2,902 chars of intent
+        // ("Let me get oriented…") ahead of 790 chars of actual output; across a
+        // turn, 6.1k of 20.6k result chars were intent echo. The output is what
+        // she must read; the reason is a label.
         let because = if intent.trim().is_empty() {
             String::new()
         } else {
-            format!(" because {}", intent.trim())
+            format!(" because {}", clip_intent(intent, budget.echoed_arg_chars()))
         };
         format!(
             "{}({}){}\nResult:\n{}\n\n",
@@ -269,8 +279,35 @@ pub fn extract_paths(input: &serde_json::Value) -> Vec<PathBuf> {
     out
 }
 
+
+/// Clip an act's intent to a one-line reason of at most `max_chars` characters
+/// (first line, head-trimmed with an ellipsis). Pure; used by the recency render.
+pub(super) fn clip_intent(intent: &str, max_chars: usize) -> String {
+    let first = intent.trim().lines().next().unwrap_or("").trim(); // unwrap_or: an empty intent clips to nothing
+    let max = max_chars.max(24);
+    if first.chars().count() <= max {
+        first.to_string()
+    } else {
+        let head: String = first.chars().take(max.saturating_sub(1)).collect();
+        format!("{}…", head.trim_end())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    // what this catches: the intent rides a tool result as a ONE-LINE label clipped to
+    // the echo budget — never the monologue (2,902 chars ahead of 790 chars of output,
+    // measured 2026-09-04). A short intent passes through untouched.
+    #[test]
+    fn intent_on_a_result_is_a_clipped_one_liner() {
+        let long = "Let me get oriented properly this time. I've been confusing myself with stale context and the board says otherwise.\nSecond line never rides.";
+        let clipped = super::clip_intent(long, 40);
+        assert!(clipped.chars().count() <= 40, "{clipped:?}");
+        assert!(clipped.ends_with('…') && !clipped.contains("Second line"), "{clipped:?}");
+        assert_eq!(super::clip_intent("read the card", 40), "read the card");
+        assert_eq!(super::clip_intent("   ", 40), "");
+    }
+
     use super::*;
 
     // what this catches: the verb→class mapping is the ONE home the `wrote` bool,

--- a/core/continuum-core/src/persona/viewstate_rag.rs
+++ b/core/continuum-core/src/persona/viewstate_rag.rs
@@ -345,9 +345,14 @@ impl RagRenderable for continuum_positron::RosterViewState {
                 if let Some(role) = slot.role_label.as_deref().filter(|r| !r.is_empty()) {
                     line.push_str(&format!(" — {role}"));
                 }
-                if let Some(avail) = slot.availability.as_deref() {
-                    line.push_str(&format!(" [{avail}]"));
-                }
+                // NO liveness flag in the mind's copy (2026-09-04): `[ready]`/`[busy]`
+                // flips with every heartbeat, and this block sits inside the STABLE
+                // system prefix — consecutive prompts of one citizen diverged at char
+                // ~9.7k of a 10.1k system on exactly this flag, forfeiting the whole
+                // prefix (hit_rate 0.0 on 57/57 turns). Who is here, their kind and
+                // role, are the stable facts; whether a peer is busy this second is
+                // presence — the live view carries it, and it belongs in the volatile
+                // tail if a turn ever needs it ([[a-mutating-system-prompt-destroys-kv-reuse]]).
                 line
             })
             .collect()
@@ -460,6 +465,25 @@ mod tests {
     /// stamping is what a live turn does).
     fn ctx() -> RagContext {
         RagContext::for_persona_in_room(Uuid::from_u128(0x9), 0, Uuid::from_u128(0xaa))
+    }
+
+    // what this catches: the mind's roster line carries NO liveness flag — `[ready]`/
+    // `[busy]` flips per heartbeat inside the STABLE system prefix and forfeited the
+    // whole prefix (hit_rate 0.0 on 57/57 turns, prompts diverging at the flag,
+    // 2026-09-04). Name, kind and role stay; presence is the live view's job.
+    #[test]
+    fn the_roster_line_carries_no_liveness_flag() {
+        let mut slot = crate::ipc::positron_source::test_roster_slot(
+            Uuid::from_u128(7),
+            "Anwen",
+            SenderKind::Agent,
+        );
+        slot.availability = Some("busy".to_string());
+        let view = RosterViewState { room_id: Uuid::from_u128(0xaa), roster: vec![slot] };
+        let units = RagRenderable::units(&view);
+        assert_eq!(units.len(), 1);
+        assert!(units[0].starts_with("Anwen"), "{units:?}");
+        assert!(!units[0].contains("[busy]") && !units[0].contains('['), "{units:?}");
     }
 
     /// what this catches: THE defect. A peer present in the room must reach the


### PR DESCRIPTION
One result header carried 2,902 chars of intent ahead of 790 chars of output. Clipped to the window-relative echo budget, first line only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo