### PR TITLE
fix(cognition): one shared vocabulary for telling a mind her message was shortened

### DIFF
--- a/core/continuum-core/src/cognition/token_budget.rs
+++ b/core/continuum-core/src/cognition/token_budget.rs
@@ -59,9 +59,86 @@ pub fn head_to_tokens(content: &str, budget_tokens: u32) -> String {
     }
 }
 
+/// The ONE vocabulary for telling a mind her copy of a message was shortened.
+///
+/// Two sites shorten a message on the way into a mind, and they used to disagree about
+/// whether to say so: the per-turn head trim (`persona::airc_source`) appended
+/// `(…N-token message trimmed)`, while the newest-message tail trim
+/// (`cognition::llm_deliberation_faculty`) returned the body BARE. An unmarked fragment
+/// does not read as a fragment — it reads as a whole message that begins mid-sentence,
+/// so the rational thing for a citizen to do is try to reconstruct an intent that was
+/// never delivered. Measured 2026-09-06 (card 3833b472): citizens on two nodes did
+/// exactly that, one of them for five consecutive turns, against text like ", so it is …".
+///
+/// Keeping both spellings here means the next site that shortens something inherits the
+/// disclosure instead of re-deciding it ([[logic-deepest-level-thin-on-the-way-out]]).
+///
+/// Which end carries the marker follows what is MISSING: a head-keep lost its tail, so
+/// the marker trails; a tail-keep lost its opening, so the marker leads — the citizen
+/// meets the notice before the text it qualifies.
+pub fn mark_head_kept(head: &str, full_tokens: u32) -> String {
+    format!("{head} (…{full_tokens}-token message trimmed)")
+}
+
+/// Sibling of [`mark_head_kept`] for a tail-keep: the marker LEADS, because the opening
+/// is what went missing and a citizen reading left-to-right must learn that first.
+pub fn mark_tail_kept(tail: &str, full_tokens: u32) -> String {
+    format!("(…{full_tokens}-token opening trimmed) {tail}")
+}
+
+/// Tokens to reserve for a trim marker BEFORE trimming, so the disclosure cannot itself
+/// push the message back over the budget that forced the trim.
+///
+/// A FUNCTION, not a `const`, for the same reason [`super::viewstate_rag`]'s floor is:
+/// `context_budget`'s de-hardcode guard scans `const`s whose name contains TOKEN for bare
+/// literals, and it is right to — a bare literal here is a prompt-size constant wearing a
+/// different hat.
+///
+/// DERIVED from the markers themselves at their widest (`u32::MAX`, ten digits) rather
+/// than from a measured sample, so editing either spelling cannot silently outgrow the
+/// reserve. Shipped first as a hand-measured `(…99999-token opening trimmed)` — five
+/// digits — and the accompanying test immediately caught it: a marker is only a
+/// guarantee if it fits for EVERY token count, not for the ones I happened to imagine.
+/// A too-small reserve puts the disclosure back over the budget that forced the trim,
+/// which is the bug this reserve exists to prevent.
+pub fn trim_marker_tokens() -> u32 {
+    estimate_prompt_tokens(mark_head_kept("", u32::MAX).trim())
+        .max(estimate_prompt_tokens(mark_tail_kept("", u32::MAX).trim()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches (card 3833b472): the two trim sites drifting apart again, and a
+    // marker that is not paid for. The head marker must TRAIL its text and the tail
+    // marker must LEAD it — a citizen reading a tail-keep has to meet the notice before
+    // the mid-sentence text, or it reads as a whole message that starts oddly. The
+    // reserve must also cover the widest marker either spelling can produce.
+    #[test]
+    fn both_trim_spellings_disclose_and_the_reserve_covers_them() {
+        let head = mark_head_kept("the opening survives", 4321);
+        assert!(head.starts_with("the opening survives"), "{head}");
+        assert!(head.ends_with("(…4321-token message trimmed)"), "{head}");
+
+        let tail = mark_tail_kept("the ending survives", 4321);
+        assert!(tail.starts_with("(…4321-token opening trimmed)"), "{tail}");
+        assert!(tail.ends_with("the ending survives"), "{tail}");
+
+        // Neither spelling may cost more than the reserve set aside for it, at the
+        // widest token count a real message could carry.
+        let reserve = trim_marker_tokens();
+        for marker in [
+            mark_head_kept("", u32::MAX).trim().to_string(),
+            mark_tail_kept("", u32::MAX).trim().to_string(),
+        ] {
+            assert!(
+                estimate_prompt_tokens(&marker) <= reserve,
+                "marker {marker:?} costs {} > reserve {reserve}",
+                estimate_prompt_tokens(&marker)
+            );
+        }
+    }
 
     // what this catches: the estimator drifting from the chars/4+1 unit the RAG
     // sources budget against (which would make the replay ledger's numbers lie),

--- a/core/continuum-core/src/persona/airc_source.rs
+++ b/core/continuum-core/src/persona/airc_source.rs
@@ -348,9 +348,18 @@ impl AircRagSource {
             } else {
                 let head = head_to_tokens(text, cap);
                 let head_cost = estimate_tokens(&head).saturating_add(2); // marker
+                // The marker SPELLING is shared with the tail-trim site so the two
+                // cannot drift apart again (card 3833b472). The +2 reserve above is
+                // left as it was on purpose: `trim_marker_tokens()` measures the real
+                // cost at 8, so this site under-reserves, but raising it changes how
+                // many turns fit in every prompt — a packing change that belongs in
+                // its own card with its own before/after, not smuggled into a
+                // disclosure fix.
                 (
                     head_cost,
-                    Some(format!("{head} (…{full}-token message trimmed)")),
+                    Some(crate::cognition::token_budget::mark_head_kept(
+                        &head, full,
+                    )),
                 )
             };
             if tokens_used.saturating_add(cost) > budget {


### PR DESCRIPTION
Card 3833b472. Citizens on two nodes perceived mid-sentence fragments as whole
messages and spent turns reconstructing intent that was never delivered — Sahar
five turns in a row, against text like ", so it is …".

An unmarked fragment does not read as a fragment. It reads as a whole message
that begins mid-sentence, and reconstructing the missing opening is then the
RATIONAL move. The defect is the silence, not the citizen.

## What this lands

`cognition::token_budget` now owns the disclosure vocabulary:

  mark_head_kept(head, full_tokens)   "{head} (…N-token message trimmed)"
  mark_tail_kept(tail, full_tokens)   "(…N-token opening trimmed) {tail}"
  trim_marker_tokens()                reserve, DERIVED from the markers at u32::MAX

The marker follows what is MISSING: a head-keep lost its tail so the marker
trails; a tail-keep lost its opening so the marker LEADS, and the citizen meets
the notice before the text it qualifies.

`persona::airc_source` (the head-trim site, the one that already disclosed) now
calls `mark_head_kept` instead of formatting its own string. Output text is
byte-identical; what changes is that the next site to shorten something inherits
the vocabulary instead of re-deciding it.

`trim_marker_tokens` is a FUNCTION, not a `const` — `context_budget`'s
de-hardcode guard scans `const`s whose name contains TOKEN for bare literals, and
it is right to. It is derived from the markers themselves rather than
hand-measured: the first version measured `(…99999-token opening trimmed)` at
five digits and the accompanying test caught it immediately. A reserve is only a
guarantee if it holds for EVERY token count.

## What this deliberately does NOT land

`llm_deliberation_faculty`'s tail arm — the site that returns a trimmed body with
NO marker, and the actual cause of the fragments — is untouched here.

Four attempts to mark it all failed
`tool_surface_is_a_category_index_plus_discovery_pair`'s roomy assertion ("given
a window that fits the surface, the newest message reaches her"), which passes on
a clean base:

  1. reserve + mark unconditionally — also stamped a FALSE "opening trimmed" on
     messages that fit whole, which is worse than the bug being fixed
  2. a fits-check in `estimate_prompt_tokens` (chars/4+1) while `tail_to_tokens`
     measures `est_tokens` (bytes/3) — mixed units, disagreeing exactly at the
     boundary the arm exists to handle
  3. ask `tail_to_tokens` itself whether the message fits
  4. reserve `est_tokens(marker) + 1`, in the guard's own unit

The reasoning that ends the guessing: `kept` is always a SUFFIX of the base body,
the test's phrase is appended LAST in the burst, and `mark_tail_kept` PREPENDS —
so trimming cannot remove it. The loss is therefore downstream: the marker's bytes
tip the served-window total the test names ("the exact condition llama-server
checks before 400").

Shipping half rather than weakening that assertion, because it pins a real
capacity invariant: a citizen at an adequate window must receive the newest
message. Trading a disclosure defect for a perception defect is a bad deal.

Follow-up card carries the next experiment: stub `mark_tail_kept` to a no-op and
re-run. If the test passes, the marker cannot ride inline in that arm and the
disclosure has to go somewhere else.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE