### PR TITLE
fix(work): a repo card's staged worktree initialises its submodules — an empty vendor dir is not Ready

### DIFF
--- a/core/continuum-core/src/modules/card_staging.rs
+++ b/core/continuum-core/src/modules/card_staging.rs
@@ -108,8 +108,40 @@ pub async fn stage_for_card(home: &Path, claimer: Uuid, card: &airc_lib::WorkCar
     })
     .await
     .unwrap_or_else(|e| Err(format!("worktree task panicked: {e}"))); // unwrap_or_else: a panicked blocking task is a staging failure, never a crash
+    // A fresh worktree has EMPTY submodule paths (core/vendor/llama.cpp): a build
+    // there dies in cmake and a symlink workaround breaks git status (IntelMac +
+    // M5, three times, 2026-09-05). Initialise them here, bounded, with a named
+    // outcome — a worktree whose vendor is empty is not Ready.
     let staged = match outcome {
-        Ok(path) => Staging::Ready { path },
+        Ok(path) => {
+            let path_for_init = path.clone();
+            let init = tokio::time::timeout(
+                std::time::Duration::from_secs(600),
+                tokio::task::spawn_blocking(move || {
+                    std::process::Command::new("git")
+                        .args(["-C", &path_for_init.to_string_lossy(), "submodule", "update", "--init", "--recursive"])
+                        .output()
+                        .map_err(|e| e.to_string())
+                        .and_then(|o| {
+                            if o.status.success() {
+                                Ok(())
+                            } else {
+                                Err(String::from_utf8_lossy(&o.stderr).trim().to_string())
+                            }
+                        })
+                }),
+            )
+            .await;
+            match init {
+                Ok(Ok(Ok(()))) => Staging::Ready { path },
+                Ok(Ok(Err(error))) => Staging::Failed { stage: "submodules", error },
+                Ok(Err(join)) => Staging::Failed { stage: "submodules", error: format!("init task panicked: {join}") },
+                Err(_) => Staging::Failed {
+                    stage: "submodules",
+                    error: "git submodule update --init --recursive did not finish within 600 s".to_string(),
+                },
+            }
+        }
         Err(error) => Staging::Failed { stage: "worktree", error },
     };
     crate::probe!(


### PR DESCRIPTION
A fresh git worktree has empty submodule paths (core/vendor/llama.cpp); a build there dies in cmake and the symlink workaround breaks git status/diff — hit three times on the M5 and once on the Intel box tonight. Repo-card staging now runs git submodule update --init --recursive in the new worktree, bounded to 600 s with a named failure (stage: submodules). The airc-side twin (ensure_worktree) is IntelMac's.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
