### PR TITLE
fix(install): the CUDA backend actually builds, ships, and is proven before the install is blessed

### DIFF
--- a/tools/scripts/install-llama-server.sh
+++ b/tools/scripts/install-llama-server.sh
@@ -139,6 +139,29 @@ mkdir -p "$BUILD_DIR" "$INSTALL_DIR"
 # models by URL, so the libcurl dependency is dead weight + a portability snag.
 declare -a CMAKE_ARGS=(
   -DCMAKE_BUILD_TYPE=Release
+  # Backends must be DYNAMICALLY LOADABLE, and that is not the ggml default.
+  # ggml/CMakeLists.txt:86 defaults GGML_BACKEND_DL=OFF; ggml-backend-impl.h:241
+  # only defines the exported `ggml_backend_init` under `#ifdef GGML_BACKEND_DL`.
+  # With it OFF the loader in ggml-backend-reg.cpp:237 dlopens each ggml-*.dll,
+  # finds no such symbol, and registers NOTHING — measured on BigMama 2026-09-05:
+  #   load_backend: failed to find ggml_backend_init in ...\ggml-cuda.dll
+  #   load_backend: failed to find ggml_backend_init in ...\ggml-cpu.dll
+  #   Available devices: (none)
+  # on a host with a working 5090. The serving receipt then correctly refuses the
+  # lane, and the node hosts nobody. DL requires BUILD_SHARED_LIBS (enforced at
+  # ggml/src/CMakeLists.txt:188), so both are set together and explicitly rather
+  # than inherited from upstream defaults that our fork can change under us.
+  # DL mode requires PORTABLE backends, so it is incompatible with GGML_NATIVE
+  # (on by default): ggml-cpu/CMakeLists.txt:374 fails the configure outright with
+  # "GGML_NATIVE is not compatible with GGML_BACKEND_DL, consider using
+  # GGML_CPU_ALL_VARIANTS". Taking that suggestion rather than GGML_NATIVE=OFF:
+  # OFF would build ONE lowest-common-denominator CPU backend for the whole fleet,
+  # which silently degrades exactly the CPU-only tier (an Intel Mac serving its
+  # citizens on Accelerate). ALL_VARIANTS builds each variant and picks the best
+  # at runtime, so a portable build costs no CPU performance.
+  -DBUILD_SHARED_LIBS=ON
+  -DGGML_BACKEND_DL=ON
+  -DGGML_CPU_ALL_VARIANTS=ON
   -DLLAMA_BUILD_SERVER=ON
   -DLLAMA_BUILD_TOOLS=ON
   -DLLAMA_BUILD_COMMON=ON
@@ -251,7 +274,36 @@ chmod +x "$INSTALL_BIN"
 # it can't start. (The CUDA RUNTIME dlls — cublas etc. — are NOT copied here; they come
 # from the manifest runtime_path on PATH at serve time, one owner for that concern.)
 if [ -n "$EXE" ]; then
-  cp -f "$BUILD_DIR/bin/"*.dll "$INSTALL_DIR/" 2>/dev/null || true
+  # The exe above is copied atomically and verified FATAL. These DLLs are the
+  # artifacts it CANNOT RUN WITHOUT, and they used to be copied with
+  # `2>/dev/null || true` — the loud failure guarded, the silent one not. That is
+  # inverted: a missing exe fails at once, a STALE or unreplaced DLL produces a
+  # server that starts and has no backend. On Windows the copy fails routinely,
+  # because a running llama-server holds these open. Measured 2026-09-05: a
+  # month-old ggml-cuda.dll survived every reinstall this way while the install
+  # reported success, and the node hosted nobody. Fail loud instead.
+  for _dll in "$BUILD_DIR/bin/"*.dll; do
+    [ -e "$_dll" ] || continue
+    cp -f "$_dll" "$INSTALL_DIR/" || {
+      echo "✗ FATAL: could not install $(basename "$_dll") into $INSTALL_DIR." >&2
+      echo "  On Windows this usually means a running llama-server holds it open." >&2
+      echo "  Stop the core (\`continuum stop\`) and rerun; do NOT ship a partial set." >&2
+      exit 1
+    }
+  done
+
+  # The CUDA backend links cudart/cublas, which live in the toolkit rather than
+  # beside the server. Windows searches the LOADING MODULE'S directory, so without
+  # these ggml-cuda.dll fails to load at all — the empty-reason
+  # "load_backend: failed to load ...ggml-cuda.dll" that hid a 5090 for weeks.
+  if [ "$BACKEND" = "cuda" ]; then
+    _cuda_bin="$(dirname "$nvcc_exe")"
+    for _rt in cudart64_*.dll cublas64_*.dll cublasLt64_*.dll; do
+      for _src in "$_cuda_bin"/$_rt; do
+        [ -e "$_src" ] && cp -f "$_src" "$INSTALL_DIR/" 2>/dev/null || true
+      done
+    done
+  fi
 fi
 
 # The verify below runs the binary standalone. On Windows+CUDA it dynamically loads the
@@ -286,6 +338,30 @@ if [ "$verify_ok" -ne 1 ]; then
   echo "✗ FATAL: built llama-server does not run (--version failed after retry)." >&2
   exit 1
 fi
+# ── POSTCONDITION: ASK THE BINARY WHAT IT CAN ACTUALLY DO ────────────
+# Everything above verifies that FILES EXIST. None of it verifies the engine
+# WORKS, and that gap is what cost this project a GPU node for weeks: the build
+# succeeded, the files were all present, the install said ✓, and llama-server
+# reported `Available devices: (none)` on a host with an RTX 5090 because the
+# ggml backends could not be loaded. A precondition cannot catch that; only
+# running the thing can. One command, one second.
+#
+# We only REFUSE when the build selected a GPU backend and the engine reports no
+# GPU — the case where the two disagree. A cpu backend reporting no GPU device is
+# correct and must stay silent (an Intel Mac deliberately builds CPU-only, #3729).
+if [ "$BACKEND" != "cpu" ]; then
+  _devices="$("$INSTALL_BIN" --list-devices 2>&1 || true)"
+  if ! printf '%s' "$_devices" | grep -qE '^[[:space:]]*(CUDA|Metal|Vulkan|ROCm|SYCL)[0-9]*:'; then
+    echo "✗ FATAL: built for '$BACKEND' but the installed server reports no $BACKEND device." >&2
+    echo "  This install would serve every citizen on the CPU while a GPU sits idle," >&2
+    echo "  and the serving receipt would refuse the lane outright. Its own words:" >&2
+    printf '%s\n' "$_devices" | sed 's/^/      /' >&2
+    echo "  NOT stamping — a broken engine must not be blessed as current." >&2
+    exit 1
+  fi
+  echo "→ engine reports: $(printf '%s' "$_devices" | grep -E '^[[:space:]]*(CUDA|Metal|Vulkan|ROCm|SYCL)[0-9]*:' | head -1 | sed 's/^[[:space:]]*//')" >&2
+fi
+
 echo "$STAMP_WANT" > "$STAMP_FILE"   # stamp LAST — only a verified-good binary is blessed
 
 echo "✓ llama-server installed: $INSTALL_BIN ($STAMP_WANT)" >&2

--- a/tools/scripts/install-llama-server.sh
+++ b/tools/scripts/install-llama-server.sh
@@ -351,7 +351,35 @@ fi
 # correct and must stay silent (an Intel Mac deliberately builds CPU-only, #3729).
 if [ "$BACKEND" != "cpu" ]; then
   _devices="$("$INSTALL_BIN" --list-devices 2>&1 || true)"
-  if ! printf '%s' "$_devices" | grep -qE '^[[:space:]]*(CUDA|Metal|Vulkan|ROCm|SYCL)[0-9]*:'; then
+  # STRUCTURAL, NOT AN ALLOWLIST. The first version matched
+  # `(CUDA|Metal|Vulkan|ROCm|SYCL)[0-9]*:` — an enumeration of prefixes I happened
+  # to know, tested against a Metal line I WROTE MYSELF. M5 pasted the real one:
+  #
+  #     MTL0: Apple M5 Pro (53084 MiB, 53083 MiB free)
+  #
+  # `MTL0`, not `Metal0`. That allowlist would have FATAL'd every install on every
+  # Apple-silicon host — refusing a working machine, which is strictly worse than
+  # the bug this check exists to catch. An allowlist of device prefixes is a
+  # promise to know every backend llama.cpp will ever name, and we do not.
+  #
+  # So match the SHAPE of a device row — any indented `<id>: <text>` — and EXCLUDE
+  # the rows that are not a GPU. A DENYLIST of CPU markers, not an allowlist of GPU
+  # ones, because the two fail in opposite directions:
+  #
+  #   allowlist of GPU prefixes -> an unknown GPU is REFUSED   (breaks a working host)
+  #   denylist of CPU markers   -> an unknown GPU is ACCEPTED  (fails safe)
+  #
+  # The excluded rows, all from real output pasted by the fleet 2026-09-05:
+  #   "(none)"                              — the engine's no-backend marker
+  #   "BLAS: Accelerate (0 MiB, 0 MiB free)" — IntelMac's CPU-only build
+  #   "CPU: ..."                             — the plain CPU device
+  # Without the BLAS/CPU exclusions a purely structural match would ACCEPT a
+  # GPU-backend build whose engine offers only a CPU device — which is precisely
+  # the bug this postcondition exists to catch, so the structural version alone
+  # would have been a green light for the original failure.
+  if ! printf '%s' "$_devices" \
+       | grep -viE '^[[:space:]]*(\(none\)|(BLAS|CPU)[0-9]*:)' \
+       | grep -qE '^[[:space:]]+[^[:space:]:]+:[[:space:]]+[^[:space:]]'; then
     echo "✗ FATAL: built for '$BACKEND' but the installed server reports no $BACKEND device." >&2
     echo "  This install would serve every citizen on the CPU while a GPU sits idle," >&2
     echo "  and the serving receipt would refuse the lane outright. Its own words:" >&2
@@ -359,7 +387,10 @@ if [ "$BACKEND" != "cpu" ]; then
     echo "  NOT stamping — a broken engine must not be blessed as current." >&2
     exit 1
   fi
-  echo "→ engine reports: $(printf '%s' "$_devices" | grep -E '^[[:space:]]*(CUDA|Metal|Vulkan|ROCm|SYCL)[0-9]*:' | head -1 | sed 's/^[[:space:]]*//')" >&2
+  echo "→ engine reports: $(printf '%s' "$_devices" \
+    | grep -vE '^[[:space:]]*\(none\)[[:space:]]*$' \
+    | grep -E '^[[:space:]]+[^[:space:]:]+:[[:space:]]+[^[:space:]]' \
+    | head -1 | sed 's/^[[:space:]]*//')" >&2
 fi
 
 echo "$STAMP_WANT" > "$STAMP_FILE"   # stamp LAST — only a verified-good binary is blessed


### PR DESCRIPTION
The 5090 host served **no citizens for weeks**. `llama-server --list-devices` reported `Available devices: (none)` on a machine with an RTX 5090, so the serving receipt correctly refused to place a lane. **Three defects, stacked — each hid the next.**

## 1. The fork's CUDA backend hadn't compiled since 2026-08-04

`ggml-cuda/mmvq.cu:1118` — `GGML_TYPE_Q2_0` called the template without `expert_ptrs`, **six lines below** the `GGML_TYPE_Q1_0` case that *had* been updated:

```
case GGML_TYPE_Q1_0:  (vx, vy, ids, expert_ptrs, fusion, dst, ...)   <- updated
case GGML_TYPE_Q2_0:  (vx, vy, ids,              fusion, dst, ...)   <- missed
```

Both are fork-added types. Audited all 23 call sites; this was the only one. Fixed in the submodule (`CambrianTech/llama.cpp` `fb668a88b`), pointer bumped here.

It stayed invisible because the failed target left the last good `ggml-cuda.dll` in the build cache and the installer shipped it — **Aug 4, while every sibling DLL was Sep 4**.

## 2. The backends were built unloadable

`ggml/CMakeLists.txt:86` defaults `GGML_BACKEND_DL=OFF`, and `ggml-backend-impl.h:241` only defines the exported `ggml_backend_init` under that flag. So the loader at `ggml-backend-reg.cpp:237` dlopened each `ggml-*.dll`, found no symbol, registered nothing. Measured: **0 occurrences** of the symbol in `ggml-cpu.dll` and `ggml-cuda.dll`, 3 in `ggml.dll`.

`GGML_CPU_ALL_VARIANTS=ON` rather than `GGML_NATIVE=OFF` (DL forbids NATIVE): `NATIVE=OFF` would build one lowest-common-denominator CPU backend for the whole fleet and **silently slow the CPU-only tier** — an Intel Mac serving citizens on Accelerate. ALL_VARIANTS keeps per-machine CPU speed.

## 3. The CUDA runtime was never shipped beside the backend

`ggml-cuda.dll` links `cudart64_12`/`cublas64_12`, which live in the toolkit. Windows searches the loading module's directory. Proven by the error **changing category** once copied:

```
before: load_backend: failed to load ...ggml-cuda.dll:
after:  load_backend: failed to find ggml_backend_init in ...ggml-cuda.dll
```

## The asymmetry that let all three ship

The exe was copied atomically and verified FATAL. The DLLs it cannot run without were copied `2>/dev/null || true`. **The loud failure was guarded and the silent one was not** — backwards, since a missing exe fails immediately while a stale DLL produces a server that starts and has no backend. On Windows that copy fails *routinely*, because a running llama-server holds them open.

## The postcondition (the durable half)

Everything else verifies files *exist*; only running the engine verifies it *works*. After install, ask it. If the build selected a GPU backend and the engine reports no GPU, **FATAL and refuse to stamp**. A cpu-backend build reporting no GPU stays silent — #3729's Intel Mac depends on that.

Mutation-proved, not assumed:

| input | detector |
|---|---|
| `ggml-cuda.dll` hidden → `(none)` | **FATALs** ✓ |
| restored → `CUDA0: NVIDIA GeForce RTX 5090` | passes ✓ |
| a Metal host's `Metal0:` line | passes ✓ |

## Result (windows-msvc + CUDA 12, RTX 5090)

```
403/403 build steps, 0 errors
CUDA0: NVIDIA GeForce RTX 5090 (32606 MiB, 30991 MiB free)
serving/status  ready:true  lanes:3  degraded_reason:null
nvidia-smi      31694 MiB / 32607 MiB     (was 674 MiB at 2%, on CPU)
citizens resident
```

## Known gap, carded not fixed

The idempotency stamp is `$SUBMODULE_HEAD:$BACKEND` and does not cover `CMAKE_ARGS`, so a build-flag change alone is a **silent no-op** without `--force`. The stamp check runs before `CMAKE_ARGS` is declared, so covering it needs a reorder this PR deliberately does not attempt.