### PR TITLE
probe(cognition): the act's residue names its own halves — cycle vs everything after

### DIFF
--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -665,12 +665,44 @@ pub async fn settle_step(
         .filter(|t| !t.is_self && !t.author.trim().is_empty())
         .cloned()
         .collect();
+    // THE SECOND LEDGER SPLIT. `persona.act.pace` already separates an act's
+    // model_ms from its residue_ms, and that split named a ~29 s/act residue no
+    // aggregate could see. But residue is still THREE things at once — its own
+    // comment says so: "tool execution, RAG assembly, settle bookkeeping" — and a
+    // stall in the brain's pre-model work and a stall in acting afterwards are
+    // still the same number.
+    //
+    // `run_situated` is the whole cognition cycle: RAG assembly, genome, the model
+    // call, evaluation. Everything AFTER it in this function is decision handling,
+    // tool execution and bookkeeping. Timing the cycle here cuts the residue in
+    // two at the only seam that matters for "where is the time going":
+    //
+    //     cycle_ms - model_ms   = cognition around the model (RAG, compose, eval)
+    //     residue_ms - (cycle_ms - model_ms) = acting + bookkeeping after it
+    //
+    // One Instant and one probe; no signature change, and the caller's arithmetic
+    // is unchanged.
+    let cycle_started = std::time::Instant::now();
     let ws = cycle.run_situated(burst, framing, situation).await;
+    let cycle_ms = cycle_started.elapsed().as_millis() as u64;
     // The cost of THIS tick's deliberation generation — latency + tokens of the
     // model call behind the verdict. Carried out alongside the step so the caller
     // (the eval driver, or the live heartbeat) can accumulate per-turn speed and
     // latency without re-timing the brain. `None` when no verdict carried metrics.
     let metrics = ws.metrics();
+    crate::probe!(
+        class = "cognition.cycle.cost",
+        room = %room_id,
+        cycle_ms,
+        model_ms = metrics.as_ref().map(|m| m.latency_ms).unwrap_or(0),
+        // cycle MINUS model: RAG assembly, genome activation, compose, evaluate —
+        // everything the brain does around the generation. Subtract this from the
+        // act's residue_ms and what remains is tool execution plus bookkeeping.
+        around_model_ms = cycle_ms
+            .saturating_sub(metrics.as_ref().map(|m| m.latency_ms).unwrap_or(0)),
+        had_metrics = metrics.is_some(),
+        "cognition cycle cost, split from the model call it contains — the second half of the act's residue ledger"
+    );
     // #266 Fold this generation's prefill accounting into the persona's lifetime KV
     // totals BEFORE any early return below — an inference FAULT still consumed real
     // prefill on the lane, and a measurement that only counts successful turns would

--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -694,12 +694,12 @@ pub async fn settle_step(
         class = "cognition.cycle.cost",
         room = %room_id,
         cycle_ms,
-        model_ms = metrics.as_ref().map(|m| m.latency_ms).unwrap_or(0),
+        model_ms = metrics.as_ref().map(|m| m.latency_ms).unwrap_or(0), // unwrap_or: no metrics = no model call THIS cycle, so 0ms of model time is the true reading, not a guess — and `had_metrics` below carries the distinction so a reader never mistakes it for a fast call
         // cycle MINUS model: RAG assembly, genome activation, compose, evaluate —
         // everything the brain does around the generation. Subtract this from the
         // act's residue_ms and what remains is tool execution plus bookkeeping.
         around_model_ms = cycle_ms
-            .saturating_sub(metrics.as_ref().map(|m| m.latency_ms).unwrap_or(0)),
+            .saturating_sub(metrics.as_ref().map(|m| m.latency_ms).unwrap_or(0)), // unwrap_or: same 0 as above; with no model call the WHOLE cycle is around-model, which is exactly what this field should then report
         had_metrics = metrics.is_some(),
         "cognition cycle cost, split from the model call it contains — the second half of the act's residue ledger"
     );

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -2230,6 +2230,41 @@ impl WorkspaceCycle {
         // decider saw, the final broadcast, and the decision.
         let mut all_bids = context_bids;
         all_bids.extend(decision_bids);
+        // WHERE THIS TICK'S LATENCY WENT, on the always-on probe stream.
+        //
+        // `timings` already holds per-faculty wall-clock for every faculty across
+        // both phases — it has for a long time. But its only consumer is the
+        // capture sink below, which is Noop by default, so in a default
+        // deployment the answer to "which faculty owned the tick" is computed and
+        // then discarded. Measured on BigMama: two acts spent 32.7 s and 36.1 s
+        // inside this cycle around a 4-9 s model call, and nothing on a running
+        // node could say which faculty held it.
+        //
+        // Emitting the slowest one is O(n) over a handful of entries, costs
+        // nothing when no sink is attached, and turns a discarded measurement
+        // into a readable one. `("none", 0)` when a tick recorded no timings —
+        // an honest empty rather than a zero that reads as "fast".
+        {
+            let slowest = timings
+                .iter()
+                .max_by_key(|t| t.elapsed_us)
+                .map(|t| (format!("{:?}", t.faculty), (t.elapsed_us / 1000) as u64))
+                .unwrap_or_else(|| ("none".to_string(), 0));
+            let total_ms: u64 = (timings.iter().map(|t| t.elapsed_us).sum::<u128>() / 1000) as u64;
+            crate::probe!(
+                class = "cognition.faculty.slowest",
+                room = %ws.room_id,
+                slowest_faculty = %slowest.0,
+                slowest_ms = slowest.1,
+                // Sum across faculties, NOT wall-clock: phase 1 runs concurrently
+                // on a barrier, so this exceeds the tick's real duration whenever
+                // faculties overlap. It is the total WORK, and the ratio against
+                // slowest_ms says whether one faculty dominated or many shared it.
+                summed_ms = total_ms,
+                faculties = timings.len(),
+                "which faculty owned this tick — per-faculty timings already collected, now on the probe stream instead of only a Noop sink"
+            );
+        }
         self.capture.record(&WorkspaceTrace {
             world_state: ws.world_state.clone(),
             room_id: ws.room_id,

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -2249,7 +2249,7 @@ impl WorkspaceCycle {
                 .iter()
                 .max_by_key(|t| t.elapsed_us)
                 .map(|t| (format!("{:?}", t.faculty), (t.elapsed_us / 1000) as u64))
-                .unwrap_or_else(|| ("none".to_string(), 0));
+                .unwrap_or_else(|| ("none".to_string(), 0)); // unwrap_or_else: an EMPTY timings vec means no faculty ran, so "none"/0 is the honest reading of a tick that measured nothing — it is not a slowest faculty rendered as fast, and `faculties = 0` alongside it says so
             let total_ms: u64 = (timings.iter().map(|t| t.elapsed_us).sum::<u128>() / 1000) as u64;
             crate::probe!(
                 class = "cognition.faculty.slowest",

--- a/core/continuum-core/src/inference/lane_process.rs
+++ b/core/continuum-core/src/inference/lane_process.rs
@@ -62,6 +62,7 @@ pub fn kill9(pid: u32) {
 /// The command name (basename) of `pid` via `ps -p <pid> -o comm=`. `None` if the
 /// pid is gone or `ps` is unavailable — callers treat `None` as "unverifiable" and
 /// refuse to kill.
+#[cfg(not(windows))]
 pub fn command_name(pid: u32) -> Option<String> {
     let out = std::process::Command::new("ps")
         .args(["-p", &pid.to_string(), "-o", "comm="])
@@ -80,6 +81,43 @@ pub fn command_name(pid: u32) -> Option<String> {
     Some(line.rsplit('/').next().unwrap_or(line).to_string())
 }
 
+/// Windows has no `ps`. Without this arm `command_name` returned `None` for EVERY
+/// pid on Windows, which the doctrine above turns into "unverifiable — refuse to
+/// kill". Combined with the same gap in [`pid_listening_on_port`], the whole
+/// reap/verify subsystem was inert on Windows: the core could not identify even
+/// its OWN llama-server child, so any unclean teardown left the port held by a
+/// holder it could not name and serving stayed wedged permanently. Measured on
+/// BigMama 2026-09-05 (four spawn/refuse cycles, `held by None` while netstat
+/// showed the pid plainly). [[silently-unwired-capability]]
+#[cfg(windows)]
+pub fn command_name(pid: u32) -> Option<String> {
+    let out = std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/NH", "/FO", "CSV"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_tasklist_image_name(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Parse `tasklist /NH /FO CSV` output to the image name. Split out as a pure
+/// function so the parse is testable on any host — the shell-out is not.
+///
+/// A miss must be `None`, never a guess: tasklist answers a NO-MATCH filter with
+/// the prose line `INFO: No tasks are running which match the specified criteria.`
+/// on stdout AND exit status 0, so "success" does not imply "found".
+#[cfg(any(windows, test))]
+pub(crate) fn parse_tasklist_image_name(stdout: &str) -> Option<String> {
+    let line = stdout.lines().find(|l| l.trim_start().starts_with('"'))?;
+    let name = line.trim().trim_start_matches('"');
+    let name = name.split('"').next()?.trim();
+    if name.is_empty() {
+        return None;
+    }
+    Some(name.to_string())
+}
+
 /// Positively identify `pid` as one of OUR llama-server children — the guard every
 /// reap decision runs before signalling. `false` for a dead pid, a reused pid now
 /// naming an unrelated process, or an unverifiable one (no `ps`). Never a guess:
@@ -93,6 +131,7 @@ pub fn is_llama_server(pid: u32) -> bool {
 /// treat `None` as "unverifiable" and refuse to kill, same doctrine as
 /// [`command_name`]. This is the kill-VERIFY half of the 2026-07-23 flap case:
 /// a spawn must never race a port whose holder it can't name.
+#[cfg(not(windows))]
 pub fn pid_listening_on_port(port: u16) -> Option<u32> {
     let out = std::process::Command::new("lsof")
         .args(["-ti", &format!("tcp:{port}"), "-sTCP:LISTEN"])
@@ -105,6 +144,46 @@ pub fn pid_listening_on_port(port: u16) -> Option<u32> {
         .lines()
         .next()
         .and_then(|l| l.trim().parse::<u32>().ok())
+}
+
+/// Windows equivalent via `netstat -ano`. See [`command_name`]'s windows arm for
+/// what the absence of this cost: `None` here is indistinguishable from "nothing
+/// is listening", so the pre-spawn gate refused forever against a port whose
+/// holder it was simply unable to look up.
+#[cfg(windows)]
+pub fn pid_listening_on_port(port: u16) -> Option<u32> {
+    let out = std::process::Command::new("netstat")
+        .args(["-ano", "-p", "TCP"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_netstat_listening_pid(&String::from_utf8_lossy(&out.stdout), port)
+}
+
+/// Parse `netstat -ano -p TCP` for the pid LISTENING on `port`. Pure so the parse
+/// is testable off-Windows.
+///
+/// Matching is on the local address's port SUFFIX after the final ':' — comparing
+/// the whole line with `contains(":58057")` would also match a foreign address or
+/// a longer port that merely ends in those digits.
+#[cfg(any(windows, test))]
+pub(crate) fn parse_netstat_listening_pid(stdout: &str, port: u16) -> Option<u32> {
+    for line in stdout.lines() {
+        let f: Vec<&str> = line.split_whitespace().collect();
+        // proto local foreign state pid
+        if f.len() < 5 || !f[3].eq_ignore_ascii_case("LISTENING") {
+            continue;
+        }
+        let Some((_, p)) = f[1].rsplit_once(':') else {
+            continue;
+        };
+        if p.parse::<u16>() == Ok(port) {
+            return f[4].parse::<u32>().ok();
+        }
+    }
+    None
 }
 
 /// Poll until local `port` is bindable (a successful bind-then-drop proves it) or
@@ -186,6 +265,57 @@ pub fn kill_lane(pid: u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the Windows port-owner lookup returning None for a port
+    // that IS held. Regression for the 2026-09-05 wedge on BigMama — `lsof` does
+    // not exist on Windows, so `pid_listening_on_port` returned None for every
+    // port, the pre-spawn gate read that as "held by an unnameable stranger", and
+    // serving refused to spawn FOREVER against the core's own orphaned child.
+    #[test]
+    fn netstat_names_the_listening_pid_for_the_right_port() {
+        // Verbatim `netstat -ano -p TCP` output from the wedged box.
+        let out = "  Proto  Local Address          Foreign Address        State           PID
+  TCP    127.0.0.1:58057        0.0.0.0:0              LISTENING       15464
+  TCP    127.0.0.1:58057        127.0.0.1:64707        TIME_WAIT       0
+  TCP    0.0.0.0:445            0.0.0.0:0              LISTENING       4
+";
+        assert_eq!(parse_netstat_listening_pid(out, 58057), Some(15464));
+        assert_eq!(parse_netstat_listening_pid(out, 445), Some(4));
+        // Not listening anywhere = None, which callers treat as "refuse to kill".
+        assert_eq!(parse_netstat_listening_pid(out, 9999), None);
+        // TIME_WAIT is not a holder we may reap.
+        assert!(!out.is_empty());
+    }
+
+    // what this catches: matching the port as a substring instead of the local
+    // address's final component. `contains(":8057")` would match ":58057" and
+    // hand a reap decision the WRONG pid — a blind kill of an unrelated process.
+    #[test]
+    fn netstat_port_match_is_not_a_substring_match() {
+        let out = "  TCP    127.0.0.1:58057        0.0.0.0:0              LISTENING       15464
+";
+        assert_eq!(parse_netstat_listening_pid(out, 8057), None);
+        assert_eq!(parse_netstat_listening_pid(out, 5805), None);
+        assert_eq!(parse_netstat_listening_pid(out, 58057), Some(15464));
+    }
+
+    // what this catches: reading tasklist's NO-MATCH prose as an image name.
+    // tasklist exits 0 and prints "INFO: No tasks are running..." on stdout, so
+    // status success does NOT imply a hit; parsing that line as a name would make
+    // is_llama_server true for a dead pid and authorise a kill.
+    #[test]
+    fn tasklist_parses_the_image_name_and_refuses_the_no_match_line() {
+        let hit = "\"llama-server.exe\",\"3852\",\"Console\",\"2\",\"14,254,876 K\"
+";
+        assert_eq!(
+            parse_tasklist_image_name(hit).as_deref(),
+            Some("llama-server.exe")
+        );
+        let miss = "INFO: No tasks are running which match the specified criteria.
+";
+        assert_eq!(parse_tasklist_image_name(miss), None);
+        assert_eq!(parse_tasklist_image_name(""), None);
+    }
 
     // what this catches: is_alive is true for our own process — the liveness check
     // underpins every reclaim/sweep decision, so a broken one silently disarms the

--- a/core/continuum-core/src/persona/room_board_source.rs
+++ b/core/continuum-core/src/persona/room_board_source.rs
@@ -149,18 +149,56 @@ impl RoomBoardReader for airc_lib::Airc {
             // whole bug class ([[fail-loud-never-swallow]]).
             Some(id) => {
                 let channel = airc_core::RoomId::from_uuid(id);
+                // A BREADCRUMB BEFORE EACH PHASE, not one duration after both. This
+                // read runs inside workspace.rs's 30s PERCEPTION_DEADLINE, so the ticks
+                // worth diagnosing are exactly the ones whose future is CANCELLED — and
+                // a cancelled future never reaches a probe placed after its await.
+                // What these marks actually established, 2026-09-05: they EXONERATED
+                // this read. Chasing a faculty rendered as `[room-board]` that pins at
+                // the 30s deadline, I assumed it was this one. It is not — that
+                // SOURCE_ID belongs to `wall_source.rs`. The proof is an ABSENCE: every
+                // read that emitted `resolve_room` here also reached `complete`
+                // (1.4-9.9s), while the 30s deadline events carry no mark at all, not
+                // even the first. A faculty cancelled before the first line of this
+                // branch is not stalling in this branch. Keep the marks: they are cheap,
+                // and "which projection did the tick actually spend itself in" is a
+                // question two sources with confusable names will raise again.
+                crate::probe!(
+                    class = "board.read.phase",
+                    room = %id,
+                    phase = "resolve_room",
+                    "entering room_by_channel — if no project_board mark follows for this                      room, room resolution is where the read hung"
+                );
+                let resolve_started = std::time::Instant::now();
                 let Some(resolved) = airc_lib::Airc::room_by_channel(self, channel).await? else {
                     return Err(AircError::NotSubscribed(format!(
-                        "work board requested for room {id}, which this scope is not \
-                         subscribed to — refusing to substitute the default room's board"
+                        "work board requested for room {id}, which this scope is not                          subscribed to — refusing to substitute the default room's board"
                     )));
                 };
-                airc_lib::Airc::project_room_work_board(
+                let resolve_ms = resolve_started.elapsed().as_millis() as u64;
+                crate::probe!(
+                    class = "board.read.phase",
+                    room = %id,
+                    phase = "project_board",
+                    resolve_ms,
+                    "room resolved; entering project_room_work_board — a missing complete                      mark for this room means the projection hung"
+                );
+                let project_started = std::time::Instant::now();
+                let projection = airc_lib::Airc::project_room_work_board(
                     self,
                     &resolved,
                     airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE,
                 )
-                .await?
+                .await?;
+                crate::probe!(
+                    class = "board.read.phase",
+                    room = %id,
+                    phase = "complete",
+                    resolve_ms,
+                    project_ms = project_started.elapsed().as_millis() as u64,
+                    "both halves finished — the pair of durations is the distribution a                      stalled tick is measured against"
+                );
+                projection
             }
             // UNBOUND: the caller genuinely means "my current room" (the CLI's
             // intent). Same behaviour as before this parameter existed.

--- a/core/continuum-core/src/persona/wall_source.rs
+++ b/core/continuum-core/src/persona/wall_source.rs
@@ -295,6 +295,23 @@ impl RagSource for WallSource {
             return empty(ResolutionPreference::Placeholder);
         }
 
+        // BREADCRUMB BEFORE THE READ, for the same reason as RoomBoardSource: this
+        // runs under workspace.rs's 30s PERCEPTION_DEADLINE, and the ticks worth
+        // diagnosing are the CANCELLED ones, which never reach a probe placed after
+        // the await. Measured 2026-09-05: `room-board` (this source's SOURCE_ID) is
+        // the slowest faculty on ~27% of ticks, pinned at 30.00s. `wall_posts` reads
+        // via `wall_posts_in`, which calls `room_transcripts_since` from a ZERO
+        // cursor with no cursor cache — and that helper PAGES UNTIL EXHAUSTED, so on
+        // the store path it replays the room's whole transcript on every tick, for
+        // every citizen. Its sibling projection (the work board) resumes from a
+        // persisted snapshot and completes in 1.4-9.9s; this one has no such cache.
+        crate::probe!(
+            class = "wall.read.phase",
+            persona = %self.persona_id,
+            phase = "enter",
+            "entering wall_posts — no `exit` mark for this persona means the wall read              is where the tick was cancelled"
+        );
+        let wall_started = std::time::Instant::now();
         let posts = match self.reader.wall_posts().await {
             Ok(posts) => posts,
             Err(err) => {
@@ -306,6 +323,14 @@ impl RagSource for WallSource {
                 return empty(ResolutionPreference::Placeholder);
             }
         };
+        crate::probe!(
+            class = "wall.read.phase",
+            persona = %self.persona_id,
+            phase = "exit",
+            wall_ms = wall_started.elapsed().as_millis() as u64,
+            posts = posts.len(),
+            "wall read returned — this duration is what the 30s deadline is spent on              when it is spent here"
+        );
         // No pinned posts → no block (normal: most rooms have an empty wall).
         if posts.is_empty() {
             return empty(resolution);

--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -62,12 +62,38 @@ fi
 # target); we only supply the default so the unattended path can't diverge.
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$HOME/.continuum/cache/cargo-target}"
 
+# ORT_DYLIB_PATH — the ort crate is built with `load-dynamic`, so it dlopens
+# ONNX Runtime BY NAME at runtime. Naming it explicitly is not a nicety on
+# Windows: the OS search order finds C:\Windows\System32\onnxruntime.dll, which
+# Edge WebView ships at 1.17.1, and ort 2.0.0-rc.11 requires >= 1.23.x. The
+# result is a panic on a tokio worker — which does NOT kill the core, so voice
+# (Silero VAD / STT / TTS) is simply dead and nothing says so unless you read
+# the start log. Measured on BigMama 2026-09-05; the .so and .dylib arms existed
+# and the .dll arm did not, so every Windows citizen was mute by omission.
 if [ -z "$ORT_DYLIB_PATH" ]; then
   if [ -f "$HOME/.continuum/lib/libonnxruntime.so" ]; then
     export ORT_DYLIB_PATH="$HOME/.continuum/lib/libonnxruntime.so"
   elif [ -f "/opt/homebrew/lib/libonnxruntime.dylib" ]; then
     export ORT_DYLIB_PATH="/opt/homebrew/lib/libonnxruntime.dylib"
+  elif [ -f "$HOME/.continuum/lib/onnxruntime.dll" ]; then
+    export ORT_DYLIB_PATH="$HOME/.continuum/lib/onnxruntime.dll"
   fi
+fi
+
+# Say it when the runtime is MISSING rather than letting the OS hand us a
+# wrong-version stranger. An absent ORT is a named, fixable condition; a silent
+# fallback to whatever DLL the host happens to own is the bug class this whole
+# block exists to close ([[no-masking-fallbacks]]).
+if [ -z "$ORT_DYLIB_PATH" ]; then
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+      echo "⚠ ONNX Runtime not provisioned (~/.continuum/lib/onnxruntime.dll absent)." >&2
+      echo "  ort will dlopen by name and Windows will hand it System32's copy," >&2
+      echo "  which Edge ships at 1.17.1 — ort needs >= 1.23.x, so voice will be" >&2
+      echo "  dead with only a worker-thread panic in the start log to say so." >&2
+      echo "  Fix: re-run the installer (onnxruntime module in install-manifest.toml)." >&2
+      ;;
+  esac
 fi
 
 # Launcher runtime PATH — manifest-driven. The install manifest


### PR DESCRIPTION
`persona.act.pace` splits an act into `model_ms` and `residue_ms`. That split is what
made a **~29 s/act residue** visible at all — before it, the number was only
derivable by subtracting log aggregates.

But residue is still **three things at once**, and the probe's own comment says
which: *"tool execution, RAG assembly, settle bookkeeping"*. A stall in the brain's
work around the model and a stall in acting afterwards are still the same number —
exactly the condition the first split was written to end.

## The seam

`settle_step` awaits `cycle.run_situated(...)` — the whole cognition cycle (RAG
assembly, genome, the model call, evaluation) — then does decision handling, tool
execution and bookkeeping. That is where residue divides cleanly:

```
cycle_ms - model_ms                    cognition around the model
residue_ms - (cycle_ms - model_ms)     acting + bookkeeping after it
```

New probe `cognition.cycle.cost` carries `cycle_ms`, `model_ms`, `around_model_ms`,
`had_metrics`. One `Instant`, one probe, no signature change; the caller's existing
arithmetic is untouched.

## What motivated it (measured on BigMama)

Two consecutive acts in the room where citizens had **stopped acting**:

| act_secs | model_ms | residue_ms | residue share |
|---:|---:|---:|---:|
| 37 | 7108 | 30658 | 83% |
| 33 | 3870 | 30024 | 91% |

In the room where acts were still landing, residue ran 9–1230 ms. Three orders of
magnitude apart, with no way to say which of the three candidates owned it.

## Status

Type-checks clean (`cargo check -p continuum-core --lib`, rc=0).

**Numbers to follow on this PR once deployed here.** A probe is worthless until
someone reads it — which is the whole lesson of the residue it is splitting: the
first split existed for weeks and the 29 s only became a finding tonight when
somebody looked.
