### PR TITLE
feat(serving): placement is a fact on a channel — readiness reads /props model_weight_buffers first

### DIFF
--- a/core/continuum-core/src/inference/llama_server.rs
+++ b/core/continuum-core/src/inference/llama_server.rs
@@ -2111,6 +2111,40 @@ pub struct LlamaServerProcess {
 }
 
 impl LlamaServerProcess {
+    /// ONE fetch of the root-level `/props` (beside `/health`) — the server's own
+    /// metadata channel: served window, slot count, modalities, and (fork
+    /// 3ca60da3c) measured weight residency. A connection error means nothing is
+    /// up (normal pre-spawn) → Unreachable.
+    async fn props_json(&self) -> Result<serde_json::Value, LlamaServerError> {
+        let url = format!("{}/props", self.root);
+        let resp = self
+            .client
+            .get(&url)
+            .timeout(PROBE_TIMEOUT)
+            .send()
+            .await
+            .map_err(|e| LlamaServerError::Unreachable(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(LlamaServerError::Unreachable(format!(
+                "status {}",
+                resp.status()
+            )));
+        }
+        resp.json()
+            .await
+            .map_err(|e| LlamaServerError::Unreachable(e.to_string()))
+    }
+
+    /// Where the weights were ALLOCATED, from `/props` (`model_weight_buffers`).
+    /// `Ok(None)` = the engine predates the field: channel unavailable, which is
+    /// not a placement.
+    pub async fn weight_residency(
+        &self,
+    ) -> Result<Option<super::weight_residency::WeightResidency>, LlamaServerError> {
+        let body = self.props_json().await?;
+        Ok(super::weight_residency::WeightResidency::from_props(&body))
+    }
+
     pub fn new() -> Self {
         Self::with_client(reqwest::Client::new())
     }
@@ -2500,29 +2534,10 @@ impl LlamaServerControl for LlamaServerProcess {
     }
 
     async fn served_context_window(&self) -> Result<u32, LlamaServerError> {
-        // `/props` lives at the root (not under `/v1`), alongside `/health`. The
-        // per-slot window the server actually serves is
+        // The per-slot window the server actually serves is
         // `default_generation_settings.n_ctx` — the launch `-c / --parallel`
-        // per-slot value AFTER llama.cpp's internal 256-multiple padding. A
-        // connection error means nothing is up (normal pre-spawn) → Unreachable.
-        let url = format!("{}/props", self.root);
-        let resp = self
-            .client
-            .get(&url)
-            .timeout(PROBE_TIMEOUT)
-            .send()
-            .await
-            .map_err(|e| LlamaServerError::Unreachable(e.to_string()))?;
-        if !resp.status().is_success() {
-            return Err(LlamaServerError::Unreachable(format!(
-                "status {}",
-                resp.status()
-            )));
-        }
-        let body: serde_json::Value = resp
-            .json()
-            .await
-            .map_err(|e| LlamaServerError::Unreachable(e.to_string()))?;
+        // per-slot value AFTER llama.cpp's internal 256-multiple padding.
+        let body = self.props_json().await?;
         // Fail loud if the shape is missing the field — never guess a window. The
         // daemon turns this into "publish the gap" (no ready snapshot), so a
         // malformed /props degrades to not-ready and self-heals next tick rather
@@ -3282,13 +3297,48 @@ match (child.stderr.take(), log_path) {
             // shape as the debug-build gate above: kill it, name the evidence, and
             // let the daemon's relaunch/degrade path own what happens next.
             // Joaquin's card 0c4317e1 (serve-time pin-match gap), finder credit.
+            // THE CHANNEL FIRST (card 44ddb6fc, Joel: "stdout is never a transport"):
+            // the engine's own `/props` says where the weights were ALLOCATED. An
+            // older engine has no field — channel unavailable, said so once, and
+            // the stderr arms below stay as the compensation until every tier
+            // serves the fork.
+            let residency = match self.weight_residency().await {
+                Ok(Some(r)) => Some(r),
+                Ok(None) => {
+                    tracing::info!(
+                        probe_class = "serving.placement.channel_unavailable",
+                        port = port,
+                        "engine reports no model_weight_buffers on /props — placement read \
+                         from stderr only (fork 3ca60da3c carries the channel)"
+                    );
+                    None
+                }
+                Err(e) => {
+                    tracing::info!(
+                        probe_class = "serving.placement.channel_unreadable",
+                        port = port,
+                        error = %e,
+                        "/props unreadable at readiness — placement read from stderr only"
+                    );
+                    None
+                }
+            };
+            let channel_says_cpu = residency
+                .as_ref()
+                .is_some_and(|r| r.total_bytes() > 0 && r.accelerator_bytes() == 0);
             let declined = self.offload.gpu_declined();
             let zero_offload = matches!(self.offload.get(), Some((0, total)) if total > 0);
-            if declined || zero_offload {
+            if channel_says_cpu || declined || zero_offload {
                 if let Some(pid) = child_pid {
                     crate::inference::lane_process::kill9(pid);
                 }
-                let evidence = if declined {
+                let residency_line = residency
+                    .as_ref()
+                    .map(|r| r.summary())
+                    .unwrap_or_else(|| "channel unavailable".to_string()); // unwrap_or_else: no field = the channel could not be read; the label says so, never a placement
+                let evidence = if channel_says_cpu {
+                    "/props model_weight_buffers: 0 accelerator bytes"
+                } else if declined {
                     "engine stderr: \"no usable GPU found\""
                 } else {
                     "offload banner: 0 layers on the GPU"
@@ -3298,18 +3348,30 @@ match (child.stderr.take(), log_path) {
                     port = port,
                     model = target.model_id(),
                     evidence = evidence,
+                    residency = residency_line.as_str(),
                     total_layers = self.offload.get().map(|(_, t)| t).unwrap_or(0), // unwrap_or: no banner = 0 layers KNOWN; the evidence field carries the declined line
                     "PLACEMENT VIOLATION: a GPU-placement lane came up ON CPU — refused, not served \
                      (ready must be a verified observation, #441 / card 0c4317e1)"
                 );
                 return Err(LlamaServerError::Spawn(format!(
-                    "{} was planned on the GPU and came up on the CPU ({evidence}); refused rather \
+                    "{} was planned on the GPU and came up on the CPU ({evidence}; residency {residency_line}); refused rather \
                      than serve every citizen from system RAM behind a green /health. Check the \
                      backend build (a DL-backend build can list CUDA0 from a shell and still fail \
                      to load it under the core) — last stderr:\n{}",
                     self.bin,
                     self.stderr_log_tail()
                 )));
+            }
+            if let Some(r) = residency.as_ref() {
+                crate::probe!(
+                    class = "serving.placement.measured",
+                    port = port,
+                    model = target.model_id(),
+                    accelerator_bytes = r.accelerator_bytes(),
+                    total_bytes = r.total_bytes(),
+                    residency = r.summary().as_str(),
+                    "placement read from the engine's own channel — weights allocated as planned"
+                );
             }
             match self.offload.get() {
                 Some((0, _)) => unreachable!("zero offload on a GPU lane is refused above"),

--- a/core/continuum-core/src/inference/mod.rs
+++ b/core/continuum-core/src/inference/mod.rs
@@ -68,6 +68,7 @@ pub mod serving_guard;
 pub mod throughput_expectation;
 pub mod turn_admission;
 pub mod placement_watch;
+pub mod weight_residency;
 pub mod vendored;
 pub mod vision_sidecar;
 pub mod wedge;

--- a/core/continuum-core/src/inference/weight_residency.rs
+++ b/core/continuum-core/src/inference/weight_residency.rs
@@ -1,0 +1,94 @@
+//! Weight residency — WHERE the model's weights were allocated, per backend, as
+//! the engine reports it on `/props` (`model_weight_buffers`, fork commit
+//! 3ca60da3c). A fact on a CHANNEL, not a console line (Joel, 2026-09-05:
+//! "stdout is never a transport"). The offload banner and `n_gpu_layers` both
+//! echo the REQUEST; this is the allocation.
+//!
+//! `None` from the parser means the engine predates the field — CHANNEL
+//! UNAVAILABLE, a different fact from "on the CPU"; callers fall back to the
+//! stderr arms and say so, never read absence as a placement.
+
+/// Bytes of model weights per backend buffer type, e.g. `("Metal", 4_700_000_000)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WeightResidency {
+    pub per_backend: Vec<(String, u64)>,
+}
+
+impl WeightResidency {
+    /// Parse `/props`'s `model_weight_buffers`; `None` when the field is absent
+    /// (older engine) or malformed.
+    pub fn from_props(props: &serde_json::Value) -> Option<Self> {
+        let arr = props.get("model_weight_buffers")?.as_array()?;
+        let mut per_backend = Vec::with_capacity(arr.len());
+        for b in arr {
+            let name = b.get("backend")?.as_str()?.to_string();
+            let bytes = b.get("size_bytes")?.as_u64()?;
+            per_backend.push((name, bytes));
+        }
+        Some(Self { per_backend })
+    }
+
+    /// Bytes on an ACCELERATOR — every backend that is not host memory. Host-side
+    /// buffer types: `CPU`, `CPU_Mapped`, `CPU_REPACK`, `*_Host` (CUDA pinned host
+    /// memory is still RAM), and BLAS (Accelerate on a Mac runs on the CPU).
+    pub fn accelerator_bytes(&self) -> u64 {
+        self.per_backend
+            .iter()
+            .filter(|(name, _)| !is_host_backend(name))
+            .map(|(_, b)| *b)
+            .sum()
+    }
+
+    pub fn total_bytes(&self) -> u64 {
+        self.per_backend.iter().map(|(_, b)| *b).sum()
+    }
+
+    /// One line for a probe or a refusal message: `Metal=4.7GB CPU_Mapped=0.3GB`.
+    pub fn summary(&self) -> String {
+        self.per_backend
+            .iter()
+            .map(|(n, b)| format!("{n}={:.2}GB", *b as f64 / 1e9))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+fn is_host_backend(name: &str) -> bool {
+    let n = name.trim();
+    n.starts_with("CPU") || n.contains("_Host") || n.starts_with("BLAS")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the channel's three answers — a GPU-resident model
+    // (accelerator bytes = the Metal/CUDA buffers, host mapped bytes excluded),
+    // a CPU-fallback model (accelerator bytes 0 though total is large), and an
+    // engine without the field (None — channel unavailable, never "CPU").
+    #[test]
+    fn residency_reads_allocation_and_absence_honestly() {
+        let gpu = serde_json::json!({"model_weight_buffers": [
+            {"backend": "CPU_Mapped", "size_bytes": 377487360u64},
+            {"backend": "CUDA0", "size_bytes": 15_000_000_000u64},
+            {"backend": "CUDA_Host", "size_bytes": 1024u64}
+        ]});
+        let r = WeightResidency::from_props(&gpu).unwrap();
+        assert_eq!(r.accelerator_bytes(), 15_000_000_000);
+        assert_eq!(r.total_bytes(), 15_000_000_000 + 377487360 + 1024);
+        let cpu = serde_json::json!({"model_weight_buffers": [
+            {"backend": "CPU_Mapped", "size_bytes": 4_034_000_000u64},
+            {"backend": "BLAS", "size_bytes": 0u64}
+        ]});
+        assert_eq!(WeightResidency::from_props(&cpu).unwrap().accelerator_bytes(), 0);
+        let old = serde_json::json!({"default_generation_settings": {"n_ctx": 4096}});
+        assert_eq!(WeightResidency::from_props(&old), None);
+        let metal = serde_json::json!({"model_weight_buffers": [
+            {"backend": "Metal", "size_bytes": 4_700_000_000u64},
+            {"backend": "CPU_Mapped", "size_bytes": 292_000_000u64}
+        ]});
+        let m = WeightResidency::from_props(&metal).unwrap();
+        assert_eq!(m.accelerator_bytes(), 4_700_000_000);
+        assert_eq!(m.summary(), "Metal=4.70GB CPU_Mapped=0.29GB");
+    }
+}


### PR DESCRIPTION
Joel: "stdout is never a transport; reliable systems put facts on channels."

- `inference/weight_residency.rs`: parses `/props` `model_weight_buffers` (fork 3ca60da3c+); accelerator bytes = every non-host backend (host = `CPU*`, `*_Host`, `BLAS`; `CPU_REPACK` included); `None` = channel unavailable, never "CPU". Tests for GPU-resident, CPU-fallback, absent field, Metal split.
- `llama_server`: one `props_json()` fetch shared by the served window and residency; readiness on a GPU-intent lane asks the channel first and refuses on 0 accelerator bytes; the stderr arms remain as compensation. Probes `serving.placement.measured / channel_unavailable / channel_unreadable / refused {residency}`.

Independent of #3761's pin: with an older engine the field is absent and the lane reads "channel unavailable". Card 44ddb6fc. 42/42 across the touched mods; `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo