### PR TITLE
probe(boot): boot.stretch step marks across the persona-host setup (the 14 s pinned on ai_provider)

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -2270,6 +2270,24 @@ pub fn start_server(
         tokio::sync::oneshot::Sender<Arc<crate::runtime::CommandExecutor>>,
     > = None;
 
+    // boot.stretch: the stretch between rag_inspect's registration and
+    // ai_provider's carried 14 s on the M5 (boot.construct attributed it to
+    // ai_provider because attribution is per REGISTER and nothing registers in
+    // between). Step marks name which part of the persona-host setup owns it.
+    let mut stretch_mark = {
+        let mut last = std::time::Instant::now();
+        move |step: &'static str| {
+            let now = std::time::Instant::now();
+            crate::probe!(
+                class = "boot.stretch",
+                stretch = "persona_host_setup",
+                step = step,
+                ms = now.duration_since(last).as_millis() as u64,
+                "pre-bind stretch step"
+            );
+            last = now;
+        }
+    };
     if let Some(daemon_socket) = persona_bootstrap_deps {
         // Grid capacity gossip (#56 step 4): this node offers its live capacity to
         // the grid on the module tick and hears every peer's offers (its own echo
@@ -2622,6 +2640,8 @@ pub fn start_server(
                 }
             }
         };
+        stretch_mark("resident_roles_and_overlay");
+        stretch_mark("before_supervisor");
         let supervisor = crate::persona::host::PersonaSpawnSupervisor::new(
             crate::persona::spawner_module::PersonaSpawnerModule::new(hw_cap, tier_cat)
                 .with_citizens(resident_roles)
@@ -3048,6 +3068,7 @@ pub fn start_server(
                 bound = Some(active);
             }
         });
+        stretch_mark("end_of_persona_host_block");
     }
 
     // AIProviderModule: Unified AI provider for cloud and local inference


### PR DESCRIPTION
boot.construct charges the whole persona-host setup block to `ai_provider` (nothing registers in between): 14,068 ms on the M5, 40 s+ on BigMama's host. Three `boot.stretch` marks (resident_roles_and_overlay, before_supervisor, end_of_persona_host_block) with ms since the previous mark. `cargo check` green; no behaviour change; receipt = the next boot's rows.

Review requested; no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo