### PR TITLE
fix(presence): the durable adoption set is the OPERATOR's rooms, never the reader's own

### DIFF
--- a/core/continuum-core/src/ipc/positron_presence.rs
+++ b/core/continuum-core/src/ipc/positron_presence.rs
@@ -722,10 +722,18 @@ pub fn spawn_node_presence_emitter(
             // never bridged: subscribed, joined, streamed, and still 0 rows of
             // history and no rail entry (card 3d4b3d9c, 2026-09-05).
             fresh.extend(crate::experience::spawned_rooms::spawned_rooms());
-            if let Ok(set) = airc.subscription_set().await {
-                for sub in set.all() {
-                    let room = sub.as_room();
-                    fresh.push((room.channel.as_uuid(), room.name));
+            // The durable half is the OPERATOR's subscription set — the rooms the
+            // human is in are exactly the rooms the desktop must project — never
+            // this reader's own set: the reader joins every room it ever adopted
+            // (finished solve rooms included), so folding its own subscriptions
+            // resurrected 20 dead `swe--…` rooms as top-level rail entries the
+            // minute #3776 deployed (measured 2026-09-05 21:44Z: 50 → 70 titles).
+            if let Some(operator) = crate::persona::operator_peer::operator_runtime() {
+                if let Ok(set) = operator.airc().subscription_set().await {
+                    for sub in set.all() {
+                        let room = sub.as_room();
+                        fresh.push((room.channel.as_uuid(), room.name));
+                    }
                 }
             }
             if let Ok(response) =


### PR DESCRIPTION
#3776 folded the presence reader's own subscription set as the durable half of room adoption. The reader joins every room it ever adopted — finished solve rooms included — so the minute it deployed the rail went 50 → 70 titles with dead `swe--…` rooms as top-level entries (measured 2026-09-05 21:44Z, frame in the session). The rooms the human is in are the rooms the desktop must project: this folds the operator runtime's subscriptions instead (`operator_peer::operator_runtime()`).

`cargo check --release --features metal,accelerate` green. Acceptance on deploy: rail titles back near 50 with the project room still listed; no `swe--` raw names at top level.

No auto-merge; a no-objection please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo