### PR TITLE
fix(persona): the work-turn resume block keeps her newest thought's CONCLUSION, not its orientation

### DIFF
--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2961,6 +2961,25 @@ mod tests {
 
     // what this catches: the resume block carries HER newest thoughts only, oldest
     // first, clipped — never another citizen's line, never a receipt.
+    // what this catches (glass-boxed 2026-09-06, Atlas on django-16899): the newest
+    // thought head-clipped to its orientation — "Let me carefully parse where I am…" —
+    // so every turn re-ran git status and the conclusion she had reached never
+    // reached her next turn. The newest thought's TAIL is the resume point.
+    #[test]
+    fn the_newest_thought_resumes_from_its_conclusion_not_its_orientation() {
+        let me = Uuid::new_v4();
+        let row = |ms, text: &str| crate::persona::durable_history::RoomRow { id: Uuid::new_v4(), sender: me, occurred_at_ms: ms, text: text.to_string() };
+        let long = format!(
+            "💭 Let me carefully parse where I actually am right now. {} So the fix is: include the index in the label at checks.py:1040.",
+            "First, the ground truth from my own board and workspace. ".repeat(6)
+        );
+        let rows = vec![row(1, "💭 earlier orientation"), row(2, &long)];
+        let state = own_recent_thoughts(&rows, me, 2, 80);
+        assert_eq!(state.len(), 2);
+        assert!(state[1].ends_with("include the index in the label at checks.py:1040."), "{state:?}");
+        assert!(!state[1].contains("carefully parse"), "the orientation is what got dropped: {state:?}");
+    }
+
     #[test]
     fn her_last_thoughts_lead_the_work_turn_oldest_first() {
         use crate::persona::durable_history::RoomRow;
@@ -2977,7 +2996,8 @@ mod tests {
         let state = own_recent_thoughts(&rows, me, 2, 40);
         assert_eq!(state.len(), 2);
         assert!(state[0].starts_with("💭 lines 107-152"), "{state:?}");
-        assert!(state[1].ends_with('…'), "clipped: {state:?}");
+        // The newest thought keeps its TAIL — the conclusion — not its opening.
+        assert!(state[1].starts_with('…') && state[1].ends_with("on this card now, really"), "newest keeps its conclusion: {state:?}");
         let text = held_work_burst(&[], &state);
         assert!(text.contains("resume from them"));
         assert!(text.contains("lines 107-152"));

--- a/core/continuum-core/src/persona/work_burst.rs
+++ b/core/continuum-core/src/persona/work_burst.rs
@@ -83,15 +83,30 @@ pub(crate) fn own_recent_thoughts_about(
     }
     mine.sort_by_key(|r| r.occurred_at_ms);
     let start = mine.len().saturating_sub(keep);
-    mine[start..]
-        .iter()
-        .map(|r| {
+    let kept = &mine[start..];
+    let newest = kept.len().saturating_sub(1);
+    kept.iter()
+        .enumerate()
+        .map(|(i, r)| {
             let one_line = r.text.split_whitespace().collect::<Vec<_>>().join(" ");
-            if one_line.chars().count() > max_chars {
+            let n = one_line.chars().count();
+            if n <= max_chars {
+                return one_line;
+            }
+            // THE NEWEST THOUGHT KEEPS ITS CONCLUSION. A stock-take thought opens
+            // with orientation ("Let me carefully parse where I actually am…") and
+            // ends with what she worked out ("so the fix is: include the index in the
+            // label at checks.py:…"). Head-clipping the newest one fed her back her own
+            // re-orientation and dropped the conclusion — glass-boxed 2026-09-06 03:49Z:
+            // Atlas held the fix in his reasoning and re-ran git status every turn.
+            // Older thoughts keep their head (what they were about); the newest keeps
+            // its tail (where it got to).
+            if i == newest {
+                let tail: String = one_line.chars().skip(n - max_chars).collect();
+                format!("…{tail}")
+            } else {
                 let cut: String = one_line.chars().take(max_chars).collect();
                 format!("{cut}…")
-            } else {
-                one_line
             }
         })
         .collect()


### PR DESCRIPTION
Glass-boxed (cognition/prompt + cognition/trace on Atlas, card django-16899, 2026-09-06 03:49Z): his reasoning already held the fix, his checkout was clean, his last five acts were git status / grep / read with `wrote=false`. The resume block clips each of the last four thoughts to their first 400 characters; a stock-take thought opens with orientation and ends with the conclusion — so every turn re-read "Let me carefully parse where I actually am…" and lost "so the fix is: include the index in the label at checks.py".

**Fix:** `own_recent_thoughts_about` — the newest thought keeps its tail, older ones their head. Tests: the existing resume test updated; `the_newest_thought_resumes_from_its_conclusion_not_its_orientation` added.

**Acceptance verb:** after deploy, `cognition/prompt {persona_id, limit 1}` on a holder must show the resume block's newest `💭` line ending with her conclusion (`…so the fix is …`), and `persona.act.observed` for that holder must include an edit within two work turns. Card 7e3e8070 (write-or-release gate) is the companion.

`persona::service_loop` resume tests = 2 passed; `cargo check --release --features metal,accelerate` green. No auto-merge; a non-author no-objection please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo