### PR TITLE
fix(persona): the command inbound pump re-opens its stream; remote requests name their model; sender breaker

### DIFF
--- a/core/continuum-core/src/inference/airc_remote/adapter.rs
+++ b/core/continuum-core/src/inference/airc_remote/adapter.rs
@@ -81,7 +81,7 @@ fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)  // unwrap_or: a clock before 1970 reads as "warm", never a panic on the inference path
+        .unwrap_or(u64::MAX)  // unwrap_or: a broken clock FAILS OPEN — `now < until` is false at MAX, so the lane reads warm and requests still go out; 0 would read every tripped lane cold forever (BigMama's review of #3814)
 }
 
 impl AircRemoteInferenceAdapter {
@@ -110,12 +110,12 @@ impl AircRemoteInferenceAdapter {
             Err(RemoteInferenceError::Timeout { .. }) => {
                 let n = self.consecutive_deadlines.fetch_add(1, Ordering::Relaxed) + 1;
                 if n >= COLD_AFTER_DEADLINES {
-                    let until = now_ms() + COLD_WINDOW.as_millis() as u64;
+                    let until = now_ms().saturating_add(COLD_WINDOW.as_millis() as u64);
                     self.cold_until_ms.store(until, Ordering::Relaxed);
                     self.consecutive_deadlines.store(0, Ordering::Relaxed);
                     crate::probe!(
                         class = "remote_lane.cold",
-                        peer = %self.default_target_peer.as_deref().unwrap_or("-"),
+                        peer = %self.default_target_peer.as_deref().unwrap_or("-"),  // unwrap_or: probe label only — "-" = no pinned peer, never a routing decision
                         deadlines = n,
                         cold_for_s = COLD_WINDOW.as_secs(),
                         "the remote peer let requests die at the deadline in a row; \
@@ -182,7 +182,7 @@ impl AIProviderAdapter for AircRemoteInferenceAdapter {
     fn default_model(&self) -> &str {
         self.default_model
             .as_deref()
-            .unwrap_or(AIRC_REMOTE_DEFAULT_MODEL)
+            .unwrap_or(AIRC_REMOTE_DEFAULT_MODEL)  // unwrap_or: the trait wants a name; the wire request itself is stamped only when with_model was set, never this placeholder
     }
 
     async fn initialize(&mut self) -> Result<(), String> {
@@ -206,12 +206,12 @@ impl AIProviderAdapter for AircRemoteInferenceAdapter {
         if self.is_cold() {
             crate::probe!(
                 class = "remote_lane.refused_cold",
-                peer = %self.default_target_peer.as_deref().unwrap_or("-"),
+                peer = %self.default_target_peer.as_deref().unwrap_or("-"),  // unwrap_or: probe label only — "-" = no pinned peer, never a routing decision
                 "remote lane is cold; request refused without a round trip"
             );
             return Err(format!(
                 "remote lane to {} is cold: {} deadline misses in a row; retry after the {} s window",
-                self.default_target_peer.as_deref().unwrap_or("the default peer"),
+                self.default_target_peer.as_deref().unwrap_or("the default peer"),  // unwrap_or: error text only — names the transport default when no peer is pinned
                 COLD_AFTER_DEADLINES,
                 COLD_WINDOW.as_secs()
             ));

--- a/core/continuum-core/src/inference/airc_remote/adapter.rs
+++ b/core/continuum-core/src/inference/airc_remote/adapter.rs
@@ -11,8 +11,9 @@
 //! interesting (correlation, framing, peer discovery, retries,
 //! timeouts) lives in the transport.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 
@@ -21,7 +22,7 @@ use crate::ai::types::{
     HealthState, HealthStatus, ModelInfo, TextGenerationRequest, TextGenerationResponse,
 };
 
-use super::protocol::RemoteInferenceRequest;
+use super::protocol::{RemoteInferenceError, RemoteInferenceRequest};
 use super::transport::AircInferenceTransport;
 
 /// Provider ID used to register + select this adapter from the
@@ -46,6 +47,12 @@ pub struct AircRemoteInferenceAdapter {
     /// Useful when a caller explicitly wants this adapter routing
     /// to one specific peer; None = let the transport decide.
     default_target_peer: Option<String>,
+    /// The model every request names when the caller names none. The
+    /// persona's durable override carries it (it chose the PEER by it), and
+    /// the receiver never picks a model for you — a request that crosses the
+    /// wire without one is refused there (measured 2026-09-06, BigMama's
+    /// `detail` field: "No provider or model specified").
+    default_model: Option<String>,
     /// Flipped to true the first time a `generate_text` round-trip
     /// succeeds. `health_check` returns `Unknown` while this is
     /// false (no observation yet) and `Healthy` once it's true.
@@ -55,6 +62,26 @@ pub struct AircRemoteInferenceAdapter {
     /// fix is no fallback to a false-positive default — admit
     /// "no signal" until traffic proves the peer is reachable.
     has_observed_success: AtomicBool,
+    /// Deadline misses in a row. Reset by any answer from the peer.
+    consecutive_deadlines: AtomicU32,
+    /// While `now < cold_until_ms` the lane is COLD: requests are refused
+    /// here, without a wire round trip. 0 = warm.
+    cold_until_ms: AtomicU64,
+}
+
+/// Deadline misses in a row before the lane reads cold. Measured 2026-09-06:
+/// two citizens bound to a peer whose command pump had died sent six requests
+/// in 100 s, each waiting the full 30 s deadline, each burning a turn.
+pub const COLD_AFTER_DEADLINES: u32 = 3;
+/// How long a cold lane stays cold before one request is let through to
+/// re-measure it.
+pub const COLD_WINDOW: Duration = Duration::from_secs(300);
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)  // unwrap_or: a clock before 1970 reads as "warm", never a panic on the inference path
 }
 
 impl AircRemoteInferenceAdapter {
@@ -62,7 +89,41 @@ impl AircRemoteInferenceAdapter {
         Self {
             transport,
             default_target_peer: None,
+            default_model: None,
             has_observed_success: AtomicBool::new(false),
+            consecutive_deadlines: AtomicU32::new(0),
+            cold_until_ms: AtomicU64::new(0),
+        }
+    }
+
+    /// Whether the lane currently refuses requests without a round trip.
+    pub fn is_cold(&self) -> bool {
+        let until = self.cold_until_ms.load(Ordering::Relaxed);
+        until != 0 && now_ms() < until
+    }
+
+    /// Fold one transport outcome into the breaker. A deadline miss counts;
+    /// any answer (even a refusal) proves the peer evaluates our mail and
+    /// resets the count.
+    fn observe(&self, outcome: &Result<(), &RemoteInferenceError>) {
+        match outcome {
+            Err(RemoteInferenceError::Timeout { .. }) => {
+                let n = self.consecutive_deadlines.fetch_add(1, Ordering::Relaxed) + 1;
+                if n >= COLD_AFTER_DEADLINES {
+                    let until = now_ms() + COLD_WINDOW.as_millis() as u64;
+                    self.cold_until_ms.store(until, Ordering::Relaxed);
+                    self.consecutive_deadlines.store(0, Ordering::Relaxed);
+                    crate::probe!(
+                        class = "remote_lane.cold",
+                        peer = %self.default_target_peer.as_deref().unwrap_or("-"),
+                        deadlines = n,
+                        cold_for_s = COLD_WINDOW.as_secs(),
+                        "the remote peer let requests die at the deadline in a row; \
+                         refusing here for the window instead of burning turns"
+                    );
+                }
+            }
+            _ => self.consecutive_deadlines.store(0, Ordering::Relaxed),
         }
     }
 
@@ -72,6 +133,13 @@ impl AircRemoteInferenceAdapter {
     /// (e.g. the operator's GPU-rich grid host).
     pub fn with_target_peer(mut self, peer: impl Into<String>) -> Self {
         self.default_target_peer = Some(peer.into());
+        self
+    }
+
+    /// Name the model every request runs when the caller leaves `model`
+    /// unset. The peer refuses a request that names none.
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.default_model = Some(model.into());
         self
     }
 }
@@ -112,7 +180,9 @@ impl AIProviderAdapter for AircRemoteInferenceAdapter {
     }
 
     fn default_model(&self) -> &str {
-        AIRC_REMOTE_DEFAULT_MODEL
+        self.default_model
+            .as_deref()
+            .unwrap_or(AIRC_REMOTE_DEFAULT_MODEL)
     }
 
     async fn initialize(&mut self) -> Result<(), String> {
@@ -128,17 +198,31 @@ impl AIProviderAdapter for AircRemoteInferenceAdapter {
 
     async fn generate_text(
         &self,
-        request: TextGenerationRequest,
+        mut request: TextGenerationRequest,
     ) -> Result<TextGenerationResponse, String> {
+        if request.model.is_none() {
+            request.model = self.default_model.clone();
+        }
+        if self.is_cold() {
+            crate::probe!(
+                class = "remote_lane.refused_cold",
+                peer = %self.default_target_peer.as_deref().unwrap_or("-"),
+                "remote lane is cold; request refused without a round trip"
+            );
+            return Err(format!(
+                "remote lane to {} is cold: {} deadline misses in a row; retry after the {} s window",
+                self.default_target_peer.as_deref().unwrap_or("the default peer"),
+                COLD_AFTER_DEADLINES,
+                COLD_WINDOW.as_secs()
+            ));
+        }
         let mut envelope = RemoteInferenceRequest::new(request);
         if let Some(peer) = &self.default_target_peer {
             envelope = envelope.with_target_peer(peer.clone());
         }
-        let response = self
-            .transport
-            .send_request(envelope)
-            .await
-            .map_err(|e| e.to_string())?;
+        let sent = self.transport.send_request(envelope).await;
+        self.observe(&sent.as_ref().map(|_| ()));
+        let response = sent.map_err(|e| e.to_string())?;
         // First successful round-trip flips the health observation
         // bit so subsequent health_check calls can report Healthy.
         // Relaxed is fine: a stale Unknown -> Healthy transition is
@@ -370,6 +454,28 @@ mod tests {
         assert!(err.contains("all peers down"));
     }
 
+    // what this catches: the breaker. Three deadline misses in a row must
+    // make the FOURTH request fail here, at once, naming the cold window —
+    // not wait another 30 s on the wire. Without it two citizens bound to a
+    // dead peer burned every turn against the deadline (2026-09-06, Kira +
+    // Mathis → Sahar).
+    #[tokio::test]
+    async fn three_deadline_misses_make_the_lane_cold_and_the_next_request_fails_fast() {
+        let transport = StubInferenceTransport::always_failing(RemoteInferenceError::Timeout {
+            elapsed_ms: 30_000,
+        });
+        let adapter = AircRemoteInferenceAdapter::new(transport).with_target_peer("df72dbf2");
+        for _ in 0..COLD_AFTER_DEADLINES {
+            assert!(!adapter.is_cold(), "warm until the third miss");
+            let err = adapter.generate_text(req("hi")).await.unwrap_err();
+            assert!(err.contains("timed out"), "a real round trip: {err}");
+        }
+        assert!(adapter.is_cold());
+        let err = adapter.generate_text(req("hi")).await.unwrap_err();
+        assert!(err.contains("cold"), "refused here, not on the wire: {err}");
+        assert!(err.contains("df72dbf2"));
+    }
+
     #[tokio::test]
     async fn timeout_error_surfaces_with_elapsed_ms() {
         let transport = StubInferenceTransport::always_failing(RemoteInferenceError::Timeout {
@@ -394,6 +500,44 @@ mod tests {
     }
 
     // ── target_peer plumbing ──────────────────────────────────
+
+    // what this catches: the request must NAME ITS MODEL on the wire. The
+    // persona's override picks the peer by model and then, before this, asked
+    // that peer to run nothing in particular: `model: None` is serialized as
+    // an ABSENT field and the receiver refuses ("No provider or model
+    // specified" — 2026-09-06, every accepted ai/generate from the M5). A
+    // caller that names a model keeps it.
+    #[tokio::test]
+    async fn the_adapter_stamps_its_model_on_a_request_that_names_none() {
+        let transport = StubInferenceTransport::new(|req: &RemoteInferenceRequest| {
+            Ok(RemoteInferenceResponse {
+                correlation_id: req.correlation_id,
+                served_by: "peer".to_string(),
+                text_response: crate::ai::types::TextGenerationResponse {
+                    text: "ok".to_string(),
+                    finish_reason: FinishReason::Stop,
+                    model: req.text_request.model.clone().unwrap_or_else(|| "ABSENT".to_string()),
+                    provider: HEURISTIC_PROVIDER_ID.to_string(),
+                    usage: Default::default(),
+                    response_time_ms: 0,
+                    request_id: "stub".to_string(),
+                    content: None,
+                    tool_calls: None,
+                    reasoning: None,
+                    routing: None,
+                    error: None,
+                    timing: None,
+                },
+            })
+        });
+        let adapter = AircRemoteInferenceAdapter::new(transport).with_model("qwen3.8-27b");
+        let out = adapter.generate_text(req("hi")).await.unwrap();
+        assert_eq!(out.model, "qwen3.8-27b", "the override's model must ride the wire");
+        let mut named = req("hi");
+        named.model = Some("caller-named".to_string());
+        let out = adapter.generate_text(named).await.unwrap();
+        assert_eq!(out.model, "caller-named", "a caller's own model is never overridden");
+    }
 
     #[tokio::test]
     async fn with_target_peer_threads_through_to_transport_envelope() {

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -514,11 +514,15 @@ impl PersonaAircRuntime {
                     source,
                 })?;
         let executor_for_acts = Arc::clone(&executor);
+        // Built before the pump so the pump can watch it: a later join_room
+        // bumps the epoch and the pump re-opens its stream.
+        let membership_epoch = tokio::sync::watch::channel(0u64).0;
         let command_pump = crate::persona::command_inbound_pump::PersonaCommandInboundPump::spawn(
             persona_id,
             Arc::clone(&airc_arc),
             executor,
             grant_authorizer,
+            membership_epoch.subscribe(),
         )
         .await
         .map_err(|source| PersonaAircRuntimeError::CommandPumpInstall {
@@ -1034,7 +1038,7 @@ impl PersonaAircRuntime {
             // state above) — before #298 this stored the passed-in operator
             // room, which could even diverge from the joined channel.
             default_room: RoomId::from_uuid(room.channel.as_uuid()),
-            membership_epoch: tokio::sync::watch::channel(0u64).0,
+            membership_epoch,
             inbound_handle: None,
             command_pump: Some(command_pump),
             executor: Some(executor_for_acts),
@@ -1168,6 +1172,7 @@ impl PersonaAircRuntime {
             Arc::clone(&self.airc),
             executor,
             grant_authorizer,
+            self.membership_epoch.subscribe(),
         )
         .await
         .map_err(|source| PersonaAircRuntimeError::CommandPumpInstall {
@@ -1182,8 +1187,10 @@ impl PersonaAircRuntime {
     /// installed. `true` after `bootstrap` (always) or after a
     /// successful `install_command_pump` call. Useful for tests +
     /// telemetry to confirm the persona is addressable.
+    /// Whether the citizen is addressable for cross-grid commands RIGHT NOW:
+    /// a pump whose task is still running, not merely a handle.
     pub fn has_command_pump(&self) -> bool {
-        self.command_pump.is_some()
+        self.command_pump.as_ref().is_some_and(|p| p.is_alive())
     }
 
     /// The persona's stable continuum identifier.

--- a/core/continuum-core/src/persona/command_inbound_pump.rs
+++ b/core/continuum-core/src/persona/command_inbound_pump.rs
@@ -186,7 +186,15 @@ impl PersonaCommandInboundPump {
             executor,
             grant_authorizer,
         );
-        let handle = tokio::spawn(run(persona_id, airc, handler, stream, membership));
+        // The pump is SUPERVISED on the persona: `run` re-opens its own stream
+        // and only returns when the runtime drops its epoch sender, so the one
+        // exit it cannot cover is a panic inside the task. The supervisor task
+        // is what `is_alive()` reads; it respawns `run` after a panic with a
+        // fresh stream and says so. Nothing outside the persona has to notice
+        // (the runtime is shared as `Arc<PersonaAircRuntime>`, so no reconciler
+        // could re-install it from outside without interior mutability —
+        // BigMama's review of #3814).
+        let handle = tokio::spawn(supervise(persona_id, airc, handler, stream, membership));
         Ok(Self { persona_id, handle })
     }
 
@@ -241,6 +249,59 @@ fn reopen_delay(attempt: u32) -> Duration {
 enum Reopen {
     StreamEnded,
     MembershipChanged,
+}
+
+async fn supervise(
+    persona_id: Uuid,
+    airc: Arc<Airc>,
+    handler: Arc<CommandRequestHandler>,
+    first_stream: FilteredEventStream,
+    membership: watch::Receiver<u64>,
+) {
+    let mut stream = Some(first_stream);
+    let mut respawns: u32 = 0;
+    loop {
+        let this_stream = match stream.take() {
+            Some(s) => s,
+            None => match crate::persona::airc_citizen::subscribe_every_room(&airc).await {
+                Ok(s) => s,
+                Err(e) => {
+                    crate::probe!(
+                        class = "persona.command_pump.reopen_failed",
+                        persona_id = %persona_id,
+                        attempt = respawns,
+                        error = %e,
+                        "command pump could not re-subscribe after a panic; retrying"
+                    );
+                    tokio::time::sleep(reopen_delay(respawns.min(5))).await;
+                    continue;
+                }
+            },
+        };
+        let task = tokio::spawn(run(
+            persona_id,
+            Arc::clone(&airc),
+            Arc::clone(&handler),
+            this_stream,
+            membership.clone(),
+        ));
+        match task.await {
+            // `run` returns only when the runtime dropped its epoch sender.
+            Ok(()) => return,
+            Err(e) if e.is_panic() => {
+                respawns = respawns.saturating_add(1);
+                crate::probe!(
+                    class = "persona.command_pump.respawned_after_panic",
+                    persona_id = %persona_id,
+                    respawns = respawns,
+                    "command pump task panicked; respawning with a fresh stream"
+                );
+                tokio::time::sleep(reopen_delay(respawns.min(5))).await;
+            }
+            // Cancelled: the supervisor itself was aborted (shutdown).
+            Err(_) => return,
+        }
+    }
 }
 
 async fn run(

--- a/core/continuum-core/src/persona/command_inbound_pump.rs
+++ b/core/continuum-core/src/persona/command_inbound_pump.rs
@@ -67,11 +67,13 @@
 
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use airc_lib::adapter::ConsumerAdapter;
 use airc_lib::{Airc, AircError, FilteredEventStream};
 use continuum_airc_protocol::{COMMAND_REQUEST_BODY_HINT, HEADER_CONTINUUM_BODY_HINT};
 use futures::stream::StreamExt;
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 use uuid::Uuid;
@@ -163,6 +165,7 @@ impl PersonaCommandInboundPump {
         airc: Arc<Airc>,
         executor: Arc<CommandExecutor>,
         grant_authorizer: Arc<GrantAuthorizer>,
+        membership: watch::Receiver<u64>,
     ) -> Result<Self, AircError> {
         // Subscribe BEFORE spawning so failure surfaces at the call
         // site. The stream moves into the spawned task; subsequent
@@ -183,7 +186,7 @@ impl PersonaCommandInboundPump {
             executor,
             grant_authorizer,
         );
-        let handle = tokio::spawn(run(persona_id, airc, handler, stream));
+        let handle = tokio::spawn(run(persona_id, airc, handler, stream, membership));
         Ok(Self { persona_id, handle })
     }
 
@@ -191,6 +194,14 @@ impl PersonaCommandInboundPump {
     /// debug-logging in the owning runtime.
     pub fn persona_id(&self) -> Uuid {
         self.persona_id
+    }
+
+    /// Whether the pump TASK is still running. `Some(pump)` on the runtime
+    /// used to mean "addressable"; measured 2026-09-06 on the M5 and the
+    /// 5090: four of five resident citizens held a `Some` whose task had
+    /// exited hours earlier. Liveness is the task, not the handle.
+    pub fn is_alive(&self) -> bool {
+        !self.handle.is_finished()
     }
 
     /// Abort the pump task and await its exit. Drop alone would
@@ -217,69 +228,156 @@ impl PersonaCommandInboundPump {
     }
 }
 
-/// The subscribe loop. Extracted for readability; spawned as a
-/// tokio task by `spawn()`. The stream is opened by the caller
-/// BEFORE spawning so subscribe failure surfaces at the call site
-/// (see the doc on `spawn` for rationale).
+/// Delay before the n-th consecutive re-open attempt: 1 s doubling to a
+/// 30 s cap. A daemon that is down stays down for a while; a stream that
+/// ended on a membership change is back in one hop.
+fn reopen_delay(attempt: u32) -> Duration {
+    Duration::from_secs(1u64 << attempt.min(5)).min(Duration::from_secs(30))
+}
+
+/// Why the pump is (re)opening its stream. Carried on the probe so a read
+/// can tell a daemon disconnect from a room join.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Reopen {
+    StreamEnded,
+    MembershipChanged,
+}
+
 async fn run(
     persona_id: Uuid,
     airc: Arc<Airc>,
     handler: Arc<CommandRequestHandler>,
     mut stream: FilteredEventStream,
+    mut membership: watch::Receiver<u64>,
 ) {
     let self_id = airc.peer_id();
-    debug!(
+    crate::probe!(
+        class = "persona.command_pump.installed",
         persona_id = %persona_id,
-        self_peer_id = %self_id.0,
-        "PersonaCommandInboundPump: subscribed; awaiting command envelopes"
+        peer_id = %self_id.0,
+        "command inbound pump subscribed; the citizen is addressable"
     );
-
-    while let Some(event) = stream.next().await {
-        let event = match event {
-            Ok(e) => e,
-            Err(lag) => {
-                // Lag is a broadcast-channel artifact — we missed
-                // some events but the stream is still alive. Log
-                // + continue per the existing chat pump's pattern
-                // (airc_persona_conversation.rs).
-                warn!(
-                    persona_id = %persona_id,
-                    "PersonaCommandInboundPump: subscribe lag: {lag}"
-                );
-                continue;
+    // The stream ends whenever the daemon closes the subscription — a daemon
+    // restart, an update, or the citizen joining a room after she was seated.
+    // Before 2026-09-06 the loop simply returned here at `debug!` level: the
+    // citizen stayed resident, chatted and worked, and every request addressed
+    // to her was heard only by the operator seat and refused as not-his. Sahar
+    // on the 5090 and four of five citizens on the M5 were unaddressable for
+    // hours with nothing on any probe. The pump now re-opens on end AND on a
+    // membership move, with a bounded backoff, and says so each time.
+    let mut attempt: u32 = 0;
+    loop {
+        let reason = loop {
+            tokio::select! {
+                next = stream.next() => match next {
+                    Some(Ok(event)) => {
+                        attempt = 0;
+                        if event.peer_id == self_id {
+                            continue;
+                        }
+                        let hint = event
+                            .headers
+                            .get(HEADER_CONTINUUM_BODY_HINT)
+                            .map(|s| s.as_str());
+                        if hint != Some(COMMAND_REQUEST_BODY_HINT) {
+                            continue;
+                        }
+                        if let Err(e) = handler.on_envelope((*event).clone()).await {
+                            warn!(
+                                persona_id = %persona_id,
+                                error = %e,
+                                "PersonaCommandInboundPump: handler.on_envelope rejected an envelope"
+                            );
+                        }
+                    }
+                    Some(Err(lag)) => {
+                        crate::probe!(
+                            class = "persona.command_pump.lag",
+                            persona_id = %persona_id,
+                            lag = %lag,
+                            "subscribe lag on the command pump — requests inside the gap are lost"
+                        );
+                        continue;
+                    }
+                    None => break Reopen::StreamEnded,
+                },
+                changed = membership.changed() => match changed {
+                    Ok(()) => break Reopen::MembershipChanged,
+                    Err(_) => {
+                        // The runtime dropped its epoch sender: the citizen is
+                        // being torn down. Exit for real, and say so.
+                        crate::probe!(
+                            class = "persona.command_pump.ended",
+                            persona_id = %persona_id,
+                            reason = "runtime_dropped",
+                            "command pump exiting with its runtime"
+                        );
+                        return;
+                    }
+                },
             }
         };
-
-        // Self-events come from our own publishes. Skip.
-        if event.peer_id == self_id {
-            continue;
-        }
-
-        // Only command-request envelopes go through the handler.
-        // Any other body_hint (chat, event-subscribe, future
-        // shapes) is for some other consumer to handle.
-        let hint = event
-            .headers
-            .get(HEADER_CONTINUUM_BODY_HINT)
-            .map(|s| s.as_str());
-        if hint != Some(COMMAND_REQUEST_BODY_HINT) {
-            continue;
-        }
-
-        // Deref-clone the broadcast Arc — `ConsumerAdapter::on_envelope`
-        // takes the owned TranscriptEvent. Same pattern as the e2e
-        // integration test in PR #1563.
-        if let Err(e) = handler.on_envelope((*event).clone()).await {
-            warn!(
-                persona_id = %persona_id,
-                error = %e,
-                "PersonaCommandInboundPump: handler.on_envelope rejected an envelope"
-            );
+        crate::probe!(
+            class = "persona.command_pump.ended",
+            persona_id = %persona_id,
+            reason = ?reason,
+            "command pump stream ended; re-opening"
+        );
+        loop {
+            let delay = reopen_delay(attempt);
+            tokio::time::sleep(delay).await;
+            // Joins arrive in bursts at boot (one per room). Every bump that
+            // landed during the sleep is folded into this one re-open.
+            let _ = membership.borrow_and_update();
+            match crate::persona::airc_citizen::subscribe_every_room(&airc).await {
+                Ok(next) => {
+                    stream = next;
+                    crate::probe!(
+                        class = "persona.command_pump.reopened",
+                        persona_id = %persona_id,
+                        reason = ?reason,
+                        attempt = attempt,
+                        delay_ms = delay.as_millis() as u64,
+                        "command pump re-subscribed; the citizen is addressable again"
+                    );
+                    attempt = 0;
+                    break;
+                }
+                Err(e) => {
+                    attempt = attempt.saturating_add(1);
+                    crate::probe!(
+                        class = "persona.command_pump.reopen_failed",
+                        persona_id = %persona_id,
+                        attempt = attempt,
+                        error = %e,
+                        "command pump could not re-subscribe; retrying"
+                    );
+                    debug!(
+                        persona_id = %persona_id,
+                        attempt,
+                        "PersonaCommandInboundPump: re-subscribe failed: {e}"
+                    );
+                }
+            }
         }
     }
+}
 
-    debug!(
-        persona_id = %persona_id,
-        "PersonaCommandInboundPump: subscribe stream ended (daemon disconnect); pump exiting"
-    );
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the re-open schedule must be bounded on BOTH ends —
+    // a zero first delay would busy-loop against a daemon that is down (the
+    // exact shape the message pump's membership contract test pins), and an
+    // unbounded doubling would leave a citizen unaddressable for minutes after
+    // one transient failure. 1 s doubling, capped at 30 s.
+    #[test]
+    fn the_reopen_schedule_is_bounded_on_both_ends() {
+        assert_eq!(reopen_delay(0), Duration::from_secs(1));
+        assert_eq!(reopen_delay(1), Duration::from_secs(2));
+        assert_eq!(reopen_delay(4), Duration::from_secs(16));
+        assert_eq!(reopen_delay(5), Duration::from_secs(30));
+        assert_eq!(reopen_delay(40), Duration::from_secs(30));
+    }
 }

--- a/core/continuum-core/src/persona/remote_lane_factory.rs
+++ b/core/continuum-core/src/persona/remote_lane_factory.rs
@@ -190,7 +190,9 @@ impl PersonaAdapterFactory for RemoteLaneAdapterFactory {
         })?;
 
         let transport = AircLiveTransport::new(Arc::clone(airc), peer);
-        let adapter = AircRemoteInferenceAdapter::new(transport).with_target_peer(peer.to_string());
+        let adapter = AircRemoteInferenceAdapter::new(transport)
+            .with_target_peer(peer.to_string())
+            .with_model(over.model_id.clone());
 
         crate::probe!(
             class = "persona.adapter.remote_lane",

--- a/core/continuum-core/tests/capability_grant_e2e.rs
+++ b/core/continuum-core/tests/capability_grant_e2e.rs
@@ -90,8 +90,16 @@ async fn owner_signed_grant_lets_grantee_run_a_tier_denied_command() {
     let grant_authorizer = build_grant_authorizer(owner, owner_home.path())
         .await
         .expect("owner builds its grant authorizer");
+    // The pump watches the runtime's membership epoch and exits only when the sender drops; hold it.
+    let (_membership_tx, membership_rx) = tokio::sync::watch::channel(0u64);
     let pump =
-        PersonaCommandInboundPump::spawn(owner_id, Arc::clone(owner), executor, grant_authorizer)
+        PersonaCommandInboundPump::spawn(
+            owner_id,
+            Arc::clone(owner),
+            executor,
+            grant_authorizer,
+            membership_rx,
+        )
             .await
             .expect("install owner command pump");
 

--- a/core/continuum-core/tests/persona_command_inbound_pump.rs
+++ b/core/continuum-core/tests/persona_command_inbound_pump.rs
@@ -13,7 +13,7 @@
 //!
 //! This test closes that gap. peer_a here is the persona side; the
 //! ONLY production-shape API the test touches is
-//! `PersonaCommandInboundPump::spawn(persona_id, airc, executor)`.
+//! `PersonaCommandInboundPump::spawn(persona_id, airc, executor, grant_authorizer, membership)`.
 //! No `CommandRequestHandler::new`, no manual subscribe loop, no
 //! manual `on_envelope` call. If the pump's install path is wrong,
 //! the test fails. If the pump silently drops command envelopes
@@ -151,11 +151,15 @@ async fn persona_command_pump_makes_persona_addressable_for_ai_generate() {
     )
     .await
     .expect("build grant authorizer for the loopback fixture");
+    // The runtime's membership epoch: the pump re-opens its stream when it
+    // moves and exits only when the sender is DROPPED, so the test holds it.
+    let (_membership_tx, membership_rx) = tokio::sync::watch::channel(0u64);
     let pump = PersonaCommandInboundPump::spawn(
         persona_id,
         Arc::clone(loop_back.peer_a()),
         executor,
         grant_authorizer,
+        membership_rx,
     )
     .await
     .expect(


### PR DESCRIPTION
## The wall BigMama's accept probe found

Requests addressed to a hosted citizen were heard by the operator seat, refused as not-his, and died. Measured on BOTH nodes on 2026-09-06 (probe `airc.command.request_not_for_me`, field `me`):

| node | citizens resident | citizens evaluating inbound frames |
|---|---|---|
| 5090 | Sahar + 1 | 0 (only the operator seat 7d4a4ce9) |
| M5 | 5 | 1 (Atlas; Demetri, Joaquin, Kira, Mathis silent) |

**Mechanism** (`persona/command_inbound_pump.rs`): the pump is one task over `subscribe_subscribed_delivery`. A lag is `continue`d; when the daemon ENDS the stream (daemon restart or update, or a `join_room` after seating), the loop returned at `debug!` level, emitted no probe, and nothing restarted it. The citizen stayed resident, chatted and worked, and was unaddressable for hours. `has_command_pump()` returned `true` the whole time because it read `Option::is_some()`, not the task.

The message pump got a quiet watchdog + store catch-up on 9/4; the command pump never did.

## Fix

- The pump re-opens its stream on end AND on a membership-epoch move (the runtime's `join_room` bumps it; the pump now watches the same `watch` the message pump watches), 1 s doubling to a 30 s cap, joins during the sleep folded into one re-open.
- Probes: `persona.command_pump.{installed, lag, ended{reason}, reopened{reason,attempt,delay_ms}, reopen_failed}`. A pump that ends and does not come back is now a visible row, not silence.
- `PersonaCommandInboundPump::is_alive()` (task liveness); `has_command_pump()` reads it.
- **Breaker on the sender** (BigMama's throttle ask): `AircRemoteInferenceAdapter` counts consecutive deadline misses; after 3 the lane reads cold for 300 s and requests are refused HERE (`remote_lane.cold`, `remote_lane.refused_cold`), not after another 30 s on the wire. Any answer resets it. Kira + Mathis sent six requests in 100 s into the dead pump, each burning a 30 s turn.

## Wall #3 (BigMama, 22:5xZ) — the request named no model

Once a request IS accepted, the 5090 refused every one: `ai/generate: [internal] No provider or model specified`. `TextGenerationRequest.model` is `skip_serializing_if = Option::is_none`, so an unset model is ABSENT on the wire, and the receiver never picks one (no fallbacks). The persona's override chose the PEER by `model_id` and then asked that peer to run nothing in particular. Fix: `AircRemoteInferenceAdapter::with_model(over.model_id)` stamps `text_request.model` when the caller names none (a caller's own model is kept); `default_model()` reports it.

## Tests
- `the_adapter_stamps_its_model_on_a_request_that_names_none`.
- `the_reopen_schedule_is_bounded_on_both_ends` (no zero delay, no unbounded doubling).
- `three_deadline_misses_make_the_lane_cold_and_the_next_request_fails_fast`.

## Acceptance (after both nodes deploy)
- `debug/probes/query classPrefix=persona.command_pump` shows `installed` for every resident citizen and `reopened` after a join.
- `airc.command.request_accepted` on the 5090 with `me = df72dbf2` (Sahar) for a request from Kira/Mathis; first `delib.generate.cache` rows for Kira/Mathis on the M5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
