### PR TITLE
probe(serving): the below-plan floor keeps speaking without drowning the log

### DIFF
--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -1902,7 +1902,25 @@ impl ServingDaemonModule {
                     // a design call on a guard written from an incident, so it is
                     // surfaced for the humans who own that history rather than
                     // quietly re-tuned by me (#332/#333).
-                    if live_space < plan_space {
+                    // CADENCE, not content. This probe exists because the SILENCE was
+                    // the defect, so it must keep speaking — but at one line per 5 s
+                    // tick it becomes the defect at the other end: measured on BigMama
+                    // 2026-09-05, 192 consecutive identical copies, and a persona's
+                    // `first_token` had to be dug out from underneath them. A chatty
+                    // floor evicts the signal from every bounded view exactly when the
+                    // lane is interesting — the same class that buried a wedge
+                    // declaration and produced a false retraction the same night.
+                    //
+                    // So: every ENTRY into the declined state is logged (streak == 1),
+                    // and it keeps saying so once a minute after that. Nothing is
+                    // suppressed that a reader needs — `streak` already carries the
+                    // duration, so the 47th copy adds no information the 1st lacked.
+                    // The 2x rule and this decision are untouched; only how often the
+                    // same unchanged verdict repeats itself.
+                    const DECLINE_LOG_EVERY_TICKS: u32 = 12; // 5 s ticks -> ~1/min
+                    let first_or_periodic =
+                        streak <= 1 || streak % DECLINE_LOG_EVERY_TICKS == 0;
+                    if live_space < plan_space && first_or_periodic {
                         crate::probe!(
                             class = "serving.reconcile.window",
                             decision = "declined",


### PR DESCRIPTION
`serving.reconcile.window decision=declined` fires **every 5 s tick** while a lane serves below plan.

Measured on BigMama, 2026-09-05:

```
grep -c "lane is serving BELOW plan and has not yet earned a re-home"  ->  192
```

192 consecutive identical copies — and a citizen's `persona.turn.first_token`, the line proving the CUDA lane was actually generating, had to be dug out from underneath them.

## Why this is a defect and not just noise

It's the bounded-window eviction class applied to the log itself: a chatty floor pushes the signal out of every `tail`, every grep window, every incident view — **exactly when the lane is interesting enough to look at.** The same shape buried a wedge declaration on this box the same night and produced a false retraction from me at 03:00.

## What is deliberately NOT changed

The probe's **content**. Its own comment is explicit that the *silence* was the original defect — a lane stranded at 62% of plan with nothing anywhere saying so (2026-08-06) — so it must keep speaking. And the 2× re-home rule it reports on is a design call its author deliberately left to the humans who own that incident history (#332/#333). Neither is touched.

## What changes

Only the repetition. Every **entry** into the declined state still logs, and it keeps saying so once a minute after that:

```rust
const DECLINE_LOG_EVERY_TICKS: u32 = 12;   // 5 s ticks -> ~1/min
streak <= 1 || streak % DECLINE_LOG_EVERY_TICKS == 0
```

Nothing a reader needs is suppressed: `streak` is already a field on the probe, so **duration is carried by the line rather than by the number of lines**, and the 47th identical copy adds no information the 1st lacked.

`192 lines / 16 min` becomes `~16`.

## Validation

`cargo check -p continuum-core --lib`: clean.

Not validated by the precommit hook — it is unpassable on any current checkout (`git-precommit.sh:5` cd's to `tools/`, `:68` then checks a relative `node_modules` in a directory with no `package.json`). Diagnosed and carded separately; not bypassed with `--no-verify`.