### PR TITLE
probe(boot): every boot.stretch mark names the step that starts next — a hang names itself

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -2276,18 +2276,20 @@ pub fn start_server(
     // between). Step marks name which part of the persona-host setup owns it.
     let mut stretch_mark = {
         let mut last = std::time::Instant::now();
-        move |step: &'static str| {
+        move |step: &'static str, next: &'static str| {
             let now = std::time::Instant::now();
             crate::probe!(
                 class = "boot.stretch",
                 stretch = "persona_host_setup",
                 step = step,
+                next = next,
                 ms = now.duration_since(last).as_millis() as u64,
-                "pre-bind stretch step"
+                "pre-bind stretch step done; the named next step starts now"
             );
             last = now;
         }
     };
+    stretch_mark("enter", "resident_roles_and_overlay");
     if let Some(daemon_socket) = persona_bootstrap_deps {
         // Grid capacity gossip (#56 step 4): this node offers its live capacity to
         // the grid on the module tick and hears every peer's offers (its own echo
@@ -2640,8 +2642,8 @@ pub fn start_server(
                 }
             }
         };
-        stretch_mark("resident_roles_and_overlay");
-        stretch_mark("before_supervisor");
+        stretch_mark("resident_roles_and_overlay", "supervisor_construct");
+        stretch_mark("supervisor_construct", "resume_task_spawn_and_rest_of_block");
         let supervisor = crate::persona::host::PersonaSpawnSupervisor::new(
             crate::persona::spawner_module::PersonaSpawnerModule::new(hw_cap, tier_cat)
                 .with_citizens(resident_roles)
@@ -3068,7 +3070,7 @@ pub fn start_server(
                 bound = Some(active);
             }
         });
-        stretch_mark("end_of_persona_host_block");
+        stretch_mark("end_of_persona_host_block", "ai_provider_register");
     }
 
     // AIProviderModule: Unified AI provider for cloud and local inference


### PR DESCRIPTION
Card 81597f07 (BigMama's review of #3742): marks-after cannot tell hung-in-step from not-reached. Each `boot.stretch` mark now carries `next` (the step beginning now) plus an `enter` mark; a wedge's last row names the step it is stuck in. `cargo check` green; no behaviour change.

Review requested; no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo