### PR TITLE
feat(rooms): every activity verb addresses a room by id — --room on archive/protect/work-create, project recipe, tenant-neutrality gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -301,7 +301,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=e31a1305f#e31a1305fda42015d3a900dbc1d882cfdbedf1c8"
+source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
 dependencies = [
  "airc-core",
  "airc-store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -301,7 +301,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=f68e48c07#f68e48c07c118899b366e23178f46ad2adb66a91"
+source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
 dependencies = [
  "airc-core",
  "airc-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,18 +185,18 @@ members = [
 # room is still its default under either verb. This is what continuum's
 # room/join needs (task #65, Joel: a persona is first-class and can subscribe to
 # many rooms). Also fixes `RoomJoinedBody.is_default`, previously hardcoded true.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,18 +185,18 @@ members = [
 # room is still its default under either verb. This is what continuum's
 # room/join needs (task #65, Joel: a persona is first-class and can subscribe to
 # many rooms). Also fixes `RoomJoinedBody.is_default`, previously hardcoded true.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "e31a1305f" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "f68e48c07" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/apps/web/src/preview.ts
+++ b/apps/web/src/preview.ts
@@ -584,7 +584,7 @@ function main(): void {
         '    continuity of the beings whose experience these genes encode.',
         ' 5. OPT-OUT ANYTIME. Revoking consent stops future sharing immediately.',
       ].join('\n'),
-      hfAccount: 'CambrianTech',
+      hfAccount: 'your-org',
       genes: [
         { gene: 'code', baseModel: 'ornith-ai/Ornith-1.5-35B-A3B-GGUF', signed: true, trials: 7, decayedLift: 0.062 },
         { gene: 'coder-4b-curriculum-mlp', baseModel: 'qwen3.5-4b', signed: true, trials: 2, decayedLift: 0.031 },

--- a/core/continuum-core/src/airc/discovery.rs
+++ b/core/continuum-core/src/airc/discovery.rs
@@ -294,7 +294,7 @@ fn parse_room_name_from_room_output(stdout: &str) -> Result<String, DiscoveryErr
 /// Output today (from airc rust-rewrite branch, as of this PR):
 /// ```text
 /// room:    continuum
-/// wire:    /Users/joel/.airc/wires/continuum
+/// wire:    ~/.airc/wires/<room>
 /// channel: 11c1a7ac-cb85-5ca0-a5b4-2847280ea3fa
 /// ```
 ///
@@ -437,7 +437,7 @@ mod tests {
     fn parses_channel_from_typical_airc_room_output() {
         let stdout = "\
 room:    continuum
-wire:    /Users/joel/.airc/wires/continuum
+wire:    ~/.airc/wires/<room>
 channel: 11c1a7ac-cb85-5ca0-a5b4-2847280ea3fa
 ";
         let uuid = parse_channel_from_room_output(stdout).expect("parse channel");

--- a/core/continuum-core/src/experience/recipes/project.json
+++ b/core/continuum-core/src/experience/recipes/project.json
@@ -1,0 +1,39 @@
+{
+  "id": "2f6b1c0e-4c7a-4d0b-9a7e-5a1c3e9f7b21",
+  "version": 1,
+  "purpose": "project",
+  "regions": [
+    {
+      "name": "board",
+      "kind": "kanban",
+      "scope": "activity",
+      "role": "primary",
+      "slot": "content",
+      "live": true
+    },
+    {
+      "name": "messages",
+      "kind": "chat",
+      "scope": "activity",
+      "role": "peripheral",
+      "slot": "content",
+      "live": true
+    },
+    {
+      "name": "roster",
+      "kind": "roster",
+      "scope": "activity",
+      "role": "peripheral",
+      "slot": "context",
+      "live": true
+    }
+  ],
+  "affordances": [],
+  "citizens": [],
+  "params": {
+    "repo": {
+      "default": "",
+      "doc": "Repository key this project builds (owner/name, from the checkout's git remote). Cards on this board name it; card rooms nest under this room."
+    }
+  }
+}

--- a/core/continuum-core/src/experience/source.rs
+++ b/core/continuum-core/src/experience/source.rs
@@ -273,6 +273,7 @@ impl RecipeExperienceSource {
             include_str!("recipes/chat.json"),
             include_str!("recipes/video-chat.json"),
             include_str!("recipes/profile.json"),
+            include_str!("recipes/project.json"),
         ]
         .into_iter()
         .map(|json| {

--- a/core/continuum-core/src/experience/source.rs
+++ b/core/continuum-core/src/experience/source.rs
@@ -112,6 +112,9 @@ pub mod shipped {
     pub const PROFILE: RecipeId = RecipeId::from_u128(0x089ac0da_d65a_4922_8cdc_36e7f589c465);
     /// Real-time voice/video (`video-chat`) — `6bc4fc12-a1c3-4482-ab2c-eb48505d52d3`.
     pub const VIDEO_CHAT: RecipeId = RecipeId::from_u128(0x6bc4fc12_a1c3_4482_ab2c_eb48505d52d3);
+    /// A project — one repo's work: a board, a room per card under it (`project`) —
+    /// `2f6b1c0e-4c7a-4d0b-9a7e-5a1c3e9f7b21`.
+    pub const PROJECT: RecipeId = RecipeId::from_u128(0x2f6b1c0e_4c7a_4d0b_9a7e_5a1c3e9f7b21);
 
     /// Every shipped id, for tests and for enumerating the prod-critical floor.
     pub const ALL: &[RecipeId] = &[BENCHMARK_HARD_RS, CHAT, PROFILE, VIDEO_CHAT];
@@ -394,7 +397,7 @@ mod tests {
     fn shipped_ids_are_unique_and_match_their_purposes() {
         let source = RecipeExperienceSource::builtins(Arc::new(FixedPurpose("chat")));
         let ids: std::collections::HashSet<_> = source.ids().collect();
-        assert_eq!(ids.len(), 4, "four distinct ids, none colliding");
+        assert_eq!(ids.len(), 5, "five distinct ids, none colliding");
 
         // The id→purpose pairing is the contract core code relies on when it says
         // `shipped::BENCHMARK_HARD_RS` and means the Rust gym.
@@ -407,6 +410,13 @@ mod tests {
                 .by_recipe_id(shipped::CHAT)
                 .map(|r| r.purpose.as_str()),
             Some("chat")
+        );
+        assert_eq!(
+            source
+                .by_recipe_id(shipped::PROJECT)
+                .map(|r| r.purpose.as_str()),
+            Some("project"),
+            "a project is a shipped activity type: org room → project room → a room per card"
         );
     }
 

--- a/core/continuum-core/src/inference_capability/gguf_loader.rs
+++ b/core/continuum-core/src/inference_capability/gguf_loader.rs
@@ -92,7 +92,7 @@ fn parse_qwen_metadata_from_content(
         crate::inference_capability::gguf_keys::architecture(content).ok_or_else(|| {
             format!(
                 "GGUF {} is missing required 'general.architecture' — refuse rather than \
-                 guess. Same rule as backends::read_gguf_metadata (Joel 2026-04-23).",
+                 guess. Same rule as backends::read_gguf_metadata (2026-04-23).",
                 path.display()
             )
         })?;

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -53,6 +53,7 @@ use airc_core::RoomId;
 use airc_lib::Airc;
 
 use crate::experience::standing::{project_standing, RoomStanding, STANDING_WALL_CATEGORY};
+use crate::modules::room_resolve::resolve_room;
 use crate::persona::PersonaAircRuntimeRegistry;
 use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
 use crate::sdk_codegen::{AccessLevel, ActionCommand, CommandError, Ctx, DynCommand};
@@ -592,35 +593,48 @@ pub async fn spawn_activity_room(
 
 // ─────────────────────────── standing ───────────────────────────
 
-/// Read the current standing of the caller's current room, or the default
-/// (live, unprotected) when nobody has ever declared one.
+
+/// The standing of ONE room the caller named — never "whatever room the
+/// scope's pointer happens to be on".
 ///
-/// The type, the wall category, and the rule for turning posts into a standing
-/// all live in [`crate::experience::standing`] — this is only the "fetch the
-/// current room's posts" half. They were born here as a private `async fn` over
-/// `&Airc`, which meant the only code that could read a standing was the command
-/// that wrote it, and `archived` shipped as a declaration nothing consumed.
-async fn current_standing(airc: &Airc) -> Result<RoomStanding, CommandError> {
+/// Joel, 2026-09-05: "You never work in rooms. You just use whatever one of
+/// you reuses." Every activity verb that means a specific room must be able
+/// to say so; the pointer default silently archives a plausible wrong room and
+/// nothing in the receipt says which. Same split airc makes for
+/// `wall_posts` / `wall_posts_in` and `work_board` / `work_board_in`.
+async fn standing_in(airc: &Airc, room: &airc_lib::Room) -> Result<RoomStanding, CommandError> {
     let posts = airc
-        .wall_posts(Some(STANDING_WALL_CATEGORY))
+        .wall_posts_in(room, Some(STANDING_WALL_CATEGORY))
         .await
         .map_err(|source| {
-            CommandError::Internal(format!("could not read room standing: {source}"))
+            CommandError::Internal(format!(
+                "could not read room standing for #{}: {source}",
+                room.name
+            ))
         })?;
     project_standing(&posts).map_err(|source| CommandError::Internal(source.to_string()))
 }
 
-/// Publish a merged standing, preserving every field the caller did not set.
-async fn publish_standing(airc: &Airc, next: &RoomStanding) -> Result<String, CommandError> {
+/// Publish a merged standing on ONE room, preserving every field the caller
+/// did not set.
+async fn publish_standing_in(
+    airc: &Airc,
+    room: &airc_lib::Room,
+    next: &RoomStanding,
+) -> Result<String, CommandError> {
     let body = serde_json::to_string(next)
         .map_err(|source| CommandError::Internal(format!("encode standing: {source}")))?;
-    airc.publish_wall_post(STANDING_WALL_CATEGORY.to_string(), body, None)
+    airc.publish_wall_post_in(room, STANDING_WALL_CATEGORY.to_string(), body, None)
         .await
         .map(|id| id.to_string())
         .map_err(|source| {
-            CommandError::Internal(format!("could not publish room standing: {source}"))
+            CommandError::Internal(format!(
+                "could not publish room standing on #{}: {source}",
+                room.name
+            ))
         })
 }
+
 
 #[derive(Debug, Clone, Serialize, TS)]
 pub struct StandingResult {
@@ -640,6 +654,12 @@ pub struct ActivityArchive {
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS, JsonSchema)]
 pub struct ActivityArchiveParams {
+    /// The room whose activity this concludes — its id or its name. Omitted =
+    /// the caller's current room. Name it: a verb that means a specific room
+    /// must never depend on where the scope's pointer happens to stand.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub room: Option<String>,
     /// `true` concludes the activity, `false` reopens it. Reversible on purpose —
     /// concluding is a judgement, and judgements get revised.
     #[serde(default = "default_true")]
@@ -674,12 +694,13 @@ impl ActionCommand for ActivityArchive {
         p: ActivityArchiveParams,
     ) -> Result<StandingResult, CommandError> {
         let airc = caller_airc(&self.registry, ctx)?;
-        let mut standing = current_standing(&airc).await?;
+        let room = resolve_room(&airc, p.room.as_deref()).await?;
+        let mut standing = standing_in(&airc, &room).await?;
         standing.archived = p.archived;
         if p.note.is_some() {
             standing.note = p.note;
         }
-        let post_id = publish_standing(&airc, &standing).await?;
+        let post_id = publish_standing_in(&airc, &room, &standing).await?;
         Ok(StandingResult {
             archived: standing.archived,
             protected: standing.protected,
@@ -697,6 +718,11 @@ pub struct ActivityProtect {
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS, JsonSchema)]
 pub struct ActivityProtectParams {
+    /// The room to protect (or release) — its id or its name. Omitted = the
+    /// caller's current room.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub room: Option<String>,
     /// `true` protects, `false` releases protection.
     #[serde(default = "default_true")]
     pub protected: bool,
@@ -725,12 +751,13 @@ impl ActionCommand for ActivityProtect {
         p: ActivityProtectParams,
     ) -> Result<StandingResult, CommandError> {
         let airc = caller_airc(&self.registry, ctx)?;
-        let mut standing = current_standing(&airc).await?;
+        let room = resolve_room(&airc, p.room.as_deref()).await?;
+        let mut standing = standing_in(&airc, &room).await?;
         standing.protected = p.protected;
         if p.note.is_some() {
             standing.note = p.note;
         }
-        let post_id = publish_standing(&airc, &standing).await?;
+        let post_id = publish_standing_in(&airc, &room, &standing).await?;
         Ok(StandingResult {
             archived: standing.archived,
             protected: standing.protected,

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -81,6 +81,7 @@ pub mod rag;
 pub mod resource_broker;
 pub mod resources_module;
 pub mod room;
+pub mod room_resolve;
 pub mod runtime_control;
 pub mod sentinel;
 pub mod serving_consumer;

--- a/core/continuum-core/src/modules/room_resolve.rs
+++ b/core/continuum-core/src/modules/room_resolve.rs
@@ -1,0 +1,96 @@
+//! ONE place that turns "the room a verb names" into an [`airc_lib::Room`].
+//!
+//! Joel, 2026-09-05: "You never work in rooms. You just use whatever one of
+//! you reuses." Every activity / work verb that means a specific room must
+//! address it by id or name; the scope's current-room pointer is the fallback
+//! only when nothing was named, never the reason a card or a standing lands
+//! somewhere. `activity/archive`, `activity/protect` and `work/create` all
+//! resolve through here so the rule has exactly one implementation.
+
+use airc_lib::Airc;
+
+use crate::sdk_codegen::CommandError;
+
+/// Resolve the room a verb names — by id or by name — among the rooms the
+/// caller is subscribed to, or the caller's current room when none is named.
+///
+/// Subscription is the reach: a room the caller is not in has no wall this
+/// handle can read or write (the same bound `AircRecipeReader::recipe_posts`
+/// states), so an unknown room is refused by name with the rooms that ARE in
+/// reach, never silently swapped for the current one.
+pub(crate) async fn resolve_room(airc: &Airc, named: Option<&str>) -> Result<airc_lib::Room, CommandError> {
+    let Some(named) = named.map(str::trim).filter(|s| !s.is_empty()) else {
+        return airc.current_room().await.map_err(|source| {
+            CommandError::Internal(format!("could not resolve the current room: {source}"))
+        });
+    };
+    let set = airc.subscription_set().await.map_err(|source| {
+        CommandError::Internal(format!("subscription set unavailable: {source}"))
+    })?;
+    let wanted = named.trim_start_matches('#');
+    let by_id = uuid::Uuid::parse_str(wanted).ok();
+    let mut names = Vec::new();
+    for sub in set.all() {
+        let room = sub.as_room();
+        if room.name == wanted || by_id == Some(room.channel.as_uuid()) {
+            return Ok(room);
+        }
+        names.push(format!("#{}", room.name));
+    }
+    Err(CommandError::Invalid(format!(
+        "room {named:?} is not among the rooms this caller is in ({}) — join it first          (room/join), or name one of these",
+        names.join(", ")
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One local scope subscribed to two rooms — the shape every activity verb
+    /// runs in: a pointer on one room, a verb that means another.
+    async fn two_room_scope() -> (tempfile::TempDir, Airc) {
+        let home = tempfile::tempdir().expect("temp airc home");
+        let airc = Airc::open_with_wire_root_for_test(home.path(), home.path())
+            .await
+            .expect("a local airc scope opens without a daemon");
+        airc.join("academy").await.expect("join academy");
+        airc.join("widgets").await.expect("join the project room");
+        (home, airc)
+    }
+
+    // what this catches: the pointer default sneaking back — a verb naming a room
+    // by NAME or by ID must get THAT room even while the scope points elsewhere.
+    #[tokio::test]
+    async fn a_named_room_resolves_by_name_or_id_regardless_of_the_pointer() {
+        let (_home, airc) = two_room_scope().await;
+        airc.join("academy").await.expect("point the scope at academy");
+        let current = airc.current_room().await.expect("current room");
+        assert_eq!(current.name, "academy", "the pointer stands on academy");
+
+        let by_name = resolve_room(&airc, Some("#widgets")).await.expect("by name");
+        assert_eq!(by_name.name, "widgets");
+        let id = by_name.channel.as_uuid().to_string();
+        let by_id = resolve_room(&airc, Some(&id)).await.expect("by id");
+        assert_eq!(by_id.channel, by_name.channel);
+
+        let none = resolve_room(&airc, None).await.expect("unnamed = current");
+        assert_eq!(none.name, "academy", "no name given → the caller's current room");
+    }
+
+    // what this catches: a room outside the caller's reach silently swapped for
+    // the current one. It must be REFUSED, naming what is in reach.
+    #[tokio::test]
+    async fn a_room_the_caller_is_not_in_is_refused_with_the_rooms_in_reach() {
+        let (_home, airc) = two_room_scope().await;
+        let err = resolve_room(&airc, Some("somewhere-else"))
+            .await
+            .expect_err("an unsubscribed room is not resolvable from this handle");
+        let text = err.to_string();
+        assert!(text.contains("somewhere-else"), "names the room asked for: {text}");
+        assert!(
+            text.contains("#academy") && text.contains("#widgets"),
+            "names the rooms that ARE in reach: {text}"
+        );
+    }
+}

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -1477,6 +1477,12 @@ pub struct WorkCreate {
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS, JsonSchema)]
 pub struct WorkCreateParams {
+    /// The activity room whose board receives the card — its id or its name.
+    /// Omitted = the caller's current room (the lobby on a fresh node, which is
+    /// how project cards ended up in #general). Name the room.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub room: Option<String>,
     /// Repository key, e.g. `CambrianTech/continuum`.
     pub repo: String,
     /// Human-readable card title.
@@ -1514,8 +1520,9 @@ impl ActionCommand for WorkCreate {
             parse_priority(p.priority.as_deref().unwrap_or("p2")),
         );
         req.body = p.body;
+        let room = crate::modules::room_resolve::resolve_room(&airc, p.room.as_deref()).await?;
         let card_id = airc
-            .create_work_card(req)
+            .create_work_card_in(&room, req)
             .await
             .map_err(|e| CommandError::Internal(e.to_string()))?;
         Ok(WorkCreateResult {

--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -114,6 +114,35 @@ pub async fn ensure_operator_peer(
                     "operator self-peer could not subscribe the airc lobby — the human cannot be heard in #general until room/join"
                 );
             }
+            // THE PROJECT TREE (Joel, 2026-09-05: "You never work in rooms… you were
+            // building continuum in its academy"): the org room airc derives from the
+            // checkout's git remote (the repo OWNER's channel, whoever that is) is the base of the project
+            // tree — project rooms nest under it, card rooms under those. The human's
+            // desktop lists the rooms the operator peer is SUBSCRIBED to, so until the
+            // operator subscribes the org room the whole project tree is invisible and
+            // every project line lands in the lobby or the commons. Subscribe without
+            // promoting (Keep): the commons join below still decides the focus.
+            for channel in airc_lib::JoinContext::from_cwd(
+                &crate::modules::persona_instance_manager::resolve_continuum_root(),
+            )
+            .channels
+            .iter()
+            .filter(|c| c.as_str() != airc_lib::GENERAL_CHANNEL)
+            {
+                match rt.subscribe_room(channel.as_str()).await {
+                    Ok(()) => crate::probe!(
+                        class = "operator.peer.project_base_subscribed",
+                        room = %channel.as_str(),
+                        "operator self-peer subscribed the project base room (the org room from the git remote)"
+                    ),
+                    Err(e) => crate::probe!(
+                        class = "operator.peer.project_base_subscribe_failed",
+                        room = %channel.as_str(),
+                        error = %e.to_string(),
+                        "operator self-peer could not subscribe the project base room — the project tree stays invisible on this desktop until room/join"
+                    ),
+                }
+            }
             if let Err(e) = rt
                 .join_room(crate::persona::airc_runtime::CITIZEN_COMMONS_ROOM)
                 .await

--- a/core/continuum-core/src/source_hygiene/mod.rs
+++ b/core/continuum-core/src/source_hygiene/mod.rs
@@ -27,6 +27,7 @@
 pub mod boundary_serialization;
 pub mod identity_discipline;
 pub mod production_reachability;
+pub mod tenant_neutrality;
 pub mod test_mod_singularity;
 pub mod unwrap_justification;
 

--- a/core/continuum-core/src/source_hygiene/tenant_neutrality.rs
+++ b/core/continuum-core/src/source_hygiene/tenant_neutrality.rs
@@ -1,0 +1,95 @@
+//! **Tenant neutrality: our own org, repo, and room names never enter production
+//! code.**
+//!
+//! Joel, 2026-09-05: *"god I hope you haven't coded Cambriantech string or continuum
+//! rooms or orgs. These are ours only… This is a repo for other people and their orgs
+//! and ideas."* Continuum is installed by strangers for THEIR orgs. The org room
+//! derives from the checkout's git remote (`airc_lib::JoinContext::from_cwd`), the
+//! project room is an activity the user spawns under it, and cards name the repo the
+//! user's checkout points at. A literal `CambrianTech` in a code path is a product
+//! that only works for us — and the first thing a stranger reads.
+//!
+//! Ratchet doctrine (same as [`super::unwrap_justification`]): the baseline may only
+//! ever go DOWN. The survivors at the day this landed are the product's OWN upstream
+//! URLs (the airc installer and the model-card attribution link), which name where
+//! the software comes from, not whose org is using it.
+
+use super::{split_code_and_comment, SourceFile, SourceRule, Violation};
+
+/// The tenant identities that must never appear in production code. Lower-case;
+/// matched case-insensitively against CODE (string literals included — a URL is
+/// code), never against comments.
+const TENANT_TOKENS: &[&str] = &["cambriantech", "joel"];
+
+/// Production occurrences when this guard landed (2026-09-05): `airc/discovery.rs`
+/// (the airc installer URL) and `forge/hf_publisher.rs` (the model-card attribution
+/// link). Both name the product's upstream. A NEW one has to argue.
+const BASELINE_TENANT_LINES: usize = 2;
+
+pub struct NoTenantIdentityInProduction;
+
+impl SourceRule for NoTenantIdentityInProduction {
+    fn name(&self) -> &'static str {
+        "no_tenant_identity_in_production_code"
+    }
+
+    fn check(&self, file: &SourceFile) -> Vec<Violation> {
+        // The guard's own token table is the one legitimate place for the word.
+        if file.rel == "source_hygiene/tenant_neutrality.rs" {
+            return Vec::new();
+        }
+        file.production_lines()
+            .filter(|(_, l)| {
+                let (code, _comment) = split_code_and_comment(l);
+                let lower = code.to_ascii_lowercase();
+                TENANT_TOKENS.iter().any(|t| lower.contains(t))
+            })
+            .map(|(line, l)| Violation {
+                rule: self.name(),
+                file: file.rel.clone(),
+                line,
+                source: l.trim().to_string(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source_hygiene::scan;
+
+    // what this catches: our org name creeping into a code path — a default room,
+    // a repo key, an example the runtime actually uses. If this fails on your
+    // change: derive the identity (git remote, spawned activity, the user's
+    // checkout) or use a placeholder (`owner/name`, `your-org`).
+    #[test]
+    fn tenant_identity_in_production_code_never_rises() {
+        let violations = scan(&[&NoTenantIdentityInProduction]);
+        assert!(
+            violations.len() <= BASELINE_TENANT_LINES,
+            "production lines naming our own org rose to {} (baseline {BASELINE_TENANT_LINES}).\n\
+             This repo is for other people and their orgs: derive the identity from the \
+             git remote or the spawned activity, never a literal.\nOffenders:\n{}",
+            violations.len(),
+            violations
+                .iter()
+                .map(|v| format!("  {}:{} — {}", v.file, v.line, v.source))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+
+    // what this catches: the predicate erring in either direction — a comment
+    // quoting the name is prose, a string literal carrying it is code.
+    #[test]
+    fn predicate_matches_code_not_prose() {
+        let rule = NoTenantIdentityInProduction;
+        let code = SourceFile::for_test("x/y.rs", r#"    let repo = "CambrianTech/thing";"#);
+        let prose = SourceFile::for_test("x/y.rs", "    // CambrianTech is where this came from");
+        let mixed = SourceFile::for_test("x/y.rs", r#"    let a = 1; // e.g. cambriantech"#);
+        assert_eq!(rule.check(&code).len(), 1, "a literal in code is a violation");
+        assert_eq!(rule.check(&prose).len(), 0, "a comment is prose");
+        assert_eq!(rule.check(&mixed).len(), 0, "the name in a trailing comment is prose");
+    }
+}


### PR DESCRIPTION
Joel, 2026-09-05: "You never work in rooms. You just use whatever one of you reuses… You guys were building continuum in its academy." The store agreed: that day the three agents put 273 lines in #academy, 109 in #general, 1 in the org room.

**The model** (trees like benches): org room (from the checkout's git remote) → project room (an activity spawned under it) → a room per card. #academy is the citizens' learning tree; #general is the lobby. Nothing lands by the scope's current-room pointer.

**What this PR does**
- `activity/archive --room` and `activity/protect --room` (id or name): a standing is declared on the room the verb NAMES, resolved among the caller's subscribed rooms; an unknown room is refused naming what is in reach. Before: only the caller's current room.
- `work/create --room`: the card lands on the named activity's board (before: the scope's current room — the lobby on a fresh node).
- One resolver for all three: `modules/room_resolve.rs`, with two regression tests.
- `project` recipe (board + messages + roster, no seated citizens — they are asked to join, not seated).
- The operator self-peer subscribes the org room airc derives from the git remote (Keep, no focus change) so the project tree renders on the desktop at all; probes for both outcomes.
- **Tenant neutrality hygiene gate** (`source_hygiene/tenant_neutrality.rs`): our own org/owner names may never rise in production code (ratchet, baseline = the product's two upstream URLs). Joel: "This is a repo for other people and their orgs." Two leaks fixed on the way (a user-facing error message and a doc path).
- airc pin → airc#1384 (`publish_wall_post_in`, `create_work_card_in`), same split as `wall_posts_in` / `work_board_in`. Re-pin to the merged sha before merge.

**Verified**: `cargo check --release --features metal,accelerate` green; the touched test files run whole (room_resolve, activity, work, tenant_neutrality, airc::discovery).

No auto-merge; a peer's no-objection please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
