### PR TITLE
chore(airc): pin accabc282 — the wall cache; projection caches governed; Devstral never the citizens' model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "airc-bus"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-core",
  "async-stream",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "airc-core"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "serde",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "airc-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "serde",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "airc-identity"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "airc-ipc"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "airc-lib"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "airc-protocol"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-core",
  "chacha20poly1305",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "airc-relay"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "airc-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "airc-transport"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-core",
  "airc-diagnostics",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "airc-trust"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "airc-wire"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-bus",
  "airc-core",
@@ -301,7 +301,7 @@ dependencies = [
 [[package]]
 name = "airc-work"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-core",
  "airc-protocol",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "airc-work-store"
 version = "0.1.0"
-source = "git+https://github.com/CambrianTech/airc?rev=78e7946e8#78e7946e8d400a5e594373eb6bceef859ca18031"
+source = "git+https://github.com/CambrianTech/airc?rev=accabc282#accabc28237a8622db5009586f4d5e528647e961"
 dependencies = [
  "airc-core",
  "airc-store",
@@ -454,7 +454,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3712,7 +3712,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4015,7 +4015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4865,7 +4865,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5537,7 +5537,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -7101,7 +7101,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9482,7 +9482,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10259,7 +10259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10768,7 +10768,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12643,7 +12643,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,18 +185,18 @@ members = [
 # room is still its default under either verb. This is what continuum's
 # room/join needs (task #65, Joel: a persona is first-class and can subscribe to
 # many rooms). Also fixes `RoomJoinedBody.is_default`, previously hardcoded true.
-airc-core = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
-airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
-airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
-airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
-airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
+airc-core = { git = "https://github.com/CambrianTech/airc", rev = "accabc282" }
+airc-protocol = { git = "https://github.com/CambrianTech/airc", rev = "accabc282" }
+airc-ipc = { git = "https://github.com/CambrianTech/airc", rev = "accabc282" }
+airc-lib = { git = "https://github.com/CambrianTech/airc", rev = "accabc282" }
+airc-wire = { git = "https://github.com/CambrianTech/airc", rev = "accabc282" }
 # airc-work: the work-board domain (cards/lanes/PRs). `Airc::work_board`
 # returns a `WorkBoardProjection` whose types (`WorkCard`, `LaneRecord`,
 # `CardState`, …) the positron kanban projector maps → `KanbanViewState`
 # at the seam. Only continuum-core (the projector) depends on it; the
 # neutral `continuum-positron` contract crate MIRRORS these enums and
 # must NOT depend on airc-work.
-airc-work = { git = "https://github.com/CambrianTech/airc", rev = "78e7946e8" }
+airc-work = { git = "https://github.com/CambrianTech/airc", rev = "accabc282" }
 
 # Candle ML framework — patched via [patch.crates-io] below.
 # Fixes: Metal buffer pool leak (#2271), RoPE NEOX convention (#3410)

--- a/core/continuum-core/src/model_registry/catalog.rs
+++ b/core/continuum-core/src/model_registry/catalog.rs
@@ -443,6 +443,10 @@ pub fn models() -> Vec<Model> {
         // Tekken (starting with the single-party collapse the coders use); stop uses Mistral's `</s>`.
         model(ModelSpec {
             id: "unsloth/Devstral-Small-2507-GGUF",
+            // Joel 2026-09-06: NOT a base model for us — old, text-only. It served the M5 for
+            // 35 minutes that day only because the boot plan picked the smallest fit from the
+            // store (card 40f53419). Benchmark opponent at most; never the citizens' model.
+            persona_serving_eligible: false,
             name: "Devstral-Small-2507 (agentic coder)",
             provider: "llama-server",
             arch: Arch::Mistral,

--- a/core/continuum-core/src/system_resources/disk_eviction.rs
+++ b/core/continuum-core/src/system_resources/disk_eviction.rs
@@ -735,6 +735,23 @@ mod tests {
             // generation's pages — that wants a pool that asks the slot pool which
             // activities are resident (their pages are one eviction from being
             // needed) versus departed, never a blind LRU.
+            // airc's per-room projection snapshots (operator scope; the personas' live under
+            // `citizens`). Size is O(rooms × projection): the board snapshot is the folded
+            // board (cards, not events), the wall snapshot is the room's posts (few). Both
+            // are accelerators rebuilt from the transcript on any anomaly, so eviction is
+            // always safe; what they want is a sweep keyed on the room directory — a
+            // snapshot for a room that is archived or no longer subscribed is dead weight.
+            (
+                "airc-board-cache",
+                "1291173d/#155: sweep snapshots of rooms absent from the directory or \
+                 archived; rebuilt from the transcript on the next read, so deletion is \
+                 always safe",
+            ),
+            (
+                "airc-wall-cache",
+                "airc#1390/#155: same sweep as airc-board-cache — one file per room, the \
+                 room's posts; rebuilt on the next read",
+            ),
             (
                 "kv-pages",
                 "#155: broker-reachable pool keyed on slot-pool residency; the \

--- a/core/continuum-core/src/system_resources/disk_reporters.rs
+++ b/core/continuum-core/src/system_resources/disk_reporters.rs
@@ -213,6 +213,15 @@ pub fn standard_tracked_dirs(home: &std::path::Path) -> Vec<Arc<TrackedDir>> {
         // `tracing_init` was exactly that until today) accumulates
         // invisibly. Owner: `RotationLogPool` — see
         // `super::rotation_log_pool`.
+        // airc's transcript-projection snapshots for the OPERATOR scope (each persona's ride
+        // inside her airc home under `citizens`): the work board's (shipped untracked, card
+        // 1291173d) and the wall's (airc#1390, 2026-09-06). One JSON per room; the wall one
+        // holds every post on the room, the board one the folded projection. Registered on
+        // the pin bump that adopted the wall cache, on the reviewer's point that a cache
+        // growing with room depth on 200k–470k-event rooms is exactly the class the
+        // 2026-07-13 rule exists to catch before it is the incident.
+        TrackedDir::new("airc-board-cache", home.join(".airc/work-board-cache")),
+        TrackedDir::new("airc-wall-cache", home.join(".airc/wall-cache")),
         TrackedDir::new("logs", home.join(".continuum/logs")),
         TrackedDir::new("probes", home.join(".continuum/probes")),
         // #312 ephemeral exam worlds: one CoW clone of the checkout per eval run


### PR DESCRIPTION
## What
- Pin airc to accabc282 (airc#1390: `wall_posts_in` is a cached projection resumed from its cursor, like the board).
- Per the #1390 reviewer: the operator scope's `work-board-cache` and `wall-cache` join `standard_tracked_dirs` with a decided sweep (snapshots of rooms absent from the directory; rebuilt on the next read).
- `unsloth/Devstral-Small-2507-GGUF` gets `persona_serving_eligible: false` — Joel: not a base model for us; it served the M5 for 35 minutes today only because the boot plan picked the smallest fit from the store.

## Acceptance (after deploy)
`debug/probes/query {"class":"wall.read.phase"}` shows `exit` rows with `wall_ms` well under the 30 s perception deadline from the second read on, on every node. A reboot never lands Devstral on the citizens' lanes.

`cargo check --release --features metal,accelerate` green; disk ledger suites green on the sibling PR #3795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo