### PR TITLE
fix(gpu): bound the remaining driver probes — six sites, not the one #3733 fixed

### DIFF
--- a/core/continuum-core/src/gpu/backends/nvidia.rs
+++ b/core/continuum-core/src/gpu/backends/nvidia.rs
@@ -202,6 +202,15 @@ fn sum_process_bytes_for_pid(stdout: &str, our_pid: u32) -> u64 {
 
 // ─── subprocess shells (the only impure surface) ───────────────────────
 
+/// Upper bound on any `nvidia-smi` invocation from this monitor (#3733's class).
+///
+/// Matches `gpu::memory_manager::GPU_PROBE_TIMEOUT` and #3719's serving probe
+/// deliberately: one number for "how long may a driver query take before we
+/// stop waiting on it", so a host that is slow in one place is not judged by
+/// three different clocks. Long enough for a cold driver query on a loaded box,
+/// short enough that a wedged one does not look like a hang.
+const NVIDIA_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 const QUERY_GPU_ARGS: [&str; 2] = [
     "--query-gpu=memory.free,memory.total,utilization.gpu,temperature.gpu,power.draw",
     "--format=csv,noheader,nounits",
@@ -211,28 +220,46 @@ const QUERY_GPU_ARGS: [&str; 2] = [
 /// `detect_cuda()`'s blocking `std::process::Command` shape so `new()` can
 /// decide "is this an NVIDIA host" before committing a daemon task.
 fn probe_blocking() -> Option<(String, SmiReading)> {
-    use std::process::Command;
-    let out = Command::new("nvidia-smi")
-        .args(QUERY_GPU_ARGS)
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let stdout = String::from_utf8(out.stdout).ok()?;
+    // BOUNDED (#3733's class, second pass). This runs from `NvidiaMonitor::new`
+    // → `gpu::monitor::detect()`, which the module CONSTRUCTION path reaches —
+    // so an unbounded wait here does not degrade GPU telemetry, it stalls boot
+    // before the IPC socket exists, exactly as the unbounded `detect_cuda`
+    // probe did. #3733 bounded that one call and left these; a hung nvidia-smi
+    // is ordinary on Windows (driver mid-recovery, a WDDM/TCC transition,
+    // another process holding the driver, an ECC query on a busy card), and
+    // BigMama measured a 209 s serving constructor on a CUDA host.
+    //
+    // A probe that cannot answer is NOT a host without a GPU — but at this seam
+    // both mean "do not commit a daemon task", so both return None. The probe!
+    // is what keeps them distinguishable to a reader of the boot log.
+    let probed = crate::system_resources::bounded_command::probe(
+        "nvidia-smi",
+        &QUERY_GPU_ARGS,
+        NVIDIA_PROBE_TIMEOUT,
+    );
+    crate::probe!(
+        class = "boot.gpu_detect",
+        backend = "nvidia",
+        stage = "monitor_probe",
+        outcome = probed.outcome(),
+        "NvidiaMonitor construction probe (bounded; an unbounded one stalls boot)"
+    );
+    let stdout = probed.stdout_if_ok()?;
     let line = stdout.lines().next()?;
     let sample = parse_gpu_csv_line(line)?;
 
     // Device name via a separate column query (kept out of the numeric
     // line so a name with a comma can't shift the CSV columns).
-    let name = Command::new("nvidia-smi")
-        .args(["--query-gpu=name", "--format=csv,noheader"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
+    let named = crate::system_resources::bounded_command::probe(
+        "nvidia-smi",
+        &["--query-gpu=name", "--format=csv,noheader"],
+        NVIDIA_PROBE_TIMEOUT,
+    );
+    let name = named
+        .stdout_if_ok()
         .and_then(|s| s.lines().next().map(|l| l.trim().to_string()))
         .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "NVIDIA GPU".to_string());
+        .unwrap_or_else(|| "NVIDIA GPU".to_string()); // unwrap_or_else: the card answered numbers but not its name — a nameless GPU still serves
 
     Some((name, sample))
 }
@@ -240,11 +267,22 @@ fn probe_blocking() -> Option<(String, SmiReading)> {
 /// Async per-tick GPU query (off the reactor — never blocks a runtime
 /// thread). `None` on any failure so the tick keeps the last-good atomics.
 async fn query_gpu() -> Option<SmiReading> {
-    let out = tokio::process::Command::new("nvidia-smi")
-        .args(QUERY_GPU_ARGS)
-        .output()
-        .await
-        .ok()?;
+    // BOUNDED: this is a per-TICK query, so an unbounded await does not stall
+    // boot — it parks the monitor task forever on the first hang and the
+    // atomics silently freeze at their last-good values. Stale telemetry that
+    // reports itself as current is the more expensive failure here, because the
+    // scheduler keeps placing lanes against numbers that stopped moving.
+    // `tokio::time::timeout` is the right tool INSIDE the runtime; the
+    // construction probe above is blocking and uses the sync helper instead.
+    let out = tokio::time::timeout(
+        NVIDIA_PROBE_TIMEOUT,
+        tokio::process::Command::new("nvidia-smi")
+            .args(QUERY_GPU_ARGS)
+            .output(),
+    )
+    .await
+    .ok()? // timeout elapsed: keep the last-good atomics, same contract as any other failure
+    .ok()?;
     if !out.status.success() {
         return None;
     }
@@ -254,14 +292,20 @@ async fn query_gpu() -> Option<SmiReading> {
 
 /// Async per-tick process-VRAM query. Sums compute-apps owned by our PID.
 async fn query_process_bytes() -> Option<u64> {
-    let out = tokio::process::Command::new("nvidia-smi")
-        .args([
-            "--query-compute-apps=pid,used_memory",
-            "--format=csv,noheader,nounits",
-        ])
-        .output()
-        .await
-        .ok()?;
+    // BOUNDED for the same reason as `query_gpu` above: a per-tick await with
+    // no ceiling parks the task on the first hang and freezes the reading.
+    let out = tokio::time::timeout(
+        NVIDIA_PROBE_TIMEOUT,
+        tokio::process::Command::new("nvidia-smi")
+            .args([
+                "--query-compute-apps=pid,used_memory",
+                "--format=csv,noheader,nounits",
+            ])
+            .output(),
+    )
+    .await
+    .ok()? // timeout elapsed: no reading this tick, last-good stands
+    .ok()?;
     if !out.status.success() {
         return None;
     }

--- a/core/continuum-core/src/inference_capability/hw_probe.rs
+++ b/core/continuum-core/src/inference_capability/hw_probe.rs
@@ -172,15 +172,28 @@ fn try_detect_metal() -> Option<(u64, String)> {
 fn try_detect_cuda() -> Option<(u64, String)> {
     #[cfg(feature = "cuda")]
     {
-        use std::process::Command;
-        let output = Command::new("nvidia-smi")
-            .args([
+        // BOUNDED (#3733's class, third site). Reached from
+        // `probe_hardware_profile`, which the inference coordinator and the
+        // capacity profile both call — so an unbounded wait here stalls
+        // whichever of those runs first, and on a boot path that is the whole
+        // startup. Same 10 s ceiling as the other driver queries: one number
+        // for "how long may nvidia-smi take", not three.
+        let probed = crate::system_resources::bounded_command::probe(
+            "nvidia-smi",
+            &[
                 "--query-gpu=memory.total,name",
                 "--format=csv,noheader,nounits",
-            ])
-            .output()
-            .ok()?;
-        let stdout = String::from_utf8(output.stdout).ok()?;
+            ],
+            std::time::Duration::from_secs(10),
+        );
+        crate::probe!(
+            class = "boot.gpu_detect",
+            backend = "cuda",
+            stage = "hw_profile",
+            outcome = probed.outcome(),
+            "hardware-profile CUDA probe (bounded)"
+        );
+        let stdout = probed.stdout_if_ok()?;
         let line = stdout.lines().next()?;
         let parts: Vec<&str> = line.split(", ").collect();
         if parts.len() < 2 {
@@ -203,12 +216,23 @@ fn try_detect_cuda() -> Option<(u64, String)> {
 fn try_detect_vulkan() -> Option<(u64, String)> {
     #[cfg(feature = "vulkan")]
     {
-        use std::process::Command;
-        let output = Command::new("vulkaninfo").arg("--summary").output().ok()?;
-        if !output.status.success() {
-            return None;
-        }
-        let stdout = String::from_utf8(output.stdout).ok()?;
+        // BOUNDED (#3733's class, fourth site). Same path as the CUDA probe
+        // above and reached when it declines, so on a host whose GPU stack is
+        // unwell this is the SECOND unbounded wait in a row — the identical
+        // shape #3733 fixed in `detect_gpu`, in a different file.
+        let probed = crate::system_resources::bounded_command::probe(
+            "vulkaninfo",
+            &["--summary"],
+            std::time::Duration::from_secs(10),
+        );
+        crate::probe!(
+            class = "boot.gpu_detect",
+            backend = "vulkan",
+            stage = "hw_profile",
+            outcome = probed.outcome(),
+            "hardware-profile Vulkan probe (bounded)"
+        );
+        let stdout = probed.stdout_if_ok()?;
         // Look for a line like "deviceName    = Some GPU Name"
         let name = stdout
             .lines()


### PR DESCRIPTION
#3733 bounded `gpu::memory_manager::detect_cuda` and stopped there. A full-tree sweep for `nvidia-smi` / `vulkaninfo` / `rocminfo` finds **five more** — and the worst are on the same class of path: module **construction**, before the IPC socket exists.

## The six sites

| site | path | failure if unbounded |
|---|---|---|
| `nvidia.rs::probe_blocking` (×2) | `NvidiaMonitor::new` → `gpu::monitor::detect()` | **stalls boot** |
| `nvidia.rs::query_gpu` | per-tick | monitor task parks forever |
| `nvidia.rs::query_process_bytes` | per-tick | monitor task parks forever |
| `hw_probe.rs::try_detect_cuda` | `probe_hardware_profile` | stalls its caller |
| `hw_probe.rs::try_detect_vulkan` | reached when CUDA declines | second unbounded wait in a row |

The word `timeout` appeared **nowhere** in `gpu/backends/nvidia.rs` before this. The last two were in nobody's list.

## Two different failures, deliberately

The construction probes stall **boot** — BigMama measured a 209s `serving` constructor on a CUDA host, and this is a candidate for where those seconds went.

The per-tick queries are quieter and arguably worse: they don't stall boot, they **park the monitor task forever on the first hang and freeze the atomics at last-good**. Stale telemetry reporting itself as current keeps the scheduler placing lanes against numbers that stopped moving — the same defect as `ready:true` surviving a SIGKILL.

## Two tools, matching the tier

Blocking construction probes use `system_resources::bounded_command` (sync — it runs on the boot thread with no runtime to await on). Per-tick queries use `tokio::time::timeout`, correct *inside* the runtime. Same contract, different tier; `bounded_command`'s module doc already warns against dragging tokio onto the pre-bind path.

One 10s ceiling everywhere, matching `GPU_PROBE_TIMEOUT` and #3719 — so a host that's slow in one place isn't judged by three clocks.

Every site emits `boot.gpu_detect` with backend + stage + outcome, keeping `ok` / `absent` / `timed_out` / `unstartable` as four distinct facts rather than one `None`.

**Complementary to #3743**, not overlapping: that PR *measures* these seams, this one *bounds* them. If its probes land first they name which call hangs; this turns whichever it is into a named row plus a boot that continues. Deliberately not folded together — a measurement PR that also changes behaviour can't tell you whether the number moved because you measured it or because you changed it.

## ⚠️ Verification, split honestly

- **Locally verified**: `gpu/backends/nvidia.rs` is deliberately ungated (its own `mod.rs` says "do not tidy a cfg onto it"), so it compiles on this Intel Mac. `cargo check -p continuum-core --lib --no-default-features --features livekit-webrtc,llama/mac-cpu-only` → **exit 0**, no errors or warnings in the changed files.
- **NOT locally verifiable**: `hw_probe.rs`'s two blocks are inside `cfg(feature = "cuda")` / `cfg(feature = "vulkan")` and cannot be type-checked on macOS. CI and a CUDA host are their first real reader, same as #3733.

Card 0f09fec7 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE
