### PR TITLE
fix(disk): a citizen layer is a shared clone, never a copy; the model store is a governed class

### DIFF
--- a/core/continuum-core/src/modules/code_commands.rs
+++ b/core/continuum-core/src/modules/code_commands.rs
@@ -127,6 +127,7 @@ fn ensure_citizen_layer_from_base(
 ) -> Result<std::path::PathBuf, CommandError> {
     let layer = citizen_layer_path(peer)?;
     if layer.is_dir() {
+        share_layer_objects_with_base(&layer, base);
         // Self-heal the stale-clone bug ([[citizen-workspaces-are-stale-one-time-
         // clones]]): the layer was a ONE-TIME CoW snapshot that never refreshed, so
         // personas drifted stale (one froze before the workers/→core/ restructure).
@@ -160,46 +161,144 @@ fn ensure_citizen_layer_from_base(
     std::fs::create_dir_all(parent)
         .map_err(|e| CommandError::Internal(format!("citizen layer mkdir failed: {e}")))?;
     let started = std::time::Instant::now();
-    // Copy-on-write clone of the shared base → the peer's layer via the platform's
-    // reflink-capable `cp`. macOS APFS uses `-c` (clonefile); GNU coreutils uses
-    // `--reflink=auto` — reflink where the filesystem supports it (btrfs/XFS), a plain
-    // recursive copy otherwise, never failing for lack of CoW. `-cR` is macOS-ONLY (GNU
-    // cp rejects `-c`), which silently broke citizen provisioning on every Linux deploy
-    // until #191 surfaced it. `cfg!` (not `#[cfg]`) so BOTH branches compile and
-    // type-check on every platform — a Linux-only arm must never escape a macOS build.
-    let mut clone = std::process::Command::new("cp");
-    if cfg!(target_os = "macos") {
-        clone.arg("-cR");
-    } else {
-        clone.args(["--reflink=auto", "-R"]);
-    }
-    let out =
-        clone.arg(base).arg(&layer).output().map_err(|e| {
-            CommandError::Internal(format!("citizen layer clone spawn failed: {e}"))
-        })?;
+    // A SHARED CLONE, never a copy (2026-09-06, the day the M5 hit zero free). The
+    // previous shape — `cp -cR` of the whole checkout — was copy-on-write for a day and
+    // 7–20 GB per citizen a week later: every clone carried the canonical repo's full
+    // history, its stale worktree metadata (5 × 462 MB of vendored packs), 4.5 GB of
+    // gitignored model caches and node_modules, and as the base moved on, every block
+    // materialized. `git clone --shared` writes ONLY the tracked tree; objects come from
+    // the base through `.git/objects/info/alternates`, so the layer's marginal disk is
+    // her working tree plus her own commits. `git_sync_from_shared` (fetch + merge) is
+    // unchanged — it never depended on the copy.
+    let out = std::process::Command::new("git")
+        .args(["clone", "--shared", "--quiet"])
+        .arg(base)
+        .arg(&layer)
+        .output()
+        .map_err(|e| CommandError::Internal(format!("citizen layer clone spawn failed: {e}")))?;
     if !out.status.success() {
         // Never leave a half-materialized layer for the next call to mistake
         // for a real one.
         let _ = std::fs::remove_dir_all(&layer);
         return Err(CommandError::Internal(format!(
-            "citizen layer CoW clone failed for peer {peer} (base {}): {}. \
-             Copy-on-write is the intent (APFS clonefile on macOS, reflink on Linux \
-             btrfs/XFS); cp falls back to a full recursive copy on a non-CoW filesystem \
-             rather than failing, so a hard error here means the base is missing or \
-             unreadable, not a missing reflink.",
+            "citizen layer shared clone failed for peer {peer} (base {}): {}",
             base.display(),
             String::from_utf8_lossy(&out.stderr).trim()
         )));
     }
+    // The vendored inference engine rides along as a submodule; reference the base's
+    // copy so its objects are shared too. Bounded and named: a layer without the vendor
+    // tree still gives her hands (the core serves inference, not her checkout).
+    let vendor = init_vendor_submodule(&layer, base);
     crate::probe!(
         class = "workspace.layer.provision",
         peer = %peer,
         base = %base.display(),
         layer = %layer.display(),
+        vendor = %vendor,
         elapsed_ms = started.elapsed().as_millis() as u64,
-        "citizen layer provisioned — CoW clone of shared base (stores only the diff)"
+        "citizen layer provisioned — shared clone of the base (objects via alternates, tracked tree only)"
     );
     Ok(layer)
+}
+
+/// `git submodule update --init --reference <base>/<path>` for the vendored engine,
+/// bounded to ten minutes. Returns the named outcome for the probe: `shared`,
+/// `absent` (the base has no vendor tree — a test base), `failed: <why>`.
+fn init_vendor_submodule(layer: &std::path::Path, base: &std::path::Path) -> String {
+    const VENDOR: &str = "core/vendor/llama.cpp";
+    let reference = base.join(VENDOR);
+    if !reference.join(".git").exists() && !reference.join("HEAD").exists() {
+        return "absent".to_string();
+    }
+    let mut child = match std::process::Command::new("git")
+        .current_dir(layer)
+        .args(["submodule", "update", "--init", "--quiet", "--reference"])
+        .arg(&reference)
+        .arg(VENDOR)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(e) => return format!("failed: spawn {e}"),
+    };
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(600);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => return "shared".to_string(),
+            Ok(Some(status)) => {
+                let mut err = String::new();
+                if let Some(mut e) = child.stderr.take() {
+                    use std::io::Read as _;
+                    let _ = e.read_to_string(&mut err);
+                }
+                return format!("failed: {status} {}", err.trim());
+            }
+            Ok(None) if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                return "failed: timed out after 600 s".to_string();
+            }
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(200)),
+            Err(e) => return format!("failed: wait {e}"),
+        }
+    }
+}
+
+/// Migrate a layer provisioned by the old `cp -cR` shape to share its objects with
+/// the base: write `alternates`, repack keeping only objects the base lacks, and drop
+/// the worktree metadata the copy inherited from the base. Idempotent (a layer that
+/// already names the base's objects is left alone); every outcome named in a probe.
+fn share_layer_objects_with_base(layer: &std::path::Path, base: &std::path::Path) {
+    let objects = layer.join(".git").join("objects");
+    let alternates = objects.join("info").join("alternates");
+    let base_objects = base.join(".git").join("objects");
+    if !objects.is_dir() || !base_objects.is_dir() {
+        return;
+    }
+    let want = format!("{}\n", base_objects.display());
+    if std::fs::read_to_string(&alternates).map(|s| s == want).unwrap_or(false) {
+        return;
+    }
+    let started = std::time::Instant::now();
+    let outcome = (|| -> Result<String, String> {
+        std::fs::create_dir_all(objects.join("info")).map_err(|e| e.to_string())?;
+        std::fs::write(&alternates, &want).map_err(|e| e.to_string())?;
+        let out = std::process::Command::new("git")
+            .current_dir(layer)
+            .args(["repack", "-a", "-d", "-l", "-q"])
+            .output()
+            .map_err(|e| e.to_string())?;
+        if !out.status.success() {
+            return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+        }
+        // Worktree entries the copy inherited point at the BASE's trees, never hers.
+        let mut dropped = 0usize;
+        if let Ok(entries) = std::fs::read_dir(layer.join(".git").join("worktrees")) {
+            for entry in entries.flatten() {
+                let gitdir = std::fs::read_to_string(entry.path().join("gitdir")).unwrap_or_default();
+                if !gitdir.trim().starts_with(&layer.display().to_string()) {
+                    let _ = std::fs::remove_dir_all(entry.path());
+                    dropped += 1;
+                }
+            }
+        }
+        Ok(format!("shared; foreign worktree entries dropped: {dropped}"))
+    })();
+    match outcome {
+        Ok(summary) => crate::probe!(
+            class = "workspace.layer.objects_shared",
+            layer = %layer.display(),
+            summary = %summary,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "citizen layer now shares its objects with the base"
+        ),
+        Err(why) => tracing::warn!(
+            layer = %layer.display(),
+            why = %why,
+            "citizen layer object sharing failed — layer keeps its own objects"
+        ),
+    }
 }
 
 /// Drop a short teaching note at the workspace root after a shared sync — the
@@ -2151,6 +2250,25 @@ mod tests {
         // clone exercised end-to-end with zero global-cwd mutation. #191.
         let base = tempfile::tempdir().expect("base");
         std::fs::write(base.path().join("Cargo.toml"), "[workspace]\n").unwrap();
+        // The base is a git repo with one commit and one IGNORED cache dir — the
+        // shape the shared clone must NOT carry (2026-09-06: 4.5 GB of ignored model
+        // caches rode into every citizen copy).
+        std::fs::write(base.path().join(".gitignore"), "tools/models/\n").unwrap();
+        std::fs::create_dir_all(base.path().join("tools/models")).unwrap();
+        std::fs::write(base.path().join("tools/models/weights.bin"), "big").unwrap();
+        for args in [
+            vec!["init", "-q", "-b", "main"],
+            vec!["add", "-A"],
+            vec!["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "base"],
+        ] {
+            let ok = std::process::Command::new("git")
+                .current_dir(base.path())
+                .args(args)
+                .status()
+                .expect("git")
+                .success();
+            assert!(ok);
+        }
         let home = tempfile::tempdir().expect("home");
         std::env::set_var("CONTINUUM_HOME", home.path());
 
@@ -2167,7 +2285,17 @@ mod tests {
         );
         assert!(
             layer.join("Cargo.toml").is_file(),
-            "layer is seeded from the base (CoW clone)"
+            "layer is seeded from the base (shared clone)"
+        );
+        let alternates = std::fs::read_to_string(layer.join(".git/objects/info/alternates"))
+            .expect("a shared clone names the base's objects");
+        assert!(
+            alternates.trim().ends_with(".git/objects"),
+            "objects come from the base, never copied: {alternates}"
+        );
+        assert!(
+            !layer.join("tools/models").exists(),
+            "an ignored cache in the base never rides into the layer"
         );
         // A peer WRITE lands in the layer, never the base.
         std::fs::write(layer.join("Cargo.toml"), "[dependencies]\n").unwrap();

--- a/core/continuum-core/src/modules/code_commands.rs
+++ b/core/continuum-core/src/modules/code_commands.rs
@@ -170,9 +170,28 @@ fn ensure_citizen_layer_from_base(
     // the base through `.git/objects/info/alternates`, so the layer's marginal disk is
     // her working tree plus her own commits. `git_sync_from_shared` (fetch + merge) is
     // unchanged — it never depended on the copy.
+    // The clone source is the base's repository ROOT: production hands the core's cwd
+    // (the checkout root), but a caller standing inside the tree (a test in
+    // core/continuum-core) means the same repository, and `git clone` wants the root.
+    // A base outside any repository is a loud error — a citizen layer without a
+    // repository is not a workspace.
+    let toplevel = std::process::Command::new("git")
+        .current_dir(base)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .map_err(|e| CommandError::Internal(format!("citizen layer: git rev-parse spawn failed: {e}")))?;
+    if !toplevel.status.success() {
+        return Err(CommandError::Internal(format!(
+            "citizen layer: base {} is not inside a git repository ({}) — a layer is a shared \
+             clone of the checkout and cannot be provisioned from a bare directory",
+            base.display(),
+            String::from_utf8_lossy(&toplevel.stderr).trim()
+        )));
+    }
+    let repo_root = std::path::PathBuf::from(String::from_utf8_lossy(&toplevel.stdout).trim());
     let out = std::process::Command::new("git")
         .args(["clone", "--shared", "--quiet"])
-        .arg(base)
+        .arg(&repo_root)
         .arg(&layer)
         .output()
         .map_err(|e| CommandError::Internal(format!("citizen layer clone spawn failed: {e}")))?;
@@ -189,7 +208,7 @@ fn ensure_citizen_layer_from_base(
     // The vendored inference engine rides along as a submodule; reference the base's
     // copy so its objects are shared too. Bounded and named: a layer without the vendor
     // tree still gives her hands (the core serves inference, not her checkout).
-    let vendor = init_vendor_submodule(&layer, base);
+    let vendor = init_vendor_submodule(&layer, &repo_root);
     crate::probe!(
         class = "workspace.layer.provision",
         peer = %peer,
@@ -257,7 +276,7 @@ fn share_layer_objects_with_base(layer: &std::path::Path, base: &std::path::Path
         return;
     }
     let want = format!("{}\n", base_objects.display());
-    if std::fs::read_to_string(&alternates).map(|s| s == want).unwrap_or(false) {
+    if std::fs::read_to_string(&alternates).map(|s| s == want).unwrap_or(false) { // unwrap_or: no/unreadable alternates = not yet shared; the migration below writes it
         return;
     }
     let started = std::time::Instant::now();
@@ -276,7 +295,7 @@ fn share_layer_objects_with_base(layer: &std::path::Path, base: &std::path::Path
         let mut dropped = 0usize;
         if let Ok(entries) = std::fs::read_dir(layer.join(".git").join("worktrees")) {
             for entry in entries.flatten() {
-                let gitdir = std::fs::read_to_string(entry.path().join("gitdir")).unwrap_or_default();
+                let gitdir = std::fs::read_to_string(entry.path().join("gitdir")).unwrap_or_default(); // unwrap_or_default: an unreadable gitdir marker is a broken entry the copy inherited — empty never names this layer, so it is dropped with the foreign ones
                 if !gitdir.trim().starts_with(&layer.display().to_string()) {
                     let _ = std::fs::remove_dir_all(entry.path());
                     dropped += 1;

--- a/core/continuum-core/src/modules/code_commands.rs
+++ b/core/continuum-core/src/modules/code_commands.rs
@@ -189,6 +189,7 @@ fn ensure_citizen_layer_from_base(
         )));
     }
     let repo_root = std::path::PathBuf::from(String::from_utf8_lossy(&toplevel.stdout).trim());
+    protect_shared_objects(&repo_root);
     let out = std::process::Command::new("git")
         .args(["clone", "--shared", "--quiet"])
         .arg(&repo_root)
@@ -264,6 +265,43 @@ fn init_vendor_submodule(layer: &std::path::Path, base: &std::path::Path) -> Str
     }
 }
 
+/// The moment a layer starts borrowing the base's objects, the base stops being
+/// safe to gc: `git-clone(1)` on `--shared` — "if you delete branches in the source
+/// repository, some objects may become dangling" — and a routine auto-gc in the base
+/// would then corrupt EVERY resident citizen's workspace at once (review on #3795).
+/// `extensions.preciousObjects = true` makes gc/prune in the base refuse to drop
+/// objects. Idempotent; a failure to set it is loud and the provisioning stops,
+/// because a layer over an unprotected base is a repo-corruption timer, not a workspace.
+fn protect_shared_objects(base: &std::path::Path) {
+    let already = std::process::Command::new("git")
+        .current_dir(base)
+        .args(["config", "--get", "extensions.preciousObjects"])
+        .output()
+        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "true")
+        .unwrap_or(false); // unwrap_or: a failed read means "not known to be set" — we set it below and check that
+    if already {
+        return;
+    }
+    let set = std::process::Command::new("git")
+        .current_dir(base)
+        .args(["config", "extensions.preciousObjects", "true"])
+        .status()
+        .map(|st| st.success())
+        .unwrap_or(false); // unwrap_or: a spawn failure is a failure to set; named below
+    crate::probe!(
+        class = "workspace.layer.base_protected",
+        base = %base.display(),
+        set,
+        "extensions.preciousObjects on the base repository — the citizens' shared objects survive its gc"
+    );
+    if !set {
+        tracing::error!(
+            base = %base.display(),
+            "could not set extensions.preciousObjects on the base — every shared citizen layer is one base gc away from corruption"
+        );
+    }
+}
+
 /// Migrate a layer provisioned by the old `cp -cR` shape to share its objects with
 /// the base: write `alternates`, repack keeping only objects the base lacks, and drop
 /// the worktree metadata the copy inherited from the base. Idempotent (a layer that
@@ -276,6 +314,7 @@ fn share_layer_objects_with_base(layer: &std::path::Path, base: &std::path::Path
         return;
     }
     let want = format!("{}\n", base_objects.display());
+    protect_shared_objects(base);
     if std::fs::read_to_string(&alternates).map(|s| s == want).unwrap_or(false) { // unwrap_or: no/unreadable alternates = not yet shared; the migration below writes it
         return;
     }
@@ -2315,6 +2354,16 @@ mod tests {
         assert!(
             !layer.join("tools/models").exists(),
             "an ignored cache in the base never rides into the layer"
+        );
+        let precious = std::process::Command::new("git")
+            .current_dir(base.path())
+            .args(["config", "--get", "extensions.preciousObjects"])
+            .output()
+            .expect("git config");
+        assert_eq!(
+            String::from_utf8_lossy(&precious.stdout).trim(),
+            "true",
+            "the base is protected from gc the moment a layer borrows its objects (review on #3795)"
         );
         // A peer WRITE lands in the layer, never the base.
         std::fs::write(layer.join("Cargo.toml"), "[dependencies]\n").unwrap();

--- a/core/continuum-core/src/system_resources/disk_eviction.rs
+++ b/core/continuum-core/src/system_resources/disk_eviction.rs
@@ -669,7 +669,26 @@ mod tests {
         // a served model); there is nothing unsafe here to defer for.
         let owned = ["cargo-target", "genome-models", "logs", "probes"];
         let deferred = [
-            ("hf-hub", "#155: hub LRU keyed on last-access — downloads are re-fetchable"),
+            (
+                "hf-hub",
+                "#155: hub LRU keyed on last-access — downloads are re-fetchable. Measured \
+                 2026-09-06 (M5): 51 GB of `models--*` blobs, every one a staging copy of a \
+                 GGUF already promoted into the `models` store; the owner evicts a hub entry \
+                 the moment its artifact is present in the store, and the rest by last access",
+            ),
+            // Registered 2026-09-06, the day the M5 hit zero free with 360 GB here and the
+            // governor unable to see it. Two sub-classes: SERVED weights (the catalog's
+            // active/pinned/roster tiers — never blind-deleted, same rule as genome-models'
+            // NvmeServingTierPool) and UNROSTERED weights (a store entry matching no catalog
+            // id: two concluded experiments held 186 GB that day). The owner evicts the
+            // second class oldest-access first and must ask the registry resolver, never a
+            // name heuristic, whether an entry is on a serving path.
+            (
+                "models",
+                "58c27b0c/#155: unrostered-weights pool — evict store entries the registry \
+                 resolves to NO catalog id and no active/pinned lane, oldest access first; \
+                 served tiers are the NvmeServingTierPool's, never this pool's",
+            ),
             (
                 "eval-captures",
                 "#155: age-based sweep — every file is a re-creatable diagnostic (kv-diag \
@@ -677,7 +696,21 @@ mod tests {
                  opt-in and quiet by default, so the class grows only while an operator is \
                  actively hunting. Owner when built: a capped appender like the log pool",
             ),
-            ("citizens", "#155/#49: workspace CoW fix removes the bulk; stores are persona MEMORY, never auto-evicted"),
+            // Measured 2026-09-06 (M5, the day the disk hit zero): 33 workspace copies of the
+            // repo (12 resident citizens, 21 dormant), 7–20 GB EACH, none of it hers: a 7.6 GB
+            // .git holding the canonical clone's history plus COPIED stale worktree metadata
+            // (5 × 462 MB of vendored llama.cpp packs per copy), 4.5 GB of gitignored model
+            // caches (tools/models), 2 GB of mobile build output, node_modules. The by-hand
+            // eviction that day (alternates to the canonical objects + repack -l, ignored
+            // dirs dropped, dormant copies patch-then-dropped) is the pool's spec.
+            (
+                "citizens",
+                "58c27b0c: (1) a workspace is a `--shared` clone of the canonical repo, never \
+                 a copy — no history, no ignored caches, no foreign worktree metadata; (2) a \
+                 DORMANT citizen's workspace (uuid on no roster, no turn for 7 days) is \
+                 patch-then-dropped: dirty checkouts archived as <inst>.patch + base sha, \
+                 tree removed; stores are persona MEMORY, never auto-evicted",
+            ),
             // Sibling of `citizens` and inherits its rule: a LIVE mind's longterm.db and
             // working-set.json are MEMORY, never auto-evicted. What IS evictable is the
             // GHOST sub-class — a dir whose uuid appears in no roster and which never

--- a/core/continuum-core/src/system_resources/disk_reporters.rs
+++ b/core/continuum-core/src/system_resources/disk_reporters.rs
@@ -186,6 +186,13 @@ pub fn standard_tracked_dirs(home: &std::path::Path) -> Vec<Arc<TrackedDir>> {
 
     let mut dirs = vec![
         TrackedDir::new("cargo-target", home.join(".continuum/cache/cargo-target")),
+        // The served-weights store. UNTRACKED until 2026-09-06 — the largest class on the
+        // volume (360 GB on the M5 that day: Flash-Next 123, Kimi-Linear 95, DeepSeek-V4-Flash
+        // 91, Qwen3.8-27B 20, Ornith 20) and invisible to both halves of the governed-disk
+        // contract while the disk went from 46 GB free to ZERO under a test build. 186 GB of
+        // it was weights on NO serving path (two concluded experiments), which is exactly the
+        // sub-class an owner evicts: not in the catalog, not the active or pinned model.
+        TrackedDir::new("models", home.join(".continuum/models")),
         TrackedDir::new("genome-models", home.join(".continuum/genome/models")),
         TrackedDir::new("citizens", home.join(".continuum/citizens")),
         // Per-persona durable mind state: longterm.db + working-set.json, one dir per uuid.


### PR DESCRIPTION
## The incident
2026-09-06 12:2xZ, the M5 went from 46 GB free to zero under a test build (the tool harness could not open an output file). What held the volume: the **untracked** model store (360 GB; 186 GB of weights on no serving path), a 51 GB Hugging Face hub cache duplicating GGUFs already in the store, and **33 citizen workspace copies at 7–20 GB each**. `ensure_citizen_layer` did `cp -cR` of the whole checkout — copy-on-write on day one, then every block materialized as the base moved; each copy carried the canonical `.git` with five stale worktree entries (462 MB of vendored packs each), 4.5 GB of gitignored model caches and node_modules.

## Source fix
- A layer is `git clone --shared` of the base: objects via `alternates`, tracked tree only; the vendored engine comes in as a `--reference` submodule, bounded (600 s) with a named outcome.
- An existing copy migrates on ensure: alternates + `repack -a -d -l`, foreign worktree entries dropped; `workspace.layer.objects_shared` probe. `git_sync_from_shared` is unchanged.

## Ledger
`~/.continuum/models` joins `standard_tracked_dirs` with a decided owner (unrostered-weights pool through the registry resolver; served tiers stay the NvmeServingTierPool's). `hf-hub` and `citizens` entries carry the day's numbers and the pool spec that was executed by hand.

## Tests
Citizen-layer test's base is now a git repo with an ignored cache: the layer names the base's objects and never carries the cache. `system_resources::disk_eviction` + `disk_reporters` + `modules::code_commands` green; `cargo check --release --features metal,accelerate` green.

## Acceptance verb (after deploy)
`debug/probes/query {"class":"workspace.layer.objects_shared"}` shows one row per resident citizen on first ensure; `du -sh ~/.continuum/citizens/peers/*/workspace/.git` reads tens of MB, not GB, for a freshly provisioned citizen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo