### PR TITLE
fix(operator): the room probe must READ the room, not create it

### DIFF
--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -123,22 +123,47 @@ pub async fn ensure_operator_peer(
             // invisible precisely because nothing ever stated the resolved room;
             // it had to be reconstructed from card_created room ids across two
             // thousand events on another machine. One probe closes that.
-            match rt
-                .airc()
-                .current_room_landing_in(crate::persona::airc_runtime::CITIZEN_COMMONS_ROOM)
-                .await
-            {
-                Ok(room) => crate::probe!(
+            //
+            // `peek_default_room`, NEVER `current_room_landing_in`. That is not
+            // a style preference — the landing variant MUTATES when no default
+            // exists yet (airc.rs: it subscribes, `set_default`s, saves,
+            // publishes presence, and emits an identity card). Used here it
+            // would fire on exactly the path where the joins above FAILED, and
+            // would then quietly perform the very subscribe that failed and
+            // report a healthy room — a probe manufacturing the state it claims
+            // to observe, which is the worst possible reading for the one line
+            // whose whole job is to be trustworthy about where cards go.
+            //
+            // airc already names this distinction and built the read-only door:
+            // `peek_default_room` exists as the #1217 regression fix, after
+            // `airc network` was caught silently subscribing to #general via
+            // `current_room` while claiming to be an inspection command. Same
+            // trap, same module, one caller later. (Found in review by IntelMac
+            // on the merged #3716 — the mutation was mine.)
+            //
+            // Three outcomes, three DIFFERENT facts, none collapsed: a room, no
+            // default at all, or an unreadable subscription set.
+            match rt.airc().peek_default_room().await {
+                Ok(Some(room)) => crate::probe!(
                     class = "operator.peer.room",
                     room = %room.name,
                     channel = %room.channel,
                     commons = %crate::persona::airc_runtime::CITIZEN_COMMONS_ROOM,
                     "operator self-peer default room — operator cards and room-scoped verbs land HERE"
                 ),
+                // No default AFTER both joins ran means both failed. Loud, and
+                // specifically NOT the same row as a successful academy landing:
+                // the human has no room, so operator cards have nowhere
+                // predictable to go and the probes above say why.
+                Ok(None) => crate::probe!(
+                    class = "operator.peer.room_unset",
+                    commons = %crate::persona::airc_runtime::CITIZEN_COMMONS_ROOM,
+                    "operator self-peer has NO default room after subscribe+join — both joins failed; operator cards have no predictable board"
+                ),
                 Err(e) => crate::probe!(
                     class = "operator.peer.room_unresolved",
                     error = %e.to_string(),
-                    "operator self-peer default room could not be read — where operator cards land is UNKNOWN, not general"
+                    "operator self-peer default room could not be READ — where operator cards land is UNKNOWN, which is not the same as unset"
                 ),
             }
             let _ = OPERATOR.set(rt);


### PR DESCRIPTION
Follow-up to #3716, from IntelMac's review of the already-merged change. The mutation was mine.

## The defect

#3716 added an `operator.peer.room` probe so the operator self-peer's landing room is *stated* at boot instead of reconstructed from where cards ended up. It called `Airc::current_room_landing_in` — which is **not a passive read**.

`airc-lib/src/airc.rs:2208`: that function returns early only when a default subscription already exists. Otherwise it subscribes, `set_default`s, saves, publishes presence, and emits an identity card.

## Why this is worse than a style bug

The probe runs **after** the lobby subscribe and the commons join.

- If those **succeeded**, a default exists, the call returns early, and the probe is harmless — which is precisely why it looked correct during verification and honestly reported `room=academy`.
- If those **failed**, there is no default. The probe would then perform the very subscribe that just failed, and report a healthy academy landing.

A probe that manufactures the state it claims to observe, on exactly the failure path it exists to expose — in the one line whose entire job is being trustworthy about where cards go.

## airc had already built the door

`peek_default_room` sits five lines below the function I reached for, documented as the read-only variant, added as the **#1217 regression fix** after `airc network` was caught silently subscribing to `#general` via `current_room` while claiming to be an inspection command.

Same trap, same module, one caller later. I didn't look for an existing read-only accessor; I took the first function that returned a `Room`.

## The fix

`peek_default_room()`, with three outcomes kept **distinct** rather than collapsed:

| outcome | meaning |
|---|---|
| `Ok(Some(room))` | the room, as before |
| `Ok(None)` | no default *after both joins ran* — so both failed. The human has no room and operator cards have no predictable board. Its own probe class, never silently the same row as a successful landing. |
| `Err(_)` | the subscription set could not be **read**. UNKNOWN — a different fact from unset. |

## Verification

`cargo check -p continuum-core --lib` clean, `rustfmt` clean.

I verified the mutation against the airc source rather than taking it from the report — `current_room_landing_in` at airc.rs:2208–2229, and `peek_default_room` at :2244.

No behavioural change on the healthy path, which is the point: this only alters what happens when the joins fail, and that path had no honest reporting before.

Not self-merging — same reasoning as #3716, and more so given this is a correction to a change I verified and still got wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc
