### PR TITLE
fix(cli): the reboot refusal names benchmark/round-stop (card 0a6fabb4)

### DIFF
--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -715,10 +715,12 @@ async fn reboot(force: bool) -> Result<(), String> {
     let benches = continuum_core::cognition::swe_bench::in_flight_solve_runs();
     if !benches.is_empty() && !force {
         return Err(format!(
-            "benchmark run(s) in flight ({}) — a reboot kills them mid-drive; the round \
-             survives and the boot resume re-fires each killed solve (rejoining its room \
-             and workspace) once serving + citizens are back. Wait for them to finish, or \
-             rerun with `continuum reboot --force` to take the restart-and-resume path.",
+            "benchmark run(s) in flight ({}) — a reboot kills them mid-drive. Stop them \
+             cleanly first: `continuum benchmark/round-stop --run_id <id>` cancels at the \
+             next task boundary and keeps every streamed grade (benchmark/pause is a HOLD \
+             and leaves them running). Or wait for them, or rerun with `continuum reboot \
+             --force` to take the restart-and-resume path (the boot resume re-fires each \
+             killed solve once serving + citizens are back).",
             benches
                 .iter()
                 .map(|(run, inst)| format!("{run} on {inst}"))


### PR DESCRIPTION
Text-only change to the in-flight-runs refusal in `continuum reboot`: it now names `benchmark/round-stop --run_id <id>` (cancels at the next task boundary, keeps every streamed grade) and says that `benchmark/pause` is a hold that leaves solves running. Today's 17:00Z gate used pause, the reboot refused, and `--force` killed four solves without a receipt. The gate scripts on the M5 now call round-stop before a reboot. Slices (2)-(3) of the card (round-stop archives each stopped run's patch and reports which runs it stopped) are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo