### PR TITLE
fix(persona): the thought receipt carries her conclusion — head + tail at the writer, not the first 240 characters

### DIFF
--- a/core/continuum-core/src/persona/presence_glyph.rs
+++ b/core/continuum-core/src/persona/presence_glyph.rs
@@ -30,11 +30,26 @@ pub fn is_presence_line(text: &str) -> bool {
     t.starts_with(THOUGHT) || t.starts_with(ACT)
 }
 
-/// A thought line, clipped to `max_chars` with an ellipsis when longer.
+/// A thought line within `max_chars`. A long thought keeps its HEAD (what it is
+/// about) and its TAIL (where it got to), with an ellipsis between.
+///
+/// Glass-boxed 2026-09-06 (Atlas, django-16899): the receipt was the first 240
+/// characters of a stock-take that opened "Let me carefully parse where I actually
+/// am…" and ended "so the fix is: include the index in the label at checks.py". Only
+/// the opening reached the room, the store, and the next turn's resume block — every
+/// turn re-oriented and the conclusion died at the writer. The tail is the part the
+/// next turn needs; the head is the part a reader needs to know what it is about.
 pub fn thought_line(thought: &str, max_chars: usize) -> String {
-    let clipped: String = thought.chars().take(max_chars).collect();
-    let more = if thought.chars().count() > max_chars { "…" } else { "" };
-    format!("{THOUGHT} {clipped}{more}")
+    let n = thought.chars().count();
+    if n <= max_chars {
+        return format!("{THOUGHT} {thought}");
+    }
+    // Head a third, tail the rest — the conclusion is worth more than the opening.
+    let head_chars = max_chars / 3;
+    let tail_chars = max_chars.saturating_sub(head_chars);
+    let head: String = thought.chars().take(head_chars).collect();
+    let tail: String = thought.chars().skip(n - tail_chars).collect();
+    format!("{THOUGHT} {head}… {tail}")
 }
 
 /// An act receipt line: `⚙ verb object ✓`.
@@ -46,6 +61,22 @@ pub fn act_line(verb: &str, object: &str, ok: bool) -> String {
 mod tests {
     use super::*;
 
+    // what this catches (Atlas, django-16899, 2026-09-06): a long stock-take receipt
+    // that keeps only its opening — the conclusion at the end is what the next turn
+    // resumes from, and it must survive the writer.
+    #[test]
+    fn a_long_thought_keeps_its_conclusion_at_the_writer() {
+        let thought = format!(
+            "Let me carefully parse where I actually am right now. {} So the fix is: include the index in the label at checks.py:1040.",
+            "First, the ground truth from my own board and workspace. ".repeat(8)
+        );
+        let line = thought_line(&thought, 240);
+        assert!(line.starts_with("💭 Let me carefully parse"), "{line}");
+        assert!(line.ends_with("include the index in the label at checks.py:1040."), "{line}");
+        assert!(line.contains("… "), "head and tail joined by an ellipsis: {line}");
+        assert!(line.chars().count() <= 240 + 4, "within budget: {}", line.chars().count());
+    }
+
     // what this catches: the plane sniff drifting from the writer — a thought
     // or act line the writer emits must read as presence at the head of the
     // line, and speech must not.
@@ -55,7 +86,7 @@ mod tests {
         assert!(is_presence_line(&act_line("code/read", "swe/x.py", true)));
         assert!(is_presence_line("  ⚙ code/edit swe/x.py ✗"));
         assert!(!is_presence_line("Joel here — which card do you hold?"));
-        assert_eq!(thought_line("abcdef", 3), "💭 abc…");
+        assert_eq!(thought_line("abcdef", 3), "💭 a… ef");
         assert_eq!(act_line("code/edit", "a.py", false), "⚙ code/edit a.py ✗");
     }
 }


### PR DESCRIPTION
#3785 fixed the resume block's clip, and on the next build Atlas's block still read as orientation — because the receipt was already clipped at the writer: `presence_glyph::thought_line` posts the first 240 characters of the spoken thought (`act_observe/apply.rs:593`). A stock-take opens "Let me carefully parse where I actually am…" and ends "so the fix is: include the index in the label at checks.py". Only the opening ever reached the room, the store, or the next turn.

**Fix:** head (a third) + tail (the rest) with an ellipsis between. One writer, so the store, the rail, and the resume block all carry the conclusion.

**Acceptance verb:** after deploy, a holder's next `💭` line in her run room (`chat/history {roomId}`) ends with her conclusion, and `cognition/prompt` on her next work turn shows the resume block's newest line ending the same way; `persona.act.observed` for her includes an edit within two work turns. Companion gate: card 7e3e8070.

`persona::presence_glyph` + `work_burst` + resume tests + `cognition::act_observe` = 46 passed; `cargo check --release --features metal,accelerate` green. No auto-merge; a non-author no-objection please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo