### PR TITLE
probe(boot): every module init and the registry scan report outcome + wall time

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1021,7 +1021,15 @@ pub fn start_server(
     // is fatal: the registry is the single source of truth for model ids
     // and a missing config is a boot-order / packaging bug, not a runtime
     // condition we can recover from.
-    match crate::model_registry::init_global() {
+    let registry_started = std::time::Instant::now();
+    let registry_init = crate::model_registry::init_global();
+    crate::probe!(
+        class = "boot.registry_init",
+        outcome = if registry_init.is_ok() { "ok" } else { "error" },
+        ms = registry_started.elapsed().as_millis() as u64,
+        "model registry scan (pre-bind; header reads + size walk)"
+    );
+    match registry_init {
         Ok(reg) => {
             log_info!(
                 "ipc",

--- a/core/continuum-core/src/runtime/runtime.rs
+++ b/core/continuum-core/src/runtime/runtime.rs
@@ -190,8 +190,21 @@ impl Runtime {
         let mut failures: Vec<String> = Vec::new();
         for name in &modules {
             if let Some(module) = self.registry.get_by_name(name) {
-                match tokio::time::timeout(PER_MODULE_INIT_DEADLINE, module.initialize(&ctx)).await
-                {
+                // BOOT IS LEGIBLE OR IT IS A WEDGE: one probe per module init with
+                // its outcome and wall time — the only way to read "core did not
+                // bind its IPC socket within 300s" (BigMama's host, 2026-09-04: a
+                // cold-disk init on the pre-bind path) without a stopwatch.
+                let started = std::time::Instant::now();
+                let attempt =
+                    tokio::time::timeout(PER_MODULE_INIT_DEADLINE, module.initialize(&ctx)).await;
+                crate::probe!(
+                    class = "boot.module_init",
+                    module = %name,
+                    outcome = match &attempt { Ok(Ok(_)) => "ok", Ok(Err(_)) => "error", Err(_) => "timeout" },
+                    ms = started.elapsed().as_millis() as u64,
+                    "module initialize"
+                );
+                match attempt {
                     Ok(Ok(_)) => {
                         info!("  {} initialized", name);
                     }


### PR DESCRIPTION
'core did not bind its IPC socket within 300s — boot is wedged' (BigMama's GPU host, 2026-09-04, models on a cold 16 TB HDD) could not say WHICH pre-bind step ate the time: module initialize logged a line per success, the registry scan nothing. boot.module_init {module, outcome, ms} and boot.registry_init {outcome, ms} make the next wedge one probe query. The structural fix (bind first, typed 'booting' refusal until initialize completes) follows on its own card.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
