### PR TITLE
fix(web/live): grid by default, stage only on click, speaking from real audio, no glow

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -408,10 +408,12 @@ export class ChatWidget extends LitElement {
         this._callParticipants = next;
         this.requestUpdate();
       },
-      onAvatar: (a) => {
-        const next = new Map(this._callSpeaking);
-        if (a.speaking) next.set(a.personaId, true);
-        else next.delete(a.personaId);
+      // Tile "speaking" = LiveKit's audio-level active speakers, never the
+      // token rail (`onAvatar.speaking` lit every tile while a persona merely
+      // generated text; Joel 2026-09-05: "they say they're talking … no output").
+      onActiveSpeakers: (ids) => {
+        const next = new Map<string, boolean>();
+        for (const id of ids) next.set(id, true);
         this._callSpeaking = next;
         this.requestUpdate();
       },
@@ -567,6 +569,10 @@ export class ChatWidget extends LitElement {
       else this._mediaAsk = { kind, denied: state === 'denied' };
     });
   }
+
+  private onLiveKeydown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && this._pinnedTile !== undefined) this._pinnedTile = undefined;
+  };
 
   /** Tile click: pin it to the stage; clicking the pinned tile unpins. */
   private onLiveTilePin = (e: Event): void => {
@@ -788,6 +794,9 @@ export class ChatWidget extends LitElement {
     this.addEventListener(LIVE_CAMERA_TOGGLE, this.onLiveCameraToggle);
     this.addEventListener(LIVE_MEDIA_ASK, this.onLiveMediaAsk);
     this.addEventListener(LIVE_TILE_PIN, this.onLiveTilePin);
+    // Escape unpins the stage (legacy LiveWidget behaviour): the grid is the
+    // resting state; a pin is a gesture the same key undoes.
+    this.addEventListener('keydown', this.onLiveKeydown);
     this.addEventListener(LIVE_CAPTIONS_TOGGLE, this.onLiveCaptionsToggle);
   }
 
@@ -4802,23 +4811,12 @@ export class ChatWidget extends LitElement {
       border-color: var(--border-accent, rgba(0, 212, 255, 0.4));
       box-shadow: 0 4px 18px rgba(0, 0, 0, 0.45);
     }
-    .live-tile:not([data-active]) {
-      opacity: 0.55;
-      filter: saturate(0.6);
-    }
-    /* SPEAKING — the reference's green active-speaker border, breathing while
-       REAL tokens flow on the live rail (never a timer animation). */
-    @keyframes live-speaking-pulse {
-      0%, 100% {
-        box-shadow: 0 0 10px rgba(63, 185, 80, 0.55), inset 0 0 14px rgba(63, 185, 80, 0.12);
-      }
-      50% {
-        box-shadow: 0 0 24px rgba(63, 185, 80, 0.95), inset 0 0 22px rgba(63, 185, 80, 0.2);
-      }
-    }
+    /* SPEAKING — a plain 2px border on the tile whose AUDIO is active (LiveKit
+       ActiveSpeakersChanged), the way Slack/Teams mark a speaker. No glow, no
+       pulse, no dimming of quiet tiles: presence IS the tile (Joel, 2026-09-05). */
     .live-tile[data-speaking] {
       border-color: var(--status-online, #3fb950);
-      animation: live-speaking-pulse 1.6s ease-in-out infinite;
+      box-shadow: 0 0 0 1px var(--status-online, #3fb950);
     }
     .lt-glyph {
       font-size: 52px;
@@ -4833,21 +4831,6 @@ export class ChatWidget extends LitElement {
       /* Legacy tile spec: VRM portraits carry the face at the top of the
          frame — a centered crop lands on the collar. */
       object-position: center top;
-    }
-    .lt-status {
-      position: absolute;
-      top: 8px;
-      left: 8px;
-      width: 10px;
-      height: 10px;
-      border-radius: 50%;
-      background: var(--status-offline, #555);
-      border: 2px solid rgba(0, 0, 0, 0.5);
-      z-index: 2;
-    }
-    .lt-status[data-on] {
-      background: var(--status-online, #3fb950);
-      box-shadow: 0 0 6px var(--status-online, #3fb950);
     }
     .lt-name {
       position: absolute;
@@ -4959,8 +4942,7 @@ export class ChatWidget extends LitElement {
       font-variant-numeric: tabular-nums;
     }
     @media (prefers-reduced-motion: reduce) {
-      .live-title-dot,
-      .live-tile[data-speaking] {
+      .live-title-dot {
         animation: none;
       }
       .live-tile:hover {

--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -408,12 +408,10 @@ export class ChatWidget extends LitElement {
         this._callParticipants = next;
         this.requestUpdate();
       },
-      // Tile "speaking" = LiveKit's audio-level active speakers, never the
-      // token rail (`onAvatar.speaking` lit every tile while a persona merely
-      // generated text; Joel 2026-09-05: "they say they're talking … no output").
-      onActiveSpeakers: (ids) => {
-        const next = new Map<string, boolean>();
-        for (const id of ids) next.set(id, true);
+      onAvatar: (a) => {
+        const next = new Map(this._callSpeaking);
+        if (a.speaking) next.set(a.personaId, true);
+        else next.delete(a.personaId);
         this._callSpeaking = next;
         this.requestUpdate();
       },
@@ -569,10 +567,6 @@ export class ChatWidget extends LitElement {
       else this._mediaAsk = { kind, denied: state === 'denied' };
     });
   }
-
-  private onLiveKeydown = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape' && this._pinnedTile !== undefined) this._pinnedTile = undefined;
-  };
 
   /** Tile click: pin it to the stage; clicking the pinned tile unpins. */
   private onLiveTilePin = (e: Event): void => {
@@ -794,9 +788,6 @@ export class ChatWidget extends LitElement {
     this.addEventListener(LIVE_CAMERA_TOGGLE, this.onLiveCameraToggle);
     this.addEventListener(LIVE_MEDIA_ASK, this.onLiveMediaAsk);
     this.addEventListener(LIVE_TILE_PIN, this.onLiveTilePin);
-    // Escape unpins the stage (legacy LiveWidget behaviour): the grid is the
-    // resting state; a pin is a gesture the same key undoes.
-    this.addEventListener('keydown', this.onLiveKeydown);
     this.addEventListener(LIVE_CAPTIONS_TOGGLE, this.onLiveCaptionsToggle);
   }
 
@@ -808,6 +799,8 @@ export class ChatWidget extends LitElement {
     this.removeEventListener(NAV_TAB_CLOSE, this.onNavTabClose);
     this.removeEventListener(LIVE_FACE_TOGGLE, this.onLiveFaceToggle);
     this.removeEventListener(LIVE_CAPTIONS_TOGGLE, this.onLiveCaptionsToggle);
+    this.removeEventListener(LIVE_TILE_PIN, this.onLiveTilePin);
+    this.removeEventListener('keydown', this.onLiveKeydown);
     super.disconnectedCallback();
   }
 
@@ -4811,12 +4804,23 @@ export class ChatWidget extends LitElement {
       border-color: var(--border-accent, rgba(0, 212, 255, 0.4));
       box-shadow: 0 4px 18px rgba(0, 0, 0, 0.45);
     }
-    /* SPEAKING — a plain 2px border on the tile whose AUDIO is active (LiveKit
-       ActiveSpeakersChanged), the way Slack/Teams mark a speaker. No glow, no
-       pulse, no dimming of quiet tiles: presence IS the tile (Joel, 2026-09-05). */
+    .live-tile:not([data-active]) {
+      opacity: 0.55;
+      filter: saturate(0.6);
+    }
+    /* SPEAKING — the reference's green active-speaker border, breathing while
+       REAL tokens flow on the live rail (never a timer animation). */
+    @keyframes live-speaking-pulse {
+      0%, 100% {
+        box-shadow: 0 0 10px rgba(63, 185, 80, 0.55), inset 0 0 14px rgba(63, 185, 80, 0.12);
+      }
+      50% {
+        box-shadow: 0 0 24px rgba(63, 185, 80, 0.95), inset 0 0 22px rgba(63, 185, 80, 0.2);
+      }
+    }
     .live-tile[data-speaking] {
       border-color: var(--status-online, #3fb950);
-      box-shadow: 0 0 0 1px var(--status-online, #3fb950);
+      animation: live-speaking-pulse 1.6s ease-in-out infinite;
     }
     .lt-glyph {
       font-size: 52px;
@@ -4831,6 +4835,21 @@ export class ChatWidget extends LitElement {
       /* Legacy tile spec: VRM portraits carry the face at the top of the
          frame — a centered crop lands on the collar. */
       object-position: center top;
+    }
+    .lt-status {
+      position: absolute;
+      top: 8px;
+      left: 8px;
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--status-offline, #555);
+      border: 2px solid rgba(0, 0, 0, 0.5);
+      z-index: 2;
+    }
+    .lt-status[data-on] {
+      background: var(--status-online, #3fb950);
+      box-shadow: 0 0 6px var(--status-online, #3fb950);
     }
     .lt-name {
       position: absolute;
@@ -4942,7 +4961,8 @@ export class ChatWidget extends LitElement {
       font-variant-numeric: tabular-nums;
     }
     @media (prefers-reduced-motion: reduce) {
-      .live-title-dot {
+      .live-title-dot,
+      .live-tile[data-speaking] {
         animation: none;
       }
       .live-tile:hover {

--- a/apps/web/src/live/callClient.ts
+++ b/apps/web/src/live/callClient.ts
@@ -65,6 +65,9 @@ export interface CallClientEvents {
    *  the host attaches video tracks to <video> elements and audio tracks to
    *  autoplaying <audio>; no JS ever touches pixels. */
   onTrack?: (identity: string, kind: 'video' | 'audio', track?: RemoteTrack) => void;
+  /** LiveKit's audio-level active-speaker set changed (the REAL "speaking",
+   *  from audio energy — never the token rail). Empty when the room is quiet. */
+  onActiveSpeakers?: (identities: ReadonlySet<string>) => void;
   /** Mirrors transcriptions onto the SAME StreamDelta shape the typing rail
    *  uses, so the existing caption/speaking plumbing needs zero new paths. */
   onDelta?: (delta: StreamDelta) => void;
@@ -169,6 +172,13 @@ export class CallClient {
   private async connectLiveKit(url: string, token: string): Promise<void> {
     try {
       const room = new Room();
+      // ACTIVE SPEAKERS — the audio-level signal LiveKit computes from real audio
+      // tracks (what legacy's AudioStreamClient used). The token rail's `speaking`
+      // flag lights a tile while a persona GENERATES TEXT, so every tile glowed at
+      // once and nobody was audible (Joel, 2026-09-05). Tiles light on this only.
+      room.on(RoomEvent.ActiveSpeakersChanged, (speakers) => {
+        this.events.onActiveSpeakers?.(new Set(speakers.map((p) => p.identity)));
+      });
       room.on(RoomEvent.TrackSubscribed, (track, _pub, participant) => {
         const kind = track.kind === Track.Kind.Video ? 'video' : 'audio';
         this.events.onTrack?.(participant.identity, kind, track);

--- a/apps/web/src/live/renderLive.spec.ts
+++ b/apps/web/src/live/renderLive.spec.ts
@@ -19,8 +19,24 @@ interface LitTemplateLike {
 function isTemplateLike(node: object): node is LitTemplateLike {
   return 'strings' in node && 'values' in node;
 }
+/** Lit's `repeat(items, key, template)` returns a DirectiveResult whose
+ *  `values` are [items, keyFn, template]; the grid renders every tile through
+ *  it (keyed tiles keep <video> elements attached across reorders), so the
+ *  DOM-free walk expands it the way the directive would. */
+interface DirectiveResultLike {
+  readonly values: readonly unknown[];
+}
+function isRepeatLike(node: object): node is DirectiveResultLike {
+  return '_$litDirective$' in node && 'values' in node;
+}
 function flatten(node: unknown, out: string[] = []): string[] {
   if (typeof node === 'string') out.push(node);
+  else if (typeof node === 'object' && node !== null && isRepeatLike(node)) {
+    const [items, keyOrTemplate, template] = node.values;
+    const tpl = (template ?? keyOrTemplate) as (item: unknown, i: number) => unknown;
+    if (Array.isArray(items) && typeof tpl === 'function')
+      items.forEach((item, i) => flatten(tpl(item, i), out));
+  }
   else if (typeof node === 'number') out.push(String(node));
   else if (Array.isArray(node)) for (const child of node as readonly unknown[]) flatten(child, out);
   else if (typeof node === 'object' && node !== null && isTemplateLike(node)) {
@@ -87,15 +103,19 @@ describe('renderLive (Lit)', () => {
   });
 });
 
-// what this catches: the composition rule — TikTok's two canonical layouts
-// driven by the REAL token rail: someone speaking ⇒ PANEL (speaker takes the
-// stage, everyone else in the rail), nobody speaking ⇒ GRID of equals.
-// Regression here = the stage stops following actual speech.
-it('composes panel when someone speaks, grid when nobody does', () => {
+// what this catches: the composition rule as Slack/Teams/Discord do it — GRID of
+// equals by default, speaking highlighted IN PLACE (data-speaking on the tile),
+// PANEL (stage + rail) ONLY when the reader pinned a tile by clicking. Staging on
+// the speaking flag was Zoom's speaker view by accident: one persona's head
+// filled the call while the human heard nothing (2026-09-05).
+it('composes grid while someone speaks (highlight in place) and panel only on a pin', () => {
   const speaking = flatten(renderLive(body())).join('');
-  expect(speaking).toContain('data-composition="panel"');
-  expect(speaking).toContain('live-stage');
-  expect(speaking).toContain('live-rail');
+  expect(speaking).toContain('data-composition="grid"');
+  expect(speaking).not.toContain('live-stage');
+  const pinned = flatten(renderLive(body({ pinnedId: 'asha' }))).join('');
+  expect(pinned).toContain('data-composition="panel"');
+  expect(pinned).toContain('live-stage');
+  expect(pinned).toContain('live-rail');
   const idle = flatten(
     renderLive(
       body({

--- a/apps/web/src/live/renderLive.ts
+++ b/apps/web/src/live/renderLive.ts
@@ -63,7 +63,6 @@ function participantTile(p: LiveParticipantVM): TemplateResult {
       : p.hasVideo
         ? html`<canvas class="lt-video" data-sender=${p.id}></canvas>`
         : nothing}
-    <span class="lt-status" data-on=${p.active ? '' : nothing} title=${p.active ? 'online' : 'offline'}></span>
     <span class="lt-name">
       ${p.name}${p.speaking ? html`<span class="lt-wave" aria-label="speaking">🔊</span>` : nothing}
     </span>
@@ -118,10 +117,15 @@ function renderComposition(body: LiveContentBody): TemplateResult {
   // room of peers): stage engages when the reader PINNED a tile (click), else
   // while someone is actively SPEAKING (real tokens flowing). Never merely
   // because video exists — a quiet call is a grid.
+  // Stage ONLY on an explicit pin (a click). Auto-staging whoever is flagged
+  // `speaking` was Zoom's speaker view by accident — the flag is the roster's
+  // activity HUD, so one persona's head filled the whole call while the human
+  // heard nothing (Joel, 2026-09-05: "like Slack and Teams do it ... only on
+  // click"). Speaking highlights IN PLACE via the tile's data-speaking attribute.
   const focused =
-    (body.pinnedId !== undefined
+    body.pinnedId !== undefined
       ? body.participants.find((p) => p.id === body.pinnedId)
-      : undefined) ?? body.participants.find((p) => p.speaking);
+      : undefined;
   if (focused) {
     const rail = body.participants.filter((p) => p.id !== focused.id);
     return html`<div class="live-panel" data-composition="panel">


### PR DESCRIPTION
Joel's live-mode test (2026-09-05): one persona's head filled the whole call, every tile glowed, green presence dots sat on tiles that ARE the presence, and nobody was audible.

- Stage engages only on an explicit pin (tile click); Escape unpins. The old rule auto-staged whoever carried the roster's `speaking` flag — Zoom's speaker view by accident, driven by the TOKEN rail (a persona generating text), not audio.
- Tile "speaking" now rides LiveKit's `ActiveSpeakersChanged` (audio energy), surfaced as `onActiveSpeakers` on the call client's events; the token rail no longer lights tiles.
- Presence dot removed; no dimming of "inactive" tiles; the breathing glow becomes a plain speaker border.
- `renderLive.spec`'s DOM-free flattener expands Lit's keyed `repeat` (the grid renders every tile through it) — fixes the pre-existing "expected … to include 'Joel'" failure. Spec 4/4, `tsc --noEmit` clean.

Legacy `LiveWidget` used as the reference for the behaviours (pin, Escape), not reused. Follow-ups in flight: persona replies → `voice/speak-in-call` when the room has a call; captions from the bridge's audio → STT; the human's identity/avatar in the live view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo