### PR TITLE
feat(ctm): --provider on generate — the consumer CLI could not make the one request the substrate accepts

### DIFF
--- a/apps/cli/src/grid_smoke.rs
+++ b/apps/cli/src/grid_smoke.rs
@@ -296,7 +296,11 @@ pub fn default_battery() -> Vec<GridSmokeSpec> {
                 let trimmed: String = text.chars().take(50).collect();
                 Ok(format!(
                     "model={model} text={trimmed:?}{}",
-                    if text.chars().count() > 50 { " (truncated)" } else { "" }
+                    if text.chars().count() > 50 {
+                        " (truncated)"
+                    } else {
+                        ""
+                    }
                 ))
             },
             expectation: ChainShape::SingleHop {
@@ -309,10 +313,7 @@ pub fn default_battery() -> Vec<GridSmokeSpec> {
 }
 
 /// Dispatch one spec, time the wall-clock, validate.
-async fn run_spec(
-    conn: &Connection<AircIpcTransport>,
-    spec: &GridSmokeSpec,
-) -> RunResult {
+async fn run_spec(conn: &Connection<AircIpcTransport>, spec: &GridSmokeSpec) -> RunResult {
     // NotYetWired rows skip dispatch entirely — the substrate would
     // error on something we already know doesn't cross the wire.
     if let ChainShape::NotYetWired { reason } = &spec.expectation {
@@ -397,12 +398,27 @@ pub fn print_report(target_peer: &str, results: &[RunResult]) {
             Outcome::Skipped(_) => String::from("    -"),
             _ => format!("{:>5}", r.elapsed.as_millis()),
         };
-        println!("  {glyph}  {:width$}  {} ms   {}", r.name, ms, body, width = name_width);
+        println!(
+            "  {glyph}  {:width$}  {} ms   {}",
+            r.name,
+            ms,
+            body,
+            width = name_width
+        );
     }
 
-    let pass = results.iter().filter(|r| matches!(r.outcome, Outcome::Ok(_))).count();
-    let fail = results.iter().filter(|r| matches!(r.outcome, Outcome::Failed(_))).count();
-    let skip = results.iter().filter(|r| matches!(r.outcome, Outcome::Skipped(_))).count();
+    let pass = results
+        .iter()
+        .filter(|r| matches!(r.outcome, Outcome::Ok(_)))
+        .count();
+    let fail = results
+        .iter()
+        .filter(|r| matches!(r.outcome, Outcome::Failed(_)))
+        .count();
+    let skip = results
+        .iter()
+        .filter(|r| matches!(r.outcome, Outcome::Skipped(_)))
+        .count();
     let total = results.len();
 
     println!("\n{pass}/{total} passed  ({fail} failed, {skip} skipped)");
@@ -412,10 +428,7 @@ pub fn print_report(target_peer: &str, results: &[RunResult]) {
 /// battery, prints the report, and returns Ok iff every spec passed.
 /// Failure -> nonzero exit so CI / scripts can gate on grid-smoke
 /// directly without parsing the report.
-pub async fn run(
-    conn: Connection<AircIpcTransport>,
-    target_peer: uuid::Uuid,
-) -> Result<()> {
+pub async fn run(conn: Connection<AircIpcTransport>, target_peer: uuid::Uuid) -> Result<()> {
     let specs = default_battery();
     let results = run_battery(conn, specs).await;
     print_report(&target_peer.to_string(), &results);

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -76,6 +76,15 @@ enum Command {
         /// selector picks a default when omitted.
         #[arg(long)]
         model: Option<String>,
+        /// Provider id to route to (e.g. `llama-server`, `docker-model-runner`,
+        /// `anthropic`). The substrate's `AdapterRegistry::select` accepts an
+        /// explicit provider with NO model and hard-refuses model-only requests
+        /// whose name matches no adapter prefix ([[no-fallbacks-ever]]) — so a
+        /// grid consumer with no local registry needs this to make the one
+        /// request a remote substrate will serve. `local` is the sentinel for
+        /// "best local GPU adapter on the target". Card 94179b72.
+        #[arg(long, env = "CONTINUUM_PROVIDER")]
+        provider: Option<String>,
 
         /// Print the raw JSON response instead of just the text field.
         #[arg(long, default_value_t = false)]
@@ -136,7 +145,12 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Command::Metrics => run_metrics(conn).await,
-        Command::Generate { prompt, model, json } => run_generate(conn, prompt, model, json).await,
+        Command::Generate {
+            prompt,
+            model,
+            provider,
+            json,
+        } => run_generate(conn, prompt, model, provider, json).await,
         Command::GridSmoke => grid_smoke::run(conn, peer).await,
     }
 }
@@ -155,6 +169,7 @@ async fn run_generate(
     conn: Connection<AircIpcTransport>,
     prompt: String,
     model: Option<String>,
+    provider: Option<String>,
     json: bool,
 ) -> Result<()> {
     // Construct the minimum-viable TextGenerationRequest shape. The
@@ -180,6 +195,9 @@ async fn run_generate(
     if let Some(m) = model {
         params["model"] = serde_json::Value::String(m);
     }
+    if let Some(p) = provider {
+        params["provider"] = serde_json::Value::String(p);
+    }
 
     let result: serde_json::Value = conn
         .commands()
@@ -200,20 +218,21 @@ async fn run_generate(
         // mask a substrate-side contract violation as a fake string;
         // surface a typed error instead so substrate bugs get caught
         // loudly.
-        let text = result
-            .get("text")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow!(
+        let text = result.get("text").and_then(|v| v.as_str()).ok_or_else(|| {
+            anyhow!(
                 "substrate `ai/generate` response missing required `text` field — \
                  substrate-side contract violation, not a CLI presentation problem"
-            ))?;
+            )
+        })?;
         println!("{text}");
-        let model = result.get("model").and_then(|v| v.as_str()).ok_or_else(|| {
-            anyhow!("substrate response missing required `model` field")
-        })?;
-        let provider = result.get("provider").and_then(|v| v.as_str()).ok_or_else(|| {
-            anyhow!("substrate response missing required `provider` field")
-        })?;
+        let model = result
+            .get("model")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("substrate response missing required `model` field"))?;
+        let provider = result
+            .get("provider")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("substrate response missing required `provider` field"))?;
         let total = result
             .get("usage")
             .and_then(|u| u.get("totalTokens"))
@@ -230,8 +249,8 @@ async fn run_generate(
 /// airc-lib does internally so the CLI doesn't fall back to a system
 /// path the user didn't expect.
 fn default_airc_home() -> Result<PathBuf> {
-    let home = env::var_os("HOME")
-        .ok_or_else(|| anyhow!("$HOME is unset; pass --home explicitly"))?;
+    let home =
+        env::var_os("HOME").ok_or_else(|| anyhow!("$HOME is unset; pass --home explicitly"))?;
     // ctm gets its OWN scope, never the operator's `~/.airc`. Two reasons,
     // both learned the hard way (2026-08-27 grid-smoke 0/3): a shared home
     // would inherit the operator's CURRENT ROOM — request/reply frames are
@@ -240,5 +259,8 @@ fn default_airc_home() -> Result<PathBuf> {
     // deadlines; and steering the shared scope's room to fix that would
     // mutate the operator's own airc state. A fresh dedicated scope lands
     // in #general (the substrate's commons) by airc's own default.
-    Ok(PathBuf::from(home).join(".continuum").join("ctm").join("airc"))
+    Ok(PathBuf::from(home)
+        .join(".continuum")
+        .join("ctm")
+        .join("airc"))
 }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -72,8 +72,11 @@ enum Command {
         #[arg(long)]
         prompt: String,
 
-        /// Model name to dispatch to. Optional; the substrate's adapter
-        /// selector picks a default when omitted.
+        /// Model name to dispatch to. Optional — but the substrate's
+        /// selector refuses a request with NEITHER model NOR provider
+        /// ([[no-fallbacks-ever]]: no silent default), so pass this or
+        /// `--provider`. A model-only request must match an adapter's
+        /// registered model prefix on the target.
         #[arg(long)]
         model: Option<String>,
         /// Provider id to route to (e.g. `llama-server`, `docker-model-runner`,


### PR DESCRIPTION
## What

`ctm generate --provider <id>` (env `CONTINUUM_PROVIDER`). Lands as the `provider` field on the `TextGenerationRequest` JSON. Plus `cargo fmt` on the crate (`grid_smoke.rs` had pre-existing drift that failed `fmt --check`).

## Why

`AdapterRegistry::select` (`ai/adapter.rs:922`) returns an adapter for an **explicit provider with no model**, and hard-refuses model-only requests whose name matches no adapter prefix — correct per `[[no-fallbacks-ever]]`. `ctm` exposed `--model` only, so a grid consumer with no local registry — the weak-node case this lane exists for — was refused on every call:

```
provider/model not available (provider=None, model=..). Available: [llama-server#2..13, docker-model-runner, llama-server]
```

(The list is provider ids, not model ids, so there was nothing the consumer could pass. That legibility bug is card a466fdd4.)

## Measured (IntelMac → BigMama 5090, over airc)

| request | result | wall |
|---|---|---|
| no model, no provider | typed refusal | ~124 ms |
| `--model qwen3.5` | typed refusal (no prefix match) | ~120 ms |
| `--provider llama-server` (this PR) | **accepted** → 120 s command deadline, no reply | 120 105 ms |

So the CLI change is proven (the substrate accepts the dispatch); the subsequent deadline is a serving/lane question on the target, being chased in `#academy`. Refused round-trips at ~120 ms give the wire+dispatch floor for the parity bar.

## Refs

- airc card: 94179b72 (this) · a466fdd4 (refusal message legibility)
- `docs/architecture/GRID-ADDRESSING-AND-ROUTING.md`, `GRID-ELASTIC-CAPABILITY.md`
- CLAUDE.md § AI QA — the consumer's failure is the bug report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE
