### PR TITLE
fix(serving): the backend receipt honours a CPU placement — a GPU-less server on a CPU-plan host is by plan, never a mis-install

### DIFF
--- a/core/continuum-core/src/inference/backend_receipt.rs
+++ b/core/continuum-core/src/inference/backend_receipt.rs
@@ -93,6 +93,12 @@ pub enum BackendVerdict {
     /// The device probe did not answer within its bound (backend init hangs): serve on
     /// the CPU and say why — never block the launch, never pretend it is on the GPU.
     ProbeHung,
+    /// The host's serving plan places lanes on the CPU on purpose (an Intel-GPU Mac whose
+    /// server is built with Metal OFF, #3729; Joel's ruling in persona/response.rs: CPU-only
+    /// adapters serve their own personas). A GPU-less server is CORRECT here, never a
+    /// mis-install. The first #3730 refused IntelMac's node because the receipt carried no
+    /// host fact at all (BigMama's read, 2026-09-05).
+    CpuByPlan,
 }
 
 impl BackendVerdict {
@@ -104,12 +110,22 @@ impl BackendVerdict {
             BackendVerdict::Gpu { .. } => "gpu",
             BackendVerdict::Refused { .. } => "refused",
             BackendVerdict::ProbeHung => "cpu",
+            BackendVerdict::CpuByPlan => "cpu",
         }
     }
 }
 
-/// `None` = the probe timed out (no transcript to read).
-pub fn backend_verdict(bin: &str, receipt: Option<&BackendReceipt>) -> BackendVerdict {
+/// `None` = the probe timed out (no transcript to read). `cpu_by_plan` is the lane's
+/// placement decision: when the plan puts this lane on the CPU, the receipt records the
+/// backend and never refuses — the decision was made upstream, by the host's config.
+pub fn backend_verdict(
+    bin: &str,
+    receipt: Option<&BackendReceipt>,
+    cpu_by_plan: bool,
+) -> BackendVerdict {
+    if cpu_by_plan {
+        return BackendVerdict::CpuByPlan;
+    }
     let Some(r) = receipt else {
         return BackendVerdict::ProbeHung;
     };
@@ -144,7 +160,7 @@ mod tests {
         let r = parse_list_devices(m5);
         assert_eq!(r.gpu_devices.len(), 1, "BLAS is not a device: {r:?}");
         assert!(r.load_errors.is_empty());
-        let v = backend_verdict("llama-server", Some(&r));
+        let v = backend_verdict("llama-server", Some(&r), false);
         assert!(matches!(v, BackendVerdict::Gpu { ref device } if device.starts_with("MTL0")));
         assert_eq!(v.backend_label(), "metal");
 
@@ -153,7 +169,7 @@ mod tests {
         let r = parse_list_devices(bigmama);
         assert!(r.gpu_devices.is_empty());
         assert_eq!(r.load_errors.len(), 2);
-        match backend_verdict("llama-server.exe", Some(&r)) {
+        match backend_verdict("llama-server.exe", Some(&r), false) {
             BackendVerdict::Refused { reason } => {
                 assert!(reason.contains("ggml-cuda.dll"), "the refusal quotes the server's own error: {reason}");
                 assert!(reason.contains("GGML_CUDA=ON"));
@@ -167,8 +183,8 @@ mod tests {
     #[test]
     fn cuda_line_is_cuda_and_a_hung_probe_degrades_to_cpu() {
         let r = parse_list_devices("Available devices:\n  CUDA0: NVIDIA GeForce RTX 5090 (32607 MiB, 31900 MiB free)\n");
-        assert_eq!(backend_verdict("x", Some(&r)).backend_label(), "cuda");
-        let hung = backend_verdict("x", None);
+        assert_eq!(backend_verdict("x", Some(&r), false).backend_label(), "cuda");
+        let hung = backend_verdict("x", None, false);
         assert_eq!(hung, BackendVerdict::ProbeHung);
         assert_eq!(hung.backend_label(), "cpu");
     }
@@ -185,6 +201,16 @@ mod tests {
     #[test]
     fn a_silent_cpu_only_build_is_refused_too() {
         let r = parse_list_devices("Available devices:\n  CPU: (0 MiB, 0 MiB free)\n");
-        assert!(matches!(backend_verdict("x", Some(&r)), BackendVerdict::Refused { .. }));
+        assert!(matches!(backend_verdict("x", Some(&r), false), BackendVerdict::Refused { .. }));
+    }
+    // what this catches: a host whose plan places lanes on the CPU (Metal OFF on an
+    // Intel-GPU Mac, #3729) must never be refused for a GPU-less server — the first
+    // #3730 refused IntelMac's node on exactly this transcript.
+    #[test]
+    fn a_cpu_placement_accepts_a_gpu_less_server_by_plan() {
+        let r = parse_list_devices("Available devices:\n  CPU: (0 MiB, 0 MiB free)\n  BLAS: Accelerate (0 MiB, 0 MiB free)\n");
+        assert_eq!(backend_verdict("llama-server", Some(&r), true), BackendVerdict::CpuByPlan);
+        assert_eq!(backend_verdict("llama-server", None, true), BackendVerdict::CpuByPlan);
+        assert_eq!(backend_verdict("llama-server", Some(&r), true).backend_label(), "cpu");
     }
 }

--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -568,6 +568,21 @@ pub enum LanePlacement {
     Cpu,
 }
 
+/// Where the host's serving plan places MAIN lanes. `CONTINUUM_SERVING_PLACEMENT=cpu` in
+/// config.env (the layer the installer writes — #3729's Intel-Mac arm builds the server
+/// with Metal OFF and records the decision here) pins every main lane to the CPU; anything
+/// else is the GPU. A decision, read from config, never a raw env var (concurrency guide).
+pub fn main_lane_placement() -> LanePlacement {
+    placement_from_config(crate::config_env::read("CONTINUUM_SERVING_PLACEMENT").as_deref())
+}
+
+pub fn placement_from_config(value: Option<&str>) -> LanePlacement {
+    match value.map(|v| v.trim().to_ascii_lowercase()) {
+        Some(v) if v == "cpu" => LanePlacement::Cpu,
+        _ => LanePlacement::Gpu,
+    }
+}
+
 /// One LoRA genome layer to load into the serving catalog at spawn. The `path`
 /// is llama.cpp's load identity (what `--lora` takes and what the per-request
 /// resolver matches against); the `alias` is ours, for logs and the snapshot.
@@ -3085,8 +3100,12 @@ impl LlamaServerControl for LlamaServerProcess {
                 None
             }
         };
-        let verdict =
-            crate::inference::backend_receipt::backend_verdict(&self.bin, receipt.as_ref());
+        let cpu_by_plan = target.placement == LanePlacement::Cpu;
+        let verdict = crate::inference::backend_receipt::backend_verdict(
+            &self.bin,
+            receipt.as_ref(),
+            cpu_by_plan,
+        );
         crate::probe!(
             class = "serving.backend_receipt",
             bin = %self.bin,
@@ -3112,7 +3131,8 @@ impl LlamaServerControl for LlamaServerProcess {
                 // Last flag wins in llama-server's parser: pin the lane to the CPU.
                 cmd.arg("--n-gpu-layers").arg("0");
             }
-            crate::inference::backend_receipt::BackendVerdict::Gpu { .. } => {}
+            crate::inference::backend_receipt::BackendVerdict::Gpu { .. }
+            | crate::inference::backend_receipt::BackendVerdict::CpuByPlan => {}
         }
         let mut child = cmd
             .stdout(Stdio::null())
@@ -4583,5 +4603,14 @@ mod tests {
             elapsed < PROBE_TIMEOUT + Duration::from_secs(4),
             "probe must be bounded by PROBE_TIMEOUT, took {elapsed:?}"
         );
+    }
+    // what this catches: the host's CPU placement decision must be one config key, read
+    // once, defaulting to the GPU — never a raw env var and never a spelling guess.
+    #[test]
+    fn main_lane_placement_reads_the_config_decision() {
+        assert_eq!(placement_from_config(Some("cpu")), LanePlacement::Cpu);
+        assert_eq!(placement_from_config(Some(" CPU ")), LanePlacement::Cpu);
+        assert_eq!(placement_from_config(Some("gpu")), LanePlacement::Gpu);
+        assert_eq!(placement_from_config(None), LanePlacement::Gpu);
     }
 }

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -2142,7 +2142,7 @@ impl ServingDaemonModule {
             adapters: desired_adapters,
             // The living persona lane: GPU-resident for throughput (every
             // offloadable layer). [[LanePlacement]].
-            placement: crate::inference::llama_server::LanePlacement::Gpu,
+            placement: crate::inference::llama_server::main_lane_placement(),
             expert_placement,
             resident_override,
             // The MAIN persona lane — the withhold rule's actual subject.

--- a/tools/scripts/install-llama-server.sh
+++ b/tools/scripts/install-llama-server.sh
@@ -94,6 +94,33 @@ fi
 # idempotency check and every downstream use.
 INSTALL_BIN="${INSTALL_BIN}${EXE}"
 
+# RECORD THE PLACEMENT DECISION WHERE THE CORE READS IT. The core's main lanes read
+# CONTINUUM_SERVING_PLACEMENT from ~/.continuum/config.env (#3740): "cpu" pins every lane
+# to the CPU and the backend receipt accepts a GPU-less server BY PLAN; anything else is
+# the GPU and the receipt refuses a server that loads no GPU backend. The decision is
+# made HERE, once, next to the build that implements it — an Intel Mac (Metal OFF, #3729)
+# is the case: BigMama's review of #3740 — "a fix that needs a human to edit a file is
+# not a fix"; IntelMac had written the key by hand an hour earlier and could not see it.
+# Replace-or-append so re-running install is idempotent and other keys survive.
+config_env_upsert() {
+  local key="$1" value="$2" file="$HOME/.continuum/config.env"
+  mkdir -p "$HOME/.continuum"
+  touch "$file"
+  if grep -qE "^[[:space:]]*${key}[[:space:]]*=" "$file"; then
+    local tmp; tmp="$(mktemp)"
+    sed -E "s|^[[:space:]]*${key}[[:space:]]*=.*|${key}=${value}|" "$file" > "$tmp" && mv "$tmp" "$file"
+  else
+    printf '%s=%s\n' "$key" "$value" >> "$file"
+  fi
+}
+if [ "$BACKEND" = "cpu" ]; then
+  config_env_upsert CONTINUUM_SERVING_PLACEMENT cpu
+  echo "serving placement: cpu (backend=$BACKEND) — recorded in ~/.continuum/config.env"
+else
+  config_env_upsert CONTINUUM_SERVING_PLACEMENT gpu
+  echo "serving placement: gpu (backend=$BACKEND) — recorded in ~/.continuum/config.env"
+fi
+
 STAMP_WANT="$SUBMODULE_HEAD:$BACKEND"
 
 # ── idempotency ──────────────────────────────────────────────────────


### PR DESCRIPTION
The first #3730 refused IntelMac's Intel-GPU Mac, whose server is deliberately built with Metal OFF (#3729): the receipt had no host fact and treated every answered-no-GPU as a mis-install. Joel's ruling in `persona/response.rs` (CPU-only adapters serve their own personas) settles the direction.

- `main_lane_placement()` reads `CONTINUUM_SERVING_PLACEMENT=cpu` from config.env (the installer's layer; #3729's Intel arm should write it beside the Metal-OFF build) → `LanePlacement::Cpu`; default GPU.
- `backend_verdict(bin, receipt, cpu_by_plan)` returns `CpuByPlan` (backend=cpu, no refusal) for a CPU lane; GPU lanes keep refusing a GPU-less server (BigMama's case).

Tests: `inference::backend_receipt` 5/5, `inference::llama_server` 40/40 (whole mods).

Installer half (IntelMac): write the key in #3729's Intel arm. Until both land, IntelMac can put the key in config.env by hand as the one-line override.

Review requested; no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo