### PR TITLE
feat/repo card staging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -265,6 +265,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "socket2 0.6.3",
  "tokio",
  "tokio-rustls",
  "uuid",
@@ -275,7 +276,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -286,7 +287,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -300,7 +301,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -313,7 +314,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=2b5bdac#2b5bdacdb8c3b9d20967f9eaa22b1908c3a46d22"
+source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
 dependencies = [
  "airc-core",
  "airc-store",
@@ -453,7 +454,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -464,7 +465,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3711,7 +3712,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4014,7 +4015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4864,7 +4865,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5536,7 +5537,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -7100,7 +7101,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9481,7 +9482,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10258,7 +10259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10767,7 +10768,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12642,7 +12643,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,18 +185,18 @@ members = [
 # room is still its default under either verb. This is what continuum's
 # room/join needs (task #65, Joel: a persona is first-class and can subscribe to
 # many rooms). Also fixes `RoomJoinedBody.is_default`, previously hardcoded true.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "2b5bdac" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -58,6 +58,7 @@ async fn run() -> Result<(), String> {
             Ok(())
         }
         "start" => {
+            record_repo_checkout();
             // Collect once: `args.any(..)` consumes the iterator, so reading a
             // second flag off it afterwards would silently always be false.
             let flags: Vec<String> = args.collect();
@@ -71,6 +72,7 @@ async fn run() -> Result<(), String> {
             start(flags.iter().any(|a| a == "--force")).await
         }
         "reboot" | "restart" => {
+            record_repo_checkout();
             let force = args.any(|a| a == "--force");
             reboot(force).await
         }
@@ -1172,6 +1174,27 @@ fn binary_build_sha(artifact: &Path) -> Result<String, String> {
 
 /// Short git HEAD SHA of the current checkout (matches what `build.rs` embeds), or `None`
 /// when not in a git tree.
+/// Record the cwd's repo checkout for the core (`modules::repo_registry`): the
+/// claim-edge staging of a REPO card needs `owner/name → path`, and the core has
+/// no cwd. Idempotent, silent outside a repo.
+fn record_repo_checkout() {
+    let out = |args: &[&str]| {
+        std::process::Command::new("git")
+            .args(args)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .filter(|s| !s.is_empty())
+    };
+    let (Some(url), Some(root)) = (out(&["remote", "get-url", "origin"]), out(&["rev-parse", "--show-toplevel"])) else {
+        return;
+    };
+    if let Some(repo) = continuum_core::modules::repo_registry::repo_id_from_remote(&url) {
+        continuum_core::modules::repo_registry::record(&repo, std::path::Path::new(&root));
+    }
+}
+
 fn git_head_short_sha() -> Option<String> {
     std::process::Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])

--- a/core/continuum-core/src/modules/card_staging.rs
+++ b/core/continuum-core/src/modules/card_staging.rs
@@ -58,6 +58,72 @@ enum Step {
 }
 
 /// Stage `title`'s work into the workspace of `claimer` under `home`.
+/// Stage for a claimed CARD: a benchmark card stages by its title recipe (below);
+/// any other card of a repo this node has a checkout of gets airc's per-card
+/// worktree (`airc_lib::work_worktree`, #1377 — the same one the CLI gives an
+/// agent), so a citizen with no cwd can pull a continuum card and root her hands
+/// there. A repo this node never checked out stages as Ordinary, said in a probe.
+pub async fn stage_for_card(home: &Path, claimer: Uuid, card: &airc_lib::WorkCard) -> Staging {
+    if crate::commands::benchmark::parse_card_title(&card.title).is_some() {
+        return stage_for_claimer(home, claimer, &card.title).await;
+    }
+    let repo = card.repo.to_string();
+    if let Some(existing) = airc_lib::work_worktree::worktree_path_for(card.card_id).filter(|p| p.join(".git").exists()) {
+        return Staging::Ready { path: existing };
+    }
+    let Some(clone) = crate::modules::repo_registry::path_for(&repo) else {
+        crate::probe!(
+            class = "work.claim.repo_unstaged",
+            claimer = %claimer,
+            repo = %repo,
+            "repo card claimed but this node has no recorded checkout of the repo — hands stay home"
+        );
+        return Staging::Ordinary;
+    };
+    let short = airc_lib::work_worktree::short_id(card.card_id);
+    let slug: String = card
+        .title
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .take(6)
+        .collect::<Vec<_>>()
+        .join("-");
+    let branch = format!("{short}/{slug}");
+    let started = std::time::Instant::now();
+    let spec_card = card.card_id;
+    let clone_for_spawn = clone.clone();
+    let branch_for_spawn = branch.clone();
+    let outcome = tokio::task::spawn_blocking(move || {
+        airc_lib::work_worktree::ensure_worktree(&airc_lib::work_worktree::WorktreeSpec {
+            card_id: spec_card,
+            clone_path: &clone_for_spawn,
+            branch: &branch_for_spawn,
+            start_point: None,
+        })
+        .map(|o| o.path().to_path_buf())
+    })
+    .await
+    .unwrap_or_else(|e| Err(format!("worktree task panicked: {e}"))); // unwrap_or_else: a panicked blocking task is a staging failure, never a crash
+    let staged = match outcome {
+        Ok(path) => Staging::Ready { path },
+        Err(error) => Staging::Failed { stage: "worktree", error },
+    };
+    crate::probe!(
+        class = "work.claim.staged",
+        claimer = %claimer,
+        bench = "repo",
+        task = %repo,
+        outcome = ?staged,
+        ms = started.elapsed().as_millis() as u64,
+        "on-claim staging — a repo card gets airc's per-card worktree"
+    );
+    staged
+}
+
 pub async fn stage_for_claimer(home: &Path, claimer: Uuid, title: &str) -> Staging {
     let Some((bench, task)) = crate::commands::benchmark::parse_card_title(title) else {
         return Staging::Ordinary;

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -31,6 +31,7 @@ pub mod benchmark_standing;
 pub mod benchmark_resume;
 pub mod bevy_consumer;
 pub mod card_staging;
+pub mod repo_registry;
 pub mod channel;
 pub mod chat;
 pub mod code;

--- a/core/continuum-core/src/modules/repo_registry.rs
+++ b/core/continuum-core/src/modules/repo_registry.rs
@@ -1,0 +1,69 @@
+//! WHICH LOCAL CHECKOUT IS `owner/name`: a per-node map from a work card's
+//! repo id to the checkout on disk, recorded whenever the CLI runs from inside
+//! a repo (start, reboot, any verb) and read by the claim-edge staging so a
+//! CITIZEN can pull a repo card — she has no cwd, and the airc CLI resolves the
+//! clone from cwd (`work_commands_git.rs`). One small file under the state dir,
+//! save-on-write like the round tracker; never a parallel source of git truth.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+fn registry_path() -> Option<PathBuf> {
+    crate::commands::benchmark::continuum_home()
+        .ok()
+        .map(|h| h.join("state").join("repos.json"))
+}
+
+fn load() -> BTreeMap<String, PathBuf> {
+    registry_path()
+        .and_then(|p| std::fs::read(p).ok())
+        .and_then(|b| serde_json::from_slice(&b).ok())
+        .unwrap_or_default() // unwrap_or: no file yet = nothing recorded, honest empty
+}
+
+/// Record that `repo` (e.g. `CambrianTech/continuum`) is checked out at `path`.
+pub fn record(repo: &str, path: &Path) {
+    let mut map = load();
+    if map.get(repo).is_some_and(|p| p == path) {
+        return;
+    }
+    map.insert(repo.to_string(), path.to_path_buf());
+    if let Some(file) = registry_path() {
+        if let Some(dir) = file.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        if let Ok(bytes) = serde_json::to_vec_pretty(&map) {
+            let _ = std::fs::write(file, bytes);
+        }
+    }
+}
+
+/// The local checkout for `repo`, if this node ever ran the CLI inside one.
+pub fn path_for(repo: &str) -> Option<PathBuf> {
+    load().get(repo).cloned().filter(|p| p.join(".git").exists())
+}
+
+/// `owner/name` from a git remote URL (https or ssh), the key work cards carry.
+pub fn repo_id_from_remote(url: &str) -> Option<String> {
+    let trimmed = url.trim().trim_end_matches('/').trim_end_matches(".git");
+    let tail = trimmed.rsplit(|c| c == '/' || c == ':').take(2).collect::<Vec<_>>();
+    match tail.as_slice() {
+        [name, owner] if !name.is_empty() && !owner.is_empty() => Some(format!("{owner}/{name}")),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the repo id drifting from the card's `owner/name` key for
+    // either remote shape — a mismatch here and no citizen ever stages a repo card.
+    #[test]
+    fn repo_id_reads_https_and_ssh_remotes_as_owner_slash_name() {
+        assert_eq!(repo_id_from_remote("https://github.com/CambrianTech/continuum.git").as_deref(), Some("CambrianTech/continuum"));
+        assert_eq!(repo_id_from_remote("git@github.com:CambrianTech/airc.git").as_deref(), Some("CambrianTech/airc"));
+        assert_eq!(repo_id_from_remote("https://github.com/CambrianTech/continuum/").as_deref(), Some("CambrianTech/continuum"));
+        assert!(repo_id_from_remote("nonsense").is_none());
+    }
+}

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -667,10 +667,10 @@ impl ActionCommand for WorkClaim {
                     use crate::modules::card_staging::Staging;
                     let staging = match crate::commands::benchmark::continuum_home() {
                         Ok(home) => {
-                            crate::modules::card_staging::stage_for_claimer(
+                            crate::modules::card_staging::stage_for_card(
                                 &home,
                                 caller.peer_id.as_uuid(),
-                                &card.title,
+                                &card,
                             )
                             .await
                         }


### PR DESCRIPTION
- **chore(airc): pin 2b5bdac → e31a1305f — claim-time worktree in airc-lib (#1377), dialect boundary (#1373), LAN beacon**
- **feat(work): a citizen can pull a REPO card — on-claim staging gives her airc's per-card worktree**
