### PR TITLE
fix(operator): the human's peer stands in the citizens' commons, not airc's lobby

### DIFF
--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -66,6 +66,15 @@ use airc_lib::{Airc, AircError, DEFAULT_HEARTBEAT_INTERVAL};
 /// migrates a living citizen.
 pub const CITIZEN_COMMONS_ROOM: &str = "academy";
 
+/// airc's OWN generic lobby — not continuum's commons.
+///
+/// Named rather than spelled inline because the distinction is the whole
+/// point: `#general` is where a bare airc scope lands when nothing tells it
+/// otherwise, and continuum always has something to say
+/// ([`CITIZEN_COMMONS_ROOM`]). A literal `"general"` in continuum code reads
+/// like a choice; nine times in ten it is the absence of one.
+pub const AIRC_LOBBY_ROOM: &str = "general";
+
 /// Abort-on-drop guard for the continuum-owned heartbeat pump (#260): keeps
 /// the airc `HeartbeatTask` teardown contract — dropping the runtime aborts
 /// the pump so a torn-down persona ages out of the roster within the
@@ -1046,6 +1055,21 @@ impl PersonaAircRuntime {
     /// turns — every per-run room was born deaf).
     pub async fn join_room(&self, name: &str) -> Result<(), AircError> {
         self.airc.join(name).await?;
+        self.membership_epoch.send_modify(|e| *e += 1);
+        Ok(())
+    }
+
+    /// Belong to `name` WITHOUT moving the focus — the citizen's verb, where
+    /// [`join_room`](Self::join_room) is the operator's.
+    ///
+    /// `Airc::join` is subscribe AND focus; this is subscribe alone. Use it for
+    /// a room this peer should receive and be able to speak in, when some OTHER
+    /// room is the one its short-shape commands (and its work cards) belong to.
+    /// Bumps the same membership epoch as `join_room`, because a subscription
+    /// change is a membership change however the focus lands — routing that off
+    /// this epoch must not care which verb moved it.
+    pub async fn subscribe_room(&self, name: &str) -> Result<(), AircError> {
+        self.airc.subscribe_room(name).await?;
         self.membership_epoch.send_modify(|e| *e += 1);
         Ok(())
     }

--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -65,18 +65,81 @@ pub async fn ensure_operator_peer(
                 peer_id = %rt.airc().peer_id(),
                 "operator self-peer online — room-scoped verbs now act as the human, not a denial (#27)"
             );
-            // The human belongs in the commons by default. Without this join the
-            // operator's chat/send to general was store+live-fed but the daemon
-            // refused the say ("this scope is not subscribed") — the human could
-            // see the room and still not be heard in it (caught live 2026-08-31,
-            // the DM-during-benchmark acid test). Idempotent; failure is loud
-            // but non-fatal — room/join remains the manual path.
-            if let Err(e) = rt.join_room("general").await {
+            // The human belongs in the CITIZENS' commons by default, and stays
+            // reachable in airc's lobby.
+            //
+            // This was `join_room("general")` — a hardcoded literal, and the
+            // wrong room. `Airc::join` is subscribe AND focus, so the operator
+            // self-peer's DEFAULT room became airc's generic lobby while every
+            // citizen on the same node lands in `CITIZEN_COMMONS_ROOM` (see
+            // `PersonaAircRuntime::bootstrap_as`). The human stood in a
+            // different room from every citizen on their own machine.
+            //
+            // Two consequences, both silent. Room-scoped verbs invoked without a
+            // persona resolved a room no citizen boards from; and `work/create`
+            // publishes to the handle's current room and returns only a
+            // `card_id`, so every operator-filed card landed on that board with
+            // nothing in the result able to say so. Measured 2026-09-04
+            // (IntelMac, 2,000 events): 47 `card_created` in `#academy` from
+            // four publishers, 3 in `#general` — all three this node's operator
+            // peer. A card filed that way and not also announced in chat simply
+            // does not exist for anyone else: no error, no empty result.
+            //
+            // ORDER IS LOAD-BEARING. `subscribe_room` joins without promoting,
+            // so the lobby stays speakable — that was the point of the original
+            // join (2026-08-31, the DM-during-benchmark acid test: the operator
+            // could SEE a room and still not be heard in it) — without becoming
+            // the focus. The `join_room` after it promotes the commons. On a
+            // FRESH scope the first subscription seeds the default and the join
+            // then corrects it; on an ESTABLISHED scope whose default drifted to
+            // the lobby, the join repairs it in place on the next boot. That
+            // self-heal is deliberate: a fix every existing install has to run
+            // by hand is not a fix.
+            //
+            // Both failures are loud and non-fatal, and the resolved room is
+            // probed below either way — a wrong room must be visible in the boot
+            // receipt rather than inferred later from where the cards went.
+            if let Err(e) = rt
+                .subscribe_room(crate::persona::airc_runtime::AIRC_LOBBY_ROOM)
+                .await
+            {
+                crate::probe!(
+                    class = "operator.peer.lobby_subscribe_failed",
+                    error = %e.to_string(),
+                    "operator self-peer could not subscribe the airc lobby — the human cannot be heard in #general until room/join"
+                );
+            }
+            if let Err(e) = rt
+                .join_room(crate::persona::airc_runtime::CITIZEN_COMMONS_ROOM)
+                .await
+            {
                 crate::probe!(
                     class = "operator.peer.commons_join_failed",
                     error = %e.to_string(),
-                    "operator self-peer could not join general — the human speaks nowhere by default until room/join"
+                    "operator self-peer could not join the citizens' commons — operator cards and room-scoped verbs land wherever the focus already was"
                 );
+            }
+            // WHERE THE HUMAN ACTUALLY ENDED UP. The bug this replaces was
+            // invisible precisely because nothing ever stated the resolved room;
+            // it had to be reconstructed from card_created room ids across two
+            // thousand events on another machine. One probe closes that.
+            match rt
+                .airc()
+                .current_room_landing_in(crate::persona::airc_runtime::CITIZEN_COMMONS_ROOM)
+                .await
+            {
+                Ok(room) => crate::probe!(
+                    class = "operator.peer.room",
+                    room = %room.name,
+                    channel = %room.channel,
+                    commons = %crate::persona::airc_runtime::CITIZEN_COMMONS_ROOM,
+                    "operator self-peer default room — operator cards and room-scoped verbs land HERE"
+                ),
+                Err(e) => crate::probe!(
+                    class = "operator.peer.room_unresolved",
+                    error = %e.to_string(),
+                    "operator self-peer default room could not be read — where operator cards land is UNKNOWN, not general"
+                ),
             }
             let _ = OPERATOR.set(rt);
         }


### PR DESCRIPTION
## The bug

`operator_peer.rs:74` bootstrapped the operator self-peer (#27 — the human's in-core identity) with a hardcoded `join_room("general")`.

Every **citizen** bootstraps with `current_room_landing_in(CITIZEN_COMMONS_ROOM)`, and that constant is `"academy"` (card daa01102: *"academy is THE default room"*). `Airc::join` is documented as *subscribe **and** focus* — it promotes to default. So the operator's default room became airc's generic lobby while every citizen on the same node stood in the commons. **The human was in a different room from every citizen on their own machine.**

### Two silent consequences

- Room-scoped verbs invoked without a persona resolved a room no citizen boards from.
- `work/create` publishes to the handle's current room and returns only a `card_id` — the result has no field that could report where the card went. "I filed a card" and "the team has the card" were indistinguishable from the filing side.

### Measured, cross-machine

IntelMac grouped 2,000 events by (room, publisher): **47 `card_created` in `#academy`** from four publishers; **3 in `#general`**, all three from a core's operator peer.

My first reading was "BigMama publishes somewhere odd" — machine-specific. IntelMac falsified it on their own box: `continuum work/create` there produced card `582caa88` from peer `5c49baf6` (their **core**, not either agent identity), and it landed in `#general` too. Two machines, two operating systems, same wrong room, same line of code. It is core-vs-CLI, not machine-specific.

**Live consequence:** a persona cannot claim a card handed to her by a core standing in a different room. M5 handed Joaquin card `0c4317e1`; her core could not see it.

## The fix

`subscribe_room(AIRC_LOBBY_ROOM)` — joins **without** promoting, so the lobby stays *speakable*. That was the whole point of the original join (2026-08-31: the operator could *see* a room and still not be heard in it), and I did not want to regress it.

`join_room(CITIZEN_COMMONS_ROOM)` — promotes the commons to focus.

**Order is load-bearing:** subscribe doesn't promote, join does. On a fresh scope the first subscription seeds the default and the join corrects it; on an established scope whose default drifted to the lobby, the join repairs it on next boot. That self-heal is deliberate — a fix every existing install has to run by hand is not a fix.

Plus an `operator.peer.room` probe stating the resolved room and channel at boot. This bug was invisible *precisely because nothing ever stated it* — it had to be reconstructed from card room-ids on another machine. The error arm reports the room as **UNKNOWN** rather than assuming the lobby, because "could not read" and "is general" are different facts.

`AIRC_LOBBY_ROOM` becomes a named constant beside `CITIZEN_COMMONS_ROOM`: a literal `"general"` in continuum code reads like a choice, and nine times in ten it is the absence of one.

`PersonaAircRuntime::subscribe_room` mirrors `join_room` and bumps the same membership epoch — a subscription change is a membership change however the focus lands.

## Verification — deployed and confirmed two independent ways

Built and deployed on BigMama (build 5034, sha `ca8bb7e8d`).

**1. The probe, verbatim from the boot log:**
```
probe_class="operator.peer.room" room=academy channel=3be59578-7f1d-5d78-8b17-1eb0834b4643 commons=academy
```
`room=academy`, self-healed from an established `#general` default with no manual step.

**2. Behaviour, not just its own probe:** the next card this core created (`0d57b778`) emitted `card_created` into room `3be59578` = `#academy`. My three previous cards all went to `5eedf7b1` = `#general`.

No unit test: this is boot wiring against a live airc and there is no fixture for it — same position M5 took on `unseat`. The probe is the self-check, and it is confirmed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc
