### PR TITLE
fix(cognition): the [rebuilt] fact says her workspace is UNCHANGED — doubt the tools, not her reads

### DIFF
--- a/core/continuum-core/src/cognition/working_memory.rs
+++ b/core/continuum-core/src/cognition/working_memory.rs
@@ -829,11 +829,12 @@ impl WorkingMemory {
         if !snap.build_sha.is_empty() && snap.build_sha != current {
             let short = |s: &str| s.chars().take(9).collect::<String>();
             self.record_fact(&format!(
-                "[rebuilt] the substrate was rebuilt while you were away ({} → {}). Action \
-                 results above this line were recorded against the OLD build: they are what \
-                 really happened, but they are not evidence about how things behave NOW. A tool \
-                 that failed before may work on this build — worth re-trying rather than \
-                 concluding from memory.",
+                "[rebuilt] the substrate was rebuilt while you were away ({} → {}). Your \
+                 workspace, its checkout, and every file you read are UNCHANGED by that — what \
+                 you learned about the code still stands; resume from your last conclusion, do \
+                 not re-read to check. Only the TOOLS may behave differently now: a tool that \
+                 failed before may work on this build, worth re-trying rather than concluding \
+                 from memory.",
                 short(&snap.build_sha),
                 short(current),
             ));
@@ -1431,6 +1432,14 @@ mod rebuilt_marker {
         assert!(
             marker.contains("0000000de"),
             "names the build she was recorded against: {marker}"
+        );
+        // what this catches (Freya, 2026-09-06, after the tenth deploy of the night): the
+        // fact read as "distrust everything above" and every citizen re-read her whole
+        // checkout after every deploy. Her workspace did not change; the fact says so and
+        // reserves doubt for the tools.
+        assert!(
+            marker.contains("UNCHANGED") && marker.contains("resume from your last conclusion"),
+            "the fact must say her workspace and reads still stand: {marker}"
         );
         assert!(
             marker.contains("re-trying") || marker.contains("not evidence"),


### PR DESCRIPTION
Glass-boxed (Freya, django-14631, after the tenth deploy of the night): her turn opened "The substrate just rebuilt (e4dc0cff7 → 491097b91), so my earlier reads are against the old build — I need to re-read fresh." The `[rebuilt]` working-memory fact said results above the line "are not evidence about how things behave NOW" — true of the tools, false of her checkout and every file she read. Every citizen re-read her whole workspace after every deploy.

**Fix:** the fact says her workspace, checkout and reads are UNCHANGED and she resumes from her last conclusion; doubt is reserved for the tools (a tool that failed before may work now). Test tightened to pin both halves.

**Acceptance verb:** after the next deploy, a holder's first `💭` line must not contain "re-read" / "against the old build"; `persona.act.observed` for holders shows edits, not a fresh sweep of `read_file` over the same files.

`cognition::working_memory` = 27 passed; `cargo check --release --features metal,accelerate` green. No auto-merge; a non-author no-objection please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo