### PR TITLE
fix(activity): a spawned room is bridged and listed the minute it exists — one adoption set, not the bench tracker's

### DIFF
--- a/core/continuum-core/src/experience/mod.rs
+++ b/core/continuum-core/src/experience/mod.rs
@@ -67,6 +67,7 @@ use crate::modules::grid::acl::required_trust;
 use crate::modules::grid::node::TrustLevel;
 
 pub mod binding;
+pub mod spawned_rooms;
 pub mod membership;
 pub mod recipe;
 pub mod source;

--- a/core/continuum-core/src/experience/spawned_rooms.rs
+++ b/core/continuum-core/src/experience/spawned_rooms.rs
@@ -1,0 +1,62 @@
+//! ONE registry of every activity room this node minted through `activity/spawn`,
+//! read by the presence emitter's refresher so a spawned room is bridged (its
+//! transcript reaches the chat store and the rail) the same minute it exists.
+//!
+//! Measured 2026-09-05 (card 3d4b3d9c): the refresher adopted rooms from the
+//! BENCHMARK tracker's list plus the daemon's room set — so a bench run room was
+//! ingested and listed within a minute, while the `continuum` project room spawned
+//! by the same `spawn_activity_room` was subscribed, joined, streamed (attach
+//! frames in the log) and STILL had `chat/history` = 0 rows and no rail entry.
+//! Benchmarks are adapters, not a parallel runner: the room registry the
+//! refresher reads must be the activity substrate's, not the bench tracker's.
+//! The tracker's list stays for solve rooms it mints itself; this one is generic.
+//!
+//! Process-lifetime only, on purpose: the durable truth is the airc subscription
+//! set of the runtime that spawned the room (the refresher folds that too), so a
+//! reboot re-adopts from subscriptions and this map only covers the window
+//! between a spawn and the next refresh tick.
+
+use std::collections::BTreeMap;
+use std::sync::{LazyLock, Mutex};
+
+use uuid::Uuid;
+
+static SPAWNED: LazyLock<Mutex<BTreeMap<Uuid, String>>> = LazyLock::new(|| Mutex::new(BTreeMap::new()));
+
+/// Record a room minted by `activity/spawn` (idempotent; the newest name wins).
+pub fn record(room: Uuid, name: &str) {
+    if name.trim().is_empty() {
+        return;
+    }
+    SPAWNED
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(room, name.to_string());
+}
+
+/// Every room recorded since boot, `(room_id, name)`.
+pub fn spawned_rooms() -> Vec<(Uuid, String)> {
+    SPAWNED
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .iter()
+        .map(|(id, name)| (*id, name.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: a spawned room falling out of the adoption set — the
+    // exact absence that left the project room unread and unlisted (3d4b3d9c).
+    #[test]
+    fn a_spawned_room_is_listed_until_the_process_ends_and_nameless_rooms_are_refused() {
+        let id = Uuid::new_v4();
+        record(id, "widgets");
+        assert!(spawned_rooms().iter().any(|(r, n)| *r == id && n == "widgets"));
+        let anon = Uuid::new_v4();
+        record(anon, "   ");
+        assert!(!spawned_rooms().iter().any(|(r, _)| *r == anon), "a nameless room cannot be adopted by name");
+    }
+}

--- a/core/continuum-core/src/ipc/positron_presence.rs
+++ b/core/continuum-core/src/ipc/positron_presence.rs
@@ -715,6 +715,19 @@ pub fn spawn_node_presence_emitter(
             ticker.tick().await;
             let mut fresh: Vec<(Uuid, String)> =
                 crate::cognition::bench_round::activity_rooms();
+            // Rooms minted by `activity/spawn` since boot (any recipe — a project, a
+            // call, a chat), and every room this emitter's own scope is subscribed to
+            // (the durable half: survives a reboot). Before this the set was the
+            // BENCH tracker's rooms + the daemon's, so a spawned project room was
+            // never bridged: subscribed, joined, streamed, and still 0 rows of
+            // history and no rail entry (card 3d4b3d9c, 2026-09-05).
+            fresh.extend(crate::experience::spawned_rooms::spawned_rooms());
+            if let Ok(set) = airc.subscription_set().await {
+                for sub in set.all() {
+                    let room = sub.as_room();
+                    fresh.push((room.channel.as_uuid(), room.name));
+                }
+            }
             if let Ok(response) =
                 airc_ipc::DaemonClient::new(registry_socket.clone()).list_rooms().await
             {

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -552,6 +552,10 @@ pub async fn spawn_activity_room(
         let room = airc.join(name).await.map_err(|source| {
             CommandError::Invalid(format!("could not create room {name:?}: {source}"))
         })?;
+        // Every spawned room enters the node's adoption set the moment it exists, so
+        // the presence emitter bridges its transcript (chat store + rail) on the next
+        // refresh — the same minute, like a bench run room, not never (card 3d4b3d9c).
+        crate::experience::spawned_rooms::record(room.channel.as_uuid(), name);
 
         // Bind the room to its recipe ON THE WALL, where every participant sees the
         // same answer to "what is this room". Without this the room forgets which


### PR DESCRIPTION
Card 3d4b3d9c (P1). The presence emitter's refresher adopted rooms from the BENCHMARK tracker's list plus the daemon's room set, so a bench run room reached the chat store and the rail within a minute while the `continuum` project room minted by the same `spawn_activity_room` was subscribed, joined, streamed (attach frames in the log) and still had `chat/history` = 0 rows and no rail entry. Benchmarks are adapters, not a parallel runner: the adoption set is the activity substrate's.

- `experience::spawned_rooms` — every `activity/spawn` records its room (any recipe); the refresher folds it.
- The refresher also folds the emitter's own subscription set (the durable half: a reboot re-adopts from subscriptions).

Verified: `cargo check --release --features metal,accelerate` green; `experience::spawned_rooms` + `experience::source` + `modules::activity` = 27 passed. Acceptance on deploy: `chat/history` on the project room returns its lines within a minute; the rail lists it under the org room.

No auto-merge; a no-objection please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo