### PR TITLE
chore(airc): pin 78e7946e8 — bounded cursor resume (airc#1389), the wall read returns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -301,7 +301,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=07dc2cb6a#07dc2cb6ab0bc954ef09b653f56f5d04e06195e8"
+source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
 dependencies = [
  "airc-core",
  "airc-store",
@@ -454,7 +454,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3712,7 +3712,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4015,7 +4015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4865,7 +4865,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5537,7 +5537,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -7101,7 +7101,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9482,7 +9482,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10259,7 +10259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10768,7 +10768,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12643,7 +12643,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,18 +185,18 @@ members = [
 # room is still its default under either verb. This is what continuum's
 # room/join needs (task #65, Joel: a persona is first-class and can subscribe to
 # many rooms). Also fixes `RoomJoinedBody.is_default`, previously hardcoded true.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "07dc2cb6a" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)


### PR DESCRIPTION
Pin bump only (Cargo.toml + Cargo.lock; carries airc#1385 identity-card publish and #1389 bounded cursor resume).

## Why
Every citizen tick paid the 30 s perception deadline to `wall_posts_in`, whose from-zero walk made the daemon materialize the whole remaining transcript per 500-row page (academy 244,037 bus_events → never returned). Reviewed and merged in airc (#1389, non-author no-objection).

## Acceptance verb (after deploy)
`debug/probes/query {"class":"wall.read.phase"}` shows `exit` rows with `wall_ms` for every `enter`; `delib.context.render` on work turns lists the wall/doctrine delivery again.

`cargo check --release --features metal,accelerate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo