### PR TITLE
fix(ai): the ai/generate refusal names the models the lanes serve — a caller can act on it

### DIFF
--- a/core/continuum-core/src/ai/adapter.rs
+++ b/core/continuum-core/src/ai/adapter.rs
@@ -459,6 +459,16 @@ pub trait AIProviderAdapter: Send + Sync {
     /// Get default model for this provider
     fn default_model(&self) -> &str;
 
+    /// The model ids this adapter will ACTUALLY serve right now — what a
+    /// refusal may tell a caller to pass. Default: just `default_model()`.
+    /// Gateway adapters whose catalog default can drift from the live lane
+    /// (llama-server / DMR after a relaunch — the 5090 2026-07-24 misname)
+    /// override this with their verified runtime set. Never a guess: an
+    /// adapter that cannot know returns its declared default only.
+    fn served_model_ids(&self) -> Vec<String> {
+        vec![self.default_model().to_string()]
+    }
+
     /// Initialize the adapter (verify API key, load the model file
     /// off disk). Pays the model-load wall-clock once at boot so
     /// downstream consumers see the model's real capabilities from
@@ -897,20 +907,28 @@ impl AdapterRegistry {
             .collect()
     }
 
-    /// What each available adapter actually serves: `(provider_id, default_model)`
-    /// in priority order. This is the list a refusal must show a caller who named
-    /// a model the registry can't route — `available()` is provider ids, which a
-    /// grid consumer with no local registry cannot turn into a valid `model`
-    /// (card a466fdd4: IntelMac → 5090 was refused with a list it couldn't act on).
-    pub fn served_models(&self) -> Vec<(&str, &str)> {
-        self.priority_order
-            .iter()
-            .filter_map(|id| {
-                self.adapters
-                    .get(id)
-                    .map(|adapter| (id.as_str(), adapter.default_model()))
-            })
-            .collect()
+    /// What each available adapter actually serves: `(provider_id, model_id)`
+    /// pairs in priority order, deduplicated, from each adapter's
+    /// [`AIProviderAdapter::served_model_ids`] (live runtime set where the
+    /// adapter has one, declared default otherwise). This is the list a refusal
+    /// must show a caller who named a model the registry can't route —
+    /// `available()` is provider ids, which a grid consumer with no local
+    /// registry cannot turn into a valid `model` (card a466fdd4: IntelMac → 5090
+    /// was refused with a list it couldn't act on).
+    pub fn served_models(&self) -> Vec<(&str, String)> {
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for id in &self.priority_order {
+            let Some(adapter) = self.adapters.get(id) else {
+                continue;
+            };
+            for model in adapter.served_model_ids() {
+                if seen.insert((id.as_str(), model.clone())) {
+                    out.push((id.as_str(), model));
+                }
+            }
+        }
+        out
     }
 
     /// Select best adapter based on request.

--- a/core/continuum-core/src/ai/adapter.rs
+++ b/core/continuum-core/src/ai/adapter.rs
@@ -897,6 +897,22 @@ impl AdapterRegistry {
             .collect()
     }
 
+    /// What each available adapter actually serves: `(provider_id, default_model)`
+    /// in priority order. This is the list a refusal must show a caller who named
+    /// a model the registry can't route — `available()` is provider ids, which a
+    /// grid consumer with no local registry cannot turn into a valid `model`
+    /// (card a466fdd4: IntelMac → 5090 was refused with a list it couldn't act on).
+    pub fn served_models(&self) -> Vec<(&str, &str)> {
+        self.priority_order
+            .iter()
+            .filter_map(|id| {
+                self.adapters
+                    .get(id)
+                    .map(|adapter| (id.as_str(), adapter.default_model()))
+            })
+            .collect()
+    }
+
     /// Select best adapter based on request.
     ///
     /// Per [[no-fallbacks-ever]] (Joel, 2026-06-01: "No fallbacks ever

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -1077,6 +1077,23 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
         &self.config.provider_id
     }
 
+    /// The live set the daemon's reconcile / `/v1/models` refresh verified
+    /// (`runtime_models`), sorted for stable output; the catalog default only
+    /// when nothing has been verified yet. `config.default_model` is a
+    /// derived catalog value and can misname the lane (5090 2026-07-24), so
+    /// a refusal must not point callers at it when the truth is known.
+    fn served_model_ids(&self) -> Vec<String> {
+        let guard = self.runtime_models.read().unwrap();
+        match guard.as_ref().filter(|set| !set.is_empty()) {
+            Some(set) => {
+                let mut ids: Vec<String> = set.iter().cloned().collect();
+                ids.sort();
+                ids
+            }
+            None => vec![self.config.default_model.clone()],
+        }
+    }
+
     fn name(&self) -> &str {
         &self.config.name
     }

--- a/core/continuum-core/src/modules/ai_provider.rs
+++ b/core/continuum-core/src/modules/ai_provider.rs
@@ -274,6 +274,14 @@ pub(crate) fn select_failure_message(
         .map(|(provider, model)| format!("{provider}={model}"))
         .collect();
     match (requested_provider, requested_model) {
+        // "local" is the best-local-GPU sentinel, not an adapter id: DMR IS
+        // registered here (the branch above handled the down case), so the
+        // honest diagnosis is "no local adapter serves that model".
+        (Some("local"), model) => format!(
+            "No local adapter can serve model {model:?}. \
+             Served models (provider=model): {served:?}. \
+             Pass `model` as one of those, or `provider` as one of {available:?}."
+        ),
         (Some(provider), _) => format!(
             "Provider {provider:?} is not available (model={requested_model:?}). \
              Available providers: {available:?}; served models (provider=model): {served:?}."
@@ -1266,14 +1274,65 @@ mod tests {
 
         let by_model = select_failure_message(&registry, None, Some("no-such-model"));
         assert!(by_model.contains("no-such-model"), "{by_model}");
-        assert!(by_model.contains(&format!("{provider}={model}")), "{by_model}");
+        assert!(
+            by_model.contains(&format!("{provider}={model}")),
+            "{by_model}"
+        );
 
         let unspecified = select_failure_message(&registry, None, None);
         assert!(unspecified.contains("never picks one"), "{unspecified}");
-        assert!(unspecified.contains(&format!("{provider}={model}")), "{unspecified}");
+        assert!(
+            unspecified.contains(&format!("{provider}={model}")),
+            "{unspecified}"
+        );
 
         let bad_provider = select_failure_message(&registry, Some("ghost"), None);
         assert!(bad_provider.contains("\"ghost\""), "{bad_provider}");
         assert!(bad_provider.contains(&provider), "{bad_provider}");
+    }
+
+    // what this catches: a gateway adapter's catalog `default_model` is a
+    // DERIVED value that can misname the live lane (5090 2026-07-24); once the
+    // daemon has verified what the lane serves (`ensure_runtime_model`), the
+    // refusal must point callers at THAT id, never the catalog placeholder —
+    // otherwise the "actionable" refusal sends them into a second refusal
+    // (#3696 review finding #1).
+    #[test]
+    fn served_models_prefers_verified_runtime_ids_over_catalog_default() {
+        // Built from a plain config, not `from_registry`: the model registry
+        // singleton is a boot-path concern, and this test is about the
+        // adapter's own runtime set vs its declared default.
+        let gateway =
+            OpenAICompatibleAdapter::new(crate::ai::openai_adapter::OpenAICompatibleConfig {
+                provider_id: crate::inference::llama_server::PROVIDER_ID.into(),
+                name: "llama-server (test)".into(),
+                base_url: "http://127.0.0.1:0".into(),
+                api_key_env: None,
+                default_model: "catalog-default".into(),
+                capabilities: std::collections::BTreeSet::new(),
+                models: Vec::new(),
+                model_prefixes: Vec::new(),
+                requires_auth: false,
+                tool_protocol: crate::model_registry::ToolProtocol::NativeFunctionCalling,
+                thinking: crate::ai::openai_adapter::ThinkingMode::Default,
+                single_resident_model: false,
+                dynamic_model_catalog: false,
+                llamacpp_sampling_extensions: false,
+            });
+        let catalog_default = gateway.default_model().to_string();
+        assert_eq!(gateway.served_model_ids(), vec![catalog_default.clone()]);
+
+        gateway.ensure_runtime_model("ornith-ai/Ornith-1.5-35B-A3B-GGUF");
+        assert_eq!(
+            gateway.served_model_ids(),
+            vec!["ornith-ai/Ornith-1.5-35B-A3B-GGUF".to_string()],
+            "verified runtime set must replace the catalog default"
+        );
+
+        let mut registry = AdapterRegistry::new();
+        registry.register(Arc::new(gateway), 0);
+        let msg = select_failure_message(&registry, None, Some("nope"));
+        assert!(msg.contains("=ornith-ai/Ornith-1.5-35B-A3B-GGUF"), "{msg}");
+        assert!(!msg.contains(&format!("={catalog_default}")), "{msg}");
     }
 }

--- a/core/continuum-core/src/modules/ai_provider.rs
+++ b/core/continuum-core/src/modules/ai_provider.rs
@@ -264,10 +264,31 @@ pub(crate) fn select_failure_message(
             available
         );
     }
-    format!(
-        "Requested provider/model not available (provider={:?}, model={:?}). Available: {:?}",
-        requested_provider, requested_model, available
-    )
+    // A refusal the caller can ACT on. `available` is provider ids; a caller
+    // who named a model (or nothing) needs the model ids the lanes actually
+    // serve, or they are stuck guessing — the weak-node consumer case, where
+    // the caller has no local registry at all (card a466fdd4).
+    let served: Vec<String> = registry
+        .served_models()
+        .into_iter()
+        .map(|(provider, model)| format!("{provider}={model}"))
+        .collect();
+    match (requested_provider, requested_model) {
+        (Some(provider), _) => format!(
+            "Provider {provider:?} is not available (model={requested_model:?}). \
+             Available providers: {available:?}; served models (provider=model): {served:?}."
+        ),
+        (None, Some(model)) => format!(
+            "Model {model:?} is not served by any available provider. \
+             Served models (provider=model): {served:?}. \
+             Pass `model` as one of those, or `provider` as one of {available:?}."
+        ),
+        (None, None) => format!(
+            "No provider or model specified — the substrate never picks one for you. \
+             Pass `provider` as one of {available:?}, or `model` as one of the served \
+             models (provider=model): {served:?}."
+        ),
+    }
 }
 
 /// Build + initialize the llama-server gateway adapter pointed at a ready
@@ -1224,4 +1245,35 @@ pub async fn generate_text(
     });
 
     Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
+
+    // what this catches: the refusal for an unknown/omitted model must name the
+    // model ids the registry actually serves, not just provider ids — a grid
+    // consumer with no local registry was refused with a list it could not act
+    // on (card a466fdd4, IntelMac → 5090, 2026-09-04).
+    #[test]
+    fn select_failure_message_names_served_models_for_model_and_no_specifier() {
+        let heuristic = HeuristicInferenceAdapter::new();
+        let provider = heuristic.provider_id().to_string();
+        let model = heuristic.default_model().to_string();
+        let mut registry = AdapterRegistry::new();
+        registry.register(Arc::new(heuristic), 0);
+
+        let by_model = select_failure_message(&registry, None, Some("no-such-model"));
+        assert!(by_model.contains("no-such-model"), "{by_model}");
+        assert!(by_model.contains(&format!("{provider}={model}")), "{by_model}");
+
+        let unspecified = select_failure_message(&registry, None, None);
+        assert!(unspecified.contains("never picks one"), "{unspecified}");
+        assert!(unspecified.contains(&format!("{provider}={model}")), "{unspecified}");
+
+        let bad_provider = select_failure_message(&registry, Some("ghost"), None);
+        assert!(bad_provider.contains("\"ghost\""), "{bad_provider}");
+        assert!(bad_provider.contains(&provider), "{bad_provider}");
+    }
 }


### PR DESCRIPTION
A grid consumer with no local registry (IntelMac -> the 5090, 2026-09-04)
was refused with a list of PROVIDER ids and no way to turn them into a
valid model:

  Requested provider/model not available (provider=None, model=None).
  Available: [llama-server#2..13, docker-model-runner, llama-server]

The refusal is right ([[no-fallbacks-ever]]); the message must let the
caller recover. AdapterRegistry::served_models() returns
(provider_id, default_model) per available adapter, and
select_failure_message now distinguishes provider-named / model-named /
unspecified and says what to pass in each case, e.g.
llama-server=ornith-ai/Ornith-1.5-35B-A3B-GGUF.

One test in modules/ai_provider.rs using the existing
HeuristicInferenceAdapter fixture.

airc card: a466fdd4

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE