### PR TITLE
fix(serving): GPU offload is always explicit — all layers for a GPU lane, 0 for CPU, never the backend's default

### DIFF
--- a/core/continuum-core/src/inference/lane_args.rs
+++ b/core/continuum-core/src/inference/lane_args.rs
@@ -322,6 +322,11 @@ pub fn base_invocation(
     }
 }
 
+/// "Every layer on the device": llama-server clamps `--n-gpu-layers` to the model's
+/// layer count, so one large value means ALL on every backend. The placement planner
+/// may lower it for a partial fit; it may never omit it.
+pub const ALL_GPU_LAYERS: &str = "999";
+
 /// The per-lane CONDITIONAL surface — flags that depend on the model's artifacts, the
 /// governor's plan, or an operator opt-in. Slice 2 of the extraction.
 ///
@@ -468,10 +473,15 @@ impl LaneInvocation {
         // VRAM a living lane already holds (the Metal decode-time OOM that muted the
         // eval). GPU lanes omit the flag — llama-server offloads all it can by default.
         // [[ServingTarget::placement]] / #59 / #56.
-        if opts.cpu_only {
-            push("--n-gpu-layers".into());
-            push("0".into());
-        }
+        // GPU offload is ALWAYS explicit. Leaving `--n-gpu-layers` to the backend's
+        // default was a Metal-only truth: Metal offloads every layer by default,
+        // CUDA offloads NONE. Measured 2026-09-05 on BigMama's Windows 5090 host
+        // (card 2c33f3f0): a 24B Devstral ran on CPU at 674 MiB of VRAM used while
+        // the GPU sat idle, prefill could not advance, and the wedge self-heal
+        // relaunched the same flags 13 times in 106 minutes. A placement decision
+        // is a number the server is told, never a default it is left to guess.
+        push("--n-gpu-layers".into());
+        push(if opts.cpu_only { "0" } else { ALL_GPU_LAYERS }.into());
         // Device-fit resident-override (#29): source the RESIDENT (non-expert) tensors
         // from the precision-shrunk fit GGUF so the whole resident tier fits VRAM
         // offloaded to GPU, while the primary GGUF streams the experts. The loader hook
@@ -721,10 +731,26 @@ mod tests {
     #[test]
     fn no_options_means_no_conditional_flags() {
         let i = inv(2, 8192).with_options(&LaneOptions::default());
-        for f in ["--cache-type-k", "--flash-attn", "--mmproj", "--spec-type", "--n-gpu-layers"] {
+        for f in ["--cache-type-k", "--flash-attn", "--mmproj", "--spec-type"] {
             assert!(!i.has(f), "{f} must be absent with default options\n{:?}", i.args);
         }
         assert!(i.envs.is_empty(), "no options must mean no environment");
+    }
+
+    // what this catches: GPU offload left to the backend's default. Metal defaults to
+    // every layer, CUDA to none — so "absent" meant "all" on the Macs and "CPU" on
+    // every CUDA host (2026-09-05, BigMama's 5090 idle at 674 MiB while a 24B model
+    // ran on CPU and the lane wedged 13 times). The flag is present on every launch
+    // and its value is the placement decision: all layers for GPU, 0 for CPU.
+    #[test]
+    fn gpu_offload_is_always_explicit_all_for_gpu_zero_for_cpu() {
+        let gpu = inv(2, 8192).with_options(&LaneOptions::default());
+        assert_eq!(gpu.value_of("--n-gpu-layers"), Some(ALL_GPU_LAYERS));
+        let cpu = inv(2, 8192).with_options(&LaneOptions {
+            cpu_only: true,
+            ..LaneOptions::default()
+        });
+        assert_eq!(cpu.value_of("--n-gpu-layers"), Some("0"));
     }
 
     // what this catches: THE 2026-08-20 SPAWN FAILURE, as a test instead of an outage.

--- a/core/continuum-core/src/inference/lane_args.rs
+++ b/core/continuum-core/src/inference/lane_args.rs
@@ -323,8 +323,15 @@ pub fn base_invocation(
 }
 
 /// "Every layer on the device": llama-server clamps `--n-gpu-layers` to the model's
-/// layer count, so one large value means ALL on every backend. The placement planner
-/// may lower it for a partial fit; it may never omit it.
+/// layer count, so one large value means ALL on every backend.
+///
+/// HONEST LIMIT (BigMama's review of #3728): nothing at launch time guarantees a DENSE
+/// artifact fits VRAM — main lanes are always `LanePlacement::Gpu`, and fit is the tier
+/// policy's quant choice plus expert `-ot` for MoE. So a dense model over VRAM on CUDA
+/// now fails at spawn LOUDLY (serving.lane.failed) where the old zero-default ran it
+/// silently on the CPU. Loud is the right side of that trade; the right answer is a
+/// partial count computed from the footprint and the VRAM budget — that is a card, not
+/// this constant. It may be lowered; it may never be omitted.
 pub const ALL_GPU_LAYERS: &str = "999";
 
 /// The per-lane CONDITIONAL surface — flags that depend on the model's artifacts, the


### PR DESCRIPTION
## What
The launch pushed `--n-gpu-layers` only for `cpu_only` and otherwise left offload to the backend's default: every layer on Metal, **none on CUDA**. Every CUDA host ran its citizens on the CPU. BigMama's 5090 (card 2c33f3f0): 674 MiB VRAM used, a 24B model prefilling on CPU from an HDD, prefill 0 of 1245 tokens at 61 s, lane wedged and relaunched with the same flags 13 times in 106 minutes.

## Fix
The flag is on every launch: `ALL_GPU_LAYERS` ("999", clamped by llama-server to the model's layer count) for GPU placement, `0` for CPU placement. A placement decision is a number the server is told, never a default it is left to guess.

## Tests
`cargo test -p continuum-core --lib --features metal,accelerate inference::lane_args` — whole mod, 13 passed. The old test that pinned the flag as absent-by-default (a Metal-only truth) is replaced by `gpu_offload_is_always_explicit_all_for_gpu_zero_for_cpu`.

## Verification owed
BigMama's box is the reproducer: after pulling this, `nvidia-smi` shows the model resident, `/slots` prefill advances, and `serving.health` wedge count stays 0 for 30 min. Half 2 (cold-tier artifact) is card 1435c598 and still bites her until the GGUF is on a hot mount.

Review requested; no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo