### PR TITLE
perf(boot): no fixed wait for the local gateway during provider init — the watcher registers it

### DIFF
--- a/core/continuum-core/src/modules/ai_provider.rs
+++ b/core/continuum-core/src/modules/ai_provider.rs
@@ -61,7 +61,16 @@ const DMR_DOWN_WARN_THRESHOLD_TICKS: u64 = 6;
 /// the gateway. Deliberately SHORT: a cold large GGUF will not finish loading
 /// in this window, and we do NOT want boot to block on it — that case hands off
 /// to the reactive watcher below ([[fallbacks-are-illegal-fail-loud]], task #71).
-const GATEWAY_FAST_PATH_WAIT: Duration = Duration::from_secs(8);
+// MEASURED 2026-09-04 on all three hosts (M5 8.1 s, 5090 host 10.1 s, Intel 8.0 s
+// of ai_provider init): on a cold boot the local server is NEVER ready inside
+// this window — the serving daemon launches it AFTER module init — so the wait
+// was a fixed ~8 s tax on the PRE-BIND path of every boot on every machine,
+// and the gateway registered through the reactive watcher anyway. Zero = "is
+// it ready right now" (a surviving server on a warm reboot still takes the fast
+// path); the cold boot hands off to the watcher immediately. A citizen's first
+// select can miss the gateway for the watcher's few hundred ms — she boots,
+// catches up, and grounds for far longer than that before her first turn.
+const GATEWAY_FAST_PATH_WAIT: Duration = Duration::ZERO;
 
 // (GATEWAY_REACTIVE_CAP retired with the one-shot watcher: the persistent
 // gateway-sync task, card ed3661c4, follows the serving snapshot for the life


### PR DESCRIPTION
IntelMac's three-host boot table (2026-09-04): ai_provider init costs ~8 s on the M5, the 5090 host and the Intel box alike — a constant, not I/O. It is GATEWAY_FAST_PATH_WAIT: register_adapters awaited the local llama-server for up to 8 s on the pre-bind path, but on a cold boot the serving daemon launches the server only after module init, so the wait always timed out and the gateway registered through the reactive watcher regardless. Zero keeps the fast path for a surviving server on a warm reboot and hands a cold boot to the watcher immediately: ~8 s off every boot on every machine.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
