### PR TITLE
fix(serving): the pin survives a reboot, and a model that cannot speak is never a base candidate

### DIFF
--- a/core/continuum-core/src/commands/serving/pin.rs
+++ b/core/continuum-core/src/commands/serving/pin.rs
@@ -152,6 +152,7 @@ crate::action_command! {
         //    daemon's next tick reconciles the live server to it (sub-second to a
         //    few seconds; observe readiness via serving/status).
         this.pin.send_replace(Some(p.model_id.clone()));
+        crate::modules::serving_pin_store::save(&p.model_id);
 
         let detail = match &previous_model {
             Some(prev) if prev == &p.model_id => format!(

--- a/core/continuum-core/src/commands/serving/unpin.rs
+++ b/core/continuum-core/src/commands/serving/unpin.rs
@@ -59,6 +59,7 @@ crate::action_command! {
         let released_model = this.pin.borrow().clone();
         if released_model.is_some() {
             this.pin.send_replace(None);
+            crate::modules::serving_pin_store::clear();
         }
         let detail = match &released_model {
             Some(m) => format!(

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -86,6 +86,7 @@ pub mod runtime_control;
 pub mod sentinel;
 pub mod serving_consumer;
 pub mod serving_daemon;
+pub mod serving_pin_store;
 pub mod serving_footprints;
 pub mod serving_tier_down;
 pub mod system_resources;

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -4896,7 +4896,15 @@ mod tests {
             context_window: 262_144,
             max_output_tokens: 4096,
             tokens_per_second: 0.0,
-            capabilities: std::collections::BTreeSet::new(),
+            // A fixture row that can SPEAK: the base-model candidate set now requires
+            // TextGeneration or Chat (can_serve_minds, card af635057), and every real
+            // catalog row carries them; an empty set here would model an embedding row.
+            capabilities: [
+                crate::model_registry::types::Capability::Chat,
+                crate::model_registry::types::Capability::TextGeneration,
+            ]
+            .into_iter()
+            .collect(),
             cost_input_per_1k: 0.0,
             cost_output_per_1k: 0.0,
             gguf_hint: None,

--- a/core/continuum-core/src/modules/serving_daemon.rs
+++ b/core/continuum-core/src/modules/serving_daemon.rs
@@ -646,7 +646,20 @@ impl ServingDaemonModule {
         let (plan_tx, _rx) = watch::channel(None);
         let (serving_tx, _srx) = watch::channel(ServingSnapshot::empty());
         let (suppressed, _urx) = watch::channel(Arc::new(HashSet::new()));
-        let (pinned, _prx) = watch::channel(None);
+        // The operator's pin is durable intent: seed the channel from the store so the
+        // FIRST plan is computed under it (cards 3160b3d0 / 9552a01e — every reboot
+        // used to lose the pin and the boot planner served whatever fit).
+        let stored_pin = crate::modules::serving_pin_store::load();
+        match &stored_pin {
+            Some(pin) => crate::probe!(
+                class = "serving.pin.restored",
+                model_id = %pin.model_id,
+                set_at_ms = pin.set_at_ms,
+                "serving pin restored from the state dir before the first plan"
+            ),
+            None => crate::probe!(class = "serving.pin.none_stored", "no stored serving pin — the planner chooses"),
+        }
+        let (pinned, _prx) = watch::channel(stored_pin.map(|p| p.model_id));
         Self {
             gpu,
             system,
@@ -3802,11 +3815,34 @@ fn servable_candidates(
         .collect()
 }
 
+/// Only a model that can SPEAK is a base-model candidate. An embedding or reranking
+/// model is a real, Ready row in the catalog with a real GGUF, and the planner picked
+/// one as the base on the 5090 after a reboot (BigMama, 2026-09-06 — card af635057):
+/// nothing served, ping read ready-less, and no line said why. Pinning bypasses
+/// eligibility (operator consent) but never this: a mind cannot run on a model with
+/// no text generation.
+pub fn can_serve_minds(model: &Model) -> bool {
+    use crate::model_registry::types::Capability;
+    model.capabilities.contains(&Capability::TextGeneration)
+        || model.capabilities.contains(&Capability::Chat)
+}
+
 pub fn candidates_from_snapshot(snapshot: &CatalogSnapshot) -> Vec<ModelFootprint> {
     snapshot
         .models
         .values()
         .filter(|live| live.status.availability == Availability::Ready)
+        .filter(|live| {
+            let ok = can_serve_minds(&live.model);
+            if !ok {
+                crate::probe!(
+                    class = "serving.plan.candidate_cannot_speak",
+                    model_id = %live.model.id,
+                    "a Ready model with no text generation is not a base-model candidate"
+                );
+            }
+            ok
+        })
         .filter_map(|live| footprint_for(&live.model))
         .collect()
 }
@@ -4831,6 +4867,23 @@ mod tests {
     /// A minimal [`Model`] for reconcile-wiring tests — only `id` is load-bearing
     /// (the FakeServer ignores the rest); the planned served window rides on the
     /// `ServingTarget`, not here.
+    // what this catches (card af635057, the 5090 after a reboot): an embedding or
+    // reranking row — Ready, with a real GGUF — chosen as the base model. A mind needs
+    // text generation; a row without it is never a candidate, pinned or not.
+    #[test]
+    fn a_model_that_cannot_speak_is_never_a_base_candidate() {
+        use crate::model_registry::types::Capability;
+        let mut speaks = fake_model("chat/model");
+        speaks.capabilities = [Capability::Chat, Capability::TextGeneration].into_iter().collect();
+        assert!(can_serve_minds(&speaks));
+        let mut embeds = fake_model("embed/model");
+        embeds.capabilities = [Capability::Embedding].into_iter().collect();
+        assert!(!can_serve_minds(&embeds), "an embedding-only row cannot host a mind");
+        let mut mute = fake_model("mute/model");
+        mute.capabilities.clear();
+        assert!(!can_serve_minds(&mute), "no capabilities = no candidate, never a guess");
+    }
+
     fn fake_model(id: &str) -> Model {
         use crate::model_registry::types::{Arch, MultiPartyChatStrategy};
         Model {

--- a/core/continuum-core/src/modules/serving_pin_store.rs
+++ b/core/continuum-core/src/modules/serving_pin_store.rs
@@ -1,0 +1,149 @@
+//! The operator's serving pin, on disk (cards 3160b3d0 / 9552a01e).
+//!
+//! `serving/pin` is durable intent — "this host serves THIS model" — but the
+//! daemon held it only in a `watch` channel, so every reboot lost it and the
+//! boot planner picked whatever fit the outgoing server's memory (a 14B coder,
+//! a 27B on two lanes, an embedding model on the 5090 — measured 2026-09-06,
+//! five re-pins by hand on the M5 in one day). One JSON file under the state
+//! dir, written on pin, removed on unpin, read ONCE at daemon construction so
+//! the very first plan is computed under the pin. Loud on a corrupt file
+//! (discarded, probe), silent on a missing one (the ordinary unpinned host).
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+const FILE: &str = "serving-pin.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredServingPin {
+    pub model_id: String,
+    pub set_at_ms: u64,
+}
+
+fn path_under(home: &Path) -> PathBuf {
+    home.join("state").join(FILE)
+}
+
+/// The pin file under the continuum home, or `None` when the home is unknown
+/// (the daemon then runs unpinned, as before, and says so).
+fn default_path() -> Option<PathBuf> {
+    crate::commands::benchmark::continuum_home()
+        .ok()
+        .map(|h| path_under(&h))
+}
+
+/// Read the stored pin. Missing file = `None` silently; unreadable or corrupt
+/// = `None` with a probe naming the file — never a guessed model.
+pub fn load() -> Option<StoredServingPin> {
+    default_path().and_then(|p| load_from(&p))
+}
+
+pub fn load_from(path: &Path) -> Option<StoredServingPin> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            crate::probe!(
+                class = "serving.pin.store_unreadable",
+                path = %path.display(),
+                error = %e,
+                "serving pin file unreadable — booting unpinned, not guessing"
+            );
+            return None;
+        }
+    };
+    match serde_json::from_slice::<StoredServingPin>(&bytes) {
+        Ok(pin) => Some(pin),
+        Err(e) => {
+            crate::probe!(
+                class = "serving.pin.store_corrupt",
+                path = %path.display(),
+                error = %e,
+                "serving pin file corrupt — booting unpinned, not guessing"
+            );
+            None
+        }
+    }
+}
+
+/// Persist the pin (atomic temp + rename). A failed save is loud and non-fatal:
+/// the live pin is set either way; only the next boot loses it.
+pub fn save(model_id: &str) {
+    let Some(path) = default_path() else {
+        return;
+    };
+    save_to(&path, model_id);
+}
+
+pub fn save_to(path: &Path, model_id: &str) {
+    let pin = StoredServingPin {
+        model_id: model_id.to_string(),
+        set_at_ms: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0), // unwrap_or: a clock before 1970 is impossible on a running host; 0 only labels the record
+    };
+    let result = (|| -> std::io::Result<()> {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+        let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+        std::fs::write(&tmp, serde_json::to_vec_pretty(&pin).map_err(std::io::Error::other)?)?;
+        std::fs::rename(&tmp, path)
+    })();
+    match result {
+        Ok(()) => crate::probe!(
+            class = "serving.pin.stored",
+            model_id = %model_id,
+            path = %path.display(),
+            "serving pin persisted — survives the next reboot"
+        ),
+        Err(e) => tracing::error!(
+            model_id = %model_id,
+            path = %path.display(),
+            error = %e,
+            "serving pin NOT persisted — the pin is live now but the next reboot loses it"
+        ),
+    }
+}
+
+/// Remove the stored pin (unpin). Missing = fine.
+pub fn clear() {
+    if let Some(path) = default_path() {
+        clear_at(&path);
+    }
+}
+
+pub fn clear_at(path: &Path) {
+    match std::fs::remove_file(path) {
+        Ok(()) => crate::probe!(class = "serving.pin.cleared", path = %path.display(), "stored serving pin removed"),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => tracing::warn!(path = %path.display(), error = %e, "stored serving pin could not be removed"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches (3160b3d0 / 9552a01e): a pin that does not come back after a
+    // restart. Save → load round-trips the model id; clear → load is None; a corrupt
+    // file loads as None (unpinned, never a guessed model).
+    #[test]
+    fn a_pin_survives_a_restart_and_a_corrupt_file_never_becomes_a_model() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state").join("serving-pin.json");
+        assert!(load_from(&path).is_none(), "missing = unpinned");
+        save_to(&path, "ornith-ai/Ornith-1.5-35B-A3B-GGUF");
+        assert_eq!(
+            load_from(&path).map(|p| p.model_id).as_deref(),
+            Some("ornith-ai/Ornith-1.5-35B-A3B-GGUF")
+        );
+        std::fs::write(&path, b"{ not json").expect("corrupt");
+        assert!(load_from(&path).is_none(), "corrupt = unpinned, not guessed");
+        save_to(&path, "x/y");
+        clear_at(&path);
+        assert!(load_from(&path).is_none(), "cleared = unpinned");
+    }
+}


### PR DESCRIPTION
## What
- `modules/serving_pin_store`: `<home>/state/serving-pin.json`, written on `serving/pin`, removed on `serving/unpin`, read once at daemon construction so the first plan is computed under the pin (probes `serving.pin.restored` / `none_stored` / `stored` / `cleared`; a corrupt file boots unpinned, never a guessed model).
- `can_serve_minds` (TextGeneration or Chat) gates `candidates_from_snapshot`, the one definition of servable; a Ready embedding/reranking row is never a base candidate, pinned or not (probe `serving.plan.candidate_cannot_speak`).

## Why (measured today)
Cards 3160b3d0 / 9552a01e: five re-pins by hand on the M5 after reboots; the boot planner served a 14B coder, then the 27B on two lanes, before each re-pin. Card af635057: the 5090's planner picked an embedding model as base after BigMama's rebuild — nothing served, ping ready-less, no line saying why.

## Tests
`modules::serving_pin_store` (round-trip, corrupt → unpinned, clear) and `serving_daemon::tests::a_model_that_cannot_speak_is_never_a_base_candidate`; release check green.

## Acceptance
After a reboot with a stored pin: `serving.pin.restored` fires before the first `serving.plan` and `serving/status` reports the pinned model without an operator re-pin. A catalog with an embedding row Ready never plans it as base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo