### PR TITLE
probe(boot): the Windows TCP bind emits the same post_init_to_bind and bind rows as the Unix socket

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -3972,7 +3972,24 @@ pub fn start_server(
             .filter(|p| *p > 0)
             .unwrap_or(9100);
         let bind_addr = format!("{bind_host}:{port}");
+        // The same two phase rows the Unix path emits around ITS bind. They were
+        // `#[cfg(unix)]`-gated with the Unix bind (the windows-msvc fix on #3714),
+        // so on Windows the stretch after load_state — where BigMama's boot spent
+        // 108 unattributed seconds and used to die — had no row at all (2026-09-05).
+        crate::probe!(
+            class = "boot.phase",
+            phase = "post_init_to_bind",
+            ms = phase_started.elapsed().as_millis() as u64,
+            "pre-bind phase (Windows TCP loopback)"
+        );
+        let bind_started = std::time::Instant::now();
         let listener = TcpListener::bind(&bind_addr)?;
+        crate::probe!(
+            class = "boot.phase",
+            phase = "bind",
+            ms = bind_started.elapsed().as_millis() as u64,
+            "the bind call itself — the TCP listener exists after this"
+        );
         log_info!(
             "ipc",
             "server",


### PR DESCRIPTION
My cfg gate on #3714 left Windows without the two bind-side phase rows; BigMama's a02fb6cf1 boot shows 108 s unattributed after load_state. The Windows TCP bind block now emits `post_init_to_bind` and `bind` exactly as the Unix block does. Not compilable on a Mac (cfg(windows)); the windows-msvc check compiles it and BigMama's next boot is the live receipt.

Review requested; no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo