### PR TITLE
fix(persona): a work turn with six acts and no write ends in an edit or a release (card 7e3e8070)

### DIFF
--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -166,7 +166,8 @@ pub(crate) async fn ask_the_act_question(
                     // `held_work_burst`); paged from the durable store, the
                     // same page the catch-up reads. A failed page is a missing
                     // block, never a failed turn.
-                    let last_state = match crate::persona::durable_history::room_rows(turn_room, 80).await {
+                    let page = crate::persona::durable_history::room_rows(turn_room, 80).await;
+                    let last_state = match &page {
                         Ok(rows) => {
                             let about: Vec<String> = held
                                 .iter()
@@ -197,7 +198,19 @@ pub(crate) async fn ask_the_act_question(
                         thoughts = last_state.len() as u64,
                         "her own newest thoughts lead the work turn"
                     );
-                    let burst_text = held_work_burst(&held, &last_state);
+                    let acts_without_write = page
+                        .as_ref()
+                        .map(|rows| crate::persona::work_burst::acts_since_last_write(rows, ctx.identity.peer_id.as_uuid()))
+                        .unwrap_or(0); // unwrap_or: no page = no acts counted; the gate stays open, never closes on absence
+                    if acts_without_write >= crate::persona::work_burst::WRITE_OR_RELEASE_AFTER_ACTS {
+                        crate::probe!(
+                            class = "persona.work.write_or_release_gate",
+                            persona = %ctx.identity.agent_name,
+                            acts_without_write,
+                            "the work turn is gated: edit now or release the card"
+                        );
+                    }
+                    let burst_text = crate::persona::work_burst::held_work_burst_gated(&held, &last_state, acts_without_write);
                     // The producer's CONTEXT half, kept before the burst is
                     // moved into the driver — one construction, so the
                     // training example records the prompt she was actually

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2999,7 +2999,7 @@ mod tests {
         assert!(text.contains("PASS: blocked"), "{text}");
 
         let mut edited = looping.clone();
-        edited.push(row(4, "💭 fixing ⚙ code/edit checks.py ✓ ⚙ code/run pytest ✓"));
+        edited.push(row(4, "💭 fixing ⚙ code/write witness_report.txt ✓ ⚙ code/run pytest ✓"));
         assert_eq!(acts_since_last_write(&edited, me), 1, "an edit resets the count");
         let text = held_work_burst_gated(&[], &[], acts_since_last_write(&edited, me));
         assert!(!text.contains("[write or release]"), "no gate after an edit: {text}");

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2980,6 +2980,32 @@ mod tests {
         assert!(!state[1].contains("carefully parse"), "the orientation is what got dropped: {state:?}");
     }
 
+    // what this catches (card 7e3e8070): the no-deliverable notice narrating instead of
+    // gating. Six acts on a held card with no file change → the work turn names the two
+    // ways out; an edit receipt resets the count and the gate stays out of the way.
+    #[test]
+    fn six_acts_without_a_write_gate_the_work_turn_and_an_edit_resets_it() {
+        use crate::persona::work_burst::{acts_since_last_write, held_work_burst_gated, WRITE_OR_RELEASE_AFTER_ACTS};
+        let me = Uuid::new_v4();
+        let row = |ms, text: &str| crate::persona::durable_history::RoomRow { id: Uuid::new_v4(), sender: me, occurred_at_ms: ms, text: text.to_string() };
+        let looping = vec![
+            row(1, "💭 reading ⚙ code/read a.py ✓ ⚙ code/search x ✓"),
+            row(2, "💭 checking ⚙ code/run pytest ✓ ⚙ code/git/status ✓"),
+            row(3, "💭 more ⚙ code/read b.py ✓ ⚙ code/shell ls ✓"),
+        ];
+        assert_eq!(acts_since_last_write(&looping, me), 6);
+        let text = held_work_burst_gated(&[], &[], acts_since_last_write(&looping, me));
+        assert!(text.contains("[write or release]"), "{text}");
+        assert!(text.contains("PASS: blocked"), "{text}");
+
+        let mut edited = looping.clone();
+        edited.push(row(4, "💭 fixing ⚙ code/edit checks.py ✓ ⚙ code/run pytest ✓"));
+        assert_eq!(acts_since_last_write(&edited, me), 1, "an edit resets the count");
+        let text = held_work_burst_gated(&[], &[], acts_since_last_write(&edited, me));
+        assert!(!text.contains("[write or release]"), "no gate after an edit: {text}");
+        assert!(WRITE_OR_RELEASE_AFTER_ACTS >= 4, "the gate is not a hair trigger");
+    }
+
     #[test]
     fn her_last_thoughts_lead_the_work_turn_oldest_first() {
         use crate::persona::durable_history::RoomRow;

--- a/core/continuum-core/src/persona/work_burst.rs
+++ b/core/continuum-core/src/persona/work_burst.rs
@@ -24,7 +24,16 @@ pub(crate) fn acts_since_last_write(rows: &[crate::persona::durable_history::Roo
     for r in mine {
         for act in r.text.split(crate::persona::presence_glyph::ACT).skip(1) {
             let verb = act.split_whitespace().next().unwrap_or(""); // unwrap_or: a bare glyph names no verb
-            if verb.starts_with("code/edit") || verb.starts_with("git_apply") || verb.starts_with("edit_file") || verb.starts_with("code/git/apply") {
+                        // Every write-capable hand resets the count (review on #3790: `code/write`
+            // is what the one card completion tonight used — a gate that reads a
+            // write as an act misfires on the behaviour it exists to reward).
+            // COUPLING: this parses the rendered ⚙ receipt (`presence_glyph::act_line`);
+            // the acceptance verb reads `persona.act.observed wrote=true`. If the
+            // receipt shape moves, this counter reads zero and the gate silently
+            // stops — read the act probe stream here when it is queryable per card.
+            if verb.starts_with("code/edit") || verb.starts_with("code/write")
+               || verb.starts_with("code/create-workspace") || verb.starts_with("git_apply")
+               || verb.starts_with("edit_file") || verb.starts_with("code/git/apply") {
                 n = 0;
             } else {
                 n += 1;

--- a/core/continuum-core/src/persona/work_burst.rs
+++ b/core/continuum-core/src/persona/work_burst.rs
@@ -5,7 +5,47 @@
 
 use uuid::Uuid;
 
+/// Acts on a held card without a file change before the work turn stops narrating
+/// and GATES: edit now, or release with a reason. Six is two turns of "let me read
+/// one more thing" — the shape every glass box found tonight (Atlas: 850+ acts, no
+/// deliverable; the substrate said "no act of mine has changed a file" and nothing
+/// followed from it).
+// context-budget-exempt: an act count, not a window or token budget
+pub(crate) const WRITE_OR_RELEASE_AFTER_ACTS: usize = 6;
+
+/// Her acts since her last file change, counted from her own ⚙ receipts in the
+/// room (oldest → newest). A `code/edit` / `git_apply` / `edit_file` receipt resets
+/// the count; a card with no edit ever counts every act. Pure.
+pub(crate) fn acts_since_last_write(rows: &[crate::persona::durable_history::RoomRow], me: Uuid) -> usize {
+    let mut mine: Vec<&crate::persona::durable_history::RoomRow> =
+        rows.iter().filter(|r| r.sender == me).collect();
+    mine.sort_by_key(|r| r.occurred_at_ms);
+    let mut n = 0usize;
+    for r in mine {
+        for act in r.text.split(crate::persona::presence_glyph::ACT).skip(1) {
+            let verb = act.split_whitespace().next().unwrap_or(""); // unwrap_or: a bare glyph names no verb
+            if verb.starts_with("code/edit") || verb.starts_with("git_apply") || verb.starts_with("edit_file") || verb.starts_with("code/git/apply") {
+                n = 0;
+            } else {
+                n += 1;
+            }
+        }
+    }
+    n
+}
+
 pub(crate) fn held_work_burst(held: &[&airc_lib::WorkCard], last_state: &[String]) -> String {
+    held_work_burst_gated(held, last_state, 0)
+}
+
+/// [`held_work_burst`] with the write-or-release gate: past
+/// [`WRITE_OR_RELEASE_AFTER_ACTS`] acts without a file change, the turn is told the
+/// investigation is finished and given exactly two ways out.
+pub(crate) fn held_work_burst_gated(
+    held: &[&airc_lib::WorkCard],
+    last_state: &[String],
+    acts_without_write: usize,
+) -> String {
     use std::fmt::Write as _;
     let mut s = String::from(
         "[work turn] The room is quiet and your speak-turn is settled. This \
@@ -40,6 +80,17 @@ pub(crate) fn held_work_burst(held: &[&airc_lib::WorkCard], last_state: &[String
          card, so use it only when the deliverable is really written. Speak only \
          to report a result or blocker to the room.",
     );
+    if acts_without_write >= WRITE_OR_RELEASE_AFTER_ACTS {
+        let _ = write!(
+            s,
+            "\n[write or release] You have made {acts_without_write} acts on this card \
+             without changing a file. The investigation is finished. This turn does ONE \
+             of two things: make the edit now (code/edit or git_apply — the fix you have \
+             already named in your last thoughts), or conclude 'PASS: blocked — <one \
+             line why>' and release the card so a peer can take it. No more reading, \
+             running, or status checks before one of those."
+        );
+    }
     s
 }
 


### PR DESCRIPTION
## What
`work_burst::acts_since_last_write` counts the holder's ⚙ receipts on the card's room since her last edit/apply receipt. At `WRITE_OR_RELEASE_AFTER_ACTS` (6) the held-work resume block appends a `[write or release]` gate: make the edit now, or conclude `PASS: blocked — <one line why>` and release the card. Below the threshold the block is unchanged.

## Why
Glass box on the holders (card 7e3e8070): 850+ acts of read/run/search with zero deliverables; the "no deliverable yet" notice narrated the state instead of gating it. Third layer of the resume pipe after #3785 (resume clip) and #3787 (receipt writer).

## Acceptance verb
After deploy: `debug/probes/query {"class":"persona.work.write_or_release_gate"}` shows `acts_without_write ≥ 6` rows for looping holders, and within two work turns each such holder either writes (`persona.act.observed wrote=true`) or releases (`work.release`). Working-round diffs: `scratchpad/round_diffs.py`.

## Tests
`persona::service_loop::tests::six_acts_without_a_write_gate_the_work_turn_and_an_edit_resets_it` (+ the two resume tests) — 3/3; `cargo check --release --features metal,accelerate` green.

No auto-merge; deploys after the M5 freeze ends on evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo