### PR TITLE
fix(live): the mic publish is a plain getUserMedia track with a bound — never a wedge

### DIFF
--- a/apps/web/src/live/callClient.ts
+++ b/apps/web/src/live/callClient.ts
@@ -25,12 +25,20 @@ import {
   Room,
   RoomEvent,
   Track,
-  createLocalAudioTrack,
   createLocalVideoTrack,
   type LocalAudioTrack,
   type LocalVideoTrack,
   type RemoteTrack,
 } from 'livekit-client';
+
+/** A capture or publish that never answers is a wedge; this turns it into a named failure. */
+const MIC_CAPTURE_TIMEOUT_MS = 10_000; // context-budget-exempt: a device wait, not a token budget
+function withTimeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`${what} did not answer within ${ms} ms`)), ms);
+    p.then((v) => { clearTimeout(t); resolve(v); }, (e) => { clearTimeout(t); reject(e); });
+  });
+}
 
 /** One remote participant's live media state, as the face consumes it. */
 export interface CallAvatarState {
@@ -243,10 +251,30 @@ export class CallClient {
     console.warn(`[live-mic] start mode=${mode} lkRoom=${this.lkRoom !== undefined} lkLive=${this.lkLive} ws=${this.ws?.readyState}`);
     if (mode !== 'ws' && this.lkRoom !== undefined && this.lkLive) {
       try {
-        console.warn('[live-mic] creating local audio track');
-        this.lkMic = await createLocalAudioTrack();
-        console.warn('[live-mic] track created; publishing');
-        await this.lkRoom.localParticipant.publishTrack(this.lkMic);
+        // A PLAIN getUserMedia track, published as-is. `createLocalAudioTrack()`
+        // wraps the same call in LiveKit's audio-processing setup and hung
+        // without a verdict on the node's own eye (fake device, headless) —
+        // measured 2026-09-05: "[live-mic] creating local audio track" was the
+        // last line, every try. The plain track is what the bridge's STT listener
+        // needs; processing is the browser's business. Bounded: a capture that
+        // never answers is a named failure, never a wedge (every probe on a
+        // launch path gets a bound and a named outcome).
+        console.warn('[live-mic] requesting a plain audio track');
+        const stream = await withTimeout(
+          navigator.mediaDevices.getUserMedia({ audio: true }),
+          MIC_CAPTURE_TIMEOUT_MS,
+          'getUserMedia(audio)',
+        );
+        const track = stream.getAudioTracks()[0];
+        if (!track) throw new Error('getUserMedia returned a stream with no audio track');
+        console.warn('[live-mic] track captured; publishing');
+        const published = await withTimeout(
+          this.lkRoom.localParticipant.publishTrack(track, { source: Track.Source.Microphone }),
+          MIC_CAPTURE_TIMEOUT_MS,
+          'publishTrack(microphone)',
+        );
+        this.lkMic = published.track as LocalAudioTrack | undefined;
+        this.micStream = stream;
         this.micLive = true;
         console.warn('[live-mic] livekit track published');
         return true;


### PR DESCRIPTION
The node's own eye (fake device, headless) hung at `createLocalAudioTrack()` on every try with no verdict. This publishes the plain `getUserMedia` audio track (what the bridge's STT listener needs) and bounds both the capture and the publish at 10 s with a named failure.

Measured on the served desktop 2026-09-05 17:50Z with the fake device: `getUserMedia(audio) did not answer within 10000 ms` — the first time the instrument said where it stalls (the device/permission layer, not LiveKit). Next instrument step is on the eye side (fake-UI flag + a dwell long enough for the plane's ~40 s connect); this half stands on its own: a wedge became a named failure.

`tsc --noEmit` and `vite build` green. No auto-merge; a no-objection please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo