### PR TITLE
fix(boot): stop re-installing — and thereby DOWNGRADING — an airc that is already here

### DIFF
--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -318,6 +318,36 @@ adopt_or_reap_llama_lanes
 #     A core with no transport is not a running system, and reporting success for
 #     one is the class of lie this whole card exists to end.
 ensure_airc_daemon() {
+  # LOOK BEFORE DECLARING ABSENCE (2026-09-06). `command -v` only sees THIS
+  # shell's PATH, and boot does not necessarily inherit the operator's. On a box
+  # where airc IS installed but `~/.local/bin` is absent from the boot shell's
+  # PATH, the branch below fired on EVERY start and re-ran install.sh — which
+  # pins its own revision, so an already-installed NEWER airc got rolled
+  # BACKWARDS. Measured on BigMama: a current airc went 156 commits behind
+  # mid-session, and the first symptom was unrelated-looking — `airc msg
+  # --stdin` and `airc inbox --room` began failing on "unexpected argument",
+  # because the flags had not shipped yet in the pinned revision.
+  #
+  # The conventional-location probe already existed twenty lines down, as the
+  # POST-install fallback, with a comment saying exactly this. It just ran after
+  # the reinstall instead of before it. Same check, moved to where it prevents
+  # the damage instead of describing it. An auto-install that never asks what is
+  # already there is a downgrade, not an install ([[silently-unwired-capability]]).
+  #
+  # `.exe` is listed explicitly: MSYS resolves a bare `airc` for `command -v`,
+  # but a bare `[ -x ]` path test is not guaranteed to append the extension, and
+  # on this platform the file on disk IS `airc.exe`
+  # ([[dir-opened-as-file-windows-only]]).
+  if ! command -v airc >/dev/null 2>&1; then
+    for _airc_cand in "${HOME}/.local/bin/airc" "${HOME}/.local/bin/airc.exe"; do
+      if [ -x "$_airc_cand" ]; then
+        export PATH="${HOME}/.local/bin:${PATH}"
+        echo "✓ airc already installed ($_airc_cand) — adding its dir to PATH for this boot, NOT reinstalling" >&2
+        break
+      fi
+    done
+  fi
+
   if ! command -v airc >/dev/null 2>&1; then
     # BOOT ACQUIRES ITS OWN TRANSPORT (2026-08-24, Joel: "this repo isn't for
     # ME — a new repo user without an agent"). A warn-and-carry-on here left a


### PR DESCRIPTION
## The bug

`ensure_airc_daemon` gated on `command -v airc`, which only sees **this shell's** PATH — and boot does not necessarily inherit the operator's. On a box where airc **is** installed but `~/.local/bin` is absent from the boot shell's PATH, the install branch fires on **every** start and re-runs `install.sh`, which pins its own revision. An already-installed **newer** airc gets rolled backwards.

## Measured

On BigMama, 2026-09-06: a current airc went **156 commits behind** mid-session.

The first symptom looked unrelated — `airc msg --stdin` and `airc inbox --room` began failing with `unexpected argument`, because those flags hadn't shipped yet in the pinned revision. I lost a message to it before realising the transport had travelled backwards underneath me.

**A transport that silently reverts is worse than one that is missing.** Missing is loud.

## The fix is a move, not a new idea

The conventional-location probe **already existed** twenty lines down as the *post-install* fallback, carrying a comment that states this exact hazard:

> PATH may not include the fresh install dir in THIS shell — try the conventional location before declaring absence.

It just ran *after* the reinstall instead of *before* it. This moves the same check to where it prevents the damage rather than describing it.

`.exe` is probed explicitly alongside the bare name: MSYS resolves a bare `airc` for `command -v`, but a bare `[ -x ]` path test isn't guaranteed to append the extension, and the file on disk on this platform **is** `airc.exe`.

## Verified in both directions

The failure directions differ, so both were tested rather than assumed:

| case | result |
|---|---|
| airc present, not on PATH | found, PATH extended, **no reinstall** |
| airc absent entirely | **still installs** — fresh clone still bootstraps |
| `.exe`-only on disk | detected |
| `bash -n` | clean |

The negative case matters most: had I only tested "don't reinstall", I could have broken fresh-clone bootstrap for every new user, which is the case this install branch exists to serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc