### PR TITLE
fix(serving): a self-heal must say WHY — the wedge reason reaches the snapshot, not just the log

### DIFF
--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -1739,12 +1739,20 @@ impl ServingDaemonModule {
             ),
             None => {
                 // Nothing servable on disk → publish "nothing live" so readers
-                // (and a grid allocator) see the gap and route elsewhere.
+                // (and a grid allocator) see the gap and route elsewhere — WITH the
+                // cause named. This is the state a fresh install sits in before any
+                // weights are pulled, and it is the one place an operator most needs
+                // the surface to distinguish "no model on this box yet" from "the
+                // serving daemon is broken". `empty()` rendered both identically.
                 self.set_active_artifact(None);
                 if self.serving_tx.borrow().active_model.is_some() {
-                    let empty = ServingSnapshot::empty();
-                    Self::emit_serving(self.bus.get(), &empty);
-                    let _ = self.serving_tx.send_replace(empty);
+                    let flipped = ServingSnapshot::degraded(
+                        "no servable model on disk — the planner found no local weights \
+                         to bring up (pull one with `continuum models/pull`)"
+                            .to_string(),
+                    );
+                    Self::emit_serving(self.bus.get(), &flipped);
+                    let _ = self.serving_tx.send_replace(flipped);
                 }
                 return None;
             }
@@ -2067,13 +2075,18 @@ impl ServingDaemonModule {
             crate::probe!(
                 class = "serving.reconcile",
                 desired = desired.as_str(),
-                "plan named a model the registry can't resolve — publishing empty snapshot",
+                "plan named a model the registry can't resolve — publishing degraded snapshot",
             );
             self.set_active_artifact(None);
             if self.serving_tx.borrow().active_model.is_some() {
-                let empty = ServingSnapshot::empty();
-                Self::emit_serving(self.bus.get(), &empty);
-                let _ = self.serving_tx.send_replace(empty);
+                // Name the killer on the SNAPSHOT, not just in the log: this is a
+                // config/catalog fault an operator must act on, and `empty()` would
+                // render it as a plain "nothing served".
+                let flipped = ServingSnapshot::degraded(format!(
+                    "the plan named model '{desired}', which the registry cannot resolve"
+                ));
+                Self::emit_serving(self.bus.get(), &flipped);
+                let _ = self.serving_tx.send_replace(flipped);
             }
             return None;
         };
@@ -2604,9 +2617,21 @@ impl ServingDaemonModule {
         reason: &str,
     ) {
         force_relaunch.store(true, Ordering::Release);
-        let empty = ServingSnapshot::empty();
-        Self::emit_serving(bus, &empty);
-        let _ = serving_tx.send_replace(empty);
+        // The reason is a PARAMETER here — publish it ON the snapshot, not only into
+        // the log. `empty()` hardcodes `degraded_reason: None`, so for the whole
+        // kill+respawn window `serving/status` read `ready:false, active_model:null,
+        // lanes:0, degraded_reason:null` — absence with no stated cause, which is
+        // indistinguishable from a node that has no brain at all. Measured live
+        // 2026-09-05 (BigMama): a wedge-heal cycle with a healthy `/health` answering
+        // on the doomed lane, recovering by itself inside 120s, three times read as a
+        // possible dead-serving defect because the surface never said "relaunching".
+        // The pre-flight guard already reserves a `degraded=` probe field for exactly
+        // this string (added 2026-08-15: "serving/status knew the exact cause and
+        // nothing surfaced it") and was being handed "" every time.
+        // [[absence-rendered-as-positive-fact]] [[fallbacks-are-illegal-fail-loud]]
+        let flipped = ServingSnapshot::degraded(reason.to_string());
+        Self::emit_serving(bus, &flipped);
+        let _ = serving_tx.send_replace(flipped);
         crate::probe!(
             class = "serving.health",
             action = "relaunch",
@@ -4054,6 +4079,47 @@ impl ServiceModule for ServingDaemonModule {
 
 #[cfg(test)]
 mod tests {
+
+    // what this catches: a self-heal that renders as a dead node. `declare_lane_wedged`
+    // TAKES the reason as a parameter, logged it, then published `ServingSnapshot::empty()`
+    // — which hardcodes `degraded_reason: None`. For the whole kill+respawn window
+    // `serving/status` showed `ready:false, active_model:null, lanes:0,
+    // degraded_reason:null`: absence with no stated cause, byte-identical to a node that
+    // never had a brain. Measured 2026-09-05 on BigMama, where a wedge-heal recovering by
+    // itself inside 120s was read three times as a possible serving-is-dead defect, and
+    // the pre-flight guard's `degraded=` probe field (added 2026-08-15 precisely to carry
+    // this string) was handed "" on every wait. The reason is IN HAND at the call site;
+    // dropping it is the silent-failure class, not a formatting nit.
+    #[test]
+    fn declaring_a_wedge_publishes_the_reason_not_a_bare_empty_snapshot() {
+        use super::*;
+
+        let (tx, _rx) = watch::channel(ServingSnapshot::empty());
+        let force = Arc::new(AtomicBool::new(false));
+
+        ServingDaemonModule::declare_lane_wedged(
+            &force,
+            &tx,
+            None,
+            "consecutive REAL generations failed on the live lane",
+        );
+
+        let snap = tx.borrow();
+        // the heal still fires: not-ready, nothing active, relaunch armed
+        assert!(!snap.ready, "a declared wedge must flip the lane not-ready");
+        assert!(snap.active_model.is_none());
+        assert!(
+            force.load(Ordering::Relaxed),
+            "the relaunch flag is what makes this a HEAL — populating the reason must \
+             not change the control path"
+        );
+        // ...and the operator is told WHY, verbatim
+        assert_eq!(
+            snap.degraded_reason.as_deref(),
+            Some("consecutive REAL generations failed on the live lane"),
+            "the wedge reason must reach the snapshot, not only the log"
+        );
+    }
 
     // what this catches (2026-09-01 live): the re-home guard measured only the
     // per-slot window, so a plan that GREW total token-space by adding lanes


### PR DESCRIPTION
## What

Three sites in `serving_daemon` had a failure reason in hand and published
`ServingSnapshot::empty()` — which hardcodes `degraded_reason: None`. They now publish
`ServingSnapshot::degraded(reason)`.

The worst is `declare_lane_wedged`: it **takes the reason as a parameter**, logs it, and
then drops it from the surface.

| Site | Before | After |
|---|---|---|
| `declare_lane_wedged` | `reason: &str` → log only | published on the snapshot |
| model-resolver failure | probe named the unresolvable id, snapshot didn't | names the model id |
| no servable model on disk | silent `empty()` — a fresh install looks broken | names it, points at `models/pull` |

## Why — measured, not inferred

BigMama, core `bb7141f83`, 2026-09-04:

```
03:01:14Z  flipped serving snapshot not-ready — reconcile will kill+respawn the wedged lane (#175 self-heal)
03:01:20Z  serving plan recomputed  lanes=2 resident=1      <- teardown dip
03:01:24Z+ spawn-at-transient guarded: successor floored... <- #363 floor doing its job
03:02:36Z  llama-server spawned, --parallel 3               <- healthy successor
```

Throughout that window `serving/status` reported `ready:false, active_model:null,
lanes:0, degraded_reason:null` — absence with no stated cause, byte-identical to a node
that never had a brain. I hit that state three times in one night and twice got as far as
drafting a defect against a system that was correctly healing itself in front of me.

The pre-flight guard already reserves a `degraded=` field on its probe for exactly this
string — added 2026-08-15 with the note *"every turn of a round waited here for 120s each
while serving/status knew the exact cause and nothing surfaced it"* — and was being handed
`""` on every wait. The field's own doc carries the same lesson from a 2026-07-24 Windows
repro. This is the third time the same defect has been written up; the reason was simply
never wired at these three call sites.

## Safety

`ServingSnapshot::degraded(r)` is `{degraded_reason: Some(r), ..empty()}`, so this is
**additive to the surface only**:

- `ready` stays false, `active_model` stays `None` → `is_live()` unchanged
- `force_relaunch` still arms → the self-heal is untouched
- `wedge_heal_floor` reads `live_ready` (still false) → unchanged
- the `last_healthy_*` latch gates on `ready && window > 0` → unchanged

Checked every consumer of `degraded_reason` — **none branch on `is_some()`**:
`serving_guard.rs:196` only stamps it onto a probe string; `positron_serving_source.rs:316`
clones it into the ViewState. So populating it cannot suppress a respawn.

Existing `a_reported_wedge_flips_the_lane_not_ready` (regression for the 4.1-hour /
172 GB-log outage) asserts `ready == false` and `force_relaunch == true` — both still hold.

## Test

One test, in the existing `mod tests`, asserting **both** halves: the reason reaches the
snapshot verbatim AND the relaunch control path is unchanged — so a future refactor can't
buy the message back by breaking the heal.

```
test modules::serving_daemon::tests::declaring_a_wedge_publishes_the_reason_not_a_bare_empty_snapshot ... ok
test result: ok. 1 passed; 0 failed
```

## Validation status — please let CI be the gate

Locally verified: clean compile, and the new test **passes by name** (not filtered away).
I also read the tests covering the changed path rather than assuming.

**The full `--lib` suite did not complete locally** and I am not claiming it green. This
box is 64.9 GB with the citizens' llama-server resident at 39.3 GB; rustc's codegen peaks
around 7–10 GB, and runs were killed at that peak with no stated cause (`[killed]`) until
I dropped debug info. No test failures appeared before the stop — but "no failures
observed" is not "suite green", so CI should be trusted over me here.

Filed separately from this branch, both measured on the same node:
- `dbebed58` — `serving/status` published `lanes:2` on a `ready` snapshot while argv said `--parallel 3` for ~2.7 min
- `a3d5421a` — the `#363` floor probe announcing a guarded successor on ticks where no process is spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc
