### PR TITLE
feat(persona): a citizen can be assigned a model served by a PEER — the durable half

### DIFF
--- a/core/continuum-core/src/commands/persona/reassign_model.rs
+++ b/core/continuum-core/src/commands/persona/reassign_model.rs
@@ -80,6 +80,27 @@ pub struct PersonaReassignModelParams {
     /// when she reassigns herself as a tool. Recorded on the override for audit.
     #[serde(default)]
     pub set_by: Option<String>,
+    /// The airc peer whose lane serves `model_id`, when her brain is to run OFF-BOX.
+    ///
+    /// Omit it (the default) and the assignment is local: `serving/pin` fit-gates the
+    /// model on THIS host and refuses loud if it is unknown, not downloaded, or won't
+    /// fit — unchanged behaviour.
+    ///
+    /// Pass it and the local fit-gate is deliberately SKIPPED, because the point is
+    /// that this host cannot serve the model: the named peer does. That is the whole
+    /// value for a node below the cognition floor — measured on IntelMac 2026-09-06,
+    /// whose only local model returns 39–42 character bare tool calls with an empty
+    /// intent, while a cross-grid `ai/generate` addressed to a citizen on another node
+    /// answered in 409 ms from that node's adapter.
+    ///
+    /// This is the DURABLE half only. Materialising her adapter as an
+    /// `AircRemoteInferenceAdapter` pinned to this peer happens where the allocator
+    /// reads the override (`persona/allocator.rs`, via `commands/persona/allocate.rs`)
+    /// and is the next slice of card `1d2f65e7`. Until that lands, the record persists
+    /// and the allocator still resolves her locally — so this flag is inert rather
+    /// than half-wired, and `models_remote` in the report says so.
+    #[serde(default)]
+    pub remote_peer: Option<String>,
 }
 
 /// What `persona/reassign-model` did: the durable assignment that now sticks, and
@@ -100,6 +121,13 @@ pub struct ReassignModelReport {
     /// `true` once the durable per-persona override is written — i.e. the
     /// assignment will survive a restart, not just this session.
     pub override_persisted: bool,
+    /// The peer serving her model when the assignment is OFF-BOX; `None` for a
+    /// local assignment. Present so a caller can tell the two apart without
+    /// re-reading the override — a remote assignment did NOT fit-gate this host and
+    /// did NOT pin anything here, so `previous_model` is meaninglessly `None` for it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub remote_peer: Option<String>,
     /// Human-readable summary.
     pub detail: String,
 }
@@ -160,39 +188,73 @@ crate::action_command! {
         // 2. Compose serving/pin — its fit-gate is the single source of "can this
         //    host actually serve that model". If it refuses, the reassignment is
         //    refused as a whole and NOTHING is persisted (no silent downgrade).
-        let executor = this
-            .executor
-            .require()
-            .map_err(CommandError::Internal)?
-            .clone();
-        let pin_outcome = executor
-            .execute(
-                "serving/pin",
-                serde_json::json!({ "model_id": p.model_id }),
-            )
-            .await;
-        let pin_value = match pin_outcome {
-            Ok(result) => result.to_json_value().map_err(CommandError::Internal)?,
-            Err(e) => {
-                return Err(CommandError::Denied(format!(
-                    "cannot reassign '{}' to '{}': serving/pin refused it — {e}. \
-                     Nothing was changed; the persona keeps her current model.",
-                    p.persona, p.model_id
-                )));
+        //
+        //    SKIPPED ENTIRELY for a remote assignment. The fit-gate asks "can THIS
+        //    host hold it", and for `remote_peer` the answer is expected to be no —
+        //    that is the reason the peer was named. Running it anyway would refuse
+        //    every off-box assignment on exactly the nodes that need one. This is a
+        //    deliberate bypass of a gate, not a fallback: the local path keeps its
+        //    gate unchanged, and the remote path is a different question that this
+        //    gate cannot answer ([[substrate-gate-vs-persona-cognition]]).
+        let (pin_composed, previous_model) = match p.remote_peer.as_deref() {
+            None => {
+                let executor = this
+                    .executor
+                    .require()
+                    .map_err(CommandError::Internal)?
+                    .clone();
+                let pin_outcome = executor
+                    .execute(
+                        "serving/pin",
+                        serde_json::json!({ "model_id": p.model_id }),
+                    )
+                    .await;
+                let pin_value = match pin_outcome {
+                    Ok(result) => result.to_json_value().map_err(CommandError::Internal)?,
+                    Err(e) => {
+                        return Err(CommandError::Denied(format!(
+                            "cannot reassign '{}' to '{}': serving/pin refused it — {e}. \
+                             Nothing was changed; the persona keeps her current model.",
+                            p.persona, p.model_id
+                        )));
+                    }
+                };
+                let previous = pin_value
+                    .get("previous_model")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                (true, previous)
+            }
+            Some(peer) => {
+                // The peer id must be a peer UUID. Refuse a malformed one HERE rather
+                // than persisting a record that can never resolve to a route — the
+                // same reason the airc interceptor refuses a bad `aircPeer` by name
+                // in ~1ms instead of timing out at 30s.
+                if uuid::Uuid::parse_str(peer).is_err() {
+                    return Err(CommandError::Invalid(format!(
+                        "remote_peer '{peer}' is not a peer UUID — pass the peer id of a \
+                         citizen or node that serves '{}'. Nothing was persisted.",
+                        p.model_id
+                    )));
+                }
+                (false, None)
             }
         };
-        let previous_model = pin_value
-            .get("previous_model")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
 
         // 3. The model is proven servable and now pinned — persist the durable
         //    per-persona assignment. A disk failure here leaves the host live on the
         //    model but the record un-persisted: fail loud and say exactly that, so
         //    the operator knows it won't survive a restart (we do NOT silently
         //    unpin — that would hide the disk fault behind a "reverted" lie).
-        let override_record =
-            PersonaModelOverride::new(p.model_id.clone(), p.set_by.clone(), now_ms());
+        let override_record = match p.remote_peer.as_deref() {
+            None => PersonaModelOverride::new(p.model_id.clone(), p.set_by.clone(), now_ms()),
+            Some(peer) => PersonaModelOverride::new_remote(
+                p.model_id.clone(),
+                p.set_by.clone(),
+                now_ms(),
+                peer,
+            ),
+        };
         override_record.write(&home).map_err(|e| {
             CommandError::Internal(format!(
                 "host is now serving '{}' for '{}' but persisting her durable assignment failed: {e}. \
@@ -202,7 +264,16 @@ crate::action_command! {
             ))
         })?;
 
-        let detail = match &previous_model {
+        let detail = match p.remote_peer.as_deref() {
+            Some(peer) => format!(
+                "'{}' is assigned '{}' served by peer {peer} — her brain runs OFF-BOX. \
+                 This host was NOT fit-gated and is not serving it. Persisted for next boot. \
+                 NOTE: adapter materialisation is the next slice of card 1d2f65e7; until it \
+                 lands the allocator still resolves her locally, so this record is durable \
+                 but not yet load-bearing.",
+                p.persona, p.model_id
+            ),
+            None => match &previous_model {
             Some(prev) if prev == &p.model_id => format!(
                 "'{}' was already serving '{}'; pin held and her durable assignment is now recorded",
                 p.persona, p.model_id
@@ -215,13 +286,17 @@ crate::action_command! {
                 "reassigned '{}' to '{}' (nothing was serving); pinned now and persisted for next boot",
                 p.persona, p.model_id
             ),
+            },
         };
+
+        let _ = pin_composed;
 
         Ok(ReassignModelReport {
             persona: p.persona,
             model_id: p.model_id,
             previous_model,
             override_persisted: true,
+            remote_peer: p.remote_peer,
             detail,
         })
     }
@@ -267,6 +342,7 @@ mod tests {
                     persona: "Nonesuch".to_string(),
                     model_id: "qwen3-coder-14b".to_string(),
                     set_by: None,
+                    remote_peer: None,
                 },
             )
             .await
@@ -294,6 +370,7 @@ mod tests {
                     persona: "Asha".to_string(),
                     model_id: "qwen3-coder-14b".to_string(),
                     set_by: Some("operator".to_string()),
+                    remote_peer: None,
                 },
             )
             .await
@@ -305,4 +382,90 @@ mod tests {
             "no override may be persisted when the serving pin couldn't be attempted"
         );
     }
+    // what this catches: a REMOTE assignment must not be fit-gated by this host.
+    // Proven by the absence of an executor — `missing_executor_fails_loud_and_persists_nothing`
+    // above shows a LOCAL reassign fails Internal when the compose seam is missing,
+    // because it must reach `serving/pin`. The same call with `remote_peer` set
+    // SUCCEEDS on the same bare command, which is only possible if the pin was never
+    // attempted. That is the fit-gate skip, tested by consequence rather than by
+    // asserting on an internal branch.
+    //
+    // Card 1d2f65e7. The gate asks "can THIS host hold it"; for an off-box assignment
+    // the answer is expected to be no, so running it would refuse every remote
+    // assignment on exactly the nodes that need one (IntelMac, whose only local model
+    // is below the cognition floor).
+    #[tokio::test]
+    async fn a_remote_assignment_skips_the_local_fit_gate_and_records_the_peer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let home = resolve_home(&root, "Asha").expect("home resolves");
+        home.ensure_exists().expect("mkdir home");
+
+        let peer = "e5f4141d-1d95-4d62-8c19-97b5f8320837";
+        let cmd = cmd_with_root(root);
+        let report = cmd
+            .run(
+                &Ctx::default(),
+                PersonaReassignModelParams {
+                    persona: "Asha".to_string(),
+                    model_id: "ornith-ai/Ornith-1.5-35B-A3B-GGUF".to_string(),
+                    set_by: Some("operator".to_string()),
+                    remote_peer: Some(peer.to_string()),
+                },
+            )
+            .await
+            .expect("a remote assignment must not need a local serving pin");
+
+        assert_eq!(report.remote_peer.as_deref(), Some(peer));
+        assert!(report.override_persisted);
+        assert!(
+            report.previous_model.is_none(),
+            "nothing was pinned here, so there is no previous local model: {:?}",
+            report.previous_model
+        );
+
+        let persisted = PersonaModelOverride::load(&home)
+            .expect("load")
+            .expect("a remote assignment persists an override");
+        assert_eq!(persisted.remote_peer.as_deref(), Some(peer));
+        assert!(persisted.is_remote());
+        assert_eq!(persisted.model_id, "ornith-ai/Ornith-1.5-35B-A3B-GGUF");
+    }
+
+    // what this catches: a peer id that can never resolve to a route being written to
+    // disk, where it would fail later at adapter-materialisation time with no clue
+    // where it came from. Refused up front and NOTHING is persisted — the same shape
+    // as the airc interceptor refusing a malformed `aircPeer` by name in ~1ms instead
+    // of letting it become a 30s timeout (measured on IntelMac, four runs, 2026-09-06).
+    #[tokio::test]
+    async fn a_malformed_remote_peer_is_refused_before_anything_is_persisted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let home = resolve_home(&root, "Asha").expect("home resolves");
+        home.ensure_exists().expect("mkdir home");
+
+        let cmd = cmd_with_root(root);
+        let err = cmd
+            .run(
+                &Ctx::default(),
+                PersonaReassignModelParams {
+                    persona: "Asha".to_string(),
+                    model_id: "ornith-ai/Ornith-1.5-35B-A3B-GGUF".to_string(),
+                    set_by: None,
+                    remote_peer: Some("not-a-uuid".to_string()),
+                },
+            )
+            .await
+            .expect_err("a non-uuid peer must be refused");
+        assert!(matches!(err, CommandError::Invalid(_)), "got {err:?}");
+        assert!(
+            err.to_string().contains("not-a-uuid"),
+            "the refusal must name the bad value: {err}"
+        );
+        assert!(
+            PersonaModelOverride::load(&home).expect("load").is_none(),
+            "a refused remote assignment must persist nothing"
+        );
+    }
+
 }

--- a/core/continuum-core/src/persona/model_override.rs
+++ b/core/continuum-core/src/persona/model_override.rs
@@ -55,6 +55,24 @@ pub struct PersonaModelOverride {
     /// Who made the assignment: an operator user-id, or the persona's own id when
     /// she reassigned herself as a tool. `None` when the origin is unknown.
     pub set_by: Option<String>,
+    /// The airc peer whose lane serves `model_id`, when her brain runs OFF-BOX.
+    ///
+    /// `None` — the default and the whole prior behaviour — means this host serves
+    /// her model locally, and the assignment is fit-gated by `serving/pin` before
+    /// anything is persisted.
+    ///
+    /// `Some(peer)` means the model is **not** expected to be servable here: her
+    /// inference crosses the grid to that peer. This is the durable half of "a
+    /// citizen's brain routes to a remote lane" (card `1d2f65e7`, lifting the one
+    /// idea out of the 449-commits-behind #2250 rather than rebasing it).
+    ///
+    /// Measured 2026-09-06 on IntelMac, which is why this field exists: a node whose
+    /// only local model is below the cognition floor cannot host a useful citizen,
+    /// and the cross-grid hop it would need was demonstrated the same night —
+    /// `ai/generate` addressed to a citizen on another node returned that node's
+    /// adapter in 409 ms, with the reply naming the REMOTE host's served models.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_peer: Option<String>,
 }
 
 /// Failure modes of reading / writing a persona's model override. Every variant
@@ -87,7 +105,33 @@ impl PersonaModelOverride {
             model_id: model_id.into(),
             set_at_ms: now_ms,
             set_by,
+            remote_peer: None,
         }
+    }
+
+    /// The same assignment, but served by `peer` over airc instead of by this host.
+    ///
+    /// Separate from [`Self::new`] rather than a fourth argument: a local assignment
+    /// and a remote one are fit-gated differently (local composes `serving/pin`,
+    /// remote deliberately does not), so the two cases should not be reachable by
+    /// passing `None` to one constructor.
+    pub fn new_remote(
+        model_id: impl Into<String>,
+        set_by: Option<String>,
+        now_ms: u64,
+        peer: impl Into<String>,
+    ) -> Self {
+        Self {
+            model_id: model_id.into(),
+            set_at_ms: now_ms,
+            set_by,
+            remote_peer: Some(peer.into()),
+        }
+    }
+
+    /// Does this assignment run off-box? `true` when a peer serves her model.
+    pub fn is_remote(&self) -> bool {
+        self.remote_peer.is_some()
     }
 
     /// Read the override for a persona home. `Ok(None)` if no override file exists

--- a/protocol/typescript/persona/PersonaReassignModelParams.ts
+++ b/protocol/typescript/persona/PersonaReassignModelParams.ts
@@ -19,4 +19,26 @@ model_id: string,
  * Who is making the assignment: an operator user-id, or the persona's own id
  * when she reassigns herself as a tool. Recorded on the override for audit.
  */
-set_by: string | null, };
+set_by: string | null, 
+/**
+ * The airc peer whose lane serves `model_id`, when her brain is to run OFF-BOX.
+ *
+ * Omit it (the default) and the assignment is local: `serving/pin` fit-gates the
+ * model on THIS host and refuses loud if it is unknown, not downloaded, or won't
+ * fit — unchanged behaviour.
+ *
+ * Pass it and the local fit-gate is deliberately SKIPPED, because the point is
+ * that this host cannot serve the model: the named peer does. That is the whole
+ * value for a node below the cognition floor — measured on IntelMac 2026-09-06,
+ * whose only local model returns 39–42 character bare tool calls with an empty
+ * intent, while a cross-grid `ai/generate` addressed to a citizen on another node
+ * answered in 409 ms from that node's adapter.
+ *
+ * This is the DURABLE half only. Materialising her adapter as an
+ * `AircRemoteInferenceAdapter` pinned to this peer happens where the allocator
+ * reads the override (`persona/allocator.rs`, via `commands/persona/allocate.rs`)
+ * and is the next slice of card `1d2f65e7`. Until that lands, the record persists
+ * and the allocator still resolves her locally — so this flag is inert rather
+ * than half-wired, and `models_remote` in the report says so.
+ */
+remote_peer: string | null, };

--- a/protocol/typescript/persona/ReassignModelReport.ts
+++ b/protocol/typescript/persona/ReassignModelReport.ts
@@ -24,6 +24,13 @@ previous_model: string | null,
  */
 override_persisted: boolean, 
 /**
+ * The peer serving her model when the assignment is OFF-BOX; `None` for a
+ * local assignment. Present so a caller can tell the two apart without
+ * re-reading the override — a remote assignment did NOT fit-gate this host and
+ * did NOT pin anything here, so `previous_model` is meaninglessly `None` for it.
+ */
+remote_peer?: string, 
+/**
  * Human-readable summary.
  */
 detail: string, };


### PR DESCRIPTION
Card 1d2f65e7, lifting the one idea out of #2250 (449 commits behind, conflicting
across 15 files) rather than rebasing it, per M5's scoping.

## Why

A node whose only local model is below the cognition floor cannot host a useful
citizen. Measured on IntelMac 2026-09-06: qwen2.5-coder-0.5b returns 39-42
character bare tool calls with an EMPTY intent field, guesses three different
tool-call syntaxes on three consecutive turns, and adopts a peer's name from one
roster line against a prompt that says "You are Paige" five times.

The cross-grid hop that would fix it was demonstrated the same night:

    continuum ai/generate {aircPeer: <citizen on the M5>}
    -> 409ms, and the error came from the REMOTE adapter, enumerating the M5's
       served models (Ornith-1.5-35B, qwen3.5-4b-code-forged). This host serves
       only qwen2.5-coder-0.5b, so the reply is provably remote.

`persona/reassign-model` could not express that: it fit-gates and force-serves on
THIS host, so there was no way to assign a citizen a model another node serves.

## What

- `PersonaModelOverride` gains `remote_peer`, plus `new_remote()` and
  `is_remote()`. A separate constructor rather than a fourth argument: local and
  remote assignments are fit-gated differently, so the two cases should not be
  reachable by passing `None` to one constructor.
- `persona/reassign-model` gains a `remote_peer` param. When set, the local
  `serving/pin` fit-gate is SKIPPED — deliberately, and documented as such. The
  gate asks "can THIS host hold it"; for an off-box assignment the answer is
  expected to be no, so running it would refuse every remote assignment on
  exactly the nodes that need one. This is a scoped bypass of a gate that cannot
  answer the question, not a fallback: the local path keeps its gate unchanged.
- A malformed peer id is refused BEFORE anything is persisted, so a record that
  could never resolve to a route never reaches disk.
- The report carries `remote_peer` so a caller can distinguish the two cases
  without re-reading the override.

## What this is NOT

The DURABLE half only. Materialising her adapter as an
`AircRemoteInferenceAdapter` pinned to the peer happens where the allocator reads
the override (`persona/allocator.rs` via `commands/persona/allocate.rs`) and is
slice 2. Until it lands the record persists and the allocator still resolves her
locally — inert rather than half-wired. The command's own `detail` string says so
to the operator; this is not left for someone to discover.

## Tests, proven by mutation rather than by reading

7/7 green. Two new:

- `a_remote_assignment_skips_the_local_fit_gate_and_records_the_peer` proves the
  skip BY CONSEQUENCE: the neighbouring `missing_executor_fails_loud_and_persists_nothing`
  shows a LOCAL reassign fails Internal without the executor because it must reach
  `serving/pin`; the same bare command with `remote_peer` set SUCCEEDS, which is
  only possible if the pin was never attempted.
- `a_malformed_remote_peer_is_refused_before_anything_is_persisted`.

MUTATION: removing the fit-gate skip (forcing the local branch) failed BOTH new
tests while all three pre-existing tests still passed. The mutation also proved
the malformed-peer test load-bearing — forcing the local branch bypasses the uuid
validation entirely. The tests enforce the behaviour; they do not merely describe it.

`cargo check --release` clean; ts-rs bindings regenerated and committed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE