### PR TITLE
feat(capacity): eligibility gains a capability CLASS and a work SHAPE — a small node is the wrong node, not dead weight

### DIFF
--- a/core/continuum-core/src/capacity/eligibility.rs
+++ b/core/continuum-core/src/capacity/eligibility.rs
@@ -39,13 +39,108 @@
 //! and the gate becomes a weight — which is exactly how "cheap enough" starts
 //! winning jobs it cannot serve.
 
+/// A class of work, not a size of work.
+///
+/// Why this exists: the gate began as a single scalar (serving bytes), which
+/// answers only "can this node HOLD the job". That is the right question for one
+/// job kind and the wrong question for a grid. A node with 6 GB and no CUDA is
+/// correctly refused a 35B LLM and is perfectly capable of a YOLO-class CNN, an
+/// embedding batch, or acting as a client — and a scalar cannot say so. Under the
+/// low-end tier contract (a weak machine is CLIENT-FIRST, excluded from GPU
+/// personas, but "we may find some things it can help with") that expressiveness
+/// IS the contract: exclusion from one class must not read as worthlessness.
+///
+/// Open-ended on purpose — new classes arrive with new hardware, and an
+/// exhaustive enum would make the substrate the bottleneck on what a node may
+/// offer. Compared by value, so an unknown class simply matches nobody rather
+/// than matching everybody.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Capability(pub String);
+
+impl Capability {
+    pub fn new(key: impl Into<String>) -> Self {
+        Self(key.into())
+    }
+    /// Text generation on a language model — the class the byte floor was
+    /// originally written for.
+    pub fn llm_inference() -> Self {
+        Self::new("llm-inference")
+    }
+    /// Convolutional vision work (detection, classification). Named because it is
+    /// the concrete thing a below-floor node was called out as able to contribute.
+    pub fn vision_cnn() -> Self {
+        Self::new("vision-cnn")
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// The classes a node claims. A SET, because one machine is several kinds of
+/// resource at once and collapsing that to a single label is what forced the
+/// all-or-nothing verdict.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CapabilitySet(Vec<Capability>);
+
+impl CapabilitySet {
+    pub fn new(caps: impl IntoIterator<Item = Capability>) -> Self {
+        let mut v: Vec<Capability> = caps.into_iter().collect();
+        v.sort();
+        v.dedup();
+        Self(v)
+    }
+    pub fn offers(&self, capability: &Capability) -> bool {
+        self.0.contains(capability)
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+    pub fn iter(&self) -> impl Iterator<Item = &Capability> {
+        self.0.iter()
+    }
+}
+
+/// Whether work can be divided across nodes — the property that decides if a
+/// POOL of modest machines is real capacity or an expensive way to be slow.
+///
+/// This is the distinction that keeps "twenty office machines are a resource"
+/// honest. Both answers are about the same silicon; only the work differs:
+///
+/// - [`WorkShape::ThroughputDivisible`] — independent units with no serial
+///   dependency between them (N persona turns, N video streams through a
+///   detector, N embedding batches, N graded benchmark cards). A pool is
+///   genuinely better here than one fast machine, and this is where a grid of
+///   misfit hardware compounds.
+/// - [`WorkShape::LatencyCoupled`] — one logical computation whose parts depend
+///   on each other within a deadline (a single forward pass). Splitting it over a
+///   LAN pays a network round trip per dependency and loses badly to one capable
+///   machine. Sharding a model across an office is this case, which is why the
+///   answer to a big model is paging and residency, not scatter.
+///
+/// A governor that cannot tell these apart will either waste a pool or promise
+/// throughput it cannot deliver — so the gate refuses to guess, and the caller
+/// must say which it has.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkShape {
+    ThroughputDivisible,
+    LatencyCoupled,
+}
+
+/// Every requirement a job places, in one place.
 /// What a job needs to run at all. Deliberately a floor, not a preference: a
 /// preference belongs in ranking, and mixing the two is how a hard gate quietly
 /// becomes a soft one.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Requirement {
     /// Serving bytes the job cannot run below.
     pub min_bytes: u64,
+    /// What KIND of work this is. A byte floor alone cannot express "this is a
+    /// vision job" — and without it a node is either eligible for everything it
+    /// has room for or nothing at all.
+    pub capability: Capability,
+    /// Whether the work can be split across nodes, which decides whether a POOL
+    /// of small machines is capacity or noise. See [`WorkShape`].
+    pub shape: WorkShape,
 }
 
 /// What a node says it can provide for this job.
@@ -53,11 +148,15 @@ pub struct Requirement {
 /// Both fields are the node's own claims. `node_total_bytes` is carried so an
 /// impossible claim is detectable here — before any work is dispatched — rather
 /// than only after a delivery fails.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Offer {
     pub advertised_bytes: u64,
     /// The node's own advertised physical ceiling.
     pub node_total_bytes: u64,
+    /// What this node claims it can DO, not merely hold. A weak node advertising
+    /// `VisionCnn` and not `LlmInference` is making an honest, useful offer — the
+    /// byte gate alone would have rendered it as "too small for everything".
+    pub capabilities: CapabilitySet,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -72,6 +171,12 @@ pub enum Eligibility {
     /// not a cheap bid to be outranked, it is not an offer at all. Refused here so
     /// an impossible promise never reaches dispatch.
     VoidClaim { over_by: u64 },
+    /// The node does not do this KIND of work. Distinct from `Insufficient` on
+    /// purpose: "too small for this job" and "does not do vision at all" are
+    /// different facts, and collapsing them is what made a capable-but-small node
+    /// look like dead weight. A node refused here may be eligible for the very
+    /// next job.
+    WrongCapability { wanted: Capability },
 }
 
 impl Eligibility {
@@ -102,12 +207,71 @@ pub fn eligible(requirement: &Requirement, offer: &Offer) -> Eligibility {
             over_by: offer.advertised_bytes - offer.node_total_bytes,
         };
     }
+    // KIND before SIZE. A node that does not do this class of work is not a small
+    // node — it is the wrong node, and reporting it as `Insufficient` would tell a
+    // caller to look for more memory when more memory would not help. Checking it
+    // first also keeps the two verdicts from masking each other: a vision-only box
+    // asked for a 35B answers "I don't do that", not "I'm 30 GB short".
+    if !offer.capabilities.offers(&requirement.capability) {
+        return Eligibility::WrongCapability {
+            wanted: requirement.capability.clone(),
+        };
+    }
     if offer.advertised_bytes < requirement.min_bytes {
         return Eligibility::Insufficient {
             short_by: requirement.min_bytes - offer.advertised_bytes,
         };
     }
     Eligibility::Eligible
+}
+
+/// What a POOL of nodes is actually worth for one requirement.
+///
+/// This exists because "twenty office machines are a resource" is true for some
+/// work and false for other work, and a governor that cannot tell which will
+/// either strand real capacity or promise throughput it cannot deliver. The
+/// answer is a function of [`WorkShape`], which is why that field is on the
+/// requirement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PoolCapacity {
+    /// The work divides, and this many members each cleared the gate on their
+    /// own. Capacity scales with the count - a room of modest machines is
+    /// genuinely more than one of them here.
+    Parallel { members: usize },
+    /// The work does not divide. Capacity is ONE eligible member however many
+    /// are standing by; the others are not capacity for this job, and counting
+    /// them would be the fallacy this type exists to refuse.
+    Single,
+    /// No member cleared the gate. Deliberately its own variant rather than
+    /// `Parallel { members: 0 }` - "there is a pool, of size zero" reads as a
+    /// pool, and a caller that pattern-matches on `Parallel` would treat an
+    /// empty one as capacity.
+    None,
+}
+
+/// Decide what a pool of offers is worth for `requirement`.
+///
+/// **Members are gated individually, and their memory is never summed.** Ten
+/// 8 GB nodes are not an 80 GB node: the unit of work still has to fit somewhere.
+/// For [`WorkShape::ThroughputDivisible`] the win is CONCURRENCY (N units in
+/// flight), not size - so a 24 GB job over a pool of 8 GB machines is
+/// [`PoolCapacity::None`], correctly, however many machines there are.
+///
+/// For [`WorkShape::LatencyCoupled`] the pool adds nothing at all: splitting one
+/// forward pass over a LAN pays a round trip per dependency. The answer to a
+/// model that does not fit is paging and residency, not scatter.
+pub fn pool_capacity(requirement: &Requirement, offers: &[Offer]) -> PoolCapacity {
+    let members = offers
+        .iter()
+        .filter(|o| eligible(requirement, o).is_eligible())
+        .count();
+    if members == 0 {
+        return PoolCapacity::None;
+    }
+    match requirement.shape {
+        WorkShape::ThroughputDivisible => PoolCapacity::Parallel { members },
+        WorkShape::LatencyCoupled => PoolCapacity::Single,
+    }
 }
 
 #[cfg(test)]
@@ -118,14 +282,32 @@ mod tests {
         n * 1024 * 1024 * 1024
     }
 
+    /// The original axis: an LLM job, which is one indivisible forward pass.
     fn need(n: u64) -> Requirement {
-        Requirement { min_bytes: gb(n) }
+        need_class(n, Capability::llm_inference(), WorkShape::LatencyCoupled)
+    }
+
+    fn need_class(n: u64, capability: Capability, shape: WorkShape) -> Requirement {
+        Requirement {
+            min_bytes: gb(n),
+            capability,
+            shape,
+        }
     }
 
     fn offer(advertised: u64, total: u64) -> Offer {
+        offer_class(advertised, total, [Capability::llm_inference()])
+    }
+
+    fn offer_class(
+        advertised: u64,
+        total: u64,
+        caps: impl IntoIterator<Item = Capability>,
+    ) -> Offer {
         Offer {
             advertised_bytes: gb(advertised),
             node_total_bytes: gb(total),
+            capabilities: CapabilitySet::new(caps),
         }
     }
 
@@ -202,5 +384,110 @@ mod tests {
     fn the_local_node_is_gated_identically() {
         assert!(!eligible(&need(48), &offer(32, 32)).is_eligible());
         assert!(eligible(&need(16), &offer(32, 32)).is_eligible());
+    }
+
+    /// what this catches: THE LOW-END TIER CONTRACT - a node excluded from one
+    /// class being rendered as worthless. This box cannot host a 35B and can
+    /// absolutely run a detector; before the class axis existed the byte floor
+    /// made those the same verdict, and a small node was dead weight for every
+    /// job rather than the wrong node for some of them.
+    #[test]
+    fn a_small_node_is_eligible_for_a_class_it_actually_serves() {
+        let weak = offer_class(6, 6, [Capability::vision_cnn()]);
+        let vision = need_class(4, Capability::vision_cnn(), WorkShape::ThroughputDivisible);
+        let llm = need(24);
+        assert!(eligible(&vision, &weak).is_eligible(), "it does this work");
+        assert!(!eligible(&llm, &weak).is_eligible(), "and not that work");
+    }
+
+    /// what this catches: the two refusals collapsing into one. "Too small" tells
+    /// a caller to look for more memory; for a wrong-class node more memory would
+    /// not help, and reporting the size verdict would send the caller after a fix
+    /// that cannot work. The class check therefore runs FIRST, and this pins that
+    /// ordering with a node that is enormous and still wrong.
+    #[test]
+    fn the_wrong_class_is_never_reported_as_merely_too_small() {
+        let huge_but_vision_only = offer_class(80, 80, [Capability::vision_cnn()]);
+        let e = eligible(&need(24), &huge_but_vision_only);
+        assert_eq!(
+            e,
+            Eligibility::WrongCapability {
+                wanted: Capability::llm_inference()
+            },
+            "size never rescues the wrong class, and never masks it either: {e:?}"
+        );
+    }
+
+    /// what this catches: the void check being demoted below the class check. A
+    /// node claiming past its own ceiling is lying whatever class it claims, and
+    /// the lie must stay the loudest fact - otherwise an overclaimer could hide
+    /// behind a class mismatch and never be recorded as dishonest.
+    #[test]
+    fn an_impossible_claim_stays_void_even_in_the_wrong_class() {
+        let lying_vision_node = offer_class(64, 16, [Capability::vision_cnn()]);
+        assert!(eligible(&need(24), &lying_vision_node).is_void());
+    }
+
+    /// what this catches: a node with no claims at all being treated as universal
+    /// rather than as offering nothing. An empty set must match NOTHING - the
+    /// opposite reading (says nothing => can do anything) is how a shell that
+    /// advertises no specifics ends up eligible for everything.
+    #[test]
+    fn claiming_no_class_offers_nothing_rather_than_everything() {
+        let silent = offer_class(80, 80, []);
+        assert!(!eligible(&need(1), &silent).is_eligible());
+    }
+
+    /// what this catches: THE POOL FALLACY. Twenty machines that each fall short
+    /// are not one machine that clears it - memory does not sum across a LAN, and
+    /// a governor that adds it up will dispatch a job nobody can hold.
+    #[test]
+    fn a_pool_of_small_machines_is_not_one_big_machine() {
+        let pool: Vec<Offer> = (0..20).map(|_| offer(8, 8)).collect();
+        let big_job = need_class(
+            24,
+            Capability::llm_inference(),
+            WorkShape::ThroughputDivisible,
+        );
+        assert_eq!(pool_capacity(&big_job, &pool), PoolCapacity::None);
+    }
+
+    /// what this catches: the same silicon being valued identically for work that
+    /// divides and work that does not. This is the whole reason WorkShape exists:
+    /// twenty machines are twenty lanes of detector frames and are still exactly
+    /// one forward pass.
+    #[test]
+    fn a_pool_is_capacity_only_when_the_work_divides() {
+        let pool: Vec<Offer> = (0..20)
+            .map(|_| {
+                offer_class(
+                    8,
+                    8,
+                    [Capability::vision_cnn(), Capability::llm_inference()],
+                )
+            })
+            .collect();
+        let frames = need_class(4, Capability::vision_cnn(), WorkShape::ThroughputDivisible);
+        let one_pass = need_class(4, Capability::llm_inference(), WorkShape::LatencyCoupled);
+        assert_eq!(
+            pool_capacity(&frames, &pool),
+            PoolCapacity::Parallel { members: 20 }
+        );
+        assert_eq!(pool_capacity(&one_pass, &pool), PoolCapacity::Single);
+    }
+
+    /// what this catches: an empty pool reading as a pool. `Parallel { members: 0 }`
+    /// would satisfy a `matches!(.., Parallel { .. })` check and quietly promise
+    /// capacity that is not there.
+    #[test]
+    fn an_empty_pool_is_none_not_a_pool_of_zero() {
+        let ineligible: Vec<Offer> = vec![offer(2, 2)];
+        let job = need_class(
+            24,
+            Capability::llm_inference(),
+            WorkShape::ThroughputDivisible,
+        );
+        assert_eq!(pool_capacity(&job, &ineligible), PoolCapacity::None);
+        assert_eq!(pool_capacity(&job, &[]), PoolCapacity::None);
     }
 }

--- a/core/continuum-core/src/modules/grid/router.rs
+++ b/core/continuum-core/src/modules/grid/router.rs
@@ -35,12 +35,20 @@
 
 use super::node::{GridNode, NodeCapability, TrustLevel};
 use super::registry::NodeRegistry;
-use crate::capacity::eligibility::{eligible, Offer, Requirement};
+use crate::capacity::eligibility::{
+    eligible, Capability, CapabilitySet, Offer, Requirement, WorkShape,
+};
 
 /// Params key by which a caller declares the floor a job cannot run below.
 ///
 /// Megabytes, to match the unit the node registry already advertises in.
 pub const PARAM_REQUIRES_VRAM_MB: &str = "requiresVramMb";
+
+/// Params key by which a caller declares the CLASS of work, not its size.
+///
+/// Optional: absent means `llm-inference`, which is what this path has always
+/// assumed. See [`requirement_from`].
+pub const PARAM_REQUIRES_CAPABILITY: &str = "requiresCapability";
 
 fn mb_to_bytes(mb: u64) -> u64 {
     mb.saturating_mul(1024 * 1024)
@@ -58,8 +66,23 @@ fn requirement_from(params: &serde_json::Value) -> Requirement {
         .get(PARAM_REQUIRES_VRAM_MB)
         .and_then(serde_json::Value::as_u64)
         .unwrap_or(0);
+    // Absent class => llm-inference: the class this whole path was written for,
+    // so an undeclared job routes EXACTLY as it did before the class axis
+    // existed. Defaulting to anything else would silently re-route live traffic
+    // on a change whose point is expressiveness, not new behaviour.
+    let capability = params
+        .get(PARAM_REQUIRES_CAPABILITY)
+        .and_then(serde_json::Value::as_str)
+        .map(Capability::new)
+        .unwrap_or_else(Capability::llm_inference);
     Requirement {
         min_bytes: mb_to_bytes(mb),
+        // This router picks ONE node, so it never reads the shape; it must still
+        // state it, and LatencyCoupled is the honest default because it promises
+        // nothing. Claiming divisibility on a job that has not said so is how a
+        // scheduler ends up scattering a forward pass across a LAN.
+        shape: WorkShape::LatencyCoupled,
+        capability,
     }
 }
 
@@ -73,7 +96,47 @@ fn offer_of(node: &GridNode) -> Offer {
     Offer {
         advertised_bytes: bytes,
         node_total_bytes: bytes,
+        capabilities: classes_of(node),
     }
+}
+
+/// The work CLASSES a node's advertised capabilities imply.
+///
+/// ONE mapping, in one function, so the work-class vocabulary
+/// ([`Capability`]) and the registry's resource-kind vocabulary
+/// ([`NodeCapability`]) cannot drift apart in two places.
+///
+/// **Honest limit, and it is the same shape as the VRAM one in the module doc.**
+/// The registry says what RESOURCE a node has (`compute`, `inference`), never
+/// what CLASS of work it will serve. So a node with a GPU reads as offering
+/// `llm-inference` - which is exactly what this path already assumed, hence no
+/// behaviour change - and `vision-cnn` is at present unclaimable by ANY node.
+/// Not because no node can do it: because no node can SAY it.
+///
+/// Inventing the claim here (e.g. "a small GPU must mean vision") would be the
+/// substrate guessing on the node's behalf, which is the class of error this
+/// gate exists to refuse - and it would put a hardcoded size-tier rule in the
+/// one place that is supposed to have none. Making it claimable is a registry
+/// change: an additive classes field on the advertisement, filled in by the NODE
+/// from what it can actually run.
+fn classes_of(node: &GridNode) -> CapabilitySet {
+    let mut caps = Vec::new();
+    for c in &node.capabilities {
+        match c {
+            NodeCapability::Compute { .. } | NodeCapability::Inference { .. } => {
+                caps.push(Capability::llm_inference())
+            }
+            // Real capabilities, but not classes of dispatchable work: storage is
+            // where artifacts live, training and forge are their own lanes with
+            // their own gates. Listed explicitly rather than caught by a wildcard
+            // so a NEW variant fails to compile here and gets a decision, instead
+            // of silently defaulting to "offers nothing".
+            NodeCapability::Storage { .. }
+            | NodeCapability::Training { .. }
+            | NodeCapability::Forge { .. } => {}
+        }
+    }
+    CapabilitySet::new(caps)
 }
 
 /// Routing decision for a command.
@@ -200,11 +263,19 @@ impl GridRouter {
     /// that exempts the local node is a gate with a hole shaped like us.
     fn local_is_eligible(&self, requirement: &Requirement) -> bool {
         let bytes = mb_to_bytes(self.local_vram_mb);
+        // Same derivation a peer gets: a GPU here means llm-inference here, and
+        // no GPU claims nothing rather than claiming everything.
+        let capabilities = if self.local_has_gpu {
+            CapabilitySet::new([Capability::llm_inference()])
+        } else {
+            CapabilitySet::default()
+        };
         eligible(
             requirement,
             &Offer {
                 advertised_bytes: bytes,
                 node_total_bytes: bytes,
+                capabilities,
             },
         )
         .is_eligible()


### PR DESCRIPTION
## What

`capacity/eligibility.rs` was a single scalar (serving bytes), which answers only **"can this node HOLD the job"**. That is the right question for one job kind and the wrong question for a grid: a 6 GB box gets refused a 35B correctly and gets refused a YOLO batch for no reason, because a scalar cannot tell those apart. Under the low-end tier contract — client-first, excluded from GPU personas, "but we may find things it can help with" — that expressiveness *is* the contract.

Two axes, both load-bearing.

### 1. Capability CLASS

`Capability` (`llm-inference` / `vision-cnn` / open-ended string) plus a new `WrongCapability` verdict, kept **distinct from `Insufficient`** and checked **before** the byte floor.

- "Too small" tells a caller to go find more memory. For a wrong-class node more memory would not help, so reporting the size verdict sends them after a fix that cannot work.
- Checking class first also stops the two refusals masking each other: a vision-only box asked for a 35B answers *"I don't do that"*, not *"I'm 30 GB short"*.
- The void check still runs **first**: an impossible claim is dishonest whatever class it claims, and that must stay the loudest fact.
- An **empty** capability set matches nothing rather than everything — "says nothing" must not read as "can do anything".

### 2. Work SHAPE

`WorkShape` (`ThroughputDivisible` / `LatencyCoupled`), read by the new `pool_capacity()` — its only reader, so the field is load-bearing rather than decorative.

- Twenty machines are twenty lanes of detector frames and are still exactly **one** forward pass.
- Members are gated individually and their memory **never sums**: a 24 GB job over a pool of 8 GB boxes is `None` however many boxes there are, because the unit still has to fit somewhere.
- An empty pool is `None`, not `Parallel { members: 0 }` — a caller matching on `Parallel` must not read an empty pool as capacity.

### Router wiring

`requiresCapability` param; absent ⇒ `llm-inference`, so undeclared jobs route byte-for-byte as they do today (pinned by the pre-existing `an_undeclared_requirement_routes_exactly_as_before`). Node classes derive from `NodeCapability` in **one** function so the work-class and resource-kind vocabularies cannot drift apart.

## Honest limit (same shape as the `VoidClaim` note already in that module)

The registry advertises a node's **resource** (`compute`, `inference`), never the **class of work** it will serve. So `vision-cnn` is at present unclaimable by *any* node — not because none can do it, but because none can **say** it.

I deliberately did **not** paper over that with a "small GPU must mean vision" rule. That would put a hardcoded size-tier clamp in the one module whose whole job is not having one, and it would be indistinguishable from correct until the first machine that breaks the correlation. Closing the gap is a registry change — an additive `classes` field the **node** fills in — not a heuristic here.

## Validation

`cargo check -p continuum-core --lib --all-targets` clean; 24 tests pass (13 `capacity::eligibility`, 11 `modules::grid::router`), including the undeclared-requirement regression. `rustfmt` clean on both files.

## Review note

No auto-merge. @IntelMac raised a design question on airc — whether `WorkShape` should grow a third *interruptible-background* value for the "twenty business machines doing other things" case — and I have answered on the wire; leaving this open for that thread to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc
