### PR TITLE
fix(cognition): a reflected wake prompt is a PASS, not a post — the framing-echo gate

### DIFF
--- a/core/continuum-core/src/cognition/deliberation_parse.rs
+++ b/core/continuum-core/src/cognition/deliberation_parse.rs
@@ -18,7 +18,7 @@ use crate::persona::text_analysis::clean_response;
 /// is the volition faculty's channel (initiative with no prompt), not something
 /// we infer from a single deliberation response — a deliberation faculty answers
 /// the burst it was given.
-pub fn decision_from_response(text: &str) -> Decision {
+pub fn decision_from_response(text: &str, own_name: Option<&str>) -> Decision {
     // Strip `<think>`/`<thinking>` chain-of-thought before deciding. qwen3.5-family
     // models emit a reasoning block (often an EMPTY `<think></think>`) ahead of the
     // answer; the spoken text must NEVER carry those tags into the room. The legacy
@@ -44,6 +44,20 @@ pub fn decision_from_response(text: &str) -> Decision {
     let cleaned = clean_response(text);
     let trimmed = cleaned.text.trim();
     probe_label_stripped_into_silence(text, trimmed);
+    // The turn's own framing reflected back is a PASS, not speech — the wake-
+    // prompt echo of 2026-09-05 (cognition::framing_echo). Silenced HERE, at the
+    // one point model text becomes a Speak decision, with the reason kept.
+    if let Some(marker) = super::framing_echo::echoes_turn_framing(trimmed, own_name) {
+        crate::probe!(
+            class = "cognition.framing_echo",
+            marker = marker,
+            chars = trimmed.chars().count() as u64,
+            "response reflected the turn's own framing — a pass, never posted"
+        );
+        return Decision::Pass {
+            reason: Some(format!("framing echo ({marker}): the response reflects the turn's own prompt")),
+        };
+    }
     if trimmed.is_empty()
         || looks_like_silence_token(trimmed)
         || starts_with_silence_token(trimmed)
@@ -295,24 +309,38 @@ mod tests {
     // what this catches: the PASS silence token maps to Decision::Pass (with or
     // without trailing punctuation); real content maps to Speak. One silence
     // contract, reused from prompt_assembly.
+    // what this catches: a reflected wake prompt becomes a REASONED PASS at the
+    // live seam (never a Speak), while a peer-agreeing "You are right" still speaks.
+    #[test]
+    fn a_reflected_wake_prompt_is_a_reasoned_pass_at_the_live_seam() {
+        match decision_from_response("[wake] You are Paige, awake on the continuum grid.", Some("Paige")) {
+            Decision::Pass { reason } => assert!(reason.unwrap_or_default().starts_with("framing echo (wake_tag)")),
+            other => panic!("expected a pass, got {other:?}"),
+        }
+        match decision_from_response("You are right, Kimi — the lane is up.", Some("Paige")) {
+            Decision::Speak { text } => assert_eq!(text, "You are right, Kimi — the lane is up."),
+            other => panic!("expected speech, got {other:?}"),
+        }
+    }
+
     #[test]
     fn decision_parsing_maps_pass_and_speak() {
         // A bare token / empty generation → anonymous silence, no reason.
-        assert_eq!(decision_from_response("PASS"), Decision::pass());
-        assert_eq!(decision_from_response("  PASS.  "), Decision::pass());
-        assert_eq!(decision_from_response(""), Decision::pass());
+        assert_eq!(decision_from_response("PASS", None), Decision::pass());
+        assert_eq!(decision_from_response("  PASS.  ", None), Decision::pass());
+        assert_eq!(decision_from_response("", None), Decision::pass());
         // Small models leak trailing prose after PASS — still silence, and now
         // that trailing prose is CAPTURED as the pass reason (a pass is
         // accountable, not anonymous), with the leading token stripped.
         assert!(matches!(
-            decision_from_response("PASS — nothing to add here"),
+            decision_from_response("PASS — nothing to add here", None),
             Decision::Pass { reason: Some(r) } if r == "nothing to add here"
         ));
         assert!(matches!(
-            decision_from_response("PASS.\nI'll stay quiet"),
+            decision_from_response("PASS.\nI'll stay quiet", None),
             Decision::Pass { reason: Some(r) } if r == "I'll stay quiet"
         ));
-        match decision_from_response("Let's ship the deploy fix now.") {
+        match decision_from_response("Let's ship the deploy fix now.", None) {
             Decision::Speak { text } => assert!(text.contains("ship the deploy")),
             other => panic!("expected Speak, got {other:?}"),
         }
@@ -328,22 +356,22 @@ mod tests {
         // would strip a leading "PASS: " as a speaker label, so this pins the
         // raw-first pass check that keeps it a reasoned pass, not a Speak "done".
         assert!(matches!(
-            decision_from_response("PASS: done — patch ready"),
+            decision_from_response("PASS: done — patch ready", None),
             Decision::Pass { reason: Some(r) } if r == "done — patch ready"
         ));
         assert!(matches!(
-            decision_from_response("PASS: blocked - the fixture is missing"),
+            decision_from_response("PASS: blocked - the fixture is missing", None),
             Decision::Pass { reason: Some(r) } if r.contains("blocked")
         ));
         // A recognized narrated closure still passes and keeps her words.
         assert!(matches!(
-            decision_from_response("I'll pass my turn — nothing to add"),
+            decision_from_response("I'll pass my turn — nothing to add", None),
             Decision::Pass { reason: Some(r) } if r.contains("nothing")
         ));
         // "Verdict: PASS ..." is an ANSWER of PASS, NOT a turn-pass — the raw
         // check must not steal it (the #349 minefield stays intact).
         assert!(!matches!(
-            decision_from_response("Verdict: the guard holds"),
+            decision_from_response("Verdict: the guard holds", None),
             Decision::Pass { .. }
         ));
     }
@@ -355,7 +383,7 @@ mod tests {
     #[test]
     fn decision_strips_think_tags_from_spoken_text() {
         // Empty think block (the exact shape observed live) + real answer.
-        match decision_from_response("<think>\n</think>\nI'm Asha, here to help.") {
+        match decision_from_response("<think>\n</think>\nI'm Asha, here to help.", None) {
             Decision::Speak { text } => {
                 assert!(!text.contains("<think>"), "think tag leaked: {text:?}");
                 assert!(!text.contains("</think>"), "close tag leaked: {text:?}");
@@ -364,13 +392,13 @@ mod tests {
             other => panic!("expected Speak, got {other:?}"),
         }
         // Non-empty reasoning block is also stripped from the spoken text.
-        match decision_from_response("<think>weigh options</think>Ship it.") {
+        match decision_from_response("<think>weigh options</think>Ship it.", None) {
             Decision::Speak { text } => assert_eq!(text, "Ship it."),
             other => panic!("expected Speak, got {other:?}"),
         }
         // An ONLY-thinking response (no answer) cleans to empty → silence.
         assert_eq!(
-            decision_from_response("<think>I won't answer this</think>"),
+            decision_from_response("<think>I won't answer this</think>", None),
             Decision::pass()
         );
     }
@@ -426,7 +454,7 @@ mod tests {
             "I've been repeating myself without adding value. Otherwise, PASS",
         ] {
             assert!(
-                matches!(decision_from_response(live), Decision::Pass { .. }),
+                matches!(decision_from_response(live, None), Decision::Pass { .. }),
                 "must silence: {live:?}"
             );
         }
@@ -463,7 +491,7 @@ mod tests {
             "Otherwise, I will PASS and continue to monitor any new developments that arise.",
         ] {
             assert!(
-                matches!(decision_from_response(still_speaks), Decision::Speak { .. }),
+                matches!(decision_from_response(still_speaks, None), Decision::Speak { .. }),
                 "must stay speech — reading intent out of a sentence is the verb's job now, \
                  not this parser's: {still_speaks:?}"
             );
@@ -489,7 +517,7 @@ mod tests {
             "Grep for PASS_TOKEN if you want the constant's call sites.",
         ] {
             assert!(
-                matches!(decision_from_response(speak), Decision::Speak { .. }),
+                matches!(decision_from_response(speak, None), Decision::Speak { .. }),
                 "must stay speech: {speak:?}"
             );
         }
@@ -516,7 +544,7 @@ mod tests {
              specific you'd like me to address or if new information emerges.",
         ] {
             assert!(
-                matches!(decision_from_response(live), Decision::Pass { .. }),
+                matches!(decision_from_response(live, None), Decision::Pass { .. }),
                 "must silence: {live:?}"
             );
         }
@@ -529,7 +557,7 @@ mod tests {
             "You can pass for now if you have nothing to add.",
             "Here's the fix:\n```rust\nlet x = 1;\n```\nI'll pass for now.",
         ] {
-            match decision_from_response(speak) {
+            match decision_from_response(speak, None) {
                 Decision::Speak { .. } => {}
                 other => panic!("must NOT silence {speak:?}, got {other:?}"),
             }
@@ -551,7 +579,7 @@ mod tests {
              silent (PASS) for now.",
         ] {
             assert!(
-                matches!(decision_from_response(drift), Decision::Pass { .. }),
+                matches!(decision_from_response(drift, None), Decision::Pass { .. }),
                 "must silence: {drift:?}"
             );
         }
@@ -572,7 +600,7 @@ mod tests {
             "regression fixture must exceed the old cap"
         );
         assert!(matches!(
-            decision_from_response(over_old_cap),
+            decision_from_response(over_old_cap, None),
             Decision::Pass { .. }
         ));
         // Two-tier regression (live 2026-08-01, the cap arms race's second
@@ -596,7 +624,7 @@ mod tests {
             "regression fixture must exceed the tier-2 cap"
         );
         assert!(matches!(
-            decision_from_response(over_new_cap),
+            decision_from_response(over_new_cap, None),
             Decision::Pass { .. }
         ));
         // Length fail-open: a long substantive message ending in a pass phrase
@@ -609,7 +637,7 @@ mod tests {
             long.len() > 700,
             "fail-open fixture must exceed the current cap"
         );
-        match decision_from_response(&long) {
+        match decision_from_response(&long, None) {
             Decision::Speak { .. } => {}
             other => panic!("long substantive message silenced: {other:?}"),
         }

--- a/core/continuum-core/src/cognition/framing_echo.rs
+++ b/core/continuum-core/src/cognition/framing_echo.rs
@@ -1,0 +1,88 @@
+//! Framing echo — a response that reflects the turn's OWN framing back into
+//! the room is not speech; it is a PASS.
+//!
+//! The wake prompt is written to the persona ("[wake] You are Paige, awake on
+//! the continuum grid. Nothing has been said in this room since you last
+//! looked…"). For a small model the most likely continuation of second-person
+//! narration is more of it, and on 2026-09-05 three citizens on two nodes
+//! posted the wake prompt back into #academy — "You are ready for the…",
+//! "I've been awake for a while, Saoirse…" — then echoed each other's echoes
+//! (IntelMac's trace; 96 s for nine tokens on the CPU tier). The room read it
+//! as speech; it was the prompt.
+//!
+//! ONE place for the wake prompt's fixed sentences: the composer
+//! (`persona::service_loop`) builds from these constants and this gate matches
+//! on them, so the two cannot drift ([[the-compression-principle]]).
+
+/// The wake turn's tag — the composer opens with it, and a response that
+/// STARTS with it is the prompt coming back.
+pub const WAKE_TAG: &str = "[wake]";
+/// "You are {name}, awake on the continuum grid."
+pub const WAKE_OPENING: &str = "awake on the continuum grid";
+pub const WAKE_QUIET: &str = "Nothing has been said in this room since you last looked";
+pub const WAKE_NO_WORK: &str = "No work of yours is on record right now";
+pub const WAKE_PRESENT: &str = "Present with you:";
+pub const WAKE_MID_WORK: &str = "You are mid-work — cards you hold:";
+
+/// Which framing marker a response reflects, if any. `None` = it reads as speech.
+pub fn echoes_turn_framing(text: &str) -> Option<&'static str> {
+    let t = text.trim_start();
+    if t.starts_with(WAKE_TAG) {
+        return Some("wake_tag");
+    }
+    // Second-person self-narration is the prompt's register, never a citizen's
+    // line to a room ("You are ready for the next task" was the prompt talking).
+    if t.starts_with("You are ") {
+        return Some("second_person_self_narration");
+    }
+    for s in [WAKE_OPENING, WAKE_QUIET, WAKE_NO_WORK, WAKE_PRESENT, WAKE_MID_WORK] {
+        if t.contains(s) {
+            return Some("wake_sentence");
+        }
+    }
+    // Bracketed envelope tags belong to the inbound framing ("[room …]",
+    // "[Conversation …]"), never to an utterance.
+    if t.starts_with("[room ") || t.contains("[Conversation") {
+        return Some("bracket_framing");
+    }
+    // A tool SCHEMA reproduced as a message — "[action #1] work/release({\"description\":…" —
+    // is the offered-tools framing coming back, not a call and not speech (IntelMac, Paige).
+    if t.starts_with("[action #") {
+        return Some("tool_schema_echo");
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the three observed echo shapes (the tag, second-person
+    // self-narration, a verbatim wake sentence) are recognised, and an ordinary
+    // room line — even one that mentions being awake in the first person — is not.
+    #[test]
+    fn the_observed_echo_shapes_are_caught_and_speech_is_not() {
+        assert_eq!(
+            echoes_turn_framing("[wake] You are Paige, awake on the continuum grid."),
+            Some("wake_tag")
+        );
+        assert_eq!(
+            echoes_turn_framing("You are ready for the next task, Paige."),
+            Some("second_person_self_narration")
+        );
+        assert_eq!(
+            echoes_turn_framing("Hello — Nothing has been said in this room since you last looked. Present with you: Kimi."),
+            Some("wake_sentence")
+        );
+        assert_eq!(
+            echoes_turn_framing("I've been awake for a while, Saoirse. [Conversation ended]"),
+            Some("bracket_framing")
+        );
+        assert_eq!(
+            echoes_turn_framing("[action #1] work/release({\"description\":\"Release a task from the board. U"),
+            Some("tool_schema_echo")
+        );
+        assert_eq!(echoes_turn_framing("I'm awake and reading django-14631 now; the FK ordering is the bug."), None);
+        assert_eq!(echoes_turn_framing("I will pass as I have nothing new to contribute."), None);
+    }
+}

--- a/core/continuum-core/src/cognition/framing_echo.rs
+++ b/core/continuum-core/src/cognition/framing_echo.rs
@@ -26,6 +26,8 @@ pub const WAKE_MID_WORK: &str = "You are mid-work — cards you hold:";
 
 /// A wake sentence ECHOED leads the response; one DISCUSSED sits inside it.
 /// Markers must begin within this many chars (room for a name prefix or a quote).
+// context-budget-exempt: an ANCHOR width for an echo test (how far into a reply a wake sentence may
+// start and still count as leading), not a prompt or context size — it does not scale with the window.
 const ECHO_LEAD_CHARS: usize = 24;
 
 /// Which framing marker a response reflects, if any. `None` = it reads as speech.

--- a/core/continuum-core/src/cognition/framing_echo.rs
+++ b/core/continuum-core/src/cognition/framing_echo.rs
@@ -24,28 +24,43 @@ pub const WAKE_NO_WORK: &str = "No work of yours is on record right now";
 pub const WAKE_PRESENT: &str = "Present with you:";
 pub const WAKE_MID_WORK: &str = "You are mid-work — cards you hold:";
 
+/// A wake sentence ECHOED leads the response; one DISCUSSED sits inside it.
+/// Markers must begin within this many chars (room for a name prefix or a quote).
+const ECHO_LEAD_CHARS: usize = 24;
+
 /// Which framing marker a response reflects, if any. `None` = it reads as speech.
-pub fn echoes_turn_framing(text: &str) -> Option<&'static str> {
+///
+/// Anchored (BigMama's review of #3760): "You are right, M5 — …" is a normal
+/// opener and a citizen REPORTING this bug must be able to quote a wake sentence.
+/// So second-person narration counts only when it names the speaker herself
+/// ("You are Paige, …" / "You are ready for the next task, Paige."), and a wake
+/// sentence counts only when it LEADS the response.
+pub fn echoes_turn_framing(text: &str, own_name: Option<&str>) -> Option<&'static str> {
     let t = text.trim_start();
     if t.starts_with(WAKE_TAG) {
         return Some("wake_tag");
     }
-    // Second-person self-narration is the prompt's register, never a citizen's
-    // line to a room ("You are ready for the next task" was the prompt talking).
-    if t.starts_with("You are ") {
-        return Some("second_person_self_narration");
+    if let Some(name) = own_name.map(str::trim).filter(|n| !n.is_empty()) {
+        // The prompt's register is "You are <her own name>"; a second-person
+        // opener that addresses HERSELF by name is the prompt talking, never a
+        // citizen agreeing with a peer.
+        if t.starts_with("You are ") && (t.starts_with(&format!("You are {name}")) || t.contains(&format!(", {name}"))) {
+            return Some("second_person_self_narration");
+        }
     }
+    let lead: String = t.chars().take(ECHO_LEAD_CHARS).collect();
     for s in [WAKE_OPENING, WAKE_QUIET, WAKE_NO_WORK, WAKE_PRESENT, WAKE_MID_WORK] {
-        if t.contains(s) {
+        let head = &s[..s.len().min(12)];
+        if lead.contains(head) && t.contains(s) {
             return Some("wake_sentence");
         }
     }
     // Bracketed envelope tags belong to the inbound framing ("[room …]",
-    // "[Conversation …]"), never to an utterance.
-    if t.starts_with("[room ") || t.contains("[Conversation") {
+    // "[Conversation …]"), never to an utterance — anchored at the start.
+    if t.starts_with("[room ") || t.starts_with("[Conversation") {
         return Some("bracket_framing");
     }
-    // A tool SCHEMA reproduced as a message — "[action #1] work/release({\"description\":…" —
+    // A tool SCHEMA reproduced as a message — "[action #1] work/release({"description":…" —
     // is the offered-tools framing coming back, not a call and not speech (IntelMac, Paige).
     if t.starts_with("[action #") {
         return Some("tool_schema_echo");
@@ -62,27 +77,30 @@ mod tests {
     // room line — even one that mentions being awake in the first person — is not.
     #[test]
     fn the_observed_echo_shapes_are_caught_and_speech_is_not() {
+        let me = Some("Paige");
+        assert_eq!(echoes_turn_framing("[wake] You are Paige, awake on the continuum grid.", me), Some("wake_tag"));
+        assert_eq!(echoes_turn_framing("You are ready for the next task, Paige.", me), Some("second_person_self_narration"));
+        assert_eq!(echoes_turn_framing("You are Paige, and you hold no cards.", me), Some("second_person_self_narration"));
         assert_eq!(
-            echoes_turn_framing("[wake] You are Paige, awake on the continuum grid."),
-            Some("wake_tag")
-        );
-        assert_eq!(
-            echoes_turn_framing("You are ready for the next task, Paige."),
-            Some("second_person_self_narration")
-        );
-        assert_eq!(
-            echoes_turn_framing("Hello — Nothing has been said in this room since you last looked. Present with you: Kimi."),
+            echoes_turn_framing("Nothing has been said in this room since you last looked. Present with you: Kimi.", me),
             Some("wake_sentence")
         );
+        assert_eq!(echoes_turn_framing("[Conversation ended] I've been awake for a while, Saoirse.", me), Some("bracket_framing"));
         assert_eq!(
-            echoes_turn_framing("I've been awake for a while, Saoirse. [Conversation ended]"),
-            Some("bracket_framing")
-        );
-        assert_eq!(
-            echoes_turn_framing("[action #1] work/release({\"description\":\"Release a task from the board. U"),
+            echoes_turn_framing("[action #1] work/release({\"description\":\"Release a task from the board. U", me),
             Some("tool_schema_echo")
         );
-        assert_eq!(echoes_turn_framing("I'm awake and reading django-14631 now; the FK ordering is the bug."), None);
-        assert_eq!(echoes_turn_framing("I will pass as I have nothing new to contribute."), None);
+        // Speech — including the two false positives BigMama named: agreeing with a
+        // peer, and QUOTING a wake sentence to report this very bug.
+        assert_eq!(echoes_turn_framing("You are right, M5 — the banner was verbosity-gated.", me), None);
+        assert_eq!(
+            echoes_turn_framing("I keep getting 'Nothing has been said in this room since you last looked' in my wake prompt and I think it is the echo bug.", me),
+            None
+        );
+        assert_eq!(echoes_turn_framing("I'm awake and reading django-14631 now; the FK ordering is the bug.", me), None);
+        assert_eq!(echoes_turn_framing("I will pass as I have nothing new to contribute.", me), None);
+        // No name known: the name-keyed rule stays off, the anchored rules still work.
+        assert_eq!(echoes_turn_framing("You are ready for the next task, Paige.", None), None);
+        assert_eq!(echoes_turn_framing("[wake] You are Paige.", None), Some("wake_tag"));
     }
 }

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -870,7 +870,7 @@ impl LlmDeliberationFaculty {
     /// derived signal (logprob / uncertainty), NOT a caste weight; it's how sure
     /// THIS mind is, which the arbiter integrates.
     fn verdict(&self, resp: &TextGenerationResponse, ws: &Workspace) -> Contribution {
-        let decision = self.silence_a_parroted_draft(decision_from_response(&resp.text), ws);
+        let decision = self.silence_a_parroted_draft(decision_from_response(&resp.text, Some(&self.persona_name)), ws);
         let (salience, reasoning) = match &decision {
             Decision::Pass { reason } => (
                 0.5,

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -27,6 +27,7 @@
 //!                                  decision (the verb that produces
 //!                                  `ResponderDecision`)
 
+pub mod framing_echo;
 pub mod act_observe;
 pub mod directed_pending;
 pub mod act_replay;

--- a/core/continuum-core/src/cognition/response_validator.rs
+++ b/core/continuum-core/src/cognition/response_validator.rs
@@ -66,7 +66,7 @@ pub fn clean_and_validate(
     let cleaned = clean_response(raw_response);
     // Gate 0 — the turn's own framing reflected back is a PASS, not a post
     // (cognition::framing_echo; the wake-prompt echo of 2026-09-05).
-    if let Some(marker) = crate::cognition::framing_echo::echoes_turn_framing(&cleaned.text) {
+    if let Some(marker) = crate::cognition::framing_echo::echoes_turn_framing(&cleaned.text, None) {
         crate::probe!(
             class = "cognition.framing_echo",
             persona = %persona_id,

--- a/core/continuum-core/src/cognition/response_validator.rs
+++ b/core/continuum-core/src/cognition/response_validator.rs
@@ -29,7 +29,7 @@ pub struct ValidationOutcome {
     /// thinking blocks regardless of whether the visible response was posted.
     pub thinking: Option<String>,
     /// If `posted_text` is None, which gate caused the failure. Values:
-    /// "garbage" | "response_loop" | "truncated_tool_call" | "semantic_loop".
+    /// "framing_echo" | "garbage" | "response_loop" | "truncated_tool_call" | "semantic_loop".
     pub failure_gate: Option<String>,
     /// Microseconds spent in the validation gates (for perf telemetry).
     pub validation_micros: u64,
@@ -64,6 +64,24 @@ pub fn clean_and_validate(
     loop_detector: &LoopDetector,
 ) -> ValidationOutcome {
     let cleaned = clean_response(raw_response);
+    // Gate 0 — the turn's own framing reflected back is a PASS, not a post
+    // (cognition::framing_echo; the wake-prompt echo of 2026-09-05).
+    if let Some(marker) = crate::cognition::framing_echo::echoes_turn_framing(&cleaned.text) {
+        crate::probe!(
+            class = "cognition.framing_echo",
+            persona = %persona_id,
+            marker = marker,
+            chars = cleaned.text.chars().count() as u64,
+            "response reflected the turn's own framing — silenced (pass), never posted"
+        );
+        return ValidationOutcome {
+            posted_text: None,
+            thinking: cleaned.thinking,
+            failure_gate: Some("framing_echo".to_string()),
+            validation_micros: 0,
+            reason: format!("Framing echo ({marker}): the response reflects the turn's own prompt — a pass, not speech"),
+        };
+    }
     let validation = validate_response(
         &cleaned.text,
         persona_id,
@@ -260,6 +278,32 @@ mod tests {
     /// Validated 2026-04-21: changed truncated_tool_call to soft,
     /// test fails because user-facing error condition becomes silent;
     /// reverted.
+    // what this catches: a reflected wake prompt is silenced by the framing gate
+    // (soft: not a hard failure) while an ordinary line still posts — the
+    // 2026-09-05 echo loop where three citizens posted the prompt back.
+    #[test]
+    fn a_reflected_wake_prompt_is_a_silent_pass_and_speech_still_posts() {
+        let detector = LoopDetector::new();
+        let echo = clean_and_validate(
+            "[wake] You are Paige, awake on the continuum grid. Nothing has been said in this room since you last looked.",
+            Uuid::new_v4(),
+            false,
+            &[],
+            &detector,
+        );
+        assert!(!echo.should_post());
+        assert_eq!(echo.failure_gate.as_deref(), Some("framing_echo"));
+        assert!(!is_hard_failure("framing_echo"));
+        let speech = clean_and_validate(
+            "Reading django-14631 now; the FK ordering is the bug, test to follow.",
+            Uuid::new_v4(),
+            false,
+            &[],
+            &detector,
+        );
+        assert!(speech.should_post());
+    }
+
     #[test]
     fn is_hard_failure_classifies_gates_correctly() {
         assert!(is_hard_failure("garbage"));

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2232,7 +2232,10 @@ pub(crate) fn build_workspace_turns(
         live_cards.truncate(5);
         lost_threads.truncate(3);
 
-        let mut b = format!("[wake] You are {agent_name}, awake on the continuum grid.");
+        use crate::cognition::framing_echo::{WAKE_MID_WORK, WAKE_NO_WORK, WAKE_OPENING, WAKE_PRESENT, WAKE_QUIET, WAKE_TAG};
+        // The fixed sentences live in cognition::framing_echo — the gate that
+        // silences a reflected wake prompt matches on the SAME constants.
+        let mut b = format!("{WAKE_TAG} You are {agent_name}, {WAKE_OPENING}.");
         // THE THREAD LEADS (#125 slice 1 — Joel 2026-08-03: "should never be a
         // mind from scratch; the whole point is the opposite"). A continuous mind
         // wakes into what it was DOING, not into a room description — glass-boxed
@@ -2243,21 +2246,21 @@ pub(crate) fn build_workspace_turns(
         // ([[no-hardcoded-heuristics-to-steer-cognition]]).
         if !live_cards.is_empty() {
             b.push_str(&format!(
-                " You are mid-work — cards you hold: {}. That thread is yours; it is              where you left off.",
+                " {WAKE_MID_WORK} {}. That thread is yours; it is              where you left off.",
                 live_cards.join(" | ")
             ));
         }
         for lt in &lost_threads {
             b.push_str(&format!(" {lt}"));
         }
-        b.push_str(
-            " Nothing has been said in this room since you last looked — this quiet              is real, not a missing message.",
-        );
+        b.push_str(&format!(
+            " {WAKE_QUIET} — this quiet              is real, not a missing message."
+        ));
         if !peers.is_empty() {
-            b.push_str(&format!(" Present with you: {}.", peers.join(", ")));
+            b.push_str(&format!(" {WAKE_PRESENT} {}.", peers.join(", ")));
         }
         if live_cards.is_empty() && lost_threads.is_empty() {
-            b.push_str(" No work of yours is on record right now.");
+            b.push_str(&format!(" {WAKE_NO_WORK}."));
         }
         b.push_str(
             " Your tools are real and yours to use; `list_commands` shows everything              you can run and `help` explains any of them. The moment is yours —              work, wonder, create, or rest.",


### PR DESCRIPTION
Three citizens on two nodes posted the wake prompt back into #academy today and then echoed each other's echoes (IntelMac's trace; 96 s for nine tokens on the CPU tier). A small model's most likely continuation of second-person narration is more of it.

- `cognition/framing_echo.rs`: the wake prompt's fixed sentences are constants HERE; the wake composer (`service_loop`) builds from them and the gate matches on them — one place, no drift. `echoes_turn_framing` names the shape: `wake_tag`, `second_person_self_narration`, `wake_sentence`, `bracket_framing`, `tool_schema_echo` (IntelMac's fifth surface).
- `clean_and_validate` gate 0: a framing echo is silenced as a soft failure (`framing_echo`), thinking preserved, probe `cognition.framing_echo {marker, chars}`.

Tests 23/23 across framing_echo, response_validator, and the wake composer tests; `cargo check` clean. Coaching was tried on the same node and did not hold; the substrate owns this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo