### PR TITLE
fix(install): the installer survives an ordinary current machine — no Docker, no storage key, no wmic

### DIFF
--- a/tools/scripts/lib/install-common.sh
+++ b/tools/scripts/lib/install-common.sh
@@ -215,7 +215,13 @@ mod_cold_storage() {
   local config_env="$HOME/.continuum/config.env"
   # Already routed to a present path? re-export + skip (idempotent).
   if [ -f "$config_env" ]; then
-    local existing; existing="$(grep -E '^[[:space:]]*CONTINUUM_STORAGE_PATH[[:space:]]*=' "$config_env" 2>/dev/null | head -1 | cut -d= -f2- | xargs)"
+    # `|| true`: `grep` exits 1 when the key is simply not there yet, which is the
+    # ordinary state of a config.env an earlier install step wrote. Under
+    # install.sh's `set -eo pipefail` (since 2026-07-05) that aborts the install
+    # one line before the `[ -n "$existing" ]` test written for exactly this
+    # empty case. Reproduced 2026-09-05 (BigMama): exit 1 on a config.env with
+    # no storage-path line.
+    local existing; existing="$(grep -E '^[[:space:]]*CONTINUUM_STORAGE_PATH[[:space:]]*=' "$config_env" 2>/dev/null | head -1 | cut -d= -f2- | xargs || true)"
     if [ -n "$existing" ] && [ -d "$(dirname "$existing")" ]; then
       _cold_export "$existing"
       module_skip "cold-storage" "already routed to $existing (edit ~/.continuum/config.env to change)"
@@ -285,7 +291,13 @@ mod_docker_wsl_integration() {
 
   local distro="${WSL_DISTRO_NAME:-$(grep '^NAME=' /etc/os-release | cut -d\" -f2 | head -1)}"
   local settings
-  settings=$(ls /mnt/c/Users/*/AppData/Roaming/Docker/settings-store.json 2>/dev/null | head -1)
+  # `|| true`: FINDING NOTHING IS THE NORMAL OUTCOME when Docker Desktop is not
+  # installed for the Windows user, and `ls` exits non-zero then. install.sh has
+  # run `set -eo pipefail` since d9cd95967 (2026-07-05), so without this guard
+  # the script dies HERE — one line before the `[ -z "$settings" ]` test below,
+  # which exists precisely to explain that case to the user. Reproduced
+  # 2026-09-05 (BigMama): exit 2, and the module_fail message never printed.
+  settings=$(ls /mnt/c/Users/*/AppData/Roaming/Docker/settings-store.json 2>/dev/null | head -1 || true)
   if [ -z "$settings" ] || [ ! -w "$settings" ]; then
     module_fail "docker-wsl-integration" "Cannot locate writable Docker Desktop settings-store.json. Is Docker Desktop installed for the Windows user?"
   fi
@@ -572,13 +584,32 @@ ic_detect_hardware() {
       # Git Bash inherits PowerShell's wmic / Get-CimInstance. wmic is the
       # most portable across Windows versions (Win10 + Win11). Total physical
       # memory in bytes → MiB.
+      # WMIC WAS REMOVED IN WINDOWS 11 24H2, so `command -v wmic` is ABSENT on a
+      # current Windows box and the old else-branch reported IC_RAM_MIB=0 on a
+      # machine with 64914 MiB (measured on 26200, BigMama 2026-09-05). Every
+      # RAM-based tier decision downstream was then made on that zero. wmic
+      # stays first because it is still present and fast on Win10 and on Win11
+      # before 24H2; PowerShell CIM is the fallback, not the replacement.
+      local total_bytes=""
       if command -v wmic >/dev/null 2>&1; then
-        local total_bytes
         total_bytes="$(wmic computersystem get TotalPhysicalMemory /value 2>/dev/null | tr -d '\r' | awk -F= '/TotalPhysicalMemory=/{print $2}')"
-        IC_RAM_MIB=$(( ${total_bytes:-0} / 1048576 ))
-      else
-        IC_RAM_MIB=0
+      elif command -v powershell.exe >/dev/null 2>&1; then
+        # `|| true`: a PowerShell that is absent or refuses leaves us without a
+        # reading, which is not a reason to abort the install — install.sh runs
+        # `set -eo pipefail`, so an unguarded failing pipeline would do exactly
+        # that. The case below is what handles the missing reading.
+        total_bytes="$(powershell.exe -NoProfile -Command '(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory' 2>/dev/null | tr -d '[:space:]' || true)"
       fi
+      # Empty or non-numeric means WE COULD NOT LOOK, which is a different fact
+      # from "this machine has no RAM". IC_RAM_MIB has one representation for
+      # both, so the difference has to be said out loud here or it is lost.
+      case "$total_bytes" in
+        ''|*[!0-9]*)
+          warn "could not read total physical memory on this Windows build — RAM-based tiering will be conservative"
+          IC_RAM_MIB=0
+          ;;
+        *) IC_RAM_MIB=$(( total_bytes / 1048576 )) ;;
+      esac
       ;;
     *)
       IC_RAM_MIB=0


### PR DESCRIPTION
Three defects on the **fresh-install path** (`install.sh` → `lib/install-common.sh`). All three fire on an ordinary machine that a stranger would install onto; none fires on the boxes the three of us have been running all night, which is why they survived.

## Not a #3736 regression

`tools/scripts/install.sh` line 26 has carried `set -eo pipefail` since **d9cd95967 (2026-07-05)** and sources this library into that shell. So sites 1 and 2 have been live for **two months**, and #3738's revert of pipefail from the `set -e` scripts does not reach them — `install-common.sh` is a sourced library that sets no `-e` of its own, and its caller supplies it.

That also makes install.sh the useful counter-example for the ratchet: pipefail is not the hazard, an **unaudited site** is.

## The three

| # | Site | Trigger on a fresh machine | Measured |
|---|---|---|---|
| 1 | `mod_cold_storage` | `config.env` exists but has no `CONTINUUM_STORAGE_PATH` line — `grep` exits 1 | **exit 1** |
| 2 | `mod_docker_wsl` | Docker Desktop not installed for the Windows user — `ls` exits 2 | **exit 2** |
| 3 | `ic_detect_hardware` RAM arm | `wmic` removed in Windows 11 24H2 → `IC_RAM_MIB=0` on a 64 GB box | **0 vs 64914 MiB** |

1 and 2 share one shape: **a pipeline whose empty result the very next line was already written to handle.** In #2 that next line is a `module_fail` that names the exact cause ("Is Docker Desktop installed for the Windows user?") — so the installer died one line before it could explain itself. Guarded with `|| true` plus a comment naming the already-handled empty case, per the burn-down rule: read a piped substitution *with its next line*, then either guard it with a stated reason or let it fail honestly.

3 is a different class — not a crash, a **confident wrong number**. The replaced comment called wmic "the most portable across Windows versions (Win10 + Win11)", which was true when written and is backwards now. wmic stays first (still present and fast on Win10 and pre-24H2 Win11); PowerShell CIM is the fallback. A non-numeric reading now `warn`s instead of silently becoming 0, because *"we could not look"* is a different fact from *"this machine has no RAM"* and `IC_RAM_MIB` has one representation for both.

## Verification

Windows 11 26200 / Git Bash, old vs new line through the same harness:

```
cold-storage   old exit 1   ->  new exit 0
docker         old exit 2   ->  new exit 0
RAM arm        old IC_RAM_MIB=0  ->  new IC_RAM_MIB=64914  (63 GB)
bash -n        OK
```

Six further candidates I flagged in the same file **did not survive inspection and are not in this diff** — the wmic/nvidia-smi/vulkaninfo probes all sit behind `command -v X` *and* an `X … >/dev/null` success check, so the command exists and has already succeeded before the substitution runs. I read those lines before I read their guards.

## Caveat on validation

This checkout has **no `.git/hooks/pre-commit` installed**, so the shared hook did not run on this commit. Not bypassed with `--no-verify` — it simply is not wired here, which I am reporting separately. Treat CI, not my local commit, as the gate.

Follow-up to #3736 / #3738; independent of both.