### PR TITLE
fix(routing): a node answers command requests for every citizen it hosts, not only its runtime peer

### DIFF
--- a/core/continuum-core/src/routing/command_handler.rs
+++ b/core/continuum-core/src/routing/command_handler.rs
@@ -475,6 +475,38 @@ pub(crate) fn addressed_to(target: &airc_core::MentionTarget, me: PeerId) -> boo
     matches!(target, airc_core::MentionTarget::Peer(p) if *p == me)
 }
 
+/// A node answers for EVERY peer it hosts: its own runtime peer and each resident
+/// citizen's airc peer. #3784 made only the addressed peer answer, and the handler
+/// runs under the node's runtime identity — so a request addressed to a hosted
+/// PERSONA (`ai/generate {aircPeer: <her peer id>}`, the whole point of the grid)
+/// was dropped by name and the requester ate the 30 s deadline (IntelMac probe 2,
+/// identical 30,001 ms on two builds with delivery acked at 32 ms rtt).
+pub(crate) fn addressed_to_hosted(
+    target: &airc_core::MentionTarget,
+    me: PeerId,
+    hosted: &[PeerId],
+) -> bool {
+    match target {
+        airc_core::MentionTarget::Peer(p) => *p == me || hosted.contains(p),
+        _ => false,
+    }
+}
+
+/// The airc peer ids of the citizens this node hosts right now — empty when the
+/// persona registry is not up (a node hosting nothing answers only for itself).
+fn hosted_peer_ids() -> Vec<PeerId> {
+    let Some(registry) = crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global()
+    else {
+        return Vec::new();
+    };
+    registry
+        .live_personas()
+        .into_iter()
+        .filter_map(|id| registry.get(id))
+        .map(|runtime| runtime.airc().peer_id())
+        .collect()
+}
+
 #[async_trait]
 impl ConsumerAdapter for CommandRequestHandler {
     fn name(&self) -> &'static str {
@@ -494,12 +526,14 @@ impl ConsumerAdapter for CommandRequestHandler {
         // A request for another peer is not ours to answer; a request for nobody in
         // particular is not a peer RPC (only kind=peer is wired) — both are ignored
         // by name, never answered.
-        if !addressed_to(&envelope.target, self.airc.peer_id()) {
+        let hosted = hosted_peer_ids();
+        if !addressed_to_hosted(&envelope.target, self.airc.peer_id(), &hosted) {
             crate::probe!(
                 class = "airc.command.request_not_for_me",
                 target = ?envelope.target,
                 me = %self.airc.peer_id().0,
-                "command request addressed to another peer (or to nobody) — not answering"
+                hosted = hosted.len(),
+                "command request addressed to a peer this node does not host (or to nobody) — not answering"
             );
             return Ok(());
         }
@@ -565,6 +599,13 @@ mod tests {
     fn only_the_addressed_peer_answers_a_command_request() {
         let me = PeerId::new();
         let other = PeerId::new();
+        // what this catches (probe 2, 2026-09-06): a request for a citizen THIS node
+        // hosts must be answered by this node's handler, which runs as the runtime peer.
+        let citizen = PeerId(Uuid::new_v4());
+        assert!(addressed_to_hosted(&MentionTarget::Peer(citizen), me, &[citizen]));
+        assert!(!addressed_to_hosted(&MentionTarget::Peer(citizen), me, &[]), "not hosted here");
+        assert!(addressed_to_hosted(&MentionTarget::Peer(me), me, &[]));
+        assert!(!addressed_to_hosted(&MentionTarget::All, me, &[citizen]));
         assert!(addressed_to(&MentionTarget::Peer(me), me));
         assert!(!addressed_to(&MentionTarget::Peer(other), me), "another peer's request is not ours");
         assert!(!addressed_to(&MentionTarget::All, me), "a broadcast is not a peer RPC");


### PR DESCRIPTION
## What
`addressed_to_hosted(target, me, hosted)`: the command-request handler answers when the target is the node's runtime peer OR any resident citizen's airc peer (from `PersonaAircRuntimeRegistry`). The `airc.command.request_not_for_me` probe now carries the hosted count.

## Why (measured)
#3784 made only the addressed peer answer, which was right, but the handler runs as the node's runtime peer, so a request addressed to a hosted persona — `ai/generate {aircPeer: <her peer id>}`, the grid's whole point — was dropped by name. IntelMac's probe 2 measured an identical 30,001 ms timeout on two builds with delivery acked at 32 ms rtt. Before #3784 the same request was answered by whoever heard it first (a loopback), so the hop has never worked end to end.

## Acceptance verb
Probe 2 on any two nodes running this: a remote `ai/generate` addressed to a named citizen returns her adapter's answer, not a timeout; the responder's `request_not_for_me` rows drop to requests for peers it truly does not host.

## Tests
`routing::command_handler` 16/16 (new: hosted citizen answered, unhosted refused, broadcast refused); `cargo check --release --features metal,accelerate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo