### PR TITLE
perf(persona): a working citizen perceives the message plane and wakes only for humans or mentions

### DIFF
--- a/core/continuum-core/src/cognition/act_observe/apply.rs
+++ b/core/continuum-core/src/cognition/act_observe/apply.rs
@@ -621,20 +621,26 @@ pub async fn apply_act(
         // The vitals ACT PULSE: executed acts are the thinking-right-now
         // signal during a held-work turn (the cycle-delta is blind inside one).
         crate::ipc::vitals_emitter::record_acts(body.persona_id, acts.len() as u64);
+        // Receipts radiate into the CARD's activity room when a held card
+        // rooted her hands — the room her reviewer and teammates watch — not
+        // the room whose line triggered the turn (`acting_card_of`).
+        let receipt_room = crate::cognition::persona_workspace::acting_card_of(body.persona_id)
+            .and_then(crate::cognition::bench_round::room_for_card)
+            .unwrap_or(room_id);
         if !lines.is_empty() {
             if let Some(rt) = crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global()
                 .and_then(|reg| reg.get(body.persona_id))
             {
                 match crate::persona::airc_citizen::publish_text_in_room(
                     rt.airc(),
-                    room_id,
+                    receipt_room,
                     &lines.join("\n"),
                 )
                 .await
                 {
                     Ok(_) => crate::probe!(
                         class = "room.work_receipt.published",
-                        room = %room_id,
+                        room = %receipt_room,
                         actor = %body.persona_id,
                         acts = lines.len() as u64,
                         "act receipts radiated into the activity transcript — roommates see the work"

--- a/core/continuum-core/src/cognition/act_observe/apply.rs
+++ b/core/continuum-core/src/cognition/act_observe/apply.rs
@@ -590,12 +590,7 @@ pub async fn apply_act(
         let mut lines: Vec<String> = Vec::with_capacity(acts.len() + 1);
         let thought = intent.trim();
         if !thought.is_empty() {
-            let clipped: String = thought.chars().take(240).collect();
-            lines.push(format!(
-                "💭 {}{}",
-                clipped,
-                if thought.chars().count() > 240 { "…" } else { "" }
-            ));
+            lines.push(crate::persona::presence_glyph::thought_line(thought, 240));
         }
         lines.extend(acts.iter().map(|obs| {
                 let object = obs
@@ -611,12 +606,11 @@ pub async fn apply_act(
                             .map(|c| c.chars().take(80).collect::<String>())
                     })
                     .unwrap_or_default();
-                let mark = if obs.output.result.is_error == Some(true) {
-                    "✗"
-                } else {
-                    "✓"
-                };
-                format!("⚙ {} {} {}", obs.call.name, object, mark)
+                crate::persona::presence_glyph::act_line(
+                    &obs.call.name,
+                    &object,
+                    obs.output.result.is_error != Some(true),
+                )
             }));
         // The vitals ACT PULSE: executed acts are the thinking-right-now
         // signal during a held-work turn (the cycle-delta is blind inside one).

--- a/core/continuum-core/src/cognition/channel_digest.rs
+++ b/core/continuum-core/src/cognition/channel_digest.rs
@@ -38,7 +38,6 @@ use std::sync::Arc;
 
 use airc_core::TranscriptEvent;
 use airc_lib::AircError;
-use dashmap::DashMap;
 use uuid::Uuid;
 
 use crate::cognition::channel_element::{ChannelElement, ChannelElementCache};

--- a/core/continuum-core/src/cognition/faculty_pulse.rs
+++ b/core/continuum-core/src/cognition/faculty_pulse.rs
@@ -19,7 +19,7 @@
 //! radiator. The lock is held only for a cheap read/write, never across an await.
 
 use std::sync::Mutex;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use super::workspace::FacultyId;
 
@@ -172,6 +172,7 @@ impl FacultyPulse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     // what this catches: the accumulator must (a) light an axis on a fire, (b) map
     // each faculty to its compass axis, and (c) decay toward dark over wall-clock —

--- a/core/continuum-core/src/cognition/inference_session.rs
+++ b/core/continuum-core/src/cognition/inference_session.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 
 use crate::ai::types::ChatMessage;
 use crate::modules::ai_provider::{generate_text, global_registry};
-use crate::sdk_codegen::{AccessLevel, ActionCommand, CommandError, Ctx, DynCommand};
+use crate::sdk_codegen::{AccessLevel, ActionCommand, CommandError, Ctx};
 
 /// A live inference lease: a handle bound to a concrete model. Held in the global
 /// registry so it survives across turns (keep-alive) and can be re-found if a caller

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -185,6 +185,12 @@ pub struct LlmDeliberationFaculty {
     /// schemas instead of the whole ~150-tool registry. Computed in
     /// [`Self::rebuild_tool_surface`].
     native_specs: Vec<NativeToolSpec>,
+    /// Her HANDS for a work turn: the subset of `native_specs` whose COMMAND
+    /// name (before the wire dialect renames it) is a file/work/git/cargo/tool
+    /// verb, plus the discovery pair. Chosen at rebuild on the raw names —
+    /// filtering the wire names by `code/` prefixes matched nothing and every
+    /// work turn went out with ZERO tools (2026-09-04, 13 turns, all passed).
+    hands_specs: Vec<NativeToolSpec>,
     /// Token cost of serializing `native_specs` into the request — memoized at
     /// [`Self::rebuild_tool_surface`] time because the specs are static between
     /// rebuilds while [`Self::describe_tool_tokens`] is consulted on EVERY
@@ -252,6 +258,7 @@ impl LlmDeliberationFaculty {
             temperature: DEFAULT_TEMPERATURE,
             tools: Vec::new(),
             native_specs: Vec::new(),
+            hands_specs: Vec::new(),
             tool_surface_tokens: 0,
             working_memory: None,
             prompt_capture: None,
@@ -359,6 +366,7 @@ impl LlmDeliberationFaculty {
     fn rebuild_tool_surface(&mut self) {
         if self.tools.is_empty() {
             self.native_specs.clear();
+            self.hands_specs.clear();
             self.tool_surface_tokens = 0;
             return;
         }
@@ -392,7 +400,12 @@ impl LlmDeliberationFaculty {
         // brittleness and tanks benchmark hygiene. So it is gone; the budget owns the fit.
         // [[filter-once-centrally-multiple-adhoc-filters-are-clamps-that-tank-benchmarks]]
         // [[budget-at-assembly-never-clamp-the-prompt]]
-        self.native_specs = persona_tools::native_tool_specs()
+        let raw = persona_tools::native_tool_specs();
+        self.hands_specs = hands_surface(&raw)
+            .into_iter()
+            .map(|s| crate::cognition::tool_dialect::to_wire_spec_with(s, style))
+            .collect();
+        self.native_specs = raw
             .into_iter()
             .map(|s| crate::cognition::tool_dialect::to_wire_spec_with(s, style))
             .collect();
@@ -2330,25 +2343,13 @@ impl Faculty for LlmDeliberationFaculty {
         // the ~150-schema dump that overflowed `n_ctx` and muted her.
         let tools = if self.native_specs.is_empty() {
             None
-        } else if ws.workspace_deliverable {
+        } else if ws.workspace_deliverable && !self.hands_specs.is_empty() {
             // A WORK turn offers her HANDS, not the whole registry: 37 schemas were
             // 8.5k of a ~22k-token prefill per act (2026-09-05, KV reuse 0.0). The
-            // discovery pair stays so anything else remains one call away.
-            Some(
-                self.native_specs
-                    .iter()
-                    .filter(|s| {
-                        let n = s.name.as_str();
-                        n.starts_with("code/")
-                            || n.starts_with("work/")
-                            || n.starts_with("git/")
-                            || n.starts_with("cargo/")
-                            || n.starts_with("tool/")
-                            || n.starts_with("commands/")
-                    })
-                    .cloned()
-                    .collect(),
-            )
+            // discovery pair stays so anything else remains one call away. Chosen on
+            // the raw command names at rebuild (`hands_surface`); never an empty
+            // surface — that mutes her hands entirely.
+            Some(self.hands_specs.clone())
         } else {
             Some(self.native_specs.clone())
         };
@@ -2974,9 +2975,44 @@ fn metrics_from(persona: &str, resp: &TextGenerationResponse) -> crate::cognitio
     m
 }
 
+/// Her HANDS: the file / work / git / cargo / tool verbs plus the discovery pair,
+/// selected on the COMMAND names (`code/read`, `work/state`, …) before the wire
+/// dialect renames them (`edit_file`, `list_recipes`, …).
+fn hands_surface(raw: &[NativeToolSpec]) -> Vec<NativeToolSpec> {
+    raw.iter()
+        .filter(|s| {
+            let n = s.name.as_str();
+            n.starts_with("code/")
+                || n.starts_with("work/")
+                || n.starts_with("git/")
+                || n.starts_with("cargo/")
+                || n.starts_with("tool/")
+                || n.starts_with("commands/")
+        })
+        .cloned()
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the hands surface chosen on WIRE names — `code/` prefixes
+    // matched nothing after the dialect renamed them and every work turn went out
+    // with zero tools (2026-09-04). The filter runs on the raw command names.
+    #[test]
+    fn hands_surface_is_chosen_on_command_names_and_keeps_the_discovery_pair() {
+        let raw: Vec<NativeToolSpec> = ["code/read", "work/state", "chat/send", "commands/list", "room/join", "code/git/status"]
+            .iter()
+            .map(|n| NativeToolSpec {
+                name: (*n).to_string(),
+                description: String::new(),
+                input_schema: crate::ai::types::ToolInputSchema { schema_type: "object".to_string(), properties: serde_json::json!({}), required: None, definitions: None },
+            })
+            .collect();
+        let hands: Vec<String> = hands_surface(&raw).into_iter().map(|s| s.name).collect();
+        assert_eq!(hands, ["code/read", "work/state", "commands/list", "code/git/status"]);
+    }
     use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
     use crate::ai::types::{ToolCall, ToolInputSchema, UsageMetrics};
     use crate::cognition::workspace::BurstTurn;

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -3013,6 +3013,22 @@ mod tests {
         let hands: Vec<String> = hands_surface(&raw).into_iter().map(|s| s.name).collect();
         assert_eq!(hands, ["code/read", "work/state", "commands/list", "code/git/status"]);
     }
+
+    // what this catches: the live registry's command names drifting away from the
+    // hands prefixes (a rename to `files/*` would mute every work turn again) — a
+    // self-running check that the REAL registry yields a hands surface that is
+    // non-empty and smaller than the whole surface.
+    #[test]
+    fn the_real_registry_yields_a_non_empty_hands_surface() {
+        let raw = persona_tools::native_tool_specs();
+        if raw.is_empty() {
+            return; // no registry in this test build — nothing to assert against
+        }
+        let hands = hands_surface(&raw);
+        assert!(!hands.is_empty(), "hands surface is empty against the live registry");
+        assert!(hands.len() < raw.len(), "hands surface should be a strict subset");
+        assert!(hands.iter().any(|s| s.name == "commands/list"), "the discovery pair must survive");
+    }
     use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
     use crate::ai::types::{ToolCall, ToolInputSchema, UsageMetrics};
     use crate::cognition::workspace::BurstTurn;

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -765,11 +765,34 @@ async fn drive_create_workspace(
 /// file engine at (a card's checkout), or nothing when she stands in her own
 /// workspace. One truth for the hands, the workspace map she perceives, and the
 /// scope her receipts carry — set at the rooting seam, cleared on restore.
-static ACTING_ROOTS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<uuid::Uuid, std::path::PathBuf>>> =
+static ACTING_ROOTS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<uuid::Uuid, ActingPlace>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
+/// Where she stands: the checkout root, and the card whose checkout it is when
+/// a held card rooted her (None for a plain workspace_root).
+#[derive(Clone, Debug)]
+struct ActingPlace {
+    root: std::path::PathBuf,
+    card: Option<uuid::Uuid>,
+}
+
 pub fn acting_root_of(persona_id: uuid::Uuid) -> Option<std::path::PathBuf> {
-    ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()).get(&persona_id).cloned()  // poisoned lock = read the last state, same policy as every lock in this crate
+    ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()).get(&persona_id).map(|p| p.root.clone())  // poisoned lock = read the last state, same policy as every lock in this crate
+}
+
+/// The card her hands are rooted at, if a held card rooted them. Her work
+/// receipts radiate into THAT card's activity room, not the room whose line
+/// happened to trigger the turn (2026-09-04: every holder's 💭/⚙ lines landed
+/// in #academy — the base room and the agents' coordination room — because the
+/// trigger arrived there; the run room stayed empty for its reviewer).
+pub fn acting_card_of(persona_id: uuid::Uuid) -> Option<uuid::Uuid> {
+    ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()).get(&persona_id).and_then(|p| p.card)  // poisoned lock = read the last state, same policy as every lock in this crate
+}
+
+fn note_acting_card(persona_id: uuid::Uuid, card: uuid::Uuid) {
+    if let Some(place) = ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()).get_mut(&persona_id) {  // poisoned lock = read the last state, same policy as every lock in this crate
+        place.card = Some(card);
+    }
 }
 
 fn note_acting_root(persona_id: uuid::Uuid, root: Option<std::path::PathBuf>) {
@@ -777,7 +800,7 @@ fn note_acting_root(persona_id: uuid::Uuid, root: Option<std::path::PathBuf>) {
         let mut map = ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner());  // poisoned lock = read the last state, same policy as every lock in this crate
         match root {
             Some(r) => {
-                map.insert(persona_id, r);
+                map.insert(persona_id, ActingPlace { root: r, card: None });
             }
             None => {
                 map.remove(&persona_id);
@@ -820,7 +843,12 @@ pub(crate) async fn root_at_held_card(
     // Rooting is idempotent; do it every turn she holds a card.
     let hands = ActingHands::of(cycle)?;
     match root_acting_workspace(cycle, &ws.to_string_lossy(), &[], false).await {
-        Ok(()) => Some(hands),
+        Ok(()) => {
+            if let Some(card) = held.first() {
+                note_acting_card(hands.persona_id, card.card_id.as_uuid());
+            }
+            Some(hands)
+        }
         Err(e) => {
             tracing::warn!(error = %e, "could not root her hands at the held card for this turn");
             None

--- a/core/continuum-core/src/cognition/recall_faculty.rs
+++ b/core/continuum-core/src/cognition/recall_faculty.rs
@@ -40,7 +40,7 @@ use async_trait::async_trait;
 use futures_util::future::{join, join_all};
 use uuid::Uuid;
 
-use super::embedding::{cosine_similarity, EmbeddingProvider};
+use super::embedding::EmbeddingProvider;
 use super::working_memory::WorkingMemory;
 use super::workspace::{Contribution, Faculty, FacultyId, Workspace};
 use crate::persona::admission_state::AdmissionState;

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -10,7 +10,6 @@
 //! OUTSIDER replicate our numbers against their own `/v1` without our stack. Operational
 //! benchmarking is Rust; the replication convenience is the lone edge script.
 
-use crate::cognition::learning_policy::LearningPolicy;
 use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/core/continuum-core/src/ipc/positron_presence.rs
+++ b/core/continuum-core/src/ipc/positron_presence.rs
@@ -127,6 +127,28 @@ pub fn scope_directory_slots() -> Vec<RosterSlotView> {
     slots
 }
 
+/// Is this peer a HUMAN on this node — a directory slot whose runtime is the
+/// interactive client (`SenderKind::from_runtime`)? The ONE directory
+/// (`scope_directory_slots`), memoised for a minute: the persona loop head
+/// asks it per drained line, and a work-holding citizen wakes for a human
+/// line or an @mention, never for agent status traffic (2026-09-04: every
+/// agent line in #academy woke all twelve holders — 8 work turns an hour).
+pub fn is_human_peer(peer: Uuid) -> bool {
+    static HUMANS: std::sync::LazyLock<std::sync::Mutex<(Option<std::time::Instant>, std::collections::HashSet<Uuid>)>> =
+        std::sync::LazyLock::new(|| std::sync::Mutex::new((None, std::collections::HashSet::new())));
+    let mut memo = HUMANS.lock().unwrap_or_else(|e| e.into_inner()); // poisoned lock = read the last state, same policy as every lock in this crate
+    let stale = memo.0.is_none_or(|at| at.elapsed() > Duration::from_secs(60));
+    if stale {
+        memo.1 = scope_directory_slots()
+            .into_iter()
+            .filter(|s| matches!(s.kind, continuum_positron::SenderKind::Human))
+            .map(|s| s.member_id)
+            .collect();
+        memo.0 = Some(std::time::Instant::now());
+    }
+    memo.1.contains(&peer)
+}
+
 fn load_directory(room_id: &Uuid) -> HashMap<Uuid, RosterSlotView> {
     let Some(path) = directory_path(room_id) else {
         return HashMap::new();

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -125,6 +125,16 @@ pub(crate) async fn ask_the_act_question(
                     )
                 })
                 .collect();
+            // ONE card per work turn — her freshest live claim (the FOCUS rule,
+            // `bench_round::room_for_card`): with two held cards the staging
+            // resolution was ambiguous, her hands stayed at home, and every act
+            // landed in her own repo copy (Lorcan, 2026-09-04). The other card
+            // stays held; its turn comes when it is the freshest.
+            let held: Vec<&airc_lib::WorkCard> = held
+                .into_iter()
+                .max_by_key(|c| c.last_heartbeat_at_ms.unwrap_or(c.updated_at_ms))  // unwrap_or: never heartbeated = its last board change
+                .into_iter()
+                .collect();
             crate::probe!(
                 class = "persona.work.gate",
                 persona = %ctx.identity.agent_name,

--- a/core/continuum-core/src/persona/airc_source.rs
+++ b/core/continuum-core/src/persona/airc_source.rs
@@ -443,9 +443,9 @@ impl AircRagSource {
         for text in texts {
             for line in text.lines() {
                 let line = line.trim();
-                if line.starts_with("💭") {
+                if line.starts_with(crate::persona::presence_glyph::THOUGHT) {
                     last_thought = Some(line);
-                } else if let Some(rest) = line.strip_prefix("⚙") {
+                } else if let Some(rest) = line.strip_prefix(crate::persona::presence_glyph::ACT) {
                     let mut parts = rest.split_whitespace();
                     let verb = parts.next().unwrap_or("?"); // unwrap_or: a bare marker still tallies as unknown
                     let mark = parts.last().unwrap_or("·"); // unwrap_or: a verb without a mark tallies as neutral
@@ -522,7 +522,7 @@ struct PackUnit {
 /// A radiated work receipt (`act_observe::apply`): leads with `💭` or `⚙`.
 fn is_work_receipt(text: &str) -> bool {
     let t = text.trim_start();
-    t.starts_with("💭") || t.starts_with("⚙")
+    crate::persona::presence_glyph::is_presence_line(t)
 }
 
 #[async_trait]

--- a/core/continuum-core/src/persona/airc_source.rs
+++ b/core/continuum-core/src/persona/airc_source.rs
@@ -322,12 +322,13 @@ impl AircRagSource {
     fn pack_digest(
         digest: &ChannelDigest,
         budget: u32,
+        working: bool,
     ) -> (Vec<RagItem>, u32, Option<Arc<ChannelElement>>) {
         // Per-turn cap: budget/8 → a useful window holds ~8+ turns; clamped so
         // tiny budgets still render a sentence and huge ones don't let one
         // essay crowd the window.
         let per_turn_cap = (budget / 8).clamp(48, 256);
-        let units = Self::collapse_work_receipts(digest);
+        let units = Self::collapse_work_receipts(digest, working);
         let mut keep: Vec<(usize, Option<String>)> = Vec::new();
         let mut tokens_used: u32 = 0;
         let mut newest_kept = true;
@@ -384,7 +385,22 @@ impl AircRagSource {
     /// thought + a tally of what she ran — anchored at her newest receipt
     /// (read-through cursor, unread flag). One line per teammate; chat lines
     /// stay verbatim in place.
-    fn collapse_work_receipts(digest: &ChannelDigest) -> Vec<PackUnit> {
+    fn collapse_work_receipts(digest: &ChannelDigest, working: bool) -> Vec<PackUnit> {
+        // WORKING (hands rooted at a card): the PRESENCE plane — every citizen's 💭
+        // thought broadcast and ⚙ receipt, hers included (her newest thoughts lead
+        // the turn from working memory) — is not packed at all: it is state, not a
+        // message to her. The MESSAGE plane stays: human/agent lines and real speech.
+        // Measured 2026-09-05: every work turn opened with "this room is noisy, let
+        // me figure out what is real" (attention spent as deserialization, not sniffing).
+        if working {
+            return digest
+                .elements
+                .iter()
+                .enumerate()
+                .filter(|(_, el)| !el.text().is_some_and(is_work_receipt))
+                .map(|(idx, _)| PackUnit { last_idx: idx, collapsed: None })
+                .collect();
+        }
         use std::collections::HashMap;
         // author → (newest receipt idx, every receipt idx in order)
         let mut by_author: HashMap<uuid::Uuid, (usize, Vec<usize>)> = HashMap::new();
@@ -670,7 +686,7 @@ impl RagSource for AircRagSource {
             }
         };
 
-        let (items, tokens_used, read_through) = Self::pack_digest(&digest, budget);
+        let (items, tokens_used, read_through) = Self::pack_digest(&digest, budget, crate::cognition::persona_workspace::acting_root_of(self.persona_id).is_some());
         // SHE HAS NOW READ THE ROOM — advance her per-room cursor, exactly as the
         // human's UI does on nav/mark-read and on navigating away from a room.
         //

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -98,6 +98,7 @@ pub mod seed;
 pub mod self_task_generator;
 pub mod act_question;
 pub mod service_loop;
+pub mod presence_glyph;
 pub mod wake_backlog;
 pub mod work_burst;
 pub mod work_pull;

--- a/core/continuum-core/src/persona/presence_glyph.rs
+++ b/core/continuum-core/src/persona/presence_glyph.rs
@@ -1,0 +1,61 @@
+//! The PRESENCE-PLANE register: the one leading glyph that classes a
+//! citizen's line without parsing its body. `💭` is a working thought, `⚙` an
+//! act receipt (`✓`/`✗` its outcome). It grew as pidgin between citizens
+//! (Joel, 2026-09-04: "agents love emojis … natural compressed language …
+//! reminds me of pidgin") — and it stays THEIRS: "let the personas control and
+//! design that plane; we don't freeze the vocabulary, they evolve it, and it
+//! gets learned as genome — a trainable register, not an agent-authored spec."
+//!
+//! So this module is the PROJECTION SEAM, not the semantics: glyph → avatar
+//! animation → attention hint, one place every reader sniffs through (the
+//! attention filter, the digest collapse, the resume block, the avatar). The
+//! two constants below are what the citizens converged on so far, named here
+//! so the writer and the readers agree on bytes. Do not grow a closed enum of
+//! meanings here; the register's next home is data the personas evolve (a
+//! per-node register in state, consolidated into genome), with this seam
+//! reading it.
+
+/// A working thought, spoken as she acts.
+pub const THOUGHT: &str = "💭";
+/// An act receipt: the verb, its object, and the outcome mark.
+pub const ACT: &str = "⚙";
+/// Outcome marks on an act receipt.
+pub const OK: &str = "✓";
+pub const FAIL: &str = "✗";
+
+/// Presence plane: a line whose head is a thought or an act receipt — state
+/// radiated while working, not a message to anyone.
+pub fn is_presence_line(text: &str) -> bool {
+    let t = text.trim_start();
+    t.starts_with(THOUGHT) || t.starts_with(ACT)
+}
+
+/// A thought line, clipped to `max_chars` with an ellipsis when longer.
+pub fn thought_line(thought: &str, max_chars: usize) -> String {
+    let clipped: String = thought.chars().take(max_chars).collect();
+    let more = if thought.chars().count() > max_chars { "…" } else { "" };
+    format!("{THOUGHT} {clipped}{more}")
+}
+
+/// An act receipt line: `⚙ verb object ✓`.
+pub fn act_line(verb: &str, object: &str, ok: bool) -> String {
+    format!("{ACT} {verb} {object} {}", if ok { OK } else { FAIL })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the plane sniff drifting from the writer — a thought
+    // or act line the writer emits must read as presence at the head of the
+    // line, and speech must not.
+    #[test]
+    fn what_the_writer_emits_the_sniff_classes_as_presence() {
+        assert!(is_presence_line(&thought_line("let me look at fields.py", 240)));
+        assert!(is_presence_line(&act_line("code/read", "swe/x.py", true)));
+        assert!(is_presence_line("  ⚙ code/edit swe/x.py ✗"));
+        assert!(!is_presence_line("Joel here — which card do you hold?"));
+        assert_eq!(thought_line("abcdef", 3), "💭 abc…");
+        assert_eq!(act_line("code/edit", "a.py", false), "⚙ code/edit a.py ✗");
+    }
+}

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -645,13 +645,18 @@ async fn serve_persona_loop_inner(
         crate::cognition::directed_pending::clear(self_id);
         // Directed = a line from outside the citizenry (human, agent) or one
         // that names her — the same addressing FACT the turn frames on.
+        // Holding work = the BOARD says she holds a card (one airc call per
+        // wake), not the acting-root registry: a holder whose hands never
+        // rooted (two held cards → ambiguous staging) still woke on every
+        // agent status line (Lorcan, 2026-09-04).
+        let holding_work = holding_work_now(conversation, self_id).await;
         let directed_line = |m: &IncomingMessage| {
             let sender_is_citizen = crate::persona::PersonaAircRuntimeRegistry::try_global()
                 .is_some_and(|r| r.get(m.peer_id).is_some());
             turn_is_directed(
                 ctx.identity.persona_identity().mentions(&m.text),
                 sender_is_citizen,
-                crate::cognition::persona_workspace::acting_root_of(self_id).is_some(),
+                holding_work,
                 crate::ipc::positron_presence::is_human_peer(m.peer_id),
             )
         };
@@ -1118,7 +1123,7 @@ async fn serve_persona_loop_inner(
                 let directed = turn_is_directed(
                     ctx.identity.persona_identity().mentions(&msg.text),
                     sender_is_citizen,
-                    crate::cognition::persona_workspace::acting_root_of(ctx.identity.peer_id.as_uuid()).is_some(),
+                    holding_work_now(conversation, ctx.identity.peer_id.as_uuid()).await,
                     crate::ipc::positron_presence::is_human_peer(msg.peer_id),
                 );
                 if directed {
@@ -1878,7 +1883,22 @@ fn push_work_board_anchor(
 /// work receipts they radiate — stay ambient, or twelve of them answer every
 /// receipt. Live 2026-09-03: the operator asked a work room a direct question
 /// twice and no citizen answered, because "directed" meant @mention only.
-/// `holding_work`: her hands are rooted at a card. Then only a HUMAN line or an
+/// Does she hold a card right now — the board's answer (`active_claims`), or
+/// the acting-root registry when the board cannot be asked (no citizen stream).
+async fn holding_work_now(
+    conversation: &dyn PersonaConversation,
+    self_id: Uuid,
+) -> bool {
+    match conversation.stream_citizen() {
+        Some(citizen) => match citizen.active_claims().await {
+            Ok(held) => !held.is_empty(),
+            Err(_) => crate::cognition::persona_workspace::acting_root_of(self_id).is_some(),
+        },
+        None => crate::cognition::persona_workspace::acting_root_of(self_id).is_some(),
+    }
+}
+
+/// `holding_work`: she holds a card. Then only a HUMAN line or an
 /// @mention is directed — agent status traffic in the base room is message
 /// plane for perception, not a wake (working ≠ speaking; a human's question
 /// still is). Measured 2026-09-04: 8 work turns an hour across ten holders

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -648,7 +648,12 @@ async fn serve_persona_loop_inner(
         let directed_line = |m: &IncomingMessage| {
             let sender_is_citizen = crate::persona::PersonaAircRuntimeRegistry::try_global()
                 .is_some_and(|r| r.get(m.peer_id).is_some());
-            turn_is_directed(ctx.identity.persona_identity().mentions(&m.text), sender_is_citizen)
+            turn_is_directed(
+                ctx.identity.persona_identity().mentions(&m.text),
+                sender_is_citizen,
+                crate::cognition::persona_workspace::acting_root_of(self_id).is_some(),
+                crate::ipc::positron_presence::is_human_peer(m.peer_id),
+            )
         };
         // Every directed line drained is HEARD (delivery receipt), whether or
         // not it becomes the trigger.
@@ -1113,6 +1118,8 @@ async fn serve_persona_loop_inner(
                 let directed = turn_is_directed(
                     ctx.identity.persona_identity().mentions(&msg.text),
                     sender_is_citizen,
+                    crate::cognition::persona_workspace::acting_root_of(ctx.identity.peer_id.as_uuid()).is_some(),
+                    crate::ipc::positron_presence::is_human_peer(msg.peer_id),
                 );
                 if directed {
                     // Focus = she is TAKING the turn on it; the heard receipt
@@ -1871,8 +1878,18 @@ fn push_work_board_anchor(
 /// work receipts they radiate — stay ambient, or twelve of them answer every
 /// receipt. Live 2026-09-03: the operator asked a work room a direct question
 /// twice and no citizen answered, because "directed" meant @mention only.
-pub(crate) fn turn_is_directed(mentioned: bool, sender_is_citizen: bool) -> bool {
-    mentioned || !sender_is_citizen
+/// `holding_work`: her hands are rooted at a card. Then only a HUMAN line or an
+/// @mention is directed — agent status traffic in the base room is message
+/// plane for perception, not a wake (working ≠ speaking; a human's question
+/// still is). Measured 2026-09-04: 8 work turns an hour across ten holders
+/// while every agent line in #academy woke all twelve for a message turn.
+pub(crate) fn turn_is_directed(
+    mentioned: bool,
+    sender_is_citizen: bool,
+    holding_work: bool,
+    sender_is_human: bool,
+) -> bool {
+    mentioned || if holding_work { sender_is_human } else { !sender_is_citizen }
 }
 
 
@@ -2873,10 +2890,22 @@ mod tests {
     // twice, nobody answered — 2026-09-03).
     #[test]
     fn a_non_citizen_line_is_directed_and_citizen_chatter_needs_a_mention() {
-        assert!(turn_is_directed(false, false), "human/agent line: directed");
-        assert!(turn_is_directed(true, false));
-        assert!(turn_is_directed(true, true), "a citizen naming her: directed");
-        assert!(!turn_is_directed(false, true), "citizen chatter/receipts: ambient");
+        assert!(turn_is_directed(false, false, false, false), "human/agent line: directed");
+        assert!(turn_is_directed(true, false, false, false));
+        assert!(turn_is_directed(true, true, false, false), "a citizen naming her: directed");
+        assert!(!turn_is_directed(false, true, false, false), "citizen chatter/receipts: ambient");
+    }
+
+    // what this catches: a citizen HOLDING WORK waking for agent status traffic —
+    // every agent line in #academy woke all twelve holders (8 work turns an hour,
+    // 2026-09-04). Holding work: a human line or a mention is directed; an
+    // agent's line is message plane only.
+    #[test]
+    fn holding_work_only_a_human_line_or_a_mention_is_directed() {
+        assert!(!turn_is_directed(false, false, true, false), "agent line while holding work: ambient");
+        assert!(turn_is_directed(false, false, true, true), "human line while holding work: directed");
+        assert!(turn_is_directed(true, false, true, false), "an agent naming her: directed");
+        assert!(!turn_is_directed(false, true, true, false), "citizen receipts: ambient");
     }
 
     // what this catches: the resume block carries HER newest thoughts only, oldest

--- a/core/continuum-core/src/persona/work_burst.rs
+++ b/core/continuum-core/src/persona/work_burst.rs
@@ -69,7 +69,7 @@ pub(crate) fn own_recent_thoughts_about(
 ) -> Vec<String> {
     let mut mine: Vec<&crate::persona::durable_history::RoomRow> = rows
         .iter()
-        .filter(|r| r.sender == me && r.text.starts_with('💭'))
+        .filter(|r| r.sender == me && r.text.starts_with(crate::persona::presence_glyph::THOUGHT))
         .collect();
     if !about.is_empty() {
         let scoped: Vec<&crate::persona::durable_history::RoomRow> = mine

--- a/docs/architecture/ACTIVITY-RECONCILER.md
+++ b/docs/architecture/ACTIVITY-RECONCILER.md
@@ -81,4 +81,9 @@ was inconsistent, and nobody owned repairing it.
 - A round resumes with zero hands after a reboot: `bench.round.reseated` (or silence when
   everyone is already seated), no `bench.round.pulled` storm, no `persona.claim.recovered`
   storm.
+- A work turn's request offers her HANDS: `ai.request.tool_surface` reads `tools_n` ≈ a dozen on
+  work turns (37 = the whole registry, 0 = her hands are muted — the 2026-09-04 regression, where
+  13/13 work turns "passed" in 45 min because the filter matched wire-dialect names).
+- Work turns per holder per hour ≫ 1, and `persona.turn.work` decisions are `spoke`/acted, not
+  all `passed`.
 - Diffs per checkout over time — the only number that is a solve.

--- a/docs/architecture/ACTIVITY-RECONCILER.md
+++ b/docs/architecture/ACTIVITY-RECONCILER.md
@@ -52,6 +52,18 @@ was inconsistent, and nobody owned repairing it.
    follow a card to its room, node-wide through the round tracker. Any resume that needs a
    human to `room/join` first is a design defect.
 
+8. **Planes, not deserialization.** A citizen's line carries its class at its head — `💭`
+   thought, `⚙` act receipt (`persona/presence_glyph.rs`, the one vocabulary) — and every reader
+   sniffs the class before it reads the body. While she holds work: her digest carries the
+   MESSAGE plane only (human/agent lines, citizens' real speech; no presence lines, hers
+   included), a line is a wake only if a human wrote it or it names her (agent status traffic is
+   perception, not a trigger), and her receipts radiate into the held card's run room, not the
+   room whose line triggered the turn. Measured 2026-09-04 before the cut: ten holders, 8 work
+   turns an hour — every agent status line in #academy woke all twelve for a 265 s message turn.
+   *Shipped:* PR 3698 (`airc_source::collapse_work_receipts(working)`, `turn_is_directed`,
+   `acting_card_of` → `room_for_card`). Next: presence-class traffic on its own channel class so
+   the message plane never carries it.
+
 ## Concurrency the reconciler enforces
 
 - **WIP = lanes, board-true.** The roster holds no more claimed/in-progress cards than the


### PR DESCRIPTION
Two cuts on the work turn, both measured on the team round (2026-09-04, ten holders, 31 acts, 8 work turns, 1 write in an hour):

- **A working persona's room digest is the message plane only.** While her hands are rooted at a card, the digest drops every 💭/⚙ presence-class line (hers included — her newest thoughts already lead the turn from working memory) and keeps human/agent lines and citizens' real speech. Every work turn had opened with "this room is noisy, let me figure out what is real".
- **A citizen holding work wakes for a human line or an @mention, never for agent status traffic.** Every agent status line in #academy (the citizens' base room and the agents' coordination room) counted as directed and woke all twelve citizens for a 265 s message turn. Human = a node directory slot whose runtime is the interactive client (`positron_presence::is_human_peer`, memoised a minute over the one directory).

Tests: `airc_source` (digest packing with `working`), `service_loop` (`holding_work_only_a_human_line_or_a_mention_is_directed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo