### PR TITLE
revert(prepush): the ESLint exit-status guard was inert — remove it, name why

### DIFF
--- a/tools/scripts/git-prepush.sh
+++ b/tools/scripts/git-prepush.sh
@@ -118,35 +118,28 @@ elif [ -x "$ESLINT_RATCHET" ]; then
     fi
 else
     BASELINE=$(cat "$BASELINE_FILE" | tr -d '[:space:]')
-    # Card aad30dee: COUNT the errors, but only after establishing that eslint
-    # actually RAN. The previous form piped eslint's merged stdout+stderr into
-    # `grep -cE "error\s+" || true` and used the count directly — so a linter
-    # that CRASHED (missing module, bad config, wrong cwd) emitted diagnostics
-    # the regex does not match ("Error: Cannot find module" has a capital E and
-    # no trailing whitespace class), yielding 0. Zero is `-le` any baseline, so
-    # a linter that never ran printed a green checkmark and let the push
-    # through. `|| true` guaranteed the pipeline could not fail on its own, and
-    # `set -e` cannot see through a pipe — the script LOOKED defended.
+    # THIS BRANCH IS UNREACHABLE, and saying so is the point of this comment.
     #
-    # eslint's exit codes: 0 = clean, 1 = lint errors found, 2 = eslint itself
-    # failed. Only 0 and 1 mean "the linter ran and has an opinion"; anything
-    # else is a broken checker and must be loud, never a silent zero.
-    # `|| LINT_RC=$?` is load-bearing, not defensive noise: `set -e` (line 5)
-    # aborts on a failing command substitution, and eslint exits 1 for the
-    # ORDINARY case of "found lint errors". Without this the script would die
-    # on the exact path it exists to report. The old `|| true` was doing this
-    # job too — it just discarded the code we now need.
-    LINT_RC=0
-    LINT_RAW=$(cd "$SRC_DIR" && npx eslint './**/*.ts' --max-warnings 0 --quiet 2>&1) || LINT_RC=$?
-    if [ "$LINT_RC" -gt 1 ]; then
-        echo "❌ ESLint FAILED TO RUN (exit $LINT_RC) — this is a broken checker, not a clean tree."
-        echo "   Refusing to report a lint result. Its output:"
-        echo "$LINT_RAW" | tail -20 | sed 's/^/      /'
-        FAILED=1
-        CURRENT=""
-    else
-        CURRENT=$(printf '%s\n' "$LINT_RAW" | grep -cE "error\s+" || true)
-    fi
+    # It runs only when scripts/ratchets/check-eslint-baseline.sh is NOT
+    # executable, and that file is committed executable (-rwxr-xr-x), so the
+    # `elif` above always wins. The whole Node phase is unreachable a second
+    # time over: `require_node_deps` (line 75) gates on `$SRC_DIR/node_modules`
+    # where SRC_DIR is `$REPO_ROOT/src`, a directory deleted in July by
+    # e46d968c5 when the Node shell moved to legacy/src.
+    #
+    # Card aad30dee briefly replaced the counting here with an exit-status check
+    # (eslint 0 = clean, 1 = found errors, >=2 = the linter itself failed), on
+    # the theory that a CRASHED linter yielded 0 and printed a green checkmark.
+    # The reasoning was right and the placement was wrong three ways: the branch
+    # cannot run, fixing SRC_DIR would not make it run, and the path that DOES
+    # run — check-eslint-baseline.sh:124 — already defends the case:
+    #
+    #     if [[ "$ESLINT_STATUS" -ne 0 && "$CURRENT" -eq 0 ]]; then … exit 2
+    #
+    # That change is reverted rather than left in place, because inert code that
+    # LOOKS like a defence is worse than no code: the next reader assumes the
+    # case is handled here and stops looking for where it actually is.
+    CURRENT=$(cd "$SRC_DIR" && npx eslint './**/*.ts' --max-warnings 0 --quiet 2>&1 | grep -cE "error\s+" || true)
 fi
 if [ -n "${CURRENT:-}" ]; then
     LINT_DUR=$(( $(date +%s) - LINT_START ))


### PR DESCRIPTION
Card aad30dee added an ESLint exit-status check to `git-prepush.sh` (0 = clean, 1 = found errors, ≥2 = the linter itself failed), on the theory that a **crashed** linter yielded a count of `0`, compared `0 -le BASELINE`, and printed a green checkmark.

The reasoning was right. The placement was wrong three separate ways — and I argued from this change repeatedly as my clean example of a *real* fix.

## Why it was inert

1. **The branch cannot run.** It is the `else` of `elif [ -x "$ESLINT_RATCHET" ]`, and `scripts/ratchets/check-eslint-baseline.sh` is committed executable (`-rwxr-xr-x`). The `elif` always wins.
2. **The whole Node phase cannot run.** `require_node_deps` (line 75) gates on `$SRC_DIR/node_modules`, and `SRC_DIR` is `$REPO_ROOT/src` — deleted in July by e46d968c5 when the Node shell moved to `legacy/src`. Repointing `SRC_DIR` would *not* resurrect the branch, because of (1).
3. **The bug is already fixed where it matters.** `check-eslint-baseline.sh:124`, the path that actually executes:

```bash
if [[ "$ESLINT_STATUS" -ne 0 && "$CURRENT" -eq 0 ]]; then … exit 2
```

The same pairing — non-zero status **and** a zero count — more compactly, in the live file. Someone had already thought it through.

## Why revert rather than leave it

Inert code that *looks* like a defence is worse than no code. The next reader finds a careful exit-status check with a long comment, concludes the case is handled here, and stops looking for where it actually is.

The comment left in its place states that the branch is unreachable and points at the file that really defends it — the only thing this location can usefully contribute.

## What I got wrong

I read the file top to bottom, found a genuine defect in the code in front of me, and never asked whether anything *called* it. The answer was two lines above my edit.

Found by ce8b9074, who also read `check-eslint-baseline.sh` and answered the question I left open — against the outcome that would have saved the change.

Card aad30dee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE
