### PR TITLE
fix(help): a placeholder must be valid for its own type, or the example cannot be copied

### DIFF
--- a/core/continuum-core/src/commands/help.rs
+++ b/core/continuum-core/src/commands/help.rs
@@ -197,7 +197,24 @@ fn param_shape(spec: &Value, root: &Value) -> (String, Value) {
                 );
             }
         }
-        return (ty.to_string(), json!(format!("<{ty}>")));
+        // A placeholder must be VALID FOR ITS OWN TYPE. `<boolean>` is a string, so a
+        // caller that copies the example verbatim — which is exactly what the manual
+        // says to do, and exactly what a small model does — gets
+        // `invalid type: string "<boolean>", expected a boolean` and cannot recover by
+        // trying harder: the example it was handed is unsatisfiable. Observed three
+        // times on 2026-09-05 (`code/edit <string>`, `code/edit … "<any>" expected a
+        // boolean`). A typed placeholder still reads as fill-me-in, and a literal copy
+        // now fails on MEANING (wrong path, missing field) instead of on SHAPE — an
+        // error the caller can act on.
+        let placeholder = match ty {
+            "boolean" => json!(true),
+            "integer" | "number" => json!(0),
+            "array" => json!([]),
+            "object" => json!({}),
+            // A string placeholder IS a valid string: it parses, then fails on content.
+            _ => json!(format!("<{ty}>")),
+        };
+        return (ty.to_string(), placeholder);
     }
     for tag in ["oneOf", "anyOf"] {
         if let Some(variants) = spec.get(tag).and_then(Value::as_array) {
@@ -344,6 +361,44 @@ mod param_shape_tests {
         let schema = json!({"type":"object","required":["p"],"properties":{"p":{"type":"string"}}});
         let out = render_ai_help("x", "y", &schema);
         assert!(out.contains("p (string, required)"), "{out}");
+    }
+
+    // what this catches: a placeholder that is invalid for its OWN type, so a caller
+    // copying the example verbatim — which the manual instructs — cannot possibly
+    // succeed. Observed 2026-09-05: `code/edit` refused with
+    // `invalid type: string "<any>", expected a boolean`, the citizen having pasted the
+    // placeholder it was shown. The example must at least DESERIALIZE; being wrong
+    // about the value is recoverable, being wrong about the shape is not.
+    #[test]
+    fn every_placeholder_deserializes_as_its_own_type() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "flag":  {"type": "boolean"},
+                "count": {"type": "integer"},
+                "items": {"type": "array"},
+                "opts":  {"type": "object"},
+                "name":  {"type": "string"},
+            }
+        });
+        for (field, ty) in [
+            ("flag", "boolean"),
+            ("count", "integer"),
+            ("items", "array"),
+            ("opts", "object"),
+            ("name", "string"),
+        ] {
+            let spec = &schema["properties"][field];
+            let (_, placeholder) = param_shape(spec, &schema);
+            let ok = match ty {
+                "boolean" => placeholder.is_boolean(),
+                "integer" => placeholder.is_number(),
+                "array" => placeholder.is_array(),
+                "object" => placeholder.is_object(),
+                _ => placeholder.is_string(),
+            };
+            assert!(ok, "{field} ({ty}) placeholder is not a {ty}: {placeholder}");
+        }
     }
 }
 

--- a/core/continuum-core/src/commands/help.rs
+++ b/core/continuum-core/src/commands/help.rs
@@ -126,7 +126,27 @@ pub(crate) fn render_ai_help(name: &str, description: &str, schema: &Value) -> S
             // `EditMode` enum) collapsed to a useless `"any"`, so a model literally
             // could not tell what to pass — the invisible-contract bug.
             let (ty, placeholder) = param_shape(spec, schema);
-            example.insert(key.clone(), placeholder);
+            // The example is the MINIMAL VALID CALL — required arguments only. Every
+            // optional one stays in the argument list below, documented, and out of the
+            // envelope a caller is told to copy.
+            //
+            // Because a caller copies the example. Measured 2026-09-05, a citizen
+            // emitted `code/edit`'s ENTIRE manual back as a tool call:
+            //
+            //   [code/edit(all=<any>, content=<any>, description=<any>, edit_mode=<any>,
+            //    end_line=<any>, file_path=<string>, line=<any>, new_content=<any>,
+            //    replace=<any>, search=<any>)]
+            //
+            // Ten arguments, nine of them optional, every one a placeholder. She was not
+            // guessing — she pasted exactly what she was shown. An example that carries
+            // every optional argument teaches the caller to send every optional argument,
+            // and for a union-typed param the placeholder cannot even deserialize.
+            //
+            // Required-only cuts that call to `{"file_path": "<string>"}`, which is the
+            // shape the manual is trying to teach in the first place.
+            if req {
+                example.insert(key.clone(), placeholder);
+            }
             arg_lines.push(format!(
                 "- {key} ({ty}, {}){}",
                 if req { "required" } else { "optional" },
@@ -399,6 +419,39 @@ mod param_shape_tests {
             };
             assert!(ok, "{field} ({ty}) placeholder is not a {ty}: {placeholder}");
         }
+    }
+
+    // what this catches: the example envelope carrying OPTIONAL arguments, which a
+    // caller then copies wholesale. Measured 2026-09-05: a citizen emitted all ten of
+    // `code/edit`'s arguments back as a tool call — nine optional, every one a
+    // placeholder — because that is what the manual showed her. The example must be
+    // the minimal valid call; the optional arguments stay documented in the list.
+    #[test]
+    fn the_example_carries_required_arguments_only() {
+        let schema = json!({
+            "type": "object",
+            "required": ["file_path"],
+            "properties": {
+                "file_path": {"type": "string"},
+                "replace":   {"type": "boolean"},
+                "line":      {"type": "integer"},
+            }
+        });
+        let out = render_ai_help("code/edit", "edit a file", &schema);
+        let envelope: Value = {
+            let start = out.find('{').expect("an envelope is rendered");
+            let end = out.rfind('}').expect("an envelope is rendered");
+            serde_json::from_str(&out[start..=end]).expect("the rendered envelope is valid JSON")
+        };
+        let args = &envelope["tool_call"]["arguments"];
+        assert!(args.get("file_path").is_some(), "the required arg is in the example: {args}");
+        assert!(
+            args.get("replace").is_none() && args.get("line").is_none(),
+            "optional args must NOT be in the copyable example: {args}"
+        );
+        // …but they are still DOCUMENTED, or the caller cannot discover them.
+        assert!(out.contains("replace (boolean, optional)"), "{out}");
+        assert!(out.contains("line (integer, optional)"), "{out}");
     }
 }
 


### PR DESCRIPTION
`commands/help` renders the canonical tool-call envelope and tells the caller to
fill in the values. For a boolean parameter it rendered the STRING
`"<boolean>"` — so a caller that copies the example verbatim, which is what the
manual instructs and what a small model does, gets:

    code/edit: [invalid] CommandRequest deserialization failed:
               invalid type: string "<any>", expected a boolean

and cannot recover by trying harder: the example it was handed is unsatisfiable
by construction. `param_shape` returned `json!(format!("<{ty}>"))` for every
scalar, so the placeholder's type was always string regardless of the declared
type.

Observed three times on 2026-09-05 from IntelMac citizens (`code/edit <string>`
twice, and the `"<any>" expected a boolean` above), each one a citizen pasting
back the example it was shown.

Now: boolean → true, integer/number → 0, array → [], object → {}. A string
placeholder stays `"<string>"`, because a string placeholder IS a valid string —
it parses, then fails on content.

The point is not that the values are right. It is that a literal copy now fails
on MEANING (wrong path, missing field), which the caller can act on, instead of
on SHAPE, which it cannot. Same principle as #3769: the substrate's example and
error surfaces are where a small model actually gets its information, and they
were handing it inputs that could not succeed.

The test asserts the INVARIANT rather than the values — every placeholder
deserializes as its own declared type — so a future placeholder change cannot
reintroduce the class.

Card: c5570f0e-3c6a-4d33-b928-466412fb7cf4

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE