### PR TITLE
feat(live): personas speak their room lines in a call; STT chain named at every joint; pump probes summarize; the human's default picture

### DIFF
--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -170,12 +170,28 @@ struct AircChatHeard {
 /// emit `chat:posted` without knowing continuum's identity model.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct AircChatPosted {
-    message_id: Uuid,
-    room_id: Uuid,
-    sender_id: Uuid,
-    content: String,
-    timestamp: u64,
+pub(crate) struct AircChatPosted {
+    pub(crate) message_id: Uuid,
+    pub(crate) room_id: Uuid,
+    pub(crate) sender_id: Uuid,
+    pub(crate) content: String,
+    pub(crate) timestamp: u64,
+}
+
+/// The airc bus wraps event bodies under a `payload` key (see
+/// `airc_bridge_directive::str_field`); accept a nested `payload` object,
+/// else the top-level value. ONE envelope rule for every bus consumer.
+pub(crate) fn bus_event_body(payload: &serde_json::Value) -> &serde_json::Value {
+    payload.get("payload").unwrap_or(payload)
+}
+
+/// Parse a `chat:posted` bus event — shared by the chat projection and the
+/// voice module's reply speaker (compression: one wire shape, one parser).
+pub(crate) fn parse_chat_posted(name: &str, payload: &serde_json::Value) -> Option<AircChatPosted> {
+    if name != CHAT_POSTED {
+        return None;
+    }
+    serde_json::from_value::<AircChatPosted>(bus_event_body(payload).clone()).ok()
 }
 
 /// Typed `presence:updated` payload — a full roster snapshot for a room.
@@ -1022,10 +1038,7 @@ enum ProjectionInput {
 }
 
 fn classify(name: &str, payload: &serde_json::Value) -> Option<ProjectionInput> {
-    // The airc bus wraps event bodies under a `payload` key (see
-    // `airc_bridge_directive::str_field`); accept a nested `payload`
-    // object, else the top-level value.
-    let body = payload.get("payload").unwrap_or(payload);
+    let body = bus_event_body(payload);
     match name {
         CHAT_HEARD => serde_json::from_value::<AircChatHeard>(body.clone())
             .ok()

--- a/core/continuum-core/src/ipc/positron_source.rs
+++ b/core/continuum-core/src/ipc/positron_source.rs
@@ -182,7 +182,7 @@ pub(crate) struct AircChatPosted {
 /// `airc_bridge_directive::str_field`); accept a nested `payload` object,
 /// else the top-level value. ONE envelope rule for every bus consumer.
 pub(crate) fn bus_event_body(payload: &serde_json::Value) -> &serde_json::Value {
-    payload.get("payload").unwrap_or(payload)
+    payload.get("payload").unwrap_or(payload) // unwrap_or: no envelope = the value IS the body (both shapes are on the wire)
 }
 
 /// Parse a `chat:posted` bus event — shared by the chat projection and the

--- a/core/continuum-core/src/live/transport/bridge_client.rs
+++ b/core/continuum-core/src/live/transport/bridge_client.rs
@@ -290,7 +290,7 @@ impl LiveKitAgentManager {
             Ok(()) => {
                 // One summary row per second, not one per frame (12 pumps ×
                 // 30 fps blinded the ledger — see pump_tally.rs).
-                let summary = self.enqueue_tally.lock().unwrap().record(frame_bytes as u64, 0);
+                let summary = self.enqueue_tally.lock().unwrap().record(frame_bytes as u64, 0); // unwrap: tally mutex holds three counters; a poisoned lock here means a panic mid-record, and dropping the probe row is the honest outcome
                 if let Some(s) = summary {
                     crate::probe!(
                         class = "media.pump.enqueue",

--- a/core/continuum-core/src/live/transport/bridge_client.rs
+++ b/core/continuum-core/src/live/transport/bridge_client.rs
@@ -71,6 +71,8 @@ pub struct LiveKitAgentManager {
     /// Frames dropped because the media queue was full (bridge stalled). Loud
     /// via rate-limited warn in [`Self::send_media`]; MUST stay 0 steady-state.
     media_dropped: Arc<AtomicU64>,
+    /// Enqueue-side per-second tally (probe summary, never a row per frame).
+    enqueue_tally: Mutex<super::pump_tally::PumpTally>,
     /// Bridge socket path.
     bridge_socket_path: String,
     /// LiveKit URL (for logging only — bridge has the actual connection).
@@ -166,6 +168,7 @@ impl LiveKitAgentManager {
             out_channels: Mutex::new(std::collections::HashMap::new()),
             next_out_channel: AtomicU64::new(1),
             media_dropped: Arc::new(AtomicU64::new(0)),
+            enqueue_tally: Mutex::new(super::pump_tally::PumpTally::new(std::time::Duration::from_secs(1))),
             bridge_socket_path,
             livekit_url,
             next_request_id: AtomicU64::new(1),
@@ -285,12 +288,19 @@ impl LiveKitAgentManager {
         let kind = label;
         match tx.try_send(item) {
             Ok(()) => {
-                crate::probe!(
-                    class = "media.pump.enqueue",
-                    module = "livekit-bridge",
-                    kind = kind,
-                    bytes = frame_bytes
-                );
+                // One summary row per second, not one per frame (12 pumps ×
+                // 30 fps blinded the ledger — see pump_tally.rs).
+                let summary = self.enqueue_tally.lock().unwrap().record(frame_bytes as u64, 0);
+                if let Some(s) = summary {
+                    crate::probe!(
+                        class = "media.pump.enqueue",
+                        module = "livekit-bridge",
+                        kind = kind,
+                        frames = s.frames,
+                        bytes = s.bytes,
+                        span_ms = s.span_ms
+                    );
+                }
                 Ok(())
             }
             Err(std::sync::mpsc::TrySendError::Full(_)) => {
@@ -762,6 +772,7 @@ fn media_pump_loop(
     rx: std::sync::mpsc::Receiver<MediaFrame>,
     writer: Arc<Mutex<Option<UnixStream>>>,
 ) {
+    let mut tally = super::pump_tally::PumpTally::new(std::time::Duration::from_secs(1));
     while let Ok(item) = rx.recv() {
         let start = std::time::Instant::now();
         let mut guard = writer.lock().unwrap();
@@ -786,13 +797,17 @@ fn media_pump_loop(
                 // state is tens of µs; a growing write_us trend means the
                 // bridge socket buffer is backing up — the drop counter's
                 // leading indicator.
-                crate::probe!(
-                    class = "media.pump.write",
-                    module = "livekit-bridge",
-                    kind = item.kind,
-                    bytes = item.wire_len(),
-                    write_us = start.elapsed().as_micros() as u64
-                );
+                if let Some(s) = tally.record(item.wire_len() as u64, start.elapsed().as_micros() as u64) {
+                    crate::probe!(
+                        class = "media.pump.write",
+                        module = "livekit-bridge",
+                        kind = item.kind,
+                        frames = s.frames,
+                        bytes = s.bytes,
+                        max_write_us = s.max_us,
+                        span_ms = s.span_ms
+                    );
+                }
             }
             None => {
                 // Connection died under us — this pump's generation is over.

--- a/core/continuum-core/src/live/transport/call_server.rs
+++ b/core/continuum-core/src/live/transport/call_server.rs
@@ -844,6 +844,14 @@ impl CallManager {
                     if let (Some(user_id), Some(display_name), Some(speech_samples)) =
                         (result.user_id, result.display_name, result.speech_samples)
                     {
+                        crate::probe!(
+                            class = "live.stt.speech_ended",
+                            module = "live",
+                            call_id = call_id.as_str(),
+                            speaker = user_id.as_str(),
+                            samples = speech_samples.len() as u64,
+                            "VAD closed an utterance — whisper runs next (or the semaphore refuses)"
+                        );
                         // Try to acquire semaphore permit (non-blocking)
                         // If we can't, drop this audio to prevent backlog
                         let semaphore = TRANSCRIPTION_SEMAPHORE.clone();
@@ -863,6 +871,15 @@ impl CallManager {
                                         speech_samples,
                                     )
                                     .await;
+                                    crate::probe!(
+                                        class = "live.stt.transcribed",
+                                        module = "live",
+                                        call_id = room.as_str(),
+                                        speaker = user_id.as_str(),
+                                        chars = text.as_ref().map(|t| t.chars().count()).unwrap_or(0) as u64,
+                                        to_minds = sink.is_some(),
+                                        "whisper returned (chars 0 = empty/failed); to_minds = a transcript sink turns it into a room line"
+                                    );
                                     if let (Some(sink), Some(text)) = (sink, text) {
                                         sink(&room, &user_id, &display_name, &text);
                                     }
@@ -872,6 +889,13 @@ impl CallManager {
                             }
                             Err(_) => {
                                 // Queue full - drop this audio to stay current
+                                crate::probe!(
+                                    class = "live.stt.refused",
+                                    module = "live",
+                                    call_id = call_id.as_str(),
+                                    speaker = user_id.as_str(),
+                                    reason = "transcription_queue_full"
+                                );
                                 clog_warn!(
                                     "🚨 Dropping audio from {} - transcription queue full ({} max)",
                                     display_name,
@@ -1032,7 +1056,13 @@ impl CallManager {
             calls.get(call_id).cloned()
         };
         let Some(call) = call else {
-            return; // no native Call — nobody has this call open on this node
+            // No native Call — nobody has this call open on this node. Silent
+            // once; on 2026-09-05 Joel spoke into a live call and no caption
+            // ever appeared, and this return was one of two places the audio
+            // could vanish without a trace. Now it says so (once per speaker
+            // per call, not per 10 ms frame).
+            Self::note_remote_audio_dropped(call_id, user_id, "no_native_call");
+            return;
         };
         let handle = {
             let call = call.read().await;
@@ -1042,10 +1072,37 @@ impl CallManager {
             // Media arrived before (or without) the WS-control join that mints
             // her handle + VAD — a real ordering that self-heals when the join
             // lands; frames until then are honestly droppable (they predate
-            // her being a participant here).
+            // her being a participant here). The bridge's speaker id is the
+            // LiveKit identity; the mixer's is the WS join's user id — when the
+            // two vocabularies differ this is where captions die.
+            Self::note_remote_audio_dropped(call_id, user_id, "no_mixer_handle");
             return;
         };
         self.push_audio(&handle, samples).await;
+    }
+
+    /// One `live.stt.audio_dropped` probe per (call, speaker, reason) — the
+    /// forwarder delivers ~100 chunks/s, so a per-chunk probe would blind the
+    /// ledger the way the video pump did (pump_tally.rs).
+    fn note_remote_audio_dropped(call_id: &str, user_id: &str, reason: &'static str) {
+        use std::collections::HashSet;
+        use std::sync::{Mutex, OnceLock};
+        static SEEN: OnceLock<Mutex<HashSet<(String, String, &'static str)>>> = OnceLock::new();
+        let seen = SEEN.get_or_init(|| Mutex::new(HashSet::new()));
+        let fresh = seen
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert((call_id.to_string(), user_id.to_string(), reason));
+        if fresh {
+            crate::probe!(
+                class = "live.stt.audio_dropped",
+                module = "live",
+                call_id = call_id,
+                speaker = user_id,
+                reason = reason,
+                "remote human audio dropped before VAD — captions cannot happen for this speaker"
+            );
+        }
     }
 
     /// Broadcast a CallMessage to all participants in a call (avatar updates, etc.)

--- a/core/continuum-core/src/live/transport/call_server.rs
+++ b/core/continuum-core/src/live/transport/call_server.rs
@@ -876,7 +876,7 @@ impl CallManager {
                                         module = "live",
                                         call_id = room.as_str(),
                                         speaker = user_id.as_str(),
-                                        chars = text.as_ref().map(|t| t.chars().count()).unwrap_or(0) as u64,
+                                        chars = text.as_ref().map(|t| t.chars().count()).unwrap_or(0) as u64, // unwrap_or: None = whisper returned nothing; 0 chars IS that fact, the row says so
                                         to_minds = sink.is_some(),
                                         "whisper returned (chars 0 = empty/failed); to_minds = a transcript sink turns it into a room line"
                                     );
@@ -1091,7 +1091,7 @@ impl CallManager {
         let seen = SEEN.get_or_init(|| Mutex::new(HashSet::new()));
         let fresh = seen
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(|e| e.into_inner()) // unwrap_or_else: a poisoned dedupe set still dedupes; the probe must fire once, never never
             .insert((call_id.to_string(), user_id.to_string(), reason));
         if fresh {
             crate::probe!(

--- a/core/continuum-core/src/live/transport/mod.rs
+++ b/core/continuum-core/src/live/transport/mod.rs
@@ -1,4 +1,5 @@
 pub mod bridge_client;
+pub mod pump_tally;
 pub mod call_room;
 pub mod call_server;
 pub mod media;

--- a/core/continuum-core/src/live/transport/pump_tally.rs
+++ b/core/continuum-core/src/live/transport/pump_tally.rs
@@ -1,0 +1,82 @@
+//! Per-second tally for a per-FRAME hot path — the probe for a 30 fps × N
+//! pump is a SUMMARY, never a row per frame.
+//!
+//! Twelve avatar pumps at 30 fps wrote ~370 `media.pump.*` rows a second into
+//! the size-rotated probe ledger; the whole file held ~34 s of history and
+//! every cognition class read ZERO for the length of a live call — the
+//! substrate looked dead while the run room filled with work receipts
+//! (2026-09-05). Per-tick probes rotate truth away
+//! ([[time-based-convergence-dies-under-restarts-and-per-tick-probes-rotate-truth-away]]);
+//! a hot path reports once a second with counts and a maximum.
+
+use std::time::{Duration, Instant};
+
+/// Frames/bytes/max-latency accumulated since the last emit. Not thread-safe
+/// by itself — the caller owns the lock (or the thread).
+#[derive(Debug)]
+pub struct PumpTally {
+    frames: u64,
+    bytes: u64,
+    max_us: u64,
+    since: Instant,
+    period: Duration,
+}
+
+/// One second's worth of pump activity, handed to the probe at emit time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PumpSummary {
+    pub frames: u64,
+    pub bytes: u64,
+    pub max_us: u64,
+    pub span_ms: u64,
+}
+
+impl PumpTally {
+    pub fn new(period: Duration) -> Self {
+        Self { frames: 0, bytes: 0, max_us: 0, since: Instant::now(), period }
+    }
+
+    /// Record one frame. Returns the period's summary when it is time to emit
+    /// (and resets), else `None` — the caller probes only on `Some`.
+    pub fn record(&mut self, bytes: u64, latency_us: u64) -> Option<PumpSummary> {
+        self.frames += 1;
+        self.bytes += bytes;
+        self.max_us = self.max_us.max(latency_us);
+        let elapsed = self.since.elapsed();
+        if elapsed < self.period {
+            return None;
+        }
+        let out = PumpSummary {
+            frames: self.frames,
+            bytes: self.bytes,
+            max_us: self.max_us,
+            span_ms: elapsed.as_millis() as u64,
+        };
+        self.frames = 0;
+        self.bytes = 0;
+        self.max_us = 0;
+        self.since = Instant::now();
+        Some(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: a per-frame hot path must emit at most once per
+    // period — N frames inside the period produce no summary, the first frame
+    // past it produces ONE carrying all N+1, and the tally restarts.
+    #[test]
+    fn a_period_of_frames_collapses_to_one_summary() {
+        let mut t = PumpTally::new(Duration::from_millis(20));
+        for _ in 0..9 {
+            assert_eq!(t.record(100, 5), None);
+        }
+        std::thread::sleep(Duration::from_millis(25));
+        let s = t.record(100, 40).expect("period elapsed → one summary");
+        assert_eq!((s.frames, s.bytes, s.max_us), (10, 1000, 40));
+        assert!(s.span_ms >= 20);
+        assert_eq!(t.record(1, 1), None, "tally restarted after the emit");
+    }
+}

--- a/core/continuum-core/src/modules/live.rs
+++ b/core/continuum-core/src/modules/live.rs
@@ -91,7 +91,7 @@ impl VoiceState {
     pub fn has_active_session(&self, call_id: &str) -> bool {
         self.active_sessions
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(|e| e.into_inner()) // unwrap_or_else: a poisoned set still answers membership; refusing would mute every call
             .contains(call_id)
     }
 
@@ -118,7 +118,7 @@ impl VoiceState {
         // HEAR her instead of the hold-music the lonely-listener mixer plays.
         // Sibling of the avatar-video tee. No-op if no native client is on the call.
         self.call_manager
-            .push_persona_audio(call_id, user_id, display_name.unwrap_or(user_id), samples)
+            .push_persona_audio(call_id, user_id, display_name.unwrap_or(user_id), samples) // unwrap_or: no display name → the identity string labels the audio, honest and unique
             .await;
         Ok((num_samples, duration_ms, sample_rate))
     }

--- a/core/continuum-core/src/modules/live.rs
+++ b/core/continuum-core/src/modules/live.rs
@@ -86,6 +86,43 @@ impl VoiceState {
     /// client-minted `session_id` resolves to the canonical airc `room_id` it was
     /// aliased to at register time; any other id (already canonical, or unknown)
     /// passes through unchanged.
+    /// Is a voice session live for this canonical call/room id? The reply
+    /// speaker asks this before turning a room line into speech.
+    pub fn has_active_session(&self, call_id: &str) -> bool {
+        self.active_sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains(call_id)
+    }
+
+    /// Synthesize `text` in `user_id`'s voice into the call (LiveKit track) and
+    /// tee the SAME samples into the native call plane so native clients hear
+    /// her too. ONE speak path — the `voice/speak-in-call` verb and the reply
+    /// speaker both come through here. Returns (samples, duration_ms, rate).
+    pub async fn speak_in_room(
+        &self,
+        call_id: &str,
+        user_id: &str,
+        text: &str,
+        voice: Option<&str>,
+        adapter: Option<&str>,
+        display_name: Option<&str>,
+    ) -> Result<(usize, u64, u32), String> {
+        let (samples, duration_ms, sample_rate) = self
+            .livekit_manager
+            .speak_in_call(call_id, user_id, text, voice, adapter, display_name)
+            .await?;
+        let num_samples = samples.len();
+        // #193 audio convergence: tee the SAME synthesized voice into the
+        // native call plane so native clients (positron web, glass-box harness)
+        // HEAR her instead of the hold-music the lonely-listener mixer plays.
+        // Sibling of the avatar-video tee. No-op if no native client is on the call.
+        self.call_manager
+            .push_persona_audio(call_id, user_id, display_name.unwrap_or(user_id), samples)
+            .await;
+        Ok((num_samples, duration_ms, sample_rate))
+    }
+
     fn canonical_call_id(&self, id: &str) -> String {
         let aliases = self
             .legacy_call_aliases
@@ -184,9 +221,12 @@ impl ServiceModule for VoiceModule {
         self.state.executor.install(executor);
     }
 
-    async fn initialize(&self, _ctx: &ModuleContext) -> Result<(), String> {
+    async fn initialize(&self, ctx: &ModuleContext) -> Result<(), String> {
         // Spawn idle watcher here (inside tokio runtime), not in VoiceState::new()
         self.state.resource_lifecycle.spawn_idle_watcher();
+        // A hosted persona's room line becomes her VOICE while the room has a
+        // live call (Joel, 2026-09-05: "they say they're talking … no output").
+        super::voice_reply_speaker::spawn(ctx.bus.clone(), self.state.clone());
         // Safety net: detect orphaned sessions (browser crash, lost WebSocket, deploy)
         self.state.resource_lifecycle.spawn_orphan_watchdog();
 
@@ -529,10 +569,9 @@ impl ServiceModule for VoiceModule {
                 // TODO: Use for Rust-side TTS output scheduling (ordering + stale detection).
                 let _timeline_seq = p.u64_opt("timeline_seq");
 
-                let (samples, duration_ms, sample_rate) = self
+                let (num_samples, duration_ms, sample_rate) = self
                     .state
-                    .livekit_manager
-                    .speak_in_call(&call_id, user_id, text, voice, adapter, display_name)
+                    .speak_in_room(&call_id, user_id, text, voice, adapter, display_name)
                     .await
                     .map_err(|e| {
                         log_error!(
@@ -543,16 +582,6 @@ impl ServiceModule for VoiceModule {
                         );
                         format!("Speak-in-call failed: {}", e)
                     })?;
-                let num_samples = samples.len();
-
-                // #193 audio convergence: tee the SAME synthesized voice into the
-                // native call plane so native clients (positron web, glass-box harness)
-                // HEAR her instead of the hold-music the lonely-listener mixer plays.
-                // Sibling of the avatar-video tee. No-op if no native client is on the call.
-                self.state
-                    .call_manager
-                    .push_persona_audio(&call_id, user_id, display_name.unwrap_or(user_id), samples)
-                    .await;
 
                 log_info!(
                     "module",

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -57,6 +57,7 @@ pub mod hippocampus;
 pub mod inference_coordinator_module;
 pub mod launch_mode;
 pub mod live;
+pub mod voice_reply_speaker;
 pub mod live_session_consumer;
 pub mod logger;
 pub mod mcp;

--- a/core/continuum-core/src/modules/voice_reply_speaker.rs
+++ b/core/continuum-core/src/modules/voice_reply_speaker.rs
@@ -1,0 +1,152 @@
+//! Reply speaker — a hosted persona's room line becomes her VOICE while the
+//! room has a live call.
+//!
+//! Before this, a call had twelve animated heads and hold music: citizens
+//! answered the human in TEXT (the room line, the token rail lit the tile)
+//! and nothing ever reached `voice/speak-in-call`, so nobody was audible
+//! (Joel, 2026-09-05: "they say they're talking … no output"). The room is
+//! the call (`call_id == room_id`, #193), so the seam is the bus: every
+//! `chat:posted` in a room with an active voice session, from a persona this
+//! node hosts, is spoken through ONE path — [`VoiceState::speak_in_room`].
+//!
+//! Shape (CONCURRENCY-STYLE-GUIDE): own task on the bus receiver, sequential
+//! speech (voices never overlap — one utterance at a time across the node),
+//! lag on the broadcast channel is skipped and counted, never a crash.
+
+use std::sync::Arc;
+
+use tokio::sync::broadcast::error::RecvError;
+
+use crate::ipc::positron_source::parse_chat_posted;
+use crate::modules::live::VoiceState;
+use crate::runtime::message_bus::MessageBus;
+
+/// Longest utterance spoken from one room line. A 500-token reply is minutes
+/// of TTS on a laptop; the first sentences carry the answer, the rest stays
+/// on screen as text.
+pub(crate) const MAX_SPOKEN_CHARS: usize = 600;
+
+pub(crate) fn spawn(bus: Arc<MessageBus>, state: Arc<VoiceState>) {
+    let mut rx = bus.receiver();
+    tokio::spawn(async move {
+        loop {
+            let event = match rx.recv().await {
+                Ok(e) => e,
+                Err(RecvError::Lagged(n)) => {
+                    crate::probe!(
+                        class = "live.tts.bus_lagged",
+                        module = "live",
+                        skipped = n,
+                        "reply speaker fell behind the bus — those lines stay text-only"
+                    );
+                    continue;
+                }
+                Err(RecvError::Closed) => return,
+            };
+            let Some(posted) = parse_chat_posted(&event.name, &event.payload) else {
+                continue;
+            };
+            let room = posted.room_id.to_string();
+            if !state.has_active_session(&room) {
+                continue;
+            }
+            // Only a persona THIS node hosts speaks here — the human's line is
+            // her own voice already, a remote peer's line is spoken on its host.
+            let Some(name) = crate::persona::PersonaAircRuntimeRegistry::try_global()
+                .and_then(|r| r.get(posted.sender_id))
+                .map(|rt| rt.agent_name().to_string())
+            else {
+                continue;
+            };
+            let Some((text, truncated)) = speakable_text(&posted.content) else {
+                continue;
+            };
+            let persona = posted.sender_id.to_string();
+            let started = std::time::Instant::now();
+            match state
+                .speak_in_room(&room, &persona, &text, None, None, Some(&name))
+                .await
+            {
+                Ok((_, duration_ms, _)) => crate::probe!(
+                    class = "live.tts.spoken",
+                    module = "live",
+                    room = room.as_str(),
+                    persona = name.as_str(),
+                    chars = text.chars().count() as u64,
+                    truncated = truncated,
+                    audio_ms = duration_ms,
+                    synth_ms = started.elapsed().as_millis() as u64,
+                    "a room line became her voice in the call"
+                ),
+                Err(e) => crate::probe!(
+                    class = "live.tts.failed",
+                    module = "live",
+                    room = room.as_str(),
+                    persona = name.as_str(),
+                    error = e.as_str(),
+                    "speak_in_room refused — the line stays text-only"
+                ),
+            }
+        }
+    });
+}
+
+/// What of a room line is worth SAYING: thought receipts (`💭 …`) are the
+/// glass box, not speech; code fences are read on screen, not aloud; and
+/// the utterance is capped at [`MAX_SPOKEN_CHARS`] on a sentence boundary.
+/// Returns `(text, truncated)`, or `None` when nothing speakable remains.
+pub(crate) fn speakable_text(content: &str) -> Option<(String, bool)> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() || trimmed.starts_with("💭") {
+        return None;
+    }
+    // Drop fenced code blocks wholesale.
+    let mut out = String::with_capacity(trimmed.len());
+    let mut in_fence = false;
+    for line in trimmed.lines() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if !in_fence {
+            out.push_str(line);
+            out.push(' ');
+        }
+    }
+    let spoken: String = out.split_whitespace().collect::<Vec<_>>().join(" ");
+    if spoken.is_empty() {
+        return None;
+    }
+    if spoken.chars().count() <= MAX_SPOKEN_CHARS {
+        return Some((spoken, false));
+    }
+    let head: String = spoken.chars().take(MAX_SPOKEN_CHARS).collect();
+    let cut = head
+        .rfind(['.', '!', '?'])
+        .map(|i| i + 1)
+        .filter(|&i| i > MAX_SPOKEN_CHARS / 3)
+        .unwrap_or(head.len());
+    Some((head[..cut].trim_end().to_string(), true))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the speakable filter's three rules — a thought
+    // receipt is never spoken, code fences are dropped while the prose around
+    // them survives, and a long reply is cut on a sentence boundary under the
+    // cap with `truncated = true`.
+    #[test]
+    fn receipts_are_silent_fences_drop_and_long_replies_cut_on_a_sentence() {
+        assert_eq!(speakable_text("💭 Let me look at the repo"), None);
+        assert_eq!(speakable_text("   "), None);
+        let (t, cut) = speakable_text("Try this:\n```rust\nlet x = 1;\n```\nThen run it.").unwrap();
+        assert_eq!((t.as_str(), cut), ("Try this: Then run it.", false));
+        let long = "One sentence here. ".repeat(60);
+        let (t, cut) = speakable_text(&long).unwrap();
+        assert!(cut);
+        assert!(t.chars().count() <= MAX_SPOKEN_CHARS);
+        assert!(t.ends_with('.'), "cut on a sentence boundary, got: {t:?}");
+    }
+}

--- a/core/continuum-core/src/modules/voice_reply_speaker.rs
+++ b/core/continuum-core/src/modules/voice_reply_speaker.rs
@@ -24,6 +24,8 @@ use crate::runtime::message_bus::MessageBus;
 /// Longest utterance spoken from one room line. A 500-token reply is minutes
 /// of TTS on a laptop; the first sentences carry the answer, the rest stays
 /// on screen as text.
+// context-budget-exempt: an UTTERANCE length for TTS, not a prompt/context size — it scales with a
+// listener's patience (~40 s of speech), not with the served window; the rest of the line stays on screen.
 pub(crate) const MAX_SPOKEN_CHARS: usize = 600;
 
 /// A line older than this at SPEAK time is dropped, not spoken. Speech is
@@ -158,7 +160,7 @@ pub(crate) fn speakable_text(content: &str) -> Option<(String, bool)> {
         .rfind(['.', '!', '?'])
         .map(|i| i + 1)
         .filter(|&i| i > MAX_SPOKEN_CHARS / 3)
-        .unwrap_or(head.len());
+        .unwrap_or(head.len()); // unwrap_or: no sentence end in the head → cut at the cap itself, still marked truncated
     Some((head[..cut].trim_end().to_string(), true))
 }
 

--- a/core/continuum-core/src/modules/voice_reply_speaker.rs
+++ b/core/continuum-core/src/modules/voice_reply_speaker.rs
@@ -26,6 +26,26 @@ use crate::runtime::message_bus::MessageBus;
 /// on screen as text.
 pub(crate) const MAX_SPOKEN_CHARS: usize = 600;
 
+/// A line older than this at SPEAK time is dropped, not spoken. Speech is
+/// serialized (one synthesis at a time), so twelve citizens answering one
+/// question queue up; a fluent answer minutes late is worse than silence
+/// because the human cannot tell it is stale (BigMama's review of #3754).
+/// Dropped for a STATED reason (`live.tts.stale_dropped`), never because a
+/// buffer happened to fill.
+pub(crate) const MAX_LINE_AGE_MS: u64 = 20_000;
+
+/// Is a line posted at `posted_ms` still worth saying at `now_ms`?
+pub(crate) fn fresh_enough(posted_ms: u64, now_ms: u64) -> bool {
+    now_ms.saturating_sub(posted_ms) <= MAX_LINE_AGE_MS
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0) // unwrap_or: a clock before 1970 is not a case this guard needs to reason about
+}
+
 pub(crate) fn spawn(bus: Arc<MessageBus>, state: Arc<VoiceState>) {
     let mut rx = bus.receiver();
     tokio::spawn(async move {
@@ -61,6 +81,19 @@ pub(crate) fn spawn(bus: Arc<MessageBus>, state: Arc<VoiceState>) {
             let Some((text, truncated)) = speakable_text(&posted.content) else {
                 continue;
             };
+            // Checked at SPEAK time, after the queue ahead of it drained.
+            let age_ms = now_ms().saturating_sub(posted.timestamp);
+            if !fresh_enough(posted.timestamp, now_ms()) {
+                crate::probe!(
+                    class = "live.tts.stale_dropped",
+                    module = "live",
+                    room = room.as_str(),
+                    persona = name.as_str(),
+                    age_ms = age_ms,
+                    "a reply older than MAX_LINE_AGE_MS reached the speaker — stays text-only (backlog, not silence)"
+                );
+                continue;
+            }
             let persona = posted.sender_id.to_string();
             let started = std::time::Instant::now();
             match state
@@ -137,6 +170,16 @@ mod tests {
     // receipt is never spoken, code fences are dropped while the prose around
     // them survives, and a long reply is cut on a sentence boundary under the
     // cap with `truncated = true`.
+    // what this catches: the staleness floor — a line 20 s old speaks, a line
+    // 20.001 s old does not, and a clock that reads earlier than the post
+    // (skew) never underflows into "infinitely fresh".
+    #[test]
+    fn a_stale_line_is_dropped_at_speak_time_and_skew_never_underflows() {
+        assert!(fresh_enough(1_000, 1_000 + MAX_LINE_AGE_MS));
+        assert!(!fresh_enough(1_000, 1_000 + MAX_LINE_AGE_MS + 1));
+        assert!(fresh_enough(5_000, 4_000), "posted 'after' now (skew) is fresh, not underflowed");
+    }
+
     #[test]
     fn receipts_are_silent_fences_drop_and_long_replies_cut_on_a_sentence() {
         assert_eq!(speakable_text("💭 Let me look at the repo"), None);

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -18,6 +18,7 @@ pub mod airc_admission;
 pub mod airc_citizen;
 pub mod airc_persona_conversation;
 pub mod airc_runtime;
+pub mod operator_avatar_seed;
 pub mod operator_peer;
 pub mod command_inbound_pump;
 // `scripted_*` are SYSTEM-level test/replay primitives per

--- a/core/continuum-core/src/persona/operator_avatar_seed.rs
+++ b/core/continuum-core/src/persona/operator_avatar_seed.rs
@@ -138,7 +138,7 @@ pub fn parse_dscl_hex(out: &str) -> Option<Vec<u8>> {
 /// next line (or on the same line after a space).
 pub fn parse_dscl_path(out: &str) -> Option<PathBuf> {
     let rest = out.split_once("Picture:")?.1.trim();
-    (!rest.is_empty()).then(|| PathBuf::from(rest.lines().next().unwrap_or("").trim()))
+    (!rest.is_empty()).then(|| PathBuf::from(rest.lines().next().unwrap_or("").trim())) // unwrap_or: rest is non-empty so a first line exists; "" only guards the type
 }
 
 #[cfg(test)]

--- a/core/continuum-core/src/persona/operator_avatar_seed.rs
+++ b/core/continuum-core/src/persona/operator_avatar_seed.rs
@@ -1,0 +1,166 @@
+//! The human's default profile picture — seeded from the OS account picture
+//! the first time the operator self-peer comes online, until they change it
+//! in the profile page (Joel, 2026-09-05: "use my image as default till I
+//! change it myself"). The roster reads `~/.continuum/avatars/<uuid>.png`
+//! (positron_presence::scan_avatar_store) — this writes exactly that file for
+//! the operator's peer id, once, and never overwrites a chosen picture.
+//!
+//! Every step is a bounded subprocess with a NAMED outcome
+//! ([[every-probe-on-a-boot-or-launch-path-gets-a-bound-and-a-named-outcome]]):
+//! `operator.avatar.present` (already chosen/seeded), `operator.avatar.seeded`
+//! (source named), `operator.avatar.not_found` (reason named). Off the boot
+//! path: spawned, never awaited by the peer's bring-up.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use uuid::Uuid;
+
+const PROBE_BOUND: Duration = Duration::from_secs(5);
+
+/// Where the roster looks for a member's picture.
+pub fn avatar_png_path(peer_id: Uuid) -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".continuum").join("avatars").join(format!("{peer_id}.png")))
+}
+
+/// Spawn the seed; returns immediately. Idempotent: an existing picture is
+/// left alone (that is the "till I change it myself" half).
+pub fn spawn_seed_default_avatar(peer_id: Uuid) {
+    tokio::spawn(async move {
+        let outcome = seed_default_avatar(peer_id).await;
+        match outcome {
+            SeedOutcome::Present => crate::probe!(
+                class = "operator.avatar.present",
+                peer_id = %peer_id,
+                "the human already has a profile picture — left as chosen"
+            ),
+            SeedOutcome::Seeded { source } => crate::probe!(
+                class = "operator.avatar.seeded",
+                peer_id = %peer_id,
+                source = source,
+                "the human's default profile picture is their OS account picture"
+            ),
+            SeedOutcome::NotFound { reason } => crate::probe!(
+                class = "operator.avatar.not_found",
+                peer_id = %peer_id,
+                reason = reason,
+                "no default picture for the human — the tile shows the glyph until they choose one"
+            ),
+        }
+    });
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SeedOutcome {
+    Present,
+    Seeded { source: &'static str },
+    NotFound { reason: &'static str },
+}
+
+pub async fn seed_default_avatar(peer_id: Uuid) -> SeedOutcome {
+    let Some(dst) = avatar_png_path(peer_id) else {
+        return SeedOutcome::NotFound { reason: "no_home_dir" };
+    };
+    if dst.exists() {
+        return SeedOutcome::Present;
+    }
+    if !cfg!(target_os = "macos") {
+        // Windows account tile / Linux AccountsService icon: not wired yet —
+        // an honest NOT_FOUND, never a fabricated face.
+        return SeedOutcome::NotFound { reason: "no_os_source_on_this_platform" };
+    }
+    let Some(user) = std::env::var("USER").ok().filter(|u| !u.trim().is_empty()) else {
+        return SeedOutcome::NotFound { reason: "no_os_user" };
+    };
+    if let Some(parent) = dst.parent() {
+        if std::fs::create_dir_all(parent).is_err() {
+            return SeedOutcome::NotFound { reason: "avatar_store_unwritable" };
+        }
+    }
+    // 1. The custom account picture (dscl JPEGPhoto: hex words of an image file).
+    if let Some(bytes) = dscl_read(&user, "JPEGPhoto").await.and_then(|out| parse_dscl_hex(&out)) {
+        let tmp = dst.with_extension("account-picture.bin");
+        if std::fs::write(&tmp, &bytes).is_ok() && sips_to_png(&tmp, &dst).await {
+            let _ = std::fs::remove_file(&tmp);
+            return SeedOutcome::Seeded { source: "macos_account_jpegphoto" };
+        }
+        let _ = std::fs::remove_file(&tmp);
+    }
+    // 2. The stock picture path (dscl Picture: a file under /Library/User Pictures).
+    if let Some(path) = dscl_read(&user, "Picture").await.and_then(|out| parse_dscl_path(&out)) {
+        if sips_to_png(&path, &dst).await {
+            return SeedOutcome::Seeded { source: "macos_account_picture_file" };
+        }
+    }
+    SeedOutcome::NotFound { reason: "no_macos_account_picture" }
+}
+
+async fn dscl_read(user: &str, attr: &str) -> Option<String> {
+    let cmd = tokio::process::Command::new("dscl")
+        .args([".", "-read", &format!("/Users/{user}"), attr])
+        .output();
+    let out = tokio::time::timeout(PROBE_BOUND, cmd).await.ok()?.ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+async fn sips_to_png(src: &std::path::Path, dst: &std::path::Path) -> bool {
+    let cmd = tokio::process::Command::new("sips")
+        .args(["-s", "format", "png"])
+        .arg(src)
+        .arg("--out")
+        .arg(dst)
+        .output();
+    matches!(tokio::time::timeout(PROBE_BOUND, cmd).await, Ok(Ok(o)) if o.status.success())
+        && dst.exists()
+}
+
+/// `dscl . -read /Users/x JPEGPhoto` prints the attribute name, then the
+/// image bytes as space-separated hex words (4 bytes each, the last may be
+/// short). Anything that is not hex ends the parse honestly (`None`).
+pub fn parse_dscl_hex(out: &str) -> Option<Vec<u8>> {
+    let body = out.split_once("JPEGPhoto:")?.1;
+    let mut bytes = Vec::with_capacity(body.len() / 2);
+    for word in body.split_whitespace() {
+        if word.len() % 2 != 0 {
+            return None;
+        }
+        for i in (0..word.len()).step_by(2) {
+            bytes.push(u8::from_str_radix(&word[i..i + 2], 16).ok()?);
+        }
+    }
+    (!bytes.is_empty()).then_some(bytes)
+}
+
+/// `dscl . -read /Users/x Picture` prints `Picture:` then the path on the
+/// next line (or on the same line after a space).
+pub fn parse_dscl_path(out: &str) -> Option<PathBuf> {
+    let rest = out.split_once("Picture:")?.1.trim();
+    (!rest.is_empty()).then(|| PathBuf::from(rest.lines().next().unwrap_or("").trim()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the two dscl output shapes we depend on — hex words
+    // (4-byte groups, short tail) decode to the exact bytes with the TIFF
+    // magic first, a non-hex word refuses the whole image (no half-decoded
+    // picture), and the Picture path is read from the line after the key.
+    #[test]
+    fn dscl_shapes_decode_or_refuse_honestly() {
+        let out = "JPEGPhoto:\n 4d4d002a 000ac448 b0b0\n";
+        assert_eq!(
+            parse_dscl_hex(out).unwrap(),
+            vec![0x4d, 0x4d, 0x00, 0x2a, 0x00, 0x0a, 0xc4, 0x48, 0xb0, 0xb0]
+        );
+        assert_eq!(parse_dscl_hex("JPEGPhoto:\n 4d4d zz\n"), None);
+        assert_eq!(parse_dscl_hex("Picture:\n /x.heic\n"), None);
+        assert_eq!(
+            parse_dscl_path("Picture:\n /Library/User Pictures/Fun/Yin-Yang.heic\n").unwrap(),
+            PathBuf::from("/Library/User Pictures/Fun/Yin-Yang.heic")
+        );
+    }
+}

--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -65,6 +65,11 @@ pub async fn ensure_operator_peer(
                 peer_id = %rt.airc().peer_id(),
                 "operator self-peer online — room-scoped verbs now act as the human, not a denial (#27)"
             );
+            // Default profile picture from the OS account picture — off the
+            // boot path, bounded, named outcome (operator_avatar_seed.rs).
+            crate::persona::operator_avatar_seed::spawn_seed_default_avatar(
+                rt.airc().peer_id().as_uuid(),
+            );
             // The human belongs in the CITIZENS' commons by default, and stays
             // reachable in airc's lobby.
             //


### PR DESCRIPTION
Joel's live test (2026-09-05): twelve animated heads, hold music, no voices, no captions, and a probe ledger that read zero for an hour.

- **Reply speaker** (`modules/voice_reply_speaker.rs`): a `chat:posted` in a room with an active voice session, from a persona this node hosts, is spoken through one path — `VoiceState::speak_in_room`, extracted from the `voice/speak-in-call` verb. Receipts (💭) silent, code fences dropped, 600-char sentence cut, voices sequential. Probes `live.tts.spoken/failed/bus_lagged`. `parse_chat_posted` is now the one chat:posted parser, shared with the chat projection.
- **STT chain named**: the human's audio channel WAS bound (09:03:04) and no transcription ran; the two silent returns in `push_remote_human_audio` now probe `live.stt.audio_dropped {no_native_call|no_mixer_handle}` (once per speaker/call), plus `live.stt.speech_ended`, `live.stt.transcribed {chars,to_minds}`, `live.stt.refused`.
- **Pump probes summarize**: per-frame `media.pump.*` rows (≈370/s during the call) blinded the size-rotated ledger — every cognition class read zero for an hour. `pump_tally.rs`: one summary/s.
- **Default picture**: the operator's avatar PNG seeded from the macOS account picture on first online (bounded, named outcome, never overwrites a chosen one).

Tests: 30/30 across the touched mods; `cargo check` clean. Cards 6e425299 (call outlives its last human) and 405d64d0 (picker / in-frame capture / stylize) carry the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo