### PR TITLE
feat(persona): a held card carries what she already read and ran (card 516738b4)

### DIFF
--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -198,6 +198,10 @@ pub(crate) async fn ask_the_act_question(
                         thoughts = last_state.len() as u64,
                         "her own newest thoughts lead the work turn"
                     );
+                    let progress = page
+                        .as_ref()
+                        .map(|rows| crate::persona::work_burst::card_progress(rows, ctx.identity.peer_id.as_uuid()))
+                        .unwrap_or_default(); // unwrap_or_default: no page = no note; a fresh card carries none
                     let acts_without_write = page
                         .as_ref()
                         .map(|rows| crate::persona::work_burst::acts_since_last_write(rows, ctx.identity.peer_id.as_uuid()))
@@ -210,7 +214,7 @@ pub(crate) async fn ask_the_act_question(
                             "the work turn is gated: edit now or release the card"
                         );
                     }
-                    let burst_text = crate::persona::work_burst::held_work_burst_gated(&held, &last_state, acts_without_write);
+                    let burst_text = crate::persona::work_burst::held_work_burst_gated(&held, &last_state, acts_without_write, &progress);
                     // The producer's CONTEXT half, kept before the burst is
                     // moved into the driver — one construction, so the
                     // training example records the prompt she was actually

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -198,10 +198,11 @@ pub(crate) async fn ask_the_act_question(
                         thoughts = last_state.len() as u64,
                         "her own newest thoughts lead the work turn"
                     );
-                    let progress = page
-                        .as_ref()
-                        .map(|rows| crate::persona::work_burst::card_progress(rows, ctx.identity.peer_id.as_uuid()))
-                        .unwrap_or_default(); // unwrap_or_default: no page = no note; a fresh card carries none
+                    // No page = no note (a fresh card carries none); the absence is not a quantity.
+                    let progress = match &page {
+                        Ok(rows) => crate::persona::work_burst::card_progress(rows, ctx.identity.peer_id.as_uuid()),
+                        Err(_) => crate::persona::work_burst::CardProgress::default(),
+                    };
                     let acts_without_write = page
                         .as_ref()
                         .map(|rows| crate::persona::work_burst::acts_since_last_write(rows, ctx.identity.peer_id.as_uuid()))

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2985,7 +2985,7 @@ mod tests {
     // ways out; an edit receipt resets the count and the gate stays out of the way.
     #[test]
     fn six_acts_without_a_write_gate_the_work_turn_and_an_edit_resets_it() {
-        use crate::persona::work_burst::{acts_since_last_write, held_work_burst_gated, WRITE_OR_RELEASE_AFTER_ACTS};
+        use crate::persona::work_burst::{acts_since_last_write, held_work_burst_gated, CardProgress, WRITE_OR_RELEASE_AFTER_ACTS};
         let me = Uuid::new_v4();
         let row = |ms, text: &str| crate::persona::durable_history::RoomRow { id: Uuid::new_v4(), sender: me, occurred_at_ms: ms, text: text.to_string() };
         let looping = vec![
@@ -2994,16 +2994,44 @@ mod tests {
             row(3, "💭 more ⚙ code/read b.py ✓ ⚙ code/shell ls ✓"),
         ];
         assert_eq!(acts_since_last_write(&looping, me), 6);
-        let text = held_work_burst_gated(&[], &[], acts_since_last_write(&looping, me));
+        let text = held_work_burst_gated(&[], &[], acts_since_last_write(&looping, me), &CardProgress::default());
         assert!(text.contains("[write or release]"), "{text}");
         assert!(text.contains("PASS: blocked"), "{text}");
 
         let mut edited = looping.clone();
         edited.push(row(4, "💭 fixing ⚙ code/write witness_report.txt ✓ ⚙ code/run pytest ✓"));
         assert_eq!(acts_since_last_write(&edited, me), 1, "an edit resets the count");
-        let text = held_work_burst_gated(&[], &[], acts_since_last_write(&edited, me));
+        let text = held_work_burst_gated(&[], &[], acts_since_last_write(&edited, me), &CardProgress::default());
         assert!(!text.contains("[write or release]"), "no gate after an edit: {text}");
         assert!(WRITE_OR_RELEASE_AFTER_ACTS >= 4, "the gate is not a hair trigger");
+    }
+
+    // what this catches (card 516738b4): a work turn that re-reads what it read.
+    // Her ⚙ receipts already say which files she read and what she ran; the block
+    // must lead with them, de-duplicated, newest last, and say nothing on a fresh card.
+    #[test]
+    fn a_held_card_carries_what_she_already_read_and_ran() {
+        use crate::persona::work_burst::{card_progress, held_work_burst_gated, progress_line, CardProgress};
+        let me = Uuid::new_v4();
+        let row = |ms, text: &str| crate::persona::durable_history::RoomRow { id: Uuid::new_v4(), sender: me, occurred_at_ms: ms, text: text.to_string() };
+        let rows = vec![
+            row(2, "💭 looking ⚙ code/read django/forms/fields.py ✓ ⚙ code/search MultiValueField ✓"),
+            row(1, "💭 first ⚙ work/get de33e1d6 ✓"),
+            row(3, "💭 again ⚙ code/read django/forms/fields.py ✓ ⚙ code/run pytest tests/forms_tests -k Multi ✗"),
+            row(4, "💭 fix ⚙ code/edit django/forms/fields.py ✓ ⚙ code/run pytest tests/forms_tests -k Multi ✓"),
+        ];
+        let p = card_progress(&rows, me);
+        assert_eq!(p.acts, 7);
+        assert_eq!(p.writes, 1);
+        assert_eq!(p.read, vec!["MultiValueField".to_string(), "django/forms/fields.py".to_string()], "de-duplicated, newest last");
+        assert_eq!(p.ran.len(), 2);
+        assert!(p.ran[1].ends_with('✓'), "{:?}", p.ran);
+        let block = held_work_burst_gated(&[], &[], 0, &p);
+        assert!(block.contains("[progress] 7 acts so far (1 writes)"), "{block}");
+        assert!(block.contains("Already read: MultiValueField, django/forms/fields.py."), "{block}");
+        assert!(block.find("[progress]").unwrap() < block.find("Your workspace holds").unwrap(), "the note leads");
+        assert!(progress_line(&CardProgress::default()).is_empty(), "a fresh card carries no note");
+        assert!(!held_work_burst_gated(&[], &[], 0, &CardProgress::default()).contains("[progress]"));
     }
 
     #[test]

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -3023,12 +3023,14 @@ mod tests {
         let p = card_progress(&rows, me);
         assert_eq!(p.acts, 7);
         assert_eq!(p.writes, 1);
-        assert_eq!(p.read, vec!["MultiValueField".to_string(), "django/forms/fields.py".to_string()], "de-duplicated, newest last");
+        assert_eq!(p.read, vec!["django/forms/fields.py".to_string()], "paths only, de-duplicated");
+        assert_eq!(p.searched, vec!["MultiValueField".to_string()], "a search term is not a read");
         assert_eq!(p.ran.len(), 2);
         assert!(p.ran[1].ends_with('✓'), "{:?}", p.ran);
         let block = held_work_burst_gated(&[], &[], 0, &p);
         assert!(block.contains("[progress] 7 acts so far (1 writes)"), "{block}");
-        assert!(block.contains("Already read: MultiValueField, django/forms/fields.py."), "{block}");
+        assert!(block.contains("Already read: django/forms/fields.py."), "{block}");
+        assert!(block.contains("Already searched: MultiValueField."), "{block}");
         assert!(block.find("[progress]").unwrap() < block.find("Your workspace holds").unwrap(), "the note leads");
         assert!(progress_line(&CardProgress::default()).is_empty(), "a fresh card carries no note");
         assert!(!held_work_burst_gated(&[], &[], 0, &CardProgress::default()).contains("[progress]"));

--- a/core/continuum-core/src/persona/work_burst.rs
+++ b/core/continuum-core/src/persona/work_burst.rs
@@ -31,9 +31,7 @@ pub(crate) fn acts_since_last_write(rows: &[crate::persona::durable_history::Roo
             // the acceptance verb reads `persona.act.observed wrote=true`. If the
             // receipt shape moves, this counter reads zero and the gate silently
             // stops — read the act probe stream here when it is queryable per card.
-            if verb.starts_with("code/edit") || verb.starts_with("code/write")
-               || verb.starts_with("code/create-workspace") || verb.starts_with("git_apply")
-               || verb.starts_with("edit_file") || verb.starts_with("code/git/apply") {
+            if is_write_verb(verb) {
                 n = 0;
             } else {
                 n += 1;
@@ -44,7 +42,106 @@ pub(crate) fn acts_since_last_write(rows: &[crate::persona::durable_history::Roo
 }
 
 pub(crate) fn held_work_burst(held: &[&airc_lib::WorkCard], last_state: &[String]) -> String {
-    held_work_burst_gated(held, last_state, 0)
+    held_work_burst_gated(held, last_state, 0, &CardProgress::default())
+}
+
+/// What she has already done on this card, derived from her own ⚙ receipts in
+/// the room page (card 516738b4): the files she read, the commands she ran, the
+/// act/write tally. No new store — the transcript already holds every act; this
+/// is the projection the next turn resumes from so it stops re-reading what it
+/// read. Measured 2026-09-06 08:0xZ: every work turn opened with "let me parse
+/// where I am", re-read the same file region, and ended; 48 acts / 0 writes in a
+/// warm 80-minute window across ten holders.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct CardProgress {
+    pub acts: usize,
+    pub writes: usize,
+    /// Distinct objects of her read-shaped acts (code/read, code/search, code/list),
+    /// newest last, capped.
+    pub read: Vec<String>,
+    /// Her newest run/shell commands with their outcome glyph, newest last, capped.
+    pub ran: Vec<String>,
+}
+
+const PROGRESS_READ_KEEP: usize = 6;
+const PROGRESS_RAN_KEEP: usize = 3;
+
+/// Fold her ⚙ receipts (oldest first) into a [`CardProgress`]. A receipt row is
+/// `⚙ verb object ✓` segments joined by the act glyph; the object is whatever the
+/// writer put there (a path, a command, a card id), clipped for the block.
+pub(crate) fn card_progress(rows: &[crate::persona::durable_history::RoomRow], me: Uuid) -> CardProgress {
+    use crate::persona::presence_glyph::{ACT, FAIL, OK};
+    let mut mine: Vec<&crate::persona::durable_history::RoomRow> =
+        rows.iter().filter(|r| r.sender == me && r.text.contains(ACT)).collect();
+    mine.sort_by_key(|r| r.occurred_at_ms);
+    let mut p = CardProgress::default();
+    for row in mine {
+        for seg in row.text.split(ACT).skip(1) {
+            let seg = seg.trim();
+            if seg.is_empty() {
+                continue;
+            }
+            let ok = seg.ends_with(OK);
+            let seg = seg.trim_end_matches(OK).trim_end_matches(FAIL).trim();
+            let mut parts = seg.splitn(2, ' ');
+            let verb = parts.next().unwrap_or("");
+            let object = parts.next().unwrap_or("").trim();
+            p.acts += 1;
+            if is_write_verb(verb) {
+                p.writes += 1;
+            }
+            let obj: String = object.chars().take(72).collect();
+            if verb.starts_with("code/read") || verb.starts_with("code/search") || verb.starts_with("code/list") {
+                if !obj.is_empty() {
+                    p.read.retain(|o| o != &obj);
+                    p.read.push(obj);
+                    if p.read.len() > PROGRESS_READ_KEEP {
+                        p.read.remove(0);
+                    }
+                }
+            } else if verb.starts_with("code/run") || verb.starts_with("code/shell") {
+                let shown = if obj.is_empty() { verb.to_string() } else { obj };
+                p.ran.push(format!("{shown} {}", if ok { OK } else { FAIL }));
+                if p.ran.len() > PROGRESS_RAN_KEEP {
+                    p.ran.remove(0);
+                }
+            }
+        }
+    }
+    p
+}
+
+/// One `[progress]` line for the head of the held-work block; empty when she has
+/// no acts yet (a fresh card carries no note).
+pub(crate) fn progress_line(p: &CardProgress) -> String {
+    if p.acts == 0 {
+        return String::new();
+    }
+    let mut s = format!("[progress] {} acts so far ({} writes).", p.acts, p.writes);
+    if !p.read.is_empty() {
+        s.push_str(" Already read: ");
+        s.push_str(&p.read.join(", "));
+        s.push('.');
+    }
+    if !p.ran.is_empty() {
+        s.push_str(" Last ran: ");
+        s.push_str(&p.ran.join("; "));
+        s.push('.');
+    }
+    s.push_str(" Do not re-read those; go on from your last thought.");
+    s
+}
+
+/// The one list of write-capable hands, shared by the write-or-release count and
+/// the progress note (review on #3790: `code/write` finished the only card
+/// completion that night and was not on the list).
+fn is_write_verb(verb: &str) -> bool {
+    verb.starts_with("code/edit")
+        || verb.starts_with("code/write")
+        || verb.starts_with("code/create-workspace")
+        || verb.starts_with("git_apply")
+        || verb.starts_with("edit_file")
+        || verb.starts_with("code/git/apply")
 }
 
 /// [`held_work_burst`] with the write-or-release gate: past
@@ -54,6 +151,7 @@ pub(crate) fn held_work_burst_gated(
     held: &[&airc_lib::WorkCard],
     last_state: &[String],
     acts_without_write: usize,
+    progress: &CardProgress,
 ) -> String {
     use std::fmt::Write as _;
     let mut s = String::from(
@@ -70,6 +168,13 @@ pub(crate) fn held_work_burst_gated(
     // zero diffs after fourteen hours). The turn resumes from her own newest
     // thoughts on this work, oldest first, instead of re-orienting from the
     // room. Her words, unedited: state, not steering.
+    // WHAT SHE ALREADY DID LEADS HER THOUGHTS (card 516738b4): the files read and
+    // commands run are facts the transcript holds; without them every turn re-read
+    // the same region before thinking.
+    let note = progress_line(progress);
+    if !note.is_empty() {
+        let _ = writeln!(s, "{note}");
+    }
     if !last_state.is_empty() {
         s.push_str(
             "Your own last thoughts on this work, oldest first — resume from them; \

--- a/core/continuum-core/src/persona/work_burst.rs
+++ b/core/continuum-core/src/persona/work_burst.rs
@@ -56,9 +56,12 @@ pub(crate) fn held_work_burst(held: &[&airc_lib::WorkCard], last_state: &[String
 pub(crate) struct CardProgress {
     pub acts: usize,
     pub writes: usize,
-    /// Distinct objects of her read-shaped acts (code/read, code/search, code/list),
+    /// Distinct objects of her read-shaped acts (code/read, code/list) — paths —
     /// newest last, capped.
     pub read: Vec<String>,
+    /// Distinct code/search terms, newest last, capped (review on #3793: a search
+    /// term is not something she "already read").
+    pub searched: Vec<String>,
     /// Her newest run/shell commands with their outcome glyph, newest last, capped.
     pub ran: Vec<String>,
 }
@@ -83,22 +86,19 @@ pub(crate) fn card_progress(rows: &[crate::persona::durable_history::RoomRow], m
             }
             let ok = seg.ends_with(OK);
             let seg = seg.trim_end_matches(OK).trim_end_matches(FAIL).trim();
-            let mut parts = seg.splitn(2, ' ');
-            let verb = parts.next().unwrap_or("");
-            let object = parts.next().unwrap_or("").trim();
+            let (verb, object) = match seg.split_once(' ') {
+                Some((v, o)) => (v, o.trim()),
+                None => (seg, ""),
+            };
             p.acts += 1;
             if is_write_verb(verb) {
                 p.writes += 1;
             }
             let obj: String = object.chars().take(72).collect();
-            if verb.starts_with("code/read") || verb.starts_with("code/search") || verb.starts_with("code/list") {
-                if !obj.is_empty() {
-                    p.read.retain(|o| o != &obj);
-                    p.read.push(obj);
-                    if p.read.len() > PROGRESS_READ_KEEP {
-                        p.read.remove(0);
-                    }
-                }
+            if verb.starts_with("code/read") || verb.starts_with("code/list") {
+                push_distinct(&mut p.read, obj);
+            } else if verb.starts_with("code/search") {
+                push_distinct(&mut p.searched, obj);
             } else if verb.starts_with("code/run") || verb.starts_with("code/shell") {
                 let shown = if obj.is_empty() { verb.to_string() } else { obj };
                 p.ran.push(format!("{shown} {}", if ok { OK } else { FAIL }));
@@ -111,6 +111,18 @@ pub(crate) fn card_progress(rows: &[crate::persona::durable_history::RoomRow], m
     p
 }
 
+/// Keep `v` a distinct, newest-last list capped at [`PROGRESS_READ_KEEP`].
+fn push_distinct(v: &mut Vec<String>, obj: String) {
+    if obj.is_empty() {
+        return;
+    }
+    v.retain(|o| o != &obj);
+    v.push(obj);
+    if v.len() > PROGRESS_READ_KEEP {
+        v.remove(0);
+    }
+}
+
 /// One `[progress]` line for the head of the held-work block; empty when she has
 /// no acts yet (a fresh card carries no note).
 pub(crate) fn progress_line(p: &CardProgress) -> String {
@@ -121,6 +133,11 @@ pub(crate) fn progress_line(p: &CardProgress) -> String {
     if !p.read.is_empty() {
         s.push_str(" Already read: ");
         s.push_str(&p.read.join(", "));
+        s.push('.');
+    }
+    if !p.searched.is_empty() {
+        s.push_str(" Already searched: ");
+        s.push_str(&p.searched.join(", "));
         s.push('.');
     }
     if !p.ran.is_empty() {


### PR DESCRIPTION
## What
`work_burst::card_progress(rows, me)` folds her own ⚙ receipts from the room page already paged for the resume block into a `CardProgress` (acts, writes, files read de-duplicated newest last, last commands run with outcome). `progress_line` renders one `[progress] …` line that leads the held-work block, ahead of her last thoughts; a fresh card carries no note. `is_write_verb` is the one list of write-capable hands, shared with the write-or-release count from #3790.

## Why
Glass box 2026-09-06 08:0xZ (freeze hour on 45a852a9b): 48 acts by ten holders, 0 writes; every work turn opened "let me parse where I am", re-read the same file region, and ended. The transcript already held what she had read and run; nothing told her. No new store — the note is a projection of the rows the turn already pages.

## Acceptance verb
After deploy, `cognition/prompt` for a holder with ≥3 acts shows a `[progress]` line naming her read files and last commands at the head of `[work turn]`; over the next hour `persona.act.observed` for that holder shows fewer repeated `code/read` objects than the freeze hour (07:03–08:23Z: 16 code/run, 9 code/shell, 3 code/read, 0 writes).

## Tests
`persona::service_loop::tests::a_held_card_carries_what_she_already_read_and_ran` + the three resume/gate tests: 4/4; `cargo check --release --features metal,accelerate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo