### PR TITLE
fix(cli): deploy-verify's ping is bounded — a core that accepts the socket but never answers fails by name

### DIFF
--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -855,12 +855,25 @@ const CLI_BUILD_SHA: &str = env!("CONTINUUM_BUILD_GIT_SHA");
 /// warning on every successful deploy.
 async fn verify_deployed_build(rebuilt_cli: bool) -> Result<(), String> {
     let socket = socket_path();
-    // The RUNNING core's provenance, from the process itself.
-    let reply = connection()
-        .commands()
-        .execute_value("ping", Value::Object(Default::default()))
-        .await
-        .map_err(|e| format!("deploy-verify: no core answering on {socket}: {e}"))?;
+    // The RUNNING core's provenance, from the process itself. BOUNDED: a core
+    // that accepts the socket mid-boot but never answers made `continuum
+    // reboot` hang for good (IntelMac's node, 50 min, 2026-09-05) — the same
+    // wall-clock-forever shape as the 300 s boot watchdog, on the other side of
+    // the socket. A named failure beats a silent hang.
+    let reply = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        connection()
+            .commands()
+            .execute_value("ping", Value::Object(Default::default())),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "deploy-verify: the core on {socket} accepted the socket but did not answer `ping` \
+             within 30 s — mid-boot (retry) or wedged (read boot.phase / boot.module_init)"
+        )
+    })?
+    .map_err(|e| format!("deploy-verify: no core answering on {socket}: {e}"))?;
     let actual = reply
         .get("buildSha")
         .and_then(|v| v.as_str())


### PR DESCRIPTION
IntelMac's node sat in `continuum reboot` for 50 minutes: the deploy-verify ping awaited a core that had accepted the socket mid-boot and never replied. Same wall-clock-forever shape as the 300 s boot watchdog, on the client side. 30 s, then a named failure that says mid-boot or wedged and where to read.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
