### PR TITLE
fix(install): turn Metal OFF explicitly on Intel Macs — omission inherits it

### DIFF
--- a/tools/scripts/install-llama-server.sh
+++ b/tools/scripts/install-llama-server.sh
@@ -74,6 +74,26 @@ declare -a BACKEND_DEFS=()
 if [ "$OS" = "Darwin" ] && [ "$ARCH" = "arm64" ]; then
   BACKEND="metal"
   BACKEND_DEFS=(-DGGML_METAL=ON -DGGML_METAL_EMBED_LIBRARY=ON)
+elif [ "$OS" = "Darwin" ]; then
+  # INTEL MAC: Metal must be turned OFF **explicitly**. Not setting it is not the same
+  # as setting it off — llama.cpp's ggml/CMakeLists.txt does
+  #     if (APPLE) set(GGML_METAL_DEFAULT ON)
+  # and APPLE is true for every macOS, Intel included. So the arm64 branch above reads
+  # as "Metal only on Apple Silicon" while an Intel Mac silently inherited a METAL BUILD
+  # from upstream's default.
+  #
+  # Measured 2026-09-05 (card cd8f0bc7): on this dual-GPU Intel Mac — UHD 630 + Radeon
+  # Pro 560X — that binary HANGS inside Metal init and never returns. `--version` prints
+  # nothing, the process sits in uninterruptible wait, and SIGKILL does not reap it.
+  # DYLD_PRINT_LIBRARIES showed every llama dylib loading fine and then stopping dead on
+  # libggml-metal → AppleIntelKBLGraphicsMTLDriver → AMDMTLBronzeDriver. It cost this
+  # node fifty minutes of downtime, an entire evening of zero hosted citizens, and five
+  # falsified hypotheses before anyone looked at what the process actually LOADS.
+  #
+  # The Rust side already knew: this tier builds with `--features llama/mac-cpu-only`.
+  # Only the llama install was guessing, and it guessed by omission.
+  BACKEND="cpu"
+  BACKEND_DEFS=(-DGGML_METAL=OFF -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=Apple)
 elif [ "$OS" = "Linux" ] && command -v nvcc >/dev/null 2>&1; then
   BACKEND="cuda"
   BACKEND_DEFS=(-DGGML_CUDA=ON)


### PR DESCRIPTION
`llama.cpp/ggml/CMakeLists.txt:94` does:

    if (APPLE)
        set(GGML_METAL_DEFAULT ON)

`APPLE` is true for EVERY macOS, Intel included. This script set
`-DGGML_METAL=ON` only for `Darwin && arm64` and never set it OFF anywhere —
so the arm64 guard READ as "Metal only on Apple Silicon" while an Intel Mac
silently inherited a Metal build from upstream's default. Not setting a flag
is not the same as setting it off.

MEASURED, card cd8f0bc7. On a dual-GPU Intel Mac (UHD 630 + Radeon Pro 560X)
that binary HANGS inside Metal initialisation and never returns:

  - `--version` prints nothing and does not exit
  - the process sits in uninterruptible wait (state U) at 0.0% CPU
  - SIGKILL does not reap it
  - `DYLD_PRINT_LIBRARIES` shows every llama dylib loading cleanly, then
    stopping dead on libggml-metal → AppleIntelKBLGraphicsMTLDriver →
    AMDMTLBronzeDriver

The install script's own verify runs that exact command, unbounded, so the
deploy hung on it: fifty minutes of downtime, a whole evening with zero hosted
citizens, and five falsified hypotheses (quarantine, executable signature,
unsigned dylibs, corrupt artifact, load pressure) before anyone looked at what
the process LOADS rather than why it might be slow.

VERIFIED AFTER THE FIX, not assumed: rebuilt with `-DGGML_METAL=OFF`, `otool`
reports zero Metal dylibs linked, and `--version` exits 0 immediately —
including the installer's own verify step, which now completes first instead
of never.

The Rust side already knew this machine's tier: it builds with
`--features llama/mac-cpu-only`. Only the llama install was guessing, and it
guessed by omission. Accelerate BLAS is added because it is the right CPU
backend on this hardware and upstream defaults it ON for APPLE anyway —
stating it makes the choice ours rather than inherited, which is the whole
point of this change.

THE GENERAL LESSON, and it is M5's from #3728 one layer down: "leaving
--n-gpu-layers to the backend's default was a Metal-only truth". Leaving
GGML_METAL to the default is an arm64-only truth. A placement decision must be
a value we PASS, never a default we LEAVE — because a default is written by
someone who did not know which machine you are.

Sibling: ce58031a, where a Windows/CUDA host gets a server whose CUDA backend
will not load and silently runs CPU-only. Same seam, opposite symptom, each
invisible to the other platform's owner. M5's backend-receipt card (c0bc4027)
is the general fix that would have caught both at install time.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE