### PR TITLE
fix(memory-bridge): per-turn capture was silently dead on Windows — two platform defaults, one hook

### DIFF
--- a/tools/plugins/memory-bridge/scripts/session-capture.sh
+++ b/tools/plugins/memory-bridge/scripts/session-capture.sh
@@ -39,15 +39,39 @@ SCOPE_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 PROJECT="$(basename "$SCOPE_DIR")"
 
 # Pull the transcript path from the hook payload, then the last assistant
-# message text from the JSONL transcript. python3 parses; it never BUILDS
+# message text from the JSONL transcript. Python parses; it never BUILDS
 # JSON for the wire (the CLI's flat --key value coercion does the escaping).
-CONTENT="$(printf '%s' "$HOOK_INPUT" | python3 -c '
+# Every I/O boundary below pins UTF-8 EXPLICITLY. Python's `open()`, `sys.stdin`
+# and `sys.stdout` all default to the platform's preferred encoding — UTF-8 on
+# Linux/macOS but cp1252 on Windows — so a transcript containing an em-dash or a
+# star (i.e. every real transcript) raised UnicodeDecodeError on Windows ONLY.
+# This is the same defect class as the `python3` alias resolved just below:
+# the hook worked on the Macs and was silently dead on the Windows node.
+# Resolve a Python that RUNS, not one that merely EXISTS. On Windows `python3`
+# is a Microsoft Store "App Execution Alias": a real file on PATH that ignores
+# its arguments, prints an install ad, and exits 49. So `command -v python3`
+# SUCCEEDS on a box with no python3, and this hook failed every turn on such a
+# box with "Python was not found" landing in the receipt — capture silently off
+# on the machine that most needed it. Presence is not liveness; probe by
+# EXECUTING a sentinel.
+# Order: python3 first (right on Linux/macOS, where bare `python` may be absent
+# or Python 2), then python, then the Windows `py` launcher.
+_probe_py() { [ "$("$@" -c 'print("ok")' 2>/dev/null)" = "ok" ]; }
+if   _probe_py python3; then BRIDGE_PY=(python3)
+elif _probe_py python;  then BRIDGE_PY=(python)
+elif _probe_py py -3;   then BRIDGE_PY=(py -3)
+else
+    bridge_receipt session-capture failed "no working python (python3, python, py -3 all failed to execute)"
+    exit 0
+fi
+
+CONTENT="$(printf '%s' "$HOOK_INPUT" | "${BRIDGE_PY[@]}" -c '
 import json, sys
 try:
-    payload = json.load(sys.stdin)
+    payload = json.loads(sys.stdin.buffer.read().decode("utf-8", "replace"))
     path = payload.get("transcript_path", "")
     last = ""
-    with open(path) as f:
+    with open(path, encoding="utf-8", errors="replace") as f:
         for line in f:
             try:
                 entry = json.loads(line)
@@ -63,7 +87,7 @@ try:
     out = last.strip()
     if len(out) > 900:
         out = out[:900] + " …[truncated]"
-    print(out)
+    sys.stdout.buffer.write(out.encode("utf-8"))
 except Exception as e:
     print("__CAPTURE_ERROR__" + type(e).__name__ + ": " + str(e)[:120], file=sys.stderr)
 ' 2>"${TMPDIR:-/tmp}/memory-bridge-capture.$$.err")"


### PR DESCRIPTION
The Stop hook that records every turn to the agent's corpus **had never stored a
turn on the Windows node.** It reported `status:"failed"` in its receipt every
single time — the receipt design is sound and is the only reason this was
findable — but nothing read those receipts until session-start recall surfaced
one.

Two independent Windows-only defects, stacked. **Fixing the first exposed the
second**, which is the only reason both are in this PR.

### 1. `python3` resolved to an ad, not an interpreter

On Windows `python3` is a Microsoft Store *App Execution Alias*: a real file on
`PATH` that ignores its arguments, prints an install ad to stdout, and exits 49.

```
$ command -v python3   -> succeeds
$ python3 -c 'print("ok")'
Python was not found; run without arguments to install from the Microsoft Store...
rc=49
```

So **any presence check picks the stub.** Replaced with a probe that *executes* a
sentinel, falling through `python3` → `python` → `py -3`, and a real receipt if
none run. Presence is not liveness.

`python3` stays first so Linux/macOS — where bare `python` may be absent or
Python 2 — are unaffected.

### 2. Underneath it: cp1252

`open()`, `sys.stdin` and `sys.stdout` all default to the platform's preferred
encoding — UTF-8 on Linux/macOS, **cp1252 on Windows**. The first em-dash in a
transcript raised `UnicodeDecodeError`. All three boundaries now pin UTF-8.

### Both are the same shape

A platform default that is correct on the author's machine and wrong elsewhere,
in a path no test covers. Sixth instance of this class in my notes; the fifth was
`--n-gpu-layers` reaching only the CPU-only branch, where a *test pinned the flag
absent* and green CI defended the bug.

### Verification — run, not read

Against this session's real 136k-line transcript:

| | receipt |
|---|---|
| before | `failed` — `"Python was not found; run without arguments..."` |
| after fix 1 | `failed` — `"UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f"` |
| after fix 2 | **`ok` — `"scope=continuum chars=277"`** |

Negative case also held: a nonexistent transcript path still reports
`failed / FileNotFoundError`, so the fix did not turn the hook into a silent
no-op — which is the failure mode this file's header comment exists to prevent.

Python here is operator tooling, not core — consistent with substrate/serving/
daemons being Rust always.
