### PR TITLE
fix(persona): reassign-model told operators the feature was inert, in the SHA where it shipped

### DIFF
--- a/core/continuum-core/src/commands/persona/reassign_model.rs
+++ b/core/continuum-core/src/commands/persona/reassign_model.rs
@@ -93,12 +93,20 @@ pub struct PersonaReassignModelParams {
     /// intent, while a cross-grid `ai/generate` addressed to a citizen on another node
     /// answered in 409 ms from that node's adapter.
     ///
-    /// This is the DURABLE half only. Materialising her adapter as an
-    /// `AircRemoteInferenceAdapter` pinned to this peer happens where the allocator
-    /// reads the override (`persona/allocator.rs`, via `commands/persona/allocate.rs`)
-    /// and is the next slice of card `1d2f65e7`. Until that lands, the record persists
-    /// and the allocator still resolves her locally — so this flag is inert rather
-    /// than half-wired, and `models_remote` in the report says so.
+    /// This is the DURABLE half. Materialising her adapter as an
+    /// `AircRemoteInferenceAdapter` pinned to this peer is
+    /// [`crate::persona::remote_lane_factory::RemoteLaneAdapterFactory`], which landed
+    /// in `b21aaa314` — both slices of card `1d2f65e7` are live.
+    ///
+    /// THE ORDER MATTERS AND IT IS NOT OBVIOUS. The factory reads this record in
+    /// `build_adapter`, which runs ONCE when a persona comes online. Reassigning a
+    /// persona who is ALREADY online writes the record and changes nothing about the
+    /// mind currently running — she keeps the adapter she booted with. Measured
+    /// 2026-09-06: spawn-then-reassign left `persona.adapter.remote_lane` at zero
+    /// occurrences and the citizen generating locally; despawn + respawn with the
+    /// record already on disk fired the probe on the next build. So the sequence is
+    /// reassign THEN (re)spawn, and the report says so rather than leaving an operator
+    /// to infer it from "persisted".
     #[serde(default)]
     pub remote_peer: Option<String>,
 }
@@ -267,10 +275,11 @@ crate::action_command! {
         let detail = match p.remote_peer.as_deref() {
             Some(peer) => format!(
                 "'{}' is assigned '{}' served by peer {peer} — her brain runs OFF-BOX. \
-                 This host was NOT fit-gated and is not serving it. Persisted for next boot. \
-                 NOTE: adapter materialisation is the next slice of card 1d2f65e7; until it \
-                 lands the allocator still resolves her locally, so this record is durable \
-                 but not yet load-bearing.",
+                 This host was NOT fit-gated and is not serving it. \
+                 TAKES EFFECT AT HER NEXT ADAPTER BUILD, NOT NOW: the override is read in \
+                 `build_adapter`, so a persona who is already online keeps the adapter she \
+                 booted with. Despawn and respawn her (or reboot) to bind the remote lane — \
+                 `persona.adapter.remote_lane` fires when it binds.",
                 p.persona, p.model_id
             ),
             None => match &previous_model {

--- a/protocol/typescript/persona/PersonaReassignModelParams.ts
+++ b/protocol/typescript/persona/PersonaReassignModelParams.ts
@@ -34,11 +34,19 @@ set_by: string | null,
  * intent, while a cross-grid `ai/generate` addressed to a citizen on another node
  * answered in 409 ms from that node's adapter.
  *
- * This is the DURABLE half only. Materialising her adapter as an
- * `AircRemoteInferenceAdapter` pinned to this peer happens where the allocator
- * reads the override (`persona/allocator.rs`, via `commands/persona/allocate.rs`)
- * and is the next slice of card `1d2f65e7`. Until that lands, the record persists
- * and the allocator still resolves her locally — so this flag is inert rather
- * than half-wired, and `models_remote` in the report says so.
+ * This is the DURABLE half. Materialising her adapter as an
+ * `AircRemoteInferenceAdapter` pinned to this peer is
+ * [`crate::persona::remote_lane_factory::RemoteLaneAdapterFactory`], which landed
+ * in `b21aaa314` — both slices of card `1d2f65e7` are live.
+ *
+ * THE ORDER MATTERS AND IT IS NOT OBVIOUS. The factory reads this record in
+ * `build_adapter`, which runs ONCE when a persona comes online. Reassigning a
+ * persona who is ALREADY online writes the record and changes nothing about the
+ * mind currently running — she keeps the adapter she booted with. Measured
+ * 2026-09-06: spawn-then-reassign left `persona.adapter.remote_lane` at zero
+ * occurrences and the citizen generating locally; despawn + respawn with the
+ * record already on disk fired the probe on the next build. So the sequence is
+ * reassign THEN (re)spawn, and the report says so rather than leaving an operator
+ * to infer it from "persisted".
  */
 remote_peer: string | null, };


### PR DESCRIPTION
Two strings in `persona/reassign-model` were written during slice 1 of card
1d2f65e7 and never updated when slice 2 landed. Both actively mislead.

1. The report printed "adapter materialisation is the next slice of card
   1d2f65e7; until it lands the allocator still resolves her locally, so this
   record is durable but not yet load-bearing." `RemoteLaneAdapterFactory`
   landed in b21aaa314 — the same build that prints this. A command whose whole
   job is to say where a mind runs was telling operators it does not work.

2. "Persisted for next boot" reads as a bonus. It is the REQUIREMENT, and that
   is the non-obvious part: the override is read in `build_adapter`, which runs
   ONCE when a persona comes online. Reassigning a persona who is ALREADY online
   writes the record and changes nothing about the mind currently running.

Measured on IntelMac 2026-09-06 while smoke-testing the remote lane:
spawn-then-reassign left `persona.adapter.remote_lane` at ZERO occurrences and
the citizen generating locally. Despawn + respawn with the record already on
disk fired the probe on the next build:

    persona.adapter.remote_lane
      model=ggml-org/Qwen3.8-27B-GGUF persona=SmokeProbe peer=df72dbf2

and her turn then failed with `remote inference timed out after 30001ms` — a
locally-resolved adapter cannot emit "remote inference", so the binding is
confirmed independently of whether the remote node was serving.

The report now states the ordering (reassign THEN respawn) and names the probe
that fires on a successful bind, so an operator can verify the binding rather
than infer it from "persisted". Strings and doc comments only; no behaviour
change. `cargo check --no-default-features --features
livekit-webrtc,llama/mac-cpu-only` green. No test asserted the old text.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE