### PR TITLE
fix(boot): spawn the airc daemon from the home that owns the socket — not the repo CWD

### DIFF
--- a/core/continuum-core/src/boot_plan.rs
+++ b/core/continuum-core/src/boot_plan.rs
@@ -106,8 +106,39 @@ fn step_airc_daemon() -> Outcome {
         Ok(out) if out.status.success() => Outcome::Ok("daemon answering".into()),
         Ok(_) => {
             // Present but not answering: start it detached, bounded wait.
+            //
+            // CWD = the OS home dir, NEVER the repo. `airc daemon` derives its
+            // scope from the working directory; spawned from a continuum
+            // checkout it derives the REPO scope, and airc's ownership guard
+            // (their #1347/#1352/#1353 family) then rightly refuses to serve
+            // the machine-account socket under a foreign identity:
+            //
+            //   airc: refusing to serve a socket this scope does not own.
+            //
+            // Measured on the 5090 node 2026-09-04: `continuum reboot` died
+            // exactly here — core built, then "no transport: no rooms, no
+            // resident citizens". This is the THIRD spawn-site instance of
+            // that bug class; airc made it a compile error internally with a
+            // newtype, but this call site lives outside airc where the type
+            // cannot reach, so the rule is enforced the only way available
+            // here: spawn from the home that owns the socket. Refusing to
+            // spawn at all when no home dir is resolvable is deliberate — a
+            // daemon under the wrong identity gives every caller the wrong
+            // peer_id, which is strictly worse than no daemon.
+            let Some(home) =
+                std::env::var_os("USERPROFILE").or_else(|| std::env::var_os("HOME"))
+            else {
+                return Outcome::Failed(
+                    "cannot spawn airc daemon: neither USERPROFILE nor HOME is set, \
+                     so the machine-account scope is unresolvable — a daemon spawned \
+                     from the repo CWD would serve the socket under the WRONG identity \
+                     and airc's ownership guard refuses it"
+                        .into(),
+                );
+            };
             let spawned = std::process::Command::new("airc")
                 .arg("daemon")
+                .current_dir(&home)
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null())
                 .spawn();


### PR DESCRIPTION
\`continuum reboot\` on current airc dies at boot:

```
airc: refusing to serve a socket this scope does not own.
  --home  <repo>/.airc
  --socket ~/.airc/runtime/airc-machine-*.sock
```

…and the core comes up with **no transport: no rooms, no resident citizens**. Measured on the 5090 node today, first boot after the Windows build unlock. Every repo user on current airc hits this.

**Root cause:** `boot_plan.rs::step_airc_daemon` runs `airc daemon` with no home and the **continuum repo as CWD**. airc derives scope from the working directory, so the daemon presents the repo-scope identity to the machine-account socket — and airc's ownership guard (their #1347/#1352/#1353 family) rightly refuses: a daemon under a foreign identity hands every caller the wrong peer_id, rooms, and advertised endpoint.

**This is the third spawn-site instance of that bug class.** airc ended it internally with a newtype the spawn API requires — a compile error instead of a night of debugging. This call site lives outside airc where the type can't reach, so the rule is enforced the only way available here: **CWD = the OS home dir**, which *is* the home that owns the socket.

When neither `USERPROFILE` nor `HOME` resolves, boot now refuses to spawn at all, loudly — a daemon under the wrong identity is strictly worse than no daemon, and the old behavior manufactured exactly that on every fresh checkout.

Validated locally (first box able to): `cargo check -p continuum-core --lib` clean; the failing reboot is the reproduction, and this node's next reboot runs the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc