### PR TITLE
fix(identity): an anonymous socket is never an identity — whoami resolves the web desktop to the operator

### DIFF
--- a/core/continuum-core/src/commands/identity_whoami.rs
+++ b/core/continuum-core/src/commands/identity_whoami.rs
@@ -52,7 +52,10 @@ crate::action_command! {
     output: WhoamiResult,
     run(_this, ctx, _p) => {
         // A persona toolbelt caller is herself.
-        if let Some(caller) = ctx.caller.as_ref() {
+        // A signed caller is who it says it is. An anonymous socket (the web
+        // desktop's WS, stamped nil by the transport) carries NO identity and
+        // resolves like a caller-less session: the claimed actor or the operator.
+        if let Some(caller) = ctx.caller.as_ref().filter(|c| !c.is_anonymous_socket()) {
             let id = caller.peer_id.as_uuid();
             let name = crate::persona::PersonaAircRuntimeRegistry::try_global()
                 .and_then(|r| r.get(id))
@@ -99,6 +102,41 @@ mod tests {
     // what this catches: the identity spine's resolution verb — its wire name
     // (every client boots against it) and AiSafe access (asking who you are is
     // the first thing any session does).
+    // what this catches: the web desktop's WS stamps every unsigned connection
+    // with the nil peer id; whoami once read that sentinel as a PERSONA and the
+    // human's profile page rendered "00000000-0000-…" as their name (2026-09-05).
+    // An anonymous socket must resolve like a caller-less session (operator /
+    // claimed actor — absent in this test, so a named refusal), never as an
+    // identity; a SIGNED caller still resolves to itself.
+    #[tokio::test]
+    async fn an_anonymous_socket_is_never_an_identity() {
+        use crate::identity::PeerId;
+        use crate::routing::CallerIdentity;
+        use crate::sdk_codegen::Ctx as CommandContext;
+
+        let anonymous = CommandContext {
+            caller: Some(CallerIdentity::ws(PeerId::from_uuid(uuid::Uuid::nil()))),
+            ..Default::default()
+        };
+        let err = IdentityWhoami
+            .run(&anonymous, WhoamiParams {})
+            .await
+            .expect_err("nil socket must not resolve to a persona");
+        assert!(
+            err.to_string().contains("operator self-peer"),
+            "falls through to the operator resolution, got: {err}"
+        );
+
+        let signed_id = PeerId::new();
+        let signed = CommandContext {
+            caller: Some(CallerIdentity::airc(signed_id.clone())),
+            ..Default::default()
+        };
+        let me = IdentityWhoami.run(&signed, WhoamiParams {}).await.unwrap();
+        assert_eq!(me.id, signed_id.as_uuid().to_string());
+        assert_eq!(me.kind, "persona");
+    }
+
     #[test]
     fn whoami_is_aisafe_under_its_wire_name() {
         assert_eq!(IdentityWhoami::NAME, "identity/whoami");

--- a/core/continuum-core/src/routing/auth_policy.rs
+++ b/core/continuum-core/src/routing/auth_policy.rs
@@ -253,6 +253,18 @@ impl CallerIdentity {
         }
     }
 
+    /// An UNAUTHENTICATED socket: a `Ws`/`Tcp` caller the transport stamped
+    /// with the nil peer id because nobody signed the connection. It is not
+    /// an identity — it is the absence of one — so anything resolving "who is
+    /// this" must fall through to the session's claimed actor (agent) or the
+    /// operator, never render the nil uuid as a person. (The web desktop
+    /// called the human "00000000-0000-…" for a day because `identity/whoami`
+    /// read this sentinel as a persona — Joel, 2026-09-05.)
+    pub fn is_anonymous_socket(&self) -> bool {
+        self.peer_id.as_uuid().is_nil()
+            && matches!(self.source, CallerSource::Ws | CallerSource::Tcp)
+    }
+
     /// Construct a POSITRON-OBSERVER caller identity — an AI observer acting
     /// through a positron session over an unauthenticated socket. `peer_id` is
     /// the socket's peer (nil today, same as the human's `ws` connection);


### PR DESCRIPTION
The web desktop's WS transport stamps every unsigned connection with the nil peer id. `identity/whoami` read that sentinel as a PERSONA, so the desktop's viewer was `00000000-0000-…`, kind persona — the human's profile page rendered the nil uuid as their name (Joel, 2026-09-05: "this system doesn't know who anyone is in the desktop").

- `CallerIdentity::is_anonymous_socket()` names the shape (nil peer on a `Ws`/`Tcp` source).
- whoami filters it out and resolves like a caller-less session: the claimed actor (agent) or the operator self-peer (`$USER`, the durable human identity per home). A signed caller still resolves to itself.
- Regression test in the whoami mod (4/4 pass); `cargo check` clean.

Effect on the desktop after deploy: the viewer's id/name become the operator's (the directory's human row), the LiveKit identity minted by `live/token` follows, and the profile page shows the human by name. The avatar half (a default picture for the human) is a separate card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo