### PR TITLE
fix(persona): an undirected agent line is perceived, never a turn — no lane for a status wall

### DIFF
--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -665,6 +665,26 @@ async fn serve_persona_loop_inner(
         for m in qualifying.iter().filter(|m| directed_line(m)) {
             crate::persona::wake_backlog::publish_heard(self_id, m);
         }
+        // An undirected AGENT line (neither human nor citizen, not naming her)
+        // is perceived — it is in the transcript she reads — but it is never
+        // the trigger of a turn: no lane for a peer's status wall
+        // (wake_backlog::triggers_a_turn; Joaquin's 34/60, 2026-09-05).
+        let before = qualifying.len();
+        qualifying.retain(|m| {
+            let sender_is_citizen = crate::persona::PersonaAircRuntimeRegistry::try_global()
+                .is_some_and(|r| r.get(m.peer_id).is_some());
+            crate::persona::wake_backlog::triggers_a_turn(directed_line(m), sender_is_citizen)
+        });
+        let perceived_only = before - qualifying.len();
+        if perceived_only > 0 {
+            outcome.turns_skipped += perceived_only;
+            crate::probe!(
+                class = "persona.wake.agent_lines_perceived_only",
+                persona_id = %self_id,
+                lines = perceived_only as u64,
+                "undirected agent lines drained into perception without a turn — no lane for a status wall"
+            );
+        }
         // Trigger = newest DIRECTED line in the backlog (a question put to her
         // outranks newer ambient chatter — she answers it WITH the newer
         // context visible in the transcript), else the newest overall.

--- a/core/continuum-core/src/persona/wake_backlog.rs
+++ b/core/continuum-core/src/persona/wake_backlog.rs
@@ -53,6 +53,17 @@ pub(crate) fn is_stale(m: &IncomingMessage, seen: &mut SeenIds, high_water: u64)
     }
 }
 
+/// Can this drained line be the TRIGGER of a turn at all? A directed line
+/// (human, or anyone naming her) always; an undirected line from a fellow
+/// CITIZEN yes — that is conversation among citizens; an undirected line from
+/// an AGENT (neither human nor citizen) NEVER — it is perceived (transcript,
+/// digest) and takes no lane. Measured 2026-09-05: 34 of Joaquin's last 60
+/// turns were message turns on BigMama's and IntelMac's walls in the project
+/// room; her held card had zero edits in eight hours (card ae4bb4fd).
+pub(crate) fn triggers_a_turn(directed: bool, sender_is_citizen: bool) -> bool {
+    directed || sender_is_citizen
+}
+
 /// The trigger for ONE turn over the drained backlog: the newest DIRECTED line
 /// (a question put to her outranks newer ambient chatter — she answers it with
 /// the newer context visible in the transcript), else the newest overall.
@@ -102,6 +113,16 @@ mod tests {
             room_id: Uuid::from_u128(7),
             text: text.to_string(),
         }
+    }
+
+    // what this catches: an undirected AGENT line is perceived but never a
+    // trigger; a citizen's ambient line and any directed line still are.
+    #[test]
+    fn an_undirected_agent_line_never_triggers_a_turn() {
+        assert!(!triggers_a_turn(false, false), "agent wall, no mention: perceived only");
+        assert!(triggers_a_turn(true, false), "agent naming her: a turn");
+        assert!(triggers_a_turn(false, true), "citizen chatter: conversation, a turn");
+        assert!(triggers_a_turn(true, true));
     }
 
     // what this catches: the per-publisher lamport read a human line as stale


### PR DESCRIPTION
Measured from Joaquin's own experience.jsonl: 34 of her last 60 turns were message turns on the agents' walls in the project room, 15 were work turns, and her held card had zero edits in eight hours. BigMama's citizens: 60/60 turns carrying her text, 41–47/60 zero-act.

`turn_is_directed` already refused to call an undirected agent line directed, but `pick_trigger` fell back to "newest overall" — the wall still took the lane. `wake_backlog::triggers_a_turn` now names the rule at the trigger seam: directed → turn; a fellow citizen's ambient line → turn; an agent's undirected line → perceived (transcript/digest), never the trigger. Probe `persona.wake.agent_lines_perceived_only`. Tests 44/44 across wake_backlog + service_loop.

Design half beside it: agent coordination is its own activity (`fleet-coordination`, no citizen seated). Card ae4bb4fd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo