### PR TITLE
ci(install): assert host detection on all three platforms, not just the one

### DIFF
--- a/.github/workflows/host-detect-matrix.yml
+++ b/.github/workflows/host-detect-matrix.yml
@@ -91,9 +91,16 @@ jobs:
         run: |
           set -o pipefail
           cp tools/scripts/lib/install-common.sh /tmp/ic.bak
-          # Force the silent-zero shape on whichever arm this platform uses.
-          perl -0pi -e 's/IC_RAM_MIB=\$\(\([^\n]*\n/IC_RAM_MIB=0  # MUTATION\n/' tools/scripts/lib/install-common.sh
-          perl -0pi -e 's/IC_RAM_MIB=\$\(awk[^\n]*\n/IC_RAM_MIB=0  # MUTATION\n/' tools/scripts/lib/install-common.sh
+          # Force the silent-zero shape on EVERY arm, by line rather than by
+          # each platform's expression. The first cut matched the macOS
+          # `$(( $(sysctl …) ))` and Linux `$(awk …)` shapes only, so on
+          # Windows — whose arm is a `case` over a captured variable since
+          # #3739 — it patched nothing, the assertions passed unchanged, and
+          # this step correctly reported "the gate is dead". The mutation step
+          # caught a hole in the mutation step, which is the argument for
+          # having one.
+          perl -pi -e 's/^(\s*)IC_RAM_MIB=.*/${1}IC_RAM_MIB=0  # MUTATION/' tools/scripts/lib/install-common.sh
+          grep -c 'MUTATION' tools/scripts/lib/install-common.sh
           if bash scripts/ci/host-detect-assert.sh > /tmp/mutation.log 2>&1; then
             echo "::error::host-detect-assert did NOT fail with RAM forced to 0 — the gate is dead."
             cat /tmp/mutation.log

--- a/.github/workflows/host-detect-matrix.yml
+++ b/.github/workflows/host-detect-matrix.yml
@@ -90,23 +90,17 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          cp tools/scripts/lib/install-common.sh /tmp/ic.bak
-          # Force the silent-zero shape on EVERY arm, by line rather than by
-          # each platform's expression. The first cut matched the macOS
-          # `$(( $(sysctl …) ))` and Linux `$(awk …)` shapes only, so on
-          # Windows — whose arm is a `case` over a captured variable since
-          # #3739 — it patched nothing, the assertions passed unchanged, and
-          # this step correctly reported "the gate is dead". The mutation step
-          # caught a hole in the mutation step, which is the argument for
-          # having one.
-          perl -pi -e 's/^(\s*)IC_RAM_MIB=.*/${1}IC_RAM_MIB=0  # MUTATION/' tools/scripts/lib/install-common.sh
-          grep -c 'MUTATION' tools/scripts/lib/install-common.sh
-          if bash scripts/ci/host-detect-assert.sh > /tmp/mutation.log 2>&1; then
+          # The defect is injected AFTER detection via a hook in the assert
+          # script, not by patching install-common.sh. Two earlier cuts sed'd
+          # "the RAM line" and each missed Windows, whose arm is a `case` over a
+          # captured variable since #3739 — a mutation that mutates nothing
+          # reports the gate dead, correctly, but the dead thing was the regex.
+          # One injection point every platform converges on cannot miss an arm.
+          if HOST_DETECT_MUTATE_RAM=1 bash scripts/ci/host-detect-assert.sh > /tmp/mutation.log 2>&1; then
             echo "::error::host-detect-assert did NOT fail with RAM forced to 0 — the gate is dead."
             cat /tmp/mutation.log
-            cp /tmp/ic.bak tools/scripts/lib/install-common.sh
             exit 1
           fi
-          cp /tmp/ic.bak tools/scripts/lib/install-common.sh
-          echo "Mutation proof passed: a silent-zero RAM figure turns this leg red."
+          grep -E 'MUTATION|FAIL ram' /tmp/mutation.log || true
+          echo "Mutation proof passed: a zero RAM figure turns this leg red."
           bash scripts/ci/host-detect-assert.sh

--- a/.github/workflows/host-detect-matrix.yml
+++ b/.github/workflows/host-detect-matrix.yml
@@ -1,0 +1,105 @@
+# Card b2e4a0bb — host detection, on every platform we ship to.
+#
+# THE GAP THIS CLOSES: `carl-install-smoke` is our only install check and it is
+# `runs-on: ubuntu-latest` with no matrix. So the install path is verified on
+# exactly one platform — and in one night (2026-09-05) every detect_host bug
+# found on the other two was invisible to it:
+#
+#   - Windows 11 24H2 REMOVED `wmic`, so the RAM arm fell through and recorded
+#     IC_RAM_MIB=0 on a machine with 64914 MiB. Every downstream tier decision
+#     ran on that zero, silently (#3739).
+#   - The Intel-Mac arm builds llama-server CPU-only because a Metal build hangs
+#     that hardware uninterruptibly — and nothing recorded that as the host's
+#     serving PLAN, so the backend receipt refused a healthy node and advised
+#     reinstalling with Metal, which would have hung it again (#3729 → #3740).
+#   - The Linux/WSL RAM arm still turns an unreadable /proc/meminfo into 0 with
+#     no warning — the same defect as the Windows one, on the platform CI does
+#     run, unnoticed because nothing asserted the value.
+#
+# Each was a detect_host fact being WRONG rather than missing, on a platform its
+# author could not run. Three operators, three boxes, and the shared CI checked
+# the tier none of them installs on.
+#
+# WHY THIS IS NOT A MATRIX ON carl-install-smoke: that job is Docker-based and
+# ~30 minutes. `install-common.sh` is sourceable and `ic_detect_hardware` is a
+# pure probe of the machine it runs on, so the per-platform leg needs no Docker,
+# no images, and no registry auth — seconds, not half an hour. The Docker smoke
+# stays the Linux end-to-end check; this is the cross-platform truth check.
+#
+# The assertions are about SHAPE, not hardware. A CI runner is none of our
+# boxes, and a test expecting an M5 or a 5090 fails for the wrong reason. What
+# must hold everywhere is that the detector produced a determinate answer rather
+# than a silent placeholder — 0 MiB of RAM, an empty GPU kind, an unrecognised
+# platform.
+
+name: host-detect-matrix
+
+on:
+  pull_request:
+    branches: [canary, main]
+    paths:
+      - 'tools/scripts/lib/install-common.sh'
+      - 'tools/scripts/install*.sh'
+      - 'scripts/ci/host-detect-assert.sh'
+      - '.github/workflows/host-detect-matrix.yml'
+  push:
+    branches: [canary, main]
+    # The SAME paths filter on both triggers, deliberately. A push trigger with
+    # no filter fires on every commit and fails on unrelated changes, which is
+    # how ts-persona-forbidden-strings-ratchet went 100/100 red until everyone
+    # learned to ignore its X. A gate people ignore is worse than no gate.
+    paths:
+      - 'tools/scripts/lib/install-common.sh'
+      - 'tools/scripts/install*.sh'
+      - 'scripts/ci/host-detect-assert.sh'
+      - '.github/workflows/host-detect-matrix.yml'
+  workflow_dispatch:
+
+jobs:
+  detect:
+    name: host-detect (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      # Every leg runs even when one fails: the point is to learn what ALL
+      # three platforms report, and fail-fast would hide the second bug behind
+      # the first — which is exactly how these stayed hidden.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # Windows runners have Git Bash, which is the shell `install.sh` actually
+      # runs under on that platform (uname -s reports MINGW64_NT-...). Using it
+      # here means the leg exercises the same branch a real Windows install
+      # takes, not a WSL or PowerShell approximation.
+      - name: Assert host detection
+        shell: bash
+        run: bash scripts/ci/host-detect-assert.sh
+
+      # The gate must be able to FAIL, or it is decoration. This injects the
+      # exact defect that shipped on 24H2 — a RAM arm that records 0 instead of
+      # refusing — and asserts the leg goes red, then restores. Written after
+      # discovering, twice in one night, that a green check can mean the checker
+      # never ran (a crashed linter counted as zero errors; a pipe returned
+      # tail's exit status instead of cargo's).
+      - name: Prove the assertion can fail (mutation)
+        shell: bash
+        run: |
+          set -o pipefail
+          cp tools/scripts/lib/install-common.sh /tmp/ic.bak
+          # Force the silent-zero shape on whichever arm this platform uses.
+          perl -0pi -e 's/IC_RAM_MIB=\$\(\([^\n]*\n/IC_RAM_MIB=0  # MUTATION\n/' tools/scripts/lib/install-common.sh
+          perl -0pi -e 's/IC_RAM_MIB=\$\(awk[^\n]*\n/IC_RAM_MIB=0  # MUTATION\n/' tools/scripts/lib/install-common.sh
+          if bash scripts/ci/host-detect-assert.sh > /tmp/mutation.log 2>&1; then
+            echo "::error::host-detect-assert did NOT fail with RAM forced to 0 — the gate is dead."
+            cat /tmp/mutation.log
+            cp /tmp/ic.bak tools/scripts/lib/install-common.sh
+            exit 1
+          fi
+          cp /tmp/ic.bak tools/scripts/lib/install-common.sh
+          echo "Mutation proof passed: a silent-zero RAM figure turns this leg red."
+          bash scripts/ci/host-detect-assert.sh

--- a/scripts/ci/host-detect-assert.sh
+++ b/scripts/ci/host-detect-assert.sh
@@ -73,6 +73,28 @@ if [ -n "${HOST_DETECT_MUTATE_RAM:-}" ]; then
 fi
 
 echo ""
+# WHICH ARM PRODUCED THE ANSWER, not just what the answer was (ce8b9074's gap
+# on #3748). A passing RAM check does not say HOW the figure was obtained, and
+# on Windows that is the whole question: `wmic` was removed in 11 24H2, so a
+# green leg means the CIM fallback worked ONLY IF wmic was absent. With wmic
+# present the leg exercises the old path and proves nothing about the fix —
+# and I claimed it proved the fallback before checking. Recording the
+# precondition makes the log answer that instead of the reader assuming.
+echo "arm evidence:"
+case "${IC_PLATFORM:-}" in
+  windows)
+    if command -v wmic >/dev/null 2>&1; then
+      note "wmic PRESENT — the RAM figure came from the legacy wmic arm; this run does NOT exercise the Get-CimInstance fallback (#3739)"
+    else
+      note "wmic ABSENT (removed in Win11 24H2) — the RAM figure came from the Get-CimInstance fallback (#3739)"
+    fi
+    ;;
+  macos) note "sysctl hw.memsize arm" ;;
+  linux|wsl) note "/proc/meminfo awk arm" ;;
+  *) note "no known arm for platform '${IC_PLATFORM:-<unset>}'" ;;
+esac
+
+echo ""
 echo "detected:"
 note "IC_PLATFORM = ${IC_PLATFORM:-<unset>}"
 note "IC_ARCH     = ${IC_ARCH:-<unset>}"

--- a/scripts/ci/host-detect-assert.sh
+++ b/scripts/ci/host-detect-assert.sh
@@ -51,6 +51,27 @@ check() {
 echo "host-detect-assert on $(uname -s) $(uname -m)"
 ic_detect_hardware
 
+# MUTATION HOOK — test scaffolding, and it lives HERE rather than in a sed over
+# install-common.sh on purpose.
+#
+# The CI job must prove this gate can fail, and the obvious way (patch the RAM
+# assignment in the source) is platform-shaped: macOS assigns from a `$(( $(…) ))`,
+# Linux from `$(awk …)`, and Windows from a `case` over a captured variable
+# since #3739. Two successive attempts to patch "the RAM line" from a Mac each
+# missed Windows and produced a green mutation — a mutation step that mutates
+# nothing reports the gate dead, which is right, but it was MY regex that was
+# dead, twice.
+#
+# Injecting the defect at the one place every platform converges — after
+# detection, before the checks — is shape-independent and cannot silently miss
+# an arm. Nothing in production reads this variable; it exists only so CI can
+# watch the assertions go red on demand.
+if [ -n "${HOST_DETECT_MUTATE_RAM:-}" ]; then
+  echo "MUTATION: forcing IC_RAM_MIB=0 (was ${IC_RAM_MIB:-<unset>})"
+  IC_RAM_MIB=0
+  IC_RAM_GB=0
+fi
+
 echo ""
 echo "detected:"
 note "IC_PLATFORM = ${IC_PLATFORM:-<unset>}"

--- a/scripts/ci/host-detect-assert.sh
+++ b/scripts/ci/host-detect-assert.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# host-detect-assert.sh — assert `ic_detect_hardware` tells the truth on THIS host.
+#
+# WHY THIS EXISTS (card b2e4a0bb, 2026-09-05). The only install check we run is
+# `carl-install-smoke`, and it is `runs-on: ubuntu-latest` with no matrix. So
+# the install path is verified on exactly one platform, and every bug found on
+# the other two in one night was invisible to it:
+#
+#   - `wmic` was REMOVED in Windows 11 24H2, so the RAM arm fell to its else
+#     branch and recorded IC_RAM_MIB=0 on a machine with 64914 MiB. Every
+#     downstream tier decision then ran on that zero (fixed in #3739).
+#   - the Intel-Mac arm builds llama-server CPU-only because a Metal build hangs
+#     that hardware uninterruptibly, and nothing recorded that as the host's
+#     serving PLAN until #3740 — so the backend receipt refused the node and
+#     advised reinstalling with Metal, which would have hung it again.
+#   - the Linux/WSL RAM arm still turns an unreadable /proc/meminfo into 0 with
+#     no warning, which is the same defect as the Windows one on a platform
+#     nobody re-checked.
+#
+# Every one of those is a `detect_host` fact being WRONG rather than absent, on
+# a platform the author could not run. That is what a matrix is for, and it does
+# NOT need Docker: `install-common.sh` is sourceable and `ic_detect_hardware`
+# is a pure probe of the machine it runs on.
+#
+# The assertions are deliberately about SHAPE, not about specific hardware — a
+# CI runner is not any of our boxes, and a test that expects an M5 or a 5090
+# fails for the wrong reason. What must hold on every host is that the detector
+# produced a determinate answer rather than a silent placeholder.
+
+set -e
+set -o pipefail  # a failing command in a pipeline must not read as success (card aad30dee)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=/dev/null
+. "$REPO_ROOT/tools/scripts/lib/install-common.sh"
+
+fail=0
+note() { printf '  %s\n' "$*"; }
+check() {
+  local what="$1" ok="$2" detail="$3"
+  if [ "$ok" = "1" ]; then
+    printf 'ok   %s — %s\n' "$what" "$detail"
+  else
+    printf 'FAIL %s — %s\n' "$what" "$detail"
+    fail=1
+  fi
+}
+
+echo "host-detect-assert on $(uname -s) $(uname -m)"
+ic_detect_hardware
+
+echo ""
+echo "detected:"
+note "IC_PLATFORM = ${IC_PLATFORM:-<unset>}"
+note "IC_ARCH     = ${IC_ARCH:-<unset>}"
+note "IC_RAM_MIB  = ${IC_RAM_MIB:-<unset>}"
+note "IC_RAM_GB   = ${IC_RAM_GB:-<unset>}"
+note "IC_GPU_KIND = ${IC_GPU_KIND:-<unset>}"
+note "IC_GPU_NAME = ${IC_GPU_NAME:-<unset>}"
+echo ""
+
+# 1. PLATFORM must be one of the known values. An unrecognised host falling
+#    through to an empty string is how the `*)` RAM arm gets reached, and that
+#    arm records 0 MiB by construction.
+case "${IC_PLATFORM:-}" in
+  macos|linux|wsl|windows) check "platform" 1 "recognised as ${IC_PLATFORM}" ;;
+  *) check "platform" 0 "unrecognised or unset (${IC_PLATFORM:-<unset>}) — the catch-all arms record placeholders" ;;
+esac
+
+# 2. RAM must be a POSITIVE integer. This is the wmic bug's assertion, and the
+#    one that would have caught it on the box it broke: a real machine always
+#    has RAM, so 0 means "we could not look" wearing the clothes of "there is
+#    none". Empty is the Linux failure shape; 0 is the Windows one.
+if [ -n "${IC_RAM_MIB:-}" ] && [ "${IC_RAM_MIB}" -gt 0 ] 2>/dev/null; then
+  check "ram" 1 "${IC_RAM_MIB} MiB (${IC_RAM_GB} GB)"
+else
+  check "ram" 0 "IC_RAM_MIB=${IC_RAM_MIB:-<empty>} — a host with no readable RAM figure will be mis-tiered, silently"
+fi
+
+# 3. ARCH must be determinate for the same reason.
+case "${IC_ARCH:-}" in
+  arm64|x86_64|other) check "arch" 1 "${IC_ARCH}" ;;
+  *) check "arch" 0 "unset or unexpected (${IC_ARCH:-<unset>})" ;;
+esac
+
+# 4. GPU KIND must be one of the declared values INCLUDING `none`. `none` is a
+#    real answer on a CI runner and must not be confused with the empty string:
+#    "no GPU" and "we did not look" are different facts, and conflating them is
+#    what made the backend receipt refuse a working CPU-by-plan host.
+case "${IC_GPU_KIND:-}" in
+  metal|cuda|vulkan|rocm|none) check "gpu_kind" 1 "${IC_GPU_KIND}" ;;
+  *) check "gpu_kind" 0 "unset or unexpected (${IC_GPU_KIND:-<unset>}) — 'none' is the answer for no GPU, empty is not" ;;
+esac
+
+# 5. THE PLACEMENT KEY, which is the whole reason this tier's fix is not just a
+#    repair of one machine (#3740). install-llama-server.sh records
+#    CONTINUUM_SERVING_PLACEMENT from the backend it decided, so a CPU-only host
+#    serves by PLAN instead of being refused as a broken GPU host. The value is
+#    only derivable where that script has run, so this leg asserts the DECISION
+#    FUNCTION rather than the file — the wire is covered by the install smoke.
+if declare -f ic_serving_placement >/dev/null 2>&1; then
+  placement="$(ic_serving_placement)"
+  case "$placement" in
+    cpu|gpu) check "placement" 1 "would record ${placement}" ;;
+    *) check "placement" 0 "ic_serving_placement returned ${placement:-<empty>}" ;;
+  esac
+else
+  printf 'skip placement — ic_serving_placement not present in install-common.sh on this ref\n'
+fi
+
+echo ""
+if [ "$fail" = "0" ]; then
+  echo "host-detect-assert: all checks passed on ${IC_PLATFORM}"
+else
+  echo "host-detect-assert: FAILED on ${IC_PLATFORM} — see above"
+fi
+exit "$fail"


### PR DESCRIPTION
Card b2e4a0bb.

## The gap

`carl-install-smoke` is our only install check, and it is `runs-on: ubuntu-latest` with **no matrix**. The install path is verified on exactly one platform — and in one night every `detect_host` bug found on the other two was invisible to it:

| bug | platform | effect |
|---|---|---|
| `wmic` removed in Win 11 24H2 | Windows | `IC_RAM_MIB=0` on a 64914 MiB machine; every tier decision ran on that zero (#3739) |
| CPU-only build not recorded as the serving *plan* | Intel Mac | receipt refused a healthy node and advised reinstalling with Metal — which hangs it (#3729 → #3740) |
| unreadable `/proc/meminfo` → empty → `0` | Linux/WSL | **still live**; same defect on the platform CI *does* run, unnoticed because nothing asserted the value |

Each was a fact being **wrong rather than missing**, on a platform its author could not run. Three operators, three boxes, and the shared CI checking the tier none of them installs on.

## Why not a matrix on `carl-install-smoke`

That job is Docker-based and ~30 minutes. `install-common.sh` is sourceable and `ic_detect_hardware` is a pure probe of the machine it runs on, so a per-platform leg needs no Docker, no images, no registry auth — seconds, not half an hour. The Docker smoke stays the Linux end-to-end check; this is the cross-platform *truth* check.

## What it asserts

Shape, not hardware. A CI runner is none of our boxes, and a test expecting an M5 or a 5090 fails for the wrong reason. What must hold everywhere:

- platform is one of the recognised values (an unrecognised host falls to the `*)` arm, which records placeholders **by construction**)
- RAM is a **positive integer** — a real machine always has RAM, so `0` is "we could not look" wearing the clothes of "there is none", and empty is the Linux failure shape
- arch is determinate
- `gpu_kind` is one of the declared values **including `none`** — "no GPU" and "we did not look" are different facts, and conflating them is what made the backend receipt refuse a working CPU-by-plan host

The Windows leg runs under **Git Bash**, the shell `install.sh` actually uses there (`uname -s` → `MINGW64_NT-...`), so it exercises the real branch rather than a WSL or PowerShell approximation. `fail-fast: false` because the point is to learn what all three report — failing fast hides the second bug behind the first, which is how these stayed hidden.

## The mutation step

The job forces the RAM arm to the silent-zero shape that shipped on 24H2 and asserts the leg goes red, then restores.

Verified by hand on an Intel Mac before commit:

```
MUTATED EXIT: 1   FAIL ram — IC_RAM_MIB=0 — a host with no readable RAM figure
                              will be mis-tiered, silently
RESTORED EXIT: 0
```

Written after finding twice in one night that a green check can mean the checker never ran — a crashed linter counted as zero errors, and a pipe returned `tail`'s exit status instead of cargo's.

Both triggers carry the same `paths` filter, per the comment on `ts-persona-forbidden-strings-ratchet.yml` where a missing filter on `push` produced 100/100 red and taught everyone to ignore the X.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE
