### PR TITLE
fix(gpu): bound every detect_* subprocess — an unbounded probe pre-bind hangs the whole boot

### DIFF
--- a/core/continuum-core/src/gpu/memory_manager.rs
+++ b/core/continuum-core/src/gpu/memory_manager.rs
@@ -208,6 +208,26 @@ pub const PRESSURE_CRITICAL: f32 = 0.95;
 /// Number of priority levels (Realtime, Interactive, Background, Batch).
 const PRIORITY_LEVELS: usize = 4;
 
+/// Upper bound on any GPU-detection subprocess (#3732).
+///
+/// These run PRE-BIND — before the IPC socket exists and before the first
+/// module is registered — so the cost of an unbounded one is the whole boot,
+/// not a degraded subsystem. 10 s matches the bound #3719 put on the serving
+/// `--version` probe: long enough that a cold driver query on a loaded host
+/// still answers, short enough that a wedged one does not look like a hang.
+///
+/// NOTE what this does NOT cover: `detect_metal()` is a direct metal-rs call,
+/// not a subprocess, so no timeout can be wrapped around it from here. That
+/// same Metal initialisation is what wedged an Intel Mac uninterruptibly on
+/// 2026-09-05 (card cd8f0bc7) — inside `llama-server`, where the fix was to
+/// stop linking Metal on that hardware. If it ever wedges in-process here, the
+/// bound has to come from the platform gate, not from this constant.
+#[cfg_attr(
+    not(any(feature = "cuda", feature = "vulkan")),
+    allow(dead_code) // only the subprocess backends consume it; macOS exits at detect_metal
+)]
+const GPU_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 pub struct GpuMemoryManager {
     total_vram_bytes: u64,
     gpu_name: String,
@@ -829,17 +849,31 @@ fn detect_cuda() -> Option<(u64, String)> {
     // candle_core doesn't expose device memory directly.
     // Use cudarc if available, otherwise estimate from device properties.
     // For now, we'll try to read from nvidia-smi output.
-    use std::process::Command;
-
-    let output = Command::new("nvidia-smi")
-        .args([
+    //
+    // BOUNDED (#3732): this runs PRE-BIND, six lines after boot.registry_init
+    // and before the first runtime.register, so an unbounded wait here does not
+    // hang a subsystem — it hangs the whole boot, silently, until the watchdog
+    // kills it. A hung `nvidia-smi` is ordinary on Windows (driver mid-recovery,
+    // a WDDM/TCC transition, another process holding the driver, an ECC query on
+    // a busy card). macOS never reaches this branch — detect_metal() answers
+    // from a direct metal-rs call with no subprocess — which is why both Macs on
+    // the grid were structurally unable to reproduce it.
+    let probed = crate::system_resources::bounded_command::probe(
+        "nvidia-smi",
+        &[
             "--query-gpu=memory.total,name",
             "--format=csv,noheader,nounits",
-        ])
-        .output()
-        .ok()?;
+        ],
+        GPU_PROBE_TIMEOUT,
+    );
+    crate::probe!(
+        class = "boot.gpu_detect",
+        backend = "cuda",
+        outcome = probed.outcome(),
+        "pre-bind GPU probe (bounded; an unbounded one hangs the boot)"
+    );
 
-    let stdout = String::from_utf8(output.stdout).ok()?;
+    let stdout = probed.stdout_if_ok()?;
     let line = stdout.lines().next()?;
     let parts: Vec<&str> = line.split(", ").collect();
     if parts.len() < 2 {
@@ -870,15 +904,19 @@ fn detect_cuda() -> Option<(u64, String)> {
 /// anyway, so this number is only used for the budget estimator.
 #[cfg(feature = "vulkan")]
 fn detect_vulkan() -> Option<(u64, String)> {
-    use std::process::Command;
+    // BOUNDED (#3732): same pre-bind path as detect_cuda above, and reached
+    // precisely when nvidia-smi already declined — so on a host whose GPU stack
+    // is unwell this is the SECOND unbounded wait in a row on the boot thread.
+    let probed =
+        crate::system_resources::bounded_command::probe("vulkaninfo", &["--summary"], GPU_PROBE_TIMEOUT);
+    crate::probe!(
+        class = "boot.gpu_detect",
+        backend = "vulkan",
+        outcome = probed.outcome(),
+        "pre-bind GPU probe (bounded; an unbounded one hangs the boot)"
+    );
 
-    let output = Command::new("vulkaninfo").arg("--summary").output().ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let stdout = String::from_utf8(output.stdout).ok()?;
+    let stdout = probed.stdout_if_ok()?;
 
     // vulkaninfo --summary format (excerpt):
     //   Devices:

--- a/core/continuum-core/src/system_resources/bounded_command.rs
+++ b/core/continuum-core/src/system_resources/bounded_command.rs
@@ -1,0 +1,228 @@
+//! A subprocess probe that ALWAYS returns, and always says which way it went.
+//!
+//! Four separate hangs on this grid in one night (2026-09-04/05) were the same
+//! defect: a `std::process::Command::output()` on a boot-critical path with no
+//! upper bound.
+//!
+//!   1. `install-llama-server.sh`'s verify awaited `--version` unbounded — a
+//!      Metal-linked binary on a dual-GPU Intel Mac went to state `U` and
+//!      survived `kill -9`; the node hosted zero citizens for an evening
+//!      (card cd8f0bc7 / #3729).
+//!   2. the serving debug-build gate awaited the same `--version` unbounded
+//!      (#3719).
+//!   3. `deploy-verify`'s ping, unbounded (#3718).
+//!   4. `gpu::memory_manager::detect_gpu()` shelling `nvidia-smi`, then
+//!      `vulkaninfo`, unbounded, PRE-BIND — the only one whose blast radius is
+//!      the entire boot (#3732, this file's reason to exist).
+//!
+//! The first three were patched individually. A fourth point-patch would have
+//! been the wrong shape, so the bound lives here once and the callers ask for
+//! it by name.
+//!
+//! # Why this is synchronous
+//!
+//! [`crate::inference::llama_server`] bounds its probe with
+//! `tokio::time::timeout` + `tokio::process`, which is the right tool INSIDE
+//! the async runtime. `detect_gpu()` runs on the boot thread before the module
+//! loop, where there is no runtime to await on — so this is a plain blocking
+//! poll with a deadline. Same contract, different tier; do not "unify" them by
+//! dragging tokio onto the pre-bind path.
+//!
+//! # Scope: small-output probes only
+//!
+//! Output is piped and read AFTER the child exits, so a child that writes more
+//! than the OS pipe buffer (~64 KiB) before exiting would block itself and be
+//! killed at the deadline rather than deadlocking us. That is the correct
+//! outcome for a probe and the wrong tool for a command that streams. Probes
+//! answer in a line or two — `nvidia-smi --query-gpu=…` prints one, and
+//! `vulkaninfo --summary` a few dozen. Anything that streams belongs on the
+//! async path with a drained reader, not here.
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// How often the deadline is checked while the child runs. Small enough that a
+/// fast probe is not measurably delayed, large enough not to spin a core.
+const POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// What happened to a bounded probe. Every variant is a RECEIPT — there is no
+/// "we don't know", because not knowing is what cost the four hangs above.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Probed {
+    /// The child exited on its own before the deadline. Carries merged stdout.
+    /// `success` is the child's own exit verdict — a program that runs and
+    /// fails (no GPU present, say) is ABSENT, not broken, and the caller
+    /// decides which it cares about.
+    Exited { stdout: String, success: bool },
+    /// The child was still running at the deadline and has been killed.
+    TimedOut,
+    /// The child could not be started at all — not installed, not executable,
+    /// not on PATH. Distinct from `TimedOut` because it means something
+    /// completely different about the host.
+    Unstartable { error: String },
+}
+
+impl Probed {
+    /// The single word that goes in a probe's `outcome` field.
+    pub fn outcome(&self) -> &'static str {
+        match self {
+            Probed::Exited { success: true, .. } => "ok",
+            Probed::Exited { success: false, .. } => "absent",
+            Probed::TimedOut => "timed_out",
+            Probed::Unstartable { .. } => "unstartable",
+        }
+    }
+
+    /// Stdout if the child ran to completion successfully, else `None`. The
+    /// ergonomic path for a caller that only wants the answer and treats every
+    /// failure the same way.
+    pub fn stdout_if_ok(&self) -> Option<&str> {
+        match self {
+            Probed::Exited {
+                stdout,
+                success: true,
+            } => Some(stdout),
+            _ => None,
+        }
+    }
+}
+
+/// Run `program args…`, and return within `timeout` NO MATTER WHAT.
+///
+/// A child still alive at the deadline is killed and reaped. The return value
+/// always names which of the three things happened; there is no path that
+/// blocks forever and none that loses the distinction between "answered no",
+/// "never answered", and "was never there".
+pub fn probe(program: &str, args: &[&str], timeout: Duration) -> Probed {
+    let mut child = match Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return Probed::Unstartable {
+                error: e.to_string(),
+            }
+        }
+    };
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                // The child is gone; reading the pipe to EOF cannot block on it.
+                let stdout = match child.wait_with_output() {
+                    Ok(out) => String::from_utf8_lossy(&out.stdout).into_owned(),
+                    // The child exited and we have its status; losing the bytes
+                    // is a degraded answer, not a hang. Report what we know.
+                    Err(_) => String::new(),
+                };
+                return Probed::Exited {
+                    stdout,
+                    success: status.success(),
+                };
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    // Best-effort: if kill fails the child is already dying, and
+                    // either way WE are no longer waiting on it.
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Probed::TimedOut;
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(e) => {
+                return Probed::Unstartable {
+                    error: e.to_string(),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the whole reason the file exists — a child that never
+    // exits must not hold the caller past the deadline. Regression for #3732;
+    // an unbounded `.output()` here hung a boot for 5.5 minutes until a
+    // watchdog killed it.
+    #[test]
+    #[cfg(unix)]
+    fn a_child_that_never_exits_returns_at_the_deadline() {
+        let started = Instant::now();
+        let outcome = probe("sleep", &["30"], Duration::from_millis(300));
+        let elapsed = started.elapsed();
+
+        assert_eq!(outcome, Probed::TimedOut);
+        assert_eq!(outcome.outcome(), "timed_out");
+        // Generous upper bound: proving it does not wait 30 s, not that the
+        // timer is precise. A machine under load may overshoot the poll.
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "returned after {elapsed:?} — the deadline did not bound the wait"
+        );
+    }
+
+    // what this catches: the bound must not cost correctness on the happy path.
+    // A probe that always timed out would pass the test above.
+    #[test]
+    #[cfg(unix)]
+    fn a_child_that_answers_returns_its_stdout() {
+        let outcome = probe("echo", &["12345, TestGPU"], Duration::from_secs(10));
+        match &outcome {
+            Probed::Exited { stdout, success } => {
+                assert!(*success, "echo should exit 0");
+                assert!(
+                    stdout.contains("12345, TestGPU"),
+                    "stdout was {stdout:?} — the child's answer was lost"
+                );
+            }
+            other => panic!("expected Exited, got {other:?}"),
+        }
+        assert_eq!(outcome.outcome(), "ok");
+        assert_eq!(outcome.stdout_if_ok(), Some("12345, TestGPU\n"));
+    }
+
+    // what this catches: "not installed" collapsing into "timed out". On a host
+    // with no nvidia-smi the boot must learn ABSENT immediately, not wait out
+    // the full timeout — and must not report the same word as a driver hang.
+    #[test]
+    fn a_program_that_does_not_exist_is_unstartable_not_timed_out() {
+        let started = Instant::now();
+        let outcome = probe(
+            "continuum-no-such-binary-3732",
+            &[],
+            Duration::from_secs(30),
+        );
+        assert!(
+            matches!(outcome, Probed::Unstartable { .. }),
+            "expected Unstartable, got {outcome:?}"
+        );
+        assert_eq!(outcome.outcome(), "unstartable");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "a missing binary must fail fast, not burn the timeout"
+        );
+    }
+
+    // what this catches: a program that RUNS and reports failure (no GPU on
+    // this host) being conflated with one that could not run. detect_gpu must
+    // be able to tell "asked, answered no" from "never asked".
+    #[test]
+    #[cfg(unix)]
+    fn a_child_that_exits_nonzero_is_absent_not_ok() {
+        let outcome = probe("false", &[], Duration::from_secs(10));
+        assert_eq!(outcome.outcome(), "absent");
+        assert_eq!(
+            outcome.stdout_if_ok(),
+            None,
+            "a failed probe must not hand its caller an answer"
+        );
+    }
+}

--- a/core/continuum-core/src/system_resources/mod.rs
+++ b/core/continuum-core/src/system_resources/mod.rs
@@ -11,6 +11,7 @@
 //!
 //! Uses the `sysinfo` crate for cross-platform (macOS/Linux/Windows) monitoring.
 
+pub mod bounded_command;
 pub mod concurrency;
 pub mod disk_eviction;
 pub mod disk_pressure;


### PR DESCRIPTION
Closes #3732.

## The defect

`GpuMemoryManager::detect()` runs in `ipc/mod.rs::start_server` six lines after the `boot.registry_init` probe and **before the first `runtime.register`** — pre-bind, before the IPC socket exists and before the module loop. On Windows/NVIDIA it shelled `nvidia-smi` through `std::process::Command::output()` with **no timeout**, falling through to `vulkaninfo` with the same unbounded call. Grep of that file: zero `timeout`, zero `probe!`.

A hung driver query therefore does not degrade a subsystem — it hangs the **entire boot**, emitting nothing, until a wall-clock watchdog kills a core that was never going to return.

**Why it survived a night of three-host debugging:** `detect_gpu()` short-circuits on macOS at `detect_metal()`, a direct metal-rs call with no subprocess. Both Macs on the grid are structurally incapable of reaching the subprocess branch.

## Fourth site of one defect

1. `install-llama-server.sh`'s verify awaited `--version` unbounded — a Metal-linked binary on a dual-GPU Intel Mac went to state `U` and survived `kill -9`; that node hosted zero citizens for an evening (cd8f0bc7 / #3729)
2. the serving debug-build gate awaited the same `--version` unbounded (#3719)
3. `deploy-verify`'s ping, unbounded (#3718)
4. **this one — the only one whose blast radius is the whole boot**

The first three were patched individually. A fourth point-patch is the wrong shape, so the bound lives once in `system_resources::bounded_command`.

## What the helper adds beyond a timeout

Four receipts where `.output().ok()?` had two:

| Outcome | Meaning |
|---|---|
| `ok` | ran, answered |
| `absent` | ran, said no (no GPU here) |
| `timed_out` | never answered — killed at the deadline |
| `unstartable` | was never there (not installed / not on PATH) |

"nvidia-smi is not installed" and "the driver is wedged" are different facts about a host, and the old code collapsed both into `None` so no caller could act on either. Each site now emits `boot.gpu_detect` with backend + outcome — which also gives the pre-bind window the progress signal card 83c99d62 reports it lacks.

## Synchronous on purpose

#3719 bounds its probe with `tokio::time::timeout` + `tokio::process`, which is correct **inside** the runtime. `detect_gpu()` runs on the boot thread before the module loop, where there is nothing to await on — so this is a blocking poll with a deadline and a kill. Same contract, different tier; the module doc says not to "unify" them by dragging tokio onto the pre-bind path.

Per [CONCURRENCY-STYLE-GUIDE.md](docs/architecture/CONCURRENCY-STYLE-GUIDE.md), a synchronous unbounded probe on the startup path is on the forbidden-moves list.

## ⚠️ Verification limits — please read before approving

`detect_cuda` and `detect_vulkan` are behind `#[cfg(feature = "cuda")]` / `#[cfg(feature = "vulkan")]`, **neither enabled on a macOS build**. A local `cargo check` on the authoring host does **not** type-check the two edited functions. **CI and a reviewer's box are the first real check on them.** I am flagging this rather than letting a green local check imply more than it covers.

The helper and its four tests are not feature-gated.

Additionally: the authoring host's own rebuild held the shared `CARGO_TARGET_DIR` for over an hour, so this branch was pushed **for CI to compile** rather than after a local build. It must not merge on anything but green.

## Tests

Each with a `// what this catches:` line:
- a child that never exits returns at the deadline — **the regression**
- a child that answers still returns its stdout (a helper that always timed out would pass the above)
- a missing binary is `unstartable` and fails fast rather than burning the timeout
- a child that exits non-zero is `absent`, not `ok`

## Not covered

`detect_metal()` is a direct metal-rs call, not a subprocess, so no timeout can wrap it from here. That same Metal init is what wedged an Intel Mac uninterruptibly (cd8f0bc7) — inside `llama-server`, where the fix was to stop linking Metal on that hardware. If it ever wedges in-process here, the bound must come from the platform gate. Documented at the constant.

Follow-up (not in this PR): a source ratchet failing CI on a bare `.output()` outside the helper. There are 99 `.output()` call sites in continuum-core; that needs its own baseline and its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE
