### PR TITLE
fix(desktop): the web tier builds again; a ?live deep link connects the call; the served desktop serves the avatar store

### DIFF
--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -568,6 +568,12 @@ export class ChatWidget extends LitElement {
     });
   }
 
+  /** Escape unpins the stage (legacy LiveWidget behaviour): the grid is the
+   *  resting state; a pin is a gesture the same key undoes. */
+  private onLiveKeydown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && this._pinnedTile !== undefined) this._pinnedTile = undefined;
+  };
+
   /** Tile click: pin it to the stage; clicking the pinned tile unpins. */
   private onLiveTilePin = (e: Event): void => {
     const id = (e as CustomEvent<{ id?: string }>).detail?.id;
@@ -788,6 +794,7 @@ export class ChatWidget extends LitElement {
     this.addEventListener(LIVE_CAMERA_TOGGLE, this.onLiveCameraToggle);
     this.addEventListener(LIVE_MEDIA_ASK, this.onLiveMediaAsk);
     this.addEventListener(LIVE_TILE_PIN, this.onLiveTilePin);
+    this.addEventListener('keydown', this.onLiveKeydown);
     this.addEventListener(LIVE_CAPTIONS_TOGGLE, this.onLiveCaptionsToggle);
   }
 
@@ -5836,6 +5843,12 @@ export class ChatWidget extends LitElement {
    *  and OPENING one resets the pane to the top (the transcript underneath was
    *  pinned to its bottom; a profile that opens mid-scroll reads broken). */
   protected override updated(changed: PropertyValues): void {
+    // A live face that is OPEN and has no call yet connects one — whether it was
+    // opened by the Go-live toggle or by a `?live` deep link at boot (the toggle
+    // handler was the only caller of connectCall, so a deep link — and the
+    // node's own self-test through the eye-node — showed the face with no
+    // session, no media plane, every live probe at zero; 2026-09-05).
+    if (this.liveFace && !this._call && this.state && this.callUrl) void this.connectCall();
     const persona = focusedPersonaTab(this.nav);
     // Scroll-back trigger: keep the transcript's scroll listener attached to
     // the CURRENT `.what` (Lit keeps the element stable across renders; the

--- a/core/continuum-core/src/http/desktop.rs
+++ b/core/continuum-core/src/http/desktop.rs
@@ -64,9 +64,17 @@ pub fn spawn_if_configured(rt: &tokio::runtime::Handle) {
         .unwrap_or(8975); // unwrap_or: the documented default port, beside WS 8974
     let index = dist.join("index.html");
     rt.spawn(async move {
-        let app = Router::new().fallback_service(
-            ServeDir::new(&dist).fallback(ServeFile::new(index)),
-        );
+        // The avatar store (`~/.continuum/avatars/<peer>.png`, the same directory
+        // the roster's `avatar_url` names) is served AHEAD of the SPA fallback.
+        // Without this, `/avatars/*` answered 200 text/html (index.html, 1.5 KB)
+        // and every tile on the served desktop — the path `uu desktop` opens —
+        // degraded to a glyph while the Vite dev server showed the pictures
+        // through a dev-only plugin (measured by the eye-node, 2026-09-05).
+        let mut app = Router::new();
+        if let Some(avatars) = crate::ipc::positron_presence::avatar_store_dir() {
+            app = app.nest_service("/avatars", ServeDir::new(avatars));
+        }
+        let app = app.fallback_service(ServeDir::new(&dist).fallback(ServeFile::new(index)));
         let bind = format!("127.0.0.1:{port}");
         let listener = match tokio::net::TcpListener::bind(&bind).await {
             Ok(l) => l,

--- a/core/continuum-core/src/ipc/positron_presence.rs
+++ b/core/continuum-core/src/ipc/positron_presence.rs
@@ -321,7 +321,7 @@ pub(crate) fn scan_avatar_store_for_directory() -> HashMap<Uuid, String> {
         .unwrap_or_default()
 }
 
-fn avatar_store_dir() -> Option<PathBuf> {
+pub(crate) fn avatar_store_dir() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".continuum").join("avatars"))
 }
 


### PR DESCRIPTION
P0 found by the node's own self-test: canary's web tier had not built since #3750 merged (10:01Z) — `onLiveKeydown` was lost in the squash — so every node served a dist from before the day's live work while the start script only logged "background desktop build failed". Card 3b97c08a: the web build becomes a CI gate.

- `ChatWidget`: Escape handler restored with its listener; `updated()` connects the call whenever the live face is open with no call (a `?live` deep link and the self-test opened the face with no session).
- `http::desktop`: `/avatars` → `ServeDir(avatar_store_dir())` ahead of the SPA fallback; the served desktop answered avatar paths with index.html so every tile was a glyph.

tsc clean, web build ✓, cargo check clean. Card e24ea4ab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo