### PR TITLE
fix(persona): a remote-bound citizen keeps her lane across serving edges; fix(cli): the core breaks away from the launcher's job on Windows

### DIFF
--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -1969,9 +1969,42 @@ async fn launch_core(wait_for_death: &[i32], policy: LaunchSource) -> Result<u64
         // not need detachment on Windows: a child is not killed when its parent exits, and
         // CREATE_NEW_PROCESS_GROUP already keeps our Ctrl+C from reaching it.
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
+        // THE CORE IS NEVER A CHILD OF ITS LAUNCHER'S JOB (card 82af11f5). A core started
+        // from an agent session on Windows died within ~45 s all evening on the 5090:
+        // the session's job object closes (KILL_ON_JOB_CLOSE) and every child dies with
+        // it. CREATE_BREAKAWAY_FROM_JOB lifts the core out of that job when the job
+        // permits breakaway; when it does not, CreateProcess fails with access denied and
+        // the spawn below retries WITHOUT the flag, naming the outcome in the start
+        // receipt — the operator then launches through a Scheduled Task (schtasks), which
+        // runs outside any job, until the supervisor slice lands.
+        const CREATE_BREAKAWAY_FROM_JOB: u32 = 0x0100_0000;
+        cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB);
     }
-    let mut child = cmd.spawn().map_err(|e| match &server_bin {
+    #[cfg(windows)]
+    let spawned = {
+        use std::os::windows::process::CommandExt;
+        match cmd.spawn() {
+            Ok(child) => {
+                eprintln!("▶ supervisor=breakaway: the core left this session's job object (survives the session)");
+                Ok(child)
+            }
+            Err(e) if e.raw_os_error() == Some(5) => {
+                eprintln!(
+                    "▶ supervisor=child (WARNING): this session's job object forbids breakaway \
+                     (access denied); the core will DIE when this session's job closes. Launch it \
+                     through a Scheduled Task instead: schtasks /create /tn continuum-core \
+                     /tr \"<the same start command>\" /sc once /st 00:00 /ru <user> /rl highest /f \
+                     && schtasks /run /tn continuum-core"
+                );
+                cmd.creation_flags(0x0000_0200 | 0x0800_0000);
+                cmd.spawn()
+            }
+            Err(e) => Err(e),
+        }
+    };
+    #[cfg(not(windows))]
+    let spawned = cmd.spawn();
+    let mut child = spawned.map_err(|e| match &server_bin {
         Some(bin) => format!("failed to spawn the core server {}: {e}", bin.display()),
         None => format!(
             "failed to spawn the source-build start script via bash: {e}. The start script \

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -1271,15 +1271,38 @@ impl PersonaWorkspaceRegistry {
         model: Option<String>,
         context_window: u32,
     ) -> usize {
+        // A citizen whose brain is assigned OFF-BOX keeps her remote binding: the
+        // local lane coming up is not her model changing (card 1d2f65e7 slice 2).
+        let root = crate::modules::persona_instance_manager::resolve_continuum_root();
+        let remote: std::collections::HashSet<Uuid> = {
+            let templates = self.templates.lock();
+            templates
+                .iter()
+                .filter(|(_, cfg)| {
+                    crate::persona::remote_lane_factory::is_remote_bound(&root, &cfg.persona_name)
+                })
+                .map(|(id, _)| *id)
+                .collect()
+        };
         let cycles = self.cycles.lock();
-        for cycle in cycles.values() {
+        let mut rehomed = 0usize;
+        for (id, cycle) in cycles.iter() {
+            if remote.contains(id) {
+                crate::probe!(
+                    class = "persona.rehome.kept_remote",
+                    persona_id = %id,
+                    "re-home skipped: her brain runs on a remote lane, the local model is not hers"
+                );
+                continue;
+            }
             cycle.rebind_model(super::llm_deliberation_faculty::ModelBinding {
                 adapter: Arc::clone(&adapter),
                 model: model.clone(),
                 context_window,
             });
+            rehomed += 1;
         }
-        cycles.len()
+        rehomed
     }
 
     /// How many persona minds are resident.

--- a/core/continuum-core/src/persona/remote_lane_factory.rs
+++ b/core/continuum-core/src/persona/remote_lane_factory.rs
@@ -81,6 +81,32 @@ pub struct RemoteLaneAdapterFactory {
     airc: Arc<tokio::sync::OnceCell<Arc<Airc>>>,
 }
 
+/// Is this persona's brain assigned to a REMOTE lane? The re-home that sweeps every
+/// resident onto a newly served local model must skip her, or the binding this
+/// factory built lasts only until the next serving edge (M5 2026-09-06 21:1xZ: Kira
+/// and Mathis were bound to the 5090 at 21:06:44 and generated on local Ornith at
+/// 21:10 after the lane came up). Reads the durable override; unreadable = not remote,
+/// loudly — a re-home never guesses a citizen off-box.
+pub(crate) fn is_remote_bound(continuum_root: &std::path::Path, persona_name: &str) -> bool {
+    let airc_dir = crate::context::citizen_home_path(
+        continuum_root,
+        crate::identity::IdentityKind::Persona,
+        None,
+        persona_name,
+    );
+    let Some(root) = airc_dir.parent() else {
+        return false;
+    };
+    let home = PersonaHome::from_root(root.to_path_buf());
+    match PersonaModelOverride::load(&home) {
+        Ok(over) => over.map(|o| o.is_remote()).unwrap_or(false), // unwrap_or: no override = local, by definition
+        Err(e) => {
+            tracing::warn!(persona = %persona_name, error = %e, "model override unreadable during re-home — treating as local");
+            false
+        }
+    }
+}
+
 impl RemoteLaneAdapterFactory {
     pub fn new(
         inner: Arc<dyn PersonaAdapterFactory>,
@@ -340,5 +366,35 @@ mod tests {
             .expect_err("a non-uuid peer cannot be routed to");
         assert_eq!(calls.load(Ordering::SeqCst), 0, "no local fallback");
         assert!(err.contains("not-a-uuid"), "must name the bad value: {err}");
+    }
+
+    // what this catches (M5 2026-09-06 21:1xZ): the serving-edge re-home sweeping a
+    // remote-bound citizen back onto the local model. A persona with a remote override
+    // on disk reads remote; one with a local override or none reads local.
+    #[test]
+    fn a_remote_override_on_disk_is_seen_by_the_rehome() {
+        let root = tempfile::tempdir().expect("root");
+        let home_root = crate::context::citizen_home_path(
+            root.path(),
+            crate::identity::IdentityKind::Persona,
+            None,
+            "Kira",
+        );
+        let home = PersonaHome::from_root(home_root.parent().expect("parent").to_path_buf());
+        std::fs::create_dir_all(home_root.parent().expect("parent")).expect("mkdir");
+        assert!(!is_remote_bound(root.path(), "Kira"), "no override = local");
+        PersonaModelOverride::new_remote(
+            "ggml-org/Qwen3.8-27B-GGUF".to_string(),
+            Some("operator".to_string()),
+            1,
+            "ce8b9074-2fca-4347-a954-a1cf720cee55",
+        )
+        .write(&home)
+        .expect("write override");
+        assert!(is_remote_bound(root.path(), "Kira"), "a remote override reads remote");
+        PersonaModelOverride::new("local/model".to_string(), Some("operator".to_string()), 2)
+            .write(&home)
+            .expect("write local");
+        assert!(!is_remote_bound(root.path(), "Kira"), "a local override reads local");
     }
 }


### PR DESCRIPTION
## What
- `re_home_all` skips a citizen whose durable model override `is_remote()` (probe `persona.rehome.kept_remote`); `remote_lane_factory::is_remote_bound` reads it. Test: a remote override on disk reads remote, a local one local.
- `launch_core` on Windows passes `CREATE_BREAKAWAY_FROM_JOB`; when the job forbids it (access denied) the spawn retries without the flag and the start receipt says `supervisor=child` with the `schtasks` command to run. Card 82af11f5 (the core is supervised, never a child of its launcher) carries the full design; this is its first slice. Compiled by the windows-msvc check.

## Why (measured today)
Kira and Mathis were bound to the 5090's 27B at 21:06:44Z ("her inference crosses the grid") and generated on local Ornith at 21:10: on every serving edge the registry re-homes every resident onto the newly served local model, so #3800's binding lasted one edge. BigMama's 5090 core died within ~45 s of every launch from an agent session all evening: the session's job object.

## Acceptance
After deploy: `persona.rehome.kept_remote` fires for the two remote-bound citizens on the next serving edge and their `delib.generate.cache` rows follow a non-local provider; on Windows the start receipt names `supervisor=breakaway` or `supervisor=child`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo