### PR TITLE
fix(operator): infer the org room from the core's cwd, and say so when there is none

### DIFF
--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -122,13 +122,30 @@ pub async fn ensure_operator_peer(
             // operator subscribes the org room the whole project tree is invisible and
             // every project line lands in the lobby or the commons. Subscribe without
             // promoting (Keep): the commons join below still decides the focus.
-            for channel in airc_lib::JoinContext::from_cwd(
-                &crate::modules::persona_instance_manager::resolve_continuum_root(),
-            )
-            .channels
-            .iter()
-            .filter(|c| c.as_str() != airc_lib::GENERAL_CHANNEL)
-            {
+            // The org channel is inferred from the git checkout the core runs IN
+            // (the process cwd — `start-server.sh` launches from the repo root), the
+            // same rule `airc join` applies. NOT the continuum home: `~/.continuum`
+            // is no checkout, so the first cut (#3770) walked its ancestors, found no
+            // remote, subscribed nothing and said nothing — an absence read as fine.
+            // An installed product with no checkout gets the named absence below;
+            // its project rooms then carry their own repo owner (follow-up: derive
+            // the org room from each `project` activity's `repo` param).
+            let cwd = std::env::current_dir().unwrap_or_else(|_| {
+                crate::modules::persona_instance_manager::resolve_continuum_root()
+            }); // unwrap_or_else: no cwd = fall back to the home; the absence probe below still fires
+            let project_bases: Vec<airc_lib::ChannelName> = airc_lib::JoinContext::from_cwd(&cwd)
+                .channels
+                .into_iter()
+                .filter(|c| c.as_str() != airc_lib::GENERAL_CHANNEL)
+                .collect();
+            if project_bases.is_empty() {
+                crate::probe!(
+                    class = "operator.peer.project_base_none",
+                    cwd = %cwd.display(),
+                    "no git remote owner under the core's cwd — no org room to subscribe; project rooms root top-level until one is spawned with a parent"
+                );
+            }
+            for channel in project_bases.iter() {
                 match rt.subscribe_room(channel.as_str()).await {
                     Ok(()) => crate::probe!(
                         class = "operator.peer.project_base_subscribed",


### PR DESCRIPTION
#3770's operator subscription walked the ancestors of `~/.continuum` for a git remote (not a checkout), found none, subscribed nothing and emitted nothing — the org room never reached the desktop and the absence read as fine. Now: the process cwd (start-server launches from the repo root; the rule `airc join` applies), plus a named absence probe `operator.peer.project_base_none` for an install with no checkout.

Compensation applied on the M5 by hand: `room/join cambriantech` for the operator (the org room cb2e21a1 now lists, the `continuum` project room nests under it).

Follow-up card: derive the org room from each `project` activity's `repo` param (product shape — a user's projects carry their own owners without a checkout).

`cargo check --release --features metal,accelerate` green. No auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo