### PR TITLE
fix(runtime): the airc hop deserializes the COMMAND through the typed envelope — the wire's integer requestId is the envelope's, never the request's

### DIFF
--- a/core/continuum-core/src/runtime/airc_interceptor.rs
+++ b/core/continuum-core/src/runtime/airc_interceptor.rs
@@ -161,7 +161,15 @@ impl CommandInterceptor for AircInterceptor {
                 // which carries the WHOLE PROMPT. `params` is already `&Value`, so
                 // borrow-decode it; `from_value(params.clone())` deep-copied the
                 // largest payload in the system on every single generation.
-                let text_request: TextGenerationRequest = serde::Deserialize::deserialize(params)
+                // The TYPED envelope: `CommandRequest<P>` consumes its own base fields
+                // (handle / sessionId / userId / contextId / requestId) and hands back the
+                // command's params as `P`. Deserializing `P` straight from the flat wire
+                // object let the envelope's integer `requestId` land in the request's own
+                // `requestId: String` (measured 2026-09-06, IntelMac's cross-node probe).
+                let text_request: TextGenerationRequest = <crate::runtime::command_envelope::CommandRequest<
+                    TextGenerationRequest,
+                > as serde::Deserialize>::deserialize(params)
+                .map(|envelope| envelope.params)
                     .map_err(|e| {
                         format!(
                             "aircPeer '{AIRC_ROUTED_GENERATE}' params aren't a \
@@ -190,6 +198,31 @@ impl CommandInterceptor for AircInterceptor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches (IntelMac, cross-node acceptance of #3779): the envelope's
+    // integer `requestId` deserialized as the request's own `requestId: String` —
+    // every well-formed peer-addressed generate refused with "invalid type: integer
+    // `1`, expected a string". The hop must read the COMMAND's params, not the envelope.
+    #[tokio::test]
+    async fn the_hop_deserializes_the_command_not_the_envelope() {
+        let interceptor = AircInterceptor::new();
+        let params = serde_json::json!({
+            "aircPeer": "11111111-2222-4333-8444-555555555555",
+            "requestId": 1,
+            "sessionId": "22222222-2222-4222-8222-222222222222",
+            "messages": [{"role": "user", "content": "hi"}],
+            "maxTokens": 5
+        });
+        let err = interceptor
+            .try_route("ai/generate", &params, None)
+            .await
+            .expect_err("no airc handle is attached in this test — the hop must refuse loudly");
+        assert!(
+            !err.contains("TextGenerationRequest"),
+            "the envelope's requestId must not be read as the request's: {err}"
+        );
+        assert!(err.contains("attached"), "the refusal names the real gap: {err}");
+    }
 
     #[tokio::test]
     async fn declines_when_no_airc_target() {

--- a/core/continuum-core/src/runtime/command_envelope.rs
+++ b/core/continuum-core/src/runtime/command_envelope.rs
@@ -187,6 +187,13 @@ pub struct CommandRequest<P> {
     #[ts(optional)]
     #[ts(optional, type = "string")]
     pub context_id: Option<Uuid>,
+    /// The wire's request counter (the IPC framing's `requestId`, an integer). Typed
+    /// here so the ENVELOPE consumes it and a command's own `requestId: String` never
+    /// sees an integer (measured 2026-09-06: the airc hop refused every well-formed
+    /// peer-addressed generate with "invalid type: integer `1`, expected a string").
+    #[serde(rename = "requestId", skip_serializing_if = "Option::is_none", default)]
+    #[ts(optional, type = "number")]
+    pub request_id: Option<u64>,
 }
 
 /// Turn serde's one-sided "missing field `cmd`" into a two-sided diagnosis.
@@ -224,12 +231,7 @@ fn param_mismatch_message(serde_error: &str, sent: &[String]) -> String {
         // it is the single likeliest mis-name (`command` for `cmd`), and suppressing it would
         // break the exact case this function exists for. A little CLI noise beats losing the
         // real diagnosis — caught by this function's own test.
-        .filter(|k| {
-            !matches!(
-                k.as_str(),
-                "handle" | "sessionId" | "userId" | "contextId" | "requestId"
-            )
-        })
+        .filter(|k| !is_envelope_field(k.as_str()))
         .collect();
     if candidates.is_empty() {
         return format!(
@@ -282,6 +284,11 @@ fn is_subsequence(short: &str, long: &str) -> bool {
     short.chars().all(|c| chars.any(|l| l == c))
 }
 
+/// The base fields every wire request may carry beside its command params.
+pub fn is_envelope_field(key: &str) -> bool {
+    matches!(key, "handle" | "sessionId" | "userId" | "contextId" | "requestId")
+}
+
 impl<P> CommandRequest<P>
 where
     P: serde::de::DeserializeOwned,
@@ -316,6 +323,7 @@ impl<P> CommandRequest<P> {
             session_id: None,
             user_id: None,
             context_id: None,
+            request_id: None,
             actor_kind: None,
         }
     }

--- a/protocol/typescript/runtime/CommandRequest.ts
+++ b/protocol/typescript/runtime/CommandRequest.ts
@@ -81,4 +81,11 @@ userId?: string,
  * shit you did to me"), never an authentication: authenticated identity
  * stays `ctx.caller` (the airc gate).
  */
-actorKind?: string, contextId?: string, } & P;
+actorKind?: string, contextId?: string, 
+/**
+ * The wire's request counter (the IPC framing's `requestId`, an integer). Typed
+ * here so the ENVELOPE consumes it and a command's own `requestId: String` never
+ * sees an integer (measured 2026-09-06: the airc hop refused every well-formed
+ * peer-addressed generate with "invalid type: integer `1`, expected a string").
+ */
+requestId?: number, } & P;


### PR DESCRIPTION
IntelMac's cross-node acceptance of #3779: probe 1 passes (bad `aircPeer` refused by name, 183 ms); probe 2, a well-formed peer-addressed `ai/generate`, refused with `invalid type: integer 1, expected a string` even with no `messages` at all. Reproduced on the M5.

**Root cause:** `TextGenerationRequest.requestId: Option<String>`; the IPC envelope flattens its own `requestId` (an integer counter) into the same flat wire object; the hop deserialized the whole envelope as the request.

**Fix, typed not stringly** (Joel: "we forbid string uuid concatenation or serialization"): `CommandRequest<P>` carries `requestId: Option<u64>` and consumes it; the hop borrow-decodes `CommandRequest<TextGenerationRequest>` and takes `.params`. No key list. `is_envelope_field` is the one list of base fields the help diagnostics use. Card d78c1f69: the request's own `requestId/userId/roomId/personaId` become typed ids next.

**Acceptance verb (IntelMac, from the Intel box after the M5 deploys):** `continuum ai/generate {"aircPeer":"2f0aed7f-3359-4dd5-9f9b-aaa0b07c6266","provider":"llama-server","messages":[{"role":"user","content":"hi"}],"maxTokens":24}` must hop (an answer from the M5's Ornith) or refuse on TRANSPORT by name — never on deserialization, never locally.

`runtime::airc_interceptor` + `runtime::command_envelope` = 25 passed; `cargo check --release --features metal,accelerate` green. No auto-merge; a non-author no-objection please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo