### PR TITLE
docs(policy): review + merge rules — reviews never route through one person

### DIFF
--- a/.airc/POLICY.md
+++ b/.airc/POLICY.md
@@ -18,6 +18,28 @@ relevant lines) and enforced by pre-push hooks where possible.
   fail the image-revision gate because pre-built canary images
   invalidate when canary advances.
 
+## Review + merge
+
+Measured 2026-09-05: six of one peer's PRs waited hours because the only
+reviewer awake was heads-down in deploys. Reviews never route through one
+person.
+
+- **One no-objection from ANY connected peer + green required checks =
+  merge.** The reviewer merges; the author never merges their own PR
+  early.
+- **Bounded review window.** Review was asked for on AIRC, the asked peer
+  is connected (heartbeating), and 45 minutes pass with no review and all
+  required checks green: the PR merges and carries the comment
+  "unreviewed, window expired". A review that requested changes is not
+  silence — the window restarts when the author answers.
+- **A red REQUIRED check never merges.** No inherited-red excuse for
+  Continuum PRs; the baseline is keyed by the PR's own repo.
+- **Every PR names its acceptance VERB.** A command the reviewer runs on
+  their own node (`continuum <verb> {...}` and the expected receipt), not
+  a paragraph. A PR without one is not ready for review.
+- **A merge to airc canary is a fleet-wide daemon restart** (auto-update):
+  batch airc merges, announce them on AIRC first, never mid-round.
+
 ## Push discipline
 
 - **`--no-verify` is forbidden.** No exceptions, even for "pre-existing

--- a/.airc/POLICY.md
+++ b/.airc/POLICY.md
@@ -24,9 +24,9 @@ Measured 2026-09-05: six of one peer's PRs waited hours because the only
 reviewer awake was heads-down in deploys. Reviews never route through one
 person.
 
-- **One no-objection from ANY connected peer + green required checks =
-  merge.** The reviewer merges; the author never merges their own PR
-  early.
+- **One no-objection from any NON-AUTHOR connected peer + green required
+  checks = merge.** The reviewer merges; the author never merges their own
+  PR early.
 - **Bounded review window.** Review was asked for on AIRC, the asked peer
   is connected (heartbeating), and 45 minutes pass with no review and all
   required checks green: the PR merges and carries the comment
@@ -39,6 +39,11 @@ person.
   a paragraph. A PR without one is not ready for review.
 - **A merge to airc canary is a fleet-wide daemon restart** (auto-update):
   batch airc merges, announce them on AIRC first, never mid-round.
+- **The window is policy, not yet machinery (card 267d68f5).** The merger
+  daemon cannot currently distinguish reviewed from unreviewed or author from
+  reviewer — in its code every green Review card merges. Until 267d68f5
+  lands, a peer applies the window by hand and posts the "unreviewed,
+  window expired" note; nobody runs the merger on a multi-author room.
 
 ## Push discipline
 


### PR DESCRIPTION
Joel: "We need good peer help." Measured today: six of IntelMac's PRs waited hours because the only reviewer awake was in deploys.

Adds a **Review + merge** section to `.airc/POLICY.md`:
- any connected peer's no-objection + green required checks = merge (the reviewer merges);
- bounded review window: asked on AIRC, peer connected, 45 min, all green → merges with "unreviewed, window expired"; a change request restarts the window when answered;
- a red required check never merges; no inherited-red excuse for Continuum;
- every PR names its acceptance verb (a command + expected receipt);
- an airc canary merge is an announced fleet restart.

IntelMac owns the merger daemon that enforces the window. Docs only. No auto-merge — this one wants an explicit no-objection from each peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo