### PR TITLE
fix(serving): the debug-build version probe is bounded — a hung --version neither verifies nor refuses

### DIFF
--- a/core/continuum-core/src/inference/debug_build_watch.rs
+++ b/core/continuum-core/src/inference/debug_build_watch.rs
@@ -1,0 +1,66 @@
+//! The SECOND half of the debug-build gate. The first half asks the binary for
+//! `--version` before launch; when that probe times out (it hangs
+//! uninterruptibly on the Intel box, 2026-09-05) the lane launches unverified.
+//! llama-server prints the same warning on its OWN stderr at startup —
+//! "warning: DEBUG BUILD (asserts enabled) -- performance numbers from this
+//! process are not valid" — and the daemon already drains that stderr line by
+//! line, so a watch on it closes the hole: a debug build never serves through
+//! either path. Build for speed (Joel, 2026-09-04).
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use super::child_log::LineWatch;
+
+/// Set once the server's startup output names itself a debug build.
+#[derive(Clone, Default)]
+pub struct DebugBuildFlag(Arc<AtomicBool>);
+
+impl DebugBuildFlag {
+    pub fn is_set(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+pub struct DebugBuildWatch {
+    flag: DebugBuildFlag,
+    seen: bool,
+}
+
+impl DebugBuildWatch {
+    pub fn new(flag: DebugBuildFlag) -> Self {
+        Self { flag, seen: false }
+    }
+}
+
+impl LineWatch for DebugBuildWatch {
+    fn observe(&mut self, line: &str) {
+        if self.seen || !line.contains("DEBUG BUILD") {
+            return;
+        }
+        self.seen = true;
+        self.flag.0.store(true, Ordering::Relaxed);
+        crate::probe!(
+            class = "serving.debug_build_detected",
+            line = %line.trim(),
+            "the spawned server named itself a DEBUG build on its own stderr"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the startup line drifting from the watch — the warning
+    // llama-server prints must set the flag; ordinary startup lines must not.
+    #[test]
+    fn the_startup_warning_sets_the_flag_and_ordinary_lines_do_not() {
+        let flag = DebugBuildFlag::default();
+        let mut w = DebugBuildWatch::new(flag.clone());
+        w.observe("build: 10229 (a28ee566c) with AppleClang");
+        assert!(!flag.is_set());
+        w.observe("warning: DEBUG BUILD (asserts enabled) -- performance numbers from this process are not valid");
+        assert!(flag.is_set());
+    }
+}

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -3003,12 +3003,29 @@ impl LlamaServerControl for LlamaServerProcess {
         // slow — BigMama's 5090 hosted one for a day. Refuse it at the door, on
         // every machine, with the rebuild instruction; the version line is the
         // receipt either way.
-        let version = tokio::process::Command::new(&self.bin)
-            .arg("--version")
-            .output()
-            .await
-            .map(|o| format!("{}{}", String::from_utf8_lossy(&o.stdout), String::from_utf8_lossy(&o.stderr)))
-            .unwrap_or_default(); // unwrap_or: a binary that cannot answer --version fails at spawn below with its own error
+        // BOUNDED: on IntelMac's box `llama-server --version` printed nothing,
+        // went to state U and survived kill -9 (2026-09-05) — an unbounded await
+        // here would have blocked every lane launch on that node forever. A
+        // probe that times out neither verifies nor refuses; it says so and the
+        // launch proceeds (the spawn below has its own failure shape).
+        let version = match tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            tokio::process::Command::new(&self.bin).arg("--version").output(),
+        )
+        .await
+        {
+            Ok(out) => out
+                .map(|o| format!("{}{}", String::from_utf8_lossy(&o.stdout), String::from_utf8_lossy(&o.stderr)))
+                .unwrap_or_default(), // unwrap_or: a binary that cannot answer --version fails at spawn below with its own error
+            Err(_) => {
+                crate::probe!(
+                    class = "serving.version_probe_timeout",
+                    bin = %self.bin,
+                    "`--version` did not answer in 10 s — neither verified nor refused; launching anyway"
+                );
+                String::new()
+            }
+        };
         crate::probe!(
             class = "serving.server_version",
             bin = %self.bin,

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -3049,6 +3049,7 @@ impl LlamaServerControl for LlamaServerProcess {
             .stderr(Stdio::piped())
             .spawn()
             .map_err(|e| LlamaServerError::Spawn(format!("{}: {e}", self.bin)))?;
+        let child_pid = child.id();
         // Hand stderr to the capped sink. If either the handle or the path is missing the
         // child still serves — unlogged, and the pipe drains to close so it cannot block.
         // The sink reads every line to keep the file capped, so it is also the cheapest
@@ -3062,6 +3063,7 @@ impl LlamaServerControl for LlamaServerProcess {
         let offload_watch = Box::new(super::placement_watch::OffloadWatch::new(
             self.offload.clone(),
         ));
+        let debug_flag = super::debug_build_watch::DebugBuildFlag::default();
         let watch: Box<dyn super::child_log::LineWatch> = match self.wedge.clone() {
             Some(flag) => Box::new(super::placement_watch::ChainWatch(
                 Box::new(super::wedge::WedgeWatch::new(flag)),
@@ -3069,7 +3071,12 @@ impl LlamaServerControl for LlamaServerProcess {
             )),
             None => offload_watch,
         };
-        match (child.stderr.take(), log_path) {
+        
+        let watch: Box<dyn super::child_log::LineWatch> = Box::new(super::placement_watch::ChainWatch(
+            Box::new(super::debug_build_watch::DebugBuildWatch::new(debug_flag.clone())),
+            watch,
+        ));
+match (child.stderr.take(), log_path) {
             (Some(stderr), Some(path)) => super::child_log::drain_capped(stderr, path, watch),
             (Some(_), None) => tracing::warn!(
                 probe_class = "serving.llama.stderr_unlogged",
@@ -3148,6 +3155,23 @@ impl LlamaServerControl for LlamaServerProcess {
         *self.served_adapters.lock().unwrap() = target.adapter_paths();
 
         self.wait_ready().await?;
+        // Second half of the debug-build gate (see debug_build_watch): the server
+        // said so on its own stderr while coming up — refuse the lane, loudly.
+        if debug_flag.is_set() {
+            if let Some(pid) = child_pid {
+                crate::inference::lane_process::kill9(pid);
+            }
+            crate::probe!(
+                class = "serving.debug_build_refused",
+                bin = %self.bin,
+                "refused to serve from a DEBUG build (startup stderr) — build for speed"
+            );
+            return Err(LlamaServerError::Spawn(format!(
+                "{} announced itself a DEBUG build on startup (asserts enabled; its speed is not valid). \
+                 Rebuild llama-server in release from the canary pin and relaunch.",
+                self.bin
+            )));
+        }
         // PLACEMENT CONTRACT READBACK (#441, Joel 2026-08-15: "models that got fucked by
         // serving and are on cpu. You never catch it and we are waiting an eternity").
         // The governor planned a placement; the engine's own load banner says what it

--- a/core/continuum-core/src/inference/mod.rs
+++ b/core/continuum-core/src/inference/mod.rs
@@ -33,6 +33,7 @@ pub mod airc_remote;
 pub mod backends;
 pub mod batching_probe;
 pub mod child_log;
+pub mod debug_build_watch;
 pub mod coordinator;
 pub mod coordinator_pool;
 pub mod footprint_registry;


### PR DESCRIPTION
IntelMac reproduced llama-server --version hanging uninterruptibly on the Intel box (zero bytes, state U, survives kill -9). The gate added in #3701 awaited that command unbounded on the launch path, so on that node every lane launch would have blocked. 10 s, then serving.version_probe_timeout and the launch proceeds; the spawn keeps its own failure shape.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
