### PR TITLE
fix(registry): a sidecar pull overwrote the model's weights path — 11x under-count that survived until restart

### DIFF
--- a/core/continuum-core/src/model_registry/artifacts.rs
+++ b/core/continuum-core/src/model_registry/artifacts.rs
@@ -636,7 +636,7 @@ fn is_gguf(path: &Path) -> bool {
 /// via `--spec-draft-model`, never `-m`.
 /// ONE predicate for every main-model collector; [`find_mmproj_beside`] and
 /// [`find_mtp_draft_beside`] remain the sidecar-POSITIVE scans.
-fn is_main_model_gguf(path: &Path) -> bool {
+pub(crate) fn is_main_model_gguf(path: &Path) -> bool {
     if !is_gguf(path) {
         return false;
     }

--- a/core/continuum-core/src/model_registry/live.rs
+++ b/core/continuum-core/src/model_registry/live.rs
@@ -237,7 +237,36 @@ impl ModelCatalog {
         if present {
             self.mutate(|snap| {
                 if let Some(live) = snap.models.get_mut(id) {
-                    live.model.gguf_local_path = Some(gguf_path);
+                    // ONLY a MAIN-model GGUF may become `gguf_local_path`. A pull can
+                    // legitimately fetch a SIDECAR into the same repo — the multimodal
+                    // projector (`mmproj-*.gguf`) or the multi-token-prediction draft
+                    // head (`mtp-*.gguf`) — and those are not the model.
+                    //
+                    // This matters because `resolve_gguf` honours an EXPLICIT path
+                    // FIRST, before the `is_main_model_gguf` filter that the hint and
+                    // model-id paths go through. So attaching a sidecar path here made
+                    // `hydrate_artifact_sizes` stamp the SIDECAR's size as the model's
+                    // `weights_bytes` — and that field is cached on the row by design
+                    // (to keep `stat` off the governor's accounting tick), so the wrong
+                    // number then survived every later plan until a process restart.
+                    //
+                    // MEASURED 2026-09-06 on BigMama: pulling the Qwen3.8-27B MTP draft
+                    // (`--quant Q4_0`) after the main weights left the planner reading
+                    // 1,680,271,648 bytes (the 1.68 GB draft) for a 18,973,870,432-byte
+                    // (18.97 GB) model — an 11x under-count. The planner believed it had
+                    // ~17 GB more headroom than it did, granted a WIDER context window
+                    // on that basis, and the card sat at 32,086/32,607 MiB = 98.4%. A
+                    // fresh core reported 18.97 GB from the same files, which is what
+                    // identified the row cache as the carrier.
+                    //
+                    // Sidecars need no path attached: the projector has its own field,
+                    // and the draft head is found by `find_mtp_draft_beside` scanning
+                    // the snapshot dir. So the correct action is to leave the main path
+                    // alone and still re-hydrate — the hydration below resolves the real
+                    // main artifact and stamps the right size.
+                    if crate::model_registry::artifacts::is_main_model_gguf(&gguf_path) {
+                        live.model.gguf_local_path = Some(gguf_path);
+                    }
                     if mmproj_path.is_some() {
                         live.model.mmproj_local_path = mmproj_path;
                     }
@@ -418,6 +447,64 @@ mod tests {
     // generation bump, so serving reads the path off the snapshot instead of
     // re-scanning disk. An unknown id reports false (no silent success).
     #[test]
+    // what this catches: a SIDECAR pull clobbering the model's main-weights path,
+    // and with it the cached `weights_bytes` every capacity estimate reads.
+    // Regression for the 2026-09-06 BigMama measurement — pulling the Qwen3.8-27B
+    // MTP draft (`models/pull --quant Q4_0`) after the main weights made the planner
+    // read 1,680,271,648 bytes (the 1.68 GB draft) for an 18,973,870,432-byte model.
+    // `resolve_gguf` honours an EXPLICIT path FIRST, before the `is_main_model_gguf`
+    // filter the hint path goes through, so the sidecar's size was stamped onto the
+    // row — and `weights_bytes` is cached there by design, so it survived every plan
+    // until a process restart. Consequence was not cosmetic: an 11x under-count
+    // granted a wider context window and left the card at 98.4% VRAM.
+    #[test]
+    fn a_sidecar_pull_never_becomes_the_models_main_weights_path() {
+        use std::path::PathBuf;
+        let reg = catalog::registry().expect("Rust catalog must validate");
+        let catalog = ModelCatalog::from_registry(&reg);
+        let id = catalog
+            .snapshot()
+            .models
+            .values()
+            .find(|m| m.status.availability == Availability::NotDownloaded)
+            .map(|m| m.model.id.clone())
+            .expect("seeded universe has a not-downloaded local model");
+
+        // The main artifact lands first, as a real pull does.
+        let main = PathBuf::from("/tmp/Qwen3.8-27B-Q4_K_M.gguf");
+        assert!(catalog.attach_local_artifact(&id, main.clone(), None));
+        assert_eq!(
+            catalog.snapshot().get(&id).unwrap().model.gguf_local_path,
+            Some(main.clone()),
+            "the main artifact IS the model's weights path"
+        );
+
+        // Then the MTP draft head — a sidecar in the SAME repo, which is exactly how
+        // ggml-org ships Qwen3.8 and exactly what `--quant Q4_0` fetches.
+        assert!(catalog.attach_local_artifact(
+            &id,
+            PathBuf::from("/tmp/mtp-Qwen3.8-27B-Q4_0.gguf"),
+            None
+        ));
+        assert_eq!(
+            catalog.snapshot().get(&id).unwrap().model.gguf_local_path,
+            Some(main.clone()),
+            "an mtp- draft head must NOT replace the main weights path"
+        );
+
+        // And the multimodal projector, the other sidecar in that repo.
+        assert!(catalog.attach_local_artifact(
+            &id,
+            PathBuf::from("/tmp/mmproj-Qwen3.8-27B-BF16.gguf"),
+            None
+        ));
+        assert_eq!(
+            catalog.snapshot().get(&id).unwrap().model.gguf_local_path,
+            Some(main),
+            "an mmproj projector must NOT replace the main weights path"
+        );
+    }
+
     fn attach_local_artifact_records_paths_and_flips_ready() {
         use std::path::PathBuf;
         let reg = catalog::registry().expect("Rust catalog must validate");


### PR DESCRIPTION
Root cause of card `a374c014`, and it feeds the guard in `plan_serving_stable` that M5 is landing.

## The bug

`attach_local_artifact` sets `gguf_local_path` to whatever path the pull hands it, then calls `hydrate_artifact_sizes`. `resolve_gguf` honours an **explicit path first** — before the `is_main_model_gguf` filter that the hint and model-id paths go through. So attaching a **sidecar** path stamped the sidecar's size onto the row as the model's `weights_bytes`.

That field is cached on the row *by design* — "every residency estimate downstream reads these instead of `stat`ing per call, which is what keeps filesystem I/O off the governor's accounting tick" — so the wrong number survived every later plan **until a process restart**.

## Measured

ggml-org ships Qwen3.8-27B with two sidecars in the same repo (`mmproj-*.gguf`, `mtp-*.gguf`), and `models/pull --quant Q4_0` fetches the MTP draft head:

```
long-running core    1,680,271,648   (1.68 GB — the DRAFT head)
fresh core          18,973,870,432   (18.97 GB — the real weights)
```

An **11× under-count**, and not cosmetic:

| | weights read | budget | window | VRAM |
|---|---|---|---|---|
| stale | 1.68 GB | 36.2 GB | 28,295 | 32,086 / 32,607 = **98.4%** |
| correct | 18.97 GB | 55.1 GB | 24,832 | 25,326 = **78%** |

The planner believed it had ~17 GB more headroom than it had and granted a *wider* context window on that basis. That is the difference between a lane with headroom and one that OOMs on the next deep prefill — the failure the capacity ranker exists to prevent.

It also feeds `plan_serving_stable`, which reasons over `&[ModelFootprint]`: an inflated headroom estimate makes a "a switch-up never reduces lanes" guard compare against a lane count that was never affordable, so it can pass the very switch that starves a roster.

## The fix

Only a **main-model** GGUF may become `gguf_local_path`. Sidecars need no path attached — the projector has its own field, and the draft head is found by `find_mtp_draft_beside` scanning the snapshot dir. Hydration still runs, so it resolves the real main artifact and stamps the right size; a sidecar pull correctly leaves the weights path alone and still flips `Ready`.

`is_main_model_gguf` already existed and already excluded both `mmproj` and `mtp-` (#106, and the Qwen3.8 layout) — it simply wasn't reachable from the explicit-path branch. Widened to `pub(crate)` so one predicate serves both.

## Test

Pins the real sequence — main lands, then the mtp draft, then the mmproj — asserting the weights path is still the main artifact after each. **8/8 green.**

## How it was found

Not by reading: by restarting. The value survived a `touch` of the main weights, which killed my mtime hypothesis and should have told me immediately that nothing on disk was being read any more. A fresh process reporting 18.97 GB from identical files is what identified the row cache as the carrier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc
