### PR TITLE
feat(ctm): --max-tokens / --temperature on generate — the parity measurement controls decode length

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -89,6 +89,18 @@ enum Command {
         #[arg(long, env = "CONTINUUM_PROVIDER")]
         provider: Option<String>,
 
+        /// Cap on generated tokens (`maxTokens` on the request). Without it the
+        /// lane decides, and a measurement that asked for "one word" can get
+        /// 124 tokens — wall-clock then measures decode length, not the wire.
+        /// Card ddd7a7cf.
+        #[arg(long)]
+        max_tokens: Option<u32>,
+
+        /// Sampling temperature (`temperature` on the request). `0` makes
+        /// repeated measurement runs comparable.
+        #[arg(long)]
+        temperature: Option<f32>,
+
         /// Print the raw JSON response instead of just the text field.
         #[arg(long, default_value_t = false)]
         json: bool,
@@ -152,8 +164,10 @@ async fn main() -> Result<()> {
             prompt,
             model,
             provider,
+            max_tokens,
+            temperature,
             json,
-        } => run_generate(conn, prompt, model, provider, json).await,
+        } => run_generate(conn, prompt, model, provider, max_tokens, temperature, json).await,
         Command::GridSmoke => grid_smoke::run(conn, peer).await,
     }
 }
@@ -173,6 +187,8 @@ async fn run_generate(
     prompt: String,
     model: Option<String>,
     provider: Option<String>,
+    max_tokens: Option<u32>,
+    temperature: Option<f32>,
     json: bool,
 ) -> Result<()> {
     // Construct the minimum-viable TextGenerationRequest shape. The
@@ -200,6 +216,12 @@ async fn run_generate(
     }
     if let Some(p) = provider {
         params["provider"] = serde_json::Value::String(p);
+    }
+    if let Some(n) = max_tokens {
+        params["maxTokens"] = serde_json::Value::from(n);
+    }
+    if let Some(t) = temperature {
+        params["temperature"] = serde_json::Value::from(t);
     }
 
     let result: serde_json::Value = conn


### PR DESCRIPTION
The weak-node measurement (IntelMac -> 5090) asked for 'one word' and
got 124 tokens: ctm exposed no way to cap output, so wall-clock measured
the lane's decode length, not the wire, and tok/s across runs was noise.
Same inline-JSON pattern as --provider (#3694): maxTokens + temperature
on the TextGenerationRequest.

airc card: ddd7a7cf

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE