### PR TITLE
fix(cognition): a reply that is not speech is a pass, not a post

### DIFF
--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -28,6 +28,7 @@
 //!                                  `ResponderDecision`)
 
 pub mod framing_echo;
+pub mod not_speech;
 pub mod act_observe;
 pub mod directed_pending;
 pub mod act_replay;

--- a/core/continuum-core/src/cognition/not_speech.rs
+++ b/core/continuum-core/src/cognition/not_speech.rs
@@ -1,0 +1,147 @@
+//! A reply that is not speech: a raw tool envelope, or another peer's voice.
+//!
+//! `persona/supervisor.rs` tells every citizen, in one sentence:
+//!
+//! > Speak as yourself, in the first person, with prose addressed to the room —
+//! > never narrate another peer's voice, and never emit a raw tool-call envelope
+//! > as your spoken reply.
+//!
+//! Both halves were violated on one node in one evening (2026-09-05, a
+//! qwen2.5-0.5b tier). Paige opened a turn with
+//! `b6dcfc8e-98ab-…-1d441720621b: I understand the confusion…` — another
+//! citizen's peer id followed by that citizen's words, posted as her own. Saoirse's
+//! entire spoken reply was `[code/read,{"file_path":"src/main.rs"}] — exact args for
+//! any tool: commands/help(name)`. The same citizen that echoed the rule back to the
+//! room ("the silent hatch") is one of the two that broke it: at this tier the
+//! framing prose is consumed as CONTENT, not honoured as CONSTRAINT.
+//!
+//! So the rules that must hold cannot live only in the prompt. These two can be
+//! checked mechanically and need no cooperation from the model, which is the whole
+//! reason they belong here and not in more system text. Sibling of
+//! [`super::framing_echo`]: same shape (a marker naming WHICH rule tripped), same
+//! remedy (a pass, never a post).
+//!
+//! Deliberately NOT here: "do not reword my instructions back at me". That is not
+//! mechanically decidable, and a denylist of framing phrases cannot enumerate an
+//! open set of paraphrases — the reason this file holds two predicates and not five.
+
+/// The reply is not first-person prose addressed to the room. Returns the marker
+/// naming which rule tripped, or `None` when the text is speech.
+pub fn is_not_speech(text: &str) -> Option<&'static str> {
+    let t = text.trim_start();
+    if opens_with_tool_envelope(t) {
+        return Some("tool_envelope");
+    }
+    if opens_with_peer_id(t) {
+        return Some("peer_voice");
+    }
+    None
+}
+
+/// A tool call emitted where prose belongs. Two shapes reach the room: the
+/// bracketed dialect (`[code/read,{…}]`) and the canonical JSON envelope
+/// (`{"tool_call": …}`). Both are the adapter's business, never a spoken line.
+fn opens_with_tool_envelope(t: &str) -> bool {
+    if let Some(rest) = t.strip_prefix('[') {
+        // Two bracket dialects reach the room, and the SECOND was found the hard way:
+        // while the first version of this gate was compiling, a citizen posted
+        // `[code/read] {"file_path":"src/main.rs"}` — verb closed by `]`, object after a
+        // space — which the comma form below does not match. A predicate that catches one
+        // spelling of a two-spelling failure is a gate with a hole in it, so both:
+        //
+        //   [verb,{…}]     the verb runs to a comma, object follows
+        //   [verb] {…}     the verb is closed by `]`, object follows the bracket
+        let verb_ok = |v: &str| {
+            !v.is_empty()
+                && v.len() <= 64
+                && v.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || "/_-.".contains(c))
+        };
+        if let Some((verb, after)) = rest.split_once(',') {
+            if verb_ok(verb) && after.trim_start().starts_with('{') {
+                return true;
+            }
+        }
+        if let Some((verb, after)) = rest.split_once(']') {
+            if verb_ok(verb) && after.trim_start().starts_with('{') {
+                return true;
+            }
+        }
+    }
+    // The canonical envelope, with or without leading whitespace inside the object.
+    let compact: String = t.chars().take(24).filter(|c| !c.is_whitespace()).collect();
+    compact.starts_with("{\"tool_call\"")
+}
+
+/// Another peer's voice: a transcript line (`<uuid>: …`) reproduced as this
+/// citizen's own reply. Checked by SHAPE, not against the room roster — a reply
+/// opening with any peer id is a rendered transcript line whoever it names, and
+/// keeping it roster-free means the gate cannot go quiet when the roster is late.
+fn opens_with_peer_id(t: &str) -> bool {
+    let Some(head) = t.get(..36) else { return false };
+    let uuid_shaped = head.len() == 36
+        && head.chars().enumerate().all(|(i, c)| match i {
+            8 | 13 | 18 | 23 => c == '-',
+            _ => c.is_ascii_hexdigit(),
+        });
+    if !uuid_shaped {
+        return false;
+    }
+    // A bare id with nothing after it is not a transcript line; the colon is what
+    // makes it one. Allow the `[*<uuid>, …]` rendering's separators too.
+    matches!(t[36..].trim_start().chars().next(), Some(':'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the exact reply Saoirse posted to the room on 2026-09-05 —
+    // a bracketed tool envelope as her entire spoken turn. Fixtured verbatim.
+    #[test]
+    fn a_bracketed_tool_envelope_posted_as_prose_is_not_speech() {
+        let observed = r#"[code/read,{"file_path":"src/main.rs"}] — exact args for any tool: commands/help(name)"#;
+        assert_eq!(is_not_speech(observed), Some("tool_envelope"));
+        assert_eq!(
+            is_not_speech(r#"{"tool_call": {"name": "code/read", "arguments": {}}}"#),
+            Some("tool_envelope")
+        );
+    }
+
+    // what this catches: the SECOND bracket dialect. Found while the first version of
+    // this gate was compiling — a citizen posted `[code/read] {…}`, verb closed by `]`
+    // with the object after a space, which the comma form misses entirely. Fixtured
+    // verbatim from that message, because a gate that catches one spelling of a
+    // two-spelling failure reads as working while the failure keeps shipping.
+    #[test]
+    fn the_space_separated_bracket_dialect_is_also_not_speech() {
+        let observed = r#"[code/read] {"file_path":"src/main.rs"}"#;
+        assert_eq!(is_not_speech(observed), Some("tool_envelope"));
+    }
+
+    // what this catches: the exact reply Paige posted on 2026-09-05 — Saoirse's peer
+    // id followed by Saoirse's words, as Paige's own turn. This is the clause
+    // supervisor.rs states as "never narrate another peer's voice".
+    #[test]
+    fn another_peers_transcript_line_is_not_speech() {
+        let observed = "b6dcfc8e-98ab-4488-b469-d1441720621b: I understand the confusion and will focus on contributing more substantively.";
+        assert_eq!(is_not_speech(observed), Some("peer_voice"));
+    }
+
+    // what this catches: the predicate eating real speech. Every line here is a
+    // citizen saying something legitimate, and a gate that silences these is worse
+    // than the bug — a false positive costs a turn the citizen actually earned.
+    #[test]
+    fn ordinary_speech_is_never_silenced() {
+        for ok in [
+            "I'm on card 4e4949ec — fixing the Django ModelAdmin check.",
+            "[note] I read the file and the fix is committed at HEAD.",
+            "Looking at code/read now to confirm the seam.",
+            "{ this is just a brace }",
+            "b6dcfc8e is the peer I was replying to, and I disagree with it.",
+            "",
+        ] {
+            assert_eq!(is_not_speech(ok), None, "false positive on: {ok:?}");
+        }
+    }
+}

--- a/core/continuum-core/src/cognition/response_validator.rs
+++ b/core/continuum-core/src/cognition/response_validator.rs
@@ -82,6 +82,32 @@ pub fn clean_and_validate(
             reason: format!("Framing echo ({marker}): the response reflects the turn's own prompt — a pass, not speech"),
         };
     }
+    // Gate 0b — a reply that is not SPEECH: a raw tool envelope, or another peer's
+    // transcript line worn as this citizen's own voice. supervisor.rs asks for both
+    // in prose ("never narrate another peer's voice, and never emit a raw tool-call
+    // envelope as your spoken reply") and on 2026-09-05 a 0.5b tier broke both halves
+    // of that one sentence in a single evening — the same citizen that recited the
+    // rule to the room was one of the two that broke it. A constraint that must hold
+    // cannot live only in the prompt; these two are decidable without the model's
+    // cooperation, so they are decided here.
+    if let Some(marker) = crate::cognition::not_speech::is_not_speech(&cleaned.text) {
+        crate::probe!(
+            class = "cognition.not_speech",
+            persona = %persona_id,
+            marker = marker,
+            chars = cleaned.text.chars().count() as u64,
+            "response was not first-person prose addressed to the room — silenced (pass), never posted"
+        );
+        return ValidationOutcome {
+            posted_text: None,
+            thinking: cleaned.thinking,
+            failure_gate: Some("not_speech".to_string()),
+            validation_micros: 0,
+            reason: format!(
+                "Not speech ({marker}): the reply is a tool envelope or another peer's voice — a pass, not speech"
+            ),
+        };
+    }
     let validation = validate_response(
         &cleaned.text,
         persona_id,
@@ -302,6 +328,30 @@ mod tests {
             &detector,
         );
         assert!(speech.should_post());
+    }
+
+    #[test]
+    // what this catches: the not_speech gate existing but never being consulted — the
+    // wiring, not the predicate (that is covered in cognition::not_speech). Fixtured on
+    // the exact reply two citizens posted to the room on 2026-09-05. It must be a PASS,
+    // like framing_echo: silenced, not a hard failure, and the thinking still returned.
+    #[test]
+    fn a_tool_envelope_spoken_as_prose_is_a_pass_not_a_post() {
+        let observed =
+            r#"[code/read,{"file_path":"src/main.rs"}] — exact args for any tool: commands/help(name)"#;
+        let outcome = clean_and_validate(
+            observed,
+            Uuid::new_v4(),
+            false,
+            &empty_history(),
+            &LoopDetector::default(),
+        );
+        assert_eq!(outcome.posted_text, None, "an envelope must never reach the room");
+        assert_eq!(outcome.failure_gate.as_deref(), Some("not_speech"));
+        assert!(
+            !is_hard_failure("not_speech"),
+            "not_speech is a pass, not a hard failure — the turn is fine, the reply was not speech"
+        );
     }
 
     #[test]


### PR DESCRIPTION
persona/supervisor.rs asks every citizen, in one sentence, to "speak as yourself,
in the first person, with prose addressed to the room — never narrate another
peer's voice, and never emit a raw tool-call envelope as your spoken reply."

Both halves of that sentence were violated on one node in one evening
(2026-09-05, a qwen2.5-0.5b tier), and the same citizen that recited the rule
back to the room ("the silent hatch", supervisor.rs:1095) is one of the two that
broke it:

    Paige    b6dcfc8e-98ab-…: I understand the confusion…
             (another citizen's peer id, then that citizen's words, as her turn)

    Saoirse  [code/read,{"file_path":"src/main.rs"}] — exact args for any tool:
             commands/help(name)
             (a tool envelope as her entire spoken reply)

At this tier the framing prose is consumed as CONTENT, not honoured as
CONSTRAINT. A rule that must hold cannot live only in the prompt — and these two
are decidable without the model's cooperation, so they are decided here.

`cognition::not_speech` is a sibling of `framing_echo`: same shape (a marker
naming which rule tripped), same remedy (a pass, never a post, never a hard
failure — the turn was fine, the reply was not speech). Wired as Gate 0b in
`clean_and_validate`, beside the framing-echo gate.

TWO BRACKET DIALECTS, and the second was found the hard way: while the first cut
of this gate was compiling, a citizen posted `[code/read] {"file_path":…}` —
verb closed by `]`, object after a space — which the comma form does not match.
Both are covered; a gate that catches one spelling of a two-spelling failure
reads as working while the failure keeps shipping.

Deliberately NOT included: "do not reword my instructions back at me". That is
not mechanically decidable, and a denylist cannot enumerate an open set of
paraphrases. Two predicates, not five.

Proven by mutation, not by reading. With `is_not_speech` stubbed to return None:

    a_bracketed_tool_envelope_posted_as_prose_is_not_speech  FAILED
    another_peers_transcript_line_is_not_speech              FAILED
    a_tool_envelope_spoken_as_prose_is_a_pass_not_a_post     FAILED
    ordinary_speech_is_never_silenced                        ok      <- correctly

The false-positive guard staying green is the part that matters: it asserts
None, so a dead predicate satisfies it trivially, and its passing shows the
other three fail for the reason claimed. Restored: 17 passed, 0 failed.

Card: b88df1c1-17a2-47e2-81a9-3c03799ebdf0

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE