### PR TITLE
feat(routing): the inbound command accept path names itself — airc.command.request_accepted

### DIFF
--- a/core/continuum-core/src/routing/command_handler.rs
+++ b/core/continuum-core/src/routing/command_handler.rs
@@ -503,6 +503,17 @@ impl ConsumerAdapter for CommandRequestHandler {
             );
             return Ok(());
         }
+        // THE ACCEPT PATH NAMES ITSELF (BigMama, 2026-09-06 22:0xZ): the only probe on
+        // inbound peer commands was the refusal, so a request that was ACCEPTED left no
+        // row and silence read as ambiguous. Now every accepted request says who was
+        // asked, by whom, and what — the receipt the grid's first hop was missing.
+        crate::probe!(
+            class = "airc.command.request_accepted",
+            target = ?envelope.target,
+            me = %self.airc.peer_id().0,
+            from = %envelope.peer_id.0,
+            "command request addressed to this citizen — executing"
+        );
         let parsed = Self::parse_envelope(&envelope)?;
         let response = self.process_request(&parsed).await;
         self.send_reply(&parsed, &response).await?;


### PR DESCRIPTION
## What
`airc.command.request_accepted {target, me, from}` fires on every inbound peer command the handler executes. Until now the only probe on that path was the refusal (`request_not_for_me`), so an accepted request left no row.

## Why (BigMama, 2026-09-06 22:0xZ)
Twelve inbound peer command requests reached the 5090 today and the only evidence was four refusals; the accepted ones were invisible. The grid's first hop needs a receipt on the answering side, not only on the asking side. Her finding also settled the addressing: the handler evaluates per hosted citizen against her own id, so a remote brain must target a serving citizen's peer (Sahar), never an agent seat.

## Acceptance
On the 5090, Kira's and Mathis's `ai/generate` (from 406242d1 / 2eaf28e0, addressed to df72dbf2) each produce one `request_accepted` row before Sahar's inference rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo