### PR TITLE
fix(tests): persona_command_inbound_pump fixture uses ..Default::default() — #1952 broke the explicit-None initializer

### DIFF
--- a/core/continuum-core/tests/persona_command_inbound_pump.rs
+++ b/core/continuum-core/tests/persona_command_inbound_pump.rs
@@ -96,6 +96,12 @@ impl ServiceModule for TestInferenceModule {
     }
 }
 
+/// A minimal request: one user message, every knob at its default.
+/// `..Default::default()` (the struct derives `Default`) instead of an
+/// explicit `None` per field — #1952 added `frequency_penalty` +
+/// `repeat_last_n` and this initializer silently stopped compiling
+/// because it enumerated every field. Struct-update syntax makes the
+/// fixture immune to the next sampling knob.
 fn request(prompt: &str) -> TextGenerationRequest {
     TextGenerationRequest {
         messages: vec![ChatMessage {
@@ -103,24 +109,7 @@ fn request(prompt: &str) -> TextGenerationRequest {
             content: MessageContent::Text(prompt.to_string()),
             name: None,
         }],
-        system_prompt: None,
-        model: None,
-        provider: None,
-        temperature: None,
-        max_tokens: None,
-        top_p: None,
-        top_k: None,
-        repeat_penalty: None,
-        stop_sequences: None,
-        tools: None,
-        tool_choice: None,
-        response_format: None,
-        active_adapters: None,
-        request_id: None,
-        user_id: None,
-        room_id: None,
-        purpose: None,
-        persona_id: None,
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
## What

`tests/persona_command_inbound_pump.rs` stopped compiling: #1952 added `frequency_penalty` + `repeat_last_n` to `TextGenerationRequest` and updated five sibling integration tests, but missed this one.

Fix: the struct derives `Default`, so the fixture now uses struct-update syntax (`..Default::default()`) instead of enumerating every field — the next sampling knob can't break it.

## Why nobody noticed

Every `[[test]]` with `required-features = ["test-fixtures"]` is compiled by **nobody** in CI: the windows job runs `cargo check --lib --tests` without `--features test-fixtures`, and the linux job runs `cargo test --lib` (no integration targets). Canary CI stayed green on `f6c177c6c` while this target was red. Found by an IntelMac cold-start `cargo check --tests --features test-fixtures`.

That's the class bug → airc card **9d249bd6** (add `--features test-fixtures` to the compile-only CI check). This PR is the symptom fix only.

## Verification

`cargo check -p continuum-core --test persona_command_inbound_pump --no-default-features --features livekit-webrtc,llama/mac-cpu-only,test-fixtures` → clean on Intel Mac.

## Refs

- airc card: 0797e204 (this) · 9d249bd6 (CI gap)
- CLAUDE.md § "If You Are About To Add a Test" — one fixture per concern, don't reinvent
- `continuum-core/Cargo.toml` § test-fixtures gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE
