### PR TITLE
fix(serving): a GPU-intent lane that comes up on the CPU is refused, not served — ready is a verified observation

### DIFF
--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -3274,18 +3274,45 @@ match (child.stderr.take(), log_path) {
         // GPU-intent lane is unambiguous.) The watcher only REPORTS; lifecycle stays
         // with the daemon, same doctrine as the wedge flag.
         if target.placement != LanePlacement::Cpu {
-            match self.offload.get() {
-                Some((0, total)) => {
-                    crate::probe!(
-                        class = "serving.placement.cpu_fallback",
-                        port = port,
-                        model = target.model_id(),
-                        total_layers = total,
-                        "PLACEMENT VIOLATION: GPU-placement lane offloaded 0/{total} layers \
-                         — the model is running ON CPU. Throughput will be an order of \
-                         magnitude below plan; every consumer of this lane is degraded (#441).",
-                    );
+            // A GPU-intent lane that came up on the CPU is REFUSED, not reported.
+            // Before 2026-09-05 this arm only probed; BigMama's 5090 then served
+            // Devstral from system RAM behind `ready:true lanes:3` (the engine
+            // said "no usable GPU found" on its own stderr, the pre-spawn device
+            // probe had said CUDA0). "Ready" must be a verified observation — same
+            // shape as the debug-build gate above: kill it, name the evidence, and
+            // let the daemon's relaunch/degrade path own what happens next.
+            // Joaquin's card 0c4317e1 (serve-time pin-match gap), finder credit.
+            let declined = self.offload.gpu_declined();
+            let zero_offload = matches!(self.offload.get(), Some((0, total)) if total > 0);
+            if declined || zero_offload {
+                if let Some(pid) = child_pid {
+                    crate::inference::lane_process::kill9(pid);
                 }
+                let evidence = if declined {
+                    "engine stderr: \"no usable GPU found\""
+                } else {
+                    "offload banner: 0 layers on the GPU"
+                };
+                crate::probe!(
+                    class = "serving.placement.refused",
+                    port = port,
+                    model = target.model_id(),
+                    evidence = evidence,
+                    total_layers = self.offload.get().map(|(_, t)| t).unwrap_or(0), // unwrap_or: no banner = 0 layers KNOWN; the evidence field carries the declined line
+                    "PLACEMENT VIOLATION: a GPU-placement lane came up ON CPU — refused, not served \
+                     (ready must be a verified observation, #441 / card 0c4317e1)"
+                );
+                return Err(LlamaServerError::Spawn(format!(
+                    "{} was planned on the GPU and came up on the CPU ({evidence}); refused rather \
+                     than serve every citizen from system RAM behind a green /health. Check the \
+                     backend build (a DL-backend build can list CUDA0 from a shell and still fail \
+                     to load it under the core) — last stderr:\n{}",
+                    self.bin,
+                    self.stderr_log_tail()
+                )));
+            }
+            match self.offload.get() {
+                Some((0, _)) => unreachable!("zero offload on a GPU lane is refused above"),
                 Some(_) => {}
                 None => {
                     // No banner observed is a different fact from "reported 0" — an

--- a/core/continuum-core/src/inference/placement_watch.rs
+++ b/core/continuum-core/src/inference/placement_watch.rs
@@ -46,7 +46,18 @@ use super::child_log::LineWatch;
 /// `None` until the load banner has been observed (a lane mid-load has no report yet,
 /// which is a different fact from "reported 0").
 #[derive(Clone, Default)]
-pub struct OffloadReport(Arc<AtomicU64>);
+pub struct OffloadReport(Arc<AtomicU64>, Arc<std::sync::atomic::AtomicBool>);
+
+/// The engine's own words when it gives up on the GPU before any offload banner —
+/// llama.cpp prints these (BigMama's 5090, 2026-09-05: a DL-backend build whose
+/// CUDA DLL loaded from a shell and not from the core's process) and then serves
+/// the whole model on CPU while /health says ok.
+const GPU_DECLINED_MARKERS: &[&str] = &["no usable GPU found", "compiled without GPU support"];
+
+/// Does this stderr line say the engine declined the GPU outright?
+pub fn is_gpu_declined_line(line: &str) -> bool {
+    GPU_DECLINED_MARKERS.iter().any(|m| line.contains(m))
+}
 
 /// Sentinel for "no banner observed yet" — a real report always has `total > 0`.
 const UNREPORTED: u64 = 0;
@@ -69,6 +80,16 @@ impl OffloadReport {
         self.0
             .store(((offloaded as u64) << 32) | total as u64, Ordering::Relaxed);
     }
+
+    /// The engine said, in its own stderr, that it found no usable GPU. A distinct
+    /// fact from `offloaded 0/N`: some builds print no banner at all after this.
+    pub fn gpu_declined(&self) -> bool {
+        self.1.load(Ordering::Relaxed)
+    }
+
+    fn note_gpu_declined(&self) {
+        self.1.store(true, Ordering::Relaxed);
+    }
 }
 
 /// The [`LineWatch`] that records the engine's offload banner into an [`OffloadReport`].
@@ -90,6 +111,8 @@ impl LineWatch for OffloadWatch {
     fn observe(&mut self, line: &str) {
         if let Some((offloaded, total)) = parse_offload_banner(line) {
             self.report.set(offloaded, total);
+        } else if is_gpu_declined_line(line) {
+            self.report.note_gpu_declined();
         }
     }
 }
@@ -152,5 +175,21 @@ mod tests {
         watch.observe("noise line");
         watch.observe("load_tensors: offloaded 0/48 layers to GPU");
         assert_eq!(report.get(), Some((0, 48)));
+    }
+
+    // what this catches: the engine's "no usable GPU" line is a first-class fact on
+    // the report (BigMama's 5090 served on CPU behind ready:true, 2026-09-05), set by
+    // the same watch that reads the offload banner, and a healthy banner does NOT set it.
+    #[test]
+    fn a_no_usable_gpu_line_marks_the_report_declined_and_a_banner_does_not() {
+        let report = OffloadReport::new();
+        let mut watch = OffloadWatch::new(report.clone());
+        watch.observe("load_tensors: offloaded 63/63 layers to GPU");
+        assert!(!report.gpu_declined());
+        assert_eq!(report.get(), Some((63, 63)));
+        watch.observe("warning: no usable GPU found, --gpu-layers option will be ignored");
+        assert!(report.gpu_declined());
+        watch.observe("warning: one possible reason is that llama.cpp was compiled without GPU support");
+        assert!(report.gpu_declined());
     }
 }


### PR DESCRIPTION
Before: the placement readback only PROBED when the engine's banner said 0 layers offloaded, and nothing parsed the engine's own "no usable GPU found" line; the daemon marked the lane ready. BigMama's 5090 served Devstral from system RAM behind `ready:true lanes:3` while every status surface said fine.

- `placement_watch`: `OffloadReport::gpu_declined()` set by the same stderr watch on "no usable GPU found" / "compiled without GPU support" (distinct from `offloaded 0/N`). Test.
- `llama_server` readiness: a GPU-placement lane with `declined || 0 offloaded` is killed and refused with the evidence + stderr tail (`serving.placement.refused`), the same shape as the debug-build gate. CPU-by-plan lanes untouched; partial offload stays legal.

Complementary to #3757 (which makes the build serve): this makes the lie impossible if a build regresses again. Finder credit: Joaquin, card 0c4317e1. Tests 41/41 across both mods; `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo